### PR TITLE
Add extension points for handling multiple promotions on one order

### DIFF
--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -371,6 +371,16 @@ module Spree
       @add_payment_sources_to_wallet_class ||= Spree::Wallet::AddPaymentSourcesToWallet
     end
 
+    attr_writer :promotions_to_remove_from_order_class
+    def promotions_to_remove_from_order_class
+      @promotions_to_remove_from_order_class ||= Spree::Promotion::PromotionsToRemoveFromOrder
+    end
+
+    attr_writer :automatic_promotion_decision_class
+    def automatic_promotion_decision_class
+      @automatic_promotion_decision_class ||= Spree::Promotion::AutomaticPromotionDecision
+    end
+
     def static_model_preferences
       @static_model_preferences ||= Spree::Preferences::StaticModelPreferences.new
     end

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -109,6 +109,12 @@ module Spree
           order_id: order.id,
           promotion_code_id: promotion_code.try!(:id)
         )
+
+        Spree::Config.promotions_to_remove_from_order_class.new(order).
+          promotions_to_remove.
+          each do |promotion|
+            promotion.remove_from(order)
+          end
       end
 
       action_taken

--- a/core/app/models/spree/promotion/automatic_promotion_decision.rb
+++ b/core/app/models/spree/promotion/automatic_promotion_decision.rb
@@ -1,0 +1,31 @@
+# This class is responsible for deciding whether to *attempt* to apply an
+# "apply_automatically" promotion to an order.
+#
+# This default class always returns true. You can substitute your own class via
+# `Spree::Config.automatic_promotion_decision_class`.
+#
+# One example scenario that this is meant to support (via customization):
+# A store that only allows a single promotion per order, and doesn't want
+# "apply_automatically" promotions to be attempted if an order already has a
+# promotion attached to it.
+#
+# Promotion eligibility rules will also be checked after this if this returns
+# true.
+class Spree::Promotion::AutomaticPromotionDecision
+  # @param order [Spree::Order] the order the promotion would be applied to
+  # @param promotion [Spree::Promotion] the "apply_automatically" promotion
+  def initialize(order:, promotion:)
+    @order = order
+    @promotion = promotion
+  end
+
+  # @return [Boolean] whether we should attempt to apply the promotion to the
+  #  order.
+  def attempt_to_apply?
+    true
+  end
+
+  private
+
+  attr_accessor :order, :promotion
+end

--- a/core/app/models/spree/promotion/promotions_to_remove_from_order.rb
+++ b/core/app/models/spree/promotion/promotions_to_remove_from_order.rb
@@ -1,0 +1,25 @@
+# This class is responsible for selecting which promotions should be removed
+# from an order after a new promotion has been activated on the order.
+# This default class does not remove any promotions from the order. You can
+# substitute your own class via
+# `Spree::Config.promotions_to_remove_from_order_class`.
+#
+# Example of customization: Only allowing the most recently applied promotion to
+# be kept on an order.
+class Spree::Promotion::PromotionsToRemoveFromOrder
+  # @param order [Spree::Order] The order we are choosing promotions for.
+  def initialize(order)
+    @order = order
+  end
+
+  # Select which promotions should be removed from the order.
+  #
+  # @return [Array<Spree::Promotion>] the promotions to remove from the order.
+  def promotions_to_remove
+    []
+  end
+
+  private
+
+  attr_accessor :order
+end

--- a/core/app/models/spree/promotion_handler/cart.rb
+++ b/core/app/models/spree/promotion_handler/cart.rb
@@ -26,7 +26,9 @@ module Spree
         end
 
         sale_promotions.each do |promotion|
-          activate_promotion(promotion)
+          if apply_sale_promotion?(promotion)
+            activate_promotion(promotion)
+          end
         end
       end
 
@@ -36,6 +38,12 @@ module Spree
         if line_item_eligible?(promotion) || order_eligible?(promotion)
           promotion.activate(line_item: line_item, order: order, promotion_code: promotion_code(promotion))
         end
+      end
+
+      def apply_sale_promotion?(promotion)
+        Spree::Config.automatic_promotion_decision_class.
+          new(order: order, promotion: promotion).
+          attempt_to_apply?
       end
 
       def line_item_eligible?(promotion)

--- a/core/app/models/spree/promotion_handler/cart.rb
+++ b/core/app/models/spree/promotion_handler/cart.rb
@@ -21,27 +21,54 @@ module Spree
       end
 
       def activate
-        promotions.each do |promotion|
-          if (line_item && promotion.eligible?(line_item, promotion_code: promotion_code(promotion))) || promotion.eligible?(order, promotion_code: promotion_code(promotion))
-            promotion.activate(line_item: line_item, order: order, promotion_code: promotion_code(promotion))
-          end
+        connected_order_promotions.each do |promotion|
+          activate_promotion(promotion)
+        end
+
+        sale_promotions.each do |promotion|
+          activate_promotion(promotion)
         end
       end
 
       private
 
-      def promotions
-        connected_order_promotions | sale_promotions
+      def activate_promotion(promotion)
+        if line_item_eligible?(promotion) || order_eligible?(promotion)
+          promotion.activate(line_item: line_item, order: order, promotion_code: promotion_code(promotion))
+        end
+      end
+
+      def line_item_eligible?(promotion)
+        line_item &&
+          promotion.eligible?(
+            line_item,
+            promotion_code: promotion_code(promotion),
+          )
+      end
+
+      def order_eligible?(promotion)
+        promotion.eligible?(
+          order,
+          promotion_code: promotion_code(promotion),
+        )
       end
 
       def connected_order_promotions
-        Promotion.active.includes(:promotion_rules).
+        @connected_order_promotions ||= Promotion.
+          active.
+          includes(:promotion_rules).
           joins(:order_promotions).
-          where(spree_orders_promotions: { order_id: order.id }).readonly(false).to_a
+          where(spree_orders_promotions: { order_id: order.id }).
+          readonly(false).
+          to_a
       end
 
       def sale_promotions
-        Promotion.where(apply_automatically: true).active.includes(:promotion_rules)
+        @sale_promotions ||= Promotion.
+          where(apply_automatically: true).
+          active.
+          includes(:promotion_rules).
+          to_a
       end
 
       def promotion_code(promotion)


### PR DESCRIPTION
This is an alternative to #1429.  Instead of supporting a single way to
handle multiple promotions, this attempts to provide extension points
where stores can implement their own requirements.

Looking for input on this. If people think it's a reasonable then I'll add
specs for it.

This PR adds these two extension points:
- Spree::Config.promotions_to_remove_from_order_class
- Spree::Config.automatic_promotion_decision_class

These are meant to allow customization around handling multiple
promotions on a single order.

One example scenario is only allowing a single promotion per order and
for that promotion to be the promotion most recently applied by the
user. This is a somewhat common way to work with promotions and helps
reduce unintended side effects from promotions interacting with each
other. E.g. accidentally giving more of a discount than a store
intends to when a clever customer applies multiple promotions.

With this PR, implementing the above should be possible via something
like this:

``` ruby
class CustomRemover < Spree::Promotion::PromotionsToRemoveFromOrder
  def promotions_to_remove
    last_promo = order.order_promotions.last.try!(:promotion)
    order.promotions - [last_promo]
  end
end

class CustomDecider < Spree::Promotion::AutomaticPromotionDecision
  def attempt_to_apply?
    order.promotions.none?
  end
end
```

There are many other ways that stores customize logic around multiple
promotions, so this is an attempt to make the behavior configurable,
rather than supporting only the use case mentioned above.
