### PR TITLE
Outstanding balance refunds

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -329,6 +329,13 @@ module Spree
     def outstanding_balance
       if state == 'canceled'
         -1 * payment_total
+      elsif reimbursements.includes(:refunds).size > 0
+        reimbursed = reimbursements.includes(:refunds).inject(0) do |sum, reimbursement|
+          sum + reimbursement.refunds.sum(:amount)
+        end
+        # If reimbursement has happened add it back to total to prevent balance_due payment state
+        # See: https://github.com/spree/spree/issues/6229
+        total - (payment_total + reimbursed)
       else
         total - payment_total
       end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -803,6 +803,17 @@ describe Spree::Order, :type => :model do
     end
   end
 
+  context "#refund_total" do
+    let(:order)  { reimbursement.order.reload }
+    let(:reimbursement) { create(:reimbursement) }
+    let!(:refund) { create(:refund, reimbursement: reimbursement, amount: 5) }
+    let!(:refund2) { create(:refund, reimbursement: reimbursement, amount: 3) }
+
+    it "sums the reimbursment refunds on the order" do
+      expect(order.refund_total).to eq(8.0)
+    end
+  end
+
   describe '#quantity' do
     # Uses a persisted record, as the quantity is retrieved via a DB count
     let(:order) { create :order_with_line_items, line_items_count: 3 }


### PR DESCRIPTION
Currently `Order#payment_total` takes into account refunds, but `Order#payment_state` does not. This has been rectified in the head of master on spree, so I'm pulling in that commit plus a slight refactoring. 