### PR TITLE
Use model attribute translations in order views.

### DIFF
--- a/backend/app/views/spree/admin/orders/_carton.html.erb
+++ b/backend/app/views/spree/admin/orders/_carton.html.erb
@@ -42,7 +42,7 @@
       <% if order.special_instructions.present? %>
         <tr class='special_instructions'>
           <td colspan="5">
-            <strong><%= Spree.t(:special_instructions) %>:&nbsp;</strong><%= order.special_instructions %>
+            <strong><%= Spree::Order.human_attribute_name(:special_instructions) %>:&nbsp;</strong><%= order.special_instructions %>
           </td>
         </tr>
       <% end %>
@@ -50,7 +50,7 @@
       <tr class="show-tracking total">
         <td colspan="5">
           <% if carton.tracking.present? %>
-            <strong><%= Spree.t(:tracking) %>:</strong> <%= carton.tracking %>
+            <strong><%= Spree::Carton.human_attribute_name(:tracking) %>:</strong> <%= carton.tracking %>
           <% else %>
             <%= Spree.t(:no_tracking_present) %>
           <% end %>

--- a/backend/app/views/spree/admin/orders/_shipment.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment.html.erb
@@ -84,7 +84,7 @@
 
         <tr class="edit-tracking hidden total">
           <td colspan="5">
-            <label><%= Spree.t(:tracking_number) %>:</label>
+            <label><%= Spree::Shipment.human_attribute_name(:tracking) %>:</label>
             <%= text_field_tag :tracking, shipment.tracking %>
           </td>
           <td class="actions">
@@ -106,7 +106,7 @@
         <tr class="show-tracking total">
           <td colspan="5" class="tracking-value">
             <% if shipment.tracking.present? %>
-              <strong><%= Spree.t(:tracking) %>:</strong> <%= shipment.tracking %>
+              <strong><%= Spree::Shipment.human_attribute_name(:tracking) %>:</strong> <%= shipment.tracking %>
             <% else %>
               <%= Spree.t(:no_tracking_present) %>
             <% end %>

--- a/backend/app/views/spree/admin/orders/confirm/_line_items.html.erb
+++ b/backend/app/views/spree/admin/orders/confirm/_line_items.html.erb
@@ -1,10 +1,10 @@
 <% if order.line_items.exists? %>
   <table class="line-items index" data-hook="line-items">
     <thead>
-      <th colspan="2"><%= Spree.t(:name) %></th>
-      <th><%= Spree.t(:price) %></th>
-      <th><%= Spree.t(:quantity) %></th>
-      <th><%= Spree.t(:total_price) %></th>
+      <th colspan="2"><%= Spree::LineItem.human_attribute_name(:name) %></th>
+      <th><%= Spree::LineItem.human_attribute_name(:price) %></th>
+      <th><%= Spree::LineItem.human_attribute_name(:quantity) %></th>
+      <th><%= Spree::LineItem.human_attribute_name(:total_price) %></th>
     </thead>
 
     <tbody>

--- a/backend/app/views/spree/admin/orders/confirm/_payments.html.erb
+++ b/backend/app/views/spree/admin/orders/confirm/_payments.html.erb
@@ -3,13 +3,12 @@
   <table class="index">
     <thead>
       <tr data-hook="payments_header">
-        <th><%= Spree.t(:identifier) %></th>
-        <th><%= "#{Spree.t('date')}/#{Spree.t('time')}" %></th>
-        <th><%= Spree.t(:amount) %></th>
-        <th><%= Spree.t(:payment_method) %></th>
+        <th><%= Spree::Payment.human_attribute_name(:number) %></th>
+        <th><%= Spree::Payment.human_attribute_name(:created_at) %></th>
+        <th><%= Spree::Payment.human_attribute_name(:amount) %></th>
         <th><%= Spree::PaymentMethod.model_name.human %></th>
-        <th><%= Spree.t(:transaction_id) %></th>
-        <th><%= Spree.t(:payment_state) %></th>
+        <th><%= Spree::Payment.human_attribute_name(:response_code) %></th>
+        <th><%= Spree::Payment.human_attribute_name(:state) %></th>
       </tr>
     </thead>
     <tbody>

--- a/backend/app/views/spree/admin/orders/confirm/_shipment.html.erb
+++ b/backend/app/views/spree/admin/orders/confirm/_shipment.html.erb
@@ -36,7 +36,7 @@
 
       <tr class="edit-tracking hidden total">
         <td colspan="5">
-          <label><%= Spree.t(:tracking_number) %>:</label>
+          <label><%= Spree::Shipment.human_attribute_name(:tracking) %>:</label>
           <%= text_field_tag :tracking, shipment.tracking %>
         </td>
       </tr>
@@ -44,7 +44,10 @@
       <% if order.special_instructions.present? %>
         <tr class='special_instructions'>
           <td colspan="5">
-            <strong><%= Spree.t(:special_instructions) %>:&nbsp;</strong><%= order.special_instructions %>
+            <strong>
+              <%= Spree::Order.human_attribute_name(:special_instructions) %>:
+            </strong>
+            <%= order.special_instructions %>
           </td>
         </tr>
       <% end %>

--- a/backend/app/views/spree/admin/orders/confirm/_shipment_manifest.html.erb
+++ b/backend/app/views/spree/admin/orders/confirm/_shipment_manifest.html.erb
@@ -6,7 +6,7 @@
     <td class="item-name">
       <%= item.variant.product.name %><br><%= "(" + variant_options(item.variant) + ")" unless item.variant.option_values.empty? %>
       <% if item.variant.sku.present? %>
-        <strong><%= Spree.t(:sku) %>:</strong> <%= item.variant.sku %>
+        <strong><%= Spree::Variant.human_attribute_name(:sku) %>:</strong> <%= item.variant.sku %>
       <% end %>
     </td>
     <td class="item-price align-center"><%= item.line_item.single_money.to_html %></td>

--- a/backend/app/views/spree/admin/orders/customer_details/_form.html.erb
+++ b/backend/app/views/spree/admin/orders/customer_details/_form.html.erb
@@ -6,7 +6,7 @@
     <div data-hook="customer_fields" class="row">
       <div class="alpha eight columns">
         <div class="field">
-          <%= f.label :email, Spree.t(:email) %>
+          <%= f.label :email %>
           <%= f.email_field :email, :class => 'fullwidth' %>
         </div>
       </div>

--- a/backend/spec/features/admin/orders/new_order_spec.rb
+++ b/backend/spec/features/admin/orders/new_order_spec.rb
@@ -180,7 +180,7 @@ describe "New Order", type: :feature do
     it "displays the user's email escaped without executing" do
       click_on "Customer Details"
       targetted_select2_search user.email, from: "#s2id_customer_search"
-      expect(page).to have_field("Email", with: xss_string)
+      expect(page).to have_field("Customer E-Mail", with: xss_string)
     end
   end
 

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -35,6 +35,8 @@ en:
       spree/calculator/tiered_percent:
         preferred_base_percent: Base Percent
         preferred_tiers: Tiers
+      spree/carton:
+        tracking: Tracking
       spree/country:
         iso: ISO
         iso3: ISO3
@@ -66,6 +68,7 @@ en:
         state: State
       spree/line_item:
         description: Item Description
+        name: Name
         price: Price
         quantity: Quantity
         total: Total price
@@ -115,7 +118,10 @@ en:
         zipcode: Shipping address zipcode
       spree/payment:
         amount: Amount
+        created_at: Date/Time
         number: Identifier
+        response_code: Transaction ID
+        state: Payment State
       spree/payment_method:
         name: Name
       spree/product:
@@ -196,6 +202,8 @@ en:
         name: Name
       spree/shipping_category:
         name: Name
+      spree/shipment:
+        tracking: Tracking Number
       spree/shipping_method:
         admin_name: Internal Name
         carrier: Carrier


### PR DESCRIPTION
This makes better use of I18n by using translations placed on specific model attributes.

This is part of an ongoing effort to improve I18n as discussed in #735.  

This was previously merged in #795 but removed temporarily in #923 because of breaking a test.  The test has been modified to reflect the changes this PR had introduced.