### PR TITLE
Add StorePaymentMethods

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -405,7 +405,10 @@ module Spree
     end
 
     def available_payment_methods
-      @available_payment_methods ||= (PaymentMethod.available(:front_end) + PaymentMethod.available(:both)).uniq
+      @available_payment_methods ||= (
+        PaymentMethod.available(:front_end, store: store) +
+        PaymentMethod.available(:both, store: store)
+      ).uniq
     end
 
     def billing_firstname

--- a/core/app/models/spree/payment_method.rb
+++ b/core/app/models/spree/payment_method.rb
@@ -8,6 +8,8 @@ module Spree
 
     has_many :payments, class_name: "Spree::Payment", inverse_of: :payment_method
     has_many :credit_cards, class_name: "Spree::CreditCard"
+    has_many :store_payment_methods, inverse_of: :payment_method
+    has_many :payment_methods, through: :store_payment_methods
 
     include Spree::Preferences::StaticallyConfigurable
 
@@ -26,10 +28,11 @@ module Spree
       raise ::NotImplementedError, "You must implement payment_source_class method for #{self.class}."
     end
 
-    def self.available(display_on = 'both')
+    def self.available(display_on = 'both', store: nil)
       all.select do |p|
         p.active &&
-        (p.display_on == display_on.to_s || p.display_on.blank?)
+        (p.display_on == display_on.to_s || p.display_on.blank?) &&
+        (store.nil? || store.payment_methods.empty? || store.payment_methods.include?(p))
       end
     end
 

--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -1,5 +1,8 @@
 module Spree
   class Store < Spree::Base
+    has_many :store_payment_methods, inverse_of: :store
+    has_many :payment_methods, through: :store_payment_methods
+
     validates :code, presence: true, uniqueness: { allow_blank: true }
     validates :name, presence: true
     validates :url, presence: true

--- a/core/app/models/spree/store_payment_method.rb
+++ b/core/app/models/spree/store_payment_method.rb
@@ -1,0 +1,6 @@
+module Spree
+  class StorePaymentMethod < ActiveRecord::Base
+    belongs_to :store, inverse_of: :store_payment_methods
+    belongs_to :payment_method, inverse_of: :store_payment_methods
+  end
+end

--- a/core/db/migrate/20150820160821_add_store_payment_methods.rb
+++ b/core/db/migrate/20150820160821_add_store_payment_methods.rb
@@ -1,0 +1,10 @@
+class AddStorePaymentMethods < ActiveRecord::Migration
+  def change
+    create_table :spree_store_payment_methods do |t|
+      t.references :store, null: false, index: true
+      t.references :payment_method, null: false, index: true
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/core/lib/spree/testing_support/factories/payment_method_factory.rb
+++ b/core/lib/spree/testing_support/factories/payment_method_factory.rb
@@ -1,10 +1,10 @@
 FactoryGirl.define do
-  factory :check_payment_method, class: Spree::PaymentMethod::Check do
-    name 'Check'
+  factory :payment_method, aliases: [:credit_card_payment_method], class: Spree::Gateway::Bogus do
+    name 'Credit Card'
   end
 
-  factory :credit_card_payment_method, class: Spree::Gateway::Bogus do
-    name 'Credit Card'
+  factory :check_payment_method, class: Spree::PaymentMethod::Check do
+    name 'Check'
   end
 
   # authorize.net was moved to spree_gateway.

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -539,6 +539,39 @@ describe Spree::Order, :type => :model do
       expect(order.available_payment_methods.count).to eq(1)
       expect(order.available_payment_methods).to include(payment_method)
     end
+
+    context 'when the order has a store' do
+      let(:order) { create(:order) }
+
+      let!(:store_with_payment_methods) do
+        create(:store,
+          payment_methods: [payment_method_with_store],
+        )
+      end
+      let!(:payment_method_with_store) { create(:payment_method) }
+      let!(:store_without_payment_methods) { create(:store) }
+      let!(:payment_method_without_store) { create(:payment_method) }
+
+      context 'when the store has payment methods' do
+        before { order.update_attributes!(store: store_with_payment_methods) }
+
+        it 'returns only the matching payment methods for that store' do
+          expect(order.available_payment_methods).to match_array(
+            [payment_method_with_store]
+          )
+        end
+      end
+
+      context 'when the store does not have payment methods' do
+        before { order.update_attributes!(store: store_without_payment_methods) }
+
+        it 'returns all matching payment methods regardless of store' do
+          expect(order.available_payment_methods).to match_array(
+            [payment_method_with_store, payment_method_without_store]
+          )
+        end
+      end
+    end
   end
 
   context "#apply_free_shipping_promotions" do


### PR DESCRIPTION
So that stores can be configured to have specific payment methods.

This is extracted from solidus_multi_domain.