### PR TITLE
Wrap OrderUpdater#update in a transaction

### DIFF
--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -15,15 +15,17 @@ module Spree
     # object with callbacks (otherwise you will end up in an infinite recursion as the
     # associations try to save and then in turn try to call +update!+ again.)
     def update
-      update_item_count
-      update_totals
-      if order.completed?
-        update_payment_state
-        update_shipments
-        update_shipment_state
+      @order.transaction do
+        update_item_count
+        update_totals
+        if order.completed?
+          update_payment_state
+          update_shipments
+          update_shipment_state
+        end
+        run_hooks
+        persist_totals
       end
-      run_hooks
-      persist_totals
     end
 
     def run_hooks


### PR DESCRIPTION
As of #1479 we are doing more work inside of OrderUpdater. We're doing additions and deletions of tax adjustments, which also causes more touching of records.

This is all made faster by wrapping the entire update in a transaction. All the writes can be queued together by the DB, and as of rails 5, dependent touching is grouped together to the end of the transaction.

Difference in queries run:
https://gist.github.com/jhawthorn/5f0b9de70a782bd3e1fd2ecec667e28c