### PR TITLE
fix for user_address association caching corner case

### DIFF
--- a/core/app/models/concerns/spree/user_address_book.rb
+++ b/core/app/models/concerns/spree/user_address_book.rb
@@ -6,9 +6,7 @@ module Spree
       has_many :user_addresses, foreign_key: "user_id", class_name: "Spree::UserAddress" do
 
         def find_first_by_address_values(address_attrs)
-          sql_record = with_address_values(address_attrs).first
-          return nil unless sql_record.present?
-          detect { |ua| ua.id == sql_record.id } #ensures we use a cached version
+          detect { |ua| ua.address == Address.new(address_attrs) }
         end
 
         # @note this method enforces one-and-only-one default address per user

--- a/core/lib/spree/testing_support/factories/address_factory.rb
+++ b/core/lib/spree/testing_support/factories/address_factory.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
-  factory :address, aliases: [:bill_address, :ship_address], class: Spree::Address do
+  factory :address, class: Spree::Address do
     firstname 'John'
     lastname 'Doe'
     company 'Company'
@@ -18,5 +18,13 @@ FactoryGirl.define do
         address.association(:country)
       end
     end
+  end
+
+  factory :ship_address, parent: :address do
+    address1 'A Different Road'
+  end
+
+  factory :bill_address, parent: :address do
+    address1 'PO Box 1337'
   end
 end

--- a/core/lib/spree/testing_support/factories/user_factory.rb
+++ b/core/lib/spree/testing_support/factories/user_factory.rb
@@ -14,9 +14,11 @@ FactoryGirl.define do
       spree_roles { [Spree::Role.find_by(name: 'admin') || create(:role, name: 'admin')] }
     end
 
-    factory :user_with_addreses do
-      ship_address
+    factory :user_with_addreses do |u|
       bill_address
+      after(:create) do |user, evaluator|
+        user.save_in_address_book(create(:ship_address).attributes, true)
+      end
     end
   end
 end

--- a/core/spec/models/spree/user_spec.rb
+++ b/core/spec/models/spree/user_spec.rb
@@ -59,8 +59,8 @@ describe Spree::LegacyUser, :type => :model do
         user.save!
         user.user_addresses.reload
 
-        expect(user.user_addresses.with_address_values(order.bill_address.attributes).first).to_not be_nil
-        expect(user.user_addresses.with_address_values(order.ship_address.attributes).first).to_not be_nil
+        expect(user.user_addresses.find_first_by_address_values(order.bill_address.attributes)).to_not be_nil
+        expect(user.user_addresses.find_first_by_address_values(order.ship_address.attributes)).to_not be_nil
       end
     end
 


### PR DESCRIPTION
This fixes a corner case Jordan and I ran into when running the backfill rake task. It would also happen in normal checkout flow because to preserve existing behavior in the interim we always set the default flag when an address is assigned to an order.

I'd like to add some randomness to the address factory, but it's a bit big to do at the moment because it risks breaking unrelated tests.