### PR TITLE
Add regression spec + bugfix #1087 Submitting nil stock transfer form 

### DIFF
--- a/backend/app/controllers/spree/admin/stock_transfers_controller.rb
+++ b/backend/app/controllers/spree/admin/stock_transfers_controller.rb
@@ -82,7 +82,7 @@ module Spree
       end
 
       def render_after_create_error
-        load_stock_locations
+        load_source_stock_locations
         super
       end
 

--- a/backend/spec/controllers/spree/admin/stock_transfers_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/stock_transfers_controller_spec.rb
@@ -97,6 +97,18 @@ module Spree
           expect(assigns(:stock_transfer).created_by).to eq(user)
         end
       end
+
+      # Regression spec for Solidus issue #1087
+      context "missing source_stock_location parameter" do
+        subject do
+          spree_post :create, stock_transfer: { source_location_id: nil, description: nil }
+        end
+
+        it "sets a flash error" do
+          subject
+          expect(flash[:error]).to eq assigns(:stock_transfer).errors.full_messages.join(', ')
+        end
+      end
     end
 
     context "#receive" do

--- a/backend/spec/features/admin/stock_transfer_spec.rb
+++ b/backend/spec/features/admin/stock_transfer_spec.rb
@@ -30,6 +30,17 @@ describe 'Stock Transfers', type: :feature, js: true do
       expect(page).to have_content('Stock Transfer has been successfully updated')
       expect(page).to have_content("NY")
     end
+
+    # Regression spec for Solidus issue #1087
+    it 'displays an error if no source location is selected' do
+      create(:stock_location_with_items, name: 'NY')
+      create(:stock_location, name: 'SF')
+      visit spree.new_admin_stock_transfer_path
+      fill_in 'stock_transfer_description', with: description
+      click_button 'Continue'
+
+      expect(page).to have_content("Source location can't be blank")
+    end
   end
 
   describe 'view a stock transfer' do


### PR DESCRIPTION
Added regression specs and small fix for #1087 

The fallback method was not updated after a refactoring of the load_stock_locations method