### PR TITLE
Cleanup use of raise_error

### DIFF
--- a/api/spec/controllers/spree/api/orders_controller_spec.rb
+++ b/api/spec/controllers/spree/api/orders_controller_spec.rb
@@ -392,7 +392,7 @@ module Spree
     end
 
     it "can create an order without any parameters" do
-      expect { api_post :create }.not_to raise_error
+      api_post :create
       expect(response.status).to eq(201)
       expect(json_response["state"]).to eq("cart")
     end
@@ -715,7 +715,7 @@ module Spree
 
       context "creation" do
         it "can create an order without any parameters" do
-          expect { api_post :create }.not_to raise_error
+          api_post :create
           expect(response.status).to eq(201)
           order = Order.last
           expect(json_response["state"]).to eq("cart")

--- a/backend/spec/controllers/spree/admin/payment_methods_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/payment_methods_controller_spec.rb
@@ -22,9 +22,7 @@ module Spree
 
     context "tries to save invalid payment" do
       it "doesn't break, responds nicely" do
-        expect {
-          spree_post :create, :payment_method => { :name => "", :type => "Spree::Gateway::Bogus" }
-        }.not_to raise_error
+        spree_post :create, :payment_method => { :name => "", :type => "Spree::Gateway::Bogus" }
       end
     end
 

--- a/backend/spec/features/admin/orders/customer_details_spec.rb
+++ b/backend/spec/features/admin/orders/customer_details_spec.rb
@@ -145,7 +145,7 @@ describe "Customer Details", type: :feature, js: true do
 
         page.select('Alabama', from: 'order_ship_address_attributes_state_id')
         fill_in "order_ship_address_attributes_phone", with: "123-456-7890"
-        expect { click_button "Update" }.not_to raise_error
+        click_button "Update"
       end
     end
   end

--- a/backend/spec/features/admin/orders/shipments_spec.rb
+++ b/backend/spec/features/admin/orders/shipments_spec.rb
@@ -15,7 +15,7 @@ describe "Shipments", :type => :feature do
     end
 
     it "can still be displayed" do
-      expect { visit spree.edit_admin_order_path(order) }.not_to raise_error
+      visit spree.edit_admin_order_path(order)
     end
   end
 

--- a/backend/spec/helpers/admin/reimbursements_helper_spec.rb
+++ b/backend/spec/helpers/admin/reimbursements_helper_spec.rb
@@ -27,7 +27,7 @@ describe Spree::Admin::ReimbursementsHelper, type: :helper do
       let(:status) { 'noop' }
 
       it 'should raise an error' do
-        expect{ subject }.to raise_error(RuntimeError)
+        expect{ subject }.to raise_error(RuntimeError, "unknown reimbursement status: noop")
       end
     end
   end

--- a/backend/spec/helpers/admin/store_credit_events_helper_spec.rb
+++ b/backend/spec/helpers/admin/store_credit_events_helper_spec.rb
@@ -88,7 +88,7 @@ describe Spree::Admin::StoreCreditEventsHelper, type: :helper do
       let(:originator) { create(:store_credit_update_reason) }
 
       it "raises an error" do
-        expect { subject }.to raise_error(RuntimeError)
+        expect { subject }.to raise_error(RuntimeError, "Unexpected originator type Spree::StoreCreditUpdateReason")
       end
     end
   end

--- a/core/spec/helpers/base_helper_spec.rb
+++ b/core/spec/helpers/base_helper_spec.rb
@@ -61,7 +61,7 @@ describe Spree::BaseHelper, :type => :helper do
 
     it "should not raise errors when style exists" do
       ActiveSupport::Deprecation.silence do
-        expect { very_strange_image(product) }.not_to raise_error
+        very_strange_image(product)
       end
     end
 
@@ -155,7 +155,7 @@ describe Spree::BaseHelper, :type => :helper do
 
     it "should not raise errors when helper method called" do
       ActiveSupport::Deprecation.silence do
-        expect { foobar_image(product) }.not_to raise_error
+        foobar_image(product)
       end
     end
 

--- a/core/spec/mailers/reimbursement_mailer_spec.rb
+++ b/core/spec/mailers/reimbursement_mailer_spec.rb
@@ -10,9 +10,7 @@ describe Spree::ReimbursementMailer, :type => :mailer do
   it "accepts a reimbursement id as an alternative to a Reimbursement object" do
     expect(Spree::Reimbursement).to receive(:find).with(reimbursement.id).and_return(reimbursement)
 
-    expect {
-      Spree::ReimbursementMailer.reimbursement_email(reimbursement.id).body
-    }.not_to raise_error
+    Spree::ReimbursementMailer.reimbursement_email(reimbursement.id).body
   end
 
   context "emails must be translatable" do

--- a/core/spec/mailers/test_mailer_spec.rb
+++ b/core/spec/mailers/test_mailer_spec.rb
@@ -8,8 +8,6 @@ describe Spree::TestMailer, :type => :mailer do
   let(:user) { create(:user) }
 
   it "confirm_email accepts a user id as an alternative to a User object" do
-    expect {
-      test_email = Spree::TestMailer.test_email('test@example.com')
-    }.not_to raise_error
+    Spree::TestMailer.test_email('test@example.com')
   end
 end

--- a/core/spec/models/spree/adjustment_reason_spec.rb
+++ b/core/spec/models/spree/adjustment_reason_spec.rb
@@ -4,9 +4,7 @@ describe Spree::AdjustmentReason do
 
   describe 'creation' do
     it 'is successful' do
-      expect {
-        create(:adjustment_reason)
-      }.to_not raise_error
+      create(:adjustment_reason)
     end
   end
 

--- a/core/spec/models/spree/carton_spec.rb
+++ b/core/spec/models/spree/carton_spec.rb
@@ -6,7 +6,9 @@ describe Spree::Carton do
   describe "#create" do
     subject { carton }
 
-    it { expect { subject }.to_not raise_error }
+    it "raises no errors" do
+      subject
+    end
   end
 
   describe "#tracking_url" do

--- a/core/spec/models/spree/classification_spec.rb
+++ b/core/spec/models/spree/classification_spec.rb
@@ -7,7 +7,7 @@ module Spree
       product = create(:product)
       taxon = create(:taxon)
       add_taxon = lambda { product.taxons << taxon }
-      expect(add_taxon).not_to raise_error
+      add_taxon.call
       expect(add_taxon).to raise_error(ActiveRecord::RecordInvalid)
     end
 

--- a/core/spec/models/spree/credit_card_spec.rb
+++ b/core/spec/models/spree/credit_card_spec.rb
@@ -193,12 +193,12 @@ describe Spree::CreditCard, type: :model do
     end
 
     it "does not blow up when passed an empty string" do
-      expect { credit_card.expiry = '' }.not_to raise_error
+      credit_card.expiry = ''
     end
 
     # Regression test for #4725
     it "does not blow up when passed one number" do
-      expect { credit_card.expiry = '12' }.not_to raise_error
+      credit_card.expiry = '12'
     end
 
   end
@@ -254,7 +254,7 @@ describe Spree::CreditCard, type: :model do
 
   context "#associations" do
     it "should be able to access its payments" do
-      expect { credit_card.payments.to_a }.not_to raise_error
+      credit_card.payments.to_a
     end
   end
 
@@ -327,7 +327,7 @@ describe Spree::CreditCard, type: :model do
     second = FactoryGirl.create(:credit_card, user: user, default: false)
     first.update_columns(year: DateTime.now.year, month: 1.month.ago.month)
 
-    expect { second.update_attributes!(default: true) }.not_to raise_error
+    second.update_attributes!(default: true)
   end
 
   it 'allows this card to save even if the previously default card has expired' do
@@ -336,6 +336,6 @@ describe Spree::CreditCard, type: :model do
     second = FactoryGirl.create(:credit_card, user: user, default: false)
     first.update_columns(year: DateTime.now.year, month: 1.month.ago.month)
 
-    expect { second.update_attributes!(default: true) }.not_to raise_error
+    second.update_attributes!(default: true)
   end
 end

--- a/core/spec/models/spree/customer_return_spec.rb
+++ b/core/spec/models/spree/customer_return_spec.rb
@@ -202,7 +202,7 @@ describe Spree::CustomerReturn, :type => :model do
 
       it "should NOT raise an error when no stock item exists in the stock location" do
         inventory_unit.find_stock_item.destroy
-        expect { create(:customer_return_without_return_items, return_items: [return_item], stock_location_id: new_stock_location.id) }.not_to raise_error
+        create(:customer_return_without_return_items, return_items: [return_item], stock_location_id: new_stock_location.id)
       end
 
       it "should not update the stock item counts in the original stock location" do

--- a/core/spec/models/spree/inventory_unit_spec.rb
+++ b/core/spec/models/spree/inventory_unit_spec.rb
@@ -40,7 +40,7 @@ describe Spree::InventoryUnit, :type => :model do
     # Regression for #3066
     it "returns modifiable objects" do
       units = Spree::InventoryUnit.backordered_for_stock_item(stock_item)
-      expect { units.first.save! }.to_not raise_error
+      units.first.save!
     end
 
     it "finds inventory units from its stock location when the unit's variant matches the stock item's variant" do

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -118,7 +118,7 @@ describe Spree::Order, :type => :model do
 
         it "doesn't raise an error if the default address is invalid" do
           order.user = mock_model(Spree::LegacyUser, ship_address: Spree::Address.new, bill_address: Spree::Address.new)
-          expect { order.next! }.to_not raise_error
+          order.next!
         end
 
         context "with default addresses" do

--- a/core/spec/models/spree/order/currency_updater_spec.rb
+++ b/core/spec/models/spree/order/currency_updater_spec.rb
@@ -8,7 +8,7 @@ describe Spree::Order, :type => :model do
 
       context "#homogenize_line_item_currencies" do
         it "succeeds without error" do
-          expect { line_item.order.update_attributes!(currency: 'EUR') }.to_not raise_error
+          line_item.order.update_attributes!(currency: 'EUR')
         end
 
         it "changes the line_item currencies" do

--- a/core/spec/models/spree/order/currency_updater_spec.rb
+++ b/core/spec/models/spree/order/currency_updater_spec.rb
@@ -20,7 +20,7 @@ describe Spree::Order, :type => :model do
         end
 
         it "fails to change the order currency when no prices are available in that currency" do
-          expect { line_item.order.update_attributes!(currency: 'GBP') }.to raise_error RuntimeError
+          expect { line_item.order.update_attributes!(currency: 'GBP') }.to raise_error(RuntimeError, /\Ano GBP price found/)
         end
 
         it "calculates the item total in the order.currency" do

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -755,7 +755,7 @@ describe Spree::Order, :type => :model do
     let(:order) { Spree::Order.create } # need a persisted in order to test locking
 
     it 'can lock' do
-      expect { order.with_lock {} }.to_not raise_error
+      order.with_lock {}
     end
   end
 

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -601,7 +601,7 @@ describe Spree::Payment, :type => :model do
       end
 
       specify do
-        expect { payment.process! }.not_to raise_error
+        payment.process!
       end
     end
   end

--- a/core/spec/models/spree/product_filter_spec.rb
+++ b/core/spec/models/spree/product_filter_spec.rb
@@ -11,7 +11,7 @@ describe 'product filters', :type => :model do
     end
 
     it "does not attempt to call value method on Arel::Table" do
-      expect { Spree::Core::ProductFilters.brand_filter }.not_to raise_error
+      Spree::Core::ProductFilters.brand_filter
     end
 
     it "can find products in the 'Nike' brand" do
@@ -20,7 +20,7 @@ describe 'product filters', :type => :model do
     it "sorts products without brand specified" do
       product.set_property("brand", "Nike")
       create(:product).set_property("brand", nil)
-      expect { Spree::Core::ProductFilters.brand_filter[:labels] }.not_to raise_error
+      Spree::Core::ProductFilters.brand_filter[:labels]
     end
   end
 end

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -232,7 +232,7 @@ describe Spree::Product, :type => :model do
 
       it "doesnt raise ReadOnlyRecord error" do
         Spree::StockMovement.create!(stock_item: stock_item, quantity: 1)
-        expect { product.destroy }.not_to raise_error
+        product.destroy
       end
     end
 

--- a/core/spec/models/spree/promotion/rules/user_spec.rb
+++ b/core/spec/models/spree/promotion/rules/user_spec.rb
@@ -31,7 +31,7 @@ describe Spree::Promotion::Rules::User, :type => :model do
     it "can assign to user_ids" do
       user1 = Spree::LegacyUser.create!(:email => "test1@example.com")
       user2 = Spree::LegacyUser.create!(:email => "test2@example.com")
-      expect { rule.user_ids = "#{user1.id}, #{user2.id}" }.not_to raise_error
+      rule.user_ids = "#{user1.id}, #{user2.id}"
     end
   end
 end

--- a/core/spec/models/spree/return_item_spec.rb
+++ b/core/spec/models/spree/return_item_spec.rb
@@ -660,7 +660,7 @@ describe Spree::ReturnItem, :type => :model do
       let(:old_reception_status) { 'cancelled' }
 
       it 'succeeds' do
-        expect { subject.save! }.to_not raise_error
+        subject.save!
       end
     end
 

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -322,7 +322,7 @@ describe Spree::Shipment, :type => :model do
 
         it "transitions to shipped" do
           shipment.update_column(:state, "ready")
-          expect { shipment.ship! }.not_to raise_error
+          shipment.ship!
         end
       end
     end

--- a/core/spec/models/spree/stock_item_spec.rb
+++ b/core/spec/models/spree/stock_item_spec.rb
@@ -149,7 +149,7 @@ describe Spree::StockItem, :type => :model do
     before { Spree::StockMovement.create(stock_item: subject, quantity: 1) }
 
     it "doesnt raise ReadOnlyRecord error" do
-      expect { subject.destroy }.not_to raise_error
+      subject.destroy
     end
   end
 
@@ -157,9 +157,7 @@ describe Spree::StockItem, :type => :model do
     before { subject.destroy }
 
     it "recreates stock item just fine" do
-      expect {
-        stock_location.stock_items.create!(variant: subject.variant)
-      }.not_to raise_error
+      stock_location.stock_items.create!(variant: subject.variant)
     end
 
     it "doesnt allow recreating more than one stock item at once" do

--- a/core/spec/models/spree/taxon_spec.rb
+++ b/core/spec/models/spree/taxon_spec.rb
@@ -68,7 +68,7 @@ describe Spree::Taxon, :type => :model do
     let(:taxonomy) { create(:taxonomy) }
 
     it "does not error out" do
-      expect { taxonomy.root.children.unscoped.where(:name => "Some name").first_or_create }.not_to raise_error
+      taxonomy.root.children.unscoped.where(:name => "Some name").first_or_create
     end
   end
 end

--- a/core/spec/models/spree/unit_cancel_spec.rb
+++ b/core/spec/models/spree/unit_cancel_spec.rb
@@ -52,7 +52,7 @@ describe Spree::UnitCancel do
       let(:line_item) { create(:line_item) }
 
       it "raises an error" do
-        expect { subject }.to raise_error RuntimeError
+        expect { subject }.to raise_error RuntimeError, "Adjustable does not match line item"
       end
     end
 

--- a/frontend/spec/controllers/spree/checkout_controller_spec.rb
+++ b/frontend/spec/controllers/spree/checkout_controller_spec.rb
@@ -126,16 +126,14 @@ describe Spree::CheckoutController, :type => :controller do
 
         context "current_user doesnt respond to persist_order_address" do
           it "doesnt raise any error" do
-            expect {
-              spree_post :update, {
-                :state => "address",
-                :order => {
-                  :bill_address_attributes => address_params,
-                  :use_billing => true
-                },
-                :save_user_address => "1"
-              }
-            }.to_not raise_error
+            spree_post :update, {
+              :state => "address",
+              :order => {
+                :bill_address_attributes => address_params,
+                :use_billing => true
+              },
+              :save_user_address => "1"
+            }
           end
         end
       end

--- a/frontend/spec/controllers/spree/products_controller_spec.rb
+++ b/frontend/spec/controllers/spree/products_controller_spec.rb
@@ -30,7 +30,7 @@ describe Spree::ProductsController, :type => :controller do
     request.env['HTTP_REFERER'] = "not|a$url"
 
     # Previously a URI::InvalidURIError exception was being thrown
-    expect { spree_get :show, :id => product.to_param }.not_to raise_error
+    spree_get :show, :id => product.to_param
   end
 
 end

--- a/frontend/spec/features/currency_spec.rb
+++ b/frontend/spec/features/currency_spec.rb
@@ -12,7 +12,7 @@ describe "Switching currencies in backend", :type => :feature do
     click_button "Add To Cart"
     # Now that we have an order...
     Spree::Config[:currency] = "AUD"
-    expect { visit spree.root_path }.not_to raise_error
+    visit spree.root_path
   end
 
 end

--- a/frontend/spec/features/order_spec.rb
+++ b/frontend/spec/features/order_spec.rb
@@ -11,7 +11,7 @@ describe 'orders', :type => :feature do
 
   it "can visit an order" do
     # Regression test for current_user call on orders/show
-    expect { visit spree.order_path(order) }.not_to raise_error
+    visit spree.order_path(order)
   end
 
   it "should display line item price" do

--- a/frontend/spec/features/order_spec.rb
+++ b/frontend/spec/features/order_spec.rb
@@ -57,9 +57,7 @@ describe 'orders', :type => :feature do
 
     specify do
       visit spree.order_path(order)
-      within '.payment-info' do
-        expect { find("img") }.to raise_error(Capybara::ElementNotFound)
-      end
+      expect(find('.payment-info')).to have_no_css('img')
     end
   end
 

--- a/frontend/spec/features/products_spec.rb
+++ b/frontend/spec/features/products_spec.rb
@@ -134,10 +134,6 @@ describe "Visiting Products", type: :feature, inaccessible: true do
       variant.option_values << option_value
     end
 
-    it "should be displayed" do
-      expect { click_link product.name }.to_not raise_error
-    end
-
     it "displays price of first variant listed", js: true do
       click_link product.name
       within("#product-price") do

--- a/frontend/spec/views/spree/checkout/_summary_spec.rb
+++ b/frontend/spec/views/spree/checkout/_summary_spec.rb
@@ -4,8 +4,6 @@ describe "spree/checkout/_summary.html.erb", :type => :view do
   # Regression spec for #4223
   it "does not use the @order instance variable" do
     order = stub_model(Spree::Order)
-    expect do
-      render :partial => "spree/checkout/summary", :locals => {:order => order}
-    end.not_to raise_error
+    render :partial => "spree/checkout/summary", :locals => {:order => order}
   end
 end


### PR DESCRIPTION
* Removed cases of `expect{ ... }.not_to raise_error`, which does nothing, as errors already cause failures.
* Always assert for a message when we're rescuing from `RuntimeError`
* Use have_no_css instead of checking for ElementNotFound exception in one test