### PR TITLE
Fix bundler version conflict for actionview

### DIFF
--- a/frontend/solidus_frontend.gemspec
+++ b/frontend/solidus_frontend.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'solidus_api', s.version
   s.add_dependency 'solidus_core', s.version
 
-  s.add_dependency 'canonical-rails', '~> 0.0.4'
+  s.add_dependency 'canonical-rails', '~> 0.1.1'
   s.add_dependency 'jquery-rails'
   s.add_dependency 'sass-rails'
   s.add_dependency 'coffee-rails'


### PR DESCRIPTION
Upon running `bundle` in a fresh checkout of the current Rails 5 branch there is a version conflict for actionview.

```
Bundler could not find compatible versions for gem "actionview":
  In Gemfile:
    rspec-rails (>= 0) ruby depends on
      actionpack (>= 3.0) ruby depends on
        actionview (= 4.1.0) ruby

    solidus (>= 0) ruby depends on
      solidus_core (= 1.4.0.alpha) ruby depends on
        rails (~> 5.0.0.beta2) ruby depends on
          actionview (= 5.0.0.beta2) ruby
Bundler could not find compatible versions for gem "activesupport":
  In Gemfile:
    activesupport (>= 3.0) ruby

    activesupport (>= 3.0) ruby

    activesupport (>= 3.0.0) ruby

    state_machines-activemodel (>= 0) ruby depends on
      activemodel (< 5.1, >= 4.1) ruby depends on
        activesupport (= 4.1.0) ruby

    state_machines-activemodel (>= 0) ruby depends on
      activemodel (< 5.1, >= 4.1) ruby depends on
        activesupport (= 4.1.0) ruby

    rspec-rails (>= 0) ruby depends on
      actionpack (>= 3.0) ruby depends on
        activesupport (= 4.0.0) ruby
Bundler could not find compatible versions for gem "activemodel":
  In Gemfile:
    state_machines-activemodel (>= 0) ruby depends on
      activemodel (< 5.1, >= 4.1) ruby

    state_machines-activerecord (>= 0) ruby depends on
      activerecord (< 5.1, >= 4.1) ruby depends on
        activemodel (= 4.1.0) ruby

    rspec-rails (>= 0) ruby depends on
      actionpack (>= 3.0) ruby depends on
        activemodel (= 3.0.0) ruby
```

This is resolved by updating canonical-rails in the frontend gem to version 0.1.1 which has Rails 5 support.