### PR TITLE
Fix a skipped test

### DIFF
--- a/frontend/spec/features/address_spec.rb
+++ b/frontend/spec/features/address_spec.rb
@@ -40,6 +40,10 @@ describe "Address", type: :feature, inaccessible: true do
         expect(find(@state_name_css)['class']).not_to match(/hidden/)
         expect(find(@state_name_css)['class']).to match(/required/)
         expect(find(@state_select_css)['class']).not_to match(/required/)
+
+        expect(page).to have_no_css("#{@state_name_css}.hidden")
+        expect(page).to have_css("#{@state_name_css}.required")
+        expect(page).to have_no_css("#{@state_select_css}.required")
         expect(page).not_to have_selector("input#{@state_name_css}[disabled]")
       end
     end
@@ -53,9 +57,9 @@ describe "Address", type: :feature, inaccessible: true do
         select canada.name, :from => @country_css
         expect(page).to have_selector(@state_select_css, visible: true)
         expect(page).to have_selector(@state_name_css, visible: false)
-        expect(find(@state_select_css)['class']).to match(/required/)
-        expect(find(@state_select_css)['class']).not_to match(/hidden/)
-        expect(find(@state_name_css)['class']).not_to match(/required/)
+        expect(page).to have_css("#{@state_select_css}.required")
+        expect(page).to have_no_css("#{@state_select_css}.hidden")
+        expect(page).to have_no_css("#{@state_name_css}.required")
       end
     end
 
@@ -63,18 +67,16 @@ describe "Address", type: :feature, inaccessible: true do
       let!(:france) { create(:country, :name => "France", :states_required => false, :iso => "FRA") }
 
       it "clears the state name" do
-        skip "This is failing on the CI server, but not when you run the tests manually... It also does not fail locally on a machine."
         click_button "Checkout"
         select canada.name, :from => @country_css
         page.find(@state_name_css).set("Toscana")
 
         select france.name, :from => @country_css
         expect(page.find(@state_name_css)).to have_content('')
-        until page.evaluate_script("$.active").to_i == 0
-          expect(find(@state_name_css)['class']).not_to match(/hidden/)
-          expect(find(@state_name_css)['class']).not_to match(/required/)
-          expect(find(@state_select_css)['class']).not_to match(/required/)
-        end
+
+        expect(page).to have_no_css("#{@state_name_css}.hidden")
+        expect(page).to have_no_css("#{@state_name_css}.required")
+        expect(page).to have_no_css("#{@state_select_css}.required")
       end
     end
   end


### PR DESCRIPTION
Switch to using more reliable capybara assertions, which probably fixes the issue causing this spec to have been skipped in the first place.
