### PR TITLE
new AddressBookController

### DIFF
--- a/api/app/controllers/spree/api/address_books_controller.rb
+++ b/api/app/controllers/spree/api/address_books_controller.rb
@@ -1,0 +1,38 @@
+module Spree
+  module Api
+    class AddressBooksController < Spree::Api::BaseController
+      # Note: the AddressBook is the resource to think about here, not individual addresses
+
+      def show
+        render_address_book
+      end
+
+      def update
+        address_params = address_book_params
+        default_flag = address_params.delete(:default)
+        address = current_api_user.save_in_address_book(address_params, default_flag)
+        if address.valid?
+          render_address_book
+        else
+          invalid_resource!(address)
+        end
+      end
+
+      def destroy
+        current_api_user.remove_from_address_book(params[:address_id])
+        render_address_book
+      end
+
+      private
+
+      def render_address_book
+        @user_addresses = current_api_user.user_addresses
+        render :show, status: :ok
+      end
+
+      def address_book_params
+        params.require(:address_book).permit(permitted_address_book_attributes)
+      end
+    end
+  end
+end

--- a/api/app/views/spree/api/address_books/show.v1.rabl
+++ b/api/app/views/spree/api/address_books/show.v1.rabl
@@ -1,0 +1,4 @@
+collection @user_addresses
+node do |user_address|
+  partial("spree/api/addresses/show", object: user_address.address).merge(default: user_address.default)
+end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -133,6 +133,8 @@ Spree::Core::Engine.add_routes do
       end
     end
 
+    resource :address_book, only: [:show, :update, :destroy]
+
     get '/config/money', to: 'config#money'
     get '/config', to: 'config#show'
     put '/classifications', to: 'classifications#update', as: :classifications

--- a/api/spec/controllers/spree/api/address_books_controller_spec.rb
+++ b/api/spec/controllers/spree/api/address_books_controller_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+
+module Spree
+  describe Api::AddressBooksController, :type => :controller do
+    render_views
+
+    context "unauthorized user" do
+      it "get 401 on /show" do
+        api_get :show
+        expect(response.status).to eq 401
+      end
+
+      it "get 401 on /update" do
+        api_put :update
+        expect(response.status).to eq 401
+      end
+
+      it "get 401 on /destroy" do
+        api_delete :destroy, address_id: 1
+        expect(response.status).to eq 401
+      end
+    end
+
+    context "authorized user with addresses" do
+      let(:address1) { create(:address) }
+      let(:address2) { create(:address, firstname: "Different") }
+
+      before do
+        stub_authentication!
+        current_api_user.save_in_address_book(address1.attributes, true)
+        current_api_user.save_in_address_book(address2.attributes, false)
+      end
+
+      it "gets their address book" do
+        api_get :show
+        expect(json_response.length).to eq 2
+      end
+
+      it "the first one is default" do
+        api_get :show
+        first, second = *json_response
+        expect(first["default"]).to be true
+        expect(second["default"]).to be false
+      end
+
+      it "can remove an address" do
+        api_delete :destroy, address_id: address1.id
+        expect(json_response.length).to eq 1
+      end
+
+      it "can update an address" do
+        updated_params = address2.attributes
+        updated_params[:firstname] = "Johnny"
+        updated_params[:default] = true
+        api_put :update, address_book: updated_params
+        expect(json_response.first["firstname"]).to eq "Johnny"
+      end
+    end
+  end
+end

--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -240,6 +240,14 @@ module Spree
     #   @return [Boolean] Creates a new allocation anytime {StoreCredit#credit} is called
     preference :credit_to_new_allocation, :boolean, default: false
 
+    # @!attribute [rw] automatic_default_address
+    #   The default value of true preserves existing backwards compatible feature of
+    #   treating the most recently used address in checkout as the user's default address.
+    #   Setting to false means that the user should manage their own default via some
+    #   custom UI that uses AddressBookController.
+    #   @return [Boolean] Whether use of an address in checkout marks it as user's default
+    preference :automatic_default_address, :boolean, default: true
+
     # searcher_class allows spree extension writers to provide their own Search class
     attr_writer :searcher_class
     def searcher_class

--- a/core/app/models/spree/user_address.rb
+++ b/core/app/models/spree/user_address.rb
@@ -4,12 +4,18 @@ module Spree
     belongs_to :address, class_name: "Spree::Address"
 
     validates_uniqueness_of :address_id, scope: :user_id
-    validates_uniqueness_of :user_id, conditions: -> { where(default: true) }, message: :default_address_exists, if: :default?
+    validates_uniqueness_of :user_id, conditions: -> { active.default }, message: :default_address_exists, if: :default?
 
     scope :with_address_values, ->(address_attributes) do
       joins(:address).merge(
         Spree::Address.with_values(address_attributes)
       )
     end
+
+    scope :all_historical, -> { unscope(where: :archived) }
+    scope :default, -> { where(default: true) }
+    scope :active, -> { where(archived: false) }
+
+    default_scope -> { order([default: :desc, updated_at: :desc]) }
   end
 end

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -5,6 +5,7 @@ module Spree
   module PermittedAttributes
     ATTRIBUTES = [
       :address_attributes,
+      :address_book_attributes,
       :checkout_attributes,
       :credit_card_update_attributes,
       :customer_return_attributes,
@@ -40,6 +41,8 @@ module Spree
       country: [:iso, :name, :iso3, :iso_name],
       state: [:name, :abbr]
     ]
+
+    @@address_book_attributes = address_attributes + [:default]
 
     @@checkout_attributes = [
       :coupon_code, :email, :shipping_method_id, :special_instructions, :use_billing

--- a/core/spec/models/spree/concerns/user_address_book_spec.rb
+++ b/core/spec/models/spree/concerns/user_address_book_spec.rb
@@ -13,7 +13,7 @@ module Spree
       context "saving a default address" do
         let(:user_address) { user.user_addresses.find_first_by_address_values(address.attributes) }
 
-        subject { user.save_in_address_book(address.attributes, true) }
+        subject { user.save_in_address_book(address.attributes.with_indifferent_access, true) }
 
         context "the address is a new record" do
           let(:address) { build(:address) }
@@ -52,15 +52,49 @@ module Spree
           context "an odd flip-flop corner case discovered running backfill rake task" do
 
             before do
-              user.save_in_address_book(original_default_address.attributes, true)
-              user.save_in_address_book(address.attributes, true)
+              user.save_in_address_book(original_default_address.attributes.with_indifferent_access, true)
+              user.save_in_address_book(address.attributes.with_indifferent_access, true)
             end
 
             it "handles setting 2 addresses as default without a reload of user" do
-              user.save_in_address_book(original_default_address.attributes, true)
-              user.save_in_address_book(address.attributes, true)
+              user.save_in_address_book(original_default_address.attributes.with_indifferent_access, true)
+              user.save_in_address_book(address.attributes.with_indifferent_access, true)
               expect(user.addresses.count).to eq 2
               expect(user.default_address.address1).to eq address.address1
+            end
+          end
+        end
+
+        context "changing existing address to default" do
+          let(:address) { create(:address) }
+
+          before do
+            user.user_addresses.create(address: address, default: false)
+          end
+
+          it "properly sets the default flag" do
+            expect(subject).to eq user.default_address
+          end
+
+          context "and changing another address field at the same time" do
+            let(:updated_address_attributes) { address.attributes.with_indifferent_access.tap {|a| a[:first_name] = "Newbie"} }
+
+            subject { user.save_in_address_book(updated_address_attributes, true) }
+
+            it "changes first name" do
+              expect(subject.first_name).to eq updated_address_attributes[:first_name]
+            end
+
+            it "preserves last name" do
+              expect(subject.last_name).to eq address.last_name
+            end
+
+            it "is a new immutable address instance" do
+              expect(subject.id).to_not eq address.id
+            end
+
+            it "is the new default" do
+              expect(subject).to eq user.default_address
             end
           end
         end
@@ -69,7 +103,7 @@ module Spree
       context "saving a non-default address" do
         let(:user_address) { user.user_addresses.find_first_by_address_values(address.attributes) }
 
-        subject { user.save_in_address_book(address.attributes) }
+        subject { user.save_in_address_book(address.attributes.with_indifferent_access) }
 
         context "the address is a new record" do
           let(:address) { build(:address) }
@@ -100,6 +134,122 @@ module Spree
           it "adds the address to the user's the associated addresses" do
             expect { subject }.to change { user.reload.addresses.count }.by(1)
           end
+        end
+      end
+
+      context "resurrecting a previously saved (but now archived) address" do
+        let(:address) { create(:address) }
+        before do
+          user.save_in_address_book(address.attributes.with_indifferent_access, true)
+          user.remove_from_address_book(address.id)
+        end
+        subject { user.save_in_address_book(address.attributes.with_indifferent_access, true) }
+
+        it "returns the address" do
+          expect(subject).to eq address
+        end
+
+        it "sets it as default" do
+          subject
+          expect(user.default_address).to eq address
+        end
+
+        context "via an edit to another address" do
+          let(:address2) { create(:address, firstname: "Different") }
+          let(:edited_attributes) do
+            # conceptually edit address2 to match the values of address
+            edited_attributes = address.attributes.with_indifferent_access
+            edited_attributes[:id] = address2.id
+            edited_attributes
+          end
+
+          before { user.save_in_address_book(address2.attributes.with_indifferent_access, true) }
+
+          subject { user.save_in_address_book(edited_attributes) }
+
+          it "returns the address" do
+            expect(subject).to eq address
+          end
+
+          it "archives address2" do
+            subject
+            user_address2 = user.user_addresses.all_historical.find_by(address_id: address2.id)
+            expect(user_address2.archived).to be true
+          end
+
+          context "via a new address that matches an archived one" do
+            let(:added_attributes) do
+              added_attributes = address.attributes.with_indifferent_access
+              added_attributes.delete(:id)
+              added_attributes
+            end
+
+            subject { user.save_in_address_book(added_attributes) }
+
+            it "returns the address" do
+              expect(subject).to eq address
+            end
+
+            it "no longer has archived user_addresses" do
+              subject
+              expect(user.user_addresses.all_historical).to eq user.user_addresses
+            end
+          end
+        end
+      end
+    end
+
+    context "#remove_from_address_book" do
+      let(:address1) { create(:address) }
+      let(:address2) { create(:address, firstname: "Different") }
+      let(:remove_id) { address1.id}
+      subject { user.remove_from_address_book(remove_id) }
+
+      before do
+        user.save_in_address_book(address1.attributes.with_indifferent_access)
+        user.save_in_address_book(address2.attributes.with_indifferent_access)
+      end
+
+      it "removes the address from user_addresses" do
+        subject
+        expect(user.user_addresses.find_first_by_address_values(address1.attributes)).to be_nil
+      end
+
+      it "leaves user_address record in an archived state" do
+        subject
+        archived_user_address = user.user_addresses.all_historical.find_first_by_address_values(address1.attributes)
+        expect(archived_user_address).to be_archived
+      end
+
+      it "returns false if the addresses is not there" do
+        expect(user.remove_from_address_book(42)).to be false
+      end
+    end
+
+    context "#persist_order_address" do
+      context "when automatic_default_address preference is at a default of true" do
+        before do
+          Spree::Config.automatic_default_address = true
+          expect(user).to receive(:save_in_address_book).with(kind_of(Hash), true)
+          expect(user).to receive(:save_in_address_book).with(kind_of(Hash), false)
+        end
+
+        it "does set the default: true flag" do
+          order = build(:order)
+          user.persist_order_address(order)
+        end
+      end
+
+      context "when automatic_default_address preference is false" do
+        before do
+          Spree::Config.automatic_default_address = false
+          expect(user).to receive(:save_in_address_book).with(kind_of(Hash)).twice
+            #and not the optional 2nd argument
+        end
+
+        it "does not set the default: true flag" do
+          order = build(:order)
+          user.persist_order_address(order)
         end
       end
     end


### PR DESCRIPTION
This is the followup to my prior address book work. It:

provides endpoints suitable for a custom address book management UI
adds a Spree:Config preference: automatic_default_address
test coverage

Here's some more background. Sorry I didn't write this up when I originally submitted the PR.

The work goes back to making Address a readonly model and avoiding cloning the Address everywhere. Given that readonly behavior, Address is no longer a resource; it's a value object. I have tried to encapsulate the logic that manages copy-on-write semantics for Address. I strongly did not want every controller that works with every model that has an Address to deal with the logic.

At the UserAddressBook concern level there's an additional constraint that I want to encapsulate in the model layer and not require controllers to deal with -- when a UserAddress is marked as default, any other UserAddress marked as default for that user has to also change (sort order also changes). The set of addresses is the unit of encapsulation. That's the core reason that I wrote this code with the Address _BOOK_ as the conceptual resource and the reason I return the entire list. I'd welcome any high level discussion of it at this level, but that's hard to achieve in a PR format.