### PR TITLE
New Content Layouts

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/components/_sidebar.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_sidebar.scss
@@ -1,6 +1,4 @@
-// Sidebar
-//---------------------------------------------------
-#sidebar {
+body:not(.new-layout) #sidebar {
   overflow: visible;
   border-top: 1px solid $color-border;
   margin-top: 17px;
@@ -29,4 +27,16 @@
       min-height: 3em;
     }
   }
+}
+
+body.new-layout .content-sidebar {
+  ul {
+    padding-left: 0;
+  }
+}
+
+body.new-layout .sidebar-title {
+  @include line-through();
+  color: $color-2;
+  font-size: 14px;
 }

--- a/backend/app/assets/stylesheets/spree/backend/globals/_mixins.css
+++ b/backend/app/assets/stylesheets/spree/backend/globals/_mixins.css
@@ -1,0 +1,2 @@
+@import "mixins/caret";
+@import "mixins/line_through";

--- a/backend/app/assets/stylesheets/spree/backend/globals/mixins/_line_through.scss
+++ b/backend/app/assets/stylesheets/spree/backend/globals/mixins/_line_through.scss
@@ -1,0 +1,22 @@
+@mixin line-through($color: $color-2, $background: $color-1) {
+  position: relative;
+  text-align: center;
+
+  &:before {
+    content: "";
+    position: absolute;
+    top: calc(50% - 1px);
+    left: 0;
+    width: 100%;
+    height: 1px;
+    background: $color;
+    z-index: 0;
+  }
+
+  > * { // usually a <span> but we'll use an * just in case
+    @include padding(null 1rem);
+    position: relative;
+    background: $background;
+    z-index: 1;
+  }
+}

--- a/backend/app/assets/stylesheets/spree/backend/sections/_products.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/_products.scss
@@ -1,10 +1,29 @@
-[data-hook="admin_products_sidebar"] {
-  // .field.checkbox:first-child {
-  //   margin-top: 36px;
-  // }
-  .actions {
-    padding: 0 !important;
+[data-hook="admin_products_index_search"] {
+  @include make-row();
+
+  > * {
+    @include make-col();
+    @include padding(0 null); // override the padding on .field
   }
+}
+
+.product-search-field-name {
+  @include make-col-span(6);
+}
+
+.product-search-field-sku {
+  @include make-col-span(4);
+}
+
+.product-search-field-show-deleted.field.checkbox {
+  // extra specificity to override styles
+  @include make-col-span(2);
+  min-height: initial; // override .field.checkbox
+  margin-bottom: 0; // override .checkbox
+}
+
+div[data-hook="admin_products_index_search_buttons"] {
+  margin-top: 2rem;
 }
 
 [data-hook="admin_product_form_fields"] {

--- a/backend/app/assets/stylesheets/spree/backend/shared/_header.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_header.scss
@@ -1,10 +1,13 @@
 .main-header {
   @include display(flex);
   @include align-items(center);
-  margin-left: $width-sidebar;
-  padding: 15px 14px;
+  padding: 15px $grid-gutter-width;
   background-color: very-light($color-3, 4);
   border-bottom: 1px solid $color-border;
+
+  body:not(.new-layout) & {
+    margin-left: $width-sidebar;
+  }
 }
 
 .page-title {

--- a/backend/app/assets/stylesheets/spree/backend/shared/_layout.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_layout.scss
@@ -38,6 +38,7 @@ body {
 .content-main {
   @include make-col();
   @include make-col-span(12);
+  overflow-x: hidden; // makes sure that the tabs are able to resize
 
   .has-sidebar & {
     @include make-col-span(9);

--- a/backend/app/assets/stylesheets/spree/backend/shared/_layout.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_layout.scss
@@ -5,6 +5,10 @@ html {
 body {
   position: relative;
   min-height: 100%;
+
+  &.new-layout {
+    padding-left: $width-sidebar;
+  }
 }
 
 .admin-nav {
@@ -12,9 +16,32 @@ body {
   width: $width-sidebar;
 }
 
-.main-content {
-  margin-left: $width-sidebar;
-  @include clearfix;
+.content-wrapper {
+  body:not(.new-layout) & {
+    margin-left: $width-sidebar;
+  }
+
+  body.new-layout & {
+    @include padding(1rem $grid-gutter-width null);
+  }
+}
+
+.content {
+  @include make-row();
+}
+
+.content-main {
+  @include make-col();
+  @include make-col-span(12);
+
+  .has-sidebar & {
+    @include make-col-span(9);
+  }
+}
+
+.content-sidebar {
+  @include make-col();
+  @include make-col-span(3);
 }
 
 #content {

--- a/backend/app/assets/stylesheets/spree/backend/shared/_layout.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_layout.scss
@@ -24,6 +24,11 @@ body {
   body.new-layout & {
     @include padding(1rem $grid-gutter-width null);
   }
+
+  &.centered {
+    @include margin(null auto);
+    max-width: map-get($container-max-widths, "xl");
+  }
 }
 
 .content {

--- a/backend/app/assets/stylesheets/spree/backend/spree_admin.scss
+++ b/backend/app/assets/stylesheets/spree/backend/spree_admin.scss
@@ -7,7 +7,7 @@
 @import 'bootstrap_custom';
 @import 'solidus_admin/bootstrap/bootstrap';
 
-@import 'spree/backend/globals/mixins/caret';
+@import 'spree/backend/globals/mixins';
 
 @import 'spree/backend/shared/skeleton';
 @import 'spree/backend/shared/typography';

--- a/backend/app/helpers/spree/admin/base_helper.rb
+++ b/backend/app/helpers/spree/admin/base_helper.rb
@@ -155,6 +155,11 @@ module Spree
         dom_id(record, 'spree')
       end
 
+      def admin_layout(layout = nil)
+        @admin_layout = layout if layout
+        @admin_layout
+      end
+
       private
 
       def attribute_name_for(field_name)

--- a/backend/app/views/spree/admin/products/index.html.erb
+++ b/backend/app/views/spree/admin/products/index.html.erb
@@ -1,3 +1,5 @@
+<% admin_layout "full-width" %>
+
 <% content_for :page_title do %>
   <%= Spree.t(:listing_products) %>
 <% end %>

--- a/backend/app/views/spree/admin/products/index.html.erb
+++ b/backend/app/views/spree/admin/products/index.html.erb
@@ -14,37 +14,28 @@
 
 <% content_for :table_filter do %>
   <div data-hook="admin_products_sidebar">
-
     <%= search_form_for [:admin, @search] do |f| %>
-
         <%- locals = {:f => f} %>
-
         <div data-hook="admin_products_index_search">
-          <div class="alpha nine columns">
-            <div class="field">
-              <%= f.label :name_cont, Spree::Product.human_attribute_name(:name) %>
-              <%= f.text_field :name_cont, :size => 15 %>
-            </div>
+          <div class="product-search-field-name field">
+            <%= f.label :name_cont, Spree::Product.human_attribute_name(:name) %>
+            <%= f.text_field :name_cont, :size => 15 %>
           </div>
-          <div class="four columns">
-            <div class="field">
-              <%= f.label :variants_including_master_sku_cont, Spree::Variant.human_attribute_name(:sku) %>
-              <%= f.text_field :variants_including_master_sku_cont, :size => 15 %>
-            </div>
+
+          <div class="product-search-field-sku field">
+            <%= f.label :variants_including_master_sku_cont, Spree::Variant.human_attribute_name(:sku) %>
+            <%= f.text_field :variants_including_master_sku_cont, :size => 15 %>
           </div>
-          <div class="three columns omega">
-            <div class="field checkbox">
-              <label>
-                <%= f.check_box :deleted_at_null, {:checked => params[:q][:deleted_at_null] == '0'}, '0', '1' %>
-                <%= Spree.t(:show_deleted) %>
-              </label>
-            </div>
+
+          <div class="product-search-field-show-deleted field checkbox">
+            <label>
+              <%= f.check_box :deleted_at_null, {:checked => params[:q][:deleted_at_null] == '0'}, '0', '1' %>
+              <%= Spree.t(:show_deleted) %>
+            </label>
           </div>
         </div>
 
-        <div class="clear"></div>
-
-        <div class="form-buttons actions filter-actions" data-hook="admin_products_index_search_buttons">
+        <div class="actions filter-actions" data-hook="admin_products_index_search_buttons">
           <%= button Spree.t(:search), 'search' %>
         </div>
     <% end %>

--- a/backend/app/views/spree/admin/shared/_sidebar.html.erb
+++ b/backend/app/views/spree/admin/shared/_sidebar.html.erb
@@ -1,5 +1,5 @@
 <% if content_for?(:sidebar) %>
-  <aside id="sidebar" data-hook class="four columns">
+  <aside id="sidebar" data-hook class="content-sidebar four columns">
 
     <% if content_for?(:sidebar_title) %>
       <h5 class="sidebar-title"><span><%= yield :sidebar_title %></span></h5>

--- a/backend/app/views/spree/layouts/admin.html.erb
+++ b/backend/app/views/spree/layouts/admin.html.erb
@@ -4,30 +4,43 @@
     <%= render 'spree/admin/shared/head' %>
   </head>
 
-  <body class="admin">
+  <body class="admin <%= "new-layout" if @admin_layout %>">
     <%= render "spree/admin/shared/navigation" %>
     <%= render "spree/admin/shared/header" %>
     <%= render "spree/admin/shared/flash" %>
     <%= render "spree/admin/shared/spinner" %>
 
-    <div class="main-content" id="wrapper" data-hook>
-      <div class="container">
-        <div class="row">
-          <div class="<%= 'with-sidebar ' if content_for?(:sidebar) %>" id="content" data-hook>
-            <% if content_for?(:tabs) %>
-              <div class="sixteen columns">
-                <%= yield :tabs %>
-              </div>
-            <% end %>
-            <div class="js-content-below-tabs <%= if content_for?(:sidebar) then 'twelve' else 'sixteen' end %> columns">
-              <%= render :partial => 'spree/admin/shared/table_filter' %>
-              <%= yield %>
-            </div>
+    <div class="content-wrapper <%= @admin_layout.presence %> <%= "has-sidebar" if content_for?(:sidebar) %>" id="wrapper" data-hook>
+      <% if @admin_layout == "full-width" %>
+        <div class="content">
+          <div class="content-main">
+            <%= yield :tabs %>
+            <%= render "spree/admin/shared/table_filter" %>
+            <%= yield %>
+          </div>
 
-            <%= render 'spree/admin/shared/sidebar' %>
+          <%= render "spree/admin/shared/sidebar" %>
+        </div>
+      <% else %>
+        <% # Legacy layout %>
+        <div class="container">
+          <div class="row">
+            <div class="<%= 'with-sidebar ' if content_for?(:sidebar) %>" id="content" data-hook>
+              <% if content_for?(:tabs) %>
+                <div class="sixteen columns">
+                  <%= yield :tabs %>
+                </div>
+              <% end %>
+              <div class="js-content-below-tabs <%= if content_for?(:sidebar) then 'twelve' else 'sixteen' end %> columns">
+                <%= render :partial => 'spree/admin/shared/table_filter' %>
+                <%= yield %>
+              </div>
+
+              <%= render 'spree/admin/shared/sidebar' %>
+            </div>
           </div>
         </div>
-      </div>
+      <% end %>
     </div>
 
     <div data-hook="admin_footer_scripts"></div>

--- a/backend/app/views/spree/layouts/admin.html.erb
+++ b/backend/app/views/spree/layouts/admin.html.erb
@@ -11,7 +11,7 @@
     <%= render "spree/admin/shared/spinner" %>
 
     <div class="content-wrapper <%= @admin_layout.presence %> <%= "has-sidebar" if content_for?(:sidebar) %>" id="wrapper" data-hook>
-      <% if @admin_layout == "full-width" %>
+      <% if @admin_layout %>
         <div class="content">
           <div class="content-main">
             <%= yield :tabs %>

--- a/backend/spec/helpers/admin/base_helper_spec.rb
+++ b/backend/spec/helpers/admin/base_helper_spec.rb
@@ -14,4 +14,34 @@ describe Spree::Admin::BaseHelper, type: :helper do
       expect(datepicker_field_value(date)).to eq("2013/08/14")
     end
   end
+
+  describe "#admin_layout" do
+    subject { admin_layout(value) }
+
+    context "when no initial value has been set" do
+      context "and an argument is sent" do
+        let(:value) { "full-width" }
+        it { is_expected.to eq "full-width" }
+      end
+
+      context "and no argument is sent" do
+        let(:value) { nil }
+        it { is_expected.to be_nil }
+      end
+    end
+
+    context "when an initial value is set" do
+      before { admin_layout("full-width") }
+
+      context "and it is called again without an argument" do
+        let(:value) { nil }
+        it { is_expected.to eq "full-width" }
+      end
+
+      context "and it is called again with an argument" do
+        let(:value) { "centered" }
+        it { is_expected.to eq "centered" }
+      end
+    end
+  end
 end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -763,7 +763,7 @@ en:
           amount_used_not_zero: "is greater than zero. Can not delete store credit"
           update_reason_required: "A reason for the change must be selected"
       variants:
-        index:
+        table_filter:
           show_deleted: Show deleted variants
         new:
           new_variant: New variant


### PR DESCRIPTION
Addresses: [Create 2 layout options for content area of admin UI](https://github.com/solidusio/solidus/issues/1078)

This implements the base for new layouts to be used in the admin. There are two specific layouts:

- Full-width
- Centered

Both of these layouts have been implemented on single pages in the admin for reference. Those pages are:

- Product Index (full-width)
- Variant Index (centered)

## Next Steps

For this to be implemented across the admin we'll need to tackle a much larger issue: forms. @Mandily, I'll be looking to you for this one 😄. What we'll want to do is define how forms are laid out and have different "form modules" that we can replace the old skeleton forms with. This will not be a simple task but we can set ourselves up for success by keeping this as modular as possible.

## Demo

For those that don't want to fire this up locally:

### Product Index: Before
<img width="1545" alt="screen shot 2016-05-03 at 2 25 50 pm" src="https://cloud.githubusercontent.com/assets/836758/14998915/07496ee4-113b-11e6-9b50-5a45a9b10d9e.png">

### Product Index: After
<img width="1541" alt="screen shot 2016-05-03 at 2 26 01 pm" src="https://cloud.githubusercontent.com/assets/836758/14998921/0bb465c4-113b-11e6-8025-d93c4f80f816.png">

### Variant Index: Before
<img width="1544" alt="screen shot 2016-05-03 at 2 28 38 pm" src="https://cloud.githubusercontent.com/assets/836758/14998984/64ad0582-113b-11e6-900d-66f35e74c8cc.png">

### Variant Index: After
<img width="1544" alt="screen shot 2016-05-03 at 2 28 22 pm" src="https://cloud.githubusercontent.com/assets/836758/14998988/6a1191aa-113b-11e6-8e7a-1d6d45aa0b71.png">

## Responsive

It took this project a while, but we're finally moving toward a responsive admin layout:

### Before
<img width="893" alt="screen shot 2016-05-03 at 2 30 49 pm" src="https://cloud.githubusercontent.com/assets/836758/14999043/a94f3e30-113b-11e6-9482-b6b52619128f.png">

### After
<img width="891" alt="screen shot 2016-05-03 at 2 29 51 pm" src="https://cloud.githubusercontent.com/assets/836758/14999045/acfb681a-113b-11e6-8179-ee48291cbc81.png">