### PR TITLE
Remove unused Order#update_line_items method

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -594,19 +594,6 @@ module Spree
       !approved?
     end
 
-    # moved from api order_decorator. This is a better place for it.
-    def update_line_items(line_item_params)
-      return if line_item_params.blank?
-      line_item_params.each_value do |attributes|
-        if attributes[:id].present?
-          self.line_items.find(attributes[:id]).update_attributes!(attributes)
-        else
-          self.line_items.create!(attributes)
-        end
-      end
-      self.ensure_updated_shipments
-    end
-
     def reload(options=nil)
       remove_instance_variable(:@tax_zone) if defined?(@tax_zone)
       super


### PR DESCRIPTION
Usage of this method was removed here:
https://github.com/solidusio/solidus/commit/8004327
and here:
https://github.com/solidusio/solidus/commit/8702342
but the method never got removed.

It also has no test coverage.

We can deprecate this instead if people think that would be better.