### PR TITLE
Remove has available shipment

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -93,7 +93,6 @@ module Spree
     validates :email, presence: true, if: :require_email
     validates :email, email: true, if: :require_email, allow_blank: true
     validates :number, presence: true, uniqueness: { allow_blank: true }
-    validate :has_available_shipment
 
     make_permalink field: :number
 
@@ -756,13 +755,6 @@ module Spree
       unless line_items.present?
         errors.add(:base, Spree.t(:there_are_no_items_for_this_order)) and return false
       end
-    end
-
-    def has_available_shipment
-      return unless has_step?("delivery")
-      return unless has_step?(:address) && address?
-      return unless ship_address && ship_address.valid?
-      # errors.add(:base, :no_shipping_methods_available) if available_shipping_methods.empty?
     end
 
     def ensure_available_shipping_rates

--- a/core/spec/models/spree/order/adjustments_spec.rb
+++ b/core/spec/models/spree/order/adjustments_spec.rb
@@ -22,8 +22,6 @@ describe Spree::Order, :type => :model do
     end
 
     before do
-      # Don't care about available payment methods in this test
-      allow(persisted_order).to receive_messages(:has_available_payment => false)
       persisted_order.line_items << line_item
       create(:adjustment, amount: -line_item.amount, label: "Promotion", adjustable: line_item, order: persisted_order)
       persisted_order.state = 'delivery'

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -166,7 +166,6 @@ describe Spree::Order, :type => :model do
       before do
         order.state = 'address'
         order.ship_address = ship_address
-        allow(order).to receive(:has_available_payment)
         shipment = FactoryGirl.create(:shipment, :order => order, :cost => 10)
         order.email = "user@example.com"
         order.save!
@@ -256,7 +255,6 @@ describe Spree::Order, :type => :model do
           order.email = "user@example.com"
           order.save!
 
-          allow(order).to receive(:has_available_payment)
           allow(order).to receive(:create_proposed_shipments)
           allow(order).to receive(:ensure_available_shipping_rates) { true }
         end

--- a/core/spec/models/spree/order/finalizing_spec.rb
+++ b/core/spec/models/spree/order/finalizing_spec.rb
@@ -70,7 +70,6 @@ describe Spree::Order, :type => :model do
     it "should freeze all adjustments" do
       # Stub this method as it's called due to a callback
       # and it's irrelevant to this test
-      allow(order).to receive :has_available_shipment
       allow(Spree::OrderMailer).to receive_message_chain :confirm_email, :deliver_later
       adjustments = [double]
       expect(order).to receive(:all_adjustments).and_return(adjustments)

--- a/core/spec/models/spree/order/state_machine_spec.rb
+++ b/core/spec/models/spree/order/state_machine_spec.rb
@@ -17,7 +17,6 @@ describe Spree::Order, :type => :model do
         allow(order).to receive_messages :payment_required? => true
         allow(order).to receive_messages :process_payments! => true
         allow(order).to receive_messages :ensure_available_shipping_rates => true
-        allow(order).to receive :has_available_shipment
       end
 
       context "when payment processing succeeds" do
@@ -132,7 +131,6 @@ describe Spree::Order, :type => :model do
 
       # Stub methods that cause side-effects in this test
       allow(shipment).to receive(:cancel!)
-      allow(order).to receive :has_available_shipment
       allow(order).to receive :restock_items!
       mail_message = double "Mail::Message"
       order_id = nil
@@ -152,7 +150,6 @@ describe Spree::Order, :type => :model do
         allow(Spree::OrderMailer).to receive(:cancel_email).and_return(mail_message = double)
         allow(mail_message).to receive :deliver_later
 
-        allow(order).to receive :has_available_shipment
       end
     end
 
@@ -165,7 +162,6 @@ describe Spree::Order, :type => :model do
         # Stubs methods that cause unwanted side effects in this test
         allow(Spree::OrderMailer).to receive(:cancel_email).and_return(mail_message = double)
         allow(mail_message).to receive :deliver_later
-        allow(order).to receive :has_available_shipment
         allow(order).to receive :restock_items!
         allow(shipment).to receive(:cancel!)
         allow(payment).to receive(:cancel!)
@@ -214,9 +210,6 @@ describe Spree::Order, :type => :model do
       allow(order).to receive_messages email: "user@spreecommerce.com"
       allow(order).to receive_messages state: "canceled"
       allow(order).to receive_messages allow_resume?: true
-
-      # Stubs method that cause unwanted side effects in this test
-      allow(order).to receive :has_available_shipment
     end
   end
 end


### PR DESCRIPTION
This method does nothing and always returns nil.

Also removes some references to has_available_payment, which doesn't exist but was being stubbed.