### PR TITLE
Only perform UPDATE when changed in shipments #update! and #update_amounts

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -274,11 +274,15 @@ module Spree
 
     def update_amounts
       if selected_shipping_rate
-        self.update_columns(
-          cost: selected_shipping_rate.cost,
-          adjustment_total: adjustments.additional.map(&:update!).compact.sum,
-          updated_at: Time.current,
-        )
+        self.cost = selected_shipping_rate.cost
+        self.adjustment_total = adjustments.additional.map(&:update!).compact.sum
+        if changed?
+          self.update_columns(
+            cost: self.cost,
+            adjustment_total: self.adjustment_total,
+            updated_at: Time.current
+          )
+        end
       end
     end
 

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -322,11 +322,13 @@ module Spree
     def update!(order)
       old_state = state
       new_state = determine_state(order)
-      update_columns(
-        state: new_state,
-        updated_at: Time.current,
-      )
-      after_ship if new_state == 'shipped' and old_state != 'shipped'
+      if new_state != old_state
+        update_columns(
+          state: new_state,
+          updated_at: Time.current,
+        )
+        after_ship if new_state == 'shipped'
+      end
     end
 
     def transfer_to_location(variant, quantity, stock_location)


### PR DESCRIPTION
Similar to ItemAdjustments in b39fb27, we only need to perform a SQL UPDATE when there are changes to the records to be saved. This behaves more similarly to if we were using `#save` here (which isn't used to avoid callbacks).

This is a bit faster performing `order.update!` on a completed order (when there are no changes to be made)

Before:
```
Calculating -------------------------------------
order.reload.update!     3.000  i/100ms
-------------------------------------------------
order.reload.update!     42.871  (±14.0%) i/s -    213.000 
```

After:
```
Calculating -------------------------------------
order.reload.update!     5.000  i/100ms
-------------------------------------------------
order.reload.update!     59.173  (± 3.4%) i/s -    300.000 
```