### PR TITLE
fix loader vertical position (centering)

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/components/_progress.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_progress.scss
@@ -3,6 +3,7 @@
   position: fixed;
   top: 0;
   right: 0;
+  bottom: 0;
   z-index: 1000;
   opacity: 0.8;
   @include calc(width, "100% - #{$width-sidebar}");
@@ -10,9 +11,12 @@
   .wrapper {
     border-radius: 10px;
     position: absolute;
+    top: 50%;
     left: 50%;
     width: 200px;
+    height: 100px;
     margin-left: -100px;
+    margin-top: -50px;
     padding: 11px 0;
     background-color: $color-3;
     color: $color-1;


### PR DESCRIPTION
I think that loader position was a little imperfect, almost seems like a bug without a vertical position/margin. So I thought that vertical centering was a good solution..but if there are better ideas I’m willing to implement them

#### Before:

![schermata 2016-05-18 alle 14 29 55](https://cloud.githubusercontent.com/assets/1180256/15358521/23b0e91a-1d05-11e6-9a83-a275b8655186.png)

#### After:

![schermata 2016-05-18 alle 14 29 33](https://cloud.githubusercontent.com/assets/1180256/15358568/504c2138-1d05-11e6-96fb-4090a1f5d27c.png)

