### PR TITLE
Select first thumbnail when any other not seleted

### DIFF
--- a/frontend/app/assets/javascripts/spree/frontend/product.js.coffee
+++ b/frontend/app/assets/javascripts/spree/frontend/product.js.coffee
@@ -2,7 +2,7 @@ Spree.ready ($) ->
   Spree.addImageHandlers = ->
     thumbnails = ($ '#product-images ul.thumbnails')
     ($ '#main-image').data 'selectedThumb', ($ '#main-image img').attr('src')
-    thumbnails.find('li').eq(0).addClass 'selected'
+    thumbnails.find('li').eq(0).addClass 'selected' unless thumbnails.find('li.selected').length
     thumbnails.find('a').on 'click', (event) ->
       ($ '#main-image').data 'selectedThumb', ($ event.currentTarget).attr('href')
       ($ '#main-image').data 'selectedThumbId', ($ event.currentTarget).parent().attr('id')


### PR DESCRIPTION
This check prevents multiple thumbnails selection because thumbnail of variants can by also selected.