### PR TITLE
Remove bullets from text_list class

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/shared/_typography.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_typography.scss
@@ -81,7 +81,7 @@ ul {
 ul.text_list {
   border-top: none;
   margin: 0;
-  list-style: disc inside none;
+  list-style-type: none;
 }
 
 dl {


### PR DESCRIPTION
This class is only used in one location in the project and we want to remove the bullets from it. As requested by @Mandily 

## With Bullets
![with_bullets](https://cloud.githubusercontent.com/assets/12613649/14361049/03577fc0-fcae-11e5-81e6-3628e95e9125.png)

## No Bullets
![nobullets](https://cloud.githubusercontent.com/assets/12613649/14361052/06804fba-fcae-11e5-9c20-bd99819b14bc.png)
