### PR TITLE
Add concept of Image gallery

### DIFF
--- a/api/app/controllers/spree/api/variants_controller.rb
+++ b/api/app/controllers/spree/api/variants_controller.rb
@@ -72,7 +72,9 @@ module Spree
         end
 
         def include_list
-          [{ option_values: :option_type }, :product, :default_price, :images, { stock_items: :stock_location }]
+          [{ option_values: :option_type }, :product, :default_price,
+           Spree::Config.variant_gallery_class.preload_params,
+           { stock_items: :stock_location }]
         end
     end
   end

--- a/api/app/controllers/spree/api/variants_controller.rb
+++ b/api/app/controllers/spree/api/variants_controller.rb
@@ -23,7 +23,7 @@ module Spree
       # we render on the view so we better update it any time a node is included
       # or removed from the views.
       def index
-        @variants = scope.includes({ option_values: :option_type }, :product, :default_price, :images, { stock_items: :stock_location })
+        @variants = scope.includes(include_list)
           .ransack(params[:q]).result.page(params[:page]).per(params[:per_page])
         respond_with(@variants)
       end
@@ -32,7 +32,7 @@ module Spree
       end
 
       def show
-        @variant = scope.includes({ option_values: :option_type }, :option_values, :product, :default_price, :images, { stock_items: :stock_location })
+        @variant = scope.includes(include_list)
           .find(params[:id])
         respond_with(@variant)
       end
@@ -69,6 +69,10 @@ module Spree
 
         def variant_params
           params.require(:variant).permit(permitted_variant_attributes)
+        end
+
+        def include_list
+          [{ option_values: :option_type }, :product, :default_price, :images, { stock_items: :stock_location }]
         end
     end
   end

--- a/backend/app/controllers/spree/admin/base_controller.rb
+++ b/backend/app/controllers/spree/admin/base_controller.rb
@@ -3,6 +3,7 @@ module Spree
     class BaseController < Spree::BaseController
       helper 'spree/admin/navigation'
       helper 'spree/admin/tables'
+      helper 'spree/images'
       layout '/spree/layouts/admin'
 
       before_action :authorize_admin

--- a/backend/app/controllers/spree/admin/products_controller.rb
+++ b/backend/app/controllers/spree/admin/products_controller.rb
@@ -128,7 +128,7 @@ module Spree
       end
 
       def product_includes
-        [{ variants: [:images], master: [:images, :default_price] }]
+        [{ variants: variant_image_includes, master: (variant_image_includes + [:default_price]) }]
       end
 
       def clone_object_url(resource)
@@ -136,7 +136,7 @@ module Spree
       end
 
       def variant_stock_includes
-        [:images, stock_items: :stock_location, option_values: :option_type]
+        [variant_image_includes, stock_items: :stock_location, option_values: :option_type]
       end
 
       def variant_scope
@@ -145,6 +145,11 @@ module Spree
 
       def updating_variant_property_rules?
         params[:product][:variant_property_rules_attributes].present?
+      end
+
+      private
+      def variant_image_includes
+        Spree::Config.variant_gallery_class.preload_params
       end
     end
   end

--- a/backend/app/controllers/spree/admin/stock_items_controller.rb
+++ b/backend/app/controllers/spree/admin/stock_items_controller.rb
@@ -50,7 +50,9 @@ module Spree
           @stock_item_stock_locations = params[:stock_location_id].present? ? @stock_locations.where(id: params[:stock_location_id]) : @stock_locations
           @variant_display_attributes = self.class.variant_display_attributes
           @variants = Spree::Config.variant_search_class.new(params[:variant_search_term], scope: variant_scope).results
-          @variants = @variants.includes(:images, stock_items: :stock_location, product: :variant_images)
+          @variants = @variants.includes(:images, stock_items: :stock_location,
+                                         product: Spree::Config.product_gallery_class.preload_params
+                                        )
           @variants = @variants.includes(option_values: :option_type)
           @variants = @variants.order(id: :desc).page(params[:page]).per(params[:per_page] || Spree::Config[:orders_per_page])
         end

--- a/backend/app/controllers/spree/admin/stock_items_controller.rb
+++ b/backend/app/controllers/spree/admin/stock_items_controller.rb
@@ -50,7 +50,9 @@ module Spree
           @stock_item_stock_locations = params[:stock_location_id].present? ? @stock_locations.where(id: params[:stock_location_id]) : @stock_locations
           @variant_display_attributes = self.class.variant_display_attributes
           @variants = Spree::Config.variant_search_class.new(params[:variant_search_term], scope: variant_scope).results
-          @variants = @variants.includes(:images, stock_items: :stock_location,
+          @variants = @variants.includes(
+                                         Spree::Config.variant_gallery_class.preload_params,
+                                         stock_items: :stock_location,
                                          product: Spree::Config.product_gallery_class.preload_params
                                         )
           @variants = @variants.includes(option_values: :option_type)

--- a/backend/app/views/spree/admin/cancellations/index.html.erb
+++ b/backend/app/views/spree/admin/cancellations/index.html.erb
@@ -25,7 +25,7 @@
       <% @inventory_units.each do |inventory_unit| %>
         <tr class="inventory-unit">
           <td class="inventory-unit-image">
-            <%= image_tag inventory_unit.variant.display_image.attachment(:mini) %>
+            <%= spree_image_tag inventory_unit.variant.gallery.best_image, :mini %>
           </td>
           <td class="inventory-unit-name">
             <%= inventory_unit.variant.product.name %><br><%= "(" + variant_options(inventory_unit.variant) + ")" unless inventory_unit.variant.option_values.empty? %>

--- a/backend/app/views/spree/admin/orders/_carton_manifest.html.erb
+++ b/backend/app/views/spree/admin/orders/_carton_manifest.html.erb
@@ -1,7 +1,7 @@
 <% carton.manifest_for_order(order).each do |item| %>
   <tr class="stock-item" data-item-quantity="<%= item.quantity %>">
     <td class="item-image">
-      <%= image_tag item.variant.display_image.attachment(:mini) %>
+      <%= spree_image_tag item.variant.gallery.best_image, :mini %>
     </td>
     <td class="item-name">
       <%= item.variant.product.name %><br><%= "(" + variant_options(item.variant) + ")" unless item.variant.option_values.empty? %>

--- a/backend/app/views/spree/admin/orders/_line_items.html.erb
+++ b/backend/app/views/spree/admin/orders/_line_items.html.erb
@@ -18,7 +18,7 @@
     <tbody>
       <% order.line_items.each do |item| %>
         <%= content_tag :tr, class: 'line-item', id: "line-item-#{item.id}", data: { line_item_id: item.id } do %>
-          <td class="line-item-image"><%= image_tag item.variant.display_image.attachment(:mini) %></td>
+          <td class="line-item-image"><%= spree_image_tag item.variant.gallery.best_image, :mini %></td>
           <td class="line-item-name">
             <%= item.variant.product.name %><br><%= "(" + variant_options(item.variant) + ")" unless item.variant.option_values.empty? %>
             <% if item.variant.sku.present? %>

--- a/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
@@ -1,7 +1,7 @@
 <% shipment_manifest.each do |item| %>
   <tr class="stock-item" data-item-quantity="<%= item.quantity %>">
     <td class="item-image">
-      <%= image_tag item.variant.display_image.attachment(:mini) %>
+      <%= spree_image_tag item.variant.gallery.best_image, :mini %>
     </td>
     <td class="item-name">
       <%= item.variant.product.name %><br><%= "(" + variant_options(item.variant) + ")" unless item.variant.option_values.empty? %>

--- a/backend/app/views/spree/admin/orders/confirm/_shipment_manifest.html.erb
+++ b/backend/app/views/spree/admin/orders/confirm/_shipment_manifest.html.erb
@@ -1,7 +1,7 @@
 <% shipment.manifest.each do |item| %>
   <tr class="stock-item" data-item-quantity="<%= item.quantity %>">
     <td class="item-image">
-      <%= image_tag item.variant.display_image.attachment(:mini) %>
+      <%= spree_image_tag item.variant.gallery.best_image, :mini %>
     </td>
     <td class="item-name">
       <%= item.variant.product.name %><br><%= "(" + variant_options(item.variant) + ")" unless item.variant.option_values.empty? %>

--- a/backend/app/views/spree/admin/products/index.html.erb
+++ b/backend/app/views/spree/admin/products/index.html.erb
@@ -76,7 +76,7 @@
       <% @collection.each do |product| %>
           <tr <%== "style='color: red;'" if product.deleted? %> id="<%= spree_dom_id product %>" data-hook="admin_products_index_rows" class="<%= cycle('odd', 'even') %>">
             <td class="align-center"><%= product.sku rescue '' %></td>
-            <td class="align-center"><%= image_tag product.display_image.attachment(:mini) %></td>
+            <td class="align-center"><%= spree_image_tag product.gallery.best_image, :mini %></td>
             <td><%= link_to product.try(:name), edit_admin_product_path(product) %></td>
             <td class="align-center"><%= product.display_price.to_html rescue '' %></td>
             <td class="actions" data-hook="admin_products_index_row_actions">

--- a/backend/app/views/spree/admin/stock_items/_stock_management.html.erb
+++ b/backend/app/views/spree/admin/stock_items/_stock_management.html.erb
@@ -30,7 +30,7 @@
         <td class="align-center no-padding" rowspan="<%= row_count %>">
           <div class='variant-container'>
             <div class='variant-image'>
-              <%= image_tag(variant.display_image(fallback: false).attachment(:small)) %>
+              <%= spree_image_tag(variant.gallery.primary_image, :small) %>
             </div>
             <div class='variant-details'>
               <table class='stock-variant-field-table'>

--- a/backend/app/views/spree/admin/stock_transfers/_transfer_item_table.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/_transfer_item_table.html.erb
@@ -22,7 +22,7 @@
           <td class="align-center no-padding">
             <div class='variant-container' data-variant-id="<%= variant.id %>">
               <div class='variant-image'>
-                <%= image_tag(variant.display_image(fallback: false).attachment(:small)) %>
+                <%= spree_image_tag(variant.gallery.primary_image, :small) %>
               </div>
               <div class='variant-details'>
                 <table class='stock-variant-field-table'>

--- a/backend/app/views/spree/admin/users/items.html.erb
+++ b/backend/app/views/spree/admin/users/items.html.erb
@@ -39,7 +39,7 @@
             <tr class="stock-item" data-item-quantity="<%= item.quantity %>">
               <td class="align-center order-completed-at"><%= l(order.completed_at.to_date) if order.completed_at %></td>
               <td class="item-image">
-                <%= image_tag item.variant.display_image.attachment(:mini) %>
+                <%= spree_image_tag item.variant.gallery.best_image, :mini %>
               </td>
               <td class="item-name">
                 <%= item.product.name %><br><%= "(" + variant_options(item.variant) + ")" unless item.variant.option_values.empty? %>

--- a/core/app/helpers/spree/images_helper.rb
+++ b/core/app/helpers/spree/images_helper.rb
@@ -14,5 +14,19 @@ module Spree
     def image_or_default(image)
       image || Spree::Image.new
     end
+
+    # Display an image_tag for the given spree image, if one exists, for the
+    # provided style, or a image_tag for the default image if no image is provided.
+    #
+    # @param image [Spree::Image, nil] The image to display, if provided, or nil
+    # if the default image should be displayed.
+    #
+    # @param style [symbol] The paperclip {Spree::Image} style to display the image_tag
+    # for
+    #
+    # @return [String] A string of the image_tag built from the provided image
+    def spree_image_tag(image, style, options={})
+      image_tag image_or_default(image).attachment(style), options
+    end
   end
 end

--- a/core/app/helpers/spree/images_helper.rb
+++ b/core/app/helpers/spree/images_helper.rb
@@ -1,0 +1,18 @@
+module Spree
+  module ImagesHelper
+    # Return the provided image if it is not nil,
+    # otherwise return a default {Spree::Image}.
+    #
+    # This is useful when displaying images for a resource when it exists,
+    # or falling back to the Paperclip default image when none is provided.
+    #
+    # @param image [Spree::Image, nil] The image to return, or nil if the default
+    #   should be used.
+    #
+    # @return [Spree::Image] the provided image if it exists, or a default
+    #   image otherwise
+    def image_or_default(image)
+      image || Spree::Image.new
+    end
+  end
+end

--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -278,6 +278,14 @@ module Spree
       @variant_gallery_class ||= Spree::Gallery::VariantAssociation
     end
 
+    attr_writer :product_gallery_class
+    # Returns the class to model the products's gallery
+    #
+    # @return a class implementing {Spree::Gallery::Base}
+    def product_gallery_class
+      @product_gallery_class ||= Spree::Gallery::ProductVariantAssociation
+    end
+
     # promotion_chooser_class allows extensions to provide their own PromotionChooser
     attr_writer :promotion_chooser_class
     def promotion_chooser_class

--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -270,6 +270,14 @@ module Spree
       @variant_search_class ||= Spree::Core::Search::Variant
     end
 
+    attr_writer :variant_gallery_class
+    # Returns the class to model the variants's gallery
+    #
+    # @return a class implementing {Spree::Gallery::Base}
+    def variant_gallery_class
+      @variant_gallery_class ||= Spree::Gallery::VariantAssociation
+    end
+
     # promotion_chooser_class allows extensions to provide their own PromotionChooser
     attr_writer :promotion_chooser_class
     def promotion_chooser_class

--- a/core/app/models/spree/gallery/base.rb
+++ b/core/app/models/spree/gallery/base.rb
@@ -1,0 +1,51 @@
+module Spree
+  module Gallery
+
+    # A gallery represents a collection of images.
+    #
+    # @abstract base class for all galleries. Implement your own
+    #   to define how images should be associated to objects in your
+    #   store
+    class Base
+
+      # A list of all images associated with this gallery
+      #
+      # @return [Enumerable<Spree::Image>] All images associated to the gallery
+      def images; raise NotImplementedError end
+
+      # The "primary" {Spree::Image} associated with the gallery
+      #
+      # Typically the most appropriate single image to display representing
+      # the gallery, but will not follow the fallback rules of {#best_image}
+      #
+      # @return [Spree::Image, nil] if primary image for the gallery exists or
+      #   nil otherwise
+      #
+      # @abstract
+      def primary_image; raise NotImplementedError end
+
+      # The "best" {Spree::Image} associated with this gallery.
+      #
+      # Will attempt to fall back to other sources and logic to find a picture
+      # if the {#primary_image} does not exist
+      #
+      # @return [Spree::Image, nil] if an image can be found to represent the gallery,
+      #   following fallback rules, and nli otherwise
+      #
+      # @abstract
+      def best_image; raise NotImplementedError end
+
+      # Return an ActiveRecord-compatible Array of objects to preload
+      #
+      # An unfortunate method to allow the application to minimize queries while
+      # allowing different Gallery implementations to maintain their own
+      # database structures
+      #
+      # @return [Array] an ActiveRecord::QueryMethods#includes compatible array
+      def self.preload_params
+        []
+      end
+
+    end
+  end
+end

--- a/core/app/models/spree/gallery/product_variant_association.rb
+++ b/core/app/models/spree/gallery/product_variant_association.rb
@@ -1,0 +1,36 @@
+module Spree
+  # Uses the ActiveRecord association for a Prodcut's Variant's Images
+  module Gallery
+    class ProductVariantAssociation < Gallery::Base
+
+      # Creates a gallery for the given product
+      # @param [Spree::Product] product The product to create the gallery for
+      def initialize(product)
+        @product = product
+      end
+
+      # (see Spree::Gallery#images)
+      def images
+        product.variant_images
+      end
+
+      # (see Spree::Gallery#primary_image)
+      def primary_image
+        product.images.first || product.variant_images.first
+      end
+
+      # Returns the primary image for the gallery
+      #
+      # Does not follow any fallback rules
+      #
+      # (see Spree::Gallery#best_image)
+      def best_image
+        primary_image
+      end
+
+      private
+      attr_reader :product
+
+    end
+  end
+end

--- a/core/app/models/spree/gallery/product_variant_association.rb
+++ b/core/app/models/spree/gallery/product_variant_association.rb
@@ -28,6 +28,16 @@ module Spree
         primary_image
       end
 
+      # Return a list of image associations to preload a Spree::Product's images
+      #
+      # @return An array compatible with ActiveRecord :includes
+      #   for a Spree::Products images preload
+      #
+      # (see Spree::Galery#preload_params)
+      def self.preload_params
+        [:variant_images]
+      end
+
       private
       attr_reader :product
 

--- a/core/app/models/spree/gallery/variant_association.rb
+++ b/core/app/models/spree/gallery/variant_association.rb
@@ -28,6 +28,16 @@ module Spree
         primary_image || products_images.first
       end
 
+      # Return a list of image associations to preload a Spree::Variant's images
+      #
+      # @return An array compatible with ActiveRecord :includes
+      #   for a Spree::Variant images preload
+      #
+      # (see Spree::Galery#preload_params)
+      def self.preload_params
+        [:images]
+      end
+
       private
       attr_reader :variant
 

--- a/core/app/models/spree/gallery/variant_association.rb
+++ b/core/app/models/spree/gallery/variant_association.rb
@@ -1,0 +1,40 @@
+module Spree
+  # Uses the ActiveRecord association between Spree::Variant and
+  #   Spree::Image
+  module Gallery
+    class VariantAssociation < Gallery::Base
+
+      # Creates a gallery for the given variant
+      # @param [Spree::Variant] variant variant to build the gallery for
+      def initialize(variant)
+        @variant = variant
+      end
+
+      # (see Spree::Gallery#images)
+      def images
+        variant.images
+      end
+
+      # (see Spree::Gallery#primary_image)
+      def primary_image
+        variant.images.first
+      end
+
+      # Will fall back to the first image on the variant's product if
+      # the variant has no associated images.
+      # @return [Spree::Image, nil] The variant's primary image, if it exists,
+      #   or the variant's products first image, if it exists, nil otherwise
+      def best_image
+        primary_image || products_images.first
+      end
+
+      private
+      attr_reader :variant
+
+      def products_images
+        variant.product.try!(:variant_images) || []
+      end
+
+    end
+  end
+end

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -270,6 +270,12 @@ module Spree
     # variants. If all else fails, will return a new image object.
     # @return [Spree::Image] the image to display
     def display_image
+      ActiveSupport::Deprecation.warn(<<WARN.squish)
+Spree::Product#display_image is being deprecated in favor of
+Spree::Product#gallery.primary_image and #Spree::Product#gallery.best_image
+to select an image, and Spree::ImagesHelper#image_or_default
+to handle displaying a fallback
+WARN
       images.first || variant_images.first || Spree::Image.new
     end
 

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -283,6 +283,18 @@ module Spree
       end
     end
 
+    # Returns the gallery for the product, which represents all the images
+    # associated to this product, by default including through its variants
+    #
+    # The class initialized can be configured by a store using
+    # the config setting {Spree::AppConfiguration#product_gallery_class}
+    #
+    # @return [Spree::Gallery::Base] this products gallery
+    # @see Spree::AppConfiguration#product_gallery_class
+    def gallery
+      @gallery ||= Spree::Config.product_gallery_class.new(self)
+    end
+
     private
 
     def add_associations_from_prototype

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -326,6 +326,18 @@ module Spree
       end.flatten.compact
     end
 
+    # Returns the gallery for the variant, which represents all the images
+    # associated to this variant
+    #
+    # The class initialized can be configured by a store using
+    # the config setting {Spree::AppConfiguration#variant_gallery_class}
+    #
+    # @return [Spree::Gallery::Base] this variants gallery
+    # @see Spree::AppConfiguration#variant_gallery_class
+    def gallery
+      @gallery ||= Spree::Config.variant_gallery_class.new(self)
+    end
+
     private
 
       def set_master_out_of_stock

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -313,6 +313,13 @@ module Spree
     #   not from this variant
     # @return [Spree::Image] the image to display
     def display_image(fallback: true)
+      ActiveSupport::Deprecation.warn(<<WARN.squish)
+Spree::Variant#display_image is being deprecated in favor of
+Spree::Variant#gallery.primary_image and #Spree::Variant#gallery.best_image
+to select an image, and Spree::ImagesHelper#image_or_default
+to handle displaying a fallback
+WARN
+
       images.first || (fallback && product.variant_images.first) || Spree::Image.new
     end
 

--- a/core/lib/spree/core/search/base.rb
+++ b/core/lib/spree/core/search/base.rb
@@ -57,7 +57,7 @@ module Spree
             # `where` constraints affecting joined tables are added to the search;
             # which is the case as soon as a taxon is added to the base scope.
             scope = scope.preload(master: :prices)
-            scope = scope.preload(master: :images) if include_images
+            scope = scope.preload(master: Spree::Config.variant_gallery_class.preload_params) if include_images
             scope
           end
 

--- a/core/lib/spree/testing_support/shared_examples/gallery.rb
+++ b/core/lib/spree/testing_support/shared_examples/gallery.rb
@@ -1,0 +1,23 @@
+shared_examples_for 'is a gallery' do
+
+  describe '#images' do
+    subject { gallery.images }
+
+    it 'behaves like an enumerable' do
+      # in rails 5 a CollectionProxy is enumerable and we can
+      # switch to is_a? Enumerable as the docs specify it should be
+      [:[], :each, :reduce].each do |enum_method|
+        expect(subject).to respond_to enum_method
+      end
+    end
+  end
+
+  [:best_image, :primary_image].each do |gallery_method|
+    subject { gallery }
+    it { is_expected.to respond_to gallery_method }
+  end
+
+  it 'has a class method to return an array for preload_params' do
+    expect(gallery.class.preload_params).to be_a Array
+  end
+end

--- a/core/spec/helpers/images_helper_spec.rb
+++ b/core/spec/helpers/images_helper_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+RSpec.describe Spree::ImagesHelper, type: :helper do
+  describe '#image_or_default' do
+    subject { helper.image_or_default(image) }
+
+    let(:image) { nil }
+
+    it 'is an image' do
+      expect(subject).to be_a Spree::Image
+    end
+
+    context 'image is provided' do
+      let(:image) { Spree::Image.new }
+
+      it 'returns that image' do
+        expect(subject).to be image
+      end
+    end
+  end
+end

--- a/core/spec/helpers/images_helper_spec.rb
+++ b/core/spec/helpers/images_helper_spec.rb
@@ -18,4 +18,39 @@ RSpec.describe Spree::ImagesHelper, type: :helper do
       end
     end
   end
+  describe '#spree_image_tag' do
+    subject { helper.spree_image_tag image, style, options}
+
+    let(:image) { nil }
+    let(:style) { :mini }
+    let(:options) { {} }
+
+    it 'uses default image' do
+      expect(subject).to eq '<img src="/assets/noimage/mini.png" alt="Mini" />'
+    end
+
+    context 'given an image' do
+      let(:image) { Spree::Image.new attachment_file_name: 'legit_image.png' }
+
+      it 'uses the provided image' do
+        expect(subject).to eq '<img src="/spree/products//mini/legit_image.png" alt="Legit image" />'
+      end
+    end
+
+    context 'large style used' do
+      let(:style) { :large }
+
+      it 'uses default image with large style' do
+        expect(subject).to eq '<img src="/assets/noimage/large.png" alt="Large" />'
+      end
+    end
+
+    context 'with options provided' do
+      let(:options) { { itemprop: 'image' } }
+
+      it 'passes the options to image_tag' do
+        expect(subject).to eq '<img itemprop="image" src="/assets/noimage/mini.png" alt="Mini" />'
+      end
+    end
+  end
 end

--- a/core/spec/models/spree/gallery/product_variant_association_spec.rb
+++ b/core/spec/models/spree/gallery/product_variant_association_spec.rb
@@ -69,4 +69,15 @@ RSpec.describe Spree::Gallery::ProductVariantAssociation, type: :model do
   describe '#best_image' do
     include_examples 'image picking'
   end
+
+  describe '.preload_params' do
+    it 'uses the right preload_params' do
+      expect(described_class.preload_params).to eq [:variant_images]
+    end
+
+    it 'is valid on products' do
+      create :product
+      expect(Spree::Product.includes(described_class.preload_params).first).to be
+    end
+  end
 end

--- a/core/spec/models/spree/gallery/product_variant_association_spec.rb
+++ b/core/spec/models/spree/gallery/product_variant_association_spec.rb
@@ -1,9 +1,12 @@
 require 'spec_helper'
+require 'spree/testing_support/shared_examples/gallery'
 
 RSpec.describe Spree::Gallery::ProductVariantAssociation, type: :model do
   let(:gallery) { described_class.new(product) }
 
   let(:product) { Spree::Product.new }
+
+  include_examples 'is a gallery'
 
   shared_context 'has multiple images' do
     let(:first_image) { Spree::Image.new }

--- a/core/spec/models/spree/gallery/product_variant_association_spec.rb
+++ b/core/spec/models/spree/gallery/product_variant_association_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+
+RSpec.describe Spree::Gallery::ProductVariantAssociation, type: :model do
+  let(:gallery) { described_class.new(product) }
+
+  let(:product) { Spree::Product.new }
+
+  shared_context 'has multiple images' do
+    let(:first_image) { Spree::Image.new }
+    let(:second_image) { Spree::Image.new }
+
+    before do
+      product.images << first_image
+      product.images << second_image
+    end
+  end
+
+  describe '#images' do
+    subject { product.images }
+
+    it 'is empty' do
+      expect(subject).to be_empty
+    end
+
+    context 'has multiple images' do
+
+      include_context 'has multiple images'
+
+      it 'has the images of the association' do
+        expect(subject).to eq [first_image, second_image]
+      end
+
+    end
+  end
+
+  shared_examples_for 'image picking' do
+    subject { gallery.best_image }
+
+    it 'is nil' do
+      expect(subject).to be_nil
+    end
+
+    context 'has images' do
+      include_context 'has multiple images'
+
+      it 'uses the first image' do
+        expect(subject).to eq first_image
+      end
+    end
+
+    context 'with non-master variant with images' do
+      let(:product) { create :product }
+      let(:variant) { create :variant, product: product }
+      let!(:image) { create :image, viewable: variant }
+
+      it 'falls back to the products image' do
+        expect(subject).to eq image
+      end
+    end
+  end
+
+  describe '#primary_image' do
+    include_examples 'image picking'
+  end
+
+  describe '#best_image' do
+    include_examples 'image picking'
+  end
+end

--- a/core/spec/models/spree/gallery/variant_association.rb
+++ b/core/spec/models/spree/gallery/variant_association.rb
@@ -86,4 +86,15 @@ RSpec.describe Spree::Gallery::VariantAssociation, type: :model do
       end
     end
   end
+
+  describe '.preload_params' do
+    it 'uses the right preload_params' do
+      expect(described_class.preload_params).to eq [:images]
+    end
+
+    it 'is valid on products' do
+      create :variant
+      expect(Spree::Variant.includes(described_class.preload_params).first).to be
+    end
+  end
 end

--- a/core/spec/models/spree/gallery/variant_association.rb
+++ b/core/spec/models/spree/gallery/variant_association.rb
@@ -1,9 +1,12 @@
 require 'spec_helper'
+require 'spree/testing_support/shared_examples/gallery'
 
 RSpec.describe Spree::Gallery::VariantAssociation, type: :model do
   let(:gallery) { described_class.new(variant) }
 
   let(:variant) { Spree::Variant.new }
+
+  include_examples 'is a gallery'
 
   shared_context 'has multiple images' do
     let(:first_image) { Spree::Image.new }

--- a/core/spec/models/spree/gallery/variant_association.rb
+++ b/core/spec/models/spree/gallery/variant_association.rb
@@ -1,0 +1,86 @@
+require 'spec_helper'
+
+RSpec.describe Spree::Gallery::VariantAssociation, type: :model do
+  let(:gallery) { described_class.new(variant) }
+
+  let(:variant) { Spree::Variant.new }
+
+  shared_context 'has multiple images' do
+    let(:first_image) { Spree::Image.new }
+    let(:second_image) { Spree::Image.new }
+
+    before do
+      variant.images << first_image
+      variant.images << second_image
+    end
+  end
+
+  describe '#images' do
+    subject { gallery.images }
+
+    it 'is empty' do
+      expect(subject).to be_empty
+    end
+
+    context 'has multiple images' do
+
+      include_context 'has multiple images'
+
+      it 'has the images of the association' do
+        expect(subject).to eq [first_image, second_image]
+      end
+
+    end
+  end
+
+  describe '#primary_image' do
+    subject { gallery.primary_image }
+
+    it 'is nil' do
+      expect(subject).to be_nil
+    end
+
+    context 'has images' do
+      include_context 'has multiple images'
+
+      it 'uses the first image' do
+        expect(subject).to eq first_image
+      end
+    end
+  end
+
+  describe '#best_image' do
+    subject { gallery.best_image }
+
+    it 'is nil' do
+      expect(subject).to be_nil
+    end
+
+    context 'has images' do
+      include_context 'has multiple images'
+
+      it 'uses the first image' do
+        expect(subject).to eq first_image
+      end
+    end
+
+    context 'variant has a product' do
+      let(:product) { Spree::Product.new }
+      let(:variant) { Spree::Variant.new product: product }
+
+      it 'is nil' do
+        expect(subject).to be_nil
+      end
+
+      context 'that has images' do
+        let(:product) { create :product }
+        let(:variant) { create :variant, product: product }
+        let!(:image) { create :image, viewable: product.master }
+
+        it 'falls back to the products image' do
+          expect(subject).to eq image
+        end
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -501,4 +501,13 @@ describe Spree::Product, :type => :model do
     product = Spree::Product.new
     expect(product.master.is_master).to be true
   end
+
+  describe '#gallery' do
+    let(:product) { Spree::Product.new }
+    subject { product.gallery }
+
+    it 'is a Spree::Gallery::Base' do
+      expect(subject).to be_a Spree::Gallery::Base
+    end
+  end
 end

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -598,4 +598,13 @@ describe Spree::Variant, :type => :model do
       end
     end
   end
+
+  describe '#gallery' do
+    let(:variant) { Spree::Variant.new }
+    subject { variant.gallery }
+
+    it 'is a Spree::Gallery::Base' do
+      expect(subject).to be_a Spree::Gallery::Base
+    end
+  end
 end

--- a/frontend/app/controllers/spree/products_controller.rb
+++ b/frontend/app/controllers/spree/products_controller.rb
@@ -15,7 +15,8 @@ module Spree
     end
 
     def show
-      @variants = @product.variants_including_master.active(current_currency).includes([:option_values, :images])
+      @variants = @product.variants_including_master.active(current_currency).includes(:option_values,
+           Spree::Config.variant_gallery_class.preload_params)
       @product_properties = @product.product_properties.includes(:property)
       @taxon = Spree::Taxon.find(params[:taxon_id]) if params[:taxon_id]
     end

--- a/frontend/app/controllers/spree/store_controller.rb
+++ b/frontend/app/controllers/spree/store_controller.rb
@@ -2,6 +2,8 @@ module Spree
   class StoreController < Spree::BaseController
     include Spree::Core::ControllerHelpers::Order
 
+    helper 'spree/images'
+
     skip_before_action :set_current_order, only: :cart_link
 
     def unauthorized

--- a/frontend/app/views/spree/checkout/_delivery.html.erb
+++ b/frontend/app/views/spree/checkout/_delivery.html.erb
@@ -26,7 +26,7 @@
             <tbody>
               <% ship_form.object.manifest.each do |item| %>
                 <tr class="stock-item">
-                  <td class="item-image"><%= image_tag item.variant.display_image.attachment(:mini) %></td>
+                  <td class="item-image"><%= spree_image_tag(item.variant.gallery.best_image, :mini) %></td>
                   <td class="item-name"><%= item.variant.name %></td>
                   <td class="item-qty"><%= item.quantity %></td>
                   <td class="item-price"><%= display_price(item.variant) %></td>
@@ -72,7 +72,7 @@
             <tbody>
               <% @differentiator.missing.each do |variant, quantity| %>
                 <tr class="stock-item">
-                  <td class="item-image"><%= image_tag variant.display_image.attachment(:mini) %></td>
+                  <td class="item-image"><%= spree_image_tag(variant.gallery.best_image, :mini) %></td>
                   <td class="item-name"><%= variant.name %></td>
                   <td class="item-qty"><%= quantity %></td>
                   <td class="item-price"><%= display_price(variant) %></td>

--- a/frontend/app/views/spree/orders/_line_item.html.erb
+++ b/frontend/app/views/spree/orders/_line_item.html.erb
@@ -2,11 +2,7 @@
 <%= order_form.fields_for :line_items, line_item do |item_form| -%>
   <tr class="<%= cycle('', 'alt') %> line-item">
     <td class="cart-item-image" data-hook="cart_item_image">
-      <% if variant.images.length == 0 %>
-        <%= link_to image_tag(variant.product.display_image.attachment(:small)), variant.product %>
-      <% else %>
-        <%= link_to image_tag(variant.images.first.attachment.url(:small)), variant.product %>
-      <% end %>
+      <%= link_to spree_image_tag(variant.gallery.best_image, :small), variant.product  %>
     </td>
     <td class="cart-item-description" data-hook="cart_item_description">
       <h4><%= link_to line_item.name, product_path(variant.product) %></h4>

--- a/frontend/app/views/spree/products/_image.html.erb
+++ b/frontend/app/views/spree/products/_image.html.erb
@@ -1,5 +1,5 @@
 <% if defined?(image) && image %>
   <%= image_tag image.attachment.url(:product), itemprop: "image" %>
 <% else %>
-  <%= image_tag @product.display_image.attachment(:product), itemprop: "image" %>
+  <%= spree_image_tag @product.gallery.best_image, :product, itemprop: "image" %>
 <% end %>

--- a/frontend/app/views/spree/shared/_order_details.html.erb
+++ b/frontend/app/views/spree/shared/_order_details.html.erb
@@ -61,11 +61,7 @@
     <% order.line_items.each do |item| %>
       <tr data-hook="order_details_line_item_row">
         <td data-hook="order_item_image">
-          <% if item.variant.images.length == 0 %>
-            <%= link_to image_tag(item.variant.product.display_image.attachment(:small)), item.variant.product %>
-          <% else %>
-            <%= link_to image_tag(item.variant.images.first.attachment.url(:small)), item.variant.product %>
-          <% end %>
+          <%= link_to spree_image_tag(item.variant.gallery.best_image, :small), item.variant.product %>
         </td>
         <td data-hook="order_item_description">
           <h4><%= item.variant.product.name %></h4>

--- a/frontend/app/views/spree/shared/_products.html.erb
+++ b/frontend/app/views/spree/shared/_products.html.erb
@@ -28,7 +28,7 @@
       <li id="product_<%= product.id %>" class="columns three <%= cycle("alpha", "secondary", "", "omega secondary", name: "classes") %>" data-hook="products_list_item" itemscope itemtype="http://schema.org/Product">
         <% cache(@taxon.present? ? [I18n.locale, current_currency, @taxon, product] : [I18n.locale, current_currency, product]) do %>
           <div class="product-image">
-            <%= link_to image_tag(product.display_image.attachment(:small), itemprop: "image"), url, itemprop: 'url' %>
+            <%= link_to spree_image_tag(product.gallery.best_image, :small, itemprop: "image"), url, itemprop: 'url' %>
           </div>
           <%= link_to truncate(product.name, length: 50), url, class: 'info', itemprop: "name", title: product.name %>
           <span itemprop="offers" itemscope itemtype="http://schema.org/Offer">


### PR DESCRIPTION
This PR comes out of the conversation of #495 

We need a better way for stores to customize how different items relate to images, I believe we're missing the concept of a "gallery" that gives stores that control.

A single ActiveRecord association is too simple for stores to model the relationship between a variant (or product) and its images, this PR creates the concept of a "Gallery" for stores to implement and model that relationship as it pertains to their store.

To do this I needed to:
- [x] Shift existing calls onto this new api
- [x] mark old API as deprecated
- [x] create ProductAssociation for Spree::Product's
- [x] make sure preload_params are used everywhere to cut down on queries

I'm open to any and all feedback on how this is being executed, and especially around me documentation which I'm specifically trying to improve upon.
