### PR TITLE
Raise on deprecations in the test app

### DIFF
--- a/api/app/controllers/spree/api/checkouts_controller.rb
+++ b/api/app/controllers/spree/api/checkouts_controller.rb
@@ -16,7 +16,7 @@ module Spree
 
       def next
         if @order.confirm?
-          ActiveSupport::Deprecation.warn "Using Spree::Api::CheckoutsController#next to transition to complete is deprecated. Please use #complete instead of #next.", caller
+          Spree::Deprecation.warn "Using Spree::Api::CheckoutsController#next to transition to complete is deprecated. Please use #complete instead of #next.", caller
           complete
           return
         end
@@ -94,12 +94,12 @@ module Spree
         massaged_params = params.deep_dup
 
         if params[:payment_source].present?
-          ActiveSupport::Deprecation.warn("Passing payment_source is deprecated. Send source parameters inside payments_attributes[:source_attributes].", caller)
+          Spree::Deprecation.warn("Passing payment_source is deprecated. Send source parameters inside payments_attributes[:source_attributes].", caller)
           move_payment_source_into_payments_attributes(massaged_params)
         end
 
         if params[:order] && params[:order][:existing_card].present?
-          ActiveSupport::Deprecation.warn("Passing order[:existing_card] is deprecated. Send existing_card_id inside of payments_attributes[:source_attributes].", caller)
+          Spree::Deprecation.warn("Passing order[:existing_card] is deprecated. Send existing_card_id inside of payments_attributes[:source_attributes].", caller)
           move_existing_card_into_payments_attributes(massaged_params)
         end
 

--- a/api/spec/controllers/spree/api/checkouts_controller_spec.rb
+++ b/api/spec/controllers/spree/api/checkouts_controller_spec.rb
@@ -237,7 +237,7 @@ module Spree
           end
 
           it "succeeds" do
-            ActiveSupport::Deprecation.silence do
+            Spree::Deprecation.silence do
               api_put(:update, params)
             end
             expect(response.status).to eq(200)
@@ -295,7 +295,7 @@ module Spree
           end
 
           it 'returns errors' do
-            ActiveSupport::Deprecation.silence do
+            Spree::Deprecation.silence do
               api_put(:update, params)
             end
 
@@ -369,7 +369,7 @@ module Spree
               receive(:verification_value=).with('456').and_call_original
             )
 
-            ActiveSupport::Deprecation.silence do
+            Spree::Deprecation.silence do
               api_put(:update, params)
             end
 
@@ -458,7 +458,7 @@ module Spree
         context "with order in confirm state" do
           subject do
             if action == :next
-              ActiveSupport::Deprecation.silence do
+              Spree::Deprecation.silence do
                 api_put action, params
               end
             else

--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -174,7 +174,7 @@ module Spree
 
     def define_image_method(style)
       self.class.send :define_method, "#{style}_image" do |product, *options|
-        ActiveSupport::Deprecation.warn "Spree image helpers will be deprecated in the near future. Use the provided resource to access the intendend image directly.", caller
+        Spree::Deprecation.warn "Spree image helpers will be deprecated in the near future. Use the provided resource to access the intendend image directly.", caller
         options = options.first || {}
         if product.images.empty?
           if !product.is_a?(Spree::Variant) && !product.variant_images.empty?

--- a/core/app/mailers/spree/base_mailer.rb
+++ b/core/app/mailers/spree/base_mailer.rb
@@ -4,7 +4,7 @@ module Spree
       if store
         store.mail_from_address
       else
-        ActiveSupport::Deprecation.warn "A Spree::Store should be provided to determine the from address.", caller
+        Spree::Deprecation.warn "A Spree::Store should be provided to determine the from address.", caller
         Spree::Config[:mails_from]
       end
     end

--- a/core/app/mailers/spree/carton_mailer.rb
+++ b/core/app/mailers/spree/carton_mailer.rb
@@ -15,7 +15,7 @@ module Spree
     #   def shipped_email(carton:, order:, resend: false)
     def shipped_email(options, deprecated_options = {})
       if options.is_a?(Integer)
-        ActiveSupport::Deprecation.warn "Calling shipped_email with a carton_id is DEPRECATED. Instead use CartonMailer.shipped_email(order: order, carton: carton)"
+        Spree::Deprecation.warn "Calling shipped_email with a carton_id is DEPRECATED. Instead use CartonMailer.shipped_email(order: order, carton: carton)"
         @carton = Carton.find(options)
         @order = @carton.orders.first # assume first order
         @manifest = @carton.manifest # use the entire manifest, since we don't know the precise order

--- a/core/app/mailers/spree/order_mailer.rb
+++ b/core/app/mailers/spree/order_mailer.rb
@@ -30,7 +30,7 @@ module Spree
       if order.respond_to?(:id)
         order
       else
-        ActiveSupport::Deprecation.warn("Calling OrderMailer with an id is deprecated. Pass the Spree::Order object instead.")
+        Spree::Deprecation.warn("Calling OrderMailer with an id is deprecated. Pass the Spree::Order object instead.")
         Spree::Order.find(order)
       end
     end

--- a/core/app/models/concerns/spree/user_payment_source.rb
+++ b/core/app/models/concerns/spree/user_payment_source.rb
@@ -15,7 +15,7 @@ module Spree
     end
 
     def drop_payment_source(source)
-      ActiveSupport::Deprecation.warn("User#drop_payment_source is deprecated", caller)
+      Spree::Deprecation.warn("User#drop_payment_source is deprecated", caller)
       gateway = source.payment_method
       gateway.disable_customer_profile(source)
     end

--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -28,7 +28,7 @@ module Spree
     end
 
     def self.default(user = nil, kind = "bill")
-      ActiveSupport::Deprecation.warn("Address.default is deprecated. Use User.default_address or Address.build_default", caller)
+      Spree::Deprecation.warn("Address.default is deprecated. Use User.default_address or Address.build_default", caller)
       if user
         user.send(:"#{kind}_address") || build_default
       else
@@ -106,12 +106,12 @@ module Spree
     end
 
     def same_as?(other_address)
-      ActiveSupport::Deprecation.warn("Address.same_as? is deprecated. It's equivalent to Address.==", caller)
+      Spree::Deprecation.warn("Address.same_as? is deprecated. It's equivalent to Address.==", caller)
       self == other_address
     end
 
     def same_as(other_address)
-      ActiveSupport::Deprecation.warn("Address.same_as is deprecated. It's equivalent to Address.==", caller)
+      Spree::Deprecation.warn("Address.same_as is deprecated. It's equivalent to Address.==", caller)
       self == other_address
     end
 

--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -31,12 +31,12 @@ module Spree
 
     scope :not_finalized, -> { where(finalized: false) }
     scope :open, -> do
-      ActiveSupport::Deprecation.warn "Adjustment.open is deprecated. Instead use Adjustment.not_finalized", caller
+      Spree::Deprecation.warn "Adjustment.open is deprecated. Instead use Adjustment.not_finalized", caller
       where(finalized: false)
     end
     scope :finalized, -> { where(finalized: true) }
     scope :closed, -> do
-      ActiveSupport::Deprecation.warn "Adjustment.closed is deprecated. Instead use Adjustment.finalized", caller
+      Spree::Deprecation.warn "Adjustment.closed is deprecated. Instead use Adjustment.finalized", caller
       where(finalized: true)
     end
     scope :cancellation, -> { where(source_type: 'Spree::UnitCancel') }
@@ -78,12 +78,12 @@ module Spree
 
     # Deprecated methods
     def state
-      ActiveSupport::Deprecation.warn "Adjustment#state is deprecated. Instead use Adjustment#finalized?", caller
+      Spree::Deprecation.warn "Adjustment#state is deprecated. Instead use Adjustment#finalized?", caller
       finalized? ? "closed" : "open"
     end
 
     def state=(new_state)
-      ActiveSupport::Deprecation.warn "Adjustment#state= is deprecated. Instead use Adjustment#finalized=", caller
+      Spree::Deprecation.warn "Adjustment#state= is deprecated. Instead use Adjustment#finalized=", caller
       case new_state
       when "open"
         self.finalized = false
@@ -95,32 +95,32 @@ module Spree
     end
 
     def open?
-      ActiveSupport::Deprecation.warn "Adjustment#open? is deprecated. Instead use Adjustment#finalized?", caller
+      Spree::Deprecation.warn "Adjustment#open? is deprecated. Instead use Adjustment#finalized?", caller
       !closed?
     end
 
     def closed?
-      ActiveSupport::Deprecation.warn "Adjustment#closed? is deprecated. Instead use Adjustment#finalized?", caller
+      Spree::Deprecation.warn "Adjustment#closed? is deprecated. Instead use Adjustment#finalized?", caller
       finalized?
     end
 
     def open
-      ActiveSupport::Deprecation.warn "Adjustment#open is deprecated. Instead use Adjustment#unfinalize", caller
+      Spree::Deprecation.warn "Adjustment#open is deprecated. Instead use Adjustment#unfinalize", caller
       unfinalize
     end
 
     def open!
-      ActiveSupport::Deprecation.warn "Adjustment#open! is deprecated. Instead use Adjustment#unfinalize!", caller
+      Spree::Deprecation.warn "Adjustment#open! is deprecated. Instead use Adjustment#unfinalize!", caller
       unfinalize!
     end
 
     def close
-      ActiveSupport::Deprecation.warn "Adjustment#close is deprecated. Instead use Adjustment#finalize", caller
+      Spree::Deprecation.warn "Adjustment#close is deprecated. Instead use Adjustment#finalize", caller
       finalize
     end
 
     def close!
-      ActiveSupport::Deprecation.warn "Adjustment#close! is deprecated. Instead use Adjustment#finalize!", caller
+      Spree::Deprecation.warn "Adjustment#close! is deprecated. Instead use Adjustment#finalize!", caller
       finalize!
     end
     # End deprecated methods
@@ -154,7 +154,7 @@ module Spree
     # @return [BigDecimal] New amount of this adjustment
     def update!(target = nil)
       if target
-        ActiveSupport::Deprecation.warn("Passing a target to Adjustment#update! is deprecated. The adjustment will use the correct target from it's adjustable association.", caller)
+        Spree::Deprecation.warn("Passing a target to Adjustment#update! is deprecated. The adjustment will use the correct target from it's adjustable association.", caller)
       end
       return amount if finalized?
 

--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -387,7 +387,7 @@ module Spree
 
       # support all the old preference methods with a warning
       define_method "preferred_#{old_preference_name}" do
-        ActiveSupport::Deprecation.warn("#{old_preference_name} is no longer supported on Spree::Config, please access it through #{store_method} on Spree::Store", bc.clean(caller))
+        Spree::Deprecation.warn("#{old_preference_name} is no longer supported on Spree::Config, please access it through #{store_method} on Spree::Store", bc.clean(caller))
         Spree::Store.default.send(store_method)
       end
     end

--- a/core/app/models/spree/country.rb
+++ b/core/app/models/spree/country.rb
@@ -7,7 +7,7 @@ module Spree
     validates :name, :iso_name, presence: true
 
     def self.states_required_by_country_id
-      ActiveSupport::Deprecation.warn "Spree::Country.states_required_by_country_id is deprecated and will be removed from future releases, Implement it yourself.", caller
+      Spree::Deprecation.warn "Spree::Country.states_required_by_country_id is deprecated and will be removed from future releases, Implement it yourself.", caller
       states_required = Hash.new(true)
       all.each { |country| states_required[country.id.to_s] = country.states_required }
       states_required
@@ -15,7 +15,7 @@ module Spree
 
     def self.default
       if Spree::Config.default_country_id
-        ActiveSupport::Deprecation.warn("Setting your default country via its ID is deprecated. Please set your default country via the `default_country_iso` setting.", caller)
+        Spree::Deprecation.warn("Setting your default country via its ID is deprecated. Please set your default country via the `default_country_iso` setting.", caller)
         find_by(id: Spree::Config.default_country_id) || find_by!(iso: Spree::Config.default_country_iso)
       else
         find_by!(iso: Spree::Config.default_country_iso)

--- a/core/app/models/spree/gateway.rb
+++ b/core/app/models/spree/gateway.rb
@@ -39,7 +39,7 @@ module Spree
     end
 
     def disable_customer_profile(source)
-      ActiveSupport::Deprecation.warn("Gateway#disable_customer_profile is deprecated")
+      Spree::Deprecation.warn("Gateway#disable_customer_profile is deprecated")
       if source.is_a? CreditCard
         source.update_column :gateway_customer_profile_id, nil
       else

--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -151,7 +151,7 @@ module Spree
 
     def handle_copy_price_override
       copy_price
-      ActiveSupport::Deprecation.warn 'You have overridden Spree::LineItem#copy_price. ' \
+      Spree::Deprecation.warn 'You have overridden Spree::LineItem#copy_price. ' \
         'This method is now called Spree::LineItem#set_pricing_attributes. ' \
         'Please adjust your override.',
         caller

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -590,7 +590,7 @@ module Spree
     end
 
     def token
-      ActiveSupport::Deprecation.warn("Spree::Order#token is DEPRECATED, please use #guest_token instead.", caller)
+      Spree::Deprecation.warn("Spree::Order#token is DEPRECATED, please use #guest_token instead.", caller)
       guest_token
     end
 

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -250,7 +250,7 @@ module Spree
 
           # @deprecated Use {OrderUpdateAttributes} instead
           def update_from_params(params, permitted_params, request_env = {})
-            ActiveSupport::Deprecation.warn "update_from_params is deprecated. Use the OrderUpdateAttributes class instead", caller
+            Spree::Deprecation.warn "update_from_params is deprecated. Use the OrderUpdateAttributes class instead", caller
             success = false
             @updating_params = params
             run_callbacks :updating_from_params do

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -155,7 +155,7 @@ module Spree
       return unless new_record?
       return if source_attributes.blank?
 
-      ActiveSupport::Deprecation.warn(<<WARN.squish)
+      Spree::Deprecation.warn(<<WARN.squish)
 Building payment sources by assigning source_attributes on payments is
 deprecated. Instead use either the PaymentCreate class or the
 OrderUpdateAttributes class.

--- a/core/app/models/spree/stock_item.rb
+++ b/core/app/models/spree/stock_item.rb
@@ -114,7 +114,7 @@ module Spree
     def inventory_cache_threshold
       # only warn if store is setting binary_inventory_cache (default = false)
       @cache_threshold ||= if Spree::Config.binary_inventory_cache
-        ActiveSupport::Deprecation.warn "Spree::Config.binary_inventory_cache=true is DEPRECATED. Instead use Spree::Config.inventory_cache_threshold=1"
+        Spree::Deprecation.warn "Spree::Config.binary_inventory_cache=true is DEPRECATED. Instead use Spree::Config.inventory_cache_threshold=1"
         1
       else
         Spree::Config.inventory_cache_threshold

--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -72,7 +72,7 @@ module Spree
     # @param [Spree::Zone] order_tax_zone is the smalles applicable zone to the order's tax address
     # @param [Array<Spree::LineItem,Spree::Shipment>] items to be adjusted
     def self.adjust(order_tax_zone, items)
-      ActiveSupport::Deprecation.warn("Please use Spree::Tax::OrderAdjuster or Spree::Tax::ItemAdjuster instead", caller)
+      Spree::Deprecation.warn("Please use Spree::Tax::OrderAdjuster or Spree::Tax::ItemAdjuster instead", caller)
       items.map do |item|
         Spree::Tax::ItemAdjuster.new(item, rates_for_order_zone: for_zone(order_tax_zone)).adjust!
       end

--- a/core/config/initializers/spree_user.rb
+++ b/core/config/initializers/spree_user.rb
@@ -4,7 +4,7 @@
 
 Spree::Core::Engine.config.to_prepare do
   if Spree.user_class && !Spree.user_class.included_modules.include?(Spree::UserMethods)
-    ActiveSupport::Deprecation.warn "#{Spree.user_class} must include Spree::UserMethods"
+    Spree::Deprecation.warn "#{Spree.user_class} must include Spree::UserMethods"
     Spree.user_class.include Spree::UserMethods
   end
 end

--- a/core/lib/generators/spree/dummy/templates/rails/test.rb
+++ b/core/lib/generators/spree/dummy/templates/rails/test.rb
@@ -29,6 +29,7 @@ Dummy::Application.configure do
   config.action_mailer.delivery_method = :test
   ActionMailer::Base.default :from => "spree@example.com"
 
-  # Print deprecation notices to the stderr
-  config.active_support.deprecation = :stderr
+  # Raise on deprecation warnings
+  ActiveSupport::Deprecation.behavior = :raise
+  Spree::Deprecation.behavior = :raise
 end

--- a/core/lib/generators/spree/dummy/templates/rails/test.rb
+++ b/core/lib/generators/spree/dummy/templates/rails/test.rb
@@ -30,6 +30,5 @@ Dummy::Application.configure do
   ActionMailer::Base.default :from => "spree@example.com"
 
   # Raise on deprecation warnings
-  ActiveSupport::Deprecation.behavior = :raise
   Spree::Deprecation.behavior = :raise
 end

--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -49,7 +49,7 @@ module Spree
     def self.const_missing(name)
       case name
       when :AdjustmentSource, :CalculatedAdjustments, :UserAddress, :UserPaymentSource
-        ActiveSupport::Deprecation.warn("Spree::Core::#{name} is deprecated! Use Spree::#{name} instead.", caller)
+        Spree::Deprecation.warn("Spree::Core::#{name} is deprecated! Use Spree::#{name} instead.", caller)
         Spree.const_get(name)
       else
         super

--- a/core/lib/spree/core/delegate_belongs_to.rb
+++ b/core/lib/spree/core/delegate_belongs_to.rb
@@ -31,7 +31,7 @@ module DelegateBelongsTo
     # delegate_belongs_to :contact, [:defaults, :address, :fullname], :class_name => 'VCard'
     ##
     def delegate_belongs_to(association, *attrs)
-      ActiveSupport::Deprecation.warn "delegate_belongs_to is deprecated. Instead use rails built in delegates.", caller
+      Spree::Deprecation.warn "delegate_belongs_to is deprecated. Instead use rails built in delegates.", caller
       opts = attrs.extract_options!
       initialize_association :belongs_to, association, opts
       attrs = get_association_column_names(association) if attrs.empty?

--- a/core/lib/spree/core/routes.rb
+++ b/core/lib/spree/core/routes.rb
@@ -2,17 +2,17 @@ module Spree
   module Core
     class Engine < ::Rails::Engine
       def self.add_routes(&block)
-        ActiveSupport::Deprecation.warn "Spree::Core::Engine.add_routes is deprecated, use Spree::Core::Engine.routes.draw instead"
+        Spree::Deprecation.warn "Spree::Core::Engine.add_routes is deprecated, use Spree::Core::Engine.routes.draw instead"
         routes.draw(&block)
       end
 
       def self.append_routes(&block)
-        ActiveSupport::Deprecation.warn "Spree::Core::Engine.append_routes is deprecated, use Spree::Core::Engine.routes.append instead"
+        Spree::Deprecation.warn "Spree::Core::Engine.append_routes is deprecated, use Spree::Core::Engine.routes.append instead"
         routes.append(&block)
       end
 
       def self.draw_routes(&block)
-        ActiveSupport::Deprecation.warn "Spree::Core::Engine.draw_routes is deprecated, use Spree::Core::Engine.routes.draw instead"
+        Spree::Deprecation.warn "Spree::Core::Engine.draw_routes is deprecated, use Spree::Core::Engine.routes.draw instead"
         routes.draw(&block)
       end
     end

--- a/core/lib/spree/core/version.rb
+++ b/core/lib/spree/core/version.rb
@@ -1,6 +1,6 @@
 module Spree
   def self.version
-    ActiveSupport::Deprecation.warn("Spree.version does not work and will be removed from solidus. Use Spree.solidus_version instead to determine the solidus version")
+    Spree::Deprecation.warn("Spree.version does not work and will be removed from solidus. Use Spree.solidus_version instead to determine the solidus version")
     "2.4.6.beta"
   end
 

--- a/core/lib/spree/testing_support/factories/reimbursement_factory.rb
+++ b/core/lib/spree/testing_support/factories/reimbursement_factory.rb
@@ -13,6 +13,7 @@ FactoryGirl.define do
       if reimbursement.return_items.empty?
         reimbursement.return_items = reimbursement.customer_return.return_items
       end
+      reimbursement.total = reimbursement.return_items.map { |ri| ri.amount }.sum
     end
   end
 end

--- a/core/spec/helpers/base_helper_spec.rb
+++ b/core/spec/helpers/base_helper_spec.rb
@@ -60,7 +60,7 @@ describe Spree::BaseHelper, type: :helper do
     end
 
     it "should not raise errors when style exists" do
-      ActiveSupport::Deprecation.silence do
+      Spree::Deprecation.silence do
         very_strange_image(product)
       end
     end
@@ -152,7 +152,7 @@ describe Spree::BaseHelper, type: :helper do
     end
 
     it "should not raise errors when helper method called" do
-      ActiveSupport::Deprecation.silence do
+      Spree::Deprecation.silence do
         foobar_image(product)
       end
     end

--- a/core/spec/lib/spree/core/delegate_belongs_to_spec.rb
+++ b/core/spec/lib/spree/core/delegate_belongs_to_spec.rb
@@ -8,7 +8,7 @@ module Spree
   class DelegateBelongsToStubModel < Spree::Base
     self.table_name = "spree_payment_methods"
     belongs_to :product
-    ActiveSupport::Deprecation.silence do
+    Spree::Deprecation.silence do
       delegate_belongs_to :product, :name
     end
   end

--- a/core/spec/lib/spree/core/importer/order_spec.rb
+++ b/core/spec/lib/spree/core/importer/order_spec.rb
@@ -123,8 +123,10 @@ module Spree
         params = { line_items_attributes: line_items }
 
         expect {
-          Importer::Order.import(user, params)
-        }.to raise_error /Validation failed/
+          Spree::Deprecation.silence do
+            Importer::Order.import(user, params)
+          end
+        }.to raise_exception ActiveRecord::RecordInvalid
       end
 
       it 'can build an order from API with variant sku' do

--- a/core/spec/lib/spree/core/testing_support/factories/reimbursement_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/reimbursement_factory_spec.rb
@@ -9,4 +9,10 @@ RSpec.describe 'reimbursement factory' do
 
     it_behaves_like 'a working factory'
   end
+
+  describe 'total' do
+    subject { FactoryGirl.create(:reimbursement).total }
+
+    it { is_expected.to be_present }
+  end
 end

--- a/core/spec/mailers/carton_mailer_spec.rb
+++ b/core/spec/mailers/carton_mailer_spec.rb
@@ -18,7 +18,7 @@ describe Spree::CartonMailer do
 
   context "deprecated signature" do
     it do
-      ActiveSupport::Deprecation.silence do
+      Spree::Deprecation.silence do
         mail = Spree::CartonMailer.shipped_email(carton.id)
         expect(mail.subject).to include "Shipment Notification"
       end

--- a/core/spec/mailers/order_mailer_spec.rb
+++ b/core/spec/mailers/order_mailer_spec.rb
@@ -30,14 +30,14 @@ describe Spree::OrderMailer, type: :mailer do
 
   it "confirm_email accepts an order id as an alternative to an Order object" do
     expect(Spree::Order).to receive(:find).with(order.id).and_return(order)
-    ActiveSupport::Deprecation.silence do
+    Spree::Deprecation.silence do
       Spree::OrderMailer.confirm_email(order.id).body
     end
   end
 
   it "cancel_email accepts an order id as an alternative to an Order object" do
     expect(Spree::Order).to receive(:find).with(order.id).and_return(order)
-    ActiveSupport::Deprecation.silence do
+    Spree::Deprecation.silence do
       Spree::OrderMailer.cancel_email(order.id).body
     end
   end

--- a/core/spec/models/spree/country_spec.rb
+++ b/core/spec/models/spree/country_spec.rb
@@ -15,11 +15,11 @@ describe Spree::Country, type: :model do
       end
 
       subject(:default_country) do
-        ActiveSupport::Deprecation.silence { described_class.default }
+        Spree::Deprecation.silence { described_class.default }
       end
 
       it 'emits a deprecation warning' do
-        expect(ActiveSupport::Deprecation).to receive(:warn)
+        expect(Spree::Deprecation).to receive(:warn)
         default_country
       end
 
@@ -34,7 +34,7 @@ describe Spree::Country, type: :model do
       end
 
       subject(:default_country) do
-        ActiveSupport::Deprecation.silence { described_class.default }
+        Spree::Deprecation.silence { described_class.default }
       end
 
       it 'loads the country configured by the ISO code' do

--- a/core/spec/models/spree/country_spec.rb
+++ b/core/spec/models/spree/country_spec.rb
@@ -14,6 +14,10 @@ describe Spree::Country, type: :model do
         Spree::Config[:default_country_id] = 2
       end
 
+      subject(:default_country) do
+        ActiveSupport::Deprecation.silence { described_class.default }
+      end
+
       it 'emits a deprecation warning' do
         expect(ActiveSupport::Deprecation).to receive(:warn)
         default_country
@@ -27,6 +31,10 @@ describe Spree::Country, type: :model do
     context 'with the configuration setting a non-existing legacy default country ID' do
       before do
         Spree::Config[:default_country_id] = 0
+      end
+
+      subject(:default_country) do
+        ActiveSupport::Deprecation.silence { described_class.default }
       end
 
       it 'loads the country configured by the ISO code' do

--- a/core/spec/models/spree/gateway/bogus_spec.rb
+++ b/core/spec/models/spree/gateway/bogus_spec.rb
@@ -6,7 +6,7 @@ module Spree
     let!(:cc) { create(:credit_card, payment_method: bogus, gateway_customer_profile_id: "BGS-RERTERT") }
 
     it "disable recurring contract by destroying payment source" do
-      ActiveSupport::Deprecation.silence do
+      Spree::Deprecation.silence do
         bogus.disable_customer_profile(cc)
       end
       expect(cc.gateway_customer_profile_id).to be_nil

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -135,13 +135,13 @@ describe Spree::LineItem, type: :model do
       end
 
       it 'should display a deprecation warning' do
-        expect(ActiveSupport::Deprecation).to receive(:warn)
+        expect(Spree::Deprecation).to receive(:warn)
         Spree::LineItem.new(variant: variant, order: order)
       end
 
       it 'should run the user-defined copy_price method' do
         expect_any_instance_of(Spree::LineItem).to receive(:copy_price).and_call_original
-        ActiveSupport::Deprecation.silence do
+        Spree::Deprecation.silence do
           Spree::LineItem.new(variant: variant, order: order)
         end
       end

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -794,7 +794,7 @@ describe Spree::Order, type: :model do
     let(:params) { {} }
 
     around do |example|
-      ActiveSupport::Deprecation.silence { example.run }
+      Spree::Deprecation.silence { example.run }
     end
 
     it 'calls update_atributes without order params' do

--- a/core/spec/models/spree/order/payment_spec.rb
+++ b/core/spec/models/spree/order/payment_spec.rb
@@ -83,7 +83,7 @@ module Spree
 
       # For the reason of this test, please see spree/spree_gateway#132
       it "keeps source attributes on assignment" do
-        ActiveSupport::Deprecation.silence do
+        Spree::Deprecation.silence do
           order.update_attributes(payments_attributes: [payment_attributes])
         end
         expect(order.unprocessed_payments.last.source.number).to be_present

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -1021,7 +1021,7 @@ describe Spree::Order, type: :model do
     let(:payment) { Spree::Payment.new(amount: 10) }
 
     around do |example|
-      ActiveSupport::Deprecation.silence do
+      Spree::Deprecation.silence do
         example.run
       end
     end

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -687,7 +687,7 @@ describe Spree::Payment, type: :model do
       context "with multiple payment attempts" do
         let(:attributes) { attributes_for(:credit_card) }
         around do |example|
-          ActiveSupport::Deprecation.silence{ example.run }
+          Spree::Deprecation.silence{ example.run }
         end
 
         it "should not try to create profiles on old failed payment attempts" do
@@ -748,7 +748,7 @@ describe Spree::Payment, type: :model do
   describe "#apply_source_attributes" do
     # This method is deprecated
     around do |example|
-      ActiveSupport::Deprecation.silence do
+      Spree::Deprecation.silence do
         example.run
       end
     end

--- a/core/spec/models/spree/stock_item_spec.rb
+++ b/core/spec/models/spree/stock_item_spec.rb
@@ -229,7 +229,7 @@ describe Spree::StockItem, type: :model do
     context "when deprecated binary_inventory_cache is used" do
       before do
         Spree::Config.binary_inventory_cache = binary_inventory_cache
-        allow(ActiveSupport::Deprecation).to receive(:warn)
+        allow(Spree::Deprecation).to receive(:warn)
         subject.set_count_on_hand(9)
       end
 
@@ -237,7 +237,7 @@ describe Spree::StockItem, type: :model do
         let(:binary_inventory_cache) { true }
 
         it "logs a deprecation warning" do
-          expect(ActiveSupport::Deprecation).to have_received(:warn)
+          expect(Spree::Deprecation).to have_received(:warn)
         end
       end
 
@@ -248,7 +248,7 @@ describe Spree::StockItem, type: :model do
         end
 
         it "does not log a deprecation warning" do
-          expect(ActiveSupport::Deprecation).not_to have_received(:warn)
+          expect(Spree::Deprecation).not_to have_received(:warn)
         end
       end
     end

--- a/core/spec/models/spree/tax_rate_spec.rb
+++ b/core/spec/models/spree/tax_rate_spec.rb
@@ -140,7 +140,7 @@ describe Spree::TaxRate, type: :model do
       let(:line_item) { stub_model(Spree::LineItem) }
 
       it 'should emit a deprecation warning and call the item adjuster' do
-        expect(ActiveSupport::Deprecation).to receive(:warn)
+        expect(Spree::Deprecation).to receive(:warn)
         expect(Spree::Tax::ItemAdjuster).to receive_message_chain(:new, :adjust!)
         Spree::TaxRate.adjust(zone, [line_item])
       end
@@ -150,7 +150,7 @@ describe Spree::TaxRate, type: :model do
       let(:shipment) { stub_model(Spree::Shipment) }
 
       it 'should emit a deprecation warning and call the item adjuster' do
-        expect(ActiveSupport::Deprecation).to receive(:warn)
+        expect(Spree::Deprecation).to receive(:warn)
         expect(Spree::Tax::ItemAdjuster).to receive_message_chain(:new, :adjust!)
         Spree::TaxRate.adjust(zone, [shipment])
       end

--- a/core/spec/models/spree/user_spec.rb
+++ b/core/spec/models/spree/user_spec.rb
@@ -96,7 +96,7 @@ describe Spree::LegacyUser, type: :model do
       end
 
       it "drops payment source" do
-        ActiveSupport::Deprecation.silence do
+        Spree::Deprecation.silence do
           user.drop_payment_source cc
         end
         expect(cc.gateway_customer_profile_id).to be_nil


### PR DESCRIPTION
We want to know when we use things that we deprecate. This commit changes `ActiveSupport::Deprecation` as well as `Spree::Deprecation` so that they raise an error instead of printing to `stderr` when they come across a deprecated things in the test suite.

It also fixes a non-silenced deprecation warning in the country spec, as well as the
reimbursement factory which gets initialized with a total of `nil`, raising a deprecation
warning from `Spree::Money` when rendering the reimbursement email.