### PR TITLE
Use with_deleted as association scope

### DIFF
--- a/core/app/models/spree/inventory_unit.rb
+++ b/core/app/models/spree/inventory_unit.rb
@@ -4,7 +4,7 @@ module Spree
     POST_SHIPMENT_STATES = %w(returned)
     CANCELABLE_STATES = ['on_hand', 'backordered', 'shipped']
 
-    belongs_to :variant, class_name: "Spree::Variant", inverse_of: :inventory_units
+    belongs_to :variant, -> { with_deleted }, class_name: "Spree::Variant", inverse_of: :inventory_units
     belongs_to :order, class_name: "Spree::Order", inverse_of: :inventory_units
     belongs_to :shipment, class_name: "Spree::Shipment", touch: true, inverse_of: :inventory_units
     belongs_to :return_authorization, class_name: "Spree::ReturnAuthorization", inverse_of: :inventory_units
@@ -85,13 +85,6 @@ module Spree
     def find_stock_item
       Spree::StockItem.where(stock_location_id: shipment.stock_location_id,
         variant_id: variant_id).first
-    end
-
-    # @note This returns the variant regardless of whether it was soft
-    #   deleted.
-    # @return [Spree::Variant] this inventory unit's variant.
-    def variant
-      Spree::Variant.unscoped { super }
     end
 
     # @return [Spree::ReturnItem] a valid return item for this inventory unit

--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -2,7 +2,7 @@ module Spree
   class LineItem < Spree::Base
     before_validation :invalid_quantity_check
     belongs_to :order, class_name: "Spree::Order", inverse_of: :line_items, touch: true
-    belongs_to :variant, class_name: "Spree::Variant", inverse_of: :line_items
+    belongs_to :variant, -> { with_deleted }, class_name: "Spree::Variant", inverse_of: :line_items
     belongs_to :tax_category, class_name: "Spree::TaxCategory"
 
     has_one :product, through: :variant
@@ -119,13 +119,6 @@ module Spree
     #   item, if there is one
     def product
       variant.product
-    end
-
-    # @note This will return the variant even if it has been deleted.
-    # @return [Spree::Variant, nil] the variant associated with this line
-    #   item, if there is one
-    def variant
-      Spree::Variant.unscoped { super }
     end
 
     # Sets the options on the line item according to the order's currency or

--- a/core/app/models/spree/payment_method.rb
+++ b/core/app/models/spree/payment_method.rb
@@ -2,7 +2,6 @@ module Spree
   class PaymentMethod < Spree::Base
     acts_as_paranoid
     DISPLAY = [:both, :front_end, :back_end]
-    default_scope -> { where(deleted_at: nil) }
 
     validates :name, presence: true
 

--- a/core/app/models/spree/price.rb
+++ b/core/app/models/spree/price.rb
@@ -1,7 +1,7 @@
 module Spree
   class Price < Spree::Base
     acts_as_paranoid
-    belongs_to :variant, class_name: 'Spree::Variant', inverse_of: :prices, touch: true
+    belongs_to :variant, -> { with_deleted }, class_name: 'Spree::Variant', inverse_of: :prices, touch: true
 
     validate :check_price
     validates :amount, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
@@ -29,13 +29,6 @@ module Spree
     # @param price [String, #to_d] a new amount
     def price=(price)
       self[:amount] = Spree::LocalizedNumber.parse(price)
-    end
-
-    # @note This returns the variant regardless of whether it was soft
-    #   deleted.
-    # @return [Spree::Variant] this price's variant.
-    def variant
-      Spree::Variant.unscoped { super }
     end
 
     private

--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -4,8 +4,6 @@ module Spree
     include Spree::CalculatedAdjustments
     DISPLAY = [:both, :front_end, :back_end]
 
-    default_scope -> { where(deleted_at: nil) }
-
     has_many :shipping_method_categories, :dependent => :destroy
     has_many :shipping_categories, through: :shipping_method_categories
     has_many :shipping_rates, inverse_of: :shipping_method

--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -13,7 +13,7 @@ module Spree
     has_many :shipping_method_zones
     has_many :zones, through: :shipping_method_zones
 
-    belongs_to :tax_category, :class_name => 'Spree::TaxCategory'
+    belongs_to :tax_category, -> { with_deleted }, :class_name => 'Spree::TaxCategory'
 
     validates :name, presence: true
 
@@ -38,10 +38,6 @@ module Spree
     # Some shipping methods are only meant to be set via backend
     def frontend?
       self.display_on != "back_end"
-    end
-
-    def tax_category
-      Spree::TaxCategory.unscoped { super }
     end
 
     private

--- a/core/app/models/spree/shipping_rate.rb
+++ b/core/app/models/spree/shipping_rate.rb
@@ -1,8 +1,8 @@
 module Spree
   class ShippingRate < Spree::Base
     belongs_to :shipment, class_name: 'Spree::Shipment'
-    belongs_to :shipping_method, class_name: 'Spree::ShippingMethod', inverse_of: :shipping_rates
-    belongs_to :tax_rate, class_name: 'Spree::TaxRate'
+    belongs_to :shipping_method, -> { with_deleted }, class_name: 'Spree::ShippingMethod', inverse_of: :shipping_rates
+    belongs_to :tax_rate, -> { with_deleted }, class_name: 'Spree::TaxRate'
 
     delegate :order, :currency, to: :shipment
     delegate :name, to: :shipping_method
@@ -42,16 +42,8 @@ module Spree
       Spree::Money.new(tax_amount, currency: currency)
     end
 
-    def shipping_method
-      Spree::ShippingMethod.unscoped { super }
-    end
-
     def shipping_method_code
       shipping_method.code
-    end
-
-    def tax_rate
-      Spree::TaxRate.unscoped { super }
     end
   end
 end

--- a/core/app/models/spree/stock_item.rb
+++ b/core/app/models/spree/stock_item.rb
@@ -3,7 +3,7 @@ module Spree
     acts_as_paranoid
 
     belongs_to :stock_location, class_name: 'Spree::StockLocation', inverse_of: :stock_items
-    belongs_to :variant, class_name: 'Spree::Variant', inverse_of: :stock_items
+    belongs_to :variant, -> { with_deleted }, class_name: 'Spree::Variant', inverse_of: :stock_items
     has_many :stock_movements, inverse_of: :stock_item
 
     validates_presence_of :stock_location, :variant
@@ -61,13 +61,6 @@ module Spree
     # @return [Boolean] true if this stock item can be included in a shipment
     def available?
       self.in_stock? || self.backorderable?
-    end
-
-    # @note This returns the variant regardless of whether it was soft
-    #   deleted.
-    # @return [Spree::Variant] this stock item's variant.
-    def variant
-      Spree::Variant.unscoped { super }
     end
 
     # Sets the count on hand to zero if it not already zero.

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -18,7 +18,7 @@ module Spree
 
     include Spree::DefaultPrice
 
-    belongs_to :product, touch: true, class_name: 'Spree::Product', inverse_of: :variants
+    belongs_to :product, -> { with_deleted }, touch: true, class_name: 'Spree::Product', inverse_of: :variants
     belongs_to :tax_category, class_name: 'Spree::TaxCategory'
 
     delegate :name, :description, :slug, :available_on, :shipping_category_id,
@@ -156,14 +156,6 @@ module Spree
     # @return [Boolean] true if this variant has been deleted
     def deleted?
       !!deleted_at
-    end
-
-    # Override ActiveRecord finder to function even if the product has been
-    # deleted.
-    #
-    # @return [Spree::Product]
-    def product
-      Spree::Product.unscoped { super }
     end
 
     # Assign given options hash to option values.


### PR DESCRIPTION
Previously we overrode association methods like the following:

``` ruby
belongs_to :variant
def variant
  Spree::Variant.unscoped { super }
end
```

This commit accomplishes the same using a scope on the `belongs_to`

``` ruby
belongs_to :variant, -> { with_deleted }
```

I believe this is shorter and reads better. I think this has only worked in recent rails versions which is why it was not done this way originally.

This is also significantly faster when accessing associations which are already loaded, as it avoids building the "unscoped" scope when a query isn't required. This operation is extremely frequent in some parts of the codebase. For example `Stock::`, which calls `InventoryUnit#variant` many times.

``` ruby
Benchmark.ips do |x|
  variant = Variant.new
  x.report("variant.product") { variant.product }
end
```

Before:
```
Calculating -------------------------------------
     variant.product     6.703k i/100ms
-------------------------------------------------
     variant.product    104.842k (± 2.7%) i/s -    529.537k
```

After:
```
Calculating -------------------------------------
     variant.product    18.930k i/100ms
-------------------------------------------------
     variant.product    737.723k (± 3.3%) i/s -      3.691M
```