### PR TITLE
Change redirect following option type update

### DIFF
--- a/backend/app/controllers/spree/admin/option_types_controller.rb
+++ b/backend/app/controllers/spree/admin/option_types_controller.rb
@@ -17,11 +17,7 @@ module Spree
       private
 
       def location_after_save
-        if @option_type.created_at == @option_type.updated_at
-          edit_admin_option_type_url(@option_type)
-        else
-          admin_option_types_url
-        end
+        edit_admin_option_type_url(@option_type)
       end
 
       def load_product


### PR DESCRIPTION
Currently there is a different behaviour when adding option values to an option type that has ever had its name or presentation altered. If either has ever been altered it will route to the option types index.  If
neither has been altered it will route to the option type itself. This  change will simply just route to the option type itself regardless and eliminate the confusing changing behaviour.  However when changing the option type name or presentation it will still redirect to the option type show page.  I suspect this is the behaviour the original code was trying to avoid but I think this changed behaviour makes more sense. 