### PR TITLE
Allow the admin screens to be printed better.

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/components/_sidebar.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_sidebar.scss
@@ -26,6 +26,8 @@ body:not(.new-layout) #sidebar {
       min-height: 3em;
     }
   }
+
+  @media print { display: none }
 }
 
 body.new-layout .content-sidebar {

--- a/backend/app/assets/stylesheets/spree/backend/components/_table-filter.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_table-filter.scss
@@ -11,4 +11,6 @@
   .actions {
     text-align: center;
   }
+
+  @media print { display: none }
 }

--- a/backend/app/assets/stylesheets/spree/backend/components/_tabs.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_tabs.scss
@@ -13,6 +13,8 @@
   a {
     padding: 1em;
   }
+
+  @media print { display: none }
 }
 
 .tabs > li:not(.in-dropdown) {

--- a/backend/app/assets/stylesheets/spree/backend/shared/_header.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_header.scss
@@ -8,6 +8,8 @@
   body:not(.new-layout) & {
     margin-left: $width-sidebar;
   }
+
+  @media print { display: none }
 }
 
 .page-title {

--- a/backend/app/assets/stylesheets/spree/backend/shared/_layout.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_layout.scss
@@ -14,11 +14,13 @@ body {
 .admin-nav {
   @include position(absolute, 0 null 0 0);
   width: $width-sidebar;
+  @media print { display: none }
 }
 
 .content-wrapper {
   body:not(.new-layout) & {
     margin-left: $width-sidebar;
+    @media print { margin-left: 0 }
   }
 
   body.new-layout & {

--- a/backend/app/views/spree/admin/shared/_head.html.erb
+++ b/backend/app/views/spree/admin/shared/_head.html.erb
@@ -7,7 +7,7 @@
 <!-- Get "Open Sans" font from Google -->
 <link href='//fonts.googleapis.com/css?family=Open+Sans:400italic,600italic,400,600&subset=latin,cyrillic,greek,vietnamese' rel='stylesheet' type='text/css'>
 
-<%= stylesheet_link_tag 'spree/backend/all' %>
+<%= stylesheet_link_tag 'spree/backend/all', media: 'all' %>
 
 <%- if Rails.env.test? %>
   <style>


### PR DESCRIPTION
The stylesheets are not used when printing resulting in some pretty awful printing of the admin screens. The primary thing here is just making the stylesheet also apply to printing. Stylesheets not optimized for printing are still better than no stylesheets.

After that I did a few small adjustments to make the stylesheets a bit more print friendly. Ideally it would be nice to go through all the screens and make sure each prints nicely, but my scope was just to get one page we are working on to print nicely. Of course these changes will help other pages as some of the changes are general layout changes used in all pages. So it's a start. Items changed for printing include:

* Removal of the header. The action buttons/links obviously have no purpose in printing, the icon is superfluous and we have limited space when printing. The only thing useful is the actual page title. Most of the time this same info is placed in the HTML page title which most browsers include at the top of a printed page making this redundant. With all this removing the header completely makes the most sense.
* Removed the left navigation. While it does provide some context, but hopefully the page title will be sufficient and we don't have the horizontal space when printing portrait.
* Removed the right sidebar. This usually has some navigation or auxiliary information not central to the page content. Again limited horizontal space in portrait encouraged me to give the right sidebar the axe.
* Removed the search forms. They have no purpose on a printed document.
* Remove the tabs. Like the left navigation they can provide context but obviously they are non-functional when printed and hopefully the page title provides sufficient context.