### PR TITLE
Revert incompatible Promotion::Rules::ItemTotal change

### DIFF
--- a/backend/app/views/spree/admin/promotions/rules/_item_total.html.erb
+++ b/backend/app/views/spree/admin/promotions/rules/_item_total.html.erb
@@ -1,8 +1,6 @@
 <div class="field alpha four columns">
-  <%= select_tag "#{param_prefix}[preferred_operator_min]", options_for_select(Spree::Promotion::Rules::ItemTotal::OPERATORS_MIN.map{|o| [Spree.t("item_total_rule.operators.#{o}"),o]}, promotion_rule.preferred_operator_min), { class: 'select2 select_item_total fullwidth' } %>
-  <%= select_tag "#{param_prefix}[preferred_operator_max]", options_for_select(Spree::Promotion::Rules::ItemTotal::OPERATORS_MAX.map{|o| [Spree.t("item_total_rule.operators.#{o}"),o]}, promotion_rule.preferred_operator_max), { class: 'select2 select_item_total fullwidth' } %>
+  <%= select_tag "#{param_prefix}[preferred_operator]", options_for_select(Spree::Promotion::Rules::ItemTotal::OPERATORS.map{|o| [Spree.t("item_total_rule.operators.#{o}"),o]}, promotion_rule.preferred_operator), {:class => 'select2 select_item_total fullwidth'} %>
 </div>
 <div class="field omega four columns">
-  <%= text_field_tag "#{param_prefix}[preferred_amount_min]", promotion_rule.preferred_amount_min, class: 'fullwidth' %>
-  <%= text_field_tag "#{param_prefix}[preferred_amount_max]", promotion_rule.preferred_amount_max, class: 'fullwidth' %>
+  <%= text_field_tag "#{param_prefix}[preferred_amount]", promotion_rule.preferred_amount, :class => 'fullwidth' %>
 </div>

--- a/backend/spec/features/admin/promotion_adjustments_spec.rb
+++ b/backend/spec/features/admin/promotion_adjustments_spec.rb
@@ -20,8 +20,7 @@ describe "Promotion Adjustments", :type => :feature do
       select2 "Item total", :from => "Add rule of type"
       within('#rule_fields') { click_button "Add" }
 
-      eventually_fill_in "promotion_promotion_rules_attributes_#{Spree::Promotion.count}_preferred_amount_min", :with => 30
-      eventually_fill_in "promotion_promotion_rules_attributes_#{Spree::Promotion.count}_preferred_amount_max", :with => 60
+      eventually_fill_in "promotion_promotion_rules_attributes_#{Spree::Promotion.count}_preferred_amount", :with => 30
       within('#rule_fields') { click_button "Update" }
 
       select2 "Create whole-order adjustment", :from => "Add action of type"
@@ -37,8 +36,7 @@ describe "Promotion Adjustments", :type => :feature do
 
       first_rule = promotion.rules.first
       expect(first_rule.class).to eq(Spree::Promotion::Rules::ItemTotal)
-      expect(first_rule.preferred_amount_min).to eq(30)
-      expect(first_rule.preferred_amount_max).to eq(60)
+      expect(first_rule.preferred_amount).to eq(30)
 
       first_action = promotion.actions.first
       expect(first_action.class).to eq(Spree::Promotion::Actions::CreateAdjustment)
@@ -81,8 +79,7 @@ describe "Promotion Adjustments", :type => :feature do
       select2 "Item total", :from => "Add rule of type"
       within('#rule_fields') { click_button "Add" }
 
-      eventually_fill_in "promotion_promotion_rules_attributes_1_preferred_amount_min", :with => 30
-      eventually_fill_in "promotion_promotion_rules_attributes_1_preferred_amount_max", :with => 60
+      eventually_fill_in "promotion_promotion_rules_attributes_1_preferred_amount", :with => 30
       within('#rule_fields') { click_button "Update" }
 
       select2 "Create whole-order adjustment", :from => "Add action of type"
@@ -97,8 +94,7 @@ describe "Promotion Adjustments", :type => :feature do
 
       first_rule = promotion.rules.first
       expect(first_rule.class).to eq(Spree::Promotion::Rules::ItemTotal)
-      expect(first_rule.preferred_amount_min).to eq(30)
-      expect(first_rule.preferred_amount_max).to eq(60)
+      expect(first_rule.preferred_amount).to eq(30)
 
       first_action = promotion.actions.first
       expect(first_action.class).to eq(Spree::Promotion::Actions::CreateAdjustment)
@@ -199,8 +195,7 @@ describe "Promotion Adjustments", :type => :feature do
 
       select2 "Item total", :from => "Add rule of type"
       within('#rule_fields') { click_button "Add" }
-      eventually_fill_in "promotion_promotion_rules_attributes_1_preferred_amount_min", :with => "50"
-      eventually_fill_in "promotion_promotion_rules_attributes_1_preferred_amount_max", :with => "150"
+      eventually_fill_in "promotion_promotion_rules_attributes_1_preferred_amount", :with => "50"
       within('#rule_fields') { click_button "Update" }
 
       select2 "Create whole-order adjustment", :from => "Add action of type"
@@ -214,8 +209,7 @@ describe "Promotion Adjustments", :type => :feature do
 
       first_rule = promotion.rules.first
       expect(first_rule.class).to eq(Spree::Promotion::Rules::ItemTotal)
-      expect(first_rule.preferred_amount_min).to eq(50)
-      expect(first_rule.preferred_amount_max).to eq(150)
+      expect(first_rule.preferred_amount).to eq(50)
 
       first_action = promotion.actions.first
       expect(first_action.class).to eq(Spree::Promotion::Actions::CreateAdjustment)

--- a/core/app/models/spree/promotion/rules/item_total.rb
+++ b/core/app/models/spree/promotion/rules/item_total.rb
@@ -4,14 +4,10 @@ module Spree
       # A rule to apply to an order greater than (or greater than or equal to)
       # a specific amount
       class ItemTotal < PromotionRule
-        preference :amount_min, :decimal, default: 100.00
-        preference :operator_min, :string, default: '>'
-        preference :amount_max, :decimal, default: 1000.00
-        preference :operator_max, :string, default: '<'
+        preference :amount, :decimal, default: 100.00
+        preference :operator, :string, default: '>'
 
-
-        OPERATORS_MIN = ['gt', 'gte']
-        OPERATORS_MAX = ['lt','lte']
+        OPERATORS = ['gt', 'gte']
 
         def applicable?(promotable)
           promotable.is_a?(Spree::Order)
@@ -19,42 +15,25 @@ module Spree
 
         def eligible?(order, options = {})
           item_total = order.item_total
-
-          lower_limit_condition = item_total.send(preferred_operator_min == 'gte' ? :>= : :>, BigDecimal.new(preferred_amount_min.to_s))
-          upper_limit_condition = item_total.send(preferred_operator_max == 'lte' ? :<= : :<, BigDecimal.new(preferred_amount_max.to_s))
-
-          eligibility_errors.add(:base, ineligible_message_max) unless upper_limit_condition
-          eligibility_errors.add(:base, ineligible_message_min) unless lower_limit_condition
+          unless item_total.send(preferred_operator == 'gte' ? :>= : :>, BigDecimal.new(preferred_amount.to_s))
+            eligibility_errors.add(:base, ineligible_message)
+          end
 
           eligibility_errors.empty?
         end
 
         private
-        def formatted_amount_min
-          Spree::Money.new(preferred_amount_min).to_s
+        def formatted_amount
+          Spree::Money.new(preferred_amount).to_s
         end
 
-        def formatted_amount_max
-          Spree::Money.new(preferred_amount_max).to_s
-        end
-
-
-        def ineligible_message_max
-          if preferred_operator_max == 'gte'
-            eligibility_error_message(:item_total_more_than_or_equal, amount: formatted_amount_max)
+        def ineligible_message
+          if preferred_operator == 'gte'
+            eligibility_error_message(:item_total_less_than, amount: formatted_amount)
           else
-            eligibility_error_message(:item_total_more_than, amount: formatted_amount_max)
+            eligibility_error_message(:item_total_less_than_or_equal, amount: formatted_amount)
           end
         end
-
-        def ineligible_message_min
-          if preferred_operator_min == 'gte'
-            eligibility_error_message(:item_total_less_than, amount: formatted_amount_min)
-          else
-            eligibility_error_message(:item_total_less_than_or_equal, amount: formatted_amount_min)
-          end
-        end
-
       end
     end
   end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -721,8 +721,6 @@ en:
         has_excluded_product: Your cart contains a product that prevents this coupon code from being applied.
         item_total_less_than: This coupon code can't be applied to orders less than %{amount}.
         item_total_less_than_or_equal: This coupon code can't be applied to orders less than or equal to %{amount}.
-        item_total_more_than: This coupon code can't be applied to orders higher than %{amount}.
-        item_total_more_than_or_equal: This coupon code can't be applied to orders higher than or equal to %{amount}.
         limit_once_per_user: This coupon code can only be used once per user.
         missing_product: This coupon code can't be applied because you don't have all of the necessary products in your cart.
         missing_taxon: You need to add a product from all applicable categories before applying this coupon code.
@@ -869,8 +867,6 @@ en:
       operators:
         gt: greater than
         gte: greater than or equal to
-        lt: less than
-        lte: less than or equal to
     items_cannot_be_shipped: We are unable to calculate shipping rates for the selected items.
     items_in_rmas: Items in Return Authorizations
     items_to_be_reimbursed: Items to be reimbursed

--- a/core/lib/spree/testing_support/factories/promotion_factory.rb
+++ b/core/lib/spree/testing_support/factories/promotion_factory.rb
@@ -47,10 +47,8 @@ FactoryGirl.define do
       after(:create) do |promotion, evaluator|
         rule = Spree::Promotion::Rules::ItemTotal.create!(
           promotion: promotion,
-          preferred_operator_min: 'gte',
-          preferred_operator_max: 'lte',
-          preferred_amount_min: evaluator.item_total_threshold_amount,
-          preferred_amount_max: evaluator.item_total_threshold_amount + 100
+          preferred_operator: 'gte',
+          preferred_amount: evaluator.item_total_threshold_amount
         )
         promotion.rules << rule
         promotion.save!

--- a/core/spec/models/spree/promotion/rules/item_total_spec.rb
+++ b/core/spec/models/spree/promotion/rules/item_total_spec.rb
@@ -4,278 +4,63 @@ describe Spree::Promotion::Rules::ItemTotal, :type => :model do
   let(:rule) { Spree::Promotion::Rules::ItemTotal.new }
   let(:order) { double(:order) }
 
-  before { rule.preferred_amount_min = 50 }
-  before { rule.preferred_amount_max = 60 }
+  before { rule.preferred_amount = 50 }
 
-  context "preferred operator_min set to gt and preferred operator_max set to lt" do
-    before do
-      rule.preferred_operator_min = 'gt'
-      rule.preferred_operator_max = 'lt'
+  context "preferred operator set to gt" do
+    before { rule.preferred_operator = 'gt' }
+
+    it "should be eligible when item total is greater than preferred amount" do
+      order.stub :item_total => 51
+      rule.should be_eligible(order)
     end
 
-    context "and item total is lower than prefered maximum amount" do
-
-      context "and item total is higher than prefered minimum amount" do
-        it "should be eligible" do
-          allow(order).to receive_messages item_total: 51
-          expect(rule).to be_eligible(order)
-        end
+    context "when item total is equal to preferred amount" do
+      before { order.stub item_total: 50 }
+      it "is not eligible" do
+        rule.should_not be_eligible(order)
       end
-
-      context "and item total is equal to the prefered minimum amount" do
-
-        before { allow(order).to receive_messages item_total: 50 }
-
-        it "should not be eligible" do
-          expect(rule).to_not be_eligible(order)
-        end
-
-        it "set an error message" do
-          rule.eligible?(order)
-          expect(rule.eligibility_errors.full_messages.first).
-            to eq "This coupon code can't be applied to orders less than or equal to $50.00."
-        end
-      end
-
-      context "and item total is lower to the prefered minimum amount" do
-        before { allow(order).to receive_messages item_total: 49 }
-
-        it "should not be eligible" do
-          expect(rule).to_not be_eligible(order)
-        end
-
-        it "set an error message" do
-          rule.eligible?(order)
-          expect(rule.eligibility_errors.full_messages.first).
-            to eq "This coupon code can't be applied to orders less than or equal to $50.00."
-        end
-      end
-    end
-
-    context "and item total is equal to the prefered maximum amount" do
-      before { allow(order).to receive_messages item_total: 60 }
-
-      it "should not be eligible" do
-        expect(rule).to_not be_eligible(order)
-      end
-
       it "set an error message" do
         rule.eligible?(order)
         expect(rule.eligibility_errors.full_messages.first).
-          to eq "This coupon code can't be applied to orders higher than $60.00."
+          to eq "This coupon code can't be applied to orders less than or equal to $50.00."
       end
     end
 
-    context "and item total is higher than the prefered maximum amount" do
-      before { allow(order).to receive_messages item_total: 61 }
-
-      it "should not be eligible" do
-        expect(rule).to_not be_eligible(order)
+    context "when item total is lower than preferred amount" do
+      before { order.stub item_total: 49 }
+      it "is not eligible" do
+        rule.should_not be_eligible(order)
       end
-
       it "set an error message" do
         rule.eligible?(order)
         expect(rule.eligibility_errors.full_messages.first).
-          to eq "This coupon code can't be applied to orders higher than $60.00."
-      end
-    end
-
-  end
-
-  context "preferred operator set to gt and preferred operator_max set to lte" do
-    before do
-      rule.preferred_operator_min = 'gt'
-      rule.preferred_operator_max = 'lte'
-    end
-
-    context "and item total is lower than prefered maximum amount" do
-
-      context "and item total is higher than prefered minimum amount" do
-        it "should be eligible" do
-          allow(order).to receive_messages item_total: 51
-          expect(rule).to be_eligible(order)
-        end
-      end
-
-      context "and item total is equal to the prefered minimum amount" do
-
-        before { allow(order).to receive_messages item_total: 50 }
-
-        it "should not be eligible" do
-          expect(rule).to_not be_eligible(order)
-        end
-
-        it "set an error message" do
-          rule.eligible?(order)
-          expect(rule.eligibility_errors.full_messages.first).
-            to eq "This coupon code can't be applied to orders less than or equal to $50.00."
-        end
-      end
-
-      context "and item total is lower to the prefered minimum amount" do
-        before { allow(order).to receive_messages item_total: 49 }
-
-        it "should not be eligible" do
-          expect(rule).to_not be_eligible(order)
-        end
-
-        it "set an error message" do
-          rule.eligible?(order)
-          expect(rule.eligibility_errors.full_messages.first).
-            to eq "This coupon code can't be applied to orders less than or equal to $50.00."
-        end
-      end
-    end
-
-    context "and item total is equal to the prefered maximum amount" do
-      before { allow(order).to receive_messages item_total: 60 }
-
-      it "should not be eligible" do
-        expect(rule).to be_eligible(order)
-      end
-    end
-
-    context "and item total is higher than the prefered maximum amount" do
-      before { allow(order).to receive_messages item_total: 61 }
-
-      it "should not be eligible" do
-        expect(rule).to_not be_eligible(order)
-      end
-
-      it "set an error message" do
-        rule.eligible?(order)
-        expect(rule.eligibility_errors.full_messages.first).
-          to eq "This coupon code can't be applied to orders higher than $60.00."
+          to eq "This coupon code can't be applied to orders less than or equal to $50.00."
       end
     end
   end
 
-  context "preferred operator set to gte and preferred operator_max set to lt" do
-    before do
-      rule.preferred_operator_min = 'gte'
-      rule.preferred_operator_max = 'lt'
+  context "preferred operator set to gte" do
+    before { rule.preferred_operator = 'gte' }
+
+    it "should be eligible when item total is greater than preferred amount" do
+      order.stub :item_total => 51
+      rule.should be_eligible(order)
     end
 
-    context "and item total is lower than prefered maximum amount" do
-
-      context "and item total is higher than prefered minimum amount" do
-        it "should be eligible" do
-          allow(order).to receive_messages item_total: 51
-          expect(rule).to be_eligible(order)
-        end
-      end
-
-      context "and item total is equal to the prefered minimum amount" do
-
-        before { allow(order).to receive_messages item_total: 50 }
-
-        it "should not be eligible" do
-          expect(rule).to be_eligible(order)
-        end
-      end
-
-      context "and item total is lower to the prefered minimum amount" do
-        before { allow(order).to receive_messages item_total: 49 }
-
-        it "should not be eligible" do
-          expect(rule).to_not be_eligible(order)
-        end
-
-        it "set an error message" do
-          rule.eligible?(order)
-          expect(rule.eligibility_errors.full_messages.first).
-            to eq "This coupon code can't be applied to orders less than $50.00."
-        end
-      end
+    it "should be eligible when item total is equal to preferred amount" do
+      order.stub :item_total => 50
+      rule.should be_eligible(order)
     end
 
-    context "and item total is equal to the prefered maximum amount" do
-      before { allow(order).to receive_messages item_total: 60 }
-
-      it "should not be eligible" do
-        expect(rule).to_not be_eligible(order)
+    context "when item total is lower than preferred amount" do
+      before { order.stub item_total: 49 }
+      it "is not eligible" do
+        rule.should_not be_eligible(order)
       end
-
       it "set an error message" do
         rule.eligible?(order)
         expect(rule.eligibility_errors.full_messages.first).
-          to eq "This coupon code can't be applied to orders higher than $60.00."
-      end
-    end
-
-    context "and item total is higher than the prefered maximum amount" do
-      before { allow(order).to receive_messages item_total: 61 }
-
-      it "should not be eligible" do
-        expect(rule).to_not be_eligible(order)
-      end
-
-      it "set an error message" do
-        rule.eligible?(order)
-        expect(rule.eligibility_errors.full_messages.first).
-          to eq "This coupon code can't be applied to orders higher than $60.00."
-      end
-    end
-
-  end
-
-  context "preferred operator set to gte and preferred operator_max set to lte" do
-    before do
-      rule.preferred_operator_min = 'gte'
-      rule.preferred_operator_max = 'lte'
-    end
-
-    context "and item total is lower than prefered maximum amount" do
-      context "and item total is higher than prefered minimum amount" do
-        it "should be eligible" do
-          allow(order).to receive_messages item_total: 51
-          expect(rule).to be_eligible(order)
-        end
-      end
-
-      context "and item total is equal to the prefered minimum amount" do
-
-        before { allow(order).to receive_messages item_total: 50 }
-
-        it "should not be eligible" do
-          expect(rule).to be_eligible(order)
-        end
-      end
-
-      context "and item total is lower to the prefered minimum amount" do
-        before { allow(order).to receive_messages item_total: 49 }
-
-        it "should not be eligible" do
-          expect(rule).to_not be_eligible(order)
-        end
-
-        it "set an error message" do
-          rule.eligible?(order)
-          expect(rule.eligibility_errors.full_messages.first).
-            to eq "This coupon code can't be applied to orders less than $50.00."
-        end
-      end
-    end
-
-    context "and item total is equal to the prefered maximum amount" do
-      before { allow(order).to receive_messages item_total: 60 }
-
-      it "should not be eligible" do
-        expect(rule).to be_eligible(order)
-      end
-    end
-
-    context "and item total is higher than the prefered maximum amount" do
-      before { allow(order).to receive_messages item_total: 61 }
-
-      it "should not be eligible" do
-        expect(rule).to_not be_eligible(order)
-      end
-
-      it "set an error message" do
-        rule.eligible?(order)
-        expect(rule.eligibility_errors.full_messages.first).
-          to eq "This coupon code can't be applied to orders higher than $60.00."
+          to eq "This coupon code can't be applied to orders less than $50.00."
       end
     end
   end

--- a/core/spec/models/spree/promotion_handler/cart_spec.rb
+++ b/core/spec/models/spree/promotion_handler/cart_spec.rb
@@ -44,7 +44,7 @@ module Spree
 
         context "promotion has item total rule" do
           let(:shirt) { create(:product) }
-          let!(:rule) { Promotion::Rules::ItemTotal.create(preferred_operator_min: 'gt', preferred_amount_min: 50, preferred_operator_max: 'lt', preferred_amount_max: 150, promotion: promotion) }
+          let!(:rule) { Promotion::Rules::ItemTotal.create(preferred_operator: 'gt', preferred_amount: 50, promotion: promotion) }
 
           before do
             # Makes the order eligible for this promotion
@@ -74,7 +74,7 @@ module Spree
 
         context "promotion has item total rule" do
           let(:shirt) { create(:product) }
-          let!(:rule) { Promotion::Rules::ItemTotal.create(preferred_operator_min: 'gt', preferred_amount_min: 50, preferred_operator_max: 'lt', preferred_amount_max: 150, promotion: promotion) }
+          let!(:rule) { Promotion::Rules::ItemTotal.create(preferred_operator: 'gt', preferred_amount: 50, promotion: promotion) }
 
           before do
             # Makes the order eligible for this promotion

--- a/frontend/spec/features/automatic_promotion_adjustments_spec.rb
+++ b/frontend/spec/features/automatic_promotion_adjustments_spec.rb
@@ -15,7 +15,7 @@ describe "Automatic promotions", :type => :feature, :js => true do
    calculator.preferred_amount = 10
 
    rule = Spree::Promotion::Rules::ItemTotal.create
-   rule.preferred_amount_min = 100
+   rule.preferred_amount = 100
    rule.save
 
    promotion.rules << rule

--- a/frontend/spec/features/coupon_code_spec.rb
+++ b/frontend/spec/features/coupon_code_spec.rb
@@ -112,7 +112,7 @@ describe "Coupon code promotions", type: :feature, js: true do
         before do
           rule = Spree::Promotion::Rules::ItemTotal.new
           rule.promotion = promotion
-          rule.preferred_amount_min = 100
+          rule.preferred_amount = 100
           rule.save
         end
 


### PR DESCRIPTION
As per #84

This was changed in 2.4 without any migration or plan to migrate existing promotions people had defined. I think reverting is the best option for now.