### PR TITLE
check for environment in paymant method migration

### DIFF
--- a/core/db/migrate/20150506181611_create_spree_store_credit_payment_method.rb
+++ b/core/db/migrate/20150506181611_create_spree_store_credit_payment_method.rb
@@ -5,27 +5,11 @@ class CreateSpreeStoreCreditPaymentMethod < ActiveRecord::Migration
   end
 
   def up
-    # Check if there is an environment column for users
-    # that are migrating from Spree 3.0.
-    if PaymentMethod.column_names.include? 'environment'
-      PaymentMethod.create_with(
-        name: Spree.t("store_credit.store_credit"),
-        description: Spree.t("store_credit.store_credit"),
-        active: true,
-        display_on: 'none',
-      ).find_or_create_by!(
-        type: "Spree::PaymentMethod::StoreCredit",
-        environment: Rails.env,
-      )
-    else
-      PaymentMethod.create_with(
-        name: Spree.t("store_credit.store_credit"),
-        description: Spree.t("store_credit.store_credit"),
-        active: true,
-        display_on: 'none',
-      ).find_or_create_by!(
-        type: "Spree::PaymentMethod::StoreCredit"
-      )
-    end
+    PaymentMethod.create_with(
+      name: Spree.t("store_credit.store_credit"),
+      description: Spree.t("store_credit.store_credit"),
+      active: true,
+      display_on: 'none',
+    ).find_or_create_by!(type: "Spree::PaymentMethod::StoreCredit")
   end
 end

--- a/core/db/migrate/20150506181611_create_spree_store_credit_payment_method.rb
+++ b/core/db/migrate/20150506181611_create_spree_store_credit_payment_method.rb
@@ -3,15 +3,29 @@ class CreateSpreeStoreCreditPaymentMethod < ActiveRecord::Migration
     self.table_name = 'spree_payment_methods'
     self.inheritance_column = :_type_disabled
   end
+
   def up
-    PaymentMethod.create_with(
-      name: Spree.t("store_credit.store_credit"),
-      description: Spree.t("store_credit.store_credit"),
-      active: true,
-      display_on: 'none',
-    ).find_or_create_by!(
-      type: "Spree::PaymentMethod::StoreCredit",
-      environment: Rails.env,
-    )
+    # Check if there is an environment column for users
+    # that are migrating from Spree 3.0.
+    if PaymentMethod.column_names.include? 'environment'
+      PaymentMethod.create_with(
+        name: Spree.t("store_credit.store_credit"),
+        description: Spree.t("store_credit.store_credit"),
+        active: true,
+        display_on: 'none',
+      ).find_or_create_by!(
+        type: "Spree::PaymentMethod::StoreCredit",
+        environment: Rails.env,
+      )
+    else
+      PaymentMethod.create_with(
+        name: Spree.t("store_credit.store_credit"),
+        description: Spree.t("store_credit.store_credit"),
+        active: true,
+        display_on: 'none',
+      ).find_or_create_by!(
+        type: "Spree::PaymentMethod::StoreCredit"
+      )
+    end
   end
 end


### PR DESCRIPTION
While migrating from Spree 3.0 at spree/spree@f71268935181e98e84aa9dc74ad5fdac526f96ff I received:

```ruby
== 20150730004961 CreateSpreeStoreCreditPaymentMethod: migrating ==============
rake aborted!
StandardError: An error has occurred, this and all later migrations canceled:

PG::UndefinedColumn: ERROR:  column spree_payment_methods.environment does not exist
LINE 1: ...ds" WHERE "spree_payment_methods"."type" = $1 AND "spree_pay...
```

This PR attempts to fix this.