### PR TITLE
Add inverse_of to the payments association.

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -49,7 +49,7 @@ module Spree
     belongs_to :store, class_name: 'Spree::Store'
     has_many :state_changes, as: :stateful
     has_many :line_items, -> { order(:created_at, :id) }, dependent: :destroy, inverse_of: :order
-    has_many :payments, dependent: :destroy
+    has_many :payments, dependent: :destroy, inverse_of: :order
     has_many :return_authorizations, dependent: :destroy, inverse_of: :order
     has_many :reimbursements, inverse_of: :order
     has_many :adjustments, -> { order(:created_at) }, as: :adjustable, inverse_of: :adjustable, dependent: :destroy

--- a/core/spec/models/spree/order/payment_spec.rb
+++ b/core/spec/models/spree/order/payment_spec.rb
@@ -69,10 +69,6 @@ module Spree
 
     context "ensure source attributes stick around" do
       # For the reason of this test, please see spree/spree_gateway#132
-      it "does not have inverse_of defined" do
-        expect(Spree::Order.reflections['payments'].options[:inverse_of]).to be_nil
-      end
-
       it "keeps source attributes after updating" do
         persisted_order = Spree::Order.create
         credit_card_payment_method = create(:credit_card_payment_method)


### PR DESCRIPTION
This is an investigative commit, as the regression for the original
issue now passes with the inverse of, though it appears to cause other
issues.

We should be able to use this now, PR'd for specs and discussion cc @jhawthorn 