### PR TITLE
Get line item currency from order

### DIFF
--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -136,7 +136,7 @@ module Spree
       # If the legacy method #copy_price has been overridden, handle that gracefully
       return handle_copy_price_override if respond_to?(:copy_price)
 
-      self.currency ||= variant.currency
+      self.currency ||= order.currency
       self.cost_price ||= variant.cost_price
       self.price ||= variant.price
     end


### PR DESCRIPTION
There seems to be a way of obtaining a line item's currency from
it's variant. That doesn't make much sense, as a variant might have
many prices in different currencies, but is not tied to a user or an
order which would know *which* of those currencies to use.
