### PR TITLE
check empty option values just in one query

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -215,9 +215,7 @@ module Spree
 
     # @return [Boolean] true if there are no option values
     def empty_option_values?
-      options.empty? || options.any? do |opt|
-        opt.option_type.option_values.empty?
-      end
+      options.empty? || !option_types.left_joins(:option_values).where('spree_option_values.id IS NULL').empty?
     end
 
     # @param property_name [String] the name of the property to find


### PR DESCRIPTION
If a product has for example 10 option types assigned, the `empty_option_values?` method will execute the same amount of queries in order to know if there are option types without option values, this could be performed in a single query.
