### PR TITLE
Migrations to fix up default store and store_id on orders

### DIFF
--- a/core/db/migrate/20140309033438_create_store_from_preferences.rb
+++ b/core/db/migrate/20140309033438_create_store_from_preferences.rb
@@ -27,6 +27,7 @@ class CreateStoreFromPreferences < ActiveRecord::Migration
         s.seo_title        = preference_store.get('spree/app_configuration/default_seo_title') {}
         s.default_currency = preference_store.get('spree/app_configuration/currency') {}
         s.code             = 'spree'
+        s.default          = true
       end.save!
     end
   end

--- a/core/db/migrate/20160608162651_ensure_default_store.rb
+++ b/core/db/migrate/20160608162651_ensure_default_store.rb
@@ -1,0 +1,13 @@
+class EnsureDefaultStore < ActiveRecord::Migration
+  class Store < ActiveRecord::Base
+    self.table_name = 'spree_stores'
+  end
+
+  def up
+    unless Store.where(default: true).exists?
+      store = Store.first
+      raise "Database has no stores. One should have been created in a previous migration." unless store
+      store.update_column(:default, true)
+    end
+  end
+end

--- a/core/db/migrate/20160608180751_ensure_store_on_orders.rb
+++ b/core/db/migrate/20160608180751_ensure_store_on_orders.rb
@@ -1,0 +1,12 @@
+class EnsureStoreOnOrders < ActiveRecord::Migration
+  class Store < ActiveRecord::Base
+    self.table_name = 'spree_stores'
+  end
+  class Order < ActiveRecord::Base
+    self.table_name = 'spree_orders'
+  end
+  def up
+    default_store = Store.find_by(default: true)
+    Order.where(store_id: nil).update_all(store_id: default_store.id)
+  end
+end


### PR DESCRIPTION
Spun off of #1224 and #1225

This PR accomplishes two things:

1)
A previous change to the `CreateStoreFromPreferences` migration caused the store to no longer be set as a default.

This updates that migration to set the store it is creating as the default. This also adds a later migration to set the first store to the default if there is not an existing default. Since the `CreateStoreFromPreferences` migration will be run very shortly after the creation of the Store table, this should be a safe assumption.

This should fix issues like #1150

2)
Adds a migration which is the equivalent of `rake solidus:migrations:ensure_store_on_orders:up`