### PR TITLE
[RFC,WIP] Remove i18n from BaseHelper#available_countries

### DIFF
--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -118,7 +118,7 @@ module Spree
     end
 
     def available_countries
-      checkout_zone = Zone.find_by(name: Spree::Config[:checkout_zone])
+      checkout_zone = Zone.find_by(name: Spree::Config[:checkout_zone]) if Spree::Config[:checkout_zone]
 
       if checkout_zone && checkout_zone.kind == 'country'
         countries = checkout_zone.country_list
@@ -126,10 +126,7 @@ module Spree
         countries = Country.all
       end
 
-      countries.collect do |country|
-        country.name = Spree.t(country.iso, scope: 'country_names', default: country.name)
-        country
-      end.sort_by { |c| c.name.parameterize }
+      countries.to_a.sort_by(&:name)
     end
 
     def seo_url(taxon)

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -651,11 +651,6 @@ en:
     country: Country
     country_based: Country Based
     country_name: Name
-    country_names:
-      CA: Canada
-      FRA: France
-      ITA: Italy
-      US: United States of America
     coupon: Coupon
     coupon_code: Coupon code
     coupon_code_already_applied: The coupon code has already been applied to this order


### PR DESCRIPTION
Two of the four translations provided didn't work, they were using iso3 as the key instead of the 2 letter iso code. Because nobody has complained or fixed this, I don't think this functionality is being relied upon. Providing translations for countries this way also does not make sense since we don't provide the same functionality for states.

Performing the translations here is very slow, the whole method takes about 250ms on my machine.

```
irb(main):001:0> h = Class.new{ include Spree::BaseHelper }.new
=> #<#<Class:0x007f4e70c69510>:0x007f4e70c69470>
irb(main):002:0> Benchmark.ms{ h.available_countries }
Spree::Zone Load (0.2ms)  SELECT  "spree_zones".* FROM "spree_zones" WHERE "spree_zones"."name" IS NULL LIMIT 1
Spree::Country Load (1.5ms)  SELECT "spree_countries".* FROM "spree_countries"
=> 240.4056079685688
```


This removes the translations from this method, which makes it significantly faster, about 6ms on my machine.