### PR TITLE
Add html templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Solidus 2.3.0 (master, unreleased)
 
+- Add missing email html template for shipped_email and inventory_cancellation
 - Deprecate `Spree::Core::CurrentStore` in favor of `Spree::CurrentStoreSelector`. [\#1993](https://github.com/solidusio/solidus/pull/1993)
 - Deprecate `Spree::Order#assign_default_addresses!` in favor of `Order.new.assign_default_user_addresses`. [\#1954](https://github.com/solidusio/solidus/pull/1954) ([kennyadsl](https://github.com/kennyadsl))
 - Change how line item options are allowed in line items controller. [\#1943](https://github.com/solidusio/solidus/pull/1943)

--- a/core/app/views/spree/carton_mailer/shipped_email.html.erb
+++ b/core/app/views/spree/carton_mailer/shipped_email.html.erb
@@ -11,7 +11,7 @@
         <%= Spree.t('shipment_mailer.shipped_email.shipment_summary') %>
       </p>
       <table>
-        <% @shipment.manifest.each do |item| %>
+        <% @manifest.each do |item| %>
           <tr>
             <td><%= item.variant.sku %></td>
             <td><%= item.variant.product.name %></td>
@@ -20,10 +20,10 @@
         <% end %>
       </table>
       <p>
-        <%= Spree.t('shipment_mailer.shipped_email.track_information', tracking: @shipment.tracking)     if @shipment.tracking %>
+        <%= Spree.t('shipment_mailer.shipped_email.track_information', tracking: @carton.tracking) if @carton.tracking %>
       </p>
       <p>
-        <%= Spree.t('shipment_mailer.shipped_email.track_link',        :url      => @shipment.tracking_url) if @shipment.tracking_url %>
+        <%= Spree.t('shipment_mailer.shipped_email.track_link',        :url      => @carton.tracking_url) if @carton.tracking_url %>
       </p>
       <p>
         <%= Spree.t('shipment_mailer.shipped_email.thanks') %>

--- a/core/app/views/spree/order_mailer/cancel_email.html.erb
+++ b/core/app/views/spree/order_mailer/cancel_email.html.erb
@@ -15,8 +15,8 @@
           <tr>
             <td><%= item.variant.sku %></td>
             <td>
-              <%= raw(item.variant.product.name) %>
-              <%= raw(item.variant.options_text) -%>
+              <%= item.variant.product.name %>
+              <%= item.variant.options_text -%>
             </td>
             <td>(<%=item.quantity%>) @ <%= item.single_money %> = <%= item.display_amount %></td>
           </tr>
@@ -29,7 +29,7 @@
         <% @order.adjustments.eligible.each do |adjustment| %>
           <tr>
             <td></td>
-            <td><%= raw(adjustment.label) %></td>
+            <td><%= sanitize(adjustment.label) %></td>
             <td><%= adjustment.display_amount %></td>
           </tr>
         <% end %>

--- a/core/app/views/spree/order_mailer/confirm_email.html.erb
+++ b/core/app/views/spree/order_mailer/confirm_email.html.erb
@@ -15,8 +15,8 @@
           <tr>
             <td><%= item.variant.sku %></td>
             <td>
-              <%= raw(item.variant.product.name) %>
-              <%= raw(item.variant.options_text) -%>
+              <%= item.variant.product.name %>
+              <%= item.variant.options_text -%>
             </td>
             <td>(<%=item.quantity%>) @ <%= item.single_money %> = <%= item.display_amount %></td>
           </tr>

--- a/core/app/views/spree/order_mailer/inventory_cancellation_email.html.erb
+++ b/core/app/views/spree/order_mailer/inventory_cancellation_email.html.erb
@@ -14,8 +14,8 @@
         <% @inventory_units.each do |item| %>
           <tr>
             <td><%= item.variant.sku %></td>
-            <td><%= raw(item.variant.product.name) %></td>
-            <td><%= raw(item.variant.options_text) -%></td>
+            <td><%= item.variant.product.name %></td>
+            <td><%= item.variant.options_text -%></td>
           </tr>
         <% end %>
       </table>

--- a/core/app/views/spree/order_mailer/inventory_cancellation_email.html.erb
+++ b/core/app/views/spree/order_mailer/inventory_cancellation_email.html.erb
@@ -1,0 +1,26 @@
+<table>
+  <tr>
+    <td>
+      <p class="lede">
+        <%= Spree.t('order_mailer.inventory_cancellation.dear_customer') %>
+      </p>
+      <p>
+        <%= Spree.t('order_mailer.inventory_cancellation.instructions') %>
+      </p>
+      <p>
+        <%= Spree.t('order_mailer.inventory_cancellation.order_summary_canceled') %>
+      </p>
+      <table>
+        <% @inventory_units.each do |item| %>
+          <tr>
+            <td><%= item.variant.sku %></td>
+            <td><%= raw(item.variant.product.name) %></td>
+            <td><%= raw(item.variant.options_text) -%></td>
+          </tr>
+        <% end %>
+      </table>
+      <p>
+    </td>
+    <td class="expander"></td>
+  </tr>
+</table>

--- a/core/app/views/spree/reimbursement_mailer/reimbursement_email.html.erb
+++ b/core/app/views/spree/reimbursement_mailer/reimbursement_email.html.erb
@@ -21,13 +21,13 @@
           <% @reimbursement.return_items.exchange_requested.each do |return_item| %>
             <tr>
               <td>
-                <%= return_item.variant.sku %> <%= raw(return_item.variant.name) %> <%= "(#{raw(return_item.variant.options_text)})" if return_item.variant.options_text.present? %>
+                <%= return_item.variant.sku %> <%= return_item.variant.name %> <%= "(#{return_item.variant.options_text})" if return_item.variant.options_text.present? %>
               </td>
               <td>
                 ->
               </td>
               <td>
-                <%= return_item.exchange_variant.sku %> <%= raw(return_item.exchange_variant.name) %> <%= "(#{raw(return_item.exchange_variant.options_text)})" if return_item.exchange_variant.options_text.present? %>
+                <%= return_item.exchange_variant.sku %> <%= return_item.exchange_variant.name %> <%= "(#{return_item.exchange_variant.options_text})" if return_item.exchange_variant.options_text.present? %>
               </td>
             </tr>
           <% end %>

--- a/core/spec/mailers/carton_mailer_spec.rb
+++ b/core/spec/mailers/carton_mailer_spec.rb
@@ -11,8 +11,8 @@ describe Spree::CartonMailer do
   # Regression test for https://github.com/spree/spree/issues/2196
   it "doesn't include out of stock in the email body" do
     shipment_email = Spree::CartonMailer.shipped_email(order: order, carton: carton)
-    expect(shipment_email.body).not_to include(%{Out of Stock})
-    expect(shipment_email.body).to include(%{Your order has been shipped})
+    expect(shipment_email).not_to have_body_text(%{Out of Stock})
+    expect(shipment_email).to have_body_text(%{Your order has been shipped})
     expect(shipment_email.subject).to eq "#{order.store.name} Shipment Notification ##{order.number}"
   end
 
@@ -38,7 +38,7 @@ describe Spree::CartonMailer do
 
         specify do
           shipped_email = Spree::CartonMailer.shipped_email(order: order, carton: carton)
-          expect(shipped_email.body).to include("Caro Cliente,")
+          expect(shipped_email).to have_body_text("Caro Cliente,")
         end
       end
     end


### PR DESCRIPTION
- Add shipped_email.html.erb
  
  When the ShipmentMailer's template was moved under CartonMailer, only the text format was moved. 
  ref https://github.com/solidusio/solidus/commit/9ff3f310e0b3f274fce6f5a2b25fe7dd6859bab7 
  
  I change the test from:
  expect(shipment_email.body).not_to include(%{Out of Stock})
  in favour of
  expect(shipment_email).not_to have_body_text(%{Out of Stock})
  for use the default_part_body method.
- Add inventory_cancellation_email.html.erb based on https://github.com/solidusio/solidus/blob/c5b9e0242291a2249ea62b046cc973b530957d51/core/app/views/spree/order_mailer/inventory_cancellation_email.text.erb 
