### PR TITLE
Report errors properly in general settings

### DIFF
--- a/backend/app/controllers/spree/admin/general_settings_controller.rb
+++ b/backend/app/controllers/spree/admin/general_settings_controller.rb
@@ -9,10 +9,12 @@ module Spree
       end
 
       def update
-        current_store.update_attributes store_params
-
-        flash[:success] = Spree.t(:successfully_updated, resource: Spree.t(:general_settings))
-        redirect_to edit_admin_general_settings_path
+        if @store.update_attributes(store_params)
+          flash[:success] = Spree.t(:successfully_updated, resource: Spree.t(:general_settings))
+          redirect_to edit_admin_general_settings_path
+        else
+          render :edit
+        end
       end
 
       def clear_cache

--- a/backend/app/controllers/spree/admin/general_settings_controller.rb
+++ b/backend/app/controllers/spree/admin/general_settings_controller.rb
@@ -9,11 +9,6 @@ module Spree
       end
 
       def update
-        params.each do |name, value|
-          next unless Spree::Config.has_preference? name
-          Spree::Config[name] = value
-        end
-
         current_store.update_attributes store_params
 
         flash[:success] = Spree.t(:successfully_updated, resource: Spree.t(:general_settings))

--- a/backend/app/views/spree/admin/general_settings/edit.html.erb
+++ b/backend/app/views/spree/admin/general_settings/edit.html.erb
@@ -10,40 +10,52 @@
     <fieldset class="general no-border-top">
 
       <%= fields_for :store do |f| %>
-        <div class="field" data-hook="admin_general_setting_input_name">
-          <%= f.label :name %>
-          <br />
-          <%= f.text_field :name, class: 'fullwidth' %>
+        <div data-hook="admin_general_setting_input_name">
+          <%= f.field_container :name do %>
+            <%= f.label :name %>
+            <%= f.text_field :name, class: 'fullwidth' %>
+            <%= f.error_message_on :name %>
+          <% end %>
         </div>
 
-        <div class="field" data-hook="admin_general_setting_input_seo_title">
-          <%= f.label :seo_title %>
-          <br />
-          <%= f.text_field :seo_title, class: 'fullwidth'  %>
+        <div data-hook="admin_general_setting_input_seo_title">
+          <%= f.field_container :seo_title do %>
+            <%= f.label :seo_title %>
+            <%= f.text_field :seo_title, class: 'fullwidth'  %>
+            <%= f.error_message_on :seo_title %>
+          <% end %>
         </div>
 
-        <div class="field" data-hook="admin_general_setting_input_meta_keywords">
-          <%= f.label :meta_keywords %>
-          <br />
-          <%= f.text_field :meta_keywords, class: 'fullwidth'  %>
+        <div data-hook="admin_general_setting_input_meta_keywords">
+          <%= f.field_container :meta_keywords do %>
+            <%= f.label :meta_keywords %>
+            <%= f.text_field :meta_keywords, class: 'fullwidth'  %>
+            <%= f.error_message_on :meta_keywords %>
+          <% end %>
         </div>
 
-        <div class="field" data-hook="admin_general_setting_input_meta_description">
-          <%= f.label :meta_description %>
-          <br />
-          <%= f.text_field :meta_description, class: 'fullwidth'  %>
+        <div data-hook="admin_general_setting_input_meta_description">
+          <%= f.field_container :meta_description do %>
+            <%= f.label :meta_description %>
+            <%= f.text_field :meta_description, class: 'fullwidth'  %>
+            <%= f.error_message_on :meta_description %>
+          <% end %>
         </div>
 
-        <div class="field" data-hook="admin_general_setting_input_url">
-          <%= f.label :url %>
-          <br />
-          <%= f.text_field :url, class: 'fullwidth'  %>
+        <div data-hook="admin_general_setting_input_url">
+          <%= f.field_container :url do %>
+            <%= f.label :url %>
+            <%= f.text_field :url, class: 'fullwidth'  %>
+            <%= f.error_message_on :url %>
+          <% end %>
         </div>
 
-        <div class="field" data-hook="admin_general_setting_mail_from_address">
-          <%= f.label :mail_from_address %>
-          <br />
-          <%= f.text_field :mail_from_address, class: 'fullwidth'  %>
+        <div data-hook="admin_general_setting_mail_from_address">
+          <%= f.field_container :mail_from_address do %>
+            <%= f.label :mail_from_address %>
+            <%= f.text_field :mail_from_address, class: 'fullwidth'  %>
+            <%= f.error_message_on :mail_from_address %>
+          <% end %>
         </div>
       <% end %>
 

--- a/backend/spec/features/admin/configuration/general_settings_spec.rb
+++ b/backend/spec/features/admin/configuration/general_settings_spec.rb
@@ -14,7 +14,7 @@ describe "General Settings", type: :feature, js: true do
     click_link "General Settings"
   end
 
-  context "visiting general settings (admin)" do
+  context "visiting general settings" do
     it "should have the right content" do
       expect(page).to have_content("General Settings")
       expect(page).to have_field("store_name", with: "Test Store")
@@ -23,7 +23,7 @@ describe "General Settings", type: :feature, js: true do
     end
   end
 
-  context "editing general settings (admin)" do
+  context "editing general settings" do
     it "should be able to update the site name" do
       fill_in "store_name", with: "Spree Demo Site99"
       fill_in "store_mail_from_address", with: "spree@example.org"
@@ -32,6 +32,16 @@ describe "General Settings", type: :feature, js: true do
       assert_successful_update_message(:general_settings)
       expect(page).to have_field("store_name", with: "Spree Demo Site99")
       expect(page).to have_field("store_mail_from_address", with: "spree@example.org")
+    end
+  end
+
+  context "update fails" do
+    it "should display the error" do
+      fill_in "Site Name", with: ""
+      click_button "Update"
+
+      expect(page).to have_content("can't be blank")
+      expect(page).to have_field("Site Name", with: "")
     end
   end
 


### PR DESCRIPTION
Previously if saving the Site failed, success would still be reported. This ensures that errors are reported properly, and the edit form is re-rendered.

Fixes #800

![](http://i.hawth.ca/s/72tcyJur.png)