### PR TITLE
Destroy all tax adjustments in the order adjuster

### DIFF
--- a/core/app/models/spree/tax/item_adjuster.rb
+++ b/core/app/models/spree/tax/item_adjuster.rb
@@ -15,6 +15,7 @@ module Spree
         @rates_for_order_zone = options[:rates_for_order_zone]
         @rates_for_default_zone = options[:rates_for_default_zone]
         @order_tax_zone = options[:order_tax_zone]
+        @skip_destroy_adjustments = options[:skip_destroy_adjustments]
       end
 
       # Deletes all existing tax adjustments and creates new adjustments for all
@@ -27,7 +28,7 @@ module Spree
       def adjust!
         return unless order_tax_zone(order)
         # Using .destroy_all to make sure callbacks fire
-        item.adjustments.tax.destroy_all
+        item.adjustments.tax.destroy_all unless @skip_destroy_adjustments
 
         TaxRate.store_pre_tax_amount(item, rates_for_item)
 

--- a/core/app/models/spree/tax/order_adjuster.rb
+++ b/core/app/models/spree/tax/order_adjuster.rb
@@ -16,6 +16,8 @@ module Spree
       def adjust!
         return unless order_tax_zone(order)
 
+        order.all_adjustments.tax.destroy_all
+
         (order.line_items + order.shipments).each do |item|
           ItemAdjuster.new(item, order_wide_options).adjust!
         end
@@ -27,7 +29,8 @@ module Spree
         {
           rates_for_order_zone: rates_for_order_zone(order),
           rates_for_default_zone: rates_for_default_zone,
-          order_tax_zone: order_tax_zone(order)
+          order_tax_zone: order_tax_zone(order),
+          skip_destroy_adjustments: true
         }
       end
     end

--- a/core/spec/models/spree/tax/order_adjuster_spec.rb
+++ b/core/spec/models/spree/tax/order_adjuster_spec.rb
@@ -30,14 +30,16 @@ RSpec.describe Spree::Tax::OrderAdjuster do
                                               line_items.first,
                                               rates_for_order_zone: rates_for_order_zone,
                                               rates_for_default_zone: [],
-                                              order_tax_zone: zone
+                                              order_tax_zone: zone,
+                                              skip_destroy_adjustments: true
                                             ).and_return(item_adjuster)
       expect(Spree::Tax::ItemAdjuster).to receive(:new).
                                             with(
                                               line_items.second,
                                               rates_for_order_zone: rates_for_order_zone,
                                               rates_for_default_zone: [],
-                                              order_tax_zone: zone
+                                              order_tax_zone: zone,
+                                              skip_destroy_adjustments: true
                                             ).and_return(item_adjuster)
 
       expect(item_adjuster).to receive(:adjust!).twice


### PR DESCRIPTION
As a mentioned in https://github.com/solidusio/solidus/issues/909,
the current implementation of the taxation system destroys
tax adjustments one item at a time.

This commit changes that so all the order is stripped of
all tax adjustments, resulting in less database calls.