### PR TITLE
Improve i18n reimbursements

### DIFF
--- a/backend/app/views/spree/admin/reimbursements/edit.html.erb
+++ b/backend/app/views/spree/admin/reimbursements/edit.html.erb
@@ -16,12 +16,12 @@
     <table class="index reimbursement-return-items">
       <thead>
         <tr>
-          <th><%= Spree.t(:product) %></th>
-          <th><%= Spree.t(:preferred_reimbursement_type) %></th>
-          <th><%= Spree.t(:reimbursement_type_override) %></th>
-          <th><%= Spree.t(:pre_tax_refund_amount) %></th>
-          <th><%= Spree.t(:total) %></th>
-          <th><%= Spree.t(:exchange_for) %></th>
+          <th><%= Spree::Product.model_name.human %></th>
+          <th><%= Spree::ReturnItem.human_attribute_name(:preferred_reimbursement_type_id) %></th>
+          <th><%= Spree::ReturnItem.human_attribute_name(:override_reimbursement_type_id) %></th>
+          <th><%= Spree::ReturnItem.human_attribute_name(:amount) %></th>
+          <th><%= Spree::ReturnItem.human_attribute_name(:total) %></th>
+          <th><%= Spree::ReturnItem.human_attribute_name(:exchange_variant) %></th>
         </tr>
       </thead>
       <tbody>
@@ -76,9 +76,9 @@
   <table class="index calculated-reimbursements">
     <thead data-hook="customer_return_header">
       <tr>
-        <th><%= Spree.t(:reimbursement_type) %></th>
+        <th><%= Spree::ReimbursementType.model_name.human %></th>
         <th><%= Spree.t(:description) %></th>
-        <th><%= Spree.t(:amount) %></th>
+        <th><%= Spree::Reimbursement.human_attribute_name(:total) %></th>
       </tr>
     </thead>
     <tbody>
@@ -93,7 +93,7 @@
   </table>
   <% if @order.has_non_reimbursement_related_refunds? %>
     <span class="red">
-      <%= "#{Spree.t('note')}: #{Spree.t('this_order_has_already_received_a_refund')}. #{Spree.t('make_sure_the_above_reimbursement_amount_is_correct')}." %>
+      <%= Spree.t(:note_already_received_a_refund) %>
     </span>
   <% end %>
   <div class="form-buttons filter-actions actions" data-hook="reimburse-buttons">

--- a/backend/app/views/spree/admin/reimbursements/index.html.erb
+++ b/backend/app/views/spree/admin/reimbursements/index.html.erb
@@ -1,7 +1,7 @@
 <%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Reimbursements' } %>
 
 <% content_for :page_title do %>
-  <i class="fa fa-arrow-right"></i> <%= Spree.t(:edit_reimbursement) %>
+  <i class="fa fa-arrow-right"></i> <%= Spree::Reimbursement.model_name.human(count: :other) %>
 <% end %>
 
 <% content_for :page_actions do %>
@@ -14,10 +14,9 @@
   <thead data-hook="customer_return_header">
     <tr>
       <th><%= Spree.t(:id) %></th>
-      <th><%= Spree.t(:total) %></th>
-      <th><%= Spree.t(:status) %></th>
-      <th><%= "#{Spree.t('date')}/#{Spree.t('time')}" %></th>
-      <th class="actions"></th>
+      <th><%= Spree::Reimbursement.human_attribute_name(:total) %></th>
+      <th><%= Spree::Reimbursement.human_attribute_name(:reimbursement_status) %></th>
+      <th><%= Spree::Reimbursement.human_attribute_name(:created_at) %></th>
     </tr>
   </thead>
   <tbody>
@@ -27,7 +26,6 @@
         <td><%= reimbursement.total %></td>
         <td><%= reimbursement.reimbursement_status %></td>
         <td><%= pretty_time(reimbursement.created_at) %></td>
-        <td></td>
       </tr>
     <% end %>
   </tbody>

--- a/backend/app/views/spree/admin/reimbursements/show.html.erb
+++ b/backend/app/views/spree/admin/reimbursements/show.html.erb
@@ -1,7 +1,7 @@
 <%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Customer Returns' } %>
 
 <% content_for :page_title do %>
-  <i class="fa fa-arrow-right"></i> <%= Spree.t(:reimbursement) %> #<%= @reimbursement.number %>
+  <i class="fa fa-arrow-right"></i> <%= Spree::Reimbursement.model_name.human %> #<%= @reimbursement.number %>
 <% end %>
 
 <% content_for :page_actions do %>
@@ -15,12 +15,12 @@
   <table class="index reimbursement-reimbursement-items">
     <thead>
       <tr>
-        <th><%= Spree.t(:product) %></th>
-        <th><%= Spree.t(:preferred_reimbursement_type) %></th>
-        <th><%= Spree.t(:reimbursement_type_override) %></th>
-        <th><%= Spree.t(:exchange_for) %></th>
-        <th><%= Spree.t(:amount) %></th>
-        <th><%= Spree.t(:total) %></th>
+        <th><%= Spree::Product.model_name.human %></th>
+        <th><%= Spree::ReturnItem.human_attribute_name(:preferred_reimbursement_type_id) %></th>
+        <th><%= Spree::ReturnItem.human_attribute_name(:override_reimbursement_type_id) %></th>
+        <th><%= Spree::ReturnItem.human_attribute_name(:exchange_variant) %></th>
+        <th><%= Spree::ReturnItem.human_attribute_name(:amount) %></th>
+        <th><%= Spree::ReturnItem.human_attribute_name(:total) %></th>
       </tr>
     </thead>
     <tbody>
@@ -54,12 +54,12 @@
 </fieldset>
 
 <fieldset class="no-border-bottom">
-  <legend align='center'><%= Spree.t(:refunds) %></legend>
+  <legend align='center'><%= Spree::Refund.model_name.human %></legend>
   <table class="index reimbursement-refunds">
     <thead data-hook="customer_return_header">
       <tr>
-        <th><%= Spree.t(:description) %></th>
-        <th><%= Spree.t(:amount) %></th>
+        <th><%= Spree::Refund.human_attribute_name(:description) %></th>
+        <th><%= Spree::Refund.human_attribute_name(:amount) %></th>
       </tr>
     </thead>
     <tbody>
@@ -79,7 +79,7 @@
     <thead data-hook="customer_return_header">
       <tr>
         <th><%= Spree.t(:description) %></th>
-        <th><%= Spree.t(:amount) %></th>
+        <th><%= Spree::ReimbursementCredit.human_attribute_name(:amount) %></th>
       </tr>
     </thead>
     <tbody>

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -116,7 +116,7 @@ Spree::Core::Engine.add_routes do
         resources :refunds, only: [:new, :create, :edit, :update]
       end
 
-      resources :reimbursements, only: [:create, :show, :edit, :update] do
+      resources :reimbursements, only: [:index, :create, :show, :edit, :update] do
         member do
           post :perform
         end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -172,6 +172,7 @@ en:
         name: Name
       spree/refund:
         amount: Amount
+        description: Description
         refund_reason_id: Reason
       spree/refund_reason:
         active: Active
@@ -182,6 +183,8 @@ en:
         number: Number
         reimbursement_status: Status
         total: Total
+      spree/reimbursement_credit:
+        amount: Amount
       spree/reimbursement_type:
         name: Name
         type: Type
@@ -197,11 +200,12 @@ en:
         exchange_variant: Exchange for
         inventory_unit_state: State
         item_received?: "Item Received?"
-        pre_tax_amount: Amount before sales tax
+        override_reimbursement_type_id: Reimbursement Type Override
         preferred_reimbursement_type_id: Preferred Reimbursement Type
         reception_status: Reception Status
         resellable: "Resellable?"
         return_reason: Reason
+        total: Total
       spree/return_reason:
         name: Name
         active: Active
@@ -1110,6 +1114,7 @@ en:
       this_file_language: English (US)
       translations: Translations
     icon: Icon
+    id: ID
     identifier: Identifier
     image: Image
     images: Images
@@ -1288,6 +1293,7 @@ en:
     not_enough_stock: There is not enough inventory at the source location to complete this transfer.
     not_found: ! '%{resource} is not found'
     note: Note
+    note_already_received_a_refund: "Note: This order has already received a refund.  Make sure the above reimbursement amount is correct."
     notice_messages:
       product_cloned: Product has been cloned
       product_deleted: Product has been deleted


### PR DESCRIPTION
Improve the reimbursements views by using I18n model name translation and attribute translations where logical.  Also added in a route to the reimbursements index so it's actually reachable (though no link exists.)

 No links exist to the reimbursement show pages either it appears but this is getting out of scope.

This is part of an ongoing effort to improve the I18n usage in solidus as discussed in #735.