### PR TITLE
UserMethods#on_sign_in method, extracted from solidus_auth_devise

### DIFF
--- a/core/app/models/concerns/spree/user_methods.rb
+++ b/core/app/models/concerns/spree/user_methods.rb
@@ -59,5 +59,20 @@ module Spree
     def total_available_store_credit
       store_credits.reload.to_a.sum(&:amount_remaining)
     end
+
+    # can be called by solidus_auth_devise, or other auth integration, upon
+    # a succesful user login, does what Solidus needs to be done, such
+    # as associating guest orders in session with the user record.
+    #
+    # Call will normally look something like:
+    #
+    #    logged_in_user.on_sign_in(guest_token: auth.cookies.signed[:guest_token])
+    def on_sign_in(guest_token:)
+      if guest_token.present?
+        Spree::Order.incomplete.where(guest_token: guest_token, user_id: nil).each do |order|
+          order.associate_user!(self)
+        end
+      end
+    end
   end
 end

--- a/core/spec/models/spree/concerns/user_methods_spec.rb
+++ b/core/spec/models/spree/concerns/user_methods_spec.rb
@@ -38,4 +38,14 @@ describe Spree::UserMethods do
       it { is_expected.to be_nil }
     end
   end
+
+  describe "#on_sign_in" do
+    let(:guest_token) { "dummy_guest_token" }
+    let!(:guest_order) { create(:order, user: nil, guest_token: guest_token) }
+
+    it "associates guest orders" do
+      test_user.on_sign_in(guest_token: guest_token)
+      expect(guest_order.reload.user).to eq(test_user)
+    end
+  end
 end


### PR DESCRIPTION
This is not devise-specific code, if it's in solidus UserMethods, then
any auth integration can simply call it, instead of copying and pasting
from solidus_auth_devise.

By naming the method "`on_sign_in`" instead of `associate_guest_orders`,
the idea is that if solidus changes it's mind about what needs to happen
on sign in, or how it should be implemented -- it can just change this method,
which auth integrations will continue to call with no changes in their code,
no need for new logic to be copied to every existing auth integration.

If this is in Solidus, the [solidus_auth_devise implementation of
the post-sign-in hook](https://github.com/solidusio/solidus_auth_devise/blob/a6e27e98d80f507a7064fdd63f2950f622b7d93e/config/initializers/warden.rb)
could be changed to something like:

```
user.on_sign_in(guest_token: auth.cookies.signed[:guest_token]) if user.is_a?(Spree::User)
```
