### PR TITLE
Simplify Default Tax Calculator

### DIFF
--- a/core/app/models/spree/calculator/default_tax.rb
+++ b/core/app/models/spree/calculator/default_tax.rb
@@ -25,7 +25,7 @@ module Spree
     end
 
     # When it comes to computing shipments or line items: same same.
-    def compute_shipment_or_line_item(item)
+    def compute_item(item)
       if rate.included_in_price
         deduced_total_by_rate(item, rate)
       else
@@ -33,17 +33,9 @@ module Spree
       end
     end
 
-    alias_method :compute_shipment, :compute_shipment_or_line_item
-    alias_method :compute_line_item, :compute_shipment_or_line_item
-
-    def compute_shipping_rate(shipping_rate)
-      if rate.included_in_price
-        deduced_total_by_rate(shipping_rate, rate)
-      else
-        with_tax_amount = shipping_rate.cost * rate.amount
-        round_to_two_places(with_tax_amount)
-      end
-    end
+    alias_method :compute_shipment, :compute_item
+    alias_method :compute_line_item, :compute_item
+    alias_method :compute_shipping_rate, :compute_item
 
     private
 


### PR DESCRIPTION
The logic for taxing line items, shipments and shipping rates is
already exactly the same. There's no need to maintain two methods
when one is enough.