### PR TITLE
Improve I18n in zone views

### DIFF
--- a/backend/app/views/spree/admin/zones/_country_members.html.erb
+++ b/backend/app/views/spree/admin/zones/_country_members.html.erb
@@ -1,9 +1,9 @@
 <div id="country_members" data-hook="member" class="omega six columns">
   <fieldset class="no-border-bottom">
-    <legend align="center"><%= Spree.t(:countries) %></legend>
+    <legend align="center"><%= Spree::Country.model_name.human(count: :other) %></legend>
 
     <%= zone_form.field_container :country_ids do %>
-      <%= zone_form.label :country_ids, Spree.t(:countries) %><br>
+      <%= zone_form.label :country_ids, Spree::Country.model_name.human(count: :other) %><br>
       <%= zone_form.collection_select :country_ids, @countries, :id, :name, {}, { :multiple => true, :class => "select2 fullwidth" } %>
     <% end %>
   </fieldset>

--- a/backend/app/views/spree/admin/zones/_form.html.erb
+++ b/backend/app/views/spree/admin/zones/_form.html.erb
@@ -3,18 +3,18 @@
     <legend align="center"><%= Spree.t(:general_settings)%></legend>
 
     <%= zone_form.field_container :name do %>
-      <%= zone_form.label :name, Spree.t(:name) %><br />
+      <%= zone_form.label :name %><br />
       <%= zone_form.text_field :name, :class => 'fullwidth' %>
     <% end %>
 
     <%= zone_form.field_container :description do %>
-      <%= zone_form.label :description, Spree.t(:description) %><br />
+      <%= zone_form.label :description %><br />
       <%= zone_form.text_field :description, :class => 'fullwidth' %>
     <% end %>
 
     <div data-hook="default" class="field">
       <%= zone_form.check_box :default_tax %>
-      <%= label_tag :zone_default_tax, Spree.t(:default_tax_zone) %>
+      <%= zone_form.label :default_tax %>
     </div>
 
     <div data-hook="type" class="field">

--- a/backend/app/views/spree/admin/zones/_state_members.html.erb
+++ b/backend/app/views/spree/admin/zones/_state_members.html.erb
@@ -1,9 +1,9 @@
 <div id="state_members" data-hook="member" class="omega six columns">
   <fieldset class="no-border-bottom">
-    <legend align="center"><%= Spree.t(:states) %></legend>
+    <legend align="center"><%= Spree::State.model_name.human(count: :other) %></legend>
 
     <%= zone_form.field_container :state_ids do %>
-      <%= zone_form.label :state_ids, Spree.t(:states) %><br>
+      <%= zone_form.label :state_ids, Spree::State.model_name.human(count: :other) %><br>
       <%= zone_form.collection_select :state_ids, @states, :id, :name, {}, { :multiple => true, :class => "select2 fullwidth" } %>
     <% end %>
   </fieldset>

--- a/backend/app/views/spree/admin/zones/index.html.erb
+++ b/backend/app/views/spree/admin/zones/index.html.erb
@@ -1,7 +1,7 @@
 <%= render 'spree/admin/shared/configuration_menu' %>
 
 <% content_for :page_title do %>
-  <%= Spree.t(:zones) %>
+  <%= Spree::Zone.model_name.human(count: :other) %>
 <% end %>
 
 <% content_for :page_actions do %>
@@ -24,9 +24,9 @@
     </colgroup>
     <thead>
       <tr data-hook="zones_header">
-        <th><%= sort_link @search,:name, Spree.t(:name), :title => 'zones_order_by_name_title' %></th>
+        <th><%= sort_link @search,:name, Spree::Zone.human_attribute_name(:name), :title => 'zones_order_by_name_title' %></th>
         <th>
-          <%= sort_link @search,:description, Spree.t(:description), {}, {:title => 'zones_order_by_description_title'} %>
+          <%= sort_link @search,:description, Spree::Zone.human_attribute_name(:description), {}, {:title => 'zones_order_by_description_title'} %>
         </th>
         <th><%= Spree.t(:default_tax) %></th>
         <th class="actions"></th>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -249,6 +249,7 @@ en:
       spree/zone:
         description: Description
         name: Name
+        default_tax: Default Tax Zone
     models:
       spree/address:
         one: Address


### PR DESCRIPTION
Use model attribute and model name translation.

This is part of an ongoing effort to improve I18n usage as discussed in #735.