### PR TITLE
Even more Capybara synchronization fixes

### DIFF
--- a/backend/spec/features/admin/configuration/general_settings_spec.rb
+++ b/backend/spec/features/admin/configuration/general_settings_spec.rb
@@ -3,9 +3,12 @@ require 'spec_helper'
 describe "General Settings", type: :feature, js: true do
   stub_authorization!
 
+  let!(:store) do
+    create(:store, name: 'Test Store', url: 'test.example.org',
+           mail_from_address: 'test@example.org')
+  end
+
   before(:each) do
-    store = create(:store, name: 'Test Store', url: 'test.example.org',
-                           mail_from_address: 'test@example.org')
     visit spree.admin_path
     click_link "Settings"
     click_link "General Settings"
@@ -14,9 +17,9 @@ describe "General Settings", type: :feature, js: true do
   context "visiting general settings (admin)" do
     it "should have the right content" do
       expect(page).to have_content("General Settings")
-      expect(find("#store_name").value).to eq("Test Store")
-      expect(find("#store_url").value).to eq("test.example.org")
-      expect(find("#store_mail_from_address").value).to eq("test@example.org")
+      expect(page).to have_field("store_name", with: "Test Store")
+      expect(page).to have_field("store_url", with: "test.example.org")
+      expect(page).to have_field("store_mail_from_address", with: "test@example.org")
     end
   end
 
@@ -27,8 +30,8 @@ describe "General Settings", type: :feature, js: true do
       click_button "Update"
 
       assert_successful_update_message(:general_settings)
-      expect(find("#store_name").value).to eq("Spree Demo Site99")
-      expect(find("#store_mail_from_address").value).to eq("spree@example.org")
+      expect(page).to have_field("store_name", with: "Spree Demo Site99")
+      expect(page).to have_field("store_mail_from_address", with: "spree@example.org")
     end
   end
 

--- a/backend/spec/features/admin/configuration/payment_methods_spec.rb
+++ b/backend/spec/features/admin/configuration/payment_methods_spec.rb
@@ -52,7 +52,7 @@ describe "Payment Methods", :type => :feature do
       fill_in "payment_method_name", :with => "Payment 99"
       click_button "Update"
       expect(page).to have_content("successfully updated!")
-      expect(find_field("payment_method_name").value).to eq("Payment 99")
+      expect(page).to have_field("payment_method_name", with: "Payment 99")
     end
 
     it "should display validation errors" do

--- a/backend/spec/features/admin/orders/customer_details_spec.rb
+++ b/backend/spec/features/admin/orders/customer_details_spec.rb
@@ -71,7 +71,7 @@ describe "Customer Details", type: :feature, js: true do
         click_button "Update"
         expect(page).to have_content "Customer Details Updated"
         click_link "Customer Details"
-        expect(find_field("order_bill_address_attributes_state_name").value).to eq("Piaui")
+        expect(page).to have_field("order_bill_address_attributes_state_name", with: "Piaui")
       end
     end
 
@@ -122,7 +122,7 @@ describe "Customer Details", type: :feature, js: true do
 
       it "sets default country when displaying form" do
         click_link "Customer Details"
-        expect(find_field("order_bill_address_attributes_country_id").value.to_i).to eq brazil.id
+        expect(page).to have_field("order_bill_address_attributes_country_id", with: brazil.id)
       end
     end
 

--- a/backend/spec/features/admin/orders/payments_spec.rb
+++ b/backend/spec/features/admin/orders/payments_spec.rb
@@ -150,10 +150,10 @@ describe 'Payments', :type => :feature do
         within_row(1) do
           click_icon(:edit)
           fill_in('amount', with: 'invalid')
-          expect(find('td.amount input').value).to eq('invalid')
-          expect(payment.reload.amount).to eq(150.00)
         end
         expect(page).to have_selector('.flash.error', text: 'Invalid resource. Please fix errors and try again.')
+        expect(page).to have_field('amount', with: 'invalid')
+        expect(payment.reload.amount).to eq(150.00)
       end
     end
 

--- a/backend/spec/features/admin/orders/payments_spec.rb
+++ b/backend/spec/features/admin/orders/payments_spec.rb
@@ -80,7 +80,7 @@ describe 'Payments', :type => :feature do
       end
 
       click_icon :void
-      expect(find('#payment_status').text).to eq('BALANCE DUE')
+      expect(page).to have_css('#payment_status', text: 'BALANCE DUE')
       expect(page).to have_content('Payment Updated')
 
       within_row(1) do

--- a/backend/spec/features/admin/products/edit/products_spec.rb
+++ b/backend/spec/features/admin/products/edit/products_spec.rb
@@ -15,14 +15,14 @@ describe 'Product Details', :type => :feature do
 
       click_link 'Product Details'
 
-      expect(find('.page-title').text.strip).to eq('Editing Product “Bún thịt nướng”')
-      expect(find('input#product_name').value).to eq('Bún thịt nướng')
-      expect(find('input#product_slug').value).to eq('bun-th-t-n-ng')
-      expect(find('textarea#product_description').text.strip).to eq('lorem ipsum')
-      expect(find('input#product_price').value).to eq('19.99')
-      expect(find('input#product_cost_price').value).to eq('17.00')
-      expect(find('input#product_available_on').value).to eq("2013/08/14")
-      expect(find('input#product_sku').value).to eq('A100')
+      expect(page).to have_css('.page-title', text: 'Editing Product “Bún thịt nướng”')
+      expect(page).to have_field('product_name', with: 'Bún thịt nướng')
+      expect(page).to have_field('product_slug', with: 'bun-th-t-n-ng')
+      expect(page).to have_field('product_description', with: 'lorem ipsum')
+      expect(page).to have_field('product_price', with: '19.99')
+      expect(page).to have_field('product_cost_price', with: '17.00')
+      expect(page).to have_field('product_available_on', with: "2013/08/14")
+      expect(page).to have_field('product_sku', with: 'A100')
     end
 
     it "should handle slug changes" do

--- a/backend/spec/features/admin/products/edit/taxons_spec.rb
+++ b/backend/spec/features/admin/products/edit/taxons_spec.rb
@@ -3,17 +3,15 @@ require 'spec_helper'
 describe "Product Taxons", :type => :feature do
   stub_authorization!
 
-  after do
-    Capybara.ignore_hidden_elements = true
-  end
-
-  before do
-    Capybara.ignore_hidden_elements = false
-  end
-
   context "managing taxons" do
-    def selected_taxons
-      find("#product_taxon_ids").value.split(',').map(&:to_i).uniq
+    def assert_selected_taxons(taxons)
+      # Regression test for #2139
+      taxons.each do |taxon|
+        expect(page).to have_css(".select2-search-choice", text: taxon.name)
+      end
+
+      expected_value = taxons.map(&:id).join(",")
+      expect(page).to have_xpath("//*[@id = 'product_taxon_ids' and @value = '#{expected_value}']", visible: :all)
     end
 
     it "should allow an admin to manage taxons", :js => true do
@@ -22,22 +20,13 @@ describe "Product Taxons", :type => :feature do
       product = create(:product)
       product.taxons << taxon_1
 
-      visit spree.admin_path
-      click_nav "Products"
-      within("table.index") do
-        click_icon :edit
-      end
+      visit spree.edit_admin_product_path(product)
 
-      expect(find(".select2-search-choice").text).to eq(taxon_1.name)
-      expect(selected_taxons).to match_array([taxon_1.id])
+      assert_selected_taxons([taxon_1])
 
       select2_search "Clothing", :from => "Taxons"
       click_button "Update"
-      expect(selected_taxons).to match_array([taxon_1.id, taxon_2.id])
-
-      # Regression test for #2139
-      expect(page).to have_css(".select2-search-choice", text: taxon_1.name)
-      expect(page).to have_css(".select2-search-choice", text: taxon_2.name)
+      assert_selected_taxons([taxon_1, taxon_2])
     end
   end
 end

--- a/backend/spec/features/admin/products/option_types_spec.rb
+++ b/backend/spec/features/admin/products/option_types_spec.rb
@@ -69,15 +69,20 @@ describe "Option Types", :type => :feature do
     # Assert that the field is hidden automatically
     expect(page).to have_no_css("tbody#option_values tr")
 
+    # Ensure the DELETE request finishes
+    expect(page).to have_no_css("#progress")
+
     # Then assert that on a page refresh that it's still not visible
     visit page.current_url
     # What *is* visible is a new option value field, with blank values
     # Sometimes the page doesn't load before the all check is done
     # lazily finding the element gives the page 10 seconds
     expect(page).to have_css("tbody#option_values")
-    all("tbody#option_values tr input", count: 2).all? { |input| input.value.blank? }
+    all("tbody#option_values tr input", count: 2).each do |input|
+      expect(input.value).to be_blank
+    end
   end
-  
+
   # Regression test for #3204
   it "can remove a non-persisted option value from an option type", :js => true do
     create(:option_type)

--- a/backend/spec/features/admin/products/products_spec.rb
+++ b/backend/spec/features/admin/products/products_spec.rb
@@ -241,9 +241,12 @@ describe "Products", :type => :feature do
         end
 
         it "should show localized price value on validation errors", :js => true do
+          fill_in "Name", :with => " "
+          select @shipping_category.name, from: "product_shipping_category_id"
           fill_in "product_price", :with => "19,99"
           click_button "Create"
-          expect(find('input#product_price').value).to eq('19,99')
+          expect(page).to have_content("Name can't be blank")
+          expect(page).to have_field('product_price', with: '19,99')
         end
       end
 

--- a/backend/spec/features/admin/products/variant_spec.rb
+++ b/backend/spec/features/admin/products/variant_spec.rb
@@ -17,12 +17,12 @@ describe "Variants", :type => :feature do
       within_row(1) { click_icon :edit }
       click_link "Variants"
       click_on "New Variant"
-      expect(find('input#variant_price').value).to eq("1.99")
-      expect(find('input#variant_cost_price').value).to eq("1.00")
-      expect(find('input#variant_weight').value).to eq("2.50")
-      expect(find('input#variant_height').value).to eq("3.00")
-      expect(find('input#variant_width').value).to eq("1.00")
-      expect(find('input#variant_depth').value).to eq("1.50")
+      expect(page).to have_field('variant_price', with: "1.99")
+      expect(page).to have_field('variant_cost_price', with: "1.00")
+      expect(page).to have_field('variant_weight', with: "2.50")
+      expect(page).to have_field('variant_height', with: "3.00")
+      expect(page).to have_field('variant_width', with: "1.00")
+      expect(page).to have_field('variant_depth', with: "1.50")
       expect(page).to have_select('variant[tax_category_id]')
     end
   end

--- a/backend/spec/features/admin/stock_transfer_spec.rb
+++ b/backend/spec/features/admin/stock_transfer_spec.rb
@@ -20,7 +20,7 @@ describe 'Stock Transfers', :type => :feature, :js => true do
       fill_in 'stock_transfer_description', with: description
       click_button 'Continue'
 
-      expect(page.find('#stock_transfer_description').value).to eq description
+      expect(page).to have_field('stock_transfer_description', with: description)
 
       select "NY", from: 'stock_transfer[destination_location_id]'
       within "form.edit_stock_transfer" do

--- a/backend/spec/features/admin/users_spec.rb
+++ b/backend/spec/features/admin/users_spec.rb
@@ -108,7 +108,7 @@ describe 'Users', :type => :feature do
 
       expect(user_a.reload.email).to eq 'a@example.com99'
       expect(page).to have_text 'Account updated'
-      expect(find_field('user_email').value).to eq 'a@example.com99'
+      expect(page).to have_field('user_email', with: 'a@example.com99')
     end
 
     it 'can edit the user password' do
@@ -126,7 +126,7 @@ describe 'Users', :type => :feature do
       check 'user_spree_role_admin'
       click_button 'Update'
       expect(page).to have_text 'Account updated'
-      expect(find_field('user_spree_role_admin')['checked']).to be true
+      expect(find_field('user_spree_role_admin')).to be_checked
     end
 
     it 'can edit user shipping address' do
@@ -135,7 +135,7 @@ describe 'Users', :type => :feature do
       within("#admin_user_edit_addresses") do
         fill_in "user_ship_address_attributes_address1", with: "1313 Mockingbird Ln"
         click_button 'Update'
-        expect(find_field('user_ship_address_attributes_address1').value).to eq "1313 Mockingbird Ln"
+        expect(page).to have_field('user_ship_address_attributes_address1', with: "1313 Mockingbird Ln")
       end
 
       expect(user_a.reload.ship_address.address1).to eq "1313 Mockingbird Ln"
@@ -147,7 +147,7 @@ describe 'Users', :type => :feature do
       within("#admin_user_edit_addresses") do
         fill_in "user_bill_address_attributes_address1", with: "1313 Mockingbird Ln"
         click_button 'Update'
-        expect(find_field('user_bill_address_attributes_address1').value).to eq "1313 Mockingbird Ln"
+        expect(page).to have_field('user_bill_address_attributes_address1', with: "1313 Mockingbird Ln")
       end
 
       expect(user_a.reload.bill_address.address1).to eq "1313 Mockingbird Ln"


### PR DESCRIPTION
More of #615, which I've split since that had already been reviewed and resolves a specific issue.

This converts a bunch more tests to the proper synchronized capybara calls. Most of these are converting to `has_field`, which I likely missed before.

Some of these are converting non-js specs, which can use capybara in a non-synchronized way without risking race conditions, but I think it is best to move everything to the proper syntax to encourage its use, and in case those specs ever use the js driver.