### PR TITLE
Remove simple_scopes from Product

### DIFF
--- a/core/app/models/spree/product/scopes.rb
+++ b/core/app/models/spree/product/scopes.rb
@@ -9,24 +9,6 @@ module Spree
       search_scopes << name.to_sym
     end
 
-    def self.simple_scopes
-      [
-        :ascend_by_updated_at,
-        :descend_by_updated_at,
-        :ascend_by_name,
-        :descend_by_name
-      ]
-    end
-
-    def self.add_simple_scopes(scopes)
-      scopes.each do |name|
-        # We should not define price scopes here, as they require something slightly different
-        next if name.to_s.include?("master_price")
-        parts = name.to_s.match(/(.*)_by_(.*)/)
-        self.scope(name.to_s, -> { order("#{Product.quoted_table_name}.#{parts[2]} #{parts[1] == 'ascend' ?  "ASC" : "DESC"}") })
-      end
-    end
-
     def self.property_conditions(property)
       properties = Property.table_name
       conditions = case property
@@ -36,7 +18,10 @@ module Spree
       end
     end
 
-    add_simple_scopes simple_scopes
+    scope :ascend_by_updated_at, -> { order(updated_at: :asc) }
+    scope :descend_by_updated_at, -> { order(updated_at: :desc) }
+    scope :ascend_by_name, -> { order(name: :asc) }
+    scope :descend_by_name, -> { order(name: :desc) }
 
     add_search_scope :ascend_by_master_price do
       joins(:master => :default_price).order("#{price_table_name}.amount ASC")

--- a/core/spec/models/spree/product/scopes_spec.rb
+++ b/core/spec/models/spree/product/scopes_spec.rb
@@ -113,36 +113,4 @@ describe "Product scopes", :type => :model do
       end
     end
   end
-
-  context '#add_simple_scopes' do
-    let(:simple_scopes) { [:ascend_by_updated_at, :descend_by_name] }
-
-    before do
-      Spree::Product.add_simple_scopes(simple_scopes)
-    end
-
-    context 'define scope' do
-      context 'ascend_by_updated_at' do
-        context 'on class' do
-          it { expect(Spree::Product.ascend_by_updated_at.to_sql).to eq Spree::Product.order("#{Spree::Product.quoted_table_name}.updated_at ASC").to_sql }
-        end
-
-        context 'on ActiveRecord::Relation' do
-          it { expect(Spree::Product.limit(2).ascend_by_updated_at.to_sql).to eq Spree::Product.limit(2).order("#{Spree::Product.quoted_table_name}.updated_at ASC").to_sql }
-          it { expect(Spree::Product.limit(2).ascend_by_updated_at.to_sql).to eq Spree::Product.ascend_by_updated_at.limit(2).to_sql }
-        end
-      end
-
-      context 'descend_by_name' do
-        context 'on class' do
-          it { expect(Spree::Product.descend_by_name.to_sql).to eq Spree::Product.order("#{Spree::Product.quoted_table_name}.name DESC").to_sql }
-        end
-
-        context 'on ActiveRecord::Relation' do
-          it { expect(Spree::Product.limit(2).descend_by_name.to_sql).to eq Spree::Product.limit(2).order("#{Spree::Product.quoted_table_name}.name DESC").to_sql }
-          it { expect(Spree::Product.limit(2).descend_by_name.to_sql).to eq Spree::Product.descend_by_name.limit(2).to_sql }
-        end
-      end
-    end
-  end
 end


### PR DESCRIPTION
It was impossible to override self.simple_scopes in a useful way. Even if it was overridden, add_simple_scopes was only called when loading the scopes file.

It is far simpler to define these manually, there is absolutely no reason to parse method names to achieve this.