### PR TITLE
Add store credit to available payment methods.

### DIFF
--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -36,6 +36,7 @@ module Spree
         app.config.spree.payment_methods = [
             Spree::Gateway::Bogus,
             Spree::Gateway::BogusSimple,
+            Spree::PaymentMethod::StoreCredit,
             Spree::PaymentMethod::Check ]
       end
 


### PR DESCRIPTION
Otherwise, attempting to edit it in the admin won't work. Since it'll try to switch the provider to something else that won't have the same preferences.