### PR TITLE
Move spree user methods to module

### DIFF
--- a/core/app/models/concerns/spree/user_methods.rb
+++ b/core/app/models/concerns/spree/user_methods.rb
@@ -1,10 +1,13 @@
-Spree::Core::Engine.config.to_prepare do
-  if Spree.user_class
-    Spree.user_class.class_eval do
+module Spree
+  module UserMethods
+    extend ActiveSupport::Concern
 
-      include Spree::UserApiAuthentication
-      include Spree::UserReporting
+    include UserApiAuthentication
+    include UserReporting
+    include UserAddress
+    include UserPaymentSource
 
+    included do
       has_many :role_users, foreign_key: "user_id", class_name: "Spree::RoleUser"
       has_many :spree_roles, through: :role_users, source: :role
 
@@ -15,15 +18,15 @@ Spree::Core::Engine.config.to_prepare do
 
       belongs_to :ship_address, class_name: 'Spree::Address'
       belongs_to :bill_address, class_name: 'Spree::Address'
+    end
 
-      # has_spree_role? simply needs to return true or false whether a user has a role or not.
-      def has_spree_role?(role_in_question)
-        spree_roles.any? { |role| role.name == role_in_question.to_s }
-      end
+    # has_spree_role? simply needs to return true or false whether a user has a role or not.
+    def has_spree_role?(role_in_question)
+      spree_roles.any? { |role| role.name == role_in_question.to_s }
+    end
 
-      def last_incomplete_spree_order
-        spree_orders.incomplete.order('created_at DESC').first
-      end
+    def last_incomplete_spree_order
+      spree_orders.incomplete.order('created_at DESC').first
     end
   end
 end

--- a/core/app/models/concerns/spree/user_methods.rb
+++ b/core/app/models/concerns/spree/user_methods.rb
@@ -19,6 +19,8 @@ module Spree
 
       belongs_to :ship_address, class_name: 'Spree::Address'
       belongs_to :bill_address, class_name: 'Spree::Address'
+
+      before_destroy :check_completed_orders
     end
 
     # has_spree_role? simply needs to return true or false whether a user has a role or not.
@@ -29,5 +31,12 @@ module Spree
     def last_incomplete_spree_order
       spree_orders.incomplete.order('created_at DESC').first
     end
+
+    private
+
+    def check_completed_orders
+      raise Spree::Core::DestroyWithOrdersError if orders.complete.present?
+    end
+
   end
 end

--- a/core/app/models/concerns/spree/user_methods.rb
+++ b/core/app/models/concerns/spree/user_methods.rb
@@ -15,6 +15,7 @@ module Spree
       has_many :stock_locations, through: :user_stock_locations
 
       has_many :spree_orders, foreign_key: "user_id", class_name: "Spree::Order"
+      has_many :orders, foreign_key: "user_id", class_name: "Spree::Order"
 
       belongs_to :ship_address, class_name: 'Spree::Address'
       belongs_to :bill_address, class_name: 'Spree::Address'

--- a/core/app/models/spree/legacy_user.rb
+++ b/core/app/models/spree/legacy_user.rb
@@ -13,9 +13,8 @@ module Spree
     attr_accessor :password_confirmation
 
     private
-
-      def check_completed_orders
-        raise Spree::Core::DestroyWithOrdersError if orders.complete.present?
-      end
+    def check_completed_orders
+      raise Spree::Core::DestroyWithOrdersError if orders.complete.present?
+    end
   end
 end

--- a/core/app/models/spree/legacy_user.rb
+++ b/core/app/models/spree/legacy_user.rb
@@ -5,16 +5,7 @@ module Spree
   #   spree_auth_devise)
   class LegacyUser < Spree::Base
     include UserMethods
-
+    attr_accessor :password, :password_confirmation
     self.table_name = 'spree_users'
-    before_destroy :check_completed_orders
-
-    attr_accessor :password
-    attr_accessor :password_confirmation
-
-    private
-    def check_completed_orders
-      raise Spree::Core::DestroyWithOrdersError if orders.complete.present?
-    end
   end
 end

--- a/core/app/models/spree/legacy_user.rb
+++ b/core/app/models/spree/legacy_user.rb
@@ -4,18 +4,10 @@ module Spree
   # @note This class is intended to be modified by extensions (ex.
   #   spree_auth_devise)
   class LegacyUser < Spree::Base
-    include UserAddress
-    include UserPaymentSource
+    include UserMethods
 
     self.table_name = 'spree_users'
-
-    has_many :orders, foreign_key: :user_id
-
     before_destroy :check_completed_orders
-
-    def has_spree_role?(role)
-      true
-    end
 
     attr_accessor :password
     attr_accessor :password_confirmation

--- a/core/config/initializers/spree_user.rb
+++ b/core/config/initializers/spree_user.rb
@@ -1,0 +1,12 @@
+module Spree
+  module Core
+    Engine.config.to_prepare do
+      methods_included = Spree.user_class.included_modules.include? UserMethods
+
+      if !methods_included
+        ActiveSupport::Deprecation.warn "#{ Spree.user_class.name } must include Spree::UserMethods"
+        Spree.user_class.class_eval { include UserMethods }
+      end
+    end
+  end
+end

--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -18,10 +18,6 @@ require 'state_machine'
 # invalid state of a Payment. In the future this should be removed.
 StateMachine::Machine.ignore_method_conflicts = true
 
-# This is required because ActiveModel::Validations#invalid? conflicts with the
-# invalid state of a Payment. In the future this should be removed.
-StateMachine::Machine.ignore_method_conflicts = true
-
 module Spree
 
   mattr_accessor :user_class

--- a/core/spec/models/spree/concerns/user_methods_spec.rb
+++ b/core/spec/models/spree/concerns/user_methods_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+describe Spree::UserMethods do
+  let(:test_user)        { create :user }
+
+  describe '#has_spree_role?' do
+    subject { test_user.has_spree_role? name }
+
+    let(:role) { Spree::Role.create(name: name) }
+    let(:name) { 'test' }
+
+    context 'with a role' do
+      before { test_user.spree_roles << role }
+      it     { is_expected.to be_truthy }
+    end
+
+    context 'without a role' do
+      it { is_expected.to be_falsy }
+    end
+  end
+
+  describe '#last_incomplete_spree_order' do
+    subject { test_user.last_incomplete_spree_order }
+
+    context 'with an incomplete order' do
+      let(:last_incomplete_order) { create :order, user: test_user }
+
+      before do
+        create(:order, user: test_user)
+        create(:order, user: test_user, created_at: 1.day.ago)
+        create(:order, user: create(:user))
+        last_incomplete_order
+      end
+
+      it { is_expected.to eq last_incomplete_order }
+    end
+
+    context 'without an incomplete order' do
+      it { is_expected.to be_nil }
+    end
+  end
+end


### PR DESCRIPTION
Move Spree::User logic into a mixin that can be included in the Spree.user_class that is defined. 