### PR TITLE
Fix mailer previews poor behaviour

### DIFF
--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -97,8 +97,4 @@ require 'spree/core/stock_configuration'
 require 'spree/permission_sets'
 require 'spree/deprecation'
 
-require 'spree/mailer_previews/order_preview'
-require 'spree/mailer_previews/carton_preview'
-require 'spree/mailer_previews/reimbursement_preview'
-
 require 'spree/core/price_migrator'

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -119,6 +119,19 @@ module Spree
       initializer "spree.core.checking_migrations", before: :load_config_initializers do |_app|
         Migrations.new(config, engine_name).check
       end
+
+      # Load in mailer previews for apps to use in development.
+      # We need to make sure we call `Preview.all` before requiring our
+      # previews, otherwise any previews the app attempts to add need to be
+      # manually required.
+      if Rails.env.development?
+        initializer "spree.mailer_previews" do
+          ActionMailer::Preview.all
+          Dir[root.join("lib/spree/mailer_previews/**/*_preview.rb")].each do |file|
+            require_dependency file
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
ActionMailer::Preview.all will only look for new previews if the [descendents list is empty.](https://github.com/rails/rails/blob/4-2-stable/actionmailer/lib/action_mailer/preview.rb#L57) By manually requiring the previews, we populate it prematurely and cause any app using this extension to be unable to load their own previews in without additional manual effort.

Instead of causing extra grief for applications including Solidus, we can ensure we call ActionMailer::Preview.all before requiring our previews. This will ensure any previews that should be automatically loaded in get picked up and we can continue to manually include ours afterwards.

Unfortunately, this won't fix any issues where an application includes multiple engines attempting to add their own mailer previews.