### PR TITLE
Fix issues related to params being received as strings

### DIFF
--- a/api/spec/controllers/spree/api/line_items_controller_spec.rb
+++ b/api/spec/controllers/spree/api/line_items_controller_spec.rb
@@ -62,12 +62,12 @@ module Spree
       end
 
       it "can add a new line item to an existing order with options" do
-        expect_any_instance_of(LineItem).to receive(:some_option=).with(4)
+        expect_any_instance_of(LineItem).to receive(:some_option=).with("foobar")
         api_post :create,
                  line_item: {
                    variant_id: product.master.to_param,
                    quantity: 1,
-                   options: { some_option: 4 }
+                   options: { some_option: "foobar" }
                  }
         expect(response.status).to eq(201)
       end
@@ -100,11 +100,11 @@ module Spree
       end
 
       it "can update a line item's options on the order" do
-        expect_any_instance_of(LineItem).to receive(:some_option=).with(12)
+        expect_any_instance_of(LineItem).to receive(:some_option=).with("foobar")
         line_item = order.line_items.first
         api_put :update,
                 id: line_item.id,
-                line_item: { quantity: 1, options: { some_option: 12 } }
+                line_item: { quantity: 1, options: { some_option: "foobar" } }
         expect(response.status).to eq(200)
       end
 

--- a/api/spec/controllers/spree/api/orders_controller_spec.rb
+++ b/api/spec/controllers/spree/api/orders_controller_spec.rb
@@ -357,13 +357,13 @@ module Spree
       expect(Order).to receive(:create!).and_return(order = Spree::Order.new)
       allow(order).to receive(:associate_user!)
       allow(order).to receive_message_chain(:contents, :add).and_return(line_item = double('LineItem'))
-      expect(line_item).to receive(:update_attributes!).with("special" => true)
+      expect(line_item).to receive(:update_attributes!).with(hash_including("special" => "foo"))
 
       allow(controller).to receive_messages(permitted_line_item_attributes: [:id, :variant_id, :quantity, :special])
       api_post :create, order: {
         line_items: {
           "0" => {
-            variant_id: variant.to_param, quantity: 5, special: true
+            variant_id: variant.to_param, quantity: 5, special: "foo"
           }
         }
       }

--- a/api/spec/controllers/spree/api/products_controller_spec.rb
+++ b/api/spec/controllers/spree/api/products_controller_spec.rb
@@ -324,7 +324,7 @@ module Spree
         end
 
         it "cannot create a new product with invalid attributes" do
-          api_post :create, product: {}
+          api_post :create, product: { foo: :bar }
           expect(response.status).to eq(422)
           expect(json_response["error"]).to eq("Invalid resource. Please fix errors and try again.")
           errors = json_response["errors"]

--- a/api/spec/controllers/spree/api/taxons_controller_spec.rb
+++ b/api/spec/controllers/spree/api/taxons_controller_spec.rb
@@ -147,7 +147,7 @@ module Spree
       end
 
       it "cannot create a new taxon with invalid attributes" do
-        api_post :create, taxonomy_id: taxonomy.id, taxon: {}
+        api_post :create, taxonomy_id: taxonomy.id, taxon: { foo: :bar }
         expect(response.status).to eq(422)
         expect(json_response["error"]).to eq("Invalid resource. Please fix errors and try again.")
 


### PR DESCRIPTION
In rails 5, controller tests treat `params` more correctly:

* values are converted to a string when posting form data.
* empty hash is not sent (can't be encoded)

Since these aren't realistic scenarios, we shouldn't be testing them.