### PR TITLE
Rails 5 preparations

### DIFF
--- a/core/app/models/spree/carton.rb
+++ b/core/app/models/spree/carton.rb
@@ -4,8 +4,8 @@ class Spree::Carton < Spree::Base
   belongs_to :shipping_method, class_name: 'Spree::ShippingMethod', inverse_of: :cartons
 
   has_many :inventory_units, class_name: "Spree::InventoryUnit", inverse_of: :carton, dependent: :nullify
-  has_many :orders, -> { uniq }, through: :inventory_units
-  has_many :shipments, -> { uniq }, through: :inventory_units
+  has_many :orders, -> { distinct }, through: :inventory_units
+  has_many :shipments, -> { distinct }, through: :inventory_units
 
   validates :address, presence: true
   validates :stock_location, presence: true

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -69,7 +69,7 @@ module Spree
     has_many :order_promotions, class_name: 'Spree::OrderPromotion'
     has_many :promotions, through: :order_promotions
 
-    has_many :cartons, -> { uniq }, through: :inventory_units
+    has_many :cartons, -> { distinct }, through: :inventory_units
     has_many :shipments, dependent: :destroy, inverse_of: :order do
       def states
         pluck(:state).uniq

--- a/core/app/models/spree/order_contents.rb
+++ b/core/app/models/spree/order_contents.rb
@@ -83,8 +83,7 @@ module Spree
         line_item.quantity += quantity.to_i
         line_item.currency = currency unless currency.nil?
       else
-        opts = { currency: order.currency }.merge ActionController::Parameters.new(options).
-                                            permit(PermittedAttributes.line_item_attributes)
+        opts = { currency: order.currency }.merge ActionController::Parameters.new(options).permit(PermittedAttributes.line_item_attributes).to_h
         line_item = order.line_items.new(quantity: quantity,
                                           variant: variant,
                                           options: opts)

--- a/core/app/models/spree/order_shipping.rb
+++ b/core/app/models/spree/order_shipping.rb
@@ -64,7 +64,7 @@ class Spree::OrderShipping
       # TODO: Remove tracking numbers from shipments.
       shipment.update_attributes!(tracking: tracking_number)
 
-      next unless shipment.inventory_units(true).all? { |iu| iu.shipped? || iu.canceled? }
+      next unless shipment.inventory_units.reload.all? { |iu| iu.shipped? || iu.canceled? }
       # TODO: make OrderShipping#ship_shipment call Shipment#ship! rather than
       # having Shipment#ship! call OrderShipping#ship_shipment. We only really
       # need this `update_columns` for the specs, until we make that change.

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -199,10 +199,10 @@ module Spree
     # @return [Hash<Spree::OptionType, Array<Spree::OptionValue>>] all option types and option values
     # associated with the products variants grouped by option type
     def variant_option_values_by_option_type(variant_scope = nil)
-      option_value_ids = Spree::OptionValuesVariant.joins(:variant)
+      option_value_scope = Spree::OptionValuesVariant.joins(:variant)
         .where(spree_variants: { product_id: id })
-        .merge(variant_scope)
-        .distinct.pluck(:option_value_id)
+      option_value_scope = option_value_scope.merge(variant_scope) if variant_scope
+      option_value_ids = option_value_scope.distinct.pluck(:option_value_id)
       Spree::OptionValue.where(id: option_value_ids).
         includes(:option_type).
         order("#{Spree::OptionType.table_name}.position, #{Spree::OptionValue.table_name}.position").

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -40,7 +40,7 @@ module Spree
       where(table[:starts_at].eq(nil).or(table[:starts_at].lt(time))).
         where(table[:expires_at].eq(nil).or(table[:expires_at].gt(time)))
     end
-    scope :applied, -> { joins(:order_promotions).uniq }
+    scope :applied, -> { joins(:order_promotions).distinct }
 
     self.whitelisted_ransackable_associations = ['codes']
     self.whitelisted_ransackable_attributes = ['path', 'promotion_category_id']

--- a/core/app/models/spree/promotion/actions/create_quantity_adjustments.rb
+++ b/core/app/models/spree/promotion/actions/create_quantity_adjustments.rb
@@ -59,7 +59,7 @@ module Spree::Promotion::Actions
       order = line_item.order
       line_items = actionable_line_items(order)
 
-      actioned_line_items = order.line_item_adjustments(true).
+      actioned_line_items = order.line_item_adjustments.reload.
         select { |a| a.source == self && a.amount < 0 }.
         map(&:adjustable)
       other_line_items = actioned_line_items - [line_item]
@@ -80,7 +80,7 @@ module Spree::Promotion::Actions
     private
 
     def actionable_line_items(order)
-      order.line_items(true).select do |item|
+      order.line_items.reload.select do |item|
         promotion.line_item_actionable? order, item
       end
     end

--- a/core/app/models/spree/promotion/rules/taxon.rb
+++ b/core/app/models/spree/promotion/rules/taxon.rb
@@ -44,7 +44,7 @@ module Spree
 
         # All taxons in an order
         def order_taxons(order)
-          Spree::Taxon.joins(products: { variants_including_master: :line_items }).where(spree_line_items: { order_id: order.id }).uniq
+          Spree::Taxon.joins(products: { variants_including_master: :line_items }).where(spree_line_items: { order_id: order.id }).distinct
         end
 
         # ids of taxons rules and taxons rules children

--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -55,7 +55,7 @@ module Spree
       arel_condition =
         arel_table[:available_to_all].eq(true).or(smsl_table[:stock_location_id].eq(stock_location.id))
 
-      joins(arel_join).where(arel_condition).uniq
+      joins(arel_join).where(arel_condition).distinct
     end
 
     # @param address [Spree::Address] address to match against zones

--- a/core/app/models/spree/zone.rb
+++ b/core/app/models/spree/zone.rb
@@ -25,7 +25,7 @@ module Spree
       matching_country =
         spree_zone_members_table[:zoneable_type].eq("Spree::Country").
         and(spree_zone_members_table[:zoneable_id].in(country_ids))
-      joins(:zone_members).where(matching_state.or(matching_country)).uniq
+      joins(:zone_members).where(matching_state.or(matching_country)).distinct
     end
 
     scope :for_address, ->(address) do
@@ -74,7 +74,7 @@ module Spree
       state_country_ids = states_and_state_country_ids.map(&:second)
       country_ids = zone.countries.pluck(:id).to_a
 
-      with_member_ids(state_ids, country_ids + state_country_ids).uniq
+      with_member_ids(state_ids, country_ids + state_country_ids).distinct
     end
 
     def kind

--- a/core/db/migrate/20130213191427_create_default_stock.rb
+++ b/core/db/migrate/20130213191427_create_default_stock.rb
@@ -1,34 +1,25 @@
 class CreateDefaultStock < ActiveRecord::Migration
+  class Variant < ActiveRecord::Base
+    self.table_name = 'spree_variants'
+  end
+  class StockLocation < ActiveRecord::Base
+    self.table_name = 'spree_stock_locations'
+  end
+  class StockItem < ActiveRecord::Base
+    self.table_name = 'spree_stock_items'
+  end
+
   def up
     unless column_exists? :spree_stock_locations, :default
       add_column :spree_stock_locations, :default, :boolean, null: false, default: false
     end
 
-    Spree::StockLocation.skip_callback(:create, :after, :create_stock_items)
-    Spree::StockLocation.skip_callback(:save, :after, :ensure_one_default)
-    Spree::StockItem.skip_callback(:save, :after, :process_backorders)
-    location = Spree::StockLocation.new(name: 'default')
-    location.save(validate: false)
+    location = StockLocation.create!(name: 'default')
 
     Spree::Variant.find_each do |variant|
-      stock_item = Spree::StockItem.unscoped.build(stock_location: location, variant: variant)
-      stock_item.send(:count_on_hand=, variant.count_on_hand)
-      # Avoid running default_scope defined by acts_as_paranoid, related to https://github.com/spree/spree/issues/3805,
-      # validations would run a query with a delete_at column that might not be present yet
-      stock_item.save! validate: false
+      StockItem.create!(stock_location: location, variant: variant, count_on_hand: variant.count_on_hand)
     end
 
     remove_column :spree_variants, :count_on_hand
-  end
-
-  def down
-    add_column :spree_variants, :count_on_hand, :integer
-
-    Spree::StockItem.find_each do |stock_item|
-      stock_item.variant.update_column :count_on_hand, stock_item.count_on_hand
-    end
-
-    Spree::StockLocation.delete_all
-    Spree::StockItem.delete_all
   end
 end

--- a/core/lib/tasks/exchanges.rake
+++ b/core/lib/tasks/exchanges.rake
@@ -2,10 +2,10 @@ namespace :exchanges do
   desc 'Takes unreturned exchanged items and creates a new order to charge
   the customer for not returning them'
   task charge_unreturned_items: :environment do
-    unreturned_return_items = Spree::ReturnItem.expecting_return.exchange_processed.includes(:exchange_inventory_unit).where([
+    unreturned_return_items = Spree::ReturnItem.expecting_return.exchange_processed.joins(:exchange_inventory_unit).where([
       "spree_inventory_units.created_at < :days_ago AND spree_inventory_units.state = :iu_state",
       days_ago: Spree::Config[:expedited_exchanges_days_window].days.ago, iu_state: "shipped"
-    ]).references(:exchange_inventory_units).to_a
+    ]).preload(:exchange_inventory_unit).to_a
 
     # Determine that a return item has already been deemed unreturned and therefore charged
     # by the fact that its exchange inventory unit has popped off to a different order

--- a/core/spec/lib/spree/core/importer/order_spec.rb
+++ b/core/spec/lib/spree/core/importer/order_spec.rb
@@ -23,7 +23,7 @@ module Spree
 
       let(:variant) {
         variant = product.master
-        variant.stock_items.each { |si| si.update_attribute(:count_on_hand, 10) }
+        variant.stock_items.each { |si| si.set_count_on_hand(10) }
         variant
       }
 

--- a/core/spec/models/spree/preferences/preferable_spec.rb
+++ b/core/spec/models/spree/preferences/preferable_spec.rb
@@ -195,12 +195,6 @@ describe Spree::Preferences::Preferable, type: :model do
         @a.set_preference(:is_hash, { 1 => 2, 3 => 4 })
         expect(@a.preferences[:is_hash]).to eql({ 1 => 2, 3 => 4 })
       end
-
-      it "with ancestor of a hash" do
-        ancestor_of_hash = ActionController::Parameters.new({ key: :value })
-        @a.set_preference(:is_hash, ancestor_of_hash)
-        expect(@a.preferences[:is_hash]).to eql({ "key" => :value })
-      end
     end
 
     context "converts any preferences to any values" do

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -514,7 +514,7 @@ describe Spree::Product, type: :model do
     it 'should return sum of stock items count_on_hand' do
       product = create(:product)
       product.stock_items.first.set_count_on_hand 5
-      product.variants_including_master(true) # force load association
+      product.variants_including_master.reload # force load association
       expect(product.total_on_hand).to eql(5)
     end
 

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -197,7 +197,7 @@ describe Spree::Shipment, type: :model do
       end
 
       it "can't get rates without a shipping address" do
-        shipment.order(ship_address: nil)
+        shipment.order.update_attributes!(ship_address: nil)
         expect(shipment.refresh_rates).to eq([])
       end
 


### PR DESCRIPTION
These are some backports from the rails 5 branch. I believe they improve code quality so we might as well get them in and reduce the number of changes we'll eventually need.

* Use `AR::Relation#distinct` instead of `#uniq`, which is deprecated in rails 5
* Use `association.reload` instead of `association(true)`, which is deprecated in rails 5
* Remove once instance of `merge(nil)`
* Some fixes related to `ActionController::Parameters`, which are no longer a subclass of `Hash` in rails 5