### PR TITLE
Remove outdated comment in Tax::ItemAdjuster

### DIFF
--- a/core/app/models/spree/tax/item_adjuster.rb
+++ b/core/app/models/spree/tax/item_adjuster.rb
@@ -20,9 +20,6 @@ module Spree
       # Deletes all existing tax adjustments and creates new adjustments for all
       # (geographically and category-wise) applicable tax rates.
       #
-      # Creating the adjustments will also run the ItemAdjustments class and
-      # persist all taxation and promotion totals on the item.
-      #
       # @return [Array<Spree::Adjustment>] newly created adjustments
       def adjust!
         return unless order_tax_zone(order)


### PR DESCRIPTION
This was changed in #1389 and OrderUpdater must now be run to update
item and order totals.