### PR TITLE
Remove ensure_line_items_are_in_stock from order transition to complete

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -425,16 +425,6 @@ module Spree
       end
     end
 
-    def ensure_line_items_are_in_stock
-      if insufficient_stock_lines.present?
-        errors.add(:base, Spree.t(:insufficient_stock_lines_present))
-        restart_checkout_flow
-        false
-      else
-        true
-      end
-    end
-
     def merge!(order, user = nil)
       order.line_items.each do |other_order_line_item|
         next unless other_order_line_item.currency == currency

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -112,7 +112,6 @@ module Spree
               before_transition to: :complete, do: :ensure_available_shipping_rates
               before_transition to: :complete, do: :ensure_promotions_eligible
               before_transition to: :complete, do: :ensure_line_item_variants_are_not_deleted
-              before_transition to: :complete, do: :ensure_line_items_are_in_stock
               before_transition to: :complete, do: :ensure_inventory_units, unless: :unreturned_exchange?
 
               after_transition to: :complete, do: :finalize!

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -103,7 +103,7 @@ module Spree
               end
 
               before_transition to: :resumed, do: :ensure_line_item_variants_are_not_deleted
-              before_transition to: :resumed, do: :ensure_line_items_are_in_stock
+              before_transition to: :resumed, do: :validate_line_item_availability
 
               # Sequence of before_transition to: :complete
               # calls matter so that we do not process payments

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -704,7 +704,6 @@ describe Spree::Order, :type => :model do
       order.stub(:ensure_available_shipping_rates).and_return(true)
       order.stub(:ensure_promotions_eligible).and_return(true)
       order.stub(:ensure_line_item_variants_are_not_deleted).and_return(true)
-      order.stub(:ensure_line_items_are_in_stock).and_return(true)
       order.stub_chain(:line_items, :present?).and_return(true)
       order.stub(validate_line_item_availability: true)
       order.should_not_receive(:payment_required?)

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -120,31 +120,6 @@ describe Spree::Order, :type => :model do
     end
   end
 
-  describe '#ensure_line_items_are_in_stock' do
-    subject { order.ensure_line_items_are_in_stock }
-
-    let(:line_item) { mock_model Spree::LineItem, :insufficient_stock? => true }
-
-    before do
-      allow(order).to receive(:restart_checkout_flow)
-      allow(order).to receive_messages(:line_items => [line_item])
-    end
-
-    it 'should restart checkout flow' do
-      expect(order).to receive(:restart_checkout_flow).once
-      subject
-    end
-
-    it 'should have error message' do
-      subject
-      expect(order.errors[:base]).to include(Spree.t(:insufficient_stock_lines_present))
-    end
-
-    it 'should be false' do
-      expect(subject).to be_falsey
-    end
-  end
-
   context "empty!" do
     let(:order) { stub_model(Spree::Order, item_count: 2) }
 


### PR DESCRIPTION
This is a partial revert of https://github.com/solidusio/solidus/commit/153fad90a18f1b318ac12ef38588d222f8726ed3

The current structure of the `ensure_line_items_are_in_stock ` does not take into account stock locations when determining if the line items have proper stock, which causes issues when you have a store with multiple stock locations with varying stock. I think ultimately this method could be refactored or replaced, but I did not have the bandwidth to look into that yet.

Additionally we have other checks that are better tested and battle-proven to make sure the proper amount of stock is where it needs to be before transitioning to complete in `validate_line_item_availability ` (relevant commit here: https://github.com/bonobos/spree/commit/4aa2b5dfe27a162656c8dd946e16efae3d8fd373)