### PR TITLE
Add OrderContents#remove_line_item

### DIFF
--- a/api/app/controllers/spree/api/line_items_controller.rb
+++ b/api/app/controllers/spree/api/line_items_controller.rb
@@ -37,8 +37,7 @@ module Spree
 
       def destroy
         @line_item = find_line_item
-        variant = Spree::Variant.unscoped.find(@line_item.variant_id)
-        @order.contents.remove(variant, @line_item.quantity)
+        @order.contents.remove_line_item(@line_item)
         respond_with(@line_item, status: 204)
       end
 

--- a/core/app/models/spree/order_contents.rb
+++ b/core/app/models/spree/order_contents.rb
@@ -16,6 +16,11 @@ module Spree
       after_add_or_remove(line_item, options)
     end
 
+    def remove_line_item(line_item, options = {})
+      line_item.destroy
+      after_add_or_remove(line_item, options)
+    end
+
     def update_cart(params)
       if order.update_attributes(params)
         unless order.completed?

--- a/core/app/models/spree/order_contents.rb
+++ b/core/app/models/spree/order_contents.rb
@@ -17,7 +17,7 @@ module Spree
     end
 
     def remove_line_item(line_item, options = {})
-      line_item.destroy
+      line_item.destroy!
       after_add_or_remove(line_item, options)
     end
 

--- a/core/spec/models/spree/order_contents_spec.rb
+++ b/core/spec/models/spree/order_contents_spec.rb
@@ -162,6 +162,48 @@ describe Spree::OrderContents, :type => :model do
     end
   end
 
+  context "#remove_line_item" do
+    context 'given a shipment' do
+      it "ensure shipment calls update_amounts instead of order calling ensure_updated_shipments" do
+        line_item = subject.add(variant, 1)
+        shipment = create(:shipment)
+        expect(subject.order).to_not receive(:ensure_updated_shipments)
+        expect(shipment).to receive(:update_amounts)
+        subject.remove_line_item(line_item, shipment: shipment)
+      end
+    end
+
+    context 'not given a shipment' do
+      it "ensures updated shipments" do
+        line_item = subject.add(variant, 1)
+        expect(subject.order).to receive(:ensure_updated_shipments)
+        subject.remove_line_item(line_item)
+      end
+    end
+
+    it 'should remove line_item' do
+      line_item = subject.add(variant, 1)
+      subject.remove_line_item(line_item)
+
+      expect(order.reload.line_items).to_not include(line_item)
+    end
+
+    it "should update order totals" do
+      expect(order.item_total.to_f).to eq(0.00)
+      expect(order.total.to_f).to eq(0.00)
+
+      line_item = subject.add(variant,2)
+
+      expect(order.item_total.to_f).to eq(39.98)
+      expect(order.total.to_f).to eq(39.98)
+
+      subject.remove_line_item(line_item)
+      expect(order.item_total.to_f).to eq(0.00)
+      expect(order.total.to_f).to eq(0.00)
+    end
+  end
+
+
   context "update cart" do
     let!(:shirt) { subject.add variant, 1 }
 


### PR DESCRIPTION
Currently the line items controller will find the line item like a regular restful route, but then it will remove through OrderContents#remove which uses the variant id to re-look it up. It seems to me we should simply delete the line item with no extra lookups.