### PR TITLE
Properly delete tax adjustments in Spree::TaxRate#adjust

### DIFF
--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -86,8 +86,8 @@ module Spree
       rates = self.match(order_tax_zone)
       tax_categories = rates.map(&:tax_category)
       relevant_items, non_relevant_items = items.partition { |item| tax_categories.include?(item.tax_category) }
-      unless relevant_items.empty?
-        Spree::Adjustment.where(adjustable: relevant_items).tax.destroy_all # using destroy_all to ensure adjustment destroy callback fires.
+      relevant_items.group_by { |item| item.class.name }.each do |class_name, items|
+        Spree::Adjustment.where(adjustable_type: class_name, adjustable_id: items.map(&:id)).tax.destroy_all
       end
       relevant_items.each do |item|
         relevant_rates = rates.select { |rate| rate.tax_category == item.tax_category }


### PR DESCRIPTION
As mentioned in #909, `Spree::TaxRate#adjust` does not
delete line item tax adjustments when the first item
in the `items` array is a `Spree::Shipment` and vice versa.

This fixes that.

It'd be great if rails would automatically generate the right
SQL for these cases, but it doesn't: https://github.com/rails/rails/blob/9b67cb3d394692aa7feb7510aab0871e557d3dd0/activerecord/lib/active_record/relation/predicate_builder/association_query_handler.rb#L60-L62