### PR TITLE
Move all calculations to DB in AdjustmentSource

### DIFF
--- a/core/app/models/concerns/spree/adjustment_source.rb
+++ b/core/app/models/concerns/spree/adjustment_source.rb
@@ -4,7 +4,7 @@ module Spree
 
     included do
       def deals_with_adjustments_for_deleted_source
-        adjustment_scope = self.adjustments.joins(:orders)
+        adjustment_scope = self.adjustments.joins(:order)
 
         # For incomplete orders, remove the adjustment completely.
         adjustment_scope.where(spree_orders: { completed_at: nil }).destroy_all

--- a/core/app/models/concerns/spree/adjustment_source.rb
+++ b/core/app/models/concerns/spree/adjustment_source.rb
@@ -4,20 +4,19 @@ module Spree
 
     included do
       def deals_with_adjustments_for_deleted_source
-        adjustment_scope = self.adjustments.includes(:order).references(:spree_orders)
+        adjustment_scope = self.adjustments.joins(:orders)
 
         # For incomplete orders, remove the adjustment completely.
-        adjustment_scope.where("spree_orders.completed_at IS NULL").destroy_all
+        adjustment_scope.where(spree_orders: { completed_at: nil }).destroy_all
 
         # For complete orders, the source will be invalid.
         # Therefore we nullify the source_id, leaving the adjustment in place.
         # This would mean that the order's total is not altered at all.
-        adjustment_scope.where("spree_orders.completed_at IS NOT NULL").each do |adjustment|
-          adjustment.update_columns(
-            source_id: nil,
-            updated_at: Time.now,
-          )
-        end
+        attrs = {
+          source_id: nil,
+          updated_at: Time.now
+        }
+        adjustment_scope.where.not(spree_orders: { completed_at: nil }).update_all(attrs)
       end
     end
   end


### PR DESCRIPTION
I replaces `includes` and `references` with `joins`. This is more explicit and don't eager load association, when it's not needed.

I changed style of where clauses to don't use SQL.

I removed iteration through all completed adjustmets with update_all call.