### PR TITLE
Update adjustments without an order reference to have one

### DIFF
--- a/core/db/migrate/20141101231208_fix_adjustment_order_presence.rb
+++ b/core/db/migrate/20141101231208_fix_adjustment_order_presence.rb
@@ -6,7 +6,7 @@ class FixAdjustmentOrderPresence < ActiveRecord::Migration
       if adjustable.is_a? Spree::Order
         adjustment.update_attributes!(order_id: adjustable.id)
       else
-        adjustment.update_attributes!(adjustable: adjustable.order)
+        adjustment.update_attributes!(order_id: adjustable.order.id)
       end
     end
   end


### PR DESCRIPTION
Found this during our upgrade process. It seems a little scary as it is currently written

cc @athal7 