### PR TITLE
Address and state factory: Be valid outside the US

### DIFF
--- a/core/lib/spree/testing_support/factories/address_factory.rb
+++ b/core/lib/spree/testing_support/factories/address_factory.rb
@@ -1,24 +1,30 @@
 require 'spree/testing_support/factories/state_factory'
 require 'spree/testing_support/factories/country_factory'
+require 'twitter_cldr'
 
 FactoryGirl.define do
   factory :address, class: Spree::Address do
+    transient do
+      # There's `Spree::Address#country_iso=`, prohibiting me from using `country_iso` here
+      country_iso_code 'US'
+    end
+
     firstname 'John'
     lastname 'Doe'
     company 'Company'
     address1 '10 Lovely Street'
     address2 'Northwest'
     city 'Herndon'
-    zipcode '35005'
+    zipcode { TwitterCldr::Shared::PostalCodes.for_territory(country_iso_code).sample.first }
     phone '555-555-0199'
     alternative_phone '555-555-0199'
 
-    state { |address| address.association(:state) }
+    state { |address| address.association(:state, country_iso: country_iso_code) }
     country do |address|
       if address.state
         address.state.country
       else
-        address.association(:country)
+        address.association(:country, iso: country_iso_code)
       end
     end
   end

--- a/core/lib/spree/testing_support/factories/address_factory.rb
+++ b/core/lib/spree/testing_support/factories/address_factory.rb
@@ -7,6 +7,7 @@ FactoryGirl.define do
     transient do
       # There's `Spree::Address#country_iso=`, prohibiting me from using `country_iso` here
       country_iso_code 'US'
+      state_code 'AL'
     end
 
     firstname 'John'
@@ -19,7 +20,11 @@ FactoryGirl.define do
     phone '555-555-0199'
     alternative_phone '555-555-0199'
 
-    state { |address| address.association(:state, country_iso: country_iso_code) }
+    state do |address|
+      Spree::State.joins(:country).where('spree_countries.iso = (?)', country_iso_code).find_by(abbr: state_code) ||
+        address.association(:state, country_iso: country_iso_code, state_code: state_code)
+    end
+
     country do |address|
       if address.state
         address.state.country

--- a/core/lib/spree/testing_support/factories/state_factory.rb
+++ b/core/lib/spree/testing_support/factories/state_factory.rb
@@ -2,13 +2,22 @@ require 'spree/testing_support/factories/country_factory'
 
 FactoryGirl.define do
   factory :state, class: Spree::State do
-    name 'Alabama'
-    abbr 'AL'
+    transient do
+      country_iso 'US'
+      carmen_subregion do
+        Carmen::Country.coded(country_iso).subregions.sort_by(&:name).first ||
+          fail("Unknown country iso code or no Country has no subregions: #{country_iso.inspect}")
+      end
+    end
+
+    abbr { carmen_subregion.code }
+    name { carmen_subregion.name }
+
     country do |country|
-      if usa = Spree::Country.find_by_numcode(840)
+      if usa = Spree::Country.find_by(iso: country_iso)
         country = usa
       else
-        country.association(:country)
+        country.association(:country, iso: country_iso)
       end
     end
   end

--- a/core/lib/spree/testing_support/factories/state_factory.rb
+++ b/core/lib/spree/testing_support/factories/state_factory.rb
@@ -4,8 +4,10 @@ FactoryGirl.define do
   factory :state, class: Spree::State do
     transient do
       country_iso 'US'
+      state_code 'AL'
       carmen_subregion do
-        Carmen::Country.coded(country_iso).subregions.sort_by(&:name).first ||
+        Carmen::Country.coded(country_iso).subregions.coded(state_code) ||
+          Carmen::Country.coded(country_iso).subregions.sort_by(&:name).first ||
           fail("Unknown country iso code or no Country has no subregions: #{country_iso.inspect}")
       end
     end
@@ -14,11 +16,8 @@ FactoryGirl.define do
     name { carmen_subregion.name }
 
     country do |country|
-      if usa = Spree::Country.find_by(iso: country_iso)
-        country = usa
-      else
+      Spree::Country.find_by(iso: country_iso) ||
         country.association(:country, iso: country_iso)
-      end
     end
   end
 end

--- a/core/spec/lib/spree/core/testing_support/factories/address_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/address_factory_spec.rb
@@ -29,4 +29,19 @@ RSpec.describe 'address factory' do
       expect(subject).to be_valid
     end
   end
+
+  describe 'when passing in a state and country' do
+    subject { build(:address, country_iso_code: country_iso_code, state_code: state_code) }
+
+    context 'when the country has a state with proper code' do
+      let(:country_iso_code) { "US" }
+      let(:state_code) { "NY" }
+
+      it 'works' do
+        expect(subject).to be_valid
+        expect(subject.state.abbr).to eq("NY")
+        expect(subject.country.iso).to eq("US")
+      end
+    end
+  end
 end

--- a/core/spec/lib/spree/core/testing_support/factories/address_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/address_factory_spec.rb
@@ -21,4 +21,12 @@ RSpec.describe 'address factory' do
 
     it_behaves_like 'a working factory'
   end
+
+  describe 'when passing in a country iso code' do
+    subject { build(:address, country_iso_code: "RO") }
+
+    it 'creates a valid address with actually valid data' do
+      expect(subject).to be_valid
+    end
+  end
 end

--- a/core/spec/lib/spree/core/testing_support/factories/state_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/state_factory_spec.rb
@@ -4,9 +4,21 @@ require 'spree/testing_support/factories/state_factory'
 RSpec.describe 'state factory' do
   let(:factory_class) { Spree::State }
 
-  describe 'plain shipping rate' do
+  describe 'plain state' do
     let(:factory) { :state }
 
     it_behaves_like 'a working factory'
+
+    it 'is Alabama' do
+      expect(build(factory).abbr).to eq('AL')
+      expect(build(factory).name).to eq('Alabama')
+    end
+  end
+
+  describe 'when give a country iso code' do
+    it 'creates the first state for that country it finds in carmen' do
+      expect(build(:state, country_iso: "DE").abbr).to eq("BW")
+      expect(build(:state, country_iso: "DE").name).to eq("Baden-Württemberg")
+    end
   end
 end


### PR DESCRIPTION
Allow the state factory to use a `country_iso` flag to be passed in
and then select the name and abbreviation as the first subregion
from that state.

Also, make the address factory accept a `country_iso_code` flag that will result in the following: 
- The address will have a valid ZIP code for that country, provided by `twitter_cldr`
- The address will have the first state from the actual country

I think we're fine with the User being called `John Doe` :) 