### PR TITLE
Connect promotions to orders even if they aren't actionable yet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## Solidus 2.1.0 (master, unreleased)
+
+*   Promotions can now be connected to an order before they are actionable, as
+    long as they meet the promotion's rule requirements.  Previously a promotion
+    would not get attached to an order unless it was immediately actionable,
+    even if it was eligible.
+
+    https://github.com/solidusio/solidus/pull/1428
+
 ## Solidus 2.0.0 (unreleased)
 
 *   Upgrade to rails 5.0

--- a/api/spec/controllers/spree/api/orders_controller_spec.rb
+++ b/api/spec/controllers/spree/api/orders_controller_spec.rb
@@ -776,7 +776,8 @@ module Spree
       end
 
       context 'when unsuccessful' do
-        let(:order) { create(:order) } # no line items to apply the code to
+        let(:order) { create(:order) }
+        let!(:rule) { Spree::Promotion::Rules::NthOrder.create!(preferred_nth_order: 10, promotion: promo) }
 
         it 'returns an error' do
           api_put :apply_coupon_code, id: order.to_param, coupon_code: promo_code.value
@@ -785,9 +786,9 @@ module Spree
           expect(order.reload.promotions).to eq []
           expect(json_response).to eq({
             "success" => nil,
-            "error" => Spree.t(:coupon_code_unknown_error),
+            "error" => Spree.t(:coupon_code_not_eligible),
             "successful" => false,
-            "status_code" => "coupon_code_unknown_error"
+            "status_code" => "coupon_code_not_eligible"
           })
         end
       end

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -112,13 +112,11 @@ module Spree
       # If an action has been taken, report back to whatever activated this promotion.
       action_taken = results.include?(true)
 
-      if action_taken
-        # connect to the order
-        order_promotions.find_or_create_by!(
-          order_id: order.id,
-          promotion_code_id: promotion_code.try!(:id)
-        )
-      end
+      # connect to the order
+      order_promotions.find_or_create_by!(
+        order_id: order.id,
+        promotion_code_id: promotion_code.try!(:id)
+      )
 
       action_taken
     end

--- a/core/app/models/spree/promotion_handler/coupon.rb
+++ b/core/app/models/spree/promotion_handler/coupon.rb
@@ -63,6 +63,9 @@ module Spree
         result = promotion.activate(order: order, promotion_code: promotion_code)
         if result
           determine_promotion_application_result
+        elsif promotion_exists_on_order?(order, promotion)
+          # the order wasn't connected and is now, but it isn't actionable yet.
+          set_success_code :coupon_code_applied
         else
           set_error_code :coupon_code_unknown_error
         end

--- a/core/lib/spree/testing_support/factories/order_factory.rb
+++ b/core/lib/spree/testing_support/factories/order_factory.rb
@@ -137,7 +137,6 @@ FactoryGirl.define do
       promotion_code = promotion.codes.first || create(:promotion_code, promotion: promotion)
 
       promotion.activate(order: order, promotion_code: promotion_code)
-      order.order_promotions.create!(promotion: promotion, promotion_code: promotion_code)
 
       # Complete the order after the promotion has been activated
       order.refresh_shipment_rates

--- a/core/spec/models/spree/promotion_handler/coupon_spec.rb
+++ b/core/spec/models/spree/promotion_handler/coupon_spec.rb
@@ -5,7 +5,7 @@ module Spree
     describe Coupon, type: :model do
       let(:order) { double("Order", coupon_code: "10off").as_null_object }
 
-      subject { Coupon.new(order) }
+      subject(:coupon) { Coupon.new(order) }
 
       def expect_order_connection(order:, promotion:, promotion_code:nil)
         expect(order.promotions.to_a).to include(promotion)
@@ -327,6 +327,17 @@ module Spree
               expect(@order.reload.total).to eq(0)
               expect(@order.additional_tax_total).to eq(0)
             end
+          end
+        end
+
+        context 'when the promotion is not actionable yet' do
+          let(:order) { create(:order, coupon_code: '10off') }
+
+          it 'successfully activates the promotion' do
+            coupon.apply
+
+            expect(coupon.success).to be_truthy
+            expect_order_connection(order: order, promotion: promotion, promotion_code: promotion_code)
           end
         end
       end

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -92,16 +92,15 @@ describe Spree::Promotion, type: :model do
   end
 
   describe "#activate" do
-    let(:promotion) { create(:promotion) }
+    let(:promotion) do
+      create(:promotion, promotion_actions: [action1, action2], created_at: 2.days.ago)
+    end
+    let(:action1) { Spree::Promotion::Actions::CreateAdjustment.create! }
+    let(:action2) { Spree::Promotion::Actions::CreateAdjustment.create! }
 
     before do
-      @action1 = Spree::Promotion::Actions::CreateAdjustment.create!
-      @action2 = Spree::Promotion::Actions::CreateAdjustment.create!
-      allow(@action1).to receive_messages perform: true
-      allow(@action2).to receive_messages perform: true
-
-      promotion.promotion_actions = [@action1, @action2]
-      promotion.created_at = 2.days.ago
+      allow(action1).to receive_messages perform: true
+      allow(action2).to receive_messages perform: true
 
       @user = create(:user)
       @order = create(:order, user: @user, created_at: DateTime.current)
@@ -111,13 +110,13 @@ describe Spree::Promotion, type: :model do
     it "should check path if present" do
       promotion.path = 'content/cvv'
       @payload[:path] = 'content/cvv'
-      expect(@action1).to receive(:perform).with(hash_including(@payload))
-      expect(@action2).to receive(:perform).with(hash_including(@payload))
+      expect(action1).to receive(:perform).with(hash_including(@payload))
+      expect(action2).to receive(:perform).with(hash_including(@payload))
       promotion.activate(@payload)
     end
 
     it "does not perform actions against an order in a finalized state" do
-      expect(@action1).not_to receive(:perform)
+      expect(action1).not_to receive(:perform)
 
       @order.state = 'complete'
       promotion.activate(@payload)
@@ -130,7 +129,7 @@ describe Spree::Promotion, type: :model do
     end
 
     it "does activate if newer then order" do
-      expect(@action1).to receive(:perform).with(hash_including(@payload))
+      expect(action1).to receive(:perform).with(hash_including(@payload))
       promotion.created_at = DateTime.current + 2
       expect(promotion.activate(@payload)).to be true
     end
@@ -166,8 +165,7 @@ describe Spree::Promotion, type: :model do
     end
 
     context "when there is a code" do
-      let(:promotion_code) { create(:promotion_code) }
-      let(:promotion) { promotion_code.promotion }
+      let(:promotion_code) { create(:promotion_code, promotion: promotion) }
 
       it "assigns the code" do
         expect(promotion.activate(order: @order, promotion_code: promotion_code)).to be true

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -162,6 +162,19 @@ describe Spree::Promotion, type: :model do
           expect(promotion.orders.reload.to_a).to eql [@order]
         end
       end
+      context 'when no action is taken' do
+        let(:promotion) do
+          create(:promotion, :with_line_item_adjustment)
+        end
+
+        it 'assigns the order' do
+          expect(
+            promotion.activate(@payload)
+          ).to eq(false)
+
+          expect(promotion.orders.reload.to_a).to eq([@order])
+        end
+      end
     end
 
     context "when there is a code" do

--- a/frontend/spec/features/quantity_promotions_spec.rb
+++ b/frontend/spec/features/quantity_promotions_spec.rb
@@ -23,23 +23,24 @@ RSpec.feature "Quantity Promotions" do
   end
 
   scenario "adding and removing items from the cart" do
-    # Attempt to use the code with too few items.
+    # Add the code with too few items.
     fill_in "Coupon code", with: "PROMO"
     click_button "Update"
-    expect(page).to have_content("This coupon code could not be applied to the cart at this time")
+    expect(page).to have_content("The coupon code was successfully applied to your order")
 
     # Add another item to our cart.
     visit spree.root_path
     click_link "DL-44"
     click_button "Add To Cart"
-
-    # Using the code should now succeed.
-    fill_in "Coupon code", with: "PROMO"
-    click_button "Update"
-    expect(page).to have_content("The coupon code was successfully applied to your order")
     within("#cart_adjustments") do
       expect(page).to have_content("-$10.00")
     end
+
+    # Applying the code again should fail.
+    fill_in "Coupon code", with: "PROMO"
+    click_button "Update"
+    expect(page).to have_content("The coupon code has already been applied to this order")
+    fill_in "Coupon code", with: "" # clear the failed code
 
     # Reduce quantity by 1, making promotion not apply.
     fill_in "order_line_items_attributes_0_quantity", with: 1


### PR DESCRIPTION
This changes behavior but seems worth it to me. I'm interested in
others' thoughts on it.

This patch makes it so that a customer can apply a coupon code to
their order before the promotion is actionable, as long as their order
meets the promotion rule requirements.

Example with a "Buy one get one 50% off" promotion:

Without this patch:
- Customer adds one item to their order
- Customer tries to apply the promotion but gets a confusing `:coupon_code_unknown_error` message (because none of the items in the cart are actionable yet)
- Customer adds a second item to their cart
- Customer successfully applies promotion and discount is given

With this patch:
- Customer adds an item to their order
- Customer successfully applies promotion  
  (note: they could be confused about not seeing a discount, if they don't understand the promo)
- Customer adds second item to cart and discount is automatically applied

This patch matches the behavior seen when a previously-actionable order
become non-actionable.  E.g. we don't disconnect a "buy one get one 50% off"
promotion from an order when a customer removes their second item from
their cart.  We leave it connected and if they add a second item the promotion
will automatically apply.

If a store really wants to prevent a coupon from being connected in a case
like this they could use `Rule`s to do so.

Thoughts?
