### PR TITLE
Remove useless stub of pending_payments in a spec

### DIFF
--- a/core/spec/models/spree/order/payment_spec.rb
+++ b/core/spec/models/spree/order/payment_spec.rb
@@ -45,7 +45,6 @@ module Spree
       it "does not use failed payments" do
         payment_1 = create(:payment, amount: 50)
         payment_2 = create(:payment, amount: 50, state: 'failed')
-        allow(order).to receive(:pending_payments).and_return([payment_1])
 
         expect(payment_2).not_to receive(:process!)
 


### PR DESCRIPTION
This method has been removed with [this commit](https://github.com/solidusio/solidus/commit/c90d5d675109ba36f78a8ac6069bb3ae4b1c8996) but it is still present in the payment spec.