### PR TITLE
NotificationDispatch central abstraction for transactional emails

### DIFF
--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -143,7 +143,7 @@ module Spree
       end
 
       def resend
-        OrderMailer.confirm_email(@order.id, true).deliver_later
+        NotificationDispatch.new(:order_confirm).deliver(@order.id, true)
         flash[:success] = Spree.t(:order_email_resent)
 
         redirect_to :back

--- a/core/app/mailers/spree/base_mailer.rb
+++ b/core/app/mailers/spree/base_mailer.rb
@@ -15,7 +15,11 @@ module Spree
     helper_method :money
 
     def mail(headers = {}, &block)
-      super if Spree::Config[:send_core_emails]
+      if Spree::Config[:send_core_emails]
+        super
+      else
+        ActiveSupport::Deprecation.warn "Not sending mail due to `Spree::Config[:send_core_emails]`. This check will be removed from Spree::BaseMailer in the future, please use Spree::NotificationDispatch#deliver instead.", caller
+      end
     end
   end
 end

--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -334,6 +334,7 @@ module Spree
     # @return [ActionMailer::Base] an object that responds to "shipped_email"
     #   (e.g. an ActionMailer with a "shipped_email" method) with the same
     #   signature as Spree::CartonMailer.shipped_email.
+    # @deprecated use Spree::NotificationDispatch::ActionMailerDispatcher.mailer_dispatch_table instead.
     attr_writer :carton_shipped_email_class
     def carton_shipped_email_class
       @carton_shipped_email_class ||= Spree::CartonMailer

--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -334,7 +334,7 @@ module Spree
     # @return [ActionMailer::Base] an object that responds to "shipped_email"
     #   (e.g. an ActionMailer with a "shipped_email" method) with the same
     #   signature as Spree::CartonMailer.shipped_email.
-    # @deprecated use Spree::NotificationDispatch::ActionMailerDispatcher.mailer_dispatch_table instead.
+    # @deprecated use Spree::NotificationDispatch::ActionMailerDispatch.mailer_dispatch_table instead.
     attr_writer :carton_shipped_email_class
     def carton_shipped_email_class
       @carton_shipped_email_class ||= Spree::CartonMailer

--- a/core/app/models/spree/notification_dispatch.rb
+++ b/core/app/models/spree/notification_dispatch.rb
@@ -1,0 +1,81 @@
+module Spree
+  # This class is responsible for sending 'transactional' emails to users,
+  # carton shipped, order confirmed, etc.
+  #
+  # By default it uses the NotificationDispatch::ActionMailerDispatcher to
+  # send emails with ActionMailer. You can change the actual delivery method
+  # by changing `Spree::NotificationDispatch.delivery_class_name` to the name
+  # of a custom class, that sends email with a different API, or even sends
+  # messages by means other than email.
+  #
+  # The sender class should have the same API as the NotificationDispatch:
+  #
+  #    SenderClass.new(message_type_symbol).deliver(messsage, arg1, arg2)
+  #
+  # To add a new notification message, edit NotificationDispatch.signatures
+  # to add the signature, and if using the ActionMailerDispatcher, edit
+  # mailer_dispatch_table there so it knows how to handle it.
+  #
+  # All messages will be suppressed if Spree::Config[:send_core_emails] is false.
+  # additionally you can send only certain messages with eg:
+  #
+  #     Spree::NotificationDispatch.only_messages = [:order_confirm, :carton_shipped]
+  #
+  # or
+  #
+  #     Spree::NotificationDispatch.except_messages = [:reimbursement_processed]
+  class NotificationDispatch
+    # These serve as the specififications of what arguments go with what
+    # notification messages, and are checked at runtime.
+    class_attribute :signatures
+    # the lambda bodies could be non-empty and check actual types if we want.
+    self.signatures = {
+      # should be (carton:, order:, resend: false), but currently supporting
+      # deprecated options.
+      carton_shipped: lambda { |options, deprecated_options = {}| },
+      order_confirm: lambda { |order, resend = false| },
+      order_cancel: lambda { |order, resend = false| },
+      order_inventory_cancel: lambda { |order, inventory_units, resend = false| },
+      reimbursement_processed: lambda { |reimbursement, resend = false| }
+    }
+
+    class_attribute :delivery_class_name
+    # The actual class that does the delivery, by default one that uses ActionMailer.
+    # This class simply needs to have a public API like NotificationDispatch itself:
+    #      sender_class.new(message).deliver(*args)
+    self.delivery_class_name = "Spree::NotificationDispatch::ActionMailerDispatch"
+
+    class_attribute :only_messages
+    class_attribute :except_messages
+
+    attr_reader :message
+
+    def initialize(message)
+      @message = message.to_sym
+      unless signatures.key? message
+        raise ArgumentError.new("Unrecognized message `#{message}`. Do you need to add a message to `#{self.class.name}.signatures`?")
+      end
+    end
+
+    def deliver(*args)
+      if should_send?
+        self.class.check_args(message, args)
+        delivery_class.new(message).deliver(*args)
+      end
+    end
+
+    def should_send?
+      Spree::Config[:send_core_emails] &&
+        (only_messages.nil? || only_messages.include?(message)) &&
+        (except_messages.nil? || except_messages.exclude?(message))
+    end
+
+    def delivery_class
+      delivery_class_name.constantize
+    end
+
+    def self.check_args(message, args)
+      signatures[message].call(*args)
+    end
+  end
+end

--- a/core/app/models/spree/notification_dispatch.rb
+++ b/core/app/models/spree/notification_dispatch.rb
@@ -2,7 +2,7 @@ module Spree
   # This class is responsible for sending 'transactional' emails to users,
   # carton shipped, order confirmed, etc.
   #
-  # By default it uses the NotificationDispatch::ActionMailerDispatcher to
+  # By default it uses the NotificationDispatch::ActionMailerDispatch to
   # send emails with ActionMailer. You can change the actual delivery method
   # by changing `Spree::NotificationDispatch.delivery_class_name` to the name
   # of a custom class, that sends email with a different API, or even sends
@@ -13,7 +13,7 @@ module Spree
   #    SenderClass.new(message_type_symbol).deliver(messsage, arg1, arg2)
   #
   # To add a new notification message, edit NotificationDispatch.signatures
-  # to add the signature, and if using the ActionMailerDispatcher, edit
+  # to add the signature, and if using the ActionMailerDispatch, edit
   # mailer_dispatch_table there so it knows how to handle it.
   #
   # All messages will be suppressed if Spree::Config[:send_core_emails] is false.

--- a/core/app/models/spree/notification_dispatch/action_mailer_dispatch.rb
+++ b/core/app/models/spree/notification_dispatch/action_mailer_dispatch.rb
@@ -23,7 +23,7 @@ class Spree::NotificationDispatch::ActionMailerDispatch
   def initialize(init_message)
     @message = init_message.to_sym
     unless mailer_dispatch_table.key?(message)
-      raise ArgumentError.new("Spree::NotificationDisaptcher::ActionMailerDispatcher: no dispatch found for message `#{message}`. Do you need to configure `#{self.class.name}.dispatch_table`?")
+      raise ArgumentError.new("Spree::NotificationDisaptcher::ActionMailerDispatch: no dispatch found for message `#{message}`. Do you need to configure `#{self.class.name}.dispatch_table`?")
     end
   end
 

--- a/core/app/models/spree/notification_dispatch/action_mailer_dispatch.rb
+++ b/core/app/models/spree/notification_dispatch/action_mailer_dispatch.rb
@@ -44,7 +44,7 @@ class Spree::NotificationDispatch::ActionMailerDispatch
     mailer_class = if message == :carton_shipped &&
                       Spree::Config.carton_shipped_email_class &&
                       Spree::Config.carton_shipped_email_class.name != mailer_class_name
-                    Spree::Deprecation.warn(":carton_shipped_email_class on Spree::Config is deprecated, please customize the #{self.class.name}.dispatch_table instead.")
+                    Spree::Deprecation.warn(":carton_shipped_email_class on Spree::Config is deprecated, please customize the #{self.class.name}.mailer_dispatch_table instead.")
                     Spree::Config.carton_shipped_email_class
                   else
                     mailer_class_name.constantize

--- a/core/app/models/spree/notification_dispatch/action_mailer_dispatch.rb
+++ b/core/app/models/spree/notification_dispatch/action_mailer_dispatch.rb
@@ -1,0 +1,55 @@
+# Default sender class for Spree::NotificationDispatch, sends via
+# ActionMailer.
+#
+# You can see the mapping from notification message types to
+# ActionMailer classes and methods in `.mailer_dispatch_table`, which
+# you can also customize to map to different mailers or methods.
+#
+# The particular argument list for each message type is
+# specified in NotificationDispatch.signatures
+class Spree::NotificationDispatch::ActionMailerDispatch
+  class_attribute :mailer_dispatch_table
+  # values are pairs of fully qualified mailer class names, and method names
+  self.mailer_dispatch_table = {
+    carton_shipped: ['Spree::CartonMailer', :shipped_email],
+    order_confirm: ['Spree::OrderMailer', :confirm_email],
+    order_cancel: ['Spree::OrderMailer', :cancel_email],
+    order_inventory_cancel: ['Spree::OrderMailer', :inventory_cancellation_email],
+    reimbursement_processed: ['Spree::ReimbursementMailer', :reimbursement_email]
+  }
+
+  attr_reader :message
+
+  def initialize(init_message)
+    @message = init_message.to_sym
+    unless mailer_dispatch_table.key?(message)
+      raise ArgumentError.new("Spree::NotificationDisaptcher::ActionMailerDispatcher: no dispatch found for message `#{message}`. Do you need to configure `#{self.class.name}.dispatch_table`?")
+    end
+  end
+
+  def deliver(*args)
+    action_mail_object(*args).deliver_later
+  end
+
+  # Returns an ActionMailer::MessageDelivery, the thing you call #deliver_later
+  # on, can be used in mailer preview actions.
+  def action_mail_object(*args)
+    action_mailer, method = lookup_dispatch
+    action_mailer.send(method, *args)
+  end
+
+  def lookup_dispatch
+    mailer_class_name, mailer_method = mailer_dispatch_table[message]
+
+    mailer_class = if message == :carton_shipped &&
+                      Spree::Config.carton_shipped_email_class &&
+                      Spree::Config.carton_shipped_email_class.name != mailer_class_name
+                    Spree::Deprecation.warn(":carton_shipped_email_class on Spree::Config is deprecated, please customize the #{self.class.name}.dispatch_table instead.")
+                    Spree::Config.carton_shipped_email_class
+                  else
+                    mailer_class_name.constantize
+                  end
+
+    [mailer_class, mailer_method]
+  end
+end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -404,7 +404,7 @@ module Spree
     end
 
     def deliver_order_confirmation_email
-      OrderMailer.confirm_email(self).deliver_later
+      NotificationDispatch.new(:order_confirm).deliver(self)
       update_column(:confirmation_delivered, true)
     end
 
@@ -752,7 +752,7 @@ module Spree
     end
 
     def send_cancel_email
-      OrderMailer.cancel_email(self).deliver_later
+      NotificationDispatch.new(:order_cancel).deliver(self)
     end
 
     def after_resume

--- a/core/app/models/spree/order_cancellations.rb
+++ b/core/app/models/spree/order_cancellations.rb
@@ -38,7 +38,9 @@ class Spree::OrderCancellations
         end
 
         update_shipped_shipments(inventory_units)
-        Spree::OrderMailer.inventory_cancellation_email(@order, inventory_units.to_a).deliver_later if Spree::OrderCancellations.send_cancellation_mailer
+        # TODO: Remove Spree::OrderCancellations.send_cancellation_mailer for
+        # :only/:except configuration in Spree::NotificationDispatch?
+        Spree::NotificationDispatch.new(:order_inventory_cancel).deliver(@order, inventory_units.to_a) if Spree::OrderCancellations.send_cancellation_mailer
       end
 
       @order.update!

--- a/core/app/models/spree/order_shipping.rb
+++ b/core/app/models/spree/order_shipping.rb
@@ -86,7 +86,7 @@ class Spree::OrderShipping
 
   def send_shipment_emails(carton)
     carton.orders.each do |order|
-      Spree::Config.carton_shipped_email_class.shipped_email(order: order, carton: carton).deliver_later
+      Spree::NotificationDispatch.new(:carton_shipped).deliver(order: order, carton: carton)
     end
   end
 end

--- a/core/app/models/spree/reimbursement.rb
+++ b/core/app/models/spree/reimbursement.rb
@@ -160,7 +160,7 @@ module Spree
     end
 
     def send_reimbursement_email
-      Spree::ReimbursementMailer.reimbursement_email(id).deliver_later
+      NotificationDispatch.new(:reimbursement_processed).deliver(id)
     end
 
     # If there are multiple different reimbursement types for a single

--- a/core/lib/spree/mailer_previews/carton_preview.rb
+++ b/core/lib/spree/mailer_previews/carton_preview.rb
@@ -4,7 +4,7 @@ module Spree
       def shipped
         carton = Carton.joins(:orders).last
         raise "Your database needs at one shipped order with a carton to render this preview" unless carton
-        Spree::Config.carton_shipped_email_class.shipped_email(order: carton.orders.first, carton: carton)
+        Spree::NotificationDispatch::ActionMailerDispatcher.new(:carton_shipped).action_mail_object(order: carton.orders.first, carton: carton)
       end
     end
   end

--- a/core/lib/spree/mailer_previews/carton_preview.rb
+++ b/core/lib/spree/mailer_previews/carton_preview.rb
@@ -4,7 +4,7 @@ module Spree
       def shipped
         carton = Carton.joins(:orders).last
         raise "Your database needs at one shipped order with a carton to render this preview" unless carton
-        Spree::NotificationDispatch::ActionMailerDispatcher.new(:carton_shipped).action_mail_object(order: carton.orders.first, carton: carton)
+        Spree::NotificationDispatch::ActionMailerDispatch.new(:carton_shipped).action_mail_object(order: carton.orders.first, carton: carton)
       end
     end
   end

--- a/core/lib/spree/mailer_previews/order_preview.rb
+++ b/core/lib/spree/mailer_previews/order_preview.rb
@@ -4,19 +4,19 @@ module Spree
       def confirm
         order = Order.complete.last
         raise "Your database needs at least one completed order to render this preview" unless order
-        Spree::NotificationDispatch::ActionMailerDispatcher.new(:order_confirm).action_mail_object(order)
+        Spree::NotificationDispatch::ActionMailerDispatch.new(:order_confirm).action_mail_object(order)
       end
 
       def cancel
         order = Order.with_state(:canceled).last
         raise "Your database needs at least one cancelled order to render this preview" unless order
-        Spree::NotificationDispatch::ActionMailerDispatcher.new(:order_cancel).action_mail_object(order)
+        Spree::NotificationDispatch::ActionMailerDispatch.new(:order_cancel).action_mail_object(order)
       end
 
       def inventory_cancellation
         order = Spree::Order.joins(:inventory_units).merge(Spree::InventoryUnit.canceled).last
         raise "Your database needs at least one order with a canceled inventory unit to render this preview" unless order
-        Spree::NotificationDispatch::ActionMailerDispatcher.new(:order_inventory_cancel).action_mail_object(order, [order.inventory_units.first])
+        Spree::NotificationDispatch::ActionMailerDispatch.new(:order_inventory_cancel).action_mail_object(order, [order.inventory_units.first])
       end
     end
   end

--- a/core/lib/spree/mailer_previews/order_preview.rb
+++ b/core/lib/spree/mailer_previews/order_preview.rb
@@ -4,19 +4,19 @@ module Spree
       def confirm
         order = Order.complete.last
         raise "Your database needs at least one completed order to render this preview" unless order
-        OrderMailer.confirm_email(order)
+        Spree::NotificationDispatch::ActionMailerDispatcher.new(:order_confirm).action_mail_object(order)
       end
 
       def cancel
         order = Order.with_state(:canceled).last
         raise "Your database needs at least one cancelled order to render this preview" unless order
-        OrderMailer.cancel_email(order)
+        Spree::NotificationDispatch::ActionMailerDispatcher.new(:order_cancel).action_mail_object(order)
       end
 
       def inventory_cancellation
         order = Spree::Order.joins(:inventory_units).merge(Spree::InventoryUnit.canceled).last
         raise "Your database needs at least one order with a canceled inventory unit to render this preview" unless order
-        OrderMailer.inventory_cancellation_email(order, [order.inventory_units.first])
+        Spree::NotificationDispatch::ActionMailerDispatcher.new(:order_inventory_cancel).action_mail_object(order, [order.inventory_units.first])
       end
     end
   end

--- a/core/lib/spree/mailer_previews/reimbursement_preview.rb
+++ b/core/lib/spree/mailer_previews/reimbursement_preview.rb
@@ -4,7 +4,7 @@ module Spree
       def reimbursement
         reimbursement = Reimbursement.last
         raise "Your database needs at least one Reimbursement to render this preview" unless reimbursement
-        ReimbursementMailer.reimbursement_email(reimbursement)
+        Spree::NotificationDispatch::ActionMailerDispatcher.new(:reimbursement_processed).action_mail_object(reimbursement)
       end
     end
   end

--- a/core/lib/spree/mailer_previews/reimbursement_preview.rb
+++ b/core/lib/spree/mailer_previews/reimbursement_preview.rb
@@ -4,7 +4,7 @@ module Spree
       def reimbursement
         reimbursement = Reimbursement.last
         raise "Your database needs at least one Reimbursement to render this preview" unless reimbursement
-        Spree::NotificationDispatch::ActionMailerDispatcher.new(:reimbursement_processed).action_mail_object(reimbursement)
+        Spree::NotificationDispatch::ActionMailerDispatch.new(:reimbursement_processed).action_mail_object(reimbursement)
       end
     end
   end

--- a/core/spec/models/spree/notification_dispatch/action_mailer_dispatch_spec.rb
+++ b/core/spec/models/spree/notification_dispatch/action_mailer_dispatch_spec.rb
@@ -1,0 +1,76 @@
+require 'spec_helper'
+
+describe Spree::NotificationDispatch::ActionMailerDispatch, type: :model do
+  let(:message) { :order_confirm }
+  let(:arguments) { create(:completed_order_with_totals) }
+  let(:expected_mailer_class_name) { Spree::NotificationDispatch::ActionMailerDispatch.mailer_dispatch_table[message].first }
+  let(:expected_mailer_method_name) { Spree::NotificationDispatch::ActionMailerDispatch.mailer_dispatch_table[message].second }
+
+  it "sends email using configured mailer" do
+    # somehow deliver_later means it's called twice? I dunno.
+    expect(expected_mailer_class_name.constantize).to receive(expected_mailer_method_name).at_least(:once).with(*arguments).and_call_original
+    expect {
+      Spree::NotificationDispatch::ActionMailerDispatch.new(message).deliver(arguments)
+    }.to change{ ActionMailer::Base.deliveries.count }.by(1)
+  end
+
+  describe "action_mail_object" do
+    it "returns ActionMailer::MessageDelivery" do
+      expect(expected_mailer_class_name.constantize).to receive(expected_mailer_method_name).at_least(:once).with(*arguments).and_call_original
+
+      result = Spree::NotificationDispatch::ActionMailerDispatch.new(message).action_mail_object(*arguments)
+
+      expect(result).to be_kind_of(ActionMailer::MessageDelivery)
+      expect(result).to respond_to(:deliver_later)
+    end
+  end
+
+  describe "with unrecognized message type" do
+    it "raises on #new" do
+      expect {
+        Spree::NotificationDispatch::ActionMailerDispatch.new(:no_such_message_type)
+      }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe "custom configured mailer and method" do
+    let(:mock_mail) { double("mail", deliver_later: true ) }
+    let(:custom_method) { :some_method }
+
+    around do |example|
+      ::DummyMailer = Class.new
+      orig_dispatch = Spree::NotificationDispatch::ActionMailerDispatch.mailer_dispatch_table[message]
+      Spree::NotificationDispatch::ActionMailerDispatch.mailer_dispatch_table[message] =
+        ["DummyMailer", custom_method]
+
+      example.run
+
+      Spree::NotificationDispatch::ActionMailerDispatch.mailer_dispatch_table[message] = orig_dispatch
+      Object.send(:remove_const, :DummyMailer)
+    end
+
+    it "sends as configured" do
+      expect(::DummyMailer).to receive(custom_method).with(*arguments).and_return(mock_mail)
+      Spree::NotificationDispatch::ActionMailerDispatch.new(message).deliver(*arguments)
+    end
+  end
+
+  describe "legacy Spree::Config.carton_shipped_email_class" do
+    let(:mock_mail) { double("mail", deliver_later: true ) }
+    let(:message) { :carton_shipped }
+    around do |example|
+      ::DummyMailer = Class.new
+      example.run
+      Object.send(:remove_const, :DummyMailer)
+    end
+    before do
+      Spree::Config.carton_shipped_email_class = DummyMailer
+    end
+
+    it "uses, with deprecation message" do
+      expect(::DummyMailer).to receive(expected_mailer_method_name).with(*arguments).and_return(mock_mail)
+      expect(Spree::Deprecation).to receive(:warn)
+      Spree::NotificationDispatch::ActionMailerDispatch.new(message).deliver(*arguments)
+    end
+  end
+end

--- a/core/spec/models/spree/notification_dispatch_spec.rb
+++ b/core/spec/models/spree/notification_dispatch_spec.rb
@@ -1,0 +1,110 @@
+require 'spec_helper'
+
+describe Spree::NotificationDispatch, type: :model do
+  let(:message) { :order_confirm }
+  let(:arguments) { create(:completed_order_with_totals) }
+
+  after do
+    # reset
+    Spree::NotificationDispatch.only_messages = nil
+    Spree::NotificationDispatch.except_messages = nil
+  end
+
+  it "has ActionMailerDispatch as default delivery" do
+    expect(Spree::NotificationDispatch.delivery_class_name).to eq("Spree::NotificationDispatch::ActionMailerDispatch")
+    expect(Spree::NotificationDispatch.new(message).delivery_class_name).to eq("Spree::NotificationDispatch::ActionMailerDispatch")
+  end
+
+  it "sends an email with good params" do
+    expect {
+      Spree::NotificationDispatch.new(message).deliver(*arguments)
+    }.to change{ ActionMailer::Base.deliveries.count }.by(1)
+  end
+
+  describe "with mocked delivery class" do
+    let(:arguments) { build(:completed_order_with_totals) }
+    let(:mock_instance) { double("delivery_class") }
+
+    around do |example|
+      ::DummyDeliveryDispatch = Class.new do
+        def initialize(message)
+        end
+
+        def deliver(*args)
+        end
+      end
+
+      orig_delivery_class_name = Spree::NotificationDispatch.delivery_class_name
+      Spree::NotificationDispatch.delivery_class_name = "DummyDeliveryDispatch"
+
+      example.run
+
+      Spree::NotificationDispatch.delivery_class_name = orig_delivery_class_name
+      Object.send(:remove_const, :DummyDeliveryDispatch)
+    end
+    before do
+      allow(::DummyDeliveryDispatch).to receive(:new).with(message).and_return(mock_instance)
+    end
+
+    describe "good arguments" do
+      before do
+        expect(::DummyDeliveryDispatch).to receive(:new).with(message).and_return(mock_instance)
+      end
+
+      it "sends to delivery class with good parameters" do
+        expect(mock_instance).to receive(:deliver).with(*arguments)
+        Spree::NotificationDispatch.new(message).deliver(*arguments)
+      end
+    end
+
+    describe "Spree::Config[:send_core_emails] false" do
+      before do
+        Spree::Config.send_core_emails = false
+      end
+      it "does not send" do
+        expect(::DummyDeliveryDispatch).not_to receive(:new)
+        Spree::NotificationDispatch.new(message).deliver(*arguments)
+      end
+    end
+
+    describe "only_messages" do
+      it "sends if message is included in .only_messages" do
+        Spree::NotificationDispatch.only_messages = [message, :whatever]
+        expect(mock_instance).to receive(:deliver).with(*arguments)
+        Spree::NotificationDispatch.new(message).deliver(*arguments)
+      end
+      it "does not send if message is not included in .only_messages" do
+        Spree::NotificationDispatch.only_messages = [:something_else, :other]
+        expect(::DummyDeliveryDispatch).not_to receive(:new).with(message)
+        Spree::NotificationDispatch.new(message).deliver(*arguments)
+      end
+    end
+
+    describe "except_messages" do
+      it "sends if message is not included in .except_messages" do
+        Spree::NotificationDispatch.except_messages = [:something_else, :other]
+        expect(mock_instance).to receive(:deliver).with(*arguments)
+        Spree::NotificationDispatch.new(message).deliver(*arguments)
+      end
+      it "does not send if message is not included in .except_messages" do
+        Spree::NotificationDispatch.except_messages = [message, :whatever]
+        expect(::DummyDeliveryDispatch).not_to receive(:new).with(message)
+        Spree::NotificationDispatch.new(message).deliver(*arguments)
+      end
+    end
+
+    describe "bad arguments" do
+      it "#new raises on unrecognized message type" do
+        expect {
+          Spree::NotificationDispatch.new(:no_such_method)
+        }.to raise_error(ArgumentError)
+      end
+
+      it "#deliver raises on bad parameters" do
+        expect {
+          Spree::NotificationDispatch.new(message).deliver(:one, :two, :three, :bad)
+        }.to raise_error(ArgumentError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Followed @jhawthorn's [ideas](https://github.com/solidusio/solidus/pull/1183#issuecomment-222553265), this is where I ended up. I think it looks pretty good, fairly low line count supporting lots of extension. I could use feedback before I add tests (yes, it's missing tests right now, yeah, I didn't do TDD here. although note it passes all current solidus tests without changing them, and there were existing tests ensuring email is sent at the right places!). 
- I was guided by customization/extension stories, trying to make sure there was a way to do common customizations. Including swapping out ActionMailer for another delivery mechanism (email or even non-email), and adding new notifications (solidus_auth_devise adds a password reset one)
- I tried to provide mechanisms for these extension that do _not_ rely on sub-classing -- I don't think subclassing is really any safer/more desirable than `class_eval`, as sub-classing still has access to all private methods and iVars just like class_eval. 
- I like @jhawthorn's suggestion to separate public API from ActionMailer implementation entirely, but didn't think the 'message type' being sent in needed to be two params (`.new(:order, :confirm)`), one suffices (`.new(:order_confirm)`). Among other things, this makes the story for adding new notification types a lot simpler, as well as diverting just certain notification types from default solidus to your own implementation. 
- With the idea of swapping out the delivery backend, I thought it needed a clear specification in one place of what the possible messages were and what arguments each took. Having to hunt down the current implementation of all the various mailers wasn't good enough. So this does include some simple specification and run-time checking -- could be enhanced in the future to specify/check more things about args within this architecture. This is also where you add additional message types (like solidus_auth_devise and it's password_reset), `Spree::NotificationDispatch.signatures`, taking lambdas that raise on bad messages. 
- I think only/except actually is important frequently needed func -- this argument is supported by the existing  `Spree::OrderCancellations.send_cancellation_mailer`, which is really a subset of general only/except functionality (and could be deprecated for the general config, but hasn't yet been in this PR). So this is built-in, at a higher level than the swappable delivery mechanism. 
- You swap out delivery mechanisms with `Spree::NotificationDispatch.delivery_class_name = 'Whatever::Whatever'` (following general late pattern of string class name instead of class itself, to not have to worry about dev-mode reloading).  Your new sender class just needs a similar `SenderClass.new(:message_type).deliver(type-specific-args)`, and shouldn't need to subclass anything, occasionally might delegate/compose the default `ActionMailerDispatch`.
- The default `ActionMailerDispatcher` lets you change what mailers/methods individual message types are dispatched to, with `Spree::NotificationDispatch::ActionMailerDispatch.mailer_dispatch_table`. 
  Want to keep default solidus for order confirm, but use your own mailer for order cancel? No problem!   (Note this is a superset of existing `carton_shipped_email_class` pref, which only existed for that one set of message types. `Spree::Config.carton_shipped_email_class` _is_ deprecated in this PR). 
