### PR TITLE
Add add/remove operation to OrderContents options for matching line items

### DIFF
--- a/core/app/models/spree/order_contents.rb
+++ b/core/app/models/spree/order_contents.rb
@@ -72,7 +72,7 @@ module Spree
       end
 
       def add_to_line_item(variant, quantity, options = {})
-        line_item = grab_line_item_by_variant(variant, false, options)
+        line_item = grab_line_item_by_variant(variant, false, options.merge(operation: 'add'))
 
         if line_item
           line_item.quantity += quantity.to_i
@@ -91,7 +91,7 @@ module Spree
       end
 
       def remove_from_line_item(variant, quantity, options = {})
-        line_item = grab_line_item_by_variant(variant, true, options)
+        line_item = grab_line_item_by_variant(variant, true, options.merge(operation: 'remove'))
         line_item.quantity -= quantity
         line_item.target_shipment= options[:shipment]
 

--- a/core/spec/models/spree/order_contents_spec.rb
+++ b/core/spec/models/spree/order_contents_spec.rb
@@ -64,6 +64,11 @@ describe Spree::OrderContents, :type => :model do
       expect(order_stock_locations.map(&:stock_location_id)).to eq([stock_location.id, stock_location_2.id])
     end
 
+    it "should pass the add operation when looking up line item" do
+      expect(order).to receive(:find_line_item_by_variant).with(variant, { operation: 'add' })
+      subject.add(variant, 1)
+    end
+
     context "running promotions" do
       let(:promotion) { create(:promotion) }
       let(:calculator) { Spree::Calculator::FlatRate.new(:preferred_amount => 10) }
@@ -159,6 +164,13 @@ describe Spree::OrderContents, :type => :model do
       subject.remove(variant,1)
       expect(order.item_total.to_f).to eq(19.99)
       expect(order.total.to_f).to eq(19.99)
+    end
+
+    it "should pass the remove operation when looking up line item" do
+      expect(order).to receive(:find_line_item_by_variant).once.with(variant, { operation: 'add' }).and_call_original
+      expect(order).to receive(:find_line_item_by_variant).once.with(variant, { operation: 'remove' }).and_call_original
+      subject.add(variant, 1)
+      subject.remove(variant, 1)
     end
   end
 


### PR DESCRIPTION
When using custom matchers for finding a line item in order contents, adding and removing are indistinguishable from one another. It is currently desired in our store to be able to match in one way when adding a line item, and a different way of matching when removing a line item of a certain type. 