### PR TITLE
Remove deface from the project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Solidus 1.2.0 (unreleased)
+
+*   Removed deface from core
+
+    If projects or extensions rely on deface they'll need to add it to their
+    dependencies rather than counting on solidus to pull it in. Core does not
+    need to deface anything.
+
 ## Solidus 1.1.0 (unreleased)
 
 *   Address is immutable (Address#readonly? is always true)

--- a/backend/lib/spree/backend.rb
+++ b/backend/lib/spree/backend.rb
@@ -2,7 +2,6 @@ require 'rails/all'
 require 'jquery-rails'
 require 'jquery-ui-rails'
 require 'bourbon'
-require 'deface'
 require 'select2-rails'
 require 'handlebars_assets'
 

--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'awesome_nested_set', '~> 3.0.1'
   s.add_dependency 'carmen', '~> 1.0.0'
   s.add_dependency 'cancancan', '~> 1.10'
-  s.add_dependency 'deface', '~> 1.0.0'
   s.add_dependency 'ffaker', '~> 1.16'
   s.add_dependency 'font-awesome-rails', '~> 4.0'
   s.add_dependency 'friendly_id', '~> 5.0.4'

--- a/frontend/lib/spree/frontend.rb
+++ b/frontend/lib/spree/frontend.rb
@@ -1,7 +1,6 @@
 require 'rails/all'
 require 'jquery-rails'
 require 'canonical-rails'
-require 'deface'
 
 require 'spree/core'
 


### PR DESCRIPTION
Deface. It isn't required anywhere in core anymore so we don't need to
include it in our dependencies. If a project (or extension) wants to
rely on it being there, they should explicitely include it in their
gemspecs.

Addresses (poorly) #490