### PR TITLE
Confirmation state cleanup

### DIFF
--- a/api/spec/controllers/spree/api/checkouts_controller_spec.rb
+++ b/api/spec/controllers/spree/api/checkouts_controller_spec.rb
@@ -31,7 +31,6 @@ module Spree
       end
 
       before(:each) do
-        allow_any_instance_of(Order).to receive_messages(confirmation_required?: true)
         allow_any_instance_of(Order).to receive_messages(payment_required?: true)
       end
 

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -188,6 +188,7 @@ module Spree
     end
 
     def confirmation_required?
+      ActiveSupport::Deprecation.warn "Order#confirmation_required is deprecated.", caller
       true
     end
 

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -67,6 +67,10 @@ module Spree
                 transition to: :awaiting_return
               end
 
+              event :complete do
+                transition to: :complete, from: :confirm
+              end
+
               if states[:payment]
                 event :payment_failed do
                   transition to: :payment, from: :confirm
@@ -81,11 +85,6 @@ module Spree
 
                 # see also process_payments_before_complete below which needs to
                 # be added in the correct sequence.
-
-                event :complete do
-                  transition to: :complete, from: :confirm
-                  transition to: :complete, from: :payment
-                end
               end
 
               before_transition from: :cart, do: :ensure_line_items_present

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -417,41 +417,6 @@ describe Spree::Order, :type => :model do
         end
       end
 
-      context "without confirmation required" do
-        before do
-          order.email = "spree@example.com"
-          order.store = FactoryGirl.build(:store)
-          allow(order).to receive_messages :payment_required? => true
-          order.payments << FactoryGirl.create(:payment, state: payment_state, order: order)
-        end
-
-        context 'when there is at least one valid payment' do
-          let(:payment_state) { 'checkout' }
-
-          before do
-            expect(order).to receive(:process_payments!).once { true }
-          end
-
-          it "transitions to complete" do
-            order.complete!
-            assert_state_changed(order, 'payment', 'complete')
-            expect(order.state).to eq('complete')
-          end
-        end
-
-        context 'when there is only an invalid payment' do
-          let(:payment_state) { 'failed' }
-
-          it "raises a StateMachines::InvalidTransition" do
-            expect {
-              order.complete!
-            }.to raise_error(StateMachines::InvalidTransition, /#{Spree.t(:no_payment_found)}/)
-
-            expect(order.errors[:base]).to include(Spree.t(:no_payment_found))
-          end
-        end
-      end
-
       # Regression test for #2028
       context "when payment is not required" do
         before do

--- a/core/spec/models/spree/unit_cancel_spec.rb
+++ b/core/spec/models/spree/unit_cancel_spec.rb
@@ -83,6 +83,7 @@ describe Spree::UnitCancel do
         order.contents.advance
         create(:payment, order: order, amount: order.total)
         order.payments.reload
+        order.contents.advance
         order.complete!
         order.reload
 

--- a/frontend/spec/controllers/spree/checkout_controller_spec.rb
+++ b/frontend/spec/controllers/spree/checkout_controller_spec.rb
@@ -172,7 +172,6 @@ describe Spree::CheckoutController, :type => :controller do
 
       context "when in the confirm state" do
         before do
-          allow(order).to receive_messages :confirmation_required? => true
           order.update_column(:state, "confirm")
           allow(order).to receive_messages :user => user
           # An order requires a payment to reach the complete state

--- a/frontend/spec/features/checkout_spec.rb
+++ b/frontend/spec/features/checkout_spec.rb
@@ -80,7 +80,6 @@ describe "Checkout", type: :feature, inaccessible: true do
   context "doesn't allow bad credit card numbers" do
     before(:each) do
       order = OrderWalkthrough.up_to(:delivery)
-      allow(order).to receive_messages :confirmation_required? => true
       allow(order).to receive_messages(:available_payment_methods => [ create(:credit_card_payment_method, :environment => 'test') ])
 
       user = create(:user)
@@ -110,7 +109,6 @@ describe "Checkout", type: :feature, inaccessible: true do
 
     let!(:order) do
       order = OrderWalkthrough.up_to(:delivery)
-      allow(order).to receive_messages :confirmation_required? => true
 
       order.reload
       order.user = user

--- a/guides/content/developer/core/orders.md
+++ b/guides/content/developer/core/orders.md
@@ -63,12 +63,7 @@ The default states are as follows:
 
 The `payment` state will only be triggered if `payment_required?` returns `true`.
 
-The `confirm` state will only be triggered if `confirmation_required?` returns `true`.
-
-The `complete` state can only be reached in one of two ways:
-
-1. No payment is required on the order.
-2. Payment is required on the order, and at least the order total has been received as payment.
+The `complete` state can only be reached from the confirm state.
 
 Assuming that an order meets the criteria for the next state, you will be able to transition it to the next state by calling `next` on that object. If this returns `false`, then the order does *not* meet the criteria. To work out why it cannot transition, check the result of an `errors` method call.
 


### PR DESCRIPTION
We've already updated so that the confirm is always included.

I noticed this while looking at some other stuff.