### PR TITLE
Add a dependent: :destroy to Spree::Role and the user.

### DIFF
--- a/core/app/models/concerns/spree/user_methods.rb
+++ b/core/app/models/concerns/spree/user_methods.rb
@@ -10,7 +10,7 @@ module Spree
     included do
       extend Spree::DisplayMoney
 
-      has_many :role_users, foreign_key: "user_id", class_name: "Spree::RoleUser"
+      has_many :role_users, foreign_key: "user_id", class_name: "Spree::RoleUser", dependent: :destroy
       has_many :spree_roles, through: :role_users, source: :role
 
       has_many :user_stock_locations, foreign_key: "user_id", class_name: "Spree::UserStockLocation"

--- a/core/app/models/spree/role.rb
+++ b/core/app/models/spree/role.rb
@@ -1,6 +1,6 @@
 module Spree
   class Role < Spree::Base
-    has_many :role_users, class_name: "Spree::RoleUser"
+    has_many :role_users, class_name: "Spree::RoleUser", dependent: :destroy
     has_many :users, through: :role_users
 
     def admin?


### PR DESCRIPTION
I believe that without these, if roles or users are deleted, the associations in the join table can remain.