### PR TITLE
Check pending payments when validating amounts

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -678,7 +678,7 @@ module Spree
         other_payments.first.update_attributes!(amount: remaining_total)
       end
 
-      if payments.checkout.sum(:amount) != total
+      if pending_payments.sum(:amount) != total
         errors.add(:base, Spree.t("store_credit.errors.unable_to_fund")) and return false
       end
     end


### PR DESCRIPTION
If someone voids a payment, this is used in the calculations, and does not work.
