### PR TITLE
Run callbacks when opening and closing adjustments in admin

### DIFF
--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -153,7 +153,7 @@ module Spree
 
       def open_adjustments
         adjustments = @order.all_adjustments.where(state: 'closed')
-        adjustments.update_all(state: 'open')
+        adjustments.each &:open!
         flash[:success] = Spree.t(:all_adjustments_opened)
 
         respond_with(@order) { |format| format.html { redirect_to :back } }
@@ -161,7 +161,7 @@ module Spree
 
       def close_adjustments
         adjustments = @order.all_adjustments.where(state: 'open')
-        adjustments.update_all(state: 'closed')
+        adjustments.each &:close!
         flash[:success] = Spree.t(:all_adjustments_closed)
 
         respond_with(@order) { |format| format.html { redirect_to :back } }

--- a/backend/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -297,16 +297,17 @@ describe Spree::Admin::OrdersController, :type => :controller do
 
     context "#open_adjustments" do
       let(:closed) { double('closed_adjustments') }
+      let(:closed_adjustment) { double }
 
       before do
         allow(adjustments).to receive(:where).and_return(closed)
-        allow(closed).to receive(:update_all)
+        allow(closed).to receive(:each).and_return([])
       end
 
       it "changes all the closed adjustments to open" do
         expect(adjustments).to receive(:where).with(state: 'closed')
-          .and_return(closed)
-        expect(closed).to receive(:update_all).with(state: 'open')
+          .and_return([closed_adjustment])
+        expect(closed_adjustment).to receive(:open!)
         spree_post :open_adjustments, id: order.number
       end
 
@@ -323,16 +324,17 @@ describe Spree::Admin::OrdersController, :type => :controller do
 
     context "#close_adjustments" do
       let(:open) { double('open_adjustments') }
+      let(:open_adjustment) { double }
 
       before do
         allow(adjustments).to receive(:where).and_return(open)
-        allow(open).to receive(:update_all)
+        allow(open).to receive(:each).and_return([])
       end
 
       it "changes all the open adjustments to closed" do
         expect(adjustments).to receive(:where).with(state: 'open')
-          .and_return(open)
-        expect(open).to receive(:update_all).with(state: 'closed')
+          .and_return([open_adjustment])
+        expect(open_adjustment).to receive(:close!)
         spree_post :close_adjustments, id: order.number
       end
 


### PR DESCRIPTION
Currently we don't run callbacks when opening and closing adjustments via admin. I don't see any callbacks that look dubious, and we are bypassing validations, which isn't ideal. Updates the controller to use the state machine transitions, which will trigger validations.