### PR TITLE
Restrict user management permissions.

### DIFF
--- a/core/lib/spree/permission_sets/user_management.rb
+++ b/core/lib/spree/permission_sets/user_management.rb
@@ -2,7 +2,15 @@ module Spree
   module PermissionSets
     class UserManagement < PermissionSets::Base
       def activate!
-        can :manage, Spree.user_class
+        # due to how cancancan filters by associations,
+        # we have to define this twice, once for `accessible_by`
+        can :manage, Spree.user_class, spree_roles: { id: nil }
+        # and once for `can?`
+        can :manage, Spree.user_class do |user|
+          user.spree_roles.none?
+        end
+
+        can :manage, Spree.user_class, id: user.id if user
         cannot [:delete, :destroy], Spree.user_class
         can :manage, Spree::StoreCredit
         can :display, Spree::Role

--- a/core/spec/models/spree/permission_sets/user_management_spec.rb
+++ b/core/spec/models/spree/permission_sets/user_management_spec.rb
@@ -1,7 +1,8 @@
 require 'spec_helper'
 
 describe Spree::PermissionSets::UserManagement do
-  let(:ability) { DummyAbility.new }
+  let(:user) { create(:user) }
+  let(:ability) { DummyAbility.new(user) }
 
   subject { ability }
 
@@ -10,7 +11,23 @@ describe Spree::PermissionSets::UserManagement do
       described_class.new(ability).activate!
     end
 
-    it { is_expected.to be_able_to(:manage, Spree.user_class) }
+    it "can manage users with no roles" do
+      expect(ability).to be_able_to :manage, create(:user)
+    end
+
+    it "cannot manage users with roles" do
+      # to protect against a privelege-escalation vulnerability whereby
+      # the lower-level admin changes a higher-level admin's email
+      # address to an email address the lower-level admin has access to,
+      # thus taking over a higher-level admin account
+
+      expect(ability).not_to be_able_to :manage, create(:admin_user)
+    end
+
+    it "can manage itself even with roles" do
+      expect(ability).to be_able_to :manage, user
+    end
+
     it { is_expected.not_to be_able_to(:delete, Spree.user_class) }
     it { is_expected.not_to be_able_to(:destroy, Spree.user_class) }
     it { is_expected.to be_able_to(:manage, Spree::StoreCredit) }

--- a/core/spec/support/dummy_ability.rb
+++ b/core/spec/support/dummy_ability.rb
@@ -1,4 +1,10 @@
 class DummyAbility
   include CanCan::Ability
+
+  attr_reader :user
+
+  def initialize(current_user = nil)
+    @user = current_user || Spree.user_class.new
+  end
 end
 


### PR DESCRIPTION
Only allow users with the UserManagement permission to edit themselves
or users who have no roles.

There is a potential for privelege escalation if we allow users to edit
user accounts that have roles, whereby they change the other user's
email to an email they have access to, thereby gaining access to a
higher-level account.

Given that we don't have a way of knowing the hierarchy of roles, it
seems safer to only allow super admins to edit of user accounts that have roles.