### PR TITLE
Fix duplicate new_prototype id

### DIFF
--- a/backend/app/views/spree/admin/prototypes/index.html.erb
+++ b/backend/app/views/spree/admin/prototypes/index.html.erb
@@ -13,7 +13,7 @@
 <%= image_tag 'select2-spinner.gif', :plugin => 'spree', :style => 'display: none', :id => 'busy_indicator' %>
 
 <%# Placeholder for new prototype form %>
-<div id="new_prototype"></div>
+<div id="new_prototype_container"></div>
 
 <% if @prototypes.any? %>
 <table class="index" id='listing_prototypes' data-hook>

--- a/backend/app/views/spree/admin/prototypes/new.js.erb
+++ b/backend/app/views/spree/admin/prototypes/new.js.erb
@@ -1,4 +1,4 @@
-$("#new_prototype").html('<%= escape_javascript(render :template => "spree/admin/prototypes/new", :formats=>[:html], :handlers=>[:erb]) %>');
+$("#new_prototype_container").html('<%= escape_javascript(render :template => "spree/admin/prototypes/new", :formats=>[:html], :handlers=>[:erb]) %>');
 <% unless Rails.env.test? %>
   $('.select2').select2();
 <% end %>


### PR DESCRIPTION
There is a div with id="new_prototype" which is the same id auto generated for the form for a new prototype. This commit replaces the parent div with id="new_prototype_container"

This fixes a spurious failure in `prototypes_spec.rb`