### PR TITLE
(api) don't allow customers to update completed orders

### DIFF
--- a/core/lib/spree/permission_sets/default_customer.rb
+++ b/core/lib/spree/permission_sets/default_customer.rb
@@ -9,6 +9,9 @@ module Spree
         can [:read, :update], Order do |order, token|
           order.user == user || order.guest_token && token == order.guest_token
         end
+        cannot :update, Order do |order|
+          order.completed?
+        end
         can :create, ReturnAuthorization do |return_authorization|
           return_authorization.order.user == user
         end


### PR DESCRIPTION
don't allow customers to update a completed order (eg, line_item adjustments, etc)

see https://github.com/solidusio/solidus/issues/546
