### PR TITLE
Introduce PriceModifierLineItemPricer

### DIFF
--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -103,16 +103,9 @@ module Spree
     # @param options [Hash] options for this line item
     def options=(options = {})
       return unless options.present?
-
-      opts = options.dup # we will be deleting from the hash, so leave the caller's copy intact
-
-      currency = opts.delete(:currency) || order.currency
-
-      self.currency = currency
-      self.price    = variant.price_in(currency).amount +
-        variant.price_modifier_amount_in(currency, opts)
-
-      assign_attributes opts
+      self.currency ||= options[:currency]
+      self.price = Spree::Pricers::PriceModifierLineItemPricer.new(self, options).price
+      assign_attributes(options)
     end
 
     private

--- a/core/app/models/spree/pricers/price_modifier_line_item_pricer.rb
+++ b/core/app/models/spree/pricers/price_modifier_line_item_pricer.rb
@@ -1,0 +1,39 @@
+module Spree
+  module Pricers
+    # This class implements an extension point previously defined on Spree::LineItem
+    # for customizing pricing from extensions. This extension point is currently used
+    # in the following Spree extensions:
+    #
+    # * https://github.com/godaddy/spree_product_sale
+    # * https://github.com/v-may/spree_simple_sales
+    #
+    # @attr_reader [Spree::LineItem] line_item The line item to find a price for
+    # @attr_reader [Hash] options Options that would modify the price, such as { gift_wrap: true }
+    # @deprecated The extension point, as far as I can overview, needs the following to work:
+    #
+    #   - `*_price_modifier_amount_in` methods defined on the variant
+    #   - Fitting `*` methods on `Spree::LineItem`
+    #   - The Line Item to accept those methods as attributes
+    #
+    #   That's a rather complex way of customizing pricing, maybe write a pricer instead.
+    class PriceModifierLineItemPricer
+      class VariantMissing < StandardError; end
+      class CurrencyMissing < StandardError; end
+
+      attr_reader :line_item, :options
+      delegate :currency, :variant, to: :line_item
+
+      def initialize(line_item, options = {})
+        @line_item = line_item
+        @options = options
+      end
+
+      # @return [Float] New price for a line item
+      def price
+        raise VariantMissing if variant.blank?
+        raise CurrencyMissing if currency.blank?
+        variant.price_in(currency).amount + variant.price_modifier_amount_in(currency, options)
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/pricers/price_modifier_line_item_pricer_spec.rb
+++ b/core/spec/models/spree/pricers/price_modifier_line_item_pricer_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+RSpec.describe Spree::Pricers::PriceModifierLineItemPricer do
+  let(:variant) { create(:variant) }
+  let(:currency) { "USD" }
+  let(:original_price) { 12.34 }
+  let(:options) { {} }
+  let(:line_item) do
+    build(:line_item, variant: variant, currency: currency, price: original_price)
+  end
+
+  subject { described_class.new(line_item, options).price }
+
+  context 'with no variant present' do
+    let(:variant) { nil }
+
+    it 'raises VariantMissing' do
+      expect { subject }.to raise_error(described_class::VariantMissing)
+    end
+  end
+
+  context 'with no currency present' do
+    let(:currency) { nil }
+
+    it 'raises CurrencyMissing' do
+      expect { subject }.to raise_error(described_class::CurrencyMissing)
+    end
+  end
+
+  shared_examples_for 'it prices the line item no matter what' do
+    it 'returns the variant price in USD' do
+      expect(subject).to eq(variant.price)
+    end
+
+    context 'with price modifiers in the options' do
+      let(:options) { { gift_wrap: true } }
+
+      before do
+        expect(variant).to receive(:gift_wrap_price_modifier_amount_in).with(currency, true).and_return(2.00)
+      end
+
+      it 'returns the variant price plus price modifiers' do
+        expect(subject).to eq(variant.price + 2)
+      end
+    end
+  end
+
+  context 'with no price present' do
+    let(:original_price) { nil }
+
+    it_behaves_like 'it prices the line item no matter what'
+  end
+
+  context 'with a price present' do
+    it_behaves_like 'it prices the line item no matter what'
+  end
+end


### PR DESCRIPTION
There is an extension point for modifying the price of a line item
that is used in the following extensions:

* https://github.com/godaddy/spree_product_sale
* https://github.com/v-may/spree_simple_sales

This extension point introduces some rather interesting code to
Spree::LineItem, which this commit extracts to a pricer object.

The extension point, as far as I can overview, needs the following to work:

- `*_price_modifier_amount_in` methods defined on the variant
- Fitting `*` methods on `Spree::LineItem`
- The Line Item to accept those methods as params

This commit extracts that code from Spree::LineItem, with the intention
of providing an example for how to write a custom pricer as well as with
the intention to remove this pricer and the associated extension point by
Solidus 2.0.