### PR TITLE
Deprecate Variant.active, Variant#price_in, Variant#amount_in

### DIFF
--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -94,9 +94,11 @@ module Spree
     # Returns variants that are not deleted and have a price in the given
     # currency.
     #
+    # @deprecated Please use the .with_prices scope instead
     # @param currency [String] the currency to filter by; defaults to Spree's default
     # @return [ActiveRecord::Relation]
     def self.active(currency = nil)
+      Spree::Deprecation.warn("`Variant.active(currency)` is deprecated. Please use `Variant.with_prices(pricing_options)` instead.", caller)
       joins(:prices).where(deleted_at: nil).where('spree_prices.currency' => currency || Spree::Config[:currency]).where('spree_prices.amount IS NOT NULL')
     end
 

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -266,19 +266,23 @@ module Spree
 
     # Converts the variant's price to the given currency.
     #
+    # @deprecated Please use #price_for(pricing_options) instead
     # @param currency [String] the desired currency
     # @return [Spree::Price] the price in the desired currency
     def price_in(currency)
       prices.currently_valid.find_by(currency: currency)
     end
+    deprecate price_in: :price_for, deprecator: Spree::Deprecation
 
     # Fetches the price amount in the specified currency.
     #
+    # @deprecated Please use #price_for instead and use a money object rathern than a BigDecimal.
     # @param currency (see #price)
     # @return [Float] the amount in the specified currency.
     def amount_in(currency)
       price_in(currency).try(:amount)
     end
+    deprecate amount_in: :price_for, deprecator: Spree::Deprecation
 
     # Generates a friendly name and sku string.
     #

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -205,6 +205,8 @@ describe Spree::Variant, type: :model do
 
   context "#default_price" do
     context "when multiple prices are present in addition to a default price" do
+      let(:pricing_options_germany) { Spree::Config.pricing_options_class.new(currency: "EUR") }
+      let(:pricing_options_united_states) { Spree::Config.pricing_options_class.new(currency: "USD") }
       before do
         variant.prices << create(:price, variant: variant, currency: "USD", amount: 12.12, is_default: false)
         variant.prices << create(:price, variant: variant, currency: "EUR", amount: 29.99)
@@ -217,8 +219,8 @@ describe Spree::Variant, type: :model do
       end
 
       it "displays default price" do
-        expect(variant.price_in("USD").display_amount.to_s).to eq("$19.99")
-        expect(variant.price_in("EUR").display_amount.to_s).to eq("€29.99")
+        expect(variant.price_for(pricing_options_united_states).to_s).to eq("$19.99")
+        expect(variant.price_for(pricing_options_germany).to_s).to eq("€29.99")
       end
     end
 
@@ -347,7 +349,10 @@ describe Spree::Variant, type: :model do
     before do
       variant.prices << create(:price, variant: variant, currency: "EUR", amount: 33.33)
     end
-    subject { variant.price_in(currency) }
+
+    subject do
+      Spree::Deprecation.silence { variant.price_in(currency) }
+    end
 
     context "when currency is not specified" do
       let(:currency) { nil }
@@ -379,7 +384,9 @@ describe Spree::Variant, type: :model do
       variant.prices << create(:price, variant: variant, currency: "EUR", amount: 33.33)
     end
 
-    subject { variant.amount_in(currency) }
+    subject do
+      Spree::Deprecation.silence { variant.amount_in(currency) }
+    end
 
     context "when currency is not specified" do
       let(:currency) { nil }


### PR DESCRIPTION
As noted in Slack by @jrochkind , all of these methods have an alternative now that can deal with more than just currency as a price determinator, and it's very hard to find out what that alternative is if you're not me. That's what these deprecations are doing. 