### PR TITLE
Fix cancel order with store credits

### DIFF
--- a/core/app/models/spree/payment_method/store_credit.rb
+++ b/core/app/models/spree/payment_method/store_credit.rb
@@ -61,7 +61,7 @@ module Spree
       handle_action(action, :void, auth_code)
     end
 
-    def credit(amount_in_cents, auth_code, gateway_options)
+    def credit(amount_in_cents, auth_code, gateway_options = {})
       action = -> (store_credit) do
         currency = gateway_options[:currency] || store_credit.currency
         originator = gateway_options[:originator]

--- a/core/app/models/spree/payment_method/store_credit.rb
+++ b/core/app/models/spree/payment_method/store_credit.rb
@@ -79,7 +79,8 @@ module Spree
       if store_credit_event.nil? || store_credit.nil?
         ActiveMerchant::Billing::Response.new(false, '', {}, {})
       elsif store_credit_event.capture_action?
-        store_credit.credit(store_credit_event.amount, auth_code, store_credit.currency)
+        amount_in_cents = (store_credit_event.amount * 100).round
+        credit(amount_in_cents, auth_code)
       elsif store_credit_event.authorization_action?
         void(auth_code)
       else

--- a/core/app/models/spree/payment_method/store_credit.rb
+++ b/core/app/models/spree/payment_method/store_credit.rb
@@ -77,13 +77,13 @@ module Spree
       store_credit = store_credit_event.try(:store_credit)
 
       if store_credit_event.nil? || store_credit.nil?
-        return false
+        ActiveMerchant::Billing::Response.new(false, '', {}, {})
       elsif store_credit_event.capture_action?
         store_credit.credit(store_credit_event.amount, auth_code, store_credit.currency)
       elsif store_credit_event.authorization_action?
         store_credit.void(auth_code)
       else
-        return false
+        ActiveMerchant::Billing::Response.new(false, '', {}, {})
       end
     end
 

--- a/core/app/models/spree/payment_method/store_credit.rb
+++ b/core/app/models/spree/payment_method/store_credit.rb
@@ -81,7 +81,7 @@ module Spree
       elsif store_credit_event.capture_action?
         store_credit.credit(store_credit_event.amount, auth_code, store_credit.currency)
       elsif store_credit_event.authorization_action?
-        store_credit.void(auth_code)
+        void(auth_code)
       else
         ActiveMerchant::Billing::Response.new(false, '', {}, {})
       end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -40,7 +40,7 @@ describe Spree::Order, type: :model do
     end
   end
 
-  describe "#cancel!", pending: true do
+  describe "#cancel!" do
     context "with captured store credit" do
       let!(:store_credit_payment_method) { create(:store_credit_payment_method) }
       let(:order_total) { 500.00 }

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -40,6 +40,28 @@ describe Spree::Order, type: :model do
     end
   end
 
+  describe "#cancel!", pending: true do
+    context "with captured store credit" do
+      let!(:store_credit_payment_method) { create(:store_credit_payment_method) }
+      let(:order_total) { 500.00 }
+      let(:store_credit) { create(:store_credit, amount: order_total) }
+      let(:order) { create(:order_with_line_items, user: store_credit.user, line_items_price: order_total) }
+
+      before do
+        order.add_store_credit_payments
+        order.finalize!
+        order.capture_payments!
+      end
+
+      subject { order.cancel! }
+
+      it "cancels the order" do
+        expect{ subject }.to change{ order.can_cancel? }.from(true).to(false)
+        expect(order).to be_canceled
+      end
+    end
+  end
+
   context "#canceled_by" do
     let(:admin_user) { create :admin_user }
     let(:order) { create :order }

--- a/core/spec/models/spree/payment_method/store_credit_spec.rb
+++ b/core/spec/models/spree/payment_method/store_credit_spec.rb
@@ -255,6 +255,12 @@ describe Spree::PaymentMethod::StoreCredit do
     let(:auth_code)    { "1-SC-20141111111111" }
     let(:captured_amount) { 10.0 }
 
+    shared_examples "a spree payment method" do
+      it "returns an ActiveMerchant::Billing::Response" do
+        expect(subject).to be_instance_of(ActiveMerchant::Billing::Response)
+      end
+    end
+
     context "capture event found" do
       let!(:store_credit_event) {
         create(:store_credit_capture_event,
@@ -289,9 +295,9 @@ describe Spree::PaymentMethod::StoreCredit do
           Spree::PaymentMethod::StoreCredit.new.cancel('INVALID')
         end
 
-        it "returns false" do
-          expect(subject).to be false
-        end
+        it_behaves_like "a spree payment method"
+
+        it { expect(subject.success?).to be(false) }
       end
     end
   end

--- a/core/spec/models/spree/payment_method/store_credit_spec.rb
+++ b/core/spec/models/spree/payment_method/store_credit_spec.rb
@@ -270,6 +270,8 @@ describe Spree::PaymentMethod::StoreCredit do
                                         store_credit: store_credit)
       }
 
+      it_behaves_like "a spree payment method"
+
       it "refunds the capture amount" do
         expect { subject }.to change{ store_credit.reload.amount_remaining }.
                               from(original_amount - captured_amount).

--- a/core/spec/models/spree/payment_method/store_credit_spec.rb
+++ b/core/spec/models/spree/payment_method/store_credit_spec.rb
@@ -286,6 +286,8 @@ describe Spree::PaymentMethod::StoreCredit do
                                           store_credit: store_credit)
         }
 
+        it_behaves_like "a spree payment method"
+
         it "refunds the capture amount" do
           expect { subject }.to change{ store_credit.reload.amount_remaining }.
                                 from(original_amount - captured_amount).


### PR DESCRIPTION
When cancelling an order that had captured store credits the refunding of those credits errors and the order cancellation fails.

This is because methods which should have been invoked on the `PaymentMethod::StoreCredit` were instead being called on the `StoreCredit` directly. This led to bare responses being returned and caused the payment processing to choke [here](https://github.com/solidusio/solidus/blob/master/core/app/models/spree/payment/processing.rb#L181 ) where it expects an `ActiveMerchant::Billing::Response`.

I have added a spec for `Order#cancel` and improved the specs for `PaymentMethod::StoreCredit#cancel` so that they confirm the desired outcome of refunded store credits.