### PR TITLE
removes :force attribute from params

### DIFF
--- a/api/app/controllers/spree/api/stock_items_controller.rb
+++ b/api/app/controllers/spree/api/stock_items_controller.rb
@@ -63,6 +63,7 @@ module Spree
       end
 
       def stock_item_params
+        params.require(:stock_item).delete(:force)
         params.require(:stock_item).permit(permitted_stock_item_attributes)
       end
 

--- a/api/spec/controllers/spree/api/stock_items_controller_spec.rb
+++ b/api/spec/controllers/spree/api/stock_items_controller_spec.rb
@@ -248,6 +248,7 @@ module Spree
               id: stock_item.to_param,
               stock_item: {
                 count_on_hand: count_on_hand,
+                backorderable: true,
                 force: true
               }
             }


### PR DESCRIPTION
This commit addresses #652 where a user was not able to update the
inventory in the admin panel due to #permitted_stock_item_attributes not
including :force as a valid parameter.

I added the attribute `:backorderable` which allowed our test suite to
pass, however I have concerns that I may be missing something here and
was contemplating whether it would be best to add the attribute in core
or strip out of the param after checking it. I went with stripping it
out of the params.

You can find the reference to attributes here
https://github.com/solidusio/solidus/blob/e15ca73e8f7083633343f0678023695a96e24d31/core/lib/spree/permitted_attributes.rb#L94