### PR TITLE
Remove unused general settings routes

### DIFF
--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -129,7 +129,7 @@ Spree::Core::Engine.add_routes do
       end
     end
 
-    resource :general_settings do
+    resource :general_settings, only: [:edit, :update] do
       collection do
         post :clear_cache
       end


### PR DESCRIPTION
The routes for the actions that were removed did not even have corresponding methods on the controller.

Could look at cleaning up other unused routes going forward.