### PR TITLE
Add by_store scope to #set_current_order

### DIFF
--- a/core/lib/spree/core/controller_helpers/order.rb
+++ b/core/lib/spree/core/controller_helpers/order.rb
@@ -59,7 +59,7 @@ module Spree
 
         def set_current_order
           if try_spree_current_user && current_order
-            try_spree_current_user.orders.incomplete.where('id != ?', current_order.id).each do |order|
+            try_spree_current_user.orders.incomplete.by_store(current_store).where('id != ?', current_order.id).each do |order|
               current_order.merge!(order, try_spree_current_user)
             end
           end


### PR DESCRIPTION
On a multi domain site we've had carts in other stores being merged together for logged in users. Adding the by_store scope fixed this.

Happy to wrap in a regression test.