### PR TITLE
Make the creation of the sandbox consistent with the dummy app.

### DIFF
--- a/lib/sandbox.sh
+++ b/lib/sandbox.sh
@@ -32,6 +32,14 @@ group :test, :development do
 end
 RUBY
 
+sed -i '/&default/a \
+  host: localhost' config/database.yml
+sed -i '/&default/a \
+  username: postgres' config/database.yml
+if [ -n "$DB_HOST" ]; then
+  sed -i "s/localhost/$DB_HOST/g" config/database.yml
+fi
+
 bundle install --gemfile Gemfile
 bundle exec rake db:drop db:create
 bundle exec rails g spree:install --auto-accept --user_class=Spree::User --enforce_available_locales=true


### PR DESCRIPTION
The dummy app [allows a DB_HOST variable](https://github.com/solidusio/solidus/blob/master/core/lib/generators/spree/dummy/templates/rails/database.yml#L30) to be set when creating test apps and the database username is `postgress`. The sandbox app on the other hand only allows the database type to be set. It is always assumed to be `localhost` and the user is assumed to be `sandbox`.

This commit makes the sandbox app consistent by allowing the DB_HOST variable to be set and it uses the same postgres user so that the a new special user does not need to be setup (i.e. we can use the same user as we are using for our tests).
