### PR TITLE
specify rails version for all migrations

### DIFF
--- a/api/db/migrate/20100107141738_add_api_key_to_spree_users.rb
+++ b/api/db/migrate/20100107141738_add_api_key_to_spree_users.rb
@@ -1,4 +1,4 @@
-class AddApiKeyToSpreeUsers < ActiveRecord::Migration
+class AddApiKeyToSpreeUsers < ActiveRecord::Migration[4.2]
   def change
     unless defined?(User)
       add_column :spree_users, :api_key, :string, limit: 40

--- a/api/db/migrate/20120411123334_resize_api_key_field.rb
+++ b/api/db/migrate/20120411123334_resize_api_key_field.rb
@@ -1,4 +1,4 @@
-class ResizeApiKeyField < ActiveRecord::Migration
+class ResizeApiKeyField < ActiveRecord::Migration[4.2]
   def change
     unless defined?(User)
       change_column :spree_users, :api_key, :string, limit: 48

--- a/api/db/migrate/20120530054546_rename_api_key_to_spree_api_key.rb
+++ b/api/db/migrate/20120530054546_rename_api_key_to_spree_api_key.rb
@@ -1,4 +1,4 @@
-class RenameApiKeyToSpreeApiKey < ActiveRecord::Migration
+class RenameApiKeyToSpreeApiKey < ActiveRecord::Migration[4.2]
   def change
     unless defined?(User)
       rename_column :spree_users, :api_key, :spree_api_key

--- a/api/db/migrate/20131017162334_add_index_to_user_spree_api_key.rb
+++ b/api/db/migrate/20131017162334_add_index_to_user_spree_api_key.rb
@@ -1,4 +1,4 @@
-class AddIndexToUserSpreeApiKey < ActiveRecord::Migration
+class AddIndexToUserSpreeApiKey < ActiveRecord::Migration[4.2]
   def change
     unless defined?(User)
       add_index :spree_users, :spree_api_key

--- a/core/db/migrate/20120831092320_spree_one_two.rb
+++ b/core/db/migrate/20120831092320_spree_one_two.rb
@@ -1,4 +1,4 @@
-class SpreeOneTwo < ActiveRecord::Migration
+class SpreeOneTwo < ActiveRecord::Migration[4.2]
   def up
     # This migration is just a compressed version of all the previous
     # migrations for spree_core. Do not run it if one of the core tables

--- a/core/db/migrate/20120831092359_spree_promo_one_two.rb
+++ b/core/db/migrate/20120831092359_spree_promo_one_two.rb
@@ -1,4 +1,4 @@
-class SpreePromoOneTwo < ActiveRecord::Migration
+class SpreePromoOneTwo < ActiveRecord::Migration[4.2]
   def up
     # This migration is just a compressed migration for all previous versions of spree_promo
     return if table_exists?(:spree_products_promotion_rules)

--- a/core/db/migrate/20120905145253_add_tax_rate_label.rb
+++ b/core/db/migrate/20120905145253_add_tax_rate_label.rb
@@ -1,4 +1,4 @@
-class AddTaxRateLabel < ActiveRecord::Migration
+class AddTaxRateLabel < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_tax_rates, :name, :string
   end

--- a/core/db/migrate/20120905151823_add_toggle_tax_rate_display.rb
+++ b/core/db/migrate/20120905151823_add_toggle_tax_rate_display.rb
@@ -1,4 +1,4 @@
-class AddToggleTaxRateDisplay < ActiveRecord::Migration
+class AddToggleTaxRateDisplay < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_tax_rates, :show_rate_in_label, :boolean, default: true
   end

--- a/core/db/migrate/20120929093553_remove_unused_preference_columns.rb
+++ b/core/db/migrate/20120929093553_remove_unused_preference_columns.rb
@@ -1,4 +1,4 @@
-class RemoveUnusedPreferenceColumns < ActiveRecord::Migration
+class RemoveUnusedPreferenceColumns < ActiveRecord::Migration[4.2]
   def change
     # Columns have already been removed if the application was upgraded from an older version, but must be removed from new apps.
     remove_column :spree_preferences, :name       if ActiveRecord::Base.connection.column_exists?(:spree_preferences, :name)

--- a/core/db/migrate/20121009142519_add_lock_version_to_variant.rb
+++ b/core/db/migrate/20121009142519_add_lock_version_to_variant.rb
@@ -1,4 +1,4 @@
-class AddLockVersionToVariant < ActiveRecord::Migration
+class AddLockVersionToVariant < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_variants, :lock_version, :integer, default: 0
   end

--- a/core/db/migrate/20121010142909_add_states_required_to_countries.rb
+++ b/core/db/migrate/20121010142909_add_states_required_to_countries.rb
@@ -1,4 +1,4 @@
-class AddStatesRequiredToCountries < ActiveRecord::Migration
+class AddStatesRequiredToCountries < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_countries, :states_required, :boolean, default: true
   end

--- a/core/db/migrate/20121012071449_add_on_demand_to_product_and_variant.rb
+++ b/core/db/migrate/20121012071449_add_on_demand_to_product_and_variant.rb
@@ -1,4 +1,4 @@
-class AddOnDemandToProductAndVariant < ActiveRecord::Migration
+class AddOnDemandToProductAndVariant < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_products, :on_demand, :boolean, default: false
     add_column :spree_variants, :on_demand, :boolean, default: false

--- a/core/db/migrate/20121017010007_remove_not_null_constraint_from_products_on_hand.rb
+++ b/core/db/migrate/20121017010007_remove_not_null_constraint_from_products_on_hand.rb
@@ -1,4 +1,4 @@
-class RemoveNotNullConstraintFromProductsOnHand < ActiveRecord::Migration
+class RemoveNotNullConstraintFromProductsOnHand < ActiveRecord::Migration[4.2]
   def up
     change_column :spree_products, :count_on_hand, :integer, null: true
     change_column :spree_variants, :count_on_hand, :integer, null: true

--- a/core/db/migrate/20121031162139_split_prices_from_variants.rb
+++ b/core/db/migrate/20121031162139_split_prices_from_variants.rb
@@ -1,4 +1,4 @@
-class SplitPricesFromVariants < ActiveRecord::Migration
+class SplitPricesFromVariants < ActiveRecord::Migration[4.2]
   def up
     create_table :spree_prices do |t|
       t.integer :variant_id, null: false

--- a/core/db/migrate/20121107003422_remove_not_null_from_spree_prices_amount.rb
+++ b/core/db/migrate/20121107003422_remove_not_null_from_spree_prices_amount.rb
@@ -1,4 +1,4 @@
-class RemoveNotNullFromSpreePricesAmount < ActiveRecord::Migration
+class RemoveNotNullFromSpreePricesAmount < ActiveRecord::Migration[4.2]
   def up
     change_column :spree_prices, :amount, :decimal, precision: 8, scale: 2, null: true
   end

--- a/core/db/migrate/20121107184631_add_currency_to_line_items.rb
+++ b/core/db/migrate/20121107184631_add_currency_to_line_items.rb
@@ -1,4 +1,4 @@
-class AddCurrencyToLineItems < ActiveRecord::Migration
+class AddCurrencyToLineItems < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_line_items, :currency, :string
   end

--- a/core/db/migrate/20121107194006_add_currency_to_orders.rb
+++ b/core/db/migrate/20121107194006_add_currency_to_orders.rb
@@ -1,4 +1,4 @@
-class AddCurrencyToOrders < ActiveRecord::Migration
+class AddCurrencyToOrders < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_orders, :currency, :string
   end

--- a/core/db/migrate/20121109173623_add_cost_currency_to_variants.rb
+++ b/core/db/migrate/20121109173623_add_cost_currency_to_variants.rb
@@ -1,4 +1,4 @@
-class AddCostCurrencyToVariants < ActiveRecord::Migration
+class AddCostCurrencyToVariants < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_variants, :cost_currency, :string, after: :cost_price
   end

--- a/core/db/migrate/20121111231553_remove_display_on_from_payment_methods.rb
+++ b/core/db/migrate/20121111231553_remove_display_on_from_payment_methods.rb
@@ -1,4 +1,4 @@
-class RemoveDisplayOnFromPaymentMethods < ActiveRecord::Migration
+class RemoveDisplayOnFromPaymentMethods < ActiveRecord::Migration[4.2]
   def up
     remove_column :spree_payment_methods, :display_on
   end

--- a/core/db/migrate/20121124203911_add_position_to_taxonomies.rb
+++ b/core/db/migrate/20121124203911_add_position_to_taxonomies.rb
@@ -1,4 +1,4 @@
-class AddPositionToTaxonomies < ActiveRecord::Migration
+class AddPositionToTaxonomies < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_taxonomies, :position, :integer, default: 0
   end

--- a/core/db/migrate/20121126040517_add_last_ip_to_spree_orders.rb
+++ b/core/db/migrate/20121126040517_add_last_ip_to_spree_orders.rb
@@ -1,4 +1,4 @@
-class AddLastIpToSpreeOrders < ActiveRecord::Migration
+class AddLastIpToSpreeOrders < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_orders, :last_ip_address, :string
   end

--- a/core/db/migrate/20121213162028_add_state_to_spree_adjustments.rb
+++ b/core/db/migrate/20121213162028_add_state_to_spree_adjustments.rb
@@ -1,4 +1,4 @@
-class AddStateToSpreeAdjustments < ActiveRecord::Migration
+class AddStateToSpreeAdjustments < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_adjustments, :state, :string
     remove_column :spree_adjustments, :locked

--- a/core/db/migrate/20130114053446_add_display_on_to_spree_payment_methods.rb
+++ b/core/db/migrate/20130114053446_add_display_on_to_spree_payment_methods.rb
@@ -1,4 +1,4 @@
-class AddDisplayOnToSpreePaymentMethods < ActiveRecord::Migration
+class AddDisplayOnToSpreePaymentMethods < ActiveRecord::Migration[4.2]
   def self.up
     add_column :spree_payment_methods, :display_on, :string
   end

--- a/core/db/migrate/20130120201805_add_position_to_product_properties.spree.rb
+++ b/core/db/migrate/20130120201805_add_position_to_product_properties.spree.rb
@@ -1,4 +1,4 @@
-class AddPositionToProductProperties < ActiveRecord::Migration
+class AddPositionToProductProperties < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_product_properties, :position, :integer, default: 0
   end

--- a/core/db/migrate/20130203232234_add_identifier_to_spree_payments.rb
+++ b/core/db/migrate/20130203232234_add_identifier_to_spree_payments.rb
@@ -1,4 +1,4 @@
-class AddIdentifierToSpreePayments < ActiveRecord::Migration
+class AddIdentifierToSpreePayments < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_payments, :identifier, :string
   end

--- a/core/db/migrate/20130207155350_add_order_id_index_to_payments.rb
+++ b/core/db/migrate/20130207155350_add_order_id_index_to_payments.rb
@@ -1,4 +1,4 @@
-class AddOrderIdIndexToPayments < ActiveRecord::Migration
+class AddOrderIdIndexToPayments < ActiveRecord::Migration[4.2]
   def self.up
     add_index :spree_payments, :order_id
   end

--- a/core/db/migrate/20130208032954_add_primary_to_spree_products_taxons.rb
+++ b/core/db/migrate/20130208032954_add_primary_to_spree_products_taxons.rb
@@ -1,4 +1,4 @@
-class AddPrimaryToSpreeProductsTaxons < ActiveRecord::Migration
+class AddPrimaryToSpreeProductsTaxons < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_products_taxons, :id, :primary_key
   end

--- a/core/db/migrate/20130211190146_create_spree_stock_items.rb
+++ b/core/db/migrate/20130211190146_create_spree_stock_items.rb
@@ -1,4 +1,4 @@
-class CreateSpreeStockItems < ActiveRecord::Migration
+class CreateSpreeStockItems < ActiveRecord::Migration[4.2]
   def change
     create_table :spree_stock_items do |t|
       t.belongs_to :stock_location

--- a/core/db/migrate/20130211191120_create_spree_stock_locations.rb
+++ b/core/db/migrate/20130211191120_create_spree_stock_locations.rb
@@ -1,4 +1,4 @@
-class CreateSpreeStockLocations < ActiveRecord::Migration
+class CreateSpreeStockLocations < ActiveRecord::Migration[4.2]
   def change
     create_table :spree_stock_locations do |t|
       t.string :name

--- a/core/db/migrate/20130213191427_create_default_stock.rb
+++ b/core/db/migrate/20130213191427_create_default_stock.rb
@@ -1,4 +1,4 @@
-class CreateDefaultStock < ActiveRecord::Migration
+class CreateDefaultStock < ActiveRecord::Migration[4.2]
   class Variant < ActiveRecord::Base
     self.table_name = 'spree_variants'
   end

--- a/core/db/migrate/20130222032153_add_order_id_index_to_shipments.rb
+++ b/core/db/migrate/20130222032153_add_order_id_index_to_shipments.rb
@@ -1,4 +1,4 @@
-class AddOrderIdIndexToShipments < ActiveRecord::Migration
+class AddOrderIdIndexToShipments < ActiveRecord::Migration[4.2]
   def change
     add_index :spree_shipments, :order_id
   end

--- a/core/db/migrate/20130226032817_change_meta_description_on_spree_products_to_text.rb
+++ b/core/db/migrate/20130226032817_change_meta_description_on_spree_products_to_text.rb
@@ -1,4 +1,4 @@
-class ChangeMetaDescriptionOnSpreeProductsToText < ActiveRecord::Migration
+class ChangeMetaDescriptionOnSpreeProductsToText < ActiveRecord::Migration[4.2]
   def change
     change_column :spree_products, :meta_description, :text, limit: nil
   end

--- a/core/db/migrate/20130226191231_add_stock_location_id_to_spree_shipments.rb
+++ b/core/db/migrate/20130226191231_add_stock_location_id_to_spree_shipments.rb
@@ -1,4 +1,4 @@
-class AddStockLocationIdToSpreeShipments < ActiveRecord::Migration
+class AddStockLocationIdToSpreeShipments < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_shipments, :stock_location_id, :integer
   end

--- a/core/db/migrate/20130227143905_add_pending_to_inventory_unit.rb
+++ b/core/db/migrate/20130227143905_add_pending_to_inventory_unit.rb
@@ -1,4 +1,4 @@
-class AddPendingToInventoryUnit < ActiveRecord::Migration
+class AddPendingToInventoryUnit < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_inventory_units, :pending, :boolean, default: true
     Spree::InventoryUnit.update_all(pending: false)

--- a/core/db/migrate/20130228164411_remove_on_demand_from_product_and_variant.rb
+++ b/core/db/migrate/20130228164411_remove_on_demand_from_product_and_variant.rb
@@ -1,4 +1,4 @@
-class RemoveOnDemandFromProductAndVariant < ActiveRecord::Migration
+class RemoveOnDemandFromProductAndVariant < ActiveRecord::Migration[4.2]
   def change
     remove_column :spree_products, :on_demand
     remove_column :spree_variants, :on_demand

--- a/core/db/migrate/20130228210442_create_shipping_method_zone.rb
+++ b/core/db/migrate/20130228210442_create_shipping_method_zone.rb
@@ -1,4 +1,4 @@
-class CreateShippingMethodZone < ActiveRecord::Migration
+class CreateShippingMethodZone < ActiveRecord::Migration[4.2]
   class ShippingMethodZone < Spree::Base
     self.table_name = 'shipping_methods_zones'
   end

--- a/core/db/migrate/20130301162745_remove_shipping_category_id_from_shipping_method.rb
+++ b/core/db/migrate/20130301162745_remove_shipping_category_id_from_shipping_method.rb
@@ -1,4 +1,4 @@
-class RemoveShippingCategoryIdFromShippingMethod < ActiveRecord::Migration
+class RemoveShippingCategoryIdFromShippingMethod < ActiveRecord::Migration[4.2]
   def change
     remove_column :spree_shipping_methods, :shipping_category_id
   end

--- a/core/db/migrate/20130301162924_create_shipping_method_categories.rb
+++ b/core/db/migrate/20130301162924_create_shipping_method_categories.rb
@@ -1,4 +1,4 @@
-class CreateShippingMethodCategories < ActiveRecord::Migration
+class CreateShippingMethodCategories < ActiveRecord::Migration[4.2]
   def change
     create_table :spree_shipping_method_categories do |t|
       t.integer :shipping_method_id, null: false

--- a/core/db/migrate/20130301205200_add_tracking_url_to_spree_shipping_methods.rb
+++ b/core/db/migrate/20130301205200_add_tracking_url_to_spree_shipping_methods.rb
@@ -1,4 +1,4 @@
-class AddTrackingUrlToSpreeShippingMethods < ActiveRecord::Migration
+class AddTrackingUrlToSpreeShippingMethods < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_shipping_methods, :tracking_url, :string
   end

--- a/core/db/migrate/20130304162240_create_spree_shipping_rates.rb
+++ b/core/db/migrate/20130304162240_create_spree_shipping_rates.rb
@@ -1,4 +1,4 @@
-class CreateSpreeShippingRates < ActiveRecord::Migration
+class CreateSpreeShippingRates < ActiveRecord::Migration[4.2]
   def up
     create_table :spree_shipping_rates do |t|
       t.belongs_to :shipment

--- a/core/db/migrate/20130304192936_remove_category_match_attributes_from_shipping_method.rb
+++ b/core/db/migrate/20130304192936_remove_category_match_attributes_from_shipping_method.rb
@@ -1,4 +1,4 @@
-class RemoveCategoryMatchAttributesFromShippingMethod < ActiveRecord::Migration
+class RemoveCategoryMatchAttributesFromShippingMethod < ActiveRecord::Migration[4.2]
   def change
     remove_column :spree_shipping_methods, :match_none
     remove_column :spree_shipping_methods, :match_one

--- a/core/db/migrate/20130305143310_create_stock_movements.rb
+++ b/core/db/migrate/20130305143310_create_stock_movements.rb
@@ -1,4 +1,4 @@
-class CreateStockMovements < ActiveRecord::Migration
+class CreateStockMovements < ActiveRecord::Migration[4.2]
   def change
     create_table :spree_stock_movements do |t|
       t.belongs_to :stock_item

--- a/core/db/migrate/20130306181701_add_address_fields_to_stock_location.rb
+++ b/core/db/migrate/20130306181701_add_address_fields_to_stock_location.rb
@@ -1,4 +1,4 @@
-class AddAddressFieldsToStockLocation < ActiveRecord::Migration
+class AddAddressFieldsToStockLocation < ActiveRecord::Migration[4.2]
   def change
     remove_column :spree_stock_locations, :address_id
 

--- a/core/db/migrate/20130306191917_add_active_field_to_stock_locations.rb
+++ b/core/db/migrate/20130306191917_add_active_field_to_stock_locations.rb
@@ -1,4 +1,4 @@
-class AddActiveFieldToStockLocations < ActiveRecord::Migration
+class AddActiveFieldToStockLocations < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_stock_locations, :active, :boolean, default: true
   end

--- a/core/db/migrate/20130306195650_add_backorderable_to_stock_item.rb
+++ b/core/db/migrate/20130306195650_add_backorderable_to_stock_item.rb
@@ -1,4 +1,4 @@
-class AddBackorderableToStockItem < ActiveRecord::Migration
+class AddBackorderableToStockItem < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_stock_items, :backorderable, :boolean, default: true
   end

--- a/core/db/migrate/20130307161754_add_default_quantity_to_stock_movement.rb
+++ b/core/db/migrate/20130307161754_add_default_quantity_to_stock_movement.rb
@@ -1,4 +1,4 @@
-class AddDefaultQuantityToStockMovement < ActiveRecord::Migration
+class AddDefaultQuantityToStockMovement < ActiveRecord::Migration[4.2]
   def change
     change_column :spree_stock_movements, :quantity, :integer, default: 0
   end

--- a/core/db/migrate/20130318151756_add_source_and_destination_to_stock_movements.rb
+++ b/core/db/migrate/20130318151756_add_source_and_destination_to_stock_movements.rb
@@ -1,4 +1,4 @@
-class AddSourceAndDestinationToStockMovements < ActiveRecord::Migration
+class AddSourceAndDestinationToStockMovements < ActiveRecord::Migration[4.2]
   def change
     change_table :spree_stock_movements do |t|
       t.references :source, polymorphic: true

--- a/core/db/migrate/20130319062004_change_orders_total_precision.rb
+++ b/core/db/migrate/20130319062004_change_orders_total_precision.rb
@@ -1,4 +1,4 @@
-class ChangeOrdersTotalPrecision < ActiveRecord::Migration
+class ChangeOrdersTotalPrecision < ActiveRecord::Migration[4.2]
    def change
     change_column :spree_orders, :item_total, :decimal, precision: 10, scale: 2, default: 0.0, null: false
     change_column :spree_orders, :total, :decimal, precision: 10, scale: 2, default: 0.0, null: false

--- a/core/db/migrate/20130319063911_change_spree_payments_amount_precision.rb
+++ b/core/db/migrate/20130319063911_change_spree_payments_amount_precision.rb
@@ -1,4 +1,4 @@
-class ChangeSpreePaymentsAmountPrecision < ActiveRecord::Migration
+class ChangeSpreePaymentsAmountPrecision < ActiveRecord::Migration[4.2]
   def change
     change_column :spree_payments, :amount, :decimal, precision: 10, scale: 2, default: 0.0, null: false
   end

--- a/core/db/migrate/20130319064308_change_spree_return_authorization_amount_precision.rb
+++ b/core/db/migrate/20130319064308_change_spree_return_authorization_amount_precision.rb
@@ -1,4 +1,4 @@
-class ChangeSpreeReturnAuthorizationAmountPrecision < ActiveRecord::Migration
+class ChangeSpreeReturnAuthorizationAmountPrecision < ActiveRecord::Migration[4.2]
   def change
     change_column :spree_return_authorizations, :amount, :decimal, precision: 10, scale: 2, default: 0.0, null: false
   end

--- a/core/db/migrate/20130319082943_change_adjustments_amount_precision.rb
+++ b/core/db/migrate/20130319082943_change_adjustments_amount_precision.rb
@@ -1,4 +1,4 @@
-class ChangeAdjustmentsAmountPrecision < ActiveRecord::Migration
+class ChangeAdjustmentsAmountPrecision < ActiveRecord::Migration[4.2]
   def change
     change_column :spree_adjustments, :amount, :decimal, precision: 10, scale: 2
   end

--- a/core/db/migrate/20130319183250_add_originator_to_stock_movement.rb
+++ b/core/db/migrate/20130319183250_add_originator_to_stock_movement.rb
@@ -1,4 +1,4 @@
-class AddOriginatorToStockMovement < ActiveRecord::Migration
+class AddOriginatorToStockMovement < ActiveRecord::Migration[4.2]
   def change
     change_table :spree_stock_movements do |t|
       t.references :originator, polymorphic: true

--- a/core/db/migrate/20130319190507_drop_source_and_destination_from_stock_movement.rb
+++ b/core/db/migrate/20130319190507_drop_source_and_destination_from_stock_movement.rb
@@ -1,4 +1,4 @@
-class DropSourceAndDestinationFromStockMovement < ActiveRecord::Migration
+class DropSourceAndDestinationFromStockMovement < ActiveRecord::Migration[4.2]
   def up
     change_table :spree_stock_movements do |t|
       t.remove_references :source, polymorphic: true

--- a/core/db/migrate/20130325163316_migrate_inventory_unit_sold_to_on_hand.rb
+++ b/core/db/migrate/20130325163316_migrate_inventory_unit_sold_to_on_hand.rb
@@ -1,4 +1,4 @@
-class MigrateInventoryUnitSoldToOnHand < ActiveRecord::Migration
+class MigrateInventoryUnitSoldToOnHand < ActiveRecord::Migration[4.2]
   def up
     Spree::InventoryUnit.where(state: 'sold').update_all(state: 'on_hand')
   end

--- a/core/db/migrate/20130326175857_add_stock_location_to_rma.rb
+++ b/core/db/migrate/20130326175857_add_stock_location_to_rma.rb
@@ -1,4 +1,4 @@
-class AddStockLocationToRma < ActiveRecord::Migration
+class AddStockLocationToRma < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_return_authorizations, :stock_location_id, :integer
   end

--- a/core/db/migrate/20130328130308_update_shipment_state_for_canceled_orders.rb
+++ b/core/db/migrate/20130328130308_update_shipment_state_for_canceled_orders.rb
@@ -1,4 +1,4 @@
-class UpdateShipmentStateForCanceledOrders < ActiveRecord::Migration
+class UpdateShipmentStateForCanceledOrders < ActiveRecord::Migration[4.2]
   def up
     shipments = Spree::Shipment.joins(:order).
       where("spree_orders.state = 'canceled'")

--- a/core/db/migrate/20130328195253_add_seo_metas_to_taxons.rb
+++ b/core/db/migrate/20130328195253_add_seo_metas_to_taxons.rb
@@ -1,4 +1,4 @@
-class AddSeoMetasToTaxons < ActiveRecord::Migration
+class AddSeoMetasToTaxons < ActiveRecord::Migration[4.2]
   def change
     change_table :spree_taxons do |t|
       t.string   :meta_title

--- a/core/db/migrate/20130329134939_remove_stock_item_and_variant_lock.rb
+++ b/core/db/migrate/20130329134939_remove_stock_item_and_variant_lock.rb
@@ -1,4 +1,4 @@
-class RemoveStockItemAndVariantLock < ActiveRecord::Migration
+class RemoveStockItemAndVariantLock < ActiveRecord::Migration[4.2]
   def up
     # we are moving to pessimistic locking on stock_items
     remove_column :spree_stock_items, :lock_version

--- a/core/db/migrate/20130413230529_add_name_to_spree_credit_cards.rb
+++ b/core/db/migrate/20130413230529_add_name_to_spree_credit_cards.rb
@@ -1,4 +1,4 @@
-class AddNameToSpreeCreditCards < ActiveRecord::Migration
+class AddNameToSpreeCreditCards < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_credit_cards, :name, :string
   end

--- a/core/db/migrate/20130414000512_update_name_fields_on_spree_credit_cards.rb
+++ b/core/db/migrate/20130414000512_update_name_fields_on_spree_credit_cards.rb
@@ -1,4 +1,4 @@
-class UpdateNameFieldsOnSpreeCreditCards < ActiveRecord::Migration
+class UpdateNameFieldsOnSpreeCreditCards < ActiveRecord::Migration[4.2]
   def up
     if ActiveRecord::Base.connection.adapter_name.downcase.include? "mysql"
       execute "UPDATE spree_credit_cards SET name = CONCAT(first_name, ' ', last_name)"

--- a/core/db/migrate/20130417120034_add_index_to_source_columns_on_adjustments.rb
+++ b/core/db/migrate/20130417120034_add_index_to_source_columns_on_adjustments.rb
@@ -1,4 +1,4 @@
-class AddIndexToSourceColumnsOnAdjustments < ActiveRecord::Migration
+class AddIndexToSourceColumnsOnAdjustments < ActiveRecord::Migration[4.2]
   def change
     add_index :spree_adjustments, [:source_type, :source_id]
   end

--- a/core/db/migrate/20130417120035_update_adjustment_states.rb
+++ b/core/db/migrate/20130417120035_update_adjustment_states.rb
@@ -1,4 +1,4 @@
-class UpdateAdjustmentStates < ActiveRecord::Migration
+class UpdateAdjustmentStates < ActiveRecord::Migration[4.2]
   def up
     Spree::Order.complete.find_each do |order|
       order.adjustments.update_all(state: 'closed')

--- a/core/db/migrate/20130417123427_add_shipping_rates_to_shipments.rb
+++ b/core/db/migrate/20130417123427_add_shipping_rates_to_shipments.rb
@@ -1,4 +1,4 @@
-class AddShippingRatesToShipments < ActiveRecord::Migration
+class AddShippingRatesToShipments < ActiveRecord::Migration[4.2]
   def up
     Spree::Shipment.find_each do |shipment|
       shipment.shipping_rates.create(shipping_method_id: shipment.shipping_method_id,

--- a/core/db/migrate/20130418125341_create_spree_stock_transfers.rb
+++ b/core/db/migrate/20130418125341_create_spree_stock_transfers.rb
@@ -1,4 +1,4 @@
-class CreateSpreeStockTransfers < ActiveRecord::Migration
+class CreateSpreeStockTransfers < ActiveRecord::Migration[4.2]
   def change
     create_table :spree_stock_transfers do |t|
       t.string :type

--- a/core/db/migrate/20130423110707_drop_products_count_on_hand.rb
+++ b/core/db/migrate/20130423110707_drop_products_count_on_hand.rb
@@ -1,4 +1,4 @@
-class DropProductsCountOnHand < ActiveRecord::Migration
+class DropProductsCountOnHand < ActiveRecord::Migration[4.2]
   def up
     remove_column :spree_products, :count_on_hand
   end

--- a/core/db/migrate/20130423223847_set_default_shipping_rate_cost.rb
+++ b/core/db/migrate/20130423223847_set_default_shipping_rate_cost.rb
@@ -1,4 +1,4 @@
-class SetDefaultShippingRateCost < ActiveRecord::Migration
+class SetDefaultShippingRateCost < ActiveRecord::Migration[4.2]
   def change
     change_column :spree_shipping_rates, :cost, :decimal, default: 0, precision: 8, scale: 2
   end

--- a/core/db/migrate/20130509115210_add_number_to_stock_transfer.rb
+++ b/core/db/migrate/20130509115210_add_number_to_stock_transfer.rb
@@ -1,4 +1,4 @@
-class AddNumberToStockTransfer < ActiveRecord::Migration
+class AddNumberToStockTransfer < ActiveRecord::Migration[4.2]
   def up
     remove_index :spree_stock_transfers, :source_location_id
     remove_index :spree_stock_transfers, :destination_location_id

--- a/core/db/migrate/20130514151929_add_sku_index_to_spree_variants.rb
+++ b/core/db/migrate/20130514151929_add_sku_index_to_spree_variants.rb
@@ -1,4 +1,4 @@
-class AddSkuIndexToSpreeVariants < ActiveRecord::Migration
+class AddSkuIndexToSpreeVariants < ActiveRecord::Migration[4.2]
   def change
     add_index :spree_variants, :sku
   end

--- a/core/db/migrate/20130515180736_add_backorderable_default_to_spree_stock_location.rb
+++ b/core/db/migrate/20130515180736_add_backorderable_default_to_spree_stock_location.rb
@@ -1,4 +1,4 @@
-class AddBackorderableDefaultToSpreeStockLocation < ActiveRecord::Migration
+class AddBackorderableDefaultToSpreeStockLocation < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_stock_locations, :backorderable_default, :boolean, default: true
   end

--- a/core/db/migrate/20130516151222_add_propage_all_variants_to_spree_stock_location.rb
+++ b/core/db/migrate/20130516151222_add_propage_all_variants_to_spree_stock_location.rb
@@ -1,4 +1,4 @@
-class AddPropageAllVariantsToSpreeStockLocation < ActiveRecord::Migration
+class AddPropageAllVariantsToSpreeStockLocation < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_stock_locations, :propagate_all_variants, :boolean, default: true
   end

--- a/core/db/migrate/20130611054351_rename_shipping_methods_zones_to_spree_shipping_methods_zones.rb
+++ b/core/db/migrate/20130611054351_rename_shipping_methods_zones_to_spree_shipping_methods_zones.rb
@@ -1,4 +1,4 @@
-class RenameShippingMethodsZonesToSpreeShippingMethodsZones < ActiveRecord::Migration
+class RenameShippingMethodsZonesToSpreeShippingMethodsZones < ActiveRecord::Migration[4.2]
   def change
     rename_table :shipping_methods_zones, :spree_shipping_methods_zones
   end

--- a/core/db/migrate/20130611185927_add_user_id_index_to_spree_orders.rb
+++ b/core/db/migrate/20130611185927_add_user_id_index_to_spree_orders.rb
@@ -1,4 +1,4 @@
-class AddUserIdIndexToSpreeOrders < ActiveRecord::Migration
+class AddUserIdIndexToSpreeOrders < ActiveRecord::Migration[4.2]
   def change
     add_index :spree_orders, :user_id
   end

--- a/core/db/migrate/20130618041418_add_updated_at_to_spree_countries.rb
+++ b/core/db/migrate/20130618041418_add_updated_at_to_spree_countries.rb
@@ -1,4 +1,4 @@
-class AddUpdatedAtToSpreeCountries < ActiveRecord::Migration
+class AddUpdatedAtToSpreeCountries < ActiveRecord::Migration[4.2]
   def up
     add_column :spree_countries, :updated_at, :datetime
   end

--- a/core/db/migrate/20130619012236_add_updated_at_to_spree_states.rb
+++ b/core/db/migrate/20130619012236_add_updated_at_to_spree_states.rb
@@ -1,4 +1,4 @@
-class AddUpdatedAtToSpreeStates < ActiveRecord::Migration
+class AddUpdatedAtToSpreeStates < ActiveRecord::Migration[4.2]
   def up
     add_column :spree_states, :updated_at, :datetime
   end

--- a/core/db/migrate/20130626232741_add_cvv_result_code_and_cvv_result_message_to_spree_payments.rb
+++ b/core/db/migrate/20130626232741_add_cvv_result_code_and_cvv_result_message_to_spree_payments.rb
@@ -1,4 +1,4 @@
-class AddCvvResultCodeAndCvvResultMessageToSpreePayments < ActiveRecord::Migration
+class AddCvvResultCodeAndCvvResultMessageToSpreePayments < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_payments, :cvv_response_code, :string
     add_column :spree_payments, :cvv_response_message, :string

--- a/core/db/migrate/20130628021056_add_unique_index_to_permalink_on_spree_products.rb
+++ b/core/db/migrate/20130628021056_add_unique_index_to_permalink_on_spree_products.rb
@@ -1,4 +1,4 @@
-class AddUniqueIndexToPermalinkOnSpreeProducts < ActiveRecord::Migration
+class AddUniqueIndexToPermalinkOnSpreeProducts < ActiveRecord::Migration[4.2]
   def change
     add_index "spree_products", ["permalink"], name: "permalink_idx_unique", unique: true
   end

--- a/core/db/migrate/20130628022817_add_unique_index_to_orders_shipments_and_stock_transfers.rb
+++ b/core/db/migrate/20130628022817_add_unique_index_to_orders_shipments_and_stock_transfers.rb
@@ -1,4 +1,4 @@
-class AddUniqueIndexToOrdersShipmentsAndStockTransfers < ActiveRecord::Migration
+class AddUniqueIndexToOrdersShipmentsAndStockTransfers < ActiveRecord::Migration[4.2]
   def add
     add_index "spree_orders", ["number"], name: "number_idx_unique", unique: true
     add_index "spree_shipments", ["number"], name: "number_idx_unique", unique: true

--- a/core/db/migrate/20130708052307_add_deleted_at_to_spree_tax_rates.rb
+++ b/core/db/migrate/20130708052307_add_deleted_at_to_spree_tax_rates.rb
@@ -1,4 +1,4 @@
-class AddDeletedAtToSpreeTaxRates < ActiveRecord::Migration
+class AddDeletedAtToSpreeTaxRates < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_tax_rates, :deleted_at, :datetime
   end

--- a/core/db/migrate/20130711200933_remove_lock_version_from_inventory_units.rb
+++ b/core/db/migrate/20130711200933_remove_lock_version_from_inventory_units.rb
@@ -1,4 +1,4 @@
-class RemoveLockVersionFromInventoryUnits < ActiveRecord::Migration
+class RemoveLockVersionFromInventoryUnits < ActiveRecord::Migration[4.2]
   def change
     # we are moving to pessimistic locking on stock_items
     remove_column :spree_inventory_units, :lock_version

--- a/core/db/migrate/20130718042445_add_cost_price_to_line_item.rb
+++ b/core/db/migrate/20130718042445_add_cost_price_to_line_item.rb
@@ -1,4 +1,4 @@
-class AddCostPriceToLineItem < ActiveRecord::Migration
+class AddCostPriceToLineItem < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_line_items, :cost_price, :decimal, precision: 8, scale: 2
   end

--- a/core/db/migrate/20130718233855_set_backorderable_to_default_to_false.rb
+++ b/core/db/migrate/20130718233855_set_backorderable_to_default_to_false.rb
@@ -1,4 +1,4 @@
-class SetBackorderableToDefaultToFalse < ActiveRecord::Migration
+class SetBackorderableToDefaultToFalse < ActiveRecord::Migration[4.2]
   def change
     change_column :spree_stock_items, :backorderable, :boolean, default: false
     change_column :spree_stock_locations, :backorderable_default, :boolean, default: false

--- a/core/db/migrate/20130725031716_add_created_by_id_to_spree_orders.rb
+++ b/core/db/migrate/20130725031716_add_created_by_id_to_spree_orders.rb
@@ -1,4 +1,4 @@
-class AddCreatedByIdToSpreeOrders < ActiveRecord::Migration
+class AddCreatedByIdToSpreeOrders < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_orders, :created_by_id, :integer
   end

--- a/core/db/migrate/20130729214043_index_completed_at_on_spree_orders.rb
+++ b/core/db/migrate/20130729214043_index_completed_at_on_spree_orders.rb
@@ -1,4 +1,4 @@
-class IndexCompletedAtOnSpreeOrders < ActiveRecord::Migration
+class IndexCompletedAtOnSpreeOrders < ActiveRecord::Migration[4.2]
   def change
     add_index :spree_orders, :completed_at
   end

--- a/core/db/migrate/20130802014537_add_tax_category_id_to_spree_line_items.rb
+++ b/core/db/migrate/20130802014537_add_tax_category_id_to_spree_line_items.rb
@@ -1,4 +1,4 @@
-class AddTaxCategoryIdToSpreeLineItems < ActiveRecord::Migration
+class AddTaxCategoryIdToSpreeLineItems < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_line_items, :tax_category_id, :integer
   end

--- a/core/db/migrate/20130802022321_migrate_tax_categories_to_line_items.rb
+++ b/core/db/migrate/20130802022321_migrate_tax_categories_to_line_items.rb
@@ -1,4 +1,4 @@
-class MigrateTaxCategoriesToLineItems < ActiveRecord::Migration
+class MigrateTaxCategoriesToLineItems < ActiveRecord::Migration[4.2]
   def change
     Spree::LineItem.find_each do |line_item|
       next if line_item.variant.nil?

--- a/core/db/migrate/20130806022521_drop_spree_mail_methods.rb
+++ b/core/db/migrate/20130806022521_drop_spree_mail_methods.rb
@@ -1,4 +1,4 @@
-class DropSpreeMailMethods < ActiveRecord::Migration
+class DropSpreeMailMethods < ActiveRecord::Migration[4.2]
   def up
     drop_table :spree_mail_methods
   end

--- a/core/db/migrate/20130806145853_set_default_stock_location_on_shipments.rb
+++ b/core/db/migrate/20130806145853_set_default_stock_location_on_shipments.rb
@@ -1,4 +1,4 @@
-class SetDefaultStockLocationOnShipments < ActiveRecord::Migration
+class SetDefaultStockLocationOnShipments < ActiveRecord::Migration[4.2]
   def change
     if Spree::Shipment.where('stock_location_id IS NULL').count > 0
       location = Spree::StockLocation.find_by(name: 'default') || Spree::StockLocation.first

--- a/core/db/migrate/20130807024301_upgrade_adjustments.rb
+++ b/core/db/migrate/20130807024301_upgrade_adjustments.rb
@@ -1,4 +1,4 @@
-class UpgradeAdjustments < ActiveRecord::Migration
+class UpgradeAdjustments < ActiveRecord::Migration[4.2]
   def up
     # Temporarily make originator association available
     Spree::Adjustment.class_eval do

--- a/core/db/migrate/20130807024302_rename_adjustment_fields.rb
+++ b/core/db/migrate/20130807024302_rename_adjustment_fields.rb
@@ -1,4 +1,4 @@
-class RenameAdjustmentFields < ActiveRecord::Migration
+class RenameAdjustmentFields < ActiveRecord::Migration[4.2]
   def up
     remove_column :spree_adjustments, :originator_id
     remove_column :spree_adjustments, :originator_type

--- a/core/db/migrate/20130809164245_add_admin_name_column_to_spree_shipping_methods.rb
+++ b/core/db/migrate/20130809164245_add_admin_name_column_to_spree_shipping_methods.rb
@@ -1,4 +1,4 @@
-class AddAdminNameColumnToSpreeShippingMethods < ActiveRecord::Migration
+class AddAdminNameColumnToSpreeShippingMethods < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_shipping_methods, :admin_name, :string
   end

--- a/core/db/migrate/20130809164330_add_admin_name_column_to_spree_stock_locations.rb
+++ b/core/db/migrate/20130809164330_add_admin_name_column_to_spree_stock_locations.rb
@@ -1,4 +1,4 @@
-class AddAdminNameColumnToSpreeStockLocations < ActiveRecord::Migration
+class AddAdminNameColumnToSpreeStockLocations < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_stock_locations, :admin_name, :string
   end

--- a/core/db/migrate/20130813004002_add_shipment_total_to_spree_orders.rb
+++ b/core/db/migrate/20130813004002_add_shipment_total_to_spree_orders.rb
@@ -1,4 +1,4 @@
-class AddShipmentTotalToSpreeOrders < ActiveRecord::Migration
+class AddShipmentTotalToSpreeOrders < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_orders, :shipment_total, :decimal, precision: 10, scale: 2, default: 0.0, null: false
   end

--- a/core/db/migrate/20130813140619_expand_order_number_size.rb
+++ b/core/db/migrate/20130813140619_expand_order_number_size.rb
@@ -1,4 +1,4 @@
-class ExpandOrderNumberSize < ActiveRecord::Migration
+class ExpandOrderNumberSize < ActiveRecord::Migration[4.2]
   def up
     change_column :spree_orders, :number, :string, limit: 32
   end

--- a/core/db/migrate/20130813232134_rename_activators_to_promotions.rb
+++ b/core/db/migrate/20130813232134_rename_activators_to_promotions.rb
@@ -1,4 +1,4 @@
-class RenameActivatorsToPromotions < ActiveRecord::Migration
+class RenameActivatorsToPromotions < ActiveRecord::Migration[4.2]
   def change
     rename_table :spree_activators, :spree_promotions
   end

--- a/core/db/migrate/20130815000406_add_adjustment_total_to_line_items.rb
+++ b/core/db/migrate/20130815000406_add_adjustment_total_to_line_items.rb
@@ -1,4 +1,4 @@
-class AddAdjustmentTotalToLineItems < ActiveRecord::Migration
+class AddAdjustmentTotalToLineItems < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_line_items, :adjustment_total, :decimal, precision: 10, scale: 2, default: 0.0
   end

--- a/core/db/migrate/20130815024413_add_adjustment_total_to_shipments.rb
+++ b/core/db/migrate/20130815024413_add_adjustment_total_to_shipments.rb
@@ -1,4 +1,4 @@
-class AddAdjustmentTotalToShipments < ActiveRecord::Migration
+class AddAdjustmentTotalToShipments < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_shipments, :adjustment_total, :decimal, precision: 10, scale: 2, default: 0.0
   end

--- a/core/db/migrate/20130826062534_add_depth_to_spree_taxons.rb
+++ b/core/db/migrate/20130826062534_add_depth_to_spree_taxons.rb
@@ -1,4 +1,4 @@
-class AddDepthToSpreeTaxons < ActiveRecord::Migration
+class AddDepthToSpreeTaxons < ActiveRecord::Migration[4.2]
   def up
     if !Spree::Taxon.column_names.include?('depth')
       add_column :spree_taxons, :depth, :integer

--- a/core/db/migrate/20130828234942_add_tax_total_to_line_items_shipments_and_orders.rb
+++ b/core/db/migrate/20130828234942_add_tax_total_to_line_items_shipments_and_orders.rb
@@ -1,4 +1,4 @@
-class AddTaxTotalToLineItemsShipmentsAndOrders < ActiveRecord::Migration
+class AddTaxTotalToLineItemsShipmentsAndOrders < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_line_items, :tax_total, :decimal, precision: 10, scale: 2, default: 0.0
     add_column :spree_shipments, :tax_total, :decimal, precision: 10, scale: 2, default: 0.0

--- a/core/db/migrate/20130830001033_add_shipping_category_to_shipping_methods_and_products.rb
+++ b/core/db/migrate/20130830001033_add_shipping_category_to_shipping_methods_and_products.rb
@@ -1,4 +1,4 @@
-class AddShippingCategoryToShippingMethodsAndProducts < ActiveRecord::Migration
+class AddShippingCategoryToShippingMethodsAndProducts < ActiveRecord::Migration[4.2]
   def up
     default_category = Spree::ShippingCategory.first
     default_category ||= Spree::ShippingCategory.create!(name: "Default")

--- a/core/db/migrate/20130830001159_migrate_old_shipping_calculators.rb
+++ b/core/db/migrate/20130830001159_migrate_old_shipping_calculators.rb
@@ -1,4 +1,4 @@
-class MigrateOldShippingCalculators < ActiveRecord::Migration
+class MigrateOldShippingCalculators < ActiveRecord::Migration[4.2]
   def up
     Spree::ShippingMethod.all.each do |shipping_method|
       old_calculator = shipping_method.calculator

--- a/core/db/migrate/20130903183026_add_code_to_spree_promotion_rules.rb
+++ b/core/db/migrate/20130903183026_add_code_to_spree_promotion_rules.rb
@@ -1,4 +1,4 @@
-class AddCodeToSpreePromotionRules < ActiveRecord::Migration
+class AddCodeToSpreePromotionRules < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_promotion_rules, :code, :string
   end

--- a/core/db/migrate/20130909115621_change_states_required_for_countries.rb
+++ b/core/db/migrate/20130909115621_change_states_required_for_countries.rb
@@ -1,4 +1,4 @@
-class ChangeStatesRequiredForCountries < ActiveRecord::Migration
+class ChangeStatesRequiredForCountries < ActiveRecord::Migration[4.2]
   def up
     change_column_default :spree_countries, :states_required, false
   end

--- a/core/db/migrate/20130915032339_add_deleted_at_to_spree_stock_items.rb
+++ b/core/db/migrate/20130915032339_add_deleted_at_to_spree_stock_items.rb
@@ -1,4 +1,4 @@
-class AddDeletedAtToSpreeStockItems < ActiveRecord::Migration
+class AddDeletedAtToSpreeStockItems < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_stock_items, :deleted_at, :datetime
   end

--- a/core/db/migrate/20130917024658_remove_promotions_event_name_field.rb
+++ b/core/db/migrate/20130917024658_remove_promotions_event_name_field.rb
@@ -1,4 +1,4 @@
-class RemovePromotionsEventNameField < ActiveRecord::Migration
+class RemovePromotionsEventNameField < ActiveRecord::Migration[4.2]
   def change
     remove_column :spree_promotions, :event_name
   end

--- a/core/db/migrate/20130924040529_add_promo_total_to_line_items_and_shipments_and_orders.rb
+++ b/core/db/migrate/20130924040529_add_promo_total_to_line_items_and_shipments_and_orders.rb
@@ -1,4 +1,4 @@
-class AddPromoTotalToLineItemsAndShipmentsAndOrders < ActiveRecord::Migration
+class AddPromoTotalToLineItemsAndShipmentsAndOrders < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_line_items, :promo_total, :decimal, precision: 10, scale: 2, default: 0.0
     add_column :spree_shipments, :promo_total, :decimal, precision: 10, scale: 2, default: 0.0

--- a/core/db/migrate/20131001013410_remove_unused_credit_card_fields.rb
+++ b/core/db/migrate/20131001013410_remove_unused_credit_card_fields.rb
@@ -1,4 +1,4 @@
-class RemoveUnusedCreditCardFields < ActiveRecord::Migration
+class RemoveUnusedCreditCardFields < ActiveRecord::Migration[4.2]
   def up
     remove_column :spree_credit_cards, :start_month if column_exists?(:spree_credit_cards, :start_month)
     remove_column :spree_credit_cards, :start_year if column_exists?(:spree_credit_cards, :start_year)

--- a/core/db/migrate/20131026154747_add_track_inventory_to_variant.rb
+++ b/core/db/migrate/20131026154747_add_track_inventory_to_variant.rb
@@ -1,4 +1,4 @@
-class AddTrackInventoryToVariant < ActiveRecord::Migration
+class AddTrackInventoryToVariant < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_variants, :track_inventory, :boolean, default: true
   end

--- a/core/db/migrate/20131107132123_add_tax_category_to_variants.rb
+++ b/core/db/migrate/20131107132123_add_tax_category_to_variants.rb
@@ -1,4 +1,4 @@
-class AddTaxCategoryToVariants < ActiveRecord::Migration
+class AddTaxCategoryToVariants < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_variants, :tax_category_id, :integer
     add_index  :spree_variants, :tax_category_id

--- a/core/db/migrate/20131113035136_add_channel_to_spree_orders.rb
+++ b/core/db/migrate/20131113035136_add_channel_to_spree_orders.rb
@@ -1,4 +1,4 @@
-class AddChannelToSpreeOrders < ActiveRecord::Migration
+class AddChannelToSpreeOrders < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_orders, :channel, :string, default: "spree"
   end

--- a/core/db/migrate/20131118043959_add_included_to_adjustments.rb
+++ b/core/db/migrate/20131118043959_add_included_to_adjustments.rb
@@ -1,4 +1,4 @@
-class AddIncludedToAdjustments < ActiveRecord::Migration
+class AddIncludedToAdjustments < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_adjustments, :included, :boolean, default: false unless Spree::Adjustment.column_names.include?("included")
   end

--- a/core/db/migrate/20131118050234_rename_tax_total_fields.rb
+++ b/core/db/migrate/20131118050234_rename_tax_total_fields.rb
@@ -1,4 +1,4 @@
-class RenameTaxTotalFields < ActiveRecord::Migration
+class RenameTaxTotalFields < ActiveRecord::Migration[4.2]
   def change
     rename_column :spree_line_items, :tax_total, :additional_tax_total
     rename_column :spree_shipments, :tax_total, :additional_tax_total

--- a/core/db/migrate/20131118183431_add_line_item_id_to_spree_inventory_units.rb
+++ b/core/db/migrate/20131118183431_add_line_item_id_to_spree_inventory_units.rb
@@ -1,4 +1,4 @@
-class AddLineItemIdToSpreeInventoryUnits < ActiveRecord::Migration
+class AddLineItemIdToSpreeInventoryUnits < ActiveRecord::Migration[4.2]
   def change
     # Stores running the product-assembly extension already have a line_item_id column
     unless column_exists? Spree::InventoryUnit.table_name, :line_item_id

--- a/core/db/migrate/20131120234456_add_updated_at_to_variants.rb
+++ b/core/db/migrate/20131120234456_add_updated_at_to_variants.rb
@@ -1,4 +1,4 @@
-class AddUpdatedAtToVariants < ActiveRecord::Migration
+class AddUpdatedAtToVariants < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_variants, :updated_at, :datetime
   end

--- a/core/db/migrate/20131127001002_add_position_to_classifications.rb
+++ b/core/db/migrate/20131127001002_add_position_to_classifications.rb
@@ -1,4 +1,4 @@
-class AddPositionToClassifications < ActiveRecord::Migration
+class AddPositionToClassifications < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_products_taxons, :position, :integer
   end

--- a/core/db/migrate/20131211112807_create_spree_orders_promotions.rb
+++ b/core/db/migrate/20131211112807_create_spree_orders_promotions.rb
@@ -1,4 +1,4 @@
-class CreateSpreeOrdersPromotions < ActiveRecord::Migration
+class CreateSpreeOrdersPromotions < ActiveRecord::Migration[4.2]
   def change
     create_table :spree_orders_promotions, id: false do |t|
       t.references :order

--- a/core/db/migrate/20131211192741_unique_shipping_method_categories.rb
+++ b/core/db/migrate/20131211192741_unique_shipping_method_categories.rb
@@ -1,4 +1,4 @@
-class UniqueShippingMethodCategories < ActiveRecord::Migration
+class UniqueShippingMethodCategories < ActiveRecord::Migration[4.2]
   def change
     klass   = Spree::ShippingMethodCategory
     columns = %w[shipping_category_id shipping_method_id]

--- a/core/db/migrate/20131218054603_add_item_count_to_spree_orders.rb
+++ b/core/db/migrate/20131218054603_add_item_count_to_spree_orders.rb
@@ -1,4 +1,4 @@
-class AddItemCountToSpreeOrders < ActiveRecord::Migration
+class AddItemCountToSpreeOrders < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_orders, :item_count, :integer, default: 0
   end

--- a/core/db/migrate/20140106065820_remove_value_type_from_spree_preferences.rb
+++ b/core/db/migrate/20140106065820_remove_value_type_from_spree_preferences.rb
@@ -1,4 +1,4 @@
-class RemoveValueTypeFromSpreePreferences < ActiveRecord::Migration
+class RemoveValueTypeFromSpreePreferences < ActiveRecord::Migration[4.2]
   def up
     remove_column :spree_preferences, :value_type
   end

--- a/core/db/migrate/20140106224208_rename_permalink_to_slug_for_products.rb
+++ b/core/db/migrate/20140106224208_rename_permalink_to_slug_for_products.rb
@@ -1,4 +1,4 @@
-class RenamePermalinkToSlugForProducts < ActiveRecord::Migration
+class RenamePermalinkToSlugForProducts < ActiveRecord::Migration[4.2]
   def change
     rename_column :spree_products, :permalink, :slug
   end

--- a/core/db/migrate/20140120160805_add_index_to_variant_id_and_currency_on_prices.rb
+++ b/core/db/migrate/20140120160805_add_index_to_variant_id_and_currency_on_prices.rb
@@ -1,4 +1,4 @@
-class AddIndexToVariantIdAndCurrencyOnPrices < ActiveRecord::Migration
+class AddIndexToVariantIdAndCurrencyOnPrices < ActiveRecord::Migration[4.2]
   def change
     add_index :spree_prices, [:variant_id, :currency]
   end

--- a/core/db/migrate/20140124023232_rename_activator_id_in_rules_and_actions_to_promotion_id.rb
+++ b/core/db/migrate/20140124023232_rename_activator_id_in_rules_and_actions_to_promotion_id.rb
@@ -1,4 +1,4 @@
-class RenameActivatorIdInRulesAndActionsToPromotionId < ActiveRecord::Migration
+class RenameActivatorIdInRulesAndActionsToPromotionId < ActiveRecord::Migration[4.2]
   def change
     rename_column :spree_promotion_rules, :activator_id, :promotion_id
     rename_column :spree_promotion_actions, :activator_id, :promotion_id

--- a/core/db/migrate/20140129024326_add_deleted_at_to_spree_prices.rb
+++ b/core/db/migrate/20140129024326_add_deleted_at_to_spree_prices.rb
@@ -1,4 +1,4 @@
-class AddDeletedAtToSpreePrices < ActiveRecord::Migration
+class AddDeletedAtToSpreePrices < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_prices, :deleted_at, :datetime
   end

--- a/core/db/migrate/20140203161722_add_approver_id_and_approved_at_to_orders.rb
+++ b/core/db/migrate/20140203161722_add_approver_id_and_approved_at_to_orders.rb
@@ -1,4 +1,4 @@
-class AddApproverIdAndApprovedAtToOrders < ActiveRecord::Migration
+class AddApproverIdAndApprovedAtToOrders < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_orders, :approver_id, :integer
     add_column :spree_orders, :approved_at, :datetime

--- a/core/db/migrate/20140204115338_add_confirmation_delivered_to_spree_orders.rb
+++ b/core/db/migrate/20140204115338_add_confirmation_delivered_to_spree_orders.rb
@@ -1,4 +1,4 @@
-class AddConfirmationDeliveredToSpreeOrders < ActiveRecord::Migration
+class AddConfirmationDeliveredToSpreeOrders < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_orders, :confirmation_delivered, :boolean, default: false
   end

--- a/core/db/migrate/20140204192230_add_auto_capture_to_payment_methods.rb
+++ b/core/db/migrate/20140204192230_add_auto_capture_to_payment_methods.rb
@@ -1,4 +1,4 @@
-class AddAutoCaptureToPaymentMethods < ActiveRecord::Migration
+class AddAutoCaptureToPaymentMethods < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_payment_methods, :auto_capture, :boolean
   end

--- a/core/db/migrate/20140205120320_create_spree_payment_capture_events.rb
+++ b/core/db/migrate/20140205120320_create_spree_payment_capture_events.rb
@@ -1,4 +1,4 @@
-class CreateSpreePaymentCaptureEvents < ActiveRecord::Migration
+class CreateSpreePaymentCaptureEvents < ActiveRecord::Migration[4.2]
   def change
     create_table :spree_payment_capture_events do |t|
       t.decimal :amount, precision: 10, scale: 2, default: 0.0

--- a/core/db/migrate/20140205144710_add_uncaptured_amount_to_payments.rb
+++ b/core/db/migrate/20140205144710_add_uncaptured_amount_to_payments.rb
@@ -1,4 +1,4 @@
-class AddUncapturedAmountToPayments < ActiveRecord::Migration
+class AddUncapturedAmountToPayments < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_payments, :uncaptured_amount, :decimal, precision: 10, scale: 2, default: 0.0
   end

--- a/core/db/migrate/20140205181631_default_variant_weight_to_zero.rb
+++ b/core/db/migrate/20140205181631_default_variant_weight_to_zero.rb
@@ -1,4 +1,4 @@
-class DefaultVariantWeightToZero < ActiveRecord::Migration
+class DefaultVariantWeightToZero < ActiveRecord::Migration[4.2]
   def up
     Spree::Variant.unscoped.where(weight: nil).update_all("weight = 0.0")
 

--- a/core/db/migrate/20140207085910_add_tax_category_id_to_shipping_methods.rb
+++ b/core/db/migrate/20140207085910_add_tax_category_id_to_shipping_methods.rb
@@ -1,4 +1,4 @@
-class AddTaxCategoryIdToShippingMethods < ActiveRecord::Migration
+class AddTaxCategoryIdToShippingMethods < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_shipping_methods, :tax_category_id, :integer
   end

--- a/core/db/migrate/20140207093021_add_tax_rate_id_to_shipping_rates.rb
+++ b/core/db/migrate/20140207093021_add_tax_rate_id_to_shipping_rates.rb
@@ -1,4 +1,4 @@
-class AddTaxRateIdToShippingRates < ActiveRecord::Migration
+class AddTaxRateIdToShippingRates < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_shipping_rates, :tax_rate_id, :integer
   end

--- a/core/db/migrate/20140211040159_add_pre_tax_amount_to_line_items_and_shipments.rb
+++ b/core/db/migrate/20140211040159_add_pre_tax_amount_to_line_items_and_shipments.rb
@@ -1,4 +1,4 @@
-class AddPreTaxAmountToLineItemsAndShipments < ActiveRecord::Migration
+class AddPreTaxAmountToLineItemsAndShipments < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_line_items, :pre_tax_amount, :decimal, precision: 8, scale: 2
     add_column :spree_shipments, :pre_tax_amount, :decimal, precision: 8, scale: 2

--- a/core/db/migrate/20140213184916_add_more_indexes.rb
+++ b/core/db/migrate/20140213184916_add_more_indexes.rb
@@ -1,4 +1,4 @@
-class AddMoreIndexes < ActiveRecord::Migration
+class AddMoreIndexes < ActiveRecord::Migration[4.2]
   def change
     add_index :spree_payment_methods, [:id, :type]
     add_index :spree_calculators, [:id, :type]

--- a/core/db/migrate/20140219060952_add_considered_risky_to_orders.rb
+++ b/core/db/migrate/20140219060952_add_considered_risky_to_orders.rb
@@ -1,4 +1,4 @@
-class AddConsideredRiskyToOrders < ActiveRecord::Migration
+class AddConsideredRiskyToOrders < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_orders, :considered_risky, :boolean, default: false
   end

--- a/core/db/migrate/20140227112348_add_preference_store_to_everything.rb
+++ b/core/db/migrate/20140227112348_add_preference_store_to_everything.rb
@@ -1,4 +1,4 @@
-class AddPreferenceStoreToEverything < ActiveRecord::Migration
+class AddPreferenceStoreToEverything < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_calculators, :preferences, :text
     add_column :spree_gateways, :preferences, :text

--- a/core/db/migrate/20140307235515_add_user_id_to_spree_credit_cards.rb
+++ b/core/db/migrate/20140307235515_add_user_id_to_spree_credit_cards.rb
@@ -1,4 +1,4 @@
-class AddUserIdToSpreeCreditCards < ActiveRecord::Migration
+class AddUserIdToSpreeCreditCards < ActiveRecord::Migration[4.2]
   def change
     unless Spree::CreditCard.column_names.include? "user_id"
       add_column :spree_credit_cards, :user_id, :integer

--- a/core/db/migrate/20140309023735_migrate_old_preferences.rb
+++ b/core/db/migrate/20140309023735_migrate_old_preferences.rb
@@ -1,4 +1,4 @@
-class MigrateOldPreferences < ActiveRecord::Migration
+class MigrateOldPreferences < ActiveRecord::Migration[4.2]
   disable_ddl_transaction!
 
   def up

--- a/core/db/migrate/20140309024355_create_spree_stores.rb
+++ b/core/db/migrate/20140309024355_create_spree_stores.rb
@@ -1,4 +1,4 @@
-class CreateSpreeStores < ActiveRecord::Migration
+class CreateSpreeStores < ActiveRecord::Migration[4.2]
   def change
     if table_exists?(:spree_stores)
       rename_column :spree_stores, :domains, :url

--- a/core/db/migrate/20140309033438_create_store_from_preferences.rb
+++ b/core/db/migrate/20140309033438_create_store_from_preferences.rb
@@ -1,4 +1,4 @@
-class CreateStoreFromPreferences < ActiveRecord::Migration
+class CreateStoreFromPreferences < ActiveRecord::Migration[4.2]
   class Store < ActiveRecord::Base
     self.table_name = 'spree_stores'
   end

--- a/core/db/migrate/20140315053743_add_timestamps_to_spree_assets.rb
+++ b/core/db/migrate/20140315053743_add_timestamps_to_spree_assets.rb
@@ -1,4 +1,4 @@
-class AddTimestampsToSpreeAssets < ActiveRecord::Migration
+class AddTimestampsToSpreeAssets < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_assets, :created_at, :datetime
     add_column :spree_assets, :updated_at, :datetime

--- a/core/db/migrate/20140318191500_create_spree_taxons_promotion_rules.rb
+++ b/core/db/migrate/20140318191500_create_spree_taxons_promotion_rules.rb
@@ -1,4 +1,4 @@
-class CreateSpreeTaxonsPromotionRules < ActiveRecord::Migration
+class CreateSpreeTaxonsPromotionRules < ActiveRecord::Migration[4.2]
   def change
     create_table :spree_taxons_promotion_rules do |t|
       t.references :taxon, index: true

--- a/core/db/migrate/20140331100557_add_additional_store_fields.rb
+++ b/core/db/migrate/20140331100557_add_additional_store_fields.rb
@@ -1,4 +1,4 @@
-class AddAdditionalStoreFields < ActiveRecord::Migration
+class AddAdditionalStoreFields < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_stores, :code, :string unless column_exists?(:spree_stores, :code)
     add_column :spree_stores, :default, :boolean, default: false, null: false unless column_exists?(:spree_stores, :default)

--- a/core/db/migrate/20140410141842_add_many_missing_indexes.rb
+++ b/core/db/migrate/20140410141842_add_many_missing_indexes.rb
@@ -1,4 +1,4 @@
-class AddManyMissingIndexes < ActiveRecord::Migration
+class AddManyMissingIndexes < ActiveRecord::Migration[4.2]
   include Spree::MigrationHelpers
 
   def change

--- a/core/db/migrate/20140410150358_correct_some_polymorphic_index_and_add_more_missing.rb
+++ b/core/db/migrate/20140410150358_correct_some_polymorphic_index_and_add_more_missing.rb
@@ -1,4 +1,4 @@
-class CorrectSomePolymorphicIndexAndAddMoreMissing < ActiveRecord::Migration
+class CorrectSomePolymorphicIndexAndAddMoreMissing < ActiveRecord::Migration[4.2]
   include Spree::MigrationHelpers
 
   def change

--- a/core/db/migrate/20140415041315_add_user_id_created_by_id_index_to_order.rb
+++ b/core/db/migrate/20140415041315_add_user_id_created_by_id_index_to_order.rb
@@ -1,4 +1,4 @@
-class AddUserIdCreatedByIdIndexToOrder < ActiveRecord::Migration
+class AddUserIdCreatedByIdIndexToOrder < ActiveRecord::Migration[4.2]
   def change
     add_index :spree_orders, [:user_id, :created_by_id]
   end

--- a/core/db/migrate/20140508151342_change_spree_price_amount_precision.rb
+++ b/core/db/migrate/20140508151342_change_spree_price_amount_precision.rb
@@ -1,4 +1,4 @@
-class ChangeSpreePriceAmountPrecision < ActiveRecord::Migration
+class ChangeSpreePriceAmountPrecision < ActiveRecord::Migration[4.2]
   def change
     change_column :spree_prices, :amount, :decimal, precision: 10, scale: 2
     change_column :spree_line_items, :price, :decimal, precision: 10, scale: 2

--- a/core/db/migrate/20140518174634_add_token_to_spree_orders.rb
+++ b/core/db/migrate/20140518174634_add_token_to_spree_orders.rb
@@ -1,4 +1,4 @@
-class AddTokenToSpreeOrders < ActiveRecord::Migration
+class AddTokenToSpreeOrders < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_orders, :guest_token, :string
   end

--- a/core/db/migrate/20140530024945_move_order_token_from_tokenized_permission.rb
+++ b/core/db/migrate/20140530024945_move_order_token_from_tokenized_permission.rb
@@ -1,4 +1,4 @@
-class MoveOrderTokenFromTokenizedPermission < ActiveRecord::Migration
+class MoveOrderTokenFromTokenizedPermission < ActiveRecord::Migration[4.2]
   class Spree::TokenizedPermission < Spree::Base
     belongs_to :permissable, polymorphic: true
   end

--- a/core/db/migrate/20140601011216_set_shipment_total_for_users_upgrading.rb
+++ b/core/db/migrate/20140601011216_set_shipment_total_for_users_upgrading.rb
@@ -1,4 +1,4 @@
-class SetShipmentTotalForUsersUpgrading < ActiveRecord::Migration
+class SetShipmentTotalForUsersUpgrading < ActiveRecord::Migration[4.2]
   def up
     # NOTE You might not need this at all unless you're upgrading from Spree 2.1.x
     # or below. For those upgrading this should populate the Order#shipment_total

--- a/core/db/migrate/20140604135309_drop_credit_card_first_name_and_last_name.rb
+++ b/core/db/migrate/20140604135309_drop_credit_card_first_name_and_last_name.rb
@@ -1,4 +1,4 @@
-class DropCreditCardFirstNameAndLastName < ActiveRecord::Migration
+class DropCreditCardFirstNameAndLastName < ActiveRecord::Migration[4.2]
   def change
     remove_column :spree_credit_cards, :first_name, :string
     remove_column :spree_credit_cards, :last_name, :string

--- a/core/db/migrate/20140609201656_add_deleted_at_to_spree_promotion_actions.rb
+++ b/core/db/migrate/20140609201656_add_deleted_at_to_spree_promotion_actions.rb
@@ -1,4 +1,4 @@
-class AddDeletedAtToSpreePromotionActions < ActiveRecord::Migration
+class AddDeletedAtToSpreePromotionActions < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_promotion_actions, :deleted_at, :datetime
     add_index :spree_promotion_actions, :deleted_at

--- a/core/db/migrate/20140616202624_remove_uncaptured_amount_from_spree_payments.rb
+++ b/core/db/migrate/20140616202624_remove_uncaptured_amount_from_spree_payments.rb
@@ -1,4 +1,4 @@
-class RemoveUncapturedAmountFromSpreePayments < ActiveRecord::Migration
+class RemoveUncapturedAmountFromSpreePayments < ActiveRecord::Migration[4.2]
   def change
     remove_column :spree_payments, :uncaptured_amount
   end

--- a/core/db/migrate/20140625214618_create_spree_refunds.rb
+++ b/core/db/migrate/20140625214618_create_spree_refunds.rb
@@ -1,4 +1,4 @@
-class CreateSpreeRefunds < ActiveRecord::Migration
+class CreateSpreeRefunds < ActiveRecord::Migration[4.2]
   def change
     create_table :spree_refunds do |t|
       t.integer :payment_id

--- a/core/db/migrate/20140702140656_create_spree_return_authorization_inventory_unit.rb
+++ b/core/db/migrate/20140702140656_create_spree_return_authorization_inventory_unit.rb
@@ -1,4 +1,4 @@
-class CreateSpreeReturnAuthorizationInventoryUnit < ActiveRecord::Migration
+class CreateSpreeReturnAuthorizationInventoryUnit < ActiveRecord::Migration[4.2]
   def change
     create_table :spree_return_authorization_inventory_units do |t|
       t.integer :return_authorization_id

--- a/core/db/migrate/20140707125621_rename_return_authorization_inventory_unit_to_return_items.rb
+++ b/core/db/migrate/20140707125621_rename_return_authorization_inventory_unit_to_return_items.rb
@@ -1,4 +1,4 @@
-class RenameReturnAuthorizationInventoryUnitToReturnItems < ActiveRecord::Migration
+class RenameReturnAuthorizationInventoryUnitToReturnItems < ActiveRecord::Migration[4.2]
   def change
     rename_table :spree_return_authorization_inventory_units, :spree_return_items
   end

--- a/core/db/migrate/20140708132019_create_order_mutex.rb
+++ b/core/db/migrate/20140708132019_create_order_mutex.rb
@@ -1,4 +1,4 @@
-class CreateOrderMutex < ActiveRecord::Migration
+class CreateOrderMutex < ActiveRecord::Migration[4.2]
   def change
     create_table :spree_order_mutexes do |t|
       t.integer :order_id, null: false

--- a/core/db/migrate/20140709160534_backfill_line_item_pre_tax_amount.rb
+++ b/core/db/migrate/20140709160534_backfill_line_item_pre_tax_amount.rb
@@ -1,4 +1,4 @@
-class BackfillLineItemPreTaxAmount < ActiveRecord::Migration
+class BackfillLineItemPreTaxAmount < ActiveRecord::Migration[4.2]
   def change
     # set pre_tax_amount to discounted_amount - included_tax_total
     execute(<<-SQL)

--- a/core/db/migrate/20140710041921_recreate_spree_return_authorizations.rb
+++ b/core/db/migrate/20140710041921_recreate_spree_return_authorizations.rb
@@ -1,4 +1,4 @@
-class RecreateSpreeReturnAuthorizations < ActiveRecord::Migration
+class RecreateSpreeReturnAuthorizations < ActiveRecord::Migration[4.2]
   def up
     # If the app has any legacy return authorizations then rename the table & columns and leave them there
     # for the spree_legacy_return_authorizations extension to pick up with.

--- a/core/db/migrate/20140710181204_add_amount_fields_to_return_items.rb
+++ b/core/db/migrate/20140710181204_add_amount_fields_to_return_items.rb
@@ -1,4 +1,4 @@
-class AddAmountFieldsToReturnItems < ActiveRecord::Migration
+class AddAmountFieldsToReturnItems < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_return_items, :pre_tax_amount, :decimal, precision: 10, scale: 2, default: 0.0, null: false
     add_column :spree_return_items, :included_tax_total, :decimal, precision: 10, scale: 2, default: 0.0, null: false

--- a/core/db/migrate/20140710190048_drop_return_authorization_amount.rb
+++ b/core/db/migrate/20140710190048_drop_return_authorization_amount.rb
@@ -1,4 +1,4 @@
-class DropReturnAuthorizationAmount < ActiveRecord::Migration
+class DropReturnAuthorizationAmount < ActiveRecord::Migration[4.2]
   def change
     remove_column :spree_return_authorizations, :amount
   end

--- a/core/db/migrate/20140713140455_create_spree_return_authorization_reasons.rb
+++ b/core/db/migrate/20140713140455_create_spree_return_authorization_reasons.rb
@@ -1,4 +1,4 @@
-class CreateSpreeReturnAuthorizationReasons < ActiveRecord::Migration
+class CreateSpreeReturnAuthorizationReasons < ActiveRecord::Migration[4.2]
   class ReturnAuthorizationReason < ActiveRecord::Base
     self.table_name = 'spree_return_authorization_reasons'
   end

--- a/core/db/migrate/20140713140527_create_spree_refund_reasons.rb
+++ b/core/db/migrate/20140713140527_create_spree_refund_reasons.rb
@@ -1,4 +1,4 @@
-class CreateSpreeRefundReasons < ActiveRecord::Migration
+class CreateSpreeRefundReasons < ActiveRecord::Migration[4.2]
   def change
     create_table :spree_refund_reasons do |t|
       t.string :name

--- a/core/db/migrate/20140713142214_rename_return_authorization_reason.rb
+++ b/core/db/migrate/20140713142214_rename_return_authorization_reason.rb
@@ -1,4 +1,4 @@
-class RenameReturnAuthorizationReason < ActiveRecord::Migration
+class RenameReturnAuthorizationReason < ActiveRecord::Migration[4.2]
   def change
     rename_column :spree_return_authorizations, :reason, :memo
   end

--- a/core/db/migrate/20140715182625_create_spree_promotion_categories.rb
+++ b/core/db/migrate/20140715182625_create_spree_promotion_categories.rb
@@ -1,4 +1,4 @@
-class CreateSpreePromotionCategories < ActiveRecord::Migration
+class CreateSpreePromotionCategories < ActiveRecord::Migration[4.2]
   def change
     create_table :spree_promotion_categories do |t|
       t.string :name

--- a/core/db/migrate/20140716204111_drop_received_at_on_return_items.rb
+++ b/core/db/migrate/20140716204111_drop_received_at_on_return_items.rb
@@ -1,4 +1,4 @@
-class DropReceivedAtOnReturnItems < ActiveRecord::Migration
+class DropReceivedAtOnReturnItems < ActiveRecord::Migration[4.2]
   def up
     remove_column :spree_return_items, :received_at
   end

--- a/core/db/migrate/20140716212330_add_reception_and_acceptance_status_to_return_items.rb
+++ b/core/db/migrate/20140716212330_add_reception_and_acceptance_status_to_return_items.rb
@@ -1,4 +1,4 @@
-class AddReceptionAndAcceptanceStatusToReturnItems < ActiveRecord::Migration
+class AddReceptionAndAcceptanceStatusToReturnItems < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_return_items, :reception_status, :string
     add_column :spree_return_items, :acceptance_status, :string

--- a/core/db/migrate/20140717155155_create_default_refund_reason.rb
+++ b/core/db/migrate/20140717155155_create_default_refund_reason.rb
@@ -1,4 +1,4 @@
-class CreateDefaultRefundReason < ActiveRecord::Migration
+class CreateDefaultRefundReason < ActiveRecord::Migration[4.2]
   def up
     Spree::RefundReason.create!(name: Spree::RefundReason::RETURN_PROCESSING_REASON, mutable: false)
   end

--- a/core/db/migrate/20140717185932_add_default_to_spree_stock_locations.rb
+++ b/core/db/migrate/20140717185932_add_default_to_spree_stock_locations.rb
@@ -1,4 +1,4 @@
-class AddDefaultToSpreeStockLocations < ActiveRecord::Migration
+class AddDefaultToSpreeStockLocations < ActiveRecord::Migration[4.2]
   def change
     unless column_exists? :spree_stock_locations, :default
       add_column :spree_stock_locations, :default, :boolean, null: false, default: false

--- a/core/db/migrate/20140718133010_create_spree_customer_returns.rb
+++ b/core/db/migrate/20140718133010_create_spree_customer_returns.rb
@@ -1,4 +1,4 @@
-class CreateSpreeCustomerReturns < ActiveRecord::Migration
+class CreateSpreeCustomerReturns < ActiveRecord::Migration[4.2]
   def change
     create_table :spree_customer_returns do |t|
       t.string :number

--- a/core/db/migrate/20140718133349_add_customer_return_id_to_return_item.rb
+++ b/core/db/migrate/20140718133349_add_customer_return_id_to_return_item.rb
@@ -1,4 +1,4 @@
-class AddCustomerReturnIdToReturnItem < ActiveRecord::Migration
+class AddCustomerReturnIdToReturnItem < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_return_items, :customer_return_id, :integer
     add_index :spree_return_items, :customer_return_id, name: 'index_return_items_on_customer_return_id'

--- a/core/db/migrate/20140718195325_create_friendly_id_slugs.rb
+++ b/core/db/migrate/20140718195325_create_friendly_id_slugs.rb
@@ -1,4 +1,4 @@
-class CreateFriendlyIdSlugs < ActiveRecord::Migration
+class CreateFriendlyIdSlugs < ActiveRecord::Migration[4.2]
   def change
     create_table :friendly_id_slugs do |t|
       t.string   :slug,           null: false

--- a/core/db/migrate/20140723004419_rename_spree_refund_return_authorization_id.rb
+++ b/core/db/migrate/20140723004419_rename_spree_refund_return_authorization_id.rb
@@ -1,4 +1,4 @@
-class RenameSpreeRefundReturnAuthorizationId < ActiveRecord::Migration
+class RenameSpreeRefundReturnAuthorizationId < ActiveRecord::Migration[4.2]
   def change
     rename_column :spree_refunds, :return_authorization_id, :customer_return_id
   end

--- a/core/db/migrate/20140723152808_increase_return_item_pre_tax_amount_precision.rb
+++ b/core/db/migrate/20140723152808_increase_return_item_pre_tax_amount_precision.rb
@@ -1,4 +1,4 @@
-class IncreaseReturnItemPreTaxAmountPrecision < ActiveRecord::Migration
+class IncreaseReturnItemPreTaxAmountPrecision < ActiveRecord::Migration[4.2]
   def up
     change_column :spree_return_items, :pre_tax_amount, :decimal, precision: 12, scale: 4, default: 0.0, null: false
     change_column :spree_return_items, :included_tax_total, :decimal, precision: 12, scale: 4, default: 0.0, null: false

--- a/core/db/migrate/20140723214541_copy_product_slugs_to_slug_history.rb
+++ b/core/db/migrate/20140723214541_copy_product_slugs_to_slug_history.rb
@@ -1,4 +1,4 @@
-class CopyProductSlugsToSlugHistory < ActiveRecord::Migration
+class CopyProductSlugsToSlugHistory < ActiveRecord::Migration[4.2]
   def change
   # do what sql does best: copy all slugs into history table in a single query
   # rather than load potentially millions of products into memory

--- a/core/db/migrate/20140725131539_create_spree_reimbursements.rb
+++ b/core/db/migrate/20140725131539_create_spree_reimbursements.rb
@@ -1,4 +1,4 @@
-class CreateSpreeReimbursements < ActiveRecord::Migration
+class CreateSpreeReimbursements < ActiveRecord::Migration[4.2]
   def change
     create_table :spree_reimbursements do |t|
       t.string :number

--- a/core/db/migrate/20140728225422_add_promotionable_to_spree_products.rb
+++ b/core/db/migrate/20140728225422_add_promotionable_to_spree_products.rb
@@ -1,4 +1,4 @@
-class AddPromotionableToSpreeProducts < ActiveRecord::Migration
+class AddPromotionableToSpreeProducts < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_products, :promotionable, :boolean, default: true
   end

--- a/core/db/migrate/20140729133613_add_exchange_inventory_unit_foreign_keys.rb
+++ b/core/db/migrate/20140729133613_add_exchange_inventory_unit_foreign_keys.rb
@@ -1,4 +1,4 @@
-class AddExchangeInventoryUnitForeignKeys < ActiveRecord::Migration
+class AddExchangeInventoryUnitForeignKeys < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_return_items, :exchange_inventory_unit_id, :integer
 

--- a/core/db/migrate/20140730155938_add_acceptance_status_errors_to_return_item.rb
+++ b/core/db/migrate/20140730155938_add_acceptance_status_errors_to_return_item.rb
@@ -1,4 +1,4 @@
-class AddAcceptanceStatusErrorsToReturnItem < ActiveRecord::Migration
+class AddAcceptanceStatusErrorsToReturnItem < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_return_items, :acceptance_status_errors, :text
   end

--- a/core/db/migrate/20140731150017_create_spree_reimbursement_types.rb
+++ b/core/db/migrate/20140731150017_create_spree_reimbursement_types.rb
@@ -1,4 +1,4 @@
-class CreateSpreeReimbursementTypes < ActiveRecord::Migration
+class CreateSpreeReimbursementTypes < ActiveRecord::Migration[4.2]
   def change
     create_table :spree_reimbursement_types do |t|
       t.string :name

--- a/core/db/migrate/20140804185157_add_default_to_shipment_cost.rb
+++ b/core/db/migrate/20140804185157_add_default_to_shipment_cost.rb
@@ -1,4 +1,4 @@
-class AddDefaultToShipmentCost < ActiveRecord::Migration
+class AddDefaultToShipmentCost < ActiveRecord::Migration[4.2]
   def up
     change_column :spree_shipments, :cost, :decimal, precision: 10, scale: 2, default: 0.0
     Spree::Shipment.where(cost: nil).update_all(cost: 0)

--- a/core/db/migrate/20140805171035_add_default_to_spree_credit_cards.rb
+++ b/core/db/migrate/20140805171035_add_default_to_spree_credit_cards.rb
@@ -1,4 +1,4 @@
-class AddDefaultToSpreeCreditCards < ActiveRecord::Migration
+class AddDefaultToSpreeCreditCards < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_credit_cards, :default, :boolean, null: false, default: false
   end

--- a/core/db/migrate/20140805171219_make_existing_credit_cards_default.rb
+++ b/core/db/migrate/20140805171219_make_existing_credit_cards_default.rb
@@ -1,4 +1,4 @@
-class MakeExistingCreditCardsDefault < ActiveRecord::Migration
+class MakeExistingCreditCardsDefault < ActiveRecord::Migration[4.2]
   def up
     # set the newest credit card for every user to be the default; SQL technique from
     # http://stackoverflow.com/questions/121387/fetch-the-row-which-has-the-max-value-for-a-column

--- a/core/db/migrate/20140806144901_add_type_to_reimbursement_type.rb
+++ b/core/db/migrate/20140806144901_add_type_to_reimbursement_type.rb
@@ -1,4 +1,4 @@
-class AddTypeToReimbursementType < ActiveRecord::Migration
+class AddTypeToReimbursementType < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_reimbursement_types, :type, :string
     add_index :spree_reimbursement_types, :type

--- a/core/db/migrate/20140808184039_create_spree_reimbursement_credits.rb
+++ b/core/db/migrate/20140808184039_create_spree_reimbursement_credits.rb
@@ -1,4 +1,4 @@
-class CreateSpreeReimbursementCredits < ActiveRecord::Migration
+class CreateSpreeReimbursementCredits < ActiveRecord::Migration[4.2]
   def change
     create_table :spree_reimbursement_credits do |t|
       t.decimal :amount, precision: 10, scale: 2, default: 0.0, null: false

--- a/core/db/migrate/20140827170513_add_meta_title_to_spree_products.rb
+++ b/core/db/migrate/20140827170513_add_meta_title_to_spree_products.rb
@@ -1,4 +1,4 @@
-class AddMetaTitleToSpreeProducts < ActiveRecord::Migration
+class AddMetaTitleToSpreeProducts < ActiveRecord::Migration[4.2]
   def change
     change_table :spree_products do |t|
       t.string   :meta_title

--- a/core/db/migrate/20140924164824_add_code_to_spree_tax_categories.rb
+++ b/core/db/migrate/20140924164824_add_code_to_spree_tax_categories.rb
@@ -1,4 +1,4 @@
-class AddCodeToSpreeTaxCategories < ActiveRecord::Migration
+class AddCodeToSpreeTaxCategories < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_tax_categories, :tax_code, :string
   end

--- a/core/db/migrate/20140927193717_default_pre_tax_amount_should_be_zero.rb
+++ b/core/db/migrate/20140927193717_default_pre_tax_amount_should_be_zero.rb
@@ -1,4 +1,4 @@
-class DefaultPreTaxAmountShouldBeZero < ActiveRecord::Migration
+class DefaultPreTaxAmountShouldBeZero < ActiveRecord::Migration[4.2]
   def change
     change_column :spree_line_items, :pre_tax_amount, :decimal, precision: 8, scale: 2, default: 0
     change_column :spree_shipments, :pre_tax_amount, :decimal, precision: 8, scale: 2, default: 0

--- a/core/db/migrate/20141002191113_add_code_to_spree_shipping_methods.rb
+++ b/core/db/migrate/20141002191113_add_code_to_spree_shipping_methods.rb
@@ -1,4 +1,4 @@
-class AddCodeToSpreeShippingMethods < ActiveRecord::Migration
+class AddCodeToSpreeShippingMethods < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_shipping_methods, :code, :string
   end

--- a/core/db/migrate/20141007230328_add_cancel_audit_fields_to_spree_orders.rb
+++ b/core/db/migrate/20141007230328_add_cancel_audit_fields_to_spree_orders.rb
@@ -1,4 +1,4 @@
-class AddCancelAuditFieldsToSpreeOrders < ActiveRecord::Migration
+class AddCancelAuditFieldsToSpreeOrders < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_orders, :canceled_at, :datetime
     add_column :spree_orders, :canceler_id, :integer

--- a/core/db/migrate/20141009204607_add_store_id_to_orders.rb
+++ b/core/db/migrate/20141009204607_add_store_id_to_orders.rb
@@ -1,4 +1,4 @@
-class AddStoreIdToOrders < ActiveRecord::Migration
+class AddStoreIdToOrders < ActiveRecord::Migration[4.2]
   class Store < ActiveRecord::Base
     self.table_name = 'spree_stores'
   end

--- a/core/db/migrate/20141012083513_create_spree_taxons_prototypes.rb
+++ b/core/db/migrate/20141012083513_create_spree_taxons_prototypes.rb
@@ -1,4 +1,4 @@
-class CreateSpreeTaxonsPrototypes < ActiveRecord::Migration
+class CreateSpreeTaxonsPrototypes < ActiveRecord::Migration[4.2]
   def change
     create_table :spree_taxons_prototypes do |t|
       t.belongs_to :taxon, index: true

--- a/core/db/migrate/20141023005240_add_counter_cache_from_spree_variants_to_spree_stock_items.rb
+++ b/core/db/migrate/20141023005240_add_counter_cache_from_spree_variants_to_spree_stock_items.rb
@@ -1,4 +1,4 @@
-class AddCounterCacheFromSpreeVariantsToSpreeStockItems < ActiveRecord::Migration
+class AddCounterCacheFromSpreeVariantsToSpreeStockItems < ActiveRecord::Migration[4.2]
   # This was unnecessary and was removed
   def up
   end

--- a/core/db/migrate/20141101231208_fix_adjustment_order_presence.rb
+++ b/core/db/migrate/20141101231208_fix_adjustment_order_presence.rb
@@ -1,4 +1,4 @@
-class FixAdjustmentOrderPresence < ActiveRecord::Migration
+class FixAdjustmentOrderPresence < ActiveRecord::Migration[4.2]
   def change
     say 'Fixing adjustments without direct order reference'
     Spree::Adjustment.where(order: nil).find_each do |adjustment|

--- a/core/db/migrate/20141105213646_update_classifications_positions.rb
+++ b/core/db/migrate/20141105213646_update_classifications_positions.rb
@@ -1,4 +1,4 @@
-class UpdateClassificationsPositions < ActiveRecord::Migration
+class UpdateClassificationsPositions < ActiveRecord::Migration[4.2]
   def up
     Spree::Taxon.all.each do |taxon|
       taxon.classifications.each_with_index do |c12n, i|

--- a/core/db/migrate/20141120135441_add_guest_token_index_to_spree_orders.rb
+++ b/core/db/migrate/20141120135441_add_guest_token_index_to_spree_orders.rb
@@ -1,4 +1,4 @@
-class AddGuestTokenIndexToSpreeOrders < ActiveRecord::Migration
+class AddGuestTokenIndexToSpreeOrders < ActiveRecord::Migration[4.2]
   def change
     add_index :spree_orders, :guest_token
   end

--- a/core/db/migrate/20141215235502_remove_extra_products_slug_index.rb
+++ b/core/db/migrate/20141215235502_remove_extra_products_slug_index.rb
@@ -1,4 +1,4 @@
-class RemoveExtraProductsSlugIndex < ActiveRecord::Migration
+class RemoveExtraProductsSlugIndex < ActiveRecord::Migration[4.2]
   def change
     remove_index :spree_products, name: :permalink_idx_unique
   end

--- a/core/db/migrate/20141217215630_update_product_slug_index.rb
+++ b/core/db/migrate/20141217215630_update_product_slug_index.rb
@@ -1,4 +1,4 @@
-class UpdateProductSlugIndex < ActiveRecord::Migration
+class UpdateProductSlugIndex < ActiveRecord::Migration[4.2]
   include Spree::MigrationHelpers
 
   def change

--- a/core/db/migrate/20141231151320_add_default_column_to_price.rb
+++ b/core/db/migrate/20141231151320_add_default_column_to_price.rb
@@ -1,4 +1,4 @@
-class AddDefaultColumnToPrice < ActiveRecord::Migration
+class AddDefaultColumnToPrice < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_prices, :is_default, :boolean, default: true, null: false
   end

--- a/core/db/migrate/20150112194216_add_position_to_stock_location.rb
+++ b/core/db/migrate/20150112194216_add_position_to_stock_location.rb
@@ -1,4 +1,4 @@
-class AddPositionToStockLocation < ActiveRecord::Migration
+class AddPositionToStockLocation < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_stock_locations, :position, :integer, default: 0
   end

--- a/core/db/migrate/20150113002122_create_spree_promotion_codes.rb
+++ b/core/db/migrate/20150113002122_create_spree_promotion_codes.rb
@@ -1,4 +1,4 @@
-class CreateSpreePromotionCodes < ActiveRecord::Migration
+class CreateSpreePromotionCodes < ActiveRecord::Migration[4.2]
   def change
     create_table :spree_promotion_codes do |t|
       t.references :promotion, index: true, null: false

--- a/core/db/migrate/20150113002123_create_adjustment_promotion_code_association.rb
+++ b/core/db/migrate/20150113002123_create_adjustment_promotion_code_association.rb
@@ -1,4 +1,4 @@
-class CreateAdjustmentPromotionCodeAssociation < ActiveRecord::Migration
+class CreateAdjustmentPromotionCodeAssociation < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_adjustments, :promotion_code_id, :integer
     add_index :spree_adjustments, :promotion_code_id

--- a/core/db/migrate/20150121022521_remove_environment_from_payment_method.rb
+++ b/core/db/migrate/20150121022521_remove_environment_from_payment_method.rb
@@ -1,4 +1,4 @@
-class RemoveEnvironmentFromPaymentMethod < ActiveRecord::Migration
+class RemoveEnvironmentFromPaymentMethod < ActiveRecord::Migration[4.2]
   def up
     Spree::PaymentMethod.where('environment != ?', Rails.env).update_all(active: false)
     remove_column :spree_payment_methods, :environment

--- a/core/db/migrate/20150121202544_add_restock_inventory_to_stock_location.rb
+++ b/core/db/migrate/20150121202544_add_restock_inventory_to_stock_location.rb
@@ -1,4 +1,4 @@
-class AddRestockInventoryToStockLocation < ActiveRecord::Migration
+class AddRestockInventoryToStockLocation < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_stock_locations, :restock_inventory, :boolean, default: true, null: false
   end

--- a/core/db/migrate/20150122202432_add_code_to_spree_promotion_categories.rb
+++ b/core/db/migrate/20150122202432_add_code_to_spree_promotion_categories.rb
@@ -1,4 +1,4 @@
-class AddCodeToSpreePromotionCategories < ActiveRecord::Migration
+class AddCodeToSpreePromotionCategories < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_promotion_categories, :code, :string
   end

--- a/core/db/migrate/20150127161843_create_order_stock_locations.rb
+++ b/core/db/migrate/20150127161843_create_order_stock_locations.rb
@@ -1,4 +1,4 @@
-class CreateOrderStockLocations < ActiveRecord::Migration
+class CreateOrderStockLocations < ActiveRecord::Migration[4.2]
   def change
     create_table :spree_order_stock_locations do |t|
       t.integer :order_id

--- a/core/db/migrate/20150128032538_remove_environment_from_tracker.rb
+++ b/core/db/migrate/20150128032538_remove_environment_from_tracker.rb
@@ -1,4 +1,4 @@
-class RemoveEnvironmentFromTracker < ActiveRecord::Migration
+class RemoveEnvironmentFromTracker < ActiveRecord::Migration[4.2]
   def up
     Spree::Tracker.where('environment != ?', Rails.env).update_all(active: false)
     remove_column :spree_trackers, :environment

--- a/core/db/migrate/20150203151219_add_fulfillable_to_stock_location.rb
+++ b/core/db/migrate/20150203151219_add_fulfillable_to_stock_location.rb
@@ -1,4 +1,4 @@
-class AddFulfillableToStockLocation < ActiveRecord::Migration
+class AddFulfillableToStockLocation < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_stock_locations, :fulfillable, :boolean, default: true, null: false
   end

--- a/core/db/migrate/20150205210527_add_code_to_refund_reason.rb
+++ b/core/db/migrate/20150205210527_add_code_to_refund_reason.rb
@@ -1,4 +1,4 @@
-class AddCodeToRefundReason < ActiveRecord::Migration
+class AddCodeToRefundReason < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_refund_reasons, :code, :string
   end

--- a/core/db/migrate/20150213160148_add_promotion_code_id_to_orders_promotions.rb
+++ b/core/db/migrate/20150213160148_add_promotion_code_id_to_orders_promotions.rb
@@ -1,4 +1,4 @@
-class AddPromotionCodeIdToOrdersPromotions < ActiveRecord::Migration
+class AddPromotionCodeIdToOrdersPromotions < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_orders_promotions, :promotion_code_id, :integer
     add_index :spree_orders_promotions, :promotion_code_id

--- a/core/db/migrate/20150213163612_add_approver_name_to_spree_orders.rb
+++ b/core/db/migrate/20150213163612_add_approver_name_to_spree_orders.rb
@@ -1,4 +1,4 @@
-class AddApproverNameToSpreeOrders < ActiveRecord::Migration
+class AddApproverNameToSpreeOrders < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_orders, :approver_name, :string
   end

--- a/core/db/migrate/20150225205344_move_promotion_code_to_promotion_code_value.rb
+++ b/core/db/migrate/20150225205344_move_promotion_code_to_promotion_code_value.rb
@@ -1,4 +1,4 @@
-class MovePromotionCodeToPromotionCodeValue < ActiveRecord::Migration
+class MovePromotionCodeToPromotionCodeValue < ActiveRecord::Migration[4.2]
   def up
     # This is done via SQL for performance reasons. For larger stores it makes
     # a difference of minutes vs hours for completion time.

--- a/core/db/migrate/20150226195213_downcase_promotion_codes_values.rb
+++ b/core/db/migrate/20150226195213_downcase_promotion_codes_values.rb
@@ -1,4 +1,4 @@
-class DowncasePromotionCodesValues < ActiveRecord::Migration
+class DowncasePromotionCodesValues < ActiveRecord::Migration[4.2]
   def up
     Spree::PromotionCode.update_all("value = lower(value)")
     Spree::Promotion.where.not(code: nil).update_all("code = lower(code)")

--- a/core/db/migrate/20150227161934_add_order_ids_to_adjustments_where_missing.rb
+++ b/core/db/migrate/20150227161934_add_order_ids_to_adjustments_where_missing.rb
@@ -1,4 +1,4 @@
-class AddOrderIdsToAdjustmentsWhereMissing < ActiveRecord::Migration
+class AddOrderIdsToAdjustmentsWhereMissing < ActiveRecord::Migration[4.2]
   def up
     Spree::Adjustment.where(order_id: nil, adjustable_type: 'Spree::Order').update_all("order_id = adjustable_id")
   end

--- a/core/db/migrate/20150303212749_add_per_code_usage_limit_to_promotions.rb
+++ b/core/db/migrate/20150303212749_add_per_code_usage_limit_to_promotions.rb
@@ -1,4 +1,4 @@
-class AddPerCodeUsageLimitToPromotions < ActiveRecord::Migration
+class AddPerCodeUsageLimitToPromotions < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_promotions, :per_code_usage_limit, :integer
   end

--- a/core/db/migrate/20150303212826_remove_usage_limit_from_promotion_codes.rb
+++ b/core/db/migrate/20150303212826_remove_usage_limit_from_promotion_codes.rb
@@ -1,4 +1,4 @@
-class RemoveUsageLimitFromPromotionCodes < ActiveRecord::Migration
+class RemoveUsageLimitFromPromotionCodes < ActiveRecord::Migration[4.2]
   def change
     remove_column :spree_promotion_codes, :usage_limit, :integer
   end

--- a/core/db/migrate/20150304211616_add_timestamps_to_order_promotions.rb
+++ b/core/db/migrate/20150304211616_add_timestamps_to_order_promotions.rb
@@ -1,4 +1,4 @@
-class AddTimestampsToOrderPromotions < ActiveRecord::Migration
+class AddTimestampsToOrderPromotions < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_orders_promotions, :created_at, :datetime
     add_column :spree_orders_promotions, :updated_at, :datetime

--- a/core/db/migrate/20150305043021_create_spree_cartons.rb
+++ b/core/db/migrate/20150305043021_create_spree_cartons.rb
@@ -1,4 +1,4 @@
-class CreateSpreeCartons < ActiveRecord::Migration
+class CreateSpreeCartons < ActiveRecord::Migration[4.2]
   def change
     create_table "spree_cartons" do |t|
       t.string "number"

--- a/core/db/migrate/20150305210403_add_timestamps_to_spree_roles_users.rb
+++ b/core/db/migrate/20150305210403_add_timestamps_to_spree_roles_users.rb
@@ -1,4 +1,4 @@
-class AddTimestampsToSpreeRolesUsers < ActiveRecord::Migration
+class AddTimestampsToSpreeRolesUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_roles_users, :id, :primary_key
     add_column :spree_roles_users, :created_at, :datetime

--- a/core/db/migrate/20150313140507_remove_considered_risky_from_spree_orders.rb
+++ b/core/db/migrate/20150313140507_remove_considered_risky_from_spree_orders.rb
@@ -1,4 +1,4 @@
-class RemoveConsideredRiskyFromSpreeOrders < ActiveRecord::Migration
+class RemoveConsideredRiskyFromSpreeOrders < ActiveRecord::Migration[4.2]
   def change
     remove_column :spree_orders, :considered_risky
   end

--- a/core/db/migrate/20150313192827_add_index_to_inventory_units_carton_id.rb
+++ b/core/db/migrate/20150313192827_add_index_to_inventory_units_carton_id.rb
@@ -1,4 +1,4 @@
-class AddIndexToInventoryUnitsCartonId < ActiveRecord::Migration
+class AddIndexToInventoryUnitsCartonId < ActiveRecord::Migration[4.2]
   def change
     add_index :spree_inventory_units, :carton_id
   end

--- a/core/db/migrate/20150313201235_add_imported_from_shipment_id_to_cartons.rb
+++ b/core/db/migrate/20150313201235_add_imported_from_shipment_id_to_cartons.rb
@@ -1,4 +1,4 @@
-class AddImportedFromShipmentIdToCartons < ActiveRecord::Migration
+class AddImportedFromShipmentIdToCartons < ActiveRecord::Migration[4.2]
   def change
     # Temporarily add this column until we're sure that this migration and the
     # upcoming code changes are working correctly

--- a/core/db/migrate/20150313201503_copy_shipped_shipments_to_cartons.rb
+++ b/core/db/migrate/20150313201503_copy_shipped_shipments_to_cartons.rb
@@ -1,4 +1,4 @@
-class CopyShippedShipmentsToCartons < ActiveRecord::Migration
+class CopyShippedShipmentsToCartons < ActiveRecord::Migration[4.2]
   # Prevent everything from running in one giant transaction in postrgres.
   disable_ddl_transaction!
 

--- a/core/db/migrate/20150330144639_create_spree_user_stock_locations.rb
+++ b/core/db/migrate/20150330144639_create_spree_user_stock_locations.rb
@@ -1,4 +1,4 @@
-class CreateSpreeUserStockLocations < ActiveRecord::Migration
+class CreateSpreeUserStockLocations < ActiveRecord::Migration[4.2]
   def change
     create_table :spree_user_stock_locations do |t|
       t.integer :user_id

--- a/core/db/migrate/20150331134544_add_stock_location_code.rb
+++ b/core/db/migrate/20150331134544_add_stock_location_code.rb
@@ -1,4 +1,4 @@
-class AddStockLocationCode < ActiveRecord::Migration
+class AddStockLocationCode < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_stock_locations, :code, :string
   end

--- a/core/db/migrate/20150402210430_create_unit_cancels.rb
+++ b/core/db/migrate/20150402210430_create_unit_cancels.rb
@@ -1,4 +1,4 @@
-class CreateUnitCancels < ActiveRecord::Migration
+class CreateUnitCancels < ActiveRecord::Migration[4.2]
   def change
     create_table :spree_unit_cancels do |t|
       t.references :inventory_unit, index: true, null: false

--- a/core/db/migrate/20150407173305_add_fields_to_stock_transfer.rb
+++ b/core/db/migrate/20150407173305_add_fields_to_stock_transfer.rb
@@ -1,4 +1,4 @@
-class AddFieldsToStockTransfer < ActiveRecord::Migration
+class AddFieldsToStockTransfer < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_stock_transfers, :shipped_at, :datetime
     add_column :spree_stock_transfers, :closed_at, :datetime

--- a/core/db/migrate/20150407173531_create_transfer_items.rb
+++ b/core/db/migrate/20150407173531_create_transfer_items.rb
@@ -1,4 +1,4 @@
-class CreateTransferItems < ActiveRecord::Migration
+class CreateTransferItems < ActiveRecord::Migration[4.2]
   def change
     create_table :spree_transfer_items do |t|
       t.integer :variant_id, null: false

--- a/core/db/migrate/20150424143547_drop_stock_transfer_type.rb
+++ b/core/db/migrate/20150424143547_drop_stock_transfer_type.rb
@@ -1,4 +1,4 @@
-class DropStockTransferType < ActiveRecord::Migration
+class DropStockTransferType < ActiveRecord::Migration[4.2]
   def up
     # type is reserved for Single Table Inheritance
     remove_column :spree_stock_transfers, :type

--- a/core/db/migrate/20150424161102_add_stock_transfer_finalized_at.rb
+++ b/core/db/migrate/20150424161102_add_stock_transfer_finalized_at.rb
@@ -1,4 +1,4 @@
-class AddStockTransferFinalizedAt < ActiveRecord::Migration
+class AddStockTransferFinalizedAt < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_stock_transfers, :finalized_at, :datetime
     add_column :spree_stock_transfers, :finalized_by_id, :integer

--- a/core/db/migrate/20150429125822_rename_stock_transfer_reference.rb
+++ b/core/db/migrate/20150429125822_rename_stock_transfer_reference.rb
@@ -1,4 +1,4 @@
-class RenameStockTransferReference < ActiveRecord::Migration
+class RenameStockTransferReference < ActiveRecord::Migration[4.2]
   def change
     rename_column :spree_stock_transfers, :reference, :description
   end

--- a/core/db/migrate/20150430233803_create_line_item_actions.rb
+++ b/core/db/migrate/20150430233803_create_line_item_actions.rb
@@ -1,4 +1,4 @@
-class CreateLineItemActions < ActiveRecord::Migration
+class CreateLineItemActions < ActiveRecord::Migration[4.2]
   def change
     create_table :spree_line_item_actions do |t|
       t.references :line_item, index: true, null: false

--- a/core/db/migrate/20150506181159_create_spree_store_credit_categories.rb
+++ b/core/db/migrate/20150506181159_create_spree_store_credit_categories.rb
@@ -1,4 +1,4 @@
-class CreateSpreeStoreCreditCategories < ActiveRecord::Migration
+class CreateSpreeStoreCreditCategories < ActiveRecord::Migration[4.2]
   def change
     create_table :spree_store_credit_categories do |t|
       t.string :name

--- a/core/db/migrate/20150506181244_create_spree_store_credits.rb
+++ b/core/db/migrate/20150506181244_create_spree_store_credits.rb
@@ -1,4 +1,4 @@
-class CreateSpreeStoreCredits < ActiveRecord::Migration
+class CreateSpreeStoreCredits < ActiveRecord::Migration[4.2]
   def change
     create_table :spree_store_credits do |t|
       t.references :user

--- a/core/db/migrate/20150506181539_create_spree_store_credit_events.rb
+++ b/core/db/migrate/20150506181539_create_spree_store_credit_events.rb
@@ -1,4 +1,4 @@
-class CreateSpreeStoreCreditEvents < ActiveRecord::Migration
+class CreateSpreeStoreCreditEvents < ActiveRecord::Migration[4.2]
   def change
     create_table :spree_store_credit_events do |t|
       t.integer :store_credit_id,    null: false

--- a/core/db/migrate/20150506181611_create_spree_store_credit_payment_method.rb
+++ b/core/db/migrate/20150506181611_create_spree_store_credit_payment_method.rb
@@ -1,4 +1,4 @@
-class CreateSpreeStoreCreditPaymentMethod < ActiveRecord::Migration
+class CreateSpreeStoreCreditPaymentMethod < ActiveRecord::Migration[4.2]
   class PaymentMethod < Spree::Base
     self.table_name = 'spree_payment_methods'
     self.inheritance_column = :_type_disabled

--- a/core/db/migrate/20150506181715_create_store_credit_types.rb
+++ b/core/db/migrate/20150506181715_create_store_credit_types.rb
@@ -1,4 +1,4 @@
-class CreateStoreCreditTypes < ActiveRecord::Migration
+class CreateStoreCreditTypes < ActiveRecord::Migration[4.2]
   def change
     create_table :spree_store_credit_types do |t|
       t.string :name

--- a/core/db/migrate/20150506182045_create_store_credit_reimbursement_type.rb
+++ b/core/db/migrate/20150506182045_create_store_credit_reimbursement_type.rb
@@ -1,4 +1,4 @@
-class CreateStoreCreditReimbursementType < ActiveRecord::Migration
+class CreateStoreCreditReimbursementType < ActiveRecord::Migration[4.2]
   def up
     Spree::ReimbursementType.create_with(name: Spree.t("store_credit.store_credit")).find_or_create_by!(type: 'Spree::ReimbursementType::StoreCredit')
   end

--- a/core/db/migrate/20150508044622_add_resellable_to_return_items.rb
+++ b/core/db/migrate/20150508044622_add_resellable_to_return_items.rb
@@ -1,4 +1,4 @@
-class AddResellableToReturnItems < ActiveRecord::Migration
+class AddResellableToReturnItems < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_return_items, :resellable, :boolean, default: true, null: false
   end

--- a/core/db/migrate/20150514185559_add_invalidated_at_to_spree_store_credits.rb
+++ b/core/db/migrate/20150514185559_add_invalidated_at_to_spree_store_credits.rb
@@ -1,4 +1,4 @@
-class AddInvalidatedAtToSpreeStoreCredits < ActiveRecord::Migration
+class AddInvalidatedAtToSpreeStoreCredits < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_store_credits, :invalidated_at, :datetime
   end

--- a/core/db/migrate/20150514201836_migrate_deleted_store_credits_to_invalidated.rb
+++ b/core/db/migrate/20150514201836_migrate_deleted_store_credits_to_invalidated.rb
@@ -1,4 +1,4 @@
-class MigrateDeletedStoreCreditsToInvalidated < ActiveRecord::Migration
+class MigrateDeletedStoreCreditsToInvalidated < ActiveRecord::Migration[4.2]
   def up
     Spree::StoreCredit.only_deleted.find_each do |store_credit|
       say "Marking deleted store credit #{store_credit.id} for #{store_credit.user.try(:email)} as invalidated"

--- a/core/db/migrate/20150515170322_add_check_stock_on_transfer.rb
+++ b/core/db/migrate/20150515170322_add_check_stock_on_transfer.rb
@@ -1,4 +1,4 @@
-class AddCheckStockOnTransfer < ActiveRecord::Migration
+class AddCheckStockOnTransfer < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_stock_locations, :check_stock_on_transfer, :boolean, default: true
   end

--- a/core/db/migrate/20150515211137_fix_adjustment_order_id.rb
+++ b/core/db/migrate/20150515211137_fix_adjustment_order_id.rb
@@ -1,4 +1,4 @@
-class FixAdjustmentOrderId < ActiveRecord::Migration
+class FixAdjustmentOrderId < ActiveRecord::Migration[4.2]
   def change
     say 'Populate order_id from adjustable_id where appropriate'
 

--- a/core/db/migrate/20150528125647_delete_inventory_units_without_shipment.rb
+++ b/core/db/migrate/20150528125647_delete_inventory_units_without_shipment.rb
@@ -1,4 +1,4 @@
-class DeleteInventoryUnitsWithoutShipment < ActiveRecord::Migration
+class DeleteInventoryUnitsWithoutShipment < ActiveRecord::Migration[4.2]
   # Prevent everything from running in one giant transaction in postrgres.
   disable_ddl_transaction!
 

--- a/core/db/migrate/20150601191251_add_deleted_at_to_stock_transfers.rb
+++ b/core/db/migrate/20150601191251_add_deleted_at_to_stock_transfers.rb
@@ -1,4 +1,4 @@
-class AddDeletedAtToStockTransfers < ActiveRecord::Migration
+class AddDeletedAtToStockTransfers < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_stock_transfers, :deleted_at, :datetime
   end

--- a/core/db/migrate/20150601204148_add_deleted_at_to_transfer_items.rb
+++ b/core/db/migrate/20150601204148_add_deleted_at_to_transfer_items.rb
@@ -1,4 +1,4 @@
-class AddDeletedAtToTransferItems < ActiveRecord::Migration
+class AddDeletedAtToTransferItems < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_transfer_items, :deleted_at, :datetime
   end

--- a/core/db/migrate/20150609093816_increase_scale_on_pre_tax_amounts.rb
+++ b/core/db/migrate/20150609093816_increase_scale_on_pre_tax_amounts.rb
@@ -1,4 +1,4 @@
-class IncreaseScaleOnPreTaxAmounts < ActiveRecord::Migration
+class IncreaseScaleOnPreTaxAmounts < ActiveRecord::Migration[4.2]
   def change
     # set pre_tax_amount on shipments to discounted_amount - included_tax_total
     # so that the null: false option on the shipment pre_tax_amount doesn't generate

--- a/core/db/migrate/20150609193231_add_preferences_to_promotion_actions.rb
+++ b/core/db/migrate/20150609193231_add_preferences_to_promotion_actions.rb
@@ -1,4 +1,4 @@
-class AddPreferencesToPromotionActions < ActiveRecord::Migration
+class AddPreferencesToPromotionActions < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_promotion_actions, :preferences, :text
   end

--- a/core/db/migrate/20150610182638_add_id_to_spree_option_values_variants.rb
+++ b/core/db/migrate/20150610182638_add_id_to_spree_option_values_variants.rb
@@ -1,4 +1,4 @@
-class AddIdToSpreeOptionValuesVariants < ActiveRecord::Migration
+class AddIdToSpreeOptionValuesVariants < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_option_values_variants, :id, :primary_key
   end

--- a/core/db/migrate/20150611200247_add_frontend_viewable_to_spree_orders.rb
+++ b/core/db/migrate/20150611200247_add_frontend_viewable_to_spree_orders.rb
@@ -1,4 +1,4 @@
-class AddFrontendViewableToSpreeOrders < ActiveRecord::Migration
+class AddFrontendViewableToSpreeOrders < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_orders, :frontend_viewable, :boolean, default: true, null: false
   end

--- a/core/db/migrate/20150612205731_remove_spree_configurations.rb
+++ b/core/db/migrate/20150612205731_remove_spree_configurations.rb
@@ -1,4 +1,4 @@
-class RemoveSpreeConfigurations < ActiveRecord::Migration
+class RemoveSpreeConfigurations < ActiveRecord::Migration[4.2]
   def up
     drop_table :spree_configurations
   end

--- a/core/db/migrate/20150616204659_add_preference_source_to_spree_payment_methods.rb
+++ b/core/db/migrate/20150616204659_add_preference_source_to_spree_payment_methods.rb
@@ -1,4 +1,4 @@
-class AddPreferenceSourceToSpreePaymentMethods < ActiveRecord::Migration
+class AddPreferenceSourceToSpreePaymentMethods < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_payment_methods, :preference_source, :string
   end

--- a/core/db/migrate/20150618191713_remove_credit_card_address_id.rb
+++ b/core/db/migrate/20150618191713_remove_credit_card_address_id.rb
@@ -1,4 +1,4 @@
-class RemoveCreditCardAddressId < ActiveRecord::Migration
+class RemoveCreditCardAddressId < ActiveRecord::Migration[4.2]
   def change
     # This hasn't been accessible for a long time:
     # https://github.com/bonobos/spree/commit/0b58afc#diff-b3d9a7a18a30a5fb3372cfcf3f925a3dL4

--- a/core/db/migrate/20150618212517_create_spree_store_credit_update_reasons.rb
+++ b/core/db/migrate/20150618212517_create_spree_store_credit_update_reasons.rb
@@ -1,4 +1,4 @@
-class CreateSpreeStoreCreditUpdateReasons < ActiveRecord::Migration
+class CreateSpreeStoreCreditUpdateReasons < ActiveRecord::Migration[4.2]
   def change
     create_table :spree_store_credit_update_reasons do |t|
       t.string :name

--- a/core/db/migrate/20150619160613_create_adjustment_reason.rb
+++ b/core/db/migrate/20150619160613_create_adjustment_reason.rb
@@ -1,4 +1,4 @@
-class CreateAdjustmentReason < ActiveRecord::Migration
+class CreateAdjustmentReason < ActiveRecord::Migration[4.2]
   def change
     create_table :spree_adjustment_reasons do |t|
       t.string   "name"

--- a/core/db/migrate/20150622144655_add_update_reason_to_store_credit_events.rb
+++ b/core/db/migrate/20150622144655_add_update_reason_to_store_credit_events.rb
@@ -1,4 +1,4 @@
-class AddUpdateReasonToStoreCreditEvents < ActiveRecord::Migration
+class AddUpdateReasonToStoreCreditEvents < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_store_credit_events, :update_reason_id, :integer
   end

--- a/core/db/migrate/20150623194316_add_return_authorization_reason_id_to_return_items.rb
+++ b/core/db/migrate/20150623194316_add_return_authorization_reason_id_to_return_items.rb
@@ -1,4 +1,4 @@
-class AddReturnAuthorizationReasonIdToReturnItems < ActiveRecord::Migration
+class AddReturnAuthorizationReasonIdToReturnItems < ActiveRecord::Migration[4.2]
   def change
     rename_table :spree_return_authorization_reasons, :spree_return_reasons
     rename_column :spree_return_authorizations, :return_authorization_reason_id, :return_reason_id

--- a/core/db/migrate/20150623214058_seed_store_credit_update_reasons.rb
+++ b/core/db/migrate/20150623214058_seed_store_credit_update_reasons.rb
@@ -1,4 +1,4 @@
-class SeedStoreCreditUpdateReasons < ActiveRecord::Migration
+class SeedStoreCreditUpdateReasons < ActiveRecord::Migration[4.2]
   def up
     Spree::StoreCreditUpdateReason.create!(name: 'Credit Given In Error')
   end

--- a/core/db/migrate/20150626200816_remove_shipping_method_id_from_spree_orders.rb
+++ b/core/db/migrate/20150626200816_remove_shipping_method_id_from_spree_orders.rb
@@ -1,4 +1,4 @@
-class RemoveShippingMethodIdFromSpreeOrders < ActiveRecord::Migration
+class RemoveShippingMethodIdFromSpreeOrders < ActiveRecord::Migration[4.2]
   def up
     remove_column :spree_orders, :shipping_method_id, :integer
   end

--- a/core/db/migrate/20150626214817_remove_counter_cache_from_spree_variants_to_spree_stock_items.rb
+++ b/core/db/migrate/20150626214817_remove_counter_cache_from_spree_variants_to_spree_stock_items.rb
@@ -1,4 +1,4 @@
-class RemoveCounterCacheFromSpreeVariantsToSpreeStockItems < ActiveRecord::Migration
+class RemoveCounterCacheFromSpreeVariantsToSpreeStockItems < ActiveRecord::Migration[4.2]
   def up
     if column_exists?(:spree_variants, :stock_items_count)
       remove_column :spree_variants, :stock_items_count

--- a/core/db/migrate/20150629175931_add_address_id_to_credit_card.rb
+++ b/core/db/migrate/20150629175931_add_address_id_to_credit_card.rb
@@ -1,4 +1,4 @@
-class AddAddressIdToCreditCard < ActiveRecord::Migration
+class AddAddressIdToCreditCard < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_credit_cards, :address_id, :integer
   end

--- a/core/db/migrate/20150630175644_copy_order_bill_address_to_credit_card.rb
+++ b/core/db/migrate/20150630175644_copy_order_bill_address_to_credit_card.rb
@@ -1,4 +1,4 @@
-class CopyOrderBillAddressToCreditCard < ActiveRecord::Migration
+class CopyOrderBillAddressToCreditCard < ActiveRecord::Migration[4.2]
   # Prevent everything from running in one giant transaction in postrgres.
   disable_ddl_transaction!
 

--- a/core/db/migrate/20150723224133_remove_unnecessary_indexes.rb
+++ b/core/db/migrate/20150723224133_remove_unnecessary_indexes.rb
@@ -3,7 +3,7 @@
 # However, most are necessary and were removed from that migration. This
 # migration deletes any of the indexes left around in stores using the
 # out-dated version of that migration
-class RemoveUnnecessaryIndexes < ActiveRecord::Migration
+class RemoveUnnecessaryIndexes < ActiveRecord::Migration[4.2]
   include Spree::MigrationHelpers
 
   def up

--- a/core/db/migrate/20150724163716_remove_state_lock_version_from_order.rb
+++ b/core/db/migrate/20150724163716_remove_state_lock_version_from_order.rb
@@ -1,4 +1,4 @@
-class RemoveStateLockVersionFromOrder < ActiveRecord::Migration
+class RemoveStateLockVersionFromOrder < ActiveRecord::Migration[4.2]
   def up
     if column_exists? :spree_orders, :state_lock_version
       remove_column :spree_orders, :state_lock_version

--- a/core/db/migrate/20150731201146_add_spree_user_addresses.rb
+++ b/core/db/migrate/20150731201146_add_spree_user_addresses.rb
@@ -1,4 +1,4 @@
-class AddSpreeUserAddresses < ActiveRecord::Migration
+class AddSpreeUserAddresses < ActiveRecord::Migration[4.2]
   def change
     create_table :spree_user_addresses do |t|
       t.integer :user_id, null: false

--- a/core/db/migrate/20150806190833_add_id_and_timestamp_to_promotion_rule_user.rb
+++ b/core/db/migrate/20150806190833_add_id_and_timestamp_to_promotion_rule_user.rb
@@ -1,4 +1,4 @@
-class AddIdAndTimestampToPromotionRuleUser < ActiveRecord::Migration
+class AddIdAndTimestampToPromotionRuleUser < ActiveRecord::Migration[4.2]
   def up
     add_column :spree_promotion_rules_users, :id, :primary_key
     add_column :spree_promotion_rules_users, :created_at, :datetime

--- a/core/db/migrate/20150811210350_remove_mandatory_from_adjustments.rb
+++ b/core/db/migrate/20150811210350_remove_mandatory_from_adjustments.rb
@@ -1,4 +1,4 @@
-class RemoveMandatoryFromAdjustments < ActiveRecord::Migration
+class RemoveMandatoryFromAdjustments < ActiveRecord::Migration[4.2]
   def change
     remove_column :spree_adjustments, :mandatory, :boolean
   end

--- a/core/db/migrate/20150811211025_add_finalized_to_spree_adjustments.rb
+++ b/core/db/migrate/20150811211025_add_finalized_to_spree_adjustments.rb
@@ -1,4 +1,4 @@
-class AddFinalizedToSpreeAdjustments < ActiveRecord::Migration
+class AddFinalizedToSpreeAdjustments < ActiveRecord::Migration[4.2]
   # This migration replaces the open/closed state column of spree_adjustments
   # with a finalized boolean.
   # This may cause a few minutes of downtime on very large stores as the

--- a/core/db/migrate/20150820160821_add_store_payment_methods.rb
+++ b/core/db/migrate/20150820160821_add_store_payment_methods.rb
@@ -1,4 +1,4 @@
-class AddStorePaymentMethods < ActiveRecord::Migration
+class AddStorePaymentMethods < ActiveRecord::Migration[4.2]
   def change
     create_table :spree_store_payment_methods do |t|
       t.references :store, null: false, index: true

--- a/core/db/migrate/20150824213633_convert_habtm_to_hmt_for_shipping_methods_zones.rb
+++ b/core/db/migrate/20150824213633_convert_habtm_to_hmt_for_shipping_methods_zones.rb
@@ -1,4 +1,4 @@
-class ConvertHabtmToHmtForShippingMethodsZones < ActiveRecord::Migration
+class ConvertHabtmToHmtForShippingMethodsZones < ActiveRecord::Migration[4.2]
   def up
     add_column :spree_shipping_methods_zones, :id, :primary_key
     add_column :spree_shipping_methods_zones, :created_at, :datetime

--- a/core/db/migrate/20150824214129_convert_habtm_to_hmt_for_products_promotion_rules.rb
+++ b/core/db/migrate/20150824214129_convert_habtm_to_hmt_for_products_promotion_rules.rb
@@ -1,4 +1,4 @@
-class ConvertHabtmToHmtForProductsPromotionRules < ActiveRecord::Migration
+class ConvertHabtmToHmtForProductsPromotionRules < ActiveRecord::Migration[4.2]
   def up
     add_column :spree_products_promotion_rules, :id, :primary_key
     add_column :spree_products_promotion_rules, :created_at, :datetime

--- a/core/db/migrate/20150825204216_drop_spree_gateways.rb
+++ b/core/db/migrate/20150825204216_drop_spree_gateways.rb
@@ -1,4 +1,4 @@
-class DropSpreeGateways < ActiveRecord::Migration
+class DropSpreeGateways < ActiveRecord::Migration[4.2]
   def up
     drop_table :spree_gateways
   end

--- a/core/db/migrate/20150826002555_convert_habtm_to_hmt_for_taxon_prototypes.rb
+++ b/core/db/migrate/20150826002555_convert_habtm_to_hmt_for_taxon_prototypes.rb
@@ -1,4 +1,4 @@
-class ConvertHabtmToHmtForTaxonPrototypes < ActiveRecord::Migration
+class ConvertHabtmToHmtForTaxonPrototypes < ActiveRecord::Migration[4.2]
   def up
     add_column :spree_taxons_prototypes, :created_at, :datetime
     add_column :spree_taxons_prototypes, :updated_at, :datetime

--- a/core/db/migrate/20150909123605_create_variant_properties_and_rules.rb
+++ b/core/db/migrate/20150909123605_create_variant_properties_and_rules.rb
@@ -1,4 +1,4 @@
-class CreateVariantPropertiesAndRules < ActiveRecord::Migration
+class CreateVariantPropertiesAndRules < ActiveRecord::Migration[4.2]
   def change
     create_table :spree_variant_property_rules do |t|
       t.references :product

--- a/core/db/migrate/20151001121454_create_spree_shipping_method_stock_locations.rb
+++ b/core/db/migrate/20151001121454_create_spree_shipping_method_stock_locations.rb
@@ -1,4 +1,4 @@
-class CreateSpreeShippingMethodStockLocations < ActiveRecord::Migration
+class CreateSpreeShippingMethodStockLocations < ActiveRecord::Migration[4.2]
   def change
     create_table :spree_shipping_method_stock_locations do |t|
       t.belongs_to :shipping_method

--- a/core/db/migrate/20151002023248_add_foreign_key_to_shipping_method_stock_location.rb
+++ b/core/db/migrate/20151002023248_add_foreign_key_to_shipping_method_stock_location.rb
@@ -1,4 +1,4 @@
-class AddForeignKeyToShippingMethodStockLocation < ActiveRecord::Migration
+class AddForeignKeyToShippingMethodStockLocation < ActiveRecord::Migration[4.2]
   def change
     add_foreign_key :spree_shipping_method_stock_locations, :spree_shipping_methods, column: :shipping_method_id
     add_foreign_key :spree_shipping_method_stock_locations, :spree_stock_locations, column: :stock_location_id

--- a/core/db/migrate/20151010003252_add_foreign_keys_for_taxons_prototypes.rb
+++ b/core/db/migrate/20151010003252_add_foreign_keys_for_taxons_prototypes.rb
@@ -1,4 +1,4 @@
-class AddForeignKeysForTaxonsPrototypes < ActiveRecord::Migration
+class AddForeignKeysForTaxonsPrototypes < ActiveRecord::Migration[4.2]
   def change
     add_foreign_key :spree_prototype_taxons, :spree_taxons, column: :taxon_id
     add_foreign_key :spree_prototype_taxons, :spree_prototypes, column: :prototype_id

--- a/core/db/migrate/20151013222921_remove_token_permissions_table.rb
+++ b/core/db/migrate/20151013222921_remove_token_permissions_table.rb
@@ -1,6 +1,6 @@
 # This is named the same as the migration in spree 3.0 so it will not be copied
 # if that has already been run.
-class RemoveTokenPermissionsTable < ActiveRecord::Migration
+class RemoveTokenPermissionsTable < ActiveRecord::Migration[4.2]
   def up
     drop_table :spree_tokenized_permissions
   end

--- a/core/db/migrate/20151014213349_rename_identifier_to_number_for_payment.rb
+++ b/core/db/migrate/20151014213349_rename_identifier_to_number_for_payment.rb
@@ -1,6 +1,6 @@
 # This file has the same name as the spree 3.0 migration to prevent it from
 # being run twice for those users.
-class RenameIdentifierToNumberForPayment < ActiveRecord::Migration
+class RenameIdentifierToNumberForPayment < ActiveRecord::Migration[4.2]
   def change
     rename_column :spree_payments, :identifier, :number
   end

--- a/core/db/migrate/20151015203732_add_foreign_keys_for_product_promotion_rules.rb
+++ b/core/db/migrate/20151015203732_add_foreign_keys_for_product_promotion_rules.rb
@@ -1,4 +1,4 @@
-class AddForeignKeysForProductPromotionRules < ActiveRecord::Migration
+class AddForeignKeysForProductPromotionRules < ActiveRecord::Migration[4.2]
   def change
     add_foreign_key :spree_product_promotion_rules, :spree_products,
                     column: :product_id

--- a/core/db/migrate/20151021113730_add_sale_to_spree_promotions.rb
+++ b/core/db/migrate/20151021113730_add_sale_to_spree_promotions.rb
@@ -1,4 +1,4 @@
-class AddSaleToSpreePromotions < ActiveRecord::Migration
+class AddSaleToSpreePromotions < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_promotions, :apply_automatically, :boolean, default: false
     add_index :spree_promotions, :apply_automatically

--- a/core/db/migrate/20151021163309_convert_sale_promotions.rb
+++ b/core/db/migrate/20151021163309_convert_sale_promotions.rb
@@ -1,4 +1,4 @@
-class ConvertSalePromotions < ActiveRecord::Migration
+class ConvertSalePromotions < ActiveRecord::Migration[4.2]
   def up
     sale_promotions.update_all(apply_automatically: true)
   end

--- a/core/db/migrate/20151026093607_change_return_item_pre_tax_amount_to_amount.rb
+++ b/core/db/migrate/20151026093607_change_return_item_pre_tax_amount_to_amount.rb
@@ -1,4 +1,4 @@
-class ChangeReturnItemPreTaxAmountToAmount < ActiveRecord::Migration
+class ChangeReturnItemPreTaxAmountToAmount < ActiveRecord::Migration[4.2]
   def up
     execute(<<-SQL)
       UPDATE spree_return_items

--- a/core/db/migrate/20151117063249_convert_habtm_to_hmt_for_properties_prototypes.rb
+++ b/core/db/migrate/20151117063249_convert_habtm_to_hmt_for_properties_prototypes.rb
@@ -1,4 +1,4 @@
-class ConvertHabtmToHmtForPropertiesPrototypes < ActiveRecord::Migration
+class ConvertHabtmToHmtForPropertiesPrototypes < ActiveRecord::Migration[4.2]
   def up
     add_column :spree_properties_prototypes, :id, :primary_key
     add_column :spree_properties_prototypes, :created_at, :datetime

--- a/core/db/migrate/20151124062500_convert_habtm_to_hmt_for_option_type_prototypes.rb
+++ b/core/db/migrate/20151124062500_convert_habtm_to_hmt_for_option_type_prototypes.rb
@@ -1,4 +1,4 @@
-class ConvertHabtmToHmtForOptionTypePrototypes < ActiveRecord::Migration
+class ConvertHabtmToHmtForOptionTypePrototypes < ActiveRecord::Migration[4.2]
   def up
     add_column :spree_option_types_prototypes, :id, :primary_key
     add_column :spree_option_types_prototypes, :created_at, :datetime

--- a/core/db/migrate/20151126063028_convert_habtm_to_hmt_for_taxons_promotion_rules.rb
+++ b/core/db/migrate/20151126063028_convert_habtm_to_hmt_for_taxons_promotion_rules.rb
@@ -1,4 +1,4 @@
-class ConvertHabtmToHmtForTaxonsPromotionRules < ActiveRecord::Migration
+class ConvertHabtmToHmtForTaxonsPromotionRules < ActiveRecord::Migration[4.2]
   def up
     add_column :spree_taxons_promotion_rules, :created_at, :datetime
     add_column :spree_taxons_promotion_rules, :updated_at, :datetime

--- a/core/db/migrate/20151219020209_add_stock_item_unique_index.rb
+++ b/core/db/migrate/20151219020209_add_stock_item_unique_index.rb
@@ -1,4 +1,4 @@
-class AddStockItemUniqueIndex < ActiveRecord::Migration
+class AddStockItemUniqueIndex < ActiveRecord::Migration[4.2]
   def change
     # Add a database-level uniqueness constraint for databases that support it
     # (postgres and sqlite > 3.8)

--- a/core/db/migrate/20160111091912_add_column_available_to_all_on_spree_shipping_method.rb
+++ b/core/db/migrate/20160111091912_add_column_available_to_all_on_spree_shipping_method.rb
@@ -1,4 +1,4 @@
-class AddColumnAvailableToAllOnSpreeShippingMethod < ActiveRecord::Migration
+class AddColumnAvailableToAllOnSpreeShippingMethod < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_shipping_methods, :available_to_all, :boolean, default: true
   end

--- a/core/db/migrate/20160116133604_add_position_to_spree_payment_methods.rb
+++ b/core/db/migrate/20160116133604_add_position_to_spree_payment_methods.rb
@@ -1,4 +1,4 @@
-class AddPositionToSpreePaymentMethods < ActiveRecord::Migration
+class AddPositionToSpreePaymentMethods < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_payment_methods, :position, :integer, default: 0
   end

--- a/core/db/migrate/20160122182105_add_carrier_and_service_level_to_spree_shipping_methods.rb
+++ b/core/db/migrate/20160122182105_add_carrier_and_service_level_to_spree_shipping_methods.rb
@@ -1,4 +1,4 @@
-class AddCarrierAndServiceLevelToSpreeShippingMethods < ActiveRecord::Migration
+class AddCarrierAndServiceLevelToSpreeShippingMethods < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_shipping_methods, :carrier, :string
     add_column :spree_shipping_methods, :service_level, :string

--- a/core/db/migrate/20160224201413_create_spree_shipping_rate_taxes.rb
+++ b/core/db/migrate/20160224201413_create_spree_shipping_rate_taxes.rb
@@ -1,4 +1,4 @@
-class CreateSpreeShippingRateTaxes < ActiveRecord::Migration
+class CreateSpreeShippingRateTaxes < ActiveRecord::Migration[4.2]
   def change
     create_table :spree_shipping_rate_taxes do |t|
       t.decimal :amount, precision: 8, scale: 2, default: 0.0, null: false

--- a/core/db/migrate/20160229133259_add_cart_tax_country_iso_to_spree_store.rb
+++ b/core/db/migrate/20160229133259_add_cart_tax_country_iso_to_spree_store.rb
@@ -1,4 +1,4 @@
-class AddCartTaxCountryIsoToSpreeStore < ActiveRecord::Migration
+class AddCartTaxCountryIsoToSpreeStore < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_stores, :cart_tax_country_iso, :string, null: true, default: nil
   end

--- a/core/db/migrate/20160301103333_remove_pre_tax_amount_on_line_item_and_shipment.rb
+++ b/core/db/migrate/20160301103333_remove_pre_tax_amount_on_line_item_and_shipment.rb
@@ -1,4 +1,4 @@
-class RemovePreTaxAmountOnLineItemAndShipment < ActiveRecord::Migration
+class RemovePreTaxAmountOnLineItemAndShipment < ActiveRecord::Migration[4.2]
   def change
     remove_column :spree_line_items, :pre_tax_amount, :decimal, precision: 12, scale: 4, default: 0.0, null: false
     remove_column :spree_shipments, :pre_tax_amount, :decimal, precision: 12, scale: 4, default: 0.0, null: false

--- a/core/db/migrate/20160308000300_disallow_adjustment_finalized_nulls.rb
+++ b/core/db/migrate/20160308000300_disallow_adjustment_finalized_nulls.rb
@@ -1,4 +1,4 @@
-class DisallowAdjustmentFinalizedNulls < ActiveRecord::Migration
+class DisallowAdjustmentFinalizedNulls < ActiveRecord::Migration[4.2]
   def up
     execute <<-SQL
       update spree_adjustments

--- a/core/db/migrate/20160318145302_add_timestamps_to_prices.rb
+++ b/core/db/migrate/20160318145302_add_timestamps_to_prices.rb
@@ -1,4 +1,4 @@
-class AddTimestampsToPrices < ActiveRecord::Migration
+class AddTimestampsToPrices < ActiveRecord::Migration[4.2]
   def change
     change_table(:spree_prices) { |t| t.timestamps null: true }
   end

--- a/core/db/migrate/20160330204846_add_missing_timestamp_columns.rb
+++ b/core/db/migrate/20160330204846_add_missing_timestamp_columns.rb
@@ -1,4 +1,4 @@
-class AddMissingTimestampColumns < ActiveRecord::Migration
+class AddMissingTimestampColumns < ActiveRecord::Migration[4.2]
   def change
     # Missing updated_at
     add_column :friendly_id_slugs, :updated_at, :datetime, null: true

--- a/core/db/migrate/20160509181311_add_country_iso_to_prices.rb
+++ b/core/db/migrate/20160509181311_add_country_iso_to_prices.rb
@@ -1,4 +1,4 @@
-class AddCountryIsoToPrices < ActiveRecord::Migration
+class AddCountryIsoToPrices < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_prices, :country_iso, :string, null: true, limit: 2
 

--- a/core/db/migrate/20160608162651_ensure_default_store.rb
+++ b/core/db/migrate/20160608162651_ensure_default_store.rb
@@ -1,4 +1,4 @@
-class EnsureDefaultStore < ActiveRecord::Migration
+class EnsureDefaultStore < ActiveRecord::Migration[4.2]
   class Store < ActiveRecord::Base
     self.table_name = 'spree_stores'
   end

--- a/core/db/migrate/20160608180751_ensure_store_on_orders.rb
+++ b/core/db/migrate/20160608180751_ensure_store_on_orders.rb
@@ -1,4 +1,4 @@
-class EnsureStoreOnOrders < ActiveRecord::Migration
+class EnsureStoreOnOrders < ActiveRecord::Migration[4.2]
   class Store < ActiveRecord::Base
     self.table_name = 'spree_stores'
   end

--- a/core/lib/generators/spree/custom_user/templates/migration.rb.tt
+++ b/core/lib/generators/spree/custom_user/templates/migration.rb.tt
@@ -1,4 +1,4 @@
-class AddSpreeFieldsToCustomUserTable < ActiveRecord::Migration
+class AddSpreeFieldsToCustomUserTable < ActiveRecord::Migration[4.2]
   def up
     add_column <%= table_name.inspect %>, :spree_api_key, :string, :limit => 48
     add_column <%= table_name.inspect %>, :ship_address_id, :integer

--- a/core/spec/models/spree/preferences/preferable_spec.rb
+++ b/core/spec/models/spree/preferences/preferable_spec.rb
@@ -224,7 +224,7 @@ describe Spree::Preferences::Preferable, type: :model do
 
   describe "persisted preferables" do
     before(:all) do
-      class CreatePrefTest < ActiveRecord::Migration
+      class CreatePrefTest < ActiveRecord::Migration[4.2]
         def self.up
           create_table :pref_tests do |t|
             t.string :col
@@ -237,8 +237,8 @@ describe Spree::Preferences::Preferable, type: :model do
         end
       end
 
-      @migration_verbosity = ActiveRecord::Migration.verbose
-      ActiveRecord::Migration.verbose = false
+      @migration_verbosity = ActiveRecord::Migration[4.2].verbose
+      ActiveRecord::Migration[4.2].verbose = false
       CreatePrefTest.migrate(:up)
 
       class PrefTest < Spree::Base
@@ -249,7 +249,7 @@ describe Spree::Preferences::Preferable, type: :model do
 
     after(:all) do
       CreatePrefTest.migrate(:down)
-      ActiveRecord::Migration.verbose = @migration_verbosity
+      ActiveRecord::Migration[4.2].verbose = @migration_verbosity
     end
 
     before(:each) do


### PR DESCRIPTION
In Rails 5 `ActiveRecord::Migrations` should have a version specified.

This commit specifies Rails 4.2 as the version for all commits that exist up to this point. 