### PR TITLE
Use order factory in specs to ensure we have a valid model

### DIFF
--- a/core/spec/models/spree/promotion_handler/coupon_spec.rb
+++ b/core/spec/models/spree/promotion_handler/coupon_spec.rb
@@ -128,7 +128,7 @@ module Spree
           end
 
           context "coexists with a non coupon code promo" do
-            let!(:order) { Order.create }
+            let!(:order) { create(:order) }
 
             before do
               allow(order).to receive_messages coupon_code: "10off"

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -135,7 +135,7 @@ describe Spree::Shipment, type: :model do
   end
 
   context "manifest" do
-    let(:order) { Spree::Order.create }
+    let(:order) { create(:order) }
     let(:variant) { create(:variant) }
     let!(:line_item) { order.contents.add variant }
     let!(:shipment) { order.create_proposed_shipments.first }


### PR DESCRIPTION
These `creates` were actually failing because the order didn't have a
store, but we were using `create` instead of `create!` so we didn't
notice.

*Then* `order.contents.add` would get called, which persists using
`order.save!(validate: false)`, bypassing the store validation and
persisting the order in an invalid state.