### PR TITLE
Change product variants index page logic

### DIFF
--- a/backend/app/views/spree/admin/variants/index.html.erb
+++ b/backend/app/views/spree/admin/variants/index.html.erb
@@ -68,7 +68,7 @@
     </tbody>
   </table>
   <%= paginate @variants, theme: "solidus_admin" %>
-<% else %>
+<% elsif !@product.empty_option_values? %>
   <div class="alpha twelve columns no-objects-found">
     <%= render 'spree/admin/shared/no_objects_found',
                  resource: Spree::Variant,
@@ -77,6 +77,12 @@
 <% end %>
 
 <% if @product.empty_option_values? %>
+  <div class="alpha twelve columns no-objects-found">
+    <%= Spree.t(:no_option_values_on_product_html, link: link_to(Spree.t(:product_details),
+                                                                 [:edit, :admin, @product])) %>
+  </div>
+<% end %>
+<% unless Spree::OptionType.any? %>
   <p class='first_add_option_types no-objects-found' data-hook="first_add_option_types">
     <%= Spree.t(:to_add_variants_you_must_first_define) %>
     <% if can?(:display, Spree::OptionType) %>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1243,6 +1243,7 @@ en:
     no_images_found: No images found
     no_inventory_selected: No inventory selected
     no_orders_found: No orders found
+    no_option_values_on_product_html: "This product has no associated option values. Add some to it through Option Types in the %{link}."
     no_payment_methods_found: No payment methods found
     no_payment_found: No payment found
     no_pending_payments: No pending payments


### PR DESCRIPTION
Currently there is a message and link to create option types (through the option types index) even if some exist but are just not linked to the product.  This will leave that link if no option types actually exist, give a link to create a variant if any option values are defined on the product, and if no option values are defined it will explain that while giving a more obvious link back to the product details where option values can be added.