### PR TITLE
Improve admin header

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/shared/_layout.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_layout.scss
@@ -107,13 +107,16 @@ body {
 }
 
 #content-header {
-  padding: 15px 0;
+  padding: 15px 14px;
   background-color: very-light($color-3, 4);
   border-bottom: 1px solid $color-border;
   position: fixed;
   left: $width-sidebar;
   width: calc(100% - #{$width-sidebar});
   z-index: 1;
+  @include display(flex);
+  @include align-items(center);
+  @include justify-content(space-between);
 
   .page-title {
     font-size: 20px;

--- a/backend/app/assets/stylesheets/spree/backend/shared/_layout.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_layout.scss
@@ -65,6 +65,10 @@ body {
   @include clearfix;
 }
 
+.content-under-header {
+  padding-top: 89px;
+}
+
 // Header
 //---------------------------------------------------
 .admin-nav-header {
@@ -106,6 +110,10 @@ body {
   padding: 15px 0;
   background-color: very-light($color-3, 4);
   border-bottom: 1px solid $color-border;
+  position: fixed;
+  left: $width-sidebar;
+  width: calc(100% - #{$width-sidebar});
+  z-index: 1;
 
   .page-title {
     font-size: 20px;

--- a/backend/app/views/spree/admin/shared/_content_header.html.erb
+++ b/backend/app/views/spree/admin/shared/_content_header.html.erb
@@ -1,23 +1,13 @@
 <% if content_for?(:page_title) || content_for?(:page_actions) %>
   <div id="content-header" data-hook>
-    <div class="container">
-      <div class="sixteen columns">
-        <div class="block-table">
-          <% if content_for?(:page_title) %>
-            <div class="table-cell">
-              <h1 class="page-title <%= yield :page_title_classes %>"><%= yield :page_title %></h1>
-            </div>
-          <% end %>
+    <h1 class="page-title <%= yield :page_title_classes %>"><%= yield :page_title %></h1>
 
-          <% if content_for?(:page_actions) %>
-            <div class="page-actions table-cell toolbar" data-hook="toolbar">
-              <ul class="inline-menu">
-                <%= yield :page_actions %>
-              </ul>
-            </div>
-          <% end %>
-        </div>
+    <% if content_for?(:page_actions) %>
+      <div class="toolbar" data-hook="toolbar">
+        <ul class="page-actions inline-menu">
+          <%= yield :page_actions %>
+        </ul>
       </div>
-    </div>
+    <% end %>
   </div>
 <% end %>

--- a/backend/app/views/spree/layouts/admin.html.erb
+++ b/backend/app/views/spree/layouts/admin.html.erb
@@ -34,7 +34,7 @@
 
       <%= render :partial => 'spree/admin/shared/content_header' %>
 
-      <div class="container">
+      <div class="container<%= ' content-under-header' if (content_for?(:page_title) || content_for?(:page_actions)) %>">
         <div class="row">
           <div class="<%= 'with-sidebar ' if content_for?(:sidebar) %>" id="content" data-hook>
             <div class="<%= if content_for?(:sidebar) then 'twelve' else 'sixteen' end %> columns">


### PR DESCRIPTION
Make the header sticky and adjust the display of the page title and actions in response to #630.  I'd like to draw attention to leaving the `<div class="toolbar" data-hook="toolbar"> ` in.  I wasn't certain it would be safe to take this out since someone might be hooking into the toolbar data-hook and it makes no difference in how the page renders. Also I took out the conditional for the page title to render the `<h1>` element.  I made this choice since the simple concise flex box setup I went with relied on having a title on the page (or at least an empty h1). I believe there are no pages in the admin that don't have content for the page_title.  Further, an empty h1 element shouldn't hurt anyone either on the off chance they removed the text for the page_title.

# Before

![before-header](https://cloud.githubusercontent.com/assets/12613649/13514719/3b19f370-e160-11e5-9531-2eb9b1337be9.png)

(I skipped including a view of the screen scrolled down with no header in view. It seemed pointless)

# After

![after-header](https://cloud.githubusercontent.com/assets/12613649/13514720/3fe5124a-e160-11e5-96dc-2b5d89aabfb8.png)


