### PR TITLE
Improve I18n in users views

### DIFF
--- a/backend/app/views/spree/admin/users/_form.html.erb
+++ b/backend/app/views/spree/admin/users/_form.html.erb
@@ -1,7 +1,7 @@
 <div data-hook="admin_user_form_fields" class="row">
   <div class="alpha six columns">
     <%= f.field_container :email do %>
-      <%= f.label :email, Spree.t(:email) %>
+      <%= f.label :email %>
       <% if can?(:update_email, @user) %>
         <%= f.email_field :email, :class => 'fullwidth' %>
       <% else %>
@@ -13,7 +13,7 @@
 
     <% if can? :display, Spree::Role %>
       <div data-hook="admin_user_form_roles" class="field">
-        <%= label_tag nil, Spree.t(:roles) %>
+        <%= label_tag nil, Spree::Role.model_name.human(count: :other) %>
         <ul>
           <% if can? :manage, Spree::Role %>
             <% @roles.each do |role| %>
@@ -33,7 +33,7 @@
 
     <% if Spree::Config[:can_restrict_stock_management] && can?(:display, Spree::StockLocation) %>
       <div data-hook="admin_user_form_stock_locations" class="field">
-        <%= label_tag nil, Spree.t(:stock_locations) %>
+        <%= label_tag nil, Spree::StockLocation.model_name.human(count: :other) %>
         <ul>
           <% if can?(:manage, Spree::UserStockLocation) %>
             <% @stock_locations.each do |stock_location| %>
@@ -55,13 +55,13 @@
 
   <div data-hook="admin_user_form_password_fields" class="omega six columns">
     <%= f.field_container :password do %>
-      <%= f.label :password, Spree.t(:password) %>
+      <%= f.label :password %>
       <%= f.password_field :password, :class => 'fullwidth' %>
       <%= f.error_message_on :password %>
     <% end %>
 
     <%= f.field_container :password do %>
-      <%= f.label :password_confirmation, Spree.t(:confirm_password) %>
+      <%= f.label :password_confirmation %>
       <%= f.password_field :password_confirmation, :class => 'fullwidth' %>
       <%= f.error_message_on :password_confirmation %>
     <% end %>

--- a/backend/app/views/spree/admin/users/addresses.html.erb
+++ b/backend/app/views/spree/admin/users/addresses.html.erb
@@ -6,7 +6,7 @@
 <%= render :partial => 'spree/admin/users/user_page_actions' %>
 
 <fieldset data-hook="admin_user_addresses" id="admin_user_edit_addresses" class="alpha twelve columns">
-  <legend><%= Spree.t('addresses', :scope => 'admin.user') %></legend>
+  <legend><%= Spree::Address.model_name.human(count: :other) %></legend>
 
   <div data-hook="admin_user_edit_form_header">
     <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @user } %>

--- a/backend/app/views/spree/admin/users/index.html.erb
+++ b/backend/app/views/spree/admin/users/index.html.erb
@@ -17,7 +17,7 @@
   </colgroup>
   <thead>
     <tr data-hook="admin_users_index_headers">
-      <th><%= sort_link @search,:email, Spree.t(:user), {}, {:title => 'users_email_title'} %></th>
+      <th><%= sort_link @search,:email, Spree::LegacyUser.model_name.human, {}, {:title => 'users_email_title'} %></th>
       <th data-hook="admin_users_index_header_actions" class="actions"></th>
     </tr>
   </thead>

--- a/backend/app/views/spree/admin/users/items.html.erb
+++ b/backend/app/views/spree/admin/users/items.html.erb
@@ -24,12 +24,12 @@
       </colgroup>
 
       <thead>
-        <th><%= sort_link @search, :completed_at, I18n.t(:completed_at, :scope => 'activerecord.attributes.spree/order'), {}, {:title => 'orders_completed_at_title'} %></th>
-        <th colspan=2><%= Spree.t(:description) %></th>
-        <th><%= I18n.t(:price, :scope => 'activerecord.attributes.spree/line_item') %></th>
-        <th><%= I18n.t(:quantity, :scope => 'activerecord.attributes.spree/line_item') %></th>
-        <th><%= Spree.t(:total) %></th>
-        <th><%= sort_link @search, :state, I18n.t(:state, :scope => 'activerecord.attributes.spree/order'), {}, {:title => 'orders_state_title'} %></th>
+        <th><%= sort_link @search, :completed_at, Spree::Order.human_attribute_name(:completed_at), {}, {:title => 'orders_completed_at_title'} %></th>
+        <th colspan=2><%= Spree::LineItem.human_attribute_name(:description) %></th>
+        <th><%= Spree::LineItem.human_attribute_name(:price) %></th>
+        <th><%= Spree::LineItem.human_attribute_name(:quantity) %></th>
+        <th><%= Spree::Order.human_attribute_name(:total) %></th>
+        <th><%= sort_link @search, :state, Spree::Order.human_attribute_name(:state), {}, {:title => 'orders_state_title'} %></th>
         <th><%= sort_link @search, :number, Spree.t(:order_num, :scope => 'admin.user'), {}, {:title => 'orders_number_title'} %></th>
       </thead>
 

--- a/backend/app/views/spree/admin/users/orders.html.erb
+++ b/backend/app/views/spree/admin/users/orders.html.erb
@@ -21,10 +21,10 @@
       </colgroup>
       <thead>
         <tr data-hook="admin_orders_index_headers">
-          <th><%= sort_link @search, :completed_at,   I18n.t(:completed_at, :scope => 'activerecord.attributes.spree/order'), {}, {:title => 'orders_completed_at_title'} %></th>
-          <th><%= sort_link @search, :number,         I18n.t(:number, :scope => 'activerecord.attributes.spree/order'), {}, {:title => 'orders_number_title'} %></th>
-          <th><%= sort_link @search, :state,          I18n.t(:state, :scope => 'activerecord.attributes.spree/order'), {}, {:title => 'orders_state_title'} %></th>
-          <th><%= sort_link @search, :total,          I18n.t(:total, :scope => 'activerecord.attributes.spree/order'), {}, {:title => 'orders_total_title'} %></th>
+          <th><%= sort_link @search, :completed_at,   Spree::Order.human_attribute_name(:completed_at), {}, {:title => 'orders_completed_at_title'} %></th>
+          <th><%= sort_link @search, :number,         Spree::Order.human_attribute_name(:number), {}, {:title => 'orders_number_title'} %></th>
+          <th><%= sort_link @search, :state,          Spree::Order.human_attribute_name(:state), {}, {:title => 'orders_state_title'} %></th>
+          <th><%= sort_link @search, :total,          Spree::Order.human_attribute_name(:total), {}, {:title => 'orders_total_title'} %></th>
         </tr>
       </thead>
       <tbody>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -66,6 +66,10 @@ en:
         attachment: Filename
       spree/inventory_unit:
         state: State
+      spree/legacy_user:
+        email: Email
+        password: Password
+        password_confirmation: Password Confirmation
       spree/line_item:
         description: Item Description
         name: Name
@@ -341,6 +345,9 @@ en:
       spree/inventory_unit:
         one: Inventory Unit
         other: Inventory Units
+      spree/legacy_user:
+        one: User
+        other: Users
       spree/line_item:
         one: Line Item
         other: Line Items


### PR DESCRIPTION
Use model attribute and model name translations.

This is part of an ongoing effort to improve I18n usage as discussed in #735.