### PR TITLE
validate empty option values to display new variant form

### DIFF
--- a/backend/app/controllers/spree/admin/variants_controller.rb
+++ b/backend/app/controllers/spree/admin/variants_controller.rb
@@ -3,6 +3,7 @@ module Spree
     class VariantsController < ResourceController
       belongs_to 'spree/product', find_by: :slug
       new_action.before :new_before
+      before_action :redirect_on_empty_option_values, only: [:new]
       before_action :load_data, only: [:new, :create, :edit, :update]
 
       # override the destroy method to set deleted_at value
@@ -47,6 +48,10 @@ module Spree
 
       def variant_includes
         [{ option_values: :option_type }, :default_price]
+      end
+
+      def redirect_on_empty_option_values
+        redirect_to admin_product_variants_url(params[:product_id]) if @product.empty_option_values?
       end
     end
   end


### PR DESCRIPTION
Admins users are able to add a new product variant only if the product has option types with option values but they are able to see the new product variant form if the access from the URL.
