### PR TITLE
Duplication of product properties when using solidus_globalize (#647)

### DIFF
--- a/core/app/models/concerns/spree/ordered_property_value_list.rb
+++ b/core/app/models/concerns/spree/ordered_property_value_list.rb
@@ -16,10 +16,10 @@ module Spree
       end
 
       def property_name=(name)
-        unless name.blank?
-          unless property = Property.find_by(name: name)
-            property = Property.create(name: name, presentation: name)
-          end
+        if name.present?
+          # don't use `find_by :name` to workaround globalize/globalize#423 bug
+          property = Property.where(name: name).first ||
+              Property.create(name: name, presentation: name)
           self.property = property
         end
       end


### PR DESCRIPTION
Problem: Update product property always creates new properties even if already exists.

Solution:: There's an issue with find_by_id and globalize. It's documented here: globalize/globalize#423

It creates a strange query

```
SELECT "spree_properties".* FROM "spree_properties" INNER JOIN "spree_property_translations" ON "spree_property_translations"."spree_property_id" = "spree_properties"."id" WHERE "spree_property_translations"."name" = '--- !ruby/object:ActiveRecord::StatementCache::Substitute {}
' AND "spree_property_translations"."locale" IN ('pt', 'en') LIMIT 1
```

We can just waived use `find_by :name` to workaround globalize/globalize#423 bug

```ruby
def property_name=(name)
  if name.present?
    property = Property.where(name: name).first ||
      Property.create(name: name, presentation: name)
    self.property = property
  end
end
```
