### PR TITLE
Reorder option type edit

### DIFF
--- a/backend/app/views/spree/admin/option_types/edit.html.erb
+++ b/backend/app/views/spree/admin/option_types/edit.html.erb
@@ -17,7 +17,10 @@
 
 <%= form_for [:admin, @option_type] do |f| %>
 
-  <%= render :partial => 'form', :locals => { :f => f } %>
+  <fieldset class="no-border-bottom">
+    <legend><%= Spree::OptionType.model_name.human %></legend>
+    <%= render :partial => 'form', :locals => { :f => f } %>
+  </fieldset>
 
   <fieldset>
     <legend><%= Spree::OptionValue.model_name.human(count: :other) %></legend>
@@ -35,7 +38,6 @@
         <% end %>
       </tbody>
     </table>
-
     <%= render :partial => 'spree/admin/shared/edit_resource_links' %>
   </fieldset>
 <% end %>

--- a/backend/app/views/spree/admin/option_types/edit.html.erb
+++ b/backend/app/views/spree/admin/option_types/edit.html.erb
@@ -16,11 +16,11 @@
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @option_type } %>
 
 <%= form_for [:admin, @option_type] do |f| %>
+
+  <%= render :partial => 'form', :locals => { :f => f } %>
+
   <fieldset>
-    <legend align="center"><%= Spree::OptionValue.model_name.human(count: :other) %></legend>
-
-    <%= render :partial => 'form', :locals => { :f => f } %>
-
+    <legend><%= Spree::OptionValue.model_name.human(count: :other) %></legend>
     <table class="index sortable" data-hook data-sortable-link="<%= update_values_positions_admin_option_types_url %>">
       <thead data-hook="option_header">
         <tr>


### PR DESCRIPTION


Currently the option type edit page is confusing as there is one legend and it is for option values while it includes the option type attributes.  This will fix that.

Before (confusing)
![before](https://cloud.githubusercontent.com/assets/12613649/13362741/e174269a-dc7a-11e5-9dd0-db5d4d5081bb.png)
After (better)
![after](https://cloud.githubusercontent.com/assets/12613649/13362742/e195ba44-dc7a-11e5-86cd-be76507d639f.png)

@cbrunsdon Makes total sense will make sure to attach these in future visual change PRs