### PR TITLE
Downgrade to sprockets 2.x

### DIFF
--- a/backend/solidus_backend.gemspec
+++ b/backend/solidus_backend.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'select2-rails',   '3.5.9.1' # 3.5.9.2 breaks forms
 
   s.add_dependency 'handlebars_assets'
+  s.add_dependency 'sprockets-rails', '~> 2.0' # 3.0 breaks handlebars_assets
 end

--- a/frontend/solidus_frontend.gemspec
+++ b/frontend/solidus_frontend.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'jquery-rails'
 
   s.add_development_dependency 'capybara-accessible'
+  s.add_development_dependency 'sprockets-rails', '~> 2.0'
 end


### PR DESCRIPTION
Sprockets-rails 3.0 just landed and is causing us test failures. https://circleci.com/gh/solidusio/solidus/1407

Still looking into it, but this commit locks us to sprockets 2.x for now