### PR TITLE
Include pry and byebug, but not pry-byebug

### DIFF
--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -38,7 +38,9 @@ end
 
 group :test, :development do
   gem 'rubocop'
+  gem 'pry'
+
   platforms :mri do
-    gem 'pry-byebug', '~> 1.0'
+    gem 'byebug'
   end
 end


### PR DESCRIPTION
Previously we were using pry-byebug ~> 1.0 to avoid behaviour of newer
byebug versions which locks all threads when the debugger is entered.
This made debugging and developing feature specs impossible.

See https://github.com/deivid-rodriguez/byebug/issues/193

I believe this gives us the best of both worlds, when we want a debugger
capable of stepping through code we can invoke byebug. When we want an
interactive REPL, we can invoke pry.

cc @eric1234 does this solve your issue in #1005?