### PR TITLE
Disable Rubocop trailing comma rules

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -85,6 +85,12 @@ Style/IndentHash:
 Style/AlignHash:
   Enabled: false
 
+Style/TrailingCommaInArguments:
+  Enabled: false
+
+Style/TrailingCommaInLiteral:
+  Enabled: false
+
 # From http://relaxed.ruby.style/
 
 Style/Alias:


### PR DESCRIPTION
Personally I like trailing commas, but more than that this just seems
like something that we don't need to make people worry about.