### PR TITLE
Fix user_methods_spec under MySQL

### DIFF
--- a/core/spec/models/spree/concerns/user_methods_spec.rb
+++ b/core/spec/models/spree/concerns/user_methods_spec.rb
@@ -26,7 +26,6 @@ describe Spree::UserMethods do
       let(:last_incomplete_order) { create :order, user: test_user }
 
       before do
-        create(:order, user: test_user)
         create(:order, user: test_user, created_at: 1.day.ago)
         create(:order, user: create(:user))
         last_incomplete_order


### PR DESCRIPTION
MySQL's timestamp precision strikes again!

Here we have two orders with the same created_at timestamp. Having
another order with a created_at in the past doesn't provide any value in
testing, so I have removed it.