### PR TITLE
Fix payment cancellation for pending store credits

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -766,7 +766,7 @@ module Spree
     def after_cancel
       shipments.each { |shipment| shipment.cancel! }
       payments.completed.each { |payment| payment.cancel! }
-      payments.store_credits.pending.each { |payment| payment.void! }
+      payments.store_credits.pending.each { |payment| payment.void_transaction! }
 
       send_cancel_email
       self.update!


### PR DESCRIPTION
This fixes store credit payment cancellation when auto-capture is
turned off.

When auto-capture is turned off an order can be canceled with its
store credit payments "authorized" but not "captured". The old code
was marking the payments as voided but not actually voiding them
and releasing the authorization.
