### PR TITLE
Split up two SQL statements in migration

### DIFF
--- a/core/db/migrate/20151026093607_change_return_item_pre_tax_amount_to_amount.rb
+++ b/core/db/migrate/20151026093607_change_return_item_pre_tax_amount_to_amount.rb
@@ -3,10 +3,11 @@ class ChangeReturnItemPreTaxAmountToAmount < ActiveRecord::Migration
     execute(<<-SQL)
       UPDATE spree_return_items
       SET included_tax_total = 0
-      WHERE included_tax_total IS NULL;
-
+      WHERE included_tax_total IS NULL
+    SQL
+    execute(<<-SQL)
       UPDATE spree_return_items
-      SET pre_tax_amount = pre_tax_amount + included_tax_total;
+      SET pre_tax_amount = pre_tax_amount + included_tax_total
     SQL
 
     rename_column :spree_return_items, :pre_tax_amount, :amount
@@ -16,10 +17,11 @@ class ChangeReturnItemPreTaxAmountToAmount < ActiveRecord::Migration
     execute(<<-SQL)
       UPDATE spree_return_items
       SET included_tax_total = 0
-      WHERE included_tax_total IS NULL;
-
+      WHERE included_tax_total IS NULL
+    SQL
+    execute(<<-SQL)
       UPDATE spree_return_items
-      SET amount = amount - included_tax_total;
+      SET amount = amount - included_tax_total
     SQL
 
     rename_column :spree_return_items, :amount, :pre_tax_amount


### PR DESCRIPTION
This previously didn't work correctly under MySQL. In Rails 4.2.6.rc1 this raises an exception, in previous versions the second statement was ignored.