### PR TITLE
Add image factory

### DIFF
--- a/core/lib/spree/testing_support/factories/image_factory.rb
+++ b/core/lib/spree/testing_support/factories/image_factory.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :image, class: Spree::Image do
+    attachment { File.new(Spree::Core::Engine.root + "spec/fixtures" + 'thinking-cat.jpg') }
+  end
+end

--- a/core/lib/spree/testing_support/factories/image_factory.rb
+++ b/core/lib/spree/testing_support/factories/image_factory.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
   factory :image, class: Spree::Image do
-    attachment { File.new(Spree::Core::Engine.root + "spec/fixtures" + 'thinking-cat.jpg') }
+    attachment { File.new(Spree::Core::Engine.root + "spec/fixtures/thinking-cat.jpg') }
   end
 end

--- a/core/lib/spree/testing_support/factories/image_factory.rb
+++ b/core/lib/spree/testing_support/factories/image_factory.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
   factory :image, class: Spree::Image do
-    attachment { File.new(Spree::Core::Engine.root + "spec/fixtures/thinking-cat.jpg') }
+    attachment { File.new(Spree::Core::Engine.root + 'spec/fixtures/thinking-cat.jpg') }
   end
 end


### PR DESCRIPTION
The `Spree::Image` model doesn't actually have a factory and I ended up using the `image` factory a lot in one of my apps. This PR basically takes the work from spree/spree 6323