### PR TITLE
Provide customizable Stock tabs

### DIFF
--- a/backend/app/models/spree/backend_configuration.rb
+++ b/backend/app/models/spree/backend_configuration.rb
@@ -15,6 +15,7 @@ module Spree
                             :shipping_categories, :stock_locations, :trackers,
                             :refund_reasons, :reimbursement_types, :return_authorization_reasons]
     PROMOTION_TABS     ||= [:promotions, :promotion_categories]
+    STOCK_TABS         ||= [:stock_items, :stock_transfers]
     USER_TABS          ||= [:users, :store_credits]
   end
 end

--- a/backend/app/views/spree/admin/shared/_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_tabs.html.erb
@@ -23,7 +23,7 @@
 <% end %>
 
 <% if can? :admin, Spree::StockItem %>
-  <%= tab(:stock_items, :stock_transfers, url: spree.admin_stock_items_path, label: :stock, icon: 'cubes', match_path: %r(^/admin/stock)) do %>
+  <%= tab(*Spree::BackendConfiguration::STOCK_TABS, url: spree.admin_stock_items_path, label: :stock, icon: 'cubes', match_path: %r(^/admin/stock)) do %>
     <%- render partial: 'spree/admin/shared/stock_sub_menu' %>
   <%- end %>
 <% end %>


### PR DESCRIPTION
Follows the convention used by other admin tabs and adds a configurable
`STOCK_TABS` constant within `Spree::BackendConfiguration`.