### PR TITLE
More docs

### DIFF
--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -21,52 +21,202 @@ require "spree/core/search/variant"
 module Spree
   class AppConfiguration < Preferences::Configuration
     # Alphabetized to more easily lookup particular preferences
-    preference :address_requires_state, :boolean, default: true # should state/state_name be required
+
+    # @!attribute [rw] address_requires_state
+    #   @return [Boolean] should state/state_name be required
+    preference :address_requires_state, :boolean, default: true
+
+    # @!attribute [rw] admin_interface_logo
+    #   @return [String] URL of logo used in admin (default: +'logo/solidus_logo.png'+)
     preference :admin_interface_logo, :string, default: 'logo/solidus_logo.png'
+
+    # @!attribute [rw] admin_products_per_page
+    #   @return [Integer] Number of products to display in admin (default: +10+)
     preference :admin_products_per_page, :integer, default: 10
+
+    # @!attribute [rw] admin_variants_per_page
+    #   @return [Integer] Number of variants to display in admin (default: +20+)
     preference :admin_variants_per_page, :integer, default: 20
+
+    # @!attribute [rw] allow_checkout_on_gateway_error
+    #   @return [Boolean] Allow checkout to complete after a failed payment (default: +false+)
     preference :allow_checkout_on_gateway_error, :boolean, default: false
+
+    # @!attribute [rw] allow_guest_checkout
+    #   @return [Boolean] When false, customers must create an account to complete an order (default: +true+)
     preference :allow_guest_checkout, :boolean, default: true
-    preference :allow_return_item_amount_editing, :boolean, default: false # Determines whether an admin is allowed to change a return item's pre-calculated amount
-    preference :alternative_billing_phone, :boolean, default: false # Request extra phone for bill addr
-    preference :alternative_shipping_phone, :boolean, default: false # Request extra phone for ship addr
+
+    # @!attribute [rw] allow_return_item_amount_editing
+    #   @return [Boolean] Determines whether an admin is allowed to change a return item's pre-calculated amount (default: +false+)
+    preference :allow_return_item_amount_editing, :boolean, default: false
+
+    # @!attribute [rw] alternative_billing_phone
+    #   @return [Boolean] Request an extra phone number for bill address (default: +false+)
+    preference :alternative_billing_phone, :boolean, default: false
+
+    # @!attribute [rw] alternative_shipping_phone
+    #   @return [Boolean] Request an extra phone number for shipping address (default: +false+)
+    preference :alternative_shipping_phone, :boolean, default: false
+
+    # @!attribute [rw] always_put_site_name_in_title
+    #   @return [Boolean] When true, site name is always appended to titles on the frontend (default: +true+)
     preference :always_put_site_name_in_title, :boolean, default: true
-    preference :auto_capture, :boolean, default: false # automatically capture the credit card (as opposed to just authorize and capture later)
-    preference :auto_capture_exchanges, :boolean, default: false # automatically capture the credit card (as opposed to just authorize and capture later)
-    preference :binary_inventory_cache, :boolean, default: false # only invalidate product cache when a stock item changes whether it is in_stock
-    preference :checkout_zone, :string, default: nil # replace with the name of a zone if you would like to limit the countries
-    preference :company, :boolean, default: false # Request company field for billing and shipping addr
-    preference :create_rma_for_unreturned_exchange, :boolean, default: false # allows rma to be created for items after unreturned exchange charge has been made
+
+    # @!attribute [rw] auto_capture
+    #   @note Setting this to true is not recommended. Performing an authorize
+    #     and later capture has far superior error handing. VISA and MasterCard
+    #     also require that shipments are sent within a certain time of the card
+    #     being charged.
+    #   @return [Boolean] Perform a sale/purchase transaction at checkout instead of a authorize and capture.
+    preference :auto_capture, :boolean, default: false
+
+    # @!attribute [rw] auto_capture_exchanges
+    # @return [Boolean] automatically capture the credit card (as opposed to just authorize and capture later) (default: +false+)
+    preference :auto_capture_exchanges, :boolean, default: false
+
+    # @!attribute [rw] binary_inventory_cache
+    #   Only invalidate product caches when they change from in stock to out of
+    #   stock. By default, caches are invalidated on any change of inventory
+    #   quantity. Setting this to true should make operations on inventory
+    #   faster.
+    #   (default: +false+)
+    #   @return [Boolean]
+    preference :binary_inventory_cache, :boolean, default: false
+
+    # @!attribute [rw] checkout_zone
+    #   @return [String] Name of a {Zone}, which limits available countries to those included in that zone. (default: +nil+)
+    preference :checkout_zone, :string, default: nil
+
+    # @!attribute [rw] company
+    #   @return [Boolean] Request company field for billing and shipping addresses. (default: +false+)
+    preference :company, :boolean, default: false
+
+    # @!attribute [rw] create_rma_for_unreturned_exchange
+    #   @return [Boolean] allows rma to be created for items after unreturned exchange charge has been made (default: +false+)
+    preference :create_rma_for_unreturned_exchange, :boolean, default: false
+
+    # @!attribute [rw] currency
+    #   Currency to use by default when not defined on the site (default: +"USD"+)
+    #   @return [String] ISO 4217 Three letter currency code
     preference :currency, :string, default: "USD"
+
+    # @!attribute [rw] default_country_id
+    #   @deprecated
+    #   @return [Integer,nil] id of {Country} to be selected by default in dropdowns (default: nil)
     preference :default_country_id, :integer
-    preference :expedited_exchanges, :boolean, default: false # NOTE this requires payment profiles to be supported on your gateway of choice as well as a delayed job handler to be configured with activejob. kicks off an exchange shipment upon return authorization save. charge customer if they do not return items within timely manner.
-    preference :expedited_exchanges_days_window, :integer, default: 14 # the amount of days the customer has to return their item after the expedited exchange is shipped in order to avoid being charged
+
+    # @!attribute [rw] expedited_exchanges
+    #   Kicks off an exchange shipment upon return authorization save.
+    #   charge customer if they do not return items within timely manner.
+    #   @note this requires payment profiles to be supported on your gateway of
+    #     choice as well as a delayed job handler to be configured with
+    #     activejob.
+    #   @return [Boolean] Use expidited exchanges (default: +false+)
+    preference :expedited_exchanges, :boolean, default: false
+
+    # @!attribute [rw] expedited_exchanges_days_window
+    #   @return [Integer] Number of days the customer has to return their item
+    #     after the expedited exchange is shipped in order to avoid being
+    #     charged (default: +14+)
+    preference :expedited_exchanges_days_window, :integer, default: 14
+
+    # @!attribute [rw] layout
+    #   @return [String] template to use for layout on the frontend (default: +"spree/layouts/spree_application"+)
     preference :layout, :string, default: 'spree/layouts/spree_application'
+
+    # @!attribute [rw] logo
+    #   @return [String] URL of logo used on frontend (default: +'logo/solidus_logo.png'+)
     preference :logo, :string, default: 'logo/solidus_logo.png'
-    preference :max_level_in_taxons_menu, :integer, default: 1 # maximum nesting level in taxons menu
-    preference :order_capturing_time_window, :integer, default: 14 # the number of days to look back for fully-shipped/cancelled orders in order to charge for them
+
+    # @!attribute [rw] order_capturing_time_window
+    #   @return [Integer] the number of days to look back for fully-shipped/cancelled orders in order to charge for them
+    preference :order_capturing_time_window, :integer, default: 14
+
+    # @!attribute [rw] max_level_in_taxons_menu
+    #   @return [Integer] maximum nesting level in taxons menu (default: +1+)
+    preference :max_level_in_taxons_menu, :integer, default: 1
+
+    # @!attribute [rw] order_mutex_max_age
+    #   @return [Integer] Max age of {OrderMutex} in seconds (default: 2 minutes)
     preference :order_mutex_max_age, :integer, default: 2.minutes
+
+    # @!attribute [rw] orders_per_page
+    #   @return [Integer] Orders to show per-page in the admin (default: +15+)
     preference :orders_per_page, :integer, default: 15
+
+    # @!attribute [rw] properties_per_page
+    #   @return [Integer] Properties to show per-page in the admin (default: +15+)
     preference :properties_per_page, :integer, default: 15
+
+    # @!attribute [rw] products_per_page
+    #   @return [Integer] Products to show per-page in the frontend (default: +12+)
     preference :products_per_page, :integer, default: 12
+
+    # @!attribute [rw] promotions_per_page
+    #   @return [Integer] Promotions to show per-page in the admin (default: +15+)
     preference :promotions_per_page, :integer, default: 15
+
+    # @!attribute [rw] customer_returns_per_page
+    #   @return [Integer] Customer returns to show per-page in the admin (default: +15+)
     preference :customer_returns_per_page, :integer, default: 15
+
+    # @!attribute [rw] require_master_price
+    #   @return [Boolean] Require a price on the master variant of a product (default: +true+)
     preference :require_master_price, :boolean, default: true
+
+    # @!attribute [rw] require_payment_to_ship
+    #   @return [Boolean] Allows shipments to be ready to ship regardless of the order being paid if false (default: +true+)
     preference :require_payment_to_ship, :boolean, default: true # Allows shipments to be ready to ship regardless of the order being paid if false
+
+    # @!attribute [rw] return_eligibility_number_of_days
+    #   @return [Integer] default: 365
     preference :return_eligibility_number_of_days, :integer, default: 365
-    preference :shipping_instructions, :boolean, default: false # Request instructions/info for shipping
+
+    # @!attribute [rw] shipping_instructions
+    #   @return [Boolean] Request instructions/info for shipping (default: +false+)
+    preference :shipping_instructions, :boolean, default: false
+
+    # @!attribute [rw] show_only_complete_orders_by_default
+    #   @return [Boolean] Only show completed orders by default in the admin (default: +true+)
     preference :show_only_complete_orders_by_default, :boolean, default: true
-    preference :show_variant_full_price, :boolean, default: false #Displays variant full price or difference with product price. Default false to be compatible with older behavior
+
+    # @!attribute [rw] show_variant_full_price
+    #   @return [Boolean] Displays variant full price or difference with product price. (default: +false+)
+    preference :show_variant_full_price, :boolean, default: false
+
+    # @!attribute [rw] show_products_without_price
+    #   @return [Boolean] Whether products without a price are visible in the frontend (default: +false+)
     preference :show_products_without_price, :boolean, default: false
+
+    # @!attribute [rw] show_raw_product_description
+    #   @return [Boolean] Don't escape HTML of product descriptions. (default: +false+)
     preference :show_raw_product_description, :boolean, :default => false
+
+    # @!attribute [rw] tax_using_ship_address
+    #   @return [Boolean] Use the shipping address rather than the billing address to determine tax (default: +true+)
     preference :tax_using_ship_address, :boolean, default: true
-    preference :track_inventory_levels, :boolean, default: true # Determines whether to track on_hand values for variants / products.
+
+    # @!attribute [rw] track_inventory_levels
+    #   Determines whether to track on_hand values for variants / products. If
+    #   you do not track inventory, or have effectively unlimited inventory for
+    #   all products you can turn this on.
+    #   @return [] Track on_hand values for variants / products. (default: true)
+    preference :track_inventory_levels, :boolean, default: true
 
     # Default mail headers settings
-    preference :send_core_emails, :boolean, :default => true
+
+    # @!attribute [rw] send_core_emails
+    #   @return [Boolean] Whether to send transactional emails (default: true)
+    preference :send_core_emails, :boolean, default: true
+
+    # @!attribute [rw] mails_from
+    #   @return [String] Email address used as +From:+ field in transactional emails.
     preference :mails_from, :string, :default => 'spree@example.com'
 
     # Store credits configurations
+
+    # @!attribute [rw] credit_to_new_allocation
+    #   @return [Boolean] Creates a new allocation anytime {StoreCredit#credit} is called
     preference :credit_to_new_allocation, :boolean, default: false
 
     # searcher_class allows spree extension writers to provide their own Search class
@@ -79,6 +229,7 @@ module Spree
     end
 
     # all the following can be deprecated when store prefs are no longer supported
+    # @private
     DEPRECATED_STORE_PREFERENCES = {
       site_name: :name,
       site_url: :url,

--- a/core/db/migrate/20140309033438_create_store_from_preferences.rb
+++ b/core/db/migrate/20140309033438_create_store_from_preferences.rb
@@ -10,13 +10,13 @@ class CreateStoreFromPreferences < ActiveRecord::Migration
       # we set defaults for the things we now require
       Spree::Store.new do |s|
         s.name              = preference_store.get 'spree/app_configuration/site_name' do
-          'Spree Demo Site'
+          'Sample Store'
         end
         s.url               = preference_store.get 'spree/app_configuration/site_url' do
-          'demo.spreecommerce.com'
+          'example.com'
         end
         s.mail_from_address = preference_store.get 'spree/app_configuration/mails_from' do
-          'spree@example.com'
+          'store@example.com'
         end
 
         s.meta_description = preference_store.get('spree/app_configuration/default_meta_description') {}

--- a/core/lib/generators/spree/install/templates/config/initializers/spree.rb
+++ b/core/lib/generators/spree/install/templates/config/initializers/spree.rb
@@ -26,7 +26,7 @@ Spree.config do |config|
   # Frontend:
 
   # Custom logo for the frontend
-  # config.logo = "logo/spree_50.png"
+  # config.logo = "logo/solidus_logo.png"
 
   # Template to use when rendering layout
   # config.layout = "spree/layouts/spree_application"
@@ -35,7 +35,7 @@ Spree.config do |config|
   # Admin:
 
   # Custom logo for the admin
-  # config.admin_interface_logo = "logo/spree_50.png"
+  # config.admin_interface_logo = "logo/solidus_logo.png"
 end
 
 Spree.user_class = <%= (options[:user_class].blank? ? "Spree::LegacyUser" : options[:user_class]).inspect %>

--- a/core/lib/generators/spree/install/templates/config/initializers/spree.rb
+++ b/core/lib/generators/spree/install/templates/config/initializers/spree.rb
@@ -1,4 +1,5 @@
 # Configure Solidus Preferences
+# See http://docs.solidus.io/Spree/AppConfiguration.html for details
 
 Spree.config do |config|
   # Without this preferences are loaded and persisted to the database. This


### PR DESCRIPTION
* Adds docs for `Spree::AppConfiguration` (class of `Spree::Config`)
* Link to new docs from generated initializer
* Small improvements to product documentation
* Remove spree branding from default store in migration