### PR TITLE
Add breadcrumbs to page title in admin backend

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/_bootstrap_custom.scss
+++ b/backend/app/assets/stylesheets/spree/backend/_bootstrap_custom.scss
@@ -624,7 +624,7 @@ $thumbnail-border-radius:     $border-radius !default;
 $breadcrumb-padding-vertical:   .75rem !default;
 $breadcrumb-padding-horizontal: 1rem !default;
 
-$breadcrumb-bg:                 $gray-lighter !default;
+$breadcrumb-bg:                 none !default;
 $breadcrumb-divider-color:      $gray-light !default;
 $breadcrumb-active-color:       $gray-light !default;
 $breadcrumb-divider:            "/" !default;

--- a/backend/app/assets/stylesheets/spree/backend/_bootstrap_custom.scss
+++ b/backend/app/assets/stylesheets/spree/backend/_bootstrap_custom.scss
@@ -626,7 +626,7 @@ $breadcrumb-padding-horizontal: 1rem !default;
 
 $breadcrumb-bg:                 none !default;
 $breadcrumb-divider-color:      $gray-light !default;
-$breadcrumb-active-color:       $gray-light !default;
+$breadcrumb-active-color:       $color-4 !default;
 $breadcrumb-divider:            "/" !default;
 
 

--- a/backend/app/assets/stylesheets/spree/backend/components/_breadcrumb.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_breadcrumb.scss
@@ -1,0 +1,4 @@
+.breadcrumb {
+  font-size: 16px;
+  margin-bottom: 0;
+}

--- a/backend/app/assets/stylesheets/spree/backend/spree_admin.scss
+++ b/backend/app/assets/stylesheets/spree/backend/spree_admin.scss
@@ -20,6 +20,7 @@
 
 @import 'spree/backend/components/states';
 @import 'spree/backend/components/actions';
+@import 'spree/backend/components/breadcrumb';
 @import 'spree/backend/components/date-picker';
 @import 'spree/backend/components/hint';
 @import 'spree/backend/components/list_group';

--- a/backend/app/helpers/spree/admin/navigation_helper.rb
+++ b/backend/app/helpers/spree/admin/navigation_helper.rb
@@ -1,6 +1,27 @@
 module Spree
   module Admin
     module NavigationHelper
+      # Add items to current page breadcrumb heirarchy
+      def add_breadcrumb(*ancestors, &block)
+        breadcrumbs.concat(ancestors) if ancestors.present?
+        breadcrumbs.push(capture(&block)) if block_given?
+      end
+
+      def add_page_title_to_breadcrumbs
+        ActiveSupport::Deprecation.warn('content_for(:page_title) is deprecated, use add_breadcrumb')
+        add_breadcrumb(content_for(:page_title))
+      end
+
+      # Render Bootstrap style breadcrumbs
+      def render_breadcrumbs
+        add_page_title_to_breadcrumbs if content_for?(:page_title)
+        content_tag :ol, class: 'breadcrumb' do
+          safe_join breadcrumbs.collect { |level|
+            content_tag(:li, level, class: "separator #{level == breadcrumbs.last ? 'active' : ''}")
+          }
+        end
+      end
+
       # Make an admin tab that coveres one or more resources supplied by symbols
       # Option hash may follow. Valid options are
       #   * :label to override link text, otherwise based on the first resource name (translated)
@@ -135,6 +156,12 @@ module Spree
         content_tag(:li, options) do
           link_to(link_text, url)
         end
+      end
+
+      private
+
+      def breadcrumbs
+        @breadcrumbs ||= []
       end
     end
   end

--- a/backend/app/helpers/spree/admin/navigation_helper.rb
+++ b/backend/app/helpers/spree/admin/navigation_helper.rb
@@ -22,6 +22,18 @@ module Spree
         end
       end
 
+      def page_title
+        if content_for?(:title)
+          content_for(:title)
+        elsif content_for?(:page_title)
+          content_for(:page_title)
+        elsif breadcrumbs.any?
+          strip_tags(breadcrumbs.last)
+        else
+          Spree.t(controller.controller_name, default: controller.controller_name.titleize)
+        end
+      end
+
       # Make an admin tab that coveres one or more resources supplied by symbols
       # Option hash may follow. Valid options are
       #   * :label to override link text, otherwise based on the first resource name (translated)

--- a/backend/app/views/spree/admin/adjustment_reasons/edit.html.erb
+++ b/backend/app/views/spree/admin/adjustment_reasons/edit.html.erb
@@ -2,7 +2,7 @@
 
 <% add_breadcrumb Spree.t(:settings) %>
 <% add_breadcrumb Spree.t('admin.tab.checkout') %>
-<% add_breadcrumb link_to Spree::AdjustmentReason.model_name.human(count: :other), spree.admin_adjustment_reasons_path %>
+<% add_breadcrumb link_to plural_resource_name(Spree::AdjustmentReason), spree.admin_adjustment_reasons_path %>
 <% add_breadcrumb @object.name %>
 
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @object } %>

--- a/backend/app/views/spree/admin/adjustment_reasons/edit.html.erb
+++ b/backend/app/views/spree/admin/adjustment_reasons/edit.html.erb
@@ -1,11 +1,13 @@
 <%= render 'spree/admin/shared/settings_checkout_tabs' %>
 
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_adjustment_reason) %>
+  <%= Spree.t(:settings) %> &#x2f;
+  <%= Spree.t('admin.tab.checkout') %> &#x2f;
+  <%= link_to Spree::AdjustmentReason.model_name.human(count: :other), spree.admin_adjustment_reasons_path %> &#x2f;
+  <%= @object.name %>
 <% end %>
 
 <% content_for :page_actions do %>
-  <li><%= link_to_with_icon 'arrow-left', Spree.t(:back_to_adjustment_reason_list), collection_url, :class => 'button' %></li>
 <% end %>
 
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @object } %>

--- a/backend/app/views/spree/admin/adjustment_reasons/edit.html.erb
+++ b/backend/app/views/spree/admin/adjustment_reasons/edit.html.erb
@@ -1,14 +1,9 @@
 <%= render 'spree/admin/shared/settings_checkout_tabs' %>
 
-<% content_for :page_title do %>
-  <%= Spree.t(:settings) %> &#x2f;
-  <%= Spree.t('admin.tab.checkout') %> &#x2f;
-  <%= link_to Spree::AdjustmentReason.model_name.human(count: :other), spree.admin_adjustment_reasons_path %> &#x2f;
-  <%= @object.name %>
-<% end %>
-
-<% content_for :page_actions do %>
-<% end %>
+<% add_breadcrumb Spree.t(:settings) %>
+<% add_breadcrumb Spree.t('admin.tab.checkout') %>
+<% add_breadcrumb link_to Spree::AdjustmentReason.model_name.human(count: :other), spree.admin_adjustment_reasons_path %>
+<% add_breadcrumb @object.name %>
 
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @object } %>
 

--- a/backend/app/views/spree/admin/adjustment_reasons/index.html.erb
+++ b/backend/app/views/spree/admin/adjustment_reasons/index.html.erb
@@ -2,7 +2,7 @@
 
 <% add_breadcrumb(Spree.t(:settings)) %>
 <% add_breadcrumb(Spree.t('admin.tab.checkout')) %>
-<% add_breadcrumb(Spree::AdjustmentReason.model_name.human(count: :other)) %>
+<% add_breadcrumb(plural_resource_name(Spree::AdjustmentReason)) %>
 
 <% content_for :page_actions do %>
   <ul class="actions inline-menu">

--- a/backend/app/views/spree/admin/adjustment_reasons/index.html.erb
+++ b/backend/app/views/spree/admin/adjustment_reasons/index.html.erb
@@ -1,10 +1,8 @@
 <%= render 'spree/admin/shared/settings_checkout_tabs' %>
 
-<% content_for :page_title do %>
-  <%= Spree.t(:settings) %> &#x2f;
-  <%= Spree.t('admin.tab.checkout') %> &#x2f;
-  <%= Spree::AdjustmentReason.model_name.human(count: :other) %>
-<% end %>
+<% add_breadcrumb(Spree.t(:settings)) %>
+<% add_breadcrumb(Spree.t('admin.tab.checkout')) %>
+<% add_breadcrumb(Spree::AdjustmentReason.model_name.human(count: :other)) %>
 
 <% content_for :page_actions do %>
   <ul class="actions inline-menu">

--- a/backend/app/views/spree/admin/adjustment_reasons/index.html.erb
+++ b/backend/app/views/spree/admin/adjustment_reasons/index.html.erb
@@ -1,7 +1,9 @@
 <%= render 'spree/admin/shared/settings_checkout_tabs' %>
 
 <% content_for :page_title do %>
-  <%= plural_resource_name(Spree::AdjustmentReason) %>
+  <%= Spree.t(:settings) %> &#x2f;
+  <%= Spree.t('admin.tab.checkout') %> &#x2f;
+  <%= Spree::AdjustmentReason.model_name.human(count: :other) %>
 <% end %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/adjustment_reasons/new.html.erb
+++ b/backend/app/views/spree/admin/adjustment_reasons/new.html.erb
@@ -2,7 +2,7 @@
 
 <% add_breadcrumb(Spree.t(:settings)) %>
 <% add_breadcrumb(Spree.t('admin.tab.checkout')) %>
-<% add_breadcrumb(link_to Spree::AdjustmentReason.model_name.human(count: :other), spree.admin_adjustment_reasons_path) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::AdjustmentReason), spree.admin_adjustment_reasons_path) %>
 <% add_breadcrumb(Spree.t(:new_adjustment_reason)) %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/adjustment_reasons/new.html.erb
+++ b/backend/app/views/spree/admin/adjustment_reasons/new.html.erb
@@ -1,11 +1,9 @@
 <%= render 'spree/admin/shared/settings_checkout_tabs' %>
 
-<% content_for :page_title do %>
-  <%= Spree.t(:settings) %> &#x2f;
-  <%= Spree.t('admin.tab.checkout') %> &#x2f;
-  <%= link_to Spree::AdjustmentReason.model_name.human(count: :other), spree.admin_adjustment_reasons_path %> &#x2f;
-  <%= Spree.t(:new_adjustment_reason) %>
-<% end %>
+<% add_breadcrumb(Spree.t(:settings)) %>
+<% add_breadcrumb(Spree.t('admin.tab.checkout')) %>
+<% add_breadcrumb(link_to Spree::AdjustmentReason.model_name.human(count: :other), spree.admin_adjustment_reasons_path) %>
+<% add_breadcrumb(Spree.t(:new_adjustment_reason)) %>
 
 <% content_for :page_actions do %>
 <% end %>

--- a/backend/app/views/spree/admin/adjustment_reasons/new.html.erb
+++ b/backend/app/views/spree/admin/adjustment_reasons/new.html.erb
@@ -1,11 +1,13 @@
 <%= render 'spree/admin/shared/settings_checkout_tabs' %>
 
 <% content_for :page_title do %>
+  <%= Spree.t(:settings) %> &#x2f;
+  <%= Spree.t('admin.tab.checkout') %> &#x2f;
+  <%= link_to Spree::AdjustmentReason.model_name.human(count: :other), spree.admin_adjustment_reasons_path %> &#x2f;
   <%= Spree.t(:new_adjustment_reason) %>
 <% end %>
 
 <% content_for :page_actions do %>
-  <li><%= link_to_with_icon 'arrow-left', Spree.t(:back_to_adjustment_reason_list), collection_url, :class => 'button' %></li>
 <% end %>
 
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @object } %>

--- a/backend/app/views/spree/admin/adjustments/edit.html.erb
+++ b/backend/app/views/spree/admin/adjustments/edit.html.erb
@@ -1,9 +1,7 @@
 <%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Adjustments' } %>
 
-<% content_for :page_title do %>
-  &#x2f; <%= link_to Spree::Adjustment.model_name.human(count: :other), spree.admin_order_adjustments_path(@order) %>
-  &#x2f; <%= Spree.t('actions.edit') %> <%= Spree::Adjustment.model_name.human %>
-<% end %>
+<% add_breadcrumb(link_to Spree::Adjustment.model_name.human(count: :other), spree.admin_order_adjustments_path(@order)) %>
+<% add_breadcrumb("#{Spree.t('actions.edit')} #{Spree::Adjustment.model_name.human}") %>
 
 <% content_for :page_actions do %>
 <% end %>

--- a/backend/app/views/spree/admin/adjustments/edit.html.erb
+++ b/backend/app/views/spree/admin/adjustments/edit.html.erb
@@ -1,11 +1,11 @@
 <%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Adjustments' } %>
 
 <% content_for :page_title do %>
-  <i class="fa fa-arrow-right"></i> <%= Spree.t('actions.edit') %> <%= Spree.t(:adjustment) %>
+  &#x2f; <%= link_to Spree::Adjustment.model_name.human(count: :other), spree.admin_order_adjustments_path(@order) %>
+  &#x2f; <%= Spree.t('actions.edit') %> <%= Spree::Adjustment.model_name.human %>
 <% end %>
 
 <% content_for :page_actions do %>
-  <li><%= button_link_to Spree.t(:back_to_adjustments_list), spree.admin_order_adjustments_url(@order), :icon => 'arrow-left' %></li>
 <% end %>
 
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @adjustment } %>

--- a/backend/app/views/spree/admin/adjustments/edit.html.erb
+++ b/backend/app/views/spree/admin/adjustments/edit.html.erb
@@ -1,6 +1,6 @@
 <%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Adjustments' } %>
 
-<% add_breadcrumb(link_to Spree::Adjustment.model_name.human(count: :other), spree.admin_order_adjustments_path(@order)) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::Adjustment), spree.admin_order_adjustments_path(@order)) %>
 <% add_breadcrumb("#{Spree.t('actions.edit')} #{Spree::Adjustment.model_name.human}") %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/adjustments/index.html.erb
+++ b/backend/app/views/spree/admin/adjustments/index.html.erb
@@ -1,6 +1,6 @@
 <%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Adjustments' } %>
 
-<% add_breadcrumb(Spree::Adjustment.model_name.human(count: :other)) %>
+<% add_breadcrumb(plural_resource_name(Spree::Adjustment)) %>
 
 <% content_for :page_actions do %>
   <% if can? :create, Spree::Adjustment %>

--- a/backend/app/views/spree/admin/adjustments/index.html.erb
+++ b/backend/app/views/spree/admin/adjustments/index.html.erb
@@ -1,7 +1,7 @@
 <%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Adjustments' } %>
 
 <% content_for :page_title do %>
-   <i class="fa fa-arrow-right"></i> <%= Spree.t(:adjustments) %>
+   &#x2f; <%= Spree::Adjustment.model_name.human(count: :other) %>
 <% end %>
 
 <% content_for :page_actions do %>
@@ -10,7 +10,6 @@
       <%= button_link_to Spree.t(:new_adjustment), new_admin_order_adjustment_url(@order), :icon => 'plus' %>
     </li>
   <% end %>
-  <li><%= button_link_to Spree.t(:back_to_orders_list), admin_orders_path, :icon => 'arrow-left' %></li>
 <% end %>
 
 <%= render :partial => 'adjustments_table' %>

--- a/backend/app/views/spree/admin/adjustments/index.html.erb
+++ b/backend/app/views/spree/admin/adjustments/index.html.erb
@@ -1,8 +1,6 @@
 <%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Adjustments' } %>
 
-<% content_for :page_title do %>
-   &#x2f; <%= Spree::Adjustment.model_name.human(count: :other) %>
-<% end %>
+<% add_breadcrumb(Spree::Adjustment.model_name.human(count: :other)) %>
 
 <% content_for :page_actions do %>
   <% if can? :create, Spree::Adjustment %>

--- a/backend/app/views/spree/admin/adjustments/new.html.erb
+++ b/backend/app/views/spree/admin/adjustments/new.html.erb
@@ -1,9 +1,8 @@
 <%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Adjustments' } %>
 
-<% content_for :page_title do %>
-  &#x2f; <%= link_to Spree::Adjustment.model_name.human(count: :other), spree.admin_order_adjustments_path(@order) %>
-  &#x2f; <%= Spree.t(:new_adjustment) %>
-<% end %>
+<% add_breadcrumb(link_to Spree::Adjustment.model_name.human(count: :other), spree.admin_order_adjustments_path(@order)) %>
+<% add_breadcrumb(Spree.t(:new_adjustment)) %>
+
 
 <% content_for :page_actions do %>
 <% end %>

--- a/backend/app/views/spree/admin/adjustments/new.html.erb
+++ b/backend/app/views/spree/admin/adjustments/new.html.erb
@@ -1,11 +1,11 @@
 <%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Adjustments' } %>
 
 <% content_for :page_title do %>
-  <i class="fa fa-arrow-right"></i> <%= Spree.t(:new_adjustment) %>
+  &#x2f; <%= link_to Spree::Adjustment.model_name.human(count: :other), spree.admin_order_adjustments_path(@order) %>
+  &#x2f; <%= Spree.t(:new_adjustment) %>
 <% end %>
 
 <% content_for :page_actions do %>
-  <li><%= button_link_to Spree.t(:back_to_adjustments_list), spree.admin_order_adjustments_url(@order), :icon => 'arrow-left' %></li>
 <% end %>
 
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @adjustment } %>

--- a/backend/app/views/spree/admin/adjustments/new.html.erb
+++ b/backend/app/views/spree/admin/adjustments/new.html.erb
@@ -1,6 +1,6 @@
 <%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Adjustments' } %>
 
-<% add_breadcrumb(link_to Spree::Adjustment.model_name.human(count: :other), spree.admin_order_adjustments_path(@order)) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::Adjustment), spree.admin_order_adjustments_path(@order)) %>
 <% add_breadcrumb(Spree.t(:new_adjustment)) %>
 
 

--- a/backend/app/views/spree/admin/cancellations/index.html.erb
+++ b/backend/app/views/spree/admin/cancellations/index.html.erb
@@ -1,8 +1,7 @@
-<% content_for :page_title do %>
-  <%= link_to Spree::Order.model_name.human(count: :other), spree.admin_orders_path %> &#x2f;
-  <%= link_to "##{@order.number}", spree.edit_admin_order_path(@order) %> &#x2f;
-  <%= Spree.t(:cancel_inventory) %>
-<% end %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::Order), spree.admin_orders_path) %>
+<% add_breadcrumb(link_to "##{@order.number}", spree.edit_admin_order_path(@order)) %>
+<% add_breadcrumb(Spree.t(:cancel_inventory)) %>
+
 
 <table class="stock-contents index">
   <colgroup>

--- a/backend/app/views/spree/admin/cancellations/index.html.erb
+++ b/backend/app/views/spree/admin/cancellations/index.html.erb
@@ -1,5 +1,7 @@
 <% content_for :page_title do %>
-  <%= link_to Spree.t(:order_number, number: @order.number), spree.edit_admin_order_path(@order) %> - <%= Spree.t(:cancel_inventory) %>
+  <%= link_to Spree::Order.model_name.human(count: :other), spree.admin_orders_path %> &#x2f;
+  <%= link_to "##{@order.number}", spree.edit_admin_order_path(@order) %> &#x2f;
+  <%= Spree.t(:cancel_inventory) %>
 <% end %>
 
 <table class="stock-contents index">

--- a/backend/app/views/spree/admin/countries/edit.html.erb
+++ b/backend/app/views/spree/admin/countries/edit.html.erb
@@ -2,7 +2,7 @@
 
 <% add_breadcrumb(Spree.t(:settings)) %>
 <% add_breadcrumb(Spree.t('admin.tab.areas')) %>
-<% add_breadcrumb(link_to Spree::Country.model_name.human(count: :other), spree.admin_countries_path) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::Country), spree.admin_countries_path) %>
 <% add_breadcrumb(@country.name) %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/countries/edit.html.erb
+++ b/backend/app/views/spree/admin/countries/edit.html.erb
@@ -1,11 +1,9 @@
 <%= render 'spree/admin/shared/areas_tabs' %>
 
-<% content_for :page_title do %>
-  <%= Spree.t(:settings) %> &#x2f;
-  <%= Spree.t('admin.tab.areas') %> &#x2f;
-  <%= link_to Spree::Country.model_name.human(count: :other), spree.admin_countries_path %> &#x2f;
-  <%= @country.name %>
-<% end %>
+<% add_breadcrumb(Spree.t(:settings)) %>
+<% add_breadcrumb(Spree.t('admin.tab.areas')) %>
+<% add_breadcrumb(link_to Spree::Country.model_name.human(count: :other), spree.admin_countries_path) %>
+<% add_breadcrumb(@country.name) %>
 
 <% content_for :page_actions do %>
 <% end %>

--- a/backend/app/views/spree/admin/countries/edit.html.erb
+++ b/backend/app/views/spree/admin/countries/edit.html.erb
@@ -1,13 +1,13 @@
 <%= render 'spree/admin/shared/areas_tabs' %>
 
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_country) %>
+  <%= Spree.t(:settings) %> &#x2f;
+  <%= Spree.t('admin.tab.areas') %> &#x2f;
+  <%= link_to Spree::Country.model_name.human(count: :other), spree.admin_countries_path %> &#x2f;
+  <%= @country.name %>
 <% end %>
 
 <% content_for :page_actions do %>
-  <li>
-    <%= button_link_to Spree.t(:back_to_countries_list), spree.admin_countries_path, :icon => 'arrow-left' %>
-  </li>
 <% end %>
 
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @country } %>

--- a/backend/app/views/spree/admin/countries/index.html.erb
+++ b/backend/app/views/spree/admin/countries/index.html.erb
@@ -1,10 +1,8 @@
 <%= render 'spree/admin/shared/areas_tabs' %>
 
-<% content_for :page_title do %>
-  <%= Spree.t(:settings) %> &#x2f;
-  <%= Spree.t('admin.tab.areas') %> &#x2f;
-  <%= Spree::Country.model_name.human(count: :other) %>
-<% end %>
+<% add_breadcrumb(Spree.t(:settings)) %>
+<% add_breadcrumb(Spree.t('admin.tab.areas')) %>
+<% add_breadcrumb(Spree::Country.model_name.human(count: :other)) %>
 
 <% content_for :page_actions do %>
   <ul class="actions inline-menu">

--- a/backend/app/views/spree/admin/countries/index.html.erb
+++ b/backend/app/views/spree/admin/countries/index.html.erb
@@ -1,7 +1,9 @@
 <%= render 'spree/admin/shared/areas_tabs' %>
 
 <% content_for :page_title do %>
-  <%= Spree.t(:listing_countries) %>
+  <%= Spree.t(:settings) %> &#x2f;
+  <%= Spree.t('admin.tab.areas') %> &#x2f;
+  <%= Spree::Country.model_name.human(count: :other) %>
 <% end %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/countries/index.html.erb
+++ b/backend/app/views/spree/admin/countries/index.html.erb
@@ -2,7 +2,7 @@
 
 <% add_breadcrumb(Spree.t(:settings)) %>
 <% add_breadcrumb(Spree.t('admin.tab.areas')) %>
-<% add_breadcrumb(Spree::Country.model_name.human(count: :other)) %>
+<% add_breadcrumb(plural_resource_name(Spree::Country)) %>
 
 <% content_for :page_actions do %>
   <ul class="actions inline-menu">

--- a/backend/app/views/spree/admin/countries/new.html.erb
+++ b/backend/app/views/spree/admin/countries/new.html.erb
@@ -1,11 +1,9 @@
 <%= render 'spree/admin/shared/areas_tabs' %>
 
-<% content_for :page_title do %>
-  <%= Spree.t(:settings) %> &#x2f;
-  <%= Spree.t('admin.tab.areas') %> &#x2f;
-  <%= link_to Spree::Country.model_name.human(count: :other), spree.admin_countries_path %> &#x2f;
-  <%= Spree.t(:new_country) %>
-<% end %>
+<% add_breadcrumb(Spree.t(:settings)) %>
+<% add_breadcrumb(Spree.t('admin.tab.areas')) %>
+<% add_breadcrumb(link_to Spree::Country.model_name.human(count: :other), spree.admin_countries_path) %>
+<% add_breadcrumb(Spree.t(:new_country)) %>
 
 <% content_for :page_actions do %>
 <% end %>

--- a/backend/app/views/spree/admin/countries/new.html.erb
+++ b/backend/app/views/spree/admin/countries/new.html.erb
@@ -1,11 +1,13 @@
 <%= render 'spree/admin/shared/areas_tabs' %>
 
 <% content_for :page_title do %>
+  <%= Spree.t(:settings) %> &#x2f;
+  <%= Spree.t('admin.tab.areas') %> &#x2f;
+  <%= link_to Spree::Country.model_name.human(count: :other), spree.admin_countries_path %> &#x2f;
   <%= Spree.t(:new_country) %>
 <% end %>
 
 <% content_for :page_actions do %>
-  <li><%= link_to_with_icon 'arrow-left', Spree.t(:back_to_countries_list), admin_countries_path, :class => 'button' %></li>
 <% end %>
 
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @countries } %>

--- a/backend/app/views/spree/admin/countries/new.html.erb
+++ b/backend/app/views/spree/admin/countries/new.html.erb
@@ -2,7 +2,7 @@
 
 <% add_breadcrumb(Spree.t(:settings)) %>
 <% add_breadcrumb(Spree.t('admin.tab.areas')) %>
-<% add_breadcrumb(link_to Spree::Country.model_name.human(count: :other), spree.admin_countries_path) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::Country), spree.admin_countries_path) %>
 <% add_breadcrumb(Spree.t(:new_country)) %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/customer_returns/edit.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/edit.html.erb
@@ -1,6 +1,6 @@
 <%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Customer Returns' } %>
 
-<% add_breadcrumb(link_to Spree::CustomerReturn.model_name.human(count: :other), spree.admin_order_customer_returns_url(@order)) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::CustomerReturn), spree.admin_order_customer_returns_url(@order)) %>
 <% add_breadcrumb(@customer_return.number) %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/customer_returns/edit.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/edit.html.erb
@@ -1,11 +1,11 @@
 <%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Customer Returns' } %>
 
 <% content_for :page_title do %>
-  <i class="fa fa-arrow-right"></i> <%= Spree::CustomerReturn.model_name.human %> #<%= @customer_return.number %>
+  &#x2f; <%= link_to Spree::CustomerReturn.model_name.human(count: :other), spree.admin_order_customer_returns_url(@order) %>
+  &#x2f;  &#35;<%= @customer_return.number %>
 <% end %>
 
 <% content_for :page_actions do %>
-  <li><%= button_link_to Spree.t(:back_to_customer_return_list), spree.admin_order_customer_returns_url(@order), :icon => 'arrow-left' %></li>
 <% end %>
 
 <% if @manual_intervention_return_items.any? %>

--- a/backend/app/views/spree/admin/customer_returns/edit.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/edit.html.erb
@@ -1,9 +1,7 @@
 <%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Customer Returns' } %>
 
-<% content_for :page_title do %>
-  &#x2f; <%= link_to Spree::CustomerReturn.model_name.human(count: :other), spree.admin_order_customer_returns_url(@order) %>
-  &#x2f;  &#35;<%= @customer_return.number %>
-<% end %>
+<% add_breadcrumb(link_to Spree::CustomerReturn.model_name.human(count: :other), spree.admin_order_customer_returns_url(@order)) %>
+<% add_breadcrumb(@customer_return.number) %>
 
 <% content_for :page_actions do %>
 <% end %>

--- a/backend/app/views/spree/admin/customer_returns/index.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/index.html.erb
@@ -8,7 +8,7 @@
   <% end %>
 <% end %>
 
-<% add_breadcrumb(Spree::CustomerReturn.model_name.human(count: :other)) %>
+<% add_breadcrumb(plural_resource_name(Spree::CustomerReturn)) %>
 
 <% if @customer_returns.any? %>
   <table class="index">

--- a/backend/app/views/spree/admin/customer_returns/index.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/index.html.erb
@@ -8,9 +8,7 @@
   <% end %>
 <% end %>
 
-<% content_for :page_title do %>
-  &#x2f; <%= Spree::CustomerReturn.model_name.human(count: :other) %>
-<% end %>
+<% add_breadcrumb(Spree::CustomerReturn.model_name.human(count: :other)) %>
 
 <% if @customer_returns.any? %>
   <table class="index">

--- a/backend/app/views/spree/admin/customer_returns/index.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/index.html.erb
@@ -6,11 +6,10 @@
       <%= button_link_to Spree.t(:new_customer_return), spree.new_admin_order_customer_return_path(@order), icon: 'plus' %>
     </li>
   <% end %>
-  <li><%= button_link_to Spree.t(:back_to_orders_list), spree.admin_orders_path, :icon => 'arrow-left' %></li>
 <% end %>
 
 <% content_for :page_title do %>
-  <i class="fa fa-arrow-right"></i> <%= plural_resource_name(Spree::CustomerReturn) %>
+  &#x2f; <%= Spree::CustomerReturn.model_name.human(count: :other) %>
 <% end %>
 
 <% if @customer_returns.any? %>

--- a/backend/app/views/spree/admin/customer_returns/new.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/new.html.erb
@@ -1,11 +1,11 @@
 <%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Customer Returns' } %>
 
 <% content_for :page_title do %>
-  <i class="fa fa-arrow-right"></i> <%= Spree.t(:new_customer_return) %>
+  &#x2f; <%= link_to Spree::CustomerReturn.model_name.human(count: :other), spree.admin_order_customer_returns_url(@order) %>
+  &#x2f; <%= Spree.t(:new_customer_return) %>
 <% end %>
 
 <% content_for :page_actions do %>
-  <li><%= button_link_to Spree.t(:back_to_customer_return_list), spree.admin_order_customer_returns_url(@order), :icon => 'arrow-left' %></li>
 <% end %>
 
 <% if @rma_return_items.any? || @new_return_items.any? %>

--- a/backend/app/views/spree/admin/customer_returns/new.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/new.html.erb
@@ -1,9 +1,8 @@
 <%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Customer Returns' } %>
 
-<% content_for :page_title do %>
-  &#x2f; <%= link_to Spree::CustomerReturn.model_name.human(count: :other), spree.admin_order_customer_returns_url(@order) %>
-  &#x2f; <%= Spree.t(:new_customer_return) %>
-<% end %>
+<% add_breadcrumb(link_to Spree::CustomerReturn.model_name.human(count: :other), spree.admin_order_customer_returns_url(@order)) %>
+<% add_breadcrumb(Spree.t(:new_customer_return)) %>
+
 
 <% content_for :page_actions do %>
 <% end %>

--- a/backend/app/views/spree/admin/customer_returns/new.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/new.html.erb
@@ -1,6 +1,6 @@
 <%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Customer Returns' } %>
 
-<% add_breadcrumb(link_to Spree::CustomerReturn.model_name.human(count: :other), spree.admin_order_customer_returns_url(@order)) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::CustomerReturn), spree.admin_order_customer_returns_url(@order)) %>
 <% add_breadcrumb(Spree.t(:new_customer_return)) %>
 
 

--- a/backend/app/views/spree/admin/general_settings/edit.html.erb
+++ b/backend/app/views/spree/admin/general_settings/edit.html.erb
@@ -1,10 +1,7 @@
 <%= render 'spree/admin/shared/general_tabs' %>
 
-<% content_for :page_title do %>
-  <%= Spree.t(:settings) %> &#x2f;
-  <%= Spree.t(:general) %> &#x2f;
-  <%= Spree.t(:settings) %>
-<% end %>
+<% add_breadcrumb(Spree.t(:settings)) %>
+<% add_breadcrumb(Spree.t(:general_settings)) %>
 
 <%= form_tag admin_general_settings_path, method: :put do %>
   <div id="preferences" data-hook>

--- a/backend/app/views/spree/admin/general_settings/edit.html.erb
+++ b/backend/app/views/spree/admin/general_settings/edit.html.erb
@@ -1,7 +1,9 @@
 <%= render 'spree/admin/shared/general_tabs' %>
 
 <% content_for :page_title do %>
-  <%= Spree.t(:general_settings) %>
+  <%= Spree.t(:settings) %> &#x2f;
+  <%= Spree.t(:general) %> &#x2f;
+  <%= Spree.t(:settings) %>
 <% end %>
 
 <%= form_tag admin_general_settings_path, method: :put do %>

--- a/backend/app/views/spree/admin/images/edit.html.erb
+++ b/backend/app/views/spree/admin/images/edit.html.erb
@@ -2,6 +2,11 @@
 
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @image } %>
 
+<% content_for :page_title do %>
+  &#x2f; <%= link_to Spree::Image.model_name.human(count: :other), admin_product_images_path(@product) %>
+&#x2f; <%= @image.attachment_file_name %>
+<% end %>
+
 <% content_for :page_actions do %>
   <li><%= button_link_to Spree.t(:back_to_images_list), admin_product_images_url(@product), :icon => 'arrow-left' %></li>
 <% end %>

--- a/backend/app/views/spree/admin/images/edit.html.erb
+++ b/backend/app/views/spree/admin/images/edit.html.erb
@@ -2,10 +2,9 @@
 
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @image } %>
 
-<% content_for :page_title do %>
-  &#x2f; <%= link_to Spree::Image.model_name.human(count: :other), admin_product_images_path(@product) %>
-&#x2f; <%= @image.attachment_file_name %>
-<% end %>
+<% add_breadcrumb(link_to Spree::Image.model_name.human(count: :other), admin_product_images_path(@product)) %>
+<% add_breadcrumb(@image.attachment_file_name) %>
+
 
 <% content_for :page_actions do %>
   <li><%= button_link_to Spree.t(:back_to_images_list), admin_product_images_url(@product), :icon => 'arrow-left' %></li>

--- a/backend/app/views/spree/admin/images/edit.html.erb
+++ b/backend/app/views/spree/admin/images/edit.html.erb
@@ -2,7 +2,7 @@
 
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @image } %>
 
-<% add_breadcrumb(link_to Spree::Image.model_name.human(count: :other), admin_product_images_path(@product)) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::Image), admin_product_images_path(@product)) %>
 <% add_breadcrumb(@image.attachment_file_name) %>
 
 

--- a/backend/app/views/spree/admin/images/index.html.erb
+++ b/backend/app/views/spree/admin/images/index.html.erb
@@ -1,5 +1,9 @@
 <%= render :partial => 'spree/admin/shared/product_tabs', :locals => {:current => 'Images'} %>
 
+<% content_for :page_title do %>
+  &#x2f; <%= Spree::Image.model_name.human(count: :other) %>
+<% end %>
+
 <% content_for :page_actions do %>
   <% if can?(:create, Spree::Image) %>
     <li><%= link_to_with_icon('plus', Spree.t(:new_image), new_admin_product_image_url(@product), :id => 'new_image_link', :class => 'button') %></li>

--- a/backend/app/views/spree/admin/images/index.html.erb
+++ b/backend/app/views/spree/admin/images/index.html.erb
@@ -1,8 +1,7 @@
 <%= render :partial => 'spree/admin/shared/product_tabs', :locals => {:current => 'Images'} %>
 
-<% content_for :page_title do %>
-  &#x2f; <%= Spree::Image.model_name.human(count: :other) %>
-<% end %>
+<% add_breadcrumb(Spree::Image.model_name.human(count: :other)) %>
+
 
 <% content_for :page_actions do %>
   <% if can?(:create, Spree::Image) %>

--- a/backend/app/views/spree/admin/images/index.html.erb
+++ b/backend/app/views/spree/admin/images/index.html.erb
@@ -1,6 +1,6 @@
 <%= render :partial => 'spree/admin/shared/product_tabs', :locals => {:current => 'Images'} %>
 
-<% add_breadcrumb(Spree::Image.model_name.human(count: :other)) %>
+<% add_breadcrumb(plural_resource_name(Spree::Image)) %>
 
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/log_entries/index.html.erb
+++ b/backend/app/views/spree/admin/log_entries/index.html.erb
@@ -1,7 +1,7 @@
 <%= render :partial => 'spree/admin/shared/order_tabs', locals: { current: 'Payments' }%>
 
 <% add_breadcrumb(Spree::Payment.model_name.human) %>
-<% add_breadcrumb(Spree::LogEntry.model_name.human(count: :other)) %>
+<% add_breadcrumb(plural_resource_name(Spree::LogEntry)) %>
 
 <% content_for :page_actions do %>
   <li><%= button_link_to Spree.t(:logs), spree.admin_order_payment_log_entries_url(@order, @payment), :icon => 'archive' %></li>

--- a/backend/app/views/spree/admin/log_entries/index.html.erb
+++ b/backend/app/views/spree/admin/log_entries/index.html.erb
@@ -1,11 +1,7 @@
 <%= render :partial => 'spree/admin/shared/order_tabs', locals: { current: 'Payments' }%>
 
-<% content_for :page_title do %>
-  <i class="fa fa-arrow-right"></i>
-  <%= Spree::Payment.model_name.human %>
-  <i class="fa fa-arrow-right"></i>
-  <%= plural_resource_name(Spree::LogEntry) %>
-<% end %>
+<% add_breadcrumb(Spree::Payment.model_name.human) %>
+<% add_breadcrumb(Spree::LogEntry.model_name.human(count: :other)) %>
 
 <% content_for :page_actions do %>
   <li><%= button_link_to Spree.t(:logs), spree.admin_order_payment_log_entries_url(@order, @payment), :icon => 'archive' %></li>

--- a/backend/app/views/spree/admin/option_types/edit.html.erb
+++ b/backend/app/views/spree/admin/option_types/edit.html.erb
@@ -1,8 +1,7 @@
-<% content_for :page_title do %>
-  <%= link_to Spree::Product.model_name.human(count: :other), spree.admin_products_path  %> &#x2f; 
-  <%= link_to Spree::OptionType.model_name.human(count: :other), spree.admin_option_types_path %> &#x2f;
-  <%= @option_type.name %>
-<% end %>
+<% add_breadcrumb(link_to Spree::Product.model_name.human(count: :other), spree.admin_products_path) %>
+<% add_breadcrumb(link_to Spree::OptionType.model_name.human(count: :other), spree.admin_option_types_path) %>
+<% add_breadcrumb(@option_type.name) %>
+
 
 <% content_for :page_actions do %>
   <li>

--- a/backend/app/views/spree/admin/option_types/edit.html.erb
+++ b/backend/app/views/spree/admin/option_types/edit.html.erb
@@ -1,5 +1,7 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_option_type) %> <span class="green">"<%= @option_type.name %>"</span>
+  <%= link_to Spree::Product.model_name.human(count: :other), spree.admin_products_path  %> &#x2f; 
+  <%= link_to Spree::OptionType.model_name.human(count: :other), spree.admin_option_types_path %> &#x2f;
+  <%= @option_type.name %>
 <% end %>
 
 <% content_for :page_actions do %>
@@ -8,10 +10,7 @@
       <%= link_to_add_fields Spree.t(:add_option_value), "tbody#option_values", :class => 'button fa fa-plus' %>
     </span>
   </li>
-  <li>
-    <%= button_link_to Spree.t(:back_to_option_types_list), spree.admin_option_types_path, :icon => 'arrow-left' %>
-  </li>
-<% end %>
+  <% end %>
 
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @option_type } %>
 

--- a/backend/app/views/spree/admin/option_types/edit.html.erb
+++ b/backend/app/views/spree/admin/option_types/edit.html.erb
@@ -1,5 +1,5 @@
-<% add_breadcrumb(link_to Spree::Product.model_name.human(count: :other), spree.admin_products_path) %>
-<% add_breadcrumb(link_to Spree::OptionType.model_name.human(count: :other), spree.admin_option_types_path) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::Product), spree.admin_products_path) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::OptionType), spree.admin_option_types_path) %>
 <% add_breadcrumb(@option_type.name) %>
 
 

--- a/backend/app/views/spree/admin/option_types/index.html.erb
+++ b/backend/app/views/spree/admin/option_types/index.html.erb
@@ -1,7 +1,6 @@
-<% content_for :page_title do %>
-  <%= link_to Spree::Product.model_name.human(count: :other), spree.admin_products_path  %> &#x2f; 
-  <%= Spree::OptionType.model_name.human(count: :other) %>
-<% end %>
+<% add_breadcrumb(link_to Spree::Product.model_name.human(count: :other), spree.admin_products_path) %>
+<% add_breadcrumb(Spree::OptionType.model_name.human(count: :other)) %>
+
 
 <% content_for :page_actions do %>
   <% if can?(:create, Spree::OptionType) %>

--- a/backend/app/views/spree/admin/option_types/index.html.erb
+++ b/backend/app/views/spree/admin/option_types/index.html.erb
@@ -1,5 +1,6 @@
 <% content_for :page_title do %>
-  <%= plural_resource_name(Spree::OptionType) %>
+  <%= link_to Spree::Product.model_name.human(count: :other), spree.admin_products_path  %> &#x2f; 
+  <%= Spree::OptionType.model_name.human(count: :other) %>
 <% end %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/option_types/index.html.erb
+++ b/backend/app/views/spree/admin/option_types/index.html.erb
@@ -1,5 +1,5 @@
-<% add_breadcrumb(link_to Spree::Product.model_name.human(count: :other), spree.admin_products_path) %>
-<% add_breadcrumb(Spree::OptionType.model_name.human(count: :other)) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::Product), spree.admin_products_path) %>
+<% add_breadcrumb(plural_resource_name(Spree::OptionType)) %>
 
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/orders/_shipment.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment.html.erb
@@ -1,3 +1,7 @@
+<% content_for :page_title do %>
+  &#x2f; <%= Spree::Shipment.model_name.human(count: :other) %>
+<% end %>
+
 <% manifest_items = Spree::ShippingManifest.new(inventory_units: shipment.inventory_units.where(carton_id: nil)).items %>
 
 <div id="<%= "shipment_#{shipment.id}" %>" class="js-shipment-edit" data-hook="admin_shipment_form">

--- a/backend/app/views/spree/admin/orders/_shipment.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment.html.erb
@@ -1,6 +1,5 @@
-<% content_for :page_title do %>
-  &#x2f; <%= Spree::Shipment.model_name.human(count: :other) %>
-<% end %>
+<% add_breadcrumb(Spree::Shipment.model_name.human(count: :other)) %>
+
 
 <% manifest_items = Spree::ShippingManifest.new(inventory_units: shipment.inventory_units.where(carton_id: nil)).items %>
 

--- a/backend/app/views/spree/admin/orders/_shipment.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment.html.erb
@@ -1,4 +1,4 @@
-<% add_breadcrumb(Spree::Shipment.model_name.human(count: :other)) %>
+<% add_breadcrumb(plural_resource_name(Spree::Shipment)) %>
 
 
 <% manifest_items = Spree::ShippingManifest.new(inventory_units: shipment.inventory_units.where(carton_id: nil)).items %>

--- a/backend/app/views/spree/admin/orders/cart.html.erb
+++ b/backend/app/views/spree/admin/orders/cart.html.erb
@@ -9,9 +9,8 @@
 
 <%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Cart' } %>
 
-<% content_for :page_title do %>
-  &#x2f; <%= Spree.t(:cart) %>
-<% end %>
+<% add_breadcrumb(Spree.t(:cart)) %>
+
 
 <div data-hook="admin_order_edit_header">
   <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @order } %>

--- a/backend/app/views/spree/admin/orders/cart.html.erb
+++ b/backend/app/views/spree/admin/orders/cart.html.erb
@@ -5,12 +5,13 @@
     <% if can?(:resend, @order) && @order.completed? %>
         <li><%= button_link_to Spree.t(:resend), resend_admin_order_url(@order), :method => :post, :icon => 'email' %></li>
     <% end %>
-    <% if can?(:admin, Spree::Order) %>
-        <li><%= button_link_to Spree.t(:back_to_orders_list), admin_orders_path, :icon => 'arrow-left' %></li>
-    <% end %>
 <% end %>
 
 <%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Cart' } %>
+
+<% content_for :page_title do %>
+  &#x2f; <%= Spree.t(:cart) %>
+<% end %>
 
 <div data-hook="admin_order_edit_header">
   <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @order } %>

--- a/backend/app/views/spree/admin/orders/confirm.html.erb
+++ b/backend/app/views/spree/admin/orders/confirm.html.erb
@@ -1,8 +1,7 @@
 <%= render partial: 'spree/admin/shared/order_tabs', locals: {current: 'Confirm'} %>
 
-<% content_for :page_title do %>
-  &#x2f; <%= Spree.t(:confirm_order) %>
-<% end %>
+<% add_breadcrumb(Spree.t(:confirm_order)) %>
+
 
 <%= render partial: 'spree/admin/orders/confirm/customer_details', locals: {order: @order} %>
 

--- a/backend/app/views/spree/admin/orders/confirm.html.erb
+++ b/backend/app/views/spree/admin/orders/confirm.html.erb
@@ -1,7 +1,7 @@
 <%= render partial: 'spree/admin/shared/order_tabs', locals: {current: 'Confirm'} %>
 
 <% content_for :page_title do %>
-  <i class="fa fa-arrow-right"></i> <%= Spree.t(:confirm_order) %>
+  &#x2f; <%= Spree.t(:confirm_order) %>
 <% end %>
 
 <%= render partial: 'spree/admin/orders/confirm/customer_details', locals: {order: @order} %>

--- a/backend/app/views/spree/admin/orders/confirm_advance.html.erb
+++ b/backend/app/views/spree/admin/orders/confirm_advance.html.erb
@@ -1,7 +1,7 @@
 <%= render partial: 'spree/admin/shared/order_tabs', locals: {current: 'Confirm'} %>
 
 <% content_for :page_title do %>
-  <i class="fa fa-arrow-right"></i> <%= Spree.t(:confirm_order) %>
+  &#x2f; <%= Spree.t(:confirm_order) %>
 <% end %>
 
 <div class="form-buttons filter-actions actions" data-hook="complete-order-button">

--- a/backend/app/views/spree/admin/orders/confirm_advance.html.erb
+++ b/backend/app/views/spree/admin/orders/confirm_advance.html.erb
@@ -1,8 +1,7 @@
 <%= render partial: 'spree/admin/shared/order_tabs', locals: {current: 'Confirm'} %>
 
-<% content_for :page_title do %>
-  &#x2f; <%= Spree.t(:confirm_order) %>
-<% end %>
+<% add_breadcrumb(Spree.t(:confirm_order)) %>
+
 
 <div class="form-buttons filter-actions actions" data-hook="complete-order-button">
   <div><%= Spree.t(:order_please_refresh) %></div><br/>

--- a/backend/app/views/spree/admin/orders/customer_details/edit.html.erb
+++ b/backend/app/views/spree/admin/orders/customer_details/edit.html.erb
@@ -1,11 +1,10 @@
 <%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Customer Details' } %>
 
 <% content_for :page_title do %>
-  <i class="fa fa-arrow-right"></i> <%= Spree.t(:customer_details) %>
+  &#x2f; <%= Spree.t(:customer_details) %>
 <% end %>
 
 <% content_for :page_actions do %>
-  <li><%= button_link_to Spree.t(:back_to_orders_list), admin_orders_path, :icon => 'arrow-left' %></li>
 <% end %>
 
 <div id="select-customer" data-hook>

--- a/backend/app/views/spree/admin/orders/customer_details/edit.html.erb
+++ b/backend/app/views/spree/admin/orders/customer_details/edit.html.erb
@@ -1,8 +1,7 @@
 <%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Customer Details' } %>
 
-<% content_for :page_title do %>
-  &#x2f; <%= Spree.t(:customer_details) %>
-<% end %>
+<% add_breadcrumb(Spree.t(:customer_details)) %>
+
 
 <% content_for :page_actions do %>
 <% end %>

--- a/backend/app/views/spree/admin/orders/customer_details/show.html.erb
+++ b/backend/app/views/spree/admin/orders/customer_details/show.html.erb
@@ -1,7 +1,7 @@
 <%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Customer Details' } %>
 
 <% content_for :page_title do %>
-  <i class="fa fa-arrow-right"></i> <%= Spree.t(:customer_details) %>
+  &#x2f; <%= Spree.t(:customer_details) %>
 <% end %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/orders/customer_details/show.html.erb
+++ b/backend/app/views/spree/admin/orders/customer_details/show.html.erb
@@ -1,8 +1,7 @@
 <%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Customer Details' } %>
 
-<% content_for :page_title do %>
-  &#x2f; <%= Spree.t(:customer_details) %>
-<% end %>
+<% add_breadcrumb(Spree.t(:customer_details)) %>
+
 
 <% content_for :page_actions do %>
   <li><%= button_link_to Spree.t(:back_to_orders_list), admin_orders_path, :icon => 'arrow-left' %></li>
@@ -26,4 +25,3 @@
     <%= render "spree/admin/shared/address", address: @order.ship_address %>
   </section>
 </main>
-

--- a/backend/app/views/spree/admin/orders/edit.html.erb
+++ b/backend/app/views/spree/admin/orders/edit.html.erb
@@ -5,9 +5,6 @@
   <% if can?(:resend, @order) && @order.completed? %>
     <li><%= button_link_to Spree.t(:resend), resend_admin_order_url(@order), method: :post, icon: 'email' %></li>
   <% end %>
-  <% if can?(:admin, Spree::Order) %>
-    <li><%= button_link_to Spree.t(:back_to_orders_list), admin_orders_path, icon: 'arrow-left' %></li>
-  <% end %>
 <% end %>
 
 <%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Shipments' } %>

--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:listing_orders) %>
+  <%= Spree::Order.model_name.human(count: :other) %>
 <% end %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -1,6 +1,5 @@
-<% content_for :page_title do %>
-  <%= Spree::Order.model_name.human(count: :other) %>
-<% end %>
+<% add_breadcrumb(Spree::Order.model_name.human(count: :other)) %>
+
 
 <% content_for :page_actions do %>
   <li>

--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -1,4 +1,4 @@
-<% add_breadcrumb(Spree::Order.model_name.human(count: :other)) %>
+<% add_breadcrumb(plural_resource_name(Spree::Order)) %>
 
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/payment_methods/edit.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/edit.html.erb
@@ -1,11 +1,9 @@
 <%= render 'spree/admin/shared/payments_tabs' %>
 
-<% content_for :page_title do %>
-  <%= Spree.t(:settings) %> &#x2f;
-  <%= Spree::Payment.model_name.human(count: :other) %> &#x2f;
-  <%= link_to Spree::PaymentMethod.model_name.human(count: :other), spree.admin_payment_methods_path %> &#x2f;
-  <%= @payment_method.name %>
-<% end %>
+<% add_breadcrumb(Spree.t(:settings)) %>
+<% add_breadcrumb(Spree::Payment.model_name.human(count: :other)) %>
+<% add_breadcrumb(link_to Spree::PaymentMethod.model_name.human(count: :other), spree.admin_payment_methods_path) %>
+<% add_breadcrumb(@payment_method.name) %>
 
 <% content_for :page_actions do %>
 <% end %>

--- a/backend/app/views/spree/admin/payment_methods/edit.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/edit.html.erb
@@ -1,8 +1,8 @@
 <%= render 'spree/admin/shared/payments_tabs' %>
 
 <% add_breadcrumb(Spree.t(:settings)) %>
-<% add_breadcrumb(Spree::Payment.model_name.human(count: :other)) %>
-<% add_breadcrumb(link_to Spree::PaymentMethod.model_name.human(count: :other), spree.admin_payment_methods_path) %>
+<% add_breadcrumb(plural_resource_name(Spree::Payment)) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::PaymentMethod), spree.admin_payment_methods_path) %>
 <% add_breadcrumb(@payment_method.name) %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/payment_methods/edit.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/edit.html.erb
@@ -1,13 +1,13 @@
 <%= render 'spree/admin/shared/payments_tabs' %>
 
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_payment_method) %> <i class="fa fa-arrow-right"></i> <%= @payment_method.name %>
+  <%= Spree.t(:settings) %> &#x2f;
+  <%= Spree::Payment.model_name.human(count: :other) %> &#x2f;
+  <%= link_to Spree::PaymentMethod.model_name.human(count: :other), spree.admin_payment_methods_path %> &#x2f;
+  <%= @payment_method.name %>
 <% end %>
 
 <% content_for :page_actions do %>
-  <li>
-    <%= button_link_to Spree.t(:back_to_payment_methods_list), spree.admin_payment_methods_path, :icon => 'arrow-left' %>
-  </li>  
 <% end %>
 
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @payment_method } %>

--- a/backend/app/views/spree/admin/payment_methods/index.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/index.html.erb
@@ -1,10 +1,9 @@
 <%= render 'spree/admin/shared/payments_tabs' %>
 
-<% content_for :page_title do %>
-  <%= Spree.t(:settings) %> &#x2f;
-  <%= Spree::Payment.model_name.human(count: :other) %> &#x2f;
-  <%= Spree::PaymentMethod.model_name.human(count: :other) %>
-<% end %>
+<% add_breadcrumb(Spree.t(:settings)) %>
+<% add_breadcrumb(Spree::Payment.model_name.human(count: :other)) %>
+<% add_breadcrumb(Spree::PaymentMethod.model_name.human(count: :other)) %>
+
 
 <% content_for :page_actions do %>
   <% if can?(:create, Spree::PaymentMethod) %>

--- a/backend/app/views/spree/admin/payment_methods/index.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/index.html.erb
@@ -1,7 +1,9 @@
 <%= render 'spree/admin/shared/payments_tabs' %>
 
 <% content_for :page_title do %>
-  <%= plural_resource_name(Spree::PaymentMethod) %>
+  <%= Spree.t(:settings) %> &#x2f;
+  <%= Spree::Payment.model_name.human(count: :other) %> &#x2f;
+  <%= Spree::PaymentMethod.model_name.human(count: :other) %>
 <% end %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/payment_methods/index.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/index.html.erb
@@ -1,8 +1,8 @@
 <%= render 'spree/admin/shared/payments_tabs' %>
 
 <% add_breadcrumb(Spree.t(:settings)) %>
-<% add_breadcrumb(Spree::Payment.model_name.human(count: :other)) %>
-<% add_breadcrumb(Spree::PaymentMethod.model_name.human(count: :other)) %>
+<% add_breadcrumb(plural_resource_name(Spree::Payment)) %>
+<% add_breadcrumb(plural_resource_name(Spree::PaymentMethod)) %>
 
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/payment_methods/new.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/new.html.erb
@@ -1,11 +1,10 @@
 <%= render 'spree/admin/shared/payments_tabs' %>
 
-<% content_for :page_title do %>
-  <%= Spree.t(:settings) %> &#x2f;
-  <%= Spree::Payment.model_name.human(count: :other) %> &#x2f;
-  <%= link_to Spree::PaymentMethod.model_name.human(count: :other), spree.admin_payment_methods_path %> &#x2f;
-  <%= Spree.t(:new_payment_method) %>
-<% end %>
+<% add_breadcrumb(Spree.t(:settings)) %>
+<% add_breadcrumb(Spree::Payment.model_name.human(count: :other)) %>
+<% add_breadcrumb(link_to Spree::PaymentMethod.model_name.human(count: :other), spree.admin_payment_methods_path) %>
+<% add_breadcrumb(Spree.t(:new_payment_method)) %>
+
 
 <% content_for :page_actions do %>
 <% end %>

--- a/backend/app/views/spree/admin/payment_methods/new.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/new.html.erb
@@ -1,13 +1,13 @@
 <%= render 'spree/admin/shared/payments_tabs' %>
 
 <% content_for :page_title do %>
+  <%= Spree.t(:settings) %> &#x2f;
+  <%= Spree::Payment.model_name.human(count: :other) %> &#x2f;
+  <%= link_to Spree::PaymentMethod.model_name.human(count: :other), spree.admin_payment_methods_path %> &#x2f;
   <%= Spree.t(:new_payment_method) %>
 <% end %>
 
 <% content_for :page_actions do %>
-  <li>
-    <%= button_link_to Spree.t(:back_to_payment_methods_list), admin_payment_methods_path, :icon => 'arrow-left' %>
-  </li>  
 <% end %>
 
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @payment_method } %>

--- a/backend/app/views/spree/admin/payment_methods/new.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/new.html.erb
@@ -1,8 +1,8 @@
 <%= render 'spree/admin/shared/payments_tabs' %>
 
 <% add_breadcrumb(Spree.t(:settings)) %>
-<% add_breadcrumb(Spree::Payment.model_name.human(count: :other)) %>
-<% add_breadcrumb(link_to Spree::PaymentMethod.model_name.human(count: :other), spree.admin_payment_methods_path) %>
+<% add_breadcrumb(plural_resource_name(Spree::Payment)) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::PaymentMethod), spree.admin_payment_methods_path) %>
 <% add_breadcrumb(Spree.t(:new_payment_method)) %>
 
 

--- a/backend/app/views/spree/admin/payments/credit.html.erb
+++ b/backend/app/views/spree/admin/payments/credit.html.erb
@@ -1,7 +1,8 @@
 <%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Creditcards' } %>
 
 <% content_for :page_title do %>
-  <i class="fa fa-arrow-right"></i> <%= Spree::Refund.model_name.human %>
+  &#x2f; <%= link_to Spree::Payment.model_name.human(count: :other), spree.admin_order_payments_path(@order) %>
+  &#x2f; <%= Spree::Refund.model_name.human %>
 <% end %>
 
 <%= form_tag do %>

--- a/backend/app/views/spree/admin/payments/credit.html.erb
+++ b/backend/app/views/spree/admin/payments/credit.html.erb
@@ -1,9 +1,8 @@
 <%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Creditcards' } %>
 
-<% content_for :page_title do %>
-  &#x2f; <%= link_to Spree::Payment.model_name.human(count: :other), spree.admin_order_payments_path(@order) %>
-  &#x2f; <%= Spree::Refund.model_name.human %>
-<% end %>
+<% add_breadcrumb(link_to Spree::Payment.model_name.human(count: :other), spree.admin_order_payments_path(@order)) %>
+<% add_breadcrumb(Spree::Refund.model_name.human) %>
+
 
 <%= form_tag do %>
   <h3><%= Spree::Refund.model_name.human %></h3>

--- a/backend/app/views/spree/admin/payments/credit.html.erb
+++ b/backend/app/views/spree/admin/payments/credit.html.erb
@@ -1,6 +1,6 @@
 <%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Creditcards' } %>
 
-<% add_breadcrumb(link_to Spree::Payment.model_name.human(count: :other), spree.admin_order_payments_path(@order)) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::Payment), spree.admin_order_payments_path(@order)) %>
 <% add_breadcrumb(Spree::Refund.model_name.human) %>
 
 

--- a/backend/app/views/spree/admin/payments/index.html.erb
+++ b/backend/app/views/spree/admin/payments/index.html.erb
@@ -8,7 +8,7 @@
   <% end %>
 <% end %>
 
-<% add_breadcrumb(Spree::Payment.model_name.human(count: :other)) %>
+<% add_breadcrumb(plural_resource_name(Spree::Payment)) %>
 
 <% if @order.outstanding_balance? %>
   <h5 class="outstanding-balance"><%= @order.outstanding_balance < 0 ? Spree.t(:credit_owed) : Spree.t(:balance_due) %>: <strong><%= @order.display_outstanding_balance %></strong></h5>

--- a/backend/app/views/spree/admin/payments/index.html.erb
+++ b/backend/app/views/spree/admin/payments/index.html.erb
@@ -8,9 +8,7 @@
   <% end %>
 <% end %>
 
-<% content_for :page_title do %>
-  &#x2f; <%= Spree::Payment.model_name.human(count: :other) %>
-<% end %>
+<% add_breadcrumb(Spree::Payment.model_name.human(count: :other)) %>
 
 <% if @order.outstanding_balance? %>
   <h5 class="outstanding-balance"><%= @order.outstanding_balance < 0 ? Spree.t(:credit_owed) : Spree.t(:balance_due) %>: <strong><%= @order.display_outstanding_balance %></strong></h5>

--- a/backend/app/views/spree/admin/payments/index.html.erb
+++ b/backend/app/views/spree/admin/payments/index.html.erb
@@ -6,11 +6,10 @@
       <%= button_link_to Spree.t(:new_payment), new_admin_order_payment_url(@order), :icon => 'plus' %>
     </li>
   <% end %>
-  <li><%= button_link_to Spree.t(:back_to_orders_list), admin_orders_path, :icon => 'arrow-left' %></li>
 <% end %>
 
 <% content_for :page_title do %>
-  <i class="fa fa-arrow-right"></i> <%= plural_resource_name(Spree::Payment) %>
+  &#x2f; <%= Spree::Payment.model_name.human(count: :other) %>
 <% end %>
 
 <% if @order.outstanding_balance? %>

--- a/backend/app/views/spree/admin/payments/new.html.erb
+++ b/backend/app/views/spree/admin/payments/new.html.erb
@@ -1,11 +1,11 @@
 <%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Payments' } %>
 
 <% content_for :page_title do %>
-  <i class="fa fa-arrow-right"></i> <%= Spree.t(:new_payment) %>
+  &#x2f; <%= link_to Spree::Payment.model_name.human(count: :other), spree.admin_order_payments_path(@order) %>
+  &#x2f; <%= Spree.t(:new_payment) %>
 <% end %>
 
 <% content_for :page_actions do %>
-  <li><%= button_link_to Spree.t(:back_to_payments_list), spree.admin_order_payments_url(@order), :icon => 'arrow-left' %></li>
 <% end %>
 
 <% if @payment_methods.any? %>

--- a/backend/app/views/spree/admin/payments/new.html.erb
+++ b/backend/app/views/spree/admin/payments/new.html.erb
@@ -1,6 +1,6 @@
 <%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Payments' } %>
 
-<% add_breadcrumb(link_to Spree::Payment.model_name.human(count: :other), spree.admin_order_payments_path(@order)) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::Payment), spree.admin_order_payments_path(@order)) %>
 <% add_breadcrumb(Spree.t(:new_payment)) %>
 
 

--- a/backend/app/views/spree/admin/payments/new.html.erb
+++ b/backend/app/views/spree/admin/payments/new.html.erb
@@ -1,9 +1,8 @@
 <%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Payments' } %>
 
-<% content_for :page_title do %>
-  &#x2f; <%= link_to Spree::Payment.model_name.human(count: :other), spree.admin_order_payments_path(@order) %>
-  &#x2f; <%= Spree.t(:new_payment) %>
-<% end %>
+<% add_breadcrumb(link_to Spree::Payment.model_name.human(count: :other), spree.admin_order_payments_path(@order)) %>
+<% add_breadcrumb(Spree.t(:new_payment)) %>
+
 
 <% content_for :page_actions do %>
 <% end %>

--- a/backend/app/views/spree/admin/payments/show.html.erb
+++ b/backend/app/views/spree/admin/payments/show.html.erb
@@ -1,10 +1,8 @@
 <%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Payments' } %>
 
 <% content_for :page_title do %>
-  <i class="fa fa-arrow-right"></i>
-  <%= Spree::Payment.model_name.human %>
-  <i class="fa fa-arrow-right"></i>
-  <%= payment_method_name(@payment) %>
+  &#x2f; <%= link_to Spree::Payment.model_name.human(count: :other), spree.admin_order_payments_path(@order) %>
+  &#x2f; <%= payment_method_name(@payment) %>
   &nbsp;
   <span class="state <%= @payment.state %>">
     <%= Spree.t(@payment.state, :scope => :payment_states, :default => @payment.state.capitalize) %>
@@ -13,7 +11,6 @@
 
 <% content_for :page_actions do %>
   <li><%= button_link_to Spree.t(:logs), spree.admin_order_payment_log_entries_url(@order, @payment), :icon => 'archive' %></li>
-  <li><%= button_link_to Spree.t(:back_to_payments_list), spree.admin_order_payments_url(@order), :icon => 'arrow-left' %></li>
 <% end %>
 
 <%= render :partial => "spree/admin/payments/source_views/#{@payment.payment_method.method_type}", :locals => { :payment => @payment.source.is_a?(Spree::Payment) ? @payment.source : @payment } %>

--- a/backend/app/views/spree/admin/payments/show.html.erb
+++ b/backend/app/views/spree/admin/payments/show.html.erb
@@ -1,6 +1,6 @@
 <%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Payments' } %>
 
-<% add_breadcrumb(link_to Spree::Payment.model_name.human(count: :other), spree.admin_order_payments_path(@order)) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::Payment), spree.admin_order_payments_path(@order)) %>
 <% add_breadcrumb do %>
   <%= payment_method_name(@payment) %>
   <span class="state <%= @payment.state %>">

--- a/backend/app/views/spree/admin/payments/show.html.erb
+++ b/backend/app/views/spree/admin/payments/show.html.erb
@@ -1,13 +1,13 @@
 <%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Payments' } %>
 
-<% content_for :page_title do %>
-  &#x2f; <%= link_to Spree::Payment.model_name.human(count: :other), spree.admin_order_payments_path(@order) %>
-  &#x2f; <%= payment_method_name(@payment) %>
-  &nbsp;
+<% add_breadcrumb(link_to Spree::Payment.model_name.human(count: :other), spree.admin_order_payments_path(@order)) %>
+<% add_breadcrumb do %>
+  <%= payment_method_name(@payment) %>
   <span class="state <%= @payment.state %>">
     <%= Spree.t(@payment.state, :scope => :payment_states, :default => @payment.state.capitalize) %>
   </span>
 <% end %>
+
 
 <% content_for :page_actions do %>
   <li><%= button_link_to Spree.t(:logs), spree.admin_order_payment_log_entries_url(@order, @payment), :icon => 'archive' %></li>

--- a/backend/app/views/spree/admin/product_properties/index.html.erb
+++ b/backend/app/views/spree/admin/product_properties/index.html.erb
@@ -1,9 +1,7 @@
 <%= render 'spree/admin/shared/product_tabs', :current => 'Product Properties' %>
 <%= render 'spree/shared/error_messages', :target => @product %>
 
-<% content_for :page_title do %>
-  &#x2f; <%= Spree::ProductProperty.model_name.human(count: :other) %>
-<% end %>
+<% add_breadcrumb(Spree::ProductProperty.model_name.human(count: :other)) %>
 
 <% content_for :page_actions do %>
   <% if can?(:create, Spree::ProductProperty) %>

--- a/backend/app/views/spree/admin/product_properties/index.html.erb
+++ b/backend/app/views/spree/admin/product_properties/index.html.erb
@@ -1,7 +1,7 @@
 <%= render 'spree/admin/shared/product_tabs', :current => 'Product Properties' %>
 <%= render 'spree/shared/error_messages', :target => @product %>
 
-<% add_breadcrumb(Spree::ProductProperty.model_name.human(count: :other)) %>
+<% add_breadcrumb(plural_resource_name(Spree::ProductProperty)) %>
 
 <% content_for :page_actions do %>
   <% if can?(:create, Spree::ProductProperty) %>

--- a/backend/app/views/spree/admin/product_properties/index.html.erb
+++ b/backend/app/views/spree/admin/product_properties/index.html.erb
@@ -1,6 +1,10 @@
 <%= render 'spree/admin/shared/product_tabs', :current => 'Product Properties' %>
 <%= render 'spree/shared/error_messages', :target => @product %>
 
+<% content_for :page_title do %>
+  &#x2f; <%= Spree::ProductProperty.model_name.human(count: :other) %>
+<% end %>
+
 <% content_for :page_actions do %>
   <% if can?(:create, Spree::ProductProperty) %>
     <ul class="tollbar inline-menu">

--- a/backend/app/views/spree/admin/products/edit.html.erb
+++ b/backend/app/views/spree/admin/products/edit.html.erb
@@ -9,9 +9,8 @@
 <%= render :partial => 'spree/admin/shared/product_tabs', :locals => { :current => 'Product Details' } %>
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @product } %>
 
-<% content_for :page_title do %>
-  &#x2f; <%= Spree.t(:product_details) %>
-<% end %>
+<% add_breadcrumb(Spree.t(:product_details)) %>
+
 <%= form_for [:admin, @product], :method => :put, :html => { :multipart => true } do |f| %>
   <fieldset class="no-border-top">
     <%= render :partial => 'form', :locals => { :f => f } %>

--- a/backend/app/views/spree/admin/products/edit.html.erb
+++ b/backend/app/views/spree/admin/products/edit.html.erb
@@ -1,5 +1,4 @@
 <% content_for :page_actions do %>
-  <li><%= button_link_to Spree.t(:back_to_products_list), session[:return_to] || admin_products_url, :icon => 'arrow-left' %></li>
   <% if can?(:create, Spree::Product) %>
     <li id="new_product_link">
       <%= button_link_to Spree.t(:new_product), new_object_url, { :icon => 'plus', :id => 'admin_new_product' } %>
@@ -10,6 +9,9 @@
 <%= render :partial => 'spree/admin/shared/product_tabs', :locals => { :current => 'Product Details' } %>
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @product } %>
 
+<% content_for :page_title do %>
+  &#x2f; <%= Spree.t(:product_details) %>
+<% end %>
 <%= form_for [:admin, @product], :method => :put, :html => { :multipart => true } do |f| %>
   <fieldset class="no-border-top">
     <%= render :partial => 'form', :locals => { :f => f } %>

--- a/backend/app/views/spree/admin/products/index.html.erb
+++ b/backend/app/views/spree/admin/products/index.html.erb
@@ -1,8 +1,6 @@
 <% admin_layout "full-width" %>
 
-<% content_for :page_title do %>
-  <%= Spree::Product.model_name.human(count: :other) %>
-<% end %>
+<% add_breadcrumb(Spree::Product.model_name.human(count: :other)) %>
 
 <% content_for :page_actions do %>
   <li id="new_product_link">

--- a/backend/app/views/spree/admin/products/index.html.erb
+++ b/backend/app/views/spree/admin/products/index.html.erb
@@ -1,6 +1,6 @@
 <% admin_layout "full-width" %>
 
-<% add_breadcrumb(Spree::Product.model_name.human(count: :other)) %>
+<% add_breadcrumb(plural_resource_name(Spree::Product)) %>
 
 <% content_for :page_actions do %>
   <li id="new_product_link">

--- a/backend/app/views/spree/admin/products/index.html.erb
+++ b/backend/app/views/spree/admin/products/index.html.erb
@@ -1,7 +1,7 @@
 <% admin_layout "full-width" %>
 
 <% content_for :page_title do %>
-  <%= Spree.t(:listing_products) %>
+  <%= Spree::Product.model_name.human(count: :other) %>
 <% end %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/promotion_categories/edit.html.erb
+++ b/backend/app/views/spree/admin/promotion_categories/edit.html.erb
@@ -1,5 +1,5 @@
-<% add_breadcrumb(link_to Spree::Promotion.model_name.human(count: :other), spree.admin_promotions_path) %>
-<% add_breadcrumb(link_to Spree::PromotionCategory.model_name.human(count: :other), spree.admin_promotion_categories_path) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::Promotion), spree.admin_promotions_path) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::PromotionCategory), spree.admin_promotion_categories_path) %>
 <% add_breadcrumb(@promotion_category.name) %>
 
 

--- a/backend/app/views/spree/admin/promotion_categories/edit.html.erb
+++ b/backend/app/views/spree/admin/promotion_categories/edit.html.erb
@@ -1,5 +1,7 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_promotion_category) %>
+  <%= link_to Spree::Promotion.model_name.human(count: :other), spree.admin_promotions_path %> &#x2f;
+  <%= link_to Spree::PromotionCategory.model_name.human(count: :other), spree.admin_promotion_categories_path %> &#x2f;
+  <%= @promotion_category.name %>
 <% end %>
 
 <%= form_for @promotion_category, :url => object_url, :method => :put do |f| %>

--- a/backend/app/views/spree/admin/promotion_categories/edit.html.erb
+++ b/backend/app/views/spree/admin/promotion_categories/edit.html.erb
@@ -1,8 +1,7 @@
-<% content_for :page_title do %>
-  <%= link_to Spree::Promotion.model_name.human(count: :other), spree.admin_promotions_path %> &#x2f;
-  <%= link_to Spree::PromotionCategory.model_name.human(count: :other), spree.admin_promotion_categories_path %> &#x2f;
-  <%= @promotion_category.name %>
-<% end %>
+<% add_breadcrumb(link_to Spree::Promotion.model_name.human(count: :other), spree.admin_promotions_path) %>
+<% add_breadcrumb(link_to Spree::PromotionCategory.model_name.human(count: :other), spree.admin_promotion_categories_path) %>
+<% add_breadcrumb(@promotion_category.name) %>
+
 
 <%= form_for @promotion_category, :url => object_url, :method => :put do |f| %>
   <fieldset class="no-border-top">

--- a/backend/app/views/spree/admin/promotion_categories/index.html.erb
+++ b/backend/app/views/spree/admin/promotion_categories/index.html.erb
@@ -1,4 +1,4 @@
-<% add_breadcrumb(link_to Spree::Promotion.model_name.human(count: :other), spree.admin_promotions_path) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::Promotion), spree.admin_promotions_path) %>
 <% add_breadcrumb(Spree::PromotionCategory.model_name.human(count: :many)) %>
 
 

--- a/backend/app/views/spree/admin/promotion_categories/index.html.erb
+++ b/backend/app/views/spree/admin/promotion_categories/index.html.erb
@@ -1,5 +1,6 @@
 <% content_for :page_title do %>
-  <%= plural_resource_name(Spree::PromotionCategory) %>
+  <%= link_to Spree::Promotion.model_name.human(count: :other), spree.admin_promotions_path %> &#x2f;
+  <%= Spree::PromotionCategory.model_name.human(count: :many) %>
 <% end %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/promotion_categories/index.html.erb
+++ b/backend/app/views/spree/admin/promotion_categories/index.html.erb
@@ -1,7 +1,6 @@
-<% content_for :page_title do %>
-  <%= link_to Spree::Promotion.model_name.human(count: :other), spree.admin_promotions_path %> &#x2f;
-  <%= Spree::PromotionCategory.model_name.human(count: :many) %>
-<% end %>
+<% add_breadcrumb(link_to Spree::Promotion.model_name.human(count: :other), spree.admin_promotions_path) %>
+<% add_breadcrumb(Spree::PromotionCategory.model_name.human(count: :many)) %>
+
 
 <% content_for :page_actions do %>
   <% if can?(:create, Spree::PromotionCategory) %>

--- a/backend/app/views/spree/admin/promotion_categories/new.html.erb
+++ b/backend/app/views/spree/admin/promotion_categories/new.html.erb
@@ -1,4 +1,6 @@
 <% content_for :page_title do %>
+  <%= link_to Spree::Promotion.model_name.human(count: :other), spree.admin_promotions_path %> &#x2f;
+  <%= link_to Spree::PromotionCategory.model_name.human(count: :other), spree.admin_promotion_categories_path %> &#x2f;
   <%= Spree.t(:new_promotion_category) %>
 <% end %>
 

--- a/backend/app/views/spree/admin/promotion_categories/new.html.erb
+++ b/backend/app/views/spree/admin/promotion_categories/new.html.erb
@@ -1,5 +1,5 @@
-<% add_breadcrumb(link_to Spree::Promotion.model_name.human(count: :other), spree.admin_promotions_path) %>
-<% add_breadcrumb(link_to Spree::PromotionCategory.model_name.human(count: :other), spree.admin_promotion_categories_path) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::Promotion), spree.admin_promotions_path) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::PromotionCategory), spree.admin_promotion_categories_path) %>
 <% add_breadcrumb(Spree.t(:new_promotion_category)) %>
 
 

--- a/backend/app/views/spree/admin/promotion_categories/new.html.erb
+++ b/backend/app/views/spree/admin/promotion_categories/new.html.erb
@@ -1,8 +1,7 @@
-<% content_for :page_title do %>
-  <%= link_to Spree::Promotion.model_name.human(count: :other), spree.admin_promotions_path %> &#x2f;
-  <%= link_to Spree::PromotionCategory.model_name.human(count: :other), spree.admin_promotion_categories_path %> &#x2f;
-  <%= Spree.t(:new_promotion_category) %>
-<% end %>
+<% add_breadcrumb(link_to Spree::Promotion.model_name.human(count: :other), spree.admin_promotions_path) %>
+<% add_breadcrumb(link_to Spree::PromotionCategory.model_name.human(count: :other), spree.admin_promotion_categories_path) %>
+<% add_breadcrumb(Spree.t(:new_promotion_category)) %>
+
 
 <%= form_for :promotion_category, :url => collection_url do |f| %>
   <fieldset class="no-border-top">

--- a/backend/app/views/spree/admin/promotions/edit.html.erb
+++ b/backend/app/views/spree/admin/promotions/edit.html.erb
@@ -1,10 +1,10 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_promotion) %>
+  <%= link_to Spree::Promotion.model_name.human(count: :other), spree.admin_promotions_path %> &#x2f;
+  <%= @promotion.name %>
 <% end %>
 
 <% content_for :page_actions do %>
   <li>
-    <%= button_link_to Spree.t(:back_to_promotions_list), admin_promotions_path, :icon => 'arrow-left' %>
     <% if can?(:display, Spree::PromotionCode) %>
       <%= button_link_to Spree.t(:download_promotion_code_list), admin_promotion_promotion_codes_path(promotion_id: @promotion.id, format: :csv), :icon => 'arrow-down' %>
     <% end %>

--- a/backend/app/views/spree/admin/promotions/edit.html.erb
+++ b/backend/app/views/spree/admin/promotions/edit.html.erb
@@ -1,7 +1,6 @@
-<% content_for :page_title do %>
-  <%= link_to Spree::Promotion.model_name.human(count: :other), spree.admin_promotions_path %> &#x2f;
-  <%= @promotion.name %>
-<% end %>
+<% add_breadcrumb(link_to Spree::Promotion.model_name.human(count: :other), spree.admin_promotions_path) %>
+<% add_breadcrumb(@promotion.name) %>
+
 
 <% content_for :page_actions do %>
   <li>

--- a/backend/app/views/spree/admin/promotions/edit.html.erb
+++ b/backend/app/views/spree/admin/promotions/edit.html.erb
@@ -1,4 +1,4 @@
-<% add_breadcrumb(link_to Spree::Promotion.model_name.human(count: :other), spree.admin_promotions_path) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::Promotion), spree.admin_promotions_path) %>
 <% add_breadcrumb(@promotion.name) %>
 
 

--- a/backend/app/views/spree/admin/promotions/index.html.erb
+++ b/backend/app/views/spree/admin/promotions/index.html.erb
@@ -1,6 +1,4 @@
-<% content_for :page_title do %>
-  <%= plural_resource_name(Spree::Promotion) %>
-<% end %>
+<% add_breadcrumb(Spree::Promotion.model_name.human(count: :other)) %>
 
 <% content_for :page_actions do %>
   <% if can? :create, Spree::Promotion %>

--- a/backend/app/views/spree/admin/promotions/index.html.erb
+++ b/backend/app/views/spree/admin/promotions/index.html.erb
@@ -1,4 +1,4 @@
-<% add_breadcrumb(Spree::Promotion.model_name.human(count: :other)) %>
+<% add_breadcrumb(plural_resource_name(Spree::Promotion)) %>
 
 <% content_for :page_actions do %>
   <% if can? :create, Spree::Promotion %>

--- a/backend/app/views/spree/admin/promotions/new.html.erb
+++ b/backend/app/views/spree/admin/promotions/new.html.erb
@@ -1,4 +1,4 @@
-<% add_breadcrumb(link_to Spree::Promotion.model_name.human(count: :other), spree.admin_promotions_path) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::Promotion), spree.admin_promotions_path) %>
 <% add_breadcrumb(Spree.t(:new_promotion)) %>
 
 

--- a/backend/app/views/spree/admin/promotions/new.html.erb
+++ b/backend/app/views/spree/admin/promotions/new.html.erb
@@ -1,4 +1,5 @@
 <% content_for :page_title do %>
+  <%= link_to Spree::Promotion.model_name.human(count: :other), spree.admin_promotions_path %> &#x2f;
   <%= Spree.t(:new_promotion) %>
 <% end %>
 

--- a/backend/app/views/spree/admin/promotions/new.html.erb
+++ b/backend/app/views/spree/admin/promotions/new.html.erb
@@ -1,7 +1,6 @@
-<% content_for :page_title do %>
-  <%= link_to Spree::Promotion.model_name.human(count: :other), spree.admin_promotions_path %> &#x2f;
-  <%= Spree.t(:new_promotion) %>
-<% end %>
+<% add_breadcrumb(link_to Spree::Promotion.model_name.human(count: :other), spree.admin_promotions_path) %>
+<% add_breadcrumb(Spree.t(:new_promotion)) %>
+
 
 <%= form_for :promotion, :url => collection_url do |f| %>
   <fieldset class="no-border-top">

--- a/backend/app/views/spree/admin/properties/edit.html.erb
+++ b/backend/app/views/spree/admin/properties/edit.html.erb
@@ -1,8 +1,7 @@
-<% content_for :page_title do %>
-  <%= link_to Spree::Product.model_name.human(count: :other), spree.admin_products_path  %> &#x2f;
-  <%= link_to Spree::Property.model_name.human(count: :other), spree.admin_properties_path %> &#x2f;
-  <%= @property.name %>
-<% end %>
+<% add_breadcrumb(link_to Spree::Product.model_name.human(count: :other), spree.admin_products_path) %>
+<% add_breadcrumb(link_to Spree::Property.model_name.human(count: :other), spree.admin_properties_path) %>
+<% add_breadcrumb(@property.name) %>
+
 
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @property } %>
 

--- a/backend/app/views/spree/admin/properties/edit.html.erb
+++ b/backend/app/views/spree/admin/properties/edit.html.erb
@@ -1,5 +1,5 @@
-<% add_breadcrumb(link_to Spree::Product.model_name.human(count: :other), spree.admin_products_path) %>
-<% add_breadcrumb(link_to Spree::Property.model_name.human(count: :other), spree.admin_properties_path) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::Product), spree.admin_products_path) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::Property), spree.admin_properties_path) %>
 <% add_breadcrumb(@property.name) %>
 
 

--- a/backend/app/views/spree/admin/properties/edit.html.erb
+++ b/backend/app/views/spree/admin/properties/edit.html.erb
@@ -1,9 +1,7 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_property) %>
-<% end %>
-
-<% content_for :page_actions do %>
-  <li><%= button_link_to Spree.t(:back_to_properties_list), admin_properties_url, :icon => 'arrow-left'%></li>
+  <%= link_to Spree::Product.model_name.human(count: :other), spree.admin_products_path  %> &#x2f;
+  <%= link_to Spree::Property.model_name.human(count: :other), spree.admin_properties_path %> &#x2f;
+  <%= @property.name %>
 <% end %>
 
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @property } %>

--- a/backend/app/views/spree/admin/properties/index.html.erb
+++ b/backend/app/views/spree/admin/properties/index.html.erb
@@ -1,5 +1,5 @@
-<% add_breadcrumb(link_to Spree::Product.model_name.human(count: :other), spree.admin_products_path) %>
-<% add_breadcrumb(Spree::Property.model_name.human(count: :other)) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::Product), spree.admin_products_path) %>
+<% add_breadcrumb(plural_resource_name(Spree::Property)) %>
 
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/properties/index.html.erb
+++ b/backend/app/views/spree/admin/properties/index.html.erb
@@ -1,5 +1,6 @@
 <% content_for :page_title do %>
-  <%= plural_resource_name(Spree::Property) %>
+  <%= link_to Spree::Product.model_name.human(count: :other), spree.admin_products_path  %> &#x2f; 
+  <%= Spree::Property.model_name.human(count: :other) %>
 <% end %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/properties/index.html.erb
+++ b/backend/app/views/spree/admin/properties/index.html.erb
@@ -1,7 +1,6 @@
-<% content_for :page_title do %>
-  <%= link_to Spree::Product.model_name.human(count: :other), spree.admin_products_path  %> &#x2f; 
-  <%= Spree::Property.model_name.human(count: :other) %>
-<% end %>
+<% add_breadcrumb(link_to Spree::Product.model_name.human(count: :other), spree.admin_products_path) %>
+<% add_breadcrumb(Spree::Property.model_name.human(count: :other)) %>
+
 
 <% content_for :page_actions do %>
   <% if can?(:create, Spree::Property) %>

--- a/backend/app/views/spree/admin/prototypes/edit.html.erb
+++ b/backend/app/views/spree/admin/prototypes/edit.html.erb
@@ -1,8 +1,6 @@
-<% content_for :page_title do %>
-  <%= link_to Spree::Product.model_name.human(count: :other), spree.admin_products_path  %> &#x2f; 
-  <%= link_to Spree::Prototype.model_name.human(count: :other), spree.admin_prototypes_path %> &#x2f;
-  <%= @prototype.name %>
-<% end %>
+<% add_breadcrumb(link_to Spree::Product.model_name.human(count: :other), spree.admin_products_path) %>
+<% add_breadcrumb(link_to Spree::Prototype.model_name.human(count: :other), spree.admin_prototypes_path) %>
+<% add_breadcrumb(@prototype.name) %>
 
 <% content_for :page_actions do %>
 <% end %>

--- a/backend/app/views/spree/admin/prototypes/edit.html.erb
+++ b/backend/app/views/spree/admin/prototypes/edit.html.erb
@@ -1,5 +1,5 @@
-<% add_breadcrumb(link_to Spree::Product.model_name.human(count: :other), spree.admin_products_path) %>
-<% add_breadcrumb(link_to Spree::Prototype.model_name.human(count: :other), spree.admin_prototypes_path) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::Product), spree.admin_products_path) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::Prototype), spree.admin_prototypes_path) %>
 <% add_breadcrumb(@prototype.name) %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/prototypes/edit.html.erb
+++ b/backend/app/views/spree/admin/prototypes/edit.html.erb
@@ -1,11 +1,10 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_prototype) %>
+  <%= link_to Spree::Product.model_name.human(count: :other), spree.admin_products_path  %> &#x2f; 
+  <%= link_to Spree::Prototype.model_name.human(count: :other), spree.admin_prototypes_path %> &#x2f;
+  <%= @prototype.name %>
 <% end %>
 
 <% content_for :page_actions do %>
-  <li>
-    <%= button_link_to Spree.t(:back_to_prototypes_list), spree.admin_prototypes_path, :icon => 'arrow-left' %>
-  </li>
 <% end %>
 
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @prototype } %>

--- a/backend/app/views/spree/admin/prototypes/index.html.erb
+++ b/backend/app/views/spree/admin/prototypes/index.html.erb
@@ -1,5 +1,6 @@
 <% content_for :page_title do %>
-  <%= plural_resource_name(Spree::Prototype) %>
+  <%= link_to Spree::Product.model_name.human(count: :other), spree.admin_products_path  %> &#x2f; 
+  <%= Spree::Prototype.model_name.human(count: :other) %>
 <% end %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/prototypes/index.html.erb
+++ b/backend/app/views/spree/admin/prototypes/index.html.erb
@@ -1,5 +1,5 @@
-<% add_breadcrumb(link_to Spree::Product.model_name.human(count: :other), spree.admin_products_path) %>
-<% add_breadcrumb(Spree::Prototype.model_name.human(count: :other)) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::Product), spree.admin_products_path) %>
+<% add_breadcrumb(plural_resource_name(Spree::Prototype)) %>
 
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/prototypes/index.html.erb
+++ b/backend/app/views/spree/admin/prototypes/index.html.erb
@@ -1,7 +1,6 @@
-<% content_for :page_title do %>
-  <%= link_to Spree::Product.model_name.human(count: :other), spree.admin_products_path  %> &#x2f; 
-  <%= Spree::Prototype.model_name.human(count: :other) %>
-<% end %>
+<% add_breadcrumb(link_to Spree::Product.model_name.human(count: :other), spree.admin_products_path) %>
+<% add_breadcrumb(Spree::Prototype.model_name.human(count: :other)) %>
+
 
 <% content_for :page_actions do %>
   <% if can?(:create, Spree::Prototype) %>

--- a/backend/app/views/spree/admin/refund_reasons/edit.html.erb
+++ b/backend/app/views/spree/admin/refund_reasons/edit.html.erb
@@ -1,11 +1,9 @@
 <%= render 'spree/admin/shared/settings_checkout_tabs' %>
 
-<% content_for :page_title do %>
-  <%= Spree.t(:settings) %> &#x2f;
-  <%= Spree.t('admin.tab.checkout') %> &#x2f;
-  <%= link_to Spree::RefundReason.model_name.human(count: :other), spree.admin_refund_reasons_path %> &#x2f;
-  <%= @refund_reason.name %>
-<% end %>
+<% add_breadcrumb(Spree.t(:settings)) %>
+<% add_breadcrumb(Spree.t('admin.tab.checkout')) %>
+<% add_breadcrumb(link_to Spree::RefundReason.model_name.human(count: :other), spree.admin_refund_reasons_path) %>
+<% add_breadcrumb(@refund_reason.name) %>
 
 <% content_for :page_actions do %>
 <% end %>

--- a/backend/app/views/spree/admin/refund_reasons/edit.html.erb
+++ b/backend/app/views/spree/admin/refund_reasons/edit.html.erb
@@ -2,7 +2,7 @@
 
 <% add_breadcrumb(Spree.t(:settings)) %>
 <% add_breadcrumb(Spree.t('admin.tab.checkout')) %>
-<% add_breadcrumb(link_to Spree::RefundReason.model_name.human(count: :other), spree.admin_refund_reasons_path) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::RefundReason), spree.admin_refund_reasons_path) %>
 <% add_breadcrumb(@refund_reason.name) %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/refund_reasons/edit.html.erb
+++ b/backend/app/views/spree/admin/refund_reasons/edit.html.erb
@@ -1,11 +1,13 @@
 <%= render 'spree/admin/shared/settings_checkout_tabs' %>
 
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_refund_reason) %>
+  <%= Spree.t(:settings) %> &#x2f;
+  <%= Spree.t('admin.tab.checkout') %> &#x2f;
+  <%= link_to Spree::RefundReason.model_name.human(count: :other), spree.admin_refund_reasons_path %> &#x2f;
+  <%= @refund_reason.name %>
 <% end %>
 
 <% content_for :page_actions do %>
-  <li><%= link_to_with_icon 'arrow-left', Spree.t(:back_to_refund_reason_list), collection_url, :class => 'button' %></li>
 <% end %>
 
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @object } %>

--- a/backend/app/views/spree/admin/refund_reasons/index.html.erb
+++ b/backend/app/views/spree/admin/refund_reasons/index.html.erb
@@ -1,10 +1,9 @@
 <%= render 'spree/admin/shared/settings_checkout_tabs' %>
 
-<% content_for :page_title do %>
-  <%= Spree.t(:settings) %> &#x2f;
-  <%= Spree.t('admin.tab.checkout') %> &#x2f;
-  <%= Spree::RefundReason.model_name.human(count: :other) %>
-<% end %>
+<% add_breadcrumb(Spree.t(:settings)) %>
+<% add_breadcrumb(Spree.t('admin.tab.checkout')) %>
+<% add_breadcrumb(Spree::RefundReason.model_name.human(count: :other)) %>
+
 
 <% content_for :page_actions do %>
   <ul class="actions inline-menu">

--- a/backend/app/views/spree/admin/refund_reasons/index.html.erb
+++ b/backend/app/views/spree/admin/refund_reasons/index.html.erb
@@ -1,7 +1,9 @@
 <%= render 'spree/admin/shared/settings_checkout_tabs' %>
 
 <% content_for :page_title do %>
-  <%= plural_resource_name(Spree::RefundReason) %>
+  <%= Spree.t(:settings) %> &#x2f;
+  <%= Spree.t('admin.tab.checkout') %> &#x2f;
+  <%= Spree::RefundReason.model_name.human(count: :other) %>
 <% end %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/refund_reasons/index.html.erb
+++ b/backend/app/views/spree/admin/refund_reasons/index.html.erb
@@ -2,7 +2,7 @@
 
 <% add_breadcrumb(Spree.t(:settings)) %>
 <% add_breadcrumb(Spree.t('admin.tab.checkout')) %>
-<% add_breadcrumb(Spree::RefundReason.model_name.human(count: :other)) %>
+<% add_breadcrumb(plural_resource_name(Spree::RefundReason)) %>
 
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/refund_reasons/new.html.erb
+++ b/backend/app/views/spree/admin/refund_reasons/new.html.erb
@@ -1,11 +1,10 @@
 <%= render 'spree/admin/shared/settings_checkout_tabs' %>
 
-<% content_for :page_title do %>
-  <%= Spree.t(:settings) %> &#x2f;
-  <%= Spree.t('admin.tab.checkout') %> &#x2f;
-  <%= link_to Spree::RefundReason.model_name.human(count: :other), spree.admin_refund_reasons_path %> &#x2f;
-  <%= Spree.t(:new_refund_reason) %>
-<% end %>
+<% add_breadcrumb(Spree.t(:settings)) %>
+<% add_breadcrumb(Spree.t('admin.tab.checkout')) %>
+<% add_breadcrumb(link_to Spree::RefundReason.model_name.human(count: :other), spree.admin_refund_reasons_path) %>
+<% add_breadcrumb(Spree.t(:new_refund_reason)) %>
+
 
 <% content_for :page_actions do %>
 <% end %>

--- a/backend/app/views/spree/admin/refund_reasons/new.html.erb
+++ b/backend/app/views/spree/admin/refund_reasons/new.html.erb
@@ -2,7 +2,7 @@
 
 <% add_breadcrumb(Spree.t(:settings)) %>
 <% add_breadcrumb(Spree.t('admin.tab.checkout')) %>
-<% add_breadcrumb(link_to Spree::RefundReason.model_name.human(count: :other), spree.admin_refund_reasons_path) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::RefundReason), spree.admin_refund_reasons_path) %>
 <% add_breadcrumb(Spree.t(:new_refund_reason)) %>
 
 

--- a/backend/app/views/spree/admin/refund_reasons/new.html.erb
+++ b/backend/app/views/spree/admin/refund_reasons/new.html.erb
@@ -1,11 +1,13 @@
 <%= render 'spree/admin/shared/settings_checkout_tabs' %>
 
 <% content_for :page_title do %>
+  <%= Spree.t(:settings) %> &#x2f;
+  <%= Spree.t('admin.tab.checkout') %> &#x2f;
+  <%= link_to Spree::RefundReason.model_name.human(count: :other), spree.admin_refund_reasons_path %> &#x2f;
   <%= Spree.t(:new_refund_reason) %>
 <% end %>
 
 <% content_for :page_actions do %>
-  <li><%= link_to_with_icon 'arrow-left', Spree.t(:back_to_refund_reason_list), collection_url, :class => 'button' %></li>
 <% end %>
 
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @object } %>

--- a/backend/app/views/spree/admin/refunds/edit.html.erb
+++ b/backend/app/views/spree/admin/refunds/edit.html.erb
@@ -1,10 +1,8 @@
 <%= render partial: 'spree/admin/shared/order_tabs', locals: {current: 'Payments'} %>
 
-<% content_for :page_title do %>
-  &#x2f; <%= link_to Spree::Payment.model_name.human(count: :other), spree.admin_order_payments_path(@order) %>
-  &#x2f; <%= link_to "#{Spree::Payment.model_name.human} #{@refund.payment.id}", admin_order_payment_path(@refund.payment.order, @refund.payment) %>
-  &#x2f; <%= Spree.t(:editing_refund) %> <%= @refund.id %>
-<% end %>
+<% add_breadcrumb(link_to Spree::Payment.model_name.human(count: :other), spree.admin_order_payments_path(@order)) %>
+<% add_breadcrumb(link_to "#{Spree::Payment.model_name.human} #{@refund.payment.id}", admin_order_payment_path(@refund.payment.order, @refund.payment)) %>
+<% add_breadcrumb("#{Spree.t(:editing_refund)} #{@refund.id}") %>
 
 <%= form_for [:admin, @refund.payment.order, @refund.payment, @refund] do |f| %>
   <fieldset class="no-border-top">

--- a/backend/app/views/spree/admin/refunds/edit.html.erb
+++ b/backend/app/views/spree/admin/refunds/edit.html.erb
@@ -1,6 +1,6 @@
 <%= render partial: 'spree/admin/shared/order_tabs', locals: {current: 'Payments'} %>
 
-<% add_breadcrumb(link_to Spree::Payment.model_name.human(count: :other), spree.admin_order_payments_path(@order)) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::Payment), spree.admin_order_payments_path(@order)) %>
 <% add_breadcrumb(link_to "#{Spree::Payment.model_name.human} #{@refund.payment.id}", admin_order_payment_path(@refund.payment.order, @refund.payment)) %>
 <% add_breadcrumb("#{Spree.t(:editing_refund)} #{@refund.id}") %>
 

--- a/backend/app/views/spree/admin/refunds/edit.html.erb
+++ b/backend/app/views/spree/admin/refunds/edit.html.erb
@@ -1,8 +1,9 @@
 <%= render partial: 'spree/admin/shared/order_tabs', locals: {current: 'Payments'} %>
 
 <% content_for :page_title do %>
-  <i class="fa fa-arrow-right"></i> <%= link_to "#{Spree::Payment.model_name.human} #{@refund.payment.id}", admin_order_payment_path(@refund.payment.order, @refund.payment) %>
-  <i class="fa fa-arrow-right"></i> <%= Spree.t(:editing_refund) %> <%= @refund.id %>
+  &#x2f; <%= link_to Spree::Payment.model_name.human(count: :other), spree.admin_order_payments_path(@order) %>
+  &#x2f; <%= link_to "#{Spree::Payment.model_name.human} #{@refund.payment.id}", admin_order_payment_path(@refund.payment.order, @refund.payment) %>
+  &#x2f; <%= Spree.t(:editing_refund) %> <%= @refund.id %>
 <% end %>
 
 <%= form_for [:admin, @refund.payment.order, @refund.payment, @refund] do |f| %>

--- a/backend/app/views/spree/admin/refunds/new.html.erb
+++ b/backend/app/views/spree/admin/refunds/new.html.erb
@@ -1,6 +1,6 @@
 <%= render partial: 'spree/admin/shared/order_tabs', locals: {current: 'Payments'} %>
 
-<% add_breadcrumb(link_to Spree::Payment.model_name.human(count: :other), spree.admin_order_payments_path(@order)) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::Payment), spree.admin_order_payments_path(@order)) %>
 <% add_breadcrumb(link_to "#{Spree::Payment.model_name.human} #{@refund.payment.id}", admin_order_payment_path(@refund.payment.order, @refund.payment)) %>
 <% add_breadcrumb(Spree.t(:new_refund)) %>
 

--- a/backend/app/views/spree/admin/refunds/new.html.erb
+++ b/backend/app/views/spree/admin/refunds/new.html.erb
@@ -1,8 +1,9 @@
 <%= render partial: 'spree/admin/shared/order_tabs', locals: {current: 'Payments'} %>
 
 <% content_for :page_title do %>
-  <i class="fa fa-arrow-right"></i> <%= link_to "#{Spree::Payment.model_name.human} #{@refund.payment.id}", admin_order_payment_path(@refund.payment.order, @refund.payment) %>
-  <i class="fa fa-arrow-right"></i> <%= Spree.t(:new_refund) %>
+  &#x2f; <%= link_to Spree::Payment.model_name.human(count: :other), spree.admin_order_payments_path(@order) %>
+  &#x2f; <%= link_to "#{Spree::Payment.model_name.human} #{@refund.payment.id}", admin_order_payment_path(@refund.payment.order, @refund.payment) %>
+  &#x2f; <%= Spree.t(:new_refund) %>
 <% end %>
 
 <%= form_for [:admin, @refund.payment.order, @refund.payment, @refund] do |f| %>

--- a/backend/app/views/spree/admin/refunds/new.html.erb
+++ b/backend/app/views/spree/admin/refunds/new.html.erb
@@ -1,10 +1,9 @@
 <%= render partial: 'spree/admin/shared/order_tabs', locals: {current: 'Payments'} %>
 
-<% content_for :page_title do %>
-  &#x2f; <%= link_to Spree::Payment.model_name.human(count: :other), spree.admin_order_payments_path(@order) %>
-  &#x2f; <%= link_to "#{Spree::Payment.model_name.human} #{@refund.payment.id}", admin_order_payment_path(@refund.payment.order, @refund.payment) %>
-  &#x2f; <%= Spree.t(:new_refund) %>
-<% end %>
+<% add_breadcrumb(link_to Spree::Payment.model_name.human(count: :other), spree.admin_order_payments_path(@order)) %>
+<% add_breadcrumb(link_to "#{Spree::Payment.model_name.human} #{@refund.payment.id}", admin_order_payment_path(@refund.payment.order, @refund.payment)) %>
+<% add_breadcrumb(Spree.t(:new_refund)) %>
+
 
 <%= form_for [:admin, @refund.payment.order, @refund.payment, @refund] do |f| %>
   <fieldset class="no-border-top">

--- a/backend/app/views/spree/admin/reimbursement_types/index.html.erb
+++ b/backend/app/views/spree/admin/reimbursement_types/index.html.erb
@@ -1,7 +1,9 @@
 <%= render 'spree/admin/shared/settings_checkout_tabs' %>
 
 <% content_for :page_title do %>
-  <%= plural_resource_name(Spree::ReimbursementType) %>
+  <%= Spree.t(:settings) %> &#x2f;
+  <%= Spree.t('admin.tab.checkout') %> &#x2f;
+  <%= Spree::ReimbursementType.model_name.human(count: :other) %>
 <% end %>
 
 <table class="index" id='listing_reimbursement_types' data-hook>

--- a/backend/app/views/spree/admin/reimbursement_types/index.html.erb
+++ b/backend/app/views/spree/admin/reimbursement_types/index.html.erb
@@ -1,10 +1,9 @@
 <%= render 'spree/admin/shared/settings_checkout_tabs' %>
 
-<% content_for :page_title do %>
-  <%= Spree.t(:settings) %> &#x2f;
-  <%= Spree.t('admin.tab.checkout') %> &#x2f;
-  <%= Spree::ReimbursementType.model_name.human(count: :other) %>
-<% end %>
+<% add_breadcrumb(Spree.t(:settings)) %>
+<% add_breadcrumb(Spree.t('admin.tab.checkout')) %>
+<% add_breadcrumb(Spree::ReimbursementType.model_name.human(count: :other)) %>
+
 
 <table class="index" id='listing_reimbursement_types' data-hook>
   <thead>

--- a/backend/app/views/spree/admin/reimbursement_types/index.html.erb
+++ b/backend/app/views/spree/admin/reimbursement_types/index.html.erb
@@ -2,7 +2,7 @@
 
 <% add_breadcrumb(Spree.t(:settings)) %>
 <% add_breadcrumb(Spree.t('admin.tab.checkout')) %>
-<% add_breadcrumb(Spree::ReimbursementType.model_name.human(count: :other)) %>
+<% add_breadcrumb(plural_resource_name(Spree::ReimbursementType)) %>
 
 
 <table class="index" id='listing_reimbursement_types' data-hook>

--- a/backend/app/views/spree/admin/reimbursements/edit.html.erb
+++ b/backend/app/views/spree/admin/reimbursements/edit.html.erb
@@ -1,8 +1,7 @@
 <%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Customer Returns' } %>
 
-<% content_for :page_title do %>
-  <i class="fa fa-arrow-right"></i> <%= Spree.t(:editing_reimbursement) %> #<%= @reimbursement.number %>
-<% end %>
+<% add_breadcrumb("#{Spree.t(:editing_reimbursement} #{@reimbursement.number}") %>
+
 
 <% content_for :page_actions do %>
   <li><%= button_link_to Spree.t(:back_to_customer_return), url_for([:edit, :admin, @order, @reimbursement.customer_return]), :icon => 'arrow-left' %></li>

--- a/backend/app/views/spree/admin/reimbursements/index.html.erb
+++ b/backend/app/views/spree/admin/reimbursements/index.html.erb
@@ -1,8 +1,6 @@
 <%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Reimbursements' } %>
 
-<% content_for :page_title do %>
-  <i class="fa fa-arrow-right"></i> <%= plural_resource_name(Spree::Reimbursement) %>
-<% end %>
+<% add_breadcrumb(Spree::Reimbursement.model_name.human(count: :other)) %>
 
 <% content_for :page_actions do %>
   <li><%= button_link_to Spree.t(:back_to_customer_return_list), spree.admin_order_customer_returns_url(@order), :icon => 'arrow-left' %></li>

--- a/backend/app/views/spree/admin/reimbursements/index.html.erb
+++ b/backend/app/views/spree/admin/reimbursements/index.html.erb
@@ -1,6 +1,6 @@
 <%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Reimbursements' } %>
 
-<% add_breadcrumb(Spree::Reimbursement.model_name.human(count: :other)) %>
+<% add_breadcrumb(plural_resource_name(Spree::Reimbursement)) %>
 
 <% content_for :page_actions do %>
   <li><%= button_link_to Spree.t(:back_to_customer_return_list), spree.admin_order_customer_returns_url(@order), :icon => 'arrow-left' %></li>

--- a/backend/app/views/spree/admin/reimbursements/show.html.erb
+++ b/backend/app/views/spree/admin/reimbursements/show.html.erb
@@ -1,8 +1,7 @@
 <%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Customer Returns' } %>
 
-<% content_for :page_title do %>
-  <i class="fa fa-arrow-right"></i> <%= Spree::Reimbursement.model_name.human %> #<%= @reimbursement.number %>
-<% end %>
+<% add_breadcrumb("#{Spree::Reimbursement.model_name.human} #{@reimbursement.number}") %>
+
 
 <% content_for :page_actions do %>
   <li><%= button_link_to Spree.t(:back_to_customer_return), url_for([:edit, :admin, @order, @reimbursement.customer_return]), :icon => 'arrow-left' %></li>

--- a/backend/app/views/spree/admin/reports/index.html.erb
+++ b/backend/app/views/spree/admin/reports/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:listing_reports) %>
+  <%= Spree.t(:reports) %>
 <% end %>
 
 <table class="index">

--- a/backend/app/views/spree/admin/reports/index.html.erb
+++ b/backend/app/views/spree/admin/reports/index.html.erb
@@ -1,6 +1,5 @@
-<% content_for :page_title do %>
-  <%= Spree.t(:reports) %>
-<% end %>
+<% add_breadcrumb(Spree.t(:reports)) %>
+
 
 <table class="index">
   <thead>

--- a/backend/app/views/spree/admin/reports/sales_total.html.erb
+++ b/backend/app/views/spree/admin/reports/sales_total.html.erb
@@ -1,9 +1,9 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:sales_totals) %>
+  <%= link_to Spree.t(:reports), spree.admin_reports_path %> &#x2f;
+  <%= Spree.t(:sales_total) %>
 <% end %>
 
 <% content_for :page_actions do %>
-  <li><%= link_to_with_icon 'arrow-left', Spree.t(:back_to_reports_list), spree.admin_reports_url, :class => 'button' %></li>
 <% end %>
 
 

--- a/backend/app/views/spree/admin/reports/sales_total.html.erb
+++ b/backend/app/views/spree/admin/reports/sales_total.html.erb
@@ -1,7 +1,5 @@
-<% content_for :page_title do %>
-  <%= link_to Spree.t(:reports), spree.admin_reports_path %> &#x2f;
-  <%= Spree.t(:sales_total) %>
-<% end %>
+<% add_breadcrumb(link_to Spree.t(:reports), spree.admin_reports_path) %>
+<% add_breadcrumb(Spree.t(:sales_total)) %>
 
 <% content_for :page_actions do %>
 <% end %>

--- a/backend/app/views/spree/admin/return_authorizations/edit.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/edit.html.erb
@@ -8,7 +8,7 @@
 
 <%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Return Authorizations' } %>
 
-<% add_breadcrumb(link_to Spree::ReturnAuthorization.model_name.human(count: :other), spree.admin_order_return_authorizations_url) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::ReturnAuthorization), spree.admin_order_return_authorizations_url) %>
 <% add_breadcrumb("#{@return_authorization.number} (#{Spree.t(@return_authorization.state.downcase)})") %>
 
 

--- a/backend/app/views/spree/admin/return_authorizations/edit.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/edit.html.erb
@@ -8,10 +8,8 @@
 
 <%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Return Authorizations' } %>
 
-<% content_for :page_title do %>
-  &#x2f; <%= link_to Spree::ReturnAuthorization.model_name.human(count: :other), spree.admin_order_return_authorizations_url %>
-  &#x2f; <%= @return_authorization.number %> &#40;<%= Spree.t(@return_authorization.state.downcase) %>&#41;
-<% end %>
+<% add_breadcrumb(link_to Spree::ReturnAuthorization.model_name.human(count: :other), spree.admin_order_return_authorizations_url) %>
+<% add_breadcrumb("#{@return_authorization.number} (#{Spree.t(@return_authorization.state.downcase)})") %>
 
 
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @return_authorization } %>

--- a/backend/app/views/spree/admin/return_authorizations/edit.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/edit.html.erb
@@ -4,15 +4,13 @@
       <%= button_link_to Spree.t('actions.cancel'), fire_admin_order_return_authorization_url(@order, @return_authorization, e: 'cancel'), method: :put, data: { confirm: Spree.t(:are_you_sure) }, icon: 'remove' %>
     </li>
   <% end %>
-  <li>
-    <%= button_link_to Spree.t(:back), spree.admin_order_return_authorizations_url(@order), icon: 'arrow-left' %>
-  </li>
 <% end %>
 
 <%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Return Authorizations' } %>
 
 <% content_for :page_title do %>
-  <i class="fa fa-arrow-right"></i> <%= Spree::ReturnAuthorization.model_name.human %> <%= @return_authorization.number %> (<%= Spree.t(@return_authorization.state.downcase) %>)
+  &#x2f; <%= link_to Spree::ReturnAuthorization.model_name.human(count: :other), spree.admin_order_return_authorizations_url %>
+  &#x2f; <%= @return_authorization.number %> &#40;<%= Spree.t(@return_authorization.state.downcase) %>&#41;
 <% end %>
 
 

--- a/backend/app/views/spree/admin/return_authorizations/index.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/index.html.erb
@@ -10,9 +10,8 @@
   <% end %>
 <% end %>
 
-<% content_for :page_title do %>
-  &#x2f; <%= Spree::ReturnAuthorization.model_name.human(count: :other) %>
-<% end %>
+<% add_breadcrumb(Spree::ReturnAuthorization.model_name.human(count: :other)) %>
+
 
 <% if @order.shipments.any?(&:shipped?) || @order.return_authorizations.any? %>
   <table class="index">

--- a/backend/app/views/spree/admin/return_authorizations/index.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/index.html.erb
@@ -10,7 +10,7 @@
   <% end %>
 <% end %>
 
-<% add_breadcrumb(Spree::ReturnAuthorization.model_name.human(count: :other)) %>
+<% add_breadcrumb(plural_resource_name(Spree::ReturnAuthorization)) %>
 
 
 <% if @order.shipments.any?(&:shipped?) || @order.return_authorizations.any? %>

--- a/backend/app/views/spree/admin/return_authorizations/index.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/index.html.erb
@@ -8,11 +8,10 @@
       <% end %>
     </li>
   <% end %>
-  <li><%= button_link_to Spree.t(:back_to_orders_list), spree.admin_orders_path, :icon => 'arrow-left' %></li>
 <% end %>
 
 <% content_for :page_title do %>
-  <i class="fa fa-arrow-right"></i> <%= plural_resource_name(Spree::ReturnAuthorization) %>
+  &#x2f; <%= Spree::ReturnAuthorization.model_name.human(count: :other) %>
 <% end %>
 
 <% if @order.shipments.any?(&:shipped?) || @order.return_authorizations.any? %>

--- a/backend/app/views/spree/admin/return_authorizations/new.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/new.html.erb
@@ -1,6 +1,6 @@
 <%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Return Authorizations' } %>
 
-<% add_breadcrumb(link_to Spree::ReturnAuthorization.model_name.human(count: :other), spree.admin_order_return_authorizations_url) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::ReturnAuthorization), spree.admin_order_return_authorizations_url) %>
 <% add_breadcrumb(Spree.t(:new_return_authorization)) %>
 
 

--- a/backend/app/views/spree/admin/return_authorizations/new.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/new.html.erb
@@ -1,9 +1,8 @@
 <%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Return Authorizations' } %>
 
-<% content_for :page_title do %>
-  &#x2f; <%= link_to Spree::ReturnAuthorization.model_name.human(count: :other), spree.admin_order_return_authorizations_url %>
-  &#x2f; <%= Spree.t(:new_return_authorization) %>
-<% end %>
+<% add_breadcrumb(link_to Spree::ReturnAuthorization.model_name.human(count: :other), spree.admin_order_return_authorizations_url) %>
+<% add_breadcrumb(Spree.t(:new_return_authorization)) %>
+
 
 <% content_for :page_actions do %>
 <% end %>

--- a/backend/app/views/spree/admin/return_authorizations/new.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/new.html.erb
@@ -1,11 +1,11 @@
 <%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Return Authorizations' } %>
 
 <% content_for :page_title do %>
-  <i class="fa fa-arrow-right"></i> <%= Spree.t(:new_return_authorization) %>
+  &#x2f; <%= link_to Spree::ReturnAuthorization.model_name.human(count: :other), spree.admin_order_return_authorizations_url %>
+  &#x2f; <%= Spree.t(:new_return_authorization) %>
 <% end %>
 
 <% content_for :page_actions do %>
-  <li><%= button_link_to Spree.t(:back_to_return_authorizations_list), spree.admin_order_return_authorizations_url, :icon => 'arrow-left' %></li>
 <% end %>
 
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @return_authorization } %>

--- a/backend/app/views/spree/admin/return_reasons/edit.html.erb
+++ b/backend/app/views/spree/admin/return_reasons/edit.html.erb
@@ -1,5 +1,5 @@
 <%= render partial: 'spree/admin/shared/named_types/edit', locals: {
   root_tab: Spree.t(:settings),
   sub_tab: Spree.t('admin.tab.checkout'),
-  index_link: link_to(Spree::ReturnReason.model_name.human(count: :other), spree.admin_return_reasons_path),
+  index_link: link_to(plural_resource_name(Spree::ReturnReason), spree.admin_return_reasons_path),
 } %>

--- a/backend/app/views/spree/admin/return_reasons/edit.html.erb
+++ b/backend/app/views/spree/admin/return_reasons/edit.html.erb
@@ -1,4 +1,5 @@
 <%= render partial: 'spree/admin/shared/named_types/edit', locals: {
-  page_title: Spree.t(:editing_rma_reason),
-  back_button_text: Spree.t(:back_to_rma_reason_list)
+  root_tab: Spree.t(:settings),
+  sub_tab: Spree.t('admin.tab.checkout'),
+  index_link: link_to(Spree::ReturnReason.model_name.human(count: :other), spree.admin_return_reasons_path),
 } %>

--- a/backend/app/views/spree/admin/return_reasons/index.html.erb
+++ b/backend/app/views/spree/admin/return_reasons/index.html.erb
@@ -1,5 +1,7 @@
 <%= render partial: 'spree/admin/shared/named_types/index', locals: {
-  page_title: plural_resource_name(Spree::ReturnReason),
+  root_tab: Spree.t(:settings),
+  sub_tab: Spree.t('admin.tab.checkout'),
+  page_title: Spree::ReturnReason.model_name.human(count: :other),
   new_button_text: Spree.t(:new_rma_reason),
   resource: Spree::ReturnReason
 } %>

--- a/backend/app/views/spree/admin/return_reasons/index.html.erb
+++ b/backend/app/views/spree/admin/return_reasons/index.html.erb
@@ -1,7 +1,7 @@
 <%= render partial: 'spree/admin/shared/named_types/index', locals: {
   root_tab: Spree.t(:settings),
   sub_tab: Spree.t('admin.tab.checkout'),
-  page_title: Spree::ReturnReason.model_name.human(count: :other),
+  page_title: plural_resource_name(Spree::ReturnReason),
   new_button_text: Spree.t(:new_rma_reason),
   resource: Spree::ReturnReason
 } %>

--- a/backend/app/views/spree/admin/return_reasons/new.html.erb
+++ b/backend/app/views/spree/admin/return_reasons/new.html.erb
@@ -1,6 +1,6 @@
 <%= render partial: 'spree/admin/shared/named_types/new', locals: {
   root_tab: Spree.t(:settings),
   sub_tab: Spree.t('admin.tab.checkout'),
-  index_link: link_to(Spree::ReturnReason.model_name.human(count: :other), spree.admin_return_reasons_path),
+  index_link: link_to(plural_resource_name(Spree::ReturnReason), spree.admin_return_reasons_path),
   new_object: Spree.t(:new_rma_reason),
 } %>

--- a/backend/app/views/spree/admin/return_reasons/new.html.erb
+++ b/backend/app/views/spree/admin/return_reasons/new.html.erb
@@ -1,4 +1,6 @@
 <%= render partial: 'spree/admin/shared/named_types/new', locals: {
-  page_title: Spree.t(:new_rma_reason),
-  back_button_text: Spree.t(:back_to_rma_reason_list)
+  root_tab: Spree.t(:settings),
+  sub_tab: Spree.t('admin.tab.checkout'),
+  index_link: link_to(Spree::ReturnReason.model_name.human(count: :other), spree.admin_return_reasons_path),
+  new_object: Spree.t(:new_rma_reason),
 } %>

--- a/backend/app/views/spree/admin/shared/_configuration_menu.html.erb
+++ b/backend/app/views/spree/admin/shared/_configuration_menu.html.erb
@@ -9,7 +9,7 @@
       <% end %>
 
       <% if can?(:display, Spree::Tracker) %>
-        <%= settings_tab_item Spree::Tracker.model_name.human(count: :other), admin_trackers_path %>
+        <%= settings_tab_item plural_resource_name(Spree::Tracker), admin_trackers_path %>
       <% end %>
     </ul>
   </nav>

--- a/backend/app/views/spree/admin/shared/_configuration_menu.html.erb
+++ b/backend/app/views/spree/admin/shared/_configuration_menu.html.erb
@@ -5,11 +5,11 @@
   <nav>
     <ul class="tabs" data-hook="admin_configurations_sidebar_menu">
       <% if can?(:edit, :general_settings) %>
-        <%= settings_tab_item Spree.t(:general), edit_admin_general_settings_path %>
+        <%= settings_tab_item Spree.t(:settings), edit_admin_general_settings_path %>
       <% end %>
 
       <% if can?(:display, Spree::Tracker) %>
-        <%= settings_tab_item Spree.t(:analytics_trackers), spree.admin_trackers_path %>
+        <%= settings_tab_item Spree::Tracker.model_name.human(count: :other), admin_trackers_path %>
       <% end %>
     </ul>
   </nav>

--- a/backend/app/views/spree/admin/shared/_configuration_menu.html.erb
+++ b/backend/app/views/spree/admin/shared/_configuration_menu.html.erb
@@ -5,7 +5,7 @@
   <nav>
     <ul class="tabs" data-hook="admin_configurations_sidebar_menu">
       <% if can?(:edit, :general_settings) %>
-        <%= settings_tab_item Spree.t(:general_settings), spree.edit_admin_general_settings_path %>
+        <%= settings_tab_item Spree.t(:general), edit_admin_general_settings_path %>
       <% end %>
 
       <% if can?(:display, Spree::Tracker) %>

--- a/backend/app/views/spree/admin/shared/_head.html.erb
+++ b/backend/app/views/spree/admin/shared/_head.html.erb
@@ -2,14 +2,7 @@
 
 <%= csrf_meta_tags %>
 
-<title>
-  <% if content_for? :title %>
-    <%= yield :title %>
-  <% else %>
-    <%= "Solidus #{Spree.t('administration')}: " %>
-    <%= Spree.t(controller.controller_name, :default => controller.controller_name.titleize) %>
-  <% end %>
-</title>
+<title><%= page_title %></title>
 
 <!-- Get "Open Sans" font from Google -->
 <link href='//fonts.googleapis.com/css?family=Open+Sans:400italic,600italic,400,600&subset=latin,cyrillic,greek,vietnamese' rel='stylesheet' type='text/css'>

--- a/backend/app/views/spree/admin/shared/_header.html.erb
+++ b/backend/app/views/spree/admin/shared/_header.html.erb
@@ -1,8 +1,6 @@
 <% if content_for?(:page_title) || content_for?(:page_actions) %>
   <div id="content-header" class="main-header" data-hook>
-    <% if content_for?(:page_title) %>
-      <h1 class="page-title"><%= yield :page_title %></h1>
-    <% end %>
+    <%= render_breadcrumbs %>
 
     <% if content_for?(:page_actions) %>
       <ul class="header-actions page-actions inline-menu" data-hook="toolbar">

--- a/backend/app/views/spree/admin/shared/_header.html.erb
+++ b/backend/app/views/spree/admin/shared/_header.html.erb
@@ -1,11 +1,9 @@
-<% if content_for?(:page_title) || content_for?(:page_actions) %>
-  <div id="content-header" class="main-header" data-hook>
-    <%= render_breadcrumbs %>
+<div id="content-header" class="main-header" data-hook>
+  <%= render_breadcrumbs %>
 
-    <% if content_for?(:page_actions) %>
-      <ul class="header-actions page-actions inline-menu" data-hook="toolbar">
-        <%= yield :page_actions %>
-      </ul>
-    <% end %>
-  </div>
-<% end %>
+  <% if content_for?(:page_actions) %>
+    <ul class="header-actions page-actions inline-menu" data-hook="toolbar">
+      <%= yield :page_actions %>
+    </ul>
+  <% end %>
+</div>

--- a/backend/app/views/spree/admin/shared/_order_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_order_tabs.html.erb
@@ -1,4 +1,4 @@
-<% add_breadcrumb(link_to Spree::Order.model_name.human(count: :other), spree.admin_orders_path) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::Order), spree.admin_orders_path) %>
 <% add_breadcrumb(link_to "##{@order.number}", spree.edit_admin_order_path(@order)) %>
 
 

--- a/backend/app/views/spree/admin/shared/_order_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_order_tabs.html.erb
@@ -1,5 +1,6 @@
 <% content_for :page_title do %>
-  <%= link_to "#{Spree::Order.model_name.human} ##{@order.number}", spree.edit_admin_order_path(@order) %>
+  <%= link_to Spree::Order.model_name.human(count: :other), spree.admin_orders_path %> &#x2f;
+  <%= link_to "##{@order.number}", spree.edit_admin_order_path(@order) %>
 <% end %>
 
 <% content_for :sidebar_title do %>

--- a/backend/app/views/spree/admin/shared/_order_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_order_tabs.html.erb
@@ -1,7 +1,6 @@
-<% content_for :page_title do %>
-  <%= link_to Spree::Order.model_name.human(count: :other), spree.admin_orders_path %> &#x2f;
-  <%= link_to "##{@order.number}", spree.edit_admin_order_path(@order) %>
-<% end %>
+<% add_breadcrumb(link_to Spree::Order.model_name.human(count: :other), spree.admin_orders_path) %>
+<% add_breadcrumb(link_to "##{@order.number}", spree.edit_admin_order_path(@order)) %>
+
 
 <% content_for :sidebar_title do %>
   <%= Spree.t(:order_information) %>

--- a/backend/app/views/spree/admin/shared/_product_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_product_tabs.html.erb
@@ -1,4 +1,4 @@
-<% add_breadcrumb(link_to Spree::Product.model_name.human(count: :other), spree.admin_products_path) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::Product), spree.admin_products_path) %>
 <% add_breadcrumb(link_to @product.name, spree.admin_product_path(@product)) %>
 
 <% content_for :tabs do %>

--- a/backend/app/views/spree/admin/shared/_product_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_product_tabs.html.erb
@@ -1,5 +1,6 @@
 <% content_for :page_title do %>
-  <%= plural_resource_name(Spree::Product) %> &#x2f; <%= @product.name %>
+  <%= link_to Spree::Product.model_name.human(count: :other), spree.admin_products_path  %> &#x2f; 
+  <%= link_to @product.name, spree.admin_product_path(@product) %>
 <% end %>
 
 <% content_for :tabs do %>

--- a/backend/app/views/spree/admin/shared/_product_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_product_tabs.html.erb
@@ -1,7 +1,5 @@
-<% content_for :page_title do %>
-  <%= link_to Spree::Product.model_name.human(count: :other), spree.admin_products_path  %> &#x2f; 
-  <%= link_to @product.name, spree.admin_product_path(@product) %>
-<% end %>
+<% add_breadcrumb(link_to Spree::Product.model_name.human(count: :other), spree.admin_products_path) %>
+<% add_breadcrumb(link_to @product.name, spree.admin_product_path(@product)) %>
 
 <% content_for :tabs do %>
   <nav>

--- a/backend/app/views/spree/admin/shared/_shipping_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_shipping_tabs.html.erb
@@ -7,6 +7,7 @@
 
       <% if can?(:display, Spree::ShippingCategory) %>
         <%= settings_tab_item plural_resource_name(Spree::ShippingCategory), spree.admin_shipping_categories_path %>
+
       <% end %>
 
       <% if can?(:display, Spree::StockLocation) %>

--- a/backend/app/views/spree/admin/shared/named_types/_edit.html.erb
+++ b/backend/app/views/spree/admin/shared/named_types/_edit.html.erb
@@ -1,12 +1,13 @@
 <%= render 'spree/admin/shared/settings_checkout_tabs' %>
 
 <% content_for :page_title do %>
-  <%= page_title %> <i class="fa fa-arrow-right"></i>
+  <%= root_tab %> &#x2f;
+  <%= sub_tab %> &#x2f;
+  <%= index_link %> &#x2f;
   <%= @object.name %>
 <% end %>
 
 <% content_for :page_actions do %>
-  <li><%= link_to_with_icon 'arrow-left', back_button_text, collection_url, :class => 'button' %></li>
 <% end %>
 
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @object } %>

--- a/backend/app/views/spree/admin/shared/named_types/_edit.html.erb
+++ b/backend/app/views/spree/admin/shared/named_types/_edit.html.erb
@@ -1,11 +1,10 @@
 <%= render 'spree/admin/shared/settings_checkout_tabs' %>
 
-<% content_for :page_title do %>
-  <%= root_tab %> &#x2f;
-  <%= sub_tab %> &#x2f;
-  <%= index_link %> &#x2f;
-  <%= @object.name %>
-<% end %>
+<% add_breadcrumb(root_tab) %>
+<% add_breadcrumb(sub_tab) %>
+<% add_breadcrumb(index_link) %>
+<% add_breadcrumb(@object.name) %>
+
 
 <% content_for :page_actions do %>
 <% end %>

--- a/backend/app/views/spree/admin/shared/named_types/_index.html.erb
+++ b/backend/app/views/spree/admin/shared/named_types/_index.html.erb
@@ -1,6 +1,8 @@
 <%= render 'spree/admin/shared/settings_checkout_tabs' %>
 
 <% content_for :page_title do %>
+  <%= root_tab %> &#x2f;
+  <%= sub_tab %> &#x2f;
   <%= page_title %>
 <% end %>
 

--- a/backend/app/views/spree/admin/shared/named_types/_index.html.erb
+++ b/backend/app/views/spree/admin/shared/named_types/_index.html.erb
@@ -1,10 +1,9 @@
 <%= render 'spree/admin/shared/settings_checkout_tabs' %>
 
-<% content_for :page_title do %>
-  <%= root_tab %> &#x2f;
-  <%= sub_tab %> &#x2f;
-  <%= page_title %>
-<% end %>
+<% add_breadcrumb(root_tab) %>
+<% add_breadcrumb(sub_tab) %>
+<% add_breadcrumb(page_title) %>
+
 
 <% content_for :page_actions do %>
   <ul class="actions inline-menu">

--- a/backend/app/views/spree/admin/shared/named_types/_new.html.erb
+++ b/backend/app/views/spree/admin/shared/named_types/_new.html.erb
@@ -1,11 +1,13 @@
 <%= render 'spree/admin/shared/settings_checkout_tabs' %>
 
 <% content_for :page_title do %>
-  <%= page_title %>
+  <%= root_tab %> &#x2f;
+  <%= sub_tab %> &#x2f;
+  <%= index_link %> &#x2f;
+  <%= new_object %>
 <% end %>
 
 <% content_for :page_actions do %>
-  <li><%= link_to_with_icon 'arrow-left', back_button_text, collection_url, :class => 'button' %></li>
 <% end %>
 
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @object } %>

--- a/backend/app/views/spree/admin/shared/named_types/_new.html.erb
+++ b/backend/app/views/spree/admin/shared/named_types/_new.html.erb
@@ -1,11 +1,10 @@
 <%= render 'spree/admin/shared/settings_checkout_tabs' %>
 
-<% content_for :page_title do %>
-  <%= root_tab %> &#x2f;
-  <%= sub_tab %> &#x2f;
-  <%= index_link %> &#x2f;
-  <%= new_object %>
-<% end %>
+<% add_breadcrumb(root_tab) %>
+<% add_breadcrumb(sub_tab) %>
+<% add_breadcrumb(index_link) %>
+<% add_breadcrumb(new_object) %>
+
 
 <% content_for :page_actions do %>
 <% end %>

--- a/backend/app/views/spree/admin/shipping_categories/edit.html.erb
+++ b/backend/app/views/spree/admin/shipping_categories/edit.html.erb
@@ -2,7 +2,7 @@
 
 <% add_breadcrumb(Spree.t(:settings)) %>
 <% add_breadcrumb(Spree.t('admin.tab.shipping')) %>
-<% add_breadcrumb(link_to Spree::ShippingCategory.model_name.human(count: :other), spree.admin_shipping_categories_path) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::ShippingCategory), spree.admin_shipping_categories_path) %>
 <% add_breadcrumb(Spree.t(:editing_shipping_category)) %>
 
 

--- a/backend/app/views/spree/admin/shipping_categories/edit.html.erb
+++ b/backend/app/views/spree/admin/shipping_categories/edit.html.erb
@@ -1,11 +1,10 @@
 <%= render 'spree/admin/shared/shipping_tabs' %>
 
-<% content_for :page_title do %>
-  <%= Spree.t(:settings) %> &#x2f;
-  <%= Spree.t('admin.tab.shipping') %> &#x2f;
-  <%= link_to Spree::ShippingCategory.model_name.human(count: :other), spree.admin_shipping_categories_path %> &#x2f;
-  <%= Spree.t(:editing_shipping_category) %>
-<% end %>
+<% add_breadcrumb(Spree.t(:settings)) %>
+<% add_breadcrumb(Spree.t('admin.tab.shipping')) %>
+<% add_breadcrumb(link_to Spree::ShippingCategory.model_name.human(count: :other), spree.admin_shipping_categories_path) %>
+<% add_breadcrumb(Spree.t(:editing_shipping_category)) %>
+
 
 <% content_for :page_actions do %>
 <% end %>

--- a/backend/app/views/spree/admin/shipping_categories/edit.html.erb
+++ b/backend/app/views/spree/admin/shipping_categories/edit.html.erb
@@ -1,13 +1,13 @@
 <%= render 'spree/admin/shared/shipping_tabs' %>
 
 <% content_for :page_title do %>
+  <%= Spree.t(:settings) %> &#x2f;
+  <%= Spree.t('admin.tab.shipping') %> &#x2f;
+  <%= link_to Spree::ShippingCategory.model_name.human(count: :other), spree.admin_shipping_categories_path %> &#x2f;
   <%= Spree.t(:editing_shipping_category) %>
 <% end %>
 
 <% content_for :page_actions do %>
-  <li>
-    <%= button_link_to Spree.t(:back_to_shipping_categories), spree.admin_shipping_categories_path, :icon => 'arrow-left' %>
-  </li>
 <% end %>
 
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @shipping_category } %>

--- a/backend/app/views/spree/admin/shipping_categories/index.html.erb
+++ b/backend/app/views/spree/admin/shipping_categories/index.html.erb
@@ -1,10 +1,9 @@
 <%= render 'spree/admin/shared/shipping_tabs' %>
 
-<% content_for :page_title do %>
-  <%= Spree.t(:settings) %> &#x2f;
-  <%= Spree.t('admin.tab.shipping') %> &#x2f;
-  <%= Spree::ShippingCategory.model_name.human(count: :other) %>
-<% end %>
+<% add_breadcrumb(Spree.t(:settings)) %>
+<% add_breadcrumb(Spree.t('admin.tab.shipping')) %>
+<% add_breadcrumb(Spree::ShippingCategory.model_name.human(count: :other)) %>
+
 
 <% content_for :page_actions do %>
   <% if can?(:create, Spree::ShippingCategory) %>

--- a/backend/app/views/spree/admin/shipping_categories/index.html.erb
+++ b/backend/app/views/spree/admin/shipping_categories/index.html.erb
@@ -1,7 +1,9 @@
 <%= render 'spree/admin/shared/shipping_tabs' %>
 
 <% content_for :page_title do %>
-  <%= plural_resource_name(Spree::ShippingCategory) %>
+  <%= Spree.t(:settings) %> &#x2f;
+  <%= Spree.t('admin.tab.shipping') %> &#x2f;
+  <%= Spree::ShippingCategory.model_name.human(count: :other) %>
 <% end %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/shipping_categories/index.html.erb
+++ b/backend/app/views/spree/admin/shipping_categories/index.html.erb
@@ -2,7 +2,7 @@
 
 <% add_breadcrumb(Spree.t(:settings)) %>
 <% add_breadcrumb(Spree.t('admin.tab.shipping')) %>
-<% add_breadcrumb(Spree::ShippingCategory.model_name.human(count: :other)) %>
+<% add_breadcrumb(plural_resource_name(Spree::ShippingCategory)) %>
 
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/shipping_categories/new.html.erb
+++ b/backend/app/views/spree/admin/shipping_categories/new.html.erb
@@ -2,7 +2,7 @@
 
 <% add_breadcrumb(Spree.t(:settings)) %>
 <% add_breadcrumb(Spree.t('admin.tab.shipping')) %>
-<% add_breadcrumb(link_to Spree::ShippingCategory.model_name.human(count: :other), spree.admin_shipping_categories_path) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::ShippingCategory), spree.admin_shipping_categories_path) %>
 <% add_breadcrumb(Spree.t(:new_shipping_category)) %>
 
 

--- a/backend/app/views/spree/admin/shipping_categories/new.html.erb
+++ b/backend/app/views/spree/admin/shipping_categories/new.html.erb
@@ -1,11 +1,10 @@
 <%= render 'spree/admin/shared/shipping_tabs' %>
 
-<% content_for :page_title do %>
-  <%= Spree.t(:settings) %> &#x2f;
-  <%= Spree.t('admin.tab.shipping') %> &#x2f;
-  <%= link_to Spree::ShippingCategory.model_name.human(count: :other), spree.admin_shipping_categories_path %> &#x2f;
-  <%= Spree.t(:new_shipping_category) %>
-<% end %>
+<% add_breadcrumb(Spree.t(:settings)) %>
+<% add_breadcrumb(Spree.t('admin.tab.shipping')) %>
+<% add_breadcrumb(link_to Spree::ShippingCategory.model_name.human(count: :other), spree.admin_shipping_categories_path) %>
+<% add_breadcrumb(Spree.t(:new_shipping_category)) %>
+
 
 <% content_for :page_actions do %>
 <% end %>

--- a/backend/app/views/spree/admin/shipping_categories/new.html.erb
+++ b/backend/app/views/spree/admin/shipping_categories/new.html.erb
@@ -1,13 +1,13 @@
 <%= render 'spree/admin/shared/shipping_tabs' %>
 
 <% content_for :page_title do %>
+  <%= Spree.t(:settings) %> &#x2f;
+  <%= Spree.t('admin.tab.shipping') %> &#x2f;
+  <%= link_to Spree::ShippingCategory.model_name.human(count: :other), spree.admin_shipping_categories_path %> &#x2f;
   <%= Spree.t(:new_shipping_category) %>
 <% end %>
 
 <% content_for :page_actions do %>
-  <li>
-    <%= button_link_to Spree.t(:back_to_shipping_categories_list), spree.admin_shipping_categories_path, :icon => 'arrow-left' %>
-  </li>
 <% end %>
 
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @shipping_category } %>

--- a/backend/app/views/spree/admin/shipping_methods/edit.html.erb
+++ b/backend/app/views/spree/admin/shipping_methods/edit.html.erb
@@ -2,7 +2,7 @@
 
 <% add_breadcrumb(Spree.t(:settings)) %>
 <% add_breadcrumb(Spree.t('admin.tab.shipping')) %>
-<% add_breadcrumb(link_to Spree::ShippingMethod.model_name.human(count: :other), spree.admin_shipping_methods_path) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::ShippingMethod), spree.admin_shipping_methods_path) %>
 <% add_breadcrumb(@shipping_method.name) %>
 
 

--- a/backend/app/views/spree/admin/shipping_methods/edit.html.erb
+++ b/backend/app/views/spree/admin/shipping_methods/edit.html.erb
@@ -1,11 +1,10 @@
 <%= render 'spree/admin/shared/shipping_tabs' %>
 
-<% content_for :page_title do %>
-  <%= Spree.t(:settings) %> &#x2f;
-  <%= Spree.t('admin.tab.shipping') %> &#x2f;
-  <%= link_to Spree::ShippingMethod.model_name.human(count: :other), spree.admin_shipping_methods_path %> &#x2f;
-  <%= @shipping_method.name %>
-<% end %>
+<% add_breadcrumb(Spree.t(:settings)) %>
+<% add_breadcrumb(Spree.t('admin.tab.shipping')) %>
+<% add_breadcrumb(link_to Spree::ShippingMethod.model_name.human(count: :other), spree.admin_shipping_methods_path) %>
+<% add_breadcrumb(@shipping_method.name) %>
+
 
 <% content_for :page_actions do %>
 <% end %>

--- a/backend/app/views/spree/admin/shipping_methods/edit.html.erb
+++ b/backend/app/views/spree/admin/shipping_methods/edit.html.erb
@@ -1,13 +1,13 @@
 <%= render 'spree/admin/shared/shipping_tabs' %>
 
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_shipping_method) %>
+  <%= Spree.t(:settings) %> &#x2f;
+  <%= Spree.t('admin.tab.shipping') %> &#x2f;
+  <%= link_to Spree::ShippingMethod.model_name.human(count: :other), spree.admin_shipping_methods_path %> &#x2f;
+  <%= @shipping_method.name %>
 <% end %>
 
 <% content_for :page_actions do %>
-  <li>
-    <%= button_link_to Spree.t(:back_to_shipping_methods_list), spree.admin_shipping_methods_path, :icon => 'arrow-left' %>
-  </li>
 <% end %>
 
 <div data-hook="admin_shipping_method_edit_form_header">

--- a/backend/app/views/spree/admin/shipping_methods/index.html.erb
+++ b/backend/app/views/spree/admin/shipping_methods/index.html.erb
@@ -2,7 +2,7 @@
 
 <% add_breadcrumb(Spree.t(:settings)) %>
 <% add_breadcrumb(Spree.t('admin.tab.shipping')) %>
-<% add_breadcrumb(Spree::ShippingMethod.model_name.human(count: :other)) %>
+<% add_breadcrumb(plural_resource_name(Spree::ShippingMethod)) %>
 
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/shipping_methods/index.html.erb
+++ b/backend/app/views/spree/admin/shipping_methods/index.html.erb
@@ -1,7 +1,9 @@
 <%= render 'spree/admin/shared/shipping_tabs' %>
 
 <% content_for :page_title do %>
-  <%= plural_resource_name(Spree::ShippingMethod) %>
+  <%= Spree.t(:settings) %> &#x2f;
+  <%= Spree.t('admin.tab.shipping') %> &#x2f;
+  <%= Spree::ShippingMethod.model_name.human(count: :other) %>
 <% end %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/shipping_methods/index.html.erb
+++ b/backend/app/views/spree/admin/shipping_methods/index.html.erb
@@ -1,10 +1,9 @@
 <%= render 'spree/admin/shared/shipping_tabs' %>
 
-<% content_for :page_title do %>
-  <%= Spree.t(:settings) %> &#x2f;
-  <%= Spree.t('admin.tab.shipping') %> &#x2f;
-  <%= Spree::ShippingMethod.model_name.human(count: :other) %>
-<% end %>
+<% add_breadcrumb(Spree.t(:settings)) %>
+<% add_breadcrumb(Spree.t('admin.tab.shipping')) %>
+<% add_breadcrumb(Spree::ShippingMethod.model_name.human(count: :other)) %>
+
 
 <% content_for :page_actions do %>
   <% if can?(:create, Spree::ShippingMethod) %>
@@ -59,4 +58,3 @@
                  new_resource_url: new_object_url %>
   </div>
 <% end %>
-

--- a/backend/app/views/spree/admin/shipping_methods/new.html.erb
+++ b/backend/app/views/spree/admin/shipping_methods/new.html.erb
@@ -1,13 +1,13 @@
 <%= render 'spree/admin/shared/shipping_tabs' %>
 
 <% content_for :page_title do %>
+  <%= Spree.t(:settings) %> &#x2f;
+  <%= Spree.t('admin.tab.shipping') %> &#x2f;
+  <%= link_to Spree::ShippingMethod.model_name.human(count: :other), spree.admin_shipping_methods_path %> &#x2f;
   <%= Spree.t(:new_shipping_method) %>
 <% end %>
 
 <% content_for :page_actions do %>
-  <li>
-    <%= button_link_to Spree.t(:back_to_shipping_methods_list), spree.admin_shipping_methods_path, :icon => 'arrow-left' %>
-  </li>
 <% end %>
 
 <div data-hook="admin_shipping_method_new_form_header">

--- a/backend/app/views/spree/admin/shipping_methods/new.html.erb
+++ b/backend/app/views/spree/admin/shipping_methods/new.html.erb
@@ -1,11 +1,10 @@
 <%= render 'spree/admin/shared/shipping_tabs' %>
 
-<% content_for :page_title do %>
-  <%= Spree.t(:settings) %> &#x2f;
-  <%= Spree.t('admin.tab.shipping') %> &#x2f;
-  <%= link_to Spree::ShippingMethod.model_name.human(count: :other), spree.admin_shipping_methods_path %> &#x2f;
-  <%= Spree.t(:new_shipping_method) %>
-<% end %>
+<% add_breadcrumb(Spree.t(:settings)) %>
+<% add_breadcrumb(Spree.t('admin.tab.shipping')) %>
+<% add_breadcrumb(link_to Spree::ShippingMethod.model_name.human(count: :other), spree.admin_shipping_methods_path) %>
+<% add_breadcrumb(Spree.t(:new_shipping_method)) %>
+
 
 <% content_for :page_actions do %>
 <% end %>

--- a/backend/app/views/spree/admin/shipping_methods/new.html.erb
+++ b/backend/app/views/spree/admin/shipping_methods/new.html.erb
@@ -2,7 +2,7 @@
 
 <% add_breadcrumb(Spree.t(:settings)) %>
 <% add_breadcrumb(Spree.t('admin.tab.shipping')) %>
-<% add_breadcrumb(link_to Spree::ShippingMethod.model_name.human(count: :other), spree.admin_shipping_methods_path) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::ShippingMethod), spree.admin_shipping_methods_path) %>
 <% add_breadcrumb(Spree.t(:new_shipping_method)) %>
 
 

--- a/backend/app/views/spree/admin/states/edit.html.erb
+++ b/backend/app/views/spree/admin/states/edit.html.erb
@@ -2,7 +2,7 @@
 
 <% add_breadcrumb(Spree.t(:settings)) %>
 <% add_breadcrumb(Spree.t('admin.tab.areas')) %>
-<% add_breadcrumb(link_to Spree::State.model_name.human(count: :other), spree.admin_states_path) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::State), spree.admin_states_path) %>
 <% add_breadcrumb(@state.name) %>
 
 

--- a/backend/app/views/spree/admin/states/edit.html.erb
+++ b/backend/app/views/spree/admin/states/edit.html.erb
@@ -1,13 +1,13 @@
 <%= render 'spree/admin/shared/areas_tabs' %>
 
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_state) %> <i class="fa fa-arrow-right"></i> <%= @state.name %>
+  <%= Spree.t(:settings) %> &#x2f;
+  <%= Spree.t('admin.tab.areas') %> &#x2f;
+  <%= link_to Spree::State.model_name.human(count: :other), spree.admin_states_path %> &#x2f;
+  <%= @state.name %>
 <% end %>
 
 <% content_for :page_actions do %>
-  <li>
-    <%= button_link_to Spree.t(:back_to_states_list), spree.admin_country_states_url(@country), :icon => 'arrow-left' %>
-  </li>
 <% end %>
 
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @state } %>

--- a/backend/app/views/spree/admin/states/edit.html.erb
+++ b/backend/app/views/spree/admin/states/edit.html.erb
@@ -1,11 +1,10 @@
 <%= render 'spree/admin/shared/areas_tabs' %>
 
-<% content_for :page_title do %>
-  <%= Spree.t(:settings) %> &#x2f;
-  <%= Spree.t('admin.tab.areas') %> &#x2f;
-  <%= link_to Spree::State.model_name.human(count: :other), spree.admin_states_path %> &#x2f;
-  <%= @state.name %>
-<% end %>
+<% add_breadcrumb(Spree.t(:settings)) %>
+<% add_breadcrumb(Spree.t('admin.tab.areas')) %>
+<% add_breadcrumb(link_to Spree::State.model_name.human(count: :other), spree.admin_states_path) %>
+<% add_breadcrumb(@state.name) %>
+
 
 <% content_for :page_actions do %>
 <% end %>

--- a/backend/app/views/spree/admin/states/index.html.erb
+++ b/backend/app/views/spree/admin/states/index.html.erb
@@ -1,7 +1,9 @@
 <%= render 'spree/admin/shared/areas_tabs' %>
 
 <% content_for :page_title do %>
-  <%= plural_resource_name(Spree::State) %>
+  <%= Spree.t(:settings) %> &#x2f;
+  <%= Spree.t('admin.tab.areas') %> &#x2f;
+  <%= Spree::State.model_name.human(count: :other) %>
 <% end %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/states/index.html.erb
+++ b/backend/app/views/spree/admin/states/index.html.erb
@@ -2,7 +2,7 @@
 
 <% add_breadcrumb(Spree.t(:settings)) %>
 <% add_breadcrumb(Spree.t('admin.tab.areas')) %>
-<% add_breadcrumb(Spree::State.model_name.human(count: :other)) %>
+<% add_breadcrumb(plural_resource_name(Spree::State)) %>
 
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/states/index.html.erb
+++ b/backend/app/views/spree/admin/states/index.html.erb
@@ -1,10 +1,9 @@
 <%= render 'spree/admin/shared/areas_tabs' %>
 
-<% content_for :page_title do %>
-  <%= Spree.t(:settings) %> &#x2f;
-  <%= Spree.t('admin.tab.areas') %> &#x2f;
-  <%= Spree::State.model_name.human(count: :other) %>
-<% end %>
+<% add_breadcrumb(Spree.t(:settings)) %>
+<% add_breadcrumb(Spree.t('admin.tab.areas')) %>
+<% add_breadcrumb(Spree::State.model_name.human(count: :other)) %>
+
 
 <% content_for :page_actions do %>
   <% if can?(:create, Spree::State) %>

--- a/backend/app/views/spree/admin/states/new.html.erb
+++ b/backend/app/views/spree/admin/states/new.html.erb
@@ -3,6 +3,9 @@
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @state } %>
 
 <% content_for :page_title do %>
+  <%= Spree.t(:settings) %> &#x2f;
+  <%= Spree.t('admin.tab.areas') %> &#x2f;
+  <%= link_to Spree::State.model_name.human(count: :other), spree.admin_states_path %> &#x2f;
   <%= Spree.t(:new_state) %>
 <% end %>
 

--- a/backend/app/views/spree/admin/states/new.html.erb
+++ b/backend/app/views/spree/admin/states/new.html.erb
@@ -4,7 +4,7 @@
 
 <% add_breadcrumb(Spree.t(:settings)) %>
 <% add_breadcrumb(Spree.t('admin.tab.areas')) %>
-<% add_breadcrumb(link_to Spree::State.model_name.human(count: :other), spree.admin_states_path) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::State), spree.admin_states_path) %>
 <% add_breadcrumb(Spree.t(:new_state)) %>
 
 

--- a/backend/app/views/spree/admin/states/new.html.erb
+++ b/backend/app/views/spree/admin/states/new.html.erb
@@ -2,12 +2,11 @@
 
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @state } %>
 
-<% content_for :page_title do %>
-  <%= Spree.t(:settings) %> &#x2f;
-  <%= Spree.t('admin.tab.areas') %> &#x2f;
-  <%= link_to Spree::State.model_name.human(count: :other), spree.admin_states_path %> &#x2f;
-  <%= Spree.t(:new_state) %>
-<% end %>
+<% add_breadcrumb(Spree.t(:settings)) %>
+<% add_breadcrumb(Spree.t('admin.tab.areas')) %>
+<% add_breadcrumb(link_to Spree::State.model_name.human(count: :other), spree.admin_states_path) %>
+<% add_breadcrumb(Spree.t(:new_state)) %>
+
 
 <%= form_for [:admin, @country, @state] do |f| %>
   <fieldset>

--- a/backend/app/views/spree/admin/stock_items/index.html.erb
+++ b/backend/app/views/spree/admin/stock_items/index.html.erb
@@ -1,14 +1,12 @@
 <% if @product %>
   <%= render :partial => 'spree/admin/shared/product_tabs', :locals => { :current => 'Stock Management' } %>
   <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @product } %>
-  <% content_for :page_title do %>
-    &#x2f; <%= Spree.t(:manage_stock) %>
-  <% end %>
+  <% add_breadcrumb(Spree.t(:manage_stock)) %>
+
 <% else %>
 
-  <% content_for :page_title do %>
-    <%= Spree.t(:stock) %>
-  <% end %>
+  <% add_breadcrumb(Spree.t(:stock)) %>
+
 <% end %>
 
 <% content_for :table_filter_title do %>

--- a/backend/app/views/spree/admin/stock_items/index.html.erb
+++ b/backend/app/views/spree/admin/stock_items/index.html.erb
@@ -1,14 +1,13 @@
 <% if @product %>
-  <% content_for :page_actions do %>
-    <li><%= button_link_to Spree.t(:back_to_products_list), session[:return_to] || admin_products_url, :icon => 'arrow-left' %></li>
-  <% end %>
-
   <%= render :partial => 'spree/admin/shared/product_tabs', :locals => { :current => 'Stock Management' } %>
   <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @product } %>
+  <% content_for :page_title do %>
+    &#x2f; <%= Spree.t(:manage_stock) %>
+  <% end %>
 <% else %>
 
   <% content_for :page_title do %>
-    <%= Spree.t(:manage_stock) %>
+    <%= Spree.t(:stock) %>
   <% end %>
 <% end %>
 

--- a/backend/app/views/spree/admin/stock_locations/edit.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/edit.html.erb
@@ -1,11 +1,10 @@
 <%= render 'spree/admin/shared/shipping_tabs' %>
 
-<% content_for :page_title do %>
-  <%= Spree.t(:settings) %> &#x2f;
-  <%= Spree.t('admin.tab.shipping') %> &#x2f;
-  <%= link_to Spree::StockLocation.model_name.human(count: :other), spree.admin_stock_locations_path %> &#x2f;
-  <%= @stock_location.name %>
-<% end %>
+<% add_breadcrumb(Spree.t(:settings)) %>
+<% add_breadcrumb(Spree.t('admin.tab.shipping')) %>
+<% add_breadcrumb(link_to Spree::StockLocation.model_name.human(count: :other), spree.admin_stock_locations_path) %>
+<% add_breadcrumb(@stock_location.name) %>
+
 
 <% content_for :page_actions do %>
 <% end %>

--- a/backend/app/views/spree/admin/stock_locations/edit.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/edit.html.erb
@@ -1,12 +1,13 @@
 <%= render 'spree/admin/shared/shipping_tabs' %>
 
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_stock_location) %> <i class="fa fa-arrow-right"></i>
+  <%= Spree.t(:settings) %> &#x2f;
+  <%= Spree.t('admin.tab.shipping') %> &#x2f;
+  <%= link_to Spree::StockLocation.model_name.human(count: :other), spree.admin_stock_locations_path %> &#x2f;
   <%= @stock_location.name %>
 <% end %>
 
 <% content_for :page_actions do %>
-  <li><%= link_to_with_icon 'arrow-left', Spree.t(:back_to_stock_locations_list), admin_stock_locations_path, :class => 'button' %></li>
 <% end %>
 
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @stock_location } %>

--- a/backend/app/views/spree/admin/stock_locations/edit.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/edit.html.erb
@@ -2,7 +2,7 @@
 
 <% add_breadcrumb(Spree.t(:settings)) %>
 <% add_breadcrumb(Spree.t('admin.tab.shipping')) %>
-<% add_breadcrumb(link_to Spree::StockLocation.model_name.human(count: :other), spree.admin_stock_locations_path) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::StockLocation), spree.admin_stock_locations_path) %>
 <% add_breadcrumb(@stock_location.name) %>
 
 

--- a/backend/app/views/spree/admin/stock_locations/index.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/index.html.erb
@@ -2,7 +2,7 @@
 
 <% add_breadcrumb(Spree.t(:settings)) %>
 <% add_breadcrumb(Spree.t('admin.tab.shipping')) %>
-<% add_breadcrumb(Spree::StockLocation.model_name.human(count: :other)) %>
+<% add_breadcrumb(plural_resource_name(Spree::StockLocation)) %>
 
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/stock_locations/index.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/index.html.erb
@@ -1,10 +1,9 @@
 <%= render 'spree/admin/shared/shipping_tabs' %>
 
-<% content_for :page_title do %>
-  <%= Spree.t(:settings) %> &#x2f;
-  <%= Spree.t('admin.tab.shipping') %> &#x2f;
-  <%= Spree::StockLocation.model_name.human(count: :other) %>
-<% end %>
+<% add_breadcrumb(Spree.t(:settings)) %>
+<% add_breadcrumb(Spree.t('admin.tab.shipping')) %>
+<% add_breadcrumb(Spree::StockLocation.model_name.human(count: :other)) %>
+
 
 <% content_for :page_actions do %>
   <ul class="actions inline-menu">

--- a/backend/app/views/spree/admin/stock_locations/index.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/index.html.erb
@@ -1,7 +1,9 @@
 <%= render 'spree/admin/shared/shipping_tabs' %>
 
 <% content_for :page_title do %>
-  <%= plural_resource_name(Spree::StockLocation) %>
+  <%= Spree.t(:settings) %> &#x2f;
+  <%= Spree.t('admin.tab.shipping') %> &#x2f;
+  <%= Spree::StockLocation.model_name.human(count: :other) %>
 <% end %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/stock_locations/new.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/new.html.erb
@@ -1,11 +1,10 @@
 <%= render 'spree/admin/shared/shipping_tabs' %>
 
-<% content_for :page_title do %>
-  <%= Spree.t(:settings) %> &#x2f;
-  <%= Spree.t('admin.tab.shipping') %> &#x2f;
-  <%= link_to Spree::StockLocation.model_name.human(count: :other), spree.admin_stock_locations_path %> &#x2f;
-  <%= Spree.t(:new_stock_location) %>
-<% end %>
+<% add_breadcrumb(Spree.t(:settings)) %>
+<% add_breadcrumb(Spree.t('admin.tab.shipping')) %>
+<% add_breadcrumb(link_to Spree::StockLocation.model_name.human(count: :other), spree.admin_stock_locations_path) %>
+<% add_breadcrumb(Spree.t(:new_stock_location)) %>
+
 
 <% content_for :page_actions do %>
 <% end %>

--- a/backend/app/views/spree/admin/stock_locations/new.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/new.html.erb
@@ -1,11 +1,13 @@
 <%= render 'spree/admin/shared/shipping_tabs' %>
 
 <% content_for :page_title do %>
+  <%= Spree.t(:settings) %> &#x2f;
+  <%= Spree.t('admin.tab.shipping') %> &#x2f;
+  <%= link_to Spree::StockLocation.model_name.human(count: :other), spree.admin_stock_locations_path %> &#x2f;
   <%= Spree.t(:new_stock_location) %>
 <% end %>
 
 <% content_for :page_actions do %>
-  <li><%= link_to_with_icon 'arrow-left', Spree.t(:back_to_stock_locations_list), admin_stock_locations_path, :class => 'button' %></li>
 <% end %>
 
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @stock_locations } %>

--- a/backend/app/views/spree/admin/stock_locations/new.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/new.html.erb
@@ -2,7 +2,7 @@
 
 <% add_breadcrumb(Spree.t(:settings)) %>
 <% add_breadcrumb(Spree.t('admin.tab.shipping')) %>
-<% add_breadcrumb(link_to Spree::StockLocation.model_name.human(count: :other), spree.admin_stock_locations_path) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::StockLocation), spree.admin_stock_locations_path) %>
 <% add_breadcrumb(Spree.t(:new_stock_location)) %>
 
 

--- a/backend/app/views/spree/admin/stock_movements/index.html.erb
+++ b/backend/app/views/spree/admin/stock_movements/index.html.erb
@@ -1,8 +1,7 @@
 <%= render 'spree/admin/shared/shipping_tabs' %>
 
-<% content_for :page_title do %>
-  <%= Spree.t(:stock_movements_for_stock_location, stock_location_name: @stock_location.name) %>
-<% end %>
+<% add_breadcrumb(Spree.t(:stock_movements_for_stock_location, stock_location_name: @stock_location.name)) %>
+
 
 <% content_for :page_actions do %>
   <% if can?(:create, Spree::StockMovement) %>

--- a/backend/app/views/spree/admin/stock_movements/new.html.erb
+++ b/backend/app/views/spree/admin/stock_movements/new.html.erb
@@ -1,6 +1,5 @@
-<% content_for :page_title do %>
-  <%= Spree.t(:new_stock_movement) %>
-<% end %>
+<% add_breadcrumb(Spree.t(:new_stock_movement)) %>
+
 
 <% content_for :page_actions do %>
   <li><%= link_to_with_icon 'arrow-left', Spree.t(:back_to_stock_movements_list), admin_stock_location_stock_movements_path(@stock_location), :class => 'button' %></li>

--- a/backend/app/views/spree/admin/stock_transfers/edit.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/edit.html.erb
@@ -1,8 +1,7 @@
-<%content_for :page_title do %>
-  <%= link_to Spree.t(:stock), spree.admin_stock_items_path %> &#x2f;
-  <%= link_to Spree::StockTransfer.model_name.human(count: :other), spree.admin_stock_transfers_path %> &#x2f;
-  <%= "#{@stock_transfer.number}" %>
-<% end %>
+<% add_breadcrumb(link_to Spree.t(:stock), spree.admin_stock_items_path) %>
+<% add_breadcrumb(link_to Spree::StockTransfer.model_name.human(count: :other), spree.admin_stock_transfers_path) %>
+<% add_breadcrumb(@stock_transfer.number) %>
+
 
 <% content_for :page_actions do %>
   <li>

--- a/backend/app/views/spree/admin/stock_transfers/edit.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/edit.html.erb
@@ -1,5 +1,5 @@
 <% add_breadcrumb(link_to Spree.t(:stock), spree.admin_stock_items_path) %>
-<% add_breadcrumb(link_to Spree::StockTransfer.model_name.human(count: :other), spree.admin_stock_transfers_path) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::StockTransfer), spree.admin_stock_transfers_path) %>
 <% add_breadcrumb(@stock_transfer.number) %>
 
 

--- a/backend/app/views/spree/admin/stock_transfers/edit.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/edit.html.erb
@@ -1,10 +1,11 @@
 <%content_for :page_title do %>
-  <%= "#{Spree.t(:editing_stock_transfer)} #{@stock_transfer.number}" %>
+  <%= link_to Spree.t(:stock), spree.admin_stock_items_path %> &#x2f;
+  <%= link_to Spree::StockTransfer.model_name.human(count: :other), spree.admin_stock_transfers_path %> &#x2f;
+  <%= "#{@stock_transfer.number}" %>
 <% end %>
 
 <% content_for :page_actions do %>
   <li>
-    <%= button_link_to Spree.t(:back_to_stock_transfers_list), admin_stock_transfers_path, icon: 'arrow-left' %>
   </li>
   <li>
     <%= button_link_to Spree.t(:ready_to_ship),

--- a/backend/app/views/spree/admin/stock_transfers/index.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/index.html.erb
@@ -1,5 +1,6 @@
 <% content_for :page_title do %>
-  <%= plural_resource_name(Spree::StockTransfer) %>
+  <%= link_to Spree.t(:stock), spree.admin_stock_items_path %> &#x2f;
+  <%= Spree::StockTransfer.model_name.human(count: :other) %>
 <% end %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/stock_transfers/index.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/index.html.erb
@@ -1,5 +1,5 @@
 <% add_breadcrumb(link_to Spree.t(:stock), spree.admin_stock_items_path) %>
-<% add_breadcrumb(Spree::StockTransfer.model_name.human(count: :other)) %>
+<% add_breadcrumb(plural_resource_name(Spree::StockTransfer)) %>
 
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/stock_transfers/index.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/index.html.erb
@@ -1,7 +1,6 @@
-<% content_for :page_title do %>
-  <%= link_to Spree.t(:stock), spree.admin_stock_items_path %> &#x2f;
-  <%= Spree::StockTransfer.model_name.human(count: :other) %>
-<% end %>
+<% add_breadcrumb(link_to Spree.t(:stock), spree.admin_stock_items_path) %>
+<% add_breadcrumb(Spree::StockTransfer.model_name.human(count: :other)) %>
+
 
 <% content_for :page_actions do %>
   <% if can? :create, Spree::StockTransfer %>

--- a/backend/app/views/spree/admin/stock_transfers/new.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/new.html.erb
@@ -1,11 +1,10 @@
 <% content_for :page_title do %>
+  <%= link_to Spree.t(:stock), spree.admin_stock_items_path %> &#x2f;
+  <%= link_to Spree::StockTransfer.model_name.human(count: :other), spree.admin_stock_transfers_path %> &#x2f;
   <%= Spree.t(:new_stock_transfer) %>
 <% end %>
 
 <% content_for :page_actions do %>
-  <li>
-    <%= button_link_to Spree.t(:back_to_stock_transfers_list), admin_stock_transfers_path, icon: 'arrow-left' %>
-  </li>
 <% end %>
 
 <%= form_for [:admin, @stock_transfer] do |f| %>

--- a/backend/app/views/spree/admin/stock_transfers/new.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/new.html.erb
@@ -1,8 +1,7 @@
-<% content_for :page_title do %>
-  <%= link_to Spree.t(:stock), spree.admin_stock_items_path %> &#x2f;
-  <%= link_to Spree::StockTransfer.model_name.human(count: :other), spree.admin_stock_transfers_path %> &#x2f;
-  <%= Spree.t(:new_stock_transfer) %>
-<% end %>
+<% add_breadcrumb(link_to Spree.t(:stock), spree.admin_stock_items_path) %>
+<% add_breadcrumb(link_to Spree::StockTransfer.model_name.human(count: :other), spree.admin_stock_transfers_path) %>
+<% add_breadcrumb(Spree.t(:new_stock_transfer)) %>
+
 
 <% content_for :page_actions do %>
 <% end %>

--- a/backend/app/views/spree/admin/stock_transfers/new.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/new.html.erb
@@ -1,5 +1,5 @@
 <% add_breadcrumb(link_to Spree.t(:stock), spree.admin_stock_items_path) %>
-<% add_breadcrumb(link_to Spree::StockTransfer.model_name.human(count: :other), spree.admin_stock_transfers_path) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::StockTransfer), spree.admin_stock_transfers_path) %>
 <% add_breadcrumb(Spree.t(:new_stock_transfer)) %>
 
 

--- a/backend/app/views/spree/admin/stock_transfers/receive.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/receive.html.erb
@@ -1,6 +1,5 @@
-<% content_for :page_title do %>
-  <%= "#{Spree.t(:receiving)} #{@stock_transfer.number}" %>
-<% end %>
+<% add_breadcrumb("#{Spree.t(:receiving)} #{@stock_transfer.number}") %>
+
 
 <% content_for :page_actions do %>
   <li>

--- a/backend/app/views/spree/admin/stock_transfers/show.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/show.html.erb
@@ -1,4 +1,5 @@
 <% content_for :page_title do %>
+  <%= link_to Spree.t(:stock), spree.admin_stock_items_path %> &#x2f;
   <%= Spree::StockTransfer.model_name.human %> <%= @stock_transfer.number %>
 <% end %>
 

--- a/backend/app/views/spree/admin/stock_transfers/show.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/show.html.erb
@@ -1,7 +1,6 @@
-<% content_for :page_title do %>
-  <%= link_to Spree.t(:stock), spree.admin_stock_items_path %> &#x2f;
-  <%= Spree::StockTransfer.model_name.human %> <%= @stock_transfer.number %>
-<% end %>
+<% add_breadcrumb(link_to Spree.t(:stock), spree.admin_stock_items_path) %>
+<% add_breadcrumb(Spree::StockTransfer.model_name.human, @stock_transfer.number) %>
+
 
 <% content_for :page_actions do %>
   <li>

--- a/backend/app/views/spree/admin/stock_transfers/tracking_info.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/tracking_info.html.erb
@@ -1,6 +1,5 @@
-<% content_for :page_title do %>
-  <%= "#{Spree.t('actions.ship')} #{Spree::StockTransfer.model_name.human} \##{@stock_transfer.number}" %>
-<% end %>
+<% add_breadcrumb("#{Spree.t('actions.ship')} #{Spree::StockTransfer.model_name.human} \##{@stock_transfer.number}") %>
+
 
 <% content_for :page_actions do %>
   <li>

--- a/backend/app/views/spree/admin/store_credits/edit_amount.html.erb
+++ b/backend/app/views/spree/admin/store_credits/edit_amount.html.erb
@@ -1,6 +1,6 @@
-<% add_breadcrumb(link_to Spree::LegacyUser.model_name.human(count: :other), spree.admin_users_path) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::LegacyUser), spree.admin_users_path) %>
 <% add_breadcrumb(link_to @user.email, edit_admin_user_url(@user)) %>
-<% add_breadcrumb(link_to Spree::StoreCredit.model_name.human(count: :other), spree.admin_user_store_credits_path(@user)) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::StoreCredit), spree.admin_user_store_credits_path(@user)) %>
 <% add_breadcrumb(link_to Spree::StoreCredit.model_name.human, admin_user_store_credit_path(@user, @store_credit)) %>
 <% add_breadcrumb(Spree.t(:edit)) %>
 

--- a/backend/app/views/spree/admin/store_credits/edit_amount.html.erb
+++ b/backend/app/views/spree/admin/store_credits/edit_amount.html.erb
@@ -1,11 +1,14 @@
 <% content_for :page_title do %>
-  <%= link_to "#{Spree.t(:editing_user)} #{@user.email}", edit_admin_user_url(@user) %>
+  <%= link_to Spree::LegacyUser.model_name.human(count: :other), spree.admin_users_path %> &#x2f;
+  <%= link_to @user.email, edit_admin_user_url(@user) %> &#x2f;
+  <%= link_to Spree::StoreCredit.model_name.human(count: :other), spree.admin_user_store_credits_path(@user) %> &#x2f;
+  <%= link_to Spree::StoreCredit.model_name.human, admin_user_store_credit_path(@user, @store_credit) %> &#x2f;
+  <%= Spree.t(:edit) %>
 <% end %>
 
 <%= render 'spree/admin/users/sidebar' %>
 <%= render 'spree/admin/users/tabs', current: :store_credits %>
 <% content_for :page_actions do %>
-  <li><%= link_to_with_icon 'arrow-left', Spree.t("admin.store_credits.back_to_edit"), admin_user_store_credit_path(@user, @store_credit), class: 'button' %></li>
 <% end %>
 
 <%= form_for [:admin, @user, @store_credit], url: update_amount_admin_user_store_credit_path, method: :put do |f| %>

--- a/backend/app/views/spree/admin/store_credits/edit_amount.html.erb
+++ b/backend/app/views/spree/admin/store_credits/edit_amount.html.erb
@@ -1,10 +1,9 @@
-<% content_for :page_title do %>
-  <%= link_to Spree::LegacyUser.model_name.human(count: :other), spree.admin_users_path %> &#x2f;
-  <%= link_to @user.email, edit_admin_user_url(@user) %> &#x2f;
-  <%= link_to Spree::StoreCredit.model_name.human(count: :other), spree.admin_user_store_credits_path(@user) %> &#x2f;
-  <%= link_to Spree::StoreCredit.model_name.human, admin_user_store_credit_path(@user, @store_credit) %> &#x2f;
-  <%= Spree.t(:edit) %>
-<% end %>
+<% add_breadcrumb(link_to Spree::LegacyUser.model_name.human(count: :other), spree.admin_users_path) %>
+<% add_breadcrumb(link_to @user.email, edit_admin_user_url(@user)) %>
+<% add_breadcrumb(link_to Spree::StoreCredit.model_name.human(count: :other), spree.admin_user_store_credits_path(@user)) %>
+<% add_breadcrumb(link_to Spree::StoreCredit.model_name.human, admin_user_store_credit_path(@user, @store_credit)) %>
+<% add_breadcrumb(Spree.t(:edit)) %>
+
 
 <%= render 'spree/admin/users/sidebar' %>
 <%= render 'spree/admin/users/tabs', current: :store_credits %>

--- a/backend/app/views/spree/admin/store_credits/edit_validity.html.erb
+++ b/backend/app/views/spree/admin/store_credits/edit_validity.html.erb
@@ -1,6 +1,6 @@
-<% add_breadcrumb(link_to Spree::LegacyUser.model_name.human(count: :other), spree.admin_users_path) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::LegacyUser), spree.admin_users_path) %>
 <% add_breadcrumb(link_to @user.email, edit_admin_user_url(@user)) %>
-<% add_breadcrumb(link_to Spree::StoreCredit.model_name.human(count: :other), spree.admin_user_store_credits_path(@user)) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::StoreCredit), spree.admin_user_store_credits_path(@user)) %>
 <% add_breadcrumb(link_to Spree::StoreCredit.model_name.human, admin_user_store_credit_path(@user, @store_credit)) %>
 <% add_breadcrumb(Spree.t(:edit)) %>
 

--- a/backend/app/views/spree/admin/store_credits/edit_validity.html.erb
+++ b/backend/app/views/spree/admin/store_credits/edit_validity.html.erb
@@ -1,11 +1,14 @@
 <% content_for :page_title do %>
-  <%= link_to "#{Spree.t(:editing_user)} #{@user.email}", edit_admin_user_url(@user) %>
+  <%= link_to Spree::LegacyUser.model_name.human(count: :other), spree.admin_users_path %> &#x2f;
+  <%= link_to @user.email, edit_admin_user_url(@user) %> &#x2f;
+  <%= link_to Spree::StoreCredit.model_name.human(count: :other), spree.admin_user_store_credits_path(@user) %> &#x2f;
+  <%= link_to Spree::StoreCredit.model_name.human, admin_user_store_credit_path(@user, @store_credit) %> &#x2f;
+  <%= Spree.t(:edit) %>
 <% end %>
 
 <%= render 'spree/admin/users/sidebar' %>
 <%= render 'spree/admin/users/tabs', current: :store_credits %>
 <% content_for :page_actions do %>
-  <li><%= link_to_with_icon 'arrow-left', Spree.t("admin.store_credits.back_to_edit"), admin_user_store_credit_path(@user, @store_credit), class: 'button' %></li>
 <% end %>
 
 <%= form_for [:admin, @user, @store_credit], url: invalidate_admin_user_store_credit_path, method: :put do |f| %>

--- a/backend/app/views/spree/admin/store_credits/edit_validity.html.erb
+++ b/backend/app/views/spree/admin/store_credits/edit_validity.html.erb
@@ -1,10 +1,9 @@
-<% content_for :page_title do %>
-  <%= link_to Spree::LegacyUser.model_name.human(count: :other), spree.admin_users_path %> &#x2f;
-  <%= link_to @user.email, edit_admin_user_url(@user) %> &#x2f;
-  <%= link_to Spree::StoreCredit.model_name.human(count: :other), spree.admin_user_store_credits_path(@user) %> &#x2f;
-  <%= link_to Spree::StoreCredit.model_name.human, admin_user_store_credit_path(@user, @store_credit) %> &#x2f;
-  <%= Spree.t(:edit) %>
-<% end %>
+<% add_breadcrumb(link_to Spree::LegacyUser.model_name.human(count: :other), spree.admin_users_path) %>
+<% add_breadcrumb(link_to @user.email, edit_admin_user_url(@user)) %>
+<% add_breadcrumb(link_to Spree::StoreCredit.model_name.human(count: :other), spree.admin_user_store_credits_path(@user)) %>
+<% add_breadcrumb(link_to Spree::StoreCredit.model_name.human, admin_user_store_credit_path(@user, @store_credit)) %>
+<% add_breadcrumb(Spree.t(:edit)) %>
+
 
 <%= render 'spree/admin/users/sidebar' %>
 <%= render 'spree/admin/users/tabs', current: :store_credits %>

--- a/backend/app/views/spree/admin/store_credits/index.html.erb
+++ b/backend/app/views/spree/admin/store_credits/index.html.erb
@@ -1,8 +1,7 @@
-<% content_for :page_title do %>
-  <%= link_to Spree::LegacyUser.model_name.human(count: :other), spree.admin_users_path %> &#x2f;
-  <%= link_to @user.email, edit_admin_user_url(@user) %> &#x2f;
-  <%= Spree::StoreCredit.model_name.human %>
-<% end %>
+<% add_breadcrumb(link_to Spree::LegacyUser.model_name.human(count: :other), spree.admin_users_path) %>
+<% add_breadcrumb(link_to @user.email, edit_admin_user_url(@user)) %>
+<% add_breadcrumb(Spree::StoreCredit.model_name.human) %>
+
 
 <%= render 'spree/admin/users/sidebar' %>
 <%= render 'spree/admin/users/tabs', current: :store_credits %>

--- a/backend/app/views/spree/admin/store_credits/index.html.erb
+++ b/backend/app/views/spree/admin/store_credits/index.html.erb
@@ -1,11 +1,12 @@
 <% content_for :page_title do %>
-  <%= link_to "#{Spree.t(:editing_user)} #{@user.email}", edit_admin_user_url(@user) %>
+  <%= link_to Spree::LegacyUser.model_name.human(count: :other), spree.admin_users_path %> &#x2f;
+  <%= link_to @user.email, edit_admin_user_url(@user) %> &#x2f;
+  <%= Spree::StoreCredit.model_name.human %>
 <% end %>
 
 <%= render 'spree/admin/users/sidebar' %>
 <%= render 'spree/admin/users/tabs', current: :store_credits %>
 <% content_for :page_actions do %>
-  <li><%= link_to_with_icon 'arrow-left', Spree.t("admin.store_credits.back_to_user_list"), admin_users_path, class: 'button' %></li>
   <% if can?(:create, Spree::StoreCredit) %>
     <li><%= link_to_with_icon 'plus', Spree.t("admin.store_credits.add"), new_admin_user_store_credit_path(@user), class: 'button' %></li>
   <% end %>

--- a/backend/app/views/spree/admin/store_credits/index.html.erb
+++ b/backend/app/views/spree/admin/store_credits/index.html.erb
@@ -1,4 +1,4 @@
-<% add_breadcrumb(link_to Spree::LegacyUser.model_name.human(count: :other), spree.admin_users_path) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::LegacyUser), spree.admin_users_path) %>
 <% add_breadcrumb(link_to @user.email, edit_admin_user_url(@user)) %>
 <% add_breadcrumb(Spree::StoreCredit.model_name.human) %>
 

--- a/backend/app/views/spree/admin/store_credits/new.html.erb
+++ b/backend/app/views/spree/admin/store_credits/new.html.erb
@@ -1,9 +1,8 @@
-<% content_for :page_title do %>
-  <%= link_to Spree::LegacyUser.model_name.human(count: :other), spree.admin_users_path %> &#x2f;
-  <%= link_to @user.email, edit_admin_user_url(@user) %> &#x2f;
-  <%= link_to Spree::StoreCredit.model_name.human, spree.admin_user_store_credits_path(@user) %> &#x2f;
-  <%= Spree.t(:new_store_credit) %>
-<% end %>
+<% add_breadcrumb(link_to Spree::LegacyUser.model_name.human(count: :other), spree.admin_users_path) %>
+<% add_breadcrumb(link_to @user.email, edit_admin_user_url(@user)) %>
+<% add_breadcrumb(link_to Spree::StoreCredit.model_name.human, spree.admin_user_store_credits_path(@user)) %>
+<% add_breadcrumb(Spree.t(:new_store_credit)) %>
+
 
 <%= render 'spree/admin/users/sidebar' %>
 <%= render 'spree/admin/users/tabs', current: :store_credits %>

--- a/backend/app/views/spree/admin/store_credits/new.html.erb
+++ b/backend/app/views/spree/admin/store_credits/new.html.erb
@@ -1,4 +1,4 @@
-<% add_breadcrumb(link_to Spree::LegacyUser.model_name.human(count: :other), spree.admin_users_path) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::LegacyUser), spree.admin_users_path) %>
 <% add_breadcrumb(link_to @user.email, edit_admin_user_url(@user)) %>
 <% add_breadcrumb(link_to Spree::StoreCredit.model_name.human, spree.admin_user_store_credits_path(@user)) %>
 <% add_breadcrumb(Spree.t(:new_store_credit)) %>

--- a/backend/app/views/spree/admin/store_credits/new.html.erb
+++ b/backend/app/views/spree/admin/store_credits/new.html.erb
@@ -1,11 +1,13 @@
 <% content_for :page_title do %>
-  <%= link_to "#{Spree.t(:editing_user)} #{@user.email}", edit_admin_user_url(@user) %>
+  <%= link_to Spree::LegacyUser.model_name.human(count: :other), spree.admin_users_path %> &#x2f;
+  <%= link_to @user.email, edit_admin_user_url(@user) %> &#x2f;
+  <%= link_to Spree::StoreCredit.model_name.human, spree.admin_user_store_credits_path(@user) %> &#x2f;
+  <%= Spree.t(:new_store_credit) %>
 <% end %>
 
 <%= render 'spree/admin/users/sidebar' %>
 <%= render 'spree/admin/users/tabs', current: :store_credits %>
 <% content_for :page_actions do %>
-  <li><%= link_to_with_icon 'arrow-left', Spree.t("admin.store_credits.back_to_store_credit_list"), admin_user_store_credits_path(@user), class: 'button' %></li>
 <% end %>
 
 <%= form_for [:admin, @user, @store_credit] do |f| %>

--- a/backend/app/views/spree/admin/store_credits/show.html.erb
+++ b/backend/app/views/spree/admin/store_credits/show.html.erb
@@ -1,9 +1,8 @@
-<% content_for :page_title do %>
-  <%= link_to Spree::LegacyUser.model_name.human(count: :other), spree.admin_users_path %> &#x2f;
-  <%= link_to @user.email, edit_admin_user_url(@user) %> &#x2f;
-  <%= link_to Spree::StoreCredit.model_name.human, spree.admin_user_store_credits_path(@user) %> &#x2f;
-  <%= @store_credit.display_amount.to_html %>
-<% end %>
+<% add_breadcrumb(link_to Spree::LegacyUser.model_name.human(count: :other), spree.admin_users_path) %>
+<% add_breadcrumb(link_to @user.email, edit_admin_user_url(@user)) %>
+<% add_breadcrumb(link_to Spree::StoreCredit.model_name.human, spree.admin_user_store_credits_path(@user)) %>
+<% add_breadcrumb(@store_credit.display_amount.to_html) %>
+
 
 <%= render 'spree/admin/users/sidebar' %>
 <%= render 'spree/admin/users/tabs', current: :store_credits %>

--- a/backend/app/views/spree/admin/store_credits/show.html.erb
+++ b/backend/app/views/spree/admin/store_credits/show.html.erb
@@ -1,4 +1,4 @@
-<% add_breadcrumb(link_to Spree::LegacyUser.model_name.human(count: :other), spree.admin_users_path) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::LegacyUser), spree.admin_users_path) %>
 <% add_breadcrumb(link_to @user.email, edit_admin_user_url(@user)) %>
 <% add_breadcrumb(link_to Spree::StoreCredit.model_name.human, spree.admin_user_store_credits_path(@user)) %>
 <% add_breadcrumb(@store_credit.display_amount.to_html) %>

--- a/backend/app/views/spree/admin/store_credits/show.html.erb
+++ b/backend/app/views/spree/admin/store_credits/show.html.erb
@@ -1,11 +1,13 @@
 <% content_for :page_title do %>
-  <%= link_to "#{Spree.t(:editing_user)} #{@user.email}", edit_admin_user_url(@user) %>
+  <%= link_to Spree::LegacyUser.model_name.human(count: :other), spree.admin_users_path %> &#x2f;
+  <%= link_to @user.email, edit_admin_user_url(@user) %> &#x2f;
+  <%= link_to Spree::StoreCredit.model_name.human, spree.admin_user_store_credits_path(@user) %> &#x2f;
+  <%= @store_credit.display_amount.to_html %>
 <% end %>
 
 <%= render 'spree/admin/users/sidebar' %>
 <%= render 'spree/admin/users/tabs', current: :store_credits %>
 <% content_for :page_actions do %>
-  <li><%= link_to_with_icon 'arrow-left', Spree.t("admin.store_credits.back_to_store_credit_list"), admin_user_store_credits_path(@user), class: 'button' %></li>
   <% if @store_credit.editable? && can?(:edit, @store_credit) %>
     <li><%= link_to_with_icon 'dollar', Spree.t("admin.store_credits.change_amount"), edit_amount_admin_user_store_credit_path(@user, @store_credit), class: 'button' %></li>
   <% end %>

--- a/backend/app/views/spree/admin/tax_categories/edit.html.erb
+++ b/backend/app/views/spree/admin/tax_categories/edit.html.erb
@@ -1,11 +1,10 @@
 <%= render 'spree/admin/shared/taxes_tabs' %>
 
-<% content_for :page_title do %>
-  <%= Spree.t(:settings) %> &#x2f;
-  <%= Spree.t('admin.tab.taxes') %> &#x2f;
-  <%= link_to Spree::TaxCategory.model_name.human(count: :other), spree.admin_tax_categories_path %> &#x2f;
-  <%= @tax_category.name %>
-<% end %>
+<% add_breadcrumb(Spree.t(:settings)) %>
+<% add_breadcrumb(Spree.t('admin.tab.taxes')) %>
+<% add_breadcrumb(link_to Spree::TaxCategory.model_name.human(count: :other), spree.admin_tax_categories_path) %>
+<% add_breadcrumb(@tax_category.name) %>
+
 
 <% content_for :page_actions do %>
 <% end %>

--- a/backend/app/views/spree/admin/tax_categories/edit.html.erb
+++ b/backend/app/views/spree/admin/tax_categories/edit.html.erb
@@ -1,11 +1,13 @@
 <%= render 'spree/admin/shared/taxes_tabs' %>
 
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_tax_category) %>
+  <%= Spree.t(:settings) %> &#x2f;
+  <%= Spree.t('admin.tab.taxes') %> &#x2f;
+  <%= link_to Spree::TaxCategory.model_name.human(count: :other), spree.admin_tax_categories_path %> &#x2f;
+  <%= @tax_category.name %>
 <% end %>
 
 <% content_for :page_actions do %>
-  <li><%= link_to_with_icon 'arrow-left', Spree.t(:back_to_tax_categories_list), admin_tax_categories_path, :class => 'button' %></li>
 <% end %>
 
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @tax_category } %>

--- a/backend/app/views/spree/admin/tax_categories/edit.html.erb
+++ b/backend/app/views/spree/admin/tax_categories/edit.html.erb
@@ -2,7 +2,7 @@
 
 <% add_breadcrumb(Spree.t(:settings)) %>
 <% add_breadcrumb(Spree.t('admin.tab.taxes')) %>
-<% add_breadcrumb(link_to Spree::TaxCategory.model_name.human(count: :other), spree.admin_tax_categories_path) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::TaxCategory), spree.admin_tax_categories_path) %>
 <% add_breadcrumb(@tax_category.name) %>
 
 

--- a/backend/app/views/spree/admin/tax_categories/index.html.erb
+++ b/backend/app/views/spree/admin/tax_categories/index.html.erb
@@ -1,7 +1,9 @@
 <%= render 'spree/admin/shared/taxes_tabs' %>
 
 <% content_for :page_title do %>
-  <%= Spree.t(:listing_tax_categories) %>
+  <%= Spree.t(:settings) %> &#x2f;
+  <%= Spree.t('admin.tab.taxes') %> &#x2f;
+  <%= Spree::TaxCategory.model_name.human(count: :other) %>
 <% end %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/tax_categories/index.html.erb
+++ b/backend/app/views/spree/admin/tax_categories/index.html.erb
@@ -2,7 +2,7 @@
 
 <% add_breadcrumb(Spree.t(:settings) ) %>
 <% add_breadcrumb(Spree.t('admin.tab.taxes')) %>
-<% add_breadcrumb(Spree::TaxCategory.model_name.human(count: :other)) %>
+<% add_breadcrumb(plural_resource_name(Spree::TaxCategory)) %>
 
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/tax_categories/index.html.erb
+++ b/backend/app/views/spree/admin/tax_categories/index.html.erb
@@ -1,10 +1,9 @@
 <%= render 'spree/admin/shared/taxes_tabs' %>
 
-<% content_for :page_title do %>
-  <%= Spree.t(:settings) %> &#x2f;
-  <%= Spree.t('admin.tab.taxes') %> &#x2f;
-  <%= Spree::TaxCategory.model_name.human(count: :other) %>
-<% end %>
+<% add_breadcrumb(Spree.t(:settings) ) %>
+<% add_breadcrumb(Spree.t('admin.tab.taxes')) %>
+<% add_breadcrumb(Spree::TaxCategory.model_name.human(count: :other)) %>
+
 
 <% content_for :page_actions do %>
   <ul class="actions inline-menu">

--- a/backend/app/views/spree/admin/tax_categories/new.html.erb
+++ b/backend/app/views/spree/admin/tax_categories/new.html.erb
@@ -2,7 +2,7 @@
 
 <% add_breadcrumb(Spree.t(:settings)) %>
 <% add_breadcrumb(Spree.t('admin.tab.taxes')) %>
-<% add_breadcrumb(link_to Spree::TaxCategory.model_name.human(count: :other), spree.admin_tax_categories_path) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::TaxCategory), spree.admin_tax_categories_path) %>
 <% add_breadcrumb(Spree.t(:new_tax_category)) %>
 
 

--- a/backend/app/views/spree/admin/tax_categories/new.html.erb
+++ b/backend/app/views/spree/admin/tax_categories/new.html.erb
@@ -1,11 +1,13 @@
 <%= render 'spree/admin/shared/taxes_tabs' %>
 
 <% content_for :page_title do %>
+  <%= Spree.t(:settings) %> &#x2f;
+  <%= Spree.t('admin.tab.taxes') %> &#x2f;
+  <%= link_to Spree::TaxCategory.model_name.human(count: :other), spree.admin_tax_categories_path %> &#x2f;
   <%= Spree.t(:new_tax_category) %>
 <% end %>
 
 <% content_for :page_actions do %>
-  <li><%= link_to_with_icon 'arrow-left', Spree.t(:back_to_tax_categories_list), admin_tax_categories_path, :class => 'button' %></li>
 <% end %>
 
 

--- a/backend/app/views/spree/admin/tax_categories/new.html.erb
+++ b/backend/app/views/spree/admin/tax_categories/new.html.erb
@@ -1,11 +1,10 @@
 <%= render 'spree/admin/shared/taxes_tabs' %>
 
-<% content_for :page_title do %>
-  <%= Spree.t(:settings) %> &#x2f;
-  <%= Spree.t('admin.tab.taxes') %> &#x2f;
-  <%= link_to Spree::TaxCategory.model_name.human(count: :other), spree.admin_tax_categories_path %> &#x2f;
-  <%= Spree.t(:new_tax_category) %>
-<% end %>
+<% add_breadcrumb(Spree.t(:settings)) %>
+<% add_breadcrumb(Spree.t('admin.tab.taxes')) %>
+<% add_breadcrumb(link_to Spree::TaxCategory.model_name.human(count: :other), spree.admin_tax_categories_path) %>
+<% add_breadcrumb(Spree.t(:new_tax_category)) %>
+
 
 <% content_for :page_actions do %>
 <% end %>

--- a/backend/app/views/spree/admin/tax_rates/edit.html.erb
+++ b/backend/app/views/spree/admin/tax_rates/edit.html.erb
@@ -1,13 +1,13 @@
 <%= render 'spree/admin/shared/taxes_tabs' %>
 
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_tax_rate) %>
+  <%= Spree.t(:settings) %> &#x2f;
+  <%= Spree.t('admin.tab.taxes') %> &#x2f;
+  <%= link_to Spree::TaxRate.model_name.human(count: :other), spree.admin_tax_rates_path %> &#x2f;
+  <%= @tax_rate.name %>
 <% end %>
 
 <% content_for :page_actions do %>
-  <li>
-    <%= button_link_to Spree.t(:back_to_tax_rates_list), spree.admin_tax_rates_path, :icon => 'arrow-left' %>
-  </li>
 <% end %>
 
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @tax_rate } %>

--- a/backend/app/views/spree/admin/tax_rates/edit.html.erb
+++ b/backend/app/views/spree/admin/tax_rates/edit.html.erb
@@ -1,11 +1,10 @@
 <%= render 'spree/admin/shared/taxes_tabs' %>
 
-<% content_for :page_title do %>
-  <%= Spree.t(:settings) %> &#x2f;
-  <%= Spree.t('admin.tab.taxes') %> &#x2f;
-  <%= link_to Spree::TaxRate.model_name.human(count: :other), spree.admin_tax_rates_path %> &#x2f;
-  <%= @tax_rate.name %>
-<% end %>
+<% add_breadcrumb(Spree.t(:settings)) %>
+<% add_breadcrumb(Spree.t('admin.tab.taxes')) %>
+<% add_breadcrumb(link_to Spree::TaxRate.model_name.human(count: :other), spree.admin_tax_rates_path) %>
+<% add_breadcrumb(@tax_rate.name) %>
+
 
 <% content_for :page_actions do %>
 <% end %>

--- a/backend/app/views/spree/admin/tax_rates/edit.html.erb
+++ b/backend/app/views/spree/admin/tax_rates/edit.html.erb
@@ -2,7 +2,7 @@
 
 <% add_breadcrumb(Spree.t(:settings)) %>
 <% add_breadcrumb(Spree.t('admin.tab.taxes')) %>
-<% add_breadcrumb(link_to Spree::TaxRate.model_name.human(count: :other), spree.admin_tax_rates_path) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::TaxRate), spree.admin_tax_rates_path) %>
 <% add_breadcrumb(@tax_rate.name) %>
 
 

--- a/backend/app/views/spree/admin/tax_rates/index.html.erb
+++ b/backend/app/views/spree/admin/tax_rates/index.html.erb
@@ -1,10 +1,9 @@
 <%= render 'spree/admin/shared/taxes_tabs' %>
 
-<% content_for :page_title do %>
-  <%= Spree.t(:settings) %> &#x2f;
-  <%= Spree.t('admin.tab.taxes') %> &#x2f;
-  <%= Spree::TaxRate.model_name.human(count: :other) %>
-<% end %>
+<% add_breadcrumb(Spree.t(:settings)) %>
+<% add_breadcrumb(Spree.t('admin.tab.taxes')) %>
+<% add_breadcrumb(Spree::TaxRate.model_name.human(count: :other)) %>
+
 
 <% content_for :page_actions do %>
   <% if can?(:create, Spree::TaxRate) %>

--- a/backend/app/views/spree/admin/tax_rates/index.html.erb
+++ b/backend/app/views/spree/admin/tax_rates/index.html.erb
@@ -1,7 +1,9 @@
 <%= render 'spree/admin/shared/taxes_tabs' %>
 
 <% content_for :page_title do %>
-  <%= plural_resource_name(Spree::TaxRate) %>
+  <%= Spree.t(:settings) %> &#x2f;
+  <%= Spree.t('admin.tab.taxes') %> &#x2f;
+  <%= Spree::TaxRate.model_name.human(count: :other) %>
 <% end %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/tax_rates/index.html.erb
+++ b/backend/app/views/spree/admin/tax_rates/index.html.erb
@@ -2,7 +2,7 @@
 
 <% add_breadcrumb(Spree.t(:settings)) %>
 <% add_breadcrumb(Spree.t('admin.tab.taxes')) %>
-<% add_breadcrumb(Spree::TaxRate.model_name.human(count: :other)) %>
+<% add_breadcrumb(plural_resource_name(Spree::TaxRate)) %>
 
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/tax_rates/new.html.erb
+++ b/backend/app/views/spree/admin/tax_rates/new.html.erb
@@ -1,13 +1,13 @@
 <%= render 'spree/admin/shared/taxes_tabs' %>
 
 <% content_for :page_title do %>
+  <%= Spree.t(:settings) %> &#x2f;
+  <%= Spree.t('admin.tab.taxes') %> &#x2f;
+  <%= link_to Spree::TaxRate.model_name.human(count: :other), spree.admin_tax_rates_path %> &#x2f;
   <%= Spree.t(:new_tax_rate) %>
 <% end %>
 
 <% content_for :page_actions do %>
-  <li>
-    <%= button_link_to Spree.t(:back_to_tax_rates_list), spree.admin_tax_rates_path, :icon => 'arrow-left' %>
-  </li>
 <% end %>
 
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @tax_rate } %>

--- a/backend/app/views/spree/admin/tax_rates/new.html.erb
+++ b/backend/app/views/spree/admin/tax_rates/new.html.erb
@@ -1,11 +1,10 @@
 <%= render 'spree/admin/shared/taxes_tabs' %>
 
-<% content_for :page_title do %>
-  <%= Spree.t(:settings) %> &#x2f;
-  <%= Spree.t('admin.tab.taxes') %> &#x2f;
-  <%= link_to Spree::TaxRate.model_name.human(count: :other), spree.admin_tax_rates_path %> &#x2f;
-  <%= Spree.t(:new_tax_rate) %>
-<% end %>
+<% add_breadcrumb(Spree.t(:settings)) %>
+<% add_breadcrumb(Spree.t('admin.tab.taxes')) %>
+<% add_breadcrumb(link_to Spree::TaxRate.model_name.human(count: :other), spree.admin_tax_rates_path) %>
+<% add_breadcrumb(Spree.t(:new_tax_rate)) %>
+
 
 <% content_for :page_actions do %>
 <% end %>

--- a/backend/app/views/spree/admin/tax_rates/new.html.erb
+++ b/backend/app/views/spree/admin/tax_rates/new.html.erb
@@ -2,7 +2,7 @@
 
 <% add_breadcrumb(Spree.t(:settings)) %>
 <% add_breadcrumb(Spree.t('admin.tab.taxes')) %>
-<% add_breadcrumb(link_to Spree::TaxRate.model_name.human(count: :other), spree.admin_tax_rates_path) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::TaxRate), spree.admin_tax_rates_path) %>
 <% add_breadcrumb(Spree.t(:new_tax_rate)) %>
 
 

--- a/backend/app/views/spree/admin/taxonomies/edit.erb
+++ b/backend/app/views/spree/admin/taxonomies/edit.erb
@@ -1,11 +1,10 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:taxonomy_edit) %>
+  <%= link_to Spree::Product.model_name.human(count: :other), spree.admin_products_path  %> &#x2f; 
+  <%= link_to Spree::Taxonomy.model_name.human(count: :other), spree.admin_taxonomies_path %> &#x2f;
+  <%= @taxonomy.name %>
 <% end %>
 
 <% content_for :page_actions do %>
-  <li>
-    <%= button_link_to Spree.t(:back_to_taxonomies_list), spree.admin_taxonomies_path, :icon => 'arrow-left' %>
-  </li>
   <li>
     <%= button_link_to Spree.t(:add_taxon), spree.admin_taxonomies_path, { icon: 'plus', class: 'add-taxon-button' } %>
   </li>

--- a/backend/app/views/spree/admin/taxonomies/edit.erb
+++ b/backend/app/views/spree/admin/taxonomies/edit.erb
@@ -1,5 +1,5 @@
-<% add_breadcrumb(link_to Spree::Product.model_name.human(count: :other), spree.admin_products_path) %>
-<% add_breadcrumb(link_to Spree::Taxonomy.model_name.human(count: :other), spree.admin_taxonomies_path) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::Product), spree.admin_products_path) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::Taxonomy), spree.admin_taxonomies_path) %>
 <% add_breadcrumb(@taxonomy.name) %>
 
 

--- a/backend/app/views/spree/admin/taxonomies/edit.erb
+++ b/backend/app/views/spree/admin/taxonomies/edit.erb
@@ -1,8 +1,7 @@
-<% content_for :page_title do %>
-  <%= link_to Spree::Product.model_name.human(count: :other), spree.admin_products_path  %> &#x2f; 
-  <%= link_to Spree::Taxonomy.model_name.human(count: :other), spree.admin_taxonomies_path %> &#x2f;
-  <%= @taxonomy.name %>
-<% end %>
+<% add_breadcrumb(link_to Spree::Product.model_name.human(count: :other), spree.admin_products_path) %>
+<% add_breadcrumb(link_to Spree::Taxonomy.model_name.human(count: :other), spree.admin_taxonomies_path) %>
+<% add_breadcrumb(@taxonomy.name) %>
+
 
 <% content_for :page_actions do %>
   <li>

--- a/backend/app/views/spree/admin/taxonomies/index.html.erb
+++ b/backend/app/views/spree/admin/taxonomies/index.html.erb
@@ -1,7 +1,6 @@
-<% content_for :page_title do %>
-  <%= link_to Spree::Product.model_name.human(count: :other), spree.admin_products_path  %> &#x2f; 
-  <%= Spree::Taxonomy.model_name.human(count: :other) %>
-<% end %>
+<% add_breadcrumb(link_to Spree::Product.model_name.human(count: :other), spree.admin_products_path) %>
+<% add_breadcrumb(Spree::Taxonomy.model_name.human(count: :other)) %>
+
 
 <% content_for :page_actions do %>
   <% if can?(:create, Spree::Taxonomy) %>

--- a/backend/app/views/spree/admin/taxonomies/index.html.erb
+++ b/backend/app/views/spree/admin/taxonomies/index.html.erb
@@ -1,5 +1,5 @@
-<% add_breadcrumb(link_to Spree::Product.model_name.human(count: :other), spree.admin_products_path) %>
-<% add_breadcrumb(Spree::Taxonomy.model_name.human(count: :other)) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::Product), spree.admin_products_path) %>
+<% add_breadcrumb(plural_resource_name(Spree::Taxonomy)) %>
 
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/taxonomies/index.html.erb
+++ b/backend/app/views/spree/admin/taxonomies/index.html.erb
@@ -1,5 +1,6 @@
 <% content_for :page_title do %>
-  <%= plural_resource_name(Spree::Taxonomy) %>
+  <%= link_to Spree::Product.model_name.human(count: :other), spree.admin_products_path  %> &#x2f; 
+  <%= Spree::Taxonomy.model_name.human(count: :other) %>
 <% end %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/taxonomies/new.html.erb
+++ b/backend/app/views/spree/admin/taxonomies/new.html.erb
@@ -1,8 +1,7 @@
-<% content_for :page_title do %>
-  <%= link_to Spree::Product.model_name.human(count: :other), spree.admin_products_path  %> &#x2f; 
-  <%= link_to Spree::Taxonomy.model_name.human(count: :other), spree.admin_taxonomies_path %> &#x2f;
-  <%= Spree.t(:new_taxonomy) %>
-<% end %>
+<% add_breadcrumb(link_to Spree::Product.model_name.human(count: :other), spree.admin_products_path) %>
+<% add_breadcrumb(link_to Spree::Taxonomy.model_name.human(count: :other), spree.admin_taxonomies_path) %>
+<% add_breadcrumb(Spree.t(:new_taxonomy)) %>
+
 
 <% content_for :page_actions do %>
 <% end %>

--- a/backend/app/views/spree/admin/taxonomies/new.html.erb
+++ b/backend/app/views/spree/admin/taxonomies/new.html.erb
@@ -1,5 +1,5 @@
-<% add_breadcrumb(link_to Spree::Product.model_name.human(count: :other), spree.admin_products_path) %>
-<% add_breadcrumb(link_to Spree::Taxonomy.model_name.human(count: :other), spree.admin_taxonomies_path) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::Product), spree.admin_products_path) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::Taxonomy), spree.admin_taxonomies_path) %>
 <% add_breadcrumb(Spree.t(:new_taxonomy)) %>
 
 

--- a/backend/app/views/spree/admin/taxonomies/new.html.erb
+++ b/backend/app/views/spree/admin/taxonomies/new.html.erb
@@ -1,11 +1,10 @@
 <% content_for :page_title do %>
+  <%= link_to Spree::Product.model_name.human(count: :other), spree.admin_products_path  %> &#x2f; 
+  <%= link_to Spree::Taxonomy.model_name.human(count: :other), spree.admin_taxonomies_path %> &#x2f;
   <%= Spree.t(:new_taxonomy) %>
 <% end %>
 
 <% content_for :page_actions do %>
-  <li>
-    <%= button_link_to Spree.t(:back_to_taxonomies_list), spree.admin_taxonomies_path, :icon => 'arrow-left' %>
-  </li>
 <% end %>
 
 <%= form_for [:admin, @taxonomy] do |f| %>

--- a/backend/app/views/spree/admin/taxons/edit.html.erb
+++ b/backend/app/views/spree/admin/taxons/edit.html.erb
@@ -1,6 +1,5 @@
-<% content_for :page_title do %>
-  <%= Spree.t(:taxon_edit) %>
-<% end %>
+<% add_breadcrumb(Spree.t(:taxon_edit)) %>
+
 
 <% content_for :page_actions do %>
   <li>

--- a/backend/app/views/spree/admin/taxons/index.html.erb
+++ b/backend/app/views/spree/admin/taxons/index.html.erb
@@ -1,4 +1,5 @@
 <% content_for :page_title do %>
+  <%= link_to Spree::Product.model_name.human(count: :other), spree.admin_products_path  %> &#x2f; 
   <%= Spree.t('admin.taxons.display_order') %>
 <% end %>
 

--- a/backend/app/views/spree/admin/taxons/index.html.erb
+++ b/backend/app/views/spree/admin/taxons/index.html.erb
@@ -1,7 +1,5 @@
-<% content_for :page_title do %>
-  <%= link_to Spree::Product.model_name.human(count: :other), spree.admin_products_path  %> &#x2f; 
-  <%= Spree.t('admin.taxons.display_order') %>
-<% end %>
+<% add_breadcrumb(link_to Spree::Product.model_name.human(count: :other), spree.admin_products_path) %>
+<% add_breadcrumb(Spree.t('admin.taxons.display_order')) %>
 
 <% content_for :table_filter_title do %>
   <%= Spree.t(:choose_a_taxon_to_sort_products_for) %>

--- a/backend/app/views/spree/admin/trackers/edit.html.erb
+++ b/backend/app/views/spree/admin/trackers/edit.html.erb
@@ -1,13 +1,13 @@
 <%= render 'spree/admin/shared/general_tabs' %>
 
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_tracker) %>
+  <%= Spree.t(:settings) %> &#x2f;
+  <%= Spree.t(:general) %> &#x2f;
+  <%= link_to Spree::Tracker.model_name.human(count: :other), spree.admin_trackers_path %> &#x2f;
+  <%= @tracker.analytics_id %>
 <% end %>
 
 <% content_for :page_actions do %>
-  <li>
-    <%= button_link_to Spree.t(:back_to_trackers_list), spree.admin_trackers_path, :icon => 'arrow-left' %>
-  </li>
 <% end %>
 
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @tracker } %>

--- a/backend/app/views/spree/admin/trackers/edit.html.erb
+++ b/backend/app/views/spree/admin/trackers/edit.html.erb
@@ -1,11 +1,10 @@
 <%= render 'spree/admin/shared/general_tabs' %>
 
-<% content_for :page_title do %>
-  <%= Spree.t(:settings) %> &#x2f;
-  <%= Spree.t(:general) %> &#x2f;
-  <%= link_to Spree::Tracker.model_name.human(count: :other), spree.admin_trackers_path %> &#x2f;
-  <%= @tracker.analytics_id %>
-<% end %>
+<% add_breadcrumb(Spree.t(:settings)) %>
+<% add_breadcrumb(Spree.t(:general_settings)) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::Tracker), spree.admin_trackers_path) %>
+<% add_breadcrumb(@tracker.analytics_id) %>
+
 
 <% content_for :page_actions do %>
 <% end %>

--- a/backend/app/views/spree/admin/trackers/index.html.erb
+++ b/backend/app/views/spree/admin/trackers/index.html.erb
@@ -1,10 +1,8 @@
 <%= render 'spree/admin/shared/general_tabs' %>
 
-<% content_for :page_title do %>
-  <%= Spree.t(:settings) %> &#x2f;
-  <%= Spree.t(:general) %> &#x2f;
-  <%= Spree::Tracker.model_name.human(count: :other) %>
-<% end %>
+<% add_breadcrumb(Spree.t(:settings)) %>
+<% add_breadcrumb(Spree.t(:general_settings)) %>
+<% add_breadcrumb(plural_resource_name(Spree::Tracker)) %>
 
 <% content_for :page_actions do %>
   <% if can?(:create, Spree::Tracker) %>

--- a/backend/app/views/spree/admin/trackers/index.html.erb
+++ b/backend/app/views/spree/admin/trackers/index.html.erb
@@ -1,7 +1,9 @@
 <%= render 'spree/admin/shared/general_tabs' %>
 
 <% content_for :page_title do %>
-  <%= plural_resource_name(Spree::Tracker) %>
+  <%= Spree.t(:settings) %> &#x2f;
+  <%= Spree.t(:general) %> &#x2f;
+  <%= Spree::Tracker.model_name.human(count: :other) %>
 <% end %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/trackers/new.html.erb
+++ b/backend/app/views/spree/admin/trackers/new.html.erb
@@ -1,13 +1,13 @@
 <%= render 'spree/admin/shared/general_tabs' %>
 
 <% content_for :page_title do %>
+  <%= Spree.t(:settings) %> &#x2f;
+  <%= Spree.t(:general) %> &#x2f;
+  <%= link_to Spree::Tracker.model_name.human(count: :other), spree.admin_trackers_path %> &#x2f;
   <%= Spree.t(:new_tracker) %>
 <% end %>
 
 <% content_for :page_actions do %>
-  <li>
-    <%= button_link_to Spree.t(:back_to_trackers_list), spree.admin_trackers_path, :icon => 'arrow-left' %>
-  </li>
 <% end %>
 
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @tracker } %>

--- a/backend/app/views/spree/admin/trackers/new.html.erb
+++ b/backend/app/views/spree/admin/trackers/new.html.erb
@@ -1,11 +1,10 @@
 <%= render 'spree/admin/shared/general_tabs' %>
 
-<% content_for :page_title do %>
-  <%= Spree.t(:settings) %> &#x2f;
-  <%= Spree.t(:general) %> &#x2f;
-  <%= link_to Spree::Tracker.model_name.human(count: :other), spree.admin_trackers_path %> &#x2f;
-  <%= Spree.t(:new_tracker) %>
-<% end %>
+<% add_breadcrumb(Spree.t(:settings)) %>
+<% add_breadcrumb(Spree.t(:general_settings)) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::Tracker), spree.admin_trackers_path) %>
+<% add_breadcrumb(Spree.t(:new_tracker)) %>
+
 
 <% content_for :page_actions do %>
 <% end %>

--- a/backend/app/views/spree/admin/trackers/new.html.erb
+++ b/backend/app/views/spree/admin/trackers/new.html.erb
@@ -5,7 +5,6 @@
 <% add_breadcrumb(link_to plural_resource_name(Spree::Tracker), spree.admin_trackers_path) %>
 <% add_breadcrumb(Spree.t(:new_tracker)) %>
 
-
 <% content_for :page_actions do %>
 <% end %>
 

--- a/backend/app/views/spree/admin/users/_user_page_actions.html.erb
+++ b/backend/app/views/spree/admin/users/_user_page_actions.html.erb
@@ -1,7 +1,4 @@
 <% content_for :page_actions do %>
-  <li>
-    <%= button_link_to Spree.t(:back_to_users_list), spree.admin_users_path, :icon => 'arrow-left' %>
-  </li>
   <% if can?([:admin, :create], Spree::Order) %>
     <li>
       <%= button_link_to Spree.t(:create_new_order), spree.new_admin_order_path(user_id: @user.id), :icon => 'plus' %>

--- a/backend/app/views/spree/admin/users/addresses.html.erb
+++ b/backend/app/views/spree/admin/users/addresses.html.erb
@@ -1,6 +1,6 @@
-<% add_breadcrumb(link_to Spree::LegacyUser.model_name.human(count: :other), spree.admin_users_path) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::LegacyUser), spree.admin_users_path) %>
 <% add_breadcrumb(link_to @user.email, edit_admin_user_url(@user)) %>
-<% add_breadcrumb(Spree::Address.model_name.human(count: :other)) %>
+<% add_breadcrumb(plural_resource_name(Spree::Address)) %>
 
 
 <%= render 'spree/admin/users/sidebar' %>

--- a/backend/app/views/spree/admin/users/addresses.html.erb
+++ b/backend/app/views/spree/admin/users/addresses.html.erb
@@ -1,5 +1,7 @@
 <% content_for :page_title do %>
-  <%= link_to "#{Spree.t(:editing_user)} #{@user.email}", edit_admin_user_url(@user) %>
+  <%= link_to Spree::LegacyUser.model_name.human(count: :other), spree.admin_users_path %> &#x2f;
+  <%= link_to @user.email, edit_admin_user_url(@user) %> &#x2f;
+  <%= Spree::Address.model_name.human(count: :other) %>
 <% end %>
 
 <%= render 'spree/admin/users/sidebar' %>

--- a/backend/app/views/spree/admin/users/addresses.html.erb
+++ b/backend/app/views/spree/admin/users/addresses.html.erb
@@ -1,8 +1,7 @@
-<% content_for :page_title do %>
-  <%= link_to Spree::LegacyUser.model_name.human(count: :other), spree.admin_users_path %> &#x2f;
-  <%= link_to @user.email, edit_admin_user_url(@user) %> &#x2f;
-  <%= Spree::Address.model_name.human(count: :other) %>
-<% end %>
+<% add_breadcrumb(link_to Spree::LegacyUser.model_name.human(count: :other), spree.admin_users_path) %>
+<% add_breadcrumb(link_to @user.email, edit_admin_user_url(@user)) %>
+<% add_breadcrumb(Spree::Address.model_name.human(count: :other)) %>
+
 
 <%= render 'spree/admin/users/sidebar' %>
 <%= render 'spree/admin/users/tabs', current: :address %>

--- a/backend/app/views/spree/admin/users/edit.html.erb
+++ b/backend/app/views/spree/admin/users/edit.html.erb
@@ -1,7 +1,6 @@
-<% content_for :page_title do %>
-  <%= link_to Spree::LegacyUser.model_name.human(count: :other), spree.admin_users_path %> &#x2f;
-  <%= @user.email %>
-<% end %>
+<% add_breadcrumb(link_to Spree::LegacyUser.model_name.human(count: :other), spree.admin_users_path) %>
+<% add_breadcrumb(@user.email) %>
+
 
 <%= render 'spree/admin/users/sidebar' %>
 <%= render 'spree/admin/users/tabs', current: :account %>

--- a/backend/app/views/spree/admin/users/edit.html.erb
+++ b/backend/app/views/spree/admin/users/edit.html.erb
@@ -1,4 +1,4 @@
-<% add_breadcrumb(link_to Spree::LegacyUser.model_name.human(count: :other), spree.admin_users_path) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::LegacyUser), spree.admin_users_path) %>
 <% add_breadcrumb(@user.email) %>
 
 

--- a/backend/app/views/spree/admin/users/edit.html.erb
+++ b/backend/app/views/spree/admin/users/edit.html.erb
@@ -1,5 +1,6 @@
 <% content_for :page_title do %>
-  <%= link_to "#{Spree.t(:editing_user)} #{@user.email}", edit_admin_user_url(@user) %>
+  <%= link_to Spree::LegacyUser.model_name.human(count: :other), spree.admin_users_path %> &#x2f;
+  <%= @user.email %>
 <% end %>
 
 <%= render 'spree/admin/users/sidebar' %>

--- a/backend/app/views/spree/admin/users/index.html.erb
+++ b/backend/app/views/spree/admin/users/index.html.erb
@@ -1,4 +1,4 @@
-<% add_breadcrumb(Spree::LegacyUser.model_name.human(count: :other)) %>
+<% add_breadcrumb(plural_resource_name(Spree::LegacyUser)) %>
 
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/users/index.html.erb
+++ b/backend/app/views/spree/admin/users/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree.t(:listing_users) %>
+  <%= Spree::LegacyUser.model_name.human(count: :other) %>
 <% end %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/users/index.html.erb
+++ b/backend/app/views/spree/admin/users/index.html.erb
@@ -1,6 +1,5 @@
-<% content_for :page_title do %>
-  <%= Spree::LegacyUser.model_name.human(count: :other) %>
-<% end %>
+<% add_breadcrumb(Spree::LegacyUser.model_name.human(count: :other)) %>
+
 
 <% content_for :page_actions do %>
   <% if can?(:admin, Spree.user_class) && can?(:create, Spree.user_class) %>

--- a/backend/app/views/spree/admin/users/items.html.erb
+++ b/backend/app/views/spree/admin/users/items.html.erb
@@ -1,5 +1,7 @@
 <% content_for :page_title do %>
-  <%= link_to "#{Spree.t(:"admin.user.items_purchased")} #{@user.email}", edit_admin_user_url(@user) %>
+  <%= link_to Spree::LegacyUser.model_name.human(count: :other), spree.admin_users_path %> &#x2f;
+  <%= link_to @user.email, edit_admin_user_url(@user) %> &#x2f;
+  <%= Spree.t('admin.user.items_purchased') %>
 <% end %>
 
 <%= render 'spree/admin/users/sidebar' %>

--- a/backend/app/views/spree/admin/users/items.html.erb
+++ b/backend/app/views/spree/admin/users/items.html.erb
@@ -1,8 +1,7 @@
-<% content_for :page_title do %>
-  <%= link_to Spree::LegacyUser.model_name.human(count: :other), spree.admin_users_path %> &#x2f;
-  <%= link_to @user.email, edit_admin_user_url(@user) %> &#x2f;
-  <%= Spree.t('admin.user.items_purchased') %>
-<% end %>
+<% add_breadcrumb(link_to Spree::LegacyUser.model_name.human(count: :other), spree.admin_users_path) %>
+<% add_breadcrumb(link_to @user.email, edit_admin_user_url(@user)) %>
+<% add_breadcrumb(Spree.t('admin.user.items_purchased')) %>
+
 
 <%= render 'spree/admin/users/sidebar' %>
 <%= render 'spree/admin/users/tabs', current: :items %>

--- a/backend/app/views/spree/admin/users/items.html.erb
+++ b/backend/app/views/spree/admin/users/items.html.erb
@@ -1,4 +1,4 @@
-<% add_breadcrumb(link_to Spree::LegacyUser.model_name.human(count: :other), spree.admin_users_path) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::LegacyUser), spree.admin_users_path) %>
 <% add_breadcrumb(link_to @user.email, edit_admin_user_url(@user)) %>
 <% add_breadcrumb(Spree.t('admin.user.items_purchased')) %>
 

--- a/backend/app/views/spree/admin/users/new.html.erb
+++ b/backend/app/views/spree/admin/users/new.html.erb
@@ -1,11 +1,8 @@
 <% content_for :page_title do %>
+  <%= link_to Spree::LegacyUser.model_name.human(count: :other), spree.admin_users_path %> &#x2f;
   <%= Spree.t(:new_user) %>
 <% end %>
-
 <% content_for :page_actions do %>
-  <li>
-    <%= button_link_to Spree.t(:back_to_users_list), spree.admin_users_path, :icon => 'arrow-left' %>
-  </li>
 <% end %>
 
 <div data-hook="admin_user_new_form_header">

--- a/backend/app/views/spree/admin/users/new.html.erb
+++ b/backend/app/views/spree/admin/users/new.html.erb
@@ -1,9 +1,5 @@
-<% content_for :page_title do %>
-  <%= link_to Spree::LegacyUser.model_name.human(count: :other), spree.admin_users_path %> &#x2f;
-  <%= Spree.t(:new_user) %>
-<% end %>
-<% content_for :page_actions do %>
-<% end %>
+<% add_breadcrumb(link_to Spree::LegacyUser.model_name.human(count: :other), spree.admin_users_path) %>
+<% add_breadcrumb(Spree.t(:new_user)) %>
 
 <div data-hook="admin_user_new_form_header">
   <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @user } %>

--- a/backend/app/views/spree/admin/users/new.html.erb
+++ b/backend/app/views/spree/admin/users/new.html.erb
@@ -1,4 +1,4 @@
-<% add_breadcrumb(link_to Spree::LegacyUser.model_name.human(count: :other), spree.admin_users_path) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::LegacyUser), spree.admin_users_path) %>
 <% add_breadcrumb(Spree.t(:new_user)) %>
 
 <div data-hook="admin_user_new_form_header">

--- a/backend/app/views/spree/admin/users/orders.html.erb
+++ b/backend/app/views/spree/admin/users/orders.html.erb
@@ -1,4 +1,4 @@
-<% add_breadcrumb(link_to Spree::LegacyUser.model_name.human(count: :other), spree.admin_users_path) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::LegacyUser), spree.admin_users_path) %>
 <% add_breadcrumb(link_to @user.email, edit_admin_user_url(@user)) %>
 <% add_breadcrumb(Spree.t('admin.user.order_history')) %>
 

--- a/backend/app/views/spree/admin/users/orders.html.erb
+++ b/backend/app/views/spree/admin/users/orders.html.erb
@@ -1,5 +1,7 @@
 <% content_for :page_title do %>
-  <%= link_to "#{Spree.t(:"admin.user.order_history")} #{@user.email}", edit_admin_user_url(@user) %>
+  <%= link_to Spree::LegacyUser.model_name.human(count: :other), spree.admin_users_path %> &#x2f;
+  <%= link_to @user.email, edit_admin_user_url(@user) %> &#x2f;
+  <%= Spree.t('admin.user.order_history') %>
 <% end %>
 
 <%= render 'spree/admin/users/sidebar' %>

--- a/backend/app/views/spree/admin/users/orders.html.erb
+++ b/backend/app/views/spree/admin/users/orders.html.erb
@@ -1,8 +1,7 @@
-<% content_for :page_title do %>
-  <%= link_to Spree::LegacyUser.model_name.human(count: :other), spree.admin_users_path %> &#x2f;
-  <%= link_to @user.email, edit_admin_user_url(@user) %> &#x2f;
-  <%= Spree.t('admin.user.order_history') %>
-<% end %>
+<% add_breadcrumb(link_to Spree::LegacyUser.model_name.human(count: :other), spree.admin_users_path) %>
+<% add_breadcrumb(link_to @user.email, edit_admin_user_url(@user)) %>
+<% add_breadcrumb(Spree.t('admin.user.order_history')) %>
+
 
 <%= render 'spree/admin/users/sidebar' %>
 <%= render 'spree/admin/users/tabs', current: :orders %>

--- a/backend/app/views/spree/admin/variants/edit.html.erb
+++ b/backend/app/views/spree/admin/variants/edit.html.erb
@@ -1,10 +1,12 @@
 <%= render :partial => 'spree/admin/shared/product_tabs', :locals => { :current => 'Variants' } %>
 
 <% content_for :page_title do %>
+  &#x2f; <%= link_to Spree::Variant.model_name.human(count: :other), admin_product_variants_path(@product) %>
   &#x2f; <%= @variant.options_text %>
 <% end %>
 
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @variant } %>
+
 
 <%= form_for [:admin, @product, @variant] do |f| %>
   <fieldset>

--- a/backend/app/views/spree/admin/variants/edit.html.erb
+++ b/backend/app/views/spree/admin/variants/edit.html.erb
@@ -1,9 +1,8 @@
 <%= render :partial => 'spree/admin/shared/product_tabs', :locals => { :current => 'Variants' } %>
 
-<% content_for :page_title do %>
-  &#x2f; <%= link_to Spree::Variant.model_name.human(count: :other), admin_product_variants_path(@product) %>
-  &#x2f; <%= @variant.options_text %>
-<% end %>
+<% add_breadcrumb(link_to Spree::Variant.model_name.human(count: :other), admin_product_variants_path(@product)) %>
+<% add_breadcrumb(@variant.options_text) %>
+
 
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @variant } %>
 

--- a/backend/app/views/spree/admin/variants/edit.html.erb
+++ b/backend/app/views/spree/admin/variants/edit.html.erb
@@ -1,6 +1,6 @@
 <%= render :partial => 'spree/admin/shared/product_tabs', :locals => { :current => 'Variants' } %>
 
-<% add_breadcrumb(link_to Spree::Variant.model_name.human(count: :other), admin_product_variants_path(@product)) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::Variant), admin_product_variants_path(@product)) %>
 <% add_breadcrumb(@variant.options_text) %>
 
 

--- a/backend/app/views/spree/admin/variants/index.html.erb
+++ b/backend/app/views/spree/admin/variants/index.html.erb
@@ -1,6 +1,6 @@
 <%= render 'spree/admin/shared/product_tabs', current: 'Variants' %>
 
-<% add_breadcrumb(Spree::Variant.model_name.human(count: :other)) %>
+<% add_breadcrumb(plural_resource_name(Spree::Variant)) %>
 
 
 <% if @variants.any? || @product.variants.only_deleted.any?%>

--- a/backend/app/views/spree/admin/variants/index.html.erb
+++ b/backend/app/views/spree/admin/variants/index.html.erb
@@ -1,5 +1,9 @@
 <%= render 'spree/admin/shared/product_tabs', current: 'Variants' %>
 
+<% content_for :page_title do %>
+  &#x2f; <%= Spree::Variant.model_name.human(count: :other) %>
+<% end %>
+
 <% if @variants.any? || @product.variants.only_deleted.any?%>
   <%= render "table_filter", product: @product %>
   <%= render "table", variants: @variants %>

--- a/backend/app/views/spree/admin/variants/index.html.erb
+++ b/backend/app/views/spree/admin/variants/index.html.erb
@@ -1,8 +1,7 @@
 <%= render 'spree/admin/shared/product_tabs', current: 'Variants' %>
 
-<% content_for :page_title do %>
-  &#x2f; <%= Spree::Variant.model_name.human(count: :other) %>
-<% end %>
+<% add_breadcrumb(Spree::Variant.model_name.human(count: :other)) %>
+
 
 <% if @variants.any? || @product.variants.only_deleted.any?%>
   <%= render "table_filter", product: @product %>

--- a/backend/app/views/spree/admin/variants/new.html.erb
+++ b/backend/app/views/spree/admin/variants/new.html.erb
@@ -1,4 +1,10 @@
+<%= render :partial => 'spree/admin/shared/product_tabs', :locals => { :current => 'Variants' } %>
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @variant } %>
+
+<% content_for :page_title do %>
+  &#x2f; <%= link_to Spree::Variant.model_name.human(count: :other), admin_product_variants_path(@product) %>
+&#x2f; <%= Spree.t(:new_variant) %>
+<% end %>
 
 <%= form_for [:admin, @product, @variant] do |f| %>
   <fieldset data-hook="admin_variant_new_form">

--- a/backend/app/views/spree/admin/variants/new.html.erb
+++ b/backend/app/views/spree/admin/variants/new.html.erb
@@ -1,10 +1,9 @@
 <%= render :partial => 'spree/admin/shared/product_tabs', :locals => { :current => 'Variants' } %>
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @variant } %>
 
-<% content_for :page_title do %>
-  &#x2f; <%= link_to Spree::Variant.model_name.human(count: :other), admin_product_variants_path(@product) %>
-&#x2f; <%= Spree.t(:new_variant) %>
-<% end %>
+<% add_breadcrumb(link_to Spree::Variant.model_name.human(count: :other), admin_product_variants_path(@product)) %>
+<% add_breadcrumb(Spree.t(:new_variant)) %>
+
 
 <%= form_for [:admin, @product, @variant] do |f| %>
   <fieldset data-hook="admin_variant_new_form">

--- a/backend/app/views/spree/admin/variants/new.html.erb
+++ b/backend/app/views/spree/admin/variants/new.html.erb
@@ -1,7 +1,7 @@
 <%= render :partial => 'spree/admin/shared/product_tabs', :locals => { :current => 'Variants' } %>
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @variant } %>
 
-<% add_breadcrumb(link_to Spree::Variant.model_name.human(count: :other), admin_product_variants_path(@product)) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::Variant), admin_product_variants_path(@product)) %>
 <% add_breadcrumb(Spree.t(:new_variant)) %>
 
 

--- a/backend/app/views/spree/admin/zones/edit.html.erb
+++ b/backend/app/views/spree/admin/zones/edit.html.erb
@@ -2,7 +2,7 @@
 
 <% add_breadcrumb(Spree.t(:settings)) %>
 <% add_breadcrumb(Spree.t('admin.tab.areas')) %>
-<% add_breadcrumb(link_to Spree::Zone.model_name.human(count: :other), spree.admin_zones_path) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::Zone), spree.admin_zones_path) %>
 <% add_breadcrumb(@zone.name) %>
 
 

--- a/backend/app/views/spree/admin/zones/edit.html.erb
+++ b/backend/app/views/spree/admin/zones/edit.html.erb
@@ -1,13 +1,13 @@
 <%= render 'spree/admin/shared/areas_tabs' %>
 
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_zone) %>
+  <%= Spree.t(:settings) %> &#x2f;
+  <%= Spree.t('admin.tab.areas') %> &#x2f;
+  <%= link_to Spree::Zone.model_name.human(count: :other), spree.admin_zones_path %> &#x2f;
+  <%= @zone.name %>
 <% end %>
 
 <% content_for :page_actions do %>
-  <li>
-    <%= button_link_to Spree.t(:back_to_zones_list), admin_zones_path, :icon => 'arrow-left' %>
-  </li>
 <% end %>
 
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @zone } %>

--- a/backend/app/views/spree/admin/zones/edit.html.erb
+++ b/backend/app/views/spree/admin/zones/edit.html.erb
@@ -1,11 +1,10 @@
 <%= render 'spree/admin/shared/areas_tabs' %>
 
-<% content_for :page_title do %>
-  <%= Spree.t(:settings) %> &#x2f;
-  <%= Spree.t('admin.tab.areas') %> &#x2f;
-  <%= link_to Spree::Zone.model_name.human(count: :other), spree.admin_zones_path %> &#x2f;
-  <%= @zone.name %>
-<% end %>
+<% add_breadcrumb(Spree.t(:settings)) %>
+<% add_breadcrumb(Spree.t('admin.tab.areas')) %>
+<% add_breadcrumb(link_to Spree::Zone.model_name.human(count: :other), spree.admin_zones_path) %>
+<% add_breadcrumb(@zone.name) %>
+
 
 <% content_for :page_actions do %>
 <% end %>

--- a/backend/app/views/spree/admin/zones/index.html.erb
+++ b/backend/app/views/spree/admin/zones/index.html.erb
@@ -2,7 +2,7 @@
 
 <% add_breadcrumb(Spree.t(:settings)) %>
 <% add_breadcrumb(Spree.t('admin.tab.areas')) %>
-<% add_breadcrumb(Spree::Zone.model_name.human(count: :other)) %>
+<% add_breadcrumb(plural_resource_name(Spree::Zone)) %>
 
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/zones/index.html.erb
+++ b/backend/app/views/spree/admin/zones/index.html.erb
@@ -1,7 +1,9 @@
 <%= render 'spree/admin/shared/areas_tabs' %>
 
 <% content_for :page_title do %>
-  <%= plural_resource_name(Spree::Zone) %>
+  <%= Spree.t(:settings) %> &#x2f;
+  <%= Spree.t('admin.tab.areas') %> &#x2f;
+  <%= Spree::Zone.model_name.human(count: :other) %>
 <% end %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/zones/index.html.erb
+++ b/backend/app/views/spree/admin/zones/index.html.erb
@@ -1,10 +1,9 @@
 <%= render 'spree/admin/shared/areas_tabs' %>
 
-<% content_for :page_title do %>
-  <%= Spree.t(:settings) %> &#x2f;
-  <%= Spree.t('admin.tab.areas') %> &#x2f;
-  <%= Spree::Zone.model_name.human(count: :other) %>
-<% end %>
+<% add_breadcrumb(Spree.t(:settings)) %>
+<% add_breadcrumb(Spree.t('admin.tab.areas')) %>
+<% add_breadcrumb(Spree::Zone.model_name.human(count: :other)) %>
+
 
 <% content_for :page_actions do %>
   <% if can?(:create, Spree::Zone) %>

--- a/backend/app/views/spree/admin/zones/new.html.erb
+++ b/backend/app/views/spree/admin/zones/new.html.erb
@@ -1,13 +1,13 @@
 <%= render 'spree/admin/shared/areas_tabs' %>
 
 <% content_for :page_title do %>
+  <%= Spree.t(:settings) %> &#x2f;
+  <%= Spree.t('admin.tab.areas') %> &#x2f;
+  <%= link_to Spree::Zone.model_name.human(count: :other), spree.admin_zones_path %> &#x2f;
   <%= Spree.t(:new_zone) %>
 <% end %>
 
 <% content_for :page_actions do %>
-  <li>
-    <%= button_link_to Spree.t(:back_to_zones_list), spree.admin_zones_path, :icon => 'arrow-left' %>
-  </li>
 <% end %>
 
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @zone } %>

--- a/backend/app/views/spree/admin/zones/new.html.erb
+++ b/backend/app/views/spree/admin/zones/new.html.erb
@@ -1,11 +1,10 @@
 <%= render 'spree/admin/shared/areas_tabs' %>
 
-<% content_for :page_title do %>
-  <%= Spree.t(:settings) %> &#x2f;
-  <%= Spree.t('admin.tab.areas') %> &#x2f;
-  <%= link_to Spree::Zone.model_name.human(count: :other), spree.admin_zones_path %> &#x2f;
-  <%= Spree.t(:new_zone) %>
-<% end %>
+<% add_breadcrumb(Spree.t(:settings)) %>
+<% add_breadcrumb(Spree.t('admin.tab.areas')) %>
+<% add_breadcrumb(link_to Spree::Zone.model_name.human(count: :other), spree.admin_zones_path) %>
+<% add_breadcrumb(Spree.t(:new_zone)) %>
+
 
 <% content_for :page_actions do %>
 <% end %>
@@ -16,6 +15,6 @@
   <%= render :partial => 'form', :locals => { :zone_form => zone_form } %>
 
   <div class="clear"></div>
-  
+
   <%= render :partial => 'spree/admin/shared/new_resource_links' %>
 <% end %>

--- a/backend/app/views/spree/admin/zones/new.html.erb
+++ b/backend/app/views/spree/admin/zones/new.html.erb
@@ -2,7 +2,7 @@
 
 <% add_breadcrumb(Spree.t(:settings)) %>
 <% add_breadcrumb(Spree.t('admin.tab.areas')) %>
-<% add_breadcrumb(link_to Spree::Zone.model_name.human(count: :other), spree.admin_zones_path) %>
+<% add_breadcrumb(link_to plural_resource_name(Spree::Zone), spree.admin_zones_path) %>
 <% add_breadcrumb(Spree.t(:new_zone)) %>
 
 

--- a/backend/spec/controllers/spree/admin/store_credits_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/store_credits_controller_spec.rb
@@ -141,7 +141,7 @@ describe Spree::Admin::StoreCreditsController do
       it "returns a success message" do
         subject
         expect(response).to have_http_status(:ok)
-        expect(JSON.parse(response.body)['message']).to match("Store credit has been successfully updated!")
+        expect(JSON.parse(response.body)['message']).to match("Store Credit has been successfully updated!")
       end
     end
 
@@ -226,7 +226,7 @@ describe Spree::Admin::StoreCreditsController do
       context "the store credit has not been used" do
         it "sets a success message in the flash" do
           subject
-          expect(flash.now[:success]).to match "Store credit has been successfully updated!"
+          expect(flash.now[:success]).to match "Store Credit has been successfully updated!"
         end
 
         it "does not create a new store credit" do

--- a/backend/spec/features/admin/configuration/general_settings_spec.rb
+++ b/backend/spec/features/admin/configuration/general_settings_spec.rb
@@ -18,7 +18,7 @@ describe "Store", type: :feature, js: true do
 
   context "visiting general store settings" do
     it "should have the right content" do
-      expect(page).to have_content("Store")
+      expect(page).to have_content("Settings / General / Store")
       expect(page).to have_field("store_name", with: "Test Store")
       expect(page).to have_field("store_url", with: "test.example.org")
       expect(page).to have_field("store_mail_from_address", with: "test@example.org")

--- a/backend/spec/features/admin/configuration/general_settings_spec.rb
+++ b/backend/spec/features/admin/configuration/general_settings_spec.rb
@@ -18,7 +18,7 @@ describe "Store", type: :feature, js: true do
 
   context "visiting general store settings" do
     it "should have the right content" do
-      expect(page).to have_content("Settings / General / Store")
+      expect(page).to have_content("SettingsStore")
       expect(page).to have_field("store_name", with: "Test Store")
       expect(page).to have_field("store_url", with: "test.example.org")
       expect(page).to have_field("store_mail_from_address", with: "test@example.org")

--- a/backend/spec/features/admin/configuration/tax_categories_spec.rb
+++ b/backend/spec/features/admin/configuration/tax_categories_spec.rb
@@ -12,7 +12,7 @@ describe "Tax Categories", type: :feature do
     it "should display the existing tax categories" do
       create(:tax_category, name: "Clothing", tax_code: "CL001", description: "For Clothing")
       click_link "Tax Categories"
-      expect(page).to have_content("Settings / Taxes / Tax Categories")
+      expect(page).to have_content("SettingsTaxesTax Categories")
       within_row(1) do
         expect(column_text(1)).to eq("Clothing")
         expect(column_text(2)).to eq("CL001")

--- a/backend/spec/features/admin/configuration/tax_categories_spec.rb
+++ b/backend/spec/features/admin/configuration/tax_categories_spec.rb
@@ -12,7 +12,7 @@ describe "Tax Categories", type: :feature do
     it "should display the existing tax categories" do
       create(:tax_category, name: "Clothing", tax_code: "CL001", description: "For Clothing")
       click_link "Tax Categories"
-      expect(page).to have_content("Tax Categories")
+      expect(page).to have_content("Settings / Taxes / Tax Categories")
       within_row(1) do
         expect(column_text(1)).to eq("Clothing")
         expect(column_text(2)).to eq("CL001")

--- a/backend/spec/features/admin/products/edit/products_spec.rb
+++ b/backend/spec/features/admin/products/edit/products_spec.rb
@@ -15,7 +15,7 @@ describe 'Product Details', type: :feature do
 
       click_link 'Product Details'
 
-      expect(page).to have_css('.page-title', text: 'Products / Bún thịt nướng')
+      expect(page).to have_content('ProductsBún thịt nướng')
       expect(page).to have_field('product_name', with: 'Bún thịt nướng')
       expect(page).to have_field('product_slug', with: 'bun-th-t-n-ng')
       expect(page).to have_field('product_description', with: 'lorem ipsum')

--- a/backend/spec/features/admin/products/option_types_spec.rb
+++ b/backend/spec/features/admin/products/option_types_spec.rb
@@ -61,7 +61,7 @@ describe "Option Types", type: :feature do
     create(:option_value)
     click_link "Option Types"
     within('table#listing_option_types') { click_icon :edit }
-    expect(page).to have_content("Editing Option Type")
+    expect(page).to have_content("Products / Option Types / foo-size-")
     expect(page).to have_css("tbody#option_values tr", count: 1)
     within("tbody#option_values") do
       find('.spree_remove_fields').click

--- a/backend/spec/features/admin/products/option_types_spec.rb
+++ b/backend/spec/features/admin/products/option_types_spec.rb
@@ -61,7 +61,7 @@ describe "Option Types", type: :feature do
     create(:option_value)
     click_link "Option Types"
     within('table#listing_option_types') { click_icon :edit }
-    expect(page).to have_content("Products / Option Types / foo-size-")
+    expect(page).to have_content("ProductsOption Typesfoo-size-")
     expect(page).to have_css("tbody#option_values tr", count: 1)
     within("tbody#option_values") do
       find('.spree_remove_fields').click

--- a/backend/spec/features/admin/products/stock_management_spec.rb
+++ b/backend/spec/features/admin/products/stock_management_spec.rb
@@ -36,7 +36,7 @@ describe "Product Stock", type: :feature do
       end
 
       it "renders" do
-        expect(page).to have_content('Products / apache baseball cap')
+        expect(page).to have_content('Productsapache baseball cap')
         expect(page.current_url).to match("admin/products/apache-baseball-cap/stock")
       end
     end

--- a/backend/spec/features/admin/products/stock_management_spec.rb
+++ b/backend/spec/features/admin/products/stock_management_spec.rb
@@ -28,7 +28,7 @@ describe "Product Stock", type: :feature do
         @product = create(:product, name: 'apache baseball cap', price: 10)
         @product.variants.create!(sku: 'FOOBAR')
         Spree::StockLocation.destroy_all
-        click_link "Back To Products List"
+        find_by_id('content-header').click_link('Products')
         within_row(1) do
           click_icon :edit
         end

--- a/backend/spec/features/admin/promotion_adjustments_spec.rb
+++ b/backend/spec/features/admin/promotion_adjustments_spec.rb
@@ -15,7 +15,7 @@ describe "Promotion Adjustments", type: :feature do
       fill_in "Base code", with: "order"
       fill_in "Number of codes", with: "1"
       click_button "Create"
-      expect(page).to have_content("Editing Promotion")
+      expect(page).to have_content("Promotions / Promotion")
 
       select2 "Item total", from: "Add rule of type"
       within('#rule_fields') { click_button "Add" }
@@ -51,7 +51,7 @@ describe "Promotion Adjustments", type: :feature do
       fill_in "Base code", with: "single_use"
       fill_in "Number of codes", with: "1"
       click_button "Create"
-      expect(page).to have_content("Editing Promotion")
+      expect(page).to have_content("Promotions / Promotion")
 
       select2 "Create whole-order adjustment", from: "Add action of type"
       within('#action_fields') { click_button "Add" }
@@ -74,7 +74,7 @@ describe "Promotion Adjustments", type: :feature do
     it "should allow an admin to create an automatic promo with flat percent discount" do
       fill_in "Name", with: "Promotion"
       click_button "Create"
-      expect(page).to have_content("Editing Promotion")
+      expect(page).to have_content("Promotions / Promotion")
 
       select2 "Item total", from: "Add rule of type"
       within('#rule_fields') { click_button "Add" }
@@ -108,7 +108,7 @@ describe "Promotion Adjustments", type: :feature do
 
       fill_in "Name", with: "Promotion"
       click_button "Create"
-      expect(page).to have_content("Editing Promotion")
+      expect(page).to have_content("Promotions / Promotion")
 
       select2 "Product(s)", from: "Add rule of type"
       within("#rule_fields") { click_button "Add" }
@@ -139,7 +139,7 @@ describe "Promotion Adjustments", type: :feature do
     it "should allow an admin to create an automatic promotion with free shipping (no code)" do
       fill_in "Name", with: "Promotion"
       click_button "Create"
-      expect(page).to have_content("Editing Promotion")
+      expect(page).to have_content("Promotions / Promotion")
 
       select2 "Item total", from: "Add rule of type"
       within('#rule_fields') { click_button "Add" }
@@ -160,7 +160,7 @@ describe "Promotion Adjustments", type: :feature do
       fill_in "Name", with: "Promotion"
       fill_in "Path", with: "content/cvv"
       click_button "Create"
-      expect(page).to have_content("Editing Promotion")
+      expect(page).to have_content("Promotions / Promotion")
 
       select2 "Create whole-order adjustment", from: "Add action of type"
       within('#action_fields') { click_button "Add" }
@@ -184,7 +184,7 @@ describe "Promotion Adjustments", type: :feature do
     it "ceasing to be eligible for a promotion with item total rule then becoming eligible again" do
       fill_in "Name", with: "Promotion"
       click_button "Create"
-      expect(page).to have_content("Editing Promotion")
+      expect(page).to have_content("Promotions / Promotion")
 
       select2 "Item total", from: "Add rule of type"
       within('#rule_fields') { click_button "Add" }

--- a/backend/spec/features/admin/promotion_adjustments_spec.rb
+++ b/backend/spec/features/admin/promotion_adjustments_spec.rb
@@ -15,7 +15,7 @@ describe "Promotion Adjustments", type: :feature do
       fill_in "Base code", with: "order"
       fill_in "Number of codes", with: "1"
       click_button "Create"
-      expect(page).to have_content("Promotions / Promotion")
+      expect(page).to have_content("PromotionsPromotion")
 
       select2 "Item total", from: "Add rule of type"
       within('#rule_fields') { click_button "Add" }
@@ -51,7 +51,7 @@ describe "Promotion Adjustments", type: :feature do
       fill_in "Base code", with: "single_use"
       fill_in "Number of codes", with: "1"
       click_button "Create"
-      expect(page).to have_content("Promotions / Promotion")
+      expect(page).to have_content("PromotionsPromotion")
 
       select2 "Create whole-order adjustment", from: "Add action of type"
       within('#action_fields') { click_button "Add" }
@@ -74,7 +74,7 @@ describe "Promotion Adjustments", type: :feature do
     it "should allow an admin to create an automatic promo with flat percent discount" do
       fill_in "Name", with: "Promotion"
       click_button "Create"
-      expect(page).to have_content("Promotions / Promotion")
+      expect(page).to have_content("PromotionsPromotion")
 
       select2 "Item total", from: "Add rule of type"
       within('#rule_fields') { click_button "Add" }
@@ -108,7 +108,7 @@ describe "Promotion Adjustments", type: :feature do
 
       fill_in "Name", with: "Promotion"
       click_button "Create"
-      expect(page).to have_content("Promotions / Promotion")
+      expect(page).to have_content("PromotionsPromotion")
 
       select2 "Product(s)", from: "Add rule of type"
       within("#rule_fields") { click_button "Add" }
@@ -139,7 +139,7 @@ describe "Promotion Adjustments", type: :feature do
     it "should allow an admin to create an automatic promotion with free shipping (no code)" do
       fill_in "Name", with: "Promotion"
       click_button "Create"
-      expect(page).to have_content("Promotions / Promotion")
+      expect(page).to have_content("PromotionsPromotion")
 
       select2 "Item total", from: "Add rule of type"
       within('#rule_fields') { click_button "Add" }
@@ -160,7 +160,7 @@ describe "Promotion Adjustments", type: :feature do
       fill_in "Name", with: "Promotion"
       fill_in "Path", with: "content/cvv"
       click_button "Create"
-      expect(page).to have_content("Promotions / Promotion")
+      expect(page).to have_content("PromotionsPromotion")
 
       select2 "Create whole-order adjustment", from: "Add action of type"
       within('#action_fields') { click_button "Add" }
@@ -184,7 +184,7 @@ describe "Promotion Adjustments", type: :feature do
     it "ceasing to be eligible for a promotion with item total rule then becoming eligible again" do
       fill_in "Name", with: "Promotion"
       click_button "Create"
-      expect(page).to have_content("Promotions / Promotion")
+      expect(page).to have_content("PromotionsPromotion")
 
       select2 "Item total", from: "Add rule of type"
       within('#rule_fields') { click_button "Add" }

--- a/backend/spec/features/admin/reports_spec.rb
+++ b/backend/spec/features/admin/reports_spec.rb
@@ -9,7 +9,7 @@ describe "Reports", type: :feature do
       click_link "Reports"
       click_link "Sales Total"
 
-      expect(page).to have_content("Reports / Sales Total")
+      expect(page).to have_content("ReportsSales Total")
       expect(page).to have_content("Item Total")
       expect(page).to have_content("Adjustment Total")
       expect(page).to have_content("Sales Total")

--- a/backend/spec/features/admin/reports_spec.rb
+++ b/backend/spec/features/admin/reports_spec.rb
@@ -9,7 +9,7 @@ describe "Reports", type: :feature do
       click_link "Reports"
       click_link "Sales Total"
 
-      expect(page).to have_content("Sales Totals")
+      expect(page).to have_content("Reports / Sales Total")
       expect(page).to have_content("Item Total")
       expect(page).to have_content("Adjustment Total")
       expect(page).to have_content("Sales Total")

--- a/backend/spec/features/admin/users_spec.rb
+++ b/backend/spec/features/admin/users_spec.rb
@@ -33,7 +33,7 @@ describe 'Users', type: :feature do
     end
 
     it 'can go back to the users list' do
-      expect(page).to have_link Spree.t(:back_to_users_list), href: spree.admin_users_path
+      expect(page).to have_link Spree::LegacyUser.model_name.human(count: :other), href: spree.admin_users_path
     end
 
     it 'can navigate to the account page' do
@@ -120,7 +120,7 @@ describe 'Users', type: :feature do
 
     it 'can edit user roles' do
       Spree::Role.create name: "admin"
-      click_link user_a.email
+      click_link 'Account'
 
       check 'user_spree_role_admin'
       click_button 'Update'

--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -66,7 +66,7 @@ module Spree
       nil
     end
 
-    def breadcrumbs(taxon, separator = "&nbsp;&raquo;&nbsp;", breadcrumb_class = "inline")
+    def taxon_breadcrumbs(taxon, separator = "&nbsp;&raquo;&nbsp;", breadcrumb_class = "inline")
       return "" if current_page?("/") || taxon.nil?
 
       crumbs = [[Spree.t(:home), spree.root_path]]

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -373,6 +373,9 @@ en:
       spree/exchange:
         one: Exchange
         other: Exchanges
+      spree/image:
+        one: Image
+        other: Images
       spree/inventory_unit:
         one: Inventory Unit
         other: Inventory Units
@@ -470,6 +473,9 @@ en:
       spree/stock_transfer:
         one: Stock Transfer
         other: Stock Transfers
+      spree/store_credit:
+        one: Store Credit
+        other: Store Credits
       spree/store_credit_category:
         one: Category
         other: Categories
@@ -1301,6 +1307,7 @@ en:
     new_stock_location: New Stock Location
     new_stock_movement: New Stock Movement
     new_stock_transfer: New Stock Transfer
+    new_store_credit: New Store Credit
     new_tax_category: New Tax Category
     new_tax_rate: New Tax Rate
     new_taxon: New Taxon

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -345,6 +345,10 @@ en:
         name: Name
         default_tax: Default Tax Zone
     models:
+      # LegacyUser maps to this model_name so we want to provide translations for it
+      user:
+        one: User
+        other: Users
       spree/address:
         one: Address
         other: Addresses

--- a/frontend/app/views/spree/layouts/spree_application.html.erb
+++ b/frontend/app/views/spree/layouts/spree_application.html.erb
@@ -15,7 +15,7 @@
 
       <div id="wrapper" class="row" data-hook>
 
-        <%= breadcrumbs(@taxon) %>
+        <%= taxon_breadcrumbs(@taxon) %>
 
         <%= render :partial => 'spree/shared/sidebar' if content_for? :sidebar %>
 


### PR DESCRIPTION


Adding breadcrumbs will make for better UX.  As requested in #1076.  The button link to indexes have been taken out and replaced with navigatable breadcrumbs at the top of just about every page.

No new partials were added but that might be something we want to look at; pulling out the code in related pages when we can.  However in a lot of cases it would just be pulling 1-2 lines of code into a partial and then still requiring to add some page title code to that individual page.  

Just about every page was touched so the easiest way to get a feel for the changes might be to pull this down and just click around locally.

## Before Breadcrumbs

![no_breadcrumbs_1](https://cloud.githubusercontent.com/assets/12613649/14685849/32b4d488-06eb-11e6-9eff-6c2bf0dcb688.png)
![no_breadcrumbs_2](https://cloud.githubusercontent.com/assets/12613649/14685852/32b87cfa-06eb-11e6-9eb9-8680861fe9ed.png)
![no_breadcrumbs_3](https://cloud.githubusercontent.com/assets/12613649/14685850/32b7c4c2-06eb-11e6-85f4-e73c9bce9c5b.png)
![no_breadcrumbs_4](https://cloud.githubusercontent.com/assets/12613649/14685851/32b7e858-06eb-11e6-9fb8-51754b1b0314.png)

## After Breadcrumbs

![afterbread1](https://cloud.githubusercontent.com/assets/12613649/16249015/0497ff7c-37c8-11e6-8a37-6de0a74cc3e1.png)
![afterbread2](https://cloud.githubusercontent.com/assets/12613649/16249022/0d5c4cb2-37c8-11e6-8430-cfca3c92c362.png)
![afterbread3](https://cloud.githubusercontent.com/assets/12613649/16249024/0ed8174c-37c8-11e6-8b6a-62f52849ced9.png)
![afterbread4](https://cloud.githubusercontent.com/assets/12613649/16249025/0fb67f96-37c8-11e6-9650-21fee1ce696f.png)
