### PR TITLE
Ledger entries for store credits.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,19 @@
     Warning: this change also deletes the `currency` database field (String)
     from the line items table, since it will not be used anymore.
 
+*   Add `Spree::StoreCreditLedgerEntry`
+
+    This will allow tracking of all financial changes to a `Spree::StoreCredit`.
+
+    All `Spree::StoreCredit` amount changes that are pending (authorize, void)
+    and all changes that are liability changes (initialize, capture, update_amount, refund, invalidate) will have a `StoreCreditLedgerEntry` that will be
+    the complete financial history for the `Spree::StoreCredit`.
+
+    Added a migration for all available `Spree::StoreCredit` that will
+    create initial `Spree::StoreCreditLedgerEntry` records for the pending
+    and liability opening balances. This ensures the correct output for
+    `Spree::StoreCreditLedgerEntry#balance` and `Spree::StoreCreditLedgerEntry#liability_balance`  
+
 *   Add `Spree::Promotion#remove_from` and `Spree::PromotionAction#remove_from`
 
     This will allow promotions to be removed from orders and allows promotion

--- a/backend/app/helpers/spree/admin/store_credit_events_helper.rb
+++ b/backend/app/helpers/spree/admin/store_credit_events_helper.rb
@@ -1,18 +1,4 @@
 module Spree::Admin::StoreCreditEventsHelper
-  mattr_accessor :originator_links
-  self.originator_links = {
-    Spree::Payment.to_s => {
-      new_tab: true,
-      href_type: :payment,
-      translation_key: 'admin.store_credits.payment_originator'
-    },
-    Spree::Refund.to_s => {
-      new_tab: true,
-      href_type: :payments,
-      translation_key: 'admin.store_credits.refund_originator'
-    }
-  }
-
   def store_credit_event_admin_action_name(store_credit_event)
     if Spree::StoreCreditEvent::NON_EXPOSED_ACTIONS.include?(store_credit_event.action) ||
        store_credit_event.action == Spree::StoreCredit::VOID_ACTION
@@ -20,65 +6,5 @@ module Spree::Admin::StoreCreditEventsHelper
     else
       store_credit_event.display_action
     end
-  end
-
-  def store_credit_event_originator_link(store_credit_event)
-    originator = store_credit_event.originator
-    return unless originator
-
-    add_user_originator_link
-    unless originator_links.key?(store_credit_event.originator.class.to_s)
-      raise "Unexpected originator type #{originator.class}"
-    end
-
-    options = {}
-    link_options = originator_links[store_credit_event.originator.class.to_s]
-    options[:target] = '_blank' if link_options[:new_tab]
-
-    # Although not all href_types are used in originator_links
-    # they are necessary because they may be used within extensions
-    case link_options[:href_type]
-    when :user
-      link_to(
-        Spree.t(link_options[:translation_key], { email: originator.email }),
-        spree.edit_admin_user_path(originator),
-        options
-      )
-    when :line_item
-      order = originator.line_item.order
-      link_to(
-        Spree.t(link_options[:translation_key], { order_number: order.number }),
-        spree.edit_admin_order_path(order),
-        options
-      )
-    when :payment
-      order = originator.order
-      link_to(
-        Spree.t(link_options[:translation_key], { order_number: order.number }),
-        spree.admin_order_payment_path(order, originator),
-        options
-      )
-    when :payments
-      order = originator.payment.order
-      link_to(
-        Spree.t(link_options[:translation_key], { order_number: order.number }),
-        spree.admin_order_payments_path(order),
-        options
-      )
-    end
-  end
-
-  private
-
-  # Cannot set the value for a user originator
-  # because Spree.user_class is not defined at that time.
-  # Spree::UserClassHandle does not work here either as
-  # the assignment is evaluated before user_class is set
-  def add_user_originator_link
-    originator_links[Spree.user_class.to_s] = {
-      new_tab: true,
-      href_type: :user,
-      translation_key: 'admin.store_credits.user_originator'
-    }
   end
 end

--- a/backend/app/helpers/spree/admin/store_credit_originator_helper.rb
+++ b/backend/app/helpers/spree/admin/store_credit_originator_helper.rb
@@ -1,0 +1,79 @@
+module Spree::Admin::StoreCreditOriginatorHelper
+  mattr_accessor :originator_links
+
+  self.originator_links = {
+    Spree::Payment.to_s => {
+      new_tab: true,
+      href_type: :payment,
+      translation_key: 'admin.store_credits.payment_originator'
+    },
+
+    Spree::Refund.to_s => {
+      new_tab: true,
+      href_type: :payments,
+      translation_key: 'admin.store_credits.refund_originator'
+    }
+  }
+
+  def store_credit_originator_link(object)
+    return unless object.originator
+
+    add_user_originator_link
+
+    originator = object.originator
+    klass = object.originator.class.to_s
+
+    unless originator_links.key?(klass)
+      raise "Unexpected originator type #{klass}"
+    end
+
+    options = {}
+    link_options = originator_links[klass]
+    options[:target] = '_blank' if link_options[:new_tab]
+
+    # Although not all href_types are used in originator_links
+    # they are necessary because they may be used within extensions
+    case link_options[:href_type]
+    when :user
+      link_to(
+        Spree.t(link_options[:translation_key], { email: originator.email }),
+        spree.edit_admin_user_path(originator),
+        options
+      )
+    when :line_item
+      order = originator.line_item.order
+      link_to(
+        Spree.t(link_options[:translation_key], { order_number: order.number }),
+        spree.edit_admin_order_path(order),
+        options
+      )
+    when :payment
+      order = originator.order
+      link_to(
+        Spree.t(link_options[:translation_key], { order_number: order.number }),
+        spree.admin_order_payment_path(order, originator),
+        options
+      )
+    when :payments
+      order = originator.payment.order
+      link_to(
+        Spree.t(link_options[:translation_key], { order_number: order.number }),
+        spree.admin_order_payments_path(order),
+        options
+      )
+    end
+  end
+
+  private
+
+  # We cannot set the value for a User originator because the user class is not
+  # defined when this module is loaded. Spree::UserClassHandle does not work
+  # here either as the assignment is evaluated before Spree.user_class is set.
+  def add_user_originator_link
+    originator_links[Spree.user_class.to_s] = {
+      new_tab: true,
+      href_type: :user,
+      translation_key: 'admin.store_credits.user_originator'
+    }
+  end
+end

--- a/backend/app/views/spree/admin/store_credits/show.html.erb
+++ b/backend/app/views/spree/admin/store_credits/show.html.erb
@@ -102,11 +102,50 @@
           </td>
           <td><%= store_credit_event_admin_action_name(event) %></td>
           <td class='align-right'><%= event.display_amount %></td>
-          <td><%= store_credit_event_originator_link(event) %></td>
+          <td><%= store_credit_originator_link(event) %></td>
           <td class='align-right'><%= event.display_user_total_amount %></td>
           <td><%= event.update_reason.try!(:name) %></td>
         </tr>
       <% end %>
+    </tbody>
+  </table>
+</fieldset>
+
+<fieldset>
+  <legend align='center'><%= Spree.t("admin.store_credits.ledger_entries") %></legend>
+  <table id='sc-ledger-table'>
+    <thead>
+      <tr>
+        <th><%= Spree::StoreCreditLedgerEntry.human_attribute_name(:amount) %></th>
+        <th><%= Spree::StoreCreditLedgerEntry.human_attribute_name(:originator) %></th>
+        <th><%= Spree::StoreCreditLedgerEntry.human_attribute_name(:liability) %></th>
+        <th><%= Spree.t(:date) %></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @store_credit.store_credit_ledger_entries.each do |entry| %>
+        <tr>
+          <td><%= Spree::Money.new(entry.amount) %></td>
+          <td><%= store_credit_originator_link(entry) %></td>
+          <td><%= entry.liability %></td>
+          <td><%= pretty_time(entry.created_at) %></td>
+        </tr>
+      <% end %>
+
+      <tr>
+        <td colspan="3">
+          <strong>
+            Current Liability Balance: <%= Spree::Money.new(@store_credit.liability_balance) %>
+          </strong>
+        </td>
+      </tr>
+      <tr>
+        <td colspan="3">
+          <strong>
+            Available for user: <%= Spree::Money.new(@store_credit.balance) %>
+          </strong>
+        </td>
+      </tr>
     </tbody>
   </table>
 </fieldset>

--- a/backend/spec/helpers/admin/store_credit_events_helper_spec.rb
+++ b/backend/spec/helpers/admin/store_credit_events_helper_spec.rb
@@ -54,42 +54,4 @@ describe Spree::Admin::StoreCreditEventsHelper, type: :helper do
       end
     end
   end
-
-  describe "#store_credit_event_originator_link" do
-    let(:store_credit_event) { create(:store_credit_adjustment_event, originator: originator) }
-
-    subject { store_credit_event_originator_link(store_credit_event) }
-
-    context "originator is a user" do
-      let(:originator) { create(:user) }
-
-      it "returns a link to the user's edit page" do
-        expect(subject).to eq %(<a target=\"_blank\" href=\"/admin/users/#{originator.id}/edit\">User - #{originator.email}</a>)
-      end
-    end
-
-    context "originator is a payment" do
-      let(:originator) { create(:payment) }
-
-      it "returns a link to the order's payments page" do
-        expect(subject).to eq %(<a target=\"_blank\" href=\"/admin/orders/#{originator.order.number}/payments/#{originator.id}\">Payment - Order ##{originator.order.number}</a>)
-      end
-    end
-
-    context "originator is a refund" do
-      let(:originator) { create(:refund, amount: 1.0) }
-
-      it "returns a link to the order's payments page" do
-        expect(subject).to eq %(<a target=\"_blank\" href=\"/admin/orders/#{originator.payment.order.number}/payments\">Refund - Order ##{originator.payment.order.number}</a>)
-      end
-    end
-
-    context "originator is not specifically handled" do
-      let(:originator) { create(:store_credit_update_reason) }
-
-      it "raises an error" do
-        expect { subject }.to raise_error(RuntimeError, "Unexpected originator type Spree::StoreCreditUpdateReason")
-      end
-    end
-  end
 end

--- a/backend/spec/helpers/admin/store_credit_originator_helper_spec.rb
+++ b/backend/spec/helpers/admin/store_credit_originator_helper_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+describe Spree::Admin::StoreCreditOriginatorHelper, type: :helper do
+  describe "#store_credit_originator_link" do
+    let(:event) { create(:store_credit_adjustment_event, originator: originator) }
+
+    subject { store_credit_originator_link(event) }
+
+    context "originator is a user" do
+      let(:originator) { create(:user) }
+
+      it "returns a link to the user's edit page" do
+        expect(subject).to eq %(<a target=\"_blank\" href=\"/admin/users/#{originator.id}/edit\">User - #{originator.email}</a>)
+      end
+    end
+
+    context "originator is a payment" do
+      let(:originator) { create(:payment) }
+
+      it "returns a link to the order's payments page" do
+        expect(subject).to eq %(<a target=\"_blank\" href=\"/admin/orders/#{originator.order.number}/payments/#{originator.id}\">Payment - Order ##{originator.order.number}</a>)
+      end
+    end
+
+    context "originator is a refund" do
+      let(:originator) { create(:refund, amount: 1.0) }
+
+      it "returns a link to the order's payments page" do
+        expect(subject).to eq %(<a target=\"_blank\" href=\"/admin/orders/#{originator.payment.order.number}/payments\">Refund - Order ##{originator.payment.order.number}</a>)
+      end
+    end
+
+    context "originator is not specifically handled" do
+      let(:originator) { create(:store_credit_update_reason) }
+
+      it "raises an error" do
+        expect { subject }.to raise_error(RuntimeError, "Unexpected originator type Spree::StoreCreditUpdateReason")
+      end
+    end
+  end
+end

--- a/core/app/models/spree/store_credit.rb
+++ b/core/app/models/spree/store_credit.rb
@@ -17,6 +17,7 @@ class Spree::StoreCredit < Spree::Base
   belongs_to :category, class_name: "Spree::StoreCreditCategory"
   belongs_to :credit_type, class_name: 'Spree::StoreCreditType', foreign_key: 'type_id'
   has_many :store_credit_events
+  has_many :store_credit_ledger_entries
 
   validates_presence_of :user_id, :category_id, :type_id, :created_by_id, :currency
   validates_numericality_of :amount, { greater_than: 0 }
@@ -30,6 +31,7 @@ class Spree::StoreCredit < Spree::Base
   scope :order_by_priority, -> { includes(:credit_type).order('spree_store_credit_types.priority ASC') }
 
   after_save :store_event
+  after_create :add_init_ledger_entry
   before_validation :associate_credit_type
   before_validation :validate_category_unchanged, on: :update
   before_destroy :validate_no_amount_used
@@ -61,9 +63,14 @@ class Spree::StoreCredit < Spree::Base
         action_amount: amount,
         action_originator: options[:action_originator],
         action_authorization_code: authorization_code,
-
         amount_authorized: amount_authorized + amount
       })
+      Spree::StoreCreditLedgerEntry.debit(
+        self,
+        amount,
+        options[:action_originator],
+        Spree::StoreCreditLedgerEntry::PENDING
+      )
       authorization_code
     else
       errors.add(:base, Spree.t('store_credit.insufficient_authorized_amount'))
@@ -94,10 +101,26 @@ class Spree::StoreCredit < Spree::Base
           action_amount: amount,
           action_originator: options[:action_originator],
           action_authorization_code: authorization_code,
-
           amount_used: amount_used + amount,
           amount_authorized: amount_authorized - auth_event.amount
         })
+
+        Spree::StoreCreditLedgerEntry.debit(
+          self,
+          amount,
+          options[:action_originator],
+          Spree::StoreCreditLedgerEntry::LIABILITY
+        )
+
+        # we need to credit the amount on the non-liabitly ledger to
+        # proper balance the amounts.
+        Spree::StoreCreditLedgerEntry.credit(
+          self,
+          amount,
+          options[:action_originator],
+          Spree::StoreCreditLedgerEntry::PENDING
+        )
+
         authorization_code
       end
     else
@@ -113,9 +136,15 @@ class Spree::StoreCredit < Spree::Base
         action_amount: auth_event.amount,
         action_authorization_code: authorization_code,
         action_originator: options[:action_originator],
-
         amount_authorized: amount_authorized - auth_event.amount
       })
+
+      Spree::StoreCreditLedgerEntry.credit(
+        self,
+        auth_event.amount,
+        options[:action_originator],
+        Spree::StoreCreditLedgerEntry::PENDING
+      )
       true
     else
       errors.add(:base, Spree.t('store_credit.unable_to_void', auth_code: authorization_code))
@@ -184,7 +213,17 @@ class Spree::StoreCredit < Spree::Base
     self.action = ADJUSTMENT_ACTION
     self.update_reason = reason
     self.action_originator = user_performing_update
-    save
+    if save
+      if action_amount > 0
+        Spree::StoreCreditLedgerEntry.credit(self, action_amount, user_performing_update)
+        true
+      elsif action_amount < 0
+        Spree::StoreCreditLedgerEntry.debit(self, action_amount, user_performing_update)
+        true
+      end
+    else
+      false
+    end
   end
 
   def invalidate(reason, user_performing_invalidation)
@@ -193,11 +232,22 @@ class Spree::StoreCredit < Spree::Base
       self.update_reason = reason
       self.action_originator = user_performing_invalidation
       self.invalidated_at = Time.current
-      save
+      self.action_amount = liability_balance
+      if save
+        Spree::StoreCreditLedgerEntry.debit(self, liability_balance, user_performing_invalidation)
+      end
     else
       errors.add(:invalidated_at, Spree.t("store_credit.errors.cannot_invalidate_uncaptured_authorization"))
       return false
     end
+  end
+
+  def liability_balance
+    Spree::StoreCreditLedgerEntry.liability_balance(self)
+  end
+
+  def balance
+    Spree::StoreCreditLedgerEntry.balance(self)
   end
 
   class << self
@@ -211,15 +261,16 @@ class Spree::StoreCredit < Spree::Base
   def create_credit_record(amount, action_attributes = {})
     # Setting credit_to_new_allocation to true will create a new allocation anytime #credit is called
     # If it is not set, it will update the store credit's amount in place
-    credit = if Spree::Config[:credit_to_new_allocation]
-      Spree::StoreCredit.new(create_credit_record_params(amount))
+    if Spree::Config[:credit_to_new_allocation]
+      credit = Spree::StoreCredit.new(create_credit_record_params(amount))
+      credit.assign_attributes(action_attributes)
+      credit.save!
     else
       self.amount_used = amount_used - amount
-      self
+      assign_attributes(action_attributes)
+      save!
+      Spree::StoreCreditLedgerEntry.credit(self, amount, action_attributes[:action_originator])
     end
-
-    credit.assign_attributes(action_attributes)
-    credit.save!
   end
 
   def create_credit_record_params(amount)
@@ -254,6 +305,10 @@ class Spree::StoreCredit < Spree::Base
       originator: action_originator,
       update_reason: update_reason
     })
+  end
+
+  def add_init_ledger_entry
+    Spree::StoreCreditLedgerEntry.credit(self, amount, action_originator)
   end
 
   def amount_used_less_than_or_equal_to_amount

--- a/core/app/models/spree/store_credit_ledger_entry.rb
+++ b/core/app/models/spree/store_credit_ledger_entry.rb
@@ -1,0 +1,86 @@
+# Financial transaction entry for a specific `store_credit`
+# it will keep track of the liability and pending transactions.
+#
+# It will follow the debit and credit rules as described [here](https://en.wikipedia.org/wiki/Debits_and_credits)
+# so all debit calls will lower the liability and credit calls will add
+# an amount.
+#
+module Spree
+  class StoreCreditLedgerEntry < Spree::Base
+    PENDING = :pending
+    LIABILITY = :liability
+
+    belongs_to :store_credit
+    belongs_to :originator, polymorphic: true
+
+    scope :chronological, -> { order(:created_at) }
+    scope :reverse_chronological, -> { order(created_at: :desc) }
+    scope :liability, -> { where(liability: true) }
+    scope :pending, -> { where(liability: false) }
+
+    delegate :currency, to: :store_credit
+
+
+    # Will add the amount to the `store_credit`, `credit` the ledger.
+    # this amount will always be positive, when there is a need to remove
+    # an amount from the `store_credit` you will have to call the [#debit]
+    #
+    # @param store_credit [Spree::StoreCredit] the store credit for this credit call
+    # @param amount [BigDecimal] the amount for the credit, should always be a positive number.
+    # @param originator [Object] polymorphic origin that triggered this credit call
+    # @param liability_type [Symbol] is either an actual liability change, or a pending transaction
+    # @return [Spree::StoreCreditLedgerEntry] the created ledger entry, or an exception when not succesful
+    def self.credit(store_credit, amount, originator, liability_type=LIABILITY)
+      create!(
+        {
+          store_credit: store_credit,
+          amount: amount,
+          originator: originator,
+          liability: liability_type == LIABILITY
+        }
+      )
+    end
+
+    # Will remove the amount from the `store_credit`, `debit` the ledger.
+    # this amount will always be stored negative, when there is a need to add
+    # an amount to the `store_credit` you will have to call the [#credit]
+    #
+    # @param store_credit [Spree::StoreCredit] the store credit for this credit call
+    # @param amount [BigDecimal] the amount for the credit, should always be a positive number.
+    # @param originator [Object] polymorphic origin that triggered this credit call
+    # @param liability_type [Symbol] is either an actual liability change, or a pending transaction
+    # @return [Spree::StoreCreditLedgerEntry] the created ledger entry, or an exception when not succesful
+    def self.debit(store_credit, amount, originator, liability_type=LIABILITY)
+      # make sure debit amounts are stored as negative number.
+      amount = -amount if amount > 0
+      create!(
+        {
+          store_credit: store_credit,
+          amount: amount,
+          originator: originator,
+          liability: liability_type == LIABILITY
+        }
+      )
+    end
+
+    # The balance for a specific `store_credit` is the sum of all
+    # pending and liability amounts. This will reflect the available
+    # store credits to spend.
+    #
+    # @param store_credit [Spree::StoreCredit] the store credit that will return his balance
+    # @return [BigDecimal] the current total balance for the `store_credit`
+    def self.balance(store_credit)
+      store_credit.store_credit_ledger_entries.sum(:amount)
+    end
+
+    # The liability balance for a specific `store_credit` is the sum of all
+    # liability amounts. This is the actual liability amount for the any
+    # financial reports
+    #
+    # @param store_credit [Spree::StoreCredit] the store credit that will return his liability balance
+    # @return [BigDecimal] the current total liability balance for the `store_credit`
+    def self.liability_balance(store_credit)
+      store_credit.store_credit_ledger_entries.liability.sum(:amount)
+    end
+  end
+end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -747,6 +747,7 @@ en:
         edit: "Editing store credit"
         edit_amount: "Editing store credit amount"
         history: "Store credit history"
+        ledger_entries: "Ledger Entries"
         invalidate_store_credit: "Invalidating store credit"
         invalidated: "Invalidated"
         issued_on: "Issued On"

--- a/core/db/migrate/20161006211441_create_spree_store_credit_ledger_entry.rb
+++ b/core/db/migrate/20161006211441_create_spree_store_credit_ledger_entry.rb
@@ -1,0 +1,12 @@
+class CreateSpreeStoreCreditLedgerEntry < ActiveRecord::Migration[5.0]
+  def change
+    create_table :spree_store_credit_ledger_entries do |t|
+      t.decimal :amount, precision: 8, scale: 2, default: 0.0, null: false
+      t.references :store_credit, index: true
+      index_name = "idx_spree_sc_ledger_entries_on_orig_type_and_orig_id"
+      t.references :originator, polymorphic: true, index: { name: index_name }
+      t.boolean :liability, default: true, null: false
+      t.timestamps null: false
+    end
+  end
+end

--- a/core/db/migrate/20161012151358_opening_ledger_entries_for_store_credits.rb
+++ b/core/db/migrate/20161012151358_opening_ledger_entries_for_store_credits.rb
@@ -1,0 +1,9 @@
+class OpeningLedgerEntriesForStoreCredits < ActiveRecord::Migration[5.0]
+  def up
+    Rake::Task["solidus:migrations:create_ledger_entries_for_store_credits:up"].invoke
+  end
+
+  def down
+    Rake::Task["solidus:migrations:create_ledger_entries_for_store_credits:down"].invoke
+  end
+end

--- a/core/lib/tasks/migrations/create_ledger_entries_for_store_credits.rake
+++ b/core/lib/tasks/migrations/create_ledger_entries_for_store_credits.rake
@@ -1,0 +1,42 @@
+namespace :solidus do
+  namespace :migrations do
+    namespace :create_ledger_entries_for_store_credits do
+      task up: :environment do
+        # invalidated store credits
+        # create ledger entry with 0.0 amount
+        ActiveRecord::Base.connection.execute <<-SQL
+        INSERT INTO spree_store_credit_ledger_entries
+          (store_credit_id, amount, created_at, updated_at)
+          SELECT id, 0, '#{Time.current.to_s(:db)}', '#{Time.current.to_s(:db)}'
+          FROM spree_store_credits
+          WHERE invalidated_at IS NOT NULL
+        SQL
+
+        # store_credits in use will have a liabilty ledger entry
+        # with an amount that is the store_credit amount minus the used
+        # store_credits
+        ActiveRecord::Base.connection.execute <<-SQL
+        INSERT INTO spree_store_credit_ledger_entries
+          (store_credit_id, amount, created_at, updated_at)
+          SELECT id, amount - amount_used, '#{Time.current.to_s(:db)}', '#{Time.current.to_s(:db)}'
+          FROM spree_store_credits
+          WHERE invalidated_at IS NULL
+        SQL
+
+        # the store_credits with amount_authorized available will need
+        # to have a 'pending' ledger entry created
+        ActiveRecord::Base.connection.execute <<-SQL
+        INSERT INTO spree_store_credit_ledger_entries
+          (store_credit_id, amount, liability, created_at, updated_at)
+          SELECT id, amount_authorized, 'f', '#{Time.current.to_s(:db)}', '#{Time.current.to_s(:db)}'
+          FROM spree_store_credits
+          WHERE invalidated_at IS NULL AND amount_authorized > 0.0
+        SQL
+      end
+
+      task down: :environment do
+        Spree::StoreCreditLedgerEntry.delete_all
+      end
+    end
+  end
+end

--- a/core/spec/lib/tasks/migrations/create_ledger_entries_for_store_credits_spec.rb
+++ b/core/spec/lib/tasks/migrations/create_ledger_entries_for_store_credits_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper'
+
+describe 'solidus:migrations:create_ledger_entries_for_store_credits' do
+  include_context(
+    'rake',
+    task_name: 'solidus:migrations:create_ledger_entries_for_store_credits:up',
+    task_path: Spree::Core::Engine.root.join('lib/tasks/migrations/create_ledger_entries_for_store_credits.rake'),
+  )
+
+  let(:store_credit) { create(:store_credit, store_credit_attr) }
+  let(:store_credit_attr) { {} }
+
+  context "Store credit without any changes" do
+    let(:store_credit_attr) { { amount: 250 } }
+
+    it 'will create a ledger entry with the right amount' do
+      store_credit
+      Spree::StoreCreditLedgerEntry.destroy_all
+      expect {
+        task.invoke
+      }.to change { Spree::StoreCreditLedgerEntry.count }.by(1)
+
+      expect(store_credit.liability_balance).to eql 250
+    end
+  end
+
+  context "Store credit with some used amounts" do
+    let(:store_credit_attr) { { amount: 250, amount_used: 100 } }
+
+    it 'will create a ledger entry with the right amount' do
+      store_credit
+      Spree::StoreCreditLedgerEntry.destroy_all
+      expect {
+        task.invoke
+      }.to change { Spree::StoreCreditLedgerEntry.count }.by(1)
+
+      expect(store_credit.liability_balance).to eql 150
+    end
+  end
+
+  context "Store credit with some used amounts and authorised amounts" do
+    let(:store_credit_attr) { { amount: 250, amount_used: 100, amount_authorized: 50 } }
+
+    it 'will create a ledger entry with the right amount' do
+      store_credit
+      Spree::StoreCreditLedgerEntry.destroy_all
+      expect {
+        task.invoke
+      }.to change { Spree::StoreCreditLedgerEntry.count }.by(2)
+
+      expect(store_credit.liability_balance).to eql 150
+    end
+  end
+
+  context "Invalidated store credit" do
+    let(:store_credit_attr) { { amount: 250, amount_used: 100 } }
+    let(:invalidation_user) { create(:user) }
+    let(:invalidation_reason) { create(:store_credit_update_reason) }
+
+    it 'will create a ledger entry with the right amount' do
+      store_credit.invalidate(invalidation_reason, invalidation_user)
+      Spree::StoreCreditLedgerEntry.destroy_all
+      expect {
+        task.invoke
+      }.to change { Spree::StoreCreditLedgerEntry.count }.by(1)
+
+      expect(store_credit.liability_balance).to eql 0
+    end
+  end
+end

--- a/core/spec/models/spree/store_credit_ledger_entry_spec.rb
+++ b/core/spec/models/spree/store_credit_ledger_entry_spec.rb
@@ -1,0 +1,359 @@
+require 'spec_helper'
+
+describe Spree::StoreCreditLedgerEntry do
+  let(:currency) { "TEST" }
+  let(:store_credit) { build(:store_credit, store_credit_attrs) }
+  let(:store_credit_attrs) { {} }
+
+  context 'store credits events' do
+    describe "callbacks" do
+      context "creating ledger entry" do
+        let(:store_credit_attrs) { { amount: 250 } }
+
+        it "on create" do
+          expect{ store_credit.save }.to change { store_credit.store_credit_ledger_entries.count }.by 1
+        end
+
+        it "will have a balance equal to the amount" do
+          store_credit.save
+          expect(store_credit.liability_balance).to eql 250
+        end
+      end
+    end
+
+    describe "#authorize" do
+      context "amount is valid" do
+        let(:authorization_amount)       { 1.0 }
+        let(:added_authorization_amount) { 3.0 }
+        let(:originator) { nil }
+
+        context "amount has not been authorized yet" do
+          before { store_credit.update_attributes(amount_authorized: authorization_amount) }
+
+          it "will store a 'pending' ledger entry" do
+            expect {
+              store_credit.authorize(added_authorization_amount, store_credit.currency)
+            }.to change{ store_credit.store_credit_ledger_entries.pending.count }
+          end
+
+          it "will set the expected balance" do
+            store_credit.authorize(added_authorization_amount, store_credit.currency)
+            expect(store_credit.balance).to eql store_credit.amount - added_authorization_amount
+          end
+
+          it "will not change the liability balance" do
+            expect {
+              store_credit.authorize(added_authorization_amount, store_credit.currency)
+            }.to_not change{ store_credit.liability_balance }
+          end
+
+          context "originator is present" do
+            let(:originator) { create(:user) } # won't actually be a user. just giving it a valid model here
+
+            subject { store_credit.authorize(added_authorization_amount, store_credit.currency, action_originator: originator) }
+
+            it "records the originator on the ledger entry" do
+              expect { subject }.to change { store_credit.store_credit_ledger_entries.pending.count }.by(1)
+              expect(store_credit.store_credit_ledger_entries.pending.last.originator).to eq originator
+            end
+          end
+        end
+      end
+    end
+
+    describe "#capture" do
+      let(:authorized_amount) { 10.00 }
+      let(:auth_code)         { "23-SC-20140602164814476128" }
+
+      before do
+        @original_authed_amount = store_credit.amount_authorized
+        @auth_code = store_credit.authorize(authorized_amount, store_credit.currency)
+      end
+
+      context "insufficient funds" do
+        subject { store_credit.capture(authorized_amount * 2, @auth_code, store_credit.currency) }
+
+        it "does not add an entry to the ledger" do
+          expect { subject }.to_not change { store_credit.store_credit_ledger_entries.count }
+        end
+      end
+
+      context "currency mismatch" do
+        subject { store_credit.capture(authorized_amount, @auth_code, "EUR") }
+
+        it "does not add an entry to the ledger" do
+          expect { subject }.to_not change { store_credit.store_credit_ledger_entries.count }
+        end
+      end
+
+      context "valid capture" do
+        let(:remaining_authorized_amount) { 1 }
+        let(:originator) { nil }
+
+        subject { store_credit.capture(authorized_amount - remaining_authorized_amount, @auth_code, store_credit.currency, action_originator: originator) }
+
+        it "adds an entry to the ledger for both liability and pending" do
+          expect { subject }.to change { store_credit.store_credit_ledger_entries.count }.by(2)
+        end
+
+        it "will lower the liability balance with the amount captured" do
+          captured_amount = authorized_amount - remaining_authorized_amount
+          expect { subject }.to change { store_credit.liability_balance }.by(-1 * captured_amount)
+        end
+
+        it "will not change the balance for the amount useable when the authorized amount is captured" do
+          expect { subject }.to_not change { store_credit.balance }
+        end
+
+        context "originator is present" do
+          let(:originator) { create(:user) } # won't actually be a user. just giving it a valid model here
+
+          it "records the originator on the ledger entry" do
+            expect { subject }.to change { store_credit.store_credit_ledger_entries.count }.by(2)
+            expect(store_credit.store_credit_ledger_entries.last.originator).to eq originator
+          end
+        end
+      end
+    end
+
+    describe "#void" do
+      let(:auth_code)    { "1-SC-20141111111111" }
+      let(:store_credit) { create(:store_credit, amount_used: 150.0) }
+      let(:originator) { nil }
+
+      subject do
+        store_credit.void(auth_code, action_originator: originator)
+      end
+
+      context "no event found for auth_code" do
+        it "does not add an entry to the ledger" do
+          expect { subject }.to_not change { store_credit.store_credit_ledger_entries.count }
+        end
+      end
+
+      context "capture event found for auth_code" do
+        let(:captured_amount) { 10.0 }
+        let!(:capture_event) {
+          create(:store_credit_auth_event,
+                                      action: Spree::StoreCredit::CAPTURE_ACTION,
+                                      authorization_code: auth_code,
+                                      amount: captured_amount,
+                                      store_credit: store_credit)
+        }
+
+        it "does not add an entry to the ledger" do
+          expect { subject }.to_not change { store_credit.store_credit_ledger_entries.count }
+        end
+      end
+
+      context "auth event found for auth_code" do
+        let(:auth_event) { create(:store_credit_auth_event) }
+
+        let(:authorized_amount) { 10.0 }
+        let!(:auth_event) {
+          create(:store_credit_auth_event,
+                                   authorization_code: auth_code,
+                                   amount: authorized_amount,
+                                   store_credit: store_credit)
+        }
+
+        it "will add a 'pending' entry to the ledger" do
+          expect { subject }.to change { store_credit.store_credit_ledger_entries.pending.count }.by(1)
+        end
+
+        it "will set the expected balance" do
+          expect { subject }.to change { store_credit.balance }.by(authorized_amount)
+        end
+
+        it "will not change the liability balance" do
+          expect { subject }.to_not change{ store_credit.liability_balance }
+        end
+
+        context "originator is present" do
+          let(:originator) { create(:user) } # won't actually be a user. just giving it a valid model here
+
+          it "records the originator on the ledger entry" do
+            expect { subject }.to change { store_credit.store_credit_ledger_entries.pending.count }.by(1)
+            expect(store_credit.store_credit_ledger_entries.pending.last.originator).to eq originator
+          end
+        end
+      end
+    end
+
+    describe "#credit" do
+      let(:event_auth_code) { "1-SC-20141111111111" }
+      let(:amount_used)     { 10.0 }
+      let(:store_credit)    { create(:store_credit, amount_used: amount_used) }
+      let!(:capture_event)  {
+        create(:store_credit_auth_event,
+                                     action: Spree::StoreCredit::CAPTURE_ACTION,
+                                     authorization_code: event_auth_code,
+                                     amount: captured_amount,
+                                     store_credit: store_credit)
+      }
+      let(:originator) { nil }
+
+      subject { store_credit.credit(credit_amount, auth_code, currency, action_originator: originator) }
+
+      context "currency does not match" do
+        let(:currency)        { "AUD" }
+        let(:credit_amount)   { 5.0 }
+        let(:captured_amount) { 100.0 }
+        let(:auth_code)       { event_auth_code }
+
+        it "does not add an entry to the ledger" do
+          expect { subject }.to_not change { store_credit.store_credit_ledger_entries.count }
+        end
+      end
+
+      context "unable to find capture event" do
+        let(:currency)        { "USD" }
+        let(:credit_amount)   { 5.0 }
+        let(:captured_amount) { 100.0 }
+        let(:auth_code)       { "UNKNOWN_CODE" }
+
+        it "does not add an entry to the ledger" do
+          expect { subject }.to_not change { store_credit.store_credit_ledger_entries.count }
+        end
+      end
+
+      context "amount is more than what is captured" do
+        let(:currency)        { "USD" }
+        let(:credit_amount)   { 100.0 }
+        let(:captured_amount) { 5.0 }
+        let(:auth_code)       { event_auth_code }
+
+        it "does not add an entry to the ledger" do
+          expect { subject }.to_not change { store_credit.store_credit_ledger_entries.count }
+        end
+      end
+
+      context "amount is successfully credited" do
+        let(:currency)        { "USD" }
+        let(:credit_amount)   { 5.0 }
+        let(:captured_amount) { 100.0 }
+        let(:auth_code)       { event_auth_code }
+
+        context "credit_to_new_allocation is set" do
+          before { Spree::Config[:credit_to_new_allocation] = true }
+
+          it "does not create a new store credit ledger entry on the parent store credit" do
+            expect { subject }.to_not change { store_credit.store_credit_ledger_entries.count }
+          end
+        end
+
+        context "credit_to_new_allocation is not set" do
+
+          it "adds an entry to the ledger" do
+            expect { subject }.to change { store_credit.store_credit_ledger_entries.count }.by(1)
+          end
+
+          it "will up the balance with the amount credited" do
+            expect { subject }.to change { store_credit.liability_balance }.by(credit_amount)
+          end
+        end
+      end
+    end
+
+    describe "#update_amount" do
+      let(:updating_user) { create(:user) }
+      let(:update_reason) { create(:store_credit_update_reason) }
+
+      subject { store_credit.update_amount(amount, update_reason, updating_user) }
+
+      context "amount is valid" do
+        let(:amount) { 10.0 }
+
+        before { store_credit.update_attributes!(amount: 30.0) }
+
+        it "adds an entry to the ledger" do
+          expect { subject }.to change { store_credit.store_credit_ledger_entries.count }.by(1)
+        end
+
+        it "records the originator on the ledger entry" do
+          subject
+          expect(Spree::StoreCreditLedgerEntry.last.originator).to eq updating_user
+        end
+
+        it "will update the balance to match the updated amount" do
+          # amount is 30
+          # adjusted amount is 10
+          # expecting the balance to change by -20
+          expect { subject }.to change { store_credit.liability_balance }.by(-20)
+        end
+
+        it "will return the correct ledger balance" do
+          # amount is 30
+          # adjusted amount is 10
+          # expecting the balance to return the adjusted amount
+          subject
+          expect(store_credit.liability_balance).to eql amount
+        end
+
+        context "and larger then the current store credit amount" do
+          let(:amount) { 50.0 }
+
+          it "will update the balance to match the updated amount" do
+            # amount is 30
+            # adjusted amount is 50
+            # expecting the balance to change by 20
+            expect { subject }.to change { store_credit.liability_balance }.by(20)
+          end
+
+          it "will return the correct ledger balance" do
+            # amount is 30
+            # adjusted amount is 50
+            # expecting the balance to return the adjusted amount
+            subject
+            expect(store_credit.liability_balance).to eql amount
+          end
+        end
+      end
+
+      context "amount is invalid" do
+        let(:amount) { -10.0 }
+
+        it "doesn't create a store credit ledger entry" do
+          expect { subject }.to_not change { store_credit.store_credit_ledger_entries.count }
+        end
+      end
+    end
+
+    describe "#invalidate" do
+      let(:invalidation_user) { create(:user) }
+      let(:invalidation_reason) { create(:store_credit_update_reason) }
+
+      before do
+        store_credit.save!
+      end
+
+      subject { store_credit.invalidate(invalidation_reason, invalidation_user) }
+
+      context "there is a captured authorization" do
+        before do
+          auth_code = store_credit.authorize(5.0, "USD")
+          store_credit.capture(5.0, auth_code, "USD")
+        end
+
+        it "adds an entry to the ledger" do
+          expect { subject }.to change { store_credit.store_credit_ledger_entries.count }.by(1)
+        end
+
+        it "will lower the ledger balance with the last remaining balance" do
+          remaining_balance = store_credit.liability_balance
+          expect { subject }.to change { store_credit.liability_balance }.by(-1 * remaining_balance)
+        end
+
+        it "will made the ledger balance be 0.0" do
+          subject
+          expect(store_credit.liability_balance).to eql 0.0
+        end
+
+        it "records the originator on the ledger entry" do
+          subject
+          expect(store_credit.store_credit_ledger_entries.last.originator).to eq invalidation_user
+        end
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/store_credit_spec.rb
+++ b/core/spec/models/spree/store_credit_spec.rb
@@ -785,10 +785,10 @@ describe Spree::StoreCredit do
   end
 
   describe "#update_amount" do
-    let(:invalidation_user) { create(:user) }
-    let(:invalidation_reason) { create(:store_credit_update_reason) }
+    let(:updating_user) { create(:user) }
+    let(:update_reason) { create(:store_credit_update_reason) }
 
-    subject { store_credit.update_amount(amount, invalidation_reason, invalidation_user) }
+    subject { store_credit.update_amount(amount, update_reason, updating_user) }
 
     context "amount is valid" do
       let(:amount) { 10.0 }
@@ -810,7 +810,7 @@ describe Spree::StoreCredit do
 
       it "sets the originator on the store credit event correctly" do
         subject
-        expect(store_credit.store_credit_events.find_by(action: Spree::StoreCredit::ADJUSTMENT_ACTION).originator).to eq invalidation_user
+        expect(store_credit.store_credit_events.find_by(action: Spree::StoreCredit::ADJUSTMENT_ACTION).originator).to eq updating_user
       end
     end
 
@@ -867,7 +867,7 @@ describe Spree::StoreCredit do
       it "creates a store credit event for the invalidation" do
         expect { subject }.to change { store_credit.store_credit_events.where(action: Spree::StoreCredit::INVALIDATE_ACTION).count }.from(0).to(1)
       end
-
+      
       it "assigns the originator as the user that is performing the invalidation" do
         subject
         expect(store_credit.store_credit_events.find_by(action: Spree::StoreCredit::INVALIDATE_ACTION).originator).to eq invalidation_user


### PR DESCRIPTION
The `store_credit_event` is recording an audit trail to provide some insight in the lifeline of a `store_credit`. However, it would be nice to have an actual ledger for the store credits, that will focus only on the events that will have a financial consequence to the store owner.

This PR introduces the `store_credit_legder_entry` that will provide historically consistent reporting of store credit liabilities. 

