### PR TITLE
Add hint tooltips component to admin

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/components/tooltips.js
+++ b/backend/app/assets/javascripts/spree/backend/components/tooltips.js
@@ -1,4 +1,6 @@
 $(function(){
+  $('body').popover({selector: '.hint-tooltip', html: true, trigger: 'hover', placement: 'top'});
+
   $('body').tooltip({selector: '.with-tip'});
 
   /*

--- a/backend/app/assets/stylesheets/spree/backend/_bootstrap_custom.scss
+++ b/backend/app/assets/stylesheets/spree/backend/_bootstrap_custom.scss
@@ -148,7 +148,7 @@ $font-family-monospace:      Menlo, Monaco, Consolas, "Courier New", monospace !
 $font-family-base:           $font-family-sans-serif !default;
 
 // Pixel value used to responsively scale all typography. Applied to the `<html>` element.
-$font-size-root:             16px !default;
+$font-size-root:             15px !default;
 
 $font-size-base:             1rem !default;
 $font-size-lg:               1.25rem !default;

--- a/backend/app/assets/stylesheets/spree/backend/components/_hint.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_hint.scss
@@ -1,0 +1,3 @@
+.hint-tooltip {
+  cursor: pointer;
+}

--- a/backend/app/assets/stylesheets/spree/backend/spree_admin.scss
+++ b/backend/app/assets/stylesheets/spree/backend/spree_admin.scss
@@ -21,6 +21,7 @@
 @import 'spree/backend/components/states';
 @import 'spree/backend/components/actions';
 @import 'spree/backend/components/date-picker';
+@import 'spree/backend/components/hint';
 @import 'spree/backend/components/list_group';
 @import 'spree/backend/components/messages';
 @import 'spree/backend/components/progress';

--- a/backend/app/helpers/spree/admin/base_helper.rb
+++ b/backend/app/helpers/spree/admin/base_helper.rb
@@ -22,6 +22,12 @@ module Spree
         end
       end
 
+      def admin_hint(title, text)
+        content_tag(:span, class: 'hint-tooltip', title: title, data: { content: text }) do
+          content_tag(:i, '', class: 'fa fa-info-circle')
+        end
+      end
+
       def datepicker_field_value(date)
         unless date.blank?
           l(date, format: Spree.t('date_picker.format', default: '%Y/%m/%d'))

--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -71,6 +71,7 @@
         <%= f.label :promotionable do %>
           <%= f.check_box :promotionable %> <%= Spree::Product.human_attribute_name(:promotionable) %>
         <% end %>
+        <%= f.field_hint :promotionable %>
       <% end %>
     </div>
 

--- a/backend/config/initializers/form_builder.rb
+++ b/backend/config/initializers/form_builder.rb
@@ -9,6 +9,12 @@ class ActionView::Helpers::FormBuilder
   def error_message_on(method, options = {})
     @template.error_message_on(@object_name, method, objectify_options(options))
   end
+
+  def field_hint(method, options = {})
+    title = options[:title] || @object.class.human_attribute_name(method)
+    text = options[:text] || I18n.t(method, scope: [:spree, :hints, @object.class.model_name.i18n_key])
+    @template.admin_hint(title, text)
+  end
 end
 
 ActionView::Base.field_error_proc = proc{ |html_tag, _instance| "<span class=\"field_with_errors\">#{html_tag}</span>".html_safe }

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1098,6 +1098,9 @@ en:
     expiration: Expiration
     extension: Extension
     existing_shipments: Existing shipments
+    hints:
+      spree/product:
+        promotionable: "This determines whether or not promotions can apply to this product.<br/>Default: checked"
     failed_payment_attempts: Failed Payment Attempts
     failure: Failure
     filename: Filename


### PR DESCRIPTION
@Mandily requested in #1167 that we add hint tooltips to provide more information in the admin.

This should be helpful to clarify the purpose of fields in the admin, which are not always obvious. For an example I've added a hint to `Product#promotionable` bca7849.

![](http://i.hawth.ca/s/UnN2Qttw.png)

This adds both a helper `admin_hint(title, text)`, as well as an extra form helper method `<%= f.field_hint :field_name %>`. The form helper version looks up text in I18n under `en.spree.hints.#{model_scope}.#{method}`.