### PR TITLE
Simplify `Spree::TaxRate#compute_amount`

### DIFF
--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -173,13 +173,9 @@ module Spree
 
     # This method is used by Adjustment#update to recalculate the cost.
     def compute_amount(item)
-      if included_in_price
-        if default_zone_or_zone_match?(item.order.tax_zone)
-          calculator.compute(item)
-        else
-          # In this case, it's a refund.
-          calculator.compute(item) * - 1
-        end
+      if included_in_price && !default_zone_or_zone_match?(item.order.tax_zone)
+        # In this case, it's a refund.
+        calculator.compute(item) * - 1
       else
         calculator.compute(item)
       end


### PR DESCRIPTION
The current taxation system does this strange trick when refunding
VAT: When there should be a refund because the order's tax zone
is outside the default vat zone, the computed amount is turned negative.

This commit makes this behaviour a little bit clearer.