### PR TITLE
build-ci.rb Save junit XML separately

### DIFF
--- a/build-ci.rb
+++ b/build-ci.rb
@@ -90,7 +90,7 @@ class Project
     args = []
     args += %w[--format documentation --profile 10]
     if report_dir = ENV['CIRCLE_TEST_REPORTS']
-      args += %W[-r rspec_junit_formatter --format RspecJunitFormatter -o #{report_dir}/rspec/junit.xml]
+      args += %W[-r rspec_junit_formatter --format RspecJunitFormatter -o #{report_dir}/rspec/#{name}.xml]
     end
     args
   end


### PR DESCRIPTION
Previously we were only reporting the failures to CircleCI from the last test suite run per-container, as the last run would overwrite the previous junit.xml file.

This keeps them separate and correctly reports the number of tests we've run.

![](http://i.hawth.ca/s/RbxTJYm3.png)