### PR TITLE
Remove nonsensical eager load

### DIFF
--- a/core/app/models/spree/stock/inventory_unit_builder.rb
+++ b/core/app/models/spree/stock/inventory_unit_builder.rb
@@ -8,15 +8,7 @@ module Spree
       def units
         @order.line_items.flat_map do |line_item|
           line_item.quantity.times.map do |i|
-            @order.inventory_units.includes(
-              variant: {
-                product: {
-                  shipping_category: {
-                    shipping_methods: [:calculator, { zones: :zone_members }]
-                  }
-                }
-              }
-            ).build(
+            @order.inventory_units.build(
               pending: true,
               variant: line_item.variant,
               line_item: line_item,


### PR DESCRIPTION
includes have no effect on a .build, so this was doing nothing.

This partially reverts commit a7b3874013266b5804721f81cef83a6f1a1c42a6.
