### PR TITLE
Privatize TaxRate#default_zone_or_zone_match

### DIFF
--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -123,11 +123,11 @@ module Spree
       end
     end
 
+    private
+
     def default_zone_or_zone_match?(order_tax_zone)
       Zone.default_tax.try!(:contains?, order_tax_zone) || zone.contains?(order_tax_zone)
     end
-
-    private
 
     def create_label
       label = ""


### PR DESCRIPTION
This method is an implementation detail (not the nicest btw) of the
current taxation system, and is only ever called from within tax_rate.rb.

It's only relevant for VATs, untested, and generally a pain that I want to
be able to freely change.