### PR TITLE
Make searching for orders by SKU better

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/orders/edit.js
+++ b/backend/app/assets/javascripts/spree/backend/orders/edit.js
@@ -2,4 +2,5 @@ $(document).ready(function () {
   'use strict';
 
   $('[data-hook="add_product_name"]').find('.variant_autocomplete').variantAutocomplete({ in_stock_only: true });
+  $("[data-hook='admin_orders_index_search']").find(".variant_autocomplete").variantAutocomplete();
 });

--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -56,11 +56,6 @@
           <%= label_tag :q_email_cont, Spree.t(:email) %>
           <%= f.text_field :email_cont %>
         </div>
-
-        <div class="field" data-hook="sku-select">
-          <%= label_tag :q_line_items_variant_id_in, Spree.t(:sku) %>
-          <%= f.select :line_items_variant_id_in, Spree::Variant.pluck(:sku, :id), {:include_blank => true}, :class => 'select2' %>
-        </div>
       </div>
 
       <div class="four columns">
@@ -80,6 +75,14 @@
             <%= f.check_box :completed_at_not_null, {:checked => @show_only_completed}, '1', '0' %>
             <%= Spree.t(:show_only_complete_orders) %>
           </label>
+        </div>
+      </div>
+
+      <div class="omega eight columns">
+        <div class="field" data-hook="sku-select">
+          <%= label_tag :q_line_items_variant_id_in, Spree.t(:variant) %>
+          <%= f.text_field :line_items_variant_id_in, class: "variant_autocomplete fullwidth" %>
+          <%= render partial: "spree/admin/variants/autocomplete", formats: :js %>
         </div>
       </div>
 

--- a/backend/spec/features/admin/orders/listing_spec.rb
+++ b/backend/spec/features/admin/orders/listing_spec.rb
@@ -59,11 +59,7 @@ describe "Orders Listing", type: :feature, js: true do
 
     it "should be able to filter on variant_id" do
       click_on 'Filter'
-      # Insure we have the SKU in the options
-      expect(find('#q_line_items_variant_id_in').all('option').collect(&:text)).to include(@order1.line_items.first.variant.sku)
-
-      # Select and filter
-      find('#q_line_items_variant_id_in').find(:xpath, 'option[2]').select_option
+      select2_search @order1.products.first.sku, from: Spree.t(:variant)
       click_on 'Filter Results'
 
       within_row(1) do


### PR DESCRIPTION
Use an AJAX call with the existing variant autocomplete stuff to find the variant. Will work much better for stores with a large number of variants. Because rendering a select box with +100,000 options is slow and impractical.