### PR TITLE
Upgrade path for shipping rate tax data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,14 @@
     The shipping rate taxer class can be exchanged for a custom estimator class
     using the new Spree::Appconfiguration.shipping_rate_taxer_class preference.
 
-    Shipping rates for completed orders before this change will, unfortunately, not be shown
-    with their taxes from Solidus 1.3 onwards. If you do change the shipping rate on an
-    old order, its taxes will be calculated correctly, though.
-
     https://github.com/solidusio/solidus/pull/904
+
+    In order to convert your historical shipping rate taxation data, please run  
+    `rake solidus:upgrade:one_point_three` - this will create persisted taxation notes
+    for historical shipping rates. Be aware though that these taxation notes are
+    estimations and should not be used for accounting purposes.
+
+    https://github.com/solidusio/solidus/pull/1068
 
 *   Deprecate setting a line item's currency by hand
 

--- a/core/db/migrate/20160225152313_remove_tax_rate_from_shipping_rate.rb
+++ b/core/db/migrate/20160225152313_remove_tax_rate_from_shipping_rate.rb
@@ -1,9 +1,0 @@
-class RemoveTaxRateFromShippingRate < ActiveRecord::Migration
-  def up
-    remove_column :spree_shipping_rates, :tax_rate_id
-  end
-
-  def down
-    add_reference :spree_shipping_rates, :tax_rate, index: true, foreign_key: true
-  end
-end

--- a/core/lib/tasks/migrations/migrate_shipping_rate_taxes.rake
+++ b/core/lib/tasks/migrations/migrate_shipping_rate_taxes.rake
@@ -1,0 +1,17 @@
+namespace :solidus do
+  namespace :migrations do
+    namespace :migrate_shipping_rate_taxes do
+      task up: :environment do
+        puts "Adding persisted tax notes to historic shipping rates"
+        Spree::ShippingRate.where.not(tax_rate_id: nil).find_each do |shipping_rate|
+          tax_rate = Spree::TaxRate.unscoped.find(shipping_rate.tax_rate_id)
+          shipping_rate.taxes.find_or_create_by!(
+            tax_rate: tax_rate,
+            amount: tax_rate.compute_amount(shipping_rate)
+          )
+        end
+        Spree::ShippingRate.where.not(tax_rate_id: nil).update_all(tax_rate: nil)
+      end
+    end
+  end
+end

--- a/core/lib/tasks/upgrade.rake
+++ b/core/lib/tasks/upgrade.rake
@@ -2,7 +2,8 @@ namespace :solidus do
   namespace :upgrade do
     desc "Upgrade Solidus to version 1.3"
     task one_point_three: [
-        'solidus:migrations:assure_store_on_orders:up'
+        'solidus:migrations:assure_store_on_orders:up',
+        'solidus:migrations:migrate_shipping_rate_taxes:up'
       ] do
       puts "Your Solidus install is ready for Solidus 1.3."
     end


### PR DESCRIPTION
Previously, we had a migration that deleted the `tax_rate_id` column
from the `spree_shipping_rates` table. Within that migration, we could not
satisfactorily create shipping rate taxes because that required a call to
`Spree::TaxRate#compute_amount`, for which we can not guarantee the interface
for all future Solidus versions to come.

This compromise works as follows: We keep the column and provide a rake task to
migrate that data up. In a future release (maybe 2.0), we can then add a migration
to delete the column that errors out if there's still data on it (indicating the
migration hasn't been run).