### PR TITLE
Remove a duplicated method.

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -621,10 +621,6 @@ module Spree
       super
     end
 
-    def tax_total
-      included_tax_total + additional_tax_total
-    end
-
     def quantity
       line_items.sum(:quantity)
     end


### PR DESCRIPTION
This method is defined twice. This is likely the result of a messed up
merge.
