### PR TITLE
Fix displaying out of stock variants for returns

### DIFF
--- a/backend/app/controllers/spree/admin/reimbursements_controller.rb
+++ b/backend/app/controllers/spree/admin/reimbursements_controller.rb
@@ -3,6 +3,7 @@ module Spree
     class ReimbursementsController < ResourceController
       belongs_to 'spree/order', find_by: :number
 
+      before_action :load_stock_locations, only: :edit
       before_action :load_simulated_refunds, only: :edit
 
       rescue_from Spree::Core::GatewayError, with: :spree_core_gateway_error, only: :perform
@@ -30,6 +31,10 @@ module Spree
         else
           edit_admin_order_reimbursement_path(parent, @reimbursement)
         end
+      end
+
+      def load_stock_locations
+        @stock_locations = Spree::StockLocation.active
       end
 
       def load_simulated_refunds

--- a/backend/app/controllers/spree/admin/return_authorizations_controller.rb
+++ b/backend/app/controllers/spree/admin/return_authorizations_controller.rb
@@ -19,6 +19,7 @@ module Spree
         load_return_items
         load_reimbursement_types
         load_return_reasons
+        load_stock_locations
       end
 
       # To satisfy how nested attributes works we want to create placeholder ReturnItems for
@@ -40,6 +41,10 @@ module Spree
 
       def load_return_reasons
         @reasons = Spree::ReturnReason.reasons_for_return_items(@return_authorization.return_items)
+      end
+
+      def load_stock_locations
+        @stock_locations = Spree::StockLocation.order_default.active
       end
     end
   end

--- a/backend/app/views/spree/admin/reimbursements/edit.html.erb
+++ b/backend/app/views/spree/admin/reimbursements/edit.html.erb
@@ -53,7 +53,7 @@
               <% if return_item.exchange_processed? %>
                 <%= return_item.exchange_variant.exchange_name %>
               <% else %>
-                <%= item_fields.collection_select :exchange_variant_id, return_item.eligible_exchange_variants, :id, :exchange_name, { include_blank: true }, { class: "select2 fullwidth return-item-exchange-selection" } %>
+                <%= item_fields.collection_select :exchange_variant_id, return_item.eligible_exchange_variants(Spree::StockLocation.active), :id, :exchange_name, { include_blank: true }, { class: "select2 fullwidth return-item-exchange-selection" } %>
               <% end %>
             </td>
           </tr>

--- a/backend/app/views/spree/admin/reimbursements/edit.html.erb
+++ b/backend/app/views/spree/admin/reimbursements/edit.html.erb
@@ -53,7 +53,7 @@
               <% if return_item.exchange_processed? %>
                 <%= return_item.exchange_variant.exchange_name %>
               <% else %>
-                <%= item_fields.collection_select :exchange_variant_id, return_item.eligible_exchange_variants(Spree::StockLocation.active), :id, :exchange_name, { include_blank: true }, { class: "select2 fullwidth return-item-exchange-selection" } %>
+                <%= item_fields.collection_select :exchange_variant_id, return_item.eligible_exchange_variants(@stock_locations), :id, :exchange_name, { include_blank: true }, { class: "select2 fullwidth return-item-exchange-selection" } %>
               <% end %>
             </td>
           </tr>

--- a/backend/app/views/spree/admin/return_authorizations/_form.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/_form.html.erb
@@ -1,4 +1,5 @@
 <% allow_return_item_changes = !@return_authorization.customer_returned_items? %>
+<% stock_locations = Spree::StockLocation.order_default.active %>
 
 <div data-hook="admin_return_authorization_form_fields">
   <table class="index return-items-table">
@@ -54,7 +55,7 @@
           </td>
           <td class="align-center">
             <% if editable %>
-              <%= item_fields.collection_select :exchange_variant_id, return_item.eligible_exchange_variants, :id, :options_text, { include_blank: true }, { class: "select2 fullwidth return-item-exchange-selection" } %>
+              <%= item_fields.collection_select :exchange_variant_id, return_item.eligible_exchange_variants(stock_locations), :id, :options_text, { include_blank: true }, { class: "select2 fullwidth return-item-exchange-selection" } %>
             <% elsif return_item.exchange_processed? %>
               <%= return_item.exchange_variant.options_text %>
             <% end %>
@@ -77,7 +78,7 @@
 
   <%= f.field_container :stock_location do %>
     <%= f.label :stock_location, Spree.t(:stock_location) %>
-    <%= f.select :stock_location_id, Spree::StockLocation.order_default.active.to_a.collect{|l|[l.name, l.id]}, {include_blank: true}, {class: 'select2 fullwidth', "data-placeholder" => Spree.t(:select_a_stock_location)} %>
+    <%= f.select :stock_location_id, stock_locations.to_a.collect{|l|[l.name, l.id]}, {include_blank: true}, {class: 'select2 fullwidth', "data-placeholder" => Spree.t(:select_a_stock_location)} %>
     <%= f.error_message_on :stock_location_id %>
   <% end %>
 

--- a/backend/app/views/spree/admin/return_authorizations/_form.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/_form.html.erb
@@ -1,5 +1,4 @@
 <% allow_return_item_changes = !@return_authorization.customer_returned_items? %>
-<% stock_locations = Spree::StockLocation.order_default.active %>
 
 <div data-hook="admin_return_authorization_form_fields">
   <table class="index return-items-table">
@@ -55,7 +54,7 @@
           </td>
           <td class="align-center">
             <% if editable %>
-              <%= item_fields.collection_select :exchange_variant_id, return_item.eligible_exchange_variants(stock_locations), :id, :options_text, { include_blank: true }, { class: "select2 fullwidth return-item-exchange-selection" } %>
+              <%= item_fields.collection_select :exchange_variant_id, return_item.eligible_exchange_variants(@stock_locations), :id, :options_text, { include_blank: true }, { class: "select2 fullwidth return-item-exchange-selection" } %>
             <% elsif return_item.exchange_processed? %>
               <%= return_item.exchange_variant.options_text %>
             <% end %>
@@ -78,7 +77,7 @@
 
   <%= f.field_container :stock_location do %>
     <%= f.label :stock_location, Spree.t(:stock_location) %>
-    <%= f.select :stock_location_id, stock_locations.to_a.collect{|l|[l.name, l.id]}, {include_blank: true}, {class: 'select2 fullwidth', "data-placeholder" => Spree.t(:select_a_stock_location)} %>
+    <%= f.select :stock_location_id, @stock_locations.to_a.collect{|l|[l.name, l.id]}, {include_blank: true}, {class: 'select2 fullwidth', "data-placeholder" => Spree.t(:select_a_stock_location)} %>
     <%= f.error_message_on :stock_location_id %>
   <% end %>
 

--- a/backend/spec/controllers/spree/admin/reimbursements_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/reimbursements_controller_spec.rb
@@ -7,6 +7,23 @@ describe Spree::Admin::ReimbursementsController, :type => :controller do
     Spree::RefundReason.find_or_create_by!(name: Spree::RefundReason::RETURN_PROCESSING_REASON, mutable: false)
   end
 
+  describe '#edit' do
+    let(:reimbursement) { create(:reimbursement) }
+    let(:order) { reimbursement.order }
+    let!(:active_stock_location) { create(:stock_location, active: true) }
+    let!(:inactive_stock_location) { create(:stock_location, active: false) }
+
+    subject do
+      spree_get :edit, order_id: order.to_param, id: reimbursement.to_param
+    end
+
+    it "loads all the active stock locations" do
+      subject
+      expect(assigns(:stock_locations)).to include(active_stock_location)
+      expect(assigns(:stock_locations)).not_to include(inactive_stock_location)
+    end
+  end
+
   describe '#create' do
     let(:customer_return)  { create(:customer_return, line_items_count: 1) }
     let(:order) { customer_return.order }

--- a/backend/spec/controllers/spree/admin/return_authorizations_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/return_authorizations_controller_spec.rb
@@ -131,6 +131,20 @@ describe Spree::Admin::ReturnAuthorizationsController, :type => :controller do
     end
   end
 
+  describe "#load_stock_locations" do
+    let!(:active_stock_location)   { create(:stock_location, active: true) }
+    let!(:inactive_stock_location) { create(:stock_location, active: false) }
+
+    before do
+      spree_get :new, order_id: order.to_param
+    end
+
+    it "loads all the active stock locations" do
+      expect(assigns(:stock_locations)).to include(active_stock_location)
+      expect(assigns(:stock_locations)).not_to include(inactive_stock_location)
+    end
+  end
+
   context '#create' do
     let(:stock_location) { create(:stock_location) }
 

--- a/core/app/models/spree/return_item.rb
+++ b/core/app/models/spree/return_item.rb
@@ -161,10 +161,11 @@ module Spree
     end
 
     # @note This uses the exchange_variant_engine configured on the class.
+    # @param stock_locations [Array<Spree::StockLocation>] the stock locations to check
     # @return [ActiveRecord::Relation<Spree::Variant>] the variants eligible
     #   for exchange for this return item
-    def eligible_exchange_variants
-      exchange_variant_engine.eligible_variants(variant)
+    def eligible_exchange_variants(stock_locations = nil)
+      exchange_variant_engine.eligible_variants(variant, stock_locations)
     end
 
     # Builds the exchange inventory unit for this return item, only if an

--- a/core/app/models/spree/return_item.rb
+++ b/core/app/models/spree/return_item.rb
@@ -165,7 +165,7 @@ module Spree
     # @return [ActiveRecord::Relation<Spree::Variant>] the variants eligible
     #   for exchange for this return item
     def eligible_exchange_variants(stock_locations = nil)
-      exchange_variant_engine.eligible_variants(variant, stock_locations)
+      exchange_variant_engine.eligible_variants(variant, stock_locations: stock_locations)
     end
 
     # Builds the exchange inventory unit for this return item, only if an

--- a/core/app/models/spree/return_item/exchange_variant_eligibility/same_option_value.rb
+++ b/core/app/models/spree/return_item/exchange_variant_eligibility/same_option_value.rb
@@ -19,8 +19,8 @@ module Spree
       # green pants with 32 waist and 30 inseam
       # blue pants with 34 waist and 32 inseam
 
-      def self.eligible_variants(variant)
-        product_variants = SameProduct.eligible_variants(variant).includes(option_values: :option_type)
+      def self.eligible_variants(variant, stock_locations = nil)
+        product_variants = SameProduct.eligible_variants(variant, stock_locations).includes(option_values: :option_type)
 
         relevant_option_values = variant.option_values.select { |ov| option_type_restrictions.include? ov.option_type.name }
         if relevant_option_values.present?

--- a/core/app/models/spree/return_item/exchange_variant_eligibility/same_option_value.rb
+++ b/core/app/models/spree/return_item/exchange_variant_eligibility/same_option_value.rb
@@ -19,8 +19,8 @@ module Spree
       # green pants with 32 waist and 30 inseam
       # blue pants with 34 waist and 32 inseam
 
-      def self.eligible_variants(variant, stock_locations = nil)
-        product_variants = SameProduct.eligible_variants(variant, stock_locations).includes(option_values: :option_type)
+      def self.eligible_variants(variant, options = {})
+        product_variants = SameProduct.eligible_variants(variant, options).includes(option_values: :option_type)
 
         relevant_option_values = variant.option_values.select { |ov| option_type_restrictions.include? ov.option_type.name }
         if relevant_option_values.present?

--- a/core/app/models/spree/return_item/exchange_variant_eligibility/same_product.rb
+++ b/core/app/models/spree/return_item/exchange_variant_eligibility/same_product.rb
@@ -1,7 +1,7 @@
 module Spree
   module ReturnItem::ExchangeVariantEligibility
     class SameProduct
-      def self.eligible_variants(variant, stock_locations = nil)
+      def self.eligible_variants(variant, stock_locations: nil)
         Spree::Variant.where(product_id: variant.product_id, is_master: variant.is_master?).in_stock(stock_locations)
       end
     end

--- a/core/app/models/spree/return_item/exchange_variant_eligibility/same_product.rb
+++ b/core/app/models/spree/return_item/exchange_variant_eligibility/same_product.rb
@@ -1,8 +1,8 @@
 module Spree
   module ReturnItem::ExchangeVariantEligibility
     class SameProduct
-      def self.eligible_variants(variant)
-        Spree::Variant.where(product_id: variant.product_id, is_master: variant.is_master?).in_stock
+      def self.eligible_variants(variant, stock_locations = nil)
+        Spree::Variant.where(product_id: variant.product_id, is_master: variant.is_master?).in_stock(stock_locations)
       end
     end
   end

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -71,9 +71,9 @@ module Spree
     # @param stock_locations [Array<Spree::StockLocation>] the stock locations to check
     # @return [ActiveRecord::Relation]
     def self.in_stock(stock_locations = nil)
-      in_stock_variants = joins(:stock_items).where('count_on_hand > ? OR track_inventory = ?', 0, false)
+      in_stock_variants = joins(:stock_items).where(Spree::StockItem.arel_table[:count_on_hand].gt(0).or(arel_table[:track_inventory].eq(false)))
       if stock_locations.present?
-        in_stock_variants = in_stock_variants.where('spree_stock_items.stock_location_id IN (?)', stock_locations.map(&:id))
+        in_stock_variants = in_stock_variants.where(Spree::StockItem.arel_table[:stock_location_id].in(stock_locations.map(&:id)))
       end
       in_stock_variants
     end

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -64,7 +64,19 @@ module Spree
 
     after_touch :clear_in_stock_cache
 
-    scope :in_stock, -> { joins(:stock_items).where('count_on_hand > ? OR track_inventory = ?', 0, false) }
+    # Returns variants that are in stock. When stock locations are provided as
+    # a parameter, the scope is limited to variants that are in stock in the
+    # provided stock locations.
+    #
+    # @param stock_locations [Array<Spree::StockLocation>] the stock locations to check
+    # @return [ActiveRecord::Relation]
+    def self.in_stock(stock_locations = nil)
+      in_stock_variants = joins(:stock_items).where('count_on_hand > ? OR track_inventory = ?', 0, false)
+      if stock_locations.present?
+        in_stock_variants = in_stock_variants.where('spree_stock_items.stock_location_id IN (?)', stock_locations.map(&:id))
+      end
+      in_stock_variants
+    end
 
     # Returns variants that are not deleted and have a price in the given
     # currency.

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -73,7 +73,7 @@ module Spree
     def self.in_stock(stock_locations = nil)
       in_stock_variants = joins(:stock_items).where(Spree::StockItem.arel_table[:count_on_hand].gt(0).or(arel_table[:track_inventory].eq(false)))
       if stock_locations.present?
-        in_stock_variants = in_stock_variants.where(Spree::StockItem.arel_table[:stock_location_id].in(stock_locations.map(&:id)))
+        in_stock_variants = in_stock_variants.where(spree_stock_items: { stock_location_id: stock_locations.map(&:id) })
       end
       in_stock_variants
     end

--- a/core/spec/models/spree/return_item_spec.rb
+++ b/core/spec/models/spree/return_item_spec.rb
@@ -548,7 +548,7 @@ describe Spree::ReturnItem, :type => :model do
   describe "#eligible_exchange_variants" do
     it "uses the exchange variant calculator to compute possible variants to exchange for" do
       return_item = build(:return_item)
-      expect(Spree::ReturnItem.exchange_variant_engine).to receive(:eligible_variants).with(return_item.variant)
+      expect(Spree::ReturnItem.exchange_variant_engine).to receive(:eligible_variants).with(return_item.variant, nil)
       return_item.eligible_exchange_variants
     end
   end

--- a/core/spec/models/spree/return_item_spec.rb
+++ b/core/spec/models/spree/return_item_spec.rb
@@ -548,7 +548,7 @@ describe Spree::ReturnItem, :type => :model do
   describe "#eligible_exchange_variants" do
     it "uses the exchange variant calculator to compute possible variants to exchange for" do
       return_item = build(:return_item)
-      expect(Spree::ReturnItem.exchange_variant_engine).to receive(:eligible_variants).with(return_item.variant, nil)
+      expect(Spree::ReturnItem.exchange_variant_engine).to receive(:eligible_variants).with(return_item.variant, stock_locations: nil)
       return_item.eligible_exchange_variants
     end
   end


### PR DESCRIPTION
Currently, when creating an exchange, a variant will be displayed as
an eligible exchange variant if there is stock for that variant in
any stock location. This can lead to errors when creating the return
shipment if there isn't any stock in the active stock locations.

This changes adds an optional parameter to the in_stock scope that
determines whether a variant is in stock for the given stock locations.
It also changes the UI for return authorizations and reimbursements to
only display the eligible exchange variants that have stock in active
stock locations.