### PR TITLE
Fix rake test_app at top level

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -20,10 +20,10 @@ end
 
 desc "Generates a dummy app for testing for every Spree engine"
 task :test_app do
-  %w(api backend core frontend sample).each do |engine|
-    ENV['LIB_NAME'] = File.join('spree', engine)
-    ENV['DUMMY_PATH'] = File.expand_path("../#{engine}/spec/dummy", __FILE__)
-    Rake::Task['common:test_app'].execute
+  %w(api backend core frontend sample).each do |gem_name|
+    Dir.chdir("#{File.dirname(__FILE__)}/#{gem_name}") do
+      sh 'rake test_app'
+    end
   end
 end
 


### PR DESCRIPTION
As of ba2fb4bc108fda51a944455da5c60807845ef007 we check if the various engines are defined when building the initializer. This means that running rake test_app at the top level now builds the initializers incorrectly as all of those are defined at the top level.

Without this we get:
```
$ rake test_app
...
$ cd core
$ rspec
/home/jhawthorn/src/solidus/core/spec/dummy/config/initializers/spree.rb:55:in `<top (required)>': uninitialized constant Spree::Backend (NameError)
        from /home/jhawthorn/src/solidus/vendor/bundle/ruby/2.3.0/gems/railties-4.2.5/lib/rails/engine.rb:652:in `block in load_config_initializer'
        from /home/jhawthorn/src/solidus/vendor/bundle/ruby/2.3.0/gems/activesupport-4.2.5/lib/active_support/notifications.rb:166:in `instrument'
        from /home/jhawthorn/src/solidus/vendor/bundle/ruby/2.3.0/gems/railties-4.2.5/lib/rails/engine.rb:651:in `load_config_initializer'
        from /home/jhawthorn/src/solidus/vendor/bundle/ruby/2.3.0/gems/railties-4.2.5/lib/rails/engine.rb:616:in `block (2 levels) in <class:Engine>'
```

This fixes that issue by running rake test_app per-subdirectory.