### PR TITLE
Remove calls to silence_stream

### DIFF
--- a/core/lib/generators/spree/install/install_generator.rb
+++ b/core/lib/generators/spree/install/install_generator.rb
@@ -108,24 +108,18 @@ Spree::Auth::Engine.load_seed if defined?(Spree::Auth)
 
     def install_migrations
       say_status :copying, "migrations"
-      silence_stream(STDOUT) do
-        silence_warnings { rake 'railties:install:migrations' }
-      end
+      rake 'railties:install:migrations'
     end
 
     def create_database
       say_status :creating, "database"
-      silence_stream(STDOUT) do
-        silence_stream(STDERR) do
-          silence_warnings { rake 'db:create' }
-        end
-      end
+      rake 'db:create'
     end
 
     def run_migrations
       if @run_migrations
         say_status :running, "migrations"
-        quietly { rake 'db:migrate' }
+        rake 'db:migrate'
       else
         say_status :skipping, "migrations (don't forget to run rake db:migrate)"
       end
@@ -139,12 +133,7 @@ Spree::Auth::Engine.load_seed if defined?(Spree::Auth)
         rake_options << "ADMIN_EMAIL=#{options[:admin_email]}" if options[:admin_email]
         rake_options << "ADMIN_PASSWORD=#{options[:admin_password]}" if options[:admin_password]
 
-        cmd = lambda { rake("db:seed #{rake_options.join(' ')}") }
-        if options[:auto_accept] || (options[:admin_email] && options[:admin_password])
-          quietly(&cmd)
-        else
-          cmd.call
-        end
+        rake("db:seed #{rake_options.join(' ')}")
       else
         say_status :skipping, "seed data (you can always run rake db:seed)"
       end
@@ -153,7 +142,7 @@ Spree::Auth::Engine.load_seed if defined?(Spree::Auth)
     def load_sample_data
       if @load_sample_data
         say_status :loading, "sample data"
-        quietly { rake 'spree_sample:load' }
+        rake 'spree_sample:load'
       else
         say_status :skipping, "sample data (you can always run rake spree_sample:load)"
       end

--- a/core/lib/generators/spree/install/install_generator.rb
+++ b/core/lib/generators/spree/install/install_generator.rb
@@ -108,7 +108,7 @@ Spree::Auth::Engine.load_seed if defined?(Spree::Auth)
 
     def install_migrations
       say_status :copying, "migrations"
-      rake 'railties:install:migrations'
+      `rake railties:install:migrations`
     end
 
     def create_database
@@ -119,7 +119,8 @@ Spree::Auth::Engine.load_seed if defined?(Spree::Auth)
     def run_migrations
       if @run_migrations
         say_status :running, "migrations"
-        rake 'db:migrate'
+
+        rake 'db:migrate VERBOSE=false'
       else
         say_status :skipping, "migrations (don't forget to run rake db:migrate)"
       end

--- a/core/lib/spree/migrations.rb
+++ b/core/lib/spree/migrations.rb
@@ -22,13 +22,6 @@ module Spree
     # engine name on the file name
     def check
       if File.directory?(app_dir)
-        engine_in_app = app_migrations.map do |file_name|
-          name, engine = file_name.split(".", 2)
-          next unless match_engine?(engine)
-          name
-        end.compact
-
-        missing_migrations = engine_migrations.sort - engine_in_app.sort
         unless missing_migrations.empty?
           puts "[#{engine_name.capitalize} WARNING] Missing migrations."
           missing_migrations.each do |migration|
@@ -38,6 +31,19 @@ module Spree
           true
         end
       end
+    end
+
+    def missing_migrations
+      @missing_migrations ||=
+        begin
+          engine_in_app = app_migrations.map do |file_name|
+            name, engine = file_name.split(".", 2)
+            next unless match_engine?(engine)
+            name
+          end.compact
+
+          engine_migrations.sort - engine_in_app.sort
+        end
     end
 
     private

--- a/core/lib/spree/testing_support/common_rake.rb
+++ b/core/lib/spree/testing_support/common_rake.rb
@@ -17,9 +17,7 @@ namespace :common do
 
     puts "Setting up dummy database..."
 
-    silence_stream(STDOUT) do
-      sh "bundle exec rake db:drop db:create db:migrate"
-    end
+    sh "bundle exec rake db:drop db:create db:migrate"
 
     begin
       require "generators/#{ENV['LIB_NAME']}/install/install_generator"
@@ -33,8 +31,6 @@ namespace :common do
   task :seed do |_t, _args|
     puts "Seeding ..."
 
-    silence_stream(STDOUT) do
-      sh "bundle exec rake db:seed RAILS_ENV=test"
-    end
+    sh "bundle exec rake db:seed RAILS_ENV=test"
   end
 end

--- a/core/lib/spree/testing_support/common_rake.rb
+++ b/core/lib/spree/testing_support/common_rake.rb
@@ -17,7 +17,7 @@ namespace :common do
 
     puts "Setting up dummy database..."
 
-    sh "bundle exec rake db:drop db:create db:migrate VERBOSE=false"
+    sh "bundle exec rake db:migrate VERBOSE=false"
 
     begin
       require "generators/#{ENV['LIB_NAME']}/install/install_generator"

--- a/core/lib/spree/testing_support/common_rake.rb
+++ b/core/lib/spree/testing_support/common_rake.rb
@@ -17,7 +17,7 @@ namespace :common do
 
     puts "Setting up dummy database..."
 
-    sh "bundle exec rake db:drop db:create db:migrate"
+    sh "bundle exec rake db:drop db:create db:migrate VERBOSE=false"
 
     begin
       require "generators/#{ENV['LIB_NAME']}/install/install_generator"

--- a/core/lib/spree/testing_support/common_rake.rb
+++ b/core/lib/spree/testing_support/common_rake.rb
@@ -24,7 +24,7 @@ namespace :common do
       puts 'Running extension installation generator...'
       "#{ENV['LIB_NAME'].camelize}::Generators::InstallGenerator".constantize.start(["--auto-run-migrations"])
     rescue LoadError
-      puts 'Skipping installation no generator to run...'
+      # No extension generator to run
     end
   end
 

--- a/core/spec/lib/spree/migrations_spec.rb
+++ b/core/spec/lib/spree/migrations_spec.rb
@@ -20,9 +20,7 @@ module Spree
       expect(Dir).to receive(:entries).with(app_dir).and_return app_migrations
       expect(Dir).to receive(:entries).with(engine_dir).and_return engine_migrations
 
-      silence_stream(STDOUT) {
-        expect(subject.check).to eq true
-      }
+      expect(subject.check).to eq true
     end
 
     context "no missing migrations" do

--- a/core/spec/lib/spree/migrations_spec.rb
+++ b/core/spec/lib/spree/migrations_spec.rb
@@ -12,22 +12,18 @@ module Spree
 
     subject { described_class.new(config, "spree") }
 
-    before do
-      expect(File).to receive(:directory?).with(app_dir).and_return true
-    end
-
-    it "warns about missing migrations" do
+    it "detects missing migrations" do
       expect(Dir).to receive(:entries).with(app_dir).and_return app_migrations
       expect(Dir).to receive(:entries).with(engine_dir).and_return engine_migrations
 
-      expect(subject.check).to eq true
+      expect(subject.missing_migrations.size).to eq 2
     end
 
     context "no missing migrations" do
       it "says nothing" do
         expect(Dir).to receive(:entries).with(engine_dir).and_return engine_migrations
         expect(Dir).to receive(:entries).with(app_dir).and_return(app_migrations + engine_migrations)
-        expect(subject.check).to eq nil
+        expect(subject.missing_migrations.size).to eq 0
       end
     end
   end

--- a/lib/sandbox.sh
+++ b/lib/sandbox.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 # Used in the sandbox rake task in Rakefile
 
+set -e
+
 case "$DB" in
 postgres|postgresql)
   RAILSDB="postgresql"


### PR DESCRIPTION
`Kernel#silence_stream` is deprecated in rails 4.2 (only in the docs, it doesn't issue a warning) and has been removed in rails 5.

`silence_stream` also was hiding any warnings (or errors) from migrations, generators, and seed in our test_app and sandbox.

Instead, this PR tries to make all of the setup steps as quiet as possible, without resorting to output redirection.