### PR TITLE
More detailed stock transfer stock location permissions

### DIFF
--- a/backend/app/views/spree/admin/stock_transfers/new.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/new.html.erb
@@ -14,7 +14,7 @@
   <fieldset class="no-border-top">
     <%= f.field_container :source_location do %>
       <%= f.label nil, Spree.t(:source_location) %>
-      <%= f.select :source_location_id, options_from_collection_for_select(@stock_locations, :id, :name), {include_blank: true}, {class: 'select2 fullwidth', "data-placeholder" => Spree.t(:select_a_stock_location)} %>
+      <%= f.select :source_location_id, options_from_collection_for_select(@source_stock_locations, :id, :name), {include_blank: true}, {class: 'select2 fullwidth', "data-placeholder" => Spree.t(:select_a_stock_location)} %>
       <%= f.error_message_on :source_location %>
     <% end %>
     <%= f.field_container :description do %>

--- a/backend/spec/controllers/spree/admin/stock_transfers_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/stock_transfers_controller_spec.rb
@@ -24,6 +24,26 @@ module Spree
           transfer.closed_at = DateTime.now
         end }
 
+      describe "stock location filtering" do
+        let(:user) { create(:admin_user) }
+        let(:ability) { Spree::Ability.new(user) }
+        let!(:sf_store) { StockLocation.create(name: "SF Store")}
+
+        before do
+          ability.cannot :manage, Spree::StockLocation
+          ability.can :transfer_from, Spree::StockLocation, id: [warehouse.id]
+          ability.can :transfer_to, Spree::StockLocation, id: [ny_store.id, la_store.id]
+
+          allow_any_instance_of(Spree::Admin::BaseController).to receive(:spree_current_user).and_return(user)
+          allow_any_instance_of(Spree::Admin::BaseController).to receive(:current_ability).and_return(ability)
+        end
+
+        it "doesn't display stock locations the user doesn't have access to" do
+          spree_get :index
+          expect(assigns(:stock_locations)).to match_array [warehouse, ny_store, la_store]
+        end
+      end
+
       it "searches by stock location" do
         spree_get :index, :q => { :source_location_id_or_destination_location_id_eq => ny_store.id }
         expect(assigns(:stock_transfers).count).to eq 1

--- a/core/spec/models/spree/permission_sets/restricted_stock_transfer_management_spec.rb
+++ b/core/spec/models/spree/permission_sets/restricted_stock_transfer_management_spec.rb
@@ -45,7 +45,7 @@ describe Spree::PermissionSets::RestrictedStockTransferManagement do
       described_class.new(ability).activate!
     end
 
-    context "when the user is associated with one of the locations" do
+    context "when the user is only associated with the source location" do
       let(:stock_locations) {[source_location]}
 
       it { is_expected.to be_able_to(:display, source_location) }
@@ -55,8 +55,11 @@ describe Spree::PermissionSets::RestrictedStockTransferManagement do
       it { is_expected.to be_able_to(:admin, Spree::StockTransfer) }
       it { is_expected.to be_able_to(:create, Spree::StockTransfer) }
 
-      it { is_expected.to be_able_to(:transfer, source_location) }
-      it { is_expected.not_to be_able_to(:transfer, destination_location) }
+      it { is_expected.to be_able_to(:transfer_from, source_location) }
+      it { is_expected.to be_able_to(:transfer_to, source_location) }
+
+      it { is_expected.not_to be_able_to(:transfer_from, destination_location) }
+      it { is_expected.not_to be_able_to(:transfer_to, destination_location) }
 
       it { is_expected.to be_able_to(:display, transfer_with_source) }
       it { is_expected.to be_able_to(:display, transfer_with_source_and_destination) }
@@ -82,8 +85,11 @@ describe Spree::PermissionSets::RestrictedStockTransferManagement do
       it { is_expected.to be_able_to(:admin, Spree::StockTransfer) }
       it { is_expected.to be_able_to(:create, Spree::StockTransfer) }
 
-      it { is_expected.to be_able_to(:transfer, source_location) }
-      it { is_expected.to be_able_to(:transfer, destination_location) }
+      it { is_expected.to be_able_to(:transfer_from, source_location) }
+      it { is_expected.to be_able_to(:transfer_to, source_location) }
+
+      it { is_expected.to be_able_to(:transfer_from, destination_location) }
+      it { is_expected.to be_able_to(:transfer_to, destination_location) }
 
       it { is_expected.to be_able_to(:display, transfer_with_source) }
       it { is_expected.to be_able_to(:display, transfer_with_source_and_destination) }
@@ -108,8 +114,11 @@ describe Spree::PermissionSets::RestrictedStockTransferManagement do
       it { is_expected.not_to be_able_to(:admin, Spree::StockTransfer) }
       it { is_expected.not_to be_able_to(:create, Spree::StockTransfer) }
 
-      it { is_expected.not_to be_able_to(:transfer, source_location) }
-      it { is_expected.not_to be_able_to(:transfer, destination_location) }
+      it { is_expected.not_to be_able_to(:transfer_from, source_location) }
+      it { is_expected.not_to be_able_to(:transfer_to, source_location) }
+
+      it { is_expected.not_to be_able_to(:transfer_from, destination_location) }
+      it { is_expected.not_to be_able_to(:transfer_to, destination_location) }
 
       it { is_expected.not_to be_able_to(:manage, transfer_with_source) }
       it { is_expected.not_to be_able_to(:manage, transfer_with_destination) }
@@ -131,8 +140,11 @@ describe Spree::PermissionSets::RestrictedStockTransferManagement do
     it { is_expected.to_not be_able_to(:display, source_location) }
     it { is_expected.to_not be_able_to(:display, destination_location) }
 
-    it { is_expected.not_to be_able_to(:transfer, source_location) }
-    it { is_expected.not_to be_able_to(:transfer, destination_location) }
+    it { is_expected.not_to be_able_to(:transfer_from, source_location) }
+    it { is_expected.not_to be_able_to(:transfer_to, source_location) }
+
+    it { is_expected.not_to be_able_to(:transfer_from, destination_location) }
+    it { is_expected.not_to be_able_to(:transfer_to, destination_location) }
 
     it { is_expected.to_not be_able_to(:display, source_location) }
     it { is_expected.to_not be_able_to(:display, destination_location) }
@@ -146,4 +158,3 @@ describe Spree::PermissionSets::RestrictedStockTransferManagement do
     it { is_expected.not_to be_able_to(:manage, source_and_destination_transfer_item) }
   end
 end
-


### PR DESCRIPTION
Allow stores to define permissions around which stock locations are permitted to transfer from and transfer to separately.