### PR TITLE
Change has_spree_role? to look at local roles

### DIFF
--- a/core/config/initializers/user_class_extensions.rb
+++ b/core/config/initializers/user_class_extensions.rb
@@ -18,7 +18,7 @@ Spree::Core::Engine.config.to_prepare do
 
       # has_spree_role? simply needs to return true or false whether a user has a role or not.
       def has_spree_role?(role_in_question)
-        spree_roles.where(name: role_in_question.to_s).any?
+        spree_roles.any? { |role| role.name == role_in_question.to_s }
       end
 
       def last_incomplete_spree_order

--- a/core/spec/models/spree/ability_spec.rb
+++ b/core/spec/models/spree/ability_spec.rb
@@ -18,19 +18,12 @@ class FooAbility
 end
 
 describe Spree::Ability, :type => :model do
-  let(:user) { create(:user) }
+  let(:user) { build(:user) }
   let(:ability) { Spree::Ability.new(user) }
   let(:token) { nil }
 
-  before do
-    user.spree_roles.clear
-  end
-
-  TOKEN = 'token123'
-
   after(:each) {
     Spree::Ability.abilities = Set.new
-    user.spree_roles = []
   }
 
   context 'register_ability' do
@@ -64,9 +57,9 @@ describe Spree::Ability, :type => :model do
     let(:resource) { Object.new }
     let(:resource_shipment) { Spree::Shipment.new }
     let(:resource_product) { Spree::Product.new }
-    let(:resource_user) { Spree.user_class.new }
+    let(:resource_user) { create :user }
     let(:resource_order) { Spree::Order.new }
-    let(:fakedispatch_user) { Spree.user_class.new }
+    let(:fakedispatch_user) { Spree.user_class.create }
     let(:fakedispatch_ability) { Spree::Ability.new(fakedispatch_user) }
 
     context 'with admin user' do
@@ -248,7 +241,7 @@ describe Spree::Ability, :type => :model do
         it_should_behave_like 'no index allowed'
       end
       context 'requested by other user' do
-        let(:resource) { Spree.user_class.new }
+        let(:resource) { Spree.user_class.create }
         it_should_behave_like 'create only'
       end
     end


### PR DESCRIPTION
Doing this without active record lets us build objects without
persisting and test against those. It also lets us :includes the
spree_role's on a user and save queries.

Does some cleanups to the tests to reflect the fact we don't need to
persist the user anymore.
