### PR TITLE
WIP: Only call `TaxRate.match` once per address

### DIFF
--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -4,12 +4,15 @@ module Spree
 
     belongs_to :country, class_name: "Spree::Country"
     belongs_to :state, class_name: "Spree::State"
+    belongs_to :zone, class_name: "Spree::Zone"
 
     validates :firstname, :lastname, :address1, :city, :country_id, presence: true
     validates :zipcode, presence: true, if: :require_zipcode?
     validates :phone, presence: true, if: :require_phone?
 
     validate :state_validate, :postal_code_validate
+
+    before_save :update_zone
 
     alias_attribute :first_name, :firstname
     alias_attribute :last_name, :lastname
@@ -156,6 +159,10 @@ module Spree
     end
 
     private
+
+    def update_zone
+      self.zone = Spree::Zone.match(self)
+    end
 
     def state_validate
       # Skip state validation without country (also required)

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -203,7 +203,7 @@ module Spree
     # Returns the relevant zone (if any) to be used for taxation purposes.
     # Uses default tax zone unless there is a specific match
     def tax_zone
-      @tax_zone ||= Zone.match(tax_address) || Zone.default_tax
+      @tax_zone ||= tax_address.try(:zone)  || Zone.default_tax
     end
 
     # Returns the address for taxation based on configuration

--- a/core/db/migrate/20160130171403_add_zone_to_spree_address.rb
+++ b/core/db/migrate/20160130171403_add_zone_to_spree_address.rb
@@ -1,0 +1,6 @@
+class AddZoneToSpreeAddress < ActiveRecord::Migration
+  def change
+    add_reference :spree_addresses, :zone, index: true
+    add_foreign_key :spree_addresses, :spree_zones, column: :zone_id
+  end
+end

--- a/core/spec/models/spree/address_spec.rb
+++ b/core/spec/models/spree/address_spec.rb
@@ -368,4 +368,14 @@ describe Spree::Address, type: :model do
 
     it { is_expected.to be_require_phone }
   end
+
+  context '#zone' do
+    let(:address) { build(:address) }
+    let(:zone) { create(:zone) }
+
+    it 'finds a matching zone after creation and saves it on the address' do
+      expect(Spree::Zone).to receive(:match).and_return(zone)
+      expect { address.save }.to change { address.zone }.from(nil).to(zone)
+    end
+  end
 end

--- a/core/spec/models/spree/order/tax_spec.rb
+++ b/core/spec/models/spree/order/tax_spec.rb
@@ -20,8 +20,8 @@ module Spree
         before { Spree::Config.set(tax_using_ship_address: true) }
 
         it "should calculate using ship_address" do
-          expect(Spree::Zone).to receive(:match).at_least(:once).with(ship_address)
-          expect(Spree::Zone).not_to receive(:match).with(bill_address)
+          expect(ship_address).to receive(:zone)
+          expect(bill_address).not_to receive(:zone)
           order.tax_zone
         end
       end
@@ -30,8 +30,8 @@ module Spree
         before { Spree::Config.set(tax_using_ship_address: false) }
 
         it "should calculate using bill_address" do
-          expect(Spree::Zone).to receive(:match).at_least(:once).with(bill_address)
-          expect(Spree::Zone).not_to receive(:match).with(ship_address)
+          expect(bill_address).to receive(:zone)
+          expect(ship_address).not_to receive(:zone)
           order.tax_zone
         end
       end


### PR DESCRIPTION
This will call the rather expensive `Spree::Zone.match` call for every address
before it is saved. The idea is to get that call out of the hot tax calculation path.

Don't look at this yet, I'm pushing this for CI builds. 