### PR TITLE
Clean up tax rate match logic

### DIFF
--- a/core/spec/models/spree/tax_rate_spec.rb
+++ b/core/spec/models/spree/tax_rate_spec.rb
@@ -360,8 +360,7 @@ describe Spree::TaxRate, :type => :model do
             expect(line_item.adjustments.tax.count).to eq(1)
           end
 
-          # This test fails intermittently - it's a matter of luck
-          xit 'has 4.79 of included tax' do
+          it 'has 4.79 of included tax' do
             expect(line_item.included_tax_total).to eq(4.79)
           end
 
@@ -382,8 +381,8 @@ describe Spree::TaxRate, :type => :model do
             expect(line_item.adjustments.tax.count).to eq(1)
           end
 
-          # Fails intermittently - xit'ed for the time being
-          xit 'has 2.02 of included tax' do
+          it 'has 2.02 of included tax' do
+            pending 'waiting for the MOSS refactoring'
             expect(line_item.included_tax_total).to eq(2.02)
           end
 


### PR DESCRIPTION
I've been complaining already in https://github.com/solidusio/solidus/pull/656 about the absolutely undecipherable bit of code there that removes some tax rates from the matching tax rates. This commit removes `Spree::TaxRate#potentially_applicable` and instead creates two arrays of rates: One for the current order's tax zone and one for the default tax zone. Then removes rates from the default tax zone rate array if they have the same tax category as any in the order tax zone rate array. 

Only at the end the two arrays are merged. 

While this is still not correct behaviour, it's at least more understandable and shows the intention of the old behaviour. It should also work with Ruby 2.3 if I understand the new `#delete_if` behaviour correctly. 

Some comments moved.