### PR TITLE
Admin orders new redirects to cart instead of edit

### DIFF
--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -60,7 +60,7 @@ module Spree
       def new
         user = Spree.user_class.find_by_id(params[:user_id]) if params[:user_id]
         @order = Spree::Core::Importer::Order.import(user, order_params)
-        redirect_to edit_admin_order_url(@order)
+        redirect_to cart_admin_order_url(@order)
       end
 
       def edit

--- a/backend/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -105,6 +105,11 @@ describe Spree::Admin::OrdersController, :type => :controller do
           spree_get :new, { user_id: user.id }
         end
       end
+
+      it "should redirect to cart" do
+        spree_get :new
+        expect(response).to redirect_to(spree.cart_admin_order_path(Spree::Order.last))
+      end
     end
 
     # Regression test for #3684


### PR DESCRIPTION
Redirecting to the edit page after creating a new order will prompt the admin for addresses via the shipments UI. This is an issue because the new order has no line items and it will be in the cart state (which is before default addresses are assigned). Since the default addresses haven't been populated, admins will have to guess at or find addresses by other means.

If instead we redirect to the cart page, admins are allowed to add a line item to the order, which also advances through the address state, which will assign any default addresses if present.