### PR TITLE
Make the default pricer country-aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,10 @@
     object. For now, this object (`Spree::Variant::PricingOptions`) only holds the
     currency. It is used for caching instead of the deprecated `current_currency` helper.
 
-    Additionally, your pricing can be customized using a `VariantPricer` object, a default
-    implementation of which can be found in `Spree::Variant::Pricer`. It is responsible for
+    Additionally, your pricing can be customized using a `VariantPriceSelector` object, a default
+    implementation of which can be found in `Spree::Variant::PriceSelector`. It is responsible for
     finding the right price for variant, be it for front-end display or for adding it to the
-    cart. You can set it through the new `Spree::Config.variant_pricer_class` setting. This
+    cart. You can set it through the new `Spree::Config.variant_price_selector_class` setting. This
     class also knows which `PricingOptions` class it cooperates with.
 
     #### Deprecated methods:
@@ -32,7 +32,7 @@
     `Spree::Variant` to be patched with methods like `Spree::Variant#gift_wrap_price_modifier_in`
     and is generally deemed a non-preferred way of modifying pricing.
     This functionality has now been moved into a [Gem of its own](https://github.com/solidusio-contrib/solidus_price_modifier)
-    to ease the transition to the new `Variant::Pricer` system.
+    to ease the transition to the new `Variant::PriceSelector` system.
 
 *   Respect `Spree::Store#default_currency`
 

--- a/backend/app/controllers/spree/admin/prices_controller.rb
+++ b/backend/app/controllers/spree/admin/prices_controller.rb
@@ -7,7 +7,10 @@ module Spree
         params[:q] ||= {}
 
         @search = @product.prices.accessible_by(current_ability, :index).ransack(params[:q])
-        @prices = @search.result.page(params[:page]).per(10)
+        @prices = @search.result
+          .currently_valid
+          .order(:variant_id, :country_iso, :currency)
+          .page(params[:page]).per(Spree::Config.admin_variants_per_page)
       end
 
       def edit

--- a/backend/app/helpers/spree/admin/products_helper.rb
+++ b/backend/app/helpers/spree/admin/products_helper.rb
@@ -24,6 +24,10 @@ module Spree
         end
         safe_join(options)
       end
+
+      def show_rebuild_vat_checkbox?
+        Spree::TaxRate.included_in_price.exists?
+      end
     end
   end
 end

--- a/backend/app/views/spree/admin/prices/_form.html.erb
+++ b/backend/app/views/spree/admin/prices/_form.html.erb
@@ -11,7 +11,7 @@
       <% end %>
     </div>
 
-    <div class="four columns alpha" data-hook="admin_product_price_form_currency">
+    <div class="three columns alpha" data-hook="admin_product_price_form_currency">
       <%= f.field_container :currency do %>
         <%= f.label :currency %>
         <%= f.select :currency,
@@ -21,14 +21,26 @@
       <% end %>
     </div>
 
-    <div class="four columns alpha" data-hook="admin_product_price_form_amount">
+    <div class="three columns" data-hook="admin_product_price_form_country">
+      <%= f.field_container :country do %>
+        <%= f.label :country %>
+        <%= f.collection_select :country_iso, available_countries, :iso, :name,
+                                {
+                                  include_blank: t(:any_country, scope: [:spree, :admin, :prices]),
+                                  selected: Spree::Config.admin_vat_country_iso
+                                },
+                                { class: 'select2 fullwidth', disabled: !f.object.new_record? } %>
+      <% end %>
+    </div>
+
+    <div class="three columns" data-hook="admin_product_price_form_amount">
       <%= f.field_container :price do %>
         <%= f.label :price %>
         <%= f.text_field :price, value: f.object.money.format, class: 'fullwidth title' %>
       <% end %>
     </div>
 
-    <div class="field four columns checkbox omega" data-hook="is_default_price">
+    <div class="field three columns checkbox omega" data-hook="is_default_price">
       <%= f.label :is_default do %>
         <%= f.check_box :is_default %>
         <%= Spree::Price.human_attribute_name(:is_default) %>

--- a/backend/app/views/spree/admin/prices/_table.html.erb
+++ b/backend/app/views/spree/admin/prices/_table.html.erb
@@ -5,8 +5,9 @@
     <tr>
       <th><%= Spree::Variant.model_name.human %> </th>
       <th><%= Spree::Price.human_attribute_name(:is_default) %></th>
-      <th><%= Spree::Price.human_attribute_name(:amount) %></th>
+      <th><%= Spree::Price.human_attribute_name(:country) %></th>
       <th><%= Spree::Price.human_attribute_name(:currency) %></th>
+      <th><%= Spree::Price.human_attribute_name(:amount) %></th>
       <th class="actions"></th>
     </tr>
   </thead>
@@ -24,8 +25,9 @@
           <span class="state canceled"> <%= Spree.t(:say_no) %> </span>
         <% end %>
       </td>
-      <td class="align-center"><%= price.money.to_html %></td>
+      <td class="align-center"><%= price.country.try(:name) || t(:any_country, scope: [:spree, :admin, :prices]) %>
       <td class="align-center"><%= price.currency %></td>
+      <td class="align-center"><%= price.money.to_html %></td>
       <td class="actions">
         <% if can?(:update, price) %>
           <%= link_to_edit(price, :no_text => true) unless price.deleted? %>

--- a/backend/app/views/spree/admin/prices/_table.html.erb
+++ b/backend/app/views/spree/admin/prices/_table.html.erb
@@ -4,7 +4,6 @@
   <thead data-hook="prices_header">
     <tr>
       <th><%= Spree::Variant.model_name.human %> </th>
-      <th><%= Spree::Price.human_attribute_name(:is_default) %></th>
       <th><%= Spree::Price.human_attribute_name(:country) %></th>
       <th><%= Spree::Price.human_attribute_name(:currency) %></th>
       <th><%= Spree::Price.human_attribute_name(:amount) %></th>
@@ -15,19 +14,10 @@
   <tbody>
   <% prices.each do |price| %>
     <tr id="<%= spree_dom_id price %>" data-hook="prices_row" class="<%= "deleted" if price.deleted? %> <%= cycle('odd', 'even')%>">
-      <td class="align-center">
-        <%= price.variant.descriptive_name %>
-      </td>
-      <td class="align-center">
-        <% if price.is_default? %>
-          <span class="state complete"> <%= Spree.t(:say_yes) %> </span>
-        <% else %>
-          <span class="state canceled"> <%= Spree.t(:say_no) %> </span>
-        <% end %>
-      </td>
-      <td class="align-center"><%= price.country.try(:name) || t(:any_country, scope: [:spree, :admin, :prices]) %>
-      <td class="align-center"><%= price.currency %></td>
-      <td class="align-center"><%= price.money.to_html %></td>
+      <td><%= price.variant.descriptive_name %></td>
+      <td><%= price.display_country %>
+      <td><%= price.currency %></td>
+      <td class="align-right"><%= price.money.to_html %></td>
       <td class="actions">
         <% if can?(:update, price) %>
           <%= link_to_edit(price, :no_text => true) unless price.deleted? %>

--- a/backend/app/views/spree/admin/prices/index.html.erb
+++ b/backend/app/views/spree/admin/prices/index.html.erb
@@ -24,8 +24,8 @@
     </div>
   </div>
 
-  <div class="four columns">
-    <div class="field" data-hook="sku-select">
+  <div class="three columns">
+    <div class="field" data-hook="currency-select">
       <%= label_tag :q_currency_eq, Spree::Price.human_attribute_name(:currency) %>
       <%= f.select :currency_eq,
                    @prices.map(&:currency).uniq,
@@ -34,15 +34,25 @@
     </div>
   </div>
 
-  <div class="four columns">
-    <div class="field" data-hook="sku-select">
+  <div class="three columns">
+    <div class="field" data-hook="country-select">
+      <%= label_tag :q_country_iso_eq, Spree::Price.human_attribute_name(:country) %>
+      <%= f.select :country_iso_eq,
+                   @prices.map(&:country).compact.uniq.map { |c| [c.name, c.iso]},
+                   {include_blank: true},
+                   class: "select2 fullwidth" %>
+    </div>
+  </div>
+
+  <div class="three columns">
+    <div class="field">
       <%= label_tag :q_amount_gt, t(".amount_greater_than") %>
       <%= f.text_field :amount_gt %>
     </div>
   </div>
 
-  <div class="omega four columns">
-    <div class="field" data-hook="sku-select">
+  <div class="omega three columns">
+    <div class="field">
       <%= label_tag :q_amount_lt, t(".amount_less_than") %>
       <%= f.text_field :amount_lt %>
     </div>

--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -27,13 +27,18 @@
   </div>
 
   <div class="right four columns omega" data-hook="admin_product_form_right">
-    <div data-hook="admin_product_form_price">
-    <%= f.field_container :price do %>
-      <%= f.label :price, class: 'required' %>
-      <%= f.text_field :price, :value => number_to_currency(@product.price, :unit => ''), :required => true %>
-      <%= f.error_message_on :price %>
-    <% end %>
+    <div data-hook="admin_product_form_price" class="alpha omega four columns">
+      <%= f.field_container :price do %>
+        <%= f.label :price, class: 'required' %>
+        <%= f.text_field :price, :value => number_to_currency(@product.price, :unit => ''), :required => true %>
+        <%= f.error_message_on :price %>
+      <% end %>
     </div>
+
+    <% if show_rebuild_vat_checkbox? %>
+      <%= render "spree/admin/shared/rebuild_vat_prices_checkbox", form: f, model_name: "product", wrapper_class: "alpha omega field four columns" %>
+      <div class="clearfix"></div>
+    <% end %>
 
     <div data-hook="admin_product_form_cost_price" class="alpha two columns">
       <%= f.field_container :cost_price do %>

--- a/backend/app/views/spree/admin/products/new.html.erb
+++ b/backend/app/views/spree/admin/products/new.html.erb
@@ -49,12 +49,20 @@
     </div>
 
     <div class='row'>
-      <div data-hook="new_product_shipping_category" class="alpha four columns">
+      <div data-hook="new_product_shipping_category" class="alpha field four columns">
         <%= f.field_container :shipping_category do %>
           <%= f.label :shipping_category_id, Spree::ShippingCategory.
                 model_name.human, class: 'required' %><br />
           <%= f.collection_select(:shipping_category_id, @shipping_categories, :id, :name, { :include_blank => Spree.t('match_choices.none') }, { :class => 'select2 fullwidth' }) %>
           <%= f.error_message_on :shipping_category_id %>
+        <% end %>
+      </div>
+
+      <div data-hook="new_product_tax_category" class="field four columns">
+        <%= f.field_container :tax_category do %>
+          <%= f.label :tax_category_id, Spree::TaxCategory.model_name.human %>
+          <%= f.collection_select(:tax_category_id, @tax_categories, :id, :name, { :include_blank => Spree.t('match_choices.none') }, { :class => 'select2 fullwidth' }) %>
+          <%= f.error_message_on :tax_category %>
         <% end %>
       </div>
     </div>

--- a/backend/app/views/spree/admin/shared/_rebuild_vat_prices_checkbox.html.erb
+++ b/backend/app/views/spree/admin/shared/_rebuild_vat_prices_checkbox.html.erb
@@ -1,0 +1,12 @@
+<div data-hook="admin_<%= model_name %>_form_generate_vat_prices" class="<%= wrapper_class %> checkbox">
+  <%= form.label :rebuild_vat_prices do %>
+    <%= form.check_box :rebuild_vat_prices, checked: form.object.prices.size <= 1 %>
+    <%= Spree::Variant.human_attribute_name(:rebuild_vat_prices) %>
+  <% end %>
+</div>
+
+<script type="text/javascript">
+  $('#<%= model_name %>_price').on('change', function(e) {
+    $('#<%= model_name %>_rebuild_vat_prices').prop('checked', true);
+  });
+</script>

--- a/backend/app/views/spree/admin/variants/_form.html.erb
+++ b/backend/app/views/spree/admin/variants/_form.html.erb
@@ -53,6 +53,10 @@
       <%= f.text_field :price, :value => number_to_currency(@variant.price, :unit => ''), :class => 'fullwidth' %>
     </div>
 
+    <% if show_rebuild_vat_checkbox? %>
+      <%= render "spree/admin/shared/rebuild_vat_prices_checkbox", form: f, model_name: "variant", wrapper_class: "field four columns" %>
+    <% end %>
+
     <div class="field four columns" data-hook="cost_price">
       <%= f.label :cost_price %>
       <%= f.text_field :cost_price, :value => number_to_currency(@variant.cost_price, :unit => ''), :class => 'fullwidth' %>

--- a/backend/spec/features/admin/products/pricing_spec.rb
+++ b/backend/spec/features/admin/products/pricing_spec.rb
@@ -16,8 +16,9 @@ describe 'Pricing' do
   end
 
   context "in the prices tab" do
+    let!(:country) { create :country, iso: "DE" }
     let(:master_price) { product.master.default_price }
-    let!(:other_price) { product.master.prices.create(amount: 34.56, currency: "RUB") }
+    let!(:other_price) { product.master.prices.create(amount: 34.56, currency: "RUB", country_iso: "DE") }
 
     before do
       visit spree.admin_product_prices_path(product)
@@ -35,6 +36,8 @@ describe 'Pricing' do
         expect(page).to have_content("34.56 ₽")
         expect(page).to have_content("RUB")
         expect(page).to have_content("Master")
+        expect(page).to have_content("Any Country")
+        expect(page).to have_content("Germany")
       end
     end
 

--- a/backend/spec/features/admin/products/pricing_spec.rb
+++ b/backend/spec/features/admin/products/pricing_spec.rb
@@ -66,7 +66,7 @@ describe 'Pricing' do
     context "deleting", js: true do
       let(:product) { create(:product, price: 65.43) }
       let!(:variant) { product.master }
-      let!(:other_price) { product.master.prices.create(amount: 34.56, is_default: false) }
+      let!(:other_price) { product.master.prices.create(amount: 34.56, currency: "EUR") }
 
       it "will delete the non-default price" do
         within "#spree_price_#{other_price.id}" do

--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -281,22 +281,22 @@ module Spree
     end
 
     # Allows implementing custom pricing for variants
-    # @!attribute [rw] variant_pricer_class
-    # @see Spree::Variant::Pricer
+    # @!attribute [rw] variant_price_selector_class
+    # @see Spree::Variant::PriceSelector
     # @return [Class] an object that conforms to the API of
-    #   the standard variant pricer class Spree::Variant::Pricer.
-    attr_writer :variant_pricer_class
-    def variant_pricer_class
-      @variant_pricer_class ||= Spree::Variant::Pricer
+    #   the standard variant price selector class Spree::Variant::PriceSelector.
+    attr_writer :variant_price_selector_class
+    def variant_price_selector_class
+      @variant_price_selector_class ||= Spree::Variant::PriceSelector
     end
 
-    # Shortcut for getting the variant pricer's pricing options class
+    # Shortcut for getting the variant price selector's pricing options class
     #
     # @return [Class] The pricing options class to be used
-    delegate :pricing_options_class, to: :variant_pricer_class
+    delegate :pricing_options_class, to: :variant_price_selector_class
 
     # Shortcut for the default pricing options
-    # @return [variant_pricer_class] An instance of the pricing options class with default desired
+    # @return [variant_price_selector_class] An instance of the pricing options class with default desired
     #   attributes
     def default_pricing_options
       @default_pricing_options ||= pricing_options_class.new

--- a/core/app/models/spree/country.rb
+++ b/core/app/models/spree/country.rb
@@ -2,6 +2,7 @@ module Spree
   class Country < Spree::Base
     has_many :states, -> { order(:name) }, dependent: :destroy
     has_many :addresses, dependent: :nullify
+    has_many :prices, class_name: "Spree::Price", foreign_key: "country_iso", primary_key: "iso"
 
     validates :name, :iso_name, presence: true
 

--- a/core/app/models/spree/price.rb
+++ b/core/app/models/spree/price.rb
@@ -27,7 +27,7 @@ module Spree
     money_methods :amount, :price
     alias_method :money, :display_amount
 
-    self.whitelisted_ransackable_attributes = %w( amount variant_id currency )
+    self.whitelisted_ransackable_attributes = %w( amount variant_id currency country_iso )
 
     # An alias for #amount
     def price

--- a/core/app/models/spree/price.rb
+++ b/core/app/models/spree/price.rb
@@ -50,6 +50,14 @@ module Spree
       country_iso.nil?
     end
 
+    def display_country
+      if country_iso
+        "#{country_iso} (#{country.name})"
+      else
+        I18n.t(:any_country, scope: [:spree, :admin, :prices])
+      end
+    end
+
     private
 
     def sum_of_vat_amounts

--- a/core/app/models/spree/price.rb
+++ b/core/app/models/spree/price.rb
@@ -5,13 +5,16 @@ module Spree
     MAXIMUM_AMOUNT = BigDecimal('99_999_999.99')
 
     belongs_to :variant, -> { with_deleted }, class_name: 'Spree::Variant', touch: true
-    has_one :product, class_name: 'Spree::Product', through: :variant
+    belongs_to :country, class_name: "Spree::Country", foreign_key: "country_iso", primary_key: "iso"
+
+    delegate :product, to: :variant
 
     validate :check_price
     validates :amount, allow_nil: true, numericality: {
       greater_than_or_equal_to: 0,
       less_than_or_equal_to: MAXIMUM_AMOUNT
     }
+    validates :country, presence: true, if: -> { country_iso.present? }
 
     validates :currency, inclusion: { in: ::Money::Currency.all.map(&:iso_code), message: :invalid_code }
 

--- a/core/app/models/spree/price.rb
+++ b/core/app/models/spree/price.rb
@@ -14,11 +14,12 @@ module Spree
       greater_than_or_equal_to: 0,
       less_than_or_equal_to: MAXIMUM_AMOUNT
     }
-    validates :country, presence: true, if: -> { country_iso.present? }
+    validates :country, presence: true, unless: -> { for_any_country? }
 
     validates :currency, inclusion: { in: ::Money::Currency.all.map(&:iso_code), message: :invalid_code }
 
     scope :currently_valid, -> { where(is_default: true) }
+    scope :for_any_country, -> { where(country: nil) }
     scope :with_default_attributes, -> { where(Spree::Config.default_pricing_options.desired_attributes) }
     after_save :set_default_price
 
@@ -42,6 +43,10 @@ module Spree
     end
 
     private
+
+    def for_any_country?
+      country_iso.nil?
+    end
 
     def check_price
       self.currency ||= Spree::Config[:currency]

--- a/core/app/models/spree/price.rb
+++ b/core/app/models/spree/price.rb
@@ -18,7 +18,7 @@ module Spree
     validates :currency, inclusion: { in: ::Money::Currency.all.map(&:iso_code), message: :invalid_code }
     validates :country, presence: true, unless: -> { for_any_country? }
 
-    scope :currently_valid, -> { where(is_default: true) }
+    scope :currently_valid, -> { where(is_default: true).order("country_iso IS NULL") }
     scope :for_any_country, -> { where(country: nil) }
     scope :with_default_attributes, -> { where(Spree::Config.default_pricing_options.desired_attributes) }
     after_save :set_default_price

--- a/core/app/models/spree/price.rb
+++ b/core/app/models/spree/price.rb
@@ -46,6 +46,10 @@ module Spree
       amount / (1 + sum_of_included_vats)
     end
 
+    def for_any_country?
+      country_iso.nil?
+    end
+
     private
 
     def sum_of_included_vats
@@ -53,10 +57,6 @@ module Spree
       variant.tax_category.tax_rates.for_address(
         Spree::Tax::TaxLocation.new(country: country)
       ).sum(:amount)
-    end
-
-    def for_any_country?
-      country_iso.nil?
     end
 
     def check_price

--- a/core/app/models/spree/price.rb
+++ b/core/app/models/spree/price.rb
@@ -42,7 +42,18 @@ module Spree
       self[:amount] = Spree::LocalizedNumber.parse(price)
     end
 
+    def net_amount
+      amount / (1 + sum_of_included_vats)
+    end
+
     private
+
+    def sum_of_included_vats
+      return 0 unless variant.tax_category
+      variant.tax_category.tax_rates.for_address(
+        Spree::Tax::TaxLocation.new(country: country)
+      ).sum(:amount)
+    end
 
     def for_any_country?
       country_iso.nil?

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -59,7 +59,10 @@ module Spree
       master || build_master
     end
 
-    MASTER_ATTRIBUTES = [:sku, :price, :currency, :display_amount, :display_price, :weight, :height, :width, :depth, :cost_currency, :price_in, :price_for, :amount_in, :cost_price]
+    MASTER_ATTRIBUTES = [
+      :rebuild_vat_prices, :sku, :price, :currency, :display_amount, :display_price, :weight,
+      :height, :width, :depth, :cost_currency, :price_in, :price_for, :amount_in, :cost_price
+    ]
     MASTER_ATTRIBUTES.each do |attr|
       delegate :"#{attr}", :"#{attr}=", to: :find_or_build_master
     end

--- a/core/app/models/spree/tax/tax_location.rb
+++ b/core/app/models/spree/tax/tax_location.rb
@@ -25,6 +25,10 @@ module Spree
         state_id == other.state_id && country_id == other.country_id
       end
 
+      def country
+        Spree::Country.find_by(id: country_id)
+      end
+
       def empty?
         country_id.nil? && state_id.nil?
       end

--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -1,14 +1,4 @@
 module Spree
-  class DefaultTaxZoneValidator < ActiveModel::Validator
-    def validate(record)
-      if record.included_in_price
-        record.errors.add(:included_in_price, Spree.t(:included_price_validation)) unless Zone.default_tax
-      end
-    end
-  end
-end
-
-module Spree
   class TaxRate < Spree::Base
     acts_as_paranoid
 
@@ -26,7 +16,6 @@ module Spree
 
     validates :amount, presence: true, numericality: true
     validates :tax_category_id, presence: true
-    validates_with DefaultTaxZoneValidator
 
     # Finds all tax rates whose zones match a given address
     scope :for_address, ->(address) { joins(:zone).merge(Spree::Zone.for_address(address)) }

--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -19,6 +19,8 @@ module Spree
 
     # Finds all tax rates whose zones match a given address
     scope :for_address, ->(address) { joins(:zone).merge(Spree::Zone.for_address(address)) }
+    scope :for_country,
+          ->(country) { for_address(Spree::Tax::TaxLocation.new(country: country)) }
 
     # Finds geographically matching tax rates for a tax zone.
     # We do not know if they are/aren't applicable until we attempt to apply these rates to

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -93,7 +93,7 @@ module Spree
     # @param pricing_options A Pricing Options object as defined on the pricer class
     # @return [ActiveRecord::Relation]
     def self.with_prices(pricing_options = Spree::Config.default_pricing_options)
-      joins(:prices).merge(Spree::Price.currently_valid.where(pricing_options.desired_attributes))
+      joins(:prices).merge(Spree::Price.currently_valid.where(pricing_options.search_arguments))
     end
 
     # @return [Spree::TaxCategory] the variant's tax category

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -93,7 +93,7 @@ module Spree
 
     # Returns variants that have a price for the given pricing options
     #
-    # @param pricing_options A Pricing Options object as defined on the pricer class
+    # @param pricing_options A Pricing Options object as defined on the price selector class
     # @return [ActiveRecord::Relation]
     def self.with_prices(pricing_options = Spree::Config.default_pricing_options)
       joins(:prices).merge(Spree::Price.currently_valid.where(pricing_options.search_arguments))
@@ -225,20 +225,20 @@ module Spree
       option_values.detect { |o| o.option_type.name == opt_name }.try(:presentation)
     end
 
-    # Returns an instance of the globally configured variant pricer class for this variant.
+    # Returns an instance of the globally configured variant price selector class for this variant.
     # It's cached so we don't create too many objects.
     #
-    # @return [Spree::Variant::Pricer] The default pricer class
-    def pricer
-      @pricer ||= Spree::Config.variant_pricer_class.new(self)
+    # @return [Spree::Variant::PriceSelector] The default price selector class
+    def price_selector
+      @price_selector ||= Spree::Config.variant_price_selector_class.new(self)
     end
 
     # Chooses an appropriate price for the given pricing options
     #
-    # @see Spree::Variant::Pricer#price_for
+    # @see Spree::Variant::PriceSelector#price_for
     # @param [Spree::Config.pricing_options_class] An instance of pricing options
     # @return [Spree::Money] The chosen price as a Money object
-    delegate :price_for, to: :pricer
+    delegate :price_for, to: :price_selector
 
     # Returns the difference in price from the master variant
     def price_difference_from_master(pricing_options = Spree::Config.default_pricing_options)
@@ -368,7 +368,7 @@ module Spree
     end
 
     def build_vat_prices
-      PriceGenerator.new(self).run
+      VatPriceGenerator.new(self).run
     end
 
     def set_position

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -17,6 +17,7 @@ module Spree
     acts_as_paranoid
     acts_as_list scope: :product
 
+    attr_writer :rebuild_vat_prices
     include Spree::DefaultPrice
 
     belongs_to :product, -> { with_deleted }, touch: true, class_name: 'Spree::Product', inverse_of: :variants
@@ -44,11 +45,12 @@ module Spree
     has_many :prices,
       class_name: 'Spree::Price',
       dependent: :destroy,
-      inverse_of: :variant
+      inverse_of: :variant,
+      autosave: true
 
     before_validation :set_cost_currency
     before_validation :set_price
-    before_validation :build_vat_prices, if: :new_record?
+    before_validation :build_vat_prices, if: -> { rebuild_vat_prices? || new_record? }
 
     validate :check_price
 
@@ -335,6 +337,10 @@ module Spree
     end
 
     private
+
+    def rebuild_vat_prices?
+      @rebuild_vat_prices != "0" && @rebuild_vat_prices
+    end
 
     def set_master_out_of_stock
       if product.master && product.master.in_stock?

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -26,6 +26,7 @@ module Spree
              :meta_description, :meta_keywords, :shipping_category,
              to: :product
     delegate :tax_category, to: :product, prefix: true
+    delegate :tax_rates, to: :tax_category
 
     has_many :inventory_units, inverse_of: :variant
     has_many :line_items, inverse_of: :variant

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -48,6 +48,7 @@ module Spree
     before_validation :set_cost_currency
 
     validate :check_price
+    validate :build_vat_prices
 
     validates :cost_price, numericality: { greater_than_or_equal_to: 0, allow_nil: true }
     validates :price,      numericality: { greater_than_or_equal_to: 0, allow_nil: true }
@@ -360,6 +361,10 @@ module Spree
       StockLocation.where(propagate_all_variants: true).each do |stock_location|
         stock_location.propagate_variant(self)
       end
+    end
+
+    def build_vat_prices
+      PriceGenerator.new(self).run
     end
 
     def set_position

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -48,6 +48,13 @@ module Spree
       inverse_of: :variant,
       autosave: true
 
+    has_many :currently_valid_prices,
+      -> { currently_valid },
+      class_name: 'Spree::Price',
+      dependent: :destroy,
+      inverse_of: :variant,
+      autosave: true
+
     before_validation :set_cost_currency
     before_validation :set_price
     before_validation :build_vat_prices, if: -> { rebuild_vat_prices? || new_record? }

--- a/core/app/models/spree/variant/price_generator.rb
+++ b/core/app/models/spree/variant/price_generator.rb
@@ -25,10 +25,12 @@ module Spree
       private
 
       def country_isos_requiring_price
+        return [nil] unless variant.tax_category
         [nil] + variant_vat_rates.map(&:zone).flat_map(&:countries).flat_map(&:iso)
       end
 
       def vat_for_country_iso(country_iso)
+        return 0 unless variant.tax_category
         variant_vat_rates.for_address(
           Spree::Tax::TaxLocation.new(country: Spree::Country.find_by(iso: country_iso))
         ).sum(:amount)

--- a/core/app/models/spree/variant/price_generator.rb
+++ b/core/app/models/spree/variant/price_generator.rb
@@ -1,5 +1,16 @@
 module Spree
   class Variant
+    # This class generates prices for all countries that have VAT configured.
+    # The prices will include their respective VAT rates. It will also generate an
+    # export (net) price for any country that doesn't have VAT.
+    # @example
+    #   The admin views German gross prices (Spree::Config.admin_vat_country_iso == "DE")
+    #   There is VATs configured for Germany (19%) and Finland (24%).
+    #   The price generator is run on a variant with a base (German) price of 10.00.
+    #   The Price Generator will generate:
+    #     - A price for Finland (country_id == "FI"): 10.42
+    #     - A price for export (country_id == nil): 8.40
+    #
     class PriceGenerator
       attr_reader :variant
 
@@ -9,7 +20,7 @@ module Spree
 
       def run
         country_isos_requiring_price.each do |country_iso|
-          # No double prices
+          # If there is a price for this country/variant combination already, don't create a new one
           next if variant.prices.map(&:country_iso).include?(country_iso)
           # Also don't re-create the default price
           next if variant.default_price && variant.default_price.country_iso == country_iso
@@ -24,6 +35,7 @@ module Spree
 
       private
 
+      # nil is added to the array so we always have an export price.
       def country_isos_requiring_price
         return [nil] unless variant.tax_category
         [nil] + variant_vat_rates.map(&:zone).flat_map(&:countries).flat_map(&:iso)

--- a/core/app/models/spree/variant/price_generator.rb
+++ b/core/app/models/spree/variant/price_generator.rb
@@ -1,0 +1,42 @@
+module Spree
+  class Variant
+    class PriceGenerator
+      attr_reader :variant
+
+      def initialize(variant)
+        @variant = variant
+      end
+
+      def run
+        country_isos_requiring_price.each do |country_iso|
+          # No double prices
+          next if variant.prices.map(&:country_iso).include?(country_iso)
+          # Also don't re-create the default price
+          next if variant.default_price && variant.default_price.country_iso == country_iso
+          variant.prices.build(
+            country_iso: country_iso,
+            amount: variant.default_price.net_amount * (1 + vat_for_country_iso(country_iso)),
+            currency: variant.default_price.currency,
+            is_default: true
+          )
+        end
+      end
+
+      private
+
+      def country_isos_requiring_price
+        [nil] + variant_vat_rates.map(&:zone).flat_map(&:countries).flat_map(&:iso)
+      end
+
+      def vat_for_country_iso(country_iso)
+        variant_vat_rates.for_address(
+          Spree::Tax::TaxLocation.new(country: Spree::Country.find_by(iso: country_iso))
+        ).sum(:amount)
+      end
+
+      def variant_vat_rates
+        variant.tax_category.tax_rates.where(included_in_price: true)
+      end
+    end
+  end
+end

--- a/core/app/models/spree/variant/price_generator.rb
+++ b/core/app/models/spree/variant/price_generator.rb
@@ -43,9 +43,7 @@ module Spree
 
       def vat_for_country_iso(country_iso)
         return 0 unless variant.tax_category
-        variant_vat_rates.for_address(
-          Spree::Tax::TaxLocation.new(country: Spree::Country.find_by(iso: country_iso))
-        ).sum(:amount)
+        variant_vat_rates.for_country(Spree::Country.find_by(iso: country_iso)).sum(:amount)
       end
 
       def variant_vat_rates

--- a/core/app/models/spree/variant/price_selector.rb
+++ b/core/app/models/spree/variant/price_selector.rb
@@ -24,12 +24,11 @@ module Spree
       # @param [Spree::Variant::PricingOptions] price_options Pricing Options to abide by
       # @return [Spree::Money, nil] The most specific price for this set of pricing options.
       def price_for(price_options)
-        variant.prices
-          .currently_valid
-          .order("country_iso IS NULL") # Make sure the nils come last
-          .find_by(
-            price_options.search_arguments
-          ).try!(:money)
+        variant.currently_valid_prices.detect do |price|
+          ( price.country_iso == price_options.desired_attributes[:country_iso] ||
+            price.country_iso.nil?
+          ) && price.currency == price_options.desired_attributes[:currency]
+        end.try!(:money)
       end
     end
   end

--- a/core/app/models/spree/variant/price_selector.rb
+++ b/core/app/models/spree/variant/price_selector.rb
@@ -1,13 +1,13 @@
 module Spree
   class Variant
-    # This class is responsible for assigning a price to a variant.
+    # This class is responsible for selecting a price for a variant given certain pricing options.
     # A variant can have multiple or even dynamic prices. The `price_for`
     # method determines which price applies under the given circumstances.
     #
-    class Pricer
+    class PriceSelector
       # The pricing options represent "given circumstances" for a price: The currency
       # we need and the country that the price applies to.
-      # Every pricer is designed to work with a particular set of pricing options
+      # Every price selector is designed to work with a particular set of pricing options
       # embodied in it's pricing options class.
       #
       def self.pricing_options_class

--- a/core/app/models/spree/variant/pricer.rb
+++ b/core/app/models/spree/variant/pricer.rb
@@ -1,6 +1,15 @@
 module Spree
   class Variant
+    # This class is responsible for assigning a price to a variant.
+    # A variant can have multiple or even dynamic prices. The `price_for`
+    # method determines which price applies under the given circumstances.
+    #
     class Pricer
+      # The pricing options represent "given circumstances" for a price: The currency
+      # we need and the country that the price applies to.
+      # Every pricer is designed to work with a particular set of pricing options
+      # embodied in it's pricing options class.
+      #
       def self.pricing_options_class
         Spree::Variant::PricingOptions
       end
@@ -11,6 +20,9 @@ module Spree
         @variant = variant
       end
 
+      # The variant's price, given a set of pricing options
+      # @param [Spree::Variant::PricingOptions] price_options Pricing Options to abide by
+      # @return [Spree::Money, nil] The most specific price for this set of pricing options.
       def price_for(price_options)
         variant.prices
           .currently_valid

--- a/core/app/models/spree/variant/pricer.rb
+++ b/core/app/models/spree/variant/pricer.rb
@@ -12,7 +12,12 @@ module Spree
       end
 
       def price_for(price_options)
-        variant.prices.currently_valid.find_by(price_options.desired_attributes).try!(:money)
+        variant.prices
+          .currently_valid
+          .order("country_iso IS NULL") # Make sure the nils come last
+          .find_by(
+            price_options.search_arguments
+          ).try!(:money)
       end
     end
   end

--- a/core/app/models/spree/variant/pricing_options.rb
+++ b/core/app/models/spree/variant/pricing_options.rb
@@ -17,7 +17,7 @@ module Spree
       end
 
       def self.from_price(price)
-        new(currency: price.currency)
+        new(currency: price.currency, country_iso: price.country_iso)
       end
 
       attr_reader :desired_attributes

--- a/core/app/models/spree/variant/pricing_options.rb
+++ b/core/app/models/spree/variant/pricing_options.rb
@@ -2,7 +2,10 @@ module Spree
   class Variant
     class PricingOptions
       def self.default_price_attributes
-        { currency: Spree::Config.currency }
+        {
+          currency: Spree::Config.currency,
+          country_iso: Spree::Config.admin_vat_country_iso
+        }
       end
 
       def self.from_line_item(line_item)
@@ -19,12 +22,22 @@ module Spree
         @desired_attributes = self.class.default_price_attributes.merge(desired_attributes)
       end
 
+      def search_arguments
+        search_arguments = desired_attributes
+        search_arguments[:country_iso] = [desired_attributes[:country_iso], nil].flatten.uniq
+        search_arguments
+      end
+
       def currency
         desired_attributes[:currency]
       end
 
+      def country_iso
+        desired_attributes[:country_iso]
+      end
+
       def cache_key
-        desired_attributes.values.map(&:to_s).join("/")
+        desired_attributes.values.select(&:present?).map(&:to_s).join("/")
       end
     end
   end

--- a/core/app/models/spree/variant/pricing_options.rb
+++ b/core/app/models/spree/variant/pricing_options.rb
@@ -1,6 +1,22 @@
 module Spree
   class Variant
+    # Instances of this class represent the set of circumstances that influence how expensive a
+    # variant is. For this particular pricing options class, country_iso and currency influence
+    # the price of a variant.
+    #
+    # Pricing options can be instantiated from a line item or from the view context:
+    # @see Spree::LineItem#pricing_options
+    # @see Spree::Core::ControllerHelpers::Pricing#current_pricing_options
+    #
     class PricingOptions
+      # When editing variants in the admin, this is the standard price the admin interacts with:
+      # The price in the admin's globally configured currency, for the admin's globally configured
+      # country. These options get merged with any options the user provides when instantiating
+      # new pricing options.
+      # @see Spree::Config.default_pricing_options
+      # @see #initialize
+      # @return [Hash] The attributes that admin prices usually have
+      #
       def self.default_price_attributes
         {
           currency: Spree::Config.currency,
@@ -8,6 +24,12 @@ module Spree
         }
       end
 
+      # This creates the correct pricing options for a line item, taking into account
+      # its currency and tax address country, if available.
+      # @see Spree::LineItem#set_pricing_attributes
+      # @see Spree::LineItem#pricing_options
+      # @return [Spree::Variant::PricingOptions] pricing options for pricing a line item
+      #
       def self.from_line_item(line_item)
         tax_address = line_item.order.try!(:tax_address)
         new(
@@ -16,30 +38,56 @@ module Spree
         )
       end
 
+      # This creates the correct pricing options for a price, so that we can easily find other prices
+      # with the same pricing-relevant attributes and mark them as non-default.
+      # @see Spree::Price#set_default_price
+      # @return [Spree::Variant::PricingOptions] pricing options for pricing a line item
+      #
       def self.from_price(price)
         new(currency: price.currency, country_iso: price.country_iso)
       end
 
+      # @return [Hash] The hash of exact desired attributes
       attr_reader :desired_attributes
 
       def initialize(desired_attributes = {})
         @desired_attributes = self.class.default_price_attributes.merge(desired_attributes)
       end
 
+      # A slightly modified version of the `desired_attributes` Hash. Instead of
+      # having "nil" or an actual country ISO code under the `:country_iso` key,
+      # this creates an array under the country_iso key that includes both the actual
+      # country iso we want and nil as a shorthand for the fallback price.
+      # This is useful so that we can determine the availability of variants by price:
+      # @see Spree::Variant.with_prices
+      # @see Spree::Core::Search::Base#retrieve_products
+      # @return [Hash] arguments to be passed into ActiveRecord.where()
+      #
       def search_arguments
         search_arguments = desired_attributes
         search_arguments[:country_iso] = [desired_attributes[:country_iso], nil].flatten.uniq
         search_arguments
       end
 
+      # Shorthand for accessing the currency part of the desired attributes
+      # @return [String,nil] three-digit currency code or nil
+      #
       def currency
         desired_attributes[:currency]
       end
 
+      # Shorthand for accessing the country part of the desired attributes
+      # @return [String,nil] two-digit country code or nil
+      #
       def country_iso
         desired_attributes[:country_iso]
       end
 
+      # Since the current pricing options determine the price to be shown to users,
+      # product pages have to be cached and their caches invalidated using the data
+      # from this object. This method makes it easy to use with Rails `cache` helper.
+      # @return [String] cache key to be used in views
+      #
       def cache_key
         desired_attributes.values.select(&:present?).map(&:to_s).join("/")
       end

--- a/core/app/models/spree/variant/pricing_options.rb
+++ b/core/app/models/spree/variant/pricing_options.rb
@@ -9,7 +9,11 @@ module Spree
       end
 
       def self.from_line_item(line_item)
-        new(currency: line_item.order.try(:currency) || line_item.currency || Spree::Config.currency )
+        tax_address = line_item.order.try!(:tax_address)
+        new(
+          currency: line_item.order.try(:currency) || line_item.currency || Spree::Config.currency,
+          country_iso: tax_address && tax_address.country.try!(:iso)
+        )
       end
 
       def self.from_price(price)

--- a/core/app/models/spree/variant/vat_price_generator.rb
+++ b/core/app/models/spree/variant/vat_price_generator.rb
@@ -33,7 +33,6 @@ module Spree
             country_iso: country_iso,
             amount: variant.default_price.net_amount * (1 + vat_for_country_iso(country_iso)),
             currency: variant.default_price.currency,
-            is_default: true
           )
         end
       end

--- a/core/app/models/spree/variant/vat_price_generator.rb
+++ b/core/app/models/spree/variant/vat_price_generator.rb
@@ -25,15 +25,15 @@ module Spree
         return if !variant.tax_category || variant_vat_rates.empty?
 
         country_isos_requiring_price.each do |country_iso|
-          # If there is a price for this country/variant combination already, don't create a new one
-          next if variant.prices.map(&:country_iso).include?(country_iso)
-          # Also don't re-create the default price
+          # Don't re-create the default price
           next if variant.default_price && variant.default_price.country_iso == country_iso
-          variant.prices.build(
+
+          foreign_price = variant.prices.find_or_initialize_by(
             country_iso: country_iso,
-            amount: variant.default_price.net_amount * (1 + vat_for_country_iso(country_iso)),
             currency: variant.default_price.currency,
           )
+
+          foreign_price.amount = variant.default_price.net_amount * (1 + vat_for_country_iso(country_iso))
         end
       end
 

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -775,6 +775,7 @@ en:
           pricing: Pricing
           pricing_hint: These values are populated from the product details page and can be overridden below
       prices:
+        any_country: "Any Country"
         index:
           amount_greater_than: Amount greater than
           amount_less_than: Amount less than

--- a/core/db/migrate/20160509181311_add_country_iso_to_prices.rb
+++ b/core/db/migrate/20160509181311_add_country_iso_to_prices.rb
@@ -1,0 +1,8 @@
+class AddCountryIsoToPrices < ActiveRecord::Migration
+  def change
+    add_column :spree_prices, :country_iso, :string, null: true, limit: 2
+
+    add_index :spree_prices, :country_iso
+    add_index :spree_countries, :iso
+  end
+end

--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -99,3 +99,5 @@ require 'spree/deprecation'
 require 'spree/mailer_previews/order_preview'
 require 'spree/mailer_previews/carton_preview'
 require 'spree/mailer_previews/reimbursement_preview'
+
+require 'spree/core/price_migrator'

--- a/core/lib/spree/core/price_migrator.rb
+++ b/core/lib/spree/core/price_migrator.rb
@@ -1,0 +1,24 @@
+module Spree
+  class PriceMigrator
+    def self.migrate_default_vat_prices
+      Spree::Config.admin_vat_country_iso = Spree::Zone.default_tax.countries.first.iso
+      Spree::Config.remove_instance_variable(:@default_pricing_options)
+      Spree::Variant.find_each do |variant|
+        new(variant).migrate_vat_prices
+      end
+      Spree::Zone.default_tax.update(default_tax: false)
+    end
+
+    attr_reader :variant
+
+    def initialize(variant)
+      @variant = variant
+    end
+
+    def migrate_vat_prices
+      variant.prices.update_all(country_iso: Spree::Config.admin_vat_country_iso)
+      Spree::Variant::PriceGenerator.new(variant).run
+      variant.save
+    end
+  end
+end

--- a/core/lib/spree/core/price_migrator.rb
+++ b/core/lib/spree/core/price_migrator.rb
@@ -4,7 +4,7 @@ module Spree
   class PriceMigrator
     # Migrate all variant's prices.
     def self.migrate_default_vat_prices
-      # We need to tag the exisiting prices as "default", so that the PriceGenerator knows
+      # We need to tag the exisiting prices as "default", so that the VatPriceGenerator knows
       # that they include the default zone's VAT.
       Spree::Config.admin_vat_country_iso = Spree::Zone.default_tax.countries.first.iso
       # If we don't remove this ivar, the above line stays without effect because of caching.
@@ -25,7 +25,7 @@ module Spree
     def migrate_vat_prices
       # With a default tax zone, all prices include VAT by default. Let's tell them which one!
       variant.prices.update_all(country_iso: Spree::Config.admin_vat_country_iso)
-      Spree::Variant::PriceGenerator.new(variant).run
+      Spree::Variant::VatPriceGenerator.new(variant).run
       variant.save
     end
   end

--- a/core/lib/spree/core/price_migrator.rb
+++ b/core/lib/spree/core/price_migrator.rb
@@ -1,11 +1,18 @@
 module Spree
+  # This class performs a data migration. It's usually run from
+  # the `solidus:migrations:create_vat_prices` rake task.
   class PriceMigrator
+    # Migrate all variant's prices.
     def self.migrate_default_vat_prices
+      # We need to tag the exisiting prices as "default", so that the PriceGenerator knows
+      # that they include the default zone's VAT.
       Spree::Config.admin_vat_country_iso = Spree::Zone.default_tax.countries.first.iso
+      # If we don't remove this ivar, the above line stays without effect because of caching.
       Spree::Config.remove_instance_variable(:@default_pricing_options)
       Spree::Variant.find_each do |variant|
         new(variant).migrate_vat_prices
       end
+      # This line stops all weird code paths that generate refunds from happening.
       Spree::Zone.default_tax.update(default_tax: false)
     end
 
@@ -16,6 +23,7 @@ module Spree
     end
 
     def migrate_vat_prices
+      # With a default tax zone, all prices include VAT by default. Let's tell them which one!
       variant.prices.update_all(country_iso: Spree::Config.admin_vat_country_iso)
       Spree::Variant::PriceGenerator.new(variant).run
       variant.save

--- a/core/lib/spree/core/search/base.rb
+++ b/core/lib/spree/core/search/base.rb
@@ -30,7 +30,7 @@ module Spree
           curr_page = page || 1
 
           unless Spree::Config.show_products_without_price
-            @products = @products.joins(:prices).merge(Spree::Price.where(pricing_options.desired_attributes)).uniq
+            @products = @products.joins(:prices).merge(Spree::Price.where(pricing_options.search_arguments)).uniq
           end
           @products = @products.page(curr_page).per(per_page)
         end

--- a/core/lib/spree/core/search/base.rb
+++ b/core/lib/spree/core/search/base.rb
@@ -70,7 +70,7 @@ module Spree
           # separate queries most of the time but opt for a join as soon as any
           # `where` constraints affecting joined tables are added to the search;
           # which is the case as soon as a taxon is added to the base scope.
-          scope = scope.preload(master: :prices)
+          scope = scope.preload(master: :currently_valid_prices)
           scope = scope.preload(master: :images) if include_images
           scope
         end

--- a/core/lib/tasks/migrations/create_vat_prices.rake
+++ b/core/lib/tasks/migrations/create_vat_prices.rake
@@ -1,0 +1,11 @@
+namespace :solidus do
+  namespace :migrations do
+    namespace :create_vat_prices do
+      task up: :environment do
+        print "Creating differentiated prices for VAT countries ... "
+        Spree::PriceMigrator.migrate_default_vat_prices
+        puts "Success."
+      end
+    end
+  end
+end

--- a/core/lib/tasks/upgrade.rake
+++ b/core/lib/tasks/upgrade.rake
@@ -3,7 +3,8 @@ namespace :solidus do
     desc "Upgrade Solidus to version 1.3"
     task one_point_three: [
         'solidus:migrations:assure_store_on_orders:up',
-        'solidus:migrations:migrate_shipping_rate_taxes:up'
+        'solidus:migrations:migrate_shipping_rate_taxes:up',
+        'solidus:migrations:create_vat_prices'
       ] do
       puts "Your Solidus install is ready for Solidus 1.3."
     end

--- a/core/spec/lib/spree/core/price_migrator_spec.rb
+++ b/core/spec/lib/spree/core/price_migrator_spec.rb
@@ -1,0 +1,356 @@
+require 'spec_helper'
+
+describe Spree::PriceMigrator do
+  let(:order) { create :order, ship_address: shipping_address, state: "delivery" }
+  let(:book_product) do
+    create :product,
+           price: 20,
+           name: "Book",
+           tax_category: books_category,
+           shipping_category: books_shipping_category
+  end
+  let(:download_product) do
+    create :product,
+           price: 10,
+           name: "Download",
+           tax_category: digital_category,
+           shipping_category: digital_shipping_category
+  end
+  let(:sweater_product) do
+    create :product,
+           price: 30,
+           name: "Download",
+           tax_category: normal_category,
+           shipping_category: normal_shipping_category
+  end
+
+  let!(:book) { book_product.master }
+  let!(:download) { download_product.master }
+  let!(:sweater) { sweater_product.master }
+
+  let(:books_category) { create :tax_category, name: "Books" }
+  let(:normal_category) { create :tax_category, name: "Normal" }
+  let(:digital_category) { create :tax_category, name: "Digital Goods" }
+
+  let(:books_shipping_category) { create :shipping_category, name: "Book Shipping" }
+  let(:normal_shipping_category) { create :shipping_category, name: "Normal Shipping" }
+  let(:digital_shipping_category) { create :shipping_category, name: "Digital Premium Download" }
+
+  let(:line_item) { order.line_items.first }
+  let(:shipment) { order.shipments.first }
+  let(:shipping_rate) { shipment.shipping_rates.first }
+
+  context 'selling from germany' do
+    let(:germany) { create :country, iso: "DE" }
+    # The weird default_tax boolean is what makes this context one with default included taxes
+    let!(:germany_zone) { create :zone, countries: [germany], default_tax: true }
+    let(:romania) { create(:country, iso: "RO") }
+    let(:romania_zone) { create(:zone, countries: [romania] ) }
+    let(:eu_zone) { create(:zone, countries: [romania, germany]) }
+    let(:world_zone) { create(:zone, :with_country) }
+
+    let!(:german_book_vat) do
+      create(
+        :tax_rate,
+        name: "German reduced VAT",
+        included_in_price: true,
+        amount: 0.07,
+        tax_category: books_category,
+        zone: eu_zone
+      )
+    end
+    let!(:german_normal_vat) do
+      create(
+        :tax_rate,
+        name: "German VAT",
+        included_in_price: true,
+        amount: 0.19,
+        tax_category: normal_category,
+        zone: eu_zone
+      )
+    end
+    let!(:german_digital_vat) do
+      create(
+        :tax_rate,
+        name: "German VAT",
+        included_in_price: true,
+        amount: 0.19,
+        tax_category: digital_category,
+        zone: germany_zone
+      )
+    end
+    let!(:romanian_digital_vat) do
+      create(
+        :tax_rate,
+        name: "Romanian VAT",
+        included_in_price: true,
+        amount: 0.24,
+        tax_category: digital_category,
+        zone: romania_zone
+      )
+    end
+    let!(:book_shipping_method) do
+      create :shipping_method,
+             cost: 8.00,
+             shipping_categories: [books_shipping_category],
+             tax_category: books_category,
+             zones: [eu_zone, world_zone]
+    end
+
+    let!(:sweater_shipping_method) do
+      create :shipping_method,
+             cost: 16.00,
+             shipping_categories: [normal_shipping_category],
+             tax_category: normal_category,
+             zones: [eu_zone, world_zone]
+    end
+
+    let!(:premium_download_shipping_method) do
+      create :shipping_method,
+             cost: 2.00,
+             shipping_categories: [digital_shipping_category],
+             tax_category: digital_category,
+             zones: [eu_zone, world_zone]
+    end
+
+    before do
+      Spree::PriceMigrator.migrate_default_vat_prices
+      order.contents.add(variant)
+    end
+
+    context 'to germany' do
+      let(:shipping_address) { create :address, country_iso_code: "DE" }
+
+      context 'an order with a book' do
+        let(:variant) { book }
+
+        it 'still has the original price' do
+          expect(line_item.price).to eq(20)
+        end
+
+        it 'has one tax adjustment' do
+          expect(line_item.adjustments.tax.count).to eq(1)
+        end
+
+        it 'has 1.13 cents of included tax' do
+          expect(line_item.included_tax_total).to eq(1.31)
+        end
+      end
+
+      context 'an order with a sweater' do
+        let(:variant) { sweater }
+
+        it 'still has the original price' do
+          expect(line_item.price).to eq(30)
+        end
+
+        it 'has one tax adjustment' do
+          expect(line_item.adjustments.tax.count).to eq(1)
+        end
+
+        it 'has 4,78 of included tax' do
+          expect(line_item.included_tax_total).to eq(4.79)
+        end
+      end
+
+      context 'an order with a download' do
+        let(:variant) { download }
+
+        it 'still has the original price' do
+          expect(line_item.price).to eq(10)
+        end
+
+        it 'has one tax adjustment' do
+          expect(line_item.adjustments.tax.count).to eq(1)
+        end
+
+        it 'has 1.60 of included tax' do
+          expect(line_item.included_tax_total).to eq(1.60)
+        end
+      end
+    end
+
+    context 'to romania' do
+      let(:shipping_address) { create :address, country_iso_code: "RO" }
+
+      context 'an order with a book' do
+        let(:variant) { book }
+
+        it 'still has the original price' do
+          expect(line_item.price).to eq(20)
+        end
+
+        it 'is adjusted to the original price' do
+          expect(line_item.total).to eq(20)
+        end
+
+        it 'has one tax adjustment' do
+          expect(line_item.adjustments.tax.count).to eq(1)
+        end
+
+        it 'has 1.13 cents of included tax' do
+          expect(line_item.included_tax_total).to eq(1.31)
+        end
+
+        it 'has a constant amount pre tax' do
+          expect(line_item.discounted_amount - line_item.included_tax_total).to eq(18.69)
+        end
+      end
+
+      context 'an order with a sweater' do
+        let(:variant) { sweater }
+
+        it 'still has the original price' do
+          expect(line_item.price).to eq(30)
+        end
+
+        it 'has one tax adjustment' do
+          expect(line_item.adjustments.tax.count).to eq(1)
+        end
+
+        it 'has 4.79 of included tax' do
+          expect(line_item.included_tax_total).to eq(4.79)
+        end
+
+        it 'has a constant amount pre tax' do
+          expect(line_item.discounted_amount - line_item.included_tax_total).to eq(25.21)
+        end
+      end
+
+      context 'an order with a download' do
+        let(:variant) { download }
+
+        it 'still has an adjusted price for romania' do
+          expect(line_item.price).to eq(10.42)
+        end
+
+        it 'has one tax adjustment' do
+          expect(line_item.adjustments.tax.count).to eq(1)
+        end
+
+        it 'has 2.02 of included tax' do
+          expect(line_item.included_tax_total).to eq(2.02)
+        end
+
+        it 'has a constant amount pre tax' do
+          expect(line_item.discounted_amount - line_item.included_tax_total).to eq(8.40)
+        end
+      end
+    end
+
+    # Technically, this can't be the case yet as the order won't pass the shipment stage,
+    # but the taxation code shouldn't implicitly depend on the shipping code.
+    context 'to an address that does not have a zone associated' do
+      let(:shipping_address) { create :address, country_iso_code: "IT" }
+
+      context 'an order with a book' do
+        let(:variant) { book }
+
+        it 'should sell at the net price' do
+          expect(line_item.price).to eq(18.69)
+        end
+
+        it 'is adjusted to the net price' do
+          expect(line_item.total).to eq(18.69)
+        end
+
+        it 'has no tax adjustments' do
+          expect(line_item.adjustments.tax.count).to eq(0)
+        end
+
+        it 'has no included tax' do
+          expect(line_item.included_tax_total).to eq(0)
+        end
+
+        it 'has no additional tax' do
+          expect(line_item.additional_tax_total).to eq(0)
+        end
+
+        it 'has a constant amount pre tax' do
+          expect(line_item.discounted_amount - line_item.included_tax_total).to eq(18.69)
+        end
+      end
+    end
+
+    # International delivery, no tax applies whatsoever
+    context 'to anywhere else in the world' do
+      let(:shipping_address) { create :address, country: world_zone.countries.first }
+
+      context 'an order with a book' do
+        let(:variant) { book }
+
+        it 'should sell at the net price' do
+          expect(line_item.price).to eq(18.69)
+        end
+
+        it 'is adjusted to the net price' do
+          expect(line_item.total).to eq(18.69)
+        end
+
+        it 'has no tax adjustments' do
+          expect(line_item.adjustments.tax.count).to eq(0)
+        end
+
+        it 'has no included tax' do
+          expect(line_item.included_tax_total).to eq(0)
+        end
+
+        it 'has no additional tax' do
+          expect(line_item.additional_tax_total).to eq(0)
+        end
+
+        it 'has a constant amount pre tax' do
+          expect(line_item.discounted_amount - line_item.included_tax_total).to eq(18.69)
+        end
+      end
+
+      context 'an order with a sweater' do
+        let(:variant) { sweater }
+
+        it 'should sell at the net price' do
+          expect(line_item.price).to eq(25.21)
+        end
+
+        it 'has no tax adjustments' do
+          expect(line_item.adjustments.tax.count).to eq(0)
+        end
+
+        it 'has no included tax' do
+          expect(line_item.included_tax_total).to eq(0)
+        end
+
+        it 'has no additional tax' do
+          expect(line_item.additional_tax_total).to eq(0)
+        end
+
+        it 'has a constant amount pre tax' do
+          expect(line_item.discounted_amount - line_item.included_tax_total).to eq(25.21)
+        end
+      end
+
+      context 'an order with a download' do
+        let(:variant) { download }
+
+        it 'should sell at the net price' do
+          expect(line_item.price).to eq(8.40)
+        end
+
+        it 'has no tax adjustments' do
+          expect(line_item.adjustments.tax.count).to eq(0)
+        end
+
+        it 'has no included tax' do
+          expect(line_item.included_tax_total).to eq(0)
+        end
+
+        it 'has no additional tax' do
+          expect(line_item.additional_tax_total).to eq(0)
+        end
+
+        it 'has a constant amount pre tax' do
+          expect(line_item.discounted_amount - line_item.included_tax_total).to eq(8.40)
+        end
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/app_configuration_spec.rb
+++ b/core/spec/models/spree/app_configuration_spec.rb
@@ -20,16 +20,16 @@ describe Spree::AppConfiguration, type: :model do
     expect(prefs.variant_search_class).to eq Spree::Core::Search::Variant
   end
 
-  it "uses variant pricer class by default" do
-    expect(prefs.variant_pricer_class).to eq Spree::Variant::Pricer
+  it "uses variant price selector class by default" do
+    expect(prefs.variant_price_selector_class).to eq Spree::Variant::PriceSelector
   end
 
-  it "has a getter for the pricing options class provided by the variant pricer class" do
-    expect(prefs.pricing_options_class).to eq Spree::Variant::Pricer.pricing_options_class
+  it "has a getter for the pricing options class provided by the variant price selector class" do
+    expect(prefs.pricing_options_class).to eq Spree::Variant::PriceSelector.pricing_options_class
   end
 
   it "has an instacached getter for the default pricing options" do
-    expect(prefs.default_pricing_options).to be_a Spree::Variant::Pricer.pricing_options_class
+    expect(prefs.default_pricing_options).to be_a Spree::Variant::PriceSelector.pricing_options_class
     expect(prefs.default_pricing_options.object_id).to eq prefs.default_pricing_options.object_id
   end
 

--- a/core/spec/models/spree/country_spec.rb
+++ b/core/spec/models/spree/country_spec.rb
@@ -49,4 +49,20 @@ describe Spree::Country, type: :model do
       end
     end
   end
+
+  describe '#prices' do
+    let(:country) { create(:country) }
+    subject { country.prices }
+
+    it { is_expected.to be_a(ActiveRecord::Associations::CollectionProxy) }
+
+    context "if the country has associated prices" do
+      let!(:price_one) { create(:price) }
+      let!(:price_two) { create(:price) }
+      let!(:price_three) { create(:price) }
+      let(:country) { create(:country, prices: [price_one, price_two]) }
+
+      it { is_expected.to contain_exactly(price_one, price_two) }
+    end
+  end
 end

--- a/core/spec/models/spree/price_spec.rb
+++ b/core/spec/models/spree/price_spec.rb
@@ -114,4 +114,18 @@ describe Spree::Price, type: :model do
       it { is_expected.to include(fallback_price) }
     end
   end
+
+  describe 'net_amount' do
+    let(:country) { create(:country, iso: "DE") }
+    let(:zone) { create(:zone, countries: [country]) }
+    let!(:tax_rate) { create(:tax_rate, included_in_price: true, zone: zone, tax_category: variant.tax_category) }
+
+    let(:variant) { create(:product).master }
+
+    let(:price) { variant.prices.create(amount: 20, country: country) }
+
+    subject { price.net_amount }
+
+    it { is_expected.to eq(BigDecimal.new(20) / 1.1) }
+  end
 end

--- a/core/spec/models/spree/price_spec.rb
+++ b/core/spec/models/spree/price_spec.rb
@@ -102,4 +102,16 @@ describe Spree::Price, type: :model do
       end
     end
   end
+
+  describe 'scopes' do
+    describe '.for_any_country' do
+      let(:country) { create(:country) }
+      let!(:fallback_price) { create(:price, country_iso: nil) }
+      let!(:country_price) { create(:price, country: country) }
+
+      subject { described_class.for_any_country }
+
+      it { is_expected.to include(fallback_price) }
+    end
+  end
 end

--- a/core/spec/models/spree/price_spec.rb
+++ b/core/spec/models/spree/price_spec.rb
@@ -45,6 +45,38 @@ describe Spree::Price, type: :model do
       let(:amount) { Spree::Price::MAXIMUM_AMOUNT }
       it { is_expected.to be_valid }
     end
+
+    context '#country_iso' do
+      subject(:price) { build(:price, country_iso: country_iso) }
+
+      context 'when country iso is nil' do
+        let(:country_iso) { nil }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'when country iso is a country code' do
+        let!(:country) { create(:country, iso: "DE") }
+        let(:country_iso) { "DE" }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'when country iso is not a country code' do
+        let(:country_iso) { "ZZ" }
+
+        it { is_expected.not_to be_valid }
+      end
+    end
+
+    describe '#country' do
+      let!(:country) { create(:country, iso: "DE") }
+      let(:price) { create(:price, country_iso: "DE", is_default: false) }
+
+      it 'returns the country object' do
+        expect(price.country).to eq(country)
+      end
+    end
   end
 
   describe "#currency" do

--- a/core/spec/models/spree/tax/tax_location_spec.rb
+++ b/core/spec/models/spree/tax/tax_location_spec.rb
@@ -34,13 +34,22 @@ RSpec.describe Spree::Tax::TaxLocation do
         expect(subject.country_id).to eq(country.id)
       end
     end
+  end
 
-    context 'with a state object' do
-      let(:args) { { state: state } }
+  describe "#country" do
+    let(:country) { create(:country) }
+    subject { described_class.new(args).country }
 
-      it "will yield a location with that state's id" do
-        expect(subject.state_id).to eq(state.id)
-      end
+    context 'with a country object' do
+      let(:args) { { country: country } }
+
+      it { is_expected.to eq(country) }
+    end
+
+    context 'with no country object' do
+      let(:args) { { country: nil } }
+
+      it { is_expected.to be nil }
     end
   end
 

--- a/core/spec/models/spree/tax/taxation_integration_spec.rb
+++ b/core/spec/models/spree/tax/taxation_integration_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe "Taxation system integration tests" do
   context 'selling from germany' do
     let(:germany) { create :country, iso: "DE" }
     # The weird default_tax boolean is what makes this context one with default included taxes
-    let!(:germany_zone) { create :zone, countries: [germany], default_tax: true }
+    let!(:germany_zone) { create :zone, countries: [germany] }
     let(:romania) { create(:country, iso: "RO") }
     let(:romania_zone) { create(:zone, countries: [romania] ) }
     let(:eu_zone) { create(:zone, countries: [romania, germany]) }
@@ -114,6 +114,7 @@ RSpec.describe "Taxation system integration tests" do
     end
 
     before do
+      Spree::Config.admin_vat_country_iso = "DE"
       order.contents.add(variant)
     end
 
@@ -310,7 +311,6 @@ RSpec.describe "Taxation system integration tests" do
         let(:variant) { download }
 
         it 'still has an adjusted price for romania' do
-          pending "waiting for the MOSS refactoring"
           expect(line_item.price).to eq(10.42)
         end
 
@@ -319,12 +319,10 @@ RSpec.describe "Taxation system integration tests" do
         end
 
         it 'has 2.02 of included tax' do
-          pending 'waiting for the MOSS refactoring'
           expect(line_item.included_tax_total).to eq(2.02)
         end
 
         it 'has a constant amount pre tax' do
-          pending 'but it changes to 8.06, because Spree thinks both VATs apply'
           expect(line_item.discounted_amount - line_item.included_tax_total).to eq(8.40)
         end
       end
@@ -357,22 +355,18 @@ RSpec.describe "Taxation system integration tests" do
         let(:variant) { book }
 
         it 'should sell at the net price' do
-          pending "Prices have to be adjusted"
           expect(line_item.price).to eq(18.69)
         end
 
         it 'is adjusted to the net price' do
-          pending 'This will turn green when the default zone is gone'
           expect(line_item.total).to eq(18.69)
         end
 
         it 'has no tax adjustments' do
-          pending "Right now it gets a refund"
           expect(line_item.adjustments.tax.count).to eq(0)
         end
 
         it 'has no included tax' do
-          pending 'This will turn green when the default zone is gone'
           expect(line_item.included_tax_total).to eq(0)
         end
 
@@ -394,7 +388,6 @@ RSpec.describe "Taxation system integration tests" do
         let(:variant) { book }
 
         it 'should sell at the net price' do
-          pending "Prices have to be adjusted"
           expect(line_item.price).to eq(18.69)
         end
 
@@ -403,7 +396,6 @@ RSpec.describe "Taxation system integration tests" do
         end
 
         it 'has no tax adjustments' do
-          pending "Right now it gets a refund"
           expect(line_item.adjustments.tax.count).to eq(0)
         end
 
@@ -412,12 +404,10 @@ RSpec.describe "Taxation system integration tests" do
         end
 
         it 'has no additional tax' do
-          pending 'but there is a refund, still'
           expect(line_item.additional_tax_total).to eq(0)
         end
 
         it 'has a constant amount pre tax' do
-          pending 'But it has a discount that abuses the additional tax total'
           expect(line_item.discounted_amount - line_item.included_tax_total).to eq(18.69)
         end
 
@@ -435,7 +425,6 @@ RSpec.describe "Taxation system integration tests" do
           end
 
           it 'has a shipping rate that correctly reflects the shipment' do
-            pending "But solidus tries refunding taxes"
             expect(shipping_rate.display_price).to eq("$8.00")
           end
         end
@@ -445,12 +434,10 @@ RSpec.describe "Taxation system integration tests" do
         let(:variant) { sweater }
 
         it 'should sell at the net price' do
-          pending 'but prices are not adjusted according to the zone yet'
           expect(line_item.price).to eq(25.21)
         end
 
         it 'has no tax adjustments' do
-          pending 'but it has a refund'
           expect(line_item.adjustments.tax.count).to eq(0)
         end
 
@@ -459,12 +446,10 @@ RSpec.describe "Taxation system integration tests" do
         end
 
         it 'has no additional tax' do
-          pending 'but it has a refund for included taxes wtf'
           expect(line_item.additional_tax_total).to eq(0)
         end
 
         it 'has a constant amount pre tax' do
-          pending 'But it has a discount that abuses the additional tax total'
           expect(line_item.discounted_amount - line_item.included_tax_total).to eq(25.21)
         end
 
@@ -482,7 +467,6 @@ RSpec.describe "Taxation system integration tests" do
           end
 
           it 'has a shipping rate that correctly reflects the shipment' do
-            pending "but solidus tries refunding taxes"
             expect(shipping_rate.display_price).to eq("$16.00")
           end
         end
@@ -492,12 +476,10 @@ RSpec.describe "Taxation system integration tests" do
         let(:variant) { download }
 
         it 'should sell at the net price' do
-          pending 'but prices are not adjusted yet'
           expect(line_item.price).to eq(8.40)
         end
 
         it 'has no tax adjustments' do
-          pending 'but a refund is created'
           expect(line_item.adjustments.tax.count).to eq(0)
         end
 
@@ -506,12 +488,10 @@ RSpec.describe "Taxation system integration tests" do
         end
 
         it 'has no additional tax' do
-          pending 'but an tax refund that disguises as additional tax is created'
           expect(line_item.additional_tax_total).to eq(0)
         end
 
         it 'has a constant amount pre tax' do
-          pending 'But it has a discount that abuses the additional tax total'
           expect(line_item.discounted_amount - line_item.included_tax_total).to eq(8.40)
         end
       end
@@ -530,7 +510,6 @@ RSpec.describe "Taxation system integration tests" do
         end
 
         it 'has a shipping rate that correctly reflects the shipment' do
-          pending 'but solidus wants to refund part of the shipment amount'
           expect(shipping_rate.display_price).to eq("$2.00")
         end
       end

--- a/core/spec/models/spree/variant/price_generator_spec.rb
+++ b/core/spec/models/spree/variant/price_generator_spec.rb
@@ -26,6 +26,12 @@ describe Spree::Variant::PriceGenerator do
       expect(variant.prices.detect { |p| p.country_iso == "FR"}.try!(:amount)).to eq(10.08)
       expect(variant.prices.detect { |p| p.country_iso.nil? }.try!(:amount)).to eq(8.40)
     end
+
+    it "will not build prices that are already present" do
+      variant.prices.build(amount: 11, country_iso: "FR")
+      variant.prices.build(amount: 11, country_iso: nil)
+      expect { subject }.not_to change { variant.prices.length }
+    end
   end
 
   context "with no default admin country" do

--- a/core/spec/models/spree/variant/price_generator_spec.rb
+++ b/core/spec/models/spree/variant/price_generator_spec.rb
@@ -1,0 +1,44 @@
+require "spec_helper"
+
+describe Spree::Variant::PriceGenerator do
+  let(:tax_category) { create(:tax_category) }
+  let(:product) { variant.product }
+  let(:variant) { create(:variant, price: 10) }
+  let(:germany) { create(:country, iso: "DE") }
+  let(:germany_zone) { create(:zone, countries: [germany]) }
+  let!(:german_vat) { create(:tax_rate, included_in_price: true, amount: 0.19, zone: germany_zone, tax_category: tax_category) }
+
+  subject { described_class.new(variant).run }
+
+  context "with Germany as default admin country" do
+    let(:france) { create(:country, iso: "FR") }
+    let(:france_zone) { create(:zone, countries: [france]) }
+    let!(:french_vat) { create(:tax_rate, included_in_price: true, amount: 0.20, zone: france_zone, tax_category: tax_category) }
+
+    before do
+      Spree::Config.admin_vat_country_iso = "DE"
+    end
+
+    it "builds a correct price including VAT for all VAT countries" do
+      subject
+      expect(variant.default_price.for_any_country?).to be false
+      expect(variant.prices.detect { |p| p.country_iso == "DE" }.try!(:amount)).to eq(10.00)
+      expect(variant.prices.detect { |p| p.country_iso == "FR"}.try!(:amount)).to eq(10.08)
+      expect(variant.prices.detect { |p| p.country_iso.nil? }.try!(:amount)).to eq(8.40)
+    end
+  end
+
+  context "with no default admin country" do
+    let(:france) { create(:country, iso: "FR") }
+    let(:france_zone) { create(:zone, countries: [france]) }
+    let!(:french_vat) { create(:tax_rate, included_in_price: true, amount: 0.20, zone: france_zone, tax_category: tax_category) }
+
+    it "builds a correct price including VAT for all VAT countries" do
+      subject
+      expect(variant.default_price.for_any_country?).to be true
+      expect(variant.prices.detect { |p| p.country_iso == "DE" }.try!(:amount)).to eq(11.90)
+      expect(variant.prices.detect { |p| p.country_iso == "FR" }.try!(:amount)).to eq(12.00)
+      expect(variant.prices.detect { |p| p.country_iso.nil? }.try!(:amount)).to eq(10.00)
+    end
+  end
+end

--- a/core/spec/models/spree/variant/price_selector_spec.rb
+++ b/core/spec/models/spree/variant/price_selector_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Spree::Variant::Pricer do
+describe Spree::Variant::PriceSelector do
   let(:variant) { build_stubbed(:variant) }
 
   subject { described_class.new(variant) }

--- a/core/spec/models/spree/variant/pricer_spec.rb
+++ b/core/spec/models/spree/variant/pricer_spec.rb
@@ -44,7 +44,7 @@ describe Spree::Variant::Pricer do
         context "with no price for that country present" do
           context "and no fallback price for the variant present" do
             before do
-              variant.prices.update_all(country_iso: "US")
+              variant.prices.delete_all
             end
 
             it "returns nil" do

--- a/core/spec/models/spree/variant/pricer_spec.rb
+++ b/core/spec/models/spree/variant/pricer_spec.rb
@@ -23,6 +23,46 @@ describe Spree::Variant::Pricer do
       it "returns the correct (default) price as a Spree::Money object" do
         expect(subject.price_for(pricing_options)).to eq(Spree::Money.new(12.34, currency: "USD"))
       end
+
+      context "with the another country iso" do
+        let(:country) { create(:country, iso: "DE") }
+
+        let(:pricing_options) do
+          described_class.pricing_options_class.new(currency: "USD", country_iso: "DE")
+        end
+
+        context "with a price for that country present" do
+          before do
+            variant.prices.create(amount: 44.44, country: country, currency: Spree::Config.currency)
+          end
+
+          it "returns the correct price" do
+            expect(subject.price_for(pricing_options)).to eq(Spree::Money.new(44.44, currency: "USD"))
+          end
+        end
+
+        context "with no price for that country present" do
+          context "and no fallback price for the variant present" do
+            before do
+              variant.prices.update_all(country_iso: "US")
+            end
+
+            it "returns nil" do
+              expect(subject.price_for(pricing_options)).to be_nil
+            end
+          end
+
+          context "and a fallback price for the variant present" do
+            before do
+              variant.prices.create(amount: 55.44, country: nil, currency: Spree::Config.currency)
+            end
+
+            it "returns the fallback price" do
+              expect(subject.price_for(pricing_options)).to eq(Spree::Money.new(55.44, currency: "USD"))
+            end
+          end
+        end
+      end
     end
 
     context "with a different currency" do

--- a/core/spec/models/spree/variant/pricing_options_spec.rb
+++ b/core/spec/models/spree/variant/pricing_options_spec.rb
@@ -67,6 +67,17 @@ describe Spree::Variant::PricingOptions do
     end
   end
 
+  context ".from_price" do
+    let(:country) { create(:country) }
+    let(:price) { create(:price, country: country) }
+
+    subject { described_class.from_price(price) }
+    it "gets the currency from the previous price" do
+      expect(subject.currency).to eq(price.currency)
+      expect(subject.country_iso).to eq(country.iso)
+    end
+  end
+
   describe '#desired_attributes' do
     context "when called with no arguments" do
       it "returns the default pricing options" do

--- a/core/spec/models/spree/variant/pricing_options_spec.rb
+++ b/core/spec/models/spree/variant/pricing_options_spec.rb
@@ -4,15 +4,20 @@ describe Spree::Variant::PricingOptions do
   subject { described_class.new }
 
   context '.default_price_attributes' do
+    subject { described_class.default_price_attributes }
+
+    it { is_expected.to have_key(:currency) }
+    it { is_expected.to have_key(:country_iso) }
+
     it 'can be passed into a WHERE clause on Spree::Prices' do
-      expect(Spree::Price.where(described_class.default_price_attributes).to_a).to eq([])
+      expect(Spree::Price.where(subject).to_a).to eq([])
     end
 
     context "with a matching price present" do
       let!(:price) { create(:price) }
 
       it 'returns a matching price' do
-        expect(Spree::Price.where(described_class.default_price_attributes).to_a).to include(price)
+        expect(Spree::Price.where(subject).to_a).to include(price)
       end
     end
   end
@@ -72,6 +77,14 @@ describe Spree::Variant::PricingOptions do
         expect(subject.desired_attributes[:currency]).to eq("EUR")
       end
     end
+
+    context "when called with a different country_iso" do
+      subject { described_class.new(country_iso: "DE") }
+
+      it "returns a Hash with the correct country" do
+        expect(subject.desired_attributes[:country_iso]).to eq("DE")
+      end
+    end
   end
 
   describe "#currency" do
@@ -91,6 +104,23 @@ describe Spree::Variant::PricingOptions do
     end
   end
 
+  describe "#country_iso" do
+    context "when initialized with no country_iso" do
+      it "returns the default country_iso" do
+        expect(Spree::Config).to receive(:admin_vat_country_iso).and_return("US")
+        expect(subject.country_iso).to eq("US")
+      end
+    end
+
+    context "when initialized with a different country_iso" do
+      subject { described_class.new(country_iso: "DE") }
+
+      it "returns that country_iso" do
+        expect(subject.country_iso).to eq("DE")
+      end
+    end
+  end
+
   describe "#cache_key" do
     it 'creates a cache key out of the values of the attributes hash' do
       expect(subject.cache_key).to eq("USD")
@@ -98,8 +128,46 @@ describe Spree::Variant::PricingOptions do
 
     context "with another currency" do
       subject { described_class.new(currency: "EUR") }
+
       it 'creates the correct cache key' do
         expect(subject.cache_key).to eq("EUR")
+      end
+
+      context "and another country" do
+        subject { described_class.new(currency: "EUR", country_iso: "DE") }
+
+        it 'creates the correct cache key' do
+          expect(subject.cache_key).to eq("EUR/DE")
+        end
+      end
+    end
+  end
+
+  describe "#search_arguments" do
+    let!(:price) { create(:price, currency: "EUR") }
+    let(:options) { {} }
+
+    subject { described_class.new(options).search_arguments }
+
+    context "with a currency given" do
+      let(:options) { { currency: "EUR" } }
+
+      it 'can be passed into a `where` clause' do
+        expect(Spree::Price.where(subject)).to eq([price])
+      end
+    end
+
+    context "with no country given" do
+      it "is an array with only nil inside" do
+        expect(subject[:country_iso]).to eq([nil])
+      end
+    end
+
+    context "with a country given" do
+      let(:options) { { country_iso: "DE" } }
+
+      it "is an array with the country and nil" do
+        expect(subject[:country_iso]).to eq(["DE", nil])
       end
     end
   end

--- a/core/spec/models/spree/variant/pricing_options_spec.rb
+++ b/core/spec/models/spree/variant/pricing_options_spec.rb
@@ -30,9 +30,13 @@ describe Spree::Variant::PricingOptions do
       expect(subject.desired_attributes[:currency]).to eq("USD")
     end
 
+    it "takes the orders tax address country" do
+      expect(subject.desired_attributes[:country_iso]).to eq("US")
+    end
+
     context "if line item has no order" do
       before do
-        expect(line_item).to receive(:order).and_return(nil)
+        expect(line_item).to receive(:order).at_least(:once).and_return(nil)
       end
 
       it "returns the line item's currency" do
@@ -53,7 +57,7 @@ describe Spree::Variant::PricingOptions do
     context "if neither order nor line item have a currency" do
       before do
         expect(line_item).to receive(:currency).and_return(nil)
-        expect(line_item).to receive(:order).and_return(nil)
+        expect(line_item).to receive(:order).at_least(:once).and_return(nil)
         expect(Spree::Config).to receive(:currency).at_least(:once).and_return("RUB")
       end
 

--- a/core/spec/models/spree/variant/vat_price_generator_spec.rb
+++ b/core/spec/models/spree/variant/vat_price_generator_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe Spree::Variant::PriceGenerator do
+describe Spree::Variant::VatPriceGenerator do
   let(:tax_category) { create(:tax_category) }
   let(:product) { variant.product }
   let(:variant) { create(:variant, price: 10, tax_category: tax_category) }
@@ -63,8 +63,7 @@ describe Spree::Variant::PriceGenerator do
     end
 
     it "creates no addditional prices" do
-      subject
-      expect(variant.prices.length).to eq(0)
+      expect { subject }.not_to change { variant.prices.length }
     end
   end
 end

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -209,23 +209,23 @@ describe Spree::Variant, type: :model do
     end
   end
 
-  context "#pricer" do
-    subject { variant.pricer }
+  context "#price_selector" do
+    subject { variant.price_selector }
 
-    it "returns an instance of a pricer" do
-      expect(variant.pricer).to be_a(Spree::Config.variant_pricer_class)
+    it "returns an instance of a price selector" do
+      expect(variant.price_selector).to be_a(Spree::Config.variant_price_selector_class)
     end
 
     it "is instacached" do
-      expect(variant.pricer.object_id).to eq(variant.pricer.object_id)
+      expect(variant.price_selector.object_id).to eq(variant.price_selector.object_id)
     end
   end
 
   context "#price_for(price_options)" do
-    let(:price_options) { Spree::Config.variant_pricer_class.pricing_options_class.new }
+    let(:price_options) { Spree::Config.variant_price_selector_class.pricing_options_class.new }
 
-    it "calls the pricer with the given options object" do
-      expect(variant.pricer).to receive(:price_for).with(price_options)
+    it "calls the price selector with the given options object" do
+      expect(variant.price_selector).to receive(:price_for).with(price_options)
       variant.price_for(price_options)
     end
   end

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -78,6 +78,28 @@ describe Spree::Variant, type: :model do
         expect(new_variant.prices.find_by(country_iso: "DK").amount).to eq(18.75)
         expect(new_variant.prices.find_by(country_iso: nil).amount).to eq(15.00)
       end
+
+      context "when the products price changes" do
+        context "and rebuild_vat_prices is set to true" do
+          subject { variant.update(price: 99, rebuild_vat_prices: true, tax_category: tax_category) }
+
+          it "creates new appropriate prices for this variant" do
+            expect { subject }.to change { Spree::Price.count }.by(3)
+            expect(variant.prices.find_by(country_iso: "FR").amount).to eq(113.85)
+            expect(variant.prices.find_by(country_iso: "DE").amount).to eq(123.75)
+            expect(variant.prices.find_by(country_iso: "DK").amount).to eq(123.75)
+            expect(variant.prices.find_by(country_iso: nil).amount).to eq(99.00)
+          end
+        end
+
+        context "and rebuild_vat_prices is not set" do
+          subject { variant.update(price: 99, tax_category: tax_category) }
+
+          it "does not create new prices" do
+            expect { subject }.not_to change { Spree::Price.count }
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
This is an addition to the standard pricer class to query for a specified country price first, and then query for a fallback price. 