### PR TITLE
Don't automatically add javascripts to dummy apps in extesions

### DIFF
--- a/core/lib/generators/spree/install/templates/vendor/assets/javascripts/spree/backend/all.js
+++ b/core/lib/generators/spree/install/templates/vendor/assets/javascripts/spree/backend/all.js
@@ -7,7 +7,4 @@
 //= require jquery
 //= require jquery_ujs
 //= require spree/backend
-<% unless options[:lib_name] == 'spree' || options[:lib_name] == 'spree/backend' %>
-//= require spree/backend/<%= options[:lib_name].gsub("/", "_") %>
-<% end %>
 //= require_tree .

--- a/core/lib/generators/spree/install/templates/vendor/assets/javascripts/spree/frontend/all.js
+++ b/core/lib/generators/spree/install/templates/vendor/assets/javascripts/spree/frontend/all.js
@@ -7,7 +7,4 @@
 //= require jquery
 //= require jquery_ujs
 //= require spree/frontend
-<% unless options[:lib_name] == 'spree' || options[:lib_name] == 'spree/frontend' %>
-//= require spree/frontend/<%= options[:lib_name].gsub("/", "_") %>
-<% end %>
 //= require_tree .

--- a/core/lib/generators/spree/install/templates/vendor/assets/stylesheets/spree/backend/all.css
+++ b/core/lib/generators/spree/install/templates/vendor/assets/stylesheets/spree/backend/all.css
@@ -4,9 +4,6 @@
  * the top of the compiled file, but it's generally better to create a new file per style scope.
  *
  *= require spree/backend
-<% unless options[:lib_name] == 'spree' || options[:lib_name] == 'spree/backend'  %>
- *= require spree/backend/<%= options[:lib_name].gsub("/", "_") %>
-<% end %>
  *= require_self
  *= require_tree .
 */

--- a/core/lib/generators/spree/install/templates/vendor/assets/stylesheets/spree/frontend/all.css
+++ b/core/lib/generators/spree/install/templates/vendor/assets/stylesheets/spree/frontend/all.css
@@ -4,9 +4,6 @@
  * the top of the compiled file, but it's generally better to create a new file per style scope.
  *
  *= require spree/frontend
-<% unless options[:lib_name] == 'spree' || options[:lib_name] == 'spree/frontend' %>
- *= require spree/frontend/<%= options[:lib_name].gsub("/", "_") %>
-<% end %>
  *= require_self
  *= require_tree .
 */


### PR DESCRIPTION
This is required to fix the extension test failures we are experiencing due to sprockets-rails 3.0 https://github.com/solidusio/solidus#extensions

LIB_NAME is used in the install generator when we are creating the spec/dummy app in an extension. Previously it added includes for files like `spree/backend/$LIB_NAME.js` whether or not they existed.

Unfortunately, as of sprockets-rails 3.0, that will cause an exception even if that section (backend/frontend) of solidus isn't visited.

If that file is needed for the extension to run, it should be added by the extension's own install generator. Most extensions already do this and won't be broken by this change (I tested a few under the solidus org).

cc @adammathys who knows the extension generators well