### PR TITLE
Add null: true to store credit model timestamps

### DIFF
--- a/core/db/migrate/20150506181159_create_spree_store_credit_categories.rb
+++ b/core/db/migrate/20150506181159_create_spree_store_credit_categories.rb
@@ -2,7 +2,7 @@ class CreateSpreeStoreCreditCategories < ActiveRecord::Migration
   def change
     create_table :spree_store_credit_categories do |t|
       t.string :name
-      t.timestamps
+      t.timestamps null: true
     end
 
     Spree::StoreCreditCategory.find_or_create_by!(name: Spree.t("store_credit_category.default"))

--- a/core/db/migrate/20150506181244_create_spree_store_credits.rb
+++ b/core/db/migrate/20150506181244_create_spree_store_credits.rb
@@ -10,7 +10,7 @@ class CreateSpreeStoreCredits < ActiveRecord::Migration
       t.string :currency
       t.text :memo
       t.datetime :spree_store_credits, :deleted_at
-      t.timestamps
+      t.timestamps null: true
     end
 
     add_index :spree_store_credits, :deleted_at

--- a/core/db/migrate/20150506181539_create_spree_store_credit_events.rb
+++ b/core/db/migrate/20150506181539_create_spree_store_credit_events.rb
@@ -8,7 +8,7 @@ class CreateSpreeStoreCreditEvents < ActiveRecord::Migration
       t.string  :authorization_code, null: false
       t.datetime :deleted_at
       t.references :originator, polymorphic: true
-      t.timestamps
+      t.timestamps null: true
     end
 
     add_index :spree_store_credit_events, :store_credit_id

--- a/core/db/migrate/20150506181715_create_store_credit_types.rb
+++ b/core/db/migrate/20150506181715_create_store_credit_types.rb
@@ -3,7 +3,7 @@ class CreateStoreCreditTypes < ActiveRecord::Migration
     create_table :spree_store_credit_types do |t|
       t.string :name
       t.integer :priority
-      t.timestamps
+      t.timestamps null: true
     end
 
     add_column :spree_store_credits, :type_id, :integer


### PR DESCRIPTION
This fixes warnings when running migrations since rails 4.2.

This was added to the rest of models in the 4.2 upgrade, this commit was made in parallel to that.
