### PR TITLE
Fix typo in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ When filing an issue on the Solidus project, please provide these details:
 
 * A comprehensive list of steps to reproduce the issue.
 * What you're *expecting* to happen compared with what's *actually* happening.
-* Your application's complete `Gemfile.lock`, and `Gemfile.lock` as text in a [Gist](https://gist.github.com) (*not as an image*)
+* Your application's complete `Gemfile`, and `Gemfile.lock` as text in a [Gist](https://gist.github.com) (*not as an image*)
 * Any relevant stack traces ("Full trace" preferred)
 
 In 99% of cases, this information is enough to determine the cause and solution


### PR DESCRIPTION
I assume we actually want to see the `Gemfile` instead of `Gemfile.lock` twice. ;)