### PR TITLE
Replace order strings with symbols/arel_table.

### DIFF
--- a/core/app/models/concerns/spree/named_type.rb
+++ b/core/app/models/concerns/spree/named_type.rb
@@ -4,7 +4,7 @@ module Spree
 
     included do
       scope :active, -> { where(active: true) }
-      default_scope -> { order("LOWER(#{self.table_name}.name)") }
+      default_scope -> { order(arel_table[:name].lower) }
 
       validates :name, presence: true, uniqueness: { case_sensitive: false }
     end

--- a/core/app/models/spree/country.rb
+++ b/core/app/models/spree/country.rb
@@ -1,6 +1,6 @@
 module Spree
   class Country < Spree::Base
-    has_many :states, -> { order('name ASC') }, dependent: :destroy
+    has_many :states, -> { order(:name) }, dependent: :destroy
     has_many :addresses, dependent: :nullify
 
     validates :name, :iso_name, presence: true

--- a/core/app/models/spree/inventory_unit.rb
+++ b/core/app/models/spree/inventory_unit.rb
@@ -28,7 +28,7 @@ module Spree
         .where("spree_shipments.state != 'canceled'").references(:shipment)
         .where(variant_id: stock_item.variant_id)
         .where('spree_orders.completed_at is not null')
-        .backordered.order("spree_orders.completed_at ASC")
+        .backordered.order(Spree::Order.arel_table[:completed_at])
     end
     scope :shippable, -> { on_hand }
 

--- a/core/app/models/spree/item_adjustments.rb
+++ b/core/app/models/spree/item_adjustments.rb
@@ -78,7 +78,7 @@ module Spree
     end
 
     def best_promotion_adjustment
-      @best_promotion_adjustment ||= adjustments.promotion.eligible.reorder("amount ASC, created_at DESC, id DESC").first
+      @best_promotion_adjustment ||= adjustments.promotion.eligible.reorder(:amount, created_at: :desc, id: :desc).first
     end
   end
 end

--- a/core/app/models/spree/option_type.rb
+++ b/core/app/models/spree/option_type.rb
@@ -10,7 +10,7 @@ module Spree
     validates :name, presence: true, uniqueness: true
     validates :presentation, presence: true
 
-    default_scope -> { order("#{self.table_name}.position") }
+    default_scope -> { order(:position) }
 
     accepts_nested_attributes_for :option_values, reject_if: lambda { |ov| ov[:name].blank? || ov[:presentation].blank? }, allow_destroy: true
 

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -49,11 +49,11 @@ module Spree
 
     belongs_to :store, class_name: 'Spree::Store'
     has_many :state_changes, as: :stateful
-    has_many :line_items, -> { order('created_at', 'id') }, dependent: :destroy, inverse_of: :order
+    has_many :line_items, -> { order(:created_at, :id) }, dependent: :destroy, inverse_of: :order
     has_many :payments, dependent: :destroy
     has_many :return_authorizations, dependent: :destroy, inverse_of: :order
     has_many :reimbursements, inverse_of: :order
-    has_many :adjustments, -> { order("#{Adjustment.table_name}.created_at ASC") }, as: :adjustable, dependent: :destroy
+    has_many :adjustments, -> { order(:created_at) }, as: :adjustable, dependent: :destroy
     has_many :line_item_adjustments, through: :line_items, source: :adjustments
     has_many :shipment_adjustments, through: :shipments, source: :adjustments
     has_many :inventory_units, inverse_of: :order

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -34,7 +34,7 @@ module Spree
     validates :amount, numericality: true
     validates :source, presence: true, if: :source_required?
 
-    default_scope -> { order("#{self.table_name}.created_at") }
+    default_scope -> { order(:created_at) }
 
     scope :from_credit_card, -> { where(source_type: 'Spree::CreditCard') }
     scope :with_state, ->(s) { where(state: s.to_s) }

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -43,17 +43,17 @@ module Spree
       class_name: 'Spree::Variant'
 
     has_many :variants,
-      -> { where(is_master: false).order("#{::Spree::Variant.quoted_table_name}.position ASC") },
+      -> { where(is_master: false).order(:position) },
       inverse_of: :product,
       class_name: 'Spree::Variant'
 
     has_many :variants_including_master,
-      -> { order("#{::Spree::Variant.quoted_table_name}.position ASC") },
+      -> { order(:position) },
       inverse_of: :product,
       class_name: 'Spree::Variant',
       dependent: :destroy
 
-    has_many :prices, -> { order('spree_variants.position, spree_variants.id, currency') }, through: :variants
+    has_many :prices, -> { order(Spree::Variant.arel_table[:position], Spree::Variant.arel_table[:id], :currency) }, through: :variants
 
     has_many :stock_items, through: :variants_including_master
 

--- a/core/app/models/spree/product/scopes.rb
+++ b/core/app/models/spree/product/scopes.rb
@@ -23,7 +23,7 @@ module Spree
         # We should not define price scopes here, as they require something slightly different
         next if name.to_s.include?("master_price")
         parts = name.to_s.match(/(.*)_by_(.*)/)
-        self.scope(name.to_s, -> { order("#{Product.quoted_table_name}.#{parts[2]} #{parts[1] == 'ascend' ?  "ASC" : "DESC"}") })
+        self.scope(name.to_s, -> { order(Spree::Product.arel_table[parts[2].to_sym].send(parts[1] == 'ascend' ?  :asc : :desc)) })
       end
     end
 
@@ -39,11 +39,11 @@ module Spree
     add_simple_scopes simple_scopes
 
     add_search_scope :ascend_by_master_price do
-      joins(:master => :default_price).order("#{price_table_name}.amount ASC")
+      joins(:master => :default_price).order(Spree::Price.arel_table[:amount])
     end
 
     add_search_scope :descend_by_master_price do
-      joins(:master => :default_price).order("#{price_table_name}.amount DESC")
+      joins(:master => :default_price).order(Spree::Price.arel_table[:amount].desc)
     end
 
     add_search_scope :price_between do |low, high|
@@ -78,7 +78,7 @@ module Spree
     add_search_scope :in_taxon do |taxon|
       includes(:classifications).
       where("spree_products_taxons.taxon_id" => taxon.self_and_descendants.pluck(:id)).
-      order("spree_products_taxons.position ASC")
+      order(Spree::Classification.arel_table[:position])
     end
 
     # This scope selects products in all taxons AND all its descendants

--- a/core/app/models/spree/product_property.rb
+++ b/core/app/models/spree/product_property.rb
@@ -7,7 +7,7 @@ module Spree
 
     validates_with Spree::Validations::DbMaximumLengthValidator, field: :value
 
-    default_scope -> { order("#{self.table_name}.position") }
+    default_scope -> { order(:position) }
 
     # virtual attributes for use with AJAX completion stuff
     def property_name

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -10,7 +10,7 @@ module Spree
 
     has_many :adjustments, as: :adjustable, dependent: :delete_all
     has_many :inventory_units, dependent: :destroy, inverse_of: :shipment
-    has_many :shipping_rates, -> { order('cost ASC') }, dependent: :delete_all
+    has_many :shipping_rates, -> { order(:cost) }, dependent: :delete_all
     has_many :shipping_methods, through: :shipping_rates
     has_many :state_changes, as: :stateful
     has_many :cartons, -> { uniq }, through: :inventory_units

--- a/core/app/models/spree/state.rb
+++ b/core/app/models/spree/state.rb
@@ -13,7 +13,7 @@ module Spree
     # blank is added elsewhere, if needed
     def self.states_group_by_country_id
       state_info = Hash.new { |h, k| h[k] = [] }
-      self.order('name ASC').each { |state|
+      self.order(:name).each { |state|
         state_info[state.country_id.to_s].push [state.id, state.name]
       }
       state_info

--- a/core/app/models/spree/stock_movement.rb
+++ b/core/app/models/spree/stock_movement.rb
@@ -8,7 +8,7 @@ module Spree
     validates :stock_item, presence: true
     validates :quantity, presence: true
 
-    scope :recent, -> { order('created_at DESC') }
+    scope :recent, -> { order(created_at: :desc) }
 
     def readonly?
       !new_record?

--- a/core/app/models/spree/taxonomy.rb
+++ b/core/app/models/spree/taxonomy.rb
@@ -9,7 +9,7 @@ module Spree
 
     after_save :set_name
 
-    default_scope -> { order("#{self.table_name}.position") }
+    default_scope -> { order(:position) }
 
     private
       def set_name

--- a/core/app/models/spree/zone.rb
+++ b/core/app/models/spree/zone.rb
@@ -19,7 +19,7 @@ module Spree
     # Returns nil in the case of no matches.
     def self.match(address)
       return unless address and matches = self.includes(:zone_members).
-        order('spree_zones.zone_members_count', 'spree_zones.created_at', 'spree_zones.id').
+        order(:zone_members_count, :created_at, :id).
         where("(spree_zone_members.zoneable_type = 'Spree::Country' AND spree_zone_members.zoneable_id = ?) OR (spree_zone_members.zoneable_type = 'Spree::State' AND spree_zone_members.zoneable_id = ?)", address.country_id, address.state_id).
         references(:zones)
 

--- a/core/spec/models/spree/product/scopes_spec.rb
+++ b/core/spec/models/spree/product/scopes_spec.rb
@@ -113,36 +113,4 @@ describe "Product scopes", :type => :model do
       end
     end
   end
-
-  context '#add_simple_scopes' do
-    let(:simple_scopes) { [:ascend_by_updated_at, :descend_by_name] }
-
-    before do
-      Spree::Product.add_simple_scopes(simple_scopes)
-    end
-
-    context 'define scope' do
-      context 'ascend_by_updated_at' do
-        context 'on class' do
-          it { expect(Spree::Product.ascend_by_updated_at.to_sql).to eq Spree::Product.order("#{Spree::Product.quoted_table_name}.updated_at ASC").to_sql }
-        end
-
-        context 'on ActiveRecord::Relation' do
-          it { expect(Spree::Product.limit(2).ascend_by_updated_at.to_sql).to eq Spree::Product.limit(2).order("#{Spree::Product.quoted_table_name}.updated_at ASC").to_sql }
-          it { expect(Spree::Product.limit(2).ascend_by_updated_at.to_sql).to eq Spree::Product.ascend_by_updated_at.limit(2).to_sql }
-        end
-      end
-
-      context 'descend_by_name' do
-        context 'on class' do
-          it { expect(Spree::Product.descend_by_name.to_sql).to eq Spree::Product.order("#{Spree::Product.quoted_table_name}.name DESC").to_sql }
-        end
-
-        context 'on ActiveRecord::Relation' do
-          it { expect(Spree::Product.limit(2).descend_by_name.to_sql).to eq Spree::Product.limit(2).order("#{Spree::Product.quoted_table_name}.name DESC").to_sql }
-          it { expect(Spree::Product.limit(2).descend_by_name.to_sql).to eq Spree::Product.descend_by_name.limit(2).to_sql }
-        end
-      end
-    end
-  end
 end

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -175,20 +175,6 @@ describe Spree::Product, :type => :model do
       end
     end
 
-    describe 'Variants sorting' do
-      context 'without master variant' do
-        it 'sorts variants by position' do
-          expect(product.variants.to_sql).to match(/ORDER BY (\`|\")spree_variants(\`|\").position ASC/)
-        end
-      end
-
-      context 'with master variant' do
-        it 'sorts variants by position' do
-          expect(product.variants_including_master.to_sql).to match(/ORDER BY (\`|\")spree_variants(\`|\").position ASC/)
-        end
-      end
-    end
-
     context "has stock movements" do
       let(:product) { create(:product) }
       let(:variant) { product.master }


### PR DESCRIPTION
There are some issues that some users can encounter to to a lack of
specific naming due to SQL errors on ordering. If the scope has
something like `.order('name')` it may cause a SQL error when we join
with another table that also has a name column.

As part of this, I got rid of a couple of generally terrible tests which
rely VERY heavily on their specific implementation.