### PR TITLE
Pre-format log entry messages

### DIFF
--- a/backend/app/views/spree/admin/log_entries/index.html.erb
+++ b/backend/app/views/spree/admin/log_entries/index.html.erb
@@ -24,7 +24,9 @@
       <tbody>
         <tr>
           <td>Message</td>
-          <td><%= entry.parsed_details.message %></td>
+          <td>
+            <pre><%= entry.parsed_details.message %></pre>
+          </td>
         </tr>
       </tbody>
   <% end %>


### PR DESCRIPTION
Pre-formatting log entries' messages will allow us to get the most value out of
active merchant billing response objects, without changing the interface
expected by any gateway. We could, for instance, return pre-formatted JSON that will be pleasantly formatted in the back end log
entry view.

E.g.
before:
![screen shot 2015-10-15 at 14 31 45](https://cloud.githubusercontent.com/assets/3162299/10528667/70da1242-734c-11e5-8177-cfda6190af37.png)
after:
![screen shot 2015-10-15 at 14 18 00](https://cloud.githubusercontent.com/assets/3162299/10528672/768b3464-734c-11e5-8086-a4a0ab9fe522.png)
