### PR TITLE
Remove ShippingMethod.on_{frontend,backend}_query

### DIFF
--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -54,13 +54,5 @@ module Spree
         errors[:base] << "You need to select at least one shipping category"
       end
     end
-
-    def self.on_backend_query
-      "#{table_name}.display_on != 'front_end' OR #{table_name}.display_on IS NULL"
-    end
-
-    def self.on_frontend_query
-      "#{table_name}.display_on != 'back_end' OR #{table_name}.display_on IS NULL"
-    end
   end
 end


### PR DESCRIPTION
These were actually public methods, but were clearly intended to be private. They haven't been used as of 3ed7d00625d2e510a2a8fbb7c1a55582f534a7bb