### PR TITLE
Maintain classification position on association collection removal

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -19,7 +19,7 @@ module Spree
     has_many :properties, through: :product_properties
 
     has_many :classifications, dependent: :delete_all, inverse_of: :product
-    has_many :taxons, through: :classifications
+    has_many :taxons, through: :classifications, before_remove: :remove_taxon
 
     has_many :product_promotion_rules
     has_many :promotion_rules, through: :product_promotion_rules
@@ -354,6 +354,10 @@ module Spree
       Spree::Taxonomy.where(id: taxonomy_ids_to_touch).update_all(updated_at: Time.current)
     end
 
+    def remove_taxon(taxon)
+      removed_classifications = classifications.where(taxon: taxon)
+      removed_classifications.each &:remove_from_list
+    end
   end
 end
 

--- a/core/spec/models/spree/classification_spec.rb
+++ b/core/spec/models/spree/classification_spec.rb
@@ -11,5 +11,83 @@ module Spree
       expect(add_taxon).to raise_error(ActiveRecord::RecordInvalid)
     end
 
+    let(:taxon_with_5_products) do
+      products = []
+      5.times do
+        products << create(:base_product)
+      end
+
+      create(:taxon, products: products)
+    end
+
+    def positions_to_be_valid(taxon)
+      positions = taxon.reload.classifications.map(&:position)
+      expect(positions).to eq((1..taxon.classifications.count).to_a)
+    end
+
+    it "has a valid fixtures" do
+      expect positions_to_be_valid(taxon_with_5_products)
+      expect(Spree::Classification.count).to eq 5
+    end
+
+    context "removing product from taxon" do
+      before :each do
+        p = taxon_with_5_products.products[1]
+        expect(p.classifications.first.position).to eq(2)
+        taxon_with_5_products.products.destroy(p)
+      end
+
+      it "resets positions" do
+        expect positions_to_be_valid(taxon_with_5_products)
+      end
+    end
+
+    context "replacing taxon's products" do
+      before :each do
+        products = taxon_with_5_products.products.to_a
+        products.pop(1)
+        taxon_with_5_products.products = products
+        taxon_with_5_products.save!
+      end
+
+      it "resets positions" do
+        expect positions_to_be_valid(taxon_with_5_products)
+      end
+    end
+
+    context "removing taxon from product" do
+      before :each do
+        p = taxon_with_5_products.products[1]
+        p.taxons.destroy(taxon_with_5_products)
+        p.save!
+      end
+
+      it "resets positions" do
+        expect positions_to_be_valid(taxon_with_5_products)
+      end
+    end
+
+    context "replacing product's taxons" do
+      before :each do
+        p = taxon_with_5_products.products[1]
+        p.taxons = []
+        p.save!
+      end
+
+      it "resets positions" do
+        expect positions_to_be_valid(taxon_with_5_products)
+      end
+    end
+
+    context "destroying classification" do
+      before :each do
+        classification = taxon_with_5_products.classifications[1]
+        classification.destroy
+      end
+
+      it "resets positions" do
+        expect positions_to_be_valid(taxon_with_5_products)
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes integrity of classifications.

Product update action adds/removes taxons via `taxons = `, which does not trigger destroy callbacks on classification. So the affected positions need to be updated via a `before_remove` callback.