### PR TITLE
Use LogEntry model name in views

### DIFF
--- a/backend/app/views/spree/admin/log_entries/index.html.erb
+++ b/backend/app/views/spree/admin/log_entries/index.html.erb
@@ -4,7 +4,7 @@
   <i class="fa fa-arrow-right"></i>
   <%= Spree::Payment.model_name.human %>
   <i class="fa fa-arrow-right"></i>
-  <%= Spree.t(:log_entries) %>
+  <%= Spree::LogEntry.model_name.human(count: :other) %>
 <% end %>
 
 <% content_for :page_actions do %>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -182,6 +182,9 @@ en:
       spree/line_item:
         one: Line Item
         other: Line Items
+      spree/log_entry:
+        one: Log Entry
+        other: Log Entries
       spree/option_type:
         one: Option Type
         other: Option Types


### PR DESCRIPTION
This is to use model name translations instead of arbitrary translations in the I18n dictionary.

This is part of an ongoing issue as discussed in #735.  