### PR TITLE
remove method option

### DIFF
--- a/backend/app/views/spree/admin/products/edit.html.erb
+++ b/backend/app/views/spree/admin/products/edit.html.erb
@@ -11,7 +11,7 @@
 
 <% admin_breadcrumb(Spree.t(:product_details)) %>
 
-<%= form_for [:admin, @product], :method => :put, :html => { :multipart => true } do |f| %>
+<%= form_for [:admin, @product], :html => { :multipart => true } do |f| %>
   <fieldset class="no-border-top">
     <%= render :partial => 'form', :locals => { :f => f } %>
     <% if can?(:update, @product) %>


### PR DESCRIPTION
Given the **form for** helper infers the method given the object is not necessary explicit include the method as a parameter.
