### PR TITLE
Use model translations in admin orders table view

### DIFF
--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -115,18 +115,18 @@
     <thead>
       <tr data-hook="admin_orders_index_headers">
         <% if @show_only_completed %>
-          <th><%= sort_link @search, :completed_at,   I18n.t(:completed_at, :scope => 'activerecord.attributes.spree/order') %></th>
+          <th><%= sort_link @search, :completed_at %></th>
         <% else %>
-          <th><%= sort_link @search, :created_at,     I18n.t(:created_at, :scope => 'activerecord.attributes.spree/order') %></th>
+          <th><%= sort_link @search, :created_at %></th>
         <% end %>
-        <th><%= sort_link @search, :number,           I18n.t(:number, :scope => 'activerecord.attributes.spree/order') %></th>
-        <th><%= sort_link @search, :state,            I18n.t(:state, :scope => 'activerecord.attributes.spree/order') %></th>
-        <th><%= sort_link @search, :payment_state,    I18n.t(:payment_state, :scope => 'activerecord.attributes.spree/order') %></th>
-         <% if Spree::Order.checkout_step_names.include?(:delivery) %>
-          <th><%= sort_link @search, :shipment_state, I18n.t(:shipment_state, :scope => 'activerecord.attributes.spree/order') %></th>
-         <% end %>
-        <th><%= sort_link @search, :email,            I18n.t(:email, :scope => 'activerecord.attributes.spree/order') %></th>
-        <th><%= sort_link @search, :total,            I18n.t(:total, :scope => 'activerecord.attributes.spree/order') %></th>
+        <th><%= sort_link @search, :number %></th>
+        <th><%= sort_link @search, :state %></th>
+        <th><%= sort_link @search, :payment_state %></th>
+        <% if Spree::Order.checkout_step_names.include?(:delivery) %>
+          <th><%= sort_link @search, :shipment_state %></th>
+        <% end %>
+        <th><%= sort_link @search, :email %></th>
+        <th><%= sort_link @search, :total %></th>
         <th data-hook="admin_orders_index_header_actions" class="actions"></th>
       </tr>
     </thead>


### PR DESCRIPTION
This will allow active record to find the correct I18n translation for us instead of needlessly adding unnecessary code.  It is much simpler and cleaner.

This is cherry picked directly from #549 and is part of an ongoing effort to improve I18n implementation as discussed in #735.