### PR TITLE
Remove uppercase styles and bump up font size

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/components/_date-picker.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_date-picker.scss
@@ -86,7 +86,6 @@
 
     .ui-datepicker-title {
       color: $color-1;
-      text-transform: uppercase;
       font-size: 85% !important;
       padding: 6px 10px;
     }

--- a/backend/app/assets/stylesheets/spree/backend/components/_navigation.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_navigation.scss
@@ -13,7 +13,6 @@ nav.menu {
         position: relative;
         text-align: left;
         border: 1px solid transparent;
-        text-transform: uppercase;
         font-weight: $font-weight-bold;
         font-size: 90%;
       }

--- a/backend/app/assets/stylesheets/spree/backend/components/_progress.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_progress.scss
@@ -28,10 +28,9 @@
   }
 
   .progress-message {
-    font-size: 120%;
+    font-size: 130%;
     font-weight: $font-weight-bold;
     margin-top: 20px;
-    text-transform: uppercase;
   }
 }
 

--- a/backend/app/assets/stylesheets/spree/backend/components/_sidebar.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_sidebar.scss
@@ -5,9 +5,8 @@ body:not(.new-layout) #sidebar {
 
   .sidebar-title {
     color: $color-2;
-    text-transform: uppercase;
     text-align: center;
-    font-size: 14px;
+    font-size: 16px;
     font-weight: $font-weight-bold;
 
     > span {

--- a/backend/app/assets/stylesheets/spree/backend/components/_states.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_states.scss
@@ -1,6 +1,5 @@
 .state {
-  text-transform: uppercase;
-  font-size: 80%;
+  font-size: 90%;
   font-weight: $font-weight-bold;
 
   &:before {

--- a/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
+++ b/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
@@ -151,7 +151,6 @@
       color: $color-body-text;
       text-align: center;
       font-weight: $font-weight-bold;
-      text-transform: uppercase;
     }
   }
 

--- a/backend/app/assets/stylesheets/spree/backend/sections/_products.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/_products.scss
@@ -47,7 +47,6 @@ div[data-hook="admin_products_index_search_buttons"] {
 
 .outstanding-balance {
   margin-bottom: 15px;
-  text-transform: uppercase;
 
   strong {
     color: $color-2;

--- a/backend/app/assets/stylesheets/spree/backend/sections/_promotions.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/_promotions.scss
@@ -122,7 +122,6 @@
 }
 
 .promotion-title {
-  text-transform: uppercase;
   text-align: left;
   font-size: 85%;
   border-bottom: 1px solid $color-border;

--- a/backend/app/assets/stylesheets/spree/backend/sections/_transfer_items.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/_transfer_items.scss
@@ -21,7 +21,6 @@
   }
   .summary-field {
     font-weight: 600;
-    text-transform: uppercase;
     font-size: 105%;
   }
   .arrow {

--- a/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
@@ -72,8 +72,7 @@ textarea {
 
 label {
   font-weight: $font-weight-bold;
-  text-transform: uppercase;
-  font-size: 85%;
+  font-size: 90%;
   display: inline;
   margin-bottom: 5px;
   color: $color-4;
@@ -102,7 +101,6 @@ button, .button {
   border-radius: $border-radius;
   background-color: $color-btn-bg;
   color: $color-btn-text;
-  text-transform: uppercase;
   font-weight: $font-weight-bold !important;
   white-space: nowrap;
 
@@ -228,9 +226,8 @@ fieldset {
   legend {
     background-color: $color-1;
     color: $color-2;
-    font-size: 14px;
+    font-size: 16px;
     font-weight: $font-weight-bold;
-    text-transform: uppercase;
     text-align: center;
     padding: 8px 15px;
     width: auto;

--- a/backend/app/assets/stylesheets/spree/backend/shared/_tables.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_tables.scss
@@ -134,9 +134,8 @@ table {
       border-top: 1px solid $color-border;
       border-bottom: none;
       background-color: $color-tbl-thead;
-      text-transform: uppercase;
       text-align: center;
-      font-size: 85%;
+      font-size: 90%;
       font-weight: $font-weight-bold;
     }
   }
@@ -202,7 +201,6 @@ table {
     &.grand-total {
       td {
         border-color: $color-2 !important;
-        text-transform: uppercase;
         font-size: 110%;
         font-weight: $font-weight-bold;
         background-color: lighten($color-2, 50);

--- a/backend/app/assets/stylesheets/spree/backend/shared/_typography.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_typography.scss
@@ -102,7 +102,6 @@ dl {
     width: 40%;
     font-weight: $font-weight-bold;
     padding-left: 0;
-    text-transform: uppercase;
     font-size: 85%;
     clear: left;
   }
@@ -136,7 +135,6 @@ dl {
 .no-objects-found {
   text-align: center;
   font-size: 120%;
-  text-transform: uppercase;
   padding: 40px 0px;
   color: lighten($color-body-text, 15);
 }

--- a/backend/spec/features/admin/configuration/payment_methods_spec.rb
+++ b/backend/spec/features/admin/configuration/payment_methods_spec.rb
@@ -73,16 +73,16 @@ describe "Payment Methods", type: :feature do
       create(:credit_card_payment_method)
       click_link "Payment Methods"
       click_icon :edit
-      expect(page).to have_content('TEST MODE')
+      expect(page).to have_content('Test Mode')
 
       select2_search 'Spree::PaymentMethod::Check', from: 'Provider'
       expect(page).to have_content('you must save first')
-      expect(page).to have_no_content('TEST MODE')
+      expect(page).to have_no_content('Test Mode')
 
       # change back
       select2_search 'Spree::Gateway::Bogus', from: 'Provider'
       expect(page).to have_no_content('you must save first')
-      expect(page).to have_content('TEST MODE')
+      expect(page).to have_content('Test Mode')
     end
 
     it "displays message when changing preference source" do
@@ -91,16 +91,16 @@ describe "Payment Methods", type: :feature do
       create(:credit_card_payment_method)
       click_link "Payment Methods"
       click_icon :edit
-      expect(page).to have_content('TEST MODE')
+      expect(page).to have_content('Test Mode')
 
       select2_search 'my_prefs', from: 'Preference Source'
       expect(page).to have_content('you must save first')
-      expect(page).to have_no_content('TEST MODE')
+      expect(page).to have_no_content('Test Mode')
 
       # change back
       select2_search 'Custom', from: 'Preference Source'
       expect(page).to have_no_content('you must save first')
-      expect(page).to have_content('TEST MODE')
+      expect(page).to have_content('Test Mode')
     end
 
     it "updates successfully and keeps secrets" do
@@ -118,7 +118,7 @@ describe "Payment Methods", type: :feature do
       # change back
       select2_search 'Custom', from: 'Preference Source'
       click_on 'Update'
-      expect(page).to have_content('TEST MODE')
+      expect(page).to have_content('Test Mode')
       expect(page).to have_no_content('secret')
     end
   end

--- a/backend/spec/features/admin/configuration/stock_locations_spec.rb
+++ b/backend/spec/features/admin/configuration/stock_locations_spec.rb
@@ -32,7 +32,7 @@ describe "Stock Locations", type: :feature do
     # Wait for API request to complete.
     wait_for_ajax
     visit current_path
-    expect(page).to have_content("NO STOCK LOCATIONS FOUND")
+    expect(page).to have_content("No Stock Locations found")
   end
 
   it "can update an existing stock location" do

--- a/backend/spec/features/admin/orders/adjustments_spec.rb
+++ b/backend/spec/features/admin/orders/adjustments_spec.rb
@@ -119,7 +119,7 @@ describe "Adjustments", type: :feature do
         end
       end
 
-      expect(page).to have_content(/TOTAL: ?\$170\.00/)
+      expect(page).to have_content(/Total: ?\$170\.00/)
     end
   end
 end

--- a/backend/spec/features/admin/orders/customer_details_spec.rb
+++ b/backend/spec/features/admin/orders/customer_details_spec.rb
@@ -89,7 +89,7 @@ describe "Customer Details", type: :feature, js: true do
       # Regression test for https://github.com/spree/spree/issues/2950 and https://github.com/spree/spree/issues/2433
       # This act should transition the state of the order as far as it will go too
       within("#order_tab_summary") do
-        expect(find("dt#order_status + dd")).to have_content("COMPLETE")
+        expect(find("dt#order_status + dd")).to have_content("complete")
       end
     end
 

--- a/backend/spec/features/admin/orders/listing_spec.rb
+++ b/backend/spec/features/admin/orders/listing_spec.rb
@@ -17,7 +17,7 @@ describe "Orders Listing", type: :feature, js: true do
     it "should list existing orders" do
       within_row(1) do
         expect(column_text(2)).to eq "R100"
-        expect(column_text(3)).to eq "CART"
+        expect(column_text(3)).to eq "cart"
       end
 
       within_row(2) do

--- a/backend/spec/features/admin/orders/new_order_spec.rb
+++ b/backend/spec/features/admin/orders/new_order_spec.rb
@@ -56,7 +56,7 @@ describe "New Order", type: :feature do
     click_on "ship"
 
     within '.carton-state' do
-      expect(page).to have_content('SHIPPED')
+      expect(page).to have_content('shipped')
     end
   end
 
@@ -173,7 +173,7 @@ describe "New Order", type: :feature do
       click_on "Continue"
 
       within(".additional-info .state") do
-        expect(page).to have_content("CONFIRM")
+        expect(page).to have_content("confirm")
       end
     end
   end

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -63,7 +63,7 @@ describe "Order Details", type: :feature, js: true do
           end
         end
 
-        expect(page).to have_content("YOUR ORDER IS EMPTY") # wait for page refresh
+        expect(page).to have_content("Your order is empty") # wait for page refresh
         expect(page).not_to have_content("spree t-shirt")
       end
 
@@ -154,7 +154,7 @@ describe "Order Details", type: :feature, js: true do
 
           expect(page).to have_selector('.select2-no-results')
           within(".select2-no-results") do
-            expect(page).to have_content("NO MATCHES FOUND")
+            expect(page).to have_content("No matches found")
           end
         end
       end
@@ -197,7 +197,7 @@ describe "Order Details", type: :feature, js: true do
             within_row(1) { click_icon 'arrows-h' }
             complete_split_to(stock_location2, quantity: 2)
 
-            expect(page).to have_content("PENDING PACKAGE FROM 'CLARKSVILLE'")
+            expect(page).to have_content("pending package from 'Clarksville'")
 
             expect(order.shipments.count).to eq(1)
             expect(order.shipments.last.backordered?).to eq(false)
@@ -211,7 +211,7 @@ describe "Order Details", type: :feature, js: true do
             within_row(1) { click_icon 'arrows-h' }
             complete_split_to(stock_location2, quantity: 5)
 
-            expect(page).to have_content("PENDING PACKAGE FROM 'CLARKSVILLE'")
+            expect(page).to have_content("pending package from 'Clarksville'")
 
             expect(order.shipments.count).to eq(1)
             expect(order.shipments.last.backordered?).to eq(false)
@@ -294,7 +294,7 @@ describe "Order Details", type: :feature, js: true do
               within_row(1) { click_icon 'arrows-h' }
               complete_split_to(stock_location2, quantity: 2)
 
-              expect(page).to have_content("PENDING PACKAGE FROM 'CLARKSVILLE'")
+              expect(page).to have_content("pending package from 'Clarksville'")
 
               expect(order.shipments.count).to eq(1)
               expect(order.shipments.first.inventory_units_for(product.master).count).to eq(2)
@@ -507,7 +507,7 @@ describe "Order Details", type: :feature, js: true do
       wait_for_ajax
 
       within '.carton-state' do
-        expect(page).to have_content('SHIPPED')
+        expect(page).to have_content('shipped')
       end
     end
   end

--- a/backend/spec/features/admin/orders/payments_spec.rb
+++ b/backend/spec/features/admin/orders/payments_spec.rb
@@ -66,17 +66,17 @@ describe 'Payments', type: :feature do
       within_row(1) do
         expect(column_text(3)).to eq('$150.00')
         expect(column_text(4)).to eq('Credit Card')
-        expect(column_text(6)).to eq('CHECKOUT')
+        expect(column_text(6)).to eq('checkout')
       end
 
       click_icon :void
-      expect(page).to have_css('#payment_status', text: 'BALANCE DUE')
+      expect(page).to have_css('#payment_status', text: 'balance due')
       expect(page).to have_content('Payment Updated')
 
       within_row(1) do
         expect(column_text(3)).to eq('$150.00')
         expect(column_text(4)).to eq('Credit Card')
-        expect(column_text(6)).to eq('VOID')
+        expect(column_text(6)).to eq('void')
       end
 
       click_on 'New Payment'
@@ -86,7 +86,7 @@ describe 'Payments', type: :feature do
 
       click_icon(:capture)
 
-      expect(page).to have_selector('#payment_status', text: 'PAID')
+      expect(page).to have_selector('#payment_status', text: 'paid')
       expect(page).not_to have_selector('#new_payment_section')
     end
 

--- a/backend/spec/features/admin/orders/shipments_spec.rb
+++ b/backend/spec/features/admin/orders/shipments_spec.rb
@@ -34,7 +34,7 @@ describe "Shipments", type: :feature do
       find(".ship-shipment-button").click
       wait_for_ajax
 
-      expect(page).to have_content("SHIPPED PACKAGE")
+      expect(page).to have_content("shipped package")
       expect(order.reload.shipment_state).to eq("shipped")
     end
   end

--- a/backend/spec/features/admin/products/edit/variants_spec.rb
+++ b/backend/spec/features/admin/products/edit/variants_spec.rb
@@ -16,7 +16,7 @@ describe "Product Variants", type: :feature do
       within_row(1) { click_icon :edit }
 
       within('nav > ul.tabs') { click_link "Variants" }
-      expect(page).to have_content("TO ADD VARIANTS, YOU MUST FIRST DEFINE")
+      expect(page).to have_content("To add variants, you must first define")
     end
 
     it "allows admin to create a variant if there are option types" do

--- a/backend/spec/features/admin/products/option_types_spec.rb
+++ b/backend/spec/features/admin/products/option_types_spec.rb
@@ -27,7 +27,7 @@ describe "Option Types", type: :feature do
     it "should allow an admin to create a new option type", js: true do
       click_link "Option Types"
       click_link "new_option_type_link"
-      expect(page).to have_content("NEW OPTION TYPE")
+      expect(page).to have_content("New Option Type")
       fill_in "option_type_name", with: "shirt colors"
       fill_in "option_type_presentation", with: "colors"
       click_button "Create"

--- a/backend/spec/features/admin/products/products_spec.rb
+++ b/backend/spec/features/admin/products/products_spec.rb
@@ -317,7 +317,7 @@ describe "Products", type: :feature do
       it 'should add option_types when selecting a prototype' do
         visit spree.admin_product_path(product)
         click_link 'Product Properties'
-        expect(page).to have_content("SELECT FROM PROTOTYPE")
+        expect(page).to have_content("Select From Prototype")
         click_link "Select From Prototype"
 
         row = find('#prototypes tr', text: 'Size')

--- a/backend/spec/features/admin/products/properties_spec.rb
+++ b/backend/spec/features/admin/products/properties_spec.rb
@@ -44,7 +44,7 @@ describe "Properties", type: :feature do
     it "should allow an admin to create a new product property", js: true do
       click_link "Property Types"
       click_link "new_property_link"
-      within('#new_property') { expect(page).to have_content("NEW PROPERTY") }
+      within('#new_property') { expect(page).to have_content("New Property Type") }
 
       fill_in "property_name", with: "color of band"
       fill_in "property_presentation", with: "color"

--- a/backend/spec/features/admin/products/prototypes_spec.rb
+++ b/backend/spec/features/admin/products/prototypes_spec.rb
@@ -48,7 +48,7 @@ describe "Prototypes", type: :feature do
       click_link "Prototypes"
       click_link "new_prototype_link"
       within('#new_prototype') do
-        expect(page).to have_content("NEW PROTOTYPE")
+        expect(page).to have_content("New Prototype")
       end
       fill_in "prototype_name", with: "male shirts"
       click_button "Create"

--- a/backend/spec/features/admin/promotion_adjustments_spec.rb
+++ b/backend/spec/features/admin/promotion_adjustments_spec.rb
@@ -148,7 +148,7 @@ describe "Promotion Adjustments", type: :feature do
 
       select2 "Free shipping", from: "Add action of type"
       within('#action_fields') { click_button "Add" }
-      expect(page).to have_content('MAKES ALL SHIPMENTS FOR THE ORDER FREE')
+      expect(page).to have_content('Makes all shipments for the order free')
 
       promotion = Spree::Promotion.find_by_name("Promotion")
       expect(promotion.codes).to be_empty

--- a/backend/spec/features/admin/promotions/option_value_rule_spec.rb
+++ b/backend/spec/features/admin/promotions/option_value_rule_spec.rb
@@ -18,8 +18,8 @@ feature 'Promotion with option value rule' do
     within("#rules_container") { click_button "Add" }
 
     within("#rules_container .promotion-block") do
-      expect(page).to have_content("PRODUCT")
-      expect(page).to have_content("OPTION VALUES")
+      expect(page).to have_content("Product")
+      expect(page).to have_content("Option Values")
 
       click_button "Add"
     end

--- a/backend/spec/features/admin/promotions/tiered_calculator_spec.rb
+++ b/backend/spec/features/admin/promotions/tiered_calculator_spec.rb
@@ -17,8 +17,8 @@ feature "Tiered Calculator Promotions" do
     within('#actions_container') { click_button "Update" }
 
     within("#actions_container .settings") do
-      expect(page).to have_content("BASE PERCENT")
-      expect(page).to have_content("TIERS")
+      expect(page).to have_content("Base Percent")
+      expect(page).to have_content("Tiers")
 
       click_button "Add"
     end


### PR DESCRIPTION
All uppercase text is harder to read because there's less definition between
each individual letterform. Sentence or title casing is each to scan.

I've removed the text transforms and then bumped up the font size just a bit
to make the font take up the same amount of space width-wise. I'd rather wait
until the new layouts are in and I understand space constraints before making
the fonts take up more space than what they currently do. 

This is a small part of the admin rebranding #520.

<img width="977" alt="screen shot 2016-07-12 at 10 39 56 am" src="https://cloud.githubusercontent.com/assets/15271353/16777074/0500ba48-481d-11e6-9fce-c6c286314901.png">
