### PR TITLE
Simplify DB cleaning in backend specs

### DIFF
--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -71,11 +71,8 @@ RSpec.configure do |config|
     DatabaseCleaner.clean_with :truncation
   end
 
-  config.before(:each) do
-    Rails.cache.clear
-    reset_spree_preferences
+  config.prepend_before(:each) do
     if RSpec.current_example.metadata[:js]
-      page.driver.browser.url_blacklist = ['http://fonts.googleapis.com']
       DatabaseCleaner.strategy = :truncation
     else
       DatabaseCleaner.strategy = :transaction
@@ -83,10 +80,15 @@ RSpec.configure do |config|
     DatabaseCleaner.start
   end
 
-  config.after(:each) do
-    # Ensure js requests finish processing before advancing to the next test
-    wait_for_ajax if RSpec.current_example.metadata[:js]
+  config.before do
+    Rails.cache.clear
+    reset_spree_preferences
+    if RSpec.current_example.metadata[:js]
+      page.driver.browser.url_blacklist = ['http://fonts.googleapis.com']
+    end
+  end
 
+  config.append_after(:each) do
     DatabaseCleaner.clean
   end
 

--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -19,7 +19,7 @@ gem 'coffee-rails'
 gem 'sass-rails'
 
 group :test do
-  gem 'capybara', '~> 2.4'
+  gem 'capybara', '~> 2.7'
   gem 'capybara-screenshot'
   gem 'database_cleaner', '~> 1.3'
   gem 'email_spec'


### PR DESCRIPTION
Previously we used wait_for_ajax after every request, which was error prone and gross.

As of Capybara 1.7, Capybara will wait for all requests to the server to finish. Because of this we can just make sure we run the DB cleaner after Capybara has been reset.