### PR TITLE
Remove hack for rails 4.2.5.1 support

### DIFF
--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -28,7 +28,7 @@ group :test do
   gem 'rspec-activemodel-mocks', '~>1.0.2'
   gem 'rspec-collection_matchers'
   gem 'rspec-its'
-  gem 'rspec-rails', '~> 3.3.0'
+  gem 'rspec-rails', '~> 3.4.1'
   gem 'simplecov'
   gem 'webmock', '1.8.11'
   gem 'poltergeist'

--- a/frontend/spec/support/rspec_rails_4_2_5_1.rb
+++ b/frontend/spec/support/rspec_rails_4_2_5_1.rb
@@ -1,7 +1,0 @@
-# Fix for rspec-rails and rails 4.2.5.1
-# This can be removed as soon as doing so doesn't cause test errors.
-# See https://github.com/rspec/rspec-rails/issues/1532
-
-RSpec::Rails::ViewRendering::EmptyTemplatePathSetDecorator.class_eval do
-  alias_method :find_all_anywhere, :find_all
-end


### PR DESCRIPTION
With the latest rspec release this is unnecessary.