### PR TITLE
Use tabs in user edit views

### DIFF
--- a/backend/app/views/spree/admin/store_credits/edit_amount.html.erb
+++ b/backend/app/views/spree/admin/store_credits/edit_amount.html.erb
@@ -2,7 +2,8 @@
   <%= link_to "#{Spree.t(:editing_user)} #{@user.email}", edit_admin_user_url(@user) %>
 <% end %>
 
-<%= render :partial => 'spree/admin/users/sidebar', :locals => { :current => :store_credits } %>
+<%= render 'spree/admin/users/sidebar' %>
+<%= render 'spree/admin/users/tabs', current: :store_credits %>
 <% content_for :page_actions do %>
   <li><%= link_to_with_icon 'arrow-left', Spree.t("admin.store_credits.back_to_edit"), admin_user_store_credit_path(@user, @store_credit), class: 'button' %></li>
 <% end %>

--- a/backend/app/views/spree/admin/store_credits/edit_validity.html.erb
+++ b/backend/app/views/spree/admin/store_credits/edit_validity.html.erb
@@ -2,7 +2,8 @@
   <%= link_to "#{Spree.t(:editing_user)} #{@user.email}", edit_admin_user_url(@user) %>
 <% end %>
 
-<%= render :partial => 'spree/admin/users/sidebar', :locals => { :current => :store_credits } %>
+<%= render 'spree/admin/users/sidebar' %>
+<%= render 'spree/admin/users/tabs', current: :store_credits %>
 <% content_for :page_actions do %>
   <li><%= link_to_with_icon 'arrow-left', Spree.t("admin.store_credits.back_to_edit"), admin_user_store_credit_path(@user, @store_credit), class: 'button' %></li>
 <% end %>

--- a/backend/app/views/spree/admin/store_credits/index.html.erb
+++ b/backend/app/views/spree/admin/store_credits/index.html.erb
@@ -2,7 +2,8 @@
   <%= link_to "#{Spree.t(:editing_user)} #{@user.email}", edit_admin_user_url(@user) %>
 <% end %>
 
-<%= render :partial => 'spree/admin/users/sidebar', :locals => { :current => :store_credits } %>
+<%= render 'spree/admin/users/sidebar' %>
+<%= render 'spree/admin/users/tabs', current: :store_credits %>
 <% content_for :page_actions do %>
   <li><%= link_to_with_icon 'arrow-left', Spree.t("admin.store_credits.back_to_user_list"), admin_users_path, class: 'button' %></li>
   <% if can?(:create, Spree::StoreCredit) %>

--- a/backend/app/views/spree/admin/store_credits/new.html.erb
+++ b/backend/app/views/spree/admin/store_credits/new.html.erb
@@ -2,7 +2,8 @@
   <%= link_to "#{Spree.t(:editing_user)} #{@user.email}", edit_admin_user_url(@user) %>
 <% end %>
 
-<%= render :partial => 'spree/admin/users/sidebar', :locals => { :current => :store_credits } %>
+<%= render 'spree/admin/users/sidebar' %>
+<%= render 'spree/admin/users/tabs', current: :store_credits %>
 <% content_for :page_actions do %>
   <li><%= link_to_with_icon 'arrow-left', Spree.t("admin.store_credits.back_to_store_credit_list"), admin_user_store_credits_path(@user), class: 'button' %></li>
 <% end %>

--- a/backend/app/views/spree/admin/store_credits/show.html.erb
+++ b/backend/app/views/spree/admin/store_credits/show.html.erb
@@ -2,7 +2,8 @@
   <%= link_to "#{Spree.t(:editing_user)} #{@user.email}", edit_admin_user_url(@user) %>
 <% end %>
 
-<%= render :partial => 'spree/admin/users/sidebar', :locals => { :current => :store_credits } %>
+<%= render 'spree/admin/users/sidebar' %>
+<%= render 'spree/admin/users/tabs', current: :store_credits %>
 <% content_for :page_actions do %>
   <li><%= link_to_with_icon 'arrow-left', Spree.t("admin.store_credits.back_to_store_credit_list"), admin_user_store_credits_path(@user), class: 'button' %></li>
   <% if @store_credit.editable? && can?(:edit, @store_credit) %>

--- a/backend/app/views/spree/admin/users/_sidebar.html.erb
+++ b/backend/app/views/spree/admin/users/_sidebar.html.erb
@@ -1,37 +1,10 @@
 <% content_for :sidebar_title do %>
-  <%= Spree.t(:"admin.user.user_information") %>
+  <%= Spree.t(:lifetime_stats) %>
 <% end %>
 
 <% content_for :sidebar do %>
   <nav class="menu">
-    <ul data-hook="admin_user_tab_options">
-      <li<%== ' class="active"' if current == :account %>>
-        <%= link_to_with_icon 'user', Spree.t(:"admin.user.account"), spree.edit_admin_user_path(@user) %>
-      </li>
-      <% if can?(:addresses, @user) %>
-        <li<%== ' class="active"' if current == :address %>>
-          <%= link_to_with_icon 'user', Spree.t(:"admin.user.addresses"), spree.addresses_admin_user_path(@user) %>
-        </li>
-      <% end %>
-      <% if can?(:orders, @user) %>
-        <li<%== ' class="active"' if current == :orders %>>
-          <%= link_to_with_icon 'shopping-cart', Spree.t(:"admin.user.orders"), spree.orders_admin_user_path(@user) %>
-        </li>
-      <% end %>
-      <% if can?(:items, @user) %>
-        <li<%== ' class="active"' if current == :items %>>
-          <%= link_to_with_icon 'edit', Spree.t(:"admin.user.items"), spree.items_admin_user_path(@user) %>
-        </li>
-      <% end %>
-      <% if can?(:display, Spree::StoreCredit) %>
-        <li<%== ' class="active"' if current == :store_credits %>>
-          <%= link_to_with_icon 'money', Spree.t(:"admin.user.store_credit"), spree.admin_user_store_credits_path(@user) %>
-        </li>
-      <% end %>
-    </ul>
-
-    <fieldset data-hook="admin_user_lifetime_stats">
-      <legend><%= Spree.t(:lifetime_stats) %></legend>
+    <fieldset class='no-border-top' data-hook="admin_user_lifetime_stats">
       <dl id="user-lifetime-stats">
         <dt><%= Spree.t(:total_sales) %>:</dt>
           <dd><%= @user.display_lifetime_value.to_html %></dd>

--- a/backend/app/views/spree/admin/users/_tabs.html.erb
+++ b/backend/app/views/spree/admin/users/_tabs.html.erb
@@ -1,0 +1,29 @@
+<% content_for :tabs do %>
+  <nav>
+    <ul class='tabs' data-hook="admin_user_tab_options">
+      <li<%== ' class="active"' if current == :account %>>
+        <%= link_to_with_icon 'user', Spree.t(:"admin.user.account"), spree.edit_admin_user_path(@user) %>
+      </li>
+      <% if can?(:addresses, @user) %>
+        <li<%== ' class="active"' if current == :address %>>
+          <%= link_to_with_icon 'user', Spree.t(:"admin.user.addresses"), spree.addresses_admin_user_path(@user) %>
+        </li>
+      <% end %>
+      <% if can?(:orders, @user) %>
+        <li<%== ' class="active"' if current == :orders %>>
+          <%= link_to_with_icon 'shopping-cart', Spree.t(:"admin.user.orders"), spree.orders_admin_user_path(@user) %>
+        </li>
+      <% end %>
+      <% if can?(:items, @user) %>
+        <li<%== ' class="active"' if current == :items %>>
+          <%= link_to_with_icon 'edit', Spree.t(:"admin.user.items"), spree.items_admin_user_path(@user) %>
+        </li>
+      <% end %>
+      <% if can?(:display, Spree::StoreCredit) %>
+        <li<%== ' class="active"' if current == :store_credits %>>
+          <%= link_to_with_icon 'money', Spree.t(:"admin.user.store_credit"), spree.admin_user_store_credits_path(@user) %>
+        </li>
+      <% end %>
+    </ul>
+  </nav>
+<% end %>

--- a/backend/app/views/spree/admin/users/_tabs.html.erb
+++ b/backend/app/views/spree/admin/users/_tabs.html.erb
@@ -11,7 +11,7 @@
       <% end %>
       <% if can?(:orders, @user) %>
         <li<%== ' class="active"' if current == :orders %>>
-          <%= link_to_with_icon 'shopping-cart', Spree.t(:"admin.user.orders"), spree.orders_admin_user_path(@user) %>
+          <%= link_to_with_icon 'shopping-cart', Spree.t(:"admin.user.order_history"), spree.orders_admin_user_path(@user) %>
         </li>
       <% end %>
       <% if can?(:items, @user) %>

--- a/backend/app/views/spree/admin/users/addresses.html.erb
+++ b/backend/app/views/spree/admin/users/addresses.html.erb
@@ -2,7 +2,8 @@
   <%= link_to "#{Spree.t(:editing_user)} #{@user.email}", edit_admin_user_url(@user) %>
 <% end %>
 
-<%= render :partial => 'spree/admin/users/sidebar', :locals => { :current => :address } %>
+<%= render 'spree/admin/users/sidebar' %>
+<%= render 'spree/admin/users/tabs', current: :address %>
 <%= render :partial => 'spree/admin/users/user_page_actions' %>
 
 <fieldset data-hook="admin_user_addresses" id="admin_user_edit_addresses" class="alpha twelve columns">

--- a/backend/app/views/spree/admin/users/edit.html.erb
+++ b/backend/app/views/spree/admin/users/edit.html.erb
@@ -2,7 +2,8 @@
   <%= link_to "#{Spree.t(:editing_user)} #{@user.email}", edit_admin_user_url(@user) %>
 <% end %>
 
-<%= render :partial => 'spree/admin/users/sidebar', :locals => { :current => :account } %>
+<%= render 'spree/admin/users/sidebar' %>
+<%= render 'spree/admin/users/tabs', current: :account %>
 <%= render :partial => 'spree/admin/users/user_page_actions' %>
 
 <fieldset data-hook="admin_user_edit_general_settings" class="alpha twelve columns">

--- a/backend/app/views/spree/admin/users/items.html.erb
+++ b/backend/app/views/spree/admin/users/items.html.erb
@@ -2,7 +2,8 @@
   <%= link_to "#{Spree.t(:"admin.user.items_purchased")} #{@user.email}", edit_admin_user_url(@user) %>
 <% end %>
 
-<%= render :partial => 'spree/admin/users/sidebar', :locals => { :current => :items } %>
+<%= render 'spree/admin/users/sidebar' %>
+<%= render 'spree/admin/users/tabs', current: :items %>
 <%= render :partial => 'spree/admin/users/user_page_actions' %>
 
 <fieldset data-hook="admin_user_items_purchased" class="alpha twelve columns">

--- a/backend/app/views/spree/admin/users/orders.html.erb
+++ b/backend/app/views/spree/admin/users/orders.html.erb
@@ -2,7 +2,8 @@
   <%= link_to "#{Spree.t(:"admin.user.order_history")} #{@user.email}", edit_admin_user_url(@user) %>
 <% end %>
 
-<%= render :partial => 'spree/admin/users/sidebar', :locals => { :current => :orders } %>
+<%= render 'spree/admin/users/sidebar' %>
+<%= render 'spree/admin/users/tabs', current: :orders %>
 <%= render :partial => 'spree/admin/users/user_page_actions' %>
 
 <fieldset data-hook="admin_user_order_history" class="alpha twelve columns">

--- a/backend/spec/features/admin/users_spec.rb
+++ b/backend/spec/features/admin/users_spec.rb
@@ -41,7 +41,7 @@ describe 'Users', type: :feature do
     end
 
     it 'can navigate to the order history' do
-      expect(page).to have_link Spree.t(:"admin.user.orders"), href: spree.orders_admin_user_path(user_a)
+      expect(page).to have_link Spree.t(:"admin.user.order_history"), href: spree.orders_admin_user_path(user_a)
     end
 
     it 'can navigate to the items purchased' do
@@ -201,7 +201,7 @@ describe 'Users', type: :feature do
     before do
       orders
       click_link user_a.email
-      within("#sidebar") { click_link Spree.t(:"admin.user.orders") }
+      within(".tabs") { click_link Spree.t(:"admin.user.order_history") }
     end
 
     it_behaves_like 'a user page'
@@ -231,7 +231,7 @@ describe 'Users', type: :feature do
     before do
       orders
       click_link user_a.email
-      within("#sidebar") { click_link Spree.t(:"admin.user.items") }
+      within(".tabs") { click_link Spree.t(:"admin.user.items") }
     end
 
     it_behaves_like 'a user page'


### PR DESCRIPTION
To continue implementing the great work @graygilmore did in #870 @Mandily got me to add tabs to these views.  A small change and it just works.  

### No tabs

![user_no_tabs](https://cloud.githubusercontent.com/assets/12613649/15332069/012c259a-1c19-11e6-8c41-2c4881cbc204.png)

### Tabs

![user_tabs](https://cloud.githubusercontent.com/assets/12613649/15332068/ffe86676-1c18-11e6-88fa-ec30cf4c7016.png)