### PR TITLE
Fix css stock item informations inside td.

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/sections/_stock_management.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/_stock_management.scss
@@ -10,6 +10,7 @@
     > tr.stock-item-edit-row {
       td {
         background-color: $color-tbl-even;
+        border-left: none;
       }
       &:nth-child(even) td {
         /* An nth-even child is actually an odd row */
@@ -39,4 +40,9 @@
     }
   }
 
+  tr:hover {
+    .stock-variant-field-table td {
+      background-color: transparent;
+    }
+  }
 }


### PR DESCRIPTION
The stock items informations are not well formatted. 

![schermata 2016-10-20 alle 23 06 22](https://cloud.githubusercontent.com/assets/387690/19603584/016dcd96-97b2-11e6-8c0b-77662d116330.png)

Fixed in scss.
