### PR TITLE
Switch to capybara's :smart matching mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@
     dependencies rather than counting on solidus to pull it in. Core does not
     need to deface anything.
 
+*   `testing_support/capybara_ext.rb` no longer changes capybara's matching
+    mode to `:prefer_exact`, and instead uses capybara's default, `:smart`.
+
+    You can restore the old behaviour (not recommended) by adding
+    `Capybara.match = :prefer_exact` to your `spec_helper.rb`.
+
+    More information can be found in [capybara's README](https://github.com/jnicklas/capybara#matching)
+
 ## Solidus 1.1.0 (unreleased)
 
 *   Address is immutable (Address#readonly? is always true)

--- a/backend/app/views/spree/admin/shipping_methods/_form.html.erb
+++ b/backend/app/views/spree/admin/shipping_methods/_form.html.erb
@@ -46,7 +46,7 @@
   <div data-hook="admin_shipping_method_form_availability_fields" class="alpha six columns">
     <fieldset class="categories no-border-bottom">
       <legend align="center"><%= Spree.t(:shipping_categories) %></legend>
-          <%= f.field_container :categories do %>
+      <%= f.field_container :categories do %>
         <% Spree::ShippingCategory.all.each do |category| %>
           <%= label_tag do %>
             <%= check_box_tag('shipping_method[shipping_categories][]', category.id, @shipping_method.shipping_categories.include?(category)) %>
@@ -84,7 +84,7 @@
   <div class="alpha six columns">
     <fieldset class="tax_categories no-border-bottom">
       <legend align="center"><%= Spree.t(:tax_category) %></legend>
-        <%= f.field_container :categories do %>
+        <%= f.field_container :tax_categories do %>
           <%= f.select :tax_category_id, @tax_categories.map { |tc| [tc.name, tc.id] }, {include_blank: true}, class: "select2 fullwidth" %>
           <%= error_message_on :shipping_method, :tax_category_id %>
         <% end %>

--- a/backend/spec/features/admin/configuration/states_spec.rb
+++ b/backend/spec/features/admin/configuration/states_spec.rb
@@ -46,7 +46,7 @@ describe "States", :type => :feature do
       click_button "Create"
       expect(page).to have_content("successfully created!")
       expect(page).to have_content("Pest megye")
-      expect(find("#s2id_country span").text).to eq("Hungary")
+      expect(find("#s2id_country")).to have_content("Hungary")
     end
 
     it "should show validation errors", :js => true do

--- a/backend/spec/features/admin/orders/cancelling_and_resuming_spec.rb
+++ b/backend/spec/features/admin/orders/cancelling_and_resuming_spec.rb
@@ -24,9 +24,7 @@ describe "Cancelling + Resuming", :type => :feature do
     visit spree.edit_admin_order_path(order.number)
     click_button 'cancel'
     within(".additional-info") do
-      within(".state") do
-        expect(page).to have_content("canceled")
-      end
+      expect(find('dt#order_status + dd')).to have_content("canceled")
     end
   end
 
@@ -39,9 +37,7 @@ describe "Cancelling + Resuming", :type => :feature do
       visit spree.edit_admin_order_path(order.number)
       click_button 'resume'
       within(".additional-info") do
-        within(".state") do
-          expect(page).to have_content("resumed")
-        end
+        expect(find('dt#order_status + dd')).to have_content("resumed")
       end
     end
   end

--- a/backend/spec/features/admin/orders/customer_details_spec.rb
+++ b/backend/spec/features/admin/orders/customer_details_spec.rb
@@ -6,7 +6,7 @@ describe "Customer Details", type: :feature, js: true do
   let(:country) { create(:country, name: "Kangaland") }
   let(:state) { create(:state, name: "Alabama", country: country) }
   let!(:shipping_method) { create(:shipping_method, display_on: "front_end") }
-  let!(:order) { create(:order, state: 'complete', completed_at: "2011-02-01 12:36:15") }
+  let!(:order) { create(:order, ship_address: ship_address, bill_address: bill_address, state: 'complete', completed_at: "2011-02-01 12:36:15") }
   let!(:product) { create(:product_in_stock) }
 
   # We need a unique name that will appear for the customer dropdown
@@ -69,6 +69,7 @@ describe "Customer Details", type: :feature, js: true do
         end
 
         click_button "Update"
+        expect(page).to have_content "Customer Details Updated"
         click_link "Customer Details"
         expect(find_field("order_bill_address_attributes_state_name").value).to eq("Piaui")
       end

--- a/backend/spec/features/admin/orders/customer_details_spec.rb
+++ b/backend/spec/features/admin/orders/customer_details_spec.rb
@@ -88,7 +88,7 @@ describe "Customer Details", type: :feature, js: true do
       # Regression test for #2950 + #2433
       # This act should transition the state of the order as far as it will go too
       within("#order_tab_summary") do
-        expect(find(".state").text).to eq("COMPLETE")
+        expect(find("dt#order_status + dd")).to have_content("COMPLETE")
       end
     end
 

--- a/backend/spec/features/admin/orders/listing_spec.rb
+++ b/backend/spec/features/admin/orders/listing_spec.rb
@@ -85,7 +85,7 @@ describe "Orders Listing", type: :feature, js: true do
         click_on 'Filter'
         uncheck "q_completed_at_not_null"
         click_on 'Filter Results'
-        within(".pagination") do
+        within(".pagination", match: :first) do
           click_link "2"
         end
         expect(page).to have_content("incomplete@example.com")

--- a/backend/spec/features/admin/orders/log_entries_spec.rb
+++ b/backend/spec/features/admin/orders/log_entries_spec.rb
@@ -21,7 +21,7 @@ describe "Log entries", :type => :feature do
 
     it "shows a successful attempt" do
       visit spree.admin_order_payments_path(payment.order)
-      find("#payment_#{payment.id} a").click
+      click_on payment.number
       click_link "Logs"
       within("#listing_log_entries") do
         expect(page).to have_content("Transaction successful")
@@ -45,7 +45,7 @@ describe "Log entries", :type => :feature do
 
     it "shows a failed attempt" do
       visit spree.admin_order_payments_path(payment.order)
-      find("#payment_#{payment.id} a").click
+      click_on payment.number
       click_link "Logs"
       within("#listing_log_entries") do
         expect(page).to have_content("Transaction failed")

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -424,26 +424,23 @@ describe "Order Details", type: :feature, js: true do
             product.master.stock_items.last.update_column(:count_on_hand, 0)
             expect(@shipment2.reload.backordered?).to eq(false)
 
-
             within_row(1) { click_icon 'arrows-h' }
             targetted_select2 @shipment2.number, from: '#s2id_item_stock_location'
             fill_in 'item_quantity', with: 1
             click_icon :ok
 
-            wait_for_ajax
+            expect(page).to have_content("1 x backordered")
 
-            expect(@shipment2.reload.backordered?).to eq(true)
+            within('.stock-contents', text: "1 x on hand") do
+              within_row(1) { click_icon 'arrows-h' }
+              targetted_select2 @shipment2.number, from: '#s2id_item_stock_location'
+              fill_in 'item_quantity', with: 1
+              click_icon :ok
+            end
 
-            within_row(1) { click_icon 'arrows-h' }
-            targetted_select2 @shipment2.number, from: '#s2id_item_stock_location'
-            fill_in 'item_quantity', with: 1
-            click_icon :ok
-
-            wait_for_ajax
-
-            expect(order.shipments.count).to eq(1)
-            expect(order.shipments.last.inventory_units_for(product.master).count).to eq(2)
-            expect(@shipment2.reload.backordered?).to eq(true)
+            # Empty shipment should be removed
+            expect(page).to have_css('.stock-contents', count: 1)
+            expect(page).to have_content("2 x backordered")
           end
         end
       end

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -373,12 +373,12 @@ describe "Order Details", type: :feature, js: true do
             fill_in 'item_quantity', with: 1
             click_icon :ok
 
-            wait_for_ajax
-
-            within_row(1) { click_icon 'arrows-h' }
-            targetted_select2 @shipment2.number, from: '#s2id_item_stock_location'
-            fill_in 'item_quantity', with: 200
-            click_icon :ok
+            within(all('.stock-contents', count: 2).first) do
+              within_row(1) { click_icon 'arrows-h' }
+              targetted_select2 @shipment2.number, from: '#s2id_item_stock_location'
+              fill_in 'item_quantity', with: 200
+              click_icon :ok
+            end
 
             wait_for_ajax
 

--- a/backend/spec/features/admin/orders/payments_spec.rb
+++ b/backend/spec/features/admin/orders/payments_spec.rb
@@ -181,7 +181,7 @@ describe 'Payments', :type => :feature do
 
       it "is able to create a new credit card payment with valid information", :js => true do
         fill_in "Card Number", :with => "4111 1111 1111 1111"
-        fill_in "Name", :with => "Test User"
+        fill_in "Name *", :with => "Test User"
         fill_in "Expiration", :with => "09 / #{Time.now.year + 1}"
         fill_in "Card Code", :with => "007"
         # Regression test for #4277

--- a/backend/spec/features/admin/products/edit/images_spec.rb
+++ b/backend/spec/features/admin/products/edit/images_spec.rb
@@ -27,7 +27,9 @@ describe "Product Images", :type => :feature do
       click_button "Update"
       expect(page).to have_content("successfully created!")
 
-      click_icon(:edit)
+      within_row(1) do
+        click_icon(:edit)
+      end
       fill_in "image_alt", :with => "ruby on rails t-shirt"
       click_button "Update"
       expect(page).to have_content("successfully updated!")

--- a/backend/spec/features/admin/products/option_types_spec.rb
+++ b/backend/spec/features/admin/products/option_types_spec.rb
@@ -46,7 +46,9 @@ describe "Option Types", :type => :feature do
       create(:option_type, :name => "tshirt-color", :presentation => "Color")
       create(:option_type, :name => "tshirt-size", :presentation => "Size")
       click_link "Option Types"
-      within('table#listing_option_types') { click_link "Edit" }
+      within('table#listing_option_types') do
+        find('tr', text: 'Size').click_link "Edit"
+      end
       fill_in "option_type_name", :with => "foo-size 99"
       click_button "Update"
       expect(page).to have_content("successfully updated!")
@@ -90,7 +92,9 @@ describe "Option Types", :type => :feature do
 
     # Remove default option type
     within("tbody#option_values") do
-      find('.fa-trash').click
+      within_row(1) do
+        find('.fa-trash').click
+      end
     end
     # Assert that the field is hidden automatically
     expect(page).to have_css("tbody#option_values tr", count: 1)

--- a/backend/spec/features/admin/products/products_spec.rb
+++ b/backend/spec/features/admin/products/products_spec.rb
@@ -327,7 +327,7 @@ describe "Products", :type => :feature do
         # inspect the first one.
         expect(page).to have_css('#product_properties .product_property', count: 2)
         within('#product_properties .product_property:nth-child(1)') do
-          expect(find('input[type=text]').value).to eq('baseball_cap_color')
+          expect(find('input[type=text]', match: :first).value).to eq('baseball_cap_color')
         end
       end
     end

--- a/backend/spec/features/admin/products/stock_management_spec.rb
+++ b/backend/spec/features/admin/products/stock_management_spec.rb
@@ -28,7 +28,7 @@ describe "Stock Management", :type => :feature do
         @product = create(:product, name: 'apache baseball cap', price: 10)
         v = @product.variants.create!(sku: 'FOOBAR')
         Spree::StockLocation.destroy_all
-        click_link "Products"
+        click_link "Back To Products List"
         within_row(1) do
           click_icon :edit
         end

--- a/backend/spec/features/admin/promotion_adjustments_spec.rb
+++ b/backend/spec/features/admin/promotion_adjustments_spec.rb
@@ -136,7 +136,7 @@ describe "Promotion Adjustments", :type => :feature do
       expect(first_action_calculator.preferred_percent).to eq(10)
     end
 
-    xit "should allow an admin to create an automatic promotion with free shipping (no code)" do
+    it "should allow an admin to create an automatic promotion with free shipping (no code)" do
       fill_in "Name", :with => "Promotion"
       click_button "Create"
       expect(page).to have_content("Editing Promotion")
@@ -146,21 +146,14 @@ describe "Promotion Adjustments", :type => :feature do
       find('[id$=_preferred_amount]').set(30)
       within('#rule_fields') { click_button "Update" }
 
-      select2 "Create whole-order adjustment", :from => "Add action of type"
+      select2 "Free shipping", :from => "Add action of type"
       within('#action_fields') { click_button "Add" }
-      select2 "Free Shipping", :from => "Calculator"
-      within('#actions_container') { click_button "Update" }
+      expect(page).to have_content('MAKES ALL SHIPMENTS FOR THE ORDER FREE')
 
       promotion = Spree::Promotion.find_by_name("Promotion")
-      expect(promotion.code.first.value).to be_blank
-
-      first_rule = promotion.rules.first
-      expect(first_rule.class).to eq(Spree::Promotion::Rules::ItemTotal)
-
-      first_action = promotion.actions.first
-      expect(first_action.class).to eq(Spree::Promotion::Actions::CreateAdjustment)
-      first_action_calculator = first_action.calculator
-      expect(first_action_calculator.class).to eq(Spree::Calculator::FreeShipping)
+      expect(promotion.codes).to be_empty
+      expect(promotion.rules.first).to be_a(Spree::Promotion::Rules::ItemTotal)
+      expect(promotion.actions.first).to be_a(Spree::Promotion::Actions::FreeShipping)
     end
 
     it "should allow an admin to create an automatic promo requiring a landing page to be visited" do

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -64,7 +64,6 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = false
 
   config.before :suite do
-    Capybara.match = :prefer_exact
     DatabaseCleaner.clean_with :truncation
   end
 

--- a/core/lib/spree/testing_support/capybara_ext.rb
+++ b/core/lib/spree/testing_support/capybara_ext.rb
@@ -88,7 +88,12 @@ module CapybaraExt
   end
 
   def find_label_by_text(text)
-    find(:xpath, "//label[text()[contains(.,'#{text}')]]")
+    # This used to find the label by it's text using an xpath query, so we use
+    # a case insensitive search to avoid breakage with existing usage.
+    # We need to select labels which are not .select2-offscreen, as select2
+    # makes a duplicate label with the same text, and we want to be sure to
+    # find the original.
+    find('label:not(.select2-offscreen)', text: %r{#{Regexp.escape(text)}}i, match: :one)
   end
 
   def wait_for_ajax

--- a/core/lib/spree/testing_support/capybara_ext.rb
+++ b/core/lib/spree/testing_support/capybara_ext.rb
@@ -118,11 +118,6 @@ module CapybaraExt
   end
 end
 
-Capybara.configure do |config|
-  config.match = :prefer_exact
-  config.ignore_hidden_elements = true
-end
-
 RSpec::Matchers.define :have_meta do |name, expected|
   match do |actual|
     has_css?("meta[name='#{name}'][content='#{expected}']", visible: false)

--- a/core/lib/spree/testing_support/capybara_ext.rb
+++ b/core/lib/spree/testing_support/capybara_ext.rb
@@ -83,7 +83,7 @@ module CapybaraExt
   def select_select2_result(value)
     # results are in a div appended to the end of the document
     within_entire_page do
-      page.find("div.select2-result-label", text: %r{#{Regexp.escape(value)}}i).click
+      page.find("div.select2-result-label", text: %r{#{Regexp.escape(value)}}i, match: :prefer_exact).click
     end
   end
 

--- a/core/lib/spree/testing_support/capybara_ext.rb
+++ b/core/lib/spree/testing_support/capybara_ext.rb
@@ -35,7 +35,7 @@ module CapybaraExt
   end
 
   def select2_search_without_selection(value, options)
-    find("#{options[:from]}:not(.select2-container-disabled)").click
+    find("#{options[:from]}:not(.select2-container-disabled):not(.select2-offscreen)").click
 
     within_entire_page do
       find("input.select2-input.select2-focused").set(value)


### PR DESCRIPTION
`:smart` has been Capybara's default since 2.1, the differences are explained [here](https://github.com/jnicklas/capybara#strategy).

The basic difference is that with this mode, capybara will raise an exception if the `page.find` would return multiple results. This should expose specs with amgiguous selectors, which may fail spuriously due to timing differences or sorting.

I believe PR exposed and fixed the issue in these two CI failures
https://circleci.com/gh/solidusio/solidus/1217
https://circleci.com/gh/solidusio/solidus/1159

note: I queued up 10 ci builds of this, since it has potential to introduce some spurious issues. 9/10 passed. one failed as far as I can tell due to a slow circleci container (causing a phantomjs crash)