### PR TITLE
Revert "Use eval_gemfile instead of plain eval"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-eval_gemfile File.expand_path('../common_spree_dependencies.rb', __FILE__)
+eval(File.read(File.dirname(__FILE__) + '/common_spree_dependencies.rb'))
 
 gemspec

--- a/api/Gemfile
+++ b/api/Gemfile
@@ -1,4 +1,4 @@
-eval_gemfile File.expand_path('../../common_spree_dependencies.rb', __FILE__)
+eval(File.read(File.dirname(__FILE__) + '/../common_spree_dependencies.rb'))
 
 gem 'solidus_core', path: '../core'
 

--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -1,4 +1,4 @@
-eval_gemfile File.expand_path('../../common_spree_dependencies.rb', __FILE__)
+eval(File.read(File.dirname(__FILE__) + '/../common_spree_dependencies.rb'))
 
 gem 'solidus_core', path: '../core'
 gem 'solidus_api', path: '../api'

--- a/core/Gemfile
+++ b/core/Gemfile
@@ -1,3 +1,3 @@
-eval_gemfile File.expand_path('../../common_spree_dependencies.rb', __FILE__)
+eval(File.read(File.dirname(__FILE__) + '/../common_spree_dependencies.rb'))
 
 gemspec

--- a/frontend/Gemfile
+++ b/frontend/Gemfile
@@ -1,4 +1,4 @@
-eval_gemfile File.expand_path('../../common_spree_dependencies.rb', __FILE__)
+eval(File.read(File.dirname(__FILE__) + '/../common_spree_dependencies.rb'))
 
 gem 'solidus_core', path: '../core'
 gem 'solidus_api', path: '../api'

--- a/sample/Gemfile
+++ b/sample/Gemfile
@@ -1,4 +1,4 @@
-eval_gemfile File.expand_path('../../common_spree_dependencies.rb', __FILE__)
+eval(File.read(File.dirname(__FILE__) + '/../common_spree_dependencies.rb'))
 
 gem 'solidus_core', path: '../core'
 


### PR DESCRIPTION
This reverts commit 9cde4243667da97be5b524c4a7256d75ef270d40.

Unfortunately, this doesn't work for a number of people due to Bundler's API not being entirely stable. :frowning: