### PR TITLE
Do not round pre-tax amounts

### DIFF
--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -97,7 +97,7 @@ module Spree
         pre_tax_amount /= (1 + included_rates.map(&:amount).sum)
       end
 
-      item.update_column(:pre_tax_amount, pre_tax_amount.round(2))
+      item.update_column(:pre_tax_amount, pre_tax_amount)
     end
 
     # Creates necessary tax adjustments for the order.

--- a/core/spec/models/spree/tax/taxation_integration_spec.rb
+++ b/core/spec/models/spree/tax/taxation_integration_spec.rb
@@ -253,7 +253,7 @@ RSpec.describe "Taxation system integration tests" do
         end
 
         it 'has a constant amount pre tax' do
-          expect(line_item.pre_tax_amount).to eq(18.69)
+          expect(line_item.discounted_amount - line_item.included_tax_total).to eq(18.69)
         end
       end
 
@@ -294,7 +294,7 @@ RSpec.describe "Taxation system integration tests" do
         end
 
         it 'has a constant amount pre tax' do
-          expect(line_item.pre_tax_amount).to eq(25.21)
+          expect(line_item.discounted_amount - line_item.included_tax_total).to eq(25.21)
         end
       end
 
@@ -338,7 +338,7 @@ RSpec.describe "Taxation system integration tests" do
 
         it 'has a constant amount pre tax' do
           pending 'but it changes to 8.06, because Spree thinks both VATs apply'
-          expect(line_item.pre_tax_amount).to eq(8.40)
+          expect(line_item.discounted_amount - line_item.included_tax_total).to eq(8.40)
         end
       end
 
@@ -397,7 +397,7 @@ RSpec.describe "Taxation system integration tests" do
         end
 
         it 'has a constant amount pre tax' do
-          expect(line_item.pre_tax_amount).to eq(18.69)
+          expect(line_item.discounted_amount - line_item.included_tax_total).to eq(18.69)
         end
       end
     end
@@ -433,7 +433,8 @@ RSpec.describe "Taxation system integration tests" do
         end
 
         it 'has a constant amount pre tax' do
-          expect(line_item.pre_tax_amount).to eq(18.69)
+          pending 'But it has a discount that abuses the additional tax total'
+          expect(line_item.discounted_amount - line_item.included_tax_total).to eq(18.69)
         end
 
         context 'an order with a book and a shipment' do
@@ -480,7 +481,8 @@ RSpec.describe "Taxation system integration tests" do
         end
 
         it 'has a constant amount pre tax' do
-          expect(line_item.pre_tax_amount).to eq(25.21)
+          pending 'But it has a discount that abuses the additional tax total'
+          expect(line_item.discounted_amount - line_item.included_tax_total).to eq(25.21)
         end
 
         context 'an order with a sweater and a shipment' do
@@ -527,7 +529,8 @@ RSpec.describe "Taxation system integration tests" do
         end
 
         it 'has a constant amount pre tax' do
-          expect(line_item.pre_tax_amount).to eq(8.40)
+          pending 'But it has a discount that abuses the additional tax total'
+          expect(line_item.discounted_amount - line_item.included_tax_total).to eq(8.40)
         end
       end
 


### PR DESCRIPTION
When rounding the pre tax amount for VAT calculations,
we run into rounding errors on creating the adjustment.

Example: We want the tax amount for $16.00 at 19% VAT
16.00 / 1.19 = 13.4453 ~ 13.45 --> 2.55 VAT
13.45 * 1.19 = 16.0055 ~ 16.01 --> 2.56 VAT (wrong wrong wrong)

Not rounding the pre tax amount fixes this rounding error.

As usual with rounding, there will still be cases where this does
not work, depending on how many digits our database stores. They
will be much rarer, though.

There is a failing test for this, but it's pending for a different
reason - in the taxation integration spec, we have the aforementioned
rounding error, but it doesn't show up because shipping rates are not
tax adjusted because of a missing `contains?` check.