### PR TITLE
Use Time.current for completed_at in factory

### DIFF
--- a/core/lib/spree/testing_support/factories/order_factory.rb
+++ b/core/lib/spree/testing_support/factories/order_factory.rb
@@ -47,7 +47,7 @@ FactoryGirl.define do
 
         after(:create) do |order|
           order.refresh_shipment_rates
-          order.update_column(:completed_at, Time.now)
+          order.update_column(:completed_at, Time.current)
         end
 
         factory :completed_order_with_pending_payment do


### PR DESCRIPTION
This fixes a test that fails in the evening when Time.now.to_date
doesn't match Time.current.to_date.