### PR TITLE
Fix UserManagement permissions issue.

### DIFF
--- a/core/lib/spree/permission_sets/user_management.rb
+++ b/core/lib/spree/permission_sets/user_management.rb
@@ -2,7 +2,7 @@ module Spree
   module PermissionSets
     class UserManagement < PermissionSets::Base
       def activate!
-        can [:admin, :display, :create, :update, :save_in_address_book, :remove_from_address_book], Spree.user_class
+        can [:admin, :display, :create, :update, :save_in_address_book, :remove_from_address_book, :addresses, :orders, :items], Spree.user_class
 
         # due to how cancancan filters by associations,
         # we have to define this twice, once for `accessible_by`


### PR DESCRIPTION
https://github.com/solidusio/solidus/commit/01a887207170d39b6a8b8a8f82c2f3ed7afd90ac
introduced a bug whereby admins with the UserManagement permission (but no
SuperUser permission) lost the ability to view the orders, addresses, and
items tabs in user admin. This code puts back that ability, plus updates
the specs so that we would catch this in the future by asserting on the
user feature specs using an admin with the UserManagement role instead of
assuming that the admin is always a SuperUser.

This makes use of the spec authorization helpers introduced in
https://github.com/solidusio/solidus/pull/449 to be able to better test
against the UserManagement role.