### PR TITLE
Make user_factory safer for non-solidus_auth_devise users

### DIFF
--- a/core/lib/spree/testing_support/factories/user_factory.rb
+++ b/core/lib/spree/testing_support/factories/user_factory.rb
@@ -9,9 +9,9 @@ FactoryGirl.define do
 
   factory :user, class: Spree.user_class do
     email { generate(:random_email) }
-    login { email }
+    login { email } if Spree.user_class.attribute_method? :login
     password 'secret'
-    password_confirmation { password }
+    password_confirmation { password } if Spree.user_class.attribute_method? :password_confirmation
     authentication_token { generate(:user_authentication_token) } if Spree.user_class.attribute_method? :authentication_token
 
     trait :with_api_key do


### PR DESCRIPTION
Non-devise auth methods may not use a password_confirmation.
And custom auth methods likely won't use a `login` attribute, which
Solidus doesn't really use at all (uses email instead), it's just in there
cause devise requires it, and the default factory sets it to the same thing
as email.

`authentication_token` already had a guard clause to make sure the
model had such an attribute before factory-ing it. Add similar guard
clause to login and password_confirmation.

The user_factory is used indirectly by many other factories, so you
need a working user factory to use many factories. This change
makes things work cleaner for custom non-solidus_auth_devise auth,
with fewer unneccesary requirements.