### PR TITLE
Display "(hidden)" for users api keys

### DIFF
--- a/backend/app/views/spree/admin/users/edit.html.erb
+++ b/backend/app/views/spree/admin/users/edit.html.erb
@@ -30,6 +30,9 @@
     <legend><%= Spree.t('access', :scope => 'api') %></legend>
 
     <% if @user.spree_api_key.present? %>
+      <div class="field">
+        <div id="current-api-key"><%= Spree.t('key', :scope => 'api') %>: (<%= Spree.t('hidden') %>)</div>
+      </div>
       <div class="filter-actions actions">
         <%= form_tag spree.clear_api_key_admin_user_path(@user), :method => :put do %>
           <%= button Spree.t('clear_key', :scope => 'api'), 'trash' %>

--- a/backend/spec/features/admin/users_spec.rb
+++ b/backend/spec/features/admin/users_spec.rb
@@ -161,6 +161,8 @@ describe 'Users', :type => :feature do
         end
 
         expect(user_a.reload.spree_api_key).to be_present
+
+        expect(page).to have_content('Key: (hidden)')
       end
     end
 
@@ -172,12 +174,13 @@ describe 'Users', :type => :feature do
       end
 
       it 'can clear an api key' do
-        within("#admin_user_edit_api_key") do
-          click_button Spree.t('clear_key', :scope => 'api')
-        end
+        expect(page).to have_css('#current-api-key')
+
+        click_button Spree.t('clear_key', :scope => 'api')
+
+        expect(page).to have_no_css('#current-api-key')
 
         expect(user_a.reload.spree_api_key).to be_blank
-        expect { find("#current-api-key") }.to raise_error Capybara::ElementNotFound
       end
 
       it 'can regenerate an api key' do
@@ -189,6 +192,8 @@ describe 'Users', :type => :feature do
 
         expect(user_a.reload.spree_api_key).to be_present
         expect(user_a.reload.spree_api_key).not_to eq old_key
+
+        expect(page).to have_content('Key: (hidden)')
       end
     end
   end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -848,6 +848,7 @@ en:
     guest_user_account: Checkout as a Guest
     has_no_shipped_units: has no shipped units
     height: Height
+    hidden: hidden
     hide_out_of_stock: Hide out of stock
     home: Home
     i18n:


### PR DESCRIPTION
A revision of 11744f3, where we began hiding api keys. This replaces
them with "(hidden)" so that they are hidden, preventing privilege
escalation, but it is clear if the user has an api key.