### PR TITLE
adds manage stock key to en.yml

### DIFF
--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -940,6 +940,7 @@ en:
     make_refund: Make refund
     make_sure_the_above_reimbursement_amount_is_correct: Make sure the above reimbursement amount is correct
     manage_promotion_categories: Manage Promotion Categories
+    manage_stock: Manage Stock
     manual_intervention_required: Manual intervention required
     manage_variants: Manage Variants
     master_price: Master Price


### PR DESCRIPTION
Simple fix for error that would show when navigating to the Stock page in the admin panel, once first creating a solidus app from the solidus branch.