### PR TITLE
Remove is_default Boolean from prices

### DIFF
--- a/backend/app/views/spree/admin/prices/_table.html.erb
+++ b/backend/app/views/spree/admin/prices/_table.html.erb
@@ -4,7 +4,6 @@
   <thead data-hook="prices_header">
     <tr>
       <th><%= Spree::Variant.model_name.human %> </th>
-      <th><%= Spree::Price.human_attribute_name(:is_default) %></th>
       <th><%= Spree::Price.human_attribute_name(:amount) %></th>
       <th><%= Spree::Price.human_attribute_name(:currency) %></th>
       <th class="actions"></th>
@@ -16,13 +15,6 @@
     <tr id="<%= spree_dom_id price %>" data-hook="prices_row" class="<%= "deleted" if price.deleted? %> <%= cycle('odd', 'even')%>">
       <td class="align-center">
         <%= price.variant.descriptive_name %>
-      </td>
-      <td class="align-center">
-        <% if price.is_default? %>
-          <span class="state complete"> <%= Spree.t(:say_yes) %> </span>
-        <% else %>
-          <span class="state canceled"> <%= Spree.t(:say_no) %> </span>
-        <% end %>
       </td>
       <td class="align-center"><%= price.money.to_html %></td>
       <td class="align-center"><%= price.currency %></td>

--- a/backend/spec/features/admin/products/pricing_spec.rb
+++ b/backend/spec/features/admin/products/pricing_spec.rb
@@ -63,7 +63,7 @@ describe 'Pricing' do
     context "deleting", js: true do
       let(:product) { create(:product, price: 65.43) }
       let!(:variant) { product.master }
-      let!(:other_price) { product.master.prices.create(amount: 34.56, is_default: false) }
+      let!(:other_price) { product.master.prices.create(amount: 34.56, currency: "EUR") }
 
       it "will delete the non-default price" do
         within "#spree_price_#{other_price.id}" do

--- a/core/app/models/spree/price.rb
+++ b/core/app/models/spree/price.rb
@@ -15,9 +15,9 @@ module Spree
 
     validates :currency, inclusion: { in: ::Money::Currency.all.map(&:iso_code), message: :invalid_code }
 
-    scope :currently_valid, -> { where(is_default: true) }
+    # This scope can and will be enhanced in the future
+    scope :currently_valid, -> { order(updated_at: :desc) }
     scope :with_default_attributes, -> { where(Spree::Config.default_pricing_options.desired_attributes) }
-    after_save :set_default_price
 
     extend DisplayMoney
     money_methods :amount, :price
@@ -42,13 +42,6 @@ module Spree
 
     def check_price
       self.currency ||= Spree::Config[:currency]
-    end
-
-    def set_default_price
-      if is_default?
-        other_default_prices = variant.prices.currently_valid.where(pricing_options.desired_attributes).where.not(id: id)
-        other_default_prices.update_all(is_default: false)
-      end
     end
 
     def pricing_options

--- a/core/db/migrate/20160524152758_remove_is_default_from_prices.rb
+++ b/core/db/migrate/20160524152758_remove_is_default_from_prices.rb
@@ -1,0 +1,5 @@
+class RemoveIsDefaultFromPrices < ActiveRecord::Migration
+  def change
+    remove_column :spree_prices, :is_default, :boolean, default: true
+  end
+end

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -157,9 +157,7 @@ describe Spree::Variant, type: :model do
   context "#default_price" do
     context "when multiple prices are present in addition to a default price" do
       before do
-        variant.prices << create(:price, variant: variant, currency: "USD", amount: 12.12, is_default: false)
-        variant.prices << create(:price, variant: variant, currency: "EUR", amount: 29.99)
-        variant.prices << create(:price, variant: variant, currency: "EUR", amount: 10.00, is_default: false)
+        variant.prices.create(currency: "EUR", amount: 29.99)
         variant.reload
       end
 
@@ -176,7 +174,7 @@ describe Spree::Variant, type: :model do
     context "when adding multiple prices" do
       it "it can reassign a default price" do
         expect(variant.default_price.amount).to eq(19.99)
-        variant.prices << create(:price, variant: variant, currency: "USD", amount: 12.12)
+        variant.prices.create(currency: "USD", amount: 12.12)
         expect(variant.reload.default_price.amount).to eq(12.12)
       end
     end


### PR DESCRIPTION
This boolean is either a very bare-bones version of `acts_as_paranoid` or
a very bare-bones version of `papertrail`. However: It's really badly named,
as `is_default` is not something I understand very well at all.

We can accomplish the same behavior by simply using an `order` clause in
the `currently_valid` scope on prices.