### PR TITLE
Recalculate the tax adjustments after customer address is updated

### DIFF
--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -15,6 +15,7 @@ module Spree
     alias_attribute :last_name, :lastname
 
     DB_ONLY_ATTRS = %w(id updated_at created_at)
+    TAX_ZONE_ONLY_ATTRS = %w(state_id country_id zipcode)
 
     self.whitelisted_ransackable_attributes = %w[firstname lastname]
 
@@ -73,9 +74,14 @@ module Spree
       base.except!(*DB_ONLY_ATTRS)
     end
 
+
     # @return [Hash] hash of attributes contributing to value equality
     def value_attributes
       self.class.value_attributes(attributes)
+    end
+
+    def tax_zone_attributes
+      self.class.value_attributes(attributes.slice(*TAX_ZONE_ONLY_ATTRS))
     end
 
     # @return [String] the full name on this address

--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -15,7 +15,7 @@ module Spree
     alias_attribute :last_name, :lastname
 
     DB_ONLY_ATTRS = %w(id updated_at created_at)
-    TAX_ZONE_ONLY_ATTRS = %w(state_id country_id zipcode)
+    TAXATION_ATTRS = %w(state_id country_id zipcode)
 
     self.whitelisted_ransackable_attributes = %w[firstname lastname]
 
@@ -74,14 +74,13 @@ module Spree
       base.except!(*DB_ONLY_ATTRS)
     end
 
-
     # @return [Hash] hash of attributes contributing to value equality
     def value_attributes
       self.class.value_attributes(attributes)
     end
 
-    def tax_zone_attributes
-      self.class.value_attributes(attributes.slice(*TAX_ZONE_ONLY_ATTRS))
+    def taxation_attributes
+      self.class.value_attributes(attributes.slice(*TAXATION_ATTRS))
     end
 
     # @return [String] the full name on this address

--- a/core/app/models/spree/order_contents.rb
+++ b/core/app/models/spree/order_contents.rb
@@ -72,17 +72,33 @@ module Spree
     private
 
     def should_recalculate_taxes?(old_address, new_address)
+      # Related to Solidus issue #894
+      # This is needed because if you update the shipping_address
+      # from the backend on an order that completed checkout,
+      # Taxes were not being recalculated if the Order tax zone
+      # was updated
+      #
       # Possible cases:
-      # [Old_address is a TaxLocation, New_address is a TaxLocation ]:
-      # NON-VAT order before Address state : we don't compute taxes.
-      # [Old_address is a TaxLocation, New_address is an Adress ]:
-      # Order who passed Address state : we compute taxes.
-      # [Old_address is an Adress, New_address is a TaxLocation ]:
-      # Should not happen, TaxLocation can be replaced by an Address but not the other way around.
-      # Order is a weird state and we do nothing because it should not happen.
+      #
+      # Case 1:
+      #
+      # If old_address is a TaxLocation it means that the order has not passed
+      # the address checkout state so taxes will be computed by the Order
+      # state machine, so we do not calculate taxes here.
+      #
+      # Case 2 :
+      # If new_address is a TaxLocation, but old_address is not, it means that
+      # an order has somehow lost his TaxAddress. Since it's not supposed to happen,
+      # we do not compute taxes.
+      #
+      # Case 3
+      # Both old_address and new_address are Spree::Address so the order
+      # has completed the checkout or that a registered user has updated his
+      # default addresses. We need to recalculate the taxes.
+
       return if old_address.is_a?(Spree::Tax::TaxLocation) || new_address.is_a?(Spree::Tax::TaxLocation)
 
-      old_address.try(:taxation_attributes) != new_address.try(:taxation_attributes)
+      old_address.try!(:taxation_attributes) != new_address.try!(:taxation_attributes)
     end
 
     def after_add_or_remove(line_item, options = {})

--- a/core/app/models/spree/order_contents.rb
+++ b/core/app/models/spree/order_contents.rb
@@ -22,7 +22,17 @@ module Spree
     end
 
     def update_cart(params)
+
+      old_tax_address = order.tax_address
+
       if order.update_attributes(params)
+
+        new_tax_address = order.tax_address
+
+        unless new_tax_address.== old_tax_address
+          order.create_tax_charge!
+        end
+
         unless order.completed?
           order.line_items = order.line_items.select { |li| li.quantity > 0 }
           # Update totals, then check if the order is eligible for any cart promotions.

--- a/core/spec/models/spree/address_spec.rb
+++ b/core/spec/models/spree/address_spec.rb
@@ -308,6 +308,28 @@ describe Spree::Address, type: :model do
     end
   end
 
+  describe '.taxation_attributes' do
+    context 'both taxation and non-taxation attributes are present ' do
+      let(:address) { stub_model(Spree::Address, firstname: 'Michael', lastname: 'Jackson', state_id: 1, country_id: 2, zipcode: '12345') }
+
+      it 'removes the non-taxation attributes' do
+        expect(address.taxation_attributes).not_to eq('firstname' => 'Michael', 'lastname' => 'Jackson')
+      end
+
+      it 'returns only the taxation attributes' do
+        expect(address.taxation_attributes).to eq('state_id' => 1, 'country_id' => 2, 'zipcode' => '12345')
+      end
+    end
+
+    context 'taxation attributes are blank' do
+      let(:address) { stub_model(Spree::Address, firstname: 'Michael', lastname: 'Jackson') }
+
+      it 'returns a subset of the attributes with the correct keys and nil values' do
+        expect(address.taxation_attributes).to eq('state_id' => nil, 'country_id' => nil, 'zipcode' => nil)
+      end
+    end
+  end
+
   context '#country_iso=' do
     let(:address) { build(:address, country_id: nil) }
     let(:country) { create(:country, iso: 'ZW') }

--- a/core/spec/models/spree/order_contents_spec.rb
+++ b/core/spec/models/spree/order_contents_spec.rb
@@ -224,39 +224,51 @@ describe Spree::OrderContents, type: :model do
       }.to change { subject.order.total }
     end
 
-    context "submits an address in a different tax zone than the current address" do
-      let(:default_address) { create :address, state_code: "NY" }
-      let(:updated_address) { create :address, state_code: "AL" }
-
-      let(:order_with_address ) { create :order, ship_address: default_address, bill_address: default_address}
+    context "given an order with existing addresses" do
+      let(:default_address) { create :address, state_code: "NY", zipcode: "17402" }
+      let(:order_with_address ) { create :order, ship_address: default_address, bill_address: default_address }
 
       subject { described_class.new(order_with_address) }
 
-      let(:params) do
-        { :ship_address_attributes => updated_address.value_attributes, bill_address_attributes: updated_address.value_attributes}
+      context "when an address in a potentially different tax zone is supplied " do
+        let(:updated_address) { build :address, state_code: "AL",  zipcode: "64092" }
+
+        let(:params) do
+          { ship_address_attributes: updated_address.value_attributes, bill_address_attributes: updated_address.value_attributes }
+        end
+
+        it "updates tax adjustments" do
+          expect(subject.order).to receive(:create_tax_charge!)
+          subject.update_cart params
+        end
       end
 
-      it "updates tax adjustments" do
-        puts params.inspect
-        expect(subject.order).to receive(:create_tax_charge!)
-        subject.update_cart params
+      context "when an address in potentially the same tax zone is supplied" do
+        let(:updated_address) { build :address, state_code: "NY", zipcode: "17402", firstname: 'Robert' }
+
+        let(:params) do
+          { ship_address_attributes: updated_address.value_attributes, bill_address_attributes: updated_address.value_attributes }
+        end
+
+        it "does not updates tax adjustments" do
+          expect(subject.order).not_to receive(:create_tax_charge!)
+          subject.update_cart params
+        end
       end
     end
 
-    context "submits an address in the same tax zone than the current address" do
+    context "given an order with no existing addresses" do
+      context "when an address is supplied" do
+        let(:updated_address) { build :address, state_code: "CA", zipcode: "14902" }
 
-      let(:default_address) { create :address, state_code: "NY", zipcode: "17402" }
-      let(:updated_address) { create :address, state_code: "NY", zipcode: "17402" }
+        let(:params) do
+          { ship_address_attributes: updated_address.attributes, bill_address_attributes: updated_address.value_attributes }
+        end
 
-      before { order.update_attributes(ship_address: default_address, bill_address: default_address) }
-
-      let(:params) do
-        { ship_address: updated_address, bill_address: updated_address}
-      end
-
-      it "does not updates tax adjustments" do
-        expect(subject.order).not_to receive(:create_tax_charge!)
-        subject.update_cart params
+        it "does not updates tax adjustments" do
+          expect(subject.order).not_to receive(:create_tax_charge!)
+          subject.update_cart params
+        end
       end
     end
 

--- a/core/spec/models/spree/order_contents_spec.rb
+++ b/core/spec/models/spree/order_contents_spec.rb
@@ -224,6 +224,36 @@ describe Spree::OrderContents, type: :model do
       }.to change { subject.order.total }
     end
 
+    context "submits an address in a different tax zone than the current address" do
+      let(:shipping_address) { create :address, state_code: "NY" }
+
+      let(:params) do
+        { ship_address: shipping_address}
+      end
+
+      it "updates tax adjustments" do
+        expect(subject.order).to receive(:create_tax_charge!)
+        subject.update_cart params
+      end
+    end
+
+    context "submits an address in the same tax zone than the current address" do
+
+      let(:default_address) { create :address, state_code: "NY", zipcode: "17402" }
+      let(:updated_address) { create :address, state_code: "NY", zipcode: "17402"}
+
+      before { order.update_attributes(ship_address: default_address, bill_address: default_address) }
+
+      let(:params) do
+        { ship_address: updated_address}
+      end
+
+      it "does not updates tax adjustments" do
+        expect(subject.order).not_to receive(:create_tax_charge!)
+        subject.update_cart params
+      end
+    end
+
     context "submits item quantity 0" do
       let(:params) do
         { line_items_attributes: {

--- a/core/spec/models/spree/order_contents_spec.rb
+++ b/core/spec/models/spree/order_contents_spec.rb
@@ -225,13 +225,19 @@ describe Spree::OrderContents, type: :model do
     end
 
     context "submits an address in a different tax zone than the current address" do
-      let(:shipping_address) { create :address, state_code: "NY" }
+      let(:default_address) { create :address, state_code: "NY" }
+      let(:updated_address) { create :address, state_code: "AL" }
+
+      let(:order_with_address ) { create :order, ship_address: default_address, bill_address: default_address}
+
+      subject { described_class.new(order_with_address) }
 
       let(:params) do
-        { ship_address: shipping_address}
+        { :ship_address_attributes => updated_address.value_attributes, bill_address_attributes: updated_address.value_attributes}
       end
 
       it "updates tax adjustments" do
+        puts params.inspect
         expect(subject.order).to receive(:create_tax_charge!)
         subject.update_cart params
       end
@@ -240,12 +246,12 @@ describe Spree::OrderContents, type: :model do
     context "submits an address in the same tax zone than the current address" do
 
       let(:default_address) { create :address, state_code: "NY", zipcode: "17402" }
-      let(:updated_address) { create :address, state_code: "NY", zipcode: "17402"}
+      let(:updated_address) { create :address, state_code: "NY", zipcode: "17402" }
 
       before { order.update_attributes(ship_address: default_address, bill_address: default_address) }
 
       let(:params) do
-        { ship_address: updated_address}
+        { ship_address: updated_address, bill_address: updated_address}
       end
 
       it "does not updates tax adjustments" do


### PR DESCRIPTION
This is a fix for issue https://github.com/solidusio/solidus/issues/894

If you update an address in the order after the checkout (like by updating the Customer Details in the admin after an order is complete but before it's shipped), this can potentially put the Order in a new Tax zone and this is currently not supported.

Added by this pull request :

**Spree::Address**

A custom method to select only the fields related to Tax Zone matching (zipcode, country_id, state_id) to compare different addresses

**Spree::OrderContent**

Added a check in update_cart to recreate Tax adjustments in certain conditions

1) The order currently has no address (only an empty TaxLocation), we add one. Nothing to be done, it will be handled by the state transitions between :address and :delivery, and :delivery to :payment.

2) The order currently has an address, we update it but editing only trivial fields (firstname, lastname). We use address.tax_zone_attributes to compare the old and the new address and determine that nothing meaningful happened regarding tax zones, we do nothing.

3) The order currently has an address, we update the state / the country / the zipcode. We compute new Tax adjustments because we might be in a different zone.

4) old_tax_address will be  TaxLocation instead of an Address if there was no Address prior to the update, so we just return because it means that the order is either a VAT order and we don't need to recalculate Tax adjustments for now, or the order is a non-VAT order in the cart state, in which case we don't want to / we can't calculate Tax yet

**Potential code issues**

I wanted to use ActiveRecord::Dirty to determine if address was updated instead of using old_tax_zone / new_tax_zone but since Spree::Address factory if creating a new record each time we update a value, it's not possible to my knowledge. There might be a better way though

**To determine**

What if an order is paid? (like if you accept the pending payments, you double-check before shipping and notice that the address is wrong)
