### PR TITLE
Fix taxon edit icon

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/templates/taxons/_tree.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/taxons/_tree.hbs
@@ -5,7 +5,7 @@
       {{name}}
       <div class="actions right">
         <a href="#" class="js-taxon-add-child fa fa-plus icon_link no-text"></a>
-        <a href="<%= spree.admin_path %>/taxonomies/{{taxonomy_id}}/taxons/{{id}}/edit" class="fa fa-edit icon_link no-text"></a>
+        <a href="/admin/taxonomies/{{taxonomy_id}}/taxons/{{id}}/edit" class="fa fa-edit icon_link no-text"></a>
         <a href="#" class="js-taxon-delete fa fa-trash icon_link no-text"></a>
       </div>
     </div>

--- a/backend/spec/features/admin/taxons_spec.rb
+++ b/backend/spec/features/admin/taxons_spec.rb
@@ -29,5 +29,13 @@ describe "Taxonomies and taxons", type: :feature do
 
     click_on('Add taxon')
     expect(page).to have_content('New node')
+
+    # Little tricky to select the right taxon. Since the text is technically
+    # inside the top-level li.
+    within '#taxonomy_tree li li', text: 'New node' do
+      click_icon :edit
+    end
+
+    expect(page).to have_current_path %r{/admin/taxonomies/\d+/taxons/\d+/edit}
   end
 end


### PR DESCRIPTION
Whoops. I broke this in #850, did not pay enough attention after cherry picking a change.

This was obviously wrong using erb in a non-erb file. There's now a spec to test for it.