### PR TITLE
Show an error when specifying an invalid DB value

### DIFF
--- a/core/lib/generators/spree/dummy/templates/rails/database.yml
+++ b/core/lib/generators/spree/dummy/templates/rails/database.yml
@@ -52,7 +52,7 @@ production:
 <% unless db_host.blank? %>
   host: <%= db_host %>
 <% end %>
-<% else %>
+<% when 'sqlite', '', nil %>
 development:
   adapter: sqlite3
   database: db/spree_development.sqlite3
@@ -62,4 +62,6 @@ test:
 production:
   adapter: sqlite3
   database: db/spree_production.sqlite3
+<% else %>
+  <% raise "Invalid DB specified: #{ENV['DB']}" %>
 <% end %>

--- a/lib/sandbox.sh
+++ b/lib/sandbox.sh
@@ -3,14 +3,14 @@
 
 case "$DB" in
 postgres|postgresql)
-	RAILSDB="postgresql"
-	;;
+  RAILSDB="postgresql"
+  ;;
 mysql)
-	RAILSDB="mysql"
-	;;
+  RAILSDB="mysql"
+  ;;
 *)
-	RAILSDB="sqlite3"
-	;;
+  RAILSDB="sqlite3"
+  ;;
 esac
 
 rm -rf ./sandbox

--- a/lib/sandbox.sh
+++ b/lib/sandbox.sh
@@ -8,8 +8,12 @@ postgres|postgresql)
 mysql)
   RAILSDB="mysql"
   ;;
-*)
+sqlite|'')
   RAILSDB="sqlite3"
+  ;;
+*)
+  echo "Invalid DB specified: $DB"
+  exit 1
   ;;
 esac
 


### PR DESCRIPTION
Just to save myself from typing `postgresq` and ending up with `sqlite`.