### PR TITLE
Avoid using String#constantize

### DIFF
--- a/backend/app/controllers/spree/admin/promotion_actions_controller.rb
+++ b/backend/app/controllers/spree/admin/promotion_actions_controller.rb
@@ -4,7 +4,7 @@ class Spree::Admin::PromotionActionsController < Spree::Admin::BaseController
 
   def create
     @calculators = Spree::Promotion::Actions::CreateAdjustment.calculators
-    @promotion_action = params[:action_type].constantize.new(params[:promotion_action])
+    @promotion_action = @promotion_action_type.new(params[:promotion_action])
     @promotion_action.promotion = @promotion
     if @promotion_action.save
       flash[:success] = Spree.t(:successfully_created, resource: Spree.t(:promotion_action))
@@ -33,8 +33,12 @@ class Spree::Admin::PromotionActionsController < Spree::Admin::BaseController
   end
 
   def validate_promotion_action_type
-    valid_promotion_action_types = Rails.application.config.spree.promotions.actions.map(&:to_s)
-    if !valid_promotion_action_types.include?(params[:action_type])
+    requested_type = params[:action_type]
+    promotion_action_types = Rails.application.config.spree.promotions.actions
+    @promotion_action_type = promotion_action_types.detect do |klass|
+      klass.name == requested_type
+    end
+    if !@promotion_action_type
       flash[:error] = Spree.t(:invalid_promotion_action)
       respond_to do |format|
         format.html { redirect_to spree.edit_admin_promotion_path(@promotion) }

--- a/backend/app/controllers/spree/admin/promotion_rules_controller.rb
+++ b/backend/app/controllers/spree/admin/promotion_rules_controller.rb
@@ -5,11 +5,7 @@ class Spree::Admin::PromotionRulesController < Spree::Admin::BaseController
   before_action :validate_promotion_rule_type, only: :create
 
   def create
-    # Remove type key from this hash so that we don't attempt
-    # to set it when creating a new record, as this is raises
-    # an error in ActiveRecord 3.2.
-    promotion_rule_type = params[:promotion_rule].delete(:type)
-    @promotion_rule = promotion_rule_type.constantize.new(params[:promotion_rule])
+    @promotion_rule = @promotion_rule_type.new(params[:promotion_rule])
     @promotion_rule.promotion = @promotion
     if @promotion_rule.save
       flash[:success] = Spree.t(:successfully_created, resource: Spree.t(:promotion_rule))
@@ -38,8 +34,12 @@ class Spree::Admin::PromotionRulesController < Spree::Admin::BaseController
   end
 
   def validate_promotion_rule_type
-    valid_promotion_rule_types = Rails.application.config.spree.promotions.rules.map(&:to_s)
-    if !valid_promotion_rule_types.include?(params[:promotion_rule][:type])
+    requested_type = params[:promotion_rule].delete(:type)
+    promotion_rule_types = Rails.application.config.spree.promotions.rules
+    @promotion_rule_type = promotion_rule_types.detect do |klass|
+      klass.name == requested_type
+    end
+    if !@promotion_rule_type
       flash[:error] = Spree.t(:invalid_promotion_rule)
       respond_to do |format|
         format.html { redirect_to spree.edit_admin_promotion_path(@promotion) }

--- a/backend/spec/controllers/spree/admin/payment_methods_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/payment_methods_controller_spec.rb
@@ -8,16 +8,22 @@ module Spree
   describe Admin::PaymentMethodsController, type: :controller do
     stub_authorization!
 
-    let(:payment_method) { GatewayWithPassword.create!(name: "Bogus", preferred_password: "haxme") }
+    context "GatewayWithPassword" do
+      let(:payment_method) { GatewayWithPassword.create!(name: "Bogus", preferred_password: "haxme") }
 
-    # regression test for https://github.com/spree/spree/issues/2094
-    it "does not clear password on update" do
-      expect(payment_method.preferred_password).to eq("haxme")
-      spree_put :update, id: payment_method.id, payment_method: { type: payment_method.class.to_s, preferred_password: "" }
-      expect(response).to redirect_to(spree.edit_admin_payment_method_path(payment_method))
+      before do
+        allow(Rails.application.config.spree).to receive(:payment_methods).and_return([GatewayWithPassword])
+      end
 
-      payment_method.reload
-      expect(payment_method.preferred_password).to eq("haxme")
+      # regression test for https://github.com/spree/spree/issues/2094
+      it "does not clear password on update" do
+        expect(payment_method.preferred_password).to eq("haxme")
+        spree_put :update, id: payment_method.id, payment_method: { type: payment_method.class.to_s, preferred_password: "" }
+        expect(response).to redirect_to(spree.edit_admin_payment_method_path(payment_method))
+
+        payment_method.reload
+        expect(payment_method.preferred_password).to eq("haxme")
+      end
     end
 
     context "tries to save invalid payment" do


### PR DESCRIPTION
The types in the `params` coming in were being validated previously (which is why this is not being done as a security release), but it would be easy to make a mistake and lose that validation.

Instead, this PR looks through the list of valid classes for the matching class.