### PR TITLE
Add missing add_taxon translation

### DIFF
--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -419,6 +419,7 @@ en:
     add_state: Add State
     add_stock: Add Stock
     add_stock_management: Add Stock Management
+    add_taxon: Add taxon
     add_to_cart: Add To Cart
     add_to_stock_location: Add to location
     add_variant: Add Variant


### PR DESCRIPTION
This key was used by #569, but the translation key was missed.