### PR TITLE
Increase scale on pre tax amount

### DIFF
--- a/core/db/migrate/20150609093816_increase_scale_on_pre_tax_amounts.rb
+++ b/core/db/migrate/20150609093816_increase_scale_on_pre_tax_amounts.rb
@@ -1,5 +1,15 @@
 class IncreaseScaleOnPreTaxAmounts < ActiveRecord::Migration
   def change
+    # set pre_tax_amount on shipments to discounted_amount - included_tax_total
+    # so that the null: false option on the shipment pre_tax_amount doesn't generate
+    # errors.
+    #
+    execute(<<-SQL)
+      UPDATE spree_shipments
+      SET pre_tax_amount = (cost + promo_total) - included_tax_total
+      WHERE pre_tax_amount IS NULL;
+    SQL
+
     change_column :spree_line_items, :pre_tax_amount, :decimal, precision: 12, scale: 4, default: 0.0, null: false
     change_column :spree_shipments, :pre_tax_amount, :decimal, precision: 12, scale: 4, default: 0.0, null: false
   end

--- a/core/db/migrate/20150609093816_increase_scale_on_pre_tax_amounts.rb
+++ b/core/db/migrate/20150609093816_increase_scale_on_pre_tax_amounts.rb
@@ -1,0 +1,6 @@
+class IncreaseScaleOnPreTaxAmounts < ActiveRecord::Migration
+  def change
+    change_column :spree_line_items, :pre_tax_amount, :decimal, precision: 12, scale: 4, default: 0.0, null: false
+    change_column :spree_shipments, :pre_tax_amount, :decimal, precision: 12, scale: 4, default: 0.0, null: false
+  end
+end

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -188,4 +188,12 @@ describe Spree::LineItem, :type => :model do
       expect(line_item.price).to eq 21.98
     end
   end
+
+  describe "precision of pre_tax_amount" do
+    let!(:line_item) { create :line_item, pre_tax_amount: 4.2051 }
+
+    it "keeps four digits of precision even when reloading" do
+      expect(line_item.reload.pre_tax_amount).to eq(4.2051)
+    end
+  end
 end

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -25,6 +25,14 @@ describe Spree::Shipment, :type => :model do
   let(:variant) { mock_model(Spree::Variant) }
   let(:line_item) { mock_model(Spree::LineItem, variant: variant) }
 
+  describe "precision of pre_tax_amount" do
+    let!(:line_item) { create :line_item, pre_tax_amount: 4.2051 }
+
+    it "keeps four digits of precision even when reloading" do
+      expect(line_item.reload.pre_tax_amount).to eq(4.2051)
+    end
+  end
+
   # Regression test for #4063
   context "number generation" do
     before do


### PR DESCRIPTION
Commits from @mamhoff in spree 3.0 which increase the scale on the pre_tax_amount columns.

Needed for #440