### PR TITLE
Localize 'settings' and 'stock' in the Admin tabs

### DIFF
--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -40,7 +40,7 @@
         </div>
 
         <div class="field">
-          <%= label_tag nil, "Shipment Number" %>
+          <%= label_tag nil, Spree.t(:shipment_number) %>
           <%= f.text_field :shipments_number_cont %>
         </div>
 

--- a/backend/app/views/spree/admin/refund_reasons/index.html.erb
+++ b/backend/app/views/spree/admin/refund_reasons/index.html.erb
@@ -24,7 +24,7 @@
     <thead>
       <tr data-hook="named_types_header">
         <th><%= Spree.t(:name) %></th>
-        <th><%= Spree.t(:state) %></th>
+        <th><%= Spree.t(:active) %></th>
         <th class="actions"></th>
       </tr>
     </thead>
@@ -35,7 +35,7 @@
             <%= named_type.name %>
           </td>
           <td class="align-center">
-            <%= Spree.t(named_type.active? ? :active : :inactive) %>
+            <%= Spree.t(named_type.active? ? :say_yes : :say_no) %>
           </td>
           <td class="actions">
             <% if can?(:update, named_type) && named_type.mutable? %>

--- a/backend/app/views/spree/admin/shared/_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_tabs.html.erb
@@ -11,7 +11,7 @@
 <% end %>
 
 <% if can? :admin, :general_settings %>
-  <%= tab *Spree::BackendConfiguration::CONFIGURATION_TABS, label: 'settings', icon: 'wrench', url: spree.edit_admin_general_settings_path %>
+  <%= tab *Spree::BackendConfiguration::CONFIGURATION_TABS, label: Spree.t(:settings), icon: 'wrench', url: spree.edit_admin_general_settings_path %>
 <% end %>
 
 <% if can? :admin, Spree::Promotion %>
@@ -19,7 +19,7 @@
 <% end %>
 
 <% if can? :admin, Spree::StockItem %>
-  <%= tab(:stock_items, :stock_transfers, :url => spree.admin_stock_items_path, :label => 'stock', :icon => 'cubes', match_path: %r(^/admin/stock)) %>
+  <%= tab(:stock_items, :stock_transfers, :url => spree.admin_stock_items_path, :label => Spree.t(:stock), :icon => 'cubes', match_path: %r(^/admin/stock)) %>
 <% end %>
 
 <% if Spree.user_class && can?(:admin, Spree.user_class) %>

--- a/backend/app/views/spree/admin/shared/named_types/_index.html.erb
+++ b/backend/app/views/spree/admin/shared/named_types/_index.html.erb
@@ -24,7 +24,7 @@
     <thead>
       <tr data-hook="named_types_header">
         <th><%= Spree.t(:name) %></th>
-        <th><%= Spree.t(:state) %></th>
+        <th><%= Spree.t(:active) %></th>
         <th class="actions"></th>
       </tr>
     </thead>
@@ -35,7 +35,7 @@
             <%= named_type.name %>
           </td>
           <td class="align-center">
-            <%= Spree.t(named_type.active? ? :active : :inactive) %>
+            <%= Spree.t(named_type.active? ? :say_yes : :say_no) %>
           </td>
           <td class="actions">
             <% if named_type.mutable? && can?(:update, named_type) %>

--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -13,11 +13,11 @@ module Spree
     end
 
     def link_to_cart(text = nil)
-      text = text ? h(text) : Spree.t('cart')
+      text = text ? h(text) : Spree.t(:cart)
       css_class = nil
 
       if simple_current_order.nil? or simple_current_order.item_count.zero?
-        text = "#{text}: (#{Spree.t('empty')})"
+        text = "#{text}: (#{Spree.t(:empty)})"
         css_class = 'empty'
       else
         text = "#{text}: (#{simple_current_order.item_count})  <span class='amount'>#{simple_current_order.display_total.to_html}</span>"

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1360,6 +1360,7 @@ en:
         track_information: ! 'Tracking Information: %{tracking}'
         track_link: ! 'Tracking Link: %{url}'
     shipment_date: Shipment date
+    shipment_number: Shipment Number
     shipment_numbers: Shipment numbers
     shipment_state: Shipment State
     shipment_states:

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -228,6 +228,7 @@ en:
       spree/state:
         one: State
         other: States
+      spree/stock: stock
       spree/stock_movement:
         one: Stock Movement
         other: Stock Movements

--- a/core/db/default/spree/zones.rb
+++ b/core/db/default/spree/zones.rb
@@ -5,7 +5,7 @@ north_america = Spree::Zone.create!(name: "North America", description: "USA + C
  "Slovakia", "Hungary", "Slovenia", "Ireland", "Austria", "Spain",
  "Italy", "Belgium", "Sweden", "Latvia", "Bulgaria", "United Kingdom",
  "Lithuania", "Cyprus", "Luxembourg", "Malta", "Denmark", "Netherlands",
- "Estonia"].
+ "Estonia", "Croatia", "Czech Republic", "Greece"].
 each do |name|
   eu_vat.zone_members.create!(zoneable: Spree::Country.find_by!(name: name))
 end

--- a/frontend/app/assets/javascripts/spree/frontend/checkout/address.js.coffee
+++ b/frontend/app/assets/javascripts/spree/frontend/checkout/address.js.coffee
@@ -43,8 +43,13 @@ $ ->
         stateSelect.prop('disabled', false).show()
         stateInput.hide().prop 'disabled', true
         statePara.show()
-        stateSpanRequired.show()
-        stateSelect.addClass('required') if statesRequired
+        if statesRequired
+          stateSelect.addClass('required')
+          stateSpanRequired.show()
+        else
+          stateSelect.removeClass('required')
+          stateSpanRequired.hide()
+        end
         stateSelect.removeClass('hidden')
         stateInput.removeClass('required')
       else

--- a/frontend/app/assets/javascripts/spree/frontend/checkout/address.js.coffee
+++ b/frontend/app/assets/javascripts/spree/frontend/checkout/address.js.coffee
@@ -49,7 +49,6 @@ $ ->
         else
           stateSelect.removeClass('required')
           stateSpanRequired.hide()
-        end
         stateSelect.removeClass('hidden')
         stateInput.removeClass('required')
       else


### PR DESCRIPTION
Add Spree.t() around 'settings' and 'stock' and
add 'spree/stock' to en.yml for completeness.