### PR TITLE
enhance configuration to persist changes

### DIFF
--- a/core/app/models/spree/preferences/preferable_class_methods.rb
+++ b/core/app/models/spree/preferences/preferable_class_methods.rb
@@ -31,6 +31,7 @@ module Spree::Preferences
       define_method preference_setter_method(name) do |value|
         value = convert_preference_value(value, type)
         preferences[name] = value
+        db_preferences[name] = value if respond_to?(:db_preferences)
 
         # If this is an activerecord object, we need to inform
         # ActiveRecord::Dirty that this value has changed, since this is an


### PR DESCRIPTION
persist to database when set preference.
But only reload from database when server initialize.
So you can't update from rails console and see change take effect in your rails server immediately.
Also, if you have more than one web server,
It would be better to only use database preference to make sure configurations between servers are persistent.