### PR TITLE
hide payment info if not needed

### DIFF
--- a/frontend/app/views/spree/shared/_order_details.html.erb
+++ b/frontend/app/views/spree/shared/_order_details.html.erb
@@ -28,15 +28,16 @@
     <% end %>
   <% end %>
 
-  <div class="columns omega four">
-    <h6><%= Spree.t(:payment_information) %> <%= link_to "(#{Spree.t(:edit)})", checkout_state_path(:payment) unless order.completed? %></h6>
-    <div class="payment-info">
-      <% order.payments.valid.each do |payment| %>
-        <%= render payment %><br/>
-      <% end %>
+  <% if order.has_step?("payment") %>
+    <div class="columns omega four">
+      <h6><%= Spree.t(:payment_information) %> <%= link_to "(#{Spree.t(:edit)})", checkout_state_path(:payment) unless order.completed? %></h6>
+      <div class="payment-info">
+        <% order.payments.valid.each do |payment| %>
+          <%= render payment %><br/>
+        <% end %>
+      </div>
     </div>
-  </div>
-
+  <% end %>
 </div>
 
 <hr />


### PR DESCRIPTION
on order details, as we do for other steps
