### PR TITLE
update taxon_picker with jquery-plugin based approach

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/taxon_autocomplete.js
+++ b/backend/app/assets/javascripts/spree/backend/taxon_autocomplete.js
@@ -1,12 +1,7 @@
-'use strict';
+$.fn.taxonAutocomplete = function () {
+  'use strict';
 
-var set_taxon_select = function(){
-  function formatTaxon(taxon) {
-    return Select2.util.escapeMarkup(taxon.pretty_name);
-  }
-
-  if ($('#product_taxon_ids').length > 0) {
-    $('#product_taxon_ids').select2({
+  this.select2({
       placeholder: Spree.translations.taxon_placeholder,
       multiple: true,
       initSelection: function (element, callback) {
@@ -24,7 +19,6 @@ var set_taxon_select = function(){
       },
       ajax: {
         url: Spree.routes.taxons_search,
-        params: { "headers": { "X-Spree-Token": Spree.api_key } },
         datatype: 'json',
         data: function (term, page) {
           return {
@@ -45,12 +39,20 @@ var set_taxon_select = function(){
           };
         }
       },
-      formatResult: formatTaxon,
-      formatSelection: formatTaxon
+      formatResult: function (taxon, container, query, escapeMarkup) {
+        return escapeMarkup(taxon.pretty_name);
+      },
+      formatSelection: function (taxon, container, escapeMarkup) {
+        return escapeMarkup(taxon.pretty_name);
+      }
     });
-  }
-}
+};
 
 $(document).ready(function () {
-  set_taxon_select()
+  $('#product_taxon_ids, .taxon_picker').taxonAutocomplete();
 });
+
+// for backwards compat...
+var set_taxon_select = function() {
+  $('#product_taxon_ids, .taxon_picker').taxonAutocomplete();
+}

--- a/backend/app/views/spree/admin/promotion_rules/create.js.erb
+++ b/backend/app/views/spree/admin/promotion_rules/create.js.erb
@@ -3,8 +3,8 @@ $('#rules .no-objects-found').hide();
 
 $('.product_picker').productAutocomplete();
 $('.user_picker').userAutocomplete();
+$('.taxon_picker').taxonAutocomplete();
 
 $('#promotion_rule_type').html('<%= escape_javascript options_for_promotion_rule_types(@promotion) %>');
 $('#promotion_rule_type').select2();
 
-set_taxon_select()


### PR DESCRIPTION
More updated flexible approach. Modelled after the existing
product_picker.js code. I needed this to allow more than
one product_picker on a page, which this style allows but
the old one did not (being #id based).

Kept filename the same, and maintained a set_taxon_select()
function, for strict backwards compatibility.