### PR TITLE
Fix Rake task email:test example usage

### DIFF
--- a/core/lib/tasks/email.rake
+++ b/core/lib/tasks/email.rake
@@ -1,7 +1,7 @@
 namespace :email do
-  desc 'Sends test email to specified address - Example: EMAIL=spree@example.com bundle exec rake test:email'
+  desc 'Sends test email to specified address - Example: EMAIL=spree@example.com bundle exec rake email:test'
   task test: :environment do
-    raise ArgumentError, "Must pass EMAIL environment variable. Example: EMAIL=spree@example.com bundle exec rake test:email" unless ENV['EMAIL'].present?
+    raise ArgumentError, "Must pass EMAIL environment variable. Example: EMAIL=spree@example.com bundle exec rake email:test" unless ENV['EMAIL'].present?
     Spree::TestMailer.test_email(ENV['EMAIL']).deliver!
   end
 end


### PR DESCRIPTION
The example usage for `rake email:test` shows an incorrect example. This fixes the example usage to show a correct example.