### PR TITLE
Cleaning up some inline js in admin settings

### DIFF
--- a/backend/app/views/spree/admin/general_settings/edit.html.erb
+++ b/backend/app/views/spree/admin/general_settings/edit.html.erb
@@ -85,11 +85,4 @@
     </fieldset>
 
   </div>
-
-
 <% end %>
-
-<script>
-  $('#store_default_currency').select2();
-  $('#currency').select2();
-</script>


### PR DESCRIPTION
the default_currency and currency fields are not present anymore in the general settings.
this commit cleans up some remaining inline js code.