### PR TITLE
Use tabs on product edit page

### DIFF
--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -1,6 +1,6 @@
 <div data-hook="admin_product_form_fields">
 
-  <div class="left eight columns alpha" data-hook="admin_product_form_left">
+  <div class="left twelve columns alpha" data-hook="admin_product_form_left">
     <div data-hook="admin_product_form_name">
       <%= f.field_container :name do %>
         <%= f.label :name, class: 'required' %>

--- a/backend/app/views/spree/admin/shared/_product_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_product_tabs.html.erb
@@ -2,13 +2,9 @@
   <%= Spree.t(:editing_product) %> &ldquo;<%= @product.name %>&rdquo;
 <% end %>
 
-<% content_for :sidebar_title do %>
-  <span class="sku"><%= @product.sku %></span>
-<% end %>
-
-<% content_for :sidebar do %>
-  <nav class="menu">
-    <ul data-hook="admin_product_tabs">
+<% content_for :tabs do %>
+  <nav>
+    <ul class="tabs" data-hook="admin_product_tabs">
       <%= content_tag :li, :class => ('active' if current == 'Product Details') do %>
         <%= link_to_with_icon 'edit', Spree.t(:product_details), edit_admin_product_url(@product) %>
       <% end if can?(:admin, Spree::Product) %>
@@ -26,5 +22,4 @@
       <% end if can?(:admin, Spree::StockItem) %>
     </ul>
   </nav>
-
 <% end %>

--- a/backend/spec/features/admin/products/edit/variants_spec.rb
+++ b/backend/spec/features/admin/products/edit/variants_spec.rb
@@ -15,7 +15,7 @@ describe "Product Variants", type: :feature do
 
       within_row(1) { click_icon :edit }
 
-      within('#sidebar') { click_link "Variants" }
+      within('nav > ul.tabs') { click_link "Variants" }
       expect(page).to have_content("TO ADD VARIANTS, YOU MUST FIRST DEFINE")
     end
 
@@ -43,7 +43,7 @@ describe "Product Variants", type: :feature do
       click_button "Update"
       expect(page).to have_content("successfully updated!")
 
-      within('#sidebar') { click_link "Variants" }
+      within('nav > ul.tabs') { click_link "Variants" }
       click_link "New Variant"
 
       targetted_select2 "black", from: "#s2id_variant_option_value_ids"


### PR DESCRIPTION
We have a great new tabs feature to replace the third-level sidebar
navigation. This commit uses the tabs feature on the product edit page.

For the time being, the only point where this messed up the existing layout
was `products#edit`. I solved it by making the first container full-width and
using the new sidebar space for pricing, variant and dimension options.

By the way: This has been amazing easy. Yay @graygilmore !

![solidus administration products 2016-04-04 13-30-06](https://cloud.githubusercontent.com/assets/703401/14246775/a023e312-fa69-11e5-8762-0521c4c6092d.png)