### PR TITLE
Use activemodel translation for order cancellations

### DIFF
--- a/backend/app/views/spree/admin/cancellations/index.html.erb
+++ b/backend/app/views/spree/admin/cancellations/index.html.erb
@@ -13,11 +13,11 @@
   </colgroup>
 
   <thead>
-    <th colspan="2"><%= Spree.t(:item_description) %></th>
-    <th><%= Spree.t(:quantity) %></th>
-    <th><%= Spree.t(:state) %></th>
-    <th><%= Spree.t(:shipment) %></th>
-    <th><%= Spree.t(:cancel) %></th>
+    <th colspan="2"><%= Spree::LineItem.human_attribute_name(:description) %></th>
+    <th><%= Spree::OrderCancellations.human_attribute_name(:quantity) %></th>
+    <th><%= Spree::OrderCancellations.human_attribute_name(:state) %></th>
+    <th><%= Spree::OrderCancellations.human_attribute_name(:shipment) %></th>
+    <th><%= Spree::OrderCancellations.human_attribute_name(:cancel) %></th>
   </thead>
 
   <tbody>
@@ -30,7 +30,7 @@
           <td class="inventory-unit-name">
             <%= inventory_unit.variant.product.name %><br><%= "(" + variant_options(inventory_unit.variant) + ")" unless inventory_unit.variant.option_values.empty? %>
             <% if inventory_unit.variant.sku.present? %>
-              <strong><%= Spree.t(:sku) %>:</strong> <%= inventory_unit.variant.sku %>
+              <strong><%= Spree::Variant.human_attribute_name(:sku) %>:</strong> <%= inventory_unit.variant.sku %>
             <% end %>
           </td>
           <td class="inventory-unit-quantity align-center">1</td>

--- a/core/app/models/spree/order_cancellations.rb
+++ b/core/app/models/spree/order_cancellations.rb
@@ -1,5 +1,7 @@
 # This class represents all of the actions one can take to modify an Order after it is complete
 class Spree::OrderCancellations
+  extend ActiveModel::Translation
+
   # If you need to message a third party service when an item is canceled then
   # set short_ship_tax_notifier to an object that responds to:
   #     #call(unit_cancels)

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1,4 +1,11 @@
 en:
+  activemodel:
+    attributes:
+      spree/order_cancellations:
+        quantity: Quantity
+        state: State
+        shipment: Shipment
+        cancel: Cancel
   activerecord:
     attributes:
       spree/address:
@@ -34,6 +41,7 @@ en:
       spree/inventory_unit:
         state: State
       spree/line_item:
+        description: Item Description
         price: Price
         quantity: Quantity
       spree/option_type:


### PR DESCRIPTION
This is to better utilize I18n with more verbosity to make it more clear and easier to translate.  

This is cherry picked from #549 with one small change to not remove a translation for `:item_description` yet as that will cause missing translations.  The appearance on the page with that change should remain unchanged but `Item Description` would be wrapped in a span to indicate the missing translation.  Regardless, this unclear translation will be removed in a later PR once it is no longer referenced anywhere.  

This is part of an ongoing meta-issue #735 