### PR TITLE
Improve I18n in variant search partial

### DIFF
--- a/backend/app/views/spree/admin/shared/_variant_search.html.erb
+++ b/backend/app/views/spree/admin/shared/_variant_search.html.erb
@@ -2,12 +2,12 @@
   <%= form_for :variant_search, url: form_path, method: :get do |f| %>
     <div class="field-block alpha four columns">
       <div class="field">
-        <%= label_tag nil, Spree.t(:stock_location) %>
+        <%= label_tag nil, Spree::StockLocation.model_name.human %>
         <%= select_tag :stock_location_id, options_from_collection_for_select(stock_locations, :id, :name, params[:stock_location_id]), { :include_blank => true, :class => 'select2 fullwidth', "data-placeholder" => Spree.t(:select_a_stock_location) } %>
       </div>
     </div>
     <div data-hook="add_product_name" class="field <%= if content_for?(:sidebar) then 'eight' else 'twelve' end %> columns alpha">
-      <%= label_tag :add_variant_id, Spree.t(:variant) %>
+      <%= label_tag :add_variant_id, Spree::Variant.model_name.human %>
       <%= text_field_tag :variant_search_term, params[:variant_search_term], :class => "fullwidth", :placeholder => Spree.t(:variant_search_placeholder) %>
     </div>
 


### PR DESCRIPTION
Use model name translations.

This is part of an ongoing effort to improve I18n usage as discussed in #735.