### PR TITLE
Reload shipments when setting shipment cost on order

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -567,7 +567,11 @@ module Spree
     end
 
     def set_shipments_cost
-      shipments.each(&:update_amounts)
+      shipments.each do |shipment|
+        shipment.reload
+        shipment.update_amounts
+      end
+
       updater.update_shipment_total
       persist_totals
     end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -63,6 +63,7 @@ describe Spree::Order, :type => :model do
     before { allow(order).to receive_messages shipments: [shipment] }
 
     it "update and persist totals" do
+      expect(shipment).to receive :reload
       expect(shipment).to receive :update_amounts
       expect(order.updater).to receive :update_shipment_total
       expect(order.updater).to receive :persist_totals


### PR DESCRIPTION
When using the api/checkouts_controller#advance endpoint, it will select the correct shipping rate for shipments, but it uses stale data in some cases, which bungles the order and shipment totals