### PR TITLE
Add terms and conditions to comply with EU legislation

### DIFF
--- a/api/app/controllers/spree/api/checkouts_controller.rb
+++ b/api/app/controllers/spree/api/checkouts_controller.rb
@@ -45,6 +45,7 @@ module Spree
         if !expected_total_ok?(params[:expected_total])
           respond_with(@order, default_template: 'spree/api/orders/expected_total_mismatch', status: 400)
         else
+          accept_terms_and_conditions
           @order.complete!
           respond_with(@order, default_template: 'spree/api/orders/show', status: 200)
         end
@@ -126,6 +127,12 @@ module Spree
       def state_callback(before_or_after = :before)
         method_name = :"#{before_or_after}_#{@order.state}"
         send(method_name) if respond_to?(method_name, true)
+      end
+
+      def accept_terms_and_conditions
+        return unless Spree::Config[:require_terms_and_conditions]
+
+        @order.terms_and_conditions = update_params[:terms_and_conditions]
       end
 
       def after_update_attributes

--- a/api/spec/controllers/spree/api/checkouts_controller_spec.rb
+++ b/api/spec/controllers/spree/api/checkouts_controller_spec.rb
@@ -516,6 +516,16 @@ module Spree
                   expect(response.status).to eq(200)
                 end
               end
+
+              context 'when terms are not accepted' do
+                let(:accepted) { false }
+
+                it 'will prevent the order completing and return errors' do
+                  subject
+                  expect(response.status).to eq(422)
+                  expect(json_response['errors']['terms_and_conditions']).to include(Spree.t(:must_accept_terms_and_conditions))
+                end
+              end
             end
           end
         end

--- a/api/spec/controllers/spree/api/checkouts_controller_spec.rb
+++ b/api/spec/controllers/spree/api/checkouts_controller_spec.rb
@@ -495,6 +495,28 @@ module Spree
               expect(response.status).to eq(400)
               expect(json_response['errors']['expected_total']).to include(Spree.t(:expected_total_mismatch, scope: 'api.order'))
             end
+
+            context "when terms_and_conditions are required" do
+              let(:params) do
+                { id: order.to_param,
+                  order_token: order.guest_token,
+                  order: { terms_and_conditions: accepted } }
+              end
+
+              before do
+                Spree::Config[:require_terms_and_conditions] = true
+                allow_any_instance_of(Spree::Order).to receive_messages(payment_required?: false)
+              end
+
+              context 'when they are accepted' do
+                let(:accepted) { true }
+
+                it 'the order will complete' do
+                  subject
+                  expect(response.status).to eq(200)
+                end
+              end
+            end
           end
         end
       end

--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -205,6 +205,11 @@ module Spree
     #   @return [Boolean] Allows shipments to be ready to ship regardless of the order being paid if false (default: +true+)
     preference :require_payment_to_ship, :boolean, default: true # Allows shipments to be ready to ship regardless of the order being paid if false
 
+    # @!attribute [rw] require_terms_and_conditions
+    #   @return [Boolean] Requires terms and conditions to be accepted during checkout flow (default: +false+)
+    preference :require_terms_and_conditions, :boolean, default: false
+    preference :terms_and_conditions_on_step, :string, default: 'confirm'
+
     # @!attribute [rw] return_eligibility_number_of_days
     #   @return [Integer] default: 365
     preference :return_eligibility_number_of_days, :integer, default: 365

--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -208,7 +208,6 @@ module Spree
     # @!attribute [rw] require_terms_and_conditions
     #   @return [Boolean] Requires terms and conditions to be accepted during checkout flow (default: +false+)
     preference :require_terms_and_conditions, :boolean, default: false
-    preference :terms_and_conditions_on_step, :string, default: 'confirm'
 
     # @!attribute [rw] return_eligibility_number_of_days
     #   @return [Integer] default: 365

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -705,8 +705,6 @@ module Spree
     end
 
     def ensure_terms_and_conditions
-      return unless has_step?(Spree::Config[:terms_and_conditions_on_step])
-
       unless terms_and_conditions_accepted?
         errors.add(:terms_and_conditions, Spree.t(:must_accept_terms_and_conditions))
       end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -30,7 +30,7 @@ module Spree
     self.whitelisted_ransackable_attributes = %w[completed_at created_at email number state payment_state shipment_state total]
 
     attr_reader :coupon_code
-    attr_accessor :temporary_address, :temporary_credit_card
+    attr_accessor :temporary_address, :temporary_credit_card, :terms_and_conditions
 
     belongs_to :user, class_name: Spree::UserClassHandle.new
     belongs_to :created_by, class_name: Spree::UserClassHandle.new
@@ -704,6 +704,16 @@ module Spree
       true unless new_record? || ['cart', 'address'].include?(state)
     end
 
+    def ensure_terms_and_conditions
+      return unless has_step?(Spree::Config[:terms_and_conditions_on_step])
+
+      unless terms_and_conditions_accepted?
+        errors.add(:terms_and_conditions, Spree.t(:must_accept_terms_and_conditions))
+      end
+
+      errors.empty?
+    end
+
     def ensure_inventory_units
       if has_step?("delivery")
         inventory_validator = Spree::Stock::InventoryValidator.new
@@ -761,6 +771,10 @@ module Spree
 
     def use_billing?
       use_billing.in?([true, 'true', '1'])
+    end
+
+    def terms_and_conditions_accepted?
+      terms_and_conditions.in?([true, 'true', '1'])
     end
 
     def set_currency

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -116,6 +116,13 @@ module Spree
               before_transition to: :complete, do: :ensure_promotions_eligible
               before_transition to: :complete, do: :ensure_line_item_variants_are_not_deleted
               before_transition to: :complete, do: :ensure_inventory_units, unless: :unreturned_exchange?
+
+              if states[Spree::Config[:terms_and_conditions_on_step].to_sym]
+                before_transition from: Spree::Config[:terms_and_conditions_on_step].to_sym,
+                                  do: :ensure_terms_and_conditions,
+                                  if: ->{ Spree::Config[:require_terms_and_conditions] }
+              end
+
               if states[:payment]
                 before_transition to: :complete, do: :process_payments_before_complete
               end

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -117,11 +117,9 @@ module Spree
               before_transition to: :complete, do: :ensure_line_item_variants_are_not_deleted
               before_transition to: :complete, do: :ensure_inventory_units, unless: :unreturned_exchange?
 
-              if states[Spree::Config[:terms_and_conditions_on_step].to_sym]
-                before_transition from: Spree::Config[:terms_and_conditions_on_step].to_sym,
-                                  do: :ensure_terms_and_conditions,
-                                  if: ->{ Spree::Config[:require_terms_and_conditions] }
-              end
+              before_transition to: :complete,
+                                do: :ensure_terms_and_conditions,
+                                if: ->{ Spree::Config[:require_terms_and_conditions] }
 
               if states[:payment]
                 before_transition to: :complete, do: :process_payments_before_complete

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -606,6 +606,7 @@ en:
   spree:
     abbreviation: Abbreviation
     accept: Accept
+    accept_terms_and_conditions: I accept the Terms and Conditions
     acceptance_status: Acceptance status
     acceptance_errors: Acceptance errors
     accepted: Accepted
@@ -1235,6 +1236,7 @@ en:
     month: Month
     more: More
     move_stock_between_locations: Move Stock Between Locations
+    must_accept_terms_and_conditions: You must accept the Terms and Conditions
     my_account: My Account
     my_orders: My Orders
     name: Name

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -45,7 +45,7 @@ module Spree
     @@address_book_attributes = address_attributes + [:default]
 
     @@checkout_attributes = [
-      :coupon_code, :email, :shipping_method_id, :special_instructions, :use_billing
+      :coupon_code, :email, :shipping_method_id, :special_instructions, :use_billing, :terms_and_conditions
     ]
 
     @@credit_card_update_attributes = [

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -558,9 +558,19 @@ describe Spree::Order, type: :model do
       end
 
       it "transitions to complete" do
-        expect(order).to receive(:ensure_terms_and_conditions)
         order.complete!
         assert_state_changed(order, 'confirm', 'complete')
+      end
+
+      context 'but not accepted' do
+        before do
+          order.terms_and_conditions = false
+        end
+
+        it 'will not complete' do
+          expect { order.complete! }.to raise_error(StateMachines::InvalidTransition)
+          expect(order.reload.state).to eq('confirm')
+        end
       end
     end
 

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -546,6 +546,24 @@ describe Spree::Order, type: :model do
       end
     end
 
+    context "with terms_and_conditions required" do
+      before do
+        Spree::Config[:require_terms_and_conditions] = true
+        order.terms_and_conditions = true
+        order.email = 'spree@example.org'
+        order.payments << FactoryGirl.create(:payment)
+        order.shipments.create!
+        allow(order).to receive_messages(payment_required?: true)
+        allow(order).to receive(:ensure_available_shipping_rates).and_return(true)
+      end
+
+      it "transitions to complete" do
+        expect(order).to receive(:ensure_terms_and_conditions)
+        order.complete!
+        assert_state_changed(order, 'confirm', 'complete')
+      end
+    end
+
     context "default credit card" do
       before do
         order.user = FactoryGirl.create(:user)

--- a/frontend/app/views/spree/checkout/_confirm.html.erb
+++ b/frontend/app/views/spree/checkout/_confirm.html.erb
@@ -6,6 +6,13 @@
 
 <br />
 
+<% if Spree::Config[:require_terms_and_conditions] %>
+  <p class="field" style='clear: both'>
+    <%= form.checkbox :terms_and_conditions %>
+    <%= form.label :terms_and_conditions, Spree.t(:accept_terms_and_conditions) %>
+  </p>
+<% end %>
+
 <div class="form-buttons" data-hook="buttons">
   <%= submit_tag Spree.t(:place_order), :class => 'continue button primary' %>
   <script>Spree.disableSaveOnClick();</script>

--- a/frontend/spec/controllers/spree/checkout_controller_spec.rb
+++ b/frontend/spec/controllers/spree/checkout_controller_spec.rb
@@ -244,6 +244,23 @@ describe Spree::CheckoutController, type: :controller do
           expect(assigns(:current_order)).to be_nil
           expect(assigns(:order)).to eql controller.current_order
         end
+
+        context 'when terms_and_conditions_required' do
+          before { Spree::Config[:require_terms_and_conditions] = true }
+
+          it "should populate the flash message" do
+            spree_post :update, { state: "confirm", order: { terms_and_conditions: true } }
+            expect(flash.notice).to eq(Spree.t(:order_processed_successfully))
+          end
+
+          context 'but not accepted' do
+
+            it "" do
+              spree_post :update, { state: "confirm", order: { terms_and_conditions: false } }
+              expect(assigns(:order).errors[:terms_and_conditions]).to include(Spree.t(:must_accept_terms_and_conditions))
+            end
+          end
+        end
       end
     end
 

--- a/frontend/spec/controllers/spree/checkout_controller_spec.rb
+++ b/frontend/spec/controllers/spree/checkout_controller_spec.rb
@@ -254,8 +254,7 @@ describe Spree::CheckoutController, type: :controller do
           end
 
           context 'but not accepted' do
-
-            it "" do
+            it "will show an error" do
               spree_post :update, { state: "confirm", order: { terms_and_conditions: false } }
               expect(assigns(:order).errors[:terms_and_conditions]).to include(Spree.t(:must_accept_terms_and_conditions))
             end


### PR DESCRIPTION
This PR will add functionality for incorporating a terms and conditions checkbox onto the order confirmation page in the checkout flow.

This is required for all stores with their main operating address within the EU, as outlined in the [Directive 2000/31/EC](http://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32000L0031&from=EN) with the specifics explained on http://www.out-law.com/page-424

> ...be required to check a box to indicate that he or she has read, understood and accepted the terms and conditions, before clicking the "Accept" button...

The order state will not be able to transition until the terms have been accepted.

We have added an additional config to toggle the functionality.

```
Spree::Config[:require_terms_and_conditions]
```

We can also create a PR into master as well if required.
