### PR TITLE
Introduce customization hook for create_proposed_shipments

### DIFF
--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -244,6 +244,12 @@ module Spree
       @promotion_chooser_class ||= Spree::PromotionChooser
     end
 
+    # Allow stores to manipulate the generated shipments' shipping method
+    attr_writer :proposed_shipments_shipping_method_handler
+    def proposed_shipments_shipping_method_handler
+      @proposed_shipments_shipping_method_handler ||= ->(proposed_shipments, original_shipping_methods) { }
+    end
+
     def static_model_preferences
       @static_model_preferences ||= Spree::Preferences::StaticModelPreferences.new
     end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -13,7 +13,6 @@ module Spree
     include Spree::Order::Payments
 
     class InsufficientStock < StandardError; end
-    class CannotRebuildShipments < StandardError; end
 
     extend Spree::DisplayMoney
     money_methods :outstanding_balance, :item_total, :adjustment_total,
@@ -516,15 +515,7 @@ module Spree
     end
 
     def create_proposed_shipments
-      if completed?
-        raise CannotRebuildShipments.new(Spree.t(:cannot_rebuild_shipments_order_completed))
-      elsif shipments.any? { |s| !s.pending? }
-        raise CannotRebuildShipments.new(Spree.t(:cannot_rebuild_shipments_shipments_not_pending))
-      else
-        adjustments.shipping.destroy_all
-        shipments.destroy_all
-        self.shipments = Spree::Stock::Coordinator.new(self).shipments
-      end
+      self.shipments = Spree::Shipment::ProposedShipmentsCreator.new(self).shipments
     end
 
     def apply_free_shipping_promotions

--- a/core/app/models/spree/shipment/proposed_shipments_creator.rb
+++ b/core/app/models/spree/shipment/proposed_shipments_creator.rb
@@ -3,11 +3,6 @@ class Spree::Shipment::ProposedShipmentsCreator
 
   class CannotRebuildShipments < StandardError; end
 
-  class_attribute :shipping_method_handler
-  # Customization hook to allow stores to manipulate
-  # the generated shipments' shipping method
-  self.shipping_method_handler = ->(proposed_shipments, original_shipping_methods) { }
-
   def initialize(order)
     @order = order
     @original_shipping_methods = order.shipments.map(&:shipping_method).compact.uniq
@@ -22,7 +17,7 @@ class Spree::Shipment::ProposedShipmentsCreator
       order.adjustments.shipping.destroy_all
       order.shipments.destroy_all
       proposed_shipments = Spree::Stock::Coordinator.new(order).shipments
-      self.shipping_method_handler.call(proposed_shipments, original_shipping_methods)
+      Spree::Config.proposed_shipments_shipping_method_handler.call(proposed_shipments, original_shipping_methods)
       proposed_shipments
     end
   end

--- a/core/app/models/spree/shipment/proposed_shipments_creator.rb
+++ b/core/app/models/spree/shipment/proposed_shipments_creator.rb
@@ -1,0 +1,29 @@
+class Spree::Shipment::ProposedShipmentsCreator
+  attr_reader :order, :original_shipping_methods
+
+  class CannotRebuildShipments < StandardError; end
+
+  class_attribute :shipping_method_handler
+  # Customization hook to allow stores to manipulate
+  # the generated shipments' shipping method
+  self.shipping_method_handler = ->(proposed_shipments, original_shipping_methods) { }
+
+  def initialize(order)
+    @order = order
+    @original_shipping_methods = order.shipments.map(&:shipping_method).compact.uniq
+  end
+
+  def shipments
+    if order.completed?
+      raise CannotRebuildShipments.new(Spree.t(:cannot_rebuild_shipments_order_completed))
+    elsif order.shipments.any? { |s| !s.pending? }
+      raise CannotRebuildShipments.new(Spree.t(:cannot_rebuild_shipments_shipments_not_pending))
+    else
+      order.adjustments.shipping.destroy_all
+      order.shipments.destroy_all
+      proposed_shipments = Spree::Stock::Coordinator.new(order).shipments
+      self.shipping_method_handler.call(proposed_shipments, original_shipping_methods)
+      proposed_shipments
+    end
+  end
+end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -901,33 +901,11 @@ describe Spree::Order, :type => :model do
   end
 
   describe "#create_proposed_shipments" do
-    it "assigns the coordinator returned shipments to its shipments" do
+    it "assigns the proposed shipment creator returned shipments to its shipments" do
       shipment = build(:shipment)
-      allow_any_instance_of(Spree::Stock::Coordinator).to receive(:shipments).and_return([shipment])
+      allow_any_instance_of(Spree::Shipment::ProposedShipmentsCreator).to receive(:shipments).and_return([shipment])
       subject.create_proposed_shipments
       expect(subject.shipments).to eq [shipment]
-    end
-
-    it "raises an error if any shipments are ready" do
-      shipment = create(:shipment, order: subject, state: "ready")
-      expect {
-        expect {
-          subject.create_proposed_shipments
-        }.to raise_error(Spree::Order::CannotRebuildShipments)
-      }.not_to change { subject.reload.shipments }
-
-      expect { shipment.reload }.not_to raise_error
-    end
-
-    it "raises an error if any shipments are shipped" do
-      shipment = create(:shipment, order: subject, state: "shipped")
-      expect {
-        expect {
-          subject.create_proposed_shipments
-        }.to raise_error(Spree::Order::CannotRebuildShipments)
-      }.not_to change { subject.reload.shipments }
-
-      expect { shipment.reload }.not_to raise_error
     end
   end
 

--- a/core/spec/models/spree/shipment/proposed_shipments_creator_spec.rb
+++ b/core/spec/models/spree/shipment/proposed_shipments_creator_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+
+describe Spree::Shipment::ProposedShipmentsCreator do
+  let(:order) { create(:order_with_line_items) }
+  let(:shipment_creator) { Spree::Shipment::ProposedShipmentsCreator.new(order) }
+
+  describe "#shipments" do
+
+    subject { shipment_creator.shipments }
+
+    it "assigns the coordinator returned shipments to its shipments" do
+      shipment = build(:shipment)
+      allow_any_instance_of(Spree::Stock::Coordinator).to receive(:shipments).and_return([shipment])
+      expect(subject).to eq [shipment]
+    end
+
+    it "raises an error if any shipments are ready" do
+      shipment = create(:shipment, order: order, state: "ready")
+      expect {
+        expect {
+          subject
+        }.to raise_error(Spree::Shipment::ProposedShipmentsCreator::CannotRebuildShipments)
+      }.not_to change { order.reload.shipments }
+
+      expect { shipment.reload }.not_to raise_error
+    end
+
+    it "raises an error if any shipments are shipped" do
+      shipment = create(:shipment, order: order, state: "shipped")
+      expect {
+        expect {
+          subject
+        }.to raise_error(Spree::Shipment::ProposedShipmentsCreator::CannotRebuildShipments)
+      }.not_to change { order.reload.shipments }
+
+      expect { shipment.reload }.not_to raise_error
+    end
+
+    context "shipping method handler is defined" do
+      before do
+        Spree::Shipment::ProposedShipmentsCreator.shipping_method_handler = -> (proposed_shipments, original_shipping_methods) { raise "TestError" }
+      end
+
+      after do
+        Spree::Shipment::ProposedShipmentsCreator.shipping_method_handler = -> (proposed_shipments, original_shipping_methods) { }
+      end
+
+      it "calls the shipping method handler after the shipments are created" do
+        shipment = build(:shipment)
+        allow_any_instance_of(Spree::Stock::Coordinator).to receive(:shipments).and_return([shipment])
+        expect { subject }.to raise_error("TestError")
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/shipment/proposed_shipments_creator_spec.rb
+++ b/core/spec/models/spree/shipment/proposed_shipments_creator_spec.rb
@@ -38,11 +38,11 @@ describe Spree::Shipment::ProposedShipmentsCreator do
 
     context "shipping method handler is defined" do
       before do
-        Spree::Shipment::ProposedShipmentsCreator.shipping_method_handler = -> (proposed_shipments, original_shipping_methods) { raise "TestError" }
+        Spree::Config.proposed_shipments_shipping_method_handler = -> (proposed_shipments, original_shipping_methods) { raise "TestError" }
       end
 
       after do
-        Spree::Shipment::ProposedShipmentsCreator.shipping_method_handler = -> (proposed_shipments, original_shipping_methods) { }
+        Spree::Config.proposed_shipments_shipping_method_handler = -> (proposed_shipments, original_shipping_methods) { }
       end
 
       it "calls the shipping method handler after the shipments are created" do


### PR DESCRIPTION
The change introduces a customization hook that allows stores to manipulate the shipments generated by Spree::Stock::Coordinator.

The particular use case for us here is to ensure a selected shipping method (selected by an admin or a user) is preserved even if create_proposed_shipments is called multiple times.