### PR TITLE
Improve i18n in return authorization views.

### DIFF
--- a/backend/app/views/spree/admin/return_authorizations/_form.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/_form.html.erb
@@ -9,13 +9,13 @@
             <%= check_box_tag 'select-all' %>
           <% end %>
         </th>
-        <th class="return-item-product"><%= Spree.t(:product) %></th>
-        <th class="return-item-state"><%= Spree.t(:state) %></th>
-        <th class="return-item-charged"><%= Spree.t(:charged) %></th>
-        <th class="return-item-pre-tax-refund-amount"><%= Spree.t(:pre_tax_refund_amount) %></th>
-        <th class="return-item-reimbursement-type"><%= Spree.t(:reimbursement_type) %></th>
-        <th class="return-item-exchange-for"><%= Spree.t(:exchange_for) %></th>
-        <th class="return-item-reason"><%= Spree.t(:reason) %></th>
+        <th class="return-item-product"><%= Spree::Product.model_name.human %></th>
+        <th class="return-item-state"><%= Spree::ReturnAuthorization.human_attribute_name(:state) %></th>
+        <th class="return-item-charged"><%= Spree::ReturnItem.human_attribute_name(:charged) %></th>
+        <th class="return-item-pre-tax-refund-amount"><%= Spree::ReturnItem.human_attribute_name(:amount) %></th>
+        <th class="return-item-reimbursement-type"><%= Spree::ReimbursementType.model_name.human %></th>
+        <th class="return-item-exchange-for"><%= Spree::ReturnItem.human_attribute_name(:exchange_variant) %></th>
+        <th class="return-item-reason"><%= Spree::ReturnItem.human_attribute_name(:return_reason) %></th>
       </tr>
     </thead>
     <tbody>
@@ -82,7 +82,7 @@
   <% end %>
 
   <%= f.field_container :memo do %>
-    <%= f.label :memo, Spree.t(:memo) %>
+    <%= f.label :memo %>
     <%= f.text_area :memo, {:style => 'height:100px;', :class => 'fullwidth'} %>
     <%= f.error_message_on :memo %>
   <% end %>

--- a/backend/app/views/spree/admin/return_authorizations/edit.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/edit.html.erb
@@ -12,7 +12,7 @@
 <%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Return Authorizations' } %>
 
 <% content_for :page_title do %>
-  <i class="fa fa-arrow-right"></i> <%= Spree.t(:return_authorization) %> <%= @return_authorization.number %> (<%= Spree.t(@return_authorization.state.downcase) %>)
+  <i class="fa fa-arrow-right"></i> <%= Spree::ReturnAuthorization.model_name.human %> <%= @return_authorization.number %> (<%= Spree.t(@return_authorization.state.downcase) %>)
 <% end %>
 
 

--- a/backend/app/views/spree/admin/return_authorizations/index.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/index.html.erb
@@ -12,17 +12,17 @@
 <% end %>
 
 <% content_for :page_title do %>
-  <i class="fa fa-arrow-right"></i> <%= Spree.t(:return_authorizations) %>
+  <i class="fa fa-arrow-right"></i> <%= Spree::ReturnAuthorization.model_name.human(count: :other) %>
 <% end %>
 
 <% if @order.shipments.any?(&:shipped?) || @order.return_authorizations.any? %>
   <table class="index">
     <thead data-hook="rma_header">
       <tr>
-        <th><%= Spree.t(:rma_number) %></th>
-        <th><%= Spree.t(:status) %></th>
-        <th><%= Spree.t(:pre_tax_total) %></th>
-        <th><%= "#{Spree.t('date')}/#{Spree.t('time')}" %></th>
+        <th><%= Spree::ReturnAuthorization.human_attribute_name(:number) %></th>
+        <th><%= Spree::ReturnAuthorization.human_attribute_name(:state) %></th>
+        <th><%= Spree::ReturnAuthorization.human_attribute_name(:pre_tax_total) %></th>
+        <th><%= Spree::ReturnAuthorization.human_attribute_name(:created_at) %></th>
         <th class="actions"></th>
       </tr>
     </thead>

--- a/backend/app/views/spree/admin/return_authorizations/new.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/new.html.erb
@@ -14,7 +14,7 @@
     <%= render :partial => 'form', :locals => { :f => f } %>
 
     <div class="form-buttons filter-actions actions" data-hook="buttons">
-      <%= button Spree.t(:create), 'ok' %>
+      <%= button Spree.t(:'actions.create'), 'ok' %>
       <%= button_link_to Spree.t('actions.cancel'), admin_order_return_authorizations_url(@order), :icon => 'remove' %>
     </div>
   </fieldset>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -184,9 +184,12 @@ en:
         created_at: "Date/Time"
       spree/return_authorization:
         amount: Amount
+        pre_tax_total: Pre-Tax Total
       spree/return_item:
         acceptance_status: Acceptance status
         acceptance_status_errors: Acceptance errors
+        amount: Amount Before Sales Tax
+        charged: Charged
         exchange_variant: Exchange for
         inventory_unit_state: State
         item_received?: "Item Received?"
@@ -198,6 +201,10 @@ en:
       spree/return_reason:
         name: Name
         active: Active
+        created_at: "Date/Time"
+        memo: Memo
+        number: RMA Number
+        state: State
       spree/role:
         name: Name
       spree/shipping_category:


### PR DESCRIPTION
Use model name and model attribute translations where logical.

This is part of an ongoing effort to improve I18n use in solidus as discussed in #735.