### PR TITLE
improve I18n use in properties views

### DIFF
--- a/backend/app/views/spree/admin/properties/_form.html.erb
+++ b/backend/app/views/spree/admin/properties/_form.html.erb
@@ -1,14 +1,14 @@
 <div data-hook="admin_property_form" class="align-center row">
   <div class="alpha eight columns">
     <%= f.field_container :name do %>
-      <%= f.label :name, Spree.t(:name), class: 'required' %><br />
+      <%= f.label :name, class: 'required' %><br />
       <%= f.text_field :name, :class => 'fullwidth' %>
       <%= f.error_message_on :name %>
     <% end %>
   </div>
   <div class="eight columns omega">
     <%= f.field_container :presentation do %>
-      <%= f.label :presentation, Spree.t(:presentation), class: 'required' %><br />
+      <%= f.label :presentation, class: 'required' %><br />
       <%= f.text_field :presentation, :class => 'fullwidth' %>
       <%= f.error_message_on :presentation %>
     <% end %>

--- a/backend/app/views/spree/admin/properties/index.html.erb
+++ b/backend/app/views/spree/admin/properties/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:properties) %>
+  <%= Spree::Property.model_name.human(count: :other) %>
 <% end %>
 
 <% content_for :page_actions do %>
@@ -50,8 +50,8 @@
   </colgroup>
   <thead>
     <tr data-hook="listing_properties_header">
-      <th><%= Spree.t(:name) %></th>
-      <th><%= Spree.t(:presentation) %></th>
+      <th><%= Spree::Property.human_attribute_name(:name) %></th>
+      <th><%= Spree::Property.human_attribute_name(:presentation) %></th>
       <th class="actions"></th>
     </tr>
   </thead>


### PR DESCRIPTION
This improves I18n use in the property views by utilizing translation  off of the models attributes and the model name.

This is part of the ongoing effort to improve I18n implementation in the project as discussed in #735.