### PR TITLE
Apply store credit to orders in the “confirm” state

### DIFF
--- a/core/app/models/spree/store_credit.rb
+++ b/core/app/models/spree/store_credit.rb
@@ -292,8 +292,8 @@ class Spree::StoreCredit < Spree::Base
 
   def apply_to_orders_in_confirm_state
     user.orders.by_state("confirm").each do |order|
-      order.update_attributes!(state: "payment")
-      order.next!
+      order.restart_checkout_flow
+      order.contents.advance
     end
   end
 end

--- a/core/spec/models/spree/store_credit_spec.rb
+++ b/core/spec/models/spree/store_credit_spec.rb
@@ -83,7 +83,7 @@ describe Spree::StoreCredit do
       before do
         order.next!
         subject
-        order.complete!
+        order.reload.complete!
       end
 
       it "creates a payment using the user's store credit" do


### PR DESCRIPTION
Currently if an admin allocates store credit to a customer and that customer has already made it to the confirmation step, that store credit will not apply to the order. This change applies the newly allocated store credit to any orders in the confirmation step. It returns the orders to the payment step and re-transitions them to “confirm” using the state machine in order for all of the hooks and callbacks to fire.