### PR TITLE
kaminari 0.17.0 deprecates num_pages for total_pages

### DIFF
--- a/api/app/views/spree/api/countries/index.v1.rabl
+++ b/api/app/views/spree/api/countries/index.v1.rabl
@@ -4,4 +4,4 @@ child(@countries => :countries) do
 end
 node(:count) { @countries.count }
 node(:current_page) { params[:page] || 1 }
-node(:pages) { @countries.num_pages }
+node(:pages) { @countries.total_pages }

--- a/api/app/views/spree/api/orders/index.v1.rabl
+++ b/api/app/views/spree/api/orders/index.v1.rabl
@@ -4,4 +4,4 @@ child(@orders => :orders) do
 end
 node(:count) { @orders.count }
 node(:current_page) { params[:page] || 1 }
-node(:pages) { @orders.num_pages }
+node(:pages) { @orders.total_pages }

--- a/api/app/views/spree/api/orders/mine.v1.rabl
+++ b/api/app/views/spree/api/orders/mine.v1.rabl
@@ -6,4 +6,4 @@ end
 
 node(:count) { @orders.count }
 node(:current_page) { params[:page] || 1 }
-node(:pages) { @orders.num_pages }
+node(:pages) { @orders.total_pages }

--- a/api/app/views/spree/api/payments/index.v1.rabl
+++ b/api/app/views/spree/api/payments/index.v1.rabl
@@ -4,4 +4,4 @@ child(@payments => :payments) do
 end
 node(:count) { @payments.count }
 node(:current_page) { params[:page] || 1 }
-node(:pages) { @payments.num_pages }
+node(:pages) { @payments.total_pages }

--- a/api/app/views/spree/api/product_properties/index.v1.rabl
+++ b/api/app/views/spree/api/product_properties/index.v1.rabl
@@ -1,7 +1,7 @@
 object false
 child(@product_properties => :product_properties) do
-  attributes *product_property_attributes 
+  attributes *product_property_attributes
 end
 node(:count) { @product_properties.count }
 node(:current_page) { params[:page] || 1 }
-node(:pages) { @product_properties.num_pages }
+node(:pages) { @product_properties.total_pages }

--- a/api/app/views/spree/api/products/index.v1.rabl
+++ b/api/app/views/spree/api/products/index.v1.rabl
@@ -3,7 +3,7 @@ node(:count) { @products.count }
 node(:total_count) { @products.total_count }
 node(:current_page) { params[:page] ? params[:page].to_i : 1 }
 node(:per_page) { params[:per_page] || Kaminari.config.default_per_page }
-node(:pages) { @products.num_pages }
+node(:pages) { @products.total_pages }
 child(@products => :products) do
   extends "spree/api/products/show"
 end

--- a/api/app/views/spree/api/properties/index.v1.rabl
+++ b/api/app/views/spree/api/properties/index.v1.rabl
@@ -4,4 +4,4 @@ child(@properties => :properties) do
 end
 node(:count) { @properties.count }
 node(:current_page) { params[:page] || 1 }
-node(:pages) { @properties.num_pages }
+node(:pages) { @properties.total_pages }

--- a/api/app/views/spree/api/return_authorizations/index.v1.rabl
+++ b/api/app/views/spree/api/return_authorizations/index.v1.rabl
@@ -4,4 +4,4 @@ child(@return_authorizations => :return_authorizations) do
 end
 node(:count) { @return_authorizations.count }
 node(:current_page) { params[:page] || 1 }
-node(:pages) { @return_authorizations.num_pages }
+node(:pages) { @return_authorizations.total_pages }

--- a/api/app/views/spree/api/shipments/mine.v1.rabl
+++ b/api/app/views/spree/api/shipments/mine.v1.rabl
@@ -2,7 +2,7 @@ object false
 
 node(:count) { @shipments.count }
 node(:current_page) { params[:page] || 1 }
-node(:pages) { @shipments.num_pages }
+node(:pages) { @shipments.total_pages }
 
 child(@shipments => :shipments) do
   extends "spree/api/shipments/big"

--- a/api/app/views/spree/api/states/index.v1.rabl
+++ b/api/app/views/spree/api/states/index.v1.rabl
@@ -7,8 +7,8 @@ child(@states => :states) do
   attributes *state_attributes
 end
 
-if @states.respond_to?(:num_pages)
+if @states.respond_to?(:total_pages)
   node(:count) { @states.count }
   node(:current_page) { params[:page] || 1 }
-  node(:pages) { @states.num_pages }
+  node(:pages) { @states.total_pages }
 end

--- a/api/app/views/spree/api/stock_items/index.v1.rabl
+++ b/api/app/views/spree/api/stock_items/index.v1.rabl
@@ -4,4 +4,4 @@ child(@stock_items => :stock_items) do
 end
 node(:count) { @stock_items.count }
 node(:current_page) { params[:page] || 1 }
-node(:pages) { @stock_items.num_pages }
+node(:pages) { @stock_items.total_pages }

--- a/api/app/views/spree/api/stock_locations/index.v1.rabl
+++ b/api/app/views/spree/api/stock_locations/index.v1.rabl
@@ -4,4 +4,4 @@ child(@stock_locations => :stock_locations) do
 end
 node(:count) { @stock_locations.count }
 node(:current_page) { params[:page] || 1 }
-node(:pages) { @stock_locations.num_pages }
+node(:pages) { @stock_locations.total_pages }

--- a/api/app/views/spree/api/stock_movements/index.v1.rabl
+++ b/api/app/views/spree/api/stock_movements/index.v1.rabl
@@ -4,4 +4,4 @@ child(@stock_movements => :stock_movements) do
 end
 node(:count) { @stock_movements.count }
 node(:current_page) { params[:page] || 1 }
-node(:pages) { @stock_movements.num_pages }
+node(:pages) { @stock_movements.total_pages }

--- a/api/app/views/spree/api/store_credit_events/mine.v1.rabl
+++ b/api/app/views/spree/api/store_credit_events/mine.v1.rabl
@@ -7,4 +7,4 @@ end
 
 node(:count) { @store_credit_events.count }
 node(:current_page) { params[:page] || 1 }
-node(:pages) { @store_credit_events.num_pages }
+node(:pages) { @store_credit_events.total_pages }

--- a/api/app/views/spree/api/taxonomies/index.v1.rabl
+++ b/api/app/views/spree/api/taxonomies/index.v1.rabl
@@ -4,4 +4,4 @@ child(@taxonomies => :taxonomies) do
 end
 node(:count) { @taxonomies.count }
 node(:current_page) { params[:page] || 1 }
-node(:pages) { @taxonomies.num_pages }
+node(:pages) { @taxonomies.total_pages }

--- a/api/app/views/spree/api/taxons/index.v1.rabl
+++ b/api/app/views/spree/api/taxons/index.v1.rabl
@@ -3,7 +3,7 @@ node(:count) { @taxons.count }
 node(:total_count) { @taxons.total_count }
 node(:current_page) { params[:page] ? params[:page].to_i : 1 }
 node(:per_page) { params[:per_page] || Kaminari.config.default_per_page }
-node(:pages) { @taxons.num_pages }
+node(:pages) { @taxons.total_pages }
 child @taxons => :taxons do
   attributes *taxon_attributes
   unless params[:without_children]

--- a/api/app/views/spree/api/users/index.v1.rabl
+++ b/api/app/views/spree/api/users/index.v1.rabl
@@ -4,4 +4,4 @@ child(@users => :users) do
 end
 node(:count) { @users.count }
 node(:current_page) { params[:page] || 1 }
-node(:pages) { @users.num_pages }
+node(:pages) { @users.total_pages }

--- a/api/app/views/spree/api/variants/index.v1.rabl
+++ b/api/app/views/spree/api/variants/index.v1.rabl
@@ -2,7 +2,7 @@ object false
 node(:count) { @variants.count }
 node(:total_count) { @variants.total_count }
 node(:current_page) { params[:page] ? params[:page].to_i : 1 }
-node(:pages) { @variants.num_pages }
+node(:pages) { @variants.total_pages }
 
 child(@variants => :variants) do
   extends "spree/api/variants/big"

--- a/api/app/views/spree/api/zones/index.v1.rabl
+++ b/api/app/views/spree/api/zones/index.v1.rabl
@@ -4,4 +4,4 @@ child(@zones => :zones) do
 end
 node(:count) { @zones.count }
 node(:current_page) { params[:page] || 1 }
-node(:pages) { @zones.num_pages }
+node(:pages) { @zones.total_pages }

--- a/api/spec/test_views/spree/api/widgets/index.v1.rabl
+++ b/api/spec/test_views/spree/api/widgets/index.v1.rabl
@@ -4,4 +4,4 @@ child(@collection => :widgets) do
 end
 node(:count) { @collection.count }
 node(:current_page) { params[:page] || 1 }
-node(:pages) { @collection.num_pages }
+node(:pages) { @collection.total_pages }

--- a/backend/app/views/spree/admin/search/products.rabl
+++ b/backend/app/views/spree/admin/search/products.rabl
@@ -3,7 +3,7 @@ node(:count) { @products.count }
 node(:total_count) { @products.total_count }
 node(:current_page) { params[:page] ? params[:page].to_i : 1 }
 node(:per_page) { params[:per_page] || Kaminari.config.default_per_page }
-node(:pages) { @products.num_pages }
+node(:pages) { @products.total_pages }
 child(@products => :products) do
   attributes :id, :name
 end

--- a/frontend/app/views/spree/shared/_products.html.erb
+++ b/frontend/app/views/spree/shared/_products.html.erb
@@ -4,7 +4,7 @@
 %>
 
 <% content_for :head do %>
-  <% if paginated_products.respond_to?(:num_pages) %>
+  <% if paginated_products.respond_to?(:total_pages) %>
     <%= rel_next_prev_link_tags paginated_products %>
   <% end %>
 <% end %>
@@ -41,6 +41,6 @@
   </ul>
 <% end %>
 
-<% if paginated_products.respond_to?(:num_pages) %>
+<% if paginated_products.respond_to?(:total_pages) %>
   <%= paginate paginated_products %>
 <% end %>


### PR DESCRIPTION
https://github.com/amatsuda/kaminari/blob/v0.17.0/lib/kaminari/models/page_scope_methods.rb#L35

total_pages is available in 0.15.0, the lowest kaminari acceptable
by spree_core gemspec, so it works to switch to total_pages.

https://github.com/amatsuda/kaminari/blob/v0.15.0/lib/kaminari/models/page_scope_methods.rb#L34