### PR TITLE
Remove ship and bill address attribute setting in Order.associate_user

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -256,8 +256,6 @@ module Spree
         self.class.unscoped.where(id: id).update_all(attrs_to_set)
       end
 
-      attrs_to_set[:ship_address_attributes] = user.ship_address.attributes.except('id', 'updated_at', 'created_at') if user.try(:ship_address)
-      attrs_to_set[:bill_address_attributes] = user.bill_address.attributes.except('id', 'updated_at', 'created_at') if user.try(:bill_address)
       assign_attributes(attrs_to_set)
     end
 


### PR DESCRIPTION
This doesn't seem to be necessary. Also it is causing https://github.com/solidusio/solidus/blob/master/api/app/controllers/spree/api/orders_controller.rb#L69-L72 to return un-persisted and incorrect addresses.

As an aside, this seems like an odd thing to put in a method called `associate_user` and the address setting seems to be untested.

Definitely open to feedback on different approaches to solving the API problem, if this is indeed necessary.