### PR TITLE
remove unused TaxonomiesController#get_children action

### DIFF
--- a/backend/app/controllers/spree/admin/taxonomies_controller.rb
+++ b/backend/app/controllers/spree/admin/taxonomies_controller.rb
@@ -1,11 +1,6 @@
 module Spree
   module Admin
     class TaxonomiesController < ResourceController
-      respond_to :json, :only => [:get_children]
-
-      def get_children
-        @taxons = Taxon.find(params[:parent_id]).children
-      end
 
       private
 

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -141,9 +141,6 @@ Spree::Core::Engine.add_routes do
       collection do
         post :update_positions
       end
-      member do
-        get :get_children
-      end
       resources :taxons
     end
 


### PR DESCRIPTION
i think this is legacy stuff from the oldest admin or something like that