### PR TITLE
Fix #326: Rename routes due to deprecation of open/close on order adjustments

### DIFF
--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -2,7 +2,7 @@ module Spree
   module Admin
     class OrdersController < Spree::Admin::BaseController
       before_action :initialize_order_events
-      before_action :load_order, only: [:edit, :update, :complete, :advance, :cancel, :resume, :approve, :resend, :open_adjustments, :close_adjustments, :cart, :confirm]
+      before_action :load_order, only: [:edit, :update, :complete, :advance, :cancel, :resume, :approve, :resend, :unfinalize_adjustments, :finalize_adjustments, :cart, :confirm]
       around_filter :lock_order, :only => [:update, :advance, :complete, :confirm, :cancel, :resume, :approve, :resend]
 
       rescue_from Spree::Order::InsufficientStock, with: :insufficient_stock_error
@@ -151,18 +151,18 @@ module Spree
         redirect_to :back
       end
 
-      def open_adjustments
+      def unfinalize_adjustments
         adjustments = @order.all_adjustments.finalized
         adjustments.each(&:unfinalize!)
-        flash[:success] = Spree.t(:all_adjustments_opened)
+        flash[:success] = Spree.t(:all_adjustments_unfinalized)
 
         respond_with(@order) { |format| format.html { redirect_to :back } }
       end
 
-      def close_adjustments
+      def finalize_adjustments
         adjustments = @order.all_adjustments.not_finalized
         adjustments.each(&:finalize!)
-        flash[:success] = Spree.t(:all_adjustments_closed)
+        flash[:success] = Spree.t(:all_adjustments_finalized)
 
         respond_with(@order) { |format| format.html { redirect_to :back } }
       end

--- a/backend/app/views/spree/admin/adjustments/_adjustments_table.html.erb
+++ b/backend/app/views/spree/admin/adjustments/_adjustments_table.html.erb
@@ -14,10 +14,10 @@
       <td class="align-center" colspan='4'>
         <% if can? :update, Spree::Adjustment %>
           <div>
-            <%= button_to Spree.t(:open_all_adjustments), open_adjustments_admin_order_path(@order), method: :get %>
+            <%= button_to Spree.t(:unfinalize_all_adjustments), adjustments_unfinalize_admin_order_path(@order), method: :get %>
           </div>
           <div>
-            <%= button_to Spree.t(:close_all_adjustments), close_adjustments_admin_order_path(@order), method: :get %>
+            <%= button_to Spree.t(:finalize_all_adjustments), adjustments_finalize_admin_order_path(@order), method: :get %>
           </div>
         <% end %>
       </td>

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -87,8 +87,8 @@ Spree::Core::Engine.add_routes do
         get :confirm
         put :complete
         post :resend
-        get :open_adjustments
-        get :close_adjustments
+        get "/adjustments/unfinalize", to: "orders#unfinalize_adjustments"
+        get "/adjustments/finalize", to: "orders#finalize_adjustments"
         put :approve
         put :cancel
         put :resume

--- a/backend/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -299,38 +299,38 @@ describe Spree::Admin::OrdersController, :type => :controller do
       let(:order) { create(:order) }
       let!(:finalized_adjustment) { create(:adjustment, finalized: true, adjustable: order, order: order) }
 
-      it "changes all the closed adjustments to open" do
-        spree_post :open_adjustments, id: order.number
+      it "changes all the finalized adjustments to unfinalized" do
+        spree_post :unfinalize_adjustments, id: order.number
         expect(finalized_adjustment.reload.finalized).to eq(false)
       end
 
       it "sets the flash success message" do
-        spree_post :open_adjustments, id: order.number
-        expect(flash[:success]).to eql('All adjustments successfully opened!')
+        spree_post :unfinalize_adjustments, id: order.number
+        expect(flash[:success]).to eql('All adjustments successfully unfinalized!')
       end
 
       it "redirects back" do
-        spree_post :open_adjustments, id: order.number
+        spree_post :unfinalize_adjustments, id: order.number
         expect(response).to redirect_to(:back)
       end
     end
 
-    context "#close_adjustments" do
+    context "#finalize_adjustments" do
       let(:order) { create(:order) }
       let!(:not_finalized_adjustment) { create(:adjustment, finalized: false, adjustable: order, order: order) }
 
-      it "changes all the open adjustments to closed" do
-        spree_post :close_adjustments, id: order.number
+      it "changes all the unfinalized adjustments to finalized" do
+        spree_post :finalize_adjustments, id: order.number
         expect(not_finalized_adjustment.reload.finalized).to eq(true)
       end
 
       it "sets the flash success message" do
-        spree_post :close_adjustments, id: order.number
-        expect(flash[:success]).to eql('All adjustments successfully closed!')
+        spree_post :finalize_adjustments, id: order.number
+        expect(flash[:success]).to eql('All adjustments successfully finalized!')
       end
 
       it "redirects back" do
-        spree_post :close_adjustments, id: order.number
+        spree_post :finalize_adjustments, id: order.number
         expect(response).to redirect_to(:back)
       end
     end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -497,8 +497,8 @@ en:
     agree_to_privacy_policy: Agree to Privacy Policy
     agree_to_terms_of_service: Agree to Terms of Service
     all: All
-    all_adjustments_closed: All adjustments successfully closed!
-    all_adjustments_opened: All adjustments successfully opened!
+    all_adjustments_finalized: All adjustments successfully finalized!
+    all_adjustments_unfinalized: All adjustments successfully unfinalized!
     all_departments: All departments
     all_items_have_been_returned: All items have been returned
     already_signed_up_for_analytics: You have already signed up for Spree Analytics
@@ -617,7 +617,6 @@ en:
     clear_cache_warning: Clearing cache will temporarily reduce the performance of your store.
     clone: Clone
     close: Close
-    close_all_adjustments: Close All Adjustments
     close_stock_transfer:
       will_cause: Closing a stock transfer will cause the following
       no_longer_edit: You will no longer be able to edit the stock transfer in any way
@@ -809,6 +808,7 @@ en:
     fill_in_customer_info: Please fill in customer info
     filter_results: Filter Results
     finalize: Finalize
+    finalize_all_adjustments: Finalize All Adjustments
     finalize_stock_transfer:
       will_cause: Finalizing a stock transfer will cause the following
       no_longer_change_items: You will no longer be able to add or edit any transfer items
@@ -1037,7 +1037,6 @@ en:
     number_of_codes: ! '%{count} codes'
     on_hand: On Hand
     open: Open
-    open_all_adjustments: Open All Adjustments
     option_type: Option Type
     option_type_placeholder: Choose an option type
     option_types: Option Types
@@ -1543,6 +1542,7 @@ en:
     unable_to_connect_to_gateway: Unable to connect to gateway.
     unable_to_create_reimbursements: Unable to create reimbursements because there are items pending manual intervention.
     unable_to_create_stock_transfer: Unable to create the stock transfer
+    unfinalize_all_adjustments: Unfinalize All Adjustments
     under_price: Under %{price}
     unlock: Unlock
     unrecognized_card_type: Unrecognized card type


### PR DESCRIPTION
* Rename routes to `/admin/orders/:id/adjustments/finalize` and
  `/admin/orders/:id/adjustments/unfinalize`

* Replace open/close with unfinalize/finalize.

Ref: https://github.com/solidusio/solidus/issues/326 https://github.com/solidusio/solidus/issues/321 #279
CC: @seantaylor @jhawthorn 