### PR TITLE
Remove ShippingMethod.calculators override

### DIFF
--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -34,10 +34,6 @@ module Spree
       tracking_url.gsub(/:tracking/, ERB::Util.url_encode(tracking)) # :url_encode exists in 1.8.7 through 2.1.0
     end
 
-    def self.calculators
-      spree_calculators.send(model_name_without_spree_namespace).select{ |c| c < Spree::ShippingCalculator }
-    end
-
     # Some shipping methods are only meant to be set via backend
     def frontend?
       display_on != "back_end"

--- a/core/spec/models/spree/shipping_method_spec.rb
+++ b/core/spec/models/spree/shipping_method_spec.rb
@@ -6,20 +6,6 @@ end
 describe Spree::ShippingMethod, type: :model do
   let(:shipping_method){ create(:shipping_method) }
 
-  context 'calculators' do
-    it "Should reject calculators that don't inherit from Spree::ShippingCalculator" do
-      allow(Spree::ShippingMethod).to receive_message_chain(:spree_calculators, :shipping_methods).and_return([
-        Spree::Calculator::Shipping::FlatPercentItemTotal,
-        Spree::Calculator::Shipping::PriceSack,
-        Spree::Calculator::DefaultTax,
-        DummyShippingCalculator # included as regression test for https://github.com/spree/spree/issues/3109
-      ])
-
-      expect(Spree::ShippingMethod.calculators).to eq([Spree::Calculator::Shipping::FlatPercentItemTotal, Spree::Calculator::Shipping::PriceSack, DummyShippingCalculator])
-      expect(Spree::ShippingMethod.calculators).not_to eq([Spree::Calculator::DefaultTax])
-    end
-  end
-
   # Regression test for https://github.com/spree/spree/issues/4492
   context "#shipments" do
     let!(:shipping_method) { create(:shipping_method) }


### PR DESCRIPTION
This was overriding the default implementation in `Spree::CalculatedAdjustments`, to select only calculators which were a subset of `Spree::ShippingCalculator`.

There is no reason to do this, as calculators are configured on `Rails.application.config.spree.calculators.shipping_methods`

Having this caused shipping calculators to disappear if code reloading caused `ShippingCalculator` to be reloaded.