### PR TITLE
[v1.1] Bump deface requirement to 1.0.2

### DIFF
--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'awesome_nested_set', '~> 3.0.1'
   s.add_dependency 'carmen', '~> 1.0.0'
   s.add_dependency 'cancancan', '~> 1.10'
-  s.add_dependency 'deface', '~> 1.0.0'
+  s.add_dependency 'deface', '~> 1.0.2'
   s.add_dependency 'ffaker', '~> 1.16'
   s.add_dependency 'font-awesome-rails', '~> 4.0'
   s.add_dependency 'friendly_id', '~> 5.0.4'


### PR DESCRIPTION
1.0.2 is required for rails 4.2 compatability.

N.B. This PR is to the 1.1 branch. We've removed deface from master, so this is unneeded.