### PR TITLE
Uses model translation in order adjustments table

### DIFF
--- a/backend/app/views/spree/admin/orders/_adjustments.html.erb
+++ b/backend/app/views/spree/admin/orders/_adjustments.html.erb
@@ -3,8 +3,8 @@
     <legend><%= title %></legend>
     <table>
       <thead>
-        <th><%= Spree.t('name')%></th>
-        <th><%= Spree.t('amount')%></th>
+        <th><%= Spree::Adjustment.human_attribute_name(:name)%></th>
+        <th><%= Spree::Adjustment.human_attribute_name(:amount)%></th>
       </thead>
       <tbody id="order-charges" data-hook="order_details_adjustments"  class="with-border">
         <% adjustments.eligible.group_by(&:label).each do |label, adjustments| %>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -15,6 +15,7 @@ en:
         adjustable: Adjustable
         amount: Amount
         label: Description
+        name: Name
         state: State
         adjustment_reason_id: Reason
       spree/adjustment_reason:


### PR DESCRIPTION
Improve I18n use by using translations off of a model instead of arbitrary ones.  Eases localization.

Cherry picked from #549 and is part of an ongoing effort to improve I18n use as discussed in #735.