### PR TITLE
Remove spree/frontend/backend.js placeholder

### DIFF
--- a/backend/app/assets/javascripts/spree/frontend/backend.js
+++ b/backend/app/assets/javascripts/spree/frontend/backend.js
@@ -1,1 +1,0 @@
-// Placeholder for backend dummy application

--- a/backend/app/assets/stylesheets/spree/frontend/backend.css
+++ b/backend/app/assets/stylesheets/spree/frontend/backend.css
@@ -1,1 +1,0 @@
-/* Placeholder for backend dummy app */


### PR DESCRIPTION
This is no longer necessary. Given the absence of a `backend/frontend.js`, this may have been unnecessary for quite a while.