### PR TITLE
Restrict who has the ability to update a user's email address.

### DIFF
--- a/api/app/controllers/spree/api/users_controller.rb
+++ b/api/app/controllers/spree/api/users_controller.rb
@@ -15,6 +15,10 @@ class Spree::Api::UsersController < Spree::Api::ResourceController
   end
 
   def permitted_resource_attributes
-    super | [bill_address_attributes: permitted_address_attributes, ship_address_attributes: permitted_address_attributes]
+    if action_name == "create" || can?(:update_email, user)
+      super | [:email]
+    else
+      super
+    end
   end
 end

--- a/backend/app/controllers/spree/admin/users_controller.rb
+++ b/backend/app/controllers/spree/admin/users_controller.rb
@@ -109,10 +109,11 @@ module Spree
         end
 
         def user_params
-          attributes = permitted_user_attributes | [
-            ship_address_attributes: permitted_address_attributes,
-            bill_address_attributes: permitted_address_attributes
-          ]
+          attributes = permitted_user_attributes
+
+          if action_name == "create" || can?(:update_email, @user)
+            attributes |= [:email]
+          end
 
           if can? :manage, Spree::Role
             attributes += [{ spree_role_ids: [] }]

--- a/backend/app/views/spree/admin/users/_form.html.erb
+++ b/backend/app/views/spree/admin/users/_form.html.erb
@@ -2,7 +2,12 @@
   <div class="alpha six columns">
     <%= f.field_container :email do %>
       <%= f.label :email, Spree.t(:email) %>
-      <%= f.email_field :email, :class => 'fullwidth', disabled: cannot?(:update_email, @user) %>
+      <% if can?(:update_email, @user) %>
+        <%= f.email_field :email, :class => 'fullwidth' %>
+      <% else %>
+        <span title="<%= Spree.t(:cannot_update_email) %>" class="fa fa-question-circle icon_link no-text with-tip"></span>
+        <%= f.email_field :email, :class => 'fullwidth', disabled: true %>
+      <% end %>
       <%= error_message_on :user, :email %>
     <% end %>
 

--- a/backend/app/views/spree/admin/users/_form.html.erb
+++ b/backend/app/views/spree/admin/users/_form.html.erb
@@ -2,7 +2,7 @@
   <div class="alpha six columns">
     <%= f.field_container :email do %>
       <%= f.label :email, Spree.t(:email) %>
-      <%= f.email_field :email, :class => 'fullwidth' %>
+      <%= f.email_field :email, :class => 'fullwidth', disabled: cannot?(:update_email, @user) %>
       <%= error_message_on :user, :email %>
     <% end %>
 

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -589,6 +589,7 @@ en:
     cannot_rebuild_shipments_shipments_not_pending: Cannot rebuild shipments for an order with non-pending shipments.
     cannot_perform_operation: Cannot perform requested operation
     cannot_set_shipping_method_without_address: Cannot set shipping method until customer details are provided.
+    cannot_update_email: You do not have access to update this user's email address. <br />Please contact a superuser if you need to perform this action.
     capture: Capture
     capture_events: Capture events
     card_code: Card Code

--- a/core/lib/spree/core/controller_helpers/strong_parameters.rb
+++ b/core/lib/spree/core/controller_helpers/strong_parameters.rb
@@ -48,6 +48,13 @@ module Spree
             product_properties_attributes: permitted_product_properties_attributes
           ]
         end
+
+        def permitted_user_attributes
+          permitted_attributes.user_attributes + [
+            bill_address_attributes: permitted_address_attributes,
+            ship_address_attributes: permitted_address_attributes
+          ]
+        end
       end
     end
   end

--- a/core/lib/spree/permission_sets/default_customer.rb
+++ b/core/lib/spree/permission_sets/default_customer.rb
@@ -17,7 +17,7 @@ module Spree
         can :display, ProductProperty
         can :display, Property
         can :create, Spree.user_class
-        can [:read, :update], Spree.user_class, id: user.id
+        can [:read, :update, :update_email], Spree.user_class, id: user.id
         can :display, State
         can :display, StockItem, stock_location: { active: true }
         can :display, StockLocation, active: true

--- a/core/lib/spree/permission_sets/user_management.rb
+++ b/core/lib/spree/permission_sets/user_management.rb
@@ -2,7 +2,16 @@ module Spree
   module PermissionSets
     class UserManagement < PermissionSets::Base
       def activate!
-        can :manage, Spree.user_class
+        can [:admin, :display, :create, :update], Spree.user_class
+
+        # due to how cancancan filters by associations,
+        # we have to define this twice, once for `accessible_by`
+        can :update_email, Spree.user_class, spree_roles: { id: nil }
+        # and once for `can?`
+        can :update_email, Spree.user_class do |user|
+          user.spree_roles.none?
+        end
+
         cannot [:delete, :destroy], Spree.user_class
         can :manage, Spree::StoreCredit
         can :display, Spree::Role

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -110,8 +110,11 @@ module Spree
 
     @@transfer_item_attributes = [:variant_id, :expected_quantity, :received_quantity]
 
-    # TODO Should probably use something like Spree.user_class.attributes
-    @@user_attributes = [:email, :password, :password_confirmation]
+    # intentionally leaving off email here to prevent privilege escalation
+    # by changing a user with higher priveleges' email to one a lower-priveleged
+    # admin owns. creating a user with an email is handled separate at the
+    # controller level
+    @@user_attributes = [:password, :password_confirmation]
 
     @@variant_attributes = [
       :name, :presentation, :cost_price, :lock_version,

--- a/core/spec/models/spree/permission_sets/user_management_spec.rb
+++ b/core/spec/models/spree/permission_sets/user_management_spec.rb
@@ -10,7 +10,13 @@ describe Spree::PermissionSets::UserManagement do
       described_class.new(ability).activate!
     end
 
-    it { is_expected.to be_able_to(:manage, Spree.user_class) }
+    it { is_expected.to be_able_to(:admin, Spree.user_class) }
+    it { is_expected.to be_able_to(:display, Spree.user_class) }
+    it { is_expected.to be_able_to(:create, Spree.user_class) }
+    it { is_expected.to be_able_to(:update, Spree.user_class) }
+    it { is_expected.to be_able_to(:update_email, Spree.user_class.new(spree_roles: [])) }
+
+    it { is_expected.not_to be_able_to(:update_email, Spree.user_class.new(spree_roles: [create(:role)])) }
     it { is_expected.not_to be_able_to(:delete, Spree.user_class) }
     it { is_expected.not_to be_able_to(:destroy, Spree.user_class) }
     it { is_expected.to be_able_to(:manage, Spree::StoreCredit) }


### PR DESCRIPTION
There is a possibility for privelege escalation whereby a lower-level
admin changes the email address of a higher-level admin to an email
address they have access to, thereby gaining access to more admin
permissions. To prevent this vulnerability, this code restricts the
ability for admins with roles below SuperUser only to update the email
address for themselves and for users with no roles.

* Refactor permitted_user_attributes, remove email, add nested address attributes that were duplicated
* Permit email attribute on create and when the user has the ability
* Restrict UserManagement permission to not update email for users with roles
* Disable the admin user email field when not authorized to update it