### PR TITLE
Rescue Spree::Order::InsufficientStock in backend

### DIFF
--- a/backend/app/controllers/spree/admin/orders/customer_details_controller.rb
+++ b/backend/app/controllers/spree/admin/orders/customer_details_controller.rb
@@ -2,6 +2,8 @@ module Spree
   module Admin
     module Orders
       class CustomerDetailsController < Spree::Admin::BaseController
+        rescue_from Spree::Order::InsufficientStock, with: :insufficient_stock_error
+
         before_action :load_order
 
         def show
@@ -58,6 +60,11 @@ module Spree
 
         def should_associate_user?
           params[:guest_checkout] == "false" && params[:user_id] && params[:user_id].to_i != @order.user_id
+        end
+
+        def insufficient_stock_error
+          flash[:error] = Spree.t(:insufficient_stock_for_order)
+          redirect_to edit_admin_order_customer_url(@order)
         end
       end
     end

--- a/backend/app/controllers/spree/admin/payments_controller.rb
+++ b/backend/app/controllers/spree/admin/payments_controller.rb
@@ -1,6 +1,8 @@
 module Spree
   module Admin
     class PaymentsController < Spree::Admin::BaseController
+      rescue_from Spree::Order::InsufficientStock, with: :insufficient_stock_error
+
       before_action :load_order, only: [:create, :new, :index, :fire]
       before_action :load_payment, except: [:create, :new, :index, :fire]
       before_action :load_payment_for_fire, only: :fire
@@ -108,6 +110,11 @@ module Spree
           flash[:notice] = Spree.t(:fill_in_customer_info)
           redirect_to edit_admin_order_customer_url(@order)
         end
+      end
+
+      def insufficient_stock_error
+        flash[:error] = Spree.t(:insufficient_stock_for_order)
+        redirect_to new_admin_order_payment_url(@order)
       end
     end
   end

--- a/core/lib/spree/testing_support/factories/product_factory.rb
+++ b/core/lib/spree/testing_support/factories/product_factory.rb
@@ -32,6 +32,12 @@ FactoryGirl.define do
         after :create do |product|
           product.master.stock_items.first.adjust_count_on_hand(10)
         end
+
+        factory :product_not_backorderable do
+          after :create do |product|
+            product.master.stock_items.first.update_column(:backorderable, false)
+          end
+        end
       end
 
       factory :product_with_option_types do


### PR DESCRIPTION
When an order contains a line_item which requires a quantity greater
than available in not
backorderable stock items, a Spree::Order::InsufficientStock exception
is raised, but there
are no rescue in controllers.

This change adds the rescue for Payments and CustomerDetails
controllers, displays an
`:insufficient_stock_for_order` error message and redirects to the
specific page.

Still needs to be ported in Spree::Api controllers

ref #566 