### PR TITLE
Fix issue displaying completed orders in admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 ## Solidus 1.3.0 (unreleased)
 
-* Removed Spree::BaseHelper#gem_available? and Spree::BaseHelper#current_spree_page?
+*   Removed Spree::BaseHelper#gem_available? and Spree::BaseHelper#current_spree_page?
 
-  Both these methods were untested and not appropriate code to be in core. If you need these
-  methods please pull them into your app. [#710](https://github.com/solidusio/solidus/pull/710).
+    Both these methods were untested and not appropriate code to be in core. If you need these
+    methods please pull them into your app. [#710](https://github.com/solidusio/solidus/pull/710).
+
+*   Fixed a bug where toggling 'show only complete order' on/off was not showing
+    all orders. [#749](https://github.com/solidusio/solidus/pull/749)
 
 ## Solidus 1.2.0 (unreleased)
 

--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -15,6 +15,7 @@ module Spree
         params[:q][:completed_at_not_null] ||= '1' if Spree::Config[:show_only_complete_orders_by_default]
         @show_only_completed = params[:q][:completed_at_not_null] == '1'
         params[:q][:s] ||= @show_only_completed ? 'completed_at desc' : 'created_at desc'
+        params[:q][:completed_at_not_null] = '' unless @show_only_completed
 
         # As date params are deleted if @show_only_completed, store
         # the original date so we can restore them into the params

--- a/backend/spec/features/admin/orders/listing_spec.rb
+++ b/backend/spec/features/admin/orders/listing_spec.rb
@@ -127,12 +127,12 @@ describe "Orders Listing", type: :feature, js: true do
       end
     end
 
-    context 'filter on complete orders' do
+    context "when toggling the completed orders checkbox" do
       before do
         create(:order, number: 'R300', completed_at: nil, state: 'cart')
       end
 
-      it "should show both complete and incomplete orders" do
+      it "shows both complete and incomplete orders" do
         check "q_completed_at_not_null"
         click_on 'Filter'
 

--- a/backend/spec/features/admin/orders/listing_spec.rb
+++ b/backend/spec/features/admin/orders/listing_spec.rb
@@ -126,5 +126,25 @@ describe "Orders Listing", type: :feature, js: true do
         within("table#listing_orders") { expect(page).not_to have_content("R200") }
       end
     end
+
+    context 'filter on complete orders' do
+      before do
+        create(:order, number: 'R300', completed_at: nil, state: 'cart')
+      end
+
+      it "should show both complete and incomplete orders" do
+        check "q_completed_at_not_null"
+        click_on 'Filter'
+
+        expect(page).to have_content("R200")
+        expect(page).to_not have_content("R300")
+
+        uncheck "q_completed_at_not_null"
+        click_on 'Filter Results'
+
+        expect(page).to have_content("R200")
+        expect(page).to have_content("R300")
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes an issue where checking the 'only show complete orders' checkbox
and then unchecking it was no longer displaying completed orders.

A similar fix was merged into Spree after the Solidus fork:
https://github.com/spree/spree/commit/69a20c3abfeef155754b4afaa3c179759b5dd60a