### PR TITLE
Remove physical attributes from variant factory

### DIFF
--- a/core/lib/spree/testing_support/factories/variant_factory.rb
+++ b/core/lib/spree/testing_support/factories/variant_factory.rb
@@ -5,10 +5,6 @@ FactoryGirl.define do
     price 19.99
     cost_price 17.00
     sku    { generate(:sku) }
-    weight { generate(:random_float) }
-    height { generate(:random_float) }
-    width  { generate(:random_float) }
-    depth  { generate(:random_float) }
     is_master 0
     track_inventory true
 


### PR DESCRIPTION
Factories should only provide the data they need to be valid or
realistic. With random values for width, height, depth, and weight it is
difficult to write tests for any feature which estimates packaging based
on these values.