### PR TITLE
Use save instead of update_columns in the OrderUpdater

### DIFF
--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -97,20 +97,7 @@ module Spree
     end
 
     def persist_totals
-      order.update_columns(
-        payment_state: order.payment_state,
-        shipment_state: order.shipment_state,
-        item_total: order.item_total,
-        item_count: order.item_count,
-        adjustment_total: order.adjustment_total,
-        included_tax_total: order.included_tax_total,
-        additional_tax_total: order.additional_tax_total,
-        payment_total: order.payment_total,
-        shipment_total: order.shipment_total,
-        promo_total: order.promo_total,
-        total: order.total,
-        updated_at: Time.current,
-      )
+      order.save!(validate: false)
     end
 
     # Updates the +shipment_state+ attribute according to the following logic:

--- a/core/lib/spree/core/importer/order.rb
+++ b/core/lib/spree/core/importer/order.rb
@@ -4,7 +4,7 @@ module Spree
       class Order
 
         def self.import(user, params)
-          begin
+          ActiveRecord::Base.transaction do
             ensure_country_id_from_params params[:ship_address_attributes]
             ensure_state_id_from_params params[:ship_address_attributes]
             ensure_country_id_from_params params[:bill_address_attributes]
@@ -45,9 +45,6 @@ module Spree
               end
             end
             order.reload
-          rescue
-            order.destroy if order && order.persisted?
-            raise
           end
         end
 


### PR DESCRIPTION
This uses a plan-old `#save(validate: false)` instead of using `update_columns`. A few changes were needed to make this work:

* Removing `homogenize_line_item_currencies`, which could cause an order update on an order save.
* Tweaking the `Importer::Order` so that `order.contents.add` wasn't called with an unsaved shipment on the order.

I don't think this would be considered a change to our public API, but it has some potential to cause issues in other stores. However, I think it's also a significant improvement, and would allow `after_save` and similar AR hooks to actually work as expected.

Looking for thoughts on:
* What is the point of `homogenize_line_item_currencies`? It was unit tested, but I don't understand what sort of store would need this behaviour.
* Can we make this change to the Updater.