### PR TITLE
Improve address form partial

### DIFF
--- a/backend/app/views/spree/admin/shared/_address_form.html.erb
+++ b/backend/app/views/spree/admin/shared/_address_form.html.erb
@@ -2,51 +2,51 @@
 
 <div id="<%= type %>" data-hook="address_fields">
   <div class="field <%= "#{type}-row" %>">
-    <%= f.label :firstname, Spree.t(:first_name) %>
+    <%= f.label :firstname %>
     <%= f.text_field :firstname, :class => 'fullwidth' %>
   </div>
 
   <div class="field <%= "#{type}-row" %>">
-    <%= f.label :lastname, Spree.t(:last_name) %>
+    <%= f.label :lastname %>
     <%= f.text_field :lastname, :class => 'fullwidth' %>
   </div>
 
   <% if Spree::Config[:company] %>
     <div class="field <%= "#{type}-row" %>">
-      <%= f.label :company, Spree.t(:company) %>
+      <%= f.label :company %>
       <%= f.text_field :company, :class => 'fullwidth' %>
     </div>
   <% end %>
 
   <div class="field <%= "#{type}-row" %>">
-    <%= f.label :address1, Spree.t(:street_address) %>
+    <%= f.label :address1 %>
     <%= f.text_field :address1, :class => 'fullwidth' %>
   </div>
 
   <div class="field <%= "#{type}-row" %>">
-    <%= f.label :address2, Spree.t(:street_address_2) %>
+    <%= f.label :address2 %>
     <%= f.text_field :address2, :class => 'fullwidth' %>
   </div>
 
   <div class="field <%= "#{type}-row" %>">
-    <%= f.label :city, Spree.t(:city) %>
+    <%= f.label :city %>
     <%= f.text_field :city, :class => 'fullwidth' %>
   </div>
 
   <div class="field <%= "#{type}-row" %>">
-    <%= f.label :zipcode, Spree.t(:zip) %>
+    <%= f.label :zipcode %>
     <%= f.text_field :zipcode, :class => 'fullwidth' %>
   </div>
 
   <div class="field <%= "#{type}-row" %>">
-    <%= f.label :country_id, Spree.t(:country) %>
+    <%= f.label :country_id %>
     <span id="<%= s_or_b %>country">
       <%= f.collection_select :country_id, available_countries, :id, :name, {}, {:class => 'select2 fullwidth'} %>
     </span>
   </div>
 
   <div class="field <%= "#{type}-row" %>">
-    <%= f.label :state_id, Spree.t(:state) %>
+    <%= f.label :state_id %>
     <span id="<%= s_or_b %>state">
       <%= f.text_field :state_name,
             :style => "display: #{f.object.country.states.empty? ? 'block' : 'none' };",
@@ -56,7 +56,7 @@
   </div>
 
   <div class="field <%= "#{type}-row" %>">
-    <%= f.label :phone, Spree.t(:phone) %>
+    <%= f.label :phone %>
     <%= f.phone_field :phone, :class => 'fullwidth' %>
   </div>
 </div>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -2,14 +2,15 @@ en:
   activerecord:
     attributes:
       spree/address:
-        address1: Address
-        address2: Address (contd.)
+        address1: Street Address
+        address2: Street Address (cont'd)
         city: City
-        country: Country
+        company: Company
+        country_id: Country
         firstname: First Name
         lastname: Last Name
         phone: Phone
-        state: State
+        state_id: State
         zipcode: Zip Code
       spree/adjustment:
         adjustable: Adjustable


### PR DESCRIPTION
Add missing translations and get form to automatically pull the translations from the dictionary.

This is part of an ongoing effort to improve I18n usage in the project as discussed in #735.