### PR TITLE
Remove no-op code

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -503,7 +503,6 @@ module Spree
       elsif shipments.any? { |s| !s.pending? }
         raise CannotRebuildShipments.new(Spree.t(:cannot_rebuild_shipments_shipments_not_pending))
       else
-        adjustments.shipping.destroy_all
         shipments.destroy_all
         self.shipments = Spree::Config.stock.coordinator_class.new(self).shipments
       end


### PR DESCRIPTION
Order adjustments can't be shipping adjustments.  The SQL generated by
this includes:
```sql
SELECT spree_adjustments.*
  FROM spree_adjustments
 WHERE spree_adjustments.adjustable_id = X
   AND spree_adjustments.adjustable_type = 'Spree::Order'
   AND spree_adjustments.adjustable_type = 'Spree::Shipment'
```