### PR TITLE
Bug demonstration of in-mem payment invalidation

### DIFF
--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -252,7 +252,11 @@ WARN
 
     def invalidate_old_payments
       if !store_credit? && !['invalid', 'failed'].include?(state)
-        order.payments.checkout.where(payment_method: payment_method).where("id != ?", id).each(&:invalidate!)
+        order.payments.select do |payment|
+          payment.state == 'checkout' &&
+            payment.payment_method_id == payment_method.try!(:id) &&
+            payment.id != id
+        end.each(&:invalidate!)
       end
     end
 

--- a/core/spec/models/spree/payment_create_spec.rb
+++ b/core/spec/models/spree/payment_create_spec.rb
@@ -187,36 +187,5 @@ module Spree
         end
       end
     end
-
-    describe "invalidating payments doesn't update in memory objects" do
-      let(:order) { Spree::Order.create! store: create(:store) }
-
-      before do
-        Spree::PaymentCreate.new(order, amount: 1).build.save!
-        expect(order.payments.map(&:state)).to contain_exactly(
-          'checkout'
-        )
-        Spree::PaymentCreate.new(order, amount: 2).build.save!
-      end
-
-      context 'without reload', pending: 'failing spec' do
-        it 'should not have stale payments' do
-          expect(order.payments.map(&:state)).to contain_exactly(
-            'invalid',
-            'checkout'
-          )
-        end
-      end
-
-      context 'with reload' do
-        it 'should not have stale payments' do
-          order.payments.reload
-          expect(order.payments.map(&:state)).to contain_exactly(
-            'invalid',
-            'checkout'
-          )
-        end
-      end
-    end
   end
 end

--- a/core/spec/models/spree/payment_create_spec.rb
+++ b/core/spec/models/spree/payment_create_spec.rb
@@ -187,5 +187,36 @@ module Spree
         end
       end
     end
+
+    describe "invalidating payments doesn't update in memory objects" do
+      let(:order) { Spree::Order.create! store: create(:store) }
+
+      before do
+        Spree::PaymentCreate.new(order, amount: 1).build.save!
+        expect(order.payments.map(&:state)).to contain_exactly(
+          'checkout'
+        )
+        Spree::PaymentCreate.new(order, amount: 2).build.save!
+      end
+
+      context 'without reload', pending: 'failing spec' do
+        it 'should not have stale payments' do
+          expect(order.payments.map(&:state)).to contain_exactly(
+            'invalid',
+            'checkout'
+          )
+        end
+      end
+
+      context 'with reload' do
+        it 'should not have stale payments' do
+          order.payments.reload
+          expect(order.payments.map(&:state)).to contain_exactly(
+            'invalid',
+            'checkout'
+          )
+        end
+      end
+    end
   end
 end

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -743,6 +743,23 @@ describe Spree::Payment, type: :model do
       invalid_payment.save
       expect(payment.reload.state).to eq('checkout')
     end
+
+    describe "invalidating payments updates in memory objects" do
+      before do
+        Spree::PaymentCreate.new(order, amount: 1).build.save!
+        expect(order.payments.map(&:state)).to contain_exactly(
+          'checkout'
+        )
+        Spree::PaymentCreate.new(order, amount: 2).build.save!
+      end
+
+      it 'should not have stale payments' do
+        expect(order.payments.map(&:state)).to contain_exactly(
+          'invalid',
+          'checkout'
+        )
+      end
+    end
   end
 
   describe "#apply_source_attributes" do


### PR DESCRIPTION
In memory payments not invalidated correctly

This demonstrates an issue where invalidating payments does not
correctly invalidate other order payments. This leads to a case where
stale data is present in memory leading to potential issues.

This is a demonstration of the issue. Ideally, the non-reload test should pass,
and the second test should not be required.

This test may be misplaced, but is there to provide a simple reproduction of
the issue.
