### PR TITLE
Remove unclear test in unreturned_item_charger

### DIFF
--- a/core/spec/lib/spree/core/unreturned_item_charger_spec.rb
+++ b/core/spec/lib/spree/core/unreturned_item_charger_spec.rb
@@ -62,11 +62,6 @@ describe Spree::UnreturnedItemCharger do
       end
     end
 
-    it "updates shipment cost" do
-      exchange_shipment.update_attributes!(cost: 0)
-      expect { subject }.to change { exchange_shipment.reload.cost }
-    end
-
     it "creates a new completed order" do
       expect { subject }.to change { Spree::Order.count }.by(1)
       expect(new_order).to_not eq(shipped_order)


### PR DESCRIPTION
This test does not add to readability or understandability of the
behavior of the unreturned item exchanger. It does not help us ensure
its behaving as expected, and is higher value to remove than keep in.