### PR TITLE
allow truncate_html dependency to float

### DIFF
--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'responders'
   s.add_dependency 'state_machines-activerecord', '~> 0.2'
   s.add_dependency 'stringex', '~> 1.5.1'
-  s.add_dependency 'truncate_html', '0.9.2'
+  s.add_dependency 'truncate_html', '~> 0.9', '>= 0.9.2'
   s.add_dependency 'twitter_cldr', '~> 3.0'
 
   s.add_development_dependency 'email_spec', '~> 1.6'


### PR DESCRIPTION
It was pinned to 0.9.2 exactly. There is a bugfix in 0.9.3.
https://github.com/hgmnz/truncate_html/compare/v0.9.2...v0.9.3