### PR TITLE
Convert blank country_iso on prices to nil

### DIFF
--- a/core/app/models/spree/price.rb
+++ b/core/app/models/spree/price.rb
@@ -58,6 +58,10 @@ module Spree
       end
     end
 
+    def country_iso=(country_iso)
+      self[:country_iso] = country_iso.presence
+    end
+
     private
 
     def sum_of_vat_amounts

--- a/core/spec/models/spree/price_spec.rb
+++ b/core/spec/models/spree/price_spec.rb
@@ -55,6 +55,12 @@ describe Spree::Price, type: :model do
         it { is_expected.to be_valid }
       end
 
+      context 'when country iso is an empty string' do
+        let(:country_iso) { "" }
+
+        it { is_expected.to be_valid }
+      end
+
       context 'when country iso is a country code' do
         let!(:country) { create(:country, iso: "DE") }
         let(:country_iso) { "DE" }
@@ -66,6 +72,15 @@ describe Spree::Price, type: :model do
         let(:country_iso) { "ZZ" }
 
         it { is_expected.not_to be_valid }
+      end
+    end
+
+    describe "country_iso=" do
+      let(:price) { Spree::Price.new(country_iso: "de") }
+
+      it "assigns nil if passed nil" do
+        price.country_iso = nil
+        expect(price.country_iso).to be_nil
       end
     end
 


### PR DESCRIPTION
When adding a new price for a product in the admin panel using the
prices tab and not selecting a country for this price ("Any Country"),
the browser will send an empty string as country iso. In the backend,
the intention of this user action is for the price to be saved with a
`country_iso` of `nil`, indicating that it is a fallback price valid
for any country.

This commit converts an empty string `country_iso` to `nil` before
validation, allowing admin users to actually create a new price.

Fixes https://github.com/solidusio/solidus/issues/1453