### PR TITLE
Add 'frontend_viewable' to spree_orders.

### DIFF
--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -164,8 +164,15 @@ module Spree
 
       private
         def order_params
-          params[:created_by_id] = try_spree_current_user.try(:id)
-          params.permit(:created_by_id)
+          params.merge!(extra_order_params)
+          params.permit(extra_order_params.keys)
+        end
+
+        def extra_order_params
+          {
+            created_by_id: try_spree_current_user.try(:id),
+            frontend_viewable: false
+          }
         end
 
         def load_order

--- a/backend/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -84,7 +84,14 @@ describe Spree::Admin::OrdersController, :type => :controller do
 
       it "imports a new order and sets the current user as a creator" do
         Spree::Core::Importer::Order.should_receive(:import)
-          .with(nil, {'created_by_id' => controller.try_spree_current_user.id})
+          .with(nil, hash_including(created_by_id: controller.try_spree_current_user.id))
+          .and_return(order)
+        spree_get :new
+      end
+
+      it "sets frontend_viewable to false" do
+        Spree::Core::Importer::Order.should_receive(:import)
+          .with(nil, hash_including(frontend_viewable: false ))
           .and_return(order)
         spree_get :new
       end
@@ -95,7 +102,7 @@ describe Spree::Admin::OrdersController, :type => :controller do
 
         it "imports a new order and assigns the user to the order" do
           Spree::Core::Importer::Order.should_receive(:import)
-            .with(user, {'created_by_id' => controller.try_spree_current_user.id})
+            .with(user, hash_including(created_by_id: controller.try_spree_current_user.id))
             .and_return(order)
           spree_get :new, { user_id: user.id }
         end

--- a/core/config/initializers/user_class_extensions.rb
+++ b/core/config/initializers/user_class_extensions.rb
@@ -26,8 +26,9 @@ Spree::Core::Engine.config.to_prepare do
 
       # @return [Spree::Order] the most-recently-created incomplete order
       # since the customer's last complete order.
-      def last_incomplete_spree_order(store: nil)
+      def last_incomplete_spree_order(store: nil, only_frontend_viewable: true)
         self_orders = self.orders
+        self_orders = self_orders.where(frontend_viewable: true) if only_frontend_viewable
         self_orders = self_orders.where(store: store) if store
         last_order = self_orders.order(:created_at).last
         last_order unless last_order.try!(:completed?)

--- a/core/db/migrate/20150611200247_add_frontend_viewable_to_spree_orders.rb
+++ b/core/db/migrate/20150611200247_add_frontend_viewable_to_spree_orders.rb
@@ -1,0 +1,5 @@
+class AddFrontendViewableToSpreeOrders < ActiveRecord::Migration
+  def change
+    add_column :spree_orders, :frontend_viewable, :boolean, default: true, null: false
+  end
+end

--- a/core/lib/spree/core/unreturned_item_charger.rb
+++ b/core/lib/spree/core/unreturned_item_charger.rb
@@ -91,7 +91,8 @@ module Spree
       order_attributes = {
         bill_address: @original_order.bill_address,
         ship_address: @original_order.ship_address,
-        email: @original_order.email
+        email: @original_order.email,
+        frontend_viewable: false
       }
       order_attributes[:store_id] = @original_order.store_id if @original_order.respond_to?(:store_id)
       order_attributes

--- a/core/spec/lib/tasks/exchanges_spec.rb
+++ b/core/spec/lib/tasks/exchanges_spec.rb
@@ -69,6 +69,11 @@ describe "exchanges:charge_unreturned_items" do
         expect(Spree::Order.last).to be_completed
       end
 
+      it "sets frontend_viewable to false" do
+        subject.invoke
+        expect(Spree::Order.last).not_to be_frontend_viewable
+      end
+
       it "moves the shipment for the unreturned items to the new order" do
         subject.invoke
         new_order = Spree::Order.last

--- a/core/spec/models/spree/user_spec.rb
+++ b/core/spec/models/spree/user_spec.rb
@@ -4,6 +4,17 @@ describe Spree::LegacyUser, :type => :model do
   context "#last_incomplete_order" do
     let!(:user) { create(:user) }
 
+
+    it "excludes orders that are not frontend_viewable" do
+      order = create(:order, user: user, frontend_viewable: false)
+      expect(user.last_incomplete_spree_order).to eq nil
+    end
+
+    it "can include orders that are not frontend viewable" do
+      order = create(:order, user: user, frontend_viewable: false)
+      expect(user.last_incomplete_spree_order(only_frontend_viewable: false)).to eq order
+    end
+
     it "can scope to a store" do
       store = create(:store)
       store_1_order = create(:order, user: user, store: store)


### PR DESCRIPTION
There are times when having an order be available as the customer's cart can create issues. A few of these include:
1) An admin-created order can create confusion if it shows up in the customer's cart
2) An unreturned exchange order that has failed to complete (e.g. payment processor issue), if it becomes the customer's cart, will create all sorts of issues / confusion for the customer and potential data loss if shipments are trying to be rebuilt.

This change makes these two types of orders not become the customer's cart.
