### PR TITLE
Fix running ItemAdjustments multiple times against the same record

### DIFF
--- a/core/app/models/spree/item_adjustments.rb
+++ b/core/app/models/spree/item_adjustments.rb
@@ -70,6 +70,13 @@ module Spree
         updated_at: Time.current
       ) if @item.changed?
 
+      # In rails 4.2 update_columns isn't reflected in the changed_attributes hash,
+      # which means that multiple updates on the same in-memory model will
+      # behave incorrectly.
+      # In rails 5.0 changed_attributes works with update_columns and this is
+      # unnecessary.
+      item.attributes_changed_by_setter.except!(:promo_total, :included_tax_total, :additional_tax_total, :adjustment_total)
+
       @item
     end
 

--- a/core/spec/models/spree/item_adjustments_spec.rb
+++ b/core/spec/models/spree/item_adjustments_spec.rb
@@ -281,18 +281,21 @@ module Spree
         Spree::LineItem.find(item.id)
       end
 
-      it "persists each change", pending: true do
+      it "persists each change" do
         adjustment.source.update_attributes!(amount: 0.1)
         update
+        expect(item).not_to be_changed
         expect(db_record).to have_attributes(adjustment_total: 1)
 
         adjustment.source.update_attributes!(amount: 0.20)
         item.reload
         update
+        expect(item).not_to be_changed
         expect(db_record).to have_attributes(adjustment_total: 2)
 
         adjustment.source.update_attributes!(amount: 0.10)
         update
+        expect(item).not_to be_changed
         expect(db_record).to have_attributes(adjustment_total: 1)
       end
     end

--- a/core/spec/models/spree/item_adjustments_spec.rb
+++ b/core/spec/models/spree/item_adjustments_spec.rb
@@ -267,5 +267,34 @@ module Spree
         expect(line_item.adjustments.promotion.eligible.first.amount.to_i).to eq(-200)
       end
     end
+
+    context "multiple updates" do
+      let(:adjustment) { create(:tax_adjustment, amount: -10) }
+      let(:item) { adjustment.adjustable }
+
+      def update
+        described_class.new(item).update
+      end
+
+      # "fresh" record from the DB
+      def db_record
+        Spree::LineItem.find(item.id)
+      end
+
+      it "persists each change", pending: true do
+        adjustment.source.update_attributes!(amount: 0.1)
+        update
+        expect(db_record).to have_attributes(adjustment_total: 1)
+
+        adjustment.source.update_attributes!(amount: 0.20)
+        item.reload
+        update
+        expect(db_record).to have_attributes(adjustment_total: 2)
+
+        adjustment.source.update_attributes!(amount: 0.10)
+        update
+        expect(db_record).to have_attributes(adjustment_total: 1)
+      end
+    end
   end
 end


### PR DESCRIPTION
Rails 4.2 doesn't update [`ActiveModel::Dirty#changed_attributes`](http://api.rubyonrails.org/classes/ActiveModel/Dirty.html#method-i-changed_attributes) when using `update_columns`. This could cause incorrect behaviour when `ItemAdjustments#update` was called multiple times on the same in-memory object.

Example (buggy) scenario:
``` ruby
> item.changes #=> {}
> ItemAdjustments.new(item)
# adjustment is (somehow) updated to be 10.
# Change is persisted to database
> item.changes #=> {"adjustment_total"=>[BigDecimal(0.0), BigDecimal(10.0)], ...}
> item.changed? #=> true
# set as changed? even though we have persisted using update_columns
> ItemAdjustments.new(item)
# adjustment is updated back to 0.
# NOT PERSISTED TO DATABASE because changed? is false
> item.changes #=> {}
> item.changed? #=> false
```

This PR fixes this issue by manually removing the attributes we know to have been persisted and changed from the `attributes_changed_by_setter` hash.

On rails 5 `update_columns` seems to update the changed hash properly and this is unneeded.