### PR TITLE
Allow pry-byebug on all version of MRI

### DIFF
--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -36,10 +36,7 @@ group :test do
 end
 
 group :test, :development do
-  platforms :ruby_19 do
-    gem 'pry-debugger'
-  end
-  platforms :ruby_20, :ruby_21 do
+  platforms :mri do
     gem 'pry-byebug', '~> 1.0'
   end
 end


### PR DESCRIPTION
We now require ruby >= 2.1 to run solidus. Removing the version
restriction in common_spree_dependencies allows using pry on ruby 2.2
