### PR TITLE
Hide niche stock restriction feature for cleaner backed UI.

### DIFF
--- a/backend/app/views/spree/admin/users/_form.html.erb
+++ b/backend/app/views/spree/admin/users/_form.html.erb
@@ -31,7 +31,7 @@
       </div>
     <% end %>
 
-    <% if can?(:display, Spree::StockLocation) %>
+    <% if Spree::Config.can_restrict_stock_management && can?(:display, Spree::StockLocation) %>
       <div data-hook="admin_user_form_stock_locations" class="field">
         <%= label_tag nil, Spree.t(:stock_locations) %>
         <ul>

--- a/backend/app/views/spree/admin/users/_form.html.erb
+++ b/backend/app/views/spree/admin/users/_form.html.erb
@@ -31,7 +31,7 @@
       </div>
     <% end %>
 
-    <% if Spree::Config.can_restrict_stock_management && can?(:display, Spree::StockLocation) %>
+    <% if Spree::Config[:can_restrict_stock_management] && can?(:display, Spree::StockLocation) %>
       <div data-hook="admin_user_form_stock_locations" class="field">
         <%= label_tag nil, Spree.t(:stock_locations) %>
         <ul>

--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -264,6 +264,10 @@ module Spree
     #   @return [Boolean] Whether use of an address in checkout marks it as user's default
     preference :automatic_default_address, :boolean, default: true
 
+    # @!attribute [rw] can_restrict_stock_management
+    #   @return [Boolean] Indicates if stock management can be restricted by location
+    preference :can_restrict_stock_management, :boolean, default: false
+
     # searcher_class allows spree extension writers to provide their own Search class
     attr_writer :searcher_class
     def searcher_class
@@ -310,19 +314,6 @@ module Spree
     attr_writer :order_merger_class
     def order_merger_class
       @order_merger_class ||= Spree::OrderMerger
-    end
-
-    # Indicats if stock management can be restricted by stock location
-    #
-    # @!attribute [rw] can_restricted_stock_management
-    # @return [Boolean] True if capability enabled, false otherwise. Default to true only when one of the restricted stock permission sets are in use
-    attr_writer :can_restrict_stock_management
-    def can_restrict_stock_management
-      return @can_restrict_stock_management if defined? @can_restrict_stock_management
-      roles = Spree::RoleConfiguration.instance.roles.values
-      permission_sets = roles.map { |r| r.permission_sets.to_a }.flatten.uniq
-      names = permission_sets.map { |ps| ps.name }
-      @can_restrict_stock_management = names.any? { |klass| klass =~ /\:\:RestrictedStock/ }
     end
 
     def static_model_preferences

--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -312,6 +312,19 @@ module Spree
       @order_merger_class ||= Spree::OrderMerger
     end
 
+    # Indicats if stock management can be restricted by stock location
+    #
+    # @!attribute [rw] can_restricted_stock_management
+    # @return [Boolean] True if capability enabled, false otherwise. Default to true only when one of the restricted stock permission sets are in use
+    attr_writer :can_restrict_stock_management
+    def can_restrict_stock_management
+      return @can_restrict_stock_management if defined? @can_restrict_stock_management
+      roles = Spree::RoleConfiguration.instance.roles.values
+      permission_sets = roles.collect {|r| r.permission_sets.to_a }.flatten.uniq
+      names = permission_sets.collect {|ps| ps.name }
+      @can_restrict_stock_management = names.any? {|klass| klass =~ /\:\:RestrictedStock/}
+    end
+
     def static_model_preferences
       @static_model_preferences ||= Spree::Preferences::StaticModelPreferences.new
     end

--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -320,9 +320,9 @@ module Spree
     def can_restrict_stock_management
       return @can_restrict_stock_management if defined? @can_restrict_stock_management
       roles = Spree::RoleConfiguration.instance.roles.values
-      permission_sets = roles.collect {|r| r.permission_sets.to_a }.flatten.uniq
-      names = permission_sets.collect {|ps| ps.name }
-      @can_restrict_stock_management = names.any? {|klass| klass =~ /\:\:RestrictedStock/}
+      permission_sets = roles.map { |r| r.permission_sets.to_a }.flatten.uniq
+      names = permission_sets.map { |ps| ps.name }
+      @can_restrict_stock_management = names.any? { |klass| klass =~ /\:\:RestrictedStock/ }
     end
 
     def static_model_preferences

--- a/core/spec/models/spree/app_configuration_spec.rb
+++ b/core/spec/models/spree/app_configuration_spec.rb
@@ -20,28 +20,6 @@ describe Spree::AppConfiguration, type: :model do
     expect(prefs.variant_search_class).to eq Spree::Core::Search::Variant
   end
 
-  describe '@can_restrict_stock_management' do
-    # Ensure we start with a clean configuration
-    before do
-      Spree::RoleConfiguration.instance.send :initialize
-      Spree::RoleConfiguration.configure do |config|
-        config.assign_permissions :default, [Spree::PermissionSets::DefaultCustomer]
-        config.assign_permissions :admin, [Spree::PermissionSets::SuperUser]
-      end
-    end
-
-    it 'defaults to false normally' do
-      expect( prefs.can_restrict_stock_management ).to be false
-    end
-
-    it 'defaults to true if using any of the restricted stock management permission sets' do
-      Spree::RoleConfiguration.configure do |config|
-        config.assign_permissions :test_restrict, [Spree::PermissionSets::RestrictedStockDisplay]
-      end
-      expect( prefs.can_restrict_stock_management ).to be true
-    end
-  end
-
   describe '#stock' do
     subject { prefs.stock }
     it { is_expected.to be_a Spree::Core::StockConfiguration }

--- a/core/spec/models/spree/app_configuration_spec.rb
+++ b/core/spec/models/spree/app_configuration_spec.rb
@@ -20,6 +20,28 @@ describe Spree::AppConfiguration, type: :model do
     expect(prefs.variant_search_class).to eq Spree::Core::Search::Variant
   end
 
+  describe '@can_restrict_stock_management' do
+    # Ensure we start with a clean configuration
+    before do
+      Spree::RoleConfiguration.instance.send :initialize
+      Spree::RoleConfiguration.configure do |config|
+        config.assign_permissions :default, [Spree::PermissionSets::DefaultCustomer]
+        config.assign_permissions :admin, [Spree::PermissionSets::SuperUser]
+      end
+    end
+
+    it 'defaults to false normally' do
+      expect( prefs.can_restrict_stock_management ).to be false
+    end
+
+    it 'defaults to true if using any of the restricted stock management permission sets' do
+      Spree::RoleConfiguration.configure do |config|
+        config.assign_permissions :test_restrict, [Spree::PermissionSets::RestrictedStockDisplay]
+      end
+      expect( prefs.can_restrict_stock_management ).to be true
+    end
+  end
+
   describe '#stock' do
     subject { prefs.stock }
     it { is_expected.to be_a Spree::Core::StockConfiguration }


### PR DESCRIPTION
The backend interface has in the user profile a "Stock Locations"
configuration. It's not clear from the UI what this feature is at all
(my first assumption was it was some indicator of where a customer should
get products shipped from by default).

Looked into it and it seems to be a order fullfillment feature to
ensure folks that are fullfilling the order can only do so out of the
stock locations they are assigned (so a worker in Seattle cannnot
fullfill with inventory from Atlanta).

This seems very much a niche feature as most stores only have one location
and even stores that do have multiple locations may not have problems
fulfilling from the wrong location. I would argue this entire feature should
be an extension.

But going down that path of moduralizing that feature is probably not worth
the effort at this point so just extended it to be less prominent. Added
a new preference that will indicate if this configuration should be shown.
Since I hate to have yet another configuration I made the default intelligent
so that it looks to see if one of the RestrictedStock permission sets are
being used to determine the default.

If you are using a custom permission set and therefore the intelligent
default fails you can still manually indicate you are using this feature but
hopefully for stores using it the feature will just work as before and for
stores not using it, they get a cleaner UI.