### PR TITLE
Show errors when adding products to shipments in admin

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/shipments.js.erb
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js.erb
@@ -160,9 +160,13 @@ adjustShipmentItems = function(shipment_number, variant_id, quantity){
         data: {
           variant_id: variant_id,
           quantity: new_quantity,
+        },
+        success: function(response) {
+          window.location.reload();
+        },
+        error: function(response) {
+          show_flash('error', response.responseJSON.message);
         }
-      }).done(function( msg ) {
-        window.location.reload();
       });
     }
 }


### PR DESCRIPTION
Currently if you add something via admin and there is an error, nothing is displayed. This will show any validation errors that surface from server.