### PR TITLE
Use CanCan::Ability.merge

### DIFF
--- a/core/app/models/spree/ability.rb
+++ b/core/app/models/spree/ability.rb
@@ -51,7 +51,7 @@ module Spree
     def register_extension_abilities
       Ability.abilities.each do |clazz|
         ability = clazz.send(:new, user)
-        @rules = rules + ability.send(:rules)
+        merge(ability)
       end
     end
 


### PR DESCRIPTION
Avoids calling the private method. Ensures this will be compatible if the implementation of rules changes.