### PR TITLE
Fix Shipment#update_attributes_and_order - run full order updater

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -296,25 +296,9 @@ module Spree
       if update_attributes params
         if params.key? :selected_shipping_rate_id
           # Changing the selected Shipping Rate won't update the cost (for now)
-          # so we persist the Shipment#cost before calculating order shipment
-          # total and updating payment state (given a change in shipment cost
-          # might change the Order#payment_state)
+          # so we persist the Shipment#cost before running `order.update!`
           update_amounts
-
-          order.updater.update_shipment_total
-          order.updater.update_payment_state
-
-          # Update shipment state only after order total is updated because it
-          # (via Order#paid?) affects the shipment state (YAY)
-          update_columns(
-            state: determine_state(order),
-            updated_at: Time.current
-          )
-
-          # And then it's time to update shipment states and finally persist
-          # order changes
-          order.updater.update_shipment_state
-          order.updater.persist_totals
+          order.update!
         end
 
         true

--- a/core/spec/lib/spree/core/testing_support/factories/order_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/order_factory_spec.rb
@@ -75,6 +75,22 @@ RSpec.describe 'order factory' do
         )
       end
     end
+
+    context 'when shipments should be taxed' do
+      let!(:ship_address) { create(:address) }
+      let!(:tax_zone) { create(:global_zone) } # will include the above address
+      let!(:tax_rate) { create(:tax_rate, amount: 0.10, zone: tax_zone, tax_category: tax_category) }
+
+      let(:tax_category) { create(:tax_category) }
+      let(:shipping_method) { create(:shipping_method, tax_category: tax_category, zones: [tax_zone]) }
+
+      it 'shipments get a tax adjustment' do
+        order = create(factory, ship_address: ship_address, shipping_method: shipping_method)
+        shipment = order.shipments[0]
+
+        expect(shipment.additional_tax_total).to be > 0
+      end
+    end
   end
 
   describe 'order ready to complete' do


### PR DESCRIPTION
Tax charges aren't being updated when the shipping method changes
because some parts of OrderUpdater aren't being run in
`Shipment#update_attributes_and_order`.

Also fix an issue in order_factory around shipment taxes.

See individual commits.
