### PR TITLE
[WIP] Use attribute translations

### DIFF
--- a/backend/app/helpers/spree/admin/base_helper.rb
+++ b/backend/app/helpers/spree/admin/base_helper.rb
@@ -152,7 +152,7 @@ module Spree
         options[:class] = '' unless options[:class]
         options[:class] += 'no-text with-tip' if options[:no_text]
         url = f.object.persisted? ? [:admin, f.object] : '#'
-        link_to_with_icon('trash', name, url, :class => "spree_remove_fields #{options[:class]}", :data => {:action => 'remove'}, :title => Spree.t(:remove)) + f.hidden_field(:_destroy)
+        link_to_with_icon('trash', name, url, :class => "spree_remove_fields #{options[:class]}", :data => {:action => 'remove'}, :title => Spree.t('actions.remove')) + f.hidden_field(:_destroy)
       end
 
       def spree_dom_id(record)

--- a/backend/app/helpers/spree/admin/navigation_helper.rb
+++ b/backend/app/helpers/spree/admin/navigation_helper.rb
@@ -54,17 +54,17 @@ module Spree
       def link_to_edit(resource, options={})
         url = options[:url] || edit_object_url(resource)
         options[:data] = {:action => 'edit'}
-        link_to_with_icon('edit', Spree.t(:edit), url, options)
+        link_to_with_icon('edit', Spree.t('actions.edit'), url, options)
       end
 
       def link_to_edit_url(url, options={})
         options[:data] = {:action => 'edit'}
-        link_to_with_icon('edit', Spree.t(:edit), url, options)
+        link_to_with_icon('edit', Spree.t('actions.edit'), url, options)
       end
 
       def link_to_delete(resource, options={})
         url = options[:url] || object_url(resource)
-        name = options[:name] || Spree.t(:delete)
+        name = options[:name] || Spree.t('actions.delete')
         options[:class] = "delete-resource"
         options[:data] = { :confirm => Spree.t(:are_you_sure), :action => 'remove' }
         link_to_with_icon 'trash', name, url, options

--- a/backend/app/views/spree/admin/adjustment_reasons/index.html.erb
+++ b/backend/app/views/spree/admin/adjustment_reasons/index.html.erb
@@ -21,8 +21,8 @@
     </colgroup>
     <thead>
       <tr data-hook="adjustment_reasons_header">
-        <th><%= Spree.t(:name) %></th>
-        <th><%= Spree.t(:state) %></th>
+        <th><%= Spree::AdjustmentReason.human_attribute_name(:name) %></th>
+        <th><%= Spree::AdjustmentReason.human_attribute_name(:state) %></th>
         <th class="actions"></th>
       </tr>
     </thead>

--- a/backend/app/views/spree/admin/adjustment_reasons/shared/_form.html.erb
+++ b/backend/app/views/spree/admin/adjustment_reasons/shared/_form.html.erb
@@ -2,19 +2,19 @@
   <div class="row">
     <div class="alpha four columns">
       <%= f.field_container :name do %>
-        <%= f.label :name, Spree.t(:name) %> <span class="required">*</span><br />
+        <%= f.label :name %> <span class="required">*</span><br />
         <%= f.text_field :name, :class => 'fullwidth' %>
       <% end %>
 
       <%= f.field_container :code do %>
-        <%= f.label :code, Spree.t(:code) %> <span class="required">*</span><br />
+        <%= f.label :code %> <span class="required">*</span><br />
         <%= f.text_field :code, :class => 'fullwidth' %>
       <% end %>
 
       <div class="checkbox">
         <label>
           <%= f.check_box :active %>
-          <%= Spree.t(:active) %>
+          <%= Spree::AdjustmentReason.human_attribute_name(:active) %>
         </label>
       </div>
     </div>

--- a/backend/app/views/spree/admin/adjustments/_adjustments_table.html.erb
+++ b/backend/app/views/spree/admin/adjustments/_adjustments_table.html.erb
@@ -1,10 +1,10 @@
 <table class="index adjustments" data-hook="adjustments">
   <thead data-hook="adjustmment_head">
     <tr>
-      <th><%= Spree.t(:adjustable) %></th>
-      <th><%= Spree.t(:description) %></th>
-      <th><%= Spree.t(:amount) %></th>
-      <th><%= Spree.t(:state) %></th>
+      <th><%= Spree::Adjustment.human_attribute_name(:adjustable) %></th>
+      <th><%= Spree::Adjustment.human_attribute_name(:label) %></th>
+      <th><%= Spree::Adjustment.human_attribute_name(:amount) %></th>
+      <th><%= Spree::Adjustment.human_attribute_name(:state) %></th>
       <th class="actions"></th>
     </tr>
   </thead>

--- a/backend/app/views/spree/admin/adjustments/_form.html.erb
+++ b/backend/app/views/spree/admin/adjustments/_form.html.erb
@@ -1,7 +1,7 @@
 <div data-hook="admin_adjustment_form_fields" class="row">
   <div class="alpha three columns">
     <%= f.field_container :amount do %>
-      <%= f.label :amount, raw(Spree.t(:amount) + content_tag(:span, " *", :class => "required")) %>
+      <%= f.label :amount %> <span class="required">*</span>
       <%= text_field :adjustment, :amount, :class => 'fullwidth' %>
       <%= f.error_message_on :amount %>
     <% end %>
@@ -9,7 +9,7 @@
 
   <div class="six columns">
     <%= f.field_container :label do %>
-      <%= f.label :label, raw(Spree.t(:description) + content_tag(:span, " *", :class => "required")) %>
+      <%= f.label :label %> <span class="required">*</span>
       <%= text_field :adjustment, :label, :class => 'fullwidth' %>
       <%= f.error_message_on :label %>
     <% end %>
@@ -17,7 +17,7 @@
 
   <div class="omega three columns">
     <%= f.field_container :label do %>
-      <%= f.label :adjustment_reason_id, Spree.t(:reason) %><br/>
+      <%= f.label :adjustment_reason_id %><br/>
       <%= f.collection_select(:adjustment_reason_id, reasons_for(@adjustment), :id, :name, {include_blank: true}, {"data-placeholder" => Spree.t(:select_a_reason), class: 'select2 fullwidth'}) %>
     <% end %>
   </div>

--- a/backend/app/views/spree/admin/adjustments/edit.html.erb
+++ b/backend/app/views/spree/admin/adjustments/edit.html.erb
@@ -1,7 +1,7 @@
 <%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Adjustments' } %>
 
 <% content_for :page_title do %>
-  <i class="fa fa-arrow-right"></i> <%= Spree.t(:edit) %> <%= Spree.t(:adjustment) %>
+  <i class="fa fa-arrow-right"></i> <%= Spree.t('actions.edit') %> <%= Spree.t(:adjustment) %>
 <% end %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/cancellations/index.html.erb
+++ b/backend/app/views/spree/admin/cancellations/index.html.erb
@@ -13,11 +13,11 @@
   </colgroup>
 
   <thead>
-    <th colspan="2"><%= Spree.t(:item_description) %></th>
-    <th><%= Spree.t(:quantity) %></th>
-    <th><%= Spree.t(:state) %></th>
-    <th><%= Spree.t(:shipment) %></th>
-    <th><%= Spree.t(:cancel) %></th>
+    <th colspan="2"><%= Spree::LineItem.human_attribute_name(:description) %></th>
+    <th><%= Spree::OrderCancellations.human_attribute_name(:quantity) %></th>
+    <th><%= Spree::OrderCancellations.human_attribute_name(:state) %></th>
+    <th><%= Spree::OrderCancellations.human_attribute_name(:shipment) %></th>
+    <th><%= Spree::OrderCancellations.human_attribute_name(:cancel) %></th>
   </thead>
 
   <tbody>

--- a/backend/app/views/spree/admin/countries/_form.html.erb
+++ b/backend/app/views/spree/admin/countries/_form.html.erb
@@ -1,13 +1,13 @@
 <div data-hook="admin_country_form_fields" class="row">
   <div class="alpha four columns">
     <div data-hook="name" class="field">
-      <%= f.label :name, Spree.t(:name) %>
+      <%= f.label :name %>
       <%= f.text_field :name, :class => 'fullwidth' %>
     </div>
   </div>
   <div class="four columns">
     <div data-hook="iso_name" class="field">
-      <%= f.label :iso_name, Spree.t(:iso_name) %>
+      <%= f.label :iso_name %>
       <%= f.text_field :iso_name, :class => 'fullwidth' %>
     </div>
   </div>
@@ -15,7 +15,7 @@
     <div data-hook="states_required" class="field checkbox">
       <label>
         <%= f.check_box :states_required %>
-        <%= Spree.t(:states_required) %>
+        <%= Spree::Country.human_attribute_name(:states_required) %>
       </label>
     </div>
   </div>

--- a/backend/app/views/spree/admin/countries/index.html.erb
+++ b/backend/app/views/spree/admin/countries/index.html.erb
@@ -23,9 +23,9 @@
   </colgroup>
   <thead>
     <tr data-hook="tax_header">
-      <th><%= Spree.t(:country_name) %></th>
-      <th><%= Spree.t(:iso_name) %></th>
-      <th><%= Spree.t(:states_required) %></th>
+      <th><%= Spree::Country.human_attribute_name(:name) %></th>
+      <th><%= Spree::Country.human_attribute_name(:iso_name) %></th>
+      <th><%= Spree::Country.human_attribute_name(:states_required) %></th>
       <th class="actions"></th>
     </tr>
   </thead>

--- a/backend/app/views/spree/admin/customer_returns/_reimbursements_table.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/_reimbursements_table.html.erb
@@ -1,10 +1,10 @@
 <table class="index">
   <thead data-hook="customer_return_header">
     <tr>
-      <th><%= Spree.t(:number) %></th>
-      <th><%= Spree.t(:total) %></th>
-      <th><%= Spree.t(:status) %></th>
-      <th><%= "#{Spree.t('date')}/#{Spree.t('time')}" %></th>
+      <th><%= Spree::Reimbursement.human_attribute_name(:number) %></th>
+      <th><%= Spree::Reimbursement.human_attribute_name(:total) %></th>
+      <th><%= Spree::Reimbursement.human_attribute_name(:reimbursement_status) %></th>
+      <th><%= Spree::Reimbursement.human_attribute_name(:created_at) %></th>
       <th class="actions"></th>
     </tr>
   </thead>

--- a/backend/app/views/spree/admin/customer_returns/_return_item_decision.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/_return_item_decision.html.erb
@@ -2,12 +2,12 @@
   <thead>
     <tr>
       <th><%= Spree.t(:product) %></th>
-      <th><%= Spree.t(:sku) %></th>
-      <th><%= Spree.t(:pre_tax_amount) %></th>
-      <th><%= Spree.t(:preferred_reimbursement_type) %></th>
-      <th><%= Spree.t(:exchange_for) %></th>
-      <th><%= Spree.t(:acceptance_errors) %></th>
-      <th><%= Spree.t(:reception_status) %></th>
+      <th><%= Spree::Variant.human_attribute_name(:sku) %></th>
+      <th><%= Spree::ReturnItem.human_attribute_name(:pre_tax_amount) %></th>
+      <th><%= Spree::ReturnItem.human_attribute_name(:preferred_reimbursement_type) %></th>
+      <th><%= Spree::ReturnItem.human_attribute_name(:exchange_variant) %></th>
+      <th><%= Spree::ReturnItem.human_attribute_name(:acceptance_status_errors) %></th>
+      <th><%= Spree::ReturnItem.human_attribute_name(:reception_status) %></th>
       <% unless return_items.all?(&:received?)%>
         <th><%= Spree.t(:item_received?) %></th>
       <% end %>

--- a/backend/app/views/spree/admin/customer_returns/_return_item_selection.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/_return_item_selection.html.erb
@@ -5,13 +5,13 @@
         <%= check_box_tag 'select-all' %>
       </th>
       <th><%= Spree.t(:product) %></th>
-      <th><%= Spree.t(:sku) %></th>
-      <th><%= Spree.t(:pre_tax_amount) %></th>
-      <th><%= Spree.t(:state) %></th>
-      <th><%= Spree.t(:exchange_for) %></th>
-      <th><%= Spree.t(:resellable?) %></th>
-      <th><%= Spree.t(:reception_status) %></th>
-      <th><%= Spree.t(:reason) %></th>
+      <th><%= Spree::Variant.human_attribute_name(:sku) %></th>
+      <th><%= Spree::ReturnItem.human_attribute_name(:pre_tax_amount) %></th>
+      <th><%= Spree::ReturnItem.human_attribute_name(:inventory_unit_state) %></th>
+      <th><%= Spree::ReturnItem.human_attribute_name(:exchange_variant) %></th>
+      <th><%= Spree::ReturnItem.human_attribute_name(:resellable) %></th>
+      <th><%= Spree::ReturnItem.human_attribute_name(:reception_status) %></th>
+      <th><%= Spree::ReturnItem.human_attribute_name(:return_reason) %></th>
     </tr>
   </thead>
   <tbody>

--- a/backend/app/views/spree/admin/customer_returns/index.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/index.html.erb
@@ -17,11 +17,11 @@
   <table class="index">
     <thead data-hook="customer_return_header">
       <tr>
-        <th><%= Spree.t(:return_number) %></th>
-        <th><%= Spree.t(:pre_tax_total) %></th>
-        <th><%= Spree.t(:total) %></th>
-        <th><%= "#{Spree.t('date')}/#{Spree.t('time')}" %></th>
-        <th><%= Spree.t(:reimbursement_status) %></th>
+        <th><%= Spree::CustomerReturn.human_attribute_name(:number) %></th>
+        <th><%= Spree::CustomerReturn.human_attribute_name(:pre_tax_total) %></th>
+        <th><%= Spree::CustomerReturn.human_attribute_name(:total) %></th>
+        <th><%= Spree::CustomerReturn.human_attribute_name(:created_at) %></th>
+        <th><%= Spree::CustomerReturn.human_attribute_name(:reimbursement_status) %></th>
         <th class="actions"></th>
       </tr>
     </thead>

--- a/backend/app/views/spree/admin/customer_returns/new.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/new.html.erb
@@ -33,7 +33,7 @@
         </fieldset>
 
         <%= f.field_container :stock_location do %>
-          <%= f.label :stock_location, Spree.t(:stock_location) %>
+          <%= f.label :stock_location_id %>
           <%= f.select :stock_location_id, Spree::StockLocation.order_default.to_a.collect{|l|[l.name.humanize, l.id]}, {include_blank: true}, {class: 'select2 fullwidth', "data-placeholder" => Spree.t(:select_a_stock_location)} %>
           <%= f.error_message_on :stock_location_id %>
         <% end %>

--- a/backend/app/views/spree/admin/images/_form.html.erb
+++ b/backend/app/views/spree/admin/images/_form.html.erb
@@ -1,7 +1,7 @@
 <div data-hook="admin_image_form_fields">
   <div class="four columns alpha">
     <div data-hook="file" class="field">
-      <%= f.label :attachment, Spree.t(:filename) %><br>
+      <%= f.label :attachment %><br>
       <%= f.file_field :attachment %>
     </div>
     <div data-hook="variant" class="field">
@@ -10,7 +10,7 @@
     </div>
   </div>
   <div data-hook="alt_text" class="field omega five columns">
-    <%= f.label :alt, Spree.t(:alt_text) %><br>
+    <%= f.label :alt %><br>
     <%= f.text_area :alt, rows: 4, class: 'fullwidth' %>
   </div>
 </div>

--- a/backend/app/views/spree/admin/images/index.html.erb
+++ b/backend/app/views/spree/admin/images/index.html.erb
@@ -53,7 +53,7 @@
           <td><%= image.alt %></td>
           <td class="actions">
             <% if can?(:update, image) %>
-              <%= link_to_with_icon 'edit', Spree.t(:edit), edit_admin_product_image_url(@product, image), :no_text => true, :data => {:action => 'edit'} %>
+              <%= link_to_with_icon 'edit', Spree.t('actions.edit'), edit_admin_product_image_url(@product, image), :no_text => true, :data => {:action => 'edit'} %>
             <% end %>
             <% if can?(:destroy, image) %>
               <%= link_to_delete image, { :url => admin_product_image_url(@product, image), :no_text => true } %>

--- a/backend/app/views/spree/admin/images/index.html.erb
+++ b/backend/app/views/spree/admin/images/index.html.erb
@@ -31,7 +31,7 @@
         <% if @product.has_variants? %>
           <th><%= Spree::Variant.model_name.human %></th>
         <% end %>
-        <th><%= Spree.t(:alt_text) %></th>
+        <th><%= Spree::Image.human_attribute_name(:alt) %></th>
         <th class="actions"></th>
       </tr>
     </thead>

--- a/backend/app/views/spree/admin/log_entries/index.html.erb
+++ b/backend/app/views/spree/admin/log_entries/index.html.erb
@@ -2,7 +2,7 @@
 
 <% content_for :page_title do %>
   <i class="fa fa-arrow-right"></i>
-  <%= I18n.t(:one, scope: "activerecord.models.spree/payment") %>
+  <%= Spree::Payment.model_name.human %>
   <i class="fa fa-arrow-right"></i>
   <%= Spree.t(:log_entries) %>
 <% end %>

--- a/backend/app/views/spree/admin/option_types/_form.html.erb
+++ b/backend/app/views/spree/admin/option_types/_form.html.erb
@@ -1,7 +1,7 @@
 <div data-hook="admin_option_type_form_fields" class="align-center row">
   <div class="alpha eight columns">
     <%= f.field_container :name do %>
-      <%= f.label :name, Spree.t(:name) %> <span class="required">*</span><br />
+      <%= f.label :name %> <span class="required">*</span><br />
       <%= f.text_field :name, :class => "fullwidth" %>
       <%= f.error_message_on :name %>
     <% end %>
@@ -9,7 +9,7 @@
 
   <div class="omega eight columns">
     <%= f.field_container :presentation do %>
-      <%= f.label :presentation, Spree.t(:presentation) %> <span class="required">*</span><br />
+      <%= f.label :presentation %> <span class="required">*</span><br />
       <%= f.text_field :presentation, :class => "fullwidth" %>
       <%= f.error_message_on :presentation %>
     <% end %>

--- a/backend/app/views/spree/admin/option_types/_option_value_fields.html.erb
+++ b/backend/app/views/spree/admin/option_types/_option_value_fields.html.erb
@@ -7,5 +7,5 @@
   <% end %>
   <td colspan="<%= f.object.persisted? ? '' : '2' %>" class="name"><%= f.text_field :name %></td>
   <td class="presentation"><%= f.text_field :presentation %></td>
-  <td class="actions"><%= link_to_remove_fields Spree.t(:remove), f, :no_text => true %></td>
+  <td class="actions"><%= link_to_remove_fields Spree.t('actions.remove'), f, :no_text => true %></td>
 </tr>

--- a/backend/app/views/spree/admin/option_types/edit.html.erb
+++ b/backend/app/views/spree/admin/option_types/edit.html.erb
@@ -8,7 +8,7 @@
   <li>
     <span id="new_add_option_value" data-hook>
       <%= link_to_add_fields Spree.t(:add_option_value), "tbody#option_values", :class => 'button fa fa-plus' %>
-    </span>      
+    </span>
   </li>
   <li>
     <%= button_link_to Spree.t(:back_to_option_types_list), spree.admin_option_types_path, :icon => 'arrow-left' %>
@@ -20,14 +20,14 @@
 <%= form_for [:admin, @option_type] do |f| %>
   <fieldset>
     <legend align="center"><%= Spree.t(:option_values) %></legend>
-    
+
     <%= render :partial => 'form', :locals => { :f => f } %>
 
     <table class="index sortable" data-hook data-sortable-link="<%= update_values_positions_admin_option_types_url %>">
       <thead data-hook="option_header">
         <tr>
-          <th colspan="2"><%= Spree.t(:name) %></th>
-          <th><%= Spree.t(:display) %></th>
+          <th colspan="2"><%= Spree::OptionValue.human_attribute_name(:name) %></th>
+          <th><%= Spree::OptionValue.human_attribute_name(:presentation) %></th>
           <th class="actions"></th>
         </tr>
       </thead>

--- a/backend/app/views/spree/admin/option_types/index.html.erb
+++ b/backend/app/views/spree/admin/option_types/index.html.erb
@@ -25,8 +25,8 @@
   <thead>
     <tr data-hook="option_header">
       <th class="no-border"></th>
-      <th><%= Spree.t(:name) %></th>
-      <th><%= Spree.t(:presentation) %></th>
+      <th><%= Spree::OptionType.human_attribute_name(:name) %></th>
+      <th><%= Spree::OptionType.human_attribute_name(:presentation) %></th>
       <th class="actions"></th>
     </tr>
   </thead>

--- a/backend/app/views/spree/admin/orders/_adjustments.html.erb
+++ b/backend/app/views/spree/admin/orders/_adjustments.html.erb
@@ -3,8 +3,8 @@
     <legend><%= title %></legend>
     <table>
       <thead>
-        <th><%= Spree.t('name')%></th>
-        <th><%= Spree.t('amount')%></th>
+        <th><%= Spree::Adjustment.human_attribute_name(:name)%></th>
+        <th><%= Spree::Adjustment.human_attribute_name(:amount)%></th>
       </thead>
       <tbody id="order-charges" data-hook="order_details_adjustments"  class="with-border">
         <% adjustments.eligible.group_by(&:label).each do |label, adjustments| %>

--- a/backend/app/views/spree/admin/orders/_carton.html.erb
+++ b/backend/app/views/spree/admin/orders/_carton.html.erb
@@ -20,10 +20,10 @@
     </colgroup>
 
     <thead>
-      <th colspan="2"><%= Spree.t(:item_description) %></th>
-      <th><%= Spree.t(:price) %></th>
-      <th><%= Spree.t(:quantity) %></th>
-      <th><%= Spree.t(:total) %></th>
+      <th colspan="2"><%= Spree::LineItem.human_attribute_name(:description) %></th>
+      <th><%= Spree::LineItem.human_attribute_name(:price) %></th>
+      <th><%= Spree::LineItem.human_attribute_name(:quantity) %></th>
+      <th><%= Spree::LineItem.human_attribute_name(:total) %></th>
     </thead>
 
     <tbody data-hook="carton-details" data-shipment-number="<%= carton.number %>" data-order-number="<%= order.number %>">

--- a/backend/app/views/spree/admin/orders/_carton_manifest.html.erb
+++ b/backend/app/views/spree/admin/orders/_carton_manifest.html.erb
@@ -6,7 +6,8 @@
     <td class="item-name">
       <%= item.variant.product.name %><br><%= "(" + variant_options(item.variant) + ")" unless item.variant.option_values.empty? %>
       <% if item.variant.sku.present? %>
-        <strong><%= Spree.t(:sku) %>:</strong> <%= item.variant.sku %>
+        <strong><%= Spree::Variant.human_attribute_name(:sku) %>:</strong>
+        <%= item.variant.sku %>
       <% end %>
     </td>
     <td class="item-price align-center"><%= item.line_item.single_money.to_html %></td>

--- a/backend/app/views/spree/admin/orders/_carton_manifest.html.erb
+++ b/backend/app/views/spree/admin/orders/_carton_manifest.html.erb
@@ -13,7 +13,7 @@
     <td class="item-price align-center"><%= item.line_item.single_money.to_html %></td>
     <td class="item-qty-show align-center">
         <% item.states.each do |state,count| %>
-          <%= count %> x <%= Spree.t(state).downcase %>
+          <%= count %> x <%= Spree.t(state, scope: 'inventory_states') %>
         <% end %>
     </td>
     <td class="item-qty-edit hidden">

--- a/backend/app/views/spree/admin/orders/_line_items.html.erb
+++ b/backend/app/views/spree/admin/orders/_line_items.html.erb
@@ -8,10 +8,10 @@
     </colgroup>
 
     <thead>
-      <th colspan="2"><%= Spree.t(:name) %></th>
-      <th><%= Spree.t(:price) %></th>
-      <th><%= Spree.t(:quantity) %></th>
-      <th><%= Spree.t(:total_price) %></th>
+      <th colspan="2"><%= Spree::Product.human_attribute_name(:name) %></th>
+      <th><%= Spree::LineItem.human_attribute_name(:price) %></th>
+      <th><%= Spree::LineItem.human_attribute_name(:quantity) %></th>
+      <th><%= Spree::LineItem.human_attribute_name(:total) %></th>
       <th class="orders-actions actions" data-hook="admin_order_form_line_items_header_actions">&nbsp;</th>
     </thead>
 
@@ -22,7 +22,7 @@
           <td class="line-item-name">
             <%= item.variant.product.name %><br><%= "(" + variant_options(item.variant) + ")" unless item.variant.option_values.empty? %>
             <% if item.variant.sku.present? %>
-              <strong><%= Spree.t(:sku) %>:</strong> <%= item.variant.sku %>
+              <strong><%= Spree::Variant.human_attribute_name(:sku) %>:</strong> <%= item.variant.sku %>
             <% end %>
           </td>
           <td class="line-item-price align-center"><%= item.single_money.to_html %></td>

--- a/backend/app/views/spree/admin/orders/_line_items.html.erb
+++ b/backend/app/views/spree/admin/orders/_line_items.html.erb
@@ -37,8 +37,8 @@
             <% if can? :update, item %>
               <%= link_to '', '#', :class => 'save-line-item fa fa-ok no-text with-tip',       :title => Spree.t('actions.save') %>
               <%= link_to '', '#', :class => 'cancel-line-item fa fa-cancel no-text with-tip', :title => Spree.t('actions.cancel') %>
-              <%= link_to '', '#', :class => 'edit-line-item fa fa-edit no-text with-tip',     :title => Spree.t('edit') %>
-              <%= link_to '', '#', :class => 'delete-line-item fa fa-trash no-text with-tip',  :title => Spree.t('delete') %>
+              <%= link_to '', '#', :class => 'edit-line-item fa fa-edit no-text with-tip',     :title => Spree.t('actions.edit') %>
+              <%= link_to '', '#', :class => 'delete-line-item fa fa-trash no-text with-tip',  :title => Spree.t('actions.delete') %>
             <% end %>
           </td>
         <% end %>

--- a/backend/app/views/spree/admin/orders/_shipment.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment.html.erb
@@ -16,7 +16,7 @@
           <%= hidden_field_tag :send_mailer, false %>
           <%= check_box_tag :send_mailer, true, true %>
           <%= label_tag :send_mailer, Spree.t(:send_mailer) %>
-          <%= submit_tag Spree.t(:ship), class: "ship-shipment-button" %>
+          <%= submit_tag Spree.t('actions.ship'), class: "ship-shipment-button" %>
         <% end %>
       <% end %>
     </fieldset>
@@ -77,7 +77,7 @@
 
             <td class="actions">
               <% if( (can? :update, shipment) and !shipment.shipped?) %>
-                <%= link_to '', '#', :class => 'edit-method fa fa-edit no-text with-tip', :data => {:action => 'edit'}, :title => Spree.t('edit') %>
+                <%= link_to '', '#', :class => 'edit-method fa fa-edit no-text with-tip', :data => {:action => 'edit'}, :title => Spree.t('actions.edit') %>
               <% end %>
             </td>
           </tr>
@@ -113,7 +113,7 @@
           </td>
           <td class="actions">
             <% if can? :update, shipment %>
-              <%= link_to '', '#', :class => 'edit-tracking fa fa-edit no-text with-tip', :data => {:action => 'edit'}, :title => Spree.t('edit') %>
+              <%= link_to '', '#', :class => 'edit-tracking fa fa-edit no-text with-tip', :data => {:action => 'edit'}, :title => Spree.t('actions.edit') %>
             <% end %>
           </td>
         </tr>

--- a/backend/app/views/spree/admin/orders/_shipment.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment.html.erb
@@ -32,10 +32,10 @@
       </colgroup>
 
       <thead>
-        <th colspan="2"><%= Spree.t(:item_description) %></th>
-        <th><%= Spree.t(:price) %></th>
-        <th><%= Spree.t(:quantity) %></th>
-        <th><%= Spree.t(:total) %></th>
+        <th colspan="2"><%= Spree::LineItem.human_attribute_name(:description) %></th>
+        <th><%= Spree::LineItem.human_attribute_name(:price) %></th>
+        <th><%= Spree::LineItem.human_attribute_name(:quantity) %></th>
+        <th><%= Spree::LineItem.human_attribute_name(:total) %></th>
         <th class="orders-actions actions" data-hook="admin_order_form_line_items_header_actions"></th>
       </thead>
 
@@ -46,7 +46,7 @@
           <tr class="edit-method hidden total">
             <td colspan="5">
               <div class="field alpha five columns">
-                <%= label_tag 'selected_shipping_rate_id', Spree.t(:shipping_method) %>
+                <%= label_tag 'selected_shipping_rate_id', Spree::ShippingMethod.model_name.human %>
                 <%= select_tag :selected_shipping_rate_id,
                       options_for_select(shipment.shipping_rates.map {|sr| ["#{sr.name} #{sr.display_price}", sr.id] }, shipment.selected_shipping_rate_id),
                       {:class => 'select2 fullwidth', :data => {'shipment-number' => shipment.number } } %>

--- a/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
@@ -6,7 +6,7 @@
     <td class="item-name">
       <%= item.variant.product.name %><br><%= "(" + variant_options(item.variant) + ")" unless item.variant.option_values.empty? %>
       <% if item.variant.sku.present? %>
-        <strong><%= Spree.t(:sku) %>:</strong> <%= item.variant.sku %>
+        <strong><%= Spree::Variant.human_attribute_name(:sku) %>:</strong> <%= item.variant.sku %>
       <% end %>
     </td>
     <td class="item-price align-center"><%= item.line_item.single_money.to_html %></td>

--- a/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
@@ -24,8 +24,8 @@
       <% if can? :update, item %>
         <%= link_to '', '#', :class => 'save-item fa fa-check no-text with-tip', :data => {'shipment-number' => shipment_number, 'variant-id' => item.variant.id, :action => 'save'}, :title => Spree.t('actions.save'), :style => 'display: none' %>
         <%= link_to '', '#', :class => 'cancel-item fa fa-cancel no-text with-tip', :data => {:action => 'cancel'}, :title => Spree.t('actions.cancel'), :style => 'display: none' %>
-        <%= link_to '', '#', :class => 'split-item icon_link fa fa-arrows-h no-text with-tip', :data => {:action => 'split', 'variant-id' => item.variant.id}, :title => Spree.t('split') %>
-        <%= link_to '', '#', :class => 'delete-item fa fa-trash no-text with-tip', :data => { 'line-item-id' => item.line_item.id}, :title => Spree.t('delete') %>
+        <%= link_to '', '#', :class => 'split-item icon_link fa fa-arrows-h no-text with-tip', :data => {:action => 'split', 'variant-id' => item.variant.id}, :title => Spree.t('actions.split') %>
+        <%= link_to '', '#', :class => 'delete-item fa fa-trash no-text with-tip', :data => { 'line-item-id' => item.line_item.id}, :title => Spree.t('actions.delete') %>
       <% end %>
     </td>
   </tr>

--- a/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
@@ -12,7 +12,7 @@
     <td class="item-price align-center"><%= item.line_item.single_money.to_html %></td>
     <td class="item-qty-show align-center">
         <% item.states.each do |state,count| %>
-          <%= count %> x <%= Spree.t(state).downcase %>
+          <%= count %> x <%= Spree.t(state, scope: 'inventory_states') %>
         <% end %>
     </td>
     <td class="item-qty-edit hidden">

--- a/backend/app/views/spree/admin/orders/confirm/_shipment.html.erb
+++ b/backend/app/views/spree/admin/orders/confirm/_shipment.html.erb
@@ -11,11 +11,11 @@
   <table class="stock-contents index" data-hook="stock-contents">
     <thead>
       <th colspan="2">
-        <%= Spree.t(:item_description) %>
+        <%= Spree::LineItem.human_attribute_name(:description) %>
       </th>
-      <th><%= Spree.t(:price) %></th>
-      <th><%= Spree.t(:quantity) %></th>
-      <th><%= Spree.t(:total) %></th>
+      <th><%= Spree::LineItem.human_attribute_name(:price) %></th>
+      <th><%= Spree::LineItem.human_attribute_name(:quantity) %></th>
+      <th><%= Spree::LineItem.human_attribute_name(:total) %></th>
     </thead>
 
     <tbody data-shipment-number="<%= shipment.number %>" data-order-number="<%= order.number %>">

--- a/backend/app/views/spree/admin/orders/confirm/_shipment_manifest.html.erb
+++ b/backend/app/views/spree/admin/orders/confirm/_shipment_manifest.html.erb
@@ -12,7 +12,7 @@
     <td class="item-price align-center"><%= item.line_item.single_money.to_html %></td>
     <td class="item-qty-show align-center">
         <% item.states.each do |state,count| %>
-          <%= count %> x <%= Spree.t(state).downcase %>
+          <%= count %> x <%= Spree.t(state, scope: 'inventory_states') %>
         <% end %>
     </td>
     <td class="item-total align-center"><%= line_item_shipment_price(item.line_item, item.quantity) %></td>

--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -115,18 +115,18 @@
     <thead>
       <tr data-hook="admin_orders_index_headers">
         <% if @show_only_completed %>
-          <th><%= sort_link @search, :completed_at,   I18n.t(:completed_at, :scope => 'activerecord.attributes.spree/order') %></th>
+          <th><%= sort_link @search, :completed_at %></th>
         <% else %>
-          <th><%= sort_link @search, :created_at,     I18n.t(:created_at, :scope => 'activerecord.attributes.spree/order') %></th>
+          <th><%= sort_link @search, :created_at %></th>
         <% end %>
-        <th><%= sort_link @search, :number,           I18n.t(:number, :scope => 'activerecord.attributes.spree/order') %></th>
-        <th><%= sort_link @search, :state,            I18n.t(:state, :scope => 'activerecord.attributes.spree/order') %></th>
-        <th><%= sort_link @search, :payment_state,    I18n.t(:payment_state, :scope => 'activerecord.attributes.spree/order') %></th>
-         <% if Spree::Order.checkout_step_names.include?(:delivery) %>
-          <th><%= sort_link @search, :shipment_state, I18n.t(:shipment_state, :scope => 'activerecord.attributes.spree/order') %></th>
-         <% end %>
-        <th><%= sort_link @search, :email,            I18n.t(:email, :scope => 'activerecord.attributes.spree/order') %></th>
-        <th><%= sort_link @search, :total,            I18n.t(:total, :scope => 'activerecord.attributes.spree/order') %></th>
+        <th><%= sort_link @search, :number %></th>
+        <th><%= sort_link @search, :state %></th>
+        <th><%= sort_link @search, :payment_state %></th>
+        <% if Spree::Order.checkout_step_names.include?(:delivery) %>
+          <th><%= sort_link @search, :shipment_state %></th>
+        <% end %>
+        <th><%= sort_link @search, :email %></th>
+        <th><%= sort_link @search, :total %></th>
         <th data-hook="admin_orders_index_header_actions" class="actions"></th>
       </tr>
     </thead>

--- a/backend/app/views/spree/admin/promotions/_actions.html.erb
+++ b/backend/app/views/spree/admin/promotions/_actions.html.erb
@@ -10,7 +10,7 @@
           <%= select_tag 'action_type', options, :class => 'select2 fullwidth' %>
         </div>
         <div class="filter-actions actions">
-          <%= button Spree.t(:add), 'plus' %>
+          <%= button Spree.t('actions.add), 'plus' %>
         </div>
       <% end %>
     </fieldset>

--- a/backend/app/views/spree/admin/promotions/_rules.html.erb
+++ b/backend/app/views/spree/admin/promotions/_rules.html.erb
@@ -10,7 +10,7 @@
           <%= select_tag('promotion_rule[type]', options_for_promotion_rule_types(@promotion), :class => 'select2 fullwidth') %>
         </div>
         <div class="filter-actions actions">
-          <%= button Spree.t(:add), 'plus' %>
+          <%= button Spree.t('actions.add), 'plus' %>
         </div>
       <% end %>
     </fieldset>

--- a/backend/app/views/spree/admin/promotions/calculators/tiered_flat_rate/_fields.html.erb
+++ b/backend/app/views/spree/admin/promotions/calculators/tiered_flat_rate/_fields.html.erb
@@ -11,4 +11,4 @@
   'form-prefix' => prefix,
   'calculator' => 'tiered_flat_rate'
 } %>
-<button class="fa fa-plus button js-add-tier"><%= Spree.t(:add) %></button>
+<button class="fa fa-plus button js-add-tier"><%= Spree.t('actions.add) %></button>

--- a/backend/app/views/spree/admin/promotions/calculators/tiered_percent/_fields.html.erb
+++ b/backend/app/views/spree/admin/promotions/calculators/tiered_percent/_fields.html.erb
@@ -11,4 +11,4 @@
   'form-prefix' => prefix,
   'calculator' => 'tiered_percent'
 } %>
-<button class="fa fa-plus button js-add-tier"><%= Spree.t(:add) %></button>
+<button class="fa fa-plus button js-add-tier"><%= Spree.t('actions.add) %></button>

--- a/backend/app/views/spree/admin/promotions/rules/_option_value.html.erb
+++ b/backend/app/views/spree/admin/promotions/rules/_option_value.html.erb
@@ -6,7 +6,7 @@
 
   <div class="js-promo-rule-option-values"></div>
 
-  <button class="fa fa-plus button js-add-promo-rule-option-value"><%= Spree.t(:add) %></button>
+  <button class="fa fa-plus button js-add-promo-rule-option-value"><%= Spree.t('actions.add) %></button>
 </div>
 
 <%= content_tag :div, nil, class: "hidden js-original-promo-rule-option-values",

--- a/backend/app/views/spree/admin/shared/_refunds.html.erb
+++ b/backend/app/views/spree/admin/shared/_refunds.html.erb
@@ -23,7 +23,7 @@
         <td class="align-center"><%= truncate(refund.reason.name, length: 100) %></td>
         <% if show_actions %>
           <td class="actions">
-            <%= link_to_with_icon 'edit', Spree.t(:edit), edit_admin_order_payment_refund_path(refund.payment.order, refund.payment, refund), no_text: true %>
+            <%= link_to_with_icon 'edit', Spree.t('actions.edit'), edit_admin_order_payment_refund_path(refund.payment.order, refund.payment, refund), no_text: true %>
           </td>
         <% end %>
       </tr>

--- a/backend/app/views/spree/admin/shared/_show_resource_links.html.erb
+++ b/backend/app/views/spree/admin/shared/_show_resource_links.html.erb
@@ -1,5 +1,0 @@
-<p class="actions" data-hook="actions">
-  <%= link_to Spree.t('actions.edit'), edit_object_url %> |
-  <%= link_to Spree.t(:back), collection_url %> |
-  <%= link_to Spree.t('actions.delete'), object_url, :method => :delete, :data => { :confirm => Spree.t(:are_you_sure_delete) } %>
-</p>

--- a/backend/app/views/spree/admin/shared/_show_resource_links.html.erb
+++ b/backend/app/views/spree/admin/shared/_show_resource_links.html.erb
@@ -1,5 +1,5 @@
 <p class="actions" data-hook="actions">
-  <%= link_to Spree.t(:edit), edit_object_url %> |
+  <%= link_to Spree.t('actions.edit'), edit_object_url %> |
   <%= link_to Spree.t(:back), collection_url %> |
-  <%= link_to Spree.t(:delete), object_url, :method => :delete, :data => { :confirm => Spree.t(:are_you_sure_you_want_to_delete_this_record) } %>
+  <%= link_to Spree.t('actions.delete'), object_url, :method => :delete, :data => { :confirm => Spree.t(:are_you_sure_delete) } %>
 </p>

--- a/backend/app/views/spree/admin/states/_state_list.html.erb
+++ b/backend/app/views/spree/admin/states/_state_list.html.erb
@@ -18,7 +18,7 @@
         <td class="align-center"><%= state.abbr %></td>
         <td class="actions">
           <% if can?(:update, state) %>
-            <%= link_to_with_icon 'edit', Spree.t(:edit), edit_admin_country_state_url(@country, state), :no_text => true %>
+            <%= link_to_with_icon 'edit', Spree.t('actions.edit'), edit_admin_country_state_url(@country, state), :no_text => true %>
           <% end %>
           <% if can?(:destroy, state) %>
             <%= link_to_delete state, :no_text => true %>

--- a/backend/app/views/spree/admin/stock_transfers/_transfer_item_actions.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/_transfer_item_actions.html.erb
@@ -2,7 +2,7 @@
   <%= render partial: 'spree/admin/shared/number_field_update_cell', locals: { resource_id: item.id, field_tag: "#{quantity_type}_quantity", number_value: item.send("#{quantity_type}_quantity") } %>
   <td class="actions">
     <%= render partial: 'spree/admin/shared/number_field_update_actions', locals: { resource: item, update_data: {} } %>
-    <%= link_to_with_icon 'trash', Spree.t('delete'), '#', no_text: true, data: { action: 'remove', id: item.id } if quantity_type == 'expected' && can?(:destroy, item) %>
+    <%= link_to_with_icon 'trash', Spree.t('actions.delete'), '#', no_text: true, data: { action: 'remove', id: item.id } if quantity_type == 'expected' && can?(:destroy, item) %>
   </td>
 <% else %>
   <td class='align-center'><%= item.send("#{quantity_type}_quantity") %></td>

--- a/backend/app/views/spree/admin/store_credits/show.html.erb
+++ b/backend/app/views/spree/admin/store_credits/show.html.erb
@@ -49,7 +49,7 @@
     </td>
     <td class='actions align-center'>
       <% if can?(:update, @store_credit) %>
-        <%= link_to '', '#', class: 'js-edit-memo edit-method fa fa-edit no-text with-tip', data: { action: 'edit' }, title: Spree.t('edit') %>
+        <%= link_to '', '#', class: 'js-edit-memo edit-method fa fa-edit no-text with-tip', data: { action: 'edit' }, title: Spree.t('actions.edit') %>
       <% end %>
     </td>
   </tr>

--- a/backend/app/views/spree/admin/taxons/_taxon_table.html.erb
+++ b/backend/app/views/spree/admin/taxons/_taxon_table.html.erb
@@ -12,7 +12,7 @@
         <td><%= taxon.name %></td>
         <td><%= taxon_path taxon %></td>
         <td class="actions">
-          <%= link_to_delete taxon, :url => remove_admin_product_taxon_url(@product, taxon), :name => icon('delete') + ' ' + Spree.t(:remove) %>
+          <%= link_to_delete taxon, :url => remove_admin_product_taxon_url(@product, taxon), :name => icon('delete') + ' ' + Spree.t('actions.remove') %>
         </td>
       </tr>
     <% end %>

--- a/core/app/models/spree/order_cancellations.rb
+++ b/core/app/models/spree/order_cancellations.rb
@@ -1,5 +1,6 @@
 # This class represents all of the actions one can take to modify an Order after it is complete
 class Spree::OrderCancellations
+  extend ActiveModel::Translation
 
   # If you need to message a third party service when an item is canceled then
   # set short_ship_tax_notifier to an object that responds to:

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -11,6 +11,17 @@ en:
         phone: Phone
         state: State
         zipcode: Zip Code
+      spree/adjustment:
+        adjustable: Adjustable
+        amount: Amount
+        label: Description
+        state: State
+        adjustment_reason_id: Reason
+      spree/adjustment_reason:
+        active: Active
+        code: Code
+        name: Name
+        state: State
       spree/calculator/tiered_flat_rate:
         preferred_base_amount: Base Amount
         preferred_tiers: Tiers

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -432,16 +432,12 @@ en:
     account_updated: Account updated
     action: Action
     actions:
+      add: Add
       cancel: Cancel
       continue: Continue
       create: Create
       delete: Delete
-      destroy: Destroy
       edit: Edit
-      list: List
-      listing: Listing
-      new: New
-      refund: Refund
       receive: Receive
       save: Save
       update: Update
@@ -449,7 +445,6 @@ en:
       ship: ship
     activate: Activate
     active: Active
-    add: Add
     added: Added
     add_action_of_type: Add action of type
     add_country: Add Country

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -41,6 +41,7 @@ en:
         iso_name: ISO Name
         name: Name
         numcode: ISO Code
+        states_required: States Required
       spree/credit_card:
         base: ''
         cc_type: Type
@@ -668,7 +669,6 @@ en:
     countries: Countries
     country: Country
     country_based: Country Based
-    country_name: Name
     country_names:
       CA: Canada
       FRA: France

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -435,6 +435,7 @@ en:
       cancel: Cancel
       continue: Continue
       create: Create
+      delete: Delete
       destroy: Destroy
       edit: Edit
       list: List
@@ -444,6 +445,8 @@ en:
       receive: Receive
       save: Save
       update: Update
+      split: Split
+      ship: ship
     activate: Activate
     active: Active
     add: Add
@@ -752,7 +755,6 @@ en:
     default_refund_amount: Default Refund Amount
     default_tax: Default Tax
     default_tax_zone: Default Tax Zone
-    delete: Delete
     deleted_variants_present: Some line items in this order have products that are no longer available.
     deleted_successfully: Deleted successfully
     delivery: Delivery
@@ -766,7 +768,6 @@ en:
     dismiss_banner: No. Thanks! I'm not interested, do not display this message again
     display: Display
     download_promotion_code_list: Download Code List
-    edit: Edit
     editing_country: Editing Country
     editing_adjustment_reason: Editing Adjustment Reason
     editing_option_type: Editing Option Type
@@ -1449,7 +1450,6 @@ en:
     source: Source
     source_location: Source location
     special_instructions: Special Instructions
-    split: Split
     spree_gateway_error_flash_for_checkout: There was a problem with your payment information. Please check your information and try again.
     ssl:
       change_protocol: "Please switch to using HTTP (rather than HTTPS) and retry this request."

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -66,6 +66,7 @@ en:
         description: Item Description
         price: Price
         quantity: Quantity
+        total: Total price
       spree/option_type:
         name: Name
         presentation: Presentation
@@ -1559,7 +1560,6 @@ en:
     total: Total
     total_per_item: Total per item
     total_pre_tax_refund: Total Pre-Tax Refund
-    total_price: Total price
     total_sales: Total Sales
     track_inventory: Track Inventory
     tracking: Tracking

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -69,6 +69,9 @@ en:
       spree/option_type:
         name: Name
         presentation: Presentation
+      spree/option_value:
+        name: Name
+        presentation: Presentation
       spree/order:
         checkout_complete: Checkout Complete
         completed_at: Completed At

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1,4 +1,11 @@
 en:
+  activemodel:
+    attributes:
+      spree/order_cancellations:
+        quantity: Quantity
+        state: State
+        shipment: Shipment
+        cancel: Cancel
   activerecord:
     attributes:
       spree/address:
@@ -45,6 +52,7 @@ en:
       spree/inventory_unit:
         state: State
       spree/line_item:
+        description: Item Description
         price: Price
         quantity: Quantity
       spree/option_type:
@@ -909,7 +917,6 @@ en:
     is_not_available_to_shipment_address: is not available to shipment address
     iso_name: Iso Name
     item: Item
-    item_description: Item Description
     item_not_in_stock_transfer: Item is not part of the stock transfer
     item_total: Item Total
     item_total_rule:

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -935,6 +935,12 @@ en:
     inventory_canceled: Inventory canceled
     inventory_error_flash_for_insufficient_quantity: An item in your cart has become unavailable.
     inventory_state: Inventory State
+    inventory_states:
+      backordered: backordered
+      canceled: canceled
+      on_hand: on hand
+      returned: returned
+      shipped: shipped
     is_not_available_to_shipment_address: is not available to shipment address
     iso_name: Iso Name
     item: Item

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -439,6 +439,7 @@ en:
       delete: Delete
       edit: Edit
       receive: Receive
+      remove: Remove
       save: Save
       update: Update
       split: Split
@@ -1316,7 +1317,6 @@ en:
     reject: Reject
     rejected: Rejected
     remember_me: Remember me
-    remove: Remove
     rename: Rename
     reports: Reports
     resend: Resend

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -50,6 +50,13 @@ en:
         verification_value: Verification Value
         year: Year
         name: Name
+      spree/customer_return:
+        number: Return Number
+        pre_tax_total: Pre-Tax Total
+        total: Total
+        created_at: "Date/Time"
+        reimbursement_status: Reimbursement status
+        stock_location_id: Stock Location
       spree/inventory_unit:
         state: State
       spree/line_item:
@@ -121,8 +128,23 @@ en:
         presentation: Presentation
       spree/prototype:
         name: Name
+      spree/reimbursement:
+        created_at: "Date/Time"
+        number: Number
+        reimbursement_status: Status
+        total: Total
       spree/return_authorization:
         amount: Amount
+      spree/return_item:
+        acceptance_status: Acceptance status
+        acceptance_status_errors: Acceptance errors
+        exchange_variant: Exchange for
+        inventory_unit_state: State
+        pre_tax_amount: Pre-Tax Amount
+        preferred_reimbursement_type: Preferred Reimbursement Type
+        reception_status: Reception Status
+        resellable: "Resellable?"
+        return_reason: Reason
       spree/role:
         name: Name
       spree/state:
@@ -402,8 +424,6 @@ en:
   spree:
     abbreviation: Abbreviation
     accept: Accept
-    acceptance_status: Acceptance status
-    acceptance_errors: Acceptance errors
     accepted: Accepted
     account: Account
     account_updated: Account updated
@@ -819,7 +839,6 @@ en:
           signup: User signup
     exceptions:
       count_on_hand_setter: Cannot set count_on_hand manually, as it is set automatically by the recalculate_count_on_hand callback. Please use `update_column(:count_on_hand, value)` instead.
-    exchange_for: Exchange for
     expedited_exchanges_warning: "Any specified exchanges will ship to the customer immediately upon saving. The customer will be charged the full amount of the item if they do not return the original item within %{days_window} days."
     excl: excl.
     expected: Expected
@@ -1174,7 +1193,6 @@ en:
     pre_tax_refund_amount: Pre-Tax Refund Amount
     pre_tax_amount: Pre-Tax Amount
     pre_tax_total: Pre-Tax Total
-    preferred_reimbursement_type: Preferred Reimbursement Type
     presentation: Presentation
     previous: Previous
     price: Price
@@ -1281,7 +1299,6 @@ en:
     received_successfully: Received Successfully
     receiving: Receiving
     receiving_match: Receiving match
-    reception_status: Reception Status
     reference: Reference
     refund: Refund
     refund_amount_must_be_greater_than_zero: Refund amount must be greater than zero
@@ -1295,7 +1312,6 @@ en:
     reimbursed: Reimbursed
     reimbursement: Reimbursement
     reimbursement_perform_failed: "Reimbursement could not be performed.  Error: %{error}"
-    reimbursement_status: Reimbursement status
     reimbursement_type: Reimbursement type
     reimbursement_type_override: Reimbursement Type Override
     reimbursement_types: Reimbursement Types
@@ -1334,7 +1350,6 @@ en:
         refund_summary: Refund Summary
         subject: Reimbursement Notification
         total_refunded: ! 'Total refunded: %{total}'
-    return_number: Return Number
     return_quantity: Return Quantity
     returned: Returned
     review: Review

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -57,6 +57,9 @@ en:
         created_at: "Date/Time"
         reimbursement_status: Reimbursement status
         stock_location_id: Stock Location
+      spree/image:
+        alt: Alternative Text
+        attachment: Filename
       spree/inventory_unit:
         state: State
       spree/line_item:
@@ -547,7 +550,6 @@ en:
     all_departments: All departments
     all_items_have_been_returned: All items have been returned
     already_signed_up_for_analytics: You have already signed up for Spree Analytics
-    alt_text: Alternative Text
     alternative_phone: Alternative Phone
     amount: Amount
     analytics_desc_header_1: Spree Analytics
@@ -848,7 +850,6 @@ en:
     existing_shipments: Existing shipments
     failed_payment_attempts: Failed Payment Attempts
     failure: Failure
-    filename: Filename
     fill_in_customer_info: Please fill in customer info
     filter_results: Filter Results
     finalize: Finalize

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -22,6 +22,7 @@ en:
         adjustable: Adjustable
         amount: Amount
         label: Description
+        name: Name
         state: State
         adjustment_reason_id: Reason
       spree/adjustment_reason:

--- a/frontend/app/views/spree/shared/_order_details.html.erb
+++ b/frontend/app/views/spree/shared/_order_details.html.erb
@@ -3,18 +3,18 @@
   <% if order.has_step?("address") %>
 
     <div class="columns alpha four" data-hook="order-bill-address">
-      <h6><%= Spree.t(:billing_address) %> <%= link_to "(#{Spree.t(:edit)})", checkout_state_path(:address) unless order.completed? %></h6>
+      <h6><%= Spree.t(:billing_address) %> <%= link_to "(#{Spree.t('actions.edit')})", checkout_state_path(:address) unless order.completed? %></h6>
       <%= render :partial => 'spree/shared/address', :locals => { :address => order.bill_address } %>
     </div>
 
     <% if order.has_step?("delivery") %>
       <div class="columns alpha four" data-hook="order-ship-address">
-        <h6><%= Spree.t(:shipping_address) %> <%= link_to "(#{Spree.t(:edit)})", checkout_state_path(:address) unless order.completed? %></h6>
+        <h6><%= Spree.t(:shipping_address) %> <%= link_to "(#{Spree.t('actions.edit')})", checkout_state_path(:address) unless order.completed? %></h6>
         <%= render :partial => 'spree/shared/address', :locals => { :address => order.ship_address } %>
       </div>
 
       <div class="columns alpha four" data-hook="order-shipment">
-        <h6><%= Spree.t(:shipments) %> <%= link_to "(#{Spree.t(:edit)})", checkout_state_path(:delivery) unless order.completed? %></h6>
+        <h6><%= Spree.t(:shipments) %> <%= link_to "(#{Spree.t('actions.edit')})", checkout_state_path(:delivery) unless order.completed? %></h6>
         <div class="delivery">
           <% order.shipments.each do |shipment| %>
             <div>
@@ -29,7 +29,7 @@
   <% end %>
 
   <div class="columns omega four">
-    <h6><%= Spree.t(:payment_information) %> <%= link_to "(#{Spree.t(:edit)})", checkout_state_path(:payment) unless order.completed? %></h6>
+    <h6><%= Spree.t(:payment_information) %> <%= link_to "(#{Spree.t('actions.edit')})", checkout_state_path(:payment) unless order.completed? %></h6>
     <div class="payment-info">
       <% order.payments.valid.each do |payment| %>
         <%= render payment %><br/>


### PR DESCRIPTION
## [WORK IN PROGRESS]

# Use Attribute Translations

This PR changes the admin forms and table headers in the manner, that it uses the Rails build in I18n attribute translations. 

In current form Spree (as Solidus is not to blame here) adds custom, way to general, translation keys in nearly every admin form. This makes translations very hard and sometimes impossible. 

I.E.: State in an address has a complete different meaning than on a shipment ;)

In using Rails' default way of translating attributes:

```
de:
  activerecord:
    attributes:
      spree/address:
        state: Bundesland
      spree/shipment:
        state: Status
  spree:
    state: Bundesland # :/
```

we'll support much better translations for foreign languages.

I'll move all current translations over to the new keys, however the [solidus_i18n project](https://github.com/solidusio-contrib/solidus_i18n) will need to be updated.

Happy translating |o/

PS: This is the beginning of a long series of PRs regarding better I18n support in Solidus.
