### PR TITLE
Use payment_source_class to find reusable sources

### DIFF
--- a/core/app/models/spree/gateway.rb
+++ b/core/app/models/spree/gateway.rb
@@ -60,7 +60,10 @@ module Spree
       if order.completed?
         sources_by_order(order)
       elsif order.user_id
-        credit_cards.where(user_id: order.user_id).with_payment_profile
+        payment_source_class.where(
+          payment_method_id: id,
+          user_id: order.user_id
+        ).with_payment_profile
       else
         []
       end


### PR DESCRIPTION
This method relied on the Gateway -> CreditCard association method `credit_cards`, which may not be present for custom gateways. By using the `payment_source_class` method, we can generalize this code for easier re-use.
