### PR TITLE
Remove invalid spec

### DIFF
--- a/core/spec/models/spree/payment_method_spec.rb
+++ b/core/spec/models/spree/payment_method_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Spree::PaymentMethod, type: :model do
   describe ".available" do
     let!(:payment_method_nil_display)  { create(:payment_method, active: true, display_on: nil) }
-    let!(:payment_method_both_display) { create(:payment_method, active: true, display_on: 'both') }
+    let!(:payment_method_both_display) { create(:payment_method, active: true, display_on: '') }
     let!(:payment_method_front_display){ create(:payment_method, active: true, display_on: 'front_end') }
     let!(:payment_method_back_display) { create(:payment_method, active: true, display_on: 'back_end') }
 
@@ -20,11 +20,11 @@ describe Spree::PaymentMethod, type: :model do
     end
 
     it "should return all methods available to front-end when display_on = :front_end" do
-      expect(Spree::PaymentMethod.available(:front_end).size).to eq(2)
+      expect(Spree::PaymentMethod.available(:front_end).size).to eq(3)
     end
 
     it "should return all methods available to back-end when display_on = :back_end" do
-      expect(Spree::PaymentMethod.available(:back_end).size).to eq(2)
+      expect(Spree::PaymentMethod.available(:back_end).size).to eq(3)
     end
 
     context 'with stores' do


### PR DESCRIPTION
The display_on value 'both' is unavailable in the admin, and should
not be included in the specs. Instead, it is set to '' when the
admin choose the display_on both option.

This increases the number of expected payment methods available to
front_end and back_end by one since there are 2 methods available to 
both areas and 1 each available only to either end.
