### PR TITLE
Fix deprecations from PromotionAction.of_type

### DIFF
--- a/core/app/models/spree/promotion_action.rb
+++ b/core/app/models/spree/promotion_action.rb
@@ -8,7 +8,7 @@ module Spree
 
     belongs_to :promotion, class_name: 'Spree::Promotion', inverse_of: :promotion_actions
 
-    scope :of_type, ->(t) { where(type: t) }
+    scope :of_type, ->(t) { where(type: t.to_s) }
 
     # Updates the state of the order or performs some other action depending on
     # the subclass options will contain the payload from the event that


### PR DESCRIPTION
```
DEPRECATION WARNING: Passing a class as a value in an Active Record
query is deprecated and will be removed. Pass a string instead. (called
from block in <class:PromotionAction> at ...
```