### PR TITLE
Simplify Spree::Price#money

### DIFF
--- a/core/app/models/spree/price.rb
+++ b/core/app/models/spree/price.rb
@@ -16,13 +16,9 @@ module Spree
 
     extend DisplayMoney
     money_methods :amount, :price
+    alias_method :money, :display_amount
 
     self.whitelisted_ransackable_attributes = ['amount']
-
-    # @return [Spree::Money] this price as a Spree::Money object
-    def money
-      Spree::Money.new(amount || 0, { currency: currency })
-    end
 
     # An alias for #amount
     def price


### PR DESCRIPTION
This is a `money_method`. Even if `amount` is nil, it will return a
money object with zero cents, so the added `|| 0` doesn't make a huge amount of sense.