### PR TITLE
A hook to pass options to OrderContents#add

### DIFF
--- a/frontend/app/controllers/spree/orders_controller.rb
+++ b/frontend/app/controllers/spree/orders_controller.rb
@@ -48,7 +48,7 @@ module Spree
       # 2,147,483,647 is crazy. See issue https://github.com/spree/spree/issues/2695.
       if quantity.between?(1, 2_147_483_647)
         begin
-          order.contents.add(variant, quantity)
+          order.contents.add(variant, quantity, order_contents_add_options)
         rescue ActiveRecord::RecordInvalid => e
           error = e.record.errors.full_messages.join(", ")
         end
@@ -114,6 +114,12 @@ module Spree
         flash[:error] = Spree.t(:order_not_found)
         redirect_to(root_path) && return
       end
+    end
+
+    # Override this method if you wish to pass more options into the
+    # OrderContents#add call from #populate
+    def order_contents_add_options
+      {}
     end
   end
 end


### PR DESCRIPTION
In the context of writting a solidus subscription gem which passes along
some extra fields from the add_to_cart form I found that I wanted to
pass extra params to OrderContents#add.

However in order to do this I needed to override the entirety of the
OrdersController#populate method.

This provides a private method which can be overriden with the options
to be passed into order contents.

In my case this would allow me to process subscription options in
OrderContents without needing to completely obfuscate the functionality
provided by the front_end controller

Im hoping this might be of use to anyone else wishing to hook into which
options get passed to OrderContents#add.