### PR TITLE
Fix regression - Allow complete the order if delivery step is removed

### DIFF
--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -110,7 +110,9 @@ module Spree
               # calls matter so that we do not process payments
               # until validations have passed
               before_transition to: :complete, do: :validate_line_item_availability, unless: :unreturned_exchange?
-              before_transition to: :complete, do: :ensure_available_shipping_rates
+              if states[:delivery]
+                before_transition to: :complete, do: :ensure_available_shipping_rates
+              end
               before_transition to: :complete, do: :ensure_promotions_eligible
               before_transition to: :complete, do: :ensure_line_item_variants_are_not_deleted
               before_transition to: :complete, do: :ensure_inventory_units, unless: :unreturned_exchange?

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -692,10 +692,17 @@ describe Spree::Order, :type => :model do
       Spree::Order.checkout_flow(&@old_checkout_flow)
     end
 
+    it "does not attempt to check shipping rates" do
+      order.email = 'user@example.com'
+      order.store = FactoryGirl.build(:store)
+      expect(order).not_to receive(:ensure_available_shipping_rates)
+      order.next!
+      assert_state_changed(order, 'cart', 'complete')
+    end
+
     it "does not attempt to process payments" do
       order.email = 'user@example.com'
       order.store = FactoryGirl.build(:store)
-      allow(order).to receive(:ensure_available_shipping_rates).and_return(true)
       allow(order).to receive(:ensure_promotions_eligible).and_return(true)
       allow(order).to receive(:ensure_line_item_variants_are_not_deleted).and_return(true)
       allow(order).to receive_message_chain(:line_items, :present?).and_return(true)


### PR DESCRIPTION
The commit https://github.com/solidusio/solidus/commit/7ba53b2c0c9a33140f299e04541834d6fbf9ccb1#diff-2c3e70899d4f22d0569021b01b0e307f added a ```before_transition``` to ```complete``` that checks the ```shipping rates```, but if the ```delivery``` step is not present, the ```order``` doesn't have ```shipments```.