### PR TITLE
Use <label class="required"> instead of extra span

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
@@ -85,6 +85,10 @@ label {
   &.block {
     display: block !important;
   }
+
+  &.required:after {
+    content: " *";
+  }
 }
 
 .label-block label { display: block }

--- a/backend/app/views/spree/admin/adjustment_reasons/shared/_form.html.erb
+++ b/backend/app/views/spree/admin/adjustment_reasons/shared/_form.html.erb
@@ -2,12 +2,12 @@
   <div class="row">
     <div class="alpha four columns">
       <%= f.field_container :name do %>
-        <%= f.label :name, Spree.t(:name) %> <span class="required">*</span><br />
+        <%= f.label :name, Spree.t(:name), class: 'required' %><br />
         <%= f.text_field :name, :class => 'fullwidth' %>
       <% end %>
 
       <%= f.field_container :code do %>
-        <%= f.label :code, Spree.t(:code) %> <span class="required">*</span><br />
+        <%= f.label :code, Spree.t(:code), class: 'required' %><br />
         <%= f.text_field :code, :class => 'fullwidth' %>
       <% end %>
 

--- a/backend/app/views/spree/admin/adjustments/_form.html.erb
+++ b/backend/app/views/spree/admin/adjustments/_form.html.erb
@@ -1,16 +1,16 @@
 <div data-hook="admin_adjustment_form_fields" class="row">
   <div class="alpha three columns">
     <%= f.field_container :amount do %>
-      <%= f.label :amount, raw(Spree.t(:amount) + content_tag(:span, " *", :class => "required")) %>
-      <%= text_field :adjustment, :amount, :class => 'fullwidth' %>
+      <%= f.label :amount, Spree.t(:amount), class: 'required' %>
+      <%= text_field :adjustment, :amount, class: 'fullwidth' %>
       <%= f.error_message_on :amount %>
     <% end %>
   </div>
 
   <div class="six columns">
     <%= f.field_container :label do %>
-      <%= f.label :label, raw(Spree.t(:description) + content_tag(:span, " *", :class => "required")) %>
-      <%= text_field :adjustment, :label, :class => 'fullwidth' %>
+      <%= f.label :label, Spree.t(:description), class: 'required' %>
+      <%= text_field :adjustment, :label, class: 'fullwidth' %>
       <%= f.error_message_on :label %>
     <% end %>
   </div>

--- a/backend/app/views/spree/admin/option_types/_form.html.erb
+++ b/backend/app/views/spree/admin/option_types/_form.html.erb
@@ -1,7 +1,7 @@
 <div data-hook="admin_option_type_form_fields" class="align-center row">
   <div class="alpha eight columns">
     <%= f.field_container :name do %>
-      <%= f.label :name, Spree.t(:name) %> <span class="required">*</span><br />
+      <%= f.label :name, Spree.t(:name), class: 'required' %><br />
       <%= f.text_field :name, :class => "fullwidth" %>
       <%= f.error_message_on :name %>
     <% end %>
@@ -9,7 +9,7 @@
 
   <div class="omega eight columns">
     <%= f.field_container :presentation do %>
-      <%= f.label :presentation, Spree.t(:presentation) %> <span class="required">*</span><br />
+      <%= f.label :presentation, Spree.t(:presentation), class: 'required' %><br />
       <%= f.text_field :presentation, :class => "fullwidth" %>
       <%= f.error_message_on :presentation %>
     <% end %>

--- a/backend/app/views/spree/admin/payments/source_forms/_gateway.html.erb
+++ b/backend/app/views/spree/admin/payments/source_forms/_gateway.html.erb
@@ -17,7 +17,7 @@
       <div data-hook="card_number">
         <div class="field">
           <%= hidden_field_tag "#{param_prefix}[cc_type]", '', {class: 'ccType'} %>
-          <%= label_tag "card_number#{payment_method.id}", raw(Spree.t(:card_number) + content_tag(:span, ' *', :class => 'required')) %>
+          <%= label_tag "card_number#{payment_method.id}", Spree.t(:card_number), class: 'required' %>
           <%= text_field_tag "#{param_prefix}[number]", '', :class => 'required fullwidth cardNumber', :id => "card_number#{payment_method.id}", :maxlength => 19 %>
           <span id="card_type" style="display:none;">
             ( <span id="looks_like" ><%= Spree.t(:card_type_is) %> <span id="type"></span></span>
@@ -30,20 +30,20 @@
     <div class="alpha four columns">
       <div data-hook="card_name">
         <div class="field">
-          <%= label_tag "card_name#{payment_method.id}", raw(Spree.t(:name) + content_tag(:span, ' *', :class => 'required')) %>
+          <%= label_tag "card_name#{payment_method.id}", Spree.t(:name), class: 'required' %>
           <%= text_field_tag "#{param_prefix}[name]", '', id: "card_name#{payment_method.id}", class: 'required fullwidth', maxlength: 19 %>
         </div>
       </div>
     </div>
     <div class="three columns">
       <div data-hook="card_expiration" class="field">
-        <%= label_tag "card_expiry#{payment_method.id}", raw(Spree.t(:expiration) + content_tag(:span, ' *', :class => 'required')) %><br>
+        <%= label_tag "card_expiry#{payment_method.id}", Spree.t(:expiration), class: 'required' %>
         <%= text_field_tag "#{param_prefix}[expiry]", '', id: "card_expiry#{payment_method.id}", class: "required cardExpiry", placeholder: "MM / YY" %>
       </div>
     </div>
     <div class="omega two columns">
       <div data-hook="card_code" class="field">
-        <%= label_tag "card_code#{payment_method.id}", raw(Spree.t(:card_code) + content_tag(:span, ' *', :class => "required")) %>
+        <%= label_tag "card_code#{payment_method.id}", Spree.t(:card_code), class: 'required' %>
         <%= text_field_tag "#{param_prefix}[verification_value]", '', id: "card_code#{payment_method.id}", class: 'required fullwidth cardCode', size: 5 %>
         <a href="/content/cvv" class="info cvvLink" target="_blank">
           (<%= Spree.t(:what_is_this) %>)

--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -3,7 +3,7 @@
   <div class="left eight columns alpha" data-hook="admin_product_form_left">
     <div data-hook="admin_product_form_name">
       <%= f.field_container :name do %>
-        <%= f.label :name, raw(Spree.t(:name) + content_tag(:span, ' *', :class => 'required')) %>
+        <%= f.label :name, Spree.t(:name), class: 'required' %>
         <%= f.text_field :name, :class => 'fullwidth title', :required => true %>
         <%= f.error_message_on :name %>
       <% end %>
@@ -11,7 +11,7 @@
 
     <div data-hook="admin_product_form_slug">
       <%= f.field_container :slug do %>
-        <%= f.label :slug, raw(Spree.t(:slug) + content_tag(:span, ' *',  :class => "required")) %>
+        <%= f.label :slug, Spree.t(:slug), class: 'required' %>
         <%= f.text_field :slug, :class => 'fullwidth title', :required => true %>
         <%= f.error_message_on :slug %>
       <% end %>
@@ -29,7 +29,7 @@
   <div class="right four columns omega" data-hook="admin_product_form_right">
     <div data-hook="admin_product_form_price">
     <%= f.field_container :price do %>
-      <%= f.label :price, raw(Spree.t(:master_price) + content_tag(:span, ' *', :class => "required")) %>
+      <%= f.label :price, Spree.t(:master_price), class: 'required' %>
       <%= f.text_field :price, :value => number_to_currency(@product.price, :unit => ''), :required => true %>
       <%= f.error_message_on :price %>
     <% end %>

--- a/backend/app/views/spree/admin/products/new.html.erb
+++ b/backend/app/views/spree/admin/products/new.html.erb
@@ -7,7 +7,7 @@
     <legend align="center"><%= Spree.t(:new_product) %></legend>
 
     <%= f.field_container :name do %>
-      <%= f.label :name, Spree.t(:name) %> <span class="required">*</span><br />
+      <%= f.label :name, Spree.t(:name), class: 'required' %><br />
       <%= f.text_field :name, :class => 'fullwidth title', :required => true %>
       <%= f.error_message_on :name %>
     <% end %>
@@ -32,7 +32,7 @@
 
       <div data-hook="new_product_price" class="four columns">
         <%= f.field_container :price do %>
-          <%= f.label :price, Spree.t(:master_price) %> <span class="required">*</span><br />
+          <%= f.label :price, Spree.t(:master_price), class: 'required' %><br />
           <%= f.text_field :price, :value => number_to_currency(@product.price, :unit => ''), :class => 'fullwidth', :required => true %>
           <%= f.error_message_on :price %>
         <% end %>
@@ -51,7 +51,7 @@
     <div class='row'>
       <div data-hook="new_product_shipping_category" class="alpha four columns">
         <%= f.field_container :shipping_category do %>
-          <%= f.label :shipping_category_id, Spree.t(:shipping_categories) %><span class="required">*</span><br />
+          <%= f.label :shipping_category_id, Spree.t(:shipping_categories), class: 'required' %><br />
           <%= f.collection_select(:shipping_category_id, @shipping_categories, :id, :name, { :include_blank => Spree.t('match_choices.none') }, { :class => 'select2 fullwidth', :required => true }) %>
           <%= f.error_message_on :shipping_category_id %>
         <% end %>

--- a/backend/app/views/spree/admin/properties/_form.html.erb
+++ b/backend/app/views/spree/admin/properties/_form.html.erb
@@ -1,14 +1,14 @@
 <div data-hook="admin_property_form" class="align-center row">
   <div class="alpha eight columns">
     <%= f.field_container :name do %>
-      <%= f.label :name, Spree.t(:name) %> <span class="required">*</span><br />
+      <%= f.label :name, Spree.t(:name), class: 'required' %><br />
       <%= f.text_field :name, :class => 'fullwidth' %>
       <%= f.error_message_on :name %>
     <% end %>
   </div>
   <div class="eight columns omega">
     <%= f.field_container :presentation do %>
-      <%= f.label :presentation, Spree.t(:presentation) %> <span class="required">*</span><br />
+      <%= f.label :presentation, Spree.t(:presentation), class: 'required' %><br />
       <%= f.text_field :presentation, :class => 'fullwidth' %>
       <%= f.error_message_on :presentation %>
     <% end %>

--- a/backend/app/views/spree/admin/prototypes/_form.html.erb
+++ b/backend/app/views/spree/admin/prototypes/_form.html.erb
@@ -1,7 +1,7 @@
 <div data-hook="admin_prototype_form_fields" class="row">
   <div class="alpha four columns">
     <%= f.field_container :name do %>
-      <%= f.label :name, Spree.t(:name) %> <span class="required">*</span><br />
+      <%= f.label :name, Spree.t(:name), class: 'required' %><br />
       <%= f.text_field :name, class: 'fullwidth' %>
       <%= f.error_message_on :name %>
     <% end %>

--- a/backend/app/views/spree/admin/refund_reasons/shared/_form.html.erb
+++ b/backend/app/views/spree/admin/refund_reasons/shared/_form.html.erb
@@ -2,12 +2,12 @@
   <div class="row">
     <div class="alpha four columns">
       <%= f.field_container :name do %>
-        <%= f.label :name, Spree.t(:name) %> <span class="required">*</span><br />
+        <%= f.label :name, Spree.t(:name), class: 'required' %><br />
         <%= f.text_field :name, :class => 'fullwidth' %>
       <% end %>
 
       <%= f.field_container :code do %>
-        <%= f.label :code, Spree.t(:code) %> <span class="required">*</span><br />
+        <%= f.label :code, Spree.t(:code), class: 'required' %><br />
         <%= f.text_field :code, :class => 'fullwidth' %>
 
       <% end %>

--- a/backend/app/views/spree/admin/shared/named_types/_form.html.erb
+++ b/backend/app/views/spree/admin/shared/named_types/_form.html.erb
@@ -2,7 +2,7 @@
   <div class="row">
     <div class="alpha four columns">
       <%= f.field_container :name do %>
-        <%= f.label :name, Spree.t(:name) %> <span class="required">*</span><br />
+        <%= f.label :name, Spree.t(:name), class: 'required' %><br />
         <%= f.text_field :name, :class => 'fullwidth' %>
       <% end %>
       <div class="checkbox">

--- a/backend/app/views/spree/admin/stock_locations/_form.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/_form.html.erb
@@ -2,7 +2,7 @@
   <div class="alpha nine columns" data-hook="stock_location_names">
     <div data-hook="stock_location_name">
       <%= f.field_container :name do %>
-        <%= f.label :name, Spree.t(:name) %> <span class="required">*</span><br />
+        <%= f.label :name, Spree.t(:name), class: 'required' %><br />
         <%= f.text_field :name, class: 'fullwidth', required: true %>
       <% end %>
     </div>

--- a/backend/app/views/spree/admin/store_credits/_form.html.erb
+++ b/backend/app/views/spree/admin/store_credits/_form.html.erb
@@ -1,14 +1,14 @@
 <div data-hook="admin_store_credit_form_fields" class="row">
   <div class="alpha twelve columns">
     <%= f.field_container :amount do %>
-      <%= f.label :amount, Spree.t(:amount) %> <span class="required">*</span><br />
+      <%= f.label :amount, Spree.t(:amount), class: 'required' %><br />
       <%= f.number_field :amount, min: 0.00, step: :any %>
       <%= f.error_message_on :amount %>
     <% end %>
   </div>
   <div class="alpha twelve columns">
     <%= f.field_container :category do %>
-      <%= f.label :category, Spree.t(:credit_type) %> <span class="required">*</span><br />
+      <%= f.label :category, Spree.t(:credit_type), class: 'required' %><br />
       <%= f.select :category_id, options_from_collection_for_select(@credit_categories, :id, :name, f.object.category.try(:id)),
         { include_blank: true }, { class: 'select2 fullwidth', placeholder: Spree.t("admin.store_credits.select_reason") } %>
       <%= f.error_message_on :category %>

--- a/backend/app/views/spree/admin/store_credits/_update_reason_field.html.erb
+++ b/backend/app/views/spree/admin/store_credits/_update_reason_field.html.erb
@@ -1,6 +1,6 @@
 <div class="alpha twelve columns">
   <%= f.field_container :reason do %>
-    <%= f.label :reason, Spree.t(:reason) %> <span class="required">*</span><br />
+    <%= f.label :reason, Spree.t(:reason), class: 'required' %><br />
     <%= select_tag :update_reason_id, options_from_collection_for_select(@update_reasons, :id, :name),
       { include_blank: true , class: 'select2 fullwidth', placeholder: Spree.t("admin.store_credits.select_amount_update_reason") } %>
     <%= f.error_message_on :reason %>

--- a/backend/app/views/spree/admin/store_credits/edit_amount.html.erb
+++ b/backend/app/views/spree/admin/store_credits/edit_amount.html.erb
@@ -13,7 +13,7 @@
     <div data-hook="admin_store_credit_form_fields" class="row">
       <div class="alpha twelve columns">
         <%= f.field_container :amount do %>
-          <%= f.label :amount, Spree.t(:amount) %> <span class="required">*</span><br />
+          <%= f.label :amount, Spree.t(:amount), class: 'required' %><br />
           <%= f.number_field :amount, min: 0.00, step: :any %>
           <%= f.error_message_on :amount %>
         <% end %>

--- a/backend/app/views/spree/admin/style_guide/topics/forms/_building_forms.html.erb
+++ b/backend/app/views/spree/admin/style_guide/topics/forms/_building_forms.html.erb
@@ -4,8 +4,8 @@
       <legend align="center">Search</legend>
       <div class="field-block alpha four columns">
         <div class="field">
-          <label for="q_number_cont">Text Field</label>
-          <input type="text">
+          <label for="q_number_cont" class="required">Text Field</label>
+          <input class="required" type="text">
         </div>
       </div>
 

--- a/backend/app/views/spree/admin/taxonomies/_form.html.erb
+++ b/backend/app/views/spree/admin/taxonomies/_form.html.erb
@@ -1,6 +1,6 @@
 <div data-hook="admin_inside_taxonomy_form" class="field align-center">
   <%= f.field_container :name do %>
-    <%= f.label :name, Spree.t(:name) %> <span class="required">*</span><br />
+    <%= f.label :name, Spree.t(:name), class: 'required' %><br />
     <%= error_message_on :taxonomy, :name, :class => 'fullwidth title' %>
     <%= text_field :taxonomy, :name %>
   <% end %>

--- a/backend/app/views/spree/admin/taxons/_form.html.erb
+++ b/backend/app/views/spree/admin/taxons/_form.html.erb
@@ -1,13 +1,13 @@
 <div data-hook="admin_inside_taxon_form" class="row">
   <div class="alpha five columns">
     <%= f.field_container :name do %>
-      <%= f.label :name, Spree.t(:name) %> <span class="required">*</span><br />
+      <%= f.label :name, Spree.t(:name), class: 'required' %><br />
       <%= text_field :taxon, :name, :class => 'fullwidth' %>
       <%= error_message_on :taxon, :name, :class => 'fullwidth title' %>
     <% end %>
 
     <%= f.field_container :permalink_part do %>
-      <%= f.label :permalink_part, Spree.t(:permalink) %> <span class="required">*</span><br />
+      <%= f.label :permalink_part, Spree.t(:permalink), class: 'required' %><br />
       <%= text_field_tag :permalink_part, @permalink_part, :class => 'fullwidth' %><br />
       <span class="info" id="permalink_part_display">
         <%= @taxon.permalink.split('/')[0...-1].join('/') + '/' %>

--- a/backend/spec/features/admin/orders/payments_spec.rb
+++ b/backend/spec/features/admin/orders/payments_spec.rb
@@ -180,7 +180,7 @@ describe 'Payments', type: :feature do
 
       it "is able to create a new credit card payment with valid information", js: true do
         fill_in "Card Number", with: "4111 1111 1111 1111"
-        fill_in "Name *", with: "Test User"
+        fill_in "Name", with: "Test User"
         fill_in "Expiration", with: "09 / #{Time.current.year + 1}"
         fill_in "Card Code", with: "007"
         # Regression test for https://github.com/spree/spree/issues/4277


### PR DESCRIPTION
There are a few advantages to this.

Previously there was a mix of `<span class="required">` inside and outside of the label. It's now consistent.

When the span and text was inside of the label, capybara would consider it part of the text of the label. Now it is considered presentation and not part of the label's text. This required changing one spec which had `fill_in "NAME *", with: ...`.

When the span and text were outside of the label, clicking the span did not focus the input field. It now does, because the label is the parent element and the click will bubble up.

How we display a required attribute is a style concern. If we change our mind about the way a required attribute's label should work we can now change it everywhere from our CSS.

This is also much shorter and easier to type in a view.