### PR TITLE
Payment factory cleanup

### DIFF
--- a/core/lib/spree/testing_support/factories/payment_factory.rb
+++ b/core/lib/spree/testing_support/factories/payment_factory.rb
@@ -8,10 +8,13 @@ FactoryGirl.define do
     response_code '12345'
 
     factory :payment_with_refund do
-      state 'completed'
-      after :create do |payment|
-        create(:refund, amount: 5, payment: payment)
+      transient do
+        refund_amount 5
       end
+
+      state 'completed'
+
+      refunds { build_list :refund, 1, amount: refund_amount }
     end
   end
 

--- a/core/lib/spree/testing_support/factories/payment_factory.rb
+++ b/core/lib/spree/testing_support/factories/payment_factory.rb
@@ -1,6 +1,5 @@
 FactoryGirl.define do
   factory :payment, aliases: [:credit_card_payment], class: Spree::Payment do
-    amount 45.75
     association(:payment_method, factory: :credit_card_payment_method)
     association(:source, factory: :credit_card)
     order
@@ -19,7 +18,6 @@ FactoryGirl.define do
   end
 
   factory :check_payment, class: Spree::Payment do
-    amount 45.75
     association(:payment_method, factory: :check_payment_method)
     order
   end

--- a/core/lib/spree/testing_support/factories/refund_factory.rb
+++ b/core/lib/spree/testing_support/factories/refund_factory.rb
@@ -2,9 +2,15 @@ FactoryGirl.define do
   sequence(:refund_transaction_id) { |n| "fake-refund-transaction-#{n}"}
 
   factory :refund, class: Spree::Refund do
+    transient do
+      payment_amount 100
+    end
+
     amount 100.00
     transaction_id { generate(:refund_transaction_id) }
-    association(:payment, state: 'completed')
+    payment do
+      association(:payment, state: 'completed', amount: payment_amount)
+    end
     association(:reason, factory: :refund_reason)
   end
 

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -772,11 +772,11 @@ describe Spree::Order, :type => :model do
 
   context "#refund_total" do
     let(:order) { create(:order_with_line_items) }
-    let!(:payment) { create(:payment_with_refund, order: order) }
-    let!(:payment2) { create(:payment_with_refund, order: order) }
+    let!(:payment) { create(:payment_with_refund, order: order, amount: 5, refund_amount: 3) }
+    let!(:payment2) { create(:payment_with_refund, order: order, amount: 5, refund_amount: 2.5) }
 
     it "sums the reimbursment refunds on the order" do
-      expect(order.refund_total).to eq(10.0)
+      expect(order.refund_total).to eq(5.5)
     end
   end
 

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -820,7 +820,7 @@ describe Spree::Order, :type => :model do
 
     context 'a reimbursement related refund exists' do
       let(:order) { refund.payment.order }
-      let(:refund) { create(:refund, reimbursement_id: 123, amount: 5)}
+      let(:refund) { create(:refund, reimbursement_id: 123, amount: 5, payment_amount: 14)}
 
       it { is_expected.to eq false }
     end

--- a/core/spec/models/spree/order_updater_spec.rb
+++ b/core/spec/models/spree/order_updater_spec.rb
@@ -12,10 +12,12 @@ module Spree
         end
       end
 
-      it "updates payment totals" do
-        create(:payment_with_refund, order: order)
-        Spree::OrderUpdater.new(order).update_payment_total
-        expect(order.payment_total).to eq(40.75)
+      context 'with refund' do
+        it "updates payment totals" do
+          create(:payment_with_refund, order: order, amount: 33.25, refund_amount: 3)
+          Spree::OrderUpdater.new(order).update_payment_total
+          expect(order.payment_total).to eq(30.25)
+        end
       end
 
       it "update item total" do


### PR DESCRIPTION
This is to get in any payment factory changes I need to clean up #542 to the point I'm happy with it.

Currently our factories aren't nearly as good as they need to be, with too much duplication, "magic values" making tests unclear, and the state of our objects not even being valid.

This PR allows us to pass more values through to dependent associations with transient attributes, and removes a magic value on the payment factory.