### PR TITLE
DummyGenerator doesn't need to create a custom_user.rb initializer

### DIFF
--- a/core/lib/generators/spree/dummy/dummy_generator.rb
+++ b/core/lib/generators/spree/dummy/dummy_generator.rb
@@ -47,7 +47,6 @@ module Spree
       template "rails/routes.rb", "#{dummy_path}/config/routes.rb", force: true
       template "rails/test.rb", "#{dummy_path}/config/environments/test.rb", force: true
       template "rails/script/rails", "#{dummy_path}/spec/dummy/script/rails", force: true
-      template "initializers/custom_user.rb", "#{dummy_path}/config/initializers/custom_user.rb", force: true
 
       # FIXME: We aren't ready for rails 5 defaults
       remove_file "#{dummy_path}/config/initializers/new_framework_defaults.rb"

--- a/core/lib/generators/spree/dummy/templates/initializers/custom_user.rb
+++ b/core/lib/generators/spree/dummy/templates/initializers/custom_user.rb
@@ -1,1 +1,0 @@
-# Spree.user_class = "User"


### PR DESCRIPTION
The InstallGenerator, which is always going to be called after the
DummyGenerator, includes a `Spree.user_class` setter in
initializers/spree.rb, which is also parameterized to use options[:user_class]
https://github.com/solidusio/solidus/blob/d7b7ef47087e998655481a467ec3bf6d9a658ce3/core/lib/generators/spree/install/templates/config/initializers/spree.rb#L79

There's no reason for DummyGenerator to create a hard-coded commented-out
Spree.user_class setter in a separate initializer. It's dead code, but
makes things somewhat more confusing for someone trying to decipher
the generator(s).