### PR TITLE
Load country factory in zone factory

### DIFF
--- a/core/lib/spree/testing_support/factories/zone_factory.rb
+++ b/core/lib/spree/testing_support/factories/zone_factory.rb
@@ -1,4 +1,5 @@
 require 'spree/testing_support/sequences'
+require 'spree/testing_support/factories/country_factory'
 
 FactoryGirl.define do
   factory :global_zone, class: Spree::Zone do


### PR DESCRIPTION
Before this commit, the `:with_country` trait would not be
usable when requiring the zone factory independently.