### PR TITLE
[WIP] Remove after_rollback from LogEntry

### DIFF
--- a/backend/spec/features/admin/orders/log_entries_spec.rb
+++ b/backend/spec/features/admin/orders/log_entries_spec.rb
@@ -14,7 +14,6 @@ describe "Log entries", :type => :feature do
       )
 
       payment.log_entries.create(
-        :source => payment.source,
         :details => response.to_yaml
       )
     end

--- a/core/app/models/spree/log_entry.rb
+++ b/core/app/models/spree/log_entry.rb
@@ -2,17 +2,6 @@ module Spree
   class LogEntry < Spree::Base
     belongs_to :source, polymorphic: true
 
-    # Fix for https://github.com/spree/spree/issues/1767
-    # If a payment fails, we want to make sure we keep the record of it failing
-    after_rollback :save_anyway
-
-    def save_anyway
-      log = Spree::LogEntry.new
-      log.source  = source
-      log.details = details
-      log.save!
-    end
-
     def parsed_details
       @details ||= YAML.load(details)
     end


### PR DESCRIPTION
WIP because I'm not yet 100% certain that removing that has no effect, need to test a bit more.

`after_rollback` has all kinds of problems. When it's run as part of our specs, the filter happens after our spec run (each spec is run inside a transaction), meaning that extra useless blank log entries end up in our database. Gross!

In core's test suite:

```
config.after(:suite){ p Spree::LogEntry.count } # => 149
```

I don't think we ever want this, if we were rolling back a log entry, we would also be rolling back a state change on a payment, which is _bad_.

This is similar to bc19fcb607377fcb02ecf0289ba6430b9d2cffd3
