### PR TITLE
Improve I18n in refund reasons views

### DIFF
--- a/backend/app/views/spree/admin/refund_reasons/index.html.erb
+++ b/backend/app/views/spree/admin/refund_reasons/index.html.erb
@@ -1,7 +1,7 @@
 <%= render partial: 'spree/admin/shared/configuration_menu' %>
 
 <% content_for :page_title do %>
-  <%= Spree.t(:refund_reasons) %>
+  <%= Spree::RefundReason.model_name.human(count: :other) %>
 <% end %>
 
 <% content_for :page_actions do %>
@@ -23,8 +23,8 @@
     </colgroup>
     <thead>
       <tr data-hook="named_types_header">
-        <th><%= Spree.t(:name) %></th>
-        <th><%= Spree.t(:active) %></th>
+        <th><%= Spree::RefundReason.human_attribute_name(:name) %></th>
+        <th><%= Spree::RefundReason.human_attribute_name(:active) %></th>
         <th class="actions"></th>
       </tr>
     </thead>

--- a/backend/app/views/spree/admin/refund_reasons/shared/_form.html.erb
+++ b/backend/app/views/spree/admin/refund_reasons/shared/_form.html.erb
@@ -2,12 +2,12 @@
   <div class="row">
     <div class="alpha four columns">
       <%= f.field_container :name do %>
-        <%= f.label :name, Spree.t(:name), class: 'required' %><br />
+        <%= f.label :name, class: 'required' %><br />
         <%= f.text_field :name, :class => 'fullwidth' %>
       <% end %>
 
       <%= f.field_container :code do %>
-        <%= f.label :code, Spree.t(:code), class: 'required' %><br />
+        <%= f.label :code, class: 'required' %><br />
         <%= f.text_field :code, :class => 'fullwidth' %>
 
       <% end %>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -143,6 +143,10 @@ en:
       spree/refund:
         amount: Amount
         refund_reason_id: Reason
+      spree/refund_reason:
+        active: Active
+        name: Name
+        code: Code
       spree/return_authorization:
         amount: Amount
       spree/return_reason:


### PR DESCRIPTION
Use model_name and model attribute translations.  Also allow the form to utilize the attribute translations when possible.

This is part of an ongoing effort to improve I18n use as discussed in #735.