### PR TITLE
Use attribute translations for image form

### DIFF
--- a/backend/app/views/spree/admin/images/_form.html.erb
+++ b/backend/app/views/spree/admin/images/_form.html.erb
@@ -1,7 +1,7 @@
 <div data-hook="admin_image_form_fields">
   <div class="four columns alpha">
     <div data-hook="file" class="field">
-      <%= f.label :attachment, Spree.t(:filename) %><br>
+      <%= f.label :attachment %><br>
       <%= f.file_field :attachment %>
     </div>
     <div data-hook="variant" class="field">
@@ -10,7 +10,7 @@
     </div>
   </div>
   <div data-hook="alt_text" class="field omega five columns">
-    <%= f.label :alt, Spree.t(:alt_text) %><br>
+    <%= f.label :alt %><br>
     <%= f.text_area :alt, rows: 4, class: 'fullwidth' %>
   </div>
 </div>

--- a/backend/app/views/spree/admin/images/index.html.erb
+++ b/backend/app/views/spree/admin/images/index.html.erb
@@ -29,7 +29,7 @@
         <% if @product.has_variants? %>
           <th><%= Spree::Variant.model_name.human %></th>
         <% end %>
-        <th><%= Spree.t(:alt_text) %></th>
+        <th><%= Spree::Image.human_attribute_name(:alt) %></th>
         <th class="actions"></th>
       </tr>
     </thead>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -31,6 +31,9 @@ en:
         verification_value: Verification Value
         year: Year
         name: Name
+      spree/image:
+        alt: Alternative Text
+        attachment: Filename
       spree/inventory_unit:
         state: State
       spree/line_item:


### PR DESCRIPTION
This is to better utilize I18n with more verbosity to make it more clear and easier to translate. 

This is cherry picked from #549 as is with no changes made as everything looks good.

This is part of an ongoing meta-issue to clean up the I18n implementation as discussed in #735 