### PR TITLE
Remove method_missing from Spree::Gatway

### DIFF
--- a/core/app/models/spree/gateway.rb
+++ b/core/app/models/spree/gateway.rb
@@ -29,14 +29,6 @@ module Spree
       preferences.to_hash
     end
 
-    def method_missing(method, *args)
-      if provider.nil? || !provider.respond_to?(method)
-        super
-      else
-        provider.send(method, *args)
-      end
-    end
-
     def payment_profiles_supported?
       false
     end

--- a/core/spec/models/spree/gateway_spec.rb
+++ b/core/spec/models/spree/gateway_spec.rb
@@ -5,9 +5,11 @@ describe Spree::Gateway, :type => :model do
     def initialize(options)
     end
 
-    def imaginary_method
-      'imaginary!'
-    end
+    def authorize; 'authorize'; end
+    def purchase; 'purchase'; end
+    def capture; 'capture'; end
+    def void; 'void'; end
+    def credit; 'credit'; end
   end
 
   class TestGateway < Spree::Gateway
@@ -16,8 +18,28 @@ describe Spree::Gateway, :type => :model do
     end
   end
 
-  it "passes through all arguments on a method_missing call" do
-    expect(TestGateway.new.imaginary_method).to eq 'imaginary!'
+  describe 'ActiveMerchant methods' do
+    let(:gateway) { TestGateway.new }
+
+    it "passes through authorize" do
+      expect(gateway.authorize).to eq 'authorize'
+    end
+
+    it "passes through purchase" do
+      expect(gateway.purchase).to eq 'purchase'
+    end
+
+    it "passes through capture" do
+      expect(gateway.capture).to eq 'capture'
+    end
+
+    it "passes through void" do
+      expect(gateway.void).to eq 'void'
+    end
+
+    it "passes through credit" do
+      expect(gateway.credit).to eq 'credit'
+    end
   end
 
   context "fetching payment sources" do


### PR DESCRIPTION
This method missing made it troublesome to develop anything on a
gateway. It also didn't bother to implement respond_to_missing.

This should be redundent with the delegate at the top of the file, which
delegates the standard ActiveMerchant methods to the provider.

``` ruby
delegate :authorize, :purchase, :capture, :void, :credit, to: :provider
```

These are probably the only methods which were used in this way, and
overriding them in subclasses of gateway should still have the same
behaviour.