### PR TITLE
Add adjustment reasons link to general settings

### DIFF
--- a/backend/app/views/spree/admin/shared/_configuration_menu.html.erb
+++ b/backend/app/views/spree/admin/shared/_configuration_menu.html.erb
@@ -66,6 +66,10 @@
       <% if can?(:display, Spree::ReturnReason) %>
         <%= configurations_sidebar_menu_item Spree.t(:return_reasons), admin_return_reasons_path %>
       <% end %>
+
+      <% if can?(:display, Spree::AdjustmentReason) %>
+        <%= configurations_sidebar_menu_item Spree.t(:adjustment_reasons), admin_adjustment_reasons_path %>
+      <% end %>
     </ul>
   </nav>
 <% end %>


### PR DESCRIPTION
Currently there is no link to the adjustment reasons index in the general settings or anywhere else.