### PR TITLE
Remove translation from Spree::LineItem

### DIFF
--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -18,8 +18,7 @@ module Spree
     validates :variant, presence: true
     validates :quantity, numericality: {
       only_integer: true,
-      greater_than: -1,
-      message: Spree.t('validation.must_be_int')
+      greater_than: -1
     }
     validates :price, numericality: true
     validate :ensure_proper_currency


### PR DESCRIPTION
Due to [what I assume is] the Rails load order, this hard code translation prohibits include/prepend/extend decoration of Spree::LineItem as the locales aren’t loaded yet.

I also believe this to be redundant, as there is a before_validation method to ensure the quantity is never less than 0 on [Line 15](
https://github.com/solidusio/solidus/blob/master/core/app/models/spree/line_item.rb#L15)