### PR TITLE
Allow title separator to be customized

### DIFF
--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -62,6 +62,10 @@ module Spree
     #   @return [Boolean] When true, site name is always appended to titles on the frontend (default: +true+)
     preference :always_put_site_name_in_title, :boolean, default: true
 
+    # @!attribute [rw] title_site_name_separator
+    #   @return [String] When always_put_site_name_in_title is true, insert a separator character before the site name in the title (default: '-')
+    preference :title_site_name_separator, :string, default: '-'
+
     # @!attribute [rw] auto_capture
     #   @note Setting this to true is not recommended. Performing an authorize
     #     and later capture has far superior error handing. VISA and MasterCard

--- a/core/lib/spree/core/controller_helpers/common.rb
+++ b/core/lib/spree/core/controller_helpers/common.rb
@@ -23,7 +23,7 @@ module Spree
           title_string = @title.present? ? @title : accurate_title
           if title_string.present?
             if Spree::Config[:always_put_site_name_in_title]
-              [title_string, default_title].join(' - ')
+              [title_string, default_title].join(" #{Spree::Config[:title_site_name_separator]} ")
             else
               title_string
             end


### PR DESCRIPTION
Companies may wish to use other types of separators for their `<title>` tags for branding purposes. This pull request keeps the default '-', however it allows others to be chosen through an initializer.

Examples
```
<title>Ruby on Rails Jr. Spaghetti - Site Name</title>
<title>Ruby on Rails Jr. Spaghetti | Site Name</title>
<title>Ruby on Rails Jr. Spaghetti at Site Name</title>
<title>Ruby on Rails Jr. Spaghetti @ Site Name</title>
```
Example overriding
```
# spree.rb
Spree.config do |config|
  config.title_site_name_separator = '|'
end
```