### PR TITLE
Remove useless jQuery.css in inline script

### DIFF
--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -192,9 +192,3 @@
 
   <div class="clear"></div>
 </div>
-
-<% unless Rails.env.test? %>
-  <script>
-$('.select2-container').css({width: '20em'})
-  </script>
-<% end %>


### PR DESCRIPTION
This is run before select2 is initialized, so it will have no effect.