### PR TITLE
make sure add_class_set#getter would return at least [] for first call

### DIFF
--- a/core/lib/spree/core/environment_extension.rb
+++ b/core/lib/spree/core/environment_extension.rb
@@ -9,7 +9,7 @@ module Spree
         def add_class_set(name)
           define_method(name) do
             set = instance_variable_get("@#{name}")
-            send("#{name}=", []) unless set
+            set = send("#{name}=", []) unless set
             set
           end
 

--- a/core/spec/lib/spree/core/environment_extension_spec.rb
+++ b/core/spec/lib/spree/core/environment_extension_spec.rb
@@ -26,8 +26,8 @@ describe Spree::Core::EnvironmentExtension do
   describe '#setter' do
     before { subject.random_name = [C1, C2]; @set = subject.random_name.to_a }
 
-    it { expect(@set).to include(C1)}
-    it { expect(@set).to include(C2)}
-    it { expect(@set).not_to include(C3)}
+    it { expect(@set).to include(C1) }
+    it { expect(@set).to include(C2) }
+    it { expect(@set).not_to include(C3) }
   end
 end

--- a/core/spec/lib/spree/core/environment_extension_spec.rb
+++ b/core/spec/lib/spree/core/environment_extension_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+class DummyClass
+  include Spree::Core::EnvironmentExtension
+end
+
+class C1; end
+class C2; end
+class C3; end
+
+describe Spree::Core::EnvironmentExtension do
+  subject { DummyClass.new }
+
+  before { subject.add_class('random_name') }
+
+  describe 'Basis' do
+    it { respond_to?(:random_name) }
+    it { respond_to?(:random_name=) }
+  end
+
+  describe '#getter' do
+    it { expect(subject.random_name).to be_empty }
+    it { expect(subject.random_name).to be_kind_of Spree::Core::ClassConstantizer::Set }
+  end
+
+  describe '#setter' do
+    before { subject.random_name = [C1, C2]; @set = subject.random_name.to_a }
+
+    it { expect(@set).to include(C1)}
+    it { expect(@set).to include(C2)}
+    it { expect(@set).not_to include(C3)}
+  end
+end


### PR DESCRIPTION
## Issue:

If in the code this is called:

        app.config.spree.calculators.product_customization_types.concat [
                                                                    Spree::Calculator::Engraving,
                                                                    Spree::Calculator::AmountTimesConstant,
                                                                    Spree::Calculator::ProductArea,
                                                                    Spree::Calculator::CustomizationImage,
                                                                    Spree::Calculator::NoCharge
                                                                   ]

and `product_customization_types` is not defined initially, then nil would be returned.

## Expected:

empty array (the set value to that instance variable) to be returned.