### PR TITLE
WIP Add vat_country relation to prices

### DIFF
--- a/backend/app/controllers/spree/admin/prices_controller.rb
+++ b/backend/app/controllers/spree/admin/prices_controller.rb
@@ -1,0 +1,16 @@
+module Spree
+  module Admin
+    class PricesController < ResourceController
+      belongs_to 'spree/product', find_by: :slug
+
+      private
+
+      def collection
+        params[:q] ||= {}
+
+        @search = super.ransack(params[:q])
+        @collection = @search.result.page(params[:page]).per(20)
+      end
+    end
+  end
+end

--- a/backend/app/models/spree/backend_configuration.rb
+++ b/backend/app/models/spree/backend_configuration.rb
@@ -7,7 +7,7 @@ module Spree
                             :customer_returns, :adjustments, :customer_details]
     PRODUCT_TABS       ||= [:products, :option_types, :properties, :prototypes,
                             :variants, :product_properties, :taxonomies,
-                            :taxons]
+                            :taxons, :prices]
     REPORT_TABS        ||= [:reports]
     CONFIGURATION_TABS ||= [:configurations, :general_settings, :tax_categories,
                             :tax_rates, :zones, :countries, :states,

--- a/backend/app/views/spree/admin/prices/index.html.erb
+++ b/backend/app/views/spree/admin/prices/index.html.erb
@@ -16,6 +16,7 @@
         <th><%= Spree::Price.human_attribute_name(:vat_country) %></th>
         <th><%= Spree::Price.human_attribute_name(:included_tax) %></th>
         <th><%= Spree::Price.human_attribute_name(:currency) %></th>
+        <th><%= Spree::Price.human_attribute_name(:variant) %></th>
         <th><%= Spree::Price.human_attribute_name(:amount) %></th>
         <th class="actions"></th>
       </tr>
@@ -26,6 +27,7 @@
         <td><%= price.vat_country.present? ? price.vat_country_name : Spree.t(:net, scope: [:prices, :index]) %></td>
         <td class="align-center"><%= price.included_tax %></td>
         <td class="align-center"><%= price.currency %></td>
+        <td class="align-center"><%= price.variant.options_text %></td>
         <td class="align-center"><%= price.amount %></td>
         <td class="actions">
           <% if can?(:update, price) %>

--- a/backend/app/views/spree/admin/prices/index.html.erb
+++ b/backend/app/views/spree/admin/prices/index.html.erb
@@ -1,0 +1,45 @@
+<%= render :partial => 'spree/admin/shared/product_tabs', :locals => {:current => 'Prices'} %>
+<% if @prices.any? %>
+  <%= paginate @prices %>
+
+  <table>
+    <colgroup>
+      <col style="width: 10%" />
+      <col style="width: 5%" />
+      <col style="width: 5%" />
+      <col style="width: 5%" />
+      <col style="width: 15%" />
+      <col style="width: 15%" />
+    </colgroup>
+    <thead data-hook="prices_header">
+      <tr>
+        <th><%= Spree::Price.human_attribute_name(:vat_country) %></th>
+        <th><%= Spree::Price.human_attribute_name(:included_tax) %></th>
+        <th><%= Spree::Price.human_attribute_name(:currency) %></th>
+        <th><%= Spree::Price.human_attribute_name(:amount) %></th>
+        <th class="actions"></th>
+      </tr>
+    </thead>
+    <tbody>
+    <% @prices.each do |price| %>
+      <tr id="<%= spree_dom_id price %>" <%= 'style="color:red;"' if price.deleted? %> data-hook="prices_row" class="<%= cycle('odd', 'even')%>">
+        <td><%= price.vat_country.present? ? price.vat_country_name : Spree.t(:net, scope: [:prices, :index]) %></td>
+        <td class="align-center"><%= price.included_tax %></td>
+        <td class="align-center"><%= price.currency %></td>
+        <td class="align-center"><%= price.amount %></td>
+        <td class="actions">
+          <% if can?(:update, price) %>
+            <%= link_to_edit(price, :no_text => true) unless price.deleted? %>
+          <% end %>
+          <% if can?(:destroy, price) %>
+            &nbsp;
+            <%= link_to_delete(price, :no_text => true) unless price.deleted? %>
+          <% end %>
+        </td>
+      </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  <%= paginate @prices %>
+<% end %>

--- a/backend/app/views/spree/admin/shared/_product_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_product_tabs.html.erb
@@ -12,6 +12,9 @@
       <%= content_tag :li, :class => ('active' if current == 'Product Details') do %>
         <%= link_to_with_icon 'edit', Spree.t(:product_details), edit_admin_product_url(@product) %>
       <% end if can?(:admin, Spree::Product) %>
+      <%= content_tag :li, :class => ('active' if current == 'Product Details') do %>
+        <%= link_to_with_icon 'money', Spree::Price.model_name.human(count: :other), admin_product_prices_url(@product) %>
+      <% end if can?(:admin, Spree::Price) %>
       <%= content_tag :li, :class => ('active' if current == 'Images') do %>
         <%= link_to_with_icon 'picture-o', Spree.t(:images), admin_product_images_url(@product) %>
       <% end if can?(:admin, Spree::Image) %>

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -50,6 +50,7 @@ Spree::Core::Engine.add_routes do
         end
       end
       resources :variants_including_master, only: [:update]
+      resources :prices, only: [:index, :edit, :destroy]
     end
     get '/products/:product_slug/stock', to: "stock_items#index", as: :product_stock
 

--- a/backend/spec/controllers/spree/admin/prices_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/prices_controller_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe Spree::Admin::PricesController, type: :controller do
+  stub_authorization!
+
+  describe "#index" do
+    subject { spree_get :index, product_id: product.slug }
+
+    let(:product) { create(:product) }
+
+    context "for a product with prices" do
+      it "succeeds" do
+        expect(response).to be_ok
+      end
+    end
+  end
+end

--- a/backend/spec/features/admin/products/prices_spec.rb
+++ b/backend/spec/features/admin/products/prices_spec.rb
@@ -1,0 +1,19 @@
+# encoding: utf-8
+require 'spec_helper'
+
+describe "Prices", type: :feature do
+  stub_authorization!
+
+  let(:product) { create(:product_with_option_types, price: "1.99", cost_price: "1.00", weight: "2.5", height: "3.0", width: "1.0", depth: "1.5") }
+  context "listing prices" do
+    let!(:variant) do
+      create(:variant, product: product, price: 19.99)
+    end
+
+    it "opens the prices tab in the product view" do
+      visit spree.edit_admin_product_path(id: product.slug)
+      click_link("Prices")
+      expect(page).to have_content("19.99")
+    end
+  end
+end

--- a/core/app/models/spree/price.rb
+++ b/core/app/models/spree/price.rb
@@ -8,6 +8,7 @@ module Spree
     belongs_to :vat_country, class_name: "Spree::Country", foreign_key: "vat_country_iso", primary_key: "iso"
 
     validate :check_price
+    validates :vat_country, absence: true, if: :is_default?
     validates :amount, allow_nil: true, numericality: {
       greater_than_or_equal_to: 0,
       less_than_or_equal_to: MAXIMUM_AMOUNT

--- a/core/app/models/spree/price.rb
+++ b/core/app/models/spree/price.rb
@@ -39,6 +39,10 @@ module Spree
       self[:amount] = Spree::LocalizedNumber.parse(price)
     end
 
+    def included_tax
+      vat_country.present?
+    end
+
     private
 
     def check_price

--- a/core/app/models/spree/price.rb
+++ b/core/app/models/spree/price.rb
@@ -5,6 +5,7 @@ module Spree
     MAXIMUM_AMOUNT = BigDecimal('99_999_999.99')
 
     belongs_to :variant, -> { with_deleted }, class_name: 'Spree::Variant', touch: true
+    belongs_to :vat_country, class_name: "Spree::Country", foreign_key: "vat_country_iso", primary_key: "iso"
 
     validate :check_price
     validates :amount, allow_nil: true, numericality: {

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -48,7 +48,7 @@ module Spree
       class_name: 'Spree::Variant',
       dependent: :destroy
 
-    has_many :prices, -> { order(Spree::Variant.arel_table[:position].asc, Spree::Variant.arel_table[:id].asc, :currency) }, through: :variants
+    has_many :prices, -> { order(Spree::Variant.arel_table[:position].asc, Spree::Variant.arel_table[:id].asc, :currency) }, through: :variants_including_master
 
     has_many :stock_items, through: :variants_including_master
 

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -357,6 +357,9 @@ en:
       spree/payment_method:
         one: Payment Method
         other: Payment Methods
+      spree/price:
+        one: Price
+        other: Prices
       spree/product:
         one: Product
         other: Products
@@ -1386,6 +1389,10 @@ en:
     presentation: Presentation
     previous: Previous
     price: Price
+    prices:
+      index:
+        title: "Prices for %{product_name}"
+        net: Nettopreis
     price_range: Price Range
     price_sack: Price Sack
     preference_source_none: '(custom)'

--- a/core/db/migrate/20160303150239_add_vat_country_iso_to_price.rb
+++ b/core/db/migrate/20160303150239_add_vat_country_iso_to_price.rb
@@ -1,0 +1,7 @@
+class AddVatCountryIsoToPrice < ActiveRecord::Migration
+  def change
+    add_column :spree_prices, :vat_country_iso, :string, limit: 2, null: false, default: ''
+    add_index :spree_prices, :vat_country_iso
+    add_index :spree_countries, :iso
+  end
+end

--- a/core/spec/models/spree/price_spec.rb
+++ b/core/spec/models/spree/price_spec.rb
@@ -6,7 +6,7 @@ describe Spree::Price, type: :model do
 
   describe '#vat_country' do
     let!(:vat_country) { create(:country, iso: "DE") }
-    let(:price) { create(:price, vat_country_iso: "DE") }
+    let(:price) { create(:price, vat_country_iso: "DE", is_default: false) }
 
     it 'returns the country object' do
       expect(price.vat_country).to eq(vat_country)
@@ -49,6 +49,38 @@ describe Spree::Price, type: :model do
     context 'when the amount is between 0 and the maximum amount' do
       let(:amount) { Spree::Price::MAXIMUM_AMOUNT }
       it { is_expected.to be_valid }
+    end
+
+    context "with default price set" do
+      subject { Spree::Price.new(variant: variant, is_default: true, vat_country: vat_country) }
+
+      context "when there is a vat country" do
+        let(:vat_country) { create(:country) }
+
+        it { is_expected.not_to be_valid }
+      end
+
+      context "when there is no vat country" do
+        let(:vat_country) { nil }
+
+        it { is_expected.to be_valid }
+      end
+    end
+
+    context "with default price not set" do
+      subject { Spree::Price.new(variant: variant, is_default: false, vat_country: vat_country) }
+
+      context "when there is a vat country" do
+        let(:vat_country) { create(:country) }
+
+        it { is_expected.to be_valid }
+      end
+
+      context "when there is no vat country" do
+        let(:vat_country) { nil }
+
+        it { is_expected.to be_valid }
+      end
     end
   end
 end

--- a/core/spec/models/spree/price_spec.rb
+++ b/core/spec/models/spree/price_spec.rb
@@ -1,6 +1,18 @@
 require 'spec_helper'
 
 describe Spree::Price, type: :model do
+  it { is_expected.to respond_to(:vat_country) }
+  it { is_expected.to respond_to(:vat_country_iso) }
+
+  describe '#vat_country' do
+    let!(:vat_country) { create(:country, iso: "DE") }
+    let(:price) { create(:price, vat_country_iso: "DE") }
+
+    it 'returns the country object' do
+      expect(price.vat_country).to eq(vat_country)
+    end
+  end
+
   describe 'validations' do
     let(:variant) { stub_model Spree::Variant }
     subject { Spree::Price.new variant: variant, amount: amount }


### PR DESCRIPTION
I chose to use the ISO code as primary/foreign key as that is just so
much easier to understand than the ever-changing country IDs.

I believe with the 2-character limit on the column and Indexes that
should not be a major performance issue, and it makes our database dumps
and SQL queries a lot easier to read.

I don't want to touch the default price and would like that to always be
the net (export) price, as that makes prices easy to compare.