### PR TITLE
Fix for rspec-rails and rails 4.2.5.1

### DIFF
--- a/frontend/spec/support/rspec_rails_4_2_5_1.rb
+++ b/frontend/spec/support/rspec_rails_4_2_5_1.rb
@@ -1,0 +1,7 @@
+# Fix for rspec-rails and rails 4.2.5.1
+# This can be removed as soon as doing so doesn't cause test errors.
+# See https://github.com/rspec/rspec-rails/issues/1532
+
+RSpec::Rails::ViewRendering::EmptyTemplatePathSetDecorator.class_eval do
+  alias_method :find_all_anywhere, :find_all
+end


### PR DESCRIPTION
Fixes ```NoMethodError: Undefined Method `cache'```

This can be removed as soon as doing so doesn't cause test errors.
See https://github.com/rspec/rspec-rails/issues/1532