### PR TITLE
Remove Order#fully_discounted?

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -588,11 +588,6 @@ module Spree
       guest_token
     end
 
-    def fully_discounted?
-      adjustment_total + line_items.map(&:final_amount).sum == 0.0
-    end
-    alias_method :fully_discounted, :fully_discounted?
-
     def unreturned_exchange?
       # created_at - 1 is a hack to ensure that this doesn't blow up on MySQL,
       # records loaded from the DB on MySQL will have a precision of 1 second,

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -948,47 +948,6 @@ describe Spree::Order, :type => :model do
     end
   end
 
-  describe "#fully_discounted?" do
-    let(:line_item) { Spree::LineItem.new(price: 10, quantity: 1) }
-    let(:shipment) { Spree::Shipment.new(cost: 10) }
-    let(:payment) { Spree::Payment.new(amount: 10) }
-
-    before do
-      allow(order).to receive(:line_items) { [line_item] }
-      allow(order).to receive(:shipments) { [shipment] }
-      allow(order).to receive(:payments) { [payment] }
-    end
-
-    context "the order had no inventory-related cost" do
-      before do
-        # discount the cost of the line items
-        allow(order).to receive(:adjustment_total) { -5 }
-        allow(line_item).to receive(:adjustment_total) { -5 }
-
-        # but leave some shipment payment amount
-        allow(shipment).to receive(:adjustment_total) { 0 }
-      end
-
-      it { expect(order.fully_discounted?).to eq true }
-
-    end
-
-    context "the order had inventory-related cost" do
-      before do
-        # partially discount the cost of the line item
-        allow(order).to receive(:adjustment_total) { 0 }
-        allow(line_item).to receive(:adjustment_total) { -5 }
-
-        # and partially discount the cost of the shipment so the total
-        # discount matches the item total for test completeness
-        allow(shipment).to receive(:adjustment_total) { -5 }
-      end
-
-      it { expect(order.fully_discounted?).to eq false }
-
-    end
-  end
-
   context "store credit" do
     shared_examples "check total store credit from payments" do
       context "with valid payments" do


### PR DESCRIPTION
This method is unused anywhere else in Solidus itself, and should be implemented at the store level. Additionally, the current implementation is not correct.

Related discussion: https://github.com/solidusio/solidus/issues/481