### PR TITLE
Use in-memory adjustments in OrderUpdater

### DIFF
--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -80,11 +80,11 @@ module Spree
 
       all_items = line_items + shipments
 
-      order.adjustment_total = all_items.sum(&:adjustment_total) + adjustments.eligible.sum(:amount)
+      order.adjustment_total = all_items.sum(&:adjustment_total) + adjustments.select(&:eligible?).sum(&:amount)
       order.included_tax_total = all_items.sum(&:included_tax_total)
       order.additional_tax_total = all_items.sum(&:additional_tax_total)
 
-      order.promo_total = all_items.sum(&:promo_total) + adjustments.promotion.eligible.sum(:amount)
+      order.promo_total = all_items.sum(&:promo_total) + adjustments.select(&:eligible?).select(&:promotion?).sum(&:amount)
 
       update_order_total
     end


### PR DESCRIPTION
From @mtomov's [suggestion](https://github.com/solidusio/solidus/pull/1389#discussion_r75265926) in #1389 

This currently fails because [this line in ItemAdjustments](https://github.com/solidusio/solidus/blob/master/core/app/models/spree/item_adjustments.rb#L90) causes the order's adjustments to become stale.