### PR TITLE
Remove currency from line items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## Solidus 2.1.0 (master, unreleased)
 
+*   Remove `currency` from line items.
+
+    It's no more allowed to have line items with different currencies on the
+    same order. This makes storing the currency on line items redundant, since
+    it will always be considered the same as the order currency.
+
+    It will raise an exception if a line item with the wrong currency is added.
+
+    Warning: this change also deletes the `currency` database field (String)
+    from the line items table, since it will not be used anymore.
+
 *   Add `Spree::Promotion#remove_from` and `Spree::PromotionAction#remove_from`
 
     This will allow promotions to be removed from orders and allows promotion

--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -40,6 +40,7 @@ module Spree
     # @return [Spree::Product, nil] the product associated with this line
     #   item, if there is one
     delegate :product, to: :variant
+    delegate :currency, to: :order, allow_nil: true
 
     attr_accessor :target_shipment
 
@@ -133,10 +134,6 @@ module Spree
       Spree::Deprecation.warn 'Spree::LineItem#currency= is deprecated ' \
         'and will take no effect.',
         caller
-    end
-
-    def currency
-      order.currency if order
     end
 
     private

--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -8,6 +8,8 @@ module Spree
   # promotion system.
   #
   class LineItem < Spree::Base
+    class CurrencyMismatch < StandardError; end
+
     belongs_to :order, class_name: "Spree::Order", inverse_of: :line_items, touch: true
     belongs_to :variant, -> { with_deleted }, class_name: "Spree::Variant", inverse_of: :line_items
     belongs_to :tax_category, class_name: "Spree::TaxCategory"
@@ -92,7 +94,9 @@ module Spree
     #
     # @param [Spree::Money] money - the money object to obtain price from
     def money_price=(money)
-      self.price = money.to_d if money
+      return unless money
+      raise CurrencyMismatch, "Line item price currency must match order currency!" if money.currency.iso_code != currency
+      self.price = money.to_d
     end
 
     # @return [Boolean] true when it is possible to supply the required

--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -94,9 +94,13 @@ module Spree
     #
     # @param [Spree::Money] money - the money object to obtain price from
     def money_price=(money)
-      return unless money
-      raise CurrencyMismatch, "Line item price currency must match order currency!" if money.currency.iso_code != currency
-      self.price = money.to_d
+      if !money
+        self.price = nil
+      elsif money.currency.iso_code != currency
+        raise CurrencyMismatch, "Line item price currency must match order currency!"
+      else
+        self.price = money.to_d
+      end
     end
 
     # @return [Boolean] true when it is possible to supply the required

--- a/core/app/models/spree/order_contents.rb
+++ b/core/app/models/spree/order_contents.rb
@@ -96,7 +96,6 @@ module Spree
       line_item ||= order.line_items.new(
         quantity: 0,
         variant: variant,
-        currency: order.currency
       )
 
       line_item.quantity += quantity.to_i

--- a/core/app/models/spree/order_merger.rb
+++ b/core/app/models/spree/order_merger.rb
@@ -26,7 +26,7 @@ module Spree
     #
     # The line items from `other_order` will be merged in to the `order` for
     # this OrderMerger object. If the line items are for the same variant, it
-    # will the quantity of the incoming line item to the existing line item.
+    # will add the quantity of the incoming line item to the existing line item.
     # Otherwise, it will assign the line item to the new order.
     #
     # After the orders have been merged the `other_order` will be destroyed.
@@ -46,11 +46,11 @@ module Spree
     # specified, the order user association will not be changed.
     # @return [void]
     def merge!(other_order, user = nil)
-      other_order.line_items.each do |other_order_line_item|
-        next unless other_order_line_item.currency == order.currency
-
-        current_line_item = find_matching_line_item(other_order_line_item)
-        handle_merge(current_line_item, other_order_line_item)
+      if other_order.currency == order.currency
+        other_order.line_items.each do |other_order_line_item|
+          current_line_item = find_matching_line_item(other_order_line_item)
+          handle_merge(current_line_item, other_order_line_item)
+        end
       end
 
       set_user(user)

--- a/core/app/models/spree/variant/pricing_options.rb
+++ b/core/app/models/spree/variant/pricing_options.rb
@@ -33,7 +33,7 @@ module Spree
       def self.from_line_item(line_item)
         tax_address = line_item.order.try!(:tax_address)
         new(
-          currency: line_item.order.try(:currency) || line_item.currency || Spree::Config.currency,
+          currency: line_item.order.try(:currency) || Spree::Config.currency,
           country_iso: tax_address && tax_address.country.try!(:iso)
         )
       end

--- a/core/app/models/spree/variant/pricing_options.rb
+++ b/core/app/models/spree/variant/pricing_options.rb
@@ -33,7 +33,7 @@ module Spree
       def self.from_line_item(line_item)
         tax_address = line_item.order.try!(:tax_address)
         new(
-          currency: line_item.order.try(:currency) || Spree::Config.currency,
+          currency: line_item.currency || Spree::Config.currency,
           country_iso: tax_address && tax_address.country.try!(:iso)
         )
       end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -538,8 +538,8 @@ en:
               cannot_destroy_shipment_state: "Cannot destroy an inventory unit for a %{state} shipment"
         spree/line_item:
           attributes:
-            currency:
-              must_match_order_currency: "Must match order currency"
+            price:
+              not_a_number: "is not valid"
         spree/price:
           attributes:
             currency:

--- a/core/db/migrate/20161009141333_remove_currency_from_line_items.rb
+++ b/core/db/migrate/20161009141333_remove_currency_from_line_items.rb
@@ -1,0 +1,5 @@
+class RemoveCurrencyFromLineItems < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :spree_line_items, :currency, :string
+  end
+end

--- a/core/lib/spree/testing_support/factories/line_item_factory.rb
+++ b/core/lib/spree/testing_support/factories/line_item_factory.rb
@@ -12,6 +12,5 @@ FactoryGirl.define do
     variant do
       (product || create(:product)).master
     end
-    currency { order.currency }
   end
 end

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -189,6 +189,15 @@ describe Spree::LineItem, type: :model do
       expect(line_item.price).to eq(new_price.cents / 100.0)
     end
 
+    context 'when the new price is nil' do
+      let(:new_price) { nil }
+
+      it 'makes the line item price empty' do
+        line_item.money_price = new_price
+        expect(line_item.price).to be_nil
+      end
+    end
+
     context 'when the price has a currency different from the order currency' do
       let(:currency) { "RUB" }
 

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -181,11 +181,22 @@ describe Spree::LineItem, type: :model do
   end
 
   describe 'money_price=' do
-    let(:new_price) { Spree::Money.new(99.00, currency: "RUB") }
+    let(:currency) { "USD" }
+    let(:new_price) { Spree::Money.new(99.00, currency: currency) }
 
     it 'assigns a new price' do
       line_item.money_price = new_price
       expect(line_item.price).to eq(new_price.cents / 100.0)
+    end
+
+    context 'when the price has a currency different from the order currency' do
+      let(:currency) { "RUB" }
+
+      it 'raises an exception' do
+        expect {
+          line_item.money_price = new_price
+        }.to raise_exception Spree::LineItem::CurrencyMismatch
+      end
     end
   end
 

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -67,7 +67,6 @@ describe Spree::LineItem, type: :model do
       before(:context) do
         Spree::LineItem.class_eval do
           def copy_price
-            self.currency = "USD"
             self.cost_price = 10
             self.price = 20
           end
@@ -128,66 +127,75 @@ describe Spree::LineItem, type: :model do
     end
   end
 
-  context 'setting the currency' do
-    let(:line_item) { order.line_items.first }
+  context 'setting a line item price' do
+    let(:store) { create(:store, default: true) }
+    let(:order) { Spree::Order.new(currency: "RUB", store: store) }
+    let(:variant) { Spree::Variant.new(product: Spree::Product.new) }
+    let(:line_item) { Spree::LineItem.new(order: order, variant: variant) }
 
-    context "currency same as order.currency" do
+    before { expect(variant).to receive(:price_for).at_least(:once).and_return(price) }
+
+    context "when a price exists in order currency" do
+      let(:price) { Spree::Money.new(99.00, currency: "RUB") }
+
       it "is a valid line item" do
-        line_item.currency = order.currency
-        line_item.valid?
-
-        expect(line_item.error_on(:currency).size).to eq(0)
+        expect(line_item.valid?).to be_truthy
+        expect(line_item.error_on(:price).size).to eq(0)
       end
     end
 
-    context "currency different than order.currency" do
-      it "is not a valid line item" do
-        expect(Spree::Deprecation).to receive(:warn).at_least(:once)
-        line_item.currency = "RUB"
-        line_item.valid?
+    context "when a price does not exist in order currency" do
+      let(:price) { nil }
 
-        expect(line_item.error_on(:currency).size).to eq(1)
+      it "is not a valid line item" do
+        expect(line_item.valid?).to be_falsey
+        expect(line_item.error_on(:price).size).to eq(1)
       end
     end
   end
 
   describe "#options=" do
-    it "can handle updating a blank line item with no order" do
-      line_item.options = { price: 123 }
-    end
+    let(:options) { { price: 123, quantity: 5 } }
 
     it "updates the data provided in the options" do
-      line_item.options = { price: 123 }
+      line_item.options = options
+
       expect(line_item.price).to eq 123
+      expect(line_item.quantity).to eq 5
     end
 
-    it "updates the price based on the options provided" do
-      expect(line_item).to receive(:gift_wrap=).with(true)
-      expect(line_item).to receive(:money_price=)
-      line_item.options = { gift_wrap: true }
+    context "when price is not provided" do
+      let(:options) { { quantity: 5 } }
+
+      it "sets price anyway, retrieving it from line item options" do
+        expect(line_item.variant)
+          .to receive(:price_for)
+          .and_return(Spree::Money.new(123, currency: "USD"))
+
+        line_item.options = options
+
+        expect(line_item.price).to eq 123
+        expect(line_item.quantity).to eq 5
+      end
     end
   end
 
   describe 'money_price=' do
-    let(:line_item) { Spree::LineItem.new }
     let(:new_price) { Spree::Money.new(99.00, currency: "RUB") }
 
-    it 'assigns a new price and currency' do
+    it 'assigns a new price' do
       line_item.money_price = new_price
       expect(line_item.price).to eq(new_price.cents / 100.0)
-      expect(line_item.currency).to eq(new_price.currency.iso_code)
     end
   end
 
   describe "#pricing_options" do
-    let(:line_item) { Spree::LineItem.new(currency: "RUB") }
-
     subject { line_item.pricing_options }
 
     it { is_expected.to be_a(Spree::Config.pricing_options_class) }
 
-    it "holds the line items's currency" do
-      expect(subject.currency).to eq("RUB")
+    it "holds the order currency" do
+      expect(subject.currency).to eq("USD")
     end
   end
 end

--- a/core/spec/models/spree/order_merger_spec.rb
+++ b/core/spec/models/spree/order_merger_spec.rb
@@ -43,6 +43,26 @@ module Spree
       end
     end
 
+    context 'merging together two orders with multiple currencies line items' do
+      let(:order_2) { Spree::Order.create(currency: 'JPY') }
+      let(:variant_2) { create(:variant) }
+
+      before do
+        Spree::Price.create(variant: variant_2, amount: 10, currency: 'JPY')
+        order_1.contents.add(variant, 1)
+        order_2.contents.add(variant_2.reload, 1)
+      end
+
+      it 'rejects other order line items' do
+        subject.merge!(order_2, user)
+        expect(order_1.line_items.count).to eq(1)
+
+        line_item = order_1.line_items.first
+        expect(line_item.quantity).to eq(1)
+        expect(line_item.variant_id).to eq(variant.id)
+      end
+    end
+
     context "merging using extension-specific line_item_comparison_hooks" do
       before do
         Spree::Order.register_line_item_comparison_hook(:foos_match)

--- a/core/spec/models/spree/variant/pricing_options_spec.rb
+++ b/core/spec/models/spree/variant/pricing_options_spec.rb
@@ -23,7 +23,7 @@ describe Spree::Variant::PricingOptions do
   end
 
   context ".from_line_item" do
-    let(:line_item) { build_stubbed(:line_item, currency: "USD") }
+    let(:line_item) { build_stubbed(:line_item) }
     subject { described_class.from_line_item(line_item) }
 
     it "returns the order's currency" do
@@ -34,29 +34,19 @@ describe Spree::Variant::PricingOptions do
       expect(subject.desired_attributes[:country_iso]).to eq("US")
     end
 
+    context 'if order has no currency' do
+      before do
+        expect(line_item.order).to receive(:currency).at_least(:once).and_return(nil)
+        expect(Spree::Config).to receive(:currency).at_least(:once).and_return("RUB")
+      end
+
+      it "returns the configured default currency" do
+        expect(subject.desired_attributes[:currency]).to eq("RUB")
+      end
+    end
+
     context "if line item has no order" do
       before do
-        expect(line_item).to receive(:order).at_least(:once).and_return(nil)
-      end
-
-      it "returns the line item's currency" do
-        expect(subject.desired_attributes[:currency]).to eq("USD")
-      end
-    end
-
-    context "if line item's order has no currency" do
-      before do
-        expect(line_item.order).to receive(:currency).and_return(nil)
-      end
-
-      it "returns the line item's currency" do
-        expect(subject.desired_attributes[:currency]).to eq("USD")
-      end
-    end
-
-    context "if neither order nor line item have a currency" do
-      before do
-        expect(line_item).to receive(:currency).and_return(nil)
         expect(line_item).to receive(:order).at_least(:once).and_return(nil)
         expect(Spree::Config).to receive(:currency).at_least(:once).and_return("RUB")
       end


### PR DESCRIPTION
This PR removes currency from line items. That field is no more useful since all order contents will have the same currency (the order one). 

ref: #1399 

#### TODO:

- [x] Understand what happens when the order currency is changed. Can this happen? Shouldn't we recalculate prices for all line items with the new currency? Is this already handled by the order merger? [Handled with a separate Issue](https://github.com/solidusio/solidus/issues/1515) 
- [x] Remove currency from `spree_line_items` database table. I'm a bit concerned about this. What happens if there are users that rely on this field has custom logic related to line item currency (like statistics)? They could loose them. Can we proceed anyway or it's better to leave the field in the database and mark it for a future removal?
- [x] Update changelog

