### PR TITLE
Improve I18n in return reason and named type views

### DIFF
--- a/backend/app/views/spree/admin/return_reasons/index.html.erb
+++ b/backend/app/views/spree/admin/return_reasons/index.html.erb
@@ -1,5 +1,5 @@
 <%= render partial: 'spree/admin/shared/named_types/index', locals: {
-  page_title: Spree.t(:return_reasons),
+  page_title: Spree::ReturnReason.model_name.human(count: :other),
   new_button_text: Spree.t(:new_rma_reason),
-  resource_name: I18n.t(:other, scope: 'activerecord.models.spree/return_reason')
+  resource_name: Spree::ReturnReason.model_name.human(count: :other)
 } %>

--- a/backend/app/views/spree/admin/shared/named_types/_form.html.erb
+++ b/backend/app/views/spree/admin/shared/named_types/_form.html.erb
@@ -2,14 +2,12 @@
   <div class="row">
     <div class="alpha four columns">
       <%= f.field_container :name do %>
-        <%= f.label :name, Spree.t(:name), class: 'required' %><br />
+        <%= f.label :name, class: 'required' %><br />
         <%= f.text_field :name, :class => 'fullwidth' %>
       <% end %>
       <div class="checkbox">
-        <label>
-          <%= f.check_box :active %>
-          <%= Spree.t(:active) %>
-        </label>
+        <%= f.check_box :active %>
+        <%= f.label :active %>
       </div>
     </div>
   </div>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -118,6 +118,9 @@ en:
         name: Name
       spree/return_authorization:
         amount: Amount
+      spree/return_reason:
+        name: Name
+        active: Active
       spree/role:
         name: Name
       spree/shipping_method:


### PR DESCRIPTION
Modify the views to use model name translation and model attribute translation.  The named type folder contains partials which "return reason" alone utilize currently. Therefore it made sense to modify them concurrently with the return reason views.

This is part of an ongoing effort to improve I18n use as discussed in #735.