### PR TITLE
Add {{admin_url}} handlebars helper to fix links when not mounted at /

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/handlebars_extensions.coffee
+++ b/backend/app/assets/javascripts/spree/backend/handlebars_extensions.coffee
@@ -7,3 +7,5 @@ Handlebars.registerHelper "t", (key)->
     console.error "No translation found for #{key}."
     key
 
+Handlebars.registerHelper "admin_url", ->
+  Spree.pathFor("admin")

--- a/backend/app/assets/javascripts/spree/backend/templates/taxons/_tree.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/taxons/_tree.hbs
@@ -5,7 +5,7 @@
       {{name}}
       <div class="actions right">
         <a href="#" class="js-taxon-add-child fa fa-plus icon_link no-text"></a>
-        <a href="/admin/taxonomies/{{taxonomy_id}}/taxons/{{id}}/edit" class="fa fa-edit icon_link no-text"></a>
+        <a href="{{admin_url}}/taxonomies/{{taxonomy_id}}/taxons/{{id}}/edit" class="fa fa-edit icon_link no-text"></a>
         <a href="#" class="js-taxon-delete fa fa-trash icon_link no-text"></a>
       </div>
     </div>


### PR DESCRIPTION
We might not be mounted at the root. We need a way in handlebars to reference routes relative to the admin root.

Fixes #884