### PR TITLE
Drop unused spree_credit_cards.address field

### DIFF
--- a/core/db/migrate/20150618191713_remove_credit_card_address_id.rb
+++ b/core/db/migrate/20150618191713_remove_credit_card_address_id.rb
@@ -1,0 +1,7 @@
+class RemoveCreditCardAddressId < ActiveRecord::Migration
+  def change
+    # This hasn't been accessible for a long time:
+    # https://github.com/bonobos/spree/commit/0b58afc#diff-b3d9a7a18a30a5fb3372cfcf3f925a3dL4
+    remove_column :spree_credit_cards, :address_id, :integer
+  end
+end


### PR DESCRIPTION
Same thing as https://github.com/bonobos/spree/pull/417.

See code comments.