### PR TITLE
Remove redundant code in Api::ShipmentsController

### DIFF
--- a/api/app/controllers/spree/api/shipments_controller.rb
+++ b/api/app/controllers/spree/api/shipments_controller.rb
@@ -21,11 +21,6 @@ module Spree
       end
 
       def create
-        # TODO: Can remove conditional here once deprecated #find_order is removed.
-        unless @order.present?
-          @order = Spree::Order.find_by!(number: params[:shipment][:order_id])
-          authorize! :read, @order
-        end
         authorize! :create, Shipment
         quantity = params[:quantity].to_i
         @shipment = @order.shipments.create(stock_location_id: params.fetch(:stock_location_id))


### PR DESCRIPTION
The removed code had already been refactored into its own method and is being called in a before_filter,  it was probably left in the create method by accident.