### PR TITLE
Support select2 pagination on the product picker

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/product_picker.js
+++ b/backend/app/assets/javascripts/spree/backend/product_picker.js
@@ -27,13 +27,15 @@ $.fn.productAutocomplete = function (options) {
             sku_cont: term
           },
           m: 'OR',
-          token: Spree.api_key
+          token: Spree.api_key,
+          page: page
         };
       },
       results: function (data, page) {
         var products = data.products ? data.products : [];
         return {
-          results: products
+          results: products,
+          more: (data.current_page * data.per_page) < data.total_count
         };
       }
     },


### PR DESCRIPTION
The endpoint supports pagination but the JavaScript wasn’t taking advantage of it. This was causing some results to never be surfaced if they weren’t part of the first page of results.