### PR TITLE
[rails5] bump the rabl version to the version specified here

### DIFF
--- a/api/solidus_api.gemspec
+++ b/api/solidus_api.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |gem|
   gem.version = Spree.solidus_version
 
   gem.add_dependency 'solidus_core', gem.version
-  gem.add_dependency 'rabl', '~> 0.12.0'
+  gem.add_dependency 'rabl', '~> 0.13.0'
   gem.add_dependency 'versioncake', '~> 3.0'
 end


### PR DESCRIPTION
the API gemspec pointed to an older version of rabl, the fork that is used for rails5 is set to 0.13.0.. this PR updates the required version for rabl in the API to the version specified here https://github.com/jhawthorn/rabl/blob/rails5/lib/rabl/version.rb