### PR TITLE
Correct use of CONCAT() in very old migration

### DIFF
--- a/core/db/migrate/20130414000512_update_name_fields_on_spree_credit_cards.rb
+++ b/core/db/migrate/20130414000512_update_name_fields_on_spree_credit_cards.rb
@@ -1,7 +1,7 @@
 class UpdateNameFieldsOnSpreeCreditCards < ActiveRecord::Migration
   def up
     if ActiveRecord::Base.connection.adapter_name.downcase.include? "mysql"
-      execute "UPDATE spree_credit_cards SET name = CONCAT(first_name, ' ', last_name)"
+      execute "UPDATE spree_credit_cards SET name = CONCAT_WS(' ', first_name, last_name)"
     else
       execute "UPDATE spree_credit_cards SET name = first_name || ' ' || last_name"
     end


### PR DESCRIPTION
In MySQL, `CONCAT()` will return `NULL` if any of the passed in arguments are `NULL`. There are scenarios in which a user might have a first or last name but not both. In this case, this migration could be losing data.

Instead, we can use `CONCAT_WS()` which will simply skip `NULL` arguments. So we're less likely to lose data while maintaining the same result for all other cases.

[1] http://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_concat
[2] http://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_concat-ws