### PR TITLE
Remove unnecessary data-update attributes

### DIFF
--- a/backend/app/helpers/spree/admin/navigation_helper.rb
+++ b/backend/app/helpers/spree/admin/navigation_helper.rb
@@ -96,13 +96,6 @@ module Spree
             button(text, html_options.delete(:icon), nil, html_options)
           end
         else
-          if html_options['data-update'].nil? && html_options[:remote]
-            object_name, action = url.split('/')[-2..-1]
-            html_options['data-update'] = [action, object_name.singularize].join('_')
-          end
-
-          html_options.delete('data-update') unless html_options['data-update']
-
           html_options[:class] += ' button'
 
           if html_options[:icon]

--- a/backend/app/views/spree/admin/product_properties/index.html.erb
+++ b/backend/app/views/spree/admin/product_properties/index.html.erb
@@ -9,7 +9,7 @@
       </li>
       <li>
         <span id="new_ptype_link">
-          <%= link_to Spree.t(:select_from_prototype), available_admin_prototypes_url, :remote => true, 'data-update' => 'prototypes', :class => 'button fa fa-copy' %>
+          <%= link_to Spree.t(:select_from_prototype), available_admin_prototypes_url, :remote => true, :class => 'button fa fa-copy' %>
         </span>
       </li>
     </ul>

--- a/backend/app/views/spree/admin/properties/index.html.erb
+++ b/backend/app/views/spree/admin/properties/index.html.erb
@@ -5,7 +5,7 @@
 <% content_for :page_actions do %>
   <% if can?(:create, Spree::Property) %>
     <li id="new_property_link">
-      <%= button_link_to Spree.t(:new_property), new_admin_property_url, { :remote => true, :icon => 'plus', 'data-update' => 'new_property_container', :id => 'new_property_link' } %>
+      <%= button_link_to Spree.t(:new_property), new_admin_property_url, { :remote => true, :icon => 'plus', :id => 'new_property_link' } %>
     </li>
   <% end %>
 <% end %>

--- a/backend/app/views/spree/admin/prototypes/index.html.erb
+++ b/backend/app/views/spree/admin/prototypes/index.html.erb
@@ -5,7 +5,7 @@
 <% content_for :page_actions do %>
   <% if can?(:create, Spree::Prototype) %>
     <li id="new_prototype_link">
-      <%= button_link_to Spree.t(:new_prototype), new_admin_prototype_url, {:remote => true, :icon => 'plus', 'data-update' => 'new_prototype', :id => 'new_prototype_link'} %>
+      <%= button_link_to Spree.t(:new_prototype), new_admin_prototype_url, {:remote => true, :icon => 'plus', :id => 'new_prototype_link'} %>
     </li>
   <% end %>
 <% end %>

--- a/backend/app/views/spree/admin/variants/index.html.erb
+++ b/backend/app/views/spree/admin/variants/index.html.erb
@@ -118,7 +118,6 @@
                                 Spree.t(:new_variant),
                                 new_admin_product_variant_url(@product),
                                 :remote => :true,
-                                :'data-update' => 'new_variant',
                                 :class => 'button'
                                ) %>
         </li>


### PR DESCRIPTION
The code that used this was removed in 2011 in favour of standard rails ujs. See 1182daf6e280da87937cb2a44af358462073f728

NB. data-update is still used by the States interface in the admin, but that is different code that is only activated there.