### PR TITLE
Reset default_address after persisting addresses

### DIFF
--- a/core/app/models/concerns/spree/user_address_book.rb
+++ b/core/app/models/concerns/spree/user_address_book.rb
@@ -108,7 +108,14 @@ module Spree
 
       if persisted?
         user_address.save!
-        user_addresses.reset # ensures proper ordering
+
+        # If these associations have already been accessed, they will be
+        # caching the existing values.
+        # user_addresses need to be reset to get the new ordering based on any changes
+        # {default_,}user_address needs to be reset as its result is likely to have changed.
+        user_addresses.reset
+        association(:default_user_address).reset
+        association(:default_address).reset
       end
 
       user_address.address

--- a/core/spec/models/spree/concerns/user_address_book_spec.rb
+++ b/core/spec/models/spree/concerns/user_address_book_spec.rb
@@ -336,4 +336,21 @@ module Spree
       expect(subject.default_address).to eq ship_address
     end
   end
+
+  describe "ship_address=" do
+    let!(:user) { create(:user) }
+    let!(:address) { create(:address) }
+
+    # https://github.com/solidusio/solidus/issues/1241
+    it "resets the association and persists" do
+      # Load (which will cache) the has_one association
+      expect(user.ship_address).to be_nil
+
+      user.update!(ship_address: address)
+      expect(user.ship_address).to eq(address)
+
+      user.reload
+      expect(user.ship_address).to eq(address)
+    end
+  end
 end


### PR DESCRIPTION
In 15c226e, `UserAddressBook` was modified so that `default_address` and `default_user_address` are proper associations and can be cached or preloaded.

This change caused an issue where assigning `user.ship_address=` didn't update the value in `user.ship_address`.

``` ruby
user.ship_address #=> nil
user.update!(ship_address: address)
user.ship_address #=> nil
user.reload
user.ship_address #=> #<Spree::Address
```

This is fixed by resetting both the `default_address` and `default_user_address` associations on each call to `save_in_address_book`

Fixes #1241

I'd like to cherry-pick this back to v1.3, since this change was first introduced there.

cc @jrochkind 