### PR TITLE
Reduce the surface area of Spree::Stock::Coordinator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Solidus 1.3.0 (unreleased)
 
+*   Removed Spree::Stock::Coordinator#packages from the public interface.
+
 *   Removed Spree::BaseHelper#gem_available? and Spree::BaseHelper#current_spree_page?
 
     Both these methods were untested and not appropriate code to be in core. If you need these

--- a/core/app/models/spree/stock/coordinator.rb
+++ b/core/app/models/spree/stock/coordinator.rb
@@ -15,6 +15,8 @@ module Spree
         end
       end
 
+      private
+
       def packages
         packages = build_location_configured_packages
         packages = build_packages(packages)
@@ -64,8 +66,6 @@ module Spree
         end
         packages
       end
-
-      private
 
       # This finds the variants we're looking for in each active stock location.
       # It returns a hash like:


### PR DESCRIPTION
Make 'shipments' the only public method of the Coordinator. It's the
only method called on Coordinator outside of the specs.

This was prompted by me looking at the Coordinator code while
reviewing some of the taxes work and thinking it might be nice to
refactor it a bit, which is easier with a reduced surface area.