### PR TITLE
Use Solidus variant searcher in backend variant index

### DIFF
--- a/backend/app/controllers/spree/admin/variants_controller.rb
+++ b/backend/app/controllers/spree/admin/variants_controller.rb
@@ -4,7 +4,6 @@ module Spree
       belongs_to 'spree/product', find_by: :slug
       new_action.before :new_before
       before_action :load_data, only: [:new, :create, :edit, :update]
-      before_action :load_option_types_values, only: [:index]
 
       # override the destroy method to set deleted_at value
       # instead of actually deleting the product.
@@ -44,17 +43,12 @@ module Spree
         @collection = search.results.includes(variant_includes).page(params[:page]).per(Spree::Config[:admin_variants_per_page])
       end
 
-      def load_option_types_values
-        @option_types = parent.option_types.includes(:option_values)
-        @option_values = @option_types.flat_map(&:option_values).uniq(&:presentation)
-      end
-
       def load_data
         @tax_categories = TaxCategory.order(:name)
       end
 
       def variant_includes
-        [{ option_values: :option_type }, :default_price, :stock_items]
+        [{ option_values: :option_type }, :default_price]
       end
     end
   end

--- a/backend/app/controllers/spree/admin/variants_controller.rb
+++ b/backend/app/controllers/spree/admin/variants_controller.rb
@@ -35,16 +35,13 @@ module Spree
         @deleted = (params.key?(:deleted) && params[:deleted] == "on") ? "checked" : ""
 
         if @deleted.blank?
-          @collection ||= super
+          base_variant_scope ||= super
         else
-          @collection ||= Variant.only_deleted.where(product_id: parent.id)
+          base_variant_scope ||= Variant.only_deleted.where(product_id: parent.id)
         end
 
-        params[:q] ||= {}
-
-        # @search needs to be defined as this is passed to search_form_for
-        @search = @collection.ransack(params[:q])
-        @collection = @search.result.includes(variant_includes).page(params[:page]).per(Spree::Config[:admin_variants_per_page])
+        search = Spree::Config.variant_search_class.new(params[:variant_search_term], scope: base_variant_scope)
+        @collection = search.results.includes(variant_includes).page(params[:page]).per(Spree::Config[:admin_variants_per_page])
       end
 
       def load_option_types_values

--- a/backend/app/views/spree/admin/variants/index.html.erb
+++ b/backend/app/views/spree/admin/variants/index.html.erb
@@ -8,39 +8,16 @@
 <% end %>
 
 <% content_for :table_filter do %>
-  <div data-hook="admin_variants_sidebar">
+  <%= form_for :variant_search, url: spree.admin_product_variants_path(@product), method: :get do |f| %>
+    <div data-hook="admin_variants_index_search" class="field fullwidth">
+      <%= f.label :variant_search_term, Spree.t(:variant_search_placeholder) %>
+      <%= text_field_tag :variant_search_term, params[:variant_search_term], :class => "fullwidth", :placeholder => Spree.t(:variant_search_placeholder) %>
+    </div>
 
-    <%= search_form_for [:admin, @search], url: admin_product_variants_url(product: @product) do |f| %>
-
-      <%- locals = {:f => f} %>
-
-      <div class="three columns">
-        <div class="field">
-          <%= f.label :sku_cont, Spree.t(:sku) %>
-          <%= f.text_field :sku_cont, :size => 15 %>
-        </div>
-      </div>
-
-      <% @option_types.each do |option_type| %>
-        <div data-hook="admin_variants_index_search">
-          <div class="three columns">
-            <div class="field">
-              <% option_values = @option_values.select { |ov| ov.option_type_id == option_type.id } %>
-              <%= f.label :option_values_presentation_in, option_type.presentation %>
-              <br />
-              <%= f.collection_select :option_values_presentation_in, option_values.sort_by(&:presentation), :presentation, :presentation, { :include_blank => Spree.t('match_choices.none') }, { class: "select2 fullwidth" } %>
-            </div>
-          </div>
-        </div>
-      <% end %>
-
-      <div class="clear"></div>
-
-      <div class="form-buttons actions filter-actions" data-hook="admin_products_index_search_buttons">
-        <%= button Spree.t(:search), 'search' %>
-      </div>
-    <% end %>
-  </div>
+    <div class="actions filter-actions">
+      <%= f.button :search %>
+    </div>
+  <% end %>
 <% end %>
 
 <% if @variants.any? %>


### PR DESCRIPTION
Before this commit, the variant search was broken - it would
only send query data from the last select box present.

This commit replaces the Ransack search form with the variant search
we're already using in the stock locations tab.

New variant search form: 
![solidus administration variants 2016-04-04 19-45-15](https://cloud.githubusercontent.com/assets/703401/14257421/04fc31ca-fa9e-11e5-9b8e-1aac090ff58f.png)

Old variant search form (the middle select won't have any effect): 
![solidus administration variants 2016-04-04 19-46-35](https://cloud.githubusercontent.com/assets/703401/14257422/0503da10-fa9e-11e5-8932-b0f7ef9185c1.png)

Fixes #855.