### PR TITLE
Update models that don't inherit from Spree::Base

### DIFF
--- a/core/app/models/spree/adjustment_reason.rb
+++ b/core/app/models/spree/adjustment_reason.rb
@@ -1,5 +1,5 @@
 module Spree
-  class AdjustmentReason < ActiveRecord::Base
+  class AdjustmentReason < Spree::Base
     has_many :adjustments, inverse_of: :adjustment_reason
 
     validates :name, presence: true

--- a/core/app/models/spree/carton.rb
+++ b/core/app/models/spree/carton.rb
@@ -1,4 +1,4 @@
-class Spree::Carton < ActiveRecord::Base
+class Spree::Carton < Spree::Base
   belongs_to :address, class_name: 'Spree::Address'
   belongs_to :stock_location, class_name: 'Spree::StockLocation', inverse_of: :cartons
   belongs_to :shipping_method, class_name: 'Spree::ShippingMethod', inverse_of: :cartons

--- a/core/app/models/spree/line_item_action.rb
+++ b/core/app/models/spree/line_item_action.rb
@@ -1,5 +1,5 @@
 module Spree
-  class LineItemAction < ActiveRecord::Base
+  class LineItemAction < Spree::Base
     belongs_to :line_item
     belongs_to :action, class_name: "Spree::PromotionAction"
   end

--- a/core/app/models/spree/option_values_variant.rb
+++ b/core/app/models/spree/option_values_variant.rb
@@ -1,5 +1,5 @@
 module Spree
-  class OptionValuesVariant < ActiveRecord::Base
+  class OptionValuesVariant < Spree::Base
     belongs_to :variant
     belongs_to :option_value
   end

--- a/core/app/models/spree/order_mutex.rb
+++ b/core/app/models/spree/order_mutex.rb
@@ -1,5 +1,5 @@
 module Spree
-  class OrderMutex < ActiveRecord::Base
+  class OrderMutex < Spree::Base
 
     class LockFailed < StandardError; end
 

--- a/core/app/models/spree/order_promotion.rb
+++ b/core/app/models/spree/order_promotion.rb
@@ -3,7 +3,7 @@ module Spree
   #
   # 1. A promotion that a user attempted to apply to their order
   # 2. The specific code that they used
-  class OrderPromotion < ActiveRecord::Base
+  class OrderPromotion < Spree::Base
     self.table_name = 'spree_orders_promotions'
 
     belongs_to :order, class_name: 'Spree::Order'

--- a/core/app/models/spree/order_stock_location.rb
+++ b/core/app/models/spree/order_stock_location.rb
@@ -1,5 +1,5 @@
 module Spree
-  class OrderStockLocation < ActiveRecord::Base
+  class OrderStockLocation < Spree::Base
     belongs_to :variant, class_name: "Spree::Variant"
     belongs_to :stock_location, class_name: "Spree::StockLocation"
     belongs_to :order, class_name: "Spree::Order"

--- a/core/app/models/spree/return_item.rb
+++ b/core/app/models/spree/return_item.rb
@@ -1,5 +1,5 @@
 module Spree
-  class ReturnItem < ActiveRecord::Base
+  class ReturnItem < Spree::Base
 
     INTERMEDIATE_RECEPTION_STATUSES = %i(given_to_customer lost_in_transit shipped_wrong_item short_shipped in_transit)
     COMPLETED_RECEPTION_STATUSES = INTERMEDIATE_RECEPTION_STATUSES + [:received]

--- a/core/app/models/spree/return_reason.rb
+++ b/core/app/models/spree/return_reason.rb
@@ -1,5 +1,5 @@
 module Spree
-  class ReturnReason < ActiveRecord::Base
+  class ReturnReason < Spree::Base
     include Spree::NamedType
 
     has_many :return_authorizations

--- a/core/app/models/spree/role_user.rb
+++ b/core/app/models/spree/role_user.rb
@@ -1,5 +1,5 @@
 module Spree
-  class RoleUser < ActiveRecord::Base
+  class RoleUser < Spree::Base
     self.table_name = "spree_roles_users"
     belongs_to :role, class_name: "Spree::Role"
     belongs_to :user, class_name: Spree::UserClassHandle.new

--- a/core/app/models/spree/store_credit.rb
+++ b/core/app/models/spree/store_credit.rb
@@ -1,4 +1,4 @@
-class Spree::StoreCredit < ActiveRecord::Base
+class Spree::StoreCredit < Spree::Base
   acts_as_paranoid
 
   VOID_ACTION       = 'void'

--- a/core/app/models/spree/store_credit_category.rb
+++ b/core/app/models/spree/store_credit_category.rb
@@ -1,4 +1,4 @@
-class Spree::StoreCreditCategory < ActiveRecord::Base
+class Spree::StoreCreditCategory < Spree::Base
   class_attribute :non_expiring_credit_types
   self.non_expiring_credit_types = [Spree.t("store_credit.non_expiring")]
 

--- a/core/app/models/spree/store_credit_event.rb
+++ b/core/app/models/spree/store_credit_event.rb
@@ -1,5 +1,5 @@
 module Spree
-  class StoreCreditEvent < ActiveRecord::Base
+  class StoreCreditEvent < Spree::Base
     acts_as_paranoid
 
     belongs_to :store_credit

--- a/core/app/models/spree/store_credit_type.rb
+++ b/core/app/models/spree/store_credit_type.rb
@@ -1,5 +1,5 @@
 module Spree
-  class StoreCreditType < ActiveRecord::Base
+  class StoreCreditType < Spree::Base
     DEFAULT_TYPE_NAME = Spree.t("store_credit.expiring")
     has_many :store_credits, class_name: 'Spree::StoreCredit', foreign_key: 'type_id'
   end

--- a/core/app/models/spree/store_credit_update_reason.rb
+++ b/core/app/models/spree/store_credit_update_reason.rb
@@ -1,2 +1,2 @@
-class Spree::StoreCreditUpdateReason < ActiveRecord::Base
+class Spree::StoreCreditUpdateReason < Spree::Base
 end

--- a/core/app/models/spree/store_payment_method.rb
+++ b/core/app/models/spree/store_payment_method.rb
@@ -1,5 +1,5 @@
 module Spree
-  class StorePaymentMethod < ActiveRecord::Base
+  class StorePaymentMethod < Spree::Base
     belongs_to :store, inverse_of: :store_payment_methods
     belongs_to :payment_method, inverse_of: :store_payment_methods
   end

--- a/core/app/models/spree/transfer_item.rb
+++ b/core/app/models/spree/transfer_item.rb
@@ -1,5 +1,5 @@
 module Spree
-  class TransferItem < ActiveRecord::Base
+  class TransferItem < Spree::Base
     acts_as_paranoid
     belongs_to :stock_transfer, inverse_of: :transfer_items
     belongs_to :variant

--- a/core/app/models/spree/unit_cancel.rb
+++ b/core/app/models/spree/unit_cancel.rb
@@ -1,7 +1,7 @@
 # This represents an inventory unit that has been canceled from an order after it has already been completed
 # The reason specifies why it was canceled.
 # This class should encapsulate logic related to canceling inventory after order complete
-class Spree::UnitCancel < ActiveRecord::Base
+class Spree::UnitCancel < Spree::Base
   SHORT_SHIP = 'Short Ship'
   belongs_to :inventory_unit
   has_one :adjustment, as: :source, dependent: :destroy

--- a/core/app/models/spree/user_address.rb
+++ b/core/app/models/spree/user_address.rb
@@ -1,5 +1,5 @@
 module Spree
-  class UserAddress < ActiveRecord::Base
+  class UserAddress < Spree::Base
     belongs_to :user, class_name: UserClassHandle.new, foreign_key: "user_id"
     belongs_to :address, class_name: "Spree::Address"
 

--- a/core/app/models/spree/user_stock_location.rb
+++ b/core/app/models/spree/user_stock_location.rb
@@ -1,5 +1,5 @@
 module Spree
-  class UserStockLocation < ActiveRecord::Base
+  class UserStockLocation < Spree::Base
     belongs_to :user, class_name: Spree::UserClassHandle.new, inverse_of: :user_stock_locations
     belongs_to :stock_location, class_name: "Spree::StockLocation", inverse_of: :user_stock_locations
   end

--- a/core/db/migrate/20130228210442_create_shipping_method_zone.rb
+++ b/core/db/migrate/20130228210442_create_shipping_method_zone.rb
@@ -1,5 +1,5 @@
 class CreateShippingMethodZone < ActiveRecord::Migration
-  class ShippingMethodZone < ActiveRecord::Base
+  class ShippingMethodZone < Spree::Base
     self.table_name = 'shipping_methods_zones'
   end
   def up

--- a/core/db/migrate/20150506181611_create_spree_store_credit_payment_method.rb
+++ b/core/db/migrate/20150506181611_create_spree_store_credit_payment_method.rb
@@ -1,5 +1,5 @@
 class CreateSpreeStoreCreditPaymentMethod < ActiveRecord::Migration
-  class PaymentMethod < ActiveRecord::Base
+  class PaymentMethod < Spree::Base
     self.table_name = 'spree_payment_methods'
     self.inheritance_column = :_type_disabled
   end

--- a/frontend/lib/spree/frontend/preference_rescue.rb
+++ b/frontend/lib/spree/frontend/preference_rescue.rb
@@ -1,5 +1,5 @@
 module Spree
-  class OldPrefs < ActiveRecord::Base
+  class OldPrefs < Spree::Base
     self.table_name = "spree_preferences"
     belongs_to  :owner, :polymorphic => true
     attr_accessor :owner_klass


### PR DESCRIPTION
I happened to notice this while looking at some other stuff.

I don't know of any reason for these not to be Spree::Base other than
they got missed in one way or another (e.g. when store credits code
was pulled into master).