### PR TITLE
Fix spec naming

### DIFF
--- a/core/spec/models/spree/preferences/scoped_store_spec.rb
+++ b/core/spec/models/spree/preferences/scoped_store_spec.rb
@@ -8,7 +8,9 @@ describe Spree::Preferences::ScopedStore, :type => :model do
 
   describe '#store' do
     subject{ scoped_store.store }
-    it{ is_expected.to be Spree::Preferences::Store.instance }
+    it "uses the global preferences instance" do
+      is_expected.to be Spree::Preferences::Store.instance
+    end
   end
 
   context 'stubbed store' do


### PR DESCRIPTION
Without this when running `rspec -f d` I get

```
Spree::Preferences::ScopedStore
 #store
   should equal #<Spree::Preferences::Store:0x007f28735406a8
     @cache=#<ActiveSupport::Cache::FileStore:0x007f288d2a99c0
     @options={}, @cache_path
     ...
```