### PR TITLE
Fixed incorrect reference to Spree::Config option :can_restrict_stock…

### DIFF
--- a/backend/app/views/spree/admin/users/_form.html.erb
+++ b/backend/app/views/spree/admin/users/_form.html.erb
@@ -31,7 +31,7 @@
       </div>
     <% end %>
 
-    <% if Spree::Config[:can_restrict_stock_management] && can?(:display, Spree::StockLocation) %>
+    <% if Spree::Config.preferences[:can_restrict_stock_management] && can?(:display, Spree::StockLocation) %>
       <div data-hook="admin_user_form_stock_locations" class="field">
         <%= label_tag nil, Spree::StockLocation.model_name.human(count: :other) %>
         <ul>


### PR DESCRIPTION
Fixed incorrect reference to Spree::Config option :can_restrict_stock_management

```
irb(main):043:0> Spree::Config.preferences[:can_restrict_stock_management]
=> nil
irb(main):044:0> Spree::Config[:can_restrict_stock_management]
NoMethodError: can_restrict_stock_management preference not defined
	from /usr/local/var/rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/solidus_core-1.2.2/app/models/spree/preferences/preferable.rb:74:in `has_preference!'
	from /usr/local/var/rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/solidus_core-1.2.2/app/models/spree/preferences/preferable.rb:45:in `get_preference'
	from (irb):44
	from /usr/local/var/rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/railties-4.2.5/lib/rails/commands/console.rb:110:in `start'
	from /usr/local/var/rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/railties-4.2.5/lib/rails/commands/console.rb:9:in `start'
	from /usr/local/var/rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/railties-4.2.5/lib/rails/commands/commands_tasks.rb:68:in `console'
	from /usr/local/var/rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/railties-4.2.5/lib/rails/commands/commands_tasks.rb:39:in `run_command!'
	from /usr/local/var/rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/railties-4.2.5/lib/rails/commands.rb:17:in `<top (required)>'
	from bin/rails:4:in `require'
	from bin/rails:4:in `<main>'
```