### PR TITLE
Remove auto payment completion in admin for completed orders

### DIFF
--- a/backend/app/controllers/spree/admin/payments_controller.rb
+++ b/backend/app/controllers/spree/admin/payments_controller.rb
@@ -27,11 +27,7 @@ module Spree
 
         begin
           if @payment.save
-            if @order.completed?
-              # If the order was already complete then go ahead and process the payment
-              # (auth and/or capture depending on payment method configuration)
-              @payment.process! if @payment.checkout?
-            else
+            if !@order.completed?
               # Transition order as far as it will go.
               while @order.next; end
             end

--- a/backend/spec/features/admin/orders/payments_spec.rb
+++ b/backend/spec/features/admin/orders/payments_spec.rb
@@ -89,9 +89,7 @@ describe 'Payments', :type => :feature do
       expect(page).to have_content('successfully created!')
 
       click_icon(:capture)
-      expect(find('#payment_status').text).to eq('PAID')
-
-      expect(page).not_to have_selector('#new_payment_section')
+      expect(find('#payment_status').text).to eq('BALANCE DUE')
     end
 
     # Regression test for #1269


### PR DESCRIPTION
This is ~~untested~~, unnecessary, is possibly unexpected, and adds
complexity.

Update: It was tested after all. I still think it should go but interested to hear what other think.