### PR TITLE
Use phantomjs 2.1.1 on CircleCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,4 @@ script:
   - bundle exec rake test_app
   - bundle exec rake spec
 rvm:
-  - 2.1.5
+  - 2.3.0

--- a/backend/app/views/spree/admin/shared/_table_filter.html.erb
+++ b/backend/app/views/spree/admin/shared/_table_filter.html.erb
@@ -1,5 +1,5 @@
 <% if content_for?(:table_filter) %>
-  <div id="table-filter" data-hook class="<%= if content_for?(:sidebar) then 'twelve' else 'sixteen' end %> columns">
+  <div id="table-filter" data-hook>
     <fieldset>
       <legend align="center"><%= yield :table_filter_title %></legend>
       <%= yield :table_filter %>

--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,7 @@ machine:
   services:
     - postgresql
   ruby:
-    version: 2.1.5
+    version: 2.3.0
 dependencies:
   override:
     - bundle check --path=vendor/bundle || bundle install --path=vendor/bundle

--- a/circle.yml
+++ b/circle.yml
@@ -7,6 +7,8 @@ machine:
     - postgresql
   ruby:
     version: 2.3.0
+  pre:
+    - sudo curl --output /usr/local/bin/phantomjs https://s3.amazonaws.com/circle-downloads/phantomjs-2.1.1
 dependencies:
   override:
     - bundle check --path=vendor/bundle || bundle install --path=vendor/bundle

--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -30,7 +30,7 @@ group :test do
   gem 'rspec-its'
   gem 'rspec-rails', '~> 3.4.1'
   gem 'simplecov'
-  gem 'poltergeist'
+  gem 'poltergeist', '~> 1.9'
   gem 'timecop'
   gem 'with_model'
   gem 'rspec_junit_formatter'


### PR DESCRIPTION
This should help avoid the suprious crashes due to old versions of webkit.

This adds a requirement on poltergeist 1.9, which is the first version supporting phantomjs 2.1.1

I'll run this PR on CI multiple times to ensure this doesn't have new spurious failures.