### PR TITLE
Improve taxation specs

### DIFF
--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -145,12 +145,10 @@ module Spree
     #
     # Those rates should never come into play at all and only the French rates should apply.
     def potentially_applicable?(order_tax_zone)
-      # If the rate's zone matches the order's tax zone, then it's applicable.
-      self.zone == order_tax_zone ||
       # If the rate's zone *contains* the order's tax zone, then it's applicable.
       self.zone.contains?(order_tax_zone) ||
-      # 1) The rate's zone is the default zone, then it's always applicable.
-      (self.included_in_price? && self.zone.default_tax)
+      # The rate is a VAT and its zone contains the default zone, then it's applicable.
+      (self.included_in_price? && self.zone.contains?(Spree::Zone.default_tax))
     end
 
     # Creates necessary tax adjustments for the order.
@@ -188,8 +186,7 @@ module Spree
     end
 
     def default_zone_or_zone_match?(order_tax_zone)
-      default_tax = Zone.default_tax
-      (default_tax && default_tax.contains?(order_tax_zone)) || order_tax_zone == self.zone
+      Zone.default_tax.try!(:contains?, order_tax_zone) || self.zone.contains?(order_tax_zone)
     end
 
     private

--- a/core/app/models/spree/zone.rb
+++ b/core/app/models/spree/zone.rb
@@ -111,6 +111,7 @@ module Spree
     # Indicates whether the specified zone falls entirely within the zone performing
     # the check.
     def contains?(target)
+      return true if self == target
       return false if kind == 'state' && target.kind == 'country'
       return false if zone_members.empty? || target.zone_members.empty?
 

--- a/core/spec/models/spree/tax_rate_spec.rb
+++ b/core/spec/models/spree/tax_rate_spec.rb
@@ -557,6 +557,19 @@ describe Spree::TaxRate, :type => :model do
           it 'has 15% additional tax' do
             expect(line_item.additional_tax_total).to eq(3)
           end
+
+          it "should delete adjustments for open order when taxrate is deleted" do
+            new_york_books_tax.destroy!
+            federal_books_tax.destroy!
+            expect(line_item.adjustments.count).to eq(0)
+          end
+
+          it "should not delete adjustments for complete order when taxrate is deleted" do
+            order.update_column :completed_at, Time.now
+            new_york_books_tax.destroy!
+            federal_books_tax.destroy!
+            expect(line_item.adjustments.count).to eq(2)
+          end
         end
 
         # This is a fictional case for when no taxes apply at all.
@@ -609,176 +622,15 @@ describe Spree::TaxRate, :type => :model do
           end
         end
       end
-    end
-  end
 
-  context 'old tests' do
-    before do
-      @country = create(:country)
-      @zone = create(:zone, :name => "Country Zone", :default_tax => true, :zone_members => [])
-      @zone.zone_members.create(:zoneable => @country)
-      @category    = Spree::TaxCategory.create :name => "Taxable Foo"
-      @category2   = Spree::TaxCategory.create(:name => "Non Taxable")
-      @rate1        = Spree::TaxRate.create(
-        :amount => 0.10,
-        :calculator => Spree::Calculator::DefaultTax.create,
-        :tax_category => @category,
-        :zone => @zone
-      )
-      @rate2       = Spree::TaxRate.create(
-        :amount => 0.05,
-        :calculator => Spree::Calculator::DefaultTax.create,
-        :tax_category => @category,
-        :zone => @zone
-      )
-      @order       = Spree::Order.create!
-      @taxable     = create(:product, :tax_category => @category)
-      @nontaxable  = create(:product, :tax_category => @category2)
-    end
+      context 'when no tax zone is given' do
+        let(:tax_zone) { nil }
 
-    context "not taxable line item " do
-      let!(:line_item) { @order.contents.add(@nontaxable.master, 1) }
+        context 'and we buy a book' do
+          let(:variant) { book }
 
-      it "should not create a tax adjustment" do
-        Spree::TaxRate.adjust(@order.tax_zone, @order.line_items)
-        expect(line_item.adjustments.tax.charge.count).to eq(0)
-      end
-
-      it "should not create a refund" do
-        Spree::TaxRate.adjust(@order.tax_zone, @order.line_items)
-        expect(line_item.adjustments.credit.count).to eq(0)
-      end
-    end
-
-    context "taxable line item" do
-      let!(:line_item) { @order.contents.add(@taxable.master, 1) }
-
-      context "when price includes tax" do
-        before do
-          @rate1.update_column(:included_in_price, true)
-          @rate2.update_column(:included_in_price, true)
-          Spree::TaxRate.store_pre_tax_amount(line_item, [@rate1, @rate2])
-        end
-
-        context "when zone is contained by default tax zone" do
-          it "should create two adjustments, one for each tax rate" do
-            Spree::TaxRate.adjust(@order.tax_zone, @order.line_items)
-            expect(line_item.adjustments.count).to eq(1)
-          end
-
-          it "should not create a tax refund" do
-            Spree::TaxRate.adjust(@order.tax_zone, @order.line_items)
-            expect(line_item.adjustments.credit.count).to eq(0)
-          end
-        end
-
-        context "when order's zone is neither the default zone, or included in the default zone, but matches the rate's zone" do
-          before do
-            # With no zone members, this zone will not contain anything
-            # Previously:
-            # Zone.stub_chain :default_tax, :contains? => false
-            @zone.zone_members.delete_all
-          end
-          it "should create an adjustment" do
-            Spree::TaxRate.adjust(@order.tax_zone, @order.line_items)
-            expect(line_item.adjustments.charge.count).to eq(1)
-          end
-
-          it "should not create a tax refund for each tax rate" do
-            Spree::TaxRate.adjust(@order.tax_zone, @order.line_items)
-            expect(line_item.adjustments.credit.count).to eq(0)
-          end
-        end
-
-        context "when order's zone does not match default zone, is not included in the default zone, AND does not match the rate's zone" do
-          before do
-            @new_zone = create(:zone, :name => "New Zone", :default_tax => false)
-            @new_country = create(:country, :name => "New Country")
-            @new_zone.zone_members.create(:zoneable => @new_country)
-            @order.ship_address = create(:address, :country => @new_country)
-            @order.save
-          end
-
-          it "should not create positive adjustments" do
-            Spree::TaxRate.adjust(@order.tax_zone, @order.line_items)
-            expect(line_item.adjustments.charge.count).to eq(0)
-          end
-
-          it "should create a tax refund for each tax rate" do
-            Spree::TaxRate.adjust(@order.tax_zone, @order.line_items)
-            expect(line_item.adjustments.credit.count).to eq(1)
-          end
-        end
-
-        context "when price does not include tax" do
-          before do
-            allow(@order).to receive_messages :tax_zone => @zone
-            [@rate1, @rate2].each do |rate|
-              rate.included_in_price = false
-              rate.zone = @zone
-              rate.save
-            end
-            Spree::TaxRate.adjust(@order.tax_zone, @order.line_items)
-          end
-
-          it "should delete adjustments for open order when taxrate is deleted" do
-            @rate1.destroy!
-            @rate2.destroy!
+          it 'does not create adjustments' do
             expect(line_item.adjustments.count).to eq(0)
-          end
-
-          it "should not delete adjustments for complete order when taxrate is deleted" do
-            @order.update_column :completed_at, Time.current
-            @rate1.destroy!
-            @rate2.destroy!
-            expect(line_item.adjustments.count).to eq(2)
-          end
-
-          it "should create an adjustment" do
-            expect(line_item.adjustments.count).to eq(2)
-          end
-
-          it "should not create a tax refund" do
-            expect(line_item.adjustments.credit.count).to eq(0)
-          end
-
-          describe 'tax adjustments' do
-            before { Spree::TaxRate.adjust(@order.tax_zone, @order.line_items) }
-
-            it "should apply adjustments when a tax zone is present" do
-              expect(line_item.adjustments.count).to eq(2)
-            end
-
-            describe 'when the tax zone is removed' do
-              before { allow(@order).to receive_messages :tax_zone => nil }
-
-              it 'does not apply any adjustments' do
-                Spree::TaxRate.adjust(@order.tax_zone, @order.line_items)
-                expect(line_item.adjustments.count).to eq(0)
-              end
-            end
-          end
-        end
-
-        context "when two rates apply" do
-          before do
-            @price_before_taxes = line_item.price / (1 + @rate1.amount + @rate2.amount)
-            # Use the same rounding method as in DefaultTax calculator
-            @price_before_taxes = BigDecimal.new(@price_before_taxes).round(2, BigDecimal::ROUND_HALF_UP)
-            line_item.update_column(:pre_tax_amount, @price_before_taxes)
-            # Clear out any previously automatically-applied adjustments
-            @order.all_adjustments.delete_all
-            @rate1.adjust(@order.tax_zone, line_item)
-            @rate2.adjust(@order.tax_zone, line_item)
-          end
-
-          it "should create two price adjustments" do
-            expect(@order.line_item_adjustments.count).to eq(2)
-          end
-
-          it "price adjustments should be accurate" do
-            included_tax = @order.line_item_adjustments.sum(:amount)
-            expect(@price_before_taxes + included_tax).to eq(line_item.price)
           end
         end
       end

--- a/core/spec/models/spree/tax_rate_spec.rb
+++ b/core/spec/models/spree/tax_rate_spec.rb
@@ -222,6 +222,7 @@ describe Spree::TaxRate, :type => :model do
       let(:romania) { create(:country, iso: "RO") }
       let(:romania_zone) { create(:zone, countries: [romania] ) }
       let(:eu_zone)  { create(:zone, countries: [romania, germany]) }
+      let(:world_zone) { create(:zone, :with_country) }
 
       let!(:german_book_vat) do
         create(
@@ -387,6 +388,96 @@ describe Spree::TaxRate, :type => :model do
 
           it 'has a constant amount pre tax' do
             pending 'but it changes to 8.06, because Spree thinks both VATs apply'
+            expect(line_item.pre_tax_amount).to eq(8.40)
+          end
+        end
+      end
+
+      # International delivery, no tax applies whatsoever
+      context 'to anywhere else in the world' do
+        let(:tax_zone) { world_zone }
+
+        context 'an order with a book' do
+          let(:variant) { book }
+
+          it 'should sell at the net price' do
+            pending "Prices have to be adjusted"
+            expect(line_item.price).to eq(18.69)
+          end
+
+          it 'is adjusted to the net price' do
+            expect(line_item.total).to eq(18.69)
+          end
+
+          it 'has no tax adjustments' do
+            pending "Right now it gets a refund"
+            expect(line_item.adjustments.tax.count).to eq(0)
+          end
+
+          it 'has no included tax' do
+            expect(line_item.included_tax_total).to eq(0)
+          end
+
+          it 'has no additional tax' do
+            pending 'but there is a refund, still'
+            expect(line_item.additional_tax_total).to eq(0)
+          end
+
+          it 'has a constant amount pre tax' do
+            expect(line_item.pre_tax_amount).to eq(18.69)
+          end
+        end
+
+        context 'an order with a sweater' do
+          let(:variant) { sweater }
+
+          it 'should sell at the net price' do
+            pending 'but prices are not adjusted according to the zone yet'
+            expect(line_item.price).to eq(25.21)
+          end
+
+          it 'has no tax adjustments' do
+            pending 'but it has a refund'
+            expect(line_item.adjustments.tax.count).to eq(0)
+          end
+
+          it 'has no included tax' do
+            expect(line_item.included_tax_total).to eq(0)
+          end
+
+          it 'has no additional tax' do
+            pending 'but it has a refund for included taxes wtf'
+            expect(line_item.additional_tax_total).to eq(0)
+          end
+
+          it 'has a constant amount pre tax' do
+            expect(line_item.pre_tax_amount).to eq(25.21)
+          end
+        end
+
+        context 'an order with a download' do
+          let(:variant) { download }
+
+          it 'should sell at the net price' do
+            pending 'but prices are not adjusted yet'
+            expect(line_item.price).to eq(8.40)
+          end
+
+          it 'has no tax adjustments' do
+            pending 'but a refund is created'
+            expect(line_item.adjustments.tax.count).to eq(0)
+          end
+
+          it 'has no included tax' do
+            expect(line_item.included_tax_total).to eq(0)
+          end
+
+          it 'has no additional tax' do
+            pending 'but an tax refund that disguises as additional tax is created'
+            expect(line_item.additional_tax_total).to eq(0)
+          end
+
+          it 'has a constant amount pre tax' do
             expect(line_item.pre_tax_amount).to eq(8.40)
           end
         end

--- a/core/spec/models/spree/zone_spec.rb
+++ b/core/spec/models/spree/zone_spec.rb
@@ -137,6 +137,16 @@ describe Spree::Zone, :type => :model do
       @target = create(:zone, name: 'target', zone_members: [])
     end
 
+    it "should contain itself" do
+      expect(@source.contains?(@source)).to be true
+    end
+
+    context "when both source and target have no members" do
+      it "should be false" do
+        expect(@source.contains?(@target)).to be false
+      end
+    end
+
     context "when the target has no members" do
       before { @source.members.create(zoneable: country1) }
 

--- a/core/spec/models/spree/zone_spec.rb
+++ b/core/spec/models/spree/zone_spec.rb
@@ -155,7 +155,6 @@ describe Spree::Zone, :type => :model do
 
     context "when both zones are the same zone" do
       before do
-        @source.members.create(zoneable: country1)
         @target = @source
       end
 


### PR DESCRIPTION
This extracts the spec improvements (and only those) from https://github.com/solidusio/solidus/pull/536. 

What I do is I create a sort-of real-world spec set-up with understandable country and zone names and attach creative tax rates to them, then expect the order/line items to be correctly adjusted. 

A number of specs are set to pending because the current tax implementation can't do them. A number of other specs are xited because they produce random failures. 

There is one fix included for some failures that occur with the MOSS cases: If the zone your customer is ordering from is inside the default zone, but not the default zone, the default zone's taxes should still apply. 

The global diff is, unfortunately, horrific - I basically replace an entire section of specs. Git sees that a little differently. If you go through the commits one by one, you'll have a much easier time reviewing. 