### PR TITLE
Update promotion_actions_create_quantity_adjustments in core/engine

### DIFF
--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -73,7 +73,7 @@ module Spree
         ]
 
         app.config.spree.calculators.add_class('promotion_actions_create_quantity_adjustments')
-        app.config.spree.calculators.promotion_actions_create_item_adjustments = [
+        app.config.spree.calculators.promotion_actions_create_quantity_adjustments = [
           Spree::Calculator::PercentOnLineItem,
           Spree::Calculator::FlatRate
         ]


### PR DESCRIPTION
I saw this while working on something else. It looks like we have already defined `app.config.spree.calculators.promotion_actions_create_item_adjustments` a few lines above. I think it was probably a copy-paste gone awry.