### PR TITLE
Improve tax rate views

### DIFF
--- a/backend/app/views/spree/admin/tax_rates/_form.html.erb
+++ b/backend/app/views/spree/admin/tax_rates/_form.html.erb
@@ -5,11 +5,11 @@
 
       <div class="alpha six columns">
         <div data-hook="name" class="field">
-          <%= f.label :name, Spree.t(:name) %>
+          <%= f.label :name %>
           <%= f.text_field :name, :class => 'fullwidth' %>
         </div>
         <div data-hook="rate" class="field">
-          <%= f.label :amount, Spree.t(:rate) %>
+          <%= f.label :amount %>
           <%= f.text_field :amount, :class => 'fullwidth' %>
           <br/><span class="info"><%= Spree.t(:tax_rate_amount_explanation) %></span>
         </div>
@@ -21,11 +21,11 @@
 
       <div class="omega six columns">
         <div data-hook="zone" class="field">
-          <%= f.label :zone, Spree.t(:zone) %>
+          <%= f.label :zone, Spree::Zone.model_name.human %>
           <%= f.collection_select(:zone_id, @available_zones, :id, :name, {}, {:class => 'select2 fullwidth'}) %>
         </div>
         <div data-hook="category" class="field">
-          <%= f.label :tax_category_id, Spree.t(:tax_category) %>
+          <%= f.label :tax_category_id, Spree::TaxCategory.model_name.human %>
           <%= f.collection_select(:tax_category_id, @available_categories,:id, :name, {}, {:class => 'select2 fullwidth'}) %>
         </div>
         <div data-hook="show_rate" class="field">

--- a/backend/app/views/spree/admin/tax_rates/index.html.erb
+++ b/backend/app/views/spree/admin/tax_rates/index.html.erb
@@ -1,7 +1,7 @@
 <%= render 'spree/admin/shared/configuration_menu' %>
 
 <% content_for :page_title do %>
-  <%= Spree.t(:tax_rates) %>
+  <%= Spree::TaxRate.model_name.human(count: :other) %>
 <% end %>
 
 <% content_for :page_actions do %>
@@ -26,13 +26,13 @@
     </colgroup>
     <thead>
       <tr data-hook="rate_header">
-        <th><%= Spree.t(:zone) %></th>
-        <th><%= Spree.t(:name) %></th>
-        <th><%= Spree.t(:category) %></th>
-        <th><%= Spree.t(:amount) %></th>
-        <th><%= Spree.t(:included_in_price) %></th>
-        <th><%= Spree.t(:show_rate_in_label) %></th>
-        <th><%= Spree.t(:calculator) %></th>
+        <th><%= Spree::TaxRate.human_attribute_name(:zone) %></th>
+        <th><%= Spree::TaxRate.human_attribute_name(:name) %></th>
+        <th><%= Spree::TaxRate.human_attribute_name(:tax_category_id) %></th>
+        <th><%= Spree::TaxRate.human_attribute_name(:amount) %></th>
+        <th><%= Spree::TaxRate.human_attribute_name(:included_in_price) %></th>
+        <th><%= Spree::TaxRate.human_attribute_name(:show_rate_in_label) %></th>
+        <th><%= Spree::Calculator.model_name.human %></th>
         <th class="actions"></th>
       </tr>
     </thead>

--- a/backend/app/views/spree/admin/tax_rates/new.html.erb
+++ b/backend/app/views/spree/admin/tax_rates/new.html.erb
@@ -14,7 +14,7 @@
 
 <%= form_for [:admin, @tax_rate] do |f| %>
   <fieldset class="no-border-top">
-    
+
     <%= render :partial => 'form', :locals => { :f => f } %>
 
     <div class="clear"></div>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -259,8 +259,9 @@ en:
         tax_code: Tax Code
       spree/tax_rate:
         amount: Rate
-        included_in_price: Included in Price
-        show_rate_in_label: Show rate in label
+        included_in_price: Included In Price
+        name: Name
+        show_rate_in_label: Show Rate In Label
       spree/taxon:
         description: Description
         icon: Icon


### PR DESCRIPTION
use model name and model attribute translations.

This is part of an ongoing effort to improve I18n use in solidus as discussed in #735.