### PR TITLE
updating positions via update_positions via js/persistence using acts_as_list has an issue

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/admin.js.erb
+++ b/backend/app/assets/javascripts/spree/backend/admin.js.erb
@@ -206,7 +206,7 @@ $(document).ready(function(){
             if (idAttr) {
               objId = idAttr.split('_').slice(-1);
               if (!isNaN(objId)) {
-                positions['positions['+objId+']'] = position;
+                positions['positions['+objId+']'] = position+1;
               }
             }
           });


### PR DESCRIPTION
Javascript is sending indices starting from 0. 

acts_as_list gem has [**top_of_list** defaults to **1**](https://github.com/swanandp/acts_as_list/blob/master/lib/acts_as_list/active_record/acts/list.rb#L38)

Steps to reproduce the Issue: 
 1. Go to images under product. 
 1. Take any element after the 1st one to the top. 
 1. Edit the one at the top (that was just dragged)
 1. Coming back to the index page shows it in the 2nd position. 

What is happening in the frontend?
 1. Javascript sends the indices starting 0. 
 1. The update_positions method in resource_controller just sets the positions as they were sent (with more stuff going on)
 1. When element in the 0th position is modified. acts_as_list figures 1 is the top of the list and sets the value to 1 along with setting anything which is already in position 1 to 0. 

This fix will not modify existing positions, but will only fix those resources for new updates.

Alternate solution could be to set the configuration for **models** ([sample location](https://github.com/solidusio/solidus/blob/master/core/app/models/spree/asset.rb#L4)) which use acts_as_list to `top_of_list: 0` which could be an alternative solution which fixes this issue from re-occurring in the first place.