### PR TITLE
be more forgiving in receiving a ready event in a shipment

### DIFF
--- a/api/app/controllers/spree/api/shipments_controller.rb
+++ b/api/app/controllers/spree/api/shipments_controller.rb
@@ -43,15 +43,12 @@ module Spree
       end
 
       def ready
-        unless @shipment.ready?
-          if @shipment.can_ready?
-            @shipment.ready!
-          else
-            logger.error("cannot_ready_shipment shipment_state=#{@shipment.state}")
-            render 'spree/api/shipments/cannot_ready_shipment', status: 422 and return
-          end
+        if @shipment.ready_to_ship
+          respond_with(@shipment, default_template: :show)
+        else
+          logger.error("cannot_ready_shipment shipment_state=#{@shipment.state}")
+          render 'spree/api/shipments/cannot_ready_shipment', status: 422 and return
         end
-        respond_with(@shipment, default_template: :show)
       end
 
       def ship

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -38,7 +38,7 @@ module Spree
 
     # shipment state machine (see http://github.com/pluginaweek/state_machine/tree/master for details)
     state_machine initial: :pending, use_transactions: false do
-      event :ready do
+      event :ready_to_ship do
         transition from: :pending, to: :shipped, if: :can_transition_from_pending_to_shipped?
         transition from: :pending, to: :ready, if: :can_transition_from_pending_to_ready?
         transition from: :shipped, to: :shipped
@@ -76,6 +76,21 @@ module Spree
 
     self.whitelisted_ransackable_associations = ['order']
     self.whitelisted_ransackable_attributes = ['number']
+
+    def ready
+      ActiveSupport::Deprecation.warn "Use the #ready_to_ship event on Shipment instead", caller
+      ready_to_ship
+    end
+
+    def ready!
+      ActiveSupport::Deprecation.warn "Use the #ready_to_ship! event on Shipment instead", caller
+      ready_to_ship!
+    end
+
+    def can_ready?
+      ActiveSupport::Deprecation.warn "Use #can_ready_to_ship? on Shipment instead", caller
+      can_ready_to_ship?
+    end
 
     def can_transition_from_pending_to_shipped?
       !requires_shipment?

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -389,7 +389,8 @@ module Spree
 
     private
 
-      def after_ship
+      def after_ship(transition)
+        return if transition.from_name == :shipped
         order.shipping.ship_shipment(self, suppress_mailer: suppress_mailer)
       end
 

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -41,6 +41,8 @@ module Spree
       event :ready do
         transition from: :pending, to: :shipped, if: :can_transition_from_pending_to_shipped?
         transition from: :pending, to: :ready, if: :can_transition_from_pending_to_ready?
+        transition from: :shipped, to: :shipped
+        transition from: :ready,   to: :ready
       end
 
       event :pend do

--- a/core/spec/models/spree/order_shipping_spec.rb
+++ b/core/spec/models/spree/order_shipping_spec.rb
@@ -230,7 +230,7 @@ describe Spree::OrderShipping do
         )
       end
 
-      before { shipment.ready! }
+      before { shipment.ready_to_ship! }
 
       it "updates the state to shipped" do
         order.shipping.ship_shipment(shipment)

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -493,15 +493,14 @@ describe Spree::Shipment, :type => :model do
 
     it "is treated as a no-op for a shipped order" do
       shipment.state = 'shipped'
+      expect(order.shipping).to receive(:ship_shipment).never
       shipment.ready_to_ship!
-      expect(shipment).to receive(:after_ship).never
       expect(shipment.state).to eq 'shipped'
     end
 
     it "is treated as a no-op for a ready order" do
       shipment.state = 'ready'
       shipment.ready_to_ship!
-      expect(shipment).to receive(:after_ship).never
       expect(shipment.state).to eq 'ready'
     end
   end

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -490,6 +490,18 @@ describe Spree::Shipment, :type => :model do
       expect(order).to receive_messages(paid?: false)
       expect(shipment).not_to be_can_ready
     end
+
+    it "is treated as a no-op for a shipped order" do
+      shipment.state = 'shipped'
+      shipment.ready!
+      expect(shipment.state).to eq 'shipped'
+    end
+
+    it "is treated as a no-op for a ready order" do
+      shipment.state = 'ready'
+      shipment.ready!
+      expect(shipment.state).to eq 'ready'
+    end
   end
 
   context "updates cost when selected shipping rate is present" do

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -488,18 +488,18 @@ describe Spree::Shipment, :type => :model do
     # Regression test for #2040
     it "cannot ready a shipment for an order if the order is unpaid" do
       expect(order).to receive_messages(paid?: false)
-      expect(shipment).not_to be_can_ready
+      expect(shipment).not_to be_can_ready_to_ship
     end
 
     it "is treated as a no-op for a shipped order" do
       shipment.state = 'shipped'
-      shipment.ready!
+      shipment.ready_to_ship!
       expect(shipment.state).to eq 'shipped'
     end
 
     it "is treated as a no-op for a ready order" do
       shipment.state = 'ready'
-      shipment.ready!
+      shipment.ready_to_ship!
       expect(shipment.state).to eq 'ready'
     end
   end
@@ -655,7 +655,7 @@ describe Spree::Shipment, :type => :model do
 
     it "are logged to the database" do
       expect(shipment.state_changes).to be_empty
-      expect(shipment.ready!).to be true
+      expect(shipment.ready_to_ship!).to be true
       expect(shipment.state_changes.count).to eq(1)
       state_change = shipment.state_changes.first
       expect(state_change.previous_state).to eq('pending')
@@ -677,13 +677,13 @@ describe Spree::Shipment, :type => :model do
     before { allow(order).to receive_messages paid?: true }
 
     it 'proceeds automatically to shipped state' do
-      unshippable_shipment.ready!
+      unshippable_shipment.ready_to_ship!
       expect(unshippable_shipment.state).to eq('shipped')
     end
 
     it 'does not send a confirmation email' do
       expect {
-        unshippable_shipment.ready!
+        unshippable_shipment.ready_to_ship!
         unshippable_shipment.inventory_units(true).each do |unit|
           expect(unit.state).to eq('shipped')
         end

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -494,12 +494,14 @@ describe Spree::Shipment, :type => :model do
     it "is treated as a no-op for a shipped order" do
       shipment.state = 'shipped'
       shipment.ready_to_ship!
+      expect(shipment).to receive(:after_ship).never
       expect(shipment.state).to eq 'shipped'
     end
 
     it "is treated as a no-op for a ready order" do
       shipment.state = 'ready'
       shipment.ready_to_ship!
+      expect(shipment).to receive(:after_ship).never
       expect(shipment.state).to eq 'ready'
     end
   end


### PR DESCRIPTION
this allows partial failures and corners cases to retry with
less manual intervention