### PR TITLE
Avoid downloading google fonts in feature specs

### DIFF
--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -72,6 +72,7 @@ RSpec.configure do |config|
     reset_spree_preferences
     WebMock.disable!
     if RSpec.current_example.metadata[:js]
+      page.driver.browser.url_blacklist = ['http://fonts.googleapis.com']
       DatabaseCleaner.strategy = :truncation
     else
       DatabaseCleaner.strategy = :transaction

--- a/frontend/spec/spec_helper.rb
+++ b/frontend/spec/spec_helper.rb
@@ -90,6 +90,7 @@ RSpec.configure do |config|
     reset_spree_preferences
     WebMock.disable!
     if RSpec.current_example.metadata[:js]
+      page.driver.browser.url_blacklist = ['http://fonts.googleapis.com']
       DatabaseCleaner.strategy = :truncation
     else
       DatabaseCleaner.strategy = :transaction


### PR DESCRIPTION
Should make specs slightly faster and remove the need for network access.

Tests speeds weren't perceivably faster after this change.