### PR TITLE
More refactoring of update_from_params

### DIFF
--- a/api/app/controllers/spree/api/checkouts_controller.rb
+++ b/api/app/controllers/spree/api/checkouts_controller.rb
@@ -54,7 +54,7 @@ module Spree
       def update
         authorize! :update, @order, order_token
 
-        if @order.update_from_params(massaged_params, permitted_checkout_attributes, request.headers.env)
+        if @order.update_from_params(update_params, request_env: request.headers.env)
           if can?(:admin, @order) && user_id.present?
             @order.associate_user!(Spree.user_class.find(user_id))
           end
@@ -75,6 +75,15 @@ module Spree
       private
         def user_id
           params[:order][:user_id] if params[:order]
+        end
+
+        def update_params
+          if update_params = massaged_params[:order]
+            update_params.permit(permitted_checkout_attributes)
+          else
+            # We current allow update requests without any parameters in them.
+            {}
+          end
         end
 
         def massaged_params

--- a/api/app/controllers/spree/api/checkouts_controller.rb
+++ b/api/app/controllers/spree/api/checkouts_controller.rb
@@ -99,7 +99,7 @@ module Spree
             move_existing_card_into_payments_attributes(massaged_params)
           end
 
-          set_payment_parameters_amount(massaged_params)
+          set_payment_parameters_amount(massaged_params, @order)
 
           massaged_params
         end

--- a/api/app/controllers/spree/api/checkouts_controller.rb
+++ b/api/app/controllers/spree/api/checkouts_controller.rb
@@ -99,6 +99,8 @@ module Spree
             move_existing_card_into_payments_attributes(massaged_params)
           end
 
+          set_payment_parameters_amount(massaged_params)
+
           massaged_params
         end
 

--- a/api/app/controllers/spree/api/checkouts_controller.rb
+++ b/api/app/controllers/spree/api/checkouts_controller.rb
@@ -54,14 +54,7 @@ module Spree
       def update
         authorize! :update, @order, order_token
 
-        update_params = if params[:payment_source].present?
-          ActiveSupport::Deprecation.warn("Passing payment_source is deprecated. Send source parameters inside payments_attributes[:source_attributes].", caller)
-          move_payment_source_into_payments_attributes(params)
-        else
-          params
-        end
-
-        if @order.update_from_params(update_params, permitted_checkout_attributes, request.headers.env)
+        if @order.update_from_params(massaged_params, permitted_checkout_attributes, request.headers.env)
           if can?(:admin, @order) && user_id.present?
             @order.associate_user!(Spree.user_class.find(user_id))
           end
@@ -82,6 +75,22 @@ module Spree
       private
         def user_id
           params[:order][:user_id] if params[:order]
+        end
+
+        def massaged_params
+          massaged_params = params.deep_dup
+
+          if params[:payment_source].present?
+            ActiveSupport::Deprecation.warn("Passing payment_source is deprecated. Send source parameters inside payments_attributes[:source_attributes].", caller)
+            move_payment_source_into_payments_attributes(massaged_params)
+          end
+
+          if params[:order] && params[:order][:existing_card].present?
+            ActiveSupport::Deprecation.warn("Passing order[:existing_card] is deprecated. Send existing_card_id inside of payments_attributes[:source_attributes].", caller)
+            move_existing_card_into_payments_attributes(massaged_params)
+          end
+
+          massaged_params
         end
 
         def nested_params

--- a/api/spec/controllers/spree/api/checkouts_controller_spec.rb
+++ b/api/spec/controllers/spree/api/checkouts_controller_spec.rb
@@ -172,6 +172,29 @@ module Spree
         expect(source_errors).to include("can't be blank")
       end
 
+      describe 'setting the payment amount' do
+        let(:params) do
+          {
+            id: order.to_param,
+            order_token: order.guest_token,
+            order: {
+              payments_attributes: [
+                {
+                  payment_method_id: @payment_method.id.to_s,
+                  source_attributes: attributes_for(:credit_card),
+                },
+              ],
+            },
+          }
+        end
+
+        it 'sets the payment amount to the order total' do
+          api_put(:update, params)
+          expect(response.status).to eq(200)
+          expect(json_response['payments'][0]['amount']).to eq(order.total.to_s)
+        end
+      end
+
       describe 'payment method with source and transition from payment to confirm' do
         before do
           order.update_column(:state, "payment")

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -236,7 +236,6 @@ module Spree
 
           def update_from_params(attributes, request_env: {})
             if attributes[:payments_attributes]
-              attributes[:payments_attributes].first[:amount] = self.total
               attributes[:payments_attributes].first[:request_env] = request_env
             end
 

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -234,11 +234,7 @@ module Spree
             checkout_step_index(state) > checkout_step_index(self.state)
           end
 
-          def update_from_params(params, permitted_params, request_env = {})
-            return true if params[:order].blank?
-
-            attributes = params[:order].permit(permitted_params).delete_if { |k,v| v.nil? }
-
+          def update_from_params(attributes, request_env: {})
             if attributes[:payments_attributes]
               attributes[:payments_attributes].first[:amount] = self.total
               attributes[:payments_attributes].first[:request_env] = request_env

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -236,7 +236,9 @@ module Spree
 
           def update_from_params(attributes, request_env: {})
             if attributes[:payments_attributes]
-              attributes[:payments_attributes].first[:request_env] = request_env
+              attributes[:payments_attributes].each do |payment_attributes|
+                payment_attributes[:request_env] = request_env
+              end
             end
 
             if update_attributes(attributes)

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -874,7 +874,6 @@ en:
     intercept_email_address: Intercept Email Address
     intercept_email_instructions: Override email recipient and replace with this address.
     internal_name: Internal Name
-    invalid_credit_card: Invalid credit card.
     invalid_exchange_variant: Invalid exchange variant.
     invalid_payment_provider: Invalid payment provider.
     invalid_promotion_action: Invalid promotion action.

--- a/core/lib/spree/core/controller_helpers/payment_parameters.rb
+++ b/core/lib/spree/core/controller_helpers/payment_parameters.rb
@@ -116,10 +116,50 @@ module Spree
       params
     end
 
-    def set_payment_parameters_amount(params)
-      if params[:payments_attributes]
-        params[:payments_attributes].first[:amount] = self.total
-      end
+    # This is a strange thing to do since an order can have multiple payments
+    # but we always assume that it only has a single payment and that its
+    # amount should be the current order total.  Also, this is pretty much
+    # overridden when the order transitions to confirm by the logic inside of
+    # Order#add_store_credit_payments.
+    # We should reconsider this method and its usage at some point.
+    #
+    # This method expects a params hash in the format of:
+    #
+    #  {
+    #    order: {
+    #      # Note that only a single entry is expected/handled in this array
+    #      payments_attributes: [
+    #        {
+    #          ...params...
+    #        },
+    #      ],
+    #      ...other params...
+    #    },
+    #    ...other params...
+    #  }
+    #
+    # And this method modifies the params into the format of:
+    #
+    #  {
+    #    order: {
+    #      payments_attributes: [
+    #        {
+    #          ...params...
+    #          amount: <the order total>,
+    #        },
+    #      ],
+    #      ...other params...
+    #    },
+    #    ...other params...
+    #  }
+    #
+    def set_payment_parameters_amount(params, order)
+      return params if params[:order].blank?
+      return params if params[:order][:payments_attributes].blank?
+
+      params[:order][:payments_attributes].first[:amount] = order.total
+
+      params
     end
 
   end

--- a/core/lib/spree/core/controller_helpers/payment_parameters.rb
+++ b/core/lib/spree/core/controller_helpers/payment_parameters.rb
@@ -1,7 +1,7 @@
 module Spree
   module Core::ControllerHelpers::PaymentParameters
     # This method handles the awkwardness of how the html forms are currently
-    # set up for frontend and admin.
+    # set up for frontend.
     #
     # This method expects a params hash in the format of:
     #
@@ -23,7 +23,7 @@ module Spree
     #    ...other params...
     #  }
     #
-    # And this method returns a new params hash in the format of:
+    # And this method modifies the params into the format of:
     #
     #  {
     #    order: {
@@ -38,9 +38,7 @@ module Spree
     #    ...other params...
     #  }
     #
-    def move_payment_source_into_payments_attributes(original_params)
-      params = original_params.deep_dup
-
+    def move_payment_source_into_payments_attributes(params)
       # Step 1: Gather all the information and ensure all the pieces are there.
 
       return params if params[:payment_source].blank?
@@ -63,5 +61,60 @@ module Spree
 
       params
     end
+
+    # This method handles the awkwardness of how the html forms are currently
+    # set up for frontend.
+    #
+    # This method expects a params hash in the format of:
+    #
+    #  {
+    #    order: {
+    #      existing_card: '123',
+    #      ...other params...
+    #    },
+    #    cvc_confirm: '456', # optional
+    #    ...other params...
+    #  }
+    #
+    # And this method modifies the params into the format of:
+    #
+    #  {
+    #    order: {
+    #      payments_attributes: [
+    #        {
+    #          source_attributes: {
+    #            existing_card_id: '123',
+    #            verification_value: '456',
+    #          },
+    #        },
+    #      ]
+    #      ...other params...
+    #    },
+    #    ...other params...
+    #  }
+    #
+    def move_existing_card_into_payments_attributes(params)
+      return params if params[:order].blank?
+
+      card_id = params[:order][:existing_card].presence
+      cvc_confirm = params[:cvc_confirm].presence
+
+      return params if card_id.nil?
+
+      params[:order][:payments_attributes] = [
+        {
+          source_attributes: {
+            existing_card_id: card_id,
+            verification_value: cvc_confirm,
+          }
+        },
+      ]
+
+      params[:order].delete(:existing_card)
+      params.delete(:cvc_confirm)
+
+      params
+    end
+
   end
 end

--- a/core/lib/spree/core/controller_helpers/payment_parameters.rb
+++ b/core/lib/spree/core/controller_helpers/payment_parameters.rb
@@ -116,5 +116,11 @@ module Spree
       params
     end
 
+    def set_payment_parameters_amount(params)
+      if params[:payments_attributes]
+        params[:payments_attributes].first[:amount] = self.total
+      end
+    end
+
   end
 end

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -84,7 +84,9 @@ module Spree
     @@source_attributes = [
       :number, :month, :year, :expiry, :verification_value,
       :first_name, :last_name, :cc_type, :gateway_customer_profile_id,
-      :gateway_payment_profile_id, :last_digits, :name, :encrypted_data]
+      :gateway_payment_profile_id, :last_digits, :name, :encrypted_data,
+      :existing_card_id,
+    ]
 
     @@stock_item_attributes = [:variant, :stock_location, :backorderable, :variant_id]
 

--- a/core/spec/lib/spree/core/controller_helpers/payment_parameters_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/payment_parameters_spec.rb
@@ -148,4 +148,33 @@ describe Spree::Core::ControllerHelpers::PaymentParameters, type: :controller do
     end
 
   end
+
+  describe '#set_payment_parameters_amount' do
+    subject do
+      controller.set_payment_parameters_amount(params, order)
+    end
+
+    let(:params) do
+      ActionController::Parameters.new(
+        order: {
+          payments_attributes: [{}],
+          other_order_param: 1,
+        },
+        other_param: 2,
+      )
+    end
+    let(:order) { create(:order_with_line_items, line_items_price: 101.00, line_items_count: 1, shipment_cost: 0) }
+
+    it 'produces the expected hash' do
+      expect(subject).to eq(
+        ActionController::Parameters.new(
+          order: {
+            payments_attributes: [{amount: 101}],
+            other_order_param: 1,
+          },
+          other_param: 2,
+        )
+      )
+    end
+  end
 end

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -766,11 +766,6 @@ describe Spree::Order, :type => :model do
       }
     end
 
-    it 'sets the payment amount' do
-      order.update_from_params(params)
-      expect(order.payments.last.amount).to eq(order.total)
-    end
-
     context 'with a request_env' do
       it 'sets the request_env on the payment' do
         expect_any_instance_of(Spree::Payment).to(

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -756,73 +756,39 @@ describe Spree::Order, :type => :model do
   end
 
   describe 'update_from_params' do
-    let(:permitted_params) { {} }
-    let(:params) { {} }
+    let(:order) { create(:order) }
 
-    it 'calls update_atributes without order params' do
-      expect(order).to receive(:update_attributes).with({})
-      order.update_from_params( params, permitted_params)
+    let(:params) do
+      ActionController::Parameters.new(
+        order: {
+          payments_attributes: [
+            {source_attributes: attributes_for(:credit_card)},
+          ],
+        }
+      )
+    end
+    let(:permitted_params) do
+      Spree::PermittedAttributes.checkout_attributes +
+        [payments_attributes: Spree::PermittedAttributes.payment_attributes]
     end
 
-    it 'runs the callbacks' do
-      expect(order).to receive(:run_callbacks).with(:updating_from_params)
-      order.update_from_params( params, permitted_params)
+    it 'sets the payment amount' do
+      order.update_from_params(params, permitted_params)
+      expect(order.payments.last.amount).to eq(order.total)
     end
 
-    context "passing a credit card" do
-      let(:permitted_params) do
-        Spree::PermittedAttributes.checkout_attributes +
-          [payments_attributes: Spree::PermittedAttributes.payment_attributes]
-      end
-
-      let(:credit_card) { create(:credit_card, user_id: order.user_id) }
-
-      let(:params) do
-        ActionController::Parameters.new(
-          order: {
-            payments_attributes: [
-              {
-                payment_method_id: 1,
-                source_attributes: attributes_for(:credit_card),
-              },
-            ],
-            existing_card: credit_card.id,
-          },
-          cvc_confirm: "737",
+    context 'with a request_env' do
+      it 'sets the request_env on the payment' do
+        expect_any_instance_of(Spree::Payment).to(
+          receive(:request_env=).with({'USER_AGENT' => 'Firefox'}).and_call_original
         )
+        order.update_from_params(params, permitted_params, {'USER_AGENT' => 'Firefox'})
       end
+    end
 
-      before { order.user_id = 3 }
-
-      it "sets confirmation value when its available via :cvc_confirm" do
-        allow(Spree::CreditCard).to receive_messages find: credit_card
-        expect(credit_card).to receive(:verification_value=)
-        order.update_from_params(params, permitted_params)
-      end
-
-      it "sets existing card as source for new payment" do
-        expect {
-          order.update_from_params(params, permitted_params)
-        }.to change { Spree::Payment.count }.by(1)
-
-        expect(Spree::Payment.last.source).to eq credit_card
-      end
-
-      it "sets request_env on payment" do
-        request_env = { "USER_AGENT" => "Firefox" }
-
-        expected_hash = { "payments_attributes" => [hash_including("request_env" => request_env)] }
-        expect(order).to receive(:update_attributes).with expected_hash
-
-        order.update_from_params(params, permitted_params, request_env)
-      end
-
-      it "dont let users mess with others users cards" do
-        credit_card.update_column :user_id, 5
-
-        expect {
-          order.update_from_params(params, permitted_params)
-        }.to raise_error Spree::Core::GatewayError
+    context 'empty params' do
+      it 'succeeds' do
+        expect(order.update_from_params({}, permitted_params)).to be_truthy
       end
     end
 
@@ -840,16 +806,6 @@ describe Spree::Order, :type => :model do
 
         it 'accepts permitted attributes' do
           expect(order).to receive(:update_attributes).with({"good_param" => 'okay'})
-          order.update_from_params(params, permitted_params)
-        end
-      end
-
-      context 'callbacks halt' do
-        before do
-          expect(order).to receive(:update_params_payment_source).and_return false
-        end
-        it 'does not let through unpermitted attributes' do
-          expect(order).not_to receive(:update_attributes).with({})
           order.update_from_params(params, permitted_params)
         end
       end

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -759,21 +759,15 @@ describe Spree::Order, :type => :model do
     let(:order) { create(:order) }
 
     let(:params) do
-      ActionController::Parameters.new(
-        order: {
-          payments_attributes: [
-            {source_attributes: attributes_for(:credit_card)},
-          ],
-        }
-      )
-    end
-    let(:permitted_params) do
-      Spree::PermittedAttributes.checkout_attributes +
-        [payments_attributes: Spree::PermittedAttributes.payment_attributes]
+      {
+        payments_attributes: [
+          {source_attributes: attributes_for(:credit_card)},
+        ],
+      }
     end
 
     it 'sets the payment amount' do
-      order.update_from_params(params, permitted_params)
+      order.update_from_params(params)
       expect(order.payments.last.amount).to eq(order.total)
     end
 
@@ -782,33 +776,15 @@ describe Spree::Order, :type => :model do
         expect_any_instance_of(Spree::Payment).to(
           receive(:request_env=).with({'USER_AGENT' => 'Firefox'}).and_call_original
         )
-        order.update_from_params(params, permitted_params, {'USER_AGENT' => 'Firefox'})
+        order.update_from_params(params, request_env: {'USER_AGENT' => 'Firefox'})
       end
     end
 
     context 'empty params' do
       it 'succeeds' do
-        expect(order.update_from_params({}, permitted_params)).to be_truthy
-      end
-    end
-
-    context 'has params' do
-      let(:permitted_params) { [ :good_param ] }
-      let(:params) { ActionController::Parameters.new(order: {  bad_param: 'okay' } ) }
-
-      it 'does not let through unpermitted attributes' do
-        expect(order).to receive(:update_attributes).with({})
-        order.update_from_params(params, permitted_params)
-      end
-
-      context 'has allowed params' do
-        let(:params) { ActionController::Parameters.new(order: {  good_param: 'okay' } ) }
-
-        it 'accepts permitted attributes' do
-          expect(order).to receive(:update_attributes).with({"good_param" => 'okay'})
-          order.update_from_params(params, permitted_params)
-        end
+        expect(order.update_from_params({})).to be_truthy
       end
     end
   end
+
 end

--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -25,7 +25,7 @@ module Spree
 
     # Updates the order and advances to the next state (when possible.)
     def update
-      if @order.update_from_params(massaged_params, permitted_checkout_attributes, request.headers.env)
+      if @order.update_from_params(update_params, request_env: request.headers.env)
         @order.temporary_address = !params[:save_user_address]
         success = if @order.state == 'confirm'
           @order.complete
@@ -51,6 +51,15 @@ module Spree
     end
 
     private
+
+      def update_params
+        if update_params = massaged_params[:order]
+          update_params.permit(permitted_checkout_attributes)
+        else
+          # We current allow update requests without any parameters in them.
+          {}
+        end
+      end
 
       def massaged_params
         massaged_params = params.deep_dup

--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -66,6 +66,7 @@ module Spree
 
         move_payment_source_into_payments_attributes(massaged_params)
         move_existing_card_into_payments_attributes(massaged_params)
+        set_payment_parameters_amount(massaged_params)
 
         massaged_params
       end

--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -25,7 +25,6 @@ module Spree
 
     # Updates the order and advances to the next state (when possible.)
     def update
-      massaged_params = move_payment_source_into_payments_attributes(params)
       if @order.update_from_params(massaged_params, permitted_checkout_attributes, request.headers.env)
         @order.temporary_address = !params[:save_user_address]
         success = if @order.state == 'confirm'
@@ -52,6 +51,16 @@ module Spree
     end
 
     private
+
+      def massaged_params
+        massaged_params = params.deep_dup
+
+        move_payment_source_into_payments_attributes(massaged_params)
+        move_existing_card_into_payments_attributes(massaged_params)
+
+        massaged_params
+      end
+
       def ensure_valid_state
         unless skip_state_validation?
           if (params[:state] && !@order.has_checkout_step?(params[:state])) ||

--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -66,7 +66,7 @@ module Spree
 
         move_payment_source_into_payments_attributes(massaged_params)
         move_existing_card_into_payments_attributes(massaged_params)
-        set_payment_parameters_amount(massaged_params)
+        set_payment_parameters_amount(massaged_params, @order)
 
         massaged_params
       end

--- a/frontend/spec/controllers/spree/checkout_controller_spec.rb
+++ b/frontend/spec/controllers/spree/checkout_controller_spec.rb
@@ -203,7 +203,7 @@ describe Spree::CheckoutController, :type => :controller do
     context "save unsuccessful" do
       before do
         allow(order).to receive_messages :user => user
-        allow(order).to receive_messages :update_attributes => false
+        allow(order).to receive_messages :update_from_params => false
       end
 
       it "should not assign order" do
@@ -238,7 +238,7 @@ describe Spree::CheckoutController, :type => :controller do
     context "Spree::Core::GatewayError" do
       before do
         allow(order).to receive_messages :user => user
-        allow(order).to receive(:update_attributes).and_raise(Spree::Core::GatewayError.new("Invalid something or other."))
+        allow(order).to receive(:update_from_params).and_raise(Spree::Core::GatewayError.new("Invalid something or other."))
         spree_post :update, {:state => "address"}
       end
 

--- a/frontend/spec/controllers/spree/checkout_controller_spec.rb
+++ b/frontend/spec/controllers/spree/checkout_controller_spec.rb
@@ -170,6 +170,55 @@ describe Spree::CheckoutController, :type => :controller do
         end
       end
 
+      # This is the only time that we need the 'set_payment_parameters_amount'
+      # controller code, because otherwise the transition to 'confirm' will
+      # trigger the 'add_store_credit_payments' transition code which will do
+      # the same thing here.
+      # Perhaps we can just remove 'set_payment_parameters_amount' entirely at
+      # some point?
+      context "when there is a checkout step between payment and confirm" do
+        before do
+          @old_checkout_flow = Spree::Order.checkout_flow
+          Spree::Order.class_eval do
+            insert_checkout_step :new_step, after: :payment
+          end
+        end
+
+        after do
+          Spree::Order.checkout_flow(&@old_checkout_flow)
+        end
+
+        let(:order) { create(:order_with_line_items) }
+        let(:payment_method) { create(:credit_card_payment_method) }
+
+        let(:params) do
+          {
+            state: 'payment',
+            order: {
+              payments_attributes: [
+                {
+                  payment_method_id: payment_method.id.to_s,
+                  source_attributes: attributes_for(:credit_card),
+                },
+              ],
+            },
+          }
+        end
+
+        before do
+          allow(order).to receive_messages(user: user)
+          3.times { order.next! } # should put us in the payment state
+        end
+
+        it 'sets the payment amount' do
+          spree_post :update, params
+          order.reload
+          expect(order.state).to eq('new_step')
+          expect(order.payments.size).to eq(1)
+          expect(order.payments.first.amount).to eq(order.total)
+        end
+      end
+
       context "when in the confirm state" do
         before do
           order.update_column(:state, "confirm")


### PR DESCRIPTION
My goal here and in #303 has been to detangle Order#update_from_params enough to be able to merge it with OrderContents#update_cart and [the other places](https://github.com/solidusio/solidus/issues/290#issuecomment-132034893) where we create payments.  More exciting updates (like maybe a CartUpdate class & etc) will come after that.

These changes are all things that don't really belong at the model level because it is mostly html-form-parameter-massaging code that should really be at the controller level.

NOTE: This PR is probably easiest to view by looking at each commit separately.