### PR TITLE
Fix duplicate new_property id on page

### DIFF
--- a/backend/app/views/spree/admin/properties/index.html.erb
+++ b/backend/app/views/spree/admin/properties/index.html.erb
@@ -5,7 +5,7 @@
 <% content_for :page_actions do %>
   <% if can?(:create, Spree::Property) %>
     <li id="new_property_link">
-      <%= button_link_to Spree.t(:new_property), new_admin_property_url, { :remote => true, :icon => 'plus', 'data-update' => 'new_property', :id => 'new_property_link' } %>
+      <%= button_link_to Spree.t(:new_property), new_admin_property_url, { :remote => true, :icon => 'plus', 'data-update' => 'new_property_container', :id => 'new_property_link' } %>
     </li>
   <% end %>
 <% end %>
@@ -39,7 +39,7 @@
   </div>
 <% end %>
 
-<div id="new_property"></div>
+<div id="new_property_container"></div>
 
 <% if @properties.any? %>
 <table class="index" id='listing_properties' data-hook>

--- a/backend/app/views/spree/admin/properties/new.js.erb
+++ b/backend/app/views/spree/admin/properties/new.js.erb
@@ -1,2 +1,2 @@
-$("#new_property").html('<%= escape_javascript(render :template => "spree/admin/properties/new", :formats => [:html], :handlers => [:erb]) %>');
+$("#new_property_container").html('<%= escape_javascript(render :template => "spree/admin/properties/new", :formats => [:html], :handlers => [:erb]) %>');
 $("#new_property_link").parent().hide();


### PR DESCRIPTION
We were using a div with `id=new_property` to inject the new property form onto the page. However that form itself also had an id of `new_property` (having two elements of the same id is invalid).

This fixes a spurious failure in
`spec/features/admin/products/properties_spec.rb`

See this failure in travis CI here: https://travis-ci.org/jhawthorn/solidus/jobs/100939754