### PR TITLE
Build payment factory from order.payments association

### DIFF
--- a/core/lib/spree/testing_support/factories/payment_factory.rb
+++ b/core/lib/spree/testing_support/factories/payment_factory.rb
@@ -27,6 +27,10 @@ FactoryGirl.define do
 
       refunds { build_list :refund, 1, amount: refund_amount }
     end
+
+    initialize_with do
+      order.payments.new(attributes)
+    end
   end
 
   factory :check_payment, class: Spree::Payment do

--- a/core/spec/models/spree/order/payment_spec.rb
+++ b/core/spec/models/spree/order/payment_spec.rb
@@ -22,8 +22,8 @@ module Spree
         expect(order.payment_state).to eq('paid')
         expect(order.payment_total).to eq(100)
 
-        expect(payment_1.reload).to be_completed
-        expect(payment_2.reload).to be_completed
+        expect(payment_1).to be_completed
+        expect(payment_2).to be_completed
       end
 
       it 'does not go over total for order' do
@@ -37,18 +37,17 @@ module Spree
         expect(order.payment_state).to eq('paid')
         expect(order.payment_total).to eq(100)
 
-        expect(payment_1.reload).to be_completed
-        expect(payment_2.reload).to be_completed
-        expect(payment_3.reload).to be_checkout
+        expect(payment_1).to be_completed
+        expect(payment_2).to be_completed
+        expect(payment_3).to be_checkout
       end
 
       it "does not use failed payments" do
-        create(:payment, order: order, amount: 50)
-        create(:payment, order: order, amount: 50, state: 'failed')
-        order.payments.reload
+        payment1 = create(:payment, order: order, amount: 50)
+        payment2 = create(:payment, order: order, amount: 50, state: 'failed')
 
-        expect(order.payments[0]).to receive(:process!).and_call_original
-        expect(order.payments[1]).not_to receive(:process!)
+        expect(payment1).to receive(:process!).and_call_original
+        expect(payment2).not_to receive(:process!)
 
         order.process_payments!
 


### PR DESCRIPTION
This keeps the order.payments association fresh.

Previously, calling `create(:payment)` would build a payment using `Spree::Payment.new(attributes)` before saving (the factory girl default). This commit changes the factory to use `order.payments.new`, so that the order's payments association will include the new payment.

Before

    order.payments #=> []
    create(:payment, order: order)
    order.payments #=> [] (cached)
    order.payments.reload #=> [#<Payment...

After

    order.payments #=> []
    create(:payment, order: order)
    order.payments #=> [#<Payment...

This PR includes a commit showing the cleanup this allows to the `order/payment_spec.rb`

This change allows #1426 to go green without any changes to specs