### PR TITLE
Introduce `amount` as a full alias to `cost` on shipment

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -88,8 +88,8 @@ module Spree
     end
 
     extend DisplayMoney
-    money_methods :cost, :discounted_cost, :final_price, :item_cost
-    alias display_amount display_cost
+    money_methods :cost, :amount, :discounted_cost, :final_price, :item_cost
+    alias_attribute :amount, :cost
 
     def add_shipping_method(shipping_method, selected = false)
       shipping_rates.create(shipping_method: shipping_method, selected: selected, cost: cost)

--- a/core/spec/models/spree/tax/taxation_integration_spec.rb
+++ b/core/spec/models/spree/tax/taxation_integration_spec.rb
@@ -142,7 +142,6 @@ RSpec.describe "Taxation system integration tests" do
         before { 2.times { order.next! } }
 
         it 'has a shipment for 8.00 dollars' do
-          pending 'No amount method yet on the shipment'
           expect(shipment.amount).to eq(8.00)
         end
 
@@ -179,7 +178,6 @@ RSpec.describe "Taxation system integration tests" do
         before { 2.times { order.next! } }
 
         it 'has a shipment for 16.00 dollars' do
-          pending 'No amount method yet on the shipment'
           expect(shipment.amount).to eq(16.00)
         end
 
@@ -216,7 +214,6 @@ RSpec.describe "Taxation system integration tests" do
         before { 2.times { order.next! } }
 
         it 'has a shipment for 4.00 dollars' do
-          pending 'No amount method yet on the shipment'
           expect(shipment.amount).to eq(2.00)
         end
 
@@ -263,7 +260,6 @@ RSpec.describe "Taxation system integration tests" do
         before { 2.times { order.next! } }
 
         it 'has a shipment for 8.00 dollars' do
-          pending 'No amount method yet on the shipment'
           expect(shipment.amount).to eq(8.00)
         end
 
@@ -304,7 +300,6 @@ RSpec.describe "Taxation system integration tests" do
         before { 2.times { order.next! } }
 
         it 'has a shipment for 16.00 dollars' do
-          pending 'No amount method yet on the shipment'
           expect(shipment.amount).to eq(16.00)
         end
 
@@ -348,7 +343,7 @@ RSpec.describe "Taxation system integration tests" do
         before { 2.times { order.next! } }
 
         it 'it has a shipment with an adjusted price to 2.08' do
-          pending 'No amount method yet on the shipment'
+          pending 'Waiting for the MOSS refactoring'
           expect(shipment.amount).to eq(2.08)
         end
 
@@ -442,7 +437,7 @@ RSpec.describe "Taxation system integration tests" do
           before { 2.times { order.next! } }
 
           it 'it has a shipment with an adjusted price to 7.47' do
-            pending 'No amount method yet on the shipment'
+            pending 'but prices are not adjusted yet'
             expect(shipment.amount).to eq(7.47)
           end
 
@@ -489,7 +484,7 @@ RSpec.describe "Taxation system integration tests" do
           before { 2.times { order.next! } }
 
           it 'it has a shipment with an adjusted price to 13.45' do
-            pending 'No amount method yet on the shipment'
+            pending 'But prices are not adjusted yet'
             expect(shipment.amount).to eq(13.45)
           end
 
@@ -537,7 +532,7 @@ RSpec.describe "Taxation system integration tests" do
         before { 2.times { order.next! } }
 
         it 'it has a shipment with an adjusted price to 1.68' do
-          pending 'No amount method yet on the shipment'
+          pending 'but prices are not adjusted yet'
           expect(shipment.amount).to eq(1.68)
         end
 
@@ -669,7 +664,6 @@ RSpec.describe "Taxation system integration tests" do
         before { 2.times { order.next! } }
 
         it 'it has a shipment with a price of 8.00' do
-          pending 'No amount method yet on the shipment'
           expect(shipment.amount).to eq(8.00)
         end
 
@@ -718,7 +712,6 @@ RSpec.describe "Taxation system integration tests" do
         before { 2.times { order.next! } }
 
         it 'it has a shipment with a price of 16.00' do
-          pending 'No amount method yet on the shipment'
           expect(shipment.amount).to eq(16.00)
         end
 
@@ -766,7 +759,6 @@ RSpec.describe "Taxation system integration tests" do
         before { 2.times { order.next! } }
 
         it 'it has a shipment with a price of 2.00' do
-          pending 'No amount method yet on the shipment'
           expect(shipment.amount).to eq(2.00)
         end
 


### PR DESCRIPTION
This greens a lot of specs and opens a migration path from the `cost` to `amount` on shipments and shipping rates. 