### PR TITLE
Remove HABTMs from property prototypes

### DIFF
--- a/core/app/models/spree/property.rb
+++ b/core/app/models/spree/property.rb
@@ -1,6 +1,7 @@
 module Spree
   class Property < Spree::Base
-    has_and_belongs_to_many :prototypes, join_table: 'spree_properties_prototypes'
+    has_many :property_prototypes
+    has_many :prototypes, through: :property_prototypes
 
     has_many :product_properties, dependent: :delete_all, inverse_of: :property
     has_many :products, through: :product_properties

--- a/core/app/models/spree/property_prototype.rb
+++ b/core/app/models/spree/property_prototype.rb
@@ -1,0 +1,6 @@
+module Spree
+  class PropertyPrototype < Spree::Base
+    belongs_to :prototype
+    belongs_to :property
+  end
+end

--- a/core/app/models/spree/prototype.rb
+++ b/core/app/models/spree/prototype.rb
@@ -1,7 +1,9 @@
 module Spree
   class Prototype < Spree::Base
-    has_and_belongs_to_many :properties, join_table: :spree_properties_prototypes
     has_and_belongs_to_many :option_types, join_table: :spree_option_types_prototypes
+
+    has_many :property_prototypes
+    has_many :properties, through: :property_prototypes
 
     has_many :prototype_taxons, dependent: :destroy
     has_many :taxons, through: :prototype_taxons

--- a/core/db/migrate/20151117063249_convert_habtm_to_hmt_for_properties_prototypes.rb
+++ b/core/db/migrate/20151117063249_convert_habtm_to_hmt_for_properties_prototypes.rb
@@ -1,0 +1,17 @@
+class ConvertHabtmToHmtForPropertiesPrototypes < ActiveRecord::Migration
+  def up
+    add_column :spree_properties_prototypes, :id, :primary_key
+    add_column :spree_properties_prototypes, :created_at, :datetime
+    add_column :spree_properties_prototypes, :updated_at, :datetime
+
+    rename_table :spree_properties_prototypes, :spree_property_prototypes
+  end
+
+  def down
+    rename_table :spree_property_prototypes, :spree_properties_prototypes
+
+    remove_column :spree_properties_prototypes, :id, :primary_key
+    remove_column :spree_properties_prototypes, :created_at, :datetime
+    remove_column :spree_properties_prototypes, :updated_at, :datetime
+  end
+end


### PR DESCRIPTION
We're working to remove HABTM relationships from the codebase for a
variety of reasons, please see #289

This is one PR in a series of me pulling apart and splitting up @BenMorganIO's work from #289