### PR TITLE
Remove is_default Boolean from prices (rebased)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Solidus 2.1.0 (master, unreleased)
 
+*   Remove `is_default` boolean from `Spree::Price` model
+
+    This boolean used to mean "the price to be used". With the new
+    pricing architecture introduced in 1.3, it is now redundant and can be
+    reduced to an order clause in the currently valid prices scope.
+
 *   Remove callback `Spree::LineItem.after_create :update_tax_charge`
 
     Any code that creates `LineItem`s outside the context of OrderContents

--- a/core/app/models/spree/price.rb
+++ b/core/app/models/spree/price.rb
@@ -18,10 +18,9 @@ module Spree
     validates :currency, inclusion: { in: ::Money::Currency.all.map(&:iso_code), message: :invalid_code }
     validates :country, presence: true, unless: -> { for_any_country? }
 
-    scope :currently_valid, -> { where(is_default: true).order("country_iso IS NULL") }
+    scope :currently_valid, -> { order("country_iso IS NULL, updated_at DESC") }
     scope :for_any_country, -> { where(country: nil) }
     scope :with_default_attributes, -> { where(Spree::Config.default_pricing_options.desired_attributes) }
-    after_save :set_default_price
 
     extend DisplayMoney
     money_methods :amount, :price
@@ -67,13 +66,6 @@ module Spree
 
     def check_price
       self.currency ||= Spree::Config[:currency]
-    end
-
-    def set_default_price
-      if is_default?
-        other_default_prices = variant.prices.currently_valid.where(pricing_options.desired_attributes).where.not(id: id)
-        other_default_prices.update_all(is_default: false)
-      end
     end
 
     def pricing_options

--- a/core/db/migrate/20160924135758_remove_is_default_from_prices.rb
+++ b/core/db/migrate/20160924135758_remove_is_default_from_prices.rb
@@ -1,0 +1,5 @@
+class RemoveIsDefaultFromPrices < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :spree_prices, :is_default, :boolean, default: true
+  end
+end

--- a/core/spec/models/spree/price_spec.rb
+++ b/core/spec/models/spree/price_spec.rb
@@ -71,7 +71,7 @@ describe Spree::Price, type: :model do
 
     describe '#country' do
       let!(:country) { create(:country, iso: "DE") }
-      let(:price) { create(:price, country_iso: "DE", is_default: false) }
+      let(:price) { create(:price, country_iso: "DE") }
 
       it 'returns the country object' do
         expect(price.country).to eq(country)

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -208,9 +208,7 @@ describe Spree::Variant, type: :model do
       let(:pricing_options_germany) { Spree::Config.pricing_options_class.new(currency: "EUR") }
       let(:pricing_options_united_states) { Spree::Config.pricing_options_class.new(currency: "USD") }
       before do
-        variant.prices << create(:price, variant: variant, currency: "USD", amount: 12.12, is_default: false)
-        variant.prices << create(:price, variant: variant, currency: "EUR", amount: 29.99)
-        variant.prices << create(:price, variant: variant, currency: "EUR", amount: 10.00, is_default: false)
+        variant.prices.create(currency: "EUR", amount: 29.99)
         variant.reload
       end
 
@@ -227,7 +225,7 @@ describe Spree::Variant, type: :model do
     context "when adding multiple prices" do
       it "it can reassign a default price" do
         expect(variant.default_price.amount).to eq(19.99)
-        variant.prices << create(:price, variant: variant, currency: "USD", amount: 12.12)
+        variant.prices.create(currency: "USD", amount: 12.12)
         expect(variant.reload.default_price.amount).to eq(12.12)
       end
     end


### PR DESCRIPTION
This boolean is either a very bare-bones version of `acts_as_paranoid` or
a very bare-bones version of `papertrail`. However: It's really badly named,
as `is_default` is not something I understand very well at all. It probably means
"the price to be used in the backend and mostly in the frontend too".

We can accomplish the same behavior by simply using an `order` clause in
the `currently_valid` scope on prices.

This PR is #1182 rebased.