### PR TITLE
Upgrade to versioncake 3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@
 
     This version changes the namespace from Faker:: to FFaker::
 
+*   versioncake has been updated to version 3.x
+
+    This version uses a rack middleware to determine the version, uses a
+    different header name, and has some configuration changes.
+
+    More information is available in the [VersionCake README](https://github.com/bwillis/versioncake)
+
 ## Solidus 1.2.0 (2016-01-26)
 
 *   Admin menu has been moved from top of the page to the left side.

--- a/api/app/controllers/spree/api/config_controller.rb
+++ b/api/app/controllers/spree/api/config_controller.rb
@@ -1,6 +1,11 @@
 module Spree
   module Api
     class ConfigController < Spree::Api::BaseController
+      def show
+      end
+
+      def money
+      end
     end
   end
 end

--- a/api/app/controllers/spree/api/line_items_controller.rb
+++ b/api/app/controllers/spree/api/line_items_controller.rb
@@ -8,6 +8,9 @@ module Spree
       before_filter :load_order, only: [:create, :update, :destroy]
       around_filter :lock_order, only: [:create, :update, :destroy]
 
+      def new
+      end
+
       def create
         variant = Spree::Variant.find(params[:line_item][:variant_id])
         @line_item = @order.contents.add(

--- a/api/app/controllers/spree/api/products_controller.rb
+++ b/api/app/controllers/spree/api/products_controller.rb
@@ -15,6 +15,9 @@ module Spree
         respond_with(@products)
       end
 
+      def new
+      end
+
       def show
         @product = find_product(params[:id])
         expires_in 15.minutes, public: true

--- a/api/app/controllers/spree/api/taxonomies_controller.rb
+++ b/api/app/controllers/spree/api/taxonomies_controller.rb
@@ -5,6 +5,9 @@ module Spree
         respond_with(taxonomies)
       end
 
+      def new
+      end
+
       def show
         respond_with(taxonomy)
       end

--- a/api/app/controllers/spree/api/taxons_controller.rb
+++ b/api/app/controllers/spree/api/taxons_controller.rb
@@ -14,6 +14,9 @@ module Spree
         respond_with(@taxons)
       end
 
+      def new
+      end
+
       def show
         @taxon = taxon
         respond_with(@taxon)

--- a/api/lib/spree/api/engine.rb
+++ b/api/lib/spree/api/engine.rb
@@ -16,11 +16,18 @@ module Spree
         config.json_engine = ActiveSupport::JSON
       end
 
-      config.view_versions = [1]
-      config.view_version_extraction_strategy = :http_header
-
       initializer "spree.api.environment", before: :load_config_initializers do |_app|
         Spree::Api::Config = Spree::ApiConfiguration.new
+      end
+
+      initializer "spree.api.versioncake" do |_app|
+        VersionCake.setup do |config|
+          config.resources do |r|
+            r.resource %r{.*}, [], [], [1]
+          end
+          config.missing_version = 1
+          config.extraction_strategy = :http_header
+        end
       end
 
       def self.activate

--- a/api/solidus_api.gemspec
+++ b/api/solidus_api.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'solidus_core', gem.version
   gem.add_dependency 'rabl', ['>= 0.9.4.pre1', '< 0.12.0']
-  gem.add_dependency 'versioncake', '~> 2.3.1'
+  gem.add_dependency 'versioncake', '~> 2.5'
 end

--- a/api/solidus_api.gemspec
+++ b/api/solidus_api.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'solidus_core', gem.version
   gem.add_dependency 'rabl', ['>= 0.9.4.pre1', '< 0.12.0']
-  gem.add_dependency 'versioncake', '~> 2.5'
+  gem.add_dependency 'versioncake', '~> 3.0'
 end

--- a/api/spec/spec_helper.rb
+++ b/api/spec/spec_helper.rb
@@ -61,6 +61,11 @@ RSpec.configure do |config|
     Spree::Api::Config[:requires_authentication] = true
   end
 
+  config.include VersionCake::TestHelpers, type: :controller
+  config.before(:each, type: :controller) do
+    set_request_version('', 1)
+  end
+
   config.use_transactional_fixtures = true
 
   config.example_status_persistence_file_path = "./spec/examples.txt"


### PR DESCRIPTION
This will be required in the future to support rails 5.

There are some breaking changes in versioncake 3.0 so we should be sure to note them in the changelog. Changes can be seen in the [versioncake README](https://github.com/bwillis/versioncake#upgrade-v20---v30)

A notable change is that version detection is now done via middleware, so setting the desired version is now required in controller specs.