### PR TITLE
Include option_type in option_values query in Variant#options_text

### DIFF
--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -119,7 +119,7 @@ module Spree
     #
     # @return [String] a sentence-ified string of option values.
     def options_text
-      values = self.option_values.sort do |a, b|
+      values = self.option_values.includes(:option_type).sort do |a, b|
         a.option_type.position <=> b.option_type.position
       end
 


### PR DESCRIPTION
It's required for the query and causing an n+1