### PR TITLE
loosen gemspec to allow awesome_nested_set 3.1 and future 3.x

### DIFF
--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'activemerchant', '~> 1.48'
   s.add_dependency 'acts_as_list', '~> 0.3'
-  s.add_dependency 'awesome_nested_set', '~> 3.0.1'
+  s.add_dependency 'awesome_nested_set', '~> 3.0', '>= 3.0.1'
   s.add_dependency 'carmen', '~> 1.0.0'
   s.add_dependency 'cancancan', '~> 1.10'
   s.add_dependency 'ffaker', '~> 2.0'


### PR DESCRIPTION
I believe 3.1 is needed for Rails5 support, although not totally sure.
In general, unless we know a dependency isn't semver, the default
should be locking to a major version with eg ~> 3.1 (allows any 3.x
gte 3.1), instead of locking to a minor with eg ~> 3.0.1 (allows
any 3.0.x gte 3.0.1)