### PR TITLE
More shipments.js cleanup

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -335,7 +335,7 @@ var ShipmentEditView = Backbone.View.extend({
 
   saveTracking: function(e) {
     e.preventDefault();
-    var tracking = this.$('input#tracking').val();
+    var tracking = this.$('[name="tracking"]').val();
     var _this = this;
     updateShipment(this.shipment_number, {
       tracking: tracking

--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -114,14 +114,13 @@ startItemSplit = function(event){
     url: Spree.routes.variants_api + "/" + variant_id,
   }).success(function(variant){
     var max_quantity = link.closest('tr').data('item-quantity');
-    var split_item_template = HandlebarsTemplates['variants/split'];
-    link.closest('tr').after(split_item_template({ variant: variant, shipments: shipments, max_quantity: max_quantity }));
-
-    $('#item_stock_location').select2({
-      width: 'resolve',
-      placeholder: Spree.translations.item_stock_placeholder,
-      minimumResultsForSearch: 8
+    var split = new ShipmentSplitItemView({
+      variant: variant,
+      shipments: shipments,
+      max_quantity: max_quantity
     });
+
+    link.closest('tr').after(split.$el);
   });
 };
 
@@ -207,6 +206,37 @@ addVariantFromStockLocation = function(stock_location_id, variant_id, quantity) 
     adjustShipmentItems(shipment.number, variant_id, quantity);
   }
 };
+
+var ShipmentSplitItemView = Backbone.View.extend({
+  tagName: 'tr',
+  className: 'stock-item-split',
+
+  initialize: function(options) {
+    this.variant = options.variant;
+    this.shipments = options.shipments;
+    this.max_quantity = options.max_quantity;
+    this.$el.data("variant-id", this.variant.id);
+    this.render()
+  },
+
+  template: HandlebarsTemplates['variants/split'],
+
+  render: function() {
+    var renderAttr = {
+      variant: this.variant,
+      shipments: this.shipments,
+      max_quantity: this.max_quantity
+    };
+    this.$el.html(this.template(renderAttr));
+
+    this.$('[name="item_stock_location"]').select2({
+      width: 'resolve',
+      placeholder: Spree.translations.item_stock_placeholder,
+      minimumResultsForSearch: 8
+    });
+  }
+});
+
 
 var ShipmentEditView = Backbone.View.extend({
   initialize: function(){

--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -193,8 +193,25 @@ var ShipmentSplitItemView = Backbone.View.extend({
     this.variant = options.variant;
     this.shipments = options.shipments;
     this.max_quantity = options.max_quantity;
+    this.shipmentItemView = options.shipmentItemView;
     this.$el.data("variant-id", this.variant.id);
     this.render()
+  },
+
+  events: {
+    "click .cancel-split": "cancelItemSplit",
+    "click .save-split": "completeItemSplit",
+  },
+
+  cancelItemSplit: function(e){
+    e.preventDefault();
+
+    this.shipmentItemView.removeSplit();
+    this.remove();
+  },
+
+  completeItemSplit: function(e){
+    completeItemSplit.apply(e.currentTarget, [e]);
   },
 
   template: HandlebarsTemplates['variants/split'],
@@ -228,22 +245,29 @@ var ShipmentItemView = Backbone.View.extend({
     "click .split-item": "onSplit",
   },
 
+  removeSplit: function() {
+    this.$('.split-item').show();
+    this.$('.delete-item').show();
+  },
+
   onSplit: function(e) {
     e.preventDefault();
     this.$('.split-item').toggle();
     this.$('.delete-item').toggle();
 
+    var _this = this;
     Spree.ajax({
       type: "GET",
       url: Spree.routes.variants_api + "/" + this.variant_id,
     }).success(function(variant){
       var split = new ShipmentSplitItemView({
+        shipmentItemView: _this,
         variant: variant,
         shipments: shipments,
-        max_quantity: this.quantity
+        max_quantity: _this.quantity
       });
 
-      this.$el.after(split.$el);
+      _this.$el.after(split.$el);
     });
   },
 
@@ -278,9 +302,6 @@ var ShipmentEditView = Backbone.View.extend({
   },
 
   events: {
-    "click a.cancel-split": "cancelItemSplit",
-    "click a.save-split": "completeItemSplit",
-
     "click a.edit-method": "toggleMethodEdit",
     "click a.cancel-method": "toggleMethodEdit",
     "click a.save-method": "saveMethod",
@@ -288,18 +309,6 @@ var ShipmentEditView = Backbone.View.extend({
     "click a.edit-tracking": "toggleTrackingEdit",
     "click a.cancel-tracking": "toggleTrackingEdit",
     "click a.save-tracking": "saveTracking",
-  },
-
-  cancelItemSplit: function(e){
-    e.preventDefault();
-
-    this.$('tr.stock-item-split').remove();
-    this.$('a.split-item').show();
-    this.$('a.delete-item').show();
-  },
-
-  completeItemSplit: function(e){
-    completeItemSplit.apply(e.currentTarget, [e]);
   },
 
   toggleMethodEdit: function(e){

--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -113,7 +113,7 @@ addVariantFromStockLocation = function(stock_location_id, variant_id, quantity) 
       url: Spree.routes.shipments_api,
       data: {
         shipment: {
-          order_id: order_number
+          order_id: window.order_number
         },
         variant_id: variant_id,
         quantity: quantity,
@@ -244,7 +244,7 @@ var ShipmentItemView = Backbone.View.extend({
         shipmentItemView: _this,
         shipment_number: _this.shipment_number,
         variant: variant,
-        shipments: shipments,
+        shipments: window.shipments,
         max_quantity: _this.quantity
       });
 

--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -197,9 +197,12 @@ var ShipmentSplitItemView = Backbone.View.extend({
   template: HandlebarsTemplates['variants/split'],
 
   render: function() {
+    /* Only display other shipments */
+    var shipments = _.reject(this.shipments, _.matcher({'number': this.shipment_number}))
+
     var renderAttr = {
       variant: this.variant,
-      shipments: this.shipments,
+      shipments: shipments,
       max_quantity: this.max_quantity
     };
     this.$el.html(this.template(renderAttr));

--- a/backend/app/assets/javascripts/spree/backend/templates/variants/split.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/variants/split.hbs
@@ -2,16 +2,16 @@
   Move {{variant.name}} to
 </td>
 <td colspan='2'>
-<select name="item_stock_location" id='item_stock_location' style='width:100%;'>
+<select name="item_stock_location" style='width:100%;'>
   <option></option>
   <optgroup label="{{ t "existing_shipments" }}">
     {{#each shipments}}
-    <option data-shipment-number='{{this.number}}' value='{{this.stock_location_id}}'>{{this.stock_location.name}}({{this.number}})</option>
+    <option value='shipment:{{this.number}}'>{{this.stock_location.name}}({{this.number}})</option>
     {{/each}}
   </optgroup>
   <optgroup label="{{ t "new_shipment_at_location" }}">
     {{#each variant.stock_items}}
-      <option data-new-shipment='true' value='{{this.stock_location_id}}'>{{this.stock_location_name}}&nbsp;({{this.count_on_hand}} on hand)</option>
+      <option value='stock_location:{{this.stock_location_id}}'>{{this.stock_location_name}}&nbsp;({{this.count_on_hand}} on hand)</option>
     {{/each}}
   </optgroup>
   </select>

--- a/backend/app/assets/javascripts/spree/backend/templates/variants/split.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/variants/split.hbs
@@ -1,27 +1,25 @@
-<tr class='stock-item-split' data-variant-id='{{variant.id}}'>
-  <td colspan='2'>
-    Move {{variant.name}} to
-  </td>
-  <td colspan='2'>
-  <select name="item_stock_location" id='item_stock_location' style='width:100%;'>
-    <option></option>
-    <optgroup label="{{ t "existing_shipments" }}">
-      {{#each shipments}}
-      <option data-shipment-number='{{this.number}}' value='{{this.stock_location_id}}'>{{this.stock_location.name}}({{this.number}})</option>
-      {{/each}}
-    </optgroup>
-    <optgroup label="{{ t "new_shipment_at_location" }}">
-      {{#each variant.stock_items}}
-        <option data-new-shipment='true' value='{{this.stock_location_id}}'>{{this.stock_location_name}}&nbsp;({{this.count_on_hand}} on hand)</option>
-      {{/each}}
-    </optgroup>
-    </select>
-  </td>
-  <td>
-    <input class="quantity" id="item_quantity" type="number" min="1" value="1" max="{{max_quantity}}">
-  </td>
-  <td class='actions'>
-    <a href='#' class='save-split icon_link fa fa-ok no-text with-tip' title='Save'></a>
-    <a href='#' class='cancel-split icon_link fa fa-cancel no-text with-tip' title='Cancel'></a>
-  </td>
-</tr>
+<td colspan='2'>
+  Move {{variant.name}} to
+</td>
+<td colspan='2'>
+<select name="item_stock_location" id='item_stock_location' style='width:100%;'>
+  <option></option>
+  <optgroup label="{{ t "existing_shipments" }}">
+    {{#each shipments}}
+    <option data-shipment-number='{{this.number}}' value='{{this.stock_location_id}}'>{{this.stock_location.name}}({{this.number}})</option>
+    {{/each}}
+  </optgroup>
+  <optgroup label="{{ t "new_shipment_at_location" }}">
+    {{#each variant.stock_items}}
+      <option data-new-shipment='true' value='{{this.stock_location_id}}'>{{this.stock_location_name}}&nbsp;({{this.count_on_hand}} on hand)</option>
+    {{/each}}
+  </optgroup>
+  </select>
+</td>
+<td>
+  <input class="quantity" id="item_quantity" type="number" min="1" value="1" max="{{max_quantity}}">
+</td>
+<td class='actions'>
+  <a href='#' class='save-split icon_link fa fa-ok no-text with-tip' title='Save'></a>
+  <a href='#' class='cancel-split icon_link fa fa-cancel no-text with-tip' title='Cancel'></a>
+</td>

--- a/backend/app/views/spree/admin/orders/_shipment.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment.html.erb
@@ -85,7 +85,7 @@
       <tr class="edit-tracking hidden total">
         <td colspan="5">
           <label><%= Spree::Shipment.human_attribute_name(:tracking) %>:</label>
-          <%= text_field_tag :tracking, shipment.tracking %>
+          <%= text_field_tag :tracking, shipment.tracking, id: nil %>
         </td>
         <td class="actions">
           <% if can? :update, shipment %>

--- a/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
@@ -1,5 +1,8 @@
 <% shipment_manifest.each do |item| %>
-  <tr class="stock-item" data-item-quantity="<%= item.quantity %>">
+  <tr class="stock-item"
+      data-item-quantity="<%= item.quantity %>"
+      data-variant-id="<%= item.variant.id %>"
+      >
     <td class="item-image">
       <%= image_tag item.variant.display_image.attachment(:mini) %>
     </td>

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -2,6 +2,8 @@
 require 'spec_helper'
 
 describe "Order Details", type: :feature, js: true do
+  include OrderFeatureHelper
+
   let!(:stock_location) { create(:stock_location_with_items) }
   let!(:product) { create(:product, name: 'spree t-shirt', price: 20.00) }
   let!(:tote) { create(:product, name: "Tote", price: 15.00) }
@@ -179,8 +181,7 @@ describe "Order Details", type: :feature, js: true do
             expect(order.shipments.first.inventory_units_for(product.master).count).to eq(2)
 
             within_row(1) { click_icon 'arrows-h' }
-            targetted_select2 stock_location2.name, from: '#s2id_item_stock_location'
-            click_icon :ok
+            complete_split_to(stock_location2)
 
             expect(page).to have_css('.shipment', count: 2)
 
@@ -194,9 +195,7 @@ describe "Order Details", type: :feature, js: true do
             expect(order.shipments.first.stock_location.id).to eq(stock_location.id)
 
             within_row(1) { click_icon 'arrows-h' }
-            targetted_select2 stock_location2.name, from: '#s2id_item_stock_location'
-            fill_in 'item_quantity', with: 2
-            click_icon :ok
+            complete_split_to(stock_location2, quantity: 2)
 
             expect(page).to have_content("PENDING PACKAGE FROM 'CLARKSVILLE'")
 
@@ -210,9 +209,7 @@ describe "Order Details", type: :feature, js: true do
             expect(order.shipments.first.stock_location.id).to eq(stock_location.id)
 
             within_row(1) { click_icon 'arrows-h' }
-            targetted_select2 stock_location2.name, from: '#s2id_item_stock_location'
-            fill_in 'item_quantity', with: 5
-            click_icon :ok
+            complete_split_to(stock_location2, quantity: 5)
 
             expect(page).to have_content("PENDING PACKAGE FROM 'CLARKSVILLE'")
 
@@ -226,9 +223,7 @@ describe "Order Details", type: :feature, js: true do
             expect(order.shipments.first.stock_location.id).to eq(stock_location.id)
 
             within_row(1) { click_icon 'arrows-h' }
-            targetted_select2 stock_location2.name, from: '#s2id_item_stock_location'
-            fill_in 'item_quantity', with: 'ff'
-            click_icon :ok
+            complete_split_to(stock_location2, quantity: 'ff')
 
             wait_for_ajax
 
@@ -241,9 +236,7 @@ describe "Order Details", type: :feature, js: true do
             expect(order.shipments.first.stock_location.id).to eq(stock_location.id)
 
             within_row(1) { click_icon 'arrows-h' }
-            targetted_select2 stock_location2.name, from: '#s2id_item_stock_location'
-            fill_in 'item_quantity', with: 0
-            click_icon :ok
+            complete_split_to(stock_location2, quantity: 0)
 
             wait_for_ajax
 
@@ -283,9 +276,7 @@ describe "Order Details", type: :feature, js: true do
               product.master.stock_items.last.update_column(:count_on_hand, 0)
 
               within_row(1) { click_icon 'arrows-h' }
-              targetted_select2 stock_location2.name, from: '#s2id_item_stock_location'
-              fill_in 'item_quantity', with: 2
-              click_icon :ok
+              complete_split_to(stock_location2, quantity: 2)
 
               wait_for_ajax
 
@@ -301,9 +292,7 @@ describe "Order Details", type: :feature, js: true do
               product.master.stock_items.last.update_column(:backorderable, true)
 
               within_row(1) { click_icon 'arrows-h' }
-              targetted_select2 stock_location2.name, from: '#s2id_item_stock_location'
-              fill_in 'item_quantity', with: 2
-              click_icon :ok
+              complete_split_to(stock_location2, quantity: 2)
 
               expect(page).to have_content("PENDING PACKAGE FROM 'CLARKSVILLE'")
 
@@ -321,8 +310,7 @@ describe "Order Details", type: :feature, js: true do
             expect(order.shipments.first.manifest.count).to eq(2)
 
             within_row(1) { click_icon 'arrows-h' }
-            targetted_select2 stock_location2.name, from: '#s2id_item_stock_location'
-            click_icon :ok
+            complete_split_to(stock_location2)
 
             expect(page).to have_css('.shipment', count: 2)
 
@@ -360,9 +348,7 @@ describe "Order Details", type: :feature, js: true do
           expect(order.shipments.count).to eq(2)
 
           within_row(1) { click_icon 'arrows-h' }
-          targetted_select2 @shipment2.number, from: '#s2id_item_stock_location'
-          fill_in 'item_quantity', with: 2
-          click_icon :ok
+          complete_split_to(@shipment2, quantity: 2)
 
           expect(page).not_to have_content(/Move .* to/)
 
@@ -380,17 +366,13 @@ describe "Order Details", type: :feature, js: true do
             expect(page).to have_css('.item-name', text: product.name, count: 1)
 
             within_row(1) { click_icon 'arrows-h' }
-            targetted_select2 @shipment2.number, from: '#s2id_item_stock_location'
-            fill_in 'item_quantity', with: 1
-            click_icon :ok
+            complete_split_to(@shipment2, quantity: 1)
 
             expect(page).to have_css('.item-name', text: product.name, count: 2)
 
             within(all('.stock-contents', count: 2).first) do
               within_row(1) { click_icon 'arrows-h' }
-              targetted_select2 @shipment2.number, from: '#s2id_item_stock_location'
-              fill_in 'item_quantity', with: 200
-              click_icon :ok
+              complete_split_to(@shipment2, quantity: 200)
             end
 
             wait_for_ajax
@@ -402,9 +384,7 @@ describe "Order Details", type: :feature, js: true do
 
           it 'should not allow a shipment to split stock to itself' do
             within_row(1) { click_icon 'arrows-h' }
-            targetted_select2 order.shipments.first.number, from: '#s2id_item_stock_location'
-            fill_in 'item_quantity', with: 1
-            click_icon :ok
+            complete_split_to(order.shipments.first, quantity: 1)
 
             wait_for_ajax
 
@@ -417,10 +397,7 @@ describe "Order Details", type: :feature, js: true do
             order.contents.add(variant2, 2, shipment: @shipment2)
 
             within_row(1) { click_icon 'arrows-h' }
-            targetted_select2 @shipment2.number, from: '#s2id_item_stock_location'
-            fill_in 'item_quantity', with: 1
-
-            click_icon :ok
+            complete_split_to(@shipment2, quantity: 1)
 
             expect(page).not_to have_content(/Move .* to/)
             expect(page).to have_css('.shipment', count: 2)
@@ -440,17 +417,13 @@ describe "Order Details", type: :feature, js: true do
             expect(@shipment2.reload.backordered?).to eq(false)
 
             within_row(1) { click_icon 'arrows-h' }
-            targetted_select2 @shipment2.number, from: '#s2id_item_stock_location'
-            fill_in 'item_quantity', with: 1
-            click_icon :ok
+            complete_split_to(@shipment2, quantity: 1)
 
             expect(page).to have_content("1 x backordered")
 
             within('.stock-contents', text: "1 x on hand") do
               within_row(1) { click_icon 'arrows-h' }
-              targetted_select2 @shipment2.number, from: '#s2id_item_stock_location'
-              fill_in 'item_quantity', with: 1
-              click_icon :ok
+              complete_split_to(@shipment2, quantity: 1)
             end
 
             # Empty shipment should be removed

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -384,12 +384,11 @@ describe "Order Details", type: :feature, js: true do
 
           it 'should not allow a shipment to split stock to itself' do
             within_row(1) { click_icon 'arrows-h' }
-            complete_split_to(order.shipments.first, quantity: 1)
-
-            wait_for_ajax
-
-            expect(order.shipments.count).to eq(2)
-            expect(order.shipments.first.inventory_units_for(product.master).count).to eq(2)
+            click_on 'Choose location'
+            within '.select2-results' do
+              expect(page).to have_content(@shipment2.number)
+              expect(page).not_to have_content(order.shipments[0].number)
+            end
           end
 
           it 'should split fine if more than one line_item is in the receiving shipment' do

--- a/backend/spec/features/admin/orders/shipments_spec.rb
+++ b/backend/spec/features/admin/orders/shipments_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe "Shipments", type: :feature do
+  include OrderFeatureHelper
+
   stub_authorization!
 
   let!(:order) { create(:order_ready_to_ship, number: "R100", state: "complete", line_items_count: 5) }
@@ -53,16 +55,14 @@ describe "Shipments", type: :feature do
       shipment1 = order.shipments[0]
 
       within_row(1) { click_icon 'arrows-h' }
-      targetted_select2 'LA', from: '#s2id_item_stock_location'
-      click_icon :ok
+      complete_split_to('LA')
 
       expect(page).to have_css("#shipment_#{shipment1.id} tr.stock-item", count: 4)
       shipment2 = (order.reload.shipments.to_a - [shipment1]).first
       expect(page).to have_css("#shipment_#{shipment2.id} tr.stock-item", count: 1)
 
       within_row(2) { click_icon 'arrows-h' }
-      targetted_select2 "LA(#{shipment2.number})", from: '#s2id_item_stock_location'
-      click_icon :ok
+      complete_split_to("LA(#{shipment2.number})")
       expect(page).to have_css("#shipment_#{shipment2.id} tr.stock-item", count: 2)
       expect(page).to have_css("#shipment_#{shipment1.id} tr.stock-item", count: 3)
     end

--- a/backend/spec/support/feature/order_feature_helper.rb
+++ b/backend/spec/support/feature/order_feature_helper.rb
@@ -1,0 +1,17 @@
+module OrderFeatureHelper
+  def complete_split_to(destination, quantity: nil)
+    if destination.is_a?(Spree::Shipment)
+      destination = destination.number
+    elsif destination.is_a?(Spree::StockLocation)
+      destination = destination.name
+    end
+
+    select2_no_label(destination, from: 'Choose location')
+
+    if quantity
+      fill_in 'item_quantity', with: quantity
+    end
+
+    click_icon :ok
+  end
+end


### PR DESCRIPTION
This has one behaviour change, the rest is just cleanup.

It's invalid to split an item to the shipment it is already in. Previously, attempting to do so would do (essentially) `alert("undefined")`. Instead, this now only shows valid choices for splitting.

Cleanup involved moving more things into backbone views to stop needing to reach into the DOM in all event handlers. This should make it easier in the future to implement the proposed changes to the shipments page.