### PR TITLE
Add failing order spec

### DIFF
--- a/api/spec/controllers/spree/api/orders_controller_spec.rb
+++ b/api/spec/controllers/spree/api/orders_controller_spec.rb
@@ -370,6 +370,18 @@ module Spree
       expect(response.status).to eq(201)
     end
 
+    it "can specify additional parameters via options for a line item" do
+      expect_any_instance_of(LineItem).to receive(:some_option=).with(4)
+      api_post :create, order: {
+        line_items: {
+          "0" => {
+            variant_id: variant.to_param, quantity: 5, options: { some_option: 4 }
+          }
+        }
+      }
+      expect(response.status).to eq(201)
+    end
+
     it "cannot arbitrarily set the line items price" do
       api_post :create, order: {
         line_items: {


### PR DESCRIPTION
Unable to create a new order with a line item with options. This is the issue/motivation behind #1112.

To reproduce:

Start by permitting a new option on to permitted on a line item:
```
PermittedAttributes.line_item_attributes << :some_option
```

Now each of the requests should create the line item with some_option set to 4:

To OrdersController#create
```
{ order: { line_items: [variant_id: 1, quantity:1, options: { some_option: 4 } ] } }
```

To LineItemsController#create
```
{ line_item: variant_id: 1, quantity:1, options: { some_option: 4 } }
```

The OrdersController fails to permit the option. 