### PR TITLE
Use `delegate` for finding the tax category of a shipment

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -74,6 +74,8 @@ module Spree
     self.whitelisted_ransackable_associations = ['order']
     self.whitelisted_ransackable_attributes = ['number']
 
+    delegate :tax_category, to: :selected_shipping_rate, allow_nil: true
+
     def can_transition_from_pending_to_shipped?
       !requires_shipment?
     end
@@ -242,10 +244,6 @@ module Spree
 
     def shipping_method
       selected_shipping_rate.try(:shipping_method) || shipping_rates.first.try(:shipping_method)
-    end
-
-    def tax_category
-      selected_shipping_rate.try(:tax_rate).try(:tax_category)
     end
 
     # Only one of either included_tax_total or additional_tax_total is set

--- a/core/app/models/spree/shipping_rate.rb
+++ b/core/app/models/spree/shipping_rate.rb
@@ -5,7 +5,7 @@ module Spree
     belongs_to :tax_rate, -> { with_deleted }, class_name: 'Spree::TaxRate'
 
     delegate :order, :currency, to: :shipment
-    delegate :name, to: :shipping_method
+    delegate :name, :tax_category, to: :shipping_method
     delegate :code, to: :shipping_method, prefix: true
 
     def display_base_price

--- a/core/spec/models/spree/tax/taxation_integration_spec.rb
+++ b/core/spec/models/spree/tax/taxation_integration_spec.rb
@@ -146,7 +146,6 @@ RSpec.describe "Taxation system integration tests" do
         end
 
         it 'has a shipment with 0.52 included tax' do
-          pending 'But the tax is not created'
           expect(shipment.included_tax_total).to eq(0.52)
         end
 
@@ -182,7 +181,6 @@ RSpec.describe "Taxation system integration tests" do
         end
 
         it 'has a shipment with 2.55 included tax' do
-          pending 'But the tax is not created'
           expect(shipment.included_tax_total).to eq(2.55)
         end
 
@@ -264,7 +262,6 @@ RSpec.describe "Taxation system integration tests" do
         end
 
         it 'has a shipment with 0.52 included tax' do
-          pending 'But the tax is not created'
           expect(shipment.included_tax_total).to eq(0.52)
         end
 
@@ -304,7 +301,6 @@ RSpec.describe "Taxation system integration tests" do
         end
 
         it 'has a shipment with 2.55 included tax' do
-          pending 'But the tax is not created'
           expect(shipment.included_tax_total).to eq(2.55)
         end
 
@@ -770,7 +766,6 @@ RSpec.describe "Taxation system integration tests" do
         end
 
         it 'has a shipment with additional tax of 0.40' do
-          pending "This does not work because the shipping code does not use contains? for finding zones"
           expect(shipment.additional_tax_total).to eq(0.40)
         end
 


### PR DESCRIPTION
This bypasses the tax rate that's associated to a shipping rate
and directly takes the tax rate from a shipping method. Step one
in allowing multiple shipping rate taxes.

This is cherry-picked from #904 so I can make that one more manageable. 