### PR TITLE
Add store to admin orders controller params

### DIFF
--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -174,7 +174,8 @@ module Spree
         def extra_order_params
           {
             created_by_id: try_spree_current_user.try(:id),
-            frontend_viewable: false
+            frontend_viewable: false,
+            store_id: current_store.try(:id)
           }
         end
 

--- a/backend/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -87,6 +87,13 @@ describe Spree::Admin::OrdersController, :type => :controller do
         spree_get :new
       end
 
+      it "should associate the order with a store" do
+        Spree::Core::Importer::Order.should_receive(:import)
+          .with(user, hash_including(store_id: controller.current_store.id))
+          .and_return(order)
+        spree_get :new, { user_id: user.id }
+      end
+
       context "when a user_id is passed as a parameter" do
         let(:user)  { mock_model(Spree.user_class) }
         before { Spree.user_class.stub :find_by_id => user }


### PR DESCRIPTION
Allows specification of the store when creating a new order in the admin. Moving this from:
https://github.com/bonobos/spree-backend/pull/1408/files#diff-6118091899ec64dc191a5ba55db7e1ecR13