### PR TITLE
Deprecate Spree::Product.active scope

### DIFF
--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -123,7 +123,7 @@ module Spree
             scope = scope.not_deleted
           end
         else
-          scope = Product.accessible_by(current_ability, :read).active.includes(*product_includes)
+          scope = Product.accessible_by(current_ability, :read).available.includes(*product_includes)
         end
 
         scope

--- a/core/app/models/spree/product/scopes.rb
+++ b/core/app/models/spree/product/scopes.rb
@@ -178,6 +178,7 @@ module Spree
     search_scopes << :available
 
     def self.active(currency = nil)
+      Spree::Deprecation.warn("This scope is deprecated, please use .available instead", caller)
       not_deleted.available(nil, currency)
     end
     search_scopes << :active

--- a/core/app/models/spree/taxon.rb
+++ b/core/app/models/spree/taxon.rb
@@ -85,7 +85,7 @@ module Spree
     # @return [ActiveRecord::Relation<Spree::Product>] the active products the
     #   belong to this taxon
     def active_products
-      products.active
+      products.not_deleted.available
     end
 
     # @return [String] this taxon's ancestors names followed by its own name,

--- a/core/lib/spree/core/search/base.rb
+++ b/core/lib/spree/core/search/base.rb
@@ -33,7 +33,7 @@ module Spree
         protected
 
         def get_base_scope
-          base_scope = Spree::Product.active
+          base_scope = Spree::Product.available
           base_scope = base_scope.in_taxon(taxon) unless taxon.blank?
           base_scope = get_products_conditions_for(base_scope, keywords)
           base_scope = add_search_scopes(base_scope)

--- a/frontend/app/controllers/spree/products_controller.rb
+++ b/frontend/app/controllers/spree/products_controller.rb
@@ -34,7 +34,7 @@ module Spree
       if try_spree_current_user.try(:has_spree_role?, "admin")
         @products = Product.with_deleted
       else
-        @products = Product.active(current_currency)
+        @products = Product.available
       end
       @product = @products.friendly.find(params[:id])
     end


### PR DESCRIPTION
This scope is badly named (calling anything "active" in a rails
project makes searching hard, and it's hard to guess what `active`)
actually means). Besides, there is a `Spree::Variant#active` scope
that does a different thing. Furthermore, it takes two arguments, both of
which are ultimately unused.

Finally, the functionality offered by `.active` can just as well be
had by calling `.available`.