### PR TITLE
Deprecate Order#fully_discounted?

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -589,6 +589,7 @@ module Spree
     end
 
     def fully_discounted?
+      ActiveSupport::Deprecation.warn("Spree::Order#fully_discounted? is deprecated.", caller)
       adjustment_total + line_items.map(&:final_amount).sum == 0.0
     end
     alias_method :fully_discounted, :fully_discounted?


### PR DESCRIPTION
This method is unused anywhere else in Solidus itself, and should be implemented at the store level. Additionally, the current implementation is not correct.

Related discussion: #481