### PR TITLE
Cleanup use of private

### DIFF
--- a/backend/app/controllers/spree/admin/reports_controller.rb
+++ b/backend/app/controllers/spree/admin/reports_controller.rb
@@ -67,8 +67,6 @@ module Spree
         end
       end
 
-      private
-
       @@available_reports = {}
     end
   end

--- a/backend/app/controllers/spree/admin/variants_controller.rb
+++ b/backend/app/controllers/spree/admin/variants_controller.rb
@@ -52,8 +52,6 @@ module Spree
         @option_values = @option_types.flat_map(&:option_values).uniq(&:presentation)
       end
 
-      private
-
       def load_data
         @tax_categories = TaxCategory.order(:name)
       end

--- a/sample/lib/spree/sample.rb
+++ b/sample/lib/spree/sample.rb
@@ -1,25 +1,27 @@
 require 'spree_core'
 module Spree
   module Sample
-    def self.load_sample(file)
-      # If file is exists within application it takes precendence.
-      if File.exist?(File.join(Rails.root, 'db', 'samples', "#{file}.rb"))
-        path = File.expand_path(File.join(Rails.root, 'db', 'samples', "#{file}.rb"))
-      else
-        # Otherwise we will use this gems default file.
-        path = File.expand_path(samples_path + "#{file}.rb")
+    class << self
+      def load_sample(file)
+        # If file is exists within application it takes precendence.
+        if File.exist?(File.join(Rails.root, 'db', 'samples', "#{file}.rb"))
+          path = File.expand_path(File.join(Rails.root, 'db', 'samples', "#{file}.rb"))
+        else
+          # Otherwise we will use this gems default file.
+          path = File.expand_path(samples_path + "#{file}.rb")
+        end
+        # Check to see if the specified file has been loaded before
+        if !$LOADED_FEATURES.include?(path)
+          require path
+          puts "Loaded #{file.titleize} samples"
+        end
       end
-      # Check to see if the specified file has been loaded before
-      if !$LOADED_FEATURES.include?(path)
-        require path
-        puts "Loaded #{file.titleize} samples"
+
+      private
+
+      def samples_path
+        Pathname.new(File.join(File.dirname(__FILE__), '..', '..', 'db', 'samples'))
       end
-    end
-
-    private
-
-    def self.samples_path
-      Pathname.new(File.join(File.dirname(__FILE__), '..', '..', 'db', 'samples'))
     end
   end
 end


### PR DESCRIPTION
This fixes serveral incorrect uses of `private`, which rubocop was helpfully pointing out.