### PR TITLE
Optimize shipping rate estimation

### DIFF
--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -14,7 +14,6 @@ module Spree
     has_many :zones, through: :shipping_method_zones
 
     belongs_to :tax_category, -> { with_deleted }, class_name: 'Spree::TaxCategory'
-    has_many :shipping_method_stock_locations, class_name: Spree::ShippingMethodStockLocation
     has_many :shipping_method_stock_locations, dependent: :destroy, class_name: "Spree::ShippingMethodStockLocation"
     has_many :stock_locations, through: :shipping_method_stock_locations
 

--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -75,10 +75,6 @@ module Spree
 
     private
 
-    def compute_amount(calculable)
-      calculator.compute(calculable)
-    end
-
     def at_least_one_shipping_category
       if shipping_categories.empty?
         errors[:base] << "You need to select at least one shipping category"

--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -22,6 +22,37 @@ module Spree
 
     validate :at_least_one_shipping_category
 
+    def self.with_all_shipping_category_ids(shipping_category_ids)
+      # Some extra care is needed with the having clause to ensure we are
+      # counting distinct records of the join table. Otherwise a join could
+      # cause this to return incorrect results.
+      join_table = ShippingMethodCategory.arel_table
+      having = join_table[:id].count(true).eq(shipping_category_ids.count)
+      joins(:shipping_method_categories).
+        where(spree_shipping_method_categories: {shipping_category_id: shipping_category_ids}).
+        group('spree_shipping_methods.id').
+        having(having)
+    end
+
+    def self.available_in_stock_location(stock_location)
+      smsl_table = ShippingMethodStockLocation.arel_table
+
+      # We are searching for either a matching entry in the stock location join
+      # table or available_to_all being true.
+      # We need to use an outer join otherwise a shipping method with no
+      # associated stock locations will be filtered out of the results. In
+      # rails 5 this will be easy using .left_join and .or, but for now we must
+      # use arel to achieve this.
+      arel_join =
+        arel_table.join(smsl_table, Arel::Nodes::OuterJoin).
+        on(arel_table[:id].eq(smsl_table[:shipping_method_id])).
+        join_sources
+      arel_condition =
+        arel_table[:available_to_all].eq(true).or(smsl_table[:stock_location_id].eq(stock_location.id))
+
+      joins(arel_join).where(arel_condition).uniq
+    end
+
     def include?(address)
       return false unless address
       zones.any? do |zone|

--- a/core/app/models/spree/stock/estimator.rb
+++ b/core/app/models/spree/stock/estimator.rb
@@ -55,7 +55,10 @@ module Spree
       end
 
       def shipping_methods(package)
-        package.shipping_methods.select do |ship_method|
+        package.shipping_methods
+          .includes(:calculator, zones: :zone_members, tax_category: :tax_rates)
+          .to_a
+          .select do |ship_method|
           calculator = ship_method.calculator
           ship_method.include?(order.ship_address) &&
             calculator.available?(package) &&

--- a/core/app/models/spree/stock/package.rb
+++ b/core/app/models/spree/stock/package.rb
@@ -99,10 +99,16 @@ module Spree
         order.currency
       end
 
+      # @return [Array<Fixnum>] the unique ids of all shipping categories of
+      #   variants in this package
+      def shipping_category_ids
+        contents.map { |item| item.variant.shipping_category_id }.compact.uniq
+      end
+
       # @return [Array<Spree::ShippingCategory>] the shipping categories of the
       #   variants in this package
       def shipping_categories
-        contents.map { |item| item.variant.shipping_category }.compact.uniq
+        ShippingCategory.where(id: shipping_category_ids)
       end
 
       # @return [Array<Spree::ShippingMethod>] the shipping methods available

--- a/core/lib/spree/testing_support/factories/shipping_method_factory.rb
+++ b/core/lib/spree/testing_support/factories/shipping_method_factory.rb
@@ -19,10 +19,11 @@ FactoryGirl.define do
     carrier 'UPS'
     service_level '1DAYGROUND'
 
-    calculator { |s| s.association(:shipping_calculator, strategy: :build, preferred_amount: s.cost) }
+    calculator { |s| s.association(:shipping_calculator, strategy: :build, preferred_amount: s.cost, preferred_currency: s.currency) }
 
     transient do
       cost 10.0
+      currency 'USD'
     end
 
     before(:create) do |shipping_method, _evaluator|

--- a/core/spec/models/spree/shipping_method_spec.rb
+++ b/core/spec/models/spree/shipping_method_spec.rb
@@ -85,4 +85,64 @@ describe Spree::ShippingMethod, type: :model do
       expect(shipping_method.deleted_at).not_to be_blank
     end
   end
+
+  describe ".with_all_shipping_category_ids" do
+    let(:category1) { create(:shipping_category) }
+    let(:category2) { create(:shipping_category) }
+
+    def matching(categories)
+      described_class.with_all_shipping_category_ids(categories.map(&:id))
+    end
+
+    context "with one associated shipping category" do
+      let!(:shipping_method) { create(:shipping_method, shipping_categories: [category1]) }
+
+      it "should match the associated category" do
+        expect(matching([category1])).to eq [shipping_method]
+      end
+
+      it "should not match the other category" do
+        expect(matching([category2])).to be_empty
+      end
+
+      it "should not match both categories" do
+        expect(matching([category1, category2])).to be_empty
+      end
+
+      context "with additional joins" do
+        before do
+          shipping_method.zones << create(:zone)
+        end
+        it "should not match both categories" do
+          result =
+            described_class.
+            joins(:zones).
+            with_all_shipping_category_ids([category1.id, category2.id])
+          expect(result).to be_empty
+        end
+      end
+    end
+
+    context "with two associated shipping categories" do
+      let!(:shipping_method) { create(:shipping_method, shipping_categories: [category1, category2]) }
+
+      it "should match the associated category" do
+        expect(matching([category1])).to eq [shipping_method]
+      end
+
+      it "should match both categories" do
+        expect(matching([category1, category2])).to eq [shipping_method]
+      end
+    end
+
+    context "with several shipping methods" do
+      let!(:shipping_method1) { create(:shipping_method, shipping_categories: [category1]) }
+      let!(:shipping_method2) { create(:shipping_method, shipping_categories: [category1, category2]) }
+      let!(:shipping_method3) { create(:shipping_method, shipping_categories: [category2]) }
+
+      it "matches correctly" do
+        expect(matching([category1])).to match_array [shipping_method1, shipping_method2]
+      end
+    end
+  end
 end

--- a/core/spec/models/spree/shipping_method_spec.rb
+++ b/core/spec/models/spree/shipping_method_spec.rb
@@ -145,4 +145,69 @@ describe Spree::ShippingMethod, type: :model do
       end
     end
   end
+
+  describe ".available_in_stock_location" do
+    let!(:stock_location) { create :stock_location }
+    let!(:other_stock_location) { create :stock_location }
+
+    subject { described_class.available_in_stock_location(stock_location) }
+
+    context "when available_to_all" do
+      let!(:shipping_method) { create(:shipping_method, available_to_all: true) }
+
+      it "returns the shipping_method" do
+        is_expected.to eq [shipping_method]
+      end
+    end
+
+    context "when in stock location" do
+      let!(:shipping_method) { create(:shipping_method, available_to_all: false, stock_locations: [stock_location]) }
+
+      it "returns the shipping_method" do
+        is_expected.to eq [shipping_method]
+      end
+    end
+
+    context "when available_to_all and in stock location" do
+      let!(:shipping_method) { create(:shipping_method, available_to_all: true, stock_locations: [stock_location]) }
+
+      it "returns the shipping_method" do
+        is_expected.to eq [shipping_method]
+      end
+    end
+
+    context "when in no stock locations" do
+      let!(:shipping_method) { create(:shipping_method, available_to_all: false) }
+
+      it "returns no results" do
+        is_expected.to be_empty
+      end
+    end
+
+    context "when in another stock location" do
+      let!(:shipping_method) { create(:shipping_method, available_to_all: false, stock_locations: [other_stock_location]) }
+
+      it "returns no results" do
+        is_expected.to be_empty
+      end
+    end
+
+    context "when available_to_all and in another stock location" do
+      let!(:shipping_method) { create(:shipping_method, available_to_all: true, stock_locations: [other_stock_location]) }
+
+      it "returns the shipping_method" do
+        is_expected.to eq [shipping_method]
+      end
+    end
+
+    context "when multiple shipping methods match" do
+      let!(:shipping_method1) { create(:shipping_method, available_to_all: true, stock_locations: [other_stock_location]) }
+      let!(:shipping_method2) { create(:shipping_method, available_to_all: false, stock_locations: [stock_location]) }
+      let!(:shipping_method3) { create(:shipping_method, available_to_all: false, stock_locations: [other_stock_location]) }
+
+      it "returns both matching shipping_methods" do
+        is_expected.to match_array([shipping_method1, shipping_method2])
+      end
+    end
+  end
 end

--- a/core/spec/models/spree/stock/estimator_spec.rb
+++ b/core/spec/models/spree/stock/estimator_spec.rb
@@ -3,9 +3,10 @@ require 'spec_helper'
 module Spree
   module Stock
     describe Estimator, type: :model do
-      let!(:shipping_method) { create(:shipping_method) }
-      let(:package) { build(:stock_package, contents: inventory_units.map { |_i| ContentItem.new(inventory_unit) }) }
-      let(:order) { build(:order_with_line_items) }
+      let(:shipping_rate) { 4.00 }
+      let!(:shipping_method) { create(:shipping_method, cost: shipping_rate, currency: currency) }
+      let(:package) { build(:stock_package, contents: inventory_units.map { |i| ContentItem.new(i) }) }
+      let(:order) { create(:order_with_line_items, shipping_method: shipping_method) }
       let(:inventory_units) { order.inventory_units }
 
       subject { Estimator.new(order) }
@@ -13,12 +14,6 @@ module Spree
       context "#shipping rates" do
         before(:each) do
           shipping_method.zones.first.members.create(zoneable: order.ship_address.country)
-          allow_any_instance_of(ShippingMethod).to receive_message_chain(:calculator, :available?).and_return(true)
-          allow_any_instance_of(ShippingMethod).to receive_message_chain(:calculator, :compute).and_return(4.00)
-          allow_any_instance_of(ShippingMethod).to receive_message_chain(:calculator, :preferences).and_return({ currency: currency })
-          allow_any_instance_of(ShippingMethod).to receive_message_chain(:calculator, :marked_for_destruction?)
-
-          allow(package).to receive_message_chain(:shipping_methods, includes: [shipping_method])
         end
 
         let(:currency) { "USD" }
@@ -46,11 +41,6 @@ module Spree
           it_should_behave_like "shipping rate doesn't match"
         end
 
-        context "when the calculator is not available for that order" do
-          before { allow_any_instance_of(ShippingMethod).to receive_message_chain(:calculator, :available?).and_return(false) }
-          it_should_behave_like "shipping rate doesn't match"
-        end
-
         context "when the currency is nil" do
           let(:currency) { nil }
           it_should_behave_like "shipping rate matches"
@@ -71,47 +61,51 @@ module Spree
         end
 
         it "sorts shipping rates by cost" do
-          shipping_methods = Array.new(3) { create(:shipping_method) }
-          allow(shipping_methods[0]).to receive_message_chain(:calculator, :compute).and_return(5.00)
-          allow(shipping_methods[1]).to receive_message_chain(:calculator, :compute).and_return(3.00)
-          allow(shipping_methods[2]).to receive_message_chain(:calculator, :compute).and_return(4.00)
+          ShippingMethod.destroy_all
+          create(:shipping_method, cost: 5)
+          create(:shipping_method, cost: 3)
+          create(:shipping_method, cost: 4)
 
-          allow(subject).to receive(:shipping_methods).and_return(shipping_methods)
-
-          expect(subject.shipping_rates(package).map(&:cost)).to eq %w[3.00 4.00 5.00].map(&BigDecimal.method(:new))
+          expect(subject.shipping_rates(package).map(&:cost)).to eq [3.00, 4.00, 5.00]
         end
 
         context "general shipping methods" do
-          let(:shipping_methods) { Array.new(2) { create(:shipping_method) } }
+          before { Spree::ShippingMethod.destroy_all }
 
-          it "selects the most affordable shipping rate" do
-            allow(shipping_methods[0]).to receive_message_chain(:calculator, :compute).and_return(5.00)
-            allow(shipping_methods[1]).to receive_message_chain(:calculator, :compute).and_return(3.00)
+          context 'with two shipping methods of different cost' do
+            let!(:shipping_methods) do
+              [
+                create(:shipping_method, cost: 5),
+                create(:shipping_method, cost: 3)
+              ]
+            end
 
-            allow(subject).to receive(:shipping_methods).and_return(shipping_methods)
-
-            expect(subject.shipping_rates(package).sort_by(&:cost).map(&:selected)).to eq [true, false]
+            it "selects the most affordable shipping rate" do
+              expect(subject.shipping_rates(package).sort_by(&:cost).map(&:selected)).to eq [true, false]
+            end
           end
 
-          it "selects the most affordable shipping rate and doesn't raise exception over nil cost" do
-            allow(shipping_methods[0]).to receive_message_chain(:calculator, :compute).and_return(1.00)
-            allow(shipping_methods[1]).to receive_message_chain(:calculator, :compute).and_return(nil)
+          context 'with one of the shipping methods having nil cost' do
+            let!(:shipping_methods) do
+              [
+                create(:shipping_method, cost: 1),
+                create(:shipping_method, cost: nil)
+              ]
+            end
 
-            allow(subject).to receive(:shipping_methods).and_return(shipping_methods)
+            it "selects the most affordable shipping rate and doesn't raise exception over nil cost" do
+              allow(shipping_methods[1]).to receive_message_chain(:calculator, :compute).and_return(nil)
+              allow(subject).to receive(:shipping_methods).and_return(shipping_methods)
 
-            subject.shipping_rates(package)
+              expect(subject.shipping_rates(package).map(&:shipping_method)).to eq([shipping_methods[0]])
+            end
           end
         end
 
         context "involves backend only shipping methods" do
-          let(:backend_method) { create(:shipping_method, display_on: "back_end") }
-          let(:generic_method) { create(:shipping_method) }
-
-          before do
-            allow(backend_method).to receive_message_chain(:calculator, :compute).and_return(0.00)
-            allow(generic_method).to receive_message_chain(:calculator, :compute).and_return(5.00)
-            allow(subject).to receive(:shipping_methods).and_return([backend_method, generic_method])
-          end
+          before{ Spree::ShippingMethod.destroy_all }
+          let!(:backend_method) { create(:shipping_method, display_on: "back_end", cost: 0.00) }
+          let!(:generic_method) { create(:shipping_method, cost: 5.00) }
 
           it "does not return backend rates at all" do
             expect(subject.shipping_rates(package).map(&:shipping_method_id)).to eq([generic_method.id])

--- a/core/spec/models/spree/stock/estimator_spec.rb
+++ b/core/spec/models/spree/stock/estimator_spec.rb
@@ -127,11 +127,7 @@ module Spree
           let!(:tax_rate) { create(:tax_rate, zone: order.tax_zone) }
 
           before do
-            Spree::ShippingMethod.all.each do |sm|
-              sm.tax_category_id = tax_rate.tax_category_id
-              sm.save
-            end
-            package.shipping_methods.map(&:reload)
+            shipping_method.update!(tax_category: tax_rate.tax_category)
           end
 
           it "links the shipping rate and the tax rate" do

--- a/core/spec/models/spree/stock/estimator_spec.rb
+++ b/core/spec/models/spree/stock/estimator_spec.rb
@@ -18,7 +18,7 @@ module Spree
           allow_any_instance_of(ShippingMethod).to receive_message_chain(:calculator, :preferences).and_return({ currency: currency })
           allow_any_instance_of(ShippingMethod).to receive_message_chain(:calculator, :marked_for_destruction?)
 
-          allow(package).to receive_messages(shipping_methods: [shipping_method])
+          allow(package).to receive_message_chain(:shipping_methods, includes: [shipping_method])
         end
 
         let(:currency) { "USD" }

--- a/core/spec/models/spree/stock/package_spec.rb
+++ b/core/spec/models/spree/stock/package_spec.rb
@@ -54,9 +54,9 @@ module Spree
         method2   = create(:shipping_method, stock_locations: [stock_location])
         method1.shipping_categories = [category1, category2]
         method2.shipping_categories = [category1, category2]
-        variant1 = mock_model(Variant, shipping_category: category1)
-        variant2 = mock_model(Variant, shipping_category: category2)
-        variant3 = mock_model(Variant, shipping_category: nil)
+        variant1 = mock_model(Variant, shipping_category_id: category1.id)
+        variant2 = mock_model(Variant, shipping_category_id: category2.id)
+        variant3 = mock_model(Variant, shipping_category_id: nil)
         contents = [ContentItem.new(build(:inventory_unit, variant: variant1)),
                     ContentItem.new(build(:inventory_unit, variant: variant1)),
                     ContentItem.new(build(:inventory_unit, variant: variant2)),
@@ -73,9 +73,9 @@ module Spree
         method2   = create(:shipping_method)
         method1.shipping_categories = [category1, category2]
         method2.shipping_categories = [category1]
-        variant1 = mock_model(Variant, shipping_category: category1)
-        variant2 = mock_model(Variant, shipping_category: category2)
-        variant3 = mock_model(Variant, shipping_category: nil)
+        variant1 = mock_model(Variant, shipping_category_id: category1.id)
+        variant2 = mock_model(Variant, shipping_category_id: category2.id)
+        variant3 = mock_model(Variant, shipping_category_id: nil)
         contents = [ContentItem.new(build(:inventory_unit, variant: variant1)),
                     ContentItem.new(build(:inventory_unit, variant: variant1)),
                     ContentItem.new(build(:inventory_unit, variant: variant2)),
@@ -86,7 +86,7 @@ module Spree
       end
 
       it 'builds an empty list of shipping methods when no categories' do
-        variant  = mock_model(Variant, shipping_category: nil)
+        variant  = mock_model(Variant, shipping_category_id: nil)
         contents = [ContentItem.new(build(:inventory_unit, variant: variant))]
         package  = Package.new(stock_location, contents)
         expect(package.shipping_methods).to be_empty


### PR DESCRIPTION
~~"WIP" as I'd like to add an additional test~~ Ready for review

The goal of this PR is to optimize shipping rate estimation, ie. `order.create_proposed_shipments`. This avoids N+1 queries over the stock locations by eager loading calculators, zones, and tax rates. This also avoids some queries selecting shipping_categories and shipping_methods.

Comparison of the SQL run by `order.create_proposed_shipments` on an order with a single line item can be seen here https://gist.github.com/jhawthorn/5d117dfd5a380a08b3f6