### PR TITLE
Remove require_email on email validation

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -93,7 +93,7 @@ module Spree
     before_create :link_by_email
 
     validates :email, presence: true, if: :require_email
-    validates :email, email: true, if: :require_email, allow_blank: true
+    validates :email, email: true, allow_blank: true
     validates :number, presence: true, uniqueness: { allow_blank: true }
     validates :store_id, presence: true
 


### PR DESCRIPTION
We only need `require_email` to be true to validate the presence of an email address. If, for whatever reason, you want to add an email address to an order *before* `require_email` is true then it should still go through the appropriate validations to make sure it's a valid email address.

Another option would be for each store to modify `require_email` but there are times where you may want to validate an email address without validating that `presence: true` so I believe this is the preferred method.