### PR TITLE
Cancelling Inventory updates tax_total & item total

### DIFF
--- a/core/spec/models/spree/order_cancellations_spec.rb
+++ b/core/spec/models/spree/order_cancellations_spec.rb
@@ -95,6 +95,27 @@ describe Spree::OrderCancellations do
       expect { subject }.to change { order.total }.by(-10.0)
     end
 
+    it 'adjusts the order tax_total', pending: 'community discussion' do
+      # set up required for tax adjustments on the line item
+      # Should probably me moved to apply to the whole spec if this is a
+      # change that is accepted
+      line_item = order.line_items.first
+      create :tax_rate, zone: order.tax_zone, tax_category: line_item.tax_category
+      line_item.send :update_tax_charge
+      order.update!
+
+      expect { subject }.to change { order.tax_total }.from(1).to(0)
+    end
+
+    it 'adjusts the order item total', pending: 'community discussion' do
+      # set up required for tax adjustments on the line item
+      # Should probably me moved to apply to the whole spec if this is a
+      # change that is accepted
+      order.update!
+
+      expect { subject }.to change { order.tax_total }.from(10).to(0)
+    end
+
     it "sends a cancellation email" do
       mail_double = double
       expect(Spree::OrderMailer).to receive(:inventory_cancellation_email).with(order, [inventory_unit]).and_return(mail_double)


### PR DESCRIPTION
Currently, when inventory is cancelled on an order, the system creates a
negative line item adjustment for the the line item total including
taxes. This works for refunding the customer appropriately because the
order.total takes the adjustments into account. However the
order.item_total and order.tax_total still reflect the number of line
items the order was completed with.

I've provided two tests to the order cancellation spec which will pass
when the orders totals are correctly updated.

The question for the community is: Should cancelling and inventory unit
update the order's tax_total and/or item_total and how this should be
implemented with regards to the existing cancellation line item
adjustment.
