### PR TITLE
Nil return value for process payments

### DIFF
--- a/core/spec/models/spree/order/payment_spec.rb
+++ b/core/spec/models/spree/order/payment_spec.rb
@@ -53,6 +53,14 @@ module Spree
       end
     end
 
+    context "with multiple payments" do
+      it "should not fail transitioning to complete when paid" do
+        payment_1 = create(:payment, :amount => 50, :state => "completed")
+        payment_2 = create(:payment, :amount => 50, :state => "failed")
+        expect(order.process_payments!).to be true
+      end
+    end
+
     context "ensure source attributes stick around" do
       # For the reason of this test, please see spree/spree_gateway#132
       it "does not have inverse_of defined" do


### PR DESCRIPTION
If the order has been paid for, the `process_payments!` function returns `nil` rather than true, which sets a bunch of problems in mention.

A more detailed walkthrough the issue is here: https://gist.github.com/alexstoick/272a53d2fdeeb5f8082c