### PR TITLE
Tweak for "Remove extraneous code"

### DIFF
--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -173,7 +173,7 @@ module Spree
             created_by_id: try_spree_current_user.try(:id),
             frontend_viewable: false,
             store_id: current_store.try(:id)
-          }
+          }.with_indifferent_access
         end
 
         def load_order


### PR DESCRIPTION
Tweak for prior commit 1f63270f479d13e0ebfc024531bf8772df2b5af2
A spec in our code made me realize that is a difference between the
old and new code.  I don't think it will change anything but it
seems good to be safe.

Note:  We could also use `ActionController::Parameters` here though
that seems a bit weird since they *aren't* actioncontroller parameters,
but lmk if people think differently.