### PR TITLE
Use model translations in adjustment_reason view

### DIFF
--- a/backend/app/views/spree/admin/adjustment_reasons/index.html.erb
+++ b/backend/app/views/spree/admin/adjustment_reasons/index.html.erb
@@ -1,7 +1,7 @@
 <%= render partial: 'spree/admin/shared/configuration_menu' %>
 
 <% content_for :page_title do %>
-  <%= Spree.t(:adjustment_reasons) %>
+  <%= Spree::AdjustmentReason.model_name.human(count: :other) %>
 <% end %>
 
 <% content_for :page_actions do %>
@@ -44,7 +44,7 @@
   </table>
 <% else %>
   <div class="alpha twelve columns no-objects-found">
-    <%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: 'activerecord.models.spree/adjustment_reason')) %>,
+    <%= Spree.t(:no_resource_found, resource: Spree::AdjustmentReason.model_name.human(count: :other)) %>,
     <%= link_to Spree.t(:add_one), new_object_url %>!
   </div>
 <% end %>


### PR DESCRIPTION
The AdjustmentReason model is used in translations in the index view.

This is to make better use of I18n and to be nicer to non English speakers.

This is part of an ongoing issue being discussed in #735.