### PR TITLE
Attribute translation in adjustment forms

### DIFF
--- a/backend/app/views/spree/admin/adjustment_reasons/index.html.erb
+++ b/backend/app/views/spree/admin/adjustment_reasons/index.html.erb
@@ -21,8 +21,8 @@
     </colgroup>
     <thead>
       <tr data-hook="adjustment_reasons_header">
-        <th><%= Spree.t(:name) %></th>
-        <th><%= Spree.t(:state) %></th>
+        <th><%= Spree::AdjustmentReason.human_attribute_name(:name) %></th>
+        <th><%= Spree::AdjustmentReason.human_attribute_name(:state) %></th>
         <th class="actions"></th>
       </tr>
     </thead>

--- a/backend/app/views/spree/admin/adjustment_reasons/shared/_form.html.erb
+++ b/backend/app/views/spree/admin/adjustment_reasons/shared/_form.html.erb
@@ -2,19 +2,19 @@
   <div class="row">
     <div class="alpha four columns">
       <%= f.field_container :name do %>
-        <%= f.label :name, Spree.t(:name), class: 'required' %><br />
+        <%= f.label :name, class: 'required' %><br />
         <%= f.text_field :name, :class => 'fullwidth' %>
       <% end %>
 
       <%= f.field_container :code do %>
-        <%= f.label :code, Spree.t(:code), class: 'required' %><br />
+        <%= f.label :code, class: 'required' %><br />
         <%= f.text_field :code, :class => 'fullwidth' %>
       <% end %>
 
       <div class="checkbox">
         <label>
           <%= f.check_box :active %>
-          <%= Spree.t(:active) %>
+          <%= Spree::AdjustmentReason.human_attribute_name(:active) %>
         </label>
       </div>
     </div>

--- a/backend/app/views/spree/admin/adjustments/_adjustments_table.html.erb
+++ b/backend/app/views/spree/admin/adjustments/_adjustments_table.html.erb
@@ -1,10 +1,10 @@
 <table class="index adjustments" data-hook="adjustments">
   <thead data-hook="adjustmment_head">
     <tr>
-      <th><%= Spree.t(:adjustable) %></th>
-      <th><%= Spree.t(:description) %></th>
-      <th><%= Spree.t(:amount) %></th>
-      <th><%= Spree.t(:state) %></th>
+      <th><%= Spree::Adjustment.human_attribute_name(:adjustable) %></th>
+      <th><%= Spree::Adjustment.human_attribute_name(:label) %></th>
+      <th><%= Spree::Adjustment.human_attribute_name(:amount) %></th>
+      <th><%= Spree::Adjustment.human_attribute_name(:state) %></th>
       <th class="actions"></th>
     </tr>
   </thead>

--- a/backend/app/views/spree/admin/adjustments/_form.html.erb
+++ b/backend/app/views/spree/admin/adjustments/_form.html.erb
@@ -1,7 +1,7 @@
 <div data-hook="admin_adjustment_form_fields" class="row">
   <div class="alpha three columns">
     <%= f.field_container :amount do %>
-      <%= f.label :amount, Spree.t(:amount), class: 'required' %>
+      <%= f.label :amount, class: 'required' %>
       <%= text_field :adjustment, :amount, class: 'fullwidth' %>
       <%= f.error_message_on :amount %>
     <% end %>
@@ -9,7 +9,7 @@
 
   <div class="six columns">
     <%= f.field_container :label do %>
-      <%= f.label :label, Spree.t(:description), class: 'required' %>
+      <%= f.label :label, class: 'required' %>
       <%= text_field :adjustment, :label, class: 'fullwidth' %>
       <%= f.error_message_on :label %>
     <% end %>
@@ -17,7 +17,7 @@
 
   <div class="omega three columns">
     <%= f.field_container :label do %>
-      <%= f.label :adjustment_reason_id, Spree.t(:reason) %><br/>
+      <%= f.label :adjustment_reason_id %><br/>
       <%= f.collection_select(:adjustment_reason_id, reasons_for(@adjustment), :id, :name, {include_blank: true}, {"data-placeholder" => Spree.t(:select_a_reason), class: 'select2 fullwidth'}) %>
     <% end %>
   </div>

--- a/backend/spec/features/admin/orders/adjustments_spec.rb
+++ b/backend/spec/features/admin/orders/adjustments_spec.rb
@@ -68,7 +68,7 @@ describe "Adjustments", type: :feature do
         fill_in "adjustment_amount", with: ""
         fill_in "adjustment_label", with: ""
         click_button "Continue"
-        expect(page).to have_content("Label can't be blank")
+        expect(page).to have_content("Description can't be blank")
         expect(page).to have_content("Amount is not a number")
       end
     end
@@ -99,7 +99,7 @@ describe "Adjustments", type: :feature do
         fill_in "adjustment_amount", with: ""
         fill_in "adjustment_label", with: ""
         click_button "Continue"
-        expect(page).to have_content("Label can't be blank")
+        expect(page).to have_content("Description can't be blank")
         expect(page).to have_content("Amount is not a number")
       end
     end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -11,6 +11,17 @@ en:
         phone: Phone
         state: State
         zipcode: Zip Code
+      spree/adjustment:
+        adjustable: Adjustable
+        amount: Amount
+        label: Description
+        state: State
+        adjustment_reason_id: Reason
+      spree/adjustment_reason:
+        active: Active
+        code: Code
+        name: Name
+        state: State
       spree/calculator/tiered_flat_rate:
         preferred_base_amount: Base Amount
         preferred_tiers: Tiers


### PR DESCRIPTION
This is to better the use of I18n in solidus.  Currently it is not utilized nearly as well as it should be in order to be friendly to non-English languages.  ActiveRecord attribute translation is implemented for adjustment forms.

This is cherry picked from #549 and is the first in a series of PRs to address that PR and #735.