### PR TITLE
Bump to more recent version of pry-byebug

### DIFF
--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -39,6 +39,6 @@ end
 group :test, :development do
   gem 'rubocop'
   platforms :mri do
-    gem 'pry-byebug', '~> 1.0'
+    gem 'pry-byebug', '~> 3.3'
   end
 end


### PR DESCRIPTION
Solidus was bound to a version several years old. I'm actually a bigger fan of just letting it float (especially since it is a dev tool) but I know some people think all dependencies should be bound to a major version and that seems to be the pattern in Solidus so following that.

Motiviation was the fact that the tool wasn't really working giving the error [described here](http://stackoverflow.com/questions/30664069/getting-error-typeerror-wrong-argument-type-nil-expected-symbol-when-using). Bumping to a more recent version solved the issue.