### PR TITLE
Add missing null: false on user addresses

### DIFF
--- a/core/db/migrate/20150731201146_add_spree_user_addresses.rb
+++ b/core/db/migrate/20150731201146_add_spree_user_addresses.rb
@@ -5,7 +5,7 @@ class AddSpreeUserAddresses < ActiveRecord::Migration
       t.integer :address_id, null: false
       t.boolean :default, default: false
       t.boolean :archived, default: false
-      t.timestamps
+      t.timestamps null: false
     end
 
     add_index :spree_user_addresses, :user_id


### PR DESCRIPTION
Without this we get a warning in migrations

> DEPRECATION WARNING: `#timestamps` was called without specifying an option for `null`. In Rails 5, this behavior will change to `null: false`. You should manually specify `null: true` to prevent the behavior of your existing migrations from changing. (called from block in change at /home/jhawthorn/src/solidus/core/spec/dummy/db/migrate/20150819221398_add_spree_user_addresses.spree.rb:9)