### PR TITLE
Encapsulate the logic for when an item is shippable.

### DIFF
--- a/core/app/models/spree/inventory_unit.rb
+++ b/core/app/models/spree/inventory_unit.rb
@@ -113,11 +113,11 @@ module Spree
       return_items.not_expired.any?(&:exchange_requested?)
     end
 
-    private
-
     def allow_ship?
       on_hand?
     end
+
+    private
 
     def fulfill_order
       reload

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -56,7 +56,7 @@ describe Spree::Shipment, type: :model do
     end
 
     it 'returns pending if backordered' do
-      allow(shipment).to receive_messages inventory_units: [mock_model(Spree::InventoryUnit, backordered?: true)]
+      allow(shipment).to receive_messages inventory_units: [mock_model(Spree::InventoryUnit, allow_ship?: false, canceled?: false)]
       expect(shipment.determine_state(order)).to eq 'pending'
     end
 
@@ -246,7 +246,7 @@ describe Spree::Shipment, type: :model do
         # Set as ready so we can test for change
         shipment.update_attributes!(state: 'ready')
 
-        allow(shipment).to receive_messages(inventory_units: [mock_model(Spree::InventoryUnit, backordered?: true)])
+        allow(shipment).to receive_messages(inventory_units: [mock_model(Spree::InventoryUnit, allow_ship?: false, canceled?: false)])
         expect(shipment).to receive(:update_columns).with(state: 'pending', updated_at: kind_of(Time))
         shipment.update!(order)
       end
@@ -422,7 +422,7 @@ describe Spree::Shipment, type: :model do
     end
 
     context "when any inventory is backordered" do
-      before { allow_any_instance_of(Spree::InventoryUnit).to receive(:backordered?).and_return(true) }
+      before { allow_any_instance_of(Spree::InventoryUnit).to receive(:allow_ship?).and_return(false) }
       it "should result in a 'ready' state" do
         shipment.resume!
         expect(shipment.state).to eq 'pending'
@@ -433,7 +433,7 @@ describe Spree::Shipment, type: :model do
       before do
         allow(order).to receive_messages(can_ship?: true)
         allow(order).to receive_messages(paid?: true)
-        allow_any_instance_of(Spree::InventoryUnit).to receive(:backordered?).and_return(false)
+        allow_any_instance_of(Spree::InventoryUnit).to receive(:allow_ship?).and_return(true)
       end
 
       it "should result in a 'ready' state" do


### PR DESCRIPTION
Transitioning an item (InventoryUnit) to `shipped` is restricted [allowing an item to ask itself if it is shippable before it is marked as shipped](https://github.com/solidusio/solidus/blob/master/core/app/models/spree/inventory_unit.rb#L58). This questioning is implemented by [verifying the item is on-hand](https://github.com/solidusio/solidus/blob/master/core/app/models/spree/inventory_unit.rb#L118-L120).

But when the overall shipment is checking to see if the item is shippable and [it does it's own interrogation of the items in the shipment rather than asking the items itself](https://github.com/solidusio/solidus/blob/master/core/app/models/spree/shipment.rb#L84).

Worse is that the implementation differs from the implementation in InventoryUnit. InventoryUnit questions if the item is "on-hand" while in Shipment it questions if the item is not backordered. Unsure if it is a real issue but it might mean we could get a case where the inventory unit is in neither state allowing the shipment to think it can ship while the inventory unit thinks it can't resulting in an error.

This commit encapulates the decision entirely in InventoryUnit allowing the item to determine if it is ready to ship. This logically should be the same as before only we now have better encapsulation.

The additional benefit (and primary motivation) is that the condition can customized now that it is properly encapsulated. I am working on an app with on-demand manufactoring with no real inventory. An item cannot be shipped until it is built. We can customize InventoryUnit as follows:

    Spree::InventoryUnit.class_eval do
      module CheckBuiltForShipping do
        def allow_ship?
          super && built?
        end
      end
      prepend CheckBuiltForShipping
    end

Prior to this commit, the system would allow the user to attempt to ship the item (since it is not "backordered") but the ship would fail since our customization made it not shippable. With this commit the shipment it now not shippable also meaning the user isn't even presented with the option.

In theory this commit should have required no test changes as it is just refactoring implementation details. Unfortunately due to the abuse of mocks there are some adjustments to the test to get things passing.