### PR TITLE
Fix spec failure from DB order issue in postgres

### DIFF
--- a/core/spec/models/spree/order_shipping_spec.rb
+++ b/core/spec/models/spree/order_shipping_spec.rb
@@ -161,8 +161,9 @@ describe Spree::OrderShipping do
 
     context "when the shipment has been partially shipped previously" do
       let(:order) { create(:order_ready_to_ship, line_items_count: 2) }
-      let(:shipped_inventory) { [shipment.inventory_units.first] }
-      let(:unshipped_inventory) { [shipment.inventory_units.last] }
+      let(:inventory_units) { shipment.inventory_units.to_a }
+      let(:shipped_inventory) { [inventory_units.first] }
+      let(:unshipped_inventory) { [inventory_units.last] }
 
       before do
         order.shipping.ship(


### PR DESCRIPTION
`inventory_units.to_a` isn't necessarily the same order as `[inventory_units.first, inventory_units.last]`

Since there is no explicit order on the association (and no need for one), it is valid to return them in any order. First and last in rails add an `ORDER BY id ASC` if there is not an existing order.
