### PR TITLE
Add StockItem#fill_status to enable perf improvements

### DIFF
--- a/core/app/models/spree/stock_item.rb
+++ b/core/app/models/spree/stock_item.rb
@@ -70,6 +70,19 @@ module Spree
       self.set_count_on_hand(0) if count_on_hand > 0
     end
 
+    def fill_status(quantity)
+      if count_on_hand >= quantity
+        on_hand = quantity
+        backordered = 0
+      else
+        on_hand = count_on_hand
+        on_hand = 0 if on_hand < 0
+        backordered = backorderable? ? (quantity - on_hand) : 0
+      end
+
+      [on_hand, backordered]
+    end
+
     private
       def verify_count_on_hand?
         count_on_hand_changed? && !backorderable? && (count_on_hand < count_on_hand_was) && (count_on_hand < 0)

--- a/core/app/models/spree/stock_location.rb
+++ b/core/app/models/spree/stock_location.rb
@@ -95,17 +95,7 @@ module Spree
 
     def fill_status(variant, quantity)
       if item = stock_item(variant)
-
-        if item.count_on_hand >= quantity
-          on_hand = quantity
-          backordered = 0
-        else
-          on_hand = item.count_on_hand
-          on_hand = 0 if on_hand < 0
-          backordered = item.backorderable? ? (quantity - on_hand) : 0
-        end
-
-        [on_hand, backordered]
+        item.fill_status(quantity)
       else
         [0, 0]
       end

--- a/core/db/migrate/20151219020209_add_stock_item_unique_index.rb
+++ b/core/db/migrate/20151219020209_add_stock_item_unique_index.rb
@@ -1,0 +1,9 @@
+class AddStockItemUniqueIndex < ActiveRecord::Migration
+  def change
+    # Add a database-level uniqueness constraint for databases that support it
+    # (postgres & sqlite)
+    if connection.adapter_name =~ /postgres|sqlite/i
+      add_index 'spree_stock_items', ['variant_id', 'stock_location_id'], where: 'deleted_at is null', unique: true
+    end
+  end
+end

--- a/core/spec/models/spree/stock/packer_spec.rb
+++ b/core/spec/models/spree/stock/packer_spec.rb
@@ -28,9 +28,8 @@ module Spree
         end
 
         it 'variants are added as backordered without enough on_hand' do
-          expect(stock_location).to receive(:fill_status).exactly(5).times.and_return(
-            *(Array.new(3, [1,0]) + Array.new(2, [0,1]))
-          )
+          inventory_units[0..2].each { |iu| stock_location.stock_item(iu.variant_id).set_count_on_hand(1) }
+          inventory_units[3..4].each { |iu| stock_location.stock_item(iu.variant_id).set_count_on_hand(0) }
 
           package = subject.default_package
           expect(package.on_hand.size).to eq 3

--- a/core/spec/models/spree/stock_location_spec.rb
+++ b/core/spec/models/spree/stock_location_spec.rb
@@ -170,10 +170,7 @@ module Spree
       end
 
       it 'zero on_hand with all backordered' do
-        zero_stock_item = mock_model(StockItem,
-                                     count_on_hand: 0,
-                                     backorderable?: true)
-        expect(subject).to receive(:stock_item).with(variant).and_return(zero_stock_item)
+        stock_item.set_count_on_hand(0)
 
         on_hand, backordered = subject.fill_status(variant, 20)
         expect(on_hand).to eq 0
@@ -182,12 +179,11 @@ module Spree
 
       context 'when backordering is not allowed' do
         before do
-          @stock_item = mock_model(StockItem, backorderable?: false)
-          expect(subject).to receive(:stock_item).with(variant).and_return(@stock_item)
+          stock_item.update!(backorderable: false)
         end
 
         it 'all on_hand' do
-          allow(@stock_item).to receive_messages(count_on_hand: 10)
+          stock_item.set_count_on_hand(10)
 
           on_hand, backordered = subject.fill_status(variant, 5)
           expect(on_hand).to eq 5
@@ -195,7 +191,7 @@ module Spree
         end
 
         it 'some on_hand' do
-          allow(@stock_item).to receive_messages(count_on_hand: 10)
+          stock_item.set_count_on_hand(10)
 
           on_hand, backordered = subject.fill_status(variant, 20)
           expect(on_hand).to eq 10
@@ -203,7 +199,7 @@ module Spree
         end
 
         it 'zero on_hand' do
-          allow(@stock_item).to receive_messages(count_on_hand: 0)
+          stock_item.set_count_on_hand(0)
 
           on_hand, backordered = subject.fill_status(variant, 20)
           expect(on_hand).to eq 0


### PR DESCRIPTION
While reviewing https://github.com/solidusio/solidus/pull/565 and checking performance I noticed that the Packer was really slow.  If people think this is worth doing then I'll add specs for the new method.

This adds a `fill_status` method to StockItem and updates
`StockLocation#fill_status` to use it.

This allows us to avoid N+1 queries by loading multiple stock items at
once and querying them directly.

While using this as a perf test:
https://gist.github.com/jordan-brough/d614babd1202a890b7da
I saw this performance difference:

Old code: 4270ms
This PR: 772ms