### PR TITLE
Add display permissions to stock locations for restricted stock transfer management.

### DIFF
--- a/core/app/models/spree/permission_sets/restricted_transfer_management.rb
+++ b/core/app/models/spree/permission_sets/restricted_transfer_management.rb
@@ -14,7 +14,8 @@ module Spree
         can [:display, :admin], Spree::StockTransfer
 
         if user.stock_locations.any?
-          can :transfer, Spree::StockLocation, id: location_ids
+          # We need display here, as by default users cannot see inactive stock locations.
+          can [:display, :transfer], Spree::StockLocation, id: location_ids
           can :update, Spree::StockItem, stock_location_id: location_ids
           can :manage, Spree::StockTransfer, source_location_id: location_ids, destination_location_id: location_ids
           can :manage, Spree::TransferItem, stock_transfer: {

--- a/core/spec/models/spree/permission_sets/restricted_transfer_management_spec.rb
+++ b/core/spec/models/spree/permission_sets/restricted_transfer_management_spec.rb
@@ -5,8 +5,10 @@ describe Spree::PermissionSets::RestrictedTransferManagement do
 
   subject { ability }
 
-  let!(:source_location) { create :stock_location }
-  let!(:destination_location) { create :stock_location }
+  # Inactive stock locations will default to not being visible
+  # for users without explicit permissions.
+  let!(:source_location) { create :stock_location, active: false }
+  let!(:destination_location) { create :stock_location, active: false }
 
   # This has the side effect of creating a stock item for each stock location above,
   # which is what we actually want.
@@ -60,6 +62,9 @@ describe Spree::PermissionSets::RestrictedTransferManagement do
       it { is_expected.to be_able_to(:transfer, source_location) }
       it { is_expected.not_to be_able_to(:transfer, destination_location) }
 
+      it { is_expected.to be_able_to(:display, source_location) }
+      it { is_expected.not_to be_able_to(:display, destination_location) }
+
       it { is_expected.to be_able_to(:manage, transfer_with_source) }
       it { is_expected.not_to be_able_to(:manage, transfer_with_destination) }
       it { is_expected.not_to be_able_to(:manage, transfer_with_source_and_destination) }
@@ -78,6 +83,9 @@ describe Spree::PermissionSets::RestrictedTransferManagement do
 
       it { is_expected.to be_able_to(:transfer, source_location) }
       it { is_expected.to be_able_to(:transfer, destination_location) }
+
+      it { is_expected.to be_able_to(:display, source_location) }
+      it { is_expected.to be_able_to(:display, destination_location) }
 
       it { is_expected.to be_able_to(:manage, transfer_with_source) }
       it { is_expected.to be_able_to(:manage, transfer_with_destination) }
@@ -119,6 +127,10 @@ describe Spree::PermissionSets::RestrictedTransferManagement do
 
     it { is_expected.not_to be_able_to(:transfer, source_location) }
     it { is_expected.not_to be_able_to(:transfer, destination_location) }
+
+    it { is_expected.not_to be_able_to(:display, source_location) }
+    it { is_expected.not_to be_able_to(:display, destination_location) }
+
 
     it { is_expected.not_to be_able_to(:manage, transfer_with_source) }
     it { is_expected.not_to be_able_to(:manage, transfer_with_destination) }


### PR DESCRIPTION
This allows users to make transfers to and from inactive stock locations if they are associated with them.