### PR TITLE
Put remove into 'actions' translations scope

### DIFF
--- a/backend/app/helpers/spree/admin/base_helper.rb
+++ b/backend/app/helpers/spree/admin/base_helper.rb
@@ -147,7 +147,7 @@ module Spree
         options[:class] = '' unless options[:class]
         options[:class] += 'no-text with-tip' if options[:no_text]
         url = f.object.persisted? ? [:admin, f.object] : '#'
-        link_to_with_icon('trash', name, url, class: "spree_remove_fields #{options[:class]}", data: { action: 'remove' }, title: Spree.t(:remove)) + f.hidden_field(:_destroy)
+        link_to_with_icon('trash', name, url, class: "spree_remove_fields #{options[:class]}", data: { action: 'remove' }, title: Spree.t('actions.remove')) + f.hidden_field(:_destroy)
       end
 
       def spree_dom_id(record)

--- a/backend/app/views/spree/admin/option_types/_option_value_fields.html.erb
+++ b/backend/app/views/spree/admin/option_types/_option_value_fields.html.erb
@@ -7,5 +7,5 @@
   <% end %>
   <td colspan="<%= f.object.persisted? ? '' : '2' %>" class="name"><%= f.text_field :name %></td>
   <td class="presentation"><%= f.text_field :presentation %></td>
-  <td class="actions"><%= link_to_remove_fields Spree.t(:remove), f, :no_text => true %></td>
+  <td class="actions"><%= link_to_remove_fields Spree.t('actions.remove'), f, :no_text => true %></td>
 </tr>

--- a/backend/app/views/spree/admin/taxons/_taxon_table.html.erb
+++ b/backend/app/views/spree/admin/taxons/_taxon_table.html.erb
@@ -12,7 +12,7 @@
         <td><%= taxon.name %></td>
         <td><%= taxon_path taxon %></td>
         <td class="actions">
-          <%= link_to_delete taxon, :url => remove_admin_product_taxon_url(@product, taxon), :name => icon('delete') + ' ' + Spree.t(:remove) %>
+          <%= link_to_delete taxon, :url => remove_admin_product_taxon_url(@product, taxon), :name => icon('delete') + ' ' + Spree.t('actions.remove') %>
         </td>
       </tr>
     <% end %>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -413,6 +413,7 @@ en:
       new: New
       refund: Refund
       receive: Receive
+      remove: Remove
       save: Save
       update: Update
     activate: Activate


### PR DESCRIPTION
This is to better utilize I18n with more verbosity to make it clear and easier to translate. 

It is cherry picked from #549 and part of an ongoing attempt to improve I18n use as discussed in #735.