### PR TITLE
Move :selected_shipping_rate to association

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -6,6 +6,7 @@ module Spree
     has_many :adjustments, as: :adjustable, inverse_of: :adjustable, dependent: :delete_all
     has_many :inventory_units, dependent: :destroy, inverse_of: :shipment
     has_many :shipping_rates, -> { order(:cost) }, dependent: :delete_all
+    has_one :selected_shipping_rate, -> { where(selected: true).order(:cost) }, class_name: Spree::ShippingRate
     has_many :shipping_methods, through: :shipping_rates
     has_many :state_changes, as: :stateful
     has_many :cartons, -> { uniq }, through: :inventory_units
@@ -193,10 +194,6 @@ module Spree
       save!
 
       shipping_rates
-    end
-
-    def selected_shipping_rate
-      shipping_rates.detect(&:selected?)
     end
 
     def manifest


### PR DESCRIPTION
@jhawthorn I noticed that the `selected_shipping_method` has changed in Solidus relative to the current Spree master (my application is on Spree 2.4 currently), and so I just wanted to make sure that this proposed PR jives with your intentions in the previous refactor of this method.

This takes the existing `selected_shipping_rate` method and turns it into a `has_one` association. This enables eager loading, for instance `Spree::Shipment.includes(:selected_shipping_rate)`, which can speed up certain queries and avoid n-query issues in some cases.