### PR TITLE
Optimize initialization on models without preferences

### DIFF
--- a/core/app/models/spree/base.rb
+++ b/core/app/models/spree/base.rb
@@ -4,10 +4,19 @@ class Spree::Base < ActiveRecord::Base
 
   include Spree::RansackableAttributes
 
-  after_initialize do
+  def initialize_preference_defaults
     if has_attribute?(:preferences)
       self.preferences = default_preferences.merge(preferences)
     end
+  end
+
+  # Only run preference initialization on models which requires it. Improves
+  # performance of record initialization slightly.
+  def self.preference(*args)
+    # after_initialize can be called multiple times with the same symbol, it
+    # will only be called once on initialization.
+    after_initialize :initialize_preference_defaults
+    super
   end
 
   if Kaminari.config.page_method_name != :page


### PR DESCRIPTION
This hook was run on initialization of every model (`after_initialize` is run both on new and find), but is only necessary on models which have preferences. The hook is fairly quick, breaking out immediately after checking `has_attribute?`, but object initialization is so common an operation we should make it as fast as possible.

# Benchmark

``` ruby
Benchmark.ips do |x|
  x.report("building") do
    Spree::InventoryUnit.new
  end

  x.report("building and accessing") do
    Spree::InventoryUnit.new.state
  end
end
```

## Before
```
Calculating -------------------------------------
            building     1.507k i/100ms
building and accessing
                         1.428k i/100ms
-------------------------------------------------
            building     16.692k (± 4.2%) i/s -     84.392k
building and accessing
                         15.554k (± 3.4%) i/s -     78.540k
```

## Using method instead of block

```
Calculating -------------------------------------
            building     1.635k i/100ms
building and accessing
                         1.619k i/100ms
-------------------------------------------------
            building     18.004k (± 4.4%) i/s -     89.925k
building and accessing
                         17.195k (± 3.8%) i/s -     87.426k
```

## After

```
Calculating -------------------------------------
            building     1.753k i/100ms
building and accessing
                         1.739k i/100ms
-------------------------------------------------
            building     19.819k (± 3.8%) i/s -     99.921k
building and accessing
                         19.465k (± 3.9%) i/s -     97.384k
```