### PR TITLE
Update in memory line items in CreateItemAdjustments

### DIFF
--- a/core/app/models/spree/promotion/actions/create_item_adjustments.rb
+++ b/core/app/models/spree/promotion/actions/create_item_adjustments.rb
@@ -68,10 +68,12 @@ module Spree
         def line_items_to_adjust(promotion, order)
           excluded_ids = adjustments.
             where(adjustable_id: order.line_items.pluck(:id), adjustable_type: 'Spree::LineItem').
-            pluck(:adjustable_id)
+            pluck(:adjustable_id).
+            to_set
 
-          order.line_items.where.not(id: excluded_ids).select do |line_item|
-            promotion.line_item_actionable? order, line_item
+          order.line_items.select do |line_item|
+            !excluded_ids.include?(line_item.id) &&
+              promotion.line_item_actionable?(order, line_item)
           end
         end
       end

--- a/core/spec/models/spree/promotion/actions/create_item_adjustments_spec.rb
+++ b/core/spec/models/spree/promotion/actions/create_item_adjustments_spec.rb
@@ -33,12 +33,18 @@ module Spree
             it "creates adjustment with item as adjustable" do
               action.perform(payload)
               expect(action.adjustments.count).to eq(1)
-              expect(line_item.reload.adjustments).to eq(action.adjustments)
+              expect(line_item.adjustments).to eq(action.adjustments)
             end
 
             it "creates adjustment with self as source" do
               action.perform(payload)
-              expect(line_item.reload.adjustments.first.source).to eq action
+              expect(line_item.adjustments.first.source).to eq action
+            end
+
+            it "updates cached order line items" do
+              order.line_items.to_a
+              action.perform(payload)
+              expect(order.line_items.map(&:adjustment_total)).to eq([-10])
             end
 
             it "does not perform twice on the same item" do

--- a/core/spec/models/spree/promotion/actions/create_item_adjustments_spec.rb
+++ b/core/spec/models/spree/promotion/actions/create_item_adjustments_spec.rb
@@ -5,8 +5,9 @@ module Spree
     module Actions
       describe CreateItemAdjustments, type: :model do
         let(:order) { create(:order) }
-        let(:promotion) { create(:promotion) }
-        let(:action) { CreateItemAdjustments.new }
+        let(:promotion) { create(:promotion, :with_line_item_adjustment, adjustment_rate: adjustment_amount) }
+        let(:adjustment_amount) { 10 }
+        let(:action) { promotion.actions.first! }
         let!(:line_item) { create(:line_item, order: order) }
         let(:payload) { { order: order, promotion: promotion } }
 
@@ -18,9 +19,7 @@ module Spree
         context "#perform" do
           # Regression test for https://github.com/spree/spree/issues/3966
           context "when calculator computes 0" do
-            before do
-              allow(action).to receive_messages compute_amount: 0
-            end
+            let(:adjustment_amount) { 0 }
 
             it "does not create an adjustment when calculator returns 0" do
               action.perform(payload)
@@ -29,10 +28,7 @@ module Spree
           end
 
           context "when calculator returns a non-zero value" do
-            before do
-              promotion.promotion_actions = [action]
-              allow(action).to receive_messages compute_amount: 10
-            end
+            let(:adjustment_amount) { 10 }
 
             it "creates adjustment with item as adjustable" do
               action.perform(payload)
@@ -83,8 +79,7 @@ module Spree
             end
 
             context "when a promotion code is used" do
-              let(:promotion_code) { create(:promotion_code) }
-              let(:promotion) { promotion_code.promotion }
+              let!(:promotion_code) { create(:promotion_code, promotion: promotion) }
               let(:payload) { { order: order, promotion: promotion, promotion_code: promotion_code } }
 
               it "should connect the adjustment to the promotion_code" do


### PR DESCRIPTION
Update in-memory line items in CreateItemAdjustments

Previously this:
```
Spree::PromotionHandler::Coupon.new(order).apply
```
would not update `adjustment_total` on any already-loaded
`order.line_items` because CreateItemAdjustments didn't operate on the
possibly-cached line items, nor did it reload/reset them.
