### PR TITLE
Remove broken `accessible_by` code for UserManagement role

### DIFF
--- a/core/lib/spree/permission_sets/user_management.rb
+++ b/core/lib/spree/permission_sets/user_management.rb
@@ -4,10 +4,8 @@ module Spree
       def activate!
         can [:admin, :display, :create, :update, :save_in_address_book, :remove_from_address_book, :addresses, :orders, :items], Spree.user_class
 
-        # due to how cancancan filters by associations,
-        # we have to define this twice, once for `accessible_by`
-        can :update_email, Spree.user_class, spree_roles: { id: nil }
-        # and once for `can?`
+        # Note: This does not work with accessible_by.
+        # See https://github.com/solidusio/solidus/pull/1263
         can :update_email, Spree.user_class do |user|
           user.spree_roles.none?
         end

--- a/core/spec/models/spree/permission_sets/user_management_spec.rb
+++ b/core/spec/models/spree/permission_sets/user_management_spec.rb
@@ -20,8 +20,25 @@ describe Spree::PermissionSets::UserManagement do
     it { is_expected.to be_able_to(:orders, Spree.user_class) }
     it { is_expected.to be_able_to(:items, Spree.user_class) }
 
-    it { is_expected.to be_able_to(:update_email, Spree.user_class.new(spree_roles: [])) }
-    it { is_expected.not_to be_able_to(:update_email, Spree.user_class.new(spree_roles: [create(:role)])) }
+    context 'when the user does not have a role' do
+      let(:user) { create(:user) }
+
+      it { is_expected.to be_able_to(:update_email, user) }
+      it 'is accessible' do
+        accessible_ids = Spree.user_class.accessible_by(ability, :update_email).pluck(:id)
+        expect(accessible_ids).to eq([user.id])
+      end
+    end
+
+    context 'when the user has a role' do
+      let(:user) { create(:user, spree_roles: [create(:role)]) }
+
+      it { is_expected.not_to be_able_to(:update_email, user) }
+      it 'is not accessible' do
+        accessible_ids = Spree.user_class.accessible_by(ability, :update_email).pluck(:id)
+        expect(accessible_ids).to eq([])
+      end
+    end
 
     it { is_expected.not_to be_able_to(:delete, Spree.user_class) }
     it { is_expected.not_to be_able_to(:destroy, Spree.user_class) }

--- a/core/spec/models/spree/permission_sets/user_management_spec.rb
+++ b/core/spec/models/spree/permission_sets/user_management_spec.rb
@@ -22,22 +22,12 @@ describe Spree::PermissionSets::UserManagement do
 
     context 'when the user does not have a role' do
       let(:user) { create(:user) }
-
       it { is_expected.to be_able_to(:update_email, user) }
-      it 'is accessible' do
-        accessible_ids = Spree.user_class.accessible_by(ability, :update_email).pluck(:id)
-        expect(accessible_ids).to eq([user.id])
-      end
     end
 
     context 'when the user has a role' do
       let(:user) { create(:user, spree_roles: [create(:role)]) }
-
       it { is_expected.not_to be_able_to(:update_email, user) }
-      it 'is not accessible' do
-        accessible_ids = Spree.user_class.accessible_by(ability, :update_email).pluck(:id)
-        expect(accessible_ids).to eq([])
-      end
     end
 
     it { is_expected.not_to be_able_to(:delete, Spree.user_class) }


### PR DESCRIPTION
The following code attempts to make the `update_email` permission work
with `accessible_by` but I don't think it actually works:

    # due to how cancancan filters by associations,
    # we have to define this twice, once for `accessible_by`
    can :update_email, Spree.user_class, spree_roles: { id: nil }
    # and once for `can?`
    can :update_email, Spree.user_class do |user|
      user.spree_roles.none?
    end

If the first `can` fails then `accessible_by` will move on to the
second one (the block form) and fail with this error:

    CanCan::Error:
    The accessible_by call cannot be used with a block 'can' definition.
    The SQL cannot be determined for :update_email Spree::LegacyUser
