### PR TITLE
Fix Store.current without args

### DIFF
--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -15,6 +15,7 @@ module Spree
     scope :by_url, lambda { |url| where("url like ?", "%#{url}%") }
 
     def self.current(store_key = nil)
+      Spree::Deprecation.warn "Spree::Store.current needs a code or URL as an argument. If you want the default store use Spree::Store.default", caller if !store_key
       current_store = Store.find_by(code: store_key) || Store.by_url(store_key).first if store_key
       current_store || Store.default
     end

--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -15,7 +15,7 @@ module Spree
     scope :by_url, lambda { |url| where("url like ?", "%#{url}%") }
 
     def self.current(store_key = nil)
-      current_store = Store.find_by(code: store_key) || Store.by_url(store_key).first
+      current_store = Store.find_by(code: store_key) || Store.by_url(store_key).first if store_key
       current_store || Store.default
     end
 

--- a/core/lib/spree/core/current_store.rb
+++ b/core/lib/spree/core/current_store.rb
@@ -13,7 +13,11 @@ module Spree
       # looking up by the requesting server's name.
       # @return [Spree::Store]
       def store
-        Spree::Store.current(store_key)
+        if store_key
+          Spree::Store.current(store_key)
+        else
+          Spree::Store.default
+        end
       end
 
       private

--- a/core/spec/models/spree/store_spec.rb
+++ b/core/spec/models/spree/store_spec.rb
@@ -16,23 +16,36 @@ describe Spree::Store, type: :model do
   end
 
   describe '.current' do
-    # there is a default store created with the test_app rake task.
-    let!(:store_1) { Spree::Store.first || create(:store) }
-
+    let!(:store_1) { create(:store) }
+    let!(:store_default) { create(:store, name: 'default', default: true) }
     let!(:store_2) { create(:store, default: false, url: 'www.subdomain.com') }
     let!(:store_3) { create(:store, default: false, url: 'www.another.com', code: 'CODE') }
 
-    it 'should return default when no domain' do
-      expect(subject.class.current).to eql(store_1)
+    delegate :current, to: :described_class
+
+    context "with no argument" do
+      it 'should return default' do
+        pending "This returns an arbitrary store"
+        expect(current).to eql(store_default)
+      end
     end
 
-    it 'should return store for domain' do
-      expect(subject.class.current('spreecommerce.com')).to eql(store_1)
-      expect(subject.class.current('www.subdomain.com')).to eql(store_2)
+    context "with no match" do
+      it 'should return the default domain' do
+        expect(current('foobar.com')).to eql(store_default)
+      end
     end
 
-    it 'should return store by code' do
-      expect(subject.class.current('CODE')).to eql(store_3)
+    context "with matching url" do
+      it 'should return matching store' do
+        expect(current('www.subdomain.com')).to eql(store_2)
+      end
+    end
+
+    context "with matching code" do
+      it 'should return matching store' do
+        expect(current('CODE')).to eql(store_3)
+      end
     end
   end
 

--- a/core/spec/models/spree/store_spec.rb
+++ b/core/spec/models/spree/store_spec.rb
@@ -25,7 +25,6 @@ describe Spree::Store, type: :model do
 
     context "with no argument" do
       it 'should return default' do
-        pending "This returns an arbitrary store"
         expect(current).to eql(store_default)
       end
     end

--- a/core/spec/models/spree/store_spec.rb
+++ b/core/spec/models/spree/store_spec.rb
@@ -25,7 +25,9 @@ describe Spree::Store, type: :model do
 
     context "with no argument" do
       it 'should return default' do
-        expect(current).to eql(store_default)
+        Spree::Deprecation.silence do
+          expect(current).to eql(store_default)
+        end
       end
     end
 


### PR DESCRIPTION
When `Store.current` is called without arguments, it's supposed to return the default store.

Previously it was returning an arbitrary store since `Store.by_url(nil)` returns an SQL scope of `url LIKE '%%'`. It was most likely to return the first, which is why this wasn't noticed.

This also adds a deprecation warning for calling `Store.current` without an argument. Developers may believe it does the same thing as `current_store` (which it can't). I'd be interested in fully deprecating `Store.current` in the future in favour of `current_store` and `order.store`.

Waiting on:

* [x] #1238