### PR TITLE
Add LegacyLineItemPricer

### DIFF
--- a/core/app/models/spree/prices/legacy_line_item_pricer.rb
+++ b/core/app/models/spree/prices/legacy_line_item_pricer.rb
@@ -1,0 +1,66 @@
+module Spree
+  module Prices
+    # Set price, cost_price and currency for a line item. This class does
+    # all the things from Spree::LineItem related to actually setting the price.
+    # Some of these things are terribly evil and bad, especially the price modifying
+    # options.
+    class LegacyLineItemPricer
+      class VariantRequired < StandardError; end
+      class << self
+        # Modify a line item's prices. If there's no price set or price modifying
+        # options present, change the price to whatever the variant returns. If
+        # the line item already has a price and there is no price modifying options
+        # present, return the item unmodified.
+        # @param [Spree::LineItem] line_item The line item to be modified
+        # @param [Hash] options Arbitrary options for pricing the line item
+        #    If the key `:currency` is set, the line item will be prices in that currency.
+        def set_price_for(line_item, options = {})
+          raise VariantRequired if line_item.variant.blank?
+
+          # If the legacy method #copy_price has been overridden, handle that gracefully
+          return handle_copy_price_override(line_item) if line_item.respond_to?(:copy_price)
+
+          if price_modifiying_options(line_item.variant, options).present?
+            line_item.currency = line_item_currency(line_item, options)
+            line_item.price = line_item_price_with_modifiers(line_item, options)
+          else
+            line_item.currency ||= line_item_currency(line_item, options)
+            line_item.price ||= line_item_price(line_item)
+          end
+
+          line_item
+        end
+
+        protected
+
+        def line_item_price(line_item)
+          line_item.variant.price_in(line_item.currency).amount
+        end
+
+        def line_item_currency(line_item, options)
+          options[:currency] || line_item.order.currency
+        end
+
+        def line_item_price_with_modifiers(line_item, options)
+          line_item_price(line_item) + line_item.variant.price_modifier_amount_in(line_item.currency, options)
+        end
+
+        def price_modifiying_options(variant, options)
+          options.select do |k, _v|
+            modifier_methods = [k.to_s + "_price_modifier_amount", k.to_s + "_price_modifier_amount_in"].map(&:to_sym)
+            modifier_methods & variant.methods
+          end
+        end
+
+        def handle_copy_price_override(line_item)
+          line_item.send(:copy_price)
+          ActiveSupport::Deprecation.warn(
+            'You have overridden Spree::LineItem#copy_price.' \
+            'Please configure a custom Line Item Pricer class for your app.',
+            caller
+          )
+        end
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/prices/legacy_line_item_pricer_spec.rb
+++ b/core/spec/models/spree/prices/legacy_line_item_pricer_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+RSpec.describe Spree::Prices::LegacyLineItemPricer do
+  describe '.set_price_for' do
+    subject { described_class.set_price_for(line_item) }
+
+    it 'responds to .set_price_for' do
+      expect(described_class).to respond_to(:set_price_for)
+    end
+
+    context 'when called with a line item without a variant' do
+      let(:line_item) { Spree::LineItem.new }
+
+      it 'will raise a variant missing error' do
+        expect { subject }.to raise_error(Spree::Prices::LegacyLineItemPricer::VariantRequired)
+      end
+    end
+
+    context 'when called with a line item with a variant' do
+      let(:line_item) { build(:line_item) }
+
+      it 'will return the same line item' do
+        expect(subject.object_id).to eq(line_item.object_id)
+      end
+    end
+
+    context 'when called with a line item without a currency' do
+      let(:line_item) { build(:line_item, currency: nil) }
+
+      it 'will return that line item with the orders currency' do
+        expect(line_item.order.currency).to be_present
+        expect(subject.currency).to eq(line_item.order.currency)
+      end
+    end
+
+    context 'when called with a line item without a price' do
+      let(:line_item) { build(:line_item, price: nil) }
+
+      it 'will return that line item with the variants price' do
+        expect(subject.price).to eq(line_item.variant.price)
+      end
+    end
+
+    context 'when called with a line item that has a price' do
+      let(:line_item) { build(:line_item, price: 20_000) }
+
+      it 'will not change the price of the line item' do
+        expect(line_item.price).to eq(20_000)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This moves setting the price of a line item to a special service object
called a `Pricer`. It supports price modifier options as well as not
changing the line item if no price modifiers are set and a price and
currency are already present.

Previously, the currency of a line item could be obtained from the
variant (which really can't know about the currency of a line item), so
that is newly streamlined into obtaining the currency from the if the
options don't say otherwise.

This is supposed to be a basis for discussion. 

I tried designing the interface of the object in such a way that existing 
`copy_price` overrides could easily be migrated into a `Pricer` object - 
hence the pattern of modifying the line item in-place. 
