### PR TITLE
customer_return factory creates more typical object

### DIFF
--- a/core/lib/spree/testing_support/factories/customer_return_factory.rb
+++ b/core/lib/spree/testing_support/factories/customer_return_factory.rb
@@ -10,13 +10,13 @@ FactoryGirl.define do
     transient do
       line_items_count 1
       return_items_count { line_items_count }
+      shipped_order { create :shipped_order, line_items_count: line_items_count }
+      return_authorization { create :return_authorization, order: shipped_order }
     end
 
     before(:create) do |customer_return, evaluator|
-      shipped_order = create(:shipped_order, line_items_count: evaluator.line_items_count)
-
-      shipped_order.inventory_units.take(evaluator.return_items_count).each do |inventory_unit|
-        customer_return.return_items << build(:return_item, inventory_unit: inventory_unit)
+      evaluator.shipped_order.inventory_units.take(evaluator.return_items_count).each do |inventory_unit|
+        customer_return.return_items << build(:return_item, inventory_unit: inventory_unit, return_authorization: evaluator.return_authorization)
       end
     end
 


### PR DESCRIPTION
An actual typical CustomerReturn is for one ReturnAuthorization and
one Order. A CustomerReturn with split ReturnAuthorizations and/or Orders is
possible in Spree (which is argubly a design mistake), but is awfully confusing,
and probably uncommon -- I don't think you can create such things with
Spree Admin.

But the pre-existing customer_return factory ends up
involving a whole bunch of ReturnAuthorizations and Orders, which
is not useful as the default factory behavior, which should be creating
a more typical object.

    # At least two different orders involved, what a mess!
    customer_return = create(:customer_return)
    customer_return.order.id # => 4
    customer_return.return_authorizations.collect {|rma| rma.order.id} # => [5]

And that's just with line_items_count == 1, if you have a greater than 1
line_item_count, you can get even more separate Orders involved, and in that
case multiple ReturnAuthorizations assoicated with the CustomerReturn too!

This patch fixes things so ONE ReturnAuthorization and ONE Order is used
when you `create(:customer_return)`.

    # Post-patch:
    customer_return = create(:customer_return, line_items_count: 5)
    # Only one Order and one ReturnAuthorization, hooray!
    customer_return.order.id # => 2
    customer_return.return_authorizations.collect {|rma| rma.order.id} #=> [2, 2, 2, 2, 2]

    customer_return.return_authorizations.collect(&:id) #=> [2, 2, 2, 2, 2]
    customer_return.return_items.collect {|ri| ri.return_authorization.id} #=> [2, 2, 2, 2, 2]

As a nice bonus, it also lets the caller specify an existing
ReturnAuthorization and/or Order as an argument to the factory too.

    create(:customer_return, shipped_order: some_order)
    create(:customer_return, return_authorization: an_rma)