### PR TITLE
Change requirements for rejecting an option value

### DIFF
--- a/core/app/models/spree/option_type.rb
+++ b/core/app/models/spree/option_type.rb
@@ -21,7 +21,7 @@ module Spree
 
     default_scope -> { order(:position) }
 
-    accepts_nested_attributes_for :option_values, reject_if: lambda { |ov| ov[:name].blank? || ov[:presentation].blank? }, allow_destroy: true
+    accepts_nested_attributes_for :option_values, reject_if: lambda { |ov| ov[:name].blank? && ov[:presentation].blank? }, allow_destroy: true
 
     after_touch :touch_all_products
     after_save :touch_all_products


### PR DESCRIPTION
Before if either field was blank it would be rejected by the option type model.  This led to a confusing behaviour where you could have one field filled in and the other blank and try to update and be told it updated successfully while it lost the option type you had started without telling you that.  Now this will throw an error if you try that telling you that the option type did not save.  However if both fields are blank it will just reject the option type.

Fixes #859 