### PR TITLE
Improve I18n use in refunds views

### DIFF
--- a/backend/app/views/spree/admin/refunds/edit.html.erb
+++ b/backend/app/views/spree/admin/refunds/edit.html.erb
@@ -1,7 +1,7 @@
 <%= render partial: 'spree/admin/shared/order_tabs', locals: {current: 'Payments'} %>
 
 <% content_for :page_title do %>
-  <i class="fa fa-arrow-right"></i> <%= link_to "#{Spree.t(:payment)} #{@refund.payment.id}", admin_order_payment_path(@refund.payment.order, @refund.payment) %>
+  <i class="fa fa-arrow-right"></i> <%= link_to "#{Spree::Payment.model_name.human} #{@refund.payment.id}", admin_order_payment_path(@refund.payment.order, @refund.payment) %>
   <i class="fa fa-arrow-right"></i> <%= Spree.t(:editing_refund) %> <%= @refund.id %>
 <% end %>
 
@@ -10,13 +10,13 @@
     <div data-hook="admin_refund_form_fields" class="row">
       <div class="alpha three columns">
         <div class="field">
-          <%= Spree.t(:amount) %><br/>
+          <%= f.label :amount %><br/>
           <%= @refund.amount %>
         </div>
       </div>
       <div class="alpha three columns">
         <div class="field">
-          <%= f.label :refund_reason_id, Spree.t(:reason) %><br/>
+          <%= f.label :refund_reason_id %><br/>
           <%= f.collection_select(:refund_reason_id, refund_reasons, :id, :name, {}, {class: 'select2 fullwidth'}) %>
         </div>
       </div>

--- a/backend/app/views/spree/admin/refunds/new.html.erb
+++ b/backend/app/views/spree/admin/refunds/new.html.erb
@@ -1,7 +1,7 @@
 <%= render partial: 'spree/admin/shared/order_tabs', locals: {current: 'Payments'} %>
 
 <% content_for :page_title do %>
-  <i class="fa fa-arrow-right"></i> <%= link_to "#{Spree.t(:payment)} #{@refund.payment.id}", admin_order_payment_path(@refund.payment.order, @refund.payment) %>
+  <i class="fa fa-arrow-right"></i> <%= link_to "#{Spree::Payment.model_name.human} #{@refund.payment.id}", admin_order_payment_path(@refund.payment.order, @refund.payment) %>
   <i class="fa fa-arrow-right"></i> <%= Spree.t(:new_refund) %>
 <% end %>
 
@@ -22,20 +22,20 @@
       </div>
       <div class="alpha three columns">
         <div class="field">
-          <%= f.label :amount, Spree.t(:amount) %><br/>
+          <%= f.label :amount %><br/>
           <%= f.text_field :amount, class: 'fullwidth' %>
         </div>
       </div>
       <div class="alpha three columns">
         <div class="field">
-          <%= f.label :refund_reason_id, Spree.t(:reason) %><br/>
+          <%= f.label :refund_reason_id %><br/>
           <%= f.collection_select(:refund_reason_id, refund_reasons, :id, :name, {include_blank: true}, {class: 'select2 fullwidth'}) %>
         </div>
       </div>
     </div>
 
     <div class="form-buttons filter-actions actions" data-hook="buttons">
-      <%= button Spree.t(:refund), 'ok' %>
+      <%= button Spree::Refund.model_name.human, 'ok' %>
       <span class="or"><%= Spree.t(:or) %></span>
       <%= button_link_to Spree.t('actions.cancel'), admin_order_payments_url(@refund.payment.order), icon: 'remove' %>
     </div>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -116,6 +116,9 @@ en:
         presentation: Presentation
       spree/prototype:
         name: Name
+      spree/refund:
+        amount: Amount
+        refund_reason_id: Reason
       spree/return_authorization:
         amount: Amount
       spree/role:
@@ -727,6 +730,7 @@ en:
     created_successfully: Created successfully
     credit: Credit
     credits: Credits
+    credit_allowed: Credit Allowed
     credit_card: Credit Card
     credit_cards: Credit Cards
     credit_owed: Credit Owed
@@ -786,6 +790,7 @@ en:
     editing_property: Editing Property
     editing_prototype: Editing Prototype
     edit_refund_reason: Edit Refund Reason
+    editing_refund: Editing Refund
     editing_refund_reason: Editing Refund Reason
     editing_reimbursement: Editing Reimbursement
     editing_reimbursement_type: Editing Reimbursement Type
@@ -1178,6 +1183,7 @@ en:
     path: Path
     pay: pay
     payment: Payment
+    payment_amount: Payment Amount
     payment_could_not_be_created: Payment could not be created.
     payment_identifier: Payment Identifier
     payment_information: Payment Information


### PR DESCRIPTION
Use attribute translations and model_name translations where applicable also fill in missing translations in the dictionary.  

This is part of an ongoing effort to improve the use of I18n in solidus as discussed in #735.