### PR TITLE
Fix performance issue on coupon code application for large sets

### DIFF
--- a/backend/app/views/spree/admin/promotion_codes/index.csv.ruby
+++ b/backend/app/views/spree/admin/promotion_codes/index.csv.ruby
@@ -1,6 +1,6 @@
 CSV.generate do |csv|
   csv << ['Code']
-  @promotion.codes.order(:id).each do |code|
-    csv << [code.value]
+  @promotion.codes.order(:id).pluck(:value).each do |value|
+    csv << [value]
   end
 end

--- a/core/app/models/spree/promotion_handler/coupon.rb
+++ b/core/app/models/spree/promotion_handler/coupon.rb
@@ -86,7 +86,7 @@ module Spree
 
       def determine_promotion_application_result
         detector = lambda { |p|
-          p.source.promotion.codes.any? { |code| code.value == order.coupon_code.downcase }
+          p.source.promotion.codes.where(value: order.coupon_code.downcase).any?
         }
 
         # Check for applied adjustments.


### PR DESCRIPTION
When a Promotion has a large number of PromotionCodes (thousands),
applying a promotion is very slow / memory intensive.
Also, dumping a CSV has a similar problem.