### PR TITLE
Remove is_default checkbox from prices edit

### DIFF
--- a/backend/app/views/spree/admin/prices/_form.html.erb
+++ b/backend/app/views/spree/admin/prices/_form.html.erb
@@ -41,12 +41,6 @@
       <% end %>
     </div>
 
-    <div class="field three columns checkbox omega" data-hook="is_default_price">
-      <%= f.label :is_default do %>
-        <%= f.check_box :is_default %>
-        <%= Spree::Price.human_attribute_name(:is_default) %>
-      <% end %>
-    </div>
   </div>
 </div>
 

--- a/backend/spec/features/admin/products/pricing_spec.rb
+++ b/backend/spec/features/admin/products/pricing_spec.rb
@@ -63,6 +63,22 @@ describe 'Pricing' do
       end
     end
 
+    context "editing" do
+      let(:variant) { create(:variant, price: 20) }
+      let(:product) { variant.product }
+
+      before do
+        product.master.update(price: 49.99)
+      end
+
+      it 'has a working edit page' do
+        within "#spree_price_#{product.master.prices.first.id}" do
+          click_icon :edit
+        end
+        expect(page).to have_content("Edit Price")
+      end
+    end
+
     context "deleting", js: true do
       let(:product) { create(:product, price: 65.43) }
       let!(:variant) { product.master }


### PR DESCRIPTION
As is_default in the Spree::Price model was removed in #1469 (#1182), the product prices page in admin backend should not have a checkbox for it as it prevents loading of the edit page with a no method error.

I've included a small test that ensures the edit page loads on being linked from the prices index page.