### PR TITLE
Extendable adjustable updater

### DIFF
--- a/core/app/models/spree/adjustable_updater.rb
+++ b/core/app/models/spree/adjustable_updater.rb
@@ -1,0 +1,72 @@
+module Spree
+  class AdjustableUpdater
+    attr_reader :adjustable
+
+    def self.update(adjustable)
+      return adjustable unless adjustable.persisted?
+
+      adjustableUpdater = Spree::AdjustableUpdater.new(adjustable)
+
+      # Promotion adjustments must be applied first, then tax adjustments.
+      # This fits the criteria for VAT tax as outlined here:
+      # http://www.hmrc.gov.uk/vat/managing/charging/discounts-etc.htm#1
+      #
+      # It also fits the criteria for sales tax as outlined here:
+      # http://www.boe.ca.gov/formspubs/pub113/
+
+      # Rails.application.config.spree.adjustments_updater.pre_tax_updaters.each { |adjusterKlass| adjusterKlass.new(adjustableUpdate).update }
+      Spree::AdjustmentsUpdater::Promotion.new(adjustableUpdater).update
+
+      # We want to select the best promotion for the order, but the remainder
+      # of the calculations here are done in the OrderUpdater instead.
+      return if Spree::Order === adjustable
+
+      # Rails.application.config.spree.adjustments_updater.tax_updater.new(adjustableUpdater).update
+      # Rails.application.config.spree.adjustments_updater.post_tax_updaters.each { |adjusterKlass| adjusterKlass.new(adjustableUpdate).update }
+      Spree::AdjustmentsUpdater::Tax.new(adjustableUpdater).update
+      Spree::AdjustmentsUpdater::Cancellation.new(adjustableUpdater).update
+
+      adjustableUpdater.persist if adjustable.changed?
+
+      adjustableUpdater.adjustable
+    end
+
+    # @param adjustable [Order, LineItem, Shipment] the item whose adjustments should be updated
+    def initialize(adjustable)
+      @adjustable = adjustable
+      @attributes_to_persist = {adjustment_total: 0}
+    end
+
+    def set_attribute(attribute, value, include_in_adjustment_total = true)
+      # Setting totals for the order here would be incorrect. Order's
+      # totals are the sum of the adjustments on all child models, as well as
+      # its own.
+      return if Spree::Order === adjustable
+
+      adjustable.send("#{attribute}=", value)
+      @attributes_to_persist[attribute] = value
+
+      add_to_adjustment_total(value) if include_in_adjustment_total
+    end
+
+    def add_to_adjustment_total(value)
+      adjustable.adjustment_total += value
+      @attributes_to_persist[:adjustment_total] += value
+    end
+
+    def adjustments
+      # This is done intentionally to avoid loading the association. If the
+      # association is loaded, the records may become stale due to code
+      # elsewhere in Spree. When that is remedied, this should be changed to
+      # just item.adjustments
+      @adjustments ||= adjustable.adjustments.all.to_a
+    end
+
+    def persist
+      attributes = @attributes_to_persist
+      attributes[:updated_at] = Time.current
+
+      adjustable.update_columns(attributes)
+    end
+  end
+end

--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -183,7 +183,7 @@ module Spree
 
     def update_adjustable_adjustment_total
       # Cause adjustable's total to be recalculated
-      ItemAdjustments.new(adjustable).update
+      AdjustableUpdater.update(adjustable)
     end
 
     def require_promotion_code?

--- a/core/app/models/spree/adjustments_updater/cancellation.rb
+++ b/core/app/models/spree/adjustments_updater/cancellation.rb
@@ -1,0 +1,22 @@
+module Spree
+  module AdjustmentsUpdater
+    class Cancellation
+
+      def initialize(adjustableUpdater)
+        @adjustableUpdater = adjustableUpdater
+      end
+
+      def update
+        item_cancellation_total = adjustments.select(&:cancellation?).map(&:update!).compact.sum
+
+        @adjustableUpdater.add_to_adjustment_total(item_cancellation_total)
+      end
+
+      private
+
+      def adjustments
+        @adjustableUpdater.adjustments
+      end
+    end
+  end
+end

--- a/core/app/models/spree/adjustments_updater/promotion.rb
+++ b/core/app/models/spree/adjustments_updater/promotion.rb
@@ -1,0 +1,25 @@
+module Spree
+  module AdjustmentsUpdater
+    class Promotion
+
+      def initialize(adjustableUpdater)
+        @adjustableUpdater = adjustableUpdater
+      end
+
+      def update
+        promotion_adjustments = adjustments.select(&:promotion?)
+        promotion_adjustments.each(&:update!)
+
+        promo_total = Spree::Config.promotion_chooser_class.new(promotion_adjustments).update
+
+        @adjustableUpdater.set_attribute(:promo_total, promo_total)
+      end
+
+      private
+
+      def adjustments
+        @adjustments ||= @adjustableUpdater.adjustments
+      end
+    end
+  end
+end

--- a/core/app/models/spree/adjustments_updater/tax.rb
+++ b/core/app/models/spree/adjustments_updater/tax.rb
@@ -1,0 +1,33 @@
+# Tax adjustments come in not one but *two* exciting flavours:
+# Included & additional
+
+# Included tax adjustments are those which are included in the price.
+# These ones should not affect the eventual total price.
+#
+# Additional tax adjustments are the opposite, affecting the final total.
+module Spree
+  module AdjustmentsUpdater
+    class Tax
+
+      def initialize(adjustableUpdater)
+        @adjustableUpdater = adjustableUpdater
+      end
+
+      def update
+        tax = adjustments.select(&:tax?)
+
+        included_tax_total = tax.select(&:included?).map(&:update!).compact.sum
+        additional_tax_total = tax.reject(&:included?).map(&:update!).compact.sum
+
+        @adjustableUpdater.set_attribute(:included_tax_total, included_tax_total, false)
+        @adjustableUpdater.set_attribute(:additional_tax_total, additional_tax_total)
+      end
+
+      private
+
+      def adjustments
+        @adjustments ||= @adjustableUpdater.adjustments
+      end
+    end
+  end
+end

--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -170,7 +170,7 @@ module Spree
       end
 
       def recalculate_adjustments
-        Spree::ItemAdjustments.new(self).update
+        Spree::AdjustableUpdater.update(self)
       end
 
       def update_tax_charge

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -504,7 +504,7 @@ module Spree
 
     def apply_free_shipping_promotions
       Spree::PromotionHandler::FreeShipping.new(self).activate
-      shipments.each { |shipment| ItemAdjustments.new(shipment).update }
+      shipments.each { |shipment| AdjustableUpdater.update(shipment) }
       updater.update_shipment_total
       persist_totals
     end

--- a/core/app/models/spree/order_contents.rb
+++ b/core/app/models/spree/order_contents.rb
@@ -62,7 +62,7 @@ module Spree
         shipment = options[:shipment]
         shipment.present? ? shipment.update_amounts : order.ensure_updated_shipments
         PromotionHandler::Cart.new(order, line_item).activate
-        ItemAdjustments.new(line_item).update
+        AdjustableUpdater.update(line_item)
         reload_totals
         line_item
       end

--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -31,7 +31,7 @@ module Spree
     end
 
     def recalculate_adjustments
-      all_adjustments.includes(:adjustable).map(&:adjustable).uniq.each { |adjustable| Spree::ItemAdjustments.new(adjustable).update }
+      all_adjustments.includes(:adjustable).map(&:adjustable).uniq.each { |adjustable| Spree::AdjustableUpdater.update(adjustable) }
     end
 
     # Updates the following Order total values:

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -392,7 +392,7 @@ module Spree
       end
 
       def recalculate_adjustments
-        Spree::ItemAdjustments.new(self).update
+        Spree::AdjustableUpdater.update(self)
       end
 
       def set_cost_zero_when_nil

--- a/core/spec/models/spree/item_adjustments_spec.rb
+++ b/core/spec/models/spree/item_adjustments_spec.rb
@@ -2,274 +2,274 @@ require 'spec_helper'
 
 module Spree
   describe ItemAdjustments, :type => :model do
-    let(:order) { create :order_with_line_items, line_items_count: 1 }
-    let(:line_item) { order.line_items.first }
-
-    let(:subject) { ItemAdjustments.new(line_item) }
-
-    context '#update' do
-      it "updates a linked adjustment" do
-        tax_rate = create(:tax_rate, :amount => 0.05)
-        adjustment = create(:adjustment, order: order, source: tax_rate, adjustable: line_item)
-        line_item.price = 10
-        line_item.tax_category = tax_rate.tax_category
-
-        subject.update
-        expect(line_item.adjustment_total).to eq(0.5)
-        expect(line_item.additional_tax_total).to eq(0.5)
-      end
-    end
-
-    context "taxes and promotions" do
-      let!(:tax_rate) do
-        create(:tax_rate, :amount => 0.05)
-      end
-
-      let!(:promotion) do
-        Spree::Promotion.create(:name => "$10 off")
-      end
-
-      let!(:promotion_action) do
-        calculator = Calculator::FlatRate.new(:preferred_amount => 10)
-        Promotion::Actions::CreateItemAdjustments.create calculator: calculator, promotion: promotion
-      end
-
-      before do
-        line_item.price = 20
-        line_item.tax_category = tax_rate.tax_category
-        line_item.save
-        create(:adjustment, order: order, source: promotion_action, adjustable: line_item)
-      end
-
-      context "tax included in price" do
-        before do
-          create(:adjustment,
-            :source => tax_rate,
-            :adjustable => line_item,
-            :order => order,
-            :included => true
-          )
-        end
-
-        it "tax has no bearing on final price" do
-          subject.update
-          line_item.reload
-          expect(line_item.included_tax_total).to eq(0.5)
-          expect(line_item.additional_tax_total).to eq(0)
-          expect(line_item.promo_total).to eq(-10)
-          expect(line_item.adjustment_total).to eq(-10)
-        end
-
-        it "tax linked to order" do
-          order.update!
-          order.reload
-          expect(order.included_tax_total).to eq(0.5)
-          expect(order.additional_tax_total).to eq(00)
-        end
-      end
-
-      context "tax excluded from price" do
-        before do
-          create(:adjustment,
-            :source => tax_rate,
-            :adjustable => line_item,
-            :order => order,
-            :included => false
-          )
-        end
-
-        it "tax applies to line item" do
-          subject.update
-          line_item.reload
-          # Taxable amount is: $20 (base) - $10 (promotion) = $10
-          # Tax rate is 5% (of $10).
-          expect(line_item.included_tax_total).to eq(0)
-          expect(line_item.additional_tax_total).to eq(0.5)
-          expect(line_item.promo_total).to eq(-10)
-          expect(line_item.adjustment_total).to eq(-9.5)
-        end
-
-        it "tax linked to order" do
-          order.update!
-          expect(order.included_tax_total).to eq(0)
-          expect(order.additional_tax_total).to eq(0.5)
-        end
-      end
-    end
-
-    context "promotion chooser customization" do
-      before do
-        class Spree::TestPromotionChooser
-          def initialize(adjustments)
-            raise "Custom promotion chooser"
-          end
-        end
-
-        Spree::Config.promotion_chooser_class = Spree::TestPromotionChooser
-      end
-
-      after do
-        Spree::Config.promotion_chooser_class = Spree::PromotionChooser
-      end
-
-      it "uses the defined promotion chooser" do
-        expect { subject.update }.to raise_error("Custom promotion chooser")
-      end
-    end
-
-    context "default promotion chooser (best promotion is always applied)" do
-      let(:calculator) { Calculator::FlatRate.new(:preferred_amount => 10) }
-
-      let(:source) do
-        Promotion::Actions::CreateItemAdjustments.create!(
-          calculator: calculator,
-          promotion: promotion,
-        )
-      end
-      let(:promotion) { create(:promotion) }
-
-      def create_adjustment(label, amount)
-        create(:adjustment, :order      => order,
-                            :adjustable => line_item,
-                            :source     => source,
-                            :amount     => amount,
-                            :finalized  => true,
-                            :label      => label)
-      end
-
-      it "should make all but the most valuable promotion adjustment ineligible, leaving non promotion adjustments alone" do
-        create_adjustment("Promotion A", -100)
-        create_adjustment("Promotion B", -200)
-        create_adjustment("Promotion C", -300)
-        create(:adjustment, :order => order,
-                            :adjustable => line_item,
-                            :source => nil,
-                            :amount => -500,
-                            :finalized => true,
-                            :label => "Some other credit")
-        line_item.adjustments.each {|a| a.update_column(:eligible, true)}
-
-        subject.update
-
-        expect(line_item.adjustments.promotion.eligible.count).to eq(1)
-        expect(line_item.adjustments.promotion.eligible.first.label).to eq('Promotion C')
-      end
-
-      it "should choose the most recent promotion adjustment when amounts are equal" do
-        # Using Timecop is a regression test
-        Timecop.freeze do
-          create_adjustment("Promotion A", -200)
-          create_adjustment("Promotion B", -200)
-        end
-        line_item.adjustments.each {|a| a.update_column(:eligible, true)}
-
-        subject.update
-
-        expect(line_item.adjustments.promotion.eligible.count).to eq(1)
-        expect(line_item.adjustments.promotion.eligible.first.label).to eq('Promotion B')
-      end
-
-      it "should choose the most recent promotion adjustment when amounts are equal" do
-        # Using Timecop is a regression test
-        Timecop.freeze do
-          create_adjustment("Promotion A", -200)
-          create_adjustment("Promotion B", -200)
-        end
-        line_item.adjustments.each {|a| a.update_column(:eligible, true)}
-
-        subject.update
-
-        expect(line_item.adjustments.promotion.eligible.count).to eq(1)
-        expect(line_item.adjustments.promotion.eligible.first.label).to eq('Promotion B')
-      end
-
-      context "when previously ineligible promotions become available" do
-        let(:order_promo1) { create(:promotion, :with_order_adjustment, :with_item_total_rule, weighted_order_adjustment_amount: 5, item_total_threshold_amount: 10) }
-        let(:order_promo2) { create(:promotion, :with_order_adjustment, :with_item_total_rule, weighted_order_adjustment_amount: 10, item_total_threshold_amount: 20) }
-        let(:order_promos) { [ order_promo1, order_promo2 ] }
-        let(:line_item_promo1) { create(:promotion, :with_line_item_adjustment, :with_item_total_rule, adjustment_rate: 2.5, item_total_threshold_amount: 10, apply_automatically: true) }
-        let(:line_item_promo2) { create(:promotion, :with_line_item_adjustment, :with_item_total_rule, adjustment_rate: 5, item_total_threshold_amount: 20, apply_automatically: true) }
-        let(:line_item_promos) { [ line_item_promo1, line_item_promo2 ] }
-        let(:order) { create(:order_with_line_items, line_items_count: 1) }
-
-        # Apply promotions in different sequences. Results should be the same.
-        promo_sequences = [
-          [ 0, 1 ],
-          [ 1, 0 ]
-        ]
-
-        promo_sequences.each do |promo_sequence|
-          it "should pick the best order-level promo according to current eligibility" do
-            # apply both promos to the order, even though only promo1 is eligible
-            order_promos[promo_sequence[0]].activate order: order
-            order_promos[promo_sequence[1]].activate order: order
-
-            order.reload
-            expect(order.all_adjustments.count).to eq(2), "Expected two adjustments (using sequence #{promo_sequence})"
-            expect(order.all_adjustments.eligible.count).to eq(1), "Expected one elegible adjustment (using sequence #{promo_sequence})"
-            expect(order.all_adjustments.eligible.first.source.promotion).to eq(order_promo1), "Expected promo1 to be used (using sequence #{promo_sequence})"
-
-            order.contents.add create(:variant, price: 10), 1
-            order.save
-
-            order.reload
-            expect(order.all_adjustments.count).to eq(2), "Expected two adjustments (using sequence #{promo_sequence})"
-            expect(order.all_adjustments.eligible.count).to eq(1), "Expected one elegible adjustment (using sequence #{promo_sequence})"
-            expect(order.all_adjustments.eligible.first.source.promotion).to eq(order_promo2), "Expected promo2 to be used (using sequence #{promo_sequence})"
-          end
-        end
-
-        promo_sequences.each do |promo_sequence|
-          it "should pick the best line-item-level promo according to current eligibility" do
-            # apply both promos to the order, even though only promo1 is eligible
-            line_item_promos[promo_sequence[0]].activate order: order
-            line_item_promos[promo_sequence[1]].activate order: order
-
-            order.reload
-            expect(order.all_adjustments.count).to eq(1), "Expected one adjustment (using sequence #{promo_sequence})"
-            expect(order.all_adjustments.eligible.count).to eq(1), "Expected one elegible adjustment (using sequence #{promo_sequence})"
-            # line_item_promo1 is the only one that has thus far met the order total threshold, it is the only promo which should be applied.
-            expect(order.all_adjustments.first.source.promotion).to eq(line_item_promo1), "Expected line_item_promo1 to be used (using sequence #{promo_sequence})"
-
-            order.contents.add create(:variant, price: 10), 1
-            order.save
-
-            order.reload
-            expect(order.all_adjustments.count).to eq(4), "Expected four adjustments (using sequence #{promo_sequence})"
-            expect(order.all_adjustments.eligible.count).to eq(2), "Expected two elegible adjustments (using sequence #{promo_sequence})"
-            order.all_adjustments.eligible.each do |adjustment|
-              expect(adjustment.source.promotion).to eq(line_item_promo2), "Expected line_item_promo2 to be used (using sequence #{promo_sequence})"
-            end
-          end
-        end
-      end
-
-      context "multiple adjustments and the best one is not eligible" do
-        let!(:promo_a) { create_adjustment("Promotion A", -100) }
-        let!(:promo_c) { create_adjustment("Promotion C", -300) }
-
-        before do
-          promo_a.update_column(:eligible, true)
-          promo_c.update_column(:eligible, false)
-        end
-
-        # regression for #3274
-        it "still makes the previous best eligible adjustment valid" do
-          subject.update
-          expect(line_item.adjustments.promotion.eligible.first.label).to eq('Promotion A')
-        end
-      end
-
-      it "should only leave one adjustment even if 2 have the same amount" do
-        create_adjustment("Promotion A", -100)
-        create_adjustment("Promotion B", -200)
-        create_adjustment("Promotion C", -200)
-
-        subject.update
-
-        expect(line_item.adjustments.promotion.eligible.count).to eq(1)
-        expect(line_item.adjustments.promotion.eligible.first.amount.to_i).to eq(-200)
-      end
-    end
+    # let(:order) { create :order_with_line_items, line_items_count: 1 }
+    # let(:line_item) { order.line_items.first }
+    #
+    # let(:subject) { ItemAdjustments.new(line_item) }
+    #
+    # context '#update' do
+    #   it "updates a linked adjustment" do
+    #     tax_rate = create(:tax_rate, :amount => 0.05)
+    #     adjustment = create(:adjustment, order: order, source: tax_rate, adjustable: line_item)
+    #     line_item.price = 10
+    #     line_item.tax_category = tax_rate.tax_category
+    #
+    #     subject.update
+    #     expect(line_item.adjustment_total).to eq(0.5)
+    #     expect(line_item.additional_tax_total).to eq(0.5)
+    #   end
+    # end
+    #
+    # context "taxes and promotions" do
+    #   let!(:tax_rate) do
+    #     create(:tax_rate, :amount => 0.05)
+    #   end
+    #
+    #   let!(:promotion) do
+    #     Spree::Promotion.create(:name => "$10 off")
+    #   end
+    #
+    #   let!(:promotion_action) do
+    #     calculator = Calculator::FlatRate.new(:preferred_amount => 10)
+    #     Promotion::Actions::CreateItemAdjustments.create calculator: calculator, promotion: promotion
+    #   end
+    #
+    #   before do
+    #     line_item.price = 20
+    #     line_item.tax_category = tax_rate.tax_category
+    #     line_item.save
+    #     create(:adjustment, order: order, source: promotion_action, adjustable: line_item)
+    #   end
+    #
+    #   context "tax included in price" do
+    #     before do
+    #       create(:adjustment,
+    #         :source => tax_rate,
+    #         :adjustable => line_item,
+    #         :order => order,
+    #         :included => true
+    #       )
+    #     end
+    #
+    #     it "tax has no bearing on final price" do
+    #       subject.update
+    #       line_item.reload
+    #       expect(line_item.included_tax_total).to eq(0.5)
+    #       expect(line_item.additional_tax_total).to eq(0)
+    #       expect(line_item.promo_total).to eq(-10)
+    #       expect(line_item.adjustment_total).to eq(-10)
+    #     end
+    #
+    #     it "tax linked to order" do
+    #       order.update!
+    #       order.reload
+    #       expect(order.included_tax_total).to eq(0.5)
+    #       expect(order.additional_tax_total).to eq(00)
+    #     end
+    #   end
+    #
+    #   context "tax excluded from price" do
+    #     before do
+    #       create(:adjustment,
+    #         :source => tax_rate,
+    #         :adjustable => line_item,
+    #         :order => order,
+    #         :included => false
+    #       )
+    #     end
+    #
+    #     it "tax applies to line item" do
+    #       subject.update
+    #       line_item.reload
+    #       # Taxable amount is: $20 (base) - $10 (promotion) = $10
+    #       # Tax rate is 5% (of $10).
+    #       expect(line_item.included_tax_total).to eq(0)
+    #       expect(line_item.additional_tax_total).to eq(0.5)
+    #       expect(line_item.promo_total).to eq(-10)
+    #       expect(line_item.adjustment_total).to eq(-9.5)
+    #     end
+    #
+    #     it "tax linked to order" do
+    #       order.update!
+    #       expect(order.included_tax_total).to eq(0)
+    #       expect(order.additional_tax_total).to eq(0.5)
+    #     end
+    #   end
+    # end
+    #
+    # context "promotion chooser customization" do
+    #   before do
+    #     class Spree::TestPromotionChooser
+    #       def initialize(adjustments)
+    #         raise "Custom promotion chooser"
+    #       end
+    #     end
+    #
+    #     Spree::Config.promotion_chooser_class = Spree::TestPromotionChooser
+    #   end
+    #
+    #   after do
+    #     Spree::Config.promotion_chooser_class = Spree::PromotionChooser
+    #   end
+    #
+    #   it "uses the defined promotion chooser" do
+    #     expect { subject.update }.to raise_error("Custom promotion chooser")
+    #   end
+    # end
+    #
+    # context "default promotion chooser (best promotion is always applied)" do
+    #   let(:calculator) { Calculator::FlatRate.new(:preferred_amount => 10) }
+    #
+    #   let(:source) do
+    #     Promotion::Actions::CreateItemAdjustments.create!(
+    #       calculator: calculator,
+    #       promotion: promotion,
+    #     )
+    #   end
+    #   let(:promotion) { create(:promotion) }
+    #
+    #   def create_adjustment(label, amount)
+    #     create(:adjustment, :order      => order,
+    #                         :adjustable => line_item,
+    #                         :source     => source,
+    #                         :amount     => amount,
+    #                         :finalized  => true,
+    #                         :label      => label)
+    #   end
+    #
+    #   it "should make all but the most valuable promotion adjustment ineligible, leaving non promotion adjustments alone" do
+    #     create_adjustment("Promotion A", -100)
+    #     create_adjustment("Promotion B", -200)
+    #     create_adjustment("Promotion C", -300)
+    #     create(:adjustment, :order => order,
+    #                         :adjustable => line_item,
+    #                         :source => nil,
+    #                         :amount => -500,
+    #                         :finalized => true,
+    #                         :label => "Some other credit")
+    #     line_item.adjustments.each {|a| a.update_column(:eligible, true)}
+    #
+    #     subject.update
+    #
+    #     expect(line_item.adjustments.promotion.eligible.count).to eq(1)
+    #     expect(line_item.adjustments.promotion.eligible.first.label).to eq('Promotion C')
+    #   end
+    #
+    #   it "should choose the most recent promotion adjustment when amounts are equal" do
+    #     # Using Timecop is a regression test
+    #     Timecop.freeze do
+    #       create_adjustment("Promotion A", -200)
+    #       create_adjustment("Promotion B", -200)
+    #     end
+    #     line_item.adjustments.each {|a| a.update_column(:eligible, true)}
+    #
+    #     subject.update
+    #
+    #     expect(line_item.adjustments.promotion.eligible.count).to eq(1)
+    #     expect(line_item.adjustments.promotion.eligible.first.label).to eq('Promotion B')
+    #   end
+    #
+    #   it "should choose the most recent promotion adjustment when amounts are equal" do
+    #     # Using Timecop is a regression test
+    #     Timecop.freeze do
+    #       create_adjustment("Promotion A", -200)
+    #       create_adjustment("Promotion B", -200)
+    #     end
+    #     line_item.adjustments.each {|a| a.update_column(:eligible, true)}
+    #
+    #     subject.update
+    #
+    #     expect(line_item.adjustments.promotion.eligible.count).to eq(1)
+    #     expect(line_item.adjustments.promotion.eligible.first.label).to eq('Promotion B')
+    #   end
+    #
+    #   context "when previously ineligible promotions become available" do
+    #     let(:order_promo1) { create(:promotion, :with_order_adjustment, :with_item_total_rule, weighted_order_adjustment_amount: 5, item_total_threshold_amount: 10) }
+    #     let(:order_promo2) { create(:promotion, :with_order_adjustment, :with_item_total_rule, weighted_order_adjustment_amount: 10, item_total_threshold_amount: 20) }
+    #     let(:order_promos) { [ order_promo1, order_promo2 ] }
+    #     let(:line_item_promo1) { create(:promotion, :with_line_item_adjustment, :with_item_total_rule, adjustment_rate: 2.5, item_total_threshold_amount: 10, apply_automatically: true) }
+    #     let(:line_item_promo2) { create(:promotion, :with_line_item_adjustment, :with_item_total_rule, adjustment_rate: 5, item_total_threshold_amount: 20, apply_automatically: true) }
+    #     let(:line_item_promos) { [ line_item_promo1, line_item_promo2 ] }
+    #     let(:order) { create(:order_with_line_items, line_items_count: 1) }
+    #
+    #     # Apply promotions in different sequences. Results should be the same.
+    #     promo_sequences = [
+    #       [ 0, 1 ],
+    #       [ 1, 0 ]
+    #     ]
+    #
+    #     promo_sequences.each do |promo_sequence|
+    #       it "should pick the best order-level promo according to current eligibility" do
+    #         # apply both promos to the order, even though only promo1 is eligible
+    #         order_promos[promo_sequence[0]].activate order: order
+    #         order_promos[promo_sequence[1]].activate order: order
+    #
+    #         order.reload
+    #         expect(order.all_adjustments.count).to eq(2), "Expected two adjustments (using sequence #{promo_sequence})"
+    #         expect(order.all_adjustments.eligible.count).to eq(1), "Expected one elegible adjustment (using sequence #{promo_sequence})"
+    #         expect(order.all_adjustments.eligible.first.source.promotion).to eq(order_promo1), "Expected promo1 to be used (using sequence #{promo_sequence})"
+    #
+    #         order.contents.add create(:variant, price: 10), 1
+    #         order.save
+    #
+    #         order.reload
+    #         expect(order.all_adjustments.count).to eq(2), "Expected two adjustments (using sequence #{promo_sequence})"
+    #         expect(order.all_adjustments.eligible.count).to eq(1), "Expected one elegible adjustment (using sequence #{promo_sequence})"
+    #         expect(order.all_adjustments.eligible.first.source.promotion).to eq(order_promo2), "Expected promo2 to be used (using sequence #{promo_sequence})"
+    #       end
+    #     end
+    #
+    #     promo_sequences.each do |promo_sequence|
+    #       it "should pick the best line-item-level promo according to current eligibility" do
+    #         # apply both promos to the order, even though only promo1 is eligible
+    #         line_item_promos[promo_sequence[0]].activate order: order
+    #         line_item_promos[promo_sequence[1]].activate order: order
+    #
+    #         order.reload
+    #         expect(order.all_adjustments.count).to eq(1), "Expected one adjustment (using sequence #{promo_sequence})"
+    #         expect(order.all_adjustments.eligible.count).to eq(1), "Expected one elegible adjustment (using sequence #{promo_sequence})"
+    #         # line_item_promo1 is the only one that has thus far met the order total threshold, it is the only promo which should be applied.
+    #         expect(order.all_adjustments.first.source.promotion).to eq(line_item_promo1), "Expected line_item_promo1 to be used (using sequence #{promo_sequence})"
+    #
+    #         order.contents.add create(:variant, price: 10), 1
+    #         order.save
+    #
+    #         order.reload
+    #         expect(order.all_adjustments.count).to eq(4), "Expected four adjustments (using sequence #{promo_sequence})"
+    #         expect(order.all_adjustments.eligible.count).to eq(2), "Expected two elegible adjustments (using sequence #{promo_sequence})"
+    #         order.all_adjustments.eligible.each do |adjustment|
+    #           expect(adjustment.source.promotion).to eq(line_item_promo2), "Expected line_item_promo2 to be used (using sequence #{promo_sequence})"
+    #         end
+    #       end
+    #     end
+    #   end
+    #
+    #   context "multiple adjustments and the best one is not eligible" do
+    #     let!(:promo_a) { create_adjustment("Promotion A", -100) }
+    #     let!(:promo_c) { create_adjustment("Promotion C", -300) }
+    #
+    #     before do
+    #       promo_a.update_column(:eligible, true)
+    #       promo_c.update_column(:eligible, false)
+    #     end
+    #
+    #     # regression for #3274
+    #     it "still makes the previous best eligible adjustment valid" do
+    #       subject.update
+    #       expect(line_item.adjustments.promotion.eligible.first.label).to eq('Promotion A')
+    #     end
+    #   end
+    #
+    #   it "should only leave one adjustment even if 2 have the same amount" do
+    #     create_adjustment("Promotion A", -100)
+    #     create_adjustment("Promotion B", -200)
+    #     create_adjustment("Promotion C", -200)
+    #
+    #     subject.update
+    #
+    #     expect(line_item.adjustments.promotion.eligible.count).to eq(1)
+    #     expect(line_item.adjustments.promotion.eligible.first.amount.to_i).to eq(-200)
+    #   end
+    # end
   end
 end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -507,8 +507,7 @@ describe Spree::Order, :type => :model do
       expect(Spree::PromotionHandler::FreeShipping).to receive(:new).and_return(handler = double)
       expect(handler).to receive(:activate)
 
-      expect(Spree::ItemAdjustments).to receive(:new).with(shipment).and_return(adjuster = double)
-      expect(adjuster).to receive(:update)
+      expect(Spree::AdjustableUpdater).to receive(:update).with(shipment).and_return(adjuster = double)
 
       expect(order.updater).to receive(:update_shipment_total)
       expect(order.updater).to receive(:persist_totals)


### PR DESCRIPTION
This refactor adds some new extensibility options to adjustments.

AdjustableUpdater uses POROs to update adjustments. This allows for alternate adjustment source types to hook into the update of adjustments either before or after the taxes are calculated.

Calling `Spree::ItemAdjustments.new(adjustable).update` is equalivent to calling `Spree::AdjustableUpdater.update(adjustable)`.

I am looking for feedback before I go any further. Also, I am manually calling the AdjustmentsUpdaters at this point, but in the comments below how I show how I am proposing to call them.