### PR TITLE
Allow newer versions of mysql2 gem

### DIFF
--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -4,9 +4,7 @@
 source 'https://rubygems.org'
 
 platforms :ruby do
-  # Version restriction because AR will not use mysql2 0.4.0
-  # This can be removed when a future version of rails is released
-  gem 'mysql2', '~> 0.3.20'
+  gem 'mysql2'
   gem 'pg'
   gem 'sqlite3'
   gem 'fast_sqlite'

--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'paperclip', '~> 4.2.0'
   s.add_dependency 'paranoia', '~> 2.1.4'
   s.add_dependency 'premailer-rails'
-  s.add_dependency 'rails', '~> 4.2.0'
+  s.add_dependency 'rails', '~> 4.2.5'
   s.add_dependency 'ransack', '~> 1.6.0'
   s.add_dependency 'responders'
   s.add_dependency 'state_machines-activerecord', '~> 0.2'


### PR DESCRIPTION
See PR #359. The previous issued was fixed in Rails 4.2.5:
https://github.com/rails/rails/commit/2dfff4d31634d669f4c198c4fb85b59d39477862
which was released on 2015-11-12.