### PR TITLE
Improve i18n of admin navigation tab helper

### DIFF
--- a/backend/app/helpers/spree/admin/navigation_helper.rb
+++ b/backend/app/helpers/spree/admin/navigation_helper.rb
@@ -15,7 +15,7 @@ module Spree
         options[:route] ||= "admin_#{args.first}"
 
         destination_url = options[:url] || spree.send("#{options[:route]}_path")
-        label = Spree.t(options[:label], default: options[:label], scope: [:admin, :tab])
+        label = Spree.t(options[:label], scope: [:admin, :tab])
 
         css_classes = []
 

--- a/backend/app/helpers/spree/admin/navigation_helper.rb
+++ b/backend/app/helpers/spree/admin/navigation_helper.rb
@@ -15,15 +15,15 @@ module Spree
         options[:route] ||= "admin_#{args.first}"
 
         destination_url = options[:url] || spree.send("#{options[:route]}_path")
-        titleized_label = Spree.t(options[:label], default: options[:label], scope: [:admin, :tab]).titleize
+        label = Spree.t(options[:label], default: options[:label], scope: [:admin, :tab])
 
         css_classes = []
 
         if options[:icon]
-          link = link_to_with_icon(options[:icon], titleized_label, destination_url)
+          link = link_to_with_icon(options[:icon], label, destination_url)
           css_classes << 'tab-with-icon'
         else
-          link = link_to(titleized_label, destination_url)
+          link = link_to(label, destination_url)
         end
 
         selected = if options[:match_path].is_a? Regexp

--- a/backend/app/views/spree/admin/shared/_stock_sub_menu.html.erb
+++ b/backend/app/views/spree/admin/shared/_stock_sub_menu.html.erb
@@ -1,8 +1,8 @@
 <ul id="sub_nav" class="admin-subnav" data-hook="admin_stock_transfer_sub_tabs">
   <% if can? :admin, Spree::StockItem %>
-    <%= tab :stock_items, label: 'management', match_path: '/stock_items' %>
+    <%= tab :stock_items, match_path: '/stock_items' %>
   <% end %>
   <% if can? :admin, Spree::StockTransfer %>
-    <%= tab :stock_transfers, label: 'transfers', match_path: '/stock_transfers' %>
+    <%= tab :stock_transfers, match_path: '/stock_transfers' %>
   <% end %>
 </ul>

--- a/backend/app/views/spree/admin/shared/_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_tabs.html.erb
@@ -13,7 +13,7 @@
 <% end %>
 
 <% if can? :admin, :general_settings %>
-  <%= tab *Spree::BackendConfiguration::CONFIGURATION_TABS, label: Spree.t(:settings), icon: 'wrench', url: spree.edit_admin_general_settings_path %>
+  <%= tab *Spree::BackendConfiguration::CONFIGURATION_TABS, label: :settings, icon: 'wrench', url: spree.edit_admin_general_settings_path %>
 <% end %>
 
 <% if can? :admin, Spree::Promotion %>
@@ -23,7 +23,7 @@
 <% end %>
 
 <% if can? :admin, Spree::StockItem %>
-  <%= tab(:stock_items, :stock_transfers, url: spree.admin_stock_items_path, label: Spree.t(:stock), icon: 'cubes', match_path: %r(^/admin/stock)) do %>
+  <%= tab(:stock_items, :stock_transfers, url: spree.admin_stock_items_path, label: :stock, icon: 'cubes', match_path: %r(^/admin/stock)) do %>
     <%- render partial: 'spree/admin/shared/stock_sub_menu' %>
   <%- end %>
 <% end %>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -462,9 +462,14 @@ en:
         overview: Overview
         products: Products
         promotions: Promotions
+        promotion_categories: Promotion Categories
         properties: Properties
         prototypes: Prototypes
         reports: Reports
+        settings: Settings
+        stock: Stock
+        stock_items: Management
+        stock_transfers: Transfers
         taxonomies: Taxonomies
         taxons: Taxons
         users: Users


### PR DESCRIPTION
Previously, the tab helper was sometimes passed a key to translate, other times a key with no translation which it would `#titleize`, and sometimes a translation from `Spree.t`. In the latter case it would "double translate" and look up the already translated string. :weary:

This makes the `tab` helper always use keys from `spree.admin.tab.*`