### PR TITLE
Improve mailer previews DB sampling

### DIFF
--- a/core/lib/spree/mailer_previews/carton_preview.rb
+++ b/core/lib/spree/mailer_previews/carton_preview.rb
@@ -2,7 +2,8 @@ module Spree
   class MailerPreviews
     class CartonPreview < ActionMailer::Preview
       def shipped
-        carton = Carton.first
+        carton = Carton.joins(:orders).last
+        raise "Your database needs at one shipped order with a carton to render this preview" unless carton
         Spree::Config.carton_shipped_email_class.shipped_email(order: carton.orders.first, carton: carton)
       end
     end

--- a/core/lib/spree/mailer_previews/order_preview.rb
+++ b/core/lib/spree/mailer_previews/order_preview.rb
@@ -2,15 +2,20 @@ module Spree
   class MailerPreviews
     class OrderPreview < ActionMailer::Preview
       def confirm
-        OrderMailer.confirm_email(Order.first)
+        order = Order.complete.last
+        raise "Your database needs at least one completed order to render this preview" unless order
+        OrderMailer.confirm_email(order)
       end
 
       def cancel
-        OrderMailer.cancel_email(Order.first)
+        order = Order.with_state(:canceled).last
+        raise "Your database needs at least one cancelled order to render this preview" unless order
+        OrderMailer.cancel_email(order)
       end
 
       def inventory_cancellation
-        order = Order.first
+        order = Spree::Order.joins(:inventory_units).merge(Spree::InventoryUnit.canceled).last
+        raise "Your database needs at least one order with a canceled inventory unit to render this preview" unless order
         OrderMailer.inventory_cancellation_email(order, [order.inventory_units.first])
       end
     end

--- a/core/lib/spree/mailer_previews/reimbursement_preview.rb
+++ b/core/lib/spree/mailer_previews/reimbursement_preview.rb
@@ -2,7 +2,9 @@ module Spree
   class MailerPreviews
     class ReimbursementPreview < ActionMailer::Preview
       def reimbursement
-        ReimbursementMailer.reimbursement_email(Reimbursement.first)
+        reimbursement = Reimbursement.last
+        raise "Your database needs at least one Reimbursement to render this preview" unless reimbursement
+        ReimbursementMailer.reimbursement_email(reimbursement)
       end
     end
   end


### PR DESCRIPTION
Previously these mailer previews just found the first object in the database and used that to render the preview.

Now they make an effort to find a suitable record in the DB (completed/cancelled order, etc.) and raise an understandable error if there is none to be found.

This also now finds the _last_ matching item in the database, which should allow a developer to, for example, cancel an order and then work on what the cancellation email would look like.

cc @Sinetheta @alexblackie 