### PR TITLE
Deprecate no-op currency argument to Product.available

### DIFF
--- a/core/app/models/spree/product/scopes.rb
+++ b/core/app/models/spree/product/scopes.rb
@@ -172,7 +172,8 @@ module Spree
     end
 
     # Can't use add_search_scope for this as it needs a default argument
-    def self.available(available_on = nil, _currency = nil)
+    def self.available(available_on = nil, currency = nil)
+      Spree::Deprecation.warn("The second currency argument on Product.available has no effect, and is deprecated", caller) if currency
       joins(master: :prices).where("#{Product.quoted_table_name}.available_on <= ?", available_on || Time.current)
     end
     search_scopes << :available


### PR DESCRIPTION
It's been a no-op since before solidus 1.0,
https://github.com/solidusio/solidus/commit/8403be61e46a46608f9a7a8a10bff1b8e110ba58
circa spree 2.1.

Time to actually deprecate it, as the spree commit in 2013 suggested
was the eventual goal.

I'm not sure the best way to find out if any code internal to solidus
is still passing no-op currency.