### PR TITLE
WIP Superseding historical prices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 ## Solidus 1.3.0 (unreleased)
 
+*   Superseding historical prices
+
+    When you change the price of a variant, from now on a new price will be created instead of
+    changing the existing one. Which price is currently valid is determined by the new `valid_from`
+    column on prices. In order to get the full price history for a variant, run
+    `Spree::Variant#prices`.
+
+    https://github.com/solidusio/solidus/pull/987
+
+*   Variant#currency= deprecated
+
+    It makes no sense to change the currency of a default price, because a price can only be the
+    default price when the currency is the default price. Spree::Price will handle that fine.
+
+    https://github.com/solidusio/solidus/pull/987
+
 *   Deprecate setting a line item's currency by hand
 
     Previously, a line item's currency could be set directly, and differently from the line item's

--- a/core/app/models/concerns/spree/default_price.rb
+++ b/core/app/models/concerns/spree/default_price.rb
@@ -9,8 +9,6 @@ module Spree
         inverse_of: :variant,
         dependent: :destroy,
         autosave: true
-
-      after_save :save_default_price
     end
 
     def find_or_build_default_price
@@ -27,16 +25,6 @@ module Spree
 
     def has_default_price?
       !default_price.nil?
-    end
-
-    private
-
-    def default_price_changed?
-      default_price && (default_price.changed? || default_price.new_record?)
-    end
-
-    def save_default_price
-      default_price.save if default_price_changed?
     end
   end
 end

--- a/core/app/models/concerns/spree/default_price.rb
+++ b/core/app/models/concerns/spree/default_price.rb
@@ -1,21 +1,44 @@
 module Spree
+  # Adds a `#default_price` `has_one` relation to the including model
+  #
+  # The default price is the price displayed in the admin as the main price for a product,
+  # for example on the Spree::Product#index page.
+  # It also defines getters for price-related properties on the variant that will return the
+  # properties of the default price.
+  # If you change the default price on a variant using `Spree::Variant#price=`, a new price object
+  # will be created and the old one soft-deleted. The deletion can not be avoided:
+  #
+  # ActiveRecord destroys stale `has_one` records, as one might expect from a 1:1 relation:
+  # https://github.com/rails/rails/blob/4-2-stable/activerecord/lib/active_record/associations/has_one_association.rb#L35
+  # https://github.com/rails/rails/blob/4-2-stable/activerecord/lib/active_record/associations/has_one_association.rb#L76-L91
+  # There is no way to prevent that, unfortunately, so we have to rely on `acts_as_paranoid`
+  # to keep historical records.
+  #
+  # We have to use an ActiveRecord association though, because the backend forms need it for Ransacks
+  # searching and sorting functionality.
+  #
   module DefaultPrice
     extend ActiveSupport::Concern
 
     included do
+      # Price to be used in the backend
+      # @return [Spree::Price] The backend price for the including object
       has_one :default_price,
-        -> { with_deleted.where(currency: Spree::Config[:currency]).valid_before_now },
+        -> { Spree::Price.default_prices },
         class_name: 'Spree::Price',
         inverse_of: name.demodulize.underscore.to_sym,
         dependent: :destroy,
         autosave: true
     end
+    # Delegate getters for price-related variant properties to the relation defined above.
     delegate :display_price, :display_amount, :price, :currency, to: :default_price, allow_nil: true
 
+    # Build a new price object and soft-delete the current one so we keep a history of prices.
     delegate :price=, to: :build_default_price
 
+    # @return [Boolean] Does the including object (ie: Variant) have a default price already?
     def has_default_price?
-      !default_price.nil?
+      default_price.present?
     end
   end
 end

--- a/core/app/models/concerns/spree/default_price.rb
+++ b/core/app/models/concerns/spree/default_price.rb
@@ -4,7 +4,7 @@ module Spree
 
     included do
       has_one :default_price,
-        -> { where currency: Spree::Config[:currency], is_default: true },
+        -> { where(currency: Spree::Config[:currency]).valid_before_now },
         class_name: 'Spree::Price',
         inverse_of: :variant,
         dependent: :destroy,

--- a/core/app/models/concerns/spree/default_price.rb
+++ b/core/app/models/concerns/spree/default_price.rb
@@ -4,24 +4,15 @@ module Spree
 
     included do
       has_one :default_price,
-        -> { where(currency: Spree::Config[:currency]).valid_before_now },
+        -> { with_deleted.where(currency: Spree::Config[:currency]).valid_before_now },
         class_name: 'Spree::Price',
         inverse_of: :variant,
         dependent: :destroy,
         autosave: true
     end
+    delegate :display_price, :display_amount, :price, :currency, to: :default_price, allow_nil: true
 
-    def find_or_build_default_price
-      default_price || build_default_price
-    end
-
-    delegate :display_price, :display_amount,
-      :price, :price=, :currency, :currency=,
-      to: :find_or_build_default_price
-
-    def default_price
-      Spree::Price.unscoped { super }
-    end
+    delegate :price=, to: :build_default_price
 
     def has_default_price?
       !default_price.nil?

--- a/core/app/models/concerns/spree/default_price.rb
+++ b/core/app/models/concerns/spree/default_price.rb
@@ -6,7 +6,7 @@ module Spree
       has_one :default_price,
         -> { with_deleted.where(currency: Spree::Config[:currency]).valid_before_now },
         class_name: 'Spree::Price',
-        inverse_of: :variant,
+        inverse_of: name.demodulize.underscore.to_sym,
         dependent: :destroy,
         autosave: true
     end

--- a/core/app/models/spree/price.rb
+++ b/core/app/models/spree/price.rb
@@ -20,6 +20,11 @@ module Spree
           -> (date) { latest_valid_from_first.where("#{Spree::Price.table_name}.valid_from <= ?", date) }
     scope :valid_before_now, -> { valid_before(Time.current) }
 
+    # Returns a cache key for all prices in a passed in relation
+    def self.cache_key
+      Digest::MD5.hexdigest(valid_before_now.pluck(:id, :updated_at).flatten.join("/"))
+    end
+
     extend DisplayMoney
     money_methods :amount, :price
 

--- a/core/app/models/spree/price.rb
+++ b/core/app/models/spree/price.rb
@@ -1,5 +1,11 @@
 module Spree
   class Price < Spree::Base
+    # Because Rails destroys stale has_one records (see the Spree::DefaultPrice module for further
+    # information), we need `acts_as_paranoid` to keep historical records for us.
+    #
+    # The price relations on `Spree::Variant` are all scoped `with_deleted`, as we can not rely
+    # on the `deleted_at` accurately reflecting whether we have the right record. We rather use
+    # `valid_from` to figure out which price is the correct one to use.
     acts_as_paranoid
 
     MAXIMUM_AMOUNT = BigDecimal('99_999_999.99')

--- a/core/app/models/spree/price.rb
+++ b/core/app/models/spree/price.rb
@@ -6,9 +6,9 @@ module Spree
 
     belongs_to :variant, -> { with_deleted }, class_name: 'Spree::Variant', touch: true
 
-    after_initialize :valid_from_today!, if: -> { valid_from.blank? }
+    before_save :valid_from_today!, if: -> { valid_from.blank? }
+    before_save :set_default_currency, if: -> { currency.blank? }
 
-    validate :check_price
     validates :amount, allow_nil: true, numericality: {
       greater_than_or_equal_to: 0,
       less_than_or_equal_to: MAXIMUM_AMOUNT
@@ -54,8 +54,8 @@ module Spree
       self.valid_from = Time.current
     end
 
-    def check_price
-      self.currency ||= Spree::Config[:currency]
+    def set_default_currency
+      self.currency = Spree::Config[:currency]
     end
   end
 end

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -274,6 +274,11 @@ module Spree
       end
     end
 
+    # Takes the product's cache key and adds a cache key for the current prices relation.
+    #
+    # This way, we expire the cache every time a new price becomes valid via its `valid_from`
+    # property.
+    #
     def cache_key
       super + "/prices/" + prices.cache_key
     end

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -274,6 +274,10 @@ module Spree
       end
     end
 
+    def cache_key
+      super + "/prices/" + prices.cache_key
+    end
+
     private
 
     def add_associations_from_prototype

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -39,6 +39,7 @@ module Spree
     has_many :images, -> { order(:position) }, as: :viewable, dependent: :destroy, class_name: "Spree::Image"
 
     has_many :prices,
+      -> { with_deleted },
       class_name: 'Spree::Price',
       dependent: :destroy,
       inverse_of: :variant

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -348,9 +348,6 @@ module Spree
           self.price = product.master.price
         end
       end
-      if currency.nil?
-        self.currency = Spree::Config[:currency]
-      end
     end
 
     def set_cost_currency

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -329,6 +329,18 @@ module Spree
       end.flatten.compact
     end
 
+    # Sets a variant's default price currency.
+    # This is deprecated, as changing the default price's currency will make that price a non-default
+    # price (as the scope for that includes the scope `in_currency(Spree::Config.currency)`)
+    # @deprecated
+    # @see Spree::DefaultPrice#default_price
+    def currency=(currency)
+      Spree::Deprecation.warn "Setting a currency on a variant is unsupported behaviour." \
+                              "Create a new price object via `variant.prices.create` instead",
+                              caller
+      default_price.currency = currency
+    end
+
     private
 
     def set_master_out_of_stock

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -214,7 +214,8 @@ module Spree
     # @param currency [String] the desired currency
     # @return [Spree::Price] the price in the desired currency
     def price_in(currency)
-      prices.detect{ |price| price.currency == currency && price.is_default } || Spree::Price.new(variant_id: id, currency: currency)
+      prices.valid_before_now.in_currency(currency).first ||
+        prices.build(currency: currency)
     end
 
     # Fetches the price amount in the specified currency.

--- a/core/db/migrate/20160314162016_add_valid_from_to_spree_prices.rb
+++ b/core/db/migrate/20160314162016_add_valid_from_to_spree_prices.rb
@@ -1,0 +1,5 @@
+class AddValidFromToSpreePrices < ActiveRecord::Migration
+  def change
+    add_column :spree_prices, :valid_from, :datetime
+  end
+end

--- a/core/db/migrate/20160318130914_migrate_default_to_current_prices.rb
+++ b/core/db/migrate/20160318130914_migrate_default_to_current_prices.rb
@@ -1,0 +1,33 @@
+class MigrateDefaultToCurrentPrices < ActiveRecord::Migration
+  def up
+    execute(<<-SQL)
+      UPDATE spree_prices
+      SET valid_from = '#{Time.current.to_s(:db)}'
+      WHERE is_default = #{ActiveRecord::Base.connection.quoted_true}
+    SQL
+
+    # Prices are saved with Time.current as valid_from if not set.
+    # This sets all non-default prices to their variant's `updated_at` date.
+    # This is not entirely accurate, but we can't do better as variants do not
+    # have a created_at timestamp.
+    execute(<<-SQL)
+      UPDATE spree_prices
+      SET valid_from = (
+        SELECT updated_at FROM spree_variants WHERE spree_prices.variant_id = spree_variants.id
+      )
+      WHERE is_default = #{ActiveRecord::Base.connection.quoted_false}
+    SQL
+
+    remove_column :spree_prices, :is_default, :boolean
+  end
+
+  def down
+    add_column :spree_prices, :is_default, :boolean
+
+    execute(<<-SQL)
+      UPDATE spree_prices
+      SET is_default = #{ActiveRecord::Base.connection.quoted_true}
+      WHERE valid_from <= '#{Time.current.to_s(:db)}' ORDER BY valid_from DESC LIMIT 1
+    SQL
+  end
+end

--- a/core/lib/spree/core/product_duplicator.rb
+++ b/core/lib/spree/core/product_duplicator.rb
@@ -44,7 +44,6 @@ module Spree
         new_master.deleted_at = nil
         new_master.images = master.images.map { |image| duplicate_image image } if @include_images
         new_master.price = master.price
-        new_master.currency = master.currency
       end
     end
 

--- a/core/lib/spree/testing_support/factories/price_factory.rb
+++ b/core/lib/spree/testing_support/factories/price_factory.rb
@@ -5,5 +5,6 @@ FactoryGirl.define do
     variant
     amount 19.99
     currency 'USD'
+    valid_from { Time.current }
   end
 end

--- a/core/spec/helpers/products_helper_spec.rb
+++ b/core/spec/helpers/products_helper_spec.rb
@@ -72,20 +72,19 @@ module Spree
       end
     end
 
-    context "#variant_price_full" do
+    context "#variant_full_price" do
+      let(:product) { create(:product, price: 10) }
+      let!(:variant1) { create(:variant, price: 15, product: product) }
+      let!(:variant2) { create(:variant, price: 20, product: product) }
+
       before do
         Spree::Config[:show_variant_full_price] = true
-        @variant1 = create(:variant, product: product)
-        @variant2 = create(:variant, product: product)
       end
 
       context "when currency is default" do
         it "should return the variant price if the price is different than master" do
-          product.price = 10
-          @variant1.price = 15
-          @variant2.price = 20
-          expect(helper.variant_price(@variant1)).to eq("$15.00")
-          expect(helper.variant_price(@variant2)).to eq("$20.00")
+          expect(helper.variant_price(variant1)).to eq("$15.00")
+          expect(helper.variant_price(variant2)).to eq("$20.00")
         end
       end
 
@@ -103,17 +102,17 @@ module Spree
 
         it "should return the variant price if the price is different than master" do
           product.price = 100
-          @variant1.price = 150
-          expect(helper.variant_price(@variant1)).to eq("&#x00A5;150")
+          variant1.price = 150
+          expect(helper.variant_price(variant1)).to eq("&#x00A5;150")
         end
       end
 
       it "should be nil when all variant prices are equal" do
         product.price = 10
-        @variant1.default_price.update_column(:amount, 10)
-        @variant2.default_price.update_column(:amount, 10)
-        expect(helper.variant_price(@variant1)).to be_nil
-        expect(helper.variant_price(@variant2)).to be_nil
+        variant1.default_price.update_column(:amount, 10)
+        variant2.default_price.update_column(:amount, 10)
+        expect(helper.variant_price(variant1)).to be_nil
+        expect(helper.variant_price(variant2)).to be_nil
       end
     end
 

--- a/core/spec/models/spree/price_spec.rb
+++ b/core/spec/models/spree/price_spec.rb
@@ -3,6 +3,64 @@ require 'spec_helper'
 describe Spree::Price, type: :model do
   it { is_expected.to respond_to(:valid_from) }
 
+  describe 'scopes' do
+    describe '.valid_before(date)' do
+      let(:variant) { create(:master_variant) }
+      let!(:past_price) { create(:price, variant: variant, valid_from: 1.year.ago) }
+      let!(:current_price) { create(:price, variant: variant, valid_from: 1.week.ago) }
+      let!(:future_price) { create(:price, variant: variant, valid_from: 1.week.from_now) }
+
+      subject { described_class.valid_before(1.second.ago) }
+
+      it { is_expected.to contain_exactly(past_price, current_price) }
+    end
+    describe '.latest_valid_from_first' do
+      let(:variant) { create(:master_variant) }
+      let!(:past_price) { create(:price, variant: variant, valid_from: 1.year.ago) }
+      let!(:current_price) { create(:price, variant: variant, valid_from: 1.week.ago) }
+      let!(:future_price) { create(:price, variant: variant, valid_from: 1.week.from_now) }
+
+      subject { described_class.latest_valid_from_first.first }
+
+      it { is_expected.to eq(future_price) }
+    end
+
+    describe '.valid_before_now' do
+      subject { described_class.valid_before_now }
+
+      it 'calls valid_before with the current time' do
+        Timecop.freeze do
+          expect(described_class).to receive(:valid_before).with(Time.current)
+          subject
+        end
+      end
+    end
+  end
+
+  describe 'initialization' do
+    let(:variant) { create(:variant) }
+    subject { described_class.new(variant: variant, valid_from: valid_from) }
+
+    context 'with a valid from date given' do
+      let(:valid_from) { "1990-01-01" }
+
+      it 'stays the same' do
+        subject.save
+        expect(subject.valid_from).to eq(Date.new(1990, 01, 01))
+      end
+    end
+
+    context 'with no valid from date given' do
+      let(:valid_from) { nil }
+      let(:now) { Time.current }
+
+      it 'gets filled up with the current time' do
+        Timecop.freeze(now) { subject.save }
+        expect(subject.valid_from).to eq(now)
+      end
+    end
+  end
+
   describe 'validations' do
     let(:variant) { stub_model Spree::Variant }
     subject { Spree::Price.new variant: variant, amount: amount }

--- a/core/spec/models/spree/price_spec.rb
+++ b/core/spec/models/spree/price_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe Spree::Price, type: :model do
+  it { is_expected.to respond_to(:valid_from) }
+
   describe 'validations' do
     let(:variant) { stub_model Spree::Variant }
     subject { Spree::Price.new variant: variant, amount: amount }

--- a/core/spec/models/spree/price_spec.rb
+++ b/core/spec/models/spree/price_spec.rb
@@ -35,6 +35,28 @@ describe Spree::Price, type: :model do
         end
       end
     end
+
+    describe '.default_prices' do
+      let(:current_price) { Spree::Price.new(amount: 10, valid_from: 1.month.ago) }
+      let(:past_price) { Spree::Price.new(amount: 11, valid_from: 1.year.ago) }
+      let(:future_price) { Spree::Price.new(amount: 9, valid_from: 1.month.from_now) }
+      let(:different_currency_price) { Spree::Price.new(amount: 111, currency: "RUB", valid_from: 1.month.ago) }
+
+      let!(:variant) do
+        create(
+          :master_variant,
+          price: nil,
+          default_price: current_price,
+          prices: [past_price, future_price, different_currency_price]
+        )
+      end
+
+      subject { described_class.default_prices }
+
+      it 'returns a scope where the first element is currently valid and has the right currency' do
+        expect(subject.where(variant: variant).first).to eq(current_price)
+      end
+    end
   end
 
   describe 'initialization' do

--- a/core/spec/models/spree/validations/db_maximum_length_validator_spec.rb
+++ b/core/spec/models/spree/validations/db_maximum_length_validator_spec.rb
@@ -8,7 +8,7 @@ describe Spree::Validations::DbMaximumLengthValidator, type: :model do
       validates_with Spree::Validations::DbMaximumLengthValidator, field: :slug
     end
     let(:limit) { 255 }
-    let(:product) { Spree::Product.new }
+    let(:product) { Spree::Product.new(price: 10) }
     let(:slug) { "x" * (limit + 1) }
 
     before do

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -7,6 +7,18 @@ describe Spree::Variant, type: :model do
 
   it_behaves_like 'default_price'
 
+  context 'changing the price' do
+    before do
+      variant.price = 1500
+      variant.save
+    end
+
+    it 'creates a new price' do
+      expect(variant.prices.with_deleted.length).to eq(2)
+      expect(variant.price).to eq(1500)
+    end
+  end
+
   context "validations" do
     it "should validate price is greater than 0" do
       variant.price = -1

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -14,7 +14,7 @@ describe Spree::Variant, type: :model do
     end
 
     it 'creates a new price' do
-      expect(variant.prices.with_deleted.length).to eq(2)
+      expect(variant.prices.length).to eq(2)
       expect(variant.price).to eq(1500)
     end
   end

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -19,6 +19,14 @@ describe Spree::Variant, type: :model do
     end
   end
 
+  context 'changing the currency' do
+    it 'issues a deprecation warning' do
+      expect(Spree::Deprecation).to receive(:warn)
+      variant.currency = "RUB"
+      expect(variant.currency).to eq("RUB")
+    end
+  end
+
   context "validations" do
     it "should validate price is greater than 0" do
       variant.price = -1

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -167,10 +167,9 @@ describe Spree::Variant, type: :model do
   context "#default_price" do
     context "when multiple prices are present in addition to a default price" do
       before do
-        variant.prices << create(:price, variant: variant, currency: "USD", amount: 12.12, is_default: false)
-        variant.prices << create(:price, variant: variant, currency: "EUR", amount: 29.99)
-        variant.prices << create(:price, variant: variant, currency: "EUR", amount: 10.00, is_default: false)
-        variant.reload
+        variant.prices.create(currency: "USD", amount: 12.12, valid_from: "2010-10-10")
+        variant.prices.create(currency: "EUR", amount: 29.99)
+        variant.prices.create(currency: "EUR", amount: 10.00, valid_from: "2010-10-10")
       end
 
       it "the default stays the same" do
@@ -186,7 +185,7 @@ describe Spree::Variant, type: :model do
     context "when adding multiple prices" do
       it "it can reassign a default price" do
         expect(variant.default_price.amount).to eq(19.99)
-        variant.prices << create(:price, variant: variant, currency: "USD", amount: 12.12)
+        variant.prices.create(currency: "USD", amount: 12.12)
         expect(variant.reload.default_price.amount).to eq(12.12)
       end
     end
@@ -194,7 +193,7 @@ describe Spree::Variant, type: :model do
 
   describe '.price_in' do
     before do
-      variant.prices << create(:price, variant: variant, currency: "EUR", amount: 33.33)
+      variant.prices.create(currency: "EUR", amount: 33.33)
     end
     subject { variant.price_in(currency).display_amount }
 

--- a/core/spec/support/concerns/default_price.rb
+++ b/core/spec/support/concerns/default_price.rb
@@ -16,6 +16,30 @@ shared_examples_for "default_price" do
     it 'should have the class name of Spree::Price' do
       expect(default_price_association.options[:class_name]).to eql 'Spree::Price'
     end
+
+    context 'when used inside the Spree namespace' do
+      let(:model) { Spree::Variant }
+
+      it 'should have an inverse option without the Spree namespace' do
+        expect(default_price_association.options[:inverse_of]).to eq(:variant)
+      end
+    end
+
+    context 'when used outside of the Spree namespace' do
+      before do
+        module MyStore
+          class Bicycle < ActiveRecord::Base
+            include Spree::DefaultPrice
+          end
+        end
+      end
+
+      let(:model) { MyStore::Bicycle }
+
+      it 'should have an inverse option without its namespace' do
+        expect(default_price_association.options[:inverse_of]).to eq(:bicycle)
+      end
+    end
   end
 
   describe '#default_price' do


### PR DESCRIPTION
This is to replace the `is_default` boolean on prices. 

That boolean governed what price would be currently valid. I'd like to replace that with logic that can tell you what price a variant was at any given point. In order to do that, I introduce a `valid_from` field, which defaults to the time the price is created and indefinitely valid afterwards. There is no `valid_until` field because the product has `available_until` and we don't want to run into a product ever *not* having a price. 

@gmacdougall mentioned that this might have caching implications. @jhawthorn Please also have a look at this. 