### PR TITLE
Bump deprecation to 2.1 for 1.4 and 2.0 branches

### DIFF
--- a/core/lib/spree/deprecation.rb
+++ b/core/lib/spree/deprecation.rb
@@ -1,3 +1,3 @@
 module Spree
-  Deprecation = ActiveSupport::Deprecation.new('2.0', 'Solidus')
+  Deprecation = ActiveSupport::Deprecation.new('2.1', 'Solidus')
 end


### PR DESCRIPTION
We're going to wait until 2.1 to remove the things that have been
deprecated in Solidus <= 1.4.

Note: This PR is against the v1.4 branch. We'll want to cherry pick
this into v2.0 as well.

See also https://github.com/solidusio/solidus/pull/1460.