### PR TITLE
Improve I18n in tracker views

### DIFF
--- a/backend/app/views/spree/admin/trackers/_form.html.erb
+++ b/backend/app/views/spree/admin/trackers/_form.html.erb
@@ -1,13 +1,13 @@
 <div data-hook="admin_tracker_form_fields" class="row">
   <div class="alpha four columns">
     <div data-hook="analytics_id" class="field">
-      <%= label_tag :tracker_analytics_id, Spree.t(:google_analytics_id) %>
-      <%= text_field :tracker, :analytics_id, :class => 'fullwidth' %>
+      <%= f.label :analytics_id %>
+      <%= f.text_field :analytics_id, :class => 'fullwidth' %>
     </div>
   </div>
   <div class="omega four columns">
     <div data-hook="active" class="field">
-      <%= label_tag nil, Spree.t(:active) %>
+      <%= f.label :active %>
       <ul>
         <li>
           <%= radio_button(:tracker, :active, true) %>

--- a/backend/app/views/spree/admin/trackers/index.html.erb
+++ b/backend/app/views/spree/admin/trackers/index.html.erb
@@ -1,7 +1,7 @@
 <%= render 'spree/admin/shared/configuration_menu' %>
 
 <% content_for :page_title do %>
-  <%= Spree.t(:analytics_trackers) %>
+  <%= Spree::Tracker.model_name.human(count: :other) %>
 <% end %>
 
 <% content_for :page_actions do %>
@@ -22,8 +22,8 @@
     </colgroup>
     <thead>
       <tr data-hook="admin_trackers_index_headers">
-        <th><%= Spree.t(:google_analytics_id) %></th>
-        <th><%= Spree.t(:active) %></th>
+        <th><%= Spree::Tracker.human_attribute_name(:analytics_id) %></th>
+        <th><%= Spree::Tracker.human_attribute_name(:active) %></th>
         <th class="actions"></th>
       </tr>
     </thead>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -205,6 +205,9 @@ en:
         position: Position
       spree/taxonomy:
         name: Name
+      spree/tracker:
+        analytics_id: Analytics ID
+        active: Active
       spree/user:
         email: Email
         password: Password
@@ -332,8 +335,8 @@ en:
         one: Taxonomy
         other: Taxonomies
       spree/tracker:
-        one: Tracker
-        other: Trackers
+        one: Analytics Tracker
+        other: Analytics Trackers
       spree/transfer_item:
         one: Transfer Item
         other: Transfer Items


### PR DESCRIPTION
Use model name and model attribute translations.

This is part of an ongoing effort to improve I18n usage as discussed in #735.