### PR TITLE
Remove deprecated method Spree::TaxRate.adjust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 *   Analytics trackers were removed from the admin panel; the extension
     `solidus_trackers` provides the same functionality
 
+*   Removals
+
+    * Removed deprecated method `Spree::TaxRate.adjust` (not to be confused with
+      Spree::TaxRate#adjust) in favor of `Spree::Tax::OrderAdjuster`.
+
 ## Solidus 2.0.0 (unreleased)
 
 *   Upgrade to rails 5.0

--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -65,19 +65,6 @@ module Spree
     scope :for_zone, ->(zone) { where(zone_id: Spree::Zone.with_shared_members(zone).pluck(:id)) }
     scope :included_in_price, -> { where(included_in_price: true) }
 
-    # Create tax adjustments for some items that have the same tax zone.
-    #
-    # @deprecated Please use Spree::Tax::OrderAdjuster or Spree::Tax::ItemAdjuster instead.
-    #
-    # @param [Spree::Zone] order_tax_zone is the smalles applicable zone to the order's tax address
-    # @param [Array<Spree::LineItem,Spree::Shipment>] items to be adjusted
-    def self.adjust(order_tax_zone, items)
-      Spree::Deprecation.warn("Please use Spree::Tax::OrderAdjuster or Spree::Tax::ItemAdjuster instead", caller)
-      items.map do |item|
-        Spree::Tax::ItemAdjuster.new(item, rates_for_order_zone: for_zone(order_tax_zone)).adjust!
-      end
-    end
-
     # Creates necessary tax adjustments for the order.
     def adjust(order_tax_zone, item)
       amount = compute_amount(item)

--- a/core/spec/models/spree/tax_rate_spec.rb
+++ b/core/spec/models/spree/tax_rate_spec.rb
@@ -133,30 +133,6 @@ describe Spree::TaxRate, type: :model do
     end
   end
 
-  context ".adjust" do
-    let(:zone) { stub_model(Spree::Zone) }
-
-    context "with line items" do
-      let(:line_item) { stub_model(Spree::LineItem) }
-
-      it 'should emit a deprecation warning and call the item adjuster' do
-        expect(Spree::Deprecation).to receive(:warn)
-        expect(Spree::Tax::ItemAdjuster).to receive_message_chain(:new, :adjust!)
-        Spree::TaxRate.adjust(zone, [line_item])
-      end
-    end
-
-    context "with shipments" do
-      let(:shipment) { stub_model(Spree::Shipment) }
-
-      it 'should emit a deprecation warning and call the item adjuster' do
-        expect(Spree::Deprecation).to receive(:warn)
-        expect(Spree::Tax::ItemAdjuster).to receive_message_chain(:new, :adjust!)
-        Spree::TaxRate.adjust(zone, [shipment])
-      end
-    end
-  end
-
   describe "#adjust" do
     let(:taxable_address) { create(:address) }
     let(:order) { create(:order_with_line_items, ship_address: order_address) }


### PR DESCRIPTION
Not to be confused with Spree::TaxRate#adjust.

This will aid in the effort to perform tax calculations all at once
for an order.

See also https://github.com/solidusio/solidus/issues/1252