### PR TITLE
Include ControllerHelpers::Pricing from ControllerHelpers::Order

### DIFF
--- a/core/lib/spree/core/controller_helpers/order.rb
+++ b/core/lib/spree/core/controller_helpers/order.rb
@@ -1,8 +1,11 @@
+require 'spree/core/controller_helpers/pricing'
+
 module Spree
   module Core
     module ControllerHelpers
       module Order
         extend ActiveSupport::Concern
+        include ControllerHelpers::Pricing
 
         included do
           before_filter :set_current_order


### PR DESCRIPTION
`ControllerHelper::Order` requires `current_currency` from the `ControllerHelper::Pricing` module in order to work.

cc @mamhoff 