### PR TITLE
Fix deprecation warnings in specs.

### DIFF
--- a/api/spec/controllers/spree/api/checkouts_controller_spec.rb
+++ b/api/spec/controllers/spree/api/checkouts_controller_spec.rb
@@ -308,7 +308,9 @@ module Spree
       context "#{action}" do
         context "with order in confirm state" do
           subject do
-            api_put action, params
+            ActiveSupport::Deprecation.silence do
+              api_put action, params
+            end
           end
 
           let(:params) { {id: order.to_param, order_token: order.guest_token} }
@@ -316,10 +318,6 @@ module Spree
 
           before do
             order.update_column(:state, "confirm")
-
-            if action == :next
-              #ActiveSupport::Deprecation.should_receive(:warn).once
-            end
           end
 
           it "can transition from confirm to complete" do

--- a/api/spec/controllers/spree/api/checkouts_controller_spec.rb
+++ b/api/spec/controllers/spree/api/checkouts_controller_spec.rb
@@ -308,7 +308,11 @@ module Spree
       context "#{action}" do
         context "with order in confirm state" do
           subject do
-            ActiveSupport::Deprecation.silence do
+            if action == :next
+              ActiveSupport::Deprecation.silence do
+                api_put action, params
+              end
+            else
               api_put action, params
             end
           end

--- a/api/spec/features/checkout_spec.rb
+++ b/api/spec/features/checkout_spec.rb
@@ -5,6 +5,7 @@ module Spree
     before { Spree::Api::Config[:requires_authentication] = false }
     let!(:promotion) { FactoryGirl.create(:promotion, :with_order_adjustment, code: 'foo', weighted_order_adjustment_amount: 10) }
     let(:promotion_code) { promotion.codes.first }
+    let!(:store) { FactoryGirl.create(:store) }
     let(:bill_address) { FactoryGirl.create(:address) }
     let(:ship_address) { FactoryGirl.create(:address) }
     let(:variant_1) { FactoryGirl.create(:variant, price: 100.00) }

--- a/backend/app/views/spree/admin/cancellations/index.html.erb
+++ b/backend/app/views/spree/admin/cancellations/index.html.erb
@@ -25,7 +25,7 @@
       <% @inventory_units.each do |inventory_unit| %>
         <tr class="inventory-unit">
           <td class="inventory-unit-image">
-            <%= mini_image(inventory_unit.variant) %>
+            <%= image_tag inventory_unit.variant.display_image.attachment(:mini) %>
           </td>
           <td class="inventory-unit-name">
             <%= inventory_unit.variant.product.name %><br><%= "(" + variant_options(inventory_unit.variant) + ")" unless inventory_unit.variant.option_values.empty? %>

--- a/backend/app/views/spree/admin/orders/_carton_manifest.html.erb
+++ b/backend/app/views/spree/admin/orders/_carton_manifest.html.erb
@@ -1,7 +1,7 @@
 <% carton.manifest_for_order(order).each do |item| %>
   <tr class="stock-item" data-item-quantity="<%= item.quantity %>">
     <td class="item-image">
-      <%= mini_image(item.variant) %>
+      <%= image_tag item.variant.display_image.attachment(:mini) %>
     </td>
     <td class="item-name">
       <%= item.variant.product.name %><br><%= "(" + variant_options(item.variant) + ")" unless item.variant.option_values.empty? %>

--- a/backend/app/views/spree/admin/orders/_line_items.html.erb
+++ b/backend/app/views/spree/admin/orders/_line_items.html.erb
@@ -18,7 +18,7 @@
     <tbody>
       <% order.line_items.each do |item| %>
         <%= content_tag :tr, class: 'line-item', id: "line-item-#{item.id}", data: { line_item_id: item.id } do %>
-          <td class="line-item-image"><%= mini_image(item.variant) %></td>
+          <td class="line-item-image"><%= image_tag item.variant.display_image.attachment(:mini) %></td>
           <td class="line-item-name">
             <%= item.variant.product.name %><br><%= "(" + variant_options(item.variant) + ")" unless item.variant.option_values.empty? %>
             <% if item.variant.sku.present? %>

--- a/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
@@ -1,7 +1,7 @@
 <% shipment_manifest.each do |item| %>
   <tr class="stock-item" data-item-quantity="<%= item.quantity %>">
     <td class="item-image">
-      <%= mini_image(item.variant) %>
+      <%= image_tag item.variant.display_image.attachment(:mini) %>
     </td>
     <td class="item-name">
       <%= item.variant.product.name %><br><%= "(" + variant_options(item.variant) + ")" unless item.variant.option_values.empty? %>

--- a/backend/app/views/spree/admin/orders/confirm/_shipment_manifest.html.erb
+++ b/backend/app/views/spree/admin/orders/confirm/_shipment_manifest.html.erb
@@ -1,7 +1,7 @@
 <% shipment.manifest.each do |item| %>
   <tr class="stock-item" data-item-quantity="<%= item.quantity %>">
     <td class="item-image">
-      <%= mini_image(item.variant) %>
+      <%= image_tag item.variant.display_image.attachment(:mini) %>
     </td>
     <td class="item-name">
       <%= item.variant.product.name %><br><%= "(" + variant_options(item.variant) + ")" unless item.variant.option_values.empty? %>

--- a/backend/app/views/spree/admin/products/index.html.erb
+++ b/backend/app/views/spree/admin/products/index.html.erb
@@ -78,7 +78,7 @@
       <% @collection.each do |product| %>
           <tr <%== "style='color: red;'" if product.deleted? %> id="<%= spree_dom_id product %>" data-hook="admin_products_index_rows" class="<%= cycle('odd', 'even') %>">
             <td class="align-center"><%= product.sku rescue '' %></td>
-            <td class="align-center"><%= mini_image(product) %></td>
+            <td class="align-center"><%= image_tag product.display_image.attachment(:mini) %></td>
             <td><%= link_to product.try(:name), edit_admin_product_path(product) %></td>
             <td class="align-center"><%= product.display_price.to_html rescue '' %></td>
             <td class="actions" data-hook="admin_products_index_row_actions">

--- a/backend/app/views/spree/admin/stock_items/_stock_management.html.erb
+++ b/backend/app/views/spree/admin/stock_items/_stock_management.html.erb
@@ -32,7 +32,7 @@
         <td class="align-center no-padding" rowspan="<%= row_count %>">
           <div class='variant-container'>
             <div class='variant-image'>
-              <%= image_tag(variant.display_image.attachment(:small)) %>
+              <%= image_tag(variant.display_image(fallback: false).attachment(:small)) %>
             </div>
             <div class='variant-details'>
               <table class='stock-variant-field-table'>

--- a/backend/app/views/spree/admin/stock_transfers/_transfer_item_table.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/_transfer_item_table.html.erb
@@ -22,7 +22,7 @@
           <td class="align-center no-padding">
             <div class='variant-container' data-variant-id="<%= variant.id %>">
               <div class='variant-image'>
-                <%= image_tag(variant.display_image.attachment(:small)) %>
+                <%= image_tag(variant.display_image(fallback: false).attachment(:small)) %>
               </div>
               <div class='variant-details'>
                 <table class='stock-variant-field-table'>

--- a/backend/app/views/spree/admin/users/items.html.erb
+++ b/backend/app/views/spree/admin/users/items.html.erb
@@ -39,7 +39,7 @@
             <tr class="stock-item" data-item-quantity="<%= item.quantity %>">
               <td class="align-center order-completed-at"><%= l(order.completed_at.to_date) if order.completed_at %></td>
               <td class="item-image">
-                <%= mini_image(item.variant) %>
+                <%= image_tag item.variant.display_image.attachment(:mini) %>
               </td>
               <td class="item-name">
                 <%= item.product.name %><br><%= "(" + variant_options(item.variant) + ")" unless item.variant.option_values.empty? %>

--- a/backend/spec/features/admin/configuration/countries_spec.rb
+++ b/backend/spec/features/admin/configuration/countries_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
 module Spree
-  describe "Countries", :type => :feature do
+  describe "Countries", type: :feature do
     stub_authorization!
 
-    it "deletes a state", js: true do
+    it "deletes a country", js: true do
       visit spree.admin_countries_path
       click_link "New Country"
 
@@ -15,9 +15,8 @@ module Spree
       accept_alert do
         click_icon :trash
       end
-      wait_for_ajax
 
-      expect { Country.find(country.id) }.to raise_error
+      expect(page).to have_content 'Country "Brazil" has been successfully removed!'
     end
   end
 end

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -237,6 +237,15 @@ module Spree
       super || variants_including_master.with_deleted.where(is_master: true).first
     end
 
+    # Image that can be used for the product.
+    #
+    # Will first search for images on the product, then those belonging to the
+    # variants. If all else fails, will return a new image object.
+    # @return [Spree::Image] the image to display
+    def display_image
+      images.first || variant_images.first || Spree::Image.new
+    end
+
     private
 
     def add_associations_from_prototype

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -304,8 +304,13 @@ module Spree
       self.track_inventory? && Spree::Config.track_inventory_levels
     end
 
+    # Image that can be used for the variant.
+    #
+    # Will first search for images on the variant, then all images from the
+    # products' variants. If all else fails, will return a new image object.
+    # @return [Spree::Image] the image to display
     def display_image
-      images.first || Spree::Image.new
+      images.first || product.variant_images.first || Spree::Image.new
     end
 
     private

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -306,11 +306,14 @@ module Spree
 
     # Image that can be used for the variant.
     #
-    # Will first search for images on the variant, then all images from the
-    # products' variants. If all else fails, will return a new image object.
+    # Will first search for images on the variant. If it doesn't find any,
+    # it'll fallback to any variant image (unless +fallback+ is +false+) or to
+    # a new {Spree::Image}.
+    # @param fallback [Boolean] whether or not we should fallback to an image
+    #   not from this variant
     # @return [Spree::Image] the image to display
-    def display_image
-      images.first || product.variant_images.first || Spree::Image.new
+    def display_image(fallback: true)
+      images.first || (fallback && product.variant_images.first) || Spree::Image.new
     end
 
     private

--- a/core/lib/spree/core/importer/order.rb
+++ b/core/lib/spree/core/importer/order.rb
@@ -12,6 +12,7 @@ module Spree
 
             create_params = params.slice :currency
             order = Spree::Order.create! create_params
+            order.store ||= Spree::Store.default
             order.associate_user!(user)
             order.save!
 

--- a/core/lib/spree/testing_support/order_walkthrough.rb
+++ b/core/lib/spree/testing_support/order_walkthrough.rb
@@ -15,7 +15,10 @@ class OrderWalkthrough
       end
     end
 
-    order = Spree::Order.create!(email: "spree@example.com")
+    order = Spree::Order.create!(
+      email: "spree@example.com",
+      store: Spree::Store.first || FactoryGirl.create(:store)
+    )
     add_line_item!(order)
     order.next!
 

--- a/core/spec/helpers/base_helper_spec.rb
+++ b/core/spec/helpers/base_helper_spec.rb
@@ -60,7 +60,9 @@ describe Spree::BaseHelper, :type => :helper do
     end
 
     it "should not raise errors when style exists" do
-      expect { very_strange_image(product) }.not_to raise_error
+      ActiveSupport::Deprecation.silence do
+        expect { very_strange_image(product) }.not_to raise_error
+      end
     end
 
     it "should raise NoMethodError when style is not exists" do
@@ -152,7 +154,9 @@ describe Spree::BaseHelper, :type => :helper do
     end
 
     it "should not raise errors when helper method called" do
-      expect { foobar_image(product) }.not_to raise_error
+      ActiveSupport::Deprecation.silence do
+        expect { foobar_image(product) }.not_to raise_error
+      end
     end
 
     it "should raise NoMethodError when statement with name equal to style name called" do

--- a/frontend/app/views/spree/checkout/_delivery.html.erb
+++ b/frontend/app/views/spree/checkout/_delivery.html.erb
@@ -26,7 +26,7 @@
             <tbody>
               <% ship_form.object.manifest.each do |item| %>
                 <tr class="stock-item">
-                  <td class="item-image"><%= mini_image(item.variant) %></td>
+                  <td class="item-image"><%= image_tag item.variant.display_image.attachment(:mini) %></td>
                   <td class="item-name"><%= item.variant.name %></td>
                   <td class="item-qty"><%= item.quantity %></td>
                   <td class="item-price"><%= display_price(item.variant) %></td>
@@ -72,7 +72,7 @@
             <tbody>
               <% @differentiator.missing.each do |variant, quantity| %>
                 <tr class="stock-item">
-                  <td class="item-image"><%= mini_image(variant) %></td>
+                  <td class="item-image"><%= image_tag variant.display_image.attachment(:mini) %></td>
                   <td class="item-name"><%= variant.name %></td>
                   <td class="item-qty"><%= quantity %></td>
                   <td class="item-price"><%= display_price(variant) %></td>

--- a/frontend/app/views/spree/orders/_line_item.html.erb
+++ b/frontend/app/views/spree/orders/_line_item.html.erb
@@ -3,7 +3,7 @@
   <tr class="<%= cycle('', 'alt') %> line-item">
     <td class="cart-item-image" data-hook="cart_item_image">
       <% if variant.images.length == 0 %>
-        <%= link_to small_image(variant.product), variant.product %>
+        <%= link_to image_tag(variant.product.display_image.attachment(:small)), variant.product %>
       <% else %>
         <%= link_to image_tag(variant.images.first.attachment.url(:small)), variant.product %>
       <% end %>

--- a/frontend/app/views/spree/products/_image.html.erb
+++ b/frontend/app/views/spree/products/_image.html.erb
@@ -1,5 +1,5 @@
 <% if defined?(image) && image %>
-  <%= image_tag image.attachment.url(:product), :itemprop => "image" %>
+  <%= image_tag image.attachment.url(:product), itemprop: "image" %>
 <% else %>
-  <%= product_image(@product, :itemprop => "image") %>
+  <%= image_tag @product.display_image.attachment(:product), itemprop: "image" %>
 <% end %>

--- a/frontend/app/views/spree/shared/_order_details.html.erb
+++ b/frontend/app/views/spree/shared/_order_details.html.erb
@@ -62,7 +62,7 @@
       <tr data-hook="order_details_line_item_row">
         <td data-hook="order_item_image">
           <% if item.variant.images.length == 0 %>
-            <%= link_to small_image(item.variant.product), item.variant.product %>
+            <%= link_to image_tag(item.variant.product.display_image.attachment(:small)), item.variant.product %>
           <% else %>
             <%= link_to image_tag(item.variant.images.first.attachment.url(:small)), item.variant.product %>
           <% end %>

--- a/frontend/app/views/spree/shared/_products.html.erb
+++ b/frontend/app/views/spree/shared/_products.html.erb
@@ -16,29 +16,29 @@
     </div>
   <% elsif params.key?(:keywords) %>
     <div data-hook="products_search_results_heading_results_found">
-      <h6 class="search-results-title"><%= Spree.t(:search_results, :keywords => h(params[:keywords])) %></h6>
+      <h6 class="search-results-title"><%= Spree.t(:search_results, keywords: h(params[:keywords])) %></h6>
     </div>
   <% end %>
 </div>
 
 <% if products.any? %>
-<ul id="products" class="inline product-listing" data-hook>
-  <% products.each do |product| %>
-    <% url = spree.product_path(product, :taxon_id => @taxon.try(:id)) %>
-    <li id="product_<%= product.id %>" class="columns three <%= cycle("alpha", "secondary", "", "omega secondary", :name => "classes") %>" data-hook="products_list_item" itemscope itemtype="http://schema.org/Product">
-      <% cache(@taxon.present? ? [I18n.locale, current_currency, @taxon, product] : [I18n.locale, current_currency, product]) do %>
-        <div class="product-image">
-          <%= link_to small_image(product, :itemprop => "image"), url, :itemprop => 'url' %>
-        </div>
-        <%= link_to truncate(product.name, :length => 50), url, :class => 'info', :itemprop => "name", :title => product.name %>
-        <span itemprop="offers" itemscope itemtype="http://schema.org/Offer">
-          <span class="price selling" itemprop="price"><%= display_price(product) %>
-        </span>
-      <% end %>
-    </li>
-  <% end %>
-  <% reset_cycle("classes") %>
-</ul>
+  <ul id="products" class="inline product-listing" data-hook>
+    <% products.each do |product| %>
+      <% url = spree.product_path(product, taxon_id: @taxon.try(:id)) %>
+      <li id="product_<%= product.id %>" class="columns three <%= cycle("alpha", "secondary", "", "omega secondary", name: "classes") %>" data-hook="products_list_item" itemscope itemtype="http://schema.org/Product">
+        <% cache(@taxon.present? ? [I18n.locale, current_currency, @taxon, product] : [I18n.locale, current_currency, product]) do %>
+          <div class="product-image">
+            <%= link_to image_tag(product.display_image.attachment(:small), itemprop: "image"), url, itemprop: 'url' %>
+          </div>
+          <%= link_to truncate(product.name, length: 50), url, class: 'info', itemprop: "name", title: product.name %>
+          <span itemprop="offers" itemscope itemtype="http://schema.org/Offer">
+            <span class="price selling" itemprop="price"><%= display_price(product) %>
+          </span>
+        <% end %>
+      </li>
+    <% end %>
+    <% reset_cycle("classes") %>
+  </ul>
 <% end %>
 
 <% if paginated_products.respond_to?(:num_pages) %>

--- a/frontend/spec/features/checkout_spec.rb
+++ b/frontend/spec/features/checkout_spec.rb
@@ -245,6 +245,7 @@ describe "Checkout", type: :feature, inaccessible: true do
 
   # regression for #2921
   context "goes back from payment to add another item", js: true do
+    let!(:store) { FactoryGirl.create(:store) }
     let!(:bag) { create(:product, :name => "RoR Bag") }
 
     it "transit nicely through checkout steps again" do

--- a/sample/db/samples/orders.rb
+++ b/sample/db/samples/orders.rb
@@ -1,6 +1,8 @@
 Spree::Sample.load_sample("addresses")
+Spree::Sample.load_sample("stores")
 
 payment_method = Spree::PaymentMethod::Check.first!
+store = Spree::Store.first!
 
 orders = []
 orders << Spree::Order.create!(
@@ -33,6 +35,7 @@ orders[1].line_items.create!(
 
 orders.each do |order|
   order.payments.create!(payment_method: payment_method)
+  order.update_attributes(store: store)
 
   order.next! while !order.can_complete?
   order.complete!

--- a/sample/db/samples/stores.rb
+++ b/sample/db/samples/stores.rb
@@ -1,0 +1,6 @@
+Spree::Store.create!(
+  name: "Sample Store",
+  code: "sample-store",
+  url: "solidus.example.com",
+  mail_from_address: "store@example.com",
+)


### PR DESCRIPTION
Instead of using the image helpers, do something slightly simpler by finding an acceptable image and displaying it in an image tag.