### PR TITLE
Fix use of with_model for MySQL

### DIFF
--- a/api/spec/controllers/spree/api/resource_controller_spec.rb
+++ b/api/spec/controllers/spree/api/resource_controller_spec.rb
@@ -22,7 +22,7 @@ module Spree
       Rails.application.reload_routes!
     end
 
-    with_model 'Widget' do
+    with_model 'Widget', scope: :all do
       table do |t|
         t.string :name
         t.integer :position

--- a/backend/spec/controllers/spree/admin/resource_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/resource_controller_spec.rb
@@ -12,7 +12,7 @@ module Spree
   end
 end
 
-describe Spree::Admin::WidgetsController, :type => :controller, :truncation => true do
+describe Spree::Admin::WidgetsController, :type => :controller do
   stub_authorization!
 
   after(:all) do
@@ -20,7 +20,7 @@ describe Spree::Admin::WidgetsController, :type => :controller, :truncation => t
     Rails.application.reload_routes!
   end
 
-  with_model 'Widget' do
+  with_model 'Widget', scope: :all do
     table do |t|
       t.string :name
       t.integer :position

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -73,7 +73,7 @@ RSpec.configure do |config|
     Rails.cache.clear
     reset_spree_preferences
     WebMock.disable!
-    if RSpec.current_example.metadata[:js] || RSpec.current_example.metadata[:truncation]
+    if RSpec.current_example.metadata[:js]
       DatabaseCleaner.strategy = :truncation
     else
       DatabaseCleaner.strategy = :transaction


### PR DESCRIPTION
PostgreSQL can make schema changes, like creating a table, in a transcation because it is just that awesome. MySQL is somewhat less awesome, so any schema changes are an implicit commit. This breaks tests which are run within a transaction.

with_model makes changes to the schema, but if we run it in a `before(:all)` or `before(:suite)` block, it will be run outside of a transaction, and it already knows how to cleanup after itself.