### PR TITLE
Add recipient override to return authorization

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/sections/_return_authorizations.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/_return_authorizations.scss
@@ -24,3 +24,19 @@
   border-radius: 4px;
   opacity: 0.6;
 }
+
+input#override_recipient_checkbox:checked {
+  & ~ fieldset {
+    .reimbursement-type-col, .exchange-for-col {
+      display: none;
+    }
+  }
+
+  & ~ .recipient-user-search {
+    display: block;
+  }
+}
+
+.recipient-user-search {
+  display: none;
+}

--- a/backend/app/views/spree/admin/return_authorizations/_form.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/_form.html.erb
@@ -13,8 +13,8 @@
         <th><%= Spree.t(:state) %></th>
         <th><%= Spree.t(:charged) %></th>
         <th><%= Spree.t(:pre_tax_refund_amount) %></th>
-        <th><%= Spree.t(:reimbursement_type) %></th>
-        <th><%= Spree.t(:exchange_for) %></th>
+        <th class="reimbursement-type-col"><%= Spree.t(:reimbursement_type) %></th>
+        <th class="exchange-for-col"><%= Spree.t(:exchange_for) %></th>
         <th><%= Spree.t(:reason) %></th>
       </tr>
     </thead>
@@ -45,14 +45,14 @@
               <%= return_item.display_pre_tax_amount %>
             <% end %>
           </td>
-          <td>
+          <td class="reimbursement-type-col">
             <% if editable %>
               <%= item_fields.select :preferred_reimbursement_type_id, @reimbursement_types.collect{|r|[r.name.humanize, r.id]}, {include_blank: true}, {class: 'select2 fullwidth'} %>
             <% else %>
               <%= return_item.preferred_reimbursement_type.try(:name) %>
             <% end %>
           </td>
-          <td class="align-center">
+          <td class="exchange-for-col align-center">
             <% if editable %>
               <%= item_fields.collection_select :exchange_variant_id, return_item.eligible_exchange_variants(@stock_locations), :id, :options_text, { include_blank: true }, { class: "select2 fullwidth return-item-exchange-selection" } %>
             <% elsif return_item.exchange_processed? %>

--- a/backend/app/views/spree/admin/return_authorizations/new.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/new.html.erb
@@ -10,6 +10,18 @@
 
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @return_authorization } %>
 <%= form_for [:admin, @order, @return_authorization] do |f| %>
+  <input type='checkbox' id='override_recipient_checkbox' name='return_authorization[override_recipient]' value='true' />
+  <label class="override_recipient_checkbox" for='override_recipient_checkbox'>
+    <%= Spree.t(:override_recipient) %>
+  </label>
+
+  <div class="recipient-user-search">
+    <label><%= Spree.t(:reimbursement_recipient) %></label>
+    <%= hidden_field_tag :customer_search,  nil, :class => 'fullwidth title' %>
+    <%= hidden_field_tag :user_id, nil, :name => 'return_authorization[recipient_id]' %>
+  </div>
+
+
   <fieldset class="no-border-top">
     <%= render :partial => 'form', :locals => { :f => f } %>
 

--- a/backend/spec/features/admin/returns/return_authorization_spec.rb
+++ b/backend/spec/features/admin/returns/return_authorization_spec.rb
@@ -1,0 +1,106 @@
+require 'spec_helper'
+
+feature 'Return authorizations' do
+  stub_authorization!
+
+  let!(:order) do
+    exchangable_variant = create(:variant_in_stock, product: create(:product))
+    create(:shipped_order, line_items_attributes: [{ variant: exchangable_variant }] )
+  end
+
+  context 'with recipient as purchaser' do
+    scenario 'creates return authorization with recipient as purchaser' do
+      visit spree.new_admin_order_return_authorization_path(order)
+      find('.add-item').click
+      select 'NY Warehouse', from: 'return_authorization_stock_location_id'
+
+      expect {
+        click_button Spree.t(:create)
+      }.to change { Spree::ReturnAuthorization.count }.from(0).to(1)
+
+      expect(page).to have_content(Spree.t(:successfully_created, resource: 'Return Authorization'))
+
+      return_authorization = Spree::ReturnAuthorization.last
+      expect(return_authorization.recipient).to eq(nil)
+    end
+  end
+
+  context 'with recipient other than purchaser', :js do
+    let!(:poptart_user) { create(:user, email: 'poptarts@toaster.org') }
+    let!(:hello_user) { create(:user, email: 'hello@example.com') }
+
+    scenario 'assigns recipient to return authorization' do
+      visit spree.new_admin_order_return_authorization_path(order)
+
+      within('.return-items-table') do
+        expect(page).to have_content(Spree.t(:reimbursement_type).upcase)
+        expect(page).to have_content(Spree.t(:exchange_for).upcase)
+      end
+      expect(page).not_to have_content(Spree.t(:reimbursement_recipient).upcase)
+
+      check Spree.t(:override_recipient)
+
+      within('.return-items-table') do
+        expect(page).not_to have_content(Spree.t(:reimbursement_type).upcase)
+        expect(page).not_to have_content(Spree.t(:exchange_for).upcase)
+      end
+      expect(page).to have_content(Spree.t(:reimbursement_recipient).upcase)
+
+      targetted_select2 'poptarts@toaster.org', from: '#s2id_customer_search'
+
+      find('.add-item').click
+      select 'NY Warehouse', from: 'return_authorization_stock_location_id'
+
+      expect {
+        click_button Spree.t(:create)
+      }.to change { Spree::ReturnAuthorization.count }.from(0).to(1)
+
+      return_authorization = Spree::ReturnAuthorization.last
+      expect(return_authorization.recipient).to eq(poptart_user)
+      expect(page).to have_content(Spree.t(:successfully_created, resource: 'Return Authorization'))
+    end
+
+    scenario 'with exchange item selected' do
+      visit spree.new_admin_order_return_authorization_path(order)
+
+      targetted_select2 'Size: S', from: '#s2id_return_authorization_return_items_attributes_0_exchange_variant_id'
+      select 'NY Warehouse', from: 'return_authorization_stock_location_id'
+
+      check Spree.t(:override_recipient)
+      targetted_select2 'poptarts@toaster.org', from: '#s2id_customer_search'
+
+      expect {
+        click_button Spree.t(:create)
+      }.not_to change { Spree::ReturnAuthorization.count }
+      expect(page).to have_content I18n.t('activerecord.errors.models.spree/return_item.attributes.exchange_variant.cannot_have_override_recipient')
+    end
+
+    scenario 'without selecting another recipient' do
+      visit spree.new_admin_order_return_authorization_path(order)
+      check Spree.t(:override_recipient)
+      find('.add-item').click
+      select 'NY Warehouse', from: 'return_authorization_stock_location_id'
+
+      expect {
+        click_button Spree.t(:create)
+      }.not_to change { Spree::ReturnAuthorization.count }
+
+      expect(page).to have_content "Recipient can't be blank"
+
+      check Spree.t(:override_recipient)
+
+      targetted_select2 'poptarts@toaster.org', from: '#s2id_customer_search'
+
+      find('.add-item').click
+      select 'NY Warehouse', from: 'return_authorization_stock_location_id'
+
+      expect {
+        click_button Spree.t(:create)
+      }.to change { Spree::ReturnAuthorization.count }.from(0).to(1)
+
+      return_authorization = Spree::ReturnAuthorization.last
+      expect(return_authorization.recipient).to eq(poptart_user)
+      expect(page).to have_content(Spree.t(:successfully_created, resource: 'Return Authorization'))
+    end
+  end
+end

--- a/core/app/models/spree/return_authorization.rb
+++ b/core/app/models/spree/return_authorization.rb
@@ -8,6 +8,7 @@ module Spree
 
     belongs_to :stock_location
     belongs_to :reason, class_name: 'Spree::ReturnReason', foreign_key: :return_reason_id
+    belongs_to :recipient, class_name: Spree::UserClassHandle.new
 
     before_create :generate_number
 
@@ -20,6 +21,8 @@ module Spree
     validate :must_have_shipped_units, on: :create
     validate :no_previously_exchanged_inventory_units, on: :create
 
+    validates :recipient, presence: true, if: :override_recipient
+    attr_accessor :override_recipient
 
     # These are called prior to generating expedited exchanges shipments.
     # Should respond to a "call" method that takes the list of return items

--- a/core/app/models/spree/return_item.rb
+++ b/core/app/models/spree/return_item.rb
@@ -43,6 +43,7 @@ module Spree
     validate :validate_acceptance_status_for_reimbursement
     validates :inventory_unit, presence: true
     validate :validate_no_other_completed_return_items
+    validate :eligible_recipient_override
 
     after_create :cancel_others, unless: :cancelled?
 
@@ -167,6 +168,12 @@ module Spree
     #   for exchange for this return item
     def eligible_exchange_variants(stock_locations = nil)
       exchange_variant_engine.eligible_variants(variant, stock_locations: stock_locations)
+    end
+
+    def eligible_recipient_override
+      if return_authorization.recipient && exchange_requested?
+        errors.add(:exchange_variant, :cannot_have_override_recipient)
+      end
     end
 
     # Builds the exchange inventory unit for this return item, only if an

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -318,6 +318,8 @@ en:
               cannot_be_associated_unless_accepted: cannot be associated to a return item that is not accepted.
             inventory_unit:
               other_completed_return_item_exists: "%{inventory_unit_id} has already been taken by return item %{return_item_id}"
+            exchange_variant:
+              cannot_have_override_recipient: cannot have an override recipient
         spree/shipment:
           attributes:
             state:
@@ -1109,6 +1111,7 @@ en:
     orders: Orders
     other_items_in_other: Other Items in Order
     out_of_stock: Out of Stock
+    override_recipient: Override Recipient
     overview: Overview
     package_from: package from
     pagination:
@@ -1276,6 +1279,7 @@ en:
     reimbursed: Reimbursed
     reimbursement: Reimbursement
     reimbursement_perform_failed: "Reimbursement could not be performed.  Error: %{error}"
+    reimbursement_recipient: Reimbursement Recipient
     reimbursement_status: Reimbursement status
     reimbursement_type: Reimbursement type
     reimbursement_type_override: Reimbursement Type Override

--- a/core/db/migrate/20151123225131_add_recipient_to_return_authorization.rb
+++ b/core/db/migrate/20151123225131_add_recipient_to_return_authorization.rb
@@ -1,0 +1,8 @@
+class AddRecipientToReturnAuthorization < ActiveRecord::Migration
+  def change
+    add_column :spree_return_authorizations, :recipient_id, :integer
+    add_index :spree_return_authorizations, :recipient_id
+
+    add_foreign_key :spree_return_authorizations, Spree.user_class.table_name, column: :recipient_id
+  end
+end

--- a/core/lib/spree/testing_support/factories/variant_factory.rb
+++ b/core/lib/spree/testing_support/factories/variant_factory.rb
@@ -17,6 +17,17 @@ FactoryGirl.define do
     factory :variant do
       # on_hand 5
       product { |p| p.association(:product) }
+
+      factory :variant_in_stock do
+
+        transient do
+          count_on_hand 1
+        end
+
+        after(:create) do |variant, evaluator|
+          variant.stock_locations.first.stock_items.where(:variant_id => variant.id).first.adjust_count_on_hand(evaluator.count_on_hand)
+        end
+      end
     end
 
     factory :master_variant do


### PR DESCRIPTION
* Add recipient_id to return_authorizations table
* Provide admin ability to select override recipient from existing users list
  when creating new return authorization