### PR TITLE
Remove accidental table cell

### DIFF
--- a/backend/app/views/spree/admin/customer_returns/_return_item_decision.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/_return_item_decision.html.erb
@@ -34,7 +34,6 @@
         </td>
         <td class="align-center">
           <%= return_item.exchange_variant.try(:exchange_name) %>
-        <td>
         </td>
         <td class="align-center">
           <%= return_item.acceptance_status_errors %>


### PR DESCRIPTION
This was adding an extra empty cell that was misaligning all the columns.