### PR TITLE
Fix reimbursement mailer text

### DIFF
--- a/core/app/views/spree/reimbursement_mailer/reimbursement_email.text.erb
+++ b/core/app/views/spree/reimbursement_mailer/reimbursement_email.text.erb
@@ -12,7 +12,7 @@
 <%= Spree.t('reimbursement_mailer.reimbursement_email.exchange_summary') %>
 ============================================================
 <% @reimbursement.return_items.exchange_requested.each do |return_item| %>
-<%= return_item.variant.sku %> <%= raw(return_item.variant.product.name) %> <%= "(#{raw(return_item.variant.options_text)})" if return_item.variant.options_text.present? -%> -> <%= return_item.exchange_variant.sku %> <%= raw(return_item.exchange_variant.product.name) if return_item.exchange_variant.options_text.present? %> <%= "(#{raw(return_item.exchange_variant.options_text)})" -%>
+<%= return_item.variant.sku %> <%= raw(return_item.variant.name) %> <%= "(#{raw(return_item.variant.options_text)})" if return_item.variant.options_text.present? %> -> <%= return_item.exchange_variant.sku %> <%= raw(return_item.exchange_variant.name) %> <%= "(#{raw(return_item.exchange_variant.options_text)})" if return_item.exchange_variant.options_text.present? %>
 <% end %>
 
 


### PR DESCRIPTION
1. removed '-' char at the end of some erb tags. They are useless and
not used the in other tags;
2. when `return_item.variant.product.name` was used, it has been changed
in `return_item.variant.name` since that method is delegated from
variant to its product;
3. in this portion: `<%= raw(return_item.exchange_variant.product.name)
if return_item.exchange_variant.options_text.present? %>` the if
condition is checking the presence of `option_text` but it's applied on
the `name`. It had to be moved to the `option_text` tag. This is
actually a bug since without this change the mail text will not have the
name printed if the `option_text` is not present on that variant. 

The previous (wrong) result was:

`ROR-00012 Ruby on Rails Bag  -> ROR-00012  ()`

while the current (expected) result is:

`ROR-00012 Ruby on Rails Bag  -> ROR-00012 Ruby on Rails Bag`