### PR TITLE
Hide clear selection if no clear option.

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
+++ b/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
@@ -30,6 +30,7 @@
     .select2-search-choice-close {
       @extend .fa;
       @extend .fa-times;
+      display: none;
       margin-top: 2px;
       font-size: 100% !important;
       background-image: none !important;


### PR DESCRIPTION
See commit message on f5b07f0 for rational. After applying this commit selects work [as specified in the select2 documentation](http://select2.github.io/select2/#placeholders). See:

![With and without clear](https://cloud.githubusercontent.com/assets/43233/16696018/e1742420-4510-11e6-9f4b-7fc79eba8c7b.png)

Note how the first one can be cleared but the second one cannot. The second one does not have a blank option while the first does. I also verified this didn't mess with multi-selects:

![Multi-select](https://cloud.githubusercontent.com/assets/43233/16696039/ff293af0-4510-11e6-8292-8f69b8c3b4c9.png)

