### PR TITLE
Fix race conditions in flash messages

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/admin.js.erb
+++ b/backend/app/assets/javascripts/spree/backend/admin.js.erb
@@ -34,9 +34,6 @@ jQuery(function($) {
       $('#powerTip').removeClass($(this).data('action'));
     })
 
-  // Make flash messages dissapear
-  setTimeout('$(".flash").fadeOut()', 5000);
-
   // Highlight hovered table column
   $('table tbody tr td.actions').find('a, button').hover(function(){
     var tr = $(this).closest('tr');
@@ -57,16 +54,6 @@ jQuery(function($) {
 
 
 $.fn.visible = function(cond) { this[cond ? 'show' : 'hide' ]() };
-
-show_flash = function(type, message) {
-  var flash_div = $('.flash.' + type);
-  if (flash_div.length == 0) {
-    flash_div = $('<div class="flash ' + type + '" />');
-    $('#wrapper').prepend(flash_div);
-  }
-  flash_div.html(message).show().delay(5000).fadeOut(500);
-}
-
 
 // Apply to individual radio button that makes another element visible when checked
 $.fn.radioControlsVisibilityOfElement = function(dependentElementSelector){

--- a/backend/app/assets/javascripts/spree/backend/flash.coffee
+++ b/backend/app/assets/javascripts/spree/backend/flash.coffee
@@ -1,0 +1,10 @@
+$ ->
+  # Make flash messages dissapear
+  setTimeout('$(".flash").fadeOut()', 5000)
+
+window.show_flash = (type, message) ->
+  flash_div = $(".flash.#{type}")
+  if flash_div.length == 0
+    flash_div = $("<div class=\"flash #{type}\" />")
+    $('#wrapper').prepend(flash_div)
+  flash_div.html(message).show().delay(5000).fadeOut(500)

--- a/backend/app/assets/javascripts/spree/backend/flash.coffee
+++ b/backend/app/assets/javascripts/spree/backend/flash.coffee
@@ -1,10 +1,12 @@
+showTime = 5000
+fadeOutTime = 500
+
 $ ->
   # Make flash messages dissapear
   setTimeout('$(".flash").fadeOut()', 5000)
 
 window.show_flash = (type, message) ->
-  flash_div = $(".flash.#{type}")
-  if flash_div.length == 0
-    flash_div = $("<div class=\"flash #{type}\" />")
-    $('#wrapper').prepend(flash_div)
-  flash_div.html(message).show().delay(5000).fadeOut(500)
+  $flashWrapper = $(".js-flash-wrapper")
+  flash_div = $("<div class=\"flash #{type}\" />")
+  $flashWrapper.prepend(flash_div)
+  flash_div.html(message).show().delay(showTime).fadeOut(fadeOutTime)

--- a/backend/app/assets/javascripts/spree/backend/flash.coffee
+++ b/backend/app/assets/javascripts/spree/backend/flash.coffee
@@ -3,7 +3,12 @@ fadeOutTime = 500
 
 $ ->
   # Make flash messages dissapear
-  setTimeout('$(".flash").fadeOut()', 5000)
+  # We only want to target the flash messages which are initially on the page.
+  # Otherwise we risk hiding messages added by show_flash
+  $initialFlash = $(".flash")
+  setTimeout (->
+    $initialFlash.fadeOut(fadeOutTime)
+  ), showTime
 
 window.show_flash = (type, message) ->
   $flashWrapper = $(".js-flash-wrapper")

--- a/backend/app/assets/stylesheets/spree/backend/components/_messages.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_messages.scss
@@ -25,14 +25,17 @@
   }
 }
 
-.flash, .alert {
+.flash-wrapper {
   position: fixed;
   top: 0;
   left: 0;
   width: 100%;
+  z-index: 1000;
+}
+
+.flash {
   padding: 16px;
   text-align: center;
-  z-index: 1000;
   font-size: 120%;
   color: $color-1;
   font-weight: $font-weight-bold;

--- a/backend/app/views/spree/layouts/admin.html.erb
+++ b/backend/app/views/spree/layouts/admin.html.erb
@@ -11,15 +11,17 @@
   <body class='admin'>
     <div id='wrapper' data-hook>
 
-      <% if flash[:error] %>
-        <div class="flash error"><%= flash[:error] %></div>
-      <% end %>
-      <% if notice %>
-        <div class="flash notice"><%= notice %></div>
-      <% end %>
-      <% if flash[:success] %>
-        <div class="flash success"><%= flash[:success] %></div>
-      <% end %>
+      <div class="flash-wrapper js-flash-wrapper">
+        <% if flash[:error] %>
+          <div class="flash error"><%= flash[:error] %></div>
+        <% end %>
+        <% if notice %>
+          <div class="flash notice"><%= notice %></div>
+        <% end %>
+        <% if flash[:success] %>
+          <div class="flash success"><%= flash[:success] %></div>
+        <% end %>
+      </div>
 
       <div id="progress">
         <div class="wrapper">


### PR DESCRIPTION
_Test errors are real errors._

In [this  build](https://circleci.com/gh/solidusio/solidus/732) from last week failed looking for the text "successfully updated" on the page. Looking at the html (thanks capybara-screenshot!) showed that the flash message should have been there, but was hidden. The message should be shown for 5 whole seconds, so it's really weird for capybara not to have found it in that time.

It turns out that several race conditions can hide the flash early (all messages are hidden 5 seconds after page load and 5 seconds after the last `show_flash` call). So it's likely that ex. any `show_flash` happening around ~4.8 seconds after document ready will be undetectable to capybara.

I've corrected the logic so that only the right flashes are hidden. I've also allowed multiple flashes to be shown at once, stacking most recent on top to least recent on the bottom, so messages should not be missed if they happen in quick succession.

cc @Sinetheta, sage of JS notification popups