### PR TITLE
Improve helpers used by StockTransfers section

### DIFF
--- a/backend/app/helpers/spree/admin/stock_locations_helper.rb
+++ b/backend/app/helpers/spree/admin/stock_locations_helper.rb
@@ -1,14 +1,10 @@
 module Spree
   module Admin
     module StockLocationsHelper
-      def display_name(stock_location)
+      def admin_stock_location_display_name(stock_location)
         name_parts = [stock_location.admin_name, stock_location.name]
         name_parts.delete_if(&:blank?)
         name_parts.join(' / ')
-      end
-
-      def state(stock_location)
-        stock_location.active? ? 'active' : 'inactive'
       end
     end
   end

--- a/backend/app/views/spree/admin/stock_locations/index.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/index.html.erb
@@ -49,8 +49,14 @@
               <span class="handle"></span>
             <% end %>
           </td>
-          <td class="align-center"><%= display_name(stock_location) %></td>
-          <td class="align-center"><span class="state <%= state(stock_location) %>"><%= Spree.t(state(stock_location)) %></span></td>
+          <td class="align-center"><%= admin_stock_location_display_name(stock_location) %></td>
+          <td class="align-center">
+            <% if stock_location.active? %>
+              <span class="state active"><%= Spree.t('active') %></span>
+            <% else %>
+              <span class="state inactive"><%= Spree.t('inactive') %></span>
+            <% end %>
+          </td>
           <td class="align-center">
             <% if can?(:display, Spree::StockMovement) %>
               <%= link_to Spree::StockMovement.model_name.human(count: :other), admin_stock_location_stock_movements_path(stock_location.id) %>

--- a/backend/app/views/spree/admin/stock_transfers/_location.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/_location.html.erb
@@ -1,0 +1,7 @@
+<div class='location'>
+  <h5>
+    <span><%= admin_stock_location_display_name(stock_transfer.source_location) %></span>
+    <span class='arrow'>&rarr;</span>
+    <span><%= admin_stock_location_display_name(stock_transfer.destination_location) if stock_transfer.destination_location %></span>
+  </h5>
+</div>

--- a/backend/app/views/spree/admin/stock_transfers/receive.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/receive.html.erb
@@ -16,13 +16,7 @@
 <% end %>
 
 <div id='stock_transfer_summary' class='fullwidth'>
-  <div class='location'>
-    <span class='summary-field'>From:</span>
-    <span><%= @stock_transfer.source_location.admin_name %></span>
-    <span class='arrow'>&rarr;</span>
-    <span class='summary-field'>To:</span>
-    <span><%= @stock_transfer.destination_location.admin_name %></span>
-  </div>
+  <%= render 'spree/admin/stock_transfers/location', stock_transfer: @stock_transfer %>
   <div class='count-summary'>
     <span id='total-received-quantity'><%= @stock_transfer.received_item_count %></span>
     /

--- a/backend/app/views/spree/admin/stock_transfers/show.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/show.html.erb
@@ -9,13 +9,7 @@
 <% end %>
 
 <fieldset class="no-border-bottom">
-  <div class='location'>
-    <h6>
-      <span><%= @stock_transfer.source_location.admin_name %></span>
-      <span class='arrow'>&rarr;</span>
-      <span><%= @stock_transfer.destination_location.try!(:admin_name) %></span>
-    </h6>
-  </div>
+  <%= render 'spree/admin/stock_transfers/location', stock_transfer: @stock_transfer %>
 
   <div>
     <label><%= Spree::StockTransfer.human_attribute_name(:description) %></label>

--- a/backend/app/views/spree/admin/stock_transfers/tracking_info.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/tracking_info.html.erb
@@ -17,13 +17,7 @@
 <% end %>
 
 <div id='stock_transfer_summary' class='fullwidth'>
-  <div class='location'>
-    <h5>
-    <span><%= @stock_transfer.source_location.admin_name %></span>
-    <span class='arrow'>&rarr;</span>
-    <span><%= @stock_transfer.destination_location.admin_name %></span>
-    </h5>
-  </div>
+  <%= render 'spree/admin/stock_transfers/location', stock_transfer: @stock_transfer %>
   <div class='shipment-description'>
     <div class='summary-field creator'><%= Spree::StockTransfer.human_attribute_name(:created_by) %>: <%= @stock_transfer.created_by.email %></div>
     <div class='summary-field description'><%= @stock_transfer.description %></div>


### PR DESCRIPTION
Previously there were two helpers, `display_name` and `state`. By default, all helpers are available to all spree controllers (both frontend and backend). These names are obviously too generic so I have renamed the former `admin_stock_location_display_name` and removed the latter (which was much clearer inline in the one place it was used).

This also uses `admin_stock_location_display_name` in all of the stock transfer views to ensure that "source -> dest" is displayed consistently at the top of each page.
