### PR TITLE
Remove/deprecate delegate_belongs_to

### DIFF
--- a/core/app/helpers/spree/products_helper.rb
+++ b/core/app/helpers/spree/products_helper.rb
@@ -52,14 +52,6 @@ module Spree
       end
     end
 
-    # Deprecated and may be removed from future releases; use
-    # line_item_description_text(line_item.description) instead.
-    def line_item_description(variant)
-      ActiveSupport::Deprecation.warn "line_item_description(variant) is deprecated and may be removed from future releases, use line_item_description_text(line_item.description) instead.", caller
-
-      line_item_description_text(variant.product.description)
-    end
-
     # Filters and truncates the given description.
     #
     # @param description_text [String] the text to filter

--- a/core/app/models/concerns/spree/default_price.rb
+++ b/core/app/models/concerns/spree/default_price.rb
@@ -8,7 +8,13 @@ module Spree
         class_name: 'Spree::Price',
         dependent: :destroy
 
-      delegate_belongs_to :default_price, :display_price, :display_amount, :price, :price=, :currency
+      def find_or_build_default_price
+        default_price || build_default_price
+      end
+
+      delegate :display_price, :display_amount,
+                :price, :price=, :currency, :currency=,
+                to: :find_or_build_default_price
 
       after_save :save_default_price
 

--- a/core/app/models/concerns/spree/default_price.rb
+++ b/core/app/models/concerns/spree/default_price.rb
@@ -4,7 +4,7 @@ module Spree
 
     included do
       has_one :default_price,
-        -> { where currency: Spree::Config[:currency] },
+        -> { where currency: Spree::Config[:currency], is_default: true },
         class_name: 'Spree::Price',
         dependent: :destroy
 

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -48,9 +48,16 @@ module Spree
     has_many :line_items, through: :variants_including_master
     has_many :orders, through: :line_items
 
-    delegate_belongs_to :master, :sku, :price, :currency, :display_amount, :display_price, :weight, :height, :width, :depth, :is_master, :has_default_price?, :cost_currency, :price_in, :amount_in
+    def find_or_build_master
+      master || build_master
+    end
 
-    delegate_belongs_to :master, :cost_price
+    MASTER_ATTRIBUTES = [:sku, :price, :currency, :display_amount, :display_price, :weight, :height, :width, :depth, :cost_currency, :price_in, :amount_in, :cost_price]
+    MASTER_ATTRIBUTES.each do |attr|
+      delegate :"#{attr}", :"#{attr}=", to: :find_or_build_master
+    end
+
+    delegate :display_amount, :display_price, :has_default_price?, to: :find_or_build_master
 
     delegate :images, to: :master, prefix: true
     alias_method :images, :master_images

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -21,9 +21,9 @@ module Spree
     belongs_to :product, touch: true, class_name: 'Spree::Product', inverse_of: :variants
     belongs_to :tax_category, class_name: 'Spree::TaxCategory'
 
-    delegate_belongs_to :product, :name, :description, :slug, :available_on,
-                        :shipping_category_id, :meta_description, :meta_keywords,
-                        :shipping_category
+    delegate :name, :description, :slug, :available_on, :shipping_category_id,
+             :meta_description, :meta_keywords, :shipping_category,
+             to: :product
 
     has_many :inventory_units, inverse_of: :variant
     has_many :line_items, inverse_of: :variant

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -38,13 +38,6 @@ module Spree
 
     has_many :images, -> { order(:position) }, as: :viewable, dependent: :destroy, class_name: "Spree::Image"
 
-    has_one :default_price,
-      -> { where(currency: Spree::Config[:currency], is_default: true) },
-      class_name: 'Spree::Price',
-      dependent: :destroy
-
-    delegate_belongs_to :default_price, :display_price, :display_amount, :price, :price=, :currency
-
     has_many :prices,
       class_name: 'Spree::Price',
       dependent: :destroy,

--- a/core/lib/spree/core/delegate_belongs_to.rb
+++ b/core/lib/spree/core/delegate_belongs_to.rb
@@ -32,6 +32,7 @@ module DelegateBelongsTo
     # delegate_belongs_to :contact, [:defaults, :address, :fullname], :class_name => 'VCard'
     ##
     def delegate_belongs_to(association, *attrs)
+      ActiveSupport::Deprecation.warn "delegate_belongs_to is deprecated. Instead use rails built in delegates.", caller
       opts = attrs.extract_options!
       initialize_association :belongs_to, association, opts
       attrs = get_association_column_names(association) if attrs.empty?

--- a/core/spec/helpers/products_helper_spec.rb
+++ b/core/spec/helpers/products_helper_spec.rb
@@ -175,13 +175,6 @@ THIS IS THE BEST PRODUCT EVER!
       end
     end
 
-    context "#line_item_description" do
-      let(:variant) { create(:variant, :product => product, description: description) }
-      subject { line_item_description_text(variant.product.description) }
-
-      it_should_behave_like "line item descriptions"
-    end
-
     context '#line_item_description_text' do
       subject { line_item_description_text description }
 

--- a/core/spec/helpers/products_helper_spec.rb
+++ b/core/spec/helpers/products_helper_spec.rb
@@ -160,7 +160,8 @@ THIS IS THE BEST PRODUCT EVER!
 
     end
 
-    shared_examples_for "line item descriptions" do
+    context '#line_item_description_text' do
+      subject { line_item_description_text description }
       context 'variant has a blank description' do
         let(:description) { nil }
         it { is_expected.to eq(Spree.t(:product_has_no_description)) }
@@ -173,12 +174,6 @@ THIS IS THE BEST PRODUCT EVER!
         let(:description) { 'test&nbsp;desc' }
         it { is_expected.to eq('test desc') }
       end
-    end
-
-    context '#line_item_description_text' do
-      subject { line_item_description_text description }
-
-      it_should_behave_like "line item descriptions"
     end
 
     context '#cache_key_for_products' do

--- a/core/spec/lib/spree/core/delegate_belongs_to_spec.rb
+++ b/core/spec/lib/spree/core/delegate_belongs_to_spec.rb
@@ -8,7 +8,9 @@ module Spree
   class DelegateBelongsToStubModel < Spree::Base
     self.table_name = "spree_payment_methods"
     belongs_to :product
-    delegate_belongs_to :product, :name
+    ActiveSupport::Deprecation.silence do
+      delegate_belongs_to :product, :name
+    end
   end
 
   describe DelegateBelongsToStubModel do

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -24,7 +24,7 @@ describe Spree::Variant, :type => :model do
 
     it "propagate to stock items" do
       expect_any_instance_of(Spree::StockLocation).to receive(:propagate_variant)
-      product.variants.create(:name => "Foobar")
+      product.variants.create!
     end
 
     context "stock location has disable propagate all variants" do
@@ -32,7 +32,7 @@ describe Spree::Variant, :type => :model do
 
       it "propagate to stock items" do
         expect_any_instance_of(Spree::StockLocation).not_to receive(:propagate_variant)
-        product.variants.create(:name => "Foobar")
+        product.variants.create!
       end
     end
 
@@ -46,7 +46,7 @@ describe Spree::Variant, :type => :model do
 
       context 'when a variant is created' do
         before(:each) do
-          product.variants.create!(:name => 'any-name')
+          product.variants.create!
         end
 
         it { expect(product.master).to_not be_in_stock }


### PR DESCRIPTION
As an alternative to #312.

This fully deprecates `delegate_belongs_to` and replaces it with rails' built in `delegate`. This adds `find_or_build_ASSOCIATION` methods in two places in order to maintain existing delegate_belongs_to behaviour.

I did end up removing a few methods, which I think are much safer gone. Their original addition may have been unintentional:

* Removed all `Variant` delegations to `Product` setters (ex. `Variant#name=` would set `Product#name=`)
* Removed `Product#is_master` and `Product#is_master=` which should always be true, since it was delegating to the master variant.
* Removed `display_amount=`, `display_price=`, `has_default_price?=` from `Product`, which did not work (no such method).
* Removed `display_price=`, `display_amount=` from `Variant`, which did not work (no such method).