### PR TITLE
Remove unnecessary require

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -1,5 +1,3 @@
-require 'ostruct'
-
 module Spree
   class Shipment < Spree::Base
     belongs_to :order, class_name: 'Spree::Order', touch: true, inverse_of: :shipments


### PR DESCRIPTION
Shipment no longer uses `OpenStruct`, so this is unnecessary.