### PR TITLE
Manual rubocop fixes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,6 +22,9 @@ Style/ClassVars:
 Style/PredicateName:
   Enabled: false
 
+Style/AccessorMethodName:
+  Enabled: false
+
 # This has been used for customization
 Style/MutableConstant:
   Enabled: false
@@ -39,6 +42,20 @@ Style/ConditionalAssignment:
   Enabled: false
 
 Performance/Count:
+  Enabled: false
+
+Style/RaiseArgs:
+  Enabled: false
+
+Style/OpMethod:
+  Enabled: false
+
+# We can use good judgement here
+Style/RegexpLiteral:
+  Enabled: false
+
+# Unicode comments are useful
+Style/AsciiComments:
   Enabled: false
 
 Lint/EndAlignment:

--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,6 @@ begin
   require 'spree/testing_support/common_rake'
 rescue LoadError
   raise "Could not find spree/testing_support/common_rake. You need to run this command using Bundler."
-  exit
 end
 
 task default: :test

--- a/api/app/controllers/spree/api/images_controller.rb
+++ b/api/app/controllers/spree/api/images_controller.rb
@@ -37,9 +37,9 @@ module Spree
 
       def scope
         if params[:product_id]
-          scope = Spree::Product.friendly.find(params[:product_id])
+          Spree::Product.friendly.find(params[:product_id])
         elsif params[:variant_id]
-          scope = Spree::Variant.find(params[:variant_id])
+          Spree::Variant.find(params[:variant_id])
         end
       end
     end

--- a/api/app/controllers/spree/api/taxons_controller.rb
+++ b/api/app/controllers/spree/api/taxons_controller.rb
@@ -4,12 +4,10 @@ module Spree
       def index
         if taxonomy
           @taxons = taxonomy.root.children
+        elsif params[:ids]
+          @taxons = Spree::Taxon.accessible_by(current_ability, :read).where(id: params[:ids].split(','))
         else
-          if params[:ids]
-            @taxons = Spree::Taxon.accessible_by(current_ability, :read).where(id: params[:ids].split(','))
-          else
-            @taxons = Spree::Taxon.accessible_by(current_ability, :read).order(:taxonomy_id, :lft).ransack(params[:q]).result
-          end
+          @taxons = Spree::Taxon.accessible_by(current_ability, :read).order(:taxonomy_id, :lft).ransack(params[:q]).result
         end
 
         @taxons = @taxons.page(params[:page]).per(params[:per_page])

--- a/api/app/helpers/spree/api/api_helpers.rb
+++ b/api/app/helpers/spree/api/api_helpers.rb
@@ -37,7 +37,7 @@ module Spree
         :variant_property_attributes
       ]
 
-      mattr_reader *ATTRIBUTES
+      mattr_reader(*ATTRIBUTES)
 
       def required_fields_for(model)
         required_fields = model._validators.select do |_field, validations|

--- a/api/lib/spree/api/engine.rb
+++ b/api/lib/spree/api/engine.rb
@@ -28,7 +28,7 @@ module Spree
           Rails.configuration.cache_classes ? require(c) : load(c)
         end
       end
-      config.to_prepare &method(:activate).to_proc
+      config.to_prepare(&method(:activate).to_proc)
 
       def self.root
         @root ||= Pathname.new(File.expand_path('../../../../', __FILE__))

--- a/api/spec/controllers/spree/api/option_types_controller_spec.rb
+++ b/api/spec/controllers/spree/api/option_types_controller_spec.rb
@@ -35,7 +35,7 @@ module Spree
 
     it "can retrieve a list of specific option types" do
       option_type_1 = create(:option_type)
-      option_type_2 = create(:option_type)
+      create(:option_type)
       api_get :index, ids: "#{option_type.id},#{option_type_1.id}"
       expect(json_response.count).to eq(2)
 
@@ -90,7 +90,6 @@ module Spree
       end
 
       it "can update an option type" do
-        original_name = option_type.name
         api_put :update, id: option_type.id, option_type: {
                               name: "Option Type"
                             }

--- a/api/spec/controllers/spree/api/option_values_controller_spec.rb
+++ b/api/spec/controllers/spree/api/option_values_controller_spec.rb
@@ -49,7 +49,7 @@ module Spree
 
       it "can retrieve a list of option types" do
         option_value_1 = create(:option_value, option_type: option_type)
-        option_value_2 = create(:option_value, option_type: option_type)
+        create(:option_value, option_type: option_type)
         api_get :index, ids: [option_value.id, option_value_1.id]
         expect(json_response.count).to eq(2)
       end
@@ -101,7 +101,6 @@ module Spree
         end
 
         it "can update an option value" do
-          original_name = option_value.name
           api_put :update, id: option_value.id, option_value: {
                                 name: "Option Value"
                               }

--- a/api/spec/controllers/spree/api/orders_controller_spec.rb
+++ b/api/spec/controllers/spree/api/orders_controller_spec.rb
@@ -508,7 +508,6 @@ module Spree
         before { order.create_proposed_shipments }
 
         it "clears out all existing shipments on line item udpate" do
-          previous_shipments = order.shipments
           api_put :update, id: order.to_param, order: {
             line_items: {
               0 => { id: line_item.id, quantity: 10 }
@@ -722,7 +721,6 @@ module Spree
         it "can create an order without any parameters" do
           api_post :create
           expect(response.status).to eq(201)
-          order = Order.last
           expect(json_response["state"]).to eq("cart")
         end
 

--- a/api/spec/controllers/spree/api/products_controller_spec.rb
+++ b/api/spec/controllers/spree/api/products_controller_spec.rb
@@ -99,7 +99,7 @@ module Spree
 
       context "pagination" do
         it "can select the next page of products" do
-          second_product = create(:product)
+          create(:product)
           api_get :index, page: 2, per_page: 1
           expect(json_response["products"].first).to have_attributes(show_attributes)
           expect(json_response["total_count"]).to eq(2)

--- a/api/spec/controllers/spree/api/stock_movements_controller_spec.rb
+++ b/api/spec/controllers/spree/api/stock_movements_controller_spec.rb
@@ -55,7 +55,7 @@ module Spree
       end
 
       it 'can query the results through a paramter' do
-        expected_result = create(:stock_movement, :received, quantity: 10, stock_item: stock_item)
+        create(:stock_movement, :received, quantity: 10, stock_item: stock_item)
         api_get :index, stock_location_id: stock_location.to_param, q: { quantity_eq: '10' }
         expect(json_response['count']).to eq(1)
       end

--- a/api/spec/controllers/spree/api/taxonomies_controller_spec.rb
+++ b/api/spec/controllers/spree/api/taxonomies_controller_spec.rb
@@ -102,7 +102,6 @@ module Spree
         api_post :create, taxonomy: {}
         expect(response.status).to eq(422)
         expect(json_response["error"]).to eq("Invalid resource. Please fix errors and try again.")
-        errors = json_response["errors"]
       end
 
       it "can destroy" do

--- a/api/spec/controllers/spree/api/taxons_controller_spec.rb
+++ b/api/spec/controllers/spree/api/taxons_controller_spec.rb
@@ -150,7 +150,6 @@ module Spree
         api_post :create, taxonomy_id: taxonomy.id, taxon: {}
         expect(response.status).to eq(422)
         expect(json_response["error"]).to eq("Invalid resource. Please fix errors and try again.")
-        errors = json_response["errors"]
 
         expect(taxonomy.reload.root.children.count).to eq 1
       end

--- a/api/spec/controllers/spree/api/users_controller_spec.rb
+++ b/api/spec/controllers/spree/api/users_controller_spec.rb
@@ -40,7 +40,6 @@ module Spree
         api_post :create, user: {}, token: user.spree_api_key
         expect(response.status).to eq(422)
         expect(json_response["error"]).to eq("Invalid resource. Please fix errors and try again.")
-        errors = json_response["errors"]
       end
 
       it "can update own details" do

--- a/api/spec/controllers/spree/api/variants_controller_spec.rb
+++ b/api/spec/controllers/spree/api/variants_controller_spec.rb
@@ -115,7 +115,7 @@ module Spree
 
       context "pagination" do
         it "can select the next page of variants" do
-          second_variant = create(:variant)
+          create(:variant)
           api_get :index, page: 2, per_page: 1
           expect(json_response["variants"].first).to have_attributes(show_attributes)
           expect(json_response["total_count"]).to eq(3)

--- a/api/spec/features/checkout_spec.rb
+++ b/api/spec/features/checkout_spec.rb
@@ -92,7 +92,7 @@ module Spree
       expect(@order.completed_at).to be_a ActiveSupport::TimeWithZone
       expect(@order.item_total).to eq 600.00
       expect(@order.total).to eq 600.00
-      expect(@order.adjustment_total).to eq -10.00
+      expect(@order.adjustment_total).to eq(-10.00)
       expect(@order.shipment_total).to eq 10.00
       expect(@order.user).to eq @user
       expect(@order.bill_address).to eq bill_address

--- a/api/spec/requests/ransackable_attributes_spec.rb
+++ b/api/spec/requests/ransackable_attributes_spec.rb
@@ -41,8 +41,8 @@ describe "Ransackable Attributes" do
 
   context "filtering by attributes" do
     it "most attributes are not filterable by default" do
-      product = create(:product, description: "special product")
-      other_product = create(:product)
+      create(:product, description: "special product")
+      create(:product)
 
       get "/api/products?q[description_cont]=special", token: user.spree_api_key
 

--- a/api/spec/requests/ransackable_attributes_spec.rb
+++ b/api/spec/requests/ransackable_attributes_spec.rb
@@ -33,7 +33,7 @@ describe "Ransackable Attributes" do
 
       get "/api/variants?q[product_name_or_sku_cont]=fritos", token: user.spree_api_key
 
-      skus = JSON.parse(response.body)['variants'].map { |variant| variant['sku'] }
+      skus = JSON.parse(response.body)['variants'].map { |x| x['sku'] }
       expect(skus).to include variant.sku
       expect(skus).not_to include other_variant.sku
     end
@@ -56,7 +56,7 @@ describe "Ransackable Attributes" do
 
       get "/api/products?q[id_eq]=#{product.id}", token: user.spree_api_key
 
-      product_names = JSON.parse(response.body)['products'].map { |product| product['name'] }
+      product_names = JSON.parse(response.body)['products'].map { |x| x['name'] }
       expect(product_names).to include product.name
       expect(product_names).not_to include other_product.name
     end
@@ -69,7 +69,7 @@ describe "Ransackable Attributes" do
 
       get "/api/products?q[name_cont]=fritos", token: user.spree_api_key
 
-      product_names = JSON.parse(response.body)['products'].map { |product| product['name'] }
+      product_names = JSON.parse(response.body)['products'].map { |x| x['name'] }
       expect(product_names).to include product.name
       expect(product_names).not_to include other_product.name
     end

--- a/backend/app/controllers/spree/admin/base_controller.rb
+++ b/backend/app/controllers/spree/admin/base_controller.rb
@@ -57,7 +57,7 @@ module Spree
 
       def lock_order
         OrderMutex.with_lock!(@order) { yield }
-      rescue Spree::OrderMutex::LockFailed => e
+      rescue Spree::OrderMutex::LockFailed
         flash[:error] = Spree.t(:order_mutex_admin_error)
         redirect_to order_mutex_redirect_path
       end

--- a/backend/app/controllers/spree/admin/customer_returns_controller.rb
+++ b/backend/app/controllers/spree/admin/customer_returns_controller.rb
@@ -63,7 +63,7 @@ module Spree
           return_item = item_params[:id] ? Spree::ReturnItem.find(item_params[:id]) : Spree::ReturnItem.new
           return_item.assign_attributes(item_params)
           if item_params[:reception_status_event].blank?
-            redirect_to(new_object_url, flash: { error: 'Reception status choice required' }) && return
+            return redirect_to(new_object_url, flash: { error: 'Reception status choice required' })
           end
           return_item
         end.compact

--- a/backend/app/controllers/spree/admin/orders/customer_details_controller.rb
+++ b/backend/app/controllers/spree/admin/orders/customer_details_controller.rb
@@ -22,7 +22,7 @@ module Spree
 
             if should_associate_user?
               requested_user = Spree.user_class.find(params[:user_id])
-              @order.associate_user!(Spree.user_class.find(params[:user_id]), @order.email.blank?)
+              @order.associate_user!(requested_user, @order.email.blank?)
             end
 
             unless @order.completed?

--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -98,11 +98,10 @@ module Spree
 
           if @order.confirm?
             flash[:success] = Spree.t('order_ready_for_confirm')
-            redirect_to confirm_admin_order_url(@order)
           else
             flash[:error] = @order.errors.full_messages
-            redirect_to confirm_admin_order_url(@order)
           end
+          redirect_to confirm_admin_order_url(@order)
         end
       end
 

--- a/backend/app/controllers/spree/admin/stock_transfers_controller.rb
+++ b/backend/app/controllers/spree/admin/stock_transfers_controller.rb
@@ -129,8 +129,11 @@ module Spree
       end
 
       def source_location
-        @source_location ||= params.key?(:transfer_receive_stock) ? nil :
+        @source_location ||= if params.key?(:transfer_receive_stock)
+                               nil
+                             else
                                StockLocation.find(params[:transfer_source_location_id])
+                             end
       end
 
       def destination_location

--- a/backend/app/helpers/spree/admin/products_helper.rb
+++ b/backend/app/helpers/spree/admin/products_helper.rb
@@ -2,18 +2,18 @@ module Spree
   module Admin
     module ProductsHelper
       def taxon_options_for(product)
-        options = @taxons.map do |taxon|
+        @taxons.map do |taxon|
           selected = product.taxons.include?(taxon)
           content_tag(:option,
                       value: taxon.id,
                       selected: ('selected' if selected)) do
-            (taxon.ancestors.pluck(:name) + [taxon.name]).join(" -> ")
-          end
+                        (taxon.ancestors.pluck(:name) + [taxon.name]).join(" -> ")
+                      end
         end.join("").html_safe
       end
 
       def option_types_options_for(product)
-        options = @option_types.map do |option_type|
+        @option_types.map do |option_type|
           selected = product.option_types.include?(option_type)
           content_tag(:option,
                       value: option_type.id,

--- a/backend/spec/controllers/spree/admin/cancellations_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/cancellations_controller_spec.rb
@@ -20,7 +20,7 @@ describe Spree::Admin::CancellationsController do
   describe "#cancel" do
     subject { spree_post :short_ship, order_id: order.number, inventory_unit_ids: inventory_units.map(&:id) }
 
-    let(:order) { order = create(:order_ready_to_ship, number: "R100", state: "complete", line_items_count: 1) }
+    let(:order) { create(:order_ready_to_ship, number: "R100", state: "complete", line_items_count: 1) }
     let(:referer) { "order_admin_page" }
 
     context "no inventory unit ids are provided" do

--- a/backend/spec/controllers/spree/admin/customer_returns_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/customer_returns_controller_spec.rb
@@ -65,7 +65,7 @@ module Spree
               total_inventory_count = 4
               rma_return_items_count = 1
               customer_return_return_items_count = 1
-              expect(assigns(:new_return_items).length).to eq (total_inventory_count - rma_return_items_count - customer_return_return_items_count)
+              expect(assigns(:new_return_items).length).to eq(total_inventory_count - rma_return_items_count - customer_return_return_items_count)
             end
 
             it "builds new return items" do

--- a/backend/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -179,7 +179,7 @@ describe Spree::Admin::OrdersController, type: :controller do
 
           it 'messages and redirects' do
             subject
-            expect(flash[:error]) == order.errors.full_messages
+            expect(flash[:error]).to eq order.errors.full_messages
             expect(response).to redirect_to(spree.confirm_admin_order_path(order))
           end
         end

--- a/backend/spec/controllers/spree/admin/payments_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/payments_controller_spec.rb
@@ -128,7 +128,6 @@ module Spree
       end
 
       describe '#fire' do
-
         describe 'authorization' do
           let(:payment) { create(:payment, state: 'checkout') }
           let(:order) { payment.order }

--- a/backend/spec/features/admin/configuration/stock_locations_spec.rb
+++ b/backend/spec/features/admin/configuration/stock_locations_spec.rb
@@ -4,7 +4,7 @@ describe "Stock Locations", type: :feature do
   stub_authorization!
 
   before(:each) do
-    country = create(:country)
+    create(:country)
     visit spree.admin_path
     click_link "Settings"
     click_link "Stock Locations"
@@ -21,7 +21,7 @@ describe "Stock Locations", type: :feature do
   end
 
   it "can delete an existing stock location", js: true do
-    location = create(:stock_location)
+    create(:stock_location)
     visit current_path
 
     expect(find('#listing_stock_locations')).to have_content("NY Warehouse")

--- a/backend/spec/features/admin/orders/adjustments_promotions_spec.rb
+++ b/backend/spec/features/admin/orders/adjustments_promotions_spec.rb
@@ -4,13 +4,13 @@ describe "Adjustments Promotions", type: :feature do
   stub_authorization!
 
   before(:each) do
-    promotion = create(:promotion_with_item_adjustment,
-                         name: "$10 off",
-                         path: 'test',
-                         code: "10_off",
-                         starts_at: 1.day.ago,
-                         expires_at: 1.day.from_now,
-                         adjustment_rate: 10)
+    create(:promotion_with_item_adjustment,
+           name: "$10 off",
+           path: 'test',
+           code: "10_off",
+           starts_at: 1.day.ago,
+           expires_at: 1.day.from_now,
+           adjustment_rate: 10)
 
     order = create(:order_with_totals)
     line_item = order.line_items.first

--- a/backend/spec/features/admin/products/stock_management_spec.rb
+++ b/backend/spec/features/admin/products/stock_management_spec.rb
@@ -54,7 +54,7 @@ describe "Stock Management", type: :feature do
       stock_item.reload
       expect(stock_item.count_on_hand).to eq 4
       expect(stock_item.stock_movements.count).to eq 1
-      expect(stock_item.stock_movements.first.quantity).to eq -6
+      expect(stock_item.stock_movements.first.quantity).to eq(-6)
     end
 
     def adjust_count_on_hand(count_on_hand)

--- a/backend/spec/features/admin/products/stock_management_spec.rb
+++ b/backend/spec/features/admin/products/stock_management_spec.rb
@@ -26,7 +26,7 @@ describe "Stock Management", type: :feature do
     context "with no stock location" do
       before do
         @product = create(:product, name: 'apache baseball cap', price: 10)
-        v = @product.variants.create!(sku: 'FOOBAR')
+        @product.variants.create!(sku: 'FOOBAR')
         Spree::StockLocation.destroy_all
         click_link "Back To Products List"
         within_row(1) do

--- a/backend/spec/features/admin/stock_transfer_spec.rb
+++ b/backend/spec/features/admin/stock_transfer_spec.rb
@@ -12,8 +12,8 @@ describe 'Stock Transfers', type: :feature, js: true do
 
   describe 'create stock transfer' do
     it 'can create a stock transfer' do
-      source_location = create(:stock_location_with_items, name: 'NY')
-      destination_location = create(:stock_location, name: 'SF')
+      create(:stock_location_with_items, name: 'NY')
+      create(:stock_location, name: 'SF')
 
       visit spree.new_admin_stock_transfer_path
       select "SF", from: 'stock_transfer[source_location_id]'

--- a/backend/spec/features/admin/users_spec.rb
+++ b/backend/spec/features/admin/users_spec.rb
@@ -25,9 +25,9 @@ describe 'Users', type: :feature do
         [:total_sales, :num_orders, :average_order_value, :member_since].each do |stat_name|
           expect(page).to have_content Spree.t(stat_name)
         end
-        expect(page).to have_content (order.total + order_2.total)
+        expect(page).to have_content(order.total + order_2.total)
         expect(page).to have_content orders.count
-        expect(page).to have_content (orders.sum(&:total) / orders.count)
+        expect(page).to have_content(orders.sum(&:total) / orders.count)
         expect(page).to have_content I18n.l(user_a.created_at.to_date)
       end
     end

--- a/build-ci.rb
+++ b/build-ci.rb
@@ -48,70 +48,6 @@ class Project
     end
   end
 
-  private
-
-  # Check if current bundle is already usable
-  #
-  # @return [Boolean]
-  def bundle_check
-    system(%W[bundle check --path=#{VENDOR_BUNDLE}])
-  end
-
-  # Install the current bundle
-  #
-  # @return [Boolean]
-  #   the success of the installation
-  def bundle_install
-    system(%W[
-      bundle
-      install
-      --path=#{VENDOR_BUNDLE}
-      --jobs=#{BUNDLER_JOBS}
-      --retry=#{BUNDLER_RETRIES}
-    ])
-  end
-
-  # Setup the test app
-  #
-  # @return [undefined]
-  def setup_test_app
-    system(%w[bundle exec rake test_app]) || fail('Failed to setup the test app')
-  end
-
-  # Run tests for subproject
-  #
-  # @return [Boolean]
-  #   the success of the tests
-  def run_tests
-    system(%w[bundle exec rspec] + rspec_arguments)
-  end
-
-  def rspec_arguments
-    args = []
-    args += %w[--format documentation --profile 10]
-    if report_dir = ENV['CIRCLE_TEST_REPORTS']
-      args += %W[-r rspec_junit_formatter --format RspecJunitFormatter -o #{report_dir}/rspec/#{name}.xml]
-    end
-    args
-  end
-
-  # Execute system command via execve
-  #
-  # No shell interpolation gets done this way. No escapes needed.
-  #
-  # @return [Boolean]
-  #   the success of the system command
-  def system(arguments)
-    Kernel.system(*arguments)
-  end
-
-  # Change to subproject directory and execute block
-  #
-  # @return [undefined]
-  def chdir(&block)
-    Dir.chdir(ROOT.join(name), &block)
-  end
-
   # Install subprojects
   #
   # @return [self]
@@ -188,6 +124,70 @@ class Project
     else
       fail "Unknown mode: #{mode.inspect}"
     end
+  end
+
+  private
+
+  # Check if current bundle is already usable
+  #
+  # @return [Boolean]
+  def bundle_check
+    system(%W[bundle check --path=#{VENDOR_BUNDLE}])
+  end
+
+  # Install the current bundle
+  #
+  # @return [Boolean]
+  #   the success of the installation
+  def bundle_install
+    system(%W[
+      bundle
+      install
+      --path=#{VENDOR_BUNDLE}
+      --jobs=#{BUNDLER_JOBS}
+      --retry=#{BUNDLER_RETRIES}
+    ])
+  end
+
+  # Setup the test app
+  #
+  # @return [undefined]
+  def setup_test_app
+    system(%w[bundle exec rake test_app]) || fail('Failed to setup the test app')
+  end
+
+  # Run tests for subproject
+  #
+  # @return [Boolean]
+  #   the success of the tests
+  def run_tests
+    system(%w[bundle exec rspec] + rspec_arguments)
+  end
+
+  def rspec_arguments
+    args = []
+    args += %w[--format documentation --profile 10]
+    if report_dir = ENV['CIRCLE_TEST_REPORTS']
+      args += %W[-r rspec_junit_formatter --format RspecJunitFormatter -o #{report_dir}/rspec/#{name}.xml]
+    end
+    args
+  end
+
+  # Execute system command via execve
+  #
+  # No shell interpolation gets done this way. No escapes needed.
+  #
+  # @return [Boolean]
+  #   the success of the system command
+  def system(arguments)
+    Kernel.system(*arguments)
+  end
+
+  # Change to subproject directory and execute block
+  #
+  # @return [undefined]
+  def chdir(&block)
+    Dir.chdir(ROOT.join(name), &block)
   end
 end # Project
 

--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -60,7 +60,7 @@ module Spree
 
       flash.each do |msg_type, text|
         unless ignore_types.include?(msg_type)
-          concat(content_tag :div, text, class: "flash #{msg_type}")
+          concat(content_tag(:div, text, class: "flash #{msg_type}"))
         end
       end
       nil

--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -174,12 +174,10 @@ module Spree
         if product.images.empty?
           if !product.is_a?(Spree::Variant) && !product.variant_images.empty?
             create_product_image_tag(product.variant_images.first, product, options, style)
+          elsif product.is_a?(Variant) && !product.product.variant_images.empty?
+            create_product_image_tag(product.product.variant_images.first, product, options, style)
           else
-            if product.is_a?(Variant) && !product.product.variant_images.empty?
-              create_product_image_tag(product.product.variant_images.first, product, options, style)
-            else
-              image_tag "noimage/#{style}.png", options
-            end
+            image_tag "noimage/#{style}.png", options
           end
         else
           create_product_image_tag(product.images.first, product, options, style)

--- a/core/app/helpers/spree/taxons_helper.rb
+++ b/core/app/helpers/spree/taxons_helper.rb
@@ -7,9 +7,9 @@ module Spree
       products = taxon.active_products.select("DISTINCT (spree_products.id), spree_products.*, spree_products_taxons.position").limit(max)
       if products.size < max
         products_arel = Spree::Product.arel_table
-        taxon.descendants.each do |taxon|
+        taxon.descendants.each do |descendent_taxon|
           to_get = max - products.length
-          products += taxon.active_products.select("DISTINCT (spree_products.id), spree_products.*, spree_products_taxons.position").where(products_arel[:id].not_in(products.map(&:id))).limit(to_get)
+          products += descendent_taxon.active_products.select("DISTINCT (spree_products.id), spree_products.*, spree_products_taxons.position").where(products_arel[:id].not_in(products.map(&:id))).limit(to_get)
           break if products.size >= max
         end
       end

--- a/core/app/mailers/spree/order_mailer.rb
+++ b/core/app/mailers/spree/order_mailer.rb
@@ -36,8 +36,8 @@ module Spree
     end
 
     def build_subject(subject_text, resend)
-      subject = (resend ? "[#{Spree.t(:resend).upcase}] " : '')
-      subject += "#{Spree::Store.current.name} #{subject_text} ##{@order.number}"
+      resend_text = (resend ? "[#{Spree.t(:resend).upcase}] " : '')
+      "#{resend_text}#{Spree::Store.current.name} #{subject_text} ##{@order.number}"
     end
   end
 end

--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -167,12 +167,10 @@ module Spree
       if state.present?
         if state.country == country
           self.state_name = nil # not required as we have a valid state and country combo
+        elsif state_name.present?
+          self.state = nil
         else
-          if state_name.present?
-            self.state = nil
-          else
-            errors.add(:state, :invalid)
-          end
+          errors.add(:state, :invalid)
         end
       end
 

--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -43,7 +43,7 @@ module Spree
     scope :tax, -> { where(source_type: 'Spree::TaxRate') }
     scope :non_tax, -> do
       source_type = arel_table[:source_type]
-      where(source_type.not_eq('Spree::TaxRate').or source_type.eq(nil))
+      where(source_type.not_eq('Spree::TaxRate').or(source_type.eq(nil)))
     end
     scope :price, -> { where(adjustable_type: 'Spree::LineItem') }
     scope :shipping, -> { where(adjustable_type: 'Spree::Shipment') }

--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -175,10 +175,6 @@ module Spree
       amount
     end
 
-    def currency
-      adjustable ? adjustable.currency : Spree::Config[:currency]
-    end
-
     private
 
     def update_adjustable_adjustment_total

--- a/core/app/models/spree/calculator/percent_per_item.rb
+++ b/core/app/models/spree/calculator/percent_per_item.rb
@@ -16,9 +16,9 @@ module Spree
 
     def compute(object = nil)
       return 0 if object.nil?
-      object.line_items.reduce(0) do |sum, line_item|
-        sum += value_for_line_item(line_item)
-      end
+      object.line_items.map { |line_item|
+        value_for_line_item(line_item)
+      }.sum
     end
 
     private

--- a/core/app/models/spree/calculator/returns/default_refund_amount.rb
+++ b/core/app/models/spree/calculator/returns/default_refund_amount.rb
@@ -23,9 +23,9 @@ module Spree
       end
 
       def percentage_of_order_total(inventory_unit)
-       return 0.0 if inventory_unit.order.pre_tax_item_amount.zero?
-       weighted_line_item_pre_tax_amount(inventory_unit) / inventory_unit.order.pre_tax_item_amount
-     end
+        return 0.0 if inventory_unit.order.pre_tax_item_amount.zero?
+        weighted_line_item_pre_tax_amount(inventory_unit) / inventory_unit.order.pre_tax_item_amount
+      end
 
       def percentage_of_line_item(inventory_unit)
         1 / BigDecimal.new(inventory_unit.line_item.quantity)

--- a/core/app/models/spree/calculator/tiered_flat_rate.rb
+++ b/core/app/models/spree/calculator/tiered_flat_rate.rb
@@ -19,7 +19,7 @@ module Spree
     end
 
     def compute(object)
-      base, amount = preferred_tiers.sort.reverse.detect{ |b, _| object.amount >= b }
+      _base, amount = preferred_tiers.sort.reverse.detect{ |b, _| object.amount >= b }
       amount || preferred_base_amount
     end
 

--- a/core/app/models/spree/calculator/tiered_percent.rb
+++ b/core/app/models/spree/calculator/tiered_percent.rb
@@ -24,7 +24,7 @@ module Spree
 
     def compute(object)
       order = object.is_a?(Order) ? object : object.order
-      base, percent = preferred_tiers.sort.reverse.detect{ |b, _| order.item_total >= b }
+      _base, percent = preferred_tiers.sort.reverse.detect{ |b, _| order.item_total >= b }
       (object.amount * (percent || preferred_base_percent) / 100).round(2)
     end
 

--- a/core/app/models/spree/gateway.rb
+++ b/core/app/models/spree/gateway.rb
@@ -58,13 +58,11 @@ module Spree
 
     def reusable_sources(order)
       if order.completed?
-        sources_by_order order
+        sources_by_order(order)
+      elsif order.user_id
+        credit_cards.where(user_id: order.user_id).with_payment_profile
       else
-        if order.user_id
-          credit_cards.where(user_id: order.user_id).with_payment_profile
-        else
-          []
-        end
+        []
       end
     end
   end

--- a/core/app/models/spree/item_adjustments.rb
+++ b/core/app/models/spree/item_adjustments.rb
@@ -49,7 +49,7 @@ module Spree
       #
       # We want to select the best promotion for the order, but the remainder
       # of the calculations here are done in the OrderUpdater instead.
-      return if Spree::Order === item
+      return if item.is_a?(Spree::Order)
 
       @item.promo_total = promo_total
 

--- a/core/app/models/spree/legacy_user.rb
+++ b/core/app/models/spree/legacy_user.rb
@@ -8,11 +8,6 @@ module Spree
 
     self.table_name = 'spree_users'
 
-    # for url generation
-    def self.model_name
-      ActiveModel::Name.new(self, nil, "User")
-    end
-
     before_destroy :check_completed_orders
 
     def self.model_name

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -154,7 +154,7 @@ module Spree
 
     # For compatiblity with Calculator::PriceSack
     def amount
-      line_items.inject(0.0) { |sum, li| sum + li.amount }
+      line_items.map(&:amount).sum
     end
 
     # Sum of all line item amounts pre-tax

--- a/core/app/models/spree/order_capturing.rb
+++ b/core/app/models/spree/order_capturing.rb
@@ -44,8 +44,9 @@ class Spree::OrderCapturing
   private
 
   def sorted_payments(order)
-    payments = order.payments.pending
-    payments = payments.sort_by { |p| [@sorted_payment_method_classes.index(p.payment_method.class), p.id] }
+    order.payments.pending.sort_by do |p|
+      [@sorted_payment_method_classes.index(p.payment_method.class), p.id]
+    end
   end
 end
 

--- a/core/app/models/spree/order_inventory.rb
+++ b/core/app/models/spree/order_inventory.rb
@@ -57,7 +57,7 @@ module Spree
         shipment.ready_or_pending? && shipment.include?(variant)
       end
 
-      shipment ||= order.shipments.detect do |shipment|
+      shipment || order.shipments.detect do |shipment|
         shipment.ready_or_pending? && variant.stock_location_ids.include?(shipment.stock_location_id)
       end
     end

--- a/core/app/models/spree/order_shipping.rb
+++ b/core/app/models/spree/order_shipping.rb
@@ -46,7 +46,7 @@ class Spree::OrderShipping
     carton = nil
 
     Spree::InventoryUnit.transaction do
-      inventory_units.each &:ship!
+      inventory_units.each(&:ship!)
 
       carton = Spree::Carton.create!(
         stock_location: stock_location,

--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -59,7 +59,7 @@ module Spree
     end
 
     def update_payment_total
-      order.payment_total = payments.completed.includes(:refunds).inject(0) { |sum, payment| sum + payment.amount - payment.refunds.sum(:amount) }
+      order.payment_total = payments.completed.includes(:refunds).map { |payment| payment.amount - payment.refunds.sum(:amount) }.sum
     end
 
     def update_shipment_total

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -262,9 +262,10 @@ WARN
     # and this is it. Related to https://github.com/spree/spree/issues/1998.
     # See https://github.com/spree/spree/issues/1998#issuecomment-12869105
     def set_unique_identifier
-      begin
+      loop do
         self.number = generate_identifier
-      end while self.class.exists?(number: number)
+        break unless self.class.exists?(number: number)
+      end
     end
 
     def generate_identifier

--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -121,7 +121,7 @@ module Spree
 
       def process_purchase
         started_processing!
-        result = gateway_action(source, :purchase, :complete)
+        gateway_action(source, :purchase, :complete)
         # This won't be called if gateway_action raises a GatewayError
         capture_events.create!(amount: amount)
       end

--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -25,12 +25,10 @@ module Spree
 
         if payment_method.auto_capture?
           purchase!
+        elsif pending?
+          # do nothing. already authorized.
         else
-          if pending?
-            # do nothing. already authorized.
-          else
-            authorize!
-          end
+          authorize!
         end
       end
 

--- a/core/app/models/spree/payment_method/store_credit.rb
+++ b/core/app/models/spree/payment_method/store_credit.rb
@@ -12,8 +12,8 @@ module Spree
       payment.pending?
     end
 
-    def authorize(amount_in_cents, store_credit, gateway_options = {})
-      if store_credit.nil?
+    def authorize(amount_in_cents, provided_store_credit, gateway_options = {})
+      if provided_store_credit.nil?
         ActiveMerchant::Billing::Response.new(false, Spree.t('store_credit.unable_to_find'), {}, {})
       else
         action = -> (store_credit) {
@@ -23,7 +23,7 @@ module Spree
             action_originator: gateway_options[:originator]
           )
         }
-        handle_action_call(store_credit, action, :authorize)
+        handle_action_call(provided_store_credit, action, :authorize)
       end
     end
 

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -355,7 +355,7 @@ module Spree
 
     def remove_taxon(taxon)
       removed_classifications = classifications.where(taxon: taxon)
-      removed_classifications.each &:remove_from_list
+      removed_classifications.each(&:remove_from_list)
     end
   end
 end

--- a/core/app/models/spree/product/scopes.rb
+++ b/core/app/models/spree/product/scopes.rb
@@ -11,9 +11,9 @@ module Spree
 
     def self.property_conditions(property)
       properties = Property.table_name
-      conditions = case property
-                   when String   then { "#{properties}.name" => property }
-                   when Property then { "#{properties}.id" => property.id }
+      case property
+      when String   then { "#{properties}.name" => property }
+      when Property then { "#{properties}.id" => property.id }
       else { "#{properties}.id" => property.to_i }
       end
     end

--- a/core/app/models/spree/promotion/rules/taxon.rb
+++ b/core/app/models/spree/promotion/rules/taxon.rb
@@ -49,7 +49,7 @@ module Spree
 
         # ids of taxons rules and taxons rules children
         def taxons_including_children_ids
-          taxons.inject([]){ |ids, taxon| ids += taxon.self_and_descendants.ids }
+          taxons.flat_map { |taxon| taxon.self_and_descendants.ids }
         end
 
         # taxons order vs taxons rules and taxons rules children
@@ -58,7 +58,7 @@ module Spree
         end
 
         def taxons_in_order_including_parents(order)
-          order_taxons_in_taxons_and_children(order).inject([]){ |taxons, taxon| taxons << taxon.self_and_ancestors }.flatten.uniq
+          order_taxons_in_taxons_and_children(order).flat_map(&:self_and_ancestors).uniq
         end
 
         def taxon_product_ids

--- a/core/app/models/spree/promotion_code/code_builder.rb
+++ b/core/app/models/spree/promotion_code/code_builder.rb
@@ -37,7 +37,7 @@ class ::Spree::PromotionCode::CodeBuilder
     valid_codes = Set.new
 
     while valid_codes.size < num_codes
-      new_codes = num_codes.times.map { generate_random_code }.to_set
+      new_codes = Array.new(num_codes) { generate_random_code }.to_set
       valid_codes += get_unique_codes(new_codes)
     end
 

--- a/core/app/models/spree/promotion_handler/coupon.rb
+++ b/core/app/models/spree/promotion_handler/coupon.rb
@@ -12,12 +12,10 @@ module Spree
         if order.coupon_code.present?
           if promotion.present? && promotion.actions.exists?
             handle_present_promotion(promotion)
+          elsif promotion_code && promotion_code.promotion.expired?
+            set_error_code :coupon_code_expired
           else
-            if promotion_code && promotion_code.promotion.expired?
-              set_error_code :coupon_code_expired
-            else
-              set_error_code :coupon_code_not_found
-            end
+            set_error_code :coupon_code_not_found
           end
         end
 
@@ -103,15 +101,13 @@ module Spree
           order.update_totals
           order.persist_totals
           set_success_code :coupon_code_applied
-        else
+        elsif order.promotions.with_coupon_code(order.coupon_code)
           # if the promotion exists on an order, but wasn't found above,
           # we've already selected a better promotion
-          if order.promotions.with_coupon_code(order.coupon_code)
-            set_error_code :coupon_code_better_exists
-          else
-            # if the promotion was created after the order
-            set_error_code :coupon_code_not_found
-          end
+          set_error_code :coupon_code_better_exists
+        else
+          # if the promotion was created after the order
+          set_error_code :coupon_code_not_found
         end
       end
     end

--- a/core/app/models/spree/reimbursement_type/credit.rb
+++ b/core/app/models/spree/reimbursement_type/credit.rb
@@ -5,7 +5,7 @@ module Spree
     class << self
       def reimburse(reimbursement, return_items, simulate)
         unpaid_amount = return_items.sum(&:total).round(2, :down)
-        reimbursement_list, unpaid_amount = create_credits(reimbursement, unpaid_amount, simulate)
+        reimbursement_list, _unpaid_amount = create_credits(reimbursement, unpaid_amount, simulate)
         reimbursement_list
       end
     end

--- a/core/app/models/spree/reimbursement_type/original_payment.rb
+++ b/core/app/models/spree/reimbursement_type/original_payment.rb
@@ -6,7 +6,7 @@ class Spree::ReimbursementType::OriginalPayment < Spree::ReimbursementType
       unpaid_amount = return_items.sum(&:total).round(2, :down)
       payments = reimbursement.order.payments.completed
 
-      refund_list, unpaid_amount = create_refunds(reimbursement, payments, unpaid_amount, simulate)
+      refund_list, _unpaid_amount = create_refunds(reimbursement, payments, unpaid_amount, simulate)
       refund_list
     end
   end

--- a/core/app/models/spree/reimbursement_type/store_credit.rb
+++ b/core/app/models/spree/reimbursement_type/store_credit.rb
@@ -12,7 +12,7 @@ class Spree::ReimbursementType::StoreCredit < Spree::ReimbursementType
 
       # If there is any amount left to pay out to the customer, then create credit with that amount
       if unpaid_amount > 0.0
-        reimbursement_list, unpaid_amount = create_credits(reimbursement, unpaid_amount, simulate, reimbursement_list)
+        reimbursement_list, _unpaid_amount = create_credits(reimbursement, unpaid_amount, simulate, reimbursement_list)
       end
 
       reimbursement_list

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -350,9 +350,6 @@ module Spree
     end
 
     def transfer_to_shipment(variant, quantity, shipment_to_transfer_to)
-      quantity_already_shipment_to_transfer_to = shipment_to_transfer_to.manifest.find{ |mi| mi.line_item.variant == variant }.try(:quantity) || 0
-      final_quantity = quantity + quantity_already_shipment_to_transfer_to
-
       if quantity <= 0 || self == shipment_to_transfer_to
         raise ArgumentError
       end

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -217,7 +217,7 @@ module Spree
     def determine_state(order)
       return 'canceled' if order.canceled?
       return 'pending' unless order.can_ship?
-      return 'pending' if inventory_units.any? &:backordered?
+      return 'pending' if inventory_units.any?(&:backordered?)
       return 'shipped' if state == 'shipped'
       if order.paid? || !Spree::Config[:require_payment_to_ship]
         'ready'

--- a/core/app/models/spree/stock/coordinator.rb
+++ b/core/app/models/spree/stock/coordinator.rb
@@ -99,13 +99,11 @@ module Spree
         # build the final lookup hash of
         #   {<stock location> => <set of variant ids>, ...}
         # using the previous results
-        hash = location_variant_ids.each_with_object({}) do |(location_id, variant_id), hash|
+        location_variant_ids.each_with_object({}) do |(location_id, variant_id), hash|
           location = location_lookup[location_id]
           hash[location] ||= Set.new
           hash[location] << variant_id
         end
-
-        hash
       end
 
       def unallocated_inventory_units

--- a/core/app/models/spree/stock/inventory_unit_builder.rb
+++ b/core/app/models/spree/stock/inventory_unit_builder.rb
@@ -7,7 +7,7 @@ module Spree
 
       def units
         @order.line_items.flat_map do |line_item|
-          line_item.quantity.times.map do |_i|
+          Array.new(line_item.quantity) do |_i|
             @order.inventory_units.build(
               pending: true,
               variant: line_item.variant,

--- a/core/app/models/spree/taxon.rb
+++ b/core/app/models/spree/taxon.rb
@@ -49,7 +49,7 @@ module Spree
     # @return [String] meta_title if set otherwise a string containing the
     #   root name and taxon name
     def seo_title
-      unless meta_title.blank?
+      if meta_title.present?
         meta_title
       else
         root? ? name : "#{root.name} - #{name}"

--- a/core/app/models/spree/taxon.rb
+++ b/core/app/models/spree/taxon.rb
@@ -91,10 +91,9 @@ module Spree
     # @return [String] this taxon's ancestors names followed by its own name,
     #   separated by arrows
     def pretty_name
-      ancestor_chain = ancestors.inject("") do |name, ancestor|
-        name += "#{ancestor.name} -> "
-      end
-      ancestor_chain + name.to_s
+      ancestor_chain = ancestors.map(&:name)
+      ancestor_chain << name
+      ancestor_chain.join(" -> ")
     end
 
     # @see https://github.com/spree/spree/issues/3390

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -182,7 +182,7 @@ module Spree
 
       current_value = option_values.detect { |o| o.option_type.name == opt_name }
 
-      unless current_value.nil?
+      if current_value
         return if current_value.name == opt_value
         option_values.delete(current_value)
       else

--- a/core/app/models/spree/variant/scopes.rb
+++ b/core/app/models/spree/variant/scopes.rb
@@ -22,7 +22,7 @@ module Spree
 
         relation = joins(option_values: :option_type).where(option_type_conditions)
 
-        option_values_conditions = option_values.each do |option_value|
+        option_values.each do |option_value|
           option_value_conditions = case option_value
                                     when OptionValue then { "#{OptionValue.table_name}.name" => option_value.name }
                                     when String      then { "#{OptionValue.table_name}.name" => option_value }

--- a/core/app/models/spree/zone.rb
+++ b/core/app/models/spree/zone.rb
@@ -145,11 +145,10 @@ module Spree
       return false if zone_members.empty? || target.zone_members.empty?
 
       if kind == target.kind
-        return false if (target.zoneables.collect(&:id) - zoneables.collect(&:id)).present?
+        (target.zoneables.collect(&:id) - zoneables.collect(&:id)).empty?
       else
-        return false if (target.zoneables.collect(&:country).collect(&:id) - zoneables.collect(&:id)).present?
+        (target.zoneables.collect(&:country).collect(&:id) - zoneables.collect(&:id)).empty?
       end
-      true
     end
 
     private

--- a/core/db/migrate/20130319064308_change_spree_return_authorization_amount_precision.rb
+++ b/core/db/migrate/20130319064308_change_spree_return_authorization_amount_precision.rb
@@ -1,5 +1,5 @@
 class ChangeSpreeReturnAuthorizationAmountPrecision < ActiveRecord::Migration
-   def change
+  def change
     change_column :spree_return_authorizations, :amount, :decimal, precision: 10, scale: 2, default: 0.0, null: false
   end
 end

--- a/core/db/migrate/20130830001159_migrate_old_shipping_calculators.rb
+++ b/core/db/migrate/20130830001159_migrate_old_shipping_calculators.rb
@@ -3,7 +3,7 @@ class MigrateOldShippingCalculators < ActiveRecord::Migration
     Spree::ShippingMethod.all.each do |shipping_method|
       old_calculator = shipping_method.calculator
       next if old_calculator.class < Spree::ShippingCalculator # We don't want to mess with new shipping calculators
-      new_calculator = eval(old_calculator.class.name.sub("::Calculator::", "::Calculator::Shipping::")).new
+      new_calculator = old_calculator.class.name.sub("::Calculator::", "::Calculator::Shipping::").constantize
       new_calculator.preferences.keys.each do |pref|
         # Preferences can't be read/set by name, you have to prefix preferred_
         pref_method = "preferred_#{pref}"

--- a/core/lib/generators/spree/install/install_generator.rb
+++ b/core/lib/generators/spree/install/install_generator.rb
@@ -141,7 +141,7 @@ Spree::Auth::Engine.load_seed if defined?(Spree::Auth)
 
         cmd = lambda { rake("db:seed #{rake_options.join(' ')}") }
         if options[:auto_accept] || (options[:admin_email] && options[:admin_password])
-          quietly &cmd
+          quietly(&cmd)
         else
           cmd.call
         end

--- a/core/lib/spree/core/controller_helpers/auth.rb
+++ b/core/lib/spree/core/controller_helpers/auth.rb
@@ -22,7 +22,7 @@ module Spree
           end
 
           rescue_from CanCan::AccessDenied do
-            instance_exec &unauthorized_redirect
+            instance_exec(&unauthorized_redirect)
           end
         end
 

--- a/core/lib/spree/core/controller_helpers/common.rb
+++ b/core/lib/spree/core/controller_helpers/common.rb
@@ -64,7 +64,7 @@ module Spree
           # Default layout is: +app/views/spree/layouts/spree_application+
           #
           def get_layout
-            layout ||= Spree::Config[:layout]
+            Spree::Config[:layout]
           end
         end
       end

--- a/core/lib/spree/core/controller_helpers/strong_parameters.rb
+++ b/core/lib/spree/core/controller_helpers/strong_parameters.rb
@@ -6,9 +6,9 @@ module Spree
           Spree::PermittedAttributes
         end
 
-        delegate *Spree::PermittedAttributes::ATTRIBUTES,
+        delegate(*Spree::PermittedAttributes::ATTRIBUTES,
                  to: :permitted_attributes,
-                 prefix: :permitted
+                 prefix: :permitted)
 
         def permitted_credit_card_update_attributes
           permitted_attributes.credit_card_update_attributes + [

--- a/core/lib/spree/core/importer/order.rb
+++ b/core/lib/spree/core/importer/order.rb
@@ -50,7 +50,6 @@ module Spree
         def self.create_shipments_from_params(shipments_hash, order)
           return [] unless shipments_hash
 
-          line_items = order.line_items
           shipments_hash.each do |s|
             shipment = Shipment.new
             shipment.tracking       = s[:tracking]

--- a/core/lib/spree/core/importer/product.rb
+++ b/core/lib/spree/core/importer/product.rb
@@ -47,9 +47,9 @@ module Spree
 
         def set_up_options
           options_attrs.each do |name|
-            option_type = Spree::OptionType.where(name: name).first_or_initialize do |option_type|
-              option_type.presentation = name
-              option_type.save!
+            option_type = Spree::OptionType.where(name: name).first_or_initialize do |ot|
+              ot.presentation = name
+              ot.save!
             end
 
             unless product.option_types.include?(option_type)

--- a/core/lib/spree/localized_number.rb
+++ b/core/lib/spree/localized_number.rb
@@ -10,7 +10,9 @@ module Spree
     def self.parse(number)
       return number unless number.is_a?(String)
 
-      separator, delimiter = I18n.t([:'number.currency.format.separator', :'number.currency.format.delimiter'])
+      # I18n.t('number.currency.format.delimiter') could be useful here, but is
+      # unnecessary as it is stripped by the non_number_characters gsub.
+      separator = I18n.t(:'number.currency.format.separator')
       non_number_characters = /[^0-9\-#{separator}]/
 
       # strip everything else first

--- a/core/lib/spree/money.rb
+++ b/core/lib/spree/money.rb
@@ -65,8 +65,8 @@ module Spree
     # Delegates comparison to the internal ruby money instance.
     #
     # @see http://www.rubydoc.info/gems/money/Money/Arithmetic#%3D%3D-instance_method
-    def ==(obj)
-      @money == obj.money
+    def ==(other)
+      @money == other.money
     end
   end
 end

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -32,7 +32,7 @@ module Spree
       :variant_attributes
     ]
 
-    mattr_reader *ATTRIBUTES
+    mattr_reader(*ATTRIBUTES)
 
     @@address_attributes = [
       :id, :firstname, :lastname, :first_name, :last_name,

--- a/core/lib/spree/testing_support/capybara_ext.rb
+++ b/core/lib/spree/testing_support/capybara_ext.rb
@@ -66,7 +66,6 @@ module CapybaraExt
     raise "Must pass a hash containing 'from'" if !options.is_a?(Hash) || !options.key?(:from)
 
     placeholder = options[:from]
-    minlength = options[:minlength] || 4
 
     click_link placeholder
 

--- a/core/lib/spree/testing_support/common_rake.rb
+++ b/core/lib/spree/testing_support/common_rake.rb
@@ -8,7 +8,7 @@ desc "Generates a dummy app for testing"
 namespace :common do
   task :test_app, :user_class do |_t, args|
     args.with_defaults(user_class: "Spree::LegacyUser")
-    require (ENV['LIB_NAME']).to_s
+    require ENV['LIB_NAME']
 
     ENV["RAILS_ENV"] = 'test'
 

--- a/core/lib/spree/testing_support/factories/zone_factory.rb
+++ b/core/lib/spree/testing_support/factories/zone_factory.rb
@@ -8,7 +8,7 @@ FactoryGirl.define do
     zone_members do |proxy|
       zone = proxy.instance_eval { @instance }
       Spree::Country.all.map do |c|
-        zone_member = Spree::ZoneMember.create(zoneable: c, zone: zone)
+        Spree::ZoneMember.create(zoneable: c, zone: zone)
       end
     end
   end

--- a/core/lib/spree/testing_support/order_walkthrough.rb
+++ b/core/lib/spree/testing_support/order_walkthrough.rb
@@ -32,8 +32,8 @@ class OrderWalkthrough
                           states[0..end_state_position]
                         end
 
-    states_to_process.each do |state|
-      send(state, order)
+    states_to_process.each do |state_to_process|
+      send(state_to_process, order)
     end
 
     order

--- a/core/lib/tasks/core.rake
+++ b/core/lib/tasks/core.rake
@@ -18,7 +18,6 @@ use rake db:load_file[/absolute/path/to/sample/filename.rb]'
 
     ruby_files = {}
     Dir.glob(File.join(dir, '**/*.{rb}')).each do |fixture_file|
-      ext = File.extname fixture_file
       ruby_files[File.basename(fixture_file, '.*')] = fixture_file
     end
     ruby_files.sort.each do |fixture, ruby_file|

--- a/core/spec/helpers/products_helper_spec.rb
+++ b/core/spec/helpers/products_helper_spec.rb
@@ -142,7 +142,7 @@ THIS IS THE BEST PRODUCT EVER!
       end
 
       it "renders a product description without any formatting based on configuration" do
-        initialDescription = %{
+        description = %{
             <p>hello world</p>
 
             <p>tihs is completely awesome and it works</p>
@@ -150,11 +150,11 @@ THIS IS THE BEST PRODUCT EVER!
             <p>why so many spaces in the code. and why some more formatting afterwards?</p>
         }
 
-        product.description = initialDescription
+        product.description = description
 
         Spree::Config[:show_raw_product_description] = true
         description = product_description(product)
-        expect(description).to eq(initialDescription)
+        expect(description).to eq(description)
       end
     end
 

--- a/core/spec/lib/search/base_spec.rb
+++ b/core/spec/lib/search/base_spec.rb
@@ -76,7 +76,7 @@ describe Spree::Core::Search::Base do
   end
 
   it "finds products in alternate currencies" do
-    price = create(:price, currency: 'EUR', variant: @product1.master)
+    create(:price, currency: 'EUR', variant: @product1.master)
     searcher = Spree::Core::Search::Base.new({})
     searcher.current_currency = 'EUR'
     expect(searcher.retrieve_products).to eq([@product1])

--- a/core/spec/lib/spree/core/importer/order_spec.rb
+++ b/core/spec/lib/spree/core/importer/order_spec.rb
@@ -122,7 +122,7 @@ module Spree
         params = { line_items_attributes: line_items }
 
         expect {
-          order = Importer::Order.import(user, params)
+          Importer::Order.import(user, params)
         }.to raise_error /Validation failed/
       end
 
@@ -191,8 +191,10 @@ module Spree
 
       context "state passed is not associated with country" do
         let(:params) do
-          params = { ship_address_attributes: ship_address,
-                     line_items_attributes: line_items }
+          {
+            ship_address_attributes: ship_address,
+            line_items_attributes: line_items
+          }
         end
 
         let(:other_state) { create(:state, name: "Uhuhuh", country: create(:country)) }
@@ -273,7 +275,7 @@ module Spree
 
         it 'ensures variant exists and is not deleted' do
           expect(Importer::Order).to receive(:ensure_variant_id_from_params).and_call_original
-          order = Importer::Order.import(user, params)
+          Importer::Order.import(user, params)
         end
 
         it 'builds them properly' do
@@ -300,7 +302,7 @@ module Spree
         it "raises if cant find stock location" do
           params[:shipments_attributes][0][:stock_location] = "doesnt exist"
           expect {
-            order = Importer::Order.import(user, params)
+            Importer::Order.import(user, params)
           }.to raise_error ActiveRecord::RecordNotFound
         end
 
@@ -415,7 +417,7 @@ module Spree
                                             }] }
 
         expect {
-          order = Importer::Order.import(user, params)
+          Importer::Order.import(user, params)
         }.to raise_error /Validation failed: Credit card Month is not a number, Credit card Year is not a number/
       end
 
@@ -424,7 +426,7 @@ module Spree
           params = { payments_attributes: [{ payment_method: "XXX" }] }
           count = Order.count
 
-          expect { order = Importer::Order.import(user, params) }.to raise_error ActiveRecord::RecordNotFound
+          expect { Importer::Order.import(user, params) }.to raise_error ActiveRecord::RecordNotFound
           expect(Order.count).to eq count
         end
       end

--- a/core/spec/lib/spree/core/importer/order_spec.rb
+++ b/core/spec/lib/spree/core/importer/order_spec.rb
@@ -349,7 +349,7 @@ module Spree
         order = Importer::Order.import(user, params)
         expect(order.adjustments.all?(&:finalized?)).to be true
         expect(order.adjustments.first.label).to eq 'Shipping Discount'
-        expect(order.adjustments.first.amount).to eq -4.99
+        expect(order.adjustments.first.amount).to eq(-4.99)
       end
 
       it "calculates final order total correctly" do

--- a/core/spec/lib/spree/core/role_configuration_spec.rb
+++ b/core/spec/lib/spree/core/role_configuration_spec.rb
@@ -139,7 +139,7 @@ describe Spree::RoleConfiguration do
 
         it "doesn't activate non matching roles" do
           subject
-          expect(ability.can? :manage, :things).to be false
+          expect(ability.can?(:manage, :things)).to be false
         end
       end
     end
@@ -149,7 +149,7 @@ describe Spree::RoleConfiguration do
 
       it "doesnt activate any new permissions" do
         subject
-        expect(ability.can? :manage, :things).to be false
+        expect(ability.can?(:manage, :things)).to be false
       end
     end
   end

--- a/core/spec/lib/spree/core/testing_support/factories/customer_return_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/customer_return_factory_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'customer return factory' do
     let(:factory) { :customer_return_without_return_items }
 
     it "builds successfully" do
-      expect(build factory).to be_a(factory_class)
+      expect(build(factory)).to be_a(factory_class)
     end
 
     # No create test, because this factory is (intentionally) invalid

--- a/core/spec/lib/spree/core/testing_support/factories/shipping_method_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/shipping_method_factory_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'shipping method factory' do
     let(:factory) { :base_shipping_method }
 
     it 'builds successfully' do
-      expect(build factory).to be_a(factory_class)
+      expect(build(factory)).to be_a(factory_class)
     end
 
     # No test for create, as that is not intended somehow

--- a/core/spec/lib/spree/core/testing_support/factories/stock_package_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/stock_package_factory_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'stock package factory' do
     let(:factory) { :stock_package }
 
     it "builds successfully" do
-      expect(build factory).to be_a(factory_class)
+      expect(build(factory)).to be_a(factory_class)
     end
 
     # No test for .create, as it's a PORO
@@ -18,7 +18,7 @@ RSpec.describe 'stock package factory' do
     let(:factory) { :stock_package_fulfilled }
 
     it "builds successfully" do
-      expect(build factory).to be_a(factory_class)
+      expect(build(factory)).to be_a(factory_class)
     end
 
     # No test for .create, as it's a PORO

--- a/core/spec/lib/spree/core/testing_support/factories/stock_packer_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/stock_packer_factory_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'stock packer factory' do
     let(:factory) { :stock_packer }
 
     it "builds successfully" do
-      expect(build factory).to be_a(factory_class)
+      expect(build(factory)).to be_a(factory_class)
     end
 
     # No test for .create, as it's a PORO

--- a/core/spec/lib/spree/core/testing_support/factories/store_credit_event_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/store_credit_event_factory_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'store credit event factory' do
     let(:factory) { :store_credit_event }
 
     it "builds successfully" do
-      expect(build factory).to be_a(factory_class)
+      expect(build(factory)).to be_a(factory_class)
     end
 
     # No test for .create, as this base factory misses an `action`

--- a/core/spec/lib/spree/migrations_spec.rb
+++ b/core/spec/lib/spree/migrations_spec.rb
@@ -28,7 +28,7 @@ module Spree
     context "no missing migrations" do
       it "says nothing" do
         expect(Dir).to receive(:entries).with(engine_dir).and_return engine_migrations
-        expect(Dir).to receive(:entries).with(app_dir).and_return (app_migrations + engine_migrations)
+        expect(Dir).to receive(:entries).with(app_dir).and_return(app_migrations + engine_migrations)
         expect(subject.check).to eq nil
       end
     end

--- a/core/spec/lib/tasks/exchanges_spec.rb
+++ b/core/spec/lib/tasks/exchanges_spec.rb
@@ -39,7 +39,7 @@ describe "exchanges:charge_unreturned_items" do
       Spree::Shipment.last.ship!
       return_item_1.lost!
       return_item_2.give!
-      Timecop.travel (Spree::Config[:expedited_exchanges_days_window] + 1).days
+      Timecop.travel((Spree::Config[:expedited_exchanges_days_window] + 1).days)
     end
     after { Timecop.return }
     it { expect { subject.invoke }.not_to change { Spree::Order.count } }

--- a/core/spec/models/spree/calculator/refunds/default_refund_amount_spec.rb
+++ b/core/spec/models/spree/calculator/refunds/default_refund_amount_spec.rb
@@ -35,7 +35,7 @@ describe Spree::Calculator::Returns::DefaultRefundAmount, type: :model do
         order.adjustments.first.update_attributes(amount: adjustment_amount)
       end
 
-      it { is_expected.to eq (pre_tax_amount - adjustment_amount.abs) / line_item_quantity }
+      it { is_expected.to eq((pre_tax_amount - adjustment_amount.abs) / line_item_quantity) }
     end
 
     context "shipping adjustments" do

--- a/core/spec/models/spree/credit_card_spec.rb
+++ b/core/spec/models/spree/credit_card_spec.rb
@@ -155,7 +155,7 @@ describe Spree::CreditCard, type: :model do
     end
 
     it "should not raise an exception on non-string input" do
-      credit_card.number = Hash.new
+      credit_card.number = {}
       expect(credit_card.number).to be_nil
     end
   end

--- a/core/spec/models/spree/customer_return_spec.rb
+++ b/core/spec/models/spree/customer_return_spec.rb
@@ -84,7 +84,7 @@ describe Spree::CustomerReturn, type: :model do
     subject { customer_return.total }
 
     it "returns the sum of the return item's total amount" do
-      expect(subject).to eq ((pre_tax_amount * 2) + (tax_amount * 2))
+      expect(subject).to eq((pre_tax_amount * 2) + (tax_amount * 2))
     end
   end
 
@@ -108,7 +108,7 @@ describe Spree::CustomerReturn, type: :model do
     subject { customer_return.pre_tax_total }
 
     it "returns the sum of the return item's pre_tax_amount" do
-      expect(subject).to eq (pre_tax_amount * 2)
+      expect(subject).to eq(pre_tax_amount * 2)
     end
   end
 

--- a/core/spec/models/spree/item_adjustments_spec.rb
+++ b/core/spec/models/spree/item_adjustments_spec.rb
@@ -10,7 +10,7 @@ module Spree
     context '#update' do
       it "updates a linked adjustment" do
         tax_rate = create(:tax_rate, amount: 0.05)
-        adjustment = create(:adjustment, order: order, source: tax_rate, adjustable: line_item)
+        create(:adjustment, order: order, source: tax_rate, adjustable: line_item)
         line_item.price = 10
         line_item.tax_category = tax_rate.tax_category
 

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -166,7 +166,7 @@ describe Spree::Order, type: :model do
       before do
         order.state = 'address'
         order.ship_address = ship_address
-        shipment = FactoryGirl.create(:shipment, order: order, cost: 10)
+        FactoryGirl.create(:shipment, order: order, cost: 10)
         order.email = "user@example.com"
         order.save!
       end
@@ -620,7 +620,7 @@ describe Spree::Order, type: :model do
       let(:order) { create(:order_with_line_items) }
 
       it 'can complete the order' do
-        payment = create(:payment, state: 'completed', order: order, amount: order.total)
+        create(:payment, state: 'completed', order: order, amount: order.total)
         order.update!
         expect(order.complete).to eq(true)
       end

--- a/core/spec/models/spree/order/payment_spec.rb
+++ b/core/spec/models/spree/order/payment_spec.rb
@@ -198,7 +198,7 @@ module Spree
           before { order.update_attributes(state: 'canceled') }
 
           it "it should be a negative amount incorporating reimbursements" do
-            expect(order.outstanding_balance).to eq -10
+            expect(order.outstanding_balance).to eq(-10)
           end
         end
 

--- a/core/spec/models/spree/order_cancellations_spec.rb
+++ b/core/spec/models/spree/order_cancellations_spec.rb
@@ -153,7 +153,7 @@ describe Spree::OrderCancellations do
       it "generates the correct total amount" do
         order.cancellations.short_ship([inventory_unit_1])
         order.cancellations.short_ship([inventory_unit_2])
-        expect(line_item.adjustments.non_tax.sum(:amount)).to eq -1.67
+        expect(line_item.adjustments.non_tax.sum(:amount)).to eq(-1.67)
         expect(line_item.total).to eq 0
       end
     end

--- a/core/spec/models/spree/order_contents_spec.rb
+++ b/core/spec/models/spree/order_contents_spec.rb
@@ -117,7 +117,7 @@ describe Spree::OrderContents, type: :model do
 
     context 'given a shipment' do
       it "ensure shipment calls update_amounts instead of order calling ensure_updated_shipments" do
-        line_item = subject.add(variant, 1)
+        subject.add(variant, 1)
         shipment = create(:shipment)
         expect(subject.order).to_not receive(:ensure_updated_shipments)
         expect(shipment).to receive(:update_amounts)
@@ -127,7 +127,7 @@ describe Spree::OrderContents, type: :model do
 
     context 'not given a shipment' do
       it "ensures updated shipments" do
-        line_item = subject.add(variant, 1)
+        subject.add(variant, 1)
         expect(subject.order).to receive(:ensure_updated_shipments)
         subject.remove(variant)
       end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -1001,7 +1001,7 @@ describe Spree::Order, type: :model do
         subject { order }
 
         it "returns the sum of the payment amounts" do
-          expect(subject.total_applicable_store_credit).to eq (payment.amount + second_payment.amount)
+          expect(subject.total_applicable_store_credit).to eq(payment.amount + second_payment.amount)
         end
       end
 
@@ -1225,7 +1225,7 @@ describe Spree::Order, type: :model do
         let(:applicable_store_credit) { 10.0 }
 
         it "deducts the applicable store credit" do
-          expect(subject.order_total_after_store_credit).to eq (order_total - applicable_store_credit)
+          expect(subject.order_total_after_store_credit).to eq(order_total - applicable_store_credit)
         end
       end
 
@@ -1309,7 +1309,7 @@ describe Spree::Order, type: :model do
       end
 
       it "returns a negative amount" do
-        expect(subject.display_total_applicable_store_credit.money.cents).to eq (total_applicable_store_credit * -100.0)
+        expect(subject.display_total_applicable_store_credit.money.cents).to eq(total_applicable_store_credit * -100.0)
       end
     end
 
@@ -1325,7 +1325,7 @@ describe Spree::Order, type: :model do
       end
 
       it "returns the order_total_after_store_credit amount" do
-        expect(subject.display_order_total_after_store_credit.money.cents).to eq (order_total_after_store_credit * 100.0)
+        expect(subject.display_order_total_after_store_credit.money.cents).to eq(order_total_after_store_credit * 100.0)
       end
     end
 
@@ -1341,7 +1341,7 @@ describe Spree::Order, type: :model do
       end
 
       it "returns the total_available_store_credit amount" do
-        expect(subject.display_total_available_store_credit.money.cents).to eq (total_available_store_credit * 100.0)
+        expect(subject.display_total_available_store_credit.money.cents).to eq(total_available_store_credit * 100.0)
       end
     end
 
@@ -1362,7 +1362,7 @@ describe Spree::Order, type: :model do
 
       it "returns all of the user's available store credit minus what's applied to the order amount" do
         amount_remaining = total_available_store_credit - total_applicable_store_credit
-        expect(subject.display_store_credit_remaining_after_capture.money.cents).to eq (amount_remaining * 100.0)
+        expect(subject.display_store_credit_remaining_after_capture.money.cents).to eq(amount_remaining * 100.0)
       end
     end
 

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -710,7 +710,7 @@ describe Spree::Payment, type: :model do
       context "when successfully connecting to the gateway" do
         it "should create a payment profile" do
           expect(payment.payment_method).to receive :create_profile
-          payment = Spree::Payment.create(
+          Spree::Payment.create(
             amount: 100,
             order: order,
             source: card,
@@ -725,7 +725,7 @@ describe Spree::Payment, type: :model do
 
       it "should not create a payment profile" do
         expect(gateway).not_to receive :create_profile
-        payment = Spree::Payment.create(
+        Spree::Payment.create(
           amount: 100,
           order: order,
           source: card,

--- a/core/spec/models/spree/product_filter_spec.rb
+++ b/core/spec/models/spree/product_filter_spec.rb
@@ -6,7 +6,7 @@ describe 'product filters', type: :model do
   context 'finds products filtered by brand' do
     let(:product) { create(:product) }
     before do
-      property = Spree::Property.create!(name: "brand", presentation: "brand")
+      Spree::Property.create!(name: "brand", presentation: "brand")
       product.set_property("brand", "Nike")
     end
 

--- a/core/spec/models/spree/promotion/actions/create_quantity_adjustments_spec.rb
+++ b/core/spec/models/spree/promotion/actions/create_quantity_adjustments_spec.rb
@@ -28,15 +28,15 @@ module Spree::Promotion::Actions
           end
           context "and an item with a quantity of 2" do
             let(:quantity) { 2 }
-            it { is_expected.to eq -10 }
+            it { is_expected.to eq(-10) }
           end
           context "and an item with a quantity of 3" do
             let(:quantity) { 3 }
-            it { is_expected.to eq -10 }
+            it { is_expected.to eq(-10) }
           end
           context "and an item with a quantity of 4" do
             let(:quantity) { 4 }
-            it { is_expected.to eq -20 }
+            it { is_expected.to eq(-20) }
           end
         end
 
@@ -49,11 +49,11 @@ module Spree::Promotion::Actions
             before { action.perform({ order: order, promotion: promotion }) }
             describe "the adjustment for the first item" do
               let(:line_item) { item_a }
-              it { is_expected.to eq -10 }
+              it { is_expected.to eq(-10) }
             end
             describe "the adjustment for the second item" do
               let(:line_item) { item_b }
-              it { is_expected.to eq -5 }
+              it { is_expected.to eq(-5) }
             end
             describe "the adjustment for the third item" do
               let(:line_item) { item_c }
@@ -71,7 +71,7 @@ module Spree::Promotion::Actions
             FactoryGirl.create :line_item, order: other_order, quantity: 3
             action.perform({ order: other_order, promotion: promotion })
           end
-          it { is_expected.to eq -10 }
+          it { is_expected.to eq(-10) }
         end
       end
 
@@ -88,11 +88,11 @@ module Spree::Promotion::Actions
             let!(:item_b) { FactoryGirl.create :line_item, order: order, quantity: 1, price: 10 }
             describe "the adjustment for the first item" do
               let(:line_item) { item_a }
-              it { is_expected.to eq -2 }
+              it { is_expected.to eq(-2) }
             end
             describe "the adjustment for the second item" do
               let(:line_item) { item_b }
-              it { is_expected.to eq -1 }
+              it { is_expected.to eq(-1) }
             end
           end
 
@@ -101,7 +101,7 @@ module Spree::Promotion::Actions
             let!(:item_b) { FactoryGirl.create :line_item, order: order, quantity: 1, price: 20 }
             describe "the adjustment for the first item" do
               let(:line_item) { item_a }
-              it { is_expected.to eq -3 }
+              it { is_expected.to eq(-3) }
             end
             describe "the adjustment for the second item" do
               let(:line_item) { item_b }

--- a/core/spec/models/spree/promotion_code/code_builder_spec.rb
+++ b/core/spec/models/spree/promotion_code/code_builder_spec.rb
@@ -39,7 +39,7 @@ describe Spree::PromotionCode::CodeBuilder do
 
       it "builds codes with the same base prefix" do
         subject
-        values = builder.promotion.codes.map &:value
+        values = builder.promotion.codes.map(&:value)
         expect(values.all? { |val| val.starts_with?("#{base_code}_") }).to be true
       end
 

--- a/core/spec/models/spree/promotion_handler/coupon_spec.rb
+++ b/core/spec/models/spree/promotion_handler/coupon_spec.rb
@@ -134,7 +134,7 @@ module Spree
               allow(order).to receive_messages coupon_code: "10off"
               calculator = Calculator::FlatRate.new(preferred_amount: 10)
               general_promo = create(:promotion, name: "General Promo")
-              general_action = Promotion::Actions::CreateItemAdjustments.create(promotion: general_promo, calculator: calculator)
+              Promotion::Actions::CreateItemAdjustments.create(promotion: general_promo, calculator: calculator)
 
               order.contents.add create(:variant)
             end

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -768,13 +768,13 @@ describe Spree::Promotion, type: :model do
       order.update!
 
       expect(line_item.adjustments.size).to eq(1)
-      expect(order.adjustment_total).to eq -5
+      expect(order.adjustment_total).to eq(-5)
 
       other_line_item = order.contents.add(variant, 1, currency: order.currency)
 
       expect(other_line_item).not_to eq line_item
       expect(other_line_item.adjustments.size).to eq(1)
-      expect(order.adjustment_total).to eq -10
+      expect(order.adjustment_total).to eq(-10)
     end
   end
 end

--- a/core/spec/models/spree/reimbursement_spec.rb
+++ b/core/spec/models/spree/reimbursement_spec.rb
@@ -121,8 +121,8 @@ describe Spree::Reimbursement, type: :model do
         return_item.reload
         expect(return_item.included_tax_total).to be > 0
         expect(return_item.included_tax_total).to eq line_item.included_tax_total
-        expect(reimbursement.total).to eq (line_item.pre_tax_amount + line_item.included_tax_total).round(2, :down)
-        expect(Spree::Refund.last.amount).to eq (line_item.pre_tax_amount + line_item.included_tax_total).round(2, :down)
+        expect(reimbursement.total).to eq((line_item.pre_tax_amount + line_item.included_tax_total).round(2, :down))
+        expect(Spree::Refund.last.amount).to eq((line_item.pre_tax_amount + line_item.included_tax_total).round(2, :down))
       end
     end
 

--- a/core/spec/models/spree/reimbursement_type/original_payment_spec.rb
+++ b/core/spec/models/spree/reimbursement_type/original_payment_spec.rb
@@ -43,7 +43,7 @@ module Spree
 
       context 'when a payment is negative' do
         before do
-          expect_any_instance_of(Spree::Payment).to receive(:amount).and_return -100
+          expect_any_instance_of(Spree::Payment).to receive(:amount).and_return(-100)
         end
 
         it 'returns an empty array' do

--- a/core/spec/models/spree/return_authorization_spec.rb
+++ b/core/spec/models/spree/return_authorization_spec.rb
@@ -151,7 +151,7 @@ describe Spree::ReturnAuthorization, type: :model do
     subject { return_authorization.pre_tax_total }
 
     it "sums it's associated return_item's pre-tax amounts" do
-      expect(subject).to eq (pre_tax_amount_1 + pre_tax_amount_2 + pre_tax_amount_3)
+      expect(subject).to eq(pre_tax_amount_1 + pre_tax_amount_2 + pre_tax_amount_3)
     end
   end
 
@@ -192,14 +192,14 @@ describe Spree::ReturnAuthorization, type: :model do
     context "no promotions" do
       let(:promo_total) { 0.0 }
       it "returns the pre-tax line item total" do
-        expect(subject).to eq (weighted_line_item_pre_tax_amount * line_item_count)
+        expect(subject).to eq(weighted_line_item_pre_tax_amount * line_item_count)
       end
     end
 
     context "promotions" do
       let(:promo_total) { -10.0 }
       it "returns the pre-tax line item total minus the order level promotion value" do
-        expect(subject).to eq (weighted_line_item_pre_tax_amount * line_item_count) + promo_total
+        expect(subject).to eq((weighted_line_item_pre_tax_amount * line_item_count) + promo_total)
       end
     end
   end

--- a/core/spec/models/spree/return_item/exchange_variant_eligibility/same_product_spec.rb
+++ b/core/spec/models/spree/return_item/exchange_variant_eligibility/same_product_spec.rb
@@ -15,7 +15,7 @@ module Spree
 
         context "product has variants" do
           it "returns all variants for the same product" do
-            product = create(:product, variants: 3.times.map { create(:variant) })
+            product = create(:product, variants: Array.new(3) { create(:variant) })
             product.variants.map { |v| v.stock_items.first.update_column(:count_on_hand, 10) }
 
             expect(SameProduct.eligible_variants(product.variants.first).sort).to eq product.variants.sort
@@ -29,7 +29,7 @@ module Spree
         end
 
         it "only returns variants that are on hand" do
-          product = create(:product, variants: 2.times.map { create(:variant) })
+          product = create(:product, variants: Array.new(2) { create(:variant) })
           in_stock_variant = product.variants.first
 
           in_stock_variant.stock_items.first.update_column(:count_on_hand, 10)

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -653,7 +653,7 @@ describe Spree::Shipment, type: :model do
 
     it "associates variant and order" do
       expect(inventory_units).to receive(:create).with(params)
-      unit = shipment.set_up_inventory('on_hand', variant, order, line_item)
+      shipment.set_up_inventory('on_hand', variant, order, line_item)
     end
   end
 

--- a/core/spec/models/spree/stock/estimator_spec.rb
+++ b/core/spec/models/spree/stock/estimator_spec.rb
@@ -71,7 +71,7 @@ module Spree
         end
 
         it "sorts shipping rates by cost" do
-          shipping_methods = 3.times.map { create(:shipping_method) }
+          shipping_methods = Array.new(3) { create(:shipping_method) }
           allow(shipping_methods[0]).to receive_message_chain(:calculator, :compute).and_return(5.00)
           allow(shipping_methods[1]).to receive_message_chain(:calculator, :compute).and_return(3.00)
           allow(shipping_methods[2]).to receive_message_chain(:calculator, :compute).and_return(4.00)
@@ -82,7 +82,7 @@ module Spree
         end
 
         context "general shipping methods" do
-          let(:shipping_methods) { 2.times.map { create(:shipping_method) } }
+          let(:shipping_methods) { Array.new(2) { create(:shipping_method) } }
 
           it "selects the most affordable shipping rate" do
             allow(shipping_methods[0]).to receive_message_chain(:calculator, :compute).and_return(5.00)

--- a/core/spec/models/spree/stock/packer_spec.rb
+++ b/core/spec/models/spree/stock/packer_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 module Spree
   module Stock
     describe Packer, type: :model do
-      let!(:inventory_units) { 5.times.map { build(:inventory_unit) } }
+      let!(:inventory_units) { Array.new(5) { build(:inventory_unit) } }
       let(:stock_location) { create(:stock_location) }
 
       subject { Packer.new(stock_location, inventory_units) }
@@ -63,7 +63,7 @@ module Spree
           let(:order) { build(:order_with_line_items, line_items_count: 1) }
           let(:line_item) { order.line_items.first }
           let(:inventory_units) {
-            30.times.map do
+            Array.new(30) do
               build(
                 :inventory_unit,
                 order: order,

--- a/core/spec/models/spree/store_credit_spec.rb
+++ b/core/spec/models/spree/store_credit_spec.rb
@@ -165,7 +165,7 @@ describe Spree::StoreCredit do
         before { store_credit.update_attributes(amount_authorized: authorized_amount) }
 
         it "subtracts the authorized amount from the credited amount" do
-          expect(store_credit.amount_remaining).to eq (store_credit.amount - authorized_amount)
+          expect(store_credit.amount_remaining).to eq(store_credit.amount - authorized_amount)
         end
       end
     end
@@ -177,7 +177,7 @@ describe Spree::StoreCredit do
 
       context "the authorized amount is not defined" do
         it "subtracts the amount used from the credited amount" do
-          expect(store_credit.amount_remaining).to eq (store_credit.amount - amount_used)
+          expect(store_credit.amount_remaining).to eq(store_credit.amount - amount_used)
         end
       end
 
@@ -187,7 +187,7 @@ describe Spree::StoreCredit do
         before { store_credit.update_attributes(amount_authorized: authorized_amount) }
 
         it "subtracts the amount used and the authorized amount from the credited amount" do
-          expect(store_credit.amount_remaining).to eq (store_credit.amount - amount_used - authorized_amount)
+          expect(store_credit.amount_remaining).to eq(store_credit.amount - amount_used - authorized_amount)
         end
       end
     end
@@ -208,7 +208,7 @@ describe Spree::StoreCredit do
 
         it "adds the new amount to authorized amount" do
           store_credit.authorize(added_authorization_amount, store_credit.currency)
-          expect(store_credit.reload.amount_authorized).to eq (authorization_amount + added_authorization_amount)
+          expect(store_credit.reload.amount_authorized).to eq(authorization_amount + added_authorization_amount)
         end
 
         context "originator is present" do
@@ -555,7 +555,7 @@ describe Spree::StoreCredit do
 
         it "credits the passed amount to the store credit amount used" do
           subject
-          expect(store_credit.reload.amount_used).to eq (amount_used - credit_amount)
+          expect(store_credit.reload.amount_used).to eq(amount_used - credit_amount)
         end
 
         it "creates a new store credit event" do
@@ -767,7 +767,7 @@ describe Spree::StoreCredit do
           subject { create(:store_credit, user: user, amount: additional_store_credit_amount) }
 
           it "saves the user's total store credit in the event" do
-            expect(subject.store_credit_events.first.user_total_amount).to eq (store_credit_amount + additional_store_credit_amount)
+            expect(subject.store_credit_events.first.user_total_amount).to eq(store_credit_amount + additional_store_credit_amount)
           end
         end
 

--- a/core/spec/models/spree/store_credit_spec.rb
+++ b/core/spec/models/spree/store_credit_spec.rb
@@ -805,7 +805,7 @@ describe Spree::StoreCredit do
 
       it "sets the adjustment amount on the store credit event correctly" do
         subject
-        expect(store_credit.store_credit_events.find_by(action: Spree::StoreCredit::ADJUSTMENT_ACTION).amount).to eq -20
+        expect(store_credit.store_credit_events.find_by(action: Spree::StoreCredit::ADJUSTMENT_ACTION).amount).to eq(-20)
       end
 
       it "sets the originator on the store credit event correctly" do

--- a/core/spec/models/spree/unit_cancel_spec.rb
+++ b/core/spec/models/spree/unit_cancel_spec.rb
@@ -12,7 +12,7 @@ describe Spree::UnitCancel do
 
       adjustment = Spree::Adjustment.last
       expect(adjustment.adjustable).to eq inventory_unit.line_item
-      expect(adjustment.amount).to eq -10.0
+      expect(adjustment.amount).to eq(-10.0)
       expect(adjustment.order).to eq inventory_unit.order
       expect(adjustment.label).to eq "Cancellation - Short Ship"
       expect(adjustment).to be_eligible
@@ -36,7 +36,7 @@ describe Spree::UnitCancel do
 
     context "all inventory on the line item are not canceled" do
       it "divides the line item total by the inventory units size" do
-        expect(subject).to eq -5.0
+        expect(subject).to eq(-5.0)
       end
     end
 
@@ -44,7 +44,7 @@ describe Spree::UnitCancel do
       before { inventory_unit2.cancel! }
 
       it "divides the line item total by the uncanceled units size" do
-        expect(subject).to eq -10.0
+        expect(subject).to eq(-10.0)
       end
     end
 

--- a/core/spec/models/spree/user_spec.rb
+++ b/core/spec/models/spree/user_spec.rb
@@ -128,7 +128,7 @@ describe Spree.user_class, type: :model do
       context "with orders" do
         before { load_orders }
         it "returns the total of completed orders for the user" do
-          expect(subject.lifetime_value).to eq (order_count * order_value)
+          expect(subject.lifetime_value).to eq(order_count * order_value)
         end
       end
       context "without orders" do
@@ -206,13 +206,13 @@ describe Spree.user_class, type: :model do
           before { additional_store_credit.update_attributes(amount_authorized: authorized_amount) }
 
           it "returns sum of amounts minus used amount and authorized amount" do
-            expect(subject.total_available_store_credit.to_f).to eq (amount + additional_amount - amount_used - authorized_amount)
+            expect(subject.total_available_store_credit.to_f).to eq(amount + additional_amount - amount_used - authorized_amount)
           end
         end
 
         context "there are no authorized amounts on any of the store credits" do
           it "returns sum of amounts minus used amount" do
-            expect(subject.total_available_store_credit.to_f).to eq (amount + additional_amount - amount_used)
+            expect(subject.total_available_store_credit.to_f).to eq(amount + additional_amount - amount_used)
           end
         end
       end
@@ -224,20 +224,20 @@ describe Spree.user_class, type: :model do
           before { additional_store_credit.update_attributes(amount_authorized: authorized_amount) }
 
           it "returns sum of amounts minus authorized amount" do
-            expect(subject.total_available_store_credit.to_f).to eq (amount + additional_amount - authorized_amount)
+            expect(subject.total_available_store_credit.to_f).to eq(amount + additional_amount - authorized_amount)
           end
         end
 
         context "there are no authorized amounts on any of the store credits" do
           it "returns sum of amounts" do
-            expect(subject.total_available_store_credit.to_f).to eq (amount + additional_amount)
+            expect(subject.total_available_store_credit.to_f).to eq(amount + additional_amount)
           end
         end
       end
 
       context "all store credits have never been used or authorized" do
         it "returns sum of amounts" do
-          expect(subject.total_available_store_credit.to_f).to eq (amount + additional_amount)
+          expect(subject.total_available_store_credit.to_f).to eq(amount + additional_amount)
         end
       end
     end

--- a/core/spec/models/spree/user_spec.rb
+++ b/core/spec/models/spree/user_spec.rb
@@ -5,7 +5,7 @@ describe Spree::LegacyUser, type: :model do
     let!(:user) { create(:user) }
 
     it "excludes orders that are not frontend_viewable" do
-      order = create(:order, user: user, frontend_viewable: false)
+      create(:order, user: user, frontend_viewable: false)
       expect(user.last_incomplete_spree_order).to eq nil
     end
 
@@ -17,18 +17,18 @@ describe Spree::LegacyUser, type: :model do
     it "can scope to a store" do
       store = create(:store)
       store_1_order = create(:order, user: user, store: store)
-      store_2_order = create(:order, user: user, store: create(:store))
+      create(:order, user: user, store: create(:store))
       expect(user.last_incomplete_spree_order(store: store)).to eq store_1_order
     end
 
     it "excludes completed orders" do
-      order = create(:completed_order_with_totals, user: user, created_by: user)
+      create(:completed_order_with_totals, user: user, created_by: user)
       expect(user.last_incomplete_spree_order).to eq nil
     end
 
     it "excludes orders created prior to the user's last completed order" do
-      incomplete_order = create(:order, user: user, created_by: user, created_at: 1.second.ago)
-      completed_order = create(:completed_order_with_totals, user: user, created_by: user)
+      create(:order, user: user, created_by: user, created_at: 1.second.ago)
+      create(:completed_order_with_totals, user: user, created_by: user)
       expect(user.last_incomplete_spree_order).to eq nil
     end
 
@@ -41,7 +41,7 @@ describe Spree::LegacyUser, type: :model do
       after { Spree::Config.completable_order_created_cutoff_days = @original_order_cutoff_preference }
 
       it "excludes orders updated outside of the cutoff date" do
-        incomplete_order = create(:order, user: user, created_by: user, created_at: 3.days.ago, updated_at: 2.days.ago)
+        create(:order, user: user, created_by: user, created_at: 3.days.ago, updated_at: 2.days.ago)
         expect(user.last_incomplete_spree_order).to eq nil
       end
     end
@@ -55,13 +55,13 @@ describe Spree::LegacyUser, type: :model do
       after { Spree::Config.completable_order_updated_cutoff_days = @original_order_cutoff_preference }
 
       it "excludes orders updated outside of the cutoff date" do
-        incomplete_order = create(:order, user: user, created_by: user, created_at: 3.days.ago, updated_at: 2.days.ago)
+        create(:order, user: user, created_by: user, created_at: 3.days.ago, updated_at: 2.days.ago)
         expect(user.last_incomplete_spree_order).to eq nil
       end
     end
 
     it "chooses the most recently created incomplete order" do
-      order_1 = create(:order, user: user, created_at: 1.second.ago)
+      create(:order, user: user, created_at: 1.second.ago)
       order_2 = create(:order, user: user)
       expect(user.last_incomplete_spree_order).to eq order_2
     end

--- a/core/spec/models/spree/variant/scopes_spec.rb
+++ b/core/spec/models/spree/variant/scopes_spec.rb
@@ -48,7 +48,8 @@ describe "Variant scopes", type: :model do
     end
 
     it "by mixed conditions" do
-      product_variants.has_option(option_type.id, "foo", option_value_2)
+      variants = product_variants.has_option(option_type.id, "foo", option_value_2)
+      expect(variants).to be_empty
     end
   end
 end

--- a/core/spec/models/spree/variant/scopes_spec.rb
+++ b/core/spec/models/spree/variant/scopes_spec.rb
@@ -48,7 +48,7 @@ describe "Variant scopes", type: :model do
     end
 
     it "by mixed conditions" do
-      variants = product_variants.has_option(option_type.id, "foo", option_value_2)
+      product_variants.has_option(option_type.id, "foo", option_value_2)
     end
   end
 end

--- a/core/spec/models/spree/zone_spec.rb
+++ b/core/spec/models/spree/zone_spec.rb
@@ -50,7 +50,7 @@ describe Spree::Zone, type: :model do
     let(:country) do
       country = create(:country)
       # Create at least one state for this country
-      state = create(:state, country: country)
+      create(:state, country: country)
       country
     end
 
@@ -159,7 +159,7 @@ describe Spree::Zone, type: :model do
       before { @foo_zone = create(:zone, name: 'whatever', default_tax: true) }
 
       it "should be the correct zone" do
-        foo_zone = create(:zone, name: 'foo')
+        create(:zone, name: 'foo')
         expect(Spree::Zone.default_tax).to eq(@foo_zone)
       end
     end
@@ -312,7 +312,7 @@ describe Spree::Zone, type: :model do
     context "when default_tax is true" do
       it "should clear previous default tax zone" do
         zone1 = create(:zone, name: 'foo', default_tax: true)
-        zone = create(:zone, name: 'bar', default_tax: true)
+        create(:zone, name: 'bar', default_tax: true)
         expect(zone1.reload.default_tax).to be false
       end
     end

--- a/core/spec/support/concerns/working_factories.rb
+++ b/core/spec/support/concerns/working_factories.rb
@@ -1,9 +1,9 @@
 RSpec.shared_examples_for 'a working factory' do
   it "builds successfully" do
-    expect(build factory).to be_a(factory_class)
+    expect(build(factory)).to be_a(factory_class)
   end
 
   it "creates successfully" do
-    expect(create factory).to be_a(factory_class)
+    expect(create(factory)).to be_a(factory_class)
   end
 end

--- a/frontend/app/controllers/spree/store_controller.rb
+++ b/frontend/app/controllers/spree/store_controller.rb
@@ -39,7 +39,7 @@ module Spree
 
     def lock_order
       OrderMutex.with_lock!(@order) { yield }
-    rescue Spree::OrderMutex::LockFailed => e
+    rescue Spree::OrderMutex::LockFailed
       flash[:error] = Spree.t(:order_mutex_error)
       redirect_to spree.cart_path
     end

--- a/frontend/spec/features/checkout_spec.rb
+++ b/frontend/spec/features/checkout_spec.rb
@@ -199,7 +199,7 @@ describe "Checkout", type: :feature, inaccessible: true do
     end
 
     it "selects first source available and customer moves on" do
-      expect(find "#use_existing_card_yes").to be_checked
+      expect(find("#use_existing_card_yes")).to be_checked
 
       expect {
         click_on "Save and Continue"


### PR DESCRIPTION
This fixes most of the remaining rubocop warnings that remained after the autocorrection.

Many of these offenses were not just rubocop warnings, but also ruby syntax warnings. This should mean that all files now pass `ruby -c -w`.

After this there are only 14 remaining offences, all of which to fix will need some minor behaviour change. To keep reviews simple, all changes made here should not effect behaviour.