### PR TITLE
Show tracking urls for shipments in api responses.

### DIFF
--- a/api/app/helpers/spree/api/api_helpers.rb
+++ b/api/app/helpers/spree/api/api_helpers.rb
@@ -104,7 +104,7 @@ module Spree
 
       @@payment_method_attributes = [:id, :name, :description]
 
-      @@shipment_attributes = [:id, :tracking, :number, :cost, :shipped_at, :state]
+      @@shipment_attributes = [:id, :tracking, :tracking_url, :number, :cost, :shipped_at, :state]
 
       @@taxonomy_attributes = [:id, :name]
 

--- a/api/spec/controllers/spree/api/shipments_controller_spec.rb
+++ b/api/spec/controllers/spree/api/shipments_controller_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Spree::Api::ShipmentsController, :type => :controller do
   render_views
   let!(:shipment) { create(:shipment, address: create(:address), inventory_units: [build(:inventory_unit, shipment: nil)]) }
-  let!(:attributes) { [:id, :tracking, :number, :cost, :shipped_at, :stock_location_name, :order_id, :shipping_rates, :shipping_methods] }
+  let!(:attributes) { [:id, :tracking, :tracking_url, :number, :cost, :shipped_at, :stock_location_name, :order_id, :shipping_rates, :shipping_methods] }
 
   before do
     stub_authentication!

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -269,6 +269,8 @@ module Spree
     end
 
     def tracking_url
+      return nil unless tracking && shipping_method
+
       @tracking_url ||= shipping_method.build_tracking_url(tracking)
     end
 

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -603,17 +603,30 @@ describe Spree::Shipment, type: :model do
   end
 
   context "#tracking_url" do
-    subject do
-      shipment.tracking_url
+    subject { shipment.tracking_url }
+
+    context "when tracking has not yet been set" do
+      it { is_expected.to be nil }
     end
 
-    before do
-      shipping_method.update!(tracking_url: "https://example.com/:tracking")
-      shipment.tracking = '1Z12345'
+    context "when tracking has been set, but a shipping method is not present" do
+      before do
+        shipment.tracking = "12345"
+        shipment.shipping_rates.clear
+      end
+
+      it { is_expected.to be nil }
     end
 
-    it "uses shipping method to determine url" do
-      is_expected.to eq("https://example.com/1Z12345")
+    context "when tracking has been set and a shipping method exists" do
+      before do
+        shipment.tracking = "12345"
+        shipment.shipping_method.update(tracking_url: "https://example.com/:tracking")
+      end
+
+      it "builds the tracking url with the shipping method" do
+        expect(subject).to eql("https://example.com/12345")
+      end
     end
   end
 


### PR DESCRIPTION
See individual commit messages for rationale on the changes.