### PR TITLE
Conservative line item pricer

### DIFF
--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -69,10 +69,19 @@ module Spree
     alias total final_amount
 
     # @return [Spree::Money] the price of this line item
-    def single_money
+    def money_price
       Spree::Money.new(price, { currency: currency })
     end
-    alias single_display_amount single_money
+    alias single_display_amount money_price
+    alias single_money money_price
+
+    # Sets price and currency from a `Spree::Money` object
+    #
+    # @param [Spree::Money] money - the money object to obtain price and currency from
+    def money_price=(money)
+      self.price = money.to_d
+      self.currency = money.currency.iso_code
+    end
 
     # @return [Spree::Moeny] the amount of this line item
     def money
@@ -133,7 +142,8 @@ module Spree
 
       self.currency ||= order.currency
       self.cost_price ||= variant.cost_price
-      self.price ||= variant.price
+      self.money_price = Pricers::Conservative.new(self).price
+      true
     end
 
     def handle_copy_price_override

--- a/core/app/models/spree/line_item/pricers/abstract.rb
+++ b/core/app/models/spree/line_item/pricers/abstract.rb
@@ -1,0 +1,26 @@
+module Spree
+  class LineItem
+    module Pricers
+      class Abstract
+        class VariantMissing < StandardError; end
+        class CurrencyMissing < StandardError; end
+
+        attr_reader :line_item
+
+        def initialize(line_item)
+          @line_item = line_item
+        end
+
+        def price
+          raise NotImplementedError, "Please implement '#price' in your pricer: #{self.class.name}"
+        end
+
+        private
+
+        def in_line_item_currency(amount)
+          Spree::Money.new(amount, currency: line_item.currency)
+        end
+      end
+    end
+  end
+end

--- a/core/app/models/spree/line_item/pricers/abstract.rb
+++ b/core/app/models/spree/line_item/pricers/abstract.rb
@@ -1,6 +1,16 @@
 module Spree
   class LineItem
+    # Pricers for line items expose `#price`, return a `Spree::Money` object,
+    # and are used to choose or calculate the correct price for a line item.
+    # Ideally, they are idempotent, that is: When run on the same line item, they will return
+    # the same price.
+    #
     module Pricers
+      # The `Abstract` pricer is here for other pricers to inherit from. It defines the common
+      # interface for pricers, as well as two practical errors, `VariantMissing` and
+      # `CurrencyMissing`.
+      #
+      # @attr [Spree::LineItem] The line item to calculate or choose a price for
       class Abstract
         class VariantMissing < StandardError; end
         class CurrencyMissing < StandardError; end
@@ -11,12 +21,18 @@ module Spree
           @line_item = line_item
         end
 
+        # Returns the calculated or chosen price
+        #
+        # @return [Spree::Money] a `Spree::Money` object representing line item's price
         def price
           raise NotImplementedError, "Please implement '#price' in your pricer: #{self.class.name}"
         end
 
         private
 
+        # This helper method converts an amount into a Spree::Money object with the given line
+        # item's currency, and will be needed for most pricers.
+        #
         def in_line_item_currency(amount)
           Spree::Money.new(amount, currency: line_item.currency)
         end

--- a/core/app/models/spree/line_item/pricers/conservative.rb
+++ b/core/app/models/spree/line_item/pricers/conservative.rb
@@ -1,0 +1,30 @@
+module Spree
+  class LineItem
+    module Pricers
+      class Conservative
+        class VariantMissing < StandardError; end
+        class CurrencyMissing < StandardError; end
+
+        attr_reader :line_item
+
+        def initialize(line_item)
+          @line_item = line_item
+        end
+
+        def price
+          raise CurrencyMissing if line_item.currency.blank?
+          return in_line_item_currency(line_item.price) if line_item.price
+
+          raise VariantMissing if line_item.variant.blank?
+          in_line_item_currency(line_item.variant.amount_in(line_item.currency))
+        end
+
+        private
+
+        def in_line_item_currency(amount)
+          Spree::Money.new(amount, currency: line_item.currency)
+        end
+      end
+    end
+  end
+end

--- a/core/app/models/spree/line_item/pricers/conservative.rb
+++ b/core/app/models/spree/line_item/pricers/conservative.rb
@@ -1,7 +1,19 @@
 module Spree
   class LineItem
     module Pricers
+      # A pricer that returns a line items price if it has one, otherwise chooses a fitting
+      # one in the line item's currency.
+      # This pricer's behaviour mimicks pricing behaviour in Solidus 1.2 and earlier (Spree 2.4 and
+      # earlier). The standard pricer in Solidus 1.3 and above will choose the price depending on
+      # the country, and will not necessarily be as conservative about a line item's current price.
+      #
+      # @note If you use price modifiers, you need to use this conservative pricer.
+      #
       class Conservative < Abstract
+        # The new price of the line item.
+        #
+        # @return Spree::Money
+        #
         def price
           raise CurrencyMissing if line_item.currency.blank?
           return in_line_item_currency(line_item.price) if line_item.price

--- a/core/app/models/spree/line_item/pricers/conservative.rb
+++ b/core/app/models/spree/line_item/pricers/conservative.rb
@@ -1,28 +1,13 @@
 module Spree
   class LineItem
     module Pricers
-      class Conservative
-        class VariantMissing < StandardError; end
-        class CurrencyMissing < StandardError; end
-
-        attr_reader :line_item
-
-        def initialize(line_item)
-          @line_item = line_item
-        end
-
+      class Conservative < Abstract
         def price
           raise CurrencyMissing if line_item.currency.blank?
           return in_line_item_currency(line_item.price) if line_item.price
 
           raise VariantMissing if line_item.variant.blank?
           in_line_item_currency(line_item.variant.amount_in(line_item.currency))
-        end
-
-        private
-
-        def in_line_item_currency(amount)
-          Spree::Money.new(amount, currency: line_item.currency)
         end
       end
     end

--- a/core/lib/spree/money.rb
+++ b/core/lib/spree/money.rb
@@ -17,7 +17,7 @@ module Spree
 
     attr_reader :money
 
-    delegate :cents, to: :money
+    delegate :cents, :currency, :to_d, to: :money
 
     # @param amount [#to_s] the value of the money object
     # @param options [Hash] the options for creating the money object

--- a/core/lib/spree/testing_support/factories/line_item_factory.rb
+++ b/core/lib/spree/testing_support/factories/line_item_factory.rb
@@ -12,5 +12,6 @@ FactoryGirl.define do
     variant do
       (product || create(:product)).master
     end
+    currency { order.currency }
   end
 end

--- a/core/spec/models/spree/line_item/pricers/abstract_spec.rb
+++ b/core/spec/models/spree/line_item/pricers/abstract_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+RSpec.describe Spree::LineItem::Pricers::Abstract do
+  let(:line_item) { build_stubbed(:line_item) }
+
+  subject { described_class.new(line_item) }
+
+  it { is_expected.to respond_to(:price) }
+
+  it 'defines two practical errors' do
+    expect(described_class::VariantMissing.ancestors).to include(StandardError)
+    expect(described_class::CurrencyMissing.ancestors).to include(StandardError)
+  end
+
+  it 'assigns line item' do
+    expect(subject.line_item).to eq(line_item)
+  end
+
+  context 'when calling price' do
+    it 'raises a NotImplementedError' do
+      expect { subject.price }.to raise_error(NotImplementedError)
+    end
+  end
+end

--- a/core/spec/models/spree/line_item/pricers/conservative_spec.rb
+++ b/core/spec/models/spree/line_item/pricers/conservative_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+
+RSpec.describe Spree::LineItem::Pricers::Conservative do
+  let(:variant) { build_stubbed(:variant) }
+  let(:currency) { "EUR" }
+  let(:original_price) { 1_000_001.00 }
+  let(:original_money_price) { Spree::Money.new(original_price, currency: currency) }
+  let(:line_item) do
+    build_stubbed(:line_item, price: original_price, variant: variant, currency: currency)
+  end
+
+  subject { described_class.new(line_item).price }
+
+  context 'for a line item that has a price' do
+    let(:original_price) { 1_000_001.00 }
+
+    it { is_expected.to eq(original_money_price) }
+
+    context 'if it has no variant' do
+      let(:variant) { nil }
+
+      it { is_expected.to eq(original_money_price) }
+    end
+
+    context 'if it has no currency' do
+      let(:currency) { nil }
+
+      it 'raises CurrencyMissing' do
+        expect { subject }.to raise_error(described_class::CurrencyMissing)
+      end
+    end
+  end
+
+  context 'for a line item with no price' do
+    let(:original_price) { nil }
+
+    it { is_expected.to eq(Spree::Money.new(line_item.variant.amount_in("USD"), currency: 'USD')) }
+
+    context 'for a line item with no variant' do
+      let(:variant) { nil }
+
+      it 'raises VariantMissing' do
+        expect { subject }.to raise_error(described_class::VariantMissing)
+      end
+    end
+
+    context 'for a line item with no currency' do
+      let(:currency) { nil }
+
+      it 'raises CurrencyMissing' do
+        expect { subject }.to raise_error(described_class::CurrencyMissing)
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -197,8 +197,7 @@ describe Spree::LineItem, type: :model do
     context "currency different than order.currency" do
       it "is not a valid line item" do
         expect(Spree::Deprecation).to receive(:warn).at_least(:once)
-
-        line_item.currency = "no currency"
+        line_item.currency = "RUB"
         line_item.valid?
 
         expect(line_item.error_on(:currency).size).to eq(1)
@@ -221,6 +220,17 @@ describe Spree::LineItem, type: :model do
       expect(line_item.variant).to receive(:gift_wrap_price_modifier_amount_in).with("USD", true).and_return 1.99
       line_item.options = { gift_wrap: true }
       expect(line_item.price).to eq 21.98
+    end
+  end
+
+  describe 'money_price=' do
+    let(:line_item) { Spree::LineItem.new }
+    let(:new_price) { Spree::Money.new(99.00, currency: "RUB") }
+
+    it 'assigns a new price and currency' do
+      line_item.money_price = new_price
+      expect(line_item.price).to eq(new_price.cents / 100.0)
+      expect(line_item.currency).to eq(new_price.currency.iso_code)
     end
   end
 end


### PR DESCRIPTION
This is the pricer that does what `LineItem` does most of the time: Not change anything if there is a price, and if there isn't, take the one from the variant. 

It's modified a little bit so that it would always take the price in the currency from the current order/line item, but otherwise very much the same behaviour. 

Stay tuned for more `Pricers`!