### PR TITLE
[WIP] move towards internationalized address format information at the database level

### DIFF
--- a/core/app/models/spree/country.rb
+++ b/core/app/models/spree/country.rb
@@ -6,6 +6,13 @@ module Spree
 
     validates :name, :iso_name, presence: true
 
+    # provence_label - "state" for U.S.; "Provence/Territory" for CAN
+    # postal_label = "Zipcode" for U.S.; "Postal Code" almost everywhere else
+
+    enum provence_specified: { exclude: 0, optional: 1, required: 2 }  # exclude, optional, or require the provence/state
+    enum postal_postion: { right: 0, left: 1, below_city: 3, above_city: 4 } # should the postal code (zip code) appear right, left, above, or below
+    enum postal_specified: { exclude: 0, optional: 1, required: 2} # should the postal code come to right, left (on city line), or above or below city line
+
     def self.states_required_by_country_id
       Spree::Deprecation.warn "Spree::Country.states_required_by_country_id is deprecated and will be removed from future releases, Implement it yourself.", caller
       states_required = Hash.new(true)

--- a/core/db/migrate/20161029130019_add_address_format_settings_to_countries.rb
+++ b/core/db/migrate/20161029130019_add_address_format_settings_to_countries.rb
@@ -1,0 +1,9 @@
+class AddAddressFormatSettingsToCountries < ActiveRecord::Migration[5.0]
+  def change
+    add_column :spree_countries, :provence_label, :string
+    add_column :spree_countries, :provence_specified, :integer, limit: 1
+    add_column :spree_countries, :postal_label, :string
+    add_column :spree_countries, :postal_position, :integer, limit: 1
+    add_column :spree_countries, :postal_specified, :integer, limit: 1
+  end
+end


### PR DESCRIPTION
this is based on an analysis of http://www.columbia.edu/~fdc/postal/

obviously WIP as this PR only adds the fields to the database, actually implementing the address formatting rules will require heavier lifting.

Seeking comment. 
- [ ] provide migration from `states_required` to `provence_specified`
- [ ] Drop `states_required` and replace it with a method that interprets new field `provence_specified`
