### PR TITLE
Remove adjustment updates in Shipment#update_amounts

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -282,11 +282,9 @@ module Spree
     def update_amounts
       if selected_shipping_rate
         self.cost = selected_shipping_rate.cost
-        self.adjustment_total = adjustments.additional.map(&:update!).compact.sum
         if changed?
           update_columns(
             cost: cost,
-            adjustment_total: adjustment_total,
             updated_at: Time.current
           )
         end

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -530,30 +530,6 @@ describe Spree::Shipment, type: :model do
         shipment.update_amounts
       }.to change { shipment.cost }.to(5)
     end
-
-    it "factors in additional adjustments to adjustment total" do
-      shipment.adjustments.create!(
-        order:    order,
-        label:    "Additional",
-        amount:   5,
-        included: false,
-        finalized: true
-      )
-      shipment.update_amounts
-      expect(shipment.reload.adjustment_total).to eq(5)
-    end
-
-    it "does not factor in included adjustments to adjustment total" do
-      shipment.adjustments.create!(
-        order:    order,
-        label:    "Included",
-        amount:   5,
-        included: true,
-        finalized: true
-      )
-      shipment.update_amounts
-      expect(shipment.reload.adjustment_total).to eq(0)
-    end
   end
 
   context "changes shipping rate via general update" do

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -523,12 +523,12 @@ describe Spree::Shipment, type: :model do
 
   context "updates cost when selected shipping rate is present" do
     let(:shipment) { create(:shipment) }
-
-    before { allow(shipment).to receive_message_chain :selected_shipping_rate, cost: 5 }
+    before { shipment.selected_shipping_rate.update!(cost: 5) }
 
     it "updates shipment totals" do
-      shipment.update_amounts
-      expect(shipment.reload.cost).to eq(5)
+      expect {
+        shipment.update_amounts
+      }.to change { shipment.cost }.to(5)
     end
 
     it "factors in additional adjustments to adjustment total" do


### PR DESCRIPTION
Previously calling `Shipment#update_amounts` (usually done by the `OrderUpdater`) would update the cost on the Shipment as well as call update! on all adjustments and update the Shipment's `adjustment_total`.

When used as part of an `OrderUpdate` this isn't necessary as the adjustments will be updated later in the process.

This relates to #1252 where @jordan-brough suggests we should no longer update adjustments outside of `OrderUpdater`.