### PR TITLE
Fix shipment spec in MySQL

### DIFF
--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -719,6 +719,7 @@ describe Spree::Shipment, :type => :model do
     subject { shipment.finalize! }
 
     it "updates the associated inventory units" do
+      inventory_unit.update_columns(updated_at: 1.hour.ago)
       expect { subject }.to change { inventory_unit.reload.updated_at }
     end
 


### PR DESCRIPTION
MySQL only has 1 second precision on timestamps, so we need to force
that value to be older to test it.