### PR TITLE
Move default permissions into PermissionSets

### DIFF
--- a/api/lib/spree/api/testing_support/helpers.rb
+++ b/api/lib/spree/api/testing_support/helpers.rb
@@ -28,7 +28,7 @@ module Spree
         # This method can be overriden (with a let block) inside a context
         # For instance, if you wanted to have an admin user instead.
         def current_api_user
-          @current_api_user ||= stub_model(Spree::LegacyUser, email: "spree@example.com")
+          @current_api_user ||= stub_model(Spree::LegacyUser, email: "spree@example.com", spree_roles: [])
         end
 
         def image(filename)

--- a/api/lib/spree/api/testing_support/setup.rb
+++ b/api/lib/spree/api/testing_support/setup.rb
@@ -4,10 +4,7 @@ module Spree
       module Setup
         def sign_in_as_admin!
           let!(:current_api_user) do
-            user = stub_model(Spree::LegacyUser)
-            allow(user).to receive_message_chain(:spree_roles, :pluck).and_return(["admin"])
-            allow(user).to receive(:has_spree_role?).with("admin").and_return(true)
-            user
+            stub_model(Spree::LegacyUser, spree_roles: [Spree::Role.new(name: 'admin')])
           end
         end
       end

--- a/api/spec/controllers/spree/api/credit_cards_controller_spec.rb
+++ b/api/spec/controllers/spree/api/credit_cards_controller_spec.rb
@@ -6,16 +6,11 @@ module Spree
       render_views
 
       let!(:admin_user) do
-        user = Spree.user_class.new(:email => "spree@example.com", :id => 1)
-        user.generate_spree_api_key!
-        allow(user).to receive(:has_spree_role?).with('admin').and_return(true)
-        user
+        create(:admin_user)
       end
 
       let!(:normal_user) do
-        user = Spree.user_class.new(:email => "spree2@example.com", :id => 2)
-        user.generate_spree_api_key!
-        user
+        create(:user, :with_api_key)
       end
 
       let!(:card) { create(:credit_card, :user_id => admin_user.id, gateway_customer_profile_id: "random") }
@@ -31,8 +26,7 @@ module Spree
 
       context "calling user is in admin role" do
         let(:current_api_user) do
-          user = admin_user
-          user
+          admin_user
         end
 
         it "no credit cards exist for user" do
@@ -55,8 +49,7 @@ module Spree
 
       context "calling user is not in admin role" do
         let(:current_api_user) do
-          user = normal_user
-          user
+          normal_user
         end
 
         let!(:card) { create(:credit_card, :user_id => normal_user.id, gateway_customer_profile_id: "random") }

--- a/api/spec/controllers/spree/api/orders_controller_spec.rb
+++ b/api/spec/controllers/spree/api/orders_controller_spec.rb
@@ -313,10 +313,7 @@ module Spree
       after { Spree::Ability.remove_ability(::BarAbility) }
 
       it "can view an order" do
-        user = build(:user)
-        allow(user).to receive_message_chain(:spree_roles, :pluck).and_return(["bar"])
-        allow(user).to receive(:has_spree_role?).with('bar').and_return(true)
-        allow(user).to receive(:has_spree_role?).with('admin').and_return(false)
+        user = build(:user, spree_roles: [Spree::Role.new(name: 'bar')])
         allow(Spree.user_class).to receive_messages find_by: user
         api_get :show, :id => order.to_param
         expect(response.status).to eq(200)
@@ -385,10 +382,7 @@ module Spree
     end
 
     context "admin user imports order" do
-      before do
-        allow(current_api_user).to receive_messages has_spree_role?: true
-        allow(current_api_user).to receive_message_chain :spree_roles, pluck: ["admin"]
-      end
+      let!(:current_api_user) { create :admin_user }
 
       it "is able to set any default unpermitted attribute" do
         api_post :create, :order => { number: "WOW" }
@@ -400,7 +394,6 @@ module Spree
     it "can create an order without any parameters" do
       expect { api_post :create }.not_to raise_error
       expect(response.status).to eq(201)
-      order = Order.last
       expect(json_response["state"]).to eq("cart")
     end
 

--- a/core/app/models/spree/ability.rb
+++ b/core/app/models/spree/ability.rb
@@ -28,7 +28,6 @@ module Spree
       @user = current_user || Spree.user_class.new
 
       alias_actions
-      grant_default_permissions
       activate_permission_sets
       register_extension_abilities
     end
@@ -45,14 +44,6 @@ module Spree
       alias_action :new_action, to: :create
       alias_action :show, to: :read
       alias_action :index, :read, to: :display
-    end
-
-    def grant_default_permissions
-      # if the user is a "super user" give them full permissions, otherwise give them the permissions
-      # required to checkout and use the frontend.
-      if user.respond_to?(:has_spree_role?) && user.has_spree_role?('admin')
-        can :manage, :all
-      end
     end
 
     # Before, this was the only way to extend this ability. Permission sets have been added since.

--- a/core/app/models/spree/ability.rb
+++ b/core/app/models/spree/ability.rb
@@ -52,35 +52,7 @@ module Spree
       # required to checkout and use the frontend.
       if user.respond_to?(:has_spree_role?) && user.has_spree_role?('admin')
         can :manage, :all
-      else
-        grant_generic_user_permissions
       end
-    end
-
-    def grant_generic_user_permissions
-      can :display, Country
-      can :display, OptionType
-      can :display, OptionValue
-      can :create, Order
-      can [:read, :update], Order do |order, token|
-        order.user == user || order.guest_token && token == order.guest_token
-      end
-      can :create, ReturnAuthorization do |return_authorization|
-        return_authorization.order.user == user
-      end
-      can [:display, :update], CreditCard, user_id: user.id
-      can :display, Product
-      can :display, ProductProperty
-      can :display, Property
-      can :create, Spree.user_class
-      can [:read, :update], Spree.user_class, id: user.id
-      can :display, State
-      can :display, StockItem, stock_location: { active: true }
-      can :display, StockLocation, active: true
-      can :display, Taxon
-      can :display, Taxonomy
-      can [:display, :view_out_of_stock], Variant
-      can :display, Zone
     end
 
     # Before, this was the only way to extend this ability. Permission sets have been added since.

--- a/core/app/models/spree/ability.rb
+++ b/core/app/models/spree/ability.rb
@@ -29,8 +29,8 @@ module Spree
 
       alias_actions
       grant_default_permissions
-      register_extension_abilities
       activate_permission_sets
+      register_extension_abilities
     end
 
     private

--- a/core/app/models/spree/permission_sets/default_customer.rb
+++ b/core/app/models/spree/permission_sets/default_customer.rb
@@ -1,0 +1,31 @@
+module Spree
+  module PermissionSets
+    class DefaultCustomer < PermissionSets::Base
+      def activate!
+        can :display, Country
+        can :display, OptionType
+        can :display, OptionValue
+        can :create, Order
+        can [:read, :update], Order do |order, token|
+          order.user == user || order.guest_token && token == order.guest_token
+        end
+        can :create, ReturnAuthorization do |return_authorization|
+          return_authorization.order.user == user
+        end
+        can [:display, :update], CreditCard, user_id: user.id
+        can :display, Product
+        can :display, ProductProperty
+        can :display, Property
+        can :create, Spree.user_class
+        can [:read, :update], Spree.user_class, id: user.id
+        can :display, State
+        can :display, StockItem, stock_location: { active: true }
+        can :display, StockLocation, active: true
+        can :display, Taxon
+        can :display, Taxonomy
+        can [:display, :view_out_of_stock], Variant
+        can :display, Zone
+      end
+    end
+  end
+end

--- a/core/app/models/spree/permission_sets/super_user.rb
+++ b/core/app/models/spree/permission_sets/super_user.rb
@@ -1,0 +1,9 @@
+module Spree
+  module PermissionSets
+    class SuperUser < PermissionSets::Base
+      def activate!
+        can :manage, :all
+      end
+    end
+  end
+end

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -13,6 +13,12 @@ module Spree
         Spree::Config = app.config.spree.preferences #legacy access
       end
 
+      initializer "spree.default_permissions" do |app|
+        Spree::RoleConfiguration.configure do |config|
+          config.assign_permissions :default, [Spree::PermissionSets::DefaultCustomer]
+        end
+      end
+
       initializer "spree.register.calculators" do |app|
         app.config.spree.calculators.shipping_methods = [
             Spree::Calculator::Shipping::FlatPercentItemTotal,

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -16,6 +16,7 @@ module Spree
       initializer "spree.default_permissions" do |app|
         Spree::RoleConfiguration.configure do |config|
           config.assign_permissions :default, [Spree::PermissionSets::DefaultCustomer]
+          config.assign_permissions :admin, [Spree::PermissionSets::SuperUser]
         end
       end
 

--- a/core/lib/spree/core/role_configuration.rb
+++ b/core/lib/spree/core/role_configuration.rb
@@ -36,7 +36,7 @@ module Spree
     # @param ability [CanCan::Ability] the ability to invoke declarations on
     # @param user [#spree_roles] the user that holds the spree_roles association.
     def activate_permissions! ability, user
-      spree_roles = user.spree_roles.pluck(:name)
+      spree_roles = ['default'] | user.spree_roles.map(&:name)
       applicable_permissions = Set.new
 
       spree_roles.each do |role_name|

--- a/core/lib/spree/testing_support/factories/user_factory.rb
+++ b/core/lib/spree/testing_support/factories/user_factory.rb
@@ -10,6 +10,12 @@ FactoryGirl.define do
     password_confirmation { password }
     authentication_token { generate(:user_authentication_token) } if Spree.user_class.attribute_method? :authentication_token
 
+    trait :with_api_key do
+      after(:create) do |user, _|
+        user.generate_spree_api_key!
+      end
+    end
+
     factory :admin_user do
       spree_roles { [Spree::Role.find_by(name: 'admin') || create(:role, name: 'admin')] }
     end

--- a/core/spec/lib/spree/core/role_configuration_spec.rb
+++ b/core/spec/lib/spree/core/role_configuration_spec.rb
@@ -17,11 +17,11 @@ describe Spree::RoleConfiguration do
 
   describe ".configure" do
     it "yields with the instance" do
-      expect { |b| described_class.configure &b }.to yield_with_args(described_class.instance)
+      expect { |b| described_class.configure(&b) }.to yield_with_args(described_class.instance)
     end
 
     it "only yields once" do
-      expect { |b| described_class.configure &b }.to yield_control.once
+      expect { |b| described_class.configure(&b) }.to yield_control.once
     end
   end
 

--- a/core/spec/lib/spree/core/role_configuration_spec.rb
+++ b/core/spec/lib/spree/core/role_configuration_spec.rb
@@ -84,13 +84,13 @@ describe Spree::RoleConfiguration do
 
   describe "#activate_permissions!" do
     let(:user) { build :user }
-    let(:roles_double) { double pluck: user_roles, any?: true }
     let(:role_name) { "testrole" }
     let(:ability) { DummyAbility.new }
 
     before do
-      allow(user).to receive(:spree_roles).and_return(roles_double)
-      allow(user).to receive(:has_spree_role?).with("admin").and_return(false)
+      user.spree_roles = user_roles.map do |role|
+        Spree::Role.create!(name: role)
+      end
     end
 
     subject { described_class.instance.activate_permissions! ability, user }

--- a/core/spec/lib/spree/core/role_configuration_spec.rb
+++ b/core/spec/lib/spree/core/role_configuration_spec.rb
@@ -100,6 +100,30 @@ describe Spree::RoleConfiguration do
         instance.roles.merge!({ role_name => described_class::Role.new(role_name, [DummyPermissionSet])})
       end
 
+      context "default_role" do
+        let(:role_name) { 'default' }
+
+        context "when the user has no roles" do
+          let(:user_roles) {[]}
+
+          it "activates the applicable permissions on the ability" do
+            expect{subject}.to change{ability.can? :manage, :things}.
+              from(false).
+              to(true)
+          end
+        end
+
+        context "when the user has a different role" do
+          let(:user_roles) {[]}
+
+          it "activates the applicable permissions on the ability" do
+            expect{subject}.to change{ability.can? :manage, :things}.
+              from(false).
+              to(true)
+          end
+        end
+      end
+
       context "when the configuration has applicable roles" do
         let(:user_roles) {[role_name, "someotherrandomrole"]}
 

--- a/core/spec/models/spree/ability_spec.rb
+++ b/core/spec/models/spree/ability_spec.rb
@@ -45,7 +45,7 @@ describe Spree::Ability, :type => :model do
 
     it 'should apply the registered abilities permissions' do
       Spree::Ability.register_ability(FooAbility)
-      expect(Spree::Ability.new(user).can?(:update, mock_model(Spree::Order, :id => 1))).to be true
+      expect(Spree::Ability.new(user).can?(:update, mock_model(Spree::Order, user: nil, :id => 1))).to be true
     end
   end
 

--- a/core/spec/models/spree/ability_spec.rb
+++ b/core/spec/models/spree/ability_spec.rb
@@ -53,7 +53,7 @@ describe Spree::Ability, :type => :model do
     let(:resource) { Object.new }
 
     context 'with admin user' do
-      before(:each) { allow(user).to receive(:has_spree_role?).and_return(true) }
+      let(:user) { build :admin_user }
       it_should_behave_like 'access granted'
       it_should_behave_like 'index allowed'
     end


### PR DESCRIPTION
Following the PermissionSet work (#136) we had some permissions hardcoded into Spree::Ability, and then configurable permissions in the RoleConfiguration object. Hardcoded rules were the full access on all objects for the admin user, and the rules needed for a normal customer.

This adds an implicit `'default'` role, which is given to all users, and two new `PermissionSets`: `DefaultCustomer` and `SuperUser`.

This required changing any of stubs of
``` ruby
allow(user).to receive(:has_spree_role?).with('admin').and_return(false)
```
to use real objects, which is better, but may require fixing in others' test suites.

cc @Senjai who I've already talked this over a bit with