### PR TITLE
Add authorize calls to shipment controller using @shipment

### DIFF
--- a/api/app/controllers/spree/api/shipments_controller.rb
+++ b/api/app/controllers/spree/api/shipments_controller.rb
@@ -116,11 +116,12 @@ module Spree
 
       def find_shipment
         if @order.present?
-          @shipment = @order.shipments.accessible_by(current_ability, :update).find_by!(number: params[:id])
+          @shipment = @order.shipments.find_by!(number: params[:id])
         else
-          @shipment = Spree::Shipment.accessible_by(current_ability, :update).readonly(false).find_by!(number: params[:id])
+          @shipment = Spree::Shipment.readonly(false).find_by!(number: params[:id])
           @order = @shipment.order
         end
+        authorize! :update, @shipment
       end
 
       def update_shipment

--- a/api/spec/controllers/spree/api/shipments_controller_spec.rb
+++ b/api/spec/controllers/spree/api/shipments_controller_spec.rb
@@ -14,12 +14,27 @@ describe Spree::Api::ShipmentsController, :type => :controller do
   context "as a non-admin" do
     it "cannot make a shipment ready" do
       api_put :ready
-      assert_not_found!
+      assert_unauthorized!
     end
 
     it "cannot make a shipment shipped" do
       api_put :ship
-      assert_not_found!
+      assert_unauthorized!
+    end
+
+    it "cannot remove order contents from shipment" do
+      api_put :remove
+      assert_unauthorized!
+    end
+
+    it "cannot add contents to the shipment" do
+      api_put :add
+      assert_unauthorized!
+    end
+
+    it "cannot update the shipment" do
+      api_put :update
+      assert_unauthorized!
     end
   end
 
@@ -279,9 +294,9 @@ describe Spree::Api::ShipmentsController, :type => :controller do
         }.not_to change(shipment, :shipped_at)
       end
 
-      it "responds with a 404" do
+      it "responds with a 401" do
         subject
-        expect(response).to be_not_found
+        expect(response).to be_unauthorized
       end
     end
   end


### PR DESCRIPTION
* Right now if a user is unauthorized to update a shipment it will
  return a 404, but it should be returning a 401. This updates the shipment controller actions that use
  the before filter `find_shipment` to now have an `authorize! :update, @shipment` on them.