### PR TITLE
[RFC] Raise exception when there is no default store

### DIFF
--- a/api/spec/requests/rabl_cache_spec.rb
+++ b/api/spec/requests/rabl_cache_spec.rb
@@ -4,6 +4,7 @@ describe "Rabl Cache", type: :request, caching: true do
   let!(:user)  { create(:admin_user) }
 
   before do
+    create(:store)
     create(:variant)
     user.generate_spree_api_key!
     expect(Spree::Product.count).to eq(1)

--- a/api/spec/requests/ransackable_attributes_spec.rb
+++ b/api/spec/requests/ransackable_attributes_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe "Ransackable Attributes" do
+  let!(:store) { create(:store) }
   let(:user) { create(:user).tap(&:generate_spree_api_key!) }
   let(:order) { create(:order_with_line_items, user: user) }
   context "filtering by attributes one association away" do

--- a/api/spec/requests/spree/api/products_controller_spec.rb
+++ b/api/spec/requests/spree/api/products_controller_spec.rb
@@ -4,6 +4,7 @@ require 'shared_examples/protect_product_actions'
 module Spree
   describe Spree::Api::ProductsController, type: :request do
 
+    let!(:store) { create(:store) }
     let!(:product) { create(:product) }
     let!(:inactive_product) { create(:product, available_on: Time.current.tomorrow, name: "inactive") }
     let(:base_attributes) { Api::ApiHelpers.product_attributes }

--- a/api/spec/requests/spree/api/unauthenticated_products_controller_spec.rb
+++ b/api/spec/requests/spree/api/unauthenticated_products_controller_spec.rb
@@ -4,6 +4,7 @@ require 'spec_helper'
 module Spree
   describe Spree::Api::ProductsController, type: :request do
 
+    let!(:store) { create(:store) }
     let!(:product) { create(:product) }
     let(:attributes) { [:id, :name, :description, :price, :available_on, :slug, :meta_description, :meta_keywords, :taxon_ids] }
 

--- a/backend/spec/features/admin/configuration/analytics_tracker_spec.rb
+++ b/backend/spec/features/admin/configuration/analytics_tracker_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+describe "Analytics Tracker", type: :feature do
+  stub_authorization!
+
+  context "index" do
+    before(:each) do
+      2.times { create(:tracker) }
+      visit spree.admin_trackers_path
+    end
+
+    it "should have the right content" do
+      expect(page).to have_content("Analytics Trackers")
+    end
+
+    it "should have the right tabular values displayed" do
+      within_row(1) do
+        expect(column_text(1)).to eq("A100")
+        expect(column_text(2)).to eq("Yes")
+      end
+
+      within_row(2) do
+        expect(column_text(1)).to eq("A100")
+        expect(column_text(2)).to eq("Yes")
+      end
+    end
+  end
+
+  context "create" do
+    it "should be able to create a new analytics tracker" do
+      visit spree.admin_trackers_path
+      click_link "admin_new_tracker_link"
+      fill_in "tracker_analytics_id", with: "A100"
+      click_button "Create"
+
+      expect(page).to have_content("successfully created!")
+      within_row(1) do
+        expect(column_text(1)).to eq("A100")
+        expect(column_text(2)).to eq("Yes")
+      end
+    end
+  end
+end

--- a/backend/spec/features/admin/configuration/payment_methods_spec.rb
+++ b/backend/spec/features/admin/configuration/payment_methods_spec.rb
@@ -3,14 +3,10 @@ require 'spec_helper'
 describe "Payment Methods", type: :feature do
   stub_authorization!
 
-  before(:each) do
-    visit spree.admin_path
-    click_link "Settings"
-  end
-
   context "admin visiting payment methods listing page" do
     before do
       create(:check_payment_method)
+      visit spree.admin_payment_methods_path
     end
 
     it "should display existing payment methods" do
@@ -32,8 +28,7 @@ describe "Payment Methods", type: :feature do
 
   context "admin creating a new payment method" do
     it "should be able to create a new payment method" do
-      click_link "Payments"
-      expect(page).to have_link 'Payment Methods'
+      visit spree.admin_payment_methods_path
       click_link "admin_new_payment_methods_link"
       expect(page).to have_content("New Payment Method")
       fill_in "payment_method_name", with: "check90"
@@ -47,8 +42,7 @@ describe "Payment Methods", type: :feature do
   context "admin editing a payment method" do
     before(:each) do
       create(:check_payment_method)
-      click_link "Payments"
-      expect(page).to have_link 'Payment Methods'
+      visit spree.admin_payment_methods_path
       within("table#listing_payment_methods") do
         click_icon(:edit)
       end
@@ -74,8 +68,7 @@ describe "Payment Methods", type: :feature do
     end
 
     it "displays message when changing type" do
-      click_link "Payments"
-      expect(page).to have_link 'Payment Methods'
+      visit spree.admin_payment_methods_path
       click_icon :edit
       expect(page).to have_content('Test Mode')
 
@@ -92,8 +85,7 @@ describe "Payment Methods", type: :feature do
     it "displays message when changing preference source" do
       Spree::Config.static_model_preferences.add(Spree::PaymentMethod::BogusCreditCard, 'my_prefs', {})
 
-      click_link "Payments"
-      expect(page).to have_link 'Payment Methods'
+      visit spree.admin_payment_methods_path
       click_icon :edit
       expect(page).to have_content('Test Mode')
 
@@ -110,8 +102,7 @@ describe "Payment Methods", type: :feature do
     it "updates successfully and keeps secrets" do
       Spree::Config.static_model_preferences.add(Spree::PaymentMethod::BogusCreditCard, 'my_prefs', { server: 'secret' })
 
-      click_link "Payments"
-      expect(page).to have_link 'Payment Methods'
+      visit spree.admin_payment_methods_path
       click_icon :edit
 
       select 'my_prefs', from: 'Preference Source'

--- a/backend/spec/features/admin/configuration/shipping_methods_spec.rb
+++ b/backend/spec/features/admin/configuration/shipping_methods_spec.rb
@@ -33,7 +33,7 @@ describe "Shipping Methods", type: :feature do
       end
 
       click_on "Create"
-      expect(current_path).to eql(spree.edit_admin_shipping_method_path(Spree::ShippingMethod.last))
+      expect(page).to have_current_path(spree.edit_admin_shipping_method_path(Spree::ShippingMethod.last))
     end
   end
 

--- a/backend/spec/features/admin/configuration/shipping_methods_spec.rb
+++ b/backend/spec/features/admin/configuration/shipping_methods_spec.rb
@@ -6,9 +6,7 @@ describe "Shipping Methods", type: :feature do
   let!(:shipping_method) { create(:shipping_method, zones: [zone]) }
 
   before do
-    visit spree.admin_path
-    click_link "Settings"
-    click_link "Shipping"
+    visit spree.admin_shipping_methods_path
   end
 
   context "show" do

--- a/backend/spec/features/admin/configuration/stock_locations_spec.rb
+++ b/backend/spec/features/admin/configuration/stock_locations_spec.rb
@@ -5,10 +5,7 @@ describe "Stock Locations", type: :feature do
 
   before(:each) do
     create(:country)
-    visit spree.admin_path
-    click_link "Settings"
-    click_link "Shipping"
-    click_link "Stock Locations"
+    visit spree.admin_stock_locations_path
   end
 
   it "can create a new stock location" do

--- a/backend/spec/features/admin/configuration/taxonomies_spec.rb
+++ b/backend/spec/features/admin/configuration/taxonomies_spec.rb
@@ -3,16 +3,11 @@ require 'spec_helper'
 describe "Taxonomies", type: :feature do
   stub_authorization!
 
-  before(:each) do
-    visit spree.admin_path
-    click_link "Settings"
-  end
-
   context "show" do
     it "should display existing taxonomies" do
       create(:taxonomy, name: 'Brand')
       create(:taxonomy, name: 'Categories')
-      click_nav "Products", "Taxonomies"
+      visit spree.admin_taxonomies_path
       within_row(1) { expect(page).to have_content("Brand") }
       within_row(2) { expect(page).to have_content("Categories") }
     end
@@ -20,7 +15,7 @@ describe "Taxonomies", type: :feature do
 
   context "create" do
     before(:each) do
-      click_nav "Products", "Taxonomies"
+      visit spree.admin_taxonomies_path
       click_link "admin_new_taxonomy_link"
     end
 
@@ -41,7 +36,7 @@ describe "Taxonomies", type: :feature do
   context "edit" do
     it "should allow an admin to update an existing taxonomy" do
       create(:taxonomy)
-      click_nav "Products", "Taxonomies"
+      visit spree.admin_taxonomies_path
       within_row(1) { click_icon :edit }
       fill_in "taxonomy_name", with: "sports 99"
       click_button "Update"

--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -32,7 +32,7 @@ module Spree
     end
 
     def self.default
-      where(default: true).first || new
+      where(default: true).first || raise("No matching or default store found.")
     end
 
     def default_cart_tax_location

--- a/core/spec/models/spree/order/address_spec.rb
+++ b/core/spec/models/spree/order/address_spec.rb
@@ -1,7 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Spree::Order, type: :model do
-  let(:order) { Spree::Order.new }
+  let(:store) { create(:store) }
+  let(:order) { Spree::Order.new(store: store) }
 
   context 'validation' do
     context "when @use_billing is populated" do

--- a/core/spec/models/spree/order/callbacks_spec.rb
+++ b/core/spec/models/spree/order/callbacks_spec.rb
@@ -4,17 +4,6 @@ RSpec.describe Spree::Order, type: :model do
   let(:store) { create(:store) }
   let(:order) { Spree::Order.new(store: store) }
 
-  context "validations" do
-    context "email validation" do
-      # Regression test for https://github.com/spree/spree/issues/1238
-      it "o'brien@gmail.com is a valid email address" do
-        order.state = 'address'
-        order.email = "o'brien@gmail.com"
-        expect(order.error_on(:email).size).to eq(0)
-      end
-    end
-  end
-
   context "#save" do
     context "when associated with a registered user" do
       let(:user) { create(:user, email: "test@example.com") }
@@ -24,15 +13,6 @@ RSpec.describe Spree::Order, type: :model do
         order.save!
         expect(order.email).to eq(user.email)
       end
-    end
-  end
-
-  context "in the cart state" do
-    it "should not validate email address" do
-      order.state = "cart"
-      order.email = nil
-      order.save!
-      expect(order.error_on(:email).size).to eq(0)
     end
   end
 end

--- a/core/spec/models/spree/order/callbacks_spec.rb
+++ b/core/spec/models/spree/order/callbacks_spec.rb
@@ -1,10 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Spree::Order, type: :model do
-  let(:order) { stub_model(Spree::Order) }
-  before do
-    Spree::Order.define_state_machine!
-  end
+  let(:store) { create(:store) }
+  let(:order) { Spree::Order.new(store: store) }
 
   context "validations" do
     context "email validation" do
@@ -19,14 +17,11 @@ RSpec.describe Spree::Order, type: :model do
 
   context "#save" do
     context "when associated with a registered user" do
-      let(:user) { double(:user, email: "test@example.com") }
-
-      before do
-        allow(order).to receive_messages user: user
-      end
+      let(:user) { create(:user, email: "test@example.com") }
 
       it "should assign the email address of the user" do
-        order.run_callbacks(:create)
+        order.user = user
+        order.save!
         expect(order.email).to eq(user.email)
       end
     end
@@ -36,6 +31,7 @@ RSpec.describe Spree::Order, type: :model do
     it "should not validate email address" do
       order.state = "cart"
       order.email = nil
+      order.save!
       expect(order.error_on(:email).size).to eq(0)
     end
   end

--- a/core/spec/models/spree/order/payment_spec.rb
+++ b/core/spec/models/spree/order/payment_spec.rb
@@ -94,8 +94,9 @@ module Spree
     end
 
     context "ensure source attributes stick around" do
-      let(:order){ Spree::Order.create }
-      let(:payment_method){ create(:credit_card_payment_method) }
+      let(:store) { create(:store) }
+      let(:order) { Spree::Order.create(store: store) }
+      let(:payment_method) { create(:credit_card_payment_method) }
       let(:payment_attributes) do
         {
           payment_method_id: payment_method.id,

--- a/core/spec/models/spree/order/tax_spec.rb
+++ b/core/spec/models/spree/order/tax_spec.rb
@@ -1,0 +1,82 @@
+require 'spec_helper'
+
+module Spree
+  describe Spree::Order, type: :model do
+    context "#tax_zone" do
+      let(:bill_address) { create :address }
+      let(:ship_address) { create :address }
+      let(:store) { create :store }
+      let(:order) { Spree::Order.create(store: store, ship_address: ship_address, bill_address: bill_address) }
+      let(:zone) { create :zone }
+
+      context "when no zones exist" do
+        it "should return nil" do
+          expect(order.tax_zone).to be_nil
+        end
+      end
+
+      context "when :tax_using_ship_address => true" do
+        before { Spree::Config.set(tax_using_ship_address: true) }
+
+        it "should calculate using ship_address" do
+          expect(Spree::Zone).to receive(:match).at_least(:once).with(ship_address)
+          expect(Spree::Zone).not_to receive(:match).with(bill_address)
+          order.tax_zone
+        end
+      end
+
+      context "when :tax_using_ship_address => false" do
+        before { Spree::Config.set(tax_using_ship_address: false) }
+
+        it "should calculate using bill_address" do
+          expect(Spree::Zone).to receive(:match).at_least(:once).with(bill_address)
+          expect(Spree::Zone).not_to receive(:match).with(ship_address)
+          order.tax_zone
+        end
+      end
+
+      context "when there is a default tax zone" do
+        before do
+          @default_zone = create(:zone, name: "foo_zone")
+          allow(Spree::Zone).to receive_messages default_tax: @default_zone
+        end
+
+        context "when there is a matching zone" do
+          before { allow(Spree::Zone).to receive_messages(match: zone) }
+
+          it "should return the matching zone" do
+            expect(order.tax_zone).to eq(zone)
+          end
+        end
+
+        context "when there is no matching zone" do
+          before { allow(Spree::Zone).to receive_messages(match: nil) }
+
+          it "should return the default tax zone" do
+            expect(order.tax_zone).to eq(@default_zone)
+          end
+        end
+      end
+
+      context "when no default tax zone" do
+        before { allow(Spree::Zone).to receive_messages default_tax: nil }
+
+        context "when there is a matching zone" do
+          before { allow(Spree::Zone).to receive_messages(match: zone) }
+
+          it "should return the matching zone" do
+            expect(order.tax_zone).to eq(zone)
+          end
+        end
+
+        context "when there is no matching zone" do
+          before { allow(Spree::Zone).to receive_messages(match: nil) }
+
+          it "should return nil" do
+            expect(order.tax_zone).to be_nil
+          end
+        end
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/order/validations_spec.rb
+++ b/core/spec/models/spree/order/validations_spec.rb
@@ -2,13 +2,58 @@ require 'rails_helper'
 
 module Spree
   RSpec.describe Spree::Order, type: :model do
-    context "validations" do
-      # Regression test for https://github.com/spree/spree/issues/2214
-      it "does not return two error messages when email is blank" do
-        order = Spree::Order.new
-        allow(order).to receive_messages(require_email: true)
-        order.valid?
-        expect(order.errors[:email]).to eq(["can't be blank"])
+    context "email validation" do
+      let(:store) { create(:store) }
+      let(:order) { Spree::Order.create!(store: store, state: state, email: email) }
+
+      shared_examples "email validated" do
+        # Regression test for https://github.com/spree/spree/issues/1238
+        context "with quote in email" do
+          let(:email) { "o'brien@gmail.com" }
+          it "o'brien@gmail.com is a valid email address" do
+            expect(order).to be_valid
+          end
+        end
+
+        context "with blank email" do
+          let(:email) { nil }
+
+          # Regression test for https://github.com/spree/spree/issues/2214
+          it "Returns a single error message" do
+            expect(order).not_to be_valid
+            expect(order.errors[:email]).to eq(["can't be blank"])
+          end
+        end
+      end
+
+      shared_examples "email not validated" do
+        context "with blank email" do
+          let(:email) { nil }
+          it "is valid" do
+            order.email = nil
+            expect(order).to be_valid
+            expect(order.error_on(:email).size).to eq(0)
+          end
+        end
+      end
+
+      context "new record" do
+        let(:order) { Spree::Order.new(store: store) }
+        it_behaves_like "email not validated"
+      end
+
+      %w[cart address].each do |state_name|
+        context "#{state_name} state" do
+          let(:state) { state_name }
+          it_behaves_like "email not validated"
+        end
+      end
+
+      %w[payment confirm complete].each do |state_name|
+        context "#{state_name} state" do
+          let(:state) { state_name }
+          it_behaves_like "email validated"
+        end
       end
     end
   end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -903,7 +903,8 @@ RSpec.describe Spree::Order, type: :model do
   end
 
   context "#can_ship?" do
-    let(:order) { Spree::Order.create }
+    let(:store) { create(:store) }
+    let(:order) { Spree::Order.create(store: store) }
 
     it "should be true for order in the 'complete' state" do
       allow(order).to receive_messages(complete?: true)
@@ -997,7 +998,8 @@ RSpec.describe Spree::Order, type: :model do
 
   # Regression test for https://github.com/spree/spree/issues/4923
   context "locking" do
-    let(:order) { Spree::Order.create } # need a persisted in order to test locking
+    let(:store) { create(:store) } # need a persisted in order to test locking
+    let(:order) { Spree::Order.create(store: store) } # need a persisted in order to test locking
 
     it 'can lock' do
       order.with_lock {}

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -23,12 +23,6 @@ RSpec.describe Spree::Order, type: :model do
     context 'when there is no store assigned' do
       subject { Spree::Order.new }
 
-      context 'when there is no default store' do
-        it "will not be valid" do
-          expect(subject).not_to be_valid
-        end
-      end
-
       context "when there is a default store" do
         let!(:store) { create(:store) }
 

--- a/core/spec/models/spree/return_authorization_spec.rb
+++ b/core/spec/models/spree/return_authorization_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe Spree::ReturnAuthorization, type: :model do
   end
 
   context "save" do
-    let(:order) { Spree::Order.create }
+    let(:store) { create(:store) }
+    let(:order) { Spree::Order.create(store: store) }
 
     it "should be invalid when order has no inventory units" do
       order.inventory_units.each(&:delete)

--- a/frontend/spec/controllers/controller_helpers_spec.rb
+++ b/frontend/spec/controllers/controller_helpers_spec.rb
@@ -4,6 +4,8 @@ require 'spec_helper'
 # So we need to use one of the controllers inside Spree.
 # ProductsController is good.
 describe Spree::ProductsController, type: :controller do
+  let!(:store) { create(:store) }
+
   before do
     I18n.enforce_available_locales = false
     Spree::Frontend::Config[:locale] = :de

--- a/frontend/spec/controllers/spree/current_order_tracking_spec.rb
+++ b/frontend/spec/controllers/spree/current_order_tracking_spec.rb
@@ -31,6 +31,7 @@ describe 'current order tracking', type: :controller do
 end
 
 describe Spree::OrdersController, type: :controller do
+  let!(:store) { create(:store) }
   let(:user) { create(:user) }
 
   before { allow(controller).to receive_messages(try_spree_current_user: user) }

--- a/frontend/spec/controllers/spree/home_controller_spec.rb
+++ b/frontend/spec/controllers/spree/home_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe Spree::HomeController, type: :controller do
+  let!(:store) { create(:store) }
+
   it "provides current user to the searcher class" do
     user = mock_model(Spree.user_class, last_incomplete_spree_order: nil, spree_api_key: 'fake')
     allow(controller).to receive_messages try_spree_current_user: user

--- a/frontend/spec/controllers/spree/products_controller_spec.rb
+++ b/frontend/spec/controllers/spree/products_controller_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe Spree::ProductsController, type: :controller do
+  let!(:store) { create(:store) }
   let!(:product) { create(:product, available_on: 1.year.from_now) }
 
   # Regression test for https://github.com/spree/spree/issues/1390

--- a/frontend/spec/controllers/spree/taxons_controller_spec.rb
+++ b/frontend/spec/controllers/spree/taxons_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe Spree::TaxonsController, type: :controller do
+  let!(:store) { create(:store) }
+
   it "should provide the current user to the searcher class" do
     taxon = create(:taxon, permalink: "test")
     user = mock_model(Spree.user_class, last_incomplete_spree_order: nil, spree_api_key: 'fake')

--- a/frontend/spec/features/caching/products_spec.rb
+++ b/frontend/spec/features/caching/products_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe 'products', type: :feature, caching: true do
+  let!(:store) { create(:store) }
   let!(:product) { create(:product) }
   let!(:product2) { create(:product) }
   let!(:taxonomy) { create(:taxonomy) }

--- a/frontend/spec/features/caching/taxons_spec.rb
+++ b/frontend/spec/features/caching/taxons_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe 'taxons', type: :feature, caching: true do
+  let!(:store) { create(:store) }
   let!(:taxonomy) { create(:taxonomy) }
   let!(:taxon) { create(:taxon, taxonomy: taxonomy) }
 

--- a/frontend/spec/features/taxons_spec.rb
+++ b/frontend/spec/features/taxons_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe "viewing products", type: :feature, inaccessible: true do
+  let!(:store) { create(:store) }
   let!(:taxonomy) { create(:taxonomy, name: "Category") }
   let!(:super_clothing) { taxonomy.root.children.create(name: "Super Clothing") }
   let!(:t_shirts) { super_clothing.children.create(name: "T-Shirts") }
@@ -10,9 +11,6 @@ describe "viewing products", type: :feature, inaccessible: true do
     product.taxons << t_shirts
   end
   let(:metas) { { meta_description: 'Brand new Ruby on Rails TShirts', meta_title: "Ruby On Rails TShirt", meta_keywords: 'ror, tshirt, ruby' } }
-  let(:store_name) do
-    ((first_store = Spree::Store.first) && first_store.name).to_s
-  end
 
   # Regression test for https://github.com/spree/spree/issues/1796
   it "can see a taxon's products, even if that taxon has child taxons" do
@@ -42,7 +40,7 @@ describe "viewing products", type: :feature, inaccessible: true do
 
     it 'displays title from taxon root and taxon name' do
       visit '/t/category/super-clothing/t-shirts'
-      expect(page).to have_title('Category - T-Shirts - ' + store_name)
+      expect(page).to have_title('Category - T-Shirts - ' + store.name)
     end
 
     # Regression test for https://github.com/spree/spree/issues/2814
@@ -57,7 +55,7 @@ describe "viewing products", type: :feature, inaccessible: true do
     it 'uses taxon name in title when meta_title set to empty string' do
       t_shirts.update_attributes meta_title: ''
       visit '/t/category/super-clothing/t-shirts'
-      expect(page).to have_title('Category - T-Shirts - ' + store_name)
+      expect(page).to have_title('Category - T-Shirts - ' + store.name)
     end
   end
 


### PR DESCRIPTION
We wanted to investigate what it would look like to raise an exception on `Store.current`/`Store.default` if there was no default store in the database.

As you can see there are a lot of spec changes needed to accomplish this, but not an obscene amount. We should think that it will be similar for users upgrading.

Some of the required changes were to avoid the "General Settings" page of the admin (which is actually a page to edit the default store). It would probably be helpful if we could make that page not error as part of #1189
