### PR TITLE
Deprecate User#drop_payment_source & Gateway#disable_customer_profile

### DIFF
--- a/core/app/models/concerns/spree/user_payment_source.rb
+++ b/core/app/models/concerns/spree/user_payment_source.rb
@@ -15,7 +15,7 @@ module Spree
     end
 
     def drop_payment_source(source)
-      ActiveSupport::Deprecation.warn("User#drop_payment_source is deprecated")
+      ActiveSupport::Deprecation.warn("User#drop_payment_source is deprecated", caller)
       gateway = source.payment_method
       gateway.disable_customer_profile(source)
     end

--- a/core/app/models/concerns/spree/user_payment_source.rb
+++ b/core/app/models/concerns/spree/user_payment_source.rb
@@ -15,6 +15,7 @@ module Spree
     end
 
     def drop_payment_source(source)
+      ActiveSupport::Deprecation.warn("User#drop_payment_source is deprecated")
       gateway = source.payment_method
       gateway.disable_customer_profile(source)
     end

--- a/core/app/models/spree/gateway.rb
+++ b/core/app/models/spree/gateway.rb
@@ -44,6 +44,7 @@ module Spree
     end
 
     def disable_customer_profile(source)
+      ActiveSupport::Deprecation.warn("Gateway#disable_customer_profile is deprecated")
       if source.is_a? CreditCard
         source.update_column :gateway_customer_profile_id, nil
       else

--- a/core/spec/models/spree/gateway/bogus_spec.rb
+++ b/core/spec/models/spree/gateway/bogus_spec.rb
@@ -6,7 +6,9 @@ module Spree
     let!(:cc) { create(:credit_card, payment_method: bogus, gateway_customer_profile_id: "BGS-RERTERT") }
 
     it "disable recurring contract by destroying payment source" do
-      bogus.disable_customer_profile(cc)
+      ActiveSupport::Deprecation.silence do
+        bogus.disable_customer_profile(cc)
+      end
       expect(cc.gateway_customer_profile_id).to be_nil
     end
   end

--- a/core/spec/models/spree/user_spec.rb
+++ b/core/spec/models/spree/user_spec.rb
@@ -96,7 +96,9 @@ describe Spree::LegacyUser, type: :model do
       end
 
       it "drops payment source" do
-        user.drop_payment_source cc
+        ActiveSupport::Deprecation.silence do
+          user.drop_payment_source cc
+        end
         expect(cc.gateway_customer_profile_id).to be_nil
       end
     end


### PR DESCRIPTION
These are not used within Solidus itself.
Erasing data doesn't seem like the right way to 'disable' something.
`User#drop_payment_source` is not an accurate name for what that
method did.
It uses `update_column` for no reason that I could ascertain.
I did a quick survey of github and could find only one public repo
that is currently using this:
https://github.com/sprangular/sprangular/blob/v0.1.0/app/controllers/sprangular/credit_cards_controller.rb

I was looking at this while looking at what it takes to create a
non-credit-card payment source.

If people feel like it's important to keep this that's fine, I'm just looking
at things that could simplify having non-credit-card payment sources.