### PR TITLE
Connect shipping rates to shipments earlier in Stock::Coordinator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## Solidus 1.3.0 (unreleased)
 
+*   Changes to Spree::Stock::Estimator
+
+    * The package passed to Spree::Stock::Estimator#shipping_rates must have its
+      shipment assigned and that shipment must have its order assigned. This
+      is needed for some upcoming tax work in to calculate taxes correctly.
+    * Spree::Stock::Estimator.new no longer accepts an order argument. The order
+      will be fetched from the shipment.
+
+    https://github.com/solidusio/solidus/pull/965
+
 *   Made Spree::Order validate :store_id
 
     All orders created since Spree v2.4 should have a store assigned. We want to build more

--- a/api/spec/controllers/spree/api/checkouts_controller_spec.rb
+++ b/api/spec/controllers/spree/api/checkouts_controller_spec.rb
@@ -136,7 +136,7 @@ module Spree
 
       it "can update shipping method and transition from delivery to payment" do
         order.update_column(:state, "delivery")
-        shipment = create(:shipment, order: order)
+        shipment = create(:shipment, order: order, address: order.ship_address)
         shipment.refresh_rates
         shipping_rate = shipment.shipping_rates.where(selected: false).first
         api_put :update, id: order.to_param, order_token: order.guest_token,

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -178,7 +178,7 @@ module Spree
       # StockEstimator.new assigment below will replace the current shipping_method
       original_shipping_method_id = shipping_method.try!(:id)
 
-      new_rates = Spree::Config.stock.estimator_class.new(order).shipping_rates(to_package)
+      new_rates = Spree::Config.stock.estimator_class.new.shipping_rates(to_package)
 
       # If one of the new rates matches the previously selected shipping
       # method, select that instead of the default provided by the estimator.
@@ -259,6 +259,7 @@ module Spree
 
     def to_package
       package = Stock::Package.new(stock_location)
+      package.shipment = self
       inventory_units.includes(:variant).joins(:variant).group_by(&:state).each do |state, state_inventory_units|
         package.add_multiple state_inventory_units, state.to_sym
       end

--- a/core/app/models/spree/stock/coordinator.rb
+++ b/core/app/models/spree/stock/coordinator.rb
@@ -20,7 +20,7 @@ module Spree
         packages = build_packages(packages)
         packages = prioritize_packages(packages)
         packages.each do |package|
-          package.shipment = package.to_shipment.tap { |s| s.address = order.ship_address }
+          package.shipment = package.to_shipment
         end
         packages = estimate_packages(packages)
         validate_packages(packages)

--- a/core/app/models/spree/stock/coordinator.rb
+++ b/core/app/models/spree/stock/coordinator.rb
@@ -10,9 +10,7 @@ module Spree
       end
 
       def shipments
-        packages.map do |package|
-          package.to_shipment.tap { |s| s.address = order.ship_address }
-        end
+        packages.map(&:shipment)
       end
 
       private
@@ -21,6 +19,9 @@ module Spree
         packages = build_location_configured_packages
         packages = build_packages(packages)
         packages = prioritize_packages(packages)
+        packages.each do |package|
+          package.shipment = package.to_shipment.tap { |s| s.address = order.ship_address }
+        end
         packages = estimate_packages(packages)
         validate_packages(packages)
         packages
@@ -122,7 +123,7 @@ module Spree
       def estimate_packages(packages)
         estimator = Spree::Config.stock.estimator_class.new(order)
         packages.each do |package|
-          package.shipping_rates = estimator.shipping_rates(package)
+          package.shipment.shipping_rates = estimator.shipping_rates(package)
         end
         packages
       end

--- a/core/app/models/spree/stock/coordinator.rb
+++ b/core/app/models/spree/stock/coordinator.rb
@@ -121,7 +121,7 @@ module Spree
       end
 
       def estimate_packages(packages)
-        estimator = Spree::Config.stock.estimator_class.new(order)
+        estimator = Spree::Config.stock.estimator_class.new
         packages.each do |package|
           package.shipment.shipping_rates = estimator.shipping_rates(package)
         end

--- a/core/app/models/spree/stock/estimator.rb
+++ b/core/app/models/spree/stock/estimator.rb
@@ -57,7 +57,7 @@ module Spree
 
       def shipping_methods(package)
         package.shipping_methods
-          .available_for_address(package.shipment.order.ship_address)
+          .available_for_address(package.shipment.address)
           .includes(:calculator, tax_category: :tax_rates)
           .to_a
           .select do |ship_method|

--- a/core/app/models/spree/stock/estimator.rb
+++ b/core/app/models/spree/stock/estimator.rb
@@ -46,7 +46,10 @@ module Spree
           end
 
           if cost
-            rate = shipping_method.shipping_rates.new(cost: cost)
+            rate = shipping_method.shipping_rates.new(
+              cost: cost,
+              shipment: package.shipment
+            )
             rate.tax_rate = tax_rate if tax_rate
           end
 

--- a/core/app/models/spree/stock/package.rb
+++ b/core/app/models/spree/stock/package.rb
@@ -123,6 +123,7 @@ module Spree
 
         Spree::Shipment.new(
           order: order,
+          address: order.ship_address,
           stock_location: stock_location,
           inventory_units: contents.map(&:inventory_unit)
         )

--- a/core/app/models/spree/stock/package.rb
+++ b/core/app/models/spree/stock/package.rb
@@ -122,6 +122,7 @@ module Spree
         contents.each { |content_item| content_item.inventory_unit.state = content_item.state.to_s }
 
         Spree::Shipment.new(
+          order: order,
           stock_location: stock_location,
           inventory_units: contents.map(&:inventory_unit)
         )

--- a/core/app/models/spree/stock/package.rb
+++ b/core/app/models/spree/stock/package.rb
@@ -2,14 +2,13 @@ module Spree
   module Stock
     class Package
       attr_reader :stock_location, :contents
-      attr_accessor :shipping_rates
+      attr_accessor :shipment
 
       # @param stock_location [Spree::StockLocation] the stock location this package originates from
       # @param contents [Array<Spree::Stock::ContentItem>] the contents of this package
       def initialize(stock_location, contents = [])
         @stock_location = stock_location
         @contents = contents
-        @shipping_rates = []
       end
 
       # Adds an inventory unit to this package.
@@ -124,7 +123,6 @@ module Spree
 
         Spree::Shipment.new(
           stock_location: stock_location,
-          shipping_rates: shipping_rates,
           inventory_units: contents.map(&:inventory_unit)
         )
       end

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -175,7 +175,7 @@ describe Spree::Shipment, type: :model do
       before { allow(shipment).to receive(:can_get_rates?){ true } }
 
       it 'should request new rates, and maintain shipping_method selection' do
-        expect(Spree::Stock::Estimator).to receive(:new).with(shipment.order).and_return(mock_estimator)
+        expect(Spree::Stock::Estimator).to receive(:new).with(no_args).and_return(mock_estimator)
         allow(shipment).to receive_messages(shipping_method: shipping_method2)
 
         expect(shipment.refresh_rates).to eq(shipping_rates)
@@ -183,7 +183,7 @@ describe Spree::Shipment, type: :model do
       end
 
       it 'should handle no shipping_method selection' do
-        expect(Spree::Stock::Estimator).to receive(:new).with(shipment.order).and_return(mock_estimator)
+        expect(Spree::Stock::Estimator).to receive(:new).with(no_args).and_return(mock_estimator)
         allow(shipment).to receive_messages(shipping_method: nil)
         expect(shipment.refresh_rates).to eq(shipping_rates)
         expect(shipment.reload.selected_shipping_rate).not_to be_nil
@@ -221,6 +221,10 @@ describe Spree::Shipment, type: :model do
           package = shipment.to_package
           expect(package.on_hand.count).to eq 1
           expect(package.backordered.count).to eq 1
+        end
+
+        it 'should set the shipment to itself' do
+          expect(shipment.to_package.shipment).to eq(shipment)
         end
       end
     end

--- a/core/spec/models/spree/stock/package_spec.rb
+++ b/core/spec/models/spree/stock/package_spec.rb
@@ -97,9 +97,9 @@ module Spree
         subject.add build_inventory_unit, :backordered
 
         shipping_method = build(:shipping_method)
-        subject.shipping_rates = [Spree::ShippingRate.new(shipping_method: shipping_method, cost: 10.00, selected: true)]
 
         shipment = subject.to_shipment
+        shipment.shipping_rates = [Spree::ShippingRate.new(shipping_method: shipping_method, cost: 10.00, selected: true)]
         expect(shipment.stock_location).to eq subject.stock_location
         expect(shipment.inventory_units.size).to eq 3
 

--- a/core/spec/models/spree/stock/package_spec.rb
+++ b/core/spec/models/spree/stock/package_spec.rb
@@ -10,7 +10,7 @@ module Spree
       subject { Package.new(stock_location) }
 
       def build_inventory_unit
-        build(:inventory_unit, variant: variant)
+        build(:inventory_unit, variant: variant, order: order)
       end
 
       it 'calculates the weight of all the contents' do
@@ -113,6 +113,7 @@ module Spree
         expect(last_unit.state).to eq 'backordered'
 
         expect(shipment.shipping_method).to eq shipping_method
+        expect(shipment.address).to eq order.ship_address
       end
 
       it 'does not add an inventory unit to a package twice' do


### PR DESCRIPTION
This will give the estimator the information it needs to calculate
taxes correctly in the pending tax work.

See comments in https://github.com/solidusio/solidus/pull/904#discussion-diff-54887938