### PR TITLE
Improve i18n in stock location views

### DIFF
--- a/backend/app/views/spree/admin/stock_locations/_transfer_stock_form.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/_transfer_stock_form.html.erb
@@ -17,14 +17,14 @@
 
       <div class="five columns">
         <div class="field" id="stock_movement_variant_id_field">
-          <%= label_tag 'variant_id', Spree.t(:variant) %>
+          <%= label_tag 'variant_id', Spree::Variant.model_name.human %>
           <%= select_tag :variant_id, options_from_collection_for_select(@variants, :id, :name_and_sku), class: 'select2 fullwidth' %>
         </div>
       </div>
 
       <div class="five columns">
         <div class="field" id="stock_movement_quantity_field">
-          <%= label_tag 'quantity', Spree.t(:quantity) %>
+          <%= label_tag 'quantity', Spree::StockMovement.human_attribute_name(:quantity) %>
           <%= number_field_tag :quantity, 1, class: 'fullwidth' %>
         </div>
       </div>

--- a/backend/app/views/spree/admin/stock_locations/index.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/index.html.erb
@@ -1,7 +1,7 @@
 <%= render :partial => 'spree/admin/shared/configuration_menu' %>
 
 <% content_for :page_title do %>
-  <%= Spree.t(:stock_locations) %>
+  <%= Spree::StockLocation.model_name.human(count: :other) %>
 <% end %>
 
 <% content_for :page_actions do %>
@@ -32,9 +32,9 @@
     <thead>
       <tr data-hook="stock_locations_header">
         <th class="no-border"></th>
-        <th><%= Spree.t(:name) %></th>
-        <th><%= Spree.t(:state) %></th>
-        <th><%= Spree.t(:stock_movements) %></th>
+        <th><%= Spree::StockLocation.human_attribute_name(:name) %></th>
+        <th><%= Spree::StockLocation.human_attribute_name(:state_id) %></th>
+        <th><%= Spree::StockMovement.model_name.human(count: :other) %></th>
         <th class="actions"></th>
       </tr>
     </thead>
@@ -53,7 +53,7 @@
           <td class="align-center"><span class="state <%= state(stock_location) %>"><%= Spree.t(state(stock_location)) %></span></td>
           <td class="align-center">
             <% if can?(:display, Spree::StockMovement) %>
-              <%= link_to Spree.t(:stock_movements), admin_stock_location_stock_movements_path(stock_location.id) %>
+              <%= link_to Spree::StockMovement.model_name.human(count: :other), admin_stock_location_stock_movements_path(stock_location.id) %>
             <% else %>
               Stock Movements
             <% end %>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -220,6 +220,7 @@ en:
         action: Action
         quantity: Quantity
         stock_item_id: Stock Item
+        quantity: Quantity
       spree/stock_transfer:
         created_at: Created At
         created_by_id: Created By


### PR DESCRIPTION
Use model name and model attribute translations.

This is part of an ongoing effort to improve I18n usage as discussed in #735.