### PR TITLE
Add the ability to get simple results from taxon API

### DIFF
--- a/api/app/controllers/spree/api/taxons_controller.rb
+++ b/api/app/controllers/spree/api/taxons_controller.rb
@@ -66,6 +66,17 @@ module Spree
         # Products#index does not do the sorting.
         taxon = Spree::Taxon.find(params[:id])
         @products = paginate(taxon.products.ransack(params[:q]).result)
+        @products = @products.includes(master: :default_price)
+
+        if params[:simple]
+          @exclude_data = {
+            variants: true,
+            option_types: true,
+            product_properties: true,
+            classifications: true
+          }
+          @product_attributes = %i(id name display_price)
+        end
         render "spree/api/products/index"
       end
 

--- a/api/app/views/spree/api/products/index.v1.rabl
+++ b/api/app/views/spree/api/products/index.v1.rabl
@@ -1,5 +1,5 @@
 object false
-node(:count) { @products.count }
+node(:count) { @products.size }
 node(:total_count) { @products.total_count }
 node(:current_page) { @products.current_page }
 node(:per_page) { @products.limit_value }

--- a/api/app/views/spree/api/products/show.v1.rabl
+++ b/api/app/views/spree/api/products/show.v1.rabl
@@ -1,31 +1,42 @@
 object @product
 cache [I18n.locale, @current_user_roles.include?('admin'), current_pricing_options, root_object]
 
-attributes *product_attributes
+@product_attributes ||= product_attributes
+attributes(*@product_attributes)
 
 node(:display_price) { |p| p.display_price.to_s }
-node(:has_variants) { |p| p.has_variants? }
 
-child :master => :master do
-  extends "spree/api/variants/small"
+@exclude_data ||= {}
+unless @exclude_data[:variants]
+  node(:has_variants) { |p| p.has_variants? }
+
+  child :master => :master do
+    extends "spree/api/variants/small"
+  end
+
+  child :variants => :variants do
+    extends "spree/api/variants/small"
+  end
 end
 
-child :variants => :variants do
-  extends "spree/api/variants/small"
+unless @exclude_data[:option_types]
+  child :option_types => :option_types do
+    attributes(*option_type_attributes)
+  end
 end
 
-child :option_types => :option_types do
-  attributes *option_type_attributes
+unless @exclude_data[:product_properties]
+  child :product_properties => :product_properties do
+    attributes(*product_property_attributes)
+  end
 end
 
-child :product_properties => :product_properties do
-  attributes *product_property_attributes
-end
+unless @exclude_data[:classifications]
+  child :classifications => :classifications do
+    attributes :taxon_id, :position
 
-child :classifications => :classifications do
-  attributes :taxon_id, :position
-
-  child(:taxon) do
-    extends "spree/api/taxons/show"
+    child(:taxon) do
+      extends "spree/api/taxons/show"
+    end
   end
 end

--- a/backend/app/assets/javascripts/spree/backend/taxons.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/taxons.js.coffee
@@ -68,6 +68,6 @@ $ ->
   $('#taxon_id').on "change", (e) ->
     Spree.ajax
       url: Spree.routes.taxon_products_api,
-      data: { id: e.val }
+      data: { id: e.val, simple: 1 }
       success: (data) ->
         sortable.html productListTemplate(data.products)


### PR DESCRIPTION
The taxon products API which is used to manage display order falls down
under its own weight in any sort of reasonable data set. In order to
simplify that, I have added the ability to customize the return data
from this controller.

In a simple case, the results will be the same as they are right now,
however you can pass `simple: 1` to the taxon/products API request and
it will return significantly less data.

Additionally, this updates the backend taxons.js.coffee to use this
simple view for all it needs. This reduces the amount of data that needs
to be queried and returned in order to make this fast. Previously I was
seeing 20+ second response times for a small number of products in a
complicated taxon structure. This reduces that down to the 100ms range.