### PR TITLE
Fix how orders payment total is calculated

### DIFF
--- a/api/app/helpers/spree/api/api_helpers.rb
+++ b/api/app/helpers/spree/api/api_helpers.rb
@@ -85,7 +85,7 @@ module Spree
         :user_id, :created_at, :updated_at, :completed_at, :payment_total,
         :shipment_state, :payment_state, :email, :special_instructions, :channel,
         :included_tax_total, :additional_tax_total, :display_included_tax_total,
-        :display_additional_tax_total, :tax_total, :currency,
+        :display_additional_tax_total, :tax_total, :currency, :incoming_payment,
         :covered_by_store_credit, :display_total_applicable_store_credit,
         :order_total_after_store_credit, :display_order_total_after_store_credit,
         :total_applicable_store_credit, :display_total_available_store_credit,

--- a/api/spec/controllers/spree/api/orders_controller_spec.rb
+++ b/api/spec/controllers/spree/api/orders_controller_spec.rb
@@ -11,8 +11,8 @@ module Spree
     let(:attributes) {
       [:number, :item_total, :display_total, :total,
        :state, :adjustment_total,
-       :user_id, :created_at, :updated_at,
-       :completed_at, :payment_total, :shipment_state,
+       :user_id, :created_at, :updated_at, :completed_at,
+       :payment_total, :incoming_payment, :shipment_state,
        :payment_state, :email, :special_instructions,
        :total_quantity, :display_item_total, :currency]
     }

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -353,19 +353,19 @@ module Spree
     end
 
     def outstanding_balance
-      # If reimbursement has happened add it back to total to prevent balance_due payment state
-      # See: https://github.com/spree/spree/issues/6229
-      adjusted_payment_total = payment_total + refund_total
-
       if state == 'canceled'
-        -1 * adjusted_payment_total
+        -1 * payment_total
       else
-        total - adjusted_payment_total
+        total - payment_total
       end
     end
 
     def outstanding_balance?
       outstanding_balance != 0
+    end
+
+    def payment_total
+      incoming_payment - refund_total
     end
 
     def refund_total

--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -50,7 +50,7 @@ module Spree
 
     # Updates the following Order total values:
     #
-    # +payment_total+      The total value of all finalized Payments (NOTE: non-finalized Payments are excluded)
+    # +incoming_total+     The total value of all finalized Payments (NOTE: non-finalized Payments are excluded)
     # +item_total+         The total value of all LineItems
     # +adjustment_total+   The total value of all adjustments (promotions, credits, etc.)
     # +promo_total+        The total value of all promotion adjustments
@@ -73,7 +73,11 @@ module Spree
     end
 
     def update_payment_total
-      order.payment_total = payments.completed.includes(:refunds).map { |payment| payment.amount - payment.refunds.sum(:amount) }.sum
+      update_incoming_payment
+    end
+
+    def update_incoming_payment
+      order.incoming_payment = payments.completed.sum(&:amount)
     end
 
     def update_shipment_total

--- a/core/db/migrate/20161028093407_add_incoming_payment_to_order.rb
+++ b/core/db/migrate/20161028093407_add_incoming_payment_to_order.rb
@@ -1,0 +1,18 @@
+class AddIncomingPaymentToOrder < ActiveRecord::Migration[5.0]
+  def change
+    add_column :spree_orders, :incoming_payment, :decimal, precision: 10, scale: 2, default: 0.0
+    remove_column :spree_orders, :payment_total, :decimal, precision: 10, scale: 2, default: 0.0
+
+    reversible do |direction|
+      direction.up do
+        Spree::Order.all.each {|o| o.update_incoming_payment }
+      end
+
+      direction.down do
+        Spree::Order.all.each do |o|
+          o.payment_total = o.payments.completed.includes(:refunds).map { |payment| payment.amount - payment.refunds.sum(:amount) }.sum
+        end
+      end
+    end
+  end
+end

--- a/core/spec/lib/spree/core/testing_support/factories/order_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/order_factory_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe 'order factory' do
         expect(order).to have_attributes(
           payment_state: 'balance_due',
           total: 110,
-          payment_total: 0 # payment is still pending
+          incoming_payment: 0 # payment is still pending
         )
 
         expect(order.payments.count).to eq 1
@@ -145,7 +145,7 @@ RSpec.describe 'order factory' do
         expect(order).to be_completed
         expect(order).to have_attributes(
           total: 110,
-          payment_total: 110,
+          incoming_payment: 110,
           payment_state: "paid",
           shipment_state: "ready"
         )
@@ -184,7 +184,7 @@ RSpec.describe 'order factory' do
         expect(order).to be_completed
         expect(order).to have_attributes(
           total: 110,
-          payment_total: 110,
+          incoming_payment: 110,
           payment_state: "paid"
         )
 

--- a/core/spec/models/spree/order_updater_spec.rb
+++ b/core/spec/models/spree/order_updater_spec.rb
@@ -14,10 +14,10 @@ module Spree
       end
 
       context 'with refund' do
-        it "updates payment totals" do
+        it "updates payment incoming" do
           create(:payment_with_refund, order: order, amount: 33.25, refund_amount: 3)
-          Spree::OrderUpdater.new(order).update_payment_total
-          expect(order.payment_total).to eq(30.25)
+          Spree::OrderUpdater.new(order).update_incoming_payment
+          expect(order.incoming_payment).to eq(33.25)
         end
       end
 
@@ -344,7 +344,7 @@ module Spree
         it "is failed" do
           create(:payment, order: order, state: 'invalid')
           order.total = 1
-          order.payment_total = 0
+          order.incoming_payment = 0
 
           updater.update_payment_state
           expect(order.payment_state).to eq('failed')
@@ -355,7 +355,7 @@ module Spree
         it 'is paid' do
           order.payments << Spree::Payment.new(state: 'invalid')
           order.total = 0
-          order.payment_total = 0
+          order.incoming_payment = 0
 
           expect {
             updater.update_payment_state
@@ -365,7 +365,7 @@ module Spree
 
       context "payment total is greater than order total" do
         it "is credit_owed" do
-          order.payment_total = 2
+          order.incoming_payment = 2
           order.total = 1
 
           expect {
@@ -376,7 +376,7 @@ module Spree
 
       context "order total is greater than payment total" do
         it "is balance_due" do
-          order.payment_total = 1
+          order.incoming_payment = 1
           order.total = 2
 
           expect {
@@ -387,7 +387,7 @@ module Spree
 
       context "order total equals payment total" do
         it "is paid" do
-          order.payment_total = 30
+          order.incoming_payment = 30
           order.total = 30
 
           expect {
@@ -403,7 +403,7 @@ module Spree
 
         context "and is still unpaid" do
           it "is void" do
-            order.payment_total = 0
+            order.incoming_payment = 0
             order.total = 30
             expect {
               updater.update_payment_state
@@ -413,7 +413,7 @@ module Spree
 
         context "and is paid" do
           it "is credit_owed" do
-            order.payment_total = 30
+            order.incoming_payment = 30
             order.total = 30
             create(:payment, order: order, state: 'completed', amount: 30)
             expect {
@@ -424,7 +424,7 @@ module Spree
 
         context "and payment is refunded" do
           it "is void" do
-            order.payment_total = 0
+            order.incoming_payment = 0
             order.total = 30
             expect {
               updater.update_payment_state

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -629,6 +629,11 @@ describe Spree::Payment, type: :model do
         payment = create(:payment, order: order, state: 'completed')
         expect(order.payment_total).to eq payment.amount
       end
+
+      it "update order incoming total" do
+        payment = create(:payment, order: order, state: 'completed')
+        expect(order.incoming_payment).to eq payment.amount
+      end
     end
 
     context "not completed payments" do
@@ -636,6 +641,12 @@ describe Spree::Payment, type: :model do
         expect {
           Spree::Payment.create(amount: 100, order: order)
         }.not_to change { order.payment_total }
+      end
+
+      it "doesn't update order incoming payment" do
+        expect {
+          Spree::Payment.create(amount: 100, order: order)
+        }.not_to change { order.incoming_payment }
       end
     end
 
@@ -651,6 +662,11 @@ describe Spree::Payment, type: :model do
       it 'updates order payment total' do
         payment.void
         expect(order.payment_total).to eq 0
+      end
+
+      it 'updates order incoming payment' do
+        payment.void
+        expect(order.incoming_payment).to eq 0
       end
     end
 

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -536,7 +536,7 @@ describe Spree::Shipment, type: :model do
     let(:store) { create :store }
     let(:order) do
       Spree::Order.create(
-        payment_total: 100,
+        incoming_payment: 100,
         payment_state: 'paid',
         total: 100,
         item_total: 100,


### PR DESCRIPTION
In Spree::OrderUpdater the `update_payment_total` was incorrectly
removing  the refunds total from each order payment. This seems
incorrect because they are separate things. Refund total has to be
taken away into the outstanding_balance calculation instead.

rel #1475
