### PR TITLE
Diable RuboCop Style/Next

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,6 +35,9 @@ Style/ClassAndModuleChildren:
 Style/GuardClause:
   Enabled: false
 
+Style/Next:
+  Enabled: false
+
 Style/WordArray:
   Enabled: false
 


### PR DESCRIPTION
This doesn't seem like a clear improvement to me:

![captura de tela 2016-09-22 as 14 16 34](https://cloud.githubusercontent.com/assets/23050/18764560/335439f2-80cf-11e6-9eac-40dbcf0c4705.png)
