### PR TITLE
Upgrade ffaker to 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 *   Fixed a bug where toggling 'show only complete order' on/off was not showing
     all orders. [#749](https://github.com/solidusio/solidus/pull/749)
 
+*   ffaker has been updated to version 2.x
+
+    This version changes the namespace from Faker:: to FFaker::
+
 ## Solidus 1.2.0 (unreleased)
 
 *   Admin menu has been moved from top of the page to the left side.

--- a/core/lib/spree/testing_support/sequences.rb
+++ b/core/lib/spree/testing_support/sequences.rb
@@ -1,9 +1,9 @@
 require 'factory_girl'
 
 FactoryGirl.define do
-  sequence(:random_code)        { Faker::Lorem.characters(10) }
-  sequence(:random_description) { Faker::Lorem.paragraphs(1 + Kernel.rand(5)).join("\n") }
-  sequence(:random_email)       { Faker::Internet.email }
-  sequence(:random_string)      { Faker::Lorem.sentence }
+  sequence(:random_code)        { FFaker::Lorem.characters(10) }
+  sequence(:random_description) { FFaker::Lorem.paragraphs(1 + Kernel.rand(5)).join("\n") }
+  sequence(:random_email)       { FFaker::Internet.email }
+  sequence(:random_string)      { FFaker::Lorem.sentence }
   sequence(:sku) { |n| "SKU-#{n}" }
 end

--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'awesome_nested_set', '~> 3.0.1'
   s.add_dependency 'carmen', '~> 1.0.0'
   s.add_dependency 'cancancan', '~> 1.10'
-  s.add_dependency 'ffaker', '~> 1.16'
+  s.add_dependency 'ffaker', '~> 2.0'
   s.add_dependency 'font-awesome-rails', '~> 4.0'
   s.add_dependency 'friendly_id', '~> 5.0'
   s.add_dependency 'highline', '~> 1.6.18' # Necessary for the install generator

--- a/core/spec/helpers/base_helper_spec.rb
+++ b/core/spec/helpers/base_helper_spec.rb
@@ -135,11 +135,10 @@ describe Spree::BaseHelper, type: :helper do
       # Because the controller_name method returns "test"
       # controller_name is used by this method to infer what it is supposed
       # to be generating meta_data_tags for
-      text = Faker::Lorem.paragraphs(2).join(" ")
-      @test = Spree::Product.new(description: text)
+      @test = Spree::Product.new(description: "a" * 200)
       tags = Nokogiri::HTML.parse(meta_data_tags)
       content = tags.css("meta[name=description]").first["content"]
-      assert content.length <= 160, "content length is not truncated to 160 characters"
+      expect(content.length).to be <= 160
     end
   end
 

--- a/sample/db/samples/addresses.rb
+++ b/sample/db/samples/addresses.rb
@@ -3,24 +3,24 @@ new_york = Spree::State.find_by_name!("New York")
 
 # Billing address
 Spree::Address.create!(
-  firstname: Faker::Name.first_name,
-  lastname: Faker::Name.last_name,
-  address1: Faker::Address.street_address,
-  address2: Faker::Address.secondary_address,
-  city: Faker::Address.city,
+  firstname: FFaker::Name.first_name,
+  lastname: FFaker::Name.last_name,
+  address1: FFaker::Address.street_address,
+  address2: FFaker::Address.secondary_address,
+  city: FFaker::Address.city,
   state: new_york,
   zipcode: 16_804,
   country: united_states,
-  phone: Faker::PhoneNumber.phone_number)
+  phone: FFaker::PhoneNumber.phone_number)
 
 # Shipping address
 Spree::Address.create!(
-  firstname: Faker::Name.first_name,
-  lastname: Faker::Name.last_name,
-  address1: Faker::Address.street_address,
-  address2: Faker::Address.secondary_address,
-  city: Faker::Address.city,
+  firstname: FFaker::Name.first_name,
+  lastname: FFaker::Name.last_name,
+  address1: FFaker::Address.street_address,
+  address2: FFaker::Address.secondary_address,
+  city: FFaker::Address.city,
   state: new_york,
   zipcode: 16_804,
   country: united_states,
-  phone: Faker::PhoneNumber.phone_number)
+  phone: FFaker::PhoneNumber.phone_number)

--- a/sample/db/samples/products.rb
+++ b/sample/db/samples/products.rb
@@ -5,7 +5,7 @@ tax_category = Spree::TaxCategory.find_by_name!("Default")
 shipping_category = Spree::ShippingCategory.find_by_name!("Default")
 
 default_attrs = {
-  description: Faker::Lorem.paragraph,
+  description: FFaker::Lorem.paragraph,
   available_on: Time.current
 }
 


### PR DESCRIPTION
This switches ffaker to the `FFaker` namespace

I was reminded by #879 that we should do this