### PR TITLE
Use OrderContents#update_cart in Api::PaymentsController#create

### DIFF
--- a/api/app/controllers/spree/api/payments_controller.rb
+++ b/api/app/controllers/spree/api/payments_controller.rb
@@ -17,8 +17,10 @@ module Spree
       end
 
       def create
-        @payment = @order.payments.build(payment_params)
-        if @payment.save
+        success = @order.contents.update_cart(payments_attributes: [payment_params])
+        @payment = @order.payments.last
+
+        if success
           respond_with(@payment, status: 201, default_template: :show)
         else
           invalid_resource!(@payment)


### PR DESCRIPTION
First step in getting all payment creation code going through a common
path.

@jhawthorn @cbrunsdon @gmacdougall @athal7 @magnusvk here's a first step in the direction we talked about this afternoon. I haven't started making a `CartUpdate` class or anything yet but I'm trying to tackle this incrementally and I think this change can stand on its own, but definitely open to any thoughts.