### PR TITLE
Restore price updating in LineItem#options=

### DIFF
--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -102,14 +102,20 @@ module Spree
       !sufficient_stock?
     end
 
-    # Sets options on the line item.
+    # Sets options on the line item and updates the price.
     #
     # The options can be arbitrary attributes on the LineItem.
     #
     # @param options [Hash] options for this line item
     def options=(options = {})
       return unless options.present?
+
       assign_attributes options
+
+      # There's no need to call a pricer if we'll set the price directly.
+      unless options.key?(:price) || options.key?('price')
+        self.money_price = variant.price_for(pricing_options)
+      end
     end
 
     def pricing_options

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -214,6 +214,12 @@ describe Spree::LineItem, type: :model do
       line_item.options = { price: 123 }
       expect(line_item.price).to eq 123
     end
+
+    it "updates the price based on the options provided" do
+      expect(line_item).to receive(:gift_wrap=).with(true)
+      expect(line_item).to receive(:money_price=)
+      line_item.options = { gift_wrap: true }
+    end
   end
 
   describe 'money_price=' do

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -207,12 +207,10 @@ describe Spree::LineItem, type: :model do
 
   describe "#options=" do
     it "can handle updating a blank line item with no order" do
-      expect(Spree::Deprecation).not_to receive(:warn)
       line_item.options = { price: 123 }
     end
 
     it "updates the data provided in the options" do
-      expect(Spree::Deprecation).not_to receive(:warn)
       line_item.options = { price: 123 }
       expect(line_item.price).to eq 123
     end


### PR DESCRIPTION
LineItem#options= previously updated the price when the options
changed.  This was removed with the Pricer work but might cause
backward-compatiblity problems for stores that are using it.

This was a breaking change for our code while updating to Solidus v1.3.  We are using a gift_wrap attribute.

There doesn't seem to be any real point to having `LineItem#options=` other than updating the price. Perhaps we should also (or instead) consider deprecating or removing or renaming `LineItem#options=`?  As @mamhoff pointed out in chat, it's strange that if you update an attribute directly it won't affect the price, but if you update it through `options=` then the price does update.