### PR TITLE
Only touch variants from option value if changed

### DIFF
--- a/core/app/models/spree/option_value.rb
+++ b/core/app/models/spree/option_value.rb
@@ -9,7 +9,7 @@ module Spree
     validates :name, presence: true, uniqueness: { scope: :option_type_id }
     validates :presentation, presence: true
 
-    after_save :touch
+    after_save :touch, if: :changed?
     after_touch :touch_all_variants
 
     # Updates the updated_at column on all the variants associated with this

--- a/core/spec/models/spree/option_value_spec.rb
+++ b/core/spec/models/spree/option_value_spec.rb
@@ -12,7 +12,7 @@ describe Spree::OptionValue, :type => :model do
     it "should touch a variant" do
       Timecop.freeze do
         option_value.touch
-        expect(variant.reload.updated_at).to eq(Time.now)
+        expect(variant.reload.updated_at).to be_within(1.second).of(Time.now)
       end
     end
 
@@ -28,7 +28,7 @@ describe Spree::OptionValue, :type => :model do
         Timecop.freeze do
           option_value.name += "--1"
           option_value.save!
-          expect(variant.reload.updated_at).to eq(Time.now)
+          expect(variant.reload.updated_at).to be_within(1.second).of(Time.now)
         end
       end
     end


### PR DESCRIPTION
Currently, we touch all matching variants on an option value save,
regardless of whether the option value has changed or not. However, that
touch can be very painful (if you save the size "L", that'll touch all
variants of that size which in our case is a lot). So it seems more
prudent to only do the touch if the option value actually changed.