### PR TITLE
Remove shipping_method_id column from spree_orders

### DIFF
--- a/core/db/migrate/20150626200816_remove_shipping_method_id_from_spree_orders.rb
+++ b/core/db/migrate/20150626200816_remove_shipping_method_id_from_spree_orders.rb
@@ -1,0 +1,9 @@
+class RemoveShippingMethodIdFromSpreeOrders < ActiveRecord::Migration
+  def up
+    remove_column :spree_orders, :shipping_method_id, :integer
+  end
+
+  def down
+    add_column :spree_orders, :shipping_method_id, :integer
+  end
+end


### PR DESCRIPTION
This is a relic from before spree separated shipments from orders and should not be used anywhere.