### PR TITLE
Use model names in translations in order views.

### DIFF
--- a/backend/app/views/spree/admin/orders/_risk_analysis.html.erb
+++ b/backend/app/views/spree/admin/orders/_risk_analysis.html.erb
@@ -12,7 +12,9 @@
         </strong></td>
           <td class="align-center">
             <span class="<%= @order.payments.failed.count > 0 ? 'state void' : 'state complete' %>">
-              <%= link_to "#{Spree.t 'payments_count', count: @order.payments.failed.count, default: pluralize(@order.payments.failed.count, Spree.t(:payment))}", spree.admin_order_payments_path(@order) %>
+              <%= link_to Spree.t(:payments_failed_count,
+                                  count: @order.payments.failed.count),
+                          spree.admin_order_payments_path(@order) %>
             </span>
         </td>
       </tr>

--- a/backend/app/views/spree/admin/orders/confirm/_payments.html.erb
+++ b/backend/app/views/spree/admin/orders/confirm/_payments.html.erb
@@ -7,6 +7,7 @@
         <th><%= "#{Spree.t('date')}/#{Spree.t('time')}" %></th>
         <th><%= Spree.t(:amount) %></th>
         <th><%= Spree.t(:payment_method) %></th>
+        <th><%= Spree::PaymentMethod.model_name.human %></th>
         <th><%= Spree.t(:transaction_id) %></th>
         <th><%= Spree.t(:payment_state) %></th>
       </tr>

--- a/backend/app/views/spree/admin/orders/confirm/_shipment.html.erb
+++ b/backend/app/views/spree/admin/orders/confirm/_shipment.html.erb
@@ -1,7 +1,7 @@
 <div id="<%= "shipment_#{shipment.id}" %>" data-hook="admin_shipment_form">
   <fieldset class="no-border-bottom">
     <legend align="center" class="stock-location" data-hook="stock-location">
-      <%= Spree.t(:shipment) %>
+      <%= Spree::Shipment.model_name.human %>
       <span class="shipment-number"><%= shipment.number %></span>
       <%= Spree.t(:from) %>
       <strong class="stock-location-name" data-hook="stock-location-name">"<%= shipment.stock_location.name %>"</strong>

--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -157,8 +157,10 @@
   </table>
 <% else %>
   <div class="alpha twelve columns no-objects-found">
-    <%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: 'activerecord.models.spree/order')) %>,
-    <%= link_to Spree.t(:add_one), spree.new_admin_order_path %>!
+    <%= Spree.t(:no_resource_found_html,
+                resource: Spree::Order.model_name.human(count: :other),
+                add_one_link: link_to(Spree.t(:no_resource_found_link),
+                                      spree.new_admin_order_path)) %>
   </div>
 <% end %>
 

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1043,6 +1043,8 @@ en:
     no_promotions_found: No promotions found
     no_results: No results
     no_rules_added: No rules added
+    no_resource_found_html: 'No %{resource} found, %{add_one_link}!'
+    no_resource_found_link: Add One
     no_resource_found: ! 'No %{resource} found'
     no_shipping_methods_found: No shipping methods found
     no_shipping_method_selected: No shipping method selected.
@@ -1148,6 +1150,9 @@ en:
     pay: pay
     payment: Payment
     payment_could_not_be_created: Payment could not be created.
+    payments_failed_count:
+      one: 1 Payment
+      other: '%{count} Payments'
     payment_identifier: Payment Identifier
     payment_information: Payment Information
     payment_method: Payment Method


### PR DESCRIPTION
Improve I18n use by using model names translations in the order views.

This is an ongoing effort to improve I18n use as discussed in #735.