### PR TITLE
Use model name translation

### DIFF
--- a/backend/app/views/spree/admin/option_types/edit.html.erb
+++ b/backend/app/views/spree/admin/option_types/edit.html.erb
@@ -17,7 +17,7 @@
 
 <%= form_for [:admin, @option_type] do |f| %>
   <fieldset>
-    <legend align="center"><%= Spree.t(:option_values) %></legend>
+    <legend align="center"><%= Spree::OptionValue.model_name.human(count: :other) %></legend>
 
     <%= render :partial => 'form', :locals => { :f => f } %>
 


### PR DESCRIPTION
This is better use of I18n.

This is part of an ongoing effort to improve I18n usage as discussed in #735.