### PR TITLE
Clean up price calculations

### DIFF
--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -104,14 +104,9 @@ module Spree
 
       currency = opts.delete(:currency) || order.try(:currency)
 
-      if currency
-        self.currency = currency
-        self.price    = variant.price_in(currency).amount +
+      self.currency = currency
+      self.price    = variant.price_in(currency).amount +
         variant.price_modifier_amount_in(currency, opts)
-      else
-        self.price = variant.price +
-        variant.price_modifier_amount(opts)
-      end
 
       assign_attributes opts
     end

--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -102,7 +102,7 @@ module Spree
 
       opts = options.dup # we will be deleting from the hash, so leave the caller's copy intact
 
-      currency = opts.delete(:currency) || order.try(:currency)
+      currency = opts.delete(:currency) || order.currency
 
       self.currency = currency
       self.price    = variant.price_in(currency).amount +

--- a/core/app/models/spree/price.rb
+++ b/core/app/models/spree/price.rb
@@ -46,7 +46,7 @@ module Spree
     def set_default_price
       if is_default?
         other_default_prices = variant.prices.where(currency: self.currency, is_default: true).where.not(id: id)
-        other_default_prices.each { |p| p.update_attributes!(is_default: false) }
+        other_default_prices.update_all(is_default: false)
       end
     end
   end

--- a/core/app/models/spree/return_authorization.rb
+++ b/core/app/models/spree/return_authorization.rb
@@ -47,7 +47,7 @@ module Spree
     end
 
     def currency
-      order.nil? ? Spree::Config[:currency] : order.currency
+      order.currency
     end
 
     def refundable_amount

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -246,6 +246,7 @@ module Spree
 
     # Calculates the sum of the specified price modifiers.
     #
+    # @deprecated This method does not handle currencies
     # @param options [Hash] for specifying keys, eg: `{keys: ['key_1', 'key_2']}`
     # @return [Fixnum] the sum
     def price_modifier_amount(options = {})
@@ -260,6 +261,7 @@ module Spree
         end
       }.sum
     end
+    deprecate :price_modifier_amount, deprecator: Spree::Deprecation
 
     # Generates a friendly name and sku string.
     #


### PR DESCRIPTION
There are several conditions around not having a currency, which is not something which can happen in our system.

Removes a dead branch which calls `price_modifier_amount`, and cleans up some other areas.