### PR TITLE
Disable Rubocop SymbolProc

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -187,6 +187,9 @@ Style/StringLiterals:
   Enabled: false
   StyleGuide: http://relaxed.ruby.style/#stylestringliterals
 
+Style/SymbolProc:
+  Enabled: false
+
 Style/WhileUntilModifier:
   Enabled: false
   StyleGuide: http://relaxed.ruby.style/#stylewhileuntilmodifier


### PR DESCRIPTION
I personally usually agree with this Cop but it doesn't seem worth
hassling people over.
https://github.com/bbatsov/rubocop/blob/v0.37.2/lib/rubocop/cop/style/symbol_proc.rb