### PR TITLE
Deprecate display_total as it's confusing

### DIFF
--- a/backend/app/helpers/spree/admin/adjustments_helper.rb
+++ b/backend/app/helpers/spree/admin/adjustments_helper.rb
@@ -24,7 +24,7 @@ module Spree
         parts = []
         parts << variant.product.name
         parts << "(#{variant.options_text})" if variant.options_text.present?
-        parts << line_item.display_total
+        parts << line_item.display_amount
         safe_join(parts, "<br />".html_safe)
       end
 

--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -88,6 +88,7 @@ module Spree
     # @return [Spree::Money] the amount of this line item
     alias money display_amount
     alias display_total display_amount
+    deprecate display_total: :display_amount, deprecator: Spree::Deprecation
 
     # Sets price and currency from a `Spree::Money` object
     #


### PR DESCRIPTION
Currently:
- `total` is currently an alias for `final_amount`.
- `display_total` is currently an alias for `display_amount`

This can create a lot of confusion as you would expect `display_xyz` to use `xyz`, but in this case it's using a totally different method.