### PR TITLE
Enforce new rspec expect syntax

### DIFF
--- a/api/spec/spec_helper.rb
+++ b/api/spec/spec_helper.rb
@@ -41,6 +41,12 @@ RSpec.configure do |config|
   config.backtrace_exclusion_patterns = [/gems\/activesupport/, /gems\/actionpack/, /gems\/rspec/]
   config.color = true
   config.infer_spec_type_from_file_location!
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+  config.mock_with :rspec do |c|
+    c.syntax = :expect
+  end
 
   config.include FactoryGirl::Syntax::Methods
   config.include Spree::Api::TestingSupport::Helpers, :type => :controller

--- a/backend/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -213,7 +213,7 @@ describe Spree::Admin::OrdersController, :type => :controller do
       end
 
       context 'when before confirm' do
-        before { order.stub completed?: false, confirm?: false }
+        before { allow(order).to receive_messages completed?: false, confirm?: false }
 
         it 'renders the confirm_advance template (to allow refreshing of the order)' do
           subject

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -52,7 +52,12 @@ Capybara.javascript_driver = :poltergeist
 RSpec.configure do |config|
   config.color = true
   config.infer_spec_type_from_file_location!
-  config.mock_with :rspec
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+  config.mock_with :rspec do |c|
+    c.syntax = :expect
+  end
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, comment the following line or assign false

--- a/core/spec/models/spree/order_updater_spec.rb
+++ b/core/spec/models/spree/order_updater_spec.rb
@@ -104,7 +104,7 @@ module Spree
     context "updating payment state" do
       let(:order) { Order.new }
       let(:updater) { order.updater }
-      before { order.stub(:refund_total).and_return(0) }
+      before { allow(order).to receive(:refund_total).and_return(0) }
 
       context 'no valid payments with non-zero order total' do
         it "is failed" do

--- a/core/spec/spec_helper.rb
+++ b/core/spec/spec_helper.rb
@@ -42,7 +42,12 @@ require 'cancan/matchers'
 RSpec.configure do |config|
   config.color = true
   config.infer_spec_type_from_file_location!
-  config.mock_with :rspec
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+  config.mock_with :rspec do |c|
+    c.syntax = :expect
+  end
 
   config.fixture_path = File.join(File.expand_path(File.dirname(__FILE__)), "fixtures")
 

--- a/frontend/spec/spec_helper.rb
+++ b/frontend/spec/spec_helper.rb
@@ -61,7 +61,12 @@ end
 RSpec.configure do |config|
   config.color = true
   config.infer_spec_type_from_file_location!
-  config.mock_with :rspec
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+  config.mock_with :rspec do |c|
+    c.syntax = :expect
+  end
 
   config.fixture_path = File.join(File.expand_path(File.dirname(__FILE__)), "fixtures")
 

--- a/sample/spec/spec_helper.rb
+++ b/sample/spec/spec_helper.rb
@@ -16,7 +16,12 @@ require 'spree_sample'
 RSpec.configure do |config|
   config.color = true
   config.infer_spec_type_from_file_location!
-  config.mock_with :rspec
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+  config.mock_with :rspec do |c|
+    c.syntax = :expect
+  end
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, comment the following line or assign false


### PR DESCRIPTION
We were receiving two deprecation warnings due to use of the old stub syntax (I may have missed it in my last go at fixing these).

To prevent this in the future, this disables the old `should` and `stub` syntax.