### PR TITLE
Find the default country by ISO code

### DIFF
--- a/api/app/views/spree/api/config/show.v1.rabl
+++ b/api/app/views/spree/api/config/show.v1.rabl
@@ -1,2 +1,3 @@
 object false
-node(:default_country_id) { Spree::Config[:default_country_id] }
+node(:default_country_id) { Spree::Country.default.id }
+node(:default_country_iso) { Spree::Config[:default_country_iso] }

--- a/api/spec/controllers/spree/api/config_controller_spec.rb
+++ b/api/spec/controllers/spree/api/config_controller_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 module Spree
   describe Api::ConfigController, type: :controller do
+    let!(:default_country) { create :country, iso: "US"}
     render_views
 
     before do
@@ -17,7 +18,8 @@ module Spree
     it "returns some configuration settings" do
       api_get :show
       expect(response).to be_success
-      expect(json_response["default_country_id"]).to eq(Spree::Config[:default_country_id])
+      expect(json_response["default_country_iso"]).to eq("US")
+      expect(json_response["default_country_id"]).to eq(default_country.id)
     end
   end
 end

--- a/backend/app/controllers/spree/admin/stock_locations_controller.rb
+++ b/backend/app/controllers/spree/admin/stock_locations_controller.rb
@@ -6,15 +6,11 @@ module Spree
       private
 
       def set_country
-          if Spree::Config[:default_country_id].present?
-            @stock_location.country = Spree::Country.find(Spree::Config[:default_country_id])
-          else
-            @stock_location.country = Spree::Country.find_by!(iso: 'US')
-          end
+        @stock_location.country = Spree::Country.default
 
       rescue ActiveRecord::RecordNotFound
-          flash[:error] = Spree.t(:stock_locations_need_a_default_country)
-          redirect_to(admin_stock_locations_path) && return
+        flash[:error] = Spree.t(:stock_locations_need_a_default_country)
+        redirect_to(admin_stock_locations_path) && return
       end
     end
   end

--- a/backend/app/views/spree/admin/shared/_configuration_menu.html.erb
+++ b/backend/app/views/spree/admin/shared/_configuration_menu.html.erb
@@ -26,7 +26,7 @@
       <% end %>
 
       <% if can?(:display, Spree::State) %>
-        <% if country = Spree::Country.find_by_id(Spree::Config[:default_country_id]) || Spree::Country.first %>
+      <% if country = Spree::Country.find_by(iso: Spree::Config[:default_country_iso]) || Spree::Country.first %>
           <%= configurations_sidebar_menu_item Spree::State.model_name.human(count: :other), admin_country_states_path(country) %>
         <% end %>
       <% end %>

--- a/backend/spec/controllers/spree/admin/stock_locations_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/stock_locations_controller_spec.rb
@@ -14,10 +14,11 @@ module Spree
         end
       end
 
-      context "with a default country present" do
+      context "with a default country other than the US present" do
+        let(:country) { create :country, iso: "BR" }
+
         before do
-          country = FactoryGirl.create(:country)
-          Spree::Config[:default_country_id] = country.id
+          Spree::Config[:default_country_iso] = country.iso
         end
 
         it "can create a new stock location" do

--- a/backend/spec/features/admin/orders/customer_details_spec.rb
+++ b/backend/spec/features/admin/orders/customer_details_spec.rb
@@ -48,7 +48,7 @@ describe "Customer Details", type: :feature, js: true do
   context "editing an order" do
     before do
       configure_spree_preferences do |config|
-        config.default_country_id = country.id
+        config.default_country_iso = country.iso
         config.company = true
       end
 
@@ -111,12 +111,12 @@ describe "Customer Details", type: :feature, js: true do
     end
 
     context "country associated was removed" do
-      let(:brazil) { create(:country, iso: "BRA", name: "Brazil") }
+      let(:brazil) { create(:country, iso: "BR", name: "Brazil") }
 
       before do
         order.bill_address.country.destroy
         configure_spree_preferences do |config|
-          config.default_country_id = brazil.id
+          config.default_country_iso = brazil.iso
         end
       end
 

--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -117,9 +117,14 @@ module Spree
     preference :currency, :string, default: "USD"
 
     # @!attribute [rw] default_country_id
-    #   @deprecated
+    #   @deprecated Use the default country ISO preference instead
     #   @return [Integer,nil] id of {Country} to be selected by default in dropdowns (default: nil)
     preference :default_country_id, :integer
+
+    # @!attribute [rw] default_country_iso
+    #   Default customer country
+    #   @return [String] id of {Country} to be selected by default in dropdowns (default: "US")
+    preference :default_country_iso, :string, default: 'US'
 
     # @!attribute [rw] expedited_exchanges
     #   Kicks off an exchange shipment upon return authorization save.

--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -122,8 +122,8 @@ module Spree
     preference :default_country_id, :integer
 
     # @!attribute [rw] default_country_iso
-    #   Default customer country
-    #   @return [String] id of {Country} to be selected by default in dropdowns (default: "US")
+    #   Default customer country ISO code
+    #   @return [String] Two-letter ISO code of a {Spree::Country} to assumed as the country of an unidentified customer (default: "US")
     preference :default_country_iso, :string, default: 'US'
 
     # @!attribute [rw] expedited_exchanges

--- a/core/app/models/spree/country.rb
+++ b/core/app/models/spree/country.rb
@@ -13,9 +13,7 @@ module Spree
     end
 
     def self.default
-      if default_country_id = Spree::Config[:default_country_id]
-        find_by_id(default_country_id)
-      end || first
+      find_by!(iso: Spree::Config.default_country_iso)
     end
 
     def <=>(other)

--- a/core/app/models/spree/country.rb
+++ b/core/app/models/spree/country.rb
@@ -13,7 +13,12 @@ module Spree
     end
 
     def self.default
-      find_by!(iso: Spree::Config.default_country_iso)
+      if Spree::Config.default_country_id
+        ActiveSupport::Deprecation.warn("Setting your default country via its ID is deprecated. Please set your default country via the `default_country_iso` setting.", caller)
+        find_by(id: Spree::Config.default_country_id) || find_by!(iso: Spree::Config.default_country_iso)
+      else
+        find_by!(iso: Spree::Config.default_country_iso)
+      end
     end
 
     def <=>(other)

--- a/core/db/default/spree/countries.rb
+++ b/core/db/default/spree/countries.rb
@@ -15,5 +15,3 @@ end
 ActiveRecord::Base.transaction do
   Spree::Country.create!(countries)
 end
-
-Spree::Config[:default_country_id] ||= Spree::Country.find_by(iso: "US").id

--- a/core/spec/models/spree/address_spec.rb
+++ b/core/spec/models/spree/address_spec.rb
@@ -165,18 +165,20 @@ describe Spree::Address, type: :model do
 
       context 'has a default country' do
         before do
-          Spree::Config[:default_country_id] = default_country.id
+          Spree::Config[:default_country_iso] = default_country.iso
         end
 
-        it "sets up a new record with Spree::Config[:default_country_id]" do
+        it "sets up a new record with Spree::Config[:default_country_iso]" do
           expect(Spree::Address.build_default.country).to eq default_country
         end
       end
 
       # Regression test for https://github.com/spree/spree/issues/1142
-      it "uses the first available country if :default_country_id is set to an invalid value" do
-        Spree::Config[:default_country_id] = "0"
-        expect(Spree::Address.build_default.country).to eq default_country
+      it "raises ActiveRecord::RecordNotFound if :default_country_iso is set to an invalid value" do
+        Spree::Config[:default_country_iso] = "00"
+        expect {
+          Spree::Address.build_default.country
+        }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
   end

--- a/core/spec/models/spree/app_configuration_spec.rb
+++ b/core/spec/models/spree/app_configuration_spec.rb
@@ -24,4 +24,10 @@ describe Spree::AppConfiguration, type: :model do
     subject { prefs.stock }
     it { is_expected.to be_a Spree::Core::StockConfiguration }
   end
+
+  describe '@default_country_iso_code' do
+    it 'is the USA by default' do
+      expect(prefs[:default_country_iso]).to eq("US")
+    end
+  end
 end

--- a/core/spec/models/spree/country_spec.rb
+++ b/core/spec/models/spree/country_spec.rb
@@ -7,6 +7,33 @@ describe Spree::Country, type: :model do
       create(:country, id: 2)
     end
 
+    subject(:default_country) { described_class.default }
+
+    context 'with the configuration setting an existing legacy default country ID' do
+      before do
+        Spree::Config[:default_country_id] = 2
+      end
+
+      it 'emits a deprecation warning' do
+        expect(ActiveSupport::Deprecation).to receive(:warn)
+        default_country
+      end
+
+      it 'is the country with that ID' do
+        expect(default_country).to eq(Spree::Country.find(2))
+      end
+    end
+
+    context 'with the configuration setting a non-existing legacy default country ID' do
+      before do
+        Spree::Config[:default_country_id] = 0
+      end
+
+      it 'loads the country configured by the ISO code' do
+        expect(default_country).to eq(Spree::Country.find(2))
+      end
+    end
+
     context 'with the configuration setting an existing ISO code' do
       it 'is a country with the configurations ISO code' do
         expect(described_class.default).to be_a(Spree::Country)

--- a/core/spec/models/spree/country_spec.rb
+++ b/core/spec/models/spree/country_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe Spree::Country, type: :model do
+  describe '.default' do
+    before do
+      create(:country, iso: "DE", id: 1)
+      create(:country, id: 2)
+    end
+
+    context 'with the configuration setting an existing ISO code' do
+      it 'is a country with the configurations ISO code' do
+        expect(described_class.default).to be_a(Spree::Country)
+        expect(described_class.default.iso).to eq('US')
+      end
+    end
+
+    context 'with the configuration setting an non-existing ISO code' do
+      before { Spree::Config[:default_country_iso] = "ZZ" }
+
+      it 'raises a Record not Found error' do
+        expect { described_class.default }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+end

--- a/frontend/spec/features/address_spec.rb
+++ b/frontend/spec/features/address_spec.rb
@@ -22,7 +22,7 @@ describe "Address", type: :feature, inaccessible: true do
     let!(:canada) { create(:country, name: "Canada", states_required: true, iso: "CA") }
     let!(:uk) { create(:country, name: "United Kingdom", states_required: true, iso: "GB") }
 
-    before { Spree::Config[:default_country_id] = uk.id }
+    before { Spree::Config[:default_country_iso] = uk.iso }
 
     context "but has no state" do
       it "shows the state input field" do
@@ -47,7 +47,7 @@ describe "Address", type: :feature, inaccessible: true do
     end
 
     context "user changes to country without states required" do
-      let!(:france) { create(:country, name: "France", states_required: false, iso: "FRA") }
+      let!(:france) { create(:country, name: "France", states_required: false, iso: "FR") }
 
       it "clears the state name" do
         click_button "Checkout"
@@ -63,7 +63,7 @@ describe "Address", type: :feature, inaccessible: true do
   end
 
   context "country does not require state", js: true do
-    let!(:france) { create(:country, name: "France", states_required: false, iso: "FRA") }
+    let!(:france) { create(:country, name: "France", states_required: false, iso: "FR") }
 
     it "shows a disabled state input field" do
        click_button "Checkout"


### PR DESCRIPTION
...so that we don't have to know database IDs on boot-up time. 