### PR TITLE
Add amount_remaining for Spree::StoreCreditEvent

### DIFF
--- a/api/app/helpers/spree/api/api_helpers.rb
+++ b/api/app/helpers/spree/api/api_helpers.rb
@@ -173,7 +173,7 @@ module Spree
 
       @@store_credit_history_attributes = [
         :display_amount, :display_user_total_amount, :display_action,
-        :display_event_date
+        :display_event_date, :display_remaining_amount
       ]
 
       def variant_attributes

--- a/backend/app/views/spree/admin/store_credits/show.html.erb
+++ b/backend/app/views/spree/admin/store_credits/show.html.erb
@@ -83,6 +83,7 @@
         <th><%= t('spree.admin.store_credits.amount_credited') %></th>
         <th><%= t('spree.admin.store_credits.created_by') %></th>
         <th><%= Spree::StoreCreditEvent.human_attribute_name(:user_total_amount) %></th>
+        <th><%= Spree::StoreCreditEvent.human_attribute_name(:amount_remaining) %></th>
         <th><%= Spree::StoreCreditUpdateReason.human_attribute_name(:name) %></th>
       </tr>
     </thead>
@@ -96,6 +97,7 @@
           <td><%= event.display_amount %></td>
           <td><%= store_credit_event_originator_link(event) %></td>
           <td><%= event.display_user_total_amount %></td>
+          <td><%= event.display_remaining_amount %></td>
           <td><%= event.update_reason.try!(:name) %></td>
         </tr>
       <% end %>

--- a/core/app/models/spree/store_credit.rb
+++ b/core/app/models/spree/store_credit.rb
@@ -246,6 +246,7 @@ class Spree::StoreCredit < Spree::PaymentSource
     event.update_attributes!({
       amount: action_amount || amount,
       authorization_code: action_authorization_code || event.authorization_code || generate_authorization_code,
+      amount_remaining: amount_remaining,
       user_total_amount: user.available_store_credit_total(currency: currency),
       originator: action_originator,
       update_reason: update_reason

--- a/core/app/models/spree/store_credit_event.rb
+++ b/core/app/models/spree/store_credit_event.rb
@@ -46,6 +46,10 @@ module Spree
       Spree::Money.new(user_total_amount, { currency: currency })
     end
 
+    def display_remaining_amount
+      Spree::Money.new(amount_remaining, { currency: currency })
+    end
+
     def display_event_date
       I18n.l(created_at.to_date, format: :long)
     end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -317,7 +317,8 @@ en:
         memo: Memo
       spree/store_credit_event:
         action: Action
-        user_total_amount: Total Unused
+        amount_remaining: Total Unused
+        user_total_amount: Total Amount
       spree/store_credit_update_reason:
         name: Reason For Updating
       spree/stock_item:

--- a/core/db/migrate/20180322142651_add_amount_remaining_to_store_credit_events.rb
+++ b/core/db/migrate/20180322142651_add_amount_remaining_to_store_credit_events.rb
@@ -1,7 +1,61 @@
 # frozen_string_literal: true
 
 class AddAmountRemainingToStoreCreditEvents < ActiveRecord::Migration[5.0]
-  def change
-    add_column :spree_store_credit_events, :amount_remaining, :decimal, precision: 8, scale: 2, default: 0.0, null: false
+  class StoreCredit < ActiveRecord::Base
+    self.table_name = 'spree_store_credits'
+    has_many :store_credit_events
+
+    VOID_ACTION       = 'void'
+    CREDIT_ACTION     = 'credit'
+    CAPTURE_ACTION    = 'capture'
+    ELIGIBLE_ACTION   = 'eligible'
+    AUTHORIZE_ACTION  = 'authorize'
+    ALLOCATION_ACTION = 'allocation'
+    ADJUSTMENT_ACTION = 'adjustment'
+    INVALIDATE_ACTION = 'invalidate'
+  end
+
+  class StoreCreditEvent < ActiveRecord::Base
+    self.table_name = "spree_store_credit_events"
+    belongs_to :store_credit
+
+    scope :chronological, -> { order(:created_at) }
+  end
+
+  def up
+    add_column :spree_store_credit_events, :amount_remaining, :decimal, precision: 8, scale: 2, default: nil, null: true
+
+    StoreCredit.includes(:store_credit_events).find_each do |credit|
+      credit_amount = credit.amount
+
+      credit.store_credit_events.chronological.each do |event|
+        case event.action
+        when StoreCredit::ALLOCATION_ACTION,
+             StoreCredit::ELIGIBLE_ACTION,
+             StoreCredit::CAPTURE_ACTION
+          # These actions do not change the amount_remaining so the previous
+          # amount available is used (either the credit's amount or the
+          # amount_remaining coming from the event right before this one).
+          credit_amount
+        when StoreCredit::AUTHORIZE_ACTION,
+             StoreCredit::INVALIDATE_ACTION
+          # These actions remove the amount from the available credit amount.
+          credit_amount -= event.amount
+        when StoreCredit::ADJUSTMENT_ACTION,
+             StoreCredit::CREDIT_ACTION,
+             StoreCredit::VOID_ACTION
+          # These actions add the amount to the available credit amount. For
+          # ADJUSTMENT_ACTION the event's amount could be negative (so it could
+          # end up subtracting the amount).
+          credit_amount += event.amount
+        end
+
+        event.update_attribute(:amount_remaining, credit_amount)
+      end
+    end
+  end
+
+  def down
+    remove_column :spree_store_credit_events, :amount_remaining
   end
 end

--- a/core/db/migrate/20180322142651_add_amount_remaining_to_store_credit_events.rb
+++ b/core/db/migrate/20180322142651_add_amount_remaining_to_store_credit_events.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddAmountRemainingToStoreCreditEvents < ActiveRecord::Migration[5.0]
+  def change
+    add_column :spree_store_credit_events, :amount_remaining, :decimal, precision: 8, scale: 2, default: 0.0, null: false
+  end
+end

--- a/core/spec/models/spree/store_credit_event_spec.rb
+++ b/core/spec/models/spree/store_credit_event_spec.rb
@@ -220,6 +220,20 @@ RSpec.describe Spree::StoreCreditEvent do
     end
   end
 
+  describe "#display_remaining_amount" do
+    let(:amount_remaining) { 300.0 }
+
+    subject { create(:store_credit_auth_event, amount_remaining: amount_remaining) }
+
+    it "returns a Spree::Money instance" do
+      expect(subject.display_remaining_amount).to be_instance_of(Spree::Money)
+    end
+
+    it "uses the events amount_remaining attribute" do
+      expect(subject.display_remaining_amount).to eq Spree::Money.new(amount_remaining, { currency: subject.currency })
+    end
+  end
+
   describe "#display_event_date" do
     let(:date) { Time.parse("2014-06-01") }
 


### PR DESCRIPTION
This additional field will make sure that credit events will record the actual unused amount for a particular `Spree::StoreCredit`.

This also hides the `user_total_amount` in the backend because it makes no sense to display the total credit a user has at her/his disposal when visiting the store credit show route in the backend.

This should close #1473. It's a temporary fix waiting for a bigger refactor of `Spree::StoreCreditEvent`.
