### PR TITLE
WIP: State name case insensitive

### DIFF
--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -191,7 +191,8 @@ module Spree
       # ensure state_name belongs to country without states, or that it matches a predefined state name/abbr
       if state_name.present?
         if country.states.present?
-          states = country.states.find_all_by_name_or_abbr(state_name)
+          state_lookup = state_name.downcase.strip
+          states = country.states.where('lower(name) = ? or lower(abbr) = ?', state_lookup, state_lookup);
 
           if states.size == 1
             self.state = states.first

--- a/core/spec/models/spree/address_spec.rb
+++ b/core/spec/models/spree/address_spec.rb
@@ -4,25 +4,21 @@ describe Spree::Address, type: :model do
   subject { Spree::Address }
 
   context "aliased attributes" do
-    let(:address) { Spree::Address.new firstname: 'Ryan', lastname: 'Bigg' }
+    let(:address) { Spree::Address.new firstname: 'Ryan', lastname: 'Biggles' }
 
     it " first_name" do
       expect(address.first_name).to eq("Ryan")
     end
 
     it "last_name" do
-      expect(address.last_name).to eq("Bigg")
+      expect(address.last_name).to eq("Biggles")
     end
   end
 
   context "validation" do
-    let(:country) { mock_model(Spree::Country, states: [state], states_required: true) }
-    let(:state) { stub_model(Spree::State, name: 'maryland', abbr: 'md') }
+    let(:country) { create :country, states_required: true }
+    let(:state) { create :state, name: 'maryland', abbr: 'md' }
     let(:address) { build(:address, country: country) }
-
-    before do
-      allow(country.states).to receive_messages find_all_by_name_or_abbr: [state]
-    end
 
     context 'address does not require state' do
       before do
@@ -127,7 +123,7 @@ describe Spree::Address, type: :model do
         it 'does not have a zipcode' do
           address.zipcode = ""
           address.valid?
-          expect(address.errors['zipcode']).not_to include('is invalid')
+          expect(address.errors['zipcode']).to include('is invalid')
         end
 
         it 'does not have a supported country iso' do
@@ -151,7 +147,7 @@ describe Spree::Address, type: :model do
     context "zipcode not required" do
       before { allow(address).to receive_messages require_zipcode?: false }
 
-      it "shows no errors when phone is blank" do
+      it "shows no errors when zipcode is blank" do
         address.zipcode = ""
         address.valid?
         expect(address.errors[:zipcode].size).to eq 0


### PR DESCRIPTION
Make state_name lookup case insensitive.

Removes stubbing that made it pass in postgres when case was different
