### PR TITLE
Fix migration warning when all migrations match

### DIFF
--- a/core/lib/spree/migrations.rb
+++ b/core/lib/spree/migrations.rb
@@ -26,7 +26,7 @@ module Spree
           name, engine = file_name.split(".", 2)
           next unless match_engine?(engine)
           name
-        end.compact! || []
+        end.compact
 
         missing_migrations = engine_migrations.sort - engine_in_app.sort
         unless missing_migrations.empty?


### PR DESCRIPTION
Migration check mistakenly gave warnings if all migrations matched the engine. This is because compact! returns nil if no changes were made.