### PR TITLE
Replace settings configuration menu with separate tabs partials

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/components/tabs.coffee
+++ b/backend/app/assets/javascripts/spree/backend/components/tabs.coffee
@@ -3,6 +3,7 @@ class Tabs
     @$tabList = $(@el)
     @$tabs = @$tabList.find(":not(.tabs-dropdown).tab")
     @tabs = @$tabs.toArray()
+    @$tabList.append("<li class='tab tabs-dropdown'><a href='#'></a><ul></ul></li>")
     @$dropdown = @$tabList.find(".tabs-dropdown")
     @setWidths()
     @initEvents()

--- a/backend/app/assets/javascripts/spree/backend/components/tabs.coffee
+++ b/backend/app/assets/javascripts/spree/backend/components/tabs.coffee
@@ -1,9 +1,9 @@
 class Tabs
   constructor: (@el) ->
     @$tabList = $(@el)
-    @$tabs = @$tabList.find(":not(.tabs-dropdown).tab")
+    @$tabs = @$tabList.find("li:not(.tabs-dropdown)")
     @tabs = @$tabs.toArray()
-    @$tabList.append("<li class='tab tabs-dropdown'><a href='#'></a><ul></ul></li>")
+    @$tabList.append("<li class='tabs-dropdown'><a href='#'></a><ul></ul></li>")
     @$dropdown = @$tabList.find(".tabs-dropdown")
     @setWidths()
     @initEvents()
@@ -23,7 +23,7 @@ class Tabs
     @lastKnownWidth = containerWidth unless @lastKnownWidth
     widthDifference = @totalTabsWidth - containerWidth
     widthDifferenceWithDropdown = widthDifference + @dropdownWidth()
-    dropdownActive = @$dropdown.find(".tab").length
+    dropdownActive = @$dropdown.find("li").length
 
     if containerWidth <= @lastKnownWidth
       # The window is being sized down or we've just loaded the page
@@ -72,7 +72,7 @@ class Tabs
       $(tab).insertBefore(@$dropdown).removeClass("in-dropdown")
 
     # Reset styles if our dropdown is now empty
-    if @$dropdown.find(".tab").length is 0
+    if @$dropdown.find("li").length is 0
       @$tabList.removeClass("tabs-overflowed")
 
 window.onload = ->

--- a/backend/app/assets/javascripts/spree/backend/components/tabs.coffee
+++ b/backend/app/assets/javascripts/spree/backend/components/tabs.coffee
@@ -46,8 +46,8 @@ class Tabs
     for tab in tabs
       # Bail if things are now fitting
       return if widthDifference <= 0
-      # Skip items already in the dropdown
-      continue if $(tab).hasClass("in-dropdown")
+      # Skip items already in the dropdown or active
+      continue if $(tab).hasClass("in-dropdown") or $(tab).hasClass("active")
 
       tabWidth = tab.offsetWidth
       @totalTabsWidth -= tabWidth

--- a/backend/app/assets/javascripts/spree/backend/components/tabs.coffee
+++ b/backend/app/assets/javascripts/spree/backend/components/tabs.coffee
@@ -1,0 +1,78 @@
+class Tabs
+  constructor: (@el) ->
+    @$tabList = $(@el)
+    @$tabs = @$tabList.find(":not(.tabs-dropdown).tab")
+    @tabs = @$tabs.toArray()
+    @$dropdown = @$tabList.find(".tabs-dropdown")
+    @setWidths()
+    @initEvents()
+
+  initEvents: ->
+    $(window).on "resize", @overflowTabs
+    @overflowTabs()
+
+  setWidths: ->
+    @tabWidths = @tabs.map (tab) ->
+      tab.offsetWidth
+    @totalTabsWidth = @tabWidths.reduce (previousValue, currentValue) ->
+      previousValue + currentValue
+
+  overflowTabs: =>
+    containerWidth = @$tabList[0].offsetWidth
+    @lastKnownWidth = containerWidth unless @lastKnownWidth
+    widthDifference = @totalTabsWidth - containerWidth
+    widthDifferenceWithDropdown = widthDifference + @dropdownWidth()
+    dropdownActive = @$dropdown.find(".tab").length
+
+    if containerWidth <= @lastKnownWidth
+      # The window is being sized down or we've just loaded the page
+      if (dropdownActive and widthDifferenceWithDropdown > 0) or (not dropdownActive and widthDifference > 0)
+        @hideTabsToFit(widthDifferenceWithDropdown)
+    if containerWidth > @lastKnownWidth
+      # The window is getting larger
+      @showTabsToFit(widthDifference)
+
+    @lastKnownWidth = containerWidth
+
+  dropdownWidth: ->
+    # If the dropdown isn't initiated we need to provide
+    # our best guess of the size it will take up
+    @$dropdown[0].offsetWidth or 50
+
+  hideTabsToFit: (widthDifference) ->
+    @$tabList.addClass("tabs-overflowed")
+    tabs = @tabs.slice().reverse()
+
+    for tab in tabs
+      # Bail if things are now fitting
+      return if widthDifference <= 0
+      # Skip items already in the dropdown
+      continue if $(tab).hasClass("in-dropdown")
+
+      tabWidth = tab.offsetWidth
+      @totalTabsWidth -= tabWidth
+      widthDifference -= tabWidth
+      $(tab).appendTo(@$dropdown.find("ul")).addClass("in-dropdown")
+
+  showTabsToFit: (widthDifference) ->
+    for tab, i in @tabs.slice()
+      # Skip items that aren't already in the dropdown
+      continue unless $(tab).hasClass("in-dropdown")
+
+      # Get our tab's width from the array
+      # We can't measure it here because it's hidden in the dropdown
+      tabWidth = @tabWidths[i]
+
+      # Bail if there's no room for this tab
+      break if widthDifference + tabWidth > 0
+
+      @totalTabsWidth += tabWidth
+      widthDifference += tabWidth
+      $(tab).insertBefore(@$dropdown).removeClass("in-dropdown")
+
+    # Reset styles if our dropdown is now empty
+    if @$dropdown.find(".tab").length is 0
+      @$tabList.removeClass("tabs-overflowed")
+
+window.onload = ->
+  new Tabs(el) for el in $(".tabs")

--- a/backend/app/assets/stylesheets/spree/backend/components/_tabs.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_tabs.scss
@@ -15,16 +15,24 @@
   }
 }
 
-.tab {
+.tab:not(.in-dropdown) {
   @include flex-grow(0);
   @include flex-shrink(0);
+
+  // Move down one pixel to sit on top of the ul's border-bottom
   position: relative;
   top: 1px;
 
-  a {
+  .tabs-overflowed &:not(.tabs-dropdown) {
+    @include flex-grow(1);
+    @include flex-shrink(1);
+  }
+
+  > a {
     display: block;
     border: 1px solid $color-border;
     border-radius: 2px 2px 0 0;
+    line-height: 1;
   }
 
   &:not(:first-child) > a {
@@ -35,15 +43,66 @@
     background: $color-tbl-thead;
   }
 
-  &.active a,
+  &.active > a,
   &.active:hover {
     background: white;
     border-bottom-color: white;
     color: $color-body-text;
   }
 
-  &:not(.active):hover a {
-    background: $color-link;
-    color: white;
+  &:not(.active):hover > a {
+    background: darken($color-tbl-thead, 5%);
+    color: $color-link;
+  }
+}
+
+.tabs-dropdown {
+  @include flex-grow(0);
+  @include flex-shrink(0);
+  position: relative;
+
+  .tabs:not(.tabs-overflowed) & {
+    display: none;
+  }
+
+  > a {
+    position: relative;
+    background: white;
+    z-index: 1;
+
+    &:before {
+      content: "\f107";
+      font-family: FontAwesome;
+      -webkit-font-smoothing: antialiased;
+    }
+  }
+
+  &:hover > a {
+    background: white;
+  }
+
+  &:not(:hover) ul {
+    display: none;
+  }
+
+  ul {
+    @include position(absolute, calc(100% - 1px) 0 null null);
+    z-index: 1;
+  }
+}
+
+.tab.in-dropdown {
+  a {
+    display: block;
+    border: 1px solid $color-border;
+    background: white;
+  }
+
+  &:not(:first-child) a {
+    border-top: none;
+  }
+
+  &:last-child a {
+    border-radius: 0 0 3px 3px;
   }
 }

--- a/backend/app/assets/stylesheets/spree/backend/components/_tabs.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_tabs.scss
@@ -15,18 +15,13 @@
   }
 }
 
-.tab:not(.in-dropdown) {
+.tabs > li:not(.in-dropdown) {
   @include flex-grow(0);
   @include flex-shrink(0);
 
   // Move down one pixel to sit on top of the ul's border-bottom
   position: relative;
   top: 1px;
-
-  .tabs-overflowed &:not(.tabs-dropdown) {
-    @include flex-grow(1);
-    @include flex-shrink(1);
-  }
 
   > a {
     display: block;
@@ -54,6 +49,11 @@
     background: darken($color-tbl-thead, 5%);
     color: $color-link;
   }
+}
+
+.tabs-overflowed.tabs > li:not(.tabs-dropdown) {
+  @include flex-grow(1);
+  @include flex-shrink(1);
 }
 
 .tabs-dropdown {
@@ -91,7 +91,7 @@
   }
 }
 
-.tab.in-dropdown {
+.tabs li.in-dropdown {
   a {
     display: block;
     border: 1px solid $color-border;

--- a/backend/app/assets/stylesheets/spree/backend/components/_tabs.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_tabs.scss
@@ -1,0 +1,49 @@
+.tabs {
+  @include display(flex);
+  margin: 1em 0;
+  border-bottom: 1px solid $color-border;
+  white-space: nowrap;
+
+  &,
+  ul {
+    padding-left: 0;
+    list-style: none;
+  }
+
+  a {
+    padding: 1em;
+  }
+}
+
+.tab {
+  @include flex-grow(0);
+  @include flex-shrink(0);
+  position: relative;
+  top: 1px;
+
+  a {
+    display: block;
+    border: 1px solid $color-border;
+    border-radius: 2px 2px 0 0;
+  }
+
+  &:not(:first-child) > a {
+    border-left: none;
+  }
+
+  &:not(.active) > a {
+    background: $color-tbl-thead;
+  }
+
+  &.active a,
+  &.active:hover {
+    background: white;
+    border-bottom-color: white;
+    color: $color-body-text;
+  }
+
+  &:not(.active):hover a {
+    background: $color-link;
+    color: white;
+  }
+}

--- a/backend/app/assets/stylesheets/spree/backend/spree_admin.scss
+++ b/backend/app/assets/stylesheets/spree/backend/spree_admin.scss
@@ -27,6 +27,7 @@
 @import 'spree/backend/components/sidebar';
 @import 'spree/backend/components/number_field_update';
 @import 'spree/backend/components/stock_table';
+@import 'spree/backend/components/tabs';
 
 @import 'font-awesome';
 @import 'spree/backend/plugins/powertip';

--- a/backend/app/controllers/spree/admin/style_guide_controller.rb
+++ b/backend/app/controllers/spree/admin/style_guide_controller.rb
@@ -17,6 +17,9 @@ module Spree
             'building_forms',
             'validation'
           ],
+          components: [
+            'tabs'
+          ],
           messaging: [
             'loading',
             'flashes',

--- a/backend/app/helpers/spree/admin/navigation_helper.rb
+++ b/backend/app/helpers/spree/admin/navigation_helper.rb
@@ -122,6 +122,18 @@ module Spree
           link_to(link_text, url)
         end
       end
+
+      def settings_tab_item(link_text, url, options = {})
+        is_active = url.ends_with?(controller.controller_name) ||
+                    url.ends_with?("#{controller.controller_name}/edit") ||
+                    url.ends_with?("#{controller.controller_name.singularize}/edit")
+        options[:class] = 'fa'
+        options[:class] += ' active' if is_active
+        options[:datahook] = "admin_settings_#{link_text.downcase.tr(' ', '_')}"
+        content_tag(:li, options) do
+          link_to(link_text, url)
+        end
+      end
     end
   end
 end

--- a/backend/app/views/spree/admin/adjustment_reasons/edit.html.erb
+++ b/backend/app/views/spree/admin/adjustment_reasons/edit.html.erb
@@ -1,3 +1,5 @@
+<%= render 'spree/admin/shared/checkout_tabs' %>
+
 <% content_for :page_title do %>
   <%= Spree.t(:editing_adjustment_reason) %>
 <% end %>

--- a/backend/app/views/spree/admin/adjustment_reasons/index.html.erb
+++ b/backend/app/views/spree/admin/adjustment_reasons/index.html.erb
@@ -1,4 +1,4 @@
-<%= render partial: 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/checkout_tabs' %>
 
 <% content_for :page_title do %>
   <%= Spree::AdjustmentReason.model_name.human(count: :other) %>

--- a/backend/app/views/spree/admin/adjustment_reasons/new.html.erb
+++ b/backend/app/views/spree/admin/adjustment_reasons/new.html.erb
@@ -1,3 +1,5 @@
+<%= render 'spree/admin/shared/checkout_tabs' %>
+
 <% content_for :page_title do %>
   <%= Spree.t(:new_adjustment_reason) %>
 <% end %>

--- a/backend/app/views/spree/admin/countries/edit.html.erb
+++ b/backend/app/views/spree/admin/countries/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/areas_tabs' %>
 
 <% content_for :page_title do %>
   <%= Spree.t(:editing_country) %>

--- a/backend/app/views/spree/admin/countries/index.html.erb
+++ b/backend/app/views/spree/admin/countries/index.html.erb
@@ -1,4 +1,4 @@
-<%= render 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/areas_tabs' %>
 
 <% content_for :page_title do %>
   <%= Spree.t(:listing_countries) %>

--- a/backend/app/views/spree/admin/countries/new.html.erb
+++ b/backend/app/views/spree/admin/countries/new.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/areas_tabs' %>
 
 <% content_for :page_title do %>
   <%= Spree.t(:new_country) %>

--- a/backend/app/views/spree/admin/general_settings/edit.html.erb
+++ b/backend/app/views/spree/admin/general_settings/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/store_tabs' %>
 
 <% content_for :page_title do %>
   <%= Spree.t(:general_settings) %>

--- a/backend/app/views/spree/admin/payment_methods/edit.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/payments_tabs' %>
 
 <% content_for :page_title do %>
   <%= Spree.t(:editing_payment_method) %> <i class="fa fa-arrow-right"></i> <%= @payment_method.name %>

--- a/backend/app/views/spree/admin/payment_methods/index.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/index.html.erb
@@ -1,4 +1,4 @@
-<%= render 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/payments_tabs' %>
 
 <% content_for :page_title do %>
   <%= Spree.t(:payment_methods) %>

--- a/backend/app/views/spree/admin/payment_methods/new.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/new.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/payments_tabs' %>
 
 <% content_for :page_title do %>
   <%= Spree.t(:new_payment_method) %>

--- a/backend/app/views/spree/admin/refund_reasons/edit.html.erb
+++ b/backend/app/views/spree/admin/refund_reasons/edit.html.erb
@@ -1,3 +1,5 @@
+<%= render 'spree/admin/shared/checkout_tabs' %>
+
 <% content_for :page_title do %>
   <%= Spree.t(:editing_refund_reason) %>
 <% end %>

--- a/backend/app/views/spree/admin/refund_reasons/index.html.erb
+++ b/backend/app/views/spree/admin/refund_reasons/index.html.erb
@@ -1,4 +1,4 @@
-<%= render partial: 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/checkout_tabs' %>
 
 <% content_for :page_title do %>
   <%= Spree::RefundReason.model_name.human(count: :other) %>

--- a/backend/app/views/spree/admin/refund_reasons/new.html.erb
+++ b/backend/app/views/spree/admin/refund_reasons/new.html.erb
@@ -1,3 +1,5 @@
+<%= render 'spree/admin/shared/checkout_tabs' %>
+
 <% content_for :page_title do %>
   <%= Spree.t(:new_refund_reason) %>
 <% end %>

--- a/backend/app/views/spree/admin/reimbursement_types/index.html.erb
+++ b/backend/app/views/spree/admin/reimbursement_types/index.html.erb
@@ -1,4 +1,4 @@
-<%= render partial: 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/checkout_tabs' %>
 
 <% content_for :page_title do %>
   <%= Spree::ReimbursementType.model_name.human(count: :other) %>

--- a/backend/app/views/spree/admin/shared/_areas_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_areas_tabs.html.erb
@@ -1,0 +1,19 @@
+<% content_for :tabs do %>
+  <nav>
+    <ul class="tabs" data-hook="admin_settings_areas_tabs">
+      <% if can? :display, Spree::Zone %>
+        <%= settings_tab_item Spree::Zone.model_name.human(count: :other), admin_zones_path %>
+      <% end %>
+
+      <% if can? :display, Spree::Country %>
+        <%= settings_tab_item Spree::Country.model_name.human(count: :other), admin_countries_path %>
+      <% end %>
+
+      <% if can?(:display, Spree::State) %>
+        <% if country = Spree::Country.find_by(iso: Spree::Config[:default_country_iso]) || Spree::Country.first %>
+          <%= settings_tab_item Spree::State.model_name.human(count: :other), admin_country_states_path(country) %>
+        <% end %>
+      <% end %>
+    </ul>
+  </nav>
+<% end %>

--- a/backend/app/views/spree/admin/shared/_checkout_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_checkout_tabs.html.erb
@@ -1,0 +1,21 @@
+<% content_for :tabs do %>
+  <nav>
+    <ul class="tabs" data-hook="admin_settings_checkout_tabs">
+      <% if can?(:display, Spree::RefundReason) %>
+        <%= settings_tab_item Spree::RefundReason.model_name.human(count: :other), admin_refund_reasons_path %>
+      <% end %>
+
+      <% if can?(:display, Spree::ReimbursementType) %>
+        <%= settings_tab_item Spree::ReimbursementType.model_name.human(count: :other), admin_reimbursement_types_path %>
+      <% end %>
+
+      <% if can?(:display, Spree::ReturnReason) %>
+        <%= settings_tab_item Spree::ReturnReason.model_name.human(count: :other), admin_return_reasons_path %>
+      <% end %>
+
+      <% if can?(:display, Spree::AdjustmentReason) %>
+        <%= settings_tab_item Spree::AdjustmentReason.model_name.human(count: :other), admin_adjustment_reasons_path %>
+      <% end %>
+    </ul>
+  </nav>
+<% end %>

--- a/backend/app/views/spree/admin/shared/_order_submenu.html.erb
+++ b/backend/app/views/spree/admin/shared/_order_submenu.html.erb
@@ -1,13 +1,13 @@
 <nav>
   <ul class="tabs" data-hook="admin_order_tabs">
     <% if (@order.shipments.count == 0 || @order.shipped_shipments.count == 0) %>
-      <li class="tab <%= "active" if current == "Cart" %>" data-hook='admin_order_tabs_order_details'>
+      <li class="<%= "active" if current == "Cart" %>" data-hook='admin_order_tabs_order_details'>
         <%= link_to_with_icon 'shopping-cart', Spree.t(:cart), cart_admin_order_url(@order) %>
       </li>
     <% end %>
 
     <% if checkout_steps.include?("address") %>
-      <li class="tab <%= "active" if (current == "Customer Details") %>" data-hook='admin_order_tabs_customer_details'>
+      <li class="<%= "active" if (current == "Customer Details") %>" data-hook='admin_order_tabs_customer_details'>
         <% if can?(:update, @order) %>
           <%= link_to_with_icon 'user', Spree.t(:customer), edit_admin_order_customer_url(@order) %>
         <% else %>
@@ -16,24 +16,24 @@
       </li>
     <% end %>
 
-    <li class="tab <%= "active" if current == "Shipments" %>" data-hook='admin_order_tabs_order_details'>
+    <li class="<%= "active" if current == "Shipments" %>" data-hook='admin_order_tabs_order_details'>
       <%= link_to_with_icon 'edit', Spree::Shipment.model_name.human(count: :other), edit_admin_order_url(@order) %>
     </li>
 
     <% if can? :display, Spree::Adjustment %>
-      <li class="tab <%= "active" if current == "Adjustments" %>" data-hook='admin_order_tabs_adjustments'>
+      <li class="<%= "active" if current == "Adjustments" %>" data-hook='admin_order_tabs_adjustments'>
         <%= link_to_with_icon 'cogs', Spree::Adjustment.model_name.human(count: :other), admin_order_adjustments_url(@order) %>
       </li>
     <% end %>
 
     <% if can?(:display, Spree::Payment) %>
-      <li class="tab <%= "active" if current == "Payments" %>" data-hook='admin_order_tabs_payments'>
+      <li class="<%= "active" if current == "Payments" %>" data-hook='admin_order_tabs_payments'>
         <%= link_to_with_icon 'credit-card', Spree::Payment.model_name.human(count: :other), admin_order_payments_url(@order) %>
       </li>
     <% end %>
 
     <% if !@order.completed? && can?(:update, @order) %>
-      <li class="tab <%= "active" if current == "Confirm" %>" data-hook='admin_order_tabs_confirm'>
+      <li class="<%= "active" if current == "Confirm" %>" data-hook='admin_order_tabs_confirm'>
         <%= link_to_with_icon 'check', Spree.t(:confirm), confirm_admin_order_url(@order) %>
       </li>
     <% end %>
@@ -48,14 +48,14 @@
 
     <% if can? :display, Spree::CustomerReturn %>
       <% if @order.completed? %>
-        <li class="tab <%= "active" if current == "Customer Returns" %>">
+        <li class="<%= "active" if current == "Customer Returns" %>">
           <%= link_to_with_icon 'download', Spree::CustomerReturn.model_name.human(count: :other), admin_order_customer_returns_url(@order) %>
         </li>
       <% end %>
     <% end %>
 
     <% if can?(:manage, Spree::OrderCancellations) && @order.inventory_units.cancelable.present? %>
-      <%= content_tag('li', class: "tab #{'active' if current == 'Cancel Inventory'}", :data => {:hook => 'admin_order_tabs_cancel_inventory'}) do %>
+      <%= content_tag('li', class: "#{'active' if current == 'Cancel Inventory'}", :data => {:hook => 'admin_order_tabs_cancel_inventory'}) do %>
         <%= link_to_with_icon 'cancel', Spree.t(:cancel_inventory), admin_order_cancellations_path(@order) %>
       <% end %>
     <% end %>

--- a/backend/app/views/spree/admin/shared/_order_submenu.html.erb
+++ b/backend/app/views/spree/admin/shared/_order_submenu.html.erb
@@ -1,13 +1,13 @@
-<nav class="menu">
-  <ul data-hook="admin_order_tabs">
+<nav>
+  <ul class="tabs" data-hook="admin_order_tabs">
     <% if (@order.shipments.count == 0 || @order.shipped_shipments.count == 0) %>
-      <li<%== ' class="active"' if current == 'Cart' %> data-hook='admin_order_tabs_order_details'>
+      <li class="tab <%= "active" if current == "Cart" %>" data-hook='admin_order_tabs_order_details'>
         <%= link_to_with_icon 'shopping-cart', Spree.t(:cart), cart_admin_order_url(@order) %>
       </li>
     <% end %>
 
     <% if checkout_steps.include?("address") %>
-      <li<%== ' class="active"' if current == 'Customer Details' %> data-hook='admin_order_tabs_customer_details'>
+      <li class="tab <%= "active" if (current == "Customer Details") %>" data-hook='admin_order_tabs_customer_details'>
         <% if can?(:update, @order) %>
           <%= link_to_with_icon 'user', Spree.t(:customer_details), edit_admin_order_customer_url(@order) %>
         <% else %>
@@ -16,31 +16,31 @@
       </li>
     <% end %>
 
-    <li<%== ' class="active"' if current == 'Shipments' %> data-hook='admin_order_tabs_order_details'>
+    <li class="tab <%= "active" if current == "Shipments" %>" data-hook='admin_order_tabs_order_details'>
       <%= link_to_with_icon 'edit', Spree::Shipment.model_name.human(count: :other), edit_admin_order_url(@order) %>
     </li>
 
     <% if can? :display, Spree::Adjustment %>
-      <li<%== ' class="active"' if current == 'Adjustments' %> data-hook='admin_order_tabs_adjustments'>
+      <li class="tab <%= "active" if current == "Adjustments" %>" data-hook='admin_order_tabs_adjustments'>
         <%= link_to_with_icon 'cogs', Spree::Adjustment.model_name.human(count: :other), admin_order_adjustments_url(@order) %>
       </li>
     <% end %>
 
     <% if can?(:display, Spree::Payment) %>
-      <li<%== ' class="active"' if current == 'Payments' %> data-hook='admin_order_tabs_payments'>
+      <li class="tab <%= "active" if current == "Payments" %>" data-hook='admin_order_tabs_payments'>
         <%= link_to_with_icon 'credit-card', Spree::Payment.model_name.human(count: :other), admin_order_payments_url(@order) %>
       </li>
     <% end %>
 
     <% if !@order.completed? && can?(:update, @order) %>
-      <li<%== ' class="active"' if current == 'Confirm' %> data-hook='admin_order_tabs_confirm'>
+      <li class="tab <%= "active" if current == "Confirm" %>" data-hook='admin_order_tabs_confirm'>
         <%= link_to_with_icon 'check', Spree.t(:confirm), confirm_admin_order_url(@order) %>
       </li>
     <% end %>
 
     <% if can? :display, Spree::ReturnAuthorization %>
       <% if @order.completed? %>
-        <li<%== ' class="active"' if current == 'Return Authorizations' %> data-hook='admin_order_tabs_return_authorizations'>
+        <li class="tab <%= "active" if current == "Return Authorizations" %>" data-hook='admin_order_tabs_return_authorizations'>
           <%= link_to_with_icon 'share', Spree::ReturnAuthorization.model_name.human(count: :other), admin_order_return_authorizations_url(@order) %>
         </li>
       <% end %>
@@ -48,14 +48,14 @@
 
     <% if can? :display, Spree::CustomerReturn %>
       <% if @order.completed? %>
-        <li<%== ' class="active"' if current == 'Customer Returns' %>>
+        <li class="tab <%= "active" if current == "Customer Returns" %>">
           <%= link_to_with_icon 'download', Spree::CustomerReturn.model_name.human(count: :other), admin_order_customer_returns_url(@order) %>
         </li>
       <% end %>
     <% end %>
 
     <% if can?(:manage, Spree::OrderCancellations) && @order.inventory_units.cancelable.present? %>
-      <%= content_tag('li', :class => ('active' if current == 'Cancel Inventory'), :data => {:hook => 'admin_order_tabs_cancel_inventory'}) do %>
+      <%= content_tag('li', class: "tab #{'active' if current == 'Cancel Inventory'}", :data => {:hook => 'admin_order_tabs_cancel_inventory'}) do %>
         <%= link_to_with_icon 'cancel', Spree.t(:cancel_inventory), admin_order_cancellations_path(@order) %>
       <% end %>
     <% end %>

--- a/backend/app/views/spree/admin/shared/_order_submenu.html.erb
+++ b/backend/app/views/spree/admin/shared/_order_submenu.html.erb
@@ -9,9 +9,9 @@
     <% if checkout_steps.include?("address") %>
       <li class="tab <%= "active" if (current == "Customer Details") %>" data-hook='admin_order_tabs_customer_details'>
         <% if can?(:update, @order) %>
-          <%= link_to_with_icon 'user', Spree.t(:customer_details), edit_admin_order_customer_url(@order) %>
+          <%= link_to_with_icon 'user', Spree.t(:customer), edit_admin_order_customer_url(@order) %>
         <% else %>
-          <%= link_to_with_icon 'user', Spree.t(:customer_details), admin_order_customer_url(@order) %>
+          <%= link_to_with_icon 'user', Spree.t(:customer), admin_order_customer_url(@order) %>
         <% end %>
       </li>
     <% end %>
@@ -41,7 +41,7 @@
     <% if can? :display, Spree::ReturnAuthorization %>
       <% if @order.completed? %>
         <li class="tab <%= "active" if current == "Return Authorizations" %>" data-hook='admin_order_tabs_return_authorizations'>
-          <%= link_to_with_icon 'share', Spree::ReturnAuthorization.model_name.human(count: :other), admin_order_return_authorizations_url(@order) %>
+          <%= link_to_with_icon 'share', Spree.t('admin.tab.rma'), admin_order_return_authorizations_url(@order) %>
         </li>
       <% end %>
     <% end %>

--- a/backend/app/views/spree/admin/shared/_order_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_order_tabs.html.erb
@@ -8,5 +8,8 @@
 
 <% content_for :sidebar do %>
   <%= render "spree/admin/shared/order_summary", checkout_steps: @order.checkout_steps %>
+<% end %>
+
+<% content_for :tabs do %>
   <%= render "spree/admin/shared/order_submenu", current: current, checkout_steps: @order.checkout_steps %>
 <% end %>

--- a/backend/app/views/spree/admin/shared/_payments_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_payments_tabs.html.erb
@@ -1,0 +1,9 @@
+<% content_for :tabs do %>
+  <nav>
+    <ul class="tabs" data-hook="admin_settings_payments_tabs">
+      <% if can?(:display, Spree::PaymentMethod) %>
+        <%= settings_tab_item Spree::PaymentMethod.model_name.human(count: :other), admin_payment_methods_path %>
+      <% end %>
+    </ul>
+  </nav>
+<% end %>

--- a/backend/app/views/spree/admin/shared/_settings_sub_menu.html.erb
+++ b/backend/app/views/spree/admin/shared/_settings_sub_menu.html.erb
@@ -1,0 +1,27 @@
+<ul id="settings_sub_nav" class="admin-subnav" data-hook="admin_settings_sub_tabs">
+
+  <% if can?(:edit, :general_settings) || can?(:display, Spree::Tracker) || can?(:display, Spree::Taxonomy) %>
+    <%= tab :general_settings, label: :store, url: spree.edit_admin_general_settings_path %>
+  <% end %>
+
+  <% if can?(:display, Spree::PaymentMethod) %>
+    <%= tab :payments, url: admin_payment_methods_path %>
+  <% end %>
+
+  <% if can?(:display, Spree::Zone) || can?(:display, Spree::Country) || can?(:display, Spree::State) %>
+    <%= tab :areas, url: admin_zones_path %>
+  <% end %>
+
+  <% if can?(:display, Spree::TaxCategory) || can?(:display, Spree::TaxRate) %>
+    <%= tab :taxes, url: admin_tax_categories_path %>
+  <% end %>
+
+  <% if can?(:display, Spree::RefundReason) || can?(:display, Spree::ReimbursementType) ||
+     can?(:display, Spree::ReturnReason) || can?(:display, Spree::AdjustmentReason) %>
+    <%= tab :checkout, url: admin_refund_reasons_path %>
+  <% end %>
+
+  <% if can?(:display, Spree::ShippingMethod) || can?(:display, Spree::ShippingCategory) || can?(:display, Spree::StockLocation) %>
+    <%= tab :shipping, url: admin_shipping_methods_path %>
+  <% end %>
+</ul>

--- a/backend/app/views/spree/admin/shared/_shipping_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_shipping_tabs.html.erb
@@ -1,0 +1,17 @@
+<% content_for :tabs do %>
+  <nav>
+    <ul class="tabs" data-hook="admin_settings_shipping_tabs">
+      <% if can?(:display, Spree::ShippingMethod) %>
+        <%= settings_tab_item Spree::ShippingMethod.model_name.human(count: :other), admin_shipping_methods_path %>
+      <% end %>
+
+      <% if can?(:display, Spree::ShippingCategory) %>
+        <%= settings_tab_item Spree::ShippingCategory.model_name.human(count: :other), admin_shipping_categories_path %>
+      <% end %>
+
+      <% if can?(:display, Spree::StockLocation) %>
+        <%= settings_tab_item Spree::StockLocation.model_name.human(count: :other), spree.admin_stock_locations_path %>
+      <% end %>
+    </ul>
+  </nav>
+<% end %>

--- a/backend/app/views/spree/admin/shared/_store_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_store_tabs.html.erb
@@ -1,0 +1,17 @@
+<% content_for :tabs do %>
+  <nav>
+    <ul class="tabs" data-hook="admin_settings_store_tabs">
+      <% if can?(:edit, :general_settings) %>
+        <%= settings_tab_item Spree.t(:general_settings), edit_admin_general_settings_path %>
+      <% end %>
+
+      <% if can?(:display, Spree::Tracker) %>
+        <%= settings_tab_item Spree.t(:analytics_trackers), admin_trackers_path %>
+      <% end %>
+
+      <% if can?(:display, Spree::Taxonomy) %>
+        <%= settings_tab_item Spree::Taxonomy.model_name.human(count: :other), admin_taxonomies_path %>
+      <% end %>
+    </ul>
+  </nav>
+<% end %>

--- a/backend/app/views/spree/admin/shared/_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_tabs.html.erb
@@ -13,7 +13,9 @@
 <% end %>
 
 <% if can? :admin, :general_settings %>
-  <%= tab *Spree::BackendConfiguration::CONFIGURATION_TABS, label: :settings, icon: 'wrench', url: spree.edit_admin_general_settings_path %>
+  <%= tab *Spree::BackendConfiguration::CONFIGURATION_TABS, label: :settings, icon: 'wrench', url: spree.edit_admin_general_settings_path do %>
+    <% render partial: 'spree/admin/shared/settings_sub_menu' %>
+  <% end %>
 <% end %>
 
 <% if can? :admin, Spree::Promotion %>

--- a/backend/app/views/spree/admin/shared/_taxes_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_taxes_tabs.html.erb
@@ -1,0 +1,13 @@
+<% content_for :tabs do %>
+  <nav>
+    <ul class="tabs" data-hook="admin_settings_taxes_tabs">
+      <% if can? :display, Spree::TaxCategory %>
+        <%= settings_tab_item Spree::TaxCategory.model_name.human(count: :other), admin_tax_categories_path %>
+      <% end %>
+
+      <% if can? :display, Spree::TaxRate %>
+        <%= settings_tab_item Spree::TaxRate.model_name.human(count: :other), admin_tax_rates_path %>
+      <% end %>
+    </ul>
+  </nav>
+<% end %>

--- a/backend/app/views/spree/admin/shared/named_types/_edit.html.erb
+++ b/backend/app/views/spree/admin/shared/named_types/_edit.html.erb
@@ -1,3 +1,5 @@
+<%= render 'spree/admin/shared/checkout_tabs' %>
+
 <% content_for :page_title do %>
   <%= page_title %> <i class="fa fa-arrow-right"></i>
   <%= @object.name %>

--- a/backend/app/views/spree/admin/shared/named_types/_index.html.erb
+++ b/backend/app/views/spree/admin/shared/named_types/_index.html.erb
@@ -1,4 +1,4 @@
-<%= render partial: 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/checkout_tabs' %>
 
 <% content_for :page_title do %>
   <%= page_title %>

--- a/backend/app/views/spree/admin/shared/named_types/_new.html.erb
+++ b/backend/app/views/spree/admin/shared/named_types/_new.html.erb
@@ -1,3 +1,5 @@
+<%= render 'spree/admin/shared/checkout_tabs' %>
+
 <% content_for :page_title do %>
   <%= page_title %>
 <% end %>

--- a/backend/app/views/spree/admin/shipping_categories/edit.html.erb
+++ b/backend/app/views/spree/admin/shipping_categories/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/shipping_tabs' %>
 
 <% content_for :page_title do %>
   <%= Spree.t(:editing_shipping_category) %>

--- a/backend/app/views/spree/admin/shipping_categories/index.html.erb
+++ b/backend/app/views/spree/admin/shipping_categories/index.html.erb
@@ -1,4 +1,4 @@
-<%= render 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/shipping_tabs' %>
 
 <% content_for :page_title do %>
   <%= Spree::ShippingCategory.model_name.human(count: :other) %>

--- a/backend/app/views/spree/admin/shipping_categories/new.html.erb
+++ b/backend/app/views/spree/admin/shipping_categories/new.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/shipping_tabs' %>
 
 <% content_for :page_title do %>
   <%= Spree.t(:new_shipping_category) %>

--- a/backend/app/views/spree/admin/shipping_methods/edit.html.erb
+++ b/backend/app/views/spree/admin/shipping_methods/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/shipping_tabs' %>
 
 <% content_for :page_title do %>
   <%= Spree.t(:editing_shipping_method) %>

--- a/backend/app/views/spree/admin/shipping_methods/index.html.erb
+++ b/backend/app/views/spree/admin/shipping_methods/index.html.erb
@@ -1,4 +1,4 @@
-<%= render 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/shipping_tabs' %>
 
 <% content_for :page_title do %>
   <%= Spree::ShippingMethod.model_name.human(count: :other) %>

--- a/backend/app/views/spree/admin/shipping_methods/new.html.erb
+++ b/backend/app/views/spree/admin/shipping_methods/new.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/shipping_tabs' %>
 
 <% content_for :page_title do %>
   <%= Spree.t(:new_shipping_method) %>

--- a/backend/app/views/spree/admin/states/edit.html.erb
+++ b/backend/app/views/spree/admin/states/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/areas_tabs' %>
 
 <% content_for :page_title do %>
   <%= Spree.t(:editing_state) %> <i class="fa fa-arrow-right"></i> <%= @state.name %>

--- a/backend/app/views/spree/admin/states/index.html.erb
+++ b/backend/app/views/spree/admin/states/index.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/areas_tabs' %>
 
 <% content_for :page_title do %>
   <%= Spree::State.model_name.human(count: :other) %>

--- a/backend/app/views/spree/admin/states/new.html.erb
+++ b/backend/app/views/spree/admin/states/new.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/areas_tabs' %>
 
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @state } %>
 

--- a/backend/app/views/spree/admin/stock_locations/edit.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/shipping_tabs' %>
 
 <% content_for :page_title do %>
   <%= Spree.t(:editing_stock_location) %> <i class="fa fa-arrow-right"></i>

--- a/backend/app/views/spree/admin/stock_locations/index.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/index.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/shipping_tabs' %>
 
 <% content_for :page_title do %>
   <%= Spree::StockLocation.model_name.human(count: :other) %>

--- a/backend/app/views/spree/admin/stock_locations/new.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/new.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/shipping_tabs' %>
 
 <% content_for :page_title do %>
   <%= Spree.t(:new_stock_location) %>

--- a/backend/app/views/spree/admin/stock_movements/index.html.erb
+++ b/backend/app/views/spree/admin/stock_movements/index.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/shipping_tabs' %>
 
 <% content_for :page_title do %>
   <%= Spree.t(:stock_movements_for_stock_location, stock_location_name: @stock_location.name) %>

--- a/backend/app/views/spree/admin/style_guide/topics/components/_tabs.html.erb
+++ b/backend/app/views/spree/admin/style_guide/topics/components/_tabs.html.erb
@@ -5,7 +5,6 @@
     <li class="tab"><a href="#">Variants</a></li>
     <li class="tab"><a href="#">Product Properties</a></li>
     <li class="tab"><a href="#">Stock Management</a></li>
-    <li class="tab tabs-dropdown"><a href="#"></a><ul></ul></li>
   </ul>
 <%- end %>
 

--- a/backend/app/views/spree/admin/style_guide/topics/components/_tabs.html.erb
+++ b/backend/app/views/spree/admin/style_guide/topics/components/_tabs.html.erb
@@ -1,0 +1,17 @@
+<%- snippet = capture do %>
+  <ul class="tabs">
+    <li class="tab active"><a href="#">Product Details</a></li>
+    <li class="tab"><a href="#">Images</a></li>
+    <li class="tab"><a href="#">Variants</a></li>
+    <li class="tab"><a href="#">Product Properties</a></li>
+    <li class="tab"><a href="#">Stock Management</a></li>
+  </ul>
+<%- end %>
+
+<div class="style-guide-result">
+  <%= snippet %>
+</div>
+
+<div class="style-guide-code">
+  <pre><code class="language-html"><%= escape_once snippet %></code></pre>
+</div>

--- a/backend/app/views/spree/admin/style_guide/topics/components/_tabs.html.erb
+++ b/backend/app/views/spree/admin/style_guide/topics/components/_tabs.html.erb
@@ -5,6 +5,7 @@
     <li class="tab"><a href="#">Variants</a></li>
     <li class="tab"><a href="#">Product Properties</a></li>
     <li class="tab"><a href="#">Stock Management</a></li>
+    <li class="tab tabs-dropdown"><a href="#"></a><ul></ul></li>
   </ul>
 <%- end %>
 

--- a/backend/app/views/spree/admin/style_guide/topics/components/_tabs.html.erb
+++ b/backend/app/views/spree/admin/style_guide/topics/components/_tabs.html.erb
@@ -1,10 +1,10 @@
 <%- snippet = capture do %>
   <ul class="tabs">
-    <li class="tab active"><a href="#">Product Details</a></li>
-    <li class="tab"><a href="#">Images</a></li>
-    <li class="tab"><a href="#">Variants</a></li>
-    <li class="tab"><a href="#">Product Properties</a></li>
-    <li class="tab"><a href="#">Stock Management</a></li>
+    <li class="active"><a href="#">Product Details</a></li>
+    <li><a href="#">Images</a></li>
+    <li><a href="#">Variants</a></li>
+    <li><a href="#">Product Properties</a></li>
+    <li><a href="#">Stock Management</a></li>
   </ul>
 <%- end %>
 

--- a/backend/app/views/spree/admin/tax_categories/edit.html.erb
+++ b/backend/app/views/spree/admin/tax_categories/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/taxes_tabs' %>
 
 <% content_for :page_title do %>
   <%= Spree.t(:editing_tax_category) %>

--- a/backend/app/views/spree/admin/tax_categories/index.html.erb
+++ b/backend/app/views/spree/admin/tax_categories/index.html.erb
@@ -1,4 +1,4 @@
-<%= render 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/taxes_tabs' %>
 
 <% content_for :page_title do %>
   <%= Spree.t(:listing_tax_categories) %>

--- a/backend/app/views/spree/admin/tax_categories/new.html.erb
+++ b/backend/app/views/spree/admin/tax_categories/new.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/taxes_tabs' %>
 
 <% content_for :page_title do %>
   <%= Spree.t(:new_tax_category) %>

--- a/backend/app/views/spree/admin/tax_categories/show.html.erb
+++ b/backend/app/views/spree/admin/tax_categories/show.html.erb
@@ -1,1 +1,1 @@
-<%= render :partial => 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/taxes_tabs' %>

--- a/backend/app/views/spree/admin/tax_rates/edit.html.erb
+++ b/backend/app/views/spree/admin/tax_rates/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/taxes_tabs' %>
 
 <% content_for :page_title do %>
   <%= Spree.t(:editing_tax_rate) %>

--- a/backend/app/views/spree/admin/tax_rates/index.html.erb
+++ b/backend/app/views/spree/admin/tax_rates/index.html.erb
@@ -1,4 +1,4 @@
-<%= render 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/taxes_tabs' %>
 
 <% content_for :page_title do %>
   <%= Spree::TaxRate.model_name.human(count: :other) %>

--- a/backend/app/views/spree/admin/tax_rates/new.html.erb
+++ b/backend/app/views/spree/admin/tax_rates/new.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/taxes_tabs' %>
 
 <% content_for :page_title do %>
   <%= Spree.t(:new_tax_rate) %>

--- a/backend/app/views/spree/admin/taxonomies/edit.erb
+++ b/backend/app/views/spree/admin/taxonomies/edit.erb
@@ -1,4 +1,4 @@
-<%= render :partial => 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/store_tabs' %>
 
 <% content_for :page_title do %>
   <%= Spree.t(:taxonomy_edit) %>

--- a/backend/app/views/spree/admin/taxonomies/index.html.erb
+++ b/backend/app/views/spree/admin/taxonomies/index.html.erb
@@ -1,4 +1,4 @@
-<%= render 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/store_tabs' %>
 
 <% content_for :page_title do %>
   <%= Spree::Taxonomy.model_name.human(count: :other) %>

--- a/backend/app/views/spree/admin/taxonomies/new.html.erb
+++ b/backend/app/views/spree/admin/taxonomies/new.html.erb
@@ -1,4 +1,4 @@
-<%= render 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/store_tabs' %>
 
 <% content_for :page_title do %>
   <%= Spree.t(:new_taxonomy) %>

--- a/backend/app/views/spree/admin/trackers/edit.html.erb
+++ b/backend/app/views/spree/admin/trackers/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/store_tabs' %>
 
 <% content_for :page_title do %>
   <%= Spree.t(:editing_tracker) %>

--- a/backend/app/views/spree/admin/trackers/index.html.erb
+++ b/backend/app/views/spree/admin/trackers/index.html.erb
@@ -1,4 +1,4 @@
-<%= render 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/store_tabs' %>
 
 <% content_for :page_title do %>
   <%= Spree::Tracker.model_name.human(count: :other) %>

--- a/backend/app/views/spree/admin/trackers/new.html.erb
+++ b/backend/app/views/spree/admin/trackers/new.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/store_tabs' %>
 
 <% content_for :page_title do %>
   <%= Spree.t(:new_tracker) %>

--- a/backend/app/views/spree/admin/zones/edit.html.erb
+++ b/backend/app/views/spree/admin/zones/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/areas_tabs' %>
 
 <% content_for :page_title do %>
   <%= Spree.t(:editing_zone) %>

--- a/backend/app/views/spree/admin/zones/index.html.erb
+++ b/backend/app/views/spree/admin/zones/index.html.erb
@@ -1,4 +1,4 @@
-<%= render 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/areas_tabs' %>
 
 <% content_for :page_title do %>
   <%= Spree::Zone.model_name.human(count: :other) %>

--- a/backend/app/views/spree/admin/zones/new.html.erb
+++ b/backend/app/views/spree/admin/zones/new.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/areas_tabs' %>
 
 <% content_for :page_title do %>
   <%= Spree.t(:new_zone) %>

--- a/backend/app/views/spree/layouts/admin.html.erb
+++ b/backend/app/views/spree/layouts/admin.html.erb
@@ -37,6 +37,11 @@
       <div class="container">
         <div class="row">
           <div class="<%= 'with-sidebar ' if content_for?(:sidebar) %>" id="content" data-hook>
+            <% if content_for?(:tabs) %>
+              <div class="sixteen columns">
+                <%= yield :tabs %>
+              </div>
+            <% end %>
             <div class="<%= if content_for?(:sidebar) then 'twelve' else 'sixteen' end %> columns">
               <%= render :partial => 'spree/admin/shared/table_filter' %>
               <%= yield %>

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -206,7 +206,7 @@ Spree::Core::Engine.add_routes do
       end
     end
 
-    resources :style_guide
+    resources :style_guide, only: [:index]
   end
 
   get '/admin', to: 'admin/root#index', as: :admin

--- a/backend/spec/features/admin/configuration/payment_methods_spec.rb
+++ b/backend/spec/features/admin/configuration/payment_methods_spec.rb
@@ -6,6 +6,7 @@ describe "Payment Methods", type: :feature do
   before(:each) do
     visit spree.admin_path
     click_link "Settings"
+    click_link "Payments"
   end
 
   context "admin visiting payment methods listing page" do

--- a/backend/spec/features/admin/configuration/shipping_methods_spec.rb
+++ b/backend/spec/features/admin/configuration/shipping_methods_spec.rb
@@ -17,7 +17,7 @@ describe "Shipping Methods", type: :feature do
 
     visit spree.admin_path
     click_link "Settings"
-    click_link "Shipping Methods"
+    click_link "Shipping"
   end
 
   context "show" do

--- a/backend/spec/features/admin/configuration/stock_locations_spec.rb
+++ b/backend/spec/features/admin/configuration/stock_locations_spec.rb
@@ -7,6 +7,7 @@ describe "Stock Locations", type: :feature do
     create(:country)
     visit spree.admin_path
     click_link "Settings"
+    click_link "Shipping"
     click_link "Stock Locations"
   end
 

--- a/backend/spec/features/admin/configuration/tax_categories_spec.rb
+++ b/backend/spec/features/admin/configuration/tax_categories_spec.rb
@@ -5,7 +5,7 @@ describe "Tax Categories", type: :feature do
 
   before(:each) do
     visit spree.admin_path
-    click_link "Settings"
+    click_link "Taxes"
   end
 
   context "admin visiting tax categories list" do

--- a/backend/spec/features/admin/configuration/tax_rates_spec.rb
+++ b/backend/spec/features/admin/configuration/tax_rates_spec.rb
@@ -7,7 +7,7 @@ describe "Tax Rates", type: :feature do
 
   before do
     visit spree.admin_path
-    click_link "Settings"
+    click_link "Taxes"
   end
 
   # Regression test for https://github.com/spree/spree/issues/535

--- a/backend/spec/features/admin/configuration/zones_spec.rb
+++ b/backend/spec/features/admin/configuration/zones_spec.rb
@@ -6,7 +6,7 @@ describe "Zones", type: :feature do
   before(:each) do
     Spree::Zone.delete_all
     visit spree.admin_path
-    click_link "Settings"
+    click_link "Areas"
   end
 
   context "show" do

--- a/backend/spec/features/admin/orders/customer_details_spec.rb
+++ b/backend/spec/features/admin/orders/customer_details_spec.rb
@@ -28,7 +28,7 @@ describe "Customer Details", type: :feature, js: true do
       end
       click_icon :plus
       expect(page).to have_css('.line-item')
-      click_link "Customer Details"
+      click_link "Customer"
       targetted_select2 "foobar@example.com", from: "#s2id_customer_search"
       # 5317 - Address prefills using user's default.
       expect(page).to have_field('First Name', with: user.bill_address.firstname)
@@ -61,7 +61,7 @@ describe "Customer Details", type: :feature, js: true do
       before { create(:country, iso: "BRA", name: "Brazil") }
 
       it "changes state field to text input" do
-        click_link "Customer Details"
+        click_link "Customer"
 
         within("#billing") do
           targetted_select2 "Brazil", from: "#s2id_order_bill_address_attributes_country_id"
@@ -70,7 +70,7 @@ describe "Customer Details", type: :feature, js: true do
 
         click_button "Update"
         expect(page).to have_content "Customer Details Updated"
-        click_link "Customer Details"
+        click_link "Customer"
         expect(page).to have_field("order_bill_address_attributes_state_name", with: "Piaui")
       end
     end
@@ -79,12 +79,12 @@ describe "Customer Details", type: :feature, js: true do
       order.ship_address = create(:address)
       order.save!
 
-      click_link "Customer Details"
+      click_link "Customer"
       within("#shipping") { fill_in_address "ship" }
       within("#billing") { fill_in_address "bill" }
 
       click_button "Update"
-      click_link "Customer Details"
+      click_link "Customer"
 
       # Regression test for https://github.com/spree/spree/issues/2950 and https://github.com/spree/spree/issues/2433
       # This act should transition the state of the order as far as it will go too
@@ -95,7 +95,7 @@ describe "Customer Details", type: :feature, js: true do
 
     it "should show validation errors" do
       order.update_attributes!(ship_address_id: nil)
-      click_link "Customer Details"
+      click_link "Customer"
       click_button "Update"
       expect(page).to have_content("Shipping address first name can't be blank")
     end
@@ -103,7 +103,7 @@ describe "Customer Details", type: :feature, js: true do
     it "updates order email for an existing order with a user" do
       order.update_columns(ship_address_id: ship_address.id, bill_address_id: bill_address.id, state: "confirm", completed_at: nil)
       previous_user = order.user
-      click_link "Customer Details"
+      click_link "Customer"
       fill_in "order_email", with: "newemail@example.com"
       expect { click_button "Update" }.to change { order.reload.email }.to "newemail@example.com"
       expect(order.user_id).to eq previous_user.id
@@ -121,7 +121,7 @@ describe "Customer Details", type: :feature, js: true do
       end
 
       it "sets default country when displaying form" do
-        click_link "Customer Details"
+        click_link "Customer"
         expect(page).to have_field("order_bill_address_attributes_country_id", with: brazil.id)
       end
     end
@@ -133,7 +133,7 @@ describe "Customer Details", type: :feature, js: true do
       end
 
       specify do
-        click_link "Customer Details"
+        click_link "Customer"
         # Need to fill in valid information so it passes validations
         fill_in "order_ship_address_attributes_firstname",  with: "John 99"
         fill_in "order_ship_address_attributes_lastname",   with: "Doe"

--- a/backend/spec/features/admin/orders/new_order_spec.rb
+++ b/backend/spec/features/admin/orders/new_order_spec.rb
@@ -29,7 +29,7 @@ describe "New Order", type: :feature do
     fill_in_quantity("table.stock-levels", "quantity_0", 2)
 
     click_icon :plus
-    click_on "Customer Details"
+    click_on "Customer"
 
     within "#select-customer" do
       targetted_select2_search user.email, from: "#s2id_customer_search"
@@ -73,7 +73,7 @@ describe "New Order", type: :feature do
         expect(page).to have_content(product.name)
       end
 
-      click_on "Customer Details"
+      click_on "Customer"
 
       within "#select-customer" do
         targetted_select2_search user.email, from: "#s2id_customer_search"
@@ -122,7 +122,7 @@ describe "New Order", type: :feature do
   # Regression test for https://github.com/spree/spree/issues/3336
   context "start by customer address" do
     it "completes order fine", js: true do
-      click_on "Customer Details"
+      click_on "Customer"
 
       within "#select-customer" do
         targetted_select2_search user.email, from: "#s2id_customer_search"
@@ -165,7 +165,7 @@ describe "New Order", type: :feature do
 
       expect(page).to have_css('.line-item')
 
-      click_link "Customer Details"
+      click_link "Customer"
       targetted_select2 user.email, from: "#s2id_customer_search"
       click_button "Update"
       expect(Spree::Order.last.state).to eq 'delivery'
@@ -178,7 +178,7 @@ describe "New Order", type: :feature do
       user.update!(email: xss_string)
     end
     it "displays the user's email escaped without executing" do
-      click_on "Customer Details"
+      click_on "Customer"
       targetted_select2_search user.email, from: "#s2id_customer_search"
       expect(page).to have_field("Email", with: xss_string)
     end

--- a/backend/spec/features/admin/orders/payments_spec.rb
+++ b/backend/spec/features/admin/orders/payments_spec.rb
@@ -22,7 +22,7 @@ describe 'Payments', type: :feature do
       within_row(1) do
         click_link order.number
       end
-      click_link 'Payments'
+      find('.tabs').click_link 'Payments'
     end
 
     def refresh_page

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -639,6 +639,7 @@ en:
         properties: Properties
         prototypes: Prototypes
         reports: Reports
+        rma: RMA
         settings: Settings
         stock: Stock
         stock_items: Management

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -629,10 +629,13 @@ en:
     adjustments: Adjustments
     admin:
       tab:
+        areas: Areas
+        checkout: Checkout
         configuration: Configuration
         option_types: Option Types
         orders: Orders
         overview: Overview
+        payments: Payments
         products: Products
         promotions: Promotions
         promotion_categories: Promotion Categories
@@ -641,9 +644,12 @@ en:
         reports: Reports
         rma: RMA
         settings: Settings
+        shipping: Shipping
         stock: Stock
         stock_items: Management
         stock_transfers: Transfers
+        store: Store
+        taxes: Taxes
         taxonomies: Taxonomies
         taxons: Taxons
         users: Users


### PR DESCRIPTION
This was done to implement issue #634.  It uses the tab functionality introduced in #870 (not yet merged) by @graygilmore.   The only changes from the plans outlined in #634 (as given by @Mandily) were to change refunds and reimbursements to checkout and to add adjustment reasons to that section.

# Before

![before tabs](https://cloud.githubusercontent.com/assets/12613649/13502861/965f3ff4-e121-11e5-865b-12800508685a.png)

# After

![after tabs](https://cloud.githubusercontent.com/assets/12613649/13479260/7e4d6766-e08a-11e5-9369-a3bbc21a1f5c.png)
