### PR TITLE
Stop mutating input in LocalizedNumber.parse

### DIFF
--- a/core/lib/spree/localized_number.rb
+++ b/core/lib/spree/localized_number.rb
@@ -16,9 +16,10 @@ module Spree
       non_number_characters = /[^0-9\-#{separator}]/
 
       # strip everything else first
-      number.gsub!(non_number_characters, '')
+      number = number.gsub(non_number_characters, '')
+
       # then replace the locale-specific decimal separator with the standard separator if necessary
-      number.gsub!(separator, '.') unless separator == '.'
+      number = number.gsub(separator, '.') unless separator == '.'
 
       number.to_d
     end


### PR DESCRIPTION
Previously, `LocalizedNumber.parse` would perform it's `gsub!` replacements directly on the string passed in.