### PR TITLE
Add ActiveModel::Naming to Exchange class

### DIFF
--- a/backend/app/views/spree/admin/orders/_carton.html.erb
+++ b/backend/app/views/spree/admin/orders/_carton.html.erb
@@ -4,7 +4,7 @@
       <span class="carton-number"><%= carton.number %></span>
       -
       <span class="carton-state"><%= Spree.t("shipment_states.shipped") %></span>
-      <span class="carton-exchange"><%= Spree.t(:exchange) if carton.any_exchanges? %></span>
+      <span class="carton-exchange"><%= Spree::Exchange.model_name.human if carton.any_exchanges? %></span>
       <%= Spree.t(:package_from) %>
       <strong class="stock-location-name" data-hook="stock-location-name">'<%= carton.stock_location.name %>'</strong>
     </legend>

--- a/core/app/models/spree/exchange.rb
+++ b/core/app/models/spree/exchange.rb
@@ -1,6 +1,7 @@
 module Spree
   class Exchange
     class UnableToCreateShipments < StandardError; end
+    extend ActiveModel::Naming
 
     def initialize(order, reimbursement_objects)
       @order = order
@@ -37,14 +38,6 @@ module Spree
 
     def self.param_key
       "spree_exchange"
-    end
-
-    def self.model_name
-      Spree::Exchange
-    end
-
-    def model_name
-      self.class.model_name
     end
   end
 end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -293,6 +293,9 @@ en:
       spree/customer_return:
         one: Customer Return
         other: Customer Returns
+      spree/exchange:
+        one: Exchange
+        other: Exchanges
       spree/inventory_unit:
         one: Inventory Unit
         other: Inventory Units

--- a/core/spec/models/spree/exchange_spec.rb
+++ b/core/spec/models/spree/exchange_spec.rb
@@ -70,9 +70,5 @@ module Spree
     describe ".param_key" do # for dom_id
       it { expect(Exchange.param_key).to eq "spree_exchange" }
     end
-
-    describe ".model_name" do # for dom_id
-      it { expect(Exchange.model_name).to eq Spree::Exchange }
-    end
   end
 end


### PR DESCRIPTION
Replace the instance of `Spree.t(:exchange)` with `Spree::Exchange.model_name.human` as discussed in #864.  Remove method on the class that is replaced by extending the Exchange class with ActiveModel::Naming.