### PR TITLE
Calculate pre tax amounts on the fly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 ## Solidus 1.3.0 (unreleased)
 
+*   Removed `pre_tax_amount` column from line item and shipment tables
+
+    This column was previously used as a caching column in the process of
+    calculating VATs. Its value should have been (but wasn't) always the same as
+    `discounted_amount - included_tax_total`. It's been replaced with a method
+    that does just that. [#941](https://github.com/solidusio/solidus/pull/941)
+
+*   Renamed return item `pre_tax_amount` column to `amount`
+
+    The naming and functioning of this column was inconsistent with how
+    shipments and line items work: In those models, the base from which we
+    calculate everything is the `amount`. The ReturnItem now works just like
+    a line item.
+
+    Usability-wise, this change entails that for VAT countries, when creating
+    a refund for an order including VAT, you now have to enter the amount
+    you want to refund including VAT. This is what a backend user working
+    with prices including tax would expect.
+
+    For a non-VAT store, nothing changes except for the form field name, which
+    now says `Amount` instead of `Pre-tax-amount`. You might want to adjust the
+    i18n translation here, depending on your circumstances.
+    [#706](https://github.com/solidusio/solidus/pull/706)
+
 *   Removed Spree::BaseHelper#gem_available? and Spree::BaseHelper#current_spree_page?
 
     Both these methods were untested and not appropriate code to be in core. If you need these

--- a/core/app/models/spree/calculator/default_tax.rb
+++ b/core/app/models/spree/calculator/default_tax.rb
@@ -2,6 +2,8 @@ require_dependency 'spree/calculator'
 
 module Spree
   class Calculator::DefaultTax < Calculator
+    include Spree::Tax::TaxHelpers
+
     def self.description
       Spree.t(:default_tax)
     end
@@ -14,7 +16,7 @@ module Spree
         line_item.tax_category == rate.tax_category
       end
 
-      line_items_total = matched_line_items.sum(&:total)
+      line_items_total = matched_line_items.sum(&:discounted_amount)
       if rate.included_in_price
         round_to_two_places(line_items_total - ( line_items_total / (1 + rate.amount) ) )
       else
@@ -25,7 +27,7 @@ module Spree
     # When it comes to computing shipments or line items: same same.
     def compute_shipment_or_line_item(item)
       if rate.included_in_price
-        deduced_total_by_rate(item.pre_tax_amount, rate)
+        deduced_total_by_rate(item, rate)
       else
         round_to_two_places(item.discounted_amount * rate.amount)
       end
@@ -36,8 +38,7 @@ module Spree
 
     def compute_shipping_rate(shipping_rate)
       if rate.included_in_price
-        pre_tax_amount = shipping_rate.cost / (1 + rate.amount)
-        deduced_total_by_rate(pre_tax_amount, rate)
+        deduced_total_by_rate(shipping_rate, rate)
       else
         with_tax_amount = shipping_rate.cost * rate.amount
         round_to_two_places(with_tax_amount)
@@ -54,8 +55,9 @@ module Spree
       BigDecimal.new(amount.to_s).round(2, BigDecimal::ROUND_HALF_UP)
     end
 
-    def deduced_total_by_rate(pre_tax_amount, rate)
-      round_to_two_places(pre_tax_amount * rate.amount)
+    def deduced_total_by_rate(item, rate)
+      unrounded_net_amount = item.discounted_amount / (1 + sum_of_included_tax_rates(item))
+      round_to_two_places(unrounded_net_amount * rate.amount)
     end
   end
 end

--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -81,6 +81,10 @@ module Spree
     alias display_total money
     alias display_amount money
 
+    def pre_tax_amount
+      discounted_amount - included_tax_total
+    end
+
     # @return [Boolean] true when it is possible to supply the required
     #   quantity of stock of this line item's variant
     def sufficient_stock?

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -163,6 +163,10 @@ module Spree
       inventory_units.includes(:line_item).map(&:line_item).uniq
     end
 
+    def pre_tax_amount
+      discounted_amount - included_tax_total
+    end
+
     def ready_or_pending?
       ready? || pending?
     end

--- a/core/app/models/spree/shipping_rate.rb
+++ b/core/app/models/spree/shipping_rate.rb
@@ -9,6 +9,8 @@ module Spree
     delegate :code, to: :shipping_method, prefix: true
     alias_attribute :amount, :cost
 
+    alias_method :discounted_amount, :amount
+
     extend DisplayMoney
     money_methods :amount
 

--- a/core/app/models/spree/tax/item_adjuster.rb
+++ b/core/app/models/spree/tax/item_adjuster.rb
@@ -29,15 +29,7 @@ module Spree
         # Using .destroy_all to make sure callbacks fire
         item.adjustments.tax.destroy_all
 
-        TaxRate.store_pre_tax_amount(item, rates_for_item)
-
-        rates_for_item.map { |rate| rate.adjust(order_tax_zone(order), item) }
-      end
-
-      private
-
-      def rates_for_item
-        @rates_for_item ||= applicable_rates(order).select { |rate| rate.tax_category == item.tax_category }
+        rates_for_item(item).map { |rate| rate.adjust(order_tax_zone(order), item) }
       end
     end
   end

--- a/core/app/models/spree/tax/tax_helpers.rb
+++ b/core/app/models/spree/tax/tax_helpers.rb
@@ -36,6 +36,14 @@ module Spree
       def order_tax_zone(order)
         @order_tax_zone ||= order.tax_zone
       end
+
+      def sum_of_included_tax_rates(item)
+        rates_for_item(item).map(&:amount).sum
+      end
+
+      def rates_for_item(item)
+        applicable_rates(item.order).select { |rate| rate.tax_category == item.tax_category }
+      end
     end
   end
 end

--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -83,16 +83,6 @@ module Spree
       end
     end
 
-    # Pre-tax amounts must be stored so that we can calculate
-    # correct rate amounts in the future. For example:
-    # https://github.com/spree/spree/issues/4318#issuecomment-34723428
-    def self.store_pre_tax_amount(item, rates)
-      sum_of_included_rates = rates.select(&:included_in_price).map(&:amount).sum
-      pre_tax_amount = item.discounted_amount / (1 + sum_of_included_rates)
-
-      item.update_column(:pre_tax_amount, pre_tax_amount)
-    end
-
     # Creates necessary tax adjustments for the order.
     def adjust(order_tax_zone, item)
       amount = compute_amount(item)

--- a/core/db/migrate/20160301103333_remove_pre_tax_amount_on_line_item_and_shipment.rb
+++ b/core/db/migrate/20160301103333_remove_pre_tax_amount_on_line_item_and_shipment.rb
@@ -1,0 +1,6 @@
+class RemovePreTaxAmountOnLineItemAndShipment < ActiveRecord::Migration
+  def change
+    remove_column :spree_line_items, :pre_tax_amount, :decimal, precision: 12, scale: 4, default: 0.0, null: false
+    remove_column :spree_shipments, :pre_tax_amount, :decimal, precision: 12, scale: 4, default: 0.0, null: false
+  end
+end

--- a/core/lib/spree/testing_support/factories/line_item_factory.rb
+++ b/core/lib/spree/testing_support/factories/line_item_factory.rb
@@ -5,7 +5,6 @@ FactoryGirl.define do
   factory :line_item, class: Spree::LineItem do
     quantity 1
     price { BigDecimal.new('10.00') }
-    pre_tax_amount { price }
     order
     transient do
       product nil

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -225,12 +225,4 @@ describe Spree::LineItem, type: :model do
       expect(line_item.price).to eq 21.98
     end
   end
-
-  describe "precision of pre_tax_amount" do
-    let!(:line_item) { create :line_item, pre_tax_amount: 4.2051 }
-
-    it "keeps four digits of precision even when reloading" do
-      expect(line_item.reload.pre_tax_amount).to eq(4.2051)
-    end
-  end
 end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -756,10 +756,10 @@ describe Spree::Order, type: :model do
   describe "#pre_tax_item_amount" do
     it "sums all of the line items' pre tax amounts" do
       subject.line_items = [
-        Spree::LineItem.new(price: 10, quantity: 2, pre_tax_amount: 5.0),
-        Spree::LineItem.new(price: 30, quantity: 1, pre_tax_amount: 14.0)
+        Spree::LineItem.new(price: 10, quantity: 2, included_tax_total: 15.0),
+        Spree::LineItem.new(price: 30, quantity: 1, included_tax_total: 16.0)
       ]
-
+      # (2*10)-15 + 30-16 = 5 + 14 = 19
       expect(subject.pre_tax_item_amount).to eq 19.0
     end
   end

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -24,14 +24,6 @@ describe Spree::Shipment, type: :model do
   let(:variant) { mock_model(Spree::Variant) }
   let(:line_item) { mock_model(Spree::LineItem, variant: variant) }
 
-  describe "precision of pre_tax_amount" do
-    let!(:line_item) { create :line_item, pre_tax_amount: 4.2051 }
-
-    it "keeps four digits of precision even when reloading" do
-      expect(line_item.reload.pre_tax_amount).to eq(4.2051)
-    end
-  end
-
   # Regression test for https://github.com/spree/spree/issues/4063
   context "number generation" do
     before { allow(order).to receive :update! }

--- a/core/spec/models/spree/tax/item_adjuster_spec.rb
+++ b/core/spec/models/spree/tax/item_adjuster_spec.rb
@@ -42,8 +42,6 @@ RSpec.describe Spree::Tax::ItemAdjuster do
       let(:tax_zone) { build_stubbed(:zone, :with_country) }
 
       before do
-        expect(item).to receive(:update_column)
-
         expect(Spree::TaxRate).to receive(:for_zone).with(tax_zone).and_return(rates_for_order_zone)
         expect(Spree::TaxRate).to receive(:for_zone).with(Spree::Zone.default_tax).and_return([])
       end


### PR DESCRIPTION
This takes away some caching and slows down some of the tax calculations
in VAT countries, but it also speeds up tax calculation for Sales tax countries.

It also makes sure that for line items and shipments, the following always
holds true:

```
discounted_amount - included_tax_total = pre_tax_amount
```

The slowdown is significant, but will be remedied by two planned improvements
in the very near future:
* Looking up rates by address
* Separating handling of default taxes vs. order taxes

I had to adjust the spec setup for the default tax calculator spec and realised the order (!) calculator code has a bug: It takes the item's `total` rather than its `discounted_amount`, applying tax rates twice. Yay. 