### PR TITLE
[WIP] Fix icon link CSS

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/components/_navigation.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_navigation.scss
@@ -131,6 +131,10 @@ nav.menu {
       }
     }
 
+    &.tab-with-icon {
+      white-space: nowrap;
+    }
+
     &.selected a {
       @extend a:hover;
     }

--- a/backend/app/assets/stylesheets/spree/backend/shared/_tables.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_tables.scss
@@ -36,6 +36,7 @@ table {
       background-color: transparent;
       border: none !important;
       text-align: center;
+      white-space: nowrap;
 
       span.text {
         font-size: $body-font-size;

--- a/backend/app/assets/stylesheets/spree/backend/shared/_tables.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_tables.scss
@@ -41,15 +41,15 @@ table {
         font-size: $body-font-size;
       }
 
-      [class*='fa-'].no-text {
+      .icon_link.no-text {
         font-size: 120%;
         background-color: very-light($color-3);
         border: 1px solid $color-border;
         border-radius: 15px;
         width: 29px;
         height: 29px;
+        line-height: 27px;
         display: inline-block;
-        padding-top: 6px;
 
         &:before {
           text-align: center !important;
@@ -62,12 +62,7 @@ table {
         }
       }
 
-      button[class*='fa-'] {
-        color: $color-link;
-        padding: 0 !important;
-      }
-
-      .fa-envelope-alt, .fa-eye-open {
+      .icon_link-envelope-alt, .icon_link-eye-open {
         color: $color-link;
         padding-left: 0px;
 
@@ -76,27 +71,27 @@ table {
           color: $color-1;
         }
       }
-      .fa-trash:hover, .fa-void:hover, .fa-failure:hover {
+      .icon_link-trash:hover, .icon_link-void:hover, .icon_link-failure:hover {
         background-color: $color-error;
         color: $color-1;
       }
-      .fa-cancel:hover {
+      .icon_link-cancel:hover {
         background-color: $color-notice;
         color: $color-1;
       }
-      .fa-edit:hover, .fa-capture:hover, .fa-ok:hover, .fa-plus:hover, .fa-save:hover {
+      .icon_link-edit:hover, .icon_link-capture:hover, .icon_link-ok:hover, .icon_link-plus:hover, .icon_link-save:hover {
         background-color: $color-success;
         color: $color-1;
       }
-      .fa-copy:hover {
+      .icon_link-copy:hover {
         background-color: $color-notice;
         color: $color-1;
       }
-      .fa-thumbs-up:hover {
+      .icon_link-thumbs-up:hover {
         background-color: $color-success;
         color: $color-1;
       }
-      .fa-thumbs-down:hover {
+      .icon_link-thumbs-down:hover {
         background-color: $color-error;
         color: $color-1;
       }

--- a/backend/app/assets/stylesheets/spree/backend/shared/_tables.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_tables.scss
@@ -50,6 +50,7 @@ table {
         height: 29px;
         line-height: 27px;
         display: inline-block;
+        text-align: center;
 
         &:before {
           text-align: center !important;

--- a/backend/app/helpers/spree/admin/navigation_helper.rb
+++ b/backend/app/helpers/spree/admin/navigation_helper.rb
@@ -80,7 +80,7 @@ module Spree
         else
           text = content_tag(:span, text, class: 'text')
         end
-        link_to(icon + text, url, options)
+        link_to(icon + ' ' + text, url, options)
       end
 
       def icon(icon_name)

--- a/backend/app/helpers/spree/admin/navigation_helper.rb
+++ b/backend/app/helpers/spree/admin/navigation_helper.rb
@@ -87,6 +87,10 @@ module Spree
         icon_name ? content_tag(:i, '', :class => icon_name) : ''
       end
 
+      def fa_icon(icon_name)
+        content_tag(:i, '', class: "fa fa-#{icon_name}")
+      end
+
       def button(text, icon_name = nil, button_type = 'submit', options={})
         button_tag(text, options.merge(:type => button_type, :class => "fa fa-#{icon_name} button"))
       end

--- a/backend/app/helpers/spree/admin/navigation_helper.rb
+++ b/backend/app/helpers/spree/admin/navigation_helper.rb
@@ -71,12 +71,16 @@ module Spree
       end
 
       def link_to_with_icon(icon_name, text, url, options = {})
-        options[:class] = (options[:class].to_s + " fa fa-#{icon_name} icon_link with-tip").strip
-        options[:class] += ' no-text' if options[:no_text]
-        options[:title] = text if options[:no_text]
-        text = options[:no_text] ? '' : raw("<span class='text'>#{text}</span>")
-        options.delete(:no_text)
-        link_to(text, url, options)
+        options[:class] = "#{options[:class]} icon_link icon_link-#{icon_name} with-tip"
+        icon = content_tag(:span, '', class: "fa fa-#{icon_name}")
+        if options.delete(:no_text)
+          options[:class] += ' no-text'
+          options[:title] = text
+          text = ''
+        else
+          text = content_tag(:span, text, class: 'text')
+        end
+        link_to(icon + text, url, options)
       end
 
       def icon(icon_name)

--- a/backend/app/views/spree/admin/orders/_shipment.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment.html.erb
@@ -54,9 +54,9 @@
             </td>
             <td class="actions">
               <% if can? :update, shipment %>
-                <%= link_to '', '#', :class => 'save-method fa fa-check no-text with-tip',
+                <%= link_to fa_icon('check'), '#', :class => 'save-method icon_link no-text with-tip',
                   :data => {'shipment-number' => shipment.number, :action => 'save'}, title: Spree.t('actions.save') %>
-                <%= link_to '', '#', :class => 'cancel-method fa fa-cancel no-text with-tip',
+                <%= link_to fa_icon('cancel'), '#', :class => 'cancel-method icon_link no-text with-tip',
                   :data => {:action => 'cancel'}, :title => Spree.t('actions.cancel') %>
               <% end %>
             </td>
@@ -77,7 +77,7 @@
 
             <td class="actions">
               <% if( (can? :update, shipment) and !shipment.shipped?) %>
-                <%= link_to '', '#', :class => 'edit-method fa fa-edit no-text with-tip', :data => {:action => 'edit'}, :title => Spree.t('edit') %>
+                <%= link_to fa_icon('edit'), '#', :class => 'edit-method icon_link no-text with-tip', :data => {:action => 'edit'}, :title => Spree.t('edit') %>
               <% end %>
             </td>
           </tr>
@@ -89,8 +89,8 @@
           </td>
           <td class="actions">
             <% if can? :update, shipment %>
-              <%= link_to '', '#', :class => 'save-tracking fa fa-check no-text with-tip', :data => {'shipment-number' => shipment.number, :action => 'save'}, :title => Spree.t('actions.save') %>
-              <%= link_to '', '#', :class => 'cancel-tracking fa fa-cancel no-text with-tip', :data => {:action => 'cancel'}, :title => Spree.t('actions.cancel') %>
+              <%= link_to fa_icon('check'), '#', :class => 'save-tracking icon_link no-text with-tip', :data => {'shipment-number' => shipment.number, :action => 'save'}, :title => Spree.t('actions.save') %>
+              <%= link_to fa_icon('cancel'), '#', :class => 'cancel-tracking icon_link no-text with-tip', :data => {:action => 'cancel'}, :title => Spree.t('actions.cancel') %>
             <% end %>
           </td>
         </tr>
@@ -113,7 +113,7 @@
           </td>
           <td class="actions">
             <% if can? :update, shipment %>
-              <%= link_to '', '#', :class => 'edit-tracking fa fa-edit no-text with-tip', :data => {:action => 'edit'}, :title => Spree.t('edit') %>
+              <%= link_to fa_icon('edit'), '#', :class => 'edit-tracking icon_link no-text with-tip', :data => {:action => 'edit'}, :title => Spree.t('edit') %>
             <% end %>
           </td>
         </tr>

--- a/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
@@ -22,10 +22,10 @@
 
     <td class="cart-item-delete actions" data-hook="cart_item_delete">
       <% if can? :update, item %>
-        <%= link_to '', '#', :class => 'save-item fa fa-check no-text with-tip', :data => {'shipment-number' => shipment_number, 'variant-id' => item.variant.id, :action => 'save'}, :title => Spree.t('actions.save'), :style => 'display: none' %>
-        <%= link_to '', '#', :class => 'cancel-item fa fa-cancel no-text with-tip', :data => {:action => 'cancel'}, :title => Spree.t('actions.cancel'), :style => 'display: none' %>
-        <%= link_to '', '#', :class => 'split-item icon_link fa fa-arrows-h no-text with-tip', :data => {:action => 'split', 'variant-id' => item.variant.id}, :title => Spree.t('split') %>
-        <%= link_to '', '#', :class => 'delete-item fa fa-trash no-text with-tip', :data => { 'shipment-number' => shipment_number, 'variant-id' => item.variant.id, :action => 'remove'}, :title => Spree.t('delete') %>
+        <%= link_to fa_icon('check'), '#', :class => 'save-item icon_link no-text with-tip', :data => {'shipment-number' => shipment_number, 'variant-id' => item.variant.id, :action => 'save'}, :title => Spree.t('actions.save'), :style => 'display: none' %>
+        <%= link_to fa_icon('cancel'), '#', :class => 'cancel-item icon_link no-text with-tip', :data => {:action => 'cancel'}, :title => Spree.t('actions.cancel'), :style => 'display: none' %>
+        <%= link_to fa_icon('arrows-h'), '#', :class => 'split-item icon_link no-text with-tip', :data => {:action => 'split', 'variant-id' => item.variant.id}, :title => Spree.t('split') %>
+        <%= link_to fa_icon('trash'), '#', :class => 'delete-item icon_link no-text with-tip', :data => { 'shipment-number' => shipment_number, 'variant-id' => item.variant.id, :action => 'remove'}, :title => Spree.t('delete') %>
       <% end %>
     </td>
   </tr>

--- a/backend/app/views/spree/admin/products/index.html.erb
+++ b/backend/app/views/spree/admin/products/index.html.erb
@@ -83,9 +83,7 @@
             <td class="align-center"><%= product.display_price.to_html rescue '' %></td>
             <td class="actions" data-hook="admin_products_index_row_actions">
               <%= link_to_edit product, :no_text => true, :class => 'edit' if can?(:edit, product) && !product.deleted? %>
-              &nbsp;
               <%= link_to_clone product, :no_text => true, :class => 'clone' if can?(:clone, product) %>
-              &nbsp;
               <%= link_to_delete product, :no_text => true if can?(:delete, product) && !product.deleted? %>
             </td>
           </tr>

--- a/backend/app/views/spree/admin/variants/index.html.erb
+++ b/backend/app/views/spree/admin/variants/index.html.erb
@@ -81,7 +81,6 @@
             <%= link_to_edit(variant, :no_text => true) unless variant.deleted? %>
           <% end %>
           <% if can?(:destroy, variant) %>
-            &nbsp;
             <%= link_to_delete(variant, :no_text => true) unless variant.deleted? %>
           <% end %>
         </td>


### PR DESCRIPTION
_PR in early stages to demonstrate the issue. Some of this was done as lazily as possible and needs more cleanup._

Currently in Solidus icons are used like this:
```html
<!-- Circle button -->
<a href="..." class="edit-tracking fa fa-edit icon_link with-tip no-text"></a>

<!-- Button with text -->
<a href="..." class="new-thingy button fa fa-plus icon_link with-tip">New Thingy</a>
```

This requires a number of hacks to make work, since the `fa`, `fa-*` classes were never intended to be used in this way. This makes it very difficult to center or space the icons properly, and makes it impossible to use the `:before` selector on these links. The correct use should be

```html
<a href="..." class="edit-tracking icon_link with-tip no-text">
  <i class="fa fa-edit"></i>
</a>

<a href="..." class="new-thingy button icon_link with-tip">
  <i class="fa fa-plus"></i> New thingy
</a>
```

Which exposes another problem: the colorization of the link on hover is based on the name of the icon used. This should probably be changed to something more semantic (maybe `icon-link-error/notice/success`).