### PR TITLE
Promotion.sale

### DIFF
--- a/backend/app/views/spree/admin/promotions/_form.html.erb
+++ b/backend/app/views/spree/admin/promotions/_form.html.erb
@@ -34,9 +34,9 @@
         <%= f.label :advertise %>
       <% end %>
 
-      <%= f.field_container :sale do %>
-        <%= f.check_box :sale %>
-        <%= f.label :sale %>
+      <%= f.field_container :apply_automatically do %>
+        <%= f.check_box :apply_automatically %>
+        <%= f.label :apply_automatically %>
       <% end %>
     </div>
 

--- a/backend/app/views/spree/admin/promotions/_form.html.erb
+++ b/backend/app/views/spree/admin/promotions/_form.html.erb
@@ -33,6 +33,11 @@
         <%= f.check_box :advertise %>
         <%= f.label :advertise %>
       <% end %>
+
+      <%= f.field_container :sale do %>
+        <%= f.check_box :sale %>
+        <%= f.label :sale %>
+      <% end %>
     </div>
 
     <div class="omega nine columns">

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -40,6 +40,7 @@ module Spree
         where(table[:expires_at].eq(nil).or(table[:expires_at].gt(time)))
     end
     scope :applied, -> { joins(:order_promotions).uniq }
+    scope :sale, -> { where(sale: true) }
 
     self.whitelisted_ransackable_associations = ['codes']
     self.whitelisted_ransackable_attributes = ['path', 'promotion_category_id']

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -28,6 +28,7 @@ module Spree
     validates :usage_limit, numericality: { greater_than: 0, allow_nil: true }
     validates :per_code_usage_limit, numericality: { greater_than_or_equal_to: 0, allow_nil: true }
     validates :description, length: { maximum: 255 }
+    validate :apply_automatically_disallowed_with_codes_or_paths
 
     before_save :normalize_blank_values
 
@@ -228,6 +229,12 @@ module Spree
 
     def match_all?
       match_policy == "all"
+    end
+
+    def apply_automatically_disallowed_with_codes_or_paths
+      return unless apply_automatically
+      errors.add(:apply_automatically, :disallowed_with_code) if codes.any?
+      errors.add(:apply_automatically, :disallowed_with_path) if path.present?
     end
   end
 end

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -41,7 +41,6 @@ module Spree
         where(table[:expires_at].eq(nil).or(table[:expires_at].gt(time)))
     end
     scope :applied, -> { joins(:order_promotions).uniq }
-    scope :applied_automatically, -> { where(apply_automatically: true) }
 
     self.whitelisted_ransackable_associations = ['codes']
     self.whitelisted_ransackable_attributes = ['path', 'promotion_category_id']

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -40,7 +40,7 @@ module Spree
         where(table[:expires_at].eq(nil).or(table[:expires_at].gt(time)))
     end
     scope :applied, -> { joins(:order_promotions).uniq }
-    scope :sale, -> { where(sale: true) }
+    scope :applied_automatically, -> { where(apply_automatically: true) }
 
     self.whitelisted_ransackable_associations = ['codes']
     self.whitelisted_ransackable_attributes = ['path', 'promotion_category_id']

--- a/core/app/models/spree/promotion_handler/cart.rb
+++ b/core/app/models/spree/promotion_handler/cart.rb
@@ -40,7 +40,7 @@ module Spree
         end
 
         def sale_promotions
-          Promotion.applied_automatically.active.includes(:promotion_rules)
+          Promotion.where(apply_automatically: true).active.includes(:promotion_rules)
         end
 
         def promotion_code(promotion)

--- a/core/app/models/spree/promotion_handler/cart.rb
+++ b/core/app/models/spree/promotion_handler/cart.rb
@@ -40,20 +40,7 @@ module Spree
         end
 
         def sale_promotions
-          promo_table = Promotion.arel_table
-          code_table  = PromotionCode.arel_table
-
-          promotion_code_join = promo_table.join(code_table, Arel::Nodes::OuterJoin).on(
-            promo_table[:id].eq(code_table[:promotion_id])
-          ).join_sources
-
-          Promotion.active.includes(:promotion_rules).
-            joins(promotion_code_join).
-            where(
-              code_table[:value].eq(nil).and(
-                promo_table[:path].eq(nil)
-              )
-            ).distinct
+          Promotion.sale.active.includes(:promotion_rules)
         end
 
         def promotion_code(promotion)

--- a/core/app/models/spree/promotion_handler/cart.rb
+++ b/core/app/models/spree/promotion_handler/cart.rb
@@ -40,7 +40,7 @@ module Spree
         end
 
         def sale_promotions
-          Promotion.sale.active.includes(:promotion_rules)
+          Promotion.applied_automatically.active.includes(:promotion_rules)
         end
 
         def promotion_code(promotion)

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -299,6 +299,11 @@ en:
           attributes:
             currency:
               must_match_order_currency: "Must match order currency"
+        spree/promotion:
+          attributes:
+            apply_automatically:
+              disallowed_with_code: Disallowed for promotions with a code
+              disallowed_with_path: Disallowed for promotions with a path
         spree/refund:
           attributes:
             amount:

--- a/core/db/migrate/20151021113730_add_sale_to_spree_promotions.rb
+++ b/core/db/migrate/20151021113730_add_sale_to_spree_promotions.rb
@@ -1,0 +1,5 @@
+class AddSaleToSpreePromotions < ActiveRecord::Migration
+  def change
+    add_column :spree_promotions, :sale, :boolean, default: false
+  end
+end

--- a/core/db/migrate/20151021113730_add_sale_to_spree_promotions.rb
+++ b/core/db/migrate/20151021113730_add_sale_to_spree_promotions.rb
@@ -1,5 +1,6 @@
 class AddSaleToSpreePromotions < ActiveRecord::Migration
   def change
     add_column :spree_promotions, :sale, :boolean, default: false
+    add_index :spree_promotions, :sale
   end
 end

--- a/core/db/migrate/20151021113730_add_sale_to_spree_promotions.rb
+++ b/core/db/migrate/20151021113730_add_sale_to_spree_promotions.rb
@@ -1,6 +1,6 @@
 class AddSaleToSpreePromotions < ActiveRecord::Migration
   def change
-    add_column :spree_promotions, :sale, :boolean, default: false
-    add_index :spree_promotions, :sale
+    add_column :spree_promotions, :apply_automatically, :boolean, default: false
+    add_index :spree_promotions, :apply_automatically
   end
 end

--- a/core/db/migrate/20151021163309_convert_sale_promotions.rb
+++ b/core/db/migrate/20151021163309_convert_sale_promotions.rb
@@ -1,0 +1,30 @@
+class ConvertSalePromotions < ActiveRecord::Migration
+  def up
+    sale_promotions.find_each do |promotion|
+      promotion.update_column(:sale, true)
+    end
+  end
+
+  def down
+    # intentionally left blank
+  end
+
+  private
+
+  def sale_promotions
+    promo_table = Spree::Promotion.arel_table
+    code_table  = Spree::PromotionCode.arel_table
+
+    promotion_code_join = promo_table.join(code_table, Arel::Nodes::OuterJoin).on(
+      promo_table[:id].eq(code_table[:promotion_id])
+    ).join_sources
+
+    Spree::Promotion.includes(:promotion_rules).
+      joins(promotion_code_join).
+      where(
+        code_table[:value].eq(nil).and(
+          promo_table[:path].eq(nil)
+        )
+      ).distinct
+  end
+end

--- a/core/db/migrate/20151021163309_convert_sale_promotions.rb
+++ b/core/db/migrate/20151021163309_convert_sale_promotions.rb
@@ -1,7 +1,7 @@
 class ConvertSalePromotions < ActiveRecord::Migration
   def up
     sale_promotions.find_each do |promotion|
-      promotion.update_column(:sale, true)
+      promotion.update_column(:apply_automatically, true)
     end
   end
 

--- a/core/db/migrate/20151021163309_convert_sale_promotions.rb
+++ b/core/db/migrate/20151021163309_convert_sale_promotions.rb
@@ -1,8 +1,6 @@
 class ConvertSalePromotions < ActiveRecord::Migration
   def up
-    sale_promotions.find_each do |promotion|
-      promotion.update_column(:apply_automatically, true)
-    end
+    sale_promotions.update_all(apply_automatically: true)
   end
 
   def down

--- a/core/spec/models/spree/item_adjustments_spec.rb
+++ b/core/spec/models/spree/item_adjustments_spec.rb
@@ -187,8 +187,8 @@ module Spree
         let(:order_promo1) { create(:promotion, :with_order_adjustment, :with_item_total_rule, weighted_order_adjustment_amount: 5, item_total_threshold_amount: 10) }
         let(:order_promo2) { create(:promotion, :with_order_adjustment, :with_item_total_rule, weighted_order_adjustment_amount: 10, item_total_threshold_amount: 20) }
         let(:order_promos) { [ order_promo1, order_promo2 ] }
-        let(:line_item_promo1) { create(:promotion, :with_line_item_adjustment, :with_item_total_rule, adjustment_rate: 2.5, item_total_threshold_amount: 10) }
-        let(:line_item_promo2) { create(:promotion, :with_line_item_adjustment, :with_item_total_rule, adjustment_rate: 5, item_total_threshold_amount: 20) }
+        let(:line_item_promo1) { create(:promotion, :with_line_item_adjustment, :with_item_total_rule, adjustment_rate: 2.5, item_total_threshold_amount: 10, sale: true) }
+        let(:line_item_promo2) { create(:promotion, :with_line_item_adjustment, :with_item_total_rule, adjustment_rate: 5, item_total_threshold_amount: 20, sale: true) }
         let(:line_item_promos) { [ line_item_promo1, line_item_promo2 ] }
         let(:order) { create(:order_with_line_items, line_items_count: 1) }
 

--- a/core/spec/models/spree/item_adjustments_spec.rb
+++ b/core/spec/models/spree/item_adjustments_spec.rb
@@ -187,8 +187,8 @@ module Spree
         let(:order_promo1) { create(:promotion, :with_order_adjustment, :with_item_total_rule, weighted_order_adjustment_amount: 5, item_total_threshold_amount: 10) }
         let(:order_promo2) { create(:promotion, :with_order_adjustment, :with_item_total_rule, weighted_order_adjustment_amount: 10, item_total_threshold_amount: 20) }
         let(:order_promos) { [ order_promo1, order_promo2 ] }
-        let(:line_item_promo1) { create(:promotion, :with_line_item_adjustment, :with_item_total_rule, adjustment_rate: 2.5, item_total_threshold_amount: 10, sale: true) }
-        let(:line_item_promo2) { create(:promotion, :with_line_item_adjustment, :with_item_total_rule, adjustment_rate: 5, item_total_threshold_amount: 20, sale: true) }
+        let(:line_item_promo1) { create(:promotion, :with_line_item_adjustment, :with_item_total_rule, adjustment_rate: 2.5, item_total_threshold_amount: 10, apply_automatically: true) }
+        let(:line_item_promo2) { create(:promotion, :with_line_item_adjustment, :with_item_total_rule, adjustment_rate: 5, item_total_threshold_amount: 20, apply_automatically: true) }
         let(:line_item_promos) { [ line_item_promo1, line_item_promo2 ] }
         let(:order) { create(:order_with_line_items, line_items_count: 1) }
 

--- a/core/spec/models/spree/order/totals_spec.rb
+++ b/core/spec/models/spree/order/totals_spec.rb
@@ -6,7 +6,7 @@ module Spree
     let(:shirt) { create(:variant) }
 
     context "adds item to cart and activates promo" do
-      let(:promotion) { Promotion.create name: 'Huhu', sale: true }
+      let(:promotion) { Promotion.create name: 'Huhu', apply_automatically: true }
       let(:calculator) { Calculator::FlatPercentItemTotal.new(:preferred_flat_percent => 10) }
       let!(:action) { Promotion::Actions::CreateAdjustment.create(promotion: promotion, calculator: calculator) }
 

--- a/core/spec/models/spree/order/totals_spec.rb
+++ b/core/spec/models/spree/order/totals_spec.rb
@@ -6,7 +6,7 @@ module Spree
     let(:shirt) { create(:variant) }
 
     context "adds item to cart and activates promo" do
-      let(:promotion) { Promotion.create name: 'Huhu' }
+      let(:promotion) { Promotion.create name: 'Huhu', sale: true }
       let(:calculator) { Calculator::FlatPercentItemTotal.new(:preferred_flat_percent => 10) }
       let!(:action) { Promotion::Actions::CreateAdjustment.create(promotion: promotion, calculator: calculator) }
 

--- a/core/spec/models/spree/order_contents_spec.rb
+++ b/core/spec/models/spree/order_contents_spec.rb
@@ -65,7 +65,7 @@ describe Spree::OrderContents, :type => :model do
     end
 
     context "running promotions" do
-      let(:promotion) { create(:promotion) }
+      let(:promotion) { create(:promotion, sale: true) }
       let(:calculator) { Spree::Calculator::FlatRate.new(:preferred_amount => 10) }
 
       shared_context "discount changes order total" do

--- a/core/spec/models/spree/order_contents_spec.rb
+++ b/core/spec/models/spree/order_contents_spec.rb
@@ -65,7 +65,7 @@ describe Spree::OrderContents, :type => :model do
     end
 
     context "running promotions" do
-      let(:promotion) { create(:promotion, sale: true) }
+      let(:promotion) { create(:promotion, apply_automatically: true) }
       let(:calculator) { Spree::Calculator::FlatRate.new(:preferred_amount => 10) }
 
       shared_context "discount changes order total" do

--- a/core/spec/models/spree/promotion_handler/cart_spec.rb
+++ b/core/spec/models/spree/promotion_handler/cart_spec.rb
@@ -5,7 +5,7 @@ module Spree
     describe Cart, :type => :model do
       let(:line_item) { create(:line_item) }
       let(:order) { line_item.order }
-      let(:promotion) { create(:promotion, sale: true) }
+      let(:promotion) { create(:promotion, apply_automatically: true) }
       let(:calculator) { Calculator::FlatPercentItemTotal.new(preferred_flat_percent: 10) }
 
       subject { Cart.new(order, line_item) }
@@ -35,7 +35,7 @@ module Spree
           include_context "creates an order promotion"
 
           context "for a non-sale promotion" do
-            let(:promotion) { create(:promotion, sale: false) }
+            let(:promotion) { create(:promotion, apply_automatically: false) }
 
             it "doesn't connect the promotion to the order" do
               expect {

--- a/core/spec/models/spree/promotion_handler/cart_spec.rb
+++ b/core/spec/models/spree/promotion_handler/cart_spec.rb
@@ -5,7 +5,7 @@ module Spree
     describe Cart, :type => :model do
       let(:line_item) { create(:line_item) }
       let(:order) { line_item.order }
-      let(:promotion) { create(:promotion) }
+      let(:promotion) { create(:promotion, sale: true) }
       let(:calculator) { Calculator::FlatPercentItemTotal.new(preferred_flat_percent: 10) }
 
       subject { Cart.new(order, line_item) }
@@ -33,6 +33,22 @@ module Spree
         context "promotion with no rules" do
           include_context "creates the adjustment"
           include_context "creates an order promotion"
+
+          context "for a non-sale promotion" do
+            let(:promotion) { create(:promotion, sale: false) }
+
+            it "doesn't connect the promotion to the order" do
+              expect {
+                subject.activate
+              }.to change { order.promotions.count }.by(0)
+            end
+
+            it "doesn't create an adjustment" do
+              expect {
+                subject.activate
+              }.to change { adjustable.adjustments.count }.by(0)
+            end
+          end
         end
 
         context "promotion includes item involved" do

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -47,6 +47,12 @@ describe Spree::Promotion, :type => :model do
     end
   end
 
+  describe "#sale" do
+    it "defaults to false" do
+      expect(subject.sale).to eq(false)
+    end
+  end
+
   describe "#save" do
     let(:promotion) { Spree::Promotion.create(:name => "delete me") }
 

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -48,8 +48,30 @@ describe Spree::Promotion, :type => :model do
   end
 
   describe "#apply_automatically" do
+    subject { build(:promotion) }
+
     it "defaults to false" do
       expect(subject.apply_automatically).to eq(false)
+    end
+
+    context "when set to true" do
+      before { subject.apply_automatically = true }
+
+      it "should remain valid" do
+        expect(subject).to be_valid
+      end
+
+      it "invalidates the promotion when it has a code" do
+        subject.codes.build(value: "foo")
+        expect(subject).to_not be_valid
+        expect(subject.errors).to include(:apply_automatically)
+      end
+
+      it "invalidates the promotion when it has a path" do
+        subject.path = "foo"
+        expect(subject).to_not be_valid
+        expect(subject.errors).to include(:apply_automatically)
+      end
     end
   end
 

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -47,9 +47,9 @@ describe Spree::Promotion, :type => :model do
     end
   end
 
-  describe "#sale" do
+  describe "#apply_automatically" do
     it "defaults to false" do
-      expect(subject.sale).to eq(false)
+      expect(subject.apply_automatically).to eq(false)
     end
   end
 

--- a/frontend/spec/features/automatic_promotion_adjustments_spec.rb
+++ b/frontend/spec/features/automatic_promotion_adjustments_spec.rb
@@ -9,7 +9,7 @@ describe "Automatic promotions", :type => :feature, :js => true do
   let!(:product) { create(:product, :name => "RoR Mug", :price => 20) }
 
   let!(:promotion) do
-    promotion = Spree::Promotion.create!(:name => "$10 off when you spend more than $100")
+    promotion = Spree::Promotion.create!(name: "$10 off when you spend more than $100", sale: true)
 
    calculator = Spree::Calculator::FlatRate.new
    calculator.preferred_amount = 10

--- a/frontend/spec/features/automatic_promotion_adjustments_spec.rb
+++ b/frontend/spec/features/automatic_promotion_adjustments_spec.rb
@@ -9,7 +9,7 @@ describe "Automatic promotions", :type => :feature, :js => true do
   let!(:product) { create(:product, :name => "RoR Mug", :price => 20) }
 
   let!(:promotion) do
-    promotion = Spree::Promotion.create!(name: "$10 off when you spend more than $100", sale: true)
+    promotion = Spree::Promotion.create!(name: "$10 off when you spend more than $100", apply_automatically: true)
 
    calculator = Spree::Calculator::FlatRate.new
    calculator.preferred_amount = 10


### PR DESCRIPTION
A promotion with no code or path is currently treated as a sale promotion in Solidus - so it's applied to all orders automatically.

As indicated in #419, there are a number of issues with this:
* querying for sale promotions is a performance bottleneck in stores with many promotions/promotion codes
* it's possible to accidentally create a sale promotion by omitting the code/path

This PR overcomes these issues by:
* adding a `Spree::Promotion#sale` attribute to specify that a promotion should be handled as a sale promotion
* adding a `Spree::Promotion.sale` scope that is used by `Spree::PromotionHandler::Cart` for finding the active sale promotions
* making the `Spree::Promotion#sale` attribute editable in the admin interface.