### PR TITLE
Use exchange_name in RMA form

### DIFF
--- a/backend/app/views/spree/admin/return_authorizations/_form.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/_form.html.erb
@@ -54,9 +54,9 @@
           </td>
           <td class="return-item-exchange-for align-center">
             <% if editable %>
-              <%= item_fields.collection_select :exchange_variant_id, return_item.eligible_exchange_variants(@stock_locations), :id, :options_text, { include_blank: true }, { class: "select2 fullwidth return-item-exchange-selection" } %>
+              <%= item_fields.collection_select :exchange_variant_id, return_item.eligible_exchange_variants(@stock_locations), :id, :exchange_name, { include_blank: true }, { class: "select2 fullwidth return-item-exchange-selection" } %>
             <% elsif return_item.exchange_processed? %>
-              <%= return_item.exchange_variant.options_text %>
+              <%= return_item.exchange_variant.try(:exchange_name) %>
             <% end %>
           </td>
           <td class="return-item-reason">


### PR DESCRIPTION
Use the exchange_name so master and non-master variants will be displayed correctly during an RMA.