### PR TITLE
Fix issue running the install generator

### DIFF
--- a/core/app/models/spree/promotion/rules/user.rb
+++ b/core/app/models/spree/promotion/rules/user.rb
@@ -4,10 +4,9 @@ module Spree
       class User < PromotionRule
         belongs_to :user, class_name: Spree::UserClassHandle.new
 
-        has_and_belongs_to_many :users, class_name: Spree::UserClassHandle.new,
-          join_table: 'spree_promotion_rules_users',
-          foreign_key: 'promotion_rule_id',
-          association_foreign_key: :user_id
+        has_many :promotion_rule_users, class_name: 'Spree::PromotionRuleUser',
+                                        foreign_key: :promotion_rule_id
+        has_many :users, through: :promotion_rule_users, class_name: Spree::UserClassHandle.new
 
         def applicable?(promotable)
           promotable.is_a?(Spree::Order)

--- a/core/app/models/spree/promotion_rule_user.rb
+++ b/core/app/models/spree/promotion_rule_user.rb
@@ -1,0 +1,8 @@
+module Spree
+  class PromotionRuleUser < Spree::Base
+    self.table_name = 'spree_promotion_rules_users'
+
+    belongs_to :promotion_rule, class_name: 'Spree::PromotionRule'
+    belongs_to :user, class_name: Spree::UserClassHandle.new
+  end
+end

--- a/core/config/initializers/spree_user.rb
+++ b/core/config/initializers/spree_user.rb
@@ -3,7 +3,7 @@
 # are still doing for compatability, but with a warning.
 
 Spree::Core::Engine.config.to_prepare do
-  unless Spree.user_class.included_modules.include?(Spree::UserMethods)
+  if Spree.user_class && !Spree.user_class.included_modules.include?(Spree::UserMethods)
     ActiveSupport::Deprecation.warn "#{Spree.user_class} must include Spree::UserMethods"
     Spree.user_class.include Spree::UserMethods
   end

--- a/core/db/migrate/20150806190833_add_id_and_timestamp_to_promotion_rule_user.rb
+++ b/core/db/migrate/20150806190833_add_id_and_timestamp_to_promotion_rule_user.rb
@@ -1,0 +1,13 @@
+class AddIdAndTimestampToPromotionRuleUser < ActiveRecord::Migration
+  def up
+    add_column :spree_promotion_rules_users, :id, :primary_key
+    add_column :spree_promotion_rules_users, :created_at, :datetime
+    add_column :spree_promotion_rules_users, :updated_at, :datetime
+  end
+
+  def down
+    remove_column :spree_promotion_rules_users, :updated_at
+    remove_column :spree_promotion_rules_users, :created_at
+    remove_column :spree_promotion_rules_users, :id
+  end
+end


### PR DESCRIPTION
The install generator raised errors (possibly just in some cases) when being run in a new store. This is because of the new more strict checks on `Spree.user_class` not being nil.

Fixed by:
* Skipping deprecation warning and include if `user_class` is nil.
* Backporting one of @BenMorganIO's HABTM splitting commits (which we'll eventually include all of), as UserClassHandle doesn't work in a HABTM, as it is `to_s`'d immediately.