### PR TITLE
Improve I18n in stock_items index view

### DIFF
--- a/backend/app/views/spree/admin/stock_items/index.html.erb
+++ b/backend/app/views/spree/admin/stock_items/index.html.erb
@@ -25,8 +25,6 @@
   <%= render :partial => 'stock_management', :locals => { :variants => @variants } %>
 <% else %>
   <div class="fullwidth no-objects-found">
-    <%= Spree.t(:no_variants_found) %>
-    <br/>
-    <%= Spree.t(:try_changing_search_values) %>
+    <%= Spree.t(:no_variants_found_try_again) %>
   </div>
 <% end %>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1081,6 +1081,7 @@ en:
     no_stock_locations_found: No stock locations found
     no_tracking_present: No tracking details provided.
     no_variants_found: No variants found.
+    no_variants_found_try_again: No variants found. Try changing the search values.
     none: None
     none_selected: None Selected
     normal_amount: Normal Amount


### PR DESCRIPTION
Condense this translation into one value so that when it is translated into a different language there are no constraints placed by the order chosen in English.

This is part of an ongoing effort to improve I18n usage as discussed in #735.