### PR TITLE
Fix duplicate store credit records in seed data

### DIFF
--- a/core/db/default/spree/store_credit.rb
+++ b/core/db/default/spree/store_credit.rb
@@ -1,8 +1,8 @@
 Spree::StoreCreditCategory.find_or_create_by!(name: Spree.t("store_credit_category.default"))
 
 Spree::PaymentMethod.create_with(
-  name: Spree.t("store_credit.store_credit"),
-  description: Spree.t("store_credit.store_credit"),
+  name: "Store Credit",
+  description: "Store credit",
   active: true,
   display_on: 'none',
 ).find_or_create_by!(
@@ -10,7 +10,11 @@ Spree::PaymentMethod.create_with(
   environment: Rails.env,
 )
 
-Spree::StoreCreditType.create_with(priority: 1).find_or_create_by!(name: Spree.t("store_credit.expiring"))
-Spree::StoreCreditType.create_with(priority: 2).find_or_create_by!(name: Spree.t("store_credit.non_expiring"))
+Spree::StoreCreditType.create_with(priority: 1).find_or_create_by!(name: 'Expiring')
+Spree::StoreCreditType.create_with(priority: 2).find_or_create_by!(name: 'Non-expiring')
 
-Spree::ReimbursementType.create_with(name: Spree.t("store_credit.store_credit")).find_or_create_by!(type: 'Spree::ReimbursementType::StoreCredit')
+Spree::ReimbursementType.create_with(name: "Store Credit").find_or_create_by!(type: 'Spree::ReimbursementType::StoreCredit')
+
+Spree::StoreCreditCategory.find_or_create_by(name: 'Gift Card')
+
+Spree::StoreCreditUpdateReason.find_or_create_by(name: 'Credit Given In Error')

--- a/core/db/seeds.rb
+++ b/core/db/seeds.rb
@@ -3,12 +3,3 @@ default_path = File.join(File.dirname(__FILE__), 'default')
 
 Rake::Task['db:load_dir'].reenable
 Rake::Task['db:load_dir'].invoke(default_path)
-
-Spree::PaymentMethod.find_or_create_by(type: "Spree::PaymentMethod::StoreCredit", name: "Store Credit", description: "Store credit.", active: true, environment: Rails.env, display_on: 'back_end')
-
-Spree::StoreCreditType.find_or_create_by(name: 'Expiring', priority: 1)
-Spree::StoreCreditType.find_or_create_by(name: 'Non-expiring', priority: 2)
-
-Spree::StoreCreditCategory.find_or_create_by(name: 'Gift Card')
-
-Spree::StoreCreditUpdateReason.find_or_create_by(name: 'Credit Given In Error')


### PR DESCRIPTION
This was generating a duplicate `PaymentMethod::StoreCredit` with the wrong settings which was causing errors in the admin (see #193).

Also removed the `Spree.t`, which isn't providing any useful translation when used in a seed.