### PR TITLE
Configurable variant search class

### DIFF
--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -238,6 +238,11 @@ module Spree
       @searcher_class ||= Spree::Core::Search::Base
     end
 
+    attr_writer :variant_search_class
+    def variant_search_class
+      @variant_search_class ||= Spree::Core::Search::Variant
+    end
+
     # promotion_chooser_class allows extensions to provide their own PromotionChooser
     attr_writer :promotion_chooser_class
     def promotion_chooser_class

--- a/core/lib/spree/core/search/variant.rb
+++ b/core/lib/spree/core/search/variant.rb
@@ -36,7 +36,13 @@ module Spree
 
         private
 
+        # Returns an array of search term symbols that will be passed to Ransack
+        # to query the DB for the given word.
         # Subclasses may override this to allow conditional filtering, etc.
+        #
+        # @param word [String] One of the search words provided by the user.
+        #   e.g. a SKU
+        # @return [Array<Symbol>] the list of search terms to use for this word
         def search_terms(word)
           self.class.search_terms
         end

--- a/core/lib/spree/core/search/variant.rb
+++ b/core/lib/spree/core/search/variant.rb
@@ -40,6 +40,7 @@ module Spree
         # to query the DB for the given word.
         # Subclasses may override this to allow conditional filtering, etc.
         #
+        # @api public
         # @param word [String] One of the search words provided by the user.
         #   e.g. a SKU
         # @return [Array<Symbol>] the list of search terms to use for this word

--- a/core/lib/spree/core/search/variant.rb
+++ b/core/lib/spree/core/search/variant.rb
@@ -28,7 +28,7 @@ module Spree
           return @scope if @query_string.blank?
 
           matches = @query_string.split.map do |word|
-            @scope.ransack(search_terms(word)).result.pluck(:id)
+            @scope.ransack(search_term_params(word)).result.pluck(:id)
           end
 
           Spree::Variant.where(id: matches.inject(:&))
@@ -36,8 +36,13 @@ module Spree
 
         private
 
+        # Subclasses may override this to allow conditional filtering, etc.
         def search_terms(word)
-          terms = Hash[self.class.search_terms.map { |t| [t, word] }]
+          self.class.search_terms
+        end
+
+        def search_term_params(word)
+          terms = Hash[search_terms(word).map { |t| [t, word] }]
           terms.merge(m: 'or')
         end
       end

--- a/core/spec/lib/search/variant_spec.rb
+++ b/core/spec/lib/search/variant_spec.rb
@@ -88,5 +88,25 @@ module Spree
         it { assert_found("5000", variant) }
       end
     end
+
+    describe '#search_terms' do
+      # Only search by SKU if the search word is a number
+      class NumericSkuSearcher < Core::Search::Variant
+        protected
+        def search_terms(word)
+          if word =~ /\A\d+\z/
+            super
+          else
+            super - [:sku_cont]
+          end
+        end
+      end
+
+      let!(:numeric_sku_variant) { FactoryGirl.create(:variant, product: product, sku: "123") }
+      let!(:non_numeric_sku_variant) { FactoryGirl.create(:variant, product: product, sku: "abc") }
+
+      it { expect(NumericSkuSearcher.new('123').results).to include numeric_sku_variant }
+      it { expect(NumericSkuSearcher.new('abc').results).not_to include non_numeric_sku_variant }
+    end
   end
 end

--- a/core/spec/models/spree/app_configuration_spec.rb
+++ b/core/spec/models/spree/app_configuration_spec.rb
@@ -17,4 +17,8 @@ describe Spree::AppConfiguration, :type => :model do
     expect(prefs.searcher_class).to eq Spree::Core::Search::Base
   end
 
+  it "uses variant search class by default" do
+    expect(prefs.variant_search_class).to eq Spree::Core::Search::Variant
+  end
+
 end


### PR DESCRIPTION
Just like base search class.

We need to work around what I consider a Ransack bug and this was the best way I could think of to allow us to do that cleanly, since it seems like a reasonable thing to do anyway and is nice and specific.

The 'Ransack bug' is that if you add numeric fields to the list of `search_terms` (we add some numeric fields in our app) and then a user supplies a search term that is a really big number (most likely intented to match one of the *string* fields) then the searcher will blow up.

e.g. this is fine:
```ruby
>> Spree::Order.where(id: 'a999999999999999999999999999').first
=> nil
```
but this blows up:
```ruby
>> Spree::Order.where(id: '999999999999999999999999999').first
RangeError: 999999999999999999999999999 is out of range for ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Integer with limit 4
```