### PR TITLE
Deprecate order tax zone

### DIFF
--- a/core/app/models/spree/calculator/default_tax.rb
+++ b/core/app/models/spree/calculator/default_tax.rb
@@ -19,7 +19,7 @@ module Spree
       line_items_total = matched_line_items.sum(&:discounted_amount)
       if rate.included_in_price
         order_tax_amount = round_to_two_places(line_items_total - ( line_items_total / (1 + rate.amount) ) )
-        refund_if_necessary(order_tax_amount, order.tax_zone)
+        refund_if_necessary(order_tax_amount, order.tax_address)
       else
         round_to_two_places(line_items_total * rate.amount)
       end
@@ -52,20 +52,20 @@ module Spree
       unrounded_net_amount = item.discounted_amount / (1 + sum_of_included_tax_rates(item))
       refund_if_necessary(
         round_to_two_places(unrounded_net_amount * rate.amount),
-        item.order.tax_zone
+        item.order.tax_address
       )
     end
 
-    def refund_if_necessary(amount, order_tax_zone)
-      if default_zone_or_zone_match?(order_tax_zone)
+    def refund_if_necessary(amount, order_tax_address)
+      if default_zone_or_zone_match?(order_tax_address)
         amount
       else
         amount * -1
       end
     end
 
-    def default_zone_or_zone_match?(order_tax_zone)
-      Zone.default_tax.try!(:contains?, order_tax_zone) || rate.zone.contains?(order_tax_zone)
+    def default_zone_or_zone_match?(order_tax_address)
+      Zone.default_tax.try!(:include?, order_tax_address) || rate.zone.include?(order_tax_address)
     end
   end
 end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -227,8 +227,10 @@ module Spree
     # Returns the relevant zone (if any) to be used for taxation purposes.
     # Uses default tax zone unless there is a specific match
     def tax_zone
-      @tax_zone ||= Zone.match(tax_address) || Zone.default_tax
+      Zone.match(tax_address) || Zone.default_tax
     end
+    deprecate tax_zone: "Please use Spree::Order#tax_address instead.",
+              deprecator: Spree::Deprecation
 
     # Returns the address for taxation based on configuration
     def tax_address
@@ -587,11 +589,6 @@ module Spree
 
     def can_approve?
       !approved?
-    end
-
-    def reload(options = nil)
-      remove_instance_variable(:@tax_zone) if defined?(@tax_zone)
-      super
     end
 
     def quantity

--- a/core/app/models/spree/tax/item_adjuster.rb
+++ b/core/app/models/spree/tax/item_adjuster.rb
@@ -16,9 +16,8 @@ module Spree
         @item = item
         @order = @item.order
         # set instance variable so `TaxRate.match` is only called when necessary
-        @rates_for_order_zone = options[:rates_for_order_zone]
+        @rates_for_order = options[:rates_for_order]
         @rates_for_default_zone = options[:rates_for_default_zone]
-        @order_tax_zone = options[:order_tax_zone]
       end
 
       # Deletes all existing tax adjustments and creates new adjustments for all
@@ -26,11 +25,11 @@ module Spree
       #
       # @return [Array<Spree::Adjustment>] newly created adjustments
       def adjust!
-        return unless order_tax_zone(order)
+        return unless order.tax_address.country_id
 
         item.adjustments.destroy(item.adjustments.select(&:tax?))
 
-        rates_for_item(item).map { |rate| rate.adjust(order_tax_zone(order), item) }
+        rates_for_item(item).map { |rate| rate.adjust(nil, item) }
       end
     end
   end

--- a/core/app/models/spree/tax/order_adjuster.rb
+++ b/core/app/models/spree/tax/order_adjuster.rb
@@ -14,7 +14,7 @@ module Spree
       # Creates tax adjustments for all taxable items (shipments and line items)
       # in the given order.
       def adjust!
-        return unless order_tax_zone(order)
+        return unless order.tax_address.country_id
 
         (order.line_items + order.shipments).each do |item|
           ItemAdjuster.new(item, order_wide_options).adjust!
@@ -25,9 +25,8 @@ module Spree
 
       def order_wide_options
         {
-          rates_for_order_zone: rates_for_order_zone(order),
-          rates_for_default_zone: rates_for_default_zone,
-          order_tax_zone: order_tax_zone(order),
+          rates_for_order: rates_for_order(order),
+          rates_for_default_zone: rates_for_default_zone
         }
       end
     end

--- a/core/app/models/spree/tax/tax_helpers.rb
+++ b/core/app/models/spree/tax/tax_helpers.rb
@@ -17,24 +17,20 @@ module Spree
       #
       # For further discussion, see https://github.com/spree/spree/issues/4397 and https://github.com/spree/spree/issues/4327.
       def applicable_rates(order)
-        order_zone_tax_categories = rates_for_order_zone(order).map(&:tax_category)
+        order_zone_tax_categories = rates_for_order(order).map(&:tax_category)
         default_rates_with_unmatched_tax_category = rates_for_default_zone.to_a.delete_if do |default_rate|
           order_zone_tax_categories.include?(default_rate.tax_category)
         end
 
-        (rates_for_order_zone(order) + default_rates_with_unmatched_tax_category).uniq
+        (rates_for_order(order) + default_rates_with_unmatched_tax_category).uniq
       end
 
-      def rates_for_order_zone(order)
-        @rates_for_order_zone ||= Spree::TaxRate.for_zone(order_tax_zone(order))
+      def rates_for_order(order)
+        @rates_for_order ||= Spree::TaxRate.for_address(order.tax_address)
       end
 
       def rates_for_default_zone
         @rates_for_default_zone ||= Spree::TaxRate.for_zone(Spree::Zone.default_tax)
-      end
-
-      def order_tax_zone(order)
-        @order_tax_zone ||= order.tax_zone
       end
 
       def sum_of_included_tax_rates(item)

--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -66,7 +66,7 @@ module Spree
     scope :included_in_price, -> { where(included_in_price: true) }
 
     # Creates necessary tax adjustments for the order.
-    def adjust(order_tax_zone, item)
+    def adjust(_order_tax_zone, item)
       amount = compute_amount(item)
       return if amount == 0
 

--- a/core/spec/lib/spree/core/unreturned_item_charger_spec.rb
+++ b/core/spec/lib/spree/core/unreturned_item_charger_spec.rb
@@ -49,7 +49,6 @@ describe Spree::UnreturnedItemCharger do
     context 'in tax zone' do
       let!(:tax_zone) { create(:zone, countries: [ship_address.country]) }
       let!(:tax_rate) { create(:tax_rate, zone: tax_zone, tax_category: original_variant.tax_category) }
-      before { tax_zone.update_attributes!(default_tax: true) }
 
       it "applies tax" do
         exchange_order = exchange_shipment.order

--- a/core/spec/lib/tasks/exchanges_spec.rb
+++ b/core/spec/lib/tasks/exchanges_spec.rb
@@ -27,7 +27,8 @@ describe "exchanges:charge_unreturned_items" do
     let(:return_item_1) { build(:exchange_return_item, inventory_unit: order.inventory_units.first) }
     let(:return_item_2) { build(:exchange_return_item, inventory_unit: order.inventory_units.last) }
     let!(:rma) { create(:return_authorization, order: order, return_items: [return_item_1, return_item_2]) }
-    let!(:tax_rate) { create(:tax_rate, zone: order.tax_zone, tax_category: return_item_2.exchange_variant.tax_category) }
+    let(:zone) { create(:zone, countries: [order.tax_address.country])}
+    let!(:tax_rate) { create(:tax_rate, zone: zone, tax_category: return_item_2.exchange_variant.tax_category) }
     before do
       rma.save!
       Spree::Shipment.last.ship!
@@ -44,7 +45,8 @@ describe "exchanges:charge_unreturned_items" do
     let(:return_item_1) { build(:exchange_return_item, inventory_unit: order.inventory_units.first) }
     let(:return_item_2) { build(:exchange_return_item, inventory_unit: order.inventory_units.last) }
     let!(:rma) { create(:return_authorization, order: order, return_items: [return_item_1, return_item_2]) }
-    let!(:tax_rate) { create(:tax_rate, zone: order.tax_zone, tax_category: return_item_2.exchange_variant.tax_category) }
+    let(:zone) { create(:zone, countries: [order.tax_address.country])}
+    let!(:tax_rate) { create(:tax_rate, zone: zone, tax_category: return_item_2.exchange_variant.tax_category) }
 
     before do
       rma.save!

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -183,7 +183,8 @@ describe Spree::Order, type: :model do
       end
 
       it "recalculates tax and updates totals" do
-        create(:tax_rate, tax_category: line_item.tax_category, amount: 0.05, zone: order.tax_zone)
+        zone = create(:zone, countries: [order.tax_address.country])
+        create(:tax_rate, tax_category: line_item.tax_category, amount: 0.05, zone: zone)
         order.next!
         expect(order).to have_attributes(
           adjustment_total: 0.5,

--- a/core/spec/models/spree/order/tax_spec.rb
+++ b/core/spec/models/spree/order/tax_spec.rb
@@ -12,7 +12,9 @@ module Spree
 
       context "when no zones exist" do
         it "should return nil" do
-          expect(order.tax_zone).to be_nil
+          Spree::Deprecation.silence do
+            expect(order.tax_zone).to be_nil
+          end
         end
       end
 
@@ -22,7 +24,9 @@ module Spree
         it "should calculate using ship_address" do
           expect(Spree::Zone).to receive(:match).at_least(:once).with(ship_address)
           expect(Spree::Zone).not_to receive(:match).with(bill_address)
-          order.tax_zone
+          Spree::Deprecation.silence do
+            order.tax_zone
+          end
         end
       end
 
@@ -32,7 +36,9 @@ module Spree
         it "should calculate using bill_address" do
           expect(Spree::Zone).to receive(:match).at_least(:once).with(bill_address)
           expect(Spree::Zone).not_to receive(:match).with(ship_address)
-          order.tax_zone
+          Spree::Deprecation.silence do
+            order.tax_zone
+          end
         end
       end
 
@@ -46,7 +52,9 @@ module Spree
           before { allow(Spree::Zone).to receive_messages(match: zone) }
 
           it "should return the matching zone" do
-            expect(order.tax_zone).to eq(zone)
+            Spree::Deprecation.silence do
+              expect(order.tax_zone).to eq(zone)
+            end
           end
         end
 
@@ -54,7 +62,9 @@ module Spree
           before { allow(Spree::Zone).to receive_messages(match: nil) }
 
           it "should return the default tax zone" do
-            expect(order.tax_zone).to eq(@default_zone)
+            Spree::Deprecation.silence do
+              expect(order.tax_zone).to eq(@default_zone)
+            end
           end
         end
       end
@@ -66,7 +76,9 @@ module Spree
           before { allow(Spree::Zone).to receive_messages(match: zone) }
 
           it "should return the matching zone" do
-            expect(order.tax_zone).to eq(zone)
+            Spree::Deprecation.silence do
+              expect(order.tax_zone).to eq(zone)
+            end
           end
         end
 
@@ -74,10 +86,13 @@ module Spree
           before { allow(Spree::Zone).to receive_messages(match: nil) }
 
           it "should return nil" do
-            expect(order.tax_zone).to be_nil
+            Spree::Deprecation.silence do
+              expect(order.tax_zone).to be_nil
+            end
           end
         end
       end
+
     end
   end
 end

--- a/core/spec/models/spree/order_contents_spec.rb
+++ b/core/spec/models/spree/order_contents_spec.rb
@@ -103,9 +103,9 @@ describe Spree::OrderContents, type: :model do
         create(:tax_rate, zone: zone, tax_category: variant.tax_category)
       end
 
-      context 'when the order has a tax zone' do
+      context 'when the order has a taxable address' do
         before do
-          expect(order.tax_zone).to be_present
+          expect(order.tax_address.country_id).to be_present
         end
 
         it 'creates a tax adjustment' do
@@ -115,10 +115,10 @@ describe Spree::OrderContents, type: :model do
         end
       end
 
-      context 'when the order does not have a tax zone' do
+      context 'when the order does not have a taxable address' do
         before do
           order.update_attributes!(ship_address: nil, bill_address: nil)
-          expect(order.tax_zone).to be_nil
+          expect(order.tax_address.country_id).to be_nil
         end
 
         it 'creates a tax adjustment' do

--- a/core/spec/models/spree/promotion_handler/coupon_spec.rb
+++ b/core/spec/models/spree/promotion_handler/coupon_spec.rb
@@ -252,57 +252,59 @@ module Spree
 
         context "for an order with taxable line items" do
           let(:store) { create(:store) }
-          before(:each) do
-            @country = create(:country)
-            @zone = create(:zone, name: "Country Zone", default_tax: true, zone_members: [])
-            @zone.zone_members.create(zoneable: @country)
-            @category = Spree::TaxCategory.create name: "Taxable Foo"
-            @rate1 = Spree::TaxRate.create(
-              amount: 0.10,
-              calculator: Spree::Calculator::DefaultTax.create,
-              tax_category: @category,
-              zone: @zone
-            )
+          let(:order) { create(:order, store: store) }
+          let(:tax_category) { create(:tax_category, name: "Taxable Foo") }
+          let(:zone) { create(:zone, :with_country) }
+          let!(:tax_rate) { create(:tax_rate, amount: 0.1, tax_category: tax_category, zone: zone )}
 
-            @order = Spree::Order.create!(store: store)
-            allow(@order).to receive_messages coupon_code: "10off"
+          before(:each) do
+            expect(order).to receive(:tax_address).at_least(:once).and_return(Spree::Tax::TaxLocation.new(country: zone.countries.first))
           end
+
           context "and the product price is less than promo discount" do
             before(:each) do
+              expect(order).to receive(:coupon_code).at_least(:once).and_return("10off")
+
               3.times do |_i|
-                taxable = create(:product, tax_category: @category, price: 9.0)
-                @order.contents.add(taxable.master, 1)
+                taxable = create(:product, tax_category: tax_category, price: 9.0)
+                order.contents.add(taxable.master, 1)
               end
             end
+
             it "successfully applies the promo" do
               # 3 * (9 + 0.9)
-              expect(@order.total).to eq(29.7)
-              coupon = Coupon.new(@order)
+              expect(order.total).to eq(29.7)
+              coupon = Coupon.new(order)
               coupon.apply
               expect(coupon.success).to be_present
               # 3 * ((9 - [9,10].min) + 0)
-              expect(@order.reload.total).to eq(0)
-              expect(@order.additional_tax_total).to eq(0)
+              expect(order.reload.total).to eq(0)
+              expect(order.additional_tax_total).to eq(0)
             end
           end
+
           context "and the product price is greater than promo discount" do
             before(:each) do
+              expect(order).to receive(:coupon_code).at_least(:once).and_return("10off")
+
               3.times do |_i|
-                taxable = create(:product, tax_category: @category, price: 11.0)
-                @order.contents.add(taxable.master, 2)
+                taxable = create(:product, tax_category: tax_category, price: 11.0)
+                order.contents.add(taxable.master, 2)
               end
             end
+
             it "successfully applies the promo" do
               # 3 * (22 + 2.2)
-              expect(@order.total.to_f).to eq(72.6)
-              coupon = Coupon.new(@order)
+              expect(order.total.to_f).to eq(72.6)
+              coupon = Coupon.new(order)
               coupon.apply
               expect(coupon.success).to be_present
               # 3 * ( (22 - 10) + 1.2)
-              expect(@order.reload.total).to eq(39.6)
-              expect(@order.additional_tax_total).to eq(3.6)
+              expect(order.reload.total).to eq(39.6)
+              expect(order.additional_tax_total).to eq(3.6)
             end
           end
+
           context "and multiple quantity per line item" do
             before(:each) do
               twnty_off = create(:promotion, name: "promo", code: "20off")
@@ -310,22 +312,23 @@ module Spree
               Promotion::Actions::CreateItemAdjustments.create(promotion: twnty_off,
                                                                calculator: twnty_off_calc)
 
-              allow(@order).to receive(:coupon_code).and_call_original
-              allow(@order).to receive_messages coupon_code: "20off"
+              expect(order).to receive(:coupon_code).at_least(:once).and_return("20off")
+
               3.times do |_i|
-                taxable = create(:product, tax_category: @category, price: 10.0)
-                @order.contents.add(taxable.master, 2)
+                taxable = create(:product, tax_category: tax_category, price: 10.0)
+                order.contents.add(taxable.master, 2)
               end
             end
+
             it "successfully applies the promo" do
               # 3 * ((2 * 10) + 2.0)
-              expect(@order.total.to_f).to eq(66)
-              coupon = Coupon.new(@order)
+              expect(order.total.to_f).to eq(66)
+              coupon = Coupon.new(order)
               coupon.apply
               expect(coupon.success).to be_present
               # 0
-              expect(@order.reload.total).to eq(0)
-              expect(@order.additional_tax_total).to eq(0)
+              expect(order.reload.total).to eq(0)
+              expect(order.additional_tax_total).to eq(0)
             end
           end
         end

--- a/core/spec/models/spree/shipping_rate_spec.rb
+++ b/core/spec/models/spree/shipping_rate_spec.rb
@@ -141,7 +141,9 @@ describe Spree::ShippingRate, type: :model do
       end
 
       it "shows correct tax amount" do
-        expect(shipping_rate.display_price.to_s).to eq("$10.00 (+ $1.00 Sales Tax, + $0.50 Other Sales Tax)")
+        expect(shipping_rate.display_price.to_s).to match(/\$10.00 \(.*, .*\)/)
+        expect(shipping_rate.display_price.to_s).to include("+ $1.00 Sales Tax")
+        expect(shipping_rate.display_price.to_s).to include("+ $0.50 Other Sales Tax")
       end
 
       context "when cost is zero" do

--- a/core/spec/models/spree/stock/estimator_spec.rb
+++ b/core/spec/models/spree/stock/estimator_spec.rb
@@ -140,7 +140,9 @@ module Spree
         end
 
         context "includes tax adjustments if applicable" do
-          let!(:tax_rate) { create(:tax_rate, zone: order.tax_zone) }
+          let(:zone) { create(:zone, countries: [order.tax_address.country])}
+
+          let!(:tax_rate) { create(:tax_rate, zone: zone) }
 
           before do
             shipping_method.update!(tax_category: tax_rate.tax_category)

--- a/core/spec/models/spree/tax/order_adjuster_spec.rb
+++ b/core/spec/models/spree/tax/order_adjuster_spec.rb
@@ -12,32 +12,28 @@ RSpec.describe Spree::Tax::OrderAdjuster do
   end
 
   describe '#adjust!' do
-    let(:zone) { build_stubbed(:zone) }
     let(:line_items) { build_stubbed_list(:line_item, 2) }
     let(:order) { build_stubbed(:order, line_items: line_items) }
     let(:rates_for_order_zone) { [] }
+    let(:rates_for_default_zone) { [] }
     let(:item_adjuster) { Spree::Tax::ItemAdjuster.new(line_items.first) }
 
     before do
-      expect(order).to receive(:tax_zone).at_least(:once).and_return(zone)
-      expect(Spree::TaxRate).to receive(:for_zone).with(zone).and_return(rates_for_order_zone)
-      expect(Spree::TaxRate).to receive(:for_zone).with(Spree::Zone.default_tax).and_return([])
+      expect(Spree::TaxRate).to receive(:for_address).with(order.tax_address).and_return(rates_for_order_zone)
     end
 
     it 'calls the item adjuster with all line items' do
       expect(Spree::Tax::ItemAdjuster).to receive(:new).
                                             with(
                                               line_items.first,
-                                              rates_for_order_zone: rates_for_order_zone,
-                                              rates_for_default_zone: [],
-                                              order_tax_zone: zone,
+                                              rates_for_order: rates_for_order_zone,
+                                              rates_for_default_zone: rates_for_default_zone
                                             ).and_return(item_adjuster)
       expect(Spree::Tax::ItemAdjuster).to receive(:new).
                                             with(
                                               line_items.second,
-                                              rates_for_order_zone: rates_for_order_zone,
-                                              rates_for_default_zone: [],
-                                              order_tax_zone: zone,
+                                              rates_for_order: rates_for_order_zone,
+                                              rates_for_default_zone: rates_for_default_zone
                                             ).and_return(item_adjuster)
 
       expect(item_adjuster).to receive(:adjust!).twice

--- a/core/spec/models/spree/tax_rate_spec.rb
+++ b/core/spec/models/spree/tax_rate_spec.rb
@@ -152,7 +152,7 @@ describe Spree::TaxRate, type: :model do
 
     describe 'adjustments' do
       before do
-        tax_rate.adjust(order.tax_zone, item)
+        tax_rate.adjust(nil, item)
       end
 
       let(:adjustment_label) { item.adjustments.tax.first.label }


### PR DESCRIPTION
This PR is two commits which are extracted from #1537, so that the Giant Removal is hopefully easier to understand. 

First, its a fix to `promotion_handler/coupon_spec`, which had weird spec setup in places that led to hard-to-debug errors. Second, it's deprecating `Spree::Order#tax_zone`, which is conceptually a terrible idea and rather expensive to use.

With the deprecation, I can also safely drop extra behaviour to `Spree::Order#reload`. Yay!
