### PR TITLE
Remove update_adjustments AR callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,12 @@
 
 *   Removed "Clear cache" button from the admin [#1275](https://github.com/solidusio/solidus/pull/1275)
 
+*   Adjustments and totals are no longer updated when saving a Shipment or LineItem.
+
+    Previously adjustments and total columns were updated after saving a Shipment or LineItem.
+    This was unnecessary since it didn't update the order totals, and running
+    order.update! would recalculate the adjustments and totals again.
+
 ## Solidus 1.3.0 (unreleased)
 
 *   Order now requires a `store_id` in validations

--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -26,7 +26,6 @@ module Spree
     after_create :update_tax_charge
 
     after_save :update_inventory
-    after_save :update_adjustments
 
     before_destroy :update_inventory
     before_destroy :destroy_inventory_units
@@ -165,17 +164,6 @@ module Spree
 
     def destroy_inventory_units
       inventory_units.destroy_all
-    end
-
-    def update_adjustments
-      if quantity_changed?
-        update_tax_charge # Called to ensure pre_tax_amount is updated.
-        recalculate_adjustments
-      end
-    end
-
-    def recalculate_adjustments
-      Spree::ItemAdjustments.new(self).update
     end
 
     def update_tax_charge

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -10,8 +10,6 @@ module Spree
     has_many :state_changes, as: :stateful
     has_many :cartons, -> { uniq }, through: :inventory_units
 
-    after_save :update_adjustments
-
     before_validation :set_cost_zero_when_nil
 
     before_destroy :ensure_can_destroy
@@ -404,18 +402,8 @@ module Spree
       stock_location.unstock item.variant, item.quantity, self
     end
 
-    def recalculate_adjustments
-      Spree::ItemAdjustments.new(self).update
-    end
-
     def set_cost_zero_when_nil
       self.cost = 0 unless cost
-    end
-
-    def update_adjustments
-      if cost_changed? && state != 'shipped'
-        recalculate_adjustments
-      end
     end
 
     def ensure_can_destroy

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -26,25 +26,6 @@ describe Spree::LineItem, type: :model do
   end
 
   context "#save" do
-    context "line item changes" do
-      before do
-        line_item.quantity = line_item.quantity + 1
-      end
-
-      it "triggers adjustment total recalculation" do
-        expect(line_item).to receive(:update_tax_charge) # Regression test for https://github.com/spree/spree/issues/4671
-        expect(line_item).to receive(:recalculate_adjustments)
-        line_item.save
-      end
-    end
-
-    context "line item does not change" do
-      it "does not trigger adjustment total recalculation" do
-        expect(line_item).not_to receive(:recalculate_adjustments)
-        line_item.save
-      end
-    end
-
     context "target_shipment is provided" do
       it "verifies inventory" do
         line_item.target_shipment = Spree::Shipment.new

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -585,32 +585,6 @@ describe Spree::Shipment, type: :model do
     end
   end
 
-  context "after_save" do
-    context "line item changes" do
-      before do
-        shipment.cost = shipment.cost + 10
-      end
-
-      it "triggers adjustment total recalculation" do
-        expect(shipment).to receive(:recalculate_adjustments)
-        shipment.save
-      end
-
-      it "does not trigger adjustment recalculation if shipment has shipped" do
-        shipment.state = 'shipped'
-        expect(shipment).not_to receive(:recalculate_adjustments)
-        shipment.save
-      end
-    end
-
-    context "line item does not change" do
-      it "does not trigger adjustment total recalculation" do
-        expect(shipment).not_to receive(:recalculate_adjustments)
-        shipment.save
-      end
-    end
-  end
-
   context "currency" do
     it "returns the order currency" do
       expect(shipment.currency).to eq(order.currency)


### PR DESCRIPTION
The existing behaviour was that line_items and shipments had their adjustments recalculated after save. This would update the item's adjustments and the item's `*_total` columns. However this doesn't update the order's `*_total` columns until `order.update!` is run.

Since order.update! will update these values anyways, and since the order is in an inconsistent state until `order.update!` is run, we should remove these callbacks.

Related to #1252