### PR TITLE
Introduce variant level properties

### DIFF
--- a/api/app/helpers/spree/api/api_helpers.rb
+++ b/api/app/helpers/spree/api/api_helpers.rb
@@ -33,7 +33,8 @@ module Spree
         :store_credit_history_attributes,
         :stock_transfer_attributes,
         :transfer_item_attributes,
-        :transfer_item_variant_attributes
+        :transfer_item_variant_attributes,
+        :variant_property_attributes
       ]
 
       mattr_reader *ATTRIBUTES
@@ -63,6 +64,10 @@ module Spree
       @@variant_attributes = [
         :id, :name, :sku, :price, :weight, :height, :width, :depth, :is_master,
         :slug, :description, :track_inventory
+      ]
+
+      @@variant_property_attributes = [
+        :id, :property_id, :value, :property_name
       ]
 
       @@image_attributes = [

--- a/api/app/views/spree/api/variants/big.v1.rabl
+++ b/api/app/views/spree/api/variants/big.v1.rabl
@@ -9,6 +9,9 @@ node :total_on_hand do
   root_object.total_on_hand
 end
 
+child :variant_properties => :variant_properties do
+  attributes *variant_property_attributes
+end
 
 child(root_object.stock_items.accessible_by(current_ability) => :stock_items) do
   attributes :id, :count_on_hand, :stock_location_id, :backorderable

--- a/backend/app/assets/javascripts/spree/backend/admin.js.erb
+++ b/backend/app/assets/javascripts/spree/backend/admin.js.erb
@@ -112,8 +112,9 @@ $(document).ready(function(){
     new_table_row.find("input, select").each(function () {
       var el = $(this);
       el.val("");
-      el.prop("id", el.prop("id").replace(/\d+/, new_id))
-      el.prop("name", el.prop("name").replace(/\d+/, new_id))
+      // Replace last occurrence of a number
+      el.prop("id", el.prop("id").replace(/\d+(?=[^\d]*$)/, new_id))
+      el.prop("name", el.prop("name").replace(/\d+(?=[^\d]*$)/, new_id))
     })
     // When cloning a new row, set the href of all icons to be an empty "#"
     // This is so that clicking on them does not perform the actions for the
@@ -204,18 +205,21 @@ $(document).ready(function(){
         placeholder: 'ui-sortable-placeholder',
         update: function(event, ui) {
           $("#progress").show();
+          tableEl = $(ui.item).closest("table.sortable")
           positions = {};
-          $.each($('table.sortable tbody tr'), function(position, obj){
-            reg = /spree_(\w+_?)+_(\d+)/;
-            parts = reg.exec($(obj).prop('id'));
-            if (parts) {
-              positions['positions['+parts[2]+']'] = position;
+          $.each(tableEl.find('tbody tr'), function(position, obj){
+            idAttr = $(obj).prop('id');
+            if (idAttr) {
+              objId = idAttr.split('_').slice(-1);
+              if (!isNaN(objId)) {
+                positions['positions['+objId+']'] = position;
+              }
             }
           });
           Spree.ajax({
             type: 'POST',
             dataType: 'script',
-            url: $(ui.item).closest("table.sortable").data("sortable-link"),
+            url: tableEl.data("sortable-link"),
             data: positions,
             success: function(data){ $("#progress").hide(); }
           });
@@ -227,9 +231,10 @@ $(document).ready(function(){
           ui.placeholder.html("<td colspan='"+(td_count-1)+"'></td><td class='actions'></td>")
         },
         stop: function (event, ui) {
+          tableEl = $(ui.item).closest("table.sortable")
           // Fix odd/even classes after reorder
-          $("table.sortable tr:even").removeClass("odd even").addClass("even");
-          $("table.sortable tr:odd").removeClass("odd even").addClass("odd");
+          tableEl.find("tr:even").removeClass("odd even").addClass("even");
+          tableEl.find("tr:odd").removeClass("odd even").addClass("odd");
         }
 
       });

--- a/backend/app/controllers/spree/admin/product_properties_controller.rb
+++ b/backend/app/controllers/spree/admin/product_properties_controller.rb
@@ -4,14 +4,23 @@ module Spree
       belongs_to 'spree/product', :find_by => :slug
       before_action :find_properties
       before_action :setup_property, only: :index, if: -> { can?(:create, model_class) }
+      before_action :setup_variant_property_rules, only: :index
 
       private
+
         def find_properties
           @properties = Spree::Property.pluck(:name)
         end
 
         def setup_property
           @product.product_properties.build
+        end
+
+        def setup_variant_property_rules
+          @option_types = @product.variant_option_values_by_option_type
+          @option_value_ids = (params[:ovi] || []).reject(&:blank?).map(&:to_i)
+          @variant_property_rule = @product.find_variant_property_rule(@option_value_ids) || @product.variant_property_rules.build
+          @variant_property_rule.values.build if can?(:create, Spree::VariantPropertyRuleValue)
         end
     end
   end

--- a/backend/app/controllers/spree/admin/product_properties_controller.rb
+++ b/backend/app/controllers/spree/admin/product_properties_controller.rb
@@ -18,9 +18,8 @@ module Spree
 
         def setup_variant_property_rules
           @option_types = @product.variant_option_values_by_option_type
-          ovis = (params[:ovi] || []).reject(&:blank?).map(&:to_i)
-          @option_value_ids = ovis.join(',')
-          @variant_property_rule = @product.find_variant_property_rule(ovis) || @product.variant_property_rules.build
+          @option_value_ids = (params[:ovi] || []).reject(&:blank?).map(&:to_i)
+          @variant_property_rule = @product.find_variant_property_rule(@option_value_ids) || @product.variant_property_rules.build
           @variant_property_rule.values.build if can?(:create, Spree::VariantPropertyRuleValue)
         end
     end

--- a/backend/app/controllers/spree/admin/product_properties_controller.rb
+++ b/backend/app/controllers/spree/admin/product_properties_controller.rb
@@ -18,8 +18,9 @@ module Spree
 
         def setup_variant_property_rules
           @option_types = @product.variant_option_values_by_option_type
-          @option_value_ids = (params[:ovi] || []).reject(&:blank?).map(&:to_i)
-          @variant_property_rule = @product.find_variant_property_rule(@option_value_ids) || @product.variant_property_rules.build
+          ovis = (params[:ovi] || []).reject(&:blank?).map(&:to_i)
+          @option_value_ids = ovis.join(',')
+          @variant_property_rule = @product.find_variant_property_rule(ovis) || @product.variant_property_rules.build
           @variant_property_rule.values.build if can?(:create, Spree::VariantPropertyRuleValue)
         end
     end

--- a/backend/app/controllers/spree/admin/products_controller.rb
+++ b/backend/app/controllers/spree/admin/products_controller.rb
@@ -147,13 +147,6 @@ module Spree
       def updating_variant_property_rules?
         params[:product][:variant_property_rules_attributes].present?
       end
-
-      def variant_property_rules_for_option_value_ids(current_rule_id, option_value_ids)
-        @product.variant_property_rules.
-          joins(:conditions).
-          where.not(id: current_rule_id).
-          where(Spree::VariantPropertyRuleCondition.arel_table[:option_value_id].in(option_value_ids))
-      end
     end
   end
 end

--- a/backend/app/controllers/spree/admin/products_controller.rb
+++ b/backend/app/controllers/spree/admin/products_controller.rb
@@ -27,7 +27,7 @@ module Spree
         end
         if updating_variant_property_rules?
           params[:product][:variant_property_rules_attributes].each do |index, param_attrs|
-            param_attrs[:option_value_ids] = param_attrs[:option_value_ids].split
+            param_attrs[:option_value_ids] = param_attrs[:option_value_ids].split(',')
           end
         end
         invoke_callbacks(:update, :before)

--- a/backend/app/controllers/spree/admin/variant_property_rule_values_controller.rb
+++ b/backend/app/controllers/spree/admin/variant_property_rule_values_controller.rb
@@ -1,0 +1,7 @@
+module Spree
+  module Admin
+    class VariantPropertyRuleValuesController < ResourceController
+      belongs_to 'spree/product', find_by: :slug
+    end
+  end
+end

--- a/backend/app/views/spree/admin/product_properties/index.html.erb
+++ b/backend/app/views/spree/admin/product_properties/index.html.erb
@@ -72,7 +72,7 @@
 <%= form_for @product, url: admin_product_url(@product), method: :put do |f| %>
   <%= f.fields_for :variant_property_rules, @variant_property_rule do |rule_form| %>
     <%= rule_form.hidden_field 'id', value: @variant_property_rule.id %>
-    <%= rule_form.hidden_field 'option_value_ids', value: @option_value_ids %>
+    <%= rule_form.hidden_field 'option_value_ids', value: @option_value_ids.join(',') %>
     <% if @option_value_ids.present? %>
       <fieldset class='no-border-top'>
         <table class="index sortable" data-hook data-sortable-link="<%= update_positions_admin_product_variant_property_rule_values_url %>">

--- a/backend/app/views/spree/admin/product_properties/index.html.erb
+++ b/backend/app/views/spree/admin/product_properties/index.html.erb
@@ -18,7 +18,8 @@
 <% end %>
 
 <%= form_for @product, :url => admin_product_url(@product), :method => :put do |f| %>
-  <fieldset class="no-border-top">
+  <fieldset>
+    <legend align="center"><%= Spree.t(:product_properties) %></legend>
     <div class="add_product_properties" data-hook="add_product_properties"></div>
 
     <div id="prototypes" data-hook></div>
@@ -47,9 +48,58 @@
   </fieldset>
 <% end %>
 
+<%= form_tag admin_product_product_properties_path, method: :get, id: 'variant_option_value_selections' do %>
+  <fieldset class='no-border-bottom'>
+    <legend align="center"><%= Spree.t(:variant_properties) %></legend>
+    <fieldset class='no-border-top'>
+      <% @option_types.each do |option_type, option_values| %>
+        <div class="field">
+          <%= label :option_type_presentation, option_type.presentation %>
+          <%= select_tag "ovi[]", options_from_collection_for_select(option_values, :id, :presentation, params[:ovi]), class: 'select2 fullwidth', include_blank: true, id: "#{option_type.name}_option_type_select" %>
+        </div>
+      <% end %>
+      <div class="form-buttons filter-actions actions">
+        <%= button Spree.t(:filter_results) %>
+        <% if @option_value_ids.present? %>
+          <span class="or"><%= Spree.t(:or) %></span>
+          <%= link_to_add_fields Spree.t(:add_variant_properties), 'tbody#variant_property_values', class: 'plus button' %>
+        <% end %>
+      </div>
+    </fieldset>
+  </fieldset>
+<% end %>
+
+<%= form_for @product, url: admin_product_url(@product), method: :put do |f| %>
+  <%= f.fields_for :variant_property_rules, @variant_property_rule do |rule_form| %>
+    <%= rule_form.hidden_field 'id', value: @variant_property_rule.id %>
+    <%= rule_form.hidden_field 'option_value_ids', value: @option_value_ids %>
+    <% if @option_value_ids.present? %>
+      <fieldset class='no-border-top'>
+        <table class="index sortable" data-hook data-sortable-link="<%= update_positions_admin_product_variant_property_rule_values_url %>">
+          <thead>
+            <tr data-hook="variant_property_values_header">
+              <th colspan="2"><%= Spree.t(:property) %></th>
+              <th><%= Spree.t(:value) %></th>
+              <th class="actions"></th>
+            </tr>
+          </thead>
+          <tbody id="variant_property_values" data-hook>
+            <%= rule_form.fields_for :values do |values_form| %>
+              <%= render 'product_property_fields', f: values_form %>
+            <% end %>
+          </tbody>
+        </table>
+        <% if can?([:create, :update], Spree::VariantPropertyRule) %>
+          <%= render 'spree/admin/shared/edit_resource_links' %>
+        <% end %>
+      </fieldset>
+    <% end %>
+  <% end %>
+<% end %>
+
 <%= javascript_tag do -%>
   var properties = <%= raw(@properties.to_json) %>;
-  $('#product_properties').on('keydown', 'input.autocomplete', function() {
+  $('#product_properties, #variant_property_values').on('keydown', 'input.autocomplete', function() {
     already_auto_completed = $(this).is('ac_input');
     if (!already_auto_completed) {
       $(this).autocomplete({source: properties});

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -31,6 +31,11 @@ Spree::Core::Engine.add_routes do
           post :update_positions
         end
       end
+      resources :variant_property_rule_values, only: [:destroy] do
+        collection do
+          post :update_positions
+        end
+      end
       resources :images do
         collection do
           post :update_positions

--- a/backend/spec/controllers/spree/admin/product_properties_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/product_properties_controller_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+
+module Spree
+  module Admin
+    describe ProductPropertiesController, type: :controller do
+      stub_authorization!
+
+      describe "#index" do
+        subject { spree_get :index, parameters }
+
+        context "no option values are provided" do
+          let(:product) { create(:product) }
+          let(:parameters) do
+            { product_id: product.to_param }
+          end
+
+          before { subject }
+
+          it "instantiates a new variant property rule" do
+            expect(assigns(:variant_property_rule)).to_not be_persisted
+          end
+
+          it "instantiates a new variant property rule value" do
+            expect(assigns(:variant_property_rule).values.size).to eq 1
+            expect(assigns(:variant_property_rule).values.first).to_not be_persisted
+          end
+        end
+
+        context "option values are provided" do
+          let(:size) { create(:option_type, name: 'size') }
+          let(:product) { create(:product, option_types: [size]) }
+          let(:size_small) { create(:option_value, name: 'small', option_type: size) }
+          let(:size_large) { create(:option_value, name: 'large', option_type: size) }
+          let!(:first_rule) { create(:variant_property_rule, product: product, option_value: size_small) }
+
+          context "no rules match the option values" do
+            let(:parameters) do
+              {
+                product_id: product.to_param,
+                ovi: [size_large.id]
+              }
+            end
+
+            before { subject }
+
+            it "instantiates a new variant property rule" do
+              expect(assigns(:variant_property_rule)).to_not be_persisted
+            end
+          end
+
+          context "a rule matches the option values" do
+            let(:parameters) do
+              {
+                product_id: product.to_param,
+                ovi: [size_small.id]
+              }
+            end
+
+            before { subject }
+
+            it "assigns the property rule to the only property rule that matches the option values" do
+              expect(assigns(:variant_property_rule)).to eq first_rule
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/backend/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/products_controller_spec.rb
@@ -22,9 +22,126 @@ describe Spree::Admin::ProductsController, :type => :controller do
       spree_put :update, :id => product.to_param, :product => { :product_properties_attributes => { "1" => { :property_name => "Foo", :value => "bar" } } }
       expect(flash[:success]).to eq("Product #{product.name.inspect} has been successfully updated!")
     end
-
   end
 
+  describe "creating variant property rules" do
+    let(:first_property) { create(:property) }
+    let(:second_property) { create(:property) }
+    let(:option_value) { create(:option_value) }
+    let!(:product) { create(:product, option_types: [option_value.option_type]) }
+    let(:payload) do
+      {
+        id: product.to_param,
+        product: {
+          id: product.id,
+          variant_property_rules_attributes: {
+            "0" => {
+              option_value_ids: option_value.id,
+              values_attributes: {
+                "0" => {
+                  property_name: first_property.name,
+                  value: "First"
+                },
+                "1" => {
+                  property_name: second_property.name,
+                  value: "Second"
+                }
+              }
+            }
+          }
+        }
+      }
+    end
+
+    subject { spree_put :update, payload }
+
+    it "creates a variant property rule" do
+      expect { subject }.to change { product.variant_property_rules.count }.by(1)
+    end
+
+    it "creates a variant property rule condition" do
+      expect { subject }.to change { product.variant_property_rule_conditions.count }.by(1)
+    end
+
+    it "creates a variant property rule value for the 'First' value" do
+      subject
+      expect(product.variant_property_rule_values.find_by(value: 'First')).to_not be_nil
+    end
+
+    it "creates a variant property rule value for the 'Second' value" do
+      subject
+      expect(product.variant_property_rule_values.find_by(value: 'Second')).to_not be_nil
+    end
+
+    it "redirects to the product properties page" do
+      subject
+      expect(response).to redirect_to(spree.admin_product_product_properties_path(product, ovi: [option_value.id]))
+    end
+  end
+
+  describe "updating variant property rules" do
+    let(:first_property) { create(:property) }
+    let(:second_property) { create(:property) }
+    let(:option_value) { create(:option_value) }
+    let(:original_option_value) { create(:option_value) }
+    let!(:product) { create(:product, option_types: [option_value.option_type]) }
+    let!(:rule) do
+      create(:variant_property_rule, product: product, option_value: original_option_value)
+    end
+    let(:payload) do
+      {
+        id: product.to_param,
+        product: {
+          id: product.id,
+          variant_property_rules_attributes: {
+            "0" => {
+              id: rule.id,
+              option_value_ids: option_value.id,
+              values_attributes: {
+                "0" => {
+                  property_name: first_property.name,
+                  value: "First Edit"
+                },
+                "1" => {
+                  property_name: second_property.name,
+                  value: "Second Edit"
+                }
+              }
+            }
+          }
+        }
+      }
+    end
+
+    subject { spree_put :update, payload }
+
+    it "does not create any new rules" do
+      expect { subject }.to_not change { Spree::VariantPropertyRule.count }
+    end
+
+    it "replaces the rule's condition" do
+      expect { subject }.to change { rule.option_value_ids }.from([original_option_value.id]).to([option_value.id])
+    end
+
+    it "adds two values to the rule" do
+      expect { subject }.to change { rule.values.count }.by(2)
+    end
+
+    it "creates the 'First Edit' value" do
+      subject
+      expect(rule.values.find_by(value: 'First Edit')).to_not be_nil
+    end
+
+    it "creates the 'Second Edit' value" do
+      subject
+      expect(rule.values.find_by(value: 'Second Edit')).to_not be_nil
+    end
+
+    it "redirects to the product properties page" do
+      subject
+      expect(response).to redirect_to(spree.admin_product_product_properties_path(product, ovi: [option_value.id]))
+    end
+  end
 
   # regression test for #801
   context "destroying a product" do

--- a/core/app/models/concerns/spree/ordered_property_value_list.rb
+++ b/core/app/models/concerns/spree/ordered_property_value_list.rb
@@ -1,0 +1,28 @@
+module Spree
+  module OrderedPropertyValueList
+    extend ActiveSupport::Concern
+
+    included do
+      acts_as_list
+
+      validates :property, presence: true
+      validates_with Spree::Validations::DbMaximumLengthValidator, field: :value
+
+      default_scope -> { order(:position) }
+
+      # virtual attributes for use with AJAX autocompletion
+      def property_name
+        property.name if property
+      end
+
+      def property_name=(name)
+        unless name.blank?
+          unless property = Property.find_by(name: name)
+            property = Property.create(name: name, presentation: name)
+          end
+          self.property = property
+        end
+      end
+    end
+  end
+end

--- a/core/app/models/spree/product_property.rb
+++ b/core/app/models/spree/product_property.rb
@@ -1,28 +1,10 @@
 module Spree
   class ProductProperty < Spree::Base
-    acts_as_list
+    include Spree::OrderedPropertyValueList
+
     belongs_to :product, touch: true, class_name: 'Spree::Product', inverse_of: :product_properties
     belongs_to :property, class_name: 'Spree::Property', inverse_of: :product_properties
 
-    validates :property, presence: true
-    validates_with Spree::Validations::DbMaximumLengthValidator, field: :value
-
-    default_scope -> { order(:position) }
-
     self.whitelisted_ransackable_attributes = ['value']
-
-    # virtual attributes for use with AJAX completion stuff
-    def property_name
-      property.name if property
-    end
-
-    def property_name=(name)
-      unless name.blank?
-        unless property = Property.find_by(name: name)
-          property = Property.create(name: name, presentation: name)
-        end
-        self.property = property
-      end
-    end
   end
 end

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -324,6 +324,16 @@ module Spree
       images.first || (fallback && product.variant_images.first) || Spree::Image.new
     end
 
+    # Determines the variant's property values by verifying which of the product's
+    # variant property rules apply to itself.
+    #
+    # @return [Array<Spree::VariantPropertyRuleValue>] variant_properties
+    def variant_properties
+      self.product.variant_property_rules.map do |rule|
+        rule.values if rule.applies_to_variant?(self)
+      end.flatten.compact
+    end
+
     private
 
       def set_master_out_of_stock

--- a/core/app/models/spree/variant_property_rule.rb
+++ b/core/app/models/spree/variant_property_rule.rb
@@ -1,0 +1,42 @@
+# The reason for variant properties not being associated with variants
+# (either directly or through an association table) is performance.
+#
+# Variant properties are intended to be applied to a group of variants based
+# on their option values. If there were thousands of variants that shared the
+# same option value, attempting to associate a variant property with that
+# group of variants would be problematic in terms of performance.
+#
+# An added benefit to this approach is not having to associate existing variant
+# properties with newly created variants. If the variant has the option values
+# targeted by the rule, the properties will automatically apply to the variant.
+module Spree
+  class VariantPropertyRule < Spree::Base
+    belongs_to :product, touch: true
+
+    has_many :values, class_name: 'Spree::VariantPropertyRuleValue', dependent: :destroy
+    has_many :properties, through: :values
+    has_many :conditions, class_name: 'Spree::VariantPropertyRuleCondition', dependent: :destroy
+    has_many :option_values, through: :conditions
+
+    accepts_nested_attributes_for :values, allow_destroy: true, reject_if: lambda { |val| val[:property_name].blank? }
+
+    # Checks whether the provided ids are the same as the rule's
+    # condition's option value ids.
+    #
+    # @param option_value_ids [Array<Integer>] list of option value ids
+    # @return [Boolean]
+    def matches_option_value_ids?(option_value_ids)
+      self.option_value_ids.sort == option_value_ids.sort
+    end
+
+    # Checks whether the rule applies to the variant by
+    # checking the rule's conditions against the variant's
+    # option values.
+    #
+    # @param variant [Spree::Variant] variant to check
+    # @return [Boolean]
+    def applies_to_variant?(variant)
+      (self.option_value_ids & variant.option_value_ids).present?
+    end
+  end
+end

--- a/core/app/models/spree/variant_property_rule_condition.rb
+++ b/core/app/models/spree/variant_property_rule_condition.rb
@@ -1,0 +1,8 @@
+module Spree
+  class VariantPropertyRuleCondition < Spree::Base
+    belongs_to :option_value
+    belongs_to :variant_property_rule, touch: true
+
+    validates_uniqueness_of :option_value_id, scope: :variant_property_rule_id
+  end
+end

--- a/core/app/models/spree/variant_property_rule_value.rb
+++ b/core/app/models/spree/variant_property_rule_value.rb
@@ -1,0 +1,8 @@
+module Spree
+  class VariantPropertyRuleValue < Spree::Base
+    include Spree::OrderedPropertyValueList
+
+    belongs_to :property
+    belongs_to :variant_property_rule, touch: true
+  end
+end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -409,6 +409,7 @@ en:
     add_option_value: Add Option Value
     add_product: Add Product
     add_product_properties: Add Product Properties
+    add_variant_properties: Add Variant Properties
     add_rule_of_type: Add rule of type
     add_state: Add State
     add_stock: Add Stock
@@ -1567,6 +1568,7 @@ en:
     value: Value
     variant: Variant
     variant_placeholder: Choose a variant
+    variant_properties: Variant Properties
     variant_search: Variant Search
     variant_search_placeholder: "SKU or Option Value"
     variant_to_add: Variant to add

--- a/core/db/migrate/20150909123605_create_variant_properties_and_rules.rb
+++ b/core/db/migrate/20150909123605_create_variant_properties_and_rules.rb
@@ -1,0 +1,28 @@
+class CreateVariantPropertiesAndRules < ActiveRecord::Migration
+  def change
+    create_table :spree_variant_property_rules do |t|
+      t.references :product
+      t.timestamps null: false
+    end
+
+    add_index :spree_variant_property_rules, :product_id
+
+    create_table :spree_variant_property_rule_conditions do |t|
+      t.references :option_value
+      t.references :variant_property_rule
+      t.timestamps null: false
+    end
+
+    add_index :spree_variant_property_rule_conditions, [:variant_property_rule_id, :option_value_id], name: "index_spree_variant_prop_rule_conditions_on_rule_and_optval"
+
+    create_table :spree_variant_property_rule_values do |t|
+      t.text       :value
+      t.integer    :position, default: 0
+      t.references :property
+      t.references :variant_property_rule
+    end
+
+    add_index :spree_variant_property_rule_values, :property_id
+    add_index :spree_variant_property_rule_values, :variant_property_rule_id, name: "index_spree_variant_property_rule_values_on_rule"
+  end
+end

--- a/core/lib/spree/testing_support/factories/variant_property_rule_condition_factory.rb
+++ b/core/lib/spree/testing_support/factories/variant_property_rule_condition_factory.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :variant_property_rule_condition, class: Spree::VariantPropertyRuleCondition do
+    variant_property_rule
+    option_value
+  end
+end

--- a/core/lib/spree/testing_support/factories/variant_property_rule_factory.rb
+++ b/core/lib/spree/testing_support/factories/variant_property_rule_factory.rb
@@ -1,0 +1,16 @@
+FactoryGirl.define do
+  factory :variant_property_rule, class: Spree::VariantPropertyRule do
+    product
+
+    transient do
+      property { create(:property) }
+      option_value { create(:option_value) }
+      property_value nil
+    end
+
+    after(:build) do |rule, evaluator|
+      rule.conditions.build(option_value: evaluator.option_value)
+      rule.values.build(property: evaluator.property, value: evaluator.property_value)
+    end
+  end
+end

--- a/core/lib/spree/testing_support/factories/variant_property_rule_value_factory.rb
+++ b/core/lib/spree/testing_support/factories/variant_property_rule_value_factory.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :variant_property_rule_value, class: Spree::VariantPropertyRuleValue do
+    variant_property_rule
+    property
+  end
+end

--- a/core/spec/models/spree/concerns/ordered_property_value_list_spec.rb
+++ b/core/spec/models/spree/concerns/ordered_property_value_list_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe Spree::OrderedPropertyValueList do
+  #
+  # Using ProductProperty as a subject
+  # since it includes OrderedPropertyValueList
+  #
+  let(:product_property) { create(:product_property) }
+
+  context "validations" do
+    # Only MySQL stores or stores that were migrated prior to the Rails 4.2
+    # upgrade have length limitations on "value":
+    # > The PostgreSQL and SQLite adapters no longer add a default limit of 255
+    # > characters on string columns.
+    # http://guides.rubyonrails.org/4_2_release_notes.html#active-record-notable-changes
+    # https://github.com/rails/rails/pull/14579
+    if Spree::ProductProperty.columns_hash['value'].limit
+      it "should validate length of value" do
+        overflow_length = Spree::ProductProperty.columns_hash['value'].limit + 1
+        product_property.value = "x" * overflow_length
+        expect(product_property).not_to be_valid
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/product_property_spec.rb
+++ b/core/spec/models/spree/product_property_spec.rb
@@ -1,29 +1,14 @@
 require 'spec_helper'
 
-describe Spree::ProductProperty, :type => :model do
-
-  context "validations" do
-    # Only MySQL stores or stores that were migrated prior to the Rails 4.2
-    # upgrade have length limitations on "value":
-    # > The PostgreSQL and SQLite adapters no longer add a default limit of 255
-    # > characters on string columns.
-    # http://guides.rubyonrails.org/4_2_release_notes.html#active-record-notable-changes
-    # https://github.com/rails/rails/pull/14579
-    if Spree::ProductProperty.columns_hash['value'].limit
-      it "should validate length of value" do
-        pp = create(:product_property)
-        overflow_length = Spree::ProductProperty.columns_hash['value'].limit + 1
-        pp.value = "x" * overflow_length
-        expect(pp).not_to be_valid
-      end
-    end
-  end
-
+describe Spree::ProductProperty, type: :model do
   context "touching" do
-    it "should update product" do
-      pp = create(:product_property)
-      expect(pp.product).to receive(:touch)
-      pp.touch
+    let(:product_property) { create(:product_property) }
+    let(:product) { product_property.product }
+
+    subject { product_property.touch }
+
+    it "touches the product" do
+      expect { subject }.to change { product.reload.updated_at }
     end
   end
 end

--- a/core/spec/models/spree/product_property_spec.rb
+++ b/core/spec/models/spree/product_property_spec.rb
@@ -5,6 +5,10 @@ describe Spree::ProductProperty, type: :model do
     let(:product_property) { create(:product_property) }
     let(:product) { product_property.product }
 
+    before do
+      product.update_columns(updated_at: 1.day.ago)
+    end
+
     subject { product_property.touch }
 
     it "touches the product" do

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -161,6 +161,44 @@ describe Spree::Product, :type => :model do
       end
     end
 
+    describe "#variant_option_values_by_option_type" do
+      let(:size) { create(:option_type, name: 'size') }
+      let(:length) { create(:option_type, name: 'length') }
+      let(:product) { create(:product, option_types: [size, length]) }
+      let(:size_small) { create(:option_value, name: 'small', option_type: size, position: 3) }
+      let(:size_medium) { create(:option_value, name: 'medium', option_type: size, position: 1) }
+      let(:size_large) { create(:option_value, name: 'large', option_type: size, position: 2) }
+      let!(:variant) { create(:variant, product: product, option_values: [size_small, size_medium]) }
+
+      subject { product.variant_option_values_by_option_type }
+
+      it "returns the option values associated with the product's variants grouped by option type" do
+        expect(subject).to eq({ size => [size_medium, size_small] })
+      end
+    end
+
+    describe "#find_variant_property_rule" do
+      let(:option_value) { create(:option_value) }
+
+      subject { product.find_variant_property_rule([option_value.id]) }
+
+      context "a matching rule exists" do
+        let!(:rule) do
+          create(:variant_property_rule, product: product, option_value: option_value)
+        end
+
+        it "returns the rule" do
+          expect(subject).to eq rule
+        end
+      end
+
+      context "a matching rule doesn't exist" do
+        it "returns nil" do
+          expect(subject).to be_nil
+        end
+      end
+    end
+
     describe 'Variants sorting' do
       let(:master){ product.master }
 

--- a/core/spec/models/spree/variant_property_rule_condition_spec.rb
+++ b/core/spec/models/spree/variant_property_rule_condition_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe Spree::VariantPropertyRuleCondition, type: :model do
+  context "touching" do
+    it "should update the variant property rule" do
+      rule_condition = create(:variant_property_rule_condition)
+      expect { rule_condition.touch }.to change { rule_condition.reload.variant_property_rule.updated_at }
+    end
+  end
+end

--- a/core/spec/models/spree/variant_property_rule_condition_spec.rb
+++ b/core/spec/models/spree/variant_property_rule_condition_spec.rb
@@ -2,8 +2,13 @@ require 'spec_helper'
 
 describe Spree::VariantPropertyRuleCondition, type: :model do
   context "touching" do
+    let(:rule_condition) { create(:variant_property_rule_condition) }
+
+    before do
+      rule_condition.variant_property_rule.update_columns(updated_at: 1.day.ago)
+    end
+
     it "should update the variant property rule" do
-      rule_condition = create(:variant_property_rule_condition)
       expect { rule_condition.touch }.to change { rule_condition.reload.variant_property_rule.updated_at }
     end
   end

--- a/core/spec/models/spree/variant_property_rule_spec.rb
+++ b/core/spec/models/spree/variant_property_rule_spec.rb
@@ -1,0 +1,79 @@
+require 'spec_helper'
+
+describe Spree::VariantPropertyRule, type: :model do
+  context "touching" do
+    let(:rule) { create(:variant_property_rule) }
+
+    it "should update the product" do
+      expect { rule.touch }.to change { rule.reload.product.updated_at }
+    end
+  end
+
+  describe "#matches_option_value_ids?" do
+    let(:first_condition_option_value) { create(:option_value) }
+    let(:second_condition_option_value) { create(:option_value) }
+    let!(:second_condition) do
+      create(:variant_property_rule_condition,
+        variant_property_rule: rule,
+        option_value: second_condition_option_value)
+    end
+    let(:rule) { create(:variant_property_rule, option_value: first_condition_option_value) }
+
+    context "provided ids are the same as the rule's condition's option value ids" do
+      subject do
+        rule.matches_option_value_ids?([second_condition_option_value.id, first_condition_option_value.id])
+      end
+
+      it { is_expected.to eq true }
+    end
+
+    context "some of the provided ids are the same as the rule's condition's option value ids" do
+      subject do
+        rule.matches_option_value_ids?([first_condition_option_value.id])
+      end
+
+      it { is_expected.to eq false }
+    end
+
+    context "none of the provided ids are the same as the rule's condition's option value ids" do
+      let(:other_option_value) { create(:option_value) }
+
+      subject do
+        rule.matches_option_value_ids?([other_option_value.id])
+      end
+
+      it { is_expected.to eq false }
+    end
+  end
+
+  describe "#applies_to_variant?" do
+    let(:variant_option_value_1) { create(:option_value) }
+    let(:variant_option_value_2) { create(:option_value) }
+    let!(:variant) { create(:variant, option_values: option_values)}
+
+    let(:rule_option_value) { create(:option_value) }
+    let(:rule) { create(:variant_property_rule, option_value: rule_option_value) }
+    let!(:rule_condition_1) { create(:variant_property_rule_condition, variant_property_rule: rule, option_value: variant_option_value_1) }
+    let!(:rule_condition_2) { create(:variant_property_rule_condition, variant_property_rule: rule, option_value: variant_option_value_2) }
+
+    subject { rule.applies_to_variant?(variant) }
+
+    context "variant matches some of the rule's conditions" do
+      let(:option_values) { [variant_option_value_1, variant_option_value_2] }
+
+      it { is_expected.to eq true }
+    end
+
+    context "variant matches none of the rule's conditions" do
+      let(:option_values) { [create(:option_value)] }
+
+      it { is_expected.to eq false }
+    end
+
+    context "variant matches all of the rule's conditions" do
+      let(:option_values) { [rule_option_value, variant_option_value_1, variant_option_value_2] }
+
+      it { is_expected.to eq true }
+    end
+  end
+end

--- a/core/spec/models/spree/variant_property_rule_spec.rb
+++ b/core/spec/models/spree/variant_property_rule_spec.rb
@@ -4,6 +4,10 @@ describe Spree::VariantPropertyRule, type: :model do
   context "touching" do
     let(:rule) { create(:variant_property_rule) }
 
+    before do
+      rule.product.update_columns(updated_at: 1.day.ago)
+    end
+
     it "should update the product" do
       expect { rule.touch }.to change { rule.reload.product.updated_at }
     end

--- a/core/spec/models/spree/variant_property_rule_value_spec.rb
+++ b/core/spec/models/spree/variant_property_rule_value_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe Spree::VariantPropertyRuleValue, type: :model do
+  context "touching" do
+    let(:rule_value) { create(:variant_property_rule_value) }
+    let(:rule) { rule_value.variant_property_rule }
+
+    subject { rule_value.touch }
+
+    it "touches the variant property rule" do
+      expect { subject }.to change { rule.reload.updated_at }
+    end
+  end
+end

--- a/core/spec/models/spree/variant_property_rule_value_spec.rb
+++ b/core/spec/models/spree/variant_property_rule_value_spec.rb
@@ -5,6 +5,10 @@ describe Spree::VariantPropertyRuleValue, type: :model do
     let(:rule_value) { create(:variant_property_rule_value) }
     let(:rule) { rule_value.variant_property_rule }
 
+    before do
+      rule.update_columns(updated_at: 1.day.ago)
+    end
+
     subject { rule_value.touch }
 
     it "touches the variant property rule" do

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -575,4 +575,27 @@ describe Spree::Variant, :type => :model do
       end
     end
   end
+
+  describe "#variant_properties" do
+    let(:option_value_1) { create(:option_value) }
+    let(:option_value_2) { create(:option_value) }
+    let(:variant) { create(:variant, option_values: [option_value_1, option_value_2]) }
+
+    subject { variant.variant_properties }
+
+    context "variant has properties" do
+      let!(:rule_1) { create(:variant_property_rule, product: variant.product, option_value: option_value_1) }
+      let!(:rule_2) { create(:variant_property_rule, product: variant.product, option_value: option_value_2) }
+
+      it "returns the variant property rule's values" do
+        expect(subject).to match_array rule_1.values + rule_2.values
+      end
+    end
+
+    context "variant doesn't have any properties" do
+      it "returns an empty list" do
+        expect(subject).to eq []
+      end
+    end
+  end
 end


### PR DESCRIPTION
Takes the concept of product properties and transfers it over to
variants.

This change allows an admin to specify properties for variants based on
a selection of option values. This prevents a lot of duplication since
many variants are going to share the same properties.

Unlike product properties which are associated directly to the product,
the variant properties are not directly associated with their variants.
A variant property rule is created which contains the option values the
rule is targeting.

The reason for this choice was due to performance. With products that
have thousands of variants, associating information for each variant
becomes a performance concern. An added benefit to this approach is that
variant properties do not have to be set up for new variant. If the
variant has the option values targeted by the rule, the properties will
automatically apply to the variant.

The UI displays the variant properties on the same page as the product
properties. The JavaScript changes were related to fixing some issues
related to adding new fields to the property list UI. The changes were
related to supporting property lists on the same page.

Screenshot below illustrates the UI for building the variant property rules:
![screen shot 2015-09-16 at 4 28 05 pm](https://cloud.githubusercontent.com/assets/2223534/9917524/1b8a6a30-5c90-11e5-9e99-fffc88e4fb75.png)
