### PR TITLE
Remove admin params logic in api orders controller. It is duplicated elsewhere

### DIFF
--- a/api/app/controllers/spree/api/orders_controller.rb
+++ b/api/app/controllers/spree/api/orders_controller.rb
@@ -5,7 +5,7 @@ module Spree
       self.admin_shipment_attributes = [:shipping_method, :stock_location, :inventory_units => [:variant_id, :sku]]
 
       class_attribute :admin_order_attributes
-      self.admin_order_attributes = [:import, :number, :completed_at, :locked_at, :channel, :user_id]
+      self.admin_order_attributes = [:import, :number, :completed_at, :locked_at, :channel, :user_id, :created_at]
 
       skip_before_action :authenticate_user, only: :apply_coupon_code
 

--- a/api/app/controllers/spree/api/orders_controller.rb
+++ b/api/app/controllers/spree/api/orders_controller.rb
@@ -34,13 +34,7 @@ module Spree
           current_api_user
         end
 
-        import_params = if can?(:admin, Spree::Order)
-          params[:order].present? ? params[:order].permit! : {}
-        else
-          order_params
-        end
-
-        @order = Spree::Core::Importer::Order.import(order_user, import_params)
+        @order = Spree::Core::Importer::Order.import(order_user, order_params)
         respond_with(@order, default_template: :show, status: 201)
       end
 


### PR DESCRIPTION
If you check `def order_params` it already takes care of permitting admin-related parameters. Additionally, the way this is currently setup anything inside the check around `can?(:admin, Spree::Order)` is losing out on the other nice things that happen in `order_params` like normalization and nil-checks. I've looked at this for awhile and can't find any good reason to have these lines of code, but let me know if I'm missing something.