### PR TITLE
Fix spurious failure in products spec

### DIFF
--- a/backend/spec/features/admin/products/products_spec.rb
+++ b/backend/spec/features/admin/products/products_spec.rb
@@ -318,13 +318,16 @@ describe "Products", :type => :feature do
         expect(page).to have_content("SELECT FROM PROTOTYPE")
         click_link "Select From Prototype"
 
-        within(:css, "#prototypes tr#row_1") do
-          click_link 'Select'
-          wait_for_ajax
-        end
+        row = find('#prototypes tr', text: 'Size')
+        row.click_link 'Select'
 
-        within(:css, "tr.product_property:first-child") do
-          expect(first('input[type=text]').value).to eq('baseball_cap_color')
+        # The following is unfortunate.
+        # It is tough to distinguish between the different fields, so we assert
+        # that there are two rows (ensuring one has been added) and then
+        # inspect the first one.
+        expect(page).to have_css('#product_properties .product_property', count: 2)
+        within('#product_properties .product_property:nth-child(1)') do
+          expect(find('input[type=text]').value).to eq('baseball_cap_color')
         end
       end
     end


### PR DESCRIPTION
This failed sometimes because the existing selector id, `row_1`, was not consistent (presumably based off of database id).

This changes it to select based on the text in the row, and removes the `wait_for_ajax`.

This spec still isn't beautiful, but it should be stable. The admin area this is testing could really use some love.