### PR TITLE
Use conditional relationship rather than manual accessor.

### DIFF
--- a/core/app/models/concerns/spree/user_address_book.rb
+++ b/core/app/models/concerns/spree/user_address_book.rb
@@ -24,6 +24,10 @@ module Spree
 
       # bill_address is only minimally used now, but we can't get rid of it without a major version release
       belongs_to :bill_address, class_name: 'Spree::Address'
+
+      has_one :default_user_address, ->{ default }, class_name: 'Spree::UserAddress', foreign_key: 'user_id'
+      has_one :default_address, through: :default_user_address, source: :address
+      alias_method :ship_address, :default_address
     end
 
     def bill_address=(address)
@@ -34,10 +38,6 @@ module Spree
 
     def bill_address_attributes=(attributes)
       self.bill_address = Address.immutable_merge(bill_address, attributes)
-    end
-
-    def default_address
-      user_addresses.default.first.try(:address)
     end
 
     def default_address=(address)
@@ -51,7 +51,6 @@ module Spree
       self.default_address = Address.immutable_merge(default_address, attributes)
     end
 
-    alias_method :ship_address, :default_address
     alias_method :ship_address_attributes=, :default_address_attributes=
 
     # saves address in address book


### PR DESCRIPTION
This is basically just a change in implementation and no change in
functionality as it still does the same thing. `Spree::User#default_address`
still returns the related default address.

Why I prefer this implementation is it allows the address to be
preloaded preventing O(N) queries if we need to print some address
info out about each user (i.e. name, phone, etc). Printing the
name for each user seems like a common operation so it seems it
would be good to provide a way to do that for a list of users
efficiently.

The `default_address=` implementation is remaining and overriding the
implmenetation the relationship would provide. This will allow the
special handling of address assignment to remain.