### PR TITLE
Promote Order#all_adjustments to association.

### DIFF
--- a/api/spec/controllers/spree/api/orders_controller_spec.rb
+++ b/api/spec/controllers/spree/api/orders_controller_spec.rb
@@ -226,7 +226,7 @@ module Spree
 
     describe 'GET #show' do
       let(:order) { create :order_with_line_items }
-      let(:adjustment) { FactoryGirl.create(:adjustment, order: order) }
+      let(:adjustment) { FactoryGirl.create(:adjustment, adjustable: order, order: order) }
 
       subject { api_get :show, id: order.to_param }
 

--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -16,7 +16,7 @@ module Spree
   class Adjustment < Spree::Base
     belongs_to :adjustable, polymorphic: true, touch: true
     belongs_to :source, polymorphic: true
-    belongs_to :order, class_name: "Spree::Order"
+    belongs_to :order, class_name: 'Spree::Order', inverse_of: :all_adjustments
     belongs_to :promotion_code, :class_name => 'Spree::PromotionCode'
     belongs_to :adjustment_reason, class_name: 'Spree::AdjustmentReason', inverse_of: :adjustments
 

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -59,6 +59,11 @@ module Spree
     has_many :products, through: :variants
     has_many :variants, through: :line_items
     has_many :refunds, through: :payments
+    has_many :all_adjustments,
+             class_name: 'Spree::Adjustment',
+             foreign_key: :order_id,
+             dependent: :destroy,
+             inverse_of: :order
 
     has_many :order_stock_locations, class_name: "Spree::OrderStockLocation"
     has_many :stock_locations, through: :order_stock_locations
@@ -143,11 +148,6 @@ module Spree
     # that should be called when determining if two line items are equal.
     def self.register_line_item_comparison_hook(hook)
       self.line_item_comparison_hooks.add(hook)
-    end
-
-    def all_adjustments
-      Adjustment.where("order_id = :order_id OR (adjustable_id = :order_id AND adjustable_type = 'Spree::Order')",
-                       order_id: self.id)
     end
 
     # For compatiblity with Calculator::PriceSack

--- a/core/db/migrate/20150515211137_fix_adjustment_order_id.rb
+++ b/core/db/migrate/20150515211137_fix_adjustment_order_id.rb
@@ -1,0 +1,80 @@
+class FixAdjustmentOrderId < ActiveRecord::Migration
+  def change
+    say 'Populate order_id from adjustable_id where appropriate'
+
+    # 3 separate execute calls to workaround MySQL limitation
+    execute(<<-'SQL'.squish)
+      UPDATE
+        spree_adjustments
+      SET
+        order_id = adjustable_id
+      WHERE
+            adjustable_type = 'Spree::Order'
+        AND order_id IS NULL
+    SQL
+
+    execute(<<-'SQL'.squish)
+      UPDATE
+        spree_adjustments
+      SET
+        order_id =
+          (SELECT order_id FROM spree_line_items WHERE spree_line_items.id = spree_adjustments.adjustable_id)
+      WHERE
+            adjustable_type = 'Spree::LineItem'
+        AND order_id IS NULL
+      ;
+    SQL
+
+    execute(<<-'SQL'.squish)
+      UPDATE
+        spree_adjustments
+      SET
+        order_id =
+          (SELECT order_id FROM spree_shipments WHERE spree_shipments.id = spree_adjustments.adjustable_id)
+      WHERE
+            adjustable_type = 'Spree::Shipment'
+        AND order_id IS NULL
+    SQL
+
+    say 'Fix schema for spree_adjustments order_id column'
+    change_table :spree_adjustments do |t|
+      t.change :order_id,      :integer, null: false
+      t.change :adjustable_id, :integer, null: false
+
+      add_foreign_key :spree_adjustments,
+                      :spree_orders,
+                      name:      'fk_spree_adjustments_order_id', # default is indeterministic
+                      column:    :order_id,
+                      on_delete: :restrict, # handled by models
+                      on_update: :restrict  # handled by models
+    end
+
+
+    if connection.adapter_name.eql?('PostgreSQL')
+      # Negated Logical implication.
+      #
+      # When adjustable_type is 'Spree::Order' (p) the adjustable_id must be order_id (q).
+      #
+      # When adjustable_type is NOT 'Spree::Order' the adjustable id allowed to be any value (including of order_id in
+      # case foreign keys match). XOR does not work here.
+      #
+      # Postgresql does not have an operator for logical implication. So we need to build the following truth table
+      # via AND with OR:
+      #
+      #  p q | CHECK = !(p -> q)
+      #  -----------
+      #  t t | t
+      #  t f | f
+      #  f t | t
+      #  f f | t
+      #
+      # According to de-morgans law the logical implication q -> p is equivalent to !p || q
+      #
+      execute(<<-SQL.squish)
+        ALTER TABLE ONLY spree_adjustments
+          ADD CONSTRAINT check_spree_adjustments_order_id CHECK
+            (adjustable_type <> 'Spree::Order' OR order_id = adjustable_id);
+      SQL
+    end
+  end
+end

--- a/core/spec/mailers/order_mailer_spec.rb
+++ b/core/spec/mailers/order_mailer_spec.rb
@@ -6,7 +6,7 @@ describe Spree::OrderMailer, :type => :mailer do
   include EmailSpec::Matchers
 
   let(:order) do
-    order = stub_model(Spree::Order)
+    order = create(:order)
     product = stub_model(Spree::Product, :name => %Q{The "BEST" product})
     variant = stub_model(Spree::Variant, :product => product)
     price = stub_model(Spree::Price, :variant => variant, :amount => 5.00)
@@ -44,8 +44,21 @@ describe Spree::OrderMailer, :type => :mailer do
 
   context "only shows eligible adjustments in emails" do
     before do
-      create(:adjustment, :order => order, :eligible => true, :label => "Eligible Adjustment")
-      create(:adjustment, :order => order, :eligible => false, :label => "Ineligible Adjustment")
+      create(
+        :adjustment,
+        adjustable: order,
+        order:      order,
+        eligible:   true,
+        label:      'Eligible Adjustment'
+      )
+
+      create(
+        :adjustment,
+        adjustable: order,
+        order:      order,
+        eligible:   false,
+        label:      'Ineligible Adjustment'
+      )
     end
 
     let!(:confirmation_email) { Spree::OrderMailer.confirm_email(order) }

--- a/core/spec/models/spree/adjustment_spec.rb
+++ b/core/spec/models/spree/adjustment_spec.rb
@@ -33,9 +33,17 @@ describe Spree::Adjustment, :type => :model do
       Spree::Adjustment.non_tax.to_a
     end
 
-    let!(:tax_adjustment) { create(:adjustment, order: order, source: create(:tax_rate))                   }
-    let!(:non_tax_adjustment_with_source) { create(:adjustment, order: order, source_type: 'Spree::Order', source_id: nil) }
-    let!(:non_tax_adjustment_without_source) { create(:adjustment, order: order, source: nil)                                 }
+    let!(:tax_adjustment) do
+      create(:adjustment, adjustable: order, order: order, source: create(:tax_rate))
+    end
+
+    let!(:non_tax_adjustment_with_source) do
+      create(:adjustment, adjustable: order, order: order, source_type: 'Spree::Order', source_id: nil)
+    end
+
+    let!(:non_tax_adjustment_without_source) do
+      create(:adjustment, adjustable: order, order: order, source: nil)
+    end
 
     it 'select non-tax adjustments' do
       expect(subject).to_not include tax_adjustment

--- a/core/spec/models/spree/calculator/refunds/default_refund_amount_spec.rb
+++ b/core/spec/models/spree/calculator/refunds/default_refund_amount_spec.rb
@@ -22,7 +22,16 @@ describe Spree::Calculator::Returns::DefaultRefundAmount, :type => :model do
       let(:adjustment_amount) { -10.0 }
 
       before do
-        order.adjustments << create(:adjustment, order: order, amount: adjustment_amount, eligible: true, label: 'Adjustment', source_type: 'Spree::Order')
+        order.adjustments << create(
+          :adjustment,
+          adjustable:  order,
+          order:       order,
+          amount:      adjustment_amount,
+          eligible:    true,
+          label:       'Adjustment',
+          source_type: 'Spree::Order'
+        )
+
         order.adjustments.first.update_attributes(amount: adjustment_amount)
       end
 

--- a/core/spec/models/spree/order/adjustments_spec.rb
+++ b/core/spec/models/spree/order/adjustments_spec.rb
@@ -1,16 +1,6 @@
 require 'spec_helper'
 
-describe Spree::Order, :type => :model do
-  context "#all_adjustments" do
-    # Regression test for #4537
-    it "does not show adjustments from other, non-order adjustables" do
-      order = Spree::Order.new(:id => 1)
-      where_sql = order.all_adjustments.where_values.to_s
-      expect(where_sql).to include("(adjustable_id = 1 AND adjustable_type = 'Spree::Order')")
-    end
-  end
-
-  # Regression test for #2191
+describe Spree::Order do
   context "when an order has an adjustment that zeroes the total, but another adjustment for shipping that raises it above zero" do
     let!(:persisted_order) { create(:order) }
     let!(:line_item) { create(:line_item) }


### PR DESCRIPTION
Promotes Order#all_adjustments to association.

Benefits:

* Kill redundant code. The predicate used before is the more complex version of a join by `order_id`
* Its possible to specify includes
* Enables other patches of ours to be applied
* Reduces the amount of handwritten SQL for an AR buildin (code reduction)
* Reduces a special case to test for the custom redundant code.
* Fix invariant violating call sides (mainly in specs).

The MySQL migration was verified, but is slower than the postgresql one.

I'd be happy to apply the check constraint for postgresql by default (under a postgresql adapter guard) feel free to get me feedback on that one.