### PR TITLE
Modify factory completed_order_with_promotion

### DIFF
--- a/core/lib/spree/testing_support/factories/order_factory.rb
+++ b/core/lib/spree/testing_support/factories/order_factory.rb
@@ -108,7 +108,7 @@ FactoryGirl.define do
     end
   end
 
-  factory :completed_order_with_promotion, parent: :completed_order_with_totals, class: "Spree::Order" do
+  factory :completed_order_with_promotion, parent: :order_with_line_items, class: "Spree::Order" do
     transient do
       promotion nil
     end
@@ -118,6 +118,11 @@ FactoryGirl.define do
       promotion_code = promotion.codes.first || create(:promotion_code, promotion: promotion)
 
       promotion.activate(order: order, promotion_code: promotion_code)
+
+      # Complete the order after the promotion has been activated
+      order.refresh_shipment_rates
+      order.update_column(:completed_at, Time.current)
+      order.update_column(:state, "complete")
     end
   end
 end

--- a/core/lib/spree/testing_support/factories/order_factory.rb
+++ b/core/lib/spree/testing_support/factories/order_factory.rb
@@ -111,16 +111,13 @@ FactoryGirl.define do
   factory :completed_order_with_promotion, parent: :completed_order_with_totals, class: "Spree::Order" do
     transient do
       promotion nil
-      promotion_code nil
     end
 
     after(:create) do |order, evaluator|
       promotion = evaluator.promotion || create(:promotion, code: "test")
-      promotion_code = evaluator.promotion_code || promotion.codes.first
+      promotion_code = promotion.codes.first || create(:promotion_code, promotion: promotion)
 
-      promotion.actions.each do |action|
-        action.perform({ order: order, promotion: promotion, promotion_code: promotion_code })
-      end
+      promotion.activate(order: order, promotion_code: promotion_code)
     end
   end
 end

--- a/core/spec/lib/spree/core/testing_support/factories/order_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/order_factory_spec.rb
@@ -45,4 +45,10 @@ RSpec.describe 'order factory' do
 
     it_behaves_like 'a working factory'
   end
+
+  describe 'completed order with promotion' do
+    let(:factory) { :completed_order_with_promotion }
+
+    it_behaves_like 'a working factory'
+  end
 end


### PR DESCRIPTION
The existing factory will not create a `Spree::OrderPromotion`. That was the original issue that lead into this refactor. I *could* have just added a `Spree::OrderPromotion.create()` at the bottom of the factory but I liked the fact that this change brings the factory more in line with a real world usage.