### PR TITLE
Allow subtraction and addition for Spree::Money objects

### DIFF
--- a/core/lib/spree/money.rb
+++ b/core/lib/spree/money.rb
@@ -70,14 +70,17 @@ module Spree
     #
     # @see http://www.rubydoc.info/gems/money/Money/Arithmetic#%3D%3D-instance_method
     def ==(other)
+      raise TypeError, "Can't compare #{other.class} to Spree::Money" if !other.respond_to?(:money)
       @money == other.money
     end
 
     def -(other)
+      raise TypeError, "Can't subtract #{other.class} to Spree::Money" if !other.respond_to?(:money)
       self.class.from_money(@money - other.money)
     end
 
     def +(other)
+      raise TypeError, "Can't add #{other.class} to Spree::Money" if !other.respond_to?(:money)
       self.class.from_money(@money + other.money)
     end
   end

--- a/core/lib/spree/money.rb
+++ b/core/lib/spree/money.rb
@@ -8,6 +8,10 @@ module Spree
   class Money
     class <<self
       attr_accessor :default_formatting_rules
+
+      def from_money(money)
+        new(money.to_d, currency: money.currency.iso_code)
+      end
     end
     self.default_formatting_rules = {
       # Ruby money currently has this as false, which is wrong for the vast
@@ -67,6 +71,14 @@ module Spree
     # @see http://www.rubydoc.info/gems/money/Money/Arithmetic#%3D%3D-instance_method
     def ==(other)
       @money == other.money
+    end
+
+    def -(other)
+      self.class.from_money(@money - other.money)
+    end
+
+    def +(other)
+      self.class.from_money(@money + other.money)
     end
   end
 end

--- a/core/spec/lib/spree/money_spec.rb
+++ b/core/spec/lib/spree/money_spec.rb
@@ -124,4 +124,44 @@ describe Spree::Money do
       expect(money.as_json(options)).to eq("$10.00")
     end
   end
+
+  describe 'subtraction' do
+    context "for money objects with same currency" do
+      let(:money_1) { Spree::Money.new(32.00, currency: "USD") }
+      let(:money_2) { Spree::Money.new(15.00, currency: "USD") }
+
+      it "subtracts correctly" do
+        expect(money_1 - money_2).to eq(Spree::Money.new(17.00, currency: "USD"))
+      end
+    end
+
+    context "when trying to subtract money objects in different currencies" do
+      let(:money_1) { Spree::Money.new(32.00, currency: "EUR") }
+      let(:money_2) { Spree::Money.new(15.00, currency: "USD") }
+
+      it "will not work" do
+        expect { money_1 - money_2 }.to raise_error(Money::Bank::UnknownRate)
+      end
+    end
+  end
+
+  describe 'addition' do
+    context "for money objects with same currency" do
+      let(:money_1) { Spree::Money.new(37.00, currency: "USD") }
+      let(:money_2) { Spree::Money.new(15.00, currency: "USD") }
+
+      it "subtracts correctly" do
+        expect(money_1 + money_2).to eq(Spree::Money.new(52.00, currency: "USD"))
+      end
+    end
+
+    context "when trying to subtract money objects in different currencies" do
+      let(:money_1) { Spree::Money.new(32.00, currency: "EUR") }
+      let(:money_2) { Spree::Money.new(15.00, currency: "USD") }
+
+      it "will not work" do
+        expect { money_1 + money_2 }.to raise_error(Money::Bank::UnknownRate)
+      end
+    end
+  end
 end

--- a/core/spec/lib/spree/money_spec.rb
+++ b/core/spec/lib/spree/money_spec.rb
@@ -143,6 +143,15 @@ describe Spree::Money do
         expect { money_1 - money_2 }.to raise_error(Money::Bank::UnknownRate)
       end
     end
+
+    context "if other does not respond to .money" do
+      let(:money_1) { Spree::Money.new(32.00, currency: "EUR") }
+      let(:money_2) { ::Money.new(1500) }
+
+      it 'raises a TypeError' do
+        expect { money_1 - money_2 }.to raise_error(TypeError)
+      end
+    end
   end
 
   describe 'addition' do
@@ -161,6 +170,26 @@ describe Spree::Money do
 
       it "will not work" do
         expect { money_1 + money_2 }.to raise_error(Money::Bank::UnknownRate)
+      end
+    end
+
+    context "if other does not respond to .money" do
+      let(:money_1) { Spree::Money.new(32.00, currency: "EUR") }
+      let(:money_2) { ::Money.new(1500) }
+
+      it 'raises a TypeError' do
+        expect { money_1 + money_2 }.to raise_error(TypeError)
+      end
+    end
+  end
+
+  describe 'equality checks' do
+    context "if other does not respond to .money" do
+      let(:money_1) { Spree::Money.new(32.00, currency: "EUR") }
+      let(:money_2) { ::Money.new(1500) }
+
+      it 'raises a TypeError' do
+        expect { money_1 == money_2 }.to raise_error(TypeError)
       end
     end
   end


### PR DESCRIPTION
Spree::Money, being a thin wrapper around the Ruby `::Money` object, can
not add or subtract. This commit adds subtraction and addition capabilities.