### PR TITLE
Fix use of `contains?` in tax_rate.rb

### DIFF
--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -145,12 +145,10 @@ module Spree
     #
     # Those rates should never come into play at all and only the French rates should apply.
     def potentially_applicable?(order_tax_zone)
-      # If the rate's zone matches the order's tax zone, then it's applicable.
-      self.zone == order_tax_zone ||
       # If the rate's zone *contains* the order's tax zone, then it's applicable.
       self.zone.contains?(order_tax_zone) ||
-      # 1) The rate's zone is the default zone, then it's always applicable.
-      (self.included_in_price? && self.zone.default_tax)
+      # The rate is a VAT and its zone contains the default zone, then it's applicable.
+      (self.included_in_price? && self.zone.contains?(Spree::Zone.default_tax))
     end
 
     # Creates necessary tax adjustments for the order.
@@ -188,8 +186,7 @@ module Spree
     end
 
     def default_zone_or_zone_match?(order_tax_zone)
-      default_tax = Zone.default_tax
-      (default_tax && default_tax.contains?(order_tax_zone)) || order_tax_zone == self.zone
+      Zone.default_tax.try!(:contains?, order_tax_zone) || self.zone.contains?(order_tax_zone)
     end
 
     private

--- a/core/app/models/spree/zone.rb
+++ b/core/app/models/spree/zone.rb
@@ -111,6 +111,7 @@ module Spree
     # Indicates whether the specified zone falls entirely within the zone performing
     # the check.
     def contains?(target)
+      return true if self == target
       return false if kind == 'state' && target.kind == 'country'
       return false if zone_members.empty? || target.zone_members.empty?
 

--- a/core/spec/models/spree/zone_spec.rb
+++ b/core/spec/models/spree/zone_spec.rb
@@ -137,6 +137,16 @@ describe Spree::Zone, :type => :model do
       @target = create(:zone, name: 'target', zone_members: [])
     end
 
+    it "should contain itself" do
+      expect(@source.contains?(@source)).to be true
+    end
+
+    context "when both source and target have no members" do
+      it "should be false" do
+        expect(@source.contains?(@target)).to be false
+      end
+    end
+
     context "when the target has no members" do
       before { @source.members.create(zoneable: country1) }
 

--- a/core/spec/models/spree/zone_spec.rb
+++ b/core/spec/models/spree/zone_spec.rb
@@ -155,7 +155,6 @@ describe Spree::Zone, :type => :model do
 
     context "when both zones are the same zone" do
       before do
-        @source.members.create(zoneable: country1)
         @target = @source
       end
 


### PR DESCRIPTION
Previously, when checking a tax rate's applicability for an order, we would do two checks: Is it the same zone? If not: Does the tax rate's zone contain the other zone? Since a zone will always contain itself, I added an early return in `Zone#contains?` for that case, and unified the applicability checks in `TaxRate`. 

This should ease mergeability of #650 (once this is in, #650 will really only be specs).