### PR TITLE
Avoid extra stock location in order factory

### DIFF
--- a/core/lib/spree/testing_support/factories/order_factory.rb
+++ b/core/lib/spree/testing_support/factories/order_factory.rb
@@ -27,16 +27,19 @@ FactoryGirl.define do
         line_items_attributes { [{}] * line_items_count }
         shipment_cost 100
         shipping_method nil
+        stock_location { create(:stock_location) }
       end
 
       after(:create) do |order, evaluator|
+        evaluator.stock_location # must evaluate before creating line items
+
         evaluator.line_items_attributes.each do |attributes|
           attributes = {order: order, price: evaluator.line_items_price}.merge(attributes)
           create(:line_item, attributes)
         end
         order.line_items.reload
 
-        create(:shipment, order: order, cost: evaluator.shipment_cost, shipping_method: evaluator.shipping_method, address: evaluator.ship_address)
+        create(:shipment, order: order, cost: evaluator.shipment_cost, shipping_method: evaluator.shipping_method, address: evaluator.ship_address, stock_location: evaluator.stock_location)
         order.shipments.reload
 
         order.update!

--- a/core/lib/spree/testing_support/factories/product_factory.rb
+++ b/core/lib/spree/testing_support/factories/product_factory.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :base_product, class: Spree::Product do
     sequence(:name) { |n| "Product ##{n} - #{Kernel.rand(9999)}" }
-    description { generate(:random_description) }
+    description "As seen on TV!"
     price 19.99
     cost_price 17.00
     sku { generate(:sku) }

--- a/core/lib/spree/testing_support/factories/shipment_factory.rb
+++ b/core/lib/spree/testing_support/factories/shipment_factory.rb
@@ -16,7 +16,7 @@ FactoryGirl.define do
 
       shipment.order.line_items.each do |line_item|
         line_item.quantity.times do
-          shipment.inventory_units.create(
+          shipment.inventory_units.create!(
             order_id: shipment.order_id,
             variant_id: line_item.variant_id,
             line_item_id: line_item.id


### PR DESCRIPTION
Previously, create(:order_with_line_items) would create two stock locations. One would be created as part of the product factory, which creates a stock location if none exists, and another would be created as part of the shipment factory.

This commit moves the creation of the stock location up a level, into the order factory. This allows it to be created before the line_item and product factory.

This also allows doing:

    create(:shipped_order, stock_location: location)

which should be helpful in testing.

This PR also includes to other small tweaks:
* Not using a random product description
* Using `create!` instead of `create`