### PR TITLE
Variant: Load default price also when including the relation

### DIFF
--- a/core/app/models/concerns/spree/default_price.rb
+++ b/core/app/models/concerns/spree/default_price.rb
@@ -4,7 +4,7 @@ module Spree
 
     included do
       has_one :default_price,
-        -> { where currency: Spree::Config[:currency], is_default: true },
+        -> { with_deleted.where(currency: Spree::Config[:currency], is_default: true) },
         class_name: 'Spree::Price',
         inverse_of: :variant,
         dependent: :destroy,
@@ -20,10 +20,6 @@ module Spree
     delegate :display_price, :display_amount,
       :price, :price=, :currency, :currency=,
       to: :find_or_build_default_price
-
-    def default_price
-      Spree::Price.unscoped { super }
-    end
 
     def has_default_price?
       !default_price.nil?

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -489,10 +489,19 @@ describe Spree::Variant, type: :model do
   end
 
   describe "deleted_at scope" do
-    before { variant.destroy && variant.reload }
-    it "should have a price if deleted" do
-      variant.price = 10
-      expect(variant.price).to eq(10)
+    let!(:previous_variant_price) { variant.display_price }
+
+    before { variant.destroy }
+
+    it "should keep its price if deleted" do
+      expect(variant.display_price).to eq(previous_variant_price)
+    end
+
+    context 'when loading with pre-fetching of default_price' do
+      it 'also keeps the previous price' do
+        reloaded_variant = Spree::Variant.with_deleted.includes(:default_price).find_by(id: variant.id)
+        expect(reloaded_variant.display_price).to eq(previous_variant_price)
+      end
     end
   end
 


### PR DESCRIPTION
Previously, the admin screen for deleted variants would always show
a price of zero, because the preloaded default_price relation would
not respect the `Spree::Price.unscoped { super }` override.

This commit introduces the `with_deleted` scope into the relation,
fixing the apparnent nilling of the price in the backend.