### PR TITLE
Have stock related permission sets conditionally operate more restrictively based on store configuration

### DIFF
--- a/api/app/controllers/spree/api/stock_items_controller.rb
+++ b/api/app/controllers/spree/api/stock_items_controller.rb
@@ -15,7 +15,6 @@ module Spree
 
       def create
         authorize! :create, StockItem
-
         @stock_item = scope.new(stock_item_params)
 
         Spree::StockItem.transaction do
@@ -56,7 +55,7 @@ module Spree
 
       def load_stock_location
         render 'spree/api/shared/stock_location_required', status: 422 and return unless params[:stock_location_id]
-        @stock_location ||= StockLocation.accessible_by(current_ability, action_name.to_sym).find(params[:stock_location_id])
+        @stock_location ||= StockLocation.accessible_by(current_ability).find(params[:stock_location_id])
       end
 
       def scope

--- a/api/spec/controllers/spree/api/stock_items_controller_spec.rb
+++ b/api/spec/controllers/spree/api/stock_items_controller_spec.rb
@@ -55,7 +55,7 @@ module Spree
           }
 
           api_post :create, params
-          expect(response.status).to eq(404)
+          expect(response.status).to eq(401)
         end
       end
 

--- a/core/app/models/spree/permission_sets/restricted_stock_display.rb
+++ b/core/app/models/spree/permission_sets/restricted_stock_display.rb
@@ -1,0 +1,16 @@
+module Spree
+  module PermissionSets
+    class RestrictedStockDisplay < PermissionSets::Base
+      def activate!
+        can [:display, :admin], Spree::StockItem, stock_location_id: location_ids
+        can :display, Spree::StockLocation, id: location_ids
+      end
+
+      private
+
+      def location_ids
+        @ids ||= user.stock_locations.pluck(:id)
+      end
+    end
+  end
+end

--- a/core/app/models/spree/permission_sets/restricted_stock_management.rb
+++ b/core/app/models/spree/permission_sets/restricted_stock_management.rb
@@ -1,0 +1,16 @@
+module Spree
+  module PermissionSets
+    class RestrictedStockManagement < PermissionSets::Base
+      def activate!
+        can :manage, Spree::StockItem, stock_location_id: location_ids
+        can :display, Spree::StockLocation, id: location_ids
+      end
+
+      private
+
+      def location_ids
+        @ids ||= user.stock_locations.pluck(:id)
+      end
+    end
+  end
+end

--- a/core/app/models/spree/permission_sets/restricted_stock_transfer_display.rb
+++ b/core/app/models/spree/permission_sets/restricted_stock_transfer_display.rb
@@ -1,0 +1,17 @@
+module Spree
+  module PermissionSets
+    class RestrictedStockTransferDisplay < PermissionSets::Base
+      def activate!
+        can [:display, :admin], Spree::StockTransfer, source_location_id: location_ids
+        can [:display, :admin], Spree::StockTransfer, destination_location_id: location_ids
+        can :display, Spree::StockLocation, id: location_ids
+      end
+
+      private
+
+      def location_ids
+        @ids ||= user.stock_locations.pluck(:id)
+      end
+    end
+  end
+end

--- a/core/app/models/spree/permission_sets/restricted_stock_transfer_management.rb
+++ b/core/app/models/spree/permission_sets/restricted_stock_transfer_management.rb
@@ -16,13 +16,10 @@ module Spree
     #   or if the user is associated with the source, and the transfer has not yet been assigned a destination.
     #
     # @see Spree::PermissionSets::Base
-    class RestrictedTransferManagement < PermissionSets::Base
+    class RestrictedStockTransferManagement < PermissionSets::Base
       def activate!
-        can [:display, :admin], Spree::StockItem
-        # We need display here, as by default users cannot see inactive stock locations.
-        can :display, Spree::StockLocation
-
         if user.stock_locations.any?
+          can :display, Spree::StockLocation, id: location_ids
           can [:admin, :create], Spree::StockTransfer
           can :display, Spree::StockTransfer, source_location_id: location_ids
           can :display, Spree::StockTransfer, destination_location_id: location_ids
@@ -31,8 +28,6 @@ module Spree
             destination_location_id: destination_location_ids
 
           can :transfer, Spree::StockLocation, id: location_ids
-
-          can :update, Spree::StockItem, stock_location_id: location_ids
 
           can :manage, Spree::TransferItem, stock_transfer: {
             source_location_id: location_ids,

--- a/core/app/models/spree/permission_sets/stock_display.rb
+++ b/core/app/models/spree/permission_sets/stock_display.rb
@@ -3,6 +3,7 @@ module Spree
     class StockDisplay < PermissionSets::Base
       def activate!
         can [:display, :admin], Spree::StockItem
+        can :display, Spree::StockLocation
       end
     end
   end

--- a/core/app/models/spree/permission_sets/stock_display.rb
+++ b/core/app/models/spree/permission_sets/stock_display.rb
@@ -3,7 +3,6 @@ module Spree
     class StockDisplay < PermissionSets::Base
       def activate!
         can [:display, :admin], Spree::StockItem
-        can [:display, :admin], Spree::StockTransfer
       end
     end
   end

--- a/core/app/models/spree/permission_sets/stock_management.rb
+++ b/core/app/models/spree/permission_sets/stock_management.rb
@@ -3,6 +3,7 @@ module Spree
     class StockManagement < PermissionSets::Base
       def activate!
         can :manage, Spree::StockItem
+        can :display, Spree::StockLocation
       end
     end
   end

--- a/core/app/models/spree/permission_sets/stock_management.rb
+++ b/core/app/models/spree/permission_sets/stock_management.rb
@@ -3,8 +3,6 @@ module Spree
     class StockManagement < PermissionSets::Base
       def activate!
         can :manage, Spree::StockItem
-        can :manage, Spree::StockTransfer
-        can :manage, Spree::TransferItem
       end
     end
   end

--- a/core/app/models/spree/permission_sets/stock_transfer_display.rb
+++ b/core/app/models/spree/permission_sets/stock_transfer_display.rb
@@ -1,0 +1,9 @@
+module Spree
+  module PermissionSets
+    class StockTransferDisplay < PermissionSets::Base
+      def activate!
+        can [:display, :admin], Spree::StockTransfer
+      end
+    end
+  end
+end

--- a/core/app/models/spree/permission_sets/stock_transfer_display.rb
+++ b/core/app/models/spree/permission_sets/stock_transfer_display.rb
@@ -3,6 +3,7 @@ module Spree
     class StockTransferDisplay < PermissionSets::Base
       def activate!
         can [:display, :admin], Spree::StockTransfer
+        can :display, Spree::StockLocation
       end
     end
   end

--- a/core/app/models/spree/permission_sets/stock_transfer_management.rb
+++ b/core/app/models/spree/permission_sets/stock_transfer_management.rb
@@ -1,0 +1,10 @@
+module Spree
+  module PermissionSets
+    class StockTransferManagement < PermissionSets::Base
+      def activate!
+        can :manage, Spree::StockTransfer
+        can :manage, Spree::TransferItem
+      end
+    end
+  end
+end

--- a/core/app/models/spree/permission_sets/stock_transfer_management.rb
+++ b/core/app/models/spree/permission_sets/stock_transfer_management.rb
@@ -4,6 +4,7 @@ module Spree
       def activate!
         can :manage, Spree::StockTransfer
         can :manage, Spree::TransferItem
+        can :display, Spree::StockLocation
       end
     end
   end

--- a/core/spec/models/spree/permission_sets/restricted_stock_display_spec.rb
+++ b/core/spec/models/spree/permission_sets/restricted_stock_display_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+describe Spree::PermissionSets::RestrictedStockDisplay do
+  let(:ability) { Spree::Ability.new(user) }
+  let(:user) { create :user }
+
+  subject { ability }
+
+  let!(:variant) { create :variant }
+
+  let(:sl1) { create :stock_location, active: false }
+  let(:sl2) { create :stock_location, active: false }
+
+  let(:item1) { variant.stock_items.where(stock_location_id: sl1.id).first }
+  let(:item2) { variant.stock_items.where(stock_location_id: sl2.id).first }
+
+  before do
+    user.stock_locations << sl1
+  end
+
+  context "when activated" do
+    before do
+      described_class.new(ability).activate!
+    end
+
+    it { is_expected.to be_able_to(:display, sl1) }
+    it { is_expected.to_not be_able_to(:display, sl2) }
+
+    it { is_expected.to be_able_to(:display, item1) }
+    it { is_expected.to_not be_able_to(:display, item2) }
+  end
+
+  context "when not activated" do
+    it { is_expected.to_not be_able_to(:display, sl1) }
+    it { is_expected.to_not be_able_to(:display, sl2) }
+
+    it { is_expected.to_not be_able_to(:display, item1) }
+    it { is_expected.to_not be_able_to(:display, item2) }
+  end
+end
+

--- a/core/spec/models/spree/permission_sets/restricted_stock_management_spec.rb
+++ b/core/spec/models/spree/permission_sets/restricted_stock_management_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+describe Spree::PermissionSets::RestrictedStockManagement do
+  let(:ability) { Spree::Ability.new(user) }
+  let(:user) { create :user }
+
+  subject { ability }
+
+  let!(:variant) { create :variant }
+
+  let(:sl1) { create :stock_location, active: false }
+  let(:sl2) { create :stock_location, active: false }
+
+  let(:item1) { variant.stock_items.where(stock_location_id: sl1.id).first }
+  let(:item2) { variant.stock_items.where(stock_location_id: sl2.id).first }
+
+  before do
+    user.stock_locations << sl1
+  end
+
+  context "when activated" do
+    before do
+      described_class.new(ability).activate!
+    end
+
+    it { is_expected.to be_able_to(:display, sl1) }
+    it { is_expected.to_not be_able_to(:display, sl2) }
+
+    it { is_expected.to be_able_to(:manage, item1) }
+    it { is_expected.to_not be_able_to(:manage, item2) }
+  end
+
+  context "when not activated" do
+    it { is_expected.to_not be_able_to(:display, sl1) }
+    it { is_expected.to_not be_able_to(:display, sl2) }
+
+    it { is_expected.to_not be_able_to(:manage, item1) }
+    it { is_expected.to_not be_able_to(:manage, item2) }
+  end
+end
+

--- a/core/spec/models/spree/permission_sets/restricted_stock_transfer_display_spec.rb
+++ b/core/spec/models/spree/permission_sets/restricted_stock_transfer_display_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+describe Spree::PermissionSets::RestrictedStockTransferDisplay do
+  let(:ability) { Spree::Ability.new(user) }
+  let(:user) { create :user }
+
+  subject { ability }
+
+  let!(:sl1) { create :stock_location, active: false }
+  let!(:sl2) { create :stock_location, active: false }
+
+  let!(:source_transfer) { create :stock_transfer, source_location: sl1 }
+  let!(:other_source_transfer) { create :stock_transfer, source_location: sl2 }
+  let!(:dest_transfer) { create :stock_transfer, source_location: sl2, destination_location: sl1 }
+
+
+  before do
+    user.stock_locations << sl1
+  end
+
+  context "when activated" do
+    before do
+      described_class.new(ability).activate!
+    end
+
+    it { is_expected.to be_able_to(:display, sl1) }
+    it { is_expected.to_not be_able_to(:display, sl2) }
+
+    it { is_expected.to be_able_to(:display, source_transfer) }
+    it { is_expected.to_not be_able_to(:display, other_source_transfer) }
+    it { is_expected.to be_able_to(:display, dest_transfer) }
+
+    it { is_expected.to be_able_to(:admin, source_transfer) }
+    it { is_expected.to_not be_able_to(:admin, other_source_transfer) }
+    it { is_expected.to be_able_to(:admin, dest_transfer) }
+  end
+
+  context "when not activated" do
+    it { is_expected.to_not be_able_to(:display, sl1) }
+    it { is_expected.to_not be_able_to(:display, sl2) }
+
+    it { is_expected.to_not be_able_to(:display, source_transfer) }
+    it { is_expected.to_not be_able_to(:display, other_source_transfer) }
+    it { is_expected.to_not be_able_to(:display, dest_transfer) }
+
+    it { is_expected.to_not be_able_to(:admin, source_transfer) }
+    it { is_expected.to_not be_able_to(:admin, other_source_transfer) }
+    it { is_expected.to_not be_able_to(:admin, dest_transfer) }
+  end
+end

--- a/core/spec/models/spree/permission_sets/restricted_stock_transfer_management_spec.rb
+++ b/core/spec/models/spree/permission_sets/restricted_stock_transfer_management_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Spree::PermissionSets::RestrictedTransferManagement do
+describe Spree::PermissionSets::RestrictedStockTransferManagement do
   let(:ability) { Spree::Ability.new(user) }
 
   subject { ability }
@@ -13,9 +13,6 @@ describe Spree::PermissionSets::RestrictedTransferManagement do
   # This has the side effect of creating a stock item for each stock location above,
   # which is what we actually want.
   let!(:variant) { create :variant }
-
-  let(:source_stock_item) { source_location.stock_items.first }
-  let(:destination_stock_item) { destination_location.stock_items.first }
 
   let(:transfer_with_source) { create :stock_transfer, source_location: source_location }
   let(:transfer_with_destination) { create :stock_transfer, source_location: destination_location  }
@@ -48,21 +45,15 @@ describe Spree::PermissionSets::RestrictedTransferManagement do
       described_class.new(ability).activate!
     end
 
-    it { is_expected.to be_able_to(:display, Spree::StockItem) }
-    it { is_expected.to be_able_to(:admin, Spree::StockItem) }
-
-    it { is_expected.to be_able_to(:display, source_location) }
-    it { is_expected.to be_able_to(:display, destination_location) }
-
     context "when the user is associated with one of the locations" do
       let(:stock_locations) {[source_location]}
+
+      it { is_expected.to be_able_to(:display, source_location) }
+      it { is_expected.to_not be_able_to(:display, destination_location) }
 
       it { is_expected.to be_able_to(:display, Spree::StockTransfer) }
       it { is_expected.to be_able_to(:admin, Spree::StockTransfer) }
       it { is_expected.to be_able_to(:create, Spree::StockTransfer) }
-
-      it { is_expected.to be_able_to(:update, source_stock_item) }
-      it { is_expected.not_to be_able_to(:update, destination_stock_item) }
 
       it { is_expected.to be_able_to(:transfer, source_location) }
       it { is_expected.not_to be_able_to(:transfer, destination_location) }
@@ -84,12 +75,12 @@ describe Spree::PermissionSets::RestrictedTransferManagement do
     context "when the user is associated with both locations" do
       let(:stock_locations) {[source_location, destination_location]}
 
+      it { is_expected.to be_able_to(:display, source_location) }
+      it { is_expected.to be_able_to(:display, destination_location) }
+
       it { is_expected.to be_able_to(:display, Spree::StockTransfer) }
       it { is_expected.to be_able_to(:admin, Spree::StockTransfer) }
       it { is_expected.to be_able_to(:create, Spree::StockTransfer) }
-
-      it { is_expected.to be_able_to(:update, source_stock_item) }
-      it { is_expected.to be_able_to(:update, destination_stock_item) }
 
       it { is_expected.to be_able_to(:transfer, source_location) }
       it { is_expected.to be_able_to(:transfer, destination_location) }
@@ -110,12 +101,12 @@ describe Spree::PermissionSets::RestrictedTransferManagement do
     context "when the user is associated with neither location" do
       let(:stock_locations) {[]}
 
+      it { is_expected.to_not be_able_to(:display, source_location) }
+      it { is_expected.to_not be_able_to(:display, destination_location) }
+
       it { is_expected.not_to be_able_to(:display, Spree::StockTransfer) }
       it { is_expected.not_to be_able_to(:admin, Spree::StockTransfer) }
       it { is_expected.not_to be_able_to(:create, Spree::StockTransfer) }
-
-      it { is_expected.not_to be_able_to(:update, source_stock_item) }
-      it { is_expected.not_to be_able_to(:update, destination_stock_item) }
 
       it { is_expected.not_to be_able_to(:transfer, source_location) }
       it { is_expected.not_to be_able_to(:transfer, destination_location) }
@@ -137,8 +128,8 @@ describe Spree::PermissionSets::RestrictedTransferManagement do
     it { is_expected.not_to be_able_to(:admin, Spree::StockTransfer) }
     it { is_expected.not_to be_able_to(:create, Spree::StockTransfer) }
 
-    it { is_expected.not_to be_able_to(:update, source_stock_item) }
-    it { is_expected.not_to be_able_to(:update, destination_stock_item) }
+    it { is_expected.to_not be_able_to(:display, source_location) }
+    it { is_expected.to_not be_able_to(:display, destination_location) }
 
     it { is_expected.not_to be_able_to(:transfer, source_location) }
     it { is_expected.not_to be_able_to(:transfer, destination_location) }

--- a/core/spec/models/spree/permission_sets/stock_display_spec.rb
+++ b/core/spec/models/spree/permission_sets/stock_display_spec.rb
@@ -11,16 +11,12 @@ describe Spree::PermissionSets::StockDisplay do
     end
 
     it { is_expected.to be_able_to(:display, Spree::StockItem) }
-    it { is_expected.to be_able_to(:display, Spree::StockTransfer) }
     it { is_expected.to be_able_to(:admin, Spree::StockItem) }
-    it { is_expected.to be_able_to(:admin, Spree::StockTransfer) }
   end
 
   context "when not activated" do
     it { is_expected.not_to be_able_to(:display, Spree::StockItem) }
-    it { is_expected.not_to be_able_to(:display, Spree::StockTransfer) }
     it { is_expected.not_to be_able_to(:admin, Spree::StockItem) }
-    it { is_expected.not_to be_able_to(:admin, Spree::StockTransfer) }
   end
 end
 

--- a/core/spec/models/spree/permission_sets/stock_display_spec.rb
+++ b/core/spec/models/spree/permission_sets/stock_display_spec.rb
@@ -12,11 +12,13 @@ describe Spree::PermissionSets::StockDisplay do
 
     it { is_expected.to be_able_to(:display, Spree::StockItem) }
     it { is_expected.to be_able_to(:admin, Spree::StockItem) }
+    it { is_expected.to be_able_to(:display, Spree::StockLocation) }
   end
 
   context "when not activated" do
     it { is_expected.not_to be_able_to(:display, Spree::StockItem) }
     it { is_expected.not_to be_able_to(:admin, Spree::StockItem) }
+    it { is_expected.not_to be_able_to(:display, Spree::StockLocation) }
   end
 end
 

--- a/core/spec/models/spree/permission_sets/stock_management_spec.rb
+++ b/core/spec/models/spree/permission_sets/stock_management_spec.rb
@@ -11,10 +11,12 @@ describe Spree::PermissionSets::StockManagement do
     end
 
     it { is_expected.to be_able_to(:manage, Spree::StockItem) }
+    it { is_expected.to be_able_to(:display, Spree::StockLocation) }
   end
 
   context "when not activated" do
     it { is_expected.not_to be_able_to(:manage, Spree::StockItem) }
+    it { is_expected.not_to be_able_to(:display, Spree::StockLocation) }
   end
 end
 

--- a/core/spec/models/spree/permission_sets/stock_management_spec.rb
+++ b/core/spec/models/spree/permission_sets/stock_management_spec.rb
@@ -11,14 +11,10 @@ describe Spree::PermissionSets::StockManagement do
     end
 
     it { is_expected.to be_able_to(:manage, Spree::StockItem) }
-    it { is_expected.to be_able_to(:manage, Spree::StockTransfer) }
-    it { is_expected.to be_able_to(:manage, Spree::TransferItem) }
   end
 
   context "when not activated" do
     it { is_expected.not_to be_able_to(:manage, Spree::StockItem) }
-    it { is_expected.not_to be_able_to(:manage, Spree::StockTransfer) }
-    it { is_expected.not_to be_able_to(:manage, Spree::TransferItem) }
   end
 end
 

--- a/core/spec/models/spree/permission_sets/stock_transfer_display_spec.rb
+++ b/core/spec/models/spree/permission_sets/stock_transfer_display_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe Spree::PermissionSets::StockTransferDisplay do
+  let(:ability) { DummyAbility.new }
+
+  subject { ability }
+
+  context "when activated" do
+    before do
+      described_class.new(ability).activate!
+    end
+
+    it { is_expected.to be_able_to(:display, Spree::StockTransfer) }
+    it { is_expected.to be_able_to(:admin, Spree::StockTransfer) }
+  end
+
+  context "when not activated" do
+    it { is_expected.not_to be_able_to(:display, Spree::StockTransfer) }
+    it { is_expected.not_to be_able_to(:admin, Spree::StockTransfer) }
+  end
+end
+

--- a/core/spec/models/spree/permission_sets/stock_transfer_display_spec.rb
+++ b/core/spec/models/spree/permission_sets/stock_transfer_display_spec.rb
@@ -12,11 +12,13 @@ describe Spree::PermissionSets::StockTransferDisplay do
 
     it { is_expected.to be_able_to(:display, Spree::StockTransfer) }
     it { is_expected.to be_able_to(:admin, Spree::StockTransfer) }
+    it { is_expected.to be_able_to(:display, Spree::StockLocation) }
   end
 
   context "when not activated" do
     it { is_expected.not_to be_able_to(:display, Spree::StockTransfer) }
     it { is_expected.not_to be_able_to(:admin, Spree::StockTransfer) }
+    it { is_expected.not_to be_able_to(:display, Spree::StockLocation) }
   end
 end
 

--- a/core/spec/models/spree/permission_sets/stock_transfer_management_spec.rb
+++ b/core/spec/models/spree/permission_sets/stock_transfer_management_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe Spree::PermissionSets::StockTransferManagement do
+  let(:ability) { DummyAbility.new }
+
+  subject { ability }
+
+  context "when activated" do
+    before do
+      described_class.new(ability).activate!
+    end
+
+    it { is_expected.to be_able_to(:manage, Spree::StockTransfer) }
+    it { is_expected.to be_able_to(:manage, Spree::TransferItem) }
+  end
+
+  context "when not activated" do
+    it { is_expected.to_not be_able_to(:manage, Spree::StockTransfer) }
+    it { is_expected.to_not be_able_to(:manage, Spree::TransferItem) }
+  end
+end
+
+

--- a/core/spec/models/spree/permission_sets/stock_transfer_management_spec.rb
+++ b/core/spec/models/spree/permission_sets/stock_transfer_management_spec.rb
@@ -12,11 +12,13 @@ describe Spree::PermissionSets::StockTransferManagement do
 
     it { is_expected.to be_able_to(:manage, Spree::StockTransfer) }
     it { is_expected.to be_able_to(:manage, Spree::TransferItem) }
+    it { is_expected.to be_able_to(:display, Spree::StockLocation) }
   end
 
   context "when not activated" do
     it { is_expected.to_not be_able_to(:manage, Spree::StockTransfer) }
     it { is_expected.to_not be_able_to(:manage, Spree::TransferItem) }
+    it { is_expected.not_to be_able_to(:display, Spree::StockLocation) }
   end
 end
 


### PR DESCRIPTION
This separates stock transfers and stock item related permissions and add conditional logic to allow limited access for each permission set bounded by the users stock location associations if `Spree::Config[:respect_stock_location_associations]` is true. 

If the value is false, which is the default, the permission sets would behave as they were before this change.

This is the first draft to this effect to encourage discussion on using this approach.