### PR TITLE
Add extension point for handling access denied.

### DIFF
--- a/core/lib/spree/core/controller_helpers/auth.rb
+++ b/core/lib/spree/core/controller_helpers/auth.rb
@@ -8,6 +8,12 @@ module Spree
           before_filter :set_guest_token
           helper_method :try_spree_current_user
 
+          # @!attribute [rw] unauthorized_redirect
+          #   @!scope class
+          #   Extension point for overriding behaviour of access denied errors.
+          #   Default behaviour is to redirect to "/unauthorized" with a flash
+          #   message.
+          #   @return [Proc] action to take when access denied error is raised.
           class_attribute :unauthorized_redirect
           self.unauthorized_redirect = -> do
             flash[:error] = Spree.t(:authorization_failure)

--- a/core/spec/lib/spree/core/controller_helpers/auth_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/auth_spec.rb
@@ -63,33 +63,4 @@ describe Spree::Core::ControllerHelpers::Auth, type: :controller do
       expect(controller.try_spree_current_user).to eq nil
     end
   end
-
-  describe '#redirect_unauthorized_access' do
-    controller(FakesController) do
-      def index; redirect_unauthorized_access; end
-    end
-    context 'when logged in' do
-      before do
-        allow(controller).to receive_messages(try_spree_current_user: double('User', id: 1, last_incomplete_spree_order: nil))
-      end
-      it 'redirects unauthorized path' do
-        get :index
-        expect(response).to redirect_to('/unauthorized')
-      end
-    end
-    context 'when guest user' do
-      before do
-        allow(controller).to receive_messages(try_spree_current_user: nil)
-      end
-      it 'redirects login path' do
-        allow(controller).to receive_messages(spree_login_path: '/login')
-        get :index
-        expect(response).to redirect_to('/login')
-      end
-      it 'redirects root path' do
-        get :index
-        expect(response).to redirect_to('/unauthorized')
-      end
-    end
-  end
 end


### PR DESCRIPTION
Makes overriding desired behaviour when handling unauthorized requests much easier. It can be done on a per-controller basis and defined in outside extensions easily.

```ruby
Spree::BaseController.unauthorized_redirect = -> do
  if try_spree_current_user
    flash[:error] = Spree.t(:authorization_failure)
    redirect_to spree.unauthorzied_path
  else
    store_location
    redirect_to spree.login_path
  end
end
```

Alternative to #43.