### PR TITLE
Incorreclty splits packages

### DIFF
--- a/api/app/controllers/spree/api/line_items_controller.rb
+++ b/api/app/controllers/spree/api/line_items_controller.rb
@@ -30,7 +30,14 @@ module Spree
 
       def update
         @line_item = find_line_item
-        if @order.contents.update_cart(line_items_attributes)
+        options = {
+          variant_stock_location_quantities: {
+            @line_item.variant_id => {
+              @line_item.variant.stock_locations.first.id => line_items_attributes[:line_items_attributes][:quantity]
+            }
+          }
+        }
+        if @order.contents.update_cart(line_items_attributes, options)
           @line_item.reload
           respond_with(@line_item, default_template: :show)
         else


### PR DESCRIPTION
rel #1366 

> On sandbox store:
> 1. In the admin, create a new order
> 2. Add 1 unit of any item
> 3. Update the quantity of item(bug 1) or re-add the same item(bug 2)
> 4. Enter customer details and click update button
> 5. Two shipments are created, the first with the first quantity added and the second with the remained quantity item

After investigation i see that the `order_stock_location` isn't update when `update_cart` is call (https://github.com/solidusio/solidus/blob/master/core/app/models/spree/order_contents.rb#L37-L67), and the `order_stock_location` creation is skipped if line_item isn't a new record(https://github.com/solidusio/solidus/blob/master/core/app/models/spree/order_contents.rb#L146).

solution to bug 1:
Update the quantity of `order_stock_location` when the `update_cart` method is called.
solution to bug 2:
Update the quantity of `order_stock_location` when an item is add to cart if already present an other `variant` and `stock_location` in the cart
