### PR TITLE
Only check once whether we're in a non-default non-order zone

### DIFF
--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -98,7 +98,7 @@ module Spree
       amount = compute_amount(item)
       return if amount == 0
 
-      included = included_in_price && default_zone_or_zone_match?(order_tax_zone)
+      included = included_in_price && amount > 0
 
       if amount < 0
         label = Spree.t(:refund) + ' ' + create_label


### PR DESCRIPTION
When calling Spree::TaxRate#adjust, Spree::TaxRate#compute_amount will
come up with negative amount only if we're processing a refund. This commit
checks for the amount of the reimbursement to be negative instead of running
a rather expensive call to Spree::Zone.contains.