### PR TITLE
Improve I18n in taxon views

### DIFF
--- a/backend/app/views/spree/admin/taxons/_form.html.erb
+++ b/backend/app/views/spree/admin/taxons/_form.html.erb
@@ -1,13 +1,13 @@
 <div data-hook="admin_inside_taxon_form" class="row">
   <div class="alpha five columns">
     <%= f.field_container :name do %>
-      <%= f.label :name, Spree.t(:name), class: 'required' %><br />
+      <%= f.label :name, class: 'required' %><br />
       <%= text_field :taxon, :name, :class => 'fullwidth' %>
       <%= error_message_on :taxon, :name, :class => 'fullwidth title' %>
     <% end %>
 
     <%= f.field_container :permalink_part do %>
-      <%= f.label :permalink_part, Spree.t(:permalink), class: 'required' %><br />
+      <%= label_tag :permalink_part, Spree::Taxon.human_attribute_name(:permalink), class: 'required' %><br />
       <%= text_field_tag :permalink_part, @permalink_part, :class => 'fullwidth' %><br />
       <span class="info" id="permalink_part_display">
         <%= @taxon.permalink.split('/')[0...-1].join('/') + '/' %>
@@ -15,31 +15,31 @@
     <% end %>
 
     <%= f.field_container :icon do %>
-      <%= f.label :icon, Spree.t(:icon) %><br />
+      <%= f.label :icon %><br />
       <%= f.file_field :icon %>
     <% end %>
   </div>
 
   <div class="omega seven columns">
     <%= f.field_container :description do %>
-      <%= f.label :description, Spree.t(:description) %><br />
+      <%= f.label :description %><br />
       <%= f.text_area :description, :class => 'fullwidth', :rows => 6 %>
     <% end %>
   </div>
 
   <div class="twelve columns alpha omega">
     <%= f.field_container :meta_title do %>
-      <%= f.label :meta_title, Spree.t(:meta_title) %><br />
+      <%= f.label :meta_title %><br />
       <%= f.text_field :meta_title, :class => 'fullwidth', :rows => 6 %>
     <% end %>
 
     <%= f.field_container :meta_description do %>
-      <%= f.label :meta_description, Spree.t(:meta_description) %><br />
+      <%= f.label :meta_description %><br />
       <%= f.text_field :meta_description, :class => 'fullwidth', :rows => 6 %>
     <% end %>
 
     <%= f.field_container :meta_keywords do %>
-      <%= f.label :meta_keywords, Spree.t(:meta_keywords) %><br />
+      <%= f.label :meta_keywords %><br />
       <%= f.text_field :meta_keywords, :class => 'fullwidth', :rows => 6 %>
     <% end %>
   </div>

--- a/backend/app/views/spree/admin/taxons/index.html.erb
+++ b/backend/app/views/spree/admin/taxons/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:taxons) %>
+  <%= Spree::Taxon.model_name.human(count: :other) %>
 <% end %>
 
 <% content_for :table_filter_title do %>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -200,6 +200,11 @@ en:
         included_in_price: Included in Price
         show_rate_in_label: Show rate in label
       spree/taxon:
+        description: Description
+        icon: Icon
+        meta_description: Meta Description
+        meta_keywords: Meta Keywords
+        meta_title: Meta Title
         name: Name
         permalink: Permalink
         position: Position


### PR DESCRIPTION
Use model attribute and model name translations where logical.

This is part of an ongoing effort to improve I18n usage as discussed in #735.