### PR TITLE
Make Order#refund_total use payments and refunds instead of through reimbursements

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -343,9 +343,7 @@ module Spree
     end
 
     def refund_total
-      reimbursements.includes(:refunds).inject(0) do |sum, reimbursement|
-        sum + reimbursement.refunds.sum(:amount)
-      end
+      payments.flat_map(&:refunds).sum(&:amount)
     end
 
     def name

--- a/core/spec/models/spree/order/state_machine_spec.rb
+++ b/core/spec/models/spree/order/state_machine_spec.rb
@@ -174,6 +174,7 @@ describe Spree::Order, :type => :model do
         allow(order).to receive_message_chain(:payments, :completed, :includes).and_return([payment])
         allow(order).to receive_message_chain(:payments, :last).and_return(payment)
         allow(order).to receive_message_chain(:payments, :store_credits, :pending).and_return([payment])
+        allow(order).to receive(:refund_total).and_return(0)
       end
 
       context "without shipped items" do

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -804,13 +804,12 @@ describe Spree::Order, :type => :model do
   end
 
   context "#refund_total" do
-    let(:order)  { reimbursement.order.reload }
-    let(:reimbursement) { create(:reimbursement) }
-    let!(:refund) { create(:refund, reimbursement: reimbursement, amount: 5) }
-    let!(:refund2) { create(:refund, reimbursement: reimbursement, amount: 3) }
+    let(:order) { create(:order_with_line_items) }
+    let!(:payment) { create(:payment_with_refund, order: order) }
+    let!(:payment2) { create(:payment_with_refund, order: order) }
 
     it "sums the reimbursment refunds on the order" do
-      expect(order.refund_total).to eq(8.0)
+      expect(order.refund_total).to eq(10.0)
     end
   end
 

--- a/core/spec/models/spree/order_updater_spec.rb
+++ b/core/spec/models/spree/order_updater_spec.rb
@@ -109,6 +109,7 @@ module Spree
     context "updating payment state" do
       let(:order) { Order.new }
       let(:updater) { order.updater }
+      before { order.stub(:refund_total).and_return(0) }
 
       context 'no valid payments with non-zero order total' do
         it "is failed" do


### PR DESCRIPTION
An order with refunded payments (without an attached reimbursement) should have refund_total reflect all combinations of these things. Go through `payments -> refunds` instead of `reimbursements -> refunds`