### PR TITLE
Add inverse_of to promotion actions and rules

### DIFF
--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -7,10 +7,10 @@ module Spree
 
     belongs_to :promotion_category
 
-    has_many :promotion_rules, autosave: true, dependent: :destroy
+    has_many :promotion_rules, autosave: true, dependent: :destroy, inverse_of: :promotion
     alias_method :rules, :promotion_rules
 
-    has_many :promotion_actions, autosave: true, dependent: :destroy
+    has_many :promotion_actions, autosave: true, dependent: :destroy, inverse_of: :promotion
     alias_method :actions, :promotion_actions
 
     has_many :order_promotions, class_name: "Spree::OrderPromotion"

--- a/core/app/models/spree/promotion_action.rb
+++ b/core/app/models/spree/promotion_action.rb
@@ -6,7 +6,7 @@ module Spree
   class PromotionAction < Spree::Base
     acts_as_paranoid
 
-    belongs_to :promotion, class_name: 'Spree::Promotion'
+    belongs_to :promotion, class_name: 'Spree::Promotion', inverse_of: :promotion_actions
 
     scope :of_type, ->(t) { where(type: t) }
 


### PR DESCRIPTION
This isn't happening automatically.

Without this patch:

    >> p = Spree::Promotion.create!(name: 'foo')
    >> p.promotion_rules << Spree::Promotion::Rules::FirstOrder.new
    >> p.promotion_actions << Spree::Promotion::Actions::FreeShipping.new

    >> p.object_id == p.promotion_rules.to_a.first.promotion.object_id
    => false

    >> p.object_id == p.promotion_actions.to_a.first.promotion.object_id
    => false

With this patch those queries return true.

It seems likely that there are a lot of other places where we should add this.  Or else figure out why it's not happening automatically.