### PR TITLE
Change to CartonMailer.shipped_email(order, carton)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@
 *   Removed `map_nested_attributes_keys` from the Api::BaseController. This
     method was only used in one place and was oblivious of strong_params.
 
+*   Change all mails deliveries to `#deliver_later`. Emails will now be sent in
+    the background if you configure active\_job to do so. See [the rails guides](http://guides.rubyonrails.org/active_job_basics.html#job-execution)
+    for more information.
+
+*   Cartons deliveries now send one email per-order, instead of one per-carton.
+    This allows setting `@order` and `@store` correctly for the template. For
+    most stores, which don't combine multiple orders into a carton, this will
+    behave the same.
+
 ## Solidus 1.0.1 (2015-08-19)
 
 See https://github.com/solidusio/solidus/releases/tag/v1.0.1

--- a/core/app/mailers/spree/carton_mailer.rb
+++ b/core/app/mailers/spree/carton_mailer.rb
@@ -8,8 +8,10 @@ module Spree
         ActiveSupport::Deprecation.warn "Calling shipped_email with a carton_id is DEPRECATED. Instead use CartonMailer.shipped_email(order, carton)"
         @carton = Carton.find(args[0])
         @order = @carton.orders.first # assume first order
+        @manifest = @carton.manifest # use the entire manifest, since we don't know the precise order
       else
         @order, @carton = args
+        @manifest = @carton.manifest_for_order(@order)
       end
       @store = @order.store
       subject = (options[:resend] ? "[#{Spree.t(:resend).upcase}] " : '')

--- a/core/app/mailers/spree/carton_mailer.rb
+++ b/core/app/mailers/spree/carton_mailer.rb
@@ -2,11 +2,17 @@ module Spree
   class CartonMailer < BaseMailer
     # Send an email to customers to notify that an individual carton has been
     # shipped.
-    def shipped_email(order, carton, resend: false)
-      @order = order
-      @store = order.store
-      @carton = carton
-      subject = (resend ? "[#{Spree.t(:resend).upcase}] " : '')
+    def shipped_email(*args)
+      options = {resend: false}.merge(args.extract_options!)
+      if args.length == 1
+        ActiveSupport::Deprecation.warn "Calling shipped_email with a carton_id is DEPRECATED. Instead use CartonMailer.shipped_email(order, carton)"
+        @carton = Carton.find(args[0])
+        @order = @carton.orders.first # assume first order
+      else
+        @order, @carton = args
+      end
+      @store = @order.store
+      subject = (options[:resend] ? "[#{Spree.t(:resend).upcase}] " : '')
       subject += "#{@store.name} #{Spree.t('shipment_mailer.shipped_email.subject')} ##{@order.number}"
       mail(to: @order.email, from: from_address(@store), subject: subject)
     end

--- a/core/app/mailers/spree/carton_mailer.rb
+++ b/core/app/mailers/spree/carton_mailer.rb
@@ -2,17 +2,19 @@ module Spree
   class CartonMailer < BaseMailer
     # Send an email to customers to notify that an individual carton has been
     # shipped.
-    def shipped_email(*args)
-      options = {resend: false}.merge(args.extract_options!)
-      if args.length == 1
-        ActiveSupport::Deprecation.warn "Calling shipped_email with a carton_id is DEPRECATED. Instead use CartonMailer.shipped_email(order, carton)"
-        @carton = Carton.find(args[0])
+    def shipped_email(options, deprecated_options={})
+      if options.is_a?(Integer)
+        ActiveSupport::Deprecation.warn "Calling shipped_email with a carton_id is DEPRECATED. Instead use CartonMailer.shipped_email(order: order, carton: carton)"
+        @carton = Carton.find(options)
         @order = @carton.orders.first # assume first order
         @manifest = @carton.manifest # use the entire manifest, since we don't know the precise order
+        options = deprecated_options
       else
-        @order, @carton = args
+        @order = options.fetch(:order)
+        @carton = options.fetch(:carton)
         @manifest = @carton.manifest_for_order(@order)
       end
+      options =  {resend: false}.merge(options)
       @store = @order.store
       subject = (options[:resend] ? "[#{Spree.t(:resend).upcase}] " : '')
       subject += "#{@store.name} #{Spree.t('shipment_mailer.shipped_email.subject')} ##{@order.number}"

--- a/core/app/mailers/spree/carton_mailer.rb
+++ b/core/app/mailers/spree/carton_mailer.rb
@@ -2,11 +2,13 @@ module Spree
   class CartonMailer < BaseMailer
     # Send an email to customers to notify that an individual carton has been
     # shipped.
-    def shipped_email(carton_id, resend: false)
-      @carton = Spree::Carton.find(carton_id)
+    def shipped_email(order, carton, resend: false)
+      @order = order
+      @store = order.store
+      @carton = carton
       subject = (resend ? "[#{Spree.t(:resend).upcase}] " : '')
-      subject += "#{Spree::Store.current.name} #{Spree.t('shipment_mailer.shipped_email.subject')} ##{@carton.order_numbers.join(', ')}"
-      mail(to: @carton.order_emails, from: from_address(Spree::Store.current), subject: subject)
+      subject += "#{@store.name} #{Spree.t('shipment_mailer.shipped_email.subject')} ##{@order.number}"
+      mail(to: @order.email, from: from_address(@store), subject: subject)
     end
   end
 end

--- a/core/app/mailers/spree/order_mailer.rb
+++ b/core/app/mailers/spree/order_mailer.rb
@@ -2,29 +2,37 @@ module Spree
   class OrderMailer < BaseMailer
     def confirm_email(order, resend = false)
       @order = find_order(order)
+      @store = @order.store
       subject = build_subject(Spree.t('order_mailer.confirm_email.subject'), resend)
 
-      mail(to: @order.email, from: from_address(@order.store), subject: subject)
+      mail(to: @order.email, from: from_address(@store), subject: subject)
     end
 
     def cancel_email(order, resend = false)
       @order = find_order(order)
+      @store = @order.store
       subject = build_subject(Spree.t('order_mailer.cancel_email.subject'), resend)
 
-      mail(to: @order.email, from: from_address(@order.store), subject: subject)
+      mail(to: @order.email, from: from_address(@store), subject: subject)
     end
 
     def inventory_cancellation_email(order, inventory_units, resend = false)
       @order, @inventory_units = find_order(order), inventory_units
+      @store = @order.store
       subject = build_subject(Spree.t('order_mailer.inventory_cancellation.subject'), resend)
 
-      mail(to: @order.email, from: from_address(@order.store), subject: subject)
+      mail(to: @order.email, from: from_address(@store), subject: subject)
     end
 
     private
 
     def find_order(order)
-      @order = order.respond_to?(:id) ? order : Spree::Order.find(order)
+      if order.respond_to?(:id)
+        order
+      else
+        ActiveSupport::Deprecation.warn("Calling OrderMailer with an id is deprecated. Pass the Spree::Order object instead.")
+        Spree::Order.find(order)
+      end
     end
 
     def build_subject(subject_text, resend)

--- a/core/app/models/spree/carton.rb
+++ b/core/app/models/spree/carton.rb
@@ -48,7 +48,7 @@ class Spree::Carton < Spree::Base
   end
 
   def manifest_for_order(order)
-    Spree::ShippingManifest.new(inventory_units: (inventory_units & order.inventory_units)).items
+    Spree::ShippingManifest.new(inventory_units: inventory_units).for_order(order).items
   end
 
   def any_exchanges?

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -394,7 +394,7 @@ module Spree
     end
 
     def deliver_order_confirmation_email
-      OrderMailer.confirm_email(self.id).deliver_later
+      OrderMailer.confirm_email(self).deliver_later
       update_column(:confirmation_delivered, true)
     end
 
@@ -768,7 +768,7 @@ module Spree
     end
 
     def send_cancel_email
-      OrderMailer.cancel_email(self.id).deliver_later
+      OrderMailer.cancel_email(self).deliver_later
     end
 
     def after_resume

--- a/core/app/models/spree/order_shipping.rb
+++ b/core/app/models/spree/order_shipping.rb
@@ -86,6 +86,8 @@ class Spree::OrderShipping
   end
 
   def send_shipment_email(carton)
-    Spree::CartonMailer.shipped_email(carton.id).deliver_later
+    carton.orders.each do |order|
+      Spree::CartonMailer.shipped_email(order, carton).deliver_later
+    end
   end
 end

--- a/core/app/models/spree/order_shipping.rb
+++ b/core/app/models/spree/order_shipping.rb
@@ -87,7 +87,7 @@ class Spree::OrderShipping
 
   def send_shipment_emails(carton)
     carton.orders.each do |order|
-      Spree::CartonMailer.shipped_email(order, carton).deliver_later
+      Spree::CartonMailer.shipped_email(order: order, carton: carton).deliver_later
     end
   end
 end

--- a/core/app/models/spree/order_shipping.rb
+++ b/core/app/models/spree/order_shipping.rb
@@ -72,7 +72,7 @@ class Spree::OrderShipping
       end
     end
 
-    send_shipment_email(carton) if stock_location.fulfillable? && !suppress_mailer # e.g. digital gift cards that aren't actually shipped
+    send_shipment_emails(carton) if stock_location.fulfillable? && !suppress_mailer # e.g. digital gift cards that aren't actually shipped
     fulfill_order_stock_locations(stock_location)
     @order.update!
 
@@ -85,7 +85,7 @@ class Spree::OrderShipping
     Spree::OrderStockLocation.fulfill_for_order_with_stock_location(@order, stock_location)
   end
 
-  def send_shipment_email(carton)
+  def send_shipment_emails(carton)
     carton.orders.each do |order|
       Spree::CartonMailer.shipped_email(order, carton).deliver_later
     end

--- a/core/app/models/spree/shipping_manifest.rb
+++ b/core/app/models/spree/shipping_manifest.rb
@@ -8,8 +8,8 @@ class Spree::ShippingManifest
   def items
     # Grouping by the ID means that we don't have to call out to the association accessor
     # This makes the grouping by faster because it results in less SQL cache hits.
-    @inventory_units.group_by(&:variant_id).map do |variant_id, units|
-      units.group_by(&:line_item_id).map do |line_item_id, units|
+    @inventory_units.group_by(&:variant_id).map do |variant_id, variant_units|
+      variant_units.group_by(&:line_item_id).map do |line_item_id, units|
 
         states = {}
         units.group_by(&:state).each { |state, iu| states[state] = iu.count }

--- a/core/app/models/spree/shipping_manifest.rb
+++ b/core/app/models/spree/shipping_manifest.rb
@@ -2,7 +2,13 @@ class Spree::ShippingManifest
   ManifestItem = Struct.new(:line_item, :variant, :quantity, :states)
 
   def initialize(inventory_units:)
-    @inventory_units = inventory_units
+    @inventory_units = inventory_units.to_a
+  end
+
+  def for_order(order)
+    Spree::ShippingManifest.new(
+      inventory_units: @inventory_units.select {|iu| iu.order_id == order.id }
+    )
   end
 
   def items

--- a/core/app/views/spree/carton_mailer/shipped_email.text.erb
+++ b/core/app/views/spree/carton_mailer/shipped_email.text.erb
@@ -5,7 +5,7 @@
 ============================================================
 <%= Spree.t('shipment_mailer.shipped_email.shipment_summary') %>
 ============================================================
-<% @carton.manifest.each do |item| %>
+<% @manifest.each do |item| %>
   <%= item.variant.sku %> <%= item.variant.product.name %> <%= item.variant.options_text %>
 <% end %>
 ============================================================

--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -92,3 +92,6 @@ require 'spree/core/controller_helpers/store'
 require 'spree/core/controller_helpers/strong_parameters'
 require 'spree/core/unreturned_item_charger'
 require 'spree/core/role_configuration'
+
+require 'spree/mailer_previews/order_preview'
+require 'spree/mailer_previews/carton_preview'

--- a/core/lib/spree/mailer_previews/carton_preview.rb
+++ b/core/lib/spree/mailer_previews/carton_preview.rb
@@ -3,7 +3,7 @@ module Spree
     class CartonPreview < ActionMailer::Preview
       def shipped
         carton = Carton.first
-        CartonMailer.shipped_email(carton.orders.first, carton)
+        CartonMailer.shipped_email(order: carton.orders.first, carton: carton)
       end
     end
   end

--- a/core/lib/spree/mailer_previews/carton_preview.rb
+++ b/core/lib/spree/mailer_previews/carton_preview.rb
@@ -1,0 +1,10 @@
+module Spree
+  class MailerPreviews
+    class CartonPreview < ActionMailer::Preview
+      def shipped
+        carton = Carton.first
+        CartonMailer.shipped_email(carton.orders.first, carton)
+      end
+    end
+  end
+end

--- a/core/lib/spree/mailer_previews/order_preview.rb
+++ b/core/lib/spree/mailer_previews/order_preview.rb
@@ -1,0 +1,18 @@
+module Spree
+  class MailerPreviews
+    class OrderPreview < ActionMailer::Preview
+      def confirm
+        OrderMailer.confirm_email(Order.first)
+      end
+
+      def cancel
+        OrderMailer.cancel_email(Order.first)
+      end
+
+      def inventory_cancellation
+        order = Order.first
+        OrderMailer.inventory_cancellation_email(order, [order.inventory_units.first])
+      end
+    end
+  end
+end

--- a/core/spec/mailers/carton_mailer_spec.rb
+++ b/core/spec/mailers/carton_mailer_spec.rb
@@ -10,7 +10,7 @@ describe Spree::CartonMailer do
 
   # Regression test for #2196
   it "doesn't include out of stock in the email body" do
-    shipment_email = Spree::CartonMailer.shipped_email(order, carton)
+    shipment_email = Spree::CartonMailer.shipped_email(order: order, carton: carton)
     expect(shipment_email.body).not_to include(%Q{Out of Stock})
     expect(shipment_email.body).to include(%Q{Your order has been shipped})
     expect(shipment_email.subject).to eq "#{order.store.name} Shipment Notification ##{order.number}"
@@ -27,7 +27,7 @@ describe Spree::CartonMailer do
 
   context "with resend option" do
     subject do
-      Spree::CartonMailer.shipped_email(order, carton, resend: true).subject
+      Spree::CartonMailer.shipped_email(order: order, carton: carton, resend: true).subject
     end
     it { is_expected.to match /^\[RESEND\] / }
   end
@@ -46,7 +46,7 @@ describe Spree::CartonMailer do
         end
 
         specify do
-          shipped_email = Spree::CartonMailer.shipped_email(order, carton)
+          shipped_email = Spree::CartonMailer.shipped_email(order: order, carton: carton)
           expect(shipped_email.body).to include("Caro Cliente,")
         end
       end

--- a/core/spec/mailers/carton_mailer_spec.rb
+++ b/core/spec/mailers/carton_mailer_spec.rb
@@ -6,16 +6,19 @@ describe Spree::CartonMailer do
   include EmailSpec::Matchers
 
   let(:carton) { create(:carton) }
+  let(:order) { carton.orders.first }
 
   # Regression test for #2196
   it "doesn't include out of stock in the email body" do
-    shipment_email = Spree::CartonMailer.shipped_email(carton.id)
+    shipment_email = Spree::CartonMailer.shipped_email(order, carton)
     expect(shipment_email.body).not_to include(%Q{Out of Stock})
+    expect(shipment_email.body).to include(%Q{Your order has been shipped})
+    expect(shipment_email.subject).to eq "#{order.store.name} Shipment Notification ##{order.number}"
   end
 
   context "with resend option" do
     subject do
-      Spree::CartonMailer.shipped_email(carton.id, resend: true).subject
+      Spree::CartonMailer.shipped_email(order, carton, resend: true).subject
     end
     it { is_expected.to match /^\[RESEND\] / }
   end
@@ -34,7 +37,7 @@ describe Spree::CartonMailer do
         end
 
         specify do
-          shipped_email = Spree::CartonMailer.shipped_email(carton.id)
+          shipped_email = Spree::CartonMailer.shipped_email(order, carton)
           expect(shipped_email.body).to include("Caro Cliente,")
         end
       end

--- a/core/spec/mailers/carton_mailer_spec.rb
+++ b/core/spec/mailers/carton_mailer_spec.rb
@@ -16,6 +16,15 @@ describe Spree::CartonMailer do
     expect(shipment_email.subject).to eq "#{order.store.name} Shipment Notification ##{order.number}"
   end
 
+  context "deprecated signature" do
+    it do
+      ActiveSupport::Deprecation.silence do
+        mail = Spree::CartonMailer.shipped_email(carton.id)
+        expect(mail.subject).to include "Shipment Notification"
+      end
+    end
+  end
+
   context "with resend option" do
     subject do
       Spree::CartonMailer.shipped_email(order, carton, resend: true).subject

--- a/core/spec/mailers/order_mailer_spec.rb
+++ b/core/spec/mailers/order_mailer_spec.rb
@@ -30,16 +30,16 @@ describe Spree::OrderMailer, :type => :mailer do
 
   it "confirm_email accepts an order id as an alternative to an Order object" do
     expect(Spree::Order).to receive(:find).with(order.id).and_return(order)
-    expect {
+    ActiveSupport::Deprecation.silence do
       Spree::OrderMailer.confirm_email(order.id).body
-    }.not_to raise_error
+    end
   end
 
   it "cancel_email accepts an order id as an alternative to an Order object" do
     expect(Spree::Order).to receive(:find).with(order.id).and_return(order)
-    expect {
+    ActiveSupport::Deprecation.silence do
       Spree::OrderMailer.cancel_email(order.id).body
-    }.not_to raise_error
+    end
   end
 
   context "only shows eligible adjustments in emails" do

--- a/core/spec/models/spree/order/finalizing_spec.rb
+++ b/core/spec/models/spree/order/finalizing_spec.rb
@@ -50,7 +50,7 @@ describe Spree::Order, :type => :model do
 
     it "should send an order confirmation email" do
       mail_message = double "Mail::Message"
-      expect(Spree::OrderMailer).to receive(:confirm_email).with(order.id).and_return mail_message
+      expect(Spree::OrderMailer).to receive(:confirm_email).with(order).and_return mail_message
       expect(mail_message).to receive :deliver_later
       order.finalize!
     end

--- a/core/spec/models/spree/order/state_machine_spec.rb
+++ b/core/spec/models/spree/order/state_machine_spec.rb
@@ -132,15 +132,9 @@ describe Spree::Order, :type => :model do
       # Stub methods that cause side-effects in this test
       allow(shipment).to receive(:cancel!)
       allow(order).to receive :restock_items!
-      mail_message = double "Mail::Message"
-      order_id = nil
-      expect(Spree::OrderMailer).to receive(:cancel_email) { |*args|
-        order_id = args[0]
-        mail_message
-      }
+      expect(Spree::OrderMailer).to receive(:cancel_email).with(order).and_return(mail_message = double)
       expect(mail_message).to receive :deliver_later
       order.cancel!
-      expect(order_id).to eq(order.id)
     end
 
     context "restocking inventory" do

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -670,11 +670,12 @@ describe Spree::Shipment, :type => :model do
     end
 
     it 'does not send a confirmation email' do
-      expect(unshippable_shipment).to_not receive(:send_shipment_email)
-      unshippable_shipment.ready!
-      unshippable_shipment.inventory_units(true).each do |unit|
-        expect(unit.state).to eq('shipped')
-      end
+      expect {
+        unshippable_shipment.ready!
+        unshippable_shipment.inventory_units(true).each do |unit|
+          expect(unit.state).to eq('shipped')
+        end
+      }.not_to change{ ActionMailer::Base.deliveries.count }
     end
   end
 

--- a/core/spec/models/spree/shipping_manifest_spec.rb
+++ b/core/spec/models/spree/shipping_manifest_spec.rb
@@ -1,0 +1,94 @@
+require 'spec_helper'
+
+module Spree
+  describe ShippingManifest, :type => :model do
+    let(:order) { Order.create! }
+    let(:variant) { create :variant }
+    let!(:shipment) { create(:shipment, state: 'pending', order: order) }
+    let(:manifest) { described_class.new(inventory_units: inventory_units) }
+
+    def build_unit(variant, attrs={})
+      attrs = {order: order, variant: variant, shipment: shipment}.merge(attrs)
+      attrs[:line_item] = attrs[:order].contents.add(attrs[:variant])
+      InventoryUnit.new(attrs)
+    end
+
+    subject{ manifest }
+
+    describe "#items" do
+      context 'empty' do
+        let(:inventory_units) { [] }
+        it "has correct item" do
+          expect(manifest.items.count).to eq 0
+        end
+      end
+
+      context 'single unit' do
+        let(:inventory_units) { [build_unit(variant)] }
+        it "has correct item" do
+          expect(manifest.items.count).to eq 1
+          expect(manifest.items[0]).to have_attributes(
+            variant: variant,
+            quantity: 1,
+            states: {"on_hand" => 1}
+          )
+        end
+      end
+
+      context 'two units of same variant' do
+        let(:inventory_units) { [build_unit(variant), build_unit(variant)] }
+        it "has correct item" do
+          expect(manifest.items.count).to eq 1
+          expect(manifest.items[0]).to have_attributes(
+            variant: variant,
+            quantity: 2,
+            states: {"on_hand" => 2}
+          )
+        end
+      end
+
+      context 'two units of different variants' do
+        let(:variant2){ create :variant }
+        let(:inventory_units) { [build_unit(variant), build_unit(variant2)] }
+        it "has correct item" do
+          expect(manifest.items.count).to eq 2
+          expect(manifest.items[0]).to have_attributes(
+            variant: variant,
+            quantity: 1,
+            states: {"on_hand" => 1}
+          )
+          expect(manifest.items[1]).to have_attributes(
+            variant: variant2,
+            quantity: 1,
+            states: {"on_hand" => 1}
+          )
+        end
+      end
+    end
+
+    describe "#for_order" do
+      let!(:order2) { Order.create! }
+      context 'single unit' do
+        let(:inventory_units) { [build_unit(variant)] }
+        it "has single ManifestItem in correct order" do
+          expect(manifest.for_order(order).items.count).to eq 1
+        end
+
+        it "has no ManifestItem in other order" do
+          expect(manifest.for_order(order2).items.count).to eq 0
+        end
+      end
+
+      context 'one units in each order' do
+        let(:inventory_units) { [build_unit(variant), build_unit(variant, order: order2)] }
+        it "has single ManifestItem in first order" do
+          expect(manifest.for_order(order).items.count).to eq 1
+        end
+
+        it "has single ManifestItem in second order" do
+          expect(manifest.for_order(order2).items.count).to eq 1
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Previously the CartonMailer was passed just a carton_id and would send the same email for all orders and emails associated.  Now it will send one email per order. This is necessary to send an email with the correct store name and template.

We may want to additionally update the view to only display items from the one order.

Also added ActionMailer::Previews
![](http://i.hawth.ca/s/GFsRi0Jx.png)