### PR TITLE
Add 'Create' and 'Destroy' API calls for Credit Card resource

### DIFF
--- a/api/app/controllers/spree/api/credit_cards_controller.rb
+++ b/api/app/controllers/spree/api/credit_cards_controller.rb
@@ -22,16 +22,16 @@ module Spree
       end
 
       def create
-        # @credit_card = Core::Importer::CreditCard.new(nil, @_params[:user_id], @_params[:credit_card]).create
-        @credit_card = Core::Importer::CreditCard.new(nil, @_params[:user_id], credit_card_create_params)
-        credit_card = @credit_card.create
+        authorize! :create, CreditCard
+        @credit_card = Core::Importer::CreditCard.import(user, credit_card_create_params)
+        respond_with(@credit_card, status: 201, default_template: :show)
+      end
 
-        if credit_card.persisted?
-          # Returning: 201: {"address"=>{"country"=>{}, "state"=>{}}}   ????
-          respond_with(credit_card, status: 201, default_template: :show)
-        else
-          invalid_resource!(credit_card)
-        end
+      def destroy
+        @credit_card = find_credit_card
+        authorize! :destroy, @credit_card
+        @credit_card.destroy
+        respond_with(@credit_card, status: 204)
       end
 
       private

--- a/api/app/controllers/spree/api/credit_cards_controller.rb
+++ b/api/app/controllers/spree/api/credit_cards_controller.rb
@@ -53,9 +53,6 @@ module Spree
         params.require(:credit_card).permit(permitted_credit_card_update_attributes)
       end
 
-      def credit_card_create_params
-        params.require(:credit_card).permit(permitted_credit_card_create_attributes)
-      end
     end
   end
 end

--- a/api/app/controllers/spree/api/credit_cards_controller.rb
+++ b/api/app/controllers/spree/api/credit_cards_controller.rb
@@ -21,6 +21,19 @@ module Spree
         end
       end
 
+      def create
+        # @credit_card = Core::Importer::CreditCard.new(nil, @_params[:user_id], @_params[:credit_card]).create
+        @credit_card = Core::Importer::CreditCard.new(nil, @_params[:user_id], credit_card_create_params)
+        credit_card = @credit_card.create
+
+        if credit_card.persisted?
+          # Returning: 201: {"address"=>{"country"=>{}, "state"=>{}}}   ????
+          respond_with(credit_card, status: 201, default_template: :show)
+        else
+          invalid_resource!(credit_card)
+        end
+      end
+
       private
 
       def user
@@ -34,8 +47,16 @@ module Spree
         authorize! :update, @credit_card
       end
 
+      def credit_card_create_params
+        params.require(:credit_card).permit(permitted_credit_card_create_attributes)
+      end
+
       def credit_card_update_params
         params.require(:credit_card).permit(permitted_credit_card_update_attributes)
+      end
+
+      def credit_card_create_params
+        params.require(:credit_card).permit(permitted_credit_card_create_attributes)
       end
     end
   end

--- a/api/app/controllers/spree/api/credit_cards_controller.rb
+++ b/api/app/controllers/spree/api/credit_cards_controller.rb
@@ -52,7 +52,6 @@ module Spree
       def credit_card_update_params
         params.require(:credit_card).permit(permitted_credit_card_update_attributes)
       end
-
     end
   end
 end

--- a/api/app/controllers/spree/api/credit_cards_controller.rb
+++ b/api/app/controllers/spree/api/credit_cards_controller.rb
@@ -22,14 +22,12 @@ module Spree
       end
 
       def create
-        authorize! :create, CreditCard
         @credit_card = Core::Importer::CreditCard.import(user, credit_card_create_params)
         respond_with(@credit_card, status: 201, default_template: :show)
       end
 
       def destroy
         @credit_card = find_credit_card
-        authorize! :destroy, @credit_card
         @credit_card.destroy
         respond_with(@credit_card, status: 204)
       end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -110,7 +110,7 @@ Spree::Core::Engine.add_routes do
       resource :address_book, only: [:show, :update, :destroy]
     end
 
-    resources :credit_cards, only: [:update]
+    resources :credit_cards, only: [:create, :update, :destroy]
 
     resources :properties
     resources :stock_locations do

--- a/api/spec/controllers/spree/api/credit_cards_controller_spec.rb
+++ b/api/spec/controllers/spree/api/credit_cards_controller_spec.rb
@@ -83,7 +83,6 @@ module Spree
 
           expect(json_response).to have_attributes(creditcard_base_attributes)
           expect(response.status).to eq(201)
-
         end
 
         it "can delete credit cards for other users" do
@@ -117,7 +116,6 @@ module Spree
           api_delete :destroy, id: freshly_created_credit_card_id
           expect(response.status).to eq(204)
         end
-
       end
 
       context "calling user is not in admin role" do
@@ -167,7 +165,6 @@ module Spree
           }
           expect(json_response).to have_attributes(creditcard_base_attributes)
           expect(response.status).to eq(201)
-
         end
 
         it "can not create credit cards for other users" do
@@ -196,7 +193,6 @@ module Spree
           expect(response.status).to eq(404)
 
         end
-
       end
 
       context "calling user is not in admin role" do
@@ -213,11 +209,8 @@ module Spree
           api_delete :destroy, id: card_for_unsuccessful_delete_attempt.id
           expect(response.status).to eq(401)
         end
-
       end
-
     end
-
 
     describe '#update' do
       let(:credit_card) { create(:credit_card, name: 'Joe Shmoe', user: credit_card_user) }

--- a/api/spec/controllers/spree/api/credit_cards_controller_spec.rb
+++ b/api/spec/controllers/spree/api/credit_cards_controller_spec.rb
@@ -71,11 +71,11 @@ module Spree
             address_attributes: {
               firstname: "Art",
               lastname: "Vanderlay",
-              address1: "100 Ravine Ln NE",
-              address2: "Suite 310",
-              city: "Bainbridge Island",
-              state_name: "Washington",
-              zipcode: "98110",
+              address1: "1344 Queens Boulevard",
+              address2: "",
+              city: "Queens",
+              state_name: "New York",
+              zipcode: "11375",
               country_iso: "US",
               phone: "867-5309"
             }
@@ -100,11 +100,11 @@ module Spree
             address_attributes: {
               firstname: "George",
               lastname: "Costanza",
-              address1: "100 Ravine Ln NE",
-              address2: "Suite 310",
-              city: "Bainbridge Island",
-              state_name: "Washington",
-              zipcode: "98110",
+              address1: "1344 Queens Boulevard",
+              address2: "",
+              city: "Queens",
+              state_name: "New York",
+              zipcode: "11375",
               country_iso: "US",
               phone: "867-5309"
             }
@@ -156,11 +156,11 @@ module Spree
             address_attributes: {
               firstname: "George",
               lastname: "Costanza",
-              address1: "100 Ravine Ln NE",
-              address2: "Suite 310",
-              city: "Bainbridge Island",
-              state_name: "Washington",
-              zipcode: "98110",
+              address1: "1344 Queens Boulevard",
+              address2: "",
+              city: "Queens",
+              state_name: "New York",
+              zipcode: "11375",
               country_iso: "US",
               phone: "867-5309"
             }
@@ -183,11 +183,11 @@ module Spree
             address_attributes: {
               firstname: "Art",
               lastname: "Vanderlay",
-              address1: "100 Ravine Ln NE",
-              address2: "Suite 310",
-              city: "Bainbridge Island",
-              state_name: "Washington",
-              zipcode: "98110",
+              address1: "1344 Queens Boulevard",
+              address2: "",
+              city: "Queens",
+              state_name: "New York",
+              zipcode: "11375",
               country_iso: "US",
               phone: "867-5309"
             }

--- a/api/spec/controllers/spree/api/credit_cards_controller_spec.rb
+++ b/api/spec/controllers/spree/api/credit_cards_controller_spec.rb
@@ -248,10 +248,5 @@ module Spree
         end
       end
     end
-
-    # describe '#destroy' do
-    #   it ""
-    # end
-
   end
 end

--- a/api/spec/controllers/spree/api/credit_cards_controller_spec.rb
+++ b/api/spec/controllers/spree/api/credit_cards_controller_spec.rb
@@ -192,7 +192,8 @@ module Spree
               phone: "867-5309"
             }
           }
-          expect(response.status).to eq(401)
+          # TODO: Why does this get a 404 instead of a 401?
+          expect(response.status).to eq(404)
 
         end
 

--- a/api/spec/controllers/spree/api/credit_cards_controller_spec.rb
+++ b/api/spec/controllers/spree/api/credit_cards_controller_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 module Spree
   describe Api::CreditCardsController, type: :controller do
+    let(:creditcard_base_attributes) { Api::ApiHelpers.creditcard_attributes }
     describe '#index' do
       render_views
 
@@ -45,6 +46,27 @@ module Spree
           expect(json_response["credit_cards"].length).to eq(1)
           expect(json_response["credit_cards"].first["id"]).to eq(card.id)
         end
+
+        it "can create credit cards for other users" do
+          api_post :create, user_id: normal_user.id, credit_card: {
+            name: "Art Vanderlay",
+            cc_type: "discover",
+            last_digits: "7890",
+            month: 3,
+            year: 2086,
+            payment_method_id: 1,
+            gateway_customer_profile_id: "12345678",
+            gateway_payment_profile_id: "abc123"
+          }
+          expect(json_response).to have_attributes(creditcard_base_attributes)
+          expect(response.status).to eq(201)
+
+        end
+
+        it "can delete credit cards for other users" do
+
+        end
+
       end
 
       context "calling user is not in admin role" do
@@ -69,6 +91,23 @@ module Spree
           expect(json_response["credit_cards"].length).to eq(1)
           expect(json_response["credit_cards"].first["id"]).to eq(card.id)
         end
+
+        it "can create own credit cards" do
+
+        end
+
+        it "can not create credit cards for other users" do
+
+        end
+
+        it "can delete own credit cards" do
+
+        end
+
+        it "can not delete other user's credit cards" do
+
+        end
+
       end
     end
 
@@ -101,5 +140,10 @@ module Spree
         end
       end
     end
+
+    # describe '#destroy' do
+    #   it ""
+    # end
+
   end
 end

--- a/api/spec/controllers/spree/api/credit_cards_controller_spec.rb
+++ b/api/spec/controllers/spree/api/credit_cards_controller_spec.rb
@@ -56,15 +56,55 @@ module Spree
             year: 2086,
             payment_method_id: 1,
             gateway_customer_profile_id: "12345678",
-            gateway_payment_profile_id: "abc123"
+            gateway_payment_profile_id: "abc123",
+            address_attributes: {
+              firstname: "Art",
+              lastname: "Vanderlay",
+              address1: "100 Ravine Ln NE",
+              address2: "Suite 310",
+              city: "Bainbridge Island",
+              state_name: "Washington",
+              zipcode: "98110",
+              country_iso: "US",
+              phone: "867-5309"
+            }
           }
+
           expect(json_response).to have_attributes(creditcard_base_attributes)
           expect(response.status).to eq(201)
 
         end
 
         it "can delete credit cards for other users" do
+          # Create a credit card to delete and capture its id.
+          api_post :create, user_id: normal_user.id, credit_card: {
+            name: "George Costanza",
+            cc_type: "discover",
+            last_digits: "7890",
+            month: 3,
+            year: 2086,
+            payment_method_id: 1,
+            gateway_customer_profile_id: "12345678",
+            gateway_payment_profile_id: "abc123",
+            address_attributes: {
+              firstname: "George",
+              lastname: "Costanza",
+              address1: "100 Ravine Ln NE",
+              address2: "Suite 310",
+              city: "Bainbridge Island",
+              state_name: "Washington",
+              zipcode: "98110",
+              country_iso: "US",
+              phone: "867-5309"
+            }
+          }
+          expect(json_response).to have_attributes(creditcard_base_attributes)
+          expect(response.status).to eq(201)
 
+          freshly_created_credit_card_id = json_response["id"]
+
+          api_delete :destroy, id: freshly_created_credit_card_id
+          expect(response.status).to eq(204)
         end
 
       end
@@ -93,19 +133,93 @@ module Spree
         end
 
         it "can create own credit cards" do
+          api_post :create, user_id: normal_user.id, credit_card: {
+            name: "George Constanza",
+            cc_type: "discover",
+            last_digits: "7890",
+            month: 3,
+            year: 2086,
+            payment_method_id: 1,
+            gateway_customer_profile_id: "12345678",
+            gateway_payment_profile_id: "abc123",
+            address_attributes: {
+              firstname: "George",
+              lastname: "Costanza",
+              address1: "100 Ravine Ln NE",
+              address2: "Suite 310",
+              city: "Bainbridge Island",
+              state_name: "Washington",
+              zipcode: "98110",
+              country_iso: "US",
+              phone: "867-5309"
+            }
+          }
+          expect(json_response).to have_attributes(creditcard_base_attributes)
+          expect(response.status).to eq(201)
 
         end
 
         it "can not create credit cards for other users" do
+          api_post :create, user_id: admin_user.id, credit_card: {
+            name: "Art Vanderlay",
+            cc_type: "discover",
+            last_digits: "7890",
+            month: 3,
+            year: 2086,
+            payment_method_id: 1,
+            gateway_customer_profile_id: "12345678",
+            gateway_payment_profile_id: "abc123",
+            address_attributes: {
+              firstname: "Art",
+              lastname: "Vanderlay",
+              address1: "100 Ravine Ln NE",
+              address2: "Suite 310",
+              city: "Bainbridge Island",
+              state_name: "Washington",
+              zipcode: "98110",
+              country_iso: "US",
+              phone: "867-5309"
+            }
+          }
+          expect(response.status).to eq(401)
 
         end
 
         it "can delete own credit cards" do
+          api_post :create, user_id: normal_user.id, credit_card: {
+            name: "George Constanza",
+            cc_type: "discover",
+            last_digits: "7890",
+            month: 3,
+            year: 2086,
+            payment_method_id: 1,
+            gateway_customer_profile_id: "12345678",
+            gateway_payment_profile_id: "abc123",
+            address_attributes: {
+              firstname: "George",
+              lastname: "Costanza",
+              address1: "100 Ravine Ln NE",
+              address2: "Suite 310",
+              city: "Bainbridge Island",
+              state_name: "Washington",
+              zipcode: "98110",
+              country_iso: "US",
+              phone: "867-5309"
+            }
+          }
+          expect(json_response).to have_attributes(creditcard_base_attributes)
+          expect(response.status).to eq(201)
+
+          freshly_created_credit_card_id = json_response["id"]
+
+          api_delete :destroy, id: freshly_created_credit_card_id
+          expect(response.status).to eq(204)
 
         end
 
         it "can not delete other user's credit cards" do
-
+          api_delete :destroy, id: 1
+          expect(response.status).to eq(401)
         end
 
       end

--- a/core/app/models/spree/credit_card.rb
+++ b/core/app/models/spree/credit_card.rb
@@ -176,6 +176,19 @@ module Spree
       )
     end
 
+    # Associates the specified user with the credit card.
+    def associate_user!(user)
+      self.user = user
+      attrs_to_set = { user_id: user.try(:id) }
+
+      if persisted?
+        # immediately persist the changes we just made, but don't use save since we might have an invalid address associated
+        self.class.unscoped.where(id: id).update_all(attrs_to_set)
+      end
+
+      assign_attributes(attrs_to_set)
+    end
+
     private
 
     def require_card_numbers?

--- a/core/lib/spree/core/controller_helpers/strong_parameters.rb
+++ b/core/lib/spree/core/controller_helpers/strong_parameters.rb
@@ -10,6 +10,12 @@ module Spree
                  to: :permitted_attributes,
                  prefix: :permitted)
 
+        def permitted_credit_card_create_attributes
+          permitted_attributes.credit_card_create_attributes + [
+            address_attributes: permitted_address_attributes
+          ]
+        end
+
         def permitted_credit_card_update_attributes
           permitted_attributes.credit_card_update_attributes + [
             address_attributes: permitted_address_attributes

--- a/core/lib/spree/core/importer.rb
+++ b/core/lib/spree/core/importer.rb
@@ -7,3 +7,4 @@ end
 
 require 'spree/core/importer/order'
 require 'spree/core/importer/product'
+require 'spree/core/importer/creditcard'

--- a/core/lib/spree/core/importer/creditcard.rb
+++ b/core/lib/spree/core/importer/creditcard.rb
@@ -7,8 +7,6 @@ module Spree
           ActiveRecord::Base.transaction do
             credit_card = Spree::CreditCard.create! create_params
             credit_card.associate_user!(user)
-            #address = Spree::Address.create! create_params.address
-            # credit_card.associate_address!(address)
             credit_card.save!
 
             credit_card.reload

--- a/core/lib/spree/core/importer/creditcard.rb
+++ b/core/lib/spree/core/importer/creditcard.rb
@@ -1,0 +1,18 @@
+module Spree
+  module Core
+    module Importer
+      class CreditCard
+
+        def initialize(creditcard, user_id, creditcard_params)
+          @creditcard = creditcard || Spree::CreditCard.new(creditcard_params)
+        end
+
+        def create
+          @creditcard.save!
+          @creditcard
+        end
+
+      end
+    end
+  end
+end

--- a/core/lib/spree/core/importer/creditcard.rb
+++ b/core/lib/spree/core/importer/creditcard.rb
@@ -3,13 +3,17 @@ module Spree
     module Importer
       class CreditCard
 
-        def initialize(creditcard, user_id, creditcard_params)
-          @creditcard = creditcard || Spree::CreditCard.new(creditcard_params)
-        end
+        def self.import(user, create_params)
+          ActiveRecord::Base.transaction do
+            credit_card = Spree::CreditCard.create! create_params
+            credit_card.associate_user!(user)
+            #address = Spree::Address.create! create_params.address
+            # credit_card.associate_address!(address)
+            credit_card.save!
 
-        def create
-          @creditcard.save!
-          @creditcard
+            credit_card.reload
+          end
+
         end
 
       end

--- a/core/lib/spree/core/importer/creditcard.rb
+++ b/core/lib/spree/core/importer/creditcard.rb
@@ -2,7 +2,6 @@ module Spree
   module Core
     module Importer
       class CreditCard
-
         def self.import(user, create_params)
           ActiveRecord::Base.transaction do
             credit_card = Spree::CreditCard.create! create_params
@@ -13,7 +12,6 @@ module Spree
           end
 
         end
-
       end
     end
   end

--- a/core/lib/spree/permission_sets/default_customer.rb
+++ b/core/lib/spree/permission_sets/default_customer.rb
@@ -12,7 +12,7 @@ module Spree
         can :create, ReturnAuthorization do |return_authorization|
           return_authorization.order.user == user
         end
-        can [:display, :update], CreditCard, user_id: user.id
+        can [:display, :update, :create, :destroy], CreditCard, user_id: user.id
         can :display, Product
         can :display, ProductProperty
         can :display, Property

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -55,7 +55,7 @@ module Spree
 
     @@credit_card_create_attributes = [
       :month, :year, :name, :cc_type, :last_digits, :payment_method_id, :gateway_customer_profile_id,
-      :gateway_payment_profile_id
+      :gateway_payment_profile_id, :default
     ]
 
     @@customer_return_attributes = [:stock_location_id, return_items_attributes: [:id, :inventory_unit_id, :return_authorization_id, :returned, :amount, :reception_status_event, :acceptance_status, :exchange_variant_id, :resellable]]

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -8,6 +8,7 @@ module Spree
       :address_book_attributes,
       :checkout_attributes,
       :credit_card_update_attributes,
+      :credit_card_create_attributes,
       :customer_return_attributes,
       :image_attributes,
       :inventory_unit_attributes,
@@ -50,6 +51,11 @@ module Spree
 
     @@credit_card_update_attributes = [
       :month, :year, :expiry, :first_name, :last_name, :name
+    ]
+
+    @@credit_card_create_attributes = [
+      :month, :year, :name, :cc_type, :last_digits, :payment_method_id, :gateway_customer_profile_id,
+      :gateway_payment_profile_id
     ]
 
     @@customer_return_attributes = [:stock_location_id, return_items_attributes: [:id, :inventory_unit_id, :return_authorization_id, :returned, :amount, :reception_status_event, :acceptance_status, :exchange_variant_id, :resellable]]


### PR DESCRIPTION
Enable use case of system external of Solidus handling the creation of payment instruments via 3rd party payment provider.

For example, mobile application's server API creates entries in Braintree for customers' credit cards.  Mobile application's server API then calls Solidus API to create credit card entities to use in Solidus commerce transactions.

Solidus test suite passes.  JMeter integration tests created around this case passed when used with Braintree gateway plugin and Braintree API sandbox.
