### PR TITLE
add Base.base_scopes

### DIFF
--- a/core/app/models/spree/base.rb
+++ b/core/app/models/spree/base.rb
@@ -26,4 +26,8 @@ class Spree::Base < ActiveRecord::Base
   end
 
   self.abstract_class = true
+
+  def self.display_includes
+    where(nil)
+  end
 end

--- a/core/lib/spree/core/search/base.rb
+++ b/core/lib/spree/core/search/base.rb
@@ -33,7 +33,7 @@ module Spree
         protected
 
         def get_base_scope
-          base_scope = Spree::Product.active
+          base_scope = Spree::Product.display_includes.active
           base_scope = base_scope.in_taxon(taxon) unless taxon.blank?
           base_scope = get_products_conditions_for(base_scope, keywords)
           base_scope = add_search_scopes(base_scope)

--- a/frontend/app/controllers/spree/products_controller.rb
+++ b/frontend/app/controllers/spree/products_controller.rb
@@ -15,7 +15,10 @@ module Spree
     end
 
     def show
-      @variants = @product.variants_including_master.active(current_currency).includes([:option_values, :images])
+      @variants = @product.variants_including_master.
+                           display_includes.
+                           active(current_currency).
+                           includes([:option_values, :images])
       @product_properties = @product.product_properties.includes(:property)
       @taxon = Spree::Taxon.find(params[:taxon_id]) if params[:taxon_id]
     end


### PR DESCRIPTION
This has no impact on base Solidus apps but it's useful for extensions that need to add some important "default scopes".
Those default scopes are not automagically applied everywhere as in `default_scope`, which is bad and problematic.
Instead, we can manually add them on main queries and encourage their use (added a few here).

The main use case is `solidus_globalize` that will do this:

```ruby
module Translatable
  class_methods do
    def self.base_scopes
      super.includes(:translations).references(:translations)
    end
  end
end
```

and finally fix the N+1 queries problem in a pretty clean way.