### PR TITLE
Use supports_partial_index? instead of checking adapter_name in migration

### DIFF
--- a/core/db/migrate/20151219020209_add_stock_item_unique_index.rb
+++ b/core/db/migrate/20151219020209_add_stock_item_unique_index.rb
@@ -1,8 +1,8 @@
 class AddStockItemUniqueIndex < ActiveRecord::Migration
   def change
     # Add a database-level uniqueness constraint for databases that support it
-    # (postgres & sqlite)
-    if connection.adapter_name =~ /postgres|sqlite/i
+    # (postgres and sqlite > 3.8)
+    if connection.supports_partial_index?
       add_index 'spree_stock_items', ['variant_id', 'stock_location_id'], where: 'deleted_at is null', unique: true
     end
   end


### PR DESCRIPTION
In `db/migrate/20151219020209_add_stock_item_unique_index.rb` we were checking adapter name to decide whether or not we could add a partial index. Unfortunately older sqlite versions (below 3.8) don't support partial indexes, which will cause specs to fail.

Fixes #1209