### PR TITLE
RfC Make shipping rates taxable like line items or shipments

### DIFF
--- a/core/app/models/spree/calculator/default_tax.rb
+++ b/core/app/models/spree/calculator/default_tax.rb
@@ -23,7 +23,7 @@ module Spree
     end
 
     # When it comes to computing shipments or line items: same same.
-    def compute_shipment_or_line_item(item)
+    def compute_item(item)
       if rate.included_in_price
         deduced_total_by_rate(item.pre_tax_amount, rate)
       else
@@ -31,22 +31,9 @@ module Spree
       end
     end
 
-    alias_method :compute_shipment, :compute_shipment_or_line_item
-    alias_method :compute_line_item, :compute_shipment_or_line_item
-
-    def compute_shipping_rate(shipping_rate)
-      if rate.included_in_price
-        pre_tax_amount = shipping_rate.cost / (1 + rate.amount)
-        if rate.zone == shipping_rate.shipment.order.tax_zone
-          deduced_total_by_rate(pre_tax_amount, rate)
-        else
-          deduced_total_by_rate(pre_tax_amount, rate) * - 1
-        end
-      else
-        with_tax_amount = shipping_rate.cost * rate.amount
-        round_to_two_places(with_tax_amount)
-      end
-    end
+    alias_method :compute_shipment, :compute_item
+    alias_method :compute_line_item, :compute_item
+    alias_method :compute_shipping_rate, :compute_item
 
     private
 

--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -117,6 +117,10 @@ module Spree
       assign_attributes opts
     end
 
+    def eligible?
+      true
+    end
+
     private
 
     # Sets the quantity to zero if it is nil or less than zero.

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -88,8 +88,8 @@ module Spree
     end
 
     extend DisplayMoney
-    money_methods :cost, :discounted_cost, :final_price, :item_cost
-    alias display_amount display_cost
+    money_methods :cost, :discounted_cost, :final_price, :item_cost, :amount
+    alias_attribute :amount, :cost
 
     def add_shipping_method(shipping_method, selected = false)
       shipping_rates.create(shipping_method: shipping_method, selected: selected, cost: cost)

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -247,7 +247,7 @@ module Spree
     end
 
     def tax_category
-      selected_shipping_rate.try(:tax_rate).try(:tax_category)
+      selected_shipping_rate.try(:tax_category)
     end
 
     # Only one of either included_tax_total or additional_tax_total is set

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -187,6 +187,8 @@ module Spree
       self.shipping_rates = new_rates
       save!
 
+      calculate_shipping_rate_taxes
+
       shipping_rates
     end
 
@@ -274,6 +276,8 @@ module Spree
     end
 
     def update_amounts
+      calculate_shipping_rate_taxes
+
       if selected_shipping_rate
         self.cost = selected_shipping_rate.cost
         self.adjustment_total = adjustments.additional.map(&:update!).compact.sum
@@ -370,6 +374,10 @@ module Spree
     end
 
     private
+
+    def calculate_shipping_rate_taxes
+      shipping_rates.map { |rate| Spree::Tax::ItemAdjuster.new(rate).adjust! }
+    end
 
     def after_ship
       order.shipping.ship_shipment(self, suppress_mailer: suppress_mailer)

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -373,6 +373,10 @@ module Spree
       !stock_location || stock_location.fulfillable?
     end
 
+    def eligible?
+      true
+    end
+
     private
 
     def calculate_shipping_rate_taxes

--- a/core/app/models/spree/shipping_rate.rb
+++ b/core/app/models/spree/shipping_rate.rb
@@ -6,7 +6,7 @@ module Spree
 
     has_many :adjustments, as: :adjustable, inverse_of: :adjustable, dependent: :delete_all
 
-    delegate :order, :currency, to: :shipment
+    delegate :order, :currency, :order_id, to: :shipment
     delegate :name, :tax_category, to: :shipping_method
     delegate :code, to: :shipping_method, prefix: true
 
@@ -26,29 +26,42 @@ module Spree
 
     def display_price
       price = display_base_price.to_s
-      if tax_rate
-        tax_amount = calculate_tax_amount
-        if tax_amount != 0
-          if tax_rate.included_in_price?
-            if tax_amount > 0
-              amount = "#{display_tax_amount(tax_amount)} #{tax_rate.name}"
-              price += " (#{Spree.t(:incl)} #{amount})"
-            else
-              amount = "#{display_tax_amount(tax_amount * -1)} #{tax_rate.name}"
-              price += " (#{Spree.t(:excl)} #{amount})"
-            end
-          else
-            amount = "#{display_tax_amount(tax_amount)} #{tax_rate.name}"
-            price += " (+ #{amount})"
-          end
-        end
-      end
-      price
+      return price if adjustments.tax.empty? || amount == 0
+
+      tax_explanations = adjustments.tax.map { |tax_adjustment| tax_explain(tax_adjustment) }.join(", ")
+
+      Spree.t :display_price_with_explanations,
+              scope: 'shipping_rate.display_price',
+              price: price,
+              explanations: tax_explanations
     end
+
     alias_method :display_cost, :display_price
 
-    def display_tax_amount(tax_amount)
-      Spree::Money.new(tax_amount, currency: currency)
+    private
+
+    def tax_explain(adjustment)
+      tax_rate = adjustment.source
+      Spree.t translation_key(adjustment),
+              scope: 'shipping_rate.display_price.tax_explanations',
+              tax_amount: display_tax_amount(adjustment),
+              tax_rate_name: tax_rate.name
+    end
+
+    def display_tax_amount(adjustment)
+      Spree::Money.new(adjustment.amount.abs, currency: currency)
+    end
+
+    def translation_key(adjustment)
+      if adjustment.source.included_in_price?
+        if adjustment.amount > 0
+          :vat
+        else
+          :vat_refund
+        end
+      else
+        :sales_tax
+      end
     end
   end
 end

--- a/core/app/models/spree/shipping_rate.rb
+++ b/core/app/models/spree/shipping_rate.rb
@@ -38,6 +38,10 @@ module Spree
 
     alias_method :display_cost, :display_price
 
+    def eligible?
+      false
+    end
+
     private
 
     def tax_explain(adjustment)

--- a/core/app/models/spree/shipping_rate.rb
+++ b/core/app/models/spree/shipping_rate.rb
@@ -4,9 +4,17 @@ module Spree
     belongs_to :shipping_method, -> { with_deleted }, class_name: 'Spree::ShippingMethod', inverse_of: :shipping_rates
     belongs_to :tax_rate, -> { with_deleted }, class_name: 'Spree::TaxRate'
 
+    has_many :adjustments, as: :adjustable, inverse_of: :adjustable, dependent: :delete_all
+
     delegate :order, :currency, to: :shipment
-    delegate :name, to: :shipping_method
+    delegate :name, :tax_category, to: :shipping_method
     delegate :code, to: :shipping_method, prefix: true
+
+    alias_attribute :amount, :cost
+
+    def discounted_amount
+      cost
+    end
 
     def display_base_price
       Spree::Money.new(cost, currency: currency)

--- a/core/app/models/spree/stock/estimator.rb
+++ b/core/app/models/spree/stock/estimator.rb
@@ -35,22 +35,10 @@ module Spree
       def calculate_shipping_rates(package)
         shipping_methods(package).map do |shipping_method|
           cost = shipping_method.calculator.compute(package)
-          tax_category = shipping_method.tax_category
-          if tax_category
-            tax_rate = tax_category.tax_rates.detect do |rate|
-              # If the rate's zone matches the order's zone, a positive adjustment will be applied.
-              # If the rate is from the default tax zone, then a negative adjustment will be applied.
-              # See the tests in shipping_rate_spec.rb for an example of this.d
-              rate.zone == order.tax_zone || rate.zone.default_tax?
-            end
-          end
 
           if cost
-            rate = shipping_method.shipping_rates.new(cost: cost)
-            rate.tax_rate = tax_rate if tax_rate
+            shipping_method.shipping_rates.new(cost: cost)
           end
-
-          rate
         end.compact
       end
 

--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -87,15 +87,8 @@ module Spree
     # correct rate amounts in the future. For example:
     # https://github.com/spree/spree/issues/4318#issuecomment-34723428
     def self.store_pre_tax_amount(item, rates)
-      pre_tax_amount = case item
-                       when Spree::LineItem then item.discounted_amount
-                       when Spree::Shipment then item.discounted_cost
-        end
-
-      included_rates = rates.select(&:included_in_price)
-      if included_rates.any?
-        pre_tax_amount /= (1 + included_rates.map(&:amount).sum)
-      end
+      sum_of_included_rates = rates.select(&:included_in_price).map(&:amount).sum
+      pre_tax_amount = item.discounted_amount / (1 + sum_of_included_rates)
 
       item.update_column(:pre_tax_amount, pre_tax_amount.round(2))
     end

--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -109,7 +109,8 @@ module Spree
         amount: amount,
         order_id: item.order_id,
         label: label || create_label,
-        included: included
+        included: included,
+        eligible: item.eligible?
       })
     end
 

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1563,6 +1563,13 @@ en:
     shipping_method: Shipping Method
     shipping_methods: Shipping Methods
     shipping_price_sack: Price sack
+    shipping_rate:
+      display_price:
+        display_price_with_explanations: "%{price} (%{explanations})"
+        tax_explanations:
+          sales_tax: "+ %{tax_amount} %{tax_rate_name}"
+          vat: "incl. %{tax_amount} %{tax_rate_name}"
+          vat_refund: "excl. %{tax_amount} %{tax_rate_name}"
     shipping_total: Shipping total
     shop_by_taxonomy: Shop by %{taxonomy}
     shopping_cart: Shopping Cart

--- a/core/db/migrate/20160128200859_add_taxation_columns_to_shipping_rate.rb
+++ b/core/db/migrate/20160128200859_add_taxation_columns_to_shipping_rate.rb
@@ -1,0 +1,9 @@
+class AddTaxationColumnsToShippingRate < ActiveRecord::Migration
+  def up
+    add_column :spree_shipping_rates, :included_tax_total, :decimal, precision: 10, scale: 2, null: false, default: 0.0
+    add_column :spree_shipping_rates, :additional_tax_total, :decimal, precision: 10, scale: 2, null: false, default: 0.0
+    add_column :spree_shipping_rates, :adjustment_total, :decimal, precision: 10, scale: 2, null: false, default: 0.0
+    add_column :spree_shipping_rates, :promo_total, :decimal, precision: 10, scale: 2, null: false, default: 0.0
+    add_column :spree_shipping_rates, :pre_tax_amount, :decimal, precision: 12, scale: 4, null: false, default: 0.0
+  end
+end

--- a/core/spec/lib/spree/core/unreturned_item_charger_spec.rb
+++ b/core/spec/lib/spree/core/unreturned_item_charger_spec.rb
@@ -1,17 +1,20 @@
 require 'spec_helper'
 
 describe Spree::UnreturnedItemCharger do
-  let(:shipped_order) { create(:shipped_order, line_items_count: 1, with_cartons: false) }
+  let(:ship_address) { create(:address) }
+  let(:shipped_order) { create(:shipped_order, ship_address: ship_address, line_items_count: 1, with_cartons: false) }
   let(:original_shipment) { shipped_order.shipments.first }
   let(:original_stock_location) { original_shipment.stock_location }
   let(:original_inventory_unit) { shipped_order.inventory_units.first }
   let(:original_variant) { original_inventory_unit.variant }
+  let(:shipping_method) { create(:shipping_method, tax_category: original_variant.tax_category) }
   let(:exchange_shipment) do
-    create(:shipment,
+    create :shipment,
            order: shipped_order,
            state: 'shipped',
            stock_location: original_stock_location,
-           created_at: 5.days.ago)
+           created_at: 5.days.ago,
+           shipping_method: shipping_method
   end
   let(:exchange_inventory_unit) { exchange_shipment.inventory_units.first }
   let(:return_item) do
@@ -43,12 +46,10 @@ describe Spree::UnreturnedItemCharger do
     end
 
     context 'in tax zone' do
-      let!(:tax_zone) { Spree::Zone.find_by(name: 'GlobalZone') || FactoryGirl.create(:global_zone) }
+      let!(:tax_zone) { create(:zone, countries: [ship_address.country]) }
       let!(:tax_rate) { create(:tax_rate, zone: tax_zone, tax_category: original_variant.tax_category) }
-      before { tax_zone.update_attributes!(default_tax: true) }
 
       it "applies tax" do
-        exchange_shipment.shipping_rates.update_all(tax_rate_id: tax_rate.id)
         exchange_order = exchange_shipment.order
         exchange_order.create_tax_charge!
         exchange_order.update!

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -6,6 +6,12 @@ describe Spree::LineItem, type: :model do
 
   it_behaves_like "a taxable item"
 
+  describe "#eligible?" do
+    it 'is always eligible' do
+      expect(line_item.eligible?).to eq(true)
+    end
+  end
+
   context '#destroy' do
     it "fetches deleted products" do
       line_item.product.destroy

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 describe Spree::LineItem, type: :model do
   let(:order) { create :order_with_line_items, line_items_count: 1 }
-  let(:line_item) { order.line_items.first }
+  subject(:line_item) { order.line_items.first }
+
+  it_behaves_like "a taxable item"
 
   context '#destroy' do
     it "fetches deleted products" do

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -26,6 +26,12 @@ describe Spree::Shipment, type: :model do
 
   it_behaves_like "a taxable item"
 
+  describe "#eligible?" do
+    it "is always eligible" do
+      expect(shipment.eligible?).to be(true)
+    end
+  end
+
   describe "precision of pre_tax_amount" do
     let!(:line_item) { create :line_item, pre_tax_amount: 4.2051 }
 

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -5,7 +5,7 @@ describe Spree::Shipment, type: :model do
   let(:order) { create(:order_ready_to_ship, line_items_count: 1) }
   let(:shipping_method) { create(:shipping_method, name: "UPS") }
   let(:stock_location) { create(:stock_location) }
-  let(:shipment) do
+  subject(:shipment) do
     order.shipments.create!(
       state: 'pending',
       cost: 1,
@@ -23,6 +23,8 @@ describe Spree::Shipment, type: :model do
 
   let(:variant) { mock_model(Spree::Variant) }
   let(:line_item) { mock_model(Spree::LineItem, variant: variant) }
+
+  it_behaves_like "a taxable item"
 
   describe "precision of pre_tax_amount" do
     let!(:line_item) { create :line_item, pre_tax_amount: 4.2051 }

--- a/core/spec/models/spree/shipping_rate_spec.rb
+++ b/core/spec/models/spree/shipping_rate_spec.rb
@@ -12,6 +12,12 @@ describe Spree::ShippingRate, type: :model do
 
   it_behaves_like 'a taxable item'
 
+  describe "#eligible?" do
+    it 'is never eligible' do
+      expect(shipping_rate.eligible?).to be(false)
+    end
+  end
+
   context "#display_price" do
     subject(:shipping_rate) do
       create :shipping_rate,

--- a/core/spec/models/spree/shipping_rate_spec.rb
+++ b/core/spec/models/spree/shipping_rate_spec.rb
@@ -5,11 +5,13 @@ require 'spec_helper'
 describe Spree::ShippingRate, type: :model do
   let(:shipment) { create(:shipment) }
   let(:shipping_method) { create(:shipping_method) }
-  let(:shipping_rate) {
+  subject(:shipping_rate) {
     Spree::ShippingRate.new(shipment: shipment,
                                                 shipping_method: shipping_method,
                                                 cost: 10)
   }
+
+  it_behaves_like 'a taxable item'
 
   context "#display_price" do
     context "when tax included in price" do

--- a/core/spec/models/spree/shipping_rate_spec.rb
+++ b/core/spec/models/spree/shipping_rate_spec.rb
@@ -3,77 +3,83 @@
 require 'spec_helper'
 
 describe Spree::ShippingRate, type: :model do
-  let(:shipment) { create(:shipment) }
-  let(:shipping_method) { create(:shipping_method) }
-  subject(:shipping_rate) {
-    Spree::ShippingRate.new(shipment: shipment,
-                                                shipping_method: shipping_method,
-                                                cost: 10)
-  }
+  let(:order) { create :order }
+  let(:shipment) { create(:shipment, order: order) }
+  let(:shipping_method) { create(:shipping_method, tax_category: tax_category) }
+  let(:tax_category) { create :tax_category }
+
+  subject(:shipping_rate) { Spree::ShippingRate.new }
 
   it_behaves_like 'a taxable item'
 
   context "#display_price" do
-    context "when tax included in price" do
-      context "when the tax rate is from the default zone" do
-        before { shipment.order.update_attributes!(ship_address_id: nil) }
-        let!(:zone) { create(:zone, default_tax: true) }
-        let(:tax_rate) do
-          create(:tax_rate,
-            name: "VAT",
-            amount: 0.1,
-            included_in_price: true,
-            zone: zone)
-        end
+    subject(:shipping_rate) do
+      create :shipping_rate,
+      shipment: shipment,
+      shipping_method: shipping_method,
+      amount: 10
+    end
 
-        before { shipping_rate.tax_rate = tax_rate }
+    let(:default_zone) { create :zone, :with_country, default_tax: true }
+    let(:other_zone) { create :zone, :with_country }
 
-        it "shows correct tax amount" do
-          expect(shipping_rate.display_price.to_s).to eq("$10.00 (incl. $0.91 #{tax_rate.name})")
-        end
+    let!(:tax_rate) do
+      create :tax_rate,
+      included_in_price: included_in_price,
+      name: rate_name,
+      zone: default_zone,
+      tax_category: tax_category
+    end
 
-        context "when cost is zero" do
-          before do
-            shipping_rate.cost = 0
-          end
+    before do
+      allow(order).to receive(:tax_zone).and_return(order_zone)
+      Spree::Tax::ItemAdjuster.new(shipping_rate).adjust!
+    end
 
-          it "shows no tax amount" do
-            expect(shipping_rate.display_price.to_s).to eq("$0.00")
-          end
-        end
+    context 'with one included tax adjustment' do
+      let(:included_in_price) { true }
+      let(:order_zone) { default_zone }
+      let(:rate_name) { "VAT" }
+
+      it "shows correct tax amount" do
+        expect(shipping_rate.display_price.to_s).to eq("$10.00 (incl. $0.91 #{tax_rate.name})")
       end
 
-      context "when the tax rate is from a non-default zone" do
-        let!(:default_zone) { create(:zone, default_tax: true) }
-        let!(:non_default_zone) { create(:zone, default_tax: false) }
-        let(:tax_rate) do
-          create(:tax_rate,
-            name: "VAT",
-            amount: 0.1,
-            included_in_price: true,
-            zone: non_default_zone)
-        end
-        before { shipping_rate.tax_rate = tax_rate }
-
-        it "shows correct tax amount" do
-          expect(shipping_rate.display_price.to_s).to eq("$10.00 (excl. $0.91 #{tax_rate.name})")
+      context "when cost is zero" do
+        before do
+          shipping_rate.cost = 0
         end
 
-        context "when cost is zero" do
-          before do
-            shipping_rate.cost = 0
-          end
-
-          it "shows no tax amount" do
-            expect(shipping_rate.display_price.to_s).to eq("$0.00")
-          end
+        it "shows no tax amount" do
+          expect(shipping_rate.display_price.to_s).to eq("$0.00")
         end
       end
     end
 
-    context "when tax is additional to price" do
-      let(:tax_rate) { create(:tax_rate, name: "Sales Tax", amount: 0.1) }
-      before { shipping_rate.tax_rate = tax_rate }
+    context 'with one tax refund' do
+      let(:included_in_price) { true }
+      let(:order_zone) { other_zone }
+      let(:rate_name) { "VAT" }
+
+      it "shows correct tax amount" do
+        expect(shipping_rate.display_price.to_s).to eq("$10.00 (excl. $0.91 #{tax_rate.name})")
+      end
+
+      context "when cost is zero" do
+        before do
+          shipping_rate.cost = 0
+        end
+
+        it "shows no tax amount" do
+          expect(shipping_rate.display_price.to_s).to eq("$0.00")
+        end
+      end
+    end
+
+    context 'with one additional tax adjustment' do
+      let(:included_in_price) { false }
+      let(:order_zone) { default_zone }
+      let(:rate_name) { "Sales tax" }
 
       it "shows correct tax amount" do
         expect(shipping_rate.display_price.to_s).to eq("$10.00 (+ $1.00 #{tax_rate.name})")
@@ -89,22 +95,12 @@ describe Spree::ShippingRate, type: :model do
         end
       end
     end
-
-    context "when the currency is JPY" do
-      let(:shipping_rate) {
-        shipping_rate = Spree::ShippingRate.new(cost: 205)
-        allow(shipping_rate).to receive_messages(currency: "JPY")
-        shipping_rate
-      }
-
-      it "displays the price in yen" do
-        expect(shipping_rate.display_price.to_s).to eq("¥205")
-      end
-    end
   end
 
   # Regression test for https://github.com/spree/spree/issues/3829
   context "#shipping_method" do
+    subject(:shipping_rate) { create :shipping_rate, shipment: shipment, shipping_method: shipping_method }
+
     it "can be retrieved" do
       expect(shipping_rate.shipping_method.reload).to eq(shipping_method)
     end
@@ -137,6 +133,8 @@ describe Spree::ShippingRate, type: :model do
   end
 
   context "#shipping_method_code" do
+    subject(:shipping_rate) { create :shipping_rate, shipment: shipment, shipping_method: shipping_method }
+
     before do
       shipping_method.code = "THE_CODE"
     end

--- a/core/spec/models/spree/stock/estimator_spec.rb
+++ b/core/spec/models/spree/stock/estimator_spec.rb
@@ -123,23 +123,6 @@ module Spree
           end
         end
 
-        context "includes tax adjustments if applicable" do
-          let!(:tax_rate) { create(:tax_rate, zone: order.tax_zone) }
-
-          before do
-            Spree::ShippingMethod.all.each do |sm|
-              sm.tax_category_id = tax_rate.tax_category_id
-              sm.save
-            end
-            package.shipping_methods.map(&:reload)
-          end
-
-          it "links the shipping rate and the tax rate" do
-            shipping_rates = subject.shipping_rates(package)
-            expect(shipping_rates.first.tax_rate).to eq(tax_rate)
-          end
-        end
-
         it 'uses the configured shipping rate selector' do
           shipping_rate = Spree::ShippingRate.new
           allow(Spree::ShippingRate).to receive(:new).and_return(shipping_rate)

--- a/core/spec/models/spree/tax/taxation_integration_spec.rb
+++ b/core/spec/models/spree/tax/taxation_integration_spec.rb
@@ -151,8 +151,7 @@ RSpec.describe "Taxation system integration tests" do
         end
 
         it 'has a shipping rate that correctly reflects the shipment' do
-          pending 'since no tax created, no correct display price'
-          expect(shipping_rate.display_price).to eq("$8.00 (incl. $0.52 German VAT)")
+          expect(shipping_rate.display_price).to eq("$8.00 (incl. $0.52 German reduced VAT)")
         end
       end
 
@@ -187,7 +186,7 @@ RSpec.describe "Taxation system integration tests" do
         end
 
         it 'has a shipping rate that correctly reflects the shipment' do
-          pending 'since no tax created, no correct display price'
+          pending 'But there is a rounding error'
           expect(shipping_rate.display_price).to eq("$16.00 (incl. $2.55 German VAT)")
         end
       end
@@ -269,8 +268,7 @@ RSpec.describe "Taxation system integration tests" do
         end
 
         it 'has a shipping rate that correctly reflects the shipment' do
-          pending 'since no tax created, no correct display price'
-          expect(shipping_rate.display_price).to eq("$8.00 (incl. $0.52 German VAT)")
+          expect(shipping_rate.display_price).to eq("$8.00 (incl. $0.52 German reduced VAT)")
         end
       end
 
@@ -309,7 +307,7 @@ RSpec.describe "Taxation system integration tests" do
         end
 
         it 'has a shipping rate that correctly reflects the shipment' do
-          pending 'since no tax created, no correct display price'
+          pending 'But there is a rounding error'
           expect(shipping_rate.display_price).to eq("$16.00 (incl. $2.55 German VAT)")
         end
       end
@@ -348,12 +346,12 @@ RSpec.describe "Taxation system integration tests" do
         end
 
         it 'has a shipment with 0.40 included tax' do
-          pending 'But the tax is not created'
+          pending 'But there is a rounding error'
           expect(shipment.included_tax_total).to eq(0.40)
         end
 
         it 'has a shipping rate that correctly reflects the shipment' do
-          pending 'since no tax created, no correct display price'
+          pending 'But the amount is not adjusted AND there is a rounding error'
           expect(shipping_rate.display_price).to eq("$2.08 (incl. $0.40 Romanian VAT)")
         end
       end
@@ -438,7 +436,7 @@ RSpec.describe "Taxation system integration tests" do
 
           it 'it has a shipment with an adjusted price to 7.47' do
             pending "but the shipment amount is not adjusted"
-            expect(shipment.amount).to eq(7.47)
+            expect(shipment.amount).to eq(7.48)
           end
 
           it 'has a shipment with no included tax' do
@@ -447,7 +445,7 @@ RSpec.describe "Taxation system integration tests" do
 
           it 'has a shipping rate that correctly reflects the shipment' do
             pending 'since no tax created, no correct display price'
-            expect(shipping_rate.display_price).to eq("$7.47")
+            expect(shipping_rate.display_price).to eq("$7.48")
           end
         end
       end
@@ -676,8 +674,9 @@ RSpec.describe "Taxation system integration tests" do
         end
 
         it 'has a shipping rate that correctly reflects the shipment' do
-          pending 'since no tax created, no correct display price'
-          expect(shipping_rate.display_price).to eq("$8.00 (+ $0.80 Federal Sales Tax, + $0.40 New York Sales Tax)")
+          expect(shipping_rate.display_price).to include("$8.00")
+          expect(shipping_rate.display_price).to include("$0.80 Federal Sales Tax")
+          expect(shipping_rate.display_price).to include("$0.40 New York Sales Tax")
         end
       end
 
@@ -772,7 +771,6 @@ RSpec.describe "Taxation system integration tests" do
         end
 
         it 'has a shipping rate that correctly reflects the shipment' do
-          pending 'since no tax created, no correct display price'
           expect(shipping_rate.display_price).to eq("$2.00 (+ $0.40 Federal Sales Tax)")
         end
       end

--- a/core/spec/models/spree/tax/taxation_integration_spec.rb
+++ b/core/spec/models/spree/tax/taxation_integration_spec.rb
@@ -1,5 +1,12 @@
 require 'spec_helper'
 
+shared_examples_for 'an order with a shipment' do
+  it 'does not conflate shipping rate and shipment adjustments on the total of eligible adjustments' do
+    expect(order.all_adjustments.eligible.map(&:amount).sum).to \
+      eq(line_item.adjustments.sum(:amount) + shipment.adjustments.sum(:amount))
+  end
+end
+
 RSpec.describe "Taxation system integration tests" do
   let(:order) { create :order, ship_address: shipping_address, state: "delivery" }
   let(:book_product) do
@@ -141,6 +148,8 @@ RSpec.describe "Taxation system integration tests" do
 
         before { 2.times { order.next! } }
 
+        it_behaves_like 'an order with a shipment'
+
         it 'has a shipment for 8.00 dollars' do
           expect(shipment.amount).to eq(8.00)
         end
@@ -174,6 +183,8 @@ RSpec.describe "Taxation system integration tests" do
         let(:variant) { sweater }
 
         before { 2.times { order.next! } }
+
+        it_behaves_like 'an order with a shipment'
 
         it 'has a shipment for 16.00 dollars' do
           expect(shipment.amount).to eq(16.00)
@@ -210,6 +221,8 @@ RSpec.describe "Taxation system integration tests" do
         let(:variant) { download }
 
         before { 2.times { order.next! } }
+
+        it_behaves_like 'an order with a shipment'
 
         it 'has a shipment for 4.00 dollars' do
           expect(shipment.amount).to eq(2.00)
@@ -257,6 +270,8 @@ RSpec.describe "Taxation system integration tests" do
 
         before { 2.times { order.next! } }
 
+        it_behaves_like 'an order with a shipment'
+
         it 'has a shipment for 8.00 dollars' do
           expect(shipment.amount).to eq(8.00)
         end
@@ -294,6 +309,8 @@ RSpec.describe "Taxation system integration tests" do
         let(:variant) { sweater }
 
         before { 2.times { order.next! } }
+
+        it_behaves_like 'an order with a shipment'
 
         it 'has a shipment for 16.00 dollars' do
           expect(shipment.amount).to eq(16.00)
@@ -337,6 +354,8 @@ RSpec.describe "Taxation system integration tests" do
         let(:variant) { download }
 
         before { 2.times { order.next! } }
+
+        it_behaves_like 'an order with a shipment'
 
         it 'it has a shipment with an adjusted price to 2.08' do
           pending 'But the shipment amount is not adjusted'
@@ -432,6 +451,8 @@ RSpec.describe "Taxation system integration tests" do
 
           before { 2.times { order.next! } }
 
+          it_behaves_like 'an order with a shipment'
+
           it 'it has a shipment with an adjusted price to 7.47' do
             pending "but the shipment amount is not adjusted"
             expect(shipment.amount).to eq(7.48)
@@ -478,6 +499,8 @@ RSpec.describe "Taxation system integration tests" do
           let(:variant) { sweater }
 
           before { 2.times { order.next! } }
+
+          it_behaves_like 'an order with a shipment'
 
           it 'it has a shipment with an adjusted price to 13.45' do
             pending 'but the amount is not adjusted'

--- a/core/spec/models/spree/tax/taxation_integration_spec.rb
+++ b/core/spec/models/spree/tax/taxation_integration_spec.rb
@@ -142,7 +142,6 @@ RSpec.describe "Taxation system integration tests" do
         before { 2.times { order.next! } }
 
         it 'has a shipment for 8.00 dollars' do
-          pending 'No amount method yet on the shipment'
           expect(shipment.amount).to eq(8.00)
         end
 
@@ -179,7 +178,6 @@ RSpec.describe "Taxation system integration tests" do
         before { 2.times { order.next! } }
 
         it 'has a shipment for 16.00 dollars' do
-          pending 'No amount method yet on the shipment'
           expect(shipment.amount).to eq(16.00)
         end
 
@@ -216,7 +214,6 @@ RSpec.describe "Taxation system integration tests" do
         before { 2.times { order.next! } }
 
         it 'has a shipment for 4.00 dollars' do
-          pending 'No amount method yet on the shipment'
           expect(shipment.amount).to eq(2.00)
         end
 
@@ -263,7 +260,6 @@ RSpec.describe "Taxation system integration tests" do
         before { 2.times { order.next! } }
 
         it 'has a shipment for 8.00 dollars' do
-          pending 'No amount method yet on the shipment'
           expect(shipment.amount).to eq(8.00)
         end
 
@@ -304,7 +300,6 @@ RSpec.describe "Taxation system integration tests" do
         before { 2.times { order.next! } }
 
         it 'has a shipment for 16.00 dollars' do
-          pending 'No amount method yet on the shipment'
           expect(shipment.amount).to eq(16.00)
         end
 
@@ -348,7 +343,7 @@ RSpec.describe "Taxation system integration tests" do
         before { 2.times { order.next! } }
 
         it 'it has a shipment with an adjusted price to 2.08' do
-          pending 'No amount method yet on the shipment'
+          pending 'But the shipment amount is not adjusted'
           expect(shipment.amount).to eq(2.08)
         end
 
@@ -442,7 +437,7 @@ RSpec.describe "Taxation system integration tests" do
           before { 2.times { order.next! } }
 
           it 'it has a shipment with an adjusted price to 7.47' do
-            pending 'No amount method yet on the shipment'
+            pending "but the shipment amount is not adjusted"
             expect(shipment.amount).to eq(7.47)
           end
 
@@ -489,7 +484,7 @@ RSpec.describe "Taxation system integration tests" do
           before { 2.times { order.next! } }
 
           it 'it has a shipment with an adjusted price to 13.45' do
-            pending 'No amount method yet on the shipment'
+            pending 'but the amount is not adjusted'
             expect(shipment.amount).to eq(13.45)
           end
 
@@ -537,7 +532,7 @@ RSpec.describe "Taxation system integration tests" do
         before { 2.times { order.next! } }
 
         it 'it has a shipment with an adjusted price to 1.68' do
-          pending 'No amount method yet on the shipment'
+          pending 'but the price is not adjusted'
           expect(shipment.amount).to eq(1.68)
         end
 
@@ -669,7 +664,6 @@ RSpec.describe "Taxation system integration tests" do
         before { 2.times { order.next! } }
 
         it 'it has a shipment with a price of 8.00' do
-          pending 'No amount method yet on the shipment'
           expect(shipment.amount).to eq(8.00)
         end
 
@@ -718,7 +712,6 @@ RSpec.describe "Taxation system integration tests" do
         before { 2.times { order.next! } }
 
         it 'it has a shipment with a price of 16.00' do
-          pending 'No amount method yet on the shipment'
           expect(shipment.amount).to eq(16.00)
         end
 
@@ -766,7 +759,6 @@ RSpec.describe "Taxation system integration tests" do
         before { 2.times { order.next! } }
 
         it 'it has a shipment with a price of 2.00' do
-          pending 'No amount method yet on the shipment'
           expect(shipment.amount).to eq(2.00)
         end
 

--- a/core/spec/models/spree/tax/taxation_integration_spec.rb
+++ b/core/spec/models/spree/tax/taxation_integration_spec.rb
@@ -146,7 +146,6 @@ RSpec.describe "Taxation system integration tests" do
         end
 
         it 'has a shipment with 0.52 included tax' do
-          pending 'But the tax is not created'
           expect(shipment.included_tax_total).to eq(0.52)
         end
 
@@ -263,7 +262,6 @@ RSpec.describe "Taxation system integration tests" do
         end
 
         it 'has a shipment with 0.52 included tax' do
-          pending 'But the tax is not created'
           expect(shipment.included_tax_total).to eq(0.52)
         end
 
@@ -766,7 +764,6 @@ RSpec.describe "Taxation system integration tests" do
         end
 
         it 'has a shipment with additional tax of 0.40' do
-          pending "This does not work because the shipping code does not use contains? for finding zones"
           expect(shipment.additional_tax_total).to eq(0.40)
         end
 

--- a/core/spec/support/concerns/taxable_items.rb
+++ b/core/spec/support/concerns/taxable_items.rb
@@ -1,0 +1,22 @@
+RSpec.shared_examples_for 'a taxable item' do
+  it { is_expected.to respond_to(:discounted_amount) }
+  it { is_expected.to respond_to(:included_tax_total) }
+  it { is_expected.to respond_to(:included_tax_total=) }
+  it { is_expected.to respond_to(:additional_tax_total) }
+  it { is_expected.to respond_to(:additional_tax_total=) }
+  it { is_expected.to respond_to(:adjustment_total) }
+  it { is_expected.to respond_to(:adjustment_total=) }
+  it { is_expected.to respond_to(:promo_total) }
+  it { is_expected.to respond_to(:promo_total=) }
+  it { is_expected.to respond_to(:pre_tax_amount) }
+  it { is_expected.to respond_to(:pre_tax_amount=) }
+
+  # TODO: taxable items should not need a pre tax amount column
+  # as amount - included_tax_total should always == pre_tax_amount.
+  # However, TaxRate.set_pre_tax_amount needs this.
+  it "also has a pre tax amount column " do
+    expect(subject.class.column_names).to include("pre_tax_amount")
+  end
+  it { is_expected.to respond_to(:tax_category) }
+  it { is_expected.to respond_to(:adjustments) }
+end

--- a/core/spec/support/concerns/taxable_items.rb
+++ b/core/spec/support/concerns/taxable_items.rb
@@ -19,4 +19,8 @@ RSpec.shared_examples_for 'a taxable item' do
   end
   it { is_expected.to respond_to(:tax_category) }
   it { is_expected.to respond_to(:adjustments) }
+
+  # This is so that the taxation system knows whether the object in question
+  # and expecially its adjustments count towards the order total or not.
+  it { is_expected.to respond_to(:eligible?) }
 end


### PR DESCRIPTION
The taxation code for shipping rates is distributed over `Spree::ShippingRate`, `Spree::Stock::Estimator` and the worst parts of `Spree::TaxRate`. The aim of the taxation refactoring I'm doing is to isolate taxation code to as few moving parts as possible. As discussed on Slack, I'm introducing a spec for taxable items so that I can easily test whether a shipment can possibly be tax adjusted using the tax adjustment mechanism we already have: `Spree::Taxrate.adjust`. 

