### PR TITLE
Don't refresh shipping rates after an order is completed.

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -196,7 +196,7 @@ module Spree
     end
 
     def refresh_rates
-      return shipping_rates if shipped?
+      return shipping_rates if shipped? || order.completed?
       return [] unless can_get_rates?
 
       # StockEstimator.new assigment below will replace the current shipping_method


### PR DESCRIPTION
It seems odd that this would happen, since we would want the total
dollar amount to be set in stone by the time the order gets completed.
# 

I'm amazed that it hasn't caused any issues yet, but I'm seeing it cause
specs on [other in-flight code](https://github.com/athal7/solidus/pull/3) to fail, and wanted to get eyes on this separately
rather than looping it into the other work.
