### PR TITLE
Remove the ability for users to destroy their own account.

### DIFF
--- a/api/spec/controllers/spree/api/users_controller_spec.rb
+++ b/api/spec/controllers/spree/api/users_controller_spec.rb
@@ -78,9 +78,9 @@ module Spree
         assert_not_found!
       end
 
-      it "can delete itself" do
+      it "cannot delete itself" do
         api_delete :destroy, id: user.id, token: user.spree_api_key
-        expect(response.status).to eq(204)
+        expect(response.status).to eq(401)
       end
 
       it "cannot delete other user" do

--- a/core/app/models/spree/ability.rb
+++ b/core/app/models/spree/ability.rb
@@ -73,7 +73,7 @@ module Spree
       can :display, ProductProperty
       can :display, Property
       can :create, Spree.user_class
-      can [:read, :update, :destroy], Spree.user_class, id: user.id
+      can [:read, :update], Spree.user_class, id: user.id
       can :display, State
       can :display, StockItem, stock_location: { active: true }
       can :display, StockLocation, active: true

--- a/core/spec/models/spree/permission_sets/user_display_spec.rb
+++ b/core/spec/models/spree/permission_sets/user_display_spec.rb
@@ -19,6 +19,8 @@ describe Spree::PermissionSets::UserDisplay do
     it { is_expected.to be_able_to(:display, Spree::StoreCredit) }
     it { is_expected.to be_able_to(:admin, Spree::StoreCredit) }
     it { is_expected.to be_able_to(:display, Spree::Role) }
+    it { is_expected.not_to be_able_to(:delete, Spree.user_class) }
+    it { is_expected.not_to be_able_to(:destroy, Spree.user_class) }
   end
 
   context "when not activated" do


### PR DESCRIPTION
This ability gets revoked by UserManagement, so it seems odd that a
normal user would have higher permissions than a person with the
UserManagement role.

=================================

Curious if any stores desire for a user to be able to destroy their account, it seems like an admin action to me.