### PR TITLE
Stock management js cleanup

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/stock_management/index.coffee
+++ b/backend/app/assets/javascripts/spree/backend/stock_management/index.coffee
@@ -1,3 +1,0 @@
-$(document).ready ->
-  return unless $('#listing_product_stock').length > 0
-  Spree.StockManagement.IndexAddForms.beginListening()

--- a/backend/app/assets/javascripts/spree/backend/stock_management/index.coffee
+++ b/backend/app/assets/javascripts/spree/backend/stock_management/index.coffee
@@ -1,4 +1,3 @@
 $(document).ready ->
   return unless $('#listing_product_stock').length > 0
   Spree.StockManagement.IndexAddForms.beginListening()
-  Spree.StockManagement.IndexUpdateForms.beginListening()

--- a/backend/app/assets/javascripts/spree/backend/stock_management/index_add_forms.coffee
+++ b/backend/app/assets/javascripts/spree/backend/stock_management/index_add_forms.coffee
@@ -5,7 +5,7 @@ Spree.AddStockItemView = Backbone.View.extend
     @$backorderable = @$("[name='backorderable']")
 
   events:
-    "click .fa-plus": "onSubmit"
+    "click .submit": "onSubmit"
 
   validate: ->
     locationSelectContainer = @$locationSelect.siblings('.select2-container')

--- a/backend/app/assets/javascripts/spree/backend/stock_management/index_add_forms.coffee
+++ b/backend/app/assets/javascripts/spree/backend/stock_management/index_add_forms.coffee
@@ -29,7 +29,7 @@ Spree.AddStockItemView = Backbone.View.extend
     selectedStockLocationOption.remove()
 
     rowTemplate = HandlebarsTemplates['stock_items/stock_location_stock_item']
-    newRow = @$el.before(
+    newRow = $(
       rowTemplate
         id: @model.get('id')
         variantId: @model.get('variant_id')
@@ -37,7 +37,7 @@ Spree.AddStockItemView = Backbone.View.extend
         stockLocationName: stockLocationName
         countOnHand: @model.get('count_on_hand')
         backorderable: @model.get('backorderable')
-    )
+    ).insertBefore(@$el)
 
     new Spree.EditStockItemView
       el: newRow

--- a/backend/app/assets/javascripts/spree/backend/stock_management/index_add_forms.coffee
+++ b/backend/app/assets/javascripts/spree/backend/stock_management/index_add_forms.coffee
@@ -28,20 +28,10 @@ Spree.AddStockItemView = Backbone.View.extend
     stockLocationName = selectedStockLocationOption.text().trim()
     selectedStockLocationOption.remove()
 
-    rowTemplate = HandlebarsTemplates['stock_items/stock_location_stock_item']
-    newRow = $(
-      rowTemplate
-        id: @model.get('id')
-        variantId: @model.get('variant_id')
-        stockLocationId: @model.get('stock_location_id')
-        stockLocationName: stockLocationName
-        countOnHand: @model.get('count_on_hand')
-        backorderable: @model.get('backorderable')
-    ).insertBefore(@$el)
-
-    new Spree.EditStockItemView
-      el: newRow
+    editView = new Spree.EditStockItemView
       model: @model
+      stockLocationName: stockLocationName
+    editView.$el.insertBefore(@$el)
 
     @model = new Spree.StockItem
       variant_id: @model.get('variant_id')

--- a/backend/app/assets/javascripts/spree/backend/stock_management/index_add_forms.coffee
+++ b/backend/app/assets/javascripts/spree/backend/stock_management/index_add_forms.coffee
@@ -1,13 +1,6 @@
-resetErrors = (locationSelectContainer, countInput) ->
-  countInput.removeClass('error')
-  locationSelectContainer.removeClass('error')
-
 validate = (locationSelect, locationSelectContainer, countInput) ->
-  if !locationSelect.val()
-    locationSelectContainer.addClass('error')
-
-  if !countInput.val()
-    countInput.addClass('error')
+  locationSelectContainer.toggleClass('error', !locationSelect.val())
+  countInput.toggleClass('error', !countInput.val())
 
 hasErrors = (locationSelectContainer, countInput) ->
   locationSelectContainer.hasClass('error') or countInput.hasClass('error')
@@ -67,7 +60,6 @@ AddStockItemView = Backbone.View.extend
     countInput = @$("[name='count_on_hand']")
     locationSelect = @$("[name='stock_location_id']")
     locationSelectContainer = locationSelect.siblings('.select2-container')
-    resetErrors(locationSelectContainer, countInput)
     validate(locationSelect, locationSelectContainer, countInput)
     return if hasErrors(locationSelectContainer, countInput)
 

--- a/backend/app/assets/javascripts/spree/backend/stock_management/index_add_forms.coffee
+++ b/backend/app/assets/javascripts/spree/backend/stock_management/index_add_forms.coffee
@@ -63,25 +63,22 @@ AddStockItemView = Backbone.View.extend
 
   onSubmit: (ev) ->
     ev.preventDefault()
-    variantId = $(ev.currentTarget).data('variant-id')
-    countInput = $("#variant-count-on-hand-#{variantId}")
-    locationSelect = $("#variant-stock-location-#{variantId}")
+    variantId = @model.get('variant_id')
+    countInput = @$("[name='count_on_hand']")
+    locationSelect = @$("[name='stock_location_id']")
     locationSelectContainer = locationSelect.siblings('.select2-container')
     resetErrors(locationSelectContainer, countInput)
     validate(locationSelect, locationSelectContainer, countInput)
     return if hasErrors(locationSelectContainer, countInput)
 
-    stockLocationId = locationSelect.val()
-    backorderable = $("#variant-backorderable-#{variantId}").prop("checked")
-    stockItem = new Spree.StockItem
-      variant_id: variantId
-      backorderable: backorderable
+    @model.set
+      backorderable: @$("[name='backorderable']").prop("checked")
       count_on_hand: countInput.val()
-      stock_location_id: stockLocationId
+      stock_location_id: locationSelect.val()
     options =
       success: successHandler
       error: errorHandler
-    stockItem.save(null, options)
+    @model.save(null, options)
 
 $ ->
   $('.js-add-stock-item').each ->

--- a/backend/app/assets/javascripts/spree/backend/stock_management/index_add_forms.coffee
+++ b/backend/app/assets/javascripts/spree/backend/stock_management/index_add_forms.coffee
@@ -17,7 +17,7 @@ successHandler = (model, response, options) =>
       countOnHand: model.get('count_on_hand')
       backorderable: model.get('backorderable')
   )
-  resetTableRowStyling(variantId)
+  updateParentTable(variantId)
 
   if stockLocationSelect.find('option').length is 1 # blank value
     stockLocationSelect.parents('tr:first').remove()
@@ -26,22 +26,19 @@ successHandler = (model, response, options) =>
     $("#variant-count-on-hand-#{variantId}").val("")
     $("#variant-backorderable-#{variantId}").prop("checked", false)
 
-  resetParentRowspan(variantId)
   show_flash("success", Spree.translations.created_successfully)
 
 errorHandler = (model, response, options) =>
   show_flash("error", response.responseText)
 
-resetTableRowStyling = (variantId) ->
+updateParentTable = (variantId) ->
   tableRows = $("tr[data-variant-id='#{variantId}']")
   tableRows.removeClass('even odd')
   for i in [0..tableRows.length]
     rowClass = if (i + 1) % 2 is 0 then 'even' else 'odd'
     tableRows.eq(i).addClass(rowClass)
 
-resetParentRowspan = (variantId) ->
-  newRowspan = $("tr[data-variant-id='#{variantId}']").length + 1
-  $("#spree_variant_#{variantId} > td").attr('rowspan', newRowspan)
+  $("#spree_variant_#{variantId} > td").attr('rowspan', tableRows.length + 1)
 
 AddStockItemView = Backbone.View.extend
   initialize: ->

--- a/backend/app/assets/javascripts/spree/backend/stock_management/index_add_forms.coffee
+++ b/backend/app/assets/javascripts/spree/backend/stock_management/index_add_forms.coffee
@@ -51,22 +51,24 @@ resetParentRowspan = (variantId) ->
   $("#spree_variant_#{variantId} > td").attr('rowspan', newRowspan)
 
 AddStockItemView = Backbone.View.extend
+  initialize: ->
+    @$countInput = @$("[name='count_on_hand']")
+    @$locationSelect = @$("[name='stock_location_id']")
+    @$backorderable = @$("[name='backorderable']")
+
   events:
     "click .fa-plus": "onSubmit"
 
   onSubmit: (ev) ->
     ev.preventDefault()
-    variantId = @model.get('variant_id')
-    countInput = @$("[name='count_on_hand']")
-    locationSelect = @$("[name='stock_location_id']")
-    locationSelectContainer = locationSelect.siblings('.select2-container')
-    validate(locationSelect, locationSelectContainer, countInput)
-    return if hasErrors(locationSelectContainer, countInput)
+    locationSelectContainer = @$locationSelect.siblings('.select2-container')
+    validate(@$locationSelect, locationSelectContainer, @$countInput)
+    return if hasErrors(locationSelectContainer, @$countInput)
 
     @model.set
-      backorderable: @$("[name='backorderable']").prop("checked")
-      count_on_hand: countInput.val()
-      stock_location_id: locationSelect.val()
+      backorderable: @$backorderable.prop("checked")
+      count_on_hand: @$countInput.val()
+      stock_location_id: @$locationSelect.val()
     options =
       success: successHandler
       error: errorHandler

--- a/backend/app/assets/javascripts/spree/backend/stock_management/index_add_forms.coffee
+++ b/backend/app/assets/javascripts/spree/backend/stock_management/index_add_forms.coffee
@@ -3,10 +3,10 @@ resetErrors = (locationSelectContainer, countInput) ->
   locationSelectContainer.removeClass('error')
 
 validate = (locationSelect, locationSelectContainer, countInput) ->
-  if locationSelect.val() is ""
+  if !locationSelect.val()
     locationSelectContainer.addClass('error')
 
-  if isNaN(parseInt(countInput.val(), 10))
+  if !countInput.val()
     countInput.addClass('error')
 
 hasErrors = (locationSelectContainer, countInput) ->

--- a/backend/app/assets/javascripts/spree/backend/stock_management/index_add_forms.coffee
+++ b/backend/app/assets/javascripts/spree/backend/stock_management/index_add_forms.coffee
@@ -1,10 +1,3 @@
-updateParentTable = (variantId) ->
-  tableRows = $("tr[data-variant-id='#{variantId}']")
-  tableRows.removeClass('even odd')
-  for i in [0..tableRows.length]
-    rowClass = if (i + 1) % 2 is 0 then 'even' else 'odd'
-    tableRows.eq(i).addClass(rowClass)
-
 Spree.AddStockItemView = Backbone.View.extend
   initialize: ->
     @$countInput = @$("[name='count_on_hand']")
@@ -41,8 +34,6 @@ Spree.AddStockItemView = Backbone.View.extend
       @$locationSelect.select2()
       @$countInput.val("")
       @$backorderable.prop("checked", false)
-
-    updateParentTable(@model.get('variant_id'))
 
   onSubmit: (ev) ->
     ev.preventDefault()

--- a/backend/app/assets/javascripts/spree/backend/stock_management/index_add_forms.coffee
+++ b/backend/app/assets/javascripts/spree/backend/stock_management/index_add_forms.coffee
@@ -5,8 +5,6 @@ updateParentTable = (variantId) ->
     rowClass = if (i + 1) % 2 is 0 then 'even' else 'odd'
     tableRows.eq(i).addClass(rowClass)
 
-  $("#spree_variant_#{variantId} > td").attr('rowspan', tableRows.length + 1)
-
 Spree.AddStockItemView = Backbone.View.extend
   initialize: ->
     @$countInput = @$("[name='count_on_hand']")

--- a/backend/app/assets/javascripts/spree/backend/stock_management/index_add_forms.coffee
+++ b/backend/app/assets/javascripts/spree/backend/stock_management/index_add_forms.coffee
@@ -1,10 +1,3 @@
-validate = (locationSelect, locationSelectContainer, countInput) ->
-  locationSelectContainer.toggleClass('error', !locationSelect.val())
-  countInput.toggleClass('error', !countInput.val())
-
-hasErrors = (locationSelectContainer, countInput) ->
-  locationSelectContainer.hasClass('error') or countInput.hasClass('error')
-
 successHandler = (model, response, options) =>
   variantId = model.get('variant_id')
   stockLocationId = model.get('stock_location_id')
@@ -59,11 +52,16 @@ AddStockItemView = Backbone.View.extend
   events:
     "click .fa-plus": "onSubmit"
 
+  validate: ->
+    locationSelectContainer = @$locationSelect.siblings('.select2-container')
+    locationSelectContainer.toggleClass('error', !@$locationSelect.val())
+    @$countInput.toggleClass('error', !@$countInput.val())
+
+    locationSelectContainer.hasClass('error') || @$countInput.hasClass('error')
+
   onSubmit: (ev) ->
     ev.preventDefault()
-    locationSelectContainer = @$locationSelect.siblings('.select2-container')
-    validate(@$locationSelect, locationSelectContainer, @$countInput)
-    return if hasErrors(locationSelectContainer, @$countInput)
+    return if @validate()
 
     @model.set
       backorderable: @$backorderable.prop("checked")

--- a/backend/app/assets/javascripts/spree/backend/stock_management/index_add_forms.coffee
+++ b/backend/app/assets/javascripts/spree/backend/stock_management/index_add_forms.coffee
@@ -13,11 +13,14 @@ class IndexAddForms
       stockLocationId = locationSelect.val()
       backorderable = $("#variant-backorderable-#{variantId}").prop("checked")
       stockItem = new Spree.StockItem
-        variantId: variantId
+        variant_id: variantId
         backorderable: backorderable
-        countOnHand: countInput.val()
-        stockLocationId: stockLocationId
-      stockItem.save(successHandler, errorHandler)
+        count_on_hand: countInput.val()
+        stock_location_id: stockLocationId
+      options =
+        success: successHandler
+        error: errorHandler
+      stockItem.save(null, options)
 
   resetErrors = (locationSelectContainer, countInput) ->
     countInput.removeClass('error')
@@ -33,9 +36,9 @@ class IndexAddForms
   hasErrors = (locationSelectContainer, countInput) ->
     locationSelectContainer.hasClass('error') or countInput.hasClass('error')
 
-  successHandler = (stockItem) =>
-    variantId = stockItem.variant_id
-    stockLocationId = stockItem.stock_location_id
+  successHandler = (model, response, options) =>
+    variantId = model.get('variant_id')
+    stockLocationId = model.get('stock_location_id')
     stockLocationSelect = $("#variant-stock-location-#{variantId}")
 
     selectedStockLocationOption = stockLocationSelect.find("option[value='#{stockLocationId}']")
@@ -45,12 +48,12 @@ class IndexAddForms
     rowTemplate = HandlebarsTemplates['stock_items/stock_location_stock_item']
     $("tr[data-variant-id='#{variantId}']:last").before(
       rowTemplate
-        id: stockItem.id
+        id: model.get('id')
         variantId: variantId
         stockLocationId: stockLocationId
         stockLocationName: stockLocationName
-        countOnHand: stockItem.count_on_hand
-        backorderable: stockItem.backorderable
+        countOnHand: model.get('count_on_hand')
+        backorderable: model.get('backorderable')
     )
     resetTableRowStyling(variantId)
 
@@ -64,8 +67,8 @@ class IndexAddForms
     resetParentRowspan(variantId)
     show_flash("success", Spree.translations.created_successfully)
 
-  errorHandler = (errorData) =>
-    show_flash("error", errorData.responseText)
+  errorHandler = (model, response, options) =>
+    show_flash("error", response.responseText)
 
   resetTableRowStyling = (variantId) ->
     tableRows = $("tr[data-variant-id='#{variantId}']")

--- a/backend/app/assets/javascripts/spree/backend/stock_management/index_update_forms.coffee
+++ b/backend/app/assets/javascripts/spree/backend/stock_management/index_update_forms.coffee
@@ -44,15 +44,13 @@ EditStockItemView = Backbone.View.extend
     backorderable = $("#backorderable-#{stockItemId}").prop("checked")
     countOnHand = parseInt($("#number-update-#{stockItemId} input[type='number']").val(), 10)
 
-    stockItem = new Spree.StockItem
-      id: stockItemId
+    @model.set
       count_on_hand: countOnHand
       backorderable: backorderable
-      stock_location_id: stockLocationId
     options =
       success: successHandler
       error: errorHandler
-    stockItem.save(force: true, options)
+    @model.save(force: true, options)
 
 $ ->
   $('.js-edit-stock-item').each ->

--- a/backend/app/assets/javascripts/spree/backend/stock_management/index_update_forms.coffee
+++ b/backend/app/assets/javascripts/spree/backend/stock_management/index_update_forms.coffee
@@ -9,7 +9,7 @@ restoreBackorderableState = (stockItemId) ->
 
 successHandler = (model, response, options) =>
   toggleBackorderable(model.get('id'), false)
-  Spree.NumberFieldUpdater.successHandler(model.get('id'), model.get('count_on_hand'))
+  Spree.NumberFieldUpdater.successHandler(model.id, model.get('count_on_hand'))
   show_flash("success", Spree.translations.updated_successfully)
 
 errorHandler = (model, response, options) ->
@@ -24,7 +24,7 @@ EditStockItemView = Backbone.View.extend
   onEdit: (ev) ->
     ev.preventDefault()
     @$('[name=backorderable]').prop('disabled', false)
-    stockItemId = $(ev.currentTarget).data('id')
+    stockItemId = @model.id
     storeBackorderableState(stockItemId)
     Spree.NumberFieldUpdater.hideReadOnly(stockItemId)
     Spree.NumberFieldUpdater.showForm(stockItemId)
@@ -32,14 +32,14 @@ EditStockItemView = Backbone.View.extend
   onCancel: (ev) ->
     ev.preventDefault()
     @$('[name=backorderable]').prop('disabled', true)
-    stockItemId = $(ev.currentTarget).data('id')
+    stockItemId = @model.id
     restoreBackorderableState(stockItemId)
     Spree.NumberFieldUpdater.hideForm(stockItemId)
     Spree.NumberFieldUpdater.showReadOnly(stockItemId)
 
   onSubmit: (ev) ->
     ev.preventDefault()
-    stockItemId = $(ev.currentTarget).data('id')
+    stockItemId = @model.id
     stockLocationId = $(ev.currentTarget).data('location-id')
     backorderable = $("#backorderable-#{stockItemId}").prop("checked")
     countOnHand = parseInt($("#number-update-#{stockItemId} input[type='number']").val(), 10)
@@ -56,5 +56,8 @@ EditStockItemView = Backbone.View.extend
 
 $ ->
   $('.js-edit-stock-item').each ->
+    $el = $(this)
+    model = new Spree.StockItem($el.data('stock-item'))
     new EditStockItemView
-      el: this
+      el: $el
+      model: model

--- a/backend/app/assets/javascripts/spree/backend/stock_management/index_update_forms.coffee
+++ b/backend/app/assets/javascripts/spree/backend/stock_management/index_update_forms.coffee
@@ -1,67 +1,70 @@
-class IndexUpdateForms
-  @beginListening: ->
-    # Edit
-    $('body').on 'click', '#listing_product_stock .fa-edit', (ev) =>
-      ev.preventDefault()
-      stockItemId = $(ev.currentTarget).data('id')
-      storeBackorderableState(stockItemId)
-      Spree.NumberFieldUpdater.hideReadOnly(stockItemId)
-      showEditForm(stockItemId)
+showReadOnlyElements = (stockItemId) ->
+  toggleBackorderable(stockItemId, false)
+  Spree.NumberFieldUpdater.showReadOnly(stockItemId)
 
-    # Cancel
-    $('body').on 'click', '#listing_product_stock .fa-void', (ev) =>
-      ev.preventDefault()
-      stockItemId = $(ev.currentTarget).data('id')
-      restoreBackorderableState(stockItemId)
-      Spree.NumberFieldUpdater.hideForm(stockItemId)
-      showReadOnlyElements(stockItemId)
+showEditForm = (stockItemId) ->
+  toggleBackorderable(stockItemId, true)
+  Spree.NumberFieldUpdater.showForm(stockItemId)
 
-    # Submit
-    $('body').on 'click', '#listing_product_stock .fa-check', (ev) =>
-      ev.preventDefault()
-      stockItemId = $(ev.currentTarget).data('id')
-      stockLocationId = $(ev.currentTarget).data('location-id')
-      backorderable = $("#backorderable-#{stockItemId}").prop("checked")
-      countOnHand = parseInt($("#number-update-#{stockItemId} input[type='number']").val(), 10)
+toggleBackorderable = (stockItemId, show) ->
+  disabledValue = if show then null else 'disabled'
+  $("#backorderable-#{stockItemId}").prop('disabled', disabledValue)
 
-      stockItem = new Spree.StockItem
-        id: stockItemId
-        count_on_hand: countOnHand
-        backorderable: backorderable
-        stock_location_id: stockLocationId
-      options =
-        success: successHandler
-        error: errorHandler
-      stockItem.save(force: true, options)
+storeBackorderableState = (stockItemId) ->
+  backorderableCheckbox = $("#backorderable-#{stockItemId}")
+  backorderableCheckbox.parent('td').attr('was-checked', backorderableCheckbox.prop('checked'))
 
-  showReadOnlyElements = (stockItemId) ->
-    toggleBackorderable(stockItemId, false)
-    Spree.NumberFieldUpdater.showReadOnly(stockItemId)
+restoreBackorderableState = (stockItemId) ->
+  backorderableCheckbox = $("#backorderable-#{stockItemId}")
+  checked = backorderableCheckbox.parent('td').attr('was-checked') is "true"
+  backorderableCheckbox.prop('checked', checked)
 
-  showEditForm = (stockItemId) ->
-    toggleBackorderable(stockItemId, true)
-    Spree.NumberFieldUpdater.showForm(stockItemId)
+successHandler = (model, response, options) =>
+  toggleBackorderable(model.get('id'), false)
+  Spree.NumberFieldUpdater.successHandler(model.get('id'), model.get('count_on_hand'))
+  show_flash("success", Spree.translations.updated_successfully)
 
-  toggleBackorderable = (stockItemId, show) ->
-    disabledValue = if show then null else 'disabled'
-    $("#backorderable-#{stockItemId}").prop('disabled', disabledValue)
+errorHandler = (model, response, options) ->
+  show_flash("error", response.responseText)
 
-  storeBackorderableState = (stockItemId) ->
-    backorderableCheckbox = $("#backorderable-#{stockItemId}")
-    backorderableCheckbox.parent('td').attr('was-checked', backorderableCheckbox.prop('checked'))
+EditStockItemView = Backbone.View.extend
+  events:
+    "click .fa-edit":  "onEdit"
+    "click .fa-check": "onSubmit"
+    "click .fa-void":  "onCancel"
 
-  restoreBackorderableState = (stockItemId) ->
-    backorderableCheckbox = $("#backorderable-#{stockItemId}")
-    checked = backorderableCheckbox.parent('td').attr('was-checked') is "true"
-    backorderableCheckbox.prop('checked', checked)
+  onEdit: (ev) ->
+    ev.preventDefault()
+    stockItemId = $(ev.currentTarget).data('id')
+    storeBackorderableState(stockItemId)
+    Spree.NumberFieldUpdater.hideReadOnly(stockItemId)
+    showEditForm(stockItemId)
 
-  successHandler = (model, response, options) =>
-    toggleBackorderable(model.get('id'), false)
-    Spree.NumberFieldUpdater.successHandler(model.get('id'), model.get('count_on_hand'))
-    show_flash("success", Spree.translations.updated_successfully)
+  onCancel: (ev) ->
+    ev.preventDefault()
+    stockItemId = $(ev.currentTarget).data('id')
+    restoreBackorderableState(stockItemId)
+    Spree.NumberFieldUpdater.hideForm(stockItemId)
+    showReadOnlyElements(stockItemId)
 
-  errorHandler = (model, response, options) ->
-    show_flash("error", response.responseText)
+  onSubmit: (ev) ->
+    ev.preventDefault()
+    stockItemId = $(ev.currentTarget).data('id')
+    stockLocationId = $(ev.currentTarget).data('location-id')
+    backorderable = $("#backorderable-#{stockItemId}").prop("checked")
+    countOnHand = parseInt($("#number-update-#{stockItemId} input[type='number']").val(), 10)
 
-Spree.StockManagement ?= {}
-Spree.StockManagement.IndexUpdateForms = IndexUpdateForms
+    stockItem = new Spree.StockItem
+      id: stockItemId
+      count_on_hand: countOnHand
+      backorderable: backorderable
+      stock_location_id: stockLocationId
+    options =
+      success: successHandler
+      error: errorHandler
+    stockItem.save(force: true, options)
+
+$ ->
+  $('.js-edit-stock-item').each ->
+    new EditStockItemView
+      el: this

--- a/backend/app/assets/javascripts/spree/backend/stock_management/index_update_forms.coffee
+++ b/backend/app/assets/javascripts/spree/backend/stock_management/index_update_forms.coffee
@@ -26,10 +26,13 @@ class IndexUpdateForms
 
       stockItem = new Spree.StockItem
         id: stockItemId
-        countOnHand: countOnHand
+        count_on_hand: countOnHand
         backorderable: backorderable
-        stockLocationId: stockLocationId
-      stockItem.update(successHandler, errorHandler)
+        stock_location_id: stockLocationId
+      options =
+        success: successHandler
+        error: errorHandler
+      stockItem.save(force: true, options)
 
   showReadOnlyElements = (stockItemId) ->
     toggleBackorderable(stockItemId, false)
@@ -52,13 +55,13 @@ class IndexUpdateForms
     checked = backorderableCheckbox.parent('td').attr('was-checked') is "true"
     backorderableCheckbox.prop('checked', checked)
 
-  successHandler = (stockItem) =>
-    toggleBackorderable(stockItem.id, false)
-    Spree.NumberFieldUpdater.successHandler(stockItem.id, stockItem.count_on_hand)
+  successHandler = (model, response, options) =>
+    toggleBackorderable(model.get('id'), false)
+    Spree.NumberFieldUpdater.successHandler(model.get('id'), model.get('count_on_hand'))
     show_flash("success", Spree.translations.updated_successfully)
 
-  errorHandler = (errorData) ->
-    show_flash("error", errorData.responseText)
+  errorHandler = (model, response, options) ->
+    show_flash("error", response.responseText)
 
 Spree.StockManagement ?= {}
 Spree.StockManagement.IndexUpdateForms = IndexUpdateForms

--- a/backend/app/assets/javascripts/spree/backend/stock_management/index_update_forms.coffee
+++ b/backend/app/assets/javascripts/spree/backend/stock_management/index_update_forms.coffee
@@ -10,9 +10,9 @@ Spree.EditStockItemView = Backbone.View.extend
     @render()
 
   events:
-    "click .fa-edit":  "onEdit"
-    "click .fa-check": "onSubmit"
-    "click .fa-void":  "onCancel"
+    "click .edit": "onEdit"
+    "click .submit": "onSubmit"
+    "click .cancel": "onCancel"
 
   template: HandlebarsTemplates['stock_items/stock_location_stock_item']
 

--- a/backend/app/assets/javascripts/spree/backend/stock_management/index_update_forms.coffee
+++ b/backend/app/assets/javascripts/spree/backend/stock_management/index_update_forms.coffee
@@ -7,11 +7,6 @@ restoreBackorderableState = (stockItemId) ->
   checked = backorderableCheckbox.parent('td').attr('was-checked') is "true"
   backorderableCheckbox.prop('checked', checked)
 
-successHandler = (model, response, options) =>
-  toggleBackorderable(model.get('id'), false)
-  Spree.NumberFieldUpdater.successHandler(model.id, model.get('count_on_hand'))
-  show_flash("success", Spree.translations.updated_successfully)
-
 errorHandler = (model, response, options) ->
   show_flash("error", response.responseText)
 
@@ -37,6 +32,11 @@ EditStockItemView = Backbone.View.extend
     Spree.NumberFieldUpdater.hideForm(stockItemId)
     Spree.NumberFieldUpdater.showReadOnly(stockItemId)
 
+  onSuccess: ->
+    @$('[name=backorderable]').prop('disabled', true)
+    Spree.NumberFieldUpdater.successHandler(@model.id, @model.get('count_on_hand'))
+    show_flash("success", Spree.translations.updated_successfully)
+
   onSubmit: (ev) ->
     ev.preventDefault()
     stockItemId = @model.id
@@ -48,7 +48,7 @@ EditStockItemView = Backbone.View.extend
       count_on_hand: countOnHand
       backorderable: backorderable
     options =
-      success: successHandler
+      success: => @onSuccess()
       error: errorHandler
     @model.save(force: true, options)
 

--- a/backend/app/assets/javascripts/spree/backend/stock_management/index_update_forms.coffee
+++ b/backend/app/assets/javascripts/spree/backend/stock_management/index_update_forms.coffee
@@ -19,8 +19,8 @@ EditStockItemView = Backbone.View.extend
   onEdit: (ev) ->
     ev.preventDefault()
     @$('[name=backorderable]').prop('disabled', false)
-    stockItemId = @model.id
     storeBackorderableState(stockItemId)
+    stockItemId = @model.id
     Spree.NumberFieldUpdater.hideReadOnly(stockItemId)
     Spree.NumberFieldUpdater.showForm(stockItemId)
 
@@ -39,10 +39,8 @@ EditStockItemView = Backbone.View.extend
 
   onSubmit: (ev) ->
     ev.preventDefault()
-    stockItemId = @model.id
-    stockLocationId = $(ev.currentTarget).data('location-id')
-    backorderable = $("#backorderable-#{stockItemId}").prop("checked")
-    countOnHand = parseInt($("#number-update-#{stockItemId} input[type='number']").val(), 10)
+    backorderable = @$('[name=backorderable]').prop("checked")
+    countOnHand = parseInt($("input[name='count_on_hand']").val(), 10)
 
     @model.set
       count_on_hand: countOnHand

--- a/backend/app/assets/javascripts/spree/backend/stock_management/index_update_forms.coffee
+++ b/backend/app/assets/javascripts/spree/backend/stock_management/index_update_forms.coffee
@@ -1,7 +1,7 @@
 errorHandler = (model, response, options) ->
   show_flash("error", response.responseText)
 
-EditStockItemView = Backbone.View.extend
+Spree.EditStockItemView = Backbone.View.extend
   events:
     "click .fa-edit":  "onEdit"
     "click .fa-check": "onSubmit"
@@ -44,6 +44,6 @@ $ ->
   $('.js-edit-stock-item').each ->
     $el = $(this)
     model = new Spree.StockItem($el.data('stock-item'))
-    new EditStockItemView
+    new Spree.EditStockItemView
       el: $el
       model: model

--- a/backend/app/assets/javascripts/spree/backend/stock_management/index_update_forms.coffee
+++ b/backend/app/assets/javascripts/spree/backend/stock_management/index_update_forms.coffee
@@ -1,15 +1,3 @@
-showReadOnlyElements = (stockItemId) ->
-  toggleBackorderable(stockItemId, false)
-  Spree.NumberFieldUpdater.showReadOnly(stockItemId)
-
-showEditForm = (stockItemId) ->
-  toggleBackorderable(stockItemId, true)
-  Spree.NumberFieldUpdater.showForm(stockItemId)
-
-toggleBackorderable = (stockItemId, show) ->
-  disabledValue = if show then null else 'disabled'
-  $("#backorderable-#{stockItemId}").prop('disabled', disabledValue)
-
 storeBackorderableState = (stockItemId) ->
   backorderableCheckbox = $("#backorderable-#{stockItemId}")
   backorderableCheckbox.parent('td').attr('was-checked', backorderableCheckbox.prop('checked'))
@@ -35,17 +23,19 @@ EditStockItemView = Backbone.View.extend
 
   onEdit: (ev) ->
     ev.preventDefault()
+    @$('[name=backorderable]').prop('disabled', false)
     stockItemId = $(ev.currentTarget).data('id')
     storeBackorderableState(stockItemId)
     Spree.NumberFieldUpdater.hideReadOnly(stockItemId)
-    showEditForm(stockItemId)
+    Spree.NumberFieldUpdater.showForm(stockItemId)
 
   onCancel: (ev) ->
     ev.preventDefault()
+    @$('[name=backorderable]').prop('disabled', true)
     stockItemId = $(ev.currentTarget).data('id')
     restoreBackorderableState(stockItemId)
     Spree.NumberFieldUpdater.hideForm(stockItemId)
-    showReadOnlyElements(stockItemId)
+    Spree.NumberFieldUpdater.showReadOnly(stockItemId)
 
   onSubmit: (ev) ->
     ev.preventDefault()

--- a/backend/app/assets/javascripts/spree/backend/stock_management/index_update_forms.coffee
+++ b/backend/app/assets/javascripts/spree/backend/stock_management/index_update_forms.coffee
@@ -1,12 +1,3 @@
-storeBackorderableState = (stockItemId) ->
-  backorderableCheckbox = $("#backorderable-#{stockItemId}")
-  backorderableCheckbox.parent('td').attr('was-checked', backorderableCheckbox.prop('checked'))
-
-restoreBackorderableState = (stockItemId) ->
-  backorderableCheckbox = $("#backorderable-#{stockItemId}")
-  checked = backorderableCheckbox.parent('td').attr('was-checked') is "true"
-  backorderableCheckbox.prop('checked', checked)
-
 errorHandler = (model, response, options) ->
   show_flash("error", response.responseText)
 
@@ -19,16 +10,15 @@ EditStockItemView = Backbone.View.extend
   onEdit: (ev) ->
     ev.preventDefault()
     @$('[name=backorderable]').prop('disabled', false)
-    storeBackorderableState(stockItemId)
     stockItemId = @model.id
     Spree.NumberFieldUpdater.hideReadOnly(stockItemId)
     Spree.NumberFieldUpdater.showForm(stockItemId)
 
   onCancel: (ev) ->
     ev.preventDefault()
-    @$('[name=backorderable]').prop('disabled', true)
+    backorderableWas = @model.previous('backorderable')
+    @$('[name=backorderable]').prop('disabled', true).val(backorderableWas)
     stockItemId = @model.id
-    restoreBackorderableState(stockItemId)
     Spree.NumberFieldUpdater.hideForm(stockItemId)
     Spree.NumberFieldUpdater.showReadOnly(stockItemId)
 

--- a/backend/app/assets/javascripts/spree/backend/stock_management/index_update_forms.coffee
+++ b/backend/app/assets/javascripts/spree/backend/stock_management/index_update_forms.coffee
@@ -6,6 +6,7 @@ Spree.EditStockItemView = Backbone.View.extend
 
   initialize: (options) ->
     @stockLocationName = options.stockLocationName
+    @editing = false
     @render()
 
   events:
@@ -17,7 +18,8 @@ Spree.EditStockItemView = Backbone.View.extend
 
   render: ->
     renderAttr =
-      StockLocationName: @stockLocationName
+      stockLocationName: @stockLocationName
+      editing: @editing
     _.extend(renderAttr, @model.attributes)
 
     @$el.attr("data-variant-id", @model.get('variant_id'))
@@ -27,22 +29,18 @@ Spree.EditStockItemView = Backbone.View.extend
 
   onEdit: (ev) ->
     ev.preventDefault()
-    @$('[name=backorderable]').prop('disabled', false)
-    stockItemId = @model.id
-    Spree.NumberFieldUpdater.hideReadOnly(stockItemId)
-    Spree.NumberFieldUpdater.showForm(stockItemId)
+    @editing = true
+    @render()
 
   onCancel: (ev) ->
     ev.preventDefault()
-    backorderableWas = @model.previous('backorderable')
-    @$('[name=backorderable]').prop('disabled', true).val(backorderableWas)
-    stockItemId = @model.id
-    Spree.NumberFieldUpdater.hideForm(stockItemId)
-    Spree.NumberFieldUpdater.showReadOnly(stockItemId)
+    @model.set(@model.previousAttributes())
+    @editing = false
+    @render()
 
   onSuccess: ->
-    @$('[name=backorderable]').prop('disabled', true)
-    Spree.NumberFieldUpdater.successHandler(@model.id, @model.get('count_on_hand'))
+    @editing = false
+    @render()
     show_flash("success", Spree.translations.updated_successfully)
 
   onSubmit: (ev) ->

--- a/backend/app/assets/javascripts/spree/backend/stock_management/index_update_forms.coffee
+++ b/backend/app/assets/javascripts/spree/backend/stock_management/index_update_forms.coffee
@@ -2,10 +2,28 @@ errorHandler = (model, response, options) ->
   show_flash("error", response.responseText)
 
 Spree.EditStockItemView = Backbone.View.extend
+  tagName: 'tr'
+
+  initialize: (options) ->
+    @stockLocationName = options.stockLocationName
+    @render()
+
   events:
     "click .fa-edit":  "onEdit"
     "click .fa-check": "onSubmit"
     "click .fa-void":  "onCancel"
+
+  template: HandlebarsTemplates['stock_items/stock_location_stock_item']
+
+  render: ->
+    renderAttr =
+      StockLocationName: @stockLocationName
+    _.extend(renderAttr, @model.attributes)
+
+    @$el.attr("data-variant-id", @model.get('variant_id'))
+    @$el.html(@template(renderAttr))
+
+    return @
 
   onEdit: (ev) ->
     ev.preventDefault()
@@ -46,4 +64,5 @@ $ ->
     model = new Spree.StockItem($el.data('stock-item'))
     new Spree.EditStockItemView
       el: $el
+      stockLocationName: $el.data('stock-location-name')
       model: model

--- a/backend/app/assets/javascripts/spree/backend/stock_management/stock_item.coffee
+++ b/backend/app/assets/javascripts/spree/backend/stock_management/stock_item.coffee
@@ -1,37 +1,4 @@
-class StockItem
-  constructor: (options = {}) ->
-    @id = options.id
-    @variantId = options.variantId
-    @backorderable = options.backorderable
-    @countOnHand = options.countOnHand
-    @stockLocationId = options.stockLocationId
-
-  save: (successHandler, errorHandler) ->
-    Spree.ajax
-      url: Spree.routes.stock_items_api(@stockLocationId)
-      type: "POST"
-      data:
-        stock_item:
-          variant_id: @variantId
-          backorderable: @backorderable
-          count_on_hand: @countOnHand
-      success: (stockItem) ->
-        successHandler(stockItem)
-      error: (errorData) ->
-        errorHandler(errorData)
-
-  update: (successHandler, errorHandler) ->
-    Spree.ajax
-      url: "#{Spree.routes.stock_items_api(@stockLocationId)}/#{@id}"
-      type: "PUT"
-      data:
-        stock_item:
-          backorderable: @backorderable
-          count_on_hand: @countOnHand
-          force: true
-      success: (stockItem) ->
-        successHandler(stockItem)
-      error: (errorData) ->
-        errorHandler(errorData)
-
-Spree.StockItem = StockItem
+Spree.StockItem = Backbone.Model.extend
+  urlRoot: ->
+    Spree.routes.stock_items_api(@get('stock_location_id'))
+  paramRoot: 'stock_item'

--- a/backend/app/assets/javascripts/spree/backend/templates/stock_items/stock_location_stock_item.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/stock_items/stock_location_stock_item.hbs
@@ -17,9 +17,9 @@
 </td>
 <td class="actions">
   {{#if editing}}
-    <a class="fa fa-check icon_link with-tip no-text" data-action="green" data-id="{{id}}" href="#"></a>
-    <a class="fa fa-void icon_link with-tip no-text" data-action="red" data-id="{{id}}" href="#"></a>
+    <a class="submit fa fa-check icon_link with-tip no-text" data-action="green" data-id="{{id}}" href="#"></a>
+    <a class="cancel fa fa-void icon_link with-tip no-text" data-action="red" data-id="{{id}}" href="#"></a>
   {{else}}
-    <a class="fa fa-edit icon_link with-tip no-text" data-action="edit" data-id="{{id}}" href="#"></a>
+    <a class="edit fa fa-edit icon_link with-tip no-text" data-action="edit" data-id="{{id}}" href="#"></a>
   {{/if}}
 </td>

--- a/backend/app/assets/javascripts/spree/backend/templates/stock_items/stock_location_stock_item.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/stock_items/stock_location_stock_item.hbs
@@ -1,19 +1,17 @@
-<tr data-variant-id="{{variantId}}">
-  <td class="align-center location-name-cell">{{stockLocationName}}</td>
-  <td class="align-center">
-    {{#if backorderable}}
-      <input id="backorderable-{{id}}" name="backorderable" type="checkbox" value="backorderable" disabled="disabled" checked="checked">
-    {{else}}
-      <input id="backorderable-{{id}}" name="backorderable" type="checkbox" value="backorderable" disabled="disabled">
-    {{/if}}
-  </td>
-  <td class="align-center" id="number-update-{{id}}">
-    <span class="js-number-update-text">{{countOnHand}}</span>
-    <input class="fullwidth js-number-update-input" name="count_on_hand" type="number" value="">
-  </td>
-  <td class="actions">
-    <a class="fa fa-edit icon_link with-tip no-text" data-action="edit" data-id="{{id}}" href="#"></a>
-    <a class="fa fa-check icon_link with-tip no-text" data-action="green" data-id="{{id}}" data-location-id="{{stockLocationId}}" href="#"></a>
-    <a class="fa fa-void icon_link with-tip no-text" data-action="red" data-id="{{id}}" href="#"></a>
-  </td>
-</tr>
+<td class="align-center location-name-cell">{{stockLocationName}} {{stock_location_id}}</td>
+<td class="align-center">
+  {{#if backorderable}}
+    <input id="backorderable-{{id}}" name="backorderable" type="checkbox" value="backorderable" disabled="disabled" checked="checked">
+  {{else}}
+    <input id="backorderable-{{id}}" name="backorderable" type="checkbox" value="backorderable" disabled="disabled">
+  {{/if}}
+</td>
+<td class="align-center" id="number-update-{{id}}">
+  <span class="js-number-update-text">{{count_on_hand}}</span>
+  <input class="fullwidth js-number-update-input" name="count_on_hand" type="number" value="">
+</td>
+<td class="actions">
+  <a class="fa fa-edit icon_link with-tip no-text" data-action="edit" data-id="{{id}}" href="#"></a>
+  <a class="fa fa-check icon_link with-tip no-text" data-action="green" data-id="{{id}}" data-location-id="{{stock_location_id}}" href="#"></a>
+  <a class="fa fa-void icon_link with-tip no-text" data-action="red" data-id="{{id}}" href="#"></a>
+</td>

--- a/backend/app/assets/javascripts/spree/backend/templates/stock_items/stock_location_stock_item.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/stock_items/stock_location_stock_item.hbs
@@ -17,9 +17,9 @@
 </td>
 <td class="actions">
   {{#if editing}}
-    <a class="submit fa fa-check icon_link with-tip no-text" data-action="green" data-id="{{id}}" href="#"></a>
-    <a class="cancel fa fa-void icon_link with-tip no-text" data-action="red" data-id="{{id}}" href="#"></a>
+    <a class="submit fa fa-check icon_link with-tip no-text" data-action="green" href="#"></a>
+    <a class="cancel fa fa-void icon_link with-tip no-text" data-action="red" href="#"></a>
   {{else}}
-    <a class="edit fa fa-edit icon_link with-tip no-text" data-action="edit" data-id="{{id}}" href="#"></a>
+    <a class="edit fa fa-edit icon_link with-tip no-text" data-action="edit" href="#"></a>
   {{/if}}
 </td>

--- a/backend/app/assets/javascripts/spree/backend/templates/stock_items/stock_location_stock_item.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/stock_items/stock_location_stock_item.hbs
@@ -1,17 +1,25 @@
-<td class="align-center location-name-cell">{{stockLocationName}} {{stock_location_id}}</td>
+<td class="align-center">{{stockLocationName}}</td>
 <td class="align-center">
-  {{#if backorderable}}
-    <input id="backorderable-{{id}}" name="backorderable" type="checkbox" value="backorderable" disabled="disabled" checked="checked">
+  <input id="backorderable-{{id}}"
+         name="backorderable"
+         type="checkbox"
+         value="backorderable"
+         {{#unless editing}} disabled="disabled" {{/unless}}
+         {{#if backorderable}} checked="checked" {{/if}}
+   >
+</td>
+<td class="align-center">
+  {{#if editing}}
+    <input class="fullwidth" name="count_on_hand" type="number" value="{{count_on_hand}}">
   {{else}}
-    <input id="backorderable-{{id}}" name="backorderable" type="checkbox" value="backorderable" disabled="disabled">
+    <span>{{count_on_hand}}</span>
   {{/if}}
 </td>
-<td class="align-center" id="number-update-{{id}}">
-  <span class="js-number-update-text">{{count_on_hand}}</span>
-  <input class="fullwidth js-number-update-input" name="count_on_hand" type="number" value="">
-</td>
 <td class="actions">
-  <a class="fa fa-edit icon_link with-tip no-text" data-action="edit" data-id="{{id}}" href="#"></a>
-  <a class="fa fa-check icon_link with-tip no-text" data-action="green" data-id="{{id}}" data-location-id="{{stock_location_id}}" href="#"></a>
-  <a class="fa fa-void icon_link with-tip no-text" data-action="red" data-id="{{id}}" href="#"></a>
+  {{#if editing}}
+    <a class="fa fa-check icon_link with-tip no-text" data-action="green" data-id="{{id}}" href="#"></a>
+    <a class="fa fa-void icon_link with-tip no-text" data-action="red" data-id="{{id}}" href="#"></a>
+  {{else}}
+    <a class="fa fa-edit icon_link with-tip no-text" data-action="edit" data-id="{{id}}" href="#"></a>
+  {{/if}}
 </td>

--- a/backend/app/assets/stylesheets/spree/backend/sections/_stock_management.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/_stock_management.scss
@@ -7,17 +7,17 @@
   }
 
   > tbody {
-    > tr {
-      > td {
-        background-color: $color-tbl-odd;
-      }
-      &.even td {
+    > tr.stock-item-edit-row {
+      td {
         background-color: $color-tbl-even;
       }
-      &:first-child {
-        td {
-          border-top: none;
-        }
+      &:nth-child(2n) td {
+        background-color: $color-tbl-odd;
+      }
+    }
+    > tr {
+      &:first-child td {
+        border-top: none;
       }
     }
   }
@@ -37,4 +37,5 @@
       border: 1px solid $color-error;
     }
   }
+
 }

--- a/backend/app/assets/stylesheets/spree/backend/sections/_stock_management.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/_stock_management.scss
@@ -11,7 +11,8 @@
       td {
         background-color: $color-tbl-even;
       }
-      &:nth-child(2n) td {
+      &:nth-child(even) td {
+        /* An nth-even child is actually an odd row */
         background-color: $color-tbl-odd;
       }
     }

--- a/backend/app/views/spree/admin/stock_items/_stock_management.html.erb
+++ b/backend/app/views/spree/admin/stock_items/_stock_management.html.erb
@@ -78,7 +78,7 @@
             <%= number_field_tag :count_on_hand, "", class: 'fullwidth', id: "variant-count-on-hand-#{variant.id}" %>
           </td>
           <td class="actions">
-            <%= link_to_with_icon 'plus', Spree.t('actions.create'), '#', :no_text => true, :data => {:action => 'green' } %>
+            <%= link_to_with_icon 'plus', Spree.t('actions.create'), '#', :no_text => true, :data => {:action => 'green' }, class: "submit" %>
           </td>
         </tr>
       <% end %>

--- a/backend/app/views/spree/admin/stock_items/_stock_management.html.erb
+++ b/backend/app/views/spree/admin/stock_items/_stock_management.html.erb
@@ -79,7 +79,7 @@
             <%= number_field_tag :count_on_hand, "", class: 'fullwidth', id: "variant-count-on-hand-#{variant.id}" %>
           </td>
           <td class="actions">
-            <%= link_to_with_icon 'plus', Spree.t('actions.create'), '#', :no_text => true, :data => {:action => 'green', :variant_id => variant.id } if can?(:create, Spree::StockItem) %>
+            <%= link_to_with_icon 'plus', Spree.t('actions.create'), '#', :no_text => true, :data => {:action => 'green' } %>
           </td>
         </tr>
       <% end %>

--- a/backend/app/views/spree/admin/stock_items/_stock_management.html.erb
+++ b/backend/app/views/spree/admin/stock_items/_stock_management.html.erb
@@ -78,7 +78,7 @@
         <% end %>
       <% end %>
       <% if display_add_row %>
-        <tr class="<%= cycle('odd', 'even', :name => 'stock_locations')%>" data-variant-id="<%= variant.id %>">
+        <tr class="js-add-stock-item <%= cycle('odd', 'even', :name => 'stock_locations')%>" data-variant-id="<%= variant.id %>">
           <td class='location-name-cell'>
             <%= select_tag :stock_location_id, options_from_collection_for_select(locations_without_items, :id, :name), { :include_blank => true, :class => 'select2', "data-placeholder" => Spree.t(:add_to_stock_location), :id => "variant-stock-location-#{variant.id}" } %>
           </td>

--- a/backend/app/views/spree/admin/stock_items/_stock_management.html.erb
+++ b/backend/app/views/spree/admin/stock_items/_stock_management.html.erb
@@ -63,7 +63,7 @@
       </tr>
       <% variant.stock_items.each do |item| %>
         <% if @stock_item_stock_locations.include?(item.stock_location) %>
-          <tr class="<%= cycle('odd', 'even', :name => 'stock_locations')%>" data-variant-id="<%= variant.id %>">
+          <tr class="js-edit-stock-item <%= cycle('odd', 'even', :name => 'stock_locations')%>" data-variant-id="<%= variant.id %>" data-stock-item="<%= item.to_json %>">
             <td class='align-center location-name-cell'><%= item.stock_location.name %></td>
             <td class='align-center'>
               <% if can?(:update, item) %>

--- a/backend/app/views/spree/admin/stock_items/_stock_management.html.erb
+++ b/backend/app/views/spree/admin/stock_items/_stock_management.html.erb
@@ -61,13 +61,13 @@
       </tr>
       <% variant.stock_items.each do |item| %>
         <% if @stock_item_stock_locations.include?(item.stock_location) %>
-          <tr class="js-edit-stock-item <%= cycle('odd', 'even', :name => 'stock_locations')%>" data-variant-id="<%= variant.id %>" data-stock-item="<%= item.to_json %>" data-stock-location-name="<%= item.stock_location.name %>">
+          <tr class="js-edit-stock-item stock-item-edit-row" data-variant-id="<%= variant.id %>" data-stock-item="<%= item.to_json %>" data-stock-location-name="<%= item.stock_location.name %>">
             <%# This is rendered in JS %>
           </tr>
         <% end %>
       <% end %>
       <% if display_add_row %>
-        <tr class="js-add-stock-item <%= cycle('odd', 'even', :name => 'stock_locations')%>" data-variant-id="<%= variant.id %>">
+        <tr class="js-add-stock-item stock-item-edit-row" data-variant-id="<%= variant.id %>">
           <td class='location-name-cell'>
             <%= select_tag :stock_location_id, options_from_collection_for_select(locations_without_items, :id, :name), { :include_blank => true, :class => 'select2', "data-placeholder" => Spree.t(:add_to_stock_location), :id => "variant-stock-location-#{variant.id}" } %>
           </td>
@@ -82,7 +82,6 @@
           </td>
         </tr>
       <% end %>
-      <% reset_cycle("stock_locations") %>
     </tbody>
   <% end %>
 </table>

--- a/backend/app/views/spree/admin/stock_items/_stock_management.html.erb
+++ b/backend/app/views/spree/admin/stock_items/_stock_management.html.erb
@@ -64,6 +64,7 @@
       <% variant.stock_items.each do |item| %>
         <% if @stock_item_stock_locations.include?(item.stock_location) %>
           <tr class="js-edit-stock-item <%= cycle('odd', 'even', :name => 'stock_locations')%>" data-variant-id="<%= variant.id %>" data-stock-item="<%= item.to_json %>" data-stock-location-name="<%= item.stock_location.name %>">
+            <%# This is rendered in JS %>
           </tr>
         <% end %>
       <% end %>

--- a/backend/app/views/spree/admin/stock_items/_stock_management.html.erb
+++ b/backend/app/views/spree/admin/stock_items/_stock_management.html.erb
@@ -63,17 +63,7 @@
       </tr>
       <% variant.stock_items.each do |item| %>
         <% if @stock_item_stock_locations.include?(item.stock_location) %>
-          <tr class="js-edit-stock-item <%= cycle('odd', 'even', :name => 'stock_locations')%>" data-variant-id="<%= variant.id %>" data-stock-item="<%= item.to_json %>">
-            <td class='align-center location-name-cell'><%= item.stock_location.name %></td>
-            <td class='align-center'>
-              <% if can?(:update, item) %>
-                <%= check_box_tag :backorderable, 'backorderable', item.backorderable?, id: "backorderable-#{item.id}", disabled: "disabled" %>
-              <% end %>
-            </td>
-            <%= render partial: 'spree/admin/shared/number_field_update_cell', locals: { resource_id: item.id, field_tag: :count_on_hand, number_value: item.count_on_hand } %>
-            <td class="actions">
-              <%= render partial: 'spree/admin/shared/number_field_update_actions', locals: { resource: item, update_data: { location_id: item.stock_location_id } } %>
-            </td>
+          <tr class="js-edit-stock-item <%= cycle('odd', 'even', :name => 'stock_locations')%>" data-variant-id="<%= variant.id %>" data-stock-item="<%= item.to_json %>" data-stock-location-name="<%= item.stock_location.name %>">
           </tr>
         <% end %>
       <% end %>

--- a/backend/app/views/spree/admin/stock_items/_stock_management.html.erb
+++ b/backend/app/views/spree/admin/stock_items/_stock_management.html.erb
@@ -1,6 +1,6 @@
 <%= paginate @variants, theme: "solidus_admin" %>
 
-<table class="index stock-table number-field-update-table" id="listing_product_stock">
+<table class="index stock-table" id="listing_product_stock">
   <colgroup>
     <col style="width: 50%" />
     <col style="width: 20%" />

--- a/backend/app/views/spree/admin/stock_items/_stock_management.html.erb
+++ b/backend/app/views/spree/admin/stock_items/_stock_management.html.erb
@@ -19,13 +19,11 @@
       <th class="actions"></th>
     </tr>
   </thead>
-  <tbody>
-    <% variants.each do |variant| %>
-      <%- locations_without_items = @stock_item_stock_locations - variant.stock_items.flat_map(&:stock_location) %>
-      <%- display_add_row = locations_without_items.any? && can?(:create, Spree::StockItem) %>
-      <%- row_count = (variant.stock_items.map(&:stock_location) & @stock_item_stock_locations).size %>
-      <%- row_count += display_add_row ? 2 : 1 %>
-
+  <% variants.each do |variant| %>
+    <%- locations_without_items = @stock_item_stock_locations - variant.stock_items.flat_map(&:stock_location) %>
+    <%- display_add_row = locations_without_items.any? && can?(:create, Spree::StockItem) %>
+    <%- row_count = @stock_item_stock_locations.count + 2 %>
+    <tbody class="variant-stock-items">
       <tr id="<%= spree_dom_id variant %>">
         <td class="align-center no-padding" rowspan="<%= row_count %>">
           <div class='variant-container'>
@@ -85,8 +83,8 @@
         </tr>
       <% end %>
       <% reset_cycle("stock_locations") %>
-    <% end %>
-  </tbody>
+    </tbody>
+  <% end %>
 </table>
 
 <%= paginate @variants, theme: "solidus_admin" %>

--- a/backend/spec/features/admin/products/stock_management_spec.rb
+++ b/backend/spec/features/admin/products/stock_management_spec.rb
@@ -58,9 +58,13 @@ describe "Stock Management", type: :feature do
     end
 
     def adjust_count_on_hand(count_on_hand)
-      find(:css, ".fa-edit[data-id='#{stock_item.id}']").trigger('click')
-      find(:css, "[data-variant-id='#{variant.id}'] input[type='number']").set(count_on_hand)
-      find(:css, ".fa-check[data-id='#{stock_item.id}']").trigger('click')
+      within('.variant-stock-items', text: variant.sku) do
+        within('tr', text: stock_item.stock_location.name) do
+          click_icon :edit
+          find(:css, "input[type='number']").set(count_on_hand)
+          click_icon :check
+        end
+      end
       expect(page).to have_content('Updated successfully')
     end
 
@@ -71,10 +75,11 @@ describe "Stock Management", type: :feature do
 
       it "can add stock items to other stock locations", js: true do
         visit current_url
-        fill_in "variant-count-on-hand-#{variant.id}", with: '3'
-        targetted_select2_search "Other location", from: "#s2id_variant-stock-location-#{variant.id}"
-        find(:css, ".fa-plus[data-variant-id='#{variant.id}']").click
-        wait_for_ajax
+        within('.variant-stock-items', text: variant.sku) do
+          fill_in "variant-count-on-hand-#{variant.id}", with: '3'
+          targetted_select2_search "Other location", from: "#s2id_variant-stock-location-#{variant.id}"
+          click_icon(:plus)
+        end
         expect(page).to have_content('Created successfully')
       end
     end


### PR DESCRIPTION
I started working on this because the JS was binding directly to buttons based on the font awesome icon class (yuck!). I then discovered that the view template was copy pasted between rails views and handlebars.

This simplifies the javascript in the stock management section. There should be no behaviour change.

* Use a backbone view for each row.
* Use backbone models to represent the StockItem
* StockItem "edit" rows are now rendered entirely in JS by handlebars rather than having duplicated views.
* We use a tbody to group rows all concerned with the same variant.
* Style even/odd rows in CSS instead of adding classes in JS
* Bind events to reasonable classes instead of icons liker `.fa-check`