### PR TITLE
Rename Spree::Promotion#expired? to Spree::Promotion#inactive?

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -256,7 +256,7 @@ module Spree
     # @return [Array] all advertised and not-rejected promotions
     def possible_promotions
       promotion_ids = promotion_rules.map(&:promotion_id).uniq
-      Spree::Promotion.advertised.where(id: promotion_ids).reject(&:expired?)
+      Spree::Promotion.advertised.where(id: promotion_ids).reject(&:inactive?)
     end
 
     # The number of on-hand stock items; Infinity if any variant does not track

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -125,7 +125,7 @@ module Spree
 
     # called anytime order.update! happens
     def eligible?(promotable, promotion_code: nil)
-      return false if expired?
+      return false if inactive?
       return false if usage_limit_exceeded?
       return false if promotion_code && promotion_code.usage_limit_exceeded?
       return false if blacklisted?(promotable)

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -73,13 +73,22 @@ module Spree
       super
     end
 
-    def expired?
-      !active?
-    end
-
     def active?
       (starts_at.nil? || starts_at < Time.current) &&
         (expires_at.nil? || expires_at > Time.current)
+    end
+
+    def inactive?
+      !active?
+    end
+
+    def expired?
+      Spree::Deprecation.warn <<-WARN.squish, caller
+        #expired? is deprecated, and will be removed in Solidus 2.0.
+        Please use #inactive? instead.
+      WARN
+
+      inactive?
     end
 
     def activate(order:, line_item: nil, user: nil, path: nil, promotion_code: nil)

--- a/core/app/models/spree/promotion_handler/coupon.rb
+++ b/core/app/models/spree/promotion_handler/coupon.rb
@@ -12,7 +12,7 @@ module Spree
         if order.coupon_code.present?
           if promotion.present? && promotion.actions.exists?
             handle_present_promotion(promotion)
-          elsif promotion_code && promotion_code.promotion.expired?
+          elsif promotion_code && promotion_code.promotion.inactive?
             set_error_code :coupon_code_expired
           else
             set_error_code :coupon_code_not_found

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -294,35 +294,35 @@ describe Spree::Promotion, type: :model do
     end
   end
 
-  context "#expired" do
+  context "#inactive" do
     it "should not be exipired" do
-      expect(promotion).not_to be_expired
+      expect(promotion).not_to be_inactive
     end
 
-    it "should be expired if it hasn't started yet" do
+    it "should be inactive if it hasn't started yet" do
       promotion.starts_at = Time.current + 1.day
-      expect(promotion).to be_expired
+      expect(promotion).to be_inactive
     end
 
-    it "should be expired if it has already ended" do
+    it "should be inactive if it has already ended" do
       promotion.expires_at = Time.current - 1.day
-      expect(promotion).to be_expired
+      expect(promotion).to be_inactive
     end
 
-    it "should not be expired if it has started already" do
+    it "should not be inactive if it has started already" do
       promotion.starts_at = Time.current - 1.day
-      expect(promotion).not_to be_expired
+      expect(promotion).not_to be_inactive
     end
 
-    it "should not be expired if it has not ended yet" do
+    it "should not be inactive if it has not ended yet" do
       promotion.expires_at = Time.current + 1.day
-      expect(promotion).not_to be_expired
+      expect(promotion).not_to be_inactive
     end
 
-    it "should not be expired if current time is within starts_at and expires_at range" do
+    it "should not be inactive if current time is within starts_at and expires_at range" do
       promotion.starts_at = Time.current - 1.day
       promotion.expires_at = Time.current + 1.day
-      expect(promotion).not_to be_expired
+      expect(promotion).not_to be_inactive
     end
   end
 


### PR DESCRIPTION
The new name better describes what the method is doing, and avoids confusion when calling it on promotions that have not run yet.