### PR TITLE
Clean up records in promotion rules

### DIFF
--- a/core/app/models/spree/promotion/rules/taxon.rb
+++ b/core/app/models/spree/promotion/rules/taxon.rb
@@ -2,7 +2,8 @@ module Spree
   class Promotion
     module Rules
       class Taxon < PromotionRule
-        has_many :promotion_rule_taxons, class_name: 'Spree::PromotionRuleTaxon', foreign_key: :promotion_rule_id
+        has_many :promotion_rule_taxons, class_name: 'Spree::PromotionRuleTaxon', foreign_key: :promotion_rule_id,
+          dependent: :destroy
         has_many :taxons, through: :promotion_rule_taxons, class_name: 'Spree::Taxon'
 
         MATCH_POLICIES = %w(any all)

--- a/core/app/models/spree/promotion/rules/user.rb
+++ b/core/app/models/spree/promotion/rules/user.rb
@@ -5,7 +5,8 @@ module Spree
         belongs_to :user, class_name: Spree::UserClassHandle.new
 
         has_many :promotion_rule_users, class_name: 'Spree::PromotionRuleUser',
-                                        foreign_key: :promotion_rule_id
+                                        foreign_key: :promotion_rule_id,
+                                        dependent: :destroy
         has_many :users, through: :promotion_rule_users, class_name: Spree::UserClassHandle.new
 
         def applicable?(promotable)


### PR DESCRIPTION
Product was the only one that had the (correct) dependent destroy on it.
When a rule is deleted we should no longer reference it in the join
table.