### PR TITLE
Pull store credits in from bonobos/spree_store_credit_payment_method

### DIFF
--- a/api/app/controllers/spree/api/store_credit_events_controller.rb
+++ b/api/app/controllers/spree/api/store_credit_events_controller.rb
@@ -1,0 +1,9 @@
+class Spree::Api::StoreCreditEventsController < Spree::Api::BaseController
+  def mine
+    if current_api_user
+      @store_credit_events = current_api_user.store_credit_events.exposed_events.page(params[:page]).per(params[:per_page]).reverse_chronological
+    else
+      render "spree/api/errors/unauthorized", status: :unauthorized
+    end
+  end
+end

--- a/api/app/helpers/spree/api/api_helpers.rb
+++ b/api/app/helpers/spree/api/api_helpers.rb
@@ -29,7 +29,8 @@ module Spree
         :stock_movement_attributes,
         :stock_item_attributes,
         :promotion_attributes,
-        :store_attributes
+        :store_attributes,
+        :store_credit_history_attributes
       ]
 
       mattr_reader *ATTRIBUTES
@@ -76,7 +77,11 @@ module Spree
         :user_id, :created_at, :updated_at, :completed_at, :payment_total,
         :shipment_state, :payment_state, :email, :special_instructions, :channel,
         :included_tax_total, :additional_tax_total, :display_included_tax_total,
-        :display_additional_tax_total, :tax_total, :currency
+        :display_additional_tax_total, :tax_total, :currency,
+        :covered_by_store_credit, :display_total_applicable_store_credit,
+        :order_total_after_store_credit, :display_order_total_after_store_credit,
+        :total_applicable_store_credit, :display_total_available_store_credit, :display_store_credit_remaining_after_capture
+
       ]
 
       @@line_item_attributes = [:id, :quantity, :price, :variant_id]
@@ -158,6 +163,11 @@ module Spree
       @@store_attributes = [
         :id, :name, :url, :meta_description, :meta_keywords, :seo_title,
         :mail_from_address, :default_currency, :code, :default
+      ]
+
+      @@store_credit_history_attributes = [
+        :display_amount, :display_user_total_amount, :display_action,
+        :display_event_date
       ]
 
       def variant_attributes

--- a/api/app/views/spree/api/store_credit_events/mine.v1.rabl
+++ b/api/app/views/spree/api/store_credit_events/mine.v1.rabl
@@ -1,0 +1,10 @@
+object false
+
+child(@store_credit_events => :store_credit_events) do
+  attributes *store_credit_history_attributes
+  node(:order_number) { |event| event.order.try(:number) }
+end
+
+node(:count) { @store_credit_events.count }
+node(:current_page) { params[:page] || 1 }
+node(:pages) { @store_credit_events.num_pages }

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -115,6 +115,12 @@ Spree::Core::Engine.add_routes do
 
     resources :stores
 
+    resources :store_credit_events, only: [] do
+      collection do
+        get :mine
+      end
+    end
+
     get '/config/money', to: 'config#money'
     get '/config', to: 'config#show'
 

--- a/api/spec/controllers/spree/api/store_credit_events_controller_spec.rb
+++ b/api/spec/controllers/spree/api/store_credit_events_controller_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+describe Spree::Api::StoreCreditEventsController, type: :controller do
+  render_views
+
+  let(:api_user) { create(:user) }
+
+  before do
+    allow(controller).to receive(:load_user)
+    controller.instance_variable_set(:@current_api_user, api_user)
+  end
+
+  describe "GET mine" do
+
+    subject { api_get :mine, { format: :json } }
+
+    before { allow(controller).to receive_messages(current_api_user: current_api_user) }
+
+    context "no current api user" do
+      let(:current_api_user) { nil }
+
+      before { subject }
+
+      it "returns a 401" do
+        expect(response.status).to eq 401
+      end
+    end
+
+    context "the current api user is authenticated" do
+      let(:current_api_user) { order.user }
+      let(:order) { create(:order, line_items: [line_item]) }
+
+      context "the user doesn't have store credit" do
+        let(:current_api_user) { create(:user) }
+
+        before { subject }
+
+        it "should set the events variable to empty list" do
+          expect(assigns(:store_credit_events)).to eq []
+        end
+
+        it "returns a 200" do
+          expect(subject.status).to eq 200
+        end
+      end
+
+      context "the user has store credit" do
+        let(:store_credit)     { create(:store_credit, user: api_user) }
+        let(:current_api_user) { store_credit.user }
+
+        before { subject }
+
+        it "should contain one store credit event" do
+          expect(assigns(:store_credit_events).size).to eq 1
+        end
+
+        it "should contain the store credit allocation event" do
+          expect(assigns(:store_credit_events).first).to eq store_credit.store_credit_events.first
+        end
+
+        it "returns a 200" do
+          expect(subject.status).to eq 200
+        end
+      end
+    end
+  end
+end
+

--- a/backend/app/controllers/spree/admin/resource_controller.rb
+++ b/backend/app/controllers/spree/admin/resource_controller.rb
@@ -108,7 +108,7 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
       def belongs_to(model_name, options = {})
         @parent_data ||= {}
         @parent_data[:model_name] = model_name
-        @parent_data[:model_class] = model_name.to_s.classify.constantize
+        @parent_data[:model_class] = (options[:model_class] || model_name.to_s.classify.constantize)
         @parent_data[:find_by] = options[:find_by] || :id
       end
     end

--- a/backend/app/controllers/spree/admin/store_credits_controller.rb
+++ b/backend/app/controllers/spree/admin/store_credits_controller.rb
@@ -1,0 +1,43 @@
+module Spree
+  module Admin
+    class StoreCreditsController < ResourceController
+      belongs_to 'spree/user', model_class: Spree.user_class
+      before_action :load_categories, only: [:new, :edit]
+      create.fails :load_categories
+      update.fails :load_categories
+      create.before :set_action_originator
+
+      def invalidate
+        if @store_credit.invalidate
+          respond_with(@store_credit) do |format|
+            format.html { redirect_to location_after_destroy }
+            format.js   { render :partial => "spree/admin/shared/destroy" }
+          end
+        else
+          respond_with(@store_credit) do |format|
+            format.html { redirect_to location_after_destroy }
+          end
+        end
+      end
+
+      private
+
+      def permitted_resource_params
+        params.require(:store_credit).permit([:amount, :category_id, :memo]).
+          merge(currency: Spree::Config[:currency], created_by: try_spree_current_user)
+      end
+
+      def collection
+        @collection = super.reverse_order
+      end
+
+      def load_categories
+        @credit_categories = Spree::StoreCreditCategory.all.order(:name)
+      end
+
+      def set_action_originator
+        @object.action_originator = try_spree_current_user
+      end
+    end
+  end
+end

--- a/backend/app/models/spree/backend_configuration.rb
+++ b/backend/app/models/spree/backend_configuration.rb
@@ -16,6 +16,6 @@ module Spree
                             :stock_locations, :trackers, :refund_reasons,
                             :reimbursement_types, :return_authorization_reasons]
     PROMOTION_TABS     ||= [:promotions, :promotion_categories]
-    USER_TABS          ||= [:users]
+    USER_TABS          ||= [:users, :store_credits]
   end
 end

--- a/backend/app/views/spree/admin/store_credits/_form.html.erb
+++ b/backend/app/views/spree/admin/store_credits/_form.html.erb
@@ -1,0 +1,24 @@
+<div data-hook="admin_store_credit_form_fields" class="row">
+  <div class="alpha twelve columns">
+    <%= f.field_container :amount do %>
+      <%= f.label :amount, Spree.t(:amount) %> <span class="required">*</span><br />
+      <%= f.number_field :amount, min: 0.00, step: :any %>
+      <%= f.error_message_on :amount %>
+    <% end %>
+  </div>
+  <div class="alpha twelve columns">
+    <%= f.field_container :category do %>
+      <%= f.label :category, Spree.t(:reason) %> <span class="required">*</span><br />
+      <%= f.select :category_id, options_from_collection_for_select(@credit_categories, :id, :name, f.object.category.try(:id)),
+        { include_blank: true }, { class: 'select2 fullwidth', placeholder: Spree.t("admin.store_credits.select_reason") } %>
+      <%= f.error_message_on :category %>
+    <% end %>
+  </div>
+  <div data-hook="admin_store_credit_memo_field" class="alpha twelve columns">
+    <%= f.field_container :memo do %>
+      <%= f.label :memo, Spree.t(:memo) %>
+      <%= f.text_area :memo, class: "fullwidth" %>
+      <%= f.error_message_on :memo %>
+    <% end %>
+  </div>
+</div>

--- a/backend/app/views/spree/admin/store_credits/edit.html.erb
+++ b/backend/app/views/spree/admin/store_credits/edit.html.erb
@@ -1,0 +1,16 @@
+<% content_for :page_title do %>
+  <%= link_to "#{Spree.t(:editing_user)} #{@user.email}", edit_admin_user_url(@user) %>
+<% end %>
+
+<%= render :partial => 'spree/admin/users/sidebar', :locals => { :current => :store_credits } %>
+<% content_for :page_actions do %>
+  <li><%= link_to_with_icon 'arrow-left', Spree.t("admin.store_credits.back_to_store_credit_list"), admin_user_store_credits_path(@user), class: 'button' %></li>
+<% end %>
+
+<%= form_for [:admin, @user, @store_credit] do |f| %>
+  <fieldset>
+    <legend align="center"><%= Spree.t("admin.store_credits.edit") %></legend>
+    <%= render :partial => 'form', :locals => { :f => f } %>
+    <%= render :partial => 'spree/admin/shared/edit_resource_links', :locals => { :collection_url => admin_user_store_credits_path(@user) } %>
+  </fieldset>
+<% end %>

--- a/backend/app/views/spree/admin/store_credits/index.html.erb
+++ b/backend/app/views/spree/admin/store_credits/index.html.erb
@@ -1,0 +1,65 @@
+<% content_for :page_title do %>
+  <%= link_to "#{Spree.t(:editing_user)} #{@user.email}", edit_admin_user_url(@user) %>
+<% end %>
+
+<%= render :partial => 'spree/admin/users/sidebar', :locals => { :current => :store_credits } %>
+<% content_for :page_actions do %>
+  <li><%= link_to_with_icon 'arrow-left', Spree.t("admin.store_credits.back_to_user_list"), admin_users_path, class: 'button' %></li>
+  <li><%= link_to_with_icon 'plus', Spree.t("admin.store_credits.add"), new_admin_user_store_credit_path(@user), class: 'button' %></li>
+<% end %>
+
+<% if @store_credits.any? %>
+  <table>
+    <thead>
+      <th><%= Spree.t("admin.store_credits.credited_html_header") %></th>
+      <th><%= Spree.t("admin.store_credits.used_html_header") %></th>
+      <th><%= Spree.t("admin.store_credits.authed_html_header") %></th>
+      <th><%= Spree.t("admin.store_credits.type_html_header") %></th>
+      <th><%= Spree.t("admin.store_credits.created_by") %></th>
+      <th><%= Spree.t("admin.store_credits.issued_on") %></th>
+      <th><%= Spree.t("admin.store_credits.invalidated") %></th>
+      <th data-hook="admin_store_credits_index_header_actions" class="actions"></th>
+    <thead>
+    <tbody>
+      <% @store_credits.each do |store_credit| %>
+        <tr>
+          <td class='align-center'>
+            <span><%= store_credit.display_amount.to_html %></span>
+          </td>
+          <td class='align-center'>
+            <span><%= store_credit.display_amount_used.to_html %></span>
+          </td>
+          <td class='align-center'>
+            <span><%= store_credit.display_amount_authorized.to_html %></span>
+          </td>
+          <td class='align-center'>
+            <span><%= store_credit.category_name %></span>
+          </td>
+          <td>
+            <span><%= store_credit.created_by_email %></span>
+          </td>
+          <td class='align-center'>
+            <span><%= l store_credit.created_at.to_date %></span>
+          </td>
+          <td class='align-center'>
+            <span><%= store_credit.invalidated? %></span>
+          </td>
+          <td class="actions" data-hook="admin_store_credits_index_row_actions">
+            <% if store_credit.editable? && can?(:edit, store_credit) %>
+              <%= link_to_edit_url edit_admin_user_store_credit_path(@user, store_credit), { no_text: true, class: 'edit' } %>
+            <% end %>
+
+            <% if store_credit.invalidateable? && can?(:invalidate, store_credit) %>
+              <%= link_to_with_icon 'ban', Spree.t("store_credit.invalidate"), invalidate_admin_user_store_credit_path(@user, store_credit), { no_text: true, class: 'edit', method: "PUT" } %>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <div class="alpha twelve columns no-objects-found">
+    <%= Spree.t(:no_resource_found, resource: Spree.t("admin.store_credits.resource_name")) %>,
+    <%= link_to Spree.t(:add_one), spree.new_admin_user_store_credit_path(@user) %>!
+  </div>
+<% end %>

--- a/backend/app/views/spree/admin/store_credits/new.html.erb
+++ b/backend/app/views/spree/admin/store_credits/new.html.erb
@@ -1,0 +1,16 @@
+<% content_for :page_title do %>
+  <%= link_to "#{Spree.t(:editing_user)} #{@user.email}", edit_admin_user_url(@user) %>
+<% end %>
+
+<%= render :partial => 'spree/admin/users/sidebar', :locals => { :current => :store_credits } %>
+<% content_for :page_actions do %>
+  <li><%= link_to_with_icon 'arrow-left', Spree.t("admin.store_credits.back_to_store_credit_list"), admin_user_store_credits_path(@user), class: 'button' %></li>
+<% end %>
+
+<%= form_for [:admin, @user, @store_credit] do |f| %>
+  <fieldset>
+    <legend align="center"><%= Spree.t("admin.store_credits.new") %></legend>
+    <%= render :partial => 'form', :locals => { :f => f } %>
+    <%= render :partial => 'spree/admin/shared/new_resource_links', :locals => { :collection_url => admin_user_store_credits_path(@user) } %>
+  </fieldset>
+<% end %>

--- a/backend/app/views/spree/admin/users/_sidebar.html.erb
+++ b/backend/app/views/spree/admin/users/_sidebar.html.erb
@@ -17,6 +17,9 @@
       <li<%== ' class="active"' if current == :items %>>
         <%= link_to_with_icon 'edit', Spree.t(:"admin.user.items"), items_admin_user_path(@user) %>
       </li>
+      <li<%== ' class="active"' if current == :store_credits %>>
+        <%= link_to_with_icon 'money', Spree.t(:"admin.user.store_credit"), admin_user_store_credits_path(@user) %>
+      </li>
     </ul>
 
     <fieldset data-hook="admin_user_lifetime_stats">

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -179,6 +179,11 @@ Spree::Core::Engine.add_routes do
         get :addresses
         put :addresses
       end
+      resources :store_credits, except: [:destroy] do
+        member do
+          put :invalidate
+        end
+      end
     end
   end
 

--- a/backend/spec/controllers/spree/admin/store_credits_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/store_credits_controller_spec.rb
@@ -1,0 +1,205 @@
+require 'spec_helper'
+
+describe Spree::Admin::StoreCreditsController do
+  stub_authorization!
+
+  let(:user) { create(:user) }
+  let(:admin_user) { create(:admin_user) }
+
+  let!(:b_credit_category) { create(:store_credit_category, name: "B category") }
+  let!(:a_credit_category) { create(:store_credit_category, name: "A category") }
+
+  describe "#new" do
+    before { spree_get :new, user_id: create(:user).id }
+    it { expect(assigns(:credit_categories)).to eq [a_credit_category, b_credit_category] }
+  end
+
+  describe "#create" do
+
+    subject { spree_post :create, parameters }
+
+    before  {
+      allow(controller).to receive_messages(try_spree_current_user: admin_user)
+      create(:primary_credit_type)
+    }
+
+    context "the passed parameters are valid" do
+      let(:parameters) do
+        {
+          user_id: user.id,
+          store_credit: {
+            amount: 1.00,
+            category_id: a_credit_category.id
+          }
+        }
+      end
+
+      it "creates a new store credit" do
+        expect { subject }.to change(Spree::StoreCredit, :count).by(1)
+      end
+
+      it "associates the store credit with the user" do
+        subject
+        expect(user.reload.store_credits.count).to eq 1
+      end
+
+      it "assigns the store credit's created by to the current user" do
+        subject
+        expect(user.reload.store_credits.first.created_by).to eq admin_user
+      end
+
+      it 'sets the admin as the store credit event originator' do
+        expect { subject }.to change { Spree::StoreCreditEvent.count }.by(1)
+        expect(Spree::StoreCreditEvent.last.originator).to eq admin_user
+      end
+    end
+
+    context "the passed parameters are invalid" do
+      let(:parameters) do
+        {
+          user_id: user.id,
+          store_credit: {
+            amount: -1.00,
+            category_id: a_credit_category.id
+          }
+        }
+      end
+
+      it { expect { subject }.not_to change(Spree::StoreCredit, :count) }
+    end
+  end
+
+  describe "#edit" do
+    let!(:store_credit) { create(:store_credit, user: user, category: a_credit_category) }
+    before { spree_get :edit, user_id: user.id, id: store_credit.id }
+
+    it { expect(assigns(:credit_categories)).to eq [a_credit_category, b_credit_category] }
+  end
+
+  describe "#update" do
+    let!(:store_credit) { create(:store_credit, user: user, category: b_credit_category) }
+
+    subject { spree_put :update, parameters }
+
+    before  { allow(controller).to receive_messages(try_spree_current_user: admin_user) }
+
+    context "the passed parameters are valid" do
+      let(:updated_amount) { 300.0 }
+
+      let(:parameters) do
+        {
+          user_id: user.id,
+          id: store_credit.id,
+          store_credit: {
+            amount: updated_amount,
+            category_id: a_credit_category.id
+          }
+        }
+      end
+
+      context "the store credit has been partially used" do
+        before { store_credit.update_attributes(amount_used: 10.0) }
+
+        context "the new amount is greater than the used amount" do
+          let(:updated_amount) { 11.0 }
+          it "updates the amount to be the passed in amount" do
+            subject
+            expect(store_credit.reload.amount).to eq updated_amount
+          end
+        end
+
+        context "the new amount is less than the used amount" do
+          let(:updated_amount) { 9.0 }
+          it "does not update the amount" do
+            expect { subject }.not_to change { store_credit.reload.amount }
+          end
+
+          it "responds with an error message" do
+            subject
+            expect(flash.now[:error]).to match "greater than the credited amount"
+          end
+        end
+      end
+
+      context "the store credit has not been used" do
+        it "redirects to index" do
+          expect(subject).to redirect_to spree.admin_user_store_credits_path(user)
+        end
+
+        it "does not create a new store credit" do
+          expect { subject }.to_not change(Spree::StoreCredit, :count)
+        end
+
+        it "assigns the store credit's created by to the current user" do
+          subject
+          expect(store_credit.reload.created_by).to eq admin_user
+        end
+
+        it "updates passed amount" do
+          subject
+          expect(store_credit.reload.amount).to eq updated_amount
+        end
+
+        it "updates passed category" do
+          subject
+          expect(store_credit.reload.category).to eq a_credit_category
+        end
+
+        it "maintains the user association" do
+          subject
+          expect(store_credit.reload.user).to eq user
+        end
+      end
+    end
+
+    context "the passed parameters are invalid" do
+      let(:parameters) do
+        {
+          user_id: user.id,
+          id: store_credit.id,
+          store_credit: { amount: -1.00, category_id: a_credit_category.id }
+        }
+      end
+
+      it { expect { subject }.not_to change { store_credit.reload.amount } }
+    end
+  end
+
+  describe "#invalidate" do
+    let!(:store_credit) { create(:store_credit, user: user, category: b_credit_category) }
+
+    it "attempts to invalidate the store credit" do
+      expect { spree_put :invalidate, user_id: user.id, id: store_credit.id }.to change { store_credit.reload.invalidated_at }.from(nil)
+    end
+
+    context "the invalidation is unsuccessful" do
+      before do
+        store_credit.authorize(5.0, "USD")
+        subject
+      end
+
+      subject { spree_put :invalidate, user_id: user.id, id: store_credit.id }
+
+      it "redirects to index" do
+        expect(response).to redirect_to spree.admin_user_store_credits_path(user)
+      end
+    end
+
+    context "html request" do
+      subject { spree_put :invalidate, user_id: user.id, id: store_credit.id }
+
+      it "redirects to index" do
+        expect(subject).to redirect_to spree.admin_user_store_credits_path(user)
+      end
+    end
+
+    context "js request" do
+      subject { spree_put :invalidate, user_id: user.id, id: store_credit.id, format: :js }
+
+      it "returns a 200 status code" do
+        subject
+        expect(response.code).to eq "200"
+      end
+    end
+  end
+end

--- a/backend/spec/features/admin/store_credits_spec.rb
+++ b/backend/spec/features/admin/store_credits_spec.rb
@@ -1,0 +1,80 @@
+require 'spec_helper'
+
+describe "Store credits admin" do
+  stub_authorization!
+  let!(:admin_user)   { create(:admin_user) }
+  let!(:store_credit) { create(:store_credit) }
+  let(:user)          { store_credit.user }
+
+  before do
+    allow(Spree.user_class).to receive(:find_by).
+      with(hash_including(:id)).
+      and_return(store_credit.user)
+  end
+
+  describe "visiting the store credits page" do
+    before do
+      visit spree.admin_path
+      click_link "Users"
+    end
+
+    it "should be on the store credits page" do
+      click_link store_credit.user.email
+      click_link "Store Credit"
+      expect(page.current_path).to eq spree.admin_user_store_credits_path(store_credit.user)
+
+      store_credit_table = page.find(".twelve.columns > table")
+      expect(store_credit_table.all('tr').count).to eq 1
+      expect(store_credit_table).to have_content(Spree::Money.new(store_credit.amount).to_s)
+      expect(store_credit_table).to have_content(Spree::Money.new(store_credit.amount_used).to_s)
+      expect(store_credit_table).to have_content(store_credit.category_name)
+      expect(store_credit_table).to have_content(store_credit.created_by_email)
+    end
+  end
+
+  describe "creating store credit" do
+    before do
+      visit spree.admin_path
+      click_link "Users"
+      click_link store_credit.user.email
+      click_link "Store Credit"
+      allow_any_instance_of(Spree::Admin::StoreCreditsController).to receive_messages(try_spree_current_user: admin_user)
+    end
+
+    it "should create store credit and associate it with the user" do
+      click_link "Add store credit"
+      page.fill_in "store_credit_amount", with: "102.00"
+      select "Exchange", from: "store_credit_category_id"
+      click_button "Create"
+
+      expect(page.current_path).to eq spree.admin_user_store_credits_path(store_credit.user)
+      store_credit_table = page.find(".twelve.columns > table")
+      expect(store_credit_table.all('tr').count).to eq 2
+      expect(Spree::StoreCredit.count).to eq 2
+    end
+  end
+
+  describe "updating store credit" do
+    let(:updated_amount) { "99.0" }
+
+    before do
+      visit spree.admin_path
+      click_link "Users"
+      click_link store_credit.user.email
+      click_link "Store Credit"
+      allow_any_instance_of(Spree::Admin::StoreCreditsController).to receive_messages(try_spree_current_user: admin_user)
+    end
+
+    it "should create store credit and associate it with the user" do
+      click_link "Edit"
+      page.fill_in "store_credit_amount", with: updated_amount
+      click_button "Update"
+
+      expect(page.current_path).to eq spree.admin_user_store_credits_path(store_credit.user)
+      store_credit_table = page.find(".twelve.columns > table")
+      expect(store_credit_table).to have_content(Spree::Money.new(updated_amount).to_s)
+      expect(store_credit.reload.amount.to_f).to eq updated_amount.to_f
+    end
+  end
+
+end

--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -67,6 +67,9 @@ module Spree
     preference :send_core_emails, :boolean, :default => true
     preference :mails_from, :string, :default => 'spree@example.com'
 
+    # Store credits configurations
+    preference :credit_to_new_allocation, :boolean, default: false
+
     # searcher_class allows spree extension writers to provide their own Search class
     def searcher_class
       @searcher_class ||= Spree::Core::Search::Base

--- a/core/app/models/spree/legacy_user.rb
+++ b/core/app/models/spree/legacy_user.rb
@@ -9,6 +9,11 @@ module Spree
 
     self.table_name = 'spree_users'
 
+    # for url generation
+    def self.model_name
+      ActiveModel::Name.new(self, nil, "User")
+    end
+
     has_many :orders, foreign_key: :user_id
 
     before_destroy :check_completed_orders

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -87,6 +87,8 @@ module Spree
                 before_transition to: :payment, do: :create_tax_charge!
                 before_transition to: :payment, do: :assign_default_credit_card
 
+                before_transition to: :confirm, do: :add_store_credit_payments
+
                 event :complete do
                   transition to: :complete, from: :confirm
                   transition to: :complete, from: :payment

--- a/core/app/models/spree/payment_method.rb
+++ b/core/app/models/spree/payment_method.rb
@@ -71,5 +71,9 @@ module Spree
     def cancel(response)
       raise ::NotImplementedError, 'You must implement cancel method for this payment method.'
     end
+
+    def store_credit?
+      is_a? Spree::PaymentMethod::StoreCredit
+    end
   end
 end

--- a/core/app/models/spree/payment_method/store_credit.rb
+++ b/core/app/models/spree/payment_method/store_credit.rb
@@ -1,0 +1,115 @@
+module Spree
+  class PaymentMethod::StoreCredit < PaymentMethod
+
+    def payment_source_class
+      ::Spree::StoreCredit
+    end
+
+    def can_capture?(payment)
+      ['checkout', 'pending'].include?(payment.state)
+    end
+
+    def can_void?(payment)
+      payment.pending?
+    end
+
+    def authorize(amount_in_cents, store_credit, gateway_options = {})
+      if store_credit.nil?
+        ActiveMerchant::Billing::Response.new(false, Spree.t('store_credit.unable_to_find'), {}, {})
+      else
+        action = -> (store_credit) {
+          store_credit.authorize(
+            amount_in_cents / 100.0.to_d,
+            gateway_options[:currency],
+            action_originator: gateway_options[:originator]
+          )
+        }
+        handle_action_call(store_credit, action, :authorize)
+      end
+    end
+
+    def capture(amount_in_cents, auth_code, gateway_options = {})
+      action = -> (store_credit) {
+        store_credit.capture(
+          amount_in_cents / 100.0.to_d,
+          auth_code,
+          gateway_options[:currency],
+          action_originator: gateway_options[:originator]
+        )
+      }
+
+      handle_action(action, :capture, auth_code)
+    end
+
+    def purchase(amount_in_cents, store_credit, gateway_options = {})
+      eligible_events = store_credit.store_credit_events.where(amount: amount_in_cents / 100.0.to_d, action: Spree::StoreCredit::ELIGIBLE_ACTION)
+      event = eligible_events.find do |eligible_event|
+        store_credit.store_credit_events.where(authorization_code: eligible_event.authorization_code)
+                                        .where.not(action: Spree::StoreCredit::ELIGIBLE_ACTION).empty?
+      end
+
+      if event.blank?
+        ActiveMerchant::Billing::Response.new(false, Spree.t('store_credit.unable_to_find'), {}, {})
+      else
+        capture(amount_in_cents, event.authorization_code, gateway_options)
+      end
+    end
+
+    def void(auth_code, gateway_options={})
+      action = -> (store_credit) {
+        store_credit.void(auth_code, action_originator: gateway_options[:originator])
+      }
+      handle_action(action, :void, auth_code)
+    end
+
+    def credit(amount_in_cents, auth_code, gateway_options)
+      action = -> (store_credit) do
+        currency = gateway_options[:currency] || store_credit.currency
+        originator = gateway_options[:originator]
+
+        store_credit.credit(amount_in_cents / 100.0.to_d, auth_code, currency, action_originator: originator)
+      end
+
+      handle_action(action, :credit, auth_code)
+    end
+
+    def cancel(auth_code)
+      store_credit_event = StoreCreditEvent.find_by(authorization_code: auth_code, action: Spree::StoreCredit::CAPTURE_ACTION)
+      store_credit = store_credit_event.try(:store_credit)
+
+      return false if !store_credit_event || !store_credit
+      store_credit.credit(store_credit_event.amount, auth_code, store_credit.currency)
+    end
+
+    def source_required?
+      true
+    end
+
+    private
+
+    def handle_action_call(store_credit, action, action_name, auth_code=nil)
+      store_credit.with_lock do
+        if response = action.call(store_credit)
+          # note that we only need to return the auth code on an 'auth', but it's innocuous to always return
+          ActiveMerchant::Billing::Response.new(true,
+                                                Spree.t('store_credit.successful_action', action: action_name),
+                                                {}, { authorization: auth_code || response })
+        else
+          ActiveMerchant::Billing::Response.new(false, store_credit.errors.full_messages.join, {}, {})
+        end
+      end
+    end
+
+    def handle_action(action, action_name, auth_code)
+      # Find first event with provided auth_code
+      store_credit = StoreCreditEvent.find_by_authorization_code(auth_code).try(:store_credit)
+
+      if store_credit.nil?
+        ActiveMerchant::Billing::Response.new(false, Spree.t('store_credit.unable_to_find_for_action', auth_code: auth_code, action: action_name), {}, {})
+      else
+        handle_action_call(store_credit, action, action_name, auth_code)
+      end
+    end
+
+  end
+end

--- a/core/app/models/spree/reimbursement.rb
+++ b/core/app/models/spree/reimbursement.rb
@@ -38,7 +38,7 @@ module Spree
     #   Refund.total_amount_reimbursed_for(reimbursement)
     # See the `reimbursement_generator` property regarding the generation of custom reimbursements.
     class_attribute :reimbursement_models
-    self.reimbursement_models = [Refund]
+    self.reimbursement_models = [Refund, Reimbursement::Credit]
 
     # The reimbursement_performer property should be set to an object that responds to the following methods:
     # - #perform

--- a/core/app/models/spree/reimbursement/credit.rb
+++ b/core/app/models/spree/reimbursement/credit.rb
@@ -1,7 +1,7 @@
 module Spree
   class Reimbursement::Credit < Spree::Base
     class_attribute :default_creditable_class
-    self.default_creditable_class = nil
+    self.default_creditable_class = Spree::StoreCredit
 
     belongs_to :reimbursement, inverse_of: :credits
     belongs_to :creditable, polymorphic: true

--- a/core/app/models/spree/reimbursement/reimbursement_type_engine.rb
+++ b/core/app/models/spree/reimbursement/reimbursement_type_engine.rb
@@ -9,7 +9,7 @@ module Spree
     self.default_reimbursement_type = Spree::ReimbursementType::OriginalPayment
 
     class_attribute :expired_reimbursement_type
-    self.expired_reimbursement_type = Spree::ReimbursementType::OriginalPayment
+    self.expired_reimbursement_type = Spree::ReimbursementType::StoreCredit
 
     class_attribute :exchange_reimbursement_type
     self.exchange_reimbursement_type = Spree::ReimbursementType::Exchange

--- a/core/app/models/spree/reimbursement_type/reimbursement_helpers.rb
+++ b/core/app/models/spree/reimbursement_type/reimbursement_helpers.rb
@@ -49,7 +49,14 @@ module Spree
     end
 
     def create_creditable(reimbursement, unpaid_amount)
-      Spree::Reimbursement::Credit.default_creditable_class.new(reimbursement: reimbursement, amount: unpaid_amount)
+      Spree::Reimbursement::Credit.default_creditable_class.new(
+        user: reimbursement.order.user,
+        amount: unpaid_amount,
+        category: Spree::StoreCreditCategory.reimbursement_category(reimbursement),
+        created_by: Spree::StoreCredit.default_created_by,
+        memo: "Refund for uncreditable payments on order #{reimbursement.order.number}",
+        currency: reimbursement.order.currency
+      )
     end
 
     def sorted_eligible_refund_payments(payments)

--- a/core/app/models/spree/reimbursement_type/store_credit.rb
+++ b/core/app/models/spree/reimbursement_type/store_credit.rb
@@ -1,0 +1,27 @@
+class Spree::ReimbursementType::StoreCredit < Spree::ReimbursementType
+  extend Spree::ReimbursementType::ReimbursementHelpers
+
+  class << self
+    def reimburse(reimbursement, return_items, simulate)
+      unpaid_amount = return_items.sum(&:total).to_d.round(2, :down)
+      payments = store_credit_payments(reimbursement)
+      reimbursement_list = []
+
+      # Credit each store credit that was used on the order
+      reimbursement_list, unpaid_amount = create_refunds(reimbursement, payments, unpaid_amount, simulate, reimbursement_list)
+
+      # If there is any amount left to pay out to the customer, then create credit with that amount
+      if unpaid_amount > 0.0
+        reimbursement_list, unpaid_amount = create_credits(reimbursement, unpaid_amount, simulate, reimbursement_list)
+      end
+
+      reimbursement_list
+    end
+
+    private
+
+    def store_credit_payments(reimbursement)
+      reimbursement.order.payments.completed.store_credits
+    end
+  end
+end

--- a/core/app/models/spree/store_credit.rb
+++ b/core/app/models/spree/store_credit.rb
@@ -1,0 +1,267 @@
+class Spree::StoreCredit < ActiveRecord::Base
+  acts_as_paranoid
+
+  VOID_ACTION       = 'void'
+  CREDIT_ACTION     = 'credit'
+  CAPTURE_ACTION    = 'capture'
+  ELIGIBLE_ACTION   = 'eligible'
+  AUTHORIZE_ACTION  = 'authorize'
+  ALLOCATION_ACTION = 'allocation'
+
+  DEFAULT_CREATED_BY_EMAIL = "spree@example.com"
+
+  belongs_to :user, class_name: Spree.user_class.to_s
+  belongs_to :created_by, class_name: Spree.user_class.to_s
+  belongs_to :category, class_name: "Spree::StoreCreditCategory"
+  belongs_to :credit_type, class_name: 'Spree::StoreCreditType', :foreign_key => 'type_id'
+  has_many :store_credit_events
+
+  validates_presence_of :user_id, :category_id, :type_id, :created_by_id, :currency
+  validates_numericality_of :amount, { greater_than: 0 }
+  validates_numericality_of :amount_used, { greater_than_or_equal_to: 0 }
+  validate :amount_used_less_than_or_equal_to_amount
+  validate :amount_authorized_less_than_or_equal_to_amount
+
+  delegate :name, to: :category, prefix: true
+  delegate :email, to: :created_by, prefix: true
+
+  scope :order_by_priority, -> { includes(:credit_type).order('spree_store_credit_types.priority ASC') }
+
+  before_validation :associate_credit_type
+  after_save :store_event
+  before_destroy :validate_no_amount_used
+
+  attr_accessor :action, :action_amount, :action_originator, :action_authorization_code
+
+  extend Spree::DisplayMoney
+  money_methods :amount, :amount_used, :amount_authorized
+
+  def amount_remaining
+    return 0.0.to_d if invalidated?
+    amount - amount_used - amount_authorized
+  end
+
+  def authorize(amount, order_currency, options={})
+    authorization_code = options[:action_authorization_code]
+    if authorization_code
+      if store_credit_events.find_by(action: AUTHORIZE_ACTION, authorization_code: authorization_code)
+        # Don't authorize again on capture
+        return true
+      end
+    else
+      authorization_code = generate_authorization_code
+    end
+
+    if validate_authorization(amount, order_currency)
+      update_attributes!({
+        action: AUTHORIZE_ACTION,
+        action_amount: amount,
+        action_originator: options[:action_originator],
+        action_authorization_code: authorization_code,
+
+        amount_authorized: self.amount_authorized + amount,
+      })
+      authorization_code
+    else
+      errors.add(:base, Spree.t('store_credit.insufficient_authorized_amount'))
+      false
+    end
+  end
+
+  def validate_authorization(amount, order_currency)
+    if amount_remaining.to_d < amount.to_d
+      errors.add(:base, Spree.t('store_credit.insufficient_funds'))
+    elsif currency != order_currency
+      errors.add(:base, Spree.t('store_credit.currency_mismatch'))
+    end
+    return errors.blank?
+  end
+
+  def capture(amount, authorization_code, order_currency, options={})
+    return false unless authorize(amount, order_currency, action_authorization_code: authorization_code)
+    auth_event = store_credit_events.find_by!(action: AUTHORIZE_ACTION, authorization_code: authorization_code)
+
+    if amount <= auth_event.amount
+      if currency != order_currency
+        errors.add(:base, Spree.t('store_credit.currency_mismatch'))
+        false
+      else
+        update_attributes!({
+          action: CAPTURE_ACTION,
+          action_amount: amount,
+          action_originator: options[:action_originator],
+          action_authorization_code: authorization_code,
+
+          amount_used: self.amount_used + amount,
+          amount_authorized: self.amount_authorized - auth_event.amount,
+        })
+        authorization_code
+      end
+    else
+      errors.add(:base, Spree.t('store_credit.insufficient_authorized_amount'))
+      false
+    end
+  end
+
+  def void(authorization_code, options={})
+    if auth_event = store_credit_events.find_by(action: AUTHORIZE_ACTION, authorization_code: authorization_code)
+      self.update_attributes!({
+        action: VOID_ACTION,
+        action_amount: auth_event.amount,
+        action_authorization_code: authorization_code,
+        action_originator: options[:action_originator],
+
+        amount_authorized: amount_authorized - auth_event.amount,
+      })
+      true
+    else
+      errors.add(:base, Spree.t('store_credit.unable_to_void', auth_code: authorization_code))
+      false
+    end
+  end
+
+  def credit(amount, authorization_code, order_currency, options={})
+    # Find the amount related to this authorization_code in order to add the store credit back
+    capture_event = store_credit_events.find_by(action: CAPTURE_ACTION, authorization_code: authorization_code)
+
+    if currency != order_currency  # sanity check to make sure the order currency hasn't changed since the auth
+      errors.add(:base, Spree.t('store_credit.currency_mismatch'))
+      false
+    elsif capture_event && amount <= capture_event.amount
+      action_attributes = {
+        action: CREDIT_ACTION,
+        action_amount: amount,
+        action_originator: options[:action_originator],
+        action_authorization_code: authorization_code,
+      }
+      create_credit_record(amount, action_attributes)
+      true
+    else
+      errors.add(:base, Spree.t('store_credit.unable_to_credit', auth_code: authorization_code))
+      false
+    end
+  end
+
+  def actions
+    [CAPTURE_ACTION, VOID_ACTION, CREDIT_ACTION]
+  end
+
+  def can_capture?(payment)
+    payment.pending? || payment.checkout?
+  end
+
+  def can_void?(payment)
+    payment.pending?
+  end
+
+  def can_credit?(payment)
+    payment.completed? && payment.credit_allowed > 0
+  end
+
+  def generate_authorization_code
+    "#{self.id}-SC-#{Time.now.utc.strftime("%Y%m%d%H%M%S%6N")}"
+  end
+
+  def editable?
+    !amount_remaining.zero?
+  end
+
+  def invalidateable?
+    !invalidated? && amount_authorized.zero?
+  end
+
+  def invalidated?
+    !!invalidated_at
+  end
+
+  def invalidate
+    if invalidateable?
+      touch(:invalidated_at)
+    else
+      errors.add(:invalidated_at, Spree.t("store_credit.errors.cannot_invalidate_uncaptured_authorization"))
+      return false
+    end
+  end
+
+  class << self
+    def default_created_by
+      Spree.user_class.find_by(email: DEFAULT_CREATED_BY_EMAIL)
+    end
+  end
+
+  private
+
+  def create_credit_record(amount, action_attributes={})
+    # Setting credit_to_new_allocation to true will create a new allocation anytime #credit is called
+    # If it is not set, it will update the store credit's amount in place
+    credit = if Spree::Config[:credit_to_new_allocation]
+      Spree::StoreCredit.new(create_credit_record_params(amount))
+    else
+      self.amount_used = amount_used - amount
+      self
+    end
+
+    credit.assign_attributes(action_attributes)
+    credit.save!
+  end
+
+  def create_credit_record_params(amount)
+    {
+      amount: amount,
+      user_id: self.user_id,
+      category_id: self.category_id,
+      created_by_id: self.created_by_id,
+      currency: self.currency,
+      type_id: self.type_id,
+      memo: credit_allocation_memo,
+    }
+  end
+
+  def credit_allocation_memo
+    Spree.t("store_credit.credit_allocation_memo", id: self.id)
+  end
+
+  def store_event
+    return unless amount_changed? || amount_used_changed? || amount_authorized_changed? || action == ELIGIBLE_ACTION
+
+    event = if action
+      store_credit_events.build(action: action)
+    else
+      store_credit_events.where(action: ALLOCATION_ACTION).first_or_initialize
+    end
+
+    event.update_attributes!({
+      amount: action_amount || amount,
+      authorization_code: action_authorization_code || event.authorization_code || generate_authorization_code,
+      user_total_amount: user.total_available_store_credit,
+      originator: action_originator,
+    })
+  end
+
+  def amount_used_less_than_or_equal_to_amount
+    return true if amount_used.nil?
+
+    if amount_used > amount
+      errors.add(:amount_used, Spree.t('admin.store_credits.errors.amount_used_cannot_be_greater'))
+    end
+  end
+
+  def amount_authorized_less_than_or_equal_to_amount
+    if (amount_used + amount_authorized) > amount
+      errors.add(:amount_authorized, Spree.t('admin.store_credits.errors.amount_authorized_exceeds_total_credit'))
+    end
+  end
+
+  def validate_no_amount_used
+    if amount_used > 0
+      errors.add(:amount_used, 'is greater than zero. Can not delete store credit')
+    end
+  end
+
+  def associate_credit_type
+    unless self.type_id
+      credit_type_name = category.try(:non_expiring?) ? Spree.t("store_credit.non_expiring") : Spree.t("store_credit.expiring")
+      self.credit_type = Spree::StoreCreditType.find_by_name(credit_type_name)
+    end
+  end
+end

--- a/core/app/models/spree/store_credit_category.rb
+++ b/core/app/models/spree/store_credit_category.rb
@@ -1,0 +1,17 @@
+class Spree::StoreCreditCategory < ActiveRecord::Base
+  class_attribute :non_expiring_credit_types
+  self.non_expiring_credit_types = [Spree.t("store_credit.non_expiring")]
+
+  class_attribute :reimbursement_category_name
+  self.reimbursement_category_name = Spree.t("store_credit_category.default")
+
+  def self.reimbursement_category(reimbursement)
+    Spree::StoreCreditCategory.find_by(name: reimbursement_category_name) ||
+      Spree::StoreCreditCategory.first
+  end
+
+  def non_expiring?
+    self.class.non_expiring_credit_types.include? name
+  end
+
+end

--- a/core/app/models/spree/store_credit_event.rb
+++ b/core/app/models/spree/store_credit_event.rb
@@ -1,0 +1,44 @@
+module Spree
+  class StoreCreditEvent < ActiveRecord::Base
+    acts_as_paranoid
+
+    belongs_to :store_credit
+    belongs_to :originator, polymorphic: true
+
+    scope :exposed_events, -> { exposable_actions.not_invalidated }
+    scope :exposable_actions, -> { where.not(action: [Spree::StoreCredit::ELIGIBLE_ACTION, Spree::StoreCredit::AUTHORIZE_ACTION]) }
+    scope :not_invalidated, -> { joins(:store_credit).where(spree_store_credits: { invalidated_at: nil }) }
+    scope :reverse_chronological, -> { order(created_at: :desc) }
+
+    delegate :currency, to: :store_credit
+
+    def display_amount
+      Spree::Money.new(amount, { currency: currency })
+    end
+
+    def display_user_total_amount
+      Spree::Money.new(user_total_amount, { currency: currency })
+    end
+
+    def display_event_date
+      I18n.l(created_at.to_date, format: :long)
+    end
+
+    def display_action
+      case action
+      when Spree::StoreCredit::CAPTURE_ACTION
+        Spree.t('store_credit.captured')
+      when Spree::StoreCredit::AUTHORIZE_ACTION
+        Spree.t('store_credit.authorized')
+      when Spree::StoreCredit::ALLOCATION_ACTION
+        Spree.t('store_credit.allocated')
+      when Spree::StoreCredit::VOID_ACTION, Spree::StoreCredit::CREDIT_ACTION
+        Spree.t('store_credit.credit')
+      end
+    end
+
+    def order
+      Spree::Payment.find_by_response_code(authorization_code).try(:order)
+    end
+  end
+end

--- a/core/app/models/spree/store_credit_type.rb
+++ b/core/app/models/spree/store_credit_type.rb
@@ -1,0 +1,6 @@
+module Spree
+  class StoreCreditType < ActiveRecord::Base
+    DEFAULT_TYPE_NAME = Spree.t("store_credit.expiring")
+    has_many :store_credits, class_name: 'Spree::StoreCredit', foreign_key: 'type_id'
+  end
+end

--- a/core/config/initializers/user_class_extensions.rb
+++ b/core/config/initializers/user_class_extensions.rb
@@ -13,6 +13,9 @@ Spree::Core::Engine.config.to_prepare do
 
       has_many :spree_orders, foreign_key: "user_id", class_name: "Spree::Order"
 
+      has_many :store_credits, -> { includes(:credit_type) }, foreign_key: "user_id", class_name: "Spree::StoreCredit"
+      has_many :store_credit_events, through: :store_credits
+
       belongs_to :ship_address, class_name: 'Spree::Address'
       belongs_to :bill_address, class_name: 'Spree::Address'
 
@@ -23,6 +26,10 @@ Spree::Core::Engine.config.to_prepare do
 
       def last_incomplete_spree_order
         spree_orders.incomplete.order('created_at DESC').first
+      end
+
+      def total_available_store_credit
+        store_credits.reload.to_a.sum{ |credit| credit.amount_remaining }
       end
     end
   end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -115,6 +115,8 @@ en:
         seo_title: Seo Title
         name: Site Name
         mail_from_address: Mail From Address
+      spree/store_credit:
+        amount_used: Amount used
       spree/tax_category:
         description: Description
         name: Name
@@ -422,7 +424,32 @@ en:
         order_history: Order History
         order_num: "Order #"
         orders: Orders
+        store_credit: Store Credit
         user_information: User Information
+      store_credits:
+        add: "Add store credit"
+        new: "New store credit"
+        edit: "Editing store credit"
+        back_to_user_list: "Back to user list"
+        back_to_store_credit_list: "Back to store credit list"
+        credited_html_header: "Amount Credited"
+        used_html_header: "Amount Used"
+        authed_html_header: "Amount Authorized"
+        type_html_header: "Credit Type"
+        created_by: "Created By"
+        invalidated: "Invalidated"
+        issued_on: "Issued On"
+        select_reason: "Select a reason for this store credit"
+        unable_to_create: "Unable to create store credit"
+        unable_to_update: "Unable to update store credit"
+        unable_to_delete: "Unable to delete store credit"
+        resource_name: "store credits"
+        no_store_credit_selected: "No store credit was selected"
+        errors:
+          cannot_change_used_store_credit: "Store credit that has been claimed cannot be changed"
+          amount_used_cannot_be_greater: "cannot be greater than the credited amount"
+          amount_authorized_exceeds_total_credit: " exceeds the available credit"
+          amount_used_not_zero: "is greater than zero. Can not delete store credit"
     administration: Administration
     agree_to_privacy_policy: Agree to Privacy Policy
     agree_to_terms_of_service: Agree to Terms of Service
@@ -1295,6 +1322,31 @@ en:
     stock_transfers: Stock Transfers
     stop: Stop
     store: Store
+    store_credit:
+      allocated: "Added"
+      authorized: "Authorized"
+      captured: "Used"
+      credit: "Credit"
+      credit_allocation_memo: "This is a credit from store credit ID %{id}"
+      currency_mismatch: "Store credit currency does not match order currency"
+      errors:
+        unable_to_fund: "Unable to pay for order using store credits"
+        cannot_invalidate_uncaptured_authorization: "Cannot invalidate a store credit with an uncaptured authorization"
+      expiring: Expiring
+      insufficient_authorized_amount: "Unable to capture more than authorized amount"
+      insufficient_funds: "Store credit amount remaining is not sufficient"
+      invalidate: "Invalidate"
+      non_expiring: Non-expiring
+      select_one_store_credit: "Select store credit to go towards remaining balance"
+      store_credit: Store Credit
+      successful_action: "Successful store credit %{action}"
+      unable_to_credit: "Unable to credit code: %{auth_code}"
+      unable_to_void: "Unable to void code: %{auth_code}"
+      unable_to_find: "Could not find store credit"
+      unable_to_find_for_action: "Could not find store credit for auth code: %{auth_code} for action: %{action}"
+      user_has_no_store_credits: "User does not have any available store credit"
+    store_credit_category:
+      default: Default
     street_address: Street Address
     street_address_2: Street Address (cont'd)
     subtotal: Subtotal

--- a/core/db/default/spree/store_credit.rb
+++ b/core/db/default/spree/store_credit.rb
@@ -1,0 +1,16 @@
+Spree::StoreCreditCategory.find_or_create_by!(name: Spree.t("store_credit_category.default"))
+
+Spree::PaymentMethod.create_with(
+  name: Spree.t("store_credit.store_credit"),
+  description: Spree.t("store_credit.store_credit"),
+  active: true,
+  display_on: 'none',
+).find_or_create_by!(
+  type: "Spree::PaymentMethod::StoreCredit",
+  environment: Rails.env,
+)
+
+Spree::StoreCreditType.create_with(priority: 1).find_or_create_by!(name: Spree.t("store_credit.expiring"))
+Spree::StoreCreditType.create_with(priority: 2).find_or_create_by!(name: Spree.t("store_credit.non_expiring"))
+
+Spree::ReimbursementType.create_with(name: Spree.t("store_credit.store_credit")).find_or_create_by!(type: 'Spree::ReimbursementType::StoreCredit')

--- a/core/db/migrate/20150506181159_create_spree_store_credit_categories.rb
+++ b/core/db/migrate/20150506181159_create_spree_store_credit_categories.rb
@@ -1,0 +1,10 @@
+class CreateSpreeStoreCreditCategories < ActiveRecord::Migration
+  def change
+    create_table :spree_store_credit_categories do |t|
+      t.string :name
+      t.timestamps
+    end
+
+    Spree::StoreCreditCategory.find_or_create_by!(name: Spree.t("store_credit_category.default"))
+  end
+end

--- a/core/db/migrate/20150506181244_create_spree_store_credits.rb
+++ b/core/db/migrate/20150506181244_create_spree_store_credits.rb
@@ -1,0 +1,19 @@
+class CreateSpreeStoreCredits < ActiveRecord::Migration
+  def change
+    create_table :spree_store_credits do |t|
+      t.references :user
+      t.references :category
+      t.references :created_by
+      t.decimal :amount, precision: 8, scale: 2, default: 0.0, null: false
+      t.decimal :amount_used, precision: 8, scale: 2, default: 0.0, null: false
+      t.decimal :amount_authorized, precision: 8, scale: 2, default: 0.0, null: false
+      t.string :currency
+      t.text :memo
+      t.datetime :spree_store_credits, :deleted_at
+      t.timestamps
+    end
+
+    add_index :spree_store_credits, :deleted_at
+    add_index :spree_store_credits, :user_id
+  end
+end

--- a/core/db/migrate/20150506181539_create_spree_store_credit_events.rb
+++ b/core/db/migrate/20150506181539_create_spree_store_credit_events.rb
@@ -1,0 +1,17 @@
+class CreateSpreeStoreCreditEvents < ActiveRecord::Migration
+  def change
+    create_table :spree_store_credit_events do |t|
+      t.integer :store_credit_id,    null: false
+      t.string  :action,             null: false
+      t.decimal :amount,             precision: 8,  scale: 2
+      t.decimal :user_total_amount,  precision: 8,  scale: 2, default: 0.0, null: false, null: false
+      t.string  :authorization_code, null: false
+      t.datetime :deleted_at
+      t.references :originator, polymorphic: true
+      t.timestamps
+    end
+
+    add_index :spree_store_credit_events, :store_credit_id
+    add_index :spree_store_credit_events, :deleted_at
+  end
+end

--- a/core/db/migrate/20150506181611_create_spree_store_credit_payment_method.rb
+++ b/core/db/migrate/20150506181611_create_spree_store_credit_payment_method.rb
@@ -1,0 +1,13 @@
+class CreateSpreeStoreCreditPaymentMethod < ActiveRecord::Migration
+  def up
+    Spree::PaymentMethod.create_with(
+      name: Spree.t("store_credit.store_credit"),
+      description: Spree.t("store_credit.store_credit"),
+      active: true,
+      display_on: 'none',
+    ).find_or_create_by!(
+      type: "Spree::PaymentMethod::StoreCredit",
+      environment: Rails.env,
+    )
+  end
+end

--- a/core/db/migrate/20150506181715_create_store_credit_types.rb
+++ b/core/db/migrate/20150506181715_create_store_credit_types.rb
@@ -1,0 +1,17 @@
+class CreateStoreCreditTypes < ActiveRecord::Migration
+  def change
+    create_table :spree_store_credit_types do |t|
+      t.string :name
+      t.integer :priority
+      t.timestamps
+    end
+
+    add_column :spree_store_credits, :type_id, :integer
+
+    add_index :spree_store_credits, :type_id
+    add_index :spree_store_credit_types, :priority
+
+    Spree::StoreCreditType.create_with(priority: 1).find_or_create_by!(name: Spree.t("store_credit.expiring"))
+    Spree::StoreCreditType.create_with(priority: 2).find_or_create_by!(name: Spree.t("store_credit.non_expiring"))
+  end
+end

--- a/core/db/migrate/20150506182045_create_store_credit_reimbursement_type.rb
+++ b/core/db/migrate/20150506182045_create_store_credit_reimbursement_type.rb
@@ -1,0 +1,5 @@
+class CreateStoreCreditReimbursementType < ActiveRecord::Migration
+  def up
+    Spree::ReimbursementType.create_with(name: Spree.t("store_credit.store_credit")).find_or_create_by!(type: 'Spree::ReimbursementType::StoreCredit')
+  end
+end

--- a/core/db/migrate/20150514185559_add_invalidated_at_to_spree_store_credits.rb
+++ b/core/db/migrate/20150514185559_add_invalidated_at_to_spree_store_credits.rb
@@ -1,0 +1,5 @@
+class AddInvalidatedAtToSpreeStoreCredits < ActiveRecord::Migration
+  def change
+    add_column :spree_store_credits, :invalidated_at, :datetime
+  end
+end

--- a/core/db/migrate/20150514201836_migrate_deleted_store_credits_to_invalidated.rb
+++ b/core/db/migrate/20150514201836_migrate_deleted_store_credits_to_invalidated.rb
@@ -1,0 +1,13 @@
+class MigrateDeletedStoreCreditsToInvalidated < ActiveRecord::Migration
+  def up
+    Spree::StoreCredit.only_deleted.find_each do |store_credit|
+      say "Marking deleted store credit #{store_credit.id} for #{store_credit.user.try(:email)} as invalidated"
+      deleted_at = store_credit.deleted_at
+      store_credit.update_attributes!(deleted_at: nil, invalidated_at: deleted_at)
+    end
+  end
+
+  def down
+    # intentionally blank
+  end
+end

--- a/core/lib/spree/testing_support/factories/order_factory.rb
+++ b/core/lib/spree/testing_support/factories/order_factory.rb
@@ -3,7 +3,7 @@ FactoryGirl.define do
     user
     bill_address
     completed_at nil
-    email { user.email }
+    email { user.try(:email) }
     store
 
     transient do

--- a/core/lib/spree/testing_support/factories/payment_factory.rb
+++ b/core/lib/spree/testing_support/factories/payment_factory.rb
@@ -20,4 +20,9 @@ FactoryGirl.define do
     association(:payment_method, factory: :check_payment_method)
     order
   end
+
+  factory :store_credit_payment, class: Spree::Payment, parent: :payment do
+    association(:payment_method, factory: :store_credit_payment_method)
+    association(:source, factory: :store_credit)
+  end
 end

--- a/core/lib/spree/testing_support/factories/payment_method_factory.rb
+++ b/core/lib/spree/testing_support/factories/payment_method_factory.rb
@@ -15,4 +15,13 @@ FactoryGirl.define do
     name 'Credit Card'
     environment 'test'
   end
+
+  factory :store_credit_payment_method, class: Spree::PaymentMethod::StoreCredit do
+    name          "Store Credit"
+    description   "Store Credit"
+    active        true
+    environment   "test"
+    display_on    'none'
+    auto_capture  true
+  end
 end

--- a/core/lib/spree/testing_support/factories/store_credit_category_factory.rb
+++ b/core/lib/spree/testing_support/factories/store_credit_category_factory.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+
+  factory :store_credit_category, class: Spree::StoreCreditCategory do
+    name "Exchange"
+  end
+end

--- a/core/lib/spree/testing_support/factories/store_credit_event_factory.rb
+++ b/core/lib/spree/testing_support/factories/store_credit_event_factory.rb
@@ -1,0 +1,11 @@
+FactoryGirl.define do
+  factory :store_credit_event, class: Spree::StoreCreditEvent do
+    store_credit       { create(:store_credit) }
+    amount             { 100.00 }
+    authorization_code { "#{store_credit.id}-SC-20140602164814476128" }
+
+    factory :store_credit_auth_event, class: Spree::StoreCreditEvent do
+      action             { Spree::StoreCredit::AUTHORIZE_ACTION }
+    end
+  end
+end

--- a/core/lib/spree/testing_support/factories/store_credit_factory.rb
+++ b/core/lib/spree/testing_support/factories/store_credit_factory.rb
@@ -1,0 +1,10 @@
+FactoryGirl.define do
+  factory :store_credit, class: Spree::StoreCredit do
+    user             { create(:user) }
+    created_by       { create(:user) }
+    category         { create(:store_credit_category) }
+    amount           { 150.00 }
+    currency         { "USD" }
+    credit_type      { create(:primary_credit_type) }
+  end
+end

--- a/core/lib/spree/testing_support/factories/store_credit_type_factory.rb
+++ b/core/lib/spree/testing_support/factories/store_credit_type_factory.rb
@@ -1,0 +1,13 @@
+FactoryGirl.define do
+
+  factory :primary_credit_type, class: Spree::StoreCreditType do
+    name      Spree::StoreCreditType::DEFAULT_TYPE_NAME
+    priority  { "1" }
+  end
+
+  factory :secondary_credit_type, class: Spree::StoreCreditType do
+    name      { "Non-expiring" }
+    priority  { "2" }
+  end
+
+end

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -355,7 +355,9 @@ describe Spree::Order, :type => :model do
     context "to payment" do
       before do
         @default_credit_card = FactoryGirl.create(:credit_card)
-        order.user = mock_model(Spree::LegacyUser, default_credit_card: @default_credit_card, email: 'spree@example.org')
+        user = Spree::LegacyUser.new(email: 'spree@example.org')
+        allow(user).to receive(:default_credit_card) { @default_credit_card }
+        order.user = user
 
         allow(order).to receive_messages(payment_required?: true)
         order.state = 'delivery'

--- a/core/spec/models/spree/order/state_machine_spec.rb
+++ b/core/spec/models/spree/order/state_machine_spec.rb
@@ -172,6 +172,7 @@ describe Spree::Order, :type => :model do
         allow(order).to receive_message_chain(:payments, :completed).and_return([payment])
         allow(order).to receive_message_chain(:payments, :completed, :includes).and_return([payment])
         allow(order).to receive_message_chain(:payments, :last).and_return(payment)
+        allow(order).to receive_message_chain(:payments, :store_credits, :pending).and_return([payment])
       end
 
       context "without shipped items" do

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -975,4 +975,367 @@ describe Spree::Order, :type => :model do
 
     end
   end
+
+  context "store credit" do
+    shared_examples "check total store credit from payments" do
+      context "with valid payments" do
+        let(:order)           { payment.order }
+        let!(:payment)        { create(:store_credit_payment) }
+        let!(:second_payment) { create(:store_credit_payment, order: order) }
+
+        subject { order }
+
+        it "returns the sum of the payment amounts" do
+          expect(subject.total_applicable_store_credit).to eq (payment.amount + second_payment.amount)
+        end
+      end
+
+      context "without valid payments" do
+        let(:order) { create(:order) }
+
+        subject { order }
+
+        it "returns 0" do
+          expect(subject.total_applicable_store_credit).to be_zero
+        end
+      end
+    end
+
+    describe "#add_store_credit_payments" do
+      let(:order_total) { 500.00 }
+
+      before { create(:store_credit_payment_method) }
+
+      subject { order.add_store_credit_payments }
+
+      context "there is no store credit" do
+        let(:order)       { create(:order, total: order_total) }
+
+        context "there is a credit card payment" do
+          let!(:cc_payment) { create(:payment, order: order) }
+
+          before do
+            # callbacks recalculate total based on line items
+            # this ensures the total is what we expect
+            order.update_column(:total, order_total)
+            subject
+            order.reload
+          end
+
+          it "charges the outstanding balance to the credit card" do
+            expect(order.payments.count).to eq 1
+            expect(order.payments.first.source).to be_a(Spree::CreditCard)
+            expect(order.payments.first.amount).to eq order_total
+          end
+        end
+
+        context "there are no other payments" do
+          it "adds an error to the model" do
+            expect(subject).to be false
+            expect(order.errors.full_messages).to include(Spree.t("store_credit.errors.unable_to_fund"))
+          end
+        end
+      end
+
+      context "there is enough store credit to pay for the entire order" do
+        let(:store_credit) { create(:store_credit, amount: order_total) }
+        let(:order)        { create(:order, user: store_credit.user, total: order_total) }
+
+        context "there are no other payments" do
+          before do
+            subject
+            order.reload
+          end
+
+          it "creates a store credit payment for the full amount" do
+            expect(order.payments.count).to eq 1
+            expect(order.payments.first).to be_store_credit
+            expect(order.payments.first.amount).to eq order_total
+          end
+        end
+
+        context "there is a credit card payment" do
+          it "invalidates the credit card payment" do
+            cc_payment = create(:payment, order: order)
+            expect { subject }.to change { cc_payment.reload.state }.to 'invalid'
+          end
+        end
+      end
+
+      context "the available store credit is not enough to pay for the entire order" do
+        let(:expected_cc_total)  { 100.0 }
+        let(:store_credit_total) { order_total - expected_cc_total }
+        let(:store_credit)       { create(:store_credit, amount: store_credit_total) }
+        let(:order)              { create(:order, user: store_credit.user, total: order_total) }
+
+
+        context "there are no other payments" do
+          it "adds an error to the model" do
+            expect(subject).to be false
+            expect(order.errors.full_messages).to include(Spree.t("store_credit.errors.unable_to_fund"))
+          end
+        end
+
+        context "there is a credit card payment" do
+          let!(:cc_payment) { create(:payment, order: order, state: "checkout") }
+
+          before do
+            # callbacks recalculate total based on line items
+            # this ensures the total is what we expect
+            order.update_column(:total, order_total)
+            subject
+            order.reload
+          end
+
+          it "charges the outstanding balance to the credit card" do
+            expect(order.payments.count).to eq 2
+            expect(order.payments.first.source).to be_a(Spree::CreditCard)
+            expect(order.payments.first.amount).to eq expected_cc_total
+          end
+        end
+      end
+
+      context "there are multiple store credits" do
+        context "they have different credit type priorities" do
+          let(:amount_difference)       { 100 }
+          let!(:primary_store_credit)   { create(:store_credit, amount: (order_total - amount_difference)) }
+          let!(:secondary_store_credit) { create(:store_credit, amount: order_total, user: primary_store_credit.user, credit_type: create(:secondary_credit_type)) }
+          let(:order)                   { create(:order, user: primary_store_credit.user, total: order_total) }
+
+          before do
+            subject
+            order.reload
+          end
+
+          it "uses the primary store credit type over the secondary" do
+            primary_payment = order.payments.first
+            secondary_payment = order.payments.last
+
+            expect(order.payments.size).to eq 2
+            expect(primary_payment.source).to eq primary_store_credit
+            expect(secondary_payment.source).to eq secondary_store_credit
+            expect(primary_payment.amount).to eq(order_total - amount_difference)
+            expect(secondary_payment.amount).to eq(amount_difference)
+          end
+        end
+      end
+    end
+
+    describe "#covered_by_store_credit" do
+      context "order doesn't have an associated user" do
+        subject { create(:order, user: nil) }
+
+        it "returns false" do
+          expect(subject.covered_by_store_credit).to be false
+        end
+      end
+
+      context "order has an associated user" do
+        let(:user) { create(:user) }
+
+        subject    { create(:order, user: user) }
+
+        context "user has enough store credit to pay for the order" do
+          before do
+            allow(user).to receive_messages(total_available_store_credit: 10.0)
+            allow(subject).to receive_messages(total: 5.0)
+          end
+
+          it "returns true" do
+            expect(subject.covered_by_store_credit).to be true
+          end
+        end
+
+        context "user does not have enough store credit to pay for the order" do
+          before do
+            allow(user).to receive_messages(total_available_store_credit: 0.0)
+            allow(subject).to receive_messages(total: 5.0)
+          end
+
+          it "returns false" do
+            expect(subject.covered_by_store_credit).to be false
+          end
+        end
+      end
+    end
+
+    describe "#total_available_store_credit" do
+      context "order does not have an associated user" do
+        subject { create(:order, user: nil) }
+
+        it "returns 0" do
+          expect(subject.total_available_store_credit).to be_zero
+        end
+      end
+
+      context "order has an associated user" do
+        let(:user)                   { create(:user) }
+        let(:available_store_credit) { 25.0 }
+
+        subject { create(:order, user: user) }
+
+        before do
+          allow(user).to receive_messages(total_available_store_credit: available_store_credit)
+        end
+
+        it "returns the user's available store credit" do
+          expect(subject.total_available_store_credit).to eq available_store_credit
+        end
+      end
+    end
+
+    describe "#order_total_after_store_credit" do
+      let(:order_total) { 100.0 }
+
+      subject { create(:order, total: order_total) }
+
+      before do
+        allow(subject).to receive_messages(total_applicable_store_credit: applicable_store_credit)
+      end
+
+      context "order's user has store credits" do
+        let(:applicable_store_credit) { 10.0 }
+
+        it "deducts the applicable store credit" do
+          expect(subject.order_total_after_store_credit).to eq (order_total - applicable_store_credit)
+        end
+      end
+
+      context "order's user does not have any store credits" do
+        let(:applicable_store_credit) { 0.0 }
+
+        it "returns the order total" do
+          expect(subject.order_total_after_store_credit).to eq order_total
+        end
+      end
+    end
+
+    describe "#total_applicable_store_credit" do
+      context "order is in the confirm state" do
+        before { order.update_attributes(state: 'confirm') }
+        include_examples "check total store credit from payments"
+      end
+
+      context "order is completed" do
+        before { order.update_attributes(state: 'complete') }
+        include_examples "check total store credit from payments"
+      end
+
+      context "order is in any state other than confirm or complete" do
+        context "the associated user has store credits" do
+          let(:store_credit) { create(:store_credit) }
+          let(:order)        { create(:order, user: store_credit.user) }
+
+          subject { order }
+
+          context "the store credit is more than the order total" do
+            let(:order_total) { store_credit.amount - 1 }
+
+            before { order.update_attributes(total: order_total) }
+
+            it "returns the order total" do
+              expect(subject.total_applicable_store_credit).to eq order_total
+            end
+          end
+
+          context "the store credit is less than the order total" do
+            let(:order_total) { store_credit.amount * 10 }
+
+            before { order.update_attributes(total: order_total) }
+
+            it "returns the store credit amount" do
+              expect(subject.total_applicable_store_credit).to eq store_credit.amount
+            end
+          end
+        end
+
+        context "the associated user does not have store credits" do
+          let(:order) { create(:order) }
+
+          subject { order }
+
+          it "returns 0" do
+            expect(subject.total_applicable_store_credit).to be_zero
+          end
+        end
+
+        context "the order does not have an associated user" do
+          subject { create(:order, user: nil) }
+
+          it "returns 0" do
+            expect(subject.total_applicable_store_credit).to be_zero
+          end
+        end
+      end
+    end
+
+    describe "#display_total_applicable_store_credit" do
+      let(:total_applicable_store_credit) { 10.00 }
+
+      subject { create(:order) }
+
+      before { allow(subject).to receive_messages(total_applicable_store_credit: total_applicable_store_credit) }
+
+      it "returns a money instance" do
+        expect(subject.display_total_applicable_store_credit).to be_a(Spree::Money)
+      end
+
+      it "returns a negative amount" do
+        expect(subject.display_total_applicable_store_credit.money.cents).to eq (total_applicable_store_credit * -100.0)
+      end
+    end
+
+    describe "#display_order_total_after_store_credit" do
+      let(:order_total_after_store_credit) { 10.00 }
+
+      subject { create(:order) }
+
+      before { allow(subject).to receive_messages(order_total_after_store_credit: order_total_after_store_credit) }
+
+      it "returns a money instance" do
+        expect(subject.display_order_total_after_store_credit).to be_a(Spree::Money)
+      end
+
+      it "returns the order_total_after_store_credit amount" do
+        expect(subject.display_order_total_after_store_credit.money.cents).to eq (order_total_after_store_credit * 100.0)
+      end
+    end
+
+    describe "#display_total_available_store_credit" do
+      let(:total_available_store_credit) { 10.00 }
+
+      subject { create(:order) }
+
+      before { allow(subject).to receive_messages(total_available_store_credit: total_available_store_credit) }
+
+      it "returns a money instance" do
+        expect(subject.display_total_available_store_credit).to be_a(Spree::Money)
+      end
+
+      it "returns the total_available_store_credit amount" do
+        expect(subject.display_total_available_store_credit.money.cents).to eq (total_available_store_credit * 100.0)
+      end
+    end
+
+    describe "#display_store_credit_remaining_after_capture" do
+      let(:total_available_store_credit)  { 10.00 }
+      let(:total_applicable_store_credit) { 5.00 }
+
+      subject { create(:order) }
+
+      before do
+        allow(subject).to receive_messages(total_available_store_credit: total_available_store_credit,
+                     total_applicable_store_credit: total_applicable_store_credit)
+      end
+
+      it "returns a money instance" do
+        expect(subject.display_store_credit_remaining_after_capture).to be_a(Spree::Money)
+      end
+
+      it "returns all of the user's available store credit minus what's applied to the order amount" do
+        amount_remaining = total_available_store_credit - total_applicable_store_credit
+        expect(subject.display_store_credit_remaining_after_capture.money.cents).to eq (amount_remaining * 100.0)
+      end
+    end
+  end
 end

--- a/core/spec/models/spree/payment_method/store_credit_spec.rb
+++ b/core/spec/models/spree/payment_method/store_credit_spec.rb
@@ -1,0 +1,281 @@
+require 'spec_helper'
+
+describe Spree::PaymentMethod::StoreCredit do
+  let(:order)           { create(:order) }
+  let(:payment)         { create(:payment, order: order) }
+  let(:gateway_options) { payment.gateway_options }
+
+  context "#authorize" do
+    subject do
+      Spree::PaymentMethod::StoreCredit.new.authorize(auth_amount, store_credit, gateway_options)
+    end
+
+    let(:auth_amount) { store_credit.amount_remaining * 100 }
+    let(:store_credit) { create(:store_credit) }
+    let(:gateway_options) { super().merge(originator: originator) }
+    let(:originator) { nil }
+
+    context 'without an invalid store credit' do
+      let(:store_credit) { nil }
+      let(:auth_amount) { 10 }
+
+      it "declines an unknown store credit" do
+        expect(subject.success?).to be false
+        expect(subject.message).to include Spree.t('store_credit.unable_to_find')
+      end
+    end
+
+    context 'with insuffient funds' do
+      let(:auth_amount) { (store_credit.amount_remaining * 100) + 1 }
+
+      it "declines a store credit" do
+        expect(subject.success?).to be false
+        expect(subject.message).to include Spree.t('store_credit.insufficient_funds')
+      end
+    end
+
+    context 'when the currency does not match the order currency' do
+      let(:store_credit) { create(:store_credit, currency: 'AUD') }
+
+      it "declines the credit" do
+        expect(subject.success?).to be false
+        expect(subject.message).to include Spree.t('store_credit.currency_mismatch')
+      end
+    end
+
+    context 'with a valid request' do
+      it "authorizes a valid store credit" do
+        expect(subject.success?).to be true
+        expect(subject.authorization).not_to be_nil
+      end
+
+      context 'with an originator' do
+        let(:originator) { double('originator') }
+
+        it 'passes the originator' do
+          expect_any_instance_of(Spree::StoreCredit).to receive(:authorize)
+            .with(anything, anything, action_originator: originator)
+          subject
+        end
+      end
+    end
+  end
+
+  context "#capture" do
+    subject do
+      Spree::PaymentMethod::StoreCredit.new.capture(capture_amount, auth_code, gateway_options)
+    end
+
+    let(:capture_amount) { 10_00 }
+    let(:auth_code) { auth_event.authorization_code }
+    let(:gateway_options) { super().merge(originator: originator) }
+
+    let(:authorized_amount) { capture_amount/100.0 }
+    let(:auth_event) { create(:store_credit_auth_event, store_credit: store_credit, amount: authorized_amount) }
+    let(:store_credit) { create(:store_credit, amount_authorized: authorized_amount) }
+    let(:originator) { nil }
+
+    context 'with an invalid auth code' do
+      let(:auth_code) { -1 }
+
+      it "declines an unknown store credit" do
+        expect(subject.success?).to be false
+        expect(subject.message).to include Spree.t('store_credit.unable_to_find')
+      end
+    end
+
+    context 'when unable to authorize the amount' do
+      let(:authorized_amount) { (capture_amount-1)/100 }
+
+      before do
+        allow_any_instance_of(Spree::StoreCredit).to receive_messages(authorize: true)
+      end
+
+      it "declines a store credit" do
+        expect(subject.success?).to be false
+        expect(subject.message).to include Spree.t('store_credit.insufficient_authorized_amount')
+      end
+    end
+
+    context 'when the currency does not match the order currency' do
+      let(:store_credit) { create(:store_credit, currency: 'AUD', amount_authorized: authorized_amount) }
+
+      it "declines the credit" do
+        expect(subject.success?).to be false
+        expect(subject.message).to include Spree.t('store_credit.currency_mismatch')
+      end
+    end
+
+    context 'with a valid request' do
+      it "captures the store credit" do
+        expect(subject.message).to include Spree.t('store_credit.successful_action', action: Spree::StoreCredit::CAPTURE_ACTION)
+        expect(subject.success?).to be true
+      end
+
+      context 'with an originator' do
+        let(:originator) { double('originator') }
+
+        it 'passes the originator' do
+          expect_any_instance_of(Spree::StoreCredit).to receive(:capture)
+            .with(anything, anything, anything, action_originator: originator)
+          subject
+        end
+      end
+    end
+  end
+
+  context "#void" do
+    subject do
+      Spree::PaymentMethod::StoreCredit.new.void(auth_code, gateway_options)
+    end
+
+    let(:auth_code) { auth_event.authorization_code }
+    let(:gateway_options) { super().merge(originator: originator) }
+    let(:auth_event) { create(:store_credit_auth_event) }
+    let(:originator) { nil }
+
+    context 'with an invalid auth code' do
+      let(:auth_code) { 1 }
+
+      it "declines an unknown store credit" do
+        expect(subject.success?).to be false
+        expect(subject.message).to include Spree.t('store_credit.unable_to_find')
+      end
+    end
+
+    context 'when the store credit is not voided successfully' do
+      before { allow_any_instance_of(Spree::StoreCredit).to receive_messages(void: false) }
+
+      it "returns an error response" do
+        expect(subject.success?).to be false
+      end
+    end
+
+    it "voids a valid store credit void request" do
+      expect(subject.success?).to be true
+      expect(subject.message).to include Spree.t('store_credit.successful_action', action: Spree::StoreCredit::VOID_ACTION)
+    end
+
+    context 'with an originator' do
+      let(:originator) { double('originator') }
+
+      it 'passes the originator' do
+        expect_any_instance_of(Spree::StoreCredit).to receive(:void)
+          .with(anything, action_originator: originator)
+        subject
+      end
+    end
+  end
+
+  context "#purchase" do
+    it "declines a purchase if it can't find a pending credit for the correct amount" do
+      amount = 100.0
+      store_credit = create(:store_credit)
+      auth_code = store_credit.generate_authorization_code
+      store_credit.store_credit_events.create!(action: Spree::StoreCredit::ELIGIBLE_ACTION,
+                                               amount: amount,
+                                               authorization_code: auth_code)
+      store_credit.store_credit_events.create!(action: Spree::StoreCredit::CAPTURE_ACTION,
+                                               amount: amount,
+                                               authorization_code: auth_code)
+
+      resp = subject.purchase(amount * 100.0, store_credit, gateway_options)
+      expect(resp.success?).to be false
+      expect(resp.message).to include Spree.t('store_credit.unable_to_find')
+    end
+
+    it "captures a purchase if it can find a pending credit for the correct amount" do
+      amount = 100.0
+      store_credit = create(:store_credit)
+      auth_code = store_credit.generate_authorization_code
+      store_credit.store_credit_events.create!(action: Spree::StoreCredit::ELIGIBLE_ACTION,
+                                               amount: amount,
+                                               authorization_code: auth_code)
+
+      resp = subject.purchase(amount * 100.0, store_credit, gateway_options)
+      expect(resp.success?).to be true
+      expect(resp.message).to include Spree.t('store_credit.successful_action', action: Spree::StoreCredit::CAPTURE_ACTION)
+    end
+  end
+
+  context "#credit" do
+    subject do
+      Spree::PaymentMethod::StoreCredit.new.credit(credit_amount, auth_code, gateway_options)
+    end
+
+    let(:credit_amount) { 100.0 }
+    let(:auth_code) { auth_event.authorization_code }
+    let(:gateway_options) { super().merge(originator: originator) }
+    let(:auth_event) { create(:store_credit_auth_event) }
+    let(:originator) { nil }
+
+    context 'with an invalid auth code' do
+      let(:auth_code) { 1 }
+
+      it "declines an unknown store credit" do
+        expect(subject.success?).to be false
+        expect(subject.message).to include Spree.t('store_credit.unable_to_find')
+      end
+    end
+
+    context "when the store credit isn't credited successfully" do
+      before { allow_any_instance_of(Spree::StoreCredit).to receive_messages(credit: false) }
+
+      it "returns an error response" do
+        expect(subject.success?).to be false
+      end
+    end
+
+    context 'with a valid credit request' do
+      before { allow_any_instance_of(Spree::StoreCredit).to receive_messages(credit: true) }
+
+      it "credits a valid store credit credit request" do
+        expect(subject.success?).to be true
+        expect(subject.message).to include Spree.t('store_credit.successful_action', action: Spree::StoreCredit::CREDIT_ACTION)
+      end
+    end
+
+    context 'with an originator' do
+      let(:originator) { double('originator') }
+
+      it 'passes the originator' do
+        expect_any_instance_of(Spree::StoreCredit).to receive(:credit)
+          .with(anything, anything, anything, action_originator: originator)
+        subject
+      end
+    end
+  end
+
+  context "#cancel" do
+    subject do
+      Spree::PaymentMethod::StoreCredit.new.cancel(auth_code)
+    end
+
+    let(:store_credit) { create(:store_credit, amount_used: captured_amount) }
+    let(:auth_code)    { "1-SC-20141111111111" }
+    let(:captured_amount) { 10.0 }
+
+    let!(:capture_event) { create(:store_credit_auth_event,
+                                    action: Spree::StoreCredit::CAPTURE_ACTION,
+                                    authorization_code: auth_code,
+                                    amount: captured_amount,
+                                    store_credit: store_credit) }
+
+    context "store credit event found" do
+      it "creates a store credit for the same amount that was captured" do
+        expect_any_instance_of(Spree::StoreCredit).to receive(:credit).with(captured_amount, auth_code, store_credit.currency)
+        subject
+      end
+    end
+
+    context "store credit event not found" do
+      subject do
+        Spree::PaymentMethod::StoreCredit.new.cancel('INVALID')
+      end
+
+      it "returns false" do
+        expect(subject).to be false
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/reimbursement_spec.rb
+++ b/core/spec/models/spree/reimbursement_spec.rb
@@ -57,7 +57,7 @@ describe Spree::Reimbursement, type: :model do
     let(:line_items_price)        { BigDecimal.new(10) }
     let(:line_item)               { order.line_items.first }
     let(:inventory_unit)          { line_item.inventory_units.first }
-    let(:payment)                 { build(:payment, amount: payment_amount, order: order, state: 'completed') }
+    let(:payment)                 { build(:payment, amount: payment_amount, order: order, state: 'checkout') }
     let(:payment_amount)          { order.total }
     let(:customer_return)         { build(:customer_return, return_items: [return_item]) }
     let(:return_item)             { build(:return_item, inventory_unit: inventory_unit) }
@@ -80,6 +80,7 @@ describe Spree::Reimbursement, type: :model do
         order.next! # confirm
       end
       order.complete! # completed
+      payment.capture!
       customer_return.save!
       return_item.accept!
     end

--- a/core/spec/models/spree/reimbursement_type/store_credit_spec.rb
+++ b/core/spec/models/spree/reimbursement_type/store_credit_spec.rb
@@ -1,0 +1,97 @@
+require 'spec_helper'
+
+module Spree
+  describe ReimbursementType::StoreCredit do
+    let(:reimbursement)           { create(:reimbursement, return_items_count: 2) }
+    let(:return_item)             { reimbursement.return_items.first }
+    let(:return_item2)            { reimbursement.return_items.last }
+    let(:payment)                 { reimbursement.order.payments.first }
+    let(:simulate)                { false }
+    let!(:default_refund_reason)  { Spree::RefundReason.find_or_create_by!(name: Spree::RefundReason::RETURN_PROCESSING_REASON, mutable: false) }
+
+    let!(:primary_credit_type)    { create(:primary_credit_type) }
+    let!(:created_by_user)        { create(:user, email: Spree::StoreCredit::DEFAULT_CREATED_BY_EMAIL) }
+    let!(:default_reimbursement_category) { create(:store_credit_category) }
+
+    subject { Spree::ReimbursementType::StoreCredit.reimburse(reimbursement, [return_item, return_item2], simulate)}
+
+    before do
+      reimbursement.update!(total: reimbursement.calculated_total)
+    end
+
+    describe '.reimburse' do
+      context 'simulate is true' do
+        let(:simulate) { true }
+
+        context 'for store credits that the customer used' do
+          before do
+            expect(Spree::ReimbursementType::StoreCredit).to receive(:store_credit_payments).and_return([payment])
+          end
+
+          it 'creates readonly refunds for all store credit payments' do
+            expect(subject.map(&:class)).to eq [Spree::Refund]
+            expect(subject.map(&:readonly?)).to eq [true]
+          end
+
+          it 'does not save to the database' do
+            expect { subject }.to_not change { payment.refunds.count }
+          end
+        end
+
+        context 'for return items that were not paid for with store credit' do
+          before do
+            expect(Spree::ReimbursementType::StoreCredit).to receive(:store_credit_payments).and_return([])
+          end
+
+          context 'creates one readonly lump credit for all outstanding balance payable to the customer' do
+            it 'creates a credit that is read only' do
+              expect(subject.map(&:class)).to eq [Spree::Reimbursement::Credit]
+              expect(subject.map(&:readonly?)).to eq [true]
+            end
+
+            it 'creates a credit which amounts to the sum of the return items rounded down' do
+              expect(return_item).to receive(:total).and_return(10.0076)
+              expect(return_item2).to receive(:total).and_return(10.0023)
+              expect(subject.sum(&:amount)).to eq 20.0
+            end
+          end
+
+          it 'does not save to the database' do
+            expect { subject }.to_not change { Spree::Reimbursement::Credit.count }
+          end
+        end
+      end
+
+      context 'simulate is false' do
+        let(:simulate) { false }
+
+        context 'for store credits that the customer used' do
+          before do
+            expect(Spree::ReimbursementType::StoreCredit).to receive(:store_credit_payments).and_return([payment])
+          end
+
+          it 'performs refunds for all store credit payments' do
+            expect { subject }.to change { payment.refunds.count }.by(1)
+            expect(payment.refunds.sum(:amount)).to eq reimbursement.return_items.to_a.sum(&:total)
+          end
+        end
+
+        context 'for return items that were not paid for with store credit' do
+          before do
+            expect(Spree::ReimbursementType::StoreCredit).to receive(:store_credit_payments).and_return([])
+          end
+
+          it 'creates one lump credit for all outstanding balance payable to the customer' do
+            expect { subject }.to change { Spree::Reimbursement::Credit.count }.by(1)
+            expect(subject.sum(&:amount)).to eq reimbursement.return_items.to_a.sum(&:total)
+          end
+
+          it "creates a store credit with the same currency as the reimbursement's order" do
+            expect { subject }.to change { Spree::StoreCredit.count }.by(1)
+            expect(Spree::StoreCredit.last.currency).to eq reimbursement.order.currency
+          end
+        end
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/store_credit_category_spec.rb
+++ b/core/spec/models/spree/store_credit_category_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe Spree::StoreCreditCategory, :type => :model do
+  describe "#non_expiring?" do
+    let(:store_credit_category) { build(:store_credit_category, name: category_name) }
+
+    context "non-expiring type store credit" do
+      let(:category_name) { "Non-expiring" }
+      it { expect(store_credit_category).to be_non_expiring }
+    end
+
+    context "expiring type store credit" do
+      let(:category_name) { "Expiring" }
+      it { expect(store_credit_category).not_to be_non_expiring }
+    end
+  end
+end

--- a/core/spec/models/spree/store_credit_event_spec.rb
+++ b/core/spec/models/spree/store_credit_event_spec.rb
@@ -1,0 +1,140 @@
+require 'spec_helper'
+
+describe Spree::StoreCreditEvent do
+
+  describe ".exposed_events" do
+
+    [
+      Spree::StoreCredit::ELIGIBLE_ACTION,
+      Spree::StoreCredit::AUTHORIZE_ACTION,
+    ].each do |action|
+      let(:action) { action }
+      it "excludes #{action} actions" do
+        event = create(:store_credit_event, action: action)
+        expect(described_class.exposed_events).not_to include event
+      end
+    end
+
+    [
+      Spree::StoreCredit::VOID_ACTION,
+      Spree::StoreCredit::CREDIT_ACTION,
+      Spree::StoreCredit::CAPTURE_ACTION,
+      Spree::StoreCredit::ALLOCATION_ACTION,
+    ].each do |action|
+      it "includes #{action} actions" do
+        event = create(:store_credit_event, action: action)
+        expect(described_class.exposed_events).to include event
+      end
+    end
+
+    it "excludes invalidated store credit events" do
+      invalidated_store_credit = create(:store_credit, invalidated_at: Time.now)
+      event = create(:store_credit_event, action: Spree::StoreCredit::VOID_ACTION, store_credit: invalidated_store_credit)
+      expect(described_class.exposed_events).not_to include event
+    end
+  end
+
+  describe "#display_amount" do
+    let(:event_amount) { 120.0 }
+
+    subject { create(:store_credit_auth_event, amount: event_amount) }
+
+    it "returns a Spree::Money instance" do
+      expect(subject.display_amount).to be_instance_of(Spree::Money)
+    end
+
+    it "uses the events amount attribute" do
+      expect(subject.display_amount).to eq Spree::Money.new(event_amount, { currency: subject.currency })
+    end
+  end
+
+  describe "#display_user_total_amount" do
+    let(:user_total_amount) { 300.0 }
+
+    subject { create(:store_credit_auth_event, user_total_amount: user_total_amount) }
+
+    it "returns a Spree::Money instance" do
+      expect(subject.display_user_total_amount).to be_instance_of(Spree::Money)
+    end
+
+    it "uses the events user_total_amount attribute" do
+      expect(subject.display_user_total_amount).to eq Spree::Money.new(user_total_amount, { currency: subject.currency })
+    end
+  end
+
+  describe "#display_event_date" do
+    let(:date) { DateTime.new(2014, 06, 1) }
+
+    subject { create(:store_credit_auth_event, created_at: date) }
+
+    it "returns the date the event was created with the format month/date/year" do
+      expect(subject.display_event_date).to eq "June 01, 2014"
+    end
+  end
+
+  describe "#display_action" do
+    subject { create(:store_credit_auth_event, action: action) }
+
+    context "capture event" do
+      let(:action) { Spree::StoreCredit::CAPTURE_ACTION }
+
+      it "returns used" do
+        expect(subject.display_action).to eq Spree.t('store_credit.captured')
+      end
+    end
+
+    context "authorize event" do
+      let(:action) { Spree::StoreCredit::AUTHORIZE_ACTION }
+
+      it "returns authorized" do
+        expect(subject.display_action).to eq Spree.t('store_credit.authorized')
+      end
+    end
+
+    context "allocation event" do
+      let(:action) { Spree::StoreCredit::ALLOCATION_ACTION }
+
+      it "returns added" do
+        expect(subject.display_action).to eq Spree.t('store_credit.allocated')
+      end
+    end
+
+    context "void event" do
+      let(:action) { Spree::StoreCredit::VOID_ACTION }
+
+      it "returns credit" do
+        expect(subject.display_action).to eq Spree.t('store_credit.credit')
+      end
+    end
+
+    context "credit event" do
+      let(:action) { Spree::StoreCredit::CREDIT_ACTION }
+
+      it "returns credit" do
+        expect(subject.display_action).to eq Spree.t('store_credit.credit')
+      end
+    end
+  end
+
+  describe "#order" do
+    context "there is no associated payment with the event" do
+      subject { create(:store_credit_auth_event) }
+
+      it "returns nil" do
+        expect(subject.order).to be_nil
+      end
+    end
+
+    context "there is an associated payment with the event" do
+      let(:authorization_code) { "1-SC-TEST" }
+      let(:order)              { create(:order) }
+      let!(:payment)           { create(:store_credit_payment, order: order, response_code: authorization_code) }
+
+      subject { create(:store_credit_auth_event, action: Spree::StoreCredit::CAPTURE_ACTION, authorization_code: authorization_code) }
+
+      it "returns the order associated with the payment" do
+        expect(subject.order).to eq order
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/store_credit_spec.rb
+++ b/core/spec/models/spree/store_credit_spec.rb
@@ -1,0 +1,806 @@
+require 'spec_helper'
+
+describe Spree::StoreCredit do
+
+  let(:currency) { "TEST" }
+  let(:store_credit) { build(:store_credit, store_credit_attrs) }
+  let(:store_credit_attrs) { {} }
+
+
+  describe "callbacks" do
+    subject { store_credit.save }
+
+    context "amount used is greater than zero" do
+      let(:store_credit) { create(:store_credit, amount: 100, amount_used: 1) }
+      subject { store_credit.destroy }
+
+      it 'can not delete the store credit' do
+        subject
+        expect(store_credit.reload).to eq store_credit
+        expect(store_credit.errors[:amount_used]).to include(Spree.t('admin.store_credits.errors.amount_used_not_zero'))
+      end
+    end
+
+    context "category is a non-expiring type" do
+      let!(:secondary_credit_type) { create(:secondary_credit_type) }
+      let(:store_credit) { build(:store_credit, credit_type: nil)}
+
+      before do
+        allow(store_credit.category).to receive(:non_expiring?).and_return(true)
+      end
+
+      it "sets the credit type to non-expiring" do
+        subject
+        expect(store_credit.credit_type.name).to eq secondary_credit_type.name
+      end
+    end
+
+    context "category is an expiring type" do
+      before do
+        allow(store_credit.category).to receive(:non_expiring?).and_return(false)
+      end
+
+      it "sets the credit type to non-expiring" do
+        subject
+        expect(store_credit.credit_type.name).to eq "Expiring"
+      end
+    end
+
+    context "the type is set" do
+      let!(:secondary_credit_type) { create(:secondary_credit_type)}
+      let(:store_credit) { build(:store_credit, credit_type: secondary_credit_type)}
+
+      before do
+        allow(store_credit.category).to receive(:non_expiring?).and_return(false)
+      end
+
+      it "doesn't overwrite the type" do
+        expect{ subject }.to_not change{ store_credit.credit_type }
+      end
+    end
+  end
+
+  describe "validations" do
+    describe "used amount should not be greater than the credited amount" do
+      context "the used amount is defined" do
+        let(:invalid_store_credit) { build(:store_credit, amount: 100, amount_used: 150) }
+
+        it "should not be valid" do
+          expect(invalid_store_credit).not_to be_valid
+        end
+
+        it "should set the correct error message" do
+          invalid_store_credit.valid?
+          attribute_name = I18n.t('activerecord.attributes.spree/store_credit.amount_used')
+          validation_message = Spree.t('admin.store_credits.errors.amount_used_cannot_be_greater')
+          expected_error_message = "#{attribute_name} #{validation_message}"
+          expect(invalid_store_credit.errors.full_messages).to include(expected_error_message)
+        end
+      end
+
+      context "the used amount is not defined yet" do
+        let(:store_credit) { build(:store_credit, amount: 100) }
+
+        it "should be valid" do
+          expect(store_credit).to be_valid
+        end
+
+      end
+    end
+
+    describe "amount used less than or equal to amount" do
+      subject { build(:store_credit, amount_used: 101.0, amount: 100.0) }
+
+      it "is not valid" do
+        expect(subject).not_to be_valid
+      end
+
+      it "adds an error message about the invalid amount used" do
+        subject.valid?
+        expect(subject.errors[:amount_used]).to include(Spree.t('admin.store_credits.errors.amount_used_cannot_be_greater'))
+      end
+    end
+
+    describe "amount authorized less than or equal to amount" do
+      subject { build(:store_credit, amount_authorized: 101.0, amount: 100.0) }
+
+      it "is not valid" do
+        expect(subject).not_to be_valid
+      end
+
+      it "adds an error message about the invalid authorized amount" do
+        subject.valid?
+        expect(subject.errors[:amount_authorized]).to include(Spree.t('admin.store_credits.errors.amount_authorized_exceeds_total_credit'))
+      end
+    end
+  end
+
+  describe "#display_amount" do
+    it "returns a Spree::Money instance" do
+      expect(store_credit.display_amount).to be_instance_of(Spree::Money)
+    end
+  end
+
+  describe "#display_amount_used" do
+    it "returns a Spree::Money instance" do
+      expect(store_credit.display_amount_used).to be_instance_of(Spree::Money)
+    end
+  end
+
+  describe "#display_amount_authorized" do
+    it "returns a Spree::Money instance" do
+      expect(store_credit.display_amount_authorized).to be_instance_of(Spree::Money)
+    end
+  end
+
+  describe "#amount_remaining" do
+    context "invalidated" do
+      before { allow(store_credit).to receive(:invalidated?) { true } }
+      it { expect(store_credit.amount_remaining).to eq 0.0 }
+    end
+
+    context "the amount_used is not defined" do
+      context "the authorized amount is not defined" do
+        it "returns the credited amount" do
+          expect(store_credit.amount_remaining).to eq store_credit.amount
+        end
+      end
+      context "the authorized amount is defined" do
+        let(:authorized_amount) { 15.00 }
+
+        before { store_credit.update_attributes(amount_authorized: authorized_amount) }
+
+        it "subtracts the authorized amount from the credited amount" do
+          expect(store_credit.amount_remaining).to eq (store_credit.amount - authorized_amount)
+        end
+      end
+    end
+
+    context "the amount_used is defined" do
+      let(:amount_used) { 10.0 }
+
+      before { store_credit.update_attributes(amount_used: amount_used) }
+
+      context "the authorized amount is not defined" do
+        it "subtracts the amount used from the credited amount" do
+          expect(store_credit.amount_remaining).to eq (store_credit.amount - amount_used)
+        end
+      end
+
+      context "the authorized amount is defined" do
+        let(:authorized_amount) { 15.00 }
+
+        before { store_credit.update_attributes(amount_authorized: authorized_amount) }
+
+        it "subtracts the amount used and the authorized amount from the credited amount" do
+          expect(store_credit.amount_remaining).to eq (store_credit.amount - amount_used - authorized_amount)
+        end
+      end
+    end
+  end
+
+  describe "#authorize" do
+    context "amount is valid" do
+      let(:authorization_amount)       { 1.0 }
+      let(:added_authorization_amount) { 3.0 }
+      let(:originator) { nil }
+
+      context "amount has not been authorized yet" do
+
+        before { store_credit.update_attributes(amount_authorized: authorization_amount) }
+
+        it "returns true" do
+          expect(store_credit.authorize(store_credit.amount - authorization_amount, store_credit.currency)).to be_truthy
+        end
+
+        it "adds the new amount to authorized amount" do
+          store_credit.authorize(added_authorization_amount, store_credit.currency)
+          expect(store_credit.reload.amount_authorized).to eq (authorization_amount + added_authorization_amount)
+        end
+
+        context "originator is present" do
+          with_model 'OriginatorThing'
+
+          let(:originator) { OriginatorThing.create! } # won't actually be a user. just giving it a valid model here
+
+          subject { store_credit.authorize(added_authorization_amount, store_credit.currency, action_originator: originator) }
+
+          it "records the originator" do
+            expect { subject }.to change { Spree::StoreCreditEvent.count }.by(1)
+            expect(Spree::StoreCreditEvent.last.originator).to eq originator
+          end
+        end
+      end
+
+      context "authorization has already happened" do
+        let!(:auth_event) { create(:store_credit_auth_event, store_credit: store_credit) }
+
+        before { store_credit.update_attributes(amount_authorized: store_credit.amount) }
+
+        it "returns true" do
+          expect(store_credit.authorize(store_credit.amount, store_credit.currency, action_authorization_code: auth_event.authorization_code)).to be true
+        end
+      end
+    end
+
+    context "amount is invalid" do
+      it "returns false" do
+        expect(store_credit.authorize(store_credit.amount * 2, store_credit.currency)).to be false
+      end
+    end
+  end
+
+  describe "#validate_authorization" do
+    context "insufficient funds" do
+      subject { store_credit.validate_authorization(store_credit.amount * 2, store_credit.currency) }
+
+      it "returns false" do
+        expect(subject).to be false
+      end
+
+      it "adds an error to the model" do
+        subject
+        expect(store_credit.errors.full_messages).to include(Spree.t('store_credit.insufficient_funds'))
+      end
+    end
+
+    context "currency mismatch" do
+      subject { store_credit.validate_authorization(store_credit.amount, "EUR") }
+
+      it "returns false" do
+        expect(subject).to be false
+      end
+
+      it "adds an error to the model" do
+        subject
+        expect(store_credit.errors.full_messages).to include(Spree.t('store_credit.currency_mismatch'))
+      end
+    end
+
+    context "valid authorization" do
+      subject { store_credit.validate_authorization(store_credit.amount, store_credit.currency) }
+
+      it "returns true" do
+        expect(subject).to be true
+      end
+    end
+
+    context 'troublesome floats' do
+      # 8.21.to_d < 8.21 => true
+      let(:store_credit_attrs) { {amount: 8.21} }
+
+      subject { store_credit.validate_authorization(store_credit_attrs[:amount], store_credit.currency) }
+
+      it { is_expected.to be_truthy }
+    end
+  end
+
+  describe "#capture" do
+    let(:authorized_amount) { 10.00 }
+    let(:auth_code)         { "23-SC-20140602164814476128" }
+
+    before do
+      @original_authed_amount = store_credit.amount_authorized
+      @auth_code = store_credit.authorize(authorized_amount, store_credit.currency)
+    end
+
+    context "insufficient funds" do
+      subject { store_credit.capture(authorized_amount * 2, @auth_code, store_credit.currency) }
+
+      it "returns false" do
+        expect(subject).to be false
+      end
+
+      it "adds an error to the model" do
+        subject
+        expect(store_credit.errors.full_messages).to include(Spree.t('store_credit.insufficient_authorized_amount'))
+      end
+
+      it "does not update the store credit model" do
+        expect { subject }.to_not change { store_credit }
+      end
+    end
+
+    context "currency mismatch" do
+      subject { store_credit.capture(authorized_amount, @auth_code, "EUR") }
+
+      it "returns false" do
+        expect(subject).to be false
+      end
+
+      it "adds an error to the model" do
+        subject
+        expect(store_credit.errors.full_messages).to include(Spree.t('store_credit.currency_mismatch'))
+      end
+
+      it "does not update the store credit model" do
+        expect { subject }.to_not change { store_credit }
+      end
+    end
+
+    context "valid capture" do
+      let(:remaining_authorized_amount) { 1 }
+      let(:originator) { nil }
+
+      subject { store_credit.capture(authorized_amount - remaining_authorized_amount, @auth_code, store_credit.currency, action_originator: originator) }
+
+      it "returns true" do
+        expect(subject).to be_truthy
+      end
+
+      it "updates the authorized amount to the difference between the store credits total authed amount and the authorized amount for this event" do
+        subject
+        expect(store_credit.reload.amount_authorized).to eq(@original_authed_amount)
+      end
+
+      it "updates the used amount to the current used amount plus the captured amount" do
+        subject
+        expect(store_credit.reload.amount_used).to eq authorized_amount - remaining_authorized_amount
+      end
+
+      context "originator is present" do
+        with_model 'OriginatorThing'
+
+        let(:originator) { OriginatorThing.create! } # won't actually be a user. just giving it a valid model here
+
+        it "records the originator" do
+          expect { subject }.to change { Spree::StoreCreditEvent.count }.by(1)
+          expect(Spree::StoreCreditEvent.last.originator).to eq originator
+        end
+      end
+    end
+  end
+
+  describe "#void" do
+    let(:auth_code)    { "1-SC-20141111111111" }
+    let(:store_credit) { create(:store_credit, amount_used: 150.0) }
+    let(:originator) { nil }
+
+    subject do
+      store_credit.void(auth_code, action_originator: originator)
+    end
+
+    context "no event found for auth_code" do
+
+      it "returns false" do
+        expect(subject).to be false
+      end
+
+      it "adds an error to the model" do
+        subject
+        expect(store_credit.errors.full_messages).to include(Spree.t('store_credit.unable_to_void', auth_code: auth_code))
+      end
+    end
+
+    context "capture event found for auth_code" do
+      let(:captured_amount) { 10.0 }
+      let!(:capture_event) { create(:store_credit_auth_event,
+                                    action: Spree::StoreCredit::CAPTURE_ACTION,
+                                    authorization_code: auth_code,
+                                    amount: captured_amount,
+                                    store_credit: store_credit) }
+
+      it "returns false" do
+        expect(subject).to be false
+      end
+
+      it "does not change the amount used on the store credit" do
+        expect { subject }.to_not change{ store_credit.amount_used.to_f }
+      end
+    end
+
+    context "auth event found for auth_code" do
+      let(:auth_event) { create(:store_credit_auth_event) }
+
+      let(:authorized_amount) { 10.0 }
+      let!(:auth_event) { create(:store_credit_auth_event,
+                                 authorization_code: auth_code,
+                                 amount: authorized_amount,
+                                 store_credit: store_credit) }
+
+      it "returns true" do
+        expect(subject).to be true
+      end
+
+      it "returns the capture amount to the store credit" do
+        expect { subject }.to change{ store_credit.amount_authorized.to_f }.by(-authorized_amount)
+      end
+
+      context "originator is present" do
+        with_model 'OriginatorThing'
+
+        let(:originator) { OriginatorThing.create! } # won't actually be a user. just giving it a valid model here
+
+        it "records the originator" do
+          expect { subject }.to change { Spree::StoreCreditEvent.count }.by(1)
+          expect(Spree::StoreCreditEvent.last.originator).to eq originator
+        end
+      end
+    end
+  end
+
+  describe "#credit" do
+    let(:event_auth_code) { "1-SC-20141111111111" }
+    let(:amount_used)     { 10.0 }
+    let(:store_credit)    { create(:store_credit, amount_used: amount_used) }
+    let!(:capture_event)  { create(:store_credit_auth_event,
+                                   action: Spree::StoreCredit::CAPTURE_ACTION,
+                                   authorization_code: event_auth_code,
+                                   amount: captured_amount,
+                                   store_credit: store_credit) }
+    let(:originator) { nil }
+
+    subject { store_credit.credit(credit_amount, auth_code, currency, action_originator: originator) }
+
+    context "currency does not match" do
+      let(:currency)        { "AUD" }
+      let(:credit_amount)   { 5.0 }
+      let(:captured_amount) { 100.0 }
+      let(:auth_code)       { event_auth_code }
+
+      it "returns false" do
+        expect(subject).to be false
+      end
+
+      it "adds an error message about the currency mismatch" do
+        subject
+        expect(store_credit.errors.full_messages).to include(Spree.t('store_credit.currency_mismatch'))
+      end
+    end
+
+    context "unable to find capture event" do
+      let(:currency)        { "USD" }
+      let(:credit_amount)   { 5.0 }
+      let(:captured_amount) { 100.0 }
+      let(:auth_code)       { "UNKNOWN_CODE" }
+
+      it "returns false" do
+        expect(subject).to be false
+      end
+
+      it "adds an error message about the currency mismatch" do
+        subject
+        expect(store_credit.errors.full_messages).to include(Spree.t('store_credit.unable_to_credit', auth_code: auth_code))
+      end
+    end
+
+    context "amount is more than what is captured" do
+      let(:currency)        { "USD" }
+      let(:credit_amount)   { 100.0 }
+      let(:captured_amount) { 5.0 }
+      let(:auth_code)       { event_auth_code }
+
+      it "returns false" do
+        expect(subject).to be false
+      end
+
+      it "adds an error message about the currency mismatch" do
+        subject
+        expect(store_credit.errors.full_messages).to include(Spree.t('store_credit.unable_to_credit', auth_code: auth_code))
+      end
+    end
+
+    context "amount is successfully credited" do
+      let(:currency)        { "USD" }
+      let(:credit_amount)   { 5.0 }
+      let(:captured_amount) { 100.0 }
+      let(:auth_code)       { event_auth_code }
+
+      context "credit_to_new_allocation is set" do
+        before { Spree::Config[:credit_to_new_allocation] = true }
+
+        it "returns true" do
+          expect(subject).to be true
+        end
+
+        it "creates a new store credit record" do
+          expect { subject }.to change { Spree::StoreCredit.count }.by(1)
+        end
+
+        it "does not create a new store credit event on the parent store credit" do
+          expect { subject }.to_not change { store_credit.store_credit_events.count }
+        end
+
+        context "credits the passed amount to a new store credit record" do
+          before do
+            subject
+            @new_store_credit = Spree::StoreCredit.last
+          end
+
+          it "does not set the amount used on hte originating store credit" do
+            expect(store_credit.reload.amount_used).to eq amount_used
+          end
+
+          it "sets the correct amount on the new store credit" do
+            expect(@new_store_credit.amount).to eq credit_amount
+          end
+
+          [:user_id, :category_id, :created_by_id, :currency, :type_id].each do |attr|
+            it "sets attribute #{attr} inherited from the originating store credit" do
+              expect(@new_store_credit.send(attr)).to eq store_credit.send(attr)
+            end
+          end
+
+          it "sets a memo" do
+            expect(@new_store_credit.memo).to eq "This is a credit from store credit ID #{store_credit.id}"
+          end
+        end
+
+        context "originator is present" do
+          with_model 'OriginatorThing'
+
+          let(:originator) { OriginatorThing.create! } # won't actually be a user. just giving it a valid model here
+
+          it "records the originator" do
+            expect { subject }.to change { Spree::StoreCreditEvent.count }.by(1)
+            expect(Spree::StoreCreditEvent.last.originator).to eq originator
+          end
+        end
+      end
+
+      context "credit_to_new_allocation is not set" do
+        it "returns true" do
+          expect(subject).to be true
+        end
+
+        it "credits the passed amount to the store credit amount used" do
+          subject
+          expect(store_credit.reload.amount_used).to eq (amount_used - credit_amount)
+        end
+
+        it "creates a new store credit event" do
+          expect { subject }.to change { store_credit.store_credit_events.count }.by(1)
+        end
+      end
+    end
+  end
+
+  describe "#amount_used" do
+    context "amount used is not defined" do
+      subject { Spree::StoreCredit.new }
+
+      it "returns zero" do
+        expect(subject.amount_used).to be_zero
+      end
+    end
+
+    context "amount used is defined" do
+      let(:amount_used) { 100.0 }
+
+      subject { create(:store_credit, amount_used: amount_used) }
+
+      it "returns the attribute value" do
+        expect(subject.amount_used).to eq amount_used
+      end
+    end
+  end
+
+  describe "#amount_authorized" do
+    context "amount authorized is not defined" do
+      subject { Spree::StoreCredit.new }
+
+      it "returns zero" do
+        expect(subject.amount_authorized).to be_zero
+      end
+    end
+
+    context "amount authorized is defined" do
+      let(:amount_authorized) { 100.0 }
+
+      subject { create(:store_credit, amount_authorized: amount_authorized) }
+
+      it "returns the attribute value" do
+        expect(subject.amount_authorized).to eq amount_authorized
+      end
+    end
+  end
+
+  describe "#can_capture?" do
+    let(:store_credit) { create(:store_credit) }
+    let(:payment)      { create(:payment, state: payment_state) }
+
+    subject { store_credit.can_capture?(payment) }
+
+    context "pending payment" do
+      let(:payment_state) { 'pending' }
+
+      it "returns true" do
+        expect(subject).to be true
+      end
+    end
+
+    context "checkout payment" do
+      let(:payment_state) { 'checkout' }
+
+      it "returns true" do
+        expect(subject).to be true
+      end
+    end
+
+    context "void payment" do
+      let(:payment_state) { Spree::StoreCredit::VOID_ACTION }
+
+      it "returns false" do
+        expect(subject).to be false
+      end
+    end
+
+    context "invalid payment" do
+      let(:payment_state) { 'invalid' }
+
+      it "returns false" do
+        expect(subject).to be false
+      end
+    end
+
+    context "complete payment" do
+      let(:payment_state) { 'completed' }
+
+      it "returns false" do
+        expect(subject).to be false
+      end
+    end
+  end
+
+  describe "#can_void?" do
+    let(:store_credit) { create(:store_credit) }
+    let(:payment)      { create(:payment, state: payment_state) }
+
+    subject { store_credit.can_void?(payment) }
+
+    context "pending payment" do
+      let(:payment_state) { 'pending' }
+
+      it "returns true" do
+        expect(subject).to be true
+      end
+    end
+
+    context "checkout payment" do
+      let(:payment_state) { 'checkout' }
+
+      it "returns false" do
+        expect(subject).to be false
+      end
+    end
+
+    context "void payment" do
+      let(:payment_state) { Spree::StoreCredit::VOID_ACTION }
+
+      it "returns false" do
+        expect(subject).to be false
+      end
+    end
+
+    context "invalid payment" do
+      let(:payment_state) { 'invalid' }
+
+      it "returns false" do
+        expect(subject).to be false
+      end
+    end
+
+    context "complete payment" do
+      let(:payment_state) { 'completed' }
+
+      it "returns false" do
+        expect(subject).to be false
+      end
+    end
+  end
+
+  describe "#can_credit?" do
+    let(:store_credit) { create(:store_credit) }
+    let(:payment)      { create(:payment, state: payment_state) }
+
+    subject { store_credit.can_credit?(payment) }
+
+    context "payment is not completed" do
+      let(:payment_state) { "pending" }
+
+      it "returns false" do
+        expect(subject).to be false
+      end
+    end
+
+    context "payment is completed" do
+      let(:payment_state) { "completed" }
+
+      context "credit is owed on the order" do
+        before { allow(payment.order).to receive_messages(payment_state: 'credit_owed') }
+
+        context "payment doesn't have allowed credit" do
+          before { allow(payment).to receive_messages(credit_allowed: 0.0) }
+
+          it "returns false" do
+            expect(subject).to be false
+          end
+        end
+
+        context "payment has allowed credit" do
+          before { allow(payment).to receive_messages(credit_allowed: 5.0) }
+
+          it "returns true" do
+            expect(subject).to be true
+          end
+        end
+      end
+    end
+
+    describe "#store_events" do
+      context "create" do
+        context "user has one store credit" do
+          let(:store_credit_amount) { 100.0 }
+
+          subject { create(:store_credit, amount: store_credit_amount) }
+
+          it "creates a store credit event" do
+            expect { subject }.to change { Spree::StoreCreditEvent.count }.by(1)
+          end
+
+          it "makes the store credit event an allocation event" do
+            expect(subject.store_credit_events.first.action).to eq Spree::StoreCredit::ALLOCATION_ACTION
+          end
+
+          it "saves the user's total store credit in the event" do
+            expect(subject.store_credit_events.first.user_total_amount).to eq store_credit_amount
+          end
+        end
+
+        context "user has multiple store credits" do
+          let(:store_credit_amount)            { 100.0 }
+          let(:additional_store_credit_amount) { 200.0 }
+
+          let(:user)                           { create(:user) }
+          let!(:store_credit)                  { create(:store_credit, user: user, amount: store_credit_amount) }
+
+          subject { create(:store_credit, user: user, amount: additional_store_credit_amount) }
+
+          it "saves the user's total store credit in the event" do
+            expect(subject.store_credit_events.first.user_total_amount).to eq (store_credit_amount + additional_store_credit_amount)
+          end
+        end
+
+        context "an action is specified" do
+          it "creates an event with the set action" do
+            store_credit = build(:store_credit)
+            store_credit.action = Spree::StoreCredit::VOID_ACTION
+            store_credit.action_authorization_code = "1-SC-TEST"
+
+            expect { store_credit.save! }.to change { Spree::StoreCreditEvent.where(action: Spree::StoreCredit::VOID_ACTION).count }.by(1)
+          end
+        end
+      end
+    end
+  end
+
+  describe "#invalidate" do
+    before { allow(store_credit).to receive(:touch) }
+    it "sets the invalidated_at field to the current time" do
+      store_credit.invalidate
+      expect(store_credit).to have_received(:touch).with(:invalidated_at)
+    end
+
+    context "there is an uncaptured authorization" do
+      before { store_credit.authorize(5.0, "USD") }
+      it "prevents invalidation" do
+        store_credit.invalidate
+        expect(store_credit).not_to have_received(:touch)
+        expect(store_credit.errors[:invalidated_at].join).to match /uncaptured authorization/
+      end
+    end
+
+    context "there is a captured authorization" do
+      before do
+        auth_code = store_credit.authorize(5.0, "USD")
+        store_credit.capture(5.0, auth_code, "USD")
+      end
+
+      it "can invalidate the rest of the store credit" do
+        store_credit.invalidate
+        expect(store_credit).to have_received(:touch).with(:invalidated_at)
+        expect(store_credit.errors).to be_blank
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/user_spec.rb
+++ b/core/spec/models/spree/user_spec.rb
@@ -127,4 +127,70 @@ describe Spree.user_class, :type => :model do
       end
     end
   end
+
+  describe "#total_available_store_credit" do
+    context "user does not have any associated store credits" do
+      subject { create(:user) }
+
+      it "returns 0" do
+        expect(subject.total_available_store_credit).to be_zero
+      end
+    end
+
+    context "user has several associated store credits" do
+      let(:user)                     { create(:user) }
+      let(:amount)                   { 120.25 }
+      let(:additional_amount)        { 55.75 }
+      let(:store_credit)             { create(:store_credit, user: user, amount: amount, amount_used: 0.0) }
+      let!(:additional_store_credit) { create(:store_credit, user: user, amount: additional_amount, amount_used: 0.0) }
+
+      subject { store_credit.user }
+
+      context "part of the store credit has been used" do
+        let(:amount_used) { 35.00 }
+
+        before { store_credit.update_attributes(amount_used: amount_used) }
+
+        context "part of the store credit has been authorized" do
+          let(:authorized_amount) { 10 }
+
+          before { additional_store_credit.update_attributes(amount_authorized: authorized_amount) }
+
+          it "returns sum of amounts minus used amount and authorized amount" do
+            expect(subject.total_available_store_credit.to_f).to eq (amount + additional_amount - amount_used - authorized_amount)
+          end
+        end
+
+        context "there are no authorized amounts on any of the store credits" do
+          it "returns sum of amounts minus used amount" do
+            expect(subject.total_available_store_credit.to_f).to eq (amount + additional_amount - amount_used)
+          end
+        end
+      end
+
+      context "store credits have never been used" do
+        context "part of the store credit has been authorized" do
+          let(:authorized_amount) { 10 }
+
+          before { additional_store_credit.update_attributes(amount_authorized: authorized_amount) }
+
+          it "returns sum of amounts minus authorized amount" do
+            expect(subject.total_available_store_credit.to_f).to eq (amount + additional_amount - authorized_amount)
+          end
+        end
+
+        context "there are no authorized amounts on any of the store credits" do
+          it "returns sum of amounts" do
+            expect(subject.total_available_store_credit.to_f).to eq (amount + additional_amount)
+          end
+        end
+      end
+
+      context "all store credits have never been used or authorized" do
+        it "returns sum of amounts" do
+          expect(subject.total_available_store_credit.to_f).to eq (amount + additional_amount)
+        end
+      end
+    end
+  end
 end

--- a/core/spec/spec_helper.rb
+++ b/core/spec/spec_helper.rb
@@ -62,4 +62,6 @@ RSpec.configure do |config|
   config.include Spree::TestingSupport::Mail
 
   config.fail_fast = ENV['FAIL_FAST'] || false
+
+  config.extend WithModel
 end

--- a/frontend/app/views/spree/checkout/_payment.html.erb
+++ b/frontend/app/views/spree/checkout/_payment.html.erb
@@ -1,7 +1,6 @@
 <fieldset id="payment" data-hook>
   <legend align="center"><%= Spree.t(:payment_information) %></legend>
   <div data-hook="checkout_payment_step">
-
     <% if @payment_sources.present? %>
       <div class="card_options">
         <%= radio_button_tag 'use_existing_card', 'yes', true %>

--- a/frontend/app/views/spree/checkout/_summary.html.erb
+++ b/frontend/app/views/spree/checkout/_summary.html.erb
@@ -57,9 +57,16 @@
       </tbody>
     <% end %>
 
+    <% if order.total_applicable_store_credit > 0.0 %>
+      <tr data-hook="checkout-summary-store-credit">
+        <td><%= Spree.t("store_credit.store_credit") %>:</td>
+        <td><%= order.display_total_applicable_store_credit.to_html %></td>
+      </tr>
+    <% end %>
+
     <tr data-hook="order_total">
       <td><strong><%= Spree.t(:order_total) %>:</strong></td>
-      <td><strong><span id='summary-order-total'><%= order.display_total.to_html %></span></strong></td>
+      <td><strong><span id='summary-order-total'><%= order.display_order_total_after_store_credit.to_html %></span></strong></td>
     </tr>
   </tbody>
 </table>

--- a/frontend/app/views/spree/payments/_payment.html.erb
+++ b/frontend/app/views/spree/payments/_payment.html.erb
@@ -10,6 +10,9 @@
   </span>
   <br />
   <span class="full-name"><%= source.name %></span>
+<% elsif source.is_a?(Spree::StoreCredit) %>
+  <%= content_tag(:span, payment.payment_method.name) %>:
+  <%= content_tag(:span, payment.display_amount) %>
 <% else %>
   <%= content_tag(:span, payment.payment_method.name) %>
 <% end %>

--- a/frontend/app/views/spree/shared/_order_details.html.erb
+++ b/frontend/app/views/spree/shared/_order_details.html.erb
@@ -32,7 +32,7 @@
     <h6><%= Spree.t(:payment_information) %> <%= link_to "(#{Spree.t(:edit)})", checkout_state_path(:payment) unless order.completed? %></h6>
     <div class="payment-info">
       <% order.payments.valid.each do |payment| %>
-        <%= render payment%><br/>
+        <%= render payment %><br/>
       <% end %>
     </div>
   </div>
@@ -81,7 +81,7 @@
   <tfoot id="order-total" data-hook="order_details_total">
     <tr class="total">
       <td colspan="4"><b><%= Spree.t(:order_total) %>:</b></td>
-      <td class="total"><span id="order_total"><%= order.display_total.to_html %></span></td>
+      <td class="total"><span id="order_total"><%= order.display_order_total_after_store_credit.to_html %></span></td>
     </tr>
   </tfoot>
 
@@ -122,6 +122,15 @@
           <td class="total"><span><%= Spree::Money.new(adjustments.sum(&:amount), currency: order.currency) %></span></td>
         </tr>
       <% end %>
+    </tfoot>
+  <% end %>
+
+  <% if order.total_applicable_store_credit > 0.0 %>
+    <tfoot id="store-credit" data-hook="order_details_store_credit">
+      <tr class="total">
+        <td colspan='4'><%= Spree.t("store_credit.store_credit") %>:</td>
+        <td class='total'><span><%= order.display_total_applicable_store_credit.to_html %></span></td>
+      </tr>
     </tfoot>
   <% end %>
 


### PR DESCRIPTION
A Spree store credit implementation that applies store credit as a payment method.

Takes into account purchasing through the API and frontend, with the default to use all available store credit.

Store credit can be granted in admin, and behaves like a credit card in that once an amount is authorized, it cannot be used elsewhere.

Store credit can be stored in multiple buckets (e.g. expiring and non-expiring) because those are taxed differently and implementors might want to prioritize use / refund different types.
## Credit Types

Out of the box, there are Expiring and Non-expiring store credits, with the Expiring type having top priority of being used in a purchase.

To add new ones, add a migration with a priority value set, and on purchase it will take the credits from lowest numerical priority to highest. You will also need to overwrite `Spree::StoreCredit#associate_credit_type`

Configure the gem with non-expiring categorizations in an initializer:

``` ruby
Spree::StoreCredits::Configuration.set_configs(non_expiring_credit_types: ['Example'])
```
## Store credit application

If a user has store credit, it will automatically get applied as a payment method for their order. Store credit is not applied manually which is why the payment method has been set to not display as a choice in the frontend or the backend. The amount used will be visible in both interfaces though.
