### PR TITLE
Lock sprockets-rails to 2.x everywhere

### DIFF
--- a/backend/solidus_backend.gemspec
+++ b/backend/solidus_backend.gemspec
@@ -27,5 +27,4 @@ Gem::Specification.new do |s|
   s.add_dependency 'select2-rails',   '3.5.9.1' # 3.5.9.2 breaks forms
 
   s.add_dependency 'handlebars_assets'
-  s.add_dependency 'sprockets-rails', '~> 2.0' # 3.0 breaks handlebars_assets
 end

--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -43,4 +43,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'twitter_cldr', '~> 3.0'
 
   s.add_development_dependency 'email_spec', '~> 1.6'
+  s.add_dependency 'sprockets-rails', '~> 2.0'
 end

--- a/frontend/solidus_frontend.gemspec
+++ b/frontend/solidus_frontend.gemspec
@@ -25,5 +25,4 @@ Gem::Specification.new do |s|
   s.add_dependency 'jquery-rails'
 
   s.add_development_dependency 'capybara-accessible'
-  s.add_development_dependency 'sprockets-rails', '~> 2.0'
 end


### PR DESCRIPTION
Same thing as 5988804b30805419e42d116a17746e0c22842ee4.
This was making api, sample, and core specs fail.  See https://circleci.com/gh/solidusio/solidus/1419