### PR TITLE
Perform bundle install at top level on CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -8,6 +8,7 @@ machine:
     version: 2.1.5
 dependencies:
   override:
+    - bundle check || bundle install
     - ./build-ci.rb install
 test:
   override:


### PR DESCRIPTION
This should shave about a minute off of our CircleCI builds!

This performs a bundle install at the top level as well as a bundle install in the individual project. Because our 5 different projects depend on different gems this meant that our bundle cache might not be complete depending on which container it saved cache from. This should allow CircleCI to properly cache all the necessary dependencies instead of having to install missing ones.

Before:
![](http://i.hawth.ca/s/6YEqcLVR.png)

After:
![](http://i.hawth.ca/s/GswKHT3x.png)