### PR TITLE
Correctly persist addresses on the user from the order

### DIFF
--- a/core/app/models/concerns/spree/user_address.rb
+++ b/core/app/models/concerns/spree/user_address.rb
@@ -12,15 +12,15 @@ module Spree
       accepts_nested_attributes_for :ship_address, :bill_address
 
       def persist_order_address(order)
-        b_address = self.bill_address || self.build_bill_address
-        b_address.attributes = order.bill_address.attributes.except('id', 'updated_at', 'created_at')
-        b_address.save
-        self.update_attributes(bill_address_id: b_address.id)
+        if self.bill_address != order.bill_address
+          b_address = order.bill_address.dup || self.build_bill_address
+          b_address.save
+          self.update_attributes(bill_address_id: b_address.id)
+        end
 
         # May not be present if delivery step has been removed
-        if order.ship_address
-          s_address = self.ship_address || self.build_ship_address
-          s_address.attributes = order.ship_address.attributes.except('id', 'updated_at', 'created_at')
+        if order.ship_address && self.ship_address != order.ship_address
+          s_address = order.ship_address.dup || self.build_ship_address
           s_address.save
           self.update_attributes(ship_address_id: s_address.id)
         end


### PR DESCRIPTION
This wasn't working correctly before; I honestly have no clue how this
code ever worked or why the specs didn't catch this. It doesn't work for
us in production right now. This fixes that.

This is from bonobos/spree#432. It may be silly to fix this now given the
work on support for multiple saved addresses but then it's an issue for us
in production now.