### PR TITLE
Reload line items after `order.merge!`

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -454,6 +454,8 @@ module Spree
 
       updater.update
 
+      self.line_items.reload
+
       # So that the destroy doesn't take out line items which may have been re-assigned
       order.line_items.reload
       order.destroy

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -261,13 +261,15 @@ describe Spree::Order, :type => :model do
           order_1.merge!(order_2)
           expect(order_1.line_items.count).to eq(2)
 
-          line_item = order_1.line_items.first
-          expect(line_item.quantity).to eq(1)
-          expect(line_item.variant_id).to eq(variant.id)
+          line_items = order_1.line_items.map do |line_item|
+            { variant_id: line_item.variant_id, quantity: line_item.quantity }
+          end
 
-          line_item = order_1.line_items.last
-          expect(line_item.quantity).to eq(1)
-          expect(line_item.variant_id).to eq(variant.id)
+          expect(line_items)
+            .to eq([
+              { variant_id: variant.id, quantity: 1 },
+              { variant_id: variant.id, quantity: 1 }
+            ])
         end
       end
     end


### PR DESCRIPTION
An order's `line_items` were not up to date after `merge!`

The tests use of `.count`, `.first` and `.last` resulted in a false positive.