### PR TITLE
Fix deleting tax adjustments in Spree::TaxRate.adjust

### DIFF
--- a/core/spec/models/spree/tax_rate_spec.rb
+++ b/core/spec/models/spree/tax_rate_spec.rb
@@ -179,6 +179,7 @@ describe Spree::TaxRate, :type => :model do
 
       before do
         allow(Spree::TaxRate).to receive_messages :match => [rate_1, rate_2]
+        allow(line_item).to receive_message_chain(:order, :all_adjustments, :tax, :destroy_all)
       end
 
       it "should only apply adjustments for matching rates" do
@@ -193,6 +194,7 @@ describe Spree::TaxRate, :type => :model do
 
       before do
         allow(Spree::TaxRate).to receive_messages :match => [rate_1, rate_2]
+        allow(shipments).to receive_message_chain(:first, :order, :all_adjustments, :tax, :destroy_all)
       end
 
       it "should apply adjustments for matching rates" do


### PR DESCRIPTION
This PR is against a stable branch, but fixes a definite bug. 

As reported in https://github.com/solidusio/solidus/issues/909, when calling `Spree::TaxRate` with a mixture of `shipments` and `line_items`, it will fail to delete some tax adjustments (those that don't happen to adjust the type of the first `item` in the passed-in `items` array).

While fixing that, I realised that this code would set the `pre_tax_amount` for untaxed items to zero, violating that the `pre_tax_amount` for something that does not have included taxes should be equal to its `discounted_amount`.