### PR TITLE
Fix spurious failure in stores_controller_spec

### DIFF
--- a/api/spec/controllers/spree/api/stores_controller_spec.rb
+++ b/api/spec/controllers/spree/api/stores_controller_spec.rb
@@ -25,7 +25,7 @@ module Spree
 
       it "I can list the available stores" do
         api_get :index
-        expect(json_response["stores"]).to eq([
+        expect(json_response["stores"]).to match_array([
           {
             "id" => store.id,
             "name" => "My Spree Store",


### PR DESCRIPTION
Fixes this error https://circleci.com/gh/solidusio/solidus/357 from #216.

Use `match_array` instead of `eq`, since it's valid for stores to be returned in any order.