### PR TITLE
One-click Heroku demo button

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ custom frontend instead of using [`solidus_frontend`](https://github.com/solidus
 [![Gem](https://img.shields.io/gem/v/solidus.svg)](https://rubygems.org/gems/solidus)
 [![License](http://img.shields.io/badge/license-BSD-yellowgreen.svg)](LICENSE.md)
 
+Demo
+----
+Try out Solidus with one-click on Heroku:
+
+[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy?template=https://github.com/solidusio/solidus)
+
 Getting started
 ---------------
 

--- a/app.json
+++ b/app.json
@@ -1,0 +1,29 @@
+{
+  "name": "Solidus Sandbox",
+  "description": "A demonstration store using Solidus with some test data.",
+  "repository": "https://github.com/solidusio/solidus",
+  "logo": "http://solidus.io/favicon.ico",
+  "keywords": [
+    "solidus",
+    "demo"
+  ],
+  "buildpacks": [
+    {"url": "https://github.com/solidusio/heroku-buildpack-solidus-demo.git"}
+  ],
+  "addons": [
+    "heroku-postgresql:hobby-dev"
+  ],
+  "scripts": {
+    "postdeploy": "rake db:migrate && rake db:seed spree_sample:load && rails runner Spree::Image.destroy_all"
+  },
+  "env": {
+    "ADMIN_EMAIL": {
+      "description": "We will create an admin user with this email.",
+      "value": "admin@example.com"
+    },
+    "ADMIN_PASSWORD": {
+      "description": "We will create an admin user with this password.",
+      "value": "test123"
+    }
+  }
+}


### PR DESCRIPTION
Building on top of @alexblackie's great work in #1136

This uses a modified heroku ruby buildpack to generate a sandbox application for deploy. https://github.com/solidusio/heroku-buildpack-solidus-demo/commit/1f7500a29f07189d1f413d8e6b948f1af4db169d. This is a bit of a hack but it doesn't require us to have additional infrastructure and we should be able to create demos of arbitrary github repos and branches!

Also improved from #1136 is that we now ask for an admin username and password when creating the app on heroku.