### PR TITLE
Use helpers from RansackableAttributes on the user model.

### DIFF
--- a/core/app/models/concerns/spree/user_methods.rb
+++ b/core/app/models/concerns/spree/user_methods.rb
@@ -23,13 +23,10 @@ module Spree
       has_many :store_credit_events, through: :store_credits
       money_methods :total_available_store_credit
 
-      def self.ransackable_associations(auth_object=nil)
-        %w[addresses]
-      end
+      include Spree::RansackableAttributes unless included_modules.include?(Spree::RansackableAttributes)
 
-      def self.ransackable_attributes(auth_object=nil)
-        %w[id email]
-      end
+      self.whitelisted_ransackable_associations = %w[addresses]
+      self.whitelisted_ransackable_attributes = %w[id email]
     end
 
     # has_spree_role? simply needs to return true or false whether a user has a role or not.


### PR DESCRIPTION
At the time this was introduced, the RansackableAttributes module was
not included into the user model. It probably could have been, but
https://github.com/solidusio/solidus_auth_devise/commit/2a5ab50368c9f196abff72b226b302187e19642a
brought my attention back to the notion that we were overriding these
whitelists differently on the user.

This change will make it easier for additions / overrides to the
whitelisted user attributes for people in their specific stores.