### PR TITLE
Show flash error messages on admin users actions

### DIFF
--- a/backend/app/controllers/spree/admin/users_controller.rb
+++ b/backend/app/controllers/spree/admin/users_controller.rb
@@ -29,6 +29,7 @@ module Spree
           load_roles
           load_stock_locations
 
+          flash.now[:error] = @user.errors.full_messages.join(", ")
           render :new, status: :unprocessable_entity
         end
       end
@@ -37,12 +38,14 @@ module Spree
         if @user.update_attributes(user_params)
           set_roles
           set_stock_locations
+
           flash[:success] = Spree.t(:account_updated)
           redirect_to edit_admin_user_url(@user)
         else
           load_roles
           load_stock_locations
 
+          flash.now[:error] = @user.errors.full_messages.join(", ")
           render :edit, status: :unprocessable_entity
         end
       end

--- a/backend/spec/features/admin/users_spec.rb
+++ b/backend/spec/features/admin/users_spec.rb
@@ -173,7 +173,13 @@ describe 'Users', type: :feature do
         fill_in 'user_email', with: 'something'
         click_button 'Update'
 
-        expect(page).to have_content("Email is invalid")
+        within('#errorExplanation') do
+          expect(page).to have_content("Email is invalid")
+        end
+
+        within('.flash.error') do
+          expect(page).to have_content("Email is invalid")
+        end
       end
     end
 


### PR DESCRIPTION
taking the default resource controller behavior from
https://github.com/nebulab/solidus/blob/284cf74d00ea842553aeffc58eff50d3e12900dd/backend/app/controllers/spree/admin/resource_controller.rb#L44

ref #1436