### PR TITLE
Fix case where `track_inventory_levels` global flag not being honored

### DIFF
--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -66,6 +66,7 @@ module Spree
     # @param stock_locations [Array<Spree::StockLocation>] the stock locations to check
     # @return [ActiveRecord::Relation]
     def self.in_stock(stock_locations = nil)
+      return all unless Spree::Config.track_inventory_levels
       in_stock_variants = joins(:stock_items).where(Spree::StockItem.arel_table[:count_on_hand].gt(0).or(arel_table[:track_inventory].eq(false)))
       if stock_locations.present?
         in_stock_variants = in_stock_variants.where(spree_stock_items: { stock_location_id: stock_locations.map(&:id) })

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -504,6 +504,7 @@ describe Spree::Variant, type: :model do
   end
 
   describe "in_stock scope" do
+    subject { Spree::Variant.in_stock }
     let!(:in_stock_variant) { create(:variant) }
     let!(:out_of_stock_variant) { create(:variant) }
     let!(:stock_location) { create(:stock_location) }
@@ -534,14 +535,21 @@ describe Spree::Variant, type: :model do
     end
 
     context "a stock location is not provided" do
-      subject { Spree::Variant.in_stock }
-
       before do
         in_stock_variant.stock_items.first.update_column(:count_on_hand, 10)
       end
 
       it "returns all in stock variants" do
         expect(subject).to eq [in_stock_variant]
+      end
+    end
+
+    context "inventory levels globally not tracked" do
+      before { Spree::Config.track_inventory_levels = false }
+      after { Spree::Config.track_inventory_levels = true }
+
+      it 'includes items without inventory' do
+        expect( subject ).to include out_of_stock_variant
       end
     end
   end


### PR DESCRIPTION
[At the instance level](https://github.com/solidusio/solidus/blob/master/core/app/models/spree/variant.rb#L307-L309) the system looks both at the variant flag as well as the global flag, but when operating [at the collection level](https://github.com/solidusio/solidus/blob/master/core/app/models/spree/variant.rb#L68-L74) only the variant flag was taken into account. This commit fixes this by making the `in_stock` scope a no-op if Solidus is configured to not track inventory levels globally.

I hit this issue when trying to create orders in the backend while configured to not track inventory. The product selector makes a call to the API and [indicates the `in_stock_only` flag](https://github.com/solidusio/solidus/blob/master/backend/app/assets/javascripts/spree/backend/orders/edit.js#L4). Since none of the products had inventory (since inventory is not tracked) no products where returned.