### PR TITLE
Quick return out of add_store_credit_payment

### DIFF
--- a/backend/spec/features/admin/orders/new_order_spec.rb
+++ b/backend/spec/features/admin/orders/new_order_spec.rb
@@ -60,6 +60,35 @@ describe "New Order", type: :feature do
     end
   end
 
+  it 'can create split payments', js: true do
+    click_on 'Cart'
+    select2_search product.name, from: Spree.t(:name_or_sku)
+
+    fill_in_quantity("table.stock-levels", "quantity_0", 2)
+    click_icon :plus
+
+    click_on "Customer"
+
+    within "#select-customer" do
+      targetted_select2_search user.email, from: "#s2id_customer_search"
+    end
+
+    check "order_use_billing"
+    fill_in_address
+    click_on "Update"
+
+    click_on "Payments"
+    fill_in "Amount", with: '10.00'
+    click_on 'Update'
+
+    click_on 'New Payment'
+    fill_in "Amount", with: '29.98'
+    click_on 'Update'
+
+    expect(page).to have_content("$10.00")
+    expect(page).to have_content("$29.98")
+  end
+
   context "adding new item to the order", js: true do
     it "inventory items show up just fine and are also registered as shipments" do
       click_on 'Cart'

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -618,6 +618,9 @@ module Spree
     end
 
     def add_store_credit_payments
+      return if user.nil?
+      return if payments.store_credits.checkout.empty? && user.total_available_store_credit.zero?
+
       payments.store_credits.checkout.each(&:invalidate!)
 
       # this can happen when multiple payments are present, auto_capture is
@@ -627,7 +630,7 @@ module Spree
 
       remaining_total = outstanding_balance - authorized_total
 
-      if user && user.store_credits.any?
+      if user.store_credits.any?
         payment_method = Spree::PaymentMethod::StoreCredit.first
 
         user.store_credits.order_by_priority.each do |credit|

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -1114,12 +1114,6 @@ describe Spree::Order, type: :model do
           end
         end
 
-        context "there are no other payments" do
-          it "adds an error to the model" do
-            expect(subject).to be false
-            expect(order.errors.full_messages).to include(Spree.t("store_credit.errors.unable_to_fund"))
-          end
-        end
       end
 
       context "there is enough store credit to pay for the entire order" do


### PR DESCRIPTION
If we don't have a user, we don't need to be inside of
add_store_credit_payment.

If we have a user that doesn't have any credit, and our order doesn't
have any credit, we don't need to be inside of add_store_credit_payment.

To accomplish this we need to *change existing behavior* of
add_store_credit_payment to not add the error message given the previous
changes. I argue its previous implementation was overstepping its bounds
in assuming it should know when and how to add that error onto the
order.

Related to #908