### PR TITLE
Skip shipment creation for unreturned exchanges

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -516,6 +516,8 @@ module Spree
     end
 
     def create_proposed_shipments
+      return self.shipments if unreturned_exchange? && shipments.all?(&:shipped?)
+
       if completed?
         raise CannotRebuildShipments.new(Spree.t(:cannot_rebuild_shipments_order_completed))
       elsif shipments.any? { |s| !s.pending? }

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -131,6 +131,7 @@ module Spree
     end
 
     def finalize!
+      return if order.unreturned_exchange?
       InventoryUnit.finalize_units!(inventory_units)
       manifest.each { |item| manifest_unstock(item) }
     end

--- a/core/lib/spree/core/unreturned_item_charger.rb
+++ b/core/lib/spree/core/unreturned_item_charger.rb
@@ -25,9 +25,9 @@ module Spree
       set_shipment_for_new_order
 
       new_order.reload.update!
-      while new_order.state != new_order.checkout_steps[-2] && new_order.next; end
-
       set_order_payment
+
+      while new_order.state != new_order.checkout_steps[-2] && new_order.next; end
 
       new_order.contents.approve(name: self.class.name)
       new_order.reload.complete!
@@ -61,7 +61,6 @@ module Spree
     def set_shipment_for_new_order
       new_order.shipments.destroy_all
       @shipment.update_attributes!(order_id: new_order.id)
-      new_order.update_attributes!(state: "confirm")
     end
 
     def set_order_payment

--- a/core/lib/spree/core/unreturned_item_charger.rb
+++ b/core/lib/spree/core/unreturned_item_charger.rb
@@ -27,6 +27,7 @@ module Spree
       new_order.reload.update!
       set_order_payment
 
+      # Transitions will call update_totals on the order
       while new_order.state != new_order.checkout_steps[-2] && new_order.next; end
 
       new_order.contents.approve(name: self.class.name)

--- a/core/lib/spree/core/unreturned_item_charger.rb
+++ b/core/lib/spree/core/unreturned_item_charger.rb
@@ -22,15 +22,12 @@ module Spree
       new_order.associate_user!(@original_order.user) if @original_order.user
 
       add_exchange_variants_to_order
+      set_shipment_for_new_order
 
       new_order.reload.update!
       while new_order.state != new_order.checkout_steps[-2] && new_order.next; end
 
       set_order_payment
-
-      # the order builds a shipment on its own on transition to delivery, but we want
-      # the original exchange shipment, not the built one
-      set_shipment_for_new_order
 
       new_order.contents.approve(name: self.class.name)
       new_order.reload.complete!

--- a/core/spec/lib/spree/core/unreturned_item_charger_spec.rb
+++ b/core/spec/lib/spree/core/unreturned_item_charger_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+describe Spree::UnreturnedItemCharger do
+  let(:shipped_order) { create(:shipped_order, line_items_count: 1, with_cartons: false) }
+  let(:original_shipment) { shipped_order.shipments.first }
+  let(:original_stock_location) { original_shipment.stock_location }
+  let(:original_inventory_unit) { shipped_order.inventory_units.first }
+  let(:original_variant) { original_inventory_unit.variant }
+  let(:exchange_shipment) do
+    create(:shipment,
+           order: shipped_order,
+           state: 'shipped',
+           stock_location: original_stock_location,
+           created_at: 5.days.ago)
+  end
+  let(:exchange_inventory_unit) { exchange_shipment.inventory_units.first }
+  let(:return_item) do
+    create(:exchange_return_item,
+           inventory_unit: original_inventory_unit,
+           exchange_inventory_unit: exchange_inventory_unit)
+  end
+
+  let!(:unreturned_item_charger) { Spree::UnreturnedItemCharger.new(exchange_shipment, [return_item]) }
+
+  before do
+    exchange_inventory_unit.ship!
+  end
+
+  describe "#charge_for_items" do
+    before do
+      original_variant.update_attributes!(track_inventory: true)
+      original_variant.stock_items.update_all(backorderable: false)
+    end
+
+    subject { unreturned_item_charger.charge_for_items }
+
+    context "item is now out of stock" do
+      before do
+        original_variant.stock_items.map { |si| si.set_count_on_hand(0) }
+      end
+
+      it "creates a new completed order" do
+        expect { subject }.to change { Spree::Order.count }.by(1)
+        new_order = exchange_inventory_unit.shipment.order.reload
+        expect(new_order).to_not eq(shipped_order)
+        expect(new_order.completed?).to eq true
+      end
+    end
+  end
+end

--- a/core/spec/lib/spree/core/unreturned_item_charger_spec.rb
+++ b/core/spec/lib/spree/core/unreturned_item_charger_spec.rb
@@ -34,6 +34,26 @@ describe Spree::UnreturnedItemCharger do
 
     subject { unreturned_item_charger.charge_for_items }
 
+    context "new order is not an unreturned exchange" do
+      before do
+        allow_any_instance_of(Spree::Shipment).to receive(:update_attributes!)
+      end
+
+      it "raises an error" do
+        expect { subject }.to raise_error(Spree::UnreturnedItemCharger::ChargeFailure, 'order is not an unreturned exchange')
+      end
+    end
+
+    context "there's an error transitioning the new order's state" do
+      before do
+        allow_any_instance_of(Spree::Order).to receive(:next).and_return(false)
+      end
+
+      it "raises an error" do
+        expect { subject }.to raise_error(Spree::UnreturnedItemCharger::ChargeFailure, 'order did not reach the confirm state')
+      end
+    end
+
     context "item is now out of stock" do
       before do
         original_variant.stock_items.map { |si| si.set_count_on_hand(0) }


### PR DESCRIPTION
This change fixes a bug whereby the UnreturnedItemCharger would fail to create a new order when any of the variants in the new order was out of stock. Since the shipment has already shipped, no verification for stock quantity is required.