### PR TITLE
Add Prices tab to Products overview

### DIFF
--- a/backend/app/controllers/spree/admin/prices_controller.rb
+++ b/backend/app/controllers/spree/admin/prices_controller.rb
@@ -7,7 +7,7 @@ module Spree
         params[:q] ||= {}
 
         @search = @product.prices.accessible_by(current_ability, :index).ransack(params[:q])
-        @prices = @search.result
+        @prices = @search.result.page(params[:page]).per(10)
       end
 
       def edit

--- a/backend/app/controllers/spree/admin/prices_controller.rb
+++ b/backend/app/controllers/spree/admin/prices_controller.rb
@@ -1,0 +1,17 @@
+module Spree
+  module Admin
+    class PricesController < ResourceController
+      belongs_to 'spree/product', find_by: :slug
+
+      def index
+        params[:q] ||= {}
+
+        @search = @product.prices.accessible_by(current_ability, :index).ransack(params[:q])
+        @prices = @search.result
+      end
+
+      def edit
+      end
+    end
+  end
+end

--- a/backend/app/views/spree/admin/prices/_form.html.erb
+++ b/backend/app/views/spree/admin/prices/_form.html.erb
@@ -14,7 +14,10 @@
     <div class="four columns alpha" data-hook="admin_product_price_form_currency">
       <%= f.field_container :currency do %>
         <%= f.label :currency %>
-        <%= f.text_field :currency, class: 'fullwidth title', disabled: !f.object.new_record? %>
+        <%= f.select :currency,
+                     Money::Currency.all.map { |c| ["#{c.iso_code} (#{c.name})", c.iso_code] },
+                     {},
+                     class: "select2 fullwidth", disabled: !f.object.new_record? %>
       <% end %>
     </div>
 

--- a/backend/app/views/spree/admin/prices/_form.html.erb
+++ b/backend/app/views/spree/admin/prices/_form.html.erb
@@ -1,0 +1,37 @@
+<div data-hook="admin_product_price_fields">
+
+  <div data-hook="admin_product_price_form">
+    <div class="four columns alpha" data-hook="admin_product_price_form_variant">
+      <%= f.field_container :variant do %>
+        <%= f.label :variant %>
+        <%= f.select :variant_id,
+                     @product.variants_including_master.map { |v| [v.options_text.presence || t(".master_variant"), v.id] },
+                     {},
+                     class: "select2 fullwidth", disabled: !f.object.new_record? %>
+      <% end %>
+    </div>
+
+    <div class="four columns alpha" data-hook="admin_product_price_form_currency">
+      <%= f.field_container :currency do %>
+        <%= f.label :currency %>
+        <%= f.text_field :currency, class: 'fullwidth title', disabled: !f.object.new_record? %>
+      <% end %>
+    </div>
+
+    <div class="four columns alpha" data-hook="admin_product_price_form_amount">
+      <%= f.field_container :price do %>
+        <%= f.label :price %>
+        <%= f.text_field :price, value: f.object.money.format, class: 'fullwidth title' %>
+      <% end %>
+    </div>
+
+    <div class="field four columns checkbox omega" data-hook="is_default_price">
+      <%= f.label :is_default do %>
+        <%= f.check_box :is_default %>
+        <%= Spree::Price.human_attribute_name(:is_default) %>
+      <% end %>
+    </div>
+  </div>
+</div>
+
+<div class="clear"></div>

--- a/backend/app/views/spree/admin/prices/_form.html.erb
+++ b/backend/app/views/spree/admin/prices/_form.html.erb
@@ -5,7 +5,7 @@
       <%= f.field_container :variant do %>
         <%= f.label :variant %>
         <%= f.select :variant_id,
-                     @product.variants_including_master.map { |v| [v.options_text.presence || t(".master_variant"), v.id] },
+                     @product.variants_including_master.map { |v| [v.descriptive_name, v.id] },
                      {},
                      class: "select2 fullwidth", disabled: !f.object.new_record? %>
       <% end %>

--- a/backend/app/views/spree/admin/prices/_table.html.erb
+++ b/backend/app/views/spree/admin/prices/_table.html.erb
@@ -1,3 +1,5 @@
+<%= paginate prices, theme: "solidus_admin" %>
+
 <table class="index prices">
   <colgroup>
     <col style="width: 15%" />
@@ -47,3 +49,5 @@
     <% end %>
   </tbody>
 </table>
+
+<%= paginate prices, theme: "solidus_admin" %>

--- a/backend/app/views/spree/admin/prices/_table.html.erb
+++ b/backend/app/views/spree/admin/prices/_table.html.erb
@@ -23,11 +23,8 @@
   <% prices.each do |price| %>
     <tr id="<%= spree_dom_id price %>" data-hook="prices_row" class="<%= "deleted" if price.deleted? %> <%= cycle('odd', 'even')%>">
       <td class="align-center">
-        <% if price.variant.is_master? %>
-          <%= t(".master_variant") %>
-        <% else %>
-          <%= price.variant.options_text %> </td>
-        <% end %>
+        <%= price.variant.descriptive_name %>
+      </td>
       <td class="align-center">
         <% if price.is_default? %>
           <span class="state complete"> <%= Spree.t(:say_yes) %> </span>

--- a/backend/app/views/spree/admin/prices/_table.html.erb
+++ b/backend/app/views/spree/admin/prices/_table.html.erb
@@ -1,0 +1,49 @@
+<table class="index prices">
+  <colgroup>
+    <col style="width: 15%" />
+    <col style="width: 35%" />
+    <col style="width: 35%" />
+    <col style="width: 15%" />
+  </colgroup>
+
+  <thead data-hook="prices_header">
+    <tr>
+      <th><%= Spree::Variant.model_name.human %> </th>
+      <th><%= Spree::Price.human_attribute_name(:is_default) %></th>
+      <th><%= Spree::Price.human_attribute_name(:amount) %></th>
+      <th><%= Spree::Price.human_attribute_name(:currency) %></th>
+      <th class="actions"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+  <% prices.each do |price| %>
+    <tr data-hook="prices_row" class="<%= "deleted" if price.deleted? %> <%= cycle('odd', 'even')%>">
+      <td class="align-center">
+        <% if price.variant.is_master? %>
+          <%= t(".master_variant") %>
+        <% else %>
+          <%= price.variant.options_text %> </td>
+        <% end %>
+      <td class="align-center">
+        <% if price.is_default? %>
+          <span class="state complete"> <%= Spree.t(:say_yes) %> </span>
+        <% else %>
+          <span class="state canceled"> <%= Spree.t(:say_no) %> </span>
+        <% end %>
+      </td>
+      <td class="align-center"><%= price.money.to_html %></td>
+      <td class="align-center"><%= price.currency %></td>
+      <td class="actions">
+        <% if can?(:update, price) %>
+          <%= link_to_edit(price, :no_text => true) unless price.deleted? %>
+        <% end %>
+        <% if can?(:destroy, price) %>
+          &nbsp;
+          <%#= link_to_delete(price, :no_text => true) unless price.deleted? %>
+        <% end %>
+      </td>
+    </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/backend/app/views/spree/admin/prices/_table.html.erb
+++ b/backend/app/views/spree/admin/prices/_table.html.erb
@@ -1,14 +1,6 @@
 <%= paginate prices, theme: "solidus_admin" %>
 
 <table class="index prices">
-  <colgroup>
-    <col style="width: 40%" />
-    <col style="width: 15%" />
-    <col style="width: 15%" />
-    <col style="width: 15%" />
-    <col style="width: 15%" />
-  </colgroup>
-
   <thead data-hook="prices_header">
     <tr>
       <th><%= Spree::Variant.model_name.human %> </th>

--- a/backend/app/views/spree/admin/prices/_table.html.erb
+++ b/backend/app/views/spree/admin/prices/_table.html.erb
@@ -2,9 +2,10 @@
 
 <table class="index prices">
   <colgroup>
+    <col style="width: 40%" />
     <col style="width: 15%" />
-    <col style="width: 35%" />
-    <col style="width: 35%" />
+    <col style="width: 15%" />
+    <col style="width: 15%" />
     <col style="width: 15%" />
   </colgroup>
 
@@ -20,7 +21,7 @@
 
   <tbody>
   <% prices.each do |price| %>
-    <tr data-hook="prices_row" class="<%= "deleted" if price.deleted? %> <%= cycle('odd', 'even')%>">
+    <tr id="<%= spree_dom_id price %>" data-hook="prices_row" class="<%= "deleted" if price.deleted? %> <%= cycle('odd', 'even')%>">
       <td class="align-center">
         <% if price.variant.is_master? %>
           <%= t(".master_variant") %>
@@ -42,7 +43,7 @@
         <% end %>
         <% if can?(:destroy, price) %>
           &nbsp;
-          <%#= link_to_delete(price, :no_text => true) unless price.deleted? %>
+          <%= link_to_delete(price, :no_text => true) unless price.deleted? %>
         <% end %>
       </td>
     </tr>

--- a/backend/app/views/spree/admin/prices/edit.html.erb
+++ b/backend/app/views/spree/admin/prices/edit.html.erb
@@ -1,0 +1,12 @@
+<%= render 'spree/admin/shared/product_tabs', current: 'Prices' %>
+
+<%= form_for @price, url: spree.admin_product_price_path(@product, @price) do |f| %>
+  <fieldset>
+    <legend> <%= t('.edit_price') %> </legend>
+    <%= render 'form', f: f %>
+
+    <% if can?(:update, @product) %>
+      <%= render :partial => 'spree/admin/shared/edit_resource_links' %>
+    <% end %>
+  </fieldset>
+<% end %>

--- a/backend/app/views/spree/admin/prices/index.html.erb
+++ b/backend/app/views/spree/admin/prices/index.html.erb
@@ -1,0 +1,63 @@
+<%= render 'spree/admin/shared/product_tabs', current: 'Prices' %>
+
+<% content_for :page_actions do %>
+  <li id="new_price_link">
+    <%= button_link_to t(".new_price"), new_object_url, { :remote => true, :icon => 'plus', :id => 'admin_new_product' } %>
+  </li>
+<% end if can?(:create, Spree::Product) %>
+
+<% content_for :table_filter_title do %>
+  <%= Spree.t(:search) %>
+<% end %>
+
+<% content_for :table_filter do %>
+<div data-hook="admin_product_prices_index_search">
+  <%= search_form_for [:admin, :product, @search] do |f| %>
+
+  <div class="alpha four columns">
+    <div class="field" data-hook="sku-select">
+      <%= label_tag :q_variant_id_eq, Spree::Variant.model_name.human %>
+      <%= f.select :variant_id_eq,
+                   @product.variants_including_master.map { |v| [v.options_text.presence || t(".master_variant"), v.id] },
+                   {include_blank: true},
+                   class: "select2 fullwidth" %>
+    </div>
+  </div>
+
+  <div class="four columns">
+    <div class="field" data-hook="sku-select">
+      <%= label_tag :q_currency_eq, Spree::Price.human_attribute_name(:currency) %>
+      <%= f.select :currency_eq,
+                   @prices.map(&:currency).uniq,
+                   {include_blank: true},
+                   class: "select2 fullwidth" %>
+    </div>
+  </div>
+
+  <div class="four columns">
+    <div class="field" data-hook="sku-select">
+      <%= label_tag :q_amount_gt, t(".amount_greater_than") %>
+      <%= f.text_field :amount_gt %>
+    </div>
+  </div>
+
+  <div class="omega four columns">
+    <div class="field" data-hook="sku-select">
+      <%= label_tag :q_amount_lt, t(".amount_less_than") %>
+      <%= f.text_field :amount_lt %>
+    </div>
+  </div>
+
+  <div class="clearfix"></div>
+
+  <div class="actions filter-actions">
+    <div data-hook="admin_orders_index_search_buttons">
+      <%= button Spree.t(:filter_results), 'search' %>
+    </div>
+  </div>
+
+  <% end %>
+</div>
+<% end %>
+
+<%= render 'table', prices: @prices %>

--- a/backend/app/views/spree/admin/prices/index.html.erb
+++ b/backend/app/views/spree/admin/prices/index.html.erb
@@ -18,7 +18,7 @@
     <div class="field" data-hook="sku-select">
       <%= label_tag :q_variant_id_eq, Spree::Variant.model_name.human %>
       <%= f.select :variant_id_eq,
-                   @product.variants_including_master.map { |v| [v.options_text.presence || t(".master_variant"), v.id] },
+                   @product.variants_including_master.map { |v| [v.descriptive_name, v.id] },
                    {include_blank: true},
                    class: "select2 fullwidth" %>
     </div>

--- a/backend/app/views/spree/admin/prices/new.html.erb
+++ b/backend/app/views/spree/admin/prices/new.html.erb
@@ -1,0 +1,7 @@
+<%= form_for [:admin, @product, @product.prices.build] do |f| %>
+  <fieldset data-hook="admin_product_price_new_form">
+    <legend><%= t('.new_price') %></legend>
+    <%= render :partial => 'form', :locals => { :f => f } %>
+    <%= render :partial => 'spree/admin/shared/new_resource_links' %>
+  </fieldset>
+<% end %>

--- a/backend/app/views/spree/admin/prices/new.js.erb
+++ b/backend/app/views/spree/admin/prices/new.js.erb
@@ -1,0 +1,2 @@
+$(".js-content-below-tabs").html('<%= escape_javascript(render :template => 'spree/admin/prices/new', :formats => [:html], :handlers => [:erb]) %>');
+$(".js-content-below-tabs .select2").select2();

--- a/backend/app/views/spree/admin/shared/_product_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_product_tabs.html.erb
@@ -14,6 +14,9 @@
       <%= content_tag :li, :class => ('active' if current == 'Variants') do %>
         <%= link_to_with_icon 'th-large', Spree::Variant.model_name.human(count: :other),  spree.admin_product_variants_url(@product) %>
       <% end if can?(:admin, Spree::Variant) %>
+      <%= content_tag :li, :class => ('active' if current == 'Prices') do %>
+        <%= link_to_with_icon 'money', Spree::Price.model_name.human(count: :other),  spree.admin_product_prices_url(@product) %>
+      <% end if can?(:admin, Spree::Price) %>
       <%= content_tag :li, :class => ('active' if current == 'Product Properties') do %>
         <%= link_to_with_icon 'tasks', Spree::ProductProperty.model_name.human(count: :other), spree.admin_product_product_properties_url(@product) %>
       <% end if can?(:admin, Spree::ProductProperty) %>

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -50,7 +50,7 @@ Spree::Core::Engine.routes.draw do
         end
       end
       resources :variants_including_master, only: [:update]
-      resources :prices, only: [:index, :edit, :update, :new, :create]
+      resources :prices, only: [:destroy, :index, :edit, :update, :new, :create]
     end
     get '/products/:product_slug/stock', to: "stock_items#index", as: :product_stock
 

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -50,6 +50,7 @@ Spree::Core::Engine.routes.draw do
         end
       end
       resources :variants_including_master, only: [:update]
+      resources :prices, only: [:index, :edit, :update, :new, :create]
     end
     get '/products/:product_slug/stock', to: "stock_items#index", as: :product_stock
 

--- a/backend/spec/controllers/spree/admin/prices_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/prices_controller_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+describe Spree::Admin::PricesController do
+  stub_authorization!
+
+  let!(:product) { create(:product) }
+
+  describe '#index' do
+    context "when only given a product" do
+      let(:product) { create(:product) }
+
+      subject { spree_get :index, product_id: product.slug }
+
+      it { is_expected.to be_success }
+
+      it 'assigns usable instance variables' do
+        subject
+        expect(assigns(:search)).to be_a(Ransack::Search)
+        expect(assigns(:prices)).to eq(product.prices)
+        expect(assigns(:product)).to eq(product)
+      end
+    end
+
+    context "when given a product and a variant" do
+      let(:variant) { create(:variant) }
+      let(:product) { variant.product }
+
+      subject { spree_get :index, product_id: product.slug, variant_id: variant.id }
+
+      it { is_expected.to be_success }
+
+      it 'assigns usable instance variables' do
+        subject
+        expect(assigns(:search)).to be_a(Ransack::Search)
+        expect(assigns(:prices)).to eq(product.prices)
+        expect(assigns(:prices)).to include(variant.default_price)
+        expect(assigns(:product)).to eq(product)
+      end
+    end
+  end
+end

--- a/backend/spec/features/admin/products/pricing_spec.rb
+++ b/backend/spec/features/admin/products/pricing_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+describe 'Pricing' do
+  stub_authorization!
+
+  let(:product) { create(:product) }
+
+  before do
+    visit spree.edit_admin_product_path(product)
+  end
+
+  it 'has a Prices tab' do
+    within(".tabs") do
+      expect(page).to have_link("Prices")
+    end
+  end
+
+  context "in the prices tab" do
+    let(:master_price) { product.master.default_price }
+    let!(:other_price) { product.master.prices.create(amount: 34.56, currency: "RUB") }
+
+    before do
+      visit spree.admin_product_prices_path(product)
+    end
+
+    it 'displays a table with the prices' do
+      expect(page).to have_content(product.name)
+      within(".tabs .active") do
+        expect(page).to have_content("Prices")
+      end
+
+      within('table.prices') do
+        expect(page).to have_content("$19.99")
+        expect(page).to have_content("USD")
+        expect(page).to have_content("34.56 ₽")
+        expect(page).to have_content("RUB")
+        expect(page).to have_content("Master Variant")
+      end
+    end
+
+    context "searching" do
+      let(:variant) { create(:variant, price: 20) }
+      let(:product) { variant.product }
+
+      before do
+        product.master.update(price: 49.99)
+      end
+
+      it 'has a working table filter' do
+        expect(page).to have_selector("#table-filter")
+        within "#table-filter" do
+          within "fieldset legend" do
+            expect(page).to have_content("Search")
+          end
+        end
+        select variant.options_text, from: "q_variant_id_eq"
+        click_button "Filter Results"
+        expect(page).to have_content("20")
+        expect(page).to_not have_content("49.99")
+      end
+    end
+  end
+end

--- a/backend/spec/features/admin/products/pricing_spec.rb
+++ b/backend/spec/features/admin/products/pricing_spec.rb
@@ -34,7 +34,7 @@ describe 'Pricing' do
         expect(page).to have_content("USD")
         expect(page).to have_content("34.56 ₽")
         expect(page).to have_content("RUB")
-        expect(page).to have_content("Master Variant")
+        expect(page).to have_content("Master")
       end
     end
 

--- a/backend/spec/features/admin/products/pricing_spec.rb
+++ b/backend/spec/features/admin/products/pricing_spec.rb
@@ -59,5 +59,31 @@ describe 'Pricing' do
         expect(page).to_not have_content("49.99")
       end
     end
+
+    context "deleting", js: true do
+      let(:product) { create(:product, price: 65.43) }
+      let!(:variant) { product.master }
+      let!(:other_price) { product.master.prices.create(amount: 34.56, is_default: false) }
+
+      it "will delete the non-default price" do
+        within "#spree_price_#{other_price.id}" do
+          accept_alert do
+            click_icon :trash
+          end
+        end
+        expect(page).to have_content("Price has been successfully removed")
+      end
+
+      it "does not break when default price is deleted" do
+        within "#spree_price_#{variant.default_price.id}" do
+          accept_alert do
+            click_icon :trash
+          end
+        end
+        expect(page).to have_content("Price has been successfully removed")
+        visit spree.admin_products_path
+        expect(page).to have_selector("#spree_product_#{product.id}")
+      end
+    end
   end
 end

--- a/core/app/models/spree/price.rb
+++ b/core/app/models/spree/price.rb
@@ -5,6 +5,7 @@ module Spree
     MAXIMUM_AMOUNT = BigDecimal('99_999_999.99')
 
     belongs_to :variant, -> { with_deleted }, class_name: 'Spree::Variant', touch: true
+    has_one :product, class_name: 'Spree::Product', through: :variant
 
     validate :check_price
     validates :amount, allow_nil: true, numericality: {
@@ -22,7 +23,7 @@ module Spree
     money_methods :amount, :price
     alias_method :money, :display_amount
 
-    self.whitelisted_ransackable_attributes = ['amount']
+    self.whitelisted_ransackable_attributes = %w( amount variant_id currency )
 
     # An alias for #amount
     def price

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -134,6 +134,10 @@ en:
         name: Name
         preference_source: Preference Source
         type: Provider
+      spree/price:
+        currency: Currency
+        amount: Price
+        is_default: Currently Valid
       spree/product:
         available_on: Available On
         cost_currency: Cost Currency
@@ -395,6 +399,9 @@ en:
       spree/payment_method:
         one: Payment Method
         other: Payment Methods
+      spree/price:
+        one: Price
+        other: Prices
       spree/product:
         one: Product
         other: Products
@@ -767,6 +774,18 @@ en:
           use_product_tax_category: Use Product Tax Category
           pricing: Pricing
           pricing_hint: These values are populated from the product details page and can be overridden below
+      prices:
+        table:
+          master_variant: Master Variant
+        index:
+          master_variant: Master Variant
+          amount_greater_than: Amount greater than
+          amount_less_than: Amount less than
+          new_price: New Price
+        edit:
+          edit_price: Edit Price
+        new:
+          new_price: New Price
     administration: Administration
     agree_to_privacy_policy: Agree to Privacy Policy
     agree_to_terms_of_service: Agree to Terms of Service

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -775,10 +775,7 @@ en:
           pricing: Pricing
           pricing_hint: These values are populated from the product details page and can be overridden below
       prices:
-        table:
-          master_variant: Master Variant
         index:
-          master_variant: Master Variant
           amount_greater_than: Amount greater than
           amount_less_than: Amount less than
           new_price: New Price

--- a/core/spec/models/spree/price_spec.rb
+++ b/core/spec/models/spree/price_spec.rb
@@ -1,6 +1,13 @@
 require 'spec_helper'
 
 describe Spree::Price, type: :model do
+  describe 'searchable columns' do
+    subject { described_class.whitelisted_ransackable_attributes }
+    it 'allows searching by variant_id' do
+      expect(subject).to include("variant_id")
+    end
+  end
+
   describe 'validations' do
     let(:variant) { stub_model Spree::Variant }
     subject { Spree::Price.new variant: variant, amount: amount }


### PR DESCRIPTION
We have great functionality for dealing with multiple prices for each variant. This is an
absolutely basic interface so that as a store admin, it's possible to edit and update prices.

I'm unsure about allowing deletion and have left it out for now: When you delete a price,
you might end up with no price that has `is_default` set, which will then make the variant
in question become "unavailable". As a new price gets the `is_default` boolean anyways, the old
one becomes so meaningless it's as if it was deleted.

There are plans for a much better interface, but I need something simple that works for 1.3
to get out the door.