### PR TITLE
Make the reference to Spree::Store explicit in app config.

### DIFF
--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -361,7 +361,7 @@ module Spree
       # support all the old preference methods with a warning
       define_method "preferred_#{old_preference_name}" do
         ActiveSupport::Deprecation.warn("#{old_preference_name} is no longer supported on Spree::Config, please access it through #{store_method} on Spree::Store", bc.clean(caller))
-        Store.default.send(store_method)
+        Spree::Store.default.send(store_method)
       end
     end
   end


### PR DESCRIPTION
This appeared to be the source of a code reloading issue when this logic
was called. I've patched it by simply removing the deprecated logic, but
adding the spree namespace here seemed to improve the rails constant
autoloading issues around this particular part of the code.

The error I saw was: ArgumentError: A copy of Spree::AppConfiguration
was removed from the module tree but is still active. We narrowed this
down to the fact rails may have been looking for the constant on
AppConfiguration and using a more qualified name would make this more
robust.