### PR TITLE
Simplify Order#to_param

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -174,7 +174,7 @@ module Spree
     end
 
     def to_param
-      number.to_s.to_url.upcase
+      number
     end
 
     def completed?


### PR DESCRIPTION
The existing `to_param` called `.to_s.to_url.upcase`, however when order is found by an incoming param `find_by_number` is always used. Therefore to_param must always match number exactly. For the default number generation this was always already the case.

This makes `Order#to_param` significantly faster (previously took about .5ms).

```
Calculating -------------------------------------
        order.number    42.199k i/100ms
order.number.to_s.to_url.upcase
                       176.000  i/100ms
-------------------------------------------------
        order.number      2.155M (± 0.7%) i/s -     10.803M
order.number.to_s.to_url.upcase
                          1.851k (±14.3%) i/s -      9.152k
```