### PR TITLE
Use static preferences also for backend and frontend configs.

### DIFF
--- a/core/lib/generators/spree/install/templates/config/initializers/spree.rb
+++ b/core/lib/generators/spree/install/templates/config/initializers/spree.rb
@@ -6,6 +6,8 @@ Spree.config do |config|
   # changes them to be stored in memory.
   # This will be the default in a future version.
   config.use_static_preferences!
+  Spree::Frontend::Config.use_static_preferences!
+  Spree::Backend::Config.use_static_preferences!
 
   # Core:
 


### PR DESCRIPTION
`Spree::Frontend::Config[:locale]` is a preference looked-up on every request. Best to avoid the sql lookup.

```sql
# Before
>> Spree::Frontend::Config[:locale] #=> nil
D, [2015-12-20T16:37:37.060809 #30296] DEBUG -- :   Spree::Preference Load (0.9ms)  SELECT  "spree_preferences".* FROM "spree_preferences" WHERE "spree_preferences"."key" = $1 LIMIT 1 /*application:Sandbox*/  [["key", "spree/frontend_configuration/locale"]]

# After
>> Spree::Frontend::Config[:locale] #=> nil
```

Not the prettiest; I can also place it at the bottom of the spree.rb template, and I welcome a better suggestion.

Alternatively, default all preferences to their static versions as mentioned in the comment.