### PR TITLE
Clean state if it doesn't belong to country

### DIFF
--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -162,7 +162,7 @@ module Spree
 
         # If states are not required we still check if state belongs to country
         # If it doesn't we just remove it without adding state errors
-        unless country.states_required || readonly?
+        unless country.states_required
           self.state = nil if state.present? && state.country != country
         end
 

--- a/core/spec/models/spree/address_spec.rb
+++ b/core/spec/models/spree/address_spec.rb
@@ -19,6 +19,7 @@ describe Spree::Address, :type => :model do
   context "validation" do
 
     let(:country) { mock_model(Spree::Country, :states => [state], :states_required => true) }
+    let(:country_without_states) { mock_model(Spree::Country, :states_required => false) }
     let(:state) { stub_model(Spree::State, :name => 'maryland', :abbr => 'md') }
     let(:address) { build(:address, :country => country) }
 
@@ -30,10 +31,18 @@ describe Spree::Address, :type => :model do
       before do
         Spree::Config.address_requires_state = false
       end
+
       it "address_requires_state preference is false" do
         address.state = nil
         address.state_name = nil
         expect(address).to be_valid
+      end
+
+      it "removes the state if it doens't belong to the country" do
+        address.state = state        
+        address.country = country_without_states
+        address.save
+        expect(address.state).to be_nil
       end
     end
 


### PR DESCRIPTION
Right now if validation isn't required, there's no clean-up done. This can lead to state being left over when changing countries.

On our solidus store we have `Spree::Config[:address_requires_state]` disabled and we only have `country.states_required = true` for countries for which we have data so we can show a select element. The current address validation for state isn't executed if `country.states_required` is false or `Spree::Config[:address_requires_state]` is false. 

This leads to a problem: when changing from a country that has states to another without states, the `state_id` remains on the address. 

This PR changes the state_validate to clean-up states.