### PR TITLE
Remove all icons from tabs and buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Solidus 1.4.0 (master, unreleased)
 
+*   Backend: UI, Remove icons from buttons and tabs
+
+*   Backend: Deprecate args/options that add icons to buttons
+
 *   Update Rules::Taxon/Product handling of invalid match policies
 
     Rules::Taxon and Rules::Product now require valid match_policy values.

--- a/backend/app/assets/javascripts/spree/backend/templates/variants/line_items_autocomplete_stock.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/variants/line_items_autocomplete_stock.hbs
@@ -61,7 +61,7 @@
 
   <fieldset class="no-border-bottom">
     <legend align="center" class="stock-location">
-      <button class="add_variant no-text fa fa-plus icon_link"  title="{{ t "add" }}" data-action="add">{{ t "add" }}</button>
+      <button class="add_variant"  title="{{ t "add" }}" data-action="add">{{ t "add" }}</button>
     </legend>
   </fieldset>
 </fieldset>

--- a/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
@@ -96,13 +96,14 @@ input[type="submit"],
 input[type="button"],
 button, .button {
   display: inline-block;
-  padding: 8px 15px;
+  padding: 6px 15px;
   border: none;
   border-radius: $border-radius;
   background-color: $color-btn-bg;
   color: $color-btn-text;
   font-weight: $font-weight-bold !important;
   white-space: nowrap;
+  line-height: $line-height;
 
   &:before {
     font-weight: normal !important;

--- a/backend/app/helpers/spree/admin/navigation_helper.rb
+++ b/backend/app/helpers/spree/admin/navigation_helper.rb
@@ -121,7 +121,12 @@ module Spree
       end
 
       def button(text, icon_name = nil, button_type = 'submit', options = {})
-        button_tag(text, options.merge(type: button_type, class: "fa fa-#{icon_name} button"))
+        class_names = "button"
+        if icon_name
+          Spree::Deprecation.warn "Using icon_name arg is deprecated. Icons could not be visible in future versions.", caller
+          class_names.prepend "fa fa-#{icon_name} "
+        end
+        button_tag(text, options.merge(type: button_type, class: class_names))
       end
 
       def button_link_to(text, url, html_options = {})
@@ -136,6 +141,7 @@ module Spree
           html_options[:class] += ' button'
 
           if html_options[:icon]
+            Spree::Deprecation.warn "Using :icon option is deprecated. Icons could not be visible in future versions.", caller
             html_options[:class] += " fa fa-#{html_options[:icon]}"
           end
           link_to(text, url, html_options)

--- a/backend/app/helpers/spree/admin/orders_helper.rb
+++ b/backend/app/helpers/spree/admin/orders_helper.rb
@@ -8,7 +8,6 @@ module Spree
           next unless @order.send("can_#{event}?")
           links << button_link_to(Spree.t(event), [event, :admin, @order],
                                   method: :put,
-                                  icon: event.to_s,
                                   data: { confirm: Spree.t(:order_sure_want_to, event: Spree.t(event)) })
         end
         safe_join(links, '&nbsp;'.html_safe)

--- a/backend/app/views/spree/admin/adjustment_reasons/index.html.erb
+++ b/backend/app/views/spree/admin/adjustment_reasons/index.html.erb
@@ -7,7 +7,7 @@
 <% content_for :page_actions do %>
   <ul class="actions inline-menu">
     <li>
-      <%= button_link_to Spree.t(:new_adjustment_reason), new_object_url, { icon: 'plus', id: 'admin_new_named_type' } %>
+      <%= button_link_to Spree.t(:new_adjustment_reason), new_object_url, { id: 'admin_new_named_type' } %>
     </li>
   </ul>
 <% end %>

--- a/backend/app/views/spree/admin/adjustments/edit.html.erb
+++ b/backend/app/views/spree/admin/adjustments/edit.html.erb
@@ -12,8 +12,8 @@
     <%= render :partial => 'form', :locals => { :f => f } %>
 
     <div class="filter-actions actions" data-hook="buttons">
-      <%= button Spree.t(:continue), 'arrow-right' %>
-      <%= link_to_with_icon 'remove', Spree.t('actions.cancel'), admin_order_adjustments_url(@order), :class => 'button' %>
+      <%= button Spree.t(:continue) %>
+      <%= link_to Spree.t('actions.cancel'), admin_order_adjustments_url(@order), :class => 'button' %>
     </div>
   </fieldset>
 <% end %>

--- a/backend/app/views/spree/admin/adjustments/index.html.erb
+++ b/backend/app/views/spree/admin/adjustments/index.html.erb
@@ -15,7 +15,7 @@
 <% if @order.can_add_coupon? %>
   <div data-hook="adjustments_new_coupon_code">
     <%= text_field_tag "coupon_code", "", :placeholder => Spree.t(:coupon_code) %>
-    <%= button Spree.t(:add_coupon_code), 'plus', 'submit', :id => "add_coupon_code" %>
+    <%= button Spree.t(:add_coupon_code), nil, 'submit', :id => "add_coupon_code" %>
   </div>
 <% end %>
 <%= javascript_tag do -%>

--- a/backend/app/views/spree/admin/adjustments/index.html.erb
+++ b/backend/app/views/spree/admin/adjustments/index.html.erb
@@ -5,7 +5,7 @@
 <% content_for :page_actions do %>
   <% if can? :create, Spree::Adjustment %>
     <li>
-      <%= button_link_to Spree.t(:new_adjustment), new_admin_order_adjustment_url(@order), :icon => 'plus' %>
+      <%= button_link_to Spree.t(:new_adjustment), new_admin_order_adjustment_url(@order) %>
     </li>
   <% end %>
 <% end %>

--- a/backend/app/views/spree/admin/adjustments/new.html.erb
+++ b/backend/app/views/spree/admin/adjustments/new.html.erb
@@ -14,8 +14,8 @@
     <%= render :partial => 'form', :locals => { :f => f } %>
 
     <div class="filter-actions actions" data-hook="buttons">
-      <%= button Spree.t(:continue), 'arrow-right' %>
-      <%= button_link_to Spree.t('actions.cancel'), admin_order_adjustments_url(@order), :icon => 'remove' %>
+      <%= button Spree.t(:continue) %>
+      <%= button_link_to Spree.t('actions.cancel'), admin_order_adjustments_url(@order) %>
     </div>
   </fieldset>
 <% end %>

--- a/backend/app/views/spree/admin/countries/index.html.erb
+++ b/backend/app/views/spree/admin/countries/index.html.erb
@@ -8,7 +8,7 @@
   <ul class="actions inline-menu">
     <% if can?(:create, Spree::Country) %>
       <li>
-        <%= button_link_to Spree.t(:new_country), new_object_url, { :icon => 'plus', :id => 'admin_new_country' } %>
+        <%= button_link_to Spree.t(:new_country), new_object_url, { :id => 'admin_new_country' } %>
       </li>
     <% end %>
   </ul>

--- a/backend/app/views/spree/admin/customer_returns/_return_item_decision.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/_return_item_decision.html.erb
@@ -45,7 +45,7 @@
           <td class='align-center'>
             <%= form_for [:admin, return_item] do |f| %>
               <%= f.hidden_field 'reception_status_event', value: 'receive' %>
-              <%= f.button Spree.t('actions.receive'), class: 'fa icon_link no-text with-tip', "data-action" => 'save' %>
+              <%= f.button Spree.t('actions.receive'), class: 'with-tip', "data-action" => 'save' %>
             <% end %>
           </td>
         <% end %>

--- a/backend/app/views/spree/admin/customer_returns/edit.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/edit.html.erb
@@ -39,7 +39,7 @@
     <% if @customer_return.completely_decided? %>
       <%= form_for [:admin, @order, Spree::Reimbursement.new] do |f| %>
         <%= hidden_field_tag :build_from_customer_return_id, @customer_return.id %>
-        <%= f.button class: 'button fa fa-reply' do %>
+        <%= f.button class: 'button' do %>
           <%= Spree.t(:create_reimbursement) %>
         <% end %>
       <% end %>

--- a/backend/app/views/spree/admin/customer_returns/index.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/index.html.erb
@@ -3,7 +3,7 @@
 <% content_for :page_actions do %>
   <% if can? :create, Spree::CustomerReturn %>
     <li>
-      <%= button_link_to Spree.t(:new_customer_return), spree.new_admin_order_customer_return_path(@order), icon: 'plus' %>
+      <%= button_link_to Spree.t(:new_customer_return), spree.new_admin_order_customer_return_path(@order) %>
     </li>
   <% end %>
 <% end %>

--- a/backend/app/views/spree/admin/customer_returns/new.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/new.html.erb
@@ -40,8 +40,8 @@
       </div>
 
       <div class="form-buttons filter-actions actions" data-hook="buttons">
-        <%= button Spree.t('actions.create'), 'ok' %>
-        <%= button_link_to Spree.t('actions.cancel'), admin_order_customer_returns_url(@order), :icon => 'remove' %>
+        <%= button Spree.t('actions.create') %>
+        <%= button_link_to Spree.t('actions.cancel'), admin_order_customer_returns_url(@order) %>
       </div>
     </fieldset>
   <% end %>

--- a/backend/app/views/spree/admin/general_settings/edit.html.erb
+++ b/backend/app/views/spree/admin/general_settings/edit.html.erb
@@ -60,8 +60,8 @@
 
       <% if can? :update, :general_settings %>
         <div class="form-buttons filter-actions actions" data-hook="buttons">
-          <%= button Spree.t('actions.update'), 'refresh' %>
-          <%= link_to_with_icon 'remove', Spree.t('actions.cancel'), edit_admin_general_settings_url, :class => 'button' %>
+          <%= button Spree.t('actions.update') %>
+          <%= link_to Spree.t('actions.cancel'), edit_admin_general_settings_url, :class => 'button' %>
         </div>
       <% end %>
 

--- a/backend/app/views/spree/admin/images/edit.html.erb
+++ b/backend/app/views/spree/admin/images/edit.html.erb
@@ -7,7 +7,7 @@
 
 
 <% content_for :page_actions do %>
-  <li><%= button_link_to Spree.t(:back_to_images_list), admin_product_images_url(@product), :icon => 'arrow-left' %></li>
+  <li><%= button_link_to Spree.t(:back_to_images_list), admin_product_images_url(@product) %></li>
 <% end %>
 
 <%= form_for [:admin, @product, @image], :html => { :multipart => true } do |f| %>
@@ -22,7 +22,7 @@
     </div>
     <div class="clear"></div>
     <div class="form-buttons filter-actions actions" data-hook="buttons">
-      <%= button Spree.t('actions.update'), 'refresh' %>
+      <%= button Spree.t('actions.update') %>
       <%= link_to Spree.t('actions.cancel'), admin_product_images_url(@product), :id => 'cancel_link', :class => 'button remove' %>
     </div>
   </fieldset>

--- a/backend/app/views/spree/admin/images/new.html.erb
+++ b/backend/app/views/spree/admin/images/new.html.erb
@@ -3,10 +3,10 @@
     <legend align="center"><%= Spree.t(:new_image) %></legend>
 
       <%= render :partial => 'form', :locals => { :f => f } %>
-    
+
       <div class="form-buttons filter-actions actions" data-hook="buttons">
-        <%= button Spree.t('actions.update'), 'refresh' %>
-        <%= link_to_with_icon 'remove', Spree.t('actions.cancel'), admin_product_images_url(@product), :id => 'cancel_link', :class => 'button' %>
+        <%= button Spree.t('actions.update') %>
+        <%= link_to Spree.t('actions.cancel'), admin_product_images_url(@product), :id => 'cancel_link', :class => 'button' %>
       </div>
   </fieldset>
 <% end %>

--- a/backend/app/views/spree/admin/log_entries/index.html.erb
+++ b/backend/app/views/spree/admin/log_entries/index.html.erb
@@ -4,8 +4,8 @@
 <% admin_breadcrumb(plural_resource_name(Spree::LogEntry)) %>
 
 <% content_for :page_actions do %>
-  <li><%= button_link_to Spree.t(:logs), spree.admin_order_payment_log_entries_url(@order, @payment), :icon => 'archive' %></li>
-  <li><%= button_link_to Spree.t(:back_to_payment), spree.admin_order_payment_url(@order, @payment), :icon => 'arrow-left' %></li>
+  <li><%= button_link_to Spree.t(:logs), spree.admin_order_payment_log_entries_url(@order, @payment) %></li>
+  <li><%= button_link_to Spree.t(:back_to_payment), spree.admin_order_payment_url(@order, @payment) %></li>
 <% end %>
 
 <table class='index' id='listing_log_entries'>

--- a/backend/app/views/spree/admin/option_types/edit.html.erb
+++ b/backend/app/views/spree/admin/option_types/edit.html.erb
@@ -6,7 +6,7 @@
 <% content_for :page_actions do %>
   <li>
     <span id="new_add_option_value" data-hook>
-      <%= link_to_add_fields Spree.t(:add_option_value), "tbody#option_values", :class => 'button fa fa-plus' %>
+      <%= link_to_add_fields Spree.t(:add_option_value), "tbody#option_values", :class => 'button' %>
     </span>
   </li>
   <% end %>

--- a/backend/app/views/spree/admin/option_types/index.html.erb
+++ b/backend/app/views/spree/admin/option_types/index.html.erb
@@ -5,7 +5,7 @@
 <% content_for :page_actions do %>
   <% if can?(:create, Spree::OptionType) %>
     <li id="new_ot_link">
-      <%= button_link_to Spree.t(:new_option_type), new_admin_option_type_url, { :remote => true, :icon => 'plus', :id => 'new_option_type_link' } %>
+      <%= button_link_to Spree.t(:new_option_type), new_admin_option_type_url, { :remote => true, :id => 'new_option_type_link' } %>
     </li>
   <% end %>
 <% end %>

--- a/backend/app/views/spree/admin/orders/cart.html.erb
+++ b/backend/app/views/spree/admin/orders/cart.html.erb
@@ -3,7 +3,7 @@
         <li><%= event_links %></li>
     <% end %>
     <% if can?(:resend, @order) && @order.completed? %>
-        <li><%= button_link_to Spree.t(:resend), resend_admin_order_url(@order), :method => :post, :icon => 'email' %></li>
+        <li><%= button_link_to Spree.t(:resend), resend_admin_order_url(@order), :method => :post %></li>
     <% end %>
 <% end %>
 

--- a/backend/app/views/spree/admin/orders/confirm.html.erb
+++ b/backend/app/views/spree/admin/orders/confirm.html.erb
@@ -54,7 +54,7 @@
 <%= render partial: 'spree/admin/orders/confirm/payments', locals: {payments: @order.payments} %>
 
 <div class="form-buttons filter-actions actions" data-hook="complete-order-button">
-  <%= button_to [:complete, :admin, @order], {class: 'button fa fa-rocket', method: 'put'} do %>
+  <%= button_to [:complete, :admin, @order], { class: 'button', method: 'put' } do %>
     <%= Spree.t(:complete_order) %>
   <% end %>
 </div>

--- a/backend/app/views/spree/admin/orders/confirm_advance.html.erb
+++ b/backend/app/views/spree/admin/orders/confirm_advance.html.erb
@@ -5,7 +5,7 @@
 
 <div class="form-buttons filter-actions actions" data-hook="complete-order-button">
   <div><%= Spree.t(:order_please_refresh) %></div><br/>
-  <%= button_to [:advance, :admin, @order], {class: 'button fa fa-refresh', method: 'put'} do %>
+  <%= button_to [:advance, :admin, @order], { class: 'button', method: 'put' } do %>
     <%= Spree.t(:order_refresh_totals) %>
   <% end %>
 </div>

--- a/backend/app/views/spree/admin/orders/customer_details/_form.html.erb
+++ b/backend/app/views/spree/admin/orders/customer_details/_form.html.erb
@@ -68,6 +68,6 @@
   <div class="clear"></div>
 
   <div class="form-buttons filter-actions actions" data-hook="buttons">
-    <%= button Spree.t('actions.update'), 'refresh' %>
+    <%= button Spree.t('actions.update') %>
   </div>
 </fieldset>

--- a/backend/app/views/spree/admin/orders/customer_details/show.html.erb
+++ b/backend/app/views/spree/admin/orders/customer_details/show.html.erb
@@ -4,7 +4,7 @@
 
 
 <% content_for :page_actions do %>
-  <li><%= button_link_to Spree.t(:back_to_orders_list), admin_orders_path, :icon => 'arrow-left' %></li>
+  <li><%= button_link_to Spree.t(:back_to_orders_list), admin_orders_path %></li>
 <% end %>
 
 

--- a/backend/app/views/spree/admin/orders/edit.html.erb
+++ b/backend/app/views/spree/admin/orders/edit.html.erb
@@ -3,7 +3,7 @@
     <li><%= event_links %></li>
   <% end %>
   <% if can?(:resend, @order) && @order.completed? %>
-    <li><%= button_link_to Spree.t(:resend), resend_admin_order_url(@order), method: :post, icon: 'email' %></li>
+    <li><%= button_link_to Spree.t(:resend), resend_admin_order_url(@order), method: :post %></li>
   <% end %>
 <% end %>
 

--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -95,7 +95,7 @@
 
       <div class="actions filter-actions">
         <div data-hook="admin_orders_index_search_buttons">
-          <%= button Spree.t(:filter_results), 'search' %>
+          <%= button Spree.t(:filter_results) %>
         </div>
       </div>
     <% end %>

--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -3,7 +3,7 @@
 
 <% content_for :page_actions do %>
   <li>
-    <%= button_link_to Spree.t(:new_order), new_admin_order_url, :icon => 'plus', :id => 'admin_new_order' %>
+    <%= button_link_to Spree.t(:new_order), new_admin_order_url, :id => 'admin_new_order' %>
   </li>
 <% end if can? :edit, Spree::Order.new %>
 

--- a/backend/app/views/spree/admin/payment_methods/edit.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/edit.html.erb
@@ -14,7 +14,7 @@
   <fieldset class="no-border-top">
     <%= render :partial => 'form', :locals => { :f => f } %>
     <div data-hook="buttons" class="filter-actions actions">
-      <%= button Spree.t('actions.update'), 'refresh' %>
+      <%= button Spree.t('actions.update') %>
     </div>
   </fieldset>
 

--- a/backend/app/views/spree/admin/payment_methods/index.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/index.html.erb
@@ -8,7 +8,7 @@
 <% content_for :page_actions do %>
   <% if can?(:create, Spree::PaymentMethod) %>
     <li>
-      <%= button_link_to Spree.t(:new_payment_method), new_object_url, :icon => 'plus', :id => 'admin_new_payment_methods_link' %>
+      <%= button_link_to Spree.t(:new_payment_method), new_object_url, :id => 'admin_new_payment_methods_link' %>
     </li>
   <% end %>
 <% end %>

--- a/backend/app/views/spree/admin/payment_methods/new.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/new.html.erb
@@ -15,7 +15,7 @@
   <fieldset class="no-border-top">
     <%= render :partial => 'form', :locals => { :f => f } %>
     <div data-hook="buttons" class="filter-actions actions">
-      <%= button Spree.t('actions.create'), 'ok' %>
+      <%= button Spree.t('actions.create') %>
     </div>
   </fieldset>
 <% end %>

--- a/backend/app/views/spree/admin/payments/index.html.erb
+++ b/backend/app/views/spree/admin/payments/index.html.erb
@@ -3,7 +3,7 @@
 <% content_for :page_actions do %>
   <% if @order.outstanding_balance? %>
     <li id="new_payment_section">
-      <%= button_link_to Spree.t(:new_payment), new_admin_order_payment_url(@order), :icon => 'plus' %>
+      <%= button_link_to Spree.t(:new_payment), new_admin_order_payment_url(@order) %>
     </li>
   <% end %>
 <% end %>

--- a/backend/app/views/spree/admin/payments/new.html.erb
+++ b/backend/app/views/spree/admin/payments/new.html.erb
@@ -15,7 +15,7 @@
       <%= render :partial => 'form', :locals => { :f => f } %>
 
       <div class="filter-actions actions" data-hook="buttons">
-        <%= button @order.cart? ? Spree.t('actions.continue') : Spree.t('actions.update'), @order.cart? ? 'arrow-right' : 'refresh' %>
+        <%= button @order.cart? ? Spree.t('actions.continue') : Spree.t('actions.update') %>
       </div>
     </fieldset>
   <% end %>

--- a/backend/app/views/spree/admin/payments/show.html.erb
+++ b/backend/app/views/spree/admin/payments/show.html.erb
@@ -10,7 +10,7 @@
 
 
 <% content_for :page_actions do %>
-  <li><%= button_link_to Spree.t(:logs), spree.admin_order_payment_log_entries_url(@order, @payment), :icon => 'archive' %></li>
+  <li><%= button_link_to Spree.t(:logs), spree.admin_order_payment_log_entries_url(@order, @payment) %></li>
 <% end %>
 
 <%= render :partial => "spree/admin/payments/source_views/#{@payment.payment_method.method_type}", :locals => { :payment => @payment.source.is_a?(Spree::Payment) ? @payment.source : @payment } %>

--- a/backend/app/views/spree/admin/prices/index.html.erb
+++ b/backend/app/views/spree/admin/prices/index.html.erb
@@ -2,7 +2,7 @@
 
 <% content_for :page_actions do %>
   <li id="new_price_link">
-    <%= button_link_to t(".new_price"), new_object_url, { :remote => true, :icon => 'plus', :id => 'admin_new_product' } %>
+    <%= button_link_to t(".new_price"), new_object_url, { :remote => true, :id => 'admin_new_product' } %>
   </li>
 <% end if can?(:create, Spree::Product) %>
 
@@ -62,7 +62,7 @@
 
   <div class="actions filter-actions">
     <div data-hook="admin_orders_index_search_buttons">
-      <%= button Spree.t(:filter_results), 'search' %>
+      <%= button Spree.t(:filter_results) %>
     </div>
   </div>
 

--- a/backend/app/views/spree/admin/products/edit.html.erb
+++ b/backend/app/views/spree/admin/products/edit.html.erb
@@ -1,7 +1,7 @@
 <% content_for :page_actions do %>
   <% if can?(:create, Spree::Product) %>
     <li id="new_product_link">
-      <%= button_link_to Spree.t(:new_product), new_object_url, { :icon => 'plus', :id => 'admin_new_product' } %>
+      <%= button_link_to Spree.t(:new_product), new_object_url, { :id => 'admin_new_product' } %>
     </li>
   <% end %>
 <% end %>

--- a/backend/app/views/spree/admin/products/index.html.erb
+++ b/backend/app/views/spree/admin/products/index.html.erb
@@ -4,7 +4,7 @@
 
 <% content_for :page_actions do %>
   <li id="new_product_link">
-    <%= button_link_to Spree.t(:new_product), new_object_url, { :remote => true, :icon => 'plus', :id => 'admin_new_product' } %>
+    <%= button_link_to Spree.t(:new_product), new_object_url, { :remote => true, :id => 'admin_new_product' } %>
   </li>
 <% end if can?(:create, Spree::Product) %>
 

--- a/backend/app/views/spree/admin/products/index.html.erb
+++ b/backend/app/views/spree/admin/products/index.html.erb
@@ -36,7 +36,7 @@
         </div>
 
         <div class="actions filter-actions" data-hook="admin_products_index_search_buttons">
-          <%= button Spree.t(:search), 'search' %>
+          <%= button Spree.t(:search) %>
         </div>
     <% end %>
   </div>

--- a/backend/app/views/spree/admin/promotion_categories/index.html.erb
+++ b/backend/app/views/spree/admin/promotion_categories/index.html.erb
@@ -5,7 +5,7 @@
 <% content_for :page_actions do %>
   <% if can?(:create, Spree::PromotionCategory) %>
     <li>
-      <%= button_link_to Spree.t(:new_promotion_category), spree.new_admin_promotion_category_path, :icon => 'plus' %>
+      <%= button_link_to Spree.t(:new_promotion_category), spree.new_admin_promotion_category_path %>
     </li>
   <% end %>
 <% end %>

--- a/backend/app/views/spree/admin/promotions/_actions.html.erb
+++ b/backend/app/views/spree/admin/promotions/_actions.html.erb
@@ -10,7 +10,7 @@
           <%= select_tag 'action_type', options, :class => 'select2 fullwidth' %>
         </div>
         <div class="filter-actions actions">
-          <%= button Spree.t('actions.add'), 'plus' %>
+          <%= button Spree.t('actions.add') %>
         </div>
       <% end %>
     </fieldset>
@@ -28,7 +28,7 @@
     </div>
     <% if can?(:update, @promotion) %>
       <div class="filter-actions actions promotion-update">
-        <%= button Spree.t('actions.update'), 'refresh' %>
+        <%= button Spree.t('actions.update') %>
       </div>
     <% end %>
   <% end %>

--- a/backend/app/views/spree/admin/promotions/_rules.html.erb
+++ b/backend/app/views/spree/admin/promotions/_rules.html.erb
@@ -10,7 +10,7 @@
           <%= select_tag('promotion_rule[type]', options_for_promotion_rule_types(@promotion), :class => 'select2 fullwidth') %>
         </div>
         <div class="filter-actions actions">
-          <%= button Spree.t('actions.add'), 'plus' %>
+          <%= button Spree.t('actions.add') %>
         </div>
       <% end %>
     </fieldset>
@@ -39,7 +39,7 @@
 
         <% if can?(:update, @promotion) %>
           <div class="promotion-update filter-actions actions">
-            <%= button Spree.t('actions.update'), 'refresh' %>
+            <%= button Spree.t('actions.update') %>
           </div>
         <% end %>
       </fieldset>

--- a/backend/app/views/spree/admin/promotions/calculators/tiered_flat_rate/_fields.html.erb
+++ b/backend/app/views/spree/admin/promotions/calculators/tiered_flat_rate/_fields.html.erb
@@ -11,4 +11,4 @@
   'form-prefix' => prefix,
   'calculator' => 'tiered_flat_rate'
 } %>
-<button class="fa fa-plus button js-add-tier"><%= Spree.t('actions.add') %></button>
+<button class="button js-add-tier"><%= Spree.t('actions.add') %></button>

--- a/backend/app/views/spree/admin/promotions/calculators/tiered_percent/_fields.html.erb
+++ b/backend/app/views/spree/admin/promotions/calculators/tiered_percent/_fields.html.erb
@@ -11,4 +11,4 @@
   'form-prefix' => prefix,
   'calculator' => 'tiered_percent'
 } %>
-<button class="fa fa-plus button js-add-tier"><%= Spree.t('actions.add') %></button>
+<button class="button js-add-tier"><%= Spree.t('actions.add') %></button>

--- a/backend/app/views/spree/admin/promotions/edit.html.erb
+++ b/backend/app/views/spree/admin/promotions/edit.html.erb
@@ -5,7 +5,7 @@
 <% content_for :page_actions do %>
   <li>
     <% if can?(:display, Spree::PromotionCode) %>
-      <%= button_link_to Spree.t(:download_promotion_code_list), admin_promotion_promotion_codes_path(promotion_id: @promotion.id, format: :csv), :icon => 'arrow-down' %>
+      <%= button_link_to Spree.t(:download_promotion_code_list), admin_promotion_promotion_codes_path(promotion_id: @promotion.id, format: :csv) %>
     <% end %>
   </li>
 <% end %>

--- a/backend/app/views/spree/admin/promotions/index.html.erb
+++ b/backend/app/views/spree/admin/promotions/index.html.erb
@@ -3,7 +3,7 @@
 <% content_for :page_actions do %>
   <% if can? :create, Spree::Promotion %>
     <li>
-      <%= button_link_to Spree.t(:new_promotion), spree.new_admin_promotion_path, :icon => 'plus' %>
+      <%= button_link_to Spree.t(:new_promotion), spree.new_admin_promotion_path %>
     </li>
   <% end %>
 <% end %>

--- a/backend/app/views/spree/admin/promotions/index.html.erb
+++ b/backend/app/views/spree/admin/promotions/index.html.erb
@@ -47,7 +47,7 @@
 
       <div class="actions filter-actions">
         <div data-hook="admin_promotions_index_search_buttons">
-          <%= button Spree.t(:filter_results), 'search' %>
+          <%= button Spree.t(:filter_results) %>
         </div>
       </div>
     <% end %>

--- a/backend/app/views/spree/admin/promotions/rules/_option_value.html.erb
+++ b/backend/app/views/spree/admin/promotions/rules/_option_value.html.erb
@@ -6,7 +6,7 @@
 
   <div class="js-promo-rule-option-values"></div>
 
-  <button class="fa fa-plus button js-add-promo-rule-option-value"><%= Spree.t('actions.add') %></button>
+  <button class="button js-add-promo-rule-option-value"><%= Spree.t('actions.add') %></button>
 </div>
 
 <%= content_tag :div, nil, class: "hidden js-original-promo-rule-option-values",

--- a/backend/app/views/spree/admin/properties/index.html.erb
+++ b/backend/app/views/spree/admin/properties/index.html.erb
@@ -5,7 +5,7 @@
 <% content_for :page_actions do %>
   <% if can?(:create, Spree::Property) %>
     <li id="new_property_link">
-      <%= button_link_to Spree.t(:new_property), new_admin_property_url, { :remote => true, :icon => 'plus', :id => 'new_property_link' } %>
+      <%= button_link_to Spree.t(:new_property), new_admin_property_url, { :remote => true, :id => 'new_property_link' } %>
     </li>
   <% end %>
 <% end %>

--- a/backend/app/views/spree/admin/properties/index.html.erb
+++ b/backend/app/views/spree/admin/properties/index.html.erb
@@ -33,7 +33,7 @@
         <div class="clear"></div>
 
         <div class="form-buttons actions filter-actions" data-hook="admin_pproperties_index_search_buttons">
-          <%= button Spree.t(:search), 'search' %>
+          <%= button Spree.t(:search) %>
         </div>
     <% end %>
   </div>

--- a/backend/app/views/spree/admin/prototypes/_prototypes.html.erb
+++ b/backend/app/views/spree/admin/prototypes/_prototypes.html.erb
@@ -14,7 +14,7 @@
       <tr id="row_<%= prototype.id %>" data-hook="available_row" class="<%= cycle('odd', 'even')%>">
         <td><%= prototype.name %></td>
         <td class="actions">
-          <%= link_to Spree.t(:select), select_admin_prototype_url(prototype), class: 'ajax button select_properties_from_prototype fa fa-ok', data: { remote: true } %>
+          <%= link_to Spree.t(:select), select_admin_prototype_url(prototype), class: 'ajax button select_properties_from_prototype', data: { remote: true } %>
         </td>
       </tr>
     <% end %>

--- a/backend/app/views/spree/admin/prototypes/index.html.erb
+++ b/backend/app/views/spree/admin/prototypes/index.html.erb
@@ -5,7 +5,7 @@
 <% content_for :page_actions do %>
   <% if can?(:create, Spree::Prototype) %>
     <li id="new_prototype_link">
-      <%= button_link_to Spree.t(:new_prototype), new_admin_prototype_url, {:remote => true, :icon => 'plus', :id => 'new_prototype_link'} %>
+      <%= button_link_to Spree.t(:new_prototype), new_admin_prototype_url, {:remote => true, :id => 'new_prototype_link'} %>
     </li>
   <% end %>
 <% end %>

--- a/backend/app/views/spree/admin/refund_reasons/index.html.erb
+++ b/backend/app/views/spree/admin/refund_reasons/index.html.erb
@@ -9,7 +9,7 @@
   <ul class="actions inline-menu">
     <% if can?(:create, Spree::RefundReason) %>
       <li>
-        <%= button_link_to Spree.t(:new_refund_reason), new_object_url, { icon: 'plus', id: 'admin_new_named_type' } %>
+        <%= button_link_to Spree.t(:new_refund_reason), new_object_url, { id: 'admin_new_named_type' } %>
       </li>
     <% end %>
   </ul>

--- a/backend/app/views/spree/admin/refunds/edit.html.erb
+++ b/backend/app/views/spree/admin/refunds/edit.html.erb
@@ -22,8 +22,8 @@
     </div>
 
     <div class="form-buttons filter-actions actions" data-hook="buttons">
-      <%= button Spree.t('actions.save'), 'ok' %>
-      <%= button_link_to Spree.t('actions.cancel'), admin_order_payments_url(@refund.payment.order), icon: 'remove' %>
+      <%= button Spree.t('actions.save') %>
+      <%= button_link_to Spree.t('actions.cancel'), admin_order_payments_url(@refund.payment.order) %>
     </div>
   </fieldset>
 <% end %>

--- a/backend/app/views/spree/admin/refunds/new.html.erb
+++ b/backend/app/views/spree/admin/refunds/new.html.erb
@@ -35,8 +35,8 @@
     </div>
 
     <div class="form-buttons filter-actions actions" data-hook="buttons">
-      <%= button Spree::Refund.model_name.human, 'ok' %>
-      <%= button_link_to Spree.t('actions.cancel'), admin_order_payments_url(@refund.payment.order), icon: 'remove' %>
+      <%= button Spree::Refund.model_name.human %>
+      <%= button_link_to Spree.t('actions.cancel'), admin_order_payments_url(@refund.payment.order) %>
     </div>
   </fieldset>
 <% end %>

--- a/backend/app/views/spree/admin/reimbursements/edit.html.erb
+++ b/backend/app/views/spree/admin/reimbursements/edit.html.erb
@@ -4,7 +4,7 @@
 
 
 <% content_for :page_actions do %>
-  <li><%= button_link_to Spree.t(:back_to_customer_return), url_for([:edit, :admin, @order, @reimbursement.customer_return]), :icon => 'arrow-left' %></li>
+  <li><%= button_link_to Spree.t(:back_to_customer_return), url_for([:edit, :admin, @order, @reimbursement.customer_return]) %></li>
 <% end %>
 
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @reimbursement } %>
@@ -97,10 +97,10 @@
   <% end %>
   <div class="form-buttons filter-actions actions" data-hook="reimburse-buttons">
     <% if !@reimbursement.reimbursed? %>
-      <%= button_to [:perform, :admin, @order, @reimbursement], {class: 'button fa fa-reply', method: 'post'} do %>
+      <%= button_to [:perform, :admin, @order, @reimbursement], { class: 'button', method: 'post' } do %>
         <%= Spree.t(:reimburse) %>
       <% end %>
-      <%= button_link_to Spree.t('actions.cancel'), url_for([:admin, @order, @reimbursement.customer_return]), :icon => 'remove' %>
+      <%= button_link_to Spree.t('actions.cancel'), url_for([:admin, @order, @reimbursement.customer_return]) %>
     <% end %>
   </div>
 </fieldset>

--- a/backend/app/views/spree/admin/reimbursements/index.html.erb
+++ b/backend/app/views/spree/admin/reimbursements/index.html.erb
@@ -3,7 +3,7 @@
 <% admin_breadcrumb(plural_resource_name(Spree::Reimbursement)) %>
 
 <% content_for :page_actions do %>
-  <li><%= button_link_to Spree.t(:back_to_customer_return_list), spree.admin_order_customer_returns_url(@order), :icon => 'arrow-left' %></li>
+  <li><%= button_link_to Spree.t(:back_to_customer_return_list), spree.admin_order_customer_returns_url(@order) %></li>
 <% end %>
 
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @customer_return } %>

--- a/backend/app/views/spree/admin/reimbursements/show.html.erb
+++ b/backend/app/views/spree/admin/reimbursements/show.html.erb
@@ -4,7 +4,7 @@
 
 
 <% content_for :page_actions do %>
-  <li><%= button_link_to Spree.t(:back_to_customer_return), url_for([:edit, :admin, @order, @reimbursement.customer_return]), :icon => 'arrow-left' %></li>
+  <li><%= button_link_to Spree.t(:back_to_customer_return), url_for([:edit, :admin, @order, @reimbursement.customer_return]) %></li>
 <% end %>
 
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @reimbursement } %>

--- a/backend/app/views/spree/admin/return_authorizations/edit.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/edit.html.erb
@@ -1,7 +1,7 @@
 <% content_for :page_actions do %>
   <% if @return_authorization.can_cancel? %>
     <li>
-      <%= button_link_to Spree.t('actions.cancel'), fire_admin_order_return_authorization_url(@order, @return_authorization, e: 'cancel'), method: :put, data: { confirm: Spree.t(:are_you_sure) }, icon: 'remove' %>
+      <%= button_link_to Spree.t('actions.cancel'), fire_admin_order_return_authorization_url(@order, @return_authorization, e: 'cancel'), method: :put, data: { confirm: Spree.t(:are_you_sure) } %>
     </li>
   <% end %>
 <% end %>
@@ -18,8 +18,8 @@
     <%= render :partial => 'form', :locals => { :f => f } %>
 
     <div class="form-buttons filter-actions actions" data-hook="buttons">
-      <%= button Spree.t('actions.update'), 'repeat' %>
-      <%= button_link_to Spree.t('actions.cancel'), admin_order_return_authorizations_url(@order), :icon => 'remove' %>
+      <%= button Spree.t('actions.update') %>
+      <%= button_link_to Spree.t('actions.cancel'), admin_order_return_authorizations_url(@order) %>
     </div>
   </fieldset>
 <% end %>

--- a/backend/app/views/spree/admin/return_authorizations/index.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/index.html.erb
@@ -4,7 +4,7 @@
   <% if @order.shipments.any? &:shipped? %>
     <li>
       <% if can? :create, Spree::ReturnAuthorization %>
-        <%= button_link_to Spree.t(:new_return_authorization), new_admin_order_return_authorization_url(@order), :icon => 'plus' %>
+        <%= button_link_to Spree.t(:new_return_authorization), new_admin_order_return_authorization_url(@order) %>
       <% end %>
     </li>
   <% end %>

--- a/backend/app/views/spree/admin/return_authorizations/new.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/new.html.erb
@@ -13,8 +13,8 @@
     <%= render :partial => 'form', :locals => { :f => f } %>
 
     <div class="form-buttons filter-actions actions" data-hook="buttons">
-      <%= button Spree.t(:'actions.create'), 'ok' %>
-      <%= button_link_to Spree.t('actions.cancel'), admin_order_return_authorizations_url(@order), :icon => 'remove' %>
+      <%= button Spree.t(:'actions.create') %>
+      <%= button_link_to Spree.t('actions.cancel'), admin_order_return_authorizations_url(@order) %>
     </div>
   </fieldset>
 <% end %>

--- a/backend/app/views/spree/admin/shared/_edit_resource_links.html.erb
+++ b/backend/app/views/spree/admin/shared/_edit_resource_links.html.erb
@@ -1,4 +1,4 @@
 <div class="form-buttons filter-actions actions" data-hook="buttons">
-  <%= button Spree.t('actions.update'), 'refresh' %>
-  <%= button_link_to Spree.t('actions.cancel'), collection_url, :icon => 'remove' %>
+  <%= button Spree.t('actions.update') %>
+  <%= button_link_to Spree.t('actions.cancel'), collection_url %>
 </div>

--- a/backend/app/views/spree/admin/shared/_new_resource_links.html.erb
+++ b/backend/app/views/spree/admin/shared/_new_resource_links.html.erb
@@ -1,4 +1,4 @@
 <div class="form-buttons filter-actions actions" data-hook="buttons">
-  <%= button Spree.t('actions.create'), 'ok' %>
-  <%= link_to_with_icon 'remove', Spree.t('actions.cancel'), collection_url, :class => 'button' %>
+  <%= button Spree.t('actions.create') %>
+  <%= link_to Spree.t('actions.cancel'), collection_url, :class => 'button' %>
 </div>

--- a/backend/app/views/spree/admin/shared/_order_submenu.html.erb
+++ b/backend/app/views/spree/admin/shared/_order_submenu.html.erb
@@ -2,46 +2,46 @@
   <ul class="tabs" data-hook="admin_order_tabs">
     <% if (@order.shipments.count == 0 || @order.shipped_shipments.count == 0) %>
       <li class="<%= "active" if current == "Cart" %>" data-hook='admin_order_tabs_order_details'>
-        <%= link_to_with_icon 'shopping-cart', Spree.t(:cart), cart_admin_order_url(@order) %>
+        <%= link_to Spree.t(:cart), cart_admin_order_url(@order) %>
       </li>
     <% end %>
 
     <% if checkout_steps.include?("address") %>
       <li class="<%= "active" if (current == "Customer Details") %>" data-hook='admin_order_tabs_customer_details'>
         <% if can?(:update, @order) %>
-          <%= link_to_with_icon 'user', Spree.t(:customer), edit_admin_order_customer_url(@order) %>
+          <%= link_to Spree.t(:customer), edit_admin_order_customer_url(@order) %>
         <% else %>
-          <%= link_to_with_icon 'user', Spree.t(:customer), admin_order_customer_url(@order) %>
+          <%= link_to Spree.t(:customer), admin_order_customer_url(@order) %>
         <% end %>
       </li>
     <% end %>
 
     <li class="<%= "active" if current == "Shipments" %>" data-hook='admin_order_tabs_order_details'>
-      <%= link_to_with_icon 'edit', plural_resource_name(Spree::Shipment), edit_admin_order_url(@order) %>
+      <%= link_to plural_resource_name(Spree::Shipment), edit_admin_order_url(@order) %>
     </li>
 
     <% if can? :display, Spree::Adjustment %>
       <li class="<%= "active" if current == "Adjustments" %>" data-hook='admin_order_tabs_adjustments'>
-        <%= link_to_with_icon 'cogs', plural_resource_name(Spree::Adjustment), admin_order_adjustments_url(@order) %>
+        <%= link_to plural_resource_name(Spree::Adjustment), admin_order_adjustments_url(@order) %>
       </li>
     <% end %>
 
     <% if can?(:display, Spree::Payment) %>
       <li class="<%= "active" if current == "Payments" %>" data-hook='admin_order_tabs_payments'>
-        <%= link_to_with_icon 'credit-card', plural_resource_name(Spree::Payment), admin_order_payments_url(@order) %>
+        <%= link_to plural_resource_name(Spree::Payment), admin_order_payments_url(@order) %>
       </li>
     <% end %>
 
     <% if !@order.completed? && can?(:update, @order) %>
       <li class="<%= "active" if current == "Confirm" %>" data-hook='admin_order_tabs_confirm'>
-        <%= link_to_with_icon 'check', Spree.t(:confirm), confirm_admin_order_url(@order) %>
+        <%= link_to Spree.t(:confirm), confirm_admin_order_url(@order) %>
       </li>
     <% end %>
 
     <% if can? :display, Spree::ReturnAuthorization %>
       <% if @order.completed? %>
         <li class="tab <%= "active" if current == "Return Authorizations" %>" data-hook='admin_order_tabs_return_authorizations'>
-          <%= link_to_with_icon 'share', Spree.t('admin.tab.rma'), admin_order_return_authorizations_url(@order) %>
+          <%= link_to Spree.t('admin.tab.rma'), admin_order_return_authorizations_url(@order) %>
         </li>
       <% end %>
     <% end %>
@@ -49,14 +49,14 @@
     <% if can? :display, Spree::CustomerReturn %>
       <% if @order.completed? %>
         <li class="<%= "active" if current == "Customer Returns" %>">
-          <%= link_to_with_icon 'download', plural_resource_name(Spree::CustomerReturn), admin_order_customer_returns_url(@order) %>
+          <%= link_to plural_resource_name(Spree::CustomerReturn), admin_order_customer_returns_url(@order) %>
         </li>
       <% end %>
     <% end %>
 
     <% if can?(:manage, Spree::OrderCancellations) && @order.inventory_units.cancelable.present? %>
       <%= content_tag('li', class: "#{'active' if current == 'Cancel Inventory'}", :data => {:hook => 'admin_order_tabs_cancel_inventory'}) do %>
-        <%= link_to_with_icon 'cancel', Spree.t(:cancel_inventory), admin_order_cancellations_path(@order) %>
+        <%= link_to Spree.t(:cancel_inventory), admin_order_cancellations_path(@order) %>
       <% end %>
     <% end %>
   </ul>

--- a/backend/app/views/spree/admin/shared/_product_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_product_tabs.html.erb
@@ -5,22 +5,22 @@
   <nav>
     <ul class="tabs" data-hook="admin_product_tabs">
       <%= content_tag :li, :class => ('active' if current == 'Product Details') do %>
-        <%= link_to_with_icon 'edit', Spree.t(:product_details), spree.edit_admin_product_url(@product) %>
+        <%= link_to Spree.t(:product_details), spree.edit_admin_product_url(@product) %>
       <% end if can?(:admin, Spree::Product) %>
       <%= content_tag :li, :class => ('active' if current == 'Images') do %>
-        <%= link_to_with_icon 'picture-o', Spree.t(:images), spree.admin_product_images_url(@product) %>
+        <%= link_to Spree.t(:images), spree.admin_product_images_url(@product) %>
       <% end if can?(:admin, Spree::Image) %>
       <%= content_tag :li, :class => ('active' if current == 'Variants') do %>
-        <%= link_to_with_icon 'th-large', plural_resource_name(Spree::Variant),  spree.admin_product_variants_url(@product) %>
+        <%= link_to plural_resource_name(Spree::Variant), spree.admin_product_variants_url(@product) %>
       <% end if can?(:admin, Spree::Variant) %>
       <%= content_tag :li, :class => ('active' if current == 'Prices') do %>
-        <%= link_to_with_icon 'money', plural_resource_name(Spree::Price),  spree.admin_product_prices_url(@product) %>
+        <%= link_to plural_resource_name(Spree::Price), spree.admin_product_prices_url(@product) %>
       <% end if can?(:admin, Spree::Price) %>
       <%= content_tag :li, :class => ('active' if current == 'Product Properties') do %>
-        <%= link_to_with_icon 'tasks', plural_resource_name(Spree::ProductProperty), spree.admin_product_product_properties_url(@product) %>
+        <%= link_to plural_resource_name(Spree::ProductProperty), spree.admin_product_product_properties_url(@product) %>
       <% end if can?(:admin, Spree::ProductProperty) %>
       <%= content_tag :li, :class => ('active' if current == 'Stock Management') do %>
-        <%= link_to_with_icon 'cubes', Spree.t(:stock_management), spree.admin_product_stock_url(@product) %>
+        <%= link_to Spree.t(:stock_management), spree.admin_product_stock_url(@product) %>
       <% end if can?(:admin, Spree::StockItem) %>
     </ul>
   </nav>

--- a/backend/app/views/spree/admin/shared/_report_criteria.html.erb
+++ b/backend/app/views/spree/admin/shared/_report_criteria.html.erb
@@ -2,7 +2,7 @@
     <div class="date-range-filter field align-center">
         <%= label_tag nil, Spree.t(:start), :class => 'inline' %>
         <%= s.text_field :created_at_gt, :class => 'datepicker datepicker-from', :value => datepicker_field_value(params[:q][:created_at_gt]) %>
-        
+
         <span class="range-divider">
           <i class="fa fa-arrow-right"></i>
         </span>
@@ -12,6 +12,6 @@
     </div>
 
     <div class="actions filter-actions">
-      <%= button Spree.t(:search), 'search'  %>
+      <%= button Spree.t(:search) %>
     </div>
 <% end %>

--- a/backend/app/views/spree/admin/shared/_report_order_criteria.html.erb
+++ b/backend/app/views/spree/admin/shared/_report_order_criteria.html.erb
@@ -2,7 +2,7 @@
   <div class="date-range-filter field align-center">
     <%= label_tag :q_completed_at_gt, Spree.t(:start), :class => 'inline' %>
     <%= s.text_field :completed_at_gt, :class => 'datepicker datepicker-from', :value => datepicker_field_value(params[:q][:completed_at_gt]) %>
-        
+
     <span class="range-divider">
       <i class="fa fa-arrow-right"></i>
     </span>
@@ -12,6 +12,6 @@
   </div>
 
   <div class="actions filter-actions">
-    <%= button Spree.t(:search), 'search'  %>
+    <%= button Spree.t(:search)  %>
   </div>
 <% end %>

--- a/backend/app/views/spree/admin/shared/_variant_search.html.erb
+++ b/backend/app/views/spree/admin/shared/_variant_search.html.erb
@@ -15,7 +15,7 @@
 
     <div class="actions filter-actions">
       <div data-hook="admin_orders_index_search_buttons">
-        <%= button Spree.t(:filter_results), 'search' %>
+        <%= button Spree.t(:filter_results) %>
       </div>
     </div>
   <% end %>

--- a/backend/app/views/spree/admin/shared/named_types/_index.html.erb
+++ b/backend/app/views/spree/admin/shared/named_types/_index.html.erb
@@ -9,7 +9,7 @@
   <ul class="actions inline-menu">
     <% if can?(:create, Spree::ReturnReason) %>
       <li>
-        <%= button_link_to new_button_text, new_object_url, { icon: 'plus', id: 'admin_new_named_type' } %>
+        <%= button_link_to new_button_text, new_object_url, { id: 'admin_new_named_type' } %>
       </li>
     <% end %>
   </ul>

--- a/backend/app/views/spree/admin/shipping_categories/index.html.erb
+++ b/backend/app/views/spree/admin/shipping_categories/index.html.erb
@@ -8,7 +8,7 @@
 <% content_for :page_actions do %>
   <% if can?(:create, Spree::ShippingCategory) %>
     <li>
-      <%= button_link_to Spree.t(:new_shipping_category), new_object_url, :icon => 'plus' %>
+      <%= button_link_to Spree.t(:new_shipping_category), new_object_url %>
     </li>
   <% end %>
 <% end %>

--- a/backend/app/views/spree/admin/shipping_methods/index.html.erb
+++ b/backend/app/views/spree/admin/shipping_methods/index.html.erb
@@ -8,7 +8,7 @@
 <% content_for :page_actions do %>
   <% if can?(:create, Spree::ShippingMethod) %>
     <li>
-      <%= button_link_to Spree.t(:new_shipping_method), new_object_url,  :icon => 'plus', :id => 'admin_new_shipping_method_link' %>
+      <%= button_link_to Spree.t(:new_shipping_method), new_object_url, :id => 'admin_new_shipping_method_link' %>
     </li>
   <% end %>
 <% end %>

--- a/backend/app/views/spree/admin/states/index.html.erb
+++ b/backend/app/views/spree/admin/states/index.html.erb
@@ -8,7 +8,7 @@
 <% content_for :page_actions do %>
   <% if can?(:create, Spree::State) %>
     <li>
-      <%= button_link_to Spree.t(:new_state), new_admin_country_state_url(@country), { :icon => 'plus', :id => 'new_state_link' } %>
+      <%= button_link_to Spree.t(:new_state), new_admin_country_state_url(@country), { :id => 'new_state_link' } %>
     </li>
   <% end %>
 <% end %>

--- a/backend/app/views/spree/admin/stock_locations/_transfer_stock_form.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/_transfer_stock_form.html.erb
@@ -31,8 +31,8 @@
     </div>
 
     <div class="form-buttons filter-actions actions" data-hook="buttons">
-      <%= button Spree.t(:transfer_stock), 'plus' %>
-      <%= link_to_with_icon 'remove', Spree.t('actions.cancel'), collection_url, :class => 'button' %>
+      <%= button Spree.t(:transfer_stock) %>
+      <%= link_to Spree.t('actions.cancel'), collection_url, :class => 'button' %>
     </div>
   </fieldset>
 <% end %>

--- a/backend/app/views/spree/admin/stock_locations/index.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/index.html.erb
@@ -9,7 +9,7 @@
   <ul class="actions inline-menu">
     <% if can?(:create, Spree::StockLocation) %>
       <li>
-        <%= button_link_to Spree.t(:new_stock_location), new_object_url, { :icon => 'plus', :id => 'admin_new_stock_location' } %>
+        <%= button_link_to Spree.t(:new_stock_location), new_object_url, { :id => 'admin_new_stock_location' } %>
       </li>
     <% end %>
 

--- a/backend/app/views/spree/admin/stock_locations/index.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/index.html.erb
@@ -15,7 +15,7 @@
 
     <% if can?(:create, Spree::StockTransfer) %>
       <li>
-        <%= button_link_to Spree.t(:new_stock_transfer), new_admin_stock_transfer_path, { :icon => 'forward' } %>
+        <%= button_link_to Spree.t(:new_stock_transfer), new_admin_stock_transfer_path %>
       </li>
     <% end %>
   </ul>

--- a/backend/app/views/spree/admin/stock_movements/index.html.erb
+++ b/backend/app/views/spree/admin/stock_movements/index.html.erb
@@ -6,7 +6,7 @@
 <% content_for :page_actions do %>
   <% if can?(:create, Spree::StockMovement) %>
     <li>
-      <%= button_link_to Spree.t(:new_stock_movement), new_admin_stock_location_stock_movement_path(@stock_location),  icon: 'plus', id: 'admin_new_stock_movement_link' %>
+      <%= button_link_to Spree.t(:new_stock_movement), new_admin_stock_location_stock_movement_path(@stock_location), id: 'admin_new_stock_movement_link' %>
     </li>
   <% end %>
 

--- a/backend/app/views/spree/admin/stock_transfers/edit.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/edit.html.erb
@@ -9,7 +9,6 @@
   <li>
     <%= button_link_to Spree.t(:ready_to_ship),
       finalize_admin_stock_transfer_path(@stock_transfer),
-      icon: 'truck',
       method: 'put',
       data: { confirm: Spree.t('finalize_stock_transfer.confirm') }
     %>
@@ -33,7 +32,7 @@
       <%= f.error_message_on :destination_location %>
     <% end %>
     <div class="filter-actions actions" data-hook="buttons">
-      <%= button Spree.t('actions.save'), 'ok' %>
+      <%= button Spree.t('actions.save') %>
     </div>
   </fieldset>
 <% end %>

--- a/backend/app/views/spree/admin/stock_transfers/index.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/index.html.erb
@@ -5,7 +5,7 @@
 <% content_for :page_actions do %>
   <% if can? :create, Spree::StockTransfer %>
     <li>
-      <%= button_link_to Spree.t(:new_stock_transfer), new_admin_stock_transfer_path, icon: 'plus' %>
+      <%= button_link_to Spree.t(:new_stock_transfer), new_admin_stock_transfer_path %>
     </li>
   <% end %>
 <% end %>

--- a/backend/app/views/spree/admin/stock_transfers/index.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/index.html.erb
@@ -59,7 +59,7 @@
 
       <div class="actions filter-actions">
         <div data-hook="admin_stock_transfers_index_search_buttons">
-          <%= button Spree.t(:filter_results), 'search' %>
+          <%= button Spree.t(:filter_results) %>
         </div>
       </div>
     <% end %>

--- a/backend/app/views/spree/admin/stock_transfers/new.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/new.html.erb
@@ -19,8 +19,8 @@
       <%= f.error_message_on :description %>
     <% end %>
     <div class="filter-actions actions" data-hook="buttons">
-      <%= button Spree.t(:continue), 'arrow-right' %>
-      <%= link_to_with_icon 'remove', Spree.t('actions.cancel'), admin_stock_transfers_path, class: 'button' %>
+      <%= button Spree.t(:continue) %>
+      <%= link_to Spree.t('actions.cancel'), admin_stock_transfers_path, class: 'button' %>
     </div>
   </fieldset>
 <% end %>

--- a/backend/app/views/spree/admin/stock_transfers/receive.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/receive.html.erb
@@ -3,12 +3,11 @@
 
 <% content_for :page_actions do %>
   <li>
-    <%= button_link_to Spree.t(:back_to_stock_transfers_list), admin_stock_transfers_path, :icon => 'arrow-left' %>
+    <%= button_link_to Spree.t(:back_to_stock_transfers_list), admin_stock_transfers_path %>
   </li>
   <li>
     <%= button_link_to Spree.t(:close),
       close_admin_stock_transfer_path(@stock_transfer),
-      icon: 'lock',
       method: 'put',
       data: { confirm: Spree.t('close_stock_transfer.confirm') } %>
   </li>

--- a/backend/app/views/spree/admin/stock_transfers/show.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/show.html.erb
@@ -4,7 +4,7 @@
 
 <% content_for :page_actions do %>
   <li>
-    <%= button_link_to Spree.t(:back_to_stock_transfers_list), admin_stock_transfers_path, :icon => 'arrow-left' %>
+    <%= button_link_to Spree.t(:back_to_stock_transfers_list), admin_stock_transfers_path %>
   </li>
 <% end %>
 

--- a/backend/app/views/spree/admin/stock_transfers/tracking_info.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/tracking_info.html.erb
@@ -3,12 +3,11 @@
 
 <% content_for :page_actions do %>
   <li>
-    <%= button_link_to Spree.t(:back_to_stock_transfers_list), admin_stock_transfers_path, icon: 'arrow-left' %>
+    <%= button_link_to Spree.t(:back_to_stock_transfers_list), admin_stock_transfers_path %>
   </li>
   <li>
     <%= button_link_to Spree.t('actions.ship'),
       ship_admin_stock_transfer_path(@stock_transfer),
-      icon: 'check',
       method: 'put',
       data: { confirm: Spree.t('ship_stock_transfer.confirm') }
       %>

--- a/backend/app/views/spree/admin/store_credits/edit_validity.html.erb
+++ b/backend/app/views/spree/admin/store_credits/edit_validity.html.erb
@@ -17,8 +17,8 @@
       <%= render partial: 'update_reason_field', locals: { f: f } %>
     </div>
     <div class="form-buttons filter-actions actions" data-hook="buttons">
-      <%= button Spree.t('store_credit.actions.invalidate'), 'ban' %>
-      <%= button_link_to Spree.t('actions.cancel'), admin_user_store_credit_path(@user, @store_credit), icon: 'remove' %>
+      <%= button Spree.t('store_credit.actions.invalidate') %>
+      <%= button_link_to Spree.t('actions.cancel'), admin_user_store_credit_path(@user, @store_credit) %>
     </div>
   </fieldset>
 <% end %>

--- a/backend/app/views/spree/admin/store_credits/index.html.erb
+++ b/backend/app/views/spree/admin/store_credits/index.html.erb
@@ -7,7 +7,7 @@
 <%= render 'spree/admin/users/tabs', current: :store_credits %>
 <% content_for :page_actions do %>
   <% if can?(:create, Spree::StoreCredit) %>
-    <li><%= link_to_with_icon 'plus', Spree.t("admin.store_credits.add"), new_admin_user_store_credit_path(@user), class: 'button' %></li>
+    <li><%= link_to Spree.t("admin.store_credits.add"), new_admin_user_store_credit_path(@user), class: 'button' %></li>
   <% end %>
 <% end %>
 

--- a/backend/app/views/spree/admin/style_guide/topics/typography/_icons.html.erb
+++ b/backend/app/views/spree/admin/style_guide/topics/typography/_icons.html.erb
@@ -7,7 +7,7 @@
   <pre><code class="language-ruby">
     icon('fa fa-user')
     link_to_with_icon('send', 'link text', '#')
-    button('button text', 'trash')
-    button_link_to('button link text', '#', icon: 'globe')
+    button('button text')
+    button_link_to('button link text', '#')
   </code></pre>
 </div>

--- a/backend/app/views/spree/admin/tax_categories/index.html.erb
+++ b/backend/app/views/spree/admin/tax_categories/index.html.erb
@@ -9,7 +9,7 @@
   <ul class="actions inline-menu">
     <% if can?(:create, Spree::TaxCategory) %>
       <li>
-        <%= button_link_to Spree.t(:new_tax_category), new_object_url, :icon => 'plus', :id => 'admin_new_tax_categories_link' %>
+        <%= button_link_to Spree.t(:new_tax_category), new_object_url, :id => 'admin_new_tax_categories_link' %>
       </li>
     <% end %>
   </ul>

--- a/backend/app/views/spree/admin/tax_rates/index.html.erb
+++ b/backend/app/views/spree/admin/tax_rates/index.html.erb
@@ -8,7 +8,7 @@
 <% content_for :page_actions do %>
   <% if can?(:create, Spree::TaxRate) %>
     <li>
-      <%= button_link_to Spree.t(:new_tax_rate), new_object_url, :icon => 'plus' %>
+      <%= button_link_to Spree.t(:new_tax_rate), new_object_url %>
     </li>
   <% end %>
 <% end %>

--- a/backend/app/views/spree/admin/taxonomies/edit.erb
+++ b/backend/app/views/spree/admin/taxonomies/edit.erb
@@ -5,7 +5,7 @@
 
 <% content_for :page_actions do %>
   <li>
-    <%= button_link_to Spree.t(:add_taxon), spree.admin_taxonomies_path, { icon: 'plus', class: 'add-taxon-button' } %>
+    <%= button_link_to Spree.t(:add_taxon), spree.admin_taxonomies_path, { class: 'add-taxon-button' } %>
   </li>
 <% end %>
 
@@ -13,8 +13,8 @@
   <fieldset class="no-border-top">
     <%= render :partial => 'form', :locals => { :f => f } %>
     <div class="filter-actions actions">
-      <%= button Spree.t('actions.update'), 'refresh' %>
-      <%= button_link_to Spree.t('actions.cancel'), admin_taxonomies_path, :icon => 'remove' %>
+      <%= button Spree.t('actions.update') %>
+      <%= button_link_to Spree.t('actions.cancel'), admin_taxonomies_path %>
     </div>
   </fieldset>
 

--- a/backend/app/views/spree/admin/taxonomies/index.html.erb
+++ b/backend/app/views/spree/admin/taxonomies/index.html.erb
@@ -5,7 +5,7 @@
 <% content_for :page_actions do %>
   <% if can?(:create, Spree::Taxonomy) %>
     <li>
-      <%= button_link_to Spree.t(:new_taxonomy), spree.new_admin_taxonomy_url, :icon => 'plus', :id => 'admin_new_taxonomy_link' %>
+      <%= button_link_to Spree.t(:new_taxonomy), spree.new_admin_taxonomy_url, :id => 'admin_new_taxonomy_link' %>
     </li>
   <% end %>
 <% end %>

--- a/backend/app/views/spree/admin/taxonomies/new.html.erb
+++ b/backend/app/views/spree/admin/taxonomies/new.html.erb
@@ -12,7 +12,7 @@
   <fieldset class="no-border-top">
     <br>
     <div class="filter-actions actions" data-hook="buttons">
-      <%= button Spree.t('actions.create'), 'ok' %>
+      <%= button Spree.t('actions.create') %>
     </div>
   </fieldset>
 <% end %>

--- a/backend/app/views/spree/admin/taxons/edit.html.erb
+++ b/backend/app/views/spree/admin/taxons/edit.html.erb
@@ -3,7 +3,7 @@
 
 <% content_for :page_actions do %>
   <li>
-    <%= button_link_to Spree.t(:back_to_taxonomies_list), spree.admin_taxonomies_path, :icon => 'arrow-left' %>
+    <%= button_link_to Spree.t(:back_to_taxonomies_list), spree.admin_taxonomies_path %>
   </li>
 <% end %>
 
@@ -13,8 +13,8 @@
   <%= render 'form', :f => f %>
 
   <div class="form-buttons filter-actions" data-hook="buttons">
-    <%= button Spree.t('actions.update'), 'refresh' %>
-    <%= button_link_to Spree.t('actions.cancel'), edit_admin_taxonomy_url(@taxonomy), :icon => "remove" %>
+    <%= button Spree.t('actions.update') %>
+    <%= button_link_to Spree.t('actions.cancel'), edit_admin_taxonomy_url(@taxonomy) %>
   </div>
 <% end %>
 

--- a/backend/app/views/spree/admin/trackers/index.html.erb
+++ b/backend/app/views/spree/admin/trackers/index.html.erb
@@ -7,7 +7,7 @@
 <% content_for :page_actions do %>
   <% if can?(:create, Spree::Tracker) %>
     <li>
-      <%= button_link_to Spree.t(:new_tracker), new_object_url, :icon => 'plus', :id => 'admin_new_tracker_link' %>
+      <%= button_link_to Spree.t(:new_tracker), new_object_url, :id => 'admin_new_tracker_link' %>
     </li>
   <% end %>
 <% end %>

--- a/backend/app/views/spree/admin/users/_tabs.html.erb
+++ b/backend/app/views/spree/admin/users/_tabs.html.erb
@@ -2,26 +2,26 @@
   <nav>
     <ul class='tabs' data-hook="admin_user_tab_options">
       <li<%== ' class="active"' if current == :account %>>
-        <%= link_to_with_icon 'user', Spree.t(:"admin.user.account"), spree.edit_admin_user_path(@user) %>
+        <%= link_to Spree.t(:"admin.user.account"), spree.edit_admin_user_path(@user) %>
       </li>
       <% if can?(:addresses, @user) %>
         <li<%== ' class="active"' if current == :address %>>
-          <%= link_to_with_icon 'user', Spree.t(:"admin.user.addresses"), spree.addresses_admin_user_path(@user) %>
+          <%= link_to Spree.t(:"admin.user.addresses"), spree.addresses_admin_user_path(@user) %>
         </li>
       <% end %>
       <% if can?(:orders, @user) %>
         <li<%== ' class="active"' if current == :orders %>>
-          <%= link_to_with_icon 'shopping-cart', Spree.t(:"admin.user.order_history"), spree.orders_admin_user_path(@user) %>
+          <%= link_to Spree.t(:"admin.user.order_history"), spree.orders_admin_user_path(@user) %>
         </li>
       <% end %>
       <% if can?(:items, @user) %>
         <li<%== ' class="active"' if current == :items %>>
-          <%= link_to_with_icon 'edit', Spree.t(:"admin.user.items"), spree.items_admin_user_path(@user) %>
+          <%= link_to Spree.t(:"admin.user.items"), spree.items_admin_user_path(@user) %>
         </li>
       <% end %>
       <% if can?(:display, Spree::StoreCredit) %>
         <li<%== ' class="active"' if current == :store_credits %>>
-          <%= link_to_with_icon 'money', Spree.t(:"admin.user.store_credit"), spree.admin_user_store_credits_path(@user) %>
+          <%= link_to Spree.t(:"admin.user.store_credit"), spree.admin_user_store_credits_path(@user) %>
         </li>
       <% end %>
     </ul>

--- a/backend/app/views/spree/admin/users/_user_page_actions.html.erb
+++ b/backend/app/views/spree/admin/users/_user_page_actions.html.erb
@@ -1,7 +1,7 @@
 <% content_for :page_actions do %>
   <% if can?([:admin, :create], Spree::Order) %>
     <li>
-      <%= button_link_to Spree.t(:create_new_order), spree.new_admin_order_path(user_id: @user.id), :icon => 'plus' %>
+      <%= button_link_to Spree.t(:create_new_order), spree.new_admin_order_path(user_id: @user.id) %>
     </li>
   <% end %>
 <% end %>

--- a/backend/app/views/spree/admin/users/edit.html.erb
+++ b/backend/app/views/spree/admin/users/edit.html.erb
@@ -36,11 +36,11 @@
       </div>
       <div class="filter-actions actions">
         <%= form_tag spree.clear_api_key_admin_user_path(@user), :method => :put do %>
-          <%= button Spree.t('clear_key', :scope => 'api'), 'trash' %>
+          <%= button Spree.t('clear_key', :scope => 'api') %>
         <% end %>
 
         <%= form_tag spree.generate_api_key_admin_user_path(@user), :method => :put do %>
-          <%= button Spree.t('regenerate_key', :scope => 'api'), 'refresh' %>
+          <%= button Spree.t('regenerate_key', :scope => 'api') %>
         <% end %>
       </div>
 
@@ -50,7 +50,7 @@
 
       <div class="filter-actions actions">
         <%= form_tag spree.generate_api_key_admin_user_path(@user), :method => :put do %>
-          <%= button Spree.t('generate_key', :scope => 'api'), 'key' %>
+          <%= button Spree.t('generate_key', :scope => 'api') %>
         <% end %>
       </div>
     <% end %>

--- a/backend/app/views/spree/admin/users/index.html.erb
+++ b/backend/app/views/spree/admin/users/index.html.erb
@@ -51,7 +51,7 @@
         <%= f.text_field :email_cont, :class => 'fullwidth' %>
       </div>
       <div data-hook="admin_users_index_search_buttons">
-        <%= button Spree.t(:search), 'search' %>
+        <%= button Spree.t(:search) %>
       </div>
     <% end %>
   </div>

--- a/backend/app/views/spree/admin/users/index.html.erb
+++ b/backend/app/views/spree/admin/users/index.html.erb
@@ -4,7 +4,7 @@
 <% content_for :page_actions do %>
   <% if can?(:admin, Spree.user_class) && can?(:create, Spree.user_class) %>
     <li>
-      <%= button_link_to Spree.t(:new_user), new_admin_user_url, :icon => 'plus', :id => 'admin_new_user_link' %>
+      <%= button_link_to Spree.t(:new_user), new_admin_user_url, :id => 'admin_new_user_link' %>
     </li>
   <% end %>
 <% end %>

--- a/backend/app/views/spree/admin/variants/index.html.erb
+++ b/backend/app/views/spree/admin/variants/index.html.erb
@@ -36,11 +36,10 @@
     <ul class="inline-menu" data-hook="toolbar">
       <% if can?(:create, Spree::Variant) %>
         <li id="new_var_link" data-hook>
-          <%= link_to_with_icon 'plus',
-                                Spree.t(:new_variant),
-                                new_admin_product_variant_url(@product),
-                                :remote => :true,
-                                :class => 'button' %>
+          <%= link_to Spree.t(:new_variant),
+                      new_admin_product_variant_url(@product),
+                      remote: :true,
+                      class: 'button' %>
         </li>
       <% end %>
     </ul>

--- a/backend/app/views/spree/admin/zones/index.html.erb
+++ b/backend/app/views/spree/admin/zones/index.html.erb
@@ -8,7 +8,7 @@
 <% content_for :page_actions do %>
   <% if can?(:create, Spree::Zone) %>
     <li>
-      <%= button_link_to Spree.t(:new_zone), new_object_url, :icon => 'plus', :id => 'admin_new_zone_link' %>
+      <%= button_link_to Spree.t(:new_zone), new_object_url, :id => 'admin_new_zone_link' %>
     </li>
   <% end %>
 <% end %>

--- a/backend/spec/features/admin/orders/customer_details_spec.rb
+++ b/backend/spec/features/admin/orders/customer_details_spec.rb
@@ -26,7 +26,7 @@ describe "Customer Details", type: :feature, js: true do
       within("table.stock-levels") do
         find('.variant_quantity').set(1)
       end
-      click_icon :plus
+      click_button 'Add'
       expect(page).to have_css('.line-item')
       click_link "Customer"
       targetted_select2 "foobar@example.com", from: "#s2id_customer_search"

--- a/backend/spec/features/admin/orders/new_order_spec.rb
+++ b/backend/spec/features/admin/orders/new_order_spec.rb
@@ -28,7 +28,7 @@ describe "New Order", type: :feature do
 
     fill_in_quantity("table.stock-levels", "quantity_0", 2)
 
-    click_icon :plus
+    click_button 'Add'
     click_on "Customer"
 
     within "#select-customer" do
@@ -65,8 +65,8 @@ describe "New Order", type: :feature do
     select2_search product.name, from: Spree.t(:name_or_sku)
 
     fill_in_quantity("table.stock-levels", "quantity_0", 2)
-    click_icon :plus
 
+    click_button 'Add'
     click_on "Customer"
 
     within "#select-customer" do
@@ -96,7 +96,7 @@ describe "New Order", type: :feature do
 
       fill_in_quantity('table.stock-levels', 'quantity_0', 2)
 
-      click_icon :plus
+      click_button 'Add'
 
       within(".line-items") do
         expect(page).to have_content(product.name)
@@ -132,7 +132,7 @@ describe "New Order", type: :feature do
 
       fill_in_quantity('table.stock-levels', 'quantity_0', 1)
 
-      click_icon :plus
+      click_button 'Add'
 
       within(".line-items") do
         within(".line-item-name") do
@@ -190,7 +190,7 @@ describe "New Order", type: :feature do
         find('.variant_quantity').set(1)
       end
 
-      click_icon :plus
+      click_button 'Add'
 
       expect(page).to have_css('.line-item')
 

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -47,7 +47,7 @@ describe "Order Details", type: :feature, js: true do
           fill_in "quantity_0", with: 2
         end
 
-        click_icon :plus
+        click_button "Add"
 
         within("#order_total") do
           expect(page).to have_content("$80.00")
@@ -135,7 +135,7 @@ describe "Order Details", type: :feature, js: true do
             fill_in "variant_quantity", with: 1
           end
 
-          click_icon :plus
+          click_button 'Add'
 
           within(".line-items") do
             expect(page).to have_content(tote.name)

--- a/backend/spec/features/admin/products/products_spec.rb
+++ b/backend/spec/features/admin/products/products_spec.rb
@@ -80,11 +80,11 @@ describe "Products", type: :feature do
         expect(page).to have_content("zomg shirt")
         expect(page).not_to have_content("apache baseball cap")
         check "Show Deleted"
-        click_icon :search
+        click_button 'Search'
         expect(page).to have_content("zomg shirt")
         expect(page).to have_content("apache baseball cap")
         uncheck "Show Deleted"
-        click_icon :search
+        click_button 'Search'
         expect(page).to have_content("zomg shirt")
         expect(page).not_to have_content("apache baseball cap")
       end
@@ -96,13 +96,13 @@ describe "Products", type: :feature do
 
         click_nav "Products"
         fill_in "q_name_cont", with: "ap"
-        click_icon :search
+        click_button 'Search'
         expect(page).to have_content("apache baseball cap")
         expect(page).to have_content("apache baseball cap2")
         expect(page).not_to have_content("zomg shirt")
 
         fill_in "q_variants_including_master_sku_cont", with: "A1"
-        click_icon :search
+        click_button "Search"
         expect(page).to have_content("apache baseball cap")
         expect(page).not_to have_content("apache baseball cap2")
         expect(page).not_to have_content("zomg shirt")
@@ -349,7 +349,7 @@ describe "Products", type: :feature do
 
         # This will show our deleted product
         check "Show Deleted"
-        click_icon :search
+        click_button "Search"
         click_link product.name
         expect(page).to have_field('Master Price', with: product.price.to_f)
       end

--- a/backend/spec/features/admin/products/properties_spec.rb
+++ b/backend/spec/features/admin/products/properties_spec.rb
@@ -32,7 +32,7 @@ describe "Properties", type: :feature do
     context "searching properties" do
       it 'should list properties matching search query', js: true do
         fill_in "q_name_cont", with: "size"
-        click_icon :search
+        click_button 'Search'
 
         expect(page).to have_content("shirt size")
         expect(page).not_to have_content("shirt fit")


### PR DESCRIPTION
This PR refers to #1161 issue. I'm not 100% sure we removed all of them but, hey, they are a lot and some of them are very hidden in the UI.

What we did:

- removed all icons from tabs and buttons
- fixed spacing in buttons without icons
- added deprecation warnings for `:icon` option in `button_link_for` and `icon_name` arg in `button` helpers methods since they are not used anymore. I'm not sure about this, but it could be good if we want to use another solution in future versions and we'll add some new style which could be incompatibile with them. Please, let me know your thoughts.

I'm available to squash commits as well...

I attach some screenshot of the result, just to be sure we did what needed:

![schermata 2016-07-29 alle 16 19 31](https://cloud.githubusercontent.com/assets/167946/17252348/ae675e1a-55ac-11e6-9b48-d280edac6534.png)


![schermata 2016-07-29 alle 16 20 00](https://cloud.githubusercontent.com/assets/167946/17252353/b5831cd4-55ac-11e6-9b6b-4e8190441c14.png)


![schermata 2016-07-29 alle 16 52 03](https://cloud.githubusercontent.com/assets/167946/17252377/d0d9dfd6-55ac-11e6-9676-9a1fe4aec173.png)

cc @Mandily 