### PR TITLE
Use attribute translations for country forms

### DIFF
--- a/backend/app/views/spree/admin/countries/_form.html.erb
+++ b/backend/app/views/spree/admin/countries/_form.html.erb
@@ -1,13 +1,13 @@
 <div data-hook="admin_country_form_fields" class="row">
   <div class="alpha four columns">
     <div data-hook="name" class="field">
-      <%= f.label :name, Spree.t(:name) %>
+      <%= f.label :name %>
       <%= f.text_field :name, :class => 'fullwidth' %>
     </div>
   </div>
   <div class="four columns">
     <div data-hook="iso_name" class="field">
-      <%= f.label :iso_name, Spree.t(:iso_name) %>
+      <%= f.label :iso_name %>
       <%= f.text_field :iso_name, :class => 'fullwidth' %>
     </div>
   </div>
@@ -15,7 +15,7 @@
     <div data-hook="states_required" class="field checkbox">
       <label>
         <%= f.check_box :states_required %>
-        <%= Spree.t(:states_required) %>
+        <%= Spree::Country.human_attribute_name(:states_required) %>
       </label>
     </div>
   </div>

--- a/backend/app/views/spree/admin/countries/index.html.erb
+++ b/backend/app/views/spree/admin/countries/index.html.erb
@@ -23,9 +23,9 @@
   </colgroup>
   <thead>
     <tr data-hook="tax_header">
-      <th><%= Spree.t(:country_name) %></th>
-      <th><%= Spree.t(:iso_name) %></th>
-      <th><%= Spree.t(:states_required) %></th>
+      <th><%= Spree::Country.human_attribute_name(:name) %></th>
+      <th><%= Spree::Country.human_attribute_name(:iso_name) %></th>
+      <th><%= Spree::Country.human_attribute_name(:states_required) %></th>
       <th class="actions"></th>
     </tr>
   </thead>

--- a/backend/spec/features/admin/configuration/countries_spec.rb
+++ b/backend/spec/features/admin/configuration/countries_spec.rb
@@ -9,7 +9,7 @@ module Spree
       click_link "New Country"
 
       fill_in "Name", with: "Brazil"
-      fill_in "Iso Name", with: "BRL"
+      fill_in "ISO Name", with: "BRL"
       click_button "Create"
 
       accept_alert do

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -23,6 +23,7 @@ en:
         iso_name: ISO Name
         name: Name
         numcode: ISO Code
+        states_required: States Required
       spree/credit_card:
         base: ''
         cc_type: Type


### PR DESCRIPTION
This is to better utilize I18n with more verbosity to make it clear and easier to translate. 

This is cherry-picked from #549 with a minor change to a spec that had been written to use an incorrect translation which was also removed (`iso_name: Iso Name`)

This is part of an ongoing chain of PRs to implement #549 as discussed in #735.  