### PR TITLE
Fix payment processing when fully paid

### DIFF
--- a/core/app/models/spree/order/payments.rb
+++ b/core/app/models/spree/order/payments.rb
@@ -39,7 +39,7 @@ module Spree
 
         def process_payments_with(method)
           # Don't run if there is nothing to pay.
-          return if payment_total >= total
+          return true if payment_total >= total
           # Prevent orders from transitioning to complete without a successfully processed payment.
           raise Core::GatewayError.new(Spree.t(:no_payment_found)) if unprocessed_payments.empty?
 

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -613,6 +613,16 @@ describe Spree::Order, :type => :model do
         expect(Spree::InventoryUnit.where(shipment_id: shipment.id).count).to eq(0)
       end
     end
+
+    context 'the order is already paid' do
+      let(:order) { create(:order_with_line_items) }
+
+      it 'can complete the order' do
+        payment = create(:payment, state: 'completed', order: order, amount: order.total)
+        order.update!
+        expect(order.complete).to eq(true)
+      end
+    end
   end
 
   context "subclassed order" do

--- a/core/spec/models/spree/order/payment_spec.rb
+++ b/core/spec/models/spree/order/payment_spec.rb
@@ -53,6 +53,20 @@ module Spree
       end
     end
 
+    context "with no payments" do
+      it "should return falsy" do
+        expect(order).to receive_messages total: 100
+        expect(order.process_payments!).to be_falsy
+      end
+    end
+
+    context "with payments completed" do
+      it "should not fail transitioning to complete when paid" do
+        expect(order).to receive_messages total: 100, payment_total: 100
+        expect(order.process_payments!).to be_truthy
+      end
+    end
+
     context "ensure source attributes stick around" do
       # For the reason of this test, please see spree/spree_gateway#132
       it "does not have inverse_of defined" do


### PR DESCRIPTION
When an order is fully paid, process_payments! was returning nil,
causing the state transition to fail. It should return true, since the
order is fully paid.

Thanks @alexstoick for the failing spec and a detailed writeup at
https://gist.github.com/alexstoick/272a53d2fdeeb5f8082c

I would also like to cherry pick this onto 1.0

This fixes #375