### PR TITLE
WIP: Add Spree::Fixtures with a stock location and a zone

### DIFF
--- a/api/spec/support/database_cleaner.rb
+++ b/api/spec/support/database_cleaner.rb
@@ -2,6 +2,9 @@ RSpec.configure do |config|
   config.before(:suite) do
     DatabaseCleaner.strategy = :transaction
     DatabaseCleaner.clean_with(:truncation)
+    # create the default stock location outside of the spec transactions but
+    # after truncation so that it's preserved between specs.
+    Spree::Fixtures.instance.stock_locations.default
   end
 
   config.before(:each) do

--- a/core/lib/spree/testing_support/factories.rb
+++ b/core/lib/spree/testing_support/factories.rb
@@ -1,14 +1,10 @@
 require 'factory_girl'
 
-Spree::Zone.class_eval do
-  def self.global
-    find_by(name: 'GlobalZone') || FactoryGirl.create(:global_zone)
-  end
-end
-
 Dir["#{File.dirname(__FILE__)}/factories/**"].each do |f|
   require File.expand_path(f)
 end
+
+require_relative "fixtures"
 
 FactoryGirl.define do
   sequence(:random_string)      { Faker::Lorem.sentence }

--- a/core/lib/spree/testing_support/factories/carton_factory.rb
+++ b/core/lib/spree/testing_support/factories/carton_factory.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :carton, class: Spree::Carton do
     address
-    stock_location
+    stock_location { Spree::Fixtures.instance.stock_locations.default }
     shipping_method
     shipped_at { Time.now }
     inventory_units do

--- a/core/lib/spree/testing_support/factories/customer_return_factory.rb
+++ b/core/lib/spree/testing_support/factories/customer_return_factory.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
 
   factory :customer_return, class: Spree::CustomerReturn do
-    association(:stock_location, factory: :stock_location)
+    stock_location { Spree::Fixtures.instance.stock_locations.default }
 
     transient do
       line_items_count 1
@@ -25,7 +25,7 @@ FactoryGirl.define do
 
   # for the case when you want to supply existing return items instead of generating some
   factory :customer_return_without_return_items, class: Spree::CustomerReturn do
-    association(:stock_location, factory: :stock_location)
+    stock_location { Spree::Fixtures.instance.stock_locations.default }
   end
 
 end

--- a/core/lib/spree/testing_support/factories/return_authorization_factory.rb
+++ b/core/lib/spree/testing_support/factories/return_authorization_factory.rb
@@ -1,14 +1,14 @@
 FactoryGirl.define do
   factory :return_authorization, class: Spree::ReturnAuthorization do
     association(:order, factory: :shipped_order)
-    association(:stock_location, factory: :stock_location)
+    stock_location { Spree::Fixtures.instance.stock_locations.default }
     association(:reason, factory: :return_authorization_reason)
     memo 'Items were broken'
   end
 
   factory :new_return_authorization, class: Spree::ReturnAuthorization do
     association(:order, factory: :shipped_order)
-    association(:stock_location, factory: :stock_location)
+    stock_location { Spree::Fixtures.instance.stock_locations.default }
     association(:reason, factory: :return_authorization_reason)
   end
 

--- a/core/lib/spree/testing_support/factories/shipment_factory.rb
+++ b/core/lib/spree/testing_support/factories/shipment_factory.rb
@@ -4,7 +4,7 @@ FactoryGirl.define do
     cost 100.00
     state 'pending'
     order
-    stock_location
+    stock_location { Spree::Fixtures.instance.stock_locations.default }
 
     transient do
       shipping_method nil

--- a/core/lib/spree/testing_support/factories/shipping_method_factory.rb
+++ b/core/lib/spree/testing_support/factories/shipping_method_factory.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :base_shipping_method, class: Spree::ShippingMethod do
-    zones { |a| [Spree::Zone.global] }
+    zones { |a| [Spree::Fixtures.instance.zones.global] }
     name 'UPS Ground'
     code 'UPS_GROUND'
 

--- a/core/lib/spree/testing_support/factories/stock_item_factory.rb
+++ b/core/lib/spree/testing_support/factories/stock_item_factory.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :stock_item, class: Spree::StockItem do
     backorderable true
-    stock_location
+    stock_location { Spree::Fixtures.instance.stock_locations.default }
     variant
 
     after(:create) { |object| object.adjust_count_on_hand(10) }

--- a/core/lib/spree/testing_support/factories/variant_factory.rb
+++ b/core/lib/spree/testing_support/factories/variant_factory.rb
@@ -15,8 +15,9 @@ FactoryGirl.define do
     product { |p| p.association(:base_product) }
     option_values { [create(:option_value)] }
 
-    # ensure stock item will be created for this variant
-    before(:create) { create(:stock_location) if Spree::StockLocation.count == 0 }
+    # ensure there is a stock location so that a stock item will be created for
+    # this variant
+    before(:create) { Spree::Fixtures.instance.stock_locations.default }
 
     factory :variant do
       # on_hand 5

--- a/core/lib/spree/testing_support/factories/zone_factory.rb
+++ b/core/lib/spree/testing_support/factories/zone_factory.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :global_zone, class: Spree::Zone do
-    name 'GlobalZone'
+    name 'global'
     description { generate(:random_string) }
     zone_members do |proxy|
       zone = proxy.instance_eval { @instance }

--- a/core/lib/spree/testing_support/fixtures.rb
+++ b/core/lib/spree/testing_support/fixtures.rb
@@ -1,0 +1,52 @@
+require 'factory_girl'
+
+class Spree::Fixtures
+  # Share a comman instance of the fixture set
+  def self.instance
+    @instance ||= new
+  end
+
+  # Clear out references to existing fixtures.
+  # Note: This does not destroy the records from the database. It assumes you
+  # have already reset the database yourself.
+  def self.reset
+    @instance = new
+  end
+
+  # stock location fixtures
+  def stock_locations
+    @stock_locations ||= StockLocations.new
+  end
+
+  # zone fixtures
+  def zones
+    @zones ||= Zones.new
+  end
+
+  module RSpecShortcut
+    # shortcut syntax for specs: `fixtures.stock_locations.default`
+    def fixtures
+      Spree::Fixtures.instance
+    end
+  end
+
+  private
+
+  class StockLocations
+    def default
+      @default ||= Spree::StockLocation.find_by(code: 'default')
+      @default ||= FactoryGirl.create(:stock_location, code: 'default')
+    end
+  end
+
+  class Zones
+    def global
+      @global ||= Spree::Zone.find_by(name: 'global')
+      @global ||= FactoryGirl.create(:global_zone, name: 'global')
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include Spree::Fixtures::RSpecShortcut
+end

--- a/core/lib/spree/testing_support/fixtures.rb
+++ b/core/lib/spree/testing_support/fixtures.rb
@@ -49,4 +49,8 @@ end
 
 RSpec.configure do |config|
   config.include Spree::Fixtures::RSpecShortcut
+
+  config.before(:each) do
+    Spree::Fixtures.reset
+  end
 end

--- a/core/lib/spree/testing_support/fixtures.rb
+++ b/core/lib/spree/testing_support/fixtures.rb
@@ -1,7 +1,7 @@
 require 'factory_girl'
 
 class Spree::Fixtures
-  # Share a comman instance of the fixture set
+  # Share a common instance of the fixture set
   def self.instance
     @instance ||= new
   end

--- a/core/lib/spree/testing_support/order_walkthrough.rb
+++ b/core/lib/spree/testing_support/order_walkthrough.rb
@@ -46,8 +46,8 @@ class OrderWalkthrough
   end
 
   def self.address(order)
-    order.bill_address = FactoryGirl.create(:address, :country_id => Spree::Zone.global.members.first.zoneable.id)
-    order.ship_address = FactoryGirl.create(:address, :country_id => Spree::Zone.global.members.first.zoneable.id)
+    order.bill_address = FactoryGirl.create(:address, :country_id => Spree::Fixtures.instance.zones.global.members.first.zoneable.id)
+    order.ship_address = FactoryGirl.create(:address, :country_id => Spree::Fixtures.instance.zones.global.members.first.zoneable.id)
     order.next!
   end
 

--- a/core/spec/spec_helper.rb
+++ b/core/spec/spec_helper.rb
@@ -50,6 +50,9 @@ RSpec.configure do |config|
 
   config.before :suite do
     DatabaseCleaner.clean_with :truncation
+    # create the default stock location outside of the spec transactions but
+    # after truncation so that it's preserved between specs.
+    Spree::Fixtures.instance.stock_locations.default
   end
 
   config.before :each do

--- a/frontend/spec/spec_helper.rb
+++ b/frontend/spec/spec_helper.rb
@@ -73,6 +73,13 @@ RSpec.configure do |config|
     end
   end
 
+  config.before(:suite) do
+    # create the default stock location outside of the spec transactions but
+    # after truncation so that it's preserved between specs.
+    # it will still get wiped out for the :js specs that use truncation.
+    Spree::Fixtures.instance.stock_locations.default
+  end
+
   config.before(:each) do
     Rails.cache.clear
     reset_spree_preferences


### PR DESCRIPTION
WIP attempt at adding a way to provide a default stock location for specs.

cc @cbrunsdon @jhawthorn 

Provide a default stock location in factories.  Accessible via:

    Spree::Fixtures.instance.stock_locations.default

because creating lots of stock locations makes things quite slow.

Also provide a shortcut syntax `fixtures.stock_locations.default` for the specs.

Provide the same thing for Zones, which previously had a different solution for
this.

This isn't actually using "fixtures" yet -- they are created on demand.  In a follow-up commit we could tackle actually fixture-izing these.

