### PR TITLE
Fix circleci caching

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -8,7 +8,7 @@ machine:
     version: 2.1.5
 dependencies:
   override:
-    - bundle check || bundle install
+    - bundle check --path=vendor/bundle || bundle install --path=vendor/bundle
     - ./build-ci.rb install
 test:
   override:


### PR DESCRIPTION
In the previous PR #672, I messed up. I needed to specify the path for the top level bundle install to match that used by the build-ci script.

In my initial testing, I verified that this worked when the bundle install was done from the build-ci.rb script, and didn't properly verify when I moved that out to circle.yml.

Oops. :disappointed: 

As proof that this actually works now for sure see the timing of this build https://circleci.com/gh/jhawthorn/solidus/497