### PR TITLE
Require ruby version 2.2.2 for all gems

### DIFF
--- a/api/solidus_api.gemspec
+++ b/api/solidus_api.gemspec
@@ -17,6 +17,9 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version = Spree.solidus_version
 
+  gem.required_ruby_version = '>= 2.2.2'
+  gem.required_rubygems_version = '>= 1.8.23'
+
   gem.add_dependency 'solidus_core', gem.version
   gem.add_dependency 'rabl', '0.13.0' # FIXME: update for proper rails 5 support
   gem.add_dependency 'versioncake', '~> 3.0'

--- a/backend/solidus_backend.gemspec
+++ b/backend/solidus_backend.gemspec
@@ -18,6 +18,9 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
+  s.required_ruby_version = '>= 2.2.2'
+  s.required_rubygems_version = '>= 1.8.23'
+
   s.add_dependency 'solidus_api', s.version
   s.add_dependency 'solidus_core', s.version
 

--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -17,7 +17,8 @@ Gem::Specification.new do |s|
   s.files        = `git ls-files`.split("\n")
   s.require_path = 'lib'
 
-  s.required_ruby_version = '>= 2.1.0'
+  s.required_ruby_version     = '>= 2.2.2'
+  s.required_rubygems_version = '>= 1.8.23'
 
   s.add_dependency 'activemerchant', '~> 1.48'
   s.add_dependency 'acts_as_list', '~> 0.3'

--- a/frontend/solidus_frontend.gemspec
+++ b/frontend/solidus_frontend.gemspec
@@ -18,6 +18,9 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
+  s.required_ruby_version = '>= 2.2.2'
+  s.required_rubygems_version = '>= 1.8.23'
+
   s.add_dependency 'solidus_api', s.version
   s.add_dependency 'solidus_core', s.version
 

--- a/sample/solidus_sample.gemspec
+++ b/sample/solidus_sample.gemspec
@@ -18,5 +18,8 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
+  s.required_ruby_version = '>= 2.2.2'
+  s.required_rubygems_version = '>= 1.8.23'
+
   s.add_dependency 'solidus_core', s.version
 end

--- a/solidus.gemspec
+++ b/solidus.gemspec
@@ -11,7 +11,8 @@ Gem::Specification.new do |s|
   s.files        = Dir['README.md', 'lib/**/*']
   s.require_path = 'lib'
   s.requirements << 'none'
-  s.required_ruby_version     = '>= 2.1.0'
+
+  s.required_ruby_version     = '>= 2.2.2'
   s.required_rubygems_version = '>= 1.8.23'
 
   s.author       = 'Solidus Team'


### PR DESCRIPTION
Rails 5 requires ruby 2.2.2, so we can now do the same.

Fixes #1494