### PR TITLE
Specify template for fresh_when

### DIFF
--- a/frontend/app/controllers/spree/store_controller.rb
+++ b/frontend/app/controllers/spree/store_controller.rb
@@ -11,7 +11,7 @@ module Spree
 
     def cart_link
       render partial: 'spree/shared/link_to_cart'
-      fresh_when(simple_current_order)
+      fresh_when(simple_current_order, template: 'spree/shared/_link_to_cart')
     end
 
     private


### PR DESCRIPTION
Noticed I was getting the error:

    Couldn't find template for digesting: store/cart_link

Indeed that template doesn't exist and we need to tell `fresh_when` which template we are actually using.