### PR TITLE
Remove Address has_many relationships

### DIFF
--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -5,10 +5,6 @@ module Spree
     belongs_to :country, class_name: "Spree::Country"
     belongs_to :state, class_name: "Spree::State"
 
-    has_many :shipments, inverse_of: :address
-    has_many :cartons, inverse_of: :address
-    has_many :credit_cards, inverse_of: :address
-
     validates :firstname, :lastname, :address1, :city, :country_id, presence: true
     validates :zipcode, presence: true, if: :require_zipcode?
     validates :phone, presence: true, if: :require_phone?

--- a/core/app/models/spree/carton.rb
+++ b/core/app/models/spree/carton.rb
@@ -1,5 +1,5 @@
 class Spree::Carton < ActiveRecord::Base
-  belongs_to :address, class_name: 'Spree::Address', inverse_of: :cartons
+  belongs_to :address, class_name: 'Spree::Address'
   belongs_to :stock_location, class_name: 'Spree::StockLocation', inverse_of: :cartons
   belongs_to :shipping_method, class_name: 'Spree::ShippingMethod', inverse_of: :cartons
 

--- a/core/app/models/spree/credit_card.rb
+++ b/core/app/models/spree/credit_card.rb
@@ -2,7 +2,7 @@ module Spree
   class CreditCard < Spree::Base
     belongs_to :payment_method
     belongs_to :user, class_name: Spree.user_class, foreign_key: 'user_id'
-    belongs_to :address, inverse_of: :credit_cards
+    belongs_to :address
     has_many :payments, as: :source
 
     before_save :set_last_digits

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -3,7 +3,7 @@ require 'ostruct'
 module Spree
   class Shipment < Spree::Base
     belongs_to :order, class_name: 'Spree::Order', touch: true, inverse_of: :shipments
-    belongs_to :address, class_name: 'Spree::Address', inverse_of: :shipments
+    belongs_to :address, class_name: 'Spree::Address'
     belongs_to :stock_location, class_name: 'Spree::StockLocation'
 
     has_many :adjustments, as: :adjustable, inverse_of: :adjustable, dependent: :delete_all


### PR DESCRIPTION
With the recent Address work the Address model is meant to be an
immutable data object that isn't viewed as something with (outgoing)
relationships.  The relationships removed here were never used in
Solidus itself and I've never seen them used in an extension or app
and I can't think of any reason why they would be.  Plus, avoiding
defining unused relationships lowers the surface area of the Solidus
api and may help increase security in some scenarios.