### PR TITLE
Only show select2 search when there are at least 8 results

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/spree-select2.js.erb
+++ b/backend/app/assets/javascripts/spree/backend/spree-select2.js.erb
@@ -3,7 +3,8 @@ jQuery(function($) {
   // Make select beautiful
   $('select.select2').select2({
     allowClear: true,
-    dropdownAutoWidth: true
+    dropdownAutoWidth: true,
+    minimumResultsForSearch: 8
   });
 
   function format_taxons(taxon) {


### PR DESCRIPTION
This removes the distracting and unnecessary search box form select2 when there are only a few options to select from.