### PR TITLE
Fix error when destination is not defined on a stock transfer

### DIFF
--- a/backend/app/views/spree/admin/stock_transfers/show.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/show.html.erb
@@ -15,7 +15,7 @@
     <h6>
       <span><%= @stock_transfer.source_location.admin_name %></span>
       <span class='arrow'>&rarr;</span>
-      <span><%= @stock_transfer.destination_location.admin_name %></span>
+      <span><%= @stock_transfer.destination_location.try!(:admin_name) %></span>
     </h6>
   </div>
 

--- a/backend/spec/features/admin/stock_transfer_spec.rb
+++ b/backend/spec/features/admin/stock_transfer_spec.rb
@@ -33,6 +33,24 @@ describe 'Stock Transfers', :type => :feature, :js => true do
     end
   end
 
+  describe 'view a stock transfer' do
+    let(:stock_transfer) do
+      create(:stock_transfer_with_items,
+             source_location: source_location,
+             destination_location: nil,
+             description: "Test stock transfer")
+    end
+    let(:source_location) { create(:stock_location, name: 'SF') }
+
+    context "stock transfer does not have a destination" do
+      it 'displays the stock transfer details' do
+        visit spree.admin_stock_transfer_path(stock_transfer)
+        expect(page).to have_content("SF")
+        expect(page).to have_content("Test stock transfer")
+      end
+    end
+  end
+
   describe 'ship stock transfer' do
     let(:stock_transfer) { create(:stock_transfer_with_items) }
 

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -812,6 +812,8 @@ en:
       no_longer_change_items: You will no longer be able to add or edit any transfer items
     find_a_taxon: Find a Taxon
     finalized: Finalized
+    finalized_at: Finalized at
+    finalized_by: Finalized by
     close_stock_transfer:
       will_cause: Closing a stock transfer will cause the following
       no_longer_edit: You will no longer be able to edit the stock transfer in any way


### PR DESCRIPTION
Stock transfers can be viewed before the destination is selected. This will prevent an error from being thrown when the destination is not yet defined.