### PR TITLE
Add note of default admin username/password

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ bundle exec rails s
 The [`solidus_frontend`](https://github.com/solidusio/solidus/tree/master/frontend) storefront will be accessible at [http://localhost:3000/](http://localhost:3000/)
 and the admin can be found at [http://localhost:3000/admin/](http://localhost:3000/admin/).
 
+### Default Username/Password
+
+As part of running the above installation steps, you will be asked to set an admin email/password combination. The default values are `admin@example.com` and `test123`, respectively.
 
 Installation options
 --------------------


### PR DESCRIPTION
These defaults are hidden in a strange place in solidus-auth-devise, and
it's possible to miss the prompt during setup, or otherwise forget these
default credentials. So, let's make it a bit easier to get started, by
making it more clear how to login to a new store.

Somewhat, but not completely, corrects #1319.