### PR TITLE
Use normal get/post/put/delete spec helpers instead of spree_*

### DIFF
--- a/backend/spec/controllers/spree/admin/cancellations_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/cancellations_controller_spec.rb
@@ -4,7 +4,7 @@ describe Spree::Admin::CancellationsController do
   stub_authorization!
 
   describe "#index" do
-    subject { spree_get :index, order_id: order.number }
+    subject { get :index, order_id: order.number }
 
     let(:order) { create(:order_ready_to_ship, line_items_count: 1) }
 
@@ -18,13 +18,13 @@ describe Spree::Admin::CancellationsController do
   end
 
   describe "#cancel" do
-    subject { spree_post :short_ship, order_id: order.number, inventory_unit_ids: inventory_units.map(&:id) }
+    subject { post :short_ship, order_id: order.number, inventory_unit_ids: inventory_units.map(&:id) }
 
     let(:order) { create(:order_ready_to_ship, number: "R100", state: "complete", line_items_count: 1) }
     let(:referer) { "order_admin_page" }
 
     context "no inventory unit ids are provided" do
-      subject { spree_post :short_ship, order_id: order.number }
+      subject { post :short_ship, order_id: order.number }
 
       it "redirects back" do
         subject

--- a/backend/spec/controllers/spree/admin/customer_returns_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/customer_returns_controller_spec.rb
@@ -10,7 +10,7 @@ module Spree
         let(:customer_return) { create(:customer_return) }
 
         subject do
-          spree_get :index, { order_id: customer_return.order.to_param }
+          get :index, { order_id: customer_return.order.to_param }
         end
 
         before { subject }
@@ -31,7 +31,7 @@ module Spree
         let!(:second_active_reimbursement_type) { create(:reimbursement_type) }
 
         subject do
-          spree_get :new, { order_id: order.to_param }
+          get :new, { order_id: order.to_param }
         end
 
         it "loads the order" do
@@ -126,7 +126,7 @@ module Spree
         let!(:manual_intervention_return_item) { customer_return.return_items.order('id').third.tap(&:require_manual_intervention!) }
 
         subject do
-          spree_get :edit, { order_id: order.to_param, id: customer_return.to_param }
+          get :edit, { order_id: order.to_param, id: customer_return.to_param }
         end
 
         it "loads the order" do
@@ -202,7 +202,7 @@ module Spree
           }
         end
 
-        subject { spree_post :create, customer_return_params }
+        subject { post :create, customer_return_params }
 
         it { expect { subject }.to change { Spree::CustomerReturn.count }.by(1) }
         it do

--- a/backend/spec/controllers/spree/admin/missing_products_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/missing_products_controller_spec.rb
@@ -9,7 +9,7 @@ describe Spree::Admin::ProductsController, type: :controller do
 
   # Regression test for GH https://github.com/spree/spree/issues/538
   it "cannot find a non-existent product" do
-    spree_get :edit, id: "non-existent-product"
+    get :edit, id: "non-existent-product"
     expect(response).to redirect_to(spree.admin_products_path)
     expect(flash[:error]).to eql("Product is not found")
   end

--- a/backend/spec/controllers/spree/admin/orders/customer_details_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/orders/customer_details_controller_spec.rb
@@ -15,13 +15,13 @@ describe Spree::Admin::Orders::CustomerDetailsController, type: :controller do
         expect(order).to receive(:update_attributes) { true }
         expect(order).to receive(:next) { false }
         attributes = { order_id: order.number, order: { email: "" } }
-        spree_put :update, attributes
+        put :update, attributes
       end
 
       it "does refresh the shipment rates with all shipping methods" do
         expect(order).to receive(:refresh_shipment_rates)
         attributes = { order_id: order.number, order: { email: "" } }
-        spree_put :update, attributes
+        put :update, attributes
       end
 
       # Regression spec
@@ -37,7 +37,7 @@ describe Spree::Admin::Orders::CustomerDetailsController, type: :controller do
         end
 
         it 'allows the updating of an email address' do
-          expect { spree_put :update, attributes }.to change { order.reload.email }.to eq 'foo@bar.com'
+          expect { put :update, attributes }.to change { order.reload.email }.to eq 'foo@bar.com'
           expect(response).to be_redirect
         end
       end
@@ -53,7 +53,7 @@ describe Spree::Admin::Orders::CustomerDetailsController, type: :controller do
           }
 
           expect {
-            spree_put :update, attributes
+            put :update, attributes
           }.to change{ order.reload.user }.to(assigned_user)
         end
       end
@@ -70,7 +70,7 @@ describe Spree::Admin::Orders::CustomerDetailsController, type: :controller do
           }
 
           expect {
-            spree_put :update, attributes
+            put :update, attributes
           }.not_to change{ order.reload.user }
         end
       end

--- a/backend/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -37,7 +37,7 @@ describe Spree::Admin::OrdersController, type: :controller do
     context "#approve" do
       it "approves an order" do
         expect(order.contents).to receive(:approve).with(user: controller.try_spree_current_user)
-        spree_put :approve, id: order.number
+        put :approve, id: order.number
         expect(flash[:success]).to eq Spree.t(:order_approved)
       end
     end
@@ -45,7 +45,7 @@ describe Spree::Admin::OrdersController, type: :controller do
     context "#cancel" do
       it "cancels an order" do
         expect(order).to receive(:canceled_by).with(controller.try_spree_current_user)
-        spree_put :cancel, id: order.number
+        put :cancel, id: order.number
         expect(flash[:success]).to eq Spree.t(:order_canceled)
       end
     end
@@ -53,14 +53,14 @@ describe Spree::Admin::OrdersController, type: :controller do
     context "#resume" do
       it "resumes an order" do
         expect(order).to receive(:resume!)
-        spree_put :resume, id: order.number
+        put :resume, id: order.number
         expect(flash[:success]).to eq Spree.t(:order_resumed)
       end
     end
 
     context "pagination" do
       it "can page through the orders" do
-        spree_get :index, page: 2, per_page: 10
+        get :index, page: 2, per_page: 10
         expect(assigns[:orders].offset_value).to eq(10)
         expect(assigns[:orders].limit_value).to eq(10)
       end
@@ -77,21 +77,21 @@ describe Spree::Admin::OrdersController, type: :controller do
         expect(Spree::Core::Importer::Order).to receive(:import)
           .with(nil, hash_including(created_by_id: controller.try_spree_current_user.id))
           .and_return(order)
-        spree_get :new
+        get :new
       end
 
       it "sets frontend_viewable to false" do
         expect(Spree::Core::Importer::Order).to receive(:import)
           .with(nil, hash_including(frontend_viewable: false ))
           .and_return(order)
-        spree_get :new
+        get :new
       end
 
       it "should associate the order with a store" do
         expect(Spree::Core::Importer::Order).to receive(:import)
           .with(user, hash_including(store_id: controller.current_store.id))
           .and_return(order)
-        spree_get :new, { user_id: user.id }
+        get :new, { user_id: user.id }
       end
 
       context "when a user_id is passed as a parameter" do
@@ -102,12 +102,12 @@ describe Spree::Admin::OrdersController, type: :controller do
           expect(Spree::Core::Importer::Order).to receive(:import)
             .with(user, hash_including(created_by_id: controller.try_spree_current_user.id))
             .and_return(order)
-          spree_get :new, { user_id: user.id }
+          get :new, { user_id: user.id }
         end
       end
 
       it "should redirect to cart" do
-        spree_get :new
+        get :new
         expect(response).to redirect_to(spree.cart_admin_order_path(Spree::Order.last))
       end
     end
@@ -117,13 +117,13 @@ describe Spree::Admin::OrdersController, type: :controller do
       it "does not refresh rates if the order is completed" do
         allow(order).to receive_messages completed?: true
         expect(order).not_to receive :refresh_shipment_rates
-        spree_get :edit, id: order.number
+        get :edit, id: order.number
       end
 
       it "does refresh the rates if the order is incomplete" do
         allow(order).to receive_messages completed?: false
         expect(order).to receive :refresh_shipment_rates
-        spree_get :edit, id: order.number
+        get :edit, id: order.number
       end
 
       context "when order does not have a ship address" do
@@ -135,7 +135,7 @@ describe Spree::Admin::OrdersController, type: :controller do
           before { Spree::Config[:order_bill_address_used] = true }
 
           it "should redirect to the customer details page" do
-            spree_get :edit, id: order.number
+            get :edit, id: order.number
             expect(response).to redirect_to(spree.edit_admin_order_customer_path(order))
           end
         end
@@ -144,7 +144,7 @@ describe Spree::Admin::OrdersController, type: :controller do
           before { Spree::Config[:order_bill_address_used] = false }
 
           it "should redirect to the customer details page" do
-            spree_get :edit, id: order.number
+            get :edit, id: order.number
             expect(response).to redirect_to(spree.edit_admin_order_customer_path(order))
           end
         end
@@ -153,7 +153,7 @@ describe Spree::Admin::OrdersController, type: :controller do
 
     describe '#advance' do
       subject do
-        spree_put :advance, id: order.number
+        put :advance, id: order.number
       end
 
       context 'when incomplete' do
@@ -199,7 +199,7 @@ describe Spree::Admin::OrdersController, type: :controller do
 
     context '#confirm' do
       subject do
-        spree_get :confirm, id: order.number
+        get :confirm, id: order.number
       end
 
       context 'when in confirm' do
@@ -234,7 +234,7 @@ describe Spree::Admin::OrdersController, type: :controller do
 
     context "#complete" do
       subject do
-        spree_put :complete, id: order.number
+        put :complete, id: order.number
       end
 
       context 'when successful' do
@@ -288,7 +288,7 @@ describe Spree::Admin::OrdersController, type: :controller do
       end
 
       it "does not display duplicated results" do
-        spree_get :index, q: {
+        get :index, q: {
           line_items_variant_id_in: Spree::Order.first.variants.map(&:id)
         }
         expect(assigns[:orders].map(&:number).count).to eq 1
@@ -300,17 +300,17 @@ describe Spree::Admin::OrdersController, type: :controller do
       let!(:finalized_adjustment) { create(:adjustment, finalized: true, adjustable: order, order: order) }
 
       it "changes all the finalized adjustments to unfinalized" do
-        spree_post :unfinalize_adjustments, id: order.number
+        post :unfinalize_adjustments, id: order.number
         expect(finalized_adjustment.reload.finalized).to eq(false)
       end
 
       it "sets the flash success message" do
-        spree_post :unfinalize_adjustments, id: order.number
+        post :unfinalize_adjustments, id: order.number
         expect(flash[:success]).to eql('All adjustments successfully unfinalized!')
       end
 
       it "redirects back" do
-        spree_post :unfinalize_adjustments, id: order.number
+        post :unfinalize_adjustments, id: order.number
         expect(response).to redirect_to(:back)
       end
     end
@@ -320,17 +320,17 @@ describe Spree::Admin::OrdersController, type: :controller do
       let!(:not_finalized_adjustment) { create(:adjustment, finalized: false, adjustable: order, order: order) }
 
       it "changes all the unfinalized adjustments to finalized" do
-        spree_post :finalize_adjustments, id: order.number
+        post :finalize_adjustments, id: order.number
         expect(not_finalized_adjustment.reload.finalized).to eq(true)
       end
 
       it "sets the flash success message" do
-        spree_post :finalize_adjustments, id: order.number
+        post :finalize_adjustments, id: order.number
         expect(flash[:success]).to eql('All adjustments successfully finalized!')
       end
 
       it "redirects back" do
-        spree_post :finalize_adjustments, id: order.number
+        post :finalize_adjustments, id: order.number
         expect(response).to redirect_to(:back)
       end
     end
@@ -346,21 +346,21 @@ describe Spree::Admin::OrdersController, type: :controller do
 
     it 'should grant access to users with an admin role' do
       user.spree_roles << Spree::Role.find_or_create_by(name: 'admin')
-      spree_get :index
+      get :index
       expect(response).to render_template :index
     end
 
     it 'should grant access to users with an bar role' do
       user.spree_roles << Spree::Role.find_or_create_by(name: 'bar')
       Spree::Ability.register_ability(BarAbility)
-      spree_get :index
+      get :index
       expect(response).to render_template :index
       Spree::Ability.remove_ability(BarAbility)
     end
 
     it 'should deny access to users without an admin role' do
       allow(user).to receive_messages has_spree_role?: false
-      spree_get :index
+      get :index
       expect(response).to redirect_to('/unauthorized')
     end
 
@@ -376,7 +376,7 @@ describe Spree::Admin::OrdersController, type: :controller do
         expect(Spree::Order.complete.count).to eq 4
 
         allow(user).to receive_messages has_spree_role?: false
-        spree_get :index
+        get :index
         expect(response).to render_template :index
         expect(assigns['orders'].size).to eq 1
         expect(assigns['orders'].first.number).to eq number
@@ -389,7 +389,7 @@ describe Spree::Admin::OrdersController, type: :controller do
 
     it "raise active record not found" do
       expect {
-        spree_get :edit, id: 0
+        get :edit, id: 0
       }.to raise_error ActiveRecord::RecordNotFound
     end
   end

--- a/backend/spec/controllers/spree/admin/payment_methods_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/payment_methods_controller_spec.rb
@@ -18,7 +18,7 @@ module Spree
       # regression test for https://github.com/spree/spree/issues/2094
       it "does not clear password on update" do
         expect(payment_method.preferred_password).to eq("haxme")
-        spree_put :update, id: payment_method.id, payment_method: { type: payment_method.class.to_s, preferred_password: "" }
+        put :update, id: payment_method.id, payment_method: { type: payment_method.class.to_s, preferred_password: "" }
         expect(response).to redirect_to(spree.edit_admin_payment_method_path(payment_method))
 
         payment_method.reload
@@ -28,13 +28,13 @@ module Spree
 
     context "tries to save invalid payment" do
       it "doesn't break, responds nicely" do
-        spree_post :create, payment_method: { name: "", type: "Spree::Gateway::Bogus" }
+        post :create, payment_method: { name: "", type: "Spree::Gateway::Bogus" }
       end
     end
 
     it "can create a payment method of a valid type" do
       expect {
-        spree_post :create, payment_method: { name: "Test Method", type: "Spree::Gateway::Bogus" }
+        post :create, payment_method: { name: "Test Method", type: "Spree::Gateway::Bogus" }
       }.to change(Spree::PaymentMethod, :count).by(1)
 
       expect(response).to be_redirect
@@ -43,7 +43,7 @@ module Spree
 
     it "can not create a payment method of an invalid type" do
       expect {
-        spree_post :create, payment_method: { name: "Invalid Payment Method", type: "Spree::InvalidType" }
+        post :create, payment_method: { name: "Invalid Payment Method", type: "Spree::InvalidType" }
       }.to change(Spree::PaymentMethod, :count).by(0)
 
       expect(response).to be_redirect
@@ -51,7 +51,7 @@ module Spree
     end
 
     describe "GET index" do
-      subject { spree_get :index }
+      subject { get :index }
 
       let!(:first_method) { GatewayWithPassword.create! name: "First", preferred_password: "1235" }
       let!(:second_method) { GatewayWithPassword.create! name: "Second", preferred_password: "1235" }

--- a/backend/spec/controllers/spree/admin/payments_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/payments_controller_spec.rb
@@ -32,7 +32,7 @@ module Spree
           end
 
           before do
-            spree_post :create, attributes
+            post :create, attributes
           end
 
           it "should process payment correctly" do
@@ -81,7 +81,7 @@ module Spree
           end
 
           it "loads backend payment methods" do
-            spree_get :new, order_id: order.number
+            get :new, order_id: order.number
             expect(response.status).to eq(200)
             expect(assigns[:payment_methods]).to include(@payment_method)
           end
@@ -97,7 +97,7 @@ module Spree
 
           context "order does not have payments" do
             it "redirect to new payments page" do
-              spree_get :index, { amount: 100, order_id: order.number }
+              get :index, { amount: 100, order_id: order.number }
               expect(response).to redirect_to(spree.new_admin_order_payment_path(order))
             end
           end
@@ -108,7 +108,7 @@ module Spree
             end
 
             it "shows the payments page" do
-              spree_get :index, { amount: 100, order_id: order.number }
+              get :index, { amount: 100, order_id: order.number }
               expect(response.code).to eq "200"
             end
           end
@@ -121,7 +121,7 @@ module Spree
           end
 
           it "should redirect to the customer details page" do
-            spree_get :index, { amount: 100, order_id: order.number }
+            get :index, { amount: 100, order_id: order.number }
             expect(response).to redirect_to(spree.edit_admin_order_customer_path(order))
           end
         end
@@ -147,7 +147,7 @@ module Spree
 
             it 'allows the action' do
               expect {
-                spree_post(:fire, id: payment.to_param, e: 'capture', order_id: order.to_param)
+                post(:fire, id: payment.to_param, e: 'capture', order_id: order.to_param)
               }.to change { payment.reload.state }.from('checkout').to('completed')
             end
 
@@ -166,7 +166,7 @@ module Spree
 
               it 'does not allow the action' do
                 expect {
-                  spree_post(:fire, id: payment.to_param, e: 'capture', order_id: order.to_param)
+                  post(:fire, id: payment.to_param, e: 'capture', order_id: order.to_param)
                 }.to_not change { payment.reload.state }
                 expect(flash[:error]).to eq('Authorization Failure')
               end

--- a/backend/spec/controllers/spree/admin/prices_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/prices_controller_spec.rb
@@ -9,7 +9,7 @@ describe Spree::Admin::PricesController do
     context "when only given a product" do
       let(:product) { create(:product) }
 
-      subject { spree_get :index, product_id: product.slug }
+      subject { get :index, product_id: product.slug }
 
       it { is_expected.to be_success }
 
@@ -25,7 +25,7 @@ describe Spree::Admin::PricesController do
       let(:variant) { create(:variant) }
       let(:product) { variant.product }
 
-      subject { spree_get :index, product_id: product.slug, variant_id: variant.id }
+      subject { get :index, product_id: product.slug, variant_id: variant.id }
 
       it { is_expected.to be_success }
 

--- a/backend/spec/controllers/spree/admin/product_properties_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/product_properties_controller_spec.rb
@@ -6,7 +6,7 @@ module Spree
       stub_authorization!
 
       describe "#index" do
-        subject { spree_get :index, parameters }
+        subject { get :index, parameters }
 
         context "no option values are provided" do
           let(:product) { create(:product) }

--- a/backend/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/products_controller_spec.rb
@@ -9,7 +9,7 @@ describe Spree::Admin::ProductsController, type: :controller do
     # Regression test for https://github.com/spree/spree/issues/1259
     it "can find a product by SKU" do
       product = create(:product, sku: "ABC123")
-      spree_get :index, q: { sku_start: "ABC123" }
+      get :index, q: { sku_start: "ABC123" }
       expect(assigns[:collection]).not_to be_empty
       expect(assigns[:collection]).to include(product)
     end
@@ -19,7 +19,7 @@ describe Spree::Admin::ProductsController, type: :controller do
   context "adding properties to a product" do
     let!(:product) { create(:product) }
     specify do
-      spree_put :update, id: product.to_param, product: { product_properties_attributes: { "1" => { property_name: "Foo", value: "bar" } } }
+      put :update, id: product.to_param, product: { product_properties_attributes: { "1" => { property_name: "Foo", value: "bar" } } }
       expect(flash[:success]).to eq("Product #{product.name.inspect} has been successfully updated!")
     end
   end
@@ -53,7 +53,7 @@ describe Spree::Admin::ProductsController, type: :controller do
       }
     end
 
-    subject { spree_put :update, payload }
+    subject { put :update, payload }
 
     it "creates a variant property rule" do
       expect { subject }.to change { product.variant_property_rules.count }.by(1)
@@ -113,7 +113,7 @@ describe Spree::Admin::ProductsController, type: :controller do
       }
     end
 
-    subject { spree_put :update, payload }
+    subject { put :update, payload }
 
     it "does not create any new rules" do
       expect { subject }.to_not change { Spree::VariantPropertyRule.count }
@@ -152,7 +152,7 @@ describe Spree::Admin::ProductsController, type: :controller do
     end
 
     it "deletes all the variants (including master) for the product" do
-      spree_delete :destroy, id: product
+      delete :destroy, id: product
       expect(product.reload.deleted_at).not_to be_nil
       product.variants_including_master.each do |variant|
         expect(variant.reload.deleted_at).not_to be_nil

--- a/backend/spec/controllers/spree/admin/promotion_actions_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/promotion_actions_controller_spec.rb
@@ -6,14 +6,14 @@ describe Spree::Admin::PromotionActionsController, type: :controller do
   let!(:promotion) { create(:promotion) }
 
   it "can create a promotion action of a valid type" do
-    spree_post :create, promotion_id: promotion.id, action_type: "Spree::Promotion::Actions::CreateAdjustment"
+    post :create, promotion_id: promotion.id, action_type: "Spree::Promotion::Actions::CreateAdjustment"
     expect(response).to be_redirect
     expect(response).to redirect_to spree.edit_admin_promotion_path(promotion)
     expect(promotion.actions.count).to eq(1)
   end
 
   it "can not create a promotion action of an invalid type" do
-    spree_post :create, promotion_id: promotion.id, action_type: "Spree::InvalidType"
+    post :create, promotion_id: promotion.id, action_type: "Spree::InvalidType"
     expect(response).to be_redirect
     expect(response).to redirect_to spree.edit_admin_promotion_path(promotion)
     expect(promotion.rules.count).to eq(0)

--- a/backend/spec/controllers/spree/admin/promotion_codes_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/promotion_codes_controller_spec.rb
@@ -10,7 +10,7 @@ describe Spree::Admin::PromotionCodesController do
   let!(:code3) { create(:promotion_code, promotion: promotion) }
 
   it "can create a promotion rule of a valid type" do
-    spree_get :index, promotion_id: promotion.id, format: 'csv'
+    get :index, promotion_id: promotion.id, format: 'csv'
     expect(response).to be_success
     parsed = CSV.parse(response.body, headers: true)
     expect(parsed.entries.map(&:to_h)).to eq([{ "Code" => code1.value }, { "Code" => code2.value }, { "Code" => code3.value }])

--- a/backend/spec/controllers/spree/admin/promotion_rules_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/promotion_rules_controller_spec.rb
@@ -6,14 +6,14 @@ describe Spree::Admin::PromotionRulesController, type: :controller do
   let!(:promotion) { create(:promotion) }
 
   it "can create a promotion rule of a valid type" do
-    spree_post :create, promotion_id: promotion.id, promotion_rule: { type: "Spree::Promotion::Rules::Product" }
+    post :create, promotion_id: promotion.id, promotion_rule: { type: "Spree::Promotion::Rules::Product" }
     expect(response).to be_redirect
     expect(response).to redirect_to spree.edit_admin_promotion_path(promotion)
     expect(promotion.rules.count).to eq(1)
   end
 
   it "can not create a promotion rule of an invalid type" do
-    spree_post :create, promotion_id: promotion.id, promotion_rule: { type: "Spree::InvalidType" }
+    post :create, promotion_id: promotion.id, promotion_rule: { type: "Spree::InvalidType" }
     expect(response).to be_redirect
     expect(response).to redirect_to spree.edit_admin_promotion_path(promotion)
     expect(promotion.rules.count).to eq(0)

--- a/backend/spec/controllers/spree/admin/promotions_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/promotions_controller_spec.rb
@@ -9,40 +9,40 @@ describe Spree::Admin::PromotionsController, type: :controller do
 
   describe "#index" do
     it "succeeds" do
-      spree_get :index
+      get :index
       expect(assigns[:promotions]).to match_array [promotion2, promotion1]
     end
 
     it "assigns promotion categories" do
-      spree_get :index
+      get :index
       expect(assigns[:promotion_categories]).to match_array [category]
     end
 
     context "search" do
       it "pages results" do
-        spree_get :index, per_page: '1'
+        get :index, per_page: '1'
         expect(assigns[:promotions]).to eq [promotion2]
       end
 
       it "filters by name" do
-        spree_get :index, q: { name_cont: promotion1.name }
+        get :index, q: { name_cont: promotion1.name }
         expect(assigns[:promotions]).to eq [promotion1]
       end
 
       it "filters by code" do
-        spree_get :index, q: { codes_value_cont: promotion1.codes.first.value }
+        get :index, q: { codes_value_cont: promotion1.codes.first.value }
         expect(assigns[:promotions]).to eq [promotion1]
       end
 
       it "filters by path" do
-        spree_get :index, q: { path_cont: promotion1.path }
+        get :index, q: { path_cont: promotion1.path }
         expect(assigns[:promotions]).to eq [promotion1]
       end
     end
   end
 
   describe "#create" do
-    subject { spree_post :create, params }
+    subject { post :create, params }
     let(:params) { { promotion: { name: 'some promo' } } }
 
     context "it succeeds" do

--- a/backend/spec/controllers/spree/admin/refunds_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/refunds_controller_spec.rb
@@ -8,7 +8,7 @@ describe Spree::Admin::RefundsController do
       let(:payment) { create(:payment) }
 
       subject do
-        spree_post :create,
+        post :create,
                    refund: { amount: "50.0", refund_reason_id: "1" },
                    order_id: payment.order_id,
                    payment_id: payment.id

--- a/backend/spec/controllers/spree/admin/reimbursements_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/reimbursements_controller_spec.rb
@@ -14,7 +14,7 @@ describe Spree::Admin::ReimbursementsController, type: :controller do
     let!(:inactive_stock_location) { create(:stock_location, active: false) }
 
     subject do
-      spree_get :edit, order_id: order.to_param, id: reimbursement.to_param
+      get :edit, order_id: order.to_param, id: reimbursement.to_param
     end
 
     it "loads all the active stock locations" do
@@ -32,7 +32,7 @@ describe Spree::Admin::ReimbursementsController, type: :controller do
     before { return_item.receive! }
 
     subject do
-      spree_post :create, order_id: order.to_param, build_from_customer_return_id: customer_return.id
+      post :create, order_id: order.to_param, build_from_customer_return_id: customer_return.id
     end
 
     it 'creates the reimbursement' do
@@ -59,7 +59,7 @@ describe Spree::Admin::ReimbursementsController, type: :controller do
         it 'redirects to the referer' do
           request.env["HTTP_REFERER"] = referer
           expect {
-            spree_post :create, order_id: order.to_param
+            post :create, order_id: order.to_param
           }.to_not change { Spree::Reimbursement.count }
           expect(response).to redirect_to(referer)
           expect(flash[:error]).to eq("something bad happened")
@@ -69,7 +69,7 @@ describe Spree::Admin::ReimbursementsController, type: :controller do
       context 'when a referer header is not present' do
         it 'redirects to the admin root' do
           expect {
-            spree_post :create, order_id: order.to_param
+            post :create, order_id: order.to_param
           }.to_not change { Spree::Reimbursement.count }
           expect(response).to redirect_to(spree.admin_path)
           expect(flash[:error]).to eq("something bad happened")
@@ -86,7 +86,7 @@ describe Spree::Admin::ReimbursementsController, type: :controller do
     let(:payment) { order.payments.first }
 
     subject do
-      spree_post :perform, order_id: order.to_param, id: reimbursement.to_param
+      post :perform, order_id: order.to_param, id: reimbursement.to_param
     end
 
     it 'redirects to customer return page' do

--- a/backend/spec/controllers/spree/admin/reports_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/reports_controller_spec.rb
@@ -44,7 +44,7 @@ describe Spree::Admin::ReportsController, type: :controller do
       order_complete_mid_month.save!
     end
 
-    subject { spree_get :sales_total, params }
+    subject { get :sales_total, params }
 
     shared_examples 'sales total report' do
       it 'should respond with success' do
@@ -126,7 +126,7 @@ describe Spree::Admin::ReportsController, type: :controller do
 
   describe 'GET index' do
     it 'should be ok' do
-      spree_get :index
+      get :index
       expect(response).to be_ok
     end
   end

--- a/backend/spec/controllers/spree/admin/resource_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/resource_controller_spec.rb
@@ -45,7 +45,7 @@ describe Spree::Admin::WidgetsController, type: :controller do
 
   describe '#new' do
     subject do
-      spree_get :new
+      get :new
     end
 
     it 'succeeds' do
@@ -58,7 +58,7 @@ describe Spree::Admin::WidgetsController, type: :controller do
     let(:widget) { Widget.create!(name: 'a widget') }
 
     subject do
-      spree_get :edit, id: widget.to_param
+      get :edit, id: widget.to_param
     end
 
     it 'succeeds' do
@@ -72,7 +72,7 @@ describe Spree::Admin::WidgetsController, type: :controller do
       { widget: { name: 'a widget' } }
     end
 
-    subject { spree_post :create, params }
+    subject { post :create, params }
 
     it 'creates the resource' do
       expect { subject }.to change { Widget.count }.by(1)
@@ -112,7 +112,7 @@ describe Spree::Admin::WidgetsController, type: :controller do
       }
     end
 
-    subject { spree_put :update, params }
+    subject { put :update, params }
 
     it 'updates the resource' do
       expect { subject }.to change { widget.reload.name }.from('a widget').to('widget renamed')
@@ -138,7 +138,7 @@ describe Spree::Admin::WidgetsController, type: :controller do
     let(:params) { { id: widget.id } }
 
     subject {
-      spree_delete :destroy, params
+      delete :destroy, params
     }
 
     it 'destroys the resource' do
@@ -151,7 +151,7 @@ describe Spree::Admin::WidgetsController, type: :controller do
     let(:widget_2) { Widget.create!(name: 'widget 2', position: 2) }
 
     subject do
-      spree_post :update_positions, id: widget_1.to_param,
+      post :update_positions, id: widget_1.to_param,
         positions: { widget_1.id => '2', widget_2.id => '1' }, format: 'js'
     end
 

--- a/backend/spec/controllers/spree/admin/return_authorizations_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/return_authorizations_controller_spec.rb
@@ -19,7 +19,7 @@ describe Spree::Admin::ReturnAuthorizationsController, type: :controller do
       let(:return_authorization) { return_item.return_authorization }
 
       it "loads all the active rma reasons" do
-        spree_get :edit, id: return_authorization.to_param, order_id: return_authorization.order.to_param
+        get :edit, id: return_authorization.to_param, order_id: return_authorization.order.to_param
         expect(assigns(:reasons)).to include(return_reason)
         expect(assigns(:reasons)).to include(inactive_rma_reason)
         expect(assigns(:reasons)).not_to include(other_inactive_rma_reason)
@@ -30,14 +30,14 @@ describe Spree::Admin::ReturnAuthorizationsController, type: :controller do
       let(:return_authorization) { create(:return_authorization, reason: return_reason) }
 
       it "loads all the active rma reasons" do
-        spree_get :edit, id: return_authorization.to_param, order_id: return_authorization.order.to_param
+        get :edit, id: return_authorization.to_param, order_id: return_authorization.order.to_param
         expect(assigns(:reasons)).to eq [return_reason]
       end
     end
 
     context "return authorization doesn't have an associated reason" do
       it "loads all the active rma reasons" do
-        spree_get :new, order_id: order.to_param
+        get :new, order_id: order.to_param
         expect(assigns(:reasons)).to eq [return_reason]
       end
     end
@@ -68,14 +68,14 @@ describe Spree::Admin::ReturnAuthorizationsController, type: :controller do
     end
 
     context '#new' do
-      subject { spree_get :new, order_id: order.to_param }
+      subject { get :new, order_id: order.to_param }
 
       include_context 'without existing return items'
     end
 
     context '#edit' do
       subject do
-        spree_get :edit, {
+        get :edit, {
           id: return_authorization.to_param,
           order_id: order.to_param
         }
@@ -89,7 +89,7 @@ describe Spree::Admin::ReturnAuthorizationsController, type: :controller do
 
     context '#create failed' do
       subject do
-        spree_post :create, {
+        post :create, {
           return_authorization: { stock_location_id: nil }, # return authorization requires valid stock location, so this will fail
           order_id: order.to_param
         }
@@ -100,7 +100,7 @@ describe Spree::Admin::ReturnAuthorizationsController, type: :controller do
 
     context '#update failed' do
       subject do
-        spree_put :update, {
+        put :update, {
           return_authorization: { stock_location_id: nil }, # return authorization requires valid stock location, so this will fail
           id: return_authorization.to_param,
           order_id: order.to_param
@@ -121,7 +121,7 @@ describe Spree::Admin::ReturnAuthorizationsController, type: :controller do
     let!(:second_active_reimbursement_type) { create(:reimbursement_type) }
 
     before do
-      spree_get :new, order_id: order.to_param
+      get :new, order_id: order.to_param
     end
 
     it "loads all the active reimbursement types" do
@@ -136,7 +136,7 @@ describe Spree::Admin::ReturnAuthorizationsController, type: :controller do
     let!(:inactive_stock_location) { create(:stock_location, active: false) }
 
     before do
-      spree_get :new, order_id: order.to_param
+      get :new, order_id: order.to_param
     end
 
     it "loads all the active stock locations" do
@@ -148,7 +148,7 @@ describe Spree::Admin::ReturnAuthorizationsController, type: :controller do
   context '#create' do
     let(:stock_location) { create(:stock_location) }
 
-    subject { spree_post :create, params }
+    subject { post :create, params }
 
     let(:params) do
       {
@@ -188,7 +188,7 @@ describe Spree::Admin::ReturnAuthorizationsController, type: :controller do
       }
     end
 
-    subject { spree_put :update, params }
+    subject { put :update, params }
 
     context "adding an item" do
       let(:return_items_params) do

--- a/backend/spec/controllers/spree/admin/return_items_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/return_items_controller_spec.rb
@@ -10,7 +10,7 @@ describe Spree::Admin::ReturnItemsController, type: :controller do
     let(:new_acceptance_status) { 'rejected' }
 
     subject do
-      spree_put :update, id: return_item.to_param, return_item: { acceptance_status: new_acceptance_status }
+      put :update, id: return_item.to_param, return_item: { acceptance_status: new_acceptance_status }
     end
 
     it 'updates the return item' do

--- a/backend/spec/controllers/spree/admin/search_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/search_controller_spec.rb
@@ -13,7 +13,7 @@ describe Spree::Admin::SearchController, type: :controller do
   end
 
   describe 'GET #users' do
-    subject { spree_xhr_get :users, params }
+    subject { get :users, { format: :json }.merge(params) }
 
     shared_examples_for 'user found by search' do
       it "should include users matching query" do

--- a/backend/spec/controllers/spree/admin/search_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/search_controller_spec.rb
@@ -66,7 +66,7 @@ describe Spree::Admin::SearchController, type: :controller do
     let!(:product_one) { create(:product, name: 'jersey') }
     let!(:product_two) { create(:product, name: 'better jersey') }
 
-    subject { spree_get :products, params }
+    subject { get :products, params }
 
     shared_examples_for 'product search' do
       it 'should respond with http success' do

--- a/backend/spec/controllers/spree/admin/shipping_methods_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/shipping_methods_controller_spec.rb
@@ -8,7 +8,7 @@ describe Spree::Admin::ShippingMethodsController, type: :controller do
     shipping_method = stub_model(Spree::ShippingMethod)
     allow(Spree::ShippingMethod).to receive_messages find: shipping_method
     expect(shipping_method.deleted_at).to be_nil
-    spree_delete :destroy, id: 1
+    delete :destroy, id: 1
     expect(shipping_method.reload.deleted_at).not_to be_nil
   end
 end

--- a/backend/spec/controllers/spree/admin/stock_items_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/stock_items_controller_spec.rb
@@ -15,7 +15,7 @@ module Spree
         before { request.env["HTTP_REFERER"] = "product_admin_page" }
 
         subject do
-          spree_post :create, { variant_id: variant, stock_location_id: stock_location, stock_movement: { quantity: 1, stock_item_id: stock_item.id } }
+          post :create, { variant_id: variant, stock_location_id: stock_location, stock_movement: { quantity: 1, stock_item_id: stock_item.id } }
         end
 
         it "creates a stock movement with originator" do
@@ -31,7 +31,7 @@ module Spree
 
         context "with product_slug param" do
           it "scopes the variants by the product" do
-            spree_get :index, product_slug: variant_1.product.slug
+            get :index, product_slug: variant_1.product.slug
             expect(assigns(:variants)).to include variant_1
             expect(assigns(:variants)).not_to include variant_2
           end
@@ -39,7 +39,7 @@ module Spree
 
         context "without product_slug params" do
           it "allows all accessible variants to be returned" do
-            spree_get :index
+            get :index
             expect(assigns(:variants)).to include variant_1
             expect(assigns(:variants)).to include variant_2
           end

--- a/backend/spec/controllers/spree/admin/stock_locations_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/stock_locations_controller_spec.rb
@@ -8,7 +8,7 @@ module Spree
       # Regression for https://github.com/spree/spree/issues/4272
       context "with no countries present" do
         it "cannot create a new stock location" do
-          spree_get :new
+          get :new
           expect(flash[:error]).to eq(Spree.t(:stock_locations_need_a_default_country))
           expect(response).to redirect_to(spree.admin_stock_locations_path)
         end
@@ -22,7 +22,7 @@ module Spree
         end
 
         it "can create a new stock location" do
-          spree_get :new
+          get :new
           expect(response).to be_success
         end
       end
@@ -33,7 +33,7 @@ module Spree
         end
 
         it "can create a new stock location" do
-          spree_get :new
+          get :new
           expect(response).to be_success
         end
       end

--- a/backend/spec/controllers/spree/admin/stock_transfers_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/stock_transfers_controller_spec.rb
@@ -40,24 +40,24 @@ module Spree
         end
 
         it "doesn't display stock locations the user doesn't have access to" do
-          spree_get :index
+          get :index
           expect(assigns(:stock_locations)).to match_array [warehouse, ny_store, la_store]
         end
       end
 
       it "searches by stock location" do
-        spree_get :index, q: { source_location_id_or_destination_location_id_eq: ny_store.id }
+        get :index, q: { source_location_id_or_destination_location_id_eq: ny_store.id }
         expect(assigns(:stock_transfers).count).to eq 1
         expect(assigns(:stock_transfers)).to include(stock_transfer1)
       end
 
       it "filters the closed stock transfers" do
-        spree_get :index, q: { closed_at_null: '1' }
+        get :index, q: { closed_at_null: '1' }
         expect(assigns(:stock_transfers)).to match_array [stock_transfer1]
       end
 
       it "doesn't filter any stock transfers" do
-        spree_get :index, q: { closed_at_null: '0' }
+        get :index, q: { closed_at_null: '0' }
         expect(assigns(:stock_transfers)).to match_array [stock_transfer1, stock_transfer2]
       end
     end
@@ -66,7 +66,7 @@ module Spree
       let(:warehouse) { StockLocation.create(name: "Warehouse", active: false) }
 
       subject do
-        spree_post :create, stock_transfer: { source_location_id: warehouse.id, description: nil }
+        post :create, stock_transfer: { source_location_id: warehouse.id, description: nil }
       end
 
       context "user doesn't have read access to the selected stock location" do
@@ -101,7 +101,7 @@ module Spree
       # Regression spec for Solidus issue #1087
       context "missing source_stock_location parameter" do
         subject do
-          spree_post :create, stock_transfer: { source_location_id: nil, description: nil }
+          post :create, stock_transfer: { source_location_id: nil, description: nil }
         end
 
         it "sets a flash error" do
@@ -118,7 +118,7 @@ module Spree
       let(:parameters)           { { id: transfer_with_items.to_param } }
 
       subject do
-        spree_get :receive, parameters
+        get :receive, parameters
       end
 
       context 'stock transfer is not receivable' do
@@ -171,7 +171,7 @@ module Spree
       end
 
       subject do
-        spree_put :finalize, id: transfer_with_items.to_param
+        put :finalize, id: transfer_with_items.to_param
       end
 
       context 'stock transfer is not finalizable' do
@@ -229,7 +229,7 @@ module Spree
       end
 
       subject do
-        spree_put :close, id: transfer_with_items.to_param
+        put :close, id: transfer_with_items.to_param
       end
 
       context 'stock transfer is not receivable' do
@@ -321,7 +321,7 @@ module Spree
       let(:warehouse_stock_item) { warehouse.stock_items.find_by(variant: transfer_variant) }
       let(:ny_stock_item) { ny_store.stock_items.find_by(variant: transfer_variant) }
 
-      subject { spree_put :ship, id: stock_transfer.number }
+      subject { put :ship, id: stock_transfer.number }
 
       before do
         warehouse_stock_item.set_count_on_hand(1)

--- a/backend/spec/controllers/spree/admin/store_credits_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/store_credits_controller_spec.rb
@@ -20,7 +20,7 @@ describe Spree::Admin::StoreCreditsController do
     let!(:store_credit) { create(:store_credit, user: user, category: a_credit_category) }
     let!(:event)        { create(:store_credit_auth_event, store_credit: store_credit, created_at: 5.days.ago) }
 
-    before { spree_get :show, user_id: user.id, id: store_credit.id }
+    before { get :show, user_id: user.id, id: store_credit.id }
 
     it "sets the store_credit variable to a new store credit model" do
       expect(assigns(:store_credit)).to eq store_credit
@@ -33,12 +33,12 @@ describe Spree::Admin::StoreCreditsController do
   end
 
   describe "#new" do
-    before { spree_get :new, user_id: create(:user).id }
+    before { get :new, user_id: create(:user).id }
     it { expect(assigns(:credit_categories)).to eq [a_credit_category, b_credit_category] }
   end
 
   describe "#create" do
-    subject { spree_post :create, parameters }
+    subject { post :create, parameters }
 
     before  {
       allow(controller).to receive_messages(try_spree_current_user: admin_user)
@@ -94,7 +94,7 @@ describe Spree::Admin::StoreCreditsController do
   describe "#edit_amount" do
     let!(:store_credit) { create(:store_credit, user: user, category: a_credit_category) }
 
-    before { spree_get :edit_amount, user_id: user.id, id: store_credit.id }
+    before { get :edit_amount, user_id: user.id, id: store_credit.id }
 
     it_behaves_like "update reason loader"
 
@@ -106,7 +106,7 @@ describe Spree::Admin::StoreCreditsController do
   describe "#edit_validity" do
     let!(:store_credit) { create(:store_credit, user: user, category: a_credit_category) }
 
-    before { spree_get :edit_validity, user_id: user.id, id: store_credit.id }
+    before { get :edit_validity, user_id: user.id, id: store_credit.id }
 
     it_behaves_like "update reason loader"
 
@@ -119,7 +119,7 @@ describe Spree::Admin::StoreCreditsController do
     let(:memo)          { "New memo" }
     let!(:store_credit) { create(:store_credit, user: user) }
 
-    subject { spree_put :update, parameters.merge(format: :json) }
+    subject { put :update, parameters.merge(format: :json) }
 
     before  { allow(controller).to receive_messages(try_spree_current_user: admin_user) }
 
@@ -182,7 +182,7 @@ describe Spree::Admin::StoreCreditsController do
       }
     end
 
-    subject { spree_put :update_amount, parameters }
+    subject { put :update_amount, parameters }
 
     before  { allow(controller).to receive_messages(try_spree_current_user: admin_user) }
 
@@ -272,7 +272,7 @@ describe Spree::Admin::StoreCreditsController do
       }
     end
 
-    subject { spree_put :invalidate, parameters }
+    subject { put :invalidate, parameters }
 
     it "attempts to invalidate the store credit" do
       expect { subject }.to change { store_credit.reload.invalidated_at }.from(nil)

--- a/backend/spec/controllers/spree/admin/users_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/users_controller_spec.rb
@@ -24,7 +24,7 @@ describe Spree::Admin::UsersController, type: :controller do
     end
 
     it "redirects to edit" do
-      spree_get :show, id: user.id
+      get :show, id: user.id
       expect(response).to redirect_to spree.edit_admin_user_path(user)
     end
   end
@@ -36,13 +36,13 @@ describe Spree::Admin::UsersController, type: :controller do
       end
 
       it 'can visit index' do
-        spree_post :index
+        post :index
         expect(response).to be_success
       end
 
       it "allows admins to update a user's API key" do
         expect {
-          spree_put :generate_api_key, id: user.id
+          put :generate_api_key, id: user.id
         }.to change { user.reload.spree_api_key }
         expect(response).to redirect_to(spree.edit_admin_user_path(user))
       end
@@ -50,7 +50,7 @@ describe Spree::Admin::UsersController, type: :controller do
       it "allows admins to clear a user's API key" do
         user.generate_spree_api_key!
         expect {
-          spree_put :clear_api_key, id: user.id
+          put :clear_api_key, id: user.id
         }.to change{ user.reload.spree_api_key }.to(nil)
         expect(response).to redirect_to(spree.edit_admin_user_path(user))
       end
@@ -61,7 +61,7 @@ describe Spree::Admin::UsersController, type: :controller do
       end
 
       it 'denies access' do
-        spree_post :index
+        post :index
         expect(response).to redirect_to '/unauthorized'
       end
     end
@@ -86,42 +86,42 @@ describe Spree::Admin::UsersController, type: :controller do
       end
 
       it "can create user with roles" do
-        spree_post :create, { user: { first_name: "Bob", spree_role_ids: [dummy_role.id] } }
+        post :create, { user: { first_name: "Bob", spree_role_ids: [dummy_role.id] } }
         expect(user.spree_roles).to eq([dummy_role])
       end
 
       it "can create user without roles" do
-        spree_post :create, { user: { first_name: "Bob" } }
+        post :create, { user: { first_name: "Bob" } }
         expect(user.spree_roles).to eq([])
       end
     end
 
     context "when the user cannot manage roles" do
       it "cannot assign users roles" do
-        spree_post :create, { user: { first_name: "Bob", spree_role_ids: [dummy_role.id] } }
+        post :create, { user: { first_name: "Bob", spree_role_ids: [dummy_role.id] } }
         expect(user.spree_roles).to eq([])
       end
 
       it "can create user without roles" do
-        spree_post :create, { user: { first_name: "Bob" } }
+        post :create, { user: { first_name: "Bob" } }
         expect(user.spree_roles).to eq([])
       end
     end
 
     it "can create a shipping_address" do
-      spree_post :create, { user: { ship_address_attributes: valid_address_attributes } }
+      post :create, { user: { ship_address_attributes: valid_address_attributes } }
       expect(user.reload.ship_address.city).to eq('New York')
     end
 
     it "can create a billing_address" do
-      spree_post :create, { user: { bill_address_attributes: valid_address_attributes } }
+      post :create, { user: { bill_address_attributes: valid_address_attributes } }
       expect(user.reload.bill_address.city).to eq('New York')
     end
 
     it "can set stock locations" do
       location = Spree::StockLocation.create(name: "my_location")
       location_2 = Spree::StockLocation.create(name: "my_location_2")
-      spree_post :create, { user: { stock_location_ids: [location.id, location_2.id] } }
+      post :create, { user: { stock_location_ids: [location.id, location_2.id] } }
       expect(user.stock_locations).to match_array([location, location_2])
     end
   end
@@ -142,14 +142,14 @@ describe Spree::Admin::UsersController, type: :controller do
 
       it "can set roles" do
         expect {
-          spree_put :update, { id: user.id, user: { first_name: "Bob", spree_role_ids: [dummy_role.id] } }
+          put :update, { id: user.id, user: { first_name: "Bob", spree_role_ids: [dummy_role.id] } }
         }.to change { user.reload.spree_roles.to_a }.to([dummy_role])
       end
 
       it "can clear roles" do
         user.spree_roles << dummy_role
         expect {
-          spree_put :update, { id: user.id, user: { first_name: "Bob", spree_role_ids: [] } }
+          put :update, { id: user.id, user: { first_name: "Bob", spree_role_ids: [] } }
         }.to change { user.reload.spree_roles.to_a }.to([])
       end
     end
@@ -157,14 +157,14 @@ describe Spree::Admin::UsersController, type: :controller do
     context "when the user cannot manage roles" do
       it "cannot set roles" do
         expect {
-          spree_put :update, { id: user.id, user: { first_name: "Bob", spree_role_ids: [dummy_role.id] } }
+          put :update, { id: user.id, user: { first_name: "Bob", spree_role_ids: [dummy_role.id] } }
         }.not_to change { user.reload.spree_roles.to_a }
       end
 
       it "cannot clear roles" do
         user.spree_roles << dummy_role
         expect {
-          spree_put :update, { id: user.id, user: { first_name: "Bob" } }
+          put :update, { id: user.id, user: { first_name: "Bob" } }
         }.not_to change { user.reload.spree_roles.to_a }
       end
     end
@@ -176,7 +176,7 @@ describe Spree::Admin::UsersController, type: :controller do
 
       it "can change email of a user" do
         expect {
-          spree_put :update, { id: user.id, user: { email: "bob@example.com" } }
+          put :update, { id: user.id, user: { email: "bob@example.com" } }
         }.to change { user.reload.email }.to("bob@example.com")
       end
     end
@@ -188,25 +188,25 @@ describe Spree::Admin::UsersController, type: :controller do
 
       it "cannot change email of a user" do
         expect {
-          spree_put :update, { id: user.id, user: { email: "bob@example.com" } }
+          put :update, { id: user.id, user: { email: "bob@example.com" } }
         }.not_to change { user.reload.email }
       end
     end
 
     it "can update ship_address attributes" do
-      spree_post :update, { id: user.id, user: { ship_address_attributes: valid_address_attributes } }
+      post :update, { id: user.id, user: { ship_address_attributes: valid_address_attributes } }
       expect(user.reload.ship_address.city).to eq('New York')
     end
 
     it "can update bill_address attributes" do
-      spree_post :update, { id: user.id, user: { bill_address_attributes: valid_address_attributes } }
+      post :update, { id: user.id, user: { bill_address_attributes: valid_address_attributes } }
       expect(user.reload.bill_address.city).to eq('New York')
     end
 
     it "can set stock locations" do
       location = Spree::StockLocation.create(name: "my_location")
       location_2 = Spree::StockLocation.create(name: "my_location_2")
-      spree_post :update, { id: user.id, user: { stock_location_ids: [location.id, location_2.id] } }
+      post :update, { id: user.id, user: { stock_location_ids: [location.id, location_2.id] } }
       expect(user.stock_locations).to match_array([location, location_2])
     end
   end
@@ -220,13 +220,13 @@ describe Spree::Admin::UsersController, type: :controller do
     before { user.orders << order }
 
     it "assigns a list of the users orders" do
-      spree_get :orders, { id: user.id }
+      get :orders, { id: user.id }
       expect(assigns[:orders].count).to eq 1
       expect(assigns[:orders].first).to eq order
     end
 
     it "assigns a ransack search for Spree::Order" do
-      spree_get :orders, { id: user.id }
+      get :orders, { id: user.id }
       expect(assigns[:search]).to be_a Ransack::Search
       expect(assigns[:search].klass).to eq Spree::Order
     end
@@ -241,13 +241,13 @@ describe Spree::Admin::UsersController, type: :controller do
     before { user.orders << order }
 
     it "assigns a list of the users orders" do
-      spree_get :items, { id: user.id }
+      get :items, { id: user.id }
       expect(assigns[:orders].count).to eq 1
       expect(assigns[:orders].first).to eq order
     end
 
     it "assigns a ransack search for Spree::Order" do
-      spree_get :items, { id: user.id }
+      get :items, { id: user.id }
       expect(assigns[:search]).to be_a Ransack::Search
       expect(assigns[:search].klass).to eq Spree::Order
     end

--- a/backend/spec/controllers/spree/admin/variants_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/variants_controller_spec.rb
@@ -14,7 +14,7 @@ module Spree
 
         context "deleted is not requested" do
           it "does not assign deleted variants for a requested product" do
-            spree_get :index, product_id: product.slug
+            get :index, product_id: product.slug
             expect(assigns(:collection)).to include variant_1
             expect(assigns(:collection)).not_to include variant_2
           end
@@ -22,7 +22,7 @@ module Spree
 
         context "deleted is requested" do
           it "assigns deleted along with non-deleted variants for a requested product" do
-            spree_get :index, product_id: product.slug, deleted: "on"
+            get :index, product_id: product.slug, deleted: "on"
             expect(assigns(:collection)).to include variant_1
             expect(assigns(:collection)).to include variant_2
           end

--- a/core/lib/spree/testing_support/controller_requests.rb
+++ b/core/lib/spree/testing_support/controller_requests.rb
@@ -49,37 +49,45 @@ module Spree
       def spree_get(action, parameters = nil, session = nil, flash = nil)
         process_spree_action(action, parameters, session, flash, "GET")
       end
+      deprecate spree_get: :get, deprecator: Spree::Deprecation
 
       # Executes a request simulating POST HTTP method and set/volley the response
       def spree_post(action, parameters = nil, session = nil, flash = nil)
         process_spree_action(action, parameters, session, flash, "POST")
       end
+      deprecate spree_post: :post, deprecator: Spree::Deprecation
 
       # Executes a request simulating PUT HTTP method and set/volley the response
       def spree_put(action, parameters = nil, session = nil, flash = nil)
         process_spree_action(action, parameters, session, flash, "PUT")
       end
+      deprecate spree_put: :put, deprecator: Spree::Deprecation
 
       # Executes a request simulating DELETE HTTP method and set/volley the response
       def spree_delete(action, parameters = nil, session = nil, flash = nil)
         process_spree_action(action, parameters, session, flash, "DELETE")
       end
+      deprecate spree_delete: :delete, deprecator: Spree::Deprecation
 
       def spree_xhr_get(action, parameters = nil, session = nil, flash = nil)
         process_spree_xhr_action(action, parameters, session, flash, :get)
       end
+      deprecate spree_xhr_get: :get, deprecator: Spree::Deprecation
 
       def spree_xhr_post(action, parameters = nil, session = nil, flash = nil)
         process_spree_xhr_action(action, parameters, session, flash, :post)
       end
+      deprecate spree_xhr_post: :post, deprecator: Spree::Deprecation
 
       def spree_xhr_put(action, parameters = nil, session = nil, flash = nil)
         process_spree_xhr_action(action, parameters, session, flash, :put)
       end
+      deprecate spree_xhr_put: :put, deprecator: Spree::Deprecation
 
       def spree_xhr_delete(action, parameters = nil, session = nil, flash = nil)
         process_spree_xhr_action(action, parameters, session, flash, :delete)
       end
+      deprecate spree_xhr_delete: :delete, deprecator: Spree::Deprecation
 
       private
 

--- a/frontend/spec/controllers/controller_extension_spec.rb
+++ b/frontend/spec/controllers/controller_extension_spec.rb
@@ -49,7 +49,7 @@ describe Spree::CustomController, type: :controller do
 
         describe "GET" do
           it "has value success" do
-            spree_get :index
+            get :index
             expect(response).to be_success
             expect(response.body).to match(/success!!!/)
           end
@@ -66,7 +66,7 @@ describe Spree::CustomController, type: :controller do
 
         describe "GET" do
           it "has value success" do
-            spree_get :index
+            get :index
             expect(response).to be_success
             expect(response.body).to match(/success!!!/)
           end
@@ -83,7 +83,7 @@ describe Spree::CustomController, type: :controller do
 
         describe "GET" do
           it "has value success" do
-            spree_get :index
+            get :index
             expect(response).to be_redirect
           end
         end
@@ -100,7 +100,7 @@ describe Spree::CustomController, type: :controller do
 
         describe "POST" do
           it "has value success" do
-            spree_post :create
+            post :create
             expect(response).to be_success
             expect(response.body).to match(/success!/)
           end
@@ -116,7 +116,7 @@ describe Spree::CustomController, type: :controller do
 
         describe "POST" do
           it "should not effect the wrong controller" do
-            spree_get :index
+            get :index
             expect(response.body).to match(/neutral/)
           end
         end

--- a/frontend/spec/controllers/controller_helpers_spec.rb
+++ b/frontend/spec/controllers/controller_helpers_spec.rb
@@ -18,7 +18,7 @@ describe Spree::ProductsController, type: :controller do
   # Regression test for https://github.com/spree/spree/issues/1184
   it "sets the default locale based off Spree::Frontend::Config[:locale]" do
     expect(I18n.locale).to eq(:en)
-    spree_get :index
+    get :index
     expect(I18n.locale).to eq(:de)
   end
 end

--- a/frontend/spec/controllers/spree/checkout_controller_spec.rb
+++ b/frontend/spec/controllers/spree/checkout_controller_spec.rb
@@ -20,31 +20,31 @@ describe Spree::CheckoutController, type: :controller do
     it 'should check if the user is authorized for :edit' do
       expect(controller).to receive(:authorize!).with(:edit, order, token)
       request.cookie_jar.signed[:guest_token] = token
-      spree_get :edit, { state: 'address' }
+      get :edit, { state: 'address' }
     end
 
     it "should redirect to the cart path unless checkout_allowed?" do
       allow(order).to receive_messages checkout_allowed?: false
-      spree_get :edit, { state: "delivery" }
+      get :edit, { state: "delivery" }
       expect(response).to redirect_to(spree.cart_path)
     end
 
     it "should redirect to the cart path if current_order is nil" do
       allow(controller).to receive(:current_order).and_return(nil)
-      spree_get :edit, { state: "delivery" }
+      get :edit, { state: "delivery" }
       expect(response).to redirect_to(spree.cart_path)
     end
 
     it "should redirect to cart if order is completed" do
       allow(order).to receive_messages(completed?: true)
-      spree_get :edit, { state: "address" }
+      get :edit, { state: "address" }
       expect(response).to redirect_to(spree.cart_path)
     end
 
     # Regression test for https://github.com/spree/spree/issues/2280
     it "should redirect to current step trying to access a future step" do
       order.update_column(:state, "address")
-      spree_get :edit, { state: "delivery" }
+      get :edit, { state: "delivery" }
       expect(response).to redirect_to spree.checkout_state_path("address")
     end
 
@@ -58,7 +58,7 @@ describe Spree::CheckoutController, type: :controller do
       it "should associate the order with a user" do
         order.update_column :user_id, nil
         expect(order).to receive(:associate_user!).with(user)
-        spree_get :edit, {}, order_id: 1
+        get :edit, {}, order_id: 1
       end
     end
   end
@@ -67,12 +67,12 @@ describe Spree::CheckoutController, type: :controller do
     it 'should check if the user is authorized for :edit' do
       expect(controller).to receive(:authorize!).with(:edit, order, token)
       request.cookie_jar.signed[:guest_token] = token
-      spree_post :update, { state: 'address' }
+      post :update, { state: 'address' }
     end
 
     context "save successful" do
-      def spree_post_address
-        spree_post :update, {
+      def post_address
+        post :update, {
           state: "address",
           order: {
             bill_address_attributes: address_params,
@@ -95,24 +95,24 @@ describe Spree::CheckoutController, type: :controller do
         end
 
         it "should assign order" do
-          spree_post :update, { state: "address" }
+          post :update, { state: "address" }
           expect(assigns[:order]).not_to be_nil
         end
 
         it "should advance the state" do
-          spree_post_address
+          post_address
           expect(order.reload.state).to eq("delivery")
         end
 
         it "should redirect the next state" do
-          spree_post_address
+          post_address
           expect(response).to redirect_to spree.checkout_state_path("delivery")
         end
 
         context "current_user respond to save address method" do
           it "calls persist order address on user" do
             expect(user).to receive(:persist_order_address)
-            spree_post :update, {
+            post :update, {
               state: "address",
               order: {
                 bill_address_attributes: address_params,
@@ -125,7 +125,7 @@ describe Spree::CheckoutController, type: :controller do
 
         context "current_user doesnt respond to persist_order_address" do
           it "doesnt raise any error" do
-            spree_post :update, {
+            post :update, {
               state: "address",
               order: {
                 bill_address_attributes: address_params,
@@ -148,7 +148,7 @@ describe Spree::CheckoutController, type: :controller do
             @expected_bill_address_id = order.bill_address.id
             @expected_ship_address_id = order.ship_address.id
 
-            spree_post :update, {
+            post :update, {
                 state: "address",
                 order: {
                     bill_address_attributes: order.bill_address.attributes.except("created_at", "updated_at"),
@@ -208,7 +208,7 @@ describe Spree::CheckoutController, type: :controller do
         end
 
         it 'sets the payment amount' do
-          spree_post :update, params
+          post :update, params
           order.reload
           expect(order.state).to eq('new_step')
           expect(order.payments.size).to eq(1)
@@ -229,17 +229,17 @@ describe Spree::CheckoutController, type: :controller do
 
         # This inadvertently is a regression test for https://github.com/spree/spree/issues/2694
         it "should redirect to the order view" do
-          spree_post :update, { state: "confirm" }
+          post :update, { state: "confirm" }
           expect(response).to redirect_to spree.order_path(order)
         end
 
         it "should populate the flash message" do
-          spree_post :update, { state: "confirm" }
+          post :update, { state: "confirm" }
           expect(flash.notice).to eq(Spree.t(:order_processed_successfully))
         end
 
         it "should remove completed order from current_order" do
-          spree_post :update, { state: "confirm" }, { order_id: "foofah" }
+          post :update, { state: "confirm" }, { order_id: "foofah" }
           expect(assigns(:current_order)).to be_nil
           expect(assigns(:order)).to eql controller.current_order
         end
@@ -253,16 +253,16 @@ describe Spree::CheckoutController, type: :controller do
       end
 
       it "should not assign order" do
-        spree_post :update, { state: "address", email: '' }
+        post :update, { state: "address", email: '' }
         expect(assigns[:order]).not_to be_nil
       end
 
       it "should not change the order state" do
-        spree_post :update, { state: 'address' }
+        post :update, { state: 'address' }
       end
 
       it "should render the edit template" do
-        spree_post :update, { state: 'address' }
+        post :update, { state: 'address' }
         expect(response).to render_template :edit
       end
     end
@@ -272,11 +272,11 @@ describe Spree::CheckoutController, type: :controller do
 
       it "should not change the state if order is completed" do
         expect(order).not_to receive(:update_attribute)
-        spree_post :update, { state: "confirm" }
+        post :update, { state: "confirm" }
       end
 
       it "should redirect to the cart_path" do
-        spree_post :update, { state: "confirm" }
+        post :update, { state: "confirm" }
         expect(response).to redirect_to spree.cart_path
       end
     end
@@ -285,7 +285,7 @@ describe Spree::CheckoutController, type: :controller do
       before do
         order.update_attributes! user: user
         allow(order).to receive(:next).and_raise(Spree::Core::GatewayError.new("Invalid something or other."))
-        spree_post :update, { state: "address" }
+        post :update, { state: "address" }
       end
 
       it "should render the edit template and display exception message" do
@@ -316,7 +316,7 @@ describe Spree::CheckoutController, type: :controller do
         end
 
         it "due to the order having errors" do
-          spree_put :update, state: order.state, order: {}
+          put :update, state: order.state, order: {}
           expect(flash[:error]).to eq("Base error\nAdjustments error")
           expect(response).to redirect_to(spree.checkout_state_path('address'))
         end
@@ -351,7 +351,7 @@ describe Spree::CheckoutController, type: :controller do
           expect(order.shipments.count).to eq(1)
           order.shipments.first.shipping_rates.delete_all
           order.update_attributes(state: 'confirm')
-          spree_put :update, state: order.state, order: {}
+          put :update, state: order.state, order: {}
           expect(flash[:error]).to eq(Spree.t(:items_cannot_be_shipped))
           expect(response).to redirect_to(spree.checkout_state_path('confirm'))
         end
@@ -379,7 +379,7 @@ describe Spree::CheckoutController, type: :controller do
 
       it "fails to transition from payment to complete" do
         allow_any_instance_of(Spree::Payment).to receive(:process!).and_raise(Spree::Core::GatewayError.new(Spree.t(:payment_processing_failed)))
-        spree_put :update, state: order.state, order: {}
+        put :update, state: order.state, order: {}
         expect(flash[:error]).to eq(Spree.t(:payment_processing_failed))
       end
     end
@@ -401,7 +401,7 @@ describe Spree::CheckoutController, type: :controller do
 
     context "and back orders are not allowed" do
       before do
-        spree_post :update, { state: "payment" }
+        post :update, { state: "payment" }
       end
 
       it "should redirect to cart" do
@@ -423,12 +423,12 @@ describe Spree::CheckoutController, type: :controller do
 
     it "doesn't set shipping address on the order" do
       expect(order).to_not receive(:ship_address=)
-      spree_post :update, state: order.state
+      post :update, state: order.state
     end
 
     it "doesn't remove unshippable items before payment" do
       expect {
-        spree_post :update, { state: "payment" }
+        post :update, { state: "payment" }
       }.to_not change { order.line_items }
     end
   end
@@ -438,7 +438,7 @@ describe Spree::CheckoutController, type: :controller do
     allow(controller).to receive_messages check_authorization: true
 
     expect {
-      spree_post :update, { state: "payment" }
+      post :update, { state: "payment" }
     }.to change { order.line_items }
   end
 end

--- a/frontend/spec/controllers/spree/checkout_controller_with_views_spec.rb
+++ b/frontend/spec/controllers/spree/checkout_controller_with_views_spec.rb
@@ -27,7 +27,7 @@ describe Spree::CheckoutController, type: :controller do
       end
 
       it "displays rate cost in correct currency" do
-        spree_get :edit
+        get :edit
         html = Nokogiri::HTML(response.body)
         expect(html.css('.rate-cost').text).to eq "£10.00"
       end

--- a/frontend/spec/controllers/spree/content_controller_spec.rb
+++ b/frontend/spec/controllers/spree/content_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 describe Spree::ContentController, type: :controller do
   it "should display CVV page" do
-    spree_get :cvv
+    get :cvv
     expect(response.response_code).to eq(200)
   end
 end

--- a/frontend/spec/controllers/spree/current_order_tracking_spec.rb
+++ b/frontend/spec/controllers/spree/current_order_tracking_spec.rb
@@ -24,7 +24,7 @@ describe 'current order tracking', type: :controller do
 
     it "doesn't create a new order out of the blue" do
       expect {
-        spree_get :index
+        get :index
       }.not_to change { Spree::Order.count }
     end
   end
@@ -38,7 +38,7 @@ describe Spree::OrdersController, type: :controller do
   describe Spree::OrdersController do
     it "doesn't create a new order out of the blue" do
       expect {
-        spree_get :edit
+        get :edit
       }.not_to change { Spree::Order.count }
     end
   end

--- a/frontend/spec/controllers/spree/home_controller_spec.rb
+++ b/frontend/spec/controllers/spree/home_controller_spec.rb
@@ -5,13 +5,13 @@ describe Spree::HomeController, type: :controller do
     user = mock_model(Spree.user_class, last_incomplete_spree_order: nil, spree_api_key: 'fake')
     allow(controller).to receive_messages try_spree_current_user: user
     expect_any_instance_of(Spree::Config.searcher_class).to receive(:current_user=).with(user)
-    spree_get :index
+    get :index
     expect(response.status).to eq(200)
   end
 
   context "layout" do
     it "renders default layout" do
-      spree_get :index
+      get :index
       expect(response).to render_template(layout: 'spree/layouts/spree_application')
     end
 
@@ -19,7 +19,7 @@ describe Spree::HomeController, type: :controller do
       before { Spree::Config.layout = 'layouts/application' }
 
       it "renders specified layout" do
-        spree_get :index
+        get :index
         expect(response).to render_template(layout: 'layouts/application')
       end
     end

--- a/frontend/spec/controllers/spree/orders_controller_ability_spec.rb
+++ b/frontend/spec/controllers/spree/orders_controller_ability_spec.rb
@@ -25,22 +25,22 @@ module Spree
       context '#populate' do
         it 'should check if user is authorized for :edit' do
           expect(controller).to receive(:authorize!).with(:edit, order, token)
-          spree_post :populate, token: token
+          post :populate, token: token
         end
         it "should check against the specified order" do
           expect(controller).to receive(:authorize!).with(:edit, specified_order, token)
-          spree_post :populate, id: specified_order.number, token: token
+          post :populate, id: specified_order.number, token: token
         end
       end
 
       context '#edit' do
         it 'should check if user is authorized for :edit' do
           expect(controller).to receive(:authorize!).with(:edit, order, token)
-          spree_get :edit, token: token
+          get :edit, token: token
         end
         it "should check against the specified order" do
           expect(controller).to receive(:authorize!).with(:edit, specified_order, token)
-          spree_get :edit, id: specified_order.number, token: token
+          get :edit, id: specified_order.number, token: token
         end
       end
 
@@ -48,30 +48,30 @@ module Spree
         it 'should check if user is authorized for :edit' do
           allow(order).to receive :update_attributes
           expect(controller).to receive(:authorize!).with(:edit, order, token)
-          spree_post :update, order: { email: "foo@bar.com" }, token: token
+          post :update, order: { email: "foo@bar.com" }, token: token
         end
         it "should check against the specified order" do
           allow(order).to receive :update_attributes
           expect(controller).to receive(:authorize!).with(:edit, specified_order, token)
-          spree_post :update, order: { email: "foo@bar.com" }, id: specified_order.number, token: token
+          post :update, order: { email: "foo@bar.com" }, id: specified_order.number, token: token
         end
       end
 
       context '#empty' do
         it 'should check if user is authorized for :edit' do
           expect(controller).to receive(:authorize!).with(:edit, order, token)
-          spree_post :empty, token: token
+          post :empty, token: token
         end
         it "should check against the specified order" do
           expect(controller).to receive(:authorize!).with(:edit, specified_order, token)
-          spree_post :empty, id: specified_order.number, token: token
+          post :empty, id: specified_order.number, token: token
         end
       end
 
       context "#show" do
         it "should check against the specified order" do
           expect(controller).to receive(:authorize!).with(:edit, specified_order, token)
-          spree_get :show, id: specified_order.number, token: token
+          get :show, id: specified_order.number, token: token
         end
       end
     end
@@ -83,19 +83,19 @@ module Spree
         context 'when token parameter present' do
           it 'always ooverride existing token when passing a new one' do
             cookies.signed[:guest_token] = "soo wrong"
-            spree_get :show, { id: 'R123', token: order.guest_token }
+            get :show, { id: 'R123', token: order.guest_token }
             expect(cookies.signed[:guest_token]).to eq(order.guest_token)
           end
 
           it 'should store as guest_token in session' do
-            spree_get :show, { id: 'R123', token: order.guest_token }
+            get :show, { id: 'R123', token: order.guest_token }
             expect(cookies.signed[:guest_token]).to eq(order.guest_token)
           end
         end
 
         context 'when no token present' do
           it 'should respond with 404' do
-            spree_get :show, { id: 'R123' }
+            get :show, { id: 'R123' }
             expect(response.code).to eq('404')
           end
         end

--- a/frontend/spec/controllers/spree/orders_controller_spec.rb
+++ b/frontend/spec/controllers/spree/orders_controller_spec.rb
@@ -16,7 +16,7 @@ describe Spree::OrdersController, type: :controller do
 
     context "#populate" do
       it "should create a new order when none specified" do
-        spree_post :populate, {}, {}
+        post :populate, {}, {}
         expect(cookies.signed[:guest_token]).not_to be_blank
         expect(Spree::Order.find_by_guest_token(cookies.signed[:guest_token])).to be_persisted
       end
@@ -24,7 +24,7 @@ describe Spree::OrdersController, type: :controller do
       context "with Variant" do
         it "should handle population" do
           expect do
-            spree_post :populate, variant_id: variant.id, quantity: 5
+            post :populate, variant_id: variant.id, quantity: 5
           end.to change { user.orders.count }.by(1)
           order = user.orders.last
           expect(response).to redirect_to spree.cart_path
@@ -44,7 +44,7 @@ describe Spree::OrdersController, type: :controller do
               and_return(["Order population failed"])
           )
 
-          spree_post :populate, variant_id: variant.id, quantity: 5
+          post :populate, variant_id: variant.id, quantity: 5
 
           expect(response).to redirect_to(spree.root_path)
           expect(flash[:error]).to eq("Order population failed")
@@ -53,7 +53,7 @@ describe Spree::OrdersController, type: :controller do
         it "shows an error when quantity is invalid" do
           request.env["HTTP_REFERER"] = spree.root_path
 
-          spree_post(
+          post(
             :populate,
             variant_id: variant.id, quantity: -1
           )
@@ -76,13 +76,13 @@ describe Spree::OrdersController, type: :controller do
         it "should render the edit view (on failure)" do
           # email validation is only after address state
           order.update_column(:state, "delivery")
-          spree_put :update, { order: { email: "" } }, { order_id: order.id }
+          put :update, { order: { email: "" } }, { order_id: order.id }
           expect(response).to render_template :edit
         end
 
         it "should redirect to cart path (on success)" do
           allow(order).to receive(:update_attributes).and_return true
-          spree_put :update, {}, { order_id: 1 }
+          put :update, {}, { order_id: 1 }
           expect(response).to redirect_to(spree.cart_path)
         end
       end
@@ -96,7 +96,7 @@ describe Spree::OrdersController, type: :controller do
       it "should destroy line items in the current order" do
         allow(controller).to receive(:current_order).and_return(order)
         expect(order).to receive(:empty!)
-        spree_put :empty
+        put :empty
         expect(response).to redirect_to(spree.cart_path)
       end
     end
@@ -109,7 +109,7 @@ describe Spree::OrdersController, type: :controller do
       end
 
       it "cannot update a blank order" do
-        spree_put :update, order: { email: "foo" }
+        put :update, order: { email: "foo" }
         expect(flash[:error]).to eq(Spree.t(:order_not_found))
         expect(response).to redirect_to(spree.root_path)
       end
@@ -128,7 +128,7 @@ describe Spree::OrdersController, type: :controller do
 
     it "removes line items on update" do
       expect(order.line_items.count).to eq 1
-      spree_put :update, order: { line_items_attributes: { "0" => { id: line_item.id, quantity: 0 } } }
+      put :update, order: { line_items_attributes: { "0" => { id: line_item.id, quantity: 0 } } }
       expect(order.reload.line_items.count).to eq 0
     end
   end

--- a/frontend/spec/controllers/spree/orders_controller_transitions_spec.rb
+++ b/frontend/spec/controllers/spree/orders_controller_transitions_spec.rb
@@ -23,7 +23,7 @@ module Spree
       it "correctly calls the transition callback" do
         expect(order.did_transition).to be_nil
         order.line_items << FactoryGirl.create(:line_item)
-        spree_put :update, { checkout: "checkout" }, { order_id: 1 }
+        put :update, { checkout: "checkout" }, { order_id: 1 }
         expect(order.did_transition).to be true
       end
     end

--- a/frontend/spec/controllers/spree/products_controller_spec.rb
+++ b/frontend/spec/controllers/spree/products_controller_spec.rb
@@ -6,12 +6,12 @@ describe Spree::ProductsController, type: :controller do
   # Regression test for https://github.com/spree/spree/issues/1390
   it "allows admins to view non-active products" do
     allow(controller).to receive_messages spree_current_user: mock_model(Spree.user_class, has_spree_role?: true, last_incomplete_spree_order: nil, spree_api_key: 'fake')
-    spree_get :show, id: product.to_param
+    get :show, id: product.to_param
     expect(response.status).to eq(200)
   end
 
   it "cannot view non-active products" do
-    spree_get :show, id: product.to_param
+    get :show, id: product.to_param
     expect(response.status).to eq(404)
   end
 
@@ -19,7 +19,7 @@ describe Spree::ProductsController, type: :controller do
     user = mock_model(Spree.user_class, last_incomplete_spree_order: nil, spree_api_key: 'fake')
     allow(controller).to receive_messages spree_current_user: user
     expect_any_instance_of(Spree::Config.searcher_class).to receive(:current_user=).with(user)
-    spree_get :index
+    get :index
     expect(response.status).to eq(200)
   end
 
@@ -30,6 +30,6 @@ describe Spree::ProductsController, type: :controller do
     request.env['HTTP_REFERER'] = "not|a$url"
 
     # Previously a URI::InvalidURIError exception was being thrown
-    spree_get :show, id: product.to_param
+    get :show, id: product.to_param
   end
 end

--- a/frontend/spec/controllers/spree/taxons_controller_spec.rb
+++ b/frontend/spec/controllers/spree/taxons_controller_spec.rb
@@ -6,7 +6,7 @@ describe Spree::TaxonsController, type: :controller do
     user = mock_model(Spree.user_class, last_incomplete_spree_order: nil, spree_api_key: 'fake')
     allow(controller).to receive_messages spree_current_user: user
     expect_any_instance_of(Spree::Config.searcher_class).to receive(:current_user=).with(user)
-    spree_get :show, id: taxon.permalink
+    get :show, id: taxon.permalink
     expect(response.status).to eq(200)
   end
 end


### PR DESCRIPTION
The spree_get and similar helpers no longer do anything. The `ControllerRequests` module now [just sets the `routes`](https://github.com/solidusio/solidus/blob/master/core/lib/spree/testing_support/controller_requests.rb#L45-L47) and the `spree_*` helpers don't do anything other than call the standard helpers.