### PR TITLE
Only check transfer_item stock in source_location before shipment

### DIFF
--- a/api/spec/controllers/spree/api/stock_transfers_controller_spec.rb
+++ b/api/spec/controllers/spree/api/stock_transfers_controller_spec.rb
@@ -46,6 +46,21 @@ module Spree
           end
         end
 
+        context "transfer item does not have stock in source location after ship" do
+          let(:variant_id) { transfer_item.variant.to_param }
+          let(:user) { create :user }
+
+          before do
+            stock_transfer.finalize(user)
+            stock_transfer.ship(shipped_at: Time.now)
+            stock_transfer.source_location.stock_item(transfer_item.variant_id).set_count_on_hand(0)
+          end
+
+          it "can still receive item" do
+            expect { subject }.to change { transfer_item.reload.received_quantity }.by(1)
+          end
+        end
+
         context "transfer item has been fully received" do
           let(:variant_id) { transfer_item.variant.to_param }
 

--- a/core/app/models/spree/transfer_item.rb
+++ b/core/app/models/spree/transfer_item.rb
@@ -21,7 +21,7 @@ module Spree
     private
 
     def ensure_stock_transfer_not_closed
-      if stock_transfer_closed?
+      if stock_transfer.closed?
         errors.add(:base, Spree.t('errors.messages.cannot_modify_transfer_item_closed_stock_transfer'))
       end
     end
@@ -47,12 +47,8 @@ module Spree
       end
     end
 
-    def stock_transfer_closed?
-      stock_transfer.closed?
-    end
-
     def check_stock?
-      !stock_transfer_closed? && stock_transfer.source_location.check_stock_on_transfer?
+      !stock_transfer.shipped? && stock_transfer.source_location.check_stock_on_transfer?
     end
   end
 end

--- a/core/spec/models/spree/transfer_item_spec.rb
+++ b/core/spec/models/spree/transfer_item_spec.rb
@@ -69,9 +69,9 @@ describe Spree::TransferItem do
         end
       end
 
-      context "transfer order is closed" do
+      context "transfer order is shipped" do
         before do
-          stock_transfer.update_attributes!(closed_at: Time.now)
+          stock_transfer.update_attributes!(shipped_at: Time.now)
         end
 
         context "variant is not available" do


### PR DESCRIPTION
Stock checks for transfer items in the source location should only happen before the transfer ships; there should not be a stock check when receiving transfer items.

* Change #check_stock validation to run when a stock_transfer has not been shipped
* Specs