### PR TITLE
Add `apply_automatically` to factory when creating promotions without code

### DIFF
--- a/core/lib/spree/testing_support/factories/promotion_factory.rb
+++ b/core/lib/spree/testing_support/factories/promotion_factory.rb
@@ -14,6 +14,10 @@ FactoryGirl.define do
       end
     end
 
+    trait :automatic do
+      apply_automatically true
+    end
+
     trait :with_line_item_adjustment do
       transient do
         adjustment_rate 10


### PR DESCRIPTION
- Otherwise, we'd need to specify it in the `create(:promotion, apply_automatically: true)`

--

Hello,

I've stumbled upon this necessary tweak during an upgrade from Spree to Solidus. 