### PR TITLE
Fix rake gem:install under bundler

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -71,7 +71,9 @@ namespace :gem do
   desc "Install all solidus gems"
   task :install => :build do
     for_each_gem do |gem_path|
-      sh "gem install #{gem_path}"
+      Bundler.with_clean_env do
+        sh "gem install #{gem_path}"
+      end
     end
   end
 


### PR DESCRIPTION
Updates the `gem:install` rake task to run outside the context of bundler. Without this it errors.

`rake gem:install` is for building and installing gems locally, most users won't use it.