### PR TITLE
Remove state and mandatory columns from adjustments

### DIFF
--- a/api/app/helpers/spree/api/api_helpers.rb
+++ b/api/app/helpers/spree/api/api_helpers.rb
@@ -129,7 +129,7 @@ module Spree
 
       @@adjustment_attributes = [
         :id, :source_type, :source_id, :adjustable_type, :adjustable_id,
-        :originator_type, :originator_id, :amount, :label, :mandatory, :promotion_code,
+        :originator_type, :originator_id, :amount, :label, :promotion_code,
         :locked, :eligible,  :created_at, :updated_at
       ]
 

--- a/backend/app/helpers/spree/admin/adjustments_helper.rb
+++ b/backend/app/helpers/spree/admin/adjustments_helper.rb
@@ -2,9 +2,8 @@ module Spree
   module Admin
     module AdjustmentsHelper
       def adjustment_state(adjustment)
-        state = adjustment.state.to_sym
-        icon = { closed: 'lock', open: 'unlock' }
-        content_tag(:span, '', class: "fa fa-#{ icon[state] }")
+        icon = adjustment.finalized? ? 'lock' : 'unlock'
+        content_tag(:span, '', class: "fa fa-#{icon}")
       end
 
       def display_adjustable(adjustable)

--- a/backend/app/views/spree/admin/adjustments/_adjustment.html.erb
+++ b/backend/app/views/spree/admin/adjustments/_adjustment.html.erb
@@ -8,7 +8,7 @@
   <td class="align-center"><%= adjustment.display_amount.to_html %></td>
   <td class="align-center"><%= adjustment_state(adjustment) %></td>
   <td class='actions'>
-    <% if adjustment.open? %>
+    <% unless adjustment.finalized? %>
       <% if can?(:update, adjustment) %>
         <%= link_to_edit adjustment, :no_text => true %>
       <% end %>

--- a/backend/spec/features/admin/orders/adjustments_spec.rb
+++ b/backend/spec/features/admin/orders/adjustments_spec.rb
@@ -14,7 +14,7 @@ describe "Adjustments", :type => :feature do
   let!(:tax_adjustment) do
     create(:tax_adjustment,
       :adjustable => line_item,
-      :state => 'closed',
+      :finalized => true,
       :order => order,
       :label => "VAT 5%",
       :amount => 10)

--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -71,7 +71,7 @@ module Spree
     # Deprecated methods
     def state
       ActiveSupport::Deprecation.warn "Adjustment#state is deprecated. Instead use Adjustment#finalized?", caller
-      finalized?? "closed" : "open"
+      finalized? ? "closed" : "open"
     end
 
     def state=(new_state)

--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -63,12 +63,12 @@ module Spree
 
     # Deprecated methods
     def state
-      ActiveSupport::Deprecation.warn "Adjustment#state is deprecated. Instead use Adjustment#finalized?"
+      ActiveSupport::Deprecation.warn "Adjustment#state is deprecated. Instead use Adjustment#finalized?", caller
       finalized?? "closed" : "open"
     end
 
     def state=(new_state)
-      ActiveSupport::Deprecation.warn "Adjustment#state= is deprecated. Instead use Adjustment#finalized="
+      ActiveSupport::Deprecation.warn "Adjustment#state= is deprecated. Instead use Adjustment#finalized=", caller
       case new_state
       when "open"
         self.finalized = false
@@ -80,22 +80,23 @@ module Spree
     end
 
     def open?
+      ActiveSupport::Deprecation.warn "Adjustment#open? is deprecated. Instead use Adjustment#finalized?", caller
       !closed?
     end
 
     def closed?
-      ActiveSupport::Deprecation.warn "Adjustment#open? and Adjustment#closed? are deprecated. Instead use Adjustment#finalized?"
+      ActiveSupport::Deprecation.warn "Adjustment#closed? is deprecated. Instead use Adjustment#finalized?", caller
       finalized?
     end
 
     def open
-      ActiveSupport::Deprecation.warn "Adjustment#open is deprecated. Instead use Adjustment#unfinalize!"
+      ActiveSupport::Deprecation.warn "Adjustment#open is deprecated. Instead use Adjustment#unfinalize!", caller
       unfinalize!
     end
     alias_method :open!, :open
 
     def close
-      ActiveSupport::Deprecation.warn "Adjustment#close is deprecated. Instead use Adjustment#finalize!"
+      ActiveSupport::Deprecation.warn "Adjustment#close is deprecated. Instead use Adjustment#finalize!", caller
       finalize!
     end
     alias_method :close!, :close
@@ -132,7 +133,7 @@ module Spree
       if target
         ActiveSupport::Deprecation.warn("Passing a target to Adjustment#update! is deprecated. The adjustment will use the correct target from it's adjustable association.", caller)
       end
-      return amount if closed?
+      return amount if finalized?
 
       # If the adjustment has no source, do not attempt to re-calculate the amount.
       # Chances are likely that this was a manually created adjustment in the admin backend.

--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -63,10 +63,12 @@ module Spree
 
     # Deprecated methods
     def state
+      ActiveSupport::Deprecation.warn "Adjustment#state is deprecated. Instead use Adjustment#finalized?"
       finalized?? "closed" : "open"
     end
 
     def state=(new_state)
+      ActiveSupport::Deprecation.warn "Adjustment#state= is deprecated. Instead use Adjustment#finalized="
       case new_state
       when "open"
         self.finalized = false
@@ -82,19 +84,22 @@ module Spree
     end
 
     def closed?
+      ActiveSupport::Deprecation.warn "Adjustment#open? and Adjustment#closed? are deprecated. Instead use Adjustment#finalized?"
       finalized?
     end
 
     def open
+      ActiveSupport::Deprecation.warn "Adjustment#open is deprecated. Instead use Adjustment#unfinalize!"
       unfinalize!
     end
     alias_method :open!, :open
 
     def close
+      ActiveSupport::Deprecation.warn "Adjustment#close is deprecated. Instead use Adjustment#finalize!"
       finalize!
     end
     alias_method :close!, :close
-    # Deprecated methods
+    # End deprecated methods
 
     def currency
       adjustable ? adjustable.currency : Spree::Config[:currency]

--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -7,16 +7,7 @@ module Spree
   #
   # == Boolean attributes
   #
-  # 1. *mandatory*
-  #
-  #    If this flag is set to true then it means the the charge is required and
-  #    will not be removed from the order, even if the amount is zero. In other
-  #    words a record will be created even if the amount is zero. This is
-  #    useful for representing things such as shipping and tax charges where
-  #    you may want to make it explicitly clear that no charge was made for
-  #    such things.
-  #
-  # 2. *eligible?*
+  # 1. *eligible?*
   #
   #    This boolean attributes stores whether this adjustment is currently
   #    eligible for its order. Only eligible adjustments count towards the
@@ -58,7 +49,6 @@ module Spree
     end
     scope :price, -> { where(adjustable_type: 'Spree::LineItem') }
     scope :shipping, -> { where(adjustable_type: 'Spree::Shipment') }
-    scope :optional, -> { where(mandatory: false) }
     scope :eligible, -> { where(eligible: true) }
     scope :charge, -> { where("#{quoted_table_name}.amount >= 0") }
     scope :credit, -> { where("#{quoted_table_name}.amount < 0") }

--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -60,6 +60,13 @@ module Spree
       update_attributes!(finalized: false)
     end
 
+    def finalize
+      update_attributes(finalized: true)
+    end
+
+    def unfinalize
+      update_attributes(finalized: false)
+    end
 
     # Deprecated methods
     def state
@@ -90,16 +97,24 @@ module Spree
     end
 
     def open
-      ActiveSupport::Deprecation.warn "Adjustment#open is deprecated. Instead use Adjustment#unfinalize!", caller
+      ActiveSupport::Deprecation.warn "Adjustment#open is deprecated. Instead use Adjustment#unfinalize", caller
+      unfinalize
+    end
+
+    def open
+      ActiveSupport::Deprecation.warn "Adjustment#open! is deprecated. Instead use Adjustment#unfinalize!", caller
       unfinalize!
     end
-    alias_method :open!, :open
 
     def close
-      ActiveSupport::Deprecation.warn "Adjustment#close is deprecated. Instead use Adjustment#finalize!", caller
+      ActiveSupport::Deprecation.warn "Adjustment#close is deprecated. Instead use Adjustment#finalize", caller
+      finalize
+    end
+
+    def close!
+      ActiveSupport::Deprecation.warn "Adjustment#close! is deprecated. Instead use Adjustment#finalize!", caller
       finalize!
     end
-    alias_method :close!, :close
     # End deprecated methods
 
     def currency

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -370,7 +370,7 @@ module Spree
     # Called after transition to complete state when payments will have been processed
     def finalize!
       # lock all adjustments (coupon promotions, etc.)
-      all_adjustments.each{|a| a.close}
+      all_adjustments.each(&:finalize!)
 
       # update payment and shipment(s) states, and save
       updater.update_payment_state

--- a/core/app/models/spree/unit_cancel.rb
+++ b/core/app/models/spree/unit_cancel.rb
@@ -20,7 +20,7 @@ class Spree::UnitCancel < ActiveRecord::Base
       order: inventory_unit.order,
       label: "#{Spree.t(:cancellation)} - #{reason}",
       eligible: true,
-      state: 'closed',
+      finalized: true
     )
   end
 

--- a/core/db/migrate/20150811210350_remove_mandatory_from_adjustments.rb
+++ b/core/db/migrate/20150811210350_remove_mandatory_from_adjustments.rb
@@ -1,0 +1,5 @@
+class RemoveMandatoryFromAdjustments < ActiveRecord::Migration
+  def change
+    remove_column :spree_adjustments, :mandatory, :boolean
+  end
+end

--- a/core/db/migrate/20150811211025_add_finalized_to_spree_adjustments.rb
+++ b/core/db/migrate/20150811211025_add_finalized_to_spree_adjustments.rb
@@ -1,0 +1,7 @@
+class AddFinalizedToSpreeAdjustments < ActiveRecord::Migration
+  def change
+    add_column :spree_adjustments, :finalized, :boolean
+    execute %q(UPDATE spree_adjustments SET finalized=('open' = state))
+    remove_column :spree_adjustments, :state, :string
+  end
+end

--- a/core/lib/spree/core/importer/order.rb
+++ b/core/lib/spree/core/importer/order.rb
@@ -122,7 +122,7 @@ module Spree
               label:  a[:label]
             )
             adjustment.save!
-            adjustment.close!
+            adjustment.finalize!
           end
         end
 

--- a/core/spec/lib/spree/core/importer/order_spec.rb
+++ b/core/spec/lib/spree/core/importer/order_spec.rb
@@ -341,7 +341,7 @@ module Spree
             { label: 'Promotion Discount', amount: -3.00 }] }
 
         order = Importer::Order.import(user,params)
-        expect(order.adjustments.all?(&:closed?)).to be true
+        expect(order.adjustments.all?(&:finalized?)).to be true
         expect(order.adjustments.first.label).to eq 'Shipping Discount'
         expect(order.adjustments.first.amount).to eq -4.99
       end

--- a/core/spec/models/spree/adjustment_spec.rb
+++ b/core/spec/models/spree/adjustment_spec.rb
@@ -44,22 +44,6 @@ describe Spree::Adjustment, :type => :model do
     end
   end
 
-  context "adjustment state" do
-    subject { build(:adjustment, order: order, state: state) }
-
-    context "#closed?" do
-      context 'is closed' do
-        let(:state) { 'closed' }
-        it { is_expected.to be_closed }
-      end
-
-      context 'is open' do
-        let(:state) { 'open' }
-        it { is_expected.to_not be_closed }
-      end
-    end
-  end
-
   context '#currency' do
     let(:order) { Spree::Order.new currency: 'JPY' }
 
@@ -96,13 +80,13 @@ describe Spree::Adjustment, :type => :model do
   end
 
   context '#update!' do
-    let(:adjustment) { Spree::Adjustment.create!(label: 'Adjustment', order: order, adjustable: order, amount: 5, state: state, source: source) }
+    let(:adjustment) { Spree::Adjustment.create!(label: 'Adjustment', order: order, adjustable: order, amount: 5, finalized: finalized, source: source) }
     let(:source) { mock_model(Spree::TaxRate, compute_amount: 10) }
 
     subject { adjustment.update! }
 
     context "when adjustment is closed" do
-      let(:state) { 'closed' }
+      let(:finalized) { true }
 
       it "does not update the adjustment" do
         expect(adjustment).to_not receive(:update_column)
@@ -110,8 +94,8 @@ describe Spree::Adjustment, :type => :model do
       end
     end
 
-    context "when adjustment is open" do
-      let(:state) { 'open' }
+    context "when adjustment isn't finalized" do
+      let(:finalized) { false }
 
       it "updates the amount" do
         expect { subject }.to change { adjustment.amount }.to(10)

--- a/core/spec/models/spree/item_adjustments_spec.rb
+++ b/core/spec/models/spree/item_adjustments_spec.rb
@@ -113,7 +113,7 @@ module Spree
                             :adjustable => line_item,
                             :source     => source,
                             :amount     => amount,
-                            :state      => "closed",
+                            :finalized  => true,
                             :label      => label)
       end
 
@@ -125,7 +125,7 @@ module Spree
                             :adjustable => line_item,
                             :source => nil,
                             :amount => -500,
-                            :state => "closed",
+                            :finalized => true,
                             :label => "Some other credit")
         line_item.adjustments.each {|a| a.update_column(:eligible, true)}
 

--- a/core/spec/models/spree/item_adjustments_spec.rb
+++ b/core/spec/models/spree/item_adjustments_spec.rb
@@ -114,8 +114,7 @@ module Spree
                             :source     => source,
                             :amount     => amount,
                             :state      => "closed",
-                            :label      => label,
-                            :mandatory  => false)
+                            :label      => label)
       end
 
       it "should make all but the most valuable promotion adjustment ineligible, leaving non promotion adjustments alone" do

--- a/core/spec/models/spree/order/finalizing_spec.rb
+++ b/core/spec/models/spree/order/finalizing_spec.rb
@@ -75,7 +75,7 @@ describe Spree::Order, :type => :model do
       adjustments = [double]
       expect(order).to receive(:all_adjustments).and_return(adjustments)
       adjustments.each do |adj|
-        expect(adj).to receive(:close)
+        expect(adj).to receive(:finalize!)
       end
       order.finalize!
     end

--- a/core/spec/models/spree/order_cancellations_spec.rb
+++ b/core/spec/models/spree/order_cancellations_spec.rb
@@ -82,7 +82,7 @@ describe Spree::OrderCancellations do
           adjustable: line_item,
           amount: 0.01,
           label: 'some fake tax',
-          state: 'closed',
+          finalized: true
         )
         order.update!
       end

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -508,7 +508,7 @@ describe Spree::Shipment, :type => :model do
         label:    "Additional",
         amount:   5,
         included: false,
-        state:    "closed"
+        finalized: true
       )
       shipment.update_amounts
       expect(shipment.reload.adjustment_total).to eq(5)
@@ -520,7 +520,7 @@ describe Spree::Shipment, :type => :model do
         label:    "Included",
         amount:   5,
         included: true,
-        state:    "closed"
+        finalized: true
       )
       shipment.update_amounts
       expect(shipment.reload.adjustment_total).to eq(0)

--- a/core/spec/models/spree/unit_cancel_spec.rb
+++ b/core/spec/models/spree/unit_cancel_spec.rb
@@ -15,8 +15,8 @@ describe Spree::UnitCancel do
       expect(adjustment.amount).to eq -10.0
       expect(adjustment.order).to eq inventory_unit.order
       expect(adjustment.label).to eq "Cancellation - Short Ship"
-      expect(adjustment.eligible).to eq true
-      expect(adjustment.state).to eq 'closed'
+      expect(adjustment).to be_eligible
+      expect(adjustment).to be_finalized
     end
 
     context "when an adjustment has already been created" do


### PR DESCRIPTION
This comes from a conversation with @jordan-brough a while ago.

The state machine on adjustment serves no purpose, as it allows changing between both states without restriction. `open` and `close` are also states which need an explanation, vs `finalized`, which we've used elsewhere in the codebase with the same meaning. `open` also isn't ideal as it overrides `Kernel#open`, which causes state machine warnings unless configured to override that method.

This also removes the `mandatory` column, which has been unused since the Spree 2.2 adjustment changes. I'm not sure how this fits in with our versioning requirements, this column has been "gone" forever in that it hasn't done anything, but I could see an old store still setting it (or setting it to false) which would now error instead of just doing nothing.