### PR TITLE
Improve I18n in state views

### DIFF
--- a/backend/app/views/spree/admin/states/_form.html.erb
+++ b/backend/app/views/spree/admin/states/_form.html.erb
@@ -1,13 +1,13 @@
 <div data-hook="admin_state_form_fields" class="row">
   <div class="alpha six columns">
     <%= f.field_container :name do %>
-      <%= f.label :name, Spree.t(:name) %>
+      <%= f.label :name %>
       <%= f.text_field :name, :class => 'fullwidth' %>
     <% end %>
   </div>
   <div class="omega six columns">
     <%= f.field_container :abbr do %>
-      <%= f.label :abbr, Spree.t(:abbreviation) %>
+      <%= f.label :abbr %>
       <%= f.text_field :abbr, :class => 'fullwidth' %>
     <% end %>
   </div>

--- a/backend/app/views/spree/admin/states/_state_list.html.erb
+++ b/backend/app/views/spree/admin/states/_state_list.html.erb
@@ -6,8 +6,8 @@
   </colgroup>
   <thead>
     <tr data-hook="states_header">
-      <th><%= Spree.t(:name) %></th>
-      <th><%= Spree.t(:abbreviation) %></th>
+      <th><%= Spree::State.human_attribute_name(:name) %></th>
+      <th><%= Spree::State.human_attribute_name(:abbr) %></th>
       <th class="actions"></th>
     </tr>
   </thead>

--- a/backend/app/views/spree/admin/states/index.html.erb
+++ b/backend/app/views/spree/admin/states/index.html.erb
@@ -1,7 +1,7 @@
 <%= render :partial => 'spree/admin/shared/configuration_menu' %>
 
 <% content_for :page_title do %>
-  <%= Spree.t(:states) %>
+  <%= Spree::State.model_name.human(count: :other) %>
 <% end %>
 
 <% content_for :page_actions do %>
@@ -13,7 +13,7 @@
 <% end %>
 
 <div data-hook="country" class="field row">
-  <%= label_tag :country, Spree.t(:country) %>
+  <%= label_tag :country, Spree::Country.model_name.human %>
   <select id="country" class='observe_field select2 fullwidth' data-base-url="<%=admin_states_path(:format => :js) %>?country_id=" data-update="#state-list">
   <%= options_from_collection_for_select(@countries, :id, :name, @country.id) %>
   </select>


### PR DESCRIPTION
Use model attribute and model name translations.

This is part of an ongoing effort to improve I18n usage as discussed in #735.