### PR TITLE
Add missing translation

### DIFF
--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1207,6 +1207,7 @@ en:
     inventory_adjustment: Inventory Adjustment
     inventory_canceled: Inventory canceled
     inventory_error_flash_for_insufficient_quantity: An item in your cart has become unavailable.
+    inventory_not_available: Inventory not available for %{item}.
     inventory_state: Inventory State
     inventory_states:
       backordered: backordered


### PR DESCRIPTION
For Spree::Stock::InventoryValidator. I noticed this was missing while
doing an audit.

It does seem a bit strange because the "item" text won't be translated
for sites that serve multiple languages:

```ruby
line_item.errors[:inventory] << Spree.t(
  :inventory_not_available,
  item: line_item.variant.name
)
```
(https://github.com/solidusio/solidus/blob/v1.3.1/core/app/models/spree/stock/inventory_validator.rb#L6-L9)
