### PR TITLE
Replace binary_inventory_cache with inventory_cache_threshold

### DIFF
--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -80,8 +80,16 @@ module Spree
     #   quantity. Setting this to true should make operations on inventory
     #   faster.
     #   (default: +false+)
+    #   @deprecated - use inventory_cache_threshold instead
     #   @return [Boolean]
     preference :binary_inventory_cache, :boolean, default: false
+
+    # @!attribute [rw] inventory_cache_threshold
+    #   Only invalidate product caches when the count on hand for a stock item
+    #   falls below or rises about the inventory_cache_threshold.  When undefined, the
+    #   product caches will be invalidated anytime the count on hand is changed.
+    #   @return [Integer]
+    preference :inventory_cache_threshold, :integer
 
     # @!attribute [rw] checkout_zone
     #   @return [String] Name of a {Zone}, which limits available countries to those included in that zone. (default: +nil+)

--- a/core/lib/generators/spree/install/templates/config/initializers/spree.rb
+++ b/core/lib/generators/spree/install/templates/config/initializers/spree.rb
@@ -18,9 +18,10 @@ Spree.config do |config|
   # Uncomment to stop tracking inventory levels in the application
   # config.track_inventory_levels = false
 
-  # When true, product caches are only invalidated when they come in or out of
-  # stock. Default is to invalidate cache on any inventory changes.
-  # config.binary_inventory_cache = true
+  # When set, product caches are only invalidated when they fall below or rise
+  # above the inventory_cache_threshold that is set. Default is to invalidate cache on
+  # any inventory changes.
+  # config.inventory_cache_threshold = 3
 
 
   # Frontend:


### PR DESCRIPTION
This allows a store to define a threshold for which the cache of a product
is invalidated should the stock count fall below or rise above the set
threshold.

Should the store not set a threshold the cache will be invalidated on
any stock change.