### PR TITLE
Unreturned exchange improvements

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -516,7 +516,7 @@ module Spree
     end
 
     def create_proposed_shipments
-      return self.shipments if unreturned_exchange? && shipments.all?(&:shipped?)
+      return self.shipments if unreturned_exchange?
 
       if completed?
         raise CannotRebuildShipments.new(Spree.t(:cannot_rebuild_shipments_order_completed))

--- a/core/lib/spree/core/unreturned_item_charger.rb
+++ b/core/lib/spree/core/unreturned_item_charger.rb
@@ -24,7 +24,7 @@ module Spree
       add_exchange_variants_to_order
       set_shipment_for_new_order
 
-      new_order.reload.update!
+      new_order.update!
       set_order_payment
 
       # There are several checks in the order state machine to skip
@@ -69,6 +69,7 @@ module Spree
 
     def set_shipment_for_new_order
       @shipment.update_attributes!(order_id: new_order.id)
+      new_order.shipments.reset
     end
 
     def set_order_payment

--- a/core/lib/spree/core/unreturned_item_charger.rb
+++ b/core/lib/spree/core/unreturned_item_charger.rb
@@ -34,10 +34,8 @@ module Spree
       end
 
       # Transitions will call update_totals on the order
-      while new_order.state != new_order.checkout_steps[-2] && new_order.next; end
-
-      if new_order.state != new_order.checkout_steps[-2]
-        raise ChargeFailure.new("order did not reach the #{new_order.checkout_steps[-2]} state", new_order)
+      until new_order.can_complete?
+        new_order.next!
       end
 
       new_order.contents.approve(name: self.class.name)

--- a/core/lib/spree/core/unreturned_item_charger.rb
+++ b/core/lib/spree/core/unreturned_item_charger.rb
@@ -100,9 +100,9 @@ module Spree
         bill_address: @original_order.bill_address,
         ship_address: @original_order.ship_address,
         email: @original_order.email,
+        store_id: @original_order.store_id,
         frontend_viewable: false
       }
-      order_attributes[:store_id] = @original_order.store_id if @original_order.respond_to?(:store_id)
       order_attributes
     end
   end

--- a/core/lib/spree/core/unreturned_item_charger.rb
+++ b/core/lib/spree/core/unreturned_item_charger.rb
@@ -68,7 +68,6 @@ module Spree
     end
 
     def set_shipment_for_new_order
-      new_order.shipments.destroy_all
       @shipment.update_attributes!(order_id: new_order.id)
     end
 

--- a/core/lib/spree/core/unreturned_item_charger.rb
+++ b/core/lib/spree/core/unreturned_item_charger.rb
@@ -95,14 +95,13 @@ module Spree
     end
 
     def exchange_order_attributes
-      order_attributes = {
+      {
         bill_address: @original_order.bill_address,
         ship_address: @original_order.ship_address,
         email: @original_order.email,
         store_id: @original_order.store_id,
         frontend_viewable: false
       }
-      order_attributes
     end
   end
 end

--- a/core/lib/spree/core/unreturned_item_charger.rb
+++ b/core/lib/spree/core/unreturned_item_charger.rb
@@ -41,7 +41,7 @@ module Spree
       end
 
       new_order.contents.approve(name: self.class.name)
-      new_order.reload.complete!
+      new_order.complete!
       Spree::OrderCapturing.new(new_order).capture_payments if (Spree::Config[:auto_capture_exchanges] && !Spree::Config[:auto_capture])
 
       @return_items.each(&:expired!)

--- a/core/lib/spree/core/unreturned_item_charger.rb
+++ b/core/lib/spree/core/unreturned_item_charger.rb
@@ -78,10 +78,11 @@ module Spree
       unless new_order.payments.present?
         card_to_reuse = @original_order.valid_credit_cards.first
         card_to_reuse = @original_order.user.credit_cards.default.first if !card_to_reuse && @original_order.user
-        Spree::Payment.create!(order: new_order,
-                               payment_method_id: card_to_reuse.try(:payment_method_id),
-                               source: card_to_reuse,
-                               amount: new_order.total)
+        new_order.payments.create!(
+          payment_method_id: card_to_reuse.try(:payment_method_id),
+          source: card_to_reuse,
+          amount: new_order.total
+        )
       end
     end
 

--- a/core/spec/lib/spree/core/unreturned_item_charger_spec.rb
+++ b/core/spec/lib/spree/core/unreturned_item_charger_spec.rb
@@ -77,6 +77,10 @@ describe Spree::UnreturnedItemCharger do
       expect(new_order.payments.first.response_code).to be_present
     end
 
+    it "delivers confirmation email" do
+      expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(1)
+    end
+
     context 'with auto_capture_exchanges' do
       before { Spree::Config[:auto_capture_exchanges] = true }
 

--- a/core/spec/lib/spree/core/unreturned_item_charger_spec.rb
+++ b/core/spec/lib/spree/core/unreturned_item_charger_spec.rb
@@ -23,6 +23,7 @@ describe Spree::UnreturnedItemCharger do
   let!(:unreturned_item_charger) { Spree::UnreturnedItemCharger.new(exchange_shipment, [return_item]) }
 
   before do
+    exchange_shipment.finalize!
     exchange_inventory_unit.ship!
   end
 

--- a/core/spec/lib/spree/core/unreturned_item_charger_spec.rb
+++ b/core/spec/lib/spree/core/unreturned_item_charger_spec.rb
@@ -107,16 +107,6 @@ describe Spree::UnreturnedItemCharger do
       end
     end
 
-    context "there's an error transitioning the new order's state" do
-      before do
-        allow_any_instance_of(Spree::Order).to receive(:next).and_return(false)
-      end
-
-      it "raises an error" do
-        expect { subject }.to raise_error(Spree::UnreturnedItemCharger::ChargeFailure, 'order did not reach the confirm state')
-      end
-    end
-
     context "item is in stock" do
       before do
         original_variant.stock_items.map { |si| si.set_count_on_hand(10) }

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -938,19 +938,6 @@ describe Spree::Order, :type => :model do
         create(:shipment, order: subject, state: second_shipment_state, created_at: 5.days.ago)
       end
 
-      context "some shipments are shipped" do
-        let(:first_shipment_state) { "shipped" }
-        let(:second_shipment_state) { "ready" }
-
-        it "raises an error" do
-          expect {
-            expect {
-              subject.create_proposed_shipments
-            }.to raise_error(Spree::Order::CannotRebuildShipments)
-          }.not_to change { subject.reload.shipments }
-        end
-      end
-
       context "all shipments are shipped" do
         let(:first_shipment_state) { "shipped" }
         let(:second_shipment_state) { "shipped" }

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -726,9 +726,9 @@ describe Spree::Shipment, :type => :model do
       expect { subject }.to change { stock_item.reload.count_on_hand }.from(10).to(9)
     end
 
-    context "exchange shipment from an unreturned exchange order" do
+    context "inventory unit already finalized" do
       before do
-        order.update_attributes!(created_at: 5.days.from_now)
+        inventory_unit.update_attributes!(pending: false)
       end
 
       it "doesn't update the associated inventory units" do


### PR DESCRIPTION
This is a light cleanup from #367 and #340 

I was able to remove the check on `unreturned_exchange?` from finalize by instead checking if an inventory unit had already been finalized (and therefore has already had inventory allocated)

Removed the check on `shipments.all?(&:shipped?)` because I can't see why that would be required or beneficial.

Otherwise just simplification and cleanup.