### PR TITLE
Improve I18n in refunds view partial

### DIFF
--- a/backend/app/views/spree/admin/shared/_refunds.html.erb
+++ b/backend/app/views/spree/admin/shared/_refunds.html.erb
@@ -1,11 +1,11 @@
 <table class="index" id='payments' data-order-id='<%= @order.number %>'>
   <thead>
     <tr data-hook="refunds_header">
-      <th><%= "#{Spree.t('date')}/#{Spree.t('time')}" %></th>
-      <th><%= Spree.t(:payment_identifier) %></th>
-      <th><%= Spree.t(:amount) %></th>
-      <th><%= Spree.t(:payment_method) %></th>
-      <th><%= Spree.t(:transaction_id) %></th>
+      <th><%= Spree::Refund.human_attribute_name(:created_at) %></th>
+      <th><%= Spree::Payment.human_attribute_name(:number) %></th>
+      <th><%= Spree::Refund.human_attribute_name(:amount) %></th>
+      <th><%= Spree::PaymentMethod.model_name.human %></th>
+      <th><%= Spree::Refund.human_attribute_name(:transaction_id) %></th>
       <th><%= Spree.t(:reason) %></th>
       <% if show_actions %>
         <th class="actions"></th>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -115,6 +115,7 @@ en:
         zipcode: Shipping address zipcode
       spree/payment:
         amount: Amount
+        number: Identifier
       spree/payment_method:
         name: Name
       spree/product:
@@ -175,6 +176,7 @@ en:
       spree/reimbursement_type:
         name: Name
         type: Type
+        created_at: "Date/Time"
       spree/return_authorization:
         amount: Amount
       spree/return_item:


### PR DESCRIPTION
Use model attribute translations and model name translations to head the table instead of arbitrary choices.

This is part of an ongoing effort to improve I18n usage as discussed in #735.