### PR TITLE
Prevent an order from completing if its pending payments do not cover the total price of the order

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -681,11 +681,6 @@ module Spree
       end
 
       payments.reset
-
-      if payments.where(state: %w(checkout pending)).sum(:amount) != total
-        errors.add(:base, Spree.t("store_credit.errors.unable_to_fund")) and return false
-      end
-
     end
 
     def covered_by_store_credit?
@@ -695,7 +690,7 @@ module Spree
     alias_method :covered_by_store_credit, :covered_by_store_credit?
 
     def covered_by_valid_payments?
-      return payments.where(state: %w(checkout pending)).sum(:amount) >= total
+      payments.where(state: %w(checkout completed pending processing)).sum(:amount) >= total
     end
 
     def total_available_store_credit

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -694,6 +694,10 @@ module Spree
     end
     alias_method :covered_by_store_credit, :covered_by_store_credit?
 
+    def covered_by_valid_payments?
+      return payments.where(state: %w(checkout pending)).sum(:amount) >= total
+    end
+
     def total_available_store_credit
       return 0.0 unless user
       user.total_available_store_credit

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -315,6 +315,11 @@ module Spree
               return false
             end
 
+            if !covered_by_valid_payments?
+              errors.add(:base, Spree.t(:payments_do_not_cover_order_total))
+              return false
+            end
+
             if process_payments!
               true
             else

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -997,6 +997,7 @@ en:
     no_orders_found: No orders found
     no_payment_methods_found: No payment methods found
     no_payment_found: No payment found
+    payments_do_not_cover_order_total: Payments do not cover order total
     no_pending_payments: No pending payments
     no_products_found: No products found
     no_promotions_found: No promotions found

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1438,7 +1438,6 @@ en:
           eligible: "Eligibility Verified"
           void: "Voided"
       errors:
-        unable_to_fund: "Unable to pay for order using store credits"
         cannot_invalidate_uncaptured_authorization: "Cannot invalidate a store credit with an uncaptured authorization"
       expiring: Expiring
       insufficient_authorized_amount: "Unable to capture more than authorized amount"

--- a/core/lib/spree/testing_support/factories/payment_factory.rb
+++ b/core/lib/spree/testing_support/factories/payment_factory.rb
@@ -1,9 +1,9 @@
 FactoryGirl.define do
   factory :payment, aliases: [:credit_card_payment], class: Spree::Payment do
-    amount 45.75
+    amount { order.total }
     association(:payment_method, factory: :credit_card_payment_method)
     association(:source, factory: :credit_card)
-    order
+    association(:order, factory: :order_with_line_items)
     state 'checkout'
     response_code '12345'
 
@@ -16,7 +16,7 @@ FactoryGirl.define do
   end
 
   factory :check_payment, class: Spree::Payment do
-    amount 45.75
+    amount { order.total }
     association(:payment_method, factory: :check_payment_method)
     order
   end

--- a/core/lib/spree/testing_support/factories/refund_factory.rb
+++ b/core/lib/spree/testing_support/factories/refund_factory.rb
@@ -2,7 +2,7 @@ FactoryGirl.define do
   sequence(:refund_transaction_id) { |n| "fake-refund-transaction-#{n}"}
 
   factory :refund, class: Spree::Refund do
-    amount 100.00
+    amount { payment.amount / 2 }
     transaction_id { generate(:refund_transaction_id) }
     association(:payment, state: 'completed')
     association(:reason, factory: :refund_reason)

--- a/core/spec/models/spree/order/state_machine_spec.rb
+++ b/core/spec/models/spree/order/state_machine_spec.rb
@@ -22,7 +22,7 @@ describe Spree::Order, :type => :model do
 
       context "when payment processing succeeds" do
         before do
-          order.payments << FactoryGirl.create(:payment, state: 'checkout', order: order)
+          order.payments << FactoryGirl.create(:payment, state: 'checkout')
           allow(order).to receive_messages process_payments: true
         end
 

--- a/core/spec/models/spree/order/state_machine_spec.rb
+++ b/core/spec/models/spree/order/state_machine_spec.rb
@@ -15,6 +15,7 @@ describe Spree::Order, :type => :model do
         order.state = "confirm"
         order.run_callbacks(:create)
         allow(order).to receive_messages :payment_required? => true
+        allow(order).to receive_messages :ensure_sufficient_payment => true
         allow(order).to receive_messages :process_payments! => true
         allow(order).to receive_messages :ensure_available_shipping_rates => true
         allow(order).to receive :has_available_shipment

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -1056,13 +1056,6 @@ describe Spree::Order, :type => :model do
             expect(order.payments.first.amount).to eq order_total
           end
         end
-
-        context "there are no other payments" do
-          it "adds an error to the model" do
-            expect(subject).to be false
-            expect(order.errors.full_messages).to include(Spree.t("store_credit.errors.unable_to_fund"))
-          end
-        end
       end
 
       context "there is enough store credit to pay for the entire order" do
@@ -1096,13 +1089,6 @@ describe Spree::Order, :type => :model do
         let(:store_credit_total) { order_total - 100 }
         let(:store_credit)       { create(:store_credit, amount: store_credit_total) }
         let(:order) { create(:order_with_totals, user: store_credit.user, line_items_price: order_total).tap(&:update!) }
-
-        context "there are no other payments" do
-          it "adds an error to the model" do
-            expect(subject).to be false
-            expect(order.errors.full_messages).to include(Spree.t("store_credit.errors.unable_to_fund"))
-          end
-        end
 
         context "there is a credit card payment" do
           let!(:cc_payment) { create(:payment, order: order, state: "checkout") }
@@ -1427,12 +1413,13 @@ describe Spree::Order, :type => :model do
         line_items_count: 3,
         line_items_price: 10,
         shipment_cost: 5,
-        payments: [credit_card_payment, store_credit_payment])
+        payments: payments)
     end
 
-    context "valid paymenets match order's total" do
+    context "valid payments match order's total" do
       let(:credit_card_payment) { create(:payment, amount: 25) }
       let(:store_credit_payment) { create(:store_credit_payment, amount: 10 )}
+      let(:payments) { [credit_card_payment, store_credit_payment] }
 
       it "is true" do
         expect(order.covered_by_valid_payments?).to be_truthy
@@ -1440,8 +1427,11 @@ describe Spree::Order, :type => :model do
     end
 
     context "valid payments do not match order's total" do
-      let(:credit_card_payment) { create(:payment, amount: 25, state: "failed") }
-      let(:store_credit_payment) { create(:store_credit_payment, amount: 10 )}
+      let(:failed_payment) { create(:payment, amount: 10, state: "failed") }
+      let(:voided_payment) { create(:payment, amount: 10, state: "void") }
+      let(:invalid_payment) { create(:payment, amount: 10, state: "invalid") }
+      let(:store_credit_payment) { create(:store_credit_payment, amount: 5 )}
+      let(:payments) { [failed_payment, voided_payment, invalid_payment, store_credit_payment] }
 
       it "is false" do
         expect(order.covered_by_valid_payments?).to be_falsey

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -1419,4 +1419,33 @@ describe Spree::Order, :type => :model do
       end
     end
   end
+
+  describe '#covered_by_valid_payments?' do
+    let(:order) do
+      create(
+        :order_with_line_items,
+        line_items_count: 3,
+        line_items_price: 10,
+        shipment_cost: 5,
+        payments: [credit_card_payment, store_credit_payment])
+    end
+
+    context "valid paymenets match order's total" do
+      let(:credit_card_payment) { create(:payment, amount: 25) }
+      let(:store_credit_payment) { create(:store_credit_payment, amount: 10 )}
+
+      it "is true" do
+        expect(order.covered_by_valid_payments?).to be_truthy
+      end
+    end
+
+    context "valid payments do not match order's total" do
+      let(:credit_card_payment) { create(:payment, amount: 25, state: "failed") }
+      let(:store_credit_payment) { create(:store_credit_payment, amount: 10 )}
+
+      it "is false" do
+        expect(order.covered_by_valid_payments?).to be_falsey
+      end
+    end
+  end
 end

--- a/core/spec/models/spree/order_updater_spec.rb
+++ b/core/spec/models/spree/order_updater_spec.rb
@@ -10,12 +10,13 @@ module Spree
         2.times do
           create(:line_item, order: order, price: 10)
         end
+        Spree::OrderUpdater.new(order).update
       end
 
       it "updates payment totals" do
         create(:payment_with_refund, order: order)
         Spree::OrderUpdater.new(order).update_payment_total
-        expect(order.payment_total).to eq(40.75)
+        expect(order.payment_total).to eq(15)
       end
 
       it "update item total" do


### PR DESCRIPTION
A check is made [here] (https://github.com/solidusio/solidus/blob/master/core/app/models/spree/order.rb#L685-L687) to ensure that an order's payments cover the total cost of the order before transitioning from the payment state to confirm. If the state machine transitions ever change so that an order is able to reach confirm or complete without making the payment -> confirm transition then this check will be bypassed and it will be possible for a user to checkout without having enough payments to cover the total cost of the order.

I think it makes sense to check that the payments will cover the cost of the order before transitioning to complete. This should guarantee that an order will never complete unless its payments can cover the total cost.

I'm also curious if there are any reasons not to perform the check when transitioning to complete. I wasn't able to think of any, but I'm not sure if there's some case I may be missing where this check would be unwanted.