### PR TITLE
Use the API for user selection through select2

### DIFF
--- a/api/app/controllers/spree/api/resource_controller.rb
+++ b/api/app/controllers/spree/api/resource_controller.rb
@@ -2,7 +2,15 @@ class Spree::Api::ResourceController < Spree::Api::BaseController
   before_action :load_resource, only: [:show, :update, :destroy]
 
   def index
-    @collection = model_class.accessible_by(current_ability, :read).ransack(params[:q]).result.page(params[:page]).per(params[:per_page])
+    collection_scope = model_class.accessible_by(current_ability, :read)
+    if params[:ids]
+      ids = params[:ids].split(",").flatten
+      collection_scope = collection_scope.where(id: ids)
+    else
+      collection_scope = collection_scope.ransack(params[:q]).result
+    end
+
+    @collection = collection_scope.page(params[:page]).per(params[:per_page])
     instance_variable_set("@#{controller_name}", @collection)
 
     respond_with(@collection)

--- a/api/spec/controllers/spree/api/resource_controller_spec.rb
+++ b/api/spec/controllers/spree/api/resource_controller_spec.rb
@@ -59,10 +59,39 @@ module Spree
         it "returns widgets" do
           api_get :index, token: admin_user.spree_api_key
           expect(response).to be_success
-          expect(json_response['widgets']).to include(
+          expect(json_response['widgets']).to include(hash_including(
             'name' => 'a widget',
             'position' => 1
-          )
+          ))
+        end
+
+        context "specifying ids" do
+          let!(:widget2) { Widget.create!(name: "a widget") }
+
+          it "returns both widgets from comma separated string" do
+            api_get :index, ids: [widget.id, widget2.id].join(','), token: admin_user.spree_api_key
+            expect(response).to be_success
+            expect(json_response['widgets'].size).to eq 2
+          end
+
+          it "returns both widgets from multiple arguments" do
+            api_get :index, ids: [widget.id, widget2.id], token: admin_user.spree_api_key
+            expect(response).to be_success
+            expect(json_response['widgets'].size).to eq 2
+          end
+
+          it "returns one requested widgets" do
+            api_get :index, ids: widget2.id.to_s, token: admin_user.spree_api_key
+            expect(response).to be_success
+            expect(json_response['widgets'].size).to eq 1
+            expect(json_response['widgets'][0]['id']).to eq widget2.id
+          end
+
+          it "returns no widgets if empty" do
+            api_get :index, ids: '', token: admin_user.spree_api_key
+            expect(response).to be_success
+            expect(json_response['widgets']).to be_empty
+          end
         end
       end
     end

--- a/api/spec/test_views/spree/api/widgets/show.v1.rabl
+++ b/api/spec/test_views/spree/api/widgets/show.v1.rabl
@@ -1,2 +1,2 @@
 object @object
-attributes :name, :position
+attributes :id, :name, :position

--- a/backend/app/assets/javascripts/spree/backend/checkouts/edit.js
+++ b/backend/app/assets/javascripts/spree/backend/checkouts/edit.js
@@ -30,31 +30,35 @@ $(document).ready(function() {
       dropdownCssClass: 'customer_search',
       formatResult: formatCustomerResult,
       formatSelection: function (customer) {
-        $('#order_email').val(customer.email);
-        $('#user_id').val(customer.id);
-        $('#guest_checkout_true').prop("checked", false);
-        $('#guest_checkout_false').prop("checked", true);
-        $('#guest_checkout_false').prop("disabled", false);
-
-        var billAddress = customer.bill_address;
-        if(billAddress) {
-          $('#order_bill_address_attributes_firstname').val(billAddress.firstname);
-          $('#order_bill_address_attributes_lastname').val(billAddress.lastname);
-          $('#order_bill_address_attributes_address1').val(billAddress.address1);
-          $('#order_bill_address_attributes_address2').val(billAddress.address2);
-          $('#order_bill_address_attributes_city').val(billAddress.city);
-          $('#order_bill_address_attributes_zipcode').val(billAddress.zipcode);
-          $('#order_bill_address_attributes_phone').val(billAddress.phone);
-
-          $('#order_bill_address_attributes_country_id').select2("val", billAddress.country_id).promise().done(function () {
-            update_state('b', function () {
-              $('#order_bill_address_attributes_state_id').select2("val", billAddress.state_id);
-            });
-          });
-        }
         return Select2.util.escapeMarkup(customer.email);
       }
     })
+
+    $("#customer_search").on("select2-selecting", function(e) {
+      var customer = e.choice;
+      $('#order_email').val(customer.email);
+      $('#user_id').val(customer.id);
+      $('#guest_checkout_true').prop("checked", false);
+      $('#guest_checkout_false').prop("checked", true);
+      $('#guest_checkout_false').prop("disabled", false);
+
+      var billAddress = customer.bill_address;
+      if (billAddress) {
+        $('#order_bill_address_attributes_firstname').val(billAddress.firstname);
+        $('#order_bill_address_attributes_lastname').val(billAddress.lastname);
+        $('#order_bill_address_attributes_address1').val(billAddress.address1);
+        $('#order_bill_address_attributes_address2').val(billAddress.address2);
+        $('#order_bill_address_attributes_city').val(billAddress.city);
+        $('#order_bill_address_attributes_zipcode').val(billAddress.zipcode);
+        $('#order_bill_address_attributes_phone').val(billAddress.phone);
+
+        $('#order_bill_address_attributes_country_id').select2("val", billAddress.country_id).promise().done(function () {
+          update_state('b', function () {
+            $('#order_bill_address_attributes_state_id').select2("val", billAddress.state_id);
+          });
+        });
+      }
+    });
   }
 
   var order_use_billing_input = $('input#order_use_billing');

--- a/backend/app/assets/javascripts/spree/backend/checkouts/edit.js
+++ b/backend/app/assets/javascripts/spree/backend/checkouts/edit.js
@@ -14,17 +14,24 @@ $(document).ready(function() {
     $("#customer_search").select2({
       placeholder: Spree.translations.choose_a_customer,
       ajax: {
-        url: Spree.routes.user_search,
+        url: Spree.routes.users_api,
         params: { "headers": { "X-Spree-Token": Spree.api_key } },
         datatype: 'json',
         data: function(term, page) {
           return {
-            q: term,
-            token: Spree.api_key
+            q: {
+              m: 'or',
+              email_start: term,
+              addresses_firstname_start: term,
+              addresses_lastname_start: term
+            }
           }
         },
         results: function(data, page) {
-          return { results: data.users }
+          return {
+            results: data.users,
+            more: data.current_page < data.pages
+          }
         }
       },
       dropdownCssClass: 'customer_search',

--- a/backend/app/assets/javascripts/spree/backend/routes.js
+++ b/backend/app/assets/javascripts/spree/backend/routes.js
@@ -13,6 +13,7 @@ Spree.routes.taxon_products_api = Spree.pathFor('api/taxons/products')
 Spree.routes.taxons_search = Spree.pathFor('api/taxons')
 Spree.routes.user_search = Spree.pathFor('admin/search/users')
 Spree.routes.variants_api = Spree.pathFor('api/variants')
+Spree.routes.users_api = Spree.pathFor('api/users')
 
 Spree.routes.line_items_api = function(order_id) {
   return Spree.pathFor('api/orders/' + order_id + '/line_items')

--- a/backend/app/assets/javascripts/spree/backend/user_picker.js
+++ b/backend/app/assets/javascripts/spree/backend/user_picker.js
@@ -9,25 +9,28 @@ $.fn.userAutocomplete = function () {
     minimumInputLength: 1,
     multiple: true,
     initSelection: function (element, callback) {
-      $.get(Spree.routes.user_search, {
+      $.get(Spree.routes.users_api, {
         ids: element.val()
       }, function (data) {
         callback(data.users);
       });
     },
     ajax: {
-      url: Spree.routes.user_search,
+      url: Spree.routes.users_api,
       datatype: 'json',
       params: { "headers": { "X-Spree-Token": Spree.api_key } },
       data: function (term) {
         return {
-          q: term,
-          token: Spree.api_key
+          m: 'or',
+          email_start: term,
+          addresses_firstname_start: term,
+          addresses_lastname_start: term
         };
       },
       results: function (data) {
         return {
-          results: data.users
+          results: data.users,
+          more: data.current_page < data.pages
         };
       }
     },


### PR DESCRIPTION
Instead of using the custom `Admin::SearchController` (which was one of the subjects of the recent security patches) use the users route from the API. We're able to accomplish everything the existing custom route did through ransack.

As an added bonus, this adds pagination to the user picker.