### PR TITLE
Use empty AR model for store migrations

### DIFF
--- a/core/db/migrate/20140309033438_create_store_from_preferences.rb
+++ b/core/db/migrate/20140309033438_create_store_from_preferences.rb
@@ -1,14 +1,17 @@
 class CreateStoreFromPreferences < ActiveRecord::Migration
+  class Store < ActiveRecord::Base
+    self.table_name = 'spree_stores'
+  end
   def change
     preference_store = Spree::Preferences::Store.instance
-    if store = Spree::Store.where(default: true).first
+    if store = Store.where(default: true).first
       store.meta_description = preference_store.get('spree/app_configuration/default_meta_description') {}
       store.meta_keywords    = preference_store.get('spree/app_configuration/default_meta_keywords') {}
       store.seo_title        = preference_store.get('spree/app_configuration/default_seo_title') {}
       store.save!
     else
       # we set defaults for the things we now require
-      Spree::Store.new do |s|
+      Store.new do |s|
         s.name              = preference_store.get 'spree/app_configuration/site_name' do
           'Sample Store'
         end

--- a/core/db/migrate/20141009204607_add_store_id_to_orders.rb
+++ b/core/db/migrate/20141009204607_add_store_id_to_orders.rb
@@ -1,8 +1,12 @@
 class AddStoreIdToOrders < ActiveRecord::Migration
+  class Store < ActiveRecord::Base
+    self.table_name = 'spree_stores'
+  end
   def change
     add_column :spree_orders, :store_id, :integer
-    if Spree::Store.default.persisted?
-      Spree::Order.where(store_id: nil).update_all(store_id: Spree::Store.default.id)
+    default_store = Store.where(default: true).first
+    if default_store
+      Spree::Order.where(store_id: nil).update_all(store_id: default_store.id)
     end
   end
 end


### PR DESCRIPTION
Fixes an issue the solidus_globalize port is having because of the globalize table not existing at the time the migration is run.

Fixes issue #485

cc @dangerdogz @athal7 