### PR TITLE
skip layout on admin json controller

### DIFF
--- a/backend/app/controllers/spree/admin/search_controller.rb
+++ b/backend/app/controllers/spree/admin/search_controller.rb
@@ -1,9 +1,11 @@
 module Spree
   module Admin
     class SearchController < Spree::Admin::BaseController
+      respond_to :json
+      layout false
+
       # http://spreecommerce.com/blog/2010/11/02/json-hijacking-vulnerability/
       before_action :check_json_authenticity, only: :index
-      respond_to :json
 
       # TODO: Clean this up by moving searching out to user_class_extensions
       # And then JSON building with something like Active Model Serializers


### PR DESCRIPTION
Looks like we are loading the layout on the json-only controller Admin::SearchController.
Should be ~50% faster now