### PR TITLE
Add currency preference to item total rule

### DIFF
--- a/backend/app/views/spree/admin/promotions/rules/_item_total.html.erb
+++ b/backend/app/views/spree/admin/promotions/rules/_item_total.html.erb
@@ -1,6 +1,9 @@
-<div class="field alpha four columns">
+<div class="field alpha three columns">
   <%= select_tag "#{param_prefix}[preferred_operator]", options_for_select(Spree::Promotion::Rules::ItemTotal::OPERATORS.map{|o| [Spree.t("item_total_rule.operators.#{o}"),o]}, promotion_rule.preferred_operator), {:class => 'select2 select_item_total fullwidth'} %>
 </div>
-<div class="field omega four columns">
+<div class="field three columns">
   <%= text_field_tag "#{param_prefix}[preferred_amount]", promotion_rule.preferred_amount, :class => 'fullwidth' %>
+</div>
+<div class="field omega two columns">
+  <%= text_field_tag "#{param_prefix}[preferred_currency]", promotion_rule.preferred_currency, :class => 'fullwidth' %>
 </div>

--- a/core/spec/models/spree/promotion/rules/item_total_spec.rb
+++ b/core/spec/models/spree/promotion/rules/item_total_spec.rb
@@ -1,24 +1,33 @@
 require 'spec_helper'
 
 describe Spree::Promotion::Rules::ItemTotal, type: :model do
-  let(:rule) { Spree::Promotion::Rules::ItemTotal.new }
-  let(:order) { double(:order) }
-
-  before { rule.preferred_amount = 50 }
+  let(:rule) do
+    Spree::Promotion::Rules::ItemTotal.new(
+      preferred_amount: preferred_amount,
+      preferred_operator: preferred_operator
+    )
+  end
+  let(:order) { double(:order, item_total: item_total) }
+  let(:preferred_amount) { 50 }
 
   context "preferred operator set to gt" do
-    before { rule.preferred_operator = 'gt' }
+    let(:preferred_operator) { 'gt' }
 
-    it "should be eligible when item total is greater than preferred amount" do
-      allow(order).to receive_messages item_total: 51
-      expect(rule).to be_eligible(order)
+    context "item total is greater than preferred amount" do
+      let(:item_total) { 51 }
+
+      it "should be eligible when item total is greater than preferred amount" do
+        expect(rule).to be_eligible(order)
+      end
     end
 
     context "when item total is equal to preferred amount" do
-      before { allow(order).to receive_messages item_total: 50 }
+      let(:item_total) { 50 }
+
       it "is not eligible" do
         expect(rule).not_to be_eligible(order)
       end
+
       it "set an error message" do
         rule.eligible?(order)
         expect(rule.eligibility_errors.full_messages.first).
@@ -27,10 +36,12 @@ describe Spree::Promotion::Rules::ItemTotal, type: :model do
     end
 
     context "when item total is lower than preferred amount" do
-      before { allow(order).to receive_messages item_total: 49 }
+      let(:item_total) { 49 }
+
       it "is not eligible" do
         expect(rule).not_to be_eligible(order)
       end
+
       it "set an error message" do
         rule.eligible?(order)
         expect(rule.eligibility_errors.full_messages.first).
@@ -40,23 +51,31 @@ describe Spree::Promotion::Rules::ItemTotal, type: :model do
   end
 
   context "preferred operator set to gte" do
-    before { rule.preferred_operator = 'gte' }
+    let(:preferred_operator) { 'gte' }
 
-    it "should be eligible when item total is greater than preferred amount" do
-      allow(order).to receive_messages item_total: 51
-      expect(rule).to be_eligible(order)
+    context "total is greater than preferred amount" do
+      let(:item_total) { 51 }
+
+      it "should be eligible when item total is greater than preferred amount" do
+        expect(rule).to be_eligible(order)
+      end
     end
 
-    it "should be eligible when item total is equal to preferred amount" do
-      allow(order).to receive_messages item_total: 50
-      expect(rule).to be_eligible(order)
+    context "item total is equal to preferred amount" do
+      let(:item_total) { 50 }
+
+      it "should be eligible" do
+        expect(rule).to be_eligible(order)
+      end
     end
 
     context "when item total is lower than preferred amount" do
-      before { allow(order).to receive_messages item_total: 49 }
+      let(:item_total) { 49 }
+
       it "is not eligible" do
         expect(rule).not_to be_eligible(order)
       end
+
       it "set an error message" do
         rule.eligible?(order)
         expect(rule.eligibility_errors.full_messages.first).

--- a/core/spec/models/spree/promotion/rules/item_total_spec.rb
+++ b/core/spec/models/spree/promotion/rules/item_total_spec.rb
@@ -7,8 +7,9 @@ describe Spree::Promotion::Rules::ItemTotal, type: :model do
       preferred_operator: preferred_operator
     )
   end
-  let(:order) { double(:order, item_total: item_total) }
+  let(:order) { double(:order, item_total: item_total, currency: order_currency) }
   let(:preferred_amount) { 50 }
+  let(:order_currency) { 'USD' }
 
   context "preferred operator set to gt" do
     let(:preferred_operator) { 'gt' }
@@ -18,6 +19,14 @@ describe Spree::Promotion::Rules::ItemTotal, type: :model do
 
       it "should be eligible when item total is greater than preferred amount" do
         expect(rule).to be_eligible(order)
+      end
+
+      context "when the order is a different currency" do
+        let(:order_currency) { "CAD" }
+
+        it "is not eligible" do
+          expect(rule).not_to be_eligible(order)
+        end
       end
     end
 
@@ -59,6 +68,14 @@ describe Spree::Promotion::Rules::ItemTotal, type: :model do
       it "should be eligible when item total is greater than preferred amount" do
         expect(rule).to be_eligible(order)
       end
+
+      context "when the order is a different currency" do
+        let(:order_currency) { "CAD" }
+
+        it "is not eligible" do
+          expect(rule).not_to be_eligible(order)
+        end
+      end
     end
 
     context "item total is equal to preferred amount" do
@@ -66,6 +83,14 @@ describe Spree::Promotion::Rules::ItemTotal, type: :model do
 
       it "should be eligible" do
         expect(rule).to be_eligible(order)
+      end
+
+      context "when the order is a different currency" do
+        let(:order_currency) { "CAD" }
+
+        it "is not eligible" do
+          expect(rule).not_to be_eligible(order)
+        end
       end
     end
 


### PR DESCRIPTION
Making a rule based on an item total makes no sense without a currency.
The default value of currency should hopefully keep this rule working
for anyone currently using it, as they are probable on a single currency
store.