### PR TITLE
Remove shipping_method_id as permitted checkout attribute

### DIFF
--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -45,7 +45,7 @@ module Spree
     @@address_book_attributes = address_attributes + [:default]
 
     @@checkout_attributes = [
-      :coupon_code, :email, :shipping_method_id, :special_instructions, :use_billing
+      :coupon_code, :email, :special_instructions, :use_billing
     ]
 
     @@credit_card_update_attributes = [


### PR DESCRIPTION
I'm not sure what this could be used for. Orders don't have a shipping_method_id attribute do they?