### PR TITLE
loosen paperclip dep to allow minor version upgrades

### DIFF
--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'highline', '~> 1.6.18' # Necessary for the install generator
   s.add_dependency 'kaminari', '~> 0.15', '>= 0.15.1'
   s.add_dependency 'monetize', '~> 1.1'
-  s.add_dependency 'paperclip', '~> 4.2.0'
+  s.add_dependency 'paperclip', '~> 4.2'
   s.add_dependency 'paranoia', '~> 2.1', '>= 2.1.4'
   s.add_dependency 'premailer-rails'
   s.add_dependency 'rails', '~> 4.2.5'


### PR DESCRIPTION
paperclip 4.3.6 is latest as of this writing.