### PR TITLE
Re-organize variant edit form and flow

### DIFF
--- a/backend/app/controllers/spree/admin/variants_controller.rb
+++ b/backend/app/controllers/spree/admin/variants_controller.rb
@@ -32,7 +32,7 @@ module Spree
 
       def collection
         if params[:deleted] == "on"
-          base_variant_scope ||= Variant.only_deleted.where(product_id: parent.id)
+          base_variant_scope ||= super.with_deleted
         else
           base_variant_scope ||= super
         end

--- a/backend/app/controllers/spree/admin/variants_controller.rb
+++ b/backend/app/controllers/spree/admin/variants_controller.rb
@@ -31,12 +31,10 @@ module Spree
       end
 
       def collection
-        @deleted = (params.key?(:deleted) && params[:deleted] == "on") ? "checked" : ""
-
-        if @deleted.blank?
-          base_variant_scope ||= super
-        else
+        if params[:deleted] == "on"
           base_variant_scope ||= Variant.only_deleted.where(product_id: parent.id)
+        else
+          base_variant_scope ||= super
         end
 
         search = Spree::Config.variant_search_class.new(params[:variant_search_term], scope: base_variant_scope)

--- a/backend/app/views/spree/admin/shared/_product_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_product_tabs.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_product) %> &ldquo;<%= @product.name %>&rdquo;
+  <%= Spree::Product.model_name.human(count: :other) %> &#x2f; <%= @product.name %>
 <% end %>
 
 <% content_for :tabs do %>

--- a/backend/app/views/spree/admin/variants/_form.html.erb
+++ b/backend/app/views/spree/admin/variants/_form.html.erb
@@ -11,22 +11,24 @@
       <% end %>
     </div>
   </fieldset>
-  <fieldset class="no-border-top no-border-bottom">
-    <% @product.option_types.each_with_index do |option_type, index| %>
-      <div class="field four columns <%= 'alpha' if index % 3 == 0 %><%= 'omega' if index % 3 == 2 %>" data-hook="presentation">
-        <%= label :new_variant, option_type.presentation %>
-        <%= f.collection_select 'option_value_ids',
-                                option_type.option_values,
-                                :id,
-                                :presentation,
-                                { include_blank: true },
-                                {
-                                  name: 'variant[option_value_ids][]',
-                                  class: "select2 fullwidth"
-                                } %>
-      </div>
-    <% end %>
-  </fieldset>
+  <% if f.object.new_record? %>
+    <fieldset class="no-border-top no-border-bottom">
+      <% @product.option_types.each_with_index do |option_type, index| %>
+        <div class="field four columns <%= 'alpha' if index % 3 == 0 %><%= 'omega' if index % 3 == 2 %>" data-hook="presentation">
+          <%= label :new_variant, option_type.presentation %>
+          <%= f.collection_select 'option_value_ids',
+                                  option_type.option_values,
+                                  :id,
+                                  :presentation,
+                                  { include_blank: true },
+                                  {
+                                    name: 'variant[option_value_ids][]',
+                                    class: "select2 fullwidth"
+                                  } %>
+        </div>
+      <% end %>
+    </fieldset>
+  <% end %>
 </div>
 
 <div data-hook="admin_variant_form_additional_fields">

--- a/backend/app/views/spree/admin/variants/_form.html.erb
+++ b/backend/app/views/spree/admin/variants/_form.html.erb
@@ -1,49 +1,68 @@
-<div data-hook="admin_variant_form_fields" class="label-block left six columns alpha">
-  <div data-hook="variants">
-    <% @product.option_types.each do |option_type| %>
-      <div class="field" data-hook="presentation">
-        <%= label :new_variant, option_type.presentation %>
-        <%= f.collection_select 'option_value_ids', option_type.option_values, :id, :presentation,
-          { :include_blank => true }, { :name => 'variant[option_value_ids][]', :class => 'select2 fullwidth' } %>
-      </div>
-    <% end %>
-
-    <div class="field" data-hook="sku">
+<div data-hook="variants">
+  <fieldset class="no-border-top no-border-bottom">
+    <div class="field four columns alpha" data-hook="sku">
       <%= f.label :sku %>
       <%= f.text_field :sku, :class => 'fullwidth' %>
     </div>
+    <div class="field four columns checkbox" data-hook="track_inventory">
+      <%= f.label :track_inventory do %>
+        <%= f.check_box :track_inventory %>
+        <%= Spree::Variant.human_attribute_name(:track_inventory) %>
+      <% end %>
+    </div>
+  </fieldset>
+  <fieldset class="no-border-top no-border-bottom">
+    <% @product.option_types.each_with_index do |option_type, index| %>
+      <div class="field four columns <%= 'alpha' if index % 3 == 0 %><%= 'omega' if index % 3 == 2 %>" data-hook="presentation">
+        <%= label :new_variant, option_type.presentation %>
+        <%= f.collection_select 'option_value_ids',
+                                option_type.option_values,
+                                :id,
+                                :presentation,
+                                { include_blank: true },
+                                {
+                                  name: 'variant[option_value_ids][]',
+                                  class: "select2 fullwidth"
+                                } %>
+      </div>
+    <% end %>
+  </fieldset>
+</div>
 
-    <div class="field" data-hook="price">
+<div data-hook="admin_variant_form_additional_fields">
+  <fieldset class="no-border-top no-border-bottom">
+    <% [:weight, :height, :width, :depth].each_with_index do |field, index| %>
+      <div class="field four columns <%= 'alpha' if index % 4 == 0 %> <%= 'omega' if index % 4 == 3 %>" data-hook="<%= field %>">
+        <%= f.label field %>
+        <%= f.text_field field,
+                         value: number_with_precision(@variant.send(field), :precision => 2),
+                         class: 'fullwidth' %>
+      </div>
+    <% end %>
+  </fieldset>
+</div>
+
+<div data-hook="admin_variant_form_fields">
+  <fieldset class="no-border-top no-border-bottom">
+    <p> <%== t('.pricing_hint') %> </p>
+
+    <div class="field four columns alpha" data-hook="price">
       <%= f.label :price %>
       <%= f.text_field :price, :value => number_to_currency(@variant.price, :unit => ''), :class => 'fullwidth' %>
     </div>
 
-    <div class="field" data-hook="cost_price">
+    <div class="field four columns" data-hook="cost_price">
       <%= f.label :cost_price %>
       <%= f.text_field :cost_price, :value => number_to_currency(@variant.cost_price, :unit => ''), :class => 'fullwidth' %>
     </div>
 
-    <div class="field" data-hook="tax_category">
+    <div class="field four columns omega" data-hook="tax_category">
       <%= f.label :tax_category_id, Spree::TaxCategory.model_name.human %>
       <%= f.collection_select(:tax_category_id, @tax_categories, :id, :name, { :include_blank => Spree.t('match_choices.none') }, { :class => 'select2 fullwidth' }) %>
     </div>
-
-    <div class="field" data-hook="tax_category">
-      <label>
-        <%= f.check_box :track_inventory %>
-        <%= Spree.t(:track_inventory) %>
-      </label>
-    </div>
-  </div>
+  </fieldset>
 </div>
 
-<div class="right six columns omega label-block" data-hook="admin_variant_form_additional_fields">
-  <% [:weight, :height, :width, :depth].each do |field| %>
-    <div class="field" data-hook="<%= field %>"><%= f.label field, Spree.t(field) %>
-      <% value = number_with_precision(@variant.send(field), :precision => 2) %>
-      <%= f.text_field field, :value => value, :class => 'fullwidth' %>
-    </div>
-  <% end %>
-</div>
+
 
 <div class="clear"></div>

--- a/backend/app/views/spree/admin/variants/_form.html.erb
+++ b/backend/app/views/spree/admin/variants/_form.html.erb
@@ -59,8 +59,13 @@
     </div>
 
     <div class="field four columns omega" data-hook="tax_category">
-      <%= f.label :tax_category_id, Spree::TaxCategory.model_name.human %>
-      <%= f.collection_select(:tax_category_id, @tax_categories, :id, :name, { :include_blank => Spree.t('match_choices.none') }, { :class => 'select2 fullwidth' }) %>
+      <%= f.label :tax_category %>
+      <%= f.collection_select :tax_category_id,
+                              @tax_categories,
+                              :id,
+                              :name,
+                              { :include_blank => t('.use_product_tax_category') },
+                              { :class => 'select2 fullwidth' } %>
     </div>
   </fieldset>
 </div>

--- a/backend/app/views/spree/admin/variants/_table.html.erb
+++ b/backend/app/views/spree/admin/variants/_table.html.erb
@@ -1,0 +1,47 @@
+<%= paginate variants, theme: "solidus_admin" %>
+
+<table class="index sortable" data-sortable-link="<%= update_positions_admin_product_variants_path(@product) %>">
+  <colgroup>
+    <col style="width: 5%" />
+    <col style="width: 25%" />
+    <col style="width: 20%" />
+    <col style="width: 20%" />
+    <col style="width: 15%" />
+    <col style="width: 15%" />
+  </colgroup>
+  <thead data-hook="variants_header">
+    <tr>
+      <th colspan="2"><%= Spree.t(:options) %></th>
+      <th><%= Spree::Variant.human_attribute_name(:price) %></th>
+      <th><%= Spree::Variant.human_attribute_name(:sku) %></th>
+      <th class="actions"></th>
+    </tr>
+  </thead>
+  <tbody>
+  <% variants.each do |variant| %>
+    <tr id="<%= spree_dom_id variant %>" data-hook="variants_row" class="<%= "deleted" if variant.deleted? %> <%= cycle('odd', 'even')%>">
+      <td class="no-border">
+        <% if can? :update_positions, Spree::Variant %>
+          <span class="handle"></span>
+        <% end %>
+      </td>
+      <td><%= variant.options_text %></td>
+      <td class="align-center"><%= variant.display_price.to_html %></td>
+      <td class="align-center"><%= variant.sku %></td>
+      <td class="actions">
+        <% if can?(:update, variant) %>
+          <%= link_to_edit(variant, :no_text => true) unless variant.deleted? %>
+        <% end %>
+        <% if can?(:destroy, variant) %>
+          &nbsp;
+          <%= link_to_delete(variant, :no_text => true) unless variant.deleted? %>
+        <% end %>
+      </td>
+    </tr>
+    <% end %>
+    <% if variants.empty? %>
+      <tr><td colspan="4"><%= Spree.t(:none) %></td></tr>
+    <% end %>
+  </tbody>
+</table>
+<%= paginate variants, theme: "solidus_admin" %>

--- a/backend/app/views/spree/admin/variants/_table_filter.html.erb
+++ b/backend/app/views/spree/admin/variants/_table_filter.html.erb
@@ -1,0 +1,25 @@
+<% content_for :table_filter_title do %>
+  <%= Spree.t(:search) %>
+<% end %>
+
+<% content_for :table_filter do %>
+  <%= form_for :variant_search, url: spree.admin_product_variants_path(product), method: :get do |f| %>
+    <div data-hook="admin_variants_index_search" class="field thirteen columns alpha">
+      <%= f.label :variant_search_term, Spree.t(:variant_search_placeholder) %>
+      <%= text_field_tag :variant_search_term, params[:variant_search_term], :class => "fullwidth", :placeholder => Spree.t(:variant_search_placeholder) %>
+    </div>
+
+    <% if product.variants.only_deleted.any? %>
+      <div class="field checkbox three columns omega">
+        <%= label_tag :deleted do %>
+          <%= check_box_tag :deleted, "on", params[:deleted] == "on" %>
+          <%= t('.show_deleted') %>
+        <% end %>
+      </div>
+    <% end %>
+
+    <div class="actions filter-actions">
+      <%= f.button :search %>
+    </div>
+  <% end %>
+<% end %>

--- a/backend/app/views/spree/admin/variants/edit.html.erb
+++ b/backend/app/views/spree/admin/variants/edit.html.erb
@@ -1,10 +1,14 @@
 <%= render :partial => 'spree/admin/shared/product_tabs', :locals => { :current => 'Variants' } %>
 
+<% content_for :page_title do %>
+  &#x2f; <%= @variant.options_text %>
+<% end %>
+
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @variant } %>
 
 <%= form_for [:admin, @product, @variant] do |f| %>
   <fieldset>
-    <legend><%= t('.edit_variant', options_text: @variant.options_text) %></legend>
+    <legend><%= t('.edit_variant') %></legend>
     <div data-hook="admin_variant_edit_form">
       <%= render :partial => 'form', :locals => { :f => f } %>
     </div>

--- a/backend/app/views/spree/admin/variants/edit.html.erb
+++ b/backend/app/views/spree/admin/variants/edit.html.erb
@@ -3,7 +3,8 @@
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @variant } %>
 
 <%= form_for [:admin, @product, @variant] do |f| %>
-  <fieldset class="no-border-top">
+  <fieldset>
+    <legend><%= t('.edit_variant') %></legend>
     <div data-hook="admin_variant_edit_form">
       <%= render :partial => 'form', :locals => { :f => f } %>
     </div>

--- a/backend/app/views/spree/admin/variants/edit.html.erb
+++ b/backend/app/views/spree/admin/variants/edit.html.erb
@@ -4,7 +4,7 @@
 
 <%= form_for [:admin, @product, @variant] do |f| %>
   <fieldset>
-    <legend><%= t('.edit_variant') %></legend>
+    <legend><%= t('.edit_variant', options_text: @variant.options_text) %></legend>
     <div data-hook="admin_variant_edit_form">
       <%= render :partial => 'form', :locals => { :f => f } %>
     </div>

--- a/backend/app/views/spree/admin/variants/index.html.erb
+++ b/backend/app/views/spree/admin/variants/index.html.erb
@@ -74,9 +74,9 @@
     </tbody>
   </table>
   <%= paginate @variants, theme: "solidus_admin" %>
-<% else %>
 
-  <% if @product.empty_option_values? %>
+<% else %>
+  <% if !Spree::OptionType.any? %>
     <p class='first_add_option_types no-objects-found' data-hook="first_add_option_types">
       <%= Spree.t(:to_add_variants_you_must_first_define) %>
       <% if can?(:display, Spree::OptionType) %>
@@ -85,6 +85,11 @@
         <%= Spree::OptionType.model_name.human(count: :other) %>
       <% end %>
     </p>
+  <% elsif @product.empty_option_values? %>
+    <div class="alpha twelve columns no-objects-found">
+      <%= Spree.t :no_option_values_on_product_html,
+                  link: link_to(Spree.t(:product_details), [:edit, :admin, @product]) %>
+    </div>
   <% else %>
     <div class="alpha twelve columns no-objects-found">
       <%= Spree.t(:no_resource, resource: Spree::Variant.model_name.human(count: :other)) %>
@@ -92,20 +97,18 @@
         <%= link_to Spree.t(:create_one), new_object_url, remote: true %>
       <% end %>
     </div>
-  <% end %>
-<% end %>
-
-<% content_for :page_actions do %>
-  <ul class="inline-menu" data-hook="toolbar">
-    <% if can?(:create, Spree::Variant) && !@product.empty_option_values? %>
-      <li id="new_var_link" data-hook>
-        <%= link_to_with_icon('plus',
-                              Spree.t(:new_variant),
-                              new_admin_product_variant_url(@product),
-                              :remote => :true,
-                              :class => 'button'
-                             ) %>
-      </li>
+    <% content_for :page_actions do %>
+      <ul class="inline-menu" data-hook="toolbar">
+        <% if can?(:create, Spree::Variant) %>
+          <li id="new_var_link" data-hook>
+            <%= link_to_with_icon 'plus',
+                                  Spree.t(:new_variant),
+                                  new_admin_product_variant_url(@product),
+                                  :remote => :true,
+                                  :class => 'button' %>
+          </li>
+        <% end %>
+      </ul>
     <% end %>
-  </ul>
+  <% end %>
 <% end %>

--- a/backend/app/views/spree/admin/variants/index.html.erb
+++ b/backend/app/views/spree/admin/variants/index.html.erb
@@ -25,18 +25,21 @@
         <%= link_to Spree.t(:create_one), new_object_url, remote: true %>
       <% end %>
     </div>
-    <% content_for :page_actions do %>
-      <ul class="inline-menu" data-hook="toolbar">
-        <% if can?(:create, Spree::Variant) %>
-          <li id="new_var_link" data-hook>
-            <%= link_to_with_icon 'plus',
-                                  Spree.t(:new_variant),
-                                  new_admin_product_variant_url(@product),
-                                  :remote => :true,
-                                  :class => 'button' %>
-          </li>
-        <% end %>
-      </ul>
-    <% end %>
+  <% end %>
+<% end %>
+
+<% if !@product.empty_option_values? %>
+  <% content_for :page_actions do %>
+    <ul class="inline-menu" data-hook="toolbar">
+      <% if can?(:create, Spree::Variant) %>
+        <li id="new_var_link" data-hook>
+          <%= link_to_with_icon 'plus',
+                                Spree.t(:new_variant),
+                                new_admin_product_variant_url(@product),
+                                :remote => :true,
+                                :class => 'button' %>
+        </li>
+      <% end %>
+    </ul>
   <% end %>
 <% end %>

--- a/backend/app/views/spree/admin/variants/index.html.erb
+++ b/backend/app/views/spree/admin/variants/index.html.erb
@@ -1,80 +1,8 @@
-<%= render :partial => 'spree/admin/shared/product_tabs', :locals => {:current => 'Variants'} %>
+<%= render 'spree/admin/shared/product_tabs', current: 'Variants' %>
 
 <% if @variants.any? || @product.variants.only_deleted.any?%>
-  <% content_for :table_filter_title do %>
-    <%= Spree.t(:search) %>
-  <% end %>
-
-  <% content_for :table_filter do %>
-    <%= form_for :variant_search, url: spree.admin_product_variants_path(@product), method: :get do |f| %>
-      <div data-hook="admin_variants_index_search" class="field thirteen columns alpha">
-        <%= f.label :variant_search_term, Spree.t(:variant_search_placeholder) %>
-        <%= text_field_tag :variant_search_term, params[:variant_search_term], :class => "fullwidth", :placeholder => Spree.t(:variant_search_placeholder) %>
-      </div>
-
-      <% if @product.variants.only_deleted.any? %>
-        <div class="field checkbox three columns omega">
-          <%= label_tag :deleted do %>
-            <%= check_box_tag :deleted, "on", params[:deleted] == "on" %>
-            <%= t('.show_deleted') %>
-          <% end %>
-        </div>
-      <% end %>
-
-      <div class="actions filter-actions">
-        <%= f.button :search %>
-      </div>
-    <% end %>
-  <% end %>
-
-  <%= paginate @variants, theme: "solidus_admin" %>
-
-  <table class="index sortable" data-sortable-link="<%= update_positions_admin_product_variants_path(@product) %>">
-    <colgroup>
-      <col style="width: 5%" />
-      <col style="width: 25%" />
-      <col style="width: 20%" />
-      <col style="width: 20%" />
-      <col style="width: 15%" />
-      <col style="width: 15%" />
-    </colgroup>
-    <thead data-hook="variants_header">
-      <tr>
-        <th colspan="2"><%= Spree.t(:options) %></th>
-        <th><%= Spree::Variant.human_attribute_name(:price) %></th>
-        <th><%= Spree::Variant.human_attribute_name(:sku) %></th>
-        <th class="actions"></th>
-      </tr>
-    </thead>
-    <tbody>
-    <% @variants.each do |variant| %>
-      <tr id="<%= spree_dom_id variant %>" data-hook="variants_row" class="<%= "deleted" if variant.deleted? %> <%= cycle('odd', 'even')%>">
-        <td class="no-border">
-          <% if can? :update_positions, Spree::Variant %>
-            <span class="handle"></span>
-          <% end %>
-        </td>
-        <td><%= variant.options_text %></td>
-        <td class="align-center"><%= variant.display_price.to_html %></td>
-        <td class="align-center"><%= variant.sku %></td>
-        <td class="actions">
-          <% if can?(:update, variant) %>
-            <%= link_to_edit(variant, :no_text => true) unless variant.deleted? %>
-          <% end %>
-          <% if can?(:destroy, variant) %>
-            &nbsp;
-            <%= link_to_delete(variant, :no_text => true) unless variant.deleted? %>
-          <% end %>
-        </td>
-      </tr>
-      <% end %>
-      <% if @variants.empty? %>
-        <tr><td colspan="4"><%= Spree.t(:none) %></td></tr>
-      <% end %>
-    </tbody>
-  </table>
-  <%= paginate @variants, theme: "solidus_admin" %>
-
+  <%= render "table_filter", product: @product %>
+  <%= render "table", variants: @variants %>
 <% else %>
   <% if !Spree::OptionType.any? %>
     <p class='first_add_option_types no-objects-found' data-hook="first_add_option_types">

--- a/backend/app/views/spree/admin/variants/index.html.erb
+++ b/backend/app/views/spree/admin/variants/index.html.erb
@@ -1,10 +1,6 @@
 <%= render :partial => 'spree/admin/shared/product_tabs', :locals => {:current => 'Variants'} %>
 
-<%# Place for new variant form %>
-<div id="new_variant" data-hook></div>
-
 <% if @variants.any? || @product.variants.only_deleted.any?%>
-
   <% content_for :table_filter_title do %>
     <%= Spree.t(:search) %>
   <% end %>

--- a/backend/app/views/spree/admin/variants/index.html.erb
+++ b/backend/app/views/spree/admin/variants/index.html.erb
@@ -3,24 +3,25 @@
 <%# Place for new variant form %>
 <div id="new_variant" data-hook></div>
 
-<% content_for :table_filter_title do %>
-  <%= Spree.t(:search) %>
-<% end %>
+<% if @variants.any? || @product.variants.only_deleted.any?%>
 
-<% content_for :table_filter do %>
-  <%= form_for :variant_search, url: spree.admin_product_variants_path(@product), method: :get do |f| %>
-    <div data-hook="admin_variants_index_search" class="field fullwidth">
-      <%= f.label :variant_search_term, Spree.t(:variant_search_placeholder) %>
-      <%= text_field_tag :variant_search_term, params[:variant_search_term], :class => "fullwidth", :placeholder => Spree.t(:variant_search_placeholder) %>
-    </div>
-
-    <div class="actions filter-actions">
-      <%= f.button :search %>
-    </div>
+  <% content_for :table_filter_title do %>
+    <%= Spree.t(:search) %>
   <% end %>
-<% end %>
 
-<% if @variants.any? %>
+  <% content_for :table_filter do %>
+    <%= form_for :variant_search, url: spree.admin_product_variants_path(@product), method: :get do |f| %>
+      <div data-hook="admin_variants_index_search" class="field fullwidth">
+        <%= f.label :variant_search_term, Spree.t(:variant_search_placeholder) %>
+        <%= text_field_tag :variant_search_term, params[:variant_search_term], :class => "fullwidth", :placeholder => Spree.t(:variant_search_placeholder) %>
+      </div>
+
+      <div class="actions filter-actions">
+        <%= f.button :search %>
+      </div>
+    <% end %>
+  <% end %>
+
   <%= paginate @variants, theme: "solidus_admin" %>
 
   <table class="index sortable" data-sortable-link="<%= update_positions_admin_product_variants_path(@product) %>">
@@ -62,43 +63,50 @@
         </td>
       </tr>
       <% end %>
-      <% unless @product.has_variants? %>
-        <tr><td colspan="5"><%= Spree.t(:none) %></td></tr>
+      <% if @variants.empty? %>
+        <tr><td colspan="4"><%= Spree.t(:none) %></td></tr>
       <% end %>
     </tbody>
   </table>
   <%= paginate @variants, theme: "solidus_admin" %>
 <% else %>
-  <div class="alpha twelve columns no-objects-found">
-    <%= render 'spree/admin/shared/no_objects_found',
-                 resource: Spree::Variant,
-                 new_resource_url: new_object_url %>
-  </div>
+
+  <% if @product.empty_option_values? %>
+    <p class='first_add_option_types no-objects-found' data-hook="first_add_option_types">
+      <%= Spree.t(:to_add_variants_you_must_first_define) %>
+      <% if can?(:display, Spree::OptionType) %>
+        <%= link_to Spree::OptionType.model_name.human(count: :other), admin_option_types_path%>
+      <% else %>
+        <%= Spree::OptionType.model_name.human(count: :other) %>
+      <% end %>
+    </p>
+  <% else %>
+    <div class="alpha twelve columns no-objects-found">
+      <%= Spree.t(:no_resource, resource: Spree::Variant.model_name.human(count: :other)) %>
+      <% if can? :create, Spree::Variant %>
+        <%= link_to Spree.t(:create_one), new_object_url, remote: true %>
+      <% end %>
+    </div>
+  <% end %>
+
 <% end %>
 
-<% if @product.empty_option_values? %>
-  <p class='first_add_option_types no-objects-found' data-hook="first_add_option_types">
-    <%= Spree.t(:to_add_variants_you_must_first_define) %>
-    <% if can?(:display, Spree::OptionType) %>
-      <%= link_to Spree::OptionType.model_name.human(count: :other), admin_option_types_path%>
-    <% else %>
-      <%= Spree::OptionType.model_name.human(count: :other) %>
+
+<% content_for :page_actions do %>
+  <ul class="inline-menu" data-hook="toolbar">
+    <% if can?(:create, Spree::Variant) && !@product.empty_option_values? %>
+      <li id="new_var_link" data-hook>
+        <%= link_to_with_icon('plus',
+                              Spree.t(:new_variant),
+                              new_admin_product_variant_url(@product),
+                              :remote => :true,
+                              :class => 'button'
+                             ) %>
+      </li>
     <% end %>
-  </p>
-<% else %>
-  <% content_for :page_actions do %>
-    <ul class="inline-menu" data-hook="toolbar">
-      <% if can?(:create, Spree::Variant) %>
-        <li id="new_var_link" data-hook>
-          <%= link_to_with_icon('plus',
-                                Spree.t(:new_variant),
-                                new_admin_product_variant_url(@product),
-                                :remote => :true,
-                                :class => 'button'
-                               ) %>
-        </li>
-      <% end %>
+
+    <% if @product.variants.only_deleted.any? %>
       <li><%= link_to_with_icon('filter', @deleted.blank? ? Spree.t(:show_deleted) : Spree.t(:show_active), admin_product_variants_url(@product, :deleted => @deleted.blank? ? "on" : "off"), :class => 'button') %></li>
-    </ul>
-  <% end %>
+    <% end %>
+  </ul>
 <% end %>

--- a/backend/app/views/spree/admin/variants/index.html.erb
+++ b/backend/app/views/spree/admin/variants/index.html.erb
@@ -12,6 +12,15 @@
         <%= text_field_tag :variant_search_term, params[:variant_search_term], :class => "fullwidth", :placeholder => Spree.t(:variant_search_placeholder) %>
       </div>
 
+      <% if @product.variants.only_deleted.any? %>
+        <div class="checkbox">
+          <%= label_tag :deleted do %>
+            <%= check_box_tag :deleted, "on", params[:deleted] == "on" %>
+            <%= t('.show_deleted') %>
+          <% end %>
+        </div>
+      <% end %>
+
       <div class="actions filter-actions">
         <%= f.button :search %>
       </div>
@@ -84,9 +93,7 @@
       <% end %>
     </div>
   <% end %>
-
 <% end %>
-
 
 <% content_for :page_actions do %>
   <ul class="inline-menu" data-hook="toolbar">
@@ -99,10 +106,6 @@
                               :class => 'button'
                              ) %>
       </li>
-    <% end %>
-
-    <% if @product.variants.only_deleted.any? %>
-      <li><%= link_to_with_icon('filter', @deleted.blank? ? Spree.t(:show_deleted) : Spree.t(:show_active), admin_product_variants_url(@product, :deleted => @deleted.blank? ? "on" : "off"), :class => 'button') %></li>
     <% end %>
   </ul>
 <% end %>

--- a/backend/app/views/spree/admin/variants/index.html.erb
+++ b/backend/app/views/spree/admin/variants/index.html.erb
@@ -7,13 +7,13 @@
 
   <% content_for :table_filter do %>
     <%= form_for :variant_search, url: spree.admin_product_variants_path(@product), method: :get do |f| %>
-      <div data-hook="admin_variants_index_search" class="field fullwidth">
+      <div data-hook="admin_variants_index_search" class="field thirteen columns alpha">
         <%= f.label :variant_search_term, Spree.t(:variant_search_placeholder) %>
         <%= text_field_tag :variant_search_term, params[:variant_search_term], :class => "fullwidth", :placeholder => Spree.t(:variant_search_placeholder) %>
       </div>
 
       <% if @product.variants.only_deleted.any? %>
-        <div class="checkbox">
+        <div class="field checkbox three columns omega">
           <%= label_tag :deleted do %>
             <%= check_box_tag :deleted, "on", params[:deleted] == "on" %>
             <%= t('.show_deleted') %>
@@ -48,7 +48,7 @@
     </thead>
     <tbody>
     <% @variants.each do |variant| %>
-      <tr id="<%= spree_dom_id variant %>" <%= 'style="color:red;"' if variant.deleted? %> data-hook="variants_row" class="<%= cycle('odd', 'even')%>">
+      <tr id="<%= spree_dom_id variant %>" data-hook="variants_row" class="<%= "deleted" if variant.deleted? %> <%= cycle('odd', 'even')%>">
         <td class="no-border">
           <% if can? :update_positions, Spree::Variant %>
             <span class="handle"></span>

--- a/backend/app/views/spree/admin/variants/new.html.erb
+++ b/backend/app/views/spree/admin/variants/new.html.erb
@@ -2,7 +2,7 @@
 
 <%= form_for [:admin, @product, @variant] do |f| %>
   <fieldset data-hook="admin_variant_new_form">
-    <legend align="center"><%= Spree.t(:new_variant) %></legend>
+    <legend><%= t('.new_variant') %></legend>
     <%= render :partial => 'form', :locals => { :f => f } %>
     <%= render :partial => 'spree/admin/shared/new_resource_links' %>
   </fieldset>

--- a/backend/app/views/spree/admin/variants/new.js.erb
+++ b/backend/app/views/spree/admin/variants/new.js.erb
@@ -1,3 +1,2 @@
-$("#new_variant").html('<%= escape_javascript(render :template => 'spree/admin/variants/new', :formats => [:html], :handlers => [:erb]) %>');
-$("#new_variant .select2").select2();
-$("#new_var_link").hide();
+$(".js-content-below-tabs").html('<%= escape_javascript(render :template => 'spree/admin/variants/new', :formats => [:html], :handlers => [:erb]) %>');
+$(".js-content-below-tabs .select2").select2();

--- a/backend/app/views/spree/layouts/admin.html.erb
+++ b/backend/app/views/spree/layouts/admin.html.erb
@@ -19,7 +19,7 @@
                 <%= yield :tabs %>
               </div>
             <% end %>
-            <div class="<%= if content_for?(:sidebar) then 'twelve' else 'sixteen' end %> columns">
+            <div class="js-content-below-tabs <%= if content_for?(:sidebar) then 'twelve' else 'sixteen' end %> columns">
               <%= render :partial => 'spree/admin/shared/table_filter' %>
               <%= yield %>
             </div>

--- a/backend/spec/controllers/spree/admin/variants_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/variants_controller_spec.rb
@@ -10,19 +10,20 @@ module Spree
         let!(:variant_1) { create(:variant, product: product) }
         let!(:variant_2) { create(:variant, product: product) }
 
+        before { variant_2.destroy }
+
         context "deleted is not requested" do
-          it "assigns the variants for a requested product" do
+          it "does not assign deleted variants for a requested product" do
             spree_get :index, product_id: product.slug
             expect(assigns(:collection)).to include variant_1
-            expect(assigns(:collection)).to include variant_2
+            expect(assigns(:collection)).not_to include variant_2
           end
         end
 
         context "deleted is requested" do
-          before { variant_2.destroy }
-          it "assigns only deleted variants for a requested product" do
+          it "assigns deleted along with non-deleted variants for a requested product" do
             spree_get :index, product_id: product.slug, deleted: "on"
-            expect(assigns(:collection)).not_to include variant_1
+            expect(assigns(:collection)).to include variant_1
             expect(assigns(:collection)).to include variant_2
           end
         end

--- a/backend/spec/features/admin/products/edit/products_spec.rb
+++ b/backend/spec/features/admin/products/edit/products_spec.rb
@@ -15,7 +15,7 @@ describe 'Product Details', type: :feature do
 
       click_link 'Product Details'
 
-      expect(page).to have_css('.page-title', text: 'Editing Product “Bún thịt nướng”')
+      expect(page).to have_css('.page-title', text: 'Products / Bún thịt nướng')
       expect(page).to have_field('product_name', with: 'Bún thịt nướng')
       expect(page).to have_field('product_slug', with: 'bun-th-t-n-ng')
       expect(page).to have_field('product_description', with: 'lorem ipsum')

--- a/backend/spec/features/admin/products/properties_spec.rb
+++ b/backend/spec/features/admin/products/properties_spec.rb
@@ -117,7 +117,7 @@ describe "Properties", type: :feature do
     end
 
     def fill_in_property
-      expect(page).to have_content('Editing Product')
+      expect(page).to have_content('Products')
       fill_in "product_product_properties_attributes_0_property_name", with: "A Property"
       fill_in "product_product_properties_attributes_0_value", with: "A Value"
       click_button "Update"

--- a/backend/spec/features/admin/products/stock_management_spec.rb
+++ b/backend/spec/features/admin/products/stock_management_spec.rb
@@ -36,7 +36,7 @@ describe "Stock Management", type: :feature do
       end
 
       it "renders" do
-        expect(page).to have_content(Spree.t(:editing_product))
+        expect(page).to have_content('Products / apache baseball cap')
         expect(page.current_url).to match("admin/products/apache-baseball-cap/stock")
       end
     end

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -24,6 +24,7 @@ module Spree
     delegate :name, :description, :slug, :available_on, :shipping_category_id,
              :meta_description, :meta_keywords, :shipping_category,
              to: :product
+    delegate :tax_category, to: :product, prefix: true
 
     has_many :inventory_units, inverse_of: :variant
     has_many :line_items, inverse_of: :variant
@@ -86,12 +87,12 @@ module Spree
     end
 
     # @return [Spree::TaxCategory] the variant's tax category
+    #
+    # This returns the product's tax category if the tax category ID on the variant is nil. It looks
+    # like an association, but really is an override.
+    #
     def tax_category
-      if self[:tax_category_id].nil?
-        product.tax_category
-      else
-        TaxCategory.find(self[:tax_category_id])
-      end
+      super || product_tax_category
     end
 
     # Sets the cost_price for the variant.

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -725,7 +725,7 @@ en:
         new:
           new_variant: New variant
         edit:
-          edit_variant: Edit variant
+          edit_variant: "Edit variant - %{options_text}"
         form:
           dimensions: Dimensions
           pricing: Pricing

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -307,6 +307,7 @@ en:
         height: Height
         price: Price
         sku: SKU
+        tax_category: Variant tax category
         weight: Weight
         width: Width
       spree/zone:
@@ -728,6 +729,7 @@ en:
           edit_variant: "Edit variant - %{options_text}"
         form:
           dimensions: Dimensions
+          use_product_tax_category: Use Product Tax Category
           pricing: Pricing
           pricing_hint: These values are populated from the product details page and can be overridden below
     administration: Administration

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -721,6 +721,15 @@ en:
           amount_authorized_exceeds_total_credit: " exceeds the available credit"
           amount_used_not_zero: "is greater than zero. Can not delete store credit"
           update_reason_required: "A reason for the change must be selected"
+      variants:
+        new:
+          new_variant: New variant
+        edit:
+          edit_variant: Edit variant
+        form:
+          dimensions: Dimensions
+          pricing: Pricing
+          pricing_hint: These values are populated from the product details page and can be overridden below
     administration: Administration
     agree_to_privacy_policy: Agree to Privacy Policy
     agree_to_terms_of_service: Agree to Terms of Service

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -723,6 +723,8 @@ en:
           amount_used_not_zero: "is greater than zero. Can not delete store credit"
           update_reason_required: "A reason for the change must be selected"
       variants:
+        index:
+          show_deleted: Show deleted variants
         new:
           new_variant: New variant
         edit:

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1256,6 +1256,7 @@ en:
     no_images_found: No images found
     no_inventory_selected: No inventory selected
     no_orders_found: No orders found
+    no_option_values_on_product_html: "This product has no associated option values. Add some to it through Option Types in the %{link}."
     no_payment_methods_found: No payment methods found
     no_payment_found: No payment found
     no_pending_payments: No pending payments

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -728,7 +728,7 @@ en:
         new:
           new_variant: New variant
         edit:
-          edit_variant: "Edit variant - %{options_text}"
+          edit_variant: Edit Variant
         form:
           dimensions: Dimensions
           use_product_tax_category: Use Product Tax Category


### PR DESCRIPTION
In order to add somewhere to edit prices, I need the variant form
to be somewhat more structured than it has been in the past. Using
nested `fieldset` elements with `legend`s, this commit breaks the
edit variant form up in a "general", a "pricing" and a "shipping"
section, each with the relevant input fields.

In order to be consistent with the search form on the index page,
I chose a four-column layout.

All `data-hook`s are still there, although I moved some of them.

I also improved I18n, using the t('.something') helper which looks
translations up according to the name of the partial from which the
`t` is called. This pattern has been (sort of) used in the user and store
credit partials already, and does really good namespacing.

**New search box, and `deleted` checkbox next to it**
![solidus administration variants 2016-04-05 18-08-25](https://cloud.githubusercontent.com/assets/703401/14289200/1082669c-fb5a-11e5-90bc-7496d14e8186.png)

**`New Variant` form, now full-width**
![solidus administration variants 2016-04-05 18-08-54](https://cloud.githubusercontent.com/assets/703401/14289201/1083fce6-fb5a-11e5-9197-1f8bbe012693.png)

**`Edit Variant` form, now full-width, without allowing the user to edit option values** 
![solidus administration variants 2016-04-05 18-09-19](https://cloud.githubusercontent.com/assets/703401/14289202/10853872-fb5a-11e5-956d-914b4db3531b.png)

**When checking the `Show deleted variants` checkbox, deleted are shown in red**
![solidus administration variants 2016-04-05 18-09-40](https://cloud.githubusercontent.com/assets/703401/14289198/1081c4a8-fb5a-11e5-9eb6-2f0e9466fe9f.png)

**Link to product details page if no option values are set for this product**
![solidus administration variants 2016-04-05 18-10-49](https://cloud.githubusercontent.com/assets/703401/14289199/10823be0-fb5a-11e5-8fb4-995c1d2a7b5c.png)




