### PR TITLE
Improve i18n

### DIFF
--- a/backend/app/views/spree/admin/products/index.html.erb
+++ b/backend/app/views/spree/admin/products/index.html.erb
@@ -22,13 +22,13 @@
         <div data-hook="admin_products_index_search">
           <div class="alpha nine columns">
             <div class="field">
-              <%= f.label :name_cont, Spree.t(:name) %>
+              <%= f.label :name_cont, Spree::Product.human_attribute_name(:name) %>
               <%= f.text_field :name_cont, :size => 15 %>
             </div>
           </div>
           <div class="four columns">
             <div class="field">
-              <%= f.label :variants_including_master_sku_cont, Spree.t(:sku) %>
+              <%= f.label :variants_including_master_sku_cont, Spree::Variant.human_attribute_name(:sku) %>
               <%= f.text_field :variants_including_master_sku_cont, :size => 15 %>
             </div>
           </div>
@@ -66,7 +66,7 @@
     </colgroup>
     <thead>
       <tr data-hook="admin_products_index_headers">
-        <th><%= Spree.t(:sku) %></th>
+        <th><%= Spree::Variant.human_attribute_name(:sku) %></th>
         <th colspan="2"><%= sort_link @search,:name, Spree::Product.human_attribute_name(:name), { :default_order => "desc" }, {:title => 'admin_products_listing_name_title'} %></th>
         <th><%= sort_link @search,:master_default_price_amount, Spree::Product.human_attribute_name(:price), {}, {:title => 'admin_products_listing_price_title'} %></th>
         <th data-hook="admin_products_index_header_actions" class="actions"></th>

--- a/backend/app/views/spree/admin/promotions/actions/_promotion_calculators_with_custom_fields.html.erb
+++ b/backend/app/views/spree/admin/promotions/actions/_promotion_calculators_with_custom_fields.html.erb
@@ -2,7 +2,7 @@
 
   <div class="field alpha four columns">
     <% field_name = "#{param_prefix}[calculator_type]" %>
-    <%= label_tag field_name, Spree.t(:calculator) %>
+    <%= label_tag field_name, Spree::Calculator.model_name.human %>
     <%= select_tag field_name,
                    options_from_collection_for_select(calculators, :to_s, :description, promotion_action.calculator.type),
                    :class => 'type-select select2 fullwidth' %>

--- a/backend/app/views/spree/admin/promotions/index.html.erb
+++ b/backend/app/views/spree/admin/promotions/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:promotions) %>
+  <%= Spree::Promotion.model_name.human(count: :other) %>
 <% end %>
 
 <% content_for :page_actions do %>
@@ -19,28 +19,28 @@
     <%= search_form_for [:admin, @search] do |f| %>
       <div class="four columns alpha">
         <div class="field">
-          <%= label_tag :q_name_cont, Spree.t(:name) %>
+          <%= label_tag :q_name_cont, Spree::Promotion.human_attribute_name(:name) %>
           <%= f.text_field :name_cont, tabindex: 1 %>
         </div>
       </div>
 
       <div class="four columns">
         <div class="field">
-          <%= label_tag :q_codes_value_cont, Spree.t(:code) %>
+          <%= label_tag :q_codes_value_cont, Spree::Promotion.human_attribute_name(:code) %>
           <%= f.text_field :codes_value_cont, tabindex: 1 %>
         </div>
       </div>
 
       <div class="four columns">
         <div class="field">
-          <%= label_tag :q_path_cont, Spree.t(:path) %>
+          <%= label_tag :q_path_cont, Spree::Promotion.human_attribute_name(:path) %>
           <%= f.text_field :path_cont, tabindex: 1 %>
         </div>
       </div>
 
       <div class="four columns omega">
         <div class="field">
-          <%= label_tag :q_promotion_category_id_eq, 'promotion category' %><br>
+          <%= label_tag :q_promotion_category_id_eq, Spree::PromotionCategory.model_name.human %><br>
           <%= f.collection_select(:promotion_category_id_eq, @promotion_categories, :id, :name, { :include_blank => Spree.t('match_choices.all') }, { :class => 'select2 fullwidth' }) %>
         </div>
       </div>
@@ -75,8 +75,8 @@
         <th><%= Spree::Promotion.human_attribute_name(:name) %></th>
         <th><%= Spree::Promotion.human_attribute_name(:code) %></th>
         <th><%= Spree::Promotion.human_attribute_name(:description) %></th>
-        <th><%= Spree.t(:usage_limit) %></th>
-        <th><%= Spree.t(:promotion_uses) %></th>
+        <th><%= Spree::Promotion.human_attribute_name(:usage_limit) %></th>
+        <th><%= Spree::Promotion.human_attribute_name(:promotion_uses) %></th>
         <th><%= Spree::Promotion.human_attribute_name(:expires_at) %></th>
         <th class="actions"></th>
       </tr>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -148,6 +148,7 @@ en:
         name: Name
         path: Path
         per_code_usage_limit: Per Code Usage Limit
+        promotion_uses: Promotion Uses
         starts_at: Starts
         usage_limit: Overall Usage Limit
       spree/promotion_category:


### PR DESCRIPTION
Use model name and attribute translation where possible.

This is part of an ongoing effort to improve I18n usage as discussed in #735.
