### PR TITLE
Configurable Spree::Config.stock.coordinator_class

### DIFF
--- a/core/app/models/spree/exchange.rb
+++ b/core/app/models/spree/exchange.rb
@@ -20,7 +20,7 @@ module Spree
 
     def perform!
       begin
-        shipments = Spree::Stock::Coordinator.new(@order, @reimbursement_objects.map(&:build_exchange_inventory_unit)).shipments
+        shipments = Spree::Config.stock.coordinator_class.new(@order, @reimbursement_objects.map(&:build_exchange_inventory_unit)).shipments
       rescue Spree::Order::InsufficientStock
         raise UnableToCreateShipments.new("Could not generate shipments for all items. Out of stock?")
       end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -505,7 +505,7 @@ module Spree
       else
         adjustments.shipping.destroy_all
         shipments.destroy_all
-        self.shipments = Spree::Stock::Coordinator.new(self).shipments
+        self.shipments = Spree::Config.stock.coordinator_class.new(self).shipments
       end
     end
 

--- a/core/lib/spree/core/stock_configuration.rb
+++ b/core/lib/spree/core/stock_configuration.rb
@@ -1,7 +1,13 @@
 module Spree
   module Core
     class StockConfiguration
+      attr_writer :coordinator_class
       attr_writer :estimator_class
+
+      def coordinator_class
+        @coordinator_class ||= '::Spree::Stock::Coordinator'
+        @coordinator_class.constantize
+      end
 
       def estimator_class
         @estimator_class ||= '::Spree::Stock::Estimator'

--- a/core/spec/lib/spree/core/stock_configuration_spec.rb
+++ b/core/spec/lib/spree/core/stock_configuration_spec.rb
@@ -1,6 +1,23 @@
 require 'spec_helper'
 
 RSpec.describe Spree::Core::StockConfiguration do
+  describe '#coordinator_class' do
+    let(:stock_configuration) { described_class.new }
+    subject { stock_configuration.coordinator_class }
+
+    it "returns Spree::Stock::Coordinator" do
+      is_expected.to be ::Spree::Stock::Coordinator
+    end
+
+    context "with another constant name assiged" do
+      MyCoordinator = Class.new
+      before { stock_configuration.coordinator_class = MyCoordinator.to_s }
+
+      it "returns the constant" do
+        is_expected.to be MyCoordinator
+      end
+    end
+  end
   describe '#estimator_class' do
     let(:stock_configuration) { described_class.new }
     subject { stock_configuration.estimator_class }


### PR DESCRIPTION
Provides the option of cleanly replacing Spree::Stock::Coordinator with a custom coordinator class.

```ruby
Spree::Config.stock.coordinator_class = MyShop::Stock::Coordinator

module MyShop
  module Stock 
    class Coordinator < Spree::Stock::Coordinator
      def stock_location_variant_ids
        ...
      end
    end
  end
end
```

Replaces #1168.