### PR TITLE
Combine Order#token_based? and Gateway#supports?

### DIFF
--- a/core/app/models/spree/gateway.rb
+++ b/core/app/models/spree/gateway.rb
@@ -39,8 +39,8 @@ module Spree
 
     def supports?(source)
       return true unless provider_class.respond_to? :supports?
-      return false unless source.brand
-      provider_class.supports?(source.brand)
+      return true if source.brand && provider_class.supports?(source.brand)
+      source.has_payment_profile?
     end
 
     def disable_customer_profile(source)

--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -134,7 +134,7 @@ module Spree
 
         if source
           if !processing?
-            if payment_method.supports?(source) || token_based?
+            if payment_method.supports?(source)
               yield
             else
               invalidate!
@@ -212,10 +212,6 @@ module Spree
       # The unique identifier to be passed in to the payment gateway
       def gateway_order_id
         "#{order.number}-#{number}"
-      end
-
-      def token_based?
-        source.gateway_customer_profile_id.present? || source.gateway_payment_profile_id.present?
       end
     end
   end

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -213,16 +213,16 @@ describe Spree::Payment, type: :model do
 
       # Regression test for https://github.com/spree/spree/issues/4598
       it "should allow payments with a gateway_customer_profile_id" do
-        allow(payment.source).to receive_messages gateway_customer_profile_id: "customer_1"
-        expect(payment.payment_method).to receive(:supports?).with(payment.source).and_return(false)
+        payment.source.update!(gateway_customer_profile_id: "customer_1", brand: 'visa')
+        expect(payment.payment_method.provider_class).to receive(:supports?).with('visa').and_return(false)
         expect(payment).to receive(:started_processing!)
         payment.process!
       end
 
       # Another regression test for https://github.com/spree/spree/issues/4598
       it "should allow payments with a gateway_payment_profile_id" do
-        allow(payment.source).to receive_messages gateway_payment_profile_id: "customer_1"
-        expect(payment.payment_method).to receive(:supports?).with(payment.source).and_return(false)
+        payment.source.update!(gateway_payment_profile_id: "customer_1", brand: 'visa')
+        expect(payment.payment_method.provider_class).to receive(:supports?).with('visa').and_return(false)
         expect(payment).to receive(:started_processing!)
         payment.process!
       end


### PR DESCRIPTION
This came out of a discussion with @mamhoff around non-credit-card
payment sources.

**This does remove a (private) method from Order and does slightly change
the behavior of the `supports?` method.**
It seems like it might be an OK change to make but extra eyes and thoughts
will be very appreciated.

`Order#token_based?` was a private method and was only used inside
`Order#handle_payment_preconditions` and only in conjunction with
the `supports?` method.  And the `supports?` method itself is only
used in that same spot.  So as best we could tell, `token_based?` was
being used to modify how `supports?` works.  Combining them seems more
straightforward.

The motivation here is to make it easier to support non-credit-card
payment sources by reducing complexity and reducing the number of methods
that a non-credit-card source is required to implement.