### PR TITLE
TieredPercent calculator for line item promotion actions

### DIFF
--- a/core/app/models/spree/calculator/tiered_percent.rb
+++ b/core/app/models/spree/calculator/tiered_percent.rb
@@ -23,7 +23,8 @@ module Spree
     end
 
     def compute(object)
-      base, percent = preferred_tiers.sort.reverse.detect{ |b,_| object.amount >= b }
+      order = object.is_a?(Order) ? object : object.order
+      base, percent = preferred_tiers.sort.reverse.detect{ |b,_| order.item_total >= b }
       (object.amount * (percent || preferred_base_percent) / 100).round(2)
     end
 

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -69,7 +69,8 @@ module Spree
         app.config.spree.calculators.promotion_actions_create_item_adjustments = [
           Spree::Calculator::PercentOnLineItem,
           Spree::Calculator::FlatRate,
-          Spree::Calculator::FlexiRate
+          Spree::Calculator::FlexiRate,
+          Spree::Calculator::TieredPercent
         ]
 
         app.config.spree.calculators.add_class('promotion_actions_create_quantity_adjustments')

--- a/core/spec/models/spree/calculator/tiered_percent_spec.rb
+++ b/core/spec/models/spree/calculator/tiered_percent_spec.rb
@@ -26,22 +26,54 @@ describe Spree::Calculator::TieredPercent, :type => :model do
   end
 
   describe "#compute" do
-    let(:line_item) { mock_model Spree::LineItem, amount: amount }
+    let(:order) { create(:order_with_line_items, line_items_count: line_item_count, line_items_price: price) }
+    let(:line_item) { order.line_items.first }
+    let(:price) { 10 }
+
     before do
       calculator.preferred_base_percent = 10
       calculator.preferred_tiers = {
-        100 => 15,
-        200 => 20
+        20 => 15,
+        30 => 20
       }
     end
+
     subject { calculator.compute(line_item) }
-    context "when amount falls within the first tier" do
-      let(:amount) { 50 }
-      it { is_expected.to eq 5 }
+
+    context "for multiple line items" do
+      context "when amount falls within the first tier" do
+        let(:line_item_count) { 1 }
+        it { is_expected.to eq 1.0 }
+      end
+
+      context "when amount falls within the second tier" do
+        let(:line_item_count) { 2 }
+        it { is_expected.to eq 1.5 }
+      end
+
+      context "when amount falls within the third tier" do
+        let(:line_item_count) { 3 }
+        it { is_expected.to eq 2.0 }
+      end
     end
-    context "when amount falls within the second tier" do
-      let(:amount) { 150 }
-      it { is_expected.to eq 22 }
+
+    context "for a single line item" do
+      let(:line_item_count) { 1 }
+
+      context "when amount falls within the first tier" do
+        let(:price) { 10 }
+        it { is_expected.to eq 1.0 }
+      end
+
+      context "when amount falls within the second tier" do
+        let(:price) { 20 }
+        it { is_expected.to eq 3.0 }
+      end
+
+      context "when amount falls within the third tier" do
+        let(:price) { 30 }
+        it { is_expected.to eq 6.0 }
+      end
     end
   end
 end


### PR DESCRIPTION
This allows running a promotion with a line-item level action with a tiered percent calculator. This calculator has been available on an order-level basis for awhile, but this calculator was slightly broken on the line-item level. Line-item level is more precise in what is being adjusted and why, so I think this should be beneficial.