### PR TITLE
New Content Layouts

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/components/_sidebar.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_sidebar.scss
@@ -1,6 +1,4 @@
-// Sidebar
-//---------------------------------------------------
-#sidebar {
+body:not(.new-layout) #sidebar {
   overflow: visible;
   border-top: 1px solid $color-border;
   margin-top: 17px;
@@ -29,4 +27,16 @@
       min-height: 3em;
     }
   }
+}
+
+body.new-layout .content-sidebar {
+  ul {
+    padding-left: 0;
+  }
+}
+
+body.new-layout .sidebar-title {
+  @include line-through();
+  color: $color-2;
+  font-size: 14px;
 }

--- a/backend/app/assets/stylesheets/spree/backend/globals/_mixins.css
+++ b/backend/app/assets/stylesheets/spree/backend/globals/_mixins.css
@@ -1,0 +1,2 @@
+@import "mixins/caret";
+@import "mixins/line_through";

--- a/backend/app/assets/stylesheets/spree/backend/globals/mixins/_line_through.scss
+++ b/backend/app/assets/stylesheets/spree/backend/globals/mixins/_line_through.scss
@@ -1,0 +1,22 @@
+@mixin line-through($color: $color-2, $background: $color-1) {
+  position: relative;
+  text-align: center;
+
+  &:before {
+    content: "";
+    position: absolute;
+    top: calc(50% - 1px);
+    left: 0;
+    width: 100%;
+    height: 1px;
+    background: $color;
+    z-index: 0;
+  }
+
+  > * { // usually a <span> but we'll use an * just in case
+    @include padding(null 1rem);
+    position: relative;
+    background: $background;
+    z-index: 1;
+  }
+}

--- a/backend/app/assets/stylesheets/spree/backend/sections/_products.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/_products.scss
@@ -1,10 +1,29 @@
-[data-hook="admin_products_sidebar"] {
-  // .field.checkbox:first-child {
-  //   margin-top: 36px;
-  // }
-  .actions {
-    padding: 0 !important;
+[data-hook="admin_products_index_search"] {
+  @include make-row();
+
+  > * {
+    @include make-col();
+    @include padding(0 null); // override the padding on .field
   }
+}
+
+.product-search-field-name {
+  @include make-col-span(6);
+}
+
+.product-search-field-sku {
+  @include make-col-span(4);
+}
+
+.product-search-field-show-deleted.field.checkbox {
+  // extra specificity to override styles
+  @include make-col-span(2);
+  min-height: initial; // override .field.checkbox
+  margin-bottom: 0; // override .checkbox
+}
+
+div[data-hook="admin_products_index_search_buttons"] {
+  margin-top: 2rem;
 }
 
 [data-hook="admin_product_form_fields"] {

--- a/backend/app/assets/stylesheets/spree/backend/shared/_header.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_header.scss
@@ -1,10 +1,13 @@
 .main-header {
   @include display(flex);
   @include align-items(center);
-  margin-left: $width-sidebar;
-  padding: 15px 14px;
+  padding: 15px $grid-gutter-width;
   background-color: very-light($color-3, 4);
   border-bottom: 1px solid $color-border;
+
+  body:not(.new-layout) & {
+    margin-left: $width-sidebar;
+  }
 }
 
 .page-title {

--- a/backend/app/assets/stylesheets/spree/backend/shared/_layout.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_layout.scss
@@ -38,6 +38,7 @@ body {
 .content-main {
   @include make-col();
   @include make-col-span(12);
+  overflow-x: hidden; // makes sure that the tabs are able to resize
 
   .has-sidebar & {
     @include make-col-span(9);

--- a/backend/app/assets/stylesheets/spree/backend/shared/_layout.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_layout.scss
@@ -5,6 +5,10 @@ html {
 body {
   position: relative;
   min-height: 100%;
+
+  &.new-layout {
+    padding-left: $width-sidebar;
+  }
 }
 
 .admin-nav {
@@ -12,9 +16,32 @@ body {
   width: $width-sidebar;
 }
 
-.main-content {
-  margin-left: $width-sidebar;
-  @include clearfix;
+.content-wrapper {
+  body:not(.new-layout) & {
+    margin-left: $width-sidebar;
+  }
+
+  body.new-layout & {
+    @include padding(1rem $grid-gutter-width null);
+  }
+}
+
+.content {
+  @include make-row();
+}
+
+.content-main {
+  @include make-col();
+  @include make-col-span(12);
+
+  .has-sidebar & {
+    @include make-col-span(9);
+  }
+}
+
+.content-sidebar {
+  @include make-col();
+  @include make-col-span(3);
 }
 
 #content {

--- a/backend/app/assets/stylesheets/spree/backend/shared/_layout.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_layout.scss
@@ -24,6 +24,11 @@ body {
   body.new-layout & {
     @include padding(1rem $grid-gutter-width null);
   }
+
+  &.centered {
+    @include margin(null auto);
+    max-width: map-get($container-max-widths, "xl");
+  }
 }
 
 .content {

--- a/backend/app/assets/stylesheets/spree/backend/spree_admin.scss
+++ b/backend/app/assets/stylesheets/spree/backend/spree_admin.scss
@@ -7,7 +7,7 @@
 @import 'bootstrap_custom';
 @import 'solidus_admin/bootstrap/bootstrap';
 
-@import 'spree/backend/globals/mixins/caret';
+@import 'spree/backend/globals/mixins';
 
 @import 'spree/backend/shared/skeleton';
 @import 'spree/backend/shared/typography';

--- a/backend/app/helpers/spree/admin/base_helper.rb
+++ b/backend/app/helpers/spree/admin/base_helper.rb
@@ -155,6 +155,11 @@ module Spree
         dom_id(record, 'spree')
       end
 
+      def admin_layout(layout = nil)
+        @admin_layout = layout if layout
+        @admin_layout
+      end
+
       private
 
       def attribute_name_for(field_name)

--- a/backend/app/views/spree/admin/products/index.html.erb
+++ b/backend/app/views/spree/admin/products/index.html.erb
@@ -1,3 +1,5 @@
+<% admin_layout "full-width" %>
+
 <% content_for :page_title do %>
   <%= Spree.t(:listing_products) %>
 <% end %>

--- a/backend/app/views/spree/admin/products/index.html.erb
+++ b/backend/app/views/spree/admin/products/index.html.erb
@@ -14,37 +14,28 @@
 
 <% content_for :table_filter do %>
   <div data-hook="admin_products_sidebar">
-
     <%= search_form_for [:admin, @search] do |f| %>
-
         <%- locals = {:f => f} %>
-
         <div data-hook="admin_products_index_search">
-          <div class="alpha nine columns">
-            <div class="field">
-              <%= f.label :name_cont, Spree::Product.human_attribute_name(:name) %>
-              <%= f.text_field :name_cont, :size => 15 %>
-            </div>
+          <div class="product-search-field-name field">
+            <%= f.label :name_cont, Spree::Product.human_attribute_name(:name) %>
+            <%= f.text_field :name_cont, :size => 15 %>
           </div>
-          <div class="four columns">
-            <div class="field">
-              <%= f.label :variants_including_master_sku_cont, Spree::Variant.human_attribute_name(:sku) %>
-              <%= f.text_field :variants_including_master_sku_cont, :size => 15 %>
-            </div>
+
+          <div class="product-search-field-sku field">
+            <%= f.label :variants_including_master_sku_cont, Spree::Variant.human_attribute_name(:sku) %>
+            <%= f.text_field :variants_including_master_sku_cont, :size => 15 %>
           </div>
-          <div class="three columns omega">
-            <div class="field checkbox">
-              <label>
-                <%= f.check_box :deleted_at_null, {:checked => params[:q][:deleted_at_null] == '0'}, '0', '1' %>
-                <%= Spree.t(:show_deleted) %>
-              </label>
-            </div>
+
+          <div class="product-search-field-show-deleted field checkbox">
+            <label>
+              <%= f.check_box :deleted_at_null, {:checked => params[:q][:deleted_at_null] == '0'}, '0', '1' %>
+              <%= Spree.t(:show_deleted) %>
+            </label>
           </div>
         </div>
 
-        <div class="clear"></div>
-
-        <div class="form-buttons actions filter-actions" data-hook="admin_products_index_search_buttons">
+        <div class="actions filter-actions" data-hook="admin_products_index_search_buttons">
           <%= button Spree.t(:search), 'search' %>
         </div>
     <% end %>

--- a/backend/app/views/spree/admin/shared/_sidebar.html.erb
+++ b/backend/app/views/spree/admin/shared/_sidebar.html.erb
@@ -1,5 +1,5 @@
 <% if content_for?(:sidebar) %>
-  <aside id="sidebar" data-hook class="four columns">
+  <aside id="sidebar" data-hook class="content-sidebar four columns">
 
     <% if content_for?(:sidebar_title) %>
       <h5 class="sidebar-title"><span><%= yield :sidebar_title %></span></h5>

--- a/backend/app/views/spree/admin/variants/_table_filter.html.erb
+++ b/backend/app/views/spree/admin/variants/_table_filter.html.erb
@@ -4,18 +4,16 @@
 
 <% content_for :table_filter do %>
   <%= form_for :variant_search, url: spree.admin_product_variants_path(product), method: :get do |f| %>
-    <div data-hook="admin_variants_index_search" class="field thirteen columns alpha">
+    <div data-hook="admin_variants_index_search" class="field">
       <%= f.label :variant_search_term, Spree.t(:variant_search_placeholder) %>
       <%= text_field_tag :variant_search_term, params[:variant_search_term], :class => "fullwidth", :placeholder => Spree.t(:variant_search_placeholder) %>
     </div>
 
     <% if product.variants.only_deleted.any? %>
-      <div class="field checkbox three columns omega">
-        <%= label_tag :deleted do %>
-          <%= check_box_tag :deleted, "on", params[:deleted] == "on" %>
-          <%= t('.show_deleted') %>
-        <% end %>
-      </div>
+      <%= label_tag :deleted do %>
+        <%= check_box_tag :deleted, "on", params[:deleted] == "on" %>
+        <%= t('.show_deleted') %>
+      <% end %>
     <% end %>
 
     <div class="actions filter-actions">

--- a/backend/app/views/spree/admin/variants/index.html.erb
+++ b/backend/app/views/spree/admin/variants/index.html.erb
@@ -34,10 +34,9 @@
       <% if can?(:create, Spree::Variant) %>
         <li id="new_var_link" data-hook>
           <%= link_to_with_icon 'plus',
-                                Spree.t(:new_variant),
-                                new_admin_product_variant_url(@product),
-                                :remote => :true,
-                                :class => 'button' %>
+              Spree.t(:new_variant),
+              new_admin_product_variant_url(@product),
+              class: 'button' %>
         </li>
       <% end %>
     </ul>

--- a/backend/app/views/spree/admin/variants/index.html.erb
+++ b/backend/app/views/spree/admin/variants/index.html.erb
@@ -1,3 +1,5 @@
+<% admin_layout 'full-width' %>
+
 <%= render 'spree/admin/shared/product_tabs', current: 'Variants' %>
 
 <% if @variants.any? || @product.variants.only_deleted.any?%>
@@ -14,12 +16,12 @@
       <% end %>
     </p>
   <% elsif @product.empty_option_values? %>
-    <div class="alpha twelve columns no-objects-found">
+    <div class="no-objects-found">
       <%= Spree.t :no_option_values_on_product_html,
                   link: link_to(Spree.t(:product_details), [:edit, :admin, @product]) %>
     </div>
   <% else %>
-    <div class="alpha twelve columns no-objects-found">
+    <div class="no-objects-found">
       <%= Spree.t(:no_resource, resource: Spree::Variant.model_name.human(count: :other)) %>
       <% if can? :create, Spree::Variant %>
         <%= link_to Spree.t(:create_one), new_object_url, remote: true %>

--- a/backend/app/views/spree/admin/variants/new.html.erb
+++ b/backend/app/views/spree/admin/variants/new.html.erb
@@ -1,9 +1,11 @@
-<%= render :partial => 'spree/shared/error_messages', :locals => { :target => @variant } %>
+<%= render 'spree/admin/shared/product_tabs', current: 'Variants' %>
+
+<%= render 'spree/shared/error_messages', target: @variant %>
 
 <%= form_for [:admin, @product, @variant] do |f| %>
   <fieldset data-hook="admin_variant_new_form">
     <legend><%= t('.new_variant') %></legend>
-    <%= render :partial => 'form', :locals => { :f => f } %>
-    <%= render :partial => 'spree/admin/shared/new_resource_links' %>
+    <%= render 'form', f: f %>
+    <%= render 'spree/admin/shared/new_resource_links' %>
   </fieldset>
 <% end %>

--- a/backend/app/views/spree/admin/variants/new.js.erb
+++ b/backend/app/views/spree/admin/variants/new.js.erb
@@ -1,2 +1,0 @@
-$(".js-content-below-tabs").html('<%= escape_javascript(render :template => 'spree/admin/variants/new', :formats => [:html], :handlers => [:erb]) %>');
-$(".js-content-below-tabs .select2").select2();

--- a/backend/app/views/spree/layouts/admin.html.erb
+++ b/backend/app/views/spree/layouts/admin.html.erb
@@ -31,7 +31,7 @@
                   <%= yield :tabs %>
                 </div>
               <% end %>
-              <div class="js-content-below-tabs <%= if content_for?(:sidebar) then 'twelve' else 'sixteen' end %> columns">
+              <div class="<%= if content_for?(:sidebar) then 'twelve' else 'sixteen' end %> columns">
                 <%= render :partial => 'spree/admin/shared/table_filter' %>
                 <%= yield %>
               </div>

--- a/backend/app/views/spree/layouts/admin.html.erb
+++ b/backend/app/views/spree/layouts/admin.html.erb
@@ -4,30 +4,43 @@
     <%= render 'spree/admin/shared/head' %>
   </head>
 
-  <body class="admin">
+  <body class="admin <%= "new-layout" if @admin_layout %>">
     <%= render "spree/admin/shared/navigation" %>
     <%= render "spree/admin/shared/header" %>
     <%= render "spree/admin/shared/flash" %>
     <%= render "spree/admin/shared/spinner" %>
 
-    <div class="main-content" id="wrapper" data-hook>
-      <div class="container">
-        <div class="row">
-          <div class="<%= 'with-sidebar ' if content_for?(:sidebar) %>" id="content" data-hook>
-            <% if content_for?(:tabs) %>
-              <div class="sixteen columns">
-                <%= yield :tabs %>
-              </div>
-            <% end %>
-            <div class="js-content-below-tabs <%= if content_for?(:sidebar) then 'twelve' else 'sixteen' end %> columns">
-              <%= render :partial => 'spree/admin/shared/table_filter' %>
-              <%= yield %>
-            </div>
+    <div class="content-wrapper <%= @admin_layout.presence %> <%= "has-sidebar" if content_for?(:sidebar) %>" id="wrapper" data-hook>
+      <% if @admin_layout == "full-width" %>
+        <div class="content">
+          <div class="content-main">
+            <%= yield :tabs %>
+            <%= render "spree/admin/shared/table_filter" %>
+            <%= yield %>
+          </div>
 
-            <%= render 'spree/admin/shared/sidebar' %>
+          <%= render "spree/admin/shared/sidebar" %>
+        </div>
+      <% else %>
+        <% # Legacy layout %>
+        <div class="container">
+          <div class="row">
+            <div class="<%= 'with-sidebar ' if content_for?(:sidebar) %>" id="content" data-hook>
+              <% if content_for?(:tabs) %>
+                <div class="sixteen columns">
+                  <%= yield :tabs %>
+                </div>
+              <% end %>
+              <div class="js-content-below-tabs <%= if content_for?(:sidebar) then 'twelve' else 'sixteen' end %> columns">
+                <%= render :partial => 'spree/admin/shared/table_filter' %>
+                <%= yield %>
+              </div>
+
+              <%= render 'spree/admin/shared/sidebar' %>
+            </div>
           </div>
         </div>
-      </div>
+      <% end %>
     </div>
 
     <div data-hook="admin_footer_scripts"></div>

--- a/backend/app/views/spree/layouts/admin.html.erb
+++ b/backend/app/views/spree/layouts/admin.html.erb
@@ -11,7 +11,7 @@
     <%= render "spree/admin/shared/spinner" %>
 
     <div class="content-wrapper <%= @admin_layout.presence %> <%= "has-sidebar" if content_for?(:sidebar) %>" id="wrapper" data-hook>
-      <% if @admin_layout == "full-width" %>
+      <% if @admin_layout %>
         <div class="content">
           <div class="content-main">
             <%= yield :tabs %>

--- a/backend/spec/helpers/admin/base_helper_spec.rb
+++ b/backend/spec/helpers/admin/base_helper_spec.rb
@@ -14,4 +14,30 @@ describe Spree::Admin::BaseHelper, type: :helper do
       expect(datepicker_field_value(date)).to eq("2013/08/14")
     end
   end
+
+  describe "#admin_layout" do
+    subject { admin_layout(value) }
+
+    context "when an initial value is set" do
+      let(:value) { "full-width" }
+
+      it "sets and returns the value passed to it" do
+        expect(subject).to eq value
+      end
+
+      context "and you call it again without an argument" do
+        before { admin_layout(value) }
+        let(:value) { nil }
+
+        it "returns the initial value that was set" do
+          expect(subject).to eq value
+        end
+      end
+    end
+
+    context "when no initial value has been set and you send no arguments" do
+      let(:value) { nil }
+      it { is_expected.to be_nil }
+    end
+  end
 end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -752,7 +752,7 @@ en:
           amount_used_not_zero: "is greater than zero. Can not delete store credit"
           update_reason_required: "A reason for the change must be selected"
       variants:
-        index:
+        table_filter:
           show_deleted: Show deleted variants
         new:
           new_variant: New variant


### PR DESCRIPTION
This is straight ripped from #1114 because we would like to get that merged in so we can begin to utilize the great work @graygilmore has done there to rework the admin views.  The only change is that the variants index now uses the `full-width` layout instead of the `centered` layout.   Thanks again @graygilmore!