### PR TITLE
Fix error handling for Admin::ReimbursementsController#create

### DIFF
--- a/backend/app/controllers/spree/admin/reimbursements_controller.rb
+++ b/backend/app/controllers/spree/admin/reimbursements_controller.rb
@@ -33,6 +33,21 @@ module Spree
         end
       end
 
+      # We don't currently have a real Reimbursement "new" page. And the only
+      # built-in way to create reimburesments via Solidus admin is from the
+      # customer returns admin page via a button that supplies the
+      # "build_from_customer_return" parameter. The "edit" page is not
+      # suitable for use here for that reason as well.
+      # Perhaps we should add a reimbursement new page of some sort.
+      def render_after_create_error
+        flash.keep
+        if request.referer
+          redirect_to request.referer
+        else
+          redirect_to admin_url
+        end
+      end
+
       def load_stock_locations
         @stock_locations = Spree::StockLocation.active
       end


### PR DESCRIPTION
We don't currently have a "new" page we can render, so instead
redirect to the most appropriate place.