### PR TITLE
Add a promotion rule for customers who have not completed an order for X days.

### DIFF
--- a/backend/app/views/spree/admin/promotions/rules/_first_repeat_purchase_since.html.erb
+++ b/backend/app/views/spree/admin/promotions/rules/_first_repeat_purchase_since.html.erb
@@ -1,0 +1,7 @@
+<div class="field alpha four columns">
+  <%= Spree.t(:form_text, scope: "promotion_rule_types.first_repeat_purchase_since")  %>
+</div>
+
+<div class="field omega four columns">
+  <%= number_field_tag "#{param_prefix}[preferred_days_ago]", promotion_rule.preferred_days_ago, :class => 'fullwidth' %>
+</div>

--- a/core/app/models/spree/promotion/rules/first_repeat_purchase_since.rb
+++ b/core/app/models/spree/promotion/rules/first_repeat_purchase_since.rb
@@ -1,0 +1,36 @@
+module Spree
+  class Promotion
+    module Rules
+      class FirstRepeatPurchaseSince < PromotionRule
+        preference :days_ago, :integer, default: 365
+        validates :preferred_days_ago, numericality: { only_integer: true, greater_than: 0 }
+
+        # This promotion is applicable to orders only.
+        def applicable?(promotable)
+          promotable.is_a?(Spree::Order)
+        end
+
+        # This is never eligible if the order does not have a user, and that user does not have any previous completed orders.
+        #
+        # This is eligible if the user's most recently completed order is more than the preferred months ago
+        # @param order [Spree::Order]
+        # @option options
+        def eligible?(order, options = {})
+          return false unless order.user
+
+          last_order = last_completed_order(order.user)
+          return false unless last_order
+
+          last_order.completed_at < preferred_days_ago.days.ago
+        end
+
+        private
+
+        def last_completed_order user
+          user.orders.complete.order(:completed_at).last
+        end
+      end
+    end
+  end
+end
+

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1228,6 +1228,10 @@ en:
         description: Apply a promotion to every nth order a user has completed.
         name: Nth Order
         form_text: "Apply this promotion on the users Nth order: "
+      first_repeat_purchase_since:
+        description: Available only to user who have not purchased in a while
+        name: First Repeat Purchase Since
+        form_text: "Apply this promotion to users whose last order was more than X days ago: "
     promotions: Promotions
     promotion_successfully_created: Promotion has been successfully created!
     promotion_total_changed_before_complete: "One or more of the promotions on your order have become ineligible and were removed. Please check the new order amounts and try again."

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -93,7 +93,8 @@ module Spree
           Spree::Promotion::Rules::OneUsePerUser,
           Spree::Promotion::Rules::Taxon,
           Spree::Promotion::Rules::NthOrder,
-          Spree::Promotion::Rules::OptionValue
+          Spree::Promotion::Rules::OptionValue,
+          Spree::Promotion::Rules::FirstRepeatPurchaseSince,
         ]
       end
 

--- a/core/spec/models/spree/promotion/rules/first_repeat_purchase_since_spec.rb
+++ b/core/spec/models/spree/promotion/rules/first_repeat_purchase_since_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+
+describe Spree::Promotion::Rules::FirstRepeatPurchaseSince do
+  describe "#applicable?" do
+    subject { described_class.new.applicable?(promotable) }
+
+    context "when the promotable is an order" do
+      let(:promotable) { Spree::Order.new }
+
+      it { is_expected.to be true }
+    end
+
+    context "when the promotable is not a order" do
+      let(:promotable) { Spree::LineItem.new }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe "eligible?" do
+    let(:instance) { described_class.new }
+    subject { instance.eligible?(order) }
+
+    before do
+      instance.preferred_days_ago = 365
+    end
+
+    context "when the order does not have a user" do
+      let(:order) { Spree::Order.new }
+
+      it { is_expected.to be false }
+    end
+
+    context "when the order has a user" do
+      let(:order) { create :order }
+      let(:user) { order.user }
+
+      context "when the user has completed orders" do
+        let(:order_completion_date_1) { 1.day.ago }
+        let(:order_completion_date_2) { 1.day.ago }
+        before do
+          old_order_1 = create :completed_order_with_totals, user: user
+          old_order_1.update_attributes(completed_at: order_completion_date_1)
+
+          old_order_2 = create :completed_order_with_totals, user: user
+          old_order_2.update_attributes(completed_at: order_completion_date_2)
+        end
+
+        context "the last completed order was greater than the preferred months ago" do
+          let(:order_completion_date_1) { 14.months.ago }
+          let(:order_completion_date_2) { 13.months.ago }
+
+          it { is_expected.to be true }
+        end
+
+        context "the last completed order was less than the preferred months ago" do
+          let(:order_completion_date_1) { 14.months.ago }
+          let(:order_completion_date_2) { 11.months.ago }
+
+          it { is_expected.to be false }
+        end
+      end
+
+      context "when the user has no completed orders " do
+        it { is_expected.to be false }
+      end
+    end
+  end
+end


### PR DESCRIPTION
This can be helpful for customer reactivation campaigns.