### PR TITLE
Cleanup of shipment spec

### DIFF
--- a/core/lib/spree/testing_support/factories/shipping_rate_factory.rb
+++ b/core/lib/spree/testing_support/factories/shipping_rate_factory.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :shipping_rate, class: Spree::ShippingRate do
+    shipment { nil }
+    cost 10
+  end
+end


### PR DESCRIPTION
Revised specs are largly based on Alex's work, found in https://github.com/solidusio/solidus/pull/49

The shipment spec in the master branch has advanced considerably to
Alex's work with regards to the state-machine's transitioning spec to
`resume`; therefore, the specs from the master-branch have replaced his
work.

Both the state-machine transition specs for `cancel` and `resume` have
been wrapped in a context block, so as to provide a reason as to why these are
a departure from the usual naming scheme. This is because these methods
are not explicity defined, and are defined via the state-machine itself.

* Add spec for `#final_price_with_items`
* Add spec for `editable_by?`