### PR TITLE
Fix incorrect test in Taxon Rule

### DIFF
--- a/core/spec/models/spree/promotion/rules/taxon_spec.rb
+++ b/core/spec/models/spree/promotion/rules/taxon_spec.rb
@@ -53,7 +53,7 @@ describe Spree::Promotion::Rules::Taxon, type: :model do
         before do
           taxon.children << taxon2
           order.products.first.taxons << taxon2
-          rule.taxons << taxon2
+          rule.taxons << taxon
         end
 
         it{ expect(rule).to be_eligible(order) }


### PR DESCRIPTION
  * The correct behaviour is to test the parent taxon set on the rule
    for eligibility against an order with a child taxon