### PR TITLE
Allow the Stock::Estimator to be customized

### DIFF
--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -17,6 +17,7 @@
 #
 require "spree/core/search/base"
 require "spree/core/search/variant"
+require 'spree/core/stock_configuration'
 
 module Spree
   class AppConfiguration < Preferences::Configuration
@@ -309,6 +310,10 @@ module Spree
 
     def static_model_preferences
       @static_model_preferences ||= Spree::Preferences::StaticModelPreferences.new
+    end
+
+    def stock
+      Spree::StockConfiguration
     end
 
     # all the following can be deprecated when store prefs are no longer supported

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -175,7 +175,7 @@ module Spree
       # StockEstimator.new assigment below will replace the current shipping_method
       original_shipping_method_id = shipping_method.try!(:id)
 
-      new_rates = Stock::Estimator.new(order).shipping_rates(to_package)
+      new_rates = Spree::Config.stock.estimator_class.new(order).shipping_rates(to_package)
 
       # If one of the new rates matches the previously selected shipping
       # method, select that instead of the default provided by the estimator.

--- a/core/app/models/spree/stock/coordinator.rb
+++ b/core/app/models/spree/stock/coordinator.rb
@@ -120,7 +120,7 @@ module Spree
       end
 
       def estimate_packages(packages)
-        estimator = Estimator.new(order)
+        estimator = Spree::Config.stock.estimator_class.new(order)
         packages.each do |package|
           package.shipping_rates = estimator.shipping_rates(package)
         end

--- a/core/lib/spree/core/stock_configuration.rb
+++ b/core/lib/spree/core/stock_configuration.rb
@@ -1,0 +1,11 @@
+module Spree
+  module StockConfiguration
+    mattr_accessor :estimator_class do
+      '::Spree::Stock::Estimator'
+    end
+
+    def self.estimator_class
+      @@estimator_class.constantize
+    end
+  end
+end

--- a/core/spec/lib/spree/core/stock_configuration_spec.rb
+++ b/core/spec/lib/spree/core/stock_configuration_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+RSpec.describe Spree::StockConfiguration do
+  before(:all) { @estimator_class = described_class.estimator_class.to_s }
+  after(:all)  { described_class.estimator_class = @estimator_class }
+
+  describe '.estimator_class' do
+    subject { described_class.estimator_class }
+    let(:foo) { Struct.new :foo }
+
+    before { described_class.estimator_class = 'Foo' }
+    before { Foo = foo }
+
+    it { is_expected.to eq foo }
+  end
+end

--- a/core/spec/models/spree/app_configuration_spec.rb
+++ b/core/spec/models/spree/app_configuration_spec.rb
@@ -21,4 +21,8 @@ describe Spree::AppConfiguration, :type => :model do
     expect(prefs.variant_search_class).to eq Spree::Core::Search::Variant
   end
 
+  describe '#stock' do
+    subject { prefs.stock }
+    it { is_expected.to eq Spree::StockConfiguration }
+  end
 end

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -210,6 +210,11 @@ describe Spree::Shipment, :type => :model do
         expect(shipment.refresh_rates).to eq([])
       end
 
+      it 'uses the pluggable estimator class' do
+        expect(Spree::StockConfiguration).to receive(:estimator_class).and_call_original
+        shipment.refresh_rates
+      end
+
       context 'to_package' do
         let(:inventory_units) do
           [build(:inventory_unit, line_item: line_item, variant: variant, state: 'on_hand'),

--- a/core/spec/models/spree/stock/coordinator_spec.rb
+++ b/core/spec/models/spree/stock/coordinator_spec.rb
@@ -15,6 +15,11 @@ module Spree
           expect(subject).to receive(:estimate_packages).ordered
           subject.packages
         end
+
+        it 'uses the pluggable estimator class' do
+          expect(Spree::StockConfiguration).to receive(:estimator_class).and_call_original
+          subject.packages
+        end
       end
 
       describe "#shipments" do


### PR DESCRIPTION
Replace the Stock::Estimator with a user defined 'pluggable' class. An example use case for this is wanting to retrieve shipping rates from an external service such as easypost.

Install a new Stock::Estimator class in an initializer in the following
way:

```ruby
# /config/initializers/spree.rb
Spree::Config.stock.estimator_classs = 'SomeNewEstimator' 
```