### PR TITLE
On admin user form, only show password_confirmation if model supports

### DIFF
--- a/backend/app/views/spree/admin/users/_form.html.erb
+++ b/backend/app/views/spree/admin/users/_form.html.erb
@@ -60,10 +60,13 @@
       <%= f.error_message_on :password %>
     <% end %>
 
-    <%= f.field_container :password do %>
-      <%= f.label :password_confirmation %>
-      <%= f.password_field :password_confirmation, :class => 'fullwidth' %>
-      <%= f.error_message_on :password_confirmation %>
+
+    <% if f.object.respond_to?(:password_confirmation) %>
+      <%= f.field_container :password do %>
+        <%= f.label :password_confirmation %>
+        <%= f.password_field :password_confirmation, :class => 'fullwidth' %>
+        <%= f.error_message_on :password_confirmation %>
+      <% end %>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
Less coupled to devise, more capable of supporting other auth
solutions, others popular ones (eg clearance) don't use a
password_confirmation field