### PR TITLE
Refactor Order factory

### DIFF
--- a/core/spec/lib/spree/core/testing_support/factories/order_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/order_factory_spec.rb
@@ -1,6 +1,46 @@
 require 'spec_helper'
 require 'spree/testing_support/factories/order_factory'
 
+RSpec.shared_examples_for 'a fresh order from the factory' do
+  subject { FactoryGirl.send(strategy, factory, options) }
+
+  let(:options) { {} }
+
+  it 'can be saved' do
+    expect { subject.save! }.not_to raise_error if strategy == :build
+  end
+
+  it 'only creates one order in the database' do
+    expect { subject.save! }.to change(Spree::Order, :count).by(1)
+  end
+
+  it 'has a bill address' do
+    expect(subject.bill_address).to be_a(Spree::Address)
+  end
+
+  it 'has a shipping address' do
+    expect(subject.shipping_address).to be_a(Spree::Address)
+  end
+
+  it 'has a store' do
+    expect(subject.store).to be_a(Spree::Store)
+  end
+
+  describe 'with options' do
+    context 'setting the line item price' do
+      let(:options) { {line_items_price: 15, line_items_count: 2} }
+
+      it 'has two line items' do
+        expect(subject.line_items.length).to eq(2)
+      end
+
+      it 'has a total of 30' do
+        expect(subject.line_items.map(&:total).sum).to eq(30)
+      end
+    end
+  end
+end
+
 RSpec.describe 'order factory' do
   let(:factory_class) { Spree::Order }
 
@@ -8,18 +48,62 @@ RSpec.describe 'order factory' do
     let(:factory) { :order }
 
     it_behaves_like 'a working factory'
+
+    describe 'when built' do
+      let(:strategy) { :build }
+
+      it_behaves_like 'a fresh order from the factory'
+    end
+
+    describe 'when created' do
+      let(:strategy) { :create }
+
+      it_behaves_like 'a fresh order from the factory'
+    end
   end
 
   describe 'order with totals' do
     let(:factory) { :order_with_totals }
 
     it_behaves_like 'a working factory'
+
+    describe 'when built' do
+      let(:strategy) { :build }
+
+      it_behaves_like 'a fresh order from the factory'
+    end
+
+    describe 'when created' do
+      let(:strategy) { :create }
+
+      it_behaves_like 'a fresh order from the factory'
+    end
   end
 
   describe 'order with line items' do
     let(:factory) { :order_with_line_items }
 
     it_behaves_like 'a working factory'
+
+    describe 'when built' do
+      let(:strategy) { :build }
+
+      it_behaves_like 'a fresh order from the factory'
+
+      it 'has one line item' do
+        expect(build(factory).line_items.length).to eq(1)
+      end
+    end
+
+    describe 'when created' do
+      let(:strategy) { :create }
+
+      it_behaves_like 'a fresh order from the factory'
+
+      it 'has one line item' do
+        expect(build(factory).line_items.length).to eq(1)
+      end
+    end
   end
 
   describe 'completed order with totals' do

--- a/core/spec/models/spree/reimbursement_spec.rb
+++ b/core/spec/models/spree/reimbursement_spec.rb
@@ -93,7 +93,7 @@ describe Spree::Reimbursement, type: :model do
       expect {
         subject
       }.to change{ Spree::Refund.count }.by(1)
-      expect(Spree::Refund.last.amount).to eq order.total
+      expect(Spree::Refund.last.amount).to eq order.item_total
     end
 
     context 'with additional tax' do
@@ -127,7 +127,7 @@ describe Spree::Reimbursement, type: :model do
     end
 
     context 'when reimbursement cannot be fully performed' do
-      let!(:non_return_refund) { create(:refund, amount: 1, payment: payment) }
+      let!(:non_return_refund) { create(:refund, amount: 1, payment: payment, reimbursement: reimbursement) }
 
       it 'raises IncompleteReimbursement error' do
         expect { subject }.to raise_error(Spree::Reimbursement::IncompleteReimbursementError)


### PR DESCRIPTION
This adds the possibility of running `build` on an order with a full
object graph that's mostly not persisted.

Mostly meaning that while associated models might still persist
associations, many many associations on the new order object will
not be persisted.

There is a minor fix in the reimbursement spec that tells actually
associates a refund to the reimbursement it checks. I do not fully grasp
why that ever worked.

Another minor fix is that the reimbursement total now does not expect
shipping to be refunded. I believe that is the standard behaviour, and
the reason it didn't work before is because of incomplete spec setup.