### PR TITLE
Price Modifier Pricer

### DIFF
--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -102,8 +102,10 @@ module Spree
       !sufficient_stock?
     end
 
-    # Sets the options on the line item according to the order's currency or
-    # one passed in.
+    # Sets options on the line item.
+    #
+    # The option can be arbitrary attributes on the LineItem. If no price is given in the options,
+    # this will call the legacy `PriceModifier` line item pricer.
     #
     # @param options [Hash] options for this line item
     def options=(options = {})

--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -109,9 +109,10 @@ module Spree
     def options=(options = {})
       return unless options.present?
 
-      self.price = variant.price_in(currency).amount +
-                   variant.price_modifier_amount_in(currency, options)
-
+      # There's no need to call a pricer if we'll set the price directly.
+      unless options.key?(:price)
+        self.money_price = Pricers::PriceModifier.new(self, options).price
+      end
       assign_attributes options
     end
 

--- a/core/app/models/spree/line_item/pricers/price_modifier.rb
+++ b/core/app/models/spree/line_item/pricers/price_modifier.rb
@@ -1,0 +1,40 @@
+module Spree
+  class LineItem
+    module Pricers
+      # This class implements an extension point previously defined on Spree::LineItem
+      # for customizing pricing from extensions. This extension point is currently used
+      # in the following Spree extensions:
+      #
+      # * https://github.com/godaddy/spree_product_sale
+      # * https://github.com/v-may/spree_simple_sales
+      #
+      # @attr_reader [Spree::LineItem] line_item The line item to find a price for
+      # @attr_reader [Hash] options Options that would modify the price, such as { gift_wrap: true }
+      # @deprecated The extension point, as far as I can overview, needs the following to work:
+      #
+      #   - `*_price_modifier_amount_in` methods defined on the variant
+      #   - Fitting `*` methods on `Spree::LineItem`
+      #   - The Line Item to accept those methods as attributes
+      #
+      #   That's a rather complex way of customizing pricing, maybe write a pricer instead.
+      class PriceModifier < Abstract
+        attr_reader :options
+        delegate :currency, :variant, to: :line_item
+
+        def initialize(line_item, options = {})
+          @line_item = line_item
+          @options = options
+        end
+
+        # @return [Spree::Money] New price for a line item
+        def price
+          raise VariantMissing if variant.blank?
+          raise CurrencyMissing if currency.blank?
+          in_line_item_currency(
+            variant.price_in(currency).amount + variant.price_modifier_amount_in(currency, options)
+          )
+        end
+      end
+    end
+  end
+end

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -230,6 +230,7 @@ module Spree
     # Calculates the sum of the specified price modifiers in the specified
     # currency.
     #
+    # @deprecated This is a very complex way of modifying prices, please write a pricer instead
     # @param currency [String] (see #price)
     # @param options (see #price_modifier_amount)
     # @return (see #price_modifier_amount)
@@ -245,6 +246,7 @@ module Spree
         end
       }.sum
     end
+    deprecate :price_modifier_amount_in, deprecator: Spree::Deprecation
 
     # Calculates the sum of the specified price modifiers.
     #

--- a/core/spec/models/spree/line_item/pricers/price_modifier_spec.rb
+++ b/core/spec/models/spree/line_item/pricers/price_modifier_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+RSpec.describe Spree::LineItem::Pricers::PriceModifier do
+  let(:variant) { create(:variant) }
+  let(:currency) { "USD" }
+  let(:original_price) { 12.34 }
+  let(:options) { {} }
+  let(:line_item) do
+    build(:line_item, variant: variant, currency: currency, price: original_price)
+  end
+
+  subject { described_class.new(line_item, options).price }
+
+  context 'with no variant present' do
+    let(:variant) { nil }
+
+    it 'raises VariantMissing' do
+      expect { subject }.to raise_error(described_class::VariantMissing)
+    end
+  end
+
+  context 'with no currency present' do
+    let(:currency) { nil }
+
+    it 'raises CurrencyMissing' do
+      expect { subject }.to raise_error(described_class::CurrencyMissing)
+    end
+  end
+
+  shared_examples_for 'it prices the line item no matter what' do
+    it 'returns the variant price in USD' do
+      expect(subject).to eq(variant.default_price.money)
+    end
+
+    context 'with price modifiers in the options' do
+      let(:options) { { gift_wrap: true } }
+
+      before do
+        expect(variant).to receive(:gift_wrap_price_modifier_amount_in).with(currency, true).and_return(2.00)
+      end
+
+      it 'returns the variant price plus price modifiers' do
+        expect(subject).to eq(Spree::Money.new(variant.price + 2))
+      end
+    end
+  end
+
+  context 'with no price present' do
+    let(:original_price) { nil }
+
+    it_behaves_like 'it prices the line item no matter what'
+  end
+
+  context 'with a price present' do
+    it_behaves_like 'it prices the line item no matter what'
+  end
+end

--- a/core/spec/models/spree/line_item/pricers/price_modifier_spec.rb
+++ b/core/spec/models/spree/line_item/pricers/price_modifier_spec.rb
@@ -28,6 +28,10 @@ RSpec.describe Spree::LineItem::Pricers::PriceModifier do
   end
 
   shared_examples_for 'it prices the line item no matter what' do
+    before do
+      expect(Spree::Deprecation).to receive(:warn)
+    end
+
     it 'returns the variant price in USD' do
       expect(subject).to eq(variant.default_price.money)
     end

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -207,15 +207,18 @@ describe Spree::LineItem, type: :model do
 
   describe "#options=" do
     it "can handle updating a blank line item with no order" do
+      expect(Spree::Deprecation).not_to receive(:warn)
       line_item.options = { price: 123 }
     end
 
     it "updates the data provided in the options" do
+      expect(Spree::Deprecation).not_to receive(:warn)
       line_item.options = { price: 123 }
       expect(line_item.price).to eq 123
     end
 
     it "updates the price based on the options provided" do
+      expect(Spree::Deprecation).to receive(:warn)
       expect(line_item).to receive(:gift_wrap=).with(true)
       expect(line_item.variant).to receive(:gift_wrap_price_modifier_amount_in).with("USD", true).and_return 1.99
       line_item.options = { gift_wrap: true }


### PR DESCRIPTION
There is an extension point for modifying the price of a line item
that is used in the following extensions:

* https://github.com/godaddy/spree_product_sale
* https://github.com/v-may/spree_simple_sales

This extension point introduces some rather interesting code to
Spree::LineItem, which this commit extracts to a pricer object.

The extension point, as far as I can overview, needs the following to work:

- `*_price_modifier_amount_in` methods defined on the variant
- Fitting `*` methods on `Spree::LineItem`
- The Line Item to accept those methods as params

This PR extracts that code from Spree::LineItem, and deprecates this extension point.