### PR TITLE
Remove references to expand_variant

### DIFF
--- a/backend/app/views/spree/admin/orders/cart.html.erb
+++ b/backend/app/views/spree/admin/orders/cart.html.erb
@@ -35,7 +35,3 @@
     <%= render :partial => 'line_items_edit_form', :locals => { :order => @order } %>
   </div>
 </div>
-
-<% content_for :head do %>
-  <%= javascript_tag 'var expand_variants = true;' %>
-<% end %>

--- a/backend/app/views/spree/admin/orders/edit.html.erb
+++ b/backend/app/views/spree/admin/orders/edit.html.erb
@@ -35,7 +35,3 @@
     <%= render partial: 'form', locals: { order: @order } %>
   </div>
 </div>
-
-<% content_for :head do %>
-  <%= javascript_tag 'var expand_variants = true;' %>
-<% end %>


### PR DESCRIPTION
The JS this was designed for was removed in 2012 5f6bbdb12d50326af0df5e25ae4471ea687a7e1f.