### PR TITLE
Fix migrating preferences from old spree versions

### DIFF
--- a/core/app/models/spree/preferences/statically_configurable.rb
+++ b/core/app/models/spree/preferences/statically_configurable.rb
@@ -22,14 +22,14 @@ module Spree
         if respond_to?(:preference_source) && preference_source
           self.class.preference_sources[preference_source] || {}
         else
-          super
+          self[:preferences]
         end
       end
 
       def preferences=(val)
         if respond_to?(:preference_source) && preference_source
         else
-          super
+          self[:preferences] = val
         end
       end
     end

--- a/core/spec/models/spree/preferences/statically_configurable_spec.rb
+++ b/core/spec/models/spree/preferences/statically_configurable_spec.rb
@@ -9,6 +9,10 @@ module Spree
         def initialize
           @preferences = { color: 'blue' }
         end
+
+        def [](key)
+          return @preferences if key == :preferences
+        end
       end
     end
     let(:klass) do


### PR DESCRIPTION
Previously this failed when migrating from an old version with:

    super: no superclass method 'preferences' for ...

This can be avoided by assigning to the attribute using `AR::Base#[]` instead of calling `super()`.