### PR TITLE
Remove accept_alert and dismiss_alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,10 @@
       and `remove_nested`. Also removes some javascript bound to selectors
       `.remove`, `a[id*=nested]`.
 
+    * Removed `accept_alert` and `dismiss_alert` from CapybaraExt.
+      `accept_alert` is now a capybara builtin (that we were overriding) and
+      `dismiss_alert` can be replaced with `dismiss_prompt`.
+
 ## Solidus 2.0.0 (unreleased)
 
 *   Upgrade to rails 5.0

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -77,7 +77,7 @@ describe "Order Details", type: :feature, js: true do
 
         within_row(1) do
           # Click "cancel" on confirmation dialog
-          dismiss_alert do
+          dismiss_prompt do
             click_icon :trash
           end
         end

--- a/core/lib/spree/testing_support/capybara_ext.rb
+++ b/core/lib/spree/testing_support/capybara_ext.rb
@@ -107,18 +107,6 @@ module CapybaraExt
       raise "AJAX request took longer than 5 seconds." if counter >= 50
     end
   end
-
-  def accept_alert
-    page.evaluate_script('window.confirm = function() { return true; }')
-    yield
-  end
-
-  def dismiss_alert
-    page.evaluate_script('window.confirm = function() { return false; }')
-    yield
-    # Restore existing default
-    page.evaluate_script('window.confirm = function() { return true; }')
-  end
 end
 
 RSpec::Matchers.define :have_meta do |name, expected|


### PR DESCRIPTION
`accept_alert` is now a part of capybara itself (and is more powerful and better implemented) that we were overriding.

`dismiss_alert` can be replaced with `dismiss_prompt`.

cc @luukveenis 