### PR TITLE
Fix user picker's select2 initial selection

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/user_picker.js
+++ b/backend/app/assets/javascripts/spree/backend/user_picker.js
@@ -9,10 +9,14 @@ $.fn.userAutocomplete = function () {
     minimumInputLength: 1,
     multiple: true,
     initSelection: function (element, callback) {
-      $.get(Spree.routes.users_api, {
-        ids: element.val()
-      }, function (data) {
-        callback(data.users);
+      Spree.ajax({
+        url: Spree.routes.users_api,
+        data: {
+          ids: element.val()
+        },
+        success: function(data) {
+          callback(data.users);
+        }
       });
     },
     ajax: {


### PR DESCRIPTION
  - was failing because of missing `token: Spree.api_key`

  - going through the Spree.ajax automatically adds the `api_key`