### PR TITLE
Remove unused `user` role.

### DIFF
--- a/core/db/default/spree/roles.rb
+++ b/core/db/default/spree/roles.rb
@@ -1,2 +1,1 @@
 Spree::Role.where(name: "admin").first_or_create
-Spree::Role.where(name: "user").first_or_create


### PR DESCRIPTION
The default solidus store doesn't use this role. The only places roles
are referenced are:

https://github.com/solidusio/solidus/blob/master/core/lib/spree/core/engine.rb#L20-L25

Here the `admin` role is referenced as well as the pseudo-role `default` (which
is not a real role but the role implied if no other role is assigned to the user).

This `user` role is not assigned for example when a customer registers so it always
remains unchecked unless manually checked. If manually checked it has no effect as
nothing references it.

I would like to remove this role as it causes confusion in the Solidus backend.
Administrators are confused by what the checkbox does (nothing) and if they need
to check it or not.

This just removes it from the default data. Existing stores would need to manually
remove the role if they don't want it. Actively removing it from legacy stores may
cause issues if the store has been customized to use the role. This just prevents
us from setting up the expectation that the role always exists in new stores. If
a store wants it they can add it to their own seed data (or even name it something
more relevant like `customer`).