### PR TITLE
Pass current user to OrderContents#update_cart

### DIFF
--- a/api/app/controllers/spree/api/line_items_controller.rb
+++ b/api/app/controllers/spree/api/line_items_controller.rb
@@ -27,7 +27,7 @@ module Spree
 
       def update
         @line_item = find_line_item
-        if @order.contents.update_cart(line_items_attributes)
+        if @order.contents.update_cart(line_items_attributes, current_user: current_api_user)
           @line_item.reload
           respond_with(@line_item, default_template: :show)
         else

--- a/api/app/controllers/spree/api/orders_controller.rb
+++ b/api/app/controllers/spree/api/orders_controller.rb
@@ -58,7 +58,7 @@ module Spree
       def update
         authorize! :update, @order, order_token
 
-        if @order.contents.update_cart(order_params)
+        if @order.contents.update_cart(order_params, current_user: current_api_user)
           user_id = params[:order][:user_id]
           if can?(:admin, @order) && user_id
             @order.associate_user!(Spree.user_class.find(user_id))

--- a/api/spec/controllers/spree/api/orders_controller_spec.rb
+++ b/api/spec/controllers/spree/api/orders_controller_spec.rb
@@ -101,7 +101,7 @@ module Spree
       it "updates the cart contents" do
         expect(order.contents).to receive(:update_cart).
           once.
-          with({"email" => "foo@foobar.com"})
+          with({"email" => "foo@foobar.com"}, current_user: current_api_user)
         subject
       end
 

--- a/backend/app/controllers/spree/admin/orders/customer_details_controller.rb
+++ b/backend/app/controllers/spree/admin/orders/customer_details_controller.rb
@@ -18,7 +18,7 @@ module Spree
         end
 
         def update
-          if @order.contents.update_cart(order_params)
+          if @order.contents.update_cart(order_params, current_user: try_spree_current_user)
 
             if should_associate_user?
               requested_user = Spree.user_class.find(params[:user_id])

--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -81,7 +81,7 @@ module Spree
       end
 
       def update
-        @order.contents.update_cart(params[:order])
+        @order.contents.update_cart(params[:order], current_user: try_spree_current_user)
         @order.errors.add(:line_items, Spree.t('errors.messages.blank')) if @order.line_items.empty?
         if @order.completed?
           render :action => :edit

--- a/backend/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -439,7 +439,7 @@ describe Spree::Admin::OrdersController, :type => :controller do
     subject { spree_put :update, payload }
 
     it "attempts to update the order" do
-      expect(order.contents).to receive(:update_cart).with(payload[:order])
+      expect(order.contents).to receive(:update_cart).with(payload[:order], current_user: nil)
       subject
     end
 

--- a/core/app/models/spree/order_contents.rb
+++ b/core/app/models/spree/order_contents.rb
@@ -16,7 +16,7 @@ module Spree
       after_add_or_remove(line_item, options)
     end
 
-    def update_cart(params)
+    def update_cart(params, current_user:nil)
       if order.update_attributes(params)
         unless order.completed?
           order.line_items = order.line_items.select {|li| li.quantity > 0 }

--- a/frontend/app/controllers/spree/orders_controller.rb
+++ b/frontend/app/controllers/spree/orders_controller.rb
@@ -17,7 +17,7 @@ module Spree
     end
 
     def update
-      if @order.contents.update_cart(order_params)
+      if @order.contents.update_cart(order_params, current_user: try_spree_current_user)
         respond_with(@order) do |format|
           format.html do
             if params.has_key?(:checkout)


### PR DESCRIPTION
This will allow stores and extensions to perform logging & auditing
and to customize #update_cart based on the user performing the update.