### PR TITLE
Fix rounding the Reimbursement total

### DIFF
--- a/core/app/models/spree/reimbursement.rb
+++ b/core/app/models/spree/reimbursement.rb
@@ -83,9 +83,9 @@ module Spree
     end
 
     def calculated_total
-      # rounding down to handle edge cases for consecutive partial returns where rounding
-      # might cause us to try to reimburse more than was originally billed
-      return_items.to_a.sum(&:total).to_d.round(2, :down)
+      # rounding every return item individually to handle edge cases for consecutive partial
+      # returns where rounding might cause us to try to reimburse more than was originally billed
+      return_items.map { |ri| ri.total.to_d.round(2) }.sum
     end
 
     def paid_amount

--- a/core/app/models/spree/reimbursement_type/credit.rb
+++ b/core/app/models/spree/reimbursement_type/credit.rb
@@ -4,7 +4,7 @@ module Spree
 
     class << self
       def reimburse(reimbursement, return_items, simulate)
-        unpaid_amount = return_items.sum(&:total).round(2, :down)
+        unpaid_amount = return_items.map { |ri| ri.total.to_d.round(2) }.sum
         reimbursement_list, unpaid_amount = create_credits(reimbursement, unpaid_amount, simulate)
         reimbursement_list
       end

--- a/core/app/models/spree/reimbursement_type/original_payment.rb
+++ b/core/app/models/spree/reimbursement_type/original_payment.rb
@@ -3,7 +3,7 @@ class Spree::ReimbursementType::OriginalPayment < Spree::ReimbursementType
 
   class << self
     def reimburse(reimbursement, return_items, simulate)
-      unpaid_amount = return_items.sum(&:total).round(2, :down)
+      unpaid_amount = return_items.map { |ri| ri.total.to_d.round(2) }.sum
       payments = reimbursement.order.payments.completed
 
       refund_list, unpaid_amount = create_refunds(reimbursement, payments, unpaid_amount, simulate)

--- a/core/spec/models/spree/reimbursement_spec.rb
+++ b/core/spec/models/spree/reimbursement_spec.rb
@@ -122,8 +122,8 @@ describe Spree::Reimbursement, type: :model do
         return_item.reload
         expect(return_item.included_tax_total).to be > 0
         expect(return_item.included_tax_total).to eq line_item.included_tax_total
-        expect(reimbursement.total).to eq (line_item.pre_tax_amount + line_item.included_tax_total).round(2, :down)
-        expect(Spree::Refund.last.amount).to eq (line_item.pre_tax_amount + line_item.included_tax_total).round(2, :down)
+        expect(reimbursement.total).to eq (line_item.pre_tax_amount + line_item.included_tax_total).round(2)
+        expect(Spree::Refund.last.amount).to eq (line_item.pre_tax_amount + line_item.included_tax_total).round(2)
       end
     end
 
@@ -188,7 +188,7 @@ describe Spree::Reimbursement, type: :model do
   end
 
   describe "#calculated_total" do
-    context 'with return item amounts that would round up' do
+    context 'with return item amounts that would round up if added' do
       let(:reimbursement) { Spree::Reimbursement.new }
 
       subject { reimbursement.calculated_total }
@@ -199,6 +199,20 @@ describe Spree::Reimbursement, type: :model do
       end
 
       it 'rounds down' do
+        expect(subject).to eq 20
+      end
+    end
+
+    context 'with a return item amount that should round up' do
+      let(:reimbursement) { Spree::Reimbursement.new }
+
+      subject { reimbursement.calculated_total }
+
+      before do
+        reimbursement.return_items << Spree::ReturnItem.new(pre_tax_amount: 19.998)
+      end
+
+      it 'rounds up' do
         expect(subject).to eq 20
       end
     end


### PR DESCRIPTION
Previously, reimbursement amounts that really should round up rounded down:
19.99999 would round to 19.99. This is unfortunate. Since every return item
should individually have a price that rounds to two digits, and rounding
individually solves the parent commit's issue, I propose
just rounding individually.

This is ported from Spree: https://github.com/spree/spree/pull/6645