### PR TITLE
improve assigning addresses to unsaved user

### DIFF
--- a/api/spec/spec_helper.rb
+++ b/api/spec/spec_helper.rb
@@ -29,7 +29,6 @@ require 'ffaker'
 Dir[File.dirname(__FILE__) + "/support/**/*.rb"].each {|f| require f}
 
 require 'spree/testing_support/factories'
-require 'spree/testing_support/rspec-activemodel-mocks_patch'
 require 'spree/testing_support/preferences'
 
 require 'spree/api/testing_support/caching'

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -33,7 +33,6 @@ require 'ffaker'
 
 require 'spree/testing_support/authorization_helpers'
 require 'spree/testing_support/factories'
-require 'spree/testing_support/rspec-activemodel-mocks_patch'
 require 'spree/testing_support/preferences'
 require 'spree/testing_support/controller_requests'
 require 'spree/testing_support/flash'

--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -27,7 +27,7 @@ group :test do
   gem 'email_spec'
   gem 'factory_girl_rails', '~> 4.5.0'
   gem 'launchy'
-  gem 'rspec-activemodel-mocks'
+  gem 'rspec-activemodel-mocks', '~>1.0.2'
   gem 'rspec-collection_matchers'
   gem 'rspec-its'
   gem 'rspec-rails', '~> 3.3.0'

--- a/core/app/models/concerns/spree/user_address_book.rb
+++ b/core/app/models/concerns/spree/user_address_book.rb
@@ -75,11 +75,8 @@ module Spree
       # @param default set whether or not this address will show up from
       # #default_address or not
       def save_in_address_book(address_attributes, default = false)
-        if address_attributes.present?
-          address_attributes = address_attributes.with_indifferent_access
-        else
-          return nil
-        end
+        return nil unless address_attributes.present?
+        address_attributes = address_attributes.with_indifferent_access
 
         new_address = Address.factory(address_attributes)
         return new_address unless new_address.valid?

--- a/core/app/models/concerns/spree/user_address_book.rb
+++ b/core/app/models/concerns/spree/user_address_book.rb
@@ -19,15 +19,6 @@ module Spree
             user_address.persisted? ? user_address.update!(default: true, archived: false) : user_address.default = true
           end
         end
-
-        def merge_one(user_address)
-          if(user_address.id)
-            # this happens if someone adds back an old address they had previously soft deleted
-            new_assoc = self.to_a.reject {|ua| ua.id == user_address.id} + [user_address]
-            replace(new_assoc)
-          end
-          # else this was created with user_addresses.build and the association already tracks it
-        end
       end
 
       has_many :addresses, through: :user_addresses
@@ -101,7 +92,6 @@ module Spree
 
         user_address = prepare_user_address(new_address)
         user_addresses.mark_default(user_address) if (default || first_one)
-        user_addresses.merge_one(user_address)
 
         if persisted?
           user_address.save!

--- a/core/lib/spree/testing_support/factories/user_factory.rb
+++ b/core/lib/spree/testing_support/factories/user_factory.rb
@@ -22,9 +22,7 @@ FactoryGirl.define do
 
     factory :user_with_addreses do |u|
       bill_address
-      after(:create) do |user, evaluator|
-        user.save_in_address_book(create(:ship_address).attributes, true)
-      end
+      ship_address
     end
   end
 end

--- a/core/lib/spree/testing_support/rspec-activemodel-mocks_patch.rb
+++ b/core/lib/spree/testing_support/rspec-activemodel-mocks_patch.rb
@@ -1,8 +1,0 @@
-# Manually applied the patch from https://github.com/jdelStrother/rspec-activemodel-mocks/commit/1211c347c5a574739616ccadf4b3b54686f9051f
-if Gem.loaded_specs['rspec-activemodel-mocks'].version.to_s != "1.0.1"
-  raise "RSpec-ActiveModel-Mocks version has changed, please check if the behaviour has already been fixed: https://github.com/rspec/rspec-activemodel-mocks/pull/10
-If so, this patch might be obsolete-"
-end
-RSpec::ActiveModel::Mocks::Mocks::ActiveRecordInstanceMethods.class_eval do
-  alias_method :_read_attribute, :[]
-end

--- a/core/spec/spec_helper.rb
+++ b/core/spec/spec_helper.rb
@@ -34,7 +34,6 @@ if ENV["CHECK_TRANSLATIONS"]
 end
 
 require 'spree/testing_support/factories'
-require 'spree/testing_support/rspec-activemodel-mocks_patch'
 require 'spree/testing_support/preferences'
 require 'cancan/matchers'
 


### PR DESCRIPTION
This was originally noticed in tests that wanted to create a user
with a ship_address at once. I don't know how common it might happen
in production, but seems a reasonable expectation. The core issue
was the `reset` at the end of `mark_default` -- the unsaved UserAddress
was getting dropped. That `reset` was originally put in place to ensure
ordering of the default address first and to let us re-add a previously
removed address. So additional tests were added and a new approach
found.