### PR TITLE
Make best_promotion_adjustment private

### DIFF
--- a/core/app/models/spree/promotion_chooser.rb
+++ b/core/app/models/spree/promotion_chooser.rb
@@ -20,6 +20,7 @@ module Spree
       end
     end
 
+    private
     # @return The best promotion from this set of adjustments.
     def best_promotion_adjustment
       @best_promotion_adjustment ||= @adjustments.select(&:eligible?).min_by do |a|


### PR DESCRIPTION
Reading through our list of configurable classes, realized that this method isn't called outside this class