### PR TITLE
Add :order_ready_to_complete factory

### DIFF
--- a/core/lib/spree/testing_support/factories/order_factory.rb
+++ b/core/lib/spree/testing_support/factories/order_factory.rb
@@ -52,6 +52,25 @@ FactoryGirl.define do
         order.update!
       end
 
+      factory :order_ready_to_complete do
+        state 'confirm'
+        payment_state 'checkout'
+
+        transient do
+          payment_type :credit_card_payment
+        end
+
+        after(:create) do |order, evaluator|
+          create(evaluator.payment_type, {
+            amount: order.total,
+            order: order,
+            state: order.payment_state
+          })
+
+          order.payments.reload
+        end
+      end
+
       factory :completed_order_with_totals do
         state 'complete'
 

--- a/core/spec/lib/spree/core/testing_support/factories/order_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/order_factory_spec.rb
@@ -22,6 +22,20 @@ RSpec.describe 'order factory' do
     it_behaves_like 'a working factory'
   end
 
+  describe 'order ready to complete' do
+    let(:factory) { :order_ready_to_complete }
+
+    it_behaves_like 'a working factory'
+
+    it "is completable" do
+      order = create(factory)
+
+      expect { order.complete! }.to change {
+        order.complete?
+      }.from(false).to(true)
+    end
+  end
+
   describe 'completed order with totals' do
     let(:factory) { :completed_order_with_totals }
 


### PR DESCRIPTION
This factory can be used to create an Order instance that is ready to
complete, with all the associated line items, shipments, and payments
necessary to complete an order.

This can be useful when testing order completion callbacks, without
having to build-up an order to a state where it can be completed.