### PR TITLE
secure compare the spree_api_key

### DIFF
--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -41,7 +41,8 @@ module Spree
       end
 
       def load_user
-        @current_api_user ||= Spree.user_class.find_by(spree_api_key: api_key.to_s)
+        user = Spree.user_class.find_by(spree_api_key: api_key.to_s)
+        @current_api_user ||= user if Spree.secure_compare(user.spree_api_key, api_key)
       end
 
       def authenticate_user

--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -43,6 +43,23 @@ module Spree
     yield(Spree::Config)
   end
 
+  # constant-time comparison algorithm to prevent timing attacks
+  #
+  # @param a [String] the first string you would like to compare.
+  # @param b [String] the second string you would like to compare.
+  # @return [TrueClass, FalseClass] the result of comparing the strings
+  def self.secure_compare(a, b)
+    return false if [a, b].any?(&:nil?)
+    return false if [a, b].any?(&:empty?)
+    return false if a.bytesize != b.bytesize
+
+    l = a.unpack "C#{a.bytesize}"
+
+    result = 0
+    b.each_byte { |byte| result |= byte ^ l.shift }
+    result == 0
+  end
+
   module Core
     autoload :ProductFilters, "spree/core/product_filters"
 


### PR DESCRIPTION
When comparing the API keys, Solidus is susceptible to timing attacks. Given a list of ~250 possible tokens:

````
0000000000000000000000000000000000000000
0100000000000000000000000000000000000000
0200000000000000000000000000000000000000
... snip 246 ...
FD00000000000000000000000000000000000000
FE00000000000000000000000000000000000000
FF00000000000000000000000000000000000000
```

A hacker can recognize that there was a 100µs difference in string comparison between, say, A1 and F3. If A1 took longer, then we know that there’s a user with a token that begins with A1… Rinse and repeat and you’ll be able to find a token.

Although the internet has a significant amount of jitter, a 2009 paper from Rice University [Crosby, Wallach, and Riedi, 2009] noted that it is possible to achieve 15-100µs accuracy. If the request was over a local network, the accuracy improved to 100ns.

http://www.cs.rice.edu/~dwallach/pub/crosby-timing2009.pdf

To prevent this, we use a constant-time comparison algorithm to compare the bytes.

References:

Crosby, S. A., Wallach, D. S., and Riedi, R. H. 2009. Opportunities and limits of remote timing
attacks. ACM Trans. Inf. Syst. Secur. 12, 3, Article 17 (January 2009), 29 pages.