### PR TITLE
[rails5] fix deprecation warning on Controller Tests not using keyword arguments

### DIFF
--- a/api/solidus_api.gemspec
+++ b/api/solidus_api.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |gem|
   gem.version = Spree.solidus_version
 
   gem.add_dependency 'solidus_core', gem.version
-  gem.add_dependency 'rabl', '~> 0.12.0'
+  gem.add_dependency 'rabl', '~> 0.13.0'
   gem.add_dependency 'versioncake', '~> 3.0'
 end

--- a/api/spec/controllers/spree/api/base_controller_spec.rb
+++ b/api/spec/controllers/spree/api/base_controller_spec.rb
@@ -51,13 +51,13 @@ describe Spree::Api::BaseController, type: :controller do
 
     it "with an invalid API key" do
       request.headers["X-Spree-Token"] = "fake_key"
-      get :index, {}
+      api_get :index, {}
       expect(json_response).to eq({ "error" => "Invalid API key (fake_key) specified." })
       expect(response.status).to eq(401)
     end
 
     it "using an invalid token param" do
-      get :index, token: "fake_key"
+      api_get :index, token: "fake_key"
       expect(json_response).to eq({ "error" => "Invalid API key (fake_key) specified." })
     end
   end
@@ -66,7 +66,7 @@ describe Spree::Api::BaseController, type: :controller do
     expect(subject).to receive(:authenticate_user).and_return(true)
     expect(subject).to receive(:load_user_roles).and_return(true)
     expect(subject).to receive(:index).and_raise("no joy")
-    get :index, token: "fake_key"
+    api_get :index, token: "fake_key"
     expect(json_response).to eq({ "exception" => "no joy" })
   end
 
@@ -75,7 +75,7 @@ describe Spree::Api::BaseController, type: :controller do
     expect(subject).to receive(:load_user_roles).and_return(true)
     expect(subject).to receive(:index).and_raise(Exception.new("no joy"))
     expect {
-      get :index, token: "fake_key"
+      api_get :index, token: "fake_key"
     }.to raise_error(Exception, "no joy")
   end
 
@@ -125,7 +125,7 @@ describe Spree::Api::BaseController, type: :controller do
     before do
       expect(subject).to receive(:authenticate_user).and_return(true)
       expect(subject).to receive(:index).and_raise(Spree::Order::InsufficientStock)
-      get :index, token: "fake_key"
+      api_get :index, token: "fake_key"
     end
 
     it "should return a 422" do

--- a/api/spec/support/controller_hacks.rb
+++ b/api/spec/support/controller_hacks.rb
@@ -25,7 +25,14 @@ module ControllerHacks
 
   def api_process(action, params = {}, session = nil, flash = nil, method = "get")
     scoping = respond_to?(:resource_scoping) ? resource_scoping : {}
-    process(action, method, params.merge(scoping).reverse_merge!(format: :json), session, flash)
+    process(
+      action,
+      method: method,
+      params: params.merge(scoping),
+      session: session,
+      flash: flash,
+      format: :json
+    )
   end
 end
 

--- a/core/lib/spree/testing_support/controller_requests.rb
+++ b/core/lib/spree/testing_support/controller_requests.rb
@@ -85,13 +85,25 @@ module Spree
 
       def process_spree_action(action, parameters = nil, session = nil, flash = nil, method = "GET")
         parameters ||= {}
-        process(action, method, parameters, session, flash)
+        process(
+          action,
+          method: method,
+          params: parameters,
+          session: session,
+          flash: flash
+        )
       end
 
       def process_spree_xhr_action(action, parameters = nil, session = nil, flash = nil, method = :get)
         parameters ||= {}
-        parameters.reverse_merge!(format: :json)
-        xml_http_request(method, action, parameters, session, flash)
+        xml_http_request(
+          action,
+          method: method,
+          params: parameters,
+          session: session,
+          flash: flash,
+          format: :json
+        )
       end
     end
   end


### PR DESCRIPTION
Rails 5.0 deprecated non keyword arguments on testing controllers. This commit updates the controller_hacks file to remove the deprecation warning by using only keyword arguments.

Depended on #1364, since we need the correct version for the forked rabl gem.