### PR TITLE
Improve store credit views

### DIFF
--- a/backend/app/views/spree/admin/store_credits/index.html.erb
+++ b/backend/app/views/spree/admin/store_credits/index.html.erb
@@ -17,13 +17,13 @@
 
   <table>
     <thead>
-      <th><%= Spree.t("admin.store_credits.amount_credited") %></th>
-      <th><%= Spree.t("admin.store_credits.amount_used") %></th>
-      <th><%= Spree.t("admin.store_credits.amount_authorized") %></th>
-      <th><%= Spree.t("admin.store_credits.credit_type") %></th>
-      <th><%= Spree.t("admin.store_credits.created_by") %></th>
-      <th><%= Spree.t("admin.store_credits.issued_on") %></th>
-      <th><%= Spree.t("admin.store_credits.invalidated") %></th>
+      <th><%= Spree::StoreCredit.human_attribute_name(:amount_credited) %></th>
+      <th><%= Spree::StoreCredit.human_attribute_name(:amount_used) %></th>
+      <th><%= Spree::StoreCredit.human_attribute_name(:amount_authorized) %></th>
+      <th><%= Spree::StoreCredit.human_attribute_name(:category_id) %></th>
+      <th><%= Spree::StoreCredit.human_attribute_name(:created_by_id) %></th>
+      <th><%= Spree::StoreCredit.human_attribute_name(:created_at) %></th>
+      <th><%= Spree::StoreCredit.human_attribute_name(:invalidated_at) %></th>
       <th data-hook="admin_store_credits_index_header_actions" class="actions"></th>
     <thead>
     <tbody>

--- a/backend/app/views/spree/admin/store_credits/show.html.erb
+++ b/backend/app/views/spree/admin/store_credits/show.html.erb
@@ -96,7 +96,7 @@
       <% @store_credit_events.each do |event| %>
         <tr>
           <td data-hook="admin_show_store_credit_date_cell">
-            <%= event.created_at %>
+            <%= pretty_time(event.created_at) %>
           </td>
           <td><%= store_credit_event_admin_action_name(event) %></td>
           <td class='align-right'><%= event.display_amount %></td>

--- a/backend/app/views/spree/admin/store_credits/show.html.erb
+++ b/backend/app/views/spree/admin/store_credits/show.html.erb
@@ -21,14 +21,14 @@
   </colgroup>
   <tr>
     <td>
-      <strong><%= Spree.t(:amount) %>:</strong>
+      <strong><%= Spree::StoreCredit.human_attribute_name(:amount) %>:</strong>
     </td>
     <td><%= @store_credit.display_amount.to_html %></td>
     <td class='actions'></td>
   </tr>
   <tr>
     <td>
-      <strong><%= Spree.t(:created_by) %>:</strong>
+      <strong><%= Spree::StoreCredit.human_attribute_name(:created_by_id) %>:</strong>
     </td>
     <td><%= @store_credit.created_by_email %></td>
     <td class='actions'></td>
@@ -42,7 +42,7 @@
   </tr>
   <tr id='memo-display-row'>
     <td>
-      <strong><%= Spree.t(:memo) %>:</strong>
+      <strong><%= Spree::StoreCredit.human_attribute_name(:memo) %>:</strong>
     </td>
     <td class='js-memo-text'>
       <%= @store_credit.memo %>
@@ -55,7 +55,7 @@
   </tr>
   <tr id='memo-edit-row' class='hidden' data-original-value='<%= @store_credit.memo %>'>
     <td>
-      <strong><%= Spree.t(:memo) %>:</strong>
+      <strong><%= Spree::StoreCredit.human_attribute_name(:memo) %>:</strong>
     </td>
     <td>
       <%= form_tag admin_user_store_credit_path(@user, @store_credit), method: :put, remote: true, id: 'sc_memo_edit_form' do %>
@@ -85,11 +85,11 @@
     <thead>
       <tr>
         <th><%= Spree.t(:date) %></th>
-        <th><%= Spree.t(:action) %></th>
+        <th><%= Spree::StoreCreditEvent.human_attribute_name(:action) %></th>
         <th><%= Spree::StoreCredit.human_attribute_name(:amount) %></th>
         <th><%= Spree::StoreCredit.human_attribute_name(:created_by_id) %></th>
-        <th><%= Spree.t("admin.store_credits.total_unused") %></th>
-        <th><%= Spree.t("admin.store_credits.reason_for_updating") %></th>
+        <th><%= Spree::StoreCreditEvent.human_attribute_name(:user_total_amount) %></th>
+        <th><%= Spree::StoreCreditUpdateReason.human_attribute_name(:name) %></th>
       </tr>
     </thead>
     <tbody>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -213,10 +213,19 @@ en:
         mail_from_address: Mail From Address
       spree/store_credit:
         amount: Amount
-        amount_used: Amount used
+        amount_authorized: Amount Authorized
+        amount_credited: Amount Credited
+        amount_used: Amount Used
         category_id: Credit Type
+        created_at: Issued On
         created_by_id: Created By
+        invalidated_at: Invalidated
         memo: Memo
+      spree/store_credit_event:
+        action: Action
+        user_total_amount: Total Unused
+      spree/store_credit_update_reason:
+        name: Reason For Updating
       spree/stock_item:
         count_on_hand: Count On Hand
       spree/stock_location:

--- a/core/spec/models/spree/store_credit_spec.rb
+++ b/core/spec/models/spree/store_credit_spec.rb
@@ -69,7 +69,7 @@ describe Spree::StoreCredit do
 
         it "should set the correct error message" do
           invalid_store_credit.valid?
-          expect(invalid_store_credit.errors.full_messages).to include("Amount used cannot be greater than the credited amount")
+          expect(invalid_store_credit.errors.full_messages).to include("Amount Used cannot be greater than the credited amount")
         end
       end
 


### PR DESCRIPTION
Use pretty time to improve the output of a date and use model attribute translation to improve the I18n usage.

This is part of an ongoing effort to improve I18n use in solidus as discussed in #735.