### PR TITLE
Uses actions namespace for edit and delete links

### DIFF
--- a/backend/app/helpers/spree/admin/navigation_helper.rb
+++ b/backend/app/helpers/spree/admin/navigation_helper.rb
@@ -54,17 +54,17 @@ module Spree
       def link_to_edit(resource, options = {})
         url = options[:url] || edit_object_url(resource)
         options[:data] = { action: 'edit' }
-        link_to_with_icon('edit', Spree.t(:edit), url, options)
+        link_to_with_icon('edit', Spree.t('actions.edit'), url, options)
       end
 
       def link_to_edit_url(url, options = {})
         options[:data] = { action: 'edit' }
-        link_to_with_icon('edit', Spree.t(:edit), url, options)
+        link_to_with_icon('edit', Spree.t('actions.edit'), url, options)
       end
 
       def link_to_delete(resource, options = {})
         url = options[:url] || object_url(resource)
-        name = options[:name] || Spree.t(:delete)
+        name = options[:name] || Spree.t('actions.delete')
         options[:class] = "delete-resource"
         options[:data] = { confirm: Spree.t(:are_you_sure), action: 'remove' }
         link_to_with_icon 'trash', name, url, options

--- a/backend/app/views/spree/admin/adjustments/edit.html.erb
+++ b/backend/app/views/spree/admin/adjustments/edit.html.erb
@@ -1,7 +1,7 @@
 <%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Adjustments' } %>
 
 <% content_for :page_title do %>
-  <i class="fa fa-arrow-right"></i> <%= Spree.t(:edit) %> <%= Spree.t(:adjustment) %>
+  <i class="fa fa-arrow-right"></i> <%= Spree.t('actions.edit') %> <%= Spree.t(:adjustment) %>
 <% end %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/images/index.html.erb
+++ b/backend/app/views/spree/admin/images/index.html.erb
@@ -51,7 +51,7 @@
           <td><%= image.alt %></td>
           <td class="actions">
             <% if can?(:update, image) %>
-              <%= link_to_with_icon 'edit', Spree.t(:edit), edit_admin_product_image_url(@product, image), :no_text => true, :data => {:action => 'edit'} %>
+              <%= link_to_with_icon 'edit', Spree.t('actions.edit'), edit_admin_product_image_url(@product, image), :no_text => true, :data => {:action => 'edit'} %>
             <% end %>
             <% if can?(:destroy, image) %>
               <%= link_to_delete image, { :url => admin_product_image_url(@product, image), :no_text => true } %>

--- a/backend/app/views/spree/admin/orders/_line_items.html.erb
+++ b/backend/app/views/spree/admin/orders/_line_items.html.erb
@@ -37,8 +37,8 @@
             <% if can? :update, item %>
               <%= link_to '', '#', :class => 'save-line-item fa fa-ok no-text with-tip',       :title => Spree.t('actions.save') %>
               <%= link_to '', '#', :class => 'cancel-line-item fa fa-cancel no-text with-tip', :title => Spree.t('actions.cancel') %>
-              <%= link_to '', '#', :class => 'edit-line-item fa fa-edit no-text with-tip',     :title => Spree.t('edit') %>
-              <%= link_to '', '#', :class => 'delete-line-item fa fa-trash no-text with-tip',  :title => Spree.t('delete') %>
+              <%= link_to '', '#', :class => 'edit-line-item fa fa-edit no-text with-tip',     :title => Spree.t('actions.edit') %>
+              <%= link_to '', '#', :class => 'delete-line-item fa fa-trash no-text with-tip',  :title => Spree.t('actions.delete') %>
             <% end %>
           </td>
         <% end %>

--- a/backend/app/views/spree/admin/orders/_shipment.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment.html.erb
@@ -16,7 +16,7 @@
           <%= hidden_field_tag :send_mailer, false %>
           <%= check_box_tag :send_mailer, true, true %>
           <%= label_tag :send_mailer, Spree.t(:send_mailer) %>
-          <%= submit_tag Spree.t(:ship), class: "ship-shipment-button" %>
+          <%= submit_tag Spree.t('actions.ship'), class: "ship-shipment-button" %>
         <% end %>
       <% end %>
     </fieldset>
@@ -77,7 +77,7 @@
 
             <td class="actions">
               <% if( (can? :update, shipment) and !shipment.shipped?) %>
-                <%= link_to '', '#', :class => 'edit-method fa fa-edit no-text with-tip', :data => {:action => 'edit'}, :title => Spree.t('edit') %>
+                <%= link_to '', '#', :class => 'edit-method fa fa-edit no-text with-tip', :data => {:action => 'edit'}, :title => Spree.t('actions.edit') %>
               <% end %>
             </td>
           </tr>
@@ -113,7 +113,7 @@
           </td>
           <td class="actions">
             <% if can? :update, shipment %>
-              <%= link_to '', '#', :class => 'edit-tracking fa fa-edit no-text with-tip', :data => {:action => 'edit'}, :title => Spree.t('edit') %>
+              <%= link_to '', '#', :class => 'edit-tracking fa fa-edit no-text with-tip', :data => {:action => 'edit'}, :title => Spree.t('actions.edit') %>
             <% end %>
           </td>
         </tr>

--- a/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
@@ -24,8 +24,8 @@
       <% if can? :update, item %>
         <%= link_to '', '#', :class => 'save-item fa fa-check no-text with-tip', :data => {'shipment-number' => shipment_number, 'variant-id' => item.variant.id, :action => 'save'}, :title => Spree.t('actions.save'), :style => 'display: none' %>
         <%= link_to '', '#', :class => 'cancel-item fa fa-cancel no-text with-tip', :data => {:action => 'cancel'}, :title => Spree.t('actions.cancel'), :style => 'display: none' %>
-        <%= link_to '', '#', :class => 'split-item icon_link fa fa-arrows-h no-text with-tip', :data => {:action => 'split', 'variant-id' => item.variant.id}, :title => Spree.t('split') %>
-        <%= link_to '', '#', :class => 'delete-item fa fa-trash no-text with-tip', :data => { 'line-item-id' => item.line_item.id}, :title => Spree.t('delete') %>
+        <%= link_to '', '#', :class => 'split-item icon_link fa fa-arrows-h no-text with-tip', :data => {:action => 'split', 'variant-id' => item.variant.id}, :title => Spree.t('actions.split') %>
+        <%= link_to '', '#', :class => 'delete-item fa fa-trash no-text with-tip', :data => { 'line-item-id' => item.line_item.id}, :title => Spree.t('actions.delete') %>
       <% end %>
     </td>
   </tr>

--- a/backend/app/views/spree/admin/shared/_refunds.html.erb
+++ b/backend/app/views/spree/admin/shared/_refunds.html.erb
@@ -23,7 +23,7 @@
         <td class="align-center"><%= truncate(refund.reason.name, length: 100) %></td>
         <% if show_actions %>
           <td class="actions">
-            <%= link_to_with_icon 'edit', Spree.t(:edit), edit_admin_order_payment_refund_path(refund.payment.order, refund.payment, refund), no_text: true %>
+            <%= link_to_with_icon 'edit', Spree.t('actions.edit'), edit_admin_order_payment_refund_path(refund.payment.order, refund.payment, refund), no_text: true %>
           </td>
         <% end %>
       </tr>

--- a/backend/app/views/spree/admin/states/_state_list.html.erb
+++ b/backend/app/views/spree/admin/states/_state_list.html.erb
@@ -18,7 +18,7 @@
         <td class="align-center"><%= state.abbr %></td>
         <td class="actions">
           <% if can?(:update, state) %>
-            <%= link_to_with_icon 'edit', Spree.t(:edit), edit_admin_country_state_url(@country, state), :no_text => true %>
+            <%= link_to_with_icon 'edit', Spree.t('actions.edit'), edit_admin_country_state_url(@country, state), :no_text => true %>
           <% end %>
           <% if can?(:destroy, state) %>
             <%= link_to_delete state, :no_text => true %>

--- a/backend/app/views/spree/admin/stock_transfers/_transfer_item_actions.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/_transfer_item_actions.html.erb
@@ -2,7 +2,7 @@
   <%= render partial: 'spree/admin/shared/number_field_update_cell', locals: { resource_id: item.id, field_tag: "#{quantity_type}_quantity", number_value: item.send("#{quantity_type}_quantity") } %>
   <td class="actions">
     <%= render partial: 'spree/admin/shared/number_field_update_actions', locals: { resource: item, update_data: {} } %>
-    <%= link_to_with_icon 'trash', Spree.t('delete'), '#', no_text: true, data: { action: 'remove', id: item.id } if quantity_type == 'expected' && can?(:destroy, item) %>
+    <%= link_to_with_icon 'trash', Spree.t('actions.delete'), '#', no_text: true, data: { action: 'remove', id: item.id } if quantity_type == 'expected' && can?(:destroy, item) %>
   </td>
 <% else %>
   <td class='align-center'><%= item.send("#{quantity_type}_quantity") %></td>

--- a/backend/app/views/spree/admin/stock_transfers/tracking_info.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/tracking_info.html.erb
@@ -7,7 +7,7 @@
     <%= button_link_to Spree.t(:back_to_stock_transfers_list), admin_stock_transfers_path, icon: 'arrow-left' %>
   </li>
   <li>
-    <%= button_link_to Spree.t(:ship), '#', icon: 'check', id: 'confirm-ship-transfer-button' %>
+    <%= button_link_to Spree.t('actions.ship'), '#', icon: 'check', id: 'confirm-ship-transfer-button' %>
   </li>
 <% end %>
 

--- a/backend/app/views/spree/admin/store_credits/show.html.erb
+++ b/backend/app/views/spree/admin/store_credits/show.html.erb
@@ -49,7 +49,7 @@
     </td>
     <td class='actions align-center'>
       <% if can?(:update, @store_credit) %>
-        <%= link_to '', '#', class: 'js-edit-memo edit-method fa fa-edit no-text with-tip', data: { action: 'edit' }, title: Spree.t('edit') %>
+        <%= link_to '', '#', class: 'js-edit-memo edit-method fa fa-edit no-text with-tip', data: { action: 'edit' }, title: Spree.t('actions.edit') %>
       <% end %>
     </td>
   </tr>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -473,6 +473,7 @@ en:
       cancel: Cancel
       continue: Continue
       create: Create
+      delete: Delete
       destroy: Destroy
       edit: Edit
       list: List
@@ -483,6 +484,8 @@ en:
       remove: Remove
       save: Save
       update: Update
+      split: Split
+      ship: ship
     activate: Activate
     active: Active
     add: Add

--- a/frontend/app/views/spree/shared/_order_details.html.erb
+++ b/frontend/app/views/spree/shared/_order_details.html.erb
@@ -3,18 +3,18 @@
   <% if order.has_step?("address") %>
 
     <div class="columns alpha four" data-hook="order-bill-address">
-      <h6><%= Spree.t(:billing_address) %> <%= link_to "(#{Spree.t(:edit)})", checkout_state_path(:address) unless order.completed? %></h6>
+      <h6><%= Spree.t(:billing_address) %> <%= link_to "(#{Spree.t('actions.edit')})", checkout_state_path(:address) unless order.completed? %></h6>
       <%= render :partial => 'spree/shared/address', :locals => { :address => order.bill_address } %>
     </div>
 
     <% if order.has_step?("delivery") %>
       <div class="columns alpha four" data-hook="order-ship-address">
-        <h6><%= Spree.t(:shipping_address) %> <%= link_to "(#{Spree.t(:edit)})", checkout_state_path(:address) unless order.completed? %></h6>
+        <h6><%= Spree.t(:shipping_address) %> <%= link_to "(#{Spree.t('actions.edit')})", checkout_state_path(:address) unless order.completed? %></h6>
         <%= render :partial => 'spree/shared/address', :locals => { :address => order.ship_address } %>
       </div>
 
       <div class="columns alpha four" data-hook="order-shipment">
-        <h6><%= Spree.t(:shipments) %> <%= link_to "(#{Spree.t(:edit)})", checkout_state_path(:delivery) unless order.completed? %></h6>
+        <h6><%= Spree.t(:shipments) %> <%= link_to "(#{Spree.t('actions.edit')})", checkout_state_path(:delivery) unless order.completed? %></h6>
         <div class="delivery">
           <% order.shipments.each do |shipment| %>
             <div>
@@ -30,7 +30,7 @@
 
   <% if order.has_step?("payment") %>
     <div class="columns omega four">
-      <h6><%= Spree.t(:payment_information) %> <%= link_to "(#{Spree.t(:edit)})", checkout_state_path(:payment) unless order.completed? %></h6>
+      <h6><%= Spree.t(:payment_information) %> <%= link_to "(#{Spree.t('actions.edit')})", checkout_state_path(:payment) unless order.completed? %></h6>
       <div class="payment-info">
         <% order.payments.valid.each do |payment| %>
           <%= render payment %><br/>


### PR DESCRIPTION
This is to better utilize I18n with more verbosity to make it clear and easier to translate. 

Clarifying distinctly that they are actions should make this more clear.  This is cherry-picked from #549 and is part of an ongoing meta-issue to improve I18n functionality as discussed in #735.