### PR TITLE
Replace spree issues with direct URLs

### DIFF
--- a/api/spec/controllers/spree/api/checkouts_controller_spec.rb
+++ b/api/spec/controllers/spree/api/checkouts_controller_spec.rb
@@ -106,7 +106,7 @@ module Spree
           expect(response.status).to eq(200)
         end
 
-        # Regression Spec for #5389 & #5880
+        # Regression Spec for https://github.com/spree/spree/issues/5389 & https://github.com/spree/spree/issues/5880
         it "can update addresses but not transition to delivery w/o shipping setup" do
           Spree::ShippingMethod.destroy_all
           api_put :update,
@@ -119,7 +119,7 @@ module Spree
           expect(response.status).to eq(422)
         end
 
-        # Regression test for #4498
+        # Regression test for https://github.com/spree/spree/issues/4498
         it "does not contain duplicate variant data in delivery return" do
           api_put :update,
             id: order.to_param, order_token: order.guest_token,
@@ -394,7 +394,7 @@ module Spree
         expect(response.status).to eq(200)
       end
 
-      # Regression test for #3784
+      # Regression test for https://github.com/spree/spree/issues/3784
       it "can update the special instructions for an order" do
         instructions = "Don't drop it. (Please)"
         api_put :update, id: order.to_param, order_token: order.guest_token,

--- a/api/spec/controllers/spree/api/checkouts_controller_spec.rb
+++ b/api/spec/controllers/spree/api/checkouts_controller_spec.rb
@@ -106,7 +106,7 @@ module Spree
           expect(response.status).to eq(200)
         end
 
-        # Regression Spec for https://github.com/spree/spree/issues/5389 & https://github.com/spree/spree/issues/5880
+        # Regression Spec for https://github.com/spree/spree/issues/5389 and https://github.com/spree/spree/issues/5880
         it "can update addresses but not transition to delivery w/o shipping setup" do
           Spree::ShippingMethod.destroy_all
           api_put :update,

--- a/api/spec/controllers/spree/api/orders_controller_spec.rb
+++ b/api/spec/controllers/spree/api/orders_controller_spec.rb
@@ -284,7 +284,7 @@ module Spree
       expect(json_response["checkout_steps"]).to eq(%w[address delivery confirm complete])
     end
 
-    # Regression test for #1992
+    # Regression test for https://github.com/spree/spree/issues/1992
     it "can view an order not in a standard state" do
       allow_any_instance_of(Order).to receive_messages :user => current_api_user
       order.update_column(:state, 'shipped')
@@ -350,7 +350,7 @@ module Spree
       expect(json_response['email']).to eq "guest@spreecommerce.com"
     end
 
-    # Regression test for #3404
+    # Regression test for https://github.com/spree/spree/issues/3404
     it "can specify additional parameters for a line item" do
       expect(Order).to receive(:create!).and_return(order = Spree::Order.new)
       allow(order).to receive(:associate_user!)
@@ -602,7 +602,7 @@ module Spree
             expect(json_response["shipments"]).not_to be_empty
             shipment = json_response["shipments"][0]
             # Test for correct shipping method attributes
-            # Regression test for #3206
+            # Regression test for https://github.com/spree/spree/issues/3206
             expect(shipment["shipping_methods"]).not_to be_nil
             json_shipping_method = shipment["shipping_methods"][0]
             expect(json_shipping_method["id"]).to eq(shipping_method.id)
@@ -612,7 +612,7 @@ module Spree
             expect(json_shipping_method["shipping_categories"]).not_to be_empty
 
             # Test for correct shipping rates attributes
-            # Regression test for #3206
+            # Regression test for https://github.com/spree/spree/issues/3206
             expect(shipment["shipping_rates"]).not_to be_nil
             shipping_rate = shipment["shipping_rates"][0]
             expect(shipping_rate["name"]).to eq(json_shipping_method["name"])
@@ -683,7 +683,7 @@ module Spree
           expect(json_response["pages"]).to eq(1)
         end
 
-        # Test for #1763
+        # Test for https://github.com/spree/spree/issues/1763
         it "can control the page size through a parameter" do
           api_get :index, :per_page => 1
           expect(json_response["orders"].count).to eq(1)

--- a/api/spec/controllers/spree/api/products_controller_spec.rb
+++ b/api/spec/controllers/spree/api/products_controller_spec.rb
@@ -222,7 +222,7 @@ module Spree
         expect(json_response["pages"]).to eq(1)
       end
 
-      # Regression test for #1626
+      # Regression test for https://github.com/spree/spree/issues/1626
       context "deleted products" do
         before do
           create(:product, :deleted_at => 1.day.ago)
@@ -305,14 +305,14 @@ module Spree
           expect(json_response["taxon_ids"]).to eq([taxon_1.id,])
         end
 
-        # Regression test for #4123
+        # Regression test for https://github.com/spree/spree/issues/4123
         it "puts the created product in the given taxons" do
           product_data[:taxon_ids] = [taxon_1.id, taxon_2.id].join(',')
           api_post :create, :product => product_data
           expect(json_response["taxon_ids"]).to eq([taxon_1.id, taxon_2.id])
         end
 
-        # Regression test for #2140
+        # Regression test for https://github.com/spree/spree/issues/2140
         context "with authentication_required set to false" do
           before do
             Spree::Api::Config.requires_authentication = false
@@ -392,13 +392,13 @@ module Spree
           expect(json_response["errors"]["name"]).to eq(["can't be blank"])
         end
 
-        # Regression test for #4123
+        # Regression test for https://github.com/spree/spree/issues/4123
         it "puts the created product in the given taxon" do
           api_put :update, :id => product.to_param, :product => {:taxon_ids => taxon_1.id.to_s}
           expect(json_response["taxon_ids"]).to eq([taxon_1.id])
         end
 
-        # Regression test for #4123
+        # Regression test for https://github.com/spree/spree/issues/4123
         it "puts the created product in the given taxons" do
           api_put :update, :id => product.to_param, :product => {:taxon_ids => [taxon_1.id, taxon_2.id].join(',')}
           expect(json_response["taxon_ids"]).to match_array([taxon_1.id, taxon_2.id])

--- a/api/spec/controllers/spree/api/taxons_controller_spec.rb
+++ b/api/spec/controllers/spree/api/taxons_controller_spec.rb
@@ -27,7 +27,7 @@ module Spree
         expect(children.first['taxons'].count).to eq 1
       end
 
-      # Regression test for #4112
+      # Regression test for https://github.com/spree/spree/issues/4112
       it "does not include children when asked not to" do
         api_get :index, :taxonomy_id => taxonomy.id, :without_children => 1
 

--- a/api/spec/controllers/spree/api/variants_controller_spec.rb
+++ b/api/spec/controllers/spree/api/variants_controller_spec.rb
@@ -72,7 +72,7 @@ module Spree
 
       end
 
-      # Regression test for #2141
+      # Regression test for https://github.com/spree/spree/issues/2141
       context "a deleted variant" do
         before do
           variant.update_column(:deleted_at, Time.current)
@@ -223,7 +223,7 @@ module Spree
       sign_in_as_admin!
       let(:resource_scoping) { { :product_id => variant.product.to_param } }
 
-      # Test for #2141
+      # Test for https://github.com/spree/spree/issues/2141
       context "deleted variants" do
         before do
           variant.update_column(:deleted_at, Time.current)

--- a/backend/spec/controllers/spree/admin/missing_products_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/missing_products_controller_spec.rb
@@ -7,7 +7,7 @@ require 'spec_helper'
 describe Spree::Admin::ProductsController, :type => :controller do
   stub_authorization!
 
-  # Regression test for GH #538
+  # Regression test for GH https://github.com/spree/spree/issues/538
   it "cannot find a non-existent product" do
     spree_get :edit, :id => "non-existent-product"
     expect(response).to redirect_to(spree.admin_products_path)

--- a/backend/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -66,7 +66,7 @@ describe Spree::Admin::OrdersController, :type => :controller do
       end
     end
 
-    # Test for #3346
+    # Test for https://github.com/spree/spree/issues/3346
     context "#new" do
       let(:user) { create(:user) }
       before do
@@ -112,7 +112,7 @@ describe Spree::Admin::OrdersController, :type => :controller do
       end
     end
 
-    # Regression test for #3684
+    # Regression test for https://github.com/spree/spree/issues/3684
     context "#edit" do
       it "does not refresh rates if the order is completed" do
         allow(order).to receive_messages :completed? => true
@@ -275,7 +275,7 @@ describe Spree::Admin::OrdersController, :type => :controller do
       end
     end
 
-    # Test for #3919
+    # Test for https://github.com/spree/spree/issues/3919
     context "search" do
       let(:user) { create(:user) }
 

--- a/backend/spec/controllers/spree/admin/payment_methods_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/payment_methods_controller_spec.rb
@@ -10,7 +10,7 @@ module Spree
 
     let(:payment_method) { GatewayWithPassword.create!(:name => "Bogus", :preferred_password => "haxme") }
 
-    # regression test for #2094
+    # regression test for https://github.com/spree/spree/issues/2094
     it "does not clear password on update" do
       expect(payment_method.preferred_password).to eq("haxme")
       spree_put :update, :id => payment_method.id, :payment_method => { :type => payment_method.class.to_s, :preferred_password => "" }

--- a/backend/spec/controllers/spree/admin/payments_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/payments_controller_spec.rb
@@ -71,7 +71,7 @@ module Spree
         end
       end
 
-      # Regression test for #3233
+      # Regression test for https://github.com/spree/spree/issues/3233
       context "with a backend payment method" do
         before do
           @payment_method = create(:check_payment_method, :display_on => "back_end")

--- a/backend/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/products_controller_spec.rb
@@ -6,7 +6,7 @@ describe Spree::Admin::ProductsController, :type => :controller do
   context "#index" do
     let(:ability_user) { stub_model(Spree::LegacyUser, :has_spree_role? => true) }
 
-    # Regression test for #1259
+    # Regression test for https://github.com/spree/spree/issues/1259
     it "can find a product by SKU" do
       product = create(:product, :sku => "ABC123")
       spree_get :index, :q => { :sku_start => "ABC123" }
@@ -15,7 +15,7 @@ describe Spree::Admin::ProductsController, :type => :controller do
     end
   end
 
-  # regression test for #1370
+  # regression test for https://github.com/spree/spree/issues/1370
   context "adding properties to a product" do
     let!(:product) { create(:product) }
     specify do
@@ -143,7 +143,7 @@ describe Spree::Admin::ProductsController, :type => :controller do
     end
   end
 
-  # regression test for #801
+  # regression test for https://github.com/spree/spree/issues/801
   context "destroying a product" do
     let(:product) do
       product = create(:product)

--- a/backend/spec/controllers/spree/admin/return_authorizations_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/return_authorizations_controller_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Spree::Admin::ReturnAuthorizationsController, :type => :controller do
   stub_authorization!
 
-  # Regression test for #1370 #3
+  # Regression test for https://github.com/spree/spree/issues/1370 #3
   let!(:order) { create(:shipped_order, line_items_count: 3) }
   let!(:return_reason) { create(:return_reason) }
   let(:inventory_unit_1) { order.inventory_units.order('id asc')[0] }

--- a/backend/spec/controllers/spree/admin/shipping_methods_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/shipping_methods_controller_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Spree::Admin::ShippingMethodsController, :type => :controller do
   stub_authorization!
 
-  # Regression test for #1240
+  # Regression test for https://github.com/spree/spree/issues/1240
   it "should not hard-delete shipping methods" do
     shipping_method = stub_model(Spree::ShippingMethod)
     allow(Spree::ShippingMethod).to receive_messages :find => shipping_method

--- a/backend/spec/controllers/spree/admin/stock_locations_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/stock_locations_controller_spec.rb
@@ -5,7 +5,7 @@ module Spree
     describe StockLocationsController, :type => :controller do
       stub_authorization!
       
-      # Regression for #4272
+      # Regression for https://github.com/spree/spree/issues/4272
       context "with no countries present" do
         it "cannot create a new stock location" do
           spree_get :new

--- a/backend/spec/features/admin/configuration/shipping_methods_spec.rb
+++ b/backend/spec/features/admin/configuration/shipping_methods_spec.rb
@@ -46,7 +46,7 @@ describe "Shipping Methods", :type => :feature do
     end
   end
 
-  # Regression test for #1331
+  # Regression test for https://github.com/spree/spree/issues/1331
   context "update" do
     it "can change the calculator", :js => true do
       within("#listing_shipping_methods") do

--- a/backend/spec/features/admin/configuration/tax_rates_spec.rb
+++ b/backend/spec/features/admin/configuration/tax_rates_spec.rb
@@ -10,7 +10,7 @@ describe "Tax Rates", :type => :feature do
     click_link "Settings"
   end
 
-  # Regression test for #535
+  # Regression test for https://github.com/spree/spree/issues/535
   it "can see a tax rate in the list if the tax category has been deleted" do
     tax_rate.tax_category.update_column(:deleted_at, Time.current)
     click_link "Tax Rates"
@@ -18,7 +18,7 @@ describe "Tax Rates", :type => :feature do
     expect(find("table tbody td:nth-child(3)")).to have_content('N/A')
   end
 
-  # Regression test for #1422
+  # Regression test for https://github.com/spree/spree/issues/1422
   it "can create a new tax rate" do
     click_link "Tax Rates"
     click_link "New Tax Rate"

--- a/backend/spec/features/admin/orders/customer_details_spec.rb
+++ b/backend/spec/features/admin/orders/customer_details_spec.rb
@@ -16,7 +16,7 @@ describe "Customer Details", type: :feature, js: true do
   let!(:user) { create(:user, email: 'foobar@example.com', ship_address: ship_address, bill_address: bill_address) }
 
   context "brand new order" do
-    # Regression test for https://github.com/spree/spree/issues/3335 & https://github.com/spree/spree/issues/5317
+    # Regression test for https://github.com/spree/spree/issues/3335 and https://github.com/spree/spree/issues/5317
     it "associates a user when not using guest checkout" do
       visit spree.admin_path
       click_link "Orders"
@@ -86,7 +86,7 @@ describe "Customer Details", type: :feature, js: true do
       click_button "Update"
       click_link "Customer Details"
 
-      # Regression test for https://github.com/spree/spree/issues/2950 + https://github.com/spree/spree/issues/2433
+      # Regression test for https://github.com/spree/spree/issues/2950 and https://github.com/spree/spree/issues/2433
       # This act should transition the state of the order as far as it will go too
       within("#order_tab_summary") do
         expect(find("dt#order_status + dd")).to have_content("COMPLETE")

--- a/backend/spec/features/admin/orders/customer_details_spec.rb
+++ b/backend/spec/features/admin/orders/customer_details_spec.rb
@@ -16,7 +16,7 @@ describe "Customer Details", type: :feature, js: true do
   let!(:user) { create(:user, email: 'foobar@example.com', ship_address: ship_address, bill_address: bill_address) }
 
   context "brand new order" do
-    # Regression test for #3335 & #5317
+    # Regression test for https://github.com/spree/spree/issues/3335 & https://github.com/spree/spree/issues/5317
     it "associates a user when not using guest checkout" do
       visit spree.admin_path
       click_link "Orders"
@@ -86,7 +86,7 @@ describe "Customer Details", type: :feature, js: true do
       click_button "Update"
       click_link "Customer Details"
 
-      # Regression test for #2950 + #2433
+      # Regression test for https://github.com/spree/spree/issues/2950 + https://github.com/spree/spree/issues/2433
       # This act should transition the state of the order as far as it will go too
       within("#order_tab_summary") do
         expect(find("dt#order_status + dd")).to have_content("COMPLETE")
@@ -126,7 +126,7 @@ describe "Customer Details", type: :feature, js: true do
       end
     end
 
-    # Regression test for #942
+    # Regression test for https://github.com/spree/spree/issues/942
     context "errors when no shipping methods are available" do
       before do
         Spree::ShippingMethod.delete_all

--- a/backend/spec/features/admin/orders/line_items_spec.rb
+++ b/backend/spec/features/admin/orders/line_items_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-# Tests for #3958's features
+# Tests for https://github.com/spree/spree/issues/3958's features
 describe "Order Line Items", type: :feature, js: true do
   stub_authorization!
 

--- a/backend/spec/features/admin/orders/listing_spec.rb
+++ b/backend/spec/features/admin/orders/listing_spec.rb
@@ -79,7 +79,7 @@ describe "Orders Listing", type: :feature, js: true do
         Spree::Config[:orders_per_page] = @old_per_page
       end
 
-      # Regression test for #4004
+      # Regression test for https://github.com/spree/spree/issues/4004
       it "should be able to go from page to page for incomplete orders" do
         10.times { Spree::Order.create email: "incomplete@example.com" }
         click_on 'Filter'

--- a/backend/spec/features/admin/orders/new_order_spec.rb
+++ b/backend/spec/features/admin/orders/new_order_spec.rb
@@ -91,7 +91,7 @@ describe "New Order", :type => :feature do
     end
   end
 
-  # Regression test for #3958
+  # Regression test for https://github.com/spree/spree/issues/3958
   context "without a delivery step", js: true do
     before do
       allow(Spree::Order).to receive_messages checkout_step_names: [:address, :payment, :confirm, :complete]
@@ -119,7 +119,7 @@ describe "New Order", :type => :feature do
     end
   end
 
-  # Regression test for #3336
+  # Regression test for https://github.com/spree/spree/issues/3336
   context "start by customer address" do
     it "completes order fine", js: true do
       click_on "Customer Details"
@@ -149,7 +149,7 @@ describe "New Order", :type => :feature do
     end
   end
 
-  # Regression test for #5327
+  # Regression test for https://github.com/spree/spree/issues/5327
   context "customer with default credit card", js: true do
     before do
       create(:credit_card, default: true, user: user)

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -67,7 +67,7 @@ describe "Order Details", type: :feature, js: true do
         expect(page).not_to have_content("spree t-shirt")
       end
 
-      # Regression test for #3862
+      # Regression test for https://github.com/spree/spree/issues/3862
       it "can cancel removing an item from a shipment" do
         expect(page).to have_content("spree t-shirt")
 

--- a/backend/spec/features/admin/orders/payments_spec.rb
+++ b/backend/spec/features/admin/orders/payments_spec.rb
@@ -30,7 +30,7 @@ describe 'Payments', :type => :feature do
       visit current_path
     end
 
-    # Regression tests for #1453
+    # Regression tests for https://github.com/spree/spree/issues/1453
     context 'with a check payment' do
       let(:order) { create(:completed_order_with_totals, number: 'R100') }
       let!(:payment) do
@@ -100,7 +100,7 @@ describe 'Payments', :type => :feature do
       expect(page).not_to have_selector('#new_payment_section')
     end
 
-    # Regression test for #1269
+    # Regression test for https://github.com/spree/spree/issues/1269
     it 'cannot create a payment for an order with no payment methods' do
       Spree::PaymentMethod.delete_all
       order.payments.delete_all
@@ -173,7 +173,7 @@ describe 'Payments', :type => :feature do
     let(:order) { create(:order_with_line_items, :line_items_count => 1) }
     let!(:payment_method) { create(:credit_card_payment_method)}
 
-    # Regression tests for #4129
+    # Regression tests for https://github.com/spree/spree/issues/4129
     context "with a credit card payment method" do
       before do
         visit spree.admin_order_payments_path(order)
@@ -184,7 +184,7 @@ describe 'Payments', :type => :feature do
         fill_in "Name *", :with => "Test User"
         fill_in "Expiration", :with => "09 / #{Time.current.year + 1}"
         fill_in "Card Code", :with => "007"
-        # Regression test for #4277
+        # Regression test for https://github.com/spree/spree/issues/4277
         expect(page).to have_css('.ccType[value="visa"]', visible: false)
         click_button "Continue"
         expect(page).to have_content("Payment has been successfully created!")

--- a/backend/spec/features/admin/orders/shipments_spec.rb
+++ b/backend/spec/features/admin/orders/shipments_spec.rb
@@ -5,7 +5,7 @@ describe "Shipments", :type => :feature do
 
   let!(:order) { create(:order_ready_to_ship, :number => "R100", :state => "complete", :line_items_count => 5) }
 
-  # Regression test for #4025
+  # Regression test for https://github.com/spree/spree/issues/4025
   context "a shipment without a shipping method" do
     before do
       order.shipments.each do |s|

--- a/backend/spec/features/admin/products/edit/images_spec.rb
+++ b/backend/spec/features/admin/products/edit/images_spec.rb
@@ -42,7 +42,7 @@ describe "Product Images", :type => :feature do
     end
   end
 
-  # Regression test for #2228
+  # Regression test for https://github.com/spree/spree/issues/2228
   it "should see variant images" do
     variant = create(:variant)
     variant.images.create!(:attachment => File.open(file_path))

--- a/backend/spec/features/admin/products/edit/products_spec.rb
+++ b/backend/spec/features/admin/products/edit/products_spec.rb
@@ -49,7 +49,7 @@ describe 'Product Details', :type => :feature do
     end
   end
 
-  # Regression test for #3385
+  # Regression test for https://github.com/spree/spree/issues/3385
   context "deleting a product", :js => true do
     it "is still able to find the master variant" do
       create(:product)

--- a/backend/spec/features/admin/products/edit/taxons_spec.rb
+++ b/backend/spec/features/admin/products/edit/taxons_spec.rb
@@ -5,7 +5,7 @@ describe "Product Taxons", :type => :feature do
 
   context "managing taxons" do
     def assert_selected_taxons(taxons)
-      # Regression test for #2139
+      # Regression test for https://github.com/spree/spree/issues/2139
       taxons.each do |taxon|
         expect(page).to have_css(".select2-search-choice", text: taxon.name)
       end

--- a/backend/spec/features/admin/products/option_types_spec.rb
+++ b/backend/spec/features/admin/products/option_types_spec.rb
@@ -56,7 +56,7 @@ describe "Option Types", :type => :feature do
     end
   end
 
-  # Regression test for #2277
+  # Regression test for https://github.com/spree/spree/issues/2277
   it "can remove an option value from an option type", :js => true do
     create(:option_value)
     click_link "Option Types"
@@ -83,7 +83,7 @@ describe "Option Types", :type => :feature do
     end
   end
 
-  # Regression test for #3204
+  # Regression test for https://github.com/spree/spree/issues/3204
   it "can remove a non-persisted option value from an option type", :js => true do
     create(:option_type)
     click_link "Option Types"

--- a/backend/spec/features/admin/products/products_spec.rb
+++ b/backend/spec/features/admin/products/products_spec.rb
@@ -60,7 +60,7 @@ describe "Products", :type => :feature do
             create(:product, :name => "Just a product", :price => 19.99)
           end
 
-          # Regression test for #2737
+          # Regression test for https://github.com/spree/spree/issues/2737
           context "uses руб as the currency symbol" do
             it "on the products listing page" do
               visit spree.admin_products_path
@@ -250,7 +250,7 @@ describe "Products", :type => :feature do
         end
       end
 
-      # Regression test for #2097
+      # Regression test for https://github.com/spree/spree/issues/2097
       it "can set the count on hand to a null value", :js => true do
         fill_in "product_name", :with => "Baseball Cap"
         fill_in "product_price", :with => "100"

--- a/backend/spec/features/admin/products/properties_spec.rb
+++ b/backend/spec/features/admin/products/properties_spec.rb
@@ -82,7 +82,7 @@ describe "Properties", :type => :feature do
       click_link "Product Properties"
     end
 
-    # Regression test for #2279
+    # Regression test for https://github.com/spree/spree/issues/2279
     it "successfully create and then remove product property" do
       fill_in_property
 
@@ -93,7 +93,7 @@ describe "Properties", :type => :feature do
       check_property_row_count(1)
     end
 
-    # Regression test for #4466
+    # Regression test for https://github.com/spree/spree/issues/4466
     it "successfully remove and create a product property at the same time" do
       fill_in_property
 

--- a/backend/spec/features/admin/products/stock_management_spec.rb
+++ b/backend/spec/features/admin/products/stock_management_spec.rb
@@ -21,7 +21,7 @@ describe "Stock Management", :type => :feature do
       click_link "Stock Management"
     end
 
-    # Regression test for #3304
+    # Regression test for https://github.com/spree/spree/issues/3304
     # It is OK to still render the stock page, ensure no errors in this case
     context "with no stock location" do
       before do

--- a/backend/spec/features/admin/products/variant_spec.rb
+++ b/backend/spec/features/admin/products/variant_spec.rb
@@ -38,7 +38,7 @@ describe "Variants", :type => :feature do
           create(:variant, :product => product, :price => 19.99)
         end
 
-        # Regression test for #2737
+        # Regression test for https://github.com/spree/spree/issues/2737
         context "uses руб as the currency symbol" do
           it "on the products listing page" do
             visit spree.admin_product_variants_path(product)

--- a/core/app/models/spree/classification.rb
+++ b/core/app/models/spree/classification.rb
@@ -5,7 +5,7 @@ module Spree
     belongs_to :product, class_name: "Spree::Product", inverse_of: :classifications
     belongs_to :taxon, class_name: "Spree::Taxon", inverse_of: :classifications, touch: true
 
-    # For #3494
+    # For https://github.com/spree/spree/issues/3494
     validates_uniqueness_of :taxon_id, scope: :product_id, message: :already_linked
   end
 end

--- a/core/app/models/spree/log_entry.rb
+++ b/core/app/models/spree/log_entry.rb
@@ -2,7 +2,7 @@ module Spree
   class LogEntry < Spree::Base
     belongs_to :source, polymorphic: true
 
-    # Fix for #1767
+    # Fix for https://github.com/spree/spree/issues/1767
     # If a payment fails, we want to make sure we keep the record of it failing
     after_rollback :save_anyway
 

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -261,7 +261,7 @@ WARN
       # Necessary because some payment gateways will refuse payments with
       # duplicate IDs. We *were* using the Order number, but that's set once and
       # is unchanging. What we need is a unique identifier on a per-payment basis,
-      # and this is it. Related to #1998.
+      # and this is it. Related to https://github.com/spree/spree/issues/1998.
       # See https://github.com/spree/spree/issues/1998#issuecomment-12869105
       def set_unique_identifier
         begin

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -231,7 +231,7 @@ module Spree
     # @param property_value [String] the property value
     def set_property(property_name, property_value)
       ActiveRecord::Base.transaction do
-        # Works around spree_i18n #301
+        # Works around spree_i18n https://github.com/spree/spree/issues/301
         property = Property.create_with(presentation: property_name).find_or_create_by(name: property_name)
         product_property = ProductProperty.where(product: self, property: property).first_or_initialize
         product_property.value = property_value
@@ -341,7 +341,7 @@ module Spree
 
     # there's a weird quirk with the delegate stuff that does not automatically save the delegate object
     # when saving so we force a save using a hook
-    # Fix for issue #5306
+    # Fix for issue https://github.com/spree/spree/issues/5306
     def save_master
       if master && (master.changed? || master.new_record? || (master.default_price && (master.default_price.changed? || master.default_price.new_record?)))
         master.save!

--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -50,7 +50,7 @@ module Spree
       # When you ship to France, you'll see a Spanish refund AND a French tax.
       # This little bit of code at the end stops the Spanish refund from appearing.
       #
-      # For further discussion, see #4397 and #4327.
+      # For further discussion, see https://github.com/spree/spree/issues/4397 and https://github.com/spree/spree/issues/4327.
 
       remaining_rates = rates.dup
       rates.each do |rate|

--- a/core/db/migrate/20130213191427_create_default_stock.rb
+++ b/core/db/migrate/20130213191427_create_default_stock.rb
@@ -13,7 +13,7 @@ class CreateDefaultStock < ActiveRecord::Migration
     Spree::Variant.find_each do |variant|
       stock_item = Spree::StockItem.unscoped.build(stock_location: location, variant: variant)
       stock_item.send(:count_on_hand=, variant.count_on_hand)
-      # Avoid running default_scope defined by acts_as_paranoid, related to #3805,
+      # Avoid running default_scope defined by acts_as_paranoid, related to https://github.com/spree/spree/issues/3805,
       # validations would run a query with a delete_at column that might not be present yet
       stock_item.save! validate: false
     end

--- a/core/db/migrate/20130306181701_add_address_fields_to_stock_location.rb
+++ b/core/db/migrate/20130306181701_add_address_fields_to_stock_location.rb
@@ -14,7 +14,7 @@ class AddAddressFieldsToStockLocation < ActiveRecord::Migration
 
     usa = Spree::Country.where(:iso => 'US').first
     # In case USA isn't found.
-    # See #3115
+    # See https://github.com/spree/spree/issues/3115
     country = usa || Spree::Country.first
     Spree::Country.reset_column_information
     Spree::StockLocation.update_all(:country_id => country)

--- a/core/lib/spree/core/controller_helpers/order.rb
+++ b/core/lib/spree/core/controller_helpers/order.rb
@@ -38,7 +38,7 @@ module Spree
           if options[:create_order_if_necessary] && (@current_order.nil? || @current_order.completed?)
             @current_order = Spree::Order.new(current_order_params)
             @current_order.user ||= try_spree_current_user
-            # See issue #3346 for reasons why this line is here
+            # See issue https://github.com/spree/spree/issues/3346 for reasons why this line is here
             @current_order.created_by ||= try_spree_current_user
             @current_order.save!
           end

--- a/core/spec/helpers/base_helper_spec.rb
+++ b/core/spec/helpers/base_helper_spec.rb
@@ -50,7 +50,7 @@ describe Spree::BaseHelper, :type => :helper do
     end
   end
 
-  # Regression test for #1436
+  # Regression test for https://github.com/spree/spree/issues/1436
   context "defining custom image helpers" do
     let(:product) { mock_model(Spree::Product, :images => [], :variant_images => []) }
     before do
@@ -71,7 +71,7 @@ describe Spree::BaseHelper, :type => :helper do
 
   end
 
-  # Regression test for #2034
+  # Regression test for https://github.com/spree/spree/issues/2034
   context "flash_message" do
     let(:flash) { {"notice" => "ok", "foo" => "foo", "bar" => "bar"} }
 
@@ -130,7 +130,7 @@ describe Spree::BaseHelper, :type => :helper do
     end
   end
 
-  # Regression test for #2396
+  # Regression test for https://github.com/spree/spree/issues/2396
   context "meta_data_tags" do
     it "truncates a product description to 160 characters" do
       # Because the controller_name method returns "test"
@@ -144,7 +144,7 @@ describe Spree::BaseHelper, :type => :helper do
     end
   end
 
-  # Regression test for #5384
+  # Regression test for https://github.com/spree/spree/issues/5384
   context "custom image helpers conflict with inproper statements" do
     let(:product) { mock_model(Spree::Product, :images => [], :variant_images => []) }
     before do

--- a/core/spec/helpers/order_helper_spec.rb
+++ b/core/spec/helpers/order_helper_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 module Spree
   describe Spree::OrdersHelper, :type => :helper do
-    # Regression test for #2518 + #2323
+    # Regression test for https://github.com/spree/spree/issues/2518 + https://github.com/spree/spree/issues/2323
     it "truncates HTML correctly in product description" do
       product = double(:description => "<strong>" + ("a" * 95) + "</strong> This content is invisible.")
       expected = "<strong>" + ("a" * 95) + "</strong>..."

--- a/core/spec/helpers/order_helper_spec.rb
+++ b/core/spec/helpers/order_helper_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 module Spree
   describe Spree::OrdersHelper, :type => :helper do
-    # Regression test for https://github.com/spree/spree/issues/2518 + https://github.com/spree/spree/issues/2323
+    # Regression test for https://github.com/spree/spree/issues/2518 and https://github.com/spree/spree/issues/2323
     it "truncates HTML correctly in product description" do
       product = double(:description => "<strong>" + ("a" * 95) + "</strong> This content is invisible.")
       expected = "<strong>" + ("a" * 95) + "</strong>..."

--- a/core/spec/helpers/products_helper_spec.rb
+++ b/core/spec/helpers/products_helper_spec.rb
@@ -42,7 +42,7 @@ module Spree
           let(:variant_price) { 15 }
 
           it { is_expected.to eq("(Add: $5.00)") }
-          # Regression test for #2737
+          # Regression test for https://github.com/spree/spree/issues/2737
           it { is_expected.to be_html_safe }
         end
 
@@ -119,7 +119,7 @@ module Spree
 
 
     context "#product_description" do
-      # Regression test for #1607
+      # Regression test for https://github.com/spree/spree/issues/1607
       it "renders a product description without excessive paragraph breaks" do
         product.description = %Q{
 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus a ligula leo. Proin eu arcu at ipsum dapibus ullamcorper. Pellentesque egestas orci nec magna condimentum luctus. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Ut ac ante et mauris bibendum ultricies non sed massa. Fusce facilisis dui eget lacus scelerisque eget aliquam urna ultricies. Duis et rhoncus quam. Praesent tellus nisi, ultrices sed iaculis quis, euismod interdum ipsum.</p>

--- a/core/spec/helpers/taxons_helper_spec.rb
+++ b/core/spec/helpers/taxons_helper_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Spree::TaxonsHelper, :type => :helper do
-  # Regression test for #4382
+  # Regression test for https://github.com/spree/spree/issues/4382
   it "#taxon_preview" do
     taxon = create(:taxon)
     child_taxon = create(:taxon, parent: taxon)

--- a/core/spec/lib/spree/money_spec.rb
+++ b/core/spec/lib/spree/money_spec.rb
@@ -97,7 +97,7 @@ describe Spree::Money do
       end
     end
 
-    # Regression test for #2634
+    # Regression test for https://github.com/spree/spree/issues/2634
     it "formats as plain by default" do
       money = Spree::Money.new(10, symbol_position: :after)
       expect(money.to_s).to eq("10.00 €")

--- a/core/spec/mailers/carton_mailer_spec.rb
+++ b/core/spec/mailers/carton_mailer_spec.rb
@@ -8,7 +8,7 @@ describe Spree::CartonMailer do
   let(:carton) { create(:carton) }
   let(:order) { carton.orders.first }
 
-  # Regression test for #2196
+  # Regression test for https://github.com/spree/spree/issues/2196
   it "doesn't include out of stock in the email body" do
     shipment_email = Spree::CartonMailer.shipped_email(order: order, carton: carton)
     expect(shipment_email.body).not_to include(%Q{Out of Stock})

--- a/core/spec/mailers/order_mailer_spec.rb
+++ b/core/spec/mailers/order_mailer_spec.rb
@@ -74,7 +74,7 @@ describe Spree::OrderMailer, :type => :mailer do
   end
 
   context "displays unit costs from line item" do
-    # Regression test for #2772
+    # Regression test for https://github.com/spree/spree/issues/2772
 
     # Tests mailer view spree/order_mailer/confirm_email.text.erb
     specify do

--- a/core/spec/models/spree/address_spec.rb
+++ b/core/spec/models/spree/address_spec.rb
@@ -175,7 +175,7 @@ describe Spree::Address, :type => :model do
         end
       end
 
-      # Regression test for #1142
+      # Regression test for https://github.com/spree/spree/issues/1142
       it "uses the first available country if :default_country_id is set to an invalid value" do
         Spree::Config[:default_country_id] = "0"
         expect(Spree::Address.build_default.country).to eq default_country

--- a/core/spec/models/spree/calculator/price_sack_spec.rb
+++ b/core/spec/models/spree/calculator/price_sack_spec.rb
@@ -12,17 +12,17 @@ describe Spree::Calculator::PriceSack, :type => :model do
   let(:order) { stub_model(Spree::Order) }
   let(:shipment) { stub_model(Spree::Shipment, :amount => 10) }
 
-  # Regression test for #714 and #739
+  # Regression test for https://github.com/spree/spree/issues/714 and https://github.com/spree/spree/issues/739
   it "computes with an order object" do
     calculator.compute(order)
   end
 
-  # Regression test for #1156
+  # Regression test for https://github.com/spree/spree/issues/1156
   it "computes with a shipment object" do
     calculator.compute(shipment)
   end
 
-  # Regression test for #2055
+  # Regression test for https://github.com/spree/spree/issues/2055
   it "computes the correct amount" do
     expect(calculator.compute(2)).to eq(calculator.preferred_normal_amount)
     expect(calculator.compute(6)).to eq(calculator.preferred_discount_amount)

--- a/core/spec/models/spree/calculator/shipping/price_sack_spec.rb
+++ b/core/spec/models/spree/calculator/shipping/price_sack_spec.rb
@@ -12,17 +12,17 @@ describe Spree::Calculator::PriceSack, :type => :model do
   let(:order) { stub_model(Spree::Order) }
   let(:shipment) { stub_model(Spree::Shipment, :amount => 10) }
 
-  # Regression test for #714 and #739
+  # Regression test for https://github.com/spree/spree/issues/714 and https://github.com/spree/spree/issues/739
   it "computes with an order object" do
     calculator.compute(order)
   end
 
-  # Regression test for #1156
+  # Regression test for https://github.com/spree/spree/issues/1156
   it "computes with a shipment object" do
     calculator.compute(shipment)
   end
 
-  # Regression test for #2055
+  # Regression test for https://github.com/spree/spree/issues/2055
   it "computes the correct amount" do
     expect(calculator.compute(2)).to eq(calculator.preferred_normal_amount)
     expect(calculator.compute(6)).to eq(calculator.preferred_discount_amount)

--- a/core/spec/models/spree/classification_spec.rb
+++ b/core/spec/models/spree/classification_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 module Spree
   describe Classification, :type => :model do
-    # Regression test for #3494
+    # Regression test for https://github.com/spree/spree/issues/3494
     it "cannot link the same taxon to the same product more than once" do
       product = create(:product)
       taxon = create(:taxon)

--- a/core/spec/models/spree/credit_card_spec.rb
+++ b/core/spec/models/spree/credit_card_spec.rb
@@ -154,7 +154,7 @@ describe Spree::CreditCard, type: :model do
     end
   end
 
-  # Regression test for #3847 & #3896
+  # Regression test for https://github.com/spree/spree/issues/3847 & https://github.com/spree/spree/issues/3896
   context "#expiry=" do
     it "can set with a 2-digit month and year" do
       credit_card.expiry = '04 / 15'
@@ -196,7 +196,7 @@ describe Spree::CreditCard, type: :model do
       credit_card.expiry = ''
     end
 
-    # Regression test for #4725
+    # Regression test for https://github.com/spree/spree/issues/4725
     it "does not blow up when passed one number" do
       credit_card.expiry = '12'
     end

--- a/core/spec/models/spree/credit_card_spec.rb
+++ b/core/spec/models/spree/credit_card_spec.rb
@@ -154,7 +154,7 @@ describe Spree::CreditCard, type: :model do
     end
   end
 
-  # Regression test for https://github.com/spree/spree/issues/3847 & https://github.com/spree/spree/issues/3896
+  # Regression test for https://github.com/spree/spree/issues/3847 and https://github.com/spree/spree/issues/3896
   context "#expiry=" do
     it "can set with a 2-digit month and year" do
       credit_card.expiry = '04 / 15'

--- a/core/spec/models/spree/gateway/bogus_simple.rb
+++ b/core/spec/models/spree/gateway/bogus_simple.rb
@@ -4,7 +4,7 @@ describe Spree::Gateway::BogusSimple, :type => :model do
 
   subject { Spree::Gateway::BogusSimple.new }
 
-  # regression test for #3824
+  # regression test for https://github.com/spree/spree/issues/3824
   describe "#capture" do
     it "returns success with the right response code" do
       response = subject.capture(123, '12345', {})

--- a/core/spec/models/spree/inventory_unit_spec.rb
+++ b/core/spec/models/spree/inventory_unit_spec.rb
@@ -37,7 +37,7 @@ describe Spree::InventoryUnit, :type => :model do
       stock_item.set_count_on_hand(-2)
     end
 
-    # Regression for #3066
+    # Regression for https://github.com/spree/spree/issues/3066
     it "returns modifiable objects" do
       units = Spree::InventoryUnit.backordered_for_stock_item(stock_item)
       units.first.save!

--- a/core/spec/models/spree/item_adjustments_spec.rb
+++ b/core/spec/models/spree/item_adjustments_spec.rb
@@ -253,7 +253,7 @@ module Spree
           promo_c.update_column(:eligible, false)
         end
 
-        # regression for #3274
+        # regression for https://github.com/spree/spree/issues/3274
         it "still makes the previous best eligible adjustment valid" do
           subject.update
           expect(line_item.adjustments.promotion.eligible.first.label).to eq('Promotion A')

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -89,7 +89,7 @@ describe Spree::LineItem, :type => :model do
     end
   end
 
-  # Test for #3391
+  # Test for https://github.com/spree/spree/issues/3391
   context '#copy_price' do
     it "copies over a variant's prices" do
       line_item.price = nil
@@ -103,7 +103,7 @@ describe Spree::LineItem, :type => :model do
     end
   end
 
-  # Test for #3481
+  # Test for https://github.com/spree/spree/issues/3481
   context '#copy_tax_category' do
     it "copies over a variant's tax category" do
       line_item.tax_category = nil

--- a/core/spec/models/spree/order/callbacks_spec.rb
+++ b/core/spec/models/spree/order/callbacks_spec.rb
@@ -8,7 +8,7 @@ describe Spree::Order, :type => :model do
 
   context "validations" do
     context "email validation" do
-      # Regression test for #1238
+      # Regression test for https://github.com/spree/spree/issues/1238
       it "o'brien@gmail.com is a valid email address" do
         order.state = 'address'
         order.email = "o'brien@gmail.com"

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -417,7 +417,7 @@ describe Spree::Order, :type => :model do
         end
       end
 
-      # Regression test for #2028
+      # Regression test for https://github.com/spree/spree/issues/2028
       context "when payment is not required" do
         before do
           allow(order).to receive_messages :payment_required? => false
@@ -675,7 +675,7 @@ describe Spree::Order, :type => :model do
     end
   end
 
-  # Regression test for #3665
+  # Regression test for https://github.com/spree/spree/issues/3665
   context "with only a complete step" do
     let!(:line_item){ create :line_item, order: order }
 

--- a/core/spec/models/spree/order/state_machine_spec.rb
+++ b/core/spec/models/spree/order/state_machine_spec.rb
@@ -198,7 +198,7 @@ describe Spree::Order, :type => :model do
   end
 
 
-  # Another regression test for #729
+  # Another regression test for https://github.com/spree/spree/issues/729
   context "#resume" do
     before do
       allow(order).to receive_messages email: "user@spreecommerce.com"

--- a/core/spec/models/spree/order/validations_spec.rb
+++ b/core/spec/models/spree/order/validations_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 module Spree
   describe Spree::Order, :type => :model do
     context "validations" do
-      # Regression test for #2214
+      # Regression test for https://github.com/spree/spree/issues/2214
       it "does not return two error messages when email is blank" do
         order = Spree::Order.new
         allow(order).to receive_messages(:require_email => true)

--- a/core/spec/models/spree/order_merger_spec.rb
+++ b/core/spec/models/spree/order_merger_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-# Regression tests for #2179
+# Regression tests for https://github.com/spree/spree/issues/2179
 module Spree
   describe OrderMerger, type: :model do
     let(:variant) { create(:variant) }

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -414,7 +414,7 @@ describe Spree::Order, :type => :model do
     end
   end
 
-  # Regression tests for #4072
+  # Regression tests for https://github.com/spree/spree/issues/4072
   context "#state_changed" do
     let(:order) { FactoryGirl.create(:order) }
 
@@ -436,7 +436,7 @@ describe Spree::Order, :type => :model do
     end
   end
 
-  # Regression test for #4199
+  # Regression test for https://github.com/spree/spree/issues/4199
   context "#available_payment_methods" do
     it "includes frontend payment methods" do
       payment_method = Spree::PaymentMethod.create!({
@@ -750,7 +750,7 @@ describe Spree::Order, :type => :model do
     end
   end
 
-  # Regression test for #4923
+  # Regression test for https://github.com/spree/spree/issues/4923
   context "locking" do
     let(:order) { Spree::Order.create } # need a persisted in order to test locking
 

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -214,7 +214,7 @@ describe Spree::Payment, :type => :model do
         expect(payment.state).to eq('invalid')
       end
 
-      # Regression test for #4598
+      # Regression test for https://github.com/spree/spree/issues/4598
       it "should allow payments with a gateway_customer_profile_id" do
         allow(payment.source).to receive_messages :gateway_customer_profile_id => "customer_1"
         expect(payment.payment_method).to receive(:supports?).with(payment.source).and_return(false)
@@ -222,7 +222,7 @@ describe Spree::Payment, :type => :model do
         payment.process!
       end
 
-      # Another regression test for #4598
+      # Another regression test for https://github.com/spree/spree/issues/4598
       it "should allow payments with a gateway_payment_profile_id" do
         allow(payment.source).to receive_messages :gateway_payment_profile_id => "customer_1"
         expect(payment.payment_method).to receive(:supports?).with(payment.source).and_return(false)
@@ -471,7 +471,7 @@ describe Spree::Payment, :type => :model do
         end
       end
 
-      # Regression test for #2119
+      # Regression test for https://github.com/spree/spree/issues/2119
       context "when payment is completed" do
         before do
           payment.state = 'completed'
@@ -558,7 +558,7 @@ describe Spree::Payment, :type => :model do
         end
       end
 
-      # Regression test for #2119
+      # Regression test for https://github.com/spree/spree/issues/2119
       context "if payment is already voided" do
         before do
           payment.state = 'void'
@@ -607,7 +607,7 @@ describe Spree::Payment, :type => :model do
   end
 
   describe "#credit_allowed" do
-    # Regression test for #4403 & #4407
+    # Regression test for https://github.com/spree/spree/issues/4403 & https://github.com/spree/spree/issues/4407
     it "is the difference between offsets total and payment amount" do
       payment.amount = 100
       allow(payment).to receive(:offsets_total).and_return(0)
@@ -890,7 +890,7 @@ describe Spree::Payment, :type => :model do
     end
   end
 
-  # Regression test for #2216
+  # Regression test for https://github.com/spree/spree/issues/2216
   describe "#gateway_options" do
     before { allow(order).to receive_messages(:last_ip_address => "192.168.1.1") }
 
@@ -908,7 +908,7 @@ describe Spree::Payment, :type => :model do
   end
 
   describe "#set_unique_identifier" do
-    # Regression test for #1998
+    # Regression test for https://github.com/spree/spree/issues/1998
     it "sets a unique identifier on create" do
       payment.run_callbacks(:create)
       expect(payment.number).not_to be_blank
@@ -916,7 +916,7 @@ describe Spree::Payment, :type => :model do
       expect(payment.number).to be_a(String)
     end
 
-    # Regression test for #3733
+    # Regression test for https://github.com/spree/spree/issues/3733
     it "does not regenerate the identifier on re-save" do
       payment.save!
       old_number = payment.number
@@ -1122,8 +1122,8 @@ describe Spree::Payment, :type => :model do
     end
   end
 
-  # Regression test for #4072 (kinda)
-  # The need for this was discovered in the research for #4072
+  # Regression test for https://github.com/spree/spree/issues/4072 (kinda)
+  # The need for this was discovered in the research for https://github.com/spree/spree/issues/4072
   context "state changes" do
     it "are logged to the database" do
       expect(payment.state_changes).to be_empty

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -607,7 +607,7 @@ describe Spree::Payment, :type => :model do
   end
 
   describe "#credit_allowed" do
-    # Regression test for https://github.com/spree/spree/issues/4403 & https://github.com/spree/spree/issues/4407
+    # Regression test for https://github.com/spree/spree/issues/4403 and https://github.com/spree/spree/issues/4407
     it "is the difference between offsets total and payment amount" do
       payment.amount = 100
       allow(payment).to receive(:offsets_total).and_return(0)

--- a/core/spec/models/spree/product_filter_spec.rb
+++ b/core/spec/models/spree/product_filter_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'spree/core/product_filters'
 
 describe 'product filters', :type => :model do
-  # Regression test for #1709
+  # Regression test for https://github.com/spree/spree/issues/1709
   context 'finds products filtered by brand' do
     let(:product) { create(:product) }
     before do

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -103,7 +103,7 @@ describe Spree::Product, :type => :model do
     end
 
     context "#price" do
-      # Regression test for #1173
+      # Regression test for https://github.com/spree/spree/issues/1173
       it 'strips non-price characters' do
         product.price = "$10"
         expect(product.price).to eq(10.0)
@@ -236,7 +236,7 @@ describe Spree::Product, :type => :model do
       end
     end
 
-    # Regression test for #3737
+    # Regression test for https://github.com/spree/spree/issues/3737
     context "has stock items" do
       let(:product) { create(:product) }
       it "can retrieve stock items" do
@@ -328,7 +328,7 @@ describe Spree::Product, :type => :model do
       }.to change { product.properties.length }.by(1)
     end
 
-    # Regression test for #2455
+    # Regression test for https://github.com/spree/spree/issues/2455
     it "should not overwrite properties' presentation names" do
       Spree::Property.where(:name => 'foo').first_or_create!(:presentation => "Foo's Presentation Name")
       product.set_property('foo', 'value1')
@@ -337,7 +337,7 @@ describe Spree::Product, :type => :model do
       expect(Spree::Property.where(:name => 'bar').first.presentation).to eq("bar")
     end
 
-    # Regression test for #4416
+    # Regression test for https://github.com/spree/spree/issues/4416
     context "#possible_promotions" do
       let!(:promotion) do
         create(:promotion, advertise: true, starts_at: 1.day.ago)
@@ -450,7 +450,7 @@ describe Spree::Product, :type => :model do
     end
   end
 
-  # Regression tests for #2352
+  # Regression tests for https://github.com/spree/spree/issues/2352
   context "classifications and taxons" do
     it "is joined through classifications" do
       reflection = Spree::Product.reflect_on_association(:taxons)

--- a/core/spec/models/spree/promotion/actions/create_adjustment_spec.rb
+++ b/core/spec/models/spree/promotion/actions/create_adjustment_spec.rb
@@ -14,7 +14,7 @@ describe Spree::Promotion::Actions::CreateAdjustment, :type => :model do
       allow(action).to receive_messages(:promotion => promotion)
     end
 
-    # Regression test for #3966
+    # Regression test for https://github.com/spree/spree/issues/3966
     it "does not apply an adjustment if the amount is 0" do
       action.calculator.preferred_amount = 0
       action.perform(payload)

--- a/core/spec/models/spree/promotion/actions/create_item_adjustments_spec.rb
+++ b/core/spec/models/spree/promotion/actions/create_item_adjustments_spec.rb
@@ -16,7 +16,7 @@ module Spree
         end
 
         context "#perform" do
-          # Regression test for #3966
+          # Regression test for https://github.com/spree/spree/issues/3966
           context "when calculator computes 0" do
             before do
               allow(action).to receive_messages :compute_amount => 0

--- a/core/spec/models/spree/promotion/rules/user_spec.rb
+++ b/core/spec/models/spree/promotion/rules/user_spec.rb
@@ -27,7 +27,7 @@ describe Spree::Promotion::Rules::User, :type => :model do
       expect(rule).not_to be_eligible(order)
     end
 
-    # Regression test for #3885
+    # Regression test for https://github.com/spree/spree/issues/3885
     it "can assign to user_ids" do
       user1 = Spree::LegacyUser.create!(:email => "test1@example.com")
       user2 = Spree::LegacyUser.create!(:email => "test2@example.com")

--- a/core/spec/models/spree/promotion_handler/coupon_spec.rb
+++ b/core/spec/models/spree/promotion_handler/coupon_spec.rb
@@ -111,7 +111,7 @@ module Spree
               end
             end
 
-            # Regression test for #4211
+            # Regression test for https://github.com/spree/spree/issues/4211
             context "with incorrect coupon code casing" do
               before { allow(order).to receive_messages :coupon_code => "10OFF" }
               it "successfully activates promo" do
@@ -140,7 +140,7 @@ module Spree
               order.contents.add create(:variant)
             end
 
-            # regression spec for #4515
+            # regression spec for https://github.com/spree/spree/issues/4515
             it "successfully activates promo" do
               subject.apply
               expect(subject).to be_successful

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -399,7 +399,7 @@ describe Spree::Promotion, :type => :model do
       expect(promotion.usage_count).to eq(0)
     end
 
-    # Regression test for #4112
+    # Regression test for https://github.com/spree/spree/issues/4112
     it "does not count ineligible adjustments" do
       adjustment.update_column(:eligible, false)
       expect(promotion.usage_count).to eq(0)
@@ -688,7 +688,7 @@ describe Spree::Promotion, :type => :model do
     end
   end
 
-  # regression for #4059
+  # regression for https://github.com/spree/spree/issues/4059
   # admin form posts the code and path as empty string
   describe "normalize blank values for path" do
     it "will save blank value as nil value instead" do

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -33,7 +33,7 @@ describe Spree::Shipment, :type => :model do
     end
   end
 
-  # Regression test for #4063
+  # Regression test for https://github.com/spree/spree/issues/4063
   context "number generation" do
     before do
       allow(order).to receive :update!
@@ -314,7 +314,7 @@ describe Spree::Shipment, :type => :model do
         shipment.update!(order)
       end
 
-      # Regression test for #4347
+      # Regression test for https://github.com/spree/spree/issues/4347
       context "with adjustments" do
         before do
           shipment.adjustments << Spree::Adjustment.create(order: order, label: "Label", amount: 5)
@@ -493,7 +493,7 @@ describe Spree::Shipment, :type => :model do
   end
 
   context "#ready" do
-    # Regression test for #2040
+    # Regression test for https://github.com/spree/spree/issues/2040
     it "cannot ready a shipment for an order if the order is unpaid" do
       expect(order).to receive_messages(paid?: false)
       expect(shipment).not_to be_can_ready
@@ -633,7 +633,7 @@ describe Spree::Shipment, :type => :model do
     end
   end
 
-  # Regression test for #3349
+  # Regression test for https://github.com/spree/spree/issues/3349
   context "#destroy" do
     it "destroys linked shipping_rates" do
       reflection = Spree::Shipment.reflect_on_association(:shipping_rates)
@@ -641,8 +641,8 @@ describe Spree::Shipment, :type => :model do
     end
   end
 
-  # Regression test for #4072 (kinda)
-  # The need for this was discovered in the research for #4702
+  # Regression test for https://github.com/spree/spree/issues/4072 (kinda)
+  # The need for this was discovered in the research for https://github.com/spree/spree/issues/4702
   context "state changes" do
     before do
       # Must be stubbed so transition can succeed

--- a/core/spec/models/spree/shipping_method_spec.rb
+++ b/core/spec/models/spree/shipping_method_spec.rb
@@ -20,7 +20,7 @@ describe Spree::ShippingMethod, :type => :model do
     end
   end
 
-  # Regression test for #4492
+  # Regression test for https://github.com/spree/spree/issues/4492
   context "#shipments" do
     let!(:shipping_method) { create(:shipping_method) }
     let!(:shipment) do
@@ -77,7 +77,7 @@ describe Spree::ShippingMethod, :type => :model do
     end
   end
 
-  # Regression test for #4320
+  # Regression test for https://github.com/spree/spree/issues/4320
   context "soft deletion" do
     let(:shipping_method) { create(:shipping_method) }
     it "soft-deletes when destroy is called" do

--- a/core/spec/models/spree/shipping_rate_spec.rb
+++ b/core/spec/models/spree/shipping_rate_spec.rb
@@ -97,7 +97,7 @@ describe Spree::ShippingRate, :type => :model do
     end
   end
 
-  # Regression test for #3829
+  # Regression test for https://github.com/spree/spree/issues/3829
   context "#shipping_method" do
     it "can be retrieved" do
       expect(shipping_rate.shipping_method.reload).to eq(shipping_method)

--- a/core/spec/models/spree/stock/estimator_spec.rb
+++ b/core/spec/models/spree/stock/estimator_spec.rb
@@ -117,7 +117,7 @@ module Spree
             expect(subject.shipping_rates(package).map(&:shipping_method_id)).to eq([generic_method.id])
           end
 
-          # regression for #3287
+          # regression for https://github.com/spree/spree/issues/3287
           it "doesn't select backend rates even if they're more affordable" do
             expect(subject.shipping_rates(package).map(&:selected)).to eq [true]
           end

--- a/core/spec/models/spree/stock/package_spec.rb
+++ b/core/spec/models/spree/stock/package_spec.rb
@@ -47,7 +47,7 @@ module Spree
         expect(item.quantity).to eq 1
       end
 
-      # Contains regression test for #2804
+      # Contains regression test for https://github.com/spree/spree/issues/2804
       it 'builds a list of shipping methods common to all categories' do
         category1 = create(:shipping_category)
         category2 = create(:shipping_category)

--- a/core/spec/models/spree/stock_item_spec.rb
+++ b/core/spec/models/spree/stock_item_spec.rb
@@ -77,7 +77,7 @@ describe Spree::StockItem, :type => :model do
         subject.update_column(:count_on_hand, -2)
       end
 
-      # Regression test for #3755
+      # Regression test for https://github.com/spree/spree/issues/3755
       it "processes existing backorders, even with negative stock" do
         expect(inventory_unit).to receive(:fill_backorder)
         expect(inventory_unit_2).not_to receive(:fill_backorder)
@@ -85,7 +85,7 @@ describe Spree::StockItem, :type => :model do
         expect(subject.count_on_hand).to eq(-1)
       end
 
-      # Test for #3755
+      # Test for https://github.com/spree/spree/issues/3755
       it "does not process backorders when stock is adjusted negatively" do
         expect(inventory_unit).not_to receive(:fill_backorder)
         expect(inventory_unit_2).not_to receive(:fill_backorder)
@@ -262,7 +262,7 @@ describe Spree::StockItem, :type => :model do
     end
   end
 
-  # Regression test for #4651
+  # Regression test for https://github.com/spree/spree/issues/4651
   context "variant" do
     it "can be found even if the variant is deleted" do
       subject.variant.destroy

--- a/core/spec/models/spree/taxon_spec.rb
+++ b/core/spec/models/spree/taxon_spec.rb
@@ -44,7 +44,7 @@ describe Spree::Taxon, :type => :model do
         expect(taxon.permalink).to eql "brands/wo"
       end
 
-      # Regression test for #3390
+      # Regression test for https://github.com/spree/spree/issues/3390
       context "setting a new node sibling position via :child_index=" do
         let(:idx) { rand(0..100) }
         before { allow(parent).to receive(:move_to_child_with_index) }
@@ -63,7 +63,7 @@ describe Spree::Taxon, :type => :model do
     end
   end
 
-  # Regression test for #2620
+  # Regression test for https://github.com/spree/spree/issues/2620
   context "creating a child node using first_or_create" do
     let(:taxonomy) { create(:taxonomy) }
 

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -255,7 +255,7 @@ describe Spree::Variant, :type => :model do
     end
   end
 
-  # Regression test for #2432
+  # Regression test for https://github.com/spree/spree/issues/2432
   describe 'options_text' do
     let!(:variant) { create(:variant, option_values: []) }
     let!(:master) { create(:master_variant) }
@@ -350,7 +350,7 @@ describe Spree::Variant, :type => :model do
 
   end
 
-  # Regression test for #2744
+  # Regression test for https://github.com/spree/spree/issues/2744
   describe "set_position" do
     it "sets variant position after creation" do
       variant = create(:variant)

--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -80,7 +80,7 @@ module Spree
           end
         end
 
-        # Fix for #4117
+        # Fix for https://github.com/spree/spree/issues/4117
         # If confirmation of payment fails, redirect back to payment screen
         if params[:state] == "confirm" && @order.payment_required? && @order.payments.valid.empty?
           flash.keep

--- a/frontend/app/controllers/spree/orders_controller.rb
+++ b/frontend/app/controllers/spree/orders_controller.rb
@@ -45,7 +45,7 @@ module Spree
       variant  = Spree::Variant.find(params[:variant_id])
       quantity = params[:quantity].to_i
 
-      # 2,147,483,647 is crazy. See issue #2695.
+      # 2,147,483,647 is crazy. See issue https://github.com/spree/spree/issues/2695.
       if quantity.between?(1, 2_147_483_647)
         begin
           order.contents.add(variant, quantity)

--- a/frontend/spec/controllers/controller_helpers_spec.rb
+++ b/frontend/spec/controllers/controller_helpers_spec.rb
@@ -16,7 +16,7 @@ describe Spree::ProductsController, :type => :controller do
     I18n.enforce_available_locales = true
   end
 
-  # Regression test for #1184
+  # Regression test for https://github.com/spree/spree/issues/1184
   it "sets the default locale based off Spree::Frontend::Config[:locale]" do
     expect(I18n.locale).to eq(:en)
     spree_get :index

--- a/frontend/spec/controllers/spree/checkout_controller_spec.rb
+++ b/frontend/spec/controllers/spree/checkout_controller_spec.rb
@@ -41,7 +41,7 @@ describe Spree::CheckoutController, :type => :controller do
       expect(response).to redirect_to(spree.cart_path)
     end
 
-    # Regression test for #2280
+    # Regression test for https://github.com/spree/spree/issues/2280
     it "should redirect to current step trying to access a future step" do
       order.update_column(:state, "address")
       spree_get :edit, { :state => "delivery" }
@@ -228,7 +228,7 @@ describe Spree::CheckoutController, :type => :controller do
           order.payments.reload
         end
 
-        # This inadvertently is a regression test for #2694
+        # This inadvertently is a regression test for https://github.com/spree/spree/issues/2694
         it "should redirect to the order view" do
           spree_post :update, {:state => "confirm"}
           expect(response).to redirect_to spree.order_path(order)

--- a/frontend/spec/controllers/spree/checkout_controller_with_views_spec.rb
+++ b/frontend/spec/controllers/spree/checkout_controller_with_views_spec.rb
@@ -12,7 +12,7 @@ describe Spree::CheckoutController, type: :controller do
     allow(controller).to receive_messages try_spree_current_user: user
   end
 
-  # Regression test for #3246
+  # Regression test for https://github.com/spree/spree/issues/3246
   context "when using GBP" do
     before do
       Spree::Config[:currency] = "GBP"

--- a/frontend/spec/controllers/spree/orders_controller_spec.rb
+++ b/frontend/spec/controllers/spree/orders_controller_spec.rb
@@ -100,7 +100,7 @@ describe Spree::OrdersController, :type => :controller do
       end
     end
 
-    # Regression test for #2750
+    # Regression test for https://github.com/spree/spree/issues/2750
     context "#update" do
       before do
         allow(user).to receive :last_incomplete_spree_order

--- a/frontend/spec/controllers/spree/orders_controller_transitions_spec.rb
+++ b/frontend/spec/controllers/spree/orders_controller_transitions_spec.rb
@@ -6,7 +6,7 @@ end
 
 module Spree
   describe OrdersController, :type => :controller do
-    # Regression test for #2004
+    # Regression test for https://github.com/spree/spree/issues/2004
     context "with a transition callback on first state" do
       let(:order) { Spree::Order.new }
 

--- a/frontend/spec/controllers/spree/products_controller_spec.rb
+++ b/frontend/spec/controllers/spree/products_controller_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Spree::ProductsController, :type => :controller do
   let!(:product) { create(:product, :available_on => 1.year.from_now) }
 
-  # Regression test for #1390
+  # Regression test for https://github.com/spree/spree/issues/1390
   it "allows admins to view non-active products" do
     allow(controller).to receive_messages :spree_current_user => mock_model(Spree.user_class, :has_spree_role? => true, :last_incomplete_spree_order => nil, :spree_api_key => 'fake')
     spree_get :show, :id => product.to_param
@@ -23,7 +23,7 @@ describe Spree::ProductsController, :type => :controller do
     expect(response.status).to eq(200)
   end
 
-  # Regression test for #2249
+  # Regression test for https://github.com/spree/spree/issues/2249
   it "doesn't error when given an invalid referer" do
     current_user = mock_model(Spree.user_class, :has_spree_role? => true, :last_incomplete_spree_order => nil, :generate_spree_api_key! => nil)
     allow(controller).to receive_messages :spree_current_user => current_user

--- a/frontend/spec/features/cart_spec.rb
+++ b/frontend/spec/features/cart_spec.rb
@@ -21,7 +21,7 @@ describe "Cart", type: :feature, inaccessible: true do
     expect(page).to have_selector('button#update-button[disabled]')
   end
 
-  # Regression test for #2006
+  # Regression test for https://github.com/spree/spree/issues/2006
   it "does not error out with a 404 when GET'ing to /orders/populate" do
     visit '/orders/populate'
     within(".error") do
@@ -59,7 +59,7 @@ describe "Cart", type: :feature, inaccessible: true do
     end
   end
 
-  # regression for #2276
+  # regression for https://github.com/spree/spree/issues/2276
   context "product contains variants but no option values" do
     let(:variant) { create(:variant) }
     let(:product) { variant.product }

--- a/frontend/spec/features/checkout_spec.rb
+++ b/frontend/spec/features/checkout_spec.rb
@@ -26,7 +26,7 @@ describe "Checkout", type: :feature, inaccessible: true do
       end
     end
 
-    # Regression test for #4079
+    # Regression test for https://github.com/spree/spree/issues/4079
     context "persists state when on address page" do
       before do
         add_mug_to_cart
@@ -39,7 +39,7 @@ describe "Checkout", type: :feature, inaccessible: true do
       end
     end
 
-    # Regression test for #1596
+    # Regression test for https://github.com/spree/spree/issues/1596
     context "full checkout" do
       before do
         shipping_method.calculator.update!(preferred_amount: 10)
@@ -61,7 +61,7 @@ describe "Checkout", type: :feature, inaccessible: true do
       end
     end
 
-    # Regression test for #4306
+    # Regression test for https://github.com/spree/spree/issues/4306
     context "free shipping" do
       before do
         add_mug_to_cart
@@ -76,7 +76,7 @@ describe "Checkout", type: :feature, inaccessible: true do
     end
   end
 
-  # Regression test for #2694 and #4117
+  # Regression test for https://github.com/spree/spree/issues/2694 and https://github.com/spree/spree/issues/4117
   context "doesn't allow bad credit card numbers" do
     before(:each) do
       order = OrderWalkthrough.up_to(:delivery)
@@ -229,7 +229,7 @@ describe "Checkout", type: :feature, inaccessible: true do
     end
   end
 
-  # regression for #2921
+  # regression for https://github.com/spree/spree/issues/2921
   context "goes back from payment to add another item", js: true do
     let!(:store) { FactoryGirl.create(:store) }
     let!(:bag) { create(:product, :name => "RoR Bag") }

--- a/frontend/spec/features/currency_spec.rb
+++ b/frontend/spec/features/currency_spec.rb
@@ -5,7 +5,7 @@ describe "Switching currencies in backend", :type => :feature do
     create(:base_product, :name => "RoR Mug")
   end
 
-  # Regression test for #2340
+  # Regression test for https://github.com/spree/spree/issues/2340
   it "does not cause current_order to become nil", inaccessible: true do
     visit spree.root_path
     click_link "RoR Mug"

--- a/frontend/spec/features/free_shipping_promotions_spec.rb
+++ b/frontend/spec/features/free_shipping_promotions_spec.rb
@@ -48,7 +48,7 @@ describe "Free shipping promotions", :type => :feature, :js => true do
       click_button "Save and Continue"
     end
 
-    # Regression test for #4428
+    # Regression test for https://github.com/spree/spree/issues/4428
     it "applies the free shipping promotion" do
       within("#checkout-summary") do
         expect(page).to have_content("Shipping total:  $10.00")

--- a/frontend/spec/features/order_spec.rb
+++ b/frontend/spec/features/order_spec.rb
@@ -15,7 +15,7 @@ describe 'orders', :type => :feature do
   end
 
   it "should display line item price" do
-    # Regression test for #2772
+    # Regression test for https://github.com/spree/spree/issues/2772
     line_item = order.line_items.first
     line_item.target_shipment = create(:shipment)
     line_item.price = 19.00
@@ -45,7 +45,7 @@ describe 'orders', :type => :feature do
     end
   end
 
-  # Regression test for #2282
+  # Regression test for https://github.com/spree/spree/issues/2282
   context "can support a credit card with blank information" do
     before do
       credit_card = create(:credit_card)

--- a/frontend/spec/features/products_spec.rb
+++ b/frontend/spec/features/products_spec.rb
@@ -74,7 +74,7 @@ describe "Visiting Products", type: :feature, inaccessible: true do
       product.tap(&:save)
     end
 
-    # Regression tests for #2737
+    # Regression tests for https://github.com/spree/spree/issues/2737
     context "uses руб as the currency symbol" do
       it "on products page" do
         visit spree.root_path

--- a/frontend/spec/features/taxons_spec.rb
+++ b/frontend/spec/features/taxons_spec.rb
@@ -14,7 +14,7 @@ describe "viewing products", type: :feature, inaccessible: true do
     ((first_store = Spree::Store.first) && first_store.name).to_s
   end
 
-  # Regression test for #1796
+  # Regression test for https://github.com/spree/spree/issues/1796
   it "can see a taxon's products, even if that taxon has child taxons" do
     visit '/t/category/super-clothing/t-shirts'
     expect(page).to have_content("Superman T-Shirt")
@@ -45,7 +45,7 @@ describe "viewing products", type: :feature, inaccessible: true do
       expect(page).to have_title('Category - T-Shirts - ' + store_name)
     end
 
-    # Regression test for #2814
+    # Regression test for https://github.com/spree/spree/issues/2814
     it "doesn't use meta_title as heading on page" do
       t_shirts.update_attributes metas
       visit '/t/category/super-clothing/t-shirts'

--- a/frontend/spec/helpers/base_helper_spec.rb
+++ b/frontend/spec/helpers/base_helper_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 module Spree
   describe BaseHelper, :type => :helper do
-    # Regression test for #2759
+    # Regression test for https://github.com/spree/spree/issues/2759
     it "nested_taxons_path works with a Taxon object" do
       taxon = create(:taxon, :name => "iphone")
       expect(spree.nested_taxons_path(taxon)).to eq("/t/iphone")

--- a/frontend/spec/views/spree/checkout/_summary_spec.rb
+++ b/frontend/spec/views/spree/checkout/_summary_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe "spree/checkout/_summary.html.erb", :type => :view do
-  # Regression spec for #4223
+  # Regression spec for https://github.com/spree/spree/issues/4223
   it "does not use the @order instance variable" do
     order = stub_model(Spree::Order)
     render :partial => "spree/checkout/summary", :locals => {:order => order}


### PR DESCRIPTION
We need to differentiate spree issues from solidus issues in our comments.

I quick informal poll in our slack showed a preference for using direct URLs `https://github.com/spree/spree/issues/123` rather than `spree/spree#123`. I agree that this is more convenient and helpful for providing context.

Initial conversion done using:

```shell
git ls-files | \
  xargs sed -i'' \
  -e '/^\s*#.*#[0-9]\{3,4\}/s/#\([0-9]\{3,4\}\)/https:\/\/github.com\/spree\/spree\/issues\/\1/g'
```