### PR TITLE
Standardize rake test_app warning

### DIFF
--- a/api/spec/spec_helper.rb
+++ b/api/spec/spec_helper.rb
@@ -17,8 +17,8 @@ ENV["RAILS_ENV"] ||= 'test'
 begin
   require File.expand_path("../dummy/config/environment", __FILE__)
 rescue LoadError
-  puts "Could not load dummy application. Please ensure you have run `bundle exec rake test_app`"
-  exit
+  $stderr.puts "Could not load dummy application. Please ensure you have run `bundle exec rake test_app`"
+  exit 1
 end
 
 require 'rspec/rails'

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -18,8 +18,8 @@ ENV["RAILS_ENV"] ||= 'test'
 begin
   require File.expand_path("../dummy/config/environment", __FILE__)
 rescue LoadError
-  puts "Could not load dummy application. Please ensure you have run `bundle exec rake test_app`"
-  exit
+  $stderr.puts "Could not load dummy application. Please ensure you have run `bundle exec rake test_app`"
+  exit 1
 end
 
 require 'rspec/rails'

--- a/core/spec/spec_helper.rb
+++ b/core/spec/spec_helper.rb
@@ -19,7 +19,8 @@ ENV["RAILS_ENV"] ||= 'test'
 begin
   require File.expand_path("../dummy/config/environment", __FILE__)
 rescue LoadError
-  puts "Could not load dummy application. Please ensure you have run `bundle exec rake test_app`"
+  $stderr.puts "Could not load dummy application. Please ensure you have run `bundle exec rake test_app`"
+  exit 1
 end
 
 require 'rspec/rails'

--- a/frontend/spec/spec_helper.rb
+++ b/frontend/spec/spec_helper.rb
@@ -18,8 +18,8 @@ ENV["RAILS_ENV"] ||= 'test'
 begin
   require File.expand_path("../dummy/config/environment", __FILE__)
 rescue LoadError
-  puts "Could not load dummy application. Please ensure you have run `bundle exec rake test_app`"
-  exit
+  $stderr.puts "Could not load dummy application. Please ensure you have run `bundle exec rake test_app`"
+  exit 1
 end
 
 require 'rspec/rails'

--- a/sample/spec/spec_helper.rb
+++ b/sample/spec/spec_helper.rb
@@ -1,7 +1,14 @@
 # This file is copied to ~/spec when you run 'ruby script/generate rspec'
 # from the project root directory.
 ENV["RAILS_ENV"] ||= 'test'
-require File.expand_path("../dummy/config/environment", __FILE__)
+
+begin
+  require File.expand_path("../dummy/config/environment", __FILE__)
+rescue LoadError
+  $stderr.puts "Could not load dummy application. Please ensure you have run `bundle exec rake test_app`"
+  exit 1
+end
+
 require 'rspec/rails'
 require 'ffaker'
 require 'spree_sample'


### PR DESCRIPTION
This should always print the same warning to STDERR, and then exit with a failure code.