### PR TITLE
Removes devise initializer from dummy generator

### DIFF
--- a/core/lib/generators/spree/dummy/dummy_generator.rb
+++ b/core/lib/generators/spree/dummy/dummy_generator.rb
@@ -48,7 +48,6 @@ module Spree
       template "rails/test.rb", "#{dummy_path}/config/environments/test.rb", :force => true
       template "rails/script/rails", "#{dummy_path}/spec/dummy/script/rails", :force => true
       template "initializers/custom_user.rb", "#{dummy_path}/config/initializers/custom_user.rb", :force => true
-      template "initializers/devise.rb", "#{dummy_path}/config/initializers/devise.rb", :force => true
     end
 
     def test_dummy_inject_extension_requirements

--- a/core/lib/generators/spree/dummy/templates/initializers/devise.rb
+++ b/core/lib/generators/spree/dummy/templates/initializers/devise.rb
@@ -1,3 +1,0 @@
-if Object.const_defined?("Devise")
-  Devise.secret_key = "<%= SecureRandom.hex(50) %>"
-end


### PR DESCRIPTION
The dummy app generator adds a devise initializer that's disabled in most of the time.

The official solidus_auth_devise gem has it's own devise initializer, that never gets generated in the dummy app, because the generator skips existing devise initializers (what's good, to prevent overwriting in the real host app).

I don't know if this will have any impact on other existing extension, but IMO it shouldn't unless they depend on devise itself.