### PR TITLE
Control raising of deprecations through ENV var

### DIFF
--- a/core/lib/generators/spree/dummy/templates/rails/test.rb
+++ b/core/lib/generators/spree/dummy/templates/rails/test.rb
@@ -30,5 +30,7 @@ Dummy::Application.configure do
   ActionMailer::Base.default :from => "spree@example.com"
 
   # Raise on deprecation warnings
-  Spree::Deprecation.behavior = :raise
+  if ENV['SOLIDUS_RAISE_DEPRECATIONS'].present?
+    Spree::Deprecation.behavior = :raise
+  end
 end


### PR DESCRIPTION
In #1255 we started raising on any depredations in the test suite.

I think this has been great in core, but in extensions, which also use the test_app, I feel this has been a little too aggressive.

This allows extensions to opt-in or out of raising on deprecations.