### PR TITLE
Allow creating state factory with existing country

### DIFF
--- a/core/lib/spree/testing_support/factories/state_factory.rb
+++ b/core/lib/spree/testing_support/factories/state_factory.rb
@@ -5,10 +5,12 @@ FactoryGirl.define do
     transient do
       country_iso 'US'
       state_code 'AL'
+
       carmen_subregion do
-        Carmen::Country.coded(country_iso).subregions.coded(state_code) ||
-          Carmen::Country.coded(country_iso).subregions.sort_by(&:name).first ||
-          fail("Unknown country iso code or no Country has no subregions: #{country_iso.inspect}")
+        carmen_country = Carmen::Country.coded(country.iso)
+        carmen_country.subregions.coded(state_code) ||
+          carmen_country.subregions.sort_by(&:name).first ||
+          fail("Country #{country.iso} has no subregions")
       end
     end
 

--- a/core/spec/lib/spree/core/testing_support/factories/address_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/address_factory_spec.rb
@@ -44,4 +44,16 @@ RSpec.describe 'address factory' do
       end
     end
   end
+
+  describe 'creating multiple addresses' do
+    let!(:address1) { create(:address) }
+    let!(:address2) { create(:address) }
+
+    it 'shares the same country and state objects' do
+      expect(address1.country).to eq(address2.country)
+      expect(address1.state).to eq(address2.state)
+      expect(Spree::Country.count).to eq(1)
+      expect(Spree::State.count).to eq(1)
+    end
+  end
 end

--- a/core/spec/lib/spree/core/testing_support/factories/state_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/state_factory_spec.rb
@@ -15,10 +15,34 @@ RSpec.describe 'state factory' do
     end
   end
 
-  describe 'when give a country iso code' do
+  describe 'when given a country iso code' do
+    let(:state) { build(:state, country_iso: "DE") }
     it 'creates the first state for that country it finds in carmen' do
-      expect(build(:state, country_iso: "DE").abbr).to eq("BW")
-      expect(build(:state, country_iso: "DE").name).to eq("Baden-Württemberg")
+      expect(state.abbr).to eq("BW")
+      expect(state.name).to eq("Baden-Württemberg")
+    end
+
+    context 'of an existing country' do
+      let!(:country){ create(:country, iso: "DE") }
+      it 'uses the existing country in the database' do
+        expect(state.country).to eq(country)
+        expect(Spree::Country.count).to eq(1)
+      end
+    end
+  end
+
+  describe 'when given a country record' do
+    let(:country) { build(:country, iso: "DE") }
+    let(:state) { build(:state, country: country) }
+    it 'creates the first state for that country it finds in carmen' do
+      expect(state.abbr).to eq("BW")
+      expect(state.name).to eq("Baden-Württemberg")
+    end
+  end
+
+  describe 'when given an invalid country iso code' do
+    it 'raises a helpful message' do
+      expect{ build(:state, country_iso: "ZZ") }.to raise_error(RuntimeError, 'Unknown country iso code: "ZZ"')
     end
   end
 end


### PR DESCRIPTION
This uses the iso code from an existing country if the object is passed in. Also adds additional specs to the country and address factory.

This builds off of @mamhoff's great work in #765