### PR TITLE
Sensibly update shipment rates

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -208,8 +208,13 @@ module Spree
     end
 
     def selected_shipping_rate_id=(id)
-      shipping_rates.update_all(selected: false)
-      shipping_rates.update(id, selected: true)
+      selected_shipping_rate.update(selected: false) if selected_shipping_rate
+      new_rate = shipping_rates.detect { |rate| rate.id == id.to_i }
+      fail(
+        ArgumentError,
+        "Could not find shipping rate id #{id} for shipment #{number}"
+      ) unless new_rate
+      new_rate.update(selected: true)
       save!
     end
 

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -810,13 +810,13 @@ describe Spree::Shipment, type: :model do
       it 'sets the new shipping rate as selected' do
         expect {
           shipment.selected_shipping_rate_id = new_rate.id
-        }.to change { new_rate.reload.selected }.from(false).to(true)
+        }.to change { new_rate.selected }.from(false).to(true)
       end
 
       it 'sets the old shipping rate as not selected' do
         expect {
           shipment.selected_shipping_rate_id = new_rate.id
-        }.to change { shipping_rate.reload.selected }.from(true).to(false)
+        }.to change { shipping_rate.selected }.from(true).to(false)
       end
     end
 
@@ -824,7 +824,7 @@ describe Spree::Shipment, type: :model do
       it 'raises a RecordNotFound error' do
         expect {
           shipment.selected_shipping_rate_id = -1
-        }.to raise_error(ActiveRecord::RecordNotFound)
+        }.to raise_error(ArgumentError)
       end
     end
   end


### PR DESCRIPTION
This updates both the ruby objects and the database when assigning shipping
rates. It then removes the need for reloading the object to see the changes
that have happened.