### PR TITLE
Improve I18n in prototypes views

### DIFF
--- a/backend/app/views/spree/admin/prototypes/_form.html.erb
+++ b/backend/app/views/spree/admin/prototypes/_form.html.erb
@@ -1,7 +1,7 @@
 <div data-hook="admin_prototype_form_fields" class="row">
   <div class="alpha four columns">
     <%= f.field_container :name do %>
-      <%= f.label :name, Spree.t(:name), class: 'required' %><br />
+      <%= f.label :name, class: 'required' %><br />
       <%= f.text_field :name, class: 'fullwidth' %>
       <%= f.error_message_on :name %>
     <% end %>
@@ -10,7 +10,7 @@
   <div class="four columns">
     <div id='properties' data-hook>
       <%= f.field_container :property_ids do %>
-        <%= f.label :property_ids, Spree.t(:properties) %><br>
+        <%= f.label :property_ids, Spree::Property.model_name.human(count: :other) %><br>
         <%= f.select :property_ids, Spree::Property.all.map { |p| ["#{p.presentation} (#{p.name})", p.id] }, {}, { multiple: true, class: "select2 fullwidth" } %>
       <% end %>
     </div>
@@ -19,7 +19,7 @@
   <div class="four columns">
     <div id="option_types" data-hook>
       <%= f.field_container :option_type_ids do %>
-        <%= f.label :option_type_ids, Spree.t(:option_types) %><br>
+        <%= f.label :option_type_ids, Spree::OptionType.model_name.human(count: :other) %><br>
         <%= f.select :option_type_ids, Spree::OptionType.all.map { |ot| ["#{ot.presentation} (#{ot.name})", ot.id] }, {}, { multiple: true, class: "select2 fullwidth" } %>
       <% end %>
     </div>
@@ -28,7 +28,7 @@
   <div class="four columns omega">
     <div id='taxons' data-hook>
       <%= f.field_container :taxon_ids do %>
-        <%= f.label :taxon_ids, Spree.t(:taxons) %><br>
+        <%= f.label :taxon_ids, Spree::Taxon.model_name.human(count: :other) %><br>
         <%= f.select :taxon_ids, Spree::Taxon.all.map { |t| [t.name, t.id] }, {}, { multiple: true, class: "select2 fullwidth" } %>
       <% end %>
     </div>

--- a/backend/app/views/spree/admin/prototypes/_prototypes.html.erb
+++ b/backend/app/views/spree/admin/prototypes/_prototypes.html.erb
@@ -5,7 +5,7 @@
   </colgroup>
   <thead>
     <tr data-hook="available_header">
-      <th><%= Spree.t(:name) %></th>
+      <th><%= Spree::Prototype.human_attribute_name(:name) %></th>
       <th class="actions"></th>
     </tr>
   </thead>

--- a/backend/app/views/spree/admin/prototypes/index.html.erb
+++ b/backend/app/views/spree/admin/prototypes/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:prototypes) %>
+  <%= Spree::Prototype.model_name.human(count: :other) %>
 <% end %>
 
 <% content_for :page_actions do %>
@@ -21,7 +21,7 @@
   </colgroup>
   <thead>
     <tr data-hook="prototypes_header">
-      <th><%= Spree.t(:name) %></th>
+      <th><%= Spree::Prototype.human_attribute_name(:name) %></th>
       <th class="actions"></th>
     </tr>
   </thead>

--- a/backend/app/views/spree/admin/prototypes/show.html.erb
+++ b/backend/app/views/spree/admin/prototypes/show.html.erb
@@ -1,5 +1,5 @@
 <% if @prototype.option_types.present? %>
-  <h2><%= Spree.t(:variants) %></h2>
+  <h2><%= Spree::Variant.model_name.human(count: :other) %></h2>
 
   <ul class="product-prototype-options">
     <% @prototype.option_types.each do |ot| %>


### PR DESCRIPTION
Use model_name translations and human_attribute_name translations.  Also automatically pull translations for the form from the dictionary.

This is part of an ongoing issue as discussed in #735 to improve I18n usage in the project.