### PR TITLE
Remove use_s3 translation

### DIFF
--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1834,7 +1834,6 @@ en:
     use_existing_cc: Use an existing card on file
     use_new_cc: Use a new card
     use_new_cc_or_payment_method: Use a new card / payment method
-    use_s3: Use Amazon S3 For Images
     user: User
     user_rule:
       choose_users: Choose users


### PR DESCRIPTION
This is referenced nowhere else in the gem.