### PR TITLE
Make PaymentsHelper available to Order views

### DIFF
--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -1,6 +1,8 @@
 module Spree
   module Admin
     class OrdersController < Spree::Admin::BaseController
+      helper 'spree/admin/payments'
+
       before_action :initialize_order_events
       before_action :load_order, only: [:edit, :update, :complete, :advance, :cancel, :resume, :approve, :resend, :unfinalize_adjustments, :finalize_adjustments, :cart, :confirm]
       around_action :lock_order, only: [:update, :advance, :complete, :confirm, :cancel, :resume, :approve, :resend]


### PR DESCRIPTION
The `confirm` screen shows the [payments info](https://github.com/solidusio/solidus/blob/master/backend/app/views/spree/admin/orders/confirm.html.erb#L54). This [uses](https://github.com/solidusio/solidus/blob/master/backend/app/views/spree/admin/payments/_list.html.erb#L22) the helper [`payment_method_name`](https://github.com/solidusio/solidus/blob/master/backend/app/helpers/spree/admin/payments_helper.rb#L4) without explicitly indicating that controller is using that helper.

In many Rails apps, this may be ok due to `config.action_controller.include_all_helpers` defaulting to `true`. But if the application has configured this to be `false` the confirm screen breaks. I am personally a fan of the old Rails behavior (i.e. don't put all helpers in a big pile but make separate helper modules actually mean something). Even though it is the old behavior it is still supported behavior by Rails so it seems an effort to work either way should be made.