### PR TITLE
OptionValue Promo Rule selected option value not appearing

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/option_value_picker.js
+++ b/backend/app/assets/javascripts/spree/backend/option_value_picker.js
@@ -15,7 +15,8 @@ $.fn.optionValueAutocomplete = function (options) {
     multiple: multiple,
     initSelection: function (element, callback) {
       $.get(Spree.routes.option_value_search, {
-        ids: element.val().split(',')
+        ids: element.val().split(','),
+        token: Spree.api_key
       }, function (data) {
         callback(multiple ? data : data[0]);
       });


### PR DESCRIPTION
Using the Spree::Promotion::Rules::OptionValue, after adding a
  product and option value, the selected option value
  was not appearing