### PR TITLE
Simplify Spree::Variant#price_in

### DIFF
--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -214,7 +214,7 @@ module Spree
     # @param currency [String] the desired currency
     # @return [Spree::Price] the price in the desired currency
     def price_in(currency)
-      prices.detect{ |price| price.currency == currency && price.is_default } || Spree::Price.new(variant_id: id, currency: currency)
+      prices.find_by(currency: currency, is_default: true)
     end
 
     # Fetches the price amount in the specified currency.

--- a/core/spec/lib/spree/core/importer/order_spec.rb
+++ b/core/spec/lib/spree/core/importer/order_spec.rb
@@ -167,7 +167,7 @@ module Spree
       end
 
       context "with a different currency" do
-        before { variant.price_in("GBP").update_attribute(:price, 18.99) }
+        before { variant.prices.create(currency: "GBP", amount: 18.99) }
 
         it "sets the order currency" do
           params = {

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -163,13 +163,13 @@ describe Spree::Variant, type: :model do
     before do
       variant.prices << create(:price, variant: variant, currency: "EUR", amount: 33.33)
     end
-    subject { variant.price_in(currency).display_amount }
+    subject { variant.price_in(currency) }
 
     context "when currency is not specified" do
       let(:currency) { nil }
 
-      it "returns 0" do
-        expect(subject.to_s).to eql "$0.00"
+      it "returns nil" do
+        expect(subject).to be_nil
       end
     end
 
@@ -177,7 +177,7 @@ describe Spree::Variant, type: :model do
       let(:currency) { 'EUR' }
 
       it "returns the value in the EUR" do
-        expect(subject.to_s).to eql "€33.33"
+        expect(subject.display_price.to_s).to eql "€33.33"
       end
     end
 
@@ -185,7 +185,7 @@ describe Spree::Variant, type: :model do
       let(:currency) { 'USD' }
 
       it "returns the value in the USD" do
-        expect(subject.to_s).to eql "$19.99"
+        expect(subject.display_price.to_s).to eql "$19.99"
       end
     end
   end
@@ -200,7 +200,7 @@ describe Spree::Variant, type: :model do
     context "when currency is not specified" do
       let(:currency) { nil }
 
-      it "returns nil" do
+      it "returns the amount in the default currency" do
         expect(subject).to be_nil
       end
     end


### PR DESCRIPTION
The commit changes behaviour. Before, `Spree::Variant#price_in` would
return a price of zero if no currency was given or no price was found in
the given currency. I think that is dangerous: You don't want your products
to randomly be sold for nothing.

This commit changes this behaviour to return the default currency if
no currency is given. It furthermore uses the database's finding capacities
rather than iterating over a potentially large array of prices, speeding things
up.

If no price for the given currency is found, returns nil.