### PR TITLE
line_item factory uses price matching variant

### DIFF
--- a/core/lib/spree/testing_support/factories/line_item_factory.rb
+++ b/core/lib/spree/testing_support/factories/line_item_factory.rb
@@ -4,7 +4,7 @@ require 'spree/testing_support/factories/product_factory'
 FactoryGirl.define do
   factory :line_item, class: Spree::LineItem do
     quantity 1
-    price { BigDecimal.new('10.00') }
+    price { variant.price }
     order
     transient do
       product nil

--- a/core/spec/lib/spree/core/testing_support/factories/inventory_unit_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/inventory_unit_factory_spec.rb
@@ -9,4 +9,12 @@ RSpec.describe 'inventory unit factory' do
 
     it_behaves_like 'a working factory'
   end
+
+  describe 'with passed in variant' do
+    let(:variant) { build(:variant) }
+    subject { build(:inventory_unit, variant: variant) }
+    it "has a line_item with proper price" do
+      expect(subject.line_item.price).to eq(variant.price)
+    end
+  end
 end


### PR DESCRIPTION
The use case where I ran into this: I was doing a `build(:stock_package)` for test data. I was passing in `variants_contents` to make a `Stock::Package` with the variants and quantities I want. 

It had the variants and quantities I wanted, but the `package.contents[x].line_item` LineItem had a price that didn't match it's `variant`, which interfered with the testing I wanted to do. 

After some debugging, this was because the `line_item` factory sets it's `price` attribute independently from it's `variant` attribute. And starting at a `package`, there's really no way to manually pass a `price` in either. You'd have to construct a whole lot of stuff manually and put it all together manually, which is confusing with spree/solidus complex object graph, and what factories are supposed to save you from. 

The solution seems to be just fixing the `line_item` factory so it's default `price` comes from it's variant. This makes it better typical default data, as you expect from factories. 

The spec contributed is on the `inventory_unit` factory, because that was involved in the chain of factories in my use case, and shows the point of why this would be done -- so factories _using_ the `line_item` factory get consistent expected data when passing in a specified `variant`. 