### PR TITLE
Include all adjustments in ItemAdjustments in adjustment_total

### DIFF
--- a/core/app/models/spree/item_adjustments.rb
+++ b/core/app/models/spree/item_adjustments.rb
@@ -60,7 +60,10 @@ module Spree
 
       adjustments.select(&:cancellation?).map(&:update!)
 
-      @item.adjustment_total = @item.adjustments.eligible.sum(:amount)
+      @item.adjustment_total = @item.adjustments.
+        eligible.
+        reject(&:included?).
+        sum(&:amount)
 
       @item.update_columns(
         promo_total: @item.promo_total,

--- a/core/app/models/spree/item_adjustments.rb
+++ b/core/app/models/spree/item_adjustments.rb
@@ -60,7 +60,7 @@ module Spree
 
       adjustments.select(&:cancellation?).each(&:update!)
 
-      @item.adjustment_total = @item.adjustments.
+      @item.adjustment_total = adjustments.
         select(&:eligible?).
         reject(&:included?).
         sum(&:amount)

--- a/core/app/models/spree/item_adjustments.rb
+++ b/core/app/models/spree/item_adjustments.rb
@@ -61,7 +61,7 @@ module Spree
       adjustments.select(&:cancellation?).map(&:update!)
 
       @item.adjustment_total = @item.adjustments.
-        eligible.
+        select(&:eligible?).
         reject(&:included?).
         sum(&:amount)
 

--- a/core/app/models/spree/item_adjustments.rb
+++ b/core/app/models/spree/item_adjustments.rb
@@ -58,6 +58,8 @@ module Spree
       @item.included_tax_total = tax.select(&:included?).map(&:update!).compact.sum
       @item.additional_tax_total = tax.reject(&:included?).map(&:update!).compact.sum
 
+      adjustments.select(&:cancellation?).map(&:update!)
+
       @item.adjustment_total = @item.adjustments.eligible.sum(:amount)
 
       @item.update_columns(

--- a/core/app/models/spree/item_adjustments.rb
+++ b/core/app/models/spree/item_adjustments.rb
@@ -58,9 +58,7 @@ module Spree
       @item.included_tax_total = tax.select(&:included?).map(&:update!).compact.sum
       @item.additional_tax_total = tax.reject(&:included?).map(&:update!).compact.sum
 
-      item_cancellation_total = adjustments.select(&:cancellation?).map(&:update!).compact.sum
-
-      @item.adjustment_total = @item.promo_total + @item.additional_tax_total + item_cancellation_total
+      @item.adjustment_total = @item.adjustments.eligible.sum(:amount)
 
       @item.update_columns(
         promo_total: @item.promo_total,

--- a/core/app/models/spree/item_adjustments.rb
+++ b/core/app/models/spree/item_adjustments.rb
@@ -58,7 +58,7 @@ module Spree
       @item.included_tax_total = tax.select(&:included?).map(&:update!).compact.sum
       @item.additional_tax_total = tax.reject(&:included?).map(&:update!).compact.sum
 
-      adjustments.select(&:cancellation?).map(&:update!)
+      adjustments.select(&:cancellation?).each(&:update!)
 
       @item.adjustment_total = @item.adjustments.
         select(&:eligible?).


### PR DESCRIPTION
Why don't we include all adjustments in `ItemAdjustments`?

I'm opening this PR to see if anyone knows and/or what breaks if we do just include all adjustments.