### PR TITLE
Fix database deletion and creation in test_app

### DIFF
--- a/core/lib/spree/testing_support/common_rake.rb
+++ b/core/lib/spree/testing_support/common_rake.rb
@@ -17,7 +17,8 @@ namespace :common do
 
     puts "Setting up dummy database..."
 
-    sh "bundle exec rake db:migrate VERBOSE=false"
+    sh "bundle exec bin/rails db:environment:set RAILS_ENV=test"
+    sh "bundle exec rake db:drop db:create db:migrate VERBOSE=false RAILS_ENV=test"
 
     begin
       require "generators/#{ENV['LIB_NAME']}/install/install_generator"


### PR DESCRIPTION
In some circumstances, creating and deleting the database was failing when running rake test_app. This was likely broken in by bc8efcb5f66057e0a6e91abaf801528c556d28d0 as well as the rails 5 upgrade.

Fixes #1491 

Thanks @kennyadsl for reporting the issue