### PR TITLE
Fetch all initial taxons for $.fn.taxonAutocomplete

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/taxon_autocomplete.js
+++ b/backend/app/assets/javascripts/spree/backend/taxon_autocomplete.js
@@ -5,11 +5,15 @@ $.fn.taxonAutocomplete = function () {
       placeholder: Spree.translations.taxon_placeholder,
       multiple: true,
       initSelection: function (element, callback) {
+        var ids = element.val(),
+            count = ids.split(",").length;
+
         Spree.ajax({
           type: "GET",
           url: Spree.routes.taxons_search,
           data: {
-            ids: element.val(),
+            ids: ids,
+            per_page: count,
             without_children: true
           },
           success: function (data) {


### PR DESCRIPTION
In cases where more than 25 taxons were already selected, this
autocomplete selector would only display the first 25, due to the
default pagination settings as defined by Kaminari.

By manually specifying a `per_page` parameter, we can ensure all
specified taxons are returned.