### PR TITLE
Add reimbursement email preview

### DIFF
--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -98,3 +98,4 @@ require 'spree/deprecation'
 
 require 'spree/mailer_previews/order_preview'
 require 'spree/mailer_previews/carton_preview'
+require 'spree/mailer_previews/reimbursement_preview'

--- a/core/lib/spree/mailer_previews/reimbursement_preview.rb
+++ b/core/lib/spree/mailer_previews/reimbursement_preview.rb
@@ -1,0 +1,9 @@
+module Spree
+  class MailerPreviews
+    class ReimbursementPreview < ActionMailer::Preview
+      def reimbursement
+        ReimbursementMailer.reimbursement_email(Reimbursement.first)
+      end
+    end
+  end
+end

--- a/sample/db/samples/reimbursements.rb
+++ b/sample/db/samples/reimbursements.rb
@@ -1,0 +1,21 @@
+Spree::Sample.load_sample("orders")
+
+order          = Spree::Order.last
+inventory_unit = order.inventory_units.first
+stock_location = inventory_unit.find_stock_item.stock_location
+
+return_item = Spree::ReturnItem.create(inventory_unit: inventory_unit)
+
+return_item.exchange_variant = return_item.eligible_exchange_variants.last
+return_item.build_exchange_inventory_unit
+return_item.accept!
+
+customer_return = Spree::CustomerReturn.create(
+  stock_location: stock_location,
+  return_items: [return_item]
+)
+
+order.reimbursements.create(
+  customer_return: customer_return,
+  return_items: [return_item]
+)

--- a/sample/lib/spree_sample.rb
+++ b/sample/lib/spree_sample.rb
@@ -25,6 +25,7 @@ module SpreeSample
 
       Spree::Sample.load_sample("orders")
       Spree::Sample.load_sample("payments")
+      Spree::Sample.load_sample("reimbursements")
     end
   end
 end


### PR DESCRIPTION
It allows testing emails like other ones with the rails preview. To watch and work with this preview a real reimbursement (persisted in the database) is needed so it adds a reimbursement sample that is loaded with the spree_sample:load task and attached to one order previously created.