### PR TITLE
Add proper scopes to property sorting

### DIFF
--- a/core/app/models/concerns/spree/ordered_property_value_list.rb
+++ b/core/app/models/concerns/spree/ordered_property_value_list.rb
@@ -3,8 +3,6 @@ module Spree
     extend ActiveSupport::Concern
 
     included do
-      acts_as_list
-
       validates :property, presence: true
       validates_with Spree::Validations::DbMaximumLengthValidator, field: :value
 

--- a/core/app/models/spree/product_property.rb
+++ b/core/app/models/spree/product_property.rb
@@ -2,6 +2,8 @@ module Spree
   class ProductProperty < Spree::Base
     include Spree::OrderedPropertyValueList
 
+    acts_as_list scope: :product
+
     belongs_to :product, touch: true, class_name: 'Spree::Product', inverse_of: :product_properties
     belongs_to :property, class_name: 'Spree::Property', inverse_of: :product_properties
 

--- a/core/app/models/spree/variant_property_rule_value.rb
+++ b/core/app/models/spree/variant_property_rule_value.rb
@@ -2,6 +2,8 @@ module Spree
   class VariantPropertyRuleValue < Spree::Base
     include Spree::OrderedPropertyValueList
 
+    acts_as_list scope: :variant_property_rule
+
     belongs_to :property
     belongs_to :variant_property_rule, touch: true
   end

--- a/core/spec/models/spree/concerns/ordered_property_value_list_spec.rb
+++ b/core/spec/models/spree/concerns/ordered_property_value_list_spec.rb
@@ -5,9 +5,34 @@ describe Spree::OrderedPropertyValueList do
   # Using ProductProperty as a subject
   # since it includes OrderedPropertyValueList
   #
-  let(:product_property) { create(:product_property) }
+
+  context 'positioning' do
+    let(:product_1) { create(:product) }
+    let!(:property_1) { create(:product_property, product: product_1) }
+    let!(:property_2) { create(:product_property, product: product_1) }
+
+    let(:product_2) { create(:product) }
+    let!(:property_3) { create(:product_property, product: product_2) }
+    let!(:property_4) { create(:product_property, product: product_2) }
+
+    before do
+      property_1.update_attribute(:position, 0)
+      property_2.update_attribute(:position, 1)
+      property_3.update_attribute(:position, 0)
+      property_4.update_attribute(:position, 1)
+    end
+
+    it 'scopes position to the product' do
+      expect(property_1.reload.position).to eq(0)
+      expect(property_2.reload.position).to eq(1)
+      expect(property_3.reload.position).to eq(0)
+      expect(property_4.reload.position).to eq(1)
+    end
+  end
 
   context "validations" do
+    let(:product_property) { create(:product_property) }
+
     # Only MySQL stores or stores that were migrated prior to the Rails 4.2
     # upgrade have length limitations on "value":
     # > The PostgreSQL and SQLite adapters no longer add a default limit of 255


### PR DESCRIPTION
Ordered properties need to be scoped to a product (or
variant_property_rule). Otherwise, when creating or updating a property record,
the position field gets overwritten for all properties in that table.

Because of the differing fields in product_property and
variant_product_rule_value, it was necessary to pull the acts_as_list
declaration out of the concern and put it directly into the model.