### PR TITLE
Add ability to set country_iso on address

### DIFF
--- a/api/app/helpers/spree/api/api_helpers.rb
+++ b/api/app/helpers/spree/api/api_helpers.rb
@@ -119,8 +119,8 @@ module Spree
 
       @@address_attributes = [
         :id, :firstname, :lastname, :full_name, :address1, :address2, :city,
-        :zipcode, :phone, :company, :alternative_phone, :country_id, :state_id,
-        :state_name, :state_text
+        :zipcode, :phone, :company, :alternative_phone, :country_id, :country_iso,
+        :state_id, :state_name, :state_text
       ]
 
       @@country_attributes = [:id, :iso_name, :iso, :iso3, :name, :numcode]

--- a/backend/app/controllers/spree/admin/users_controller.rb
+++ b/backend/app/controllers/spree/admin/users_controller.rb
@@ -134,7 +134,7 @@ module Spree
           when 'basic'
             collection.map { |u| { 'id' => u.id, 'name' => u.email } }.to_json
           else
-            address_fields = [:firstname, :lastname, :address1, :address2, :city, :zipcode, :phone, :state_name, :state_id, :country_id]
+            address_fields = [:firstname, :lastname, :address1, :address2, :city, :zipcode, :phone, :state_name, :state_id, :country_id, :country_iso]
             includes = { :only => address_fields , :include => { :state => { :only => :name }, :country => { :only => :name } } }
 
             collection.to_json(:only => [:id, :email], :include =>

--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -37,7 +37,7 @@ module Spree
 
     # @return [Address] an equal address already in the database or a newly created one
     def self.factory(attributes)
-      full_attributes = value_attributes(column_defaults, attributes)
+      full_attributes = value_attributes(column_defaults, new(attributes).attributes)
       find_or_initialize_by(full_attributes)
     end
 
@@ -146,6 +146,13 @@ module Spree
     # Since addresses do not change, you won't accidentally alter historical data.
     def readonly?
       persisted?
+    end
+
+    # @param iso [String] 2 letter Country ISO
+    # @return [Country] setter that sets self.country to the Country with a matching 2 letter iso
+    # @raise [ActiveRecord::RecordNotFound] if country with the iso doesn't exist
+    def country_iso=(iso)
+      self.country = Country.find_by!(iso: iso)
     end
 
     private

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -36,7 +36,7 @@ module Spree
     @@address_attributes = [
       :id, :firstname, :lastname, :first_name, :last_name,
       :address1, :address2, :city, :country_id, :state_id,
-      :zipcode, :phone, :state_name, :alternative_phone, :company,
+      :zipcode, :phone, :state_name, :country_iso, :alternative_phone, :company,
       country: [:iso, :name, :iso3, :iso_name],
       state: [:name, :abbr]
     ]

--- a/core/spec/models/spree/address_spec.rb
+++ b/core/spec/models/spree/address_spec.rb
@@ -183,6 +183,18 @@ describe Spree::Address, :type => :model do
     end
   end
 
+
+  context '.factory' do
+    context 'with attributes that use setters defined in Address' do
+      let(:address_attributes) { attributes_for(:address, country_id: nil, country_iso: country.iso) }
+      let(:country) { create(:country, iso: 'ZZ') }
+
+      it 'uses the setters' do
+        expect(subject.factory(address_attributes).country_id).to eq(country.id)
+      end
+    end
+  end
+
   context ".immutable_merge" do
     RSpec::Matchers.define :be_address_equivalent_attributes do |expected|
       fields_of_interest = [:firstname, :lastname, :company, :address1, :address2, :city, :zipcode, :phone, :alternative_phone]
@@ -295,6 +307,22 @@ describe Spree::Address, :type => :model do
         expect(base_attributes).to eq('first_name' => 'Jordan')
         expect(merge_attributes).to eq('last_name' => 'Brough')
       end
+    end
+  end
+
+  context '#country_iso=' do
+    let(:address) { build(:address, :country_id => nil) }
+    let(:country) { create(:country, iso: 'ZZ') }
+
+    it 'sets the country to the country with the matching iso code' do
+      address.country_iso = country.iso
+      expect(address.country_id).to eq(country.id)
+    end
+
+    it 'raises an exception if the iso is not found' do
+      expect {
+        address.country_iso = "NOCOUNTRY"
+      }.to raise_error(::ActiveRecord::RecordNotFound, "Couldn't find Spree::Country")
     end
   end
 


### PR DESCRIPTION
We’re adding Paypal support into the https://github.com/solidusio/solidus_braintree gem, but ran into an issue. Paypal sends back a billing and shipping address, and I can map everything easily except for the country. Paypal sends back a 2 letter ISO country code, but unless I make an API request to solidus to get the entire iso to id mapping, there doesn’t seem to be an easy way to PUT this on the `/api/orders` endpoint.

This PR adds a setter method called `#country_iso` and if set, will find and set the country_id to the result.