### PR TITLE
Pre-rubocop cleanup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-eval(File.read(File.dirname(__FILE__) + '/common_spree_dependencies.rb'))
+eval_gemfile File.expand_path('../common_spree_dependencies.rb', __FILE__)
 
 gemspec

--- a/api/Gemfile
+++ b/api/Gemfile
@@ -1,4 +1,4 @@
-eval(File.read(File.dirname(__FILE__) + '/../common_spree_dependencies.rb'))
+eval_gemfile File.expand_path('../../common_spree_dependencies.rb', __FILE__)
 
 gem 'solidus_core', :path => '../core'
 

--- a/api/spec/models/spree/legacy_user_spec.rb
+++ b/api/spec/models/spree/legacy_user_spec.rb
@@ -47,7 +47,7 @@ module Spree
         end
 
         context "roles_for_auto_api_key is defined" do
-          let (:role) { create(:role, name: 'hobbit') }
+          let(:role) { create(:role, name: 'hobbit') }
           let(:undesired_role) { create(:role, name: "foo") }
 
           before {
@@ -60,9 +60,9 @@ module Spree
         end
 
         context "for all roles" do
-          let (:role) { create(:role, name: 'hobbit') }
-          let (:other_role) { create(:role, name: 'wizard') }
-          let (:other_user) { create(:user) }
+          let(:role) { create(:role, name: 'hobbit') }
+          let(:other_role) { create(:role, name: 'wizard') }
+          let(:other_user) { create(:user) }
 
           before {
             user.clear_spree_api_key!

--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -1,4 +1,4 @@
-eval(File.read(File.dirname(__FILE__) + '/../common_spree_dependencies.rb'))
+eval_gemfile File.expand_path('../../common_spree_dependencies.rb', __FILE__)
 
 gem 'solidus_core', :path => '../core'
 gem 'solidus_api', :path => '../api'

--- a/core/Gemfile
+++ b/core/Gemfile
@@ -1,3 +1,3 @@
-eval(File.read(File.dirname(__FILE__) + '/../common_spree_dependencies.rb'))
+eval_gemfile File.expand_path('../../common_spree_dependencies.rb', __FILE__)
 
 gemspec

--- a/core/app/models/spree/calculator/flat_rate.rb
+++ b/core/app/models/spree/calculator/flat_rate.rb
@@ -9,8 +9,8 @@ module Spree
       Spree.t(:flat_rate_per_order)
     end
 
-    def compute(object=nil)
-      if object && preferred_currency.upcase == object.currency.upcase
+    def compute(object = nil)
+      if object && preferred_currency.casecmp(object.currency).zero?
         preferred_amount
       else
         0

--- a/core/spec/models/spree/app_configuration_spec.rb
+++ b/core/spec/models/spree/app_configuration_spec.rb
@@ -1,8 +1,7 @@
 require 'spec_helper'
 
 describe Spree::AppConfiguration, :type => :model do
-
-  let (:prefs) { Rails.application.config.spree.preferences }
+  let(:prefs) { Rails.application.config.spree.preferences }
 
   it "should be available from the environment" do
     prefs.layout = "my/layout"

--- a/core/spec/models/spree/credit_card_spec.rb
+++ b/core/spec/models/spree/credit_card_spec.rb
@@ -117,10 +117,17 @@ describe Spree::CreditCard, type: :model do
     end
 
     let!(:persisted_card) { Spree::CreditCard.find(credit_card.id) }
-    let (:valid_address_attributes) { {firstname: "Hugo", lastname: "Furst",
-                                       address1: "123 Main", city: "Somewhere",
-                                       country_id: 1, zipcode: 55555,
-                                       phone: "1234567890"} }
+    let(:valid_address_attributes) do
+      {
+        firstname: "Hugo",
+        lastname: "Furst",
+        address1: "123 Main",
+        city: "Somewhere",
+        country_id: 1,
+        zipcode: 55_555,
+        phone: "1234567890"
+      }
+    end
 
     it "should not actually store the number" do
       expect(persisted_card.number).to be_blank

--- a/frontend/Gemfile
+++ b/frontend/Gemfile
@@ -1,4 +1,4 @@
-eval(File.read(File.dirname(__FILE__) + '/../common_spree_dependencies.rb'))
+eval_gemfile File.expand_path('../../common_spree_dependencies.rb', __FILE__)
 
 gem 'solidus_core', :path => '../core'
 gem 'solidus_api', :path => '../api'

--- a/frontend/spec/controllers/controller_extension_spec.rb
+++ b/frontend/spec/controllers/controller_extension_spec.rb
@@ -51,7 +51,7 @@ describe Spree::CustomController, :type => :controller do
           it "has value success" do
             spree_get :index
             expect(response).to be_success
-            assert (response.body =~ /success!!!/)
+            expect(response.body).to match(/success!!!/)
           end
         end
       end
@@ -68,7 +68,7 @@ describe Spree::CustomController, :type => :controller do
           it "has value success" do
             spree_get :index
             expect(response).to be_success
-            assert (response.body =~ /success!!!/)
+            expect(response.body).to match(/success!!!/)
           end
         end
       end
@@ -102,7 +102,7 @@ describe Spree::CustomController, :type => :controller do
           it "has value success" do
             spree_post :create
             expect(response).to be_success
-            assert (response.body =~ /success!/)
+            expect(response.body).to match(/success!/)
           end
         end
       end
@@ -117,7 +117,7 @@ describe Spree::CustomController, :type => :controller do
         describe "POST" do
           it "should not effect the wrong controller" do
             spree_get :index
-            assert (response.body =~ /neutral/)
+            expect(response.body).to match(/neutral/)
           end
         end
       end

--- a/sample/Gemfile
+++ b/sample/Gemfile
@@ -1,4 +1,4 @@
-eval(File.read(File.dirname(__FILE__) + '/../common_spree_dependencies.rb'))
+eval_gemfile File.expand_path('../../common_spree_dependencies.rb', __FILE__)
 
 gem 'solidus_core', :path => '../core'
 


### PR DESCRIPTION
A couple pieces of cleanup extracted from work on #709. These fixes that rubocop warned about, or caused rubocop's parser to barf.

I think these are better to review separately from the main rubocop PR since they were done manually.

Changes:
* Use `eval_gemfile` instead of `eval` in our Gemfiles
* Change `let (:var) { :value }` to `let(:var) { :value }`
* Use `expect` instead of `assert`
* Don't use `||=` on the constants of `BackendConfiguration` (which I believe to be unnecessary)
* Use casecmp instead of `a.upcase == b.upcase`