### PR TITLE
Re-write slow Order/Shipment migration with SQL

### DIFF
--- a/core/db/migrate/20140601011216_set_shipment_total_for_users_upgrading.rb
+++ b/core/db/migrate/20140601011216_set_shipment_total_for_users_upgrading.rb
@@ -3,8 +3,20 @@ class SetShipmentTotalForUsersUpgrading < ActiveRecord::Migration
     # NOTE You might not need this at all unless you're upgrading from Spree 2.1.x
     # or below. For those upgrading this should populate the Order#shipment_total
     # for legacy orders
-    Spree::Order.complete.where('shipment_total = ?', 0).includes(:shipments).find_each do |order|
-      order.update_column(:shipment_total, order.shipments.sum(:cost))
-    end
+    execute <<-EOS.squish
+      UPDATE spree_orders
+      SET shipment_total =
+        COALESCE(
+          (
+            SELECT SUM(spree_shipments.cost)
+            FROM spree_shipments
+            WHERE spree_shipments.order_id = spree_orders.id
+          ),
+          0
+        )
+      WHERE
+        spree_orders.completed_at IS NOT NULL
+        AND spree_orders.shipment_total = 0
+    EOS
   end
 end


### PR DESCRIPTION
This migration was originally written with SQL, but was updated to use
ActiveRecord logic due to an issue related to shipments with no cost:

https://github.com/spree/spree/commit/2b7638eeeb6c5c2f0dded0122ce9a82c1d0f6956

However, the performance of the ActiveRecord version of this query is
significantly impacted by large numbers of Orders and Shipments.

Fortunately for us, the previous SQL version only needs a `COALESCE()`
wrapper around the sub-select to address the same issue the AR version
was written to fix.