### PR TITLE
Remove all remaining references to JSTree

### DIFF
--- a/api/app/controllers/spree/api/taxonomies_controller.rb
+++ b/api/app/controllers/spree/api/taxonomies_controller.rb
@@ -10,11 +10,6 @@ module Spree
         respond_with(taxonomy)
       end
 
-      # Because JSTree wants parameters in a *slightly* different format
-      def jstree
-        show
-      end
-
       def create
         authorize! :create, Taxonomy
         @taxonomy = Taxonomy.new(taxonomy_params)

--- a/api/app/controllers/spree/api/taxons_controller.rb
+++ b/api/app/controllers/spree/api/taxons_controller.rb
@@ -21,10 +21,6 @@ module Spree
         respond_with(@taxon)
       end
 
-      def jstree
-        show
-      end
-
       def create
         authorize! :create, Taxon
         @taxon = Spree::Taxon.new(taxon_params)

--- a/api/app/views/spree/api/taxonomies/jstree.rabl
+++ b/api/app/views/spree/api/taxonomies/jstree.rabl
@@ -1,8 +1,0 @@
-object false
-node(:data) { @taxonomy.root.name }
-node(:attr) do
-  { :id => @taxonomy.root.id,
-    :name => @taxonomy.root.name
-  }
-end
-node(:state) { "closed" }

--- a/api/app/views/spree/api/taxons/jstree.rabl
+++ b/api/app/views/spree/api/taxons/jstree.rabl
@@ -1,8 +1,0 @@
-collection @taxon.children, :object_root => false
-node(:data) { |taxon| taxon.name }
-node(:attr) do |taxon|
-  { :id => taxon.id,
-    :name => taxon.name
-  }
-end
-node(:state) { "closed" }

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -91,14 +91,7 @@ Spree::Core::Engine.add_routes do
     resources :states, only: [:index, :show]
 
     resources :taxonomies do
-      member do
-        get :jstree
-      end
-      resources :taxons do
-        member do
-          get :jstree
-        end
-      end
+      resources :taxons
     end
 
     resources :taxons, only: [:index]

--- a/api/spec/controllers/spree/api/taxonomies_controller_spec.rb
+++ b/api/spec/controllers/spree/api/taxonomies_controller_spec.rb
@@ -59,13 +59,6 @@ module Spree
         expect(children.first.key?('taxons')).to be true
       end
 
-      it "gets the jstree-friendly version of a taxonomy" do
-        api_get :jstree, :id => taxonomy.id
-        expect(json_response["data"]).to eq(taxonomy.root.name)
-        expect(json_response["attr"]).to eq({ "id" => taxonomy.root.id, "name" => taxonomy.root.name})
-        expect(json_response["state"]).to eq("closed")
-      end
-
       it "can learn how to create a new taxonomy" do
         api_get :new
         expect(json_response["attributes"]).to eq(attributes.map(&:to_s))

--- a/api/spec/controllers/spree/api/taxons_controller_spec.rb
+++ b/api/spec/controllers/spree/api/taxons_controller_spec.rb
@@ -92,14 +92,6 @@ module Spree
         expect(json_response['taxons'].count).to eq 1
       end
 
-      it "gets all taxons in JSTree form" do
-        api_get :jstree, :taxonomy_id => taxonomy.id, :id => taxon.id
-        response = json_response.first
-        expect(response["data"]).to eq(taxon2.name)
-        expect(response["attr"]).to eq({ "name" => taxon2.name, "id" => taxon2.id})
-        expect(response["state"]).to eq("closed")
-      end
-
       it "can learn how to create a new taxon" do
         api_get :new, :taxonomy_id => taxonomy.id
         expect(json_response["attributes"]).to eq(attributes.map(&:to_s))


### PR DESCRIPTION
This commit continues the cleanup that was accomplished when we moved from JSTree to jQuery UI Sortable in this PR: https://github.com/solidusio/solidus/pull/569

Closes https://github.com/solidusio/solidus/issues/194