### PR TITLE
Make tab dropdowns always visible in test env

### DIFF
--- a/backend/app/views/spree/admin/shared/_head.html.erb
+++ b/backend/app/views/spree/admin/shared/_head.html.erb
@@ -23,6 +23,12 @@
     as it must, which means a bottom of page notification will obstruct interactions.
     */
     .flash-wrapper { position: static; }
+
+    /* Capybara doesn't know how to use dropdowns */
+    .tabs-dropdown ul {
+      display: block !important;
+      position: static;
+    }
   </style>
 <%- elsif Rails.env.development? %>
   <style>


### PR DESCRIPTION
Capybara+poltergeist can only click links which are visible and clickable. Our tab component collapses tabs into a dropdown when the screen is narrow. This commit forces that dropdown to be open in the
test environment and also changes it from an absolutely positioned element to a static elemnt so that it doesn't cover other on-screen items.

This fixes some failures in extensions, for example https://travis-ci.org/solidusio-contrib/solidus_related_products/jobs/119700687