### PR TITLE
Remove unused Gateway.current method

### DIFF
--- a/core/app/models/spree/gateway.rb
+++ b/core/app/models/spree/gateway.rb
@@ -11,11 +11,6 @@ module Spree
       CreditCard
     end
 
-    # instantiates the selected gateway and configures with the options stored in the database
-    def self.current
-      super
-    end
-
     def provider
       gateway_options = options
       gateway_options.delete :login if gateway_options.key?(:login) && gateway_options[:login].nil?

--- a/sample/db/samples/payments.rb
+++ b/sample/db/samples/payments.rb
@@ -1,13 +1,6 @@
 # create payments based on the totals since they can't be known in YAML (quantities are random)
 method = Spree::PaymentMethod.where(name: 'Credit Card', active: true).first
 
-# Hack the current method so we're able to return a gateway without a RAILS_ENV
-Spree::Gateway.class_eval do
-  def self.current
-    Spree::Gateway::Bogus.new
-  end
-end
-
 # This table was previously called spree_creditcards, and older migrations
 # reference it as such. Make it explicit here that this table has been renamed.
 Spree::CreditCard.table_name = 'spree_credit_cards'


### PR DESCRIPTION
The 'super' method referenced here doesn't exist.  It was removed in:
https://github.com/solidusio/solidus/commit/df32600