### PR TITLE
Deleting an item from the shipments page should only delete it from that shipment

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -102,21 +102,6 @@ adjustShipmentItems = function(shipment_number, variant_id, quantity){
   }
 };
 
-deleteLineItem = function(line_item_id){
-  var url = Spree.routes.line_items_api(order_number) + "/" + line_item_id;
-
-  Spree.ajax({
-    type: "DELETE",
-    url: url,
-    success: function() {
-      window.location.reload();
-    },
-    error: function(response) {
-      show_flash('error', response.responseJSON.message);
-    }
-  });
-};
-
 startItemSplit = function(event){
   event.preventDefault();
   var link = $(this);
@@ -258,9 +243,9 @@ var ShipmentEditView = Backbone.View.extend({
     e.preventDefault();
     if (confirm(Spree.translations.are_you_sure_delete)) {
       var del = $(e.currentTarget);
-      var line_item_id = del.data('line-item-id');
+      var variant_id = del.data('variant-id');
 
-      deleteLineItem(line_item_id);
+      adjustShipmentItems(this.shipment_number, variant_id, 0);
     }
   },
 

--- a/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
@@ -20,7 +20,7 @@
     <td class="cart-item-delete actions" data-hook="cart_item_delete">
       <% if can? :update, item %>
         <%= link_to '', '#', :class => 'split-item icon_link fa fa-arrows-h no-text with-tip', :data => {:action => 'split', 'variant-id' => item.variant.id}, :title => Spree.t('actions.split') %>
-        <%= link_to '', '#', :class => 'delete-item fa fa-trash no-text with-tip', :data => { 'line-item-id' => item.line_item.id}, :title => Spree.t('actions.delete') %>
+        <%= link_to '', '#', :class => 'delete-item fa fa-trash no-text with-tip', :data => { 'variant-id' => item.variant.id}, :title => Spree.t('actions.delete') %>
       <% end %>
     </td>
   </tr>

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -334,6 +334,22 @@ describe "Order Details", type: :feature, js: true do
         end
       end
 
+      context 'removing an item' do
+        it "removes only the one item" do
+          @shipment2 = order.shipments.create(stock_location_id: stock_location2.id)
+          order.line_items[0].inventory_units[0].update!(shipment: @shipment2)
+          visit spree.edit_admin_order_path(order)
+
+          expect(page).to have_css('.stock-item', count: 2)
+
+          within '[data-hook=admin_shipment_form]', text: @shipment2.number do
+            click_icon :trash
+          end
+
+          expect(page).to have_css('.stock-item', count: 1)
+        end
+      end
+
       context 'splitting to shipment' do
         before do
           @shipment2 = order.shipments.create(stock_location_id: stock_location2.id)


### PR DESCRIPTION
Previously, removing an item from the admin shipments page would remove
it from all shipments.

This is a regression in solidus 1.2

This reverts c6fa6226d3028a2259461e66376c888588c02a5e

Fixes #1039

cc @dholdren @cbrunsdon 