### PR TITLE
Make last names optional on Spree::Address

### DIFF
--- a/backend/spec/controllers/spree/admin/payments_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/payments_controller_spec.rb
@@ -54,7 +54,6 @@ module Spree
             let(:address_attributes) do
               {
                 'firstname' => address.firstname,
-                'lastname' => address.lastname,
                 'address1' => address.address1,
                 'city' => address.city,
                 'country_id' => address.country_id,

--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -11,7 +11,7 @@ module Spree
     belongs_to :country, class_name: "Spree::Country"
     belongs_to :state, class_name: "Spree::State"
 
-    validates :firstname, :lastname, :address1, :city, :country_id, presence: true
+    validates :firstname, :address1, :city, :country_id, presence: true
     validates :zipcode, presence: true, if: :require_zipcode?
     validates :phone, presence: true, if: :require_phone?
 

--- a/core/lib/spree/testing_support/factories/address_factory.rb
+++ b/core/lib/spree/testing_support/factories/address_factory.rb
@@ -11,7 +11,7 @@ FactoryGirl.define do
     end
 
     firstname 'John'
-    lastname 'Doe'
+    lastname nil
     company 'Company'
     address1 '10 Lovely Street'
     address2 'Northwest'


### PR DESCRIPTION
Redo of #1369 to fix a failing spec.