### PR TITLE
Debug logging for all order transitions

### DIFF
--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -133,7 +133,7 @@ module Spree
 
 
               after_failure do |order, transition|
-                order.logger.debug "Order #{order.number} halted transition on event #{transition.event} state #{transition.from}"
+                order.logger.debug "Order #{order.number} halted transition on event #{transition.event} state #{transition.from}: #{order.errors.full_messages.join}"
               end
             end
 

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -126,6 +126,15 @@ module Spree
                 order.update_totals
                 order.persist_totals
               end
+
+              after_transition do |order, transition|
+                order.logger.debug "Order #{order.number} transitioned from #{transition.from} to #{transition.to} via #{transition.event}"
+              end
+
+
+              after_failure do |order, transition|
+                order.logger.debug "Order #{order.number} halted transition on event #{transition.event} state #{transition.from}"
+              end
             end
 
             alias_method :save_state, :save


### PR DESCRIPTION
Adds logging for any successful or failed Order state transitions. Should help debugging and since this is at the debug level (same level as SQL queries) I'm hopeful it isn't too spammy.

I tried to be careful with the wording of the failure message, because we often have failures intentionally (ie. when using `#advance`) and we don't want that to sound like a fatal error.

Idea from @dkendal.

