### PR TITLE
Improve i18n in promotion views

### DIFF
--- a/backend/app/views/spree/admin/promotions/_actions.html.erb
+++ b/backend/app/views/spree/admin/promotions/_actions.html.erb
@@ -3,7 +3,7 @@
   <%= form_tag spree.admin_promotion_promotion_actions_path(@promotion), :remote => true, :id => 'new_promotion_action_form' do %>
     <% options = options_for_select(  Rails.application.config.spree.promotions.actions.map(&:name).map {|name| [ Spree.t("promotion_action_types.#{name.demodulize.underscore}.name"), name] } ) %>
     <fieldset>
-      <legend align="center"><%= Spree.t(:promotion_actions) %></legend>
+      <legend align="center"><%= Spree::PromotionAction.model_name.human(count: :other) %></legend>
       <% if can?(:update, @promotion) %>
         <div class="field">
           <%= label_tag :action_type, Spree.t(:add_action_of_type)%>

--- a/backend/app/views/spree/admin/promotions/_form.html.erb
+++ b/backend/app/views/spree/admin/promotions/_form.html.erb
@@ -47,7 +47,7 @@
       <% end %>
 
       <%= f.field_container :category do %>
-        <%= f.label :promotion_category %><br />
+        <%= f.label :promotion_category_id %><br />
         <%= f.collection_select(:promotion_category_id, @promotion_categories, :id, :name, { :include_blank => Spree.t('match_choices.none') }, { :class => 'select2 fullwidth' }) %>
       <% end %>
     </div>
@@ -55,7 +55,7 @@
 
   <div id="expiry_fields" class="three columns omega">
     <%= f.field_container :overall_usage_limit do %>
-      <%= f.label :overall_usage_limit %><br />
+      <%= f.label :usage_limit %><br />
       <%= f.number_field :usage_limit, :min => 0, :class => 'fullwidth' %><br>
       <span class="info">
         <%= Spree.t(:current_promotion_usage, :count => @promotion.usage_count) %>

--- a/backend/app/views/spree/admin/promotions/index.html.erb
+++ b/backend/app/views/spree/admin/promotions/index.html.erb
@@ -72,12 +72,12 @@
     </colgroup>
     <thead>
       <tr>
-        <th><%= Spree.t(:name) %></th>
-        <th><%= Spree.t(:code) %></th>
-        <th><%= Spree.t(:description) %></th>
+        <th><%= Spree::Promotion.human_attribute_name(:name) %></th>
+        <th><%= Spree::Promotion.human_attribute_name(:code) %></th>
+        <th><%= Spree::Promotion.human_attribute_name(:description) %></th>
         <th><%= Spree.t(:usage_limit) %></th>
         <th><%= Spree.t(:promotion_uses) %></th>
-        <th><%= Spree.t(:expiration) %></th>
+        <th><%= Spree::Promotion.human_attribute_name(:expires_at) %></th>
         <th class="actions"></th>
       </tr>
     </thead>

--- a/backend/app/views/spree/admin/promotions/rules/_option_value.html.erb
+++ b/backend/app/views/spree/admin/promotions/rules/_option_value.html.erb
@@ -1,7 +1,7 @@
 <div class="field alpha omega eight columns promo-rule-option-values">
   <div class="param-prefix hidden" data-param-prefix="<%= param_prefix %>"></div>
-  <div class="four columns alpha"><%= label_tag nil, Spree.t(:product) %></div>
-  <div class="three columns omega"><%= label_tag nil, Spree.t(:option_values) %></div>
+  <div class="four columns alpha"><%= label_tag nil, Spree::Product.model_name.human %></div>
+  <div class="three columns omega"><%= label_tag nil, Spree::OptionValue.model_name.human(count: :other) %></div>
   <div class="clear"></div>
 
   <div class="js-promo-rule-option-values"></div>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -101,14 +101,17 @@ en:
         tax_category: Tax Category
       spree/promotion:
         advertise: Advertise
+        apply_automatically: Apply Automatically
         code: Code
         description: Description
         event_name: Event Name
-        expires_at: Expires At
+        expires_at: Expiration
         name: Name
         path: Path
-        starts_at: Starts At
-        usage_limit: Usage Limit
+        per_code_usage_limit: Per Code Usage Limit
+        promotion_category_id: Promotion Category
+        starts_at: Starts
+        usage_limit: Overall Usage Limit
       spree/promotion_category:
         name: Name
       spree/property:


### PR DESCRIPTION
Model attribute translation and model name translations were utilized where they were not before in order to improve localization.

This is part of an ongoing effort to improve I18n use as discussed in #735.