### PR TITLE
Remove unnecessary update_order_state.js hacks

### DIFF
--- a/backend/app/views/spree/admin/orders/_form.html.erb
+++ b/backend/app/views/spree/admin/orders/_form.html.erb
@@ -39,6 +39,5 @@
     <% @order.shipments.each do |shipment| %>
             shipments.push(<%== shipment.as_json(:root => false, :only => [:id, :tracking, :number, :state, :stock_location_id], :include => [:inventory_units, :stock_location]).to_json %>);
     <% end %>
-    <%= render :partial => 'spree/admin/shared/update_order_state', :handlers => [:js] %>
   <% end -%>
 </div>

--- a/backend/app/views/spree/admin/orders/_line_items_edit_form.html.erb
+++ b/backend/app/views/spree/admin/orders/_line_items_edit_form.html.erb
@@ -34,7 +34,5 @@
       <% @order.shipments.each do |shipment| %>
             shipments.push(<%== shipment.as_json(:root => false, :only => [:id, :tracking, :number, :state, :stock_location_id], :include => [:inventory_units, :stock_location]).to_json %>);
       <% end %>
-
-      <%= render :partial => 'spree/admin/shared/update_order_state', :handlers => [:js] %>
   <% end -%>
 </div>

--- a/backend/app/views/spree/admin/shared/_destroy.js.erb
+++ b/backend/app/views/spree/admin/shared/_destroy.js.erb
@@ -2,5 +2,3 @@
 if success %>
   show_flash('success', "<%= j success %>")
 <% end %>
-
-<%= render :partial => '/spree/admin/shared/update_order_state' if @order %>

--- a/backend/app/views/spree/admin/shared/_update_order_state.js
+++ b/backend/app/views/spree/admin/shared/_update_order_state.js
@@ -1,7 +1,0 @@
-$('#order_tab_summary h5#order_status').html('<%= j Spree.t(:status) %>: <%= j Spree.t(@order.state, :scope => :order_state) %>');
-$('#order_tab_summary h5#order_total').html('<%= j Spree.t(:total) %>: <%= j @order.display_total.to_html %>');
-
-<% if @order.completed? %>
-  $('#order_tab_summary h5#payment_status').html('<%= j Spree.t(:payment) %>: <%= j Spree.t(@order.payment_state, :scope => :payment_states, :default => [:missing, "none"]) %>');
-  $('#order_tab_summary h5#shipment_status').html('<%= j Spree.t(:shipment) %>: <%= j Spree.t(@order.shipment_state, :scope => :shipment_state, :default => [:missing, "none"]) %>');
-<% end %>


### PR DESCRIPTION
This referenced `<h5>`s in the order tab summary, which no longer exist.