### PR TITLE
Remove obsolete Adjustment attrs from API

### DIFF
--- a/api/app/helpers/spree/api/api_helpers.rb
+++ b/api/app/helpers/spree/api/api_helpers.rb
@@ -135,7 +135,7 @@ module Spree
 
       @@adjustment_attributes = [
         :id, :source_type, :source_id, :adjustable_type, :adjustable_id,
-        :originator_type, :originator_id, :amount, :label, :promotion_code,
+        :amount, :label, :promotion_code,
         :locked, :eligible, :created_at, :updated_at
       ]
 


### PR DESCRIPTION
`originator_type` and `originator_id` are no longer valid fields on
Adjustment.