### PR TITLE
Merge product slug indexes

### DIFF
--- a/core/db/migrate/20141215235502_remove_extra_products_slug_index.rb
+++ b/core/db/migrate/20141215235502_remove_extra_products_slug_index.rb
@@ -1,0 +1,5 @@
+class RemoveExtraProductsSlugIndex < ActiveRecord::Migration
+  def change
+    remove_index :spree_products, name: :permalink_idx_unique
+  end
+end

--- a/core/db/migrate/20141217215630_update_product_slug_index.rb
+++ b/core/db/migrate/20141217215630_update_product_slug_index.rb
@@ -1,0 +1,6 @@
+class UpdateProductSlugIndex < ActiveRecord::Migration
+  def change
+    remove_index :spree_products, :slug
+    add_index :spree_products, :slug, unique: true
+  end
+end


### PR DESCRIPTION
This is a backport from spree 3.0

schema diff:

```
-  add_index "spree_products", ["slug"], name: "index_spree_products_on_slug", using: :btree
-  add_index "spree_products", ["slug"], name: "permalink_idx_unique", unique: true, using: :btree
+  add_index "spree_products", ["slug"], name: "index_spree_products_on_slug", unique: true, using: :btree
```