### PR TITLE
Add the ability to run the seeds/examples multiple times

### DIFF
--- a/core/db/default/spree/zones.rb
+++ b/core/db/default/spree/zones.rb
@@ -1,5 +1,5 @@
-eu_vat = Spree::Zone.create!(name: "EU_VAT", description: "Countries that make up the EU VAT zone.")
-north_america = Spree::Zone.create!(name: "North America", description: "USA + Canada")
+eu_vat = Spree::Zone.find_or_create_by!(name: "EU_VAT", description: "Countries that make up the EU VAT zone.")
+north_america = Spree::Zone.find_or_create_by!(name: "North America", description: "USA + Canada")
 
 ["Poland", "Finland", "Portugal", "Romania", "Germany", "France",
  "Slovakia", "Hungary", "Slovenia", "Ireland", "Austria", "Spain",

--- a/sample/db/samples/tax_categories.rb
+++ b/sample/db/samples/tax_categories.rb
@@ -1,1 +1,1 @@
-Spree::TaxCategory.create!(:name => "Default")
+Spree::TaxCategory.create!(:name => Spree::TaxCategory.find_by!(:name => "Default"))

--- a/sample/db/samples/tax_categories.rb
+++ b/sample/db/samples/tax_categories.rb
@@ -1,1 +1,1 @@
-Spree::TaxCategory.create!(:name => Spree::TaxCategory.find_by!(:name => "Default"))
+Spree::TaxCategory.find_or_create_by!(:name => "Default")


### PR DESCRIPTION
We have to have the ability to run the seeds/examples multiple time without it giving
errors about records were already existing.

The seeds were not idempotent which means that if you would run the seeds
multiple time you would not able to complete without it giving you an error or
create saying a record was already existing. 

Also if you were to run your custom seeds before running these seeds, you would
get multiple issue saying the record already exists.
