### PR TITLE
Use autosave for Product#master and Variant#default_price

### DIFF
--- a/api/spec/controllers/spree/api/products_controller_spec.rb
+++ b/api/spec/controllers/spree/api/products_controller_spec.rb
@@ -334,8 +334,7 @@ module Spree
           expect(response.status).to eq(422)
           expect(json_response["error"]).to eq("Invalid resource. Please fix errors and try again.")
           errors = json_response["errors"]
-          errors.delete("slug") # Don't care about this one.
-          expect(errors.keys).to match_array(["name", "price", "shipping_category_id"])
+          expect(errors.keys).to include("name", "price", "shipping_category_id")
         end
       end
 

--- a/core/app/models/concerns/spree/default_price.rb
+++ b/core/app/models/concerns/spree/default_price.rb
@@ -7,7 +7,8 @@ module Spree
         -> { where currency: Spree::Config[:currency], is_default: true },
         class_name: 'Spree::Price',
         inverse_of: :variant,
-        dependent: :destroy
+        dependent: :destroy,
+        autosave: true
 
       def find_or_build_default_price
         default_price || build_default_price

--- a/core/app/models/concerns/spree/default_price.rb
+++ b/core/app/models/concerns/spree/default_price.rb
@@ -6,6 +6,7 @@ module Spree
       has_one :default_price,
         -> { where currency: Spree::Config[:currency], is_default: true },
         class_name: 'Spree::Price',
+        inverse_of: :variant,
         dependent: :destroy
 
       def find_or_build_default_price

--- a/core/app/models/spree/price.rb
+++ b/core/app/models/spree/price.rb
@@ -1,7 +1,7 @@
 module Spree
   class Price < Spree::Base
     acts_as_paranoid
-    belongs_to :variant, -> { with_deleted }, class_name: 'Spree::Variant', inverse_of: :prices, touch: true
+    belongs_to :variant, -> { with_deleted }, class_name: 'Spree::Variant', touch: true
 
     validate :check_price
     validates :amount, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -341,11 +341,8 @@ module Spree
       end
     end
 
-    # If the master cannot be saved, the Product object will get its errors
-    # and will be destroyed
+    # If the master is invalid, the Product object will be assigned its errors
     def validate_master
-      # We call master.default_price here to ensure price is initialized.
-      # Required to avoid Variant#check_price validation failing on create.
       unless master.valid?
         master.errors.each do |att, error|
           self.errors.add(att, error)

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -346,7 +346,7 @@ module Spree
     def validate_master
       # We call master.default_price here to ensure price is initialized.
       # Required to avoid Variant#check_price validation failing on create.
-      unless master.default_price && master.valid?
+      unless master.valid?
         master.errors.each do |att, error|
           self.errors.add(att, error)
         end

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -34,7 +34,8 @@ module Spree
     has_one :master,
       -> { where(is_master: true).with_deleted },
       inverse_of: :product,
-      class_name: 'Spree::Variant'
+      class_name: 'Spree::Variant',
+      autosave: true
 
     has_many :variants,
       -> { where(is_master: false).order(:position) },
@@ -77,9 +78,7 @@ module Spree
 
     after_initialize :ensure_master
 
-    after_save :save_master
-    after_save :run_touch_callbacks, if: :anything_changed?
-    after_save :reset_nested_changes
+    after_save :run_touch_callbacks, if: :changed?
     after_touch :touch_taxons
 
     before_validation :normalize_slug, on: :update
@@ -321,24 +320,6 @@ module Spree
 
     def punch_slug
       update_column :slug, "#{Time.current.to_i}_#{slug}" # punch slug with date prefix to allow reuse of original
-    end
-
-    def anything_changed?
-      changed? || @nested_changes
-    end
-
-    def reset_nested_changes
-      @nested_changes = false
-    end
-
-    # there's a weird quirk with the delegate stuff that does not automatically save the delegate object
-    # when saving so we force a save using a hook
-    # Fix for issue https://github.com/spree/spree/issues/5306
-    def save_master
-      if master && (master.changed? || master.new_record? || (master.default_price && (master.default_price.changed? || master.default_price.new_record?)))
-        master.save!
-        @nested_changes = true
-      end
     end
 
     # If the master is invalid, the Product object will be assigned its errors

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -338,9 +338,12 @@ module Spree
       # Ensures a new variant takes the product master price when price is not supplied
       def check_price
         if price.nil? && Spree::Config[:require_master_price]
-          raise 'No master variant found to infer price' unless (product && product.master)
-          raise 'Must supply price for variant or master.price for product.' if self == product.master
-          self.price = product.master.price
+          if is_master?
+            errors.add :price, 'Must supply price for variant or master.price for product.'
+          else
+            raise 'No master variant found to infer price' unless (product && product.master)
+            self.price = product.master.price
+          end
         end
         if currency.nil?
           self.currency = Spree::Config[:currency]

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -46,11 +46,25 @@ describe Spree::Product, :type => :model do
         it "should change updated_at" do
           expect { subject }.to change{ product.updated_at }
         end
+
+        it "should touch taxons" do
+          taxon = create(:taxon, products: [product])
+          taxon.update_columns(updated_at: 1.day.ago)
+          product.taxons.reload
+          expect { subject }.to change{ taxon.reload.updated_at }
+        end
       end
 
       shared_examples "no change occurred" do
         it "should not change updated_at" do
           expect { subject }.not_to change{ product.updated_at }
+        end
+
+        it "should not touch taxons" do
+          taxon = create(:taxon, products: [product])
+          taxon.update_columns(updated_at: 1.day.ago)
+          product.taxons.reload
+          expect { subject }.not_to change{ taxon.reload.updated_at }
         end
       end
 


### PR DESCRIPTION
When we save a Product, solidus automatically will save the associated master and the master's associated default_price. Previously, we were implementing this behaviour manually on the product and it was looking a little ugly and convoluted. Some extra logic was also needed because Variant#valid? would raise exceptions in certain cases instead of just setting errors on the object.

Rails has this functionality built in as `autosave: true` on an association. In rails, newly created associations are saved when the parent object is saved (by default). By specifying autosave: true, is will always have this behaviour.

Using `autosave: true` should make this behaviour more consistent, and eliminates a bunch of code and special cases in our product model.

I added specs around the taxon touching behaviour, which determined it was unnecessary to call when master changed, since saving master will cause a touch on product due to the `touch: true`.

Incompatibilities:
* The `check_price` validation no longer raises exceptions (which required several workarounds)
* Because `:autosave` is true, validations will always be performed on master and default_price (previously were only sometimes performed, to avoid the above exception)
* master errors are added on the product to as `"master.price"`. The validation product had on `"price"` still exists. See the required change to the api specs.