### PR TITLE
Add reimbursement type permissions to order permission set.

### DIFF
--- a/core/app/models/spree/permission_sets/order_management.rb
+++ b/core/app/models/spree/permission_sets/order_management.rb
@@ -2,6 +2,7 @@ module Spree
   module PermissionSets
     class OrderManagement < PermissionSets::Base
       def activate!
+        can :display, Spree::ReimbursementType
         can :manage, Spree::Order
         can :manage, Spree::Payment
         can :manage, Spree::Shipment

--- a/core/spec/models/spree/permission_sets/order_management_spec.rb
+++ b/core/spec/models/spree/permission_sets/order_management_spec.rb
@@ -17,6 +17,7 @@ describe Spree::PermissionSets::OrderManagement do
     it { is_expected.to be_able_to(:manage, Spree::LineItem) }
     it { is_expected.to be_able_to(:manage, Spree::ReturnAuthorization) }
     it { is_expected.to be_able_to(:manage, Spree::CustomerReturn) }
+    it { is_expected.to be_able_to(:display, Spree::ReimbursementType) }
   end
 
   context "when not activated" do
@@ -27,6 +28,7 @@ describe Spree::PermissionSets::OrderManagement do
     it { is_expected.not_to be_able_to(:manage, Spree::LineItem) }
     it { is_expected.not_to be_able_to(:manage, Spree::ReturnAuthorization) }
     it { is_expected.not_to be_able_to(:manage, Spree::CustomerReturn) }
+    it { is_expected.not_to be_able_to(:display, Spree::ReimbursementType) }
   end
 end
 


### PR DESCRIPTION
This lets the user select a reimbursement type from the drop down when
creating a return authorization. Previously it would not be populated.