### PR TITLE
Improve PermittedAttributes extensibility

### DIFF
--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -11,9 +11,6 @@ module Spree
       include Spree::Core::ControllerHelpers::Pricing
       include Spree::Core::ControllerHelpers::StrongParameters
 
-      class_attribute :admin_line_item_attributes
-      self.admin_line_item_attributes = [:price, :variant_id, :sku]
-
       attr_accessor :current_api_user
 
       class_attribute :error_notifier
@@ -34,11 +31,7 @@ module Spree
 
       # users should be able to set price when importing orders via api
       def permitted_line_item_attributes
-        if can?(:admin, Spree::LineItem)
-          super + admin_line_item_attributes
-        else
-          super
-        end
+        can?(:admin, Spree::LineItem) ? permitted_admin_line_item_attributes : super
       end
 
       def load_user
@@ -103,6 +96,7 @@ module Spree
       def api_key
         request.headers["X-Spree-Token"] || params[:token]
       end
+
       helper_method :api_key
 
       def order_token

--- a/api/app/controllers/spree/api/line_items_controller.rb
+++ b/api/app/controllers/spree/api/line_items_controller.rb
@@ -1,10 +1,6 @@
 module Spree
   module Api
     class LineItemsController < Spree::Api::BaseController
-      class_attribute :line_item_options
-
-      self.line_item_options = []
-
       before_filter :load_order, only: [:create, :update, :destroy]
       around_filter :lock_order, only: [:create, :update, :destroy]
 
@@ -66,11 +62,7 @@ module Spree
       end
 
       def line_item_params
-        params.require(:line_item).permit(
-          :quantity,
-            :variant_id,
-            options: line_item_options
-        )
+        params.require(:line_item).permit(permitted_line_item_attributes)
       end
     end
   end

--- a/api/app/controllers/spree/api/orders_controller.rb
+++ b/api/app/controllers/spree/api/orders_controller.rb
@@ -1,12 +1,6 @@
 module Spree
   module Api
     class OrdersController < Spree::Api::BaseController
-      class_attribute :admin_shipment_attributes
-      self.admin_shipment_attributes = [:shipping_method, :stock_location, inventory_units: [:variant_id, :sku]]
-
-      class_attribute :admin_order_attributes
-      self.admin_order_attributes = [:import, :number, :completed_at, :locked_at, :channel, :user_id, :created_at]
-
       skip_before_action :authenticate_user, only: :apply_coupon_code
 
       before_action :find_order, except: [:create, :mine, :current, :index]
@@ -119,15 +113,11 @@ module Spree
       end
 
       def permitted_order_attributes
-        can?(:admin, Spree::Order) ? (super + admin_order_attributes) : super
+        can?(:admin, Spree::Order) ? permitted_admin_order_attributes : super
       end
 
       def permitted_shipment_attributes
-        if can?(:admin, Spree::Shipment)
-          super + admin_shipment_attributes
-        else
-          super
-        end
+        can?(:admin, Spree::Shipment) ? (super + permitted_admin_shipment_attributes) : super
       end
 
       def find_order(_lock = false)

--- a/api/spec/controllers/spree/api/line_items_controller_spec.rb
+++ b/api/spec/controllers/spree/api/line_items_controller_spec.rb
@@ -2,15 +2,12 @@ require 'spec_helper'
 
 module Spree
   PermittedAttributes::Base.module_eval do
-    mattr_writer :line_item_attributes
+    mattr_writer :line_item_option_attributes
   end
 
-  unless PermittedAttributes::Base.line_item_attributes.include? :some_option
-    PermittedAttributes::Base.line_item_attributes += [:some_option]
+  unless PermittedAttributes::Base.line_item_option_attributes.include? :some_option
+    PermittedAttributes::Base.line_item_option_attributes += [:some_option]
   end
-
-  # This should go in an initializer
-  Spree::Api::LineItemsController.line_item_options += [:some_option]
 
   describe Api::LineItemsController, type: :controller do
     render_views

--- a/api/spec/controllers/spree/api/line_items_controller_spec.rb
+++ b/api/spec/controllers/spree/api/line_items_controller_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 
 module Spree
-  PermittedAttributes.module_eval do
+  PermittedAttributes::Base.module_eval do
     mattr_writer :line_item_attributes
   end
 
-  unless PermittedAttributes.line_item_attributes.include? :some_option
-    PermittedAttributes.line_item_attributes += [:some_option]
+  unless PermittedAttributes::Base.line_item_attributes.include? :some_option
+    PermittedAttributes::Base.line_item_attributes += [:some_option]
   end
 
   # This should go in an initializer

--- a/api/spec/controllers/spree/api/orders_controller_spec.rb
+++ b/api/spec/controllers/spree/api/orders_controller_spec.rb
@@ -2,6 +2,14 @@ require 'spec_helper'
 require 'spree/testing_support/bar_ability'
 
 module Spree
+  PermittedAttributes::Base.module_eval do
+    mattr_writer :line_item_option_attributes
+  end
+
+  unless PermittedAttributes::Base.line_item_option_attributes.include? :some_option
+    PermittedAttributes::Base.line_item_option_attributes += [:some_option]
+  end
+
   describe Api::OrdersController, type: :controller do
     render_views
     let!(:order) { create(:order) }
@@ -121,7 +129,7 @@ module Spree
         end
 
         it "updates the otherwise forbidden attributes" do
-          expect{ subject }.to change{ order.reload.number }.
+          expect { subject }.to change { order.reload.number }.
             to("anothernumber")
         end
       end
@@ -133,7 +141,7 @@ module Spree
         end
 
         it "does not change forbidden attributes" do
-          expect{ subject }.to_not change{ order.reload.number }
+          expect { subject }.to_not change { order.reload.number }
         end
       end
     end
@@ -353,17 +361,12 @@ module Spree
     end
 
     # Regression test for https://github.com/spree/spree/issues/3404
-    it "can specify additional parameters for a line item" do
-      expect(Order).to receive(:create!).and_return(order = Spree::Order.new)
-      allow(order).to receive(:associate_user!)
-      allow(order).to receive_message_chain(:contents, :add).and_return(line_item = double('LineItem'))
-      expect(line_item).to receive(:update_attributes!).with("special" => true)
-
-      allow(controller).to receive_messages(permitted_line_item_attributes: [:id, :variant_id, :quantity, :special])
+    it "can specify additional parameters via options for a line item" do
+      expect_any_instance_of(LineItem).to receive(:some_option=).with(4)
       api_post :create, order: {
         line_items: {
           "0" => {
-            variant_id: variant.to_param, quantity: 5, special: true
+            variant_id: variant.to_param, quantity: 5, options: { some_option: 4 }
           }
         }
       }
@@ -374,7 +377,7 @@ module Spree
       api_post :create, order: {
         line_items: {
           "0" => {
-            price: 33.0, variant_id: variant.to_param, quantity: 5
+            variant_id: variant.to_param, quantity: 5, options: { price: 33.0 }
           }
         }
       }
@@ -407,13 +410,13 @@ module Spree
       let(:address_params) { { country_id: country.id } }
       let(:billing_address) {
         { firstname: "Tiago", lastname: "Motta", address1: "Av Paulista",
-                                city: "Sao Paulo", zipcode: "01310-300", phone: "12345678",
-                                country_id: country.id }
+          city: "Sao Paulo", zipcode: "01310-300", phone: "12345678",
+          country_id: country.id }
       }
       let(:shipping_address) {
         { firstname: "Tiago", lastname: "Motta", address1: "Av Paulista",
-                                 city: "Sao Paulo", zipcode: "01310-300", phone: "12345678",
-                                 country_id: country.id }
+          city: "Sao Paulo", zipcode: "01310-300", phone: "12345678",
+          country_id: country.id }
       }
       let(:country) { create(:country, { name: "Brazil", iso_name: "BRAZIL", iso: "BR", iso3: "BRA", numcode: 76 }) }
 
@@ -450,7 +453,7 @@ module Spree
       it "cannot change the price of an existing line item" do
         api_put :update, id: order.to_param, order: {
           line_items: {
-            0 => { id: line_item.id, price: 0 }
+            0 => { id: line_item.id, options: { price: 0 } }
           }
         }
 
@@ -728,7 +731,7 @@ module Spree
           api_post :create, order: {
             line_items: {
               "0" => {
-                price: 33.0, variant_id: variant.to_param, quantity: 5
+                variant_id: variant.to_param, quantity: 5, options: { price: 33.0 }
               }
             }
           }

--- a/backend/app/controllers/spree/admin/general_settings_controller.rb
+++ b/backend/app/controllers/spree/admin/general_settings_controller.rb
@@ -30,7 +30,7 @@ module Spree
       end
 
       def permitted_params
-        Spree::PermittedAttributes.store_attributes
+        Spree::PermittedAttributes::Base.store_attributes
       end
 
       def set_store

--- a/core/app/models/spree/order_contents.rb
+++ b/core/app/models/spree/order_contents.rb
@@ -86,7 +86,7 @@ module Spree
       )
 
       line_item.quantity += quantity.to_i
-      line_item.options = ActionController::Parameters.new(options).permit(PermittedAttributes::Base.line_item_attributes)
+      line_item.options = options.except(:stock_location_quantities, :shipment)
 
       if line_item.new_record?
         create_order_stock_locations(line_item, options[:stock_location_quantities])

--- a/core/app/models/spree/order_contents.rb
+++ b/core/app/models/spree/order_contents.rb
@@ -86,7 +86,7 @@ module Spree
       )
 
       line_item.quantity += quantity.to_i
-      line_item.options = ActionController::Parameters.new(options).permit(PermittedAttributes.line_item_attributes)
+      line_item.options = ActionController::Parameters.new(options).permit(PermittedAttributes::Base.line_item_attributes)
 
       if line_item.new_record?
         create_order_stock_locations(line_item, options[:stock_location_quantities])

--- a/core/lib/spree/core/controller_helpers/strong_parameters.rb
+++ b/core/lib/spree/core/controller_helpers/strong_parameters.rb
@@ -24,6 +24,18 @@ module Spree
           ]
         end
 
+        def permitted_line_item_attributes
+          base_attributes.line_item_attributes + [
+            options: base_attributes.line_item_option_attributes
+          ]
+        end
+
+        def permitted_admin_line_item_attributes
+          base_attributes.line_item_attributes + admin_attributes.line_item_attributes + [
+            options: base_attributes.line_item_option_attributes
+          ]
+        end
+
         def permitted_payment_attributes
           base_attributes.payment_attributes + [
             source_attributes: permitted_source_attributes

--- a/core/lib/spree/core/controller_helpers/strong_parameters.rb
+++ b/core/lib/spree/core/controller_helpers/strong_parameters.rb
@@ -2,34 +2,42 @@ module Spree
   module Core
     module ControllerHelpers
       module StrongParameters
-        def permitted_attributes
+        def base_attributes
           Spree::PermittedAttributes
         end
 
         delegate(*Spree::PermittedAttributes::ATTRIBUTES,
-                 to: :permitted_attributes,
+                 to: :base_attributes,
                  prefix: :permitted)
 
+        def admin_attributes
+          Spree::PermittedAttributes::Admin
+        end
+
+        delegate(*Spree::PermittedAttributes::Admin::ATTRIBUTES,
+                 to: :admin_attributes,
+                 prefix: :permitted_admin)
+
         def permitted_credit_card_update_attributes
-          permitted_attributes.credit_card_update_attributes + [
+          base_attributes.credit_card_update_attributes + [
             address_attributes: permitted_address_attributes
           ]
         end
 
         def permitted_payment_attributes
-          permitted_attributes.payment_attributes + [
+          base_attributes.payment_attributes + [
             source_attributes: permitted_source_attributes
           ]
         end
 
         def permitted_source_attributes
-          permitted_attributes.source_attributes + [
+          base_attributes.source_attributes + [
             address_attributes: permitted_address_attributes
           ]
         end
 
         def permitted_checkout_attributes
-          permitted_attributes.checkout_attributes + [
+          base_attributes.checkout_attributes + [
             bill_address_attributes: permitted_address_attributes,
             ship_address_attributes: permitted_address_attributes,
             payments_attributes: permitted_payment_attributes,
@@ -43,14 +51,20 @@ module Spree
           ]
         end
 
+        def permitted_admin_order_attributes
+          permitted_checkout_attributes + admin_attributes.order_attributes + [
+            line_items_attributes: permitted_admin_line_item_attributes
+          ]
+        end
+
         def permitted_product_attributes
-          permitted_attributes.product_attributes + [
+          base_attributes.product_attributes + [
             product_properties_attributes: permitted_product_properties_attributes
           ]
         end
 
         def permitted_user_attributes
-          permitted_attributes.user_attributes + [
+          base_attributes.user_attributes + [
             bill_address_attributes: permitted_address_attributes,
             ship_address_attributes: permitted_address_attributes
           ]

--- a/core/lib/spree/core/controller_helpers/strong_parameters.rb
+++ b/core/lib/spree/core/controller_helpers/strong_parameters.rb
@@ -32,7 +32,7 @@ module Spree
 
         def permitted_admin_line_item_attributes
           base_attributes.line_item_attributes + admin_attributes.line_item_attributes + [
-            options: base_attributes.line_item_option_attributes
+            options: base_attributes.line_item_option_attributes + admin_attributes.line_item_option_attributes
           ]
         end
 

--- a/core/lib/spree/core/importer/order.rb
+++ b/core/lib/spree/core/importer/order.rb
@@ -97,15 +97,8 @@ module Spree
         def self.create_line_items_from_params(line_items_hash, order)
           return {} unless line_items_hash
           line_items_hash.each_key do |k|
-            extra_params = line_items_hash[k].except(:variant_id, :quantity, :sku)
             line_item = ensure_variant_id_from_params(line_items_hash[k])
-            line_item = order.contents.add(Spree::Variant.find(line_item[:variant_id]), line_item[:quantity])
-            # Raise any errors with saving to prevent import succeeding with line items failing silently.
-            if extra_params.present?
-              line_item.update_attributes!(extra_params)
-            else
-              line_item.save!
-            end
+            order.contents.add(Spree::Variant.find(line_item[:variant_id]), line_item[:quantity], line_item[:options] || {})
           end
         end
 

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -102,7 +102,7 @@ module Spree
       :quantity, :stock_item, :stock_item_id, :originator, :action]
 
     @@store_attributes = [:name, :url, :seo_title, :meta_keywords,
-                          :meta_description, :default_currency, :mail_from_address]
+      :meta_description, :default_currency, :mail_from_address]
 
     @@taxonomy_attributes = [:name]
 
@@ -125,3 +125,5 @@ module Spree
       :weight, :height, :width, :depth, :sku, :cost_currency, option_value_ids: [], options: [:name, :value]]
   end
 end
+
+require 'spree/permitted_attributes/admin'

--- a/core/lib/spree/permitted_attributes/admin.rb
+++ b/core/lib/spree/permitted_attributes/admin.rb
@@ -1,0 +1,19 @@
+module Spree
+  module PermittedAttributes
+    module Admin
+      ATTRIBUTES = [
+        :line_item_attributes,
+        :order_attributes,
+        :shipment_attributes
+      ]
+
+      mattr_reader(*ATTRIBUTES)
+
+      @@line_item_attributes = [:price, :variant_id, :sku] + PermittedAttributes.line_item_attributes
+
+      @@order_attributes = [:import, :number, :completed_at, :locked_at, :channel, :user_id, :created_at]
+
+      @@shipment_attributes = [:shipping_method, :stock_location, inventory_units: [:variant_id, :sku]] + PermittedAttributes.shipment_attributes
+    end
+  end
+end

--- a/core/lib/spree/permitted_attributes/admin.rb
+++ b/core/lib/spree/permitted_attributes/admin.rb
@@ -2,6 +2,7 @@ module Spree
   module PermittedAttributes
     module Admin
       ATTRIBUTES = [
+        :line_item_option_attributes,
         :line_item_attributes,
         :order_attributes,
         :shipment_attributes
@@ -9,7 +10,9 @@ module Spree
 
       mattr_reader(*ATTRIBUTES)
 
-      @@line_item_attributes = [:price, :variant_id, :sku] + PermittedAttributes.line_item_attributes
+      @@line_item_option_attributes = [:price]
+
+      @@line_item_attributes = [:sku] + PermittedAttributes.line_item_attributes
 
       @@order_attributes = [:import, :number, :completed_at, :locked_at, :channel, :user_id, :created_at]
 

--- a/core/spec/lib/spree/core/controller_helpers/strong_parameters_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/strong_parameters_spec.rb
@@ -43,6 +43,18 @@ describe Spree::Core::ControllerHelpers::StrongParameters, type: :controller do
     end
   end
 
+  describe '#permitted_line_item_attributes' do
+    it 'returns Array class' do
+      expect(controller.permitted_line_item_attributes.class).to eq Array
+    end
+  end
+
+  describe '#permitted_admin_line_item_attributes' do
+    it 'returns Array class' do
+      expect(controller.permitted_admin_line_item_attributes.class).to eq Array
+    end
+  end
+
   describe '#permitted_admin_order_attributes' do
     it 'returns Array class' do
       expect(controller.permitted_admin_order_attributes.class).to eq Array

--- a/core/spec/lib/spree/core/controller_helpers/strong_parameters_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/strong_parameters_spec.rb
@@ -7,9 +7,15 @@ end
 describe Spree::Core::ControllerHelpers::StrongParameters, type: :controller do
   controller(FakesController) {}
 
-  describe '#permitted_attributes' do
+  describe '#base_attributes' do
     it 'returns Spree::PermittedAttributes module' do
-      expect(controller.permitted_attributes).to eq Spree::PermittedAttributes
+      expect(controller.base_attributes).to eq Spree::PermittedAttributes
+    end
+  end
+
+  describe '#admin_attributes' do
+    it 'returns Spree::PermittedAttributes::Admin module' do
+      expect(controller.admin_attributes).to eq Spree::PermittedAttributes::Admin
     end
   end
 
@@ -34,6 +40,12 @@ describe Spree::Core::ControllerHelpers::StrongParameters, type: :controller do
   describe '#permitted_product_attributes' do
     it 'returns Array class' do
       expect(controller.permitted_product_attributes.class).to eq Array
+    end
+  end
+
+  describe '#permitted_admin_order_attributes' do
+    it 'returns Array class' do
+      expect(controller.permitted_admin_order_attributes.class).to eq Array
     end
   end
 end


### PR DESCRIPTION
Resubmission of #1110 with Hound cleanup and simpler structure.

The changes in these commits address some extensibility issues we've run into with permitted attributes. I understand there are some significant changes in here, I am looking for feedback on the general direction and from there implementation specifics.

In multiple places throughout the api controllers additional "admin attributes" are being combined with attributes defined in PermittedAttributes to allow admins to make certain changes. Here is one example from the api/orders_controller:
```
def permitted_order_attributes
  can?(:admin, Spree::Order) ? (super + admin_order_attributes) : super
end
```
These are supported by class attributes defined on specific controllers, here is one from api/orders_controller:
```
class_attribute :admin_order_attributes
self.admin_order_attributes = [:import, :number, :completed_at, :locked_at, :channel, :user_id, :created_at]
```
A setup like this is currently being used in:
- api/base_controller
- api/orders_controller
- api/line_items_controller

The first commit 
- creates a new a new PermittedAttributes::Admin module
- extracts "admin attributes" logic from api/controllers into this new module

This should make sense for all the same reasons the original PermittedAttributes module exists: code reuse, simpler controllers, etc. The next two commits use this new module to simplify logic in the api/controllers, import/order and order_contents.

The second commit:
- extracts line_item_options logic out of the api/line_items_controller and into the core PermittedAttributes/StrongParameters modules
- removes all permitting logic from order_contents (I can't find another place in the codebase where StrongParameters are used outside of a controller)

The third commit addresses an issue that prevents options from being passed in on a line_item when creating a new order through the Api. Because that line_item_options logic was specifically in the api/line_items_controller, permitting the options attributes became non-trivial.

One of the major changes here is that any line item attribute that isn't variant_id and quantity is now passed in one consistent way, through options. So anyone doing `line_item: {variant_id: 1, price: 33}` would need to move to `line_item: {variant_id: 1, options: {price: 33}}`.

The benefits to the consistency can immediately been seen in the simplification of the order importer. Rather than an "ugly" conditional update based on additional parameters existing in the hash, everything instead can run cleanly through OrderContents.