### PR TITLE
Improve performance of Taxon promotion rule

### DIFF
--- a/core/spec/models/spree/promotion/rules/taxon_spec.rb
+++ b/core/spec/models/spree/promotion/rules/taxon_spec.rb
@@ -1,29 +1,30 @@
 require 'spec_helper'
 
 describe Spree::Promotion::Rules::Taxon, type: :model do
+  let(:taxon)   { create :taxon, name: 'first' }
+  let(:taxon2)  { create :taxon, name: 'second' }
+  let(:order)   { create :order_with_line_items }
+  let(:product) { order.products.first }
+
   let(:rule) do
     Spree::Promotion::Rules::Taxon.create!(promotion: create(:promotion))
   end
 
   context '#eligible?(order)' do
-    let(:taxon){ create :taxon, name: 'first' }
-    let(:taxon2){ create :taxon, name: 'second' }
-    let(:order){ create :order_with_line_items }
-
     context 'with any match policy' do
       before do
         rule.update!(preferred_match_policy: 'any')
       end
 
       it 'is eligible if order does have any prefered taxon' do
-        order.products.first.taxons << taxon
+        product.taxons << taxon
         rule.taxons << taxon
         expect(rule).to be_eligible(order)
       end
 
       context 'when order contains items from different taxons' do
         before do
-          order.products.first.taxons << taxon
+          product.taxons << taxon
           rule.taxons << taxon
         end
 
@@ -50,7 +51,7 @@ describe Spree::Promotion::Rules::Taxon, type: :model do
       context 'when a product has a taxon child of a taxon rule' do
         before do
           taxon.children << taxon2
-          order.products.first.taxons << taxon2
+          product.taxons << taxon2
           rule.taxons << taxon
         end
 
@@ -64,7 +65,7 @@ describe Spree::Promotion::Rules::Taxon, type: :model do
       end
 
       it 'is eligible order has all prefered taxons' do
-        order.products.first.taxons << taxon2
+        product.taxons << taxon2
         order.products.last.taxons << taxon
 
         rule.taxons = [taxon, taxon2]
@@ -83,17 +84,16 @@ describe Spree::Promotion::Rules::Taxon, type: :model do
       end
 
       context 'when a product has a taxon child of a taxon rule' do
-        let(:taxon3){ create :taxon }
+        let(:taxon3) { create :taxon }
 
         before do
           taxon.children << taxon2
-          order.products.first.taxons << taxon2
-          order.products.last.taxons << taxon3
-          rule.taxons << taxon2
-          rule.taxons << taxon3
+          taxon.save!
+          product.taxons = [taxon2, taxon3]
+          rule.taxons = [taxon, taxon3]
         end
 
-        it{ expect(rule).to be_eligible(order) }
+        it { expect(rule).to be_eligible(order) }
       end
     end
 


### PR DESCRIPTION
1. Before `#actionable?` was bringing all product ids of the rule's taxons
    from the database. On a particular case in a store with 1mil
    products, the promotion was bringing 0.6mil of them, with a query ~ 5sec
    and 5mil ids in Ruby.
   
    After, the `exists?` query is a milliseconds one.
2. Before `#eligible?` was fetching all parent taxons of each taxon on a
    product, which is not required for the match process.
   
    So, given an order with 10 line items, with each line item having a
    product with 3 taxons, each of them having 2 parent taxons
    would mean 30 queries to the db to fetch the ancestors, bringing a
    total of 60 taxons in Ruby memory.
   
    All of them unnecessary, as the matching processes can be done solely
    based on the rule's taxons, which if 5 would mean 5 queries to the DB
    (self_and_descendants)
3. Fix incorrect test on `#eligible?#all` for taxon child of a taxon rule
    case.
   - there were no children tested in the case
4. On `#eligible?#all`, take only the IDs from the DB to
    reduce memory overhead
## 

On a next PR, I will see to fix `#actionable?` to perform matching with the rule's descendant taxons.
