### PR TITLE
Perf improvements for Stock::Coordinator#build_packages

### DIFF
--- a/core/app/models/spree/stock/coordinator.rb
+++ b/core/app/models/spree/stock/coordinator.rb
@@ -55,9 +55,8 @@ module Spree
       #
       # Returns an array of Package instances
       def build_packages(packages = Array.new)
-        requested_stock_items.group_by(&:stock_location).each do |stock_location, stock_items|
-          variant_ids_in_stock_location = stock_items.map(&:variant_id)
-          units_for_location = unallocated_inventory_units.select { |unit| variant_ids_in_stock_location.include?(unit.variant_id) }
+        stock_location_variant_ids.each do |stock_location, variant_ids|
+          units_for_location = unallocated_inventory_units.select { |unit| variant_ids.include?(unit.variant_id) }
           packer = build_packer(stock_location, units_for_location)
           packages += packer.packages
         end
@@ -66,12 +65,19 @@ module Spree
 
       private
 
-      def unallocated_inventory_units
-        inventory_units - @preallocated_inventory_units
+      def stock_location_variant_ids
+        location_variant_ids = StockItem.where(variant_id: unallocated_variant_ids).joins(:stock_location).merge(StockLocation.active).pluck(:stock_location_id, :variant_id)
+
+        location_lookup = StockLocation.where(id: location_variant_ids.map(&:first).uniq).map { |l| [l.id, l] }.to_h
+
+        location_variant_ids.each_with_object({}) do |(location_id, variant_id), hash|
+          hash[location_lookup[location_id]] ||= Set.new
+          hash[location_lookup[location_id]] << variant_id
+        end
       end
 
-      def requested_stock_items
-        Spree::StockItem.where(variant_id: unallocated_variant_ids).joins(:stock_location).merge(StockLocation.active).includes(:stock_location)
+      def unallocated_inventory_units
+        inventory_units - @preallocated_inventory_units
       end
 
       def unallocated_variant_ids


### PR DESCRIPTION
I noticed this while looking at PR 565. Just for kicks I took a stab at improving the stock item querying and eliminating the querying and instantiation of a stock location for every stock item and here's what I saw for [an extreme test case](https://gist.github.com/jordan-brough/d4d690636cd4306211e0) (30 variants and 100 stock locations):

- Previous: 1,918ms
- PR #565: 332ms
- This PR: 75ms

This does use 2 queries instead of 1, but each query is simpler and should be faster.

Overall I'm not sure this one is worth the extra complexity but what do others think?