### PR TITLE
Use model name translations in configuration menu

### DIFF
--- a/backend/app/views/spree/admin/shared/_configuration_menu.html.erb
+++ b/backend/app/views/spree/admin/shared/_configuration_menu.html.erb
@@ -10,45 +10,45 @@
       <% end %>
 
       <% if can? :display, Spree::TaxCategory %>
-        <%= configurations_sidebar_menu_item Spree.t(:tax_categories), admin_tax_categories_path %>
+        <%= configurations_sidebar_menu_item Spree::TaxCategory.model_name.human(count: :other), admin_tax_categories_path %>
       <% end %>
 
       <% if can? :display, Spree::TaxRate %>
-        <%= configurations_sidebar_menu_item Spree.t(:tax_rates), admin_tax_rates_path %>
+        <%= configurations_sidebar_menu_item Spree::TaxRate.model_name.human(count: :other), admin_tax_rates_path %>
       <% end %>
 
       <% if can? :display, Spree::Zone %>
-        <%= configurations_sidebar_menu_item Spree.t(:zones), admin_zones_path %>
+        <%= configurations_sidebar_menu_item Spree::Zone.model_name.human(count: :other), admin_zones_path %>
       <% end %>
 
       <% if can? :display, Spree::Country %>
-        <%= configurations_sidebar_menu_item Spree.t(:countries), admin_countries_path %>
+        <%= configurations_sidebar_menu_item Spree::Country.model_name.human(count: :other), admin_countries_path %>
       <% end %>
 
       <% if can?(:display, Spree::State) %>
         <% if country = Spree::Country.find_by_id(Spree::Config[:default_country_id]) || Spree::Country.first %>
-          <%= configurations_sidebar_menu_item Spree.t(:states), admin_country_states_path(country) %>
+          <%= configurations_sidebar_menu_item Spree::State.model_name.human(count: :other), admin_country_states_path(country) %>
         <% end %>
       <% end %>
 
       <% if can?(:display, Spree::PaymentMethod) %>
-        <%= configurations_sidebar_menu_item Spree.t(:payment_methods), admin_payment_methods_path %>
+        <%= configurations_sidebar_menu_item Spree::PaymentMethod.model_name.human(count: :other), admin_payment_methods_path %>
       <% end %>
 
       <% if can?(:display, Spree::Taxonomy) %>
-        <%= configurations_sidebar_menu_item Spree.t(:taxonomies), admin_taxonomies_path %>
+        <%= configurations_sidebar_menu_item Spree::Taxonomy.model_name.human(count: :other), admin_taxonomies_path %>
       <% end %>
 
       <% if can?(:display, Spree::ShippingMethod) %>
-        <%= configurations_sidebar_menu_item Spree.t(:shipping_methods), admin_shipping_methods_path %>
+        <%= configurations_sidebar_menu_item Spree::ShippingMethod.model_name.human(count: :other), admin_shipping_methods_path %>
       <% end %>
 
       <% if can?(:display, Spree::ShippingCategory) %>
-        <%= configurations_sidebar_menu_item Spree.t(:shipping_categories), admin_shipping_categories_path %>
+        <%= configurations_sidebar_menu_item Spree::ShippingCategory.model_name.human(count: :other), admin_shipping_categories_path %>
       <% end %>
 
       <% if can?(:display, Spree::StockLocation) %>
-        <%= configurations_sidebar_menu_item Spree.t(:stock_locations), spree.admin_stock_locations_path %>
+        <%= configurations_sidebar_menu_item Spree::StockLocation.model_name.human(count: :other), spree.admin_stock_locations_path %>
       <% end %>
 
       <% if can?(:display, Spree::Tracker) %>
@@ -56,15 +56,15 @@
       <% end %>
 
       <% if can?(:display, Spree::RefundReason) %>
-        <%= configurations_sidebar_menu_item Spree.t(:refund_reasons), admin_refund_reasons_path %>
+        <%= configurations_sidebar_menu_item Spree::RefundReason.model_name.human(count: :other), admin_refund_reasons_path %>
       <% end %>
 
       <% if can?(:display, Spree::ReimbursementType) %>
-        <%= configurations_sidebar_menu_item Spree.t(:reimbursement_types), admin_reimbursement_types_path %>
+        <%= configurations_sidebar_menu_item Spree::ReimbursementType.model_name.human(count: :other), admin_reimbursement_types_path %>
       <% end %>
 
       <% if can?(:display, Spree::ReturnReason) %>
-        <%= configurations_sidebar_menu_item Spree.t(:return_reasons), admin_return_reasons_path %>
+        <%= configurations_sidebar_menu_item Spree::ReturnReason.model_name.human(count: :other), admin_return_reasons_path %>
       <% end %>
     </ul>
   </nav>


### PR DESCRIPTION
Model name translations should be used instead of generic translations pulled from the dictionary.

This is part of an ongoing effort to improve I18n usage as discussed in #735.