### PR TITLE
Allow setting nil in preferences

### DIFF
--- a/core/app/models/spree/preferences/preferable.rb
+++ b/core/app/models/spree/preferences/preferable.rb
@@ -97,6 +97,7 @@ module Spree::Preferences::Preferable
   private
 
   def convert_preference_value(value, type)
+    return nil if value.nil?
     case type
     when :string, :text
       value.to_s

--- a/core/spec/models/spree/preferences/preferable_spec.rb
+++ b/core/spec/models/spree/preferences/preferable_spec.rb
@@ -117,6 +117,11 @@ describe Spree::Preferences::Preferable, type: :model do
         @a.set_preference(:is_integer, '')
         expect(@a.preferences[:is_integer]).to eq(0)
       end
+
+      it 'does not convert if value is nil' do
+        @a.set_preference(:is_integer, nil)
+        expect(@a.preferences[:is_integer]).to be_nil
+      end
     end
 
     context "converts decimal preferences to BigDecimal values" do


### PR DESCRIPTION
Previously, a nil value on an integer preference would .to_i to 0.

Leaving it as nil rather than casting it to an int makes more sense
and would be more in line with what I would expect to happen.

This came out of an issue I had in an upgrade from 1.2 to 1.3.

I wanted to nil out default_country_id and switch to default_country_iso, but as I was unable to set default_country_id to nil I was unable to switch:
https://github.com/solidusio/solidus/blob/master/core/app/models/spree/country.rb#L16