### PR TITLE
Use #constantize for configurable class lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,6 +187,11 @@
     * JavaScript for it has been moved from address.js into its own `spree/frontend/checkout/coupon-code`
     * Numerous small nuisances have been fixed [#1090](https://github.com/solidusio/solidus/pull/1090)
 
+*   Lists of classes in configuration (`config.spree.calculators`, `spree.spree.calculators`, etc.) are
+    now stored internally as strings and constantized when accessed. This allows these classes to be
+    reloaded in development mode and loaded later in the boot process.
+    [#1203](https://github.com/solidusio/solidus/pull/1203)
+
 ## Solidus 1.2.0 (2016-01-26)
 
 *   Admin menu has been moved from top of the page to the left side.

--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -63,6 +63,7 @@ end
 
 require 'spree/core/version'
 
+require 'spree/core/class_constantizer'
 require 'spree/core/environment_extension'
 require 'spree/core/environment/calculators'
 require 'spree/core/environment'

--- a/core/lib/spree/core/class_constantizer.rb
+++ b/core/lib/spree/core/class_constantizer.rb
@@ -1,0 +1,31 @@
+module Spree
+  module Core
+    module ClassConstantizer
+      class Set
+        include Enumerable
+
+        def initialize
+          @collection = ::Set.new
+        end
+
+        def <<(klass)
+          @collection << klass.to_s
+        end
+
+        def concat(klasses)
+          klasses.each do |klass|
+            self << klass
+          end
+        end
+
+        delegate :clear, :empty?, to: :@collection
+
+        def each
+          @collection.each do |klass|
+            yield klass.constantize
+          end
+        end
+      end
+    end
+  end
+end

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -54,7 +54,6 @@ module Spree
       # We need to define promotions rules here so extensions and existing apps
       # can add their custom classes on their initializer files
       initializer 'spree.promo.environment', before: :load_config_initializers do |app|
-        app.config.spree.add_class('promotions')
         app.config.spree.promotions = Spree::Promo::Environment.new
         app.config.spree.promotions.rules = []
       end

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -26,29 +26,29 @@ module Spree
 
       initializer "spree.register.calculators", before: :load_config_initializers do |app|
         app.config.spree.calculators.shipping_methods = [
-            Spree::Calculator::Shipping::FlatPercentItemTotal,
-            Spree::Calculator::Shipping::FlatRate,
-            Spree::Calculator::Shipping::FlexiRate,
-            Spree::Calculator::Shipping::PerItem,
-            Spree::Calculator::Shipping::PriceSack]
+            'Spree::Calculator::Shipping::FlatPercentItemTotal',
+            'Spree::Calculator::Shipping::FlatRate',
+            'Spree::Calculator::Shipping::FlexiRate',
+            'Spree::Calculator::Shipping::PerItem',
+            'Spree::Calculator::Shipping::PriceSack']
 
         app.config.spree.calculators.tax_rates = [
-           Spree::Calculator::DefaultTax]
+           'Spree::Calculator::DefaultTax']
       end
 
       initializer "spree.register.stock_splitters", before: :load_config_initializers do |app|
         app.config.spree.stock_splitters = [
-          Spree::Stock::Splitter::ShippingCategory,
-          Spree::Stock::Splitter::Backordered
+          'Spree::Stock::Splitter::ShippingCategory',
+          'Spree::Stock::Splitter::Backordered'
         ]
       end
 
       initializer "spree.register.payment_methods", before: :load_config_initializers do |app|
         app.config.spree.payment_methods = [
-            Spree::Gateway::Bogus,
-            Spree::Gateway::BogusSimple,
-            Spree::PaymentMethod::StoreCredit,
-            Spree::PaymentMethod::Check]
+            'Spree::Gateway::Bogus',
+            'Spree::Gateway::BogusSimple',
+            'Spree::PaymentMethod::StoreCredit',
+            'Spree::PaymentMethod::Check']
       end
 
       # We need to define promotions rules here so extensions and existing apps
@@ -61,25 +61,25 @@ module Spree
       initializer 'spree.promo.register.promotion.calculators', before: :load_config_initializers do |app|
         app.config.spree.calculators.add_class('promotion_actions_create_adjustments')
         app.config.spree.calculators.promotion_actions_create_adjustments = [
-          Spree::Calculator::FlatPercentItemTotal,
-          Spree::Calculator::FlatRate,
-          Spree::Calculator::FlexiRate,
-          Spree::Calculator::TieredPercent,
-          Spree::Calculator::TieredFlatRate
+          'Spree::Calculator::FlatPercentItemTotal',
+          'Spree::Calculator::FlatRate',
+          'Spree::Calculator::FlexiRate',
+          'Spree::Calculator::TieredPercent',
+          'Spree::Calculator::TieredFlatRate'
         ]
 
         app.config.spree.calculators.add_class('promotion_actions_create_item_adjustments')
         app.config.spree.calculators.promotion_actions_create_item_adjustments = [
-          Spree::Calculator::PercentOnLineItem,
-          Spree::Calculator::FlatRate,
-          Spree::Calculator::FlexiRate,
-          Spree::Calculator::TieredPercent
+          'Spree::Calculator::PercentOnLineItem',
+          'Spree::Calculator::FlatRate',
+          'Spree::Calculator::FlexiRate',
+          'Spree::Calculator::TieredPercent'
         ]
 
         app.config.spree.calculators.add_class('promotion_actions_create_quantity_adjustments')
         app.config.spree.calculators.promotion_actions_create_quantity_adjustments = [
-          Spree::Calculator::PercentOnLineItem,
-          Spree::Calculator::FlatRate
+          'Spree::Calculator::PercentOnLineItem',
+          'Spree::Calculator::FlatRate'
         ]
       end
 
@@ -89,25 +89,26 @@ module Spree
       # the app initializer)
       config.after_initialize do
         Rails.application.config.spree.promotions.rules.concat [
-          Spree::Promotion::Rules::ItemTotal,
-          Spree::Promotion::Rules::Product,
-          Spree::Promotion::Rules::User,
-          Spree::Promotion::Rules::FirstOrder,
-          Spree::Promotion::Rules::UserLoggedIn,
-          Spree::Promotion::Rules::OneUsePerUser,
-          Spree::Promotion::Rules::Taxon,
-          Spree::Promotion::Rules::NthOrder,
-          Spree::Promotion::Rules::OptionValue,
-          Spree::Promotion::Rules::FirstRepeatPurchaseSince
+          'Spree::Promotion::Rules::ItemTotal',
+          'Spree::Promotion::Rules::Product',
+          'Spree::Promotion::Rules::User',
+          'Spree::Promotion::Rules::FirstOrder',
+          'Spree::Promotion::Rules::UserLoggedIn',
+          'Spree::Promotion::Rules::OneUsePerUser',
+          'Spree::Promotion::Rules::Taxon',
+          'Spree::Promotion::Rules::NthOrder',
+          'Spree::Promotion::Rules::OptionValue',
+          'Spree::Promotion::Rules::FirstRepeatPurchaseSince'
         ]
       end
 
       initializer 'spree.promo.register.promotions.actions', before: :load_config_initializers do |app|
         app.config.spree.promotions.actions = [
-          Promotion::Actions::CreateAdjustment,
-          Promotion::Actions::CreateItemAdjustments,
-          Promotion::Actions::CreateQuantityAdjustments,
-          Promotion::Actions::FreeShipping]
+          'Spree::Promotion::Actions::CreateAdjustment',
+          'Spree::Promotion::Actions::CreateItemAdjustments',
+          'Spree::Promotion::Actions::CreateQuantityAdjustments',
+          'Spree::Promotion::Actions::FreeShipping'
+        ]
       end
 
       # filter sensitive information during logging

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -62,7 +62,6 @@ module Spree
       end
 
       initializer 'spree.promo.register.promotion.calculators', before: :load_config_initializers do |app|
-        app.config.spree.calculators.add_class('promotion_actions_create_adjustments')
         app.config.spree.calculators.promotion_actions_create_adjustments = %w[
           Spree::Calculator::FlatPercentItemTotal
           Spree::Calculator::FlatRate
@@ -71,7 +70,6 @@ module Spree
           Spree::Calculator::TieredFlatRate
         ]
 
-        app.config.spree.calculators.add_class('promotion_actions_create_item_adjustments')
         app.config.spree.calculators.promotion_actions_create_item_adjustments = %w[
           Spree::Calculator::PercentOnLineItem
           Spree::Calculator::FlatRate
@@ -79,7 +77,6 @@ module Spree
           Spree::Calculator::TieredPercent
         ]
 
-        app.config.spree.calculators.add_class('promotion_actions_create_quantity_adjustments')
         app.config.spree.calculators.promotion_actions_create_quantity_adjustments = %w[
           Spree::Calculator::PercentOnLineItem
           Spree::Calculator::FlatRate

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -86,12 +86,8 @@ module Spree
         ]
       end
 
-      # Promotion rules need to be evaluated on after initialize otherwise
-      # Spree.user_class would be nil and users might experience errors related
-      # to malformed model associations (Spree.user_class is only defined on
-      # the app initializer)
-      config.after_initialize do
-        Rails.application.config.spree.promotions.rules.concat %w[
+      initializer 'spree.promo.register.promotion.rules', before: :load_config_initializers do |app|
+        app.config.spree.promotions.rules = %w[
           Spree::Promotion::Rules::ItemTotal
           Spree::Promotion::Rules::Product
           Spree::Promotion::Rules::User

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -25,30 +25,33 @@ module Spree
       end
 
       initializer "spree.register.calculators", before: :load_config_initializers do |app|
-        app.config.spree.calculators.shipping_methods = [
-            'Spree::Calculator::Shipping::FlatPercentItemTotal',
-            'Spree::Calculator::Shipping::FlatRate',
-            'Spree::Calculator::Shipping::FlexiRate',
-            'Spree::Calculator::Shipping::PerItem',
-            'Spree::Calculator::Shipping::PriceSack']
+        app.config.spree.calculators.shipping_methods = %w[
+          Spree::Calculator::Shipping::FlatPercentItemTotal
+          Spree::Calculator::Shipping::FlatRate
+          Spree::Calculator::Shipping::FlexiRate
+          Spree::Calculator::Shipping::PerItem
+          Spree::Calculator::Shipping::PriceSack
+        ]
 
-        app.config.spree.calculators.tax_rates = [
-           'Spree::Calculator::DefaultTax']
+        app.config.spree.calculators.tax_rates = %w[
+          Spree::Calculator::DefaultTax
+        ]
       end
 
       initializer "spree.register.stock_splitters", before: :load_config_initializers do |app|
-        app.config.spree.stock_splitters = [
-          'Spree::Stock::Splitter::ShippingCategory',
-          'Spree::Stock::Splitter::Backordered'
+        app.config.spree.stock_splitters = %w[
+          Spree::Stock::Splitter::ShippingCategory
+          Spree::Stock::Splitter::Backordered
         ]
       end
 
       initializer "spree.register.payment_methods", before: :load_config_initializers do |app|
-        app.config.spree.payment_methods = [
-            'Spree::Gateway::Bogus',
-            'Spree::Gateway::BogusSimple',
-            'Spree::PaymentMethod::StoreCredit',
-            'Spree::PaymentMethod::Check']
+        app.config.spree.payment_methods = %w[
+          Spree::Gateway::Bogus
+          Spree::Gateway::BogusSimple
+          Spree::PaymentMethod::StoreCredit
+          Spree::PaymentMethod::Check
+        ]
       end
 
       # We need to define promotions rules here so extensions and existing apps
@@ -60,26 +63,26 @@ module Spree
 
       initializer 'spree.promo.register.promotion.calculators', before: :load_config_initializers do |app|
         app.config.spree.calculators.add_class('promotion_actions_create_adjustments')
-        app.config.spree.calculators.promotion_actions_create_adjustments = [
-          'Spree::Calculator::FlatPercentItemTotal',
-          'Spree::Calculator::FlatRate',
-          'Spree::Calculator::FlexiRate',
-          'Spree::Calculator::TieredPercent',
-          'Spree::Calculator::TieredFlatRate'
+        app.config.spree.calculators.promotion_actions_create_adjustments = %w[
+          Spree::Calculator::FlatPercentItemTotal
+          Spree::Calculator::FlatRate
+          Spree::Calculator::FlexiRate
+          Spree::Calculator::TieredPercent
+          Spree::Calculator::TieredFlatRate
         ]
 
         app.config.spree.calculators.add_class('promotion_actions_create_item_adjustments')
-        app.config.spree.calculators.promotion_actions_create_item_adjustments = [
-          'Spree::Calculator::PercentOnLineItem',
-          'Spree::Calculator::FlatRate',
-          'Spree::Calculator::FlexiRate',
-          'Spree::Calculator::TieredPercent'
+        app.config.spree.calculators.promotion_actions_create_item_adjustments = %w[
+          Spree::Calculator::PercentOnLineItem
+          Spree::Calculator::FlatRate
+          Spree::Calculator::FlexiRate
+          Spree::Calculator::TieredPercent
         ]
 
         app.config.spree.calculators.add_class('promotion_actions_create_quantity_adjustments')
-        app.config.spree.calculators.promotion_actions_create_quantity_adjustments = [
-          'Spree::Calculator::PercentOnLineItem',
-          'Spree::Calculator::FlatRate'
+        app.config.spree.calculators.promotion_actions_create_quantity_adjustments = %w[
+          Spree::Calculator::PercentOnLineItem
+          Spree::Calculator::FlatRate
         ]
       end
 
@@ -88,26 +91,26 @@ module Spree
       # to malformed model associations (Spree.user_class is only defined on
       # the app initializer)
       config.after_initialize do
-        Rails.application.config.spree.promotions.rules.concat [
-          'Spree::Promotion::Rules::ItemTotal',
-          'Spree::Promotion::Rules::Product',
-          'Spree::Promotion::Rules::User',
-          'Spree::Promotion::Rules::FirstOrder',
-          'Spree::Promotion::Rules::UserLoggedIn',
-          'Spree::Promotion::Rules::OneUsePerUser',
-          'Spree::Promotion::Rules::Taxon',
-          'Spree::Promotion::Rules::NthOrder',
-          'Spree::Promotion::Rules::OptionValue',
-          'Spree::Promotion::Rules::FirstRepeatPurchaseSince'
+        Rails.application.config.spree.promotions.rules.concat %w[
+          Spree::Promotion::Rules::ItemTotal
+          Spree::Promotion::Rules::Product
+          Spree::Promotion::Rules::User
+          Spree::Promotion::Rules::FirstOrder
+          Spree::Promotion::Rules::UserLoggedIn
+          Spree::Promotion::Rules::OneUsePerUser
+          Spree::Promotion::Rules::Taxon
+          Spree::Promotion::Rules::NthOrder
+          Spree::Promotion::Rules::OptionValue
+          Spree::Promotion::Rules::FirstRepeatPurchaseSince
         ]
       end
 
       initializer 'spree.promo.register.promotions.actions', before: :load_config_initializers do |app|
-        app.config.spree.promotions.actions = [
-          'Spree::Promotion::Actions::CreateAdjustment',
-          'Spree::Promotion::Actions::CreateItemAdjustments',
-          'Spree::Promotion::Actions::CreateQuantityAdjustments',
-          'Spree::Promotion::Actions::FreeShipping'
+        app.config.spree.promotions.actions = %w[
+          Spree::Promotion::Actions::CreateAdjustment
+          Spree::Promotion::Actions::CreateItemAdjustments
+          Spree::Promotion::Actions::CreateQuantityAdjustments
+          Spree::Promotion::Actions::FreeShipping
         ]
       end
 

--- a/core/lib/spree/core/environment.rb
+++ b/core/lib/spree/core/environment.rb
@@ -3,12 +3,15 @@ module Spree
     class Environment
       include EnvironmentExtension
 
-      attr_accessor :calculators, :payment_methods, :preferences,
-                    :stock_splitters
+      add_class_set :payment_methods
+      add_class_set :stock_splitters
+
+      attr_accessor :calculators, :preferences, :promotions
 
       def initialize
         @calculators = Calculators.new
         @preferences = Spree::AppConfiguration.new
+        @promotions = Spree::Promo::Environment.new
       end
     end
   end

--- a/core/lib/spree/core/environment/calculators.rb
+++ b/core/lib/spree/core/environment/calculators.rb
@@ -4,7 +4,8 @@ module Spree
       class Calculators
         include EnvironmentExtension
 
-        attr_accessor :shipping_methods, :tax_rates
+        add_class_set :shipping_methods
+        add_class_set :tax_rates
       end
     end
   end

--- a/core/lib/spree/core/environment/calculators.rb
+++ b/core/lib/spree/core/environment/calculators.rb
@@ -6,6 +6,10 @@ module Spree
 
         add_class_set :shipping_methods
         add_class_set :tax_rates
+
+        add_class_set :promotion_actions_create_adjustments
+        add_class_set :promotion_actions_create_item_adjustments
+        add_class_set :promotion_actions_create_quantity_adjustments
       end
     end
   end

--- a/core/lib/spree/core/environment_extension.rb
+++ b/core/lib/spree/core/environment_extension.rb
@@ -1,24 +1,28 @@
+require 'spree/core/class_constantizer'
+
 module Spree
   module Core
     module EnvironmentExtension
       extend ActiveSupport::Concern
 
-      def add_class(name)
-        instance_variable_set "@#{name}", Set.new
+      class_methods do
+        def add_class_set(name)
+          define_method(name) do
+            set = instance_variable_get("@#{name}")
+            send("#{name}=", []) unless set
+            set
+          end
 
-        create_method( "#{name}=".to_sym ) { |val|
-          instance_variable_set( "@" + name, val)
-        }
-
-        create_method(name.to_sym) do
-          instance_variable_get( "@" + name )
+          define_method("#{name}=") do |klasses|
+            set = ClassConstantizer::Set.new
+            set.concat(klasses)
+            instance_variable_set("@#{name}", set)
+          end
         end
       end
 
-      private
-
-      def create_method(name, &block)
-        self.class.send(:define_method, name, &block)
+      def add_class(name)
+        singleton_class.send(:add_class_set, name)
       end
     end
   end

--- a/core/lib/spree/promo/environment.rb
+++ b/core/lib/spree/promo/environment.rb
@@ -3,7 +3,8 @@ module Spree
     class Environment
       include Core::EnvironmentExtension
 
-      attr_accessor :rules, :actions
+      add_class_set :rules
+      add_class_set :actions
     end
   end
 end

--- a/core/spec/lib/spree/core/class_constantizer_spec.rb
+++ b/core/spec/lib/spree/core/class_constantizer_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+module ClassConstantizerTest
+  ClassA = Class.new
+  ClassB = Class.new
+
+  def self.reload
+    [:ClassA, :ClassB].each do |klass|
+      remove_const(klass)
+      const_set(klass, Class.new)
+    end
+  end
+end
+
+describe Spree::Core::ClassConstantizer::Set do
+  let(:set) { described_class.new }
+
+  describe "#concat" do
+    it "can add one item" do
+      set.concat(['ClassConstantizerTest::ClassA'])
+      expect(set).to include(ClassConstantizerTest::ClassA)
+    end
+
+    it "can add two items" do
+      set.concat(['ClassConstantizerTest::ClassA', ClassConstantizerTest::ClassB])
+      expect(set).to include(ClassConstantizerTest::ClassA)
+      expect(set).to include(ClassConstantizerTest::ClassB)
+    end
+  end
+
+  describe "<<" do
+    it "can add by string" do
+      set << "ClassConstantizerTest::ClassA"
+      expect(set).to include(ClassConstantizerTest::ClassA)
+    end
+
+    it "can add by class" do
+      set << ClassConstantizerTest::ClassA
+      expect(set).to include(ClassConstantizerTest::ClassA)
+    end
+
+    describe "class redefinition" do
+      shared_examples "working code reloading" do
+        it "works with a class" do
+          original = ClassConstantizerTest::ClassA
+
+          ClassConstantizerTest.reload
+
+          # Sanity check
+          expect(original).not_to eq(ClassConstantizerTest::ClassA)
+
+          expect(set).to include(ClassConstantizerTest::ClassA)
+          expect(set).to_not include(original)
+        end
+      end
+
+      context "with a class" do
+        before { set << ClassConstantizerTest::ClassA }
+        it_should_behave_like "working code reloading"
+      end
+
+      context "with a string" do
+        before { set << "ClassConstantizerTest::ClassA" }
+        it_should_behave_like "working code reloading"
+      end
+    end
+  end
+end


### PR DESCRIPTION
In solidus, we have a `Spree::Core::Environment` class. This class is what's exposed as `config.spree` in initializers and holds mostly configuration on available classes: `shipping_methods`, `payment_methods`, `promotion_rules`, etc.

This has caused some weird issues for quite a while since these classes are put into an array at compile time. If any of these classes are reloaded (as they will be in development) the configuration will hold an out of date version. #899 is an example of an issue arising from this.


This PR adds a `ClassConstantizer::Set` collection to hold these lists of classes. It works by `to_s`ing anything being inserted into the list, and `constantize`ing them when the list is iterated over. This should be backwards compatible for common ways to insert .

This also solves issues caused by autoloading classes too early (#1192)

For the same reasons as this activerecord relations hold `class_name` instead of just a class. Our [UserClassHandle](https://github.com/solidusio/solidus/blob/master/core/app/models/spree/user_class_handle.rb) also serves a similar purpose.