### PR TITLE
Improve I18n use in customer return views

### DIFF
--- a/backend/app/views/spree/admin/customer_returns/_return_item_decision.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/_return_item_decision.html.erb
@@ -1,7 +1,7 @@
 <table class="show return-items-table">
   <thead>
     <tr>
-      <th><%= Spree.t(:product) %></th>
+      <th><%= Spree::Product.model_name.human %></th>
       <th><%= Spree.t(:sku) %></th>
       <th><%= Spree.t(:pre_tax_amount) %></th>
       <th><%= Spree.t(:preferred_reimbursement_type) %></th>
@@ -45,7 +45,7 @@
           <td class='align-center'>
             <%= form_for [:admin, return_item] do |f| %>
               <%= f.hidden_field 'reception_status_event', value: 'receive' %>
-              <%= f.button Spree.t(:receive), class: 'fa icon_link no-text with-tip', "data-action" => 'save' %>
+              <%= f.button Spree.t('actions.receive'), class: 'fa icon_link no-text with-tip', "data-action" => 'save' %>
             <% end %>
           </td>
         <% end %>

--- a/backend/app/views/spree/admin/customer_returns/_return_item_selection.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/_return_item_selection.html.erb
@@ -4,7 +4,7 @@
       <th>
         <%= check_box_tag 'select-all' %>
       </th>
-      <th><%= Spree.t(:product) %></th>
+      <th><%= Spree::Product.model_name.human %></th>
       <th><%= Spree.t(:sku) %></th>
       <th><%= Spree.t(:pre_tax_amount) %></th>
       <th><%= Spree.t(:state) %></th>

--- a/backend/app/views/spree/admin/customer_returns/edit.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/edit.html.erb
@@ -1,7 +1,7 @@
 <%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Customer Returns' } %>
 
 <% content_for :page_title do %>
-  <i class="fa fa-arrow-right"></i> <%= Spree.t(:customer_return) %> #<%= @customer_return.number %>
+  <i class="fa fa-arrow-right"></i> <%= Spree::CustomerReturn.model_name.human %> #<%= @customer_return.number %>
 <% end %>
 
 <% content_for :page_actions do %>
@@ -54,7 +54,7 @@
 <% end %>
 
 <fieldset data-hook="reimbursements" class="no-border-bottom align-center">
-  <legend align="center"><%= Spree.t(:reimbursements) %></legend>
+  <legend align="center"><%= Spree::Reimbursement.model_name.human(count: :other) %></legend>
   <% if @customer_return.reimbursements.any? %>
     <%= render partial: 'reimbursements_table', locals: {reimbursements: @customer_return.reimbursements} %>
   <% else %>

--- a/backend/app/views/spree/admin/customer_returns/index.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/index.html.erb
@@ -10,7 +10,7 @@
 <% end %>
 
 <% content_for :page_title do %>
-  <i class="fa fa-arrow-right"></i> <%= Spree.t(:customer_returns) %>
+  <i class="fa fa-arrow-right"></i> <%= Spree::CustomerReturn.model_name.human(count: :other) %>
 <% end %>
 
 <% if @customer_returns.any? %>
@@ -48,7 +48,7 @@
   </table>
 <% else %>
   <div class="alpha twelve columns no-objects-found">
-    <%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: 'activerecord.models.spree/customer_return')) %>
+    <%= Spree.t(:no_resource_found, resource: Spree::CustomerReturn.model_name.human(count: :other)) %>
     <% if can? :create, Spree::CustomerReturn %>
       <%= link_to Spree.t(:add_one), spree.new_admin_order_customer_return_path(@order) %>!
     <% end %>

--- a/backend/app/views/spree/admin/customer_returns/new.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/new.html.erb
@@ -41,7 +41,7 @@
       </div>
 
       <div class="form-buttons filter-actions actions" data-hook="buttons">
-        <%= button Spree.t(:create), 'ok' %>
+        <%= button Spree.t('actions.create'), 'ok' %>
         <span class="or"><%= Spree.t(:or) %></span>
         <%= button_link_to Spree.t('actions.cancel'), admin_order_customer_returns_url(@order), :icon => 'remove' %>
       </div>


### PR DESCRIPTION
Use actions namespace and model names where applicable.  This is to improve use of I18n in this project.

This is part of an ongoing effort as discussed in #735 

Much of these views still appear unfinished but that's because they are handled in open PR #764 