### PR TITLE
Fix migration checks inside extensions

### DIFF
--- a/core/lib/spree/migrations.rb
+++ b/core/lib/spree/migrations.rb
@@ -21,7 +21,7 @@ module Spree
     # Shouldn't run on test mode because migrations inside engine don't have
     # engine name on the file name
     def check
-      if File.directory?("db/migrate")
+      if File.directory?(app_dir)
         engine_in_app = app_migrations.map do |file_name|
           name, engine = file_name.split(".", 2)
           next unless match_engine?(engine)
@@ -42,18 +42,26 @@ module Spree
 
     private
       def engine_migrations
-        Dir.entries("#{config.root}/db/migrate").map do |file_name|
+        Dir.entries(engine_dir).map do |file_name|
           name = file_name.split("_", 2).last.split(".", 2).first
           name.empty? ? next : name
         end.compact! || []
       end
 
       def app_migrations
-        Dir.entries("db/migrate").map do |file_name|
+        Dir.entries(app_dir).map do |file_name|
           next if [".", ".."].include? file_name
           name = file_name.split("_", 2).last
           name.empty? ? next : name
         end.compact! || []
+      end
+
+      def app_dir
+        "#{Rails.root}/db/migrate"
+      end
+
+      def engine_dir
+        "#{config.root}/db/migrate"
       end
 
       def match_engine?(engine)

--- a/core/spec/lib/spree/migrations_spec.rb
+++ b/core/spec/lib/spree/migrations_spec.rb
@@ -7,15 +7,18 @@ module Spree
 
     let(:config) { double("Config", root: "dir") }
 
+    let(:engine_dir) { "dir/db/migrate" }
+    let(:app_dir) { "#{Rails.root}/db/migrate" }
+
     subject { described_class.new(config, "spree")  }
 
     before do
-      expect(File).to receive(:directory?).with("db/migrate").and_return true
+      expect(File).to receive(:directory?).with(app_dir).and_return true
     end
 
     it "warns about missing migrations" do
-      expect(Dir).to receive(:entries).with("db/migrate").and_return app_migrations
-      expect(Dir).to receive(:entries).with("dir/db/migrate").and_return engine_migrations
+      expect(Dir).to receive(:entries).with(app_dir).and_return app_migrations
+      expect(Dir).to receive(:entries).with(engine_dir).and_return engine_migrations
 
       silence_stream(STDOUT) {
         expect(subject.check).to eq true
@@ -24,8 +27,8 @@ module Spree
 
     context "no missing migrations" do
       it "says nothing" do
-        expect(Dir).to receive(:entries).with("dir/db/migrate").and_return engine_migrations
-        expect(Dir).to receive(:entries).with("db/migrate").and_return (app_migrations + engine_migrations)
+        expect(Dir).to receive(:entries).with(engine_dir).and_return engine_migrations
+        expect(Dir).to receive(:entries).with(app_dir).and_return (app_migrations + engine_migrations)
         expect(subject.check).to eq nil
       end
     end


### PR DESCRIPTION
Previous code checked "./db/migrate" for the app's migrations. If the
current directory wasn't the rails application root (as it wouldn't be
if the app was in spec/dummy).
