### PR TITLE
Auth fix and payment refactors

### DIFF
--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -305,9 +305,7 @@ module Spree
           private
 
           def process_payments_before_complete
-            if !payment_required?
-              return
-            end
+            return if !payment_required?
 
             if payments.valid.empty?
               errors.add(:base, Spree.t(:no_payment_found))

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -72,16 +72,7 @@ module Spree
                   transition to: :payment, from: :confirm
                 end
 
-                before_transition to: :complete do |order|
-                  if order.payment_required? && order.payments.valid.empty?
-                    order.errors.add(:base, Spree.t(:no_payment_found))
-                    false
-                  elsif order.payment_required?
-                    order.process_payments!.tap do |success|
-                      order.handle_failed_payments unless success
-                    end
-                  end
-                end
+                before_transition to: :complete, do: :process_payments_before_complete
                 after_transition to: :complete, do: :persist_user_credit_card
                 before_transition to: :payment, do: :set_shipments_cost
                 before_transition to: :payment, do: :create_tax_charge!
@@ -311,13 +302,28 @@ module Spree
             end
           end
 
-          def handle_failed_payments
-            errors = self.errors[:base]
-            self.payment_failed!
-            errors.each { |error| self.errors.add(:base, error) }
+          private
+
+          def process_payments_before_complete
+            if !payment_required?
+              return
+            end
+
+            if payments.valid.empty?
+              errors.add(:base, Spree.t(:no_payment_found))
+              return false
+            end
+
+            if process_payments!
+              true
+            else
+              saved_errors = errors[:base]
+              payment_failed!
+              saved_errors.each { |error| errors.add(:base, error) }
+              false
+            end
           end
 
-          private
           # For payment step, filter order parameters to produce the expected nested
           # attributes for a single payment and its source, discarding attributes
           # for payment methods other than the one selected

--- a/core/app/models/spree/order/payments.rb
+++ b/core/app/models/spree/order/payments.rb
@@ -9,7 +9,7 @@ module Spree
         #
         # Returns:
         #
-        # - true if all pending_payments processed successfully
+        # - true if all pending payments processed successfully
         #
         # - true if a payment failed, ie. raised a GatewayError
         #   which gets rescued and converted to TRUE when
@@ -29,10 +29,6 @@ module Spree
 
         def capture_payments!
           process_payments_with(:purchase!)
-        end
-
-        def pending_payments
-          payments.select { |payment| payment.pending? }
         end
 
         def unprocessed_payments

--- a/core/app/models/spree/order_capturing.rb
+++ b/core/app/models/spree/order_capturing.rb
@@ -41,7 +41,7 @@ class Spree::OrderCapturing
   private
 
   def sorted_payments(order)
-    payments = order.pending_payments
+    payments = order.payments.pending
     payments = payments.sort_by { |p| [@sorted_payment_method_classes.index(p.payment_method.class), p.id] }
   end
 end

--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -2,7 +2,9 @@ module Spree
   class Payment < Spree::Base
     module Processing
       def process!
-        if payment_method && payment_method.auto_capture?
+        return if payment_method.nil?
+
+        if payment_method.auto_capture?
           purchase!
         else
           authorize!
@@ -106,19 +108,20 @@ module Spree
           raise ArgumentError.new("handle_payment_preconditions must be called with a block")
         end
 
-        if payment_method && payment_method.source_required?
-          if source
-            if !processing?
-              if payment_method.supports?(source) || token_based?
-                yield
-              else
-                invalidate!
-                raise Core::GatewayError.new(Spree.t(:payment_method_not_supported))
-              end
+        return if payment_method.nil?
+        return if !payment_method.source_required?
+
+        if source
+          if !processing?
+            if payment_method.supports?(source) || token_based?
+              yield
+            else
+              invalidate!
+              raise Core::GatewayError.new(Spree.t(:payment_method_not_supported))
             end
-          else
-            raise Core::GatewayError.new(Spree.t(:payment_processing_failed))
           end
+        else
+          raise Core::GatewayError.new(Spree.t(:payment_processing_failed))
         end
       end
 

--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -6,6 +6,7 @@ module Spree
       #     - There is no payment method
       #     - The payment method does not require a source
       #     - The payment is in the "processing" state
+      #     - 'auto_capture?' is false and the payment is already authorized.
       #   - Raise an exception when:
       #     - The source is missing or invalid
       #     - The payment is in a state that cannot transition to 'processing'
@@ -25,7 +26,11 @@ module Spree
         if payment_method.auto_capture?
           purchase!
         else
-          authorize!
+          if pending?
+            # do nothing. already authorized.
+          else
+            authorize!
+          end
         end
       end
 

--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -1,6 +1,24 @@
 module Spree
   class Payment < Spree::Base
     module Processing
+      # "process!" means:
+      #   - Do nothing when:
+      #     - There is no payment method
+      #     - The payment method does not require a source
+      #     - The payment is in the "processing" state
+      #   - Raise an exception when:
+      #     - The source is missing or invalid
+      #     - The payment is in a state that cannot transition to 'processing'
+      #       (failed/void/invalid states). Note: 'completed' can transition to
+      #       'processing' and thus calling #process! on a completed Payment
+      #       will attempt to re-authorize/re-purchase the payment.
+      #   - Otherwise:
+      #     - If 'auto_capture?' is true:
+      #       - Call #purchase on the payment gateway. (i.e. authorize+capture)
+      #         even if the payment is already failed/completed/etc.
+      #     - Else:
+      #       - Call #authorize on the payment gateway even if the payment is
+      #         already authorized/failed/completed/etc.
       def process!
         return if payment_method.nil?
 

--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -16,10 +16,10 @@ module Spree
       #   - Otherwise:
       #     - If 'auto_capture?' is true:
       #       - Call #purchase on the payment gateway. (i.e. authorize+capture)
-      #         even if the payment is already failed/completed/etc.
+      #         even if the payment is already completed.
       #     - Else:
       #       - Call #authorize on the payment gateway even if the payment is
-      #         already authorized/failed/completed/etc.
+      #         already completed.
       def process!
         return if payment_method.nil?
 

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -175,7 +175,7 @@ describe Spree::Payment, :type => :model do
         context 'when in the pending state' do
           before { payment.update_attributes!(state: 'pending') }
 
-          it "does not authorize" do
+          it "does not re-authorize" do
             expect(payment).to_not receive(:authorize!)
             payment.process!
             expect(payment).to be_pending
@@ -195,7 +195,7 @@ describe Spree::Payment, :type => :model do
         context 'when in the completed state' do
           before { payment.update_attributes!(state: 'completed') }
 
-          it "raises an exception" do
+          it "authorizes" do
             payment.process!
             # TODO: Is this really what we want to happen in this case?
             expect(payment).to be_pending

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -5,7 +5,7 @@ describe Spree::Payment, :type => :model do
   let(:refund_reason) { create(:refund_reason) }
 
   let(:gateway) do
-    gateway = Spree::Gateway::Bogus.new(:environment => 'test', :active => true)
+    gateway = Spree::Gateway::Bogus.new(:environment => 'test', :active => true, :name => 'Bogus gateway')
     allow(gateway).to receive_messages :source_required => true
     gateway
   end
@@ -138,16 +138,69 @@ describe Spree::Payment, :type => :model do
 
   context "processing" do
     describe "#process!" do
-      it "should purchase if with auto_capture" do
-        expect(payment.payment_method).to receive(:auto_capture?).and_return(true)
-        payment.process!
-        expect(payment).to be_completed
+      context 'with autocapture' do
+        before do
+          payment.payment_method.update_attributes!(auto_capture: true)
+        end
+
+        it "should purchase" do
+          payment.process!
+          expect(payment).to be_completed
+        end
       end
 
-      it "should authorize without auto_capture" do
-        expect(payment.payment_method).to receive(:auto_capture?).and_return(false)
-        payment.process!
-        expect(payment).to be_pending
+      context 'without autocapture' do
+        before do
+          payment.payment_method.update_attributes!(auto_capture: false)
+        end
+
+        context 'when in the checkout state' do
+          before { payment.update_attributes!(state: 'checkout') }
+
+          it "authorizes" do
+            payment.process!
+            expect(payment).to be_pending
+          end
+        end
+
+        context 'when in the processing state' do
+          before { payment.update_attributes!(state: 'processing') }
+
+          it "does not authorize" do
+            payment.process!
+            expect(payment).to be_processing
+          end
+        end
+
+        context 'when in the pending state' do
+          before { payment.update_attributes!(state: 'pending') }
+
+          it "does not authorize" do
+            expect(payment).to_not receive(:authorize!)
+            payment.process!
+            expect(payment).to be_pending
+          end
+        end
+
+        context 'when in a failed state' do
+          before { payment.update_attributes!(state: 'failed') }
+
+          it "raises an exception" do
+            expect {
+              payment.process!
+            }.to raise_error(StateMachines::InvalidTransition, /Cannot transition/)
+          end
+        end
+
+        context 'when in the completed state' do
+          before { payment.update_attributes!(state: 'completed') }
+
+          it "raises an exception" do
+            payment.process!
+            # TODO: Is this really what we want to happen in this case?
+            expect(payment).to be_pending
+          end
+        end
       end
 
       it "should make the state 'processing'" do


### PR DESCRIPTION
FYI: I did some refactoring while I was working on this so it'll probably be easiest to understand this PR by looking at the commits one at a time.  The most important fix is in the final commit.

This fixes a bug where payments might be re-authorized after they've already been authorized once, which causes errors with store credits and results in over-authorization with credit cards.