### PR TITLE
[WIP] Load factories instead of requiring them

### DIFF
--- a/core/lib/spree/testing_support/factories.rb
+++ b/core/lib/spree/testing_support/factories.rb
@@ -1,5 +1,5 @@
 require 'factory_girl'
 
 Dir["#{File.dirname(__FILE__)}/factories/**"].each do |f|
-  require File.expand_path(f)
+  load File.expand_path(f)
 end


### PR DESCRIPTION
As explained on spree/spree#6534 and rails/spring#412, there is a problem loading factories from an engine when using spring.