### PR TITLE
Prefer keeping order.order_promotions relationship up to date

### DIFF
--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -114,10 +114,11 @@ module Spree
 
       if action_taken
         # connect to the order
-        order_promotions.find_or_create_by!(
-          order_id: order.id,
-          promotion_code_id: promotion_code.try!(:id)
+        order.order_promotions.find_or_create_by!(
+          promotion: self,
+          promotion_code: promotion_code,
         )
+        order.promotions.reset
       end
 
       action_taken

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -119,6 +119,8 @@ module Spree
           promotion_code: promotion_code,
         )
         order.promotions.reset
+        order_promotions.reset
+        orders.reset
       end
 
       action_taken

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -142,6 +142,30 @@ describe Spree::Promotion, type: :model do
           expect(promotion.activate(@payload)).to be true
           expect(promotion.orders.first).to eql @order
         end
+
+        it 'keeps in-memory associations updated' do
+          # load all the relevant associations into memory
+          promotion.order_promotions.to_a
+          promotion.orders.to_a
+          @order.order_promotions.to_a
+          @order.promotions.to_a
+
+          expect(promotion.order_promotions.size).to eq(0)
+          expect(promotion.orders.size).to eq(0)
+          expect(@order.order_promotions.size).to eq(0)
+          expect(@order.promotions.size).to eq(0)
+
+          expect(
+            promotion.activate(@payload)
+          ).to eq(true)
+
+          aggregate_failures do
+            expect(promotion.order_promotions.size).to eq(1)
+            expect(promotion.orders.size).to eq(1)
+            expect(@order.order_promotions.size).to eq(1)
+            expect(@order.promotions.size).to eq(1)
+          end
+        end
       end
       context "when not activated" do
         it "will not assign the order" do


### PR DESCRIPTION
Prefer keeping `Order#order_promotions` up to date instead of
`Promotion#order_promotions`.  The former is more likely to be
important.

It seems like keeping `Promotion#order_promotions` up to date might not be worth the hassle, but if we wanted to, some ideas are:

```ruby
order.order_promotions.find_or_create_by!(...)
order_promotions.reset # (this is different than order.promotions.reset)
```

or

```ruby
order_promotions << order.order_promotions.find_or_create_by!(...)
```
This generates an extra SQL query though.

or

```ruby
order_promotion = order.order_promotions.find_or_create_by!(...)
if order_promotions.loaded? && !order_promotions.include?(order_promotion)
  order_promotions.proxy_association.add_to_target(order_promotion)
end
```
That seems a bit excessive for this though.
