### PR TITLE
Add promotion codes index view

### DIFF
--- a/backend/app/controllers/spree/admin/promotion_codes_controller.rb
+++ b/backend/app/controllers/spree/admin/promotion_codes_controller.rb
@@ -1,12 +1,16 @@
+require 'csv'
+
 module Spree
   module Admin
-    class PromotionCodesController < Spree::Admin::BaseController
-      require 'csv'
-
+    class PromotionCodesController < Spree::Admin::ResourceController
       def index
         @promotion = Spree::Promotion.accessible_by(current_ability, :read).find(params[:promotion_id])
+        @promotion_codes = @promotion.promotion_codes
 
         respond_to do |format|
+          format.html do
+            @promotion_codes = @promotion_codes.page(params[:page]).per(50)
+          end
           format.csv do
             filename = "promotion-code-list-#{@promotion.id}.csv"
             headers["Content-Type"] = "text/csv"

--- a/backend/app/views/spree/admin/promotion_codes/index.csv.ruby
+++ b/backend/app/views/spree/admin/promotion_codes/index.csv.ruby
@@ -1,6 +1,6 @@
 CSV.generate do |csv|
   csv << ['Code']
-  @promotion.codes.order(:id).pluck(:value).each do |value|
+  @promotion_codes.order(:id).pluck(:value).each do |value|
     csv << [value]
   end
 end

--- a/backend/app/views/spree/admin/promotion_codes/index.html.erb
+++ b/backend/app/views/spree/admin/promotion_codes/index.html.erb
@@ -1,0 +1,28 @@
+<% admin_breadcrumb link_to plural_resource_name(Spree::Promotion), spree.admin_promotions_path %>
+<% admin_breadcrumb link_to(@promotion.name, spree.edit_admin_promotion_path(@promotion)) %>
+<% admin_breadcrumb plural_resource_name(Spree::PromotionCode) %>
+
+<% content_for :page_actions do %>
+  <li>
+    <%= button_link_to Spree.t(:download_promotion_code_list), admin_promotion_promotion_codes_path(promotion_id: @promotion.id, format: :csv) %>
+  </li>
+<% end %>
+
+<div class="pagination-summary">
+  <%= page_entries_info(@promotion_codes) %>
+</div>
+
+<table>
+  <thead>
+    <th><%= Spree::PromotionCode.human_attribute_name :value %></th>
+  </thead>
+  <tbody>
+    <% @promotion_codes.each do |promotion_code| %>
+      <tr>
+        <td><%= promotion_code.value %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<%= paginate @promotion_codes, theme: "solidus_admin" %>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -471,6 +471,9 @@ en:
       spree/promotion_code_batch:
         one: Promotion Code Batch
         other: Promotion Code Batches
+      spree/promotion_code:
+        one: Promotion Code
+        other: Promotion Codes
       spree/property:
         one: Property Type
         other: Property Types


### PR DESCRIPTION
Previously we only showed codes via a CSV download, which is a useful feature, but it might be nice to give the user a preview of what they are about to download.

![](http://i.hawth.ca/s/776EYliH.png)

Marking this as WIP, because it should be updated when #1524 is merged
