### PR TITLE
Allow option_values_ids to be an array

### DIFF
--- a/api/spec/controllers/spree/api/variants_controller_spec.rb
+++ b/api/spec/controllers/spree/api/variants_controller_spec.rb
@@ -241,6 +241,14 @@ module Spree
         expect(variant.product.variants.count).to eq(1)
       end
 
+      it "creates new variants with nested option values" do
+        option_values = create_list(:option_value, 2)
+        expect do
+          api_post :create, variant: { sku: "12345",
+                                       option_value_ids: option_values.map(&:id) }
+        end.to change { Spree::OptionValuesVariant.count }.by(2)
+      end
+
       it "can update a variant" do
         api_put :update, id: variant.to_param, variant: { sku: "12345" }
         expect(response.status).to eq(200)

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -120,8 +120,8 @@ module Spree
 
     @@variant_attributes = [
       :name, :presentation, :cost_price, :lock_version,
-      :position, :option_value_ids, :track_inventory,
+      :position, :track_inventory,
       :product_id, :product, :option_values_attributes, :price,
-      :weight, :height, :width, :depth, :sku, :cost_currency, options: [:name, :value]]
+      :weight, :height, :width, :depth, :sku, :cost_currency, option_value_ids: [], options: [:name, :value]]
   end
 end


### PR DESCRIPTION
Previously the permitted variants on an attribute would only allow for a
scalar value.

This changes it to allow an array, but will have the side-effect of no
longer allowing a scalar to be set. I'd suggest this is a  pretty safe as
nobody should be sending _ids a single value, while we're fixing
something that is a bug.