### PR TITLE
Improve i18n in Shipping Method views

### DIFF
--- a/backend/app/views/spree/admin/shipping_methods/_form.html.erb
+++ b/backend/app/views/spree/admin/shipping_methods/_form.html.erb
@@ -1,7 +1,7 @@
 <div data-hook="admin_shipping_method_form_fields" class="alpha twelve columns">
   <div data-hook="admin_shipping_method_form_name_field" class="alpha six columns">
     <%= f.field_container :name do %>
-      <%= f.label :name, Spree.t(:name) %><br />
+      <%= f.label :name %><br />
       <%= f.text_field :name, :class => 'fullwidth' %>
       <%= error_message_on :shipping_method, :name %>
     <% end %>
@@ -9,7 +9,7 @@
 
   <div data-hook="admin_shipping_method_form_display_field" class="omega six columns">
     <%= f.field_container :display_on do %>
-      <%= f.label :display_on, Spree.t(:display) %><br />
+      <%= f.label :display_on %><br />
       <%= select(:shipping_method, :display_on, Spree::ShippingMethod::DISPLAY.collect { |display| [Spree.t(display), display == :both ? nil : display.to_s] }, {}, {:class => 'select2 fullwidth'}) %>
       <%= error_message_on :shipping_method, :display_on %>
     <% end %>
@@ -18,7 +18,7 @@
   <div class="alpha omega twelve columns">
     <div data-hook="admin_shipping_method_form_internal_name_field" class="alpha six columns">
       <%= f.field_container :admin_name do %>
-        <%= f.label :admin_name, Spree.t(:internal_name) %><br />
+        <%= f.label :admin_name %><br />
         <%= f.text_field :admin_name, :class => 'fullwidth', :label => false  %>
         <%= error_message_on :shipping_method, :admin_name %>
       <% end %>
@@ -26,7 +26,7 @@
 
     <div data-hook="admin_shipping_method_form_code" class="omega six columns">
       <%= f.field_container :code do %>
-        <%= f.label :code, Spree.t(:code) %><br />
+        <%= f.label :code %><br />
         <%= f.text_field :code, :class => 'fullwidth', :label => false  %>
         <%= error_message_on :shipping_method, :code %>
       <% end %>
@@ -53,7 +53,7 @@
 
   <div data-hook="admin_shipping_method_form_tracking_url_field" class="alpha twelve columns">
     <%= f.field_container :tracking_url do %>
-      <%= f.label :tracking_url, Spree.t(:tracking_url) %><br />
+      <%= f.label :tracking_url %><br />
       <%= f.text_field :tracking_url, :class => 'fullwidth', :placeholder => Spree.t(:tracking_url_placeholder) %>
       <%= error_message_on :shipping_method, :tracking_url %>
     <% end %>
@@ -63,7 +63,7 @@
 <div class="alpha six columns">
   <div data-hook="admin_shipping_method_form_availability_fields" class="alpha six columns">
     <fieldset class="categories no-border-bottom">
-      <legend align="center"><%= Spree.t(:shipping_categories) %></legend>
+      <legend align="center"><%= Spree::ShippingCategory.model_name.human(count: :other) %></legend>
       <%= f.field_container :categories do %>
         <% Spree::ShippingCategory.all.each do |category| %>
           <%= label_tag do %>
@@ -78,7 +78,7 @@
 
   <div class="alpha six columns">
     <fieldset class="no-border-bottom">
-      <legend align="center"><%= Spree.t(:zones) %></legend>
+      <legend align="center"><%= Spree::Zone.model_name.human(count: :other) %></legend>
       <%= f.field_container :zones do %>
         <% shipping_method_zones = @shipping_method.zones.to_a %>
         <% Spree::Zone.all.each do |zone| %>
@@ -101,7 +101,7 @@
 <div class="alpha six columns">
   <div class="alpha six columns">
     <fieldset class="tax_categories no-border-bottom">
-      <legend align="center"><%= Spree.t(:tax_category) %></legend>
+      <legend align="center"><%= Spree::TaxCategory.model_name.human %></legend>
         <%= f.field_container :tax_categories do %>
           <%= f.select :tax_category_id, @tax_categories.map { |tc| [tc.name, tc.id] }, {include_blank: true}, class: "select2 fullwidth" %>
           <%= error_message_on :shipping_method, :tax_category_id %>

--- a/backend/app/views/spree/admin/shipping_methods/index.html.erb
+++ b/backend/app/views/spree/admin/shipping_methods/index.html.erb
@@ -1,7 +1,7 @@
 <%= render 'spree/admin/shared/configuration_menu' %>
 
 <% content_for :page_title do %>
-  <%= Spree.t(:shipping_methods) %>
+  <%= Spree::ShippingMethod.model_name.human(count: :other) %>
 <% end %>
 
 <% content_for :page_actions do %>
@@ -23,10 +23,10 @@
     </colgroup>
     <thead>
       <tr data-hook="admin_shipping_methods_index_headers">
-        <th><%= Spree.t(:name) %></th>
-        <th><%= Spree.t(:zone) %></th>
-        <th><%= Spree.t(:calculator) %></th>
-        <th><%= Spree.t(:display) %></th>
+        <th><%= Spree::ShippingMethod.human_attribute_name(:name) %></th>
+        <th><%= Spree::Zone.model_name.human %></th>
+        <th><%= Spree::Calculator.model_name.human %></th>
+        <th><%= Spree::ShippingMethod.human_attribute_name(:display_on) %></th>
         <th data-hook="admin_shipping_methods_index_header_actions" class="actions"></th>
       </tr>
     </thead>
@@ -36,7 +36,7 @@
           <td class="align-center"><%= shipping_method.admin_name + ' / ' if shipping_method.admin_name.present? %><%= shipping_method.name %></td>
           <td class="align-center"><%= shipping_method.zones.collect(&:name).join(", ") if shipping_method.zones %></td>
           <td class="align-center"><%= shipping_method.calculator.description %></td>
-          <td class="align-center"><%= shipping_method.display_on.blank? ? Spree.t(:both) : Spree.t(shipping_method.display_on) %></td>
+          <td class="align-center"><%= shipping_method.display_on.blank? ? Spree.t(:both) : Spree.t(shipping_method.display_on.downcase.tr(" ", "_")) %></td>
           <td data-hook="admin_shipping_methods_index_row_actions" class="actions">
             <% if can?(:update, shipping_method) %>
               <%= link_to_edit shipping_method, :no_text => true %>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -121,8 +121,13 @@ en:
       spree/role:
         name: Name
       spree/shipping_method:
+        admin_name: Internal Name
         carrier: Carrier
+        code: Code
+        display_on: Display
+        name: Name
         service_level: Service Level
+        tracking_url: Tracking URL
       spree/state:
         abbr: Abbreviation
         name: Name


### PR DESCRIPTION
Use model attribute translation and model name translation in shipping method views.  Convert `shipping_method.display_on` string to syntax used for dictionary keys.

This is part of an ongoing effort to improve I18n usage as discussed in #735.