### PR TITLE
Make use of Backbone in shipments edit page

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/line_items_on_order_edit.js
+++ b/backend/app/assets/javascripts/spree/backend/line_items_on_order_edit.js
@@ -9,6 +9,8 @@ $(document).ready(function () {
         var variant = _.find(window.variants, function(variant){
             return variant.id == variant_id
         })
+
+        var variantLineItemTemplate = HandlebarsTemplates["variants/line_items_autocomplete_stock"];
         $('#stock_details').html(variantLineItemTemplate({variant: variant}));
         $('#stock_details').show();
 

--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -271,6 +271,14 @@ var ShipmentEditView = Backbone.View.extend({
 
   cancelItemSplit: function(e){
     e.preventDefault();
+
+    /* We are removing this row including the currently hovered button, which
+     * gives no opportunity for events to fire.
+     * We must trigger them manually to ensure the tooltip is destroyed and the
+     * table colours are restored.
+     */
+    $(e.target).mouseleave().tooltip("hide");
+
     this.$('tr.stock-item-split').remove();
     this.$('a.split-item').show();
     this.$('a.delete-item').show();

--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -17,15 +17,28 @@ $(document).ready(function () {
       }
     });
   });
+});
 
-  // add header to ship ujs ajax call
-  $("form#admin-ship-shipment").on("ajax:beforeSend", function(event, xhr, settings) {
-    xhr.setRequestHeader("X-Spree-Token", Spree.api_key);
-  });
-
-  $("form#admin-ship-shipment").on("ajax:success", function(event, xhr, settings) {
-    window.location.reload();
-  });
+var ShipShipmentView = Backbone.View.extend({
+  initialize: function(options){
+    this.shipment_number = options.shipment_number;
+  },
+  events: {
+    "submit": "onSubmit"
+  },
+  onSubmit: function(e){
+    Spree.ajax({
+      type: "PUT",
+      url: Spree.routes.shipments_api + "/" + this.shipment_number + "/ship",
+      data: {
+        send_mailer: this.$("[name='send_mailer']").val()
+      },
+      success: function(){
+        window.location.reload()
+      }
+    });
+    return false;
+  }
 });
 
 updateShipment = function(shipment_number, attributes) {
@@ -202,8 +215,16 @@ addVariantFromStockLocation = function(event) {
 var ShipmentEditView = Backbone.View.extend({
   initialize: function(){
     var tbody = this.$("tbody[data-order-number][data-shipment-number]");
-    this.shipment_number = tbody.data("shipment-number");
+    var shipment_number = tbody.data("shipment-number");
+    this.shipment_number = shipment_number;
     this.order_number = tbody.data("order-number");
+
+    this.$("form.admin-ship-shipment").each(function(){
+      new ShipShipmentView({
+        el: this,
+        shipment_number: shipment_number
+      });
+    });
   },
 
   events: {
@@ -291,6 +312,6 @@ var ShipmentEditView = Backbone.View.extend({
 
 $(function(){
   $(".js-shipment-edit").each(function(){
-    new ShipmentEditView({ el: $(this) });
+    new ShipmentEditView({ el: this });
   });
 });

--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -15,9 +15,6 @@ $(document).ready(function () {
     $('button.add_variant').click(addVariantFromStockLocation);
   });
 
-  //handle edit click
-  $('a.edit-item').click(toggleItemEdit);
-
   //handle cancel click
   $('a.cancel-item').click(toggleItemEdit);
 
@@ -186,7 +183,6 @@ toggleMethodEdit = function(){
 
 toggleItemEdit = function(){
   var link = $(this);
-  link.parent().find('a.edit-item').toggle();
   link.parent().find('a.cancel-item').toggle();
   link.parent().find('a.split-item').toggle();
   link.parent().find('a.save-item').toggle();
@@ -200,7 +196,6 @@ toggleItemEdit = function(){
 startItemSplit = function(event){
   event.preventDefault();
   var link = $(this);
-  link.parent().find('a.edit-item').toggle();
   link.parent().find('a.split-item').toggle();
   link.parent().find('a.delete-item').toggle();
   var variant_id = link.data('variant-id');
@@ -297,7 +292,6 @@ cancelItemSplit = function(event) {
   var link = $(this);
   var prev_row = link.closest('tr').prev();
   link.closest('tr').remove();
-  prev_row.find('a.edit-item').toggle();
   prev_row.find('a.split-item').toggle();
   prev_row.find('a.delete-item').toggle();
 }

--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -38,20 +38,20 @@ updateShipment = function(shipment_number, attributes) {
       shipment: attributes
     }
   });
-}
+};
 
 adjustShipmentItems = function(shipment_number, variant_id, quantity){
-  var shipment = _.findWhere(shipments, {number: shipment_number + ''});
+  var shipment = _.findWhere(shipments, {number: shipment_number});
   var inventory_units = _.where(shipment.inventory_units, {variant_id: variant_id});
 
   var url = Spree.routes.shipments_api + "/" + shipment_number;
 
   var new_quantity = 0;
   if(inventory_units.length<quantity){
-    url += "/add"
+    url += "/add";
     new_quantity = (quantity - inventory_units.length);
   }else if(inventory_units.length>quantity){
-    url += "/remove"
+    url += "/remove";
     new_quantity = (inventory_units.length - quantity);
   }
   url += '.json';
@@ -64,15 +64,15 @@ adjustShipmentItems = function(shipment_number, variant_id, quantity){
         variant_id: variant_id,
         quantity: new_quantity,
       },
-      success: function(response) {
+      success: function() {
         window.location.reload();
       },
       error: function(response) {
-        show_flash('error', response.responseJSON.message);
+        window.show_flash('error', response.responseJSON.message);
       }
     });
   }
-}
+};
 
 deleteLineItem = function(line_item_id){
   var url = Spree.routes.line_items_api(order_number) + "/" + line_item_id + ".json";
@@ -80,14 +80,14 @@ deleteLineItem = function(line_item_id){
   Spree.ajax({
     type: "DELETE",
     url: url,
-    success: function(response) {
+    success: function() {
       window.location.reload();
     },
     error: function(response) {
       show_flash('error', response.responseJSON.message);
     }
   });
-}
+};
 
 startItemSplit = function(event){
   event.preventDefault();
@@ -105,15 +105,15 @@ startItemSplit = function(event){
     link.closest('tr').after(split_item_template({ variant: variant, shipments: shipments, max_quantity: max_quantity }));
 
     $('#item_stock_location').select2({ width: 'resolve', placeholder: Spree.translations.item_stock_placeholder });
-  })
-}
+  });
+};
 
 completeItemSplit = function(event) {
   event.preventDefault();
 
   if($('#item_stock_location').val() === ""){
-      alert('Please select the split destination.');
-      return false;
+    alert('Please select the split destination.');
+    return false;
   }
 
   var link = $(this);
@@ -135,35 +135,35 @@ completeItemSplit = function(event) {
         type: "POST",
         url: Spree.routes.shipments_api + "/transfer_to_location",
         data: {
-            original_shipment_number: original_shipment_number,
-            variant_id: variant_id,
-            quantity: quantity,
-            stock_location_id: stock_location_id
+          original_shipment_number: original_shipment_number,
+          variant_id: variant_id,
+          quantity: quantity,
+          stock_location_id: stock_location_id
         }
       }).error(function(msg) {
-          alert(msg.responseJSON['message']);
-      }).done(function(msg) {
+        alert(msg.responseJSON['message']);
+      }).done(function() {
         window.Spree.advanceOrder();
       });
     } else {
-        // TRANSFER TO AN EXISTING SHIPMENT
-        Spree.ajax({
-            type: "POST",
-            url: Spree.routes.shipments_api + "/transfer_to_shipment",
-            data: {
-                original_shipment_number: original_shipment_number,
-                target_shipment_number: target_shipment_number,
-                variant_id: variant_id,
-                quantity: quantity
-            }
-        }).error(function(msg) {
-            alert(msg.responseJSON['message']);
-        }).done(function(msg) {
-            window.Spree.advanceOrder();
-        });
+      // TRANSFER TO AN EXISTING SHIPMENT
+      Spree.ajax({
+        type: "POST",
+        url: Spree.routes.shipments_api + "/transfer_to_shipment",
+        data: {
+          original_shipment_number: original_shipment_number,
+          target_shipment_number: target_shipment_number,
+          variant_id: variant_id,
+          quantity: quantity
+        }
+      }).error(function(msg) {
+        alert(msg.responseJSON['message']);
+      }).done(function() {
+        window.Spree.advanceOrder();
+      });
     }
   }
-}
+};
 
 addVariantFromStockLocation = function(event) {
   event.preventDefault();
@@ -190,14 +190,14 @@ addVariantFromStockLocation = function(event) {
         quantity: quantity,
         stock_location_id: stock_location_id,
       }
-    }).done(function( msg ) {
+    }).done(function(){
       window.location.reload();
     });
   }else{
     //add to existing shipment
     adjustShipmentItems(shipment.number, variant_id, quantity);
   }
-}
+};
 
 var ShipmentEditView = Backbone.View.extend({
   initialize: function(){
@@ -266,8 +266,8 @@ var ShipmentEditView = Backbone.View.extend({
 
   toggleTrackingEdit: function(e) {
     e.preventDefault();
-    this.$("tr.edit-tracking").toggle()
-    this.$("tr.show-tracking").toggle()
+    this.$("tr.edit-tracking").toggle();
+    this.$("tr.show-tracking").toggle();
   },
 
   saveTracking: function(e) {

--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -15,24 +15,8 @@ $(document).ready(function () {
     $('button.add_variant').click(addVariantFromStockLocation);
   });
 
-  //handle cancel click
-  $('a.cancel-item').click(toggleItemEdit);
-
   //handle split click
   $('a.split-item').click(startItemSplit);
-
-  //handle save click
-  $('a.save-item').click(function(){
-    var save = $(this);
-    var shipment_number = save.data('shipment-number');
-    var variant_id = save.data('variant-id');
-
-    var quantity = parseInt(save.parents('tr').find('input.line_item_quantity').val());
-
-    toggleItemEdit();
-    adjustShipmentItems(shipment_number, variant_id, quantity);
-    return false;
-  });
 
   //handle delete click
   $('a.delete-item').click(function(event){
@@ -40,7 +24,6 @@ $(document).ready(function () {
       var del = $(this);
       var line_item_id = del.data('line-item-id');
 
-      toggleItemEdit();
       deleteLineItem(line_item_id);
     }
     return false;
@@ -177,18 +160,6 @@ toggleMethodEdit = function(){
   var link = $(this);
   link.parents('tbody').find('tr.edit-method').toggle();
   link.parents('tbody').find('tr.show-method').toggle();
-
-  return false;
-}
-
-toggleItemEdit = function(){
-  var link = $(this);
-  link.parent().find('a.cancel-item').toggle();
-  link.parent().find('a.split-item').toggle();
-  link.parent().find('a.save-item').toggle();
-  link.parent().find('a.delete-item').toggle();
-  link.parents('tr').find('td.item-qty-show').toggle();
-  link.parents('tr').find('td.item-qty-edit').toggle();
 
   return false;
 }

--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -33,16 +33,8 @@ $(document).ready(function () {
     var link = $(this);
     var shipment_number = link.data('shipment-number');
     var selected_shipping_rate_id = link.parents('tbody').find("select#selected_shipping_rate_id[data-shipment-number='" + shipment_number + "']").val();
-    var url = Spree.routes.shipments_api + '/' + shipment_number + '.json';
-
-    Spree.ajax({
-      type: 'PUT',
-      url: url,
-      data: {
-        shipment: {
-          selected_shipping_rate_id: selected_shipping_rate_id,
-        }
-      }
+    updateShipment(shipment_number, {
+      selected_shipping_rate_id: selected_shipping_rate_id
     }).done(function () {
       window.location.reload();
     });
@@ -55,17 +47,8 @@ $(document).ready(function () {
     var link = $(this);
     var shipment_number = link.data('shipment-number');
     var tracking = link.parents('tbody').find('input#tracking').val();
-    var url = Spree.routes.shipments_api + '/' + shipment_number + '.json';
 
-    Spree.ajax({
-      type: 'PUT',
-      url: url,
-      data: {
-        shipment: {
-          tracking: tracking
-        }
-      }
-    }).done(function (data) {
+    updateShipment(shipment_number, {tracking: tracking}).done(function (data) {
       link.parents('tbody').find('tr.edit-tracking').toggle();
 
       var show = link.parents('tbody').find('tr.show-tracking');
@@ -74,6 +57,18 @@ $(document).ready(function () {
     });
   });
 });
+
+updateShipment = function(shipment_number, attributes) {
+  var url = Spree.routes.shipments_api + '/' + shipment_number + '.json';
+
+  return Spree.ajax({
+    type: 'PUT',
+    url: url,
+    data: {
+      shipment: attributes
+    }
+  });
+}
 
 adjustShipmentItems = function(shipment_number, variant_id, quantity){
     var shipment = _.findWhere(shipments, {number: shipment_number + ''});

--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -204,8 +204,8 @@ addVariantFromStockLocation = function(event) {
 var ShipmentEditView = Backbone.View.extend({
   initialize: function(){
     var tbody = this.$("tbody[data-order-number][data-shipment-number]");
-    this.shipment_number = tbody.data("shipment-number")
-    this.order_number = tbody.data("order-number")
+    this.shipment_number = tbody.data("shipment-number");
+    this.order_number = tbody.data("order-number");
   },
 
   events: {

--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -6,15 +6,16 @@ $(document).ready(function () {
   $('#add_variant_id').change(function(){
     var variant_id = $(this).val();
 
-    var variant = _.find(window.variants, function(variant){
-      return variant.id == variant_id
-    })
+    Spree.ajax({
+      url: Spree.routes.variants_api + "/" + variant_id,
+      success: function(variant){
+        var variantStockTemplate = HandlebarsTemplates["variants/autocomplete_stock"];
+        $('#stock_details').html(variantStockTemplate({variant: variant}));
+        $('#stock_details').show();
 
-    var variantStockTemplate = HandlebarsTemplates["variants/autocomplete_stock"];
-    $('#stock_details').html(variantStockTemplate({variant: variant}));
-    $('#stock_details').show();
-
-    $('button.add_variant').click(addVariantFromStockLocation);
+        $('button.add_variant').click(addVariantFromStockLocation);
+      }
+    });
   });
 
   // add header to ship ujs ajax call

--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -242,11 +242,9 @@ var ShipmentEditView = Backbone.View.extend({
 
   cancelItemSplit: function(e){
     e.preventDefault();
-    var link = $(e.currentTarget);
-    var prev_row = link.closest('tr').prev();
-    link.closest('tr').remove();
-    prev_row.find('a.split-item').show();
-    prev_row.find('a.delete-item').show();
+    this.$('tr.stock-item-split').remove();
+    this.$('a.split-item').show();
+    this.$('a.delete-item').show();
   },
 
   completeItemSplit: function(e){

--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -283,10 +283,9 @@ var ShipmentEditView = Backbone.View.extend({
     }
   },
 
-  toggleTrackingEdit: function(e) {
-    var link = $(e.currentTarget);
-    link.parents('tbody').find('tr.edit-tracking').toggle();
-    link.parents('tbody').find('tr.show-tracking').toggle();
+  toggleTrackingEdit: function() {
+    this.$("tr.edit-tracking").toggle()
+    this.$("tr.show-tracking").toggle()
   }
 });
 

--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -42,7 +42,7 @@ var ShipShipmentView = Backbone.View.extend({
 });
 
 updateShipment = function(shipment_number, attributes) {
-  var url = Spree.routes.shipments_api + '/' + shipment_number + '.json';
+  var url = Spree.routes.shipments_api + '/' + shipment_number;
 
   return Spree.ajax({
     type: 'PUT',
@@ -67,7 +67,6 @@ adjustShipmentItems = function(shipment_number, variant_id, quantity){
     url += "/remove";
     new_quantity = (inventory_units.length - quantity);
   }
-  url += '.json';
 
   if(new_quantity!=0){
     Spree.ajax({
@@ -88,7 +87,7 @@ adjustShipmentItems = function(shipment_number, variant_id, quantity){
 };
 
 deleteLineItem = function(line_item_id){
-  var url = Spree.routes.line_items_api(order_number) + "/" + line_item_id + ".json";
+  var url = Spree.routes.line_items_api(order_number) + "/" + line_item_id;
 
   Spree.ajax({
     type: "DELETE",

--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -199,7 +199,6 @@ addVariantFromStockLocation = function(event) {
     //add to existing shipment
     adjustShipmentItems(shipment.number, variant_id, quantity);
   }
-  return 1
 }
 
 var ShipmentEditView = Backbone.View.extend({

--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -210,15 +210,6 @@ completeItemSplit = function(event) {
   }
 }
 
-cancelItemSplit = function(event) {
-  event.preventDefault();
-  var link = $(this);
-  var prev_row = link.closest('tr').prev();
-  link.closest('tr').remove();
-  prev_row.find('a.split-item').toggle();
-  prev_row.find('a.delete-item').toggle();
-}
-
 addVariantFromStockLocation = function(event) {
   event.preventDefault();
 
@@ -272,7 +263,11 @@ var ShipmentEditView = Backbone.View.extend({
   },
 
   cancelItemSplit: function(e){
-    cancelItemSplit.bind(e.currentTarget)(e);
+    var link = $(e.currentTarget);
+    var prev_row = link.closest('tr').prev();
+    link.closest('tr').remove();
+    prev_row.find('a.split-item').show();
+    prev_row.find('a.delete-item').show();
   },
 
   completeItemSplit: function(e){

--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -9,6 +9,8 @@ $(document).ready(function () {
     var variant = _.find(window.variants, function(variant){
       return variant.id == variant_id
     })
+
+    var variantStockTemplate = HandlebarsTemplates["variants/autocomplete_stock"];
     $('#stock_details').html(variantStockTemplate({variant: variant}));
     $('#stock_details').show();
 

--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -253,11 +253,9 @@ var ShipmentEditView = Backbone.View.extend({
     this.$("tr.show-tracking").toggle()
   },
 
-  saveMethod: function(e) {
-    var link = $(e.currentTarget);
-    var shipment_number = link.data('shipment-number');
-    var selected_shipping_rate_id = link.parents('tbody').find("select#selected_shipping_rate_id[data-shipment-number='" + shipment_number + "']").val();
-    updateShipment(shipment_number, {
+  saveMethod: function() {
+    var selected_shipping_rate_id = this.$("select#selected_shipping_rate_id").val();
+    updateShipment(this.shipment_number, {
       selected_shipping_rate_id: selected_shipping_rate_id
     }).done(function () {
       window.location.reload();
@@ -265,17 +263,20 @@ var ShipmentEditView = Backbone.View.extend({
   },
 
   // handle tracking save
-  saveTracking: function (e) {
-    var link = $(e.currentTarget);
-    var shipment_number = link.data('shipment-number');
-    var tracking = link.parents('tbody').find('input#tracking').val();
+  saveTracking: function() {
+    var tracking = this.$('input#tracking').val();
+    var _this = this;
+    updateShipment(this.shipment_number, {
+      tracking: tracking
+    }).done(function (data) {
+      _this.$('tr.edit-tracking').toggle();
 
-    updateShipment(shipment_number, {tracking: tracking}).done(function (data) {
-      link.parents('tbody').find('tr.edit-tracking').toggle();
-
-      var show = link.parents('tbody').find('tr.show-tracking');
-      show.toggle();
-      show.find('.tracking-value').html($("<strong>").html(Spree.translations.tracking + ": ")).append(data.tracking);
+      var show = _this.$('tr.show-tracking');
+      show.toggle()
+          .find('.tracking-value')
+          .html($("<strong>")
+          .html(Spree.translations.tracking + ": "))
+          .append(document.createTextNode(data.tracking));
     });
   }
 });

--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -59,8 +59,7 @@ $(document).ready(function () {
       data: {
         shipment: {
           selected_shipping_rate_id: selected_shipping_rate_id,
-        },
-        token: Spree.api_key
+        }
       }
     }).done(function () {
       window.location.reload();
@@ -94,8 +93,7 @@ $(document).ready(function () {
       data: {
         shipment: {
           tracking: tracking
-        },
-        token: Spree.api_key
+        }
       }
     }).done(function (data) {
       link.parents('tbody').find('tr.edit-tracking').toggle();
@@ -216,8 +214,7 @@ completeItemSplit = function(event) {
             original_shipment_number: original_shipment_number,
             variant_id: variant_id,
             quantity: quantity,
-            stock_location_id: stock_location_id,
-            token: Spree.api_key
+            stock_location_id: stock_location_id
         }
       }).error(function(msg) {
           alert(msg.responseJSON['message']);
@@ -234,8 +231,7 @@ completeItemSplit = function(event) {
                 original_shipment_number: original_shipment_number,
                 target_shipment_number: target_shipment_number,
                 variant_id: variant_id,
-                quantity: quantity,
-                token: Spree.api_key
+                quantity: quantity
             }
         }).error(function(msg) {
             alert(msg.responseJSON['message']);

--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -25,37 +25,6 @@ $(document).ready(function () {
   $("form#admin-ship-shipment").on("ajax:success", function(event, xhr, settings) {
     window.location.reload();
   });
-
-  // handle shipping method save
-  $('[data-hook=admin_shipment_form] a.save-method').on('click', function (event) {
-    event.preventDefault();
-
-    var link = $(this);
-    var shipment_number = link.data('shipment-number');
-    var selected_shipping_rate_id = link.parents('tbody').find("select#selected_shipping_rate_id[data-shipment-number='" + shipment_number + "']").val();
-    updateShipment(shipment_number, {
-      selected_shipping_rate_id: selected_shipping_rate_id
-    }).done(function () {
-      window.location.reload();
-    });
-  });
-
-  // handle tracking save
-  $('[data-hook=admin_shipment_form] a.save-tracking').on('click', function (event) {
-    event.preventDefault();
-
-    var link = $(this);
-    var shipment_number = link.data('shipment-number');
-    var tracking = link.parents('tbody').find('input#tracking').val();
-
-    updateShipment(shipment_number, {tracking: tracking}).done(function (data) {
-      link.parents('tbody').find('tr.edit-tracking').toggle();
-
-      var show = link.parents('tbody').find('tr.show-tracking');
-      show.toggle();
-      show.find('.tracking-value').html($("<strong>").html(Spree.translations.tracking + ": ")).append(data.tracking);
-    });
-  });
 });
 
 updateShipment = function(shipment_number, attributes) {
@@ -239,6 +208,8 @@ var ShipmentEditView = Backbone.View.extend({
     "click a.cancel-tracking": "toggleTrackingEdit",
     "click a.cancel-split": "cancelItemSplit",
     "click a.save-split": "completeItemSplit",
+    "click a.save-method": "saveMethod",
+    "click a.save-tracking": "saveTracking",
   },
 
   startItemSplit: function(e){
@@ -274,6 +245,32 @@ var ShipmentEditView = Backbone.View.extend({
   toggleTrackingEdit: function() {
     this.$("tr.edit-tracking").toggle()
     this.$("tr.show-tracking").toggle()
+  },
+
+  saveMethod: function(e) {
+    var link = $(e.currentTarget);
+    var shipment_number = link.data('shipment-number');
+    var selected_shipping_rate_id = link.parents('tbody').find("select#selected_shipping_rate_id[data-shipment-number='" + shipment_number + "']").val();
+    updateShipment(shipment_number, {
+      selected_shipping_rate_id: selected_shipping_rate_id
+    }).done(function () {
+      window.location.reload();
+    });
+  },
+
+  // handle tracking save
+  saveTracking: function (e) {
+    var link = $(e.currentTarget);
+    var shipment_number = link.data('shipment-number');
+    var tracking = link.parents('tbody').find('input#tracking').val();
+
+    updateShipment(shipment_number, {tracking: tracking}).done(function (data) {
+      link.parents('tbody').find('tr.edit-tracking').toggle();
+
+      var show = link.parents('tbody').find('tr.show-tracking');
+      show.toggle();
+      show.find('.tracking-value').html($("<strong>").html(Spree.translations.tracking + ": ")).append(data.tracking);
+    });
   }
 });
 

--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -219,15 +219,18 @@ var ShipmentEditView = Backbone.View.extend({
   },
 
   startItemSplit: function(e){
+    e.preventDefault();
     startItemSplit.apply(e.currentTarget, [e]);
   },
 
-  toggleMethodEdit: function(){
+  toggleMethodEdit: function(e){
+    e.preventDefault();
     this.$('tr.edit-method').toggle();
     this.$('tr.show-method').toggle();
   },
 
   cancelItemSplit: function(e){
+    e.preventDefault();
     var link = $(e.currentTarget);
     var prev_row = link.closest('tr').prev();
     link.closest('tr').remove();
@@ -240,6 +243,7 @@ var ShipmentEditView = Backbone.View.extend({
   },
 
   deleteItem: function(e){
+    e.preventDefault();
     if (confirm(Spree.translations.are_you_sure_delete)) {
       var del = $(e.currentTarget);
       var line_item_id = del.data('line-item-id');
@@ -248,12 +252,14 @@ var ShipmentEditView = Backbone.View.extend({
     }
   },
 
-  toggleTrackingEdit: function() {
+  toggleTrackingEdit: function(e) {
+    e.preventDefault();
     this.$("tr.edit-tracking").toggle()
     this.$("tr.show-tracking").toggle()
   },
 
-  saveMethod: function() {
+  saveMethod: function(e) {
+    e.preventDefault();
     var selected_shipping_rate_id = this.$("select#selected_shipping_rate_id").val();
     updateShipment(this.shipment_number, {
       selected_shipping_rate_id: selected_shipping_rate_id
@@ -262,8 +268,8 @@ var ShipmentEditView = Backbone.View.extend({
     });
   },
 
-  // handle tracking save
-  saveTracking: function() {
+  saveTracking: function(e) {
+    e.preventDefault();
     var tracking = this.$('input#tracking').val();
     var _this = this;
     updateShipment(this.shipment_number, {

--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -64,8 +64,6 @@ $(document).ready(function () {
       }
     }).done(function () {
       window.location.reload();
-    }).error(function (msg) {
-      console.log(msg);
     });
   });
 
@@ -281,8 +279,6 @@ addVariantFromStockLocation = function(event) {
       }
     }).done(function( msg ) {
       window.location.reload();
-    }).error(function( msg ) {
-      console.log(msg);
     });
   }else{
     //add to existing shipment

--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -17,20 +17,6 @@ $(document).ready(function () {
     $('button.add_variant').click(addVariantFromStockLocation);
   });
 
-  //handle split click
-  $('a.split-item').click(startItemSplit);
-
-  //handle delete click
-  $('a.delete-item').click(function(event){
-    if (confirm(Spree.translations.are_you_sure_delete)) {
-      var del = $(this);
-      var line_item_id = del.data('line-item-id');
-
-      deleteLineItem(line_item_id);
-    }
-    return false;
-  });
-
   // add header to ship ujs ajax call
   $("form#admin-ship-shipment").on("ajax:beforeSend", function(event, xhr, settings) {
     xhr.setRequestHeader("X-Spree-Token", Spree.api_key);
@@ -39,10 +25,6 @@ $(document).ready(function () {
   $("form#admin-ship-shipment").on("ajax:success", function(event, xhr, settings) {
     window.location.reload();
   });
-
-  // handle shipping method edit click
-  $('a.edit-method').click(toggleMethodEdit);
-  $('a.cancel-method').click(toggleMethodEdit);
 
   // handle shipping method save
   $('[data-hook=admin_shipment_form] a.save-method').on('click', function (event) {
@@ -65,18 +47,6 @@ $(document).ready(function () {
       window.location.reload();
     });
   });
-
-  var toggleTrackingEdit = function(event) {
-    event.preventDefault();
-
-    var link = $(this);
-    link.parents('tbody').find('tr.edit-tracking').toggle();
-    link.parents('tbody').find('tr.show-tracking').toggle();
-  }
-
-  // handle tracking edit click
-  $('a.edit-tracking').click(toggleTrackingEdit);
-  $('a.cancel-tracking').click(toggleTrackingEdit);
 
   // handle tracking save
   $('[data-hook=admin_shipment_form] a.save-tracking').on('click', function (event) {
@@ -176,8 +146,6 @@ startItemSplit = function(event){
     var max_quantity = link.closest('tr').data('item-quantity');
     var split_item_template = HandlebarsTemplates['variants/split'];
     link.closest('tr').after(split_item_template({ variant: variant, shipments: shipments, max_quantity: max_quantity }));
-    $('a.cancel-split').click(cancelItemSplit);
-    $('a.save-split').click(completeItemSplit);
 
     $('#item_stock_location').select2({ width: 'resolve', placeholder: Spree.translations.item_stock_placeholder });
   })
@@ -282,3 +250,53 @@ addVariantFromStockLocation = function(event) {
   }
   return 1
 }
+
+var ShipmentEditView = Backbone.View.extend({
+  events: {
+    "click a.split-item": "startItemSplit",
+    "click a.edit-method": "toggleMethodEdit",
+    "click a.cancel-method": "toggleMethodEdit",
+    "click a.delete-item": "deleteItem",
+    "click a.edit-tracking": "toggleTrackingEdit",
+    "click a.cancel-tracking": "toggleTrackingEdit",
+    "click a.cancel-split": "cancelItemSplit",
+    "click a.save-split": "completeItemSplit",
+  },
+
+  startItemSplit: function(e){
+    startItemSplit.bind(e.currentTarget)(e);
+  },
+
+  toggleMethodEdit: function(e){
+    toggleMethodEdit.bind(e.currentTarget)(e);
+  },
+
+  cancelItemSplit: function(e){
+    cancelItemSplit.bind(e.currentTarget)(e);
+  },
+
+  completeItemSplit: function(e){
+    completeItemSplit.bind(e.currentTarget)(e);
+  },
+
+  deleteItem: function(e){
+    if (confirm(Spree.translations.are_you_sure_delete)) {
+      var del = $(e.currentTarget);
+      var line_item_id = del.data('line-item-id');
+
+      deleteLineItem(line_item_id);
+    }
+  },
+
+  toggleTrackingEdit: function(e) {
+    var link = $(e.currentTarget);
+    link.parents('tbody').find('tr.edit-tracking').toggle();
+    link.parents('tbody').find('tr.show-tracking').toggle();
+  }
+});
+
+$(function(){
+  $(".js-shipment-edit").each(function(){
+    new ShipmentEditView({ el: $(this) });
+  });
+});

--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -182,8 +182,11 @@ addVariantFromStockLocation = function(event) {
   if(shipment==undefined){
     Spree.ajax({
       type: "POST",
-      url: Spree.routes.shipments_api + "?shipment[order_id]=" + order_number,
+      url: Spree.routes.shipments_api,
       data: {
+        shipment: {
+          order_id: order_number
+        },
         variant_id: variant_id,
         quantity: quantity,
         stock_location_id: stock_location_id,

--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -173,30 +173,18 @@ startItemSplit = function(event){
   link.parent().find('a.delete-item').toggle();
   var variant_id = link.data('variant-id');
 
-  var variant = {};
   Spree.ajax({
     type: "GET",
-    async: false,
-    url: Spree.routes.variants_api,
-    data: {
-      q: {
-        "id_eq": variant_id
-      },
-      token: Spree.api_key
-    }
-  }).success(function( data ) {
-    variant = data['variants'][0];
-  }).error(function( msg ) {
-    console.log(msg);
-  });
+    url: Spree.routes.variants_api + "/" + variant_id,
+  }).success(function(variant){
+    var max_quantity = link.closest('tr').data('item-quantity');
+    var split_item_template = HandlebarsTemplates['variants/split'];
+    link.closest('tr').after(split_item_template({ variant: variant, shipments: shipments, max_quantity: max_quantity }));
+    $('a.cancel-split').click(cancelItemSplit);
+    $('a.save-split').click(completeItemSplit);
 
-  var max_quantity = link.closest('tr').data('item-quantity');
-  var split_item_template = HandlebarsTemplates['variants/split'];
-  link.closest('tr').after(split_item_template({ variant: variant, shipments: shipments, max_quantity: max_quantity }));
-  $('a.cancel-split').click(cancelItemSplit);
-  $('a.save-split').click(completeItemSplit);
-
-  $('#item_stock_location').select2({ width: 'resolve', placeholder: Spree.translations.item_stock_placeholder });
+    $('#item_stock_location').select2({ width: 'resolve', placeholder: Spree.translations.item_stock_placeholder });
+  })
 }
 
 completeItemSplit = function(event) {

--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -213,7 +213,7 @@ var ShipmentEditView = Backbone.View.extend({
   },
 
   startItemSplit: function(e){
-    startItemSplit.bind(e.currentTarget)(e);
+    startItemSplit.apply(e.currentTarget, [e]);
   },
 
   toggleMethodEdit: function(){
@@ -230,7 +230,7 @@ var ShipmentEditView = Backbone.View.extend({
   },
 
   completeItemSplit: function(e){
-    completeItemSplit.bind(e.currentTarget)(e);
+    completeItemSplit.apply(e.currentTarget, [e]);
   },
 
   deleteItem: function(e){

--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -206,27 +206,34 @@ var ShipmentEditView = Backbone.View.extend({
   },
 
   events: {
-    "click a.split-item": "startItemSplit",
-    "click a.edit-method": "toggleMethodEdit",
-    "click a.cancel-method": "toggleMethodEdit",
     "click a.delete-item": "deleteItem",
-    "click a.edit-tracking": "toggleTrackingEdit",
-    "click a.cancel-tracking": "toggleTrackingEdit",
+
+    "click a.split-item": "startItemSplit",
     "click a.cancel-split": "cancelItemSplit",
     "click a.save-split": "completeItemSplit",
+
+    "click a.edit-method": "toggleMethodEdit",
+    "click a.cancel-method": "toggleMethodEdit",
     "click a.save-method": "saveMethod",
+
+    "click a.edit-tracking": "toggleTrackingEdit",
+    "click a.cancel-tracking": "toggleTrackingEdit",
     "click a.save-tracking": "saveTracking",
+  },
+
+  deleteItem: function(e){
+    e.preventDefault();
+    if (confirm(Spree.translations.are_you_sure_delete)) {
+      var del = $(e.currentTarget);
+      var line_item_id = del.data('line-item-id');
+
+      deleteLineItem(line_item_id);
+    }
   },
 
   startItemSplit: function(e){
     e.preventDefault();
     startItemSplit.apply(e.currentTarget, [e]);
-  },
-
-  toggleMethodEdit: function(e){
-    e.preventDefault();
-    this.$('tr.edit-method').toggle();
-    this.$('tr.show-method').toggle();
   },
 
   cancelItemSplit: function(e){
@@ -242,20 +249,10 @@ var ShipmentEditView = Backbone.View.extend({
     completeItemSplit.apply(e.currentTarget, [e]);
   },
 
-  deleteItem: function(e){
+  toggleMethodEdit: function(e){
     e.preventDefault();
-    if (confirm(Spree.translations.are_you_sure_delete)) {
-      var del = $(e.currentTarget);
-      var line_item_id = del.data('line-item-id');
-
-      deleteLineItem(line_item_id);
-    }
-  },
-
-  toggleTrackingEdit: function(e) {
-    e.preventDefault();
-    this.$("tr.edit-tracking").toggle()
-    this.$("tr.show-tracking").toggle()
+    this.$('tr.edit-method').toggle();
+    this.$('tr.show-method').toggle();
   },
 
   saveMethod: function(e) {
@@ -266,6 +263,12 @@ var ShipmentEditView = Backbone.View.extend({
     }).done(function () {
       window.location.reload();
     });
+  },
+
+  toggleTrackingEdit: function(e) {
+    e.preventDefault();
+    this.$("tr.edit-tracking").toggle()
+    this.$("tr.show-tracking").toggle()
   },
 
   saveTracking: function(e) {

--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -133,7 +133,6 @@ completeItemSplit = function(event) {
       // TRANSFER TO A NEW LOCATION
       Spree.ajax({
         type: "POST",
-        async: false,
         url: Spree.routes.shipments_api + "/transfer_to_location",
         data: {
             original_shipment_number: original_shipment_number,
@@ -150,7 +149,6 @@ completeItemSplit = function(event) {
         // TRANSFER TO AN EXISTING SHIPMENT
         Spree.ajax({
             type: "POST",
-            async: false,
             url: Spree.routes.shipments_api + "/transfer_to_shipment",
             data: {
                 original_shipment_number: original_shipment_number,

--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -124,14 +124,6 @@ deleteLineItem = function(line_item_id){
   });
 }
 
-toggleMethodEdit = function(){
-  var link = $(this);
-  link.parents('tbody').find('tr.edit-method').toggle();
-  link.parents('tbody').find('tr.show-method').toggle();
-
-  return false;
-}
-
 startItemSplit = function(event){
   event.preventDefault();
   var link = $(this);
@@ -258,8 +250,9 @@ var ShipmentEditView = Backbone.View.extend({
     startItemSplit.bind(e.currentTarget)(e);
   },
 
-  toggleMethodEdit: function(e){
-    toggleMethodEdit.bind(e.currentTarget)(e);
+  toggleMethodEdit: function(){
+    this.$('tr.edit-method').toggle();
+    this.$('tr.show-method').toggle();
   },
 
   cancelItemSplit: function(e){

--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -41,37 +41,37 @@ updateShipment = function(shipment_number, attributes) {
 }
 
 adjustShipmentItems = function(shipment_number, variant_id, quantity){
-    var shipment = _.findWhere(shipments, {number: shipment_number + ''});
-    var inventory_units = _.where(shipment.inventory_units, {variant_id: variant_id});
+  var shipment = _.findWhere(shipments, {number: shipment_number + ''});
+  var inventory_units = _.where(shipment.inventory_units, {variant_id: variant_id});
 
-    var url = Spree.routes.shipments_api + "/" + shipment_number;
+  var url = Spree.routes.shipments_api + "/" + shipment_number;
 
-    var new_quantity = 0;
-    if(inventory_units.length<quantity){
-      url += "/add"
-      new_quantity = (quantity - inventory_units.length);
-    }else if(inventory_units.length>quantity){
-      url += "/remove"
-      new_quantity = (inventory_units.length - quantity);
-    }
-    url += '.json';
+  var new_quantity = 0;
+  if(inventory_units.length<quantity){
+    url += "/add"
+    new_quantity = (quantity - inventory_units.length);
+  }else if(inventory_units.length>quantity){
+    url += "/remove"
+    new_quantity = (inventory_units.length - quantity);
+  }
+  url += '.json';
 
-    if(new_quantity!=0){
-      Spree.ajax({
-        type: "PUT",
-        url: url,
-        data: {
-          variant_id: variant_id,
-          quantity: new_quantity,
-        },
-        success: function(response) {
-          window.location.reload();
-        },
-        error: function(response) {
-          show_flash('error', response.responseJSON.message);
-        }
-      });
-    }
+  if(new_quantity!=0){
+    Spree.ajax({
+      type: "PUT",
+      url: url,
+      data: {
+        variant_id: variant_id,
+        quantity: new_quantity,
+      },
+      success: function(response) {
+        window.location.reload();
+      },
+      error: function(response) {
+        show_flash('error', response.responseJSON.message);
+      }
+    });
+  }
 }
 
 deleteLineItem = function(line_item_id){

--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -132,7 +132,11 @@ startItemSplit = function(event){
     var split_item_template = HandlebarsTemplates['variants/split'];
     link.closest('tr').after(split_item_template({ variant: variant, shipments: shipments, max_quantity: max_quantity }));
 
-    $('#item_stock_location').select2({ width: 'resolve', placeholder: Spree.translations.item_stock_placeholder });
+    $('#item_stock_location').select2({
+      width: 'resolve',
+      placeholder: Spree.translations.item_stock_placeholder,
+      minimumResultsForSearch: 8
+    });
   });
 };
 

--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -199,6 +199,12 @@ addVariantFromStockLocation = function(event) {
 }
 
 var ShipmentEditView = Backbone.View.extend({
+  initialize: function(){
+    var tbody = this.$("tbody[data-order-number][data-shipment-number]");
+    this.shipment_number = tbody.data("shipment-number")
+    this.order_number = tbody.data("order-number")
+  },
+
   events: {
     "click a.split-item": "startItemSplit",
     "click a.edit-method": "toggleMethodEdit",

--- a/backend/app/assets/javascripts/spree/backend/variant_autocomplete.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/variant_autocomplete.js.coffee
@@ -1,8 +1,6 @@
 # variant autocompletion
-$(document).ready ->
-  window.variantTemplate = HandlebarsTemplates["variants/autocomplete"]
-  window.variantStockTemplate = HandlebarsTemplates["variants/autocomplete_stock"]
-  window.variantLineItemTemplate = HandlebarsTemplates["variants/line_items_autocomplete_stock"]
+
+variantTemplate = HandlebarsTemplates["variants/autocomplete"]
 
 formatVariantResult = (variant) ->
   variant.image = variant.images[0].mini_url  if variant["images"][0] isnt `undefined` and variant["images"][0].mini_url isnt `undefined`

--- a/backend/app/assets/stylesheets/spree/backend/sections/_orders.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/_orders.scss
@@ -90,7 +90,7 @@
   font-size: 2em;
 }
 
-form#admin-ship-shipment {
+form.admin-ship-shipment {
   display: block;
   text-align: center;
   input[type='submit'] { margin-left: 5px; }

--- a/backend/app/views/spree/admin/orders/_add_product.html.erb
+++ b/backend/app/views/spree/admin/orders/_add_product.html.erb
@@ -1,4 +1,4 @@
-<div id="add-line-item" data-hook>
+<div id="add-line-item" class="js-shipment-add-variant" data-hook>
   <fieldset class="no-border-bottom">
     <legend align="center"><%= Spree.t(:add_product) %></legend>
 

--- a/backend/app/views/spree/admin/orders/_carton_manifest.html.erb
+++ b/backend/app/views/spree/admin/orders/_carton_manifest.html.erb
@@ -16,9 +16,6 @@
           <%= count %> x <%= Spree.t(state, scope: 'inventory_states') %>
         <% end %>
     </td>
-    <td class="item-qty-edit hidden">
-      <%= number_field_tag :quantity, item.quantity, :min => 0, :class => "line_item_quantity", :size => 5 %>
-    </td>
     <td class="item-total align-center"><%= line_item_shipment_price(item.line_item, item.quantity) %></td>
   </tr>
 <% end %>

--- a/backend/app/views/spree/admin/orders/_shipment.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment.html.erb
@@ -1,7 +1,7 @@
 <% manifest_items = Spree::ShippingManifest.new(inventory_units: shipment.inventory_units.where(carton_id: nil)).items %>
 
 <% unless manifest_items.empty? %>
-  <div id="<%= "shipment_#{shipment.id}" %>" data-hook="admin_shipment_form">
+  <div id="<%= "shipment_#{shipment.id}" %>" class="js-shipment-edit" data-hook="admin_shipment_form">
     <fieldset class="no-border-bottom">
       <legend align="center" class="stock-location" data-hook="stock-location">
         <span class="shipment-number"><%= shipment.number %></span>

--- a/backend/app/views/spree/admin/orders/_shipment.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment.html.erb
@@ -12,8 +12,7 @@
       </legend>
 
       <% if shipment.ready? && can?(:ship, shipment) %>
-        <%= form_tag(spree.ship_api_shipment_path(shipment), { method: "PUT", remote: true, id: "admin-ship-shipment" }) do %>
-          <%= hidden_field_tag :send_mailer, false %>
+        <%= form_tag("#", class: "admin-ship-shipment") do %>
           <%= check_box_tag :send_mailer, true, true %>
           <%= label_tag :send_mailer, Spree.t(:send_mailer) %>
           <%= submit_tag Spree.t('actions.ship'), class: "ship-shipment-button" %>

--- a/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
@@ -22,8 +22,6 @@
 
     <td class="cart-item-delete actions" data-hook="cart_item_delete">
       <% if can? :update, item %>
-        <%= link_to '', '#', :class => 'save-item fa fa-check no-text with-tip', :data => {'shipment-number' => shipment_number, 'variant-id' => item.variant.id, :action => 'save'}, :title => Spree.t('actions.save'), :style => 'display: none' %>
-        <%= link_to '', '#', :class => 'cancel-item fa fa-cancel no-text with-tip', :data => {:action => 'cancel'}, :title => Spree.t('actions.cancel'), :style => 'display: none' %>
         <%= link_to '', '#', :class => 'split-item icon_link fa fa-arrows-h no-text with-tip', :data => {:action => 'split', 'variant-id' => item.variant.id}, :title => Spree.t('actions.split') %>
         <%= link_to '', '#', :class => 'delete-item fa fa-trash no-text with-tip', :data => { 'line-item-id' => item.line_item.id}, :title => Spree.t('actions.delete') %>
       <% end %>

--- a/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
@@ -15,9 +15,6 @@
           <%= count %> x <%= Spree.t(state, scope: 'inventory_states') %>
         <% end %>
     </td>
-    <td class="item-qty-edit hidden">
-      <%= number_field_tag :quantity, item.quantity, :min => 0, :class => "line_item_quantity", :size => 5 %>
-    </td>
     <td class="item-total align-center"><%= line_item_shipment_price(item.line_item, item.quantity) %></td>
 
     <td class="cart-item-delete actions" data-hook="cart_item_delete">

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -462,7 +462,6 @@ describe "Order Details", type: :feature, js: true do
       # Order item actions
       expect(page).not_to have_css('.delete-item')
       expect(page).not_to have_css('.split-item')
-      expect(page).not_to have_css('.edit-item')
       expect(page).not_to have_css('.edit-tracking')
 
       expect(page).not_to have_css('#add-line-item')
@@ -486,8 +485,6 @@ describe "Order Details", type: :feature, js: true do
     it 'should not display order tabs or edit buttons without ability' do
       visit spree.edit_admin_order_path(order)
 
-      # Order Form
-      expect(page).not_to have_css('.edit-item')
       # Order Tabs
       expect(page).not_to have_link('Adjustments')
       expect(page).not_to have_link('Payments')

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -348,7 +348,7 @@ describe "Order Details", type: :feature, js: true do
           fill_in 'item_quantity', with: 2
           click_icon :ok
 
-          wait_for_ajax
+          expect(page).to have_css("#shipment_#{@shipment2.id}", count: 1)
 
           expect(order.shipments.count).to eq(1)
           expect(order.shipments.last.inventory_units_for(product.master).count).to eq(2)
@@ -398,9 +398,10 @@ describe "Order Details", type: :feature, js: true do
             within_row(1) { click_icon 'arrows-h' }
             targetted_select2 @shipment2.number, from: '#s2id_item_stock_location'
             fill_in 'item_quantity', with: 1
+
             click_icon :ok
 
-            wait_for_ajax
+            expect(page).to have_css('.shipment', count: 2)
 
             expect(order.shipments.count).to eq(2)
             expect(order.shipments.first.inventory_units_for(product.master).count).to eq 1

--- a/backend/spec/features/admin/orders/shipments_spec.rb
+++ b/backend/spec/features/admin/orders/shipments_spec.rb
@@ -50,16 +50,21 @@ describe "Shipments", type: :feature do
 
     it "can move a variant to a new and to an existing shipment" do
       expect(order.shipments.count).to eq(1)
+      shipment1 = order.shipments[0]
 
       within_row(1) { click_icon 'arrows-h' }
       targetted_select2 'LA', from: '#s2id_item_stock_location'
       click_icon :ok
-      expect(page).to have_css("#shipment_#{order.shipments.first.id}")
+
+      expect(page).to have_css("#shipment_#{shipment1.id} tr.stock-item", count: 4)
+      shipment2 = (order.reload.shipments.to_a - [shipment1]).first
+      expect(page).to have_css("#shipment_#{shipment2.id} tr.stock-item", count: 1)
 
       within_row(2) { click_icon 'arrows-h' }
-      targetted_select2 "LA(#{order.reload.shipments.last.number})", from: '#s2id_item_stock_location'
+      targetted_select2 "LA(#{shipment2.number})", from: '#s2id_item_stock_location'
       click_icon :ok
-      expect(page).to have_css("#shipment_#{order.reload.shipments.last.id}")
+      expect(page).to have_css("#shipment_#{shipment2.id} tr.stock-item", count: 2)
+      expect(page).to have_css("#shipment_#{shipment1.id} tr.stock-item", count: 3)
     end
   end
 end


### PR DESCRIPTION
The `shipments.js` file had become a sprawl of jQuery soup. This aims to introduce some structure by moving the events into a Backbone view. This also cleaned up the event handlers a fair bit since they now have access to the shipment's top level div as well as the order and shipment number.

This should not change any behaviour.

There's certainly more work to be done here, but I believe this is a good first step.