### PR TITLE
API - Countries: Do not query states for the index

### DIFF
--- a/api/app/controllers/spree/api/countries_controller.rb
+++ b/api/app/controllers/spree/api/countries_controller.rb
@@ -5,7 +5,7 @@ module Spree
 
       def index
         @countries = Country.accessible_by(current_ability, :read).ransack(params[:q]).result.
-                     includes(:states).order('name ASC').
+                     order('name ASC').
                      page(params[:page]).per(params[:per_page])
         country = Country.order("updated_at ASC").last
         if stale?(country)


### PR DESCRIPTION
An index call would result in a ridiculous amount of queries. The states are not meant to be displayed for that view.
