### PR TITLE
replace all ActiveSupport::Deprecation occurrences with Spree::Deprecation

### DIFF
--- a/core/app/models/spree/promotion/rules/taxon.rb
+++ b/core/app/models/spree/promotion/rules/taxon.rb
@@ -64,8 +64,7 @@ module Spree
         def warn_invalid_match_policy(assume:)
           Spree::Deprecation.warn(
             "#{self.class.name} id=#{id} has unexpected match policy #{preferred_match_policy.inspect}. "\
-            "Interpreting it as '#{assume}'." \
-            "In future versions of Solidus this will be an error."
+            "Interpreting it as '#{assume}'."
           )
         end
 

--- a/core/app/models/spree/promotion/rules/taxon.rb
+++ b/core/app/models/spree/promotion/rules/taxon.rb
@@ -62,7 +62,7 @@ module Spree
         private
 
         def warn_invalid_match_policy(assume:)
-          ActiveSupport::Deprecation.warn(
+          Spree::Deprecation.warn(
             "#{self.class.name} id=#{id} has unexpected match policy #{preferred_match_policy.inspect}. "\
             "Interpreting it as '#{assume}'." \
             "In future versions of Solidus this will be an error."

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -376,7 +376,7 @@ module Spree
     end
 
     def address
-      ActiveSupport::Deprecation.warn("Calling Shipment#address is deprecated. Use Order#ship_address instead", caller)
+      Spree::Deprecation.warn("Calling Shipment#address is deprecated. Use Order#ship_address instead", caller)
       order.ship_address if order
     end
 

--- a/core/spec/models/spree/promotion/rules/taxon_spec.rb
+++ b/core/spec/models/spree/promotion/rules/taxon_spec.rb
@@ -106,7 +106,7 @@ describe Spree::Promotion::Rules::Taxon, type: :model do
       end
 
       it 'logs a warning and uses "any" policy' do
-        expect(ActiveSupport::Deprecation).to(
+        expect(Spree::Deprecation).to(
           receive(:warn).
           with(/has unexpected match policy "invalid"/)
         )
@@ -132,7 +132,7 @@ describe Spree::Promotion::Rules::Taxon, type: :model do
 
     context 'with an invalid match policy' do
       it 'logs a warning and uses "any" policy' do
-        expect(ActiveSupport::Deprecation).to(
+        expect(Spree::Deprecation).to(
           receive(:warn).
           with(/has unexpected match policy "invalid"/)
         )


### PR DESCRIPTION
after #1255 there were still some traces of ActiveSupport::Deprecation flying around. This PR replaces them all with Spree::Deprecation.