### PR TITLE
Add ability to filter orders by store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
     * JavaScript for it has been moved from address.js into its own `spree/frontend/checkout/coupon-code`
     * Numerous small nuisances have been fixed [#1090](https://github.com/solidusio/solidus/pull/1090)
 
+*   Filter orders by store when more than a single store is present. [#1149](https://github.com/solidusio/solidus/pull/1140)
+
 
 ## Solidus 1.3.0 (unreleased)
 

--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -70,6 +70,13 @@
       </div>
 
       <div class="omega four columns">
+        <% if Spree::Store.count > 1 %>
+          <div class="field">
+            <%= label_tag nil, Spree.t(:store) %>
+            <%= f.select :store_id_eq, Spree::Store.all.map { |s| [s.name, s.id] }, { include_blank: true }, { class: "select2" } %>
+          </div>
+        <% end %>
+
         <div class="field checkbox">
           <label>
             <%= f.check_box :completed_at_not_null, {:checked => @show_only_completed}, '1', '0' %>

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -27,7 +27,7 @@ module Spree
     end
 
     self.whitelisted_ransackable_associations = %w[shipments user promotions bill_address ship_address line_items]
-    self.whitelisted_ransackable_attributes = %w[completed_at created_at email number state payment_state shipment_state total]
+    self.whitelisted_ransackable_attributes = %w[completed_at created_at email number state payment_state shipment_state total store_id]
 
     attr_reader :coupon_code
     attr_accessor :temporary_address, :temporary_credit_card


### PR DESCRIPTION
If there's more than one store, allow admins to filter the orders by the stores so that it's easier to find the things they are looking for.