### PR TITLE
Fix a condition which would lead to MySQL deadlock

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -524,7 +524,7 @@ module Spree
     end
 
     def create_proposed_shipments
-      adjustments.shipping.delete_all
+      adjustments.shipping.destroy_all
       shipments.destroy_all
       self.shipments = Spree::Stock::Coordinator.new(self).shipments
     end


### PR DESCRIPTION
Running a delete by an index condition, for example:

```
DELETE FROM spree_adjustments
  WHERE adjustable_id = 1
  AND adjustable_type = 'Spree::Shipment'
```

will require MySQL to acquire a gap lock on the index which indexes
adjustable_id and adjustable_type.

Running this in a heavily loaded environment can lead to deadlocks in
MySQL as multiple threads need an exclusive gap lock on the index in
question.

By deleting records by the primary key instead, MySQL is able to deal
with this without requiring an exclusive lock on the primary key index,
avoiding the deadlock situation.