### PR TITLE
update price maximum value validation

### DIFF
--- a/core/app/models/spree/price.rb
+++ b/core/app/models/spree/price.rb
@@ -1,11 +1,17 @@
 module Spree
   class Price < Spree::Base
     acts_as_paranoid
+
+    MAXIMUM_AMOUNT = BigDecimal('99_999_999.99')
+
     belongs_to :variant, -> { with_deleted }, class_name: 'Spree::Variant', touch: true
 
     validate :check_price
-    validates :amount, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
-    validate :validate_amount_maximum
+    validates :amount, allow_nil: true, numericality: {
+      greater_than_or_equal_to: 0,
+      less_than_or_equal_to: MAXIMUM_AMOUNT
+    }
+
     after_save :set_default_price
 
     extend DisplayMoney
@@ -35,16 +41,6 @@ module Spree
 
     def check_price
       self.currency ||= Spree::Config[:currency]
-    end
-
-    def maximum_amount
-      BigDecimal '999999.99'
-    end
-
-    def validate_amount_maximum
-      if amount && amount > maximum_amount
-        errors.add :amount, I18n.t('errors.messages.less_than_or_equal_to', count: maximum_amount)
-      end
     end
 
     def set_default_price

--- a/core/spec/models/spree/price_spec.rb
+++ b/core/spec/models/spree/price_spec.rb
@@ -22,20 +22,20 @@ describe Spree::Price, :type => :model do
       end
     end
 
-    context 'when the amount is greater than 999,999.99' do
-      let(:amount) { 1_000_000 }
+    context 'when the amount is greater than maximum amount' do
+      let(:amount) { Spree::Price::MAXIMUM_AMOUNT + 1 }
 
       it 'has 1 error_on' do
         expect(subject.error_on(:amount).size).to eq(1)
       end
       it 'populates errors' do
         subject.valid?
-        expect(subject.errors.messages[:amount].first).to eq 'must be less than or equal to 999999.99'
+        expect(subject.errors.messages[:amount].first).to eq "must be less than or equal to #{Spree::Price::MAXIMUM_AMOUNT}"
       end
     end
 
-    context 'when the amount is between 0 and 999,999.99' do
-      let(:amount) { 100 }
+    context 'when the amount is between 0 and the maximum amount' do
+      let(:amount) { Spree::Price::MAXIMUM_AMOUNT }
       it { is_expected.to be_valid }
     end
   end


### PR DESCRIPTION
validation was not in sync with actual database field precision.
moved the private method to a constant