### PR TITLE
Re-render form on error.

### DIFF
--- a/backend/app/controllers/spree/admin/users_controller.rb
+++ b/backend/app/controllers/spree/admin/users_controller.rb
@@ -29,7 +29,10 @@ module Spree
           flash[:success] = Spree.t(:created_successfully)
           redirect_to edit_admin_user_url(@user)
         else
-          redirect_to new_admin_user_url
+          load_roles
+          load_stock_locations
+
+          render :new, status: :unprocessable_entity
         end
       end
 


### PR DESCRIPTION
Redirecting to the form will clear out the errors. Making it useless in most cases, since not knowing what was entered incorrectly helps no one.