### PR TITLE
WIP: Prevent completion of orders lacking sufficient payment

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -658,6 +658,10 @@ module Spree
     end
     alias_method :covered_by_store_credit, :covered_by_store_credit?
 
+    def covered_by_valid_payments?
+      return payments.where(state: %w(checkout pending)).sum(:amount) >= total
+    end
+
     def total_available_store_credit
       return 0.0 unless user
       user.total_available_store_credit

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -645,11 +645,6 @@ module Spree
       end
 
       payments.reset
-
-      if payments.where(state: %w(checkout pending)).sum(:amount) != total
-        errors.add(:base, Spree.t("store_credit.errors.unable_to_fund")) and return false
-      end
-
     end
 
     def covered_by_store_credit?
@@ -659,7 +654,7 @@ module Spree
     alias_method :covered_by_store_credit, :covered_by_store_credit?
 
     def covered_by_valid_payments?
-      return payments.where(state: %w(checkout pending)).sum(:amount) >= total
+      payments.where(state: %w(checkout completed pending processing)).sum(:amount) >= total
     end
 
     def total_available_store_credit

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -337,6 +337,11 @@ module Spree
               return false
             end
 
+            if !covered_by_valid_payments?
+              errors.add(:base, Spree.t(:payments_do_not_cover_order_total))
+              return false
+            end
+
             if process_payments!
               true
             else

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -82,6 +82,7 @@ module Spree
                 before_transition to: :payment, do: :assign_default_credit_card
 
                 before_transition to: :confirm, do: :add_store_credit_payments
+                before_transition to: :confirm, do: :ensure_sufficient_payment
 
                 # see also process_payments_before_complete below which needs to
                 # be added in the correct sequence.
@@ -115,6 +116,7 @@ module Spree
               before_transition to: :complete, do: :ensure_line_item_variants_are_not_deleted
               before_transition to: :complete, do: :ensure_inventory_units, unless: :unreturned_exchange?
               if states[:payment]
+                before_transition to: :complete, do: :ensure_sufficient_payment
                 before_transition to: :complete, do: :process_payments_before_complete
               end
 
@@ -329,7 +331,7 @@ module Spree
 
           private
 
-          def process_payments_before_complete
+          def ensure_sufficient_payment
             return if !payment_required?
 
             if payments.valid.empty?
@@ -341,6 +343,12 @@ module Spree
               errors.add(:base, Spree.t(:payments_do_not_cover_order_total))
               return false
             end
+
+            true
+          end
+
+          def process_payments_before_complete
+            return if !payment_required?
 
             if process_payments!
               true

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1461,7 +1461,6 @@ en:
           eligible: "Eligibility Verified"
           void: "Voided"
       errors:
-        unable_to_fund: "Unable to pay for order using store credits"
         cannot_invalidate_uncaptured_authorization: "Cannot invalidate a store credit with an uncaptured authorization"
       expiring: Expiring
       insufficient_authorized_amount: "Unable to capture more than authorized amount"

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1012,6 +1012,7 @@ en:
     no_orders_found: No orders found
     no_payment_methods_found: No payment methods found
     no_payment_found: No payment found
+    payments_do_not_cover_order_total: Payments do not cover order total
     no_pending_payments: No pending payments
     no_products_found: No products found
     no_promotions_found: No promotions found

--- a/core/lib/spree/testing_support/factories/payment_factory.rb
+++ b/core/lib/spree/testing_support/factories/payment_factory.rb
@@ -2,7 +2,7 @@ FactoryGirl.define do
   factory :payment, aliases: [:credit_card_payment], class: Spree::Payment do
     association(:payment_method, factory: :credit_card_payment_method)
     association(:source, factory: :credit_card)
-    order
+    association(:order, factory: :order_with_line_items)
     state 'checkout'
     response_code '12345'
 

--- a/core/spec/models/spree/order/state_machine_spec.rb
+++ b/core/spec/models/spree/order/state_machine_spec.rb
@@ -15,6 +15,7 @@ describe Spree::Order, :type => :model do
         order.state = "confirm"
         order.run_callbacks(:create)
         allow(order).to receive_messages :payment_required? => true
+        allow(order).to receive_messages :ensure_sufficient_payment => true
         allow(order).to receive_messages :process_payments! => true
         allow(order).to receive_messages :ensure_available_shipping_rates => true
       end

--- a/core/spec/models/spree/order/state_machine_spec.rb
+++ b/core/spec/models/spree/order/state_machine_spec.rb
@@ -21,7 +21,7 @@ describe Spree::Order, :type => :model do
 
       context "when payment processing succeeds" do
         before do
-          order.payments << FactoryGirl.create(:payment, state: 'checkout', order: order)
+          order.payments << FactoryGirl.create(:payment, state: 'checkout')
           allow(order).to receive_messages process_payments: true
         end
 

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -1405,4 +1405,33 @@ describe Spree::Order, :type => :model do
       end
     end
   end
+
+  describe '#covered_by_valid_payments?' do
+    let(:order) do
+      create(
+        :order_with_line_items,
+        line_items_count: 3,
+        line_items_price: 10,
+        shipment_cost: 5,
+        payments: [credit_card_payment, store_credit_payment])
+    end
+
+    context "valid paymenets match order's total" do
+      let(:credit_card_payment) { create(:payment, amount: 25) }
+      let(:store_credit_payment) { create(:store_credit_payment, amount: 10 )}
+
+      it "is true" do
+        expect(order.covered_by_valid_payments?).to be_truthy
+      end
+    end
+
+    context "valid payments do not match order's total" do
+      let(:credit_card_payment) { create(:payment, amount: 25, state: "failed") }
+      let(:store_credit_payment) { create(:store_credit_payment, amount: 10 )}
+
+      it "is false" do
+        expect(order.covered_by_valid_payments?).to be_falsey
+      end
+    end
+  end
 end

--- a/core/spec/models/spree/order_updater_spec.rb
+++ b/core/spec/models/spree/order_updater_spec.rb
@@ -10,6 +10,7 @@ module Spree
         2.times do
           create(:line_item, order: order, price: 10)
         end
+        Spree::OrderUpdater.new(order).update
       end
 
       context 'with refund' do


### PR DESCRIPTION
This is WIP commit of me taking over #281 as I don't have push access to that repo.
##### _Below is the description stolen from Peter's PR:_

A check is made [here](https://github.com/solidusio/solidus/blob/master/core/app/models/spree/order.rb#L685-L687) to ensure that an order's payments cover the total cost of the order before transitioning from the payment state to confirm. If the state machine transitions ever change so that an order is able to reach confirm or complete without making the payment -> confirm transition then this check will be bypassed and it will be possible for a user to checkout without having enough payments to cover the total cost of the order.

I think it makes sense to check that the payments will cover the cost of the order before transitioning to complete. This should guarantee that an order will never complete unless its payments can cover the total cost.

I'm also curious if there are any reasons not to perform the check when transitioning to complete. I wasn't able to think of any, but I'm not sure if there's some case I may be missing where this check would be unwanted.
