### PR TITLE
Restore some Api::UsersController methods

### DIFF
--- a/api/app/controllers/spree/api/users_controller.rb
+++ b/api/app/controllers/spree/api/users_controller.rb
@@ -3,7 +3,7 @@ class Spree::Api::UsersController < Spree::Api::ResourceController
   private
 
   def user
-  	@user
+    @user
   end
 
   def model_class
@@ -11,7 +11,7 @@ class Spree::Api::UsersController < Spree::Api::ResourceController
   end
 
   def user_params
-  	permitted_resource_params
+    permitted_resource_params
   end
 
   def permitted_resource_attributes

--- a/api/app/controllers/spree/api/users_controller.rb
+++ b/api/app/controllers/spree/api/users_controller.rb
@@ -1,9 +1,17 @@
 class Spree::Api::UsersController < Spree::Api::ResourceController
 
-  protected
+  private
+
+  def user
+  	@user
+  end
 
   def model_class
     Spree.user_class
+  end
+
+  def user_params
+  	permitted_resource_params
   end
 
   def permitted_resource_attributes


### PR DESCRIPTION
These were removed in https://github.com/solidusio/solidus/pull/319
and replaced by generically-named equivalents, but subclassing
controllers in apps like ours can be reasonably expecting these methods
to be there.

I do think we should restore these but I'm not sure whether we should
mark them as officially supported or deprecate them. Any thoughts?