### PR TITLE
Make adjustment created labels customizable

### DIFF
--- a/core/app/models/spree/promotion/actions/create_adjustment.rb
+++ b/core/app/models/spree/promotion/actions/create_adjustment.rb
@@ -27,7 +27,7 @@ module Spree
             order: order,
             source: self,
             promotion_code: options[:promotion_code],
-            label: "#{Spree.t(:promotion)} (#{promotion.name})"
+            label: Spree.t('adjustment_labels.order', promotion: Spree::Promotion.model_name.human, promotion_name: promotion.name)
           )
           true
         end

--- a/core/app/models/spree/promotion/actions/create_item_adjustments.rb
+++ b/core/app/models/spree/promotion/actions/create_item_adjustments.rb
@@ -59,7 +59,7 @@ module Spree
             amount: amount,
             order: order,
             promotion_code: promotion_code,
-            label: "#{Spree.t(:promotion)} (#{promotion.name})"
+            label: Spree.t('adjustment_labels.line_item', promotion: Spree::Promotion.model_name.human, promotion_name: promotion.name)
           )
           true
         end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -682,6 +682,8 @@ en:
     adjustment: Adjustment
     adjustment_amount: Amount
     adjustment_labels:
+      line_item: '%{promotion} (%{promotion_name})'
+      order: '%{promotion} (%{promotion_name})'
       tax_rates:
         sales_tax: '%{name}'
         vat: '%{name} (Included in Price)'


### PR DESCRIPTION
Currently adjustments are given labels that are hardcoded into one
format. This puts all of the information into an I18n translation which
is much simpler to override and will make labels much easier to utilize
in the views.  This will have no impact on the created labels until 
someone goes in and overrides the default translations.