### PR TITLE
Introduce Spree::Promotion.scheduled_after scope

### DIFF
--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -41,6 +41,9 @@ module Spree
         where(table[:expires_at].eq(nil).or(table[:expires_at].gt(time)))
     end
     scope :applied, -> { joins(:order_promotions).distinct }
+    scope :scheduled_after, -> (time) do
+      where(arel_table[:starts_at].gt(time))
+    end
 
     self.whitelisted_ransackable_associations = ['codes']
     self.whitelisted_ransackable_attributes = ['path', 'promotion_category_id']

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -36,6 +36,18 @@ describe Spree::Promotion, type: :model do
     end
   end
 
+  describe ".scheduled_after" do
+    let(:old_promotion) { create(:promotion, starts_at: 1.week.ago) }
+    let(:new_promotion) { create(:promotion, starts_at: 1.week.from_now) }
+
+    subject { Spree::Promotion.scheduled_after(Time.current) }
+
+    it "scopes promotions that are scheduled to start after the given time" do
+      expect(subject).to include(new_promotion)
+      expect(subject).not_to include(old_promotion)
+    end
+  end
+
   describe ".advertised" do
     let(:promotion) { create(:promotion) }
     let(:advertised_promotion) { create(:promotion, advertise: true) }


### PR DESCRIPTION
This commit introduces a new scope for the Spree::Promotion model,
`scheduled_after(time)`. This scope is useful for finding all promotions
scheduled to start after the provided time.