### PR TITLE
Improve I18n use in stock transfer views

### DIFF
--- a/backend/app/views/spree/admin/stock_transfers/_stock_movements.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/_stock_movements.html.erb
@@ -8,10 +8,10 @@
   </colgroup>
   <thead data-hook="bulk_variants_header">
     <tr>
-      <th><%= Spree.t('variant') %></th>
-      <th><%= Spree.t('sku') %></th>
-      <th><%= Spree.t('quantity') %></th>
-      <th><%= Spree.t('count_on_hand') %></th>
+      <th><%= Spree::Variant.model_name.human %></th>
+      <th><%= Spree::Variant.human_attribute_name(:sku) %></th>
+      <th><%= Spree::StockMovement.human_attribute_name(:quantity) %></th>
+      <th><%= Spree::StockItem.human_attribute_name(:count_on_hand) %></th>
     </tr>
   </thead>
   <tbody id="bulk_variants_tbody">

--- a/backend/app/views/spree/admin/stock_transfers/_transfer_item_table.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/_transfer_item_table.html.erb
@@ -59,5 +59,5 @@
     </tbody>
   </table>
   <div class="no-objects-found" <%= 'hidden' if @stock_transfer.transfer_items.any? %>>
-    <%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: 'activerecord.models.spree/transfer_item')) %>
+    <%= Spree.t(:no_resource_found, resource: Spree::TransferItem.model_name.human) %>
   </div>

--- a/backend/app/views/spree/admin/stock_transfers/edit.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/edit.html.erb
@@ -17,7 +17,7 @@
     <span><%= Spree.t(:you_cannot_undo_action) %></span>
   </div>
   <div class='action-consequences'>
-    <span><%= Spree.t('finalize_stock_transfer.will_cause') %>:</span>
+    <span><%= Spree.t('finalize_stock_transfer.will_cause') %></span>
     <ul data-hook='finalize-stock-transfer-consequences'>
       <li><%= Spree.t('finalize_stock_transfer.no_longer_change_items') %></li>
     </ul>
@@ -36,12 +36,12 @@
       <p><%= @stock_transfer.created_by.email %></p>
     </div>
     <%= f.field_container :description do %>
-      <%= f.label nil, Spree.t(:description) %>
+      <%= f.label :description %>
       <%= f.text_field :description, value: @stock_transfer.description, maxlength: 255, size: 0, class: 'fullwidth' %>
       <%= f.error_message_on :description %>
     <% end %>
     <%= f.field_container :destination_location do %>
-      <%= f.label nil, Spree.t(:destination_location) %>
+      <%= f.label :destination_location_id %>
       <%= f.select :destination_location_id, options_from_collection_for_select(@destination_stock_locations, :id, :name, @stock_transfer.destination_location_id), {include_blank: true}, {class: 'select2 fullwidth', "data-placeholder" => Spree.t(:select_a_stock_location)} %>
       <%= f.error_message_on :destination_location %>
     <% end %>

--- a/backend/app/views/spree/admin/stock_transfers/index.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:stock_transfers) %>
+  <%= Spree::StockTransfer.model_name.human(count: :other) %>
 <% end %>
 
 <% content_for :page_actions do %>
@@ -41,7 +41,7 @@
 
       <div class="field-block alpha four columns">
         <div class="field">
-          <%= f.label nil, Spree.t(:transfer_number) %>
+          <%= f.label nil, Spree::StockTransfer.human_attribute_name(:number) %>
           <%= f.text_field :number_cont, value: params[:q][:number_cont] %>
         </div>
       </div>

--- a/backend/app/views/spree/admin/stock_transfers/new.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/new.html.erb
@@ -11,12 +11,12 @@
 <%= form_for [:admin, @stock_transfer] do |f| %>
   <fieldset class="no-border-top">
     <%= f.field_container :source_location do %>
-      <%= f.label nil, Spree.t(:source_location) %>
+      <%= f.label :source_location_id %>
       <%= f.select :source_location_id, options_from_collection_for_select(@source_stock_locations, :id, :name), {include_blank: true}, {class: 'select2 fullwidth', "data-placeholder" => Spree.t(:select_a_stock_location)} %>
       <%= f.error_message_on :source_location %>
     <% end %>
     <%= f.field_container :description do %>
-      <%= f.label nil, Spree.t(:description) %>
+      <%= f.label :description %>
       <%= f.text_field :description, maxlength: 255, size: 0, class: 'fullwidth' %>
       <%= f.error_message_on :description %>
     <% end %>

--- a/backend/app/views/spree/admin/stock_transfers/receive.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/receive.html.erb
@@ -17,7 +17,7 @@
     <span><%= Spree.t(:you_cannot_undo_action) %></span>
   </div>
   <div class='action-consequences'>
-    <span><%= Spree.t('close_stock_transfer.will_cause') %>:</span>
+    <span><%= Spree.t('close_stock_transfer.will_cause') %></span>
     <ul data-hook='close-stock-transfer-consequences'>
       <li><%= Spree.t('close_stock_transfer.no_longer_edit') %></li>
       <li><%= Spree.t('close_stock_transfer.stock_movements_created') %></li>
@@ -42,7 +42,7 @@
     <span id='total-received-quantity'><%= @stock_transfer.received_item_count %></span>
     /
     <span><%= @stock_transfer.expected_item_count %></span>
-    <span class='summary-field'>Received</span>
+    <span class='summary-field'><%= Spree.t(:received) %></span>
   </div>
 </div>
 

--- a/backend/app/views/spree/admin/stock_transfers/show.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree.t('stock_transfer') %> <%= @stock_transfer.number %>
+  <%= Spree::StockTransfer.model_name.human %> <%= @stock_transfer.number %>
 <% end %>
 
 <% content_for :page_actions do %>
@@ -18,37 +18,37 @@
   </div>
 
   <div>
-    <label><%= Spree.t(:description) %></label>
+    <label><%= Spree::StockTransfer.human_attribute_name(:description) %></label>
     <p><%= @stock_transfer.description %></p>
   </div>
 
   <div class='field-block alpha three columns'>
-    <label><%= Spree.t(:created_by) %></label>
+    <label><%= Spree::StockTransfer.human_attribute_name(:created_by_id) %></label>
     <p><%= @stock_transfer.created_by.email %></p>
   </div>
 
   <div class='field-block alpha three columns'>
-    <label><%= Spree.t(:created_at) %></label>
+    <label><%= Spree::StockTransfer.human_attribute_name(:created_at) %></label>
     <p><%= @stock_transfer.created_at.try(:to_date) %></p>
   </div>
 
   <div class='field-block alpha three columns'>
-    <label><%= Spree.t(:finalized_at) %></label>
+    <label><%= Spree::StockTransfer.human_attribute_name(:finalized_at) %></label>
     <p><%= @stock_transfer.finalized_at.try(:to_date) %></p>
   </div>
 
   <div class='field-block alpha three columns'>
-    <label><%= Spree.t(:finalized_by) %></label>
+    <label><%= Spree::StockTransfer.human_attribute_name(:finalized_by_id) %></label>
     <p><%= @stock_transfer.finalized_by.try(:email) %></p>
   </div>
 
   <div class='field-block alpha three columns'>
-    <label><%= Spree.t(:shipped_at) %></label>
+    <label><%= Spree::StockTransfer.human_attribute_name(:shipped_at) %></label>
     <p><%= @stock_transfer.shipped_at.try(:to_date) %></p>
   </div>
 </fieldset>
 
 <fieldset>
-  <legend><%= Spree.t(:transfer_items) %></legend>
+  <legend><%= Spree::TransferItem.model_name.human(count: :other) %></legend>
   <%= render partial: 'transfer_item_table', locals: { transfer_items: @stock_transfer.transfer_items, show_expected: true, show_received: true, show_actions: false } %>
 </fieldset>

--- a/backend/app/views/spree/admin/stock_transfers/tracking_info.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/tracking_info.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= "#{Spree.t(:ship)} #{Spree.t(:stock_transfer)} \##{@stock_transfer.number}" %>
+  <%= "#{Spree.t('actions.ship')} #{Spree::StockTransfer.model_name.human} \##{@stock_transfer.number}" %>
 <% end %>
 
 <% content_for :page_actions do %>
@@ -17,7 +17,7 @@
     <span><%= Spree.t(:you_cannot_undo_action) %></span>
   </div>
   <div class='action-consequences'>
-    <span><%= Spree.t('ship_stock_transfer.will_cause') %>:</span>
+    <span><%= Spree.t('ship_stock_transfer.will_cause') %></span>
     <ul data-hook='ship-stock-transfer-consequences'>
       <li><%= Spree.t('ship_stock_transfer.no_further_changes') %></li>
     </ul>
@@ -38,7 +38,7 @@
     </h5>
   </div>
   <div class='shipment-description'>
-    <div class='summary-field creator'><%= Spree.t(:created_by) %>: <%= @stock_transfer.created_by.email %></div>
+    <div class='summary-field creator'><%= Spree::StockTransfer.human_attribute_name(:created_by) %>: <%= @stock_transfer.created_by.email %></div>
     <div class='summary-field description'><%= @stock_transfer.description %></div>
   </div>
 </div>
@@ -48,7 +48,7 @@
     <%= form_for [:admin, @stock_transfer] do |f| %>
     <div class='field-block alpha'>
       <div class='field'>
-        <%= f.label "tracking_number", Spree.t(:tracking_number) %>
+        <%= f.label :tracking_number %>
         <%= f.text_field :tracking_number, value: @stock_transfer.tracking_number, maxlength: 255, size: 0, class: 'fullwidth' %>
       </div>
     </div>
@@ -62,6 +62,6 @@
 </fieldset>
 
 <fieldset id='stock-transfer-transfer-items'>
-  <legend align="center"><%= Spree.t(:transfer_items) %></legend>
+  <legend align="center"><%= Spree::TransferItem.model_name.human(count: :other) %></legend>
   <%= render partial: 'transfer_item_table', locals: { transfer_items: @stock_transfer.transfer_items, show_expected: true, show_received: false, show_actions: false } %>
 </fieldset>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -192,6 +192,8 @@ en:
         amount_used: Amount used
         category_id: Credit Type
         memo: Memo
+      spree/stock_item:
+        count_on_hand: Count On Hand
       spree/stock_location:
         admin_name: Internal Name
         active: Active
@@ -215,6 +217,17 @@ en:
         action: Action
         quantity: Quantity
         stock_item_id: Stock Item
+      spree/stock_transfer:
+        created_at: Created At
+        created_by_id: Created By
+        description: Description
+        destination_location_id: Destination Location
+        finalized_at: Finalized At
+        finalized_by_id: Finalized By
+        number: Transfer Number
+        shipped_at: Shipped At
+        source_location_id: Source Location
+        tracking_number: Tracking Number
       spree/tax_category:
         description: Description
         name: Name
@@ -520,6 +533,7 @@ en:
       receive: Receive
       remove: Remove
       save: Save
+      ship: ship
       update: Update
       split: Split
       ship: ship
@@ -755,7 +769,7 @@ en:
     clone: Clone
     close: Close
     close_stock_transfer:
-      will_cause: Closing a stock transfer will cause the following
+      will_cause: "Closing a stock transfer will cause the following:"
       no_longer_edit: You will no longer be able to edit the stock transfer in any way
       stock_movements_created: Stock movements will be created for the received items
     code: Code
@@ -948,16 +962,12 @@ en:
     finalize: Finalize
     finalize_all_adjustments: Finalize All Adjustments
     finalize_stock_transfer:
-      will_cause: Finalizing a stock transfer will cause the following
+      will_cause: "Finalizing a stock transfer will cause the following:"
       no_longer_change_items: You will no longer be able to add or edit any transfer items
     find_a_taxon: Find a Taxon
     finalized: Finalized
     finalized_at: Finalized at
     finalized_by: Finalized by
-    close_stock_transfer:
-      will_cause: Closing a stock transfer will cause the following
-      no_longer_edit: You will no longer be able to edit the stock transfer in any way
-      stock_movements_created: Stock movements will be created for the received items
     first_item: First Item
     first_name: First Name
     first_name_begins_with: First Name Begins With
@@ -1499,7 +1509,7 @@ en:
     ship_address: Ship Address
     ship_address_required: Valid shipping address required
     ship_stock_transfer:
-      will_cause: Shipping a stock transfer will cause the following
+      will_cause: "Shipping a stock transfer will cause the following:"
       no_further_changes: You will no longer be able to make changes to the stock transfer
     ship_total: Ship Total
     shipped_at: Shipped At


### PR DESCRIPTION
Use model name and model attribute translations where logical.

Brought `:` into some translations in case it doesn't translate well into other languages.

This is part of an ongoing effort to improve I18n usage as discussed in #735.