### PR TITLE
Loosen paranoia dependency spec to allow minor version bump

### DIFF
--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'kaminari', '~> 0.15', '>= 0.15.1'
   s.add_dependency 'monetize', '~> 1.1'
   s.add_dependency 'paperclip', '~> 4.2.0'
-  s.add_dependency 'paranoia', '~> 2.1.4'
+  s.add_dependency 'paranoia', '~> 2.1', '>= 2.1.4'
   s.add_dependency 'premailer-rails'
   s.add_dependency 'rails', '~> 4.2.5'
   s.add_dependency 'ransack', '~> 1.6'


### PR DESCRIPTION
Paranoia README suggest locking to major version not minor version,
semver style. At present 2.1.5 is the latest paranoia release,
but this change will allow paranoia 2.2.x if/when released, but not
3.x. 2.1.4 is still the minimum required version, as it was previously.