### PR TITLE
Get CustomerReturn currency from order

### DIFF
--- a/core/app/models/spree/customer_return.rb
+++ b/core/app/models/spree/customer_return.rb
@@ -16,10 +16,9 @@ module Spree
     accepts_nested_attributes_for :return_items
 
     extend DisplayMoney
-    money_methods pre_tax_total: { currency: Spree::Config[:currency] },
-                  total: { currency: Spree::Config[:currency] },
-                  amount: { currency: Spree::Config[:currency] }
+    money_methods :pre_tax_total, :total, :amount
 
+    delegate :currency, to: :order
     delegate :id, to: :order, prefix: true, allow_nil: true
 
     def total

--- a/core/spec/models/spree/customer_return_spec.rb
+++ b/core/spec/models/spree/customer_return_spec.rb
@@ -89,11 +89,20 @@ describe Spree::CustomerReturn, type: :model do
   end
 
   describe "#display_total" do
-    let(:customer_return) { Spree::CustomerReturn.new }
+    let(:customer_return) { stub_model(Spree::CustomerReturn, total: 21.22, currency: "GBP") }
 
     it "returns a Spree::Money" do
-      allow(customer_return).to receive_messages(total: 21.22)
-      expect(customer_return.display_total).to eq(Spree::Money.new(21.22))
+      expect(customer_return.display_total).to eq(Spree::Money.new(21.22, currency: "GBP"))
+    end
+  end
+
+  describe "#currency" do
+    let(:order) { stub_model(Spree::Order, currency: "GBP") }
+    let(:customer_return) { stub_model(Spree::CustomerReturn, order: order) }
+
+    it 'returns the order currency' do
+      expect(Spree::Config.currency).to eq("USD")
+      expect(customer_return.currency).to eq("GBP")
     end
   end
 
@@ -113,11 +122,10 @@ describe Spree::CustomerReturn, type: :model do
   end
 
   describe "#display_amount" do
-    let(:customer_return) { Spree::CustomerReturn.new }
+    let(:customer_return) { stub_model(Spree::CustomerReturn, amount: 21.22, currency: "RUB") }
 
     it "returns a Spree::Money" do
-      allow(customer_return).to receive_messages(amount: 21.22)
-      expect(customer_return.display_amount).to eq(Spree::Money.new(21.22))
+      expect(customer_return.display_amount).to eq(Spree::Money.new(21.22, currency: "RUB"))
     end
   end
 


### PR DESCRIPTION
Before this commit, any customer return, even for orders in a non-default currency,
would display their `amount`, `total` and `pre_tax_total` in the default currency.

This commit changes this so that customer returns always use their order's currency.