### PR TITLE
Use model name translation for calculator partial

### DIFF
--- a/backend/app/views/spree/admin/shared/_calculator_fields.html.erb
+++ b/backend/app/views/spree/admin/shared/_calculator_fields.html.erb
@@ -1,9 +1,9 @@
 <fieldset id="calculator_fields" data-hook class="no-border-bottom">
-  <legend align="center"><%= Spree.t(:calculator) %></legend>
+  <legend align="center"><%= Spree::Calculator.model_name.human %></legend>
 
   <div id="preference-settings" data-hook>
     <div class="field">
-      <%= f.label(:calculator_type, Spree.t(:calculator), :for => 'calc_type') %>
+      <%= f.label(:calculator_type, Spree::Calculator.model_name.human, :for => 'calc_type') %>
       <%= f.select(:calculator_type, @calculators.map { |c| [c.description, c.name] }, {}, {:id => 'calc_type', :class => 'select2 fullwidth'}) %>
     </div>
     <% if !@object.new_record? %>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -193,6 +193,9 @@ en:
       spree/adjustment_reason:
         one: Adjustment Reason
         other: Adjustment Reasons
+      spree/calculator:
+        one: Calculator
+        other: Calculators
       spree/country:
         one: Country
         other: Countries


### PR DESCRIPTION
It is better to use a model name translation through I18n than a generic.

This is part of an ongoing effort to improve I18n usage as discussed in #735.