### PR TITLE
Improvements to capybara usage

### DIFF
--- a/backend/spec/features/admin/configuration/tax_rates_spec.rb
+++ b/backend/spec/features/admin/configuration/tax_rates_spec.rb
@@ -13,10 +13,9 @@ describe "Tax Rates", :type => :feature do
   # Regression test for #535
   it "can see a tax rate in the list if the tax category has been deleted" do
     tax_rate.tax_category.update_column(:deleted_at, Time.now)
-    expect { click_link "Tax Rates" }.not_to raise_error
-    within(:xpath, all("table tbody td")[2].path) do
-      expect(page).to have_content("N/A")
-    end
+    click_link "Tax Rates"
+
+    expect(find("table tbody td:nth-child(3)")).to have_content('N/A')
   end
 
   # Regression test for #1422

--- a/backend/spec/features/admin/products/option_types_spec.rb
+++ b/backend/spec/features/admin/products/option_types_spec.rb
@@ -60,12 +60,12 @@ describe "Option Types", :type => :feature do
     click_link "Option Types"
     within('table#listing_option_types') { click_icon :edit }
     expect(page).to have_content("Editing Option Type")
-    expect(all("tbody#option_values tr").count).to eq(1)
+    expect(page).to have_css("tbody#option_values tr", count: 1)
     within("tbody#option_values") do
       find('.spree_remove_fields').click
     end
     # Assert that the field is hidden automatically
-    expect(all("tbody#option_values tr").select(&:visible?).count).to eq(0)
+    expect(page).to have_no_css("tbody#option_values tr")
 
     # Then assert that on a page refresh that it's still not visible
     visit page.current_url
@@ -73,7 +73,7 @@ describe "Option Types", :type => :feature do
     # Sometimes the page doesn't load before the all check is done
     # lazily finding the element gives the page 10 seconds
     expect(page).to have_css("tbody#option_values")
-    all("tbody#option_values tr input").all? { |input| input.value.blank? }
+    all("tbody#option_values tr input", count: 2).all? { |input| input.value.blank? }
   end
   
   # Regression test for #3204
@@ -82,33 +82,25 @@ describe "Option Types", :type => :feature do
     click_link "Option Types"
     within('table#listing_option_types') { click_icon :edit }
 
-    wait_for_ajax
-    page.find("tbody#option_values", :visible => true)
-
-    expect(all("tbody#option_values tr").select(&:visible?).count).to eq(1)
+    expect(page).to have_css("tbody#option_values tr", count: 1)
 
     # Add a new option type
     click_link "Add Option Value"
-    expect(all("tbody#option_values tr").select(&:visible?).count).to eq(2)
+    expect(page).to have_css("tbody#option_values tr", count: 2)
 
     # Remove default option type
     within("tbody#option_values") do
       find('.fa-trash').click
     end
-    # Check that there was no HTTP request
-    expect(all("div#progress[style]").count).to eq(0)
     # Assert that the field is hidden automatically
-    expect(all("tbody#option_values tr").select(&:visible?).count).to eq(1)
+    expect(page).to have_css("tbody#option_values tr", count: 1)
 
     # Remove added option type
     within("tbody#option_values") do
       find('.fa-trash').click
     end
-    # Check that there was no HTTP request
-    expect(all("div#progress[style]").count).to eq(0)
     # Assert that the field is hidden automatically
-    expect(all("tbody#option_values tr").select(&:visible?).count).to eq(0)
-
+    expect(page).to have_css("tbody#option_values tr", count: 0)
   end
 
 end

--- a/backend/spec/features/admin/stock_transfer_spec.rb
+++ b/backend/spec/features/admin/stock_transfer_spec.rb
@@ -77,7 +77,7 @@ describe 'Stock Transfers', :type => :feature, :js => true do
         visit spree.tracking_info_admin_stock_transfer_path(stock_transfer)
         click_link 'ship'
 
-        first('#confirm-ship-link', visible: false).click
+        find('#confirm-ship-link', visible: false).click
         expect(current_path).to eq spree.admin_stock_transfers_path
         expect(stock_transfer.reload.shipped_at).to_not be_nil
       end
@@ -95,7 +95,7 @@ describe 'Stock Transfers', :type => :feature, :js => true do
 
         click_link 'ship'
 
-        first('#confirm-ship-link', visible: false).click
+        find('#confirm-ship-link', visible: false).click
         expect(current_path).to eq spree.tracking_info_admin_stock_transfer_path(stock_transfer)
         expect(stock_transfer.reload.shipped_at).to be_nil
       end

--- a/backend/spec/features/admin/store_credits_spec.rb
+++ b/backend/spec/features/admin/store_credits_spec.rb
@@ -24,7 +24,7 @@ describe "Store credits admin" do
       expect(page.current_path).to eq spree.admin_user_store_credits_path(store_credit.user)
 
       store_credit_table = page.find(".twelve.columns > table")
-      expect(store_credit_table.all('tr').count).to eq 1
+      expect(store_credit_table).to have_css('tr', count: 1)
       expect(store_credit_table).to have_content(Spree::Money.new(store_credit.amount).to_s)
       expect(store_credit_table).to have_content(Spree::Money.new(store_credit.amount_used).to_s)
       expect(store_credit_table).to have_content(store_credit.category_name)
@@ -49,7 +49,7 @@ describe "Store credits admin" do
 
       expect(page.current_path).to eq spree.admin_user_store_credits_path(store_credit.user)
       store_credit_table = page.find(".twelve.columns > table")
-      expect(store_credit_table.all('tr').count).to eq 2
+      expect(store_credit_table).to have_css('tr', count: 2)
       expect(Spree::StoreCredit.count).to eq 2
     end
   end

--- a/core/lib/spree/testing_support/capybara_ext.rb
+++ b/core/lib/spree/testing_support/capybara_ext.rb
@@ -13,19 +13,11 @@ module CapybaraExt
   end
 
   def within_row(num, &block)
-    if RSpec.current_example.metadata[:js]
-      within("table.index tbody tr:nth-child(#{num})", &block)
-    else
-      within(:xpath, all("table.index tbody tr")[num-1].path, &block)
-    end
+    within("table.index tbody tr:nth-of-type(#{num})", &block)
   end
 
   def column_text(num)
-    if RSpec.current_example.metadata[:js]
-      find("td:nth-child(#{num})").text
-    else
-      all("td")[num-1].text
-    end
+    find("td:nth-of-type(#{num})").text
   end
 
   def fill_in_quantity(table_column, selector, quantity)

--- a/core/lib/spree/testing_support/capybara_ext.rb
+++ b/core/lib/spree/testing_support/capybara_ext.rb
@@ -43,18 +43,16 @@ module CapybaraExt
   end
 
   def select2_search_without_selection(value, options)
-    page.execute_script "$('#{options[:from]}').select2('open');"
-    page.execute_script "$('input.select2-input').val('#{value}').trigger('keyup-change');"
-  end
-
-  def targetted_select2_search(value, options)
     find("#{options[:from]}:not(.select2-container-disabled)").click
 
     within_entire_page do
       select2input = first("#select2-drop input.select2-input") || find("input.select2-input")
       select2input.set(value)
     end
+  end
 
+  def targetted_select2_search(value, options)
+    select2_search_without_selection(value, from: options[:from])
     select_select2_result(value)
   end
 

--- a/core/lib/spree/testing_support/capybara_ext.rb
+++ b/core/lib/spree/testing_support/capybara_ext.rb
@@ -46,8 +46,7 @@ module CapybaraExt
     find("#{options[:from]}:not(.select2-container-disabled)").click
 
     within_entire_page do
-      select2input = first("#select2-drop input.select2-input") || find("input.select2-input")
-      select2input.set(value)
+      find("input.select2-input.select2-focused").set(value)
     end
   end
 


### PR DESCRIPTION
Replace `execute_script`-based `select2_search_without_selection` with proper capybara usage.

Combine the js and non-js versions of `within_row` and `column_text`.

Switch to blocking capybara finders (like `find`) wherever I found the non-blocking versions (like `all` and `first`). Most of these occurred after a proper blocking find or were in a non-js test (where everything is synchronous), but I believe it's still best to change them to the blocking versions everywhere.
