### PR TITLE
associate store to its orders

### DIFF
--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -1,5 +1,7 @@
 module Spree
   class Store < Spree::Base
+    has_many :orders, dependent: :destroy
+
     has_many :store_payment_methods, inverse_of: :store
     has_many :payment_methods, through: :store_payment_methods
 


### PR DESCRIPTION
You'll notice that an order actually belongs to a store. When a store "Closes Shop" then we should be able to set the `deleted_at` field for those orders as well.