### PR TITLE
Fix payment bugs

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -669,9 +669,12 @@ module Spree
         other_payments.first.update_attributes!(amount: remaining_total)
       end
 
+      payments.reload
+
       if payments.checkout.sum(:amount) != total
         errors.add(:base, Spree.t("store_credit.errors.unable_to_fund")) and return false
       end
+
     end
 
     def covered_by_store_credit?

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -643,7 +643,12 @@ module Spree
     def add_store_credit_payments
       payments.store_credits.checkout.each(&:invalidate!)
 
-      remaining_total = outstanding_balance
+      # this can happen when multiple payments are present, auto_capture is
+      # turned off, and one of the payments fails when the user tries to
+      # complete the order, which sends the order back to the 'payment' state.
+      authorized_total = payments.pending.sum(:amount)
+
+      remaining_total = outstanding_balance - authorized_total
 
       if user && user.store_credits.any?
         payment_method = Spree::PaymentMethod::StoreCredit.first
@@ -671,7 +676,7 @@ module Spree
 
       payments.reload
 
-      if payments.checkout.sum(:amount) != total
+      if payments.where(state: %w(checkout pending)).sum(:amount) != total
         errors.add(:base, Spree.t("store_credit.errors.unable_to_fund")) and return false
       end
 

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -1023,6 +1023,7 @@ describe Spree::Order, :type => :model do
           end
 
           it "charges the outstanding balance to the credit card" do
+            expect(order.errors.messages).to be_empty
             expect(order.payments.count).to eq 1
             expect(order.payments.first.source).to be_a(Spree::CreditCard)
             expect(order.payments.first.amount).to eq order_total
@@ -1048,6 +1049,7 @@ describe Spree::Order, :type => :model do
           end
 
           it "creates a store credit payment for the full amount" do
+            expect(order.errors.messages).to be_empty
             expect(order.payments.count).to eq 1
             expect(order.payments.first).to be_store_credit
             expect(order.payments.first.amount).to eq order_total
@@ -1088,6 +1090,7 @@ describe Spree::Order, :type => :model do
           end
 
           it "charges the outstanding balance to the credit card" do
+            expect(order.errors.messages).to be_empty
             expect(order.payments.count).to eq 2
             expect(order.payments.first.source).to be_a(Spree::CreditCard)
             expect(order.payments.first.amount).to eq expected_cc_total

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -1040,7 +1040,7 @@ describe Spree::Order, :type => :model do
 
       context "there is enough store credit to pay for the entire order" do
         let(:store_credit) { create(:store_credit, amount: order_total) }
-        let(:order)        { create(:order, user: store_credit.user, total: order_total) }
+        let(:order) { create(:order_with_totals, user: store_credit.user, line_items_price: order_total).tap(&:update!) }
 
         context "there are no other payments" do
           before do
@@ -1113,7 +1113,7 @@ describe Spree::Order, :type => :model do
           let(:amount_difference)       { 100 }
           let!(:primary_store_credit)   { create(:store_credit, amount: (order_total - amount_difference)) }
           let!(:secondary_store_credit) { create(:store_credit, amount: order_total, user: primary_store_credit.user, credit_type: create(:secondary_credit_type)) }
-          let(:order)                   { create(:order, user: primary_store_credit.user, total: order_total) }
+          let(:order) { create(:order_with_totals, user: primary_store_credit.user, line_items_price: order_total).tap(&:update!) }
 
           before do
             subject

--- a/core/spec/models/spree/unit_cancel_spec.rb
+++ b/core/spec/models/spree/unit_cancel_spec.rb
@@ -82,6 +82,7 @@ describe Spree::UnitCancel do
         order.contents.add(variant, 2)
         order.contents.advance
         create(:payment, order: order, amount: order.total)
+        order.payments.reload
         order.complete!
         order.reload
 


### PR DESCRIPTION
Copied and updated from https://github.com/bonobos/spree_store_credit_payment_method/pull/68

- Fix stale-data bug
- Recognize authorized store credit payments when calculating amounts

These were resulting in bogus "Unable to pay for order using store credits" errors which left users stuck in the "payment" state without being able to progress.

Also:  Make some specs more reliable.