### PR TITLE
Improve I18n in reimbursement type views

### DIFF
--- a/backend/app/views/spree/admin/reimbursement_types/index.html.erb
+++ b/backend/app/views/spree/admin/reimbursement_types/index.html.erb
@@ -1,14 +1,14 @@
 <%= render partial: 'spree/admin/shared/configuration_menu' %>
 
 <% content_for :page_title do %>
-  <%= Spree.t(:reimbursement_types) %>
+  <%= Spree::ReimbursementType.model_name.human(count: :other) %>
 <% end %>
 
 <table class="index" id='listing_reimbursement_types' data-hook>
   <thead>
     <tr data-hook="reimbursement_types_header">
-      <th><%= Spree.t(:name) %></th>
-      <th><%= Spree.t(:type) %></th>
+      <th><%= Spree::ReimbursementType.human_attribute_name(:name) %></th>
+      <th><%= Spree::ReimbursementType.human_attribute_name(:type) %></th>
     </tr>
   </thead>
   <tbody>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -160,6 +160,9 @@ en:
         active: Active
         name: Name
         code: Code
+      spree/reimbursement_type:
+        name: Name
+        type: Type
       spree/return_authorization:
         amount: Amount
       spree/return_reason:


### PR DESCRIPTION
Use model name and model attribute translations where applicable to improve I18n use in the project.

This is part of an ongoing effort as discussed in #735 to improve I18n use.