### PR TITLE
Move the strange refunding logic from Spree::TaxRate into the default tax calculator

### DIFF
--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -104,19 +104,10 @@ module Spree
 
     # This method is used by Adjustment#update to recalculate the cost.
     def compute_amount(item)
-      if included_in_price && !default_zone_or_zone_match?(item.order.tax_zone)
-        # In this case, it's a refund.
-        calculator.compute(item) * - 1
-      else
-        calculator.compute(item)
-      end
+      calculator.compute(item)
     end
 
     private
-
-    def default_zone_or_zone_match?(order_tax_zone)
-      Zone.default_tax.try!(:contains?, order_tax_zone) || zone.contains?(order_tax_zone)
-    end
 
     def adjustment_label(amount)
       Spree.t translation_key(amount),


### PR DESCRIPTION
When reviewing #904, we realized that we can not change the logic of
Spree::TaxRate#compute_amount if we want the migration included there to
always to the right thing. Because that method modifies the tax amount of things,
it should actually be in a calculator. I now moved that logic to the default tax
calculator, with the intention of deprecating use of that calculator entirely.

There is code for pre-Spree-2.2 order-based taxation in there, as well as code for
generating tax refunds, which in the future we won't need either.