### PR TITLE
Specify RSpec as default testing framework

### DIFF
--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -8,6 +8,10 @@ module Spree
         load File.join(root, "lib", "tasks", "exchanges.rake")
       end
 
+      config.generators do |g|
+        g.test_framework :rspec
+      end
+
       initializer "spree.environment", before: :load_config_initializers do |app|
         app.config.spree = Spree::Core::Environment.new
         Spree::Config = app.config.spree.preferences # legacy access


### PR DESCRIPTION
This commit changes the behaviour of `rails g model`, such that instead
of `test-unit` style spec files, you'll get `rspec` style spec templates.