### PR TITLE
Replace ul/li-s with a div, place weight last

### DIFF
--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -97,24 +97,24 @@
         <% end %>
       </div>
 
-      <ul id="shipping_specs">
-        <li id="shipping_specs_weight_field" data-hook="admin_product_form_weight" class="field alpha two columns">
-          <%= f.label :weight %>
-          <%= f.text_field :weight, :size => 4 %>
-        </li>
-        <li id="shipping_specs_height_field" data-hook="admin_product_form_height" class="field omega two columns">
+      <div id="shipping_specs">
+        <div id="shipping_specs_height_field" data-hook="admin_product_form_height" class="field alpha two columns">
           <%= f.label :height %>
           <%= f.text_field :height, :size => 4 %>
-        </li>
-        <li id="shipping_specs_width_field" data-hook="admin_product_form_width" class="field alpha two columns">
+        </div>
+        <div id="shipping_specs_width_field" data-hook="admin_product_form_width" class="field omega two columns">
           <%= f.label :width %>
           <%= f.text_field :width, :size => 4 %>
-        </li>
-        <li id="shipping_specs_depth_field" data-hook="admin_product_form_depth" class="field omega two columns">
+        </div>
+        <div id="shipping_specs_depth_field" data-hook="admin_product_form_depth" class="field alpha two columns">
           <%= f.label :depth %>
           <%= f.text_field :depth, :size => 4 %>
-        </li>
-      </ul>
+        </div>
+        <div id="shipping_specs_weight_field" data-hook="admin_product_form_weight" class="field omega two columns">
+          <%= f.label :weight %>
+          <%= f.text_field :weight, :size => 4 %>
+        </div>
+      </div>
     <% end %>
 
     <div data-hook="admin_product_form_shipping_categories">


### PR DESCRIPTION
This commit replaces use of ul/li-s on the product form with plain
divs, achieving a much nicer visual layout for the product height/
width/depth/weight fields, which were previously clunky and misaligned.

The weight field has been moved from the 1st to the 4th position,
for improved intuitiveness in the new layout.

How it looked before:

![before](https://cloud.githubusercontent.com/assets/112993/13898539/20b037f2-edd5-11e5-80ce-8e73184fb199.png)

How it looks now:

![after](https://cloud.githubusercontent.com/assets/112993/13898541/242f5584-edd5-11e5-9dfe-be13da6026ba.png)