### PR TITLE
Always pass the new order number on unreturned exchange failures

### DIFF
--- a/core/lib/spree/core/unreturned_item_charger.rb
+++ b/core/lib/spree/core/unreturned_item_charger.rb
@@ -10,7 +10,7 @@ module Spree
 
     class_attribute :failure_handler
 
-    attr_reader :original_order
+    attr_reader :original_order, :new_order
 
     def initialize(shipment, return_items)
       @shipment = shipment
@@ -19,6 +19,8 @@ module Spree
     end
 
     def charge_for_items
+      self.new_order = Spree::Order.create!(exchange_order_attributes)
+
       new_order.associate_user!(@original_order.user) if @original_order.user
 
       add_exchange_variants_to_order
@@ -53,11 +55,9 @@ module Spree
 
     end
 
-    def new_order
-      @new_order ||= Spree::Order.create!(exchange_order_attributes)
-    end
-
     private
+
+    attr_writer :new_order
 
     def add_exchange_variants_to_order
       @return_items.group_by(&:exchange_variant).map do |variant, variant_return_items|

--- a/core/lib/spree/core/unreturned_item_charger.rb
+++ b/core/lib/spree/core/unreturned_item_charger.rb
@@ -53,11 +53,11 @@ module Spree
 
     end
 
-    private
-
     def new_order
       @new_order ||= Spree::Order.create!(exchange_order_attributes)
     end
+
+    private
 
     def add_exchange_variants_to_order
       @return_items.group_by(&:exchange_variant).map do |variant, variant_return_items|

--- a/core/lib/tasks/exchanges.rake
+++ b/core/lib/tasks/exchanges.rake
@@ -20,12 +20,13 @@ namespace :exchanges do
       begin
         item_charger.charge_for_items
       rescue Spree::UnreturnedItemCharger::ChargeFailure => e
-        failure = {message: e.message, new_order: e.new_order.try(:number)}
+        failure = { message: e.message }
       rescue Exception => e
-        failure = {message: "#{e.class}: #{e.message}"}
+        failure = { message: "#{e.class}: #{e.message}" }
       end
 
       if failure
+        failure[:new_order] = item_charger.new_order.number if item_charger.new_order
         failures << failure.merge({
           order: item_charger.original_order.number,
           shipment: shipment.number,

--- a/core/lib/tasks/exchanges.rake
+++ b/core/lib/tasks/exchanges.rake
@@ -21,7 +21,7 @@ namespace :exchanges do
         item_charger.charge_for_items
       rescue Spree::UnreturnedItemCharger::ChargeFailure => e
         failure = { message: e.message }
-      rescue Exception => e
+      rescue => e
         failure = { message: "#{e.class}: #{e.message}" }
       end
 


### PR DESCRIPTION
Currently, anything that's not specifically a `ChargeFailure` will not
include the new order number. That's a pity, because something like an
out of stock error shows up as an exception that is not a
`ChargeFailure` and then it's really hard to even find the new error.

This always makes the new order available to the outside so that we
don't have to specifically read it from the exception.