### PR TITLE
Allow users with order management to cancel inventory.

### DIFF
--- a/backend/app/controllers/spree/admin/cancellations_controller.rb
+++ b/backend/app/controllers/spree/admin/cancellations_controller.rb
@@ -35,6 +35,10 @@ module Spree
         @order = Order.find_by_number!(params[:order_id])
         authorize! action, @order
       end
+
+      def model_class
+        Spree::OrderCancellations
+      end
     end
   end
 end

--- a/backend/app/views/spree/admin/shared/_order_submenu.html.erb
+++ b/backend/app/views/spree/admin/shared/_order_submenu.html.erb
@@ -54,7 +54,7 @@
       <% end %>
     <% end %>
 
-    <% if can?(:short_ship, @order) && @order.inventory_units.cancelable.present? %>
+    <% if can?(:manage, Spree::OrderCancellations) && @order.inventory_units.cancelable.present? %>
       <%= content_tag('li', :class => ('active' if current == 'Cancel Inventory'), :data => {:hook => 'admin_order_tabs_cancel_inventory'}) do %>
         <%= link_to_with_icon 'cancel', Spree.t(:cancel_inventory), admin_order_cancellations_path(@order) %>
       <% end %>

--- a/core/app/models/spree/permission_sets/order_management.rb
+++ b/core/app/models/spree/permission_sets/order_management.rb
@@ -10,6 +10,7 @@ module Spree
         can :manage, Spree::LineItem
         can :manage, Spree::ReturnAuthorization
         can :manage, Spree::CustomerReturn
+        can :manage, Spree::OrderCancellations
       end
     end
   end

--- a/core/spec/models/spree/permission_sets/order_management_spec.rb
+++ b/core/spec/models/spree/permission_sets/order_management_spec.rb
@@ -18,6 +18,7 @@ describe Spree::PermissionSets::OrderManagement do
     it { is_expected.to be_able_to(:manage, Spree::ReturnAuthorization) }
     it { is_expected.to be_able_to(:manage, Spree::CustomerReturn) }
     it { is_expected.to be_able_to(:display, Spree::ReimbursementType) }
+    it { is_expected.to be_able_to(:manage, Spree::OrderCancellations) }
   end
 
   context "when not activated" do
@@ -29,6 +30,7 @@ describe Spree::PermissionSets::OrderManagement do
     it { is_expected.not_to be_able_to(:manage, Spree::ReturnAuthorization) }
     it { is_expected.not_to be_able_to(:manage, Spree::CustomerReturn) }
     it { is_expected.not_to be_able_to(:display, Spree::ReimbursementType) }
+    it { is_expected.not_to be_able_to(:manage, Spree::OrderCancellations) }
   end
 end
 


### PR DESCRIPTION
This was missed, as it was added to the project instead of Solidus which
was pointed out recently. cc @athal7 