### PR TITLE
Remove extra set_current_order calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 ## Solidus 1.4.0 (unreleased)
 
+*   Order Merging on Sign In:
+
+    Previously a before filter added in `core/lib/spree/core/controller_helpers/order.rb`
+    would cause sql queries to be used on almost every request in the frontend.
+    If you do not use Solidus Auth you will need to hook into this helper and
+    call `set_current_order` where your user signs in. This merges incomplete
+    orders a user has going with their current cart.  If you do use
+    Solidus Auth you will need to make sure you use a current enough
+    version that includes this explicit call. If you do use Solidus Auth but do _not_
+    use Solidus Frontend you will also need to hook into this helper and call
+    `set_current_order` where your user signs in.
+
 *   Use in-memory objects in OrderUpdater and related areas.
 
     Solidus now uses in-memory data for updating orders in and around

--- a/api/app/controllers/spree/api/checkouts_controller.rb
+++ b/api/app/controllers/spree/api/checkouts_controller.rb
@@ -11,9 +11,6 @@ module Spree
       # TODO: Remove this after deprecated usage in #update is removed
       include Spree::Core::ControllerHelpers::PaymentParameters
 
-      # This before_action comes from Spree::Core::ControllerHelpers::Order
-      skip_before_action :set_current_order
-
       def next
         if @order.confirm?
           Spree::Deprecation.warn "Using Spree::Api::CheckoutsController#next to transition to complete is deprecated. Please use #complete instead of #next.", caller

--- a/core/lib/spree/core/controller_helpers/order.rb
+++ b/core/lib/spree/core/controller_helpers/order.rb
@@ -8,8 +8,6 @@ module Spree
         include ControllerHelpers::Pricing
 
         included do
-          before_action :set_current_order
-
           helper_method :current_order
           helper_method :simple_current_order
         end

--- a/frontend/app/controllers/spree/store_controller.rb
+++ b/frontend/app/controllers/spree/store_controller.rb
@@ -3,8 +3,6 @@ module Spree
     include Spree::Core::ControllerHelpers::Pricing
     include Spree::Core::ControllerHelpers::Order
 
-    skip_before_action :set_current_order, only: :cart_link
-
     def unauthorized
       render 'spree/shared/unauthorized', layout: Spree::Config[:layout], status: 401
     end


### PR DESCRIPTION
Currently this method set_current_order is called on almost every request in the front end resulting in many unnecessary SQL requests.  We want to push this to where it should be which is just when we sign in to authentication systems.  This is currently done in solidus_auth_devise, 
https://github.com/solidusio/solidus_auth_devise/pull/51 ,  and is clarified in the patch notes for 1.4 so people using other gems can see this and address it.  This addresses #1116.

The one concern is that we need to make sure people use a recent enough version of Solidus Auth to match this change.
