### PR TITLE
Deprecate parsing in Spree::Money.new

### DIFF
--- a/core/lib/spree/money.rb
+++ b/core/lib/spree/money.rb
@@ -6,6 +6,8 @@ module Spree
   # Spree::Money is a relatively thin wrapper around Monetize which handles
   # formatting via Spree::Config.
   class Money
+    RUBY_NUMERIC_STRING = /\A-?\d+(\.\d+)?\z/
+
     class <<self
       attr_accessor :default_formatting_rules
 
@@ -39,7 +41,7 @@ module Spree
         @money = amount
       else
         currency = (options[:currency] || Spree::Config[:currency])
-        if amount.to_s =~ /\A-?\d+(\.\d+)?\z/
+        if amount.to_s =~ RUBY_NUMERIC_STRING
           @money = Monetize.from_string(amount, currency)
         else
           @money = Spree::Money.parse_to_money(amount, currency)

--- a/core/lib/spree/money.rb
+++ b/core/lib/spree/money.rb
@@ -10,7 +10,7 @@ module Spree
       attr_accessor :default_formatting_rules
 
       def from_money(money)
-        new(money.to_d, currency: money.currency.iso_code)
+        new(money)
       end
     end
     self.default_formatting_rules = {
@@ -23,7 +23,7 @@ module Spree
 
     delegate :cents, :currency, :to_d, :zero?, to: :money
 
-    # @param amount [#to_s] the value of the money object
+    # @param amount [Money, #to_s] the value of the money object
     # @param options [Hash] the options for creating the money object
     # @option options [String] currency the currency for the money object
     # @option options [Boolean] with_currency when true, show the currency
@@ -37,7 +37,11 @@ module Spree
     # @option options [:before, :after] symbol_position the position of the
     #   currency symbol
     def initialize(amount, options = {})
-      @money = Monetize.parse(amount, (options[:currency] || Spree::Config[:currency]))
+      if amount.is_a?(::Money)
+        @money = amount
+      else
+        @money = Monetize.parse(amount, (options[:currency] || Spree::Config[:currency]))
+      end
       @options = Spree::Money.default_formatting_rules.merge(options)
     end
 

--- a/core/lib/spree/money.rb
+++ b/core/lib/spree/money.rb
@@ -37,7 +37,7 @@ module Spree
     # @option options [:before, :after] symbol_position the position of the
     #   currency symbol
     def initialize(amount, options = {})
-      @money = Monetize.parse([amount, (options[:currency] || Spree::Config[:currency])].join)
+      @money = Monetize.parse(amount, (options[:currency] || Spree::Config[:currency]))
       @options = Spree::Money.default_formatting_rules.merge(options)
     end
 

--- a/core/lib/spree/money.rb
+++ b/core/lib/spree/money.rb
@@ -24,18 +24,7 @@ module Spree
     delegate :cents, :currency, :to_d, :zero?, to: :money
 
     # @param amount [Money, #to_s] the value of the money object
-    # @param options [Hash] the options for creating the money object
-    # @option options [String] currency the currency for the money object
-    # @option options [Boolean] with_currency when true, show the currency
-    # @option options [Boolean] no_cents when true, round to the closest dollar
-    # @option options [String] decimal_mark the mark for delimiting the
-    #   decimals
-    # @option options [String, false, nil] thousands_separator the character to
-    #   delimit powers of 1000, if one is desired, otherwise false or nil
-    # @option options [Boolean] sign_before_symbol when true the sign of the
-    #   value comes before the currency symbol
-    # @option options [:before, :after] symbol_position the position of the
-    #   currency symbol
+    # @param options [Hash] the default options for formatting the money object See #format
     def initialize(amount, options = {})
       if amount.is_a?(::Money)
         @money = amount
@@ -48,7 +37,24 @@ module Spree
     # @return [String] the value of this money object formatted according to
     #   its options
     def to_s
-      @money.format(@options)
+      format
+    end
+
+    # @param options [Hash, String] the options for formatting the money object
+    # @option options [Boolean] with_currency when true, show the currency
+    # @option options [Boolean] no_cents when true, round to the closest dollar
+    # @option options [String] decimal_mark the mark for delimiting the
+    #   decimals
+    # @option options [String, false, nil] thousands_separator the character to
+    #   delimit powers of 1000, if one is desired, otherwise false or nil
+    # @option options [Boolean] sign_before_symbol when true the sign of the
+    #   value comes before the currency symbol
+    # @option options [:before, :after] symbol_position the position of the
+    #   currency symbol
+    # @return [String] the value of this money object formatted according to
+    #   its options
+    def format(options={})
+      @money.format(@options.merge(options))
     end
 
     # @note If you pass in options, ensure you pass in the html: true as well.
@@ -56,7 +62,7 @@ module Spree
     # @return [String] the value of this money object formatted according to
     #   its options and any additional options, by default as html.
     def to_html(options = { html: true })
-      output = @money.format(@options.merge(options))
+      output = format(options)
       if options[:html]
         # 1) prevent blank, breaking spaces
         # 2) prevent escaping of HTML character entities

--- a/core/lib/spree/money.rb
+++ b/core/lib/spree/money.rb
@@ -11,10 +11,6 @@ module Spree
     class <<self
       attr_accessor :default_formatting_rules
 
-      def from_money(money)
-        new(money)
-      end
-
       def parse(amount, currency = Spree::Config[:currency])
         new(parse_to_money(amount, currency))
       end
@@ -106,12 +102,12 @@ module Spree
 
     def -(other)
       raise TypeError, "Can't subtract #{other.class} to Spree::Money" if !other.respond_to?(:money)
-      self.class.from_money(@money - other.money)
+      self.class.new(@money - other.money)
     end
 
     def +(other)
       raise TypeError, "Can't add #{other.class} to Spree::Money" if !other.respond_to?(:money)
-      self.class.from_money(@money + other.money)
+      self.class.new(@money + other.money)
     end
   end
 end

--- a/core/spec/lib/spree/money_spec.rb
+++ b/core/spec/lib/spree/money_spec.rb
@@ -8,6 +8,76 @@ describe Spree::Money do
     end
   end
 
+  describe '#initialize' do
+    subject { described_class.new(amount, currency: currency, with_currency: true).to_s }
+    context 'with no currency' do
+      let(:currency) { nil }
+      let(:amount){ 10 }
+      it { should == "$10.00 USD" }
+    end
+
+    context 'with currency' do
+      let(:currency){ 'USD' }
+
+      context "CAD" do
+        let(:amount){ '10.00' }
+        let(:currency){ 'CAD' }
+        it { should == "$10.00 CAD" }
+      end
+
+      context "with string amount" do
+        let(:amount){ '10.00' }
+        it { should == "$10.00 USD" }
+      end
+
+      context "with no decimal point" do
+        let(:amount){ '10' }
+        it { should == "$10.00 USD" }
+      end
+
+      context "with symbol" do
+        let(:amount){ '$10.00' }
+        it { should == "$10.00 USD" }
+      end
+
+      context "with extra currency" do
+        let(:amount){ '$10.00 USD' }
+        it { should == "$10.00 USD" }
+      end
+
+      context "with different currency" do
+        let(:currency){ 'USD' }
+        let(:amount){ '$10.00 CAD' }
+        it { should == "$10.00 CAD" }
+      end
+
+      context "with commas" do
+        let(:amount){ '1,000.00' }
+        it { should == "$1,000.00 USD" }
+      end
+
+      context "with comma for decimal point" do
+        let(:amount){ '10,00' }
+        it { should == "$10.00 USD" }
+      end
+
+      context 'with fixnum' do
+        let(:amount){ 10 }
+        it { should == "$10.00 USD" }
+      end
+
+      context 'with float' do
+        let(:amount){ 10.00 }
+        it { should == "$10.00 USD" }
+      end
+
+      context 'with BigDecimal' do
+        let(:amount){ BigDecimal.new('10.00') }
+        it { should == "$10.00 USD" }
+      end
+    end
+  end
+
   it "formats correctly" do
     money = Spree::Money.new(10)
     expect(money.to_s).to eq("$10.00")

--- a/core/spec/lib/spree/money_spec.rb
+++ b/core/spec/lib/spree/money_spec.rb
@@ -9,7 +9,12 @@ describe Spree::Money do
   end
 
   describe '#initialize' do
-    subject { described_class.new(amount, currency: currency, with_currency: true).to_s }
+    subject do
+      Spree::Deprecation.silence do
+        described_class.new(amount, currency: currency, with_currency: true).to_s
+      end
+    end
+
     context 'with no currency' do
       let(:currency) { nil }
       let(:amount){ 10 }


### PR DESCRIPTION
Previously Spree::Money was always initialized with a string which would be parsed, like `"$1.00 USD"` or `"$2,10 EUR"`. This introduces a Spree::Money.parse which should be used instead for this type of input. Any currency passed in was appended to the `amount` string before parsing to end up with the correct currency.

This PR deprecates the complex parsing in `Spree::Money.new`, requiring either a Numeric or a string which is valid as input to `BigDecimal.new`. In solidus Money was already used in this way, but this deprecates the existing behaviour to be as safe as possible.

This now allows initializing `Spree::Money` with an existing `::Money` object. `Spree::Money.parse` was introduced to provide the existing behaviour, matching `Monetize.parse`.

This should be faster and less error-prone.

Inspired by @mamhoff's recent work improving Spree::Money