### PR TITLE
Add "only_allow_most_recent_promotion" configuration

### DIFF
--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -274,6 +274,12 @@ module Spree
     #   @return [Boolean] Indicates if stock management can be restricted by location
     preference :can_restrict_stock_management, :boolean, default: false
 
+    # @!attribute [rw] only_allow_most_recent_promotion
+    #   @return [Boolean] When this is set to true then previous promotions will
+    #     be removed from an order when a new promotion is activate on the
+    #     order. (default: +false+)
+    preference :only_allow_most_recent_promotion, :boolean, default: false
+
     # searcher_class allows spree extension writers to provide their own Search class
     attr_writer :searcher_class
     def searcher_class

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -706,22 +706,6 @@ module Spree
       Spree::Money.new(total_available_store_credit - total_applicable_store_credit, { currency: currency })
     end
 
-    # Remove a promotion from this order along with any associated adjustments
-    # Note: OrderUpdater will need to be invoked after this is called
-    # @param promotion [Spree::Promotion] the promotion to remove
-    # @return [undefined]
-    def remove_promotion(promotion)
-      [self, *line_items, *shipments].each do |item|
-        item.adjustments.each do |adjustment|
-          if promotion.actions.include?(adjustment.source)
-            item.adjustments.destroy(adjustment)
-          end
-        end
-      end
-      # note: this destroys the join table entry, not the promotion itself
-      promotions.destroy(promotion)
-    end
-
     private
 
     def associate_store

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -706,6 +706,22 @@ module Spree
       Spree::Money.new(total_available_store_credit - total_applicable_store_credit, { currency: currency })
     end
 
+    # Remove a promotion from this order along with any associated adjustments
+    # Note: OrderUpdater will need to be invoked after this is called
+    # @param promotion [Spree::Promotion] the promotion to remove
+    # @return [undefined]
+    def remove_promotion(promotion)
+      [self, *line_items, *shipments].each do |item|
+        item.adjustments.each do |adjustment|
+          if promotion.actions.include?(adjustment.source)
+            item.adjustments.destroy(adjustment)
+          end
+        end
+      end
+      # note: this destroys the join table entry, not the promotion itself
+      promotions.destroy(promotion)
+    end
+
     private
 
     def associate_store

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -252,8 +252,16 @@ module Spree
 
     def remove_other_promotions_from_order(order)
       (order.promotions - [self]).each do |promotion|
-        order.remove_promotion(promotion)
+        promotion.remove_from(order)
       end
+    end
+
+    def remove_from(order)
+      actions.each do |action|
+        action.remove_from(order)
+      end
+      # note: this destroys the join table entry, not the promotion itself
+      order.promotions.destroy(self)
     end
   end
 end

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -118,6 +118,10 @@ module Spree
           order_id: order.id,
           promotion_code_id: promotion_code.try!(:id)
         )
+
+        if Spree::Config.only_allow_most_recent_promotion
+          remove_other_promotions_from_order(order)
+        end
       end
 
       action_taken
@@ -244,6 +248,12 @@ module Spree
       return unless apply_automatically
       errors.add(:apply_automatically, :disallowed_with_code) if codes.any?
       errors.add(:apply_automatically, :disallowed_with_path) if path.present?
+    end
+
+    def remove_other_promotions_from_order(order)
+      (order.promotions - [self]).each do |promotion|
+        order.remove_promotion(promotion)
+      end
     end
   end
 end

--- a/core/app/models/spree/promotion_action.rb
+++ b/core/app/models/spree/promotion_action.rb
@@ -19,5 +19,22 @@ module Spree
     def perform(_options = {})
       raise 'perform should be implemented in a sub-class of PromotionAction'
     end
+
+    # Removes the action from an order
+    #
+    # @note A PromotionAction subclass should override this method if it does
+    # something other than add adjustments.
+    #
+    # @param order [Spree::Order] the order to remove the action from
+    # @return [undefined]
+    def remove_from(order)
+      [order, *order.line_items, *order.shipments].each do |item|
+        item.adjustments.each do |adjustment|
+          if adjustment.source == self
+            item.adjustments.destroy(adjustment)
+          end
+        end
+      end
+    end
   end
 end

--- a/core/app/models/spree/promotion_handler/cart.rb
+++ b/core/app/models/spree/promotion_handler/cart.rb
@@ -21,27 +21,54 @@ module Spree
       end
 
       def activate
-        promotions.each do |promotion|
-          if (line_item && promotion.eligible?(line_item, promotion_code: promotion_code(promotion))) || promotion.eligible?(order, promotion_code: promotion_code(promotion))
-            promotion.activate(line_item: line_item, order: order, promotion_code: promotion_code(promotion))
-          end
+        connected_order_promotions.each do |promotion|
+          activate_promotion(promotion)
+        end
+
+        sale_promotions.each do |promotion|
+          activate_promotion(promotion)
         end
       end
 
       private
 
-      def promotions
-        connected_order_promotions | sale_promotions
+      def activate_promotion(promotion)
+        if line_item_eligible?(promotion) || order_eligible?(promotion)
+          promotion.activate(line_item: line_item, order: order, promotion_code: promotion_code(promotion))
+        end
+      end
+
+      def line_item_eligible?(promotion)
+        line_item &&
+          promotion.eligible?(
+            line_item,
+            promotion_code: promotion_code(promotion),
+          )
+      end
+
+      def order_eligible?(promotion)
+        promotion.eligible?(
+          order,
+          promotion_code: promotion_code(promotion),
+        )
       end
 
       def connected_order_promotions
-        Promotion.active.includes(:promotion_rules).
+        @connected_order_promotions ||= Promotion.
+          active.
+          includes(:promotion_rules).
           joins(:order_promotions).
-          where(spree_orders_promotions: { order_id: order.id }).readonly(false).to_a
+          where(spree_orders_promotions: { order_id: order.id }).
+          readonly(false).
+          to_a
       end
 
       def sale_promotions
-        Promotion.where(apply_automatically: true).active.includes(:promotion_rules)
+        @sale_promotions ||= Promotion.
+          where(apply_automatically: true).
+          active.
+          includes(:promotion_rules).
+          to_a
       end
 
       def promotion_code(promotion)

--- a/core/app/models/spree/promotion_handler/cart.rb
+++ b/core/app/models/spree/promotion_handler/cart.rb
@@ -38,6 +38,15 @@ module Spree
         end
       end
 
+      def apply_sale_promotions?
+        if Spree::Config.only_allow_most_recent_promotion &&
+           connected_order_promotions.any?
+          false
+        else
+          true
+        end
+      end
+
       def line_item_eligible?(promotion)
         line_item &&
           promotion.eligible?(


### PR DESCRIPTION
Looking for input on this. If people think it's a reasonable then I'll add
specs for it.

UPDATE: I've opened #1433 as an alternative (more general/customizable
approach to solving this issue).

Add an `only_allow_most_recent_promotion` config that allows stores to
only allow a single promotion per order and for that promotion to be
the promotion most recently applied by the user.

This is a somewhat common way to work with promotions and helps reduce
unintended side effects from promotions interacting with each other.
E.g. accidentally giving more of a discount than a store intends to
when a clever customer applies multiple promotions.

This also requires adjusting PromotionHandler::Cart so that it won't
automatically apply "apply_automatically" promotions if this config is
enabled and the order in question already has a promotion applied to
it.
