### PR TITLE
Improve I18n pluralization to avoid errors with some calculators

### DIFF
--- a/backend/app/views/spree/admin/adjustment_reasons/index.html.erb
+++ b/backend/app/views/spree/admin/adjustment_reasons/index.html.erb
@@ -1,7 +1,7 @@
 <%= render 'spree/admin/shared/settings_checkout_tabs' %>
 
 <% content_for :page_title do %>
-  <%= Spree::AdjustmentReason.model_name.human(count: :other) %>
+  <%= plural_resource_name(Spree::AdjustmentReason) %>
 <% end %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/customer_returns/edit.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/edit.html.erb
@@ -54,7 +54,7 @@
 <% end %>
 
 <fieldset data-hook="reimbursements" class="no-border-bottom align-center">
-  <legend align="center"><%= Spree::Reimbursement.model_name.human(count: :other) %></legend>
+  <legend align="center"><%= plural_resource_name(Spree::Reimbursement) %></legend>
   <% if @customer_return.reimbursements.any? %>
     <%= render partial: 'reimbursements_table', locals: {reimbursements: @customer_return.reimbursements} %>
   <% else %>

--- a/backend/app/views/spree/admin/customer_returns/index.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/index.html.erb
@@ -10,7 +10,7 @@
 <% end %>
 
 <% content_for :page_title do %>
-  <i class="fa fa-arrow-right"></i> <%= Spree::CustomerReturn.model_name.human(count: :other) %>
+  <i class="fa fa-arrow-right"></i> <%= plural_resource_name(Spree::CustomerReturn) %>
 <% end %>
 
 <% if @customer_returns.any? %>

--- a/backend/app/views/spree/admin/log_entries/index.html.erb
+++ b/backend/app/views/spree/admin/log_entries/index.html.erb
@@ -4,7 +4,7 @@
   <i class="fa fa-arrow-right"></i>
   <%= Spree::Payment.model_name.human %>
   <i class="fa fa-arrow-right"></i>
-  <%= Spree::LogEntry.model_name.human(count: :other) %>
+  <%= plural_resource_name(Spree::LogEntry) %>
 <% end %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/option_types/edit.html.erb
+++ b/backend/app/views/spree/admin/option_types/edit.html.erb
@@ -23,7 +23,7 @@
   </fieldset>
 
   <fieldset>
-    <legend><%= Spree::OptionValue.model_name.human(count: :other) %></legend>
+    <legend><%= plural_resource_name(Spree::OptionValue) %></legend>
     <table class="index sortable" data-hook data-sortable-link="<%= update_values_positions_admin_option_types_url %>">
       <thead data-hook="option_header">
         <tr>

--- a/backend/app/views/spree/admin/option_types/index.html.erb
+++ b/backend/app/views/spree/admin/option_types/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree::OptionType.model_name.human(count: :other) %>
+  <%= plural_resource_name(Spree::OptionType) %>
 <% end %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/orders/confirm/_payments.html.erb
+++ b/backend/app/views/spree/admin/orders/confirm/_payments.html.erb
@@ -1,5 +1,5 @@
 <fieldset class="no-border-bottom">
-  <legend><%= Spree::Payment.model_name.human(count: :other) %></legend>
+  <legend><%= plural_resource_name(Spree::Payment) %></legend>
   <table class="index">
     <thead>
       <tr data-hook="payments_header">

--- a/backend/app/views/spree/admin/payment_methods/index.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/index.html.erb
@@ -1,7 +1,7 @@
 <%= render 'spree/admin/shared/payments_tabs' %>
 
 <% content_for :page_title do %>
-  <%= Spree::PaymentMethod.model_name.human(count: :other) %>
+  <%= plural_resource_name(Spree::PaymentMethod) %>
 <% end %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/payments/_capture_events.html.erb
+++ b/backend/app/views/spree/admin/payments/_capture_events.html.erb
@@ -1,5 +1,5 @@
 <% if @payment.capture_events.exists? %>
-  <h3><%= Spree::PaymentCaptureEvent.model_name.human(count: :other) %></h3>
+  <h3><%= plural_resource_name(Spree::PaymentCaptureEvent) %></h3>
   <table class="index" id="capture_events">
     <thead>
       <tr data-hook="payments_header">

--- a/backend/app/views/spree/admin/payments/index.html.erb
+++ b/backend/app/views/spree/admin/payments/index.html.erb
@@ -10,7 +10,7 @@
 <% end %>
 
 <% content_for :page_title do %>
-  <i class="fa fa-arrow-right"></i> <%= Spree::Payment.model_name.human(count: :other) %>
+  <i class="fa fa-arrow-right"></i> <%= plural_resource_name(Spree::Payment) %>
 <% end %>
 
 <% if @order.outstanding_balance? %>
@@ -20,13 +20,13 @@
 <% if @payments.any? %>
 
   <fieldset data-hook="payment_list" class="no-border-bottom">
-    <legend align="center"><%= Spree::Payment.model_name.human(count: :other) %></legend>
+    <legend align="center"><%= plural_resource_name(Spree::Payment) %></legend>
     <%= render :partial => 'list', :locals => { :payments => @payments } %>
   </fieldset>
 
   <% if @refunds.any? %>
     <fieldset data-hook="payment_list" class="no-border-bottom">
-      <legend align="center"><%= Spree::Refund.model_name.human(count: :other) %></legend>
+      <legend align="center"><%= plural_resource_name(Spree::Refund) %></legend>
       <%= render :partial => 'spree/admin/shared/refunds', :locals => { :refunds => @refunds, show_actions: true } %>
     </fieldset>
   <% end %>

--- a/backend/app/views/spree/admin/product_properties/index.html.erb
+++ b/backend/app/views/spree/admin/product_properties/index.html.erb
@@ -18,7 +18,7 @@
 
 <%= form_for @product, :url => admin_product_url(@product), :method => :put do |f| %>
   <fieldset>
-    <legend align="center"><%= Spree::ProductProperty.model_name.human(count: :other) %></legend>
+    <legend align="center"><%= plural_resource_name(Spree::ProductProperty) %></legend>
     <div class="add_product_properties" data-hook="add_product_properties"></div>
 
     <div id="prototypes" data-hook></div>

--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -137,14 +137,14 @@
   <div class="twelve columns alpha omega">
     <div data-hook="admin_product_form_taxons">
       <%= f.field_container :taxons do %>
-        <%= f.label :taxon_ids, Spree::Taxon.model_name.human(count: :other) %><br />
+        <%= f.label :taxon_ids, plural_resource_name(Spree::Taxon) %><br />
         <%= f.hidden_field :taxon_ids, :value => @product.taxon_ids.join(',') %>
       <% end %>
     </div>
 
     <div data-hook="admin_product_form_option_types">
       <%= f.field_container :option_types do %>
-        <%= f.label :option_type_ids, Spree::OptionType.model_name.human(count: :other) %>
+        <%= f.label :option_type_ids, plural_resource_name(Spree::OptionType) %>
         <%= f.hidden_field :option_type_ids, :value => @product.option_type_ids.join(',') %>
       <% end %>
     </div>

--- a/backend/app/views/spree/admin/products/_properties_form.erb
+++ b/backend/app/views/spree/admin/products/_properties_form.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree::Property.model_name.human(count: :other) %>
+  <%= plural_resource_name(Spree::Property) %>
 <% end %>
 
 <% f.fields_for :product_properties do |properties_form| %>

--- a/backend/app/views/spree/admin/promotion_categories/index.html.erb
+++ b/backend/app/views/spree/admin/promotion_categories/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree::PromotionCategory.model_name.human(count: :many) %>
+  <%= plural_resource_name(Spree::PromotionCategory) %>
 <% end %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/promotions/_actions.html.erb
+++ b/backend/app/views/spree/admin/promotions/_actions.html.erb
@@ -3,7 +3,7 @@
   <%= form_tag spree.admin_promotion_promotion_actions_path(@promotion), :remote => true, :id => 'new_promotion_action_form' do %>
     <% options = options_for_select(  Rails.application.config.spree.promotions.actions.map(&:name).map {|name| [ Spree.t("promotion_action_types.#{name.demodulize.underscore}.name"), name] } ) %>
     <fieldset>
-      <legend align="center"><%= Spree::PromotionAction.model_name.human(count: :other) %></legend>
+      <legend align="center"><%= plural_resource_name(Spree::PromotionAction) %></legend>
       <% if can?(:update, @promotion) %>
         <div class="field">
           <%= label_tag :action_type, Spree.t(:add_action_of_type)%>

--- a/backend/app/views/spree/admin/promotions/index.html.erb
+++ b/backend/app/views/spree/admin/promotions/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree::Promotion.model_name.human(count: :other) %>
+  <%= plural_resource_name(Spree::Promotion) %>
 <% end %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/promotions/rules/_option_value.html.erb
+++ b/backend/app/views/spree/admin/promotions/rules/_option_value.html.erb
@@ -1,7 +1,7 @@
 <div class="field alpha omega eight columns promo-rule-option-values">
   <div class="param-prefix hidden" data-param-prefix="<%= param_prefix %>"></div>
   <div class="four columns alpha"><%= label_tag nil, Spree::Product.model_name.human %></div>
-  <div class="three columns omega"><%= label_tag nil, Spree::OptionValue.model_name.human(count: :other) %></div>
+  <div class="three columns omega"><%= label_tag nil, plural_resource_name(Spree::OptionValue) %></div>
   <div class="clear"></div>
 
   <div class="js-promo-rule-option-values"></div>

--- a/backend/app/views/spree/admin/properties/index.html.erb
+++ b/backend/app/views/spree/admin/properties/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree::Property.model_name.human(count: :other) %>
+  <%= plural_resource_name(Spree::Property) %>
 <% end %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/prototypes/_form.html.erb
+++ b/backend/app/views/spree/admin/prototypes/_form.html.erb
@@ -10,7 +10,7 @@
   <div class="four columns">
     <div id='properties' data-hook>
       <%= f.field_container :property_ids do %>
-        <%= f.label :property_ids, Spree::Property.model_name.human(count: :other) %><br>
+        <%= f.label :property_ids, plural_resource_name(Spree::Property) %><br>
         <%= f.select :property_ids, Spree::Property.all.map { |p| ["#{p.presentation} (#{p.name})", p.id] }, {}, { multiple: true, class: "select2 fullwidth" } %>
       <% end %>
     </div>
@@ -19,7 +19,7 @@
   <div class="four columns">
     <div id="option_types" data-hook>
       <%= f.field_container :option_type_ids do %>
-        <%= f.label :option_type_ids, Spree::OptionType.model_name.human(count: :other) %><br>
+        <%= f.label :option_type_ids, plural_resource_name(Spree::OptionType) %><br>
         <%= f.select :option_type_ids, Spree::OptionType.all.map { |ot| ["#{ot.presentation} (#{ot.name})", ot.id] }, {}, { multiple: true, class: "select2 fullwidth" } %>
       <% end %>
     </div>
@@ -28,7 +28,7 @@
   <div class="four columns omega">
     <div id='taxons' data-hook>
       <%= f.field_container :taxon_ids do %>
-        <%= f.label :taxon_ids, Spree::Taxon.model_name.human(count: :other) %><br>
+        <%= f.label :taxon_ids, plural_resource_name(Spree::Taxon) %><br>
         <%= f.select :taxon_ids, Spree::Taxon.all.map { |t| [t.name, t.id] }, {}, { multiple: true, class: "select2 fullwidth" } %>
       <% end %>
     </div>

--- a/backend/app/views/spree/admin/prototypes/index.html.erb
+++ b/backend/app/views/spree/admin/prototypes/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree::Prototype.model_name.human(count: :other) %>
+  <%= plural_resource_name(Spree::Prototype) %>
 <% end %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/prototypes/show.html.erb
+++ b/backend/app/views/spree/admin/prototypes/show.html.erb
@@ -1,5 +1,5 @@
 <% if @prototype.option_types.present? %>
-  <h2><%= Spree::Variant.model_name.human(count: :other) %></h2>
+  <h2><%= plural_resource_name(Spree::Variant) %></h2>
 
   <ul class="product-prototype-options">
     <% @prototype.option_types.each do |ot| %>
@@ -7,7 +7,7 @@
         <b>
           <%= check_box_tag "option_types[]", ot.id, (params[:option_types] || []).include?(ot.id.to_s), :id => "option_type_#{ot.id}", :class => "option-type" %>
           <%= label_tag "option_type_#{ot.id}", ot.presentation %>
-        </b>      
+        </b>
         <ul class="option-type-values">
         <% ot.option_values.each do |ov| %>
           <li>

--- a/backend/app/views/spree/admin/refund_reasons/index.html.erb
+++ b/backend/app/views/spree/admin/refund_reasons/index.html.erb
@@ -1,7 +1,7 @@
 <%= render 'spree/admin/shared/settings_checkout_tabs' %>
 
 <% content_for :page_title do %>
-  <%= Spree::RefundReason.model_name.human(count: :other) %>
+  <%= plural_resource_name(Spree::RefundReason) %>
 <% end %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/reimbursement_types/index.html.erb
+++ b/backend/app/views/spree/admin/reimbursement_types/index.html.erb
@@ -1,7 +1,7 @@
 <%= render 'spree/admin/shared/settings_checkout_tabs' %>
 
 <% content_for :page_title do %>
-  <%= Spree::ReimbursementType.model_name.human(count: :other) %>
+  <%= plural_resource_name(Spree::ReimbursementType) %>
 <% end %>
 
 <table class="index" id='listing_reimbursement_types' data-hook>

--- a/backend/app/views/spree/admin/reimbursements/index.html.erb
+++ b/backend/app/views/spree/admin/reimbursements/index.html.erb
@@ -1,7 +1,7 @@
 <%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Reimbursements' } %>
 
 <% content_for :page_title do %>
-  <i class="fa fa-arrow-right"></i> <%= Spree::Reimbursement.model_name.human(count: :other) %>
+  <i class="fa fa-arrow-right"></i> <%= plural_resource_name(Spree::Reimbursement) %>
 <% end %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/return_authorizations/index.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/index.html.erb
@@ -12,7 +12,7 @@
 <% end %>
 
 <% content_for :page_title do %>
-  <i class="fa fa-arrow-right"></i> <%= Spree::ReturnAuthorization.model_name.human(count: :other) %>
+  <i class="fa fa-arrow-right"></i> <%= plural_resource_name(Spree::ReturnAuthorization) %>
 <% end %>
 
 <% if @order.shipments.any?(&:shipped?) || @order.return_authorizations.any? %>

--- a/backend/app/views/spree/admin/return_reasons/index.html.erb
+++ b/backend/app/views/spree/admin/return_reasons/index.html.erb
@@ -1,5 +1,5 @@
 <%= render partial: 'spree/admin/shared/named_types/index', locals: {
-  page_title: Spree::ReturnReason.model_name.human(count: :other),
+  page_title: plural_resource_name(Spree::ReturnReason),
   new_button_text: Spree.t(:new_rma_reason),
   resource: Spree::ReturnReason
 } %>

--- a/backend/app/views/spree/admin/shared/_areas_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_areas_tabs.html.erb
@@ -2,16 +2,16 @@
   <nav>
     <ul class="tabs" data-hook="admin_settings_areas_tabs">
       <% if can? :display, Spree::Zone %>
-        <%= settings_tab_item Spree::Zone.model_name.human(count: :other), spree.admin_zones_path %>
+        <%= settings_tab_item plural_resource_name(Spree::Zone), spree.admin_zones_path %>
       <% end %>
 
       <% if can? :display, Spree::Country %>
-        <%= settings_tab_item Spree::Country.model_name.human(count: :other), spree.admin_countries_path %>
+        <%= settings_tab_item plural_resource_name(Spree::Country), spree.admin_countries_path %>
       <% end %>
 
       <% if can?(:display, Spree::State) %>
         <% if country = Spree::Country.find_by(iso: Spree::Config[:default_country_iso]) || Spree::Country.first %>
-          <%= settings_tab_item Spree::State.model_name.human(count: :other), spree.admin_country_states_path(country) %>
+          <%= settings_tab_item plural_resource_name(Spree::State), spree.admin_country_states_path(country) %>
         <% end %>
       <% end %>
     </ul>

--- a/backend/app/views/spree/admin/shared/_no_objects_found.html.erb
+++ b/backend/app/views/spree/admin/shared/_no_objects_found.html.erb
@@ -1,4 +1,4 @@
-<%= Spree.t(:no_resource, resource: resource.model_name.human(count: :other)) %>
+<%= Spree.t(:no_resource, resource: plural_resource_name(resource)) %>
 <% if can? :create, resource %>
   <%= link_to Spree.t(:create_one), new_resource_url %>
 <% end %>

--- a/backend/app/views/spree/admin/shared/_order_submenu.html.erb
+++ b/backend/app/views/spree/admin/shared/_order_submenu.html.erb
@@ -17,18 +17,18 @@
     <% end %>
 
     <li class="<%= "active" if current == "Shipments" %>" data-hook='admin_order_tabs_order_details'>
-      <%= link_to_with_icon 'edit', Spree::Shipment.model_name.human(count: :other), edit_admin_order_url(@order) %>
+      <%= link_to_with_icon 'edit', plural_resource_name(Spree::Shipment), edit_admin_order_url(@order) %>
     </li>
 
     <% if can? :display, Spree::Adjustment %>
       <li class="<%= "active" if current == "Adjustments" %>" data-hook='admin_order_tabs_adjustments'>
-        <%= link_to_with_icon 'cogs', Spree::Adjustment.model_name.human(count: :other), admin_order_adjustments_url(@order) %>
+        <%= link_to_with_icon 'cogs', plural_resource_name(Spree::Adjustment), admin_order_adjustments_url(@order) %>
       </li>
     <% end %>
 
     <% if can?(:display, Spree::Payment) %>
       <li class="<%= "active" if current == "Payments" %>" data-hook='admin_order_tabs_payments'>
-        <%= link_to_with_icon 'credit-card', Spree::Payment.model_name.human(count: :other), admin_order_payments_url(@order) %>
+        <%= link_to_with_icon 'credit-card', plural_resource_name(Spree::Payment), admin_order_payments_url(@order) %>
       </li>
     <% end %>
 
@@ -49,7 +49,7 @@
     <% if can? :display, Spree::CustomerReturn %>
       <% if @order.completed? %>
         <li class="<%= "active" if current == "Customer Returns" %>">
-          <%= link_to_with_icon 'download', Spree::CustomerReturn.model_name.human(count: :other), admin_order_customer_returns_url(@order) %>
+          <%= link_to_with_icon 'download', plural_resource_name(Spree::CustomerReturn), admin_order_customer_returns_url(@order) %>
         </li>
       <% end %>
     <% end %>

--- a/backend/app/views/spree/admin/shared/_payments_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_payments_tabs.html.erb
@@ -2,7 +2,7 @@
   <nav>
     <ul class="tabs" data-hook="admin_settings_payments_tabs">
       <% if can?(:display, Spree::PaymentMethod) %>
-        <%= settings_tab_item Spree::PaymentMethod.model_name.human(count: :other), spree.admin_payment_methods_path %>
+        <%= settings_tab_item plural_resource_name(Spree::PaymentMethod), spree.admin_payment_methods_path %>
       <% end %>
     </ul>
   </nav>

--- a/backend/app/views/spree/admin/shared/_product_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_product_tabs.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree::Product.model_name.human(count: :other) %> &#x2f; <%= @product.name %>
+  <%= plural_resource_name(Spree::Product) %> &#x2f; <%= @product.name %>
 <% end %>
 
 <% content_for :tabs do %>
@@ -12,13 +12,13 @@
         <%= link_to_with_icon 'picture-o', Spree.t(:images), spree.admin_product_images_url(@product) %>
       <% end if can?(:admin, Spree::Image) %>
       <%= content_tag :li, :class => ('active' if current == 'Variants') do %>
-        <%= link_to_with_icon 'th-large', Spree::Variant.model_name.human(count: :other),  spree.admin_product_variants_url(@product) %>
+        <%= link_to_with_icon 'th-large', plural_resource_name(Spree::Variant),  spree.admin_product_variants_url(@product) %>
       <% end if can?(:admin, Spree::Variant) %>
       <%= content_tag :li, :class => ('active' if current == 'Prices') do %>
-        <%= link_to_with_icon 'money', Spree::Price.model_name.human(count: :other),  spree.admin_product_prices_url(@product) %>
+        <%= link_to_with_icon 'money', plural_resource_name(Spree::Price),  spree.admin_product_prices_url(@product) %>
       <% end if can?(:admin, Spree::Price) %>
       <%= content_tag :li, :class => ('active' if current == 'Product Properties') do %>
-        <%= link_to_with_icon 'tasks', Spree::ProductProperty.model_name.human(count: :other), spree.admin_product_product_properties_url(@product) %>
+        <%= link_to_with_icon 'tasks', plural_resource_name(Spree::ProductProperty), spree.admin_product_product_properties_url(@product) %>
       <% end if can?(:admin, Spree::ProductProperty) %>
       <%= content_tag :li, :class => ('active' if current == 'Stock Management') do %>
         <%= link_to_with_icon 'cubes', Spree.t(:stock_management), spree.admin_product_stock_url(@product) %>

--- a/backend/app/views/spree/admin/shared/_settings_checkout_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_settings_checkout_tabs.html.erb
@@ -2,19 +2,19 @@
   <nav>
     <ul class="tabs" data-hook="admin_settings_checkout_tabs">
       <% if can?(:display, Spree::RefundReason) %>
-        <%= settings_tab_item Spree::RefundReason.model_name.human(count: :other), spree.admin_refund_reasons_path %>
+        <%= settings_tab_item plural_resource_name(Spree::RefundReason), spree.admin_refund_reasons_path %>
       <% end %>
 
       <% if can?(:display, Spree::ReimbursementType) %>
-        <%= settings_tab_item Spree::ReimbursementType.model_name.human(count: :other), spree.admin_reimbursement_types_path %>
+        <%= settings_tab_item plural_resource_name(Spree::ReimbursementType), spree.admin_reimbursement_types_path %>
       <% end %>
 
       <% if can?(:display, Spree::ReturnReason) %>
-        <%= settings_tab_item Spree::ReturnReason.model_name.human(count: :other), spree.admin_return_reasons_path %>
+        <%= settings_tab_item plural_resource_name(Spree::ReturnReason), spree.admin_return_reasons_path %>
       <% end %>
 
       <% if can?(:display, Spree::AdjustmentReason) %>
-        <%= settings_tab_item Spree::AdjustmentReason.model_name.human(count: :other), spree.admin_adjustment_reasons_path %>
+        <%= settings_tab_item plural_resource_name(Spree::AdjustmentReason), spree.admin_adjustment_reasons_path %>
       <% end %>
     </ul>
   </nav>

--- a/backend/app/views/spree/admin/shared/_shipping_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_shipping_tabs.html.erb
@@ -2,15 +2,15 @@
   <nav>
     <ul class="tabs" data-hook="admin_settings_shipping_tabs">
       <% if can?(:display, Spree::ShippingMethod) %>
-        <%= settings_tab_item Spree::ShippingMethod.model_name.human(count: :other), spree.admin_shipping_methods_path %>
+        <%= settings_tab_item plural_resource_name(Spree::ShippingMethod), spree.admin_shipping_methods_path %>
       <% end %>
 
       <% if can?(:display, Spree::ShippingCategory) %>
-        <%= settings_tab_item Spree::ShippingCategory.model_name.human(count: :other), spree.admin_shipping_categories_path %>
+        <%= settings_tab_item plural_resource_name(Spree::ShippingCategory), spree.admin_shipping_categories_path %>
       <% end %>
 
       <% if can?(:display, Spree::StockLocation) %>
-        <%= settings_tab_item Spree::StockLocation.model_name.human(count: :other), spree.admin_stock_locations_path %>
+        <%= settings_tab_item plural_resource_name(Spree::StockLocation), spree.admin_stock_locations_path %>
       <% end %>
     </ul>
   </nav>

--- a/backend/app/views/spree/admin/shared/_taxes_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_taxes_tabs.html.erb
@@ -2,11 +2,11 @@
   <nav>
     <ul class="tabs" data-hook="admin_settings_taxes_tabs">
       <% if can? :display, Spree::TaxCategory %>
-        <%= settings_tab_item Spree::TaxCategory.model_name.human(count: :other), spree.admin_tax_categories_path %>
+        <%= settings_tab_item plural_resource_name(Spree::TaxCategory), spree.admin_tax_categories_path %>
       <% end %>
 
       <% if can? :display, Spree::TaxRate %>
-        <%= settings_tab_item Spree::TaxRate.model_name.human(count: :other), spree.admin_tax_rates_path %>
+        <%= settings_tab_item plural_resource_name(Spree::TaxRate), spree.admin_tax_rates_path %>
       <% end %>
     </ul>
   </nav>

--- a/backend/app/views/spree/admin/shipping_categories/index.html.erb
+++ b/backend/app/views/spree/admin/shipping_categories/index.html.erb
@@ -1,7 +1,7 @@
 <%= render 'spree/admin/shared/shipping_tabs' %>
 
 <% content_for :page_title do %>
-  <%= Spree::ShippingCategory.model_name.human(count: :other) %>
+  <%= plural_resource_name(Spree::ShippingCategory) %>
 <% end %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/shipping_methods/_form.html.erb
+++ b/backend/app/views/spree/admin/shipping_methods/_form.html.erb
@@ -63,7 +63,7 @@
 <div class="alpha six columns">
   <div data-hook="admin_shipping_method_form_availability_fields" class="alpha six columns">
     <fieldset class="categories no-border-bottom">
-      <legend align="center"><%= Spree::ShippingCategory.model_name.human(count: :other) %></legend>
+      <legend align="center"><%= plural_resource_name(Spree::ShippingCategory) %></legend>
       <%= f.field_container :categories do %>
         <% Spree::ShippingCategory.all.each do |category| %>
           <%= label_tag do %>
@@ -78,7 +78,7 @@
 
   <div class="alpha six columns">
     <fieldset class="no-border-bottom">
-      <legend align="center"><%= Spree::Zone.model_name.human(count: :other) %></legend>
+      <legend align="center"><%= plural_resource_name(Spree::Zone) %></legend>
       <%= f.field_container :zones do %>
         <% shipping_method_zones = @shipping_method.zones.to_a %>
         <% Spree::Zone.all.each do |zone| %>

--- a/backend/app/views/spree/admin/shipping_methods/index.html.erb
+++ b/backend/app/views/spree/admin/shipping_methods/index.html.erb
@@ -1,7 +1,7 @@
 <%= render 'spree/admin/shared/shipping_tabs' %>
 
 <% content_for :page_title do %>
-  <%= Spree::ShippingMethod.model_name.human(count: :other) %>
+  <%= plural_resource_name(Spree::ShippingMethod) %>
 <% end %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/states/index.html.erb
+++ b/backend/app/views/spree/admin/states/index.html.erb
@@ -1,7 +1,7 @@
 <%= render 'spree/admin/shared/areas_tabs' %>
 
 <% content_for :page_title do %>
-  <%= Spree::State.model_name.human(count: :other) %>
+  <%= plural_resource_name(Spree::State) %>
 <% end %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/stock_locations/index.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/index.html.erb
@@ -1,7 +1,7 @@
 <%= render 'spree/admin/shared/shipping_tabs' %>
 
 <% content_for :page_title do %>
-  <%= Spree::StockLocation.model_name.human(count: :other) %>
+  <%= plural_resource_name(Spree::StockLocation) %>
 <% end %>
 
 <% content_for :page_actions do %>
@@ -34,7 +34,7 @@
         <th class="no-border"></th>
         <th><%= Spree::StockLocation.human_attribute_name(:name) %></th>
         <th><%= Spree::StockLocation.human_attribute_name(:state_id) %></th>
-        <th><%= Spree::StockMovement.model_name.human(count: :other) %></th>
+        <th><%= plural_resource_name(Spree::StockMovement) %></th>
         <th class="actions"></th>
       </tr>
     </thead>
@@ -59,7 +59,7 @@
           </td>
           <td class="align-center">
             <% if can?(:display, Spree::StockMovement) %>
-              <%= link_to Spree::StockMovement.model_name.human(count: :other), admin_stock_location_stock_movements_path(stock_location.id) %>
+              <%= link_to plural_resource_name(Spree::StockMovement), admin_stock_location_stock_movements_path(stock_location.id) %>
             <% else %>
               Stock Movements
             <% end %>

--- a/backend/app/views/spree/admin/stock_transfers/_transfer_item_table.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/_transfer_item_table.html.erb
@@ -59,5 +59,5 @@
     </tbody>
   </table>
   <div class="no-objects-found" <%= 'hidden' if @stock_transfer.transfer_items.any? %>>
-    <%= Spree.t(:no_resource, resource: Spree::TransferItem.model_name.human(count: :other)) %>
+    <%= Spree.t(:no_resource, resource: plural_resource_name(Spree::TransferItem)) %>
   </div>

--- a/backend/app/views/spree/admin/stock_transfers/index.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree::StockTransfer.model_name.human(count: :other) %>
+  <%= plural_resource_name(Spree::StockTransfer) %>
 <% end %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/stock_transfers/show.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/show.html.erb
@@ -43,6 +43,6 @@
 </fieldset>
 
 <fieldset>
-  <legend><%= Spree::TransferItem.model_name.human(count: :other) %></legend>
+  <legend><%= plural_resource_name(Spree::TransferItem) %></legend>
   <%= render partial: 'transfer_item_table', locals: { transfer_items: @stock_transfer.transfer_items, show_expected: true, show_received: true, show_actions: false } %>
 </fieldset>

--- a/backend/app/views/spree/admin/stock_transfers/tracking_info.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/tracking_info.html.erb
@@ -43,6 +43,6 @@
 </fieldset>
 
 <fieldset id='stock-transfer-transfer-items'>
-  <legend align="center"><%= Spree::TransferItem.model_name.human(count: :other) %></legend>
+  <legend align="center"><%= plural_resource_name(Spree::TransferItem) %></legend>
   <%= render partial: 'transfer_item_table', locals: { transfer_items: @stock_transfer.transfer_items, show_expected: true, show_received: false, show_actions: false } %>
 </fieldset>

--- a/backend/app/views/spree/admin/tax_rates/index.html.erb
+++ b/backend/app/views/spree/admin/tax_rates/index.html.erb
@@ -1,7 +1,7 @@
 <%= render 'spree/admin/shared/taxes_tabs' %>
 
 <% content_for :page_title do %>
-  <%= Spree::TaxRate.model_name.human(count: :other) %>
+  <%= plural_resource_name(Spree::TaxRate) %>
 <% end %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/taxonomies/index.html.erb
+++ b/backend/app/views/spree/admin/taxonomies/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree::Taxonomy.model_name.human(count: :other) %>
+  <%= plural_resource_name(Spree::Taxonomy) %>
 <% end %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/taxons/index.html.erb
+++ b/backend/app/views/spree/admin/taxons/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree::Taxon.model_name.human(count: :other) %>
+  <%= plural_resource_name(Spree::Taxon) %>
 <% end %>
 
 <% content_for :table_filter_title do %>

--- a/backend/app/views/spree/admin/trackers/index.html.erb
+++ b/backend/app/views/spree/admin/trackers/index.html.erb
@@ -1,7 +1,7 @@
 <%= render 'spree/admin/shared/general_tabs' %>
 
 <% content_for :page_title do %>
-  <%= Spree::Tracker.model_name.human(count: :other) %>
+  <%= plural_resource_name(Spree::Tracker) %>
 <% end %>
 
 <% content_for :page_actions do %>

--- a/backend/app/views/spree/admin/users/_form.html.erb
+++ b/backend/app/views/spree/admin/users/_form.html.erb
@@ -13,7 +13,7 @@
 
     <% if can? :display, Spree::Role %>
       <div data-hook="admin_user_form_roles" class="field">
-        <%= label_tag nil, Spree::Role.model_name.human(count: :other) %>
+        <%= label_tag nil, plural_resource_name(Spree::Role) %>
         <ul>
           <% if can? :manage, Spree::Role %>
             <% @roles.each do |role| %>
@@ -33,7 +33,7 @@
 
     <% if Spree::Config[:can_restrict_stock_management] && can?(:display, Spree::StockLocation) %>
       <div data-hook="admin_user_form_stock_locations" class="field">
-        <%= label_tag nil, Spree::StockLocation.model_name.human(count: :other) %>
+        <%= label_tag nil, plural_resource_name(Spree::StockLocation) %>
         <ul>
           <% if can?(:manage, Spree::UserStockLocation) %>
             <% @stock_locations.each do |stock_location| %>

--- a/backend/app/views/spree/admin/users/addresses.html.erb
+++ b/backend/app/views/spree/admin/users/addresses.html.erb
@@ -7,7 +7,7 @@
 <%= render :partial => 'spree/admin/users/user_page_actions' %>
 
 <fieldset data-hook="admin_user_addresses" id="admin_user_edit_addresses" class="alpha twelve columns">
-  <legend><%= Spree::Address.model_name.human(count: :other) %></legend>
+  <legend><%= plural_resource_name(Spree::Address) %></legend>
 
   <div data-hook="admin_user_edit_form_header">
     <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @user } %>

--- a/backend/app/views/spree/admin/variants/index.html.erb
+++ b/backend/app/views/spree/admin/variants/index.html.erb
@@ -8,9 +8,9 @@
     <p class='first_add_option_types no-objects-found' data-hook="first_add_option_types">
       <%= Spree.t(:to_add_variants_you_must_first_define) %>
       <% if can?(:display, Spree::OptionType) %>
-        <%= link_to Spree::OptionType.model_name.human(count: :other), admin_option_types_path%>
+        <%= link_to plural_resource_name(Spree::OptionType), admin_option_types_path%>
       <% else %>
-        <%= Spree::OptionType.model_name.human(count: :other) %>
+        <%= plural_resource_name(Spree::OptionType) %>
       <% end %>
     </p>
   <% elsif @product.empty_option_values? %>
@@ -20,7 +20,7 @@
     </div>
   <% else %>
     <div class="alpha twelve columns no-objects-found">
-      <%= Spree.t(:no_resource, resource: Spree::Variant.model_name.human(count: :other)) %>
+      <%= Spree.t(:no_resource, resource: plural_resource_name(Spree::Variant)) %>
       <% if can? :create, Spree::Variant %>
         <%= link_to Spree.t(:create_one), new_object_url, remote: true %>
       <% end %>

--- a/backend/app/views/spree/admin/zones/_country_members.html.erb
+++ b/backend/app/views/spree/admin/zones/_country_members.html.erb
@@ -1,9 +1,9 @@
 <div id="country_members" data-hook="member" class="omega six columns">
   <fieldset class="no-border-bottom">
-    <legend align="center"><%= Spree::Country.model_name.human(count: :other) %></legend>
+    <legend align="center"><%= plural_resource_name(Spree::Country) %></legend>
 
     <%= zone_form.field_container :country_ids do %>
-      <%= zone_form.label :country_ids, Spree::Country.model_name.human(count: :other) %><br>
+      <%= zone_form.label :country_ids, plural_resource_name(Spree::Country) %><br>
       <%= zone_form.collection_select :country_ids, @countries, :id, :name, {}, { :multiple => true, :class => "select2 fullwidth" } %>
     <% end %>
   </fieldset>

--- a/backend/app/views/spree/admin/zones/_state_members.html.erb
+++ b/backend/app/views/spree/admin/zones/_state_members.html.erb
@@ -1,9 +1,9 @@
 <div id="state_members" data-hook="member" class="omega six columns">
   <fieldset class="no-border-bottom">
-    <legend align="center"><%= Spree::State.model_name.human(count: :other) %></legend>
+    <legend align="center"><%= plural_resource_name(Spree::State) %></legend>
 
     <%= zone_form.field_container :state_ids do %>
-      <%= zone_form.label :state_ids, Spree::State.model_name.human(count: :other) %><br>
+      <%= zone_form.label :state_ids, plural_resource_name(Spree::State) %><br>
       <%= zone_form.collection_select :state_ids, @states, :id, :name, {}, { :multiple => true, :class => "select2 fullwidth" } %>
     <% end %>
   </fieldset>

--- a/backend/app/views/spree/admin/zones/index.html.erb
+++ b/backend/app/views/spree/admin/zones/index.html.erb
@@ -1,7 +1,7 @@
 <%= render 'spree/admin/shared/areas_tabs' %>
 
 <% content_for :page_title do %>
-  <%= Spree::Zone.model_name.human(count: :other) %>
+  <%= plural_resource_name(Spree::Zone) %>
 <% end %>
 
 <% content_for :page_actions do %>

--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -153,6 +153,10 @@ module Spree
       end
     end
 
+    def plural_resource_name(resource_class)
+      resource_class.model_name.human(count: Spree::Config.i18n_generic_plural)
+    end
+
     private
 
     # Returns style of image or nil

--- a/core/lib/spree/i18n.rb
+++ b/core/lib/spree/i18n.rb
@@ -7,8 +7,15 @@ module Spree
   end
 
   class << self
+    # This value is used as a count for the pluralization helpers related to I18n
+    # ex: Spree::Order.model_name.human(count: Spree::I18N_GENERIC_PLURAL)
+    # Related to Solidus issue #1164, this is needed to avoid problems with
+    # some pluralization calculators
+
+    Spree::I18N_GENERIC_PLURAL = 2.1
     # Add spree namespace and delegate to Rails TranslationHelper for some nice
     # extra functionality. e.g return reasonable strings for missing translations
+
     def translate(key, options = {})
       options[:scope] = [:spree, *options[:scope]]
       TranslationHelperWrapper.new.translate(key, options)

--- a/core/spec/helpers/base_helper_spec.rb
+++ b/core/spec/helpers/base_helper_spec.rb
@@ -167,4 +167,20 @@ describe Spree::BaseHelper, type: :helper do
       expect(pretty_time(DateTime.new(2012, 5, 6, 13, 33))).to eq "May 06, 2012  1:33 PM"
     end
   end
+
+  context "plural_resource_name" do
+    let(:plural_config) { Spree::Config.i18n_generic_plural }
+    let(:base_class) { Spree::Product }
+
+    subject { plural_resource_name(base_class) }
+
+    it "should use ActiveModel::Naming module to pluralize model names" do
+      expect(subject).to eq Spree::Product.model_name.human(count: plural_config)
+    end
+
+    it "should use Spree::Config[:i18n_general_value] as a value for count" do
+      expect(Spree::Config).to receive(:i18n_generic_plural).and_call_original
+      subject
+    end
+  end
 end

--- a/core/spec/lib/i18n_spec.rb
+++ b/core/spec/lib/i18n_spec.rb
@@ -40,6 +40,10 @@ describe "i18n" do
     expect(Spree.t(:missing_entry)).to include("<span")
   end
 
+  it "has a Spree::I18N_GENERIC_PLURAL constant" do
+    expect(Spree::I18N_GENERIC_PLURAL).to eq 2.1
+  end
+
   context "missed + unused translations" do
     def key_with_locale(key)
       "#{key} (#{I18n.locale})"


### PR DESCRIPTION
This is a fix for issue #1164 

1) First commit is to add a preference containing the "magic number"
2) Second commit is to add the helper to wrap the usage of ActiveRecord::Naming
3) Third commit is find/replace to use the helpers

It is likely that we'll need to add more keys to fully support every pluralization calculators (slavic languages use more keys like : [ few, many ] and we only use one/other) but this address the underlying issue of trying to compare if a Symbol is less or greater than an integer which was causing crashes with the OneUptoTwoOther calculator used by the french language.

I opted for the preference/helper approach so the number can be updated without patching or monkey patching core, and the usage can be updated without editing every file from the backend but I can revert to a simpler usage if needed

EDIT : I also confirm that it fixes the issues raised by https://github.com/luukveenis/solidus_i18n/pull/6

Suggestions welcome