### PR TITLE
Remove "or" wording from admin backend

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
@@ -272,21 +272,6 @@ fieldset {
     > * + * {
       margin-left: 2em;
     }
-
-    span.or {
-      background-color: $color-1;
-      border-width: 5px;
-      margin-left: 5px;
-      margin-right: 11px;
-      position: relative;
-      z-index: 1;
-
-      -webkit-box-shadow: 0 0 0 5px $color-1;
-         -moz-box-shadow: 0 0 0 5px $color-1;
-          -ms-box-shadow: 0 0 0 5px $color-1;
-           -o-box-shadow: 0 0 0 5px $color-1;
-              box-shadow: 0 0 0 5px $color-1;
-    }
   }
 
   &.labels-inline {

--- a/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
@@ -268,6 +268,11 @@ fieldset {
       }
     }
 
+    // Always make sure the choices at the bottom of a fieldset are spaced out
+    > * + * {
+      margin-left: 2em;
+    }
+
     span.or {
       background-color: $color-1;
       border-width: 5px;

--- a/backend/app/views/spree/admin/adjustments/edit.html.erb
+++ b/backend/app/views/spree/admin/adjustments/edit.html.erb
@@ -15,7 +15,6 @@
 
     <div class="filter-actions actions" data-hook="buttons">
       <%= button Spree.t(:continue), 'arrow-right' %>
-      <span class="or"><%= Spree.t(:or) %></span>
       <%= link_to_with_icon 'remove', Spree.t('actions.cancel'), admin_order_adjustments_url(@order), :class => 'button' %>
     </div>
   </fieldset>

--- a/backend/app/views/spree/admin/adjustments/new.html.erb
+++ b/backend/app/views/spree/admin/adjustments/new.html.erb
@@ -16,7 +16,6 @@
 
     <div class="filter-actions actions" data-hook="buttons">
       <%= button Spree.t(:continue), 'arrow-right' %>
-      <span class="or"><%= Spree.t(:or) %></span>
       <%= button_link_to Spree.t('actions.cancel'), admin_order_adjustments_url(@order), :icon => 'remove' %>
     </div>
   </fieldset>

--- a/backend/app/views/spree/admin/customer_returns/new.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/new.html.erb
@@ -42,7 +42,6 @@
 
       <div class="form-buttons filter-actions actions" data-hook="buttons">
         <%= button Spree.t('actions.create'), 'ok' %>
-        <span class="or"><%= Spree.t(:or) %></span>
         <%= button_link_to Spree.t('actions.cancel'), admin_order_customer_returns_url(@order), :icon => 'remove' %>
       </div>
     </fieldset>

--- a/backend/app/views/spree/admin/general_settings/edit.html.erb
+++ b/backend/app/views/spree/admin/general_settings/edit.html.erb
@@ -78,7 +78,6 @@
       <% if can? :update, :general_settings %>
         <div class="form-buttons filter-actions actions" data-hook="buttons">
           <%= button Spree.t('actions.update'), 'refresh' %>
-          <span class="or"><%= Spree.t(:or) %></span>
           <%= link_to_with_icon 'remove', Spree.t('actions.cancel'), edit_admin_general_settings_url, :class => 'button' %>
         </div>
       <% end %>

--- a/backend/app/views/spree/admin/images/edit.html.erb
+++ b/backend/app/views/spree/admin/images/edit.html.erb
@@ -19,7 +19,6 @@
     <div class="clear"></div>
     <div class="form-buttons filter-actions actions" data-hook="buttons">
       <%= button Spree.t('actions.update'), 'refresh' %>
-      <span class="or"><%= Spree.t(:or) %></span>
       <%= link_to Spree.t('actions.cancel'), admin_product_images_url(@product), :id => 'cancel_link', :class => 'button remove' %>
     </div>
   </fieldset>

--- a/backend/app/views/spree/admin/images/new.html.erb
+++ b/backend/app/views/spree/admin/images/new.html.erb
@@ -6,7 +6,6 @@
     
       <div class="form-buttons filter-actions actions" data-hook="buttons">
         <%= button Spree.t('actions.update'), 'refresh' %>
-        <span class="or"><%= Spree.t(:or) %></span>
         <%= link_to_with_icon 'remove', Spree.t('actions.cancel'), admin_product_images_url(@product), :id => 'cancel_link', :class => 'button' %>
       </div>
   </fieldset>

--- a/backend/app/views/spree/admin/product_properties/index.html.erb
+++ b/backend/app/views/spree/admin/product_properties/index.html.erb
@@ -59,7 +59,6 @@
       <div class="form-buttons filter-actions actions">
         <%= button Spree.t(:filter_results) %>
         <% if @option_value_ids.present? %>
-          <span class="or"><%= Spree.t(:or) %></span>
           <%= link_to_add_fields Spree.t(:add_variant_properties), 'tbody#variant_property_values', class: 'plus button' %>
         <% end %>
       </div>

--- a/backend/app/views/spree/admin/refunds/edit.html.erb
+++ b/backend/app/views/spree/admin/refunds/edit.html.erb
@@ -24,7 +24,6 @@
 
     <div class="form-buttons filter-actions actions" data-hook="buttons">
       <%= button Spree.t('actions.save'), 'ok' %>
-      <span class="or"><%= Spree.t(:or) %></span>
       <%= button_link_to Spree.t('actions.cancel'), admin_order_payments_url(@refund.payment.order), icon: 'remove' %>
     </div>
   </fieldset>

--- a/backend/app/views/spree/admin/refunds/new.html.erb
+++ b/backend/app/views/spree/admin/refunds/new.html.erb
@@ -36,7 +36,6 @@
 
     <div class="form-buttons filter-actions actions" data-hook="buttons">
       <%= button Spree::Refund.model_name.human, 'ok' %>
-      <span class="or"><%= Spree.t(:or) %></span>
       <%= button_link_to Spree.t('actions.cancel'), admin_order_payments_url(@refund.payment.order), icon: 'remove' %>
     </div>
   </fieldset>

--- a/backend/app/views/spree/admin/reimbursements/edit.html.erb
+++ b/backend/app/views/spree/admin/reimbursements/edit.html.erb
@@ -101,7 +101,6 @@
       <%= button_to [:perform, :admin, @order, @reimbursement], {class: 'button fa fa-reply', method: 'post'} do %>
         <%= Spree.t(:reimburse) %>
       <% end %>
-      <span class="or"><%= Spree.t(:or) %></span>
       <%= button_link_to Spree.t('actions.cancel'), url_for([:admin, @order, @reimbursement.customer_return]), :icon => 'remove' %>
     <% end %>
   </div>

--- a/backend/app/views/spree/admin/return_authorizations/edit.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/edit.html.erb
@@ -23,7 +23,6 @@
 
     <div class="form-buttons filter-actions actions" data-hook="buttons">
       <%= button Spree.t('actions.update'), 'repeat' %>
-      <span class="or"><%= Spree.t(:or) %></span>
       <%= button_link_to Spree.t('actions.cancel'), admin_order_return_authorizations_url(@order), :icon => 'remove' %>
     </div>
   </fieldset>

--- a/backend/app/views/spree/admin/return_authorizations/new.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/new.html.erb
@@ -15,7 +15,6 @@
 
     <div class="form-buttons filter-actions actions" data-hook="buttons">
       <%= button Spree.t(:create), 'ok' %>
-      <span class="or"><%= Spree.t(:or) %></span>
       <%= button_link_to Spree.t('actions.cancel'), admin_order_return_authorizations_url(@order), :icon => 'remove' %>
     </div>
   </fieldset>

--- a/backend/app/views/spree/admin/shared/_edit_resource_links.html.erb
+++ b/backend/app/views/spree/admin/shared/_edit_resource_links.html.erb
@@ -1,5 +1,4 @@
 <div class="form-buttons filter-actions actions" data-hook="buttons">
   <%= button Spree.t('actions.update'), 'refresh' %>
-  <span class="or"><%= Spree.t(:or) %></span>
   <%= button_link_to Spree.t('actions.cancel'), collection_url, :icon => 'remove' %>
 </div>

--- a/backend/app/views/spree/admin/shared/_new_resource_links.html.erb
+++ b/backend/app/views/spree/admin/shared/_new_resource_links.html.erb
@@ -1,5 +1,4 @@
 <div class="form-buttons filter-actions actions" data-hook="buttons">
   <%= button Spree.t('actions.create'), 'ok' %>
-  <span class="or"><%= Spree.t(:or) %></span>
   <%= link_to_with_icon 'remove', Spree.t('actions.cancel'), collection_url, :class => 'button' %>
 </div>

--- a/backend/app/views/spree/admin/stock_locations/_transfer_stock_form.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/_transfer_stock_form.html.erb
@@ -32,7 +32,6 @@
 
     <div class="form-buttons filter-actions actions" data-hook="buttons">
       <%= button Spree.t(:transfer_stock), 'plus' %>
-      <span class="or"><%= Spree.t(:or) %></span>
       <%= link_to_with_icon 'remove', Spree.t('actions.cancel'), collection_url, :class => 'button' %>
     </div>
   </fieldset>

--- a/backend/app/views/spree/admin/stock_transfers/new.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/new.html.erb
@@ -22,7 +22,6 @@
     <% end %>
     <div class="filter-actions actions" data-hook="buttons">
       <%= button Spree.t(:continue), 'arrow-right' %>
-      <span class="or"><%= Spree.t(:or) %></span>
       <%= link_to_with_icon 'remove', Spree.t('actions.cancel'), admin_stock_transfers_path, class: 'button' %>
     </div>
   </fieldset>

--- a/backend/app/views/spree/admin/store_credits/edit_validity.html.erb
+++ b/backend/app/views/spree/admin/store_credits/edit_validity.html.erb
@@ -15,7 +15,6 @@
     </div>
     <div class="form-buttons filter-actions actions" data-hook="buttons">
       <%= button Spree.t('store_credit.actions.invalidate'), 'ban' %>
-      <span class="or"><%= Spree.t(:or) %></span>
       <%= button_link_to Spree.t('actions.cancel'), admin_user_store_credit_path(@user, @store_credit), icon: 'remove' %>
     </div>
   </fieldset>

--- a/backend/app/views/spree/admin/taxonomies/edit.erb
+++ b/backend/app/views/spree/admin/taxonomies/edit.erb
@@ -18,7 +18,6 @@
     <%= render :partial => 'form', :locals => { :f => f } %>
     <div class="filter-actions actions">
       <%= button Spree.t('actions.update'), 'refresh' %>
-      <span class="or"><%= Spree.t(:or) %></span>
       <%= button_link_to Spree.t('actions.cancel'), admin_taxonomies_path, :icon => 'remove' %>
     </div>
   </fieldset>

--- a/backend/app/views/spree/admin/taxons/edit.html.erb
+++ b/backend/app/views/spree/admin/taxons/edit.html.erb
@@ -13,7 +13,7 @@
 <%= form_for [:admin, @taxonomy, @taxon], :method => :put, :url => form_url, :html => { :multipart => true } do |f| %>
   <%= render 'form', :f => f %>
 
-  <div class="form-buttons" data-hook="buttons">
+  <div class="form-buttons filter-actions" data-hook="buttons">
     <%= button Spree.t('actions.update'), 'refresh' %>
     <%= Spree.t(:or) %>
     <%= button_link_to Spree.t('actions.cancel'), edit_admin_taxonomy_url(@taxonomy), :icon => "remove" %>

--- a/backend/app/views/spree/admin/taxons/edit.html.erb
+++ b/backend/app/views/spree/admin/taxons/edit.html.erb
@@ -15,7 +15,6 @@
 
   <div class="form-buttons filter-actions" data-hook="buttons">
     <%= button Spree.t('actions.update'), 'refresh' %>
-    <%= Spree.t(:or) %>
     <%= button_link_to Spree.t('actions.cancel'), edit_admin_taxonomy_url(@taxonomy), :icon => "remove" %>
   </div>
 <% end %>

--- a/backend/app/views/spree/admin/users/edit.html.erb
+++ b/backend/app/views/spree/admin/users/edit.html.erb
@@ -38,8 +38,6 @@
           <%= button Spree.t('clear_key', :scope => 'api'), 'trash' %>
         <% end %>
 
-        <span class="or"><%= Spree.t(:or)%></span>
-
         <%= form_tag spree.generate_api_key_admin_user_path(@user), :method => :put do %>
           <%= button Spree.t('regenerate_key', :scope => 'api'), 'refresh' %>
         <% end %>


### PR DESCRIPTION
In many places the admin control gives us an option to `update` or `cancel`.  The or is unnecessary, ugly, and implied.  It is better without it.  I don't believe @Mandily has this in an issue but it is at her request so UX approved.

# before

![before or](https://cloud.githubusercontent.com/assets/12613649/13580087/7c6998f6-e455-11e5-90fe-2656870f5b73.png)

# after

![after or](https://cloud.githubusercontent.com/assets/12613649/13580091/815160a6-e455-11e5-92e0-4d9fb86c5359.png)
