### PR TITLE
RFC: Carton inventory units must all be from the same store

### DIFF
--- a/core/app/models/spree/carton.rb
+++ b/core/app/models/spree/carton.rb
@@ -12,6 +12,7 @@ class Spree::Carton < ActiveRecord::Base
   validates :shipping_method, presence: true
   validates :inventory_units, presence: true
   validates :shipped_at, presence: true
+  validate :validate_one_store_per_carton
 
   make_permalink field: :number, length: 11, prefix: 'C'
 
@@ -39,6 +40,10 @@ class Spree::Carton < ActiveRecord::Base
     shipments.map(&:number)
   end
 
+  def store
+    orders.first.store
+  end
+
   def display_shipped_at
     shipped_at.to_s(:rfc822)
   end
@@ -53,5 +58,13 @@ class Spree::Carton < ActiveRecord::Base
 
   def any_exchanges?
     inventory_units.any?(&:original_return_item)
+  end
+
+  private
+
+  def validate_one_store_per_carton
+    if orders.map(&:store).uniq.size > 1
+      errors.add(:base, "Cartons cannot contain items from multiple stores") # TODO: use Spree.t
+    end
   end
 end


### PR DESCRIPTION
See this comment from @jhawthorn: https://github.com/solidusio/solidus/pull/172/files#diff-89dd08a6a430f052d78852ddb7329a9dL9

Right now a carton can contain items from multiple orders and potentially multiple stores.  That makes some things more complex.  I can think of three options:

1. Treat cartons appropriately under these conditions. e.g. when sending a "shipped" email, we send the user one email for every store connected to the items inside the carton.
2. (This PR) Require inventory units in a carton to all come from orders from the same store.
3. Go even further than option 2 and require all inventory units in a carton to come from the same order.

I'm not sold on any of the options.  I just picked a quick one for a PR as a conversation starting point. What do people think about this?

The original reason for allowing cartons to contain items from multiple orders was the thought that cartons should model real-world physical boxes. And in real life it seems plausible that a store might combine two orders into a single box when shipping.  I'm not sure we actually do need to be that faithful to 'possible reality' but that's the background.