### PR TITLE
Improve uniqueness validations for paranoia models

### DIFF
--- a/core/app/models/spree/stock_item.rb
+++ b/core/app/models/spree/stock_item.rb
@@ -7,8 +7,7 @@ module Spree
     has_many :stock_movements, inverse_of: :stock_item
 
     validates_presence_of :stock_location, :variant
-    # TODO: Drop the `conditions` once we require paranoia >= 2.1.4
-    validates_uniqueness_of :variant_id, scope: [:stock_location_id], unless: :deleted_at, conditions: -> { where(deleted_at: nil) }
+    validates_uniqueness_of :variant_id, scope: [:stock_location_id], unless: :deleted_at
     validates :count_on_hand, numericality: { greater_than_or_equal_to: 0 }, if: :verify_count_on_hand?
 
     delegate :weight, :should_track_inventory?, to: :variant

--- a/core/app/models/spree/stock_item.rb
+++ b/core/app/models/spree/stock_item.rb
@@ -7,7 +7,8 @@ module Spree
     has_many :stock_movements, inverse_of: :stock_item
 
     validates_presence_of :stock_location, :variant
-    validates_uniqueness_of :variant_id, scope: [:stock_location_id, :deleted_at]
+    # TODO: Drop the `conditions` once we require paranoia >= 2.1.4
+    validates_uniqueness_of :variant_id, scope: [:stock_location_id], unless: :deleted_at, conditions: -> { where(deleted_at: nil) }
     validates :count_on_hand, numericality: { greater_than_or_equal_to: 0 }, if: :verify_count_on_hand?
 
     delegate :weight, :should_track_inventory?, to: :variant

--- a/core/app/models/spree/tax_category.rb
+++ b/core/app/models/spree/tax_category.rb
@@ -1,7 +1,9 @@
 module Spree
   class TaxCategory < Spree::Base
     acts_as_paranoid
-    validates :name, presence: true, uniqueness: { scope: :deleted_at, allow_blank: true }
+    validates :name, presence: true
+    # TODO: Drop the `conditions` once we require paranoia >= 2.1.4
+    validates_uniqueness_of :name, unless: :deleted_at, conditions: -> { where(deleted_at: nil) }
 
     has_many :tax_rates, dependent: :destroy, inverse_of: :tax_category
     after_save :ensure_one_default

--- a/core/app/models/spree/tax_category.rb
+++ b/core/app/models/spree/tax_category.rb
@@ -2,8 +2,7 @@ module Spree
   class TaxCategory < Spree::Base
     acts_as_paranoid
     validates :name, presence: true
-    # TODO: Drop the `conditions` once we require paranoia >= 2.1.4
-    validates_uniqueness_of :name, unless: :deleted_at, conditions: -> { where(deleted_at: nil) }
+    validates_uniqueness_of :name, unless: :deleted_at
 
     has_many :tax_rates, dependent: :destroy, inverse_of: :tax_category
     after_save :ensure_one_default

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -49,7 +49,8 @@ module Spree
 
     validates :cost_price, numericality: { greater_than_or_equal_to: 0, allow_nil: true }
     validates :price,      numericality: { greater_than_or_equal_to: 0, allow_nil: true }
-    validates_uniqueness_of :sku, allow_blank: true, conditions: -> { where(deleted_at: nil) }
+    # TODO: Drop the `conditions` once we require paranoia >= 2.1.4
+    validates_uniqueness_of :sku, allow_blank: true, unless: :deleted_at, conditions: -> { where(deleted_at: nil) }
 
     after_create :create_stock_items
     after_create :set_position

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -49,8 +49,7 @@ module Spree
 
     validates :cost_price, numericality: { greater_than_or_equal_to: 0, allow_nil: true }
     validates :price,      numericality: { greater_than_or_equal_to: 0, allow_nil: true }
-    # TODO: Drop the `conditions` once we require paranoia >= 2.1.4
-    validates_uniqueness_of :sku, allow_blank: true, unless: :deleted_at, conditions: -> { where(deleted_at: nil) }
+    validates_uniqueness_of :sku, allow_blank: true, unless: :deleted_at
 
     after_create :create_stock_items
     after_create :set_position

--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'kaminari', '~> 0.15', '>= 0.15.1'
   s.add_dependency 'monetize', '~> 1.1'
   s.add_dependency 'paperclip', '~> 4.2.0'
-  s.add_dependency 'paranoia', '~> 2.1.0'
+  s.add_dependency 'paranoia', '~> 2.1.4'
   s.add_dependency 'premailer-rails'
   s.add_dependency 'rails', '~> 4.2.0'
   s.add_dependency 'ransack', '~> 1.6.0'


### PR DESCRIPTION
- Including "deleted_at" in the "scope" of a uniqueness validation is
not really what we want.  Instead, we just don't need to check
uniqueness at all for deleted items, and we want to check with
`deleted_at: nil` for non-deleted items.
- The `deleted_at: nil` condition isn't needed anymore after Paranoia
2.1.4 since it is added automatically. Make note of that.

We could require Paranoia >= 2.1.4 if we'd like and clean this up even further.