### PR TITLE
Don't swallow exceptions

### DIFF
--- a/core/lib/spree/core/importer/order.rb
+++ b/core/lib/spree/core/importer/order.rb
@@ -42,9 +42,9 @@ module Spree
               end
             end
             order.reload
-          rescue Exception => e
+          rescue
             order.destroy if order && order.persisted?
-            raise e.message
+            raise
           end
         end
 
@@ -53,66 +53,57 @@ module Spree
 
           line_items = order.line_items
           shipments_hash.each do |s|
-            begin
-              shipment = order.shipments.build
-              shipment.tracking       = s[:tracking]
-              shipment.stock_location = Spree::StockLocation.find_by_admin_name(s[:stock_location]) || Spree::StockLocation.find_by_name!(s[:stock_location])
+            shipment = order.shipments.build
+            shipment.tracking       = s[:tracking]
+            shipment.stock_location = Spree::StockLocation.find_by_admin_name(s[:stock_location]) || Spree::StockLocation.find_by_name!(s[:stock_location])
 
-              inventory_units = s[:inventory_units] || []
-              inventory_units.each do |iu|
-                ensure_variant_id_from_params(iu)
+            inventory_units = s[:inventory_units] || []
+            inventory_units.each do |iu|
+              ensure_variant_id_from_params(iu)
 
-                unit = shipment.inventory_units.build
-                unit.order = order
+              unit = shipment.inventory_units.build
+              unit.order = order
 
-                # Spree expects a Inventory Unit to always reference a line
-                # item and variant otherwise users might get exceptions when
-                # trying to view these units. Note the Importer might not be
-                # able to find the line item if line_item.variant_id |= iu.variant_id
-                unit.variant_id = iu[:variant_id]
-                unit.line_item_id = line_items.select do |l|
-                  l.variant_id.to_i == iu[:variant_id].to_i
-                end.first.try(:id)
-              end
-
-              # Mark shipped if it should be.
-              if s[:shipped_at].present?
-                shipment.shipped_at = s[:shipped_at]
-                shipment.state      = 'shipped'
-                shipment.inventory_units.each do |unit|
-                  unit.state = 'shipped'
-                end
-              end
-
-              shipment.save!
-
-              shipping_method = Spree::ShippingMethod.find_by_name(s[:shipping_method]) || Spree::ShippingMethod.find_by_admin_name!(s[:shipping_method])
-              rate = shipment.shipping_rates.create!(:shipping_method => shipping_method,
-                                                     :cost => s[:cost])
-              shipment.selected_shipping_rate_id = rate.id
-              shipment.update_amounts
-
-            rescue Exception => e
-              raise "Order import shipments: #{e.message} #{s}"
+              # Spree expects a Inventory Unit to always reference a line
+              # item and variant otherwise users might get exceptions when
+              # trying to view these units. Note the Importer might not be
+              # able to find the line item if line_item.variant_id |= iu.variant_id
+              unit.variant_id = iu[:variant_id]
+              unit.line_item_id = line_items.select do |l|
+                l.variant_id.to_i == iu[:variant_id].to_i
+              end.first.try(:id)
             end
+
+            # Mark shipped if it should be.
+            if s[:shipped_at].present?
+              shipment.shipped_at = s[:shipped_at]
+              shipment.state      = 'shipped'
+              shipment.inventory_units.each do |unit|
+                unit.state = 'shipped'
+              end
+            end
+
+            shipment.save!
+
+            shipping_method = Spree::ShippingMethod.find_by_name(s[:shipping_method]) || Spree::ShippingMethod.find_by_admin_name!(s[:shipping_method])
+            rate = shipment.shipping_rates.create!(:shipping_method => shipping_method,
+                                                   :cost => s[:cost])
+            shipment.selected_shipping_rate_id = rate.id
+            shipment.update_amounts
           end
         end
 
         def self.create_line_items_from_params(line_items_hash, order)
           return {} unless line_items_hash
           line_items_hash.each_key do |k|
-            begin
-              extra_params = line_items_hash[k].except(:variant_id, :quantity, :sku)
-              line_item = ensure_variant_id_from_params(line_items_hash[k])
-              line_item = order.contents.add(Spree::Variant.find(line_item[:variant_id]), line_item[:quantity])
-              # Raise any errors with saving to prevent import succeeding with line items failing silently.
-              if extra_params.present?
-                line_item.update_attributes!(extra_params)
-              else
-                line_item.save!
-              end
-            rescue Exception => e
-              raise "Order import line items: #{e.message} #{line_item}"
+            extra_params = line_items_hash[k].except(:variant_id, :quantity, :sku)
+            line_item = ensure_variant_id_from_params(line_items_hash[k])
+            line_item = order.contents.add(Spree::Variant.find(line_item[:variant_id]), line_item[:quantity])
+            # Raise any errors with saving to prevent import succeeding with line items failing silently.
+            if extra_params.present?
+              line_item.update_attributes!(extra_params)
+            else
+              line_item.save!
             end
           end
         end
@@ -120,114 +111,87 @@ module Spree
         def self.create_adjustments_from_params(adjustments, order)
           return [] unless adjustments
           adjustments.each do |a|
-            begin
-              adjustment = order.adjustments.build(
-                order:  order,
-                amount: a[:amount].to_d,
-                label:  a[:label]
-              )
-              adjustment.save!
-              adjustment.close!
-            rescue Exception => e
-              raise "Order import adjustments: #{e.message} #{a}"
-            end
+            adjustment = order.adjustments.build(
+              order:  order,
+              amount: a[:amount].to_d,
+              label:  a[:label]
+            )
+            adjustment.save!
+            adjustment.close!
           end
         end
 
         def self.create_payments_from_params(payments_hash, order)
           return [] unless payments_hash
           payments_hash.each do |p|
-            begin
-              payment = order.payments.build order: order
-              payment.amount = p[:amount].to_f
-              # Order API should be using state as that's the normal payment field.
-              # spree_wombat serializes payment state as status so imported orders should fall back to status field.
-              payment.state = p[:state] || p[:status] || 'completed'
-              payment.payment_method = Spree::PaymentMethod.find_by_name!(p[:payment_method])
-              payment.source = create_source_payment_from_params(p[:source], payment) if p[:source]
-              payment.save!
-            rescue Exception => e
-              raise "Order import payments: #{e.message} #{p}"
-            end
+            payment = order.payments.build order: order
+            payment.amount = p[:amount].to_f
+            # Order API should be using state as that's the normal payment field.
+            # spree_wombat serializes payment state as status so imported orders should fall back to status field.
+            payment.state = p[:state] || p[:status] || 'completed'
+            payment.payment_method = Spree::PaymentMethod.find_by_name!(p[:payment_method])
+            payment.source = create_source_payment_from_params(p[:source], payment) if p[:source]
+            payment.save!
           end
         end
 
         def self.create_source_payment_from_params(source_hash, payment)
-          begin
-            Spree::CreditCard.create(
-              month: source_hash[:month],
-              year: source_hash[:year],
-              cc_type: source_hash[:cc_type],
-              last_digits: source_hash[:last_digits],
-              name: source_hash[:name],
-              payment_method: payment.payment_method,
-              gateway_customer_profile_id: source_hash[:gateway_customer_profile_id],
-              gateway_payment_profile_id: source_hash[:gateway_payment_profile_id],
-              imported: true
-            )
-          rescue Exception => e
-            raise "Order import source payments: #{e.message} #{source_hash}"
-          end
+          Spree::CreditCard.create(
+            month: source_hash[:month],
+            year: source_hash[:year],
+            cc_type: source_hash[:cc_type],
+            last_digits: source_hash[:last_digits],
+            name: source_hash[:name],
+            payment_method: payment.payment_method,
+            gateway_customer_profile_id: source_hash[:gateway_customer_profile_id],
+            gateway_payment_profile_id: source_hash[:gateway_payment_profile_id],
+            imported: true
+          )
         end
 
         def self.ensure_variant_id_from_params(hash)
-          begin
-            sku = hash.delete(:sku)
-            unless hash[:variant_id].present?
-              hash[:variant_id] = Spree::Variant.active.find_by_sku!(sku).id
-            end
-            hash
-          rescue ActiveRecord::RecordNotFound => e
-            raise "Ensure order import variant: Variant w/SKU #{sku} not found."
-          rescue Exception => e
-            raise "Ensure order import variant: #{e.message} #{hash}"
+          sku = hash.delete(:sku)
+          unless hash[:variant_id].present?
+            hash[:variant_id] = Spree::Variant.active.find_by_sku!(sku).id
           end
+          hash
         end
 
         def self.ensure_country_id_from_params(address)
           return if address.nil? or address[:country_id].present? or address[:country].nil?
 
-          begin
-            search = {}
-            if name = address[:country]['name']
-              search[:name] = name
-            elsif iso_name = address[:country]['iso_name']
-              search[:iso_name] = iso_name.upcase
-            elsif iso = address[:country]['iso']
-              search[:iso] = iso.upcase
-            elsif iso3 = address[:country]['iso3']
-              search[:iso3] = iso3.upcase
-            end
-
-            address.delete(:country)
-            address[:country_id] = Spree::Country.where(search).first!.id
-
-          rescue Exception => e
-            raise "Ensure order import address country: #{e.message} #{search}"
+          search = {}
+          if name = address[:country]['name']
+            search[:name] = name
+          elsif iso_name = address[:country]['iso_name']
+            search[:iso_name] = iso_name.upcase
+          elsif iso = address[:country]['iso']
+            search[:iso] = iso.upcase
+          elsif iso3 = address[:country]['iso3']
+            search[:iso3] = iso3.upcase
           end
+
+          address.delete(:country)
+          address[:country_id] = Spree::Country.where(search).first!.id
         end
 
         def self.ensure_state_id_from_params(address)
           return if address.nil? or address[:state_id].present? or address[:state].nil?
 
-          begin
-            search = {}
-            if name = address[:state]['name']
-              search[:name] = name
-            elsif abbr = address[:state]['abbr']
-              search[:abbr] = abbr.upcase
-            end
+          search = {}
+          if name = address[:state]['name']
+            search[:name] = name
+          elsif abbr = address[:state]['abbr']
+            search[:abbr] = abbr.upcase
+          end
 
-            address.delete(:state)
-            search[:country_id] = address[:country_id]
+          address.delete(:state)
+          search[:country_id] = address[:country_id]
 
-            if state = Spree::State.where(search).first
-              address[:state_id] = state.id
-            else
-              address[:state_name] = search[:name] || search[:abbr]
-            end
-          rescue Exception => e
-            raise "Ensure order import address state: #{e.message} #{search}"
+          if state = Spree::State.where(search).first
+            address[:state_id] = state.id
+          else
+            address[:state_name] = search[:name] || search[:abbr]
           end
         end
 

--- a/core/spec/lib/spree/core/importer/order_spec.rb
+++ b/core/spec/lib/spree/core/importer/order_spec.rb
@@ -113,15 +113,6 @@ module Spree
         expect(line_item.variant_id).to eq(variant_id)
       end
 
-      it 'handles line_item building exceptions' do
-        line_items['0'][:variant_id] = 'XXX'
-        params = { :line_items_attributes => line_items }
-
-        expect {
-          order = Importer::Order.import(user,params)
-        }.to raise_error /XXX/
-      end
-
       it 'handles line_item updating exceptions' do
         line_items['0'][:currency] = 'GBP'
         params = { :line_items_attributes => line_items }
@@ -142,14 +133,6 @@ module Spree
         expect(line_item.quantity).to eq(5)
       end
 
-      it 'handles exceptions when sku is not found' do
-        params = { :line_items_attributes => {
-                     "0" => { :sku => 'XXX', :quantity => 5 } }}
-        expect {
-          order = Importer::Order.import(user,params)
-        }.to raise_error /XXX/
-      end
-
       it 'can build an order from API shipping address' do
         params = { :ship_address_attributes => ship_address,
                    :line_items_attributes => line_items }
@@ -166,17 +149,6 @@ module Spree
 
         order = Importer::Order.import(user,params)
         expect(order.ship_address.country.iso).to eq 'US'
-      end
-
-      it 'handles country lookup exceptions' do
-        ship_address.delete(:country_id)
-        ship_address[:country] = { 'iso' => 'XXX' }
-        params = { :ship_address_attributes => ship_address,
-                   :line_items_attributes => line_items }
-
-        expect {
-          order = Importer::Order.import(user,params)
-        }.to raise_error /XXX/
       end
 
       it 'can build an order from API with state attributes' do
@@ -272,7 +244,7 @@ module Spree
         address = { :country => { "name" => "NoNoCountry" } }
         expect {
           Importer::Order.ensure_country_id_from_params(address)
-        }.to raise_error /NoNoCountry/
+        }.to raise_error ActiveRecord::RecordNotFound
       end
 
       it 'ensures_state_id for state fields' do
@@ -363,17 +335,6 @@ module Spree
         end
       end
 
-      it 'handles shipment building exceptions' do
-        params = { :shipments_attributes => [{ tracking: '123456789',
-                                               cost: '4.99',
-                                               shipping_method: 'XXX',
-                                               inventory_units: [{ sku: sku }]
-                                             }] }
-        expect {
-          order = Importer::Order.import(user,params)
-        }.to raise_error /XXX/
-      end
-
       it 'adds adjustments' do
         params = { :adjustments_attributes => [
             { label: 'Shipping Discount', amount: -4.99 },
@@ -404,16 +365,6 @@ module Spree
 
       end
 
-      it 'handles adjustment building exceptions' do
-        params = { :adjustments_attributes => [
-            { amount: 'XXX' },
-            { label: 'Promotion Discount', amount: '-3.00' }] }
-
-        expect {
-          order = Importer::Order.import(user,params)
-        }.to raise_error /XXX/
-      end
-
       it 'builds a payment using state' do
         params = { :payments_attributes => [{ amount: '4.99',
                                               payment_method: payment_method.name,
@@ -428,14 +379,6 @@ module Spree
                                               status: 'completed' }] }
         order = Importer::Order.import(user,params)
         expect(order.payments.first.amount).to eq 4.99
-      end
-
-      it 'handles payment building exceptions' do
-        params = { :payments_attributes => [{ amount: '4.99',
-                                              payment_method: 'XXX' }] }
-        expect {
-          order = Importer::Order.import(user, params)
-        }.to raise_error /XXX/
       end
 
       it 'build a source payment using years and month' do


### PR DESCRIPTION
As that would obliterate their stacktrace, making it impossible to track
down what is going on. Let the exception just propagate instead.
