### PR TITLE
Fix spec failures related to MySQL timestamps

### DIFF
--- a/api/spec/controllers/spree/api/orders_controller_spec.rb
+++ b/api/spec/controllers/spree/api/orders_controller_spec.rb
@@ -166,13 +166,13 @@ module Spree
       end
 
       it "returns orders in reverse chronological order by completed_at" do
-        order.update_columns completed_at: Time.current
+        order.update_columns completed_at: Time.current, created_at: 3.days.ago
 
-        order2 = Order.create user: order.user, completed_at: Time.current - 1.day, store: store
+        order2 = Order.create user: order.user, completed_at: Time.current - 1.day, created_at: 2.day.ago, store: store
         expect(order2.created_at).to be > order.created_at
-        order3 = Order.create user: order.user, completed_at: nil, store: store
+        order3 = Order.create user: order.user, completed_at: nil, created_at: 1.day.ago, store: store
         expect(order3.created_at).to be > order2.created_at
-        order4 = Order.create user: order.user, completed_at: nil, store: store
+        order4 = Order.create user: order.user, completed_at: nil, created_at: 0.days.ago, store: store
         expect(order4.created_at).to be > order3.created_at
 
         request.env['SERVER_NAME'] = store.url

--- a/core/spec/models/spree/adjustment_spec.rb
+++ b/core/spec/models/spree/adjustment_spec.rb
@@ -14,7 +14,8 @@ describe Spree::Adjustment, type: :model do
     let(:adjustment) { Spree::Adjustment.create(label: "Adjustment", amount: 5, order: order, adjustable: line_item) }
 
     it 'touches the adjustable' do
-      expect { adjustment.save }.to change { line_item.updated_at }
+      line_item.update_columns(updated_at: 1.day.ago)
+      expect { adjustment.save! }.to change { line_item.updated_at }
     end
   end
 

--- a/core/spec/models/spree/order_shipping_spec.rb
+++ b/core/spec/models/spree/order_shipping_spec.rb
@@ -30,7 +30,7 @@ describe Spree::OrderShipping do
 
     it "updates shipment.shipped_at" do
       Timecop.freeze do |now|
-        expect { subject }.to change { shipment.shipped_at }.from(nil).to(now)
+        expect { subject }.to change { shipment.shipped_at }.from(nil).to be_within(1.second).of(now)
       end
     end
 
@@ -40,7 +40,7 @@ describe Spree::OrderShipping do
         Timecop.freeze(future) do
           subject
         end
-      end.to change { order.updated_at }.from(order.updated_at).to(future)
+      end.to change { order.updated_at }.to be_within(1.second).of(future)
     end
   end
 

--- a/core/spec/models/spree/store_credit_spec.rb
+++ b/core/spec/models/spree/store_credit_spec.rb
@@ -838,10 +838,10 @@ describe Spree::StoreCredit do
     subject { store_credit.invalidate(invalidation_reason, invalidation_user) }
 
     it "sets the invalidated_at field to the current time" do
-      invalidated_at = Time.current
+      invalidated_at = 2.minutes.from_now
       Timecop.freeze(invalidated_at) do
         subject
-        expect(store_credit.invalidated_at).to eq invalidated_at
+        expect(store_credit.invalidated_at).to be_within(1.second).of invalidated_at
       end
     end
 


### PR DESCRIPTION
Since the upgrade to rails 5, some specs have failed on MySQL due to datetime fields not having decimal precision.

Rails 5 is smarter about casting these timestamp values, and they are rounded on the models even before reloading the value from the database.

This fixes the specs by ensuring all tests of `updated_at` are for more than one second of difference.