### PR TITLE
Remove json gem

### DIFF
--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'font-awesome-rails', '~> 4.0'
   s.add_dependency 'friendly_id', '~> 5.0'
   s.add_dependency 'highline', '~> 1.6.18' # Necessary for the install generator
-  s.add_dependency 'json', '~> 1.7'
   s.add_dependency 'kaminari', '~> 0.15', '>= 0.15.1'
   s.add_dependency 'monetize', '~> 1.1'
   s.add_dependency 'paperclip', '~> 4.2.0'


### PR DESCRIPTION
Per recommendation of http://www.mikeperham.com/2016/02/09/kill-your-dependencies/

All modern Rubies ship JSON as part of stdlib.