### PR TITLE
Use attribute translations for customer return forms

### DIFF
--- a/backend/app/views/spree/admin/customer_returns/_reimbursements_table.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/_reimbursements_table.html.erb
@@ -1,10 +1,10 @@
 <table class="index customer-return-reimbursements">
   <thead data-hook="customer_return_header">
     <tr>
-      <th><%= Spree.t(:number) %></th>
-      <th><%= Spree.t(:total) %></th>
-      <th><%= Spree.t(:status) %></th>
-      <th><%= "#{Spree.t('date')}/#{Spree.t('time')}" %></th>
+      <th><%= Spree::Reimbursement.human_attribute_name(:number) %></th>
+      <th><%= Spree::Reimbursement.human_attribute_name(:total) %></th>
+      <th><%= Spree::Reimbursement.human_attribute_name(:reimbursement_status) %></th>
+      <th><%= Spree::Reimbursement.human_attribute_name(:created_at) %></th>
       <th class="actions"></th>
     </tr>
   </thead>

--- a/backend/app/views/spree/admin/customer_returns/_return_item_decision.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/_return_item_decision.html.erb
@@ -2,14 +2,14 @@
   <thead>
     <tr>
       <th><%= Spree::Product.model_name.human %></th>
-      <th><%= Spree.t(:sku) %></th>
-      <th><%= Spree.t(:pre_tax_amount) %></th>
-      <th><%= Spree.t(:preferred_reimbursement_type) %></th>
-      <th><%= Spree.t(:exchange_for) %></th>
-      <th><%= Spree.t(:acceptance_errors) %></th>
-      <th><%= Spree.t(:reception_status) %></th>
+      <th><%= Spree::Variant.human_attribute_name(:sku) %></th>
+      <th><%= Spree::ReturnItem.human_attribute_name(:pre_tax_amount) %></th>
+      <th><%= Spree::ReturnItem.human_attribute_name(:preferred_reimbursement_type) %></th>
+      <th><%= Spree::ReturnItem.human_attribute_name(:exchange_variant) %></th>
+      <th><%= Spree::ReturnItem.human_attribute_name(:acceptance_status_errors) %></th>
+      <th><%= Spree::ReturnItem.human_attribute_name(:reception_status) %></th>
       <% unless return_items.all?(&:received?)%>
-        <th><%= Spree.t(:item_received?) %></th>
+        <th><%= Spree::ReturnItem.human_attribute_name(:item_received?) %></th>
       <% end %>
       <% if show_decision %>
         <th class="actions"></th>

--- a/backend/app/views/spree/admin/customer_returns/_return_item_selection.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/_return_item_selection.html.erb
@@ -5,13 +5,13 @@
         <%= check_box_tag 'select-all' %>
       </th>
       <th><%= Spree::Product.model_name.human %></th>
-      <th><%= Spree.t(:sku) %></th>
-      <th><%= Spree.t(:pre_tax_amount) %></th>
-      <th><%= Spree.t(:state) %></th>
-      <th><%= Spree.t(:exchange_for) %></th>
-      <th><%= Spree.t(:resellable?) %></th>
-      <th><%= Spree.t(:reception_status) %></th>
-      <th><%= Spree.t(:reason) %></th>
+      <th><%= Spree::Variant.human_attribute_name(:sku) %></th>
+      <th><%= Spree::ReturnItem.human_attribute_name(:pre_tax_amount) %></th>
+      <th><%= Spree::ReturnItem.human_attribute_name(:inventory_unit_state) %></th>
+      <th><%= Spree::ReturnItem.human_attribute_name(:exchange_variant) %></th>
+      <th><%= Spree::ReturnItem.human_attribute_name(:resellable) %></th>
+      <th><%= Spree::ReturnItem.human_attribute_name(:reception_status) %></th>
+      <th><%= Spree::ReturnItem.human_attribute_name(:return_reason) %></th>
     </tr>
   </thead>
   <tbody>

--- a/backend/app/views/spree/admin/customer_returns/index.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/index.html.erb
@@ -17,11 +17,11 @@
   <table class="index">
     <thead data-hook="customer_return_header">
       <tr>
-        <th><%= Spree.t(:return_number) %></th>
-        <th><%= Spree.t(:pre_tax_total) %></th>
-        <th><%= Spree.t(:total) %></th>
-        <th><%= "#{Spree.t('date')}/#{Spree.t('time')}" %></th>
-        <th><%= Spree.t(:reimbursement_status) %></th>
+        <th><%= Spree::CustomerReturn.human_attribute_name(:number) %></th>
+        <th><%= Spree::CustomerReturn.human_attribute_name(:pre_tax_total) %></th>
+        <th><%= Spree::CustomerReturn.human_attribute_name(:total) %></th>
+        <th><%= Spree::CustomerReturn.human_attribute_name(:created_at) %></th>
+        <th><%= Spree::CustomerReturn.human_attribute_name(:reimbursement_status) %></th>
         <th class="actions"></th>
       </tr>
     </thead>

--- a/backend/app/views/spree/admin/customer_returns/new.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/new.html.erb
@@ -33,7 +33,7 @@
         </fieldset>
 
         <%= f.field_container :stock_location do %>
-          <%= f.label :stock_location, Spree.t(:stock_location) %>
+          <%= f.label :stock_location_id, Spree::StockLocation.model_name.human %>
           <%= f.select :stock_location_id, Spree::StockLocation.order_default.to_a.collect{|l|[l.name.humanize, l.id]}, {include_blank: true}, {class: 'select2 fullwidth', "data-placeholder" => Spree.t(:select_a_stock_location)} %>
           <%= f.error_message_on :stock_location_id %>
         <% end %>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -51,6 +51,12 @@ en:
         number: Number
         verification_value: Verification Value
         year: Year
+      spree/customer_return:
+        number: Return Number
+        pre_tax_total: Pre-Tax Total
+        total: Total
+        created_at: "Date/Time"
+        reimbursement_status: Reimbursement status
         name: Name
       spree/image:
         alt: Alternative Text
@@ -160,11 +166,27 @@ en:
         active: Active
         name: Name
         code: Code
+      spree/reimbursement:
+        created_at: "Date/Time"
+        number: Number
+        reimbursement_status: Status
+        total: Total
       spree/reimbursement_type:
         name: Name
         type: Type
       spree/return_authorization:
         amount: Amount
+      spree/return_item:
+        acceptance_status: Acceptance status
+        acceptance_status_errors: Acceptance errors
+        exchange_variant: Exchange for
+        inventory_unit_state: State
+        item_received?: "Item Received?"
+        pre_tax_amount: Pre-Tax Amount
+        preferred_reimbursement_type: Preferred Reimbursement Type
+        reception_status: Reception Status
+        resellable: "Resellable?"
+        return_reason: Reason
       spree/return_reason:
         name: Name
         active: Active

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -48,6 +48,7 @@ en:
         base: ''
         cc_type: Type
         month: Month
+        name: Name
         number: Number
         verification_value: Verification Value
         year: Year
@@ -183,7 +184,7 @@ en:
         inventory_unit_state: State
         item_received?: "Item Received?"
         pre_tax_amount: Pre-Tax Amount
-        preferred_reimbursement_type: Preferred Reimbursement Type
+        preferred_reimbursement_type_id: Preferred Reimbursement Type
         reception_status: Reception Status
         resellable: "Resellable?"
         return_reason: Reason


### PR DESCRIPTION
This is to better utilize I18n with more verbosity to make it clear and easier to translate.  By using attributes from the model it will be much more clear what is happening instead of taking the translation from "some place" in the dictionary.  

This is cherry picked from #549 and is part of an ongoing chain of PRs as discussed in #735 to improve the I18n implementation.

The only changes from the commit is not erasing things in the dictionary and adding `item_received?` to the ReturnItem section.