### PR TITLE
Uses model_name.human for payment log entries index

### DIFF
--- a/backend/app/views/spree/admin/log_entries/index.html.erb
+++ b/backend/app/views/spree/admin/log_entries/index.html.erb
@@ -2,7 +2,7 @@
 
 <% content_for :page_title do %>
   <i class="fa fa-arrow-right"></i>
-  <%= I18n.t(:one, scope: "activerecord.models.spree/payment") %>
+  <%= Spree::Payment.model_name.human %>
   <i class="fa fa-arrow-right"></i>
   <%= Spree.t(:log_entries) %>
 <% end %>


### PR DESCRIPTION
This is to make much better use of I18n and be nicer to non English speakers and everyone else.

Cherry picked straight from #549 as part of an ongoing effort to improve I18n as discussed in #735.  