### PR TITLE
Make Cart Tax Country ISO editable in admin

### DIFF
--- a/backend/app/views/spree/admin/general_settings/edit.html.erb
+++ b/backend/app/views/spree/admin/general_settings/edit.html.erb
@@ -56,6 +56,17 @@
             <%= f.error_message_on :mail_from_address %>
           <% end %>
         </div>
+
+        <div data-hook="admin_general_setting_default_tax_country">
+          <%= f.field_container :cart_tax_country_iso do %>
+            <%= f.label :cart_tax_country_iso %>
+            <%= f.select :cart_tax_country_iso,
+                         Spree::Country.all.map { |c| [c.name, c.iso] },
+                         { include_blank: t(".no_cart_tax_country") },
+                         { class: "select2 fullwidth" } %>
+            <%= f.error_message_on :cart_tax_country_iso %>
+          <% end %>
+        </div>
       <% end %>
 
       <% if can? :update, :general_settings %>

--- a/backend/spec/features/admin/configuration/general_settings_spec.rb
+++ b/backend/spec/features/admin/configuration/general_settings_spec.rb
@@ -8,6 +8,8 @@ describe "Store", type: :feature, js: true do
            mail_from_address: 'test@example.org')
   end
 
+  let!(:vat_country) { create(:country, iso: "DE", name: "Germany") }
+
   before(:each) do
     visit spree.admin_path
     click_link "Settings"
@@ -34,6 +36,16 @@ describe "Store", type: :feature, js: true do
       assert_successful_update_message(:general_settings)
       expect(page).to have_field("store_name", with: "Spree Demo Site99")
       expect(page).to have_field("store_mail_from_address", with: "spree@example.org")
+    end
+
+    it "should be able to update the default cart tax country" do
+      expect(page).to have_select("Tax Country for Empty Carts", selected: "No taxes on carts without address")
+
+      select "Germany", from: "Tax Country for Empty Carts"
+      click_button "Update"
+
+      assert_successful_update_message(:general_settings)
+      expect(page).to have_select("Tax Country for Empty Carts", selected: "Germany")
     end
   end
 

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -252,6 +252,7 @@ en:
         seo_title: Seo Title
         name: Site Name
         mail_from_address: Mail From Address
+        cart_tax_country_iso: Tax Country for Empty Carts
       spree/store_credit:
         amount: Amount
         amount_authorized: Amount Authorized
@@ -723,6 +724,9 @@ en:
         taxonomies: Taxonomies
         taxons: Taxons
         users: Users
+      general_settings:
+        edit:
+          no_cart_tax_country: "No taxes on carts without address"
       user:
         account: Account
         addresses: Addresses

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -102,7 +102,8 @@ module Spree
       :quantity, :stock_item, :stock_item_id, :originator, :action]
 
     @@store_attributes = [:name, :url, :seo_title, :meta_keywords,
-                          :meta_description, :default_currency, :mail_from_address]
+                          :meta_description, :default_currency,
+                          :mail_from_address, :cart_tax_country_iso]
 
     @@taxonomy_attributes = [:name]
 


### PR DESCRIPTION
In VAT stores, prices are required to include VAT when adding them to
the cart. Solidus supports this via the `cart_tax_country_iso` setting
on `Spree::Store`. However, this setting has not been available in the
admin area. This commit adds a form field in the "General Settings"
area that allows the default tax country to be selected.