### PR TITLE
Improve JS handling for OrdersController

### DIFF
--- a/frontend/app/controllers/spree/orders_controller.rb
+++ b/frontend/app/controllers/spree/orders_controller.rb
@@ -18,10 +18,11 @@ module Spree
 
     def update
       if @order.contents.update_cart(order_params)
+        @order.next if params.key?(:checkout) && @order.cart?
+
         respond_with(@order) do |format|
           format.html do
             if params.key?(:checkout)
-              @order.next if @order.cart?
               redirect_to checkout_state_path(@order.checkout_steps.first)
             else
               redirect_to cart_path

--- a/frontend/app/controllers/spree/orders_controller.rb
+++ b/frontend/app/controllers/spree/orders_controller.rb
@@ -41,27 +41,30 @@ module Spree
 
     # Adds a new item to the order (creating a new order if none already exists)
     def populate
-      order    = current_order(create_order_if_necessary: true)
+      @order   = current_order(create_order_if_necessary: true)
       variant  = Spree::Variant.find(params[:variant_id])
       quantity = params[:quantity].to_i
 
       # 2,147,483,647 is crazy. See issue https://github.com/spree/spree/issues/2695.
-      if quantity.between?(1, 2_147_483_647)
-        begin
-          order.contents.add(variant, quantity)
-        rescue ActiveRecord::RecordInvalid => e
-          error = e.record.errors.full_messages.join(", ")
-        end
-      else
-        error = Spree.t(:please_enter_reasonable_quantity)
+      if !quantity.between?(1, 2_147_483_647)
+        @order.errors.add(:base, Spree.t(:please_enter_reasonable_quantity))
       end
 
-      if error
-        flash[:error] = error
-        redirect_back_or_default(spree.root_path)
-      else
-        respond_with(order) do |format|
-          format.html { redirect_to cart_path }
+      begin
+        @line_item = @order.contents.add(variant, quantity)
+      rescue ActiveRecord::RecordInvalid => e
+        @order.errors.add(:base, e.record.errors.full_messages.join(", "))
+      end
+
+      respond_with(@order) do |format|
+        format.html do
+          if @order.errors.any?
+            flash[:error] = @order.errors.full_messages.join(", ")
+            redirect_back_or_default(spree.root_path)
+            return
+          else
+            redirect_to cart_path
+          end
         end
       end
     end

--- a/frontend/spec/controllers/spree/orders_controller_spec.rb
+++ b/frontend/spec/controllers/spree/orders_controller_spec.rb
@@ -18,7 +18,12 @@ describe Spree::OrdersController, type: :controller do
       it "should create a new order when none specified" do
         post :populate
         expect(cookies.signed[:guest_token]).not_to be_blank
-        expect(Spree::Order.find_by_guest_token(cookies.signed[:guest_token])).to be_persisted
+
+        order_by_token = Spree::Order.find_by_guest_token(cookies.signed[:guest_token])
+        assigned_order = assigns[:order]
+
+        expect(assigned_order).to eq order_by_token
+        expect(assigned_order).to be_persisted
       end
 
       context "with Variant" do

--- a/frontend/spec/controllers/spree/orders_controller_spec.rb
+++ b/frontend/spec/controllers/spree/orders_controller_spec.rb
@@ -90,6 +90,13 @@ describe Spree::OrdersController, type: :controller do
           put :update, session: { order_id: 1 }
           expect(response).to redirect_to(spree.cart_path)
         end
+
+        it "should advance the order if :checkout button is pressed" do
+          allow(order).to receive(:update_attributes).and_return true
+          expect(order).to receive(:next)
+          put :update, { checkout: true }, { order_id: 1 }
+          expect(response).to redirect_to checkout_state_path('address')
+        end
       end
     end
 


### PR DESCRIPTION
  * Using an instance variable allows JS populate operations to have
    access to the @order from within the rendered `.js.erb` files

  * Assign all line_item errors to the order's base

  * Allow to respond to JS requests for `#populate` and `#update` actions.
    It is left for the developer to actually implement the `js.erb` views

* Adjusts `#update` to perform the behave properly for JS actions as well

--

To consider:

  - to avoid the whole rescue operation, and manually assigning line item
    errors to the order's `:base`, we'd need to do to be doing `order.save`
    instead of `line_item.save!` in [`OrderContents`](https://github.com/solidusio/solidus/blob/master/core/app/models/spree/order_contents.rb#L151)

  -> That would have the effect to "automatically" assign the line item
     errors on the order in the form: `line_items.quantity` in Rails 4.x
     and "line_items[0].quantity" in Rails 5


  More info:
  - https://github.com/rails/rails/pull/8638
  - https://github.com/rails/rails/pull/19686