### PR TITLE
require 'ffaker' in testing_support/factories

### DIFF
--- a/core/lib/spree/testing_support/sequences.rb
+++ b/core/lib/spree/testing_support/sequences.rb
@@ -1,4 +1,5 @@
 require 'factory_girl'
+require 'ffaker'
 
 FactoryGirl.define do
   sequence(:random_code)        { Faker::Lorem.characters(10) }


### PR DESCRIPTION
As spree factories use ffaker, a consuming app can't
`require 'spree/testing_support/factories'` unless it manually
requires ffaker -- testing_support/factories should require it's
own dependencies so the consumer doesn't need to figure it out.