### PR TITLE
Fix query in Promotion::Actions::FreeShipping

### DIFF
--- a/core/app/models/spree/promotion/actions/free_shipping.rb
+++ b/core/app/models/spree/promotion/actions/free_shipping.rb
@@ -33,7 +33,7 @@ module Spree
         private
 
         def promotion_credit_exists?(shipment)
-          shipment.adjustments.where(source_id: id).exists?
+          shipment.adjustments.where(source: self).exists?
         end
       end
     end


### PR DESCRIPTION
The previous query can match the wrong source_type.

I'm thinking this is worth a spec but lmk if someone thinks otherwise.