### PR TITLE
Update gems in common_spree_dependencies.rb

### DIFF
--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -15,8 +15,8 @@ platforms :jruby do
   gem 'activerecord-jdbcsqlite3-adapter'
 end
 
-gem 'coffee-rails', '~> 4.0.0'
-gem 'sass-rails', '~> 4.0.2'
+gem 'coffee-rails'
+gem 'sass-rails'
 
 group :test do
   gem 'capybara', '~> 2.4'
@@ -27,7 +27,7 @@ group :test do
   gem 'rspec-activemodel-mocks'
   gem 'rspec-collection_matchers'
   gem 'rspec-its'
-  gem 'rspec-rails', '~> 3.1.0'
+  gem 'rspec-rails', '~> 3.3.0'
   gem 'simplecov'
   gem 'webmock', '1.8.11'
   gem 'poltergeist'


### PR DESCRIPTION
We should expect to support any versions of sass-rails and coffee-rails which our gemspecs allow, so it is inappropriate to have a restriction on them for testing. This allows us to test with sprockets 3.x.

Also bump rspec-rails to 3.3.x