### PR TITLE
Make Spree.fetch_cart honor app mount path

### DIFF
--- a/frontend/app/assets/javascripts/spree/frontend/cart.js.coffee
+++ b/frontend/app/assets/javascripts/spree/frontend/cart.js.coffee
@@ -8,8 +8,8 @@ Spree.ready ($) ->
   ($ 'form#update-cart').submit ->
     ($ 'form#update-cart #update-button').attr('disabled', true)
 
-Spree.fetch_cart = (cart_url) ->
+Spree.fetch_cart = (cartLinkUrl) ->
   Spree.ajax
-    url: cart_url || Spree.pathFor("cart_link"),
+    url: cartLinkUrl || Spree.pathFor("cart_link"),
     success: (data) ->
       $('#link-to-cart').html data

--- a/frontend/app/assets/javascripts/spree/frontend/cart.js.coffee
+++ b/frontend/app/assets/javascripts/spree/frontend/cart.js.coffee
@@ -8,8 +8,8 @@ Spree.ready ($) ->
   ($ 'form#update-cart').submit ->
     ($ 'form#update-cart #update-button').attr('disabled', true)
 
-Spree.fetch_cart = ->
+Spree.fetch_cart = (cart_url) ->
   Spree.ajax
-    url: Spree.pathFor("cart_link"),
+    url: cart_url || Spree.pathFor("cart_link"),
     success: (data) ->
       $('#link-to-cart').html data

--- a/frontend/app/views/spree/shared/_main_nav_bar.html.erb
+++ b/frontend/app/views/spree/shared/_main_nav_bar.html.erb
@@ -7,6 +7,6 @@
       </noscript>
       &nbsp;
     </li>
-    <script>Spree.fetch_cart()</script>
+    <script>Spree.fetch_cart('<%= j cart_link_url %>')</script>
   </ul>
 </nav>


### PR DESCRIPTION
Spree.fetch_cart now honors the application mount path
(which may vary per request) instead of using a fixed
value of /cart_link (in case Solidus was mounted at "/").

The primary benefit of this change is to allow the cart
to be properly localized automatically, as soon as the
mount is wrapped into something like:

scope "(:locale)", locale: /en|de|it/ do
  mount Spree::Core::Engine, :at => '/'
end