### PR TITLE
Get available calculators from configuration.

### DIFF
--- a/backend/app/controllers/spree/admin/shipping_methods_controller.rb
+++ b/backend/app/controllers/spree/admin/shipping_methods_controller.rb
@@ -39,7 +39,7 @@ module Spree
       def load_data
         @available_zones = Zone.order(:name)
         @tax_categories = Spree::TaxCategory.order(:name)
-        @calculators = ShippingMethod.calculators.sort_by(&:name)
+        @calculators = Rails.application.config.spree.calculators.shipping_methods
       end
     end
   end

--- a/backend/app/controllers/spree/admin/tax_rates_controller.rb
+++ b/backend/app/controllers/spree/admin/tax_rates_controller.rb
@@ -8,7 +8,7 @@ module Spree
       def load_data
         @available_zones = Zone.order(:name)
         @available_categories = TaxCategory.order(:name)
-        @calculators = TaxRate.calculators.sort_by(&:name)
+        @calculators = Rails.application.config.spree.calculators.tax_rates
       end
     end
   end


### PR DESCRIPTION
Currently, admin page pulls the list of available calculators from calculators that are already present in the shipping methods in the database. If you delete all the shipping methods in the database, you cannot select calculator when trying to add a new shipping method.