### PR TITLE
Have Spree::Product#prices return master prices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Solidus 1.3.0 (unreleased)
 
+*   Make Spree::Product#prices association return all prices
+
+    Previously, only non-master variant prices would have been returned here.
+    Now, we get all the prices, including those from the master variant.
+
+    https://github.com/solidusio/solidus/pull/969
+
 *   Changes to Spree::Stock::Estimator
 
     * The package passed to Spree::Stock::Estimator#shipping_rates must have its

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -48,7 +48,7 @@ module Spree
       class_name: 'Spree::Variant',
       dependent: :destroy
 
-    has_many :prices, -> { order(Spree::Variant.arel_table[:position].asc, Spree::Variant.arel_table[:id].asc, :currency) }, through: :variants
+    has_many :prices, -> { order(Spree::Variant.arel_table[:position].asc, Spree::Variant.arel_table[:id].asc, :currency) }, through: :variants_including_master
 
     has_many :stock_items, through: :variants_including_master
 


### PR DESCRIPTION
All other associations are `:through variants_including_master`, this
one strangely is not.