### PR TITLE
Improve I18n in tax category views

### DIFF
--- a/backend/app/views/spree/admin/tax_categories/_form.html.erb
+++ b/backend/app/views/spree/admin/tax_categories/_form.html.erb
@@ -1,30 +1,28 @@
 <div data-hook="admin_tax_category_form_fields" class="row">
   <div class="alpha four columns">
     <%= f.field_container :name do %>
-      <%= f.label :name, Spree.t(:name) %>
+      <%= f.label :name %>
       <%= f.text_field :name, :class => 'fullwidth' %>
     <% end %>
   </div>
 
   <div class="two columns">
     <%= f.field_container :tax_code do %>
-      <%= f.label :tax_code, Spree.t(:tax_code) %>
+      <%= f.label :tax_code %>
       <%= f.text_field :tax_code, :class => 'fullwidth' %>
     <% end %>
   </div>
 
   <div class="two columns omega">
     <%= f.field_container :is_default, :class => ['checkbox'] do %>
-      <label>
-        <%= f.check_box :is_default %>
-        <%= Spree.t(:default) %>
-      </label>
+      <%= f.check_box :is_default %>
+      <%= f.label :is_default %>
     <% end %>
   </div>
 
   <div class="alpha six columns">
     <%= f.field_container :description do %>
-      <%= f.label :description, Spree.t(:description) %><br>
+      <%= f.label :description %><br>
       <%= f.text_area :description, :class => 'fullwidth' %>
     <% end %>
   </div>

--- a/backend/app/views/spree/admin/tax_categories/index.html.erb
+++ b/backend/app/views/spree/admin/tax_categories/index.html.erb
@@ -25,10 +25,10 @@
   </colgroup>
   <thead>
     <tr data-hook="tax_header">
-      <th><%= Spree.t(:name) %></th>
-      <th><%= Spree.t(:tax_code) %></th>
-      <th><%= Spree.t(:description) %></th>
-      <th><%= Spree.t(:default) %></th>
+      <th><%= Spree::TaxCategory.human_attribute_name(:name) %></th>
+      <th><%= Spree::TaxCategory.human_attribute_name(:tax_code) %></th>
+      <th><%= Spree::TaxCategory.human_attribute_name(:description) %></th>
+      <th><%= Spree::TaxCategory.human_attribute_name(:is_default) %></th>
       <th class="actions"></th>
     </tr>
   </thead>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -195,6 +195,8 @@ en:
       spree/tax_category:
         description: Description
         name: Name
+        is_default: Default
+        tax_code: Tax Code
       spree/tax_rate:
         amount: Rate
         included_in_price: Included in Price


### PR DESCRIPTION
Use model attribute translation instead of generic translations.

This is part of an ongoing effort to improve I18n usage as discussed in #735.