### PR TITLE
Allow configuring Capybara's default_max_wait_time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,19 @@ before_script:
   - export DISPLAY=:99.0
 bundler_args: --without development production --quiet
 env:
-  - GEM=api DB=mysql
-  - GEM=api DB=postgres
-  - GEM=backend DB=mysql
-  - GEM=backend DB=postgres
-  - GEM=core DB=mysql
-  - GEM=core DB=postgres
-  - GEM=frontend DB=mysql
-  - GEM=frontend DB=postgres
-  - GEM=sample DB=mysql
-  - GEM=sample DB=postgres
+  global:
+    DEFAULT_MAX_WAIT_TIME: 10
+  matrix:
+    - GEM=api DB=mysql
+    - GEM=api DB=postgres
+    - GEM=backend DB=mysql
+    - GEM=backend DB=postgres
+    - GEM=core DB=mysql
+    - GEM=core DB=postgres
+    - GEM=frontend DB=mysql
+    - GEM=frontend DB=postgres
+    - GEM=sample DB=mysql
+    - GEM=sample DB=postgres
 before_install:
   - cd $GEM; export BUNDLE_GEMFILE="`pwd`/Gemfile"
 script:

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -50,6 +50,8 @@ Capybara.javascript_driver = :poltergeist
 
 ActionView::Base.raise_on_missing_translations = true
 
+Capybara.default_max_wait_time = ENV['DEFAULT_MAX_WAIT_TIME'].to_f if ENV['DEFAULT_MAX_WAIT_TIME'].present?
+
 RSpec.configure do |config|
   config.color = true
   config.infer_spec_type_from_file_location!

--- a/circle.yml
+++ b/circle.yml
@@ -2,6 +2,7 @@
 machine:
   environment:
     DB: postgresql
+    DEFAULT_MAX_WAIT_TIME: 10
   services:
     - postgresql
   ruby:

--- a/frontend/spec/spec_helper.rb
+++ b/frontend/spec/spec_helper.rb
@@ -58,6 +58,8 @@ else
   Capybara.javascript_driver = :poltergeist
 end
 
+Capybara.default_max_wait_time = ENV['DEFAULT_MAX_WAIT_TIME'].to_f if ENV['DEFAULT_MAX_WAIT_TIME'].present?
+
 RSpec.configure do |config|
   config.color = true
   config.infer_spec_type_from_file_location!


### PR DESCRIPTION
I had been trying to avoid this commit, which increases this timeout on CI, because we shouldn't have to. No interaction in our admin should take more than 2 seconds to occur.

Though they don't ever take that long under normal circumstances, it certainly seems like they do sometimes on CircleCI. See
[any](https://circleci.com/gh/solidusio/solidus/1839)
[of](https://circleci.com/gh/solidusio/solidus/1831)
[these](https://circleci.com/gh/solidusio/solidus/1779)
[failures](https://circleci.com/gh/solidusio/solidus/1776)
which timeout, but have the expected content by the time capybara-screenshot saves a screenshot.

This also allows reducing the default_max_wait_time to try and debug issues (all tests pass for me with 0.5 seconds locally).