### PR TITLE
Add by_store scope to Spree::Shipment

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -35,6 +35,7 @@ module Spree
     scope :with_state, ->(*s) { where(state: s) }
     # sort by most recent shipped_at, falling back to created_at. add "id desc" to make specs that involve this scope more deterministic.
     scope :reverse_chronological, -> { order('coalesce(spree_shipments.shipped_at, spree_shipments.created_at) desc', id: :desc) }
+    scope :by_store, ->(store) { joins(:order).merge(Spree::Order.by_store(store)) }
 
     # shipment state machine (see http://github.com/pluginaweek/state_machine/tree/master for details)
     state_machine initial: :pending, use_transactions: false do

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -750,4 +750,18 @@ describe Spree::Shipment, :type => :model do
       end
     end
   end
+
+  describe ".by_store" do
+    it "returns shipments by store" do
+      olivanders_store = create(:store, name: 'Olivanders')
+      wizard_shipment = create(:shipment, order: create(:order, store: olivanders_store))
+      create(:shipment, order: build(:order, store: create(:store, name: 'Target')))
+
+      shipments = Spree::Shipment.by_store(olivanders_store)
+
+      expect(Spree::Shipment.count).to eq(2)
+      expect(shipments.count).to eq(1)
+      expect(shipments.first).to eq(wizard_shipment)
+    end
+  end
 end


### PR DESCRIPTION
The current use case for this scope is to limit order history to a specific store.