### PR TITLE
Add tooltip to store cart tax iso country field

### DIFF
--- a/backend/app/views/spree/admin/general_settings/edit.html.erb
+++ b/backend/app/views/spree/admin/general_settings/edit.html.erb
@@ -2,72 +2,70 @@
 
 <% admin_breadcrumb(Spree.t(:settings)) %>
 <% admin_breadcrumb(Spree.t(:general_settings)) %>
-
-<%= form_tag admin_general_settings_path, method: :put do %>
+<%= form_for @store, url: admin_general_settings_path do |f| %>
   <div id="preferences" data-hook>
 
     <fieldset class="general no-border-top">
 
-      <%= fields_for :store do |f| %>
-        <div data-hook="admin_general_setting_input_name">
-          <%= f.field_container :name do %>
-            <%= f.label :name %>
-            <%= f.text_field :name, class: 'fullwidth' %>
-            <%= f.error_message_on :name %>
-          <% end %>
-        </div>
+      <div data-hook="admin_general_setting_input_name">
+        <%= f.field_container :name do %>
+          <%= f.label :name %>
+          <%= f.text_field :name, class: 'fullwidth' %>
+          <%= f.error_message_on :name %>
+        <% end %>
+      </div>
 
-        <div data-hook="admin_general_setting_input_seo_title">
-          <%= f.field_container :seo_title do %>
-            <%= f.label :seo_title %>
-            <%= f.text_field :seo_title, class: 'fullwidth'  %>
-            <%= f.error_message_on :seo_title %>
-          <% end %>
-        </div>
+      <div data-hook="admin_general_setting_input_seo_title">
+        <%= f.field_container :seo_title do %>
+          <%= f.label :seo_title %>
+          <%= f.text_field :seo_title, class: 'fullwidth'  %>
+          <%= f.error_message_on :seo_title %>
+        <% end %>
+      </div>
 
-        <div data-hook="admin_general_setting_input_meta_keywords">
-          <%= f.field_container :meta_keywords do %>
-            <%= f.label :meta_keywords %>
-            <%= f.text_field :meta_keywords, class: 'fullwidth'  %>
-            <%= f.error_message_on :meta_keywords %>
-          <% end %>
-        </div>
+      <div data-hook="admin_general_setting_input_meta_keywords">
+        <%= f.field_container :meta_keywords do %>
+          <%= f.label :meta_keywords %>
+          <%= f.text_field :meta_keywords, class: 'fullwidth'  %>
+          <%= f.error_message_on :meta_keywords %>
+        <% end %>
+      </div>
 
-        <div data-hook="admin_general_setting_input_meta_description">
-          <%= f.field_container :meta_description do %>
-            <%= f.label :meta_description %>
-            <%= f.text_field :meta_description, class: 'fullwidth'  %>
-            <%= f.error_message_on :meta_description %>
-          <% end %>
-        </div>
+      <div data-hook="admin_general_setting_input_meta_description">
+        <%= f.field_container :meta_description do %>
+          <%= f.label :meta_description %>
+          <%= f.text_field :meta_description, class: 'fullwidth'  %>
+          <%= f.error_message_on :meta_description %>
+        <% end %>
+      </div>
 
-        <div data-hook="admin_general_setting_input_url">
-          <%= f.field_container :url do %>
-            <%= f.label :url %>
-            <%= f.text_field :url, class: 'fullwidth'  %>
-            <%= f.error_message_on :url %>
-          <% end %>
-        </div>
+      <div data-hook="admin_general_setting_input_url">
+        <%= f.field_container :url do %>
+          <%= f.label :url %>
+          <%= f.text_field :url, class: 'fullwidth'  %>
+          <%= f.error_message_on :url %>
+        <% end %>
+      </div>
 
-        <div data-hook="admin_general_setting_mail_from_address">
-          <%= f.field_container :mail_from_address do %>
-            <%= f.label :mail_from_address %>
-            <%= f.text_field :mail_from_address, class: 'fullwidth'  %>
-            <%= f.error_message_on :mail_from_address %>
-          <% end %>
-        </div>
+      <div data-hook="admin_general_setting_mail_from_address">
+        <%= f.field_container :mail_from_address do %>
+          <%= f.label :mail_from_address %>
+          <%= f.text_field :mail_from_address, class: 'fullwidth'  %>
+          <%= f.error_message_on :mail_from_address %>
+        <% end %>
+      </div>
 
-        <div data-hook="admin_general_setting_default_tax_country">
-          <%= f.field_container :cart_tax_country_iso do %>
-            <%= f.label :cart_tax_country_iso %>
-            <%= f.select :cart_tax_country_iso,
-                         Spree::Country.all.map { |c| [c.name, c.iso] },
-                         { include_blank: t(".no_cart_tax_country") },
-                         { class: "select2 fullwidth" } %>
-            <%= f.error_message_on :cart_tax_country_iso %>
-          <% end %>
-        </div>
-      <% end %>
+      <div data-hook="admin_general_setting_default_tax_country">
+        <%= f.field_container :cart_tax_country_iso do %>
+          <%= f.field_hint :cart_tax_country_iso %>
+          <%= f.label :cart_tax_country_iso %>
+          <%= f.select :cart_tax_country_iso,
+                       Spree::Country.all.map { |c| [c.name, c.iso] },
+                       { include_blank: t(".no_cart_tax_country") },
+                       { class: "select2 fullwidth" } %>
+          <%= f.error_message_on :cart_tax_country_iso %>
+        <% end %>
+      </div>
 
       <% if can? :update, :general_settings %>
         <div class="form-buttons filter-actions actions" data-hook="buttons">

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1123,6 +1123,8 @@ en:
         promotionable: "This determines whether or not promotions can apply to this product.<br/>Default: Checked"
         shipping_category: "This determines what kind of shipping this product requires.<br/> Default: Default"
         tax_category: "This determines what kind of taxation is applied to this product.<br/> Default: None"
+      spree/store:
+        cart_tax_country_iso: "This determines which country is used for taxes on carts (orders which don't yet have an address).<br/> Default: None."
       spree/variant:
         tax_category: "This determines what kind of taxation is applied to this variant.<br/> Default: Use tax category of the product associated with this variant"
         deleted: "Deleted Variant"


### PR DESCRIPTION
This adds a tooltip using the new `field_hint` method.

However, `field_hint` does not currently work with `fields_for`, which is
why this PR removes the `fields_for` call and instead uses a full form object
for just the store.

Advantages: We now limit the `GeneralSettingsController` to only change things for the store.
Disadvantages: See advantages - if anyone patched their `GeneralSettingsController`,
this would be an issue.