### PR TITLE
Always print address fields br tags

### DIFF
--- a/frontend/app/views/spree/address/_form.html.erb
+++ b/frontend/app/views/spree/address/_form.html.erb
@@ -59,11 +59,11 @@
   <% end %>
 
   <p class="field" id=<%="#{address_id}zipcode" %>>
-    <%= form.label :zipcode, Spree.t(:zip) %><% if address.require_zipcode? %><span class="required">*</span><br /><% end %>
+    <%= form.label :zipcode, Spree.t(:zip) %><% if address.require_zipcode? %><span class="required">*</span><% end %><br />
     <%= form.text_field :zipcode, :class => "#{'required' if address.require_zipcode?}" %>
   </p>
   <p class="field" id=<%="#{address_id}phone" %>>
-    <%= form.label :phone, Spree.t(:phone) %><% if address.require_phone? %><span class="required">*</span><br /><% end %>
+    <%= form.label :phone, Spree.t(:phone) %><% if address.require_phone? %><span class="required">*</span><% end %><br />
     <%= form.phone_field :phone, :class => "#{'required' if address.require_phone?}" %>
   </p>
   <% if Spree::Config[:alternative_shipping_phone] %>


### PR DESCRIPTION
Right now br tags are not printed when zipcode or address are not
required making the markup not consistent