### PR TITLE
Fixes error 'undefined local variable or method 'cart_link_url'

### DIFF
--- a/frontend/app/views/spree/shared/_main_nav_bar.html.erb
+++ b/frontend/app/views/spree/shared/_main_nav_bar.html.erb
@@ -7,6 +7,6 @@
       </noscript>
       &nbsp;
     </li>
-    <script>Spree.fetch_cart('<%= j cart_link_url %>')</script>
+    <script>Spree.fetch_cart('<%= j spree.cart_link_url %>')</script>
   </ul>
 </nav>


### PR DESCRIPTION
Fixes error like this 'undefined local variable or method 'cart_link_url'' for custom controller views  that extend from Spree::StoreController

To replicate the error

1. Create a new app using solidus engine
2. Add a new controller
3. Add a new view and use the engine's default frontend layout.
![screen shot 2015-12-06 at 3 59 42 pm](https://cloud.githubusercontent.com/assets/1588699/11616531/7710c0de-9c32-11e5-8909-f96d95188535.png)
