### PR TITLE
Fix spurious spec failure due to DB ordering

### DIFF
--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -13,7 +13,7 @@ describe "Order Details", type: :feature, js: true do
   let!(:shipping_method) { create(:shipping_method, name: "Default") }
 
   before do
-    order.shipments.create(stock_location_id: stock_location.id)
+    @shipment1 = order.shipments.create(stock_location_id: stock_location.id)
     order.contents.add(product.master, 2)
   end
 
@@ -387,7 +387,7 @@ describe "Order Details", type: :feature, js: true do
             click_on 'Choose location'
             within '.select2-results' do
               expect(page).to have_content(@shipment2.number)
-              expect(page).not_to have_content(order.shipments[0].number)
+              expect(page).not_to have_content(@shipment1.number)
             end
           end
 


### PR DESCRIPTION
In #1052, I inadvertently introduced a spurious failure due to DB ordering. It is valid for the DB to return `order.shipments` in any order, so `order.shipments[0]` wasn't always the right shipment.

The error can be seen here: https://circleci.com/gh/solidusio/solidus/3275#artifacts