### PR TITLE
Remove unused FakeCalculator class in tests

### DIFF
--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -1,11 +1,5 @@
 require 'spec_helper'
 
-class FakeCalculator < Spree::Calculator
-  def compute(_computable)
-    5
-  end
-end
-
 describe Spree::Order, type: :model do
   let(:store) { build_stubbed(:store) }
   let(:user) { stub_model(Spree::LegacyUser, email: "spree@example.com") }


### PR DESCRIPTION
The spec referencing this was removed in 2011