### PR TITLE
country_factory: Build attributes using carmen

### DIFF
--- a/core/lib/spree/testing_support/factories/country_factory.rb
+++ b/core/lib/spree/testing_support/factories/country_factory.rb
@@ -1,9 +1,19 @@
+require 'carmen'
+
 FactoryGirl.define do
   factory :country, class: Spree::Country do
-    iso_name 'UNITED STATES'
-    name 'United States of America'
     iso 'US'
-    iso3 'USA'
-    numcode 840
+
+    transient do
+      carmen_country { Carmen::Country.coded(iso) || fail("Unknown country iso code: #{iso.inspect}") }
+    end
+
+    iso_name { carmen_country.name.upcase }
+    name { carmen_country.name }
+    iso3 { carmen_country.alpha_3_code }
+    numcode { carmen_country.numeric_code }
+
+    # FIXME: We should set states required, but it causes failing tests
+    # states_required { carmen_country.subregions? }
   end
 end

--- a/core/spec/models/spree/address_spec.rb
+++ b/core/spec/models/spree/address_spec.rb
@@ -187,7 +187,7 @@ describe Spree::Address, :type => :model do
   context '.factory' do
     context 'with attributes that use setters defined in Address' do
       let(:address_attributes) { attributes_for(:address, country_id: nil, country_iso: country.iso) }
-      let(:country) { create(:country, iso: 'ZZ') }
+      let(:country) { create(:country, iso: 'ZW') }
 
       it 'uses the setters' do
         expect(subject.factory(address_attributes).country_id).to eq(country.id)
@@ -312,7 +312,7 @@ describe Spree::Address, :type => :model do
 
   context '#country_iso=' do
     let(:address) { build(:address, :country_id => nil) }
-    let(:country) { create(:country, iso: 'ZZ') }
+    let(:country) { create(:country, iso: 'ZW') }
 
     it 'sets the country to the country with the matching iso code' do
       address.country_iso = country.iso

--- a/frontend/spec/features/address_spec.rb
+++ b/frontend/spec/features/address_spec.rb
@@ -20,7 +20,7 @@ describe "Address", type: :feature, inaccessible: true do
 
   context "country requires state", :js => true, :focus => true do
     let!(:canada) { create(:country, :name => "Canada", :states_required => true, :iso => "CA") }
-    let!(:uk) { create(:country, :name => "United Kingdom", :states_required => true, :iso => "UK") }
+    let!(:uk) { create(:country, :name => "United Kingdom", :states_required => true, :iso => "GB") }
 
     before { Spree::Config[:default_country_id] = uk.id }
 


### PR DESCRIPTION
Previously we would always build countries which were basically the USA, but had whatever attributes were specified different. This PR changes the country factory to build attributes based on an ISO code provided.

This fixes [a spurious failure](https://circleci.com/gh/jhawthorn/solidus/521) where the state factory was finding a country with `numcode: 840` and causing address to fail zip code validation :bomb: 