### PR TITLE
Cleanup verification value on assignment

### DIFF
--- a/core/app/models/spree/credit_card.rb
+++ b/core/app/models/spree/credit_card.rb
@@ -13,10 +13,8 @@ module Spree
 
     accepts_nested_attributes_for :address
 
-    attr_reader :number
-    attr_accessor :encrypted_data,
-                    :imported,
-                    :verification_value
+    attr_reader :number, :verification_value
+    attr_accessor :encrypted_data, :imported
 
     validates :month, :year, numericality: { only_integer: true }, if: :require_card_numbers?, on: :create
     validates :number, presence: true, if: :require_card_numbers?, on: :create, unless: :imported
@@ -72,6 +70,10 @@ module Spree
         end
     end
 
+    def verification_value=(value)
+      @verification_value = value.to_s.gsub(/\s/, '')
+    end
+
     # Sets the credit card type, converting it to the preferred internal
     # representation from jquery.payment's representation when appropriate.
     #
@@ -90,7 +92,6 @@ module Spree
 
     # Sets the last digits field based on the assigned credit card number.
     def set_last_digits
-      verification_value.to_s.gsub!(/\s/, '')
       self.last_digits ||= number.to_s.length <= 4 ? number : number.to_s.slice(-4..-1)
     end
 

--- a/core/spec/models/spree/credit_card_spec.rb
+++ b/core/spec/models/spree/credit_card_spec.rb
@@ -160,6 +160,28 @@ describe Spree::CreditCard, type: :model do
     end
   end
 
+  describe "#verification_value=" do
+    it "accepts a valid 3-digit value" do
+      credit_card.verification_value = "123"
+      expect(credit_card.verification_value).to eq("123")
+    end
+
+    it "accepts a valid 4-digit value" do
+      credit_card.verification_value = "1234"
+      expect(credit_card.verification_value).to eq("1234")
+    end
+
+    it "stringifies an integer" do
+      credit_card.verification_value = 123
+      expect(credit_card.verification_value).to eq("123")
+    end
+
+    it "strips any whitespace" do
+      credit_card.verification_value = ' 1 2  3 '
+      expect(credit_card.verification_value).to eq('123')
+    end
+  end
+
   # Regression test for https://github.com/spree/spree/issues/3847 and https://github.com/spree/spree/issues/3896
   describe "#expiry=" do
     it "can set with a 2-digit month and year" do
@@ -299,7 +321,7 @@ describe Spree::CreditCard, type: :model do
       expect(am_card.month).to eq(Time.current.month)
       expect(am_card.first_name).to eq("Ludwig")
       expect(am_card.last_name).to eq("van Beethoven")
-      expect(am_card.verification_value).to eq(123)
+      expect(am_card.verification_value).to eq("123")
     end
   end
 


### PR DESCRIPTION
Instead of performing the cleanup in `set_last_digits`, convert to a string and strip whitespace in `verification_value=`. This avoids mutating the value assigned to `verification_value=`.