### PR TITLE
Allow migrating from spree 3.0

### DIFF
--- a/core/db/migrate/20150506181611_create_spree_store_credit_payment_method.rb
+++ b/core/db/migrate/20150506181611_create_spree_store_credit_payment_method.rb
@@ -4,14 +4,18 @@ class CreateSpreeStoreCreditPaymentMethod < ActiveRecord::Migration
     self.inheritance_column = :_type_disabled
   end
   def up
+    # If migrating from Spree 3.0, the environment column is already gone.
+    # We remove it in a later migration if upgrading from spree <= 2.4 to soldius
+    if column_exists?(:spree_payment_methods, :environment)
+      attributes = {type: "Spree::PaymentMethod::StoreCredit", environment: Rails.env}
+    else
+      attributes = {type: "Spree::PaymentMethod::StoreCredit"}
+    end
     PaymentMethod.create_with(
       name: Spree.t("store_credit.store_credit"),
       description: Spree.t("store_credit.store_credit"),
       active: true,
       display_on: 'none',
-    ).find_or_create_by!(
-      type: "Spree::PaymentMethod::StoreCredit",
-      environment: Rails.env,
-    )
+    ).find_or_create_by!(attributes)
   end
 end


### PR DESCRIPTION
This is an alternative to #229 and builds on #248

This should probably be merged after #248