### PR TITLE
Admin shipment delete line item hits api/line_items instead of api/shipments

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/shipments.js.erb
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js.erb
@@ -50,11 +50,10 @@ $(document).ready(function () {
   $('a.delete-item').click(function(event){
     if (confirm(Spree.translations.are_you_sure_delete)) {
       var del = $(this);
-      var shipment_number = del.data('shipment-number');
-      var variant_id = del.data('variant-id');
+      var line_item_id = del.data('line-item-id');
 
       toggleItemEdit();
-      adjustShipmentItems(shipment_number, variant_id, 0);
+      deleteLineItem(line_item_id);
     }
     return false;
   });
@@ -169,6 +168,21 @@ adjustShipmentItems = function(shipment_number, variant_id, quantity){
         }
       });
     }
+}
+
+deleteLineItem = function(line_item_id){
+  var url = Spree.routes.line_items_api(order_number) + "/" + line_item_id + ".json";
+
+  Spree.ajax({
+    type: "DELETE",
+    url: Spree.url(url),
+    success: function(response) {
+      window.location.reload();
+    },
+    error: function(response) {
+      show_flash('error', response.responseJSON.message);
+    }
+  });
 }
 
 toggleMethodEdit = function(){

--- a/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
@@ -25,7 +25,7 @@
         <%= link_to '', '#', :class => 'save-item fa fa-check no-text with-tip', :data => {'shipment-number' => shipment_number, 'variant-id' => item.variant.id, :action => 'save'}, :title => Spree.t('actions.save'), :style => 'display: none' %>
         <%= link_to '', '#', :class => 'cancel-item fa fa-cancel no-text with-tip', :data => {:action => 'cancel'}, :title => Spree.t('actions.cancel'), :style => 'display: none' %>
         <%= link_to '', '#', :class => 'split-item icon_link fa fa-arrows-h no-text with-tip', :data => {:action => 'split', 'variant-id' => item.variant.id}, :title => Spree.t('split') %>
-        <%= link_to '', '#', :class => 'delete-item fa fa-trash no-text with-tip', :data => { 'shipment-number' => shipment_number, 'variant-id' => item.variant.id, :action => 'remove'}, :title => Spree.t('delete') %>
+        <%= link_to '', '#', :class => 'delete-item fa fa-trash no-text with-tip', :data => { 'line-item-id' => item.line_item.id}, :title => Spree.t('delete') %>
       <% end %>
     </td>
   </tr>


### PR DESCRIPTION
Instead of hitting the shipments#remove endpoint, let's hit the line_items#destroy endpoint. The former isn't really restful, and the latter is easier to reason about.