### PR TITLE
Allow the user sidebar partial to be used outside the Solidus engine

### DIFF
--- a/backend/app/views/spree/admin/users/_sidebar.html.erb
+++ b/backend/app/views/spree/admin/users/_sidebar.html.erb
@@ -6,26 +6,26 @@
   <nav class="menu">
     <ul data-hook="admin_user_tab_options">
       <li<%== ' class="active"' if current == :account %>>
-        <%= link_to_with_icon 'user', Spree.t(:"admin.user.account"), edit_admin_user_path(@user) %>
+        <%= link_to_with_icon 'user', Spree.t(:"admin.user.account"), spree.edit_admin_user_path(@user) %>
       </li>
       <% if can?(:addresses, @user) %>
         <li<%== ' class="active"' if current == :address %>>
-          <%= link_to_with_icon 'user', Spree.t(:"admin.user.addresses"), addresses_admin_user_path(@user) %>
+          <%= link_to_with_icon 'user', Spree.t(:"admin.user.addresses"), spree.addresses_admin_user_path(@user) %>
         </li>
       <% end %>
       <% if can?(:orders, @user) %>
         <li<%== ' class="active"' if current == :orders %>>
-          <%= link_to_with_icon 'shopping-cart', Spree.t(:"admin.user.orders"), orders_admin_user_path(@user) %>
+          <%= link_to_with_icon 'shopping-cart', Spree.t(:"admin.user.orders"), spree.orders_admin_user_path(@user) %>
         </li>
       <% end %>
       <% if can?(:items, @user) %>
         <li<%== ' class="active"' if current == :items %>>
-          <%= link_to_with_icon 'edit', Spree.t(:"admin.user.items"), items_admin_user_path(@user) %>
+          <%= link_to_with_icon 'edit', Spree.t(:"admin.user.items"), spree.items_admin_user_path(@user) %>
         </li>
       <% end %>
       <% if can?(:display, Spree::StoreCredit) %>
         <li<%== ' class="active"' if current == :store_credits %>>
-          <%= link_to_with_icon 'money', Spree.t(:"admin.user.store_credit"), admin_user_store_credits_path(@user) %>
+          <%= link_to_with_icon 'money', Spree.t(:"admin.user.store_credit"), spree.admin_user_store_credits_path(@user) %>
         </li>
       <% end %>
     </ul>


### PR DESCRIPTION
This should be a no-op for a stock solidus store. Where it comes in
handy is when you are trying to keep a separation of concerns between
custom code vs. Spree code while still maintaining a consistent UI for
the user.

My custom code operates in it's own context (the app or independent engines)
but I have data hanging off of the user model (i.e. info related to the user).
I don't want the user to have multiple admin screens so my custom code has
a light bit of integration to make it fit in with the Spree admin interface
(uses the same layout and uses shared partials such as this sidebar).

This setup generally works as many of the links already explicitly reference
the `spree` engine. For example the main menu does this at:

https://github.com/solidusio/solidus/blob/master/backend/app/helpers/spree/admin/navigation_helper.rb#L17

This commit updates this sidebar partial to follow the pattern set by the
main menu and explicitly indicate the engine. This allows it to work within the
spree engine as well as outside the spree engine.