### PR TITLE
Fix stock_management_spec ordering failure

### DIFF
--- a/backend/spec/features/admin/products/stock_management_spec.rb
+++ b/backend/spec/features/admin/products/stock_management_spec.rb
@@ -59,10 +59,8 @@ describe "Stock Management", :type => :feature do
 
     def adjust_count_on_hand(count_on_hand)
       find(:css, ".fa-edit[data-id='#{stock_item.id}']").click
-      expect(page).to have_selector("#number-update-#{variant.id} input[type='number']", visible: true)
-      find(:css, "#number-update-#{variant.id} input[type='number']").set(count_on_hand)
+      find(:css, "[data-variant-id='#{variant.id}'] input[type='number']").set(count_on_hand)
       find(:css, ".fa-check[data-id='#{stock_item.id}']").click
-      wait_for_ajax
       expect(page).to have_content('Updated successfully')
     end
 


### PR DESCRIPTION
This spec sometimes failed when run in a random order. It was looking
for the field "#number-update-#{variant.id}", but the id used in that
css id was from stock_item, not variant. Fixed to use a class which
actually has the variant id.

Also remove a wait_for_ajax and redundant capybara statements.