### PR TITLE
Fix user picker search request

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/user_picker.js
+++ b/backend/app/assets/javascripts/spree/backend/user_picker.js
@@ -25,10 +25,12 @@ $.fn.userAutocomplete = function () {
       params: { "headers": { "X-Spree-Token": Spree.api_key } },
       data: function (term) {
         return {
-          m: 'or',
-          email_start: term,
-          addresses_firstname_start: term,
-          addresses_lastname_start: term
+          q: {
+            m: 'or',
+            email_start: term,
+            addresses_firstname_start: term,
+            addresses_lastname_start: term
+          }
         };
       },
       results: function (data) {


### PR DESCRIPTION
The users API controller expects the search params to be contains in a
`q` node.