### PR TITLE
Fix style choosing a customer on admin

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/templates/orders/customer_details/autocomplete.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/orders/customer_details/autocomplete.hbs
@@ -1,6 +1,6 @@
 <div class='customer-autocomplete-item'>
   <div class='customer-details'>
-    <h5 class="customer-email">{{customer.email}}</h5>
+    <span class="customer-email">{{customer.email}}</span>
     {{#if bill_address.firstname }}
       <strong>{{t 'bill_address' }}</strong>
       {{bill_address.firstname}} {{bill_address.lastname}}<br>


### PR DESCRIPTION
Fix style choosing a customer inside admin -> order -> customer section

From:
<img width="769" alt="screen shot 2016-06-09 at 1 25 45 am" src="https://cloud.githubusercontent.com/assets/957520/15920809/914fd1fa-2de2-11e6-85cd-ff2f7e16fec5.png">

To:
<img width="774" alt="screen shot 2016-06-09 at 1 25 12 am" src="https://cloud.githubusercontent.com/assets/957520/15920812/9721c8d6-2de2-11e6-9e2d-bcc43629fe20.png">
