### PR TITLE
Remove duplicate line_items method definition

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -164,10 +164,6 @@ module Spree
       inventory_units.includes(:line_item).map(&:line_item).uniq
     end
 
-    def line_items
-      inventory_units.includes(:line_item).map(&:line_item).uniq
-    end
-
     def ready_or_pending?
       self.ready? || self.pending?
     end


### PR DESCRIPTION
Just reading through the code I noticed this method is defined twice.