### PR TITLE
Fix for repair adjustments code

### DIFF
--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -184,7 +184,7 @@ module Spree
     end
 
     def repair_adjustments_associations_on_create
-      if adjustable.adjustments.loaded? && !adjustable.adjustments.include?(self)
+      if adjustable.adjustments.loaded? && !adjustable.adjustments.include?(self) && Spree::Adjustment.exists?(id)
         Spree::Deprecation.warn("Adjustment #{id} was not added to #{adjustable.class} #{adjustable.id}. Add adjustments via `adjustable.adjustments.create!`. Partial call stack: #{caller.select { |line| line =~ %r(/(app|spec)/) }}.", caller)
         adjustable.adjustments.proxy_association.add_to_target(self)
       end

--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -185,14 +185,14 @@ module Spree
 
     def repair_adjustments_associations_on_create
       if adjustable.adjustments.loaded? && !adjustable.adjustments.include?(self)
-        Spree::Deprecation.warn("Adjustment was not added to #{adjustable.class}. Add adjustments via `adjustable.adjustments.create!`. Partial call stack: #{caller.select { |line| line =~ %r(/(app|spec)/) }}.", caller)
+        Spree::Deprecation.warn("Adjustment #{id} was not added to #{adjustable.class} #{adjustable.id}. Add adjustments via `adjustable.adjustments.create!`. Partial call stack: #{caller.select { |line| line =~ %r(/(app|spec)/) }}.", caller)
         adjustable.adjustments.proxy_association.add_to_target(self)
       end
     end
 
     def repair_adjustments_associations_on_destroy
       if adjustable.adjustments.loaded? && adjustable.adjustments.include?(self)
-        Spree::Deprecation.warn("Adjustment was not removed from #{adjustable.class}. Remove adjustments via `adjustable.adjustments.destroy`. Partial call stack: #{caller.select { |line| line =~ %r(/(app|spec)/) }}.", caller)
+        Spree::Deprecation.warn("Adjustment #{id} was not removed from #{adjustable.class} #{adjustable.id}. Remove adjustments via `adjustable.adjustments.destroy`. Partial call stack: #{caller.select { |line| line =~ %r(/(app|spec)/) }}.", caller)
         adjustable.adjustments.proxy_association.target.delete(self)
       end
     end

--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -184,7 +184,7 @@ module Spree
     end
 
     def repair_adjustments_associations_on_create
-      if adjustable.adjustments.loaded? && !adjustable.adjustments.include?(self) && Spree::Adjustment.exists?(id)
+      if adjustable.adjustments.loaded? && !adjustable.adjustments.include?(self) && !destroyed?
         Spree::Deprecation.warn("Adjustment #{id} was not added to #{adjustable.class} #{adjustable.id}. Add adjustments via `adjustable.adjustments.create!`. Partial call stack: #{caller.select { |line| line =~ %r(/(app|spec)/) }}.", caller)
         adjustable.adjustments.proxy_association.add_to_target(self)
       end

--- a/core/spec/models/spree/adjustment_spec.rb
+++ b/core/spec/models/spree/adjustment_spec.rb
@@ -267,7 +267,7 @@ describe Spree::Adjustment, type: :model do
         end
 
         context 'when adjustable.adjustments is not loaded' do
-          it 'does repair' do
+          it 'does not repair' do
             expect(Spree::Deprecation).not_to receive(:warn)
             adjustment.destroy!
           end

--- a/core/spec/models/spree/adjustment_spec.rb
+++ b/core/spec/models/spree/adjustment_spec.rb
@@ -193,6 +193,16 @@ describe Spree::Adjustment, type: :model do
             adjustment = create_adjustment
             expect(adjustable.adjustments).to include(adjustment)
           end
+
+          context 'when the adjustment is destroyed before after_commit runs' do
+            it 'does not repair' do
+              expect(Spree::Deprecation).not_to receive(:warn)
+              Spree::Adjustment.transaction do
+                adjustment = create_adjustment
+                adjustment.destroy!
+              end
+            end
+          end
         end
 
         context 'when adjustable.adjustments is not loaded' do


### PR DESCRIPTION
Fix for Adjustment#repair_adjustments_associations_on_create

When the item gets deleted before after_commit runs.

I ran into this while working on some changes where some tax
adjustments would get created and destroyed in the same transaction.

Also add specs for this code.
See individual commits.

Is this worth adding to the 2.0 & 1.4 branches as well?