### PR TITLE
Use spree RouteSet in navigation helper

### DIFF
--- a/backend/app/helpers/spree/admin/navigation_helper.rb
+++ b/backend/app/helpers/spree/admin/navigation_helper.rb
@@ -29,7 +29,7 @@ module Spree
         selected = if options[:match_path].is_a? Regexp
           request.fullpath =~ options[:match_path]
         elsif options[:match_path]
-          request.fullpath.starts_with?("#{admin_path}#{options[:match_path]}")
+          request.fullpath.starts_with?("#{spree.admin_path}#{options[:match_path]}")
         else
           request.fullpath.starts_with?(destination_url) ||
             args.include?(controller.controller_name.to_sym)

--- a/backend/spec/helpers/admin/navigation_helper_spec.rb
+++ b/backend/spec/helpers/admin/navigation_helper_spec.rb
@@ -37,8 +37,7 @@ describe Spree::Admin::NavigationHelper, type: :helper do
 
       context "when match_path option is supplied" do
         before do
-          allow(helper).to receive(:admin_path).and_return("/somepath")
-          allow(helper).to receive(:request).and_return(double(ActionDispatch::Request, fullpath: "/somepath/orders/edit/1"))
+          allow(helper).to receive(:request).and_return(double(ActionDispatch::Request, fullpath: "/admin/orders/edit/1"))
         end
 
         it "should be selected if the fullpath matches" do


### PR DESCRIPTION
This does not work correctly with admin pages outside of the Spree
namespace because the spree RouteSet is not explicitly invoked. The
spree RouteSet is used above in this class, but was not used correctly
here.