### PR TITLE
Do not require 'wrapper_class' var in price checkbox partial

### DIFF
--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -38,7 +38,7 @@
       </div>
 
       <% if show_rebuild_vat_checkbox? %>
-        <%= render "spree/admin/shared/rebuild_vat_prices_checkbox", form: f, model_name: "product"%>
+        <%= render "spree/admin/shared/rebuild_vat_prices_checkbox", form: f, model_name: "product" %>
         <div class="clearfix"></div>
       <% end %>
 

--- a/backend/app/views/spree/admin/shared/_rebuild_vat_prices_checkbox.html.erb
+++ b/backend/app/views/spree/admin/shared/_rebuild_vat_prices_checkbox.html.erb
@@ -1,4 +1,4 @@
-<div data-hook="admin_<%= model_name %>_form_generate_vat_prices" class="<%= wrapper_class %> checkbox">
+<div data-hook="admin_<%= model_name %>_form_generate_vat_prices" class="<%= local_assigns[:wrapper_class] %> checkbox">
   <%= form.label :rebuild_vat_prices do %>
     <%= form.check_box :rebuild_vat_prices, checked: form.object.prices.size <= 1 %>
     <%= Spree::Variant.human_attribute_name(:rebuild_vat_prices) %>


### PR DESCRIPTION
In the bootstrap refactoring, the argument "wrapper_class" given to
rendering the `rebuild_vat_prices_checkbox` was lost, leading to
method not founds for stores with VAT. This commit changes the
reference from `wrapper_class` to `local_assigns[:wrapper_class]`
so that

  1. the partial does not error out when rendered without it and
  2. it is immediately apparent to the reader that `wrapper_class`
     is not a helper.