### PR TITLE
Drop bundle exec from bin/rails in test_app

### DIFF
--- a/core/lib/spree/testing_support/common_rake.rb
+++ b/core/lib/spree/testing_support/common_rake.rb
@@ -17,8 +17,8 @@ namespace :common do
 
     puts "Setting up dummy database..."
 
-    sh "bundle exec bin/rails db:environment:set RAILS_ENV=test"
-    sh "bundle exec rake db:drop db:create db:migrate VERBOSE=false RAILS_ENV=test"
+    sh "bin/rails db:environment:set RAILS_ENV=test"
+    sh "bin/rails db:drop db:create db:migrate VERBOSE=false RAILS_ENV=test"
 
     begin
       require "generators/#{ENV['LIB_NAME']}/install/install_generator"


### PR DESCRIPTION
Without this we are getting [bundler errors](https://travis-ci.org/jhawthorn/solidus/builds/167214524)

    bundle exec bin/rails db:environment:set RAILS_ENV=test
    bundler: failed to load command: bin/rails (bin/rails)
    Gem::LoadError: You have already activated arel 7.1.4, but your Gemfile requires arel 7.1.2. Prepending `bundle exec` to your command may solve this.
      /home/jhawthorn/.gem/ruby/2.3.1/gems/bundler-1.13.1/lib/bundler/runtime.rb:40:in `block in setup'
      /home/jhawthorn/.gem/ruby/2.3.1/gems/bundler-1.13.1/lib/bundler/runtime.rb:25:in `map'
      /home/jhawthorn/.gem/ruby/2.3.1/gems/bundler-1.13.1/lib/bundler/runtime.rb:25:in `setup'
      /home/jhawthorn/.gem/ruby/2.3.1/gems/bundler-1.13.1/lib/bundler.rb:99:in `setup'
      /home/jhawthorn/src/solidus/core/spec/dummy/config/boot.rb:6:in `<top (required)>'
      bin/rails:3:in `require_relative'
      bin/rails:3:in `<top (required)>'
    rake aborted!
    Command failed with status (1): [bundle exec bin/rails db:environment:set R...]