### PR TITLE
Use correct SPDX ID for license in gemspec

### DIFF
--- a/api/solidus_api.gemspec
+++ b/api/solidus_api.gemspec
@@ -5,6 +5,7 @@ Gem::Specification.new do |gem|
   gem.author        = 'Solidus Team'
   gem.email         = 'contact@solidus.io'
   gem.homepage      = 'http://solidus.io/'
+  gem.license       = 'BSD-3-Clause'
 
   gem.summary       = 'REST API for the Solidus e-commerce framework.'
   gem.description   = gem.summary

--- a/backend/solidus_backend.gemspec
+++ b/backend/solidus_backend.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |s|
   s.email       = 'contact@solidus.io'
   s.homepage    = 'http://solidus.io'
   s.license     = 'BSD-3-Clause'
-  s.rubyforge_project = 'solidus_backend'
 
   s.files        = `git ls-files`.split("\n")
   s.require_path = 'lib'

--- a/backend/solidus_backend.gemspec
+++ b/backend/solidus_backend.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |s|
   s.author      = 'Solidus Team'
   s.email       = 'contact@solidus.io'
   s.homepage    = 'http://solidus.io'
+  s.license     = 'BSD-3-Clause'
   s.rubyforge_project = 'solidus_backend'
 
   s.files        = `git ls-files`.split("\n")

--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.author      = 'Solidus Team'
   s.email       = 'contact@solidus.io'
   s.homepage    = 'http://solidus.io'
-  s.license     = 'BSD-3'
+  s.license     = 'BSD-3-Clause'
 
   s.files        = `git ls-files`.split("\n")
   s.require_path = 'lib'

--- a/frontend/solidus_frontend.gemspec
+++ b/frontend/solidus_frontend.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |s|
   s.author      = 'Solidus Team'
   s.email       = 'contact@solidus.io'
   s.homepage    = 'http://solidus.io/'
+  s.license     = 'BSD-3-Clause'
   s.rubyforge_project = 'solidus_frontend'
 
   s.files        = `git ls-files`.split("\n")

--- a/frontend/solidus_frontend.gemspec
+++ b/frontend/solidus_frontend.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |s|
   s.email       = 'contact@solidus.io'
   s.homepage    = 'http://solidus.io/'
   s.license     = 'BSD-3-Clause'
-  s.rubyforge_project = 'solidus_frontend'
 
   s.files        = `git ls-files`.split("\n")
   s.require_path = 'lib'

--- a/sample/solidus_sample.gemspec
+++ b/sample/solidus_sample.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.author      = 'Solidus Team'
   s.email       = 'contact@solidus.io'
   s.homepage    = 'http://solidus.io/'
-  s.license     = 'BSD-3'
+  s.license     = 'BSD-3-Clause'
 
   s.files        = `git ls-files`.split("\n")
   s.require_path = 'lib'

--- a/solidus.gemspec
+++ b/solidus.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.author       = 'Solidus Team'
   s.email        = 'contact@solidus.io'
   s.homepage     = 'http://solidus.io'
-  s.license      = 'BSD-3'
+  s.license      = 'BSD-3-Clause'
 
   s.add_dependency 'solidus_core', s.version
   s.add_dependency 'solidus_api', s.version


### PR DESCRIPTION
Previously we were using "BSD-3", but the correct SPDX ID is "BSD-3-CLAUSE". This fixes a warning rubygems emits when building gems.

Also removes the `rubyforge_project` option.

http://spdx.org/licenses/
http://spdx.org/licenses/BSD-3-Clause.html