### PR TITLE
Remove Line Item currency attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Solidus 1.3.0 (unreleased)
 
+*   Remove currency attribute on `Spree::LineItem`
+
+    A valid line item always has its order's currency. Therefore it is not necessary to save
+    that in the database.
+
 *   Taxes for carts now configurable via the `Spree::Store` object
 
     In VAT countries, carts (orders without addresses) have to be shown with

--- a/core/app/models/spree/order_contents.rb
+++ b/core/app/models/spree/order_contents.rb
@@ -1,6 +1,6 @@
 module Spree
   class OrderContents
-    attr_accessor :order, :currency
+    attr_accessor :order
 
     def initialize(order)
       @order = order
@@ -79,17 +79,19 @@ module Spree
     def add_to_line_item(variant, quantity, options = {})
       line_item = grab_line_item_by_variant(variant, false, options)
 
-      if line_item
-        line_item.quantity += quantity.to_i
-        line_item.currency = currency unless currency.nil?
-      else
-        opts = { currency: order.currency }.merge ActionController::Parameters.new(options).permit(PermittedAttributes.line_item_attributes).to_h
-        line_item = order.line_items.new(quantity: quantity,
-                                          variant: variant,
-                                          options: opts)
+      line_item ||= order.line_items.new(
+        quantity: 0,
+        variant: variant
+      )
+
+      line_item.quantity += quantity.to_i
+      line_item.options = ActionController::Parameters.new(options).permit(PermittedAttributes.line_item_attributes)
+
+      if line_item.new_record?
         create_order_stock_locations(line_item, options[:stock_location_quantities])
       end
-      line_item.target_shipment = options[:shipment] if options.key? :shipment
+
+      line_item.target_shipment = options[:shipment]
       line_item.save!
       line_item
     end

--- a/core/db/migrate/20160320190803_remove_currency_from_line_item.rb
+++ b/core/db/migrate/20160320190803_remove_currency_from_line_item.rb
@@ -1,0 +1,5 @@
+class RemoveCurrencyFromLineItem < ActiveRecord::Migration
+  def change
+    remove_column :spree_line_items, :currency, :string
+  end
+end


### PR DESCRIPTION
Somehow, in the past, it was possible to have orders with line items
in multiple currencies. The code to remedy this (Order#homogenize_line_item_currencies)
disappeared in #635, and now we have a bunch of code in different places
that allows setting it, raises errors if it's not there, and so on.

This commit delegates the line items currency to the order.
Whenever people try *setting* a line item's currency, they get a
pretty deprecation warning telling them not to do so.

The error handling functionality that seems to be used in the order
importer is still present (ie: If we know an imported line item has
a currency different from the order, we'll error out).

This commit replaces all that behaviour with a simple delegate that
always obtains a line item's currency from it's order.

Adds a changelog entry.

I also refactored `OrderContents#add_to_line_item`, taking code from
MountainRoseHerbs/spree@461f975.

That method should now be much easier to understand.

