### PR TITLE
Loosen restriction on activemerchant

### DIFF
--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.1.0'
 
-  s.add_dependency 'activemerchant', '~> 1.48.0'
+  s.add_dependency 'activemerchant', '~> 1.48'
   s.add_dependency 'acts_as_list', '~> 0.3'
   s.add_dependency 'awesome_nested_set', '~> 3.0.1'
   s.add_dependency 'carmen', '~> 1.0.0'


### PR DESCRIPTION
The exact version should be left up to developers or extensions if a specific version is required. This also better follows semver.

Fixes #1009