### PR TITLE
Remove deprecated code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 *   Analytics trackers were removed from the admin panel; the extension
     `solidus_trackers` provides the same functionality
 
+*   Removals
+
+    * Removed deprecated method `Promotion#expired?` in favor of
+      `Promotion#inactive?`
+
 ## Solidus 2.0.0 (unreleased)
 
 *   Upgrade to rails 5.0

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -82,15 +82,6 @@ module Spree
       !active?
     end
 
-    def expired?
-      Spree::Deprecation.warn <<-WARN.squish, caller
-        #expired? is deprecated, and will be removed in Solidus 2.0.
-        Please use #inactive? instead.
-      WARN
-
-      inactive?
-    end
-
     def activate(order:, line_item: nil, user: nil, path: nil, promotion_code: nil)
       return unless self.class.order_activatable?(order)
 


### PR DESCRIPTION
In the deprecation warning we said we'd remove this in Solidus 2.0.

If instead we don't actually want to remove this yet, we should probably update the deprecation message.