### PR TITLE
Admin option_types edit form add data-hook

### DIFF
--- a/backend/app/views/spree/admin/option_types/edit.html.erb
+++ b/backend/app/views/spree/admin/option_types/edit.html.erb
@@ -17,12 +17,12 @@
 
 <%= form_for [:admin, @option_type] do |f| %>
 
-  <fieldset class="no-border-bottom">
+  <fieldset data-hook="option-type-edit-form" class="no-border-bottom">
     <legend><%= Spree::OptionType.model_name.human %></legend>
     <%= render :partial => 'form', :locals => { :f => f } %>
   </fieldset>
 
-  <fieldset>
+  <fieldset data-hook="option-value-edit-form">
     <legend><%= plural_resource_name(Spree::OptionValue) %></legend>
     <table class="index sortable" data-hook data-sortable-link="<%= update_values_positions_admin_option_types_url %>">
       <thead data-hook="option_header">


### PR DESCRIPTION
1. datahook added to better locate the fieldset
2. moved the confirm link (`<%= render :partial => 'spree/admin/shared/edit_resource_links' %>`) outside of the fieldset since it is confirming the entire form

![image](https://cloud.githubusercontent.com/assets/1553760/15918832/c21c17b6-2e3d-11e6-9b80-28f5d264e39e.png)
