### PR TITLE
Update spree_adjustments.finalized to be non null

### DIFF
--- a/core/db/migrate/20160308000300_disallow_adjustment_finalized_nulls.rb
+++ b/core/db/migrate/20160308000300_disallow_adjustment_finalized_nulls.rb
@@ -1,0 +1,19 @@
+class DisallowAdjustmentFinalizedNulls < ActiveRecord::Migration
+  def up
+    execute <<-SQL
+      update spree_adjustments
+      set finalized = #{ActiveRecord::Base.connection.quoted_false}
+      where finalized is null
+    SQL
+
+    change_table :spree_adjustments do |t|
+      t.change :finalized, :boolean, null: false, default: false
+    end
+  end
+
+  def down
+    change_table :spree_adjustments do |t|
+      t.change :finalized, :boolean, null: true, default: nil
+    end
+  end
+end


### PR DESCRIPTION
When we migrated from state=open/closed to finalized=true/false in
https://github.com/solidusio/solidus/pull/279 we added `finalized` as a nullable column.  This breaks the
scopes that we added in that commit -- when finalized is null the
adjustments are neither `finalized` nor `not_finalized`.

I noticed this while trying to add some code and specs using the
`not_finalized` scope.

We could try to tweak the scopes but I think it'd be better to just
avoid the ternary logic altogether by disallowing nulls.

In the old code we had `state_machine :state, initial: :open` which
prevented this problem even though the `state` column itself was
nullable.