### PR TITLE
Use git ls-files for the gemspec file listing

### DIFF
--- a/backend/solidus_backend.gemspec
+++ b/backend/solidus_backend.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'http://solidus.io'
   s.rubyforge_project = 'solidus_backend'
 
-  s.files        = Dir['LICENSE', 'README.md', 'app/**/*', 'config/**/*', 'lib/**/*', 'db/**/*', 'vendor/**/*']
+  s.files        = `git ls-files`.split("\n")
   s.require_path = 'lib'
   s.requirements << 'none'
 

--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'http://solidus.io'
   s.license     = %q{BSD-3}
 
-  s.files        = Dir['LICENSE', 'README.md', 'app/**/*', 'config/**/*', 'lib/**/*', 'db/**/*', 'vendor/**/*']
+  s.files        = `git ls-files`.split("\n")
   s.require_path = 'lib'
 
   s.required_ruby_version = '>= 2.1.0'

--- a/frontend/solidus_frontend.gemspec
+++ b/frontend/solidus_frontend.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'http://solidus.io/'
   s.rubyforge_project = 'solidus_frontend'
 
-  s.files        = Dir['LICENSE', 'README.md', 'app/**/*', 'config/**/*', 'lib/**/*', 'db/**/*', 'vendor/**/*']
+  s.files        = `git ls-files`.split("\n")
   s.require_path = 'lib'
   s.requirements << 'none'
 

--- a/sample/solidus_sample.gemspec
+++ b/sample/solidus_sample.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'http://solidus.io/'
   s.license     = %q{BSD-3}
 
-  s.files        = Dir['LICENSE', 'README.md', 'lib/**/*', 'db/**/*']
+  s.files        = `git ls-files`.split("\n")
   s.require_path = 'lib'
   s.requirements << 'none'
 


### PR DESCRIPTION
Currently the new image factory doesn't work in projects including the gem because the image isn't being bundled into the gem.

This ensures we're bundling all the files in the repo, and it makes it harder to accidentally include files we don't want in a release. One change is that this will include specs in the gem where it didn't before, which IMO is fine.

api project's gemspec wasn't changed here because it already used `git ls-files`

Fixes #543