### PR TITLE
Always validate count_on_hand of StockItem

### DIFF
--- a/core/app/models/spree/stock_item.rb
+++ b/core/app/models/spree/stock_item.rb
@@ -8,7 +8,7 @@ module Spree
 
     validates :stock_location, :variant, presence: true
     validates :variant_id, uniqueness: { scope: [:stock_location_id, :deleted_at] }, allow_blank: true, unless: :deleted_at
-    validates :count_on_hand, numericality: { greater_than_or_equal_to: 0 }, if: :verify_count_on_hand?
+    validates :count_on_hand, numericality: { greater_than_or_equal_to: 0 }, unless: :backorderable?
 
     delegate :weight, :should_track_inventory?, to: :variant
 
@@ -82,10 +82,6 @@ module Spree
     end
 
     private
-
-    def verify_count_on_hand?
-      count_on_hand_changed? && !backorderable? && (count_on_hand < count_on_hand_was) && (count_on_hand < 0)
-    end
 
     def count_on_hand=(value)
       write_attribute(:count_on_hand, value)

--- a/core/spec/models/spree/stock_item_spec.rb
+++ b/core/spec/models/spree/stock_item_spec.rb
@@ -271,170 +271,60 @@ describe Spree::StockItem, type: :model do
   end
 
   describe 'validations' do
+    before do
+      subject.backorderable = backorderable
+      subject.send(:count_on_hand=, count_on_hand)
+    end
+
     describe 'count_on_hand' do
       shared_examples_for 'valid count_on_hand' do
-        before(:each) do
-          subject.save
-        end
-
         it 'has :no errors_on' do
+          expect(subject).to be_valid
           expect(subject.errors_on(:count_on_hand).size).to eq(0)
         end
       end
 
-      shared_examples_for 'not valid count_on_hand' do
-        before(:each) do
-          subject.save
-        end
-
-        it 'has 1 error_on' do
+      shared_examples_for 'invalid count_on_hand' do
+        it 'has the correct error on count_on_hand' do
+          expect(subject).not_to be_valid
           expect(subject.error_on(:count_on_hand).size).to eq(1)
-        end
-        it { expect(subject.errors[:count_on_hand]).to include 'must be greater than or equal to 0' }
-      end
-
-      context 'when count_on_hand not changed' do
-        context 'when not backorderable' do
-          before(:each) do
-            subject.backorderable = false
-          end
-          it_should_behave_like 'valid count_on_hand'
-        end
-
-        context 'when backorderable' do
-          before(:each) do
-            subject.backorderable = true
-          end
-          it_should_behave_like 'valid count_on_hand'
+          expect(subject.errors[:count_on_hand]).to include('must be greater than or equal to 0')
         end
       end
 
-      context 'when count_on_hand changed' do
-        context 'when backorderable' do
-          before(:each) do
-            subject.backorderable = true
-          end
-          context 'when both count_on_hand and count_on_hand_was are positive' do
-            context 'when count_on_hand is greater than count_on_hand_was' do
-              before(:each) do
-                subject.update_column(:count_on_hand, 3)
-                subject.send(:count_on_hand=, subject.count_on_hand + 3)
-              end
-              it_should_behave_like 'valid count_on_hand'
-            end
+      context 'when backorderable' do
+        let(:backorderable) { true }
 
-            context 'when count_on_hand is smaller than count_on_hand_was' do
-              before(:each) do
-                subject.update_column(:count_on_hand, 3)
-                subject.send(:count_on_hand=, subject.count_on_hand - 2)
-              end
-
-              it_should_behave_like 'valid count_on_hand'
-            end
-          end
-
-          context 'when both count_on_hand and count_on_hand_was are negative' do
-            context 'when count_on_hand is greater than count_on_hand_was' do
-              before(:each) do
-                subject.update_column(:count_on_hand, -3)
-                subject.send(:count_on_hand=, subject.count_on_hand + 2)
-              end
-              it_should_behave_like 'valid count_on_hand'
-            end
-
-            context 'when count_on_hand is smaller than count_on_hand_was' do
-              before(:each) do
-                subject.update_column(:count_on_hand, 3)
-                subject.send(:count_on_hand=, subject.count_on_hand - 3)
-              end
-
-              it_should_behave_like 'valid count_on_hand'
-            end
-          end
-
-          context 'when both count_on_hand is positive and count_on_hand_was is negative' do
-            context 'when count_on_hand is greater than count_on_hand_was' do
-              before(:each) do
-                subject.update_column(:count_on_hand, -3)
-                subject.send(:count_on_hand=, subject.count_on_hand + 6)
-              end
-              it_should_behave_like 'valid count_on_hand'
-            end
-          end
-
-          context 'when both count_on_hand is negative and count_on_hand_was is positive' do
-            context 'when count_on_hand is greater than count_on_hand_was' do
-              before(:each) do
-                subject.update_column(:count_on_hand, 3)
-                subject.send(:count_on_hand=, subject.count_on_hand - 6)
-              end
-              it_should_behave_like 'valid count_on_hand'
-            end
-          end
+        context 'when count_on_hand is positive' do
+          let(:count_on_hand) { 3 }
+          it_should_behave_like "valid count_on_hand"
         end
 
-        context 'when not backorderable' do
-          before(:each) do
+        context 'when count_on_hand is negative' do
+          let(:count_on_hand) { -3 }
+
+          it_should_behave_like "valid count_on_hand"
+
+          it "can't be changed to not backorderable" do
+            expect(subject).to be_valid
             subject.backorderable = false
+            expect(subject).not_to be_valid
           end
+        end
+      end
 
-          context 'when both count_on_hand and count_on_hand_was are positive' do
-            context 'when count_on_hand is greater than count_on_hand_was' do
-              before(:each) do
-                subject.update_column(:count_on_hand, 3)
-                subject.send(:count_on_hand=, subject.count_on_hand + 3)
-              end
-              it_should_behave_like 'valid count_on_hand'
-            end
+      context 'when not backorderable' do
+        let(:backorderable) { false }
 
-            context 'when count_on_hand is smaller than count_on_hand_was' do
-              before(:each) do
-                subject.update_column(:count_on_hand, 3)
-                subject.send(:count_on_hand=, subject.count_on_hand - 2)
-              end
+        context 'when count_on_hand is positive' do
+          let(:count_on_hand) { 3 }
+          it_should_behave_like "valid count_on_hand"
+        end
 
-              it_should_behave_like 'valid count_on_hand'
-            end
-          end
+        context 'when count_on_hand is negative' do
+          let(:count_on_hand) { -3 }
 
-          context 'when both count_on_hand and count_on_hand_was are negative' do
-            context 'when count_on_hand is greater than count_on_hand_was' do
-              before(:each) do
-                subject.update_column(:count_on_hand, -3)
-                subject.send(:count_on_hand=, subject.count_on_hand + 2)
-              end
-              it_should_behave_like 'valid count_on_hand'
-            end
-
-            context 'when count_on_hand is smaller than count_on_hand_was' do
-              before(:each) do
-                subject.update_column(:count_on_hand, -3)
-                subject.send(:count_on_hand=, subject.count_on_hand - 3)
-              end
-
-              it_should_behave_like 'not valid count_on_hand'
-            end
-          end
-
-          context 'when both count_on_hand is positive and count_on_hand_was is negative' do
-            context 'when count_on_hand is greater than count_on_hand_was' do
-              before(:each) do
-                subject.update_column(:count_on_hand, -3)
-                subject.send(:count_on_hand=, subject.count_on_hand + 6)
-              end
-              it_should_behave_like 'valid count_on_hand'
-            end
-          end
-
-          context 'when both count_on_hand is negative and count_on_hand_was is positive' do
-            context 'when count_on_hand is greater than count_on_hand_was' do
-              before(:each) do
-                subject.update_column(:count_on_hand, 3)
-                subject.send(:count_on_hand=, subject.count_on_hand - 6)
-              end
-              it_should_behave_like 'not valid count_on_hand'
-            end
-          end
+          it_should_behave_like "invalid count_on_hand"
         end
       end
     end

--- a/frontend/spec/features/checkout_unshippable_spec.rb
+++ b/frontend/spec/features/checkout_unshippable_spec.rb
@@ -9,7 +9,7 @@ describe "checkout with unshippable items", type: :feature, inaccessible: true d
     order.reload
     line_item = order.line_items.last
     stock_item = stock_location.stock_item(line_item.variant)
-    stock_item.adjust_count_on_hand(-999)
+    stock_item.adjust_count_on_hand(0)
     stock_item.backorderable = false
     stock_item.save!
 


### PR DESCRIPTION
Previously, `count_on_hand` was only validated if it was changed and specifically if it was changed to a lower number than it was previously.

This isn't a good approach. A record should be valid based on it's current attributes. It shouldn't be considered valid just because it's "more" or "less" valid than before. The existing code would allow, for
example, creating a valid backorderable `StockItem` with a negative count_on_hand, and then setting it to be `backorderable=false`. This is an invalid state but would be allowed because count_on_hand wasn't changed.

This commit just changes the validation to just always run when `backorderable=false`.