### PR TITLE
Use DbMaximumLengthValidator on product_properties.value

### DIFF
--- a/core/app/models/spree/product_property.rb
+++ b/core/app/models/spree/product_property.rb
@@ -4,7 +4,7 @@ module Spree
     belongs_to :property, class_name: 'Spree::Property', inverse_of: :product_properties
 
     validates :property, presence: true
-    validates :value, length: { maximum: 255 }
+    validates_with Spree::Validations::DbMaximumLengthValidator, field: :value
 
     default_scope -> { order("#{self.table_name}.position") }
 

--- a/core/spec/models/spree/product_property_spec.rb
+++ b/core/spec/models/spree/product_property_spec.rb
@@ -3,8 +3,12 @@ require 'spec_helper'
 describe Spree::ProductProperty, :type => :model do
 
   context "validations" do
-    # Only MySQL and stores that were migrated prior to the Rails 4.1(?) upgrade
-    # have length limitations on "value".
+    # Only MySQL stores or stores that were migrated prior to the Rails 4.2
+    # upgrade have length limitations on "value":
+    # > The PostgreSQL and SQLite adapters no longer add a default limit of 255
+    # > characters on string columns.
+    # http://guides.rubyonrails.org/4_2_release_notes.html#active-record-notable-changes
+    # https://github.com/rails/rails/pull/14579
     if Spree::ProductProperty.columns_hash['value'].limit
       it "should validate length of value" do
         pp = create(:product_property)

--- a/core/spec/models/spree/product_property_spec.rb
+++ b/core/spec/models/spree/product_property_spec.rb
@@ -3,10 +3,15 @@ require 'spec_helper'
 describe Spree::ProductProperty, :type => :model do
 
   context "validations" do
-    it "should validate length of value" do
-      pp = create(:product_property)
-      pp.value = "x" * 256
-      expect(pp).not_to be_valid
+    # Only MySQL and stores that were migrated prior to the Rails 4.1(?) upgrade
+    # have length limitations on "value".
+    if Spree::ProductProperty.columns_hash['value'].limit
+      it "should validate length of value" do
+        pp = create(:product_property)
+        overflow_length = Spree::ProductProperty.columns_hash['value'].limit + 1
+        pp.value = "x" * overflow_length
+        expect(pp).not_to be_valid
+      end
     end
   end
 


### PR DESCRIPTION
This was reverted in 31352dae44d1db7ce09cf195e2f8ce2168bce1ca but it
seems to actually work.  Currently only MySQL seems to have a length
restriction on the "value" field here.