### PR TITLE
Improve I18n in shipping category views

### DIFF
--- a/backend/app/views/spree/admin/shipping_categories/_form.html.erb
+++ b/backend/app/views/spree/admin/shipping_categories/_form.html.erb
@@ -1,6 +1,6 @@
 <div data-hook="admin_shipping_category_form_fields">
   <div data-hook="name" class="field align-center">
-    <%= label_tag :shipping_category_name, Spree.t(:name) %><br>
-    <%= f.text_field :name %>    
+    <%= f.label :name %><br>
+    <%= f.text_field :name %>
   </div>
 </div>

--- a/backend/app/views/spree/admin/shipping_categories/index.html.erb
+++ b/backend/app/views/spree/admin/shipping_categories/index.html.erb
@@ -1,7 +1,7 @@
 <%= render 'spree/admin/shared/configuration_menu' %>
 
 <% content_for :page_title do %>
-  <%= Spree.t(:shipping_categories) %>
+  <%= Spree::ShippingCategory.model_name.human(count: :other) %>
 <% end %>
 
 <% content_for :page_actions do %>
@@ -20,7 +20,7 @@
   </colgroup>
   <thead>
     <tr data-hook="categories_header">
-      <th><%= Spree.t(:name) %></th>
+      <th><%= Spree::ShippingCategory.human_attribute_name(:name) %></th>
       <th class="actions"></th>
     </tr>
   </thead>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -120,6 +120,8 @@ en:
         amount: Amount
       spree/role:
         name: Name
+      spree/shipping_category:
+        name: Name
       spree/shipping_method:
         carrier: Carrier
         service_level: Service Level


### PR DESCRIPTION
Use model name and model attribute translation instead of generic translations.

This is part of an ongoing effort to improve I18n usage as discussed in #735.