### PR TITLE
Make PromotionChooser extensible

### DIFF
--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -238,6 +238,12 @@ module Spree
       @searcher_class ||= Spree::Core::Search::Base
     end
 
+    # promotion_chooser_class allows extensions to provide their own PromotionChooser
+    attr_writer :promotion_chooser_class
+    def promotion_chooser_class
+      @promotion_chooser_class ||= Spree::PromotionChooser
+    end
+
     def static_model_preferences
       @static_model_preferences ||= Spree::Preferences::StaticModelPreferences.new
     end

--- a/core/app/models/spree/item_adjustments.rb
+++ b/core/app/models/spree/item_adjustments.rb
@@ -41,7 +41,7 @@ module Spree
       promotion_adjustments = adjustments.select(&:promotion?)
       promotion_adjustments.each(&:update!)
 
-      promo_total = PromotionChooser.new(promotion_adjustments).update
+      promo_total = Spree::Config.promotion_chooser_class.new(promotion_adjustments).update
 
       # Calculating the totals for the order here would be incorrect. Order's
       # totals are the sum of the adjustments on all child models, as well as

--- a/core/spec/models/spree/item_adjustments_spec.rb
+++ b/core/spec/models/spree/item_adjustments_spec.rb
@@ -97,7 +97,27 @@ module Spree
       end
     end
 
-    context "best promotion is always applied" do
+    context "promotion chooser customization" do
+      before do
+        class Spree::TestPromotionChooser
+          def initialize(adjustments)
+            raise "Custom promotion chooser"
+          end
+        end
+
+        Spree::Config.promotion_chooser_class = Spree::TestPromotionChooser
+      end
+
+      after do
+        Spree::Config.promotion_chooser_class = Spree::PromotionChooser
+      end
+
+      it "uses the defined promotion chooser" do
+        expect { subject.update }.to raise_error("Custom promotion chooser")
+      end
+    end
+
+    context "default promotion chooser (best promotion is always applied)" do
       let(:calculator) { Calculator::FlatRate.new(:preferred_amount => 10) }
 
       let(:source) do


### PR DESCRIPTION
Provides an extension point for stores to define their own promotion chooser.