### PR TITLE
Add hack for specifying user class in association.

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -28,17 +28,10 @@ module Spree
     attr_reader :coupon_code
     attr_accessor :temporary_address, :temporary_credit_card
 
-    if Spree.user_class
-      belongs_to :user, class_name: Spree.user_class.to_s
-      belongs_to :created_by, class_name: Spree.user_class.to_s
-      belongs_to :approver, class_name: Spree.user_class.to_s
-      belongs_to :canceler, class_name: Spree.user_class.to_s
-    else
-      belongs_to :user
-      belongs_to :created_by
-      belongs_to :approver
-      belongs_to :canceler
-    end
+    belongs_to :user, class_name: Spree::UserClassHandle.new
+    belongs_to :created_by, class_name: Spree::UserClassHandle.new
+    belongs_to :approver, class_name: Spree::UserClassHandle.new
+    belongs_to :canceler, class_name: Spree::UserClassHandle.new
 
     belongs_to :bill_address, foreign_key: :bill_address_id, class_name: 'Spree::Address'
     alias_attribute :billing_address, :bill_address

--- a/core/app/models/spree/promotion/rules/user.rb
+++ b/core/app/models/spree/promotion/rules/user.rb
@@ -2,9 +2,9 @@ module Spree
   class Promotion
     module Rules
       class User < PromotionRule
-        belongs_to :user, class_name: "::#{Spree.user_class.to_s}"
+        belongs_to :user, class_name: Spree::UserClassHandle.new
 
-        has_and_belongs_to_many :users, class_name: "::#{Spree.user_class.to_s}",
+        has_and_belongs_to_many :users, class_name: Spree::UserClassHandle.new,
           join_table: 'spree_promotion_rules_users',
           foreign_key: 'promotion_rule_id',
           association_foreign_key: :user_id

--- a/core/app/models/spree/role_user.rb
+++ b/core/app/models/spree/role_user.rb
@@ -2,7 +2,7 @@ module Spree
   class RoleUser < ActiveRecord::Base
     self.table_name = "spree_roles_users"
     belongs_to :role, class_name: "Spree::Role"
-    belongs_to :user, class_name: Spree.user_class.to_s
+    belongs_to :user, class_name: Spree::UserClassHandle.new
 
     after_save :generate_admin_api_key
 

--- a/core/app/models/spree/store_credit.rb
+++ b/core/app/models/spree/store_credit.rb
@@ -10,8 +10,8 @@ class Spree::StoreCredit < ActiveRecord::Base
 
   DEFAULT_CREATED_BY_EMAIL = "spree@example.com"
 
-  belongs_to :user, class_name: Spree.user_class.to_s
-  belongs_to :created_by, class_name: Spree.user_class.to_s
+  belongs_to :user, class_name: Spree::UserClassHandle.new
+  belongs_to :created_by, class_name: Spree::UserClassHandle.new
   belongs_to :category, class_name: "Spree::StoreCreditCategory"
   belongs_to :credit_type, class_name: 'Spree::StoreCreditType', :foreign_key => 'type_id'
   has_many :store_credit_events

--- a/core/app/models/spree/user_class_handle.rb
+++ b/core/app/models/spree/user_class_handle.rb
@@ -1,7 +1,20 @@
 module Spree
+  # Placeholder for name of Spree.user_class to ensure later evaluation at
+  # runtime.
+  #
+  # Unfortunately, it is possible for classes to get loaded before
+  # Spree.user_class has been set in the initializer. As a result, they end up
+  # with class_name: "" in their association definitions. For obvious reasons,
+  # that doesn't work.
+  #
+  # For now, Rails does not call to_s on the instance passed in until runtime.
+  # So this little hack provides a wrapper around Spree.user_class so that we
+  # can basically lazy-evaluate it. Yay! Problem solved forever.
   class UserClassHandle
-    # Super hack to get around load order.
+    # @return [String] the name of the user class as a string.
+    # @raise [RuntimeError] if Spree.user_class is nil
     def to_s
+      fail "'Spree.user_class' has not been set yet." unless Spree.user_class
       Spree.user_class.to_s
     end
   end

--- a/core/app/models/spree/user_class_handle.rb
+++ b/core/app/models/spree/user_class_handle.rb
@@ -1,0 +1,8 @@
+module Spree
+  class UserClassHandle
+    # Super hack to get around load order.
+    def to_s
+      Spree.user_class.to_s
+    end
+  end
+end

--- a/core/app/models/spree/user_class_handle.rb
+++ b/core/app/models/spree/user_class_handle.rb
@@ -15,7 +15,7 @@ module Spree
     # @raise [RuntimeError] if Spree.user_class is nil
     def to_s
       fail "'Spree.user_class' has not been set yet." unless Spree.user_class
-      Spree.user_class.to_s
+      "::#{Spree.user_class}"
     end
   end
 end

--- a/core/app/models/spree/user_stock_location.rb
+++ b/core/app/models/spree/user_stock_location.rb
@@ -1,6 +1,6 @@
 module Spree
   class UserStockLocation < ActiveRecord::Base
-    belongs_to :user, class_name: Spree.user_class.to_s, inverse_of: :user_stock_locations
+    belongs_to :user, class_name: Spree::UserClassHandle.new, inverse_of: :user_stock_locations
     belongs_to :stock_location, class_name: "Spree::StockLocation", inverse_of: :user_stock_locations
   end
 end


### PR DESCRIPTION
Unfortunately, it is possible for classes to get loaded before `Spree.user_class` has been set in the initializer. As a result, they end up with `class_name: ""` in their association definitions. For obvious reasons, that don't work.

For now, Rails does not call `to_s` on the class passed in until runtime. So this little hack provides a wrapper around `Spree.user_class` so that we can basically lazy-evaluate it. Yay!  Problem solved *forever*.

Let it be known that @jhawthorn is mostly responsible for this monstrosity. I can only accept partial credit.