### PR TITLE
Failing spec for change in Coordinator behavior

### DIFF
--- a/core/app/models/spree/stock/inventory_unit_builder.rb
+++ b/core/app/models/spree/stock/inventory_unit_builder.rb
@@ -7,8 +7,8 @@ module Spree
 
       def units
         @order.line_items.flat_map do |line_item|
-          Array.new(line_item.quantity) do |_i|
-            @order.inventory_units.build(
+          Array.new(line_item.quantity) do
+            Spree::InventoryUnit.new(
               pending: true,
               variant: line_item.variant,
               line_item: line_item,

--- a/core/spec/models/spree/stock/coordinator_spec.rb
+++ b/core/spec/models/spree/stock/coordinator_spec.rb
@@ -42,6 +42,15 @@ module Spree
             expect(subject.shipments.count).to eq(StockLocation.count - 1)
           end
         end
+
+        it "does not unintentionally add shipments to the order" do
+          subject.shipments
+          expect {
+            order.update!
+          }.not_to change {
+            order.shipments.count
+          }
+        end
       end
 
       # regression spec


### PR DESCRIPTION
I'm not sure whether I think this is a bug or not, but it was unexpected for
me and broke how we're using Coordinator in our app.  This spec passes
in Solidus 1.2.

In our app we are using Coordinator to generate tentative shipments
without necessarily using those shipments or attaching them to the
order.

But in Solidus v1.3 things have changed so that this has a side effect:

Edit: See @jhawthorn's comment below.

~~In Solidus 1.3 one of my own commits updated Package so that
generated shipments get attached to the order right away:~~
~~https://github.com/solidusio/solidus/commit/796ed7f#diff-e742b21f326403fa3a2b3553e15874ba~~

~~This was to enable tax calculations on shipments and shipping rates.
(See [this comment thread in PR 904](https://github.com/solidusio/solidus/pull/904/#discussion-diff-54887938).)~~

The side effect is that if you call `Coordinator.new(order).shipments` and
then happen to call `order.update!` (or `order.save!`, etc) later then the
new shipments will be saved and attached to the order.

It feels like `Coordinator#shipments` shouldn't mutate the order, and if so
then this is probably a bug.  If we don't think it's a bug then we at least
probably need to add a note to the method and the changelog about this
side effect.

Thoughts?

Just a note - in Solidus 1.2 `order.update!` would not have triggered
this issue since it used `update_columns` instead of `save`.  But
using `save` is a definite improvement, so no complaints about that,
just a note that it's an additional avenue to trigger this in 1.3.
