### PR TITLE
Move product SKUs list to a tooltip hint

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
@@ -130,7 +130,6 @@ button, .button {
 span.info {
   font-size: 85%;
   color: lighten($color-body-text, 15);
-  display: block;
   line-height: 20px;
   margin: 5px 0;
   .field & {

--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -85,7 +85,7 @@
           <%=
             admin_hint(
               Spree.t(:skus),
-                product.variants.order("sku ASC").map{ |variant| variant.sku }.join(", ")
+                @product.variants.order("sku ASC").map{ |variant| variant.sku }.join(", ")
               )
           %>
           <div class="info-actions">

--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -78,21 +78,21 @@
     <% if @product.has_variants? %>
       <div data-hook="admin_product_form_multiple_variants">
         <%= f.label :skus, Spree.t(:skus) %>
-        <span class="info">
-          <%= Spree.t(:info_product_has_multiple_skus, count: @product.variants.count) %>
-          <ul class="text_list">
-            <% @product.variants.first(5).each do |variant| %>
-              <li><%= link_to variant.sku, spree.edit_admin_product_variant_path(@product, variant) %></li>
+        <div class="info-multiple_skus">
+          <span class="info">
+            <%= Spree.t(:info_product_has_multiple_skus, count: @product.variants.count) %>
+          </span>
+          <%=
+            admin_hint(
+              Spree.t(:skus),
+                product.variants.order("sku ASC").map{ |variant| variant.sku }.join(", ")
+              )
+          %>
+          <div class="info-actions">
+            <% if can?(:admin, Spree::Variant) %>
+              <%= link_to_with_icon 'th-large', Spree.t(:manage_variants), admin_product_variants_url(@product) %>
             <% end %>
-          </ul>
-          <% if @product.variants.count > 5 %>
-            <%= Spree.t(:info_number_of_skus_not_shown, count: @product.variants.count - 5) %>
-          <% end %>
-        </span>
-        <div class="info-actions">
-          <% if can?(:admin, Spree::Variant) %>
-            <%= link_to_with_icon 'th-large', Spree.t(:manage_variants), admin_product_variants_url(@product) %>
-          <% end %>
+          </div>
         </div>
       </div>
     <% else %>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1168,10 +1168,7 @@ en:
     included_in_price: Included in Price
     included_price_validation: cannot be selected unless you have set a Default Tax Zone
     incomplete: Incomplete
-    info_product_has_multiple_skus: "This product has %{count} variants:"
-    info_number_of_skus_not_shown:
-      one: "and one other"
-      other: "and %{count} others"
+    info_product_has_multiple_skus: "This product has %{count} variant SKUs."
     instructions_to_reset_password: Please enter your email on the form below
     insufficient_stock: Insufficient stock available, only %{on_hand} remaining
     insufficient_stock_for_order: Insufficient stock for order


### PR DESCRIPTION
When editing products with multiple SKUs, we have some explanatory text and a list of five SKUs. This was intended to help beginners understand why they can't edit the SKU for a product, and guide them to editing the variants instead.

Now that we have tooltip hints in admin, it's tidier to move the list of SKUs into one of those. As a side-effect, we no longer have to limit the list to five SKUs, as the text isn't cluttering up the visible edit page.

One downside is that we lose links to edit the variants. However, the Manage Variants link is still present, and arguably provides more guidance for beginners to understand the relationship between products and variants.