### PR TITLE
Request taxons without children from autocomplete

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/taxon_autocomplete.js.erb
+++ b/backend/app/assets/javascripts/spree/backend/taxon_autocomplete.js.erb
@@ -8,6 +8,7 @@ var set_taxon_select = function(){
       initSelection: function (element, callback) {
         var url = Spree.url(Spree.routes.taxons_search, {
           ids: element.val(),
+          without_children: true
         });
         return Spree.getJSON(url, null, function (data) {
           return callback(data['taxons']);


### PR DESCRIPTION
Without this the response is large and very slow to render. We only need
this to determine the pretty name, so this is of no use.
