### PR TITLE
Admin menu configuration partial to be usable outside of Solidus engine

### DIFF
--- a/backend/app/views/spree/admin/shared/_areas_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_areas_tabs.html.erb
@@ -2,16 +2,16 @@
   <nav>
     <ul class="tabs" data-hook="admin_settings_areas_tabs">
       <% if can? :display, Spree::Zone %>
-        <%= settings_tab_item Spree::Zone.model_name.human(count: :other), admin_zones_path %>
+        <%= settings_tab_item Spree::Zone.model_name.human(count: :other), spree.admin_zones_path %>
       <% end %>
 
       <% if can? :display, Spree::Country %>
-        <%= settings_tab_item Spree::Country.model_name.human(count: :other), admin_countries_path %>
+        <%= settings_tab_item Spree::Country.model_name.human(count: :other), spree.admin_countries_path %>
       <% end %>
 
       <% if can?(:display, Spree::State) %>
         <% if country = Spree::Country.find_by(iso: Spree::Config[:default_country_iso]) || Spree::Country.first %>
-          <%= settings_tab_item Spree::State.model_name.human(count: :other), admin_country_states_path(country) %>
+          <%= settings_tab_item Spree::State.model_name.human(count: :other), spree.admin_country_states_path(country) %>
         <% end %>
       <% end %>
     </ul>

--- a/backend/app/views/spree/admin/shared/_configuration_menu.html.erb
+++ b/backend/app/views/spree/admin/shared/_configuration_menu.html.erb
@@ -5,11 +5,11 @@
   <nav>
     <ul class="tabs" data-hook="admin_configurations_sidebar_menu">
       <% if can?(:edit, :general_settings) %>
-        <%= settings_tab_item Spree.t(:general_settings), edit_admin_general_settings_path %>
+        <%= settings_tab_item Spree.t(:general_settings), spree.edit_admin_general_settings_path %>
       <% end %>
 
       <% if can?(:display, Spree::Tracker) %>
-        <%= settings_tab_item Spree.t(:analytics_trackers), admin_trackers_path %>
+        <%= settings_tab_item Spree.t(:analytics_trackers), spree.admin_trackers_path %>
       <% end %>
     </ul>
   </nav>

--- a/backend/app/views/spree/admin/shared/_payments_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_payments_tabs.html.erb
@@ -2,7 +2,7 @@
   <nav>
     <ul class="tabs" data-hook="admin_settings_payments_tabs">
       <% if can?(:display, Spree::PaymentMethod) %>
-        <%= settings_tab_item Spree::PaymentMethod.model_name.human(count: :other), admin_payment_methods_path %>
+        <%= settings_tab_item Spree::PaymentMethod.model_name.human(count: :other), spree.admin_payment_methods_path %>
       <% end %>
     </ul>
   </nav>

--- a/backend/app/views/spree/admin/shared/_settings_checkout_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_settings_checkout_tabs.html.erb
@@ -2,19 +2,19 @@
   <nav>
     <ul class="tabs" data-hook="admin_settings_checkout_tabs">
       <% if can?(:display, Spree::RefundReason) %>
-        <%= settings_tab_item Spree::RefundReason.model_name.human(count: :other), admin_refund_reasons_path %>
+        <%= settings_tab_item Spree::RefundReason.model_name.human(count: :other), spree.admin_refund_reasons_path %>
       <% end %>
 
       <% if can?(:display, Spree::ReimbursementType) %>
-        <%= settings_tab_item Spree::ReimbursementType.model_name.human(count: :other), admin_reimbursement_types_path %>
+        <%= settings_tab_item Spree::ReimbursementType.model_name.human(count: :other), spree.admin_reimbursement_types_path %>
       <% end %>
 
       <% if can?(:display, Spree::ReturnReason) %>
-        <%= settings_tab_item Spree::ReturnReason.model_name.human(count: :other), admin_return_reasons_path %>
+        <%= settings_tab_item Spree::ReturnReason.model_name.human(count: :other), spree.admin_return_reasons_path %>
       <% end %>
 
       <% if can?(:display, Spree::AdjustmentReason) %>
-        <%= settings_tab_item Spree::AdjustmentReason.model_name.human(count: :other), admin_adjustment_reasons_path %>
+        <%= settings_tab_item Spree::AdjustmentReason.model_name.human(count: :other), spree.admin_adjustment_reasons_path %>
       <% end %>
     </ul>
   </nav>

--- a/backend/app/views/spree/admin/shared/_settings_sub_menu.html.erb
+++ b/backend/app/views/spree/admin/shared/_settings_sub_menu.html.erb
@@ -4,23 +4,23 @@
   <% end %>
 
   <% if can?(:display, Spree::PaymentMethod) %>
-    <%= tab :payments, url: admin_payment_methods_path %>
+    <%= tab :payments, url: spree.admin_payment_methods_path %>
   <% end %>
 
   <% if can?(:display, Spree::Zone) || can?(:display, Spree::Country) || can?(:display, Spree::State) %>
-    <%= tab :areas, url: admin_zones_path %>
+    <%= tab :areas, url: spree.admin_zones_path %>
   <% end %>
 
   <% if can?(:display, Spree::TaxCategory) || can?(:display, Spree::TaxRate) %>
-    <%= tab :taxes, url: admin_tax_categories_path %>
+    <%= tab :taxes, url: spree.admin_tax_categories_path %>
   <% end %>
 
   <% if can?(:display, Spree::RefundReason) || can?(:display, Spree::ReimbursementType) ||
      can?(:display, Spree::ReturnReason) || can?(:display, Spree::AdjustmentReason) %>
-    <%= tab :checkout, url: admin_refund_reasons_path %>
+    <%= tab :checkout, url: spree.admin_refund_reasons_path %>
   <% end %>
 
   <% if can?(:display, Spree::ShippingMethod) || can?(:display, Spree::ShippingCategory) || can?(:display, Spree::StockLocation) %>
-    <%= tab :shipping, url: admin_shipping_methods_path, match_path: %r(shipping_methods|shipping_categories|stock_locations) %>
+    <%= tab :shipping, url: spree.admin_shipping_methods_path, match_path: %r(shipping_methods|shipping_categories|stock_locations) %>
   <% end %>
 </ul>

--- a/backend/app/views/spree/admin/shared/_shipping_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_shipping_tabs.html.erb
@@ -2,11 +2,11 @@
   <nav>
     <ul class="tabs" data-hook="admin_settings_shipping_tabs">
       <% if can?(:display, Spree::ShippingMethod) %>
-        <%= settings_tab_item Spree::ShippingMethod.model_name.human(count: :other), admin_shipping_methods_path %>
+        <%= settings_tab_item Spree::ShippingMethod.model_name.human(count: :other), spree.admin_shipping_methods_path %>
       <% end %>
 
       <% if can?(:display, Spree::ShippingCategory) %>
-        <%= settings_tab_item Spree::ShippingCategory.model_name.human(count: :other), admin_shipping_categories_path %>
+        <%= settings_tab_item Spree::ShippingCategory.model_name.human(count: :other), spree.admin_shipping_categories_path %>
       <% end %>
 
       <% if can?(:display, Spree::StockLocation) %>

--- a/backend/app/views/spree/admin/shared/_taxes_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_taxes_tabs.html.erb
@@ -2,11 +2,11 @@
   <nav>
     <ul class="tabs" data-hook="admin_settings_taxes_tabs">
       <% if can? :display, Spree::TaxCategory %>
-        <%= settings_tab_item Spree::TaxCategory.model_name.human(count: :other), admin_tax_categories_path %>
+        <%= settings_tab_item Spree::TaxCategory.model_name.human(count: :other), spree.admin_tax_categories_path %>
       <% end %>
 
       <% if can? :display, Spree::TaxRate %>
-        <%= settings_tab_item Spree::TaxRate.model_name.human(count: :other), admin_tax_rates_path %>
+        <%= settings_tab_item Spree::TaxRate.model_name.human(count: :other), spree.admin_tax_rates_path %>
       <% end %>
     </ul>
   </nav>


### PR DESCRIPTION
A continuation of the work done on PR #964. Refer there for rational and discussion.
I also see application configuration as a common extension point and requiring everything
to be in the `spree` engine defeats the purpose of namespaces so making it usable
to other engines.