### PR TITLE
Better selected page detection for admin menu.

### DIFF
--- a/backend/app/helpers/spree/admin/navigation_helper.rb
+++ b/backend/app/helpers/spree/admin/navigation_helper.rb
@@ -31,7 +31,8 @@ module Spree
         elsif options[:match_path]
           request.fullpath.starts_with?("#{admin_path}#{options[:match_path]}")
         else
-          args.include?(controller.controller_name.to_sym)
+          request.fullpath.starts_with?(destination_url) ||
+            args.include?(controller.controller_name.to_sym)
         end
         css_classes << 'selected' if selected
 

--- a/backend/spec/helpers/admin/navigation_helper_spec.rb
+++ b/backend/spec/helpers/admin/navigation_helper_spec.rb
@@ -23,6 +23,16 @@ describe Spree::Admin::NavigationHelper, type: :helper do
           allow(controller).to receive(:controller_name).and_return("bonobos")
           expect(subject).not_to include('class="selected"')
         end
+
+        it "should be selected if the current path" do
+          allow(helper).to receive(:request).and_return(double(ActionDispatch::Request, fullpath: "/admin/orders"))
+          expect(subject).to include('class="selected"')
+        end
+
+        it "should not be selected if not current path" do
+          allow(helper).to receive(:request).and_return(double(ActionDispatch::Request, fullpath: "/admin/products"))
+          expect(subject).not_to include('class="selected"')
+        end
       end
 
       context "when match_path option is supplied" do


### PR DESCRIPTION
Previously if you used a custom URL you had to do something like this:

    <%= tab :leads, match_path: 'batch_communications/leads',
      url: main_app.admin_batch_communications_leads_path if can? :admin, Lead %>

Basically we are specifying the path twice. Once to indicate where we should link to and once to indicate if the we are at that path. Generally if we link to the path then we should also match that path. This patch allows the above to work without the `match_path` option.

If you specify a `match_path` that will take priority. This just provides a nice default to reduce the amount of boilerplate code.