### PR TITLE
Add more payment information in the shipments API response

### DIFF
--- a/api/app/views/spree/api/shipments/big.v1.rabl
+++ b/api/app/views/spree/api/shipments/big.v1.rabl
@@ -41,6 +41,13 @@ child order: :order do
 
   child payments: :payments do
     attributes :id, :amount, :display_amount, :state
+    child source: :source do |s|
+      if s.is_a?(Spree::CreditCard)
+        attributes :id, :cc_type
+      else
+        attributes :id
+      end
+    end
     child payment_method: :payment_method do
       attributes :id, :name
     end

--- a/api/app/views/spree/api/shipments/big.v1.rabl
+++ b/api/app/views/spree/api/shipments/big.v1.rabl
@@ -42,11 +42,11 @@ child order: :order do
   child payments: :payments do
     attributes :id, :amount, :display_amount, :state
     child source: :source do |s|
-      if s.is_a?(Spree::CreditCard)
-        attributes :id, :cc_type
-      else
-        attributes :id
+      attrs = [:id]
+      if s.respond_to?(:cc_type)
+        attrs << :cc_type
       end
+      attributes *attrs
     end
     child payment_method: :payment_method do
       attributes :id, :name

--- a/api/spec/controllers/spree/api/shipments_controller_spec.rb
+++ b/api/spec/controllers/spree/api/shipments_controller_spec.rb
@@ -162,6 +162,25 @@ describe Spree::Api::ShipmentsController, :type => :controller do
             subject
             expect(rendered_shipment_ids).to match_array current_api_user.orders.flat_map(&:shipments).map(&:id)
           end
+
+          context "credit card payment" do
+            before { subject }
+
+            it 'contains the id and cc_type of the credit card' do
+              expect(json_response['shipments'][0]['order']['payments'][0]['source'].keys).to match_array ["id", "cc_type"]
+            end
+          end
+
+          context "store credit payment" do
+            let(:current_api_user) { shipped_order.user }
+            let(:shipped_order)    { create(:shipped_order, payment_type: :store_credit_payment) }
+
+            before { subject }
+
+            it 'only contains the id of the payment source' do
+              expect(json_response['shipments'][0]['order']['payments'][0]['source'].keys).to match_array ["id"]
+            end
+          end
         end
 
         context 'with filtering' do

--- a/core/lib/spree/testing_support/factories/order_factory.rb
+++ b/core/lib/spree/testing_support/factories/order_factory.rb
@@ -60,8 +60,12 @@ FactoryGirl.define do
           payment_state 'paid'
           shipment_state 'ready'
 
-          after(:create) do |order|
-            create(:payment, amount: order.total, order: order, state: 'completed')
+          transient do
+            payment_type :credit_card_payment
+          end
+
+          after(:create) do |order, evaluator|
+            create(evaluator.payment_type, amount: order.total, order: order, state: 'completed')
             order.shipments.each do |shipment|
               shipment.inventory_units.update_all state: 'on_hand'
               shipment.update_column('state', 'ready')


### PR DESCRIPTION
Adds some information about the payment’s source in the shipments API response.

This allows us to display more details to the customer about the payments associated with the shipment’s order.