### PR TITLE
Use better i18n for generating tax adjustment labels

### DIFF
--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -100,15 +100,11 @@ module Spree
 
       included = included_in_price && default_zone_or_zone_match?(order_tax_zone)
 
-      if amount < 0
-        label = Spree.t(:refund) + ' ' + create_label
-      end
-
       adjustments.create!({
         adjustable: item,
         amount: amount,
         order_id: item.order_id,
-        label: label || create_label,
+        label: adjustment_label(amount),
         included: included
       })
     end
@@ -129,12 +125,25 @@ module Spree
       Zone.default_tax.try!(:contains?, order_tax_zone) || zone.contains?(order_tax_zone)
     end
 
-    def create_label
-      label = ""
-      label << (name.present? ? name : tax_category.name) + " "
-      label << (show_rate_in_label? ? "#{amount * 100}%" : "")
-      label << " (#{Spree.t(:included_in_price)})" if included_in_price?
-      label
+    def adjustment_label(amount)
+      Spree.t translation_key(amount),
+              scope: "adjustment_labels.tax_rates",
+              name: name.presence || tax_category.name,
+              amount: amount_for_adjustment_label
+    end
+
+    def amount_for_adjustment_label
+      ActiveSupport::NumberHelper::NumberToPercentageConverter.convert(
+        amount * 100,
+        locale: I18n.locale
+      )
+    end
+
+    def translation_key(amount)
+      key = included_in_price? ? "vat" : "sales_tax"
+      key += "_refund" if amount < 0
+      key += "_with_rate" if show_rate_in_label?
+      key.to_sym
     end
   end
 end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -622,6 +622,16 @@ en:
     adjustable: Adjustable
     adjustment: Adjustment
     adjustment_amount: Amount
+    adjustment_labels:
+      tax_rates:
+        sales_tax: '%{name}'
+        vat: '%{name} (Included in Price)'
+        sales_tax_with_rate: '%{name} %{amount}'
+        vat_with_rate: '%{name} %{amount} (Included in Price)'
+        sales_tax_refund: 'Refund: %{name}'
+        vat_refund: 'Refund: %{name} (Included in Price)'
+        sales_tax_refund_with_rate: 'Refund: %{name} %{amount}'
+        vat_refund_with_rate: 'Refund: %{name} %{amount} (Included in Price)'
     adjustment_reasons: Adjustment Reasons
     adjustment_successfully_closed: Adjustment has been successfully closed!
     adjustment_successfully_opened: Adjustment has been successfully opened!


### PR DESCRIPTION
The previous code for generating tax adjustment labels has several
drawbacks:

* The i18n keys used are not namespaced
* The i18n in place did not allow the main app to specify
  the number format, which is bad for Europe, where we often
  write numbers different than the US (1,40 Euro, anyone?)
* The code in place did not allow the format of the label
  to be anything different from what was in Spree::TaxRate#create_label.
* The code on place relied on MRI interpreter quirks (namely that a
  variable in an untouched `if` branch would become `nil` rather
  than raising a `NoMethodError`).

In the future, adjustments should IMO not actually store their translations
in the database at all, but instead create them using their own data. But
that's not something I want to tackle now.