### PR TITLE
Add Spree::ShippingRateTax model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 ## Solidus 1.3.0 (unreleased)
 
+*   Persist tax estimations on shipping rates
+
+    Previously, shipping rate taxes were calculated on the fly every time
+    a shipping rate would be displayed. Now, shipping rate taxes are stored
+    on a dedicated table to look up.
+
+    There is a new model Spree::ShippingRateTax where the taxes are stored,
+    and a new Spree::Tax::ShippingRateTaxer that builds those taxes from within
+    Spree::Stock::Estimator.
+
+    The shipping rate taxer class can be exchanged for a custom estimator class
+    using the new Spree::Appconfiguration.shipping_rate_taxer_class preference.
+
+    https://github.com/solidusio/solidus/pull/904
+
 *   Deprecate setting a line item's currency by hand
 
     Previously, a line item's currency could be set directly, and differently from the line item's

--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -301,6 +301,11 @@ module Spree
       @shipping_rate_selector_class ||= Spree::Stock::ShippingRateSelector
     end
 
+    attr_writer :shipping_rate_taxer_class
+    def shipping_rate_taxer_class
+      @shipping_rate_taxer_class ||= Spree::Tax::ShippingRateTaxer
+    end
+
     # Allows providing your own Mailer for shipped cartons.
     #
     # @!attribute [rw] carton_shipped_email_class

--- a/core/app/models/spree/shipping_rate.rb
+++ b/core/app/models/spree/shipping_rate.rb
@@ -3,6 +3,10 @@ module Spree
     belongs_to :shipment, class_name: 'Spree::Shipment'
     belongs_to :shipping_method, -> { with_deleted }, class_name: 'Spree::ShippingMethod', inverse_of: :shipping_rates
     belongs_to :tax_rate, -> { with_deleted }, class_name: 'Spree::TaxRate'
+    has_many :taxes,
+             class_name: "Spree::ShippingRateTax",
+             foreign_key: "shipping_rate_id",
+             dependent: :destroy
 
     delegate :order, :currency, to: :shipment
     delegate :name, :tax_category, to: :shipping_method

--- a/core/app/models/spree/shipping_rate.rb
+++ b/core/app/models/spree/shipping_rate.rb
@@ -2,7 +2,7 @@ module Spree
   class ShippingRate < Spree::Base
     belongs_to :shipment, class_name: 'Spree::Shipment'
     belongs_to :shipping_method, -> { with_deleted }, class_name: 'Spree::ShippingMethod', inverse_of: :shipping_rates
-    belongs_to :tax_rate, -> { with_deleted }, class_name: 'Spree::TaxRate'
+
     has_many :taxes,
              class_name: "Spree::ShippingRateTax",
              foreign_key: "shipping_rate_id",
@@ -18,10 +18,6 @@ module Spree
     extend DisplayMoney
     money_methods :amount
 
-    def calculate_tax_amount
-      tax_rate.compute_amount(self)
-    end
-
     def display_price
       price = display_amount.to_s
 
@@ -35,10 +31,6 @@ module Spree
                explanations: tax_explanations
     end
     alias_method :display_cost, :display_price
-
-    def display_tax_amount(tax_amount)
-      Spree::Money.new(tax_amount, currency: currency)
-    end
 
     private
 

--- a/core/app/models/spree/shipping_rate.rb
+++ b/core/app/models/spree/shipping_rate.rb
@@ -24,29 +24,26 @@ module Spree
 
     def display_price
       price = display_amount.to_s
-      if tax_rate
-        tax_amount = calculate_tax_amount
-        if tax_amount != 0
-          if tax_rate.included_in_price?
-            if tax_amount > 0
-              amount = "#{display_tax_amount(tax_amount)} #{tax_rate.name}"
-              price += " (#{Spree.t(:incl)} #{amount})"
-            else
-              amount = "#{display_tax_amount(tax_amount * -1)} #{tax_rate.name}"
-              price += " (#{Spree.t(:excl)} #{amount})"
-            end
-          else
-            amount = "#{display_tax_amount(tax_amount)} #{tax_rate.name}"
-            price += " (+ #{amount})"
-          end
-        end
-      end
-      price
+
+      return price if taxes.empty? || amount == 0
+
+      tax_explanations = taxes.map(&:label).join(tax_label_separator)
+
+      Spree.t :display_price_with_explanations,
+               scope: 'shipping_rate.display_price',
+               price: price,
+               explanations: tax_explanations
     end
     alias_method :display_cost, :display_price
 
     def display_tax_amount(tax_amount)
       Spree::Money.new(tax_amount, currency: currency)
+    end
+
+    private
+
+    def tax_label_separator
+      Spree.t :tax_label_separator, scope: 'shipping_rate.display_price'
     end
   end
 end

--- a/core/app/models/spree/shipping_rate_tax.rb
+++ b/core/app/models/spree/shipping_rate_tax.rb
@@ -1,0 +1,6 @@
+module Spree
+  class ShippingRateTax < ActiveRecord::Base
+    belongs_to :shipping_rate, class_name: "Spree::ShippingRate"
+    belongs_to :tax_rate, class_name: "Spree::TaxRate"
+  end
+end

--- a/core/app/models/spree/shipping_rate_tax.rb
+++ b/core/app/models/spree/shipping_rate_tax.rb
@@ -2,5 +2,9 @@ module Spree
   class ShippingRateTax < ActiveRecord::Base
     belongs_to :shipping_rate, class_name: "Spree::ShippingRate"
     belongs_to :tax_rate, class_name: "Spree::TaxRate"
+
+    def absolute_amount
+      amount.abs
+    end
   end
 end

--- a/core/app/models/spree/shipping_rate_tax.rb
+++ b/core/app/models/spree/shipping_rate_tax.rb
@@ -3,6 +3,9 @@ module Spree
     belongs_to :shipping_rate, class_name: "Spree::ShippingRate"
     belongs_to :tax_rate, class_name: "Spree::TaxRate"
 
+    extend DisplayMoney
+    money_methods :absolute_amount
+
     def absolute_amount
       amount.abs
     end

--- a/core/app/models/spree/shipping_rate_tax.rb
+++ b/core/app/models/spree/shipping_rate_tax.rb
@@ -6,6 +6,8 @@ module Spree
     extend DisplayMoney
     money_methods :absolute_amount
 
+    delegate :currency, to: :shipping_rate, allow_nil: true
+
     def absolute_amount
       amount.abs
     end

--- a/core/app/models/spree/shipping_rate_tax.rb
+++ b/core/app/models/spree/shipping_rate_tax.rb
@@ -8,8 +8,29 @@ module Spree
 
     delegate :currency, to: :shipping_rate, allow_nil: true
 
+    def label
+      Spree.t translation_key,
+        scope: 'shipping_rate_tax.label',
+        amount: display_absolute_amount,
+        tax_rate_name: tax_rate.name
+    end
+
     def absolute_amount
       amount.abs
+    end
+
+    private
+
+    def translation_key
+      if tax_rate.included_in_price?
+        if amount > 0
+           :vat
+         else
+           :vat_refund
+         end
+       else
+         :sales_tax
+      end
     end
   end
 end

--- a/core/app/models/spree/shipping_rate_tax.rb
+++ b/core/app/models/spree/shipping_rate_tax.rb
@@ -1,4 +1,9 @@
 module Spree
+  # Used to persist shipping rate tax estimations.
+  # @attr [Spree::ShippingRate] shipping_rate The shipping rate to be taxed
+  # @attr [Spree::TaxRate] tax_rate The tax rate used to calculate the tax amount
+  # @since 1.3.0
+  # @see Spree::Tax::ShippingRateTaxer
   class ShippingRateTax < ActiveRecord::Base
     belongs_to :shipping_rate, class_name: "Spree::ShippingRate"
     belongs_to :tax_rate, class_name: "Spree::TaxRate"

--- a/core/app/models/spree/stock/estimator.rb
+++ b/core/app/models/spree/stock/estimator.rb
@@ -49,9 +49,8 @@ module Spree
               shipment: package.shipment
             )
             rate.tax_rate = tax_rate if tax_rate
+            Spree::Tax::ShippingRateTaxer.new.tax(rate)
           end
-
-          Spree::Tax::ShippingRateTaxer.new.tax(rate)
         end.compact
       end
 

--- a/core/app/models/spree/stock/estimator.rb
+++ b/core/app/models/spree/stock/estimator.rb
@@ -51,7 +51,7 @@ module Spree
             rate.tax_rate = tax_rate if tax_rate
           end
 
-          rate
+          Spree::Tax::ShippingRateTaxer.new.tax(rate)
         end.compact
       end
 

--- a/core/app/models/spree/stock/estimator.rb
+++ b/core/app/models/spree/stock/estimator.rb
@@ -33,22 +33,11 @@ module Spree
       def calculate_shipping_rates(package)
         shipping_methods(package).map do |shipping_method|
           cost = shipping_method.calculator.compute(package)
-          tax_category = shipping_method.tax_category
-          if tax_category
-            tax_rate = tax_category.tax_rates.detect do |rate|
-              # If the rate's zone matches the order's zone, a positive adjustment will be applied.
-              # If the rate is from the default tax zone, then a negative adjustment will be applied.
-              # See the tests in shipping_rate_spec.rb for an example of this.d
-              rate.zone == package.shipment.order.tax_zone || rate.zone.default_tax?
-            end
-          end
-
           if cost
             rate = shipping_method.shipping_rates.new(
               cost: cost,
               shipment: package.shipment
             )
-            rate.tax_rate = tax_rate if tax_rate
             Spree::Tax::ShippingRateTaxer.new.tax(rate)
           end
         end.compact

--- a/core/app/models/spree/stock/estimator.rb
+++ b/core/app/models/spree/stock/estimator.rb
@@ -38,7 +38,7 @@ module Spree
               cost: cost,
               shipment: package.shipment
             )
-            Spree::Tax::ShippingRateTaxer.new.tax(rate)
+            Spree::Config.shipping_rate_taxer_class.new.tax(rate)
           end
         end.compact
       end

--- a/core/app/models/spree/tax/shipping_rate_taxer.rb
+++ b/core/app/models/spree/tax/shipping_rate_taxer.rb
@@ -1,8 +1,24 @@
 module Spree
   module Tax
     class ShippingRateTaxer
+      include TaxHelpers
+
       def tax(shipping_rate)
+        tax_rates_for_shipping_rate(shipping_rate).each do |tax_rate|
+          shipping_rate.taxes.build(
+            amount: tax_rate.compute_amount(shipping_rate),
+            tax_rate: tax_rate
+          )
+        end
         shipping_rate
+      end
+
+      private
+
+      def tax_rates_for_shipping_rate(shipping_rate)
+        applicable_rates(shipping_rate.order).select do |tax_rate|
+          tax_rate.tax_category == shipping_rate.tax_category
+        end
       end
     end
   end

--- a/core/app/models/spree/tax/shipping_rate_taxer.rb
+++ b/core/app/models/spree/tax/shipping_rate_taxer.rb
@@ -1,0 +1,9 @@
+module Spree
+  module Tax
+    class ShippingRateTaxer
+      def tax(shipping_rate)
+        shipping_rate
+      end
+    end
+  end
+end

--- a/core/app/models/spree/tax/shipping_rate_taxer.rb
+++ b/core/app/models/spree/tax/shipping_rate_taxer.rb
@@ -1,8 +1,14 @@
 module Spree
   module Tax
+    # Used to build shipping rate taxes
     class ShippingRateTaxer
       include TaxHelpers
 
+      # Build shipping rate taxes for a shipping rate
+      # Modifies the passed-in shipping rate with associated shipping rate taxes.
+      # @param [Spree::ShippingRate] shipping_rate The shipping rate to add taxes to.
+      #   This parameter will be modified.
+      # @return [Spree::ShippingRate] The shipping rate with associated tax objects
       def tax(shipping_rate)
         tax_rates_for_shipping_rate(shipping_rate).each do |tax_rate|
           shipping_rate.taxes.build(

--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -22,6 +22,7 @@ module Spree
     belongs_to :tax_category, class_name: "Spree::TaxCategory", inverse_of: :tax_rates
 
     has_many :adjustments, as: :source
+    has_many :shipping_rate_taxes, class_name: "Spree::ShippingRateTax"
 
     validates :amount, presence: true, numericality: true
     validates :tax_category_id, presence: true

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -212,6 +212,11 @@ en:
         name: Name
         service_level: Service Level
         tracking_url: Tracking URL
+      spree/shipping_rate:
+        label: Label
+        tax_rate: Tax Rate
+        shipping_rate: Shipping Rate
+        amount: Amount
       spree/state:
         abbr: Abbreviation
         name: Name

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1646,6 +1646,10 @@ en:
     shipping_method: Shipping Method
     shipping_methods: Shipping Methods
     shipping_price_sack: Price sack
+    shipping_rate:
+      display_price:
+        display_price_with_explanations: "%{price} (%{explanations})"
+        tax_label_separator: ", "
     shipping_rate_tax:
       label:
         sales_tax: "+ %{amount} %{tax_rate_name}"

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1646,6 +1646,11 @@ en:
     shipping_method: Shipping Method
     shipping_methods: Shipping Methods
     shipping_price_sack: Price sack
+    shipping_rate_tax:
+      label:
+        sales_tax: "+ %{amount} %{tax_rate_name}"
+        vat: "incl. %{amount} %{tax_rate_name}"
+        vat_refund: "excl. %{amount} %{tax_rate_name}"
     shipping_total: Shipping total
     shop_by_taxonomy: Shop by %{taxonomy}
     shopping_cart: Shopping Cart

--- a/core/db/migrate/20160224201413_create_spree_shipping_rate_taxes.rb
+++ b/core/db/migrate/20160224201413_create_spree_shipping_rate_taxes.rb
@@ -1,0 +1,11 @@
+class CreateSpreeShippingRateTaxes < ActiveRecord::Migration
+  def change
+    create_table :spree_shipping_rate_taxes do |t|
+      t.decimal :amount, precision: 8, scale: 2, default: 0.0, null: false
+      t.references :tax_rate, index: true
+      t.references :shipping_rate, index: true
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/core/db/migrate/20160225152313_remove_tax_rate_from_shipping_rate.rb
+++ b/core/db/migrate/20160225152313_remove_tax_rate_from_shipping_rate.rb
@@ -1,0 +1,40 @@
+class RemoveTaxRateFromShippingRate < ActiveRecord::Migration
+  class Spree::ShippingRate < Spree::Base; end
+  class Spree::TaxRate < Spree::Base
+    has_one :calculator, class_name: "Spree::Calculator", as: :calculable, inverse_of: :calculable, dependent: :destroy, autosave: true
+    def compute_amount(item)
+      calculator.compute(item)
+    end
+  end
+
+  def up
+    say_with_time "Pre-calculating taxes for existing shipping rates" do
+      Spree::ShippingRate.find_each do |shipping_rate|
+        tax_rate_id = shipping_rate.tax_rate_id
+        if tax_rate_id
+          tax_rate = Spree::TaxRate.unscoped.find_by(shipping_rate.tax_rate_id)
+          shipping_rate.taxes.create(
+            tax_rate: tax_rate,
+            amount: tax_rate.compute_amount(shipping_rate)
+          )
+        end
+      end
+    end
+
+    remove_column :spree_shipping_rates, :tax_rate_id
+  end
+
+  def down
+    add_reference :spree_shipping_rates, :tax_rate, index: true, foreign_key: true
+    say_with_time "Attaching a tax rate to shipping rates" do
+      Spree::ShippingRate.find_each do |shipping_rate|
+        shipping_taxes = Spree::ShippingRateTax.where(shipping_rate_id: shipping_rate.id)
+        # We can only use one tax rate, so let's take the biggest.
+        selected_tax = shipping_taxes.sort_by(&:amount).last
+        if selected_tax
+          shipping_rate.update(tax_rate_id: tax_rate_id)
+        end
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/shipping_rate_spec.rb
+++ b/core/spec/models/spree/shipping_rate_spec.rb
@@ -170,25 +170,6 @@ describe Spree::ShippingRate, type: :model do
     end
   end
 
-  context "#tax_rate" do
-    let!(:tax_rate) { create(:tax_rate) }
-
-    before do
-      shipping_rate.tax_rate = tax_rate
-    end
-
-    it "can be retrieved" do
-      expect(shipping_rate.tax_rate.reload).to eq(tax_rate)
-    end
-
-    it "can be retrieved even when deleted" do
-      tax_rate.update_column(:deleted_at, Time.current)
-      shipping_rate.save
-      shipping_rate.reload
-      expect(shipping_rate.tax_rate).to eq(tax_rate)
-    end
-  end
-
   context "#shipping_method_code" do
     before do
       shipping_method.code = "THE_CODE"

--- a/core/spec/models/spree/shipping_rate_spec.rb
+++ b/core/spec/models/spree/shipping_rate_spec.rb
@@ -8,11 +8,15 @@ describe Spree::ShippingRate, type: :model do
   let(:tax_category) { create(:tax_category) }
   let(:shipment) { create(:shipment) }
   let(:shipping_method) { create(:shipping_method, tax_category: tax_category) }
-  let(:shipping_rate) {
-    Spree::ShippingRate.new(shipment: shipment,
-                                                shipping_method: shipping_method,
-                                                cost: 10)
-  }
+  subject(:shipping_rate) do
+    Spree::ShippingRate.new(
+      shipment: shipment,
+      shipping_method: shipping_method,
+      cost: 10
+    )
+  end
+
+  it { is_expected.to respond_to(:taxes) }
 
   context "#display_price" do
     context "when tax included in price" do

--- a/core/spec/models/spree/shipping_rate_tax_spec.rb
+++ b/core/spec/models/spree/shipping_rate_tax_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+module Spree
+  RSpec.describe ShippingRateTax, type: :model do
+    subject(:shipping_rate_tax) { described_class.new }
+
+    it { is_expected.to respond_to(:amount) }
+    it { is_expected.to respond_to(:tax_rate) }
+    it { is_expected.to respond_to(:shipping_rate) }
+  end
+end

--- a/core/spec/models/spree/shipping_rate_tax_spec.rb
+++ b/core/spec/models/spree/shipping_rate_tax_spec.rb
@@ -49,5 +49,35 @@ module Spree
         end
       end
     end
+
+    describe '#label' do
+      subject(:shipping_rate_tax) { described_class.new(amount: amount, tax_rate: tax_rate).label }
+
+      context 'with an included tax rate' do
+        let(:tax_rate) { build_stubbed(:tax_rate, included_in_price: true, name: "VAT") }
+        context 'with a negative amount' do
+          let(:amount) { -2.2 }
+          it 'labels a refund' do
+            expect(subject).to eq("excl. $2.20 VAT")
+          end
+        end
+
+        context 'with a positive amount' do
+          let(:amount) { 2.2 }
+          it 'labels an included tax' do
+            expect(subject).to eq("incl. $2.20 VAT")
+          end
+        end
+      end
+
+      context 'with an additional tax rate' do
+        let(:tax_rate) { build_stubbed(:tax_rate, included_in_price: false, name: "Sales Tax") }
+        let(:amount) { 2.2 }
+
+        it 'labels an additional tax' do
+          expect(subject).to eq("+ $2.20 Sales Tax")
+        end
+      end
+    end
   end
 end

--- a/core/spec/models/spree/shipping_rate_tax_spec.rb
+++ b/core/spec/models/spree/shipping_rate_tax_spec.rb
@@ -22,5 +22,11 @@ module Spree
         it { is_expected.to eq(19) }
       end
     end
+
+    describe 'display_absolute_amount' do
+      subject(:shipping_rate_tax) { described_class.new(amount: 10).display_absolute_amount.to_s }
+
+      it { is_expected.to eq("$10.00") }
+    end
   end
 end

--- a/core/spec/models/spree/shipping_rate_tax_spec.rb
+++ b/core/spec/models/spree/shipping_rate_tax_spec.rb
@@ -28,5 +28,26 @@ module Spree
 
       it { is_expected.to eq("$10.00") }
     end
+
+    describe '#currency' do
+      subject(:shipping_rate_tax) { described_class.new(amount: 10, shipping_rate: shipping_rate).currency }
+
+      context 'when we have a shipping rate' do
+        let(:shipping_rate) { build_stubbed(:shipping_rate) }
+
+        it 'delegates the call to the shipment' do
+          expect(shipping_rate).to receive(:currency)
+          subject
+        end
+      end
+
+      context "when we don't have a shipping rate" do
+        let(:shipping_rate) { nil }
+
+        it 'is nil' do
+          expect(subject).to eq(nil)
+        end
+      end
+    end
   end
 end

--- a/core/spec/models/spree/shipping_rate_tax_spec.rb
+++ b/core/spec/models/spree/shipping_rate_tax_spec.rb
@@ -7,5 +7,20 @@ module Spree
     it { is_expected.to respond_to(:amount) }
     it { is_expected.to respond_to(:tax_rate) }
     it { is_expected.to respond_to(:shipping_rate) }
+
+    describe 'absolute_amount' do
+      subject(:shipping_rate_tax) { described_class.new(amount: amount).absolute_amount }
+
+      context 'with a negative amount' do
+        let(:amount) { -19 }
+
+        it { is_expected.to eq(19) }
+      end
+
+      context 'with a positive amount' do
+        let(:amount) { 19 }
+        it { is_expected.to eq(19) }
+      end
+    end
   end
 end

--- a/core/spec/models/spree/stock/estimator_spec.rb
+++ b/core/spec/models/spree/stock/estimator_spec.rb
@@ -185,6 +185,24 @@ module Spree
 
           Spree::Config.shipping_rate_sorter_class = nil
         end
+
+        it 'uses the configured shipping rate taxer' do
+          class Spree::Tax::TestTaxer
+            def initialize
+            end
+
+            def tax(_)
+              Spree::ShippingRate.new
+            end
+          end
+          Spree::Config.shipping_rate_taxer_class = Spree::Tax::TestTaxer
+
+          shipping_rate = Spree::ShippingRate.new
+          allow(Spree::ShippingRate).to receive(:new).and_return(shipping_rate)
+
+          expect(Spree::Tax::TestTaxer).to receive(:new).and_call_original
+          subject.shipping_rates(package)
+        end
       end
     end
   end

--- a/core/spec/models/spree/stock/estimator_spec.rb
+++ b/core/spec/models/spree/stock/estimator_spec.rb
@@ -148,7 +148,7 @@ module Spree
 
           it "links the shipping rate and the tax rate" do
             shipping_rates = subject.shipping_rates(package)
-            expect(shipping_rates.first.tax_rate).to eq(tax_rate)
+            expect(shipping_rates.first.taxes.first.tax_rate).to eq(tax_rate)
           end
         end
 

--- a/core/spec/models/spree/stock/estimator_spec.rb
+++ b/core/spec/models/spree/stock/estimator_spec.rb
@@ -153,7 +153,7 @@ module Spree
         end
 
         it 'uses the configured shipping rate selector' do
-          shipping_rate = Spree::ShippingRate.new
+          shipping_rate = build(:shipping_rate)
           allow(Spree::ShippingRate).to receive(:new).and_return(shipping_rate)
 
           selector_class = Class.new do

--- a/core/spec/models/spree/tax/shipping_rate_taxer_spec.rb
+++ b/core/spec/models/spree/tax/shipping_rate_taxer_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Spree::Tax::ShippingRateTaxer do
+  let(:shipping_rate) { build_stubbed(:shipping_rate) }
+
+  subject(:taxer) { described_class.new(shipping_rate) }
+
+  describe '#tax' do
+    subject(:taxer) { described_class.new.tax(shipping_rate) }
+
+    context 'with no matching tax rates' do
+      it 'returns the object' do
+        expect(subject).to eq(shipping_rate)
+        expect(subject.taxes).to eq([])
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/tax/shipping_rate_taxer_spec.rb
+++ b/core/spec/models/spree/tax/shipping_rate_taxer_spec.rb
@@ -14,5 +14,37 @@ describe Spree::Tax::ShippingRateTaxer do
         expect(subject.taxes).to eq([])
       end
     end
+
+    context 'with tax rates' do
+      let(:ship_address) { create :address }
+      let(:tax_category) { create :tax_category }
+      let(:order) { create :order, ship_address: ship_address }
+      let(:shipment) { create :shipment, order: order }
+      let!(:shipping_method) { create :shipping_method, tax_category: tax_category, zones: [zone] }
+      let(:zone) { create :zone, countries: [ship_address.country] }
+      let!(:tax_rate_one) { create :tax_rate, tax_category: tax_category, zone: zone, amount: 0.1 }
+      let!(:tax_rate_two) { create :tax_rate, tax_category: tax_category, zone: zone, amount: 0.2 }
+      let!(:non_applicable_rate) { create :tax_rate, zone: zone }
+      let(:shipping_rate) { create :shipping_rate, cost: 10, shipping_method: shipping_method }
+
+      it 'builds a shipping rate tax for every tax rate' do
+        expect(subject.taxes.length).to eq(2)
+        expect(subject.taxes.map(&:tax_rate)).to include(tax_rate_one)
+        expect(subject.taxes.map(&:tax_rate)).to include(tax_rate_two)
+        # This rate has a different tax category.
+        expect(subject.taxes.map(&:tax_rate)).not_to include(non_applicable_rate)
+      end
+
+      it 'will produce a shipping rate that, when saved, also saves the taxes' do
+        expect { subject.save }.to change(Spree::ShippingRateTax, :count).by(2)
+      end
+
+      it 'will produce a shipping rate with correct taxes' do
+        tax_one = subject.taxes.detect { |tax| tax.tax_rate == tax_rate_one }
+        tax_two = subject.taxes.detect { |tax| tax.tax_rate == tax_rate_two }
+        expect(tax_one.amount).to eq(shipping_rate.cost * tax_rate_one.amount)
+        expect(tax_two.amount).to eq(shipping_rate.cost * tax_rate_two.amount)
+      end
+    end
   end
 end

--- a/core/spec/models/spree/tax/taxation_integration_spec.rb
+++ b/core/spec/models/spree/tax/taxation_integration_spec.rb
@@ -150,8 +150,7 @@ RSpec.describe "Taxation system integration tests" do
         end
 
         it 'has a shipping rate that correctly reflects the shipment' do
-          pending 'since no tax created, no correct display price'
-          expect(shipping_rate.display_price).to eq("$8.00 (incl. $0.52 German VAT)")
+          expect(shipping_rate.display_price).to eq("$8.00 (incl. $0.52 German reduced VAT)")
         end
       end
 
@@ -185,7 +184,6 @@ RSpec.describe "Taxation system integration tests" do
         end
 
         it 'has a shipping rate that correctly reflects the shipment' do
-          pending 'since no tax created, no correct display price'
           expect(shipping_rate.display_price).to eq("$16.00 (incl. $2.55 German VAT)")
         end
       end
@@ -266,8 +264,7 @@ RSpec.describe "Taxation system integration tests" do
         end
 
         it 'has a shipping rate that correctly reflects the shipment' do
-          pending 'since no tax created, no correct display price'
-          expect(shipping_rate.display_price).to eq("$8.00 (incl. $0.52 German VAT)")
+          expect(shipping_rate.display_price).to eq("$8.00 (incl. $0.52 German reduced VAT)")
         end
       end
 
@@ -305,7 +302,6 @@ RSpec.describe "Taxation system integration tests" do
         end
 
         it 'has a shipping rate that correctly reflects the shipment' do
-          pending 'since no tax created, no correct display price'
           expect(shipping_rate.display_price).to eq("$16.00 (incl. $2.55 German VAT)")
         end
       end
@@ -349,7 +345,7 @@ RSpec.describe "Taxation system integration tests" do
         end
 
         it 'has a shipping rate that correctly reflects the shipment' do
-          pending 'since no tax created, no correct display price'
+          pending 'But the shipping rate is not adjusted'
           expect(shipping_rate.display_price).to eq("$2.08 (incl. $0.40 Romanian VAT)")
         end
       end
@@ -675,8 +671,9 @@ RSpec.describe "Taxation system integration tests" do
         end
 
         it 'has a shipping rate that correctly reflects the shipment' do
-          pending 'since no tax created, no correct display price'
-          expect(shipping_rate.display_price).to eq("$8.00 (+ $0.80 Federal Sales Tax, + $0.40 New York Sales Tax)")
+          expect(shipping_rate.display_price).to include("$8.00")
+          expect(shipping_rate.display_price).to include("+ $0.80 Federal Sales Tax")
+          expect(shipping_rate.display_price).to include("+ $0.40 New York Sales Tax")
         end
       end
 
@@ -770,7 +767,6 @@ RSpec.describe "Taxation system integration tests" do
         end
 
         it 'has a shipping rate that correctly reflects the shipment' do
-          pending 'since no tax created, no correct display price'
           expect(shipping_rate.display_price).to eq("$2.00 (+ $0.40 Federal Sales Tax)")
         end
       end

--- a/core/spec/models/spree/tax_rate_spec.rb
+++ b/core/spec/models/spree/tax_rate_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe Spree::TaxRate, type: :model do
+  it { is_expected.to respond_to(:shipping_rate_taxes) }
+
   context '.for_address' do
     let(:germany) { create(:country, iso: "DE") }
     let(:germany_zone) { create(:zone, countries: [germany]) }


### PR DESCRIPTION
Previously, shipping rate taxes were calculated on the fly every time
a shipping rate would be displayed. Now, shipping rate taxes are stored
on a dedicated table to look up.

There is a new model Spree::ShippingRateTax where the taxes are stored,
and a new Spree::Tax::ShippingRateTaxer that builds those taxes from within
Spree::Stock::Estimator.

The shipping rate taxer class can be exchanged for a custom estimator class
using the new Spree::Appconfiguration.shipping_rate_taxer_class preference.


