### PR TITLE
Spree::Config.send_core_emails supports :only and :except

### DIFF
--- a/core/app/mailers/spree/base_mailer.rb
+++ b/core/app/mailers/spree/base_mailer.rb
@@ -15,7 +15,30 @@ module Spree
     helper_method :money
 
     def mail(headers = {}, &block)
-      super if Spree::Config[:send_core_emails]
+      super if should_send_mail?
+    end
+
+    private
+
+    def should_send_mail?
+      pref = Spree::Config[:send_core_emails]
+
+      if pref == true || pref == false
+        return pref
+      end
+
+      # let preference be expressed without the Spree:: prefix for convenience
+      class_names = [self.class.name.sub(/\ASpree::/, ''), self.class.name]
+
+      if pref[:only].present? && (pref[:only] & class_names).empty?
+        return false
+      end
+
+      if pref[:except].present? && (pref[:except] & class_names).present?
+        return false
+      end
+
+      !!pref
     end
   end
 end

--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -249,8 +249,10 @@ module Spree
     # Default mail headers settings
 
     # @!attribute [rw] send_core_emails
-    #   @return [Boolean] Whether to send transactional emails (default: true)
-    preference :send_core_emails, :boolean, default: true
+    #   Whether to send transactional emails. Can be true or false,
+    #   or a hash with :only or :except.
+    #   @return Boolean or hash config on whether to send transactional emails (default: true)
+    preference :send_core_emails, :object, default: true
 
     # @!attribute [rw] mails_from
     #   @return [String] Email address used as +From:+ field in transactional emails.

--- a/core/spec/mailers/base_mailer_spec.rb
+++ b/core/spec/mailers/base_mailer_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+require 'email_spec'
+
+describe Spree::OrderMailer, type: :mailer do
+  include EmailSpec::Helpers
+  include EmailSpec::Matchers
+
+  context "preference :send_core_emails" do
+    let(:carton) { create(:carton) }
+    let(:order) { carton.orders.first }
+
+    shared_examples "sent mail" do
+      it "sends email" do
+        expect(subject.message).not_to be_kind_of(ActionMailer::Base::NullMail)
+        expect(subject.body.present? || (subject.parts && subject.parts.all?(&:present?)))
+      end
+    end
+
+    shared_examples "not sent mail" do
+      it "does not send email" do
+        expect(subject.message).to be_kind_of(ActionMailer::Base::NullMail)
+        expect(subject.body.blank? && subject.parts.nil? || (subject.parts.present? && subject.parts.all?(&:blank?)))
+      end
+    end
+
+    context "with default preference :send_core_emails" do
+      subject { Spree::OrderMailer.confirm_email(order) }
+      it_behaves_like 'sent mail'
+    end
+
+    context "with preference :send_core_emails set to false" do
+      before do
+        Spree::Config.send_core_emails = false
+      end
+      subject { Spree::OrderMailer.confirm_email(order) }
+      it_behaves_like 'not sent mail'
+    end
+
+    context "with preference :send_core_emails :only" do
+      before do
+        Spree::Config.send_core_emails = { only: ['OrderMailer'] }
+      end
+      let(:carton) { create(:carton) }
+      describe "with a mailer listed" do
+        subject { Spree::OrderMailer.confirm_email(order) }
+        it_behaves_like 'sent mail'
+      end
+      describe 'with a mailer not listed' do
+        subject { Spree::CartonMailer.shipped_email(order: order, carton: carton) }
+        it_behaves_like 'not sent mail'
+      end
+    end
+
+    context "with preference :send_core_emails :except" do
+      before do
+        Spree::Config.send_core_emails = { except: ['OrderMailer'] }
+      end
+      let(:carton) { create(:carton) }
+      describe "with a mailer listed" do
+        subject { Spree::OrderMailer.confirm_email(order) }
+        it_behaves_like 'not sent mail'
+      end
+      describe "with a mailer not listed" do
+        subject { Spree::CartonMailer.shipped_email(order: order, carton: carton) }
+        it_behaves_like 'sent mail'
+      end
+    end
+  end
+end

--- a/core/spec/mailers/order_mailer_spec.rb
+++ b/core/spec/mailers/order_mailer_spec.rb
@@ -122,12 +122,4 @@ describe Spree::OrderMailer, type: :mailer do
       end
     end
   end
-
-  context "with preference :send_core_emails set to false" do
-    it "sends no email" do
-      Spree::Config.send_core_emails = false
-      message = Spree::OrderMailer.confirm_email(order)
-      expect(message.body).to be_blank
-    end
-  end
 end


### PR DESCRIPTION
Previously send_core_emails could be true or false. Now it
also supports a Hash with :only and/or :except, to turn off
mailing for certain Mailers only. 

The existing test for send_core_emails in order_mailer_spec
was actually a false positive, it would have returned
true even if send_core_emails=true, because a multi-part
email has no #body. The new specs have been moved to a
base_mailer_spec, and the one existing spec rewritten
to actually spec the right thing, with some kind of
hacky shared examples that seem to test actual situation
when #mail is called or not.