### PR TITLE
Improve I18n in stock movement views

### DIFF
--- a/backend/app/views/spree/admin/stock_movements/_form.html.erb
+++ b/backend/app/views/spree/admin/stock_movements/_form.html.erb
@@ -1,11 +1,11 @@
 <div data-hook="admin_stock_movements_form_fields" class="row">
   <div class="alpha twelve columns">
     <%= f.field_container :quantity do %>
-      <%= f.label :quantity, Spree.t(:quantity) %>
+      <%= f.label :quantity %>
       <%= f.text_field :quantity %>
     <% end %>
     <%= f.field_container :stock_item_id do %>
-      <%= f.label :stock_item_id, Spree.t(:stock_item_id) %>
+      <%= f.label :stock_item_id %>
       <%= f.text_field 'stock_item_id', :class => 'fullwidth', :'data-stock-location-id' => params[:stock_location_id] %>
     <% end %>
   </div>

--- a/backend/app/views/spree/admin/stock_movements/index.html.erb
+++ b/backend/app/views/spree/admin/stock_movements/index.html.erb
@@ -27,9 +27,9 @@
   </colgroup>
   <thead>
     <tr data-hook="admin_stock_movements_index_headers">
-      <th><%= Spree.t(:stock_item) %>
-      <th><%= Spree.t(:quantity) %></th>
-      <th><%= Spree.t(:action) %></th>
+      <th><%= Spree::StockMovement.human_attribute_name(:stock_item) %>
+      <th><%= Spree::StockMovement.human_attribute_name(:quantity) %></th>
+      <th><%= Spree::StockMovement.human_attribute_name(:action) %></th>
     </tr>
   </thead>
   <tbody>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -157,6 +157,10 @@ en:
         restock_inventory: Restock Inventory
         state_id: State
         zipcode: Zip
+      spree/stock_movement:
+        action: Action
+        quantity: Quantity
+        stock_item_id: Stock Item
       spree/tax_category:
         description: Description
         name: Name


### PR DESCRIPTION
Use model attribute translations.

This is part of an ongoing effort to improve I18n usage as discussed in #735.