### PR TITLE
Variant: Remove duplicated option value accessor spec

### DIFF
--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -85,39 +85,6 @@ describe Spree::Variant, type: :model do
         }.to change(multi_variant.option_values, :count).by(1)
       end
     end
-
-    context "product has other variants" do
-      describe "option value accessors" do
-        before {
-          @multi_variant = create(:variant, product: variant.product)
-          variant.product.reload
-        }
-
-        let(:multi_variant) { @multi_variant }
-
-        it "should set option value" do
-          expect(multi_variant.option_value('media_type')).to be_nil
-
-          multi_variant.set_option_value('media_type', 'DVD')
-          expect(multi_variant.option_value('media_type')).to eql 'DVD'
-
-          multi_variant.set_option_value('media_type', 'CD')
-          expect(multi_variant.option_value('media_type')).to eql 'CD'
-        end
-
-        it "should not duplicate associated option values when set multiple times" do
-          multi_variant.set_option_value('media_type', 'CD')
-
-          expect {
-           multi_variant.set_option_value('media_type', 'DVD')
-          }.to_not change(multi_variant.option_values, :count)
-
-          expect {
-            multi_variant.set_option_value('coolness_type', 'awesome')
-          }.to change(multi_variant.option_values, :count).by(1)
-        end
-      end
-    end
   end
 
   context "#cost_price=" do


### PR DESCRIPTION
These specs are still there, just a little above.