### PR TITLE
Update pry-byebug dependency

### DIFF
--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -39,6 +39,6 @@ end
 group :test, :development do
   gem 'rubocop'
   platforms :mri do
-    gem 'pry-byebug', '~> 1.0'
+    gem 'pry-byebug', '~> 3.4'
   end
 end


### PR DESCRIPTION
pry-byebug is up to 3.4, but is locked at 1.x.
pry-byebug 1.x depends on a very old version of byebug (2.x), whereas
byebug is up to 9.x. That old version of byebug doesn't work properly
with newer MRI's like 2.3.

Update pry-byebug to something recent so it allows a recent
byebug that isn't buggy with new rubies.