### PR TITLE
Simplify buggy tax rate migration

### DIFF
--- a/core/db/migrate/20160225152313_remove_tax_rate_from_shipping_rate.rb
+++ b/core/db/migrate/20160225152313_remove_tax_rate_from_shipping_rate.rb
@@ -1,40 +1,9 @@
 class RemoveTaxRateFromShippingRate < ActiveRecord::Migration
-  class Spree::ShippingRate < Spree::Base; end
-  class Spree::TaxRate < Spree::Base
-    has_one :calculator, class_name: "Spree::Calculator", as: :calculable, inverse_of: :calculable, dependent: :destroy, autosave: true
-    def compute_amount(item)
-      calculator.compute(item)
-    end
-  end
-
   def up
-    say_with_time "Pre-calculating taxes for existing shipping rates" do
-      Spree::ShippingRate.find_each do |shipping_rate|
-        tax_rate_id = shipping_rate.tax_rate_id
-        if tax_rate_id
-          tax_rate = Spree::TaxRate.unscoped.find_by(shipping_rate.tax_rate_id)
-          shipping_rate.taxes.create(
-            tax_rate: tax_rate,
-            amount: tax_rate.compute_amount(shipping_rate)
-          )
-        end
-      end
-    end
-
     remove_column :spree_shipping_rates, :tax_rate_id
   end
 
   def down
     add_reference :spree_shipping_rates, :tax_rate, index: true, foreign_key: true
-    say_with_time "Attaching a tax rate to shipping rates" do
-      Spree::ShippingRate.find_each do |shipping_rate|
-        shipping_taxes = Spree::ShippingRateTax.where(shipping_rate_id: shipping_rate.id)
-        # We can only use one tax rate, so let's take the biggest.
-        selected_tax = shipping_taxes.sort_by(&:amount).last
-        if selected_tax
-          shipping_rate.update(tax_rate_id: tax_rate_id)
-        end
-      end
-    end
   end
 end


### PR DESCRIPTION
This migration did not work, and requires a call to `TaxRate#compute_amount`.

We could have fixed the "the does not work", but the `compute_amount` call requires
half of Solidus' object graph (including the `Spree::Calculator` STI table as well
as `Spree::Order`, `Spree::Shipment`, `Spree::TaxRate` - this is still not exhaustive).

We felt adding all of those into the migration was less than ideal, especially if your
local shipping rate was taxed using a different system than the default tax calculator.

The downside of this is ONLY that in the backend for old shipping orders, you will not be
shown the shipping rate tax (included or additional).

The reduced-in-complexity migration now just adds the `tax_rate_id` column on `Spree::ShippingRate`.