### PR TITLE
Add no-border CSS class to payment method handle

### DIFF
--- a/backend/app/views/spree/admin/payment_methods/index.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/index.html.erb
@@ -25,7 +25,7 @@
     </colgroup>
     <thead>
       <tr data-hook="admin_payment_methods_index_headers">
-        <th></th>
+        <th class="no-border"></th>
         <th><%= Spree::PaymentMethod.human_attribute_name(:name) %></th>
         <th><%= Spree::PaymentMethod.human_attribute_name(:type) %></th>
         <th><%= Spree::PaymentMethod.human_attribute_name(:display_on) %></th>


### PR DESCRIPTION
These were recently made sortable. Needs a tiny tweak to remove an out-of-place looking separator.

Before:
![](http://i.hawth.ca/s/klkAMan6.png)

After:
![](http://i.hawth.ca/s/8YOPO5kD.png)

This matches the other sortable tables in the admin