### PR TITLE
set_count_on_hand should use lock just like adjust_count_on_hand

### DIFF
--- a/core/app/models/spree/stock_item.rb
+++ b/core/app/models/spree/stock_item.rb
@@ -45,10 +45,12 @@ module Spree
     # @note This will cause backorders to be processed.
     # @param value [Fixnum] the desired count on hand
     def set_count_on_hand(value)
-      self.count_on_hand = value
-      process_backorders(count_on_hand - count_on_hand_was)
+      with_lock do
+        self.count_on_hand = value
+        process_backorders(count_on_hand - count_on_hand_was)
 
-      save!
+        save!
+      end
     end
 
     # @return [Boolean] true if this stock item's count on hand is not zero


### PR DESCRIPTION
No idea how to write a test for this. But if adjust_count_on_hand, right
above this method, needs a db lock to avoid race conditions -- then surely
set_count_on_hand does too, no?  

Or if neither does, that's a different PR.
