### PR TITLE
Show term and condition to user when required acceptance

### DIFF
--- a/frontend/app/assets/javascripts/spree/frontend/checkout.js.coffee
+++ b/frontend/app/assets/javascripts/spree/frontend/checkout.js.coffee
@@ -7,3 +7,11 @@
 Spree.disableSaveOnClick = ->
   ($ 'form.edit_order').submit ->
     ($ this).find(':submit, :image').attr('disabled', true).removeClass('primary').addClass 'disabled'
+
+Spree.ready ($) ->
+  termsCheckbox = ($ '#accept_terms_and_conditions')
+  termsCheckbox.change( () ->
+    submitBtn = $(this.closest('form')).find(':submit')
+    submitBtn.prop('disabled', !this.checked)
+    submitBtn.toggleClass('disabled', !this.checked)
+  )

--- a/frontend/app/assets/stylesheets/spree/frontend/screen.css.scss
+++ b/frontend/app/assets/stylesheets/spree/frontend/screen.css.scss
@@ -935,6 +935,14 @@ p[data-hook="use_billing"] {
   }
 }
 
+.terms_and_conditions {
+  .policy {
+    height: 100px;
+    width: 100%;
+    overflow: scroll;
+  }
+}
+
 /*--------------------------------------*/
 /* Cart
 /*--------------------------------------*/

--- a/frontend/app/assets/stylesheets/spree/frontend/screen.css.scss
+++ b/frontend/app/assets/stylesheets/spree/frontend/screen.css.scss
@@ -216,6 +216,16 @@ input[type= "reset"], button, a.button {
   }
 }
 
+input[type=button],
+input[type=submit],
+button {
+  &.disabled {
+    background:#ccc;
+    border-color: #ccc;
+    text-shadow:none;
+  }
+}
+
 input[type="checkbox"], label {
   vertical-align: middle;
 }

--- a/frontend/app/models/spree/frontend_configuration.rb
+++ b/frontend/app/models/spree/frontend_configuration.rb
@@ -1,5 +1,8 @@
 module Spree
   class FrontendConfiguration < Preferences::Configuration
     preference :locale, :string, default: Rails.application.config.i18n.default_locale
+
+    # Add your terms and conditions in app/views/spree/checkout/_terms_and_conditions.en.html.erb
+    preference :require_terms_and_conditions_acceptance, :boolean, default: false
   end
 end

--- a/frontend/app/views/spree/checkout/_confirm.html.erb
+++ b/frontend/app/views/spree/checkout/_confirm.html.erb
@@ -7,6 +7,19 @@
 <br />
 
 <div class="form-buttons" data-hook="buttons">
-  <%= submit_tag Spree.t(:place_order), :class => 'continue button primary' %>
+  <% Spree::Frontend::Config[:require_terms_and_conditions_acceptance].tap do |requires_acceptance| %>
+    <% if requires_acceptance %>
+      <div class="terms_and_conditions" data-hook="terms_and_conditions">
+        <div class="policy"><%= render partial: "spree/checkout/terms_and_conditions" %></div>
+        <%= check_box_tag :accept_terms_and_conditions, 'accepted', false %>
+        <%= label_tag :accept_terms_and_conditions, Spree.t(:agree_to_terms_of_service) %>
+      </div>
+    <% end %>
+
+    <%= submit_tag Spree.t(:place_order),
+      disabled: requires_acceptance,
+      class: "continue button primary #{ 'disabled' if requires_acceptance }" %>
+  <% end %>
+
   <script>Spree.disableSaveOnClick();</script>
 </div>

--- a/frontend/app/views/spree/checkout/_terms_and_conditions.en.html.erb
+++ b/frontend/app/views/spree/checkout/_terms_and_conditions.en.html.erb
@@ -1,0 +1,1 @@
+Put your terms and conditions here


### PR DESCRIPTION
When the preference `require_term_and_condition_acceptance` is true, the button
`place_order` is disable and over the button appear a textarea with
checkbox. The textarea contains the terms and conditions of checkout, and
is required to check the checkbox to remove disabled state from
`place_order` button, and procede to the next state.

rel #1196 
