### PR TITLE
Add OrderCancellations#cancel_unit + #reimburse_units

### DIFF
--- a/core/app/models/spree/inventory_unit.rb
+++ b/core/app/models/spree/inventory_unit.rb
@@ -2,7 +2,7 @@ module Spree
   class InventoryUnit < Spree::Base
     PRE_SHIPMENT_STATES = %w(backordered on_hand)
     POST_SHIPMENT_STATES = %w(returned)
-    CANCELABLE_STATES = ['on_hand', 'backordered']
+    CANCELABLE_STATES = ['on_hand', 'backordered', 'shipped']
 
     belongs_to :variant, class_name: "Spree::Variant", inverse_of: :inventory_units
     belongs_to :order, class_name: "Spree::Order", inverse_of: :inventory_units

--- a/core/app/models/spree/reimbursement.rb
+++ b/core/app/models/spree/reimbursement.rb
@@ -136,6 +136,16 @@ module Spree
       return_items.all?(&:exchange_processed?)
     end
 
+    # Accepts all return items, saves the reimbursement, and performs the reimbursement
+    #
+    # @api public
+    # @return [void]
+    def return_all
+      return_items.each(&:accept!)
+      save!
+      perform!
+    end
+
     private
 
     def generate_number

--- a/core/app/models/spree/unit_cancel.rb
+++ b/core/app/models/spree/unit_cancel.rb
@@ -3,6 +3,8 @@
 # This class should encapsulate logic related to canceling inventory after order complete
 class Spree::UnitCancel < Spree::Base
   SHORT_SHIP = 'Short Ship'
+  DEFAULT_REASON = 'Cancel'
+
   belongs_to :inventory_unit
   has_one :adjustment, as: :source, dependent: :destroy
 


### PR DESCRIPTION
* Ability to cancel a unit after it has been marked shipped
* Easy way to reimburse canceled units

We currently have a need to cancel an inventory unit and reimburse it after it has been marked as shipped. This is different than a vanilla return since it is for a case when you have shipped the unit but for any reason you do not want it to be shipped any longer (so it's not being returned). We also have a need  to easily reimburse these canceled units, so I am piggy-backing off the current Reimbursement logic which already does all of the hard stuff for us.