### PR TITLE
Stop using request referer in admin product controller

### DIFF
--- a/backend/app/controllers/spree/admin/products_controller.rb
+++ b/backend/app/controllers/spree/admin/products_controller.rb
@@ -9,7 +9,6 @@ module Spree
       helper_method :clone_object_url
 
       def show
-        session[:return_to] ||= request.referer
         redirect_to action: :edit
       end
 


### PR DESCRIPTION
Prevent setting `session[:return_to]` to a user-inputted value.
It originally tried to ensure that the "Back to Product" link on the
edit page would be preserved with the previous product url query from
the index page, but since the url is saved in `session[:return_to]`
in the index action, setting/protecting from it not being set isn't
neccessary here.