### PR TITLE
Move method definitions out of ActiveSupport::Concern included blocks

### DIFF
--- a/core/app/models/concerns/spree/adjustment_source.rb
+++ b/core/app/models/concerns/spree/adjustment_source.rb
@@ -1,23 +1,19 @@
 module Spree
   module AdjustmentSource
-    extend ActiveSupport::Concern
+    def deals_with_adjustments_for_deleted_source
+      adjustment_scope = adjustments.joins(:order)
 
-    included do
-      def deals_with_adjustments_for_deleted_source
-        adjustment_scope = adjustments.joins(:order)
+      # For incomplete orders, remove the adjustment completely.
+      adjustment_scope.where(spree_orders: { completed_at: nil }).destroy_all
 
-        # For incomplete orders, remove the adjustment completely.
-        adjustment_scope.where(spree_orders: { completed_at: nil }).destroy_all
-
-        # For complete orders, the source will be invalid.
-        # Therefore we nullify the source_id, leaving the adjustment in place.
-        # This would mean that the order's total is not altered at all.
-        attrs = {
-          source_id: nil,
-          updated_at: Time.current
-        }
-        adjustment_scope.where.not(spree_orders: { completed_at: nil }).update_all(attrs)
-      end
+      # For complete orders, the source will be invalid.
+      # Therefore we nullify the source_id, leaving the adjustment in place.
+      # This would mean that the order's total is not altered at all.
+      attrs = {
+        source_id: nil,
+        updated_at: Time.current
+      }
+      adjustment_scope.where.not(spree_orders: { completed_at: nil }).update_all(attrs)
     end
   end
 end

--- a/core/app/models/concerns/spree/calculated_adjustments.rb
+++ b/core/app/models/concerns/spree/calculated_adjustments.rb
@@ -6,29 +6,31 @@ module Spree
       has_one :calculator, class_name: "Spree::Calculator", as: :calculable, inverse_of: :calculable, dependent: :destroy, autosave: true
       accepts_nested_attributes_for :calculator
       validates :calculator, presence: true
+    end
 
-      def self.calculators
+    class_methods do
+      def calculators
         spree_calculators.send model_name_without_spree_namespace
-      end
-
-      def calculator_type
-        calculator.class.to_s if calculator
-      end
-
-      def calculator_type=(calculator_type)
-        klass = calculator_type.constantize if calculator_type
-        self.calculator = klass.new if klass && !calculator.is_a?(klass)
       end
 
       private
 
-      def self.model_name_without_spree_namespace
+      def model_name_without_spree_namespace
         to_s.tableize.tr('/', '_').sub('spree_', '')
       end
 
-      def self.spree_calculators
+      def spree_calculators
         Rails.application.config.spree.calculators
       end
+    end
+
+    def calculator_type
+      calculator.class.to_s if calculator
+    end
+
+    def calculator_type=(calculator_type)
+      klass = calculator_type.constantize if calculator_type
+      self.calculator = klass.new if klass && !calculator.is_a?(klass)
     end
   end
 end

--- a/core/app/models/concerns/spree/default_price.rb
+++ b/core/app/models/concerns/spree/default_price.rb
@@ -10,33 +10,33 @@ module Spree
         dependent: :destroy,
         autosave: true
 
-      def find_or_build_default_price
-        default_price || build_default_price
-      end
-
-      delegate :display_price, :display_amount,
-                :price, :price=, :currency, :currency=,
-                to: :find_or_build_default_price
-
       after_save :save_default_price
+    end
 
-      def default_price
-        Spree::Price.unscoped { super }
-      end
+    def find_or_build_default_price
+      default_price || build_default_price
+    end
 
-      def has_default_price?
-        !default_price.nil?
-      end
+    delegate :display_price, :display_amount,
+      :price, :price=, :currency, :currency=,
+      to: :find_or_build_default_price
 
-      private
+    def default_price
+      Spree::Price.unscoped { super }
+    end
 
-      def default_price_changed?
-        default_price && (default_price.changed? || default_price.new_record?)
-      end
+    def has_default_price?
+      !default_price.nil?
+    end
 
-      def save_default_price
-        default_price.save if default_price_changed?
-      end
+    private
+
+    def default_price_changed?
+      default_price && (default_price.changed? || default_price.new_record?)
+    end
+
+    def save_default_price
+      default_price.save if default_price_changed?
     end
   end
 end

--- a/core/app/models/concerns/spree/ordered_property_value_list.rb
+++ b/core/app/models/concerns/spree/ordered_property_value_list.rb
@@ -9,19 +9,19 @@ module Spree
       validates_with Spree::Validations::DbMaximumLengthValidator, field: :value
 
       default_scope -> { order(:position) }
+    end
 
-      # virtual attributes for use with AJAX autocompletion
-      def property_name
-        property.name if property
-      end
+    # virtual attributes for use with AJAX autocompletion
+    def property_name
+      property.name if property
+    end
 
-      def property_name=(name)
-        unless name.blank?
-          unless property = Property.find_by(name: name)
-            property = Property.create(name: name, presentation: name)
-          end
-          self.property = property
+    def property_name=(name)
+      unless name.blank?
+        unless property = Property.find_by(name: name)
+          property = Property.create(name: name, presentation: name)
         end
+        self.property = property
       end
     end
   end

--- a/core/app/models/concerns/spree/ransackable_attributes.rb
+++ b/core/app/models/concerns/spree/ransackable_attributes.rb
@@ -6,12 +6,14 @@ module Spree::RansackableAttributes
 
     class_attribute :default_ransackable_attributes
     self.default_ransackable_attributes = %w[id name]
+  end
 
-    def self.ransackable_associations(*_args)
+  class_methods do
+    def ransackable_associations(*_args)
       whitelisted_ransackable_associations || []
     end
 
-    def self.ransackable_attributes(*_args)
+    def ransackable_attributes(*_args)
       default_ransackable_attributes | (whitelisted_ransackable_attributes || [])
     end
   end

--- a/core/app/models/concerns/spree/user_address_book.rb
+++ b/core/app/models/concerns/spree/user_address_book.rb
@@ -24,110 +24,110 @@ module Spree
 
       # bill_address is only minimally used now, but we can't get rid of it without a major version release
       belongs_to :bill_address, class_name: 'Spree::Address'
+    end
 
-      def bill_address=(address)
-        # stow a copy in our address book too
-        address = save_in_address_book(address.attributes) if address
-        super(address)
+    def bill_address=(address)
+      # stow a copy in our address book too
+      address = save_in_address_book(address.attributes) if address
+      super(address)
+    end
+
+    def bill_address_attributes=(attributes)
+      self.bill_address = Address.immutable_merge(bill_address, attributes)
+    end
+
+    def default_address
+      user_addresses.default.first.try(:address)
+    end
+
+    def default_address=(address)
+      save_in_address_book(address.attributes, true) if address
+    end
+
+    def default_address_attributes=(attributes)
+      # see "Nested Attributes Examples" section of http://apidock.com/rails/ActionView/Helpers/FormHelper/fields_for
+      # this #{fieldname}_attributes= method works with fields_for in the views
+      # even without declaring accepts_nested_attributes_for
+      self.default_address = Address.immutable_merge(default_address, attributes)
+    end
+
+    alias_method :ship_address, :default_address
+    alias_method :ship_address_attributes=, :default_address_attributes=
+
+    # saves address in address book
+    # sets address to the default if automatic_default_address is set to true
+    # if address is nil, does nothing and returns nil
+    def ship_address=(address)
+      be_default = Spree::Config.automatic_default_address
+      save_in_address_book(address.attributes, be_default) if address
+    end
+
+    # saves order.ship_address and order.bill_address in address book
+    # sets ship_address to the default if automatic_default_address is set to true
+    # sets bill_address to the default if automatic_default_address is set to true and there is no ship_address
+    # if one address is nil, does not save that address
+    def persist_order_address(order)
+      save_in_address_book(
+        order.ship_address.attributes,
+        Spree::Config.automatic_default_address
+      ) if order.ship_address
+
+      save_in_address_book(
+        order.bill_address.attributes,
+        order.ship_address.nil? && Spree::Config.automatic_default_address
+      ) if order.bill_address
+    end
+
+    # Add an address to the user's list of saved addresses for future autofill
+    # @param address_attributes HashWithIndifferentAccess of attributes that will be
+    # treated as value equality to de-dup among existing Addresses
+    # @param default set whether or not this address will show up from
+    # #default_address or not
+    def save_in_address_book(address_attributes, default = false)
+      return nil unless address_attributes.present?
+      address_attributes = address_attributes.with_indifferent_access
+
+      new_address = Address.factory(address_attributes)
+      return new_address unless new_address.valid?
+
+      first_one = user_addresses.empty?
+
+      if address_attributes[:id].present? && new_address.id != address_attributes[:id]
+        remove_from_address_book(address_attributes[:id])
       end
 
-      def bill_address_attributes=(attributes)
-        self.bill_address = Address.immutable_merge(bill_address, attributes)
+      user_address = prepare_user_address(new_address)
+      user_addresses.mark_default(user_address) if default || first_one
+
+      if persisted?
+        user_address.save!
+        user_addresses.reset # ensures proper ordering
       end
 
-      def default_address
-        user_addresses.default.first.try(:address)
+      user_address.address
+    end
+
+    def mark_default_address(address)
+      user_addresses.mark_default(user_addresses.find_by(address: address))
+    end
+
+    def remove_from_address_book(address_id)
+      user_address = user_addresses.find_by(address_id: address_id)
+      if user_address
+        user_address.update_attributes(archived: true, default: false)
+      else
+        false
       end
+    end
 
-      def default_address=(address)
-        save_in_address_book(address.attributes, true) if address
-      end
+    private
 
-      def default_address_attributes=(attributes)
-        # see "Nested Attributes Examples" section of http://apidock.com/rails/ActionView/Helpers/FormHelper/fields_for
-        # this #{fieldname}_attributes= method works with fields_for in the views
-        # even without declaring accepts_nested_attributes_for
-        self.default_address = Address.immutable_merge(default_address, attributes)
-      end
-
-      alias_method :ship_address, :default_address
-      alias_method :ship_address_attributes=, :default_address_attributes=
-
-      # saves address in address book
-      # sets address to the default if automatic_default_address is set to true
-      # if address is nil, does nothing and returns nil
-      def ship_address=(address)
-        be_default = Spree::Config.automatic_default_address
-        save_in_address_book(address.attributes, be_default) if address
-      end
-
-      # saves order.ship_address and order.bill_address in address book
-      # sets ship_address to the default if automatic_default_address is set to true
-      # sets bill_address to the default if automatic_default_address is set to true and there is no ship_address
-      # if one address is nil, does not save that address
-      def persist_order_address(order)
-        save_in_address_book(
-          order.ship_address.attributes,
-          Spree::Config.automatic_default_address
-        ) if order.ship_address
-
-        save_in_address_book(
-          order.bill_address.attributes,
-          order.ship_address.nil? && Spree::Config.automatic_default_address
-        ) if order.bill_address
-      end
-
-      # Add an address to the user's list of saved addresses for future autofill
-      # @param address_attributes HashWithIndifferentAccess of attributes that will be
-      # treated as value equality to de-dup among existing Addresses
-      # @param default set whether or not this address will show up from
-      # #default_address or not
-      def save_in_address_book(address_attributes, default = false)
-        return nil unless address_attributes.present?
-        address_attributes = address_attributes.with_indifferent_access
-
-        new_address = Address.factory(address_attributes)
-        return new_address unless new_address.valid?
-
-        first_one = user_addresses.empty?
-
-        if address_attributes[:id].present? && new_address.id != address_attributes[:id]
-          remove_from_address_book(address_attributes[:id])
-        end
-
-        user_address = prepare_user_address(new_address)
-        user_addresses.mark_default(user_address) if default || first_one
-
-        if persisted?
-          user_address.save!
-          user_addresses.reset # ensures proper ordering
-        end
-
-        user_address.address
-      end
-
-      def mark_default_address(address)
-        user_addresses.mark_default(user_addresses.find_by(address: address))
-      end
-
-      def remove_from_address_book(address_id)
-        user_address = user_addresses.find_by(address_id: address_id)
-        if user_address
-          user_address.update_attributes(archived: true, default: false)
-        else
-          false
-        end
-      end
-
-      private
-
-      def prepare_user_address(new_address)
-        user_address = user_addresses.all_historical.find_first_by_address_values(new_address.attributes)
-        user_address ||= user_addresses.build
-        user_address.address = new_address
-        user_address.archived = false
-        user_address
-      end
+    def prepare_user_address(new_address)
+      user_address = user_addresses.all_historical.find_first_by_address_values(new_address.attributes)
+      user_address ||= user_addresses.build
+      user_address.address = new_address
+      user_address.archived = false
+      user_address
     end
   end
 end

--- a/core/app/models/concerns/spree/user_payment_source.rb
+++ b/core/app/models/concerns/spree/user_payment_source.rb
@@ -4,16 +4,19 @@ module Spree
 
     included do
       has_many :credit_cards, class_name: "Spree::CreditCard", foreign_key: :user_id
-      def default_credit_card; credit_cards.default.first; end
+    end
 
-      def payment_sources
-        credit_cards.with_payment_profile
-      end
+    def default_credit_card
+      credit_cards.default.first
+    end
 
-      def drop_payment_source(source)
-        gateway = source.payment_method
-        gateway.disable_customer_profile(source)
-      end
+    def payment_sources
+      credit_cards.with_payment_profile
+    end
+
+    def drop_payment_source(source)
+      gateway = source.payment_method
+      gateway.disable_customer_profile(source)
     end
   end
 end

--- a/core/app/models/spree/order/payments.rb
+++ b/core/app/models/spree/order/payments.rb
@@ -1,61 +1,58 @@
 module Spree
   class Order < Spree::Base
     module Payments
-      extend ActiveSupport::Concern
-      included do
-        # processes any pending payments and must return a boolean as it's
-        # return value is used by the checkout state_machine to determine
-        # success or failure of the 'complete' event for the order
-        #
-        # Returns:
-        #
-        # - true if all pending payments processed successfully
-        #
-        # - true if a payment failed, ie. raised a GatewayError
-        #   which gets rescued and converted to TRUE when
-        #   :allow_checkout_gateway_error is set to true
-        #
-        # - false if a payment failed, ie. raised a GatewayError
-        #   which gets rescued and converted to FALSE when
-        #   :allow_checkout_on_gateway_error is set to false
-        #
-        def process_payments!
-          process_payments_with(:process!)
-        end
+      # processes any pending payments and must return a boolean as it's
+      # return value is used by the checkout state_machine to determine
+      # success or failure of the 'complete' event for the order
+      #
+      # Returns:
+      #
+      # - true if all pending payments processed successfully
+      #
+      # - true if a payment failed, ie. raised a GatewayError
+      #   which gets rescued and converted to TRUE when
+      #   :allow_checkout_gateway_error is set to true
+      #
+      # - false if a payment failed, ie. raised a GatewayError
+      #   which gets rescued and converted to FALSE when
+      #   :allow_checkout_on_gateway_error is set to false
+      #
+      def process_payments!
+        process_payments_with(:process!)
+      end
 
-        def authorize_payments!
-          process_payments_with(:authorize!)
-        end
+      def authorize_payments!
+        process_payments_with(:authorize!)
+      end
 
-        def capture_payments!
-          process_payments_with(:purchase!)
-        end
+      def capture_payments!
+        process_payments_with(:purchase!)
+      end
 
-        def unprocessed_payments
-          payments.select(&:checkout?)
-        end
+      def unprocessed_payments
+        payments.select(&:checkout?)
+      end
 
-        private
+      private
 
-        def process_payments_with(method)
-          # Don't run if there is nothing to pay.
-          return true if payment_total >= total
-          # Prevent orders from transitioning to complete without a successfully processed payment.
-          raise Core::GatewayError.new(Spree.t(:no_payment_found)) if unprocessed_payments.empty?
+      def process_payments_with(method)
+        # Don't run if there is nothing to pay.
+        return true if payment_total >= total
+        # Prevent orders from transitioning to complete without a successfully processed payment.
+        raise Core::GatewayError.new(Spree.t(:no_payment_found)) if unprocessed_payments.empty?
 
-          unprocessed_payments.each do |payment|
-            break if payment_total >= total
+        unprocessed_payments.each do |payment|
+          break if payment_total >= total
 
-            payment.public_send(method)
+          payment.public_send(method)
 
-            if payment.completed?
-              self.payment_total += payment.amount
-            end
+          if payment.completed?
+            self.payment_total += payment.amount
           end
-        rescue Core::GatewayError => e
-          result = !!Spree::Config[:allow_checkout_on_gateway_error]
-          errors.add(:base, e.message) && (return result)
         end
+      rescue Core::GatewayError => e
+        result = !!Spree::Config[:allow_checkout_on_gateway_error]
+        errors.add(:base, e.message) && (return result)
       end
     end
   end

--- a/core/lib/spree/core/controller_helpers/common.rb
+++ b/core/lib/spree/core/controller_helpers/common.rb
@@ -11,61 +11,61 @@ module Spree
           layout :get_layout
 
           before_filter :set_user_language
+        end
 
-          protected
+        protected
 
-          # can be used in views as well as controllers.
-          # e.g. <% self.title = 'This is a custom title for this view' %>
-          attr_writer :title
+        # can be used in views as well as controllers.
+        # e.g. <% self.title = 'This is a custom title for this view' %>
+        attr_writer :title
 
-          def title
-            title_string = @title.present? ? @title : accurate_title
-            if title_string.present?
-              if Spree::Config[:always_put_site_name_in_title]
-                [title_string, default_title].join(' - ')
-              else
-                title_string
-              end
+        def title
+          title_string = @title.present? ? @title : accurate_title
+          if title_string.present?
+            if Spree::Config[:always_put_site_name_in_title]
+              [title_string, default_title].join(' - ')
             else
-              default_title
+              title_string
             end
+          else
+            default_title
           end
+        end
 
-          def default_title
-            current_store.name
+        def default_title
+          current_store.name
+        end
+
+        # this is a hook for subclasses to provide title
+        def accurate_title
+          current_store.seo_title
+        end
+
+        def render_404(_exception = nil)
+          respond_to do |type|
+            type.html { render status: :not_found, file: "#{::Rails.root}/public/404", formats: [:html], layout: nil }
+            type.all  { render status: :not_found, nothing: true }
           end
+        end
 
-          # this is a hook for subclasses to provide title
-          def accurate_title
-            current_store.seo_title
-          end
+        private
 
-          def render_404(_exception = nil)
-            respond_to do |type|
-              type.html { render status: :not_found, file: "#{::Rails.root}/public/404", formats: [:html], layout: nil }
-              type.all  { render status: :not_found, nothing: true }
-            end
-          end
+        def set_user_language
+          locale = session[:locale]
+          locale ||= config_locale if respond_to?(:config_locale, true)
+          locale ||= Rails.application.config.i18n.default_locale
+          locale ||= I18n.default_locale
+          I18n.locale = locale
+        end
 
-          private
-
-          def set_user_language
-            locale = session[:locale]
-            locale ||= config_locale if respond_to?(:config_locale, true)
-            locale ||= Rails.application.config.i18n.default_locale
-            locale ||= I18n.default_locale
-            I18n.locale = locale
-          end
-
-          # Returns which layout to render.
-          #
-          # You can set the layout you want to render inside your Spree configuration with the +:layout+ option.
-          #
-          # Default layout is: +app/views/spree/layouts/spree_application+
-          #
-          def get_layout
-            Spree::Config[:layout]
-          end
+        # Returns which layout to render.
+        #
+        # You can set the layout you want to render inside your Spree configuration with the +:layout+ option.
+        #
+        # Default layout is: +app/views/spree/layouts/spree_application+
+        #
+        def get_layout
+          Spree::Config[:layout]
         end
       end
     end

--- a/core/lib/spree/core/controller_helpers/store.rb
+++ b/core/lib/spree/core/controller_helpers/store.rb
@@ -13,10 +13,11 @@ module Spree
           class_attribute :current_store_class
           self.current_store_class = Spree::Core::CurrentStore
 
-          def current_store
-            @current_store ||= current_store_class.new(request).store
-          end
           helper_method :current_store
+        end
+
+        def current_store
+          @current_store ||= current_store_class.new(request).store
         end
       end
     end


### PR DESCRIPTION
`ActiveSupport::Concern`'s included block should only include logic which needs a `class_eval` on the including object. For any methods which don't need dynamic definition at include time we can just define them in the module for instance methods, or inside a `class_methods` block (or a module named `ClassMethods`) for class methods.