### PR TITLE
Move header title and actions out of 16 column skeleton

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/shared/_layout.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_layout.scss
@@ -103,7 +103,9 @@ body {
 }
 
 #content-header {
-  padding: 15px 0;
+  @include display(flex);
+  @include align-items(center);
+  padding: 15px 14px;
   background-color: very-light($color-3, 4);
   border-bottom: 1px solid $color-border;
 
@@ -113,12 +115,15 @@ body {
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
   }
-  .page-actions {
-    text-align: right;
-    line-height: 38px;
-    form {
-      display: inline-block;
-    }
+}
+
+.header-actions {
+  @include flex-grow(1);
+  text-align: right;
+  line-height: 38px;
+
+  form {
+    display: inline-block;
   }
 }
 

--- a/backend/app/views/spree/admin/shared/_content_header.html.erb
+++ b/backend/app/views/spree/admin/shared/_content_header.html.erb
@@ -1,23 +1,15 @@
 <% if content_for?(:page_title) || content_for?(:page_actions) %>
   <div id="content-header" data-hook>
-    <div class="container">
-      <div class="sixteen columns">
-        <div class="block-table">
-          <% if content_for?(:page_title) %>
-            <div class="table-cell">
-              <h1 class="page-title <%= yield :page_title_classes %>"><%= yield :page_title %></h1>
-            </div>
-          <% end %>
+    <% if content_for?(:page_title) %>
+      <h1 class="page-title <%= yield :page_title_classes %>"><%= yield :page_title %></h1>
+    <% end %>
 
-          <% if content_for?(:page_actions) %>
-            <div class="page-actions table-cell toolbar" data-hook="toolbar">
-              <ul class="inline-menu">
-                <%= yield :page_actions %>
-              </ul>
-            </div>
-          <% end %>
-        </div>
+    <% if content_for?(:page_actions) %>
+      <div class="header-actions page-actions table-cell toolbar" data-hook="toolbar">
+        <ul class="inline-menu">
+          <%= yield :page_actions %>
+        </ul>
       </div>
-    </div>
+    <% end %>
   </div>
 <% end %>

--- a/backend/app/views/spree/admin/shared/_content_header.html.erb
+++ b/backend/app/views/spree/admin/shared/_content_header.html.erb
@@ -1,7 +1,7 @@
 <% if content_for?(:page_title) || content_for?(:page_actions) %>
   <div id="content-header" data-hook>
     <% if content_for?(:page_title) %>
-      <h1 class="page-title <%= yield :page_title_classes %>"><%= yield :page_title %></h1>
+      <h1 class="page-title"><%= yield :page_title %></h1>
     <% end %>
 
     <% if content_for?(:page_actions) %>

--- a/backend/app/views/spree/admin/shared/_content_header.html.erb
+++ b/backend/app/views/spree/admin/shared/_content_header.html.erb
@@ -5,11 +5,9 @@
     <% end %>
 
     <% if content_for?(:page_actions) %>
-      <div class="header-actions page-actions table-cell toolbar" data-hook="toolbar">
-        <ul class="inline-menu">
-          <%= yield :page_actions %>
-        </ul>
-      </div>
+      <ul class="header-actions page-actions inline-menu" data-hook="toolbar">
+        <%= yield :page_actions %>
+      </ul>
     <% end %>
   </div>
 <% end %>


### PR DESCRIPTION
We are moving away from the skeleton and would like to move the page title and page actions out to the edges.  This is a stripped down version of #959 implementing @graygilmore's suggestions since we weren't sure about making the header sticky at crunch time (opinions at #630 please).  

# Before

![before-header](https://cloud.githubusercontent.com/assets/12613649/13542244/469a6d7c-e216-11e5-96e3-d5647e0b29b3.png)

# After

![after-split](https://cloud.githubusercontent.com/assets/12613649/13542256/4e7b4390-e216-11e5-972e-ff2419a28e16.png)

