### PR TITLE
API Authorization Audit

### DIFF
--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -43,13 +43,12 @@ module Spree
       end
 
 
-      protected
+      private
 
       def is_admin?
         current_api_user && current_api_user.has_spree_role?("admin")
       end
 
-      private
       # users should be able to set price when importing orders via api
       def permitted_line_item_attributes
         if is_admin?

--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -42,12 +42,7 @@ module Spree
         end.with_indifferent_access
       end
 
-
       private
-
-      def is_admin?
-        current_api_user && current_api_user.has_spree_role?("admin")
-      end
 
       # users should be able to set price when importing orders via api
       def permitted_line_item_attributes

--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -147,7 +147,7 @@ module Spree
       end
 
       def product_scope
-        if is_admin?
+        if can?(:admin, Spree::Product)
           scope = Product.with_deleted.accessible_by(current_ability, :read).includes(*product_includes)
 
           unless params[:show_deleted]

--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -42,14 +42,6 @@ module Spree
         end.with_indifferent_access
       end
 
-      # users should be able to set price when importing orders via api
-      def permitted_line_item_attributes
-        if is_admin?
-          super + admin_line_item_attributes
-        else
-          super
-        end
-      end
 
       protected
 
@@ -58,6 +50,14 @@ module Spree
       end
 
       private
+      # users should be able to set price when importing orders via api
+      def permitted_line_item_attributes
+        if is_admin?
+          super + admin_line_item_attributes
+        else
+          super
+        end
+      end
 
       def set_content_type
         content_type = case params[:format]

--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -51,7 +51,7 @@ module Spree
 
       # users should be able to set price when importing orders via api
       def permitted_line_item_attributes
-        if is_admin?
+        if can?(:admin, Spree::LineItem)
           super + admin_line_item_attributes
         else
           super

--- a/api/app/controllers/spree/api/checkouts_controller.rb
+++ b/api/app/controllers/spree/api/checkouts_controller.rb
@@ -52,7 +52,7 @@ module Spree
         authorize! :update, @order, order_token
 
         if @order.update_from_params(params, permitted_checkout_attributes, request.headers.env)
-          if current_api_user.has_spree_role?('admin') && user_id.present?
+          if can?(:admin, @order) && user_id.present?
             @order.associate_user!(Spree.user_class.find(user_id))
           end
 

--- a/api/app/controllers/spree/api/countries_controller.rb
+++ b/api/app/controllers/spree/api/countries_controller.rb
@@ -1,7 +1,6 @@
 module Spree
   module Api
     class CountriesController < Spree::Api::BaseController
-      skip_before_action :check_for_user_or_api_key
       skip_before_action :authenticate_user
 
       def index

--- a/api/app/controllers/spree/api/orders_controller.rb
+++ b/api/app/controllers/spree/api/orders_controller.rb
@@ -110,46 +110,47 @@ module Spree
       end
 
       private
-        def order_params
-          if params[:order]
-            normalize_params
-            params.require(:order).permit(permitted_order_attributes)
-          else
-            {}
-          end
-        end
 
-        def normalize_params
-          params[:order][:payments_attributes] = params[:order].delete(:payments) if params[:order][:payments]
-          params[:order][:shipments_attributes] = params[:order].delete(:shipments) if params[:order][:shipments]
-          params[:order][:line_items_attributes] = params[:order].delete(:line_items) if params[:order][:line_items]
-          params[:order][:ship_address_attributes] = params[:order].delete(:ship_address) if params[:order][:ship_address].present?
-          params[:order][:bill_address_attributes] = params[:order].delete(:bill_address) if params[:order][:bill_address].present?
+      def order_params
+        if params[:order]
+          normalize_params
+          params.require(:order).permit(permitted_order_attributes)
+        else
+          {}
         end
+      end
 
-        def permitted_order_attributes
-          if is_admin?
-            super + admin_order_attributes
-          else
-            super
-          end
-        end
+      def normalize_params
+        params[:order][:payments_attributes] = params[:order].delete(:payments) if params[:order][:payments]
+        params[:order][:shipments_attributes] = params[:order].delete(:shipments) if params[:order][:shipments]
+        params[:order][:line_items_attributes] = params[:order].delete(:line_items) if params[:order][:line_items]
+        params[:order][:ship_address_attributes] = params[:order].delete(:ship_address) if params[:order][:ship_address].present?
+        params[:order][:bill_address_attributes] = params[:order].delete(:bill_address) if params[:order][:bill_address].present?
+      end
 
-        def permitted_shipment_attributes
-          if is_admin?
-            super + admin_shipment_attributes
-          else
-            super
-          end
+      def permitted_order_attributes
+        if is_admin?
+          super + admin_order_attributes
+        else
+          super
         end
+      end
 
-        def find_order(lock = false)
-          @order = Spree::Order.find_by!(number: params[:id])
+      def permitted_shipment_attributes
+        if is_admin?
+          super + admin_shipment_attributes
+        else
+          super
         end
+      end
 
-        def order_id
-          super || params[:id]
-        end
+      def find_order(lock = false)
+        @order = Spree::Order.find_by!(number: params[:id])
+      end
+
+      def order_id
+        super || params[:id]
+      end
     end
   end
 end

--- a/api/app/controllers/spree/api/orders_controller.rb
+++ b/api/app/controllers/spree/api/orders_controller.rb
@@ -29,13 +29,14 @@ module Spree
 
       def create
         authorize! :create, Order
-        order_user = if @current_user_roles.include?('admin') && order_params[:user_id]
+
+        order_user = if order_params[:user_id]
           Spree.user_class.find(order_params[:user_id])
         else
           current_api_user
         end
 
-        import_params = if @current_user_roles.include?("admin")
+        import_params = if can?(:admin, Spree::Order)
           params[:order].present? ? params[:order].permit! : {}
         else
           order_params

--- a/api/app/controllers/spree/api/orders_controller.rb
+++ b/api/app/controllers/spree/api/orders_controller.rb
@@ -9,9 +9,7 @@ module Spree
 
       skip_before_action :authenticate_user, only: :apply_coupon_code
 
-      before_action :find_order, except: [:create, :mine, :current, :index, :update]
-
-      before_filter :find_order, except: [:create, :mine, :current, :index]
+      before_action :find_order, except: [:create, :mine, :current, :index]
       around_filter :lock_order, except: [:create, :mine, :current, :index]
 
       # Dynamically defines our stores checkout steps to ensure we check authorization on each step.

--- a/api/app/controllers/spree/api/orders_controller.rb
+++ b/api/app/controllers/spree/api/orders_controller.rb
@@ -125,7 +125,7 @@ module Spree
       end
 
       def permitted_shipment_attributes
-        if is_admin?
+        if can?(:admin, Spree::Shipment)
           super + admin_shipment_attributes
         else
           super

--- a/api/app/controllers/spree/api/orders_controller.rb
+++ b/api/app/controllers/spree/api/orders_controller.rb
@@ -65,15 +65,7 @@ module Spree
       def update
         authorize! :update, @order, order_token
 
-        result = if request.patch?
-          # This will update the order without a checkout reset.
-          @order.update_attributes(order_params)
-        else
-          # This will reset checkout back to address and delete all shipments.
-          @order.contents.update_cart(order_params)
-        end
-
-        if result
+        if @order.contents.update_cart(order_params)
           user_id = params[:order][:user_id]
           if current_api_user.has_spree_role?('admin') && user_id
             @order.associate_user!(Spree.user_class.find(user_id))

--- a/api/app/controllers/spree/api/orders_controller.rb
+++ b/api/app/controllers/spree/api/orders_controller.rb
@@ -7,7 +7,6 @@ module Spree
       class_attribute :admin_order_attributes
       self.admin_order_attributes = [:import, :number, :completed_at, :locked_at, :channel]
 
-      skip_before_action :check_for_user_or_api_key, only: :apply_coupon_code
       skip_before_action :authenticate_user, only: :apply_coupon_code
 
       before_action :find_order, except: [:create, :mine, :current, :index, :update]

--- a/api/app/controllers/spree/api/states_controller.rb
+++ b/api/app/controllers/spree/api/states_controller.rb
@@ -1,8 +1,6 @@
 module Spree
   module Api
     class StatesController < Spree::Api::BaseController
-      skip_before_action :set_expiry
-      skip_before_action :check_for_user_or_api_key
       skip_before_action :authenticate_user
 
       def index

--- a/api/spec/controllers/spree/api/orders_controller_spec.rb
+++ b/api/spec/controllers/spree/api/orders_controller_spec.rb
@@ -27,28 +27,6 @@ module Spree
       stub_authentication!
     end
 
-    describe 'PATCH #update' do
-      subject { api_patch :update, id: order.to_param, order: { email: "foo@bar.com" } }
-
-      before do
-        allow_any_instance_of(Spree::Order).to receive_messages :user => current_api_user
-      end
-
-      it 'should be ok' do
-        expect(subject).to be_ok
-      end
-
-      it 'should not invoke OrderContents#update_cart' do
-        expect_any_instance_of(Spree::OrderContents).to_not receive(:update_cart)
-        subject
-      end
-
-      it 'should update the email' do
-        subject
-        expect(order.reload.email).to eq('foo@bar.com')
-      end
-    end
-
     it "cannot view all orders" do
       api_get :index
       assert_unauthorized!

--- a/api/spec/controllers/spree/api/orders_controller_spec.rb
+++ b/api/spec/controllers/spree/api/orders_controller_spec.rb
@@ -359,16 +359,6 @@ module Spree
 
       before { allow_any_instance_of(Order).to receive_messages user: current_api_user }
 
-      context "line_items hash not present in request" do
-        it "responds successfully" do
-          api_put :update, :id => order.to_param, :order => {
-            :email => "hublock@spreecommerce.com"
-          }
-
-          expect(response).to be_success
-        end
-      end
-
       it "updates quantities of existing line items" do
         api_put :update, :id => order.to_param, :order => {
           :line_items => {

--- a/api/spec/support/controller_hacks.rb
+++ b/api/spec/support/controller_hacks.rb
@@ -19,10 +19,6 @@ module ControllerHacks
     api_process(action, params, session, flash, "PUT")
   end
 
-  def api_patch(action, params={}, session=nil, flash=nil)
-    api_process(action, params, session, flash, "PATCH")
-  end
-
   def api_delete(action, params={}, session=nil, flash=nil)
     api_process(action, params, session, flash, "DELETE")
   end


### PR DESCRIPTION
This had to be done to remove the explicit has_spree_role? checks we had littered through the API. 

Done to ensure conventions established in #136 hold true for the API as well.

Most of this should be pretty straight forward, given that having the admin role is a blanket manage everything permission, we explicitly check for the admin permission on records of interest. 

This follows the convention in https://github.com/solidusio/solidus/blob/master/backend/app/controllers/spree/admin/base_controller.rb#L22-L23 with the expectation that authorization is also performed for the action (e.g. `:create`, or `:update`)

Also includes minor cleanup.