### PR TITLE
Granular stock management

### DIFF
--- a/backend/app/views/spree/admin/shared/_number_field_update_actions.html.erb
+++ b/backend/app/views/spree/admin/shared/_number_field_update_actions.html.erb
@@ -1,3 +1,5 @@
-<%= link_to_with_icon 'edit', Spree.t('actions.edit'), '#', no_text: true, data: { action: 'edit', id: resource.id } if can?(:edit, resource) %>
-<%= link_to_with_icon 'check', Spree.t('actions.update'), '#', no_text: true, data: update_data.merge(action: 'green', id: resource.id) if can?(:edit, resource) %>
-<%= link_to_with_icon 'void', Spree.t('actions.cancel'), '#', no_text: true, data: { action: 'red', id: resource.id } if can?(:edit, resource) %>
+<% if can?(:update, resource) %>
+  <%= link_to_with_icon 'edit', Spree.t('actions.edit'), '#', no_text: true, data: { action: 'edit', id: resource.id } %>
+  <%= link_to_with_icon 'check', Spree.t('actions.update'), '#', no_text: true, data: update_data.merge(action: 'green', id: resource.id) %>
+  <%= link_to_with_icon 'void', Spree.t('actions.cancel'), '#', no_text: true, data: { action: 'red', id: resource.id } %>
+<% end %>

--- a/core/app/models/spree/ability.rb
+++ b/core/app/models/spree/ability.rb
@@ -10,6 +10,8 @@ module Spree
     class_attribute :abilities
     self.abilities = Set.new
 
+    attr_reader :user
+
     # Allows us to go beyond the standard cancan initialize method which makes it difficult for engines to
     # modify the default +Ability+ of an application.  The +ability+ argument must be a class that includes
     # the +CanCan::Ability+ module.  The registered ability should behave properly as a stand-alone class
@@ -22,7 +24,9 @@ module Spree
       self.abilities.delete(ability)
     end
 
-    def initialize(user)
+    def initialize(current_user)
+      @user = current_user || Spree.user_class.new
+
       self.clear_aliased_actions
 
       # override cancan default aliasing (we don't want to differentiate between read and index)
@@ -32,9 +36,6 @@ module Spree
       alias_action :new_action, to: :create
       alias_action :show, to: :read
       alias_action :index, :read, to: :display
-
-
-      user ||= Spree.user_class.new
 
       if user.respond_to?(:has_spree_role?) && user.has_spree_role?('admin')
         can :manage, :all

--- a/core/app/models/spree/permission_sets/base.rb
+++ b/core/app/models/spree/permission_sets/base.rb
@@ -11,7 +11,8 @@ module Spree
 
       private
 
-      delegate :can, :cannot, to: :@ability
+      attr_reader :ability
+      delegate :can, :cannot, :user, to: :ability
     end
   end
 end

--- a/core/app/models/spree/permission_sets/base.rb
+++ b/core/app/models/spree/permission_sets/base.rb
@@ -1,10 +1,22 @@
 module Spree
   module PermissionSets
+    # This is the base class used for crafting permission sets.
+    #
+    # This is used by {Spree::RoleConfiguration} when adding custom behavior to {Spree::Ability}.
+    # See one of the subclasses for example structure such as {Spree::PermissionSets::UserDisplay}
+    #
+    # @see Spree::RoleConfiguration
+    # @see Spree::PermissionSets
     class Base
+      # @param ability [CanCan::Ability]
+      #   The ability that will be extended with the current permission set.
+      #   The ability passed in must respond to #user
       def initialize ability
         @ability = ability
       end
 
+      # Activate permissions on the ability. Put your can and cannot statements here.
+      # Must be overriden by subclasses
       def activate!
         raise NotImplementedError.new
       end

--- a/core/app/models/spree/permission_sets/restricted_transfer_management.rb
+++ b/core/app/models/spree/permission_sets/restricted_transfer_management.rb
@@ -1,0 +1,35 @@
+module Spree
+  module PermissionSets
+    # This is a permission set that offers an alternative to {StockManagement}.
+    #
+    # Instead of allowing management access for all stock transfers and items, only allow
+    # the management of stock transfers for locations the user is associated with.
+    #
+    # Users can be associated with stock locations via the admin user interface.
+    #
+    # @see Spree::PermissionSets::Base
+    class RestrictedTransferManagement < PermissionSets::Base
+      def activate!
+        can [:display, :admin], Spree::StockItem
+        can [:display, :admin], Spree::StockTransfer
+
+        if user.stock_locations.any?
+          can :transfer, Spree::StockLocation, id: location_ids
+          can :update, Spree::StockItem, stock_location_id: location_ids
+          can :manage, Spree::StockTransfer, source_location_id: location_ids, destination_location_id: location_ids
+          can :manage, Spree::TransferItem, stock_transfer: {
+            source_location_id: location_ids,
+            destination_location_id: location_ids
+          }
+        end
+      end
+
+      private
+
+      def location_ids
+        # either source_location_id or destination_location_id can be nil.
+        @ids ||= user.stock_locations.pluck(:id) + [nil]
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/permission_sets/restricted_transfer_management_spec.rb
+++ b/core/spec/models/spree/permission_sets/restricted_transfer_management_spec.rb
@@ -1,0 +1,132 @@
+require 'spec_helper'
+
+describe Spree::PermissionSets::RestrictedTransferManagement do
+  let(:ability) { Spree::Ability.new(user) }
+
+  subject { ability }
+
+  let!(:source_location) { create :stock_location }
+  let!(:destination_location) { create :stock_location }
+
+  # This has the side effect of creating a stock item for each stock location above,
+  # which is what we actually want.
+  let!(:variant) { create :variant }
+
+  let(:source_stock_item) { source_location.stock_items.first }
+  let(:destination_stock_item) { destination_location.stock_items.first }
+
+  let(:transfer_with_source) { create :stock_transfer, source_location: source_location }
+  let(:transfer_with_destination) { create :stock_transfer, source_location: destination_location  }
+  let(:transfer_with_source_and_destination) do
+    create :stock_transfer, source_location: source_location, destination_location: destination_location
+  end
+
+  let(:transfer_amount) { 1 }
+  let(:source_transfer_item) do
+    transfer_with_source.transfer_items.create(variant: variant, expected_quantity: transfer_amount)
+  end
+  let(:destination_transfer_item) do
+    transfer_with_destination.transfer_items.create(variant: variant, expected_quantity: transfer_amount)
+  end
+  let(:source_and_destination_transfer_item) do
+    transfer_with_source_and_destination.transfer_items.create(variant: variant, expected_quantity: transfer_amount)
+  end
+
+  context "when activated" do
+    let(:user) { create :user, stock_locations: stock_locations }
+    let(:stock_locations) {[]}
+
+    before do
+      user.stock_locations = stock_locations
+      # When creating transfer_items for a stock transfer, stock items must have a count on hand
+      # with an amount that would allow a transfer item to pass validations (meaning the count on hand has to be equal
+      # to the expected_quantity for the transfer)
+      variant.stock_items.update_all count_on_hand: transfer_amount
+
+      described_class.new(ability).activate!
+    end
+
+    it { should be_able_to(:display, Spree::StockItem) }
+    it { should be_able_to(:display, Spree::StockTransfer) }
+    it { should be_able_to(:admin, Spree::StockItem) }
+    it { should be_able_to(:admin, Spree::StockTransfer) }
+
+    context "when the user is associated with one of the locations" do
+      let(:stock_locations) {[source_location]}
+
+      it { should be_able_to(:update, source_stock_item) }
+      it { should_not be_able_to(:update, destination_stock_item) }
+
+      it { should be_able_to(:transfer, source_location) }
+      it { should_not be_able_to(:transfer, destination_location) }
+
+      it { should be_able_to(:manage, transfer_with_source) }
+      it { should_not be_able_to(:manage, transfer_with_destination) }
+      it { should_not be_able_to(:manage, transfer_with_source_and_destination) }
+
+      it { should be_able_to(:manage, source_transfer_item) }
+      it { should_not be_able_to(:manage, destination_transfer_item) }
+      it { should_not be_able_to(:manage, source_and_destination_transfer_item) }
+    end
+
+
+    context "when the user is associated with both locations" do
+      let(:stock_locations) {[source_location, destination_location]}
+
+      it { should be_able_to(:update, source_stock_item) }
+      it { should be_able_to(:update, destination_stock_item) }
+
+      it { should be_able_to(:transfer, source_location) }
+      it { should be_able_to(:transfer, destination_location) }
+
+      it { should be_able_to(:manage, transfer_with_source) }
+      it { should be_able_to(:manage, transfer_with_destination) }
+      it { should be_able_to(:manage, transfer_with_source_and_destination) }
+
+      it { should be_able_to(:manage, source_transfer_item) }
+      it { should be_able_to(:manage, destination_transfer_item) }
+      it { should be_able_to(:manage, source_and_destination_transfer_item) }
+    end
+
+    context "when the user is associated with neither location" do
+      let(:stock_locations) {[]}
+
+      it { should_not be_able_to(:update, source_stock_item) }
+      it { should_not be_able_to(:update, destination_stock_item) }
+
+      it { should_not be_able_to(:transfer, source_location) }
+      it { should_not be_able_to(:transfer, destination_location) }
+
+      it { should_not be_able_to(:manage, transfer_with_source) }
+      it { should_not be_able_to(:manage, transfer_with_destination) }
+      it { should_not be_able_to(:manage, transfer_with_source_and_destination) }
+
+      it { should_not be_able_to(:manage, source_transfer_item) }
+      it { should_not be_able_to(:manage, destination_transfer_item) }
+      it { should_not be_able_to(:manage, source_and_destination_transfer_item) }
+    end
+  end
+
+  context "when not activated" do
+    let(:user) { create :user }
+
+    it { should_not be_able_to(:display, Spree::StockTransfer) }
+    it { should_not be_able_to(:admin, Spree::StockItem) }
+    it { should_not be_able_to(:admin, Spree::StockTransfer) }
+
+    it { should_not be_able_to(:update, source_stock_item) }
+    it { should_not be_able_to(:update, destination_stock_item) }
+
+    it { should_not be_able_to(:transfer, source_location) }
+    it { should_not be_able_to(:transfer, destination_location) }
+
+    it { should_not be_able_to(:manage, transfer_with_source) }
+    it { should_not be_able_to(:manage, transfer_with_destination) }
+    it { should_not be_able_to(:manage, transfer_with_source_and_destination) }
+
+    it { should_not be_able_to(:manage, source_transfer_item) }
+    it { should_not be_able_to(:manage, destination_transfer_item) }
+    it { should_not be_able_to(:manage, source_and_destination_transfer_item) }
+  end
+end
+


### PR DESCRIPTION
This adds a permission set that offers an alternative to `Spree::PermissionSets::StockManagement` in that it authorizes actions based on a users associated stock locations.

I also added a a user method to `Spree::Ability` as it makes sense for the class to store the user it is initialized with, as we need it for more intricate permission sets like this one.