### PR TITLE
[RFC] Allow zero dollar order adjustments

### DIFF
--- a/core/app/models/spree/promotion/actions/create_adjustment.rb
+++ b/core/app/models/spree/promotion/actions/create_adjustment.rb
@@ -22,7 +22,6 @@ module Spree
           return if promotion_credit_exists?(order)
 
           amount = compute_amount(order)
-          return if amount == 0
           Spree::Adjustment.create!(
             amount: amount,
             order: order,

--- a/core/spec/models/spree/promotion/actions/create_adjustment_spec.rb
+++ b/core/spec/models/spree/promotion/actions/create_adjustment_spec.rb
@@ -14,12 +14,10 @@ describe Spree::Promotion::Actions::CreateAdjustment, :type => :model do
       allow(action).to receive_messages(:promotion => promotion)
     end
 
-    # Regression test for https://github.com/spree/spree/issues/3966
-    it "does not apply an adjustment if the amount is 0" do
+    it "does apply an adjustment if the amount is 0" do
       action.calculator.preferred_amount = 0
       action.perform(payload)
-      expect(promotion.usage_count).to eq(0)
-      expect(order.adjustments.count).to eq(0)
+      expect(order.adjustments.count).to eq(1)
     end
 
     it "should create a discount with correct negative amount" do

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -740,6 +740,11 @@ describe Spree::Promotion, :type => :model do
 
       context 'when the order is not complete' do
         let(:order) { create :order, user: user }
+
+        # The before clause above sets the completed at
+        # value for this order
+        before { order.update completed_at: nil }
+
         it { is_expected.to be false }
       end
     end


### PR DESCRIPTION
Sometimes the current value of a promotion is zero dollars, however with the return check here the Spree::OrderPromotion will not be created and so the promotion can never be applied in the future by order.update!

This check was added in spree/spree@17c59ec as an aesthetic change which should not affect promotion logic this deep into the modeling.

A more appropriate place that change would have been a view override of some kind. As mentioned by @jormon here:

spree/spree#3966 (comment)