### PR TITLE
fix product description meta tag truncate

### DIFF
--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -42,7 +42,7 @@ module Spree
       end
 
       if meta[:description].blank? && object.kind_of?(Spree::Product)
-        meta[:description] = strip_tags(truncate(object.description, length: 160, separator: ' '))
+        meta[:description] = truncate(strip_tags(object.description), length: 160, separator: ' ')
       end
 
       meta.reverse_merge!({


### PR DESCRIPTION
we must `strip_tags` _before_ `truncate`, of course