### PR TITLE
Bug Fix: Edit multiple stock count error

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/stock_management/index_update_forms.coffee
+++ b/backend/app/assets/javascripts/spree/backend/stock_management/index_update_forms.coffee
@@ -46,7 +46,7 @@ Spree.EditStockItemView = Backbone.View.extend
   onSubmit: (ev) ->
     ev.preventDefault()
     backorderable = @$('[name=backorderable]').prop("checked")
-    countOnHand = parseInt($("input[name='count_on_hand']").val(), 10)
+    countOnHand = parseInt(@$("input[name='count_on_hand']").val(), 10)
 
     @model.set
       count_on_hand: countOnHand


### PR DESCRIPTION
# How to reproduce:

in path: `/spree/admin/stock_items`, try to mark multiple stocks as `edit` state, and save one item

![image](https://cloud.githubusercontent.com/assets/1553760/18987087/948e2912-8732-11e6-8db7-1b88646a0df7.png)


# What's Expected:

The edited item to be saved

# What's Happening:

Nothing changed

# Cause of issue
`$("input[name='count_on_hand']")` would select all the opened edit, and calling `$("input[name='count_on_hand']").val()` would return the value of the first value in the array only.