### PR TITLE
Improve I18n use in payment method views

### DIFF
--- a/backend/app/views/spree/admin/payment_methods/_form.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/_form.html.erb
@@ -5,12 +5,12 @@
     <div class="alpha four columns">
       <div id="preference-settings">
         <div class="field">
-          <%= f.label :type, Spree.t(:provider) %>
+          <%= f.label :type %>
           <%= collection_select(:payment_method, :type, @providers, :to_s, :name, {}, {:id => 'gtwy-type', :class => 'select2 fullwidth js-gateway-type'}) %>
         </div>
 
         <div class="field js-preference-source-wrapper">
-          <%= label_tag :preference_source, 'Preference Source' %>
+          <%= f.label :preference_source %>
           <%= f.select(:preference_source, [[Spree.t(:preference_source_none), nil]] + @object.class.available_preference_sources, {}, class: 'select2 fullwidth js-preference-source') %>
         </div>
 
@@ -25,15 +25,15 @@
         <div class="info warning js-gateway-settings-warning"><%= Spree.t(:provider_settings_warning) %></div>
       </div>
       <div data-hook="display" class="field">
-        <%= label_tag :payment_method_display_on, Spree.t(:display) %>
+        <%= f.label :display_on %>
         <%= select(:payment_method, :display_on, Spree::PaymentMethod::DISPLAY.collect { |display| [Spree.t(display), display == :both ? nil : display.to_s] }, {}, {:class => 'select2 fullwidth'}) %>
       </div>
       <div data-hook="auto_capture" class="field">
-        <%= label_tag :payment_method_auto_capture, Spree.t(:auto_capture) %>
+        <%= f.label :auto_capture %>
         <%= select(:payment_method, :auto_capture, [["#{Spree.t(:use_app_default)} (#{Spree::Config[:auto_capture]})", ''], [Spree.t(:say_yes), true], [Spree.t(:say_no), false]], {}, {:class => 'select2 fullwidth'}) %>
       </div>
       <div data-hook="active" class="field">
-        <%= label_tag nil, Spree.t(:active) %>
+        <%= label_tag nil, Spree::PaymentMethod.human_attribute_name(:active) %>
         <ul>
           <li>
             <%= radio_button :payment_method, :active, true %>
@@ -49,15 +49,14 @@
 
     <div class="omega eight columns">
       <div data-hook="name" class="field">
-        <%= label_tag :payment_method_name, Spree.t(:name) %>
-        <%= text_field :payment_method, :name, :class => 'fullwidth' %>
+        <%= f.label :name %>
+        <%= f.text_field :name, :class => 'fullwidth' %>
       </div>
       <div data-hook="description" class="field">
-        <%= label_tag :payment_method_description, Spree.t(:description) %>
-        <%= text_area :payment_method, :description, {:cols => 60, :rows => 6, :class => 'fullwidth'} %>
+        <%= f.label :description %>
+        <%= f.text_area :description, {:cols => 60, :rows => 6, :class => 'fullwidth'} %>
       </div>
     </div>
-
   </div>
 </div>
 

--- a/backend/app/views/spree/admin/payment_methods/index.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/index.html.erb
@@ -1,7 +1,7 @@
 <%= render 'spree/admin/shared/configuration_menu' %>
 
 <% content_for :page_title do %>
-  <%= Spree.t(:payment_methods) %>
+  <%= Spree::PaymentMethod.model_name.human(count: :other) %>
 <% end %>
 
 <% content_for :page_actions do %>
@@ -24,10 +24,10 @@
     </colgroup>
     <thead>
       <tr data-hook="admin_payment_methods_index_headers">
-        <th><%= Spree.t(:name) %></th>
-        <th><%= Spree.t(:provider) %></th>
-        <th><%= Spree.t(:display) %></th>
-        <th><%= Spree.t(:active) %></th>
+        <th><%= Spree::PaymentMethod.human_attribute_name(:name) %></th>
+        <th><%= Spree::PaymentMethod.human_attribute_name(:type) %></th>
+        <th><%= Spree::PaymentMethod.human_attribute_name(:display_on) %></th>
+        <th><%= Spree::PaymentMethod.human_attribute_name(:active) %></th>
         <th data-hook="admin_payment_methods_index_header_actions" class="actions"></th>
       </tr>
     </thead>

--- a/backend/app/views/spree/admin/payment_methods/new.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/new.html.erb
@@ -16,7 +16,7 @@
   <fieldset class="no-border-top">
     <%= render :partial => 'form', :locals => { :f => f } %>
     <div data-hook="buttons" class="filter-actions actions">
-      <%= button Spree.t(:create), 'ok' %>
+      <%= button Spree.t('actions.create'), 'ok' %>
     </div>
   </fieldset>
 <% end %>

--- a/backend/spec/features/admin/configuration/payment_methods_spec.rb
+++ b/backend/spec/features/admin/configuration/payment_methods_spec.rb
@@ -49,14 +49,14 @@ describe "Payment Methods", type: :feature do
     end
 
     it "should be able to edit an existing payment method" do
-      fill_in "payment_method_name", with: "Payment 99"
+      fill_in "payment_method_check_name", with: "Payment 99"
       click_button "Update"
       expect(page).to have_content("successfully updated!")
-      expect(page).to have_field("payment_method_name", with: "Payment 99")
+      expect(page).to have_field("payment_method_check_name", with: "Payment 99")
     end
 
     it "should display validation errors" do
-      fill_in "payment_method_name", with: ""
+      fill_in "payment_method_check_name", with: ""
       click_button "Update"
       expect(page).to have_content("Name can't be blank")
     end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -115,7 +115,13 @@ en:
         amount: Amount
         number: Identifier
       spree/payment_method:
+        active: Active
+        auto_capture: Auto Capture
+        description: Description
+        display_on: Display
         name: Name
+        preference_source: Preference Source
+        type: Provider
       spree/product:
         available_on: Available On
         cost_currency: Cost Currency


### PR DESCRIPTION
Use model name and attribute translation.

This is part of an ongoing effort to improve I18n use in solidus as discussed in #735.