### PR TITLE
Improved promotions form

### DIFF
--- a/backend/app/assets/javascripts/spree/backend.js
+++ b/backend/app/assets/javascripts/spree/backend.js
@@ -42,6 +42,7 @@
 //= require spree/backend/product_picker
 //= require spree/backend/progress
 //= require spree/backend/promotions
+//= require spree/backend/promotions/activation
 //= require spree/backend/returns/return_item_selection
 //= require spree/backend/routes
 //= require spree/backend/select_payments

--- a/backend/app/assets/javascripts/spree/backend/promotions/activation.js
+++ b/backend/app/assets/javascripts/spree/backend/promotions/activation.js
@@ -1,0 +1,26 @@
+Spree.PromotionActivationView = Backbone.View.extend({
+  events: {
+    "change [name=activation_type]": "render"
+  },
+
+  initialize: function(){
+    this.render();
+  },
+
+  render: function(){
+    var activation_type = this.$("[name=activation_type]:checked").val();
+    this.$('[data-activation-type]').each(function(){
+      var selected = ($(this).data('activation-type') === activation_type);
+      $(this).find(':input').prop("disabled", !selected);
+      $(this).toggle(selected);
+    });
+  }
+});
+
+$(function(){
+  if($("#js_promotion_activation").length) {
+    new Spree.PromotionActivationView({
+      el: $("#js_promotion_activation")
+    });
+  }
+});

--- a/backend/app/controllers/spree/admin/promotions_controller.rb
+++ b/backend/app/controllers/spree/admin/promotions_controller.rb
@@ -9,7 +9,12 @@ module Spree
         @promotion = Spree::Promotion.new(permitted_resource_params)
         @promotion.codes.new(value: params[:single_code]) if params[:single_code].present?
 
+        if params[:promotion_code_batch]
+          @promotion_code_batch = @promotion.promotion_code_batches.new(promotion_code_batch_params)
+        end
+
         if @promotion.save
+          @promotion_code_batch.process if @promotion_code_batch
           flash[:success] = Spree.t(:promotion_successfully_created)
           redirect_to location_after_save
         else
@@ -42,6 +47,10 @@ module Spree
           per(params[:per_page] || Spree::Config[:promotions_per_page])
 
         @collection
+      end
+
+      def promotion_code_batch_params
+        params.require(:promotion_code_batch).permit!
       end
 
       def promotion_includes

--- a/backend/app/views/spree/admin/promotions/_activations_edit.html.erb
+++ b/backend/app/views/spree/admin/promotions/_activations_edit.html.erb
@@ -1,0 +1,22 @@
+<% if @promotion.apply_automatically? %>
+  <p>
+    <%= t('.auto') %>
+  </p>
+<% end %>
+
+<% if @promotion.codes.count == 1 %>
+  <p>
+    <%= t('.single_code_html', code: @promotion.codes.first.value) %>
+  </p>
+<% elsif @promotion.codes.count > 1 %>
+  <p>
+    <%= t('.multiple_codes_html', count: @promotion.codes.count) %>
+  </p>
+<% end %>
+
+<% if @promotion.path %>
+  <div class="field">
+    <%= f.label :path %>
+    <%= f.text_field :path, class: "fullwidth" %>
+  </p>
+<% end %>

--- a/backend/app/views/spree/admin/promotions/_activations_new.html.erb
+++ b/backend/app/views/spree/admin/promotions/_activations_new.html.erb
@@ -34,20 +34,20 @@
 
     <div data-activation-type="single_code">
       <div class="field">
-        <%= label_tag :single_code %>
-        <%= text_field_tag :single_code, @promotion.codes.first.try!(:value), class: "fullwidth" %>
+        <%= label_tag :single_code, Spree::PromotionCode.model_name.human, class: "required" %>
+        <%= text_field_tag :single_code, @promotion.codes.first.try!(:value), class: "fullwidth", required: true %>
       </div>
     </div>
 
     <div data-activation-type="multiple_codes">
       <%= fields_for :promotion_code_batch, @promotion_code_batch do |batch| %>
         <div class="field">
-          <%= batch.label :base_code %>
-          <%= batch.text_field :base_code, class: "fullwidth" %>
+          <%= batch.label :base_code, class: "required" %>
+          <%= batch.text_field :base_code, class: "fullwidth", required: true %>
         </div>
         <div class="field">
-          <%= batch.label :number_of_codes %>
-          <%= batch.text_field :number_of_codes, class: "fullwidth" %>
+          <%= batch.label :number_of_codes, class: "required" %>
+          <%= batch.number_field :number_of_codes, class: "fullwidth", min: 1, required: true %>
         </div>
         <div class="field">
           <%= f.label :per_code_usage_limit %>
@@ -58,8 +58,8 @@
 
     <div data-activation-type="path">
       <div class="field" id="promotion_path_field">
-        <%= f.label :path %>
-        <%= f.text_field :path, class: "fullwidth" %>
+        <%= f.label :path, class: "required" %>
+        <%= f.text_field :path, class: "fullwidth", required: true %>
       </div>
     </div>
   </div>

--- a/backend/app/views/spree/admin/promotions/_activations_new.html.erb
+++ b/backend/app/views/spree/admin/promotions/_activations_new.html.erb
@@ -1,0 +1,66 @@
+<% activation_type = params[:activation_type] || 'single_code' %>
+<div class="row" id="js_promotion_activation">
+  <div class="col-xs-3">
+    <div class="form-check">
+      <label class="form-check-label">
+        <%= radio_button_tag('activation_type', 'auto', activation_type == 'auto') %>
+        <%= t('.auto') %>
+      </label>
+    </div>
+    <div class="form-check">
+      <label class="form-check-label">
+        <%= radio_button_tag('activation_type', 'single_code', activation_type == 'single_code') %>
+        <%= t('.single_code') %>
+      </label>
+    </div>
+    <div class="form-check">
+      <label class="form-check-label">
+        <%= radio_button_tag('activation_type', 'multiple_codes', activation_type == 'multiple_codes') %>
+        <%= t('.multiple_codes') %>
+      </label>
+    </div>
+    <div class="form-check">
+      <label class="form-check-label">
+        <%= radio_button_tag('activation_type', 'path', activation_type == 'path') %>
+        <%= t('.path') %>
+      </label>
+    </div>
+  </div>
+  <div class="col-xs-9">
+    <input name="promotion[apply_automatically]" type="hidden" value="0">
+    <div data-activation-type="auto">
+      <input name="promotion[apply_automatically]" type="hidden" value="1">
+    </div>
+
+    <div data-activation-type="single_code">
+      <div class="field">
+        <%= label_tag :single_code %>
+        <%= text_field_tag :single_code, @promotion.codes.first.try!(:value), class: "fullwidth" %>
+      </div>
+    </div>
+
+    <div data-activation-type="multiple_codes">
+      <%= fields_for :promotion_code_batch, @promotion_code_batch do |batch| %>
+        <div class="field">
+          <%= batch.label :base_code %>
+          <%= batch.text_field :base_code, class: "fullwidth" %>
+        </div>
+        <div class="field">
+          <%= batch.label :number_of_codes %>
+          <%= batch.text_field :number_of_codes, class: "fullwidth" %>
+        </div>
+        <div class="field">
+          <%= f.label :per_code_usage_limit %>
+          <%= f.text_field :per_code_usage_limit, class: "fullwidth" %>
+        </div>
+      <% end %>
+    </div>
+
+    <div data-activation-type="path">
+      <div class="field" id="promotion_path_field">
+        <%= f.label :path %>
+        <%= f.text_field :path, class: "fullwidth" %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/backend/app/views/spree/admin/promotions/_form.html.erb
+++ b/backend/app/views/spree/admin/promotions/_form.html.erb
@@ -1,72 +1,66 @@
 <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @promotion } %>
-<div class="row">
-  <div id="general_fields" class="col-xs-9">
-    <div class="row">
-      <div class="col-xs-3">
-        <%= f.field_container :name do %>
-          <%= f.label :name %>
-          <%= f.text_field :name, :class => 'fullwidth' %>
-        <% end %>
+<fieldset class="form-group no-border-bottom">
+  <legend><%= t '.general' %></legend>
 
-        <div class="field" data-hook="promotion-single-code-field">
-          <%= label_tag :single_code %>
-          <%= text_field_tag :single_code, @promotion.codes.first.try!(:value), :readonly => !@promotion.new_record?, :class => 'fullwidth' %>
+  <div class="row">
+    <div id="general_fields" class="col-xs-9">
+      <div class="row">
+        <div class="col-xs-3">
+          <%= f.field_container :name do %>
+            <%= f.label :name %>
+            <%= f.text_field :name, :class => 'fullwidth' %>
+          <% end %>
+
+          <%= f.field_container :advertise do %>
+            <%= f.check_box :advertise %>
+            <%= f.label :advertise %>
+          <% end %>
         </div>
 
-        <%= f.field_container :per_code_usage_limit do %>
-          <%= f.label :per_code_usage_limit %>
-          <%= f.text_field :per_code_usage_limit, class: 'fullwidth' %>
-        <% end %>
+        <div class="col-xs-9">
+          <%= f.field_container :description do %>
+            <%= f.label :description %><br />
+            <%= f.text_area :description, :rows => 7, :class => 'fullwidth' %>
+          <% end %>
 
-        <%= f.field_container :path do %>
-          <%= f.label :path %>
-          <%= f.text_field :path, :class => 'fullwidth' %>
-        <% end %>
+          <%= f.field_container :category do %>
+            <%= f.label :promotion_category_id, Spree::PromotionCategory.model_name.human %><br />
+            <%= f.collection_select(:promotion_category_id, @promotion_categories, :id, :name, { :include_blank => Spree.t('match_choices.none') }, { :class => 'select2 fullwidth' }) %>
+          <% end %>
+        </div>
+      </div>
+    </div>
 
-        <%= f.field_container :advertise do %>
-          <%= f.check_box :advertise %>
-          <%= f.label :advertise %>
-        <% end %>
+    <div id="expiry_fields" class="col-xs-3">
+      <%= f.field_container :overall_usage_limit do %>
+        <%= f.label :usage_limit %><br />
+        <%= f.number_field :usage_limit, :min => 0, :class => 'fullwidth' %><br>
+        <span class="info">
+          <%= Spree.t(:current_promotion_usage, :count => @promotion.usage_count) %>
+        </span>
+      <% end %>
 
-        <%= f.field_container :apply_automatically do %>
-          <%= f.check_box :apply_automatically %>
-          <%= f.label :apply_automatically %>
-        <% end %>
+      <div id="starts_at_field" class="field">
+        <%= f.label :starts_at %>
+        <%= f.field_hint :starts_at %>
+        <%= f.text_field :starts_at, :value => datepicker_field_value(@promotion.starts_at), :placeholder => t(".starts_at_placeholder"), :class => 'datepicker datepicker-from fullwidth' %>
       </div>
 
-      <div class="col-xs-9">
-        <%= f.field_container :description do %>
-          <%= f.label :description %><br />
-          <%= f.text_area :description, :rows => 7, :class => 'fullwidth' %>
-        <% end %>
-
-        <%= f.field_container :category do %>
-          <%= f.label :promotion_category_id, Spree::PromotionCategory.model_name.human %><br />
-          <%= f.collection_select(:promotion_category_id, @promotion_categories, :id, :name, { :include_blank => Spree.t('match_choices.none') }, { :class => 'select2 fullwidth' }) %>
-        <% end %>
+      <div id="expires_at_field" class="field">
+        <%= f.label :expires_at %>
+        <%= f.field_hint :expires_at %>
+        <%= f.text_field :expires_at, :value => datepicker_field_value(@promotion.expires_at), :placeholder => t(".expires_at_placeholder"), :class => 'datepicker datepicker-to fullwidth' %>
       </div>
     </div>
   </div>
+</fieldset>
 
-  <div id="expiry_fields" class="col-xs-3">
-    <%= f.field_container :overall_usage_limit do %>
-      <%= f.label :usage_limit %><br />
-      <%= f.number_field :usage_limit, :min => 0, :class => 'fullwidth' %><br>
-      <span class="info">
-        <%= Spree.t(:current_promotion_usage, :count => @promotion.usage_count) %>
-      </span>
-    <% end %>
+<fieldset class="form-group no-border-bottom">
+  <legend><%= t '.activation' %></legend>
 
-    <div id="starts_at_field" class="field">
-      <%= f.label :starts_at %>
-      <%= f.field_hint :starts_at %>
-      <%= f.text_field :starts_at, :value => datepicker_field_value(@promotion.starts_at), :placeholder => t(".starts_at_placeholder"), :class => 'datepicker datepicker-from fullwidth' %>
-    </div>
-
-    <div id="expires_at_field" class="field">
-      <%= f.label :expires_at %>
-      <%= f.field_hint :expires_at %>
-      <%= f.text_field :expires_at, :value => datepicker_field_value(@promotion.expires_at), :placeholder => t(".expires_at_placeholder"), :class => 'datepicker datepicker-to fullwidth' %>
-    </div>
-  </div>
-</div>
+  <% if @promotion.new_record? %>
+    <%= render 'spree/admin/promotions/activations_new', f: f %>
+  <% else %>
+    <%= render 'spree/admin/promotions/activations_edit', f: f %>
+  <% end %>
+</fieldset>

--- a/backend/app/views/spree/admin/promotions/_form.html.erb
+++ b/backend/app/views/spree/admin/promotions/_form.html.erb
@@ -7,8 +7,8 @@
       <div class="row">
         <div class="col-xs-3">
           <%= f.field_container :name do %>
-            <%= f.label :name %>
-            <%= f.text_field :name, :class => 'fullwidth' %>
+            <%= f.label :name, class: 'required' %>
+            <%= f.text_field :name, class: 'fullwidth', required: true %>
           <% end %>
 
           <%= f.field_container :advertise do %>

--- a/backend/app/views/spree/admin/promotions/_rules.html.erb
+++ b/backend/app/views/spree/admin/promotions/_rules.html.erb
@@ -48,6 +48,4 @@
         <% end %>
       </fieldset>
     <% end %>
-
-
 </fieldset>

--- a/backend/app/views/spree/admin/promotions/edit.html.erb
+++ b/backend/app/views/spree/admin/promotions/edit.html.erb
@@ -1,6 +1,7 @@
+<% admin_layout "full-width" %>
+
 <% admin_breadcrumb(link_to plural_resource_name(Spree::Promotion), spree.admin_promotions_path) %>
 <% admin_breadcrumb(@promotion.name) %>
-
 
 <% content_for :page_actions do %>
   <li>
@@ -15,12 +16,10 @@
 <% end %>
 
 <%= form_for @promotion, :url => object_url, :method => :put do |f| %>
-  <fieldset class="no-border-top">
-    <%= render :partial => 'form', :locals => { :f => f } %>
-    <% if can?(:update, @promotion) %>
-      <%= render :partial => 'spree/admin/shared/edit_resource_links' %>
-    <% end %>
-  </fieldset>
+  <%= render :partial => 'form', :locals => { :f => f } %>
+  <% if can?(:update, @promotion) %>
+    <%= render :partial => 'spree/admin/shared/edit_resource_links' %>
+  <% end %>
 <% end %>
 
 <div id="promotion-filters" class="row">

--- a/backend/app/views/spree/admin/promotions/new.html.erb
+++ b/backend/app/views/spree/admin/promotions/new.html.erb
@@ -1,10 +1,9 @@
+<% admin_layout "full-width" %>
+
 <% admin_breadcrumb(link_to plural_resource_name(Spree::Promotion), spree.admin_promotions_path) %>
 <% admin_breadcrumb(Spree.t(:new_promotion)) %>
 
-
 <%= form_for @promotion, :url => collection_url do |f| %>
-  <fieldset class="no-border-top">
-    <%= render :partial => 'form', :locals => { :f => f } %>
-    <%= render :partial => 'spree/admin/shared/new_resource_links' %>
-  </fieldset>
+  <%= render :partial => 'form', :locals => { :f => f } %>
+  <%= render :partial => 'spree/admin/shared/new_resource_links' %>
 <% end %>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -166,12 +166,12 @@ en:
         code: Code
         description: Description
         event_name: Event Name
-        expires_at: Expiration
+        expires_at: Expiration date
         name: Name
         path: Path
         per_code_usage_limit: Per Code Usage Limit
         promotion_uses: Promotion Uses
-        starts_at: Starts
+        starts_at: Start date
         usage_limit: Overall Usage Limit
       spree/promotion_category:
         name: Name
@@ -778,6 +778,17 @@ en:
         form:
           starts_at_placeholder: Immediately
           expires_at_placeholder: Never
+          activation: Activation
+          general: General
+        activations_new:
+          auto: Apply to all orders
+          multiple_codes: Multiple promotion codes
+          path: URL Path
+          single_code: Single promotion code
+        activations_edit:
+          auto: All orders will attempt to use this promotion
+          single_code_html: "This promotion uses the promotion code: <code>%{code}</code>"
+          multiple_codes_html: "This promotion uses %{count} promotion codes"
       store_credits:
         add: "Add store credit"
         amount_authorized: "Amount Authorized"


### PR DESCRIPTION
I think it is universally agreed that the promotions form is too complicated and confusing.

Existing form:

![](http://i.hawth.ca/s/4wUTDNny.png)

I felt that one of the biggest problems with this form is that it is difficult for an inexperienced user (and even users with years of spree/solidus experience) to know how to create a new promotion that activates when they want it.

A user needs to know
- What "Apply Automatically" means (that it will be applied to all orders)
- What "Path" means (probably not used by most stores)
- To get a single promotion code (a very common use case) "Number of codes" must be set to 1 and then "base code" can be used as the desired promotion code.
- How the promotion code generator works and how to download the codes when specifying multiple codes.

To make this easier to use, I've created a set of radio buttons to help guide a user to their desired behaviour without knowing the meanings behind all these magic fields.

These radio buttons are only used by JS and aren't persisted.
## Redesigned page

![](http://i.hawth.ca/s/WIhd4kVF.png)

Designing things is usually not my forte, but I think this is an improvement. I started by splitting the fields into three sections, with the last one being the new radio buttons.
## Radio buttons

![](http://i.hawth.ca/s/DTNI9ln1.png)

![](http://i.hawth.ca/s/bS9PsW9Z.png)

![](http://i.hawth.ca/s/CFsRl7Jn.png)

![](http://i.hawth.ca/s/sK0zPror.png)
## Work to do:
- [x] There will be updates needed after #1410 (or equivalent) is merged
- [x] Figure out what to do on the edit page
- [x] Fix specs
