### PR TITLE
Do not require lastname in frontend address form

### DIFF
--- a/frontend/app/views/spree/address/_form.html.erb
+++ b/frontend/app/views/spree/address/_form.html.erb
@@ -6,7 +6,7 @@
   </p>
   <p class="field" id=<%="#{address_id}lastname" %>>
     <%= form.label :lastname, Spree.t(:last_name) %><span class="required">*</span><br />
-    <%= form.text_field :lastname, :class => 'required' %>
+    <%= form.text_field :lastname %>
   </p>
   <% if Spree::Config[:company] %>
     <p class="field" id=<%="#{address_id}company" %>>

--- a/frontend/spec/features/locale_spec.rb
+++ b/frontend/spec/features/locale_spec.rb
@@ -40,7 +40,7 @@ describe 'setting locale', type: :feature do
         visit '/checkout/address'
         find('.form-buttons input[type=submit]').click
 
-        %w(firstname lastname address1 city).each do |attr|
+        %w(firstname address1 city).each do |attr|
           expect(find(".field#b#{attr} label.error")).to have_text(message)
         end
       end


### PR DESCRIPTION
Last names are now [optional][1] on Address records, and are no longer
generated by the default `:address` factory. As a result, this field
should no longer be considered required by solidus-frontend.

[1]: https://github.com/solidusio/solidus/pull/1369