### PR TITLE
Fix Reimbursement show page (references non-existent class)

### DIFF
--- a/backend/app/views/spree/admin/reimbursements/show.html.erb
+++ b/backend/app/views/spree/admin/reimbursements/show.html.erb
@@ -79,7 +79,7 @@
     <thead data-hook="customer_return_header">
       <tr>
         <th><%= Spree.t(:description) %></th>
-        <th><%= Spree::ReimbursementCredit.human_attribute_name(:amount) %></th>
+        <th><%= Spree::Reimbursement::Credit.human_attribute_name(:amount) %></th>
       </tr>
     </thead>
     <tbody>

--- a/backend/spec/features/admin/reimbursements_spec.rb
+++ b/backend/spec/features/admin/reimbursements_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe 'Promotions', type: :feature do
+  stub_authorization!
+  let!(:reimbursement) { create(:reimbursement) }
+
+  it "should display the reimbursements table" do
+    visit spree.admin_order_reimbursement_path(reimbursement.order, reimbursement)
+    expect(page).to have_css('table thead tr th', text: 'Product')
+    expect(page).to have_css('table thead tr th', text: 'Preferred Reimbursement Type')
+    expect(page).to have_css('table thead tr th', text: 'Reimbursement Type Override')
+    expect(page).to have_css('table thead tr th', text: 'Exchange for')
+    expect(page).to have_css('table thead tr th', text: 'Amount Before Sales Tax')
+    expect(page).to have_css('table thead tr th', text: 'Total')
+  end
+end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -189,7 +189,7 @@ en:
         number: Number
         reimbursement_status: Status
         total: Total
-      spree/reimbursement_credit:
+      spree/reimbursement/credit:
         amount: Amount
       spree/reimbursement_type:
         name: Name


### PR DESCRIPTION
I cherry picked in #1092 and added a spec as requested by @cbrunsdon. Thanks to @adaddeo for catching the breaking change I'd snuck into master.