### PR TITLE
Make TaxHelper method accept params

### DIFF
--- a/core/app/models/spree/tax/item_adjuster.rb
+++ b/core/app/models/spree/tax/item_adjuster.rb
@@ -12,7 +12,8 @@ module Spree
         @item = item
         @order = @item.order
         # set instance variable so `TaxRate.match` is only called when necessary
-        @rates_for_order_zone = options[:rates_for_order_zone]
+        @applicable_rates = options[:applicable_rates]
+        @order_tax_zone = options[:order_tax_zone]
       end
 
       # Deletes all existing tax adjustments and creates new adjustments for all
@@ -23,19 +24,19 @@ module Spree
       #
       # @return [Array<Spree::Adjustment>] newly created adjustments
       def adjust!
-        return unless order_tax_zone
+        return unless order_tax_zone(order)
         # Using .destroy_all to make sure callbacks fire
         item.adjustments.tax.destroy_all
 
         TaxRate.store_pre_tax_amount(item, rates_for_item)
 
-        rates_for_item.map { |rate| rate.adjust(order_tax_zone, item) }
+        rates_for_item.map { |rate| rate.adjust(order_tax_zone(order), item) }
       end
 
       private
 
       def rates_for_item
-        @rates_for_item ||= applicable_rates.select { |rate| rate.tax_category == item.tax_category }
+        @rates_for_item ||= applicable_rates(order).select { |rate| rate.tax_category == item.tax_category }
       end
     end
   end

--- a/core/app/models/spree/tax/item_adjuster.rb
+++ b/core/app/models/spree/tax/item_adjuster.rb
@@ -12,7 +12,8 @@ module Spree
         @item = item
         @order = @item.order
         # set instance variable so `TaxRate.match` is only called when necessary
-        @applicable_rates = options[:applicable_rates]
+        @rates_for_order_zone = options[:rates_for_order_zone]
+        @rates_for_default_zone = options[:rates_for_default_zone]
         @order_tax_zone = options[:order_tax_zone]
       end
 

--- a/core/app/models/spree/tax/order_adjuster.rb
+++ b/core/app/models/spree/tax/order_adjuster.rb
@@ -14,10 +14,10 @@ module Spree
       # Creates tax adjustments for all taxable items (shipments and line items)
       # in the given order.
       def adjust!
-        return unless order_tax_zone
+        return unless order_tax_zone(order)
 
         (order.line_items + order.shipments).each do |item|
-          ItemAdjuster.new(item, rates_for_order_zone: applicable_rates).adjust!
+          ItemAdjuster.new(item, rates_for_order_zone: applicable_rates(order)).adjust!
         end
       end
     end

--- a/core/app/models/spree/tax/order_adjuster.rb
+++ b/core/app/models/spree/tax/order_adjuster.rb
@@ -17,8 +17,18 @@ module Spree
         return unless order_tax_zone(order)
 
         (order.line_items + order.shipments).each do |item|
-          ItemAdjuster.new(item, rates_for_order_zone: applicable_rates(order)).adjust!
+          ItemAdjuster.new(item, order_wide_options).adjust!
         end
+      end
+
+      private
+
+      def order_wide_options
+        {
+          rates_for_order_zone: rates_for_order_zone(order),
+          rates_for_default_zone: rates_for_default_zone,
+          order_tax_zone: order_tax_zone(order)
+        }
       end
     end
   end

--- a/core/app/models/spree/tax/tax_helpers.rb
+++ b/core/app/models/spree/tax/tax_helpers.rb
@@ -16,24 +16,24 @@ module Spree
       # This little bit of code at the end stops the Spanish refund from appearing.
       #
       # For further discussion, see https://github.com/spree/spree/issues/4397 and https://github.com/spree/spree/issues/4327.
-      def applicable_rates
-        order_zone_tax_categories = rates_for_order_zone.map(&:tax_category)
+      def applicable_rates(order)
+        order_zone_tax_categories = rates_for_order_zone(order).map(&:tax_category)
         default_rates_with_unmatched_tax_category = rates_for_default_zone.to_a.delete_if do |default_rate|
           order_zone_tax_categories.include?(default_rate.tax_category)
         end
 
-        (rates_for_order_zone + default_rates_with_unmatched_tax_category).uniq
+        (rates_for_order_zone(order) + default_rates_with_unmatched_tax_category).uniq
       end
 
-      def rates_for_order_zone
-        @rates_for_order_zone ||= Spree::TaxRate.for_zone(order_tax_zone)
+      def rates_for_order_zone(order)
+        @rates_for_order_zone ||= Spree::TaxRate.for_zone(order_tax_zone(order))
       end
 
       def rates_for_default_zone
         @rates_for_default_zone ||= Spree::TaxRate.for_zone(Spree::Zone.default_tax)
       end
 
-      def order_tax_zone
+      def order_tax_zone(order)
         @order_tax_zone ||= order.tax_zone
       end
     end

--- a/core/spec/models/spree/tax/order_adjuster_spec.rb
+++ b/core/spec/models/spree/tax/order_adjuster_spec.rb
@@ -25,8 +25,20 @@ RSpec.describe Spree::Tax::OrderAdjuster do
     end
 
     it 'calls the item adjuster with all line items' do
-      expect(Spree::Tax::ItemAdjuster).to receive(:new).with(line_items.first, rates_for_order_zone: rates_for_order_zone).and_return(item_adjuster)
-      expect(Spree::Tax::ItemAdjuster).to receive(:new).with(line_items.second, rates_for_order_zone: rates_for_order_zone).and_return(item_adjuster)
+      expect(Spree::Tax::ItemAdjuster).to receive(:new).
+                                            with(
+                                              line_items.first,
+                                              rates_for_order_zone: rates_for_order_zone,
+                                              rates_for_default_zone: [],
+                                              order_tax_zone: zone
+                                            ).and_return(item_adjuster)
+      expect(Spree::Tax::ItemAdjuster).to receive(:new).
+                                            with(
+                                              line_items.second,
+                                              rates_for_order_zone: rates_for_order_zone,
+                                              rates_for_default_zone: [],
+                                              order_tax_zone: zone
+                                            ).and_return(item_adjuster)
 
       expect(item_adjuster).to receive(:adjust!).twice
       adjuster.adjust!


### PR DESCRIPTION
While reviewing the PR that would add a ShippingRateTaxer object,
we found that having these method implicitly rely on an `order` method
defined in the including code is not so desirable.

This commit changes the signatures of the tax helper methods so they always
explicitly take an order object.

There's a second commit coming up in this PR. It's tiny. 