### PR TITLE
Refactor

### DIFF
--- a/api/app/controllers/spree/api/products_controller.rb
+++ b/api/app/controllers/spree/api/products_controller.rb
@@ -5,7 +5,7 @@ module Spree
       def index
         if params[:ids]
           ids = params[:ids].split(",").flatten
-          @products = product_scope.where(:id => ids)
+          @products = product_scope.where(id: ids)
         else
           @products = product_scope.ransack(params[:q]).result
         end
@@ -59,14 +59,14 @@ module Spree
       #
       def create
         authorize! :create, Product
-        params[:product][:available_on] ||= Time.now
+        params[:product][:available_on] ||= Time.current
         set_up_shipping_category
 
         options = { variants_attrs: variants_params, options_attrs: option_types_params }
         @product = Core::Importer::Product.new(nil, product_params, options).create
 
         if @product.persisted?
-          respond_with(@product, :status => 201, :default_template => :show)
+          respond_with(@product, status: 201, default_template: :show)
         else
           invalid_resource!(@product)
         end
@@ -80,7 +80,7 @@ module Spree
         @product = Core::Importer::Product.new(@product, product_params, options).update
 
         if @product.errors.empty?
-          respond_with(@product.reload, :status => 200, :default_template => :show)
+          respond_with(@product.reload, status: 200, default_template: :show)
         else
           invalid_resource!(@product)
         end

--- a/api/spec/controllers/spree/api/checkouts_controller_spec.rb
+++ b/api/spec/controllers/spree/api/checkouts_controller_spec.rb
@@ -380,7 +380,7 @@ module Spree
       end
 
       it "can transition from confirm to complete" do
-        order.update_columns(completed_at: Time.now, state: 'complete')
+        order.update_columns(completed_at: Time.current, state: 'complete')
         allow_any_instance_of(Spree::Order).to receive_messages(payment_required?: false)
         api_put :update, id: order.to_param, order_token: order.guest_token
         expect(json_response['state']).to eq('complete')
@@ -388,7 +388,7 @@ module Spree
       end
 
       it "returns the order if the order is already complete" do
-        order.update_columns(completed_at: Time.now, state: 'complete')
+        order.update_columns(completed_at: Time.current, state: 'complete')
         api_put :update, id: order.to_param, order_token: order.guest_token
         expect(json_response['number']).to eq(order.number)
         expect(response.status).to eq(200)

--- a/api/spec/controllers/spree/api/classifications_controller_spec.rb
+++ b/api/spec/controllers/spree/api/classifications_controller_spec.rb
@@ -37,7 +37,7 @@ module Spree
       end
 
       it "should touch the taxon" do
-        taxon.update_attributes(updated_at: Time.now - 10.seconds)
+        taxon.update_attributes(updated_at: Time.current - 10.seconds)
         taxon_last_updated_at = taxon.updated_at
         api_put :update, taxon_id: taxon, product_id: last_product, position: 0
         taxon.reload

--- a/api/spec/controllers/spree/api/orders_controller_spec.rb
+++ b/api/spec/controllers/spree/api/orders_controller_spec.rb
@@ -185,9 +185,9 @@ module Spree
       end
 
       it "returns orders in reverse chronological order by completed_at" do
-        order.update_columns completed_at: Time.now
+        order.update_columns completed_at: Time.current
 
-        order2 = Order.create user: order.user, completed_at: Time.now - 1.day, store: store
+        order2 = Order.create user: order.user, completed_at: Time.current - 1.day, store: store
         expect(order2.created_at).to be > order.created_at
         order3 = Order.create user: order.user, completed_at: nil, store: store
         expect(order3.created_at).to be > order2.created_at
@@ -321,7 +321,7 @@ module Spree
     end
 
     it "cannot cancel an order that doesn't belong to them" do
-      order.update_attribute(:completed_at, Time.now)
+      order.update_attribute(:completed_at, Time.current)
       order.update_attribute(:shipment_state, "ready")
       api_put :cancel, :id => order.to_param
       assert_unauthorized!
@@ -754,7 +754,7 @@ module Spree
         before do
           Spree::Config[:mails_from] = "spree@example.com"
 
-          order.completed_at = Time.now
+          order.completed_at = Time.current
           order.state = 'complete'
           order.shipment_state = 'ready'
           order.save!

--- a/api/spec/controllers/spree/api/products_controller_spec.rb
+++ b/api/spec/controllers/spree/api/products_controller_spec.rb
@@ -6,7 +6,7 @@ module Spree
     render_views
 
     let!(:product) { create(:product) }
-    let!(:inactive_product) { create(:product, available_on: Time.now.tomorrow, name: "inactive") }
+    let!(:inactive_product) { create(:product, available_on: Time.current.tomorrow, name: "inactive") }
     let(:base_attributes) { Api::ApiHelpers.product_attributes }
     let(:show_attributes) { base_attributes.dup.push(:has_variants) }
     let(:new_attributes) { base_attributes }

--- a/api/spec/controllers/spree/api/shipments_controller_spec.rb
+++ b/api/spec/controllers/spree/api/shipments_controller_spec.rb
@@ -235,7 +235,7 @@ describe Spree::Api::ShipmentsController, :type => :controller do
           subject
           shipment.reload
           expect(shipment.state).to eq 'shipped'
-          expect(shipment.shipped_at.to_i).to eq Time.now.to_i
+          expect(shipment.shipped_at.to_i).to eq Time.current.to_i
         end
       end
 

--- a/api/spec/controllers/spree/api/stock_transfers_controller_spec.rb
+++ b/api/spec/controllers/spree/api/stock_transfers_controller_spec.rb
@@ -52,7 +52,7 @@ module Spree
 
           before do
             stock_transfer.finalize(user)
-            stock_transfer.ship(shipped_at: Time.now)
+            stock_transfer.ship(shipped_at: Time.current)
             stock_transfer.source_location.stock_item(transfer_item.variant_id).set_count_on_hand(0)
           end
 

--- a/api/spec/controllers/spree/api/transfer_items_controller_spec.rb
+++ b/api/spec/controllers/spree/api/transfer_items_controller_spec.rb
@@ -134,7 +134,7 @@ module Spree
 
         context "has been finalized" do
           before do
-            stock_transfer.update_attributes(finalized_at: Time.now)
+            stock_transfer.update_attributes(finalized_at: Time.current)
           end
 
           it "returns an error status code" do

--- a/api/spec/controllers/spree/api/variants_controller_spec.rb
+++ b/api/spec/controllers/spree/api/variants_controller_spec.rb
@@ -75,7 +75,7 @@ module Spree
       # Regression test for #2141
       context "a deleted variant" do
         before do
-          variant.update_column(:deleted_at, Time.now)
+          variant.update_column(:deleted_at, Time.current)
         end
 
         it "is not returned in the results" do
@@ -226,7 +226,7 @@ module Spree
       # Test for #2141
       context "deleted variants" do
         before do
-          variant.update_column(:deleted_at, Time.now)
+          variant.update_column(:deleted_at, Time.current)
         end
 
         it "are visible by admin" do

--- a/backend/app/controllers/spree/admin/payment_methods_controller.rb
+++ b/backend/app/controllers/spree/admin/payment_methods_controller.rb
@@ -27,7 +27,7 @@ module Spree
         if @payment_method['type'].to_s != payment_method_type
           @payment_method.update_columns(
             type: payment_method_type,
-            updated_at: Time.now,
+            updated_at: Time.current,
           )
           @payment_method = PaymentMethod.find(params[:id])
         end

--- a/backend/app/controllers/spree/admin/reports_controller.rb
+++ b/backend/app/controllers/spree/admin/reports_controller.rb
@@ -29,9 +29,9 @@ module Spree
         params[:q] = {} unless params[:q]
 
         if params[:q][:completed_at_gt].blank?
-          params[:q][:completed_at_gt] = Time.zone.now.beginning_of_month
+          params[:q][:completed_at_gt] = Time.current.beginning_of_month
         else
-          params[:q][:completed_at_gt] = Time.zone.parse(params[:q][:completed_at_gt]).beginning_of_day rescue Time.zone.now.beginning_of_month
+          params[:q][:completed_at_gt] = Time.zone.parse(params[:q][:completed_at_gt]).beginning_of_day rescue Time.current.beginning_of_month
         end
 
         if params[:q] && !params[:q][:completed_at_lt].blank?

--- a/backend/app/controllers/spree/admin/search_controller.rb
+++ b/backend/app/controllers/spree/admin/search_controller.rb
@@ -9,26 +9,28 @@ module Spree
       # And then JSON building with something like Active Model Serializers
       def users
         if params[:ids]
-          @users = Spree.user_class.where(:id => params[:ids].split(','))
+          # split here may be String#split or Array#split, so we must flatten the results
+          @users = Spree.user_class.where(id: params[:ids].split(',').flatten)
         else
           @users = Spree.user_class.ransack({
-            :m => 'or',
-            :email_start => params[:q],
-            :addresses_firstname_start => params[:q],
-            :addresses_lastname_start => params[:q]
+            m: 'or',
+            email_start: params[:q],
+            addresses_firstname_start: params[:q],
+            addresses_lastname_start: params[:q]
           }).result.limit(10)
         end
       end
 
       def products
         if params[:ids]
-          @products = Product.where(:id => params[:ids].split(",").flatten)
+          # split here may be String#split or Array#split, so we must flatten the results
+          @products = Product.where(id: params[:ids].split(",").flatten)
         else
           @products = Product.ransack(params[:q]).result
         end
 
         @products = @products.distinct.page(params[:page]).per(params[:per_page])
-        expires_in 15.minutes, :public => true
+        expires_in 15.minutes, public: true
         headers['Surrogate-Control'] = "max-age=#{15.minutes}"
       end
     end

--- a/backend/app/controllers/spree/admin/search_controller.rb
+++ b/backend/app/controllers/spree/admin/search_controller.rb
@@ -22,7 +22,7 @@ module Spree
 
       def products
         if params[:ids]
-          @products = Product.where(:id => params[:ids].split(","))
+          @products = Product.where(:id => params[:ids].split(",").flatten)
         else
           @products = Product.ransack(params[:q]).result
         end

--- a/backend/app/controllers/spree/admin/stock_transfers_controller.rb
+++ b/backend/app/controllers/spree/admin/stock_transfers_controller.rb
@@ -43,7 +43,7 @@ module Spree
 
       def ship
         if @stock_transfer.transfer
-          @stock_transfer.ship(shipped_at: DateTime.now)
+          @stock_transfer.ship(shipped_at: DateTime.current)
           flash[:success] = Spree.t(:stock_transfer_complete)
           redirect_to admin_stock_transfers_path
         else

--- a/backend/spec/controllers/spree/admin/payments_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/payments_controller_spec.rb
@@ -23,7 +23,7 @@ module Spree
               :source_attributes => {
                 :name => "Test User",
                 :number => "4111 1111 1111 1111",
-                :expiry => "09 / #{Time.now.year + 1}",
+                :expiry => "09 / #{Time.current.year + 1}",
                 :verification_value => "123"
               }
             }

--- a/backend/spec/controllers/spree/admin/reports_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/reports_controller_spec.rb
@@ -31,10 +31,10 @@ describe Spree::Admin::ReportsController, :type => :controller do
 
     before do
       # can't set completed_at during factory creation
-      order_complete_start_of_month.completed_at = Time.zone.now.beginning_of_month + 1.minute
+      order_complete_start_of_month.completed_at = Time.current.beginning_of_month + 1.minute
       order_complete_start_of_month.save!
 
-      order_complete_mid_month.completed_at = Time.zone.now.beginning_of_month + 15.days
+      order_complete_mid_month.completed_at = Time.current.beginning_of_month + 15.days
       order_complete_mid_month.save!
     end
 
@@ -84,7 +84,7 @@ describe Spree::Admin::ReportsController, :type => :controller do
     end
 
     context 'when params has a completed_at_gt' do
-      let(:params) { { q: { completed_at_gt: Time.zone.now.beginning_of_month + 1.day } } }
+      let(:params) { { q: { completed_at_gt: Time.current.beginning_of_month + 1.day } } }
 
       it_behaves_like 'sales total report' do
         let(:expected_returned_orders) { [order_complete_mid_month] }
@@ -101,7 +101,7 @@ describe Spree::Admin::ReportsController, :type => :controller do
     end
 
     context 'when params has a compeleted_at_lt' do
-      let(:params) { { q: { completed_at_lt: Time.zone.now.beginning_of_month } } }
+      let(:params) { { q: { completed_at_lt: Time.current.beginning_of_month } } }
 
       it_behaves_like 'sales total report' do
         let(:expected_returned_orders) { [order_complete_start_of_month] }

--- a/backend/spec/controllers/spree/admin/stock_transfers_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/stock_transfers_controller_spec.rb
@@ -20,8 +20,8 @@ module Spree
         StockTransfer.create do |transfer|
           transfer.source_location_id = warehouse.id
           transfer.destination_location_id = la_store.id
-          transfer.finalized_at = DateTime.now
-          transfer.closed_at = DateTime.now
+          transfer.finalized_at = DateTime.current
+          transfer.closed_at = DateTime.current
         end }
 
       describe "stock location filtering" do
@@ -163,7 +163,7 @@ module Spree
 
       context 'stock transfer is not finalizable' do
         before do
-          transfer_with_items.update_attributes(finalized_at: Time.now)
+          transfer_with_items.update_attributes(finalized_at: Time.current)
         end
 
         it 'redirects back to edit' do

--- a/backend/spec/features/admin/configuration/tax_rates_spec.rb
+++ b/backend/spec/features/admin/configuration/tax_rates_spec.rb
@@ -12,7 +12,7 @@ describe "Tax Rates", :type => :feature do
 
   # Regression test for #535
   it "can see a tax rate in the list if the tax category has been deleted" do
-    tax_rate.tax_category.update_column(:deleted_at, Time.now)
+    tax_rate.tax_category.update_column(:deleted_at, Time.current)
     click_link "Tax Rates"
 
     expect(find("table tbody td:nth-child(3)")).to have_content('N/A')

--- a/backend/spec/features/admin/orders/cancelling_and_resuming_spec.rb
+++ b/backend/spec/features/admin/orders/cancelling_and_resuming_spec.rb
@@ -14,8 +14,8 @@ describe "Cancelling + Resuming", :type => :feature do
   let(:order) do
     order = create(:order)
     order.update_columns({
-      :state => 'complete',
-      :completed_at => Time.now
+      state: 'complete',
+      completed_at: Time.current
     })
     order
   end

--- a/backend/spec/features/admin/orders/payments_spec.rb
+++ b/backend/spec/features/admin/orders/payments_spec.rb
@@ -182,7 +182,7 @@ describe 'Payments', :type => :feature do
       it "is able to create a new credit card payment with valid information", :js => true do
         fill_in "Card Number", :with => "4111 1111 1111 1111"
         fill_in "Name *", :with => "Test User"
-        fill_in "Expiration", :with => "09 / #{Time.now.year + 1}"
+        fill_in "Expiration", :with => "09 / #{Time.current.year + 1}"
         fill_in "Card Code", :with => "007"
         # Regression test for #4277
         expect(page).to have_css('.ccType[value="visa"]', visible: false)

--- a/backend/spec/features/admin/reports_spec.rb
+++ b/backend/spec/features/admin/reports_spec.rb
@@ -20,12 +20,12 @@ describe "Reports", :type => :feature do
     before do
       order = create(:order)
       order.update_columns({:adjustment_total => 100})
-      order.completed_at = Time.now
+      order.completed_at = Time.current
       order.save!
 
       order = create(:order)
       order.update_columns({:adjustment_total => 200})
-      order.completed_at = Time.now
+      order.completed_at = Time.current
       order.save!
 
       #incomplete order

--- a/core/app/models/concerns/spree/adjustment_source.rb
+++ b/core/app/models/concerns/spree/adjustment_source.rb
@@ -14,7 +14,7 @@ module Spree
         # This would mean that the order's total is not altered at all.
         attrs = {
           source_id: nil,
-          updated_at: Time.now
+          updated_at: Time.current
         }
         adjustment_scope.where.not(spree_orders: { completed_at: nil }).update_all(attrs)
       end

--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -170,7 +170,7 @@ module Spree
         # Persist only if changed
         # This is only not a save! to avoid the extra queries to load the order
         # (for validations) and to touch the adjustment.
-        update_columns(eligible: eligible, amount: amount, updated_at: Time.now) if changed?
+        update_columns(eligible: eligible, amount: amount, updated_at: Time.current) if changed?
       end
       amount
     end

--- a/core/app/models/spree/credit_card.rb
+++ b/core/app/models/spree/credit_card.rb
@@ -11,8 +11,8 @@ module Spree
 
     accepts_nested_attributes_for :address
 
+    attr_reader :number
     attr_accessor :encrypted_data,
-                    :number,
                     :imported,
                     :verification_value
 

--- a/core/app/models/spree/credit_card.rb
+++ b/core/app/models/spree/credit_card.rb
@@ -181,7 +181,7 @@ module Spree
     def ensure_one_default
       if self.user_id && self.default
         CreditCard.where(default: true).where.not(id: self.id).where(user_id: self.user_id).each do |ucc|
-          ucc.update_columns(default: false, updated_at: Time.now)
+          ucc.update_columns(default: false, updated_at: Time.current)
         end
       end
     end

--- a/core/app/models/spree/inventory_unit.rb
+++ b/core/app/models/spree/inventory_unit.rb
@@ -79,7 +79,7 @@ module Spree
       inventory_units.map do |iu|
         iu.update_columns(
           pending: false,
-          updated_at: Time.now,
+          updated_at: Time.current,
         )
       end
     end

--- a/core/app/models/spree/item_adjustments.rb
+++ b/core/app/models/spree/item_adjustments.rb
@@ -63,11 +63,11 @@ module Spree
       @item.adjustment_total = @item.promo_total + @item.additional_tax_total + item_cancellation_total
 
       @item.update_columns(
-        :promo_total => @item.promo_total,
-        :included_tax_total => @item.included_tax_total,
-        :additional_tax_total => @item.additional_tax_total,
-        :adjustment_total => @item.adjustment_total,
-        :updated_at => Time.now,
+        promo_total: @item.promo_total,
+        included_tax_total: @item.included_tax_total,
+        additional_tax_total: @item.additional_tax_total,
+        adjustment_total: @item.adjustment_total,
+        updated_at: Time.current,
       ) if @item.changed?
 
       @item

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -528,7 +528,7 @@ module Spree
 
       self.update_columns(
         state: 'cart',
-        updated_at: Time.now,
+        updated_at: Time.current,
       )
       self.next! if self.line_items.size > 0
     end
@@ -556,7 +556,7 @@ module Spree
         cancel!
         self.update_columns(
           canceler_id: user.id,
-          canceled_at: Time.now,
+          canceled_at: Time.current,
         )
       end
     end

--- a/core/app/models/spree/order_cancellations.rb
+++ b/core/app/models/spree/order_cancellations.rb
@@ -65,7 +65,7 @@ class Spree::OrderCancellations
 
     shipments.each do |shipment|
       if shipment.inventory_units.all? {|iu| iu.shipped? || iu.canceled? }
-        shipment.update_attributes!(state: 'shipped', shipped_at: Time.now)
+        shipment.update_attributes!(state: 'shipped', shipped_at: Time.current)
       end
     end
   end

--- a/core/app/models/spree/order_contents.rb
+++ b/core/app/models/spree/order_contents.rb
@@ -51,7 +51,7 @@ module Spree
       order.update_attributes!(
         approver: user,
         approver_name: name,
-        approved_at: Time.now,
+        approved_at: Time.current,
       )
     end
 

--- a/core/app/models/spree/order_shipping.rb
+++ b/core/app/models/spree/order_shipping.rb
@@ -19,7 +19,7 @@ class Spree::OrderShipping
       stock_location: shipment.stock_location,
       address: shipment.address,
       shipping_method: shipment.shipping_method,
-      shipped_at: Time.now,
+      shipped_at: Time.current,
       external_number: external_number,
       # TODO: Remove the `|| shipment.tracking` once Shipment#ship! is called by
       # OrderShipping#ship rather than vice versa
@@ -41,7 +41,7 @@ class Spree::OrderShipping
   # @param tracking_number An option tracking number.
   # @return The carton created.
   def ship(inventory_units:, stock_location:, address:, shipping_method:,
-           shipped_at: Time.now, external_number: nil, tracking_number: nil, suppress_mailer: false)
+           shipped_at: Time.current, external_number: nil, tracking_number: nil, suppress_mailer: false)
 
     carton = nil
 
@@ -68,7 +68,7 @@ class Spree::OrderShipping
         # TODO: make OrderShipping#ship_shipment call Shipment#ship! rather than
         # having Shipment#ship! call OrderShipping#ship_shipment. We only really
         # need this `update_columns` for the specs, until we make that change.
-        shipment.update_columns(state: 'shipped', shipped_at: Time.now)
+        shipment.update_columns(state: 'shipped', shipped_at: Time.current)
       end
     end
 

--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -109,7 +109,7 @@ module Spree
         shipment_total: order.shipment_total,
         promo_total: order.promo_total,
         total: order.total,
-        updated_at: Time.now,
+        updated_at: Time.current,
       )
     end
 

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -328,7 +328,7 @@ module Spree
     end
 
     def punch_slug
-      update_column :slug, "#{Time.now.to_i}_#{slug}" # punch slug with date prefix to allow reuse of original
+      update_column :slug, "#{Time.current.to_i}_#{slug}" # punch slug with date prefix to allow reuse of original
     end
 
     def anything_changed?

--- a/core/app/models/spree/product/scopes.rb
+++ b/core/app/models/spree/product/scopes.rb
@@ -168,12 +168,12 @@ module Spree
     end
 
     add_search_scope :not_deleted do
-      where("#{Product.quoted_table_name}.deleted_at IS NULL or #{Product.quoted_table_name}.deleted_at >= ?", Time.zone.now)
+      where("#{Product.quoted_table_name}.deleted_at IS NULL or #{Product.quoted_table_name}.deleted_at >= ?", Time.current)
     end
 
     # Can't use add_search_scope for this as it needs a default argument
     def self.available(available_on = nil, currency = nil)
-      joins(:master => :prices).where("#{Product.quoted_table_name}.available_on <= ?", available_on || Time.now)
+      joins(:master => :prices).where("#{Product.quoted_table_name}.available_on <= ?", available_on || Time.current)
     end
     search_scopes << :available
 

--- a/core/app/models/spree/promotion/rules/nth_order.rb
+++ b/core/app/models/spree/promotion/rules/nth_order.rb
@@ -30,7 +30,7 @@ module Spree
             user.
             orders.
             complete.
-            where(Spree::Order.arel_table[:completed_at].lt(order.completed_at || Time.now)).
+            where(Spree::Order.arel_table[:completed_at].lt(order.completed_at || Time.current)).
             count
         end
 

--- a/core/app/models/spree/return_item/eligibility_validator/time_since_purchase.rb
+++ b/core/app/models/spree/return_item/eligibility_validator/time_since_purchase.rb
@@ -1,7 +1,7 @@
 module Spree
   class ReturnItem::EligibilityValidator::TimeSincePurchase < Spree::ReturnItem::EligibilityValidator::BaseValidator
     def eligible_for_return?
-      if (@return_item.inventory_unit.order.completed_at + Spree::Config[:return_eligibility_number_of_days].days) > Time.now
+      if (@return_item.inventory_unit.order.completed_at + Spree::Config[:return_eligibility_number_of_days].days) > Time.current
         return true
       else
         add_error(:number_of_days, Spree.t('return_item_time_period_ineligible'))

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -240,7 +240,7 @@ module Spree
 
     def shipped=(value)
       return unless value == '1' && shipped_at.nil?
-      self.shipped_at = Time.now
+      self.shipped_at = Time.current
     end
 
     def shipping_method
@@ -279,7 +279,7 @@ module Spree
         self.update_columns(
           cost: selected_shipping_rate.cost,
           adjustment_total: adjustments.additional.map(&:update!).compact.sum,
-          updated_at: Time.now,
+          updated_at: Time.current,
         )
       end
     end
@@ -301,7 +301,7 @@ module Spree
           # (via Order#paid?) affects the shipment state (YAY)
           self.update_columns(
             state: determine_state(order),
-            updated_at: Time.now
+            updated_at: Time.current
           )
 
           # And then it's time to update shipment states and finally persist
@@ -322,7 +322,7 @@ module Spree
       new_state = determine_state(order)
       update_columns(
         state: new_state,
-        updated_at: Time.now,
+        updated_at: Time.current,
       )
       after_ship if new_state == 'shipped' and old_state != 'shipped'
     end

--- a/core/app/models/spree/stock_location.rb
+++ b/core/app/models/spree/stock_location.rb
@@ -77,7 +77,7 @@ module Spree
       item = stock_item_or_create(variant)
       item.update_columns(
         count_on_hand: item.count_on_hand + quantity,
-        updated_at: Time.now
+        updated_at: Time.current
       )
     end
 

--- a/core/app/models/spree/stock_transfer.rb
+++ b/core/app/models/spree/stock_transfer.rb
@@ -70,7 +70,7 @@ module Spree
 
     def finalize(finalized_by)
       if finalizable?
-        self.update_attributes({ finalized_at: Time.now, finalized_by: finalized_by })
+        self.update_attributes({ finalized_at: Time.current, finalized_by: finalized_by })
       else
         errors.add(:base, Spree.t(:stock_transfer_cannot_be_finalized))
         false
@@ -91,7 +91,7 @@ module Spree
 
     def close(closed_by)
       if receivable?
-        self.update_attributes({ closed_at: Time.now, closed_by: closed_by })
+        self.update_attributes({ closed_at: Time.current, closed_by: closed_by })
       else
         errors.add(:base, Spree.t(:stock_transfer_must_be_receivable))
         false

--- a/core/app/models/spree/store_credit.rb
+++ b/core/app/models/spree/store_credit.rb
@@ -162,7 +162,7 @@ class Spree::StoreCredit < Spree::Base
   end
 
   def generate_authorization_code
-    "#{self.id}-SC-#{Time.now.utc.strftime("%Y%m%d%H%M%S%6N")}"
+    "#{self.id}-SC-#{Time.current.utc.strftime("%Y%m%d%H%M%S%6N")}"
   end
 
   def editable?
@@ -192,7 +192,7 @@ class Spree::StoreCredit < Spree::Base
       self.action = INVALIDATE_ACTION
       self.update_reason = reason
       self.action_originator = user_performing_invalidation
-      self.invalidated_at = Time.now
+      self.invalidated_at = Time.current
       save
     else
       errors.add(:invalidated_at, Spree.t("store_credit.errors.cannot_invalidate_uncaptured_authorization"))

--- a/core/app/models/spree/tax_category.rb
+++ b/core/app/models/spree/tax_category.rb
@@ -12,7 +12,7 @@ module Spree
 
     def ensure_one_default
       if is_default
-        Spree::TaxCategory.where(is_default: true).where.not(id: self.id).update_all(is_default: false, updated_at: Time.now)
+        Spree::TaxCategory.where(is_default: true).where.not(id: self.id).update_all(is_default: false, updated_at: Time.current)
       end
     end
   end

--- a/core/app/models/spree/taxon.rb
+++ b/core/app/models/spree/taxon.rb
@@ -96,7 +96,7 @@ module Spree
 
     def touch_ancestors_and_taxonomy
       # Touches all ancestors at once to avoid recursive taxonomy touch, and reduce queries.
-      self.class.where(id: ancestors.pluck(:id)).update_all(updated_at: Time.now)
+      self.class.where(id: ancestors.pluck(:id)).update_all(updated_at: Time.current)
       # Have taxonomy touch happen in #touch_ancestors_and_taxonomy rather than association option in order for imports to override.
       taxonomy.try!(:touch)
     end

--- a/core/app/models/spree/taxonomy.rb
+++ b/core/app/models/spree/taxonomy.rb
@@ -16,7 +16,7 @@ module Spree
         if root
           root.update_columns(
             name: name,
-            updated_at: Time.now,
+            updated_at: Time.current,
           )
         else
           self.root = Taxon.create!(taxonomy_id: id, name: name)

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -356,7 +356,7 @@ module Spree
       end
 
       def set_cost_currency
-        self.cost_currency = Spree::Config[:currency] if cost_currency.nil? || cost_currency.empty?
+        self.cost_currency = Spree::Config[:currency] if cost_currency.blank?
       end
 
       def create_stock_items

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -554,6 +554,7 @@ en:
     back_to_reports_list: Back To Reports List
     back_to_refund_reason_list: Back To Refund Reason List
     back_to_reimbursement_type_list: Back To Reimbursement Type List
+    back_to_return_authorizations_list: Back To Return Authorizations List
     back_to_rma_reason_list: Back To RMA Reason List
     back_to_shipping_categories: Back To Shipping Categories
     back_to_shipping_categories_list: Back To Shipping Categories List

--- a/core/db/migrate/20150225205344_move_promotion_code_to_promotion_code_value.rb
+++ b/core/db/migrate/20150225205344_move_promotion_code_to_promotion_code_value.rb
@@ -11,8 +11,8 @@ class MovePromotionCodeToPromotionCodeValue < ActiveRecord::Migration
         select
           spree_promotions.id,
           spree_promotions.code,
-          '#{Time.now.to_s(:db)}',
-          '#{Time.now.to_s(:db)}'
+          '#{Time.current.to_s(:db)}',
+          '#{Time.current.to_s(:db)}'
         from spree_promotions
         left join spree_promotion_codes
           on spree_promotion_codes.promotion_id = spree_promotions.id

--- a/core/lib/spree/testing_support/factories/carton_factory.rb
+++ b/core/lib/spree/testing_support/factories/carton_factory.rb
@@ -3,7 +3,7 @@ FactoryGirl.define do
     address
     stock_location
     shipping_method
-    shipped_at { Time.now }
+    shipped_at { Time.current }
     inventory_units do
       [
         build(

--- a/core/lib/spree/testing_support/factories/order_factory.rb
+++ b/core/lib/spree/testing_support/factories/order_factory.rb
@@ -80,14 +80,14 @@ FactoryGirl.define do
             after(:create) do |order, evaluator|
               order.shipments.each do |shipment|
                 shipment.inventory_units.update_all state: 'shipped'
-                shipment.update_columns(state: 'shipped', shipped_at: Time.now)
+                shipment.update_columns(state: 'shipped', shipped_at: Time.current)
                 if evaluator.with_cartons
                   Spree::Carton.create!(
                     stock_location: shipment.stock_location,
                     address: shipment.address,
                     shipping_method: shipment.shipping_method,
                     inventory_units: shipment.inventory_units,
-                    shipped_at: Time.now,
+                    shipped_at: Time.current,
                   )
                 end
               end

--- a/core/lib/spree/testing_support/factories/stock_transfer_factory.rb
+++ b/core/lib/spree/testing_support/factories/stock_transfer_factory.rb
@@ -20,8 +20,8 @@ FactoryGirl.define do
       end
 
       factory :receivable_stock_transfer_with_items do
-        finalized_at  { Time.now }
-        shipped_at    { Time.now }
+        finalized_at  { Time.current }
+        shipped_at    { Time.current }
       end
     end
   end

--- a/core/lib/spree/testing_support/factories/user_factory.rb
+++ b/core/lib/spree/testing_support/factories/user_factory.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   sequence :user_authentication_token do |n|
-    "xxxx#{Time.now.to_i}#{rand(1000)}#{n}xxxxxxxxxxxxx"
+    "xxxx#{Time.current.to_i}#{rand(1000)}#{n}xxxxxxxxxxxxx"
   end
 
   factory :user, class: Spree.user_class do

--- a/core/lib/tasks/migrations/copy_shipped_shipments_to_cartons.rake
+++ b/core/lib/tasks/migrations/copy_shipped_shipments_to_cartons.rake
@@ -55,8 +55,8 @@ namespace 'spree:migrations:copy_shipped_shipments_to_cartons' do
               spree_shipping_rates.shipping_method_id,
               spree_shipments.tracking,
               spree_shipments.shipped_at,
-              '#{Time.now.to_s(:db)}', -- created_at
-              '#{Time.now.to_s(:db)}' -- updated_at
+              '#{Time.current.to_s(:db)}', -- created_at
+              '#{Time.current.to_s(:db)}' -- updated_at
             from spree_shipments
             left join spree_shipping_rates
               on spree_shipping_rates.shipment_id = spree_shipments.id

--- a/core/spec/lib/spree/core/importer/order_spec.rb
+++ b/core/spec/lib/spree/core/importer/order_spec.rb
@@ -46,7 +46,7 @@ module Spree
 
       it 'optionally add completed at' do
         params = { email: 'test@test.com',
-                   completed_at: Time.now,
+                   completed_at: Time.current,
                    line_items_attributes: line_items }
         order = Importer::Order.import(user,params)
         expect(order).to be_completed

--- a/core/spec/models/spree/address_spec.rb
+++ b/core/spec/models/spree/address_spec.rb
@@ -277,14 +277,14 @@ describe Spree::Address, :type => :model do
       let(:base_attributes) do
         {
           'id' => 1,
-          'created_at' => Time.now,
-          'updated_at' => Time.now,
+          'created_at' => Time.current,
+          'updated_at' => Time.current,
           'address1' => '1234 way',
         }
       end
       let(:merge_attributes) do
         {
-          'updated_at' => Time.now,
+          'updated_at' => Time.current,
           'address2' => 'apt 2',
         }
       end

--- a/core/spec/models/spree/credit_card_spec.rb
+++ b/core/spec/models/spree/credit_card_spec.rb
@@ -5,7 +5,7 @@ describe Spree::CreditCard, type: :model do
     {
       number: '4111111111111111',
       verification_value: '123',
-      expiry: "12 / #{(Time.now.year + 1).to_s.last(2)}",
+      expiry: "12 / #{(Time.current.year + 1).to_s.last(2)}",
       name: 'Spree Commerce'
     }
   end
@@ -38,12 +38,12 @@ describe Spree::CreditCard, type: :model do
 
   context "#can_capture?" do
     it "should be true if payment is pending" do
-      payment = mock_model(Spree::Payment, pending?: true, created_at: Time.now)
+      payment = mock_model(Spree::Payment, pending?: true, created_at: Time.current)
       expect(credit_card.can_capture?(payment)).to be true
     end
 
     it "should be true if payment is checkout" do
-      payment = mock_model(Spree::Payment, pending?: false, checkout?: true, created_at: Time.now)
+      payment = mock_model(Spree::Payment, pending?: false, checkout?: true, created_at: Time.current)
       expect(credit_card.can_capture?(payment)).to be true
     end
   end
@@ -281,8 +281,8 @@ describe Spree::CreditCard, type: :model do
   context "#to_active_merchant" do
     before do
       credit_card.number = "4111111111111111"
-      credit_card.year = Time.now.year
-      credit_card.month = Time.now.month
+      credit_card.year = Time.current.year
+      credit_card.month = Time.current.month
       credit_card.name = "Ludwig van Beethoven"
       credit_card.verification_value = 123
     end
@@ -290,8 +290,8 @@ describe Spree::CreditCard, type: :model do
     it "converts to an ActiveMerchant::Billing::CreditCard object" do
       am_card = credit_card.to_active_merchant
       expect(am_card.number).to eq("4111111111111111")
-      expect(am_card.year).to eq(Time.now.year)
-      expect(am_card.month).to eq(Time.now.month)
+      expect(am_card.year).to eq(Time.current.year)
+      expect(am_card.month).to eq(Time.current.month)
       expect(am_card.first_name).to eq("Ludwig")
       expect(am_card.last_name).to eq("van Beethoven")
       expect(am_card.verification_value).to eq(123)
@@ -325,7 +325,7 @@ describe Spree::CreditCard, type: :model do
     user = FactoryGirl.create(:user)
     first = FactoryGirl.create(:credit_card, user: user, default: true)
     second = FactoryGirl.create(:credit_card, user: user, default: false)
-    first.update_columns(year: DateTime.now.year, month: 1.month.ago.month)
+    first.update_columns(year: DateTime.current.year, month: 1.month.ago.month)
 
     expect { second.update_attributes!(default: true) }.not_to raise_error
   end
@@ -334,7 +334,7 @@ describe Spree::CreditCard, type: :model do
     user = FactoryGirl.create(:user)
     first = FactoryGirl.create(:credit_card, user: user, default: true)
     second = FactoryGirl.create(:credit_card, user: user, default: false)
-    first.update_columns(year: DateTime.now.year, month: 1.month.ago.month)
+    first.update_columns(year: DateTime.current.year, month: 1.month.ago.month)
 
     expect { second.update_attributes!(default: true) }.not_to raise_error
   end

--- a/core/spec/models/spree/inventory_unit_spec.rb
+++ b/core/spec/models/spree/inventory_unit_spec.rb
@@ -8,7 +8,7 @@ describe Spree::InventoryUnit, :type => :model do
   context "#backordered_for_stock_item" do
     let(:order) do
       order = create(:order, state: 'complete', ship_address: create(:ship_address))
-      order.completed_at = Time.now
+      order.completed_at = Time.current
       create(:shipment, order: order, stock_location: stock_location)
       order.shipments.reload
       create(:line_item, order: order, variant: stock_item.variant)

--- a/core/spec/models/spree/option_type_spec.rb
+++ b/core/spec/models/spree/option_type_spec.rb
@@ -8,7 +8,7 @@ describe Spree::OptionType, :type => :model do
       product = product_option_type.product
       product.update_column(:updated_at, 1.day.ago)
       option_type.touch
-      expect(product.reload.updated_at).to be_within(3.seconds).of(Time.now)
+      expect(product.reload.updated_at).to be_within(3.seconds).of(Time.current)
     end
   end
 end

--- a/core/spec/models/spree/option_value_spec.rb
+++ b/core/spec/models/spree/option_value_spec.rb
@@ -12,7 +12,7 @@ describe Spree::OptionValue, :type => :model do
     it "should touch a variant" do
       Timecop.freeze do
         option_value.touch
-        expect(variant.reload.updated_at).to be_within(1.second).of(Time.now)
+        expect(variant.reload.updated_at).to be_within(1.second).of(Time.current)
       end
     end
 
@@ -28,7 +28,7 @@ describe Spree::OptionValue, :type => :model do
         Timecop.freeze do
           option_value.name += "--1"
           option_value.save!
-          expect(variant.reload.updated_at).to be_within(1.second).of(Time.now)
+          expect(variant.reload.updated_at).to be_within(1.second).of(Time.current)
         end
       end
     end

--- a/core/spec/models/spree/order_contents_spec.rb
+++ b/core/spec/models/spree/order_contents_spec.rb
@@ -245,7 +245,7 @@ describe Spree::OrderContents, :type => :model do
   end
 
   context "completed order" do
-    let(:order) { Spree::Order.create! state: 'complete', completed_at: Time.now }
+    let(:order) { Spree::Order.create! state: 'complete', completed_at: Time.current }
 
     before { order.shipments.create! stock_location_id: variant.stock_location_ids.first }
 

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -325,7 +325,7 @@ describe Spree::Order, :type => :model do
     context 'when the order is completed' do
       before do
         order.state = 'complete'
-        order.completed_at = Time.now
+        order.completed_at = Time.current
         order.update_column(:shipment_total, 5)
         order.shipments.create!
       end
@@ -691,7 +691,7 @@ describe Spree::Order, :type => :model do
       order.completed_at = nil
       expect(order.completed?).to be false
 
-      order.completed_at = Time.now
+      order.completed_at = Time.current
       expect(order.completed?).to be true
     end
   end
@@ -730,14 +730,14 @@ describe Spree::Order, :type => :model do
     it "should be false for completed order in the canceled state" do
       order.state = 'canceled'
       order.shipment_state = 'ready'
-      order.completed_at = Time.now
+      order.completed_at = Time.current
       expect(order.can_cancel?).to be false
     end
 
     it "should be true for completed order with no shipment" do
       order.state = 'complete'
       order.shipment_state = nil
-      order.completed_at = Time.now
+      order.completed_at = Time.current
       expect(order.can_cancel?).to be true
     end
   end

--- a/core/spec/models/spree/permission_sets/restricted_stock_transfer_management_spec.rb
+++ b/core/spec/models/spree/permission_sets/restricted_stock_transfer_management_spec.rb
@@ -75,7 +75,7 @@ describe Spree::PermissionSets::RestrictedStockTransferManagement do
 
       context "stock transfer has been shipped" do
         before do
-          transfer_with_source_and_destination.update_attributes!(shipped_at: Time.now)
+          transfer_with_source_and_destination.update_attributes!(shipped_at: Time.current)
           described_class.new(ability).activate!
         end
 
@@ -114,7 +114,7 @@ describe Spree::PermissionSets::RestrictedStockTransferManagement do
 
       context "stock transfer has been shipped" do
         before do
-          transfer_with_source_and_destination.update_attributes!(shipped_at: Time.now)
+          transfer_with_source_and_destination.update_attributes!(shipped_at: Time.current)
           described_class.new(ability).activate!
         end
 
@@ -153,7 +153,7 @@ describe Spree::PermissionSets::RestrictedStockTransferManagement do
 
       context "stock transfer has been shipped" do
         before do
-          transfer_with_source_and_destination.update_attributes!(shipped_at: Time.now)
+          transfer_with_source_and_destination.update_attributes!(shipped_at: Time.current)
           described_class.new(ability).activate!
         end
 

--- a/core/spec/models/spree/promotion/actions/create_item_adjustments_spec.rb
+++ b/core/spec/models/spree/promotion/actions/create_item_adjustments_spec.rb
@@ -143,7 +143,7 @@ module Spree
           end
 
           it "nullifies adjustments for completed orders" do
-            order = Order.create(completed_at: Time.now)
+            order = Order.create(completed_at: Time.current)
             adjustment = action.adjustments.create!(label: "Check", amount: 0, order: order, adjustable: order)
 
             expect {

--- a/core/spec/models/spree/promotion/rules/nth_order_spec.rb
+++ b/core/spec/models/spree/promotion/rules/nth_order_spec.rb
@@ -47,7 +47,7 @@ describe Spree::Promotion::Rules::NthOrder do
 
         context "when this order is completed and is still the 'nth' order" do
           before do
-            order.update_attributes(completed_at: Time.now)
+            order.update_attributes(completed_at: Time.current)
           end
 
           it { is_expected.to be true }

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -104,7 +104,7 @@ describe Spree::Promotion, :type => :model do
       promotion.created_at = 2.days.ago
 
       @user = create(:user)
-      @order = create(:order, user: @user, created_at: DateTime.now)
+      @order = create(:order, user: @user, created_at: DateTime.current)
       @payload = { :order => @order, :user => @user }
     end
 
@@ -131,7 +131,7 @@ describe Spree::Promotion, :type => :model do
 
     it "does activate if newer then order" do
       expect(@action1).to receive(:perform).with(hash_including(@payload))
-      promotion.created_at = DateTime.now + 2
+      promotion.created_at = DateTime.current + 2
       expect(promotion.activate(@payload)).to be true
     end
 
@@ -301,28 +301,28 @@ describe Spree::Promotion, :type => :model do
     end
 
     it "should be expired if it hasn't started yet" do
-      promotion.starts_at = Time.now + 1.day
+      promotion.starts_at = Time.current + 1.day
       expect(promotion).to be_expired
     end
 
     it "should be expired if it has already ended" do
-      promotion.expires_at = Time.now - 1.day
+      promotion.expires_at = Time.current - 1.day
       expect(promotion).to be_expired
     end
 
     it "should not be expired if it has started already" do
-      promotion.starts_at = Time.now - 1.day
+      promotion.starts_at = Time.current - 1.day
       expect(promotion).not_to be_expired
     end
 
     it "should not be expired if it has not ended yet" do
-      promotion.expires_at = Time.now + 1.day
+      promotion.expires_at = Time.current + 1.day
       expect(promotion).not_to be_expired
     end
 
     it "should not be expired if current time is within starts_at and expires_at range" do
-      promotion.starts_at = Time.now - 1.day
-      promotion.expires_at = Time.now + 1.day
+      promotion.starts_at = Time.current - 1.day
+      promotion.expires_at = Time.current + 1.day
       expect(promotion).not_to be_expired
     end
   end
@@ -333,28 +333,28 @@ describe Spree::Promotion, :type => :model do
     end
 
     it "should not be active if it hasn't started yet" do
-      promotion.starts_at = Time.now + 1.day
+      promotion.starts_at = Time.current + 1.day
       expect(promotion.active?).to eq(false)
     end
 
     it "should not be active if it has already ended" do
-      promotion.expires_at = Time.now - 1.day
+      promotion.expires_at = Time.current - 1.day
       expect(promotion.active?).to eq(false)
     end
 
     it "should be active if it has started already" do
-      promotion.starts_at = Time.now - 1.day
+      promotion.starts_at = Time.current - 1.day
       expect(promotion.active?).to eq(true)
     end
 
     it "should be active if it has not ended yet" do
-      promotion.expires_at = Time.now + 1.day
+      promotion.expires_at = Time.current + 1.day
       expect(promotion.active?).to eq(true)
     end
 
     it "should be active if current time is within starts_at and expires_at range" do
-      promotion.starts_at = Time.now - 1.day
-      promotion.expires_at = Time.now + 1.day
+      promotion.starts_at = Time.current - 1.day
+      promotion.expires_at = Time.current + 1.day
       expect(promotion.active?).to eq(true)
     end
 
@@ -440,7 +440,7 @@ describe Spree::Promotion, :type => :model do
     it { is_expected.to be true }
 
     context "when promotion is expired" do
-      before { promotion.expires_at = Time.now - 10.days }
+      before { promotion.expires_at = Time.current - 10.days }
       it { is_expected.to be false }
     end
 
@@ -714,7 +714,7 @@ describe Spree::Promotion, :type => :model do
       before do
         promotion.activate(order: order)
         order.update!
-        order.completed_at = Time.now
+        order.completed_at = Time.current
         order.save!
       end
 

--- a/core/spec/models/spree/return_item_spec.rb
+++ b/core/spec/models/spree/return_item_spec.rb
@@ -18,7 +18,7 @@ describe Spree::ReturnItem, :type => :model do
   end
 
   describe '#receive!' do
-    let(:now)            { Time.now }
+    let(:now)            { Time.current }
     let(:order)          { create(:shipped_order)}
     let(:inventory_unit) { create(:inventory_unit, order: order,state: 'shipped') }
     let!(:customer_return) { create(:customer_return_without_return_items, return_items: [return_item], stock_location_id: inventory_unit.shipment.stock_location_id) }

--- a/core/spec/models/spree/shipping_rate_spec.rb
+++ b/core/spec/models/spree/shipping_rate_spec.rb
@@ -104,7 +104,7 @@ describe Spree::ShippingRate, :type => :model do
     end
 
     it "can be retrieved even when deleted" do
-      shipping_method.update_column(:deleted_at, Time.now)
+      shipping_method.update_column(:deleted_at, Time.current)
       shipping_rate.save
       shipping_rate.reload
       expect(shipping_rate.shipping_method).to eq(shipping_method)
@@ -123,7 +123,7 @@ describe Spree::ShippingRate, :type => :model do
     end
 
     it "can be retrieved even when deleted" do
-      tax_rate.update_column(:deleted_at, Time.now)
+      tax_rate.update_column(:deleted_at, Time.current)
       shipping_rate.save
       shipping_rate.reload
       expect(shipping_rate.tax_rate).to eq(tax_rate)

--- a/core/spec/models/spree/stock_transfer_spec.rb
+++ b/core/spec/models/spree/stock_transfer_spec.rb
@@ -48,7 +48,7 @@ module Spree
 
       context "finalized" do
         before do
-          stock_transfer.update_attributes(finalized_at: Time.now)
+          stock_transfer.update_attributes(finalized_at: Time.current)
         end
 
         it { is_expected.to eq false }
@@ -56,7 +56,7 @@ module Spree
 
       context "shipped" do
         before do
-          stock_transfer.update_attributes(shipped_at: Time.now)
+          stock_transfer.update_attributes(shipped_at: Time.current)
         end
 
         it { is_expected.to eq false }
@@ -64,7 +64,7 @@ module Spree
 
       context "closed" do
         before do
-          stock_transfer.update_attributes(closed_at: Time.now)
+          stock_transfer.update_attributes(closed_at: Time.current)
         end
 
         it { is_expected.to eq false }
@@ -72,7 +72,7 @@ module Spree
 
       context "finalized and closed" do
         before do
-          stock_transfer.update_attributes(finalized_at: Time.now, closed_at: Time.now)
+          stock_transfer.update_attributes(finalized_at: Time.current, closed_at: Time.current)
         end
 
         it { is_expected.to eq false }
@@ -80,7 +80,7 @@ module Spree
 
       context "shipped and closed" do
         before do
-          stock_transfer.update_attributes(shipped_at: Time.now, closed_at: Time.now)
+          stock_transfer.update_attributes(shipped_at: Time.current, closed_at: Time.current)
         end
 
         it { is_expected.to eq false }
@@ -88,7 +88,7 @@ module Spree
 
       context "finalized and shipped" do
         before do
-          stock_transfer.update_attributes(finalized_at: Time.now, shipped_at: Time.now)
+          stock_transfer.update_attributes(finalized_at: Time.current, shipped_at: Time.current)
         end
 
         it { is_expected.to eq true }
@@ -100,7 +100,7 @@ module Spree
 
       context "finalized" do
         before do
-          stock_transfer.update_attributes(finalized_at: Time.now)
+          stock_transfer.update_attributes(finalized_at: Time.current)
         end
 
         it { is_expected.to eq false }
@@ -108,7 +108,7 @@ module Spree
 
       context "shipped" do
         before do
-          stock_transfer.update_attributes(shipped_at: Time.now)
+          stock_transfer.update_attributes(shipped_at: Time.current)
         end
 
         it { is_expected.to eq false }
@@ -116,7 +116,7 @@ module Spree
 
       context "closed" do
         before do
-          stock_transfer.update_attributes(closed_at: Time.now)
+          stock_transfer.update_attributes(closed_at: Time.current)
         end
 
         it { is_expected.to eq false }
@@ -124,7 +124,7 @@ module Spree
 
       context "finalized and closed" do
         before do
-          stock_transfer.update_attributes(finalized_at: Time.now, closed_at: Time.now)
+          stock_transfer.update_attributes(finalized_at: Time.current, closed_at: Time.current)
         end
 
         it { is_expected.to eq false }
@@ -132,7 +132,7 @@ module Spree
 
       context "shipped and closed" do
         before do
-          stock_transfer.update_attributes(shipped_at: Time.now, closed_at: Time.now)
+          stock_transfer.update_attributes(shipped_at: Time.current, closed_at: Time.current)
         end
 
         it { is_expected.to eq false }
@@ -165,7 +165,7 @@ module Spree
 
       context "can't be finalized" do
         before do
-          stock_transfer.update_attributes(finalized_at: Time.now)
+          stock_transfer.update_attributes(finalized_at: Time.current)
         end
 
         it "doesn't set a finalized_at date" do
@@ -225,7 +225,7 @@ module Spree
 
       context "stock transfer is finalized" do
         before do
-          stock_transfer.update_attributes!(finalized_at: Time.now)
+          stock_transfer.update_attributes!(finalized_at: Time.current)
         end
 
         it "doesn't destroy the stock transfer" do

--- a/core/spec/models/spree/store_credit_event_spec.rb
+++ b/core/spec/models/spree/store_credit_event_spec.rb
@@ -28,7 +28,7 @@ describe Spree::StoreCreditEvent do
     end
 
     it "excludes invalidated store credit events" do
-      invalidated_store_credit = create(:store_credit, invalidated_at: Time.now)
+      invalidated_store_credit = create(:store_credit, invalidated_at: Time.current)
       event = create(:store_credit_event, action: Spree::StoreCredit::VOID_ACTION, store_credit: invalidated_store_credit)
       expect(described_class.exposed_events).not_to include event
     end

--- a/core/spec/models/spree/store_credit_spec.rb
+++ b/core/spec/models/spree/store_credit_spec.rb
@@ -837,7 +837,7 @@ describe Spree::StoreCredit do
     subject { store_credit.invalidate(invalidation_reason, invalidation_user) }
 
     it "sets the invalidated_at field to the current time" do
-      invalidated_at = Time.now
+      invalidated_at = Time.current
       Timecop.freeze(invalidated_at) do
         subject
         expect(store_credit.invalidated_at).to eq invalidated_at

--- a/core/spec/models/spree/tax_rate_spec.rb
+++ b/core/spec/models/spree/tax_rate_spec.rb
@@ -319,7 +319,7 @@ describe Spree::TaxRate, :type => :model do
           end
 
           it "should not delete adjustments for complete order when taxrate is deleted" do
-            @order.update_column :completed_at, Time.now
+            @order.update_column :completed_at, Time.current
             @rate1.destroy!
             @rate2.destroy!
             expect(line_item.adjustments.count).to eq(2)

--- a/core/spec/models/spree/transfer_item_spec.rb
+++ b/core/spec/models/spree/transfer_item_spec.rb
@@ -71,7 +71,7 @@ describe Spree::TransferItem do
 
       context "transfer order is shipped" do
         before do
-          stock_transfer.update_attributes!(shipped_at: Time.now)
+          stock_transfer.update_attributes!(shipped_at: Time.current)
         end
 
         context "variant is not available" do
@@ -153,7 +153,7 @@ describe Spree::TransferItem do
 
       context "stock_transfer is closed" do
         before do
-          stock_transfer.update_attributes!(closed_at: Time.now)
+          stock_transfer.update_attributes!(closed_at: Time.current)
         end
 
         it { is_expected.to eq false }
@@ -173,7 +173,7 @@ describe Spree::TransferItem do
 
     context "stock transfer is finalized" do
       before do
-        stock_transfer.update_attributes(finalized_at: Time.now)
+        stock_transfer.update_attributes(finalized_at: Time.current)
       end
 
       it "adds an error message" do
@@ -206,7 +206,7 @@ describe Spree::TransferItem do
 
     context "stock transfer is finalized" do
       before do
-        stock_transfer.update_attributes(finalized_at: Time.now)
+        stock_transfer.update_attributes(finalized_at: Time.current)
       end
 
       it "does not destroy the transfer item" do

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -463,7 +463,7 @@ describe Spree::Variant, :type => :model do
     it "updates a product" do
       variant.product.update_column(:updated_at, 1.day.ago)
       variant.touch
-      expect(variant.product.reload.updated_at).to be_within(3.seconds).of(Time.now)
+      expect(variant.product.reload.updated_at).to be_within(3.seconds).of(Time.current)
     end
 
     it "clears the in_stock cache key" do

--- a/sample/db/samples/products.rb
+++ b/sample/db/samples/products.rb
@@ -5,8 +5,8 @@ tax_category = Spree::TaxCategory.find_by_name!("Default")
 shipping_category = Spree::ShippingCategory.find_by_name!("Default")
 
 default_attrs = {
-  :description => Faker::Lorem.paragraph,
-  :available_on => Time.zone.now
+  description: Faker::Lorem.paragraph,
+  available_on: Time.current
 }
 
 products = [


### PR DESCRIPTION
1.) Use #blank? which provides the  same functionality provided by the combination of #nil? and #empty?.

2.) Added missing translation of back_to_return_authorizations_list.

3.) Use Time.current/Time.zone.now instead of Time.now in order to use application time zone.

4.) Removed deprecation of passing a nested array to ActiveRecord finder methods by flattening the array

5.) Remove #number= writer method provided by attr_accessor since it's already being overridden on line 66