### PR TITLE
Remove attribute translations for associations

### DIFF
--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -119,7 +119,7 @@
 
     <div data-hook="admin_product_form_shipping_categories">
       <%= f.field_container :shipping_categories do %>
-        <%= f.label :shipping_category_id %>
+        <%= f.label :shipping_category_id, Spree::ShippingCategory.model_name.human %>
         <%= f.collection_select(:shipping_category_id, @shipping_categories, :id, :name, { :include_blank => Spree.t('match_choices.none') }, { :class => 'select2' }) %>
         <%= f.error_message_on :shipping_category %>
       <% end %>
@@ -127,7 +127,7 @@
 
     <div data-hook="admin_product_form_tax_category">
       <%= f.field_container :tax_category do %>
-        <%= f.label :tax_category_id %>
+        <%= f.label :tax_category_id, Spree::TaxCategory.model_name.human %>
         <%= f.collection_select(:tax_category_id, @tax_categories, :id, :name, { :include_blank => Spree.t('match_choices.none') }, { :class => 'select2' }) %>
         <%= f.error_message_on :tax_category %>
       <% end %>

--- a/backend/app/views/spree/admin/products/new.html.erb
+++ b/backend/app/views/spree/admin/products/new.html.erb
@@ -51,7 +51,8 @@
     <div class='row'>
       <div data-hook="new_product_shipping_category" class="alpha four columns">
         <%= f.field_container :shipping_category do %>
-          <%= f.label :shipping_category_id, class: 'required' %><br />
+          <%= f.label :shipping_category_id, Spree::ShippingCategory.
+                model_name.human, class: 'required' %><br />
           <%= f.collection_select(:shipping_category_id, @shipping_categories, :id, :name, { :include_blank => Spree.t('match_choices.none') }, { :class => 'select2 fullwidth', :required => true }) %>
           <%= f.error_message_on :shipping_category_id %>
         <% end %>

--- a/backend/app/views/spree/admin/promotions/_form.html.erb
+++ b/backend/app/views/spree/admin/promotions/_form.html.erb
@@ -47,7 +47,7 @@
       <% end %>
 
       <%= f.field_container :category do %>
-        <%= f.label :promotion_category_id %><br />
+        <%= f.label :promotion_category_id, Spree::PromotionCategory.model_name.human %><br />
         <%= f.collection_select(:promotion_category_id, @promotion_categories, :id, :name, { :include_blank => Spree.t('match_choices.none') }, { :class => 'select2 fullwidth' }) %>
       <% end %>
     </div>

--- a/backend/app/views/spree/admin/return_authorizations/_form.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/_form.html.erb
@@ -76,7 +76,7 @@
   <% end %>
 
   <%= f.field_container :stock_location do %>
-    <%= f.label :stock_location, Spree.t(:stock_location) %>
+    <%= f.label :stock_location_id, Spree::StockLocation.model_name.human %>
     <%= f.select :stock_location_id, @stock_locations.to_a.collect{|l|[l.name, l.id]}, {include_blank: true}, {class: 'select2 fullwidth', "data-placeholder" => Spree.t(:select_a_stock_location)} %>
     <%= f.error_message_on :stock_location_id %>
   <% end %>

--- a/backend/app/views/spree/admin/shared/_address_form.html.erb
+++ b/backend/app/views/spree/admin/shared/_address_form.html.erb
@@ -39,14 +39,14 @@
   </div>
 
   <div class="field <%= "#{type}-row" %>">
-    <%= f.label :country_id %>
+    <%= f.label :country_id, Spree::Country.model_name.human %>
     <span id="<%= s_or_b %>country">
       <%= f.collection_select :country_id, available_countries, :id, :name, {}, {:class => 'select2 fullwidth'} %>
     </span>
   </div>
 
   <div class="field <%= "#{type}-row" %>">
-    <%= f.label :state_id %>
+    <%= f.label :state_id, Spree::State.model_name.human %>
     <span id="<%= s_or_b %>state">
       <%= f.text_field :state_name,
             :style => "display: #{f.object.country.states.empty? ? 'block' : 'none' };",

--- a/backend/app/views/spree/admin/stock_movements/_form.html.erb
+++ b/backend/app/views/spree/admin/stock_movements/_form.html.erb
@@ -5,7 +5,7 @@
       <%= f.text_field :quantity %>
     <% end %>
     <%= f.field_container :stock_item_id do %>
-      <%= f.label :stock_item_id %>
+      <%= f.label :stock_item_id, Spree::StockItem.model_name.human %>
       <%= f.text_field 'stock_item_id', :class => 'fullwidth', :'data-stock-location-id' => params[:stock_location_id] %>
     <% end %>
   </div>

--- a/backend/spec/features/admin/products/products_spec.rb
+++ b/backend/spec/features/admin/products/products_spec.rb
@@ -176,7 +176,7 @@ describe "Products", type: :feature do
         select "Size", from: "Prototype"
         check "Large"
         click_button "Create"
-        expect(page).to have_content("Shipping Category can't be blank")
+        expect(page).to have_content("Shipping category can't be blank")
         expect(field_labeled("Size")).to be_checked
         expect(field_labeled("Large")).to be_checked
         expect(field_labeled("Small")).not_to be_checked
@@ -210,7 +210,7 @@ describe "Products", type: :feature do
         fill_in "product_sku", with: "B100"
         fill_in "product_price", with: "100"
         click_button "Create"
-        expect(page).to have_content("Shipping Category can't be blank")
+        expect(page).to have_content("Shipping category can't be blank")
       end
 
       context "using a locale with a different decimal format " do

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -13,11 +13,9 @@ en:
         address2: Street Address (cont'd)
         city: City
         company: Company
-        country_id: Country
         firstname: First Name
         lastname: Last Name
         phone: Phone
-        state_id: State
         zipcode: Zip Code
       spree/adjustment:
         adjustable: Adjustable
@@ -133,7 +131,6 @@ en:
         price: Master Price
         promotionable: Promotable
         shipping_category: Shipping Category
-        shipping_category_id: Shipping Category
         slug: Slug
         tax_category: Tax Category
         weight: Weight
@@ -150,7 +147,6 @@ en:
         name: Name
         path: Path
         per_code_usage_limit: Per Code Usage Limit
-        promotion_category_id: Promotion Category
         starts_at: Starts
         usage_limit: Overall Usage Limit
       spree/promotion_category:
@@ -242,8 +238,6 @@ en:
         zipcode: Zip
       spree/stock_movement:
         action: Action
-        quantity: Quantity
-        stock_item_id: Stock Item
         quantity: Quantity
       spree/stock_transfer:
         created_at: Created At
@@ -394,6 +388,9 @@ en:
         one: State
         other: States
       spree/stock: stock
+      spree/stock_item:
+        one: Stock Item
+        other: Stock Items
       spree/stock_movement:
         one: Stock Movement
         other: Stock Movements


### PR DESCRIPTION
As an example instead of having
```
activerecord:
  attributes:
    spree/address:
      country_id: Country
```
just explicitly use `Spree::Country.model_name.human` on the form label.

This PR will correct previous changes made to this preferred method as discussed in #735 and pointed out by https://github.com/solidusio/solidus/pull/856#discussion_r52799804