### PR TITLE
Replace broken Spree.t erb from JS

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/shipments.js.erb
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js.erb
@@ -132,7 +132,7 @@ $(document).ready(function () {
 
       var show = link.parents('tbody').find('tr.show-tracking');
       show.toggle();
-      show.find('.tracking-value').html($("<strong>").html("<%= Spree.t(:tracking) %>: ")).append(data.tracking);
+      show.find('.tracking-value').html($("<strong>").html(Spree.translations.tracking + ": ")).append(data.tracking);
     });
   });
 });

--- a/backend/app/views/spree/admin/shared/_translations.html.erb
+++ b/backend/app/views/spree/admin/shared/_translations.html.erb
@@ -37,6 +37,7 @@
     :sku                          => Spree.t(:sku),
     :type_to_search               => Spree.t(:type_to_search),
     :taxon_placeholder            => Spree.t(:taxon_placeholder),
+    :tracking                     => Spree.t(:tracking),
     :variant_placeholder          => Spree.t(:variant_placeholder),
     :value                        => Spree.t(:value),
     :currency_separator           => I18n.t('number.currency.format.separator'),

--- a/backend/spec/features/admin/locale_spec.rb
+++ b/backend/spec/features/admin/locale_spec.rb
@@ -25,7 +25,6 @@ describe "setting locale", :type => :feature do
 
   it "should be in french" do
     visit spree.admin_path
-    click_link "Ordres"
     expect(page).to have_content("Ordres")
   end
 end


### PR DESCRIPTION
I was looking at this failure, https://circleci.com/gh/solidusio/solidus/223, which has the JS erroring on every page of the admin. Weird error.

Turns out, this is because of `<%= Spree.t(:tracking) %>:` being used in `shipments.js.erb`, which will be a missing translation (and thus syntax error) if locale_spec is first spec run which compiles JS. This was also wrong because it would only use whatever locale the JS was compiled with, no change as the locale did.