### PR TITLE
Delete associated promotion codes when promotion is destroyed

### DIFF
--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -16,7 +16,7 @@ module Spree
     has_many :order_promotions, class_name: "Spree::OrderPromotion"
     has_many :orders, through: :order_promotions
 
-    has_many :codes, class_name: "Spree::PromotionCode", inverse_of: :promotion
+    has_many :codes, class_name: "Spree::PromotionCode", inverse_of: :promotion, dependent: :destroy
     alias_method :promotion_codes, :codes
 
     accepts_nested_attributes_for :promotion_actions, :promotion_rules

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -47,30 +47,6 @@ describe Spree::Promotion, :type => :model do
     end
   end
 
-  describe "#destroy" do
-    let(:promotion) { Spree::Promotion.create(:name => "delete me") }
-
-    before(:each) do
-      promotion.actions << Spree::Promotion::Actions::CreateAdjustment.new
-      promotion.rules << Spree::Promotion::Rules::FirstOrder.new
-      promotion.codes << Spree::PromotionCode.new(value: "Test")
-      promotion.save!
-      promotion.destroy
-    end
-
-    it "should delete actions" do
-      expect(Spree::PromotionAction.count).to eq(0)
-    end
-
-    it "should delete rules" do
-      expect(Spree::PromotionRule.count).to eq(0)
-    end
-
-    it "should delete codes" do
-      expect(Spree::PromotionCode.count).to eq(0)
-    end
-  end
-
   describe "#save" do
     let(:promotion) { Spree::Promotion.create(:name => "delete me") }
 

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -53,6 +53,7 @@ describe Spree::Promotion, :type => :model do
     before(:each) do
       promotion.actions << Spree::Promotion::Actions::CreateAdjustment.new
       promotion.rules << Spree::Promotion::Rules::FirstOrder.new
+      promotion.codes << Spree::PromotionCode.new(value: "Test")
       promotion.save!
       promotion.destroy
     end
@@ -63,6 +64,10 @@ describe Spree::Promotion, :type => :model do
 
     it "should delete rules" do
       expect(Spree::PromotionRule.count).to eq(0)
+    end
+
+    it "should delete codes" do
+      expect(Spree::PromotionCode.count).to eq(0)
     end
   end
 


### PR DESCRIPTION
As we discussed [here](https://github.com/solidusio/solidus/pull/435), we should clean up promotion codes when promotion is destroyed.