### PR TITLE
Require bourbon "> 4", "< 6"

### DIFF
--- a/backend/solidus_backend.gemspec
+++ b/backend/solidus_backend.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'solidus_api', version
   s.add_dependency 'solidus_core', version
 
-  s.add_dependency 'bourbon'
+  s.add_dependency 'bourbon', '>= 4', '< 6'
   s.add_dependency 'jquery-rails'
   s.add_dependency 'jquery-ui-rails', '~> 5.0.0'
   s.add_dependency 'select2-rails',   '3.5.9.1' # 3.5.9.2 breaks forms


### PR DESCRIPTION
Testing against bourbon 3 fails with

    List index is 3 but list is only 2 items long for `nth'

This required a small change to be usable in solidus_auth_devise: https://github.com/Sinetheta/solidus_auth_devise/commit/c57c080a0ed35a6310b0b341f6024c584fb8bf72 . Before this commit, solidus_auth_devise would only be able to pull in bourbon 3.0 which failed.