### PR TITLE
Make last names optional on Spree::Address

### DIFF
--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -5,7 +5,7 @@ module Spree
     belongs_to :country, class_name: "Spree::Country"
     belongs_to :state, class_name: "Spree::State"
 
-    validates :firstname, :lastname, :address1, :city, :country_id, presence: true
+    validates :firstname, :address1, :city, :country_id, presence: true
     validates :zipcode, presence: true, if: :require_zipcode?
     validates :phone, presence: true, if: :require_phone?
 

--- a/core/lib/spree/testing_support/factories/address_factory.rb
+++ b/core/lib/spree/testing_support/factories/address_factory.rb
@@ -11,7 +11,7 @@ FactoryGirl.define do
     end
 
     firstname 'John'
-    lastname 'Doe'
+    lastname nil
     company 'Company'
     address1 '10 Lovely Street'
     address2 'Northwest'


### PR DESCRIPTION
For example, we're integrating with Amazon Payments right now and
Amazon doesn't require two names, which breaks this validation. And
it's hard to remove an ActiveRecord validation at the app level.

In chat @jhawthorn mentioned that it'd be nice to move to a single name field eventually, and also pointed to https://www.kalzumeus.com/2010/06/17/falsehoods-programmers-believe-about-names/.

Some ideas I can think of:

- Removal:  Remove the validation on lastname (the current state of this PR)
- Optional:  Make the validation on lastname optional (probably defaulting to true for backwards-compatibility?)
- Validate full_name:  Do `validates_presence of :full_name` instead of validating each field individually
- Combine:  See if there is any progress we can make toward merging the firstname and lastname fields.  Perhaps combine the DB fields into a new `name` field and have ruby methods for firstname and lastname (i.e. the opposite of what we have now)

Other thoughts?