### PR TITLE
include necessary helpers for views to render correctly in reimbursem…

### DIFF
--- a/backend/app/controllers/spree/admin/customer_returns_controller.rb
+++ b/backend/app/controllers/spree/admin/customer_returns_controller.rb
@@ -2,6 +2,7 @@ module Spree
   module Admin
     class CustomerReturnsController < ResourceController
       belongs_to 'spree/order', find_by: :number
+      helper "spree/admin/reimbursement_type"
 
       before_action :parent # ensure order gets loaded to support our pseudo parent-child relationship
       before_action :load_form_data, only: [:new, :edit]

--- a/backend/app/controllers/spree/admin/reimbursements_controller.rb
+++ b/backend/app/controllers/spree/admin/reimbursements_controller.rb
@@ -2,6 +2,8 @@ module Spree
   module Admin
     class ReimbursementsController < ResourceController
       belongs_to 'spree/order', find_by: :number
+      helper "spree/admin/reimbursement_type"
+      helper "spree/admin/customer_returns"
 
       before_action :load_stock_locations, only: :edit
       before_action :load_simulated_refunds, only: :edit


### PR DESCRIPTION
…ent and customer return views

Errors occurring while creating customer return and reimbursements:
1. undefined local variable or method reimbursement_type_name. https://github.com/solidusio/solidus/blob/v1.2/backend/app/views/spree/admin/reimbursements/edit.html.erb#L37
The method is here https://github.com/solidusio/solidus/blob/v1.2/backend/app/helpers/spree/admin/reimbursement_type_helper.rb#L4 so we would have to include that helper in the reimbursements controller.
2. undefined local variable or method reimbursement_types
https://github.com/solidusio/solidus/blob/v1.2/backend/app/views/spree/admin/reimbursements/edit.html.erb#L41
That is because it is located in the CustomerReturnsHelper https://github.com/solidusio/solidus/blob/v1.2/backend/app/helpers/spree/admin/customer_returns_helper.rb