### PR TITLE
Refund indexes

### DIFF
--- a/core/db/migrate/20160718205341_add_payment_id_index_to_spree_refunds.rb
+++ b/core/db/migrate/20160718205341_add_payment_id_index_to_spree_refunds.rb
@@ -1,0 +1,5 @@
+class AddPaymentIdIndexToSpreeRefunds < ActiveRecord::Migration
+  def change
+    add_index(:spree_refunds, :payment_id)
+  end
+end

--- a/core/db/migrate/20160718205859_add_reimbursement_id_index_to_spree_refunds.rb
+++ b/core/db/migrate/20160718205859_add_reimbursement_id_index_to_spree_refunds.rb
@@ -1,0 +1,5 @@
+class AddReimbursementIdIndexToSpreeRefunds < ActiveRecord::Migration
+  def change
+    add_index(:spree_refunds, :reimbursement_id)
+  end
+end


### PR DESCRIPTION
There were two indexes that were missing from the refunds table that slow down queries that use them. When the table was created, the migration created them as integer fields instead of using the `references` helper which adds a foreign key column and the index together.