### PR TITLE
Fix NoMethodError with Tiered Percent calculator

### DIFF
--- a/core/app/models/spree/promotion/actions/create_quantity_adjustments.rb
+++ b/core/app/models/spree/promotion/actions/create_quantity_adjustments.rb
@@ -121,6 +121,10 @@ module Spree::Promotion::Actions
         @line_item.price
       end
 
+      def order
+        @line_item.order
+      end
+
       def currency
         @line_item.currency
       end


### PR DESCRIPTION
Using the Tiered Percent calculator with the `CreateQuantityAdjustment` promotion action generates a NoMethodError because the Tiered Percent calculator tries to access the order through the line_item to access the totals, but `CreateQuantityAdjustment` use a PartialLineItem with no reference to the order.

This PR adds the reference with related coverage, a slight overhaul of the rest of the CreateQuantityAdjustment to ensure that the order is properly updated on creation.