### PR TITLE
Restart checkout flow is no-op for cart-state orders

### DIFF
--- a/api/spec/controllers/spree/api/orders_controller_spec.rb
+++ b/api/spec/controllers/spree/api/orders_controller_spec.rb
@@ -325,7 +325,7 @@ module Spree
 
       expect(json_response['number']).to be_present
       expect(json_response["token"]).not_to be_blank
-      expect(json_response["state"]).to eq("address")
+      expect(json_response["state"]).to eq("cart")
       expect(order.user).to eq(current_api_user)
       expect(order.email).to eq(current_api_user.email)
       expect(json_response["user_id"]).to eq(current_api_user.id)
@@ -575,6 +575,7 @@ module Spree
           end
 
           before do
+            order.next!
             order.next!
             order.save
           end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -551,6 +551,8 @@ module Spree
     end
 
     def restart_checkout_flow
+      return if self.state == 'cart'
+
       self.update_columns(
         state: 'cart',
         updated_at: Time.now,

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -481,6 +481,13 @@ describe Spree::Order, :type => :model do
   end
 
   describe "#restart_checkout_flow" do
+    context "when in cart state" do
+      let(:order)  { create(:order_with_totals, state: "cart") }
+
+      it "remains in cart state" do
+        expect { order.restart_checkout_flow }.not_to change { order.state }
+      end
+    end
     it "updates the state column to the first checkout_steps value" do
       order = create(:order_with_totals, state: "delivery")
       expect(order.checkout_steps).to eql ["address", "delivery", "confirm", "complete"]


### PR DESCRIPTION
This currently allows orders to go from cart to address state when in reality, restarting the checkout flow on a cart order should do nothing.

cc @magnusvk 