### PR TITLE
Better error messaging for stock transfers

### DIFF
--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1029,7 +1029,7 @@ en:
     normal_amount: Normal Amount
     not: not
     not_available: N/A
-    not_enough_stock: There is not enough inventory at the source location to complete this transfer.
+    not_enough_stock: "There is not enough inventory at the source location to complete this transfer. Errors: %{errors}."
     not_found: ! '%{resource} is not found'
     note: Note
     notice_messages:


### PR DESCRIPTION
Looking for feedback on this PR. We want to bubble up more detailed information when a stock transfer has errors (particularly when we go to finalize the transfer or actually make the transfer).  Does this seem like a reasonable way to do this?  Any other ideas?  If it seems OK I will add specs.

- Ensure that all items are in stock before finalizing a stock
transfer. This was already happening before `transfer` but not before
`finalize`.
- Bubble up more error information when items are not in stock.