### PR TITLE
Remove have_title matcher

### DIFF
--- a/core/lib/spree/testing_support/capybara_ext.rb
+++ b/core/lib/spree/testing_support/capybara_ext.rb
@@ -133,21 +133,6 @@ RSpec::Matchers.define :have_meta do |name, expected|
   end
 end
 
-RSpec::Matchers.define :have_title do |expected|
-  match do |actual|
-    has_css?("title", text: expected, visible: false)
-  end
-
-  failure_message do |actual|
-    actual = first("title")
-    if actual
-      "expected that title would have been '#{expected}' but was '#{actual.text}'"
-    else
-      "expected that title would exist with '#{expected}'"
-    end
-  end
-end
-
 RSpec.configure do |c|
   c.include CapybaraExt
 end


### PR DESCRIPTION
This matcher already exists in capybara as of 2.1