### PR TITLE
Fix api checkouts spec

### DIFF
--- a/api/spec/controllers/spree/api/checkouts_controller_spec.rb
+++ b/api/spec/controllers/spree/api/checkouts_controller_spec.rb
@@ -379,14 +379,6 @@ module Spree
         end
       end
 
-      it "can transition from confirm to complete" do
-        order.update_columns(completed_at: Time.current, state: 'complete')
-        allow_any_instance_of(Spree::Order).to receive_messages(payment_required?: false)
-        api_put :update, id: order.to_param, order_token: order.guest_token
-        expect(json_response['state']).to eq('complete')
-        expect(response.status).to eq(200)
-      end
-
       it "returns the order if the order is already complete" do
         order.update_columns(completed_at: Time.current, state: 'complete')
         api_put :update, id: order.to_param, order_token: order.guest_token

--- a/api/spec/controllers/spree/api/checkouts_controller_spec.rb
+++ b/api/spec/controllers/spree/api/checkouts_controller_spec.rb
@@ -503,7 +503,7 @@ module Spree
     context "PUT 'advance'" do
       let!(:order) { create(:order_with_line_items) }
 
-      it 'continues to advance advances an order while it can move forward' do
+      it 'continues to advance an order while it can move forward' do
         expect_any_instance_of(Spree::Order).to receive(:next).exactly(3).times.and_return(true, true, false)
         api_put :advance, id: order.to_param, order_token: order.guest_token
       end


### PR DESCRIPTION
This spec had an initial order state (`complete`) that was the same as the outcome order state. The test passed, but for the wrong reason. After setting the initial state to `confirm`, the spec failed as the API no longer allows transitioning order state to complete using a `PUT` on the order. You must instead call the `complete` action, for which there is already a spec.

Thanks to @mhaylock who [fixed this issue in Spree](https://github.com/spree/spree/pull/7048).