### PR TITLE
Assert factories create valid objects

### DIFF
--- a/core/spec/support/concerns/working_factories.rb
+++ b/core/spec/support/concerns/working_factories.rb
@@ -6,4 +6,8 @@ RSpec.shared_examples_for 'a working factory' do
   it "creates successfully" do
     expect(create(factory)).to be_a(factory_class)
   end
+
+  it "is creates a valid record" do
+    expect(create(factory)).to be_valid
+  end
 end


### PR DESCRIPTION
In previous versions of Spree factories could create invalid objects.
Let's simply assert that objects that get created are in fact valid.