### PR TITLE
Also backfill spree_line_items pre_tax_amount for impending null constraint.

### DIFF
--- a/core/db/migrate/20150609093816_increase_scale_on_pre_tax_amounts.rb
+++ b/core/db/migrate/20150609093816_increase_scale_on_pre_tax_amounts.rb
@@ -10,6 +10,16 @@ class IncreaseScaleOnPreTaxAmounts < ActiveRecord::Migration
       WHERE pre_tax_amount IS NULL;
     SQL
 
+    # set pre_tax_amount on line_items to discounted_amount - included_tax_total
+    # so that the null: false option on the line_item pre_tax_amount doesn't generate
+    # errors.
+    #
+    execute(<<-SQL)
+      UPDATE spree_line_items
+      SET pre_tax_amount = (price * quantity + promo_total) - included_tax_total
+      WHERE pre_tax_amount IS NULL;
+    SQL
+
     change_column :spree_line_items, :pre_tax_amount, :decimal, precision: 12, scale: 4, default: 0.0, null: false
     change_column :spree_shipments, :pre_tax_amount, :decimal, precision: 12, scale: 4, default: 0.0, null: false
   end


### PR DESCRIPTION
Line items might also have a null pre_tax_amount, so we should backfill
those as well before trying to make that column not allow null.