### PR TITLE
Only show "resend" for completed orders

### DIFF
--- a/backend/app/views/spree/admin/orders/cart.html.erb
+++ b/backend/app/views/spree/admin/orders/cart.html.erb
@@ -2,7 +2,7 @@
     <% if can?(:fire, @order) %>
         <li><%= event_links %></li>
     <% end %>
-    <% if can?(:resend, @order) %>
+    <% if can?(:resend, @order) && @order.completed? %>
         <li><%= button_link_to Spree.t(:resend), resend_admin_order_url(@order), :method => :post, :icon => 'email' %></li>
     <% end %>
     <% if can?(:admin, Spree::Order) %>

--- a/backend/app/views/spree/admin/orders/edit.html.erb
+++ b/backend/app/views/spree/admin/orders/edit.html.erb
@@ -2,7 +2,7 @@
   <% if can?(:fire, @order) %>
     <li><%= event_links %></li>
   <% end %>
-  <% if can?(:resend, @order) %>
+  <% if can?(:resend, @order) && @order.completed? %>
     <li><%= button_link_to Spree.t(:resend), resend_admin_order_url(@order), method: :post, icon: 'email' %></li>
   <% end %>
   <% if can?(:admin, Spree::Order) %>


### PR DESCRIPTION
Just triggering specs.  Same thing as https://github.com/bonobos/spree/pull/415

It seems like it makes sense to only "resend" if it's been sent previously.

And it seems reasonable for customized email templates to expect to be given
completed orders (like ours does).  We got an error when an admin accidentally
clicked "resend" on an incomplete order.

(cherry picked from commit 4f83996f0bc7e2b26ce80a9fdbac80eac040cb30 in bonobos/spree)

Conflicts:
  backend/app/views/spree/admin/orders/edit.html.erb