### PR TITLE
Upload images in admin with drag and drop

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/handlebars_extensions.coffee
+++ b/backend/app/assets/javascripts/spree/backend/handlebars_extensions.coffee
@@ -1,11 +1,19 @@
 #= require handlebars
 
-Handlebars.registerHelper "t", (key)->
-  if Spree.translations[key]
-    Spree.translations[key]
-  else
-    console.error "No translation found for #{key}."
-    key
+# Resolves string keys with dots in a deeply nested object
+# http://stackoverflow.com/a/22129960/4405214
+resolveObject = (path, obj) ->
+  path.split('.').reduce ((prev, curr) ->
+    if prev then prev[curr] else undefined
+  ), obj || self
+
+
+Handlebars.registerHelper "t", (key) ->
+  translation = resolveObject key, Spree.translations
+  return translation if translation
+
+  console.error "No translation found for #{key}."
+  key
 
 Handlebars.registerHelper "admin_url", ->
   Spree.pathFor("admin")

--- a/backend/app/assets/javascripts/spree/backend/images/upload.js
+++ b/backend/app/assets/javascripts/spree/backend/images/upload.js
@@ -162,6 +162,8 @@ Spree.prepareImageUploader = function () {
       "clear" : "clear"
     },
 
+    className: 'col-sm-6 col-md-4 margin-bottom-one',
+
     attributes: function() {
       return {
         "data-upload-id": this.model.cid

--- a/backend/app/assets/javascripts/spree/backend/images/upload.js
+++ b/backend/app/assets/javascripts/spree/backend/images/upload.js
@@ -107,6 +107,7 @@ Spree.prepareImageUploader = function () {
     template: _.template(progressTmpl),
 
     initialize: function() {
+      this.listenTo(this.model, 'change:progress', this.updateProgressBar);
       this.listenTo(this.model, 'change', this.render);
       this.listenTo(this.model, 'destroy', this.remove);
     },
@@ -122,7 +123,17 @@ Spree.prepareImageUploader = function () {
     },
 
     render: function() {
+      // Skip progress bar update
+      var changedAttrs = Object.keys(this.model.changed);
+      if(changedAttrs.length === 1 && changedAttrs[0] == 'progress') return this;
+
       this.el.innerHTML = this.template(this.model.attributes);
+      return this;
+    },
+
+    updateProgressBar: function() {
+      var progressBar = this.el.querySelector('progress');
+      progressBar.value = progressBar.innerHTML = this.model.get('progress');
       return this;
     },
 

--- a/backend/app/assets/javascripts/spree/backend/images/upload.js
+++ b/backend/app/assets/javascripts/spree/backend/images/upload.js
@@ -11,8 +11,8 @@ Spree.prepareImageUploader = function () {
     },
     support = {
       filereader: document.getElementById('filereader'),
-      formdata: document.getElementById('formdata'),
-      progress: document.getElementById('progress')
+      formdata:   document.getElementById('formdata'),
+      progress:   document.getElementById('progress')
     },
     acceptedTypes = {
       'image/png': true,
@@ -51,11 +51,11 @@ Spree.prepareImageUploader = function () {
   function upload(file) {
     if (!tests.formdata) return;
 
-    var formData = new FormData(),
+    var formData    = new FormData(),
         progressRow = progressTmpl.cloneNode(true),
         progressBar = progressRow.querySelector('progress'),
-        summary = progressRow.querySelector('summary'),
-        uploadedId = Math.round((Math.random()*1000000)).toString();
+        summary     = progressRow.querySelector('summary'),
+        uploadedId  = Math.round((Math.random()*1000000)).toString();
 
     formData.append('image[attachment]', file);
     formData.append('image[viewable_id]', variantId);
@@ -90,7 +90,7 @@ Spree.prepareImageUploader = function () {
     }).done(function() {
       progressBar.value = progressBar.innerHTML = 100;
     }).error(function() {
-      progressRow.querySelector('error').classList.remove('hidden') ;
+      progressRow.querySelector('error').classList.remove('hidden');
     });
   }
 

--- a/backend/app/assets/javascripts/spree/backend/images/upload.js
+++ b/backend/app/assets/javascripts/spree/backend/images/upload.js
@@ -23,7 +23,7 @@ Spree.prepareImageUploader = function () {
     },
 
     upload: function(file) {
-      if (!this.tests.formdata) return;
+      if (!FormData) return;
 
       var progressModel = new ProgressModel({file: file});
       progressModel.previewFile();
@@ -33,29 +33,26 @@ Spree.prepareImageUploader = function () {
       this.progressZone.appendChild(progressView.render().el);
     },
 
-    onDragOver: function() {
-      this.el.className = 'hover';
-      return false;
+    dragClass: 'with-images',
+
+    onDragOver: function(e) {
+      this.el.classList.add(this.dragClass);
+      e.preventDefault();
     },
 
     onDragLeave: function() {
-      this.el.className = '';
-      return false;
+      this.el.classList.remove(this.dragClass);
     },
 
     onDrop: function(e) {
-      this.el.className = '';
+      this.el.classList.remove(this.dragClass);
       e.preventDefault();
 
-      for (var i = 0; i < e.originalEvent.dataTransfer.files.length; i++) {
-        this.upload(e.originalEvent.dataTransfer.files[i]);
-      }
+      _.each(e.originalEvent.dataTransfer.files, this.upload, this);
     },
 
     onFileBrowserSelect: function(e) {
-      for (var i = 0; i < e.target.files.length; i++) {
-        this.upload(e.target.files[i]);
-      }
+      _.each(e.target.files, this.upload, this);
     },
 
     tests: {
@@ -153,7 +150,7 @@ Spree.prepareImageUploader = function () {
     tagName: "div",
 
     // Cache the template function for a single item.
-    template: _.template(document.getElementById('upload-progress-tmpl').innerHTML),
+    template: HandlebarsTemplates["products/upload_progress"],
 
     initialize: function() {
       this.listenTo(this.model, 'change:progress', this.updateProgressBar);

--- a/backend/app/assets/javascripts/spree/backend/images/upload.js
+++ b/backend/app/assets/javascripts/spree/backend/images/upload.js
@@ -23,7 +23,7 @@ Spree.prepareImageUploader = function () {
     progressZone = document.getElementById('progress-zone'),
     progressTmpl = document.getElementById('upload-progress-tmpl').innerHTML,
     uploadForm   = document.getElementById('upload-form'),
-    variantId    = uploadForm.querySelector('input[name="image[viewable_id]"').value;
+    variantId    = uploadForm.querySelector('input[name="image[viewable_id]"]').value;
 
 
   var ProgressModel = Backbone.Model.extend({
@@ -94,7 +94,7 @@ Spree.prepareImageUploader = function () {
         }
       }).done(function() {
         that.set({progress: 100})
-      }).error(function() {
+      }).error(function(jqXHR, textStatus, errorThrown) {
         that.set({serverError: true});
       });
     }

--- a/backend/app/assets/javascripts/spree/backend/images/upload.js
+++ b/backend/app/assets/javascripts/spree/backend/images/upload.js
@@ -1,0 +1,108 @@
+// Inspired by: http://html5demos.com/dnd-upload
+Spree.prepareImageUploader = function () {
+  var uploadZone = document.getElementById('upload-zone');
+  if(!uploadZone) return;
+
+  var tests = {
+      filereader: typeof FileReader != 'undefined',
+      dnd: 'draggable' in document.createElement('span'),
+      formdata: !!window.FormData,
+      progress: "upload" in new XMLHttpRequest
+    },
+    support = {
+      filereader: document.getElementById('filereader'),
+      formdata: document.getElementById('formdata'),
+      progress: document.getElementById('progress')
+    },
+    acceptedTypes = {
+      'image/png': true,
+      'image/jpeg': true,
+      'image/gif': true
+    },
+    progressTmpl = document.createElement('div'),
+    progressZone = document.getElementById('progress-zone'),
+    fileupload   = document.getElementById('upload-form'),
+    csrfToken    = document.querySelector('meta[name="csrf-token"]').content,
+    variantId    = fileupload.querySelector('input[name="image[viewable_id]"').value;
+
+
+  // Parse the progress template
+  progressTmpl.innerHTML = document.getElementById('progress-tmpl').innerHTML;
+
+  "filereader formdata progress".split(' ').forEach(function (api) {
+    support[api].className = (tests[api] === false) ? 'red' : 'hidden'
+  });
+
+  function previewFile(file, progressRow) {
+    if (tests.filereader === true && acceptedTypes[file.type] === true) {
+      var reader = new FileReader();
+      reader.onload = function (event) {
+        var image = progressRow.querySelector('img');
+        image.src = event.target.result;
+      };
+
+      reader.readAsDataURL(file);
+    }  else {
+      progressRow.innerHTML += '<p>Uploaded ' + file.name + ' ' + (file.size ? (file.size/1024|0) + 'K' : '');
+      console.log(file);
+    }
+  }
+
+  function upload(file) {
+    if (!tests.formdata) return;
+
+    var formData = new FormData(),
+        progressRow = progressTmpl.cloneNode(true),
+        progressBar = progressRow.querySelector('progress'),
+        details = progressRow.querySelector('details');
+
+    formData.append('image[attachment]', file);
+    formData.append('image[viewable_id]', variantId);
+
+    previewFile(file, progressRow);
+    details.innerHTML = file.name;
+    progressZone.appendChild(progressRow);
+
+    // send the image to the server
+    var xhr = new XMLHttpRequest();
+    xhr.open('POST', window.location.pathname);
+    xhr.setRequestHeader('X-CSRF-Token', csrfToken);
+    xhr.onload = function() {
+      progressBar.value = progressBar.innerHTML = 100;
+    };
+
+    if (tests.progress) {
+      xhr.upload.onprogress = function (event) {
+        if (event.lengthComputable) {
+          var complete = (event.loaded / event.total * 100 | 0);
+          progressBar.value = progressBar.innerHTML = complete;
+        }
+      }
+    }
+
+    xhr.send(formData);
+  }
+
+  if (tests.dnd) {
+    uploadZone.ondragover = function () { this.className = 'hover'; return false; };
+    uploadZone.ondragend = function () { this.className = ''; return false; };
+    uploadZone.ondrop = function (e) {
+      this.className = '';
+      e.preventDefault();
+      for (var i = 0; i < e.dataTransfer.files.length; i++) {
+        upload(e.dataTransfer.files[i]);
+      }
+    }
+  } else {
+    fileupload.className = 'hidden';
+    fileupload.querySelector('input').onchange = function () {
+      for (var i = 0; i < this.files.length; i++) {
+        upload(this.files[i]);
+      }
+    };
+  }
+};
+
+Spree.ready(function () {
+  Spree.prepareImageUploader();
+});

--- a/backend/app/assets/javascripts/spree/backend/templates/products/upload_progress.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/products/upload_progress.hbs
@@ -1,11 +1,12 @@
-<div class="row row-xs-center margin-bottom-one">
-  <div class="col-xs-2">
-    <img src="{{ imgSrc }}" class="img-fluid">
-  </div>
+<div class="card progress-card">
+  <img src="{{ imgSrc }}" class="card-img-top img-fluid">
 
-  <div class="col-xs-10">
+  <div class="card-block">
     <progress min="0" max="100" value="{{ progress }}">{{ progress }}</progress>
+
     <summary>{{ summary }}</summary>
-    <error class="red {{#unless serverError}} hidden {{/unless}}">{{t 'admin.images.index.image_process_failed' }}</error>
+    <br>
+
+    <error class="text-danger {{#unless serverError}} hidden {{/unless}}">{{t 'admin.images.index.image_process_failed' }}</error>
   </div>
 </div>

--- a/backend/app/assets/javascripts/spree/backend/templates/products/upload_progress.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/products/upload_progress.hbs
@@ -1,0 +1,11 @@
+<div class="row row-xs-center margin-bottom-one">
+  <div class="col-xs-2">
+    <img src="{{ imgSrc }}" class="img-fluid">
+  </div>
+
+  <div class="col-xs-10">
+    <progress min="0" max="100" value="{{ progress }}">{{ progress }}</progress>
+    <summary>{{ summary }}</summary>
+    <error class="red {{#unless serverError}} hidden {{/unless}}">Server failed to process the image</error>
+  </div>
+</div>

--- a/backend/app/assets/javascripts/spree/backend/templates/products/upload_progress.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/products/upload_progress.hbs
@@ -6,6 +6,6 @@
   <div class="col-xs-10">
     <progress min="0" max="100" value="{{ progress }}">{{ progress }}</progress>
     <summary>{{ summary }}</summary>
-    <error class="red {{#unless serverError}} hidden {{/unless}}">Server failed to process the image</error>
+    <error class="red {{#unless serverError}} hidden {{/unless}}">{{t 'admin.images.index.image_process_failed' }}</error>
   </div>
 </div>

--- a/backend/app/assets/stylesheets/spree/backend/sections/_products.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/_products.scss
@@ -55,3 +55,8 @@ progress {
 .margin-bottom-one {
   margin-bottom: 1rem;
 }
+
+.progress-card {
+  height: 100%;
+  padding: 1rem;
+}

--- a/backend/app/assets/stylesheets/spree/backend/sections/_products.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/_products.scss
@@ -43,7 +43,7 @@ div[data-hook="admin_products_index_search_buttons"] {
   text-align: center;
   margin-bottom: 1.5rem;
 
-  &.hover {
+  &.with-images {
     border-color: $color-success;
   }
 }

--- a/backend/app/assets/stylesheets/spree/backend/sections/_products.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/_products.scss
@@ -35,3 +35,23 @@ div[data-hook="admin_products_index_search_buttons"] {
     color: $color-2;
   }
 }
+
+#upload-zone {
+  border: 10px dashed $color-border;
+  min-height: 100px;
+  padding: 1rem 5rem;
+  text-align: center;
+  margin-bottom: 1.5rem;
+
+  &.hover {
+    border-color: $color-success;
+  }
+}
+
+progress {
+  width: 100%;
+}
+
+.margin-bottom-one {
+  margin-bottom: 1rem;
+}

--- a/backend/app/views/spree/admin/images/_image_row.html.erb
+++ b/backend/app/views/spree/admin/images/_image_row.html.erb
@@ -1,0 +1,22 @@
+<tr id="<%= spree_dom_id image %>" data-hook="images_row" class="<%= cycle('odd', 'even')%>">
+  <td class="no-border">
+    <% if can?(:update_positions, Spree::Image) %>
+      <span class="handle"></span>
+    <% end %>
+  </td>
+  <td>
+    <%= link_to image_tag(image.attachment.url(:mini)), image.attachment.url(:product) %>
+  </td>
+  <% if @product.has_variants? %>
+    <td><%= options_text_for(image) %></td>
+  <% end %>
+  <td><%= image.alt %></td>
+  <td class="actions">
+    <% if can?(:update, image) %>
+      <%= link_to_with_icon 'edit', Spree.t('actions.edit'), edit_admin_product_image_url(@product, image), :no_text => true, :data => {:action => 'edit'} %>
+    <% end %>
+    <% if can?(:destroy, image) %>
+      <%= link_to_delete image, { :url => admin_product_image_url(@product, image), :no_text => true } %>
+    <% end %>
+  </td>
+</tr>

--- a/backend/app/views/spree/admin/images/create.js.erb
+++ b/backend/app/views/spree/admin/images/create.js.erb
@@ -1,4 +1,4 @@
-var uploadedRow = $('[data-upload-id="<%= params[:upload_id] %>"');
+var uploadedRow = $('[data-upload-id="<%= params[:upload_id] %>"]');
 
 <% if @image.persisted? %>
   uploadedRow.trigger('clear');

--- a/backend/app/views/spree/admin/images/create.js.erb
+++ b/backend/app/views/spree/admin/images/create.js.erb
@@ -1,11 +1,9 @@
+var uploadedRow = $('[data-uploaded-id="<%=params[:uploaded_id]%>"');
+
 <% if @image.persisted? %>
-  $('[data-uploaded-id="<%=params[:uploaded_id]%>"').slideUp();
-  $('[data-hook="images_table"] tbody').append('<%= j render partial: "image_row", locals: {image: @image } %>');
-  $('select.select2').select2({
-    allowClear: true,
-    dropdownAutoWidth: true
-  });
+  uploadedRow.slideUp();
+  $('#images-table').removeClass('hidden').find('tbody').append('<%= j render partial: "image_row", locals: {image: @image } %>');
   $('.no-objects-found').hide();
 <% else %>
-  console.log('<%= j @image.errors.full_messages.join("<br>") %>');
+  uploadedRow.find('error').text('<%= j @image.errors.full_messages.join("<br>") %>');
 <% end %>

--- a/backend/app/views/spree/admin/images/create.js.erb
+++ b/backend/app/views/spree/admin/images/create.js.erb
@@ -5,5 +5,5 @@ var uploadedRow = $('[data-upload-id="<%= params[:upload_id] %>"]');
   $('#images-table').removeClass('hidden').find('tbody').append('<%= j render partial: "image_row", locals: {image: @image } %>');
   $('.no-objects-found').hide();
 <% else %>
-  uploadedRow.find('error').text('<%= j @image.errors.full_messages.join("<br>") %>');
+  uploadedRow.find('error').removeClass('hidden').html('<%= j @image.errors.full_messages.join("<br>").html_safe %>');
 <% end %>

--- a/backend/app/views/spree/admin/images/create.js.erb
+++ b/backend/app/views/spree/admin/images/create.js.erb
@@ -1,0 +1,11 @@
+<% if @image.persisted? %>
+  $('[data-uploaded-id="<%=params[:uploaded_id]%>"').slideUp();
+  $('[data-hook="images_table"] tbody').append('<%= j render partial: "image_row", locals: {image: @image } %>');
+  $('select.select2').select2({
+    allowClear: true,
+    dropdownAutoWidth: true
+  });
+  $('.no-objects-found').hide();
+<% else %>
+  console.log('<%= j @image.errors.full_messages.join("<br>") %>');
+<% end %>

--- a/backend/app/views/spree/admin/images/create.js.erb
+++ b/backend/app/views/spree/admin/images/create.js.erb
@@ -1,7 +1,7 @@
-var uploadedRow = $('[data-uploaded-id="<%=params[:uploaded_id]%>"');
+var uploadedRow = $('[data-upload-id="<%= params[:upload_id] %>"');
 
 <% if @image.persisted? %>
-  uploadedRow.slideUp();
+  uploadedRow.trigger('clear');
   $('#images-table').removeClass('hidden').find('tbody').append('<%= j render partial: "image_row", locals: {image: @image } %>');
   $('.no-objects-found').hide();
 <% else %>

--- a/backend/app/views/spree/admin/images/index.html.erb
+++ b/backend/app/views/spree/admin/images/index.html.erb
@@ -11,6 +11,46 @@
 
 <div id="images" data-hook></div>
 
+<style>
+  #upload-zone { border: 10px dashed #ccc; height: 100px; padding: 2rem 5rem; text-align: center; }
+  #upload-zone.hover { border: 10px dashed #0c0; }
+  .margin-bottom-one { margin-bottom: 1rem; }
+  progress { width: 100%; }
+  progress:after { content: '%'; }
+</style>
+
+<fieldset>
+  <legend align="center"><%= Spree.t(:new_image) %></legend>
+
+  <p id="upload-zone">
+    Drag images from your desktop on to the drop zone to upload to the server.
+  </p>
+
+  <%= form_for [:admin, @product, Spree::Image.new],
+      :html => { :multipart => true, id: 'upload-form', class: 'hidden' } do |f| %>
+    <label>Drag &amp; drop not supported, but you can still upload via this input field:<br>
+      <%= f.file_field :attachment %>
+      <%= f.hidden_field :viewable_id, value: @product.master.id %>
+    </label>
+  <% end %>
+
+  <p id="filereader">File API &amp; FileReader API not supported</p>
+  <p id="formdata">XHR2's FormData is not supported</p>
+  <p id="progress">XHR2's upload progress isn't supported</p>
+
+  <script id="progress-tmpl" type="text/x-progress-template">
+    <div class="row row-xs-center margin-bottom-one">
+      <div class="col-xs-10">
+        <progress min="0" max="100" value="0">0</progress>
+        <details></details>
+      </div>
+      <div class="col-xs-2"><img src="" class="img-fluid"></div>
+    </div>
+  </script>
+
+  <div id="progress-zone"></div>
+</fieldset>
+
 <% unless @product.images.any? || @product.variant_images.any? %>
   <div class="no-objects-found">
     <%= Spree.t(:no_images_found) %>.

--- a/backend/app/views/spree/admin/images/index.html.erb
+++ b/backend/app/views/spree/admin/images/index.html.erb
@@ -25,7 +25,7 @@
 </style>
 
 <fieldset>
-  <legend align="center"><%= Spree.t(:new_image) %></legend>
+  <legend align="center"><%= t(".upload_images") %></legend>
 
   <div id="upload-zone">
     <%= form_for [:admin, @product, Spree::Image.new],

--- a/backend/app/views/spree/admin/images/index.html.erb
+++ b/backend/app/views/spree/admin/images/index.html.erb
@@ -12,8 +12,14 @@
 <div id="images" data-hook></div>
 
 <style>
-  #upload-zone { border: 10px dashed #ccc; height: 100px; padding: 1rem 5rem; text-align: center; }
-  #upload-zone.hover { border: 10px dashed #0c0; }
+  #upload-zone {
+    border: 10px dashed #ccc;
+    min-height: 100px;
+    padding: 1rem 5rem;
+    text-align: center;
+    margin-bottom: 1.5rem;
+  }
+  #upload-zone.hover { border-color: #0c0; }
   .margin-bottom-one { margin-bottom: 1rem; }
   progress { width: 100%; }
 </style>
@@ -21,7 +27,7 @@
 <fieldset>
   <legend align="center"><%= Spree.t(:new_image) %></legend>
 
-  <div id="upload-zone" class="margin-bottom-one">
+  <div id="upload-zone">
     <%= form_for [:admin, @product, Spree::Image.new],
         :html => { :multipart => true, id: 'upload-form' } do |f| %>
       <label>
@@ -37,14 +43,14 @@
   <p id="formdata">XHR2's FormData is not supported</p>
   <p id="progress">XHR2's upload progress isn't supported</p>
 
-  <script id="progress-tmpl" type="text/x-progress-template">
+  <script type="text/template" id="upload-progress-tmpl">
     <div class="row row-xs-center margin-bottom-one">
       <div class="col-xs-10">
-        <progress min="0" max="100" value="0">0</progress>
-        <summary></summary>
-        <error class="red hidden">Server failed to process the image</error>
+        <progress min="0" max="100" value="{{= progress }}">{{= progress }}</progress>
+        <summary>{{= summary }}</summary>
+        <error class="red {{ if(!serverError) print('hidden'); }}">Server failed to process the image</error>
       </div>
-      <div class="col-xs-2"><img src="" class="img-fluid"></div>
+      <div class="col-xs-2"><img src="{{= imgSrc }}" class="img-fluid"></div>
     </div>
   </script>
 

--- a/backend/app/views/spree/admin/images/index.html.erb
+++ b/backend/app/views/spree/admin/images/index.html.erb
@@ -16,7 +16,6 @@
   #upload-zone.hover { border: 10px dashed #0c0; }
   .margin-bottom-one { margin-bottom: 1rem; }
   progress { width: 100%; }
-  progress:after { content: '%'; }
 </style>
 
 <fieldset>
@@ -52,34 +51,36 @@
   <div id="progress-zone"></div>
 </fieldset>
 
-  <table class="index sortable" data-hook="images_table" data-sortable-link="<%= update_positions_admin_product_images_url(@product) %>">
-    <colgroup>
-      <col style="width: 5%">
-      <col style="width: 10%">
+<% no_images = @product.images.empty? && @product.variant_images.empty? %>
+
+<table class="index sortable <%= 'hidden' if no_images %>" id="images-table" data-hook="images_table" data-sortable-link="<%= update_positions_admin_product_images_url(@product) %>">
+  <colgroup>
+    <col style="width: 5%">
+    <col style="width: 10%">
+    <% if @product.has_variants? %>
+      <col style="width: 25%">
+    <% end %>
+    <col style="width: 45%">
+    <col style="width: 15%">
+  </colgroup>
+  <thead>
+    <tr data-hook="images_header">
+      <th colspan="2"><%= Spree.t(:thumbnail) %></th>
       <% if @product.has_variants? %>
-        <col style="width: 25%">
+        <th><%= Spree::Variant.model_name.human %></th>
       <% end %>
-      <col style="width: 45%">
-      <col style="width: 15%">
-    </colgroup>
-    <thead>
-      <tr data-hook="images_header">
-        <th colspan="2"><%= Spree.t(:thumbnail) %></th>
-        <% if @product.has_variants? %>
-          <th><%= Spree::Variant.model_name.human %></th>
-        <% end %>
-        <th><%= Spree::Image.human_attribute_name(:alt) %></th>
-        <th class="actions"></th>
-      </tr>
-    </thead>
+      <th><%= Spree::Image.human_attribute_name(:alt) %></th>
+      <th class="actions"></th>
+    </tr>
+  </thead>
 
-    <tbody>
-      <%= render partial: 'image_row', collection: @product.variant_images, as: :image %>
-    </tbody>
-  </table>
+  <tbody>
+    <%= render partial: 'image_row', collection: @product.variant_images, as: :image %>
+  </tbody>
+</table>
 
-  <% if @product.images.empty? && @product.variant_images.empty? %>
-    <div class="no-objects-found">
-      <%= Spree.t(:no_images_found) %>.
-    </div>
-  <% end %>
+<% if no_images %>
+  <div class="no-objects-found">
+    <%= Spree.t(:no_images_found) %>.
+  </div>
+<% end %>

--- a/backend/app/views/spree/admin/images/index.html.erb
+++ b/backend/app/views/spree/admin/images/index.html.erb
@@ -11,19 +11,6 @@
 
 <div id="images" data-hook></div>
 
-<style>
-  #upload-zone {
-    border: 10px dashed #ccc;
-    min-height: 100px;
-    padding: 1rem 5rem;
-    text-align: center;
-    margin-bottom: 1.5rem;
-  }
-  #upload-zone.hover { border-color: #0c0; }
-  .margin-bottom-one { margin-bottom: 1rem; }
-  progress { width: 100%; }
-</style>
-
 <fieldset>
   <legend align="center"><%= t(".upload_images") %></legend>
 
@@ -31,7 +18,7 @@
     <%= form_for [:admin, @product, Spree::Image.new],
         :html => { :multipart => true, id: 'upload-form' } do |f| %>
       <label>
-        <p>Drag images from your desktop on to the drop zone to upload to the server.</p>
+        <p><%= t(".drag_images_to_upload") %></p>
         <%= f.file_field :attachment, multiple: '' %>
         <%= f.hidden_field :viewable_id, value: @product.master.id %>
       </label>
@@ -45,12 +32,15 @@
 
   <script type="text/template" id="upload-progress-tmpl">
     <div class="row row-xs-center margin-bottom-one">
+      <div class="col-xs-2">
+        <img src="{{= imgSrc }}" class="img-fluid">
+      </div>
+
       <div class="col-xs-10">
         <progress min="0" max="100" value="{{= progress }}">{{= progress }}</progress>
         <summary>{{= summary }}</summary>
         <error class="red {{ if(!serverError) print('hidden'); }}">Server failed to process the image</error>
       </div>
-      <div class="col-xs-2"><img src="{{= imgSrc }}" class="img-fluid"></div>
     </div>
   </script>
 

--- a/backend/app/views/spree/admin/images/index.html.erb
+++ b/backend/app/views/spree/admin/images/index.html.erb
@@ -12,7 +12,7 @@
 <div id="images" data-hook></div>
 
 <style>
-  #upload-zone { border: 10px dashed #ccc; height: 100px; padding: 2rem 5rem; text-align: center; }
+  #upload-zone { border: 10px dashed #ccc; height: 100px; padding: 1rem 5rem; text-align: center; }
   #upload-zone.hover { border: 10px dashed #0c0; }
   .margin-bottom-one { margin-bottom: 1rem; }
   progress { width: 100%; }
@@ -22,17 +22,17 @@
 <fieldset>
   <legend align="center"><%= Spree.t(:new_image) %></legend>
 
-  <p id="upload-zone">
-    Drag images from your desktop on to the drop zone to upload to the server.
-  </p>
+  <div id="upload-zone" class="margin-bottom-one">
+    <%= form_for [:admin, @product, Spree::Image.new],
+        :html => { :multipart => true, id: 'upload-form' } do |f| %>
+      <label>
+        <p>Drag images from your desktop on to the drop zone to upload to the server.</p>
+        <%= f.file_field :attachment, multiple: '' %>
+        <%= f.hidden_field :viewable_id, value: @product.master.id %>
+      </label>
+    <% end %>
+  </div>
 
-  <%= form_for [:admin, @product, Spree::Image.new],
-      :html => { :multipart => true, id: 'upload-form', class: 'hidden' } do |f| %>
-    <label>Drag &amp; drop not supported, but you can still upload via this input field:<br>
-      <%= f.file_field :attachment %>
-      <%= f.hidden_field :viewable_id, value: @product.master.id %>
-    </label>
-  <% end %>
 
   <p id="filereader">File API &amp; FileReader API not supported</p>
   <p id="formdata">XHR2's FormData is not supported</p>
@@ -42,7 +42,8 @@
     <div class="row row-xs-center margin-bottom-one">
       <div class="col-xs-10">
         <progress min="0" max="100" value="0">0</progress>
-        <details></details>
+        <summary></summary>
+        <error class="red hidden">Server failed to process the image</error>
       </div>
       <div class="col-xs-2"><img src="" class="img-fluid"></div>
     </div>
@@ -51,11 +52,6 @@
   <div id="progress-zone"></div>
 </fieldset>
 
-<% unless @product.images.any? || @product.variant_images.any? %>
-  <div class="no-objects-found">
-    <%= Spree.t(:no_images_found) %>.
-  </div>
-<% else %>
   <table class="index sortable" data-hook="images_table" data-sortable-link="<%= update_positions_admin_product_images_url(@product) %>">
     <colgroup>
       <col style="width: 5%">
@@ -78,30 +74,12 @@
     </thead>
 
     <tbody>
-      <% (@product.variant_images).each do |image| %>
-        <tr id="<%= spree_dom_id image %>" data-hook="images_row" class="<%= cycle('odd', 'even')%>">
-          <td class="no-border">
-            <% if can?(:update_positions, Spree::Image) %>
-              <span class="handle"></span>
-            <% end %>
-          </td>
-          <td>
-            <%= link_to image_tag(image.attachment.url(:mini)), image.attachment.url(:product) %>
-          </td>
-          <% if @product.has_variants? %>
-            <td><%= options_text_for(image) %></td>
-          <% end %>
-          <td><%= image.alt %></td>
-          <td class="actions">
-            <% if can?(:update, image) %>
-              <%= link_to_with_icon 'edit', Spree.t('actions.edit'), edit_admin_product_image_url(@product, image), :no_text => true, :data => {:action => 'edit'} %>
-            <% end %>
-            <% if can?(:destroy, image) %>
-              <%= link_to_delete image, { :url => admin_product_image_url(@product, image), :no_text => true } %>
-            <% end %>
-          </td>
-        </tr>
-      <% end %>
+      <%= render partial: 'image_row', collection: @product.variant_images, as: :image %>
     </tbody>
   </table>
-<% end %>
+
+  <% if @product.images.empty? && @product.variant_images.empty? %>
+    <div class="no-objects-found">
+      <%= Spree.t(:no_images_found) %>.
+    </div>
+  <% end %>

--- a/backend/app/views/spree/admin/images/index.html.erb
+++ b/backend/app/views/spree/admin/images/index.html.erb
@@ -30,20 +30,6 @@
   <p id="formdata">XHR2's FormData is not supported</p>
   <p id="progress">XHR2's upload progress isn't supported</p>
 
-  <script type="text/template" id="upload-progress-tmpl">
-    <div class="row row-xs-center margin-bottom-one">
-      <div class="col-xs-2">
-        <img src="{{= imgSrc }}" class="img-fluid">
-      </div>
-
-      <div class="col-xs-10">
-        <progress min="0" max="100" value="{{= progress }}">{{= progress }}</progress>
-        <summary>{{= summary }}</summary>
-        <error class="red {{ if(!serverError) print('hidden'); }}">Server failed to process the image</error>
-      </div>
-    </div>
-  </script>
-
   <div id="progress-zone"></div>
 </fieldset>
 

--- a/backend/app/views/spree/admin/images/index.html.erb
+++ b/backend/app/views/spree/admin/images/index.html.erb
@@ -30,7 +30,7 @@
   <p id="formdata">XHR2's FormData is not supported</p>
   <p id="progress">XHR2's upload progress isn't supported</p>
 
-  <div id="progress-zone"></div>
+  <div id="progress-zone" class="row"></div>
 </fieldset>
 
 <% no_images = @product.images.empty? && @product.variant_images.empty? %>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -748,6 +748,7 @@ en:
           no_cart_tax_country: "No taxes on carts without address"
       images:
         index:
+          drag_images_to_upload: Drag images from your desktop on to the drop zone to upload
           upload_images: Upload Images
       payments:
         source_forms:

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -746,6 +746,9 @@ en:
       general_settings:
         edit:
           no_cart_tax_country: "No taxes on carts without address"
+      images:
+        index:
+          upload_images: Upload Images
       payments:
         source_forms:
           storecredit:

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -749,6 +749,7 @@ en:
       images:
         index:
           drag_images_to_upload: Drag images from your desktop on to the drop zone to upload
+          image_process_failed: Server failed to process the image
           upload_images: Upload Images
       payments:
         source_forms:


### PR DESCRIPTION
I wanted to see how much effort it would be to do a modern drag and drop image upload (#1518), and that pretty much does it. Code is ~~not~~ ideal, but wanted to post it here if somebody wants to try it out, have any comments, etc ..

In summary:
- The JavaScript is just about ~~100 lines~~ (grew to ~ 200 with Backbone), even non-coffee-script (as I started with a non coffee example, but can convert it around). 
- Code I started from includes tests for feature detection (Drag and Drop, File Upload, Progress Bar). I decided to leave them for reference, but they can be removed, as I think that admin users should run the very latest of browsers, and if they don't - they can use the old functionality.
- All of the old way of uploading images is in place, so if someone is stuck with some unsupported functions, they can always fallback to that.
- There's a `javascript` response from the server, which appends a row in the images table .. not sure if it's an accepted practice
- I need to add a capybara test, but shouldn't be difficult, as I have also left in place a Browse button if somebody doesn't want to drag and drop
- Image is automatically assigned the master variant
  - so to make it a truly nice experience, the rows in the images table will have an select dropdown field with ability to change the variant, and click a Tick button on the right, similarly to the Stock Items page, and other in-place row edits.

And some pictures:

![screenshot from 2016-10-27 23 30 25](https://cloud.githubusercontent.com/assets/1651750/19788196/e5890608-9c9e-11e6-9176-a94803ea2ecf.png)

![screenshot from 2016-10-27 23 40 48](https://cloud.githubusercontent.com/assets/1651750/19788195/e5867a82-9c9e-11e6-8452-493f017181d4.png)

or in boxes:

![screenshot from 2016-11-03 21 40 05](https://cloud.githubusercontent.com/assets/1651750/19986643/6df43ae2-a20f-11e6-8773-0d30bef3e212.png)
