### PR TITLE
Allow customizing the carton mailer class

### DIFF
--- a/core/app/mailers/spree/carton_mailer.rb
+++ b/core/app/mailers/spree/carton_mailer.rb
@@ -1,7 +1,18 @@
 module Spree
   class CartonMailer < BaseMailer
     # Send an email to customers to notify that an individual carton has been
-    # shipped.
+    # shipped. If a carton contains items from multiple orders then this will be
+    # called with that carton one time for each order.
+    #
+    # @param carton [Spree::Carton] the shipped carton
+    # @param order [Spree::Order] one of the orders with items in the carton
+    # @param resend [Boolean] indicates whether the email is a 'resend' (e.g.
+    #        triggered by the admin "resend" button)
+    # @return [Mail::Message]
+    #
+    # Note: The signature of this method has changed. The new (non-deprecated)
+    # signature is:
+    #   def shipped_email(carton:, order:, resend: false)
     def shipped_email(options, deprecated_options={})
       if options.is_a?(Integer)
         ActiveSupport::Deprecation.warn "Calling shipped_email with a carton_id is DEPRECATED. Instead use CartonMailer.shipped_email(order: order, carton: carton)"

--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -265,6 +265,15 @@ module Spree
       @promotion_chooser_class ||= Spree::PromotionChooser
     end
 
+    # @!attribute [rw] carton_shipped_email_class
+    #   @return [Class] The returned class should respond to:
+    #     `shipped_email(carton:, order:, resend: false)`
+    #     and should return a Mail::Message object.
+    attr_writer :carton_shipped_email_class
+    def carton_shipped_email_class
+      @carton_shipped_email_class ||= Spree::CartonMailer
+    end
+
     def static_model_preferences
       @static_model_preferences ||= Spree::Preferences::StaticModelPreferences.new
     end

--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -265,10 +265,12 @@ module Spree
       @promotion_chooser_class ||= Spree::PromotionChooser
     end
 
+    # Allows providing your own Mailer for shipped cartons.
+    #
     # @!attribute [rw] carton_shipped_email_class
-    #   @return [Class] The returned class should respond to:
-    #     `shipped_email(carton:, order:, resend: false)`
-    #     and should return a Mail::Message object.
+    # @return [ActionMailer::Base] an object that responds to "shipped_email"
+    #   (e.g. an ActionMailer with a "shipped_email" method) with the same
+    #   signature as Spree::CartonMailer.shipped_email.
     attr_writer :carton_shipped_email_class
     def carton_shipped_email_class
       @carton_shipped_email_class ||= Spree::CartonMailer

--- a/core/app/models/spree/order_shipping.rb
+++ b/core/app/models/spree/order_shipping.rb
@@ -87,7 +87,7 @@ class Spree::OrderShipping
 
   def send_shipment_emails(carton)
     carton.orders.each do |order|
-      Spree::CartonMailer.shipped_email(order: order, carton: carton).deliver_later
+      Spree::Config.carton_shipped_email_class.shipped_email(order: order, carton: carton).deliver_later
     end
   end
 end

--- a/core/lib/spree/mailer_previews/carton_preview.rb
+++ b/core/lib/spree/mailer_previews/carton_preview.rb
@@ -3,7 +3,7 @@ module Spree
     class CartonPreview < ActionMailer::Preview
       def shipped
         carton = Carton.first
-        CartonMailer.shipped_email(order: carton.orders.first, carton: carton)
+        Spree::Config.carton_shipped_email_class.shipped_email(order: carton.orders.first, carton: carton)
       end
     end
   end


### PR DESCRIPTION
So that stores can customize these emails in a more fine-tuned way
without having to monkey patch Spree::CartonMailer.

We were monkey patching Spree::CartonMailer and #310 ended up
breaking our monkey patch. Things we are customizing:

- add a bcc
- customize the subject
- set a custom instance variable that we use in our templates
- dynamically set the template path depending on the order's store

Instead of this PR we could alternatively provide hooks for
each of those things (and for some of them we could use
ActionMailer's `before_action` hooks).  Thoughts?

I'm guessing that emails are a frequently customized aspect of
Solidus.

If we do want to go the route of this PR then we should probably
add preferences like this for the order and reimbursement mailers
as well.  And possibly split out the OrderMailer into separate
classes for each type of Order email, so that we can
add/remove/deprecate different emails individually.