### PR TITLE
Use model translations in order line item views

### DIFF
--- a/backend/app/views/spree/admin/orders/_carton.html.erb
+++ b/backend/app/views/spree/admin/orders/_carton.html.erb
@@ -20,10 +20,10 @@
     </colgroup>
 
     <thead>
-      <th colspan="2"><%= Spree.t(:item_description) %></th>
-      <th><%= Spree.t(:price) %></th>
-      <th><%= Spree.t(:quantity) %></th>
-      <th><%= Spree.t(:total) %></th>
+      <th colspan="2"><%= Spree::LineItem.human_attribute_name(:description) %></th>
+      <th><%= Spree::LineItem.human_attribute_name(:price) %></th>
+      <th><%= Spree::LineItem.human_attribute_name(:quantity) %></th>
+      <th><%= Spree::LineItem.human_attribute_name(:total) %></th>
     </thead>
 
     <tbody data-hook="carton-details" data-shipment-number="<%= carton.number %>" data-order-number="<%= order.number %>">

--- a/backend/app/views/spree/admin/orders/_carton_manifest.html.erb
+++ b/backend/app/views/spree/admin/orders/_carton_manifest.html.erb
@@ -6,7 +6,8 @@
     <td class="item-name">
       <%= item.variant.product.name %><br><%= "(" + variant_options(item.variant) + ")" unless item.variant.option_values.empty? %>
       <% if item.variant.sku.present? %>
-        <strong><%= Spree.t(:sku) %>:</strong> <%= item.variant.sku %>
+        <strong><%= Spree::Variant.human_attribute_name(:sku) %>:</strong>
+        <%= item.variant.sku %>
       <% end %>
     </td>
     <td class="item-price align-center"><%= item.line_item.single_money.to_html %></td>

--- a/backend/app/views/spree/admin/orders/_line_items.html.erb
+++ b/backend/app/views/spree/admin/orders/_line_items.html.erb
@@ -8,10 +8,10 @@
     </colgroup>
 
     <thead>
-      <th colspan="2"><%= Spree.t(:name) %></th>
-      <th><%= Spree.t(:price) %></th>
-      <th><%= Spree.t(:quantity) %></th>
-      <th><%= Spree.t(:total_price) %></th>
+      <th colspan="2"><%= Spree::Product.human_attribute_name(:name) %></th>
+      <th><%= Spree::LineItem.human_attribute_name(:price) %></th>
+      <th><%= Spree::LineItem.human_attribute_name(:quantity) %></th>
+      <th><%= Spree::LineItem.human_attribute_name(:total) %></th>
       <th class="orders-actions actions" data-hook="admin_order_form_line_items_header_actions">&nbsp;</th>
     </thead>
 
@@ -22,7 +22,7 @@
           <td class="line-item-name">
             <%= item.variant.product.name %><br><%= "(" + variant_options(item.variant) + ")" unless item.variant.option_values.empty? %>
             <% if item.variant.sku.present? %>
-              <strong><%= Spree.t(:sku) %>:</strong> <%= item.variant.sku %>
+              <strong><%= Spree::Variant.human_attribute_name(:sku) %>:</strong> <%= item.variant.sku %>
             <% end %>
           </td>
           <td class="line-item-price align-center"><%= item.single_money.to_html %></td>

--- a/backend/app/views/spree/admin/orders/_shipment.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment.html.erb
@@ -32,10 +32,10 @@
       </colgroup>
 
       <thead>
-        <th colspan="2"><%= Spree.t(:item_description) %></th>
-        <th><%= Spree.t(:price) %></th>
-        <th><%= Spree.t(:quantity) %></th>
-        <th><%= Spree.t(:total) %></th>
+        <th colspan="2"><%= Spree::LineItem.human_attribute_name(:description) %></th>
+        <th><%= Spree::LineItem.human_attribute_name(:price) %></th>
+        <th><%= Spree::LineItem.human_attribute_name(:quantity) %></th>
+        <th><%= Spree::LineItem.human_attribute_name(:total) %></th>
         <th class="orders-actions actions" data-hook="admin_order_form_line_items_header_actions"></th>
       </thead>
 
@@ -46,7 +46,7 @@
           <tr class="edit-method hidden total">
             <td colspan="5">
               <div class="field alpha five columns">
-                <%= label_tag 'selected_shipping_rate_id', Spree.t(:shipping_method) %>
+                <%= label_tag 'selected_shipping_rate_id', Spree::ShippingMethod.model_name.human %>
                 <%= select_tag :selected_shipping_rate_id,
                       options_for_select(shipment.shipping_rates.map {|sr| ["#{sr.name} #{sr.display_price}", sr.id] }, shipment.selected_shipping_rate_id),
                       {:class => 'select2 fullwidth', :data => {'shipment-number' => shipment.number } } %>

--- a/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
@@ -6,7 +6,7 @@
     <td class="item-name">
       <%= item.variant.product.name %><br><%= "(" + variant_options(item.variant) + ")" unless item.variant.option_values.empty? %>
       <% if item.variant.sku.present? %>
-        <strong><%= Spree.t(:sku) %>:</strong> <%= item.variant.sku %>
+        <strong><%= Spree::Variant.human_attribute_name(:sku) %>:</strong> <%= item.variant.sku %>
       <% end %>
     </td>
     <td class="item-price align-center"><%= item.line_item.single_money.to_html %></td>

--- a/backend/app/views/spree/admin/orders/confirm/_shipment.html.erb
+++ b/backend/app/views/spree/admin/orders/confirm/_shipment.html.erb
@@ -11,11 +11,11 @@
   <table class="stock-contents index" data-hook="stock-contents">
     <thead>
       <th colspan="2">
-        <%= Spree.t(:item_description) %>
+        <%= Spree::LineItem.human_attribute_name(:description) %>
       </th>
-      <th><%= Spree.t(:price) %></th>
-      <th><%= Spree.t(:quantity) %></th>
-      <th><%= Spree.t(:total) %></th>
+      <th><%= Spree::LineItem.human_attribute_name(:price) %></th>
+      <th><%= Spree::LineItem.human_attribute_name(:quantity) %></th>
+      <th><%= Spree::LineItem.human_attribute_name(:total) %></th>
     </thead>
 
     <tbody data-shipment-number="<%= shipment.number %>" data-order-number="<%= order.number %>">

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -45,8 +45,10 @@ en:
       spree/inventory_unit:
         state: State
       spree/line_item:
+        description: Item Description
         price: Price
         quantity: Quantity
+        total: Total price
       spree/option_type:
         name: Name
         presentation: Presentation


### PR DESCRIPTION
This uses translations off of models instead of generic ones in the dictionary to be more clear and easier to localise.  It is a better use if I18n.

This is cherry-picked from #549 and is part of an ongoing attempt to improve I18n implementation as discussed in #735.