### PR TITLE
Disable RuboCop Style/EmptyElse

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,6 +32,9 @@ Style/MutableConstant:
 Style/ClassAndModuleChildren:
   Enabled: false
 
+Style/EmptyElse:
+  Enabled: false
+
 Style/GuardClause:
   Enabled: false
 


### PR DESCRIPTION
I think an explicit nil sometimes makes code more readable. E.g.:

    if
      ...
    elsif
      ...
    elsif
      ...
    elsif
      ...
    else
      nil
    end

lets me know that the "else" case was specifically considered and not
just forgotten.  It's also a great spot to leave a comment sometimes.

In any case, it doesn't seem like something we need to mandate
globally.