### PR TITLE
Remove user_id from PromotionRules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 *   Allow filtering orders by store when multiple stores are present. [#1149](https://github.com/solidusio/solidus/pull/1140)
 
+*   Remove unused `user_id` column from PromotionRule. [#1259](https://github.com/solidusio/solidus/pull/1259)
+
 ## Solidus 1.3.0 (unreleased)
 
 *   Order now requires a `store_id` in validations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,7 @@
     * JavaScript for it has been moved from address.js into its own `spree/frontend/checkout/coupon-code`
     * Numerous small nuisances have been fixed [#1090](https://github.com/solidusio/solidus/pull/1090)
 
-*   Filter orders by store when more than a single store is present. [#1149](https://github.com/solidusio/solidus/pull/1140)
-
+*   Allow filtering orders by store when multiple stores are present. [#1149](https://github.com/solidusio/solidus/pull/1140)
 
 ## Solidus 1.3.0 (unreleased)
 

--- a/core/app/models/spree/promotion/rules/user.rb
+++ b/core/app/models/spree/promotion/rules/user.rb
@@ -2,8 +2,6 @@ module Spree
   class Promotion
     module Rules
       class User < PromotionRule
-        belongs_to :user, class_name: Spree::UserClassHandle.new
-
         has_many :promotion_rule_users, class_name: 'Spree::PromotionRuleUser',
                                         foreign_key: :promotion_rule_id
         has_many :users, through: :promotion_rule_users, class_name: Spree::UserClassHandle.new

--- a/core/db/migrate/20160616232103_remove_user_id_from_promotion_rules.rb
+++ b/core/db/migrate/20160616232103_remove_user_id_from_promotion_rules.rb
@@ -1,0 +1,11 @@
+class RemoveUserIdFromPromotionRules < ActiveRecord::Migration
+  def up
+    remove_index :spree_promotion_rules, name: 'index_promotion_rules_on_user_id'
+    remove_column :spree_promotion_rules, :user_id
+  end
+
+  def down
+    add_column :spree_promotion_rules, :user_id, :integer
+    add_index :spree_promotion_rules, [:user_id], name: 'index_promotion_rules_on_user_id'
+  end
+end


### PR DESCRIPTION
Both the `belongs_to` and the column have been around since promo was merged into `spree_core`, but I don't think they have ever been used.