### PR TITLE
Promotion OptionValue Rules

### DIFF
--- a/api/app/controllers/spree/api/option_values_controller.rb
+++ b/api/app/controllers/spree/api/option_values_controller.rb
@@ -5,7 +5,7 @@ module Spree
         if params[:ids]
           @option_values = scope.where(:id => params[:ids])
         else
-          @option_values = scope.ransack(params[:q]).result
+          @option_values = scope.ransack(params[:q]).result.distinct
         end
         respond_with(@option_values)
       end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -61,6 +61,7 @@ Spree::Core::Engine.add_routes do
     resources :option_types do
       resources :option_values
     end
+    resources :option_values
 
     resources :option_values, only: :index
     get '/orders/mine', to: 'orders#mine', as: 'my_orders'

--- a/backend/app/assets/javascripts/spree/backend/admin.js.erb
+++ b/backend/app/assets/javascripts/spree/backend/admin.js.erb
@@ -5,6 +5,7 @@
 //= require spree/backend/option_type_autocomplete
 //= require spree/backend/user_picker
 //= require spree/backend/product_picker
+//= require spree/backend/option_value_picker
 //= require spree/backend/taxons
 
 /**

--- a/backend/app/assets/javascripts/spree/backend/option_value_picker.js
+++ b/backend/app/assets/javascripts/spree/backend/option_value_picker.js
@@ -1,0 +1,43 @@
+$.fn.optionValueAutocomplete = function (options) {
+  'use strict';
+
+  // Default options
+  options = options || {}
+  var multiple = typeof(options['multiple']) !== 'undefined' ? options['multiple'] : true;
+  var productSelect = options['productSelect'];
+
+  this.select2({
+    minimumInputLength: 3,
+    multiple: multiple,
+    initSelection: function (element, callback) {
+      $.get(Spree.routes.option_value_search, {
+        ids: element.val().split(',')
+      }, function (data) {
+        callback(multiple ? data : data[0]);
+      });
+    },
+    ajax: {
+      url: Spree.routes.option_value_search,
+      datatype: 'json',
+      data: function (term, page) {
+        var productId = typeof(productSelect) !== 'undefined' ? $(productSelect).select2('val') : null;
+        return {
+          q: {
+            name_cont: term,
+            variants_product_id_eq: productId
+          },
+          token: Spree.api_key
+        };
+      },
+      results: function (data, page) {
+        return { results: data };
+      }
+    },
+    formatResult: function (option_value) {
+      return option_value.name;
+    },
+    formatSelection: function (option_value) {
+      return option_value.name;
+    }
+  });
+};

--- a/backend/app/assets/javascripts/spree/backend/promotions.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/promotions.js.coffee
@@ -28,14 +28,16 @@ window.initProductActions = ->
   #
   # Option Value Promo Rule
   #
-  if $('#promo-rule-option-value-template').length
-    optionValueSelectNameTemplate = Handlebars.compile($('#promo-rule-option-value-option-values-select-name-template').html())
-    optionValueTemplate = Handlebars.compile($('#promo-rule-option-value-template').html())
+  if $('.promo-rule-option-values').length
+    optionValueSelectNameTemplate = HandlebarsTemplates['promotions/rules/option_values_select']
+    optionValueTemplate = HandlebarsTemplates['promotions/rules/option_values']
 
     addOptionValue = (product, values) ->
+      paramPrefix = $('.promo-rule-option-values').find('.param-prefix').data('param-prefix')
       $('.js-promo-rule-option-values').append optionValueTemplate(
         productSelect: value: product
-        optionValuesSelect: value: values)
+        optionValuesSelect: value: values
+        paramPrefix: paramPrefix)
       optionValue = $('.js-promo-rule-option-values .promo-rule-option-value').last()
       optionValue.find('.js-promo-rule-option-value-product-select').productAutocomplete multiple: false
       optionValue.find('.js-promo-rule-option-value-option-values-select').optionValueAutocomplete productSelect: '.js-promo-rule-option-value-product-select'
@@ -59,7 +61,8 @@ window.initProductActions = ->
       return
     $(document).on 'change', '.js-promo-rule-option-value-product-select', ->
       optionValueSelect = $(this).parents('.promo-rule-option-value').find('input.js-promo-rule-option-value-option-values-select')
-      optionValueSelect.attr 'name', optionValueSelectNameTemplate(product_id: $(this).val()).trim()
+      paramPrefix = $('.promo-rule-option-values').find('.param-prefix').data('param-prefix')
+      optionValueSelect.attr 'name', optionValueSelectNameTemplate(product_id: $(this).val(), param_prefix: paramPrefix).trim()
       optionValueSelect.prop('disabled', $(this).val() == '').select2 'val', ''
       return
 

--- a/backend/app/assets/javascripts/spree/backend/promotions.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/promotions.js.coffee
@@ -26,6 +26,44 @@ window.initProductActions = ->
         $settings.find('input').prop 'disabled', 'disabled'
 
   #
+  # Option Value Promo Rule
+  #
+  if $('#promo-rule-option-value-template').length
+    optionValueSelectNameTemplate = Handlebars.compile($('#promo-rule-option-value-option-values-select-name-template').html())
+    optionValueTemplate = Handlebars.compile($('#promo-rule-option-value-template').html())
+
+    addOptionValue = (product, values) ->
+      $('.js-promo-rule-option-values').append optionValueTemplate(
+        productSelect: value: product
+        optionValuesSelect: value: values)
+      optionValue = $('.js-promo-rule-option-values .promo-rule-option-value').last()
+      optionValue.find('.js-promo-rule-option-value-product-select').productAutocomplete multiple: false
+      optionValue.find('.js-promo-rule-option-value-option-values-select').optionValueAutocomplete productSelect: '.js-promo-rule-option-value-product-select'
+      if product == null
+        optionValue.find('.js-promo-rule-option-value-option-values-select').prop 'disabled', true
+      return
+
+    originalOptionValues = $('.js-original-promo-rule-option-values').data('original-option-values')
+    if !$('.js-original-promo-rule-option-values').data('loaded')
+      if $.isEmptyObject(originalOptionValues)
+        addOptionValue null, null
+      else
+        $.each originalOptionValues, addOptionValue
+    $('.js-original-promo-rule-option-values').data 'loaded', true
+    $(document).on 'click', '.js-add-promo-rule-option-value', (event) ->
+      event.preventDefault()
+      addOptionValue null, null
+      return
+    $(document).on 'click', '.js-remove-promo-rule-option-value', ->
+      $(this).parents('.promo-rule-option-value').remove()
+      return
+    $(document).on 'change', '.js-promo-rule-option-value-product-select', ->
+      optionValueSelect = $(this).parents('.promo-rule-option-value').find('input.js-promo-rule-option-value-option-values-select')
+      optionValueSelect.attr 'name', optionValueSelectNameTemplate(product_id: $(this).val()).trim()
+      optionValueSelect.prop('disabled', $(this).val() == '').select2 'val', ''
+      return
+
+  #
   # Tiered Calculator
   #
   if $('.js-tiers').length

--- a/backend/app/assets/javascripts/spree/backend/routes.js
+++ b/backend/app/assets/javascripts/spree/backend/routes.js
@@ -1,6 +1,7 @@
 Spree.routes.checkouts_api = Spree.pathFor('api/checkouts')
 Spree.routes.classifications_api = Spree.pathFor('api/classifications')
 Spree.routes.clear_cache = Spree.pathFor('admin/general_settings/clear_cache')
+Spree.routes.option_value_search = Spree.pathFor('api/option_values')
 Spree.routes.option_type_search = Spree.pathFor('api/option_types')
 Spree.routes.orders_api = Spree.pathFor('api/orders')
 Spree.routes.product_search = Spree.pathFor('api/products')

--- a/backend/app/assets/javascripts/spree/backend/templates/promotions/rules/option_values.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/promotions/rules/option_values.hbs
@@ -1,0 +1,10 @@
+<div class="fullwidth promo-rule-option-value">
+  <div class="four columns alpha">
+    <input class="js-promo-rule-option-value-product-select fullwidth" type="hidden" value="{{ productSelect.value }}">
+  </div>
+  <div class="three columns omega">
+    <input class="js-promo-rule-option-value-option-values-select fullwidth" name="{{ paramPrefix }}[preferred_eligible_values][{{ productSelect.value }}]" type="hidden" value={{optionValuesSelect.value}}>
+  </div>
+  <a class="fa fa-trash remove js-remove-promo-rule-option-value"></a>
+  <div class="clear"></div>
+</div>

--- a/backend/app/assets/javascripts/spree/backend/templates/promotions/rules/option_values_select.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/promotions/rules/option_values_select.hbs
@@ -1,0 +1,1 @@
+{{ param_prefix }}[preferred_eligible_values][{{product_id}}]

--- a/backend/app/assets/stylesheets/spree/backend/sections/_promotions.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/_promotions.scss
@@ -34,6 +34,22 @@
     margin-bottom: 0;
   }
 
+  .promo-rule-option-value {
+    position: relative;
+    padding-bottom: 10px;
+
+    .remove {
+      cursor: pointer;
+      position: absolute;
+      right: 10px;
+      top: 10px;
+
+      &:hover {
+        color: #c60f13;
+      }
+    }
+  }
+
   .tier {
     position: relative;
     padding-bottom: 10px;

--- a/backend/app/views/spree/admin/promotions/rules/_option_value.html.erb
+++ b/backend/app/views/spree/admin/promotions/rules/_option_value.html.erb
@@ -1,0 +1,29 @@
+<div class="field alpha omega eight columns promo-rule-option-values">
+  <div class="four columns alpha"><%= label_tag nil, Spree.t(:product) %></div>
+  <div class="three columns omega"><%= label_tag nil, Spree.t(:option_values) %></div>
+  <div class="clear"></div>
+
+  <div class="js-promo-rule-option-values"></div>
+
+  <button class="fa fa-plus button js-add-promo-rule-option-value"><%= Spree.t(:add) %></button>
+</div>
+
+<%= content_tag :div, nil, class: "hidden js-original-promo-rule-option-values",
+  data: { :'original-option-values' => promotion_rule.preferred_eligible_values } %>
+
+<script type="text/x-handlebars-template" id="promo-rule-option-value-option-values-select-name-template">
+  <%= param_prefix %>[preferred_eligible_values][{{product_id}}]
+</script>
+
+<script type="text/x-handlebars-template" id="promo-rule-option-value-template">
+  <div class="fullwidth promo-rule-option-value">
+    <div class="four columns alpha">
+      <input class="js-promo-rule-option-value-product-select fullwidth" type="hidden" value="{{ productSelect.value }}">
+    </div>
+    <div class="three columns omega">
+      <input class="js-promo-rule-option-value-option-values-select fullwidth" name="<%= param_prefix %>[preferred_eligible_values][{{ productSelect.value }}]" type="hidden" value={{optionValuesSelect.value}}>
+    </div>
+    <a class="fa fa-trash remove js-remove-promo-rule-option-value"></a>
+    <div class="clear"></div>
+  </div>
+</script>

--- a/backend/app/views/spree/admin/promotions/rules/_option_value.html.erb
+++ b/backend/app/views/spree/admin/promotions/rules/_option_value.html.erb
@@ -1,4 +1,5 @@
 <div class="field alpha omega eight columns promo-rule-option-values">
+  <div class="param-prefix hidden" data-param-prefix="<%= param_prefix %>"></div>
   <div class="four columns alpha"><%= label_tag nil, Spree.t(:product) %></div>
   <div class="three columns omega"><%= label_tag nil, Spree.t(:option_values) %></div>
   <div class="clear"></div>
@@ -10,20 +11,3 @@
 
 <%= content_tag :div, nil, class: "hidden js-original-promo-rule-option-values",
   data: { :'original-option-values' => promotion_rule.preferred_eligible_values } %>
-
-<script type="text/x-handlebars-template" id="promo-rule-option-value-option-values-select-name-template">
-  <%= param_prefix %>[preferred_eligible_values][{{product_id}}]
-</script>
-
-<script type="text/x-handlebars-template" id="promo-rule-option-value-template">
-  <div class="fullwidth promo-rule-option-value">
-    <div class="four columns alpha">
-      <input class="js-promo-rule-option-value-product-select fullwidth" type="hidden" value="{{ productSelect.value }}">
-    </div>
-    <div class="three columns omega">
-      <input class="js-promo-rule-option-value-option-values-select fullwidth" name="<%= param_prefix %>[preferred_eligible_values][{{ productSelect.value }}]" type="hidden" value={{optionValuesSelect.value}}>
-    </div>
-    <a class="fa fa-trash remove js-remove-promo-rule-option-value"></a>
-    <div class="clear"></div>
-  </div>
-</script>

--- a/backend/spec/features/admin/promotions/option_value_rule_spec.rb
+++ b/backend/spec/features/admin/promotions/option_value_rule_spec.rb
@@ -1,0 +1,65 @@
+require 'spec_helper'
+
+feature 'Promotion with option value rule' do
+  stub_authorization!
+
+  given(:variant) { create :variant }
+  given!(:product) { variant.product }
+  given!(:option_value) { variant.option_values.first }
+
+  given(:promotion) { create :promotion }
+
+  background do
+    visit spree.edit_admin_promotion_path(promotion)
+  end
+
+  scenario "adding an option value rule", js: true do
+    select2 "Option Value(s)", from: "Add rule of type"
+    within("#rules_container") { click_button "Add" }
+
+    within("#rules_container .promotion-block") do
+      expect(page).to have_content("PRODUCT")
+      expect(page).to have_content("OPTION VALUES")
+
+      click_button "Add"
+    end
+
+    within('.promo-rule-option-value') do
+      targetted_select2_search product.name, from: '.js-promo-rule-option-value-product-select'
+      targetted_select2_search option_value.name, from: '.js-promo-rule-option-value-option-values-select'
+    end
+
+    within('#rules_container') { click_button "Update" }
+
+    first_rule = promotion.rules(true).first
+    expect(first_rule.class).to eq Spree::Promotion::Rules::OptionValue
+    expect(first_rule.preferred_eligible_values).to eq Hash[product.id => [option_value.id]]
+  end
+
+  context "with an existing option value rule" do
+    given(:variant1) { create :variant }
+    given(:variant2) { create :variant }
+    background do
+      rule = Spree::Promotion::Rules::OptionValue.new
+      rule.promotion = promotion
+      rule.preferred_eligible_values = Hash[
+        variant1.product_id => variant1.option_values.pluck(:id),
+        variant2.product_id => variant2.option_values.pluck(:id)
+      ]
+      rule.save!
+
+      visit spree.edit_admin_promotion_path(promotion)
+    end
+
+    scenario "deleting a product", js: true do
+      within(".promo-rule-option-value:last-child") do
+        find(".remove").click
+      end
+
+      within('#rules_container') { click_button "Update" }
+
+      first_rule = promotion.rules(true).first
+      expect(first_rule.preferred_eligible_values).to eq Hash[variant1.product_id => variant1.option_values.pluck(:id)]
+    end
+  end
+end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1207,6 +1207,9 @@ en:
       one_use_per_user:
         description: Only One Use Per User
         name: One Use Per User
+      option_value:
+        description: Order includes specified product(s) with matching option value(s)
+        name: Option Value(s)
       product:
         description: Order includes specified product(s)
         name: Product(s)

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -92,7 +92,8 @@ module Spree
           Spree::Promotion::Rules::UserLoggedIn,
           Spree::Promotion::Rules::OneUsePerUser,
           Spree::Promotion::Rules::Taxon,
-          Spree::Promotion::Rules::NthOrder
+          Spree::Promotion::Rules::NthOrder,
+          Spree::Promotion::Rules::OptionValue
         ]
       end
 

--- a/core/lib/spree/testing_support/capybara_ext.rb
+++ b/core/lib/spree/testing_support/capybara_ext.rb
@@ -51,7 +51,8 @@ module CapybaraExt
     find("#{options[:from]}:not(.select2-container-disabled)").click
 
     within_entire_page do
-      find("input.select2-input").set(value)
+      select2input = first("#select2-drop input.select2-input") || find("input.select2-input")
+      select2input.set(value)
     end
 
     select_select2_result(value)


### PR DESCRIPTION
I believe this is something that was meant to be brought over from our fork, but somehow we missed a commit. This is just a cherry-pick and cleanup of https://github.com/bonobos/spree/commit/e7813d81265548b06970339fcad35dfa5f906acd

We currently have a good portion of the code in solidus that does the heavy-lifting, but it is not visible in the admin UI. This will get it visible and working.