### PR TITLE
Refactor shipping_specs on admin product form

### DIFF
--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -104,22 +104,12 @@
       </div>
 
       <div id="shipping_specs">
-        <div id="shipping_specs_height_field" data-hook="admin_product_form_height" class="field alpha two columns">
-          <%= f.label :height %>
-          <%= f.text_field :height, :size => 4 %>
-        </div>
-        <div id="shipping_specs_width_field" data-hook="admin_product_form_width" class="field omega two columns">
-          <%= f.label :width %>
-          <%= f.text_field :width, :size => 4 %>
-        </div>
-        <div id="shipping_specs_depth_field" data-hook="admin_product_form_depth" class="field alpha two columns">
-          <%= f.label :depth %>
-          <%= f.text_field :depth, :size => 4 %>
-        </div>
-        <div id="shipping_specs_weight_field" data-hook="admin_product_form_weight" class="field omega two columns">
-          <%= f.label :weight %>
-          <%= f.text_field :weight, :size => 4 %>
-        </div>
+        <% [:height, :width, :depth, :weight].each_with_index do |field, index| %>
+          <div id="shipping_specs_<%= field %>_field" data-hook="admin_product_form_<%= field %>" class="field two columns <%= index.even? ? 'alpha' : 'omega' %>">
+            <%= f.label field %>
+            <%= f.text_field field, value: number_with_precision(@product.send(field), precision: 2) %>
+          </div>
+        <% end %>
       </div>
     <% end %>
 

--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -105,7 +105,7 @@
 
       <div id="shipping_specs">
         <% [:height, :width, :depth, :weight].each_with_index do |field, index| %>
-          <div id="shipping_specs_<%= field %>_field" data-hook="admin_product_form_<%= field %>" class="field two columns <%= index.even? ? 'alpha' : 'omega' %>">
+          <div id="shipping_specs_<%= field %>_field" class="field two columns <%= index.even? ? 'alpha' : 'omega' %>">
             <%= f.label field %>
             <%= f.text_field field, value: number_with_precision(@product.send(field), precision: 2) %>
           </div>


### PR DESCRIPTION
Works in the same way as in admin variants from
(https://github.com/solidusio/solidus/blob/60ee1dffc7c3932cd7652cc2b4566f08a12f74b8/backend/app/views/spree/admin/variants/_form.html.erb#L41)
Fixes a bug coming from Spree on weight on different locales
(https://github.com/spree/spree/issues/6480)