### PR TITLE
Add extension points for shipping rate sorting and selection

### DIFF
--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -276,6 +276,16 @@ module Spree
       @promotion_chooser_class ||= Spree::PromotionChooser
     end
 
+    attr_writer :shipping_rate_sorter_class
+    def shipping_rate_sorter_class
+      @shipping_rate_sorter_class ||= Spree::Stock::ShippingRateSorter
+    end
+
+    attr_writer :shipping_rate_selector_class
+    def shipping_rate_selector_class
+      @shipping_rate_selector_class ||= Spree::Stock::ShippingRateSelector
+    end
+
     # Allows providing your own Mailer for shipped cartons.
     #
     # @!attribute [rw] carton_shipped_email_class

--- a/core/app/models/spree/stock/estimator.rb
+++ b/core/app/models/spree/stock/estimator.rb
@@ -20,18 +20,15 @@ module Spree
         rates = calculate_shipping_rates(package)
         rates.select! { |rate| rate.shipping_method.frontend? } if frontend_only
         choose_default_shipping_rate(rates)
-        sort_shipping_rates(rates)
+        Spree::Config.shipping_rate_sorter_class.new(rates).sort
       end
 
       private
       def choose_default_shipping_rate(shipping_rates)
         unless shipping_rates.empty?
-          shipping_rates.min_by(&:cost).selected = true
+          default_shipping_rate = Spree::Config.shipping_rate_selector_class.new(shipping_rates).find_default
+          default_shipping_rate.selected = true
         end
-      end
-
-      def sort_shipping_rates(shipping_rates)
-        shipping_rates.sort_by!(&:cost)
       end
 
       def calculate_shipping_rates(package)

--- a/core/app/models/spree/stock/shipping_rate_selector.rb
+++ b/core/app/models/spree/stock/shipping_rate_selector.rb
@@ -1,0 +1,16 @@
+module Spree
+  module Stock
+    class ShippingRateSelector
+
+      attr_reader :shipping_rates
+
+      def initialize(shipping_rates)
+        @shipping_rates = shipping_rates
+      end
+
+      def find_default
+        shipping_rates.min_by(&:cost)
+      end
+    end
+  end
+end

--- a/core/app/models/spree/stock/shipping_rate_sorter.rb
+++ b/core/app/models/spree/stock/shipping_rate_sorter.rb
@@ -1,0 +1,16 @@
+module Spree
+  module Stock
+    class ShippingRateSorter
+
+      attr_reader :shipping_rates
+
+      def initialize(shipping_rates)
+        @shipping_rates = shipping_rates
+      end
+
+      def sort
+        shipping_rates.sort_by(&:cost)
+      end
+    end
+  end
+end

--- a/core/lib/spree/testing_support/factories/shipping_rate_factory.rb
+++ b/core/lib/spree/testing_support/factories/shipping_rate_factory.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :shipping_rate, class: Spree::ShippingRate do
+    shipping_method
+    shipment
+  end
+end

--- a/core/spec/models/spree/stock/estimator_spec.rb
+++ b/core/spec/models/spree/stock/estimator_spec.rb
@@ -140,6 +140,40 @@ module Spree
             expect(shipping_rates.first.tax_rate).to eq(tax_rate)
           end
         end
+
+        it 'uses the configured shipping rate selector' do
+          shipping_rate = Spree::ShippingRate.new
+          allow(Spree::ShippingRate).to receive(:new).and_return(shipping_rate)
+
+          selector_class = Class.new do
+            def initialize(_); end;
+
+            def find_default
+              Spree::ShippingRate.new
+            end
+          end
+          Spree::Config.shipping_rate_selector_class = selector_class
+
+          subject.shipping_rates(package)
+
+          expect(shipping_rate.selected).to eq(true)
+
+          Spree::Config.shipping_rate_selector_class = nil
+        end
+
+        it 'uses the configured shipping rate sorter' do
+          class Spree::Stock::TestSorter; end;
+          Spree::Config.shipping_rate_sorter_class = Spree::Stock::TestSorter
+
+          sorter = double(:sorter, sort: nil)
+          allow(Spree::Stock::TestSorter).to receive(:new).and_return(sorter)
+
+          subject.shipping_rates(package)
+
+          expect(sorter).to have_received(:sort)
+
+          Spree::Config.shipping_rate_sorter_class = nil
+        end
       end
     end
   end

--- a/core/spec/models/spree/stock/shipping_rate_selector_spec.rb
+++ b/core/spec/models/spree/stock/shipping_rate_selector_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe Spree::Stock::ShippingRateSelector do
+  describe '#sort' do
+    it 'sorts by increasing cost' do
+      cheapest_shipping_rate = Spree::ShippingRate.new(cost: 1.00)
+      middle_shipping_rate = Spree::ShippingRate.new(cost: 5.00)
+      expensive_shipping_rate = Spree::ShippingRate.new(cost: 42.00)
+      shipping_rates = [expensive_shipping_rate, middle_shipping_rate, cheapest_shipping_rate]
+
+      sorter = Spree::Stock::ShippingRateSelector.new(shipping_rates)
+
+      expect(sorter.find_default).to eq(cheapest_shipping_rate)
+    end
+  end
+end

--- a/core/spec/models/spree/stock/shipping_rate_sorter_spec.rb
+++ b/core/spec/models/spree/stock/shipping_rate_sorter_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe Spree::Stock::ShippingRateSorter do
+  describe '#sort' do
+    it 'sorts by increasing cost' do
+      cheapest_shipping_rate = Spree::ShippingRate.new(cost: 1.00)
+      middle_shipping_rate = Spree::ShippingRate.new(cost: 5.00)
+      expensive_shipping_rate = Spree::ShippingRate.new(cost: 42.00)
+      shipping_rates = [expensive_shipping_rate, middle_shipping_rate, cheapest_shipping_rate]
+
+      sorter = Spree::Stock::ShippingRateSorter.new(shipping_rates)
+
+      expect(sorter.sort).to eq([cheapest_shipping_rate, middle_shipping_rate, expensive_shipping_rate])
+    end
+  end
+end


### PR DESCRIPTION
* Clients can provide a shipping_rate_sorter_class and a
  shipping_rate_selector_class via Spree::Config.
* By default, the shipping rate is sorted in ascending order by cost and
  the cheapest shipping rate is selected.