### PR TITLE
Show empty shipments in the admin

### DIFF
--- a/backend/app/views/spree/admin/orders/_shipment.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment.html.erb
@@ -74,7 +74,7 @@
           <% end %>
 
           <td class="actions">
-            <% if( (can? :update, shipment) and !shipment.shipped?) %>
+            <% if can?(:update, shipment) && !shipment.shipped? %>
               <%= link_to '', '#', :class => 'edit-method fa fa-edit no-text with-tip', :data => {:action => 'edit'}, :title => Spree.t('actions.edit') %>
             <% end %>
           </td>

--- a/backend/app/views/spree/admin/orders/_shipment.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment.html.erb
@@ -1,122 +1,120 @@
 <% manifest_items = Spree::ShippingManifest.new(inventory_units: shipment.inventory_units.where(carton_id: nil)).items %>
 
-<% unless manifest_items.empty? %>
-  <div id="<%= "shipment_#{shipment.id}" %>" class="js-shipment-edit" data-hook="admin_shipment_form">
-    <fieldset class="no-border-bottom">
-      <legend align="center" class="stock-location" data-hook="stock-location">
-        <span class="shipment-number"><%= shipment.number %></span>
-        -
-        <span class="shipment-state"><%= Spree.t("shipment_states.#{shipment.state}") %></span>
-        <%= Spree.t(:package_from) %>
-        <strong class="stock-location-name" data-hook="stock-location-name">'<%= shipment.stock_location.name %>'</strong>
-      </legend>
+<div id="<%= "shipment_#{shipment.id}" %>" class="js-shipment-edit" data-hook="admin_shipment_form">
+  <fieldset class="no-border-bottom">
+    <legend align="center" class="stock-location" data-hook="stock-location">
+      <span class="shipment-number"><%= shipment.number %></span>
+      -
+      <span class="shipment-state"><%= Spree.t("shipment_states.#{shipment.state}") %></span>
+      <%= Spree.t(:package_from) %>
+      <strong class="stock-location-name" data-hook="stock-location-name">'<%= shipment.stock_location.name %>'</strong>
+    </legend>
 
-      <% if shipment.ready? && can?(:ship, shipment) %>
-        <%= form_tag("#", class: "admin-ship-shipment") do %>
-          <%= check_box_tag :send_mailer, true, true %>
-          <%= label_tag :send_mailer, Spree.t(:send_mailer) %>
-          <%= submit_tag Spree.t('actions.ship'), class: "ship-shipment-button" %>
-        <% end %>
+    <% if shipment.ready? && can?(:ship, shipment) %>
+      <%= form_tag("#", class: "admin-ship-shipment") do %>
+        <%= check_box_tag :send_mailer, true, true %>
+        <%= label_tag :send_mailer, Spree.t(:send_mailer) %>
+        <%= submit_tag Spree.t('actions.ship'), class: "ship-shipment-button" %>
       <% end %>
-    </fieldset>
+    <% end %>
+  </fieldset>
 
-    <table class="stock-contents shipment index" data-hook="stock-contents">
-      <colgroup>
-        <col style="width: 10%;" />
-        <col style="width: 30%;" />
-        <col style="width: 15%;" />
-        <col style="width: 15%;" />
-        <col style="width: 15%;" />
-        <col style="width: 15%;" />
-      </colgroup>
+  <table class="stock-contents shipment index" data-hook="stock-contents">
+    <colgroup>
+      <col style="width: 10%;" />
+      <col style="width: 30%;" />
+      <col style="width: 15%;" />
+      <col style="width: 15%;" />
+      <col style="width: 15%;" />
+      <col style="width: 15%;" />
+    </colgroup>
 
-      <thead>
-        <th colspan="2"><%= Spree::LineItem.human_attribute_name(:description) %></th>
-        <th><%= Spree::LineItem.human_attribute_name(:price) %></th>
-        <th><%= Spree::LineItem.human_attribute_name(:quantity) %></th>
-        <th><%= Spree::LineItem.human_attribute_name(:total) %></th>
-        <th class="orders-actions actions" data-hook="admin_order_form_line_items_header_actions"></th>
-      </thead>
+    <thead>
+      <th colspan="2"><%= Spree::LineItem.human_attribute_name(:description) %></th>
+      <th><%= Spree::LineItem.human_attribute_name(:price) %></th>
+      <th><%= Spree::LineItem.human_attribute_name(:quantity) %></th>
+      <th><%= Spree::LineItem.human_attribute_name(:total) %></th>
+      <th class="orders-actions actions" data-hook="admin_order_form_line_items_header_actions"></th>
+    </thead>
 
-      <tbody data-shipment-number="<%= shipment.number %>" data-order-number="<%= order.number %>">
-        <%= render 'spree/admin/orders/shipment_manifest', { shipment_number: shipment.number, shipment_manifest: manifest_items } %>
+    <tbody data-shipment-number="<%= shipment.number %>" data-order-number="<%= order.number %>">
+      <%= render 'spree/admin/orders/shipment_manifest', { shipment_number: shipment.number, shipment_manifest: manifest_items } %>
 
-        <% unless shipment.shipped? %>
-          <tr class="edit-method hidden total">
-            <td colspan="5">
-              <div class="field alpha five columns">
-                <%= label_tag 'selected_shipping_rate_id', Spree::ShippingMethod.model_name.human %>
-                <%= select_tag :selected_shipping_rate_id,
-                      options_for_select(shipment.shipping_rates.map {|sr| ["#{sr.name} #{sr.display_price}", sr.id] }, shipment.selected_shipping_rate_id),
-                      {:class => 'select2 fullwidth', :data => {'shipment-number' => shipment.number } } %>
-              </div>
+      <% unless shipment.shipped? %>
+        <tr class="edit-method hidden total">
+          <td colspan="5">
+            <div class="field alpha five columns">
+              <%= label_tag 'selected_shipping_rate_id', Spree::ShippingMethod.model_name.human %>
+              <%= select_tag :selected_shipping_rate_id,
+                    options_for_select(shipment.shipping_rates.map {|sr| ["#{sr.name} #{sr.display_price}", sr.id] }, shipment.selected_shipping_rate_id),
+                    {:class => 'select2 fullwidth', :data => {'shipment-number' => shipment.number } } %>
+            </div>
+          </td>
+          <td class="actions">
+            <% if can? :update, shipment %>
+              <%= link_to '', '#', :class => 'save-method fa fa-check no-text with-tip',
+                :data => {'shipment-number' => shipment.number, :action => 'save'}, title: Spree.t('actions.save') %>
+              <%= link_to '', '#', :class => 'cancel-method fa fa-cancel no-text with-tip',
+                :data => {:action => 'cancel'}, :title => Spree.t('actions.cancel') %>
+            <% end %>
+          </td>
+        </tr>
+        <% end %>
+
+        <tr class="show-method total">
+          <% if rate = shipment.selected_shipping_rate %>
+            <td colspan="4">
+              <strong><%= rate.name %></strong>
             </td>
-            <td class="actions">
-              <% if can? :update, shipment %>
-                <%= link_to '', '#', :class => 'save-method fa fa-check no-text with-tip',
-                  :data => {'shipment-number' => shipment.number, :action => 'save'}, title: Spree.t('actions.save') %>
-                <%= link_to '', '#', :class => 'cancel-method fa fa-cancel no-text with-tip',
-                  :data => {:action => 'cancel'}, :title => Spree.t('actions.cancel') %>
-              <% end %>
+            <td class="total" align="center">
+              <span><%= shipment.display_cost %></span>
             </td>
-          </tr>
+          <% else %>
+            <td colspan='5'><%= Spree.t(:no_shipping_method_selected) %></td>
           <% end %>
 
-          <tr class="show-method total">
-            <% if rate = shipment.selected_shipping_rate %>
-              <td colspan="4">
-                <strong><%= rate.name %></strong>
-              </td>
-              <td class="total" align="center">
-                <span><%= shipment.display_cost %></span>
-              </td>
-            <% else %>
-              <td colspan='5'><%= Spree.t(:no_shipping_method_selected) %></td>
+          <td class="actions">
+            <% if( (can? :update, shipment) and !shipment.shipped?) %>
+              <%= link_to '', '#', :class => 'edit-method fa fa-edit no-text with-tip', :data => {:action => 'edit'}, :title => Spree.t('actions.edit') %>
             <% end %>
+          </td>
+        </tr>
 
-            <td class="actions">
-              <% if( (can? :update, shipment) and !shipment.shipped?) %>
-                <%= link_to '', '#', :class => 'edit-method fa fa-edit no-text with-tip', :data => {:action => 'edit'}, :title => Spree.t('actions.edit') %>
-              <% end %>
-            </td>
-          </tr>
+      <tr class="edit-tracking hidden total">
+        <td colspan="5">
+          <label><%= Spree::Shipment.human_attribute_name(:tracking) %>:</label>
+          <%= text_field_tag :tracking, shipment.tracking %>
+        </td>
+        <td class="actions">
+          <% if can? :update, shipment %>
+            <%= link_to '', '#', :class => 'save-tracking fa fa-check no-text with-tip', :data => {'shipment-number' => shipment.number, :action => 'save'}, :title => Spree.t('actions.save') %>
+            <%= link_to '', '#', :class => 'cancel-tracking fa fa-cancel no-text with-tip', :data => {:action => 'cancel'}, :title => Spree.t('actions.cancel') %>
+          <% end %>
+        </td>
+      </tr>
 
-        <tr class="edit-tracking hidden total">
+      <% if order.special_instructions.present? %>
+        <tr class='special_instructions'>
           <td colspan="5">
-            <label><%= Spree::Shipment.human_attribute_name(:tracking) %>:</label>
-            <%= text_field_tag :tracking, shipment.tracking %>
-          </td>
-          <td class="actions">
-            <% if can? :update, shipment %>
-              <%= link_to '', '#', :class => 'save-tracking fa fa-check no-text with-tip', :data => {'shipment-number' => shipment.number, :action => 'save'}, :title => Spree.t('actions.save') %>
-              <%= link_to '', '#', :class => 'cancel-tracking fa fa-cancel no-text with-tip', :data => {:action => 'cancel'}, :title => Spree.t('actions.cancel') %>
-            <% end %>
+            <strong><%= Spree.t(:special_instructions) %>:&nbsp;</strong><%= order.special_instructions %>
           </td>
         </tr>
+      <% end %>
 
-        <% if order.special_instructions.present? %>
-          <tr class='special_instructions'>
-            <td colspan="5">
-              <strong><%= Spree.t(:special_instructions) %>:&nbsp;</strong><%= order.special_instructions %>
-            </td>
-          </tr>
-        <% end %>
-
-        <tr class="show-tracking total">
-          <td colspan="5" class="tracking-value">
-            <% if shipment.tracking.present? %>
-              <strong><%= Spree::Shipment.human_attribute_name(:tracking) %>:</strong> <%= shipment.tracking %>
-            <% else %>
-              <%= Spree.t(:no_tracking_present) %>
-            <% end %>
-          </td>
-          <td class="actions">
-            <% if can? :update, shipment %>
-              <%= link_to '', '#', :class => 'edit-tracking fa fa-edit no-text with-tip', :data => {:action => 'edit'}, :title => Spree.t('actions.edit') %>
-            <% end %>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
-<% end %>
+      <tr class="show-tracking total">
+        <td colspan="5" class="tracking-value">
+          <% if shipment.tracking.present? %>
+            <strong><%= Spree::Shipment.human_attribute_name(:tracking) %>:</strong> <%= shipment.tracking %>
+          <% else %>
+            <%= Spree.t(:no_tracking_present) %>
+          <% end %>
+        </td>
+        <td class="actions">
+          <% if can? :update, shipment %>
+            <%= link_to '', '#', :class => 'edit-tracking fa fa-edit no-text with-tip', :data => {:action => 'edit'}, :title => Spree.t('actions.edit') %>
+          <% end %>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -348,6 +348,8 @@ describe "Order Details", type: :feature, js: true do
           fill_in 'item_quantity', with: 2
           click_icon :ok
 
+          expect(page).not_to have_content(/Move .* to/)
+
           expect(page).to have_css("#shipment_#{@shipment2.id}", count: 1)
 
           expect(order.shipments.count).to eq(1)
@@ -359,11 +361,14 @@ describe "Order Details", type: :feature, js: true do
 
           it 'should not allow a split if the receiving shipment qty plus the incoming is greater than the count_on_hand' do
             expect(order.shipments.count).to eq(2)
+            expect(page).to have_css('.item-name', text: product.name, count: 1)
 
             within_row(1) { click_icon 'arrows-h' }
             targetted_select2 @shipment2.number, from: '#s2id_item_stock_location'
             fill_in 'item_quantity', with: 1
             click_icon :ok
+
+            expect(page).to have_css('.item-name', text: product.name, count: 2)
 
             within(all('.stock-contents', count: 2).first) do
               within_row(1) { click_icon 'arrows-h' }
@@ -401,6 +406,7 @@ describe "Order Details", type: :feature, js: true do
 
             click_icon :ok
 
+            expect(page).not_to have_content(/Move .* to/)
             expect(page).to have_css('.shipment', count: 2)
 
             expect(order.shipments.count).to eq(2)


### PR DESCRIPTION
Previously, empty shipments would be hidden from admins. If there is a shipment on the order in the database, it should be shown to admins so that they are aware of the true status of their order.