### PR TITLE
Permitted attributes improvements

### DIFF
--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -11,9 +11,6 @@ module Spree
       include Spree::Core::ControllerHelpers::Pricing
       include Spree::Core::ControllerHelpers::StrongParameters
 
-      class_attribute :admin_line_item_attributes
-      self.admin_line_item_attributes = [:price, :variant_id, :sku]
-
       attr_accessor :current_api_user
 
       class_attribute :error_notifier
@@ -34,11 +31,7 @@ module Spree
 
       # users should be able to set price when importing orders via api
       def permitted_line_item_attributes
-        if can?(:admin, Spree::LineItem)
-          super + admin_line_item_attributes
-        else
-          super
-        end
+        can?(:admin, Spree::LineItem) ? permitted_admin_line_item_attributes : super
       end
 
       def load_user

--- a/api/app/controllers/spree/api/line_items_controller.rb
+++ b/api/app/controllers/spree/api/line_items_controller.rb
@@ -1,10 +1,6 @@
 module Spree
   module Api
     class LineItemsController < Spree::Api::BaseController
-      class_attribute :line_item_options
-
-      self.line_item_options = []
-
       before_filter :load_order, only: [:create, :update, :destroy]
       around_filter :lock_order, only: [:create, :update, :destroy]
 
@@ -66,11 +62,7 @@ module Spree
       end
 
       def line_item_params
-        params.require(:line_item).permit(
-          :quantity,
-            :variant_id,
-            options: line_item_options
-        )
+        params.require(:line_item).permit(permitted_line_item_attributes)
       end
     end
   end

--- a/api/app/controllers/spree/api/orders_controller.rb
+++ b/api/app/controllers/spree/api/orders_controller.rb
@@ -1,12 +1,6 @@
 module Spree
   module Api
     class OrdersController < Spree::Api::BaseController
-      class_attribute :admin_shipment_attributes
-      self.admin_shipment_attributes = [:shipping_method, :stock_location, inventory_units: [:variant_id, :sku]]
-
-      class_attribute :admin_order_attributes
-      self.admin_order_attributes = [:import, :number, :completed_at, :locked_at, :channel, :user_id, :created_at]
-
       skip_before_action :authenticate_user, only: :apply_coupon_code
 
       before_action :find_order, except: [:create, :mine, :current, :index]
@@ -119,15 +113,11 @@ module Spree
       end
 
       def permitted_order_attributes
-        can?(:admin, Spree::Order) ? (super + admin_order_attributes) : super
+        can?(:admin, Spree::Order) ? permitted_admin_order_attributes : super
       end
 
       def permitted_shipment_attributes
-        if can?(:admin, Spree::Shipment)
-          super + admin_shipment_attributes
-        else
-          super
-        end
+        can?(:admin, Spree::Shipment) ? permitted_admin_shipment_attributes : super
       end
 
       def find_order(_lock = false)

--- a/api/spec/controllers/spree/api/line_items_controller_spec.rb
+++ b/api/spec/controllers/spree/api/line_items_controller_spec.rb
@@ -2,15 +2,12 @@ require 'spec_helper'
 
 module Spree
   PermittedAttributes.module_eval do
-    mattr_writer :line_item_attributes
+    mattr_writer :line_item_option_attributes
   end
 
-  unless PermittedAttributes.line_item_attributes.include? :some_option
-    PermittedAttributes.line_item_attributes += [:some_option]
+  unless PermittedAttributes.line_item_option_attributes.include? :some_option
+    PermittedAttributes.line_item_option_attributes += [:some_option]
   end
-
-  # This should go in an initializer
-  Spree::Api::LineItemsController.line_item_options += [:some_option]
 
   describe Api::LineItemsController, type: :controller do
     render_views

--- a/core/app/models/spree/order_contents.rb
+++ b/core/app/models/spree/order_contents.rb
@@ -86,7 +86,7 @@ module Spree
       )
 
       line_item.quantity += quantity.to_i
-      line_item.options = ActionController::Parameters.new(options).permit(PermittedAttributes.line_item_attributes)
+      line_item.options = options.except(:stock_location_quantities, :shipment)
 
       if line_item.new_record?
         create_order_stock_locations(line_item, options[:stock_location_quantities])

--- a/core/lib/spree/core/controller_helpers/strong_parameters.rb
+++ b/core/lib/spree/core/controller_helpers/strong_parameters.rb
@@ -24,6 +24,18 @@ module Spree
           ]
         end
 
+        def permitted_line_item_attributes
+          base_attributes.line_item_attributes + [
+            options: base_attributes.line_item_option_attributes
+          ]
+        end
+
+        def permitted_admin_line_item_attributes
+          base_attributes.line_item_attributes + admin_attributes.line_item_attributes + [
+            options: base_attributes.line_item_option_attributes + admin_attributes.line_item_option_attributes
+          ]
+        end
+
         def permitted_payment_attributes
           base_attributes.payment_attributes + [
             source_attributes: permitted_source_attributes
@@ -47,13 +59,13 @@ module Spree
 
         def permitted_order_attributes
           permitted_checkout_attributes + [
-            line_items_attributes: base_attributes.line_item_attributes
+            line_items_attributes: permitted_line_item_attributes
           ]
         end
 
         def permitted_admin_order_attributes
           permitted_checkout_attributes + admin_attributes.order_attributes + [
-            line_items_attributes: base_attributes.line_item_attributes + admin_attributes.line_item_attributes
+            line_items_attributes: permitted_admin_line_item_attributes
           ]
         end
 

--- a/core/lib/spree/core/controller_helpers/strong_parameters.rb
+++ b/core/lib/spree/core/controller_helpers/strong_parameters.rb
@@ -32,7 +32,11 @@ module Spree
 
         def permitted_admin_line_item_attributes
           base_attributes.line_item_attributes + admin_attributes.line_item_attributes + [
+<<<<<<< HEAD
             options: base_attributes.line_item_option_attributes + admin_attributes.line_item_option_attributes
+=======
+            options: base_attributes.line_item_option_attributes +  admin_attributes.line_item_option_attributes
+>>>>>>> 3862505... Simplify order_contents line_item add
           ]
         end
 

--- a/core/lib/spree/core/controller_helpers/strong_parameters.rb
+++ b/core/lib/spree/core/controller_helpers/strong_parameters.rb
@@ -2,34 +2,42 @@ module Spree
   module Core
     module ControllerHelpers
       module StrongParameters
-        def permitted_attributes
+        def base_attributes
           Spree::PermittedAttributes
         end
 
         delegate(*Spree::PermittedAttributes::ATTRIBUTES,
-                 to: :permitted_attributes,
+                 to: :base_attributes,
                  prefix: :permitted)
 
+        def admin_attributes
+          Spree::PermittedAttributes::Admin
+        end
+
+        delegate(*Spree::PermittedAttributes::Admin::ATTRIBUTES,
+                 to: :admin_attributes,
+                 prefix: :permitted_admin)
+
         def permitted_credit_card_update_attributes
-          permitted_attributes.credit_card_update_attributes + [
+          base_attributes.credit_card_update_attributes + [
             address_attributes: permitted_address_attributes
           ]
         end
 
         def permitted_payment_attributes
-          permitted_attributes.payment_attributes + [
+          base_attributes.payment_attributes + [
             source_attributes: permitted_source_attributes
           ]
         end
 
         def permitted_source_attributes
-          permitted_attributes.source_attributes + [
+          base_attributes.source_attributes + [
             address_attributes: permitted_address_attributes
           ]
         end
 
         def permitted_checkout_attributes
-          permitted_attributes.checkout_attributes + [
+          base_attributes.checkout_attributes + [
             bill_address_attributes: permitted_address_attributes,
             ship_address_attributes: permitted_address_attributes,
             payments_attributes: permitted_payment_attributes,
@@ -39,18 +47,24 @@ module Spree
 
         def permitted_order_attributes
           permitted_checkout_attributes + [
-            line_items_attributes: permitted_line_item_attributes
+            line_items_attributes: base_attributes.line_item_attributes
+          ]
+        end
+
+        def permitted_admin_order_attributes
+          permitted_checkout_attributes + admin_attributes.order_attributes + [
+            line_items_attributes: base_attributes.line_item_attributes + admin_attributes.line_item_attributes
           ]
         end
 
         def permitted_product_attributes
-          permitted_attributes.product_attributes + [
+          base_attributes.product_attributes + [
             product_properties_attributes: permitted_product_properties_attributes
           ]
         end
 
         def permitted_user_attributes
-          permitted_attributes.user_attributes + [
+          base_attributes.user_attributes + [
             bill_address_attributes: permitted_address_attributes,
             ship_address_attributes: permitted_address_attributes
           ]

--- a/core/lib/spree/core/importer/order.rb
+++ b/core/lib/spree/core/importer/order.rb
@@ -97,15 +97,8 @@ module Spree
         def self.create_line_items_from_params(line_items_hash, order)
           return {} unless line_items_hash
           line_items_hash.each_key do |k|
-            extra_params = line_items_hash[k].except(:variant_id, :quantity, :sku)
             line_item = ensure_variant_id_from_params(line_items_hash[k])
-            line_item = order.contents.add(Spree::Variant.find(line_item[:variant_id]), line_item[:quantity])
-            # Raise any errors with saving to prevent import succeeding with line items failing silently.
-            if extra_params.present?
-              line_item.update_attributes!(extra_params)
-            else
-              line_item.save!
-            end
+            order.contents.add(Spree::Variant.find(line_item[:variant_id]), line_item[:quantity], line_item[:options] || {})
           end
         end
 

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -101,8 +101,9 @@ module Spree
     @@stock_movement_attributes = [
       :quantity, :stock_item, :stock_item_id, :originator, :action]
 
-    @@store_attributes = [:name, :url, :seo_title, :meta_keywords,
-                          :meta_description, :default_currency, :mail_from_address]
+    @@store_attributes = [
+      :name, :url, :seo_title, :meta_keywords,
+      :meta_description, :default_currency, :mail_from_address]
 
     @@taxonomy_attributes = [:name]
 
@@ -125,3 +126,5 @@ module Spree
       :weight, :height, :width, :depth, :sku, :cost_currency, option_value_ids: [], options: [:name, :value]]
   end
 end
+
+require 'spree/permitted_attributes/admin'

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -12,6 +12,7 @@ module Spree
       :image_attributes,
       :inventory_unit_attributes,
       :line_item_attributes,
+      :line_item_option_attributes,
       :option_type_attributes,
       :option_value_attributes,
       :payment_attributes,
@@ -59,6 +60,8 @@ module Spree
     @@inventory_unit_attributes = [:shipment, :variant_id]
 
     @@line_item_attributes = [:id, :variant_id, :quantity]
+
+    @@line_item_option_attributes = []
 
     @@option_type_attributes = [:name, :presentation, :option_values_attributes]
 

--- a/core/lib/spree/permitted_attributes/admin.rb
+++ b/core/lib/spree/permitted_attributes/admin.rb
@@ -10,7 +10,9 @@ module Spree
 
       mattr_reader(*ATTRIBUTES)
 
-      @@line_item_attributes = [:price, :variant_id, :sku]
+      @@line_item_attributes = [:sku]
+
+      @@line_item_option_attributes = [:price]
 
       @@line_item_option_attributes = []
 

--- a/core/lib/spree/permitted_attributes/admin.rb
+++ b/core/lib/spree/permitted_attributes/admin.rb
@@ -3,6 +3,7 @@ module Spree
     module Admin
       ATTRIBUTES = [
         :line_item_attributes,
+        :line_item_option_attributes,
         :order_attributes,
         :shipment_attributes
       ]
@@ -10,6 +11,8 @@ module Spree
       mattr_reader(*ATTRIBUTES)
 
       @@line_item_attributes = [:price, :variant_id, :sku]
+
+      @@line_item_option_attributes = []
 
       @@order_attributes = [:import, :number, :completed_at, :locked_at, :channel, :user_id, :created_at]
 

--- a/core/lib/spree/permitted_attributes/admin.rb
+++ b/core/lib/spree/permitted_attributes/admin.rb
@@ -1,0 +1,19 @@
+module Spree
+  module PermittedAttributes
+    module Admin
+      ATTRIBUTES = [
+        :line_item_attributes,
+        :order_attributes,
+        :shipment_attributes
+      ]
+
+      mattr_reader(*ATTRIBUTES)
+
+      @@line_item_attributes = [:price, :variant_id, :sku]
+
+      @@order_attributes = [:import, :number, :completed_at, :locked_at, :channel, :user_id, :created_at]
+
+      @@shipment_attributes = [:shipping_method, :stock_location, inventory_units: [:variant_id, :sku]] + PermittedAttributes.shipment_attributes
+    end
+  end
+end

--- a/core/spec/lib/spree/core/controller_helpers/strong_parameters_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/strong_parameters_spec.rb
@@ -43,6 +43,18 @@ describe Spree::Core::ControllerHelpers::StrongParameters, type: :controller do
     end
   end
 
+  describe '#permitted_line_item_attributes' do
+    it 'returns Array class' do
+      expect(controller.permitted_line_item_attributes.class).to eq Array
+    end
+  end
+
+  describe '#permitted_admin_line_item_attributes' do
+    it 'returns Array class' do
+      expect(controller.permitted_admin_line_item_attributes.class).to eq Array
+    end
+  end
+
   describe '#permitted_admin_order_attributes' do
     it 'returns Array class' do
       expect(controller.permitted_admin_order_attributes.class).to eq Array

--- a/core/spec/lib/spree/core/controller_helpers/strong_parameters_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/strong_parameters_spec.rb
@@ -7,9 +7,15 @@ end
 describe Spree::Core::ControllerHelpers::StrongParameters, type: :controller do
   controller(FakesController) {}
 
-  describe '#permitted_attributes' do
+  describe '#base_attributes' do
     it 'returns Spree::PermittedAttributes module' do
-      expect(controller.permitted_attributes).to eq Spree::PermittedAttributes
+      expect(controller.base_attributes).to eq Spree::PermittedAttributes
+    end
+  end
+
+  describe '#admin_attributes' do
+    it 'returns Spree::PermittedAttributes::Admin module' do
+      expect(controller.admin_attributes).to eq Spree::PermittedAttributes::Admin
     end
   end
 
@@ -34,6 +40,12 @@ describe Spree::Core::ControllerHelpers::StrongParameters, type: :controller do
   describe '#permitted_product_attributes' do
     it 'returns Array class' do
       expect(controller.permitted_product_attributes.class).to eq Array
+    end
+  end
+
+  describe '#permitted_admin_order_attributes' do
+    it 'returns Array class' do
+      expect(controller.permitted_admin_order_attributes.class).to eq Array
     end
   end
 end

--- a/core/spec/lib/spree/core/importer/order_spec.rb
+++ b/core/spec/lib/spree/core/importer/order_spec.rb
@@ -1,6 +1,14 @@
 require 'spec_helper'
 
 module Spree
+  PermittedAttributes.module_eval do
+    mattr_writer :line_item_option_attributes
+  end
+
+  unless PermittedAttributes.line_item_option_attributes.include? :some_option
+    PermittedAttributes.line_item_option_attributes += [:price, :currency]
+  end
+
   module Core
     describe Importer::Order do
       let!(:store) { create(:store) }
@@ -119,7 +127,7 @@ module Spree
       end
 
       it 'handles line_item updating exceptions' do
-        line_items['0'][:currency] = 'GBP'
+        line_items['0'][:options] = { currency: 'GBP' }
         params = { line_items_attributes: line_items }
 
         expect {
@@ -182,7 +190,7 @@ module Spree
             currency: "GBP",
             line_items_attributes: line_items
           }
-          line_items["0"].merge! currency: "GBP", price: 1.99
+          line_items["0"][:options] = { currency: "GBP", price: 1.99 }
           order = Importer::Order.import(user, params)
           expect(order.currency).to eq "GBP"
           expect(order.line_items.first.price).to eq 1.99


### PR DESCRIPTION
The changes in these commits address some extensibility issues we've run into with permitted attributes. I understand there are some significant changes in here, I am looking for feedback on the general direction and from there implementation specifics.

In multiple places throughout the api controllers additional "admin attributes" are being combined with attributes defined in PermittedAttributes to allow admins to make certain changes. Here is one example from the api/orders_controller:
```
def permitted_order_attributes
  can?(:admin, Spree::Order) ? (super + admin_order_attributes) : super
end
```
These are supported by class attributes defined on specific controllers, here is one from api/orders_controller:
```
class_attribute :admin_order_attributes
self.admin_order_attributes = [:import, :number, :completed_at, :locked_at, :channel, :user_id, :created_at]
```
A setup like this is currently being used in:
- api/base_controller
- api/orders_controller
- api/line_items_controller

The first commit 
- creates a new PermittedAttributes::Admin module
- extracts "admin attributes" logic from api/controllers into this new module

This should make sense for all the same reasons the original PermittedAttributes module exists: code reuse, simpler controllers, etc. The next two commits use this new module to simplify logic in the api/controllers, import/order and order_contents.

The second commit:
- extracts line_item_options logic out of the api/line_items_controller and into the core PermittedAttributes/StrongParameters modules
- removes all permitting logic from order_contents (I can't find another place in the codebase where StrongParameters are used outside of a controller)

The third commit addresses an issue that prevents options from being passed in on a line_item when creating a new order through the Api. Because that line_item_options logic was specifically in the api/line_items_controller, permitting the line_item_options attributes in the orders_controller became non-trivial.

One of the major changes here is that any line item attribute that isn't variant_id and quantity is now passed in one consistent way, through options. So anyone doing `line_item: {variant_id: 1, price: 33}` would need to move to `line_item: {variant_id: 1, options: {price: 33}}`.

The benefits to the consistency can immediately been seen in the simplification of the order importer. Rather than the importer needing to run a conditional update based on additional parameters, all adding/assigning logic runs cleanly through order_contents.add.