### PR TITLE
Tweak docs for unauthorized_redirect.

### DIFF
--- a/core/lib/spree/core/controller_helpers/auth.rb
+++ b/core/lib/spree/core/controller_helpers/auth.rb
@@ -4,16 +4,17 @@ module Spree
       module Auth
         extend ActiveSupport::Concern
 
+        # @!attribute [rw] unauthorized_redirect
+        #   @!scope class
+        #   Extension point for overriding behaviour of access denied errors.
+        #   Default behaviour is to redirect to "/unauthorized" with a flash
+        #   message.
+        #   @return [Proc] action to take when access denied error is raised.
+
         included do
           before_filter :set_guest_token
           helper_method :try_spree_current_user
 
-          # @!attribute [rw] unauthorized_redirect
-          #   @!scope class
-          #   Extension point for overriding behaviour of access denied errors.
-          #   Default behaviour is to redirect to "/unauthorized" with a flash
-          #   message.
-          #   @return [Proc] action to take when access denied error is raised.
           class_attribute :unauthorized_redirect
           self.unauthorized_redirect = -> do
             flash[:error] = Spree.t(:authorization_failure)


### PR DESCRIPTION
Doesn't play super nice with included blocks. Needed to move it out in order for it to show up in the generated documentation.

![docs](https://cloud.githubusercontent.com/assets/876067/8731236/c7cfa3e4-2baa-11e5-8b03-921dff1fcff0.png)
