### PR TITLE
Fix association to point to right objects

### DIFF
--- a/core/app/models/spree/payment_method.rb
+++ b/core/app/models/spree/payment_method.rb
@@ -9,7 +9,7 @@ module Spree
     has_many :payments, class_name: "Spree::Payment", inverse_of: :payment_method
     has_many :credit_cards, class_name: "Spree::CreditCard"
     has_many :store_payment_methods, inverse_of: :payment_method
-    has_many :payment_methods, through: :store_payment_methods
+    has_many :stores, through: :store_payment_methods
 
     scope :ordered_by_position, -> { order(:position) }
 


### PR DESCRIPTION
Having payment methods point to themselves doesn't really help any. Let's actually point the association at the object it should point to.