### PR TITLE
Use in-memory objects in OrderUpdater and remove Adjustment callbacks

### DIFF
--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -185,6 +185,8 @@ describe "Order Details", type: :feature, js: true do
 
             expect(page).to have_css('.shipment', count: 2)
 
+            order.shipments.reload
+
             expect(order.shipments.count).to eq(2)
             expect(order.shipments.last.backordered?).to eq(false)
             expect(order.shipments.first.inventory_units_for(product.master).count).to eq(1)
@@ -198,6 +200,8 @@ describe "Order Details", type: :feature, js: true do
             complete_split_to(stock_location2, quantity: 2)
 
             expect(page).to have_content("pending package from 'Clarksville'")
+
+            order.shipments.reload
 
             expect(order.shipments.count).to eq(1)
             expect(order.shipments.last.backordered?).to eq(false)
@@ -213,6 +217,8 @@ describe "Order Details", type: :feature, js: true do
 
             expect(page).to have_content("pending package from 'Clarksville'")
 
+            order.shipments.reload
+
             expect(order.shipments.count).to eq(1)
             expect(order.shipments.last.backordered?).to eq(false)
             expect(order.shipments.first.inventory_units_for(product.master).count).to eq(5)
@@ -227,6 +233,8 @@ describe "Order Details", type: :feature, js: true do
 
             wait_for_ajax
 
+            order.shipments.reload
+
             expect(order.shipments.count).to eq(1)
             expect(order.shipments.first.inventory_units_for(product.master).count).to eq(2)
             expect(order.shipments.first.stock_location.id).to eq(stock_location.id)
@@ -239,6 +247,8 @@ describe "Order Details", type: :feature, js: true do
             complete_split_to(stock_location2, quantity: 0)
 
             wait_for_ajax
+
+            order.shipments.reload
 
             expect(order.shipments.count).to eq(1)
             expect(order.shipments.first.inventory_units_for(product.master).count).to eq(2)
@@ -280,6 +290,8 @@ describe "Order Details", type: :feature, js: true do
 
               wait_for_ajax
 
+              order.shipments.reload
+
               expect(order.shipments.count).to eq(1)
               expect(order.shipments.first.inventory_units_for(product.master).count).to eq(2)
               expect(order.shipments.first.stock_location.id).to eq(stock_location.id)
@@ -295,6 +307,8 @@ describe "Order Details", type: :feature, js: true do
               complete_split_to(stock_location2, quantity: 2)
 
               expect(page).to have_content("pending package from 'Clarksville'")
+
+              order.shipments.reload
 
               expect(order.shipments.count).to eq(1)
               expect(order.shipments.first.inventory_units_for(product.master).count).to eq(2)
@@ -314,6 +328,8 @@ describe "Order Details", type: :feature, js: true do
 
             expect(page).to have_css('.shipment', count: 2)
 
+            order.shipments.reload
+
             expect(order.shipments.count).to eq(2)
             expect(order.shipments.last.backordered?).to eq(false)
             expect(order.shipments.first.inventory_units_for(product.master).count).to eq(1)
@@ -325,6 +341,7 @@ describe "Order Details", type: :feature, js: true do
       context 'removing an item' do
         it "removes only the one item" do
           @shipment2 = order.shipments.create(stock_location_id: stock_location2.id)
+          order.line_items.reload # inventory units are outdated
           order.line_items[0].inventory_units[0].update!(shipment: @shipment2)
           visit spree.edit_admin_order_path(order)
 
@@ -354,6 +371,8 @@ describe "Order Details", type: :feature, js: true do
 
           expect(page).to have_css("#shipment_#{@shipment2.id}", count: 1)
 
+          order.shipments.reload
+
           expect(order.shipments.count).to eq(1)
           expect(order.shipments.last.inventory_units_for(product.master).count).to eq(2)
         end
@@ -376,6 +395,8 @@ describe "Order Details", type: :feature, js: true do
             end
 
             wait_for_ajax
+
+            order.shipments.reload
 
             expect(order.shipments.count).to eq(2)
             expect(order.shipments.first.inventory_units_for(product.master).count).to eq(1)
@@ -400,6 +421,8 @@ describe "Order Details", type: :feature, js: true do
 
             expect(page).not_to have_content(/Move .* to/)
             expect(page).to have_css('.shipment', count: 2)
+
+            order.shipments.reload
 
             expect(order.shipments.count).to eq(2)
             expect(order.shipments.first.inventory_units_for(product.master).count).to eq 1

--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -26,9 +26,6 @@ module Spree
     validates :amount, numericality: true
     validates :promotion_code, presence: true, if: :require_promotion_code?
 
-    after_create :update_adjustable_adjustment_total
-    after_destroy :update_adjustable_adjustment_total
-
     scope :not_finalized, -> { where(finalized: false) }
     scope :open, -> do
       Spree::Deprecation.warn "Adjustment.open is deprecated. Instead use Adjustment.not_finalized", caller
@@ -176,11 +173,6 @@ module Spree
     end
 
     private
-
-    def update_adjustable_adjustment_total
-      # Cause adjustable's total to be recalculated
-      ItemAdjustments.new(adjustable).update
-    end
 
     def require_promotion_code?
       promotion? && source.promotion.codes.any?

--- a/core/app/models/spree/order_contents.rb
+++ b/core/app/models/spree/order_contents.rb
@@ -30,7 +30,7 @@ module Spree
     end
 
     def remove_line_item(line_item, options = {})
-      line_item.destroy!
+      order.line_items.destroy(line_item)
       after_add_or_remove(line_item, options)
     end
 

--- a/core/app/models/spree/order_contents.rb
+++ b/core/app/models/spree/order_contents.rb
@@ -130,7 +130,6 @@ module Spree
 
     def reload_totals
       order_updater.update
-      order.reload
     end
 
     def add_to_line_item(variant, quantity, options = {})
@@ -160,7 +159,7 @@ module Spree
       line_item.target_shipment = options[:shipment]
 
       if line_item.quantity == 0
-        line_item.destroy
+        order.line_items.destroy(line_item)
       else
         line_item.save!
       end

--- a/core/app/models/spree/order_merger.rb
+++ b/core/app/models/spree/order_merger.rb
@@ -135,9 +135,7 @@ module Spree
     # @api private
     # @return [void]
     def persist_merge
-      updater.update_item_count
-      updater.update_item_total
-      updater.persist_totals
+      updater.update
     end
   end
 end

--- a/core/app/models/spree/order_merger.rb
+++ b/core/app/models/spree/order_merger.rb
@@ -111,7 +111,7 @@ module Spree
         current_line_item.quantity += other_order_line_item.quantity
         handle_error(current_line_item) unless current_line_item.save
       else
-        other_order_line_item.order_id = order.id
+        order.line_items << other_order_line_item
         handle_error(other_order_line_item) unless other_order_line_item.save
       end
     end

--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -31,7 +31,11 @@ module Spree
     end
 
     def recalculate_adjustments
-      all_adjustments.includes(:adjustable).map(&:adjustable).uniq.each { |adjustable| Spree::ItemAdjustments.new(adjustable).update }
+      adjustables = [*line_items, *shipments, order]
+
+      adjustables.each do |adjustable|
+        Spree::ItemAdjustments.new(adjustable).update
+      end
     end
 
     # Updates the following Order total values:

--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -67,7 +67,7 @@ module Spree
     end
 
     def update_shipment_total
-      order.shipment_total = shipments.sum(:cost)
+      order.shipment_total = shipments.to_a.sum(&:cost)
       update_order_total
     end
 
@@ -77,15 +77,14 @@ module Spree
 
     def update_adjustment_total
       recalculate_adjustments
-      order.adjustment_total = line_items.sum(:adjustment_total) +
-      shipments.sum(:adjustment_total) +
-      adjustments.eligible.sum(:amount)
-      order.included_tax_total = line_items.sum(:included_tax_total) + shipments.sum(:included_tax_total)
-      order.additional_tax_total = line_items.sum(:additional_tax_total) + shipments.sum(:additional_tax_total)
 
-      order.promo_total = line_items.sum(:promo_total) +
-      shipments.sum(:promo_total) +
-      adjustments.promotion.eligible.sum(:amount)
+      all_items = line_items + shipments
+
+      order.adjustment_total = all_items.sum(&:adjustment_total) + adjustments.eligible.sum(:amount)
+      order.included_tax_total = all_items.sum(&:included_tax_total)
+      order.additional_tax_total = all_items.sum(&:additional_tax_total)
+
+      order.promo_total = all_items.sum(&:promo_total) + adjustments.promotion.eligible.sum(:amount)
 
       update_order_total
     end
@@ -95,7 +94,7 @@ module Spree
     end
 
     def update_item_total
-      order.item_total = line_items.sum('price * quantity')
+      order.item_total = line_items.to_a.sum(&:amount)
       update_order_total
     end
 

--- a/core/spec/models/spree/adjustment_spec.rb
+++ b/core/spec/models/spree/adjustment_spec.rb
@@ -10,16 +10,6 @@ describe Spree::Adjustment, type: :model do
 
   let(:adjustment) { Spree::Adjustment.create!(label: 'Adjustment', adjustable: order, order: order, amount: 5) }
 
-  context '#create & #destroy' do
-    let(:adjustment) { Spree::Adjustment.new(label: "Adjustment", amount: 5, order: order, adjustable: line_item) }
-
-    it 'calls #update_adjustable_adjustment_total' do
-      expect(adjustment).to receive(:update_adjustable_adjustment_total).twice
-      adjustment.save
-      adjustment.destroy
-    end
-  end
-
   context '#save' do
     let(:adjustment) { Spree::Adjustment.create(label: "Adjustment", amount: 5, order: order, adjustable: line_item) }
 

--- a/core/spec/models/spree/item_adjustments_spec.rb
+++ b/core/spec/models/spree/item_adjustments_spec.rb
@@ -200,6 +200,7 @@ module Spree
             order_promos[promo_sequence[0]].activate order: order
             order_promos[promo_sequence[1]].activate order: order
 
+            order.update!
             order.reload
             expect(order.all_adjustments.count).to eq(2), "Expected two adjustments (using sequence #{promo_sequence})"
             expect(order.all_adjustments.eligible.count).to eq(1), "Expected one elegible adjustment (using sequence #{promo_sequence})"

--- a/core/spec/models/spree/order_cancellations_spec.rb
+++ b/core/spec/models/spree/order_cancellations_spec.rb
@@ -152,7 +152,13 @@ describe Spree::OrderCancellations do
       it "generates the correct total amount" do
         order.cancellations.short_ship([inventory_unit_1])
         order.cancellations.short_ship([inventory_unit_2])
-        expect(line_item.adjustments.map(&:amount)).to match_array([0.01, -0.83, -0.84])
+        expect(line_item.adjustments.map(&:amount)).to match_array(
+          [
+            0.01, # tax adjustment
+            -0.84, # short ship 1
+            -0.83, # short ship 2
+          ]
+        )
         expect(line_item.total).to eq 0
       end
     end

--- a/core/spec/models/spree/order_cancellations_spec.rb
+++ b/core/spec/models/spree/order_cancellations_spec.rb
@@ -131,13 +131,12 @@ describe Spree::OrderCancellations do
 
     context "when rounding is required" do
       let(:order) { create(:order_ready_to_ship, line_items_count: 1, line_items_price: 0.83) }
-      let(:line_item) { order.line_items.first }
+      let(:line_item) { order.line_items.to_a.first }
       let(:inventory_unit_1) { line_item.inventory_units[0] }
       let(:inventory_unit_2) { line_item.inventory_units[1] }
 
       before do
         order.contents.add(line_item.variant)
-        line_item.reload
 
         # make the total $1.67 so it divides unevenly
         Spree::Adjustment.tax.create!(
@@ -152,9 +151,7 @@ describe Spree::OrderCancellations do
 
       it "generates the correct total amount" do
         order.cancellations.short_ship([inventory_unit_1])
-        inventory_unit_2.line_item.reload # UnitCancel#compute_amount needs updated amounts
         order.cancellations.short_ship([inventory_unit_2])
-        line_item.reload
         expect(line_item.adjustments.map(&:amount)).to match_array([0.01, -0.83, -0.84])
         expect(line_item.total).to eq 0
       end

--- a/core/spec/models/spree/order_cancellations_spec.rb
+++ b/core/spec/models/spree/order_cancellations_spec.rb
@@ -155,7 +155,7 @@ describe Spree::OrderCancellations do
         inventory_unit_2.line_item.reload # UnitCancel#compute_amount needs updated amounts
         order.cancellations.short_ship([inventory_unit_2])
         line_item.reload
-        expect(line_item.adjustments.non_tax.sum(:amount)).to eq(-1.67)
+        expect(line_item.adjustments.map(&:amount)).to match_array([0.01, -0.83, -0.84])
         expect(line_item.total).to eq 0
       end
     end

--- a/core/spec/models/spree/order_cancellations_spec.rb
+++ b/core/spec/models/spree/order_cancellations_spec.rb
@@ -152,7 +152,9 @@ describe Spree::OrderCancellations do
 
       it "generates the correct total amount" do
         order.cancellations.short_ship([inventory_unit_1])
+        inventory_unit_2.line_item.reload # UnitCancel#compute_amount needs updated amounts
         order.cancellations.short_ship([inventory_unit_2])
+        line_item.reload
         expect(line_item.adjustments.non_tax.sum(:amount)).to eq(-1.67)
         expect(line_item.total).to eq 0
       end

--- a/core/spec/models/spree/order_merger_spec.rb
+++ b/core/spec/models/spree/order_merger_spec.rb
@@ -104,15 +104,17 @@ module Spree
 
       specify do
         subject.merge!(order_2)
-        line_items = order_1.line_items.reload
-        expect(line_items.count).to eq(2)
+
+        # Both in memory and in DB line items
+        expect(order_1.line_items.length).to eq(2)
+        expect(order_1.line_items.count).to eq(2)
 
         expect(order_1.item_count).to eq 2
-        expect(order_1.item_total).to eq line_items.map(&:amount).sum
+        expect(order_1.item_total).to eq order_1.line_items.map(&:amount).sum
 
         # No guarantee on ordering of line items, so we do this:
-        expect(line_items.pluck(:quantity)).to match_array([1, 1])
-        expect(line_items.pluck(:variant_id)).to match_array([variant.id, variant_2.id])
+        expect(order_1.line_items.pluck(:quantity)).to match_array([1, 1])
+        expect(order_1.line_items.pluck(:variant_id)).to match_array([variant.id, variant_2.id])
       end
     end
 

--- a/core/spec/models/spree/order_merger_spec.rb
+++ b/core/spec/models/spree/order_merger_spec.rb
@@ -126,6 +126,7 @@ module Spree
 
       it "should create errors with invalid line items" do
         variant_2.really_destroy!
+        order_2.line_items.to_a.first.reload # so that it registers as invalid
         subject.merge!(order_2)
         expect(order_1.errors.full_messages).not_to be_empty
       end

--- a/core/spec/models/spree/order_updater_spec.rb
+++ b/core/spec/models/spree/order_updater_spec.rb
@@ -302,5 +302,16 @@ module Spree
         expect(order.promo_total).to eq(-1)
       end
     end
+
+    context "with item with no adjustment and incorrect totals" do
+      let!(:line_item) { create(:line_item, order: order, price: 10) }
+
+      it "updates the totals" do
+        line_item.update!(adjustment_total: 100)
+        expect {
+          order.update!
+        }.to change { line_item.reload.adjustment_total }.from(100).to(0)
+      end
+    end
   end
 end

--- a/core/spec/models/spree/order_updater_spec.rb
+++ b/core/spec/models/spree/order_updater_spec.rb
@@ -47,6 +47,7 @@ module Spree
           updater.update
           create(:adjustment, source: promotion_action, adjustable: order, order: order)
           create(:line_item, order: order, price: 10) # in addition to the two already created
+          order.line_items.reload # need to pick up the extra line item
           updater.update
         end
 

--- a/core/spec/models/spree/order_updater_spec.rb
+++ b/core/spec/models/spree/order_updater_spec.rb
@@ -57,21 +57,13 @@ module Spree
       end
 
       it "update order adjustments" do
-        # TODO: Make this into a more valid test, so that stubbing
-        # `recalculate_adjustments` isn't necessary.
-        #
-        # A line item will not have both additional and included tax,
-        # so please just humour me for now.
-        order.line_items.first.update_columns({
-          adjustment_total: 10.05,
-          additional_tax_total: 0.05,
-          included_tax_total: 0.05
-        })
-        allow(updater).to receive(:recalculate_adjustments)
-        updater.update_adjustment_total
-        expect(order.adjustment_total).to eq(10.05)
-        expect(order.additional_tax_total).to eq(0.05)
-        expect(order.included_tax_total).to eq(0.05)
+        create(:adjustment, adjustable: order, order: order, source: nil, amount: 10)
+
+        expect {
+          updater.update_adjustment_total
+        }.to change {
+          order.adjustment_total
+        }.from(0).to(10)
       end
     end
 

--- a/core/spec/models/spree/promotion/actions/create_item_adjustments_spec.rb
+++ b/core/spec/models/spree/promotion/actions/create_item_adjustments_spec.rb
@@ -41,12 +41,6 @@ module Spree
               expect(line_item.adjustments.first.source).to eq action
             end
 
-            it "updates cached order line items" do
-              order.line_items.to_a
-              action.perform(payload)
-              expect(order.line_items.map(&:adjustment_total)).to eq([-10])
-            end
-
             it "does not perform twice on the same item" do
               2.times { action.perform(payload) }
               expect(action.adjustments.count).to eq(1)

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -121,6 +121,7 @@ describe Spree::Shipment, type: :model do
     it 'should equal line items final amount with tax' do
       shipment = create(:shipment, order: create(:order_with_totals))
       create :tax_adjustment, adjustable: shipment.order.line_items.first, order: shipment.order
+      shipment.order.update!
       expect(shipment.item_cost).to eql(11.0)
     end
   end

--- a/frontend/spec/controllers/spree/checkout_controller_spec.rb
+++ b/frontend/spec/controllers/spree/checkout_controller_spec.rb
@@ -439,6 +439,6 @@ describe Spree::CheckoutController, type: :controller do
 
     expect {
       post :update, { state: "payment" }
-    }.to change { order.line_items }
+    }.to change { order.line_items.to_a.size }.from(1).to(0)
   end
 end


### PR DESCRIPTION
My primary goal here is to make it easy to integrate 3rd party tax services
in a clean and reliable way by removing extraneous calls to
`ItemAdjustments#update`. (See https://github.com/solidusio/solidus/issues/1252.)

### Use in-memory objects in OrderUpdater:
Operate on `order.line_items` and `order.shipments` inside OrderUpdater
Instead of loading separate copies from the DB. This should give us:

- Better performance
- Return more accurate results. I.e. when calling `order.update!` the
`order.line_items` on that order object will get updated.

The second point is extra important as we work on removing extraneous calls
to `ItemAdjustments` (see below), which previously had the side effect of
updating some in-memory objects that won't otherwise get updated until
a `.reload` is invoked.

### Remove Adjustment callbacks:
Same idea as https://github.com/solidusio/solidus/pull/1356, and likewise related to https://github.com/solidusio/solidus/issues/1252.

Currently we do this:

- Add adjustment to item
  - Trigger `ItemAdjustments#update` via an after_create on Adjustment
- Call `order.update!` on items order
  - Trigger `ItemAdjustments#update` via OrderUpdater#update_totals

We should be able to eliminate the first call to
`ItemAdjustments#update` because we can rely on `order.update!` being
called.  If it weren't called then order-level amounts would be
incorrect.