### PR TITLE
admin users#edit shows validation errors

### DIFF
--- a/backend/app/controllers/spree/admin/users_controller.rb
+++ b/backend/app/controllers/spree/admin/users_controller.rb
@@ -38,9 +38,13 @@ module Spree
           set_roles
           set_stock_locations
           flash[:success] = Spree.t(:account_updated)
-        end
+          redirect_to edit_admin_user_url(@user)
+        else
+          load_roles
+          load_stock_locations
 
-        redirect_to edit_admin_user_url(@user)
+          render :edit, status: :unprocessable_entity
+        end
       end
 
       def addresses


### PR DESCRIPTION
1. Turns out the default Spree.user_class, at least under test, doesn't
   have any validations at all. Kind of tricky to figure out how to
   test, I think this is the most reasonable way even though it's
   kind of screwy. Started out with a `allow_any_instance_of` mock,
   but realized the test I had would pass without this change too,
   it was a false pass. 

2. Don't entirely understand why I need to call load_roles and
   load_stock_locations -- or rather, I don't understand
   why the ordinary #edit action does NOT seem to need
   to do this. But I did, copied from the error
   case in #create. After spending so much time on
   figuring out how to set up the test as above, I called
   it a day.