### PR TITLE
Document promotion availability

### DIFF
--- a/backend/app/views/spree/admin/promotions/_form.html.erb
+++ b/backend/app/views/spree/admin/promotions/_form.html.erb
@@ -66,12 +66,12 @@
 
     <div id="starts_at_field" class="field">
       <%= f.label :starts_at %>
-      <%= f.text_field :starts_at, :value => datepicker_field_value(@promotion.starts_at), :class => 'datepicker datepicker-from fullwidth' %>
+      <%= f.text_field :starts_at, :value => datepicker_field_value(@promotion.starts_at), :placeholder => "Immediately", :class => 'datepicker datepicker-from fullwidth' %>
     </div>
 
     <div id="expires_at_field" class="field">
       <%= f.label :expires_at %>
-      <%= f.text_field :expires_at, :value => datepicker_field_value(@promotion.expires_at), :class => 'datepicker datepicker-to fullwidth' %>
+      <%= f.text_field :expires_at, :value => datepicker_field_value(@promotion.expires_at), :placeholder => "Never", :class => 'datepicker datepicker-to fullwidth' %>
     </div>
   </div>
 </div>

--- a/backend/app/views/spree/admin/promotions/_form.html.erb
+++ b/backend/app/views/spree/admin/promotions/_form.html.erb
@@ -66,11 +66,13 @@
 
     <div id="starts_at_field" class="field">
       <%= f.label :starts_at %>
+      <%= f.field_hint :starts_at %>
       <%= f.text_field :starts_at, :value => datepicker_field_value(@promotion.starts_at), :placeholder => "Immediately", :class => 'datepicker datepicker-from fullwidth' %>
     </div>
 
     <div id="expires_at_field" class="field">
       <%= f.label :expires_at %>
+      <%= f.field_hint :expires_at %>
       <%= f.text_field :expires_at, :value => datepicker_field_value(@promotion.expires_at), :placeholder => "Never", :class => 'datepicker datepicker-to fullwidth' %>
     </div>
   </div>

--- a/backend/app/views/spree/admin/promotions/_form.html.erb
+++ b/backend/app/views/spree/admin/promotions/_form.html.erb
@@ -67,13 +67,13 @@
     <div id="starts_at_field" class="field">
       <%= f.label :starts_at %>
       <%= f.field_hint :starts_at %>
-      <%= f.text_field :starts_at, :value => datepicker_field_value(@promotion.starts_at), :placeholder => "Immediately", :class => 'datepicker datepicker-from fullwidth' %>
+      <%= f.text_field :starts_at, :value => datepicker_field_value(@promotion.starts_at), :placeholder => t(".starts_at_placeholder"), :class => 'datepicker datepicker-from fullwidth' %>
     </div>
 
     <div id="expires_at_field" class="field">
       <%= f.label :expires_at %>
       <%= f.field_hint :expires_at %>
-      <%= f.text_field :expires_at, :value => datepicker_field_value(@promotion.expires_at), :placeholder => "Never", :class => 'datepicker datepicker-to fullwidth' %>
+      <%= f.text_field :expires_at, :value => datepicker_field_value(@promotion.expires_at), :placeholder => t(".expires_at_placeholder"), :class => 'datepicker datepicker-to fullwidth' %>
     </div>
   </div>
 </div>

--- a/backend/app/views/spree/admin/promotions/new.html.erb
+++ b/backend/app/views/spree/admin/promotions/new.html.erb
@@ -2,7 +2,7 @@
 <% admin_breadcrumb(Spree.t(:new_promotion)) %>
 
 
-<%= form_for :promotion, :url => collection_url do |f| %>
+<%= form_for @promotion, :url => collection_url do |f| %>
   <fieldset class="no-border-top">
     <%= render :partial => 'form', :locals => { :f => f } %>
     <%= render :partial => 'spree/admin/shared/new_resource_links' %>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1172,6 +1172,9 @@ en:
         promotionable: "This determines whether or not promotions can apply to this product.<br/>Default: Checked"
         shipping_category: "This determines what kind of shipping this product requires.<br/> Default: Default"
         tax_category: "This determines what kind of taxation is applied to this product.<br/> Default: None"
+      spree/promotion:
+        starts_at: "This determines when the promotion can be applied to orders. <br/> If no value is specified, the promotion will be immediately available."
+        expires_at: "This determines when the promotion expires. <br/> If no value is specified, the promotion will never expires."
       spree/store:
         cart_tax_country_iso: "This determines which country is used for taxes on carts (orders which don't yet have an address).<br/> Default: None."
       spree/variant:

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -760,6 +760,10 @@ en:
           edit_price: Edit Price
         new:
           new_price: New Price
+      promotions:
+        form:
+          starts_at_placeholder: Immediately
+          expires_at_placeholder: Never
       store_credits:
         add: "Add store credit"
         amount_authorized: "Amount Authorized"


### PR DESCRIPTION
This adds tooltips to the `starts_at` and `expires_at` promotion fields. It might not be obvious that if no values is set, the promotion will be immediately usable.

<img width="1015" alt="screen shot 2016-11-01 at 8 24 51 pm" src="https://cloud.githubusercontent.com/assets/4110905/19915717/89afdc18-a071-11e6-8871-4d4903340193.png">

<img width="1011" alt="screen shot 2016-11-01 at 8 26 20 pm" src="https://cloud.githubusercontent.com/assets/4110905/19915722/92903ada-a071-11e6-811a-27cf9af2f860.png">

<img width="1015" alt="screen shot 2016-11-01 at 8 37 57 pm" src="https://cloud.githubusercontent.com/assets/4110905/19915959/1e9a1806-a073-11e6-8a69-e7b7797c8287.png">
