### PR TITLE
Improved API pagination

### DIFF
--- a/api/app/views/spree/api/countries/index.v1.rabl
+++ b/api/app/views/spree/api/countries/index.v1.rabl
@@ -3,5 +3,5 @@ child(@countries => :countries) do
   attributes *country_attributes
 end
 node(:count) { @countries.count }
-node(:current_page) { params[:page] || 1 }
+node(:current_page) { @countries.current_page }
 node(:pages) { @countries.total_pages }

--- a/api/app/views/spree/api/credit_cards/index.v1.rabl
+++ b/api/app/views/spree/api/credit_cards/index.v1.rabl
@@ -3,5 +3,5 @@ child(@credit_cards => :credit_cards) do
   extends "spree/api/credit_cards/show"
 end
 node(:count) { @credit_cards.count }
-node(:current_page) { params[:page] || 1 }
+node(:current_page) { @credit_cards.current_page }
 node(:pages) { @credit_cards.total_pages }

--- a/api/app/views/spree/api/orders/index.v1.rabl
+++ b/api/app/views/spree/api/orders/index.v1.rabl
@@ -3,5 +3,5 @@ child(@orders => :orders) do
   extends "spree/api/orders/order"
 end
 node(:count) { @orders.count }
-node(:current_page) { params[:page] || 1 }
+node(:current_page) { @orders.current_page }
 node(:pages) { @orders.total_pages }

--- a/api/app/views/spree/api/orders/mine.v1.rabl
+++ b/api/app/views/spree/api/orders/mine.v1.rabl
@@ -5,5 +5,5 @@ child(@orders => :orders) do
 end
 
 node(:count) { @orders.count }
-node(:current_page) { params[:page] || 1 }
+node(:current_page) { @orders.current_page }
 node(:pages) { @orders.total_pages }

--- a/api/app/views/spree/api/payments/index.v1.rabl
+++ b/api/app/views/spree/api/payments/index.v1.rabl
@@ -3,5 +3,5 @@ child(@payments => :payments) do
   attributes *payment_attributes
 end
 node(:count) { @payments.count }
-node(:current_page) { params[:page] || 1 }
+node(:current_page) { @payments.current_page }
 node(:pages) { @payments.total_pages }

--- a/api/app/views/spree/api/product_properties/index.v1.rabl
+++ b/api/app/views/spree/api/product_properties/index.v1.rabl
@@ -3,5 +3,5 @@ child(@product_properties => :product_properties) do
   attributes *product_property_attributes
 end
 node(:count) { @product_properties.count }
-node(:current_page) { params[:page] || 1 }
+node(:current_page) { @product_properties.current_page }
 node(:pages) { @product_properties.total_pages }

--- a/api/app/views/spree/api/products/index.v1.rabl
+++ b/api/app/views/spree/api/products/index.v1.rabl
@@ -2,7 +2,7 @@ object false
 node(:count) { @products.count }
 node(:total_count) { @products.total_count }
 node(:current_page) { @products.current_page }
-node(:per_page) { params[:per_page] || Kaminari.config.default_per_page }
+node(:per_page) { @products.limit_value }
 node(:pages) { @products.total_pages }
 child(@products => :products) do
   extends "spree/api/products/show"

--- a/api/app/views/spree/api/products/index.v1.rabl
+++ b/api/app/views/spree/api/products/index.v1.rabl
@@ -1,7 +1,7 @@
 object false
 node(:count) { @products.count }
 node(:total_count) { @products.total_count }
-node(:current_page) { params[:page] ? params[:page].to_i : 1 }
+node(:current_page) { @products.current_page }
 node(:per_page) { params[:per_page] || Kaminari.config.default_per_page }
 node(:pages) { @products.total_pages }
 child(@products => :products) do

--- a/api/app/views/spree/api/properties/index.v1.rabl
+++ b/api/app/views/spree/api/properties/index.v1.rabl
@@ -3,5 +3,5 @@ child(@properties => :properties) do
   attributes *property_attributes
 end
 node(:count) { @properties.count }
-node(:current_page) { params[:page] || 1 }
+node(:current_page) { @properties.current_page }
 node(:pages) { @properties.total_pages }

--- a/api/app/views/spree/api/return_authorizations/index.v1.rabl
+++ b/api/app/views/spree/api/return_authorizations/index.v1.rabl
@@ -3,5 +3,5 @@ child(@return_authorizations => :return_authorizations) do
   attributes *return_authorization_attributes
 end
 node(:count) { @return_authorizations.count }
-node(:current_page) { params[:page] || 1 }
+node(:current_page) { @return_authorizations.current_page }
 node(:pages) { @return_authorizations.total_pages }

--- a/api/app/views/spree/api/shipments/mine.v1.rabl
+++ b/api/app/views/spree/api/shipments/mine.v1.rabl
@@ -1,7 +1,7 @@
 object false
 
 node(:count) { @shipments.count }
-node(:current_page) { params[:page] || 1 }
+node(:current_page) { @shipments.current_page }
 node(:pages) { @shipments.total_pages }
 
 child(@shipments => :shipments) do

--- a/api/app/views/spree/api/states/index.v1.rabl
+++ b/api/app/views/spree/api/states/index.v1.rabl
@@ -9,6 +9,6 @@ end
 
 if @states.respond_to?(:total_pages)
   node(:count) { @states.count }
-  node(:current_page) { params[:page] || 1 }
+  node(:current_page) { @states.current_page }
   node(:pages) { @states.total_pages }
 end

--- a/api/app/views/spree/api/stock_items/index.v1.rabl
+++ b/api/app/views/spree/api/stock_items/index.v1.rabl
@@ -3,5 +3,5 @@ child(@stock_items => :stock_items) do
   extends 'spree/api/stock_items/show'
 end
 node(:count) { @stock_items.count }
-node(:current_page) { params[:page] || 1 }
+node(:current_page) { @stock_items.current_page }
 node(:pages) { @stock_items.total_pages }

--- a/api/app/views/spree/api/stock_locations/index.v1.rabl
+++ b/api/app/views/spree/api/stock_locations/index.v1.rabl
@@ -3,5 +3,5 @@ child(@stock_locations => :stock_locations) do
   extends 'spree/api/stock_locations/show'
 end
 node(:count) { @stock_locations.count }
-node(:current_page) { params[:page] || 1 }
+node(:current_page) { @stock_locations.current_page }
 node(:pages) { @stock_locations.total_pages }

--- a/api/app/views/spree/api/stock_movements/index.v1.rabl
+++ b/api/app/views/spree/api/stock_movements/index.v1.rabl
@@ -3,5 +3,5 @@ child(@stock_movements => :stock_movements) do
   extends 'spree/api/stock_movements/show'
 end
 node(:count) { @stock_movements.count }
-node(:current_page) { params[:page] || 1 }
+node(:current_page) { @stock_movements.current_page }
 node(:pages) { @stock_movements.total_pages }

--- a/api/app/views/spree/api/store_credit_events/mine.v1.rabl
+++ b/api/app/views/spree/api/store_credit_events/mine.v1.rabl
@@ -6,5 +6,5 @@ child(@store_credit_events => :store_credit_events) do
 end
 
 node(:count) { @store_credit_events.count }
-node(:current_page) { params[:page] || 1 }
+node(:current_page) { @store_credit_events.current_page }
 node(:pages) { @store_credit_events.total_pages }

--- a/api/app/views/spree/api/taxonomies/index.v1.rabl
+++ b/api/app/views/spree/api/taxonomies/index.v1.rabl
@@ -3,5 +3,5 @@ child(@taxonomies => :taxonomies) do
   extends "spree/api/taxonomies/show"
 end
 node(:count) { @taxonomies.count }
-node(:current_page) { params[:page] || 1 }
+node(:current_page) { @taxonomies.current_page }
 node(:pages) { @taxonomies.total_pages }

--- a/api/app/views/spree/api/taxons/index.v1.rabl
+++ b/api/app/views/spree/api/taxons/index.v1.rabl
@@ -2,7 +2,7 @@ object false
 node(:count) { @taxons.count }
 node(:total_count) { @taxons.total_count }
 node(:current_page) { @taxons.current_page }
-node(:per_page) { params[:per_page] || Kaminari.config.default_per_page }
+node(:per_page) { @taxons.limit_value }
 node(:pages) { @taxons.total_pages }
 child @taxons => :taxons do
   attributes *taxon_attributes

--- a/api/app/views/spree/api/taxons/index.v1.rabl
+++ b/api/app/views/spree/api/taxons/index.v1.rabl
@@ -1,7 +1,7 @@
 object false
 node(:count) { @taxons.count }
 node(:total_count) { @taxons.total_count }
-node(:current_page) { params[:page] ? params[:page].to_i : 1 }
+node(:current_page) { @taxons.current_page }
 node(:per_page) { params[:per_page] || Kaminari.config.default_per_page }
 node(:pages) { @taxons.total_pages }
 child @taxons => :taxons do

--- a/api/app/views/spree/api/users/index.v1.rabl
+++ b/api/app/views/spree/api/users/index.v1.rabl
@@ -3,5 +3,5 @@ child(@users => :users) do
   extends "spree/api/users/show"
 end
 node(:count) { @users.count }
-node(:current_page) { params[:page] || 1 }
+node(:current_page) { @users.current_page }
 node(:pages) { @users.total_pages }

--- a/api/app/views/spree/api/variants/index.v1.rabl
+++ b/api/app/views/spree/api/variants/index.v1.rabl
@@ -1,7 +1,7 @@
 object false
 node(:count) { @variants.count }
 node(:total_count) { @variants.total_count }
-node(:current_page) { params[:page] ? params[:page].to_i : 1 }
+node(:current_page) { @variants.current_page }
 node(:pages) { @variants.total_pages }
 
 child(@variants => :variants) do

--- a/api/app/views/spree/api/zones/index.v1.rabl
+++ b/api/app/views/spree/api/zones/index.v1.rabl
@@ -3,5 +3,5 @@ child(@zones => :zones) do
   extends 'spree/api/zones/show'
 end
 node(:count) { @zones.count }
-node(:current_page) { params[:page] || 1 }
+node(:current_page) { @zones.current_page }
 node(:pages) { @zones.total_pages }

--- a/api/spec/controllers/spree/api/states_controller_spec.rb
+++ b/api/spec/controllers/spree/api/states_controller_spec.rb
@@ -24,27 +24,14 @@ module Spree
     end
 
     context "pagination" do
-      before do
-        expect(State).to receive(:accessible_by).and_return(@scope = double)
-        allow(@scope).to receive_message_chain(:ransack, :result, :includes, :order).and_return(@scope)
-      end
+      it "can select the next page and control page size" do
+        create(:state)
+        api_get :index, page: 2, per_page: 1
 
-      it "does not paginate states results when asked not to do so" do
-        expect(@scope).not_to receive(:page)
-        expect(@scope).not_to receive(:per)
-        api_get :index
-      end
-
-      it "paginates when page parameter is passed through" do
-        expect(@scope).to receive(:page).with(1).and_return(@scope)
-        expect(@scope).to receive(:per).with(nil)
-        api_get :index, page: 1
-      end
-
-      it "paginates when per_page parameter is passed through" do
-        expect(@scope).to receive(:page).with(nil).and_return(@scope)
-        expect(@scope).to receive(:per).with(25)
-        api_get :index, per_page: 25
+        expect(json_response["states"].size).to eq(1)
+        expect(json_response["pages"]).to eq(2)
+        expect(json_response["current_page"]).to eq(2)
+        expect(json_response["count"]).to eq(1)
       end
     end
 


### PR DESCRIPTION
## current_page

Previously, when displaying the current page in an API response, we used `params[:page]` when displaying the current page.

In many places we were using `params[:page] || 1`, which will display the page as a string (`"current_page":"2"` for `?page=2`). In other places we used `params[:page] ? params[:page].to_i : 1`, which usually displayed the page correctly as an integer, but would display `"current_page": 0` for non-integer input (`?page=foo`), even though the page was actually `1`.

Kaminari adds a `current_page` method to the scope, so we should just use that.

## per_page

We only displayed the `per_page` value in two places using `params[:per_page] || Kaminari.config.default_per_page`. This had the same problem of displaying a string instead of an integer. I've replaced this with `.limit_value`

