### PR TITLE
Simplify handling AC::Params in PaymentCreate

### DIFF
--- a/core/app/models/spree/payment_create.rb
+++ b/core/app/models/spree/payment_create.rb
@@ -2,7 +2,7 @@ module Spree
   # Service object for creating new payments on an Order
   class PaymentCreate
     # @param order [Order] The order for the new payment
-    # @param attributes [Hash] attributes which are assigned to the new payment
+    # @param attributes [Hash,ActionController::Parameters] attributes which are assigned to the new payment
     #   * :payment_method_id Id of payment method used for this payment
     #   * :source_attributes Attributes used to build the source of this payment. Usually a {CreditCard}
     #     * :existing_card_id (Integer) The id of an existing {CreditCard} object to use
@@ -11,7 +11,10 @@ module Spree
     def initialize(order, attributes, payment: nil, request_env: {})
       @order = order
       @payment = payment
-      @attributes = attributes.dup.with_indifferent_access
+
+      # If AC::Params are passed in, attributes.to_h gives us a hash of only
+      # the permitted attributes.
+      @attributes = attributes.to_h.with_indifferent_access
       @source_attributes = @attributes.delete(:source_attributes) || {}
       @request_env = request_env
     end

--- a/core/spec/models/spree/payment_create_spec.rb
+++ b/core/spec/models/spree/payment_create_spec.rb
@@ -43,6 +43,12 @@ module Spree
         expect(new_payment.source.payment_method_id).to eq payment_method.id
       end
 
+      it "doesn't modify passed-in hash" do
+        original = attributes.dup
+        new_payment
+        expect(original).to eq(attributes)
+      end
+
       context "when payment source not valid" do
         let(:attributes) do
           {

--- a/core/spec/models/spree/payment_create_spec.rb
+++ b/core/spec/models/spree/payment_create_spec.rb
@@ -150,8 +150,12 @@ module Spree
       context "unpermitted" do
         let(:attributes) { ActionController::Parameters.new(valid_attributes) }
 
-        it "raises ForbiddenAttributesError" do
-          expect { new_payment }.to raise_error(ActiveModel::ForbiddenAttributesError)
+        it "ignores all attributes" do
+          expect(new_payment).to have_attributes(
+            amount: 0,
+            payment_method: nil,
+            source: nil
+          )
         end
       end
 


### PR DESCRIPTION
Previously, if PaymentCreate was passed attributes as `ActionController::Parameters` it would eventually pass them as `ActionController::Parameters` to `ActiveRecord`. This worked and was safe, but difficult to reason about.

This PR instead immediately converts the attributes to a hash of just the sanitized attributes. This is easier to reason about and verify its safety.

This change is needed for rails5 because the behaviour of `ActionController::Parameters#with_indifferent_access` has changed now that the class is no longer a subclass of `HashWithIndifferentAccess`.