### PR TITLE
Allow stock transfer permissions to view stock transfers to/from from viewable stock locations.

### DIFF
--- a/backend/app/controllers/spree/admin/stock_transfers_controller.rb
+++ b/backend/app/controllers/spree/admin/stock_transfers_controller.rb
@@ -7,7 +7,7 @@ module Spree
         { translation_key: :name, attr_name: :name }
       ]
 
-      before_filter :load_transferable_stock_locations, only: :index
+      before_filter :load_viewable_stock_locations, only: :index
       before_filter :load_variant_display_attributes, only: [:receive, :edit, :show, :tracking_info]
       before_filter :load_source_stock_locations, only: :new
       before_filter :load_destination_stock_locations, only: :edit
@@ -100,16 +100,16 @@ module Spree
         authorize! :create, duplicate
       end
 
-      def load_transferable_stock_locations
-        @stock_locations = accessible_source_stock_locations | accessible_destination_stock_locations
+      def load_viewable_stock_locations
+        @stock_locations = Spree::StockLocation.accessible_by(current_ability, :read)
       end
 
       def load_source_stock_locations
-        @source_stock_locations = accessible_source_stock_locations
+        @source_stock_locations ||= Spree::StockLocation.accessible_by(current_ability, :transfer_from)
       end
 
       def load_destination_stock_locations
-        @destination_stock_locations = accessible_destination_stock_locations.where.not(id: @stock_transfer.source_location_id)
+        @destination_stock_locations ||= Spree::StockLocation.accessible_by(current_ability, :transfer_to).where.not(id: @stock_transfer.source_location_id)
       end
 
       def load_variant_display_attributes
@@ -141,14 +141,6 @@ module Spree
         @stock_movements = @stock_transfer.transfer_items.received.map do |transfer_item|
           @stock_transfer.destination_location.move(transfer_item.variant, transfer_item.received_quantity, @stock_transfer)
         end
-      end
-
-      def accessible_source_stock_locations
-        @source_locations ||= Spree::StockLocation.accessible_by(current_ability, :transfer_from)
-      end
-
-      def accessible_destination_stock_locations
-        @destination_locations ||= Spree::StockLocation.accessible_by(current_ability, :transfer_to)
       end
     end
   end

--- a/backend/spec/controllers/spree/admin/stock_transfers_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/stock_transfers_controller_spec.rb
@@ -31,8 +31,8 @@ module Spree
 
         before do
           ability.cannot :manage, Spree::StockLocation
-          ability.can :transfer_from, Spree::StockLocation, id: [warehouse.id]
-          ability.can :transfer_to, Spree::StockLocation, id: [ny_store.id, la_store.id]
+          ability.can :display, Spree::StockLocation, id: [warehouse.id]
+          ability.can :display, Spree::StockLocation, id: [ny_store.id, la_store.id]
 
           allow_any_instance_of(Spree::Admin::BaseController).to receive(:spree_current_user).and_return(user)
           allow_any_instance_of(Spree::Admin::BaseController).to receive(:current_ability).and_return(ability)


### PR DESCRIPTION
    When given the stock transfer display or stock transfer management
    permissions, there is a dropdown in admin/stock locations to filter by
    stock locations, which was filled by the ability to transfer_to or
    transfer_from a stock location. This change allows people with the stock
    transfer permission sets to use that feature of stock transfers without
    having to also have the ability to transfer_to or transfer_from a stock
    location.