### PR TITLE
Add Api::CreditCardsController#update endpoint

### DIFF
--- a/api/app/controllers/spree/api/credit_cards_controller.rb
+++ b/api/app/controllers/spree/api/credit_cards_controller.rb
@@ -14,7 +14,7 @@ module Spree
       end
 
       def update
-        if @credit_card.update_attributes(credit_card_params)
+        if @credit_card.update_attributes(credit_card_update_params)
           respond_with(@credit_card, default_template: :show)
         else
           invalid_resource!(@credit_card)
@@ -34,7 +34,7 @@ module Spree
           authorize! :update, @credit_card
         end
 
-        def credit_card_params
+        def credit_card_update_params
           params.require(:credit_card).permit(permitted_credit_card_update_attributes)
         end
     end

--- a/api/app/controllers/spree/api/credit_cards_controller.rb
+++ b/api/app/controllers/spree/api/credit_cards_controller.rb
@@ -1,7 +1,8 @@
 module Spree
   module Api
     class CreditCardsController < Spree::Api::BaseController
-      before_action :user
+      before_action :user, only: [:index]
+      before_action :find_credit_card, only: [:update]
 
       def index
         @credit_cards = user
@@ -12,6 +13,14 @@ module Spree
         respond_with(@credit_cards)
       end
 
+      def update
+        if @credit_card.update_attributes(credit_card_params)
+          respond_with(@credit_card, default_template: :show)
+        else
+          invalid_resource!(@credit_card)
+        end
+      end
+
       private
 
         def user
@@ -20,6 +29,14 @@ module Spree
           end
         end
 
+        def find_credit_card
+          @credit_card = Spree::CreditCard.find(params[:id])
+          authorize! :update, @credit_card
+        end
+
+        def credit_card_params
+          params.require(:credit_card).permit(permitted_credit_card_attributes)
+        end
     end
   end
 end

--- a/api/app/controllers/spree/api/credit_cards_controller.rb
+++ b/api/app/controllers/spree/api/credit_cards_controller.rb
@@ -35,7 +35,7 @@ module Spree
         end
 
         def credit_card_params
-          params.require(:credit_card).permit(permitted_credit_card_attributes)
+          params.require(:credit_card).permit(permitted_credit_card_update_attributes)
         end
     end
   end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -108,6 +108,8 @@ Spree::Core::Engine.add_routes do
       resources :credit_cards, only: [:index]
     end
 
+    resources :credit_cards, only: [:update]
+
     resources :properties
     resources :stock_locations do
       resources :stock_movements

--- a/api/spec/controllers/spree/api/credit_cards_controller_spec.rb
+++ b/api/spec/controllers/spree/api/credit_cards_controller_spec.rb
@@ -2,78 +2,80 @@ require 'spec_helper'
 
 module Spree
   describe Api::CreditCardsController, :type => :controller do
-    render_views
+    describe '#index' do
+      render_views
 
-    let!(:admin_user) do
-      user = Spree.user_class.new(:email => "spree@example.com", :id => 1)
-      user.generate_spree_api_key!
-      allow(user).to receive(:has_spree_role?).with('admin').and_return(true)
-      user
-    end
-
-    let!(:normal_user) do
-      user = Spree.user_class.new(:email => "spree2@example.com", :id => 2)
-      user.generate_spree_api_key!
-      user
-    end
-
-    let!(:card) { create(:credit_card, :user_id => admin_user.id, gateway_customer_profile_id: "random") }
-
-    before do
-      stub_authentication!
-    end
-
-    it "the user id doesn't exist" do
-      api_get :index, user_id: 1000
-      expect(response.status).to eq(404)
-    end
-
-    context "calling user is in admin role" do
-      let(:current_api_user) do
-        user = admin_user
+      let!(:admin_user) do
+        user = Spree.user_class.new(:email => "spree@example.com", :id => 1)
+        user.generate_spree_api_key!
+        allow(user).to receive(:has_spree_role?).with('admin').and_return(true)
         user
       end
 
-      it "no credit cards exist for user" do
-        api_get :index, user_id: normal_user.id
-
-        expect(response.status).to eq(200)
-        expect(json_response["pages"]).to eq(0)
-      end
-
-      it "can view all credit cards for user" do
-        api_get :index, user_id: current_api_user.id
-
-        expect(response.status).to eq(200)
-        expect(json_response["pages"]).to eq(1)
-        expect(json_response["current_page"]).to eq(1)
-        expect(json_response["credit_cards"].length).to eq(1)
-        expect(json_response["credit_cards"].first["id"]).to eq(card.id)
-      end
-    end
-
-    context "calling user is not in admin role" do
-      let(:current_api_user) do
-        user = normal_user
+      let!(:normal_user) do
+        user = Spree.user_class.new(:email => "spree2@example.com", :id => 2)
+        user.generate_spree_api_key!
         user
       end
 
-      let!(:card) { create(:credit_card, :user_id => normal_user.id, gateway_customer_profile_id: "random") }
+      let!(:card) { create(:credit_card, :user_id => admin_user.id, gateway_customer_profile_id: "random") }
 
-      it "can not view user" do
-        api_get :index, user_id: admin_user.id
+      before do
+        stub_authentication!
+      end
 
+      it "the user id doesn't exist" do
+        api_get :index, user_id: 1000
         expect(response.status).to eq(404)
       end
 
-      it "can view own credit cards" do
-        api_get :index, user_id: normal_user.id
+      context "calling user is in admin role" do
+        let(:current_api_user) do
+          user = admin_user
+          user
+        end
 
-        expect(response.status).to eq(200)
-        expect(json_response["pages"]).to eq(1)
-        expect(json_response["current_page"]).to eq(1)
-        expect(json_response["credit_cards"].length).to eq(1)
-        expect(json_response["credit_cards"].first["id"]).to eq(card.id)
+        it "no credit cards exist for user" do
+          api_get :index, user_id: normal_user.id
+
+          expect(response.status).to eq(200)
+          expect(json_response["pages"]).to eq(0)
+        end
+
+        it "can view all credit cards for user" do
+          api_get :index, user_id: current_api_user.id
+
+          expect(response.status).to eq(200)
+          expect(json_response["pages"]).to eq(1)
+          expect(json_response["current_page"]).to eq(1)
+          expect(json_response["credit_cards"].length).to eq(1)
+          expect(json_response["credit_cards"].first["id"]).to eq(card.id)
+        end
+      end
+
+      context "calling user is not in admin role" do
+        let(:current_api_user) do
+          user = normal_user
+          user
+        end
+
+        let!(:card) { create(:credit_card, :user_id => normal_user.id, gateway_customer_profile_id: "random") }
+
+        it "can not view user" do
+          api_get :index, user_id: admin_user.id
+
+          expect(response.status).to eq(404)
+        end
+
+        it "can view own credit cards" do
+          api_get :index, user_id: normal_user.id
+
+          expect(response.status).to eq(200)
+          expect(json_response["pages"]).to eq(1)
+          expect(json_response["current_page"]).to eq(1)
+          expect(json_response["credit_cards"].length).to eq(1)
+          expect(json_response["credit_cards"].first["id"]).to eq(card.id)
+        end
       end
     end
   end

--- a/api/spec/controllers/spree/api/credit_cards_controller_spec.rb
+++ b/api/spec/controllers/spree/api/credit_cards_controller_spec.rb
@@ -78,5 +78,35 @@ module Spree
         end
       end
     end
+
+    describe '#update' do
+      let(:credit_card) { create(:credit_card, name: 'Joe Shmoe', user: credit_card_user) }
+      let(:credit_card_user) { create(:user) }
+
+      before do
+        stub_authentication!
+      end
+
+      context 'when the user is authorized' do
+        let(:current_api_user) { credit_card_user }
+
+        it 'updates the credit card' do
+          expect {
+            api_put :update, id: credit_card.to_param, credit_card: {name: 'Jordan Brough'}
+          }.to change {
+            credit_card.reload.name
+          }.from('Joe Shmoe').to('Jordan Brough')
+        end
+      end
+
+      context 'when the user is not authorized' do
+        let(:current_api_user) { create(:user) }
+
+        it 'rejects the request' do
+          api_put :update, id: credit_card.to_param, credit_card: {name: 'Jordan Brough'}
+          expect(response.status).to eq(401)
+        end
+      end
+    end
   end
 end

--- a/core/app/models/spree/ability.rb
+++ b/core/app/models/spree/ability.rb
@@ -49,7 +49,7 @@ module Spree
         can :create, ReturnAuthorization do |return_authorization|
           return_authorization.order.user == user
         end
-        can :display, CreditCard, user_id: user.id
+        can [:display, :update], CreditCard, user_id: user.id
         can :display, Product
         can :display, ProductProperty
         can :display, Property

--- a/core/lib/spree/core/controller_helpers/strong_parameters.rb
+++ b/core/lib/spree/core/controller_helpers/strong_parameters.rb
@@ -10,8 +10,10 @@ module Spree
                  to: :permitted_attributes,
                  prefix: :permitted
 
-        def permitted_credit_card_attributes
-          permitted_source_attributes
+        def permitted_credit_card_update_attributes
+          permitted_attributes.credit_card_update_attributes + [
+            address_attributes: permitted_address_attributes,
+          ]
         end
 
         def permitted_payment_attributes

--- a/core/lib/spree/core/controller_helpers/strong_parameters.rb
+++ b/core/lib/spree/core/controller_helpers/strong_parameters.rb
@@ -10,6 +10,10 @@ module Spree
                  to: :permitted_attributes,
                  prefix: :permitted
 
+        def permitted_credit_card_attributes
+          permitted_source_attributes
+        end
+
         def permitted_payment_attributes
           permitted_attributes.payment_attributes + [
             source_attributes: permitted_source_attributes

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -6,6 +6,7 @@ module Spree
     ATTRIBUTES = [
       :address_attributes,
       :checkout_attributes,
+      :credit_card_update_attributes,
       :customer_return_attributes,
       :image_attributes,
       :inventory_unit_attributes,
@@ -42,6 +43,10 @@ module Spree
 
     @@checkout_attributes = [
       :coupon_code, :email, :shipping_method_id, :special_instructions, :use_billing
+    ]
+
+    @@credit_card_update_attributes = [
+      :month, :year, :expiry, :first_name, :last_name, :name,
     ]
 
     @@customer_return_attributes = [:stock_location_id, return_items_attributes: [:id, :inventory_unit_id, :return_authorization_id, :returned, :pre_tax_amount, :reception_status_event, :acceptance_status, :exchange_variant_id, :resellable]]


### PR DESCRIPTION
To allow updating a user's credit cards. E.g. updating the name or
address on a credit card from the 'my account' page.
