### PR TITLE
Improve I18n in taxonomy views

### DIFF
--- a/backend/app/views/spree/admin/taxonomies/_form.html.erb
+++ b/backend/app/views/spree/admin/taxonomies/_form.html.erb
@@ -1,6 +1,6 @@
 <div data-hook="admin_inside_taxonomy_form" class="field align-center">
   <%= f.field_container :name do %>
-    <%= f.label :name, Spree.t(:name), class: 'required' %><br />
+    <%= f.label :name, class: 'required' %><br />
     <%= error_message_on :taxonomy, :name, :class => 'fullwidth title' %>
     <%= text_field :taxonomy, :name %>
   <% end %>

--- a/backend/app/views/spree/admin/taxonomies/_list.html.erb
+++ b/backend/app/views/spree/admin/taxonomies/_list.html.erb
@@ -7,7 +7,7 @@
   <thead>
     <tr data-hook="taxonomies_header">
       <th class="no-border"></th>
-      <th><%= Spree.t(:name) %></th>
+      <th><%= Spree::Taxonomy.human_attribute_name(:name) %></th>
       <th class="actions"></th>
     </tr>
   </thead>

--- a/backend/app/views/spree/admin/taxonomies/index.html.erb
+++ b/backend/app/views/spree/admin/taxonomies/index.html.erb
@@ -1,7 +1,7 @@
 <%= render 'spree/admin/shared/configuration_menu' %>
 
 <% content_for :page_title do %>
-  <%= Spree.t(:taxonomies) %>
+  <%= Spree::Taxonomy.model_name.human(count: :other) %>
 <% end %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/taxonomies/new.html.erb
+++ b/backend/app/views/spree/admin/taxonomies/new.html.erb
@@ -16,7 +16,7 @@
   <fieldset class="no-border-top">
     <br>
     <div class="filter-actions actions" data-hook="buttons">
-      <%= button Spree.t(:create), 'ok' %>
+      <%= button Spree.t('actions.create'), 'ok' %>
     </div>
   </fieldset>
 <% end %>


### PR DESCRIPTION
Use model attribute translations where logical.

This is part of an ongoing effort to improve I18n usage as discussed in #735.