### PR TITLE
Clean up some deprecation warnings in core.

### DIFF
--- a/backend/spec/features/admin/orders/new_order_spec.rb
+++ b/backend/spec/features/admin/orders/new_order_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe "New Order", :type => :feature do
   let!(:product) { create(:product_in_stock) }
   let!(:state) { create(:state) }
+  let!(:store) { create(:store) }
   let!(:user) { create(:user, ship_address: create(:address), bill_address: create(:address)) }
   let!(:payment_method) { create(:check_payment_method) }
   let!(:shipping_method) { create(:shipping_method, cost: 0.0) }

--- a/core/app/mailers/spree/carton_mailer.rb
+++ b/core/app/mailers/spree/carton_mailer.rb
@@ -6,7 +6,7 @@ module Spree
       @carton = Spree::Carton.find(carton_id)
       subject = (resend ? "[#{Spree.t(:resend).upcase}] " : '')
       subject += "#{Spree::Store.current.name} #{Spree.t('shipment_mailer.shipped_email.subject')} ##{@carton.order_numbers.join(', ')}"
-      mail(to: @carton.order_emails, from: from_address, subject: subject)
+      mail(to: @carton.order_emails, from: from_address(Spree::Store.current), subject: subject)
     end
   end
 end

--- a/core/app/mailers/spree/reimbursement_mailer.rb
+++ b/core/app/mailers/spree/reimbursement_mailer.rb
@@ -2,9 +2,10 @@ module Spree
   class ReimbursementMailer < BaseMailer
       def reimbursement_email(reimbursement, resend = false)
         @reimbursement = reimbursement.respond_to?(:id) ? reimbursement : Spree::Reimbursement.find(reimbursement)
+        store = @reimbursement.order.store
         subject = (resend ? "[#{Spree.t(:resend).upcase}] " : '')
-        subject += "#{Spree::Store.current.name} #{Spree.t('reimbursement_mailer.reimbursement_email.subject')} ##{@reimbursement.order.number}"
-        mail(to: @reimbursement.order.email, from: from_address, subject: subject)
+        subject += "#{store.name} #{Spree.t('reimbursement_mailer.reimbursement_email.subject')} ##{@reimbursement.order.number}"
+        mail(to: @reimbursement.order.email, from: from_address(store), subject: subject)
       end
   end
 end

--- a/core/app/mailers/spree/test_mailer.rb
+++ b/core/app/mailers/spree/test_mailer.rb
@@ -2,7 +2,7 @@ module Spree
   class TestMailer < BaseMailer
     def test_email(email)
       subject = "#{Spree::Store.current.name} #{Spree.t('test_mailer.test_email.subject')}"
-      mail(to: email, from: from_address, subject: subject)
+      mail(to: email, from: from_address(Spree::Store.current), subject: subject)
     end
   end
 end

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -298,7 +298,7 @@ module Spree
             if self.payments.from_credit_card.count == 0 && self.user && self.user.default_credit_card.try(:valid?)
               cc = self.user.default_credit_card
               self.payments.create!(payment_method_id: cc.payment_method_id, source: cc)
-              self.bill_address ||= self.user.bill_address.try!(:clone) if self.user.bill_address.try!(:valid?)
+              self.bill_address ||= self.user.bill_address.try!(:dup) if self.user.bill_address.try!(:valid?)
             end
           end
 

--- a/core/app/models/spree/order_cancellations.rb
+++ b/core/app/models/spree/order_cancellations.rb
@@ -29,7 +29,7 @@ class Spree::OrderCancellations
         end
 
         update_shipped_shipments(inventory_units)
-        Spree::OrderMailer.inventory_cancellation_email(@order, inventory_units).deliver if Spree::OrderCancellations.send_cancellation_mailer
+        Spree::OrderMailer.inventory_cancellation_email(@order, inventory_units.to_a).deliver_later if Spree::OrderCancellations.send_cancellation_mailer
       end
 
       @order.update!

--- a/core/app/models/spree/promotion_rule.rb
+++ b/core/app/models/spree/promotion_rule.rb
@@ -13,11 +13,11 @@ module Spree
     end
 
     def applicable?(promotable)
-      raise 'applicable? should be implemented in a sub-class of Spree::PromotionRule'
+      raise NotImplementedError, "applicable? should be implemented in a sub-class of Spree::PromotionRule"
     end
 
     def eligible?(promotable, options = {})
-      raise 'eligible? should be implemented in a sub-class of Spree::PromotionRule'
+      raise NotImplementedError, "eligible? should be implemented in a sub-class of Spree::PromotionRule"
     end
 
     # This states if a promotion can be applied to the specified line item

--- a/core/db/migrate/20150619160613_create_adjustment_reason.rb
+++ b/core/db/migrate/20150619160613_create_adjustment_reason.rb
@@ -5,7 +5,7 @@ class CreateAdjustmentReason < ActiveRecord::Migration
       t.string   "code"
       t.boolean  "active",     default: true
 
-      t.timestamps
+      t.timestamps null: true
     end
 
     add_index :spree_adjustment_reasons, :code

--- a/core/spec/lib/i18n_spec.rb
+++ b/core/spec/lib/i18n_spec.rb
@@ -34,11 +34,11 @@ describe "i18n" do
   it "raise error without any context when using a path" do
     expect {
       Spree.normal_t('.legacy_translation')
-    }.to raise_error
+    }.to raise_error RuntimeError
 
     expect {
       Spree.translate('.legacy_translation')
-    }.to raise_error
+    }.to raise_error RuntimeError
   end
 
   it "prepends a string scope" do

--- a/core/spec/lib/spree/core/importer/order_spec.rb
+++ b/core/spec/lib/spree/core/importer/order_spec.rb
@@ -228,7 +228,7 @@ module Spree
           hash = { sku: variant.sku }
           expect {
             Importer::Order.ensure_variant_id_from_params(hash)
-          }.to raise_error
+          }.to raise_error ActiveRecord::RecordNotFound
         end
       end
 
@@ -297,7 +297,7 @@ module Spree
           params[:shipments_attributes][0][:stock_location] = "doesnt exist"
           expect {
             order = Importer::Order.import(user,params)
-          }.to raise_error
+          }.to raise_error ActiveRecord::RecordNotFound
         end
 
         context 'when completed_at and shipped_at present' do
@@ -421,7 +421,7 @@ module Spree
           params = { :payments_attributes => [{ payment_method: "XXX" }] }
           count = Order.count
 
-          expect { order = Importer::Order.import(user,params) }.to raise_error
+          expect { order = Importer::Order.import(user,params) }.to raise_error ActiveRecord::RecordNotFound
           expect(Order.count).to eq count
         end
       end

--- a/core/spec/lib/tasks/exchanges_spec.rb
+++ b/core/spec/lib/tasks/exchanges_spec.rb
@@ -147,9 +147,8 @@ describe "exchanges:charge_unreturned_items" do
       end
 
       it "associates the store of the original order with the exchange order" do
-        allow_any_instance_of(Spree::Order).to receive(:store_id).and_return(123)
-
-        expect(Spree::Order).to receive(:create!).once.with(hash_including({store_id: 123})) { |attrs| Spree::Order.new(attrs.except(:store_id)).tap(&:save!) }
+        store = order.store
+        expect(Spree::Order).to receive(:create!).once.with(hash_including({store_id: store.id})).and_call_original
         subject.invoke
       end
 

--- a/core/spec/mailers/carton_mailer_spec.rb
+++ b/core/spec/mailers/carton_mailer_spec.rb
@@ -7,13 +7,6 @@ describe Spree::CartonMailer do
 
   let(:carton) { create(:carton) }
 
-  context ":from not set explicitly" do
-    it "falls back to spree config" do
-      message = Spree::CartonMailer.shipped_email(carton.id)
-      message.from.should == [Spree::Config[:mails_from]]
-    end
-  end
-
   # Regression test for #2196
   it "doesn't include out of stock in the email body" do
     shipment_email = Spree::CartonMailer.shipped_email(carton.id)

--- a/core/spec/mailers/order_mailer_spec.rb
+++ b/core/spec/mailers/order_mailer_spec.rb
@@ -10,28 +10,17 @@ describe Spree::OrderMailer, :type => :mailer do
     product = stub_model(Spree::Product, :name => %Q{The "BEST" product})
     variant = stub_model(Spree::Variant, :product => product)
     price = stub_model(Spree::Price, :variant => variant, :amount => 5.00)
+    store = FactoryGirl.build :store, mail_from_address: "store@example.com"
     line_item = stub_model(Spree::LineItem, :variant => variant, :order => order, :quantity => 1, :price => 4.99)
     allow(variant).to receive_messages(:default_price => price)
     allow(order).to receive_messages(:line_items => [line_item])
+    allow(order).to receive(:store).and_return(store)
     order
   end
 
-  context ":from not set explicitly" do
-    it "falls back to spree config" do
-      message = Spree::OrderMailer.confirm_email(order)
-      expect(message.from).to eq([Spree::Config[:mails_from]])
-    end
-  end
-
-  context "when order has a store" do
-    before do
-      store = FactoryGirl.build :store, mail_from_address: "store@example.com"
-      allow(order).to receive(:store).and_return(store)
-    end
-    it "uses the order's store for the from address" do
-      message = Spree::OrderMailer.confirm_email(order)
-      expect(message.from).to eq ["store@example.com"]
-    end
+  it "uses the order's store for the from address" do
+    message = Spree::OrderMailer.confirm_email(order)
+    expect(message.from).to eq ["store@example.com"]
   end
 
   it "doesn't aggressively escape double quotes in confirmation body" do

--- a/core/spec/mailers/reimbursement_mailer_spec.rb
+++ b/core/spec/mailers/reimbursement_mailer_spec.rb
@@ -7,13 +7,6 @@ describe Spree::ReimbursementMailer, :type => :mailer do
 
   let(:reimbursement) { create(:reimbursement) }
 
-  context ":from not set explicitly" do
-    it "falls back to spree config" do
-      message = Spree::ReimbursementMailer.reimbursement_email(reimbursement)
-      expect(message.from).to eq [Spree::Config[:mails_from]]
-    end
-  end
-
   it "accepts a reimbursement id as an alternative to a Reimbursement object" do
     expect(Spree::Reimbursement).to receive(:find).with(reimbursement.id).and_return(reimbursement)
 

--- a/core/spec/mailers/test_mailer_spec.rb
+++ b/core/spec/mailers/test_mailer_spec.rb
@@ -7,13 +7,6 @@ describe Spree::TestMailer, :type => :mailer do
 
   let(:user) { create(:user) }
 
-  context ":from not set explicitly" do
-    it "falls back to spree config" do
-      message = Spree::TestMailer.test_email('test@example.com')
-      expect(message.from).to eq([Spree::Config[:mails_from]])
-    end
-  end
-
   it "confirm_email accepts a user id as an alternative to a User object" do
     expect {
       test_email = Spree::TestMailer.test_email('test@example.com')

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -171,7 +171,7 @@ describe Spree::Order, :type => :model do
         let(:ship_address) { nil }
 
         it "does not transition without a ship address" do
-          expect { order.next! }.to raise_error
+          expect { order.next! }.to raise_error StateMachines::InvalidTransition
         end
       end
 
@@ -850,7 +850,7 @@ describe Spree::Order, :type => :model do
 
         expect {
           order.update_from_params(params, permitted_params)
-        }.to raise_error
+        }.to raise_error Spree::Core::GatewayError
       end
     end
 

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -420,6 +420,7 @@ describe Spree::Order, :type => :model do
       context "without confirmation required" do
         before do
           order.email = "spree@example.com"
+          order.store = FactoryGirl.build(:store)
           allow(order).to receive_messages :payment_required? => true
           order.payments << FactoryGirl.create(:payment, state: payment_state, order: order)
         end
@@ -547,6 +548,7 @@ describe Spree::Order, :type => :model do
       context 'when the line items are not available' do
         before do
           order.line_items << FactoryGirl.create(:line_item)
+          order.store = FactoryGirl.build(:store)
           Spree::OrderUpdater.new(order).update
 
           order.save!
@@ -576,6 +578,7 @@ describe Spree::Order, :type => :model do
     context "default credit card" do
       before do
         order.user = FactoryGirl.create(:user)
+        order.store = FactoryGirl.create(:store)
         order.email = 'spree@example.org'
         order.payments << FactoryGirl.create(:payment)
 
@@ -697,6 +700,7 @@ describe Spree::Order, :type => :model do
 
     it "does not attempt to process payments" do
       order.email = 'user@example.com'
+      order.store = FactoryGirl.build(:store)
       order.stub(:ensure_available_shipping_rates).and_return(true)
       order.stub(:ensure_promotions_eligible).and_return(true)
       order.stub(:ensure_line_item_variants_are_not_deleted).and_return(true)

--- a/core/spec/models/spree/order/currency_updater_spec.rb
+++ b/core/spec/models/spree/order/currency_updater_spec.rb
@@ -9,7 +9,7 @@ describe Spree::Order, :type => :model do
       context "#homogenize_line_item_currencies" do
         it "succeeds without error" do
           expect { line_item.order.update_attributes!(currency: 'EUR') }.to_not raise_error
-        end      
+        end
 
         it "changes the line_item currencies" do
           expect { line_item.order.update_attributes!(currency: 'EUR') }.to change{ line_item.reload.currency }.from('USD').to('EUR')
@@ -20,7 +20,7 @@ describe Spree::Order, :type => :model do
         end
 
         it "fails to change the order currency when no prices are available in that currency" do
-          expect { line_item.order.update_attributes!(currency: 'GBP') }.to raise_error
+          expect { line_item.order.update_attributes!(currency: 'GBP') }.to raise_error RuntimeError
         end
 
         it "calculates the item total in the order.currency" do

--- a/core/spec/models/spree/order/finalizing_spec.rb
+++ b/core/spec/models/spree/order/finalizing_spec.rb
@@ -4,7 +4,8 @@ describe Spree::Order, :type => :model do
   let(:order) { stub_model("Spree::Order") }
 
   context "#finalize!" do
-    let(:order) { Spree::Order.create(email: 'test@example.com') }
+    let(:order) { Spree::Order.create(email: 'test@example.com', store: store) }
+    let(:store) { FactoryGirl.build(:store) }
 
     before do
       order.update_column :state, 'complete'
@@ -85,7 +86,7 @@ describe Spree::Order, :type => :model do
       end
 
       context "and order is approved" do
-        before do 
+        before do
           allow(order).to receive_messages :approved? => true
         end
 

--- a/core/spec/models/spree/order_cancellations_spec.rb
+++ b/core/spec/models/spree/order_cancellations_spec.rb
@@ -35,7 +35,7 @@ describe Spree::OrderCancellations do
     it "sends a cancellation email" do
       mail_double = double
       expect(Spree::OrderMailer).to receive(:inventory_cancellation_email).with(order, [inventory_unit]).and_return(mail_double)
-      expect(mail_double).to receive(:deliver)
+      expect(mail_double).to receive(:deliver_later)
       subject
     end
 

--- a/core/spec/models/spree/promotion_rule_spec.rb
+++ b/core/spec/models/spree/promotion_rule_spec.rb
@@ -1,18 +1,18 @@
 require 'spec_helper'
 
 module Spree
-  describe Spree::PromotionRule, :type => :model do
+  describe Spree::PromotionRule, type: :model do
 
     class BadTestRule < Spree::PromotionRule; end
 
     class TestRule < Spree::PromotionRule
-      def eligible?
+      def eligible?(promotable, options = {})
         true
       end
     end
 
-    it "should force developer to implement eligible? method" do
-      expect { BadTestRule.new.eligible? }.to raise_error ArgumentError
+    it "forces developer to implement eligible? method" do
+      expect { BadTestRule.new.eligible?("promotable") }.to raise_error NotImplementedError
     end
 
     it "validates unique rules for a promotion" do
@@ -24,6 +24,5 @@ module Spree
       p2.promotion_id = 1
       expect(p2).not_to be_valid
     end
-
   end
 end

--- a/core/spec/models/spree/promotion_rule_spec.rb
+++ b/core/spec/models/spree/promotion_rule_spec.rb
@@ -12,7 +12,7 @@ module Spree
     end
 
     it "should force developer to implement eligible? method" do
-      expect { BadTestRule.new.eligible? }.to raise_error
+      expect { BadTestRule.new.eligible? }.to raise_error ArgumentError
     end
 
     it "validates unique rules for a promotion" do

--- a/core/spec/models/spree/returns_calculator_spec.rb
+++ b/core/spec/models/spree/returns_calculator_spec.rb
@@ -8,7 +8,7 @@ module Spree
     it 'compute_shipment must be overridden' do
       expect {
         subject.compute(return_item)
-      }.to raise_error
+      }.to raise_error NotImplementedError
     end
   end
 end

--- a/core/spec/models/spree/shipping_calculator_spec.rb
+++ b/core/spec/models/spree/shipping_calculator_spec.rb
@@ -25,13 +25,13 @@ module Spree
     it 'compute_shipment must be overridden' do
       expect {
         subject.compute_shipment(shipment)
-      }.to raise_error
+      }.to raise_error NameError
     end
 
     it 'compute_package must be overridden' do
       expect {
         subject.compute_package(package)
-      }.to raise_error
+      }.to raise_error NotImplementedError
     end
 
     it 'checks availability for a package' do

--- a/core/spec/models/spree/stock_item_spec.rb
+++ b/core/spec/models/spree/stock_item_spec.rb
@@ -167,7 +167,7 @@ describe Spree::StockItem, :type => :model do
 
       expect {
         stock_location.stock_items.create!(variant: subject.variant)
-      }.to raise_error
+      }.to raise_error ActiveRecord::RecordInvalid
     end
   end
 

--- a/core/spec/models/spree/unit_cancel_spec.rb
+++ b/core/spec/models/spree/unit_cancel_spec.rb
@@ -52,7 +52,7 @@ describe Spree::UnitCancel do
       let(:line_item) { create(:line_item) }
 
       it "raises an error" do
-        expect { subject }.to raise_error
+        expect { subject }.to raise_error RuntimeError
       end
     end
 


### PR DESCRIPTION
As part of moving towards a 1.0 release, we should try to remove as many deprecation warnings from our code as possible. Especially deprecation warnings we've added. If we expect users not to use the deprecated methods we shouldn't be using them ourselves.