### PR TITLE
Improved CircleCI reporting

### DIFF
--- a/build-ci.rb
+++ b/build-ci.rb
@@ -86,11 +86,12 @@ private
   end
 
   def rspec_arguments
+    args = []
+    args += %W[--format documentation --profile 10]
     if report_dir = ENV['CIRCLE_TEST_REPORTS']
-      %W[-r rspec_junit_formatter --format RspecJunitFormatter -o #{report_dir}/rspec/junit.xml]
-    else
-      []
+      args += %W[-r rspec_junit_formatter --format RspecJunitFormatter -o #{report_dir}/rspec/junit.xml]
     end
+    args
   end
 
   # Execute system command via execve

--- a/build-ci.rb
+++ b/build-ci.rb
@@ -82,7 +82,15 @@ private
   # @return [Boolean]
   #   the success of the tests
   def run_tests
-    system(%w[bundle exec rspec spec])
+    system(%w[bundle exec rspec] + rspec_arguments)
+  end
+
+  def rspec_arguments
+    if report_dir = ENV['CIRCLE_TEST_REPORTS']
+      %W[-r rspec_junit_formatter --format RspecJunitFormatter -o #{report_dir}/rspec/junit.xml]
+    else
+      []
+    end
   end
 
   # Execute system command via execve

--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -36,6 +36,7 @@ group :test do
   gem 'poltergeist'
   gem 'timecop'
   gem 'with_model'
+  gem 'rspec_junit_formatter'
 end
 
 group :test, :development do


### PR DESCRIPTION
You can see an example run [here](https://circleci.com/gh/jhawthorn/solidus/408)

# Add JUnit Formatter

This allows CircleCI to understand the results of our test runs and reports them at the top of the page. Saves us from having to open the containers log output one-by-one.

## Before

![](http://i.hawth.ca/s/YMFFrup7.png)

## After

![](http://i.hawth.ca/s/3yubXZ30.png)

# Documentation formatter

Much more verbose, but should help determine run order. I don't think the dots were particularly helpful in the non-interactive CI environment

## Before

![](http://i.hawth.ca/s/0tmPLkxl.png)

## After

![](http://i.hawth.ca/s/0wTkty8K.png)

# Profile output

![](http://i.hawth.ca/s/Whl3kYN6.png)
