### PR TITLE
Ensure root redirects work for unauthenticated users.

### DIFF
--- a/backend/app/controllers/spree/admin/root_controller.rb
+++ b/backend/app/controllers/spree/admin/root_controller.rb
@@ -12,8 +12,16 @@ module Spree
       def admin_root_redirect_path
         if can?(:display, Spree::Order) && can?(:admin, Spree::Order)
           spree.admin_orders_path
-        else
+        elsif can?(:admin, :dashboards) && can?(:home, :dashboards)
           spree.home_admin_dashboards_path
+        else
+          # Invoke the unauthorized redirect, which will ideally go to the login controller
+          # of the users chosen authorization implimentation. For devise this is /admin/login.
+          #
+          # This is done so devise redirects back to this controller, instead of the one specified
+          # below, so this controller can use the user that is required for the path to
+          # be calculated.
+          raise CanCan::AccessDenied
         end
       end
     end


### PR DESCRIPTION
Previously, if you were not logged in, this would redirect you to the
dashboards url, which would redirect you to the login url.

After login you'd be redirected to where you came from, being the
dashboards url, when this user could have been redirected to the order
url.

By raising here to invoke the unauthorized exception handler, we get
redirected back to RootController#index instead and we can make a proper
decision on the users final destination.

This also prevents the unauthorized flash from showing up after
successful login. cc @jhawthorn 