### PR TITLE
Fix left nav submenus sharing an id

### DIFF
--- a/backend/app/views/spree/admin/shared/_product_sub_menu.html.erb
+++ b/backend/app/views/spree/admin/shared/_product_sub_menu.html.erb
@@ -1,4 +1,4 @@
-<ul id="sub_nav" class="admin-subnav" data-hook="admin_product_sub_tabs">
+<ul class="admin-subnav" data-hook="admin_product_sub_tabs">
   <% if can? :admin, Spree::Product %>
     <%= tab :products, match_path: '/products' %>
   <% end %>

--- a/backend/app/views/spree/admin/shared/_promotion_sub_menu.html.erb
+++ b/backend/app/views/spree/admin/shared/_promotion_sub_menu.html.erb
@@ -1,4 +1,4 @@
-<ul id="sub_nav" class="admin-subnav" data-hook="admin_promotion_sub_tabs">
+<ul class="admin-subnav" data-hook="admin_promotion_sub_tabs">
   <% if can? :admin, Spree::Promotion %>
     <%= tab :promotions %>
   <% end %>

--- a/backend/app/views/spree/admin/shared/_stock_sub_menu.html.erb
+++ b/backend/app/views/spree/admin/shared/_stock_sub_menu.html.erb
@@ -1,4 +1,4 @@
-<ul id="sub_nav" class="admin-subnav" data-hook="admin_stock_transfer_sub_tabs">
+<ul class="admin-subnav" data-hook="admin_stock_transfer_sub_tabs">
   <% if can? :admin, Spree::StockItem %>
     <%= tab :stock_items, match_path: '/stock_items' %>
   <% end %>


### PR DESCRIPTION
Currently each submenu partial has the same id of "sub_nav".  While they aren't used anywhere in the codebase currently it is incredibly bad practice to have duplicate ID attributes on a page.