### PR TITLE
Associate trackers to stores

### DIFF
--- a/backend/app/views/spree/admin/trackers/_form.html.erb
+++ b/backend/app/views/spree/admin/trackers/_form.html.erb
@@ -1,11 +1,11 @@
 <div data-hook="admin_tracker_form_fields" class="row">
-  <div class="alpha four columns">
+  <div class="alpha eight columns">
     <div data-hook="analytics_id" class="field">
       <%= f.label :analytics_id %>
       <%= f.text_field :analytics_id, :class => 'fullwidth' %>
     </div>
   </div>
-  <div class="omega four columns">
+  <div class="four columns">
     <div data-hook="active" class="field">
       <%= f.label :active %>
       <ul>
@@ -18,6 +18,14 @@
           <%= label_tag :tracker_active_false, Spree.t(:say_no) %>
         </li>
       </ul>
+    </div>
+  </div>
+  <div class="omega four columns">
+    <div class="field">
+      <%= f.label :store %>
+      <%= collection_select(
+        :tracker, :store_id, Spree::Store.all, :id, :name,
+        {}, {class: "select2 fullwidth"}) %>
     </div>
   </div>
 

--- a/backend/app/views/spree/admin/trackers/index.html.erb
+++ b/backend/app/views/spree/admin/trackers/index.html.erb
@@ -15,15 +15,16 @@
 <% if @trackers.any? %>
   <table class="index">
     <colgroup>
-      <col style="width: 30%">
       <col style="width: 40%">
       <col style="width: 15%">
+      <col style="width: 30%">
       <col style="width: 15%">
     </colgroup>
     <thead>
       <tr data-hook="admin_trackers_index_headers">
         <th><%= Spree::Tracker.human_attribute_name(:analytics_id) %></th>
         <th><%= Spree::Tracker.human_attribute_name(:active) %></th>
+        <th><%= Spree::Tracker.human_attribute_name(:store) %></th>
         <th class="actions"></th>
       </tr>
     </thead>
@@ -32,6 +33,7 @@
         <tr id="<%= spree_dom_id tracker %>" data-hook="admin_trackers_index_rows" class="<%= cycle('odd', 'even')%>">
           <td class="align-center"><%= tracker.analytics_id %></td>
           <td class="align-center"><%= tracker.active ? Spree.t(:say_yes) : Spree.t(:say_no) %></td>
+          <td class="align-center"><%= tracker.store.try(:name) %></td>
           <td class="actions">
             <% if can?(:update, tracker) %>
               <%= link_to_edit tracker, :no_text => true %>

--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -4,6 +4,8 @@ module Spree
     has_many :payment_methods, through: :store_payment_methods
     has_many :orders, class_name: "Spree::Order"
 
+    has_one :tracker
+
     validates :code, presence: true, uniqueness: { allow_blank: true }
     validates :name, presence: true
     validates :url, presence: true

--- a/core/app/models/spree/tracker.rb
+++ b/core/app/models/spree/tracker.rb
@@ -1,5 +1,7 @@
 module Spree
   class Tracker < Spree::Base
+    belongs_to :store
+
     def self.current
       tracker = where(active: true).first
       tracker.analytics_id.present? ? tracker : nil if tracker

--- a/core/app/models/spree/tracker.rb
+++ b/core/app/models/spree/tracker.rb
@@ -2,9 +2,19 @@ module Spree
   class Tracker < Spree::Base
     belongs_to :store
 
-    def self.current
-      tracker = where(active: true).first
-      tracker.analytics_id.present? ? tracker : nil if tracker
+    def self.current(store = nil)
+      tracker =
+        if store
+          find_by(active: true, store_id: store.id)
+        else
+          ActiveSupport::Deprecation.warn <<-EOS.squish, caller
+            Calling Spree::Tracker.current without a store is DEPRECATED.
+            Instead, please provide a Spree::Store.
+          EOS
+          find_by(active: true)
+        end
+
+      tracker.try(:analytics_id).blank? ? nil : tracker
     end
   end
 end

--- a/core/db/migrate/20160510184056_add_store_id_to_trackers.rb
+++ b/core/db/migrate/20160510184056_add_store_id_to_trackers.rb
@@ -1,0 +1,7 @@
+class AddStoreIdToTrackers < ActiveRecord::Migration
+  def change
+    unless column_exists?(:spree_trackers, :store_id)
+      add_column :spree_trackers, :store_id, :integer
+    end
+  end
+end

--- a/core/db/migrate/20160510194833_assign_trackers_to_stores.rb
+++ b/core/db/migrate/20160510194833_assign_trackers_to_stores.rb
@@ -1,0 +1,25 @@
+class AssignTrackersToStores < ActiveRecord::Migration
+  class Tracker < ActiveRecord::Base
+    self.table_name = "spree_trackers"
+    belongs_to :store
+  end
+
+  class Store < ActiveRecord::Base
+    self.table_name = "spree_stores"
+  end
+
+  def up
+    default_store = Store.find_by(default: true)
+
+    unless default_store.nil? || Tracker.find_by(store_id: default_store.id)
+      say_with_time "assigning active tracker to default store" do
+        tracker = Tracker.find_by(active: true, store_id: nil)
+        tracker.update!(store: default_store) if tracker
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/core/lib/spree/core/controller_helpers/store.rb
+++ b/core/lib/spree/core/controller_helpers/store.rb
@@ -14,10 +14,15 @@ module Spree
           self.current_store_class = Spree::Core::CurrentStore
 
           helper_method :current_store
+          helper_method :current_tracker
         end
 
         def current_store
           @current_store ||= current_store_class.new(request).store
+        end
+
+        def current_tracker
+          @current_tracker ||= Spree::Tracker.current(current_store)
         end
       end
     end

--- a/frontend/app/views/spree/shared/_google_analytics.html.erb
+++ b/frontend/app/views/spree/shared/_google_analytics.html.erb
@@ -1,4 +1,4 @@
-<% if tracker = Spree::Tracker.current %>
+<% if tracker = Spree::Tracker.current(current_store) %>
   <script>
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/frontend/app/views/spree/shared/_google_analytics.html.erb
+++ b/frontend/app/views/spree/shared/_google_analytics.html.erb
@@ -1,11 +1,11 @@
-<% if tracker = Spree::Tracker.current(current_store) %>
+<% if current_tracker %>
   <script>
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-    ga('create', '<%= tracker.analytics_id %>', 'auto');
+    ga('create', '<%= current_tracker.analytics_id %>', 'auto');
     ga('require', 'displayfeatures');
     ga('send', 'pageview');
 


### PR DESCRIPTION
This functionality was originally provided by [`solidus_multi_domain`](https://github.com/solidusio/solidus_multi_domain) but is just as valid as part of core. This is basically a continuation of the work from https://github.com/solidusio/solidus/commit/2fdfae5c5f7e1abba1f4b91d8dd5640d576a5b08.