### PR TITLE
Use new BreadcrumbList Schema.org markup

### DIFF
--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -66,8 +66,8 @@ module Spree
       nil
     end
 
-    def taxon_breadcrumbs(taxon, separator = "&nbsp;&raquo;&nbsp;", breadcrumb_class = "inline")
-      return "" if current_page?("/") || taxon.nil?
+    def taxon_breadcrumbs(taxon, separator = '&nbsp;&raquo;&nbsp;', breadcrumb_class = 'inline')
+      return '' if current_page?('/') || taxon.nil?
 
       crumbs = [[Spree.t(:home), spree.root_path]]
 
@@ -81,15 +81,15 @@ module Spree
 
       separator = raw(separator)
 
-      crumbs.map! do |crumb|
-        content_tag(:li, itemscope: "itemscope", itemtype: "http://data-vocabulary.org/Breadcrumb") do
-          link_to(crumb.last, itemprop: "url") do
-            content_tag(:span, crumb.first, itemprop: "title")
+      items = crumbs.each_with_index.collect do |crumb, i|
+        content_tag(:li, itemprop: 'itemListElement', itemscope: '', itemtype: 'https://schema.org/ListItem') do
+          link_to(crumb.last, itemprop: 'item') do
+            content_tag(:span, crumb.first, itemprop: 'name') + tag('meta', { itemprop: 'position', content: (i+1).to_s }, false, false)
           end + (crumb == crumbs.last ? '' : separator)
         end
       end
 
-      content_tag(:nav, content_tag(:ul, raw(crumbs.map(&:mb_chars).join), class: breadcrumb_class), id: 'breadcrumbs', class: 'sixteen columns')
+      content_tag(:nav, content_tag(:ol, raw(items.map(&:mb_chars).join), class: breadcrumb_class, itemscope: '', itemtype: 'https://schema.org/BreadcrumbList'), id: 'breadcrumbs', class: 'sixteen columns')
     end
 
     def taxons_tree(root_taxon, current_taxon, max_level = 1)


### PR DESCRIPTION
The Breadcrumb lists currently being used for the Taxons are outdated and use non-HTTPS references. Google now suggest[1] using the Schema.org/BreadcrumbList markup[2]. There are no existing tests for this that I can find. I've attached a screenshot of the Google structured data testing tool[3] to show it passing, however I'm not currently able to write Spec test cases (hoping someone could help with that?)

I've removed the destructive `map!` function on the list and changed non-interpolation strings to single quotes.

**Sources**
[1] https://developers.google.com/search/docs/data-types/breadcrumbs
[2] https://schema.org/BreadcrumbList
[3] https://search.google.com/structured-data/testing-tool/

<img width="674" alt="breadcrumblist-schema" src="https://cloud.githubusercontent.com/assets/18415/19645299/f4f0dd74-99eb-11e6-8d73-08d4bff99fdf.png">