### PR TITLE
Add in_transit return item reception status transition

### DIFF
--- a/core/app/models/spree/return_item.rb
+++ b/core/app/models/spree/return_item.rb
@@ -89,6 +89,7 @@ module Spree
       event(:lost) { transition to: :lost_in_transit, from: :awaiting }
       event(:wrong_item_shipped) { transition to: :shipped_wrong_item, from: :awaiting }
       event(:short_shipped) { transition to: :short_shipped, from: :awaiting }
+      event(:in_transit) { transition to: :in_transit, from: :awaiting }
       event(:expired) { transition to: :expired, from: :awaiting }
     end
 

--- a/core/spec/models/spree/return_item_spec.rb
+++ b/core/spec/models/spree/return_item_spec.rb
@@ -274,6 +274,7 @@ describe Spree::ReturnItem, :type => :model do
     give: 'given_to_customer',
     lost: 'lost_in_transit',
     wrong_item_shipped: 'shipped_wrong_item',
+    in_transit: 'in_transit',
     short_shipped: 'short_shipped'
   }.each do |transition, status|
     describe "##{transition}" do


### PR DESCRIPTION
We already had in_transit in the INTERMEDIATE_RECEPTION_STATUSES constant but didn’t have the event for it. This was causing “In transit” to not be available as a reception status in the admin when creating a customer return.