### PR TITLE
Simplify payment row amount edit JS

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/payments/edit.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/payments/edit.js.coffee
@@ -125,10 +125,6 @@ jQuery ($) ->
       $('<input />')
         .prop(id: 'amount', value: amount)
         .width(width)
-        .one
-          blur: =>
-            clicked = (@$buttons().filter -> $(@).data('clicked')).length
-            @save() unless clicked
         .css('text-align': 'right')
 
     $input: ->

--- a/backend/app/assets/javascripts/spree/backend/payments/edit.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/payments/edit.js.coffee
@@ -1,141 +1,34 @@
-jQuery ($) ->
-  # Payment model
+PaymentRowView = Backbone.View.extend
+  events:
+    "click .js-edit": "onEdit"
+    "click .js-save": "onSave"
+    "click .js-cancel": "onCancel"
+    "click .js-display-amount": "onEdit"
+
+  onEdit: (e) ->
+    e.preventDefault()
+    @$el.addClass("editing")
+
+  onCancel: (e) ->
+    e.preventDefault()
+    @$el.removeClass("editing")
+
+  onSave: (e) ->
+    e.preventDefault()
+    amount = @$(".js-edit-amount").val()
+    options =
+      success: (model, response, options) =>
+        @$(".js-display-amount").text(model.attributes.display_amount)
+        @$el.removeClass("editing")
+      error: (model, response, options) =>
+        show_flash 'error', response.responseJSON.error
+    @model.save({ amount: amount }, options)
+
+$ ->
   order_id = $('#payments').data('order-id')
-  class Payment
-    constructor: (id) ->
-      @url  = "#{Spree.routes.payments_api(order_id)}/#{id}.json"
-      @json = Spree.getJSON @url, (data) =>
-        @data = data
+  Payment = Backbone.Model.extend
+    urlRoot: Spree.routes.payments_api(order_id)
 
-    if_pending: (callback) ->
-      @json.done (data) ->
-        callback() if data.state is 'pending'
-
-    update: (attributes, success) ->
-      jqXHR = Spree.ajax
-        type: 'PUT'
-        url:  @url
-        data: { payment: attributes }
-      jqXHR.done (data) =>
-        @data = data
-      jqXHR.fail ->
-        response = $.parseJSON(jqXHR.responseText)
-        show_flash('error', response.error)
-
-    amount:         -> @data.amount
-    display_amount: -> @data.display_amount
-
-  # Payment base view
-  class PaymentView
-    constructor: (@$el, @payment) ->
-      @render()
-
-    render: ->
-      @add_action_button()
-
-    show: ->
-      @remove_buttons()
-      new ShowPaymentView(@$el, @payment)
-
-    edit: ->
-      @remove_buttons()
-      new EditPaymentView(@$el, @payment)
-
-    add_action_button: ->
-      @$actions().prepend @$new_button(@action)
-
-    remove_buttons: ->
-      @$buttons().remove()
-
-    $new_button: (action) ->
-      $('<a />')
-        .attr
-          class: "fa fa-#{action} icon_link no-text with-tip"
-          title: Spree.translations[action]
-        .data
-          action: action
-        .one
-          click: (event) ->
-            event.preventDefault()
-          mousedown: ->
-            $(@).data('clicked', true)
-          mouseup: =>
-            @[action]()
-
-    $buttons: ->
-      @$actions().find(".fa-#{@action}, .fa-cancel")
-
-    $actions: ->
-      @$el.find('.actions')
-
-    $amount: ->
-      @$el.find('td.amount')
-
-  # Payment show view
-  class ShowPaymentView extends PaymentView
-    action: 'edit'
-
-    render: ->
-      super
-      @set_actions_display()
-      @show_actions()
-      @show_amount()
-
-    set_actions_display: ->
-      width = @$actions().width()
-      @$actions().width(width).css('text-align', 'left')
-
-    show_actions: ->
-      @$actions().find('a').show()
-
-    show_amount: ->
-      amount = $('<span />')
-        .html(@payment.display_amount())
-        .one('click', => @edit().$input().focus())
-      @$amount().html(amount)
-
-  # Payment edit view
-  class EditPaymentView extends PaymentView
-    action: 'save'
-
-    render: ->
-      super
-      @hide_actions()
-      @edit_amount()
-      @add_cancel_button()
-
-    add_cancel_button: ->
-      @$actions().append @$new_button('cancel')
-
-    hide_actions: ->
-      @$actions().find('a').not(@$buttons()).hide()
-
-    edit_amount: ->
-      amount = @$amount()
-      amount.html(@$new_input(amount.find('span').width()))
-
-    save: (event) ->
-      @payment.update(amount: @$input().val())
-        .done(=> @show())
-
-    cancel: @::show
-
-    $new_input: (width) ->
-      amount = @constructor.normalize_amount(@payment.display_amount())
-      $('<input />')
-        .prop(id: 'amount', value: amount)
-        .width(width)
-        .css('text-align': 'right')
-
-    $input: ->
-      @$amount().find('input')
-
-    @normalize_amount: (amount) ->
-      separator = Spree.translations.currency_separator
-      amount.replace(///[^\d#{separator}]///g, '')
-
-  # Attach ShowPaymentView to each pending payment in the table
-  $('.admin tr[data-hook=payments_row]').each ->
-    $el = $(@)
-    payment = new Payment($el.prop('id').match(/\d+$/))
-    payment.if_pending -> new ShowPaymentView($el, payment)
+  $('tr.payment').each ->
+    model = new Payment({id: $(@).data('payment-id')})
+    new PaymentRowView({el: @, model: model})

--- a/backend/app/assets/stylesheets/spree/backend/sections/_payments.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/_payments.scss
@@ -1,0 +1,14 @@
+/* hide and show elements based on editing */
+tr.payment {
+  .edit-payment-amount {
+    text-align: right;
+  }
+
+  &:not(.editing) .editing-show {
+    display: none;
+  }
+
+  &.editing .editing-hide {
+    display: none;
+  }
+}

--- a/backend/app/assets/stylesheets/spree/backend/spree_admin.scss
+++ b/backend/app/assets/stylesheets/spree/backend/spree_admin.scss
@@ -50,3 +50,4 @@
 @import 'spree/backend/sections/transfer_items';
 @import 'spree/backend/sections/stock_transfers';
 @import 'spree/backend/sections/style_guide';
+@import 'spree/backend/sections/payments';

--- a/backend/app/views/spree/admin/payments/_list.html.erb
+++ b/backend/app/views/spree/admin/payments/_list.html.erb
@@ -12,24 +12,36 @@
   </thead>
   <tbody>
     <% payments.each do |payment| %>
-      <tr id="<%= dom_id(payment) %>" data-hook="payments_row" class="<%= cycle('odd', 'even', name: 'payment_table_cycle')%>">
+      <tr id="<%= dom_id(payment) %>" data-hook="payments_row" class="payment <%= cycle('odd', 'even', name: 'payment_table_cycle')%>" data-payment-id="<%= payment.id %>">
         <td><%= link_to payment.number, spree.admin_order_payment_path(@order, payment) %></td>
         <td><%= pretty_time(payment.created_at) %></td>
-        <td class="align-center amount"><%= payment.display_amount.to_html %></td>
+        <td class="align-center amount">
+          <%= text_field_tag :amount, payment.amount, class: 'js-edit-amount edit-payment-amount editing-show' %>
+          <span class="js-display-amount editing-hide"><%= payment.display_amount.to_html %></span>
+        </td>
         <td class="align-center"><%= payment_method_name(payment) %></td>
         <td class="align-center"><%= payment.transaction_id %></td>
         <td class="align-center"> <span class="state <%= payment.state %>"><%= Spree.t(payment.state, :scope => :payment_states, :default => payment.state.capitalize) %></span></td>
         <td class="actions">
-          <% allowed_actions = payment.actions.select { |a| can?(a.to_sym, payment) } %>
-          <% allowed_actions.each do |action| %>
-            <% if action == 'credit' %>
-              <%= link_to_with_icon 'reply', Spree.t(:refund), new_admin_order_payment_refund_path(@order, payment), no_text: true %>
-            <% elsif action == 'capture' && !@order.completed? %>
-              <%# no capture prior to completion. payments get captured when the order completes. %>
-            <% else %>
-              <%= link_to_with_icon action, Spree.t(action), fire_admin_order_payment_path(@order, payment, :e => action), :method => :put, :no_text => true, :data => {:action => action} %>
+          <div class="editing-show">
+            <%= link_to_with_icon 'save', Spree.t('actions.save'), nil, no_text: true, class: "js-save", data: {action: 'save'} %>
+            <%= link_to_with_icon 'cancel', Spree.t('actions.cancel'), nil, no_text: true, class: "js-cancel", data: {action: 'cancel'} %>
+          </div>
+          <div class="editing-hide">
+            <% if payment.pending? %>
+              <%= link_to_with_icon 'edit', Spree.t('actions.edit'), nil, no_text: true, class: "js-edit", data: {action: 'edit'} %>
             <% end %>
-          <% end %>
+            <% allowed_actions = payment.actions.select { |a| can?(a.to_sym, payment) } %>
+            <% allowed_actions.each do |action| %>
+              <% if action == 'credit' %>
+                <%= link_to_with_icon 'reply', Spree.t(:refund), new_admin_order_payment_refund_path(@order, payment), no_text: true %>
+              <% elsif action == 'capture' && !@order.completed? %>
+                <%# no capture prior to completion. payments get captured when the order completes. %>
+              <% else %>
+                <%= link_to_with_icon action, Spree.t(action), fire_admin_order_payment_path(@order, payment, :e => action), :method => :put, :no_text => true, :data => {:action => action} %>
+              <% end %>
+            <% end %>
+          </div>
         </td>
       </tr>
     <% end %>

--- a/backend/spec/features/admin/orders/payments_spec.rb
+++ b/backend/spec/features/admin/orders/payments_spec.rb
@@ -116,6 +116,7 @@ describe 'Payments', type: :feature do
         within_row(1) do
           click_icon(:edit)
           fill_in('amount', with: '$1')
+          click_icon(:save)
           expect(page).to have_selector('td.amount span', text: '$1.00')
           expect(payment.reload.amount).to eq(1.00)
         end
@@ -125,6 +126,7 @@ describe 'Payments', type: :feature do
         within_row(1) do
           find('td.amount span').click
           fill_in('amount', with: '$1.01')
+          click_icon(:save)
           expect(page).to have_selector('td.amount span', text: '$1.01')
           expect(payment.reload.amount).to eq(1.01)
         end
@@ -149,6 +151,7 @@ describe 'Payments', type: :feature do
         within_row(1) do
           click_icon(:edit)
           fill_in('amount', with: 'invalid')
+          click_icon(:save)
         end
         expect(page).to have_selector('.flash.error', text: 'Invalid resource. Please fix errors and try again.')
         expect(page).to have_field('amount', with: 'invalid')

--- a/backend/spec/features/admin/orders/payments_spec.rb
+++ b/backend/spec/features/admin/orders/payments_spec.rb
@@ -13,20 +13,11 @@ describe 'Payments', type: :feature do
       )
     end
 
-    let(:order) { create(:completed_order_with_totals, number: 'R100', line_items_count: 5) }
+    let(:order) { create(:completed_order_with_totals, number: 'R100', line_items_price: 50) }
     let(:state) { 'checkout' }
 
     before do
-      visit spree.admin_path
-      click_link 'Orders'
-      within_row(1) do
-        click_link order.number
-      end
-      click_link 'Payments'
-    end
-
-    def refresh_page
-      visit current_path
+      visit "/admin/orders/#{order.number}/payments"
     end
 
     # Regression tests for https://github.com/spree/spree/issues/1453

--- a/backend/spec/features/admin/orders/payments_spec.rb
+++ b/backend/spec/features/admin/orders/payments_spec.rb
@@ -165,7 +165,6 @@ describe 'Payments', type: :feature do
       it 'does not allow the amount to be edited' do
         within_row(1) do
           expect(page).not_to have_selector('.fa-edit')
-          expect(page).not_to have_selector('td.amount span')
         end
       end
     end


### PR DESCRIPTION
Refactor to the inline edit feature on the payments page.

![](http://i.hawth.ca/s/d1IAy4QD.png)

This started as a want to remove the JS being tied to the icon of the action buttons (`@$actions().find(".fa-#{@action}, .fa-cancel")`), but the existing JS was very opaque and using 145 lines for a simple inline edit seemed excessive.

This removes an automatic save whenever the amount input was unfocused, which I believe is bad UI. It's not clear that the user intends to save, they may intend to cancel, or even copy an amount from a previous payment. I ran this by @Mandily who agreed.

This replaces 145 lines of coffeescript soup with 34 well structured lines.
* All HTML is now declared in the view
* The edit button is visible on page load (previously it only showed up
  after an ajax request). This might solve some spurious CI failures on
  this page.
* No ajax requests on page load (previously one per payment).
* JS doesn't tie behaviour to the icon shown on the button.

Thanks to @Sinetheta who's recommendation of the `editing` class set most of this in motion.