### PR TITLE
Update Region Seed Datat for Idempotence

### DIFF
--- a/core/db/default/spree/countries.rb
+++ b/core/db/default/spree/countries.rb
@@ -1,17 +1,11 @@
 require 'carmen'
 
-countries = []
 Carmen::Country.all.each do |country|
-  countries << {
+  Spree::Country.where(iso: country.alpha_2_code).first_or_create(
     name: country.name,
     iso3: country.alpha_3_code,
-    iso: country.alpha_2_code,
     iso_name: country.name.upcase,
     numcode: country.numeric_code,
     states_required: country.subregions?
-  }
-end
-
-ActiveRecord::Base.transaction do
-  Spree::Country.create!(countries)
+  )
 end

--- a/core/db/default/spree/states.rb
+++ b/core/db/default/spree/states.rb
@@ -1,15 +1,10 @@
-ActiveRecord::Base.transaction do
-  Spree::Country.all.each do |country|
-    carmen_country = Carmen::Country.named(country.name)
-    @states ||= []
-    next unless carmen_country.subregions?
-    carmen_country.subregions.each do |subregion|
-      @states << {
-        name: subregion.name,
-        abbr: subregion.code,
-        country: country
-      }
-    end
+Spree::Country.all.each do |country|
+  carmen_country = Carmen::Country.coded(country.iso)
+  next unless carmen_country.subregions?
+
+  carmen_country.subregions.each do |subregion|
+    Spree::State.where(abbr: subregion.code, country: country).first_or_create(
+      name: subregion.name
+    )
   end
-  Spree::State.create!(@states)
 end


### PR DESCRIPTION
Ensure that region seed data will not create duplicate entries if it is run more than once.

This won't update countries [when their names change](http://www.iso.org/iso/home/standards/country_codes/updates_on_iso_3166.htm), but it will at least ensure that we don't create them again. 

For states, this additionally switches to finding the country by its ISO code rather than the name, as a name can change.