### PR TITLE
Improve I18n in order summary partial

### DIFF
--- a/backend/app/views/spree/admin/shared/_order_summary.html.erb
+++ b/backend/app/views/spree/admin/shared/_order_summary.html.erb
@@ -8,46 +8,46 @@
       <dd id='order_user_link'><%= link_to @order.user.email, edit_admin_user_path(@order.user) %></dd>
     <% end %>
 
-    <dt data-hook='admin_order_tab_subtotal_title'><%= Spree.t(:subtotal) %>:</dt>
+    <dt data-hook='admin_order_tab_subtotal_title'><%= Spree::Order.human_attribute_name(:item_total) %>:</dt>
     <dd id='item_total'><%= @order.display_item_total.to_html %></dd>
     <% if checkout_steps.include?("delivery") && @order.ship_total > 0 %>
-      <dt data-hook='admin_order_tab_ship_total_title'><%= Spree.t(:ship_total) %>:</dt>
+      <dt data-hook='admin_order_tab_ship_total_title'><%= Spree::Order.human_attribute_name(:shipment_total) %>:</dt>
       <dd id='ship_total'><%= @order.display_ship_total.to_html %></dd>
     <% end %>
 
     <% if @order.included_tax_total != 0 %>
-      <dt data-hook='admin_order_tab_included_tax_title'><%= Spree.t(:tax_included) %>:</dt>
+      <dt data-hook='admin_order_tab_included_tax_title'><%= Spree::Order.human_attribute_name(:included_tax_total) %>:</dt>
       <dd id='included_tax_total'><%= @order.display_included_tax_total.to_html %></dd>
     <% end %>
 
     <% if @order.additional_tax_total != 0 %>
-      <dt data-hook='admin_order_tab_additional_tax_title'><%= Spree.t(:tax) %>:</dt>
+      <dt data-hook='admin_order_tab_additional_tax_title'><%= Spree::Order.human_attribute_name(:additional_tax_total) %>:</dt>
       <dd id='additional_tax_total'><%= @order.display_additional_tax_total.to_html %></dd>
     <% end %>
 
-    <dt data-hook='admin_order_tab_total_title'><%= Spree.t(:total) %>:</dt>
+    <dt data-hook='admin_order_tab_total_title'><%= Spree::Order.human_attribute_name(:total) %>:</dt>
     <dd id='order_total'><%= @order.display_total.to_html %></dd>
 
     <% if @order.completed? %>
-      <dt><%= Spree.t(:shipment) %>: </dt>
+      <dt><%= Spree::Shipment.model_name.human %>: </dt>
       <dd id='shipment_status'><span class="state <%= @order.shipment_state %>"><%= Spree.t(@order.shipment_state, :scope => :shipment_states, :default => [:missing, "none"]) %></span></dd>
-      <dt><%= Spree.t(:payment) %>: </dt>
+      <dt><%= Spree::Payment.model_name.human %>: </dt>
       <dd id='payment_status'><span class="state <%= @order.payment_state %>"><%= Spree.t(@order.payment_state, :scope => :payment_states, :default => [:missing, "none"]) %></span></dd>
-      <dt data-hook='admin_order_tab_date_completed_title'><%= Spree.t(:date_completed) %>:</dt>
+      <dt data-hook='admin_order_tab_date_completed_title'><%= Spree::Order.human_attribute_name(:completed_at) %>:</dt>
       <dd id='date_complete'><%= pretty_time(@order.completed_at) %></dd>
     <% end %>
 
     <% if @order.approved? %>
-      <dt><%= Spree.t(:approver) %></dt>
+      <dt><%= Spree::Order.human_attribute_name(:approver) %></dt>
       <dd><%= @order.approver.try(:email) || @order.approver_name %></dd>
-      <dt><%= Spree.t(:approved_at) %></dt>
+      <dt><%= Spree::Order.human_attribute_name(:approved_at) %></dt>
       <dd><%= pretty_time(@order.approved_at) %></dd>
     <% end %>
 
     <% if @order.canceled? && @order.canceler && @order.canceled_at %>
-      <dt><%= Spree.t(:canceler) %></dt>
+      <dt><%= Spree::Order.human_attribute_name(:canceler) %></dt>
       <dd><%= @order.canceler.email %></td>
-      <dt><%= Spree.t(:canceled_at) %></dt>
+      <dt><%= Spree::Order.human_attribute_name(:canceled_at) %></dt>
       <dd><%= pretty_time(@order.canceled_at) %></dd>
     <% end %>
   </dl>

--- a/backend/app/views/spree/admin/shared/_order_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_order_tabs.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= link_to "#{Spree.t(:order)} ##{@order.number}", spree.edit_admin_order_path(@order) %>
+  <%= link_to "#{Spree::Order.model_name.human} ##{@order.number}", spree.edit_admin_order_path(@order) %>
 <% end %>
 
 <% content_for :sidebar_title do %>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -55,16 +55,23 @@ en:
         name: Name
         presentation: Presentation
       spree/order:
+        additional_tax_total: Tax
+        approved_at: Approved at
+        approver_id: Approver
+        canceled_at: Canceled at
+        canceler_id: Canceler
         checkout_complete: Checkout Complete
         completed_at: Completed At
         coupon_code: Coupon Code
         created_at: Order Date
         email: Customer E-Mail
+        included_tax_total: Tax (incl.)
         ip_address: IP Address
         item_total: Item Total
         number: Number
         payment_state: Payment State
         shipment_state: Shipment State
+        shipment_total: Ship Total
         special_instructions: Special Instructions
         state: State
         total: Total


### PR DESCRIPTION
Uses model name translation and model attribute translation instead of generic name changes

Changed subtotal to item total in the displayed text in order to be more in line with attribute being displayed and with the `reports/sales_total.html.erb` view.

Noted that the adjustments (outside of tax) aren't being shown in the order submenu so that is something we might want to look at but is out of scope for this PR.

This is part of an ongoing effort to improve I18n usage as discussed in #735.