### PR TITLE
Use model translations for option types forms

### DIFF
--- a/backend/app/views/spree/admin/option_types/_form.html.erb
+++ b/backend/app/views/spree/admin/option_types/_form.html.erb
@@ -1,7 +1,7 @@
 <div data-hook="admin_option_type_form_fields" class="align-center row">
   <div class="alpha eight columns">
     <%= f.field_container :name do %>
-      <%= f.label :name, Spree.t(:name), class: 'required' %><br />
+      <%= f.label :name, class: 'required' %><br />
       <%= f.text_field :name, :class => "fullwidth" %>
       <%= f.error_message_on :name %>
     <% end %>
@@ -9,7 +9,7 @@
 
   <div class="omega eight columns">
     <%= f.field_container :presentation do %>
-      <%= f.label :presentation, Spree.t(:presentation), class: 'required' %><br />
+      <%= f.label :presentation, class: 'required' %><br />
       <%= f.text_field :presentation, :class => "fullwidth" %>
       <%= f.error_message_on :presentation %>
     <% end %>

--- a/backend/app/views/spree/admin/option_types/edit.html.erb
+++ b/backend/app/views/spree/admin/option_types/edit.html.erb
@@ -24,8 +24,8 @@
     <table class="index sortable" data-hook data-sortable-link="<%= update_values_positions_admin_option_types_url %>">
       <thead data-hook="option_header">
         <tr>
-          <th colspan="2"><%= Spree.t(:name) %></th>
-          <th><%= Spree.t(:display) %></th>
+          <th colspan="2"><%= Spree::OptionValue.human_attribute_name(:name) %></th>
+          <th><%= Spree::OptionValue.human_attribute_name(:presentation) %></th>
           <th class="actions"></th>
         </tr>
       </thead>

--- a/backend/app/views/spree/admin/option_types/index.html.erb
+++ b/backend/app/views/spree/admin/option_types/index.html.erb
@@ -23,8 +23,8 @@
   <thead>
     <tr data-hook="option_header">
       <th class="no-border"></th>
-      <th><%= Spree.t(:name) %></th>
-      <th><%= Spree.t(:presentation) %></th>
+      <th><%= Spree::OptionType.human_attribute_name(:name) %></th>
+      <th><%= Spree::OptionType.human_attribute_name(:presentation) %></th>
       <th class="actions"></th>
     </tr>
   </thead>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -50,6 +50,9 @@ en:
       spree/option_type:
         name: Name
         presentation: Presentation
+      spree/option_value:
+        name: Name
+        presentation: Presentation
       spree/order:
         checkout_complete: Checkout Complete
         completed_at: Completed At


### PR DESCRIPTION
This is to better use I18n to help localization into other languages.  Translations off of model attributes will be used in lieu of pulling words from the dictionary located somewhere in there.

This is cherry picked from #549 and is part of an ongoing attempt to improve the I18n logic as discussed in #735.