### PR TITLE
Allow cancelling orders that have been fully refunded

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -852,7 +852,7 @@ module Spree
 
     def after_cancel
       shipments.each(&:cancel!)
-      payments.completed.each(&:cancel!)
+      payments.completed.each { |payment| payment.cancel! unless payment.fully_refunded? }
       payments.store_credits.pending.each(&:void_transaction!)
 
       send_cancel_email

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -146,6 +146,11 @@ module Spree
       credit_allowed > 0
     end
 
+    # @return [Boolean] true when this payment has been fully refunded
+    def fully_refunded?
+      refunds.map(&:amount).sum == amount
+    end
+
     # @return [Array<String>] the actions available on this payment
     def actions
       sa = source_actions

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -630,6 +630,25 @@ RSpec.describe Spree::Payment, type: :model do
     end
   end
 
+  describe "#fully_refunded?" do
+    subject { payment.fully_refunded? }
+
+    before { payment.amount = 100 }
+
+    context 'before refund' do
+      it { is_expected.to be false }
+    end
+
+    context 'when refund total equals payment amount' do
+      before do
+        create(:refund, payment: payment, amount: 50)
+        create(:refund, payment: payment, amount: 50)
+      end
+
+      it { is_expected.to be true }
+    end
+  end
+
   describe "#save" do
     context "captured payments" do
       it "update order payment total" do


### PR DESCRIPTION
This fixes https://github.com/solidusio/solidus/issues/1066 but I could use some feedback.

After an order is cancelled, all completed payments are also cancelled [here](https://github.com/solidusio/solidus/blob/master/core/app/models/spree/order.rb#L750). Each payment then tries to call cancel on it's payment method [here](https://github.com/solidusio/solidus/blob/master/core/app/models/spree/payment/processing.rb#L82), the implementation of which is left to the provider [here](https://github.com/solidusio/solidus/blob/master/core/app/models/spree/payment/processing.rb#L82).

I can't speak for the other gateways, but Braintree's cancel looks like this in solidus_gateway

``` rb
def cancel(response_code)
  provider
  transaction = ::Braintree::Transaction.find(response_code)
  # "A transaction can be refunded if its status is settled or settling.
  # If the transaction has not yet begun settlement, it should be voided instead of refunded.
  if transaction.status == Braintree::Transaction::Status::SubmittedForSettlement
    provider.void(response_code)
  else
    provider.refund(response_code)
  end
end
```

The reason why it's sufficient to simply check whether a payment is "settled" or not, is because the Braintree provider [docs say that](https://developers.braintreepayments.com/reference/request/transaction/refund/ruby#amount)

> If you do not specify an amount to refund, the entire transaction amount will be refunded.

and

> If you have already partially refunded a transaction, performing another refund without specifying the balance it will create a refund for the remaining non-refunded amount of the transaction.

but there's one more case, where a payment has already been fully refunded (through one or many refunds). In that case we get an error. This error is what causes the order cancellation to fail.

We could address this anywhere along the chain, but here are my thoughts.
1. Not in the Braintree ruby SDK, I can understand how a failure to create _any_ refund could be considered an error even if a partial refund is not.
2. Not in solidus_gateway, because we don't currently pass the `payment` when calling cancel on the gateway and I'm not sure we should.

Any ideas how I might add a regression test for this? The behaviour seems specific to one (albeit an important) gateway.
