### PR TITLE
Use safe index changes

### DIFF
--- a/core/db/migrate/20140410141842_add_many_missing_indexes.rb
+++ b/core/db/migrate/20140410141842_add_many_missing_indexes.rb
@@ -1,17 +1,19 @@
 class AddManyMissingIndexes < ActiveRecord::Migration
+  include Spree::MigrationHelpers
+
   def change
-    add_index :spree_adjustments, [:adjustable_id, :adjustable_type]
-    add_index :spree_adjustments, :eligible
-    add_index :spree_adjustments, :order_id
-    add_index :spree_promotions, :code
-    add_index :spree_promotions, :expires_at
-    add_index :spree_states, :country_id
-    add_index :spree_stock_items, :deleted_at
-    add_index :spree_option_types, :position
-    add_index :spree_option_values, :position
-    add_index :spree_product_option_types, :option_type_id
-    add_index :spree_product_option_types, :product_id
-    add_index :spree_products_taxons, :position
-    add_index :spree_promotions, :starts_at
+    safe_add_index :spree_adjustments, [:adjustable_id, :adjustable_type]
+    safe_add_index :spree_adjustments, :eligible
+    safe_add_index :spree_adjustments, :order_id
+    safe_add_index :spree_promotions, :code
+    safe_add_index :spree_promotions, :expires_at
+    safe_add_index :spree_states, :country_id
+    safe_add_index :spree_stock_items, :deleted_at
+    safe_add_index :spree_option_types, :position
+    safe_add_index :spree_option_values, :position
+    safe_add_index :spree_product_option_types, :option_type_id
+    safe_add_index :spree_product_option_types, :product_id
+    safe_add_index :spree_products_taxons, :position
+    safe_add_index :spree_promotions, :starts_at
   end
 end

--- a/core/db/migrate/20140410150358_correct_some_polymorphic_index_and_add_more_missing.rb
+++ b/core/db/migrate/20140410150358_correct_some_polymorphic_index_and_add_more_missing.rb
@@ -1,63 +1,65 @@
 class CorrectSomePolymorphicIndexAndAddMoreMissing < ActiveRecord::Migration
+  include Spree::MigrationHelpers
+
   def change
-    add_index :spree_addresses, :country_id
-    add_index :spree_addresses, :state_id
+    safe_add_index :spree_addresses, :country_id
+    safe_add_index :spree_addresses, :state_id
 
-    remove_index :spree_adjustments, [:source_type, :source_id]
-    add_index :spree_adjustments, [:source_id, :source_type]
+    safe_remove_index :spree_adjustments, [:source_type, :source_id]
+    safe_add_index :spree_adjustments, [:source_id, :source_type]
 
-    add_index :spree_inventory_units, :return_authorization_id
+    safe_add_index :spree_inventory_units, :return_authorization_id
 
-    add_index :spree_log_entries, [:source_id, :source_type]
+    safe_add_index :spree_log_entries, [:source_id, :source_type]
 
-    add_index :spree_orders, :approver_id
-    add_index :spree_orders, :created_by_id
-    add_index :spree_orders, :ship_address_id
-    add_index :spree_orders, :bill_address_id
-    add_index :spree_orders, :considered_risky
+    safe_add_index :spree_orders, :approver_id
+    safe_add_index :spree_orders, :created_by_id
+    safe_add_index :spree_orders, :ship_address_id
+    safe_add_index :spree_orders, :bill_address_id
+    safe_add_index :spree_orders, :considered_risky
 
-    add_index :spree_orders_promotions, [:order_id, :promotion_id]
+    safe_add_index :spree_orders_promotions, [:order_id, :promotion_id]
 
-    add_index :spree_payments, [:source_id, :source_type]
+    safe_add_index :spree_payments, [:source_id, :source_type]
 
-    add_index :spree_product_option_types, :position
+    safe_add_index :spree_product_option_types, :position
 
-    add_index :spree_product_properties, :position
-    add_index :spree_product_properties, :property_id
+    safe_add_index :spree_product_properties, :position
+    safe_add_index :spree_product_properties, :property_id
 
-    add_index :spree_promotion_action_line_items, :promotion_action_id
-    add_index :spree_promotion_action_line_items, :variant_id
+    safe_add_index :spree_promotion_action_line_items, :promotion_action_id
+    safe_add_index :spree_promotion_action_line_items, :variant_id
 
-    add_index :spree_promotion_rules, :promotion_id
+    safe_add_index :spree_promotion_rules, :promotion_id
 
-    add_index :spree_promotions, :advertise
+    safe_add_index :spree_promotions, :advertise
 
-    add_index :spree_return_authorizations, :number
-    add_index :spree_return_authorizations, :order_id
-    add_index :spree_return_authorizations, :stock_location_id
+    safe_add_index :spree_return_authorizations, :number
+    safe_add_index :spree_return_authorizations, :order_id
+    safe_add_index :spree_return_authorizations, :stock_location_id
 
-    add_index :spree_shipments, :address_id
+    safe_add_index :spree_shipments, :address_id
 
-    add_index :spree_shipping_methods, :tax_category_id
+    safe_add_index :spree_shipping_methods, :tax_category_id
 
-    add_index :spree_state_changes, [:stateful_id, :stateful_type]
-    add_index :spree_state_changes, :user_id
+    safe_add_index :spree_state_changes, [:stateful_id, :stateful_type]
+    safe_add_index :spree_state_changes, :user_id
 
-    add_index :spree_stock_locations, :country_id
-    add_index :spree_stock_locations, :state_id
+    safe_add_index :spree_stock_locations, :country_id
+    safe_add_index :spree_stock_locations, :state_id
 
-    add_index :spree_tax_rates, :deleted_at
-    add_index :spree_tax_rates, :tax_category_id
-    add_index :spree_tax_rates, :zone_id
+    safe_add_index :spree_tax_rates, :deleted_at
+    safe_add_index :spree_tax_rates, :tax_category_id
+    safe_add_index :spree_tax_rates, :zone_id
 
-    add_index :spree_taxonomies, :position
+    safe_add_index :spree_taxonomies, :position
 
-    add_index :spree_taxons, :position
+    safe_add_index :spree_taxons, :position
 
-    add_index :spree_variants, :position
-    add_index :spree_variants, :track_inventory
+    safe_add_index :spree_variants, :position
+    safe_add_index :spree_variants, :track_inventory
 
-    add_index :spree_zone_members, :zone_id
-    add_index :spree_zone_members, [:zoneable_id, :zoneable_type]
+    safe_add_index :spree_zone_members, :zone_id
+    safe_add_index :spree_zone_members, [:zoneable_id, :zoneable_type]
   end
 end

--- a/core/db/migrate/20141217215630_update_product_slug_index.rb
+++ b/core/db/migrate/20141217215630_update_product_slug_index.rb
@@ -1,6 +1,8 @@
 class UpdateProductSlugIndex < ActiveRecord::Migration
+  include Spree::MigrationHelpers
+
   def change
-    remove_index :spree_products, :slug
-    add_index :spree_products, :slug, unique: true
+    safe_remove_index :spree_products, :slug
+    safe_add_index :spree_products, :slug, unique: true
   end
 end

--- a/core/db/migrate/20150723224133_remove_unnecessary_indexes.rb
+++ b/core/db/migrate/20150723224133_remove_unnecessary_indexes.rb
@@ -4,6 +4,8 @@
 # migration deletes any of the indexes left around in stores using the
 # out-dated version of that migration
 class RemoveUnnecessaryIndexes < ActiveRecord::Migration
+  include Spree::MigrationHelpers
+
   def up
     safe_remove_index :spree_credit_cards, :address_id
     safe_remove_index :spree_gateways, :active
@@ -58,15 +60,5 @@ class RemoveUnnecessaryIndexes < ActiveRecord::Migration
     safe_add_index :spree_variants, :is_master
     safe_add_index :spree_variants, :deleted_at
     safe_add_index :spree_zones, :default_tax
-  end
-
-  private
-
-  def safe_remove_index(table, column)
-    remove_index(table, column) if index_exists?(table, column)
-  end
-
-  def safe_add_index(table, column)
-    add_index(table, column) if column_exists?(table, column)
   end
 end

--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -68,6 +68,7 @@ require 'spree/core/environment/calculators'
 require 'spree/core/environment'
 require 'spree/promo/environment'
 require 'spree/migrations'
+require 'spree/migration_helpers'
 require 'spree/core/engine'
 
 require 'spree/i18n'

--- a/core/lib/spree/migration_helpers.rb
+++ b/core/lib/spree/migration_helpers.rb
@@ -1,0 +1,19 @@
+module Spree
+  module MigrationHelpers
+    def safe_remove_index(table, column)
+      remove_index(table, column) if index_exists?(table, column)
+    end
+
+    def safe_add_index(table, column, options = {})
+      if columns_exist?(table, column) && !index_exists?(table, column, options)
+        add_index(table, column, options)
+      end
+    end
+
+    private
+
+    def columns_exist?(table, columns)
+      Array.wrap(columns).all? { |column| column_exists?(table, column) }
+    end
+  end
+end


### PR DESCRIPTION
Some Spree stores migrating to Solidus may have backported these indexes
or used custom names to define these indexes. No need to stop the
migrations from running if they already exist or don't exist.