### PR TITLE
Don't stub nonexistant available_shipping_methods

### DIFF
--- a/frontend/spec/controllers/spree/checkout_controller_spec.rb
+++ b/frontend/spec/controllers/spree/checkout_controller_spec.rb
@@ -83,7 +83,6 @@ describe Spree::CheckoutController, type: :controller do
 
       before do
         # Must have *a* shipping method and a payment method so updating from address works
-        allow(order).to receive_messages available_shipping_methods: [stub_model(Spree::ShippingMethod)]
         allow(order).to receive_messages available_payment_methods: [stub_model(Spree::PaymentMethod)]
         allow(order).to receive_messages ensure_available_shipping_rates: true
         order.line_items << FactoryGirl.create(:line_item)


### PR DESCRIPTION
Eric Saupe brought this up in slack, this method does not exist and
should not be stubbed. Was discovered by using verifying doubles in his
local specs.