### PR TITLE
Drop spree_gateways table

### DIFF
--- a/core/db/migrate/20150825204216_drop_spree_gateways.rb
+++ b/core/db/migrate/20150825204216_drop_spree_gateways.rb
@@ -1,0 +1,20 @@
+class DropSpreeGateways < ActiveRecord::Migration
+  def up
+    drop_table :spree_gateways
+  end
+
+  def down
+    create_table "spree_gateways" do |t|
+      t.string   "type"
+      t.string   "name"
+      t.text     "description"
+      t.boolean  "active",      default: true
+      t.string   "environment", default: "development"
+      t.string   "server",      default: "test"
+      t.boolean  "test_mode",   default: true
+      t.datetime "created_at"
+      t.datetime "updated_at"
+      t.text     "preferences"
+    end
+  end
+end


### PR DESCRIPTION
Spree::Gateway inherits from Spree::PaymentMethod and uses the
spree_payment_methods table.

Does anyone know the history of why this table exists? I took a quick look and it wasn't immediately obvious.  It's empty in our DB.

(I'm a bit nervous about dropping something like this w/o knowing the story for it)