### PR TITLE
Do not set currency on variants

### DIFF
--- a/core/app/models/concerns/spree/default_price.rb
+++ b/core/app/models/concerns/spree/default_price.rb
@@ -15,9 +15,8 @@ module Spree
       default_price || build_default_price
     end
 
-    delegate :display_price, :display_amount,
-      :price, :price=, :currency, :currency=,
-      to: :find_or_build_default_price
+    delegate :display_price, :display_amount, :price, :currency, to: :find_or_build_default_price
+    delegate :price=, :currency=, to: :find_or_build_default_price
 
     def has_default_price?
       !default_price.nil?

--- a/core/app/models/concerns/spree/default_price.rb
+++ b/core/app/models/concerns/spree/default_price.rb
@@ -17,6 +17,7 @@ module Spree
 
     delegate :display_price, :display_amount, :price, :currency, to: :find_or_build_default_price
     delegate :price=, :currency=, to: :find_or_build_default_price
+    deprecate :currency=, :currency, deprecator: Spree::Deprecation
 
     def has_default_price?
       !default_price.nil?

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -349,9 +349,6 @@ module Spree
           self.price = product.master.price
         end
       end
-      if currency.nil?
-        self.currency = Spree::Config[:currency]
-      end
     end
 
     def set_cost_currency

--- a/core/lib/spree/core/product_duplicator.rb
+++ b/core/lib/spree/core/product_duplicator.rb
@@ -44,7 +44,6 @@ module Spree
         new_master.deleted_at = nil
         new_master.images = master.images.map { |image| duplicate_image image } if @include_images
         new_master.price = master.price
-        new_master.currency = master.currency
       end
     end
 

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -131,7 +131,9 @@ describe Spree::Variant, type: :model do
 
   context "#currency" do
     it "returns the globally configured currency" do
-      expect(variant.currency).to eql "USD"
+      Spree::Deprecation.silence do
+        expect(variant.currency).to eql "USD"
+      end
     end
   end
 

--- a/frontend/app/views/spree/products/_cart_form.html.erb
+++ b/frontend/app/views/spree/products/_cart_form.html.erb
@@ -37,7 +37,7 @@
             <span class="price selling" itemprop="price">
               <%= display_price(@product) %>
             </span>
-            <span itemprop="priceCurrency" content="<%= @product.currency %>"></span>
+            <span itemprop="priceCurrency" content="<%= current_currency %>"></span>
           </div>
 
           <% if @product.master.can_supply? %>


### PR DESCRIPTION
Setting a currency on a variant doesn't make sense. This deprecates setting and getting the currency from a variant. 