### PR TITLE
Use model name translation in order submenu

### DIFF
--- a/backend/app/views/spree/admin/shared/_order_submenu.html.erb
+++ b/backend/app/views/spree/admin/shared/_order_submenu.html.erb
@@ -17,18 +17,18 @@
     <% end %>
 
     <li<%== ' class="active"' if current == 'Shipments' %> data-hook='admin_order_tabs_order_details'>
-      <%= link_to_with_icon 'edit', Spree.t(:shipments), edit_admin_order_url(@order) %>
+      <%= link_to_with_icon 'edit', Spree::Shipment.model_name.human(count: :other), edit_admin_order_url(@order) %>
     </li>
 
     <% if can? :display, Spree::Adjustment %>
       <li<%== ' class="active"' if current == 'Adjustments' %> data-hook='admin_order_tabs_adjustments'>
-        <%= link_to_with_icon 'cogs', Spree.t(:adjustments), admin_order_adjustments_url(@order) %>
+        <%= link_to_with_icon 'cogs', Spree::Adjustment.model_name.human(count: :other), admin_order_adjustments_url(@order) %>
       </li>
     <% end %>
 
     <% if can?(:display, Spree::Payment) %>
       <li<%== ' class="active"' if current == 'Payments' %> data-hook='admin_order_tabs_payments'>
-        <%= link_to_with_icon 'credit-card', Spree.t(:payments), admin_order_payments_url(@order) %>
+        <%= link_to_with_icon 'credit-card', Spree::Payment.model_name.human(count: :other), admin_order_payments_url(@order) %>
       </li>
     <% end %>
 
@@ -41,7 +41,7 @@
     <% if can? :display, Spree::ReturnAuthorization %>
       <% if @order.completed? %>
         <li<%== ' class="active"' if current == 'Return Authorizations' %> data-hook='admin_order_tabs_return_authorizations'>
-          <%= link_to_with_icon 'share', Spree.t(:return_authorizations), admin_order_return_authorizations_url(@order) %>
+          <%= link_to_with_icon 'share', Spree::ReturnAuthorization.model_name.human(count: :other), admin_order_return_authorizations_url(@order) %>
         </li>
       <% end %>
     <% end %>
@@ -49,7 +49,7 @@
     <% if can? :display, Spree::CustomerReturn %>
       <% if @order.completed? %>
         <li<%== ' class="active"' if current == 'Customer Returns' %>>
-          <%= link_to_with_icon 'download', Spree.t(:customer_returns), admin_order_customer_returns_url(@order) %>
+          <%= link_to_with_icon 'download', Spree::CustomerReturn.model_name.human(count: :other), admin_order_customer_returns_url(@order) %>
         </li>
       <% end %>
     <% end %>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -190,6 +190,9 @@ en:
       spree/address:
         one: Address
         other: Addresses
+      spree/adjustment:
+        one: Adjustment
+        other: Adjustments
       spree/adjustment_reason:
         one: Adjustment Reason
         other: Adjustment Reasons


### PR DESCRIPTION
Model name translation is used in lieu of generic translations taken out of the dictionary.

This is part of an ongoing effort to improve I18n usage as discussed in #735.