### PR TITLE
Prefer credit card bill address to order address

### DIFF
--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -106,8 +106,13 @@ module Spree
                          :discount => order.promo_total * 100,
                          :currency => currency })
 
-        options.merge!({ :billing_address  => order.bill_address.try(:active_merchant_hash),
-                        :shipping_address => order.ship_address.try(:active_merchant_hash) })
+        bill_address = source.is_a?(Spree::CreditCard) && source.address
+        bill_address ||= order.bill_address
+
+        options.merge!(
+          billing_address: bill_address.try(:active_merchant_hash),
+          shipping_address: order.ship_address.try(:active_merchant_hash),
+        )
 
         options
       end

--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -106,12 +106,12 @@ module Spree
                          :discount => order.promo_total * 100,
                          :currency => currency })
 
-        bill_address = source.is_a?(Spree::CreditCard) && source.address
+        bill_address = source.try(:address)
         bill_address ||= order.bill_address
 
         options.merge!(
-          billing_address: bill_address.try(:active_merchant_hash),
-          shipping_address: order.ship_address.try(:active_merchant_hash),
+          billing_address: bill_address.try!(:active_merchant_hash),
+          shipping_address: order.ship_address.try!(:active_merchant_hash),
         )
 
         options

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -253,6 +253,70 @@ describe Spree::Payment, :type => :model do
         payment.authorize!
       end
 
+      describe 'billing_address option' do
+        context 'when the source is a credit card with an address' do
+          let(:card) { create(:credit_card, address: address) }
+          let(:address) { create(:address) }
+
+          it 'sends the credit card address' do
+            expect(payment.payment_method).to(
+              receive(:authorize).
+                with(
+                  amount_in_cents,
+                  card,
+                  hash_including(billing_address: card.address.active_merchant_hash)
+                ).
+                and_return(success_response)
+            )
+            payment.authorize!
+          end
+        end
+
+        context 'when the source is a credit card without an address' do
+          let(:card) { create(:credit_card, address: nil) }
+          before { order.update_attributes!(bill_address: address) }
+          let(:address) { create(:address) }
+
+          it 'send the order bill address' do
+            expect(payment.payment_method).to(
+              receive(:authorize).
+                with(
+                  amount_in_cents,
+                  card,
+                  hash_including(billing_address: order.bill_address.active_merchant_hash)
+                ).
+                and_return(success_response)
+            )
+            payment.authorize!
+          end
+        end
+
+        context 'when the source is not a credit card' do
+          before do
+            payment.source = store_credit_payment
+            payment.payment_method = store_credit_payment_method
+          end
+
+          let(:store_credit_payment) { create(:store_credit_payment) }
+          let(:store_credit_payment_method) { create(:store_credit_payment_method) }
+          before { order.update_attributes!(bill_address: address) }
+          let(:address) { create(:address) }
+
+          it 'send the order bill address' do
+            expect(payment.payment_method).to(
+              receive(:authorize).
+                with(
+                  amount_in_cents,
+                  store_credit_payment,
+                  hash_including(billing_address: order.bill_address.active_merchant_hash)
+                ).
+                and_return(success_response)
+            )
+            payment.authorize!
+          end
+        end
+      end
+
       context "when gateway does not match the environment" do
         it "should raise an exception" do
           allow(gateway).to receive_messages :environment => "foo"


### PR DESCRIPTION
When sending payments to processors.  Since credit cards now have
addresses.