### PR TITLE
Display credit card addresses in admin

### DIFF
--- a/backend/app/views/spree/admin/payments/source_views/_gateway.html.erb
+++ b/backend/app/views/spree/admin/payments/source_views/_gateway.html.erb
@@ -16,6 +16,9 @@
         <dt><%= Spree.t(:expiration) %>:</dt>
         <dd><%= payment.source.month %>/<%= payment.source.year %></dd>
       </dl>
+      <% if payment.source.address %>
+        <%= render partial: 'spree/admin/shared/address', locals: {address: payment.source.address} %>
+      <% end %>
     </div>
   </div>
 </fieldset>

--- a/backend/spec/features/admin/orders/payments_spec.rb
+++ b/backend/spec/features/admin/orders/payments_spec.rb
@@ -66,6 +66,12 @@ describe 'Payments', :type => :feature do
       # end
     end
 
+    it 'displays the address for a credit card when present' do
+      payment.source.update!(address: create(:address, address1: 'my cc address'))
+      visit spree.admin_order_payment_path(order, payment)
+      expect(page).to have_content 'my cc address'
+    end
+
     it 'lists and create payments for an order', js: true do
       within_row(1) do
         expect(column_text(3)).to eq('$150.00')


### PR DESCRIPTION
Credit cards can now have addresses but we don't display them anywhere
in the admin. This displays them when present.

Doesn't look amazingly beautiful but better than nothing...

<img width="551" alt="screenshot 2015-09-16 14 54 31" src="https://cloud.githubusercontent.com/assets/23050/9918656/428af5a6-5c85-11e5-8092-acbbbf342846.png">

I'm happy to take suggestions on making it prettier or whatever. (Or as separate PRs)