### PR TITLE
Avoid extra query when default_country_id unset

### DIFF
--- a/core/app/models/spree/country.rb
+++ b/core/app/models/spree/country.rb
@@ -13,9 +13,9 @@ module Spree
     end
 
     def self.default
-      find(Spree::Config[:default_country_id])
-    rescue ActiveRecord::RecordNotFound
-      first
+      if default_country_id = Spree::Config[:default_country_id]
+        find_by_id(default_country_id)
+      end || first
     end
 
     def <=>(other)


### PR DESCRIPTION
Also avoids raising an exception in that case.