### PR TITLE
Don't cache Spree::Config.default_pricing_options

### DIFF
--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -299,7 +299,7 @@ module Spree
     # @return [variant_price_selector_class] An instance of the pricing options class with default desired
     #   attributes
     def default_pricing_options
-      @default_pricing_options ||= pricing_options_class.new
+      pricing_options_class.new
     end
 
     attr_writer :variant_search_class

--- a/core/lib/spree/core/price_migrator.rb
+++ b/core/lib/spree/core/price_migrator.rb
@@ -7,10 +7,6 @@ module Spree
       # We need to tag the exisiting prices as "default", so that the VatPriceGenerator knows
       # that they include the default zone's VAT.
       Spree::Config.admin_vat_country_iso = Spree::Zone.default_tax.countries.first.iso
-      # If we don't remove this ivar, the above line stays without effect because of caching.
-      if Spree::Config.instance_variables.include?(:@default_pricing_options)
-        Spree::Config.remove_instance_variable(:@default_pricing_options)
-      end
       Spree::Variant.find_each do |variant|
         new(variant).migrate_vat_prices
       end

--- a/core/spec/models/spree/app_configuration_spec.rb
+++ b/core/spec/models/spree/app_configuration_spec.rb
@@ -28,11 +28,6 @@ describe Spree::AppConfiguration, type: :model do
     expect(prefs.pricing_options_class).to eq Spree::Variant::PriceSelector.pricing_options_class
   end
 
-  it "has an instacached getter for the default pricing options" do
-    expect(prefs.default_pricing_options).to be_a Spree::Variant::PriceSelector.pricing_options_class
-    expect(prefs.default_pricing_options.object_id).to eq prefs.default_pricing_options.object_id
-  end
-
   describe '#stock' do
     subject { prefs.stock }
     it { is_expected.to be_a Spree::Core::StockConfiguration }

--- a/frontend/spec/features/products_spec.rb
+++ b/frontend/spec/features/products_spec.rb
@@ -66,7 +66,6 @@ describe "Visiting Products", type: :feature, inaccessible: true do
   context "using Russian Rubles as a currency" do
     before do
       Spree::Config[:currency] = "RUB"
-      Spree::Config.remove_instance_variable(:@default_pricing_options)
     end
 
     let!(:product) do


### PR DESCRIPTION
This is built on top of #1246. The commit to be reviewed is https://github.com/solidusio/solidus/pull/1249/commits/62b247bc6a4e7f58f49e84cdd97a4e6576639846

I don't think there's a need to cache this as the only work it does is look up two Config settings.

Removing the caching allows removing a hack from the `PriceMigrator`.