### PR TITLE
Remove 'remove' class from cancel button on image edit page

### DIFF
--- a/backend/app/views/spree/admin/images/edit.html.erb
+++ b/backend/app/views/spree/admin/images/edit.html.erb
@@ -23,7 +23,7 @@
     <div class="clear"></div>
     <div class="form-buttons filter-actions actions" data-hook="buttons">
       <%= button Spree.t('actions.update') %>
-      <%= link_to Spree.t('actions.cancel'), admin_product_images_url(@product), :id => 'cancel_link', :class => 'button remove' %>
+      <%= link_to Spree.t('actions.cancel'), admin_product_images_url(@product), :id => 'cancel_link', :class => 'button' %>
     </div>
   </fieldset>
 <% end %>


### PR DESCRIPTION
The 'Cancel' button in the edit images admin page inadvertently has a `remove` class attached to it.
This causes the unexpected behaviour of hiding the form-buttons instead of returning to the images index.

The `remove` class appears to only be used in promotions forms as is defined in [nested-attributes.js](https://github.com/solidusio/solidus/blob/master/backend/app/assets/javascripts/spree/backend/nested-attribute.js).