### PR TITLE
FIx a stale data issue when using Spree::OrderCapturing.

### DIFF
--- a/core/app/models/spree/order_capturing.rb
+++ b/core/app/models/spree/order_capturing.rb
@@ -33,7 +33,10 @@ class Spree::OrderCapturing
           end
         end
       ensure
-        @order.update!
+        # FIXME: Adding the inverse_of on the payments relation for orders -should- fix this,
+        # however it only appears to make it worse (calling with changes three times instead of once.
+        # Warrants an investigation. Reloading for now.
+        @order.reload.update!
       end
     end
   end


### PR DESCRIPTION
As described in the comment, calling `payment.capture!` triggers an
after_save on Spree::Payment. In this after_save, things can happen, one
of those things is an `order.update!`.

That means if the `order.update!` happens within a payment after save, the order we have stored in `@order` is now out of date, and has to be reloaded.

If we don't reload it, the hooks in the order updater will be called
twice. If they make decisions around fresh state changes, idempotency
could be compromised. cc @athal7 