### PR TITLE
Fixes for adjustment finalizing/unfinalizing

### DIFF
--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -152,16 +152,16 @@ module Spree
       end
 
       def open_adjustments
-        adjustments = @order.all_adjustments.where(state: 'closed')
-        adjustments.each &:open!
+        adjustments = @order.all_adjustments.closed
+        adjustments.each(&:unfinalize!)
         flash[:success] = Spree.t(:all_adjustments_opened)
 
         respond_with(@order) { |format| format.html { redirect_to :back } }
       end
 
       def close_adjustments
-        adjustments = @order.all_adjustments.where(state: 'open')
-        adjustments.each &:close!
+        adjustments = @order.all_adjustments.open
+        adjustments.each(&:finalize!)
         flash[:success] = Spree.t(:all_adjustments_closed)
 
         respond_with(@order) { |format| format.html { redirect_to :back } }

--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -152,7 +152,7 @@ module Spree
       end
 
       def open_adjustments
-        adjustments = @order.all_adjustments.closed
+        adjustments = @order.all_adjustments.finalized
         adjustments.each(&:unfinalize!)
         flash[:success] = Spree.t(:all_adjustments_opened)
 
@@ -160,7 +160,7 @@ module Spree
       end
 
       def close_adjustments
-        adjustments = @order.all_adjustments.open
+        adjustments = @order.all_adjustments.not_finalized
         adjustments.each(&:finalize!)
         flash[:success] = Spree.t(:all_adjustments_closed)
 

--- a/backend/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -296,19 +296,12 @@ describe Spree::Admin::OrdersController, :type => :controller do
     end
 
     context "#open_adjustments" do
-      let(:closed) { double('closed_adjustments') }
-      let(:closed_adjustment) { double }
-
-      before do
-        allow(adjustments).to receive(:where).and_return(closed)
-        allow(closed).to receive(:each).and_return([])
-      end
+      let(:order) { create(:order) }
+      let!(:closed_adjustment) { create(:adjustment, finalized: true, adjustable: order, order: order) }
 
       it "changes all the closed adjustments to open" do
-        expect(adjustments).to receive(:where).with(state: 'closed')
-          .and_return([closed_adjustment])
-        expect(closed_adjustment).to receive(:open!)
         spree_post :open_adjustments, id: order.number
+        expect(closed_adjustment.reload.finalized).to eq(false)
       end
 
       it "sets the flash success message" do
@@ -323,19 +316,12 @@ describe Spree::Admin::OrdersController, :type => :controller do
     end
 
     context "#close_adjustments" do
-      let(:open) { double('open_adjustments') }
-      let(:open_adjustment) { double }
-
-      before do
-        allow(adjustments).to receive(:where).and_return(open)
-        allow(open).to receive(:each).and_return([])
-      end
+      let(:order) { create(:order) }
+      let!(:open_adjustment) { create(:adjustment, finalized: false, adjustable: order, order: order) }
 
       it "changes all the open adjustments to closed" do
-        expect(adjustments).to receive(:where).with(state: 'open')
-          .and_return([open_adjustment])
-        expect(open_adjustment).to receive(:close!)
         spree_post :close_adjustments, id: order.number
+        expect(open_adjustment.reload.finalized).to eq(true)
       end
 
       it "sets the flash success message" do

--- a/backend/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -295,13 +295,13 @@ describe Spree::Admin::OrdersController, :type => :controller do
       end
     end
 
-    context "#open_adjustments" do
+    context "#not_finalized_adjustments" do
       let(:order) { create(:order) }
-      let!(:closed_adjustment) { create(:adjustment, finalized: true, adjustable: order, order: order) }
+      let!(:finalized_adjustment) { create(:adjustment, finalized: true, adjustable: order, order: order) }
 
       it "changes all the closed adjustments to open" do
         spree_post :open_adjustments, id: order.number
-        expect(closed_adjustment.reload.finalized).to eq(false)
+        expect(finalized_adjustment.reload.finalized).to eq(false)
       end
 
       it "sets the flash success message" do
@@ -317,11 +317,11 @@ describe Spree::Admin::OrdersController, :type => :controller do
 
     context "#close_adjustments" do
       let(:order) { create(:order) }
-      let!(:open_adjustment) { create(:adjustment, finalized: false, adjustable: order, order: order) }
+      let!(:not_finalized_adjustment) { create(:adjustment, finalized: false, adjustable: order, order: order) }
 
       it "changes all the open adjustments to closed" do
         spree_post :close_adjustments, id: order.number
-        expect(open_adjustment.reload.finalized).to eq(true)
+        expect(not_finalized_adjustment.reload.finalized).to eq(true)
       end
 
       it "sets the flash success message" do

--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -101,7 +101,7 @@ module Spree
       unfinalize
     end
 
-    def open
+    def open!
       ActiveSupport::Deprecation.warn "Adjustment#open! is deprecated. Instead use Adjustment#unfinalize!", caller
       unfinalize!
     end

--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -29,8 +29,16 @@ module Spree
     after_create :update_adjustable_adjustment_total
     after_destroy :update_adjustable_adjustment_total
 
-    scope :open, -> { where(finalized: false) }
-    scope :closed, -> { where(finalized: true) }
+    scope :not_finalized, -> { where(finalized: false) }
+    scope :open, -> do
+      ActiveSupport::Deprecation.warn "Adjustment.open is deprecated. Instead use Adjustment.not_finalized", caller
+      where(finalized: false)
+    end
+    scope :finalized, -> { where(finalized: true) }
+    scope :closed, -> do
+      ActiveSupport::Deprecation.warn "Adjustment.closed is deprecated. Instead use Adjustment.finalized", caller
+      where(finalized: true)
+    end
     scope :cancellation, -> { where(source_type: 'Spree::UnitCancel') }
     scope :tax, -> { where(source_type: 'Spree::TaxRate') }
     scope :non_tax, -> do


### PR DESCRIPTION
The `where(state: ...)` clauses were broken here. The specs didn't
catch this because they were stubbed out.

Also, there was a `!` missing on the `Adjustment#open!` method.