### PR TITLE
Allow nesting of OrderMutex

### DIFF
--- a/api/spec/controllers/spree/api/base_controller_spec.rb
+++ b/api/spec/controllers/spree/api/base_controller_spec.rb
@@ -158,9 +158,7 @@ describe Spree::Api::BaseController, :type => :controller do
     end
 
     context 'with an existing lock' do
-      around do |example|
-        Spree::OrderMutex.with_lock!(order) { example.run }
-      end
+      before { Spree::OrderMutex.create!(order: order) }
 
       it 'returns a 409 conflict' do
         api_get :index, order_token: order.guest_token, order_id: order.number

--- a/core/spec/models/spree/order_mutex_spec.rb
+++ b/core/spec/models/spree/order_mutex_spec.rb
@@ -37,7 +37,7 @@ describe Spree::OrderMutex do
   end
 
   context "when another thread requests lock on already locked order" do
-    it "throws exception" do
+    it "raises a LockFailed error" do
       Thread.new do
         Spree::OrderMutex.with_lock!(order) {|o| sleep(3) }
       end
@@ -47,7 +47,7 @@ describe Spree::OrderMutex do
 
       expect {
         expect { |b|
-          Spree::OrderMutex.with_lock!(order)
+          Spree::OrderMutex.with_lock!(order, &b)
         }.not_to yield_control
       }.to raise_error(Spree::OrderMutex::LockFailed)
     end


### PR DESCRIPTION
Currently, if you have a method that acquires an OrderMutex lock, which calls another method that attempts to lock the order, you will get a LockFailed error.

It would be ideal if we could lock the order, and if further down the chain we attempt to do it again, it would know that we have already acquired it and to just yield to the block without erroring.

This is my attempt at making it work. The spec is a little hairy, so if anyone has tips on testing multi-threaded stuff, let me know!