### PR TITLE
Improvements to Spree::Order::InsufficientStock handling in the api

### DIFF
--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -184,6 +184,10 @@ module Spree
         render text: e.message, status: 409
       end
 
+      def insufficient_stock_error(exception)
+        render json: { errors: [I18n.t(:quantity_is_not_available, :scope => "spree.api.order")], type: 'insufficient_stock' }, status: 422
+      end
+
     end
   end
 end

--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -185,7 +185,13 @@ module Spree
       end
 
       def insufficient_stock_error(exception)
-        render json: { errors: [I18n.t(:quantity_is_not_available, :scope => "spree.api.order")], type: 'insufficient_stock' }, status: 422
+        render(
+          json: {
+            errors: [I18n.t(:quantity_is_not_available, :scope => "spree.api.order")],
+            type: 'insufficient_stock',
+          },
+          status: 422,
+        )
       end
 
     end

--- a/api/app/controllers/spree/api/checkouts_controller.rb
+++ b/api/app/controllers/spree/api/checkouts_controller.rb
@@ -124,10 +124,6 @@ module Spree
           return true if expected_total.blank?
           @order.total == BigDecimal(expected_total)
         end
-
-        def insufficient_stock_error(exception)
-          render json: { errors: [I18n.t(:quantity_is_not_available, :scope => "spree.api.order")], type: 'insufficient_stock' }, status: 422
-        end
     end
   end
 end

--- a/api/app/controllers/spree/api/return_authorizations_controller.rb
+++ b/api/app/controllers/spree/api/return_authorizations_controller.rb
@@ -4,6 +4,8 @@ module Spree
       before_filter :load_order
       around_filter :lock_order, only: [:create, :update, :destroy, :add, :receive, :cancel]
 
+      rescue_from Spree::Order::InsufficientStock, with: :insufficient_stock_error
+
       def create
         authorize! :create, ReturnAuthorization
         @return_authorization = @order.return_authorizations.build(return_authorization_params)

--- a/api/spec/controllers/spree/api/checkouts_controller_spec.rb
+++ b/api/spec/controllers/spree/api/checkouts_controller_spec.rb
@@ -347,26 +347,6 @@ module Spree
           end
         end
       end
-
-      context 'insufficient stock' do
-        let(:order) { create(:order_with_line_items) }
-        before do
-          expect_any_instance_of(Spree::Order).to receive(:next!).and_raise(Spree::Order::InsufficientStock)
-        end
-
-        subject { api_put :next, :id => order.to_param, :order_token => order.guest_token }
-
-        it "should return a 422" do
-          expect(subject.status).to eq(422)
-        end
-
-        it "returns an error message" do
-          subject
-          expect(JSON.parse(response.body)).to eq(
-            {"errors" => ["Quantity is not available for items in your order"], "type" => "insufficient_stock"}
-          )
-        end
-      end
     end
 
     context "PUT 'advance'" do


### PR DESCRIPTION
This change moves the handling of the Spree::Order::InsufficientStock exception to the base controller so that we have a consistent response across all of the api controllers for this type of error.

* Move insufficient_stock_error method to BaseController
* Add rescue_from in the api return_authorization controller

Conflicts:
	api/app/controllers/spree/api/checkouts_controller.rb
	api/spec/controllers/spree/api/checkouts_controller_spec.rb