### PR TITLE
Use #reset instead of #reload

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -681,7 +681,7 @@ module Spree
         other_payments.first.update_attributes!(amount: remaining_total)
       end
 
-      payments.reload
+      payments.reset
 
       if payments.where(state: %w(checkout pending)).sum(:amount) != total
         errors.add(:base, Spree.t("store_credit.errors.unable_to_fund")) and return false


### PR DESCRIPTION
This was using `reload` previously because CollectionProxy#reset is
broken in Rails < 4.1.0.  Solidus now has a more recent version of
Rails so we can update this.

See https://github.com/solidusio/solidus/commit/1428d2d#commitcomment-11866528
and https://github.com/rails/rails/commit/43675f0

cc @jhawthorn 