### PR TITLE
Promotion#line_item_actionable? should guard against non-promotionable products

### DIFF
--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -176,8 +176,9 @@ module Spree
         count(:order_id)
     end
 
-    # TODO: specs
     def line_item_actionable?(order, line_item, promotion_code: nil)
+      return false if blacklisted?(line_item)
+
       if eligible?(order, promotion_code: promotion_code)
         rules = eligible_rules(order)
         if rules.blank?

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -664,6 +664,12 @@ describe Spree::Promotion, type: :model do
             it { is_expected.not_to be }
           end
         end
+
+        context 'when the line item has an non-promotionable product' do
+          let(:rules) { [true_rule] }
+          let(:line_item) { build(:line_item) { |li| li.product.promotionable = false } }
+          it { is_expected.not_to be }
+        end
       end
     end
 


### PR DESCRIPTION
This gets very confusing, because of the apparent legacy of line-item-specific
actionable not always existing. But I _think_ there are cases where an ORDER can
get through all the checks, but then line_item_actionable will be called
on a specific line item with a blacklisted product, and prior to this fix
incorrectly return true. 

It's hard for me to be completely sure of this, I thought I had an example
but now I've lost it, and the code split amongst many models, and the
tests written with lots of doubles, all make it hard to be sure. 

But at worst this PR will be unneccesary, it will never cause any
wrong decision, and I believe makes things more robust. One would expect
a  line_item_actionable? method would never return true for a line item
with a blacklisted product, and this simple change makes it so.