### PR TITLE
Fix sequencing of Order#process_payments_before_complete

### DIFF
--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -512,6 +512,7 @@ describe Spree::Order, :type => :model do
 
         expect(order.state).to eq 'confirm'
         expect(order.line_items.first.errors[:quantity]).to be_present
+        expect(order.payments.first.state).to eq('checkout')
       end
     end
 
@@ -533,6 +534,7 @@ describe Spree::Order, :type => :model do
 
         expect(order.state).to eq 'confirm'
         expect(order.line_items.first.errors[:inventory]).to be_present
+        expect(order.payments.first.state).to eq('checkout')
       end
     end
 
@@ -570,6 +572,7 @@ describe Spree::Order, :type => :model do
         context 'when the exchange is not for an unreturned item' do
           it 'does not allow the order to completed' do
             expect { order.complete! }.to raise_error  Spree::Order::InsufficientStock
+            expect(order.payments.first.state).to eq('checkout')
           end
         end
       end


### PR DESCRIPTION
I was looking at adding a before_transition in our app code and I
noticed this.  It looks like this was accidentally changed here:
https://github.com/solidusio/solidus/commit/27b2bb4