### PR TITLE
Rebrand admin flash notifications

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/components/_messages.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_messages.scss
@@ -45,10 +45,12 @@
 
   &.success {
     @include flash-variant($color-success);
+    @include prepend-icon($character-check);
   }
 
   &.error   {
     @include flash-variant($color-error);
+    @include prepend-icon($character-exclamation);
   }
 
   &:before {

--- a/backend/app/assets/stylesheets/spree/backend/components/_messages.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_messages.scss
@@ -30,16 +30,30 @@
   z-index: 1000;
 }
 
-.flash {
-  padding: 16px;
-  text-align: center;
-  font-size: 120%;
-  color: $color-1;
-  font-weight: $font-weight-bold;
+@mixin flash-variant($color) {
+  color: $color;
+  background-color: rgba($color, 0.3);
+}
 
-  &.notice  { background-color: rgba($color-notice,  0.8) }
-  &.success { background-color: rgba($color-success, 0.8) }
-  &.error   { background-color: rgba($color-error,   0.8) }
+.flash {
+  padding: 1em;
+  font-size: 120%;
+
+  &.notice  {
+    @include flash-variant($color-notice);
+  }
+
+  &.success {
+    @include flash-variant($color-success);
+  }
+
+  &.error   {
+    @include flash-variant($color-error);
+  }
+
+  &:before {
+    margin-right: 1em;
+  }
 }
 
 .alert {

--- a/backend/app/assets/stylesheets/spree/backend/globals/_variables.scss
+++ b/backend/app/assets/stylesheets/spree/backend/globals/_variables.scss
@@ -195,3 +195,8 @@ $width-sidebar-flyout:           225px !default;
 // Stacking
 //--------------------------------------------------------------
 $z-index-navbar-flyout:          1000;
+
+// Characters
+//--------------------------------------------------------------
+$character-check:           "\f00c";
+$character-exclamation:     "\f12a";

--- a/backend/app/assets/stylesheets/spree/backend/globals/_variables.scss
+++ b/backend/app/assets/stylesheets/spree/backend/globals/_variables.scss
@@ -10,6 +10,10 @@ $base-font-family: "Open Sans", "Helvetica Neue", "Helvetica", Helvetica, Arial,
 //--------------------------------------------------------------
 
 // Basic color palette for admin
+$apple:                          hsl(105, 48, 37) !default;
+$old-brick:                      hsl(5, 67, 36) !default;
+$pirate-gold:                    hsl(45, 100, 37) !default;
+
 $color-1:                        #FFFFFF !default;    // White
 $color-2:                        #9FC820 !default;    // Green
 $color-3:                        #5498DA !default;    // Light Blue
@@ -41,9 +45,9 @@ $color-navbar-submenu-bg:       very-light($color-navbar-bg, 4) !default;
 $color-navbar-text:             $color-1 !default;
 
 // Basic flash colors
-$color-success:                  $color-2 !default;
-$color-notice:                   $color-6 !default;
-$color-error:                    $color-5 !default;
+$color-success:                  $apple !default;
+$color-notice:                   $pirate-gold !default;
+$color-error:                    $old-brick !default;
 
 // Color for spinner
 $color-spinner: #fff;

--- a/backend/app/assets/stylesheets/spree/backend/globals/mixins/prepend_icon.scss
+++ b/backend/app/assets/stylesheets/spree/backend/globals/mixins/prepend_icon.scss
@@ -1,0 +1,6 @@
+@mixin prepend-icon($character) {
+  &:before {
+    @extend .fa;
+    content: $character;
+  }
+}

--- a/backend/app/assets/stylesheets/spree/backend/spree_admin.scss
+++ b/backend/app/assets/stylesheets/spree/backend/spree_admin.scss
@@ -5,6 +5,7 @@
 @import 'spree/backend/globals/variables';
 
 @import 'spree/backend/globals/mixins/caret';
+@import 'spree/backend/globals/mixins/prepend_icon';
 
 @import 'spree/backend/shared/typography';
 @import 'spree/backend/shared/tables';


### PR DESCRIPTION
Part of [Solidus admin branding](https://github.com/solidusio/solidus/issues/520)

These colours are going to need some tweaks. 30% opacity on flash notifications is just too transparent for something that needs to sit on top of content. We can achieve the same colour with a `tint` and keep them someone legible.

## Before
![screen shot 2015-12-18 at 3 49 04 pm](https://cloud.githubusercontent.com/assets/1529452/11909788/5176fee8-a5a0-11e5-8ca2-eeb5b784be74.png)

## After
![screen shot 2015-12-18 at 3 50 38 pm](https://cloud.githubusercontent.com/assets/1529452/11909791/5720ee58-a5a0-11e5-845c-6973f1b35db0.png)
