### PR TITLE
Drop duplicated find for shipping category

### DIFF
--- a/sample/db/samples/products.rb
+++ b/sample/db/samples/products.rb
@@ -78,12 +78,11 @@ products.each do |product_attrs|
   eur_price = product_attrs.delete(:eur_price)
   Spree::Config[:currency] = "USD"
 
-  default_shipping_category = Spree::ShippingCategory.find_by_name!("Default")
   product = Spree::Product.create!(default_attrs.merge(product_attrs))
   Spree::Config[:currency] = "EUR"
   product.reload
   product.price = eur_price
-  product.shipping_category = default_shipping_category
+  product.shipping_category = shipping_category
   product.save!
 end
 


### PR DESCRIPTION
The default shipping category already gets predefined at the beginning of the script, hence this second lookup that happens on every product creation is not necessary.

[:ok_hand: FIAS: 1 / 3 / 3 = 7](http://harvesthq.github.io/fias/?v1=1&v2=3&v3=3) -- (needs one +1)