### PR TITLE
Raise errors on missing i18n translations

### DIFF
--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -89,16 +89,6 @@ module Spree
         end
       end
 
-      def update
-        @order.contents.update_cart(params[:order])
-        @order.errors.add(:line_items, Spree.t('errors.messages.blank')) if @order.line_items.empty?
-        if @order.completed?
-          render action: :edit
-        else
-          redirect_to admin_order_customer_path(@order)
-        end
-      end
-
       def advance
         if @order.completed?
           flash[:notice] = Spree.t('order_already_completed')

--- a/backend/app/views/spree/admin/shared/_head.html.erb
+++ b/backend/app/views/spree/admin/shared/_head.html.erb
@@ -24,6 +24,10 @@
     */
     .flash-wrapper { position: static; }
   </style>
+<%- elsif Rails.env.development? %>
+  <style>
+    .translation_missing { background: red; }
+  </style>
 <%- end %>
 
 

--- a/backend/app/views/spree/admin/stock_locations/_form.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/_form.html.erb
@@ -2,19 +2,19 @@
   <div class="alpha nine columns" data-hook="stock_location_names">
     <div data-hook="stock_location_name">
       <%= f.field_container :name do %>
-        <%= f.label :name, Spree.t(:name), class: 'required' %><br />
+        <%= f.label :name, class: 'required' %><br />
         <%= f.text_field :name, class: 'fullwidth', required: true %>
       <% end %>
     </div>
     <div data-hook="stock_location_code">
       <%= f.field_container :code do %>
-        <%= f.label :code, Spree.t(:code) %>
+        <%= f.label :code %>
         <%= f.text_field :code, :class => 'fullwidth', :label => false %>
       <% end %>
     </div>
     <div data-hook="stock_location_admin_name">
       <%= f.field_container :admin_name do %>
-        <%= f.label :admin_name, Spree.t(:internal_name) %>
+        <%= f.label :admin_name %>
         <%= f.text_field :admin_name, class: 'fullwidth', label: false %>
       <% end %>
     </div>
@@ -26,69 +26,69 @@
       <ul>
         <li class="fullwidth" data-hook="stock_location_active">
           <%= f.check_box :active %>
-          <%= f.label :active, Spree.t(:active) %>
+          <%= f.label :active %>
         </li>
         <li class="fullwidth" data-hook="stock_location_default">
           <%= f.check_box :default %>
-          <%= f.label :default, Spree.t(:default) %>
+          <%= f.label :default %>
         </li>
         <li class="fullwidth" data-hook="stock_location_backorderable_default">
           <%= f.check_box :backorderable_default %>
-          <%= f.label :backorderable_default, Spree.t(:backorderable_default) %>
+          <%= f.label :backorderable_default %>
         </li>
         <li class="fullwidth" data-hook="stock_location_propagate_all_variants">
           <%= f.check_box :propagate_all_variants %>
-          <%= f.label :propagate_all_variants, Spree.t(:propagate_all_variants) %>
+          <%= f.label :propagate_all_variants %>
         </li>
         <li class="fullwidth">
-          <%= f.label :active, Spree.t(:restock_inventory) %>
           <%= f.check_box :restock_inventory %>
+          <%= f.label :restock_inventory %>
         </li>
         <li>
-          <%= f.label :active, Spree.t(:fulfillable_stock) %>
           <%= f.check_box :fulfillable %>
+          <%= f.label :fulfillable %>
         </li>
         <li class="fullwidth">
-          <%= f.label :check_stock_on_transfer, Spree.t(:check_stock_on_transfer) %>
           <%= f.check_box :check_stock_on_transfer %>
+          <%= f.label :check_stock_on_transfer %>
         </li>
       </ul>
     <% end %>
   </div>
 
   <div class="alpha six columns field" data-hook="stock_location_address1">
-    <%= f.label :address1, Spree.t(:street_address) %>
+    <%= f.label :address1 %>
     <%= f.text_field :address1, class: 'fullwidth' %>
   </div>
 
   <div class="omega six columns field" data-hook="stock_location_city">
-    <%= f.label :city, Spree.t(:city) %>
+    <%= f.label :city %>
     <%= f.text_field :city, class: 'fullwidth' %>
   </div>
 
   <div class="alpha six columns field" data-hook="stock_location_address2">
-    <%= f.label :address2, Spree.t(:street_address_2) %>
+    <%= f.label :address2 %>
     <%= f.text_field :address2, class: 'fullwidth' %>
   </div>
 
   <div class="three columns field" data-hook="stock_location_zipcode">
-    <%= f.label :zipcode, Spree.t(:zip) %>
+    <%= f.label :zipcode %>
     <%= f.text_field :zipcode, class: 'fullwidth' %>
   </div>
 
   <div class="omega three columns field" data-hook="stock_location_phone">
-    <%= f.label :phone, Spree.t(:phone) %>
+    <%= f.label :phone %>
     <%= f.phone_field :phone, class: 'fullwidth' %>
   </div>
 
   <div class="alpha six columns field" data-hook="stock_location_country">
-    <%= f.label :country_id, Spree.t(:country) %>
+    <%= f.label :country_id %>
     <span id="country"><%= f.collection_select :country_id, available_countries, :id, :name, {}, { class: 'select2 fullwidth' } %></span>
   </div>
 
   <div class="omega six columns field" data-hook="stock_location_state">
     <% if f.object.country %>
-      <%= f.label :state_id, Spree.t(:state) %>
+      <%= f.label :state_id %>
       <span id="state" class="region">
         <%= f.text_field :state_name, style: "display: #{f.object.country.states.empty? ? 'block' : 'none' };", disabled: !f.object.country.states.empty?, class: 'fullwidth state_name' %>
         <%= f.collection_select :state_id, f.object.country.states.sort, :id, :name, { include_blank: true }, {class: 'select2 fullwidth', style: "display: #{f.object.country.states.empty? ? 'none' : 'block' };", disabled: f.object.country.states.empty?} %>

--- a/backend/app/views/spree/admin/store_credits/_form.html.erb
+++ b/backend/app/views/spree/admin/store_credits/_form.html.erb
@@ -1,14 +1,14 @@
 <div data-hook="admin_store_credit_form_fields" class="row">
   <div class="alpha twelve columns">
     <%= f.field_container :amount do %>
-      <%= f.label :amount, Spree.t(:amount), class: 'required' %><br />
+      <%= f.label :amount, class: 'required' %><br />
       <%= f.number_field :amount, min: 0.00, step: :any %>
       <%= f.error_message_on :amount %>
     <% end %>
   </div>
   <div class="alpha twelve columns">
     <%= f.field_container :category do %>
-      <%= f.label :category, Spree.t(:credit_type), class: 'required' %><br />
+      <%= f.label :category_id, class: 'required' %><br />
       <%= f.select :category_id, options_from_collection_for_select(@credit_categories, :id, :name, f.object.category.try(:id)),
         { include_blank: true }, { class: 'select2 fullwidth', placeholder: Spree.t("admin.store_credits.select_reason") } %>
       <%= f.error_message_on :category %>
@@ -16,7 +16,7 @@
   </div>
   <div data-hook="admin_store_credit_memo_field" class="alpha twelve columns">
     <%= f.field_container :memo do %>
-      <%= f.label :memo, Spree.t(:memo) %>
+      <%= f.label :memo %>
       <%= f.text_area :memo, class: "fullwidth" %>
       <%= f.error_message_on :memo %>
     <% end %>

--- a/backend/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -336,31 +336,30 @@ describe Spree::Admin::OrdersController, type: :controller do
   end
 
   context '#authorize_admin' do
-    let(:user) { create(:user) }
-    let(:order) { create(:completed_order_with_totals, number: 'R987654321') }
+    let!(:user) { create(:user) }
+    let!(:order) { create(:completed_order_with_totals, number: 'R987654321') }
 
     before do
-      allow(Spree::Order).to receive_messages find_by_number!: order
       allow(controller).to receive_messages spree_current_user: user
     end
 
     it 'should grant access to users with an admin role' do
       user.spree_roles << Spree::Role.find_or_create_by(name: 'admin')
-      spree_post :index
+      spree_get :index
       expect(response).to render_template :index
     end
 
     it 'should grant access to users with an bar role' do
       user.spree_roles << Spree::Role.find_or_create_by(name: 'bar')
       Spree::Ability.register_ability(BarAbility)
-      spree_post :index
+      spree_get :index
       expect(response).to render_template :index
       Spree::Ability.remove_ability(BarAbility)
     end
 
     it 'should deny access to users without an admin role' do
       allow(user).to receive_messages has_spree_role?: false
-      spree_post :index
+      spree_get :index
       expect(response).to redirect_to('/unauthorized')
     end
 

--- a/backend/spec/controllers/spree/admin/reports_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/reports_controller_spec.rb
@@ -16,8 +16,16 @@ describe Spree::Admin::ReportsController, type: :controller do
   describe 'ReportsController.add_available_report!' do
     context 'when adding the report name' do
       it 'should contain the report' do
+        I18n.backend.store_translations(:en, spree: {
+          some_report: 'Awesome Report',
+          some_report_description: 'This report is great!'
+        })
         Spree::Admin::ReportsController.add_available_report!(:some_report)
         expect(Spree::Admin::ReportsController.available_reports.keys.include?(:some_report)).to be true
+        expect(Spree::Admin::ReportsController.available_reports[:some_report]).to eq(
+          name: 'Awesome Report',
+          description: 'This report is great!'
+        )
       end
     end
   end

--- a/backend/spec/features/admin/locale_spec.rb
+++ b/backend/spec/features/admin/locale_spec.rb
@@ -4,6 +4,7 @@ describe "setting locale", type: :feature do
   stub_authorization!
 
   before do
+    ActionView::Base.raise_on_missing_translations = false
     I18n.locale = I18n.default_locale
     I18n.backend.store_translations(:fr,
       date: {
@@ -21,6 +22,7 @@ describe "setting locale", type: :feature do
   after do
     I18n.locale = I18n.default_locale
     Spree::Backend::Config[:locale] = "en"
+    ActionView::Base.raise_on_missing_translations = true
   end
 
   it "should be in french" do

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -48,6 +48,8 @@ Capybara.save_and_open_page_path = ENV['CIRCLE_ARTIFACTS'] if ENV['CIRCLE_ARTIFA
 require 'capybara/poltergeist'
 Capybara.javascript_driver = :poltergeist
 
+ActionView::Base.raise_on_missing_translations = true
+
 RSpec.configure do |config|
   config.color = true
   config.infer_spec_type_from_file_location!

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -558,6 +558,7 @@ en:
     backordered: Backordered
     back_to_adjustments_list: Back To Adjustments List
     back_to_adjustment_reason_list: Back To Adjustment Reason List
+    back_to_countries_list: Back To Countries List
     back_to_customer_return: Back To Customer Return
     back_to_customer_return_list: Back To Customer Return List
     back_to_images_list: Back To Images List
@@ -585,6 +586,7 @@ en:
     back_to_stock_transfers_list: Back to Stock Transfers List
     back_to_store: Go Back To Store
     back_to_tax_categories_list: Back To Tax Categories List
+    back_to_tax_rates_list: Back To Tax Rates List
     back_to_taxonomies_list: Back To Taxonomies List
     back_to_trackers_list: Back To Trackers List
     back_to_users_list: Back To Users List
@@ -901,6 +903,7 @@ en:
       other: "and %{count} others"
     instructions_to_reset_password: Please enter your email on the form below
     insufficient_stock: Insufficient stock available, only %{on_hand} remaining
+    insufficient_stock_for_order: Insufficient stock for order
     insufficient_stock_lines_present: Some line items in this order have insufficient quantity.
     intercept_email_address: Intercept Email Address
     intercept_email_instructions: Override email recipient and replace with this address.
@@ -1317,6 +1320,7 @@ en:
     resend: Resend
     reset_password: Reset my password
     response_code: Response Code
+    restock_inventory: Restock Inventory
     resume: resume
     resumed: Resumed
     return: return

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -137,6 +137,25 @@ en:
         amount_used: Amount used
         category_id: Credit Type
         memo: Memo
+      spree/stock_location:
+        admin_name: Internal Name
+        active: Active
+        address1: Street Address
+        address2: Street Address (cont'd)
+        backorderable_default: Backorderable default
+        check_stock_on_transfer: Check stock on transfer
+        city: City
+        code: Code
+        country_id: Country
+        default: Default
+        fulfillable: Fulfillable
+        internal_name: Internal Name
+        name: Name
+        phone: Phone
+        propagate_all_variants: Propagate all variants
+        restock_inventory: Restock Inventory
+        state_id: State
+        zipcode: Zip
       spree/tax_category:
         description: Description
         name: Name

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -133,7 +133,10 @@ en:
         name: Site Name
         mail_from_address: Mail From Address
       spree/store_credit:
+        amount: Amount
         amount_used: Amount used
+        category_id: Credit Type
+        memo: Memo
       spree/tax_category:
         description: Description
         name: Name


### PR DESCRIPTION
Upgrades to using ActiveModel::Translation based translations for the store credit and stock location pages, as those previously had missing translations.

This raises errors in the test suite for any missed translations, which should ensure we never add missing translations again! I've done this only for the backend to start. You can see this in action before I fixed the last few here: https://circleci.com/gh/jhawthorn/solidus/626

This also adds a red background to any missed translations in development mode, which should help when developing in the sandbox. I used to apply this style in a browser extension, but we might as well make it a default for everyone.

![](http://i.hawth.ca/s/x8eYoQAu.png)

This also includes #779, as that removed a missing translation