### PR TITLE
Fix incorrectly scoped variant api cache #453

### DIFF
--- a/api/app/views/spree/api/variants/big.v1.rabl
+++ b/api/app/views/spree/api/variants/big.v1.rabl
@@ -1,7 +1,7 @@
 object @variant
 attributes *variant_attributes
 
-cache [I18n.locale, @current_user_roles.include?('admin'), 'big_variant', root_object]
+cache [I18n.locale, Spree::StockLocation.accessible_by(current_ability).pluck(:id).sort.join(":"), 'big_variant', root_object]
 
 extends "spree/api/variants/small"
 

--- a/api/app/views/spree/api/variants/small.v1.rabl
+++ b/api/app/views/spree/api/variants/small.v1.rabl
@@ -1,4 +1,4 @@
-cache [I18n.locale, @current_user_roles.include?('admin'), 'small_variant', root_object]
+cache [I18n.locale, 'small_variant', root_object]
 
 attributes *variant_attributes
 


### PR DESCRIPTION
Fixes https://github.com/solidusio/solidus/issues/453

* Variant big rabl has stock-location specific information, so the cache
key just based on whether the user has the admin role doesn't
sufficienty cache information for the user, possibly either leaking too
much, or not returning enough information
* Variant small rabl has no need to care about whether the user is an admin,
since it has no information that would change by that role