### PR TITLE
Fix TaxRate.match under ruby 2.3

### DIFF
--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -51,10 +51,17 @@ module Spree
       # This little bit of code at the end stops the Spanish refund from appearing.
       #
       # For further discussion, see #4397 and #4327.
-      rates.delete_if do |rate|
-        rate.included_in_price? &&
-        (rates - [rate]).map(&:tax_category).include?(rate.tax_category)
+
+      remaining_rates = rates.dup
+      rates.each do |rate|
+        if rate.included_in_price?
+          if remaining_rates.any?{|r| r != rate && r.tax_category == rate.tax_category }
+            remaining_rates.delete(rate)
+          end
+        end
       end
+
+      remaining_rates
     end
 
     # Pre-tax amounts must be stored so that we can calculate


### PR DESCRIPTION
The behaviour of delete_if has changed in ruby 2.3. Previously, in ruby 2.2, it would delete the items from the `Array` immediately. Now, in ruby 2.3, the items are removed after iterating over all the items.

This replaces the `#delete_if` loop from TaxRate.match with more explicit behaviour with a more explicit `#each` loop. This works in all versions of ruby we support and makes the behaviour of that method more clear.

See https://bugs.ruby-lang.org/issues/10714

This might be made obsolete by @mamhoff's work improving the tax system, but I think it's important to see what the existing behaviour was. I would also like to backport this change to our 1.0.x and 1.1.x branches.

This fixes spec runs under ruby 2.3