### PR TITLE
Move admin menu definition to configuration

### DIFF
--- a/backend/app/models/spree/backend_configuration.rb
+++ b/backend/app/models/spree/backend_configuration.rb
@@ -17,5 +17,105 @@ module Spree
     PROMOTION_TABS     ||= [:promotions, :promotion_categories]
     STOCK_TABS         ||= [:stock_items, :stock_transfers]
     USER_TABS          ||= [:users, :store_credits]
+
+    # An item which should be drawn in the admin menu
+    class MenuItem
+      attr_reader :icon, :label, :partial, :condition, :sections, :url
+
+      # @param sections [Array<Symbol>] The sections which are contained within
+      #   this admin menu section.
+      # @param icon [String] The icon to draw for this menu item
+      # @param condition [Proc] A proc which returns true if this menu item
+      #   should be drawn. If nil, it will be replaced with a proc which always
+      #   returns true.
+      # @param label [Symbol] The translation key for a label to use for this
+      #   menu item.
+      # @param partial [String] A partial to draw within this menu item for use
+      #   in declaring a submenu
+      # @param url [String] A url where this link should send the user to
+      def initialize(
+        sections,
+        icon,
+        condition: nil,
+        label: nil,
+        partial: nil,
+        url: nil
+      )
+
+        @condition = condition || -> { true }
+        @sections = sections
+        @icon = icon
+        @label = label || sections.first
+        @partial = partial
+        @url = url
+      end
+    end
+
+    # Items can be added to the menu by using code like the following:
+    #
+    # Spree::Backend::Config.configure do |config|
+    #   config.menu_items << config.class::MenuItem.new(
+    #     [:section],
+    #     'icon-name',
+    #     url: 'https://solidus.io/'
+    #   )
+    # end
+    #
+    # @!attribute menu_items
+    #   @return [Array<Spree::BackendConfiguration::MenuItem>]
+    attr_writer :menu_items
+
+    # Return the menu items which should be drawn in the menu
+    #
+    # @api public
+    # @return [Array<Spree::BackendConfiguration::MenuItem>]
+    def menu_items
+      @menu_items ||= [
+        MenuItem.new(
+          ORDER_TABS,
+          'shopping-cart',
+          condition: -> { can?(:admin, Spree::Order) },
+        ),
+        MenuItem.new(
+          PRODUCT_TABS,
+          'th-large',
+          condition: -> { can?(:admin, Spree::Product) },
+          partial: 'spree/admin/shared/product_sub_menu'
+        ),
+        MenuItem.new(
+          REPORT_TABS,
+          'file',
+          condition: -> { can?(:admin, :reports) },
+        ),
+        MenuItem.new(
+          CONFIGURATION_TABS,
+          'wrench',
+          condition: -> { can?(:admin, :general_settings) },
+          label: :settings,
+          partial: 'spree/admin/shared/settings_sub_menu',
+          url: :edit_admin_general_settings_path
+        ),
+        MenuItem.new(
+          PROMOTION_TABS,
+          'bullhorn',
+          condition: -> { can?(:admin, Spree::Promotion) },
+          url: :admin_promotions_path
+        ),
+        MenuItem.new(
+          STOCK_TABS,
+          'cubes',
+          condition: -> { can?(:admin, Spree::StockItem) },
+          label: :stock,
+          partial: 'spree/admin/shared/stock_sub_menu',
+          url: :admin_stock_items_path
+        ),
+        MenuItem.new(
+          USER_TABS,
+          'user',
+          condition: -> { Spree.user_class && can?(:admin, Spree.user_class) },
+          url: :admin_users_path
+        )
+      ]
+    end
   end
 end

--- a/backend/app/views/spree/admin/shared/_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_tabs.html.erb
@@ -1,39 +1,14 @@
-<% if can? :admin, Spree::Order %>
-  <%= tab *Spree::BackendConfiguration::ORDER_TABS, icon: 'shopping-cart' %>
-<% end %>
-
-<% if can? :admin, Spree::Product %>
-  <%= tab *Spree::BackendConfiguration::PRODUCT_TABS, icon: 'th-large' do %>
-    <%- render partial: 'spree/admin/shared/product_sub_menu' %>
-  <%- end %>
-<% end %>
-
-<% if can? :admin, :reports %>
-  <%= tab *Spree::BackendConfiguration::REPORT_TABS, icon: 'file'  %>
-<% end %>
-
-<% if can? :admin, :general_settings %>
-  <%= tab *Spree::BackendConfiguration::CONFIGURATION_TABS, label: :settings, icon: 'wrench', url: spree.edit_admin_general_settings_path do %>
-    <% render partial: 'spree/admin/shared/settings_sub_menu' %>
+<% Spree::Backend::Config.menu_items.each do |menu_item| %>
+  <% if instance_exec(&menu_item.condition) %>
+    <%=
+      tab(
+        *menu_item.sections,
+        icon: menu_item.icon,
+        label: menu_item.label,
+        url: menu_item.url.is_a?(Symbol) ? spree.public_send(menu_item.url) : menu_item.url
+      ) do
+    %>
+      <%- render partial: menu_item.partial if menu_item.partial %>
+    <%- end %>
   <% end %>
-<% end %>
-
-<% if can? :admin, Spree::Promotion %>
-  <%= tab *Spree::BackendConfiguration::PROMOTION_TABS, url: spree.admin_promotions_path, icon: 'bullhorn' do %>
-    <%- render partial: 'spree/admin/shared/promotion_sub_menu' %>
-  <%- end %>
-<% end %>
-
-<% if can? :admin, Spree::StockItem %>
-  <%= tab(
-    *Spree::BackendConfiguration::STOCK_TABS,
-    url: spree.admin_stock_items_path,
-    label: :stock, icon: 'cubes',
-    match_path: %r(^/admin/stock(?!_locations))) do %>
-    <%- render partial: 'spree/admin/shared/stock_sub_menu' %>
-  <%- end %>
-<% end %>
-
-<% if Spree.user_class && can?(:admin, Spree.user_class) %>
-  <%= tab *Spree::BackendConfiguration::USER_TABS, url: spree.admin_users_path, icon: 'user' %>
 <% end %>


### PR DESCRIPTION
This moves the admin menu to a configurable class. This allows people to
customize the menu by modifying it to their own will.

This can be accomplished by adding configuration to
Spree::Backend::Config.configure upon initialization of your app.

Example use:

```Ruby
Spree::Backend::Config.configure do |config|
  config.menu_items << Spree::BackendConfiguration::MenuItem.new(
    [:section],
    'icon-name',
    url: 'https://solidus.io/'
  )
end
```