### PR TITLE
Allow specifying DB=postgresql

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ testing purposes.
 This sandbox includes solidus\_auth\_devise and generates with seed and sample
 data already loaded.
 
-* Create the sandbox application (`DB=mysql` or `DB=postgres` can be specified
+* Create the sandbox application (`DB=mysql` or `DB=postgresql` can be specified
   to override the default sqlite)
 
   ```shell
@@ -192,7 +192,7 @@ bundle exec rspec spec
 If you would like to run specs against a particular database you may specify the
 dummy apps database, which defaults to sqlite3.
 ```shell
-DB=postgres bundle exec rake test_app
+DB=postgresql bundle exec rake test_app
 ```
 
 You can also enable fail fast in order to stop tests at the first failure

--- a/build.sh
+++ b/build.sh
@@ -8,8 +8,8 @@ set_gemfile(){
   export BUNDLE_GEMFILE="`pwd`/Gemfile"
 }
 
-# Target postgres. Override with: `DB=sqlite bash build.sh`
-export DB=${DB:-postgres}
+# Target postgresql. Override with: `DB=sqlite bash build.sh`
+export DB=${DB:-postgresql}
 
 # Spree defaults
 echo "Setup Spree defaults and creating test application..."

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,7 @@
 ---
 machine:
   environment:
-    DB: postgres
+    DB: postgresql
   services:
     - postgresql
   ruby:

--- a/core/lib/generators/spree/dummy/templates/rails/database.yml
+++ b/core/lib/generators/spree/dummy/templates/rails/database.yml
@@ -26,7 +26,7 @@ production:
   adapter: mysql2
   database: <%= database_prefix %><%= options[:lib_name] %>_spree_production
   encoding: utf8
-<% when 'postgres' %>
+<% when 'postgres', 'postgresql' %>
 <% db_host = ENV['DB_HOST'] -%>
 development:
   adapter: postgresql

--- a/lib/sandbox.sh
+++ b/lib/sandbox.sh
@@ -2,7 +2,7 @@
 # Used in the sandbox rake task in Rakefile
 
 case "$DB" in
-postgres)
+postgres|postgresql)
 	RAILSDB="postgresql"
 	;;
 mysql)


### PR DESCRIPTION
Previously `rake sandbox` and `rake test_app` (and therefore `build.sh` and `build-ci.rb`) were configured to use PostgreSQL through the environment variable `DB=postgres`. I think `DB=postgresql` is a better way to specify that we want to use PostgreSQL. Among other reasons, rails is initialized as `rails new myapp --database=postgresql`.

This PR has two commits:

* The first just enables postgresql as an alias to postgres
* The second changes our documentation to refer to `DB=postgresql` instead. `DB=postgres` will of course continue to work.

I think the first change is uncontroversial, but I'd like to make sure that my feeling about `DB=postgresql` being better is shared.