### PR TITLE
Give populate_redirect its own controller action

### DIFF
--- a/frontend/app/controllers/spree/orders_controller.rb
+++ b/frontend/app/controllers/spree/orders_controller.rb
@@ -66,6 +66,11 @@ module Spree
       end
     end
 
+    def populate_redirect
+      flash[:error] = Spree.t(:populate_get_error)
+      redirect_to('/cart')
+    end
+
     def empty
       if @order = current_order
         @order.empty!

--- a/frontend/config/routes.rb
+++ b/frontend/config/routes.rb
@@ -10,12 +10,7 @@ Spree::Core::Engine.routes.draw do
   get '/checkout/:state', to: 'checkout#edit', as: :checkout_state
   get '/checkout', to: 'checkout#edit', as: :checkout
 
-  populate_redirect = redirect do |_params, request|
-    request.flash[:error] = Spree.t(:populate_get_error)
-    request.referer || '/cart'
-  end
-
-  get '/orders/populate', to: populate_redirect
+  get '/orders/populate', to: 'orders#populate_redirect'
   get '/orders/:id/token/:token' => 'orders#show', :as => :token_order
 
   resources :orders, except: [:index, :new, :create, :destroy] do


### PR DESCRIPTION
For some reason setting the flash in the inline redirect doesn't work in rails 5.