### PR TITLE
Stop generating dummy app with old_style_hash

### DIFF
--- a/core/lib/generators/spree/dummy/dummy_generator.rb
+++ b/core/lib/generators/spree/dummy/dummy_generator.rb
@@ -30,7 +30,6 @@ module Spree
       opts[:database] = 'sqlite3' if opts[:database].blank?
       opts[:force] = true
       opts[:skip_bundle] = true
-      opts[:old_style_hash] = true
 
       puts "Generating dummy Rails application..."
       invoke Rails::Generators::AppGenerator,


### PR DESCRIPTION
This is no longer an option, and there is no reason to use it.

See rails/rails@9cf38be008aff555b3aecc53a6f18800cea30a71