### PR TITLE
Refactor line_item.rb

### DIFF
--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -13,8 +13,7 @@ module Spree
     has_many :actions, through: :line_item_actions
 
     before_validation :invalid_quantity_check
-    before_validation :copy_price
-    before_validation :copy_tax_category
+    before_validation :copy_variant_attributes
 
     validates :variant, presence: true
     validates :quantity, numericality: {
@@ -127,22 +126,14 @@ module Spree
       self.quantity = 0 if quantity.nil? || quantity < 0
     end
 
-    # Sets this line item's price, cost price, and currency from this line
-    # item's variant if they are nil and a variant is present.
-    def copy_price
-      if variant
-        self.price = variant.price if price.nil?
-        self.cost_price = variant.cost_price if cost_price.nil?
-        self.currency = variant.currency if currency.nil?
-      end
-    end
-
-    # Sets this line item's tax category from this line item's variant if a
-    # variant is present.
-    def copy_tax_category
-      if variant
-        self.tax_category = variant.tax_category
-      end
+    # Sets this line item's  tax category, price, cost price, and currency from
+    # its variant if they are nil and a variant is present.
+    def copy_variant_attributes
+      return unless variant
+      self.tax_category ||= variant.tax_category
+      self.currency ||= variant.currency
+      self.cost_price ||= variant.cost_price
+      self.price ||= variant.price
     end
 
     def update_inventory

--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -12,7 +12,7 @@ module Spree
     has_many :line_item_actions, dependent: :destroy
     has_many :actions, through: :line_item_actions
 
-    before_validation :invalid_quantity_check
+    before_validation :normalize_quantity
     before_validation :copy_variant_attributes
 
     validates :variant, presence: true
@@ -121,8 +121,9 @@ module Spree
     end
 
     private
+
     # Sets the quantity to zero if it is nil or less than zero.
-    def invalid_quantity_check
+    def normalize_quantity
       self.quantity = 0 if quantity.nil? || quantity < 0
     end
 

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -128,6 +128,7 @@ describe Spree::LineItem, :type => :model do
 
   describe "#discounted_money" do
     it "should return a money object with the discounted amount" do
+      expect(line_item.discounted_amount).to eq(10.00)
       expect(line_item.discounted_money.to_s).to eq "$10.00"
     end
   end

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -89,26 +89,31 @@ describe Spree::LineItem, :type => :model do
     end
   end
 
-  # Test for https://github.com/spree/spree/issues/3391
-  context '#copy_price' do
-    it "copies over a variant's prices" do
-      line_item.price = nil
-      line_item.cost_price = nil
-      line_item.currency = nil
-      line_item.copy_price
-      variant = line_item.variant
-      expect(line_item.price).to eq(variant.price)
-      expect(line_item.cost_price).to eq(variant.cost_price)
-      expect(line_item.currency).to eq(variant.currency)
-    end
-  end
+  describe 'line item creation' do
+    let(:variant) { create :variant }
 
-  # Test for https://github.com/spree/spree/issues/3481
-  context '#copy_tax_category' do
-    it "copies over a variant's tax category" do
-      line_item.tax_category = nil
-      line_item.copy_tax_category
-      expect(line_item.tax_category).to eq(line_item.variant.tax_category)
+    subject(:line_item) { Spree::LineItem.new(variant: variant, order: order) }
+
+    # Tests for https://github.com/spree/spree/issues/3391
+    context 'before validation' do
+      before { line_item.valid? }
+
+      it 'copies the variants price' do
+        expect(line_item.price).to eq(variant.price)
+      end
+
+      it 'copies the variants cost_price' do
+        expect(line_item.cost_price).to eq(variant.cost_price)
+      end
+
+      it 'copies the variants currency' do
+        expect(line_item.currency).to eq(variant.currency)
+      end
+
+      # Test for https://github.com/spree/spree/issues/3481
+      it 'copies the variants tax category' do
+        expect(line_item.tax_category).to eq(line_item.variant.tax_category)
+      end
     end
   end
 


### PR DESCRIPTION
This PR was supposed to be preparation for the VAT stuff, but turned out to be more of a housekeeping exercise: Some naming improvements and a little bit of code style, plus different tests for creating line items. 

In order to improve readability of the file, I sorted the code by what it does (associations, callbacks, methods, private methods). 

Nevertheless, I do think this is an improvement, so I'm keeping the PR open. 