### PR TITLE
Enabled bootstrap classes

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/_bootstrap_custom.scss
+++ b/backend/app/assets/stylesheets/spree/backend/_bootstrap_custom.scss
@@ -49,7 +49,7 @@ $enable-shadows:            false !default;
 $enable-gradients:          false !default;
 $enable-transitions:        false !default;
 $enable-hover-media-query:  false !default;
-$enable-grid-classes:       false !default;
+$enable-grid-classes:       true !default;
 
 
 // Spacing

--- a/backend/app/assets/stylesheets/spree/backend/sections/_products.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/_products.scss
@@ -1,20 +1,3 @@
-[data-hook="admin_products_index_search"] {
-  @include make-row();
-
-  > * {
-    @include make-col();
-    @include padding(0 null); // override the padding on .field
-  }
-}
-
-.product-search-field-name {
-  @include make-col-span(6);
-}
-
-.product-search-field-sku {
-  @include make-col-span(4);
-}
-
 .product-search-field-show-deleted.field.checkbox {
   // extra specificity to override styles
   @include make-col-span(2);

--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -1,174 +1,187 @@
 <div data-hook="admin_product_form_fields">
 
-  <div class="left twelve columns alpha" data-hook="admin_product_form_left">
-    <div data-hook="admin_product_form_name">
-      <%= f.field_container :name do %>
-        <%= f.label :name, class: 'required' %>
-        <%= f.text_field :name, :class => 'fullwidth title', :required => true %>
-        <%= f.error_message_on :name %>
-      <% end %>
+  <div class="row">
+
+    <div class="left col-xs-9" data-hook="admin_product_form_left">
+      <div data-hook="admin_product_form_name">
+        <%= f.field_container :name do %>
+          <%= f.label :name, class: 'required' %>
+          <%= f.text_field :name, :class => 'fullwidth title', :required => true %>
+          <%= f.error_message_on :name %>
+        <% end %>
+      </div>
+
+      <div data-hook="admin_product_form_slug">
+        <%= f.field_container :slug do %>
+          <%= f.label :slug, class: 'required' %>
+          <%= f.text_field :slug, :class => 'fullwidth title', :required => true %>
+          <%= f.error_message_on :slug %>
+        <% end %>
+      </div>
+
+      <div data-hook="admin_product_form_description">
+        <%= f.field_container :description do %>
+          <%= f.label :description %>
+          <%= f.text_area :description, {:rows => "#{unless @product.has_variants? then '22' else '15' end}", :class => 'fullwidth'} %>
+          <%= f.error_message_on :description %>
+        <% end %>
+      </div>
     </div>
 
-    <div data-hook="admin_product_form_slug">
-      <%= f.field_container :slug do %>
-        <%= f.label :slug, class: 'required' %>
-        <%= f.text_field :slug, :class => 'fullwidth title', :required => true %>
-        <%= f.error_message_on :slug %>
+    <div class="right col-xs-3" data-hook="admin_product_form_right">
+      <div data-hook="admin_product_form_price">
+        <%= f.field_container :price do %>
+          <%= f.label :price, class: 'required' %>
+          <%= f.text_field :price, :value => number_to_currency(@product.price, :unit => ''), :required => true %>
+          <%= f.error_message_on :price %>
+        <% end %>
+      </div>
+
+      <% if show_rebuild_vat_checkbox? %>
+        <%= render "spree/admin/shared/rebuild_vat_prices_checkbox", form: f, model_name: "product"%>
+        <div class="clearfix"></div>
       <% end %>
+
+      <div class="row">
+
+        <div data-hook="admin_product_form_cost_price" class="col-xs-6">
+          <%= f.field_container :cost_price do %>
+            <%= f.label :cost_price %>
+            <%= f.text_field :cost_price, :value => number_to_currency(@product.cost_price, :unit => '') %>
+            <%= f.error_message_on :cost_price %>
+          <% end %>
+        </div>
+
+        <div data-hook="admin_product_form_cost_currency" class="col-xs-6">
+          <%= f.field_container :cost_currency do %>
+            <%= f.label :cost_currency %>
+            <%= f.text_field :cost_currency %>
+            <%= f.error_message_on :cost_currency %>
+          <% end %>
+        </div>
+
+      </div>
+
+      <div class="clear"></div>
+
+      <div data-hook="admin_product_form_available_on">
+        <%= f.field_container :available_on do %>
+          <%= f.label :available_on %>
+          <%= f.error_message_on :available_on %>
+          <%= f.text_field :available_on, :value => datepicker_field_value(@product.available_on), :class => 'datepicker' %>
+        <% end %>
+      </div>
+
+      <div data-hook="admin_product_form_promotionable">
+        <%= f.field_container :promotionable do %>
+          <%= f.label :promotionable do %>
+            <%= f.check_box :promotionable %> <%= Spree::Product.human_attribute_name(:promotionable) %>
+          <% end %>
+          <%= f.field_hint :promotionable %>
+        <% end %>
+      </div>
+
+      <% if @product.has_variants? %>
+        <div data-hook="admin_product_form_multiple_variants">
+          <%= f.label :skus, Spree.t(:skus) %>
+          <span class="info">
+            <%= Spree.t(:info_product_has_multiple_skus, count: @product.variants.count) %>
+            <ul class="text_list">
+              <% @product.variants.first(5).each do |variant| %>
+                <li><%= link_to variant.sku, spree.edit_admin_product_variant_path(@product, variant) %></li>
+              <% end %>
+            </ul>
+            <% if @product.variants.count > 5 %>
+              <%= Spree.t(:info_number_of_skus_not_shown, count: @product.variants.count - 5) %>
+            <% end %>
+          </span>
+          <div class="info-actions">
+            <% if can?(:admin, Spree::Variant) %>
+              <%= link_to_with_icon 'th-large', Spree.t(:manage_variants), admin_product_variants_url(@product) %>
+            <% end %>
+          </div>
+        </div>
+      <% else %>
+        <div data-hook="admin_product_form_sku">
+          <%= f.field_container :sku do %>
+            <%= f.label :sku, Spree::Variant.human_attribute_name(:sku) %>
+            <%= f.text_field :sku, :size => 16 %>
+          <% end %>
+        </div>
+
+        <div id="shipping_specs" class="row">
+          <% [:height, :width, :depth, :weight].each_with_index do |field, index| %>
+            <div id="shipping_specs_<%= field %>_field" class="col-xs-6">
+              <%= f.label field %>
+              <%= f.text_field field, value: number_with_precision(@product.send(field), precision: 2) %>
+            </div>
+          <% end %>
+        </div>
+
+      <% end %>
+
+      <div data-hook="admin_product_form_shipping_categories">
+        <%= f.field_container :shipping_categories do %>
+          <%= f.label :shipping_category_id, Spree::ShippingCategory.model_name.human %>
+          <%= f.field_hint :shipping_category %>
+          <%= f.collection_select(:shipping_category_id, @shipping_categories, :id, :name, { :include_blank => Spree.t('match_choices.none') }, { :class => 'select2' }) %>
+          <%= f.error_message_on :shipping_category %>
+        <% end %>
+      </div>
+
+      <div data-hook="admin_product_form_tax_category">
+        <%= f.field_container :tax_category do %>
+          <%= f.label :tax_category_id, Spree::TaxCategory.model_name.human %>
+          <%= f.field_hint :tax_category %>
+          <%= f.collection_select(:tax_category_id, @tax_categories, :id, :name, { :include_blank => Spree.t('match_choices.none') }, { :class => 'select2' }) %>
+          <%= f.error_message_on :tax_category %>
+        <% end %>
+      </div>
     </div>
 
-    <div data-hook="admin_product_form_description">
-      <%= f.field_container :description do %>
-        <%= f.label :description %>
-        <%= f.text_area :description, {:rows => "#{unless @product.has_variants? then '22' else '15' end}", :class => 'fullwidth'} %>
-        <%= f.error_message_on :description %>
-      <% end %>
-    </div>
   </div>
 
-  <div class="right four columns omega" data-hook="admin_product_form_right">
-    <div data-hook="admin_product_form_price" class="alpha omega four columns">
-      <%= f.field_container :price do %>
-        <%= f.label :price, class: 'required' %>
-        <%= f.text_field :price, :value => number_to_currency(@product.price, :unit => ''), :required => true %>
-        <%= f.error_message_on :price %>
-      <% end %>
-    </div>
+  <div class="row">
 
-    <% if show_rebuild_vat_checkbox? %>
-      <%= render "spree/admin/shared/rebuild_vat_prices_checkbox", form: f, model_name: "product", wrapper_class: "alpha omega field four columns" %>
-      <div class="clearfix"></div>
-    <% end %>
-
-    <div data-hook="admin_product_form_cost_price" class="alpha two columns">
-      <%= f.field_container :cost_price do %>
-        <%= f.label :cost_price %>
-        <%= f.text_field :cost_price, :value => number_to_currency(@product.cost_price, :unit => '') %>
-        <%= f.error_message_on :cost_price %>
-      <% end %>
-    </div>
-
-    <div data-hook="admin_product_form_cost_currency" class="omega two columns">
-      <%= f.field_container :cost_currency do %>
-        <%= f.label :cost_currency %>
-        <%= f.text_field :cost_currency %>
-        <%= f.error_message_on :cost_currency %>
-      <% end %>
-    </div>
-
-    <div class="clear"></div>
-
-    <div data-hook="admin_product_form_available_on">
-      <%= f.field_container :available_on do %>
-        <%= f.label :available_on %>
-        <%= f.error_message_on :available_on %>
-        <%= f.text_field :available_on, :value => datepicker_field_value(@product.available_on), :class => 'datepicker' %>
-      <% end %>
-    </div>
-
-    <div data-hook="admin_product_form_promotionable">
-      <%= f.field_container :promotionable do %>
-        <%= f.label :promotionable do %>
-          <%= f.check_box :promotionable %> <%= Spree::Product.human_attribute_name(:promotionable) %>
+    <div class="col-xs-9">
+      <div data-hook="admin_product_form_taxons">
+        <%= f.field_container :taxons do %>
+          <%= f.label :taxon_ids, plural_resource_name(Spree::Taxon) %><br />
+          <%= f.hidden_field :taxon_ids, :value => @product.taxon_ids.join(',') %>
         <% end %>
-        <%= f.field_hint :promotionable %>
-      <% end %>
-    </div>
+      </div>
 
-    <% if @product.has_variants? %>
-      <div data-hook="admin_product_form_multiple_variants">
-        <%= f.label :skus, Spree.t(:skus) %>
-        <span class="info">
-          <%= Spree.t(:info_product_has_multiple_skus, count: @product.variants.count) %>
-          <ul class="text_list">
-            <% @product.variants.first(5).each do |variant| %>
-              <li><%= link_to variant.sku, spree.edit_admin_product_variant_path(@product, variant) %></li>
-            <% end %>
-          </ul>
-          <% if @product.variants.count > 5 %>
-            <%= Spree.t(:info_number_of_skus_not_shown, count: @product.variants.count - 5) %>
+      <div data-hook="admin_product_form_option_types">
+        <%= f.field_container :option_types do %>
+          <%= f.label :option_type_ids, plural_resource_name(Spree::OptionType) %>
+          <%= f.hidden_field :option_type_ids, :value => @product.option_type_ids.join(',') %>
+        <% end %>
+      </div>
+
+      <div data-hook="admin_product_form_meta">
+        <div data-hook="admin_product_form_meta_title">
+          <%= f.field_container :meta_title do %>
+            <%= f.label :meta_title %>
+            <%= f.text_field :meta_title, :class => 'fullwidth' %>
           <% end %>
-        </span>
-        <div class="info-actions">
-          <% if can?(:admin, Spree::Variant) %>
-            <%= link_to_with_icon 'th-large', Spree.t(:manage_variants), admin_product_variants_url(@product) %>
+        </div>
+
+        <div data-hook="admin_product_form_meta_keywords">
+          <%= f.field_container :meta_keywords do %>
+            <%= f.label :meta_keywords %>
+            <%= f.text_field :meta_keywords, :class => 'fullwidth' %>
+          <% end %>
+        </div>
+
+        <div data-hook="admin_product_form_meta_description">
+          <%= f.field_container :meta_description do %>
+            <%= f.label :meta_description %>
+            <%= f.text_field :meta_description, :class => 'fullwidth' %>
           <% end %>
         </div>
       </div>
-    <% else %>
-      <div data-hook="admin_product_form_sku">
-        <%= f.field_container :sku do %>
-          <%= f.label :sku, Spree::Variant.human_attribute_name(:sku) %>
-          <%= f.text_field :sku, :size => 16 %>
-        <% end %>
-      </div>
-
-      <div id="shipping_specs">
-        <% [:height, :width, :depth, :weight].each_with_index do |field, index| %>
-          <div id="shipping_specs_<%= field %>_field" class="field two columns <%= index.even? ? 'alpha' : 'omega' %>">
-            <%= f.label field %>
-            <%= f.text_field field, value: number_with_precision(@product.send(field), precision: 2) %>
-          </div>
-        <% end %>
-      </div>
-    <% end %>
-
-    <div data-hook="admin_product_form_shipping_categories">
-      <%= f.field_container :shipping_categories do %>
-        <%= f.label :shipping_category_id, Spree::ShippingCategory.model_name.human %>
-        <%= f.field_hint :shipping_category %>
-        <%= f.collection_select(:shipping_category_id, @shipping_categories, :id, :name, { :include_blank => Spree.t('match_choices.none') }, { :class => 'select2' }) %>
-        <%= f.error_message_on :shipping_category %>
-      <% end %>
     </div>
 
-    <div data-hook="admin_product_form_tax_category">
-      <%= f.field_container :tax_category do %>
-        <%= f.label :tax_category_id, Spree::TaxCategory.model_name.human %>
-        <%= f.field_hint :tax_category %>
-        <%= f.collection_select(:tax_category_id, @tax_categories, :id, :name, { :include_blank => Spree.t('match_choices.none') }, { :class => 'select2' }) %>
-        <%= f.error_message_on :tax_category %>
-      <% end %>
-    </div>
-  </div>
-
-  <div class="twelve columns alpha omega">
-    <div data-hook="admin_product_form_taxons">
-      <%= f.field_container :taxons do %>
-        <%= f.label :taxon_ids, plural_resource_name(Spree::Taxon) %><br />
-        <%= f.hidden_field :taxon_ids, :value => @product.taxon_ids.join(',') %>
-      <% end %>
-    </div>
-
-    <div data-hook="admin_product_form_option_types">
-      <%= f.field_container :option_types do %>
-        <%= f.label :option_type_ids, plural_resource_name(Spree::OptionType) %>
-        <%= f.hidden_field :option_type_ids, :value => @product.option_type_ids.join(',') %>
-      <% end %>
-    </div>
-  </div>
-
-  <div data-hook="admin_product_form_meta" class="alpha omega twelve columns">
-    <div data-hook="admin_product_form_meta_title">
-      <%= f.field_container :meta_title do %>
-        <%= f.label :meta_title %>
-        <%= f.text_field :meta_title, :class => 'fullwidth' %>
-      <% end %>
-    </div>
-
-    <div data-hook="admin_product_form_meta_keywords">
-      <%= f.field_container :meta_keywords do %>
-        <%= f.label :meta_keywords %>
-        <%= f.text_field :meta_keywords, :class => 'fullwidth' %>
-      <% end %>
-    </div>
-
-    <div data-hook="admin_product_form_meta_description">
-      <%= f.field_container :meta_description do %>
-        <%= f.label :meta_description %>
-        <%= f.text_field :meta_description, :class => 'fullwidth' %>
-      <% end %>
-    </div>
   </div>
 
   <div class="clear"></div>
@@ -180,6 +193,6 @@
 
 <% unless Rails.env.test? %>
   <script>
-  $('.select2-container').css({width: '20em'})
+$('.select2-container').css({width: '20em'})
   </script>
 <% end %>

--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -112,8 +112,10 @@
         <div id="shipping_specs" class="row">
           <% [:height, :width, :depth, :weight].each_with_index do |field, index| %>
             <div id="shipping_specs_<%= field %>_field" class="col-xs-6">
-              <%= f.label field %>
-              <%= f.text_field field, value: number_with_precision(@product.send(field), precision: 2) %>
+              <div class="field">
+                <%= f.label field %>
+                <%= f.text_field field, value: number_with_precision(@product.send(field), precision: 2) %>
+              </div>
             </div>
           <% end %>
         </div>

--- a/backend/app/views/spree/admin/products/index.html.erb
+++ b/backend/app/views/spree/admin/products/index.html.erb
@@ -16,18 +16,18 @@
   <div data-hook="admin_products_sidebar">
     <%= search_form_for [:admin, @search] do |f| %>
         <%- locals = {:f => f} %>
-        <div data-hook="admin_products_index_search">
-          <div class="product-search-field-name field">
+        <div class="row" data-hook="admin_products_index_search">
+          <div class="col-xs-6 field">
             <%= f.label :name_cont, Spree::Product.human_attribute_name(:name) %>
             <%= f.text_field :name_cont, :size => 15 %>
           </div>
 
-          <div class="product-search-field-sku field">
+          <div class="col-xs-4 field">
             <%= f.label :variants_including_master_sku_cont, Spree::Variant.human_attribute_name(:sku) %>
             <%= f.text_field :variants_including_master_sku_cont, :size => 15 %>
           </div>
 
-          <div class="product-search-field-show-deleted field checkbox">
+          <div class="col-xs-2 field checkbox">
             <label>
               <%= f.check_box :deleted_at_null, {:checked => params[:q][:deleted_at_null] == '0'}, '0', '1' %>
               <%= Spree.t(:show_deleted) %>
@@ -82,7 +82,7 @@
     </tbody>
   </table>
 <% else %>
-  <div class="alpha twelve columns no-objects-found">
+  <div class="col-xs-9 no-objects-found">
     <%= render 'spree/admin/shared/no_objects_found',
                   resource: Spree::Product,
                   new_resource_url: new_object_url %>

--- a/backend/app/views/spree/admin/products/index.html.erb
+++ b/backend/app/views/spree/admin/products/index.html.erb
@@ -16,22 +16,28 @@
   <div data-hook="admin_products_sidebar">
     <%= search_form_for [:admin, @search] do |f| %>
         <%- locals = {:f => f} %>
-        <div class="row" data-hook="admin_products_index_search">
-          <div class="col-xs-6 field">
-            <%= f.label :name_cont, Spree::Product.human_attribute_name(:name) %>
-            <%= f.text_field :name_cont, :size => 15 %>
+        <div class="row" data-hook="admin_products_index_search" >
+          <div class="col-xs-6">
+            <div class="field">
+              <%= f.label :name_cont, Spree::Product.human_attribute_name(:name) %>
+              <%= f.text_field :name_cont, :size => 15 %>
+            </div>
           </div>
 
-          <div class="col-xs-4 field">
-            <%= f.label :variants_including_master_sku_cont, Spree::Variant.human_attribute_name(:sku) %>
-            <%= f.text_field :variants_including_master_sku_cont, :size => 15 %>
+          <div class="col-xs-4">
+            <div class="field">
+              <%= f.label :variants_including_master_sku_cont, Spree::Variant.human_attribute_name(:sku) %>
+              <%= f.text_field :variants_including_master_sku_cont, :size => 15 %>
+            </div>
           </div>
 
-          <div class="col-xs-2 field checkbox">
-            <label>
-              <%= f.check_box :deleted_at_null, {:checked => params[:q][:deleted_at_null] == '0'}, '0', '1' %>
-              <%= Spree.t(:show_deleted) %>
-            </label>
+          <div class="col-xs-2">
+            <div class="field checkbox">
+              <label>
+                <%= f.check_box :deleted_at_null, {:checked => params[:q][:deleted_at_null] == '0'}, '0', '1' %>
+                <%= Spree.t(:show_deleted) %>
+              </label>
+            </div>
           </div>
         </div>
 

--- a/backend/app/views/spree/admin/products/new.html.erb
+++ b/backend/app/views/spree/admin/products/new.html.erb
@@ -14,7 +14,7 @@
 
     <div data-hook="new_product_attrs" class="row">
       <% unless @product.has_variants? %>
-        <div data-hook="new_product_sku" class="alpha four columns">
+        <div data-hook="new_product_sku" class="col-xs-3">
           <%= f.field_container :sku do %>
             <%= f.label :sku, Spree.t(:sku) %><br />
             <%= f.text_field :sku, :size => 16, :class => 'fullwidth' %>
@@ -23,14 +23,14 @@
         </div>
       <% end %>
 
-      <div data-hook="new_product_prototype" class="four columns">
+      <div data-hook="new_product_prototype" class="col-xs-3">
         <%= f.field_container :prototype do %>
           <%= f.label :prototype_id, Spree::Prototype.model_name.human %><br />
           <%= f.collection_select :prototype_id, Spree::Prototype.all, :id, :name, {:include_blank => true}, {:class => 'select2 fullwidth'} %>
         <% end %>
       </div>
 
-      <div data-hook="new_product_price" class="four columns">
+      <div data-hook="new_product_price" class="col-xs-3">
         <%= f.field_container :price do %>
           <%= f.label :price, class: 'required' %><br />
           <%= f.text_field :price, :value => number_to_currency(@product.price, :unit => ''), :class => 'fullwidth', :required => true %>
@@ -38,7 +38,7 @@
         <% end %>
       </div>
 
-      <div data-hook="new_product_available_on" class="omega four columns">
+      <div data-hook="new_product_available_on" class="col-xs-3">
         <%= f.field_container :available_on do %>
           <%= f.label :available_on %>
           <%= f.error_message_on :available_on %>
@@ -49,7 +49,7 @@
     </div>
 
     <div class='row'>
-      <div data-hook="new_product_shipping_category" class="alpha field four columns">
+      <div data-hook="new_product_shipping_category" class="col-xs-3">
         <%= f.field_container :shipping_category do %>
           <%= f.label :shipping_category_id, Spree::ShippingCategory.
                 model_name.human, class: 'required' %>
@@ -59,7 +59,7 @@
         <% end %>
       </div>
 
-      <div data-hook="new_product_tax_category" class="field four columns">
+      <div data-hook="new_product_tax_category" class="col-xs-3">
         <%= f.field_container :tax_category do %>
           <%= f.label :tax_category_id, Spree::TaxCategory.model_name.human %>
           <%= f.field_hint :tax_category %>


### PR DESCRIPTION
This pull request enables bootstrap-grid-classes in order to facilitate moving from skeleton grid classes to the bootstrap grid system in solidus/backend admin views.