### PR TITLE
Admin logo easy config

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/shared/_layout.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_layout.scss
@@ -14,6 +14,9 @@ body {
 .admin-nav {
   @include position(absolute, 0 null 0 0);
   width: $width-sidebar;
+  img {
+    max-width: 100%;
+  }
 }
 
 .content-wrapper {


### PR DESCRIPTION
This PR adds a max-width to the admin-nav-header's logo, enabling admins to have their custom logos (set in the spree initializer) fit the nav-bar by default.
