### PR TITLE
Revert "Don't refresh shipping rates after an order is completed."

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -196,7 +196,7 @@ module Spree
     end
 
     def refresh_rates
-      return shipping_rates if shipped? || order.completed?
+      return shipping_rates if shipped?
       return [] unless can_get_rates?
 
       # StockEstimator.new assigment below will replace the current shipping_method


### PR DESCRIPTION
This reverts commit a05a9090c1979badf9530214718dc8fc1e5144d0.

Unfortunately I missed the chance to chime in on this one.  Out of all the code in Solidus, I am least familiar with the shipping side of things, but I'm not sure if this is exactly what we want for solidus as a whole.

There are currently stores that split shipments after an order is complete. One scenario where this can happen is when inventory is drop shipped and shipped separately from different manufacturers. Shipments are split after completion which may or may not incur additional shipping charges that the merchant can choose to adjust down to the original payment.

Another situation can happen when a customer calls in and asks the merchant to short ship half of their order, instead of waiting for complete fulfilment if the shipment is waiting on back ordered stock. The customer may opt to pay additional shipping fees in this situation.

cc @athal7 @gmacdougall @adammathys 
