### PR TITLE
Remove hanging tooltips from removed DOM elements

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/admin.js
+++ b/backend/app/assets/javascripts/spree/backend/admin.js
@@ -15,14 +15,6 @@ Hopefully, this will evolve into a propper class.
 **/
 
 jQuery(function($) {
-  $('body').tooltip({selector: '.with-tip'})
-
-  $('body').on('inserted.bs.tooltip', function(e){
-    var $target = $(e.target);
-    var $tooltip = $("#" + $target.attr("aria-describedby"));
-    $tooltip.addClass("action-" + $target.data("action"));
-  });
-
   // Highlight hovered table column
   $('table').on("mouseenter", 'td.actions a, td.actions button', function(){
     var tr = $(this).closest('tr');

--- a/backend/app/assets/javascripts/spree/backend/components/tooltips.js
+++ b/backend/app/assets/javascripts/spree/backend/components/tooltips.js
@@ -1,8 +1,30 @@
 $(function(){
-  $('body').tooltip({selector: '.with-tip'})
+  $('body').tooltip({selector: '.with-tip'});
+
+  /*
+   * Poll tooltips to hide them if they are no longer being hovered.
+   *
+   * This is necessary to fix tooltips hanging around after their attached
+   * element has been removed from the DOM (and will therefore receive no
+   * mouseleave event). This may be unnecessary in a future version of
+   * bootstrap, which intends to solve this using MutationObserver.
+   */
+  var removeDesyncedTooltip = function(tooltip) {
+    var interval = setInterval(function(){
+      if(!$(tooltip.element).is(":hover")) {
+        tooltip.hide();
+        clearInterval(interval);
+      }
+    }, 200);
+    $(tooltip.element).on('hidden.bs.tooltip', function(){
+      clearInterval(interval);
+    });
+  };
 
   $('body').on('inserted.bs.tooltip', function(e){
     var $target = $(e.target);
+    var tooltip = $target.data('bs.tooltip');
+    removeDesyncedTooltip(tooltip);
     var $tooltip = $("#" + $target.attr("aria-describedby"));
     $tooltip.addClass("action-" + $target.data("action"));
   });

--- a/backend/app/assets/javascripts/spree/backend/components/tooltips.js
+++ b/backend/app/assets/javascripts/spree/backend/components/tooltips.js
@@ -1,0 +1,9 @@
+$(function(){
+  $('body').tooltip({selector: '.with-tip'})
+
+  $('body').on('inserted.bs.tooltip', function(e){
+    var $target = $(e.target);
+    var $tooltip = $("#" + $target.attr("aria-describedby"));
+    $tooltip.addClass("action-" + $target.data("action"));
+  });
+});

--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -272,13 +272,6 @@ var ShipmentEditView = Backbone.View.extend({
   cancelItemSplit: function(e){
     e.preventDefault();
 
-    /* We are removing this row including the currently hovered button, which
-     * gives no opportunity for events to fire.
-     * We must trigger them manually to ensure the tooltip is destroyed and the
-     * table colours are restored.
-     */
-    $(e.target).mouseleave().tooltip("hide");
-
     this.$('tr.stock-item-split').remove();
     this.$('a.split-item').show();
     this.$('a.delete-item').show();


### PR DESCRIPTION
This is a bit of a hack, but I don't know of a better alternative, and it's fairly self-contained.

When a DOM element is removed, any associated tooltips will remain on the page permanently, because the element will never receive the `mouseleave` event. Our previous tooltip solution, powerTip, [solved this using polling](https://github.com/stevenbenner/jquery-powertip/blob/dc5972bcbbd4229043bb1cf42ab7004c8846277e/src/tooltipcontroller.js#L359-L399). This does the same.

Hiding these tooltips when we remove elements isn't feasible because it's too common for us to remove elements from the DOM (both due to removal and re-rendering mustache templates).

It's possible this will be unnecessary in a future version of bootstrap, as they're planning to investigate using the new MutationObserver API to detect these changes to the DOM.