### PR TITLE
Flesh out the returns permissions for order display/management

### DIFF
--- a/core/app/models/spree/permission_sets/order_display.rb
+++ b/core/app/models/spree/permission_sets/order_display.rb
@@ -9,6 +9,10 @@ module Spree
         can [:display, :admin], Spree::LineItem
         can [:display, :admin], Spree::ReturnAuthorization
         can [:display, :admin], Spree::CustomerReturn
+        can [:display, :admin], Spree::OrderCancellations
+        can [:display, :admin], Spree::Reimbursement
+        can [:display, :admin], Spree::ReturnItem
+        can [:display, :admin], Spree::Refund
       end
     end
   end

--- a/core/app/models/spree/permission_sets/order_management.rb
+++ b/core/app/models/spree/permission_sets/order_management.rb
@@ -11,6 +11,9 @@ module Spree
         can :manage, Spree::ReturnAuthorization
         can :manage, Spree::CustomerReturn
         can :manage, Spree::OrderCancellations
+        can :manage, Spree::Reimbursement
+        can :manage, Spree::ReturnItem
+        can :manage, Spree::Refund
       end
     end
   end

--- a/core/spec/models/spree/permission_sets/order_display_spec.rb
+++ b/core/spec/models/spree/permission_sets/order_display_spec.rb
@@ -26,6 +26,9 @@ describe Spree::PermissionSets::OrderDisplay do
     it { is_expected.to be_able_to(:admin, Spree::CustomerReturn) }
     it { is_expected.to be_able_to(:edit, Spree::Order) }
     it { is_expected.to be_able_to(:cart, Spree::Order) }
+    it { is_expected.to be_able_to(:display, Spree::Reimbursement) }
+    it { is_expected.to be_able_to(:display, Spree::ReturnItem) }
+    it { is_expected.to be_able_to(:display, Spree::Refund) }
   end
 
   context "when not activated" do
@@ -44,6 +47,9 @@ describe Spree::PermissionSets::OrderDisplay do
     it { is_expected.not_to be_able_to(:admin, Spree::ReturnAuthorization) }
     it { is_expected.not_to be_able_to(:admin, Spree::CustomerReturn) }
     it { is_expected.not_to be_able_to(:cart, Spree::Order) }
+    it { is_expected.not_to be_able_to(:display, Spree::Reimbursement) }
+    it { is_expected.not_to be_able_to(:display, Spree::ReturnItem) }
+    it { is_expected.not_to be_able_to(:display, Spree::Refund) }
   end
 end
 

--- a/core/spec/models/spree/permission_sets/order_management_spec.rb
+++ b/core/spec/models/spree/permission_sets/order_management_spec.rb
@@ -19,6 +19,9 @@ describe Spree::PermissionSets::OrderManagement do
     it { is_expected.to be_able_to(:manage, Spree::CustomerReturn) }
     it { is_expected.to be_able_to(:display, Spree::ReimbursementType) }
     it { is_expected.to be_able_to(:manage, Spree::OrderCancellations) }
+    it { is_expected.to be_able_to(:manage, Spree::Reimbursement) }
+    it { is_expected.to be_able_to(:manage, Spree::ReturnItem) }
+    it { is_expected.to be_able_to(:manage, Spree::Refund) }
   end
 
   context "when not activated" do
@@ -31,6 +34,9 @@ describe Spree::PermissionSets::OrderManagement do
     it { is_expected.not_to be_able_to(:manage, Spree::CustomerReturn) }
     it { is_expected.not_to be_able_to(:display, Spree::ReimbursementType) }
     it { is_expected.not_to be_able_to(:manage, Spree::OrderCancellations) }
+    it { is_expected.not_to be_able_to(:manage, Spree::Reimbursement) }
+    it { is_expected.not_to be_able_to(:manage, Spree::ReturnItem) }
+    it { is_expected.not_to be_able_to(:manage, Spree::Refund) }
   end
 end
 


### PR DESCRIPTION
There are a few more models required to fully enable returns management
with the order-related permission sets.