### PR TITLE
Select results highlighted

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/templates/orders/customer_details/autocomplete.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/orders/customer_details/autocomplete.hbs
@@ -1,6 +1,6 @@
 <div class='customer-autocomplete-item'>
   <div class='customer-details'>
-    <h5>{{customer.email}}</h5>
+    <h5 class="customer-email">{{customer.email}}</h5>
     {{#if bill_address.firstname }}
       <strong>{{t 'bill_address' }}</strong>
       {{bill_address.firstname}} {{bill_address.lastname}}<br>

--- a/backend/app/assets/javascripts/spree/backend/templates/variants/autocomplete.hbs.erb
+++ b/backend/app/assets/javascripts/spree/backend/templates/variants/autocomplete.hbs.erb
@@ -9,7 +9,7 @@
 
   <div class="media-body">
     <h6 class="media-heading">{{variant.name}}</h6>
-    <dl class="dl-collapse">
+    <dl class="media-content dl-collapse">
       {{#if variant.option_values}}
         {{#each variant.option_values}}
           <dt>{{this.option_type_presentation}}:</dt>

--- a/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
+++ b/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
@@ -134,6 +134,14 @@
       min-height: 22px;
       clear: both;
       overflow: auto;
+
+      .variant-autocomplete-item {
+        .media-content {
+          dd {
+            margin: 0;
+          }
+        }
+      }
     }
 
     &.select2-no-results, &.select2-searching {

--- a/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
+++ b/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
@@ -111,7 +111,8 @@
 }
 
 .select2-results {
-  padding-left: 0 !important;
+  margin: 4px 0;
+  padding: 0 4px;
 
   li {
     font-size: 85% !important;

--- a/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
+++ b/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
@@ -123,7 +123,7 @@
 
     &.select2-highlighted {
       .select2-result-label {
-        &, h6 {
+        &, .media-heading, .media-content {
           color: $color-1 !important;
         }
       }

--- a/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
+++ b/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
@@ -123,7 +123,7 @@
 
     &.select2-highlighted {
       .select2-result-label {
-        &, .media-heading, .media-content {
+        &, .media-heading, .media-content, .customer-email {
           color: $color-1 !important;
         }
       }


### PR DESCRIPTION
I fixed some little visual defects on search results like:

* Color of result text highlighted
* Outside spacing
* Margin of inner elements

#### Before

![schermata 2016-05-18 alle 16 30 13](https://cloud.githubusercontent.com/assets/1180256/15389377/d58574d8-1db6-11e6-9085-8fe26a7c8204.png)

![schermata 2016-05-18 alle 16 25 27](https://cloud.githubusercontent.com/assets/1180256/15389438/39cb5854-1db7-11e6-9d64-9218959030ab.png)

#### After 

![schermata 2016-05-19 alle 11 34 42](https://cloud.githubusercontent.com/assets/1180256/15389380/dac5d712-1db6-11e6-8301-6f0aae83b5d9.png)

![schermata 2016-05-19 alle 11 46 19](https://cloud.githubusercontent.com/assets/1180256/15389457/59479d5a-1db7-11e6-8438-86d1e3906f98.png)
