### PR TITLE
Fix failure in Splitter::ShippingCategory spec

### DIFF
--- a/core/spec/models/spree/stock/splitter/shipping_category_spec.rb
+++ b/core/spec/models/spree/stock/splitter/shipping_category_spec.rb
@@ -2,46 +2,44 @@ require 'spec_helper'
 
 module Spree
   module Stock
-    module Splitter
-      describe ShippingCategory, type: :model do
-        let(:order) { create(:order_with_line_items, line_items_count: 1) }
-        let(:line_item) { order.line_items.first }
-        let(:variant1) { build(:variant) }
-        let(:variant2) { build(:variant) }
-        let(:shipping_category_1) { create(:shipping_category, name: 'A') }
-        let(:shipping_category_2) { create(:shipping_category, name: 'B') }
+    describe Splitter::ShippingCategory, type: :model do
+      let(:order) { create(:order_with_line_items, line_items_count: 1) }
+      let(:line_item) { order.line_items.first }
+      let(:variant1) { build(:variant) }
+      let(:variant2) { build(:variant) }
+      let(:shipping_category_1) { create(:shipping_category, name: 'A') }
+      let(:shipping_category_2) { create(:shipping_category, name: 'B') }
 
-        def inventory_unit1
-          build(:inventory_unit, variant: variant1, order: order, line_item: line_item).tap do |inventory_unit|
-            inventory_unit.variant.product.shipping_category = shipping_category_1
-          end
+      def inventory_unit1
+        build(:inventory_unit, variant: variant1, order: order, line_item: line_item).tap do |inventory_unit|
+          inventory_unit.variant.product.shipping_category = shipping_category_1
         end
+      end
 
-        def inventory_unit2
-          build(:inventory_unit, variant: variant2, order: order, line_item: line_item).tap do |inventory_unit|
-            inventory_unit.variant.product.shipping_category = shipping_category_2
-          end
+      def inventory_unit2
+        build(:inventory_unit, variant: variant2, order: order, line_item: line_item).tap do |inventory_unit|
+          inventory_unit.variant.product.shipping_category = shipping_category_2
         end
+      end
 
-        let(:packer) { build(:stock_packer) }
+      let(:packer) { build(:stock_packer) }
 
-        subject { ShippingCategory.new(packer) }
+      subject { described_class.new(packer) }
 
-        it 'splits each package by shipping category' do
-          package1 = Package.new(packer.stock_location)
-          4.times { package1.add inventory_unit1 }
-          8.times { package1.add inventory_unit2 }
+      it 'splits each package by shipping category' do
+        package1 = Package.new(packer.stock_location)
+        4.times { package1.add inventory_unit1 }
+        8.times { package1.add inventory_unit2 }
 
-          package2 = Package.new(packer.stock_location)
-          6.times { package2.add inventory_unit1 }
-          9.times { package2.add inventory_unit2, :backordered }
+        package2 = Package.new(packer.stock_location)
+        6.times { package2.add inventory_unit1 }
+        9.times { package2.add inventory_unit2, :backordered }
 
-          packages = subject.split([package1, package2])
-          expect(packages[0].quantity).to eq 4
-          expect(packages[1].quantity).to eq 8
-          expect(packages[2].quantity).to eq 6
-          expect(packages[3].quantity).to eq 9
-        end
+        packages = subject.split([package1, package2])
+        expect(packages[0].quantity).to eq 4
+        expect(packages[1].quantity).to eq 8
+        expect(packages[2].quantity).to eq 6
+        expect(packages[3].quantity).to eq 9
       end
     end
   end


### PR DESCRIPTION
After the change to use the `ClassConstantizer::Set` in the core engine initializers (#1203), it is possible for this spec to be run before `Spree::Stock::Splitter::ShippingCategory` is loaded. In that case, `ShippingCategory` as it is used here would resolve to `::ShippingCategory` (rails needs a const_missing to fire in order to provide it's autoloading feature).

This fixes the spurious error:

```
ArgumentError:
  When assigning attributes, you must pass a hash as an argument.
# ./spec/models/spree/stock/splitter/shipping_category_spec.rb:28:in `block (2 levels) in <module:Splitter>'
# ./spec/models/spree/stock/splitter/shipping_category_spec.rb:39:in `block (2 levels) in <module:Splitter>'
```