### PR TITLE
Redirect to the orders path by default.

### DIFF
--- a/backend/app/controllers/spree/admin/root_controller.rb
+++ b/backend/app/controllers/spree/admin/root_controller.rb
@@ -10,7 +10,11 @@ module Spree
       protected
 
       def admin_root_redirect_path
-        spree.home_admin_dashboards_path
+        if can?(:display, Spree::Order) && can?(:admin, Spree::Order)
+          spree.admin_orders_path
+        else
+          spree.home_admin_dashboards_path
+        end
       end
     end
   end

--- a/backend/spec/controllers/spree/admin/root_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/root_controller_spec.rb
@@ -1,35 +1,29 @@
 require 'spec_helper'
 
 describe Spree::Admin::RootController do
-
-  context "unauthorized request" do
-
-    before :each do
+  describe "GET index" do
+    before do
       Spree::Admin::RootController.any_instance.stub(:spree_current_user).and_return(nil)
     end
 
-    it "redirects to orders path by default" do
-      get :index
+    subject { get :index }
 
-      expect(response).to redirect_to '/admin/dashboards/home'
+    context "when a user can admin and display spree orders" do
+      before do
+        allow_any_instance_of(Spree::Ability).to receive(:can?).
+          with(:admin, Spree::Order).
+          and_return(true)
+
+        allow_any_instance_of(Spree::Ability).to receive(:can?).
+          with(:display, Spree::Order).
+          and_return(true)
+      end
+
+      it { should redirect_to(spree.admin_orders_path) }
     end
-  end
 
-  context "authorized request" do
-    stub_authorization!
-
-    it "redirects to orders path by default" do
-      get :index
-
-      expect(response).to redirect_to '/admin/dashboards/home'
-    end
-
-    it "redirects to wherever admin_root_redirects_path tells it to" do
-      Spree::Admin::RootController.any_instance.stub(:admin_root_redirect_path).and_return('/grooot')
-
-      get :index
-
-      expect(response).to redirect_to '/grooot'
+    context "when a user cannot admin and display spree orders" do
+      it { should redirect_to(spree.home_admin_dashboards_path) }
     end
   end
 end


### PR DESCRIPTION
If the user can display and administrate orders, show them to the orders
path. Otherwise send them to the dashboard.