### PR TITLE
Add AdjustmentReason model

### DIFF
--- a/backend/app/controllers/spree/admin/adjustment_reasons_controller.rb
+++ b/backend/app/controllers/spree/admin/adjustment_reasons_controller.rb
@@ -1,0 +1,6 @@
+module Spree
+  module Admin
+    class AdjustmentReasonsController < ResourceController
+    end
+  end
+end

--- a/backend/app/controllers/spree/admin/adjustments_controller.rb
+++ b/backend/app/controllers/spree/admin/adjustments_controller.rb
@@ -12,6 +12,8 @@ module Spree
 
       before_action :find_adjustment, only: [:destroy, :edit, :update]
 
+      helper_method :reasons_for
+
       def index
         @adjustments = @order.all_adjustments.order("created_at ASC")
       end
@@ -33,6 +35,12 @@ module Spree
         parent.adjustments.build(order: parent)
       end
 
+      def reasons_for(adjustment)
+        [
+          AdjustmentReason.active.to_a,
+          @adjustment.adjustment_reason,
+        ].flatten.compact.uniq.sort_by { |r| r.name.downcase }
+      end
     end
   end
 end

--- a/backend/app/views/spree/admin/adjustment_reasons/edit.html.erb
+++ b/backend/app/views/spree/admin/adjustment_reasons/edit.html.erb
@@ -1,0 +1,16 @@
+<% content_for :page_title do %>
+  <%= Spree.t(:editing_adjustment_reason) %>
+<% end %>
+
+<% content_for :page_actions do %>
+  <li><%= link_to_with_icon 'arrow-left', Spree.t(:back_to_adjustment_reason_list), collection_url, :class => 'button' %></li>
+<% end %>
+
+<%= render :partial => 'spree/shared/error_messages', :locals => { :target => @object } %>
+
+<%= form_for [:admin, @adjustment_reason] do |f| %>
+  <fieldset class="no-border-top">
+    <%= render :partial => 'spree/admin/adjustment_reasons/shared/form', :locals => { :f => f } %>
+    <%= render :partial => 'spree/admin/shared/edit_resource_links' %>
+  </fieldset>
+<% end %>

--- a/backend/app/views/spree/admin/adjustment_reasons/index.html.erb
+++ b/backend/app/views/spree/admin/adjustment_reasons/index.html.erb
@@ -1,0 +1,50 @@
+<%= render partial: 'spree/admin/shared/configuration_menu' %>
+
+<% content_for :page_title do %>
+  <%= Spree.t(:adjustment_reasons) %>
+<% end %>
+
+<% content_for :page_actions do %>
+  <ul class="actions inline-menu">
+    <li>
+      <%= button_link_to Spree.t(:new_adjustment_reason), new_object_url, { icon: 'plus', id: 'admin_new_named_type' } %>
+    </li>
+  </ul>
+<% end %>
+
+<% if @adjustment_reasons.any? %>
+  <table class="index" id='listing_adjustment_reasons'>
+    <colgroup>
+      <col style="width: 65%" />
+      <col style="width: 20%" />
+      <col style="width: 15%" />
+    </colgroup>
+    <thead>
+      <tr data-hook="adjustment_reasons_header">
+        <th><%= Spree.t(:name) %></th>
+        <th><%= Spree.t(:state) %></th>
+        <th class="actions"></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @adjustment_reasons.each do |adjustment_reason| %>
+        <tr id="<%= spree_dom_id adjustment_reason %>" data-hook="adjustment_reason_row" class="<%= cycle('odd', 'even')%>">
+          <td class="align-center">
+            <%= adjustment_reason.name %>
+          </td>
+          <td class="align-center">
+            <%= Spree.t(adjustment_reason.active? ? :active : :inactive) %>
+          </td>
+          <td class="actions">
+            <%= link_to_edit adjustment_reason, no_text: true %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <div class="alpha twelve columns no-objects-found">
+    <%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: 'activerecord.models.spree/adjustment_reason')) %>,
+    <%= link_to Spree.t(:add_one), new_object_url %>!
+  </div>
+<% end %>

--- a/backend/app/views/spree/admin/adjustment_reasons/new.html.erb
+++ b/backend/app/views/spree/admin/adjustment_reasons/new.html.erb
@@ -1,0 +1,16 @@
+<% content_for :page_title do %>
+  <%= Spree.t(:new_adjustment_reason) %>
+<% end %>
+
+<% content_for :page_actions do %>
+  <li><%= link_to_with_icon 'arrow-left', Spree.t(:back_to_adjustment_reason_list), collection_url, :class => 'button' %></li>
+<% end %>
+
+<%= render :partial => 'spree/shared/error_messages', :locals => { :target => @object } %>
+
+<%= form_for [:admin, @adjustment_reason] do |f| %>
+  <fieldset class="no-border-top">
+    <%= render :partial => 'spree/admin/adjustment_reasons/shared/form', :locals => { :f => f } %>
+    <%= render :partial => 'spree/admin/shared/new_resource_links' %>
+  </fieldset>
+<% end %>

--- a/backend/app/views/spree/admin/adjustment_reasons/shared/_form.html.erb
+++ b/backend/app/views/spree/admin/adjustment_reasons/shared/_form.html.erb
@@ -1,0 +1,22 @@
+<div data-hook="admin_adjustment_reason_form_fields" class="row">
+  <div class="row">
+    <div class="alpha four columns">
+      <%= f.field_container :name do %>
+        <%= f.label :name, Spree.t(:name) %> <span class="required">*</span><br />
+        <%= f.text_field :name, :class => 'fullwidth' %>
+      <% end %>
+
+      <%= f.field_container :code do %>
+        <%= f.label :code, Spree.t(:code) %> <span class="required">*</span><br />
+        <%= f.text_field :code, :class => 'fullwidth' %>
+      <% end %>
+
+      <div class="checkbox">
+        <label>
+          <%= f.check_box :active %>
+          <%= Spree.t(:active) %>
+        </label>
+      </div>
+    </div>
+  </div>
+</div>

--- a/backend/app/views/spree/admin/adjustments/_form.html.erb
+++ b/backend/app/views/spree/admin/adjustments/_form.html.erb
@@ -6,11 +6,19 @@
       <%= f.error_message_on :amount %>
     <% end %>
   </div>
-  <div class="omega nine columns">
+
+  <div class="six columns">
     <%= f.field_container :label do %>
       <%= f.label :label, raw(Spree.t(:description) + content_tag(:span, " *", :class => "required")) %>
       <%= text_field :adjustment, :label, :class => 'fullwidth' %>
       <%= f.error_message_on :label %>
+    <% end %>
+  </div>
+
+  <div class="omega three columns">
+    <%= f.field_container :label do %>
+      <%= f.label :adjustment_reason_id, Spree.t(:reason) %><br/>
+      <%= f.collection_select(:adjustment_reason_id, reasons_for(@adjustment), :id, :name, {include_blank: true}, {"data-placeholder" => Spree.t(:select_a_reason), class: 'select2 fullwidth'}) %>
     <% end %>
   </div>
 </div>

--- a/backend/app/views/spree/admin/shared/_configuration_menu.html.erb
+++ b/backend/app/views/spree/admin/shared/_configuration_menu.html.erb
@@ -19,6 +19,7 @@
       <%= configurations_sidebar_menu_item Spree.t(:shipping_categories), admin_shipping_categories_path %>
       <%= configurations_sidebar_menu_item Spree.t(:stock_locations), spree.admin_stock_locations_path %>
       <%= configurations_sidebar_menu_item Spree.t(:analytics_trackers), admin_trackers_path %>
+      <%= configurations_sidebar_menu_item Spree.t(:adjustment_reasons), admin_adjustment_reasons_path %>
       <%= configurations_sidebar_menu_item Spree.t(:refund_reasons), admin_refund_reasons_path %>
       <%= configurations_sidebar_menu_item Spree.t(:reimbursement_types), admin_reimbursement_types_path %>
       <%= configurations_sidebar_menu_item Spree.t(:return_reasons), admin_return_reasons_path %>

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -152,6 +152,7 @@ Spree::Core::Engine.add_routes do
     end
 
     resources :reimbursement_types, only: [:index]
+    resources :adjustment_reasons, except: [:show, :destroy]
     resources :refund_reasons, except: [:show, :destroy]
     resources :return_reasons, except: [:show, :destroy]
 

--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -27,6 +27,7 @@ module Spree
     belongs_to :source, polymorphic: true
     belongs_to :order, class_name: "Spree::Order"
     belongs_to :promotion_code, :class_name => 'Spree::PromotionCode'
+    belongs_to :adjustment_reason, class_name: 'Spree::AdjustmentReason', inverse_of: :adjustments
 
     validates :adjustable, presence: true
     validates :order, presence: true

--- a/core/app/models/spree/adjustment_reason.rb
+++ b/core/app/models/spree/adjustment_reason.rb
@@ -1,0 +1,12 @@
+module Spree
+  class AdjustmentReason < ActiveRecord::Base
+    has_many :adjustments, inverse_of: :adjustment_reason
+
+    validates :name, presence: true
+    validates :name, uniqueness: {case_sensitive: false}
+    validates :code, presence: true
+    validates :code, uniqueness: {case_sensitive: false}
+
+    scope :active, -> { where(active: true) }
+  end
+end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -150,6 +150,9 @@ en:
       spree/address:
         one: Address
         other: Addresses
+      spree/adjustment_reason:
+        one: Adjustment Reason
+        other: Adjustment Reasons
       spree/country:
         one: Country
         other: Countries
@@ -415,6 +418,7 @@ en:
     adjustable: Adjustable
     adjustment: Adjustment
     adjustment_amount: Amount
+    adjustment_reasons: Adjustment Reasons
     adjustment_successfully_closed: Adjustment has been successfully closed!
     adjustment_successfully_opened: Adjustment has been successfully opened!
     adjustment_total: Adjustment Total
@@ -506,6 +510,7 @@ en:
     back_end: Backend
     backordered: Backordered
     back_to_adjustments_list: Back To Adjustments List
+    back_to_adjustment_reason_list: Back To Adjustment Reason List
     back_to_customer_return: Back To Customer Return
     back_to_customer_return_list: Back To Customer Return List
     back_to_images_list: Back To Images List
@@ -693,6 +698,7 @@ en:
     download_promotion_code_list: Download Code List
     edit: Edit
     editing_country: Editing Country
+    editing_adjustment_reason: Editing Adjustment Reason
     editing_option_type: Editing Option Type
     editing_payment_method: Editing Payment Method
     editing_product: Editing Product
@@ -929,6 +935,7 @@ en:
     negative_movement_absent_item: Cannot create negative movement for absent stock item.
     new: New
     new_adjustment: New Adjustment
+    new_adjustment_reason: New Adjustment Reason
     new_customer: New Customer
     new_customer_return: New Customer Return
     new_country: New Country
@@ -1292,6 +1299,7 @@ en:
     security_settings: Security Settings
     select: Select
     select_from_prototype: Select From Prototype
+    select_a_reason: Select a reason
     select_a_stock_location: Select a stock location
     select_stock: Select stock
     selected_quantity_not_available: ! 'selected of %{item} is not available.'

--- a/core/db/migrate/20150619160613_create_adjustment_reason.rb
+++ b/core/db/migrate/20150619160613_create_adjustment_reason.rb
@@ -1,0 +1,18 @@
+class CreateAdjustmentReason < ActiveRecord::Migration
+  def change
+    create_table :spree_adjustment_reasons do |t|
+      t.string   "name"
+      t.string   "code"
+      t.boolean  "active",     default: true
+
+      t.timestamps
+    end
+
+    add_index :spree_adjustment_reasons, :code
+    add_index :spree_adjustment_reasons, :active
+
+    change_table :spree_adjustments do |t|
+      t.references :adjustment_reason
+    end
+  end
+end

--- a/core/lib/spree/testing_support/factories/adjustment_reason_factory.rb
+++ b/core/lib/spree/testing_support/factories/adjustment_reason_factory.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :adjustment_reason, class: Spree::AdjustmentReason do
+    sequence(:name) { |n| "Refund for return ##{n}" }
+    sequence(:code) { |n| "Code #{n}"}
+  end
+end

--- a/core/spec/models/spree/adjustment_reason_spec.rb
+++ b/core/spec/models/spree/adjustment_reason_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe Spree::AdjustmentReason do
+
+  describe 'creation' do
+    it 'is successful' do
+      expect {
+        create(:adjustment_reason)
+      }.to_not raise_error
+    end
+  end
+
+end


### PR DESCRIPTION
(already :+1:'d in https://github.com/bonobos/spree/pull/419)

Similar to RefundReason.

Allow assigning adjustment reason codes when creating admin
adjustments.

(cherry picked from commit b5f3d336921e0a62d9c147d7f12227d105b7867b in
bonobos/spree)