### PR TITLE
Fix capybara-screenshot on CI

### DIFF
--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -43,7 +43,7 @@ require 'spree/testing_support/capybara_ext'
 require 'paperclip/matchers'
 
 require 'capybara-screenshot/rspec'
-Capybara.save_and_open_page_path = ENV['CIRCLE_ARTIFACTS'] if ENV['CIRCLE_ARTIFACTS']
+Capybara.save_path = ENV['CIRCLE_ARTIFACTS'] if ENV['CIRCLE_ARTIFACTS']
 
 require 'capybara/poltergeist'
 Capybara.javascript_driver = :poltergeist

--- a/frontend/spec/spec_helper.rb
+++ b/frontend/spec/spec_helper.rb
@@ -48,7 +48,7 @@ require 'spree/testing_support/caching'
 require 'paperclip/matchers'
 
 require 'capybara-screenshot/rspec'
-Capybara.save_and_open_page_path = ENV['CIRCLE_ARTIFACTS'] if ENV['CIRCLE_ARTIFACTS']
+Capybara.save_path = ENV['CIRCLE_ARTIFACTS'] if ENV['CIRCLE_ARTIFACTS']
 
 if ENV['WEBDRIVER'] == 'accessible'
   require 'capybara/accessible'


### PR DESCRIPTION
capybara-screenshot stopped working on CI. I think previously it was using `Capybara.save_and_open_page_path`, which has now been deprecated and replaced with `Capybara.save_path`