### PR TITLE
Moving selected_shipping_rate method to has_one association

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -10,6 +10,7 @@ module Spree
     has_many :shipping_methods, through: :shipping_rates
     has_many :state_changes, as: :stateful
     has_many :cartons, -> { uniq }, through: :inventory_units
+    has_one :selected_shipping_rate, -> { where(selected: true).order(:cost) }, class_name: "Spree::ShippingRate"
 
     after_save :update_adjustments
 
@@ -188,10 +189,6 @@ module Spree
       save!
 
       shipping_rates
-    end
-
-    def selected_shipping_rate
-      shipping_rates.detect(&:selected?)
     end
 
     def manifest


### PR DESCRIPTION
Moving this method to a has_one association will help us to preload the association fixing a lot of N + 1 queries when dealing with shipments across the application.