### PR TITLE
Add style guide logo to precompiled asset list

### DIFF
--- a/backend/config/initializers/assets.rb
+++ b/backend/config/initializers/assets.rb
@@ -1,1 +1,1 @@
-Rails.application.config.assets.precompile += %w( jquery-ui/* )
+Rails.application.config.assets.precompile += %w( jquery-ui/* solidus-style-guide-logo.png )

--- a/backend/spec/features/admin/style_guide_spec.rb
+++ b/backend/spec/features/admin/style_guide_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+describe "Style guide", type: :feature do
+  stub_authorization!
+
+  it "should render successfully" do
+    visit "/admin/style_guide"
+
+    # Somewhere in a style guide you'd expect to talk about colors
+    expect(page).to have_text "Colors"
+  end
+end


### PR DESCRIPTION
This fixes the style guide page under sprockets-rails 3.0

This should be backported to the 1.2 branch