### PR TITLE
Calculate taxes in OrderContents instead of in a LineItem callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Solidus 2.1.0 (master, unreleased)
 
+*   Remove callback `Spree::LineItem.after_create :update_tax_charge`
+
+    Any code that creates `LineItem`s outside the context of OrderContents
+    should ensure that it calls `order.create_tax_charge!` after doing so.
+
+*   Mark `Spree::Tax::ItemAdjuster` as api-private
+
 *   Analytics trackers were removed from the admin panel; the extension
     `solidus_trackers` provides the same functionality
 

--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -31,8 +31,6 @@ module Spree
     validates :price, numericality: true
     validate :ensure_proper_currency
 
-    after_create :update_tax_charge
-
     after_save :update_inventory
 
     before_destroy :update_inventory
@@ -172,10 +170,6 @@ module Spree
 
     def destroy_inventory_units
       inventory_units.destroy_all
-    end
-
-    def update_tax_charge
-      Spree::Tax::ItemAdjuster.new(self).adjust!
     end
 
     def ensure_proper_currency

--- a/core/app/models/spree/tax/item_adjuster.rb
+++ b/core/app/models/spree/tax/item_adjuster.rb
@@ -1,3 +1,7 @@
+# @api private
+# @note This is a helper class for Tax::OrderAdjuster.  It is marked as api
+#   private because taxes should always be calculated on the entire order, so
+#   external code should call Tax::OrderAdjuster instead of Tax::ItemAdjuster.
 module Spree
   module Tax
     # Adjust a single taxable item (line item or shipment)

--- a/core/lib/spree/core/unreturned_item_charger.rb
+++ b/core/lib/spree/core/unreturned_item_charger.rb
@@ -24,6 +24,7 @@ module Spree
       new_order.associate_user!(@original_order.user) if @original_order.user
 
       add_exchange_variants_to_order
+      new_order.create_tax_charge!
       set_shipment_for_new_order
 
       new_order.update!

--- a/core/lib/spree/testing_support/factories/order_factory.rb
+++ b/core/lib/spree/testing_support/factories/order_factory.rb
@@ -45,6 +45,7 @@ FactoryGirl.define do
           create(:line_item, attributes)
         end
         order.line_items.reload
+        order.create_tax_charge!
 
         create(:shipment, order: order, cost: evaluator.shipment_cost, shipping_method: evaluator.shipping_method, stock_location: evaluator.stock_location)
         order.shipments.reload

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -35,41 +35,6 @@ describe Spree::LineItem, type: :model do
     end
   end
 
-  context "#create" do
-    let(:variant) { create(:variant) }
-
-    before do
-      create(:tax_rate, zone: order.tax_zone, tax_category: variant.tax_category)
-    end
-
-    context "when order has a tax zone" do
-      before do
-        expect(order.tax_zone).to be_present
-      end
-
-      it "creates a tax adjustment" do
-        order.contents.add(variant)
-        line_item = order.find_line_item_by_variant(variant)
-        expect(line_item.adjustments.tax.count).to eq(1)
-      end
-    end
-
-    context "when order does not have a tax zone" do
-      before do
-        order.bill_address = nil
-        order.ship_address = nil
-        order.save
-        expect(order.reload.tax_zone).to be_nil
-      end
-
-      it "does not create a tax adjustment" do
-        order.contents.add(variant)
-        line_item = order.find_line_item_by_variant(variant)
-        expect(line_item.adjustments.tax.count).to eq(0)
-      end
-    end
-  end
-
   describe 'line item creation' do
     let(:variant) { create :variant }
 

--- a/core/spec/models/spree/order_contents_spec.rb
+++ b/core/spec/models/spree/order_contents_spec.rb
@@ -2,12 +2,12 @@ require 'spec_helper'
 
 describe Spree::OrderContents, type: :model do
   let!(:store) { create :store }
-  let(:order) { Spree::Order.create }
+  let(:order) { create(:order) }
   let(:variant) { create(:variant) }
   let!(:stock_location) { variant.stock_locations.first }
   let(:stock_location_2) { create(:stock_location) }
 
-  subject { described_class.new(order) }
+  subject(:order_contents) { described_class.new(order) }
 
   context "#add" do
     context 'given quantity is not explicitly provided' do
@@ -94,6 +94,38 @@ describe Spree::OrderContents, type: :model do
         end
 
         include_context "discount changes order total"
+      end
+    end
+
+    describe 'tax calculations' do
+      let!(:zone) { create(:global_zone) }
+      let!(:tax_rate) do
+        create(:tax_rate, zone: zone, tax_category: variant.tax_category)
+      end
+
+      context 'when the order has a tax zone' do
+        before do
+          expect(order.tax_zone).to be_present
+        end
+
+        it 'creates a tax adjustment' do
+          order_contents.add(variant)
+          line_item = order.find_line_item_by_variant(variant)
+          expect(line_item.adjustments.tax.count).to eq(1)
+        end
+      end
+
+      context 'when the order does not have a tax zone' do
+        before do
+          order.update_attributes!(ship_address: nil, bill_address: nil)
+          expect(order.tax_zone).to be_nil
+        end
+
+        it 'creates a tax adjustment' do
+          order_contents.add(variant)
+          line_item = order.find_line_item_by_variant(variant)
+          expect(line_item.adjustments.tax.count).to eq(0)
+        end
       end
     end
   end
@@ -224,52 +256,9 @@ describe Spree::OrderContents, type: :model do
       }.to change { subject.order.total }
     end
 
-    context "given an order with existing addresses" do
-      let(:default_address) { create :address, state_code: "NY", zipcode: "17402" }
-      let(:order_with_address ) { create :order, ship_address: default_address, bill_address: default_address }
-
-      subject { described_class.new(order_with_address) }
-
-      context "when an address in a potentially different tax zone is supplied " do
-        let(:updated_address) { build :address, state_code: "AL",  zipcode: "64092" }
-
-        let(:params) do
-          { ship_address_attributes: updated_address.value_attributes, bill_address_attributes: updated_address.value_attributes }
-        end
-
-        it "updates tax adjustments" do
-          expect(subject.order).to receive(:create_tax_charge!)
-          subject.update_cart params
-        end
-      end
-
-      context "when an address in potentially the same tax zone is supplied" do
-        let(:updated_address) { build :address, state_code: "NY", zipcode: "17402", firstname: 'Robert' }
-
-        let(:params) do
-          { ship_address_attributes: updated_address.value_attributes, bill_address_attributes: updated_address.value_attributes }
-        end
-
-        it "does not updates tax adjustments" do
-          expect(subject.order).not_to receive(:create_tax_charge!)
-          subject.update_cart params
-        end
-      end
-    end
-
-    context "given an order with no existing addresses" do
-      context "when an address is supplied" do
-        let(:updated_address) { build :address, state_code: "CA", zipcode: "14902" }
-
-        let(:params) do
-          { ship_address_attributes: updated_address.attributes, bill_address_attributes: updated_address.value_attributes }
-        end
-
-        it "does not updates tax adjustments" do
-          expect(subject.order).not_to receive(:create_tax_charge!)
-          subject.update_cart params
-        end
-      end
+    it "updates tax adjustments" do
+      expect(subject.order).to receive(:create_tax_charge!)
+      subject.update_cart params
     end
 
     context "submits item quantity 0" do


### PR DESCRIPTION
And mark Tax::ItemAdjuster as api-private (to discourage stores &
extensions from calling it outside of the context of
Tax::OrderAdjuster).

This PR may result in a little more load because we're now calling
Tax::OrderAdjuster at some times when previously we would've just
called Tax::ItemAdjuster.

Also, we're now _always_ calling Tax::OrderAdjuster after
OrderContents#update_cart, instead of only when the location changes.

Benefits:
- It gets rid of an ActiveRecord callback
- It seems safer to call this in more cases
- It moves toward performing tax calculations at the order level
instead of at the line level.

See also https://github.com/solidusio/solidus/issues/1252