### PR TITLE
Fix mysql2 version requirement

### DIFF
--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -4,7 +4,7 @@
 source 'https://rubygems.org'
 
 platforms :ruby do
-  gem 'mysql2'
+  gem 'mysql2', '~> 0.3.20'
   gem 'pg'
   gem 'sqlite3'
   gem 'fast_sqlite'

--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -4,6 +4,8 @@
 source 'https://rubygems.org'
 
 platforms :ruby do
+  # Version restriction because AR will not use mysql2 0.4.0
+  # This can be removed when a future version of rails is released
   gem 'mysql2', '~> 0.3.20'
   gem 'pg'
   gem 'sqlite3'


### PR DESCRIPTION
mysql2 has released version 0.4.0, but ActiveRecord 4.2 requires 0.3.x.

This fixes

> Specified 'mysql2' for database adapter, but the gem is not loaded.

See https://github.com/brianmario/mysql2/issues/675

Fixes build in travis: https://travis-ci.org/jhawthorn/solidus/builds/79551102