### PR TITLE
Rewrite payment method selection for admin new payment

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/select_payments.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/select_payments.js.coffee
@@ -1,7 +1,12 @@
 $ ->
   if $('.new_payment').is('*')
-    $('.payment-method-settings fieldset').addClass('hidden').first().removeClass('hidden')
-    $('input[name="payment[payment_method_id]"]').click ()->
-      $('.payment-method-settings fieldset').addClass('hidden')
-      id = $(this).parents('li').data('id')
-      $("fieldset[data-id='#{id}']").removeClass('hidden')
+    $input = $('input[name="payment[payment_method_id]"]')
+    $paymentMethods = $('.payment-method-settings .payment-methods')
+
+    updateSelected = ->
+      id = $input.filter(":checked").val()
+      $paymentMethods.addClass('hidden')
+      $paymentMethods.filter("#payment_method_#{id}").removeClass('hidden')
+
+    $input.on('click', updateSelected)
+    updateSelected()

--- a/backend/app/views/spree/admin/payments/_form.html.erb
+++ b/backend/app/views/spree/admin/payments/_form.html.erb
@@ -10,7 +10,7 @@
       <label><%= Spree::PaymentMethod.model_name.human %></label>
       <ul>
         <% @payment_methods.each do |method| %>
-          <li data-id="<%= Spree.t(method.name, :scope => :payment_methods, :default => method.name).parameterize %>">
+          <li>
             <label data-hook="payment_method_field">
               <%= radio_button_tag 'payment[payment_method_id]', method.id, method == @payment_method, { class: "payment_methods_radios" } %>
               <%= method.name %>

--- a/backend/app/views/spree/admin/payments/source_forms/_gateway.html.erb
+++ b/backend/app/views/spree/admin/payments/source_forms/_gateway.html.erb
@@ -1,4 +1,4 @@
-<fieldset data-id='credit-card' class="no-border-bottom">
+<fieldset class="no-border-bottom">
   <div class="field" data-hook="previous_cards">
     <% if previous_cards.any? %>
       <% previous_cards.each do |card| %>

--- a/backend/spec/features/admin/orders/payments_spec.rb
+++ b/backend/spec/features/admin/orders/payments_spec.rb
@@ -223,4 +223,25 @@ describe 'Payments', type: :feature do
       end
     end
   end
+
+  # Previously this would fail unless the method was named "Credit Card"
+  context "with an differently named payment method" do
+    let(:order) { create(:order_with_line_items, line_items_count: 1) }
+    let!(:chequing_payment_method) { create(:check_payment_method) }
+    let!(:payment_method) { create(:credit_card_payment_method, name: "Multipass!") }
+
+    before do
+      visit spree.admin_order_payments_path(order.reload)
+    end
+
+    it "is able to create a new payment", js: true do
+      choose payment_method.name
+      fill_in "Card Number", with: "4111 1111 1111 1111"
+      fill_in "Name", with: "Test User"
+      fill_in "Expiration", with: "09 / #{Time.current.year + 1}"
+      fill_in "Card Code", with: "007"
+      click_button "Continue"
+      expect(page).to have_content("Payment has been successfully created!")
+    end
+  end
 end


### PR DESCRIPTION
Previously a credit card payment method would have to be named "Credit Card" in order to allow creating new payments through the admin. This is because it was using the payment method's name, running it through I18n, and using that as a selector to find a fieldset to show.

Now it just finds a div with the correct id.

Thanks @Murph33 who pointed this out a while ago