### PR TITLE
Payment Factory should associate source with User

### DIFF
--- a/core/lib/spree/testing_support/factories/payment_factory.rb
+++ b/core/lib/spree/testing_support/factories/payment_factory.rb
@@ -6,7 +6,7 @@ require 'spree/testing_support/factories/store_credit_factory'
 FactoryGirl.define do
   factory :payment, aliases: [:credit_card_payment], class: Spree::Payment do
     association(:payment_method, factory: :credit_card_payment_method)
-    association(:source, factory: :credit_card)
+    source { create(:credit_card, user: order.user) }
     order
     state 'checkout'
     response_code '12345'

--- a/core/spec/lib/spree/core/testing_support/factories/payment_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/payment_factory_spec.rb
@@ -8,6 +8,12 @@ RSpec.describe 'payment factory' do
     let(:factory) { :payment }
 
     it_behaves_like 'a working factory'
+
+    it "assigns the Order's user to the created Credit Card" do
+      payment = create(factory)
+      expect(payment.source.user).to be_present
+      expect(payment.source.user).to eq payment.order.user
+    end
   end
 
   describe 'check payment' do


### PR DESCRIPTION
In the process of creating a Payment via the factories, a new CreditCard
record is created, but not associated with any user.

If we create a Payment via one of the Order factories, this can be quite
confusing, as the created Order may have a payment, but the created
Credit Card associated with the payment is not associated with the User
that created the order.

To correct this, we can provide the order's associated user to the
credit card we create as the payment source.
