### PR TITLE
Set billing address to default address

### DIFF
--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -295,11 +295,13 @@ module Spree
 
           def assign_default_addresses!
             if user
+              bill_address = (user.bill_address || user.default_address)
+              ship_address = (user.ship_address || user.default_address)
               # this is one of 2 places still using User#bill_address
-              self.bill_address ||= user.bill_address if user.bill_address.try!(:valid?)
+              self.bill_address ||= bill_address if bill_address.try!(:valid?)
               # Skip setting ship address if order doesn't have a delivery checkout step
               # to avoid triggering validations on shipping address
-              self.ship_address ||= user.ship_address if user.ship_address.try!(:valid?) && checkout_steps.include?("delivery")
+              self.ship_address ||= ship_address if ship_address.try!(:valid?) && checkout_steps.include?("delivery")
             end
           end
 


### PR DESCRIPTION
Set `bill_address` to default address, if user has one.

Currently when an order goes to `address` state, only `ship_address` gets filled in from a previously entered address. This is because `ship_address` is an alias for `default_address` in the `UserAddressBook` module.
https://github.com/solidusio/solidus/blob/master/core/app/models/concerns/spree/user_address_book.rb#L53
However, `bill_address` is not an alias, so it is not prefilled and user has to enter it every time. Rather than making it into an alias, just try default_address in `assign_default_address!` if user has one.
