### PR TITLE
Route all tax calculation through Spree::TaxRate.compute_amount

### DIFF
--- a/core/app/models/spree/calculator/default_tax.rb
+++ b/core/app/models/spree/calculator/default_tax.rb
@@ -37,11 +37,7 @@ module Spree
     def compute_shipping_rate(shipping_rate)
       if rate.included_in_price
         pre_tax_amount = shipping_rate.cost / (1 + rate.amount)
-        if rate.zone == shipping_rate.shipment.order.tax_zone
-          deduced_total_by_rate(pre_tax_amount, rate)
-        else
-          deduced_total_by_rate(pre_tax_amount, rate) * - 1
-        end
+        deduced_total_by_rate(pre_tax_amount, rate)
       else
         with_tax_amount = shipping_rate.cost * rate.amount
         round_to_two_places(with_tax_amount)

--- a/core/app/models/spree/shipping_rate.rb
+++ b/core/app/models/spree/shipping_rate.rb
@@ -13,7 +13,7 @@ module Spree
     end
 
     def calculate_tax_amount
-      tax_rate.calculator.compute_shipping_rate(self)
+      tax_rate.compute_amount(self)
     end
 
     def display_price


### PR DESCRIPTION
This commit makes all tax calcuation go through Spree::TaxRate.compute_amount.
It has the most robust check for whether we should be refunding.

In the future, I'd like to see this go altogether, but for the time being this
alleviates some issues.