### PR TITLE
Fix order mutex max age usage.

### DIFF
--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -138,7 +138,7 @@ module Spree
 
     # @!attribute [rw] order_mutex_max_age
     #   @return [Integer] Max age of {OrderMutex} in seconds (default: 2 minutes)
-    preference :order_mutex_max_age, :integer, default: 2.minutes
+    preference :order_mutex_max_age, :integer, default: 120
 
     # @!attribute [rw] orders_per_page
     #   @return [Integer] Orders to show per-page in the admin (default: +15+)

--- a/core/app/models/spree/order_mutex.rb
+++ b/core/app/models/spree/order_mutex.rb
@@ -5,7 +5,7 @@ module Spree
 
     belongs_to :order, class_name: "Spree::Order"
 
-    scope :expired, -> { where("#{quoted_table_name}.created_at <= ?", Spree::Config[:order_mutex_max_age].ago) }
+    scope :expired, -> { where("#{quoted_table_name}.created_at <= ?", Spree::Config[:order_mutex_max_age].seconds.ago) }
 
     class << self
       # Obtain a lock on an order, execute the supplied block and then release the lock.

--- a/core/app/models/spree/order_mutex.rb
+++ b/core/app/models/spree/order_mutex.rb
@@ -5,7 +5,7 @@ module Spree
 
     belongs_to :order, class_name: "Spree::Order"
 
-    scope :expired, -> { where("#{quoted_table_name}.created_at <= ?", Spree::Config[:order_mutex_max_age].seconds.ago) }
+    scope :expired, -> { where(arel_table[:created_at].lteq(Spree::Config[:order_mutex_max_age].seconds.ago)) }
 
     class << self
       # Obtain a lock on an order, execute the supplied block and then release the lock.

--- a/core/spec/models/spree/order_mutex_spec.rb
+++ b/core/spec/models/spree/order_mutex_spec.rb
@@ -41,7 +41,7 @@ describe Spree::OrderMutex do
   context "with an expired existing lock on the same order" do
     around do |example|
       Spree::OrderMutex.with_lock!(order) do
-        future = Spree::Config[:order_mutex_max_age].from_now + 1.second
+        future = Spree::Config[:order_mutex_max_age].seconds.from_now + 1.second
         Timecop.freeze(future) do
           example.run
         end


### PR DESCRIPTION
We expect the value to be an integer, but treat it as a duration everywhere. The only reason it worked before, is due to duck-typing and the default being a duration.