### PR TITLE
Validate currency on Spree::Price

### DIFF
--- a/core/app/models/spree/price.rb
+++ b/core/app/models/spree/price.rb
@@ -12,6 +12,8 @@ module Spree
       less_than_or_equal_to: MAXIMUM_AMOUNT
     }
 
+    validates :currency, inclusion: { in: ::Money::Currency.all.map(&:iso_code), message: :invalid_code }
+
     scope :currently_valid, -> { where(is_default: true) }
     scope :with_default_attributes, -> { where(Spree::Config.default_pricing_options.desired_attributes) }
     after_save :set_default_price

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -523,6 +523,10 @@ en:
           attributes:
             currency:
               must_match_order_currency: "Must match order currency"
+        spree/price:
+          attributes:
+            currency:
+              invalid_code: "is not a valid currency code"
         spree/promotion:
           attributes:
             apply_automatically:

--- a/core/spec/models/spree/price_spec.rb
+++ b/core/spec/models/spree/price_spec.rb
@@ -39,4 +39,28 @@ describe Spree::Price, type: :model do
       it { is_expected.to be_valid }
     end
   end
+
+  describe "#currency" do
+    let(:variant) { stub_model Spree::Variant }
+    subject { Spree::Price.new variant: variant, amount: 10, currency: currency }
+
+    describe "validation" do
+      context "with an invalid currency" do
+        let(:currency) { "XYZ" }
+
+        it { is_expected.to be_invalid }
+
+        it "has an understandable error message" do
+          subject.valid?
+          expect(subject.errors.messages[:currency].first).to eq("is not a valid currency code")
+        end
+      end
+
+      context "with a valid currency" do
+        let(:currency) { "USD" }
+
+        it { is_expected.to be_valid }
+      end
+    end
+  end
 end


### PR DESCRIPTION
Currently, the currency of a Spree::Price instance can be set to anything, and the price object won't validate it. 

This commit changes this so that only the currencies the Ruby Money library knows are accepted.
