### PR TITLE
Do not delete option value configuration when destroying variant

### DIFF
--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -33,7 +33,7 @@ module Spree
     has_many :stock_locations, through: :stock_items
     has_many :stock_movements, through: :stock_items
 
-    has_many :option_values_variants, dependent: :destroy
+    has_many :option_values_variants
     has_many :option_values, through: :option_values_variants
 
     has_many :images, -> { order(:position) }, as: :viewable, dependent: :destroy, class_name: "Spree::Image"
@@ -56,6 +56,8 @@ module Spree
     after_create :set_master_out_of_stock, unless: :is_master?
 
     after_touch :clear_in_stock_cache
+
+    after_real_destroy :destroy_option_values_variants
 
     # Returns variants that are in stock. When stock locations are provided as
     # a parameter, the scope is limited to variants that are in stock in the
@@ -372,6 +374,10 @@ module Spree
 
     def clear_in_stock_cache
       Rails.cache.delete(in_stock_cache_key)
+    end
+
+    def destroy_option_values_variants
+      option_values_variants.destroy_all
     end
   end
 end

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -84,6 +84,27 @@ describe Spree::Variant, type: :model do
           multi_variant.set_option_value('coolness_type', 'awesome')
         }.to change(multi_variant.option_values, :count).by(1)
       end
+
+      context "and a variant is soft-deleted" do
+        let!(:old_options_text) { variant.options_text }
+
+        before { variant.destroy }
+
+        it "still keeps the option values for that variant" do
+          expect(variant.reload.options_text).to eq(old_options_text)
+        end
+      end
+
+      context "and a variant is really deleted" do
+        let!(:old_option_values_variant_ids) { variant.option_values_variants.pluck(:id) }
+
+        before { variant.really_destroy! }
+
+        it "leaves no stale records behind" do
+          expect(old_option_values_variant_ids).to be_present
+          expect(Spree::OptionValuesVariant.where(id: old_option_values_variant_ids)).to be_empty
+        end
+      end
     end
 
     context "product has other variants" do


### PR DESCRIPTION
Before this change, a soft-deleted variant would have its
option value variants join table entries hard-deleted. The effect
of this behaviour was that in the backend, your deleted variants
would have no options and would be, therefore, indistinguishable.

The alternative would have been to make `Spree::OptionValuesVariants` also
act as paranoid. However, this leads to many complications. Instead, I just make sure
that all option values join table entries are actually destroyed when
the record is acutally removed from the database.