### PR TITLE
Add `inverse_of` to order.payments

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -47,7 +47,7 @@ module Spree
     belongs_to :store, class_name: 'Spree::Store'
     has_many :state_changes, as: :stateful
     has_many :line_items, -> { order(:created_at, :id) }, dependent: :destroy, inverse_of: :order
-    has_many :payments, dependent: :destroy
+    has_many :payments, dependent: :destroy, inverse_of: :order
     has_many :return_authorizations, dependent: :destroy, inverse_of: :order
     has_many :reimbursements, inverse_of: :order
     has_many :adjustments, -> { order(:created_at) }, as: :adjustable, inverse_of: :adjustable, dependent: :destroy

--- a/core/app/models/spree/order_capturing.rb
+++ b/core/app/models/spree/order_capturing.rb
@@ -21,22 +21,15 @@ class Spree::OrderCapturing
     Spree::OrderMutex.with_lock!(@order) do
       uncaptured_amount = @order.display_total.cents
 
-      begin
-        sorted_payments(@order).each do |payment|
-          amount = [uncaptured_amount, payment.money.cents].min
+      sorted_payments(@order).each do |payment|
+        amount = [uncaptured_amount, payment.money.cents].min
 
-          if amount > 0
-            payment.capture!(amount)
-            uncaptured_amount -= amount
-          elsif Spree::OrderCapturing.void_unused_payments
-            payment.void_transaction!
-          end
+        if amount > 0
+          payment.capture!(amount)
+          uncaptured_amount -= amount
+        elsif Spree::OrderCapturing.void_unused_payments
+          payment.void_transaction!
         end
-      ensure
-        # FIXME: Adding the inverse_of on the payments relation for orders -should- fix this,
-        # however it only appears to make it worse (calling with changes three times instead of once.
-        # Warrants an investigation. Reloading for now.
-        @order.reload.update!
       end
     end
   end

--- a/core/spec/models/spree/order_capturing_spec.rb
+++ b/core/spec/models/spree/order_capturing_spec.rb
@@ -4,8 +4,8 @@ describe Spree::OrderCapturing do
   describe '#capture_payments' do
     subject { Spree::OrderCapturing.new(order, payment_methods).capture_payments }
 
-    # Regression for the order.update! in the ensure block.
-    # See the comment there.
+    # Regression for https://github.com/solidusio/solidus/pull/407
+    # See also https://github.com/solidusio/solidus/pull/1406
     context "updating the order" do
       let(:order) { create :completed_order_with_totals }
       let(:payment_methods) { [] }


### PR DESCRIPTION
This doesn't seem to happen automatically and is more important now
that we're using cached association objects in OrderUpdater (see
#1389).  Solidus 1.4 broke some functionality in our app without it.  [This](https://github.com/solidusio/solidus/blob/v1.4.0.beta1/core/app/models/spree/payment.rb#L27-L28)
`after_save` in Payment triggers `order.update!` if the Order or the
Payment is complete.  That update needs to operate on the in-memory order
object or things can get out of sync.

It seems like this would be worth getting into Solidus 1.4.

In a Solidus sandbox without this patch:

    >> o = Spree::Order.create!
    >> p = o.payments.create!
    >> puts p.order.object_id, o.object_id
    70240633410460
    70240634674300

With this patch:

    >> o = Spree::Order.create!
    >> p = o.payments.create!
    >> puts p.order.object_id, o.object_id
    70145793491740
    70145793491740

There is some important history around this particular `inverse_of` --
see #407 and spree/spree_gateway#132.

Commit d7b8c73 removed part of the specs around this,
assuming that the `inverse_of` was automatically added, but it doesn't
actually seem to be (see above). The remaining tests around the issue
still pass.

I think I need to look further into the details of the prior issues to ensure
that we won't bring back bugs with this.  Any extra eyes or thoughts are
appreciated.  Any ideas on specs to add with this are also welcome.