### PR TITLE
Add an inventory_states translation scope

### DIFF
--- a/backend/app/views/spree/admin/orders/_carton_manifest.html.erb
+++ b/backend/app/views/spree/admin/orders/_carton_manifest.html.erb
@@ -12,7 +12,7 @@
     <td class="item-price align-center"><%= item.line_item.single_money.to_html %></td>
     <td class="item-qty-show align-center">
         <% item.states.each do |state,count| %>
-          <%= count %> x <%= Spree.t(state).downcase %>
+          <%= count %> x <%= Spree.t(state, scope: 'inventory_states') %>
         <% end %>
     </td>
     <td class="item-qty-edit hidden">

--- a/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
@@ -12,7 +12,7 @@
     <td class="item-price align-center"><%= item.line_item.single_money.to_html %></td>
     <td class="item-qty-show align-center">
         <% item.states.each do |state,count| %>
-          <%= count %> x <%= Spree.t(state).downcase %>
+          <%= count %> x <%= Spree.t(state, scope: 'inventory_states') %>
         <% end %>
     </td>
     <td class="item-qty-edit hidden">

--- a/backend/app/views/spree/admin/orders/confirm/_shipment_manifest.html.erb
+++ b/backend/app/views/spree/admin/orders/confirm/_shipment_manifest.html.erb
@@ -12,7 +12,7 @@
     <td class="item-price align-center"><%= item.line_item.single_money.to_html %></td>
     <td class="item-qty-show align-center">
         <% item.states.each do |state,count| %>
-          <%= count %> x <%= Spree.t(state).downcase %>
+          <%= count %> x <%= Spree.t(state, scope: 'inventory_states') %>
         <% end %>
     </td>
     <td class="item-total align-center"><%= line_item_shipment_price(item.line_item, item.quantity) %></td>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -910,6 +910,12 @@ en:
     inventory_canceled: Inventory canceled
     inventory_error_flash_for_insufficient_quantity: An item in your cart has become unavailable.
     inventory_state: Inventory State
+    inventory_states:
+      backordered: backordered
+      canceled: canceled
+      on_hand: on hand
+      returned: returned
+      shipped: shipped
     is_not_available_to_shipment_address: is not available to shipment address
     iso_name: Iso Name
     item: Item


### PR DESCRIPTION
Scoping transition states to a particular area in I18n helps make it more clear what those translations belong to and should improve localisation efforts.  

This was cherry-picked from #549 and is part of an ongoing effort to improve I18n use as discussed in #735.