### PR TITLE
Touch associated product when its option types change.

### DIFF
--- a/core/app/models/spree/product_option_type.rb
+++ b/core/app/models/spree/product_option_type.rb
@@ -1,6 +1,6 @@
 module Spree
   class ProductOptionType < Spree::Base
-    belongs_to :product, class_name: 'Spree::Product', inverse_of: :product_option_types
+    belongs_to :product, class_name: 'Spree::Product', inverse_of: :product_option_types, touch: true
     belongs_to :option_type, class_name: 'Spree::OptionType', inverse_of: :product_option_types
     acts_as_list scope: :product
   end

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -242,9 +242,26 @@ describe Spree::Product, :type => :model do
 
         expect(product2.slug).to eq 'test-456'
       end
-
     end
 
+    context "associations" do
+      describe "product_option_types" do
+        it "touches the product instance when an option type is added" do
+          expect {
+            product.product_option_types.create(option_type: create(:option_type, name: 'new-option-type'))
+            product.reload
+          }.to change { product.updated_at }
+        end
+
+        it "touches product instance when an option type is removed" do
+          product.product_option_types.create(option_type: create(:option_type, name: 'new-option-type'))
+          expect {
+            product.product_option_types = []
+            product.reload
+          }.to change { product.updated_at }
+        end
+      end
+    end
   end
 
   context "properties" do
@@ -432,7 +449,7 @@ describe Spree::Product, :type => :model do
       expect(product.reload.total_on_hand).to eql(5)
     end
   end
-  
+
   # Regression spec for https://github.com/spree/spree/issues/5588
   context '#validate_master when duplicate SKUs entered' do
     let!(:first_product) { create(:product, sku: 'a-sku') }


### PR DESCRIPTION
There may be use cases where we want to react to changes to a product's option types. For example, category items may do some expensive calculations that involve its associated product's (i.e., categorizable) option types.

@magnusvk , @athal7, following up with our conversation on Friday, there are scenarios when these touches won't happen, but verified that they're typical AR (e.g., `product.product_option_types.delete` will not trigger callback but product.product_option_types.destroy will). 