### PR TITLE
Store credit originator link

### DIFF
--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -94,7 +94,11 @@ module Spree
           # payment gateways happy.
           #
           # For more information, please see Spree::Payment#set_unique_identifier
-          order_id: gateway_order_id
+          order_id: gateway_order_id,
+          # The originator is passed to options used by the payment method.
+          # One example of a place that it is used is in:
+          # app/models/spree/payment_method/store_credit.rb
+          originator: self
         }
 
         options[:shipping] = order.ship_total * 100

--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -85,15 +85,17 @@ module Spree
 
       def gateway_options
         order.reload
-        options = { email: order.email,
-                    customer: order.email,
-                    customer_id: order.user_id,
-                    ip: order.last_ip_address,
-                    # Need to pass in a unique identifier here to make some
-                    # payment gateways happy.
-                    #
-                    # For more information, please see Spree::Payment#set_unique_identifier
-                    order_id: gateway_order_id }
+        options = {
+          email: order.email,
+          customer: order.email,
+          customer_id: order.user_id,
+          ip: order.last_ip_address,
+          # Need to pass in a unique identifier here to make some
+          # payment gateways happy.
+          #
+          # For more information, please see Spree::Payment#set_unique_identifier
+          order_id: gateway_order_id
+        }
 
         options[:shipping] = order.ship_total * 100
         options[:tax] = order.additional_tax_total * 100


### PR DESCRIPTION
Add originator to gateway options

Adding the originator of the Payment in to the gateway options allows store credit events to bind their originator correctly providing better reporting.

Fixed #1471
