### PR TITLE
Update Rules::Taxon/Product handling of invalid match policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Solidus 1.4.0 (master, unreleased)
 
+*   Update Rules::Taxon/Product handling of invalid match policies
+
+    Rules::Taxon and Rules::Product now require valid match_policy values.
+    Please ensure that all your Taxon and Product Rules have valid match_policy
+    values.
+
 *   Fix default value for Spree::Promotion::Rules::Taxon preferred_match_policy.
 
     Previously this was defaulting to nil, which was sometimes interpreted as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Solidus 1.4.0 (master, unreleased)
 
+*   Fix default value for Spree::Promotion::Rules::Taxon preferred_match_policy.
+
+    Previously this was defaulting to nil, which was sometimes interpreted as
+    'none'.
+
 *   Deprecate `Spree::Shipment#address` (column renamed)
 
     `Spree::Shipment#address` was not actually being used for anything in

--- a/core/app/models/spree/promotion/rules/taxon.rb
+++ b/core/app/models/spree/promotion/rules/taxon.rb
@@ -7,7 +7,7 @@ module Spree
         has_many :taxons, through: :promotion_rule_taxons, class_name: 'Spree::Taxon'
 
         MATCH_POLICIES = %w(any all)
-        preference :match_policy, default: MATCH_POLICIES.first
+        preference :match_policy, :string, default: MATCH_POLICIES.first
 
         def applicable?(promotable)
           promotable.is_a?(Spree::Order)

--- a/core/spec/models/spree/promotion/rules/taxon_spec.rb
+++ b/core/spec/models/spree/promotion/rules/taxon_spec.rb
@@ -1,20 +1,18 @@
 require 'spec_helper'
 
 describe Spree::Promotion::Rules::Taxon, type: :model do
-  let(:rule) { Spree::Promotion::Rules::Taxon.create!(promotion: create(:promotion)) }
+  let(:rule) do
+    Spree::Promotion::Rules::Taxon.create!(promotion: create(:promotion))
+  end
 
-  context '#elegible?(order)' do
+  context '#eligible?(order)' do
     let(:taxon){ create :taxon, name: 'first' }
     let(:taxon2){ create :taxon, name: 'second' }
     let(:order){ create :order_with_line_items }
 
-    before do
-      rule.save
-    end
-
     context 'with any match policy' do
       before do
-        rule.preferred_match_policy = 'any'
+        rule.update!(preferred_match_policy: 'any')
       end
 
       it 'is eligible if order does have any prefered taxon' do
@@ -62,7 +60,7 @@ describe Spree::Promotion::Rules::Taxon, type: :model do
 
     context 'with all match policy' do
       before do
-        rule.preferred_match_policy = 'all'
+        rule.update!(preferred_match_policy: 'all')
       end
 
       it 'is eligible order has all prefered taxons' do


### PR DESCRIPTION
This is extracted from discussion in https://github.com/solidusio/solidus/pull/1113.
The goal is to make invalid match_policy values less likely and to
have consistent handling of invalid values should they occur.

For `Rules::Product`: We now raise an error for invalid match policies. This was already
happening in `Rules::Product#actionable?`, it just wasn't happening in
`Rules::Product#eligible`.

For `Rules::Taxon`: We now log a warning and assume it was meant to be an `any`
match policy.  I'm being more lenient here because `Rules::Taxon` had a bug
with the default value for match policies and assuming `any` is essentially
what the previous logic did.

Also:  Add validations to help avoid invalid values in the first place.
Also:  Fix the default value for Rules::Taxon#preferred_match_policy.

See individual commits.