### PR TITLE
Add capybara-screenshot

### DIFF
--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -43,6 +43,9 @@ require 'spree/testing_support/capybara_ext'
 
 require 'paperclip/matchers'
 
+require 'capybara-screenshot/rspec'
+Capybara.save_and_open_page_path = ENV['CIRCLE_ARTIFACTS'] if ENV['CIRCLE_ARTIFACTS']
+
 require 'capybara/poltergeist'
 Capybara.javascript_driver = :poltergeist
 

--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -20,6 +20,7 @@ gem 'sass-rails'
 
 group :test do
   gem 'capybara', '~> 2.4'
+  gem 'capybara-screenshot'
   gem 'database_cleaner', '~> 1.3'
   gem 'email_spec'
   gem 'factory_girl_rails', '~> 4.5.0'

--- a/frontend/spec/spec_helper.rb
+++ b/frontend/spec/spec_helper.rb
@@ -47,6 +47,9 @@ require 'spree/testing_support/caching'
 
 require 'paperclip/matchers'
 
+require 'capybara-screenshot/rspec'
+Capybara.save_and_open_page_path = ENV['CIRCLE_ARTIFACTS'] if ENV['CIRCLE_ARTIFACTS']
+
 if ENV['WEBDRIVER'] == 'accessible'
   require 'capybara/accessible'
   Capybara.javascript_driver = :accessible


### PR DESCRIPTION
https://github.com/mattheworiordan/capybara-screenshot

This gem takes a screenshot of the page on every test failure. Should make it a little nicer to write and debug feature specs.

I've also configured the spec helpers to put the output in CircleCI's artifacts folder, so we can get these from CI.