### PR TITLE
Add missing #orders relation on Spree::Store

### DIFF
--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -2,6 +2,7 @@ module Spree
   class Store < Spree::Base
     has_many :store_payment_methods, inverse_of: :store
     has_many :payment_methods, through: :store_payment_methods
+    has_many :orders, class_name: "Spree::Order"
 
     validates :code, presence: true, uniqueness: { allow_blank: true }
     validates :name, presence: true


### PR DESCRIPTION
There's a `belongs_to` association on Spree::Order, but no corresponding `has_many` association on the Spree::Store.

The commit adds the missing `has_many` line.