### PR TITLE
Check that preference source exists before using

### DIFF
--- a/core/app/models/spree/preferences/statically_configurable.rb
+++ b/core/app/models/spree/preferences/statically_configurable.rb
@@ -19,7 +19,7 @@ module Spree
       end
 
       def preferences
-        if preference_source.present?
+        if respond_to?(:preference_source) && preference_source
           self.class.preference_sources[preference_source] || {}
         else
           super
@@ -27,7 +27,7 @@ module Spree
       end
 
       def preferences=(val)
-        if preference_source
+        if respond_to?(:preference_source) && preference_source
         else
           super
         end


### PR DESCRIPTION
Not doing so will result in a couple of migrations failing depending on how far along a store is. (Specifically, anything that tries to load a Spree::Gateway record before running the preference_store migration.)