### PR TITLE
Add random ordering and status persistence to rspec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ spree_dev
 spree_test
 testapp
 **/spec/dummy
+**/spec/examples.txt
 tmp
 public/google_base.xml
 public/template_google_base.xml

--- a/api/spec/spec_helper.rb
+++ b/api/spec/spec_helper.rb
@@ -57,4 +57,6 @@ RSpec.configure do |config|
   end
 
   config.use_transactional_fixtures = true
+
+  config.example_status_persistence_file_path = "./spec/examples.txt"
 end

--- a/api/spec/spec_helper.rb
+++ b/api/spec/spec_helper.rb
@@ -59,4 +59,8 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = true
 
   config.example_status_persistence_file_path = "./spec/examples.txt"
+
+  config.order = :random
+
+  Kernel.srand config.seed
 end

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -108,4 +108,8 @@ RSpec.configure do |config|
   config.fail_fast = ENV['FAIL_FAST'] || false
 
   config.example_status_persistence_file_path = "./spec/examples.txt"
+
+  config.order = :random
+
+  Kernel.srand config.seed
 end

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -106,4 +106,6 @@ RSpec.configure do |config|
   config.extend WithModel
 
   config.fail_fast = ENV['FAIL_FAST'] || false
+
+  config.example_status_persistence_file_path = "./spec/examples.txt"
 end

--- a/core/app/models/spree/payment_method.rb
+++ b/core/app/models/spree/payment_method.rb
@@ -16,14 +16,14 @@ module Spree
     end
 
     def provider_class
-      raise ::NotImplementedError, 'You must implement provider_class method for this gateway.'
+      raise ::NotImplementedError, "You must implement provider_class method for #{self.class}."
     end
 
     # The class that will process payments for this payment type, used for @payment.source
     # e.g. CreditCard in the case of a the Gateway payment type
     # nil means the payment method doesn't require a source e.g. check
     def payment_source_class
-      raise ::NotImplementedError, 'You must implement payment_source_class method for this gateway.'
+      raise ::NotImplementedError, "You must implement payment_source_class method for #{self.class}."
     end
 
     def self.available(display_on = 'both')

--- a/core/lib/spree/testing_support/order_walkthrough.rb
+++ b/core/lib/spree/testing_support/order_walkthrough.rb
@@ -1,10 +1,5 @@
 class OrderWalkthrough
   def self.up_to(state)
-    # A payment method must exist for an order to proceed through the Address state
-    unless Spree::PaymentMethod.exists?
-      FactoryGirl.create(:check_payment_method)
-    end
-
     # Need to create a valid zone too...
     zone = FactoryGirl.create(:zone)
     country = FactoryGirl.create(:country)
@@ -56,8 +51,8 @@ class OrderWalkthrough
   end
 
   def self.payment(order)
-    FactoryGirl.create(:credit_card) unless Spree::CreditCard.exists?
-    order.payments.create!(:payment_method => Spree::PaymentMethod.first, :amount => order.total, source: Spree::CreditCard.first)
+    credit_card = FactoryGirl.create(:credit_card)
+    order.payments.create!(:payment_method => credit_card.payment_method, :amount => order.total, source: credit_card)
     # TODO: maybe look at some way of making this payment_state change automatic
     order.payment_state = 'paid'
     order.next!

--- a/core/spec/spec_helper.rb
+++ b/core/spec/spec_helper.rb
@@ -70,4 +70,8 @@ RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
 
   config.example_status_persistence_file_path = "./spec/examples.txt"
+
+  config.order = :random
+
+  Kernel.srand config.seed
 end

--- a/core/spec/spec_helper.rb
+++ b/core/spec/spec_helper.rb
@@ -68,4 +68,6 @@ RSpec.configure do |config|
   config.extend WithModel
   config.filter_run focus: true
   config.run_all_when_everything_filtered = true
+
+  config.example_status_persistence_file_path = "./spec/examples.txt"
 end

--- a/frontend/spec/features/cart_spec.rb
+++ b/frontend/spec/features/cart_spec.rb
@@ -34,9 +34,7 @@ describe "Cart", type: :feature, inaccessible: true do
     visit spree.root_path
     click_link "RoR Mug"
     click_button "add-to-cart-button"
-    within("#line_items") do
-      click_link "delete_line_item_1"
-    end
+    find('.cart-item-delete .delete').click
     expect(page).not_to have_content("Line items quantity must be an integer")
     expect(page).not_to have_content("RoR Mug")
     expect(page).to have_content("Your cart is empty")

--- a/frontend/spec/spec_helper.rb
+++ b/frontend/spec/spec_helper.rb
@@ -73,6 +73,10 @@ RSpec.configure do |config|
     end
   end
 
+  config.before(:suite) do
+    DatabaseCleaner.clean_with :truncation
+  end
+
   config.before(:each) do
     Rails.cache.clear
     reset_spree_preferences

--- a/frontend/spec/spec_helper.rb
+++ b/frontend/spec/spec_helper.rb
@@ -113,4 +113,6 @@ RSpec.configure do |config|
   config.include Paperclip::Shoulda::Matchers
 
   config.fail_fast = ENV['FAIL_FAST'] || false
+
+  config.example_status_persistence_file_path = "./spec/examples.txt"
 end

--- a/frontend/spec/spec_helper.rb
+++ b/frontend/spec/spec_helper.rb
@@ -115,4 +115,8 @@ RSpec.configure do |config|
   config.fail_fast = ENV['FAIL_FAST'] || false
 
   config.example_status_persistence_file_path = "./spec/examples.txt"
+
+  config.order = :random
+
+  Kernel.srand config.seed
 end

--- a/sample/spec/spec_helper.rb
+++ b/sample/spec/spec_helper.rb
@@ -18,4 +18,6 @@ RSpec.configure do |config|
 
   config.include FactoryGirl::Syntax::Methods
   config.fail_fast = ENV['FAIL_FAST'] || false
+
+  config.example_status_persistence_file_path = "./spec/examples.txt"
 end

--- a/sample/spec/spec_helper.rb
+++ b/sample/spec/spec_helper.rb
@@ -20,4 +20,8 @@ RSpec.configure do |config|
   config.fail_fast = ENV['FAIL_FAST'] || false
 
   config.example_status_persistence_file_path = "./spec/examples.txt"
+
+  config.order = :random
+
+  Kernel.srand config.seed
 end


### PR DESCRIPTION
See http://rspec.info/blog/2015/06/rspec-3-3-has-been-released/

This allows us to use rspec's new `--only-failures` and` --next-failure` commands.

Random ordering should help ensure that our specs don't modify any global state.

I'll want to see this PR pass many times on CI before merging it in.