### PR TITLE
Allows stores to specify a cutoff time for incomplete orders

### DIFF
--- a/core/app/models/concerns/spree/user_methods.rb
+++ b/core/app/models/concerns/spree/user_methods.rb
@@ -43,6 +43,8 @@ module Spree
       self_orders = self.orders
       self_orders = self_orders.where(frontend_viewable: true) if only_frontend_viewable
       self_orders = self_orders.where(store: store) if store
+      self_orders = self_orders.where('updated_at > ?', Spree::Config.completable_order_updated_cutoff_days.days.ago) if Spree::Config.completable_order_updated_cutoff_days
+      self_orders = self_orders.where('created_at > ?', Spree::Config.completable_order_created_cutoff_days.days.ago) if Spree::Config.completable_order_created_cutoff_days
       last_order = self_orders.order(:created_at).last
       last_order unless last_order.try!(:completed?)
     end

--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -84,6 +84,14 @@ module Spree
     #   @return [Boolean]
     preference :binary_inventory_cache, :boolean, default: false
 
+    # @!attribute [rw] completable_order_created_cutoff
+    #   @return [Integer] the number of days to look back for created orders which get returned to the user as last completed
+    preference :completable_order_created_cutoff_days, :integer, default: nil
+
+    # @!attribute [rw] completable_order_created_cutoff
+    #   @return [Integer] the number of days to look back for updated orders which get returned to the user as last completed
+    preference :completable_order_updated_cutoff_days, :integer, default: nil
+
     # @!attribute [rw] inventory_cache_threshold
     #   Only invalidate product caches when the count on hand for a stock item
     #   falls below or rises about the inventory_cache_threshold.  When undefined, the

--- a/core/spec/models/spree/user_spec.rb
+++ b/core/spec/models/spree/user_spec.rb
@@ -33,6 +33,34 @@ describe Spree::LegacyUser, :type => :model do
       expect(user.last_incomplete_spree_order).to eq nil
     end
 
+    context "with completable_order_created_cutoff set" do
+      before do
+        @original_order_cutoff_preference = Spree::Config.completable_order_created_cutoff_days
+        Spree::Config.completable_order_created_cutoff_days = 1
+      end
+
+      after { Spree::Config.completable_order_created_cutoff_days = @original_order_cutoff_preference }
+
+      it "excludes orders updated outside of the cutoff date" do
+        incomplete_order = create(:order, user: user, created_by: user, created_at: 3.days.ago, updated_at: 2.days.ago)
+        expect(user.last_incomplete_spree_order).to eq nil
+      end
+    end
+
+    context "with completable_order_created_cutoff set" do
+      before do
+        @original_order_cutoff_preference = Spree::Config.completable_order_updated_cutoff_days
+        Spree::Config.completable_order_updated_cutoff_days = 1
+      end
+
+      after { Spree::Config.completable_order_updated_cutoff_days = @original_order_cutoff_preference }
+
+      it "excludes orders updated outside of the cutoff date" do
+        incomplete_order = create(:order, user: user, created_by: user, created_at: 3.days.ago, updated_at: 2.days.ago)
+        expect(user.last_incomplete_spree_order).to eq nil
+      end
+    end
+
     it "chooses the most recently created incomplete order" do
       order_1 = create(:order, user: user, created_at: 1.second.ago)
       order_2 = create(:order, user: user)


### PR DESCRIPTION
The problem being solved is really old and stale orders being returned via the API with strange state, out of stock items, among other issues.