### PR TITLE
Use gross amount in return items

### DIFF
--- a/backend/app/controllers/spree/admin/return_authorizations_controller.rb
+++ b/backend/app/controllers/spree/admin/return_authorizations_controller.rb
@@ -30,7 +30,7 @@ module Spree
         unassociated_inventory_units = all_inventory_units - associated_inventory_units
 
         new_return_items = unassociated_inventory_units.map do |new_unit|
-          Spree::ReturnItem.new(inventory_unit: new_unit).tap(&:set_default_pre_tax_amount)
+          Spree::ReturnItem.new(inventory_unit: new_unit).tap(&:set_default_amount)
         end
         @form_return_items = (@return_authorization.return_items + new_return_items).sort_by(&:inventory_unit_id)
       end

--- a/backend/app/views/spree/admin/customer_returns/_return_item_decision.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/_return_item_decision.html.erb
@@ -3,7 +3,7 @@
     <tr>
       <th><%= Spree::Product.model_name.human %></th>
       <th><%= Spree::Variant.human_attribute_name(:sku) %></th>
-      <th><%= Spree::ReturnItem.human_attribute_name(:pre_tax_amount) %></th>
+      <th><%= Spree::ReturnItem.human_attribute_name(:amount) %></th>
       <th><%= Spree::ReturnItem.human_attribute_name(:preferred_reimbursement_type) %></th>
       <th><%= Spree::ReturnItem.human_attribute_name(:exchange_variant) %></th>
       <th><%= Spree::ReturnItem.human_attribute_name(:acceptance_status_errors) %></th>
@@ -27,7 +27,7 @@
           <%= return_item.inventory_unit.variant.sku %>
         </td>
         <td class="align-center">
-          <%= return_item.display_pre_tax_amount %>
+          <%= return_item.display_amount %>
         </td>
         <td class="align-center">
           <%= reimbursement_type_name(return_item.preferred_reimbursement_type) %>

--- a/backend/app/views/spree/admin/customer_returns/_return_item_selection.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/_return_item_selection.html.erb
@@ -6,7 +6,7 @@
       </th>
       <th><%= Spree::Product.model_name.human %></th>
       <th><%= Spree::Variant.human_attribute_name(:sku) %></th>
-      <th><%= Spree::ReturnItem.human_attribute_name(:pre_tax_amount) %></th>
+      <th><%= Spree::ReturnItem.human_attribute_name(:amount) %></th>
       <th><%= Spree::ReturnItem.human_attribute_name(:inventory_unit_state) %></th>
       <th><%= Spree::ReturnItem.human_attribute_name(:exchange_variant) %></th>
       <th><%= Spree::ReturnItem.human_attribute_name(:resellable) %></th>
@@ -23,9 +23,9 @@
           <div style="display:none">
             <%= item_fields.hidden_field :inventory_unit_id %>
             <%= item_fields.hidden_field :return_authorization_id %>
-            <%= item_fields.hidden_field :pre_tax_amount %>
+            <%= item_fields.hidden_field :amount %>
           </div>
-          <%= item_fields.check_box :returned, {checked: false, class: 'add-item', "data-price" => return_item.pre_tax_amount}, '1', '0' %>
+          <%= item_fields.check_box :returned, {checked: false, class: 'add-item', "data-price" => return_item.amount}, '1', '0' %>
         </td>
         <td>
           <div class="variant-name"><%= return_item.inventory_unit.variant.name %></div>
@@ -35,7 +35,7 @@
           <%= return_item.inventory_unit.variant.sku %>
         </td>
         <td class="align-center">
-          <%= return_item.display_pre_tax_amount %>
+          <%= return_item.display_amount %>
         </td>
         <td class="align-center">
           <%= return_item.inventory_unit.state %>

--- a/backend/app/views/spree/admin/reimbursements/edit.html.erb
+++ b/backend/app/views/spree/admin/reimbursements/edit.html.erb
@@ -44,7 +44,7 @@
               ) %>
             </td>
             <td class="align-center">
-              <%= item_fields.text_field :pre_tax_amount, { class: 'refund-amount-input' } %>
+              <%= item_fields.text_field :amount, { class: 'refund-amount-input' } %>
             </td>
             <td class="align-center">
               <%= return_item.display_total %>

--- a/backend/app/views/spree/admin/reimbursements/show.html.erb
+++ b/backend/app/views/spree/admin/reimbursements/show.html.erb
@@ -19,7 +19,7 @@
         <th><%= Spree.t(:preferred_reimbursement_type) %></th>
         <th><%= Spree.t(:reimbursement_type_override) %></th>
         <th><%= Spree.t(:exchange_for) %></th>
-        <th><%= Spree.t(:pre_tax_amount) %></th>
+        <th><%= Spree.t(:amount) %></th>
         <th><%= Spree.t(:total) %></th>
       </tr>
     </thead>
@@ -41,7 +41,7 @@
             <%= return_item.exchange_variant.try(:exchange_name) %>
           </td>
           <td class="align-center">
-            <%= return_item.display_pre_tax_amount %>
+            <%= return_item.display_amount %>
           </td>
           <td class="align-center">
             <%= return_item.display_total %>

--- a/backend/app/views/spree/admin/return_authorizations/_form.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/_form.html.erb
@@ -27,7 +27,7 @@
           <td class="return-item-checkbox align-center inventory-unit-checkbox">
             <% if editable %>
               <%= item_fields.hidden_field :inventory_unit_id %>
-              <%= item_fields.check_box :_destroy, {checked: return_item.persisted?, class: 'add-item', "data-price" => return_item.pre_tax_amount}, '0', '1' %>
+              <%= item_fields.check_box :_destroy, {checked: return_item.persisted?, class: 'add-item', "data-price" => return_item.amount}, '0', '1' %>
             <% end %>
           </td>
           <td class="return-item-product">
@@ -36,13 +36,13 @@
           </td>
           <td class="return-item-state align-center"><%= inventory_unit.state.humanize %></td>
           <td class="return-item-charged align-center">
-            <%= return_item.display_pre_tax_amount %>
+            <%= return_item.display_amount %>
           </td>
           <td class="return-item-pre-tax-refund-amount align-center">
             <% if editable %>
-              <%= item_fields.text_field :pre_tax_amount, { class: 'refund-amount-input' } %>
+              <%= item_fields.text_field :amount, { class: 'refund-amount-input' } %>
             <% else %>
-              <%= return_item.display_pre_tax_amount %>
+              <%= return_item.display_amount %>
             <% end %>
           </td>
           <td class="return-item-reimbursement-type">

--- a/backend/spec/controllers/spree/admin/customer_returns_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/customer_returns_controller_spec.rb
@@ -193,7 +193,7 @@ module Spree
               return_items_attributes: {
                 "0" => {
                   returned: "1",
-                  "pre_tax_amount" => "15.99",
+                  amount: "15.99",
                   inventory_unit_id: order.inventory_units.shipped.last.id,
                   reception_status_event: reception_status_event
                 }

--- a/core/app/models/spree/calculator/returns/default_refund_amount.rb
+++ b/core/app/models/spree/calculator/returns/default_refund_amount.rb
@@ -9,7 +9,7 @@ module Spree
 
       def compute(return_item)
         return 0.0.to_d if return_item.part_of_exchange?
-        weighted_order_adjustment_amount(return_item.inventory_unit) + weighted_line_item_pre_tax_amount(return_item.inventory_unit)
+        weighted_order_adjustment_amount(return_item.inventory_unit) + weighted_line_item_amount(return_item.inventory_unit)
       end
 
       private
@@ -18,18 +18,18 @@ module Spree
         inventory_unit.order.adjustments.eligible.non_tax.sum(:amount) * percentage_of_order_total(inventory_unit)
       end
 
-      def weighted_line_item_pre_tax_amount(inventory_unit)
-        inventory_unit.line_item.pre_tax_amount * percentage_of_line_item(inventory_unit)
+      def weighted_line_item_amount(inventory_unit)
+        inventory_unit.line_item.discounted_amount * percentage_of_line_item(inventory_unit)
       end
 
       def percentage_of_order_total(inventory_unit)
-        return 0.0 if inventory_unit.order.pre_tax_item_amount.zero?
-        weighted_line_item_pre_tax_amount(inventory_unit) / inventory_unit.order.pre_tax_item_amount
+        return 0.0 if inventory_unit.order.discounted_item_amount.zero?
+        weighted_line_item_amount(inventory_unit) / inventory_unit.order.discounted_item_amount
       end
 
       def percentage_of_line_item(inventory_unit)
         1 / BigDecimal.new(inventory_unit.line_item.quantity)
       end
-   end
- end
+    end
+  end
 end

--- a/core/app/models/spree/customer_return.rb
+++ b/core/app/models/spree/customer_return.rb
@@ -17,7 +17,8 @@ module Spree
 
     extend DisplayMoney
     money_methods pre_tax_total: { currency: Spree::Config[:currency] },
-                  total: { currency: Spree::Config[:currency] }
+                  total: { currency: Spree::Config[:currency] },
+                  amount: { currency: Spree::Config[:currency] }
 
     delegate :id, to: :order, prefix: true, allow_nil: true
 
@@ -26,7 +27,11 @@ module Spree
     end
 
     def pre_tax_total
-      return_items.sum(:pre_tax_amount)
+      return_items.map(&:pre_tax_amount).sum
+    end
+
+    def amount
+      return_items.sum(:amount)
     end
 
     # Temporarily tie a customer_return to one order

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -162,6 +162,11 @@ module Spree
       line_items.to_a.sum(&:pre_tax_amount)
     end
 
+    # Sum of all line item amounts after promotions, before added tax
+    def discounted_item_amount
+      line_items.to_a.sum(&:discounted_amount)
+    end
+
     def currency
       self[:currency] || Spree::Config[:currency]
     end

--- a/core/app/models/spree/reimbursement_tax_calculator.rb
+++ b/core/app/models/spree/reimbursement_tax_calculator.rb
@@ -18,7 +18,7 @@ module Spree
       private
 
       def set_tax!(return_item)
-        percent_of_tax = (return_item.pre_tax_amount <= 0) ? 0 : return_item.pre_tax_amount / Spree::ReturnItem.refund_amount_calculator.new.compute(return_item)
+        percent_of_tax = (return_item.amount <= 0) ? 0 : return_item.amount / Spree::ReturnItem.refund_amount_calculator.new.compute(return_item)
 
         additional_tax_total = percent_of_tax * return_item.inventory_unit.additional_tax_total
         included_tax_total   = percent_of_tax * return_item.inventory_unit.included_tax_total

--- a/core/app/models/spree/return_authorization.rb
+++ b/core/app/models/spree/return_authorization.rb
@@ -34,12 +34,16 @@ module Spree
     end
 
     extend DisplayMoney
-    money_methods :pre_tax_total
+    money_methods :pre_tax_total, :amount
 
     self.whitelisted_ransackable_attributes = ['memo']
 
     def pre_tax_total
-      return_items.sum(:pre_tax_amount)
+      return_items.map(&:pre_tax_amount).sum
+    end
+
+    def amount
+      return_item.sum(:amount)
     end
 
     def currency
@@ -47,7 +51,7 @@ module Spree
     end
 
     def refundable_amount
-      order.pre_tax_item_amount + order.promo_total
+      order.discounted_item_amount + order.promo_total
     end
 
     def customer_returned_items?

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -184,7 +184,7 @@ en:
         exchange_variant: Exchange for
         inventory_unit_state: State
         item_received?: "Item Received?"
-        pre_tax_amount: Pre-Tax Amount
+        pre_tax_amount: Amount before sales tax
         preferred_reimbursement_type_id: Preferred Reimbursement Type
         reception_status: Reception Status
         resellable: "Resellable?"

--- a/core/db/migrate/20151026093607_change_return_item_pre_tax_amount_to_amount.rb
+++ b/core/db/migrate/20151026093607_change_return_item_pre_tax_amount_to_amount.rb
@@ -1,0 +1,27 @@
+class ChangeReturnItemPreTaxAmountToAmount < ActiveRecord::Migration
+  def up
+    execute(<<-SQL)
+      UPDATE spree_return_items
+      SET included_tax_total = 0
+      WHERE included_tax_total IS NULL;
+
+      UPDATE spree_return_items
+      SET pre_tax_amount = pre_tax_amount + included_tax_total;
+    SQL
+
+    rename_column :spree_return_items, :pre_tax_amount, :amount
+  end
+
+  def down
+    execute(<<-SQL)
+      UPDATE spree_return_items
+      SET included_tax_total = 0
+      WHERE included_tax_total IS NULL;
+
+      UPDATE spree_return_items
+      SET amount = amount - included_tax_total;
+    SQL
+
+    rename_column :spree_return_items, :amount, :pre_tax_amount
+  end
+end

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -52,7 +52,7 @@ module Spree
       :month, :year, :expiry, :first_name, :last_name, :name
     ]
 
-    @@customer_return_attributes = [:stock_location_id, return_items_attributes: [:id, :inventory_unit_id, :return_authorization_id, :returned, :pre_tax_amount, :reception_status_event, :acceptance_status, :exchange_variant_id, :resellable]]
+    @@customer_return_attributes = [:stock_location_id, return_items_attributes: [:id, :inventory_unit_id, :return_authorization_id, :returned, :amount, :reception_status_event, :acceptance_status, :exchange_variant_id, :resellable]]
 
     @@image_attributes = [:alt, :attachment, :position, :viewable_type, :viewable_id]
 

--- a/core/spec/models/spree/customer_return_spec.rb
+++ b/core/spec/models/spree/customer_return_spec.rb
@@ -72,19 +72,19 @@ describe Spree::CustomerReturn, type: :model do
   end
 
   describe "#total" do
-    let(:pre_tax_amount) { 15.0 }
+    let(:amount) { 15.0 }
     let(:tax_amount) { 5.0 }
     let(:customer_return) { create(:customer_return, line_items_count: 2) }
 
     before do
-      Spree::ReturnItem.where(customer_return_id: customer_return.id).update_all(pre_tax_amount: pre_tax_amount, additional_tax_total: tax_amount)
+      Spree::ReturnItem.where(customer_return_id: customer_return.id).update_all(amount: amount, additional_tax_total: tax_amount)
       customer_return.reload
     end
 
     subject { customer_return.total }
 
     it "returns the sum of the return item's total amount" do
-      expect(subject).to eq((pre_tax_amount * 2) + (tax_amount * 2))
+      expect(subject).to eq((amount * 2) + (tax_amount * 2))
     end
   end
 
@@ -97,27 +97,27 @@ describe Spree::CustomerReturn, type: :model do
     end
   end
 
-  describe "#pre_tax_total" do
-    let(:pre_tax_amount)  { 15.0 }
+  describe "#amount" do
+    let(:amount) { 15.0 }
     let(:customer_return) { create(:customer_return, line_items_count: 2) }
 
     before do
-      Spree::ReturnItem.where(customer_return_id: customer_return.id).update_all(pre_tax_amount: pre_tax_amount)
+      Spree::ReturnItem.where(customer_return_id: customer_return.id).update_all(amount: amount)
     end
 
-    subject { customer_return.pre_tax_total }
+    subject { customer_return.amount }
 
-    it "returns the sum of the return item's pre_tax_amount" do
-      expect(subject).to eq(pre_tax_amount * 2)
+    it "returns the sum of the return item's amount" do
+      expect(subject).to eq(amount * 2)
     end
   end
 
-  describe "#display_pre_tax_total" do
+  describe "#display_amount" do
     let(:customer_return) { Spree::CustomerReturn.new }
 
     it "returns a Spree::Money" do
-      allow(customer_return).to receive_messages(pre_tax_total: 21.22)
-      expect(customer_return.display_pre_tax_total).to eq(Spree::Money.new(21.22))
+      allow(customer_return).to receive_messages(amount: 21.22)
+      expect(customer_return.display_amount).to eq(Spree::Money.new(21.22))
     end
   end
 

--- a/core/spec/models/spree/reimbursement_spec.rb
+++ b/core/spec/models/spree/reimbursement_spec.rb
@@ -106,8 +106,8 @@ describe Spree::Reimbursement, type: :model do
         return_item.reload
         expect(return_item.additional_tax_total).to be > 0
         expect(return_item.additional_tax_total).to eq line_item.additional_tax_total
-        expect(reimbursement.total).to eq line_item.pre_tax_amount + line_item.additional_tax_total
-        expect(Spree::Refund.last.amount).to eq line_item.pre_tax_amount + line_item.additional_tax_total
+        expect(reimbursement.total).to eq line_item.amount + line_item.additional_tax_total
+        expect(Spree::Refund.last.amount).to eq line_item.amount + line_item.additional_tax_total
       end
     end
 
@@ -192,8 +192,8 @@ describe Spree::Reimbursement, type: :model do
       subject { reimbursement.calculated_total }
 
       before do
-        reimbursement.return_items << Spree::ReturnItem.new(pre_tax_amount: 10.003)
-        reimbursement.return_items << Spree::ReturnItem.new(pre_tax_amount: 10.003)
+        reimbursement.return_items << Spree::ReturnItem.new(amount: 10.003)
+        reimbursement.return_items << Spree::ReturnItem.new(amount: 10.003)
       end
 
       it 'rounds down' do

--- a/core/spec/models/spree/reimbursement_type/original_payment_spec.rb
+++ b/core/spec/models/spree/reimbursement_type/original_payment_spec.rb
@@ -61,7 +61,7 @@ module Spree
 
         before do
           reimbursement.order.payments.first.update_attributes!(amount: 5.0)
-          return_item.update_attributes!(pre_tax_amount: refund_amount)
+          return_item.update_attributes!(amount: refund_amount)
         end
 
         it "includes refunds all payment type" do

--- a/core/spec/models/spree/return_authorization_spec.rb
+++ b/core/spec/models/spree/return_authorization_spec.rb
@@ -137,19 +137,19 @@ describe Spree::ReturnAuthorization, type: :model do
   end
 
   describe "#pre_tax_total" do
-    let(:pre_tax_amount_1) { 15.0 }
-    let!(:return_item_1) { create(:return_item, return_authorization: return_authorization, pre_tax_amount: pre_tax_amount_1) }
+    let(:amount_1) { 15.0 }
+    let!(:return_item_1) { create(:return_item, return_authorization: return_authorization, amount: amount_1) }
 
-    let(:pre_tax_amount_2) { 50.0 }
-    let!(:return_item_2) { create(:return_item, return_authorization: return_authorization, pre_tax_amount: pre_tax_amount_2) }
+    let(:amount_2) { 50.0 }
+    let!(:return_item_2) { create(:return_item, return_authorization: return_authorization, amount: amount_2) }
 
-    let(:pre_tax_amount_3) { 5.0 }
-    let!(:return_item_3) { create(:return_item, return_authorization: return_authorization, pre_tax_amount: pre_tax_amount_3) }
+    let(:amount_3) { 5.0 }
+    let!(:return_item_3) { create(:return_item, return_authorization: return_authorization, amount: amount_3) }
 
-    subject { return_authorization.pre_tax_total }
+    subject { return_authorization.reload.pre_tax_total }
 
-    it "sums it's associated return_item's pre-tax amounts" do
-      expect(subject).to eq(pre_tax_amount_1 + pre_tax_amount_2 + pre_tax_amount_3)
+    it "sums it's associated return_item's amounts" do
+      expect(subject).to eq(amount_1 + amount_2 + amount_3)
     end
   end
 
@@ -177,27 +177,27 @@ describe Spree::ReturnAuthorization, type: :model do
   end
 
   describe "#refundable_amount" do
-    let(:weighted_line_item_pre_tax_amount) { 5.0 }
-    let(:line_item_count)                   { return_authorization.order.line_items.count }
+    let(:line_item_price) { 5.0 }
+    let(:line_item_count) { return_authorization.order.line_items.count }
 
     subject { return_authorization.refundable_amount }
 
     before do
-      return_authorization.order.line_items.update_all(pre_tax_amount: weighted_line_item_pre_tax_amount)
+      return_authorization.order.line_items.update_all(price: line_item_price)
       return_authorization.order.update_attribute(:promo_total, promo_total)
     end
 
     context "no promotions" do
       let(:promo_total) { 0.0 }
       it "returns the pre-tax line item total" do
-        expect(subject).to eq(weighted_line_item_pre_tax_amount * line_item_count)
+        expect(subject).to eq(line_item_price * line_item_count)
       end
     end
 
     context "promotions" do
       let(:promo_total) { -10.0 }
       it "returns the pre-tax line item total minus the order level promotion value" do
-        expect(subject).to eq((weighted_line_item_pre_tax_amount * line_item_count) + promo_total)
+        expect(subject).to eq((line_item_price * line_item_count) + promo_total)
       end
     end
   end


### PR DESCRIPTION
I believe the notion of `pre_tax_amount` is only present in the return items because
someone from a sales tax country wanted to use something excluding sales (additional) taxes.

This leads to unfortunate behaviour in VAT stores: While every other price or amount
is entered including VAT, for returns a store admin has to enter the return amount
excluding VAT. For most normal people, that's a complex, error-prone op, and one we
shouldn't make them do.

This PR replaces the `pre_tax_amount` with one called `amount` that behaves like the `amount` on line items: including included taxes, but excluding sales taxes. 

Unfortunately, this entails a lot of naming changes.

This ports https://github.com/spree/spree/pull/6852 to Solidus. 

It's one large commit because all the naming changes affects everything :(