### PR TITLE
Customer return hooks

### DIFF
--- a/backend/app/views/spree/admin/customer_returns/_return_item_selection.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/_return_item_selection.html.erb
@@ -19,7 +19,7 @@
       <% return_item = item_fields.object %>
 
       <tr>
-        <td class="align-center" class="inventory-unit-checkbox">
+        <td class="align-center inventory-unit-checkbox">
           <div style="display:none">
             <%= item_fields.hidden_field :inventory_unit_id %>
             <%= item_fields.hidden_field :return_authorization_id %>

--- a/backend/app/views/spree/admin/customer_returns/edit.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/edit.html.erb
@@ -16,7 +16,7 @@
 <% end %>
 
 <% if @pending_return_items.any? %>
-  <fieldset data-hook="accepted_return_items" class="no-border-bottom">
+  <fieldset data-hook="pending_return_items" class="no-border-bottom">
     <legend align="center"><%= Spree.t(:pending) %></legend>
     <%= render partial: 'return_item_decision', locals: {return_items: @pending_return_items, show_decision: true} %>
   </fieldset>


### PR DESCRIPTION
I found a couple of admin view hooks that were just broken recently. This should get them into a usable state. The first one we were duplicating the `class` attribute on the DOM, which isn't valid. The second one, it was a bad case of copy pasta.