### PR TITLE
Fix order issue in api/products_controller_spec

### DIFF
--- a/api/spec/controllers/spree/api/products_controller_spec.rb
+++ b/api/spec/controllers/spree/api/products_controller_spec.rb
@@ -394,8 +394,8 @@ module Spree
           expect(json_response['variants'].count).to eq(2) # 2 variants
 
           variants = json_response['variants'].select { |v| !v['is_master'] }
-          expect(variants.last['option_values'][0]['name']).to eq('small')
-          expect(variants.last['option_values'][0]['option_type_name']).to eq('size')
+          size_option_value = variants.last['option_values'].detect{|x| x['option_type_name'] == 'size' }
+          expect(size_option_value['name']).to eq('small')
 
           expect(json_response['option_types'].count).to eq(2) # size, color
         end


### PR DESCRIPTION
It is valid for the option_values array to be returned in any order, our spec should look for the one we care about.