### PR TITLE
Remove useless unless setting i18n locale

### DIFF
--- a/core/lib/spree/core/controller_helpers/common.rb
+++ b/core/lib/spree/core/controller_helpers/common.rb
@@ -53,7 +53,7 @@ module Spree
             locale = session[:locale]
             locale ||= config_locale if respond_to?(:config_locale, true)
             locale ||= Rails.application.config.i18n.default_locale
-            locale ||= I18n.default_locale unless I18n.available_locales.map(&:to_s).include?(locale)
+            locale ||= I18n.default_locale
             I18n.locale = locale
           end
 

--- a/frontend/spec/controllers/controller_helpers_spec.rb
+++ b/frontend/spec/controllers/controller_helpers_spec.rb
@@ -7,7 +7,6 @@ describe Spree::ProductsController, :type => :controller do
 
   before do
     I18n.enforce_available_locales = false
-    expect(I18n).to receive(:available_locales).and_return([:en, :de])
     Spree::Frontend::Config[:locale] = :de
   end
 


### PR DESCRIPTION
The guarded expression, `locale ||= I18n.default_locale`, only had an effect when locale was nil. This makes the unless clause useless.