### PR TITLE
Improve I18n in variant views

### DIFF
--- a/backend/app/views/spree/admin/variants/_form.html.erb
+++ b/backend/app/views/spree/admin/variants/_form.html.erb
@@ -9,22 +9,22 @@
     <% end %>
 
     <div class="field" data-hook="sku">
-      <%= f.label :sku, Spree.t(:sku) %>
+      <%= f.label :sku %>
       <%= f.text_field :sku, :class => 'fullwidth' %>
     </div>
 
     <div class="field" data-hook="price">
-      <%= f.label :price, Spree.t(:price) %>
+      <%= f.label :price %>
       <%= f.text_field :price, :value => number_to_currency(@variant.price, :unit => ''), :class => 'fullwidth' %>
     </div>
 
     <div class="field" data-hook="cost_price">
-      <%= f.label :cost_price, Spree.t(:cost_price) %>
+      <%= f.label :cost_price %>
       <%= f.text_field :cost_price, :value => number_to_currency(@variant.cost_price, :unit => ''), :class => 'fullwidth' %>
     </div>
 
     <div class="field" data-hook="tax_category">
-      <%= f.label :tax_category_id, Spree.t(:tax_category) %>
+      <%= f.label :tax_category_id, Spree::TaxCategory.model_name.human %>
       <%= f.collection_select(:tax_category_id, @tax_categories, :id, :name, { :include_blank => Spree.t('match_choices.none') }, { :class => 'select2 fullwidth' }) %>
     </div>
 

--- a/backend/app/views/spree/admin/variants/index.html.erb
+++ b/backend/app/views/spree/admin/variants/index.html.erb
@@ -58,8 +58,8 @@
     <thead data-hook="variants_header">
       <tr>
         <th colspan="2"><%= Spree.t(:options) %></th>
-        <th><%= Spree.t(:price) %></th>
-        <th><%= Spree.t(:sku) %></th>
+        <th><%= Spree::Variant.human_attribute_name(:price) %></th>
+        <th><%= Spree::Variant.human_attribute_name(:sku) %></th>
         <th class="actions"></th>
       </tr>
     </thead>
@@ -104,9 +104,9 @@
   <p class='first_add_option_types no-objects-found' data-hook="first_add_option_types">
     <%= Spree.t(:to_add_variants_you_must_first_define) %>
     <% if can?(:display, Spree::OptionType) %>
-      <%= link_to Spree.t(:option_types), admin_option_types_path%>
+      <%= link_to Spree::OptionType.model_name.human(count: :other), admin_option_types_path%>
     <% else %>
-      <%= Spree.t(:option_types) %>
+      <%= Spree::OptionType.model_name.human(count: :other) %>
     <% end %>
   </p>
 <% else %>


### PR DESCRIPTION
Use model name and model attribute translation.

I had considered changing the form to not use the `label-block` class so that then I could use model attribute translation on the `track_inventory` checkbox but decided against it as it changed the spacing of all the labels too much.

This is part of an ongoing effort to improve I18n usage as discussed in #735.
