### PR TITLE
product_picker.js sku lookup actually works

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/product_picker.js
+++ b/backend/app/assets/javascripts/spree/backend/product_picker.js
@@ -28,9 +28,9 @@ $.fn.productAutocomplete = function (options) {
         return {
           q: {
             name_cont: term,
-            sku_cont: term
+            master_sku_cont: term,
+            m: 'or'
           },
-          m: 'OR',
           token: Spree.api_key,
           page: page
         };

--- a/backend/app/assets/javascripts/spree/backend/product_picker.js
+++ b/backend/app/assets/javascripts/spree/backend/product_picker.js
@@ -28,7 +28,7 @@ $.fn.productAutocomplete = function (options) {
         return {
           q: {
             name_cont: term,
-            master_sku_cont: term,
+            master_sku_eq: term,
             m: 'or'
           },
           token: Spree.api_key,

--- a/backend/app/assets/javascripts/spree/backend/product_picker.js
+++ b/backend/app/assets/javascripts/spree/backend/product_picker.js
@@ -28,7 +28,7 @@ $.fn.productAutocomplete = function (options) {
         return {
           q: {
             name_cont: term,
-            master_sku_eq: term,
+            variants_including_master_sku_start: term,
             m: 'or'
           },
           token: Spree.api_key,


### PR DESCRIPTION
This is used in the backend UI for picking products for
Spree::Promotion::Rules::Product, might be used other places too.

There was code in there that looked like someone was trying to
let the query match a product name or sku. But it totally didn't work,
didn't do anything, was wrong in like two or three different ways. (useless ransack attribute name for `sku`; `m` has to be inside the `q`; value of `m` has to be lowercased `or` not `OR`). 

Took me a couple hours to figure out what was going on, so I figured
I'd share the fix. Sorry, don't know how to test this, looks like
there aren't any tests for this kind of JS yet?