### PR TITLE
Move 'add' action into 'actions' namespace.

### DIFF
--- a/backend/app/views/spree/admin/promotions/_actions.html.erb
+++ b/backend/app/views/spree/admin/promotions/_actions.html.erb
@@ -10,7 +10,7 @@
           <%= select_tag 'action_type', options, :class => 'select2 fullwidth' %>
         </div>
         <div class="filter-actions actions">
-          <%= button Spree.t(:add), 'plus' %>
+          <%= button Spree.t('actions.add'), 'plus' %>
         </div>
       <% end %>
     </fieldset>

--- a/backend/app/views/spree/admin/promotions/_rules.html.erb
+++ b/backend/app/views/spree/admin/promotions/_rules.html.erb
@@ -10,7 +10,7 @@
           <%= select_tag('promotion_rule[type]', options_for_promotion_rule_types(@promotion), :class => 'select2 fullwidth') %>
         </div>
         <div class="filter-actions actions">
-          <%= button Spree.t(:add), 'plus' %>
+          <%= button Spree.t('actions.add'), 'plus' %>
         </div>
       <% end %>
     </fieldset>

--- a/backend/app/views/spree/admin/promotions/calculators/tiered_flat_rate/_fields.html.erb
+++ b/backend/app/views/spree/admin/promotions/calculators/tiered_flat_rate/_fields.html.erb
@@ -11,4 +11,4 @@
   'form-prefix' => prefix,
   'calculator' => 'tiered_flat_rate'
 } %>
-<button class="fa fa-plus button js-add-tier"><%= Spree.t(:add) %></button>
+<button class="fa fa-plus button js-add-tier"><%= Spree.t('actions.add') %></button>

--- a/backend/app/views/spree/admin/promotions/calculators/tiered_percent/_fields.html.erb
+++ b/backend/app/views/spree/admin/promotions/calculators/tiered_percent/_fields.html.erb
@@ -11,4 +11,4 @@
   'form-prefix' => prefix,
   'calculator' => 'tiered_percent'
 } %>
-<button class="fa fa-plus button js-add-tier"><%= Spree.t(:add) %></button>
+<button class="fa fa-plus button js-add-tier"><%= Spree.t('actions.add') %></button>

--- a/backend/app/views/spree/admin/promotions/rules/_option_value.html.erb
+++ b/backend/app/views/spree/admin/promotions/rules/_option_value.html.erb
@@ -6,7 +6,7 @@
 
   <div class="js-promo-rule-option-values"></div>
 
-  <button class="fa fa-plus button js-add-promo-rule-option-value"><%= Spree.t(:add) %></button>
+  <button class="fa fa-plus button js-add-promo-rule-option-value"><%= Spree.t('actions.add') %></button>
 </div>
 
 <%= content_tag :div, nil, class: "hidden js-original-promo-rule-option-values",

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -403,6 +403,7 @@ en:
     account_updated: Account updated
     action: Action
     actions:
+      add: Add
       cancel: Cancel
       continue: Continue
       create: Create


### PR DESCRIPTION
This is to increase the verbosity of I18n usage in the project.  The add action has been moved into the actions namespace.

This work was cherry-picked from #549 with a slight correction and change to not delete anything from the dictionary.  It is part of an ongoing issue as discussed in #735.