### PR TITLE
Change around SKUS appearance on product page

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
@@ -128,12 +128,14 @@ button, .button {
 }
 
 span.info {
-  font-style: italic;
   font-size: 85%;
   color: lighten($color-body-text, 15);
   display: block;
   line-height: 20px;
   margin: 5px 0;
+  .field & {
+    font-style: italic;
+  }
 }
 
 .field {

--- a/backend/app/assets/stylesheets/spree/backend/shared/_typography.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_typography.scss
@@ -81,7 +81,8 @@ ul {
 ul.text_list {
   border-top: none;
   margin: 0;
-  list-style: disc inside none;
+  list-style-type: none;
+  padding-left: 0;
 }
 
 dl {

--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -76,7 +76,7 @@
           <%= Spree.t(:info_product_has_multiple_skus, count: @product.variants.count) %>
           <ul class="text_list">
             <% @product.variants.first(5).each do |variant| %>
-              <li><%= variant.sku %></li>
+              <li><%= link_to variant.sku, spree.edit_admin_product_variant_path(@product, variant) %></li>
             <% end %>
           </ul>
           <% if @product.variants.count > 5 %>


### PR DESCRIPTION


We wanted to remove the bullets, italics, and the indent.  Did this through minor adjustments to a class we only use in one place and a tweak to the info class so it doesn't italicize in this location. As requested by @Mandily 

## Before
![with_bullets](https://cloud.githubusercontent.com/assets/12613649/14361049/03577fc0-fcae-11e5-81e6-3628e95e9125.png)

## After
![final_changes](https://cloud.githubusercontent.com/assets/12613649/14753820/8b661982-088c-11e6-9c09-076172bc7794.png)