### PR TITLE
Remove class="hidden" for state input elements

### DIFF
--- a/frontend/app/assets/javascripts/spree/frontend/checkout/address.js.coffee
+++ b/frontend/app/assets/javascripts/spree/frontend/checkout/address.js.coffee
@@ -52,7 +52,6 @@ $ ->
         else
           stateSelect.removeClass('required')
           stateSpanRequired.hide()
-        stateSelect.removeClass('hidden')
         stateInput.removeClass('required')
       else
         stateSelect.hide().prop 'disabled', true
@@ -66,7 +65,6 @@ $ ->
           stateInput.removeClass('required')
         statePara.toggle(!!statesRequired)
         stateInput.prop('disabled', !statesRequired)
-        stateInput.removeClass('hidden')
         stateSelect.removeClass('required')
 
     $('#bcountry select').change ->

--- a/frontend/app/views/spree/address/_form.html.erb
+++ b/frontend/app/views/spree/address/_form.html.erb
@@ -39,19 +39,25 @@
       <%= form.label :state, Spree.t(:state) %><span class='required' id=<%="#{address_id}state-required"%>>*</span><br/>
 
       <span class="js-address-fields" style="display: none;">
-        <%= form.collection_select(
-          :state_id, address.country.states, :id, :name,
-          {include_blank: true},
-          {
-            class: have_states ? 'required' : 'hidden',
-            disabled: !have_states
-          }) %>
-        <%= form.text_field(
-          :state_name,
-          class: !have_states ? 'required' : 'hidden',
-          disabled: have_states) %>
+        <%=
+          form.collection_select(
+            :state_id, address.country.states, :id, :name,
+            {:include_blank => true},
+            {
+              class: have_states ? 'required' : '',
+              style: have_states ? '' : 'display: none;',
+              disabled: !have_states
+            })
+          %>
+        <%=
+          form.text_field(
+            :state_name,
+            class: !have_states ? 'required' : '',
+            style: have_states ? 'display: none;' : '',
+            disabled: have_states
+          )
+        %>
       </span>
-
       <noscript>
         <%= form.text_field :state_name, :class => 'required' %>
       </noscript>


### PR DESCRIPTION
This class isn't defined in CSS and doesn't work. We need to use `style="display: none;"` instead, which is what jQuery's `show()` and `hide()` work with.

This fixes the disabled `state_name` text field appearing briefly on screen when the page loads.