### PR TITLE
Extract methods inStock::Coordinator#stock_location_variant_ids

### DIFF
--- a/core/app/models/spree/stock/coordinator.rb
+++ b/core/app/models/spree/stock/coordinator.rb
@@ -79,32 +79,33 @@ module Spree
       # queries that are kept as performant as possible, and only loads the
       # minimum required ActiveRecord objects.
       def stock_location_variant_ids
-        # associate the variant ids we're interested in with stock location ids
-        location_variant_ids = StockItem.
-          where(variant_id: unallocated_variant_ids).
-          joins(:stock_location).
-          merge(StockLocation.active).
-          pluck(:stock_location_id, :variant_id)
-
-        # load activerecord objects for the stock location ids and turn them
-        # into a lookup hash like:
-        #   {
-        #     <stock location id> => <stock location>,
-        #     ...,
-        #   }
-        location_lookup = StockLocation.
-          where(id: location_variant_ids.map(&:first).uniq).
-          map { |l| [l.id, l] }.
-          to_h
-
-        # build the final lookup hash of
-        #   {<stock location> => <set of variant ids>, ...}
-        # using the previous results
         location_variant_ids.each_with_object({}) do |(location_id, variant_id), hash|
           location = location_lookup[location_id]
           hash[location] ||= Set.new
           hash[location] << variant_id
         end
+      end
+
+      # associate the variant ids we're interested in with stock location ids
+      def location_variant_ids
+        StockItem.
+          where(variant_id: unallocated_variant_ids).
+          joins(:stock_location).
+          merge(StockLocation.active).
+          pluck(:stock_location_id, :variant_id)
+      end
+
+      # load activerecord objects for the stock location ids and turn them
+      # into a lookup hash like:
+      #   {
+      #     <stock location id> => <stock location>,
+      #     ...,
+      #   }
+      def location_lookup
+        StockLocation.
+          where(id: location_variant_ids.map(&:first).uniq).
+          map { |l| [l.id, l] }.
+          to_h
       end
 
       def unallocated_inventory_units


### PR DESCRIPTION
Breaks up Spree::Stock::Coordinator#stock_location_variant_ids into smaller methods that are easier to override.

My goal here is to be able to use a decorator to modify the query in `location_variant_ids` (I want to retrieve only stock items that haven't been reserved by some other user) without having to bring all of `stock_location_variant_ids` into my decorator.