### PR TITLE
Use attribute translation orders

### DIFF
--- a/backend/app/views/spree/admin/orders/_carton.html.erb
+++ b/backend/app/views/spree/admin/orders/_carton.html.erb
@@ -42,7 +42,7 @@
       <% if order.special_instructions.present? %>
         <tr class='special_instructions'>
           <td colspan="5">
-            <strong><%= Spree.t(:special_instructions) %>:&nbsp;</strong><%= order.special_instructions %>
+            <strong><%= Spree::Order.human_attribute_name(:special_instructions) %>:&nbsp;</strong><%= order.special_instructions %>
           </td>
         </tr>
       <% end %>
@@ -50,7 +50,7 @@
       <tr class="show-tracking total">
         <td colspan="5">
           <% if carton.tracking.present? %>
-            <strong><%= Spree.t(:tracking) %>:</strong> <%= carton.tracking %>
+            <strong><%= Spree::Carton.human_attribute_name(:tracking) %>:</strong> <%= carton.tracking %>
           <% else %>
             <%= Spree.t(:no_tracking_present) %>
           <% end %>

--- a/backend/app/views/spree/admin/orders/_shipment.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment.html.erb
@@ -84,7 +84,7 @@
 
         <tr class="edit-tracking hidden total">
           <td colspan="5">
-            <label><%= Spree.t(:tracking_number) %>:</label>
+            <label><%= Spree::Shipment.human_attribute_name(:tracking) %>:</label>
             <%= text_field_tag :tracking, shipment.tracking %>
           </td>
           <td class="actions">
@@ -106,7 +106,7 @@
         <tr class="show-tracking total">
           <td colspan="5" class="tracking-value">
             <% if shipment.tracking.present? %>
-              <strong><%= Spree.t(:tracking) %>:</strong> <%= shipment.tracking %>
+              <strong><%= Spree::Shipment.human_attribute_name(:tracking) %>:</strong> <%= shipment.tracking %>
             <% else %>
               <%= Spree.t(:no_tracking_present) %>
             <% end %>

--- a/backend/app/views/spree/admin/orders/confirm/_line_items.html.erb
+++ b/backend/app/views/spree/admin/orders/confirm/_line_items.html.erb
@@ -1,10 +1,10 @@
 <% if order.line_items.exists? %>
   <table class="line-items index" data-hook="line-items">
     <thead>
-      <th colspan="2"><%= Spree.t(:name) %></th>
-      <th><%= Spree.t(:price) %></th>
-      <th><%= Spree.t(:quantity) %></th>
-      <th><%= Spree.t(:total_price) %></th>
+      <th colspan="2"><%= Spree::LineItem.human_attribute_name(:name) %></th>
+      <th><%= Spree::LineItem.human_attribute_name(:price) %></th>
+      <th><%= Spree::LineItem.human_attribute_name(:quantity) %></th>
+      <th><%= Spree::LineItem.human_attribute_name(:total_price) %></th>
     </thead>
 
     <tbody>

--- a/backend/app/views/spree/admin/orders/confirm/_payments.html.erb
+++ b/backend/app/views/spree/admin/orders/confirm/_payments.html.erb
@@ -3,13 +3,12 @@
   <table class="index">
     <thead>
       <tr data-hook="payments_header">
-        <th><%= Spree.t(:identifier) %></th>
-        <th><%= "#{Spree.t('date')}/#{Spree.t('time')}" %></th>
-        <th><%= Spree.t(:amount) %></th>
-        <th><%= Spree.t(:payment_method) %></th>
+        <th><%= Spree::Payment.human_attribute_name(:number) %></th>
+        <th><%= Spree::Payment.human_attribute_name(:created_at) %></th>
+        <th><%= Spree::Payment.human_attribute_name(:amount) %></th>
         <th><%= Spree::PaymentMethod.model_name.human %></th>
-        <th><%= Spree.t(:transaction_id) %></th>
-        <th><%= Spree.t(:payment_state) %></th>
+        <th><%= Spree::Payment.human_attribute_name(:response_code) %></th>
+        <th><%= Spree::Payment.human_attribute_name(:state) %></th>
       </tr>
     </thead>
     <tbody>

--- a/backend/app/views/spree/admin/orders/confirm/_shipment.html.erb
+++ b/backend/app/views/spree/admin/orders/confirm/_shipment.html.erb
@@ -36,7 +36,7 @@
 
       <tr class="edit-tracking hidden total">
         <td colspan="5">
-          <label><%= Spree.t(:tracking_number) %>:</label>
+          <label><%= Spree::Shipment.human_attribute_name(:tracking) %>:</label>
           <%= text_field_tag :tracking, shipment.tracking %>
         </td>
       </tr>
@@ -44,7 +44,10 @@
       <% if order.special_instructions.present? %>
         <tr class='special_instructions'>
           <td colspan="5">
-            <strong><%= Spree.t(:special_instructions) %>:&nbsp;</strong><%= order.special_instructions %>
+            <strong>
+              <%= Spree::Order.human_attribute_name(:special_instructions) %>:
+            </strong>
+            <%= order.special_instructions %>
           </td>
         </tr>
       <% end %>

--- a/backend/app/views/spree/admin/orders/confirm/_shipment_manifest.html.erb
+++ b/backend/app/views/spree/admin/orders/confirm/_shipment_manifest.html.erb
@@ -6,7 +6,7 @@
     <td class="item-name">
       <%= item.variant.product.name %><br><%= "(" + variant_options(item.variant) + ")" unless item.variant.option_values.empty? %>
       <% if item.variant.sku.present? %>
-        <strong><%= Spree.t(:sku) %>:</strong> <%= item.variant.sku %>
+        <strong><%= Spree::Variant.human_attribute_name(:sku) %>:</strong> <%= item.variant.sku %>
       <% end %>
     </td>
     <td class="item-price align-center"><%= item.line_item.single_money.to_html %></td>

--- a/backend/app/views/spree/admin/orders/customer_details/_form.html.erb
+++ b/backend/app/views/spree/admin/orders/customer_details/_form.html.erb
@@ -6,7 +6,7 @@
     <div data-hook="customer_fields" class="row">
       <div class="alpha eight columns">
         <div class="field">
-          <%= f.label :email, Spree.t(:email) %>
+          <%= f.label :email %>
           <%= f.email_field :email, :class => 'fullwidth' %>
         </div>
       </div>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -843,9 +843,6 @@ en:
     coupon_code_not_eligible: This coupon code is not eligible for this order
     coupon_code_not_found: The coupon code you entered doesn't exist. Please try again.
     coupon_code_unknown_error: This coupon code could not be applied to the cart at this time.
-    customer: Customer
-    customer_return: Customer Return
-    customer_returns: Customer Returns
     create: Create
     create_a_new_account: Create a new account
     create_new_order: Create new order
@@ -866,6 +863,8 @@ en:
     customer: Customer
     customer_details: Customer Details
     customer_details_updated: Customer Details Updated
+    customer_return: Customer Return
+    customer_returns: Customer Returns
     customer_search: Customer Search
     cut: Cut
     cvv_response: CVV Response

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -35,6 +35,8 @@ en:
       spree/calculator/tiered_percent:
         preferred_base_percent: Base Percent
         preferred_tiers: Tiers
+      spree/carton:
+        tracking: Tracking
       spree/country:
         iso: ISO
         iso3: ISO3
@@ -64,6 +66,7 @@ en:
         state: State
       spree/line_item:
         description: Item Description
+        name: Name
         price: Price
         quantity: Quantity
         total: Total price
@@ -113,7 +116,10 @@ en:
         zipcode: Shipping address zipcode
       spree/payment:
         amount: Amount
+        created_at: Date/Time
         number: Identifier
+        response_code: Transaction ID
+        state: Payment State
       spree/payment_method:
         name: Name
       spree/product:
@@ -193,6 +199,8 @@ en:
         name: Name
       spree/shipping_category:
         name: Name
+      spree/shipment:
+        tracking: Tracking Number
       spree/shipping_method:
         admin_name: Internal Name
         carrier: Carrier


### PR DESCRIPTION
This is to improve the Orders views ease of localization by using model attribute values more in translations as opposed to generic values.  

This is an ongoing effort as discussed in #735.