### PR TITLE
Make link to store text shorter and more clear

### DIFF
--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -762,7 +762,7 @@ en:
     back_to_stock_locations_list: Back to Stock Locations List
     back_to_stock_movements_list: Back to Stock Movements List
     back_to_stock_transfers_list: Back to Stock Transfers List
-    back_to_store: Go Back To Store
+    back_to_store: View store
     back_to_tax_categories_list: Back To Tax Categories List
     back_to_tax_rates_list: Back To Tax Rates List
     back_to_taxonomies_list: Back To Taxonomies List


### PR DESCRIPTION
Rewrote the link label to make more sense. 

![view store](https://cloud.githubusercontent.com/assets/15271353/13513198/2daa1ba4-e154-11e5-925f-0923f2ed3618.png)
