### PR TITLE
Add gem depencies on sass-rails and coffee-rails

### DIFF
--- a/backend/lib/spree/backend.rb
+++ b/backend/lib/spree/backend.rb
@@ -1,6 +1,8 @@
 require 'rails/all'
 require 'jquery-rails'
 require 'jquery-ui-rails'
+require 'coffee-rails'
+require 'sass-rails'
 require 'bourbon'
 require 'select2-rails'
 require 'handlebars_assets'

--- a/backend/solidus_backend.gemspec
+++ b/backend/solidus_backend.gemspec
@@ -21,6 +21,8 @@ Gem::Specification.new do |s|
   s.add_dependency 'solidus_api', s.version
   s.add_dependency 'solidus_core', s.version
 
+  s.add_dependency 'sass-rails'
+  s.add_dependency 'coffee-rails'
   s.add_dependency 'bourbon', '>= 4', '< 6'
   s.add_dependency 'jquery-rails'
   s.add_dependency 'jquery-ui-rails', '~> 5.0.0'

--- a/frontend/lib/spree/frontend.rb
+++ b/frontend/lib/spree/frontend.rb
@@ -1,6 +1,8 @@
 require 'rails/all'
 require 'jquery-rails'
 require 'canonical-rails'
+require 'coffee-rails'
+require 'sass-rails'
 require 'font-awesome-rails'
 
 require 'spree/core'

--- a/frontend/solidus_frontend.gemspec
+++ b/frontend/solidus_frontend.gemspec
@@ -23,6 +23,8 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'canonical-rails', '~> 0.0.4'
   s.add_dependency 'jquery-rails'
+  s.add_dependency 'sass-rails'
+  s.add_dependency 'coffee-rails'
   s.add_dependency 'font-awesome-rails', '~> 4.0'
 
   s.add_development_dependency 'capybara-accessible'


### PR DESCRIPTION
These gems are required to run the frontend and backend projects, so we should declare them as necessary and require them instead of relying on them to be a part of the default rails application.

This should fix issues running specs for a few extensions where sass-rails was not being pulled in through other means.