### PR TITLE
Remove stubbing from state_machine_spec.rb

### DIFF
--- a/core/lib/spree/testing_support/factories/credit_card_factory.rb
+++ b/core/lib/spree/testing_support/factories/credit_card_factory.rb
@@ -7,5 +7,9 @@ FactoryGirl.define do
     name 'Spree Commerce'
     association(:payment_method, factory: :credit_card_payment_method)
     association(:address)
+
+    trait :failing do
+      number "0000000000000000"
+    end
   end
 end

--- a/core/lib/spree/testing_support/factories/payment_factory.rb
+++ b/core/lib/spree/testing_support/factories/payment_factory.rb
@@ -11,6 +11,11 @@ FactoryGirl.define do
     state 'checkout'
     response_code '12345'
 
+    trait :failing do
+      response_code '00000'
+      association(:source, :failing, {factory: :credit_card})
+    end
+
     factory :payment_with_refund do
       transient do
         refund_amount 5

--- a/core/spec/models/spree/order/state_machine_spec.rb
+++ b/core/spec/models/spree/order/state_machine_spec.rb
@@ -1,171 +1,97 @@
 require 'spec_helper'
 
 describe Spree::Order, :type => :model do
-  let(:order) { Spree::Order.new }
-  before do
-    # Ensure state machine has been re-defined correctly
-    Spree::Order.define_state_machine!
-    # We don't care about this validation here
-    allow(order).to receive(:require_email)
-  end
+  let(:order) { create(:order_with_line_items) }
 
   context "#next!" do
     context "when current state is confirm" do
       before do
         order.state = "confirm"
-        order.run_callbacks(:create)
-        allow(order).to receive_messages :payment_required? => true
-        allow(order).to receive_messages :process_payments! => true
-        allow(order).to receive_messages :ensure_available_shipping_rates => true
+        order.save!
       end
 
       context "when payment processing succeeds" do
-        before do
-          order.payments << FactoryGirl.create(:payment, state: 'checkout', order: order)
-          allow(order).to receive_messages process_payments: true
+        let!(:payment) do
+          create(:payment, state: 'checkout', order: order)
         end
 
         it "should finalize order when transitioning to complete state" do
-          expect(order).to receive(:finalize!)
           order.complete!
+          expect(order).to be_complete
+          expect(order).to be_completed
         end
 
         context "when credit card processing fails" do
-          before { allow(order).to receive_messages :process_payments! => false }
+          let!(:payment) do
+            create(:payment, :failing, state: 'checkout', order: order)
+          end
 
           it "should not complete the order" do
-             order.next
-             expect(order.state).to eq("confirm")
-           end
-        end
-      end
-
-      context "when payment processing fails" do
-        before { allow(order).to receive_messages :process_payments! => false }
-
-        it "cannot transition to complete" do
-         order.next
-         expect(order.state).to eq("confirm")
+            expect(order.complete).to be false
+            expect(order.state).to eq("confirm")
+          end
         end
       end
     end
 
-    context "when current state is delivery" do
+    context "when current state is address" do
       before do
-        allow(order).to receive_messages :payment_required? => true
-        allow(order).to receive :apply_free_shipping_promotions
-        order.state = "delivery"
+        order.ensure_updated_shipments
+        order.next!
+        expect(order.all_adjustments).to be_empty
+        expect(order.state).to eq "address"
       end
 
       it "adjusts tax rates when transitioning to delivery" do
-        # Once for the line items
-        expect(Spree::TaxRate).to receive(:adjust).once
-        allow(order).to receive :set_shipments_cost
-        order.next!
-      end
-
-      it "adjusts tax rates twice if there are any shipments" do
-        # Once for the line items, once for the shipments
-        order.shipments.build
-        expect(Spree::TaxRate).to receive(:adjust).twice
-        allow(order).to receive :set_shipments_cost
+        expect(Spree::TaxRate).to receive(:adjust).once.with(order.tax_zone, order.line_items)
         order.next!
       end
     end
   end
 
   context "#can_cancel?" do
+    let(:order) { create(:completed_order_with_totals) }
     states = [:pending, :backorder, :ready]
 
     states.each do |shipment_state|
       it "should be true if shipment_state is #{shipment_state}" do
-        allow(order).to receive_messages :completed? => true
+        expect(order).to be_completed
         order.shipment_state = shipment_state
-        expect(order.can_cancel?).to be true
+
+        expect(order).to be_can_cancel
       end
     end
 
     (Spree::Shipment.state_machine.states.keys - states).each do |shipment_state|
       it "should be false if shipment_state is #{shipment_state}" do
-        allow(order).to receive_messages :completed? => true
+        expect(order).to be_completed
         order.shipment_state = shipment_state
-        expect(order.can_cancel?).to be false
+        expect(order).not_to be_can_cancel
       end
     end
 
   end
 
   context "#cancel" do
-    let!(:variant) { stub_model(Spree::Variant) }
-    let!(:inventory_units) { [stub_model(Spree::InventoryUnit, :variant => variant),
-                              stub_model(Spree::InventoryUnit, :variant => variant) ]}
-    let!(:shipment) do
-      shipment = stub_model(Spree::Shipment)
-      allow(shipment).to receive_messages :inventory_units => inventory_units, :order => order
-      allow(order).to receive_messages :shipments => [shipment]
-      shipment
-    end
+    let!(:order) { create(:completed_order_with_totals) }
+    let!(:shipment) { order.shipments.first }
 
-    before do
-
-      2.times do
-        create(:line_item, :order => order, price: 10)
-      end
-
-      allow(order.line_items).to receive_messages :find_by_variant_id => order.line_items.first
-
-      allow(order).to receive_messages :completed? => true
-      allow(order).to receive_messages :allow_cancel? => true
-
-      shipments = [shipment]
-      allow(order).to receive_messages :shipments => shipments
-      allow(shipments).to receive_messages :states => []
-      allow(shipments).to receive_messages :ready => []
-      allow(shipments).to receive_messages :pending => []
-      allow(shipments).to receive_messages :shipped => []
-
-      allow_any_instance_of(Spree::OrderUpdater).to receive(:update_adjustment_total) { 10 }
+    it "is setup correctly" do
+      expect(order).to be_completed
+      expect(order).to be_complete
+      expect(order).to be_allow_cancel
     end
 
     it "should send a cancel email" do
-
-      # Stub methods that cause side-effects in this test
-      allow(shipment).to receive(:cancel!)
-      allow(order).to receive :restock_items!
-      expect(Spree::OrderMailer).to receive(:cancel_email).with(order).and_return(mail_message = double)
-      expect(mail_message).to receive :deliver_later
       order.cancel!
-    end
 
-    context "restocking inventory" do
-      before do
-        allow(shipment).to receive(:ensure_correct_adjustment)
-        allow(shipment).to receive(:update_order)
-        allow(Spree::OrderMailer).to receive(:cancel_email).and_return(mail_message = double)
-        allow(mail_message).to receive :deliver_later
-
-      end
+      mail = ActionMailer::Base.deliveries.last
+      expect(mail.subject).to include "Cancellation"
     end
 
     context "resets payment state" do
 
-      let(:payment) { create(:payment, amount: order.total) }
-
-      before do
-        # TODO: This is ugly :(
-        # Stubs methods that cause unwanted side effects in this test
-        allow(Spree::OrderMailer).to receive(:cancel_email).and_return(mail_message = double)
-        allow(mail_message).to receive :deliver_later
-        allow(order).to receive :restock_items!
-        allow(shipment).to receive(:cancel!)
-        allow(payment).to receive(:cancel!)
-        allow(order).to receive_message_chain(:payments, :valid, :size).and_return(1)
-        allow(order).to receive_message_chain(:payments, :completed).and_return([payment])
-        allow(order).to receive_message_chain(:payments, :completed, :includes).and_return([payment])
-        allow(order).to receive_message_chain(:payments, :last).and_return(payment)
-        allow(order).to receive_message_chain(:payments, :store_credits, :pending).and_return([payment])
-        allow(order).to receive(:refund_total).and_return(0)
-      end
+      let!(:payment) { create(:payment, order: order, amount: order.total, state: "completed") }
 
       context "without shipped items" do
         it "should set payment state to 'void'" do
@@ -175,35 +101,20 @@ describe Spree::Order, :type => :model do
 
       context "with shipped items" do
         before do
-          allow(order).to receive_messages shipment_state: 'partial'
-          allow(order).to receive_messages outstanding_balance?: false
-          allow(order).to receive_messages payment_state: "paid"
+          order.shipments[0].ship!
         end
 
         it "should not alter the payment state" do
-          order.cancel!
+          expect(order).to_not be_allow_cancel
+          expect(order.cancel).to be false
           expect(order.payment_state).to eql "paid"
         end
       end
 
-      context "with payments" do
-        let(:payment) { create(:payment) }
-
-        it "should automatically refund all payments" do
-          expect(payment).to receive(:cancel!)
-          order.cancel!
-        end
+      it "should automatically refund all payments" do
+        expect(order).to be_allow_cancel
+        expect { order.cancel! }.to change{ payment.reload.state }.to("void")
       end
-    end
-  end
-
-
-  # Another regression test for https://github.com/spree/spree/issues/729
-  context "#resume" do
-    before do
-      allow(order).to receive_messages email: "user@spreecommerce.com"
-      allow(order).to receive_messages state: "canceled"
-      allow(order).to receive_messages allow_resume?: true
     end
   end
 end


### PR DESCRIPTION
This removes two context sections which had before blocks but no tests.

This had so much stubbing of the system under test that many of these
tests passed regardless of the behaviour of order.