### PR TITLE
Fix (very, very unlikely) spurious test failure

### DIFF
--- a/core/spec/models/spree/concerns/user_address_book_spec.rb
+++ b/core/spec/models/spree/concerns/user_address_book_spec.rb
@@ -238,7 +238,7 @@ module Spree
       end
 
       it "returns false if the addresses is not there" do
-        expect(user.remove_from_address_book(42)).to be false
+        expect(user.remove_from_address_book(0)).to be false
       end
     end
 


### PR DESCRIPTION
It is perfectly valid for to have an address book with id=42. This changes that magic value to 0, which is never a valid id.

Failure can be seen here https://circleci.com/gh/jhawthorn/solidus/594