### PR TITLE
Better support for legacy bill/ship address.

### DIFF
--- a/backend/app/views/spree/admin/users/_addresses_form.html.erb
+++ b/backend/app/views/spree/admin/users/_addresses_form.html.erb
@@ -1,8 +1,7 @@
 <div data-hook="bill_address_wrapper" class="alpha six columns">
   <fieldset class="no-border-bottom">
     <legend align="center"><%= Spree.t(:billing_address) %></legend>
-    <%= f.fields_for :bill_address, @user.bill_address do |ba_form| %>
-      <% ba_form.object ||= Spree::Address.build_default %>
+    <%= f.fields_for :bill_address, @user.bill_address || Spree::Address.build_default do |ba_form| %>
       <%= render :partial => 'spree/admin/shared/address_form', :locals => { :f => ba_form, :type => "billing" } %>
     <% end %>
   </fieldset>
@@ -11,8 +10,7 @@
 <div data-hook="ship_address_wrapper" class="alpha six columns">
   <fieldset class="no-border-bottom">
     <legend align="center"><%= Spree.t(:shipping_address) %></legend>
-    <%= f.fields_for :ship_address, @user.ship_address do |sa_form| %>
-      <% sa_form.object ||= Spree::Address.build_default  %>
+    <%= f.fields_for :ship_address, @user.ship_address || Spree::Address.build_default do |sa_form| %>
       <%= render :partial => 'spree/admin/shared/address_form', :locals => { :f => sa_form, :type => "shipping" } %>
     <% end %>
   </fieldset>

--- a/core/app/models/concerns/spree/user_address_book.rb
+++ b/core/app/models/concerns/spree/user_address_book.rb
@@ -66,15 +66,23 @@ module Spree
     # sets bill_address to the default if automatic_default_address is set to true and there is no ship_address
     # if one address is nil, does not save that address
     def persist_order_address(order)
-      save_in_address_book(
-        order.ship_address.attributes,
-        Spree::Config.automatic_default_address
-      ) if order.ship_address
+      if order.ship_address
+        address = save_in_address_book(
+          order.ship_address.attributes,
+          Spree::Config.automatic_default_address
+        )
+        self.ship_address_id = address.id if address && address.persisted?
+      end
 
-      save_in_address_book(
-        order.bill_address.attributes,
-        order.ship_address.nil? && Spree::Config.automatic_default_address
-      ) if order.bill_address
+      if order.bill_address
+        address = save_in_address_book(
+          order.bill_address.attributes,
+          order.ship_address.nil? && Spree::Config.automatic_default_address
+        )
+        self.bill_address_id = address.id if address && address.persisted?
+      end
+
+      save! # In case the ship_address_id or bill_address_id was set
     end
 
     # Add an address to the user's list of saved addresses for future autofill

--- a/core/spec/models/spree/concerns/user_address_book_spec.rb
+++ b/core/spec/models/spree/concerns/user_address_book_spec.rb
@@ -243,6 +243,15 @@ module Spree
     end
 
     context "#persist_order_address" do
+      it 'will save the bill/ship_address reference if it can' do
+        order = create :order
+        user.persist_order_address(order)
+
+        expect( user.bill_address_id ).to eq order.bill_address_id
+        expect( user.ship_address_id ).to eq order.ship_address_id
+        expect( user.bill_address_id ).not_to eq user.ship_address_id
+      end
+
       context "when automatic_default_address preference is at a default of true" do
         before do
           Spree::Config.automatic_default_address = true


### PR DESCRIPTION
At the model level we are moving to having an address book associated with a user with one of those addresses being the "default". There is some code layered on top of the address book for compatibility for the old model. In addition the frontend and backend uses this compatibility layer as the frontend and backend UI has not yet been refactored to use this new address book model.

Unfortuantly there are places where this compatability is incomplete. Key areas noticed are:

* If you edit a user in the backend who does not already have an address there are no fields for the admin user to edit. This is because the nested fields block was not populating the form with an in-memory address object correctly.
* In the frontend, if you choose to "save" your addresses on an order with your user profile they were being correctly added to the address book but the legacy bill_address_id and ship_address_id field were not being populated. ship_address_id is not so much of an issue as the default and ship address are sort of synonmous in this compatability layer. But with bill address we have a loss of information. Even though we know of this address the system doesn't know it should display this address where the bill addresses is needed. This becomes apparent at two places:
  * In the backend if you view the user, only the ship address is populated.
  * If the user creates another order only the ship address is pre-populated.

This commit provides the better compatibility between the old model and the new model by fixing the nested field block as well as populating the bill_address_id and ship_address_id.

Moving forward I hope we can get rid of this duel model as it adds complication but I'm guessing the address UI needs to be written first. Also I question if we really want to have only one "default" address. It seems having a default shipping and a default billing would be more appropriate. Without this the user will always need to correct the system with every order as it would populate the billing and
shipping with the single default.