### PR TITLE
Use the order updater when shipping shipments, or dealing with payments.

### DIFF
--- a/core/app/models/spree/order_shipping.rb
+++ b/core/app/models/spree/order_shipping.rb
@@ -74,7 +74,7 @@ class Spree::OrderShipping
 
     send_shipment_email(carton) if stock_location.fulfillable? && !suppress_mailer # e.g. digital gift cards that aren't actually shipped
     fulfill_order_stock_locations(stock_location)
-    update_order_state
+    @order.update!
 
     carton
   end
@@ -83,14 +83,6 @@ class Spree::OrderShipping
 
   def fulfill_order_stock_locations(stock_location)
     Spree::OrderStockLocation.fulfill_for_order_with_stock_location(@order, stock_location)
-  end
-
-  def update_order_state
-    new_state = Spree::OrderUpdater.new(@order).update_shipment_state
-    @order.update_columns(
-      shipment_state: new_state,
-      updated_at: Time.now,
-    )
   end
 
   def send_shipment_email(carton)

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -243,18 +243,8 @@ module Spree
       end
 
       def update_order
-        if completed? || void?
-          order.updater.update_payment_total
-        end
-
-        if order.completed?
-          order.updater.update_payment_state
-          order.updater.update_shipments
-          order.updater.update_shipment_state
-        end
-
-        if self.completed? || order.completed?
-          order.persist_totals
+        if order.completed? || completed? || void?
+          order.update!
         end
       end
 


### PR DESCRIPTION
Each commit describes the reasons for their respective changes.

At a high level, none of these objects should need to know how to update an order after performing their responsibilities. It is fair to say that they could know that the order should be updated, but the logic for doing so should be encapsulated in the order updater.

Every time we don't use the updater in situations were we should, our codebase becomes less cohesive. A problem that was recently discovered was how difficult it was to be notified when the order was updated to a new state, or set of states. The updater provides hooks for this, but they're not used as classes outside of the updater have been updating the order themselves.