### PR TITLE
Drop version requirement on jquery-rails

### DIFF
--- a/backend/solidus_backend.gemspec
+++ b/backend/solidus_backend.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'solidus_api', version
   s.add_dependency 'solidus_core', version
 
-  s.add_dependency 'jquery-rails', '~> 3.1.2'
+  s.add_dependency 'jquery-rails'
   s.add_dependency 'jquery-ui-rails', '~> 5.0.0'
   s.add_dependency 'select2-rails',   '3.5.9.1' # 3.5.9.2 breaks forms
 end

--- a/frontend/solidus_frontend.gemspec
+++ b/frontend/solidus_frontend.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'solidus_core', version
 
   s.add_dependency 'canonical-rails', '~> 0.0.4'
-  s.add_dependency 'jquery-rails', '~> 3.1.2'
+  s.add_dependency 'jquery-rails'
 
   s.add_development_dependency 'capybara-accessible'
 end


### PR DESCRIPTION
rails installs with no explicit requirement on the version of jquery
rails. Everything should work with any modern verson of jquery-rails.

This makes the experience of creating a new solidus app better as the
Gemfile.lock from a fresh rails install won't conflict with our
requirements.

The version requirement was added originally to avoid an issue in
jquery-rails 3.0.1 specifically (double alert confirmation message).
