### PR TITLE
API: Add Pagination Helpers + Extension Point

### DIFF
--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -161,6 +161,16 @@ module Spree
           status: 422
         )
       end
+
+      def paginate(resource)
+        resource.
+          page(params[:page]).
+          per(params[:per_page] || default_per_page)
+      end
+
+      def default_per_page
+        Kaminari.config.default_per_page
+      end
     end
   end
 end

--- a/api/app/controllers/spree/api/countries_controller.rb
+++ b/api/app/controllers/spree/api/countries_controller.rb
@@ -4,11 +4,17 @@ module Spree
       skip_before_action :authenticate_user
 
       def index
-        @countries = Country.accessible_by(current_ability, :read).ransack(params[:q]).result.
-                     includes(:states).order('name ASC').
-                     page(params[:page]).per(params[:per_page])
+        @countries = Country.
+          accessible_by(current_ability, :read).
+          ransack(params[:q]).
+          result.
+          includes(:states).
+          order('name ASC')
+
         country = Country.order("updated_at ASC").last
+
         if stale?(country)
+          @countries = paginate(@countries)
           respond_with(@countries)
         end
       end

--- a/api/app/controllers/spree/api/credit_cards_controller.rb
+++ b/api/app/controllers/spree/api/credit_cards_controller.rb
@@ -9,7 +9,9 @@ module Spree
           .credit_cards
           .accessible_by(current_ability, :read)
           .with_payment_profile
-          .ransack(params[:q]).result.page(params[:page]).per(params[:per_page])
+          .ransack(params[:q]).result
+
+        @credit_cards = paginate(@credit_cards)
         respond_with(@credit_cards)
       end
 

--- a/api/app/controllers/spree/api/orders_controller.rb
+++ b/api/app/controllers/spree/api/orders_controller.rb
@@ -39,7 +39,7 @@ module Spree
 
       def index
         authorize! :index, Order
-        @orders = Order.ransack(params[:q]).result.page(params[:page]).per(params[:per_page])
+        @orders = paginate(Order.ransack(params[:q]).result)
         respond_with(@orders)
       end
 
@@ -72,7 +72,8 @@ module Spree
 
       def mine
         if current_api_user
-          @orders = current_api_user.orders.by_store(current_store).reverse_chronological.ransack(params[:q]).result.page(params[:page]).per(params[:per_page])
+          @orders = current_api_user.orders.by_store(current_store).reverse_chronological.ransack(params[:q]).result
+          @orders = paginate(@orders)
         else
           render "spree/api/errors/unauthorized", status: :unauthorized
         end

--- a/api/app/controllers/spree/api/payments_controller.rb
+++ b/api/app/controllers/spree/api/payments_controller.rb
@@ -6,7 +6,7 @@ module Spree
       before_action :find_payment, only: [:update, :show, :authorize, :purchase, :capture, :void, :credit]
 
       def index
-        @payments = @order.payments.ransack(params[:q]).result.page(params[:page]).per(params[:per_page])
+        @payments = paginate(@order.payments.ransack(params[:q]).result)
         respond_with(@payments)
       end
 

--- a/api/app/controllers/spree/api/product_properties_controller.rb
+++ b/api/app/controllers/spree/api/product_properties_controller.rb
@@ -5,9 +5,14 @@ module Spree
       before_action :product_property, only: [:show, :update, :destroy]
 
       def index
-        @product_properties = @product.product_properties.accessible_by(current_ability, :read).
-                              ransack(params[:q]).result.
-                              page(params[:page]).per(params[:per_page])
+        @product_properties = @product.
+          product_properties.
+          accessible_by(current_ability, :read).
+          ransack(params[:q]).
+          result
+
+        @product_properties = paginate(@product_properties)
+
         respond_with(@product_properties)
       end
 

--- a/api/app/controllers/spree/api/products_controller.rb
+++ b/api/app/controllers/spree/api/products_controller.rb
@@ -9,7 +9,7 @@ module Spree
           @products = product_scope.ransack(params[:q]).result
         end
 
-        @products = @products.distinct.page(params[:page]).per(params[:per_page])
+        @products = paginate(@products.distinct)
         expires_in 15.minutes, public: true
         headers['Surrogate-Control'] = "max-age=#{15.minutes}"
         respond_with(@products)

--- a/api/app/controllers/spree/api/properties_controller.rb
+++ b/api/app/controllers/spree/api/properties_controller.rb
@@ -13,7 +13,7 @@ module Spree
           @properties = @properties.ransack(params[:q]).result
         end
 
-        @properties = @properties.page(params[:page]).per(params[:per_page])
+        @properties = paginate(@properties)
         respond_with(@properties)
       end
 

--- a/api/app/controllers/spree/api/resource_controller.rb
+++ b/api/app/controllers/spree/api/resource_controller.rb
@@ -10,7 +10,7 @@ class Spree::Api::ResourceController < Spree::Api::BaseController
       collection_scope = collection_scope.ransack(params[:q]).result
     end
 
-    @collection = collection_scope.page(params[:page]).per(params[:per_page])
+    @collection = paginate(collection_scope)
     instance_variable_set("@#{controller_name}", @collection)
 
     respond_with(@collection)

--- a/api/app/controllers/spree/api/return_authorizations_controller.rb
+++ b/api/app/controllers/spree/api/return_authorizations_controller.rb
@@ -24,9 +24,15 @@ module Spree
 
       def index
         authorize! :admin, ReturnAuthorization
-        @return_authorizations = @order.return_authorizations.accessible_by(current_ability, :read).
-                                 ransack(params[:q]).result.
-                                 page(params[:page]).per(params[:per_page])
+
+        @return_authorizations = @order.
+          return_authorizations.
+          accessible_by(current_ability, :read).
+          ransack(params[:q]).
+          result
+
+        @return_authorizations = paginate(@return_authorizations)
+
         respond_with(@return_authorizations)
       end
 

--- a/api/app/controllers/spree/api/shipments_controller.rb
+++ b/api/app/controllers/spree/api/shipments_controller.rb
@@ -14,7 +14,9 @@ module Spree
             .joins(:order)
             .where(spree_orders: { user_id: current_api_user.id })
             .includes(mine_includes)
-            .ransack(params[:q]).result.page(params[:page]).per(params[:per_page])
+            .ransack(params[:q]).result
+
+          @shipments = paginate(@shipments)
         else
           render "spree/api/errors/unauthorized", status: :unauthorized
         end

--- a/api/app/controllers/spree/api/states_controller.rb
+++ b/api/app/controllers/spree/api/states_controller.rb
@@ -8,7 +8,7 @@ module Spree
                     includes(:country).order('name ASC')
 
         if params[:page] || params[:per_page]
-          @states = @states.page(params[:page]).per(params[:per_page])
+          @states = paginate(@states)
         end
 
         respond_with(@states)

--- a/api/app/controllers/spree/api/stock_items_controller.rb
+++ b/api/app/controllers/spree/api/stock_items_controller.rb
@@ -4,7 +4,7 @@ module Spree
       before_action :load_stock_location, only: [:index, :show, :create]
 
       def index
-        @stock_items = scope.ransack(params[:q]).result.page(params[:page]).per(params[:per_page])
+        @stock_items = paginate(scope.ransack(params[:q]).result)
         respond_with(@stock_items)
       end
 

--- a/api/app/controllers/spree/api/stock_locations_controller.rb
+++ b/api/app/controllers/spree/api/stock_locations_controller.rb
@@ -3,7 +3,15 @@ module Spree
     class StockLocationsController < Spree::Api::BaseController
       def index
         authorize! :read, StockLocation
-        @stock_locations = StockLocation.accessible_by(current_ability, :read).order('name ASC').ransack(params[:q]).result.page(params[:page]).per(params[:per_page])
+
+        @stock_locations = StockLocation.
+          accessible_by(current_ability, :read).
+          order('name ASC').
+          ransack(params[:q]).
+          result
+
+        @stock_locations = paginate(@stock_locations)
+
         respond_with(@stock_locations)
       end
 

--- a/api/app/controllers/spree/api/stock_movements_controller.rb
+++ b/api/app/controllers/spree/api/stock_movements_controller.rb
@@ -5,7 +5,7 @@ module Spree
 
       def index
         authorize! :read, StockMovement
-        @stock_movements = scope.ransack(params[:q]).result.page(params[:page]).per(params[:per_page])
+        @stock_movements = paginate(scope.ransack(params[:q]).result)
         respond_with(@stock_movements)
       end
 

--- a/api/app/controllers/spree/api/store_credit_events_controller.rb
+++ b/api/app/controllers/spree/api/store_credit_events_controller.rb
@@ -1,7 +1,9 @@
 class Spree::Api::StoreCreditEventsController < Spree::Api::BaseController
   def mine
     if current_api_user
-      @store_credit_events = current_api_user.store_credit_events.exposed_events.page(params[:page]).per(params[:per_page]).reverse_chronological
+      @store_credit_events = paginate(
+        current_api_user.store_credit_events.exposed_events
+      ).reverse_chronological
     else
       render "spree/api/errors/unauthorized", status: :unauthorized
     end

--- a/api/app/controllers/spree/api/taxonomies_controller.rb
+++ b/api/app/controllers/spree/api/taxonomies_controller.rb
@@ -2,7 +2,8 @@ module Spree
   module Api
     class TaxonomiesController < Spree::Api::BaseController
       def index
-        respond_with(taxonomies)
+        @taxonomies = paginate(taxonomies)
+        respond_with(@taxonomies)
       end
 
       def new
@@ -45,9 +46,12 @@ module Spree
       private
 
       def taxonomies
-        @taxonomies = Taxonomy.accessible_by(current_ability, :read).order('name').includes(root: :children).
-                      ransack(params[:q]).result.
-                      page(params[:page]).per(params[:per_page])
+        @taxonomies = Taxonomy.
+          accessible_by(current_ability, :read).
+          order('name').
+          includes(root: :children).
+          ransack(params[:q]).
+          result
       end
 
       def taxonomy

--- a/api/app/controllers/spree/api/taxons_controller.rb
+++ b/api/app/controllers/spree/api/taxons_controller.rb
@@ -10,7 +10,7 @@ module Spree
           @taxons = Spree::Taxon.accessible_by(current_ability, :read).order(:taxonomy_id, :lft).ransack(params[:q]).result
         end
 
-        @taxons = @taxons.page(params[:page]).per(params[:per_page])
+        @taxons = paginate(@taxons)
         respond_with(@taxons)
       end
 
@@ -65,12 +65,15 @@ module Spree
         # Returns the products sorted by their position with the classification
         # Products#index does not do the sorting.
         taxon = Spree::Taxon.find(params[:id])
-        @products = taxon.products.ransack(params[:q]).result
-        @products = @products.page(params[:page]).per(params[:per_page] || 500)
+        @products = paginate(taxon.products.ransack(params[:q]).result)
         render "spree/api/products/index"
       end
 
       private
+
+      def default_per_page
+        500
+      end
 
       def taxonomy
         if params[:taxonomy_id].present?

--- a/api/app/controllers/spree/api/variants_controller.rb
+++ b/api/app/controllers/spree/api/variants_controller.rb
@@ -24,7 +24,9 @@ module Spree
       # or removed from the views.
       def index
         @variants = scope.includes({ option_values: :option_type }, :product, :default_price, :images, { stock_items: :stock_location })
-          .ransack(params[:q]).result.page(params[:page]).per(params[:per_page])
+          .ransack(params[:q]).result
+
+        @variants = paginate(@variants)
         respond_with(@variants)
       end
 

--- a/api/app/controllers/spree/api/zones_controller.rb
+++ b/api/app/controllers/spree/api/zones_controller.rb
@@ -18,7 +18,14 @@ module Spree
       end
 
       def index
-        @zones = Zone.accessible_by(current_ability, :read).order('name ASC').ransack(params[:q]).result.page(params[:page]).per(params[:per_page])
+        @zones = Zone.
+          accessible_by(current_ability, :read).
+          order('name ASC').
+          ransack(params[:q]).
+          result
+
+        @zones = paginate(@zones)
+
         respond_with(@zones)
       end
 


### PR DESCRIPTION
This PR provides a configuration point for API response pagination at the controller, through a `default_per_page` private method.

This can be used to determine how many instances of a resource will be shown on a given "page" of API responses, and by default will return Kaminari's default count of 25.

Extracting the pagination controller method concern to a discrete method also provides a further extension point, for stores that might prefer to skip out on pagination entirely, or use their own solution besides Kaminari.