### PR TITLE
Admin pricing view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,9 @@
 
 *   The `lastname` field on `Address` is now optional. [#1369](https://github.com/solidusio/solidus/pull/1369)
 
+*   The admin prices listings page now shows master and variant prices
+    seperately. This changes `@prices` to `@master_prices` and `@variant_prices` in prices_controller
+
 *   Removals
 
     * Removed deprecated method `Spree::TaxRate.adjust` (not to be confused with

--- a/backend/app/controllers/spree/admin/prices_controller.rb
+++ b/backend/app/controllers/spree/admin/prices_controller.rb
@@ -7,8 +7,14 @@ module Spree
         params[:q] ||= {}
 
         @search = @product.prices.accessible_by(current_ability, :index).ransack(params[:q])
-        @prices = @search.result
+        @master_prices = @search.result
           .currently_valid
+          .for_master
+          .order(:variant_id, :country_iso, :currency)
+          .page(params[:page]).per(Spree::Config.admin_variants_per_page)
+        @variant_prices = @search.result
+          .currently_valid
+          .for_variant
           .order(:variant_id, :country_iso, :currency)
           .page(params[:page]).per(Spree::Config.admin_variants_per_page)
       end

--- a/backend/app/views/spree/admin/prices/_master_variant_table.html.erb
+++ b/backend/app/views/spree/admin/prices/_master_variant_table.html.erb
@@ -1,0 +1,41 @@
+<div class="row">
+  <div class="col-xs-12">
+    <fieldset class="no-border-bottom <%= "no-border-top" if !variants %>">
+      <% if variants %>
+        <legend align="center"><%= I18n.t(:master_variant, scope: :spree) %> <%= admin_hint I18n.t(:master_variant, scope: :spree), I18n.t(:master_variant, scope: [:spree, :hints, "spree/price"]) %></legend>
+      <% end %>
+      <table class="index master_prices">
+        <colgroup>
+          <col style="width: 30%">
+          <col style="width: 30%">
+          <col style="width: 20%">
+          <col style="width: 20%">
+        </colgroup>
+        <thead data-hook="master_prices_header">
+          <tr>
+            <th><%= Spree::Price.human_attribute_name(:country) %></th>
+            <th><%= Spree::Price.human_attribute_name(:currency) %></th>
+            <th><%= Spree::Price.human_attribute_name(:amount) %></th>
+            <th class="actions"></th>
+          </tr>
+        </thead>
+        <% master_prices.each do |price| %>
+          <tr id="<%= spree_dom_id price %>" data-hook="prices_row" class="<%= "deleted" if price.deleted? %> <%= cycle('odd', 'even')%>">
+            <td><%= price.display_country %></td>
+            <td><%= price.currency %></td>
+            <td class="align-right"><%= price.money.to_html %></td>
+            <td class="actions">
+              <% if can?(:update, price) %>
+                <%= link_to_edit(price, :no_text => true) unless price.deleted? %>
+              <% end %>
+              <% if can?(:destroy, price) %>
+                &nbsp;
+                <%= link_to_delete(price, :no_text => true) unless price.deleted? %>
+              <% end %>
+            </td>
+          </tr>
+        <% end %>
+      </table>
+    </fieldset>
+  </div>
+</div>

--- a/backend/app/views/spree/admin/prices/_table.html.erb
+++ b/backend/app/views/spree/admin/prices/_table.html.erb
@@ -1,39 +1,5 @@
 <%= paginate variant_prices, theme: "solidus_admin" %>
 
-<div class="row">
-  <div class="col-xs-8">
-    <fieldset class="no-border-bottom">
-      <legend align="center"><%= I18n.t(:master_variant, scope: :spree) %> <%= admin_hint I18n.t(:master_variant, scope: :spree), I18n.t(:master_variant, scope: [:spree, :hints, "spree/price"]) %></legend>
-      <table class="index master_prices">
-        <thead data-hook="master_prices_header">
-          <tr>
-            <th><%= Spree::Price.human_attribute_name(:country) %></th>
-            <th><%= Spree::Price.human_attribute_name(:currency) %></th>
-            <th><%= Spree::Price.human_attribute_name(:amount) %></th>
-            <th class="actions"></th>
-          </tr>
-        </thead>
-        <% master_prices.each do |price| %>
-          <tr id="<%= spree_dom_id price %>" data-hook="prices_row" class="<%= "deleted" if price.deleted? %> <%= cycle('odd', 'even')%>">
-            <td><%= price.display_country %></td>
-            <td><%= price.currency %></td>
-            <td class="align-right"><%= price.money.to_html %></td>
-            <td class="actions">
-              <% if can?(:update, price) %>
-                <%= link_to_edit(price, :no_text => true) unless price.deleted? %>
-              <% end %>
-              <% if can?(:destroy, price) %>
-                &nbsp;
-                <%= link_to_delete(price, :no_text => true) unless price.deleted? %>
-              <% end %>
-            </td>
-          </tr>
-        <% end %>
-      </table>
-    </fieldset>
-  </div>
-</div>
-
 <fieldset class="no-border-bottom">
   <legend align="center"><%= I18n.t(:variant_pricing, scope: :spree) %></legend>
   <table class="index prices">

--- a/backend/app/views/spree/admin/prices/_table.html.erb
+++ b/backend/app/views/spree/admin/prices/_table.html.erb
@@ -1,4 +1,41 @@
-<%= paginate prices, theme: "solidus_admin" %>
+<%= paginate variant_prices, theme: "solidus_admin" %>
+
+<div class="row">
+  <div class="col-xs-8">
+    <table class="index master_prices">
+      <thead data-hook="master_prices_header">
+        <tr>
+          <th colspan="3">Master Variant</th>
+        </tr>
+        <tr>
+          <th><%= Spree::Price.human_attribute_name(:country) %></th>
+          <th><%= Spree::Price.human_attribute_name(:currency) %></th>
+          <th><%= Spree::Price.human_attribute_name(:amount) %></th>
+          <th class="actions"></th>
+        </tr>
+      </thead>
+      <% master_prices.each do |price| %>
+        <tr id="<%= spree_dom_id price %>" data-hook="prices_row" class="<%= "deleted" if price.deleted? %> <%= cycle('odd', 'even')%>">
+          <td><%= price.display_country %></td>
+          <td><%= price.currency %></td>
+          <td class="align-right"><%= price.money.to_html %></td>
+          <td class="actions">
+            <% if can?(:update, price) %>
+              <%= link_to_edit(price, :no_text => true) unless price.deleted? %>
+            <% end %>
+            <% if can?(:destroy, price) %>
+              &nbsp;
+              <%= link_to_delete(price, :no_text => true) unless price.deleted? %>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </table>
+  </div>
+  <div class="col-xs-4">
+    
+  </div>
+</div>
 
 <table class="index prices">
   <thead data-hook="prices_header">
@@ -10,12 +47,11 @@
       <th class="actions"></th>
     </tr>
   </thead>
-
   <tbody>
-  <% prices.each do |price| %>
+  <% variant_prices.each do |price| %>
     <tr id="<%= spree_dom_id price %>" data-hook="prices_row" class="<%= "deleted" if price.deleted? %> <%= cycle('odd', 'even')%>">
       <td><%= price.variant.descriptive_name %></td>
-      <td><%= price.display_country %>
+      <td><%= price.display_country %></td>
       <td><%= price.currency %></td>
       <td class="align-right"><%= price.money.to_html %></td>
       <td class="actions">
@@ -32,4 +68,4 @@
   </tbody>
 </table>
 
-<%= paginate prices, theme: "solidus_admin" %>
+<%= paginate variant_prices, theme: "solidus_admin" %>

--- a/backend/app/views/spree/admin/prices/_table.html.erb
+++ b/backend/app/views/spree/admin/prices/_table.html.erb
@@ -2,20 +2,75 @@
 
 <div class="row">
   <div class="col-xs-8">
-    <table class="index master_prices">
-      <thead data-hook="master_prices_header">
-        <tr>
-          <th colspan="3"><%= I18n.t(:master_variant, scope: :spree) %> <%= admin_hint I18n.t(:master_variant, scope: :spree), I18n.t(:master_variant, scope: [:spree, :hints, "spree/price"]) %></th>
-        </tr>
-        <tr>
-          <th><%= Spree::Price.human_attribute_name(:country) %></th>
-          <th><%= Spree::Price.human_attribute_name(:currency) %></th>
-          <th><%= Spree::Price.human_attribute_name(:amount) %></th>
-          <th class="actions"></th>
-        </tr>
-      </thead>
-      <% master_prices.each do |price| %>
+    <fieldset class="no-border-bottom">
+      <legend align="center"><%= I18n.t(:master_variant, scope: :spree) %> <%= admin_hint I18n.t(:master_variant, scope: :spree), I18n.t(:master_variant, scope: [:spree, :hints, "spree/price"]) %></legend>
+      <table class="index master_prices">
+        <thead data-hook="master_prices_header">
+          <tr>
+            <th><%= Spree::Price.human_attribute_name(:country) %></th>
+            <th><%= Spree::Price.human_attribute_name(:currency) %></th>
+            <th><%= Spree::Price.human_attribute_name(:amount) %></th>
+            <th class="actions"></th>
+          </tr>
+        </thead>
+        <% master_prices.each do |price| %>
+          <tr id="<%= spree_dom_id price %>" data-hook="prices_row" class="<%= "deleted" if price.deleted? %> <%= cycle('odd', 'even')%>">
+            <td><%= price.display_country %></td>
+            <td><%= price.currency %></td>
+            <td class="align-right"><%= price.money.to_html %></td>
+            <td class="actions">
+              <% if can?(:update, price) %>
+                <%= link_to_edit(price, :no_text => true) unless price.deleted? %>
+              <% end %>
+              <% if can?(:destroy, price) %>
+                &nbsp;
+                <%= link_to_delete(price, :no_text => true) unless price.deleted? %>
+              <% end %>
+            </td>
+          </tr>
+        <% end %>
+      </table>
+    </fieldset>
+  </div>
+  <div class="col-xs-4">
+    <fieldset class="no-border-bottom">
+      <legend align="center"><%= I18n.t(:options, scope: :spree) %> <%= admin_hint I18n.t(:options, scope: :spree), I18n.t(:options, scope: [:spree, :hints, "spree/price"]) %></legend>
+      <table class="index options">
+        <thead data-hook="options_header">
+          <tr>
+            <th><%= Spree::Price.human_attribute_name(:option_type) %></th>
+            <th><%= Spree::Price.human_attribute_name(:option_values) %></th>
+          </tr>
+        </thead>
+        <tbody>
+          <% option_types.each do |option_type| %>
+            <tr>
+              <td><%= option_type.presentation %></td>
+              <td><%= option_type.option_values.map {|option_value| option_value.presentation}.join(", ") %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </fieldset>
+  </div>
+</div>
+
+<fieldset class="no-border-bottom">
+  <legend align="center"><%= I18n.t(:variant_pricing, scope: :spree) %></legend>
+  <table class="index prices">
+    <thead data-hook="prices_header">
+      <tr>
+        <th><%= Spree::Variant.model_name.human %> </th>
+        <th><%= Spree::Price.human_attribute_name(:country) %></th>
+        <th><%= Spree::Price.human_attribute_name(:currency) %></th>
+        <th><%= Spree::Price.human_attribute_name(:amount) %></th>
+        <th class="actions"></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% variant_prices.each do |price| %>
         <tr id="<%= spree_dom_id price %>" data-hook="prices_row" class="<%= "deleted" if price.deleted? %> <%= cycle('odd', 'even')%>">
+          <td><%= price.variant.descriptive_name %></td>
           <td><%= price.display_country %></td>
           <td><%= price.currency %></td>
           <td class="align-right"><%= price.money.to_html %></td>
@@ -30,60 +85,8 @@
           </td>
         </tr>
       <% end %>
-    </table>
-  </div>
-  <div class="col-xs-4">
-    <table class="index options">
-      <thead data-hook="options_header">
-        <tr>
-          <th colspan="2"><%= I18n.t(:options, scope: :spree) %> <%= admin_hint I18n.t(:options, scope: :spree), I18n.t(:options, scope: [:spree, :hints, "spree/price"]) %></th>
-        </tr>
-        <tr>
-          <th><%= Spree::Price.human_attribute_name(:option_type) %></th>
-          <th><%= Spree::Price.human_attribute_name(:option_values) %></th>
-        </tr>
-      </thead>
-      <tbody>
-        <% option_types.each do |option_type| %>
-          <tr>
-            <td><%= option_type.presentation %></td>
-            <td><%= option_type.option_values.map {|option_value| option_value.presentation}.join(", ") %></td>
-          </tr>
-        <% end %>
-      </tbody>
-    </table>
-  </div>
-</div>
-
-<table class="index prices">
-  <thead data-hook="prices_header">
-    <tr>
-      <th><%= Spree::Variant.model_name.human %> </th>
-      <th><%= Spree::Price.human_attribute_name(:country) %></th>
-      <th><%= Spree::Price.human_attribute_name(:currency) %></th>
-      <th><%= Spree::Price.human_attribute_name(:amount) %></th>
-      <th class="actions"></th>
-    </tr>
-  </thead>
-  <tbody>
-  <% variant_prices.each do |price| %>
-    <tr id="<%= spree_dom_id price %>" data-hook="prices_row" class="<%= "deleted" if price.deleted? %> <%= cycle('odd', 'even')%>">
-      <td><%= price.variant.descriptive_name %></td>
-      <td><%= price.display_country %></td>
-      <td><%= price.currency %></td>
-      <td class="align-right"><%= price.money.to_html %></td>
-      <td class="actions">
-        <% if can?(:update, price) %>
-          <%= link_to_edit(price, :no_text => true) unless price.deleted? %>
-        <% end %>
-        <% if can?(:destroy, price) %>
-          &nbsp;
-          <%= link_to_delete(price, :no_text => true) unless price.deleted? %>
-        <% end %>
-      </td>
-    </tr>
-    <% end %>
-  </tbody>
-</table>
+    </tbody>
+  </table>
+</fieldset>
 
 <%= paginate variant_prices, theme: "solidus_admin" %>

--- a/backend/app/views/spree/admin/prices/_table.html.erb
+++ b/backend/app/views/spree/admin/prices/_table.html.erb
@@ -5,7 +5,7 @@
     <table class="index master_prices">
       <thead data-hook="master_prices_header">
         <tr>
-          <th colspan="3">Master Variant</th>
+          <th colspan="3"><%= I18n.t(:master_variant, scope: :spree) %> <%= admin_hint I18n.t(:master_variant, scope: :spree), I18n.t(:master_variant, scope: [:spree, :hints, "spree/price"]) %></th>
         </tr>
         <tr>
           <th><%= Spree::Price.human_attribute_name(:country) %></th>

--- a/backend/app/views/spree/admin/prices/_table.html.erb
+++ b/backend/app/views/spree/admin/prices/_table.html.erb
@@ -32,27 +32,6 @@
       </table>
     </fieldset>
   </div>
-  <div class="col-xs-4">
-    <fieldset class="no-border-bottom">
-      <legend align="center"><%= I18n.t(:options, scope: :spree) %> <%= admin_hint I18n.t(:options, scope: :spree), I18n.t(:options, scope: [:spree, :hints, "spree/price"]) %></legend>
-      <table class="index options">
-        <thead data-hook="options_header">
-          <tr>
-            <th><%= Spree::Price.human_attribute_name(:option_type) %></th>
-            <th><%= Spree::Price.human_attribute_name(:option_values) %></th>
-          </tr>
-        </thead>
-        <tbody>
-          <% option_types.each do |option_type| %>
-            <tr>
-              <td><%= option_type.presentation %></td>
-              <td><%= option_type.option_values.map {|option_value| option_value.presentation}.join(", ") %></td>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
-    </fieldset>
-  </div>
 </div>
 
 <fieldset class="no-border-bottom">

--- a/backend/app/views/spree/admin/prices/_table.html.erb
+++ b/backend/app/views/spree/admin/prices/_table.html.erb
@@ -33,7 +33,25 @@
     </table>
   </div>
   <div class="col-xs-4">
-    
+    <table class="index options">
+      <thead data-hook="options_header">
+        <tr>
+          <th colspan="2"><%= I18n.t(:options, scope: :spree) %> <%= admin_hint I18n.t(:options, scope: :spree), I18n.t(:options, scope: [:spree, :hints, "spree/price"]) %></th>
+        </tr>
+        <tr>
+          <th><%= Spree::Price.human_attribute_name(:option_type) %></th>
+          <th><%= Spree::Price.human_attribute_name(:option_values) %></th>
+        </tr>
+      </thead>
+      <tbody>
+        <% option_types.each do |option_type| %>
+          <tr>
+            <td><%= option_type.presentation %></td>
+            <td><%= option_type.option_values.map {|option_value| option_value.presentation}.join(", ") %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
   </div>
 </div>
 

--- a/backend/app/views/spree/admin/prices/index.html.erb
+++ b/backend/app/views/spree/admin/prices/index.html.erb
@@ -71,4 +71,5 @@
 </div>
 <% end %>
 
-<%= render 'table', variant_prices: @variant_prices, master_prices: @master_prices, option_types: @product.option_types %>
+<%= render 'master_variant_table', master_prices: @master_prices, variants: @product.variants.any? %>
+<%= render 'table', variant_prices: @variant_prices if @product.variants.any? %>

--- a/backend/app/views/spree/admin/prices/index.html.erb
+++ b/backend/app/views/spree/admin/prices/index.html.erb
@@ -71,4 +71,4 @@
 </div>
 <% end %>
 
-<%= render 'table', prices: @prices %>
+<%= render 'table', variant_prices: @variant_prices, master_prices: @master_prices %>

--- a/backend/app/views/spree/admin/prices/index.html.erb
+++ b/backend/app/views/spree/admin/prices/index.html.erb
@@ -71,4 +71,4 @@
 </div>
 <% end %>
 
-<%= render 'table', variant_prices: @variant_prices, master_prices: @master_prices %>
+<%= render 'table', variant_prices: @variant_prices, master_prices: @master_prices, option_types: @product.option_types %>

--- a/backend/spec/controllers/spree/admin/prices_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/prices_controller_spec.rb
@@ -16,7 +16,8 @@ describe Spree::Admin::PricesController do
       it 'assigns usable instance variables' do
         subject
         expect(assigns(:search)).to be_a(Ransack::Search)
-        expect(assigns(:prices)).to eq(product.prices)
+        expect(assigns(:variant_prices)).to eq(product.prices.for_variant)
+        expect(assigns(:master_prices)).to eq(product.prices.for_master)
         expect(assigns(:product)).to eq(product)
       end
     end
@@ -32,8 +33,9 @@ describe Spree::Admin::PricesController do
       it 'assigns usable instance variables' do
         subject
         expect(assigns(:search)).to be_a(Ransack::Search)
-        expect(assigns(:prices)).to eq(product.prices)
-        expect(assigns(:prices)).to include(variant.default_price)
+        expect(assigns(:variant_prices)).to eq(product.prices.for_variant)
+        expect(assigns(:master_prices)).to eq(product.prices.for_master)
+        expect(assigns(:variant_prices)).to include(variant.default_price)
         expect(assigns(:product)).to eq(product)
       end
     end

--- a/backend/spec/features/admin/products/pricing_spec.rb
+++ b/backend/spec/features/admin/products/pricing_spec.rb
@@ -30,12 +30,11 @@ describe 'Pricing' do
         expect(page).to have_content("Prices")
       end
 
-      within('table.prices') do
+      within('table.master_prices') do
         expect(page).to have_content("$19.99")
         expect(page).to have_content("USD")
         expect(page).to have_content("34.56 ₽")
         expect(page).to have_content("RUB")
-        expect(page).to have_content("Master")
         expect(page).to have_content("Any Country")
         expect(page).to have_content("Germany")
       end

--- a/core/app/models/spree/price.rb
+++ b/core/app/models/spree/price.rb
@@ -19,6 +19,8 @@ module Spree
     validates :country, presence: true, unless: -> { for_any_country? }
 
     scope :currently_valid, -> { order("country_iso IS NULL, updated_at DESC") }
+    scope :for_master, -> { joins(:variant).where(spree_variants: { is_master: true }) }
+    scope :for_variant, -> { joins(:variant).where(spree_variants: { is_master: false }) }
     scope :for_any_country, -> { where(country: nil) }
     scope :with_default_attributes, -> { where(Spree::Config.default_pricing_options.desired_attributes) }
 

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1177,6 +1177,8 @@ en:
     hints:
       spree/price:
         country: "This determines in what country the price is valid.<br/>Default: Any Country"
+        master_variant: "Changing master variant prices will not change variant prices below, but will be used to populate all new variants"
+        options: "These options are used to create variants in the variants table. They can be changed in the variants tab"
       spree/product:
         promotionable: "This determines whether or not promotions can apply to this product.<br/>Default: Checked"
         shipping_category: "This determines what kind of shipping this product requires.<br/> Default: Default"
@@ -1337,6 +1339,7 @@ en:
     manual_intervention_required: Manual intervention required
     manage_variants: Manage Variants
     master_price: Master Price
+    master_variant: Master Variant
     match_choices:
       all: All
       none: None
@@ -1992,6 +1995,7 @@ en:
     value: Value
     variant: Variant
     variant_placeholder: Choose a variant
+    variant_pricing: Variant Pricing
     variant_properties: Variant Properties
     variant_search: Variant Search
     variant_search_placeholder: "SKU or Option Value"


### PR DESCRIPTION
This PR expands on the Admin Prices view to clarify master/variant pricing. See #1167 

Master and Variant related prices have been separated into their own tables utilising new scopes on the Price model. Additionally, Option Types and Option Values are shown in a table as a reference for the user. As recommended by @Mandily Tooltips are shown in the Master Variant and Options tables to clarify their content.

Tests regarding assigns in this context have been updated to reflect these changes.

Here is a screenshot for reference:
![tooltip](https://cloud.githubusercontent.com/assets/12424770/19207491/5c5e05ac-8ca6-11e6-978a-828454bc88e9.png)
