### PR TITLE
Add Zone#states and Zone#countries associations

### DIFF
--- a/core/app/models/spree/zone.rb
+++ b/core/app/models/spree/zone.rb
@@ -3,6 +3,11 @@ module Spree
     has_many :zone_members, dependent: :destroy, class_name: "Spree::ZoneMember", inverse_of: :zone
     has_many :tax_rates, dependent: :destroy, inverse_of: :zone
 
+    with_options through: :zone_members, source: :zoneable do
+      has_many :countries, source_type: "Spree::Country"
+      has_many :states, source_type: "Spree::State"
+    end
+
     has_many :shipping_method_zones
     has_many :shipping_methods, through: :shipping_method_zones
 

--- a/core/lib/spree/testing_support/factories/zone_factory.rb
+++ b/core/lib/spree/testing_support/factories/zone_factory.rb
@@ -13,5 +13,9 @@ FactoryGirl.define do
   factory :zone, class: Spree::Zone do
     name { generate(:random_string) }
     description { generate(:random_string) }
+
+    trait :with_country do
+      countries { [create(:country)] }
+    end
   end
 end

--- a/core/spec/models/spree/zone_spec.rb
+++ b/core/spec/models/spree/zone_spec.rb
@@ -302,4 +302,29 @@ describe Spree::Zone, :type => :model do
       end
     end
   end
+
+  context "state and country associations" do
+    let!(:country)  { create(:country) }
+
+    context "has countries associated" do
+      let!(:zone) do
+        create(:zone, countries: [country])
+      end
+
+      it "can access associated countries" do
+        expect(zone.countries).to include(country)
+      end
+    end
+
+    context "has states associated" do
+      let!(:state)  { create(:state, country: country) }
+      let!(:zone) do
+        create(:zone, states: [state])
+      end
+
+      it "can access associated states" do
+        expect(zone.states).to include(state)
+      end
+    end
+  end
 end

--- a/core/spec/models/spree/zone_spec.rb
+++ b/core/spec/models/spree/zone_spec.rb
@@ -312,7 +312,7 @@ describe Spree::Zone, :type => :model do
       end
 
       it "can access associated countries" do
-        expect(zone.countries).to include(country)
+        expect(zone.countries).to eq([country])
       end
     end
 
@@ -323,7 +323,7 @@ describe Spree::Zone, :type => :model do
       end
 
       it "can access associated states" do
-        expect(zone.states).to include(state)
+        expect(zone.states).to eq([state])
       end
     end
   end


### PR DESCRIPTION
This PR also adds a `:with_country` factory to ease writing tests for taxation. 