### PR TITLE
Assign order’s bill address when using a user’s default credit card

### DIFF
--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -307,7 +307,7 @@ module Spree
             if self.payments.from_credit_card.count == 0 && self.user && self.user.default_credit_card.try(:valid?)
               cc = self.user.default_credit_card
               self.payments.create!(payment_method_id: cc.payment_method_id, source: cc)
-              self.bill_address ||= self.user.bill_address.try(:clone) if self.user.bill_address.try(:valid?)
+              self.bill_address ||= self.user.bill_address.try!(:clone) if self.user.bill_address.try!(:valid?)
             end
           end
 

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -307,6 +307,7 @@ module Spree
             if self.payments.from_credit_card.count == 0 && self.user && self.user.default_credit_card.try(:valid?)
               cc = self.user.default_credit_card
               self.payments.create!(payment_method_id: cc.payment_method_id, source: cc)
+              self.bill_address ||= self.user.bill_address.try(:clone) if self.user.bill_address.try(:valid?)
             end
           end
 


### PR DESCRIPTION
This fixes an issue that can be replicated in the following way:

1 - As a non-registered user, add something to your cart
2 - Register and fill out checkout information until the address state is reached
3 - On a separate browser login as the registered user created in step 2
4 - Add something to your cart
5 - Complete checkout for order created in step 4
6 - Advance order (trigger an order.order_contents.advance) created in step 2
7 - Billing address is not defined for the original order

Since the first order is already in the address state and the ship/bill addresses are assigned in assign_default_addresses! before transitioning to the address state, the bill address never gets assigned. This change will either use the bill address that’s already assigned to the order (if present) or clone the user’s default billing address if present and valid when using the user’s default credit card as a form of payment.

Conflicts:
	core/spec/models/spree/order/checkout_spec.rb