### PR TITLE
Remove HABTM in promotion rule taxons

### DIFF
--- a/core/app/models/spree/promotion/rules/taxon.rb
+++ b/core/app/models/spree/promotion/rules/taxon.rb
@@ -2,7 +2,8 @@ module Spree
   class Promotion
     module Rules
       class Taxon < PromotionRule
-        has_and_belongs_to_many :taxons, class_name: '::Spree::Taxon', join_table: 'spree_taxons_promotion_rules', foreign_key: 'promotion_rule_id'
+        has_many :promotion_rule_taxons, class_name: 'Spree::PromotionRuleTaxon', foreign_key: :promotion_rule_id
+        has_many :taxons, through: :promotion_rule_taxons, class_name: 'Spree::Taxon'
 
         MATCH_POLICIES = %w(any all)
         preference :match_policy, default: MATCH_POLICIES.first

--- a/core/app/models/spree/promotion_rule_taxon.rb
+++ b/core/app/models/spree/promotion_rule_taxon.rb
@@ -1,0 +1,6 @@
+module Spree
+  class PromotionRuleTaxon < Spree::Base
+    belongs_to :promotion_rule
+    belongs_to :taxon
+  end
+end

--- a/core/app/models/spree/taxon.rb
+++ b/core/app/models/spree/taxon.rb
@@ -9,6 +9,9 @@ module Spree
     has_many :prototype_taxons, dependent: :destroy
     has_many :prototypes, through: :prototype_taxons
 
+    has_many :promotion_rule_taxons
+    has_many :promotion_rules, through: :promotion_rule_taxons
+
     before_create :set_permalink
 
     validates :name, presence: true

--- a/core/db/migrate/20151126063028_convert_habtm_to_hmt_for_taxons_promotion_rules.rb
+++ b/core/db/migrate/20151126063028_convert_habtm_to_hmt_for_taxons_promotion_rules.rb
@@ -1,0 +1,15 @@
+class ConvertHabtmToHmtForTaxonsPromotionRules < ActiveRecord::Migration
+  def up
+    add_column :spree_taxons_promotion_rules, :created_at, :datetime
+    add_column :spree_taxons_promotion_rules, :updated_at, :datetime
+
+    rename_table :spree_taxons_promotion_rules, :spree_promotion_rule_taxons
+  end
+
+  def down
+    rename_table :spree_promotion_rule_taxons, :spree_taxons_promotion_rules
+
+    remove_column :spree_taxons_promotion_rules, :created_at, :datetime
+    remove_column :spree_taxons_promotion_rules, :updated_at, :datetime
+  end
+end


### PR DESCRIPTION
Should be the last cherry-pick from #289 to remove HABTM's from the
codebase.