### PR TITLE
Use ActiveModel::Naming for default tax calculator

### DIFF
--- a/core/app/models/spree/calculator.rb
+++ b/core/app/models/spree/calculator.rb
@@ -17,9 +17,10 @@ module Spree
       end
     end
 
-    # overwrite to provide description for your calculators
+    # A description for this calculator in few words
+    # @return [String] A description for the calculator
     def self.description
-      'Base Calculator'
+      model_name.human
     end
 
     ###################################################################

--- a/core/app/models/spree/calculator/default_tax.rb
+++ b/core/app/models/spree/calculator/default_tax.rb
@@ -4,10 +4,6 @@ module Spree
   class Calculator::DefaultTax < Calculator
     include Spree::Tax::TaxHelpers
 
-    def self.description
-      Spree.t(:default_tax)
-    end
-
     # Default tax calculator still needs to support orders for legacy reasons
     # Orders created before Spree 2.1 had tax adjustments applied to the order, as a whole.
     # Orders created with Spree 2.2 and after, have them applied to the line items individually.

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -357,8 +357,11 @@ en:
         one: Adjustment Reason
         other: Adjustment Reasons
       spree/calculator:
-        one: Calculator
-        other: Calculators
+        one: Base Calculator
+        other: Base Calculators
+      spree/calculator/default_tax:
+        one: Default Tax
+        other: Default Tax
       spree/country:
         one: Country
         other: Countries

--- a/core/spec/models/spree/calculator/default_tax_spec.rb
+++ b/core/spec/models/spree/calculator/default_tax_spec.rb
@@ -9,6 +9,11 @@ describe Spree::Calculator::DefaultTax, type: :model do
   let(:included_in_price) { false }
   subject(:calculator) { Spree::Calculator::DefaultTax.new(calculable: rate ) }
 
+  describe ".description" do
+    subject { described_class.description }
+    it { is_expected.to eq("Default Tax") }
+  end
+
   context "#compute" do
     context "when given an order" do
       let(:order) do


### PR DESCRIPTION
The descriptions for calculators are not namespaced. This commit makes
`Spree::Calculator.description` are shortcut to `Spree::Calculator.model_name.human`.

This way, we can eliminate a few lines from the codebase, as well as
converging around Rails conventions for naming things.

This PR only touches the default tax calculator, and is supposed to be a blueprint / RFC type PR. 