### PR TITLE
Remove include since it's already done by parent

### DIFF
--- a/core/app/models/spree/promotion/actions/create_quantity_adjustments.rb
+++ b/core/app/models/spree/promotion/actions/create_quantity_adjustments.rb
@@ -1,7 +1,5 @@
 module Spree::Promotion::Actions
   class CreateQuantityAdjustments < CreateItemAdjustments
-    include Spree::CalculatedAdjustments
-
     preference :group_size, :integer, default: 1
 
     has_many :line_item_actions, foreign_key: :action_id, dependent: :destroy


### PR DESCRIPTION
It has already been included in the parent class here: <https://github.com/solidusio/solidus/blob/master/core/app/models/spree/promotion/actions/create_item_adjustments.rb#L5>