### PR TITLE
Remove callbacks from refund model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Extract stock transfers to the [solidus_stock_transfers](https://github.com/solidusio-contrib/solidus_stock_transfers) gem. [#2379](https://github.com/solidusio/solidus/pull/2379) ([jhawthorn](https://github.com/jhawthorn))
 
+- Remove `#perform!` callback from refund model. Refunds can be created without performing the transaction implicitly; `#perform!` must be called for the transaction to be processed. [#1415](https://github.com/solidusio/solidus/pull/1415) ([swively](https:/github.com/swively))
+
 ## Solidus 2.4.0 (unreleased)
 
 ### Major changes

--- a/backend/app/controllers/spree/admin/refunds_controller.rb
+++ b/backend/app/controllers/spree/admin/refunds_controller.rb
@@ -8,6 +8,21 @@ module Spree
 
       rescue_from Spree::Core::GatewayError, with: :spree_core_gateway_error
 
+      def create
+        @refund.attributes = refund_params
+        if @refund.perform!
+          flash[:success] = flash_message_for(@refund, :successfully_created)
+          respond_with(@refund) do |format|
+            format.html { redirect_to location_after_save }
+          end
+        else
+          flash.now[:error] = @refund.errors.full_messages.join(", ")
+          respond_with(@refund) do |format|
+            format.html { render action: 'new' }
+          end
+        end
+      end
+
       private
 
       def location_after_save
@@ -21,6 +36,10 @@ module Spree
 
       def refund_reasons
         @refund_reasons ||= Spree::RefundReason.active.all
+      end
+
+      def refund_params
+        params.require(:refund).permit!
       end
 
       def build_resource

--- a/backend/spec/controllers/spree/admin/refunds_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/refunds_controller_spec.rb
@@ -4,22 +4,46 @@ describe Spree::Admin::RefundsController do
   stub_authorization!
 
   describe "POST create" do
-    context "a Spree::Core::GatewayError is raised" do
-      let(:payment) { create(:payment) }
+    let(:refund_reason) { create(:refund_reason) }
+    let(:refund_amount) { 100.0 }
 
-      subject do
-        post :create,
-          params: {
-          refund: { amount: "50.0", refund_reason_id: "1" },
+    let(:payment) { create(:payment, amount: payment_amount) }
+    let(:payment_amount) { refund_amount * 2 }
+
+    subject do
+      post :create,
+        params: {
+          refund: {
+            amount: refund_amount,
+            refund_reason_id: refund_reason.id,
+            transaction_id: nil
+          },
           order_id: payment.order_id,
           payment_id: payment.id
         }
+    end
+
+    context "and no Spree::Core::GatewayError is raised" do
+      it "creates a refund record" do
+        expect{ subject }.to change(Spree::Refund, :count).by(1)
       end
 
-      before(:each) do
-        def controller.create
-          raise Spree::Core::GatewayError.new('An error has occurred')
-        end
+      it "calls #perform!" do
+        subject
+        # transaction_id comes from Spree::Gateway::Bogus.credit
+        expect(Spree::Refund.last.transaction_id).to eq("12345")
+      end
+    end
+
+    context "a Spree::Core::GatewayError is raised" do
+      before do
+        expect_any_instance_of(Spree::Refund).
+          to receive(:perform!).
+          and_raise(Spree::Core::GatewayError.new('An error has occurred'))
+      end
+
+      it "does not create a refund record" do
+        expect{ subject }.to_not change { Spree::Refund.count }
       end
 
       it "sets an error message with the correct text" do

--- a/core/app/models/spree/payment/cancellation.rb
+++ b/core/app/models/spree/payment/cancellation.rb
@@ -29,7 +29,7 @@ module Spree
           if response = payment.payment_method.try_void(payment)
             payment.send(:handle_void_response, response)
           else
-            payment.refunds.create!(amount: payment.credit_allowed, reason: refund_reason)
+            payment.refunds.create!(amount: payment.credit_allowed, reason: refund_reason).perform!
           end
         else
           # For payment methods not yet implemeting `try_void`

--- a/core/app/models/spree/refund.rb
+++ b/core/app/models/spree/refund.rb
@@ -8,13 +8,9 @@ module Spree
 
     validates :payment, presence: true
     validates :reason, presence: true
-    validates :transaction_id, presence: true, on: :update # can't require this on create because the before_create needs to run first
     validates :amount, presence: true, numericality: { greater_than: 0 }
 
     validate :amount_is_less_than_or_equal_to_allowed_amount, on: :create
-
-    after_create :perform!
-    after_create :create_log_entry
 
     scope :non_reimbursement, -> { where(reimbursement_id: nil) }
 
@@ -35,21 +31,23 @@ module Spree
       payment.payment_method.name
     end
 
-    private
-
-    # attempts to perform the refund.
+    # Must be called for the refund transaction to be processed.
+    #
+    # Attempts to perform the refund,
     # raises an error if the refund fails.
     def perform!
       return true if transaction_id.present?
 
       credit_cents = money.cents
 
-      @response = process!(credit_cents)
+      response = process!(credit_cents)
+      log_entries.build(details: response.to_yaml)
 
-      self.transaction_id = @response.authorization
-      update_columns(transaction_id: transaction_id)
+      update!(transaction_id: response.authorization)
       update_order
     end
+
+    private
 
     # return an activemerchant response object if successful or else raise an error
     def process!(credit_cents)
@@ -69,10 +67,6 @@ module Spree
     rescue ActiveMerchant::ConnectionError => e
       logger.error(I18n.t('spree.gateway_error') + "  #{e.inspect}")
       raise Core::GatewayError.new(I18n.t('spree.unable_to_connect_to_gateway'))
-    end
-
-    def create_log_entry
-      log_entries.create!(details: @response.to_yaml)
     end
 
     def amount_is_less_than_or_equal_to_allowed_amount

--- a/core/app/models/spree/reimbursement_type/reimbursement_helpers.rb
+++ b/core/app/models/spree/reimbursement_type/reimbursement_helpers.rb
@@ -35,7 +35,7 @@ module Spree
         reason: Spree::RefundReason.return_processing_reason
       })
 
-      simulate ? refund.readonly! : refund.save!
+      simulate ? refund.readonly! : refund.perform!
       refund
     end
 

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Spree::Order, type: :model do
       let(:payment) { create(:payment, order: order, amount: payment_amount, state: 'completed') }
 
       before do
-        create(:refund, payment: payment, amount: payment_amount)
+        create(:refund, payment: payment, amount: payment_amount).perform!
       end
 
       it "cancels the order" do
@@ -229,7 +229,7 @@ RSpec.describe Spree::Order, type: :model do
       order.cancellations.short_ship([order.inventory_units.first])
       expect(order.outstanding_balance).to be_negative
       expect(order.payment_state).to eq('credit_owed')
-      create(:refund, amount: order.outstanding_balance.abs, payment: payment, transaction_id: nil)
+      create(:refund, amount: order.outstanding_balance.abs, payment: payment, transaction_id: nil).perform!
       order.reload
       expect(order.outstanding_balance).to eq(0)
       expect(order.payment_state).to eq('paid')

--- a/core/spec/models/spree/payment/cancellation_spec.rb
+++ b/core/spec/models/spree/payment/cancellation_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Spree::Payment::Cancellation do
             payment.refunds.create!(
               amount: credit_amount,
               reason: Spree::RefundReason.where(name: 'test').first_or_create
-            )
+            ).perform!
           end
 
           it 'only refunds the allowed credit amount' do

--- a/core/spec/models/spree/refund_spec.rb
+++ b/core/spec/models/spree/refund_spec.rb
@@ -1,58 +1,71 @@
 require 'rails_helper'
 
 RSpec.describe Spree::Refund, type: :model do
+  let(:amount) { 100.0 }
+  let(:amount_in_cents) { amount * 100 }
+
+  let(:authorization) { generate(:refund_transaction_id) }
+
+  let(:payment) { create(:payment, amount: payment_amount, payment_method: payment_method) }
+  let(:payment_amount) { amount * 2 }
+  let(:payment_method) { create(:credit_card_payment_method) }
+
+  let(:refund_reason) { create(:refund_reason) }
+
+  let(:gateway_response) {
+    ActiveMerchant::Billing::Response.new(
+      gateway_response_success,
+      gateway_response_message,
+      gateway_response_params,
+      gateway_response_options
+    )
+  }
+  let(:gateway_response_success) { true }
+  let(:gateway_response_message) { "" }
+  let(:gateway_response_params) { {} }
+  let(:gateway_response_options) { {} }
+
+  before do
+    allow(payment.payment_method)
+      .to receive(:credit)
+      .with(amount_in_cents, payment.source, payment.transaction_id, { originator: an_instance_of(Spree::Refund) })
+      .and_return(gateway_response)
+  end
+
   describe 'create' do
-    let(:amount) { 100.0 }
-    let(:amount_in_cents) { amount * 100 }
-
-    let(:authorization) { generate(:refund_transaction_id) }
-
-    let(:payment) { create(:payment, amount: payment_amount, payment_method: payment_method) }
-    let(:payment_amount) { amount * 2 }
-    let(:payment_method) { create(:credit_card_payment_method) }
-
-    let(:refund_reason) { create(:refund_reason) }
-
-    let(:gateway_response) {
-      ActiveMerchant::Billing::Response.new(
-        gateway_response_success,
-        gateway_response_message,
-        gateway_response_params,
-        gateway_response_options
-      )
-    }
-    let(:gateway_response_success) { true }
-    let(:gateway_response_message) { "" }
-    let(:gateway_response_params) { {} }
-    let(:gateway_response_options) { {} }
-
     subject { create(:refund, payment: payment, amount: amount, reason: refund_reason, transaction_id: nil) }
 
-    before do
-      allow(payment.payment_method)
-        .to receive(:credit)
-        .with(amount_in_cents, payment.source, payment.transaction_id, { originator: an_instance_of(Spree::Refund) })
-        .and_return(gateway_response)
+    it "creates a refund record" do
+      expect{ subject }.to change { Spree::Refund.count }.by(1)
     end
 
-    context "transaction id exists on creation" do
-      let(:transaction_id) { "12kfjas0" }
-      subject { create(:refund, payment: payment, amount: amount, reason: refund_reason, transaction_id: transaction_id) }
+    it "saves the amount" do
+      expect(subject.reload.amount).to eq amount
+      expect(subject.money).to be_a(Spree::Money)
+    end
 
-      it "creates a refund record" do
-        expect{ subject }.to change { Spree::Refund.count }.by(1)
-      end
+    it "does not attempt to process a transaction" do
+      expect(subject.transaction_id).to be_nil
+    end
+  end
+
+  describe "#perform!" do
+    subject do
+      refund = Spree::Refund.create!(
+        payment: payment,
+        amount: amount,
+        reason: refund_reason,
+        transaction_id: transaction_id
+      )
+      refund.perform!
+      refund
+    end
+
+    context "when transaction_id exists" do
+      let(:transaction_id) { "12kfjas0" }
 
       it "maintains the transaction id" do
         expect(subject.reload.transaction_id).to eq transaction_id
-      end
-
-      it "saves the amount" do
-        expect(subject.reload.amount).to eq amount
-      end
-
-      it "creates a log entry" do
-        expect(subject.log_entries).to be_present
       end
 
       it "does not attempt to process a transaction" do
@@ -61,103 +74,109 @@ RSpec.describe Spree::Refund, type: :model do
       end
     end
 
-    context "processing is successful" do
-      let(:gateway_response_options) { { authorization: authorization } }
+    context "when transaction_id is nil" do
+      let(:transaction_id) { nil }
 
-      it 'should create a refund' do
-        expect{ subject }.to change{ Spree::Refund.count }.by(1)
+      context "processing is successful" do
+        let(:gateway_response_options) { { authorization: authorization } }
+
+        it 'should create a refund' do
+          expect{ subject }.to change{ Spree::Refund.count }.by(1)
+        end
+
+        it 'returns the newly created refund' do
+          expect(subject).to be_a(Spree::Refund)
+        end
+
+        it 'should save the returned authorization value' do
+          expect(subject.reload.transaction_id).to eq authorization
+        end
+
+        it 'should save the passed amount as the refund amount' do
+          expect(subject.amount).to eq amount
+        end
+
+        it 'should create a log entry' do
+          expect(subject.log_entries).to be_present
+        end
+
+        it "attempts to process a transaction" do
+          expect(payment.payment_method).to receive(:credit).once
+          subject
+        end
+
+        it 'should update the payment total' do
+          expect(payment.order.updater).to receive(:update)
+          subject
+        end
       end
 
-      it 'return the newly created refund' do
-        expect(subject).to be_a(Spree::Refund)
+      context "processing fails" do
+        let(:gateway_response_success) { false }
+        let(:gateway_response_message) { "failure message" }
+
+        it 'should raise error and not create a refund' do
+          expect do
+            expect { subject }.to raise_error(Spree::Core::GatewayError, gateway_response_message)
+          end.to change{ Spree::Refund.count }
+        end
       end
 
-      it 'should save the returned authorization value' do
-        expect(subject.reload.transaction_id).to eq authorization
+      context 'without payment profiles supported' do
+        let(:gateway_response_options) { { authorization: authorization } }
+        before do
+          allow(payment.payment_method).to receive(:payment_profiles_supported?) { false }
+        end
+
+        it 'should not supply the payment source' do
+          expect(payment.payment_method)
+            .to receive(:credit)
+            .with(amount * 100, payment.transaction_id, { originator: an_instance_of(Spree::Refund) })
+            .and_return(gateway_response)
+
+          subject
+        end
       end
 
-      it 'should save the passed amount as the refund amount' do
-        expect(subject.amount).to eq amount
+      context 'with payment profiles supported' do
+        let(:gateway_response_options) { { authorization: authorization } }
+        before do
+          allow(payment.payment_method).to receive(:payment_profiles_supported?) { true }
+        end
+
+        it 'should supply the payment source' do
+          expect(payment.payment_method)
+            .to receive(:credit)
+            .with(amount_in_cents, payment.source, payment.transaction_id, { originator: an_instance_of(Spree::Refund) })
+            .and_return(gateway_response)
+
+          subject
+        end
       end
 
-      it 'should create a log entry' do
-        expect(subject.log_entries).to be_present
+      context 'with an activemerchant gateway connection error' do
+        before do
+          expect(payment.payment_method)
+            .to receive(:credit)
+            .with(amount_in_cents, payment.source, payment.transaction_id, { originator: an_instance_of(Spree::Refund) })
+            .and_raise(ActiveMerchant::ConnectionError.new("foo", nil))
+        end
+
+        it 'raises Spree::Core::GatewayError' do
+          expect { subject }.to raise_error(Spree::Core::GatewayError, I18n.t('spree.unable_to_connect_to_gateway'))
+        end
       end
 
-      it "attempts to process a transaction" do
-        expect(payment.payment_method).to receive(:credit).once
-        subject
-      end
+      context 'with amount too large' do
+        let(:payment_amount) { 10 }
+        let(:amount) { payment_amount * 2 }
 
-      it 'should update the payment total' do
-        expect(payment.order.updater).to receive(:update)
-        subject
-      end
-    end
-
-    context "processing fails" do
-      let(:gateway_response_success) { false }
-      let(:gateway_response_message) { "failure message" }
-
-      it 'should raise error and not create a refund' do
-        expect do
-          expect { subject }.to raise_error(Spree::Core::GatewayError, gateway_response_message)
-        end.to_not change{ Spree::Refund.count }
-      end
-    end
-
-    context 'without payment profiles supported' do
-      before do
-        allow(payment.payment_method).to receive(:payment_profiles_supported?) { false }
-      end
-
-      it 'should not supply the payment source' do
-        expect(payment.payment_method)
-          .to receive(:credit)
-          .with(amount * 100, payment.transaction_id, { originator: an_instance_of(Spree::Refund) })
-          .and_return(gateway_response)
-
-        subject
-      end
-    end
-
-    context 'with payment profiles supported' do
-      before do
-        allow(payment.payment_method).to receive(:payment_profiles_supported?) { true }
-      end
-
-      it 'should supply the payment source' do
-        expect(payment.payment_method)
-          .to receive(:credit)
-          .with(amount_in_cents, payment.source, payment.transaction_id, { originator: an_instance_of(Spree::Refund) })
-          .and_return(gateway_response)
-
-        subject
-      end
-    end
-
-    context 'with an activemerchant gateway connection error' do
-      before do
-        expect(payment.payment_method)
-          .to receive(:credit)
-          .with(amount_in_cents, payment.source, payment.transaction_id, { originator: an_instance_of(Spree::Refund) })
-          .and_raise(ActiveMerchant::ConnectionError.new("foo", nil))
-      end
-
-      it 'raises Spree::Core::GatewayError' do
-        expect { subject }.to raise_error(Spree::Core::GatewayError, I18n.t('spree.unable_to_connect_to_gateway'))
-      end
-    end
-
-    context 'with amount too large' do
-      let(:payment_amount) { 10 }
-      let(:amount) { payment_amount * 2 }
-
-      it 'is invalid' do
-        expect { subject }.to raise_error { |error|
-          expect(error).to be_a(ActiveRecord::RecordInvalid)
-          expect(error.record.errors.full_messages).to eq ["Amount #{I18n.t('activerecord.errors.models.spree/refund.attributes.amount.greater_than_allowed')}"]
-        }
+        it 'is invalid' do
+          expect { subject }.to raise_error { |error|
+            expect(error).to be_a(ActiveRecord::RecordInvalid)
+            expect(error.record.errors.full_messages).to eq ["Amount #{I18n.t('activerecord.errors.models.spree/refund.attributes.amount.greater_than_allowed')}"]
+          }
+        end
       end
     end
 


### PR DESCRIPTION
This PR removes two `after_create` callbacks from the refund model; refunds may now be created without automatically performing the transaction. 

The instance method `#perform_and_save!` was created to perform the transaction, and will raise an error if the transaction fails due to the validation of `transaction_id` on `update`
- `perform_and_save!` method is explicitly called from `reimbursement_helpers.rb`
- `create_log_entry` is called during the transaction
