### PR TITLE
Reset Spree::Config instance variables between specs

### DIFF
--- a/core/lib/spree/testing_support/preferences.rb
+++ b/core/lib/spree/testing_support/preferences.rb
@@ -9,6 +9,7 @@ module Spree
       # end
       #
       def reset_spree_preferences(&config_block)
+        Spree::Config.instance_variables.each { |iv| Spree::Config.remove_instance_variable(iv) }
         Spree::Config.preference_store = Spree::Config.default_preferences
 
         configure_spree_preferences(&config_block) if block_given?

--- a/core/spec/lib/spree/core/testing_support/preferences_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/preferences_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+RSpec.describe Spree::TestingSupport::Preferences do
+  describe 'resetting the app configuration' do
+    before do
+      @original_spree_mails_from = Spree::Config.mails_from
+      @original_spree_searcher_class = Spree::Config.searcher_class
+      class MySearcherClass; end
+      include Spree::TestingSupport::Preferences
+      Spree::Config.mails_from = "hello@myserver.com"
+      Spree::Config.searcher_class = MySearcherClass
+    end
+
+    it 'resets normal preferences' do
+      expect(Spree::Config.mails_from).to eq("hello@myserver.com")
+      reset_spree_preferences
+      expect(Spree::Config.mails_from).to eq(@original_spree_mails_from)
+    end
+
+    it 'resets cached configuration instance variables' do
+      expect(Spree::Config.searcher_class).to eq(MySearcherClass)
+      reset_spree_preferences
+      expect(Spree::Config.searcher_class).to eq(@original_spree_searcher_class)
+    end
+  end
+end

--- a/core/spec/lib/tasks/exchanges_spec.rb
+++ b/core/spec/lib/tasks/exchanges_spec.rb
@@ -17,12 +17,9 @@ describe "exchanges:charge_unreturned_items" do
   end
 
   before do
-    @original_expedited_exchanges_pref = Spree::Config[:expedited_exchanges]
     Spree::Config[:expedited_exchanges] = true
     Spree::StockItem.update_all(count_on_hand: 10)
   end
-
-  after { Spree::Config[:expedited_exchanges] = @original_expedited_exchanges_pref }
 
   context "there are no unreturned items" do
     it { expect { subject.invoke }.not_to change { Spree::Order.count } }
@@ -119,11 +116,8 @@ describe "exchanges:charge_unreturned_items" do
 
         context "auto_capture_exchanges is true" do
           before do
-            @original_auto_capture_exchanges = Spree::Config[:auto_capture_exchanges]
             Spree::Config[:auto_capture_exchanges] = true
           end
-
-          after { Spree::Config[:auto_capture_exchanges] = @original_auto_capture_exchanges }
 
           it 'creates a pending payment' do
             expect { subject.invoke }.to change { Spree::Payment.count }.by(1)
@@ -134,11 +128,8 @@ describe "exchanges:charge_unreturned_items" do
 
         context "auto_capture_exchanges is false" do
           before do
-            @original_auto_capture_exchanges = Spree::Config[:auto_capture_exchanges]
             Spree::Config[:auto_capture_exchanges] = false
           end
-
-          after { Spree::Config[:auto_capture_exchanges] = @original_auto_capture_exchanges }
 
           it 'captures payment' do
             expect { subject.invoke }.to change { Spree::Payment.count }.by(1)

--- a/core/spec/models/spree/item_adjustments_spec.rb
+++ b/core/spec/models/spree/item_adjustments_spec.rb
@@ -108,10 +108,6 @@ module Spree
         Spree::Config.promotion_chooser_class = Spree::TestPromotionChooser
       end
 
-      after do
-        Spree::Config.promotion_chooser_class = Spree::PromotionChooser
-      end
-
       it "uses the defined promotion chooser" do
         expect { subject.update }.to raise_error("Custom promotion chooser")
       end

--- a/core/spec/models/spree/order/finalizing_spec.rb
+++ b/core/spec/models/spree/order/finalizing_spec.rb
@@ -41,7 +41,6 @@ describe Spree::Order, type: :model do
       expect(order.shipment_state).to eq('ready')
     end
 
-    after { Spree::Config.set track_inventory_levels: true }
     it "should not sell inventory units if track_inventory_levels is false" do
       Spree::Config.set track_inventory_levels: false
       expect(Spree::InventoryUnit).not_to receive(:sell_units)

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -221,10 +221,6 @@ describe Spree::Order, type: :model do
         Spree::Config.order_merger_class = TestOrderMerger
       end
 
-      after do
-        Spree::Config.order_merger_class = Spree::PromotionChooser
-      end
-
       let(:user) { build(:user) }
 
       it 'uses the configured order merger' do

--- a/core/spec/models/spree/return_authorization_spec.rb
+++ b/core/spec/models/spree/return_authorization_spec.rb
@@ -52,13 +52,11 @@ describe Spree::ReturnAuthorization, type: :model do
       subject                    { create(:return_authorization, order: order, return_items: [exchange_return_item, return_item]) }
 
       before do
-        @expediteted_exchanges_config = Spree::Config[:expedited_exchanges]
         Spree::Config[:expedited_exchanges] = true
         @pre_exchange_hooks = subject.class.pre_expedited_exchange_hooks
       end
 
       after do
-        Spree::Config[:expedited_exchanges] = @expediteted_exchanges_config
         subject.class.pre_expedited_exchange_hooks = @pre_exchange_hooks
       end
 

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -278,12 +278,7 @@ describe Spree::Shipment, type: :model do
 
     context "when payment is not required" do
       before do
-        @original_require_payment = Spree::Config[:require_payment_to_ship]
         Spree::Config[:require_payment_to_ship] = false
-      end
-
-      after do
-        Spree::Config[:require_payment_to_ship] = @original_require_payment
       end
 
       it "should result in a 'ready' state" do
@@ -340,8 +335,6 @@ describe Spree::Shipment, type: :model do
   end
 
   context "when order is completed" do
-    after { Spree::Config.set track_inventory_levels: true }
-
     before do
       allow(order).to receive_messages completed?: true
       allow(order).to receive_messages canceled?: false

--- a/core/spec/models/spree/unit_cancel_spec.rb
+++ b/core/spec/models/spree/unit_cancel_spec.rb
@@ -68,11 +68,7 @@ describe Spree::UnitCancel do
       end
 
       before do
-        @old_expedited_exchanges_value = Spree::Config[:expedited_exchanges]
         Spree::Config[:expedited_exchanges] = true
-      end
-      after do
-        Spree::Config[:expedited_exchanges] = @old_expedited_exchanges_value
       end
 
       # This sets up an order with one shipped inventory unit, one unshipped

--- a/core/spec/models/spree/user_spec.rb
+++ b/core/spec/models/spree/user_spec.rb
@@ -34,11 +34,8 @@ describe Spree::LegacyUser, type: :model do
 
     context "with completable_order_created_cutoff set" do
       before do
-        @original_order_cutoff_preference = Spree::Config.completable_order_created_cutoff_days
         Spree::Config.completable_order_created_cutoff_days = 1
       end
-
-      after { Spree::Config.completable_order_created_cutoff_days = @original_order_cutoff_preference }
 
       it "excludes orders updated outside of the cutoff date" do
         create(:order, user: user, created_by: user, created_at: 3.days.ago, updated_at: 2.days.ago)
@@ -48,11 +45,8 @@ describe Spree::LegacyUser, type: :model do
 
     context "with completable_order_created_cutoff set" do
       before do
-        @original_order_cutoff_preference = Spree::Config.completable_order_updated_cutoff_days
         Spree::Config.completable_order_updated_cutoff_days = 1
       end
-
-      after { Spree::Config.completable_order_updated_cutoff_days = @original_order_cutoff_preference }
 
       it "excludes orders updated outside of the cutoff date" do
         create(:order, user: user, created_by: user, created_at: 3.days.ago, updated_at: 2.days.ago)


### PR DESCRIPTION
In order to not have to manually reset configuration values between specs
only if they are of the cached instance variable type, add one line
to the `reset_spree_preferences` method that resets all instance variables
between specs.

Bonus: Specs for a spec helper method!