### PR TITLE
Avoid alias_method_chain in OptionValue promo rule

### DIFF
--- a/core/app/models/spree/promotion/rules/option_value.rb
+++ b/core/app/models/spree/promotion/rules/option_value.rb
@@ -24,15 +24,14 @@ module Spree
           product_ids.include?(pid) && (value_ids(pid) & ovids).present?
         end
 
-        def preferred_eligible_values_with_numerification
-          values = preferred_eligible_values_without_numerification || {}
+        def preferred_eligible_values
+          values = preferences[:eligible_values] || {}
           Hash[values.keys.map(&:to_i).zip(
             values.values.map do |v|
               (v.is_a?(Array) ? v : v.split(",")).map(&:to_i)
             end
           )]
         end
-        alias_method_chain :preferred_eligible_values, :numerification
 
         private
 


### PR DESCRIPTION
`alias_method_chain` is deprecated in rails5.