### PR TITLE
Remove option_type_prototype HABTM

### DIFF
--- a/core/app/models/spree/option_type.rb
+++ b/core/app/models/spree/option_type.rb
@@ -12,7 +12,9 @@ module Spree
     has_many :option_values, -> { order(:position) }, dependent: :destroy, inverse_of: :option_type
     has_many :product_option_types, dependent: :destroy, inverse_of: :option_type
     has_many :products, through: :product_option_types
-    has_and_belongs_to_many :prototypes, join_table: 'spree_option_types_prototypes'
+
+    has_many :option_type_prototypes
+    has_many :prototypes, through: :option_type_prototypes
 
     validates :name, presence: true, uniqueness: true
     validates :presentation, presence: true

--- a/core/app/models/spree/option_type_prototype.rb
+++ b/core/app/models/spree/option_type_prototype.rb
@@ -1,0 +1,6 @@
+module Spree
+  class OptionTypePrototype < Spree::Base
+    belongs_to :option_type
+    belongs_to :prototype
+  end
+end

--- a/core/app/models/spree/prototype.rb
+++ b/core/app/models/spree/prototype.rb
@@ -1,9 +1,11 @@
 module Spree
   class Prototype < Spree::Base
-    has_and_belongs_to_many :option_types, join_table: :spree_option_types_prototypes
 
     has_many :property_prototypes
     has_many :properties, through: :property_prototypes
+
+    has_many :option_type_prototypes
+    has_many :option_types, through: :option_type_prototypes
 
     has_many :prototype_taxons, dependent: :destroy
     has_many :taxons, through: :prototype_taxons

--- a/core/db/migrate/20151124062500_convert_habtm_to_hmt_for_option_type_prototypes.rb
+++ b/core/db/migrate/20151124062500_convert_habtm_to_hmt_for_option_type_prototypes.rb
@@ -1,0 +1,17 @@
+class ConvertHabtmToHmtForOptionTypePrototypes < ActiveRecord::Migration
+  def up
+    add_column :spree_option_types_prototypes, :id, :primary_key
+    add_column :spree_option_types_prototypes, :created_at, :datetime
+    add_column :spree_option_types_prototypes, :updated_at, :datetime
+
+    rename_table :spree_option_types_prototypes, :spree_option_type_prototypes
+  end
+
+  def down
+    remove_column :spree_option_types_prototypes, :id
+    remove_column :spree_option_types_prototypes, :created_at
+    remove_column :spree_option_types_prototypes, :updated_at
+
+    rename_table :spree_option_type_prototypes, :spree_option_types_prototypes
+  end
+end


### PR DESCRIPTION
Another cherry-pick from #289 as we remove all the has and belongs to
many relationships from the codebase.