### PR TITLE
Avoid re-creating tax adjustments

### DIFF
--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -68,7 +68,6 @@ module Spree
     # Creates necessary tax adjustments for the order.
     def adjust(_order_tax_zone, item)
       amount = compute_amount(item)
-      return if amount == 0
 
       included = included_in_price && amount > 0
 


### PR DESCRIPTION
Previously, `ItemAdjuster#adjust!` would always destroy all tax adjustments on the item and recreate them. This was unnecessarily slow in the common case of needing no changes (especially following #1479).

This changes `ItemAdjuster#adjust!` to instead update the adjustment for a rate if it already exists, create adjustments if they are missing for a matching rate, and destroy adjustments for rates which are no longer matching.

With this change, the speed of an `order.update!` which requires no changes is comparable to before #1479 :tada: 

[Comparison of queries run](https://gist.github.com/jhawthorn/6807bcb46871c19b674850e2a25894dd)