### PR TITLE
Remove deprecated call to ActiveMerchant::Billing::Base.gateway_mode

### DIFF
--- a/core/app/models/spree/gateway.rb
+++ b/core/app/models/spree/gateway.rb
@@ -15,7 +15,7 @@ module Spree
       gateway_options = options
       gateway_options.delete :login if gateway_options.key?(:login) && gateway_options[:login].nil?
       if gateway_options[:server]
-        ActiveMerchant::Billing::Base.gateway_mode = gateway_options[:server].to_sym
+        ActiveMerchant::Billing::Base.mode = gateway_options[:server].to_sym
       end
       @provider ||= provider_class.new(gateway_options)
     end


### PR DESCRIPTION
This has been deprecated in
https://github.com/activemerchant/active_merchant/commit/03883cb66e58002cf9e040ae0cb02a38f2413a1c

It does not raise an exception as they use their own deprecation class, but we should not call
deprecated methods in other gems, either.