### PR TITLE
Allow to update Ransack version

### DIFF
--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'paranoia', '~> 2.1.4'
   s.add_dependency 'premailer-rails'
   s.add_dependency 'rails', '~> 4.2.5'
-  s.add_dependency 'ransack', '~> 1.6.0'
+  s.add_dependency 'ransack', '~> 1.6'
   s.add_dependency 'responders'
   s.add_dependency 'state_machines-activerecord', '~> 0.2'
   s.add_dependency 'stringex', '~> 1.5.1'


### PR DESCRIPTION
Ransack v1.6.x and bellow is unable to use ActiveRecord and Mongoid side by side.
It is fixed in https://github.com/activerecord-hackery/ransack/pull/541 and is included in v1.7.0.