### PR TITLE
Add Tax extension point and merge tax updating code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Solidus 2.1.0 (master, unreleased)
 
+*   Added Spree::Config.tax_adjuster_class
+
+    To allow easier customization of tax calculation in extensions or
+    applications.
+
+    https://github.com/solidusio/solidus/pull/1479
+
 *   Add `Spree::Promotion#remove_from` and `Spree::PromotionAction#remove_from`
 
     This will allow promotions to be removed from orders and allows promotion
@@ -39,7 +46,7 @@
 *   Removals
 
     * Removed deprecated method `Spree::TaxRate.adjust` (not to be confused with
-      Spree::TaxRate#adjust) in favor of `Spree::Tax::OrderAdjuster`.
+      Spree::TaxRate#adjust) in favor of `Spree::Config.tax_adjuster_class`.
 
       https://github.com/solidusio/solidus/pull/1462
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 *   Remove callback `Spree::LineItem.after_create :update_tax_charge`
 
     Any code that creates `LineItem`s outside the context of OrderContents
-    should ensure that it calls `order.create_tax_charge!` after doing so.
+    should ensure that it calls `order.update!` after doing so.
 
 *   Mark `Spree::Tax::ItemAdjuster` as api-private
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 ## Solidus 2.1.0 (master, unreleased)
 
+*   The OrderUpdater (as used by `order.update!`) now fully updates taxes.
+
+    Previously there were two different ways taxes were calculated: a "full"
+    and a "quick" calculation. The full calculation was performed with
+    `order.create_tax_charge!` and would determine which tax rates applied and
+    add taxes to items. The "quick" calculation was performed as part of an
+    order update, and would only update the tax amounts on existing line items
+    with taxes.
+
+    Now `order.update!` will perform the full calculation every time.
+    `order.create_tax_charge!` is now deprecated and has been made equivalent
+    to `order.update!`.
+
+    https://github.com/solidusio/solidus/pull/1479
+
 *   Added Spree::Config.tax_adjuster_class
 
     To allow easier customization of tax calculation in extensions or

--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -371,6 +371,16 @@ module Spree
       @add_payment_sources_to_wallet_class ||= Spree::Wallet::AddPaymentSourcesToWallet
     end
 
+    # Allows providing your own class for calculating taxes on an order.
+    #
+    # @!attribute [rw] tax_adjuster_class
+    # @return [Class] a class with the same public interfaces as
+    #   Spree::Tax::OrderAdjuster
+    attr_writer :tax_adjuster_class
+    def tax_adjuster_class
+      @tax_adjuster_class ||= Spree::Tax::OrderAdjuster
+    end
+
     def static_model_preferences
       @static_model_preferences ||= Spree::Preferences::StaticModelPreferences.new
     end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -17,7 +17,7 @@ module Spree
   # `checkout_allowed?` or `payment_required?`.
   #
   #  * Implements an interface for mutating the order with methods like
-  # `create_tax_charge!` and `fulfill!`.
+  # `empty!` and `fulfill!`.
   #
   class Order < Spree::Base
     ORDER_NUMBER_LENGTH  = 9
@@ -348,9 +348,11 @@ module Spree
 
     # Creates new tax charges if there are any applicable rates. If prices already
     # include taxes then price adjustments are created instead.
+    # @deprecated This now happens during #update!
     def create_tax_charge!
       Spree::Tax::OrderAdjuster.new(self).adjust!
     end
+    deprecate create_tax_charge!: :update!, deprecator: Spree::Deprecation
 
     def outstanding_balance
       # If reimbursement has happened add it back to total to prevent balance_due payment state

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -350,7 +350,7 @@ module Spree
     # include taxes then price adjustments are created instead.
     # @deprecated This now happens during #update!
     def create_tax_charge!
-      Spree::Tax::OrderAdjuster.new(self).adjust!
+      Spree::Config.tax_adjuster_class.new(self).adjust!
     end
     deprecate create_tax_charge!: :update!, deprecator: Spree::Deprecation
 

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -78,7 +78,6 @@ module Spree
 
                 after_transition to: :complete, do: :add_payment_sources_to_wallet
                 before_transition to: :payment, do: :set_shipments_cost
-                before_transition to: :payment, do: :create_tax_charge!
                 before_transition to: :payment, do: :assign_default_credit_card
 
                 before_transition to: :confirm, do: :add_store_credit_payments
@@ -90,7 +89,6 @@ module Spree
               before_transition from: :cart, do: :ensure_line_items_present
 
               if states[:address]
-                before_transition from: :address, do: :create_tax_charge!
                 before_transition to: :address, do: :assign_default_addresses!
                 before_transition from: :address, do: :persist_user_address!
               end

--- a/core/app/models/spree/order_contents.rb
+++ b/core/app/models/spree/order_contents.rb
@@ -36,8 +36,6 @@ module Spree
 
     def update_cart(params)
       if order.update_attributes(params)
-        order.create_tax_charge!
-
         unless order.completed?
           order.line_items = order.line_items.select { |li| li.quantity > 0 }
           # Update totals, then check if the order is eligible for any cart promotions.
@@ -77,7 +75,6 @@ module Spree
       shipment = options[:shipment]
       shipment.present? ? shipment.update_amounts : order.ensure_updated_shipments
       PromotionHandler::Cart.new(order, line_item).activate
-      order.create_tax_charge!
       reload_totals
       line_item
     end

--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -197,7 +197,7 @@ module Spree
     end
 
     def update_taxes
-      Spree::Tax::OrderAdjuster.new(order).adjust!
+      Spree::Config.tax_adjuster_class.new(order).adjust!
 
       [*line_items, *shipments].each do |item|
         tax_adjustments = item.adjustments.select(&:tax?)

--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -197,10 +197,10 @@ module Spree
     end
 
     def update_taxes
+      Spree::Tax::OrderAdjuster.new(order).adjust!
+
       [*line_items, *shipments].each do |item|
         tax_adjustments = item.adjustments.select(&:tax?)
-
-        tax_adjustments.each(&:update!)
         # Tax adjustments come in not one but *two* exciting flavours:
         # Included & additional
 

--- a/core/lib/spree/core/unreturned_item_charger.rb
+++ b/core/lib/spree/core/unreturned_item_charger.rb
@@ -24,7 +24,6 @@ module Spree
       new_order.associate_user!(@original_order.user) if @original_order.user
 
       add_exchange_variants_to_order
-      new_order.create_tax_charge!
       set_shipment_for_new_order
 
       new_order.update!

--- a/core/lib/spree/testing_support/factories/order_factory.rb
+++ b/core/lib/spree/testing_support/factories/order_factory.rb
@@ -45,7 +45,6 @@ FactoryGirl.define do
           create(:line_item, attributes)
         end
         order.line_items.reload
-        order.create_tax_charge!
 
         create(:shipment, order: order, cost: evaluator.shipment_cost, shipping_method: evaluator.shipping_method, stock_location: evaluator.stock_location)
         order.shipments.reload

--- a/core/spec/lib/spree/core/unreturned_item_charger_spec.rb
+++ b/core/spec/lib/spree/core/unreturned_item_charger_spec.rb
@@ -53,7 +53,6 @@ describe Spree::UnreturnedItemCharger do
 
       it "applies tax" do
         exchange_order = exchange_shipment.order
-        exchange_order.create_tax_charge!
         exchange_order.update!
         subject
         expect(new_order.additional_tax_total).to be > 0

--- a/core/spec/models/spree/order/updating_spec.rb
+++ b/core/spec/models/spree/order/updating_spec.rb
@@ -1,11 +1,9 @@
 require 'spec_helper'
 
 describe Spree::Order, type: :model do
-  let(:order) { stub_model(Spree::Order) }
+  let(:order) { create(:order) }
 
   context "#update!" do
-    let(:line_items) { [mock_model(Spree::LineItem, amount: 5)] }
-
     context "when there are update hooks" do
       before { Spree::Order.register_update_hook :foo }
       after { Spree::Order.update_hooks.clear }

--- a/core/spec/models/spree/order_contents_spec.rb
+++ b/core/spec/models/spree/order_contents_spec.rb
@@ -256,11 +256,6 @@ describe Spree::OrderContents, type: :model do
       }.to change { subject.order.total }
     end
 
-    it "updates tax adjustments" do
-      expect(subject.order).to receive(:create_tax_charge!)
-      subject.update_cart params
-    end
-
     context "submits item quantity 0" do
       let(:params) do
         { line_items_attributes: {

--- a/core/spec/models/spree/order_updater_spec.rb
+++ b/core/spec/models/spree/order_updater_spec.rb
@@ -276,7 +276,6 @@ module Spree
         let(:order) do
           create(
             :order_with_line_items,
-            line_items_count: 1,
             line_items_attributes: [{ price: 10, variant: variant }],
             ship_address: ship_address,
           )

--- a/core/spec/models/spree/order_updater_spec.rb
+++ b/core/spec/models/spree/order_updater_spec.rb
@@ -298,6 +298,23 @@ module Spree
             }.from(1).to(2)
           end
         end
+
+        context 'with a custom tax_adjuster_class' do
+          let(:custom_adjuster_class) { double }
+          let(:custom_adjuster_instance) { double }
+
+          before do
+            order # generate this first so we can expect it
+            Spree::Config.tax_adjuster_class = custom_adjuster_class
+          end
+
+          it 'uses the configured class' do
+            expect(custom_adjuster_class).to receive(:new).with(order).at_least(:once).and_return(custom_adjuster_instance)
+            expect(custom_adjuster_instance).to receive(:adjust!).at_least(:once)
+
+            order.update!
+          end
+        end
       end
     end
 

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -118,10 +118,23 @@ describe Spree::Shipment, type: :model do
   end
 
   context "#item_cost" do
+    let(:shipment) { order.shipments[0] }
+
+    let(:order) do
+      create(
+        :order_ready_to_ship,
+        line_items_attributes: [{ price: 10, variant: variant }],
+        ship_address: ship_address,
+      )
+    end
+
+    let!(:ship_address) { create(:address) }
+    let!(:tax_zone) { create(:global_zone) } # will include the above address
+    let!(:tax_rate) { create(:tax_rate, amount: 0.1, zone: tax_zone, tax_category: tax_category) }
+    let(:tax_category) { create(:tax_category) }
+    let(:variant) { create(:variant, tax_category: tax_category) }
+
     it 'should equal line items final amount with tax' do
-      shipment = create(:shipment, order: create(:order_with_totals))
-      create :tax_adjustment, adjustable: shipment.order.line_items.first, order: shipment.order
-      shipment.order.update!
       expect(shipment.item_cost).to eql(11.0)
     end
   end


### PR DESCRIPTION
To allow easier customization of tax calculation in extensions or
applications.

This should resolve (or get a lot closer to resolving) #1252.

See individual commits.

There is a possible performance hit here, as I've merged two sections of tax updating code, and used the more encompassing method in both places, and the more encompassing method is heavier weight.  We could look into optimizing that code if we think we need to.  (I've discussed some ideas with the core team around adding a sort of caching, though it's always scary to add caching.)
