### PR TITLE
Turbolinks 5.0 friendly frontend

### DIFF
--- a/core/app/assets/javascripts/spree.js.coffee.erb
+++ b/core/app/assets/javascripts/spree.js.coffee.erb
@@ -1,7 +1,10 @@
 #= require jsuri
 class window.Spree
   @ready: (callback) ->
-    jQuery(document).ready(callback)
+    if typeof Turbolinks isnt 'undefined' and Turbolinks.supported
+      jQuery(document).on 'turbolinks:load', -> callback(jQuery)
+    else
+      jQuery(document).ready(callback)
 
   @mountedAt: ->
     "<%= Rails.application.routes.url_helpers.spree_path(trailing_slash: true) %>"

--- a/frontend/app/assets/javascripts/spree/frontend/checkout.js.coffee
+++ b/frontend/app/assets/javascripts/spree/frontend/checkout.js.coffee
@@ -7,6 +7,3 @@
 Spree.disableSaveOnClick = ->
   ($ 'form.edit_order').submit ->
     ($ this).find(':submit, :image').attr('disabled', true).removeClass('primary').addClass 'disabled'
-
-Spree.ready ($) ->
-  Spree.Checkout = {}

--- a/frontend/app/assets/javascripts/spree/frontend/checkout/address.js.coffee
+++ b/frontend/app/assets/javascripts/spree/frontend/checkout/address.js.coffee
@@ -1,4 +1,4 @@
-$ ->
+Spree.ready ($) ->
   if $('#checkout_form_address').is('*')
     # Hidden by default to support browsers with javascript disabled
     $('.js-address-fields').show()

--- a/frontend/app/assets/javascripts/spree/frontend/checkout/payment.js.coffee
+++ b/frontend/app/assets/javascripts/spree/frontend/checkout/payment.js.coffee
@@ -29,12 +29,11 @@ Spree.ready ($) ->
         ($ '#payment_method_' + @value).show() if @checked
       )
 
-      ($ document).on('click', '#cvv_link', (event) ->
+      ($ '#cvv_link').on 'click', (event) ->
         windowName = 'cvv_info'
         windowOptions = 'left=20,top=20,width=500,height=500,toolbar=0,resizable=0,scrollbars=1'
         window.open(($ this).attr('href'), windowName, windowOptions)
         event.preventDefault()
-      )
 
       # Activate already checked payment method if form is re-rendered
       # i.e. if user enters invalid data

--- a/frontend/app/assets/javascripts/spree/frontend/product.js.coffee
+++ b/frontend/app/assets/javascripts/spree/frontend/product.js.coffee
@@ -1,4 +1,4 @@
-$ ->
+Spree.ready ($) ->
   Spree.addImageHandlers = ->
     thumbnails = ($ '#product-images ul.thumbnails')
     ($ '#main-image').data 'selectedThumb', ($ '#main-image img').attr('src')


### PR DESCRIPTION
This change allows all Spree frontend javascript to work seamlessly with Turbolinks 5.0, while not disturbing if Turbolinks is not present.

* I've tested with Turbolinks 5.0 the following sections with Spree JavaScript and they all work when fetched with Turbolinks (through get requests)
  - product page's thumbs
  - address validation on address stage checkout
  - credit card validation on payment stage checkout
  - cart delete button press
  - coupon code applicator

_I can re-arrange the commits and all if needed_