### PR TITLE
Use model name translation

### DIFF
--- a/backend/app/views/spree/admin/orders/confirm/_payments.html.erb
+++ b/backend/app/views/spree/admin/orders/confirm/_payments.html.erb
@@ -1,5 +1,5 @@
 <fieldset class="no-border-bottom">
-  <legend><%= Spree.t(:payments) %></legend>
+  <legend><%= Spree::Payment.model_name.human(count: :other) %></legend>
   <table class="index">
     <thead>
       <tr data-hook="payments_header">

--- a/backend/app/views/spree/admin/shared/_configuration_menu.html.erb
+++ b/backend/app/views/spree/admin/shared/_configuration_menu.html.erb
@@ -52,7 +52,7 @@
       <% end %>
 
       <% if can?(:display, Spree::Tracker) %>
-        <%= configurations_sidebar_menu_item Spree.t(:analytics_trackers), admin_trackers_path %>
+        <%= configurations_sidebar_menu_item Spree::Tracker.model_name.human(count: :other), admin_trackers_path %>
       <% end %>
 
       <% if can?(:display, Spree::RefundReason) %>

--- a/backend/app/views/spree/admin/shared/_product_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_product_tabs.html.erb
@@ -16,10 +16,10 @@
         <%= link_to_with_icon 'picture-o', Spree.t(:images), admin_product_images_url(@product) %>
       <% end if can?(:admin, Spree::Image) %>
       <%= content_tag :li, :class => ('active' if current == 'Variants') do %>
-        <%= link_to_with_icon 'th-large', Spree.t(:variants),  admin_product_variants_url(@product) %>
+        <%= link_to_with_icon 'th-large', Spree::Variant.model_name.human(count: :other),  admin_product_variants_url(@product) %>
       <% end if can?(:admin, Spree::Variant) %>
       <%= content_tag :li, :class => ('active' if current == 'Product Properties') do %>
-        <%= link_to_with_icon 'tasks', Spree.t(:product_properties), admin_product_product_properties_url(@product) %>
+        <%= link_to_with_icon 'tasks', Spree::ProductProperty.model_name.human(count: :other), admin_product_product_properties_url(@product) %>
       <% end if can?(:admin, Spree::ProductProperty) %>
       <%= content_tag :li, :class => ('active' if current == 'Stock Management') do %>
         <%= link_to_with_icon 'cubes', Spree.t(:stock_management), admin_product_stock_url(@product) %>

--- a/backend/app/views/spree/admin/stock_items/_stock_management.html.erb
+++ b/backend/app/views/spree/admin/stock_items/_stock_management.html.erb
@@ -13,7 +13,7 @@
     <tr>
       <th><%= Spree.t(:item) %></th>
       <th><%= Spree.t(:options) %></th>
-      <th><%= Spree.t(:stock_location) %></th>
+      <th><%= Spree::StockLocation.model_name.human %></th>
       <th><%= Spree.t(:backorderable_header) %></th>
       <th><%= Spree.t(:count_on_hand) %></th>
       <th class="actions"></th>

--- a/backend/app/views/spree/admin/stock_transfers/index.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/index.html.erb
@@ -19,7 +19,7 @@
     <%= search_form_for [:admin, @search] do |f| %>
       <div class="field-block alpha four columns">
         <div class="field">
-          <%= f.label nil, Spree.t(:stock_location) %>
+          <%= f.label nil, Spree::StockLocation.model_name.human %>
           <%= f.select :source_location_id_or_destination_location_id_eq, options_from_collection_for_select(@stock_locations, :id, :name, params[:q][:source_location_id_or_destination_location_id_eq]), {include_blank: true}, {class: 'select2 fullwidth'} %>
         </div>
       </div>


### PR DESCRIPTION
A few places were missed that could have utilized model name translation.  

This is part of an ongoing effort to improve I18n use in solidus as discussed in #735.