### PR TITLE
Remove unused stock_items counter cache

### DIFF
--- a/core/app/models/spree/stock_item.rb
+++ b/core/app/models/spree/stock_item.rb
@@ -3,7 +3,7 @@ module Spree
     acts_as_paranoid
 
     belongs_to :stock_location, class_name: 'Spree::StockLocation', inverse_of: :stock_items
-    belongs_to :variant, class_name: 'Spree::Variant', inverse_of: :stock_items, counter_cache: true
+    belongs_to :variant, class_name: 'Spree::Variant', inverse_of: :stock_items
     has_many :stock_movements, inverse_of: :stock_item
 
     validates_presence_of :stock_location, :variant

--- a/core/db/migrate/20141023005240_add_counter_cache_from_spree_variants_to_spree_stock_items.rb
+++ b/core/db/migrate/20141023005240_add_counter_cache_from_spree_variants_to_spree_stock_items.rb
@@ -1,13 +1,8 @@
 class AddCounterCacheFromSpreeVariantsToSpreeStockItems < ActiveRecord::Migration
+  # This was unnecessary and was removed
   def up
-    add_column :spree_variants, :stock_items_count, :integer, default: 0, null: false
-
-    Spree::Variant.find_each do |variant|
-      Spree::Variant.reset_counters(variant.id, :stock_items)
-    end
   end
 
   def down
-    remove_column :spree_variants, :stock_items_count
   end
 end

--- a/core/db/migrate/20150626214817_remove_counter_cache_from_spree_variants_to_spree_stock_items.rb
+++ b/core/db/migrate/20150626214817_remove_counter_cache_from_spree_variants_to_spree_stock_items.rb
@@ -1,0 +1,10 @@
+class RemoveCounterCacheFromSpreeVariantsToSpreeStockItems < ActiveRecord::Migration
+  def up
+    if column_exists?(:spree_variants, :stock_items_count)
+      remove_column :spree_variants, :stock_items_count
+    end
+  end
+
+  def down
+  end
+end


### PR DESCRIPTION
I don't believe this is used anywhere, and I can't think of a situation it would be useful to know the number of stock items a variant had without wanting to look at the stock items themselves.