### PR TITLE
Don't throw error when an order doesn't have unprocessed payments

### DIFF
--- a/core/app/models/spree/order/payments.rb
+++ b/core/app/models/spree/order/payments.rb
@@ -38,8 +38,6 @@ module Spree
       def process_payments_with(method)
         # Don't run if there is nothing to pay.
         return true if payment_total >= total
-        # Prevent orders from transitioning to complete without a successfully processed payment.
-        raise Core::GatewayError.new(Spree.t(:no_payment_found)) if unprocessed_payments.empty?
 
         unprocessed_payments.each do |payment|
           break if payment_total >= total

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -506,6 +506,23 @@ describe Spree::Order, type: :model do
       end
     end
 
+    context "with a payment in the pending state" do
+      let(:order) { create :order_ready_to_complete }
+      let(:payment) { create :payment, state: "pending", amount: order.total }
+
+      before do
+        order.payments = [payment]
+        order.save!
+      end
+
+      it "allows the order to complete" do
+        expect { order.complete! }.
+          to change { order.state }.
+          from("confirm").
+          to("complete")
+      end
+    end
+
     context "exchange order completion" do
       before do
         order.email = 'spree@example.org'

--- a/core/spec/models/spree/order/payment_spec.rb
+++ b/core/spec/models/spree/order/payment_spec.rb
@@ -52,13 +52,6 @@ module Spree
       end
     end
 
-    context "with no payments" do
-      it "should return falsy" do
-        expect(order).to receive_messages total: 100
-        expect(order.process_payments!).to be_falsy
-      end
-    end
-
     context "with payments completed" do
       it "should not fail transitioning to complete when paid" do
         expect(order).to receive_messages total: 100, payment_total: 100
@@ -115,13 +108,6 @@ module Spree
       it "should process the payments" do
         expect(payment).to receive(:process!)
         expect(order.process_payments!).to be_truthy
-      end
-
-      # Regression spec for https://github.com/spree/spree/issues/5436
-      it 'should raise an error if there are no payments to process' do
-        allow(order).to receive_messages unprocessed_payments: []
-        expect(payment).to_not receive(:process!)
-        expect(order.process_payments!).to be_falsey
       end
 
       context "when a payment raises a GatewayError" do


### PR DESCRIPTION
This has been causing us grief with certain payment methods where the payment is already authorized when we get to the confirm step. In this case the payment may be pending already and it will raise an error.