### PR TITLE
Remove duplicate test from addresses_controller_spec.rb

### DIFF
--- a/api/spec/controllers/spree/api/addresses_controller_spec.rb
+++ b/api/spec/controllers/spree/api/addresses_controller_spec.rb
@@ -37,15 +37,6 @@ module Spree
           expect(json_response['errors']['address1'].first).to eq "can't be blank"
         end
       end
-
-      it "receives the errors object if address is invalid" do
-        api_put :update, id: @address.id, order_id: @order.number,
-                         address: { address1: "" }
-
-        expect(json_response['error']).not_to be_nil
-        expect(json_response['errors']).not_to be_nil
-        expect(json_response['errors']['address1'].first).to eq "can't be blank"
-      end
     end
 
     context "on an address that does not belong to this order" do


### PR DESCRIPTION
This PR removes a duplicate test from addresses_controller_spec.rb. I found the duplicate while perusing your code base after finding your job posting on stack overflow. I find your focus on mentorship and high quality code extremely appealing, so I decided to try to be useful at the same time as introducing myself. I'd love to chat about what you are looking for in a junior developer and what I can bring to your team.

