### PR TITLE
Connect promotions to orders even if they aren't actionable yet

### DIFF
--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -112,13 +112,11 @@ module Spree
       # If an action has been taken, report back to whatever activated this promotion.
       action_taken = results.include?(true)
 
-      if action_taken
-        # connect to the order
-        order_promotions.find_or_create_by!(
-          order_id: order.id,
-          promotion_code_id: promotion_code.try!(:id)
-        )
-      end
+      # connect to the order
+      order_promotions.find_or_create_by!(
+        order_id: order.id,
+        promotion_code_id: promotion_code.try!(:id)
+      )
 
       action_taken
     end

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -92,16 +92,15 @@ describe Spree::Promotion, type: :model do
   end
 
   describe "#activate" do
-    let(:promotion) { create(:promotion) }
+    let(:promotion) do
+      create(:promotion, promotion_actions: [action1, action2], created_at: 2.days.ago)
+    end
+    let(:action1) { Spree::Promotion::Actions::CreateAdjustment.create! }
+    let(:action2) { Spree::Promotion::Actions::CreateAdjustment.create! }
 
     before do
-      @action1 = Spree::Promotion::Actions::CreateAdjustment.create!
-      @action2 = Spree::Promotion::Actions::CreateAdjustment.create!
-      allow(@action1).to receive_messages perform: true
-      allow(@action2).to receive_messages perform: true
-
-      promotion.promotion_actions = [@action1, @action2]
-      promotion.created_at = 2.days.ago
+      allow(action1).to receive_messages perform: true
+      allow(action2).to receive_messages perform: true
 
       @user = create(:user)
       @order = create(:order, user: @user, created_at: DateTime.current)
@@ -111,13 +110,13 @@ describe Spree::Promotion, type: :model do
     it "should check path if present" do
       promotion.path = 'content/cvv'
       @payload[:path] = 'content/cvv'
-      expect(@action1).to receive(:perform).with(hash_including(@payload))
-      expect(@action2).to receive(:perform).with(hash_including(@payload))
+      expect(action1).to receive(:perform).with(hash_including(@payload))
+      expect(action2).to receive(:perform).with(hash_including(@payload))
       promotion.activate(@payload)
     end
 
     it "does not perform actions against an order in a finalized state" do
-      expect(@action1).not_to receive(:perform)
+      expect(action1).not_to receive(:perform)
 
       @order.state = 'complete'
       promotion.activate(@payload)
@@ -130,7 +129,7 @@ describe Spree::Promotion, type: :model do
     end
 
     it "does activate if newer then order" do
-      expect(@action1).to receive(:perform).with(hash_including(@payload))
+      expect(action1).to receive(:perform).with(hash_including(@payload))
       promotion.created_at = DateTime.current + 2
       expect(promotion.activate(@payload)).to be true
     end
@@ -166,8 +165,7 @@ describe Spree::Promotion, type: :model do
     end
 
     context "when there is a code" do
-      let(:promotion_code) { create(:promotion_code) }
-      let(:promotion) { promotion_code.promotion }
+      let(:promotion_code) { create(:promotion_code, promotion: promotion) }
 
       it "assigns the code" do
         expect(promotion.activate(order: @order, promotion_code: promotion_code)).to be true

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -162,6 +162,19 @@ describe Spree::Promotion, type: :model do
           expect(promotion.orders.reload.to_a).to eql [@order]
         end
       end
+      context 'when no action is taken' do
+        let(:promotion) do
+          create(:promotion, :with_line_item_adjustment)
+        end
+
+        it 'assigns the order' do
+          expect(
+            promotion.activate(@payload)
+          ).to eq(false)
+
+          expect(promotion.orders.reload.to_a).to eq([@order])
+        end
+      end
     end
 
     context "when there is a code" do


### PR DESCRIPTION
This changes behavior but seems worth it to me. I'm interested in
others' thoughts on it.

This patch makes it so that a customer can apply a coupon code to
their order before the promotion is actionable, as long as their order
meets the promotion rule requirements.

Example with a "Buy one get one 50% off" promotion:

Without this patch:
- Customer adds one item to their order
- Customer tries to apply the promotion but gets a confusing `:coupon_code_unknown_error` message (because none of the items in the cart are actionable yet)
- Customer adds a second item to their cart
- Customer successfully applies promotion and discount is given

With this patch:
- Customer adds an item to their order
- Customer successfully applies promotion  
  (note: they could be confused about not seeing a discount, if they don't understand the promo)
- Customer adds second item to cart and discount is automatically applied

This patch matches the behavior seen when a previously-actionable order
become non-actionable.  E.g. we don't disconnect a "buy one get one 50% off"
promotion from an order when a customer removes their second item from
their cart.  We leave it connected and if they add a second item the promotion
will automatically apply.

If a store really wants to prevent a coupon from being connected in a case
like this they could use `Rule`s to do so.

Thoughts?