### PR TITLE
Association shipping methods to stores

### DIFF
--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -41,12 +41,12 @@ module Spree
 
     # @param stock_location [Spree::StockLocation] stock location
     # @return [ActiveRecord::Relation] shipping methods which are available
-    #   with the stock location or are marked available_to_all
+    #   with the stock location or are marked available_to_all_stock_locations
     def self.available_in_stock_location(stock_location)
       smsl_table = ShippingMethodStockLocation.arel_table
 
       # We are searching for either a matching entry in the stock location join
-      # table or available_to_all being true.
+      # table or available_to_all_stock_locations being true.
       # We need to use an outer join otherwise a shipping method with no
       # associated stock locations will be filtered out of the results. In
       # rails 5 this will be easy using .left_join and .or, but for now we must
@@ -56,7 +56,7 @@ module Spree
         on(arel_table[:id].eq(smsl_table[:shipping_method_id])).
         join_sources
       arel_condition =
-        arel_table[:available_to_all].eq(true).or(smsl_table[:stock_location_id].eq(stock_location.id))
+        arel_table[:available_to_all_stock_locations].eq(true).or(smsl_table[:stock_location_id].eq(stock_location.id))
 
       joins(arel_join).where(arel_condition).distinct
     end

--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -4,6 +4,9 @@ module Spree
     include Spree::CalculatedAdjustments
     DISPLAY = [:both, :front_end, :back_end]
 
+    has_many :store_shipping_methods, inverse_of: :shipping_method
+    has_many :stores, through: :store_shipping_methods
+
     has_many :shipping_method_categories, dependent: :destroy
     has_many :shipping_categories, through: :shipping_method_categories
     has_many :shipping_rates, inverse_of: :shipping_method

--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -85,6 +85,23 @@ module Spree
       display_on != "back_end"
     end
 
+    def available_to_all=(val)
+      ActiveSupport::Deprecation.warn <<-EOS.squish, caller
+        ShippingMethod#available_to_all= has been deprecated. The column has
+        been renamed to available_to_all_stock_locations.
+      EOS
+      self.available_to_all_stock_locations = val
+    end
+
+    def available_to_all
+      ActiveSupport::Deprecation.warn <<-EOS.squish, caller
+        ShippingMethod#available_to_all has been deprecated. The column has
+        been renamed to available_to_all_stock_locations.
+      EOS
+      available_to_all_stock_locations
+    end
+    alias_method :available_to_all?, :available_to_all
+
     private
 
     def at_least_one_shipping_category

--- a/core/app/models/spree/stock/package.rb
+++ b/core/app/models/spree/stock/package.rb
@@ -107,9 +107,9 @@ module Spree
       # @return [ActiveRecord::Relation] the [Spree::ShippingMethod]s available
       #   for this pacakge based on the stock location and shipping categories.
       def shipping_methods
-        order.store.shipping_methods.
-          with_all_shipping_category_ids(shipping_category_ids).
-          available_in_stock_location(stock_location)
+        ShippingMethod.available_for_store(order.try(:store)).
+        with_all_shipping_category_ids(shipping_category_ids).
+        available_in_stock_location(stock_location)
       end
 
       # @return [Spree::Shipment] a new shipment containing this package's

--- a/core/app/models/spree/stock/package.rb
+++ b/core/app/models/spree/stock/package.rb
@@ -107,7 +107,7 @@ module Spree
       # @return [ActiveRecord::Relation] the [Spree::ShippingMethod]s available
       #   for this pacakge based on the stock location and shipping categories.
       def shipping_methods
-        Spree::ShippingMethod.
+        order.store.shipping_methods.
           with_all_shipping_category_ids(shipping_category_ids).
           available_in_stock_location(stock_location)
       end

--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -1,5 +1,8 @@
 module Spree
   class Store < Spree::Base
+    has_many :store_shipping_methods, inverse_of: :store
+    has_many :shipping_methods, through: :store_shipping_methods
+
     has_many :store_payment_methods, inverse_of: :store
     has_many :payment_methods, through: :store_payment_methods
     has_many :orders, class_name: "Spree::Order"

--- a/core/app/models/spree/store_shipping_method.rb
+++ b/core/app/models/spree/store_shipping_method.rb
@@ -1,0 +1,6 @@
+module Spree
+  class StoreShippingMethod < ActiveRecord::Base
+    belongs_to :store, inverse_of: :store_shipping_methods
+    belongs_to :shipping_method, inverse_of: :store_shipping_methods
+  end
+end

--- a/core/db/migrate/20160509204438_create_store_shipping_methods.rb
+++ b/core/db/migrate/20160509204438_create_store_shipping_methods.rb
@@ -1,0 +1,17 @@
+class CreateStoreShippingMethods < ActiveRecord::Migration
+  include Spree::MigrationHelpers
+
+  def change
+    unless table_exists?(:spree_store_shipping_methods)
+      create_table :spree_store_shipping_methods do |t|
+        t.integer :store_id
+        t.integer :shipping_method_id
+
+        t.timestamps null: false
+      end
+    end
+
+    safe_add_index :spree_store_shipping_methods, :store_id
+    safe_add_index :spree_store_shipping_methods, :shipping_method_id
+  end
+end

--- a/core/db/migrate/20160510154122_rename_shipping_method_available_to_all.rb
+++ b/core/db/migrate/20160510154122_rename_shipping_method_available_to_all.rb
@@ -1,0 +1,5 @@
+class RenameShippingMethodAvailableToAll < ActiveRecord::Migration
+  def change
+    rename_column :spree_shipping_methods, :available_to_all, :available_to_all_stock_locations
+  end
+end

--- a/core/db/migrate/20160510154620_add_available_to_all_stores_to_shipping_methods.rb
+++ b/core/db/migrate/20160510154620_add_available_to_all_stores_to_shipping_methods.rb
@@ -1,0 +1,5 @@
+class AddAvailableToAllStoresToShippingMethods < ActiveRecord::Migration
+  def change
+    add_column :spree_shipping_methods, :available_to_all_stores, :boolean, default: true
+  end
+end

--- a/core/spec/models/spree/shipping_method_spec.rb
+++ b/core/spec/models/spree/shipping_method_spec.rb
@@ -130,8 +130,8 @@ describe Spree::ShippingMethod, type: :model do
 
     subject { described_class.available_in_stock_location(stock_location) }
 
-    context "when available_to_all" do
-      let!(:shipping_method) { create(:shipping_method, available_to_all: true) }
+    context "when available_to_all_stock_locations" do
+      let!(:shipping_method) { create(:shipping_method, available_to_all_stock_locations: true) }
 
       it "returns the shipping_method" do
         is_expected.to eq [shipping_method]
@@ -139,15 +139,15 @@ describe Spree::ShippingMethod, type: :model do
     end
 
     context "when in stock location" do
-      let!(:shipping_method) { create(:shipping_method, available_to_all: false, stock_locations: [stock_location]) }
+      let!(:shipping_method) { create(:shipping_method, available_to_all_stock_locations: false, stock_locations: [stock_location]) }
 
       it "returns the shipping_method" do
         is_expected.to eq [shipping_method]
       end
     end
 
-    context "when available_to_all and in stock location" do
-      let!(:shipping_method) { create(:shipping_method, available_to_all: true, stock_locations: [stock_location]) }
+    context "when available_to_all_stock_locations and in stock location" do
+      let!(:shipping_method) { create(:shipping_method, available_to_all_stock_locations: true, stock_locations: [stock_location]) }
 
       it "returns the shipping_method" do
         is_expected.to eq [shipping_method]
@@ -155,7 +155,7 @@ describe Spree::ShippingMethod, type: :model do
     end
 
     context "when in no stock locations" do
-      let!(:shipping_method) { create(:shipping_method, available_to_all: false) }
+      let!(:shipping_method) { create(:shipping_method, available_to_all_stock_locations: false) }
 
       it "returns no results" do
         is_expected.to be_empty
@@ -163,15 +163,15 @@ describe Spree::ShippingMethod, type: :model do
     end
 
     context "when in another stock location" do
-      let!(:shipping_method) { create(:shipping_method, available_to_all: false, stock_locations: [other_stock_location]) }
+      let!(:shipping_method) { create(:shipping_method, available_to_all_stock_locations: false, stock_locations: [other_stock_location]) }
 
       it "returns no results" do
         is_expected.to be_empty
       end
     end
 
-    context "when available_to_all and in another stock location" do
-      let!(:shipping_method) { create(:shipping_method, available_to_all: true, stock_locations: [other_stock_location]) }
+    context "when available_to_all_stock_locations and in another stock location" do
+      let!(:shipping_method) { create(:shipping_method, available_to_all_stock_locations: true, stock_locations: [other_stock_location]) }
 
       it "returns the shipping_method" do
         is_expected.to eq [shipping_method]
@@ -179,9 +179,9 @@ describe Spree::ShippingMethod, type: :model do
     end
 
     context "when multiple shipping methods match" do
-      let!(:shipping_method1) { create(:shipping_method, available_to_all: true, stock_locations: [other_stock_location]) }
-      let!(:shipping_method2) { create(:shipping_method, available_to_all: false, stock_locations: [stock_location]) }
-      let!(:shipping_method3) { create(:shipping_method, available_to_all: false, stock_locations: [other_stock_location]) }
+      let!(:shipping_method1) { create(:shipping_method, available_to_all_stock_locations: true, stock_locations: [other_stock_location]) }
+      let!(:shipping_method2) { create(:shipping_method, available_to_all_stock_locations: false, stock_locations: [stock_location]) }
+      let!(:shipping_method3) { create(:shipping_method, available_to_all_stock_locations: false, stock_locations: [other_stock_location]) }
 
       it "returns both matching shipping_methods" do
         is_expected.to match_array([shipping_method1, shipping_method2])

--- a/core/spec/models/spree/stock/package_spec.rb
+++ b/core/spec/models/spree/stock/package_spec.rb
@@ -48,38 +48,42 @@ module Spree
       end
 
       it 'builds the correct list of shipping methods based on stock location and categories' do
+        store = create(:store)
+        order = mock_model(Spree::Order, store: store)
         category1 = create(:shipping_category)
         category2 = create(:shipping_category)
-        method1   = create(:shipping_method, available_to_all: true)
-        method2   = create(:shipping_method, stock_locations: [stock_location])
+        method1   = create(:shipping_method, available_to_all: true, stores: [store])
+        method2   = create(:shipping_method, stock_locations: [stock_location], stores: [store])
         method1.shipping_categories = [category1, category2]
         method2.shipping_categories = [category1, category2]
         variant1 = mock_model(Variant, shipping_category_id: category1.id)
         variant2 = mock_model(Variant, shipping_category_id: category2.id)
         variant3 = mock_model(Variant, shipping_category_id: nil)
-        contents = [ContentItem.new(build(:inventory_unit, variant: variant1)),
-                    ContentItem.new(build(:inventory_unit, variant: variant1)),
-                    ContentItem.new(build(:inventory_unit, variant: variant2)),
-                    ContentItem.new(build(:inventory_unit, variant: variant3))]
+        contents = [ContentItem.new(build(:inventory_unit, variant: variant1, order: order)),
+                    ContentItem.new(build(:inventory_unit, variant: variant1, order: order)),
+                    ContentItem.new(build(:inventory_unit, variant: variant2, order: order)),
+                    ContentItem.new(build(:inventory_unit, variant: variant3, order: order))]
 
         package = Package.new(stock_location, contents)
         expect(package.shipping_methods).to match_array([method1, method2])
       end
       # Contains regression test for https://github.com/spree/spree/issues/2804
       it 'builds a list of shipping methods common to all categories' do
+        store = create(:store)
+        order = mock_model(Spree::Order, store: store)
         category1 = create(:shipping_category)
         category2 = create(:shipping_category)
-        method1   = create(:shipping_method)
-        method2   = create(:shipping_method)
+        method1   = create(:shipping_method, stores: [store])
+        method2   = create(:shipping_method, stores: [store])
         method1.shipping_categories = [category1, category2]
         method2.shipping_categories = [category1]
         variant1 = mock_model(Variant, shipping_category_id: category1.id)
         variant2 = mock_model(Variant, shipping_category_id: category2.id)
         variant3 = mock_model(Variant, shipping_category_id: nil)
-        contents = [ContentItem.new(build(:inventory_unit, variant: variant1)),
-                    ContentItem.new(build(:inventory_unit, variant: variant1)),
-                    ContentItem.new(build(:inventory_unit, variant: variant2)),
-                    ContentItem.new(build(:inventory_unit, variant: variant3))]
+        contents = [ContentItem.new(build(:inventory_unit, variant: variant1, order: order)),
+                    ContentItem.new(build(:inventory_unit, variant: variant1, order: order)),
+                    ContentItem.new(build(:inventory_unit, variant: variant2, order: order)),
+                    ContentItem.new(build(:inventory_unit, variant: variant3, order: order))]
 
         package = Package.new(stock_location, contents)
         expect(package.shipping_methods).to match_array([method1])

--- a/core/spec/models/spree/stock/package_spec.rb
+++ b/core/spec/models/spree/stock/package_spec.rb
@@ -70,7 +70,7 @@ module Spree
 
         context "based on stock location and categories" do
           let(:first_method) do
-            FactoryGirl.create(:shipping_method, available_to_all: true)
+            FactoryGirl.create(:shipping_method, available_to_all_stock_locations: true)
           end
           let(:second_method) do
             FactoryGirl.create(:shipping_method, stock_locations: [stock_location])

--- a/core/spec/models/spree/stock/package_spec.rb
+++ b/core/spec/models/spree/stock/package_spec.rb
@@ -48,7 +48,7 @@ module Spree
       end
 
       describe "#shipping_methods" do
-        let(:store) { FactoryGirl.build(:store) }
+        let(:store) { FactoryGirl.create(:store) }
         let(:order) { FactoryGirl.build(:order, store: store) }
 
         let(:categories) { FactoryGirl.build_pair(:shipping_category) }
@@ -84,6 +84,25 @@ module Spree
           end
 
           it { is_expected.to match_array [first_method, second_method] }
+        end
+
+        context "when the method is available to all stores" do
+          let!(:method) do
+            FactoryGirl.create(
+              :shipping_method,
+              shipping_categories: categories,
+              available_to_all_stores: true
+            )
+          end
+          let!(:other_method) do
+            FactoryGirl.create(
+              :shipping_method,
+              shipping_categories: categories,
+              available_to_all_stores: false
+            )
+          end
+
+          it { is_expected.to match_array [method] }
         end
 
         context "based on categories" do


### PR DESCRIPTION
This functionality was originally provided by [`solidus_multi_domain`](https://github.com/solidusio/solidus_multi_domain) but is just as valid as part of core. This is basically a continuation of the work from https://github.com/solidusio/solidus/commit/2fdfae5c5f7e1abba1f4b91d8dd5640d576a5b08.