### PR TITLE
Update reference to solidus:auth:install

### DIFF
--- a/lib/sandbox.sh
+++ b/lib/sandbox.sh
@@ -35,4 +35,4 @@ RUBY
 bundle install --gemfile Gemfile
 bundle exec rake db:drop db:create
 bundle exec rails g spree:install --auto-accept --user_class=Spree::User --enforce_available_locales=true
-bundle exec rails g spree:auth:install
+bundle exec rails g solidus:auth:install


### PR DESCRIPTION
To fix these errors when generating a sandbox:

> Could not find generator 'spree:auth:install'. Maybe you meant 'spree:install', 'solidus:auth:install' or 'devise:install'
> Run `rails generate --help` for more options.