### PR TITLE
More auth tweaks

### DIFF
--- a/backend/app/controllers/spree/admin/stock_transfers_controller.rb
+++ b/backend/app/controllers/spree/admin/stock_transfers_controller.rb
@@ -7,8 +7,7 @@ module Spree
         { translation_key: :name, attr_name: :name }
       ]
 
-      before_filter :load_readable_stock_locations, only: :index
-      before_filter :load_transferable_stock_locations, only: :new
+      before_filter :load_transferable_stock_locations, only: [:index, :new]
       before_filter :load_variant_display_attributes, only: [:receive, :edit, :show, :tracking_info]
       before_filter :load_destination_stock_locations, only: :edit
       before_filter :ensure_access_to_stock_location, only: :create
@@ -102,16 +101,8 @@ module Spree
         authorize! :create, duplicate
       end
 
-      def accessible_stock_locations
-        Spree::StockLocation.accessible_by(current_ability, :index)
-      end
-
       def transferable_stock_locations
-        accessible_stock_locations.accessible_by(current_ability, :transfer)
-      end
-
-      def load_readable_stock_locations
-        @stock_locations = accessible_stock_locations
+        Spree::StockLocation.accessible_by(current_ability, :transfer)
       end
 
       def load_transferable_stock_locations

--- a/backend/app/views/spree/admin/promotions/_actions.html.erb
+++ b/backend/app/views/spree/admin/promotions/_actions.html.erb
@@ -4,13 +4,15 @@
     <% options = options_for_select(  Rails.application.config.spree.promotions.actions.map(&:name).map {|name| [ Spree.t("promotion_action_types.#{name.demodulize.underscore}.name"), name] } ) %>
     <fieldset>
       <legend align="center"><%= Spree.t(:promotion_actions) %></legend>
-      <div class="field">
-        <%= label_tag :action_type, Spree.t(:add_action_of_type)%>
-        <%= select_tag 'action_type', options, :class => 'select2 fullwidth' %>  
-      </div>
-      <div class="filter-actions actions">
-        <%= button Spree.t(:add), 'plus' %>
-      </div>
+      <% if can?(:update, @promotion) %>
+        <div class="field">
+          <%= label_tag :action_type, Spree.t(:add_action_of_type)%>
+          <%= select_tag 'action_type', options, :class => 'select2 fullwidth' %>
+        </div>
+        <div class="filter-actions actions">
+          <%= button Spree.t(:add), 'plus' %>
+        </div>
+      <% end %>
     </fieldset>
   <% end %>
 
@@ -24,9 +26,11 @@
         </div>
       <% end %>
     </div>
-    <div class="filter-actions actions promotion-update">
-      <%= button Spree.t('actions.update'), 'refresh' %>
-    </div>
+    <% if can?(:update, @promotion) %>
+      <div class="filter-actions actions promotion-update">
+        <%= button Spree.t('actions.update'), 'refresh' %>
+      </div>
+    <% end %>
   <% end %>
 
 </fieldset>

--- a/backend/app/views/spree/admin/promotions/_promotion_action.html.erb
+++ b/backend/app/views/spree/admin/promotions/_promotion_action.html.erb
@@ -1,11 +1,13 @@
 <div class="promotion_action promotion-block <%= promotion_action.type.to_s.demodulize.underscore %>" id="<%= dom_id promotion_action %>">
   <% type_name = promotion_action.class.name.demodulize.underscore %>
   <h6 class="promotion-title"><%= Spree.t("promotion_action_types.#{type_name}.description") %></h6>
-  <%= link_to_with_icon 'trash', '', spree.admin_promotion_promotion_action_path(@promotion, promotion_action), :remote => true, :method => :delete, :class => 'delete' %>
-  
+  <% if can?(:destroy, promotion_action) %>
+    <%= link_to_with_icon 'trash', '', spree.admin_promotion_promotion_action_path(@promotion, promotion_action), :remote => true, :method => :delete, :class => 'delete' %>
+  <% end %>
+
   <% param_prefix = "promotion[promotion_actions_attributes][#{promotion_action.id}]" %>
   <%= hidden_field_tag "#{param_prefix}[id]", promotion_action.id %>
-  
+
   <%= render :partial => "spree/shared/error_messages", :locals => { :target => promotion_action } %>
   <%= render :partial => "spree/admin/promotions/actions/#{type_name}",
              :locals => { :promotion_action => promotion_action, :param_prefix => param_prefix } %>

--- a/backend/app/views/spree/admin/promotions/_promotion_rule.html.erb
+++ b/backend/app/views/spree/admin/promotions/_promotion_rule.html.erb
@@ -1,10 +1,12 @@
 <div class="promotion_rule promotion-block alpha omega eight columns" id="<%= dom_id promotion_rule %>">
   <% type_name = promotion_rule.class.name.demodulize.underscore %>
   <h6 class='promotion-title <%= 'no-text' if type_name == 'user_logged_in' || type_name == 'first_order'%>'><%= Spree.t("promotion_rule_types.#{type_name}.description") %></h6>
-  <%= link_to_with_icon 'trash', '', spree.admin_promotion_promotion_rule_path(@promotion, promotion_rule), :remote => true, :method => :delete, :class => 'delete' %>
-  
+  <% if can?(:destroy, promotion_rule) %>
+    <%= link_to_with_icon 'trash', '', spree.admin_promotion_promotion_rule_path(@promotion, promotion_rule), :remote => true, :method => :delete, :class => 'delete' %>
+  <% end %>
+
   <% param_prefix = "promotion[promotion_rules_attributes][#{promotion_rule.id}]" %>
-  <%= hidden_field_tag "#{param_prefix}[id]", promotion_rule.id %>  
+  <%= hidden_field_tag "#{param_prefix}[id]", promotion_rule.id %>
   <%= render :partial => "spree/shared/error_messages", :locals => { :target => promotion_rule } %>
   <%= render :partial => "spree/admin/promotions/rules/#{type_name}", :locals => { :promotion_rule => promotion_rule, :param_prefix => param_prefix } %>
 </div>

--- a/backend/app/views/spree/admin/promotions/_rules.html.erb
+++ b/backend/app/views/spree/admin/promotions/_rules.html.erb
@@ -4,27 +4,29 @@
     <fieldset>
       <legend align="center"><%= Spree.t(:rules) %></legend>
 
-      <div class="field">
-        <%= label_tag :promotion_rule_type, Spree.t(:add_rule_of_type) %>  
-        <%= select_tag('promotion_rule[type]', options_for_promotion_rule_types(@promotion), :class => 'select2 fullwidth') %>
-      </div>
-      <div class="filter-actions actions">
-        <%= button Spree.t(:add), 'plus' %>
-      </div>
+      <% if can?(:update, @promotion) %>
+        <div class="field">
+          <%= label_tag :promotion_rule_type, Spree.t(:add_rule_of_type) %>
+          <%= select_tag('promotion_rule[type]', options_for_promotion_rule_types(@promotion), :class => 'select2 fullwidth') %>
+        </div>
+        <div class="filter-actions actions">
+          <%= button Spree.t(:add), 'plus' %>
+        </div>
+      <% end %>
     </fieldset>
   <% end %>
 
-  
+
     <%= form_for @promotion, :url => object_url, :method => :put do |f| %>
       <fieldset class="no-border-top">
         <div id="promotion-pilicy-select" class="align-center row">
           <% Spree::Promotion::MATCH_POLICIES.each do |policy| %>
             <div class="alpha four columns">
-              <label><%= f.radio_button :match_policy, policy %> <%= Spree.t "promotion_form.match_policies.#{policy}" %></label>  
+              <label><%= f.radio_button :match_policy, policy %> <%= Spree.t "promotion_form.match_policies.#{policy}" %></label>
             </div>
           <% end %>
         </div>
-        
+
         <div id="rules" class="filter_list row">
           <% if @promotion.rules.any? %>
             <%= render :partial => 'promotion_rule', :collection => @promotion.rules, :locals => {} %>
@@ -35,11 +37,13 @@
           <% end %>
         </div>
 
-        <div class="promotion-update filter-actions actions">
-          <%= button Spree.t('actions.update'), 'refresh' %>
-        </div>
+        <% if can?(:update, @promotion) %>
+          <div class="promotion-update filter-actions actions">
+            <%= button Spree.t('actions.update'), 'refresh' %>
+          </div>
+        <% end %>
       </fieldset>
     <% end %>
-  
+
 
 </fieldset>

--- a/backend/app/views/spree/admin/promotions/edit.html.erb
+++ b/backend/app/views/spree/admin/promotions/edit.html.erb
@@ -7,14 +7,18 @@
 <% content_for :page_actions do %>
   <li>
     <%= button_link_to Spree.t(:back_to_promotions_list), admin_promotions_path, :icon => 'arrow-left' %>
-    <%= button_link_to Spree.t(:download_promotion_code_list), admin_promotion_promotion_codes_path(promotion_id: @promotion.id, format: :csv), :icon => 'arrow-down' %>
+    <% if can?(:display, Spree::PromotionCode) %>
+      <%= button_link_to Spree.t(:download_promotion_code_list), admin_promotion_promotion_codes_path(promotion_id: @promotion.id, format: :csv), :icon => 'arrow-down' %>
+    <% end %>
   </li>
 <% end %>
 
 <%= form_for @promotion, :url => object_url, :method => :put do |f| %>
   <fieldset class="no-border-top">
     <%= render :partial => 'form', :locals => { :f => f } %>
-    <%= render :partial => 'spree/admin/shared/edit_resource_links' %>
+    <% if can?(:update, @promotion) %>
+      <%= render :partial => 'spree/admin/shared/edit_resource_links' %>
+    <% end %>
   </fieldset>
 <% end %>
 

--- a/backend/app/views/spree/admin/promotions/index.html.erb
+++ b/backend/app/views/spree/admin/promotions/index.html.erb
@@ -93,7 +93,7 @@
           <td class="align-center"><%= Spree.t(:current_promotion_usage, :count => promotion.usage_count) %></td>
           <td class="align-center"><%= promotion.expires_at.to_date.to_s(:short_date) if promotion.expires_at %></td>
           <td class="actions">
-            <% if can?(:update, promotion) %>
+            <% if can?(:edit, promotion) %>
               <%= link_to_edit promotion, :no_text => true %>
             <% end %>
             <% if can?(:destroy, promotion) %>

--- a/core/app/models/spree/permission_sets/promotion_display.rb
+++ b/core/app/models/spree/permission_sets/promotion_display.rb
@@ -2,10 +2,11 @@ module Spree
   module PermissionSets
     class PromotionDisplay < PermissionSets::Base
       def activate!
-        can [:display, :admin], Spree::Promotion
+        can [:display, :admin, :edit], Spree::Promotion
         can [:display, :admin], Spree::PromotionRule
         can [:display, :admin], Spree::PromotionAction
         can [:display, :admin], Spree::PromotionCategory
+        can [:display, :admin], Spree::PromotionCode
       end
     end
   end

--- a/core/spec/models/spree/permission_sets/promotion_display_spec.rb
+++ b/core/spec/models/spree/permission_sets/promotion_display_spec.rb
@@ -14,10 +14,13 @@ describe Spree::PermissionSets::PromotionDisplay do
     it { is_expected.to be_able_to(:display, Spree::PromotionRule) }
     it { is_expected.to be_able_to(:display, Spree::PromotionAction) }
     it { is_expected.to be_able_to(:display, Spree::PromotionCategory) }
+    it { is_expected.to be_able_to(:display, Spree::PromotionCode) }
     it { is_expected.to be_able_to(:admin, Spree::Promotion) }
     it { is_expected.to be_able_to(:admin, Spree::PromotionRule) }
     it { is_expected.to be_able_to(:admin, Spree::PromotionAction) }
     it { is_expected.to be_able_to(:admin, Spree::PromotionCategory) }
+    it { is_expected.to be_able_to(:admin, Spree::PromotionCode) }
+    it { is_expected.to be_able_to(:edit, Spree::Promotion) }
   end
 
   context "when not activated" do
@@ -25,10 +28,13 @@ describe Spree::PermissionSets::PromotionDisplay do
     it { is_expected.not_to be_able_to(:display, Spree::PromotionRule) }
     it { is_expected.not_to be_able_to(:display, Spree::PromotionAction) }
     it { is_expected.not_to be_able_to(:display, Spree::PromotionCategory) }
+    it { is_expected.not_to be_able_to(:display, Spree::PromotionCode) }
     it { is_expected.not_to be_able_to(:admin, Spree::Promotion) }
     it { is_expected.not_to be_able_to(:admin, Spree::PromotionRule) }
     it { is_expected.not_to be_able_to(:admin, Spree::PromotionAction) }
     it { is_expected.not_to be_able_to(:admin, Spree::PromotionCategory) }
+    it { is_expected.not_to be_able_to(:admin, Spree::PromotionCode) }
+    it { is_expected.not_to be_able_to(:edit, Spree::Promotion) }
   end
 end
 

--- a/core/spec/models/spree/permission_sets/restricted_transfer_management_spec.rb
+++ b/core/spec/models/spree/permission_sets/restricted_transfer_management_spec.rb
@@ -49,12 +49,17 @@ describe Spree::PermissionSets::RestrictedTransferManagement do
     end
 
     it { is_expected.to be_able_to(:display, Spree::StockItem) }
-    it { is_expected.to be_able_to(:display, Spree::StockTransfer) }
     it { is_expected.to be_able_to(:admin, Spree::StockItem) }
-    it { is_expected.to be_able_to(:admin, Spree::StockTransfer) }
+
+    it { is_expected.to be_able_to(:display, source_location) }
+    it { is_expected.to be_able_to(:display, destination_location) }
 
     context "when the user is associated with one of the locations" do
       let(:stock_locations) {[source_location]}
+
+      it { is_expected.to be_able_to(:display, Spree::StockTransfer) }
+      it { is_expected.to be_able_to(:admin, Spree::StockTransfer) }
+      it { is_expected.to be_able_to(:create, Spree::StockTransfer) }
 
       it { is_expected.to be_able_to(:update, source_stock_item) }
       it { is_expected.not_to be_able_to(:update, destination_stock_item) }
@@ -62,8 +67,9 @@ describe Spree::PermissionSets::RestrictedTransferManagement do
       it { is_expected.to be_able_to(:transfer, source_location) }
       it { is_expected.not_to be_able_to(:transfer, destination_location) }
 
-      it { is_expected.to be_able_to(:display, source_location) }
-      it { is_expected.not_to be_able_to(:display, destination_location) }
+      it { is_expected.to be_able_to(:display, transfer_with_source) }
+      it { is_expected.to be_able_to(:display, transfer_with_source_and_destination) }
+      it { is_expected.not_to be_able_to(:display, transfer_with_destination) }
 
       it { is_expected.to be_able_to(:manage, transfer_with_source) }
       it { is_expected.not_to be_able_to(:manage, transfer_with_destination) }
@@ -78,14 +84,19 @@ describe Spree::PermissionSets::RestrictedTransferManagement do
     context "when the user is associated with both locations" do
       let(:stock_locations) {[source_location, destination_location]}
 
+      it { is_expected.to be_able_to(:display, Spree::StockTransfer) }
+      it { is_expected.to be_able_to(:admin, Spree::StockTransfer) }
+      it { is_expected.to be_able_to(:create, Spree::StockTransfer) }
+
       it { is_expected.to be_able_to(:update, source_stock_item) }
       it { is_expected.to be_able_to(:update, destination_stock_item) }
 
       it { is_expected.to be_able_to(:transfer, source_location) }
       it { is_expected.to be_able_to(:transfer, destination_location) }
 
-      it { is_expected.to be_able_to(:display, source_location) }
-      it { is_expected.to be_able_to(:display, destination_location) }
+      it { is_expected.to be_able_to(:display, transfer_with_source) }
+      it { is_expected.to be_able_to(:display, transfer_with_source_and_destination) }
+      it { is_expected.to be_able_to(:display, transfer_with_destination) }
 
       it { is_expected.to be_able_to(:manage, transfer_with_source) }
       it { is_expected.to be_able_to(:manage, transfer_with_destination) }
@@ -98,6 +109,10 @@ describe Spree::PermissionSets::RestrictedTransferManagement do
 
     context "when the user is associated with neither location" do
       let(:stock_locations) {[]}
+
+      it { is_expected.not_to be_able_to(:display, Spree::StockTransfer) }
+      it { is_expected.not_to be_able_to(:admin, Spree::StockTransfer) }
+      it { is_expected.not_to be_able_to(:create, Spree::StockTransfer) }
 
       it { is_expected.not_to be_able_to(:update, source_stock_item) }
       it { is_expected.not_to be_able_to(:update, destination_stock_item) }
@@ -119,8 +134,8 @@ describe Spree::PermissionSets::RestrictedTransferManagement do
     let(:user) { create :user }
 
     it { is_expected.not_to be_able_to(:display, Spree::StockTransfer) }
-    it { is_expected.not_to be_able_to(:admin, Spree::StockItem) }
     it { is_expected.not_to be_able_to(:admin, Spree::StockTransfer) }
+    it { is_expected.not_to be_able_to(:create, Spree::StockTransfer) }
 
     it { is_expected.not_to be_able_to(:update, source_stock_item) }
     it { is_expected.not_to be_able_to(:update, destination_stock_item) }
@@ -128,9 +143,8 @@ describe Spree::PermissionSets::RestrictedTransferManagement do
     it { is_expected.not_to be_able_to(:transfer, source_location) }
     it { is_expected.not_to be_able_to(:transfer, destination_location) }
 
-    it { is_expected.not_to be_able_to(:display, source_location) }
-    it { is_expected.not_to be_able_to(:display, destination_location) }
-
+    it { is_expected.to_not be_able_to(:display, source_location) }
+    it { is_expected.to_not be_able_to(:display, destination_location) }
 
     it { is_expected.not_to be_able_to(:manage, transfer_with_source) }
     it { is_expected.not_to be_able_to(:manage, transfer_with_destination) }


### PR DESCRIPTION
This PR contains a number of further tweaks around permissions. Specifically the intentions for the restricted stock transfer permission set where modified around what stock transfers can be shown. 

Additionally there was a desire to have users with read only permissions on promotions be able to visit promotions#edit on the backend.