### PR TITLE
Simplify select_properties_from_prototype

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/admin.js.erb
+++ b/backend/app/assets/javascripts/spree/backend/admin.js.erb
@@ -170,18 +170,6 @@ $(document).ready(function(){
     return false;
   });
 
-  $('body').on('click', '.select_properties_from_prototype', function(){
-    $("#busy_indicator").show();
-    var clicked_link = $(this);
-    Spree.ajax({ dataType: 'script', url: clicked_link.prop("href"), type: 'get',
-        success: function(data){
-          clicked_link.parent("td").parent("tr").hide();
-          $("#busy_indicator").hide();
-        }
-    });
-    return false;
-  });
-
   // Fix sortable helper
   var fixHelper = function(e, ui) {
       ui.children().each(function() {

--- a/backend/app/views/spree/admin/product_properties/index.html.erb
+++ b/backend/app/views/spree/admin/product_properties/index.html.erb
@@ -22,7 +22,6 @@
     <div class="add_product_properties" data-hook="add_product_properties"></div>
 
     <div id="prototypes" data-hook></div>
-    <%= image_tag 'select2-spinner.gif', :plugin => 'spree', :style => 'display:none;', :id => 'busy_indicator' %>
 
     <table class="index sortable" data-hook data-sortable-link="<%= update_positions_admin_product_product_properties_url %>">
       <thead>

--- a/backend/app/views/spree/admin/prototypes/_prototypes.html.erb
+++ b/backend/app/views/spree/admin/prototypes/_prototypes.html.erb
@@ -14,7 +14,7 @@
       <tr id="row_<%= prototype.id %>" data-hook="available_row" class="<%= cycle('odd', 'even')%>">
         <td><%= prototype.name %></td>
         <td class="actions">
-          <%= link_to Spree.t(:select), select_admin_prototype_url(prototype), :class => 'ajax button select_properties_from_prototype fa fa-ok' %>
+          <%= link_to Spree.t(:select), select_admin_prototype_url(prototype), class: 'ajax button select_properties_from_prototype fa fa-ok', data: { remote: true } %>
         </td>
       </tr>
     <% end %>

--- a/backend/app/views/spree/admin/prototypes/index.html.erb
+++ b/backend/app/views/spree/admin/prototypes/index.html.erb
@@ -10,8 +10,6 @@
   <% end %>
 <% end %>
 
-<%= image_tag 'select2-spinner.gif', :plugin => 'spree', :style => 'display: none', :id => 'busy_indicator' %>
-
 <%# Placeholder for new prototype form %>
 <div id="new_prototype"></div>
 


### PR DESCRIPTION
This had custom javascript which could have the same behaviour implemented in standard rails ujs.

This also removes the now unnecessary busy_indicators