### PR TITLE
Fix deleted tracking numbers on stock transfers

### DIFF
--- a/core/app/models/spree/stock_transfer.rb
+++ b/core/app/models/spree/stock_transfer.rb
@@ -46,7 +46,7 @@ module Spree
       finalized? && shipped? && !closed?
     end
 
-    def ship(tracking_number: nil, shipped_at: nil)
+    def ship(tracking_number: self.tracking_number, shipped_at: nil)
       update_attributes!(tracking_number: tracking_number, shipped_at: shipped_at)
     end
 

--- a/core/spec/models/spree/stock_transfer_spec.rb
+++ b/core/spec/models/spree/stock_transfer_spec.rb
@@ -249,6 +249,26 @@ module Spree
       end
     end
 
+    describe '#ship' do
+      let(:stock_transfer) { create(:stock_transfer, tracking_number: "ABC123") }
+
+      context "tracking number is provided" do
+        subject { stock_transfer.ship(tracking_number: "XYZ123") }
+
+        it "updates the tracking number" do
+          expect { subject }.to change { stock_transfer.tracking_number }.from("ABC123").to("XYZ123")
+        end
+      end
+
+      context "tracking number is not provided" do
+        subject { stock_transfer.ship }
+
+        it "preserves the existing tracking number" do
+          expect { subject }.to_not change { stock_transfer.tracking_number }.from("ABC123")
+        end
+      end
+    end
+
     describe '#transfer' do
       let(:stock_transfer) { create(:stock_transfer_with_items) }
 


### PR DESCRIPTION
When a stock transfer already has a tracking number, the value was being overridden by the default value of the ship method.