### PR TITLE
Remove admin/orders_controller#update

### DIFF
--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -89,16 +89,6 @@ module Spree
         end
       end
 
-      def update
-        @order.contents.update_cart(params[:order])
-        @order.errors.add(:line_items, Spree.t('errors.messages.blank')) if @order.line_items.empty?
-        if @order.completed?
-          render action: :edit
-        else
-          redirect_to admin_order_customer_path(@order)
-        end
-      end
-
       def advance
         if @order.completed?
           flash[:notice] = Spree.t('order_already_completed')

--- a/backend/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -336,31 +336,30 @@ describe Spree::Admin::OrdersController, type: :controller do
   end
 
   context '#authorize_admin' do
-    let(:user) { create(:user) }
-    let(:order) { create(:completed_order_with_totals, number: 'R987654321') }
+    let!(:user) { create(:user) }
+    let!(:order) { create(:completed_order_with_totals, number: 'R987654321') }
 
     before do
-      allow(Spree::Order).to receive_messages find_by_number!: order
       allow(controller).to receive_messages spree_current_user: user
     end
 
     it 'should grant access to users with an admin role' do
       user.spree_roles << Spree::Role.find_or_create_by(name: 'admin')
-      spree_post :index
+      spree_get :index
       expect(response).to render_template :index
     end
 
     it 'should grant access to users with an bar role' do
       user.spree_roles << Spree::Role.find_or_create_by(name: 'bar')
       Spree::Ability.register_ability(BarAbility)
-      spree_post :index
+      spree_get :index
       expect(response).to render_template :index
       Spree::Ability.remove_ability(BarAbility)
     end
 
     it 'should deny access to users without an admin role' do
       allow(user).to receive_messages has_spree_role?: false
-      spree_post :index
+      spree_get :index
       expect(response).to redirect_to('/unauthorized')
     end
 


### PR DESCRIPTION
This had some questionable logic:

* `render :edit` when `@order.completed?` ??
* Set an error message, which is actually an invalid translation (there's no `spree.errors.messages.blank`), and then redirect... losing that error message

No feature specs fail after removing this, which leads me to believe it isn't being used. The API should be used instead to provide this functionality.