### PR TITLE
Rename before_filter/around_filter to before_action/around_action in controllers

### DIFF
--- a/api/app/controllers/spree/api/address_books_controller.rb
+++ b/api/app/controllers/spree/api/address_books_controller.rb
@@ -2,7 +2,7 @@ module Spree
   module Api
     class AddressBooksController < Spree::Api::BaseController
       # Note: the AddressBook is the resource to think about here, not individual addresses
-      before_filter :load_user_addresses
+      before_action :load_user_addresses
 
       def show
         authorize! :show, address_book_user

--- a/api/app/controllers/spree/api/checkouts_controller.rb
+++ b/api/app/controllers/spree/api/checkouts_controller.rb
@@ -1,9 +1,9 @@
 module Spree
   module Api
     class CheckoutsController < Spree::Api::BaseController
-      before_filter :load_order, only: [:next, :advance, :update, :complete]
-      around_filter :lock_order, only: [:next, :advance, :update, :complete]
-      before_filter :update_order_state, only: [:next, :advance, :update, :complete]
+      before_action :load_order, only: [:next, :advance, :update, :complete]
+      around_action :lock_order, only: [:next, :advance, :update, :complete]
+      before_action :update_order_state, only: [:next, :advance, :update, :complete]
 
       rescue_from Spree::Order::InsufficientStock, with: :insufficient_stock_error
 
@@ -11,7 +11,7 @@ module Spree
       # TODO: Remove this after deprecated usage in #update is removed
       include Spree::Core::ControllerHelpers::PaymentParameters
 
-      # This before_filter comes from Spree::Core::ControllerHelpers::Order
+      # This before_action comes from Spree::Core::ControllerHelpers::Order
       skip_before_action :set_current_order
 
       def next

--- a/api/app/controllers/spree/api/line_items_controller.rb
+++ b/api/app/controllers/spree/api/line_items_controller.rb
@@ -5,8 +5,8 @@ module Spree
 
       self.line_item_options = []
 
-      before_filter :load_order, only: [:create, :update, :destroy]
-      around_filter :lock_order, only: [:create, :update, :destroy]
+      before_action :load_order, only: [:create, :update, :destroy]
+      around_action :lock_order, only: [:create, :update, :destroy]
 
       def new
       end

--- a/api/app/controllers/spree/api/orders_controller.rb
+++ b/api/app/controllers/spree/api/orders_controller.rb
@@ -10,7 +10,7 @@ module Spree
       skip_before_action :authenticate_user, only: :apply_coupon_code
 
       before_action :find_order, except: [:create, :mine, :current, :index]
-      around_filter :lock_order, except: [:create, :mine, :current, :index]
+      around_action :lock_order, except: [:create, :mine, :current, :index]
 
       # Dynamically defines our stores checkout steps to ensure we check authorization on each step.
       Order.checkout_steps.keys.each do |step|

--- a/api/app/controllers/spree/api/payments_controller.rb
+++ b/api/app/controllers/spree/api/payments_controller.rb
@@ -1,9 +1,9 @@
 module Spree
   module Api
     class PaymentsController < Spree::Api::BaseController
-      before_filter :find_order
-      around_filter :lock_order, only: [:create, :update, :destroy, :authorize, :capture, :purchase, :void, :credit]
-      before_filter :find_payment, only: [:update, :show, :authorize, :purchase, :capture, :void, :credit]
+      before_action :find_order
+      around_action :lock_order, only: [:create, :update, :destroy, :authorize, :capture, :purchase, :void, :credit]
+      before_action :find_payment, only: [:update, :show, :authorize, :purchase, :capture, :void, :credit]
 
       def index
         @payments = @order.payments.ransack(params[:q]).result.page(params[:page]).per(params[:per_page])

--- a/api/app/controllers/spree/api/promotions_controller.rb
+++ b/api/app/controllers/spree/api/promotions_controller.rb
@@ -1,8 +1,8 @@
 module Spree
   module Api
     class PromotionsController < Spree::Api::BaseController
-      before_filter :requires_admin
-      before_filter :load_promotion
+      before_action :requires_admin
+      before_action :load_promotion
 
       def show
         if @promotion

--- a/api/app/controllers/spree/api/return_authorizations_controller.rb
+++ b/api/app/controllers/spree/api/return_authorizations_controller.rb
@@ -1,8 +1,8 @@
 module Spree
   module Api
     class ReturnAuthorizationsController < Spree::Api::BaseController
-      before_filter :load_order
-      around_filter :lock_order, only: [:create, :update, :destroy, :add, :receive, :cancel]
+      before_action :load_order
+      around_action :lock_order, only: [:create, :update, :destroy, :add, :receive, :cancel]
 
       rescue_from Spree::Order::InsufficientStock, with: :insufficient_stock_error
 

--- a/api/app/controllers/spree/api/shipments_controller.rb
+++ b/api/app/controllers/spree/api/shipments_controller.rb
@@ -1,11 +1,11 @@
 module Spree
   module Api
     class ShipmentsController < Spree::Api::BaseController
-      before_filter :find_order_on_create, only: :create
-      before_filter :find_shipment, only: [:update, :ship, :ready, :add, :remove]
+      before_action :find_order_on_create, only: :create
+      before_action :find_shipment, only: [:update, :ship, :ready, :add, :remove]
       before_action :load_transfer_params, only: [:transfer_to_location, :transfer_to_shipment]
-      around_filter :lock_order, except: [:mine]
-      before_filter :update_shipment, only: [:ship, :ready, :add, :remove]
+      around_action :lock_order, except: [:mine]
+      before_action :update_shipment, only: [:ship, :ready, :add, :remove]
 
       def mine
         if current_api_user

--- a/api/app/controllers/spree/api/stock_items_controller.rb
+++ b/api/app/controllers/spree/api/stock_items_controller.rb
@@ -1,7 +1,7 @@
 module Spree
   module Api
     class StockItemsController < Spree::Api::BaseController
-      before_filter :load_stock_location, only: [:index, :show, :create]
+      before_action :load_stock_location, only: [:index, :show, :create]
 
       def index
         @stock_items = scope.ransack(params[:q]).result.page(params[:page]).per(params[:per_page])

--- a/api/app/controllers/spree/api/stores_controller.rb
+++ b/api/app/controllers/spree/api/stores_controller.rb
@@ -1,7 +1,7 @@
 module Spree
   module Api
     class StoresController < Spree::Api::BaseController
-      before_filter :get_store, except: [:index, :create]
+      before_action :get_store, except: [:index, :create]
 
       def index
         authorize! :read, Store

--- a/api/spec/controllers/spree/api/base_controller_spec.rb
+++ b/api/spec/controllers/spree/api/base_controller_spec.rb
@@ -143,7 +143,7 @@ describe Spree::Api::BaseController, type: :controller do
     let!(:order) { create :order }
 
     controller(Spree::Api::BaseController) do
-      around_filter :lock_order
+      around_action :lock_order
 
       def index
         render text: { "products" => [] }.to_json

--- a/backend/app/controllers/spree/admin/cancellations_controller.rb
+++ b/backend/app/controllers/spree/admin/cancellations_controller.rb
@@ -1,7 +1,7 @@
 module Spree
   module Admin
     class CancellationsController < Spree::Admin::BaseController
-      before_filter :load_order, only: [:index, :short_ship]
+      before_action :load_order, only: [:index, :short_ship]
 
       def index
         @inventory_units = @order.inventory_units.cancelable

--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -3,7 +3,7 @@ module Spree
     class OrdersController < Spree::Admin::BaseController
       before_action :initialize_order_events
       before_action :load_order, only: [:edit, :update, :complete, :advance, :cancel, :resume, :approve, :resend, :unfinalize_adjustments, :finalize_adjustments, :cart, :confirm]
-      around_filter :lock_order, only: [:update, :advance, :complete, :confirm, :cancel, :resume, :approve, :resend]
+      around_action :lock_order, only: [:update, :advance, :complete, :confirm, :cancel, :resume, :approve, :resend]
 
       rescue_from Spree::Order::InsufficientStock, with: :insufficient_stock_error
 

--- a/backend/app/controllers/spree/admin/payments_controller.rb
+++ b/backend/app/controllers/spree/admin/payments_controller.rb
@@ -1,11 +1,11 @@
 module Spree
   module Admin
     class PaymentsController < Spree::Admin::BaseController
-      before_filter :load_order, only: [:create, :new, :index, :fire]
-      before_filter :load_payment, except: [:create, :new, :index, :fire]
-      before_filter :load_payment_for_fire, only: :fire
-      before_filter :load_data
-      before_filter :require_bill_address, only: [:index]
+      before_action :load_order, only: [:create, :new, :index, :fire]
+      before_action :load_payment, except: [:create, :new, :index, :fire]
+      before_action :load_payment_for_fire, only: :fire
+      before_action :load_data
+      before_action :require_bill_address, only: [:index]
 
       respond_to :html
 

--- a/backend/app/controllers/spree/admin/products_controller.rb
+++ b/backend/app/controllers/spree/admin/products_controller.rb
@@ -3,7 +3,7 @@ module Spree
     class ProductsController < ResourceController
       helper 'spree/products'
 
-      before_filter :load_data, except: [:index]
+      before_action :load_data, except: [:index]
       create.before :create_before
       update.before :update_before
       helper_method :clone_object_url

--- a/backend/app/controllers/spree/admin/root_controller.rb
+++ b/backend/app/controllers/spree/admin/root_controller.rb
@@ -1,7 +1,7 @@
 module Spree
   module Admin
     class RootController < Spree::Admin::BaseController
-      skip_before_filter :authorize_admin
+      skip_before_action :authorize_admin
 
       def index
         redirect_to admin_root_redirect_path

--- a/backend/app/controllers/spree/admin/stock_transfers_controller.rb
+++ b/backend/app/controllers/spree/admin/stock_transfers_controller.rb
@@ -7,12 +7,12 @@ module Spree
         { translation_key: :name, attr_name: :name }
       ]
 
-      before_filter :load_viewable_stock_locations, only: :index
-      before_filter :load_variant_display_attributes, only: [:receive, :edit, :show, :tracking_info]
-      before_filter :load_source_stock_locations, only: :new
-      before_filter :load_destination_stock_locations, only: :edit
-      before_filter :ensure_access_to_stock_location, only: :create
-      before_filter :ensure_receivable_stock_transfer, only: :receive
+      before_action :load_viewable_stock_locations, only: :index
+      before_action :load_variant_display_attributes, only: [:receive, :edit, :show, :tracking_info]
+      before_action :load_source_stock_locations, only: :new
+      before_action :load_destination_stock_locations, only: :edit
+      before_action :ensure_access_to_stock_location, only: :create
+      before_action :ensure_receivable_stock_transfer, only: :receive
 
       create.before :authorize_transfer_attributes!
 

--- a/backend/app/controllers/spree/admin/users_controller.rb
+++ b/backend/app/controllers/spree/admin/users_controller.rb
@@ -5,7 +5,7 @@ module Spree
 
       after_action :sign_in_if_change_own_password, only: :update
 
-      before_filter :load_roles, :load_stock_locations, only: [:edit, :new]
+      before_action :load_roles, :load_stock_locations, only: [:edit, :new]
 
       def index
         respond_with(@collection) do |format|

--- a/core/lib/spree/core/controller_helpers/auth.rb
+++ b/core/lib/spree/core/controller_helpers/auth.rb
@@ -12,7 +12,7 @@ module Spree
         #   @return [Proc] action to take when access denied error is raised.
 
         included do
-          before_filter :set_guest_token
+          before_action :set_guest_token
           helper_method :try_spree_current_user
 
           class_attribute :unauthorized_redirect

--- a/core/lib/spree/core/controller_helpers/common.rb
+++ b/core/lib/spree/core/controller_helpers/common.rb
@@ -10,7 +10,7 @@ module Spree
 
           layout :get_layout
 
-          before_filter :set_user_language
+          before_action :set_user_language
         end
 
         protected

--- a/core/lib/spree/core/controller_helpers/order.rb
+++ b/core/lib/spree/core/controller_helpers/order.rb
@@ -8,7 +8,7 @@ module Spree
         include ControllerHelpers::Pricing
 
         included do
-          before_filter :set_current_order
+          before_action :set_current_order
 
           helper_method :current_order
           helper_method :simple_current_order

--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -4,9 +4,9 @@ module Spree
   # checkout which has nothing to do with updating an order that this approach
   # is warranted.
   class CheckoutController < Spree::StoreController
-    before_filter :load_order
-    around_filter :lock_order
-    before_filter :set_state_if_present
+    before_action :load_order
+    around_action :lock_order
+    before_action :set_state_if_present
 
     before_action :ensure_order_not_completed
     before_action :ensure_checkout_allowed

--- a/frontend/app/controllers/spree/orders_controller.rb
+++ b/frontend/app/controllers/spree/orders_controller.rb
@@ -6,11 +6,11 @@ module Spree
 
     respond_to :html
 
-    before_filter :assign_order, only: :update
+    before_action :assign_order, only: :update
     # note: do not lock the #edit action because that's where we redirect when we fail to acquire a lock
-    around_filter :lock_order, only: :update
-    before_filter :apply_coupon_code, only: :update
-    skip_before_filter :verify_authenticity_token, only: [:populate]
+    around_action :lock_order, only: :update
+    before_action :apply_coupon_code, only: :update
+    skip_before_action :verify_authenticity_token, only: [:populate]
 
     def show
       @order = Order.find_by_number!(params[:id])


### PR DESCRIPTION
Since before/around/after_filter callbacks are gonna be [deprecated](https://github.com/rails/rails/blob/v5.0.0.beta2/actionpack/lib/abstract_controller/callbacks.rb#L190-L193) soon, I thought this could be a nice improvement to keep things up to date.