### PR TITLE
set default order argument to nil

### DIFF
--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -82,7 +82,7 @@ module Spree
         (expires_at.nil? || expires_at > Time.current)
     end
 
-    def activate(order:, line_item: nil, user: nil, path: nil, promotion_code: nil)
+    def activate(order: nil, line_item: nil, user: nil, path: nil, promotion_code: nil)
       return unless self.class.order_activatable?(order)
 
       payload = {


### PR DESCRIPTION
This will fix below syntax error message when starting the server

<img width="1276" alt="screen shot 2015-11-11 at 12 49 17 am" src="https://cloud.githubusercontent.com/assets/794601/11068817/212119cc-880e-11e5-83bd-ca4d3466f70a.png">

```Ruby
/Users/iqbalhasnan/.rvm/gems/ruby-2.1.5@test_shop/gems/solidus_core-1.0.2/app/models/spree/promotion.rb:84: 
syntax error, unexpected ',' (SyntaxError) 
```
