### PR TITLE
Product Property list positions update

### DIFF
--- a/core/app/models/spree/product_property.rb
+++ b/core/app/models/spree/product_property.rb
@@ -1,5 +1,6 @@
 module Spree
   class ProductProperty < Spree::Base
+    acts_as_list
     belongs_to :product, touch: true, class_name: 'Spree::Product', inverse_of: :product_properties
     belongs_to :property, class_name: 'Spree::Property', inverse_of: :product_properties
 


### PR DESCRIPTION
In admin the list positions of the drag and drop table in Product Property was not allowing update due to the missing method :set_list_position.

The ActsAsList gem needs the line 'acts_as_list' inside the model of product property in order to give us the method set_list_position.

This adds that line back in so that the positions can be updated as intended.