### PR TITLE
Rename spree_payments.identifier to number

### DIFF
--- a/backend/app/views/spree/admin/orders/confirm/_payments.html.erb
+++ b/backend/app/views/spree/admin/orders/confirm/_payments.html.erb
@@ -15,7 +15,7 @@
       <% payments.each do |payment| %>
         <tr>
           <td>
-            <%= link_to payment.identifier, spree.admin_order_payment_path(@order, payment) %>
+            <%= link_to payment.number, spree.admin_order_payment_path(@order, payment) %>
           </td>
           <td>
             <%= pretty_time(payment.created_at) %>

--- a/backend/app/views/spree/admin/payments/_list.html.erb
+++ b/backend/app/views/spree/admin/payments/_list.html.erb
@@ -13,7 +13,7 @@
   <tbody>
     <% payments.each do |payment| %>
       <tr id="<%= dom_id(payment) %>" data-hook="payments_row" class="<%= cycle('odd', 'even', name: 'payment_table_cycle')%>">
-        <td><%= link_to payment.identifier, spree.admin_order_payment_path(@order, payment) %></td>
+        <td><%= link_to payment.number, spree.admin_order_payment_path(@order, payment) %></td>
         <td><%= pretty_time(payment.created_at) %></td>
         <td class="align-center amount"><%= payment.display_amount.to_html %></td>
         <td class="align-center"><%= payment_method_name(payment) %></td>

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -3,6 +3,7 @@ module Spree
     include Spree::Payment::Processing
 
     alias_attribute :identifier, :number
+    deprecate :identifier, :identifier=, deprecator: Spree::Deprecation
 
     IDENTIFIER_CHARS    = (('A'..'Z').to_a + ('0'..'9').to_a - %w(0 1 I O)).freeze
     NON_RISKY_AVS_CODES = ['B', 'D', 'H', 'J', 'M', 'Q', 'T', 'V', 'X', 'Y'].freeze
@@ -257,8 +258,8 @@ module Spree
       # See https://github.com/spree/spree/issues/1998#issuecomment-12869105
       def set_unique_identifier
         begin
-          self.identifier = generate_identifier
-        end while self.class.exists?(identifier: self.identifier)
+          self.number = generate_identifier
+        end while self.class.exists?(number: self.number)
       end
 
       def generate_identifier

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -2,6 +2,8 @@ module Spree
   class Payment < Spree::Base
     include Spree::Payment::Processing
 
+    alias_attribute :identifier, :number
+
     IDENTIFIER_CHARS    = (('A'..'Z').to_a + ('0'..'9').to_a - %w(0 1 I O)).freeze
     NON_RISKY_AVS_CODES = ['B', 'D', 'H', 'J', 'M', 'Q', 'T', 'V', 'X', 'Y'].freeze
     RISKY_AVS_CODES     = ['A', 'C', 'E', 'F', 'G', 'I', 'K', 'L', 'N', 'O', 'P', 'R', 'S', 'U', 'W', 'Z'].freeze

--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -218,7 +218,7 @@ module Spree
 
       # The unique identifier to be passed in to the payment gateway
       def gateway_order_id
-        "#{order.number}-#{self.identifier}"
+        "#{order.number}-#{self.number}"
       end
 
       def token_based?

--- a/core/db/migrate/20151014213349_rename_identifier_to_number_for_payment.rb
+++ b/core/db/migrate/20151014213349_rename_identifier_to_number_for_payment.rb
@@ -1,0 +1,7 @@
+# This file has the same name as the spree 3.0 migration to prevent it from
+# being run twice for those users.
+class RenameIdentifierToNumberForPayment < ActiveRecord::Migration
+  def change
+    rename_column :spree_payments, :identifier, :number
+  end
+end

--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -93,6 +93,7 @@ require 'spree/core/controller_helpers/strong_parameters'
 require 'spree/core/unreturned_item_charger'
 require 'spree/core/role_configuration'
 require 'spree/permission_sets'
+require 'spree/deprecation'
 
 require 'spree/mailer_previews/order_preview'
 require 'spree/mailer_previews/carton_preview'

--- a/core/lib/spree/deprecation.rb
+++ b/core/lib/spree/deprecation.rb
@@ -1,0 +1,3 @@
+module Spree
+  Deprecation = ActiveSupport::Deprecation.new('2.0', 'Solidus')
+end

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -828,17 +828,17 @@ describe Spree::Payment, :type => :model do
     # Regression test for #1998
     it "sets a unique identifier on create" do
       payment.run_callbacks(:create)
-      expect(payment.identifier).not_to be_blank
-      expect(payment.identifier.size).to eq(8)
-      expect(payment.identifier).to be_a(String)
+      expect(payment.number).not_to be_blank
+      expect(payment.number.size).to eq(8)
+      expect(payment.number).to be_a(String)
     end
 
     # Regression test for #3733
     it "does not regenerate the identifier on re-save" do
-      payment.save
-      old_identifier = payment.identifier
-      payment.save
-      expect(payment.identifier).to eq(old_identifier)
+      payment.save!
+      old_number = payment.number
+      payment.save!
+      expect(payment.number).to eq(old_number)
     end
 
     context "other payment exists" do
@@ -853,13 +853,13 @@ describe Spree::Payment, :type => :model do
       before { other_payment.save! }
 
       it "doesn't set duplicate identifier" do
-        expect(payment).to receive(:generate_identifier).and_return(other_payment.identifier)
+        expect(payment).to receive(:generate_identifier).and_return(other_payment.number)
         expect(payment).to receive(:generate_identifier).and_call_original
 
         payment.run_callbacks(:create)
 
-        expect(payment.identifier).not_to be_blank
-        expect(payment.identifier).not_to eq(other_payment.identifier)
+        expect(payment.number).not_to be_blank
+        expect(payment.number).not_to eq(other_payment.number)
       end
     end
   end


### PR DESCRIPTION
More consistent as other models use number instead of identifier.

This change was made in spree 3.0, porting it over to alow for a direct
upgrade path.