### PR TITLE
Add carriers and service levels to shipping methods.

### DIFF
--- a/backend/app/views/spree/admin/shipping_methods/_form.html.erb
+++ b/backend/app/views/spree/admin/shipping_methods/_form.html.erb
@@ -33,6 +33,24 @@
     </div>
   </div>
 
+  <div class="alpha omega twelve columns">
+    <div class="alpha six columns">
+      <%= f.field_container :carrier do %>
+        <%= f.label :carrier %><br />
+        <%= f.text_field :carrier, :class => 'fullwidth', :label => false  %>
+        <%= error_message_on :shipping_method, :carrier %>
+      <% end %>
+    </div>
+
+    <div class="omega six columns">
+      <%= f.field_container :service_level do %>
+        <%= f.label :service_level %><br />
+        <%= f.text_field :service_level, :class => 'fullwidth', :label => false  %>
+        <%= error_message_on :shipping_method, :service_level %>
+      <% end %>
+    </div>
+  </div>
+
   <div data-hook="admin_shipping_method_form_tracking_url_field" class="alpha twelve columns">
     <%= f.field_container :tracking_url do %>
       <%= f.label :tracking_url, Spree.t(:tracking_url) %><br />

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -105,6 +105,9 @@ en:
         amount: Amount
       spree/role:
         name: Name
+      spree/shipping_method:
+        carrier: Carrier
+        service_level: Service Level
       spree/state:
         abbr: Abbreviation
         name: Name

--- a/core/db/migrate/20160122182105_add_carrier_and_service_level_to_spree_shipping_methods.rb
+++ b/core/db/migrate/20160122182105_add_carrier_and_service_level_to_spree_shipping_methods.rb
@@ -1,0 +1,6 @@
+class AddCarrierAndServiceLevelToSpreeShippingMethods < ActiveRecord::Migration
+  def change
+    add_column :spree_shipping_methods, :carrier, :string
+    add_column :spree_shipping_methods, :service_level, :string
+  end
+end

--- a/core/lib/spree/testing_support/factories/shipping_method_factory.rb
+++ b/core/lib/spree/testing_support/factories/shipping_method_factory.rb
@@ -16,6 +16,8 @@ FactoryGirl.define do
 
     name 'UPS Ground'
     code 'UPS_GROUND'
+    carrier 'UPS'
+    service_level '1DAYGROUND'
 
     calculator { |s| s.association(:shipping_calculator, strategy: :build, preferred_amount: s.cost) }
 


### PR DESCRIPTION
When we're dealing with a shipping method, we have no formal way of
adding additional information that would be useful for fulfilment
purposes.

We can add an "internal" name to the shipping method, but that would
require pattern matching to get any useful information from. Often, in
most fulfilment scenarios, we have a desire to know _exactly_ what
carrier and service level a specific shipping method is representative
of.

Given a shipment I can then infer that it should be shipped with UPS one
day shipping by introspecting on the methods' carrier and service_level
columns as necessary.

This is optional as it stands, but validations can be added in stores as
required for complex fulfilment scenarios.

cc @forkata, @cbrunsdon, @athal7 

![Interface changes](http://i.imgur.com/50iUjfD.png)