### PR TITLE
remove return authorization reason seeds in migration

### DIFF
--- a/core/db/migrate/20140713140455_create_spree_return_authorization_reasons.rb
+++ b/core/db/migrate/20140713140455_create_spree_return_authorization_reasons.rb
@@ -8,22 +8,6 @@ class CreateSpreeReturnAuthorizationReasons < ActiveRecord::Migration
       t.timestamps null: true
     end
 
-    reversible do |direction|
-      direction.up do
-        if defined?(Spree::ReturnAuthorizationReason)
-          Spree::ReturnAuthorizationReason.create!(name: 'Better price available')
-          Spree::ReturnAuthorizationReason.create!(name: 'Missed estimated delivery date')
-          Spree::ReturnAuthorizationReason.create!(name: 'Missing parts or accessories')
-          Spree::ReturnAuthorizationReason.create!(name: 'Damaged/Defective')
-          Spree::ReturnAuthorizationReason.create!(name: 'Different from what was ordered')
-          Spree::ReturnAuthorizationReason.create!(name: 'Different from description')
-          Spree::ReturnAuthorizationReason.create!(name: 'No longer needed/wanted')
-          Spree::ReturnAuthorizationReason.create!(name: 'Accidental order')
-          Spree::ReturnAuthorizationReason.create!(name: 'Unauthorized purchase')
-        end
-      end
-    end
-
     add_column :spree_return_authorizations, :return_authorization_reason_id, :integer
     add_index :spree_return_authorizations, :return_authorization_reason_id, name: 'index_return_authorizations_on_return_authorization_reason_id'
   end


### PR DESCRIPTION
This data is sitting in the seeds and probably doesn’t belong in a
migration anyways.

Also, while doing a Spree 3 --> Solidus transition, I discovered that there was an existing migration with this name failing. I've updated the migration and removed this in favour of what the seeds provide me.

Although the application will function just as it always has with this code, I'm removing it because we don't need it anymore. Solidus and Spree already seed the return authorizations in, well, the seeds.

[#deletecode](https://twitter.com/search?q=%23deletecode)