### PR TITLE
Convert grid classes in backend admin from skeleton to bootstrap

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/templates/promotions/calculators/fields/tiered_flat_rate.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/promotions/calculators/fields/tiered_flat_rate.hbs
@@ -1,16 +1,18 @@
 <div class="fullwidth tier">
   <a class="fa fa-trash remove js-remove-tier"></a>
-  <div class="two columns alpha omega">
-    <div class="input-group">
-      <span class="input-group-addon">$</span>
-      <input class="js-base-input form-control" type="text" value={{baseField.value}}>
+  <div class="row">
+    <div class="col-xs-6">
+      <div class="input-group">
+        <span class="input-group-addon">$</span>
+        <input class="js-base-input form-control" type="text" value={{baseField.value}}>
+      </div>
     </div>
-  </div>
-  <div class="two columns alpha omega right">
-    <div class="input-group">
-      <span class="input-group-addon">$</span>
-      <input class="js-value-input form-control"
-        name="{{valueField.name}}" type="text" value={{valueField.value}}>
+    <div class="col-xs-6">
+      <div class="input-group">
+        <span class="input-group-addon">$</span>
+        <input class="js-value-input form-control"
+          name="{{valueField.name}}" type="text" value={{valueField.value}}>
+      </div>
     </div>
   </div>
   <div class="clear"></div>

--- a/backend/app/assets/javascripts/spree/backend/templates/promotions/calculators/fields/tiered_flat_rate.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/promotions/calculators/fields/tiered_flat_rate.hbs
@@ -1,7 +1,7 @@
 <div class="fullwidth tier">
-  <a class="fa fa-trash remove js-remove-tier"></a>
   <div class="row">
     <div class="col-xs-6">
+      <a class="fa fa-trash remove js-remove-tier"></a>
       <div class="input-group">
         <span class="input-group-addon">$</span>
         <input class="js-base-input form-control" type="text" value={{baseField.value}}>

--- a/backend/app/assets/javascripts/spree/backend/templates/promotions/calculators/fields/tiered_percent.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/promotions/calculators/fields/tiered_percent.hbs
@@ -1,16 +1,18 @@
 <div class="fullwidth tier">
   <a class="fa fa-trash remove js-remove-tier"></a>
-  <div class="two columns alpha omega">
-    <div class="input-group">
-      <span class="input-group-addon">$</span>
-      <input class="js-base-input form-control" type="text" value={{baseField.value}}>
+  <div class="row">
+    <div class="col-xs-6">
+      <div class="input-group">
+        <span class="input-group-addon">$</span>
+        <input class="js-base-input form-control" type="text" value={{baseField.value}}>
+      </div>
     </div>
-  </div>
-  <div class="two columns alpha omega right">
-    <div class="input-group">
-      <input class="js-value-input form-control right-align"
-        name="{{valueField.name}}" type="text" value={{valueField.value}}>
-      <span class="input-group-addon">%</span>
+    <div class="col-xs-6">
+      <div class="input-group">
+        <input class="js-value-input form-control right-align"
+          name="{{valueField.name}}" type="text" value={{valueField.value}}>
+        <span class="input-group-addon">%</span>
+      </div>
     </div>
   </div>
   <div class="clear"></div>

--- a/backend/app/assets/javascripts/spree/backend/templates/promotions/rules/option_values.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/promotions/rules/option_values.hbs
@@ -1,9 +1,11 @@
 <div class="fullwidth promo-rule-option-value">
-  <div class="four columns alpha">
-    <input class="js-promo-rule-option-value-product-select fullwidth" type="hidden" value="{{ productSelect.value }}">
-  </div>
-  <div class="three columns omega">
-    <input class="js-promo-rule-option-value-option-values-select fullwidth" name="{{ paramPrefix }}[preferred_eligible_values][{{ productSelect.value }}]" type="hidden" value={{optionValuesSelect.value}}>
+  <div class="row">
+    <div class="col-xs-6">
+      <input class="js-promo-rule-option-value-product-select fullwidth" type="hidden" value="{{ productSelect.value }}">
+    </div>
+    <div class="col-xs-5">
+      <input class="js-promo-rule-option-value-option-values-select fullwidth" name="{{ paramPrefix }}[preferred_eligible_values][{{ productSelect.value }}]" type="hidden" value={{optionValuesSelect.value}}>
+    </div>
   </div>
   <a class="fa fa-trash remove js-remove-promo-rule-option-value"></a>
   <div class="clear"></div>

--- a/backend/app/assets/stylesheets/spree/backend/shared/_utilities.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_utilities.scss
@@ -26,8 +26,7 @@
   margin-right: -10px;
 }
 
-.container .column,
-.container .columns {
+.container {
   // Float container right instead of left.
   .right {
     float: right;

--- a/backend/app/views/spree/admin/adjustment_reasons/index.html.erb
+++ b/backend/app/views/spree/admin/adjustment_reasons/index.html.erb
@@ -43,7 +43,7 @@
     </tbody>
   </table>
 <% else %>
-  <div class="alpha twelve columns no-objects-found">
+  <div class="col-xs-9 no-objects-found">
     <%= render 'spree/admin/shared/no_objects_found',
                  resource: Spree::AdjustmentReason,
                  new_resource_url: new_object_url %>

--- a/backend/app/views/spree/admin/adjustment_reasons/shared/_form.html.erb
+++ b/backend/app/views/spree/admin/adjustment_reasons/shared/_form.html.erb
@@ -1,22 +1,20 @@
 <div data-hook="admin_adjustment_reason_form_fields" class="row">
-  <div class="row">
-    <div class="alpha four columns">
-      <%= f.field_container :name do %>
-        <%= f.label :name, class: 'required' %><br />
-        <%= f.text_field :name, :class => 'fullwidth' %>
-      <% end %>
+  <div class="col-xs-3">
+    <%= f.field_container :name do %>
+      <%= f.label :name, class: 'required' %><br />
+      <%= f.text_field :name, :class => 'fullwidth' %>
+    <% end %>
 
-      <%= f.field_container :code do %>
-        <%= f.label :code, class: 'required' %><br />
-        <%= f.text_field :code, :class => 'fullwidth' %>
-      <% end %>
+    <%= f.field_container :code do %>
+      <%= f.label :code, class: 'required' %><br />
+      <%= f.text_field :code, :class => 'fullwidth' %>
+    <% end %>
 
-      <div class="checkbox">
-        <label>
-          <%= f.check_box :active %>
-          <%= Spree::AdjustmentReason.human_attribute_name(:active) %>
-        </label>
-      </div>
+    <div class="checkbox">
+      <label>
+        <%= f.check_box :active %>
+        <%= Spree::AdjustmentReason.human_attribute_name(:active) %>
+      </label>
     </div>
   </div>
 </div>

--- a/backend/app/views/spree/admin/adjustments/_form.html.erb
+++ b/backend/app/views/spree/admin/adjustments/_form.html.erb
@@ -1,24 +1,28 @@
-<div data-hook="admin_adjustment_form_fields" class="row">
-  <div class="alpha three columns">
-    <%= f.field_container :amount do %>
-      <%= f.label :amount, class: 'required' %>
-      <%= text_field :adjustment, :amount, class: 'fullwidth' %>
-      <%= f.error_message_on :amount %>
-    <% end %>
-  </div>
+<div data-hook="admin_adjustment_form_fields">
+  <div class="row">
 
-  <div class="six columns">
-    <%= f.field_container :label do %>
-      <%= f.label :label, class: 'required' %>
-      <%= text_field :adjustment, :label, class: 'fullwidth' %>
-      <%= f.error_message_on :label %>
-    <% end %>
-  </div>
+    <div class="col-xs-3">
+      <%= f.field_container :amount do %>
+        <%= f.label :amount, class: 'required' %>
+        <%= text_field :adjustment, :amount, class: 'fullwidth' %>
+        <%= f.error_message_on :amount %>
+      <% end %>
+    </div>
 
-  <div class="omega three columns">
-    <%= f.field_container :label do %>
-      <%= f.label :adjustment_reason_id %><br/>
-      <%= f.collection_select(:adjustment_reason_id, reasons_for(@adjustment), :id, :name, {include_blank: true}, {"data-placeholder" => Spree.t(:select_a_reason), class: 'select2 fullwidth'}) %>
-    <% end %>
+    <div class="col-xs-6">
+      <%= f.field_container :label do %>
+        <%= f.label :label, class: 'required' %>
+        <%= text_field :adjustment, :label, class: 'fullwidth' %>
+        <%= f.error_message_on :label %>
+      <% end %>
+    </div>
+
+    <div class="col-xs-3">
+      <%= f.field_container :label do %>
+        <%= f.label :adjustment_reason_id %><br/>
+        <%= f.collection_select(:adjustment_reason_id, reasons_for(@adjustment), :id, :name, {include_blank: true}, {"data-placeholder" => Spree.t(:select_a_reason), class: 'select2 fullwidth'}) %>
+      <% end %>
+    </div>
+
   </div>
 </div>

--- a/backend/app/views/spree/admin/countries/_form.html.erb
+++ b/backend/app/views/spree/admin/countries/_form.html.erb
@@ -1,17 +1,17 @@
 <div data-hook="admin_country_form_fields" class="row">
-  <div class="alpha four columns">
+  <div class="col-xs-5">
     <div data-hook="name" class="field">
       <%= f.label :name %>
       <%= f.text_field :name, :class => 'fullwidth' %>
     </div>
   </div>
-  <div class="four columns">
+  <div class="col-xs-5">
     <div data-hook="iso_name" class="field">
       <%= f.label :iso_name %>
       <%= f.text_field :iso_name, :class => 'fullwidth' %>
     </div>
   </div>
-  <div class="omega four columns">
+  <div class="col-xs-2">
     <div data-hook="states_required" class="field checkbox">
       <label>
         <%= f.check_box :states_required %>

--- a/backend/app/views/spree/admin/customer_returns/index.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/index.html.erb
@@ -44,7 +44,7 @@
     </tbody>
   </table>
 <% else %>
-  <div class="alpha twelve columns no-objects-found">
+  <div class="col-xs-9 no-objects-found">
     <%= render 'spree/admin/shared/no_objects_found',
                  resource: Spree::CustomerReturn,
                  new_resource_url: new_object_url %>

--- a/backend/app/views/spree/admin/customer_returns/new.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/new.html.erb
@@ -18,7 +18,7 @@
           <% if @rma_return_items.any? %>
             <%= render partial: 'return_item_selection', locals: {f: f, return_items: @rma_return_items} %>
           <% else %>
-            <div class="alpha twelve columns no-objects-found"><%= Spree.t(:none) %></div>
+            <div class="col-xs-9 no-objects-found"><%= Spree.t(:none) %></div>
           <% end %>
         </fieldset>
 
@@ -27,7 +27,7 @@
           <% if @new_return_items.any? %>
             <%= render partial: 'return_item_selection', locals: {f: f, return_items: @new_return_items} %>
           <% else %>
-            <div class="alpha twelve columns no-objects-found"><%= Spree.t(:none) %></div>
+            <div class="col-xs-9 no-objects-found"><%= Spree.t(:none) %></div>
           <% end %>
         </fieldset>
 

--- a/backend/app/views/spree/admin/customer_returns/new.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/new.html.erb
@@ -48,11 +48,9 @@
 
 <% else %>
 
-  <div class="twelve columns">
-    <div class="alpha twelve columns no-objects-found">
-      <%= Spree.t(:all_items_have_been_returned) %>,
-      <%= link_to Spree.t(:back_to_customer_return_list), spree.admin_order_customer_returns_path(@order) %>.
-    </div>
+  <div class="col-xs-9 no-objects-found">
+    <%= Spree.t(:all_items_have_been_returned) %>,
+    <%= link_to Spree.t(:back_to_customer_return_list), spree.admin_order_customer_returns_path(@order) %>.
   </div>
 
 <% end %>

--- a/backend/app/views/spree/admin/images/_form.html.erb
+++ b/backend/app/views/spree/admin/images/_form.html.erb
@@ -1,17 +1,19 @@
 <div data-hook="admin_image_form_fields">
-  <div class="four columns alpha">
-    <div data-hook="file" class="field">
-      <%= f.label :attachment %><br>
-      <%= f.file_field :attachment %>
+  <div class="row">
+    <div class="col-xs-3">
+      <div data-hook="file" class="field">
+        <%= f.label :attachment %><br>
+        <%= f.file_field :attachment %>
+      </div>
+      <div data-hook="variant" class="field">
+        <%= f.label :viewable_id, Spree::Variant.model_name.human %><br>
+        <%= f.select :viewable_id, @variants, {}, { class: 'select2 fullwidth' } %>
+      </div>
     </div>
-    <div data-hook="variant" class="field">
-      <%= f.label :viewable_id, Spree::Variant.model_name.human %><br>
-      <%= f.select :viewable_id, @variants, {}, { class: 'select2 fullwidth' } %>
+    <div data-hook="alt_text" class="field col-xs-4">
+      <%= f.label :alt %><br>
+      <%= f.text_area :alt, rows: 4, class: 'fullwidth' %>
     </div>
-  </div>
-  <div data-hook="alt_text" class="field omega five columns">
-    <%= f.label :alt %><br>
-    <%= f.text_area :alt, rows: 4, class: 'fullwidth' %>
   </div>
 </div>
 

--- a/backend/app/views/spree/admin/images/edit.html.erb
+++ b/backend/app/views/spree/admin/images/edit.html.erb
@@ -13,14 +13,18 @@
 <%= form_for [:admin, @product, @image], :html => { :multipart => true } do |f| %>
   <fieldset data-hook="edit_image">
     <legend align="center"><%= @image.attachment_file_name%></legend>
-    <div data-hook="thumbnail" class="field alpha three columns align-center">
-      <%= f.label Spree.t(:thumbnail) %><br>
-      <%= link_to image_tag(@image.attachment.url(:small)), @image.attachment.url(:product) %>
+
+    <div class="row">
+      <div data-hook="thumbnail" class="field col-xs-2 align-center">
+        <%= f.label Spree.t(:thumbnail) %><br>
+        <%= link_to image_tag(@image.attachment.url(:small)), @image.attachment.url(:product) %>
+      </div>
+      <div class="col-xs-10">
+        <%= render :partial => 'form', :locals => { :f => f } %>
+      </div>
+      <div class="clear"></div>
     </div>
-    <div class="nine columns omega">
-      <%= render :partial => 'form', :locals => { :f => f } %>
-    </div>
-    <div class="clear"></div>
+
     <div class="form-buttons filter-actions actions" data-hook="buttons">
       <%= button Spree.t('actions.update') %>
       <%= link_to Spree.t('actions.cancel'), admin_product_images_url(@product), :id => 'cancel_link', :class => 'button' %>

--- a/backend/app/views/spree/admin/option_types/_form.html.erb
+++ b/backend/app/views/spree/admin/option_types/_form.html.erb
@@ -1,5 +1,5 @@
 <div data-hook="admin_option_type_form_fields" class="align-center row">
-  <div class="alpha eight columns">
+  <div class="col-xs-6">
     <%= f.field_container :name do %>
       <%= f.label :name, class: 'required' %><br />
       <%= f.text_field :name, :class => "fullwidth" %>
@@ -7,7 +7,7 @@
     <% end %>
   </div>
 
-  <div class="omega eight columns">
+  <div class="col-xs-6">
     <%= f.field_container :presentation do %>
       <%= f.label :presentation, class: 'required' %><br />
       <%= f.text_field :presentation, :class => "fullwidth" %>

--- a/backend/app/views/spree/admin/option_types/index.html.erb
+++ b/backend/app/views/spree/admin/option_types/index.html.erb
@@ -47,7 +47,7 @@
   </tbody>
 </table>
 <% else %>
-  <div class="alpha twelve columns no-objects-found">
+  <div class="col-xs-9 no-objects-found">
     <%= render 'spree/admin/shared/no_objects_found',
                  resource: Spree::OptionType,
                  new_resource_url: new_object_url %>

--- a/backend/app/views/spree/admin/orders/_add_line_item.html.erb
+++ b/backend/app/views/spree/admin/orders/_add_line_item.html.erb
@@ -2,9 +2,11 @@
   <fieldset class="no-border-bottom">
     <legend align="center"><%= Spree.t(:add_product) %></legend>
 
-    <div data-hook="add_product_name" class="field twelve columns alpha">
-      <%= label_tag :add_line_item_variant_id, Spree.t(:name_or_sku) %>
-      <%= text_field_tag :add_line_item_variant_id, "", :class => "variant_autocomplete fullwidth" %>
+    <div class="col-xs-9">
+      <div data-hook="add_product_name" class="field">
+        <%= label_tag :add_line_item_variant_id, Spree.t(:name_or_sku) %>
+        <%= text_field_tag :add_line_item_variant_id, "", :class => "variant_autocomplete fullwidth" %>
+      </div>
     </div>
 
   </fieldset>

--- a/backend/app/views/spree/admin/orders/_add_product.html.erb
+++ b/backend/app/views/spree/admin/orders/_add_product.html.erb
@@ -2,9 +2,11 @@
   <fieldset class="no-border-bottom">
     <legend align="center"><%= Spree.t(:add_product) %></legend>
 
-    <div data-hook="add_product_name" class="field twelve columns alpha">
-      <%= label_tag :add_variant_id, Spree.t(:name_or_sku) %>
-      <%= text_field_tag :add_variant_id, "", :class => "variant_autocomplete fullwidth" %>
+    <div class="col-xs-9">
+      <div data-hook="add_product_name" class="field">
+        <%= label_tag :add_variant_id, Spree.t(:name_or_sku) %>
+        <%= text_field_tag :add_variant_id, "", :class => "variant_autocomplete fullwidth" %>
+      </div>
     </div>
 
   </fieldset>

--- a/backend/app/views/spree/admin/orders/_shipment.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment.html.erb
@@ -48,11 +48,15 @@
       <% unless shipment.shipped? %>
         <tr class="edit-method hidden total">
           <td colspan="5">
-            <div class="field alpha five columns">
-              <%= label_tag 'selected_shipping_rate_id', Spree::ShippingMethod.model_name.human %>
-              <%= select_tag :selected_shipping_rate_id,
-                    options_for_select(shipment.shipping_rates.map {|sr| ["#{sr.name} #{sr.display_price}", sr.id] }, shipment.selected_shipping_rate_id),
-                    {:class => 'select2 fullwidth', :data => {'shipment-number' => shipment.number } } %>
+            <div class="row">
+              <div class="col-xs-4">
+                <div class="field">
+                  <%= label_tag 'selected_shipping_rate_id', Spree::ShippingMethod.model_name.human %>
+                  <%= select_tag :selected_shipping_rate_id,
+                        options_for_select(shipment.shipping_rates.map {|sr| ["#{sr.name} #{sr.display_price}", sr.id] }, shipment.selected_shipping_rate_id),
+                        {:class => 'select2 fullwidth', :data => {'shipment-number' => shipment.number } } %>
+                </div>
+              </div>
             </div>
           </td>
           <td class="actions">

--- a/backend/app/views/spree/admin/orders/confirm/_customer_details.html.erb
+++ b/backend/app/views/spree/admin/orders/confirm/_customer_details.html.erb
@@ -4,21 +4,23 @@
 </fieldsset>
 
 <fieldset class="no-border-bottom no-border-top">
-  <div data-hook="bill_address_wrapper" class="alpha six columns">
-    <fieldset class="no-border-bottom">
-      <legend align="center"><%= Spree.t(:billing_address) %></legend>
-      <% if order.bill_address %>
-        <%= render partial: 'spree/admin/shared/address', locals: {address: order.bill_address} %>
-      <% end %>
-    </fieldset>
-  </div>
+  <div class="row">
+    <div data-hook="bill_address_wrapper" class="col-xs-6">
+      <fieldset class="no-border-bottom">
+        <legend align="center"><%= Spree.t(:billing_address) %></legend>
+        <% if order.bill_address %>
+          <%= render partial: 'spree/admin/shared/address', locals: {address: order.bill_address} %>
+        <% end %>
+      </fieldset>
+    </div>
 
-  <div class="omega six columns" data-hook="ship_address_wrapper">
-    <fieldset class="no-border-bottom">
-      <legend align="center"><%= Spree.t(:shipping_address) %></legend>
-      <% if order.ship_address %>
-        <%= render partial: 'spree/admin/shared/address', locals: {address: order.ship_address} %>
-      <% end %>
-    </fieldset>
+    <div class="col-xs-6" data-hook="ship_address_wrapper">
+      <fieldset class="no-border-bottom">
+        <legend align="center"><%= Spree.t(:shipping_address) %></legend>
+        <% if order.ship_address %>
+          <%= render partial: 'spree/admin/shared/address', locals: {address: order.ship_address} %>
+        <% end %>
+      </fieldset>
+    </div>
   </div>
 </fieldset>

--- a/backend/app/views/spree/admin/orders/customer_details/_form.html.erb
+++ b/backend/app/views/spree/admin/orders/customer_details/_form.html.erb
@@ -4,13 +4,13 @@
     <legend align="center"><%= Spree.t(:account) %></legend>
 
     <div data-hook="customer_fields" class="row">
-      <div class="alpha eight columns">
+      <div class="col-xs-9">
         <div class="field">
           <%= f.label :email %>
           <%= f.email_field :email, :class => 'fullwidth' %>
         </div>
       </div>
-      <div class="omega four columns">
+      <div class="col-xs-3">
         <div class="field">
           <%= label_tag nil, Spree.t(:guest_checkout) %>
           <ul>
@@ -36,34 +36,36 @@
     </div>
   </fieldset>
 
-  <div class="alpha six columns" data-hook="ship_address_wrapper">
-    <fieldset class="no-border-bottom">
-      <legend align="center"><%= Spree.t(:shipping_address) %></legend>
-      <%= f.fields_for :ship_address do |sa_form| %>
-        <% if Spree::Config[:order_bill_address_used] %>
-          <div class="field" style="position: absolute;margin-top: -15px;left: 0;">
-            <span data-hook="use_billing">
-              <%= check_box_tag 'order[use_billing]', '1', ((@order.bill_address.empty? && @order.ship_address.empty?) && @order.bill_address == @order.ship_address) %>
-              <%= label_tag 'order[use_billing]', Spree.t(:use_billing_address) %>
-            </span>
-          </div>
-        <% end %>
-
-        <%= render :partial => 'spree/admin/shared/address_form', :locals => { :f => sa_form, :type => 'shipping' } %>
-      <% end %>
-    </fieldset>
-  </div>
-
-  <% if Spree::Config[:order_bill_address_used] %>
-    <div class="omega six columns" data-hook="bill_address_wrapper">
+  <div class="row">
+    <div class="col-xs-6" data-hook="ship_address_wrapper">
       <fieldset class="no-border-bottom">
-        <legend align="center"><%= Spree.t(:billing_address) %></legend>
-        <%= f.fields_for :bill_address do |ba_form| %>
-          <%= render :partial => 'spree/admin/shared/address_form', :locals => { :f => ba_form, :type => "billing" } %>
+        <legend align="center"><%= Spree.t(:shipping_address) %></legend>
+        <%= f.fields_for :ship_address do |sa_form| %>
+          <% if Spree::Config[:order_bill_address_used] %>
+            <div class="field" style="position: absolute;margin-top: -15px;left: 0;">
+              <span data-hook="use_billing">
+                <%= check_box_tag 'order[use_billing]', '1', ((@order.bill_address.empty? && @order.ship_address.empty?) && @order.bill_address == @order.ship_address) %>
+                <%= label_tag 'order[use_billing]', Spree.t(:use_billing_address) %>
+              </span>
+            </div>
+          <% end %>
+
+          <%= render :partial => 'spree/admin/shared/address_form', :locals => { :f => sa_form, :type => 'shipping' } %>
         <% end %>
       </fieldset>
     </div>
-  <% end %>
+
+    <% if Spree::Config[:order_bill_address_used] %>
+      <div class="col-xs-6" data-hook="bill_address_wrapper">
+        <fieldset class="no-border-bottom">
+          <legend align="center"><%= Spree.t(:billing_address) %></legend>
+          <%= f.fields_for :bill_address do |ba_form| %>
+            <%= render :partial => 'spree/admin/shared/address_form', :locals => { :f => ba_form, :type => "billing" } %>
+          <% end %>
+        </fieldset>
+      </div>
+    <% end %>
+  </div>
 
   <div class="clear"></div>
 

--- a/backend/app/views/spree/admin/orders/customer_details/show.html.erb
+++ b/backend/app/views/spree/admin/orders/customer_details/show.html.erb
@@ -8,7 +8,7 @@
 <% end %>
 
 
-<main class="alpha eight columns">
+<main class="col-xs-5">
   <section>
     <%= content_tag :h4, Spree.t(:account) %>
     <%= Spree.t(:email) %>: <%= @order.email %><br>

--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -14,81 +14,88 @@
 <% content_for :table_filter do %>
   <div data-hook="admin_orders_index_search">
     <%= search_form_for [:admin, @search] do |f| %>
-      <div class="field-block alpha four columns">
-        <div class="date-range-filter field">
-          <%= label_tag :q_created_at_gt, Spree.t(:date_range) %>
-          <div class="date-range-fields">
-            <%= f.text_field :created_at_gt, :class => 'datepicker datepicker-from', :value => params[:q][:created_at_gt], :placeholder => Spree.t(:start) %>
+      <div class="row">
+        <div class="field-block col-xs-3">
+          <div class="date-range-filter field">
+            <%= label_tag :q_created_at_gt, Spree.t(:date_range) %>
+            <div class="date-range-fields">
+              <%= f.text_field :created_at_gt, :class => 'datepicker datepicker-from', :value => params[:q][:created_at_gt], :placeholder => Spree.t(:start) %>
 
-            <span class="range-divider">
-              <i class="fa fa-arrow-right"></i>
-            </span>
+              <span class="range-divider">
+                <i class="fa fa-arrow-right"></i>
+              </span>
 
-            <%= f.text_field :created_at_lt, :class => 'datepicker datepicker-to', :value => params[:q][:created_at_lt], :placeholder => Spree.t(:stop) %>
+              <%= f.text_field :created_at_lt, :class => 'datepicker datepicker-to', :value => params[:q][:created_at_lt], :placeholder => Spree.t(:stop) %>
+            </div>
           </div>
-        </div>
 
-        <div class="field">
-          <%= label_tag :q_state_eq, Spree.t(:status) %>
-          <%= f.select :state_eq, Spree::Order.state_machines[:state].states.collect {|s| [Spree.t("order_state.#{s.name}"), s.value]}, {:include_blank => true}, :class => 'select2' %>
-        </div>
-
-        <div class="field">
-          <%= label_tag nil, Spree.t(:promotion) %>
-          <%= f.text_field :promotions_codes_value_cont, :size => 25 %>
-        </div>
-
-        <div class="field">
-          <%= label_tag nil, Spree.t(:shipment_number) %>
-          <%= f.text_field :shipments_number_cont %>
-        </div>
-
-      </div>
-
-      <div class="four columns">
-        <div class="field">
-          <%= label_tag :q_number_cont, Spree.t(:order_number, :number => '') %>
-          <%= f.text_field :number_cont %>
-        </div>
-
-        <div class="field">
-          <%= label_tag :q_email_cont, Spree.t(:email) %>
-          <%= f.text_field :email_cont %>
-        </div>
-      </div>
-
-      <div class="four columns">
-        <div class="field">
-          <%= label_tag :q_bill_address_firstname_start, Spree.t(:first_name_begins_with) %>
-          <%= f.text_field :bill_address_firstname_start, :size => 25 %>
-        </div>
-        <div class="field">
-          <%= label_tag :q_bill_address_lastname_start, Spree.t(:last_name_begins_with) %>
-          <%= f.text_field :bill_address_lastname_start, :size => 25%>
-        </div>
-      </div>
-
-      <div class="omega four columns">
-        <% if Spree::Store.count > 1 %>
           <div class="field">
-            <%= label_tag nil, Spree.t(:store) %>
-            <%= f.select :store_id_eq, Spree::Store.all.map { |s| [s.name, s.id] }, { include_blank: true }, { class: "select2" } %>
+            <%= label_tag :q_state_eq, Spree.t(:status) %>
+            <%= f.select :state_eq, Spree::Order.state_machines[:state].states.collect {|s| [Spree.t("order_state.#{s.name}"), s.value]}, {:include_blank => true}, :class => 'select2' %>
           </div>
-        <% end %>
 
-        <div class="field checkbox">
-          <label>
-            <%= f.check_box :completed_at_not_null, {:checked => @show_only_completed}, '1', '0' %>
-            <%= Spree.t(:show_only_complete_orders) %>
-          </label>
-        </div>
-      </div>
+          <div class="field">
+            <%= label_tag nil, Spree.t(:promotion) %>
+            <%= f.text_field :promotions_codes_value_cont, :size => 25 %>
+          </div>
 
-      <div class="omega eight columns">
-        <div class="field" data-hook="sku-select">
-          <%= label_tag :q_line_items_variant_id_in, Spree.t(:variant) %>
-          <%= f.text_field :line_items_variant_id_in, class: "variant_autocomplete fullwidth" %>
+          <div class="field">
+            <%= label_tag nil, Spree.t(:shipment_number) %>
+            <%= f.text_field :shipments_number_cont %>
+          </div>
+
         </div>
+
+        <div class="col-xs-6">
+          <div class="row">
+            <div class="col-xs-6">
+              <div class="field">
+                <%= label_tag :q_number_cont, Spree.t(:order_number, :number => '') %>
+                <%= f.text_field :number_cont %>
+              </div>
+
+              <div class="field">
+                <%= label_tag :q_email_cont, Spree.t(:email) %>
+                <%= f.text_field :email_cont %>
+              </div>
+            </div>
+
+            <div class="col-xs-6">
+              <div class="field">
+                <%= label_tag :q_bill_address_firstname_start, Spree.t(:first_name_begins_with) %>
+                <%= f.text_field :bill_address_firstname_start, :size => 25 %>
+              </div>
+              <div class="field">
+                <%= label_tag :q_bill_address_lastname_start, Spree.t(:last_name_begins_with) %>
+                <%= f.text_field :bill_address_lastname_start, :size => 25%>
+              </div>
+            </div>
+
+            <div class="col-xs-12">
+              <div class="field" data-hook="sku-select">
+                <%= label_tag :q_line_items_variant_id_in, Spree.t(:variant) %>
+                <%= f.text_field :line_items_variant_id_in, class: "variant_autocomplete fullwidth" %>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-xs-3">
+          <% if Spree::Store.count > 1 %>
+            <div class="field">
+              <%= label_tag nil, Spree.t(:store) %>
+              <%= f.select :store_id_eq, Spree::Store.all.map { |s| [s.name, s.id] }, { include_blank: true }, { class: "select2" } %>
+            </div>
+          <% end %>
+
+          <div class="field checkbox">
+            <label>
+              <%= f.check_box :completed_at_not_null, {:checked => @show_only_completed}, '1', '0' %>
+              <%= Spree.t(:show_only_complete_orders) %>
+            </label>
+          </div>
+        </div>
+
       </div>
 
       <div class="clearfix"></div>
@@ -162,7 +169,7 @@
     </tbody>
   </table>
 <% else %>
-  <div class="alpha twelve columns no-objects-found">
+  <div class="col-xs-9 no-objects-found">
     <%= render 'spree/admin/shared/no_objects_found',
                  resource: Spree::Order,
                  new_resource_url: spree.new_admin_order_path %>

--- a/backend/app/views/spree/admin/payment_methods/_form.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/_form.html.erb
@@ -2,59 +2,61 @@
 
   <div data-hook="payment_method">
 
-    <div class="alpha four columns">
-      <div id="preference-settings">
-        <div class="field">
-          <%= f.label :type %>
-          <%= collection_select(:payment_method, :type, @providers, :to_s, :name, {}, {:id => 'gtwy-type', :class => 'select2 fullwidth js-gateway-type'}) %>
+    <div class="row">
+      <div class="col-xs-3">
+        <div id="preference-settings">
+          <div class="field">
+            <%= f.label :type %>
+            <%= collection_select(:payment_method, :type, @providers, :to_s, :name, {}, {:id => 'gtwy-type', :class => 'select2 fullwidth js-gateway-type'}) %>
+          </div>
+
+          <div class="field js-preference-source-wrapper">
+            <%= f.label :preference_source %>
+            <%= f.select(:preference_source, [[Spree.t(:preference_source_none), nil]] + @object.class.available_preference_sources, {}, class: 'select2 fullwidth js-preference-source') %>
+          </div>
+
+          <div class="gateway-settings js-gateway-settings">
+            <% if @object.preference_source.present? %>
+              <%= Spree.t :preference_source_using, name: @object.preference_source %>
+            <% elsif !@object.new_record? %>
+              <%= preference_fields(@object, f) %>
+            <% end %>
+          </div>
+
+          <div class="info warning js-gateway-settings-warning"><%= Spree.t(:provider_settings_warning) %></div>
         </div>
-
-        <div class="field js-preference-source-wrapper">
-          <%= f.label :preference_source %>
-          <%= f.select(:preference_source, [[Spree.t(:preference_source_none), nil]] + @object.class.available_preference_sources, {}, class: 'select2 fullwidth js-preference-source') %>
+        <div data-hook="display" class="field">
+          <%= f.label :display_on %>
+          <%= select(:payment_method, :display_on, Spree::PaymentMethod::DISPLAY.collect { |display| [Spree.t(display), display == :both ? nil : display.to_s] }, {}, {:class => 'select2 fullwidth'}) %>
         </div>
-
-        <div class="gateway-settings js-gateway-settings">
-          <% if @object.preference_source.present? %>
-            <%= Spree.t :preference_source_using, name: @object.preference_source %>
-          <% elsif !@object.new_record? %>
-            <%= preference_fields(@object, f) %>
-          <% end %>
+        <div data-hook="auto_capture" class="field">
+          <%= f.label :auto_capture %>
+          <%= select(:payment_method, :auto_capture, [["#{Spree.t(:use_app_default)} (#{Spree::Config[:auto_capture]})", ''], [Spree.t(:say_yes), true], [Spree.t(:say_no), false]], {}, {:class => 'select2 fullwidth'}) %>
         </div>
+        <div data-hook="active" class="field">
+          <%= label_tag nil, Spree::PaymentMethod.human_attribute_name(:active) %>
+          <ul>
+            <li>
+              <%= radio_button :payment_method, :active, true %>
+              <%= label_tag :payment_method_active_true, Spree.t(:say_yes) %>
+            </li>
+            <li>
+              <%= radio_button :payment_method, :active, false %>
+              <%= label_tag :payment_method_active_false, Spree.t(:say_no) %>
+            </li>
+          </ul>
+        </div>
+      </div>
 
-        <div class="info warning js-gateway-settings-warning"><%= Spree.t(:provider_settings_warning) %></div>
-      </div>
-      <div data-hook="display" class="field">
-        <%= f.label :display_on %>
-        <%= select(:payment_method, :display_on, Spree::PaymentMethod::DISPLAY.collect { |display| [Spree.t(display), display == :both ? nil : display.to_s] }, {}, {:class => 'select2 fullwidth'}) %>
-      </div>
-      <div data-hook="auto_capture" class="field">
-        <%= f.label :auto_capture %>
-        <%= select(:payment_method, :auto_capture, [["#{Spree.t(:use_app_default)} (#{Spree::Config[:auto_capture]})", ''], [Spree.t(:say_yes), true], [Spree.t(:say_no), false]], {}, {:class => 'select2 fullwidth'}) %>
-      </div>
-      <div data-hook="active" class="field">
-        <%= label_tag nil, Spree::PaymentMethod.human_attribute_name(:active) %>
-        <ul>
-          <li>
-            <%= radio_button :payment_method, :active, true %>
-            <%= label_tag :payment_method_active_true, Spree.t(:say_yes) %>
-          </li>
-          <li>
-            <%= radio_button :payment_method, :active, false %>
-            <%= label_tag :payment_method_active_false, Spree.t(:say_no) %>
-          </li>
-        </ul>
-      </div>
-    </div>
-
-    <div class="omega eight columns">
-      <div data-hook="name" class="field">
-        <%= f.label :name %>
-        <%= f.text_field :name, :class => 'fullwidth' %>
-      </div>
-      <div data-hook="description" class="field">
-        <%= f.label :description %>
-        <%= f.text_area :description, {:cols => 60, :rows => 6, :class => 'fullwidth'} %>
+      <div class="col-xs-6">
+        <div data-hook="name" class="field">
+          <%= f.label :name %>
+          <%= f.text_field :name, :class => 'fullwidth' %>
+        </div>
+        <div data-hook="description" class="field">
+          <%= f.label :description %>
+          <%= f.text_area :description, {:cols => 60, :rows => 6, :class => 'fullwidth'} %>
+        </div>
       </div>
     </div>
   </div>

--- a/backend/app/views/spree/admin/payment_methods/index.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/index.html.erb
@@ -55,7 +55,7 @@
     </tbody>
   </table>
 <% else %>
-  <div class="alpha twelve columns no-objects-found">
+  <div class="col-xs-9 no-objects-found">
     <%= render 'spree/admin/shared/no_objects_found',
                  resource: Spree::PaymentMethod,
                  new_resource_url: new_object_url %>

--- a/backend/app/views/spree/admin/payments/_form.html.erb
+++ b/backend/app/views/spree/admin/payments/_form.html.erb
@@ -1,11 +1,11 @@
 <div data-hook="admin_payment_form_fields" class="row">
-  <div class="alpha three columns">
+  <div class="col-xs-3">
     <div class="field">
       <%= f.label :amount %>
       <%= f.text_field :amount, :value => @order.display_outstanding_balance.money, :class => 'fullwidth' %>
     </div>
   </div>
-  <div class="omega nine columns">
+  <div class="col-xs-9">
     <div class="field">
       <label><%= Spree::PaymentMethod.model_name.human %></label>
       <ul>

--- a/backend/app/views/spree/admin/payments/index.html.erb
+++ b/backend/app/views/spree/admin/payments/index.html.erb
@@ -29,5 +29,5 @@
   <% end %>
 
 <% else %>
-  <div class="alpha twelve columns no-objects-found"><%= Spree.t(:order_has_no_payments) %></div>
+  <div class="col-xs-9 no-objects-found"><%= Spree.t(:order_has_no_payments) %></div>
 <% end %>

--- a/backend/app/views/spree/admin/payments/source_forms/_gateway.html.erb
+++ b/backend/app/views/spree/admin/payments/source_forms/_gateway.html.erb
@@ -13,41 +13,43 @@
 
     <div class="clear"></div>
 
-    <div class="alpha four columns">
-      <div data-hook="card_number">
-        <div class="field">
-          <%= hidden_field_tag "#{param_prefix}[cc_type]", '', {class: 'ccType'} %>
-          <%= label_tag "card_number#{payment_method.id}", Spree::CreditCard.human_attribute_name(:number), class: 'required' %>
-          <%= text_field_tag "#{param_prefix}[number]", '', :class => 'required fullwidth cardNumber', :id => "card_number#{payment_method.id}", :maxlength => 19 %>
-          <span id="card_type" style="display:none;">
-            ( <span id="looks_like" ><%= Spree.t(:card_type_is) %> <span id="type"></span></span>
-              <span id="unrecognized"><%= Spree.t(:unrecognized_card_type) %></span>
-            )
-          </span>
+    <div class="row">
+      <div class="col-xs-5">
+        <div data-hook="card_number">
+          <div class="field">
+            <%= hidden_field_tag "#{param_prefix}[cc_type]", '', {class: 'ccType'} %>
+            <%= label_tag "card_number#{payment_method.id}", Spree::CreditCard.human_attribute_name(:number), class: 'required' %>
+            <%= text_field_tag "#{param_prefix}[number]", '', :class => 'required fullwidth cardNumber', :id => "card_number#{payment_method.id}", :maxlength => 19 %>
+            <span id="card_type" style="display:none;">
+              ( <span id="looks_like" ><%= Spree.t(:card_type_is) %> <span id="type"></span></span>
+                <span id="unrecognized"><%= Spree.t(:unrecognized_card_type) %></span>
+              )
+            </span>
+          </div>
         </div>
       </div>
-    </div>
-    <div class="alpha four columns">
-      <div data-hook="card_name">
-        <div class="field">
-          <%= label_tag "card_name#{payment_method.id}", Spree::CreditCard.human_attribute_name(:name), class: 'required' %>
-          <%= text_field_tag "#{param_prefix}[name]", '', id: "card_name#{payment_method.id}", class: 'required fullwidth', maxlength: 19 %>
+      <div class="col-xs-5">
+        <div data-hook="card_name">
+          <div class="field">
+            <%= label_tag "card_name#{payment_method.id}", Spree::CreditCard.human_attribute_name(:name), class: 'required' %>
+            <%= text_field_tag "#{param_prefix}[name]", '', id: "card_name#{payment_method.id}", class: 'required fullwidth', maxlength: 19 %>
+          </div>
         </div>
       </div>
-    </div>
-    <div class="three columns">
-      <div data-hook="card_expiration" class="field">
-        <%= label_tag "card_expiry#{payment_method.id}", Spree::CreditCard.human_attribute_name(:expiration), class: 'required' %>
-        <%= text_field_tag "#{param_prefix}[expiry]", '', id: "card_expiry#{payment_method.id}", class: "required cardExpiry", placeholder: "MM / YY" %>
+      <div class="col-xs-4">
+        <div data-hook="card_expiration" class="field">
+          <%= label_tag "card_expiry#{payment_method.id}", Spree::CreditCard.human_attribute_name(:expiration), class: 'required' %>
+          <%= text_field_tag "#{param_prefix}[expiry]", '', id: "card_expiry#{payment_method.id}", class: "required cardExpiry", placeholder: "MM / YY" %>
+        </div>
       </div>
-    </div>
-    <div class="omega two columns">
-      <div data-hook="card_code" class="field">
-        <%= label_tag "card_code#{payment_method.id}", Spree::CreditCard.human_attribute_name(:card_code), class: 'required' %>
-        <%= text_field_tag "#{param_prefix}[verification_value]", '', id: "card_code#{payment_method.id}", class: 'required fullwidth cardCode', size: 5 %>
-        <a href="/content/cvv" class="info cvvLink" target="_blank">
-          (<%= Spree.t(:what_is_this) %>)
-        </a>
+      <div class="col-xs-3">
+        <div data-hook="card_code" class="field">
+          <%= label_tag "card_code#{payment_method.id}", Spree::CreditCard.human_attribute_name(:card_code), class: 'required' %>
+          <%= text_field_tag "#{param_prefix}[verification_value]", '', id: "card_code#{payment_method.id}", class: 'required fullwidth cardCode', size: 5 %>
+          <a href="/content/cvv" class="info cvvLink" target="_blank">
+            (<%= Spree.t(:what_is_this) %>)
+          </a>
+        </div>
       </div>
     </div>
 

--- a/backend/app/views/spree/admin/payments/source_views/_gateway.html.erb
+++ b/backend/app/views/spree/admin/payments/source_views/_gateway.html.erb
@@ -2,7 +2,7 @@
   <legend align="center"><%= Spree::CreditCard.model_name.human %></legend>
 
   <div class="row">
-    <div class="alpha six columns">
+    <div class="col-xs-4">
       <dl>
         <dt><%= Spree.t(:name_on_card) %>:</dt>
         <dd><%= payment.source.name %></dd>

--- a/backend/app/views/spree/admin/payments/source_views/_storecredit.html.erb
+++ b/backend/app/views/spree/admin/payments/source_views/_storecredit.html.erb
@@ -2,7 +2,7 @@
   <legend align="center"><%= Spree::StoreCredit.model_name.human %></legend>
 
   <div class="row">
-    <div class="alpha six columns">
+    <div class="col-xs-4">
       <dl>
         <dt><%= Spree::StoreCreditCategory.model_name.human %>:</dt>
         <dd><%= payment.source.category.name%></dd>

--- a/backend/app/views/spree/admin/prices/_form.html.erb
+++ b/backend/app/views/spree/admin/prices/_form.html.erb
@@ -1,47 +1,48 @@
 <div data-hook="admin_product_price_fields">
 
   <div data-hook="admin_product_price_form">
-    <div class="four columns alpha" data-hook="admin_product_price_form_variant">
-      <%= f.field_container :variant do %>
-        <%= f.label :variant %>
-        <%= f.select :variant_id,
-                     @product.variants_including_master.map { |v| [v.descriptive_name, v.id] },
-                     {},
-                     class: "select2 fullwidth", disabled: !f.object.new_record? %>
-      <% end %>
-    </div>
+    <div class="row">
+      <div class="col-xs-3" data-hook="admin_product_price_form_variant">
+        <%= f.field_container :variant do %>
+          <%= f.label :variant %>
+          <%= f.select :variant_id,
+                      @product.variants_including_master.map { |v| [v.descriptive_name, v.id] },
+                      {},
+                      class: "select2 fullwidth", disabled: !f.object.new_record? %>
+        <% end %>
+      </div>
 
-    <div class="three columns alpha" data-hook="admin_product_price_form_currency">
-      <%= f.field_container :currency do %>
-        <%= f.label :currency %>
-        <%= f.select :currency,
-                     Money::Currency.all.map { |c| ["#{c.iso_code} (#{c.name})", c.iso_code] },
-                     {},
-                     class: "select2 fullwidth", disabled: !f.object.new_record? %>
-      <% end %>
-    </div>
+      <div class="col-xs-2" data-hook="admin_product_price_form_currency">
+        <%= f.field_container :currency do %>
+          <%= f.label :currency %>
+          <%= f.select :currency,
+                      Money::Currency.all.map { |c| ["#{c.iso_code} (#{c.name})", c.iso_code] },
+                      {},
+                      class: "select2 fullwidth", disabled: !f.object.new_record? %>
+        <% end %>
+      </div>
 
-    <div class="three columns" data-hook="admin_product_price_form_country">
-      <%= f.field_container :country do %>
-        <%= f.label :country %>
-        <%= f.field_hint :country %>
-        <%= f.collection_select :country_iso, available_countries, :iso, :name,
-                                {
-                                  include_blank: t(:any_country, scope: [:spree, :admin, :prices]),
-                                  selected: Spree::Config.admin_vat_country_iso
-                                },
-                                { class: 'select2 fullwidth', disabled: !f.object.new_record? } %>
-      <% end %>
-    </div>
+      <div class="col-xs-2" data-hook="admin_product_price_form_country">
+        <%= f.field_container :country do %>
+          <%= f.label :country %>
+          <%= f.field_hint :country %>
+          <%= f.collection_select :country_iso, available_countries, :iso, :name,
+                                  {
+                                    include_blank: t(:any_country, scope: [:spree, :admin, :prices]),
+                                    selected: Spree::Config.admin_vat_country_iso
+                                  },
+                                  { class: 'select2 fullwidth', disabled: !f.object.new_record? } %>
+        <% end %>
+      </div>
 
-    <div class="three columns" data-hook="admin_product_price_form_amount">
-      <%= f.field_container :price do %>
-        <%= f.label :price %>
-        <%= f.text_field :price, value: f.object.money.format, class: 'fullwidth title' %>
-      <% end %>
-    </div>
-
+      <div class="col-xs-2" data-hook="admin_product_price_form_amount">
+        <%= f.field_container :price do %>
+          <%= f.label :price %>
+          <%= f.text_field :price, value: f.object.money.format, class: 'fullwidth title' %>
+        <% end %>
+      </div>
   </div>
+
 </div>
 
 <div class="clear"></div>

--- a/backend/app/views/spree/admin/prices/index.html.erb
+++ b/backend/app/views/spree/admin/prices/index.html.erb
@@ -14,50 +14,51 @@
 <div data-hook="admin_product_prices_index_search">
   <%= search_form_for [:admin, :product, @search] do |f| %>
 
-  <div class="alpha four columns">
-    <div class="field" data-hook="sku-select">
-      <%= label_tag :q_variant_id_eq, Spree::Variant.model_name.human %>
-      <%= f.select :variant_id_eq,
-                   @product.variants_including_master.map { |v| [v.descriptive_name, v.id] },
-                   {include_blank: true},
-                   class: "select2 fullwidth" %>
+  <div class="row">
+    <div class="col-xs-4">
+      <div class="field" data-hook="sku-select">
+        <%= label_tag :q_variant_id_eq, Spree::Variant.model_name.human %>
+        <%= f.select :variant_id_eq,
+                    @product.variants_including_master.map { |v| [v.descriptive_name, v.id] },
+                    {include_blank: true},
+                    class: "select2 fullwidth" %>
+      </div>
+    </div>
+
+    <div class="col-xs-2">
+      <div class="field" data-hook="currency-select">
+        <%= label_tag :q_currency_eq, Spree::Price.human_attribute_name(:currency) %>
+        <%= f.select :currency_eq,
+                    @prices.map(&:currency).uniq,
+                    {include_blank: true},
+                    class: "select2 fullwidth" %>
+      </div>
+    </div>
+
+    <div class="col-xs-2">
+      <div class="field" data-hook="country-select">
+        <%= label_tag :q_country_iso_eq, Spree::Price.human_attribute_name(:country) %>
+        <%= f.select :country_iso_eq,
+                    @prices.map(&:country).compact.uniq.map { |c| [c.name, c.iso]},
+                    {include_blank: true},
+                    class: "select2 fullwidth" %>
+      </div>
+    </div>
+
+    <div class="col-xs-2">
+      <div class="field">
+        <%= label_tag :q_amount_gt, t(".amount_greater_than") %>
+        <%= f.text_field :amount_gt %>
+      </div>
+    </div>
+
+    <div class="col-xs-2">
+      <div class="field">
+        <%= label_tag :q_amount_lt, t(".amount_less_than") %>
+        <%= f.text_field :amount_lt %>
+      </div>
     </div>
   </div>
-
-  <div class="three columns">
-    <div class="field" data-hook="currency-select">
-      <%= label_tag :q_currency_eq, Spree::Price.human_attribute_name(:currency) %>
-      <%= f.select :currency_eq,
-                   @prices.map(&:currency).uniq,
-                   {include_blank: true},
-                   class: "select2 fullwidth" %>
-    </div>
-  </div>
-
-  <div class="three columns">
-    <div class="field" data-hook="country-select">
-      <%= label_tag :q_country_iso_eq, Spree::Price.human_attribute_name(:country) %>
-      <%= f.select :country_iso_eq,
-                   @prices.map(&:country).compact.uniq.map { |c| [c.name, c.iso]},
-                   {include_blank: true},
-                   class: "select2 fullwidth" %>
-    </div>
-  </div>
-
-  <div class="three columns">
-    <div class="field">
-      <%= label_tag :q_amount_gt, t(".amount_greater_than") %>
-      <%= f.text_field :amount_gt %>
-    </div>
-  </div>
-
-  <div class="omega three columns">
-    <div class="field">
-      <%= label_tag :q_amount_lt, t(".amount_less_than") %>
-      <%= f.text_field :amount_lt %>
-    </div>
-  </div>
-
   <div class="clearfix"></div>
 
   <div class="actions filter-actions">

--- a/backend/app/views/spree/admin/promotion_categories/_form.html.erb
+++ b/backend/app/views/spree/admin/promotion_categories/_form.html.erb
@@ -1,7 +1,7 @@
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @promotion } %>
 
 <div class='row'>
-  <div class='alpha six columns'>
+  <div class='col-xs-4'>
     <%= f.field_container :name do %>
       <%= f.label :name %>
       <%= f.text_field :name, :class => 'fullwidth' %>

--- a/backend/app/views/spree/admin/promotions/_actions.html.erb
+++ b/backend/app/views/spree/admin/promotions/_actions.html.erb
@@ -1,4 +1,4 @@
-<fieldset id="action_fields" class="eight columns omega no-border-top">
+<fieldset id="action_fields" class="no-border-top">
 
   <%= form_tag spree.admin_promotion_promotion_actions_path(@promotion), :remote => true, :id => 'new_promotion_action_form' do %>
     <% options = options_for_select(  Rails.application.config.spree.promotions.actions.map(&:name).map {|name| [ Spree.t("promotion_action_types.#{name.demodulize.underscore}.name"), name] } ) %>

--- a/backend/app/views/spree/admin/promotions/_form.html.erb
+++ b/backend/app/views/spree/admin/promotions/_form.html.erb
@@ -1,59 +1,61 @@
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @promotion } %>
 <div class="row">
-  <div id="general_fields" class="alpha thirteen columns">
-    <div class="alpha four columns">
-      <%= f.field_container :name do %>
-        <%= f.label :name %>
-        <%= f.text_field :name, :class => 'fullwidth' %>
-      <% end %>
-
-      <%= fields_for :promotion_builder do |bf| %>
-        <%= bf.field_container :base_code do %>
-          <%= bf.label :base_code %>
-          <%= bf.text_field :base_code, :readonly => !@promotion.new_record?, :class => 'fullwidth' %>
+  <div id="general_fields" class="col-xs-9">
+    <div class="row">
+      <div class="col-xs-3">
+        <%= f.field_container :name do %>
+          <%= f.label :name %>
+          <%= f.text_field :name, :class => 'fullwidth' %>
         <% end %>
 
-        <%= bf.field_container :number_of_codes do %>
-          <%= bf.label :number_of_codes %>
-          <%= bf.text_field :number_of_codes, :readonly => !@promotion.new_record?, class: 'fullwidth' %>
+        <%= fields_for :promotion_builder do |bf| %>
+          <%= bf.field_container :base_code do %>
+            <%= bf.label :base_code %>
+            <%= bf.text_field :base_code, :readonly => !@promotion.new_record?, :class => 'fullwidth' %>
+          <% end %>
+
+          <%= bf.field_container :number_of_codes do %>
+            <%= bf.label :number_of_codes %>
+            <%= bf.text_field :number_of_codes, :readonly => !@promotion.new_record?, class: 'fullwidth' %>
+          <% end %>
         <% end %>
-      <% end %>
 
-      <%= f.field_container :per_code_usage_limit do %>
-        <%= f.label :per_code_usage_limit %>
-        <%= f.text_field :per_code_usage_limit, class: 'fullwidth' %>
-      <% end %>
+        <%= f.field_container :per_code_usage_limit do %>
+          <%= f.label :per_code_usage_limit %>
+          <%= f.text_field :per_code_usage_limit, class: 'fullwidth' %>
+        <% end %>
 
-      <%= f.field_container :path do %>
-        <%= f.label :path %>
-        <%= f.text_field :path, :class => 'fullwidth' %>
-      <% end %>
+        <%= f.field_container :path do %>
+          <%= f.label :path %>
+          <%= f.text_field :path, :class => 'fullwidth' %>
+        <% end %>
 
-      <%= f.field_container :advertise do %>
-        <%= f.check_box :advertise %>
-        <%= f.label :advertise %>
-      <% end %>
+        <%= f.field_container :advertise do %>
+          <%= f.check_box :advertise %>
+          <%= f.label :advertise %>
+        <% end %>
 
-      <%= f.field_container :apply_automatically do %>
-        <%= f.check_box :apply_automatically %>
-        <%= f.label :apply_automatically %>
-      <% end %>
-    </div>
+        <%= f.field_container :apply_automatically do %>
+          <%= f.check_box :apply_automatically %>
+          <%= f.label :apply_automatically %>
+        <% end %>
+      </div>
 
-    <div class="omega nine columns">
-      <%= f.field_container :description do %>
-        <%= f.label :description %><br />
-        <%= f.text_area :description, :rows => 7, :class => 'fullwidth' %>
-      <% end %>
+      <div class="col-xs-9">
+        <%= f.field_container :description do %>
+          <%= f.label :description %><br />
+          <%= f.text_area :description, :rows => 7, :class => 'fullwidth' %>
+        <% end %>
 
-      <%= f.field_container :category do %>
-        <%= f.label :promotion_category_id, Spree::PromotionCategory.model_name.human %><br />
-        <%= f.collection_select(:promotion_category_id, @promotion_categories, :id, :name, { :include_blank => Spree.t('match_choices.none') }, { :class => 'select2 fullwidth' }) %>
-      <% end %>
+        <%= f.field_container :category do %>
+          <%= f.label :promotion_category_id, Spree::PromotionCategory.model_name.human %><br />
+          <%= f.collection_select(:promotion_category_id, @promotion_categories, :id, :name, { :include_blank => Spree.t('match_choices.none') }, { :class => 'select2 fullwidth' }) %>
+        <% end %>
+      </div>
     </div>
   </div>
 
-  <div id="expiry_fields" class="three columns omega">
+  <div id="expiry_fields" class="col-xs-3">
     <%= f.field_container :overall_usage_limit do %>
       <%= f.label :usage_limit %><br />
       <%= f.number_field :usage_limit, :min => 0, :class => 'fullwidth' %><br>

--- a/backend/app/views/spree/admin/promotions/_promotion_rule.html.erb
+++ b/backend/app/views/spree/admin/promotions/_promotion_rule.html.erb
@@ -1,4 +1,4 @@
-<div class="promotion_rule promotion-block alpha omega eight columns" id="<%= dom_id promotion_rule %>">
+<div class="promotion_rule promotion-block col-xs-12" id="<%= dom_id promotion_rule %>">
   <% type_name = promotion_rule.class.name.demodulize.underscore %>
   <h6 class='promotion-title <%= 'no-text' if type_name == 'user_logged_in' || type_name == 'first_order'%>'><%= Spree.t("promotion_rule_types.#{type_name}.description") %></h6>
   <% if can?(:destroy, promotion_rule) %>

--- a/backend/app/views/spree/admin/promotions/_rules.html.erb
+++ b/backend/app/views/spree/admin/promotions/_rules.html.erb
@@ -1,4 +1,4 @@
-<fieldset id="rule_fields" class ="alpha eight columns no-border-bottom no-border-top">
+<fieldset id="rule_fields" class ="no-border-bottom no-border-top">
 
   <%= form_tag spree.admin_promotion_promotion_rules_path(@promotion), :remote => true, :id => 'new_product_rule_form' do %>
     <fieldset>
@@ -21,15 +21,19 @@
       <fieldset class="no-border-top">
         <div id="promotion-pilicy-select" class="align-center row">
           <% Spree::Promotion::MATCH_POLICIES.each do |policy| %>
-            <div class="alpha four columns">
+            <div class="col-xs-6">
               <label><%= f.radio_button :match_policy, policy %> <%= Spree.t "promotion_form.match_policies.#{policy}" %></label>
             </div>
           <% end %>
         </div>
 
-        <div id="rules" class="filter_list row">
+        <div id="rules" class="filter_list">
           <% if @promotion.rules.any? %>
-            <%= render :partial => 'promotion_rule', :collection => @promotion.rules, :locals => {} %>
+            <div class="col-xs-12">
+              <div class="row">
+                <%= render :partial => 'promotion_rule', :collection => @promotion.rules, :locals => {} %>
+              </div>
+            </div>
           <% else %>
             <div class="no-objects-found">
               <%= Spree.t(:no_rules_added) %>

--- a/backend/app/views/spree/admin/promotions/actions/_create_quantity_adjustments.html.erb
+++ b/backend/app/views/spree/admin/promotions/actions/_create_quantity_adjustments.html.erb
@@ -1,8 +1,12 @@
-<div class="row">
-  <div class="field eight columns alpha omega">
-    <% field_name = "#{param_prefix}[preferred_group_size]" %>
-    <%= label_tag field_name, Spree.t(:group_size) %>
-    <%= number_field_tag field_name, promotion_action.preferred_group_size, class: "fullwidth", min: 1 %>
+<div class="col-xs-12">
+  <div class="row">
+    <div class="col-xs-12">
+      <div class="field">
+        <% field_name = "#{param_prefix}[preferred_group_size]" %>
+        <%= label_tag field_name, Spree.t(:group_size) %>
+        <%= number_field_tag field_name, promotion_action.preferred_group_size, class: "fullwidth", min: 1 %>
+      </div>
+    </div>
   </div>
 </div>
 

--- a/backend/app/views/spree/admin/promotions/actions/_promotion_calculators_with_custom_fields.html.erb
+++ b/backend/app/views/spree/admin/promotions/actions/_promotion_calculators_with_custom_fields.html.erb
@@ -1,28 +1,34 @@
-<div class="calculator-fields row">
+<div class="col-xs-12">
+  <div class="calculator-fields row">
 
-  <div class="field alpha four columns">
-    <% field_name = "#{param_prefix}[calculator_type]" %>
-    <%= label_tag field_name, Spree::Calculator.model_name.human %>
-    <%= select_tag field_name,
-                   options_from_collection_for_select(calculators, :to_s, :description, promotion_action.calculator.type),
-                   :class => 'type-select select2 fullwidth' %>
-    <% if promotion_action.calculator.respond_to?(:preferences) %>
-      <span class="warning info"><%= Spree.t(:calculator_settings_warning) %></span>
+    <div class="col-xs-6">
+      <div class="field">
+        <% field_name = "#{param_prefix}[calculator_type]" %>
+        <%= label_tag field_name, Spree::Calculator.model_name.human %>
+        <%= select_tag field_name,
+                      options_from_collection_for_select(calculators, :to_s, :description, promotion_action.calculator.type),
+                      :class => 'type-select select2 fullwidth' %>
+        <% if promotion_action.calculator.respond_to?(:preferences) %>
+          <span class="warning info"><%= Spree.t(:calculator_settings_warning) %></span>
+        <% end %>
+      </div>
+    </div>
+
+    <% unless promotion_action.new_record? %>
+      <div class="col-xs-6">
+        <div class="settings field">
+          <% type_name = promotion_action.calculator.type.demodulize.underscore %>
+          <% if lookup_context.exists?("fields",
+              ["spree/admin/promotions/calculators/#{type_name}"], true) %>
+            <%= render "spree/admin/promotions/calculators/#{type_name}/fields",
+              calculator: promotion_action.calculator, prefix: param_prefix %>
+          <% else %>
+            <%= render "spree/admin/promotions/calculators/default_fields",
+              calculator: promotion_action.calculator, prefix: param_prefix %>
+          <% end %>
+          <%= hidden_field_tag "#{param_prefix}[calculator_attributes][id]", promotion_action.calculator.id %>
+        </div>
+      </div>
     <% end %>
   </div>
-
-  <% unless promotion_action.new_record? %>
-    <div class="settings field omega four columns">
-      <% type_name = promotion_action.calculator.type.demodulize.underscore %>
-      <% if lookup_context.exists?("fields",
-          ["spree/admin/promotions/calculators/#{type_name}"], true) %>
-        <%= render "spree/admin/promotions/calculators/#{type_name}/fields",
-          calculator: promotion_action.calculator, prefix: param_prefix %>
-      <% else %>
-        <%= render "spree/admin/promotions/calculators/default_fields",
-          calculator: promotion_action.calculator, prefix: param_prefix %>
-      <% end %>
-      <%= hidden_field_tag "#{param_prefix}[calculator_attributes][id]", promotion_action.calculator.id %>
-    </div>
-  <% end %>
 </div>

--- a/backend/app/views/spree/admin/promotions/edit.html.erb
+++ b/backend/app/views/spree/admin/promotions/edit.html.erb
@@ -20,11 +20,11 @@
 <% end %>
 
 <div id="promotion-filters" class="row">
-  <div id="rules_container" class="alpha eight columns">
+  <div id="rules_container" class="col-xs-6">
     <%= render :partial => 'rules' %>
   </div>
 
-  <div id="actions_container" class="omega eight columns">
+  <div id="actions_container" class="col-xs-6">
     <%= render :partial => 'actions' %>
   </div>
 </div>

--- a/backend/app/views/spree/admin/promotions/index.html.erb
+++ b/backend/app/views/spree/admin/promotions/index.html.erb
@@ -15,31 +15,33 @@
 <% content_for :table_filter do %>
   <div data-hook="admin_promotions_index_search">
     <%= search_form_for [:admin, @search] do |f| %>
-      <div class="four columns alpha">
-        <div class="field">
-          <%= label_tag :q_name_cont, Spree::Promotion.human_attribute_name(:name) %>
-          <%= f.text_field :name_cont, tabindex: 1 %>
+      <div class="row">
+        <div class="col-xs-3">
+          <div class="field">
+            <%= label_tag :q_name_cont, Spree::Promotion.human_attribute_name(:name) %>
+            <%= f.text_field :name_cont, tabindex: 1 %>
+          </div>
         </div>
-      </div>
 
-      <div class="four columns">
-        <div class="field">
-          <%= label_tag :q_codes_value_cont, Spree::Promotion.human_attribute_name(:code) %>
-          <%= f.text_field :codes_value_cont, tabindex: 1 %>
+        <div class="col-xs-3">
+          <div class="field">
+            <%= label_tag :q_codes_value_cont, Spree::Promotion.human_attribute_name(:code) %>
+            <%= f.text_field :codes_value_cont, tabindex: 1 %>
+          </div>
         </div>
-      </div>
 
-      <div class="four columns">
-        <div class="field">
-          <%= label_tag :q_path_cont, Spree::Promotion.human_attribute_name(:path) %>
-          <%= f.text_field :path_cont, tabindex: 1 %>
+        <div class="col-xs-3">
+          <div class="field">
+            <%= label_tag :q_path_cont, Spree::Promotion.human_attribute_name(:path) %>
+            <%= f.text_field :path_cont, tabindex: 1 %>
+          </div>
         </div>
-      </div>
 
-      <div class="four columns omega">
-        <div class="field">
-          <%= label_tag :q_promotion_category_id_eq, Spree::PromotionCategory.model_name.human %><br>
-          <%= f.collection_select(:promotion_category_id_eq, @promotion_categories, :id, :name, { :include_blank => Spree.t('match_choices.all') }, { :class => 'select2 fullwidth' }) %>
+        <div class="col-xs-3">
+          <div class="field">
+            <%= label_tag :q_promotion_category_id_eq, Spree::PromotionCategory.model_name.human %><br>
+            <%= f.collection_select(:promotion_category_id_eq, @promotion_categories, :id, :name, { :include_blank => Spree.t('match_choices.all') }, { :class => 'select2 fullwidth' }) %>
+          </div>
         </div>
       </div>
 
@@ -101,7 +103,7 @@
     </tbody>
   </table>
 <% else %>
-  <div class="alpha twelve columns no-objects-found">
+  <div class="col-xs-9 no-objects-found">
     <%= render 'spree/admin/shared/no_objects_found',
                  resource: Spree::Promotion,
                  new_resource_url: new_object_url %>

--- a/backend/app/views/spree/admin/promotions/rules/_first_repeat_purchase_since.html.erb
+++ b/backend/app/views/spree/admin/promotions/rules/_first_repeat_purchase_since.html.erb
@@ -1,7 +1,13 @@
-<div class="field alpha four columns">
-  <%= Spree.t(:form_text, scope: "promotion_rule_types.first_repeat_purchase_since")  %>
-</div>
+<div class="row">
+  <div class="col-xs-6">
+    <div class="field">
+      <%= Spree.t(:form_text, scope: "promotion_rule_types.first_repeat_purchase_since")  %>
+    </div>
+  </div>
 
-<div class="field omega four columns">
-  <%= number_field_tag "#{param_prefix}[preferred_days_ago]", promotion_rule.preferred_days_ago, :class => 'fullwidth' %>
+  <div class="col-xs-6">
+    <div class="field">
+      <%= number_field_tag "#{param_prefix}[preferred_days_ago]", promotion_rule.preferred_days_ago, :class => 'fullwidth' %>
+    </div>
+  </div>
 </div>

--- a/backend/app/views/spree/admin/promotions/rules/_item_total.html.erb
+++ b/backend/app/views/spree/admin/promotions/rules/_item_total.html.erb
@@ -1,9 +1,19 @@
-<div class="field alpha three columns">
-  <%= select_tag "#{param_prefix}[preferred_operator]", options_for_select(Spree::Promotion::Rules::ItemTotal::OPERATORS.map{|o| [Spree.t("item_total_rule.operators.#{o}"),o]}, promotion_rule.preferred_operator), {:class => 'select2 select_item_total fullwidth'} %>
-</div>
-<div class="field three columns">
-  <%= text_field_tag "#{param_prefix}[preferred_amount]", promotion_rule.preferred_amount, :class => 'fullwidth' %>
-</div>
-<div class="field omega two columns">
-  <%= text_field_tag "#{param_prefix}[preferred_currency]", promotion_rule.preferred_currency, :class => 'fullwidth' %>
+<div class="col-xs-12">
+  <div class="row">
+    <div class="col-xs-4">
+      <div class="field">
+        <%= select_tag "#{param_prefix}[preferred_operator]", options_for_select(Spree::Promotion::Rules::ItemTotal::OPERATORS.map{|o| [Spree.t("item_total_rule.operators.#{o}"),o]}, promotion_rule.preferred_operator), {:class => 'select2 select_item_total fullwidth'} %>
+      </div>
+    </div>
+    <div class="col-xs-4">
+      <div class="field">
+        <%= text_field_tag "#{param_prefix}[preferred_amount]", promotion_rule.preferred_amount, :class => 'fullwidth' %>
+      </div>
+    </div>
+    <div class="col-xs-4">
+      <div class="field">
+        <%= text_field_tag "#{param_prefix}[preferred_currency]", promotion_rule.preferred_currency, :class => 'fullwidth' %>
+      </div>
+    </div>
+  </div>
 </div>

--- a/backend/app/views/spree/admin/promotions/rules/_landing_page.html.erb
+++ b/backend/app/views/spree/admin/promotions/rules/_landing_page.html.erb
@@ -1,5 +1,7 @@
-<div class="field alpha omega eight columns">
-  <label for="<%= "#{param_prefix}_preferred_path" %>"><%= Spree.t('promotion_rule_types.landing_page.description') %>:</label>  
-  <%= text_field_tag "#{param_prefix}[preferred_path]", promotion_rule.preferred_path, :class => 'fullwidth' %>  
-  <span class="info"><%= Spree.t('landing_page_rule.must_have_visited_path') %></span>
+<div class="col-xs-12">
+  <div class="field">
+    <label for="<%= "#{param_prefix}_preferred_path" %>"><%= Spree.t('promotion_rule_types.landing_page.description') %>:</label>  
+    <%= text_field_tag "#{param_prefix}[preferred_path]", promotion_rule.preferred_path, :class => 'fullwidth' %>  
+    <span class="info"><%= Spree.t('landing_page_rule.must_have_visited_path') %></span>
+  </div>
 </div>

--- a/backend/app/views/spree/admin/promotions/rules/_nth_order.html.erb
+++ b/backend/app/views/spree/admin/promotions/rules/_nth_order.html.erb
@@ -1,7 +1,14 @@
-<div class="field alpha four columns">
-  <%= Spree.t(:form_text, scope: "promotion_rule_types.nth_order")  %>
-</div>
-
-<div class="field omega four columns">
-  <%= number_field_tag "#{param_prefix}[preferred_nth_order]", promotion_rule.preferred_nth_order, :class => 'fullwidth' %>
+<div class="col-xs-12">
+  <div class="row">
+    <div class="col-xs-6">
+      <div class="field">
+        <%= Spree.t(:form_text, scope: "promotion_rule_types.nth_order")  %>
+      </div>
+    </div>
+    <div class="col-xs-6">
+      <div class="field">
+        <%= number_field_tag "#{param_prefix}[preferred_nth_order]", promotion_rule.preferred_nth_order, :class => 'fullwidth' %>
+      </div>
+    </div>
+  </div>
 </div>

--- a/backend/app/views/spree/admin/promotions/rules/_option_value.html.erb
+++ b/backend/app/views/spree/admin/promotions/rules/_option_value.html.erb
@@ -1,12 +1,16 @@
-<div class="field alpha omega eight columns promo-rule-option-values">
-  <div class="param-prefix hidden" data-param-prefix="<%= param_prefix %>"></div>
-  <div class="four columns alpha"><%= label_tag nil, Spree::Product.model_name.human %></div>
-  <div class="three columns omega"><%= label_tag nil, plural_resource_name(Spree::OptionValue) %></div>
-  <div class="clear"></div>
+<div class="col-xs-12">
+  <div class="field promo-rule-option-values">
+    <div class="param-prefix hidden" data-param-prefix="<%= param_prefix %>"></div>
+    <div class="row">
+      <div class="col-xs-6"><%= label_tag nil, Spree::Product.model_name.human %></div>
+      <div class="col-xs-6"><%= label_tag nil, plural_resource_name(Spree::OptionValue) %></div>
+    </div>
+    <div class="clear"></div>
 
-  <div class="js-promo-rule-option-values"></div>
+    <div class="js-promo-rule-option-values"></div>
 
-  <button class="button js-add-promo-rule-option-value"><%= Spree.t('actions.add') %></button>
+    <button class="button js-add-promo-rule-option-value"><%= Spree.t('actions.add') %></button>
+  </div>
 </div>
 
 <%= content_tag :div, nil, class: "hidden js-original-promo-rule-option-values",

--- a/backend/app/views/spree/admin/promotions/rules/_product.html.erb
+++ b/backend/app/views/spree/admin/promotions/rules/_product.html.erb
@@ -1,9 +1,13 @@
-<div class="field alpha omega eight columns products_rule_products">
-  <%= label_tag "#{param_prefix}_product_ids_string", Spree.t('product_rule.choose_products') %>
-  <%= hidden_field_tag "#{param_prefix}[product_ids_string]", promotion_rule.product_ids.join(","), :class => "product_picker fullwidth" %>
+<div class="col-xs-12">
+  <div class="field products_rule_products">
+    <%= label_tag "#{param_prefix}_product_ids_string", Spree.t('product_rule.choose_products') %>
+    <%= hidden_field_tag "#{param_prefix}[product_ids_string]", promotion_rule.product_ids.join(","), :class => "product_picker fullwidth" %>
+  </div>
 </div>
-<div class="field alpha omega eight columns">
-  <label>
-    <%= Spree.t('product_rule.label', :select => select_tag("#{param_prefix}[preferred_match_policy]", options_for_select(Spree::Promotion::Rules::Product::MATCH_POLICIES.map{|s| [Spree.t("product_rule.match_#{s}"),s] }, promotion_rule.preferred_match_policy), {:class => 'select_product select2'})).html_safe %>
-  </label>
+<div class="col-xs-12">
+  <div class="field">
+    <label>
+      <%= Spree.t('product_rule.label', :select => select_tag("#{param_prefix}[preferred_match_policy]", options_for_select(Spree::Promotion::Rules::Product::MATCH_POLICIES.map{|s| [Spree.t("product_rule.match_#{s}"),s] }, promotion_rule.preferred_match_policy), {:class => 'select_product select2'})).html_safe %>
+    </label>
+  </div>
 </div>

--- a/backend/app/views/spree/admin/promotions/rules/_taxon.html.erb
+++ b/backend/app/views/spree/admin/promotions/rules/_taxon.html.erb
@@ -1,9 +1,15 @@
-<div class="field alpha omega eight columns taxons_rule_taxons">
-  <%= label_tag "#{param_prefix}_taxon_ids_string", Spree.t('taxon_rule.choose_taxons') %>
-  <%= hidden_field_tag "#{param_prefix}[taxon_ids_string]", promotion_rule.taxon_ids.join(","), :class => "taxon_picker fullwidth", id: 'product_taxon_ids' %>
-</div>
-<div class="field alpha omega eight columns">
-  <label>
-    <%= Spree.t('taxon_rule.label', :select => select_tag("#{param_prefix}[preferred_match_policy]", options_for_select(Spree::Promotion::Rules::Taxon::MATCH_POLICIES.map{|s| [Spree.t("taxon_rule.match_#{s}"),s] }, promotion_rule.preferred_match_policy), {:class => 'select_taxon select2'})).html_safe %>
-  </label>
-</div>
+  <div class="row">
+    <div class="col-xs-11">
+      <div class="field taxons_rule_taxons">
+        <%= label_tag "#{param_prefix}_taxon_ids_string", Spree.t('taxon_rule.choose_taxons') %>
+        <%= hidden_field_tag "#{param_prefix}[taxon_ids_string]", promotion_rule.taxon_ids.join(","), :class => "taxon_picker fullwidth", id: 'product_taxon_ids' %>
+      </div>
+    </div>
+    <div class="col-xs-12">
+      <div class="field">
+        <label>
+          <%= Spree.t('taxon_rule.label', :select => select_tag("#{param_prefix}[preferred_match_policy]", options_for_select(Spree::Promotion::Rules::Taxon::MATCH_POLICIES.map{|s| [Spree.t("taxon_rule.match_#{s}"),s] }, promotion_rule.preferred_match_policy), {:class => 'select_taxon select2'})).html_safe %>
+        </label>
+      </div>
+    </div>
+  </div>

--- a/backend/app/views/spree/admin/promotions/rules/_user.html.erb
+++ b/backend/app/views/spree/admin/promotions/rules/_user.html.erb
@@ -1,4 +1,6 @@
-<div class="field alpha omega eight columns">
-  <label><%= Spree.t('user_rule.choose_users') %></label><br>
-  <input type='hidden' name='<%= param_prefix %>[user_ids_string]' class='user_picker fullwidth' value='<%= promotion_rule.user_ids.join(",") %>'>
+<div class="col-xs-12">
+  <div class="field">
+    <label><%= Spree.t('user_rule.choose_users') %></label><br>
+    <input type='hidden' name='<%= param_prefix %>[user_ids_string]' class='user_picker fullwidth' value='<%= promotion_rule.user_ids.join(",") %>'>
+  </div>
 </div>

--- a/backend/app/views/spree/admin/properties/_form.html.erb
+++ b/backend/app/views/spree/admin/properties/_form.html.erb
@@ -1,12 +1,12 @@
 <div data-hook="admin_property_form" class="align-center row">
-  <div class="alpha eight columns">
+  <div class="col-xs-6">
     <%= f.field_container :name do %>
       <%= f.label :name, class: 'required' %><br />
       <%= f.text_field :name, :class => 'fullwidth' %>
       <%= f.error_message_on :name %>
     <% end %>
   </div>
-  <div class="eight columns omega">
+  <div class="col-xs-6">
     <%= f.field_container :presentation do %>
       <%= f.label :presentation, class: 'required' %><br />
       <%= f.text_field :presentation, :class => 'fullwidth' %>

--- a/backend/app/views/spree/admin/properties/index.html.erb
+++ b/backend/app/views/spree/admin/properties/index.html.erb
@@ -22,10 +22,12 @@
         <%- locals = {:f => f} %>
 
         <div data-hook="admin_property_index_search">
-          <div class="alpha eight columns">
-            <div class="field">
-              <%= f.label :name_cont, Spree.t(:name) %>
-              <%= f.text_field :name_cont, :size => 15 %>
+          <div class="row">
+            <div class="col-xs-6">
+              <div class="field">
+                <%= f.label :name_cont, Spree.t(:name) %>
+                <%= f.text_field :name_cont, :size => 15 %>
+              </div>
             </div>
           </div>
         </div>
@@ -73,7 +75,7 @@
   </tbody>
 </table>
 <% else %>
-  <div class="alpha twelve columns no-objects-found">
+  <div class="col-xs-9 no-objects-found">
     <%= render 'spree/admin/shared/no_objects_found',
                  resource: Spree::Property,
                  new_resource_url: new_object_url %>

--- a/backend/app/views/spree/admin/prototypes/_form.html.erb
+++ b/backend/app/views/spree/admin/prototypes/_form.html.erb
@@ -1,5 +1,5 @@
 <div data-hook="admin_prototype_form_fields" class="row">
-  <div class="alpha four columns">
+  <div class="col-xs-3">
     <%= f.field_container :name do %>
       <%= f.label :name, class: 'required' %><br />
       <%= f.text_field :name, class: 'fullwidth' %>
@@ -7,7 +7,7 @@
     <% end %>
   </div>
 
-  <div class="four columns">
+  <div class="col-xs-3">
     <div id='properties' data-hook>
       <%= f.field_container :property_ids do %>
         <%= f.label :property_ids, plural_resource_name(Spree::Property) %><br>
@@ -16,7 +16,7 @@
     </div>
   </div>
 
-  <div class="four columns">
+  <div class="col-xs-3">
     <div id="option_types" data-hook>
       <%= f.field_container :option_type_ids do %>
         <%= f.label :option_type_ids, plural_resource_name(Spree::OptionType) %><br>
@@ -25,7 +25,7 @@
     </div>
   </div>
 
-  <div class="four columns omega">
+  <div class="col-xs-3">
     <div id='taxons' data-hook>
       <%= f.field_container :taxon_ids do %>
         <%= f.label :taxon_ids, plural_resource_name(Spree::Taxon) %><br>

--- a/backend/app/views/spree/admin/prototypes/index.html.erb
+++ b/backend/app/views/spree/admin/prototypes/index.html.erb
@@ -42,7 +42,7 @@
   </tbody>
 </table>
 <% else %>
-  <div class="alpha twelve columns no-objects-found">
+  <div class="col-xs-9 no-objects-found">
     <%= render 'spree/admin/shared/no_objects_found',
                  resource: Spree::Prototype,
                  new_resource_url: new_object_url %>

--- a/backend/app/views/spree/admin/refund_reasons/index.html.erb
+++ b/backend/app/views/spree/admin/refund_reasons/index.html.erb
@@ -48,7 +48,7 @@
     </tbody>
   </table>
 <% else %>
-  <div class="alpha twelve columns no-objects-found">
+  <div class="col-xs-9 no-objects-found">
     <%= render 'spree/admin/shared/no_objects_found',
                  resource: Spree::RefundReason,
                  new_resource_url: new_object_url %>

--- a/backend/app/views/spree/admin/refund_reasons/shared/_form.html.erb
+++ b/backend/app/views/spree/admin/refund_reasons/shared/_form.html.erb
@@ -1,22 +1,20 @@
 <div data-hook="admin_named_type_form_fields" class="row">
-  <div class="row">
-    <div class="alpha four columns">
-      <%= f.field_container :name do %>
-        <%= f.label :name, class: 'required' %><br />
-        <%= f.text_field :name, :class => 'fullwidth' %>
-      <% end %>
+  <div class="col-xs-3">
+    <%= f.field_container :name do %>
+      <%= f.label :name, class: 'required' %><br />
+      <%= f.text_field :name, :class => 'fullwidth' %>
+    <% end %>
 
-      <%= f.field_container :code do %>
-        <%= f.label :code, class: 'required' %><br />
-        <%= f.text_field :code, :class => 'fullwidth' %>
+    <%= f.field_container :code do %>
+      <%= f.label :code, class: 'required' %><br />
+      <%= f.text_field :code, :class => 'fullwidth' %>
 
-      <% end %>
-      <div class="checkbox">
-        <label>
-          <%= f.check_box :active %>
-          <%= Spree.t(:active) %>
-        </label>
-      </div>
+    <% end %>
+    <div class="checkbox">
+      <label>
+        <%= f.check_box :active %>
+        <%= Spree.t(:active) %>
+      </label>
     </div>
   </div>
 </div>

--- a/backend/app/views/spree/admin/refunds/edit.html.erb
+++ b/backend/app/views/spree/admin/refunds/edit.html.erb
@@ -7,13 +7,13 @@
 <%= form_for [:admin, @refund.payment.order, @refund.payment, @refund] do |f| %>
   <fieldset class="no-border-top">
     <div data-hook="admin_refund_form_fields" class="row">
-      <div class="alpha three columns">
+      <div class="col-xs-3">
         <div class="field">
           <%= f.label :amount %><br/>
           <%= @refund.amount %>
         </div>
       </div>
-      <div class="alpha three columns">
+      <div class="col-xs-3">
         <div class="field">
           <%= f.label :refund_reason_id %><br/>
           <%= f.collection_select(:refund_reason_id, refund_reasons, :id, :name, {}, {class: 'select2 fullwidth'}) %>

--- a/backend/app/views/spree/admin/refunds/new.html.erb
+++ b/backend/app/views/spree/admin/refunds/new.html.erb
@@ -8,25 +8,25 @@
 <%= form_for [:admin, @refund.payment.order, @refund.payment, @refund] do |f| %>
   <fieldset class="no-border-top">
     <div data-hook="admin_refund_form_fields" class="row">
-      <div class="alpha three columns">
+      <div class="col-xs-3">
         <div class="field">
           <%= Spree.t(:payment_amount) %><br/>
           <%= @refund.payment.amount %>
         </div>
       </div>
-      <div class="alpha three columns">
+      <div class="col-xs-3">
         <div class="field">
           <%= Spree.t(:credit_allowed) %><br/>
           <%= @refund.payment.credit_allowed %>
         </div>
       </div>
-      <div class="alpha three columns">
+      <div class="col-xs-3">
         <div class="field">
           <%= f.label :amount %><br/>
           <%= f.text_field :amount, class: 'fullwidth' %>
         </div>
       </div>
-      <div class="alpha three columns">
+      <div class="col-xs-3">
         <div class="field">
           <%= f.label :refund_reason_id %><br/>
           <%= f.collection_select(:refund_reason_id, refund_reasons, :id, :name, {include_blank: true}, {class: 'select2 fullwidth'}) %>

--- a/backend/app/views/spree/admin/shared/_sidebar.html.erb
+++ b/backend/app/views/spree/admin/shared/_sidebar.html.erb
@@ -1,5 +1,5 @@
 <% if content_for?(:sidebar) %>
-  <aside id="sidebar" data-hook class="content-sidebar four columns">
+  <aside id="sidebar" data-hook class="content-sidebar col-xs-3">
 
     <% if content_for?(:sidebar_title) %>
       <h5 class="sidebar-title"><span><%= yield :sidebar_title %></span></h5>

--- a/backend/app/views/spree/admin/shared/_variant_search.html.erb
+++ b/backend/app/views/spree/admin/shared/_variant_search.html.erb
@@ -1,14 +1,18 @@
 <div data-hook="admin_orders_index_search">
   <%= form_for :variant_search, url: form_path, method: :get do |f| %>
-    <div class="field-block alpha four columns">
-      <div class="field">
-        <%= label_tag nil, Spree::StockLocation.model_name.human %>
-        <%= select_tag :stock_location_id, options_from_collection_for_select(stock_locations, :id, :name, params[:stock_location_id]), { :include_blank => true, :class => 'select2 fullwidth', "data-placeholder" => Spree.t(:select_a_stock_location) } %>
+    <div class="row">
+      <div class="field-block col-xs-3">
+        <div class="field">
+          <%= label_tag nil, Spree::StockLocation.model_name.human %>
+          <%= select_tag :stock_location_id, options_from_collection_for_select(stock_locations, :id, :name, params[:stock_location_id]), { :include_blank => true, :class => 'select2 fullwidth', "data-placeholder" => Spree.t(:select_a_stock_location) } %>
+        </div>
       </div>
-    </div>
-    <div data-hook="add_product_name" class="field <%= if content_for?(:sidebar) then 'eight' else 'twelve' end %> columns alpha">
-      <%= label_tag :add_variant_id, Spree::Variant.model_name.human %>
-      <%= text_field_tag :variant_search_term, params[:variant_search_term], :class => "fullwidth", :placeholder => Spree.t(:variant_search_placeholder) %>
+      <div class="<%= if content_for?(:sidebar) then 'col-xs-6' else 'col-xs-9' end %>">
+        <div data-hook="add_product_name" class="field">
+          <%= label_tag :add_variant_id, Spree::Variant.model_name.human %>
+          <%= text_field_tag :variant_search_term, params[:variant_search_term], :class => "fullwidth", :placeholder => Spree.t(:variant_search_placeholder) %>
+        </div>
+      </div>
     </div>
 
     <div class="clearfix"></div>

--- a/backend/app/views/spree/admin/shared/named_types/_form.html.erb
+++ b/backend/app/views/spree/admin/shared/named_types/_form.html.erb
@@ -1,6 +1,6 @@
 <div data-hook="admin_named_type_form_fields" class="row">
   <div class="row">
-    <div class="alpha four columns">
+    <div class="col-xs-3">
       <%= f.field_container :name do %>
         <%= f.label :name, class: 'required' %><br />
         <%= f.text_field :name, :class => 'fullwidth' %>

--- a/backend/app/views/spree/admin/shared/named_types/_index.html.erb
+++ b/backend/app/views/spree/admin/shared/named_types/_index.html.erb
@@ -48,7 +48,7 @@
     </tbody>
   </table>
 <% else %>
-  <div class="alpha twelve columns no-objects-found">
+  <div class="col-xs-9 no-objects-found">
     <%= render 'spree/admin/shared/no_objects_found',
                  resource: resource,
                  new_resource_url: new_object_url %>

--- a/backend/app/views/spree/admin/shipping_categories/index.html.erb
+++ b/backend/app/views/spree/admin/shipping_categories/index.html.erb
@@ -43,7 +43,7 @@
   </tbody>
 </table>
 <% else %>
-  <div class="alpha twelve columns no-objects-found">
+  <div class="col-xs-9 no-objects-found">
     <%= render 'spree/admin/shared/no_objects_found',
                  resource: Spree::ShippingCategory,
                  new_resource_url: new_object_url %>

--- a/backend/app/views/spree/admin/shipping_methods/_form.html.erb
+++ b/backend/app/views/spree/admin/shipping_methods/_form.html.erb
@@ -1,5 +1,5 @@
-<div data-hook="admin_shipping_method_form_fields" class="alpha twelve columns">
-  <div data-hook="admin_shipping_method_form_name_field" class="alpha six columns">
+<div data-hook="admin_shipping_method_form_fields" class="row">
+  <div data-hook="admin_shipping_method_form_name_field" class="col-xs-5">
     <%= f.field_container :name do %>
       <%= f.label :name %><br />
       <%= f.text_field :name, :class => 'fullwidth' %>
@@ -7,7 +7,7 @@
     <% end %>
   </div>
 
-  <div data-hook="admin_shipping_method_form_display_field" class="omega six columns">
+  <div data-hook="admin_shipping_method_form_display_field" class="col-xs-5">
     <%= f.field_container :display_on do %>
       <%= f.label :display_on %><br />
       <%= select(:shipping_method, :display_on, Spree::ShippingMethod::DISPLAY.collect { |display| [Spree.t(display), display == :both ? nil : display.to_s] }, {}, {:class => 'select2 fullwidth'}) %>
@@ -15,43 +15,39 @@
     <% end %>
   </div>
 
-  <div class="alpha omega twelve columns">
-    <div data-hook="admin_shipping_method_form_internal_name_field" class="alpha six columns">
-      <%= f.field_container :admin_name do %>
-        <%= f.label :admin_name %><br />
-        <%= f.text_field :admin_name, :class => 'fullwidth', :label => false  %>
-        <%= error_message_on :shipping_method, :admin_name %>
-      <% end %>
-    </div>
-
-    <div data-hook="admin_shipping_method_form_code" class="omega six columns">
-      <%= f.field_container :code do %>
-        <%= f.label :code %><br />
-        <%= f.text_field :code, :class => 'fullwidth', :label => false  %>
-        <%= error_message_on :shipping_method, :code %>
-      <% end %>
-    </div>
+  <div data-hook="admin_shipping_method_form_internal_name_field" class="col-xs-5">
+    <%= f.field_container :admin_name do %>
+      <%= f.label :admin_name %><br />
+      <%= f.text_field :admin_name, :class => 'fullwidth', :label => false  %>
+      <%= error_message_on :shipping_method, :admin_name %>
+    <% end %>
   </div>
 
-  <div class="alpha omega twelve columns">
-    <div class="alpha six columns">
-      <%= f.field_container :carrier do %>
-        <%= f.label :carrier %><br />
-        <%= f.text_field :carrier, :class => 'fullwidth', :label => false  %>
-        <%= error_message_on :shipping_method, :carrier %>
-      <% end %>
-    </div>
-
-    <div class="omega six columns">
-      <%= f.field_container :service_level do %>
-        <%= f.label :service_level %><br />
-        <%= f.text_field :service_level, :class => 'fullwidth', :label => false  %>
-        <%= error_message_on :shipping_method, :service_level %>
-      <% end %>
-    </div>
+  <div data-hook="admin_shipping_method_form_code" class="col-xs-5">
+    <%= f.field_container :code do %>
+      <%= f.label :code %><br />
+      <%= f.text_field :code, :class => 'fullwidth', :label => false  %>
+      <%= error_message_on :shipping_method, :code %>
+    <% end %>
   </div>
 
-  <div data-hook="admin_shipping_method_form_tracking_url_field" class="alpha twelve columns">
+  <div class="col-xs-5">
+    <%= f.field_container :carrier do %>
+      <%= f.label :carrier %><br />
+      <%= f.text_field :carrier, :class => 'fullwidth', :label => false  %>
+      <%= error_message_on :shipping_method, :carrier %>
+    <% end %>
+  </div>
+
+  <div class="col-xs-5">
+    <%= f.field_container :service_level do %>
+      <%= f.label :service_level %><br />
+      <%= f.text_field :service_level, :class => 'fullwidth', :label => false  %>
+      <%= error_message_on :shipping_method, :service_level %>
+    <% end %>
+  </div>
+
+  <div data-hook="admin_shipping_method_form_tracking_url_field" class="col-xs-10">
     <%= f.field_container :tracking_url do %>
       <%= f.label :tracking_url %><br />
       <%= f.text_field :tracking_url, :class => 'fullwidth', :placeholder => Spree.t(:tracking_url_placeholder) %>
@@ -60,53 +56,52 @@
   </div>
 </div>
 
-<div class="alpha six columns">
-  <div data-hook="admin_shipping_method_form_availability_fields" class="alpha six columns">
-    <fieldset class="categories no-border-bottom">
-      <legend align="center"><%= plural_resource_name(Spree::ShippingCategory) %></legend>
-      <%= f.field_container :categories do %>
-        <% Spree::ShippingCategory.all.each do |category| %>
-          <%= label_tag do %>
-            <%= check_box_tag('shipping_method[shipping_categories][]', category.id, @shipping_method.shipping_categories.include?(category)) %>
-            <%= category.name %><br>
+<div class="row">
+  <div class="col-xs-5">
+    <div data-hook="admin_shipping_method_form_availability_fields" class="col-xs-5">
+      <fieldset class="categories no-border-bottom">
+        <legend align="center"><%= plural_resource_name(Spree::ShippingCategory) %></legend>
+        <%= f.field_container :categories do %>
+          <% Spree::ShippingCategory.all.each do |category| %>
+            <%= label_tag do %>
+              <%= check_box_tag('shipping_method[shipping_categories][]', category.id, @shipping_method.shipping_categories.include?(category)) %>
+              <%= category.name %><br>
+            <% end %>
           <% end %>
+          <%= error_message_on :shipping_method, :shipping_category_id %>
         <% end %>
-        <%= error_message_on :shipping_method, :shipping_category_id %>
-      <% end %>
-    </fieldset>
-  </div>
+      </fieldset>
+    </div>
 
-  <div class="alpha six columns">
-    <fieldset class="no-border-bottom">
-      <legend align="center"><%= plural_resource_name(Spree::Zone) %></legend>
-      <%= f.field_container :zones do %>
-        <% shipping_method_zones = @shipping_method.zones.to_a %>
-        <% Spree::Zone.all.each do |zone| %>
-          <%= label_tag do %>
-            <%= check_box_tag('shipping_method[zones][]', zone.id, shipping_method_zones.include?(zone)) %>
-            <%= zone.name %>
+    <div class="col-xs-5">
+      <fieldset class="no-border-bottom">
+        <legend align="center"><%= plural_resource_name(Spree::Zone) %></legend>
+        <%= f.field_container :zones do %>
+          <% shipping_method_zones = @shipping_method.zones.to_a %>
+          <% Spree::Zone.all.each do |zone| %>
+            <%= label_tag do %>
+              <%= check_box_tag('shipping_method[zones][]', zone.id, shipping_method_zones.include?(zone)) %>
+              <%= zone.name %>
+            <% end %>
+            <br>
           <% end %>
-          <br>
+          <%= error_message_on :shipping_method, :zone_id %>
         <% end %>
-        <%= error_message_on :shipping_method, :zone_id %>
-      <% end %>
-    </fieldset>
+      </fieldset>
+    </div>
+  </div>
+  <div class="col-xs-5">
+    <div data-hook="admin_shipping_method_form_calculator_fields" class="col-xs-5">
+      <%= render :partial => 'spree/admin/shared/calculator_fields', :locals => { :f => f } %>
+    </div>
+    <div class="col-xs-5">
+      <fieldset class="tax_categories no-border-bottom">
+        <legend align="center"><%= Spree::TaxCategory.model_name.human %></legend>
+          <%= f.field_container :tax_categories do %>
+            <%= f.select :tax_category_id, @tax_categories.map { |tc| [tc.name, tc.id] }, {include_blank: true}, class: "select2 fullwidth" %>
+            <%= error_message_on :shipping_method, :tax_category_id %>
+          <% end %>
+      </fieldset>
+    </div>
   </div>
 </div>
-
-<div data-hook="admin_shipping_method_form_calculator_fields" class="omega six columns">
-  <%= render :partial => 'spree/admin/shared/calculator_fields', :locals => { :f => f } %>
-</div>
-
-<div class="alpha six columns">
-  <div class="alpha six columns">
-    <fieldset class="tax_categories no-border-bottom">
-      <legend align="center"><%= Spree::TaxCategory.model_name.human %></legend>
-        <%= f.field_container :tax_categories do %>
-          <%= f.select :tax_category_id, @tax_categories.map { |tc| [tc.name, tc.id] }, {include_blank: true}, class: "select2 fullwidth" %>
-          <%= error_message_on :shipping_method, :tax_category_id %>
-        <% end %>
-    </fieldset>
-  </div>
-</div>
-

--- a/backend/app/views/spree/admin/shipping_methods/index.html.erb
+++ b/backend/app/views/spree/admin/shipping_methods/index.html.erb
@@ -52,7 +52,7 @@
     </tbody>
   </table>
 <% else %>
-  <div class="alpha twelve columns no-objects-found">
+  <div class="col-xs-9 no-objects-found">
     <%= render 'spree/admin/shared/no_objects_found',
                  resource: Spree::ShippingMethod,
                  new_resource_url: new_object_url %>

--- a/backend/app/views/spree/admin/states/_form.html.erb
+++ b/backend/app/views/spree/admin/states/_form.html.erb
@@ -1,11 +1,11 @@
 <div data-hook="admin_state_form_fields" class="row">
-  <div class="alpha six columns">
+  <div class="col-xs-6">
     <%= f.field_container :name do %>
       <%= f.label :name %>
       <%= f.text_field :name, :class => 'fullwidth' %>
     <% end %>
   </div>
-  <div class="omega six columns">
+  <div class="col-xs-6">
     <%= f.field_container :abbr do %>
       <%= f.label :abbr %>
       <%= f.text_field :abbr, :class => 'fullwidth' %>

--- a/backend/app/views/spree/admin/states/index.html.erb
+++ b/backend/app/views/spree/admin/states/index.html.erb
@@ -13,11 +13,15 @@
   <% end %>
 <% end %>
 
-<div data-hook="country" class="field row">
-  <%= label_tag :country, Spree::Country.model_name.human %>
-  <select id="country" class='observe_field select2 fullwidth' data-base-url="<%=admin_states_path(:format => :js) %>?country_id=" data-update="#state-list">
-  <%= options_from_collection_for_select(@countries, :id, :name, @country.id) %>
-  </select>
+<div class="row">
+  <div class="col-xs-12">
+    <div data-hook="country" class="field">
+      <%= label_tag :country, Spree::Country.model_name.human %>
+      <select id="country" class='observe_field select2 fullwidth' data-base-url="<%=admin_states_path(:format => :js) %>?country_id=" data-update="#state-list">
+      <%= options_from_collection_for_select(@countries, :id, :name, @country.id) %>
+      </select>
+    </div>
+  </div>
 </div>
 
 <div id="new_state" data-hook>

--- a/backend/app/views/spree/admin/stock_locations/_form.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/_form.html.erb
@@ -1,5 +1,5 @@
 <div data-hook="admin_stock_locations_form_fields" class="row">
-  <div class="alpha nine columns" data-hook="stock_location_names">
+  <div class="col-xs-7" data-hook="stock_location_names">
     <div data-hook="stock_location_name">
       <%= f.field_container :name do %>
         <%= f.label :name, class: 'required' %><br />
@@ -20,7 +20,7 @@
     </div>
   </div>
 
-  <div class="omega three columns" data-hook="stock_location_status">
+  <div class="col-xs-3" data-hook="stock_location_status">
     <%= f.field_container :active do %>
       <label for="active"><%= Spree.t(:status) %></label>
       <ul>
@@ -56,44 +56,58 @@
     <% end %>
   </div>
 
-  <div class="alpha six columns field" data-hook="stock_location_address1">
-    <%= f.label :address1 %>
-    <%= f.text_field :address1, class: 'fullwidth' %>
+  <div class="col-xs-5" data-hook="stock_location_address1">
+    <div class="field">
+      <%= f.label :address1 %>
+      <%= f.text_field :address1, class: 'fullwidth' %>
+    </div>
   </div>
 
-  <div class="omega six columns field" data-hook="stock_location_city">
-    <%= f.label :city %>
-    <%= f.text_field :city, class: 'fullwidth' %>
+  <div class="col-xs-5" data-hook="stock_location_city">
+    <div class="field">
+      <%= f.label :city %>
+      <%= f.text_field :city, class: 'fullwidth' %>
+    </div>
   </div>
 
-  <div class="alpha six columns field" data-hook="stock_location_address2">
-    <%= f.label :address2 %>
-    <%= f.text_field :address2, class: 'fullwidth' %>
+  <div class="col-xs-5" data-hook="stock_location_address2">
+    <div class="field">
+      <%= f.label :address2 %>
+      <%= f.text_field :address2, class: 'fullwidth' %>
+    </div>
   </div>
 
-  <div class="three columns field" data-hook="stock_location_zipcode">
-    <%= f.label :zipcode %>
-    <%= f.text_field :zipcode, class: 'fullwidth' %>
+  <div class="col-xs-2" data-hook="stock_location_zipcode">
+    <div class="field">
+      <%= f.label :zipcode %>
+      <%= f.text_field :zipcode, class: 'fullwidth' %>
+    </div>
   </div>
 
-  <div class="omega three columns field" data-hook="stock_location_phone">
-    <%= f.label :phone %>
-    <%= f.phone_field :phone, class: 'fullwidth' %>
+  <div class="col-xs-3" data-hook="stock_location_phone">
+    <div class="field">
+      <%= f.label :phone %>
+      <%= f.phone_field :phone, class: 'fullwidth' %>
+    </div>
   </div>
 
-  <div class="alpha six columns field" data-hook="stock_location_country">
-    <%= f.label :country_id %>
-    <span id="country"><%= f.collection_select :country_id, available_countries, :id, :name, {}, { class: 'select2 fullwidth' } %></span>
+  <div class="col-xs-5" data-hook="stock_location_country">
+    <div class="field">
+      <%= f.label :country_id %>
+      <span id="country"><%= f.collection_select :country_id, available_countries, :id, :name, {}, { class: 'select2 fullwidth' } %></span>
+    </div>
   </div>
 
-  <div class="omega six columns field" data-hook="stock_location_state">
-    <% if f.object.country %>
-      <%= f.label :state_id %>
-      <span id="state" class="region">
-        <%= f.text_field :state_name, style: "display: #{f.object.country.states.empty? ? 'block' : 'none' };", disabled: !f.object.country.states.empty?, class: 'fullwidth state_name' %>
-        <%= f.collection_select :state_id, f.object.country.states.sort, :id, :name, { include_blank: true }, {class: 'select2 fullwidth', style: "display: #{f.object.country.states.empty? ? 'none' : 'block' };", disabled: f.object.country.states.empty?} %>
-      </span>
-    <% end %>
+  <div class="col-xs-5" data-hook="stock_location_state">
+    <div class="field">
+      <% if f.object.country %>
+        <%= f.label :state_id %>
+        <span id="state" class="region">
+          <%= f.text_field :state_name, style: "display: #{f.object.country.states.empty? ? 'block' : 'none' };", disabled: !f.object.country.states.empty?, class: 'fullwidth state_name' %>
+          <%= f.collection_select :state_id, f.object.country.states.sort, :id, :name, { include_blank: true }, {class: 'select2 fullwidth', style: "display: #{f.object.country.states.empty? ? 'none' : 'block' };", disabled: f.object.country.states.empty?} %>
+        </span>
+      <% end %>
+    </div>
   </div>
 </div>
 

--- a/backend/app/views/spree/admin/stock_locations/_transfer_stock_form.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/_transfer_stock_form.html.erb
@@ -2,27 +2,27 @@
   <fieldset>
     <legend align="center"><%= Spree.t(:move_stock_between_locations)%></legend>
     <div data-hook="admin_stock_movements_form_fields" class="row">
-      <div class="five columns">
+      <div class="col-xs-3">
         <div class="field" id="stock_movement_transfer_from_field">
           <%= label_tag :stock_location_from_id, Spree.t(:transfer_from_location) %>
           <%= select_tag :stock_location_from_id, options_from_collection_for_select(@stock_locations, :id, :name), class: 'select2 fullwidth' %>
         </div>
       </div>
-      <div class="five columns">
+      <div class="col-xs-3">
         <div class="field" id="stock_movement_transfer_to_field">
           <%= label_tag :stock_location_to_id, Spree.t(:transfer_to_location) %>
           <%= select_tag :stock_location_to_id, options_from_collection_for_select(@stock_locations, :id, :name), class: 'select2 fullwidth' %>
         </div>
       </div>
 
-      <div class="five columns">
+      <div class="col-xs-3">
         <div class="field" id="stock_movement_variant_id_field">
           <%= label_tag 'variant_id', Spree::Variant.model_name.human %>
           <%= select_tag :variant_id, options_from_collection_for_select(@variants, :id, :name_and_sku), class: 'select2 fullwidth' %>
         </div>
       </div>
 
-      <div class="five columns">
+      <div class="col-xs-3">
         <div class="field" id="stock_movement_quantity_field">
           <%= label_tag 'quantity', Spree::StockMovement.human_attribute_name(:quantity) %>
           <%= number_field_tag :quantity, 1, class: 'fullwidth' %>

--- a/backend/app/views/spree/admin/stock_locations/index.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/index.html.erb
@@ -78,7 +78,7 @@
     </tbody>
   </table>
 <% else %>
-  <div class="alpha twelve columns no-objects-found">
+  <div class="col-xs-9 no-objects-found">
     <%= render 'spree/admin/shared/no_objects_found',
                         resource: Spree::StockLocation,
                         new_resource_url: new_object_url %>

--- a/backend/app/views/spree/admin/stock_movements/_form.html.erb
+++ b/backend/app/views/spree/admin/stock_movements/_form.html.erb
@@ -1,5 +1,5 @@
 <div data-hook="admin_stock_movements_form_fields" class="row">
-  <div class="alpha twelve columns">
+  <div class="col-xs-9">
     <%= f.field_container :quantity do %>
       <%= f.label :quantity %>
       <%= f.text_field :quantity %>

--- a/backend/app/views/spree/admin/stock_movements/index.html.erb
+++ b/backend/app/views/spree/admin/stock_movements/index.html.erb
@@ -44,7 +44,7 @@
   </tbody>
 </table>
 <% else %>
-  <div class="alpha twelve columns no-objects-found">
+  <div class="col-xs-9 no-objects-found">
     <%= render 'spree/admin/shared/no_objects_found',
                  resource: Spree::StockMovement,
                  new_resource_url: new_object_url %>

--- a/backend/app/views/spree/admin/stock_transfers/_stock_movements.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/_stock_movements.html.erb
@@ -1,4 +1,4 @@
-<div id="source-movements-table" class="twelve columns alpha">
+<div id="source-movements-table" class="col-xs-9">
 <table class="index sortable">
   <colgroup>
     <col style="width: 40%" />

--- a/backend/app/views/spree/admin/stock_transfers/index.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/index.html.erb
@@ -17,41 +17,43 @@
 <% content_for :table_filter do %>
   <div data-hook="admin_stock_transfers_index_search">
     <%= search_form_for [:admin, @search] do |f| %>
-      <div class="field-block alpha four columns">
-        <div class="field">
-          <%= f.label nil, Spree::StockLocation.model_name.human %>
-          <%= f.select :source_location_id_or_destination_location_id_eq, options_from_collection_for_select(@stock_locations, :id, :name, params[:q][:source_location_id_or_destination_location_id_eq]), {include_blank: true}, {class: 'select2 fullwidth'} %>
-        </div>
-      </div>
-
-      <div class="field-block alpha four columns">
-        <div class="date-range-filter field">
-          <%= f.label nil, Spree.t(:date_range) %>
-          <div class="date-range-fields">
-            <%= f.text_field :created_at_gt, class: 'datepicker datepicker-from', include_blank: true, value: params[:q][:created_at_gt], placeholder: Spree.t(:start) %>
-
-            <span class="range-divider">
-              <i class="fa fa-arrow-right"></i>
-            </span>
-
-            <%= f.text_field :created_at_lt, class: 'datepicker datepicker-to', include_blank: true, value: params[:q][:created_at_lt], placeholder: Spree.t(:stop) %>
+      <div class="row">
+        <div class="field-block col-xs-3">
+          <div class="field">
+            <%= f.label nil, Spree::StockLocation.model_name.human %>
+            <%= f.select :source_location_id_or_destination_location_id_eq, options_from_collection_for_select(@stock_locations, :id, :name, params[:q][:source_location_id_or_destination_location_id_eq]), {include_blank: true}, {class: 'select2 fullwidth'} %>
           </div>
         </div>
-      </div>
 
-      <div class="field-block alpha four columns">
-        <div class="field">
-          <%= f.label nil, Spree::StockTransfer.human_attribute_name(:number) %>
-          <%= f.text_field :number_cont, value: params[:q][:number_cont] %>
+        <div class="field-block col-xs-3">
+          <div class="date-range-filter field">
+            <%= f.label nil, Spree.t(:date_range) %>
+            <div class="date-range-fields">
+              <%= f.text_field :created_at_gt, class: 'datepicker datepicker-from', include_blank: true, value: params[:q][:created_at_gt], placeholder: Spree.t(:start) %>
+
+              <span class="range-divider">
+                <i class="fa fa-arrow-right"></i>
+              </span>
+
+              <%= f.text_field :created_at_lt, class: 'datepicker datepicker-to', include_blank: true, value: params[:q][:created_at_lt], placeholder: Spree.t(:stop) %>
+            </div>
+          </div>
         </div>
-      </div>
 
-      <div class="field-block alpha four columns">
-        <div class="field checkbox">
-          <label>
-            <%= f.check_box :closed_at_null, { checked: @show_only_open }, '1', '0' %>
-            <%= Spree.t(:show_only_open_transfers) %>
-          </label>
+        <div class="field-block col-xs-3">
+          <div class="field">
+            <%= f.label nil, Spree::StockTransfer.human_attribute_name(:number) %>
+            <%= f.text_field :number_cont, value: params[:q][:number_cont] %>
+          </div>
+        </div>
+
+        <div class="field-block col-xs-3">
+          <div class="field checkbox">
+            <label>
+              <%= f.check_box :closed_at_null, { checked: @show_only_open }, '1', '0' %>
+              <%= Spree.t(:show_only_open_transfers) %>
+            </label>
+          </div>
         </div>
       </div>
 
@@ -107,7 +109,7 @@
     </tbody>
   </table>
 <% else %>
-  <div class="alpha sixteen columns no-objects-found">
+  <div class="col-xs-9 no-objects-found">
     <%= render 'spree/admin/shared/no_objects_found',
                   resource: Spree::StockTransfer,
                   new_resource_url: new_object_url %>

--- a/backend/app/views/spree/admin/stock_transfers/show.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/show.html.erb
@@ -16,30 +16,32 @@
     <p><%= @stock_transfer.description %></p>
   </div>
 
-  <div class='field-block alpha three columns'>
-    <label><%= Spree::StockTransfer.human_attribute_name(:created_by_id) %></label>
-    <p><%= @stock_transfer.created_by.email %></p>
-  </div>
+  <div class="row">
+    <div class='field-block col-xs-3'>
+      <label><%= Spree::StockTransfer.human_attribute_name(:created_by_id) %></label>
+      <p><%= @stock_transfer.created_by.email %></p>
+    </div>
 
-  <div class='field-block alpha three columns'>
-    <label><%= Spree::StockTransfer.human_attribute_name(:created_at) %></label>
-    <p><%= @stock_transfer.created_at.try(:to_date) %></p>
-  </div>
+    <div class='field-block col-xs-2'>
+      <label><%= Spree::StockTransfer.human_attribute_name(:created_at) %></label>
+      <p><%= @stock_transfer.created_at.try(:to_date) %></p>
+    </div>
 
-  <div class='field-block alpha three columns'>
-    <label><%= Spree::StockTransfer.human_attribute_name(:finalized_at) %></label>
-    <p><%= @stock_transfer.finalized_at.try(:to_date) %></p>
-  </div>
+    <div class='field-block col-xs-2'>
+      <label><%= Spree::StockTransfer.human_attribute_name(:finalized_at) %></label>
+      <p><%= @stock_transfer.finalized_at.try(:to_date) %></p>
+    </div>
 
-  <div class='field-block alpha three columns'>
-    <label><%= Spree::StockTransfer.human_attribute_name(:finalized_by_id) %></label>
-    <p><%= @stock_transfer.finalized_by.try(:email) %></p>
-  </div>
+    <div class='field-block col-xs-3'>
+      <label><%= Spree::StockTransfer.human_attribute_name(:finalized_by_id) %></label>
+      <p><%= @stock_transfer.finalized_by.try(:email) %></p>
+    </div>
 
-  <div class='field-block alpha three columns'>
-    <label><%= Spree::StockTransfer.human_attribute_name(:shipped_at) %></label>
-    <p><%= @stock_transfer.shipped_at.try(:to_date) %></p>
-  </div>
+    <div class='field-block col-xs-2'>
+      <label><%= Spree::StockTransfer.human_attribute_name(:shipped_at) %></label>
+      <p><%= @stock_transfer.shipped_at.try(:to_date) %></p>
+    </div>
+  </div> 
 </fieldset>
 
 <fieldset>

--- a/backend/app/views/spree/admin/store_credits/_form.html.erb
+++ b/backend/app/views/spree/admin/store_credits/_form.html.erb
@@ -1,12 +1,12 @@
 <div data-hook="admin_store_credit_form_fields" class="row">
-  <div class="alpha twelve columns">
+  <div class="col-xs-12">
     <%= f.field_container :amount do %>
       <%= f.label :amount, class: 'required' %><br />
       <%= f.number_field :amount, min: 0.00, step: :any %>
       <%= f.error_message_on :amount %>
     <% end %>
   </div>
-  <div class="alpha twelve columns">
+  <div class="col-xs-12">
     <%= f.field_container :category do %>
       <%= f.label :category_id, class: 'required' %><br />
       <%= f.select :category_id, options_from_collection_for_select(@credit_categories, :id, :name, f.object.category.try(:id)),
@@ -14,7 +14,7 @@
       <%= f.error_message_on :category %>
     <% end %>
   </div>
-  <div data-hook="admin_store_credit_memo_field" class="alpha twelve columns">
+  <div data-hook="admin_store_credit_memo_field" class="col-xs-12">
     <%= f.field_container :memo do %>
       <%= f.label :memo %>
       <%= f.text_area :memo, class: "fullwidth" %>

--- a/backend/app/views/spree/admin/store_credits/_update_reason_field.html.erb
+++ b/backend/app/views/spree/admin/store_credits/_update_reason_field.html.erb
@@ -1,4 +1,4 @@
-<div class="alpha twelve columns">
+<div class="col-xs-12">
   <%= f.field_container :reason do %>
     <%= f.label :reason, Spree.t(:reason), class: 'required' %><br />
     <%= select_tag :update_reason_id, options_from_collection_for_select(@update_reasons, :id, :name),

--- a/backend/app/views/spree/admin/store_credits/edit_amount.html.erb
+++ b/backend/app/views/spree/admin/store_credits/edit_amount.html.erb
@@ -14,7 +14,7 @@
   <fieldset>
     <legend align="center"><%= Spree.t("admin.store_credits.edit_amount") %></legend>
     <div data-hook="admin_store_credit_form_fields" class="row">
-      <div class="alpha twelve columns">
+      <div class="col-xs-9">
         <%= f.field_container :amount do %>
           <%= f.label :amount, class: 'required' %><br />
           <%= f.number_field :amount, min: 0.00, step: :any %>

--- a/backend/app/views/spree/admin/store_credits/index.html.erb
+++ b/backend/app/views/spree/admin/store_credits/index.html.erb
@@ -61,7 +61,7 @@
     </tbody>
   </table>
 <% else %>
-  <div class="alpha twelve columns no-objects-found">
+  <div class="col-xs-9 no-objects-found">
     <%= render 'spree/admin/shared/no_objects_found',
                  resource: Spree::StoreCredit,
                  new_resource_url: new_object_url %>

--- a/backend/app/views/spree/admin/store_credits/index.html.erb
+++ b/backend/app/views/spree/admin/store_credits/index.html.erb
@@ -16,7 +16,7 @@
     <strong><%= Spree.t("admin.store_credits.current_balance") %> </strong><%= @user.display_total_available_store_credit %>
   </div>
 
-  <table>
+  <table id="sc-table">
     <thead>
       <th><%= Spree::StoreCredit.human_attribute_name(:amount_credited) %></th>
       <th><%= Spree::StoreCredit.human_attribute_name(:amount_used) %></th>

--- a/backend/app/views/spree/admin/style_guide/topics/forms/_building_forms.html.erb
+++ b/backend/app/views/spree/admin/style_guide/topics/forms/_building_forms.html.erb
@@ -1,62 +1,64 @@
 <%- snippet = capture do %>
-  <form id="table-filter" class="sixteen columns">
+  <form id="table-filter">
     <fieldset>
       <legend align="center">Search</legend>
-      <div class="field-block alpha four columns">
-        <div class="field">
-          <label for="q_number_cont" class="required">Text Field</label>
-          <input class="required" type="text">
-        </div>
-      </div>
-
-      <div class="field-block four columns">
-        <div class="date-range-filter field">
-          <label for="q_created_at_gt">Date Range</label>
-          <div class="date-range-fields">
-            <input class="datepicker" placeholder="Date">
-            <span class="range-divider"><i class="fa fa-arrow-right"></i></span>
-            <input class="datepicker" placeholder="Picker">
+      <div class="row">
+        <div class="field-block col-xs-3">
+          <div class="field">
+            <label for="q_number_cont" class="required">Text Field</label>
+            <input class="required" type="text">
           </div>
         </div>
-      </div>
 
-      <div class="four columns">
-        <div class="field checkbox">
-          <label>Select Box
-            <select>
-              <option>Option</option>
+        <div class="field-block col-xs-3">
+          <div class="date-range-filter field">
+            <label for="q_created_at_gt">Date Range</label>
+            <div class="date-range-fields">
+              <input class="datepicker" placeholder="Date">
+              <span class="range-divider"><i class="fa fa-arrow-right"></i></span>
+              <input class="datepicker" placeholder="Picker">
+            </div>
+          </div>
+        </div>
+
+        <div class="col-xs-3">
+          <div class="field checkbox">
+            <label>Select Box
+              <select>
+                <option>Option</option>
+              </select>
+            </label>
+          </div>
+
+          <div class="field">
+            <select class="select2">
+              <option>Select 2</option>
             </select>
-          </label>
+          </div>
         </div>
 
-        <div class="field">
-          <select class="select2">
-            <option>Select 2</option>
-          </select>
-        </div>
-      </div>
+        <div class="col-xs-3">
+          <div class="field checkbox">
+            <label>
+              <input type="checkbox" checked="checked">
+              Checkbox
+            </label>
+          </div>
 
-      <div class="omega four columns">
-        <div class="field checkbox">
-          <label>
-            <input type="checkbox" checked="checked">
-            Checkbox
-          </label>
-        </div>
-
-        <div class='field'>
-          <label>
-            <input name='radio' type='radio'>
-            Option 1
-          </label>
-          <label>
-            <input name='radio' type='radio'>
-            Option 2
-          </label>
-          <label>
-            <input name='radio' type='radio'>
-            Option 3
-          </label>
+          <div class='field'>
+            <label>
+              <input name='radio' type='radio'>
+              Option 1
+            </label>
+            <label>
+              <input name='radio' type='radio'>
+              Option 2
+            </label>
+            <label>
+              <input name='radio' type='radio'>
+              Option 3
+            </label>
+          </div>
         </div>
       </div>
     </fieldset>

--- a/backend/app/views/spree/admin/tax_categories/_form.html.erb
+++ b/backend/app/views/spree/admin/tax_categories/_form.html.erb
@@ -1,26 +1,26 @@
 <div data-hook="admin_tax_category_form_fields" class="row">
-  <div class="alpha four columns">
+  <div class="col-xs-3">
     <%= f.field_container :name do %>
       <%= f.label :name %>
       <%= f.text_field :name, :class => 'fullwidth' %>
     <% end %>
   </div>
 
-  <div class="two columns">
+  <div class="col-xs-2">
     <%= f.field_container :tax_code do %>
       <%= f.label :tax_code %>
       <%= f.text_field :tax_code, :class => 'fullwidth' %>
     <% end %>
   </div>
 
-  <div class="two columns omega">
+  <div class="col-xs-1">
     <%= f.field_container :is_default, :class => ['checkbox'] do %>
       <%= f.check_box :is_default %>
       <%= f.label :is_default %>
     <% end %>
   </div>
 
-  <div class="alpha six columns">
+  <div class="col-xs-4">
     <%= f.field_container :description do %>
       <%= f.label :description %><br>
       <%= f.text_area :description, :class => 'fullwidth' %>

--- a/backend/app/views/spree/admin/tax_categories/index.html.erb
+++ b/backend/app/views/spree/admin/tax_categories/index.html.erb
@@ -55,7 +55,7 @@
   </tbody>
 </table>
 <% else %>
-  <div class="alpha twelve columns no-objects-found">
+  <div class="col-xs-9 no-objects-found">
     <%= render 'spree/admin/shared/no_objects_found',
                  resource: Spree::TaxCategory,
                  new_resource_url: new_object_url %>

--- a/backend/app/views/spree/admin/tax_rates/_form.html.erb
+++ b/backend/app/views/spree/admin/tax_rates/_form.html.erb
@@ -1,40 +1,40 @@
 <div data-hook="admin_tax_rate_form_fields">
-  <div class="alpha twelve columns">
     <fieldset data-hook="tax_rates" class=" no-border-bottom">
       <legend align="center"><%= Spree.t(:general_settings) %></legend>
+      <div class="row">
 
-      <div class="alpha six columns">
-        <div data-hook="name" class="field">
-          <%= f.label :name %>
-          <%= f.text_field :name, :class => 'fullwidth' %>
+        <div class="col-xs-5">
+          <div data-hook="name" class="field">
+            <%= f.label :name %>
+            <%= f.text_field :name, :class => 'fullwidth' %>
+          </div>
+          <div data-hook="rate" class="field">
+            <%= f.label :amount %>
+            <%= f.text_field :amount, :class => 'fullwidth' %>
+            <br/><span class="info"><%= Spree.t(:tax_rate_amount_explanation) %></span>
+          </div>
+          <div data-hook="included" class="field">
+            <%= f.check_box :included_in_price %>
+            <%= f.label :included_in_price, Spree.t(:included_in_price) %>
+          </div>
         </div>
-        <div data-hook="rate" class="field">
-          <%= f.label :amount %>
-          <%= f.text_field :amount, :class => 'fullwidth' %>
-          <br/><span class="info"><%= Spree.t(:tax_rate_amount_explanation) %></span>
-        </div>
-        <div data-hook="included" class="field">
-          <%= f.check_box :included_in_price %>
-          <%= f.label :included_in_price, Spree.t(:included_in_price) %>
-        </div>
-      </div>
 
-      <div class="omega six columns">
-        <div data-hook="zone" class="field">
-          <%= f.label :zone, Spree::Zone.model_name.human %>
-          <%= f.collection_select(:zone_id, @available_zones, :id, :name, {}, {:class => 'select2 fullwidth'}) %>
-        </div>
-        <div data-hook="category" class="field">
-          <%= f.label :tax_category_id, Spree::TaxCategory.model_name.human %>
-          <%= f.collection_select(:tax_category_id, @available_categories,:id, :name, {}, {:class => 'select2 fullwidth'}) %>
-        </div>
-        <div data-hook="show_rate" class="field">
-          <%= f.check_box :show_rate_in_label %>
-          <%= f.label :show_rate_in_label, Spree.t(:show_rate_in_label) %>
+        <div class="col-xs-5">
+          <div data-hook="zone" class="field">
+            <%= f.label :zone, Spree::Zone.model_name.human %>
+            <%= f.collection_select(:zone_id, @available_zones, :id, :name, {}, {:class => 'select2 fullwidth'}) %>
+          </div>
+          <div data-hook="category" class="field">
+            <%= f.label :tax_category_id, Spree::TaxCategory.model_name.human %>
+            <%= f.collection_select(:tax_category_id, @available_categories,:id, :name, {}, {:class => 'select2 fullwidth'}) %>
+          </div>
+          <div data-hook="show_rate" class="field">
+            <%= f.check_box :show_rate_in_label %>
+            <%= f.label :show_rate_in_label, Spree.t(:show_rate_in_label) %>
+          </div>
         </div>
       </div>
     </fieldset>
-  </div>
 
   <div class="clear"></div>
 

--- a/backend/app/views/spree/admin/tax_rates/index.html.erb
+++ b/backend/app/views/spree/admin/tax_rates/index.html.erb
@@ -60,7 +60,7 @@
     </tbody>
   </table>
 <% else %>
-  <div class="alpha twelve columns no-objects-found">
+  <div class="col-xs-9 no-objects-found">
     <%= render 'spree/admin/shared/no_objects_found',
                  resource: Spree::TaxRate,
                  new_resource_url: new_object_url %>

--- a/backend/app/views/spree/admin/taxonomies/index.html.erb
+++ b/backend/app/views/spree/admin/taxonomies/index.html.erb
@@ -15,7 +15,7 @@
   <%= render 'list' %>
 </div>
 <% else %>
-  <div class="alpha twelve columns no-objects-found">
+  <div class="col-xs-9 no-objects-found">
     <%= render 'spree/admin/shared/no_objects_found',
                  resource: Spree::Taxonomy,
                  new_resource_url: new_object_url %>

--- a/backend/app/views/spree/admin/taxons/_form.html.erb
+++ b/backend/app/views/spree/admin/taxons/_form.html.erb
@@ -1,5 +1,5 @@
 <div data-hook="admin_inside_taxon_form" class="row">
-  <div class="alpha five columns">
+  <div class="col-xs-5">
     <%= f.field_container :name do %>
       <%= f.label :name, class: 'required' %><br />
       <%= text_field :taxon, :name, :class => 'fullwidth' %>
@@ -21,14 +21,14 @@
     <% end %>
   </div>
 
-  <div class="omega seven columns">
+  <div class="col-xs-5">
     <%= f.field_container :description do %>
       <%= f.label :description %><br />
       <%= f.text_area :description, :class => 'fullwidth', :rows => 6 %>
     <% end %>
   </div>
 
-  <div class="twelve columns alpha omega">
+  <div class="col-xs-10">
     <%= f.field_container :meta_title do %>
       <%= f.label :meta_title %><br />
       <%= f.text_field :meta_title, :class => 'fullwidth', :rows => 6 %>

--- a/backend/app/views/spree/admin/taxons/index.html.erb
+++ b/backend/app/views/spree/admin/taxons/index.html.erb
@@ -6,11 +6,11 @@
 <% end %>
 
 <% content_for :table_filter do %>
-  <div data-hook="admin_orders_index_search" class="columns six">
+  <div data-hook="admin_orders_index_search" class="col-xs-4">
     <input type='text' id='taxon_id' />
   </div>
 <% end %>
 
-<div class='sixteen columns'>
+<div class='col-xs-10'>
   <div id='taxon_products' class='list-group'></div>
 </div>

--- a/backend/app/views/spree/admin/users/_addresses_form.html.erb
+++ b/backend/app/views/spree/admin/users/_addresses_form.html.erb
@@ -1,17 +1,21 @@
-<div data-hook="bill_address_wrapper" class="alpha six columns">
-  <fieldset class="no-border-bottom">
-    <legend align="center"><%= Spree.t(:billing_address) %></legend>
-    <%= f.fields_for :bill_address, @user.bill_address || Spree::Address.build_default do |ba_form| %>
-      <%= render :partial => 'spree/admin/shared/address_form', :locals => { :f => ba_form, :type => "billing" } %>
-    <% end %>
-  </fieldset>
-</div>
+<div class="row">
+    
+  <div data-hook="bill_address_wrapper" class="col-xs-6">
+    <fieldset class="no-border-bottom">
+      <legend align="center"><%= Spree.t(:billing_address) %></legend>
+      <%= f.fields_for :bill_address, @user.bill_address || Spree::Address.build_default do |ba_form| %>
+        <%= render :partial => 'spree/admin/shared/address_form', :locals => { :f => ba_form, :type => "billing" } %>
+      <% end %>
+    </fieldset>
+  </div>
 
-<div data-hook="ship_address_wrapper" class="alpha six columns">
-  <fieldset class="no-border-bottom">
-    <legend align="center"><%= Spree.t(:shipping_address) %></legend>
-    <%= f.fields_for :ship_address, @user.ship_address || Spree::Address.build_default do |sa_form| %>
-      <%= render :partial => 'spree/admin/shared/address_form', :locals => { :f => sa_form, :type => "shipping" } %>
-    <% end %>
-  </fieldset>
+  <div data-hook="ship_address_wrapper" class="col-xs-6">
+    <fieldset class="no-border-bottom">
+      <legend align="center"><%= Spree.t(:shipping_address) %></legend>
+      <%= f.fields_for :ship_address, @user.ship_address || Spree::Address.build_default do |sa_form| %>
+        <%= render :partial => 'spree/admin/shared/address_form', :locals => { :f => sa_form, :type => "shipping" } %>
+      <% end %>
+    </fieldset>
+  </div>
+
 </div>

--- a/backend/app/views/spree/admin/users/_form.html.erb
+++ b/backend/app/views/spree/admin/users/_form.html.erb
@@ -1,5 +1,5 @@
 <div data-hook="admin_user_form_fields" class="row">
-  <div class="alpha six columns">
+  <div class="col-xs-6">
     <%= f.field_container :email do %>
       <%= f.label :email %>
       <% if can?(:update_email, @user) %>
@@ -53,7 +53,7 @@
 
   </div>
 
-  <div data-hook="admin_user_form_password_fields" class="omega six columns">
+  <div data-hook="admin_user_form_password_fields" class="col-xs-6">
     <%= f.field_container :password do %>
       <%= f.label :password %>
       <%= f.password_field :password, :class => 'fullwidth' %>

--- a/backend/app/views/spree/admin/users/addresses.html.erb
+++ b/backend/app/views/spree/admin/users/addresses.html.erb
@@ -7,7 +7,7 @@
 <%= render 'spree/admin/users/tabs', current: :address %>
 <%= render :partial => 'spree/admin/users/user_page_actions' %>
 
-<fieldset data-hook="admin_user_addresses" id="admin_user_edit_addresses" class="alpha twelve columns">
+<fieldset data-hook="admin_user_addresses" id="admin_user_edit_addresses" class="col-xs-12">
   <legend><%= plural_resource_name(Spree::Address) %></legend>
 
   <div data-hook="admin_user_edit_form_header">

--- a/backend/app/views/spree/admin/users/edit.html.erb
+++ b/backend/app/views/spree/admin/users/edit.html.erb
@@ -6,7 +6,7 @@
 <%= render 'spree/admin/users/tabs', current: :account %>
 <%= render :partial => 'spree/admin/users/user_page_actions' %>
 
-<fieldset data-hook="admin_user_edit_general_settings" class="alpha twelve columns">
+<fieldset data-hook="admin_user_edit_general_settings" class="col-xs-9">
   <legend><%= Spree.t(:general_settings) %></legend>
 
   <div data-hook="admin_user_edit_form_header">
@@ -27,7 +27,7 @@
 </fieldset>
 
 <% if can?(:update, @user) %>
-  <fieldset data-hook="admin_user_api_key" id="admin_user_edit_api_key" class="alpha twelve columns">
+  <fieldset data-hook="admin_user_api_key" id="admin_user_edit_api_key" class="col-xs-9">
     <legend><%= Spree.t('access', :scope => 'api') %></legend>
 
     <% if @user.spree_api_key.present? %>

--- a/backend/app/views/spree/admin/users/items.html.erb
+++ b/backend/app/views/spree/admin/users/items.html.erb
@@ -7,7 +7,7 @@
 <%= render 'spree/admin/users/tabs', current: :items %>
 <%= render :partial => 'spree/admin/users/user_page_actions' %>
 
-<fieldset data-hook="admin_user_items_purchased" class="alpha twelve columns">
+<fieldset data-hook="admin_user_items_purchased" class="col-xs-9">
   <legend><%= Spree.t(:"admin.user.items_purchased") %></legend>
 
   <%= paginate @orders, theme: "solidus_admin" %>
@@ -73,7 +73,7 @@
         <% end %>
     </table>
   <% else %>
-    <div class="alpha twelve columns no-objects-found">
+    <div class="col-xs-9 no-objects-found">
       <%= render 'spree/admin/shared/no_objects_found',
                    resource: Spree::Order,
                    new_resource_url: spree.new_admin_order_path %>

--- a/backend/app/views/spree/admin/users/orders.html.erb
+++ b/backend/app/views/spree/admin/users/orders.html.erb
@@ -7,7 +7,7 @@
 <%= render 'spree/admin/users/tabs', current: :orders %>
 <%= render :partial => 'spree/admin/users/user_page_actions' %>
 
-<fieldset data-hook="admin_user_order_history" class="alpha twelve columns">
+<fieldset data-hook="admin_user_order_history" class="col-xs-9">
   <legend><%= Spree.t(:"admin.user.order_history") %></legend>
 
   <%= paginate @orders, theme: "solidus_admin" %>
@@ -55,7 +55,7 @@
       </tbody>
     </table>
   <% else %>
-    <div class="alpha twelve columns no-objects-found">
+    <div class="col-xs-9 no-objects-found">
       <%= render 'spree/admin/shared/no_objects_found',
                    resource: Spree::Order,
                    new_resource_url: spree.new_admin_order_path %>

--- a/backend/app/views/spree/admin/variants/_form.html.erb
+++ b/backend/app/views/spree/admin/variants/_form.html.erb
@@ -1,46 +1,60 @@
 <div data-hook="variants">
   <fieldset class="no-border-top no-border-bottom">
-    <div class="field four columns alpha" data-hook="sku">
-      <%= f.label :sku %>
-      <%= f.text_field :sku, :class => 'fullwidth' %>
-    </div>
-    <div class="field four columns checkbox" data-hook="track_inventory">
-      <%= f.label :track_inventory do %>
-        <%= f.check_box :track_inventory %>
-        <%= Spree::Variant.human_attribute_name(:track_inventory) %>
-      <% end %>
+    <div class="row">
+      <div class="col-xs-3">
+        <div class="field" data-hook="sku">
+          <%= f.label :sku %>
+          <%= f.text_field :sku, :class => 'fullwidth' %>
+        </div>
+      </div>
+      <div class="col-xs-3">
+        <div class="field checkbox" data-hook="track_inventory">
+          <%= f.label :track_inventory do %>
+            <%= f.check_box :track_inventory %>
+            <%= Spree::Variant.human_attribute_name(:track_inventory) %>
+          <% end %>
+        </div>
+      </div>
     </div>
   </fieldset>
   <% if f.object.new_record? %>
     <fieldset class="no-border-top no-border-bottom">
+      <div class="row">
       <% @product.option_types.each_with_index do |option_type, index| %>
-        <div class="field four columns <%= 'alpha' if index % 3 == 0 %><%= 'omega' if index % 3 == 2 %>" data-hook="presentation">
-          <%= label :new_variant, option_type.presentation %>
-          <%= f.collection_select 'option_value_ids',
-                                  option_type.option_values,
-                                  :id,
-                                  :presentation,
-                                  { include_blank: true },
-                                  {
-                                    name: 'variant[option_value_ids][]',
-                                    class: "select2 fullwidth"
-                                  } %>
-        </div>
+          <div class="col-xs-3">
+            <div class="field" data-hook="presentation">
+              <%= label :new_variant, option_type.presentation %>
+              <%= f.collection_select 'option_value_ids',
+                                      option_type.option_values,
+                                      :id,
+                                      :presentation,
+                                      { include_blank: true },
+                                      {
+                                        name: 'variant[option_value_ids][]',
+                                        class: "select2 fullwidth"
+                                      } %>
+            </div>
+          </div>
       <% end %>
+      </div>
     </fieldset>
   <% end %>
 </div>
 
 <div data-hook="admin_variant_form_additional_fields">
   <fieldset class="no-border-top no-border-bottom">
-    <% [:weight, :height, :width, :depth].each_with_index do |field, index| %>
-      <div class="field four columns <%= 'alpha' if index % 4 == 0 %> <%= 'omega' if index % 4 == 3 %>" data-hook="<%= field %>">
-        <%= f.label field %>
-        <%= f.text_field field,
-                         value: number_with_precision(@variant.send(field), :precision => 2),
-                         class: 'fullwidth' %>
-      </div>
-    <% end %>
+    <div class="row">
+      <% [:weight, :height, :width, :depth].each_with_index do |field, index| %>
+        <div class="col-xs-3">
+          <div class="field" data-hook="<%= field %>">
+            <%= f.label field %>
+            <%= f.text_field field,
+                            value: number_with_precision(@variant.send(field), :precision => 2),
+                            class: 'fullwidth' %>
+          </div>
+        </div>
+      <% end %>
+    </div>
   </fieldset>
 </div>
 
@@ -48,29 +62,39 @@
   <fieldset class="no-border-top no-border-bottom">
     <p> <%== t('.pricing_hint') %> </p>
 
-    <div class="field four columns alpha" data-hook="price">
-      <%= f.label :price %>
-      <%= f.text_field :price, :value => number_to_currency(@variant.price, :unit => ''), :class => 'fullwidth' %>
-    </div>
+    <div class="row">
+      <div class="col-xs-3">
+        <div class="field" data-hook="price">
+          <%= f.label :price %>
+          <%= f.text_field :price, :value => number_to_currency(@variant.price, :unit => ''), :class => 'fullwidth' %>
+        </div>
+      </div>
 
-    <% if show_rebuild_vat_checkbox? %>
-      <%= render "spree/admin/shared/rebuild_vat_prices_checkbox", form: f, model_name: "variant", wrapper_class: "field four columns" %>
-    <% end %>
+      <% if show_rebuild_vat_checkbox? %>
+        <div class="col-xs-3">
+          <%= render "spree/admin/shared/rebuild_vat_prices_checkbox", form: f, model_name: "variant", wrapper_class: "field" %>
+        </div>
+      <% end %>
 
-    <div class="field four columns" data-hook="cost_price">
-      <%= f.label :cost_price %>
-      <%= f.text_field :cost_price, :value => number_to_currency(@variant.cost_price, :unit => ''), :class => 'fullwidth' %>
-    </div>
+      <div class="col-xs-3">
+        <div class="field" data-hook="cost_price">
+          <%= f.label :cost_price %>
+          <%= f.text_field :cost_price, :value => number_to_currency(@variant.cost_price, :unit => ''), :class => 'fullwidth' %>
+        </div>
+      </div>
 
-    <div class="field four columns omega" data-hook="tax_category">
-      <%= f.label :tax_category %>
-      <%= f.field_hint :tax_category %>
-      <%= f.collection_select :tax_category_id,
-                              @tax_categories,
-                              :id,
-                              :name,
-                              { :include_blank => t('.use_product_tax_category') },
-                              { :class => 'select2 fullwidth' } %>
+      <div class="col-xs-3">
+        <div class="field" data-hook="tax_category">
+          <%= f.label :tax_category %>
+          <%= f.field_hint :tax_category %>
+          <%= f.collection_select :tax_category_id,
+                                  @tax_categories,
+                                  :id,
+                                  :name,
+                                  { :include_blank => t('.use_product_tax_category') },
+                                  { :class => 'select2 fullwidth' } %>
+        </div>
+      </div>
     </div>
   </fieldset>
 </div>

--- a/backend/app/views/spree/admin/variants/_table_filter.html.erb
+++ b/backend/app/views/spree/admin/variants/_table_filter.html.erb
@@ -4,17 +4,21 @@
 
 <% content_for :table_filter do %>
   <%= form_for :variant_search, url: spree.admin_product_variants_path(product), method: :get do |f| %>
-    <div data-hook="admin_variants_index_search" class="field thirteen columns alpha">
-      <%= f.label :variant_search_term, Spree.t(:variant_search_placeholder) %>
-      <%= text_field_tag :variant_search_term, params[:variant_search_term], :class => "fullwidth", :placeholder => Spree.t(:variant_search_placeholder) %>
+    <div class="col-xs-10">
+      <div data-hook="admin_variants_index_search" class="field">
+        <%= f.label :variant_search_term, Spree.t(:variant_search_placeholder) %>
+        <%= text_field_tag :variant_search_term, params[:variant_search_term], :class => "fullwidth", :placeholder => Spree.t(:variant_search_placeholder) %>
+      </div>
     </div>
 
     <% if product.variants.only_deleted.any? %>
-      <div class="field checkbox three columns omega">
-        <%= label_tag :deleted do %>
-          <%= check_box_tag :deleted, "on", params[:deleted] == "on" %>
-          <%= t('.show_deleted') %>
-        <% end %>
+      <div class="col-xs-2">
+        <div class="field checkbox">
+          <%= label_tag :deleted do %>
+            <%= check_box_tag :deleted, "on", params[:deleted] == "on" %>
+            <%= t('.show_deleted') %>
+          <% end %>
+        </div>
       </div>
     <% end %>
 

--- a/backend/app/views/spree/admin/variants/index.html.erb
+++ b/backend/app/views/spree/admin/variants/index.html.erb
@@ -17,12 +17,12 @@
       <% end %>
     </p>
   <% elsif @product.empty_option_values? %>
-    <div class="alpha twelve columns no-objects-found">
+    <div class="col-xs-9 no-objects-found">
       <%= Spree.t :no_option_values_on_product_html,
                   link: link_to(Spree.t(:product_details), [:edit, :admin, @product]) %>
     </div>
   <% else %>
-    <div class="alpha twelve columns no-objects-found">
+    <div class="col-xs-9 no-objects-found">
       <%= Spree.t(:no_resource, resource: plural_resource_name(Spree::Variant)) %>
       <% if can? :create, Spree::Variant %>
         <%= link_to Spree.t(:create_one), new_object_url, remote: true %>

--- a/backend/app/views/spree/admin/zones/_country_members.html.erb
+++ b/backend/app/views/spree/admin/zones/_country_members.html.erb
@@ -1,4 +1,4 @@
-<div id="country_members" data-hook="member" class="omega six columns">
+<div id="country_members" data-hook="member">
   <fieldset class="no-border-bottom">
     <legend align="center"><%= plural_resource_name(Spree::Country) %></legend>
 

--- a/backend/app/views/spree/admin/zones/_form.html.erb
+++ b/backend/app/views/spree/admin/zones/_form.html.erb
@@ -1,37 +1,45 @@
-<div class="alpha six columns" data-hook="admin_zone_form_fields">
-  <fieldset class="no-border-bottom">
-    <legend align="center"><%= Spree.t(:general_settings)%></legend>
+<div class="row">
+  <div class="col-xs-5">
 
-    <%= zone_form.field_container :name do %>
-      <%= zone_form.label :name %><br />
-      <%= zone_form.text_field :name, :class => 'fullwidth' %>
-    <% end %>
+    <div data-hook="admin_zone_form_fields">
+      <fieldset class="no-border-bottom">
+        <legend align="center"><%= Spree.t(:general_settings)%></legend>
 
-    <%= zone_form.field_container :description do %>
-      <%= zone_form.label :description %><br />
-      <%= zone_form.text_field :description, :class => 'fullwidth' %>
-    <% end %>
+        <%= zone_form.field_container :name do %>
+          <%= zone_form.label :name %><br />
+          <%= zone_form.text_field :name, :class => 'fullwidth' %>
+        <% end %>
 
-    <div data-hook="default" class="field">
-      <%= zone_form.check_box :default_tax %>
-      <%= zone_form.label :default_tax %>
+        <%= zone_form.field_container :description do %>
+          <%= zone_form.label :description %><br />
+          <%= zone_form.text_field :description, :class => 'fullwidth' %>
+        <% end %>
+
+        <div data-hook="default" class="field">
+          <%= zone_form.check_box :default_tax %>
+          <%= zone_form.label :default_tax %>
+        </div>
+
+        <div data-hook="type" class="field">
+          <%= label_tag Spree.t(:type) %>
+          <ul>
+            <li>
+              <%= zone_form.radio_button('kind', 'country', { :id => 'country_based' }) %>
+              <%= label_tag :country_based, Spree.t(:country_based) %>
+            </li>
+            <li>
+              <%= zone_form.radio_button('kind', 'state', { :id => 'state_based' }) %>
+              <%= label_tag :state_based, Spree.t(:state_based) %>
+            </li>
+          </ul>
+        </div>
+      </fieldset>
     </div>
+  </div>
+  <div class="col-xs-5">
 
-    <div data-hook="type" class="field">
-      <%= label_tag Spree.t(:type) %>
-      <ul>
-        <li>
-          <%= zone_form.radio_button('kind', 'country', { :id => 'country_based' }) %>
-          <%= label_tag :country_based, Spree.t(:country_based) %>
-        </li>
-        <li>
-          <%= zone_form.radio_button('kind', 'state', { :id => 'state_based' }) %>
-          <%= label_tag :state_based, Spree.t(:state_based) %>
-        </li>
-      </ul>
-    </div>
-  </fieldset>
+    <%= render :partial => 'state_members', :locals => { :zone_form => zone_form }%>
+    <%= render :partial => 'country_members', :locals => { :zone_form => zone_form } %>
+  </div>
+
 </div>
-
-<%= render :partial => 'state_members', :locals => { :zone_form => zone_form }%>
-<%= render :partial => 'country_members', :locals => { :zone_form => zone_form } %>

--- a/backend/app/views/spree/admin/zones/_state_members.html.erb
+++ b/backend/app/views/spree/admin/zones/_state_members.html.erb
@@ -1,4 +1,4 @@
-<div id="state_members" data-hook="member" class="omega six columns">
+<div id="state_members" data-hook="member">
   <fieldset class="no-border-bottom">
     <legend align="center"><%= plural_resource_name(Spree::State) %></legend>
 

--- a/backend/app/views/spree/admin/zones/index.html.erb
+++ b/backend/app/views/spree/admin/zones/index.html.erb
@@ -52,7 +52,7 @@
     </tbody>
   </table>
 <% else %>
-  <div class="alpha twelve columns no-objects-found">
+  <div class="col-xs-9 no-objects-found">
     <%= render 'spree/admin/shared/no_objects_found',
                  resource: Spree::Zone,
                  new_resource_url: new_object_url %>

--- a/backend/app/views/spree/layouts/admin.html.erb
+++ b/backend/app/views/spree/layouts/admin.html.erb
@@ -24,14 +24,14 @@
       <% else %>
         <% # Legacy layout %>
         <div class="container">
-          <div class="row">
-            <div class="<%= 'with-sidebar ' if content_for?(:sidebar) %>" id="content" data-hook>
+          <div class="<%= 'with-sidebar ' if content_for?(:sidebar) %>" id="content" data-hook>
+            <div class="row">
               <% if content_for?(:tabs) %>
-                <div class="sixteen columns">
+                <div class="col-xs-12">
                   <%= yield :tabs %>
                 </div>
               <% end %>
-              <div class="js-content-below-tabs <%= if content_for?(:sidebar) then 'twelve' else 'sixteen' end %> columns">
+              <div class="js-content-below-tabs <%= if content_for?(:sidebar) then 'col-xs-9' else 'col-xs-12' end %>">
                 <%= render :partial => 'spree/admin/shared/table_filter' %>
                 <%= yield %>
               </div>

--- a/backend/spec/features/admin/store_credits_spec.rb
+++ b/backend/spec/features/admin/store_credits_spec.rb
@@ -23,7 +23,7 @@ describe "Store credits admin" do
       click_link "Store Credit"
       expect(page.current_path).to eq spree.admin_user_store_credits_path(store_credit.user)
 
-      store_credit_table = page.find(".twelve.columns > table")
+      store_credit_table = page.find("#sc-table")
       expect(store_credit_table).to have_css('tr', count: 1)
       expect(store_credit_table).to have_content(Spree::Money.new(store_credit.amount).to_s)
       expect(store_credit_table).to have_content(Spree::Money.new(store_credit.amount_used).to_s)
@@ -48,7 +48,7 @@ describe "Store credits admin" do
       click_button "Create"
 
       expect(page.current_path).to eq spree.admin_user_store_credits_path(store_credit.user)
-      store_credit_table = page.find(".twelve.columns > table")
+      store_credit_table = page.find("#sc-table")
       expect(store_credit_table).to have_css('tr', count: 2)
       expect(Spree::StoreCredit.count).to eq 2
     end
@@ -67,7 +67,7 @@ describe "Store credits admin" do
     end
 
     it "updates the store credit's amount" do
-      page.find(".twelve.columns > table td.actions a.fa-edit").click
+      page.find("#sc-table td.actions a.fa-edit").click
       expect(page).to have_content 'Store credit history'
       click_link "Change amount"
       expect(page).to have_content 'Editing store credit amount'


### PR DESCRIPTION
This PR contains commits for all views within backend/app/views/spree that rely on skeleton grid classes.

This continues work on the Solidus admin roadmap #655 #1153 and allows the possibility of implementing the content-layout system introduced in #1114 by @graygilmore across any admin view without other modifications.

Each of these views have been updated using bootstrap grid classes and all skeleton classes have been removed. Layouts have not been significantly altered and no functionality has been added or removed.

Skeleton has been left enabled in order to maintain support for extensions that rely on it.
Because both skeleton and bootstrap implement a `row` class, bootstrap inherits skeleton's additional vertical spacing on `row`. This only affects bootstrap visually and `row`s work as intended if bootstrap classes are used.

Here is an example of an updated view, first with skeleton classes:
![skeleton](https://cloud.githubusercontent.com/assets/12424770/18973388/1390eb96-8652-11e6-8404-eb18ea195d7b.png)

And with bootstrap classes:
![bootstrap](https://cloud.githubusercontent.com/assets/12424770/18973395/185fb972-8652-11e6-98f2-b8dc2d9e1e25.png)