### PR TITLE
allow Product#really_destroy

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -319,7 +319,8 @@ module Spree
     end
 
     def punch_slug
-      update_column :slug, "#{Time.current.to_i}_#{slug}" # punch slug with date prefix to allow reuse of original
+      # punch slug with date prefix to allow reuse of original
+      update_column :slug, "#{Time.current.to_i}_#{slug}" unless frozen?
     end
 
     # If the master is invalid, the Product object will be assigned its errors

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -332,6 +332,13 @@ describe Spree::Product, :type => :model do
         end
       end
     end
+
+    context "#really_destroy!" do
+      it "destroy the product" do
+        product.really_destroy!
+        expect(product).not_to be_persisted
+      end
+    end
   end
 
   context "properties" do


### PR DESCRIPTION
this allow the use of paranoia gem's `really_destroy!` method, instead of getting `RuntimeError: can't modify frozen Hash` or `cannot update a destroyed record`.

people probably doesn't hard-delete products so often, but that's a basic and important feature we are breaking.