### PR TITLE
Admin product edit view bootstrap grid upgrade

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
+++ b/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
@@ -213,3 +213,9 @@ label .select2-container {
     }
   }
 }
+
+// Set the width of placeholders to 100% to force respecting parent width
+// https://github.com/t0m/select2-bootstrap-css/issues/42
+input.select2-input[placeholder] {
+  width: 100% !important;
+}

--- a/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
@@ -27,6 +27,10 @@ textarea {
   line-height: 19px;
 }
 
+input.datepicker {
+  cursor: pointer;
+}
+
 .fullwidth {
   width: 100%;
 }

--- a/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
@@ -306,3 +306,27 @@ fieldset {
 .form-buttons {
   text-align: center;
 }
+
+.form-section {
+  margin: 10px 0px;
+  padding: 10px 0px;
+  background: very-light($color-3, 4);
+  border: 1px solid very-light($color-3, 32);
+}
+
+.text-field-addon {
+  position: absolute;
+  right: 25px;
+  bottom: 21px;
+  pointer-events: none;
+}
+
+.max-width-form {
+  @include margin(null null auto null);
+  max-width: map-get($container-max-widths, "xl");
+}
+
+.helpful-text-sidebar {
+  margin: 10px 0px;
+  padding: 10px 0px;
+}

--- a/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
@@ -308,6 +308,7 @@ fieldset {
 }
 
 .form-section {
+  @include make-row(0px);
   margin: 10px 0px;
   padding: 10px 0px;
   background: very-light($color-3, 4);

--- a/backend/app/assets/stylesheets/spree/backend/shared/_layout.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_layout.scss
@@ -34,6 +34,11 @@ body {
     @include margin(null auto);
     max-width: map-get($container-max-widths, "xl");
   }
+
+  &.max-width {
+    @include margin(null null auto null);
+    max-width: map-get($container-max-widths, "xl");
+  }
 }
 
 .content {

--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -5,16 +5,13 @@
     <div class="form-section">
 
       <% if !@product.has_variants? %>
-        <div class="col-xs-12">
-          <div class="row">
-            <div data-hook="admin_product_sku" class="col-xs-12 col-md-6">
-              <%= f.field_container :sku do %>
-                <%= f.label :sku, Spree::Variant.human_attribute_name(:sku) %>
-                <%= f.text_field :sku, :size => 16 %>
-              <% end %>
-            </div>
-          </div>
+        <div data-hook="admin_product_sku" class="col-xs-12 col-md-6">
+          <%= f.field_container :sku do %>
+            <%= f.label :sku, Spree::Variant.human_attribute_name(:sku) %>
+            <%= f.text_field :sku, :size => 16 %>
+          <% end %>
         </div>
+        <div class="col-md-6 hidden-dm-down"></div>
       <% end %>
 
       <div data-hook="admin_product_form_name" class="col-md-6 col-xs-12">
@@ -57,52 +54,42 @@
         <h4><%= I18n.t(:pricing, scope: [:spree, :product_sections]) %></h4>
       </div>
 
-      <div class="col-xs-12">
-        <div class="row">
-          <div data-hook="admin_product_form_price" class="col-lg-3 col-xs-6">
-            <%= f.field_container :price do %>
-              <%= f.label :price, class: 'required' %>
-              <%= f.text_field :price, :value => number_to_currency(@product.price, :unit => ''), :required => true %>
-              <%= f.error_message_on :price %>
-            <% end %>
-          </div>
-        </div>
+      <div data-hook="admin_product_form_price" class="col-lg-3 col-xs-6">
+        <%= f.field_container :price do %>
+          <%= f.label :price, class: 'required' %>
+          <%= f.text_field :price, :value => number_to_currency(@product.price, :unit => ''), :required => true %>
+          <%= f.error_message_on :price %>
+        <% end %>
+      </div>
+      <div class="col-lg-9 hidden-md-down"></div>
+      <div class="col-xs-6 hidden-lg-up"></div>
+
+      <div data-hook="admin_product_form_cost_price" class="col-lg-3 col-xs-6">
+        <%= f.field_container :cost_price do %>
+          <%= f.label :cost_price %>
+          <%= f.text_field :cost_price, :value => number_to_currency(@product.cost_price, :unit => '') %>
+          <%= f.error_message_on :cost_price %>
+        <% end %>
       </div>
 
-      <div class="col-xs-12">
-        <div class="row">
-
-          <div data-hook="admin_product_form_cost_price" class="col-lg-3 col-xs-6">
-            <%= f.field_container :cost_price do %>
-              <%= f.label :cost_price %>
-              <%= f.text_field :cost_price, :value => number_to_currency(@product.cost_price, :unit => '') %>
-              <%= f.error_message_on :cost_price %>
-            <% end %>
-          </div>
-
-          <div data-hook="admin_product_form_cost_currency" class="col-lg-3 col-xs-6">
-            <%= f.field_container :cost_currency do %>
-              <%= f.label :cost_currency %>
-              <%= f.text_field :cost_currency %>
-              <%= f.error_message_on :cost_currency %>
-            <% end %>
-          </div>
-
-        </div>
+      <div data-hook="admin_product_form_cost_currency" class="col-lg-3 col-xs-6">
+        <%= f.field_container :cost_currency do %>
+          <%= f.label :cost_currency %>
+          <%= f.text_field :cost_currency %>
+          <%= f.error_message_on :cost_currency %>
+        <% end %>
       </div>
+      <div class="col-lg-9 hidden-md-down"></div>
 
-      <div class="col-xs-12">
-        <div class="row">
-          <div data-hook="admin_product_form_tax_category" class="col-md-6 col-xs-12">
-            <%= f.field_container :tax_category do %>
-              <%= f.label :tax_category_id, Spree::TaxCategory.model_name.human %>
-              <%= f.field_hint :tax_category %>
-              <%= f.collection_select(:tax_category_id, @tax_categories, :id, :name, { :include_blank => Spree.t('match_choices.none') }, { :class => 'select2' }) %>
-              <%= f.error_message_on :tax_category %>
-            <% end %>
-          </div>
-        </div>
+      <div data-hook="admin_product_form_tax_category" class="col-md-6 col-xs-12">
+        <%= f.field_container :tax_category do %>
+          <%= f.label :tax_category_id, Spree::TaxCategory.model_name.human %>
+          <%= f.field_hint :tax_category %>
+          <%= f.collection_select(:tax_category_id, @tax_categories, :id, :name, { :include_blank => Spree.t('match_choices.none') }, { :class => 'select2' }) %>
+          <%= f.error_message_on :tax_category %>
+        <% end %>
       </div>
+      <div class="col-md-6 hidden-sm-down"></div>
 
       <div data-hook="admin_product_form_promotionable" class="col-md-4 col-xs-12">
         <%= f.field_container :promotionable do %>
@@ -127,32 +114,25 @@
         <h4><%= I18n.t(:shipping, scope: [:spree, :product_sections]) %></h4>
       </div>
 
-      <div class="col-xs-12">
-        <div class="row">
-          <div data-hook="admin_product_form_shipping_categories" class="col-md-6 col-xs-12">
-            <%= f.field_container :shipping_categories do %>
-              <%= f.label :shipping_category_id, Spree::ShippingCategory.model_name.human %>
-              <%= f.field_hint :shipping_category %>
-              <%= f.collection_select(:shipping_category_id, @shipping_categories, :id, :name, { :include_blank => Spree.t('match_choices.none') }, { :class => 'select2' }) %>
-              <%= f.error_message_on :shipping_category %>
-            <% end %>
-          </div>
-        </div>
+      <div data-hook="admin_product_form_shipping_categories" class="col-md-6 col-xs-12">
+        <%= f.field_container :shipping_categories do %>
+          <%= f.label :shipping_category_id, Spree::ShippingCategory.model_name.human %>
+          <%= f.field_hint :shipping_category %>
+          <%= f.collection_select(:shipping_category_id, @shipping_categories, :id, :name, { :include_blank => Spree.t('match_choices.none') }, { :class => 'select2' }) %>
+          <%= f.error_message_on :shipping_category %>
+        <% end %>
       </div>
+      <div class="col-md-6 hidden-sm-down"></div>
 
       <% if !@product.has_variants? %>
-        <div class="col-xs-12">
-          <div id="shipping_specs" class="row">
-            <% [:height, :width, :depth, :weight].each_with_index do |field, index| %>
-              <div id="shipping_specs_<%= field %>_field" class="col-md-3 col-xs-6">
-                <div class="field">
-                  <%= f.label field %>
-                  <%= f.text_field field, value: number_with_precision(@product.send(field), precision: 2) %>
-                </div>
-              </div>
-            <% end %>
+        <% [:height, :width, :depth, :weight].each_with_index do |field, index| %>
+          <div id="shipping_specs_<%= field %>_field" class="col-md-3 col-xs-6">
+            <div class="field">
+              <%= f.label field %>
+              <%= f.text_field field, value: number_with_precision(@product.send(field), precision: 2) %>
+            </div>
           </div>
-        </div>
+        <% end %>
       <% end %>
 
     </div>

--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -2,7 +2,7 @@
 
   <div data-hook="admin_product_form_left" class="col-lg-8 col-xs-12">
 
-    <div class="row form-section">
+    <div class="form-section">
 
       <% if !@product.has_variants? %>
         <div class="col-xs-12">
@@ -51,7 +51,7 @@
 
     </div>
 
-    <div class="row form-section">
+    <div class="form-section">
 
       <div class="col-xs-12">
         <h4><%= I18n.t(:pricing, scope: [:spree, :product_sections]) %></h4>
@@ -121,7 +121,7 @@
 
     </div>
 
-    <div class="row form-section">
+    <div class="form-section">
 
       <div class="col-xs-12">
         <h4><%= I18n.t(:shipping, scope: [:spree, :product_sections]) %></h4>
@@ -160,7 +160,7 @@
   </div>
 
   <div data-hook="admin_product_form_right" class="col-lg-4 col-xs-12">
-    <div class="row form-section">
+    <div class="form-section">
 
       <div class="col-xs-12">
         <h4><%= I18n.t(:delay_publishing, scope: [:spree, :product_sections]) %></h4>
@@ -216,7 +216,7 @@
 
   <div class="col-lg-8 col-xs-12" >
 
-    <div class="row form-section">
+    <div class="form-section">
 
       <div class="col-xs-12">
         <h4><%= I18n.t(:search_engine_optimization, scope: [:spree, :product_sections]) %></h4>

--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -1,9 +1,23 @@
-<div data-hook="admin_product_form_fields">
+<div data-hook="admin_product_form_fields" class="row">
 
-  <div class="row">
+  <div data-hook="admin_product_form_left" class="col-lg-8 col-xs-12">
 
-    <div class="left col-xs-9" data-hook="admin_product_form_left">
-      <div data-hook="admin_product_form_name">
+    <div class="row form-section">
+
+      <% if !@product.has_variants? %>
+        <div class="col-xs-12">
+          <div class="row">
+            <div data-hook="admin_product_sku" class="col-xs-12 col-md-6">
+              <%= f.field_container :sku do %>
+                <%= f.label :sku, Spree::Variant.human_attribute_name(:sku) %>
+                <%= f.text_field :sku, :size => 16 %>
+              <% end %>
+            </div>
+          </div>
+        </div>
+      <% end %>
+
+      <div data-hook="admin_product_form_name" class="col-md-6 col-xs-12">
         <%= f.field_container :name do %>
           <%= f.label :name, class: 'required' %>
           <%= f.text_field :name, :class => 'fullwidth title', :required => true %>
@@ -11,7 +25,7 @@
         <% end %>
       </div>
 
-      <div data-hook="admin_product_form_slug">
+      <div data-hook="admin_product_form_slug" class="col-md-6 col-xs-12">
         <%= f.field_container :slug do %>
           <%= f.label :slug, class: 'required' %>
           <%= f.text_field :slug, :class => 'fullwidth title', :required => true %>
@@ -19,60 +33,78 @@
         <% end %>
       </div>
 
-      <div data-hook="admin_product_form_description">
+      <div data-hook="admin_product_form_description" class="col-xs-12">
         <%= f.field_container :description do %>
           <%= f.label :description %>
-          <%= f.text_area :description, {:rows => "#{unless @product.has_variants? then '22' else '15' end}", :class => 'fullwidth'} %>
+          <%= f.text_area :description, {:rows => '9', :class => 'fullwidth'} %>
           <%= f.error_message_on :description %>
         <% end %>
       </div>
+
+      <div data-hook="admin_product_form_taxons" class="col-xs-12">
+        <%= f.field_container :taxons do %>
+          <%= f.label :taxon_ids, plural_resource_name(Spree::Taxon) %><br />
+          <%= f.hidden_field :taxon_ids, :value => @product.taxon_ids.join(',') %>
+          <span class="fa fa-caret-down text-field-addon"></span>
+        <% end %>
+      </div>
+
     </div>
 
-    <div class="right col-xs-3" data-hook="admin_product_form_right">
-      <div data-hook="admin_product_form_price">
-        <%= f.field_container :price do %>
-          <%= f.label :price, class: 'required' %>
-          <%= f.text_field :price, :value => number_to_currency(@product.price, :unit => ''), :required => true %>
-          <%= f.error_message_on :price %>
-        <% end %>
+    <div class="row form-section">
+
+      <div class="col-xs-12">
+        <h4><%= I18n.t(:pricing, scope: [:spree, :product_sections]) %></h4>
       </div>
 
-      <% if show_rebuild_vat_checkbox? %>
-        <%= render "spree/admin/shared/rebuild_vat_prices_checkbox", form: f, model_name: "product" %>
-        <div class="clearfix"></div>
-      <% end %>
-
-      <div class="row">
-
-        <div data-hook="admin_product_form_cost_price" class="col-xs-6">
-          <%= f.field_container :cost_price do %>
-            <%= f.label :cost_price %>
-            <%= f.text_field :cost_price, :value => number_to_currency(@product.cost_price, :unit => '') %>
-            <%= f.error_message_on :cost_price %>
-          <% end %>
+      <div class="col-xs-12">
+        <div class="row">
+          <div data-hook="admin_product_form_price" class="col-lg-3 col-xs-6">
+            <%= f.field_container :price do %>
+              <%= f.label :price, class: 'required' %>
+              <%= f.text_field :price, :value => number_to_currency(@product.price, :unit => ''), :required => true %>
+              <%= f.error_message_on :price %>
+            <% end %>
+          </div>
         </div>
+      </div>
 
-        <div data-hook="admin_product_form_cost_currency" class="col-xs-6">
-          <%= f.field_container :cost_currency do %>
-            <%= f.label :cost_currency %>
-            <%= f.text_field :cost_currency %>
-            <%= f.error_message_on :cost_currency %>
-          <% end %>
+      <div class="col-xs-12">
+        <div class="row">
+
+          <div data-hook="admin_product_form_cost_price" class="col-lg-3 col-xs-6">
+            <%= f.field_container :cost_price do %>
+              <%= f.label :cost_price %>
+              <%= f.text_field :cost_price, :value => number_to_currency(@product.cost_price, :unit => '') %>
+              <%= f.error_message_on :cost_price %>
+            <% end %>
+          </div>
+
+          <div data-hook="admin_product_form_cost_currency" class="col-lg-3 col-xs-6">
+            <%= f.field_container :cost_currency do %>
+              <%= f.label :cost_currency %>
+              <%= f.text_field :cost_currency %>
+              <%= f.error_message_on :cost_currency %>
+            <% end %>
+          </div>
+
         </div>
-
       </div>
 
-      <div class="clear"></div>
-
-      <div data-hook="admin_product_form_available_on">
-        <%= f.field_container :available_on do %>
-          <%= f.label :available_on %>
-          <%= f.error_message_on :available_on %>
-          <%= f.text_field :available_on, :value => datepicker_field_value(@product.available_on), :class => 'datepicker' %>
-        <% end %>
+      <div class="col-xs-12">
+        <div class="row">
+          <div data-hook="admin_product_form_tax_category" class="col-md-6 col-xs-12">
+            <%= f.field_container :tax_category do %>
+              <%= f.label :tax_category_id, Spree::TaxCategory.model_name.human %>
+              <%= f.field_hint :tax_category %>
+              <%= f.collection_select(:tax_category_id, @tax_categories, :id, :name, { :include_blank => Spree.t('match_choices.none') }, { :class => 'select2' }) %>
+              <%= f.error_message_on :tax_category %>
+            <% end %>
+          </div>
+        </div>
       </div>
 
-      <div data-hook="admin_product_form_promotionable">
+      <div data-hook="admin_product_form_promotionable" class="col-md-4 col-xs-12">
         <%= f.field_container :promotionable do %>
           <%= f.label :promotionable do %>
             <%= f.check_box :promotionable %> <%= Spree::Product.human_attribute_name(:promotionable) %>
@@ -81,9 +113,84 @@
         <% end %>
       </div>
 
+      <% if show_rebuild_vat_checkbox? %>
+        <div class="col-md-4 col-xs-12">
+          <%= render "spree/admin/shared/rebuild_vat_prices_checkbox", form: f, model_name: "product"%>
+        </div>
+      <% end %>
+
+    </div>
+
+    <div class="row form-section">
+
+      <div class="col-xs-12">
+        <h4><%= I18n.t(:shipping, scope: [:spree, :product_sections]) %></h4>
+      </div>
+
+      <div class="col-xs-12">
+        <div class="row">
+          <div data-hook="admin_product_form_shipping_categories" class="col-md-6 col-xs-12">
+            <%= f.field_container :shipping_categories do %>
+              <%= f.label :shipping_category_id, Spree::ShippingCategory.model_name.human %>
+              <%= f.field_hint :shipping_category %>
+              <%= f.collection_select(:shipping_category_id, @shipping_categories, :id, :name, { :include_blank => Spree.t('match_choices.none') }, { :class => 'select2' }) %>
+              <%= f.error_message_on :shipping_category %>
+            <% end %>
+          </div>
+        </div>
+      </div>
+
+      <% if !@product.has_variants? %>
+        <div class="col-xs-12">
+          <div id="shipping_specs" class="row">
+            <% [:height, :width, :depth, :weight].each_with_index do |field, index| %>
+              <div id="shipping_specs_<%= field %>_field" class="col-md-3 col-xs-6">
+                <div class="field">
+                  <%= f.label field %>
+                  <%= f.text_field field, value: number_with_precision(@product.send(field), precision: 2) %>
+                </div>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+
+    </div>
+
+  </div>
+
+  <div data-hook="admin_product_form_right" class="col-lg-4 col-xs-12">
+    <div class="row form-section">
+
+      <div class="col-xs-12">
+        <h4><%= I18n.t(:delay_publishing, scope: [:spree, :product_sections]) %></h4>
+        <p><%= I18n.t(:delay_publishing, scope: [:spree, :hints, "spree/product"]) %></p>
+      </div>
+
+      <div data-hook="admin_product_form_available_on" class="col-xs-12">
+        <%= f.field_container :available_on do %>
+          <%= f.label :available_on %>
+          <%= f.error_message_on :available_on %>
+          <%= f.text_field :available_on, :value => datepicker_field_value(@product.available_on), :class => 'datepicker' %>
+          <span class="fa fa-calendar text-field-addon"></span>
+        <% end %>
+      </div>
+
+      <div class="col-xs-12">
+        <h4><%= I18n.t(:variant_setup, scope: [:spree, :product_sections]) %></h4>
+        <p><%= I18n.t(:variant_setup, scope: [:spree, :hints, "spree/product"]) %></p>
+      </div>
+
+      <div data-hook="admin_product_form_option_types" class="col-xs-12">
+        <%= f.field_container :option_types do %>
+          <%= f.label :option_type_ids, plural_resource_name(Spree::OptionType) %>
+          <%= f.hidden_field :option_type_ids, :value => @product.option_type_ids.join(',') %>
+          <span class="fa fa-caret-down text-field-addon"></span>
+        <% end %>
+      </div>
+
       <% if @product.has_variants? %>
-        <div data-hook="admin_product_form_multiple_variants">
-          <%= f.label :skus, Spree.t(:skus) %>
+        <div data-hook="admin_product_form_multiple_variants" class="col-xs-12">
           <span class="info">
             <%= Spree.t(:info_product_has_multiple_skus, count: @product.variants.count) %>
             <ul class="text_list">
@@ -101,66 +208,25 @@
             <% end %>
           </div>
         </div>
-      <% else %>
-        <div data-hook="admin_product_form_sku">
-          <%= f.field_container :sku do %>
-            <%= f.label :sku, Spree::Variant.human_attribute_name(:sku) %>
-            <%= f.text_field :sku, :size => 16 %>
-          <% end %>
-        </div>
-
-        <div id="shipping_specs" class="row">
-          <% [:height, :width, :depth, :weight].each_with_index do |field, index| %>
-            <div id="shipping_specs_<%= field %>_field" class="col-xs-6">
-              <div class="field">
-                <%= f.label field %>
-                <%= f.text_field field, value: number_with_precision(@product.send(field), precision: 2) %>
-              </div>
-            </div>
-          <% end %>
-        </div>
-
       <% end %>
 
-      <div data-hook="admin_product_form_shipping_categories">
-        <%= f.field_container :shipping_categories do %>
-          <%= f.label :shipping_category_id, Spree::ShippingCategory.model_name.human %>
-          <%= f.field_hint :shipping_category %>
-          <%= f.collection_select(:shipping_category_id, @shipping_categories, :id, :name, { :include_blank => Spree.t('match_choices.none') }, { :class => 'select2' }) %>
-          <%= f.error_message_on :shipping_category %>
-        <% end %>
-      </div>
-
-      <div data-hook="admin_product_form_tax_category">
-        <%= f.field_container :tax_category do %>
-          <%= f.label :tax_category_id, Spree::TaxCategory.model_name.human %>
-          <%= f.field_hint :tax_category %>
-          <%= f.collection_select(:tax_category_id, @tax_categories, :id, :name, { :include_blank => Spree.t('match_choices.none') }, { :class => 'select2' }) %>
-          <%= f.error_message_on :tax_category %>
-        <% end %>
-      </div>
     </div>
 
   </div>
 
-  <div class="row">
+  <div class="col-lg-8 col-xs-12" >
 
-    <div class="col-xs-9">
-      <div data-hook="admin_product_form_taxons">
-        <%= f.field_container :taxons do %>
-          <%= f.label :taxon_ids, plural_resource_name(Spree::Taxon) %><br />
-          <%= f.hidden_field :taxon_ids, :value => @product.taxon_ids.join(',') %>
-        <% end %>
+    <div class="row form-section">
+
+      <div class="col-xs-12">
+        <h4><%= I18n.t(:search_engine_optimization, scope: [:spree, :product_sections]) %></h4>
+        <div class="hidden-lg-up">
+          <p><%= I18n.t(:search_engine_optimization, scope: [:spree, :hints, "spree/product"]) %></p>
+        </div>
       </div>
 
-      <div data-hook="admin_product_form_option_types">
-        <%= f.field_container :option_types do %>
-          <%= f.label :option_type_ids, plural_resource_name(Spree::OptionType) %>
-          <%= f.hidden_field :option_type_ids, :value => @product.option_type_ids.join(',') %>
-        <% end %>
-      </div>
+      <div data-hook="admin_product_form_meta" class="col-xs-12">
 
-      <div data-hook="admin_product_form_meta">
         <div data-hook="admin_product_form_meta_title">
           <%= f.field_container :meta_title do %>
             <%= f.label :meta_title %>
@@ -178,17 +244,26 @@
         <div data-hook="admin_product_form_meta_description">
           <%= f.field_container :meta_description do %>
             <%= f.label :meta_description %>
-            <%= f.text_field :meta_description, :class => 'fullwidth' %>
+            <%= f.text_area :meta_description, :rows => 3, :class => 'fullwidth' %>
           <% end %>
         </div>
+
+      </div>
+
+    </div>
+
+    <div data-hook="admin_product_form_additional_fields"></div>
+
+  </div>
+
+  <div class="col-lg-4 hidden-md-down">
+
+    <div class="row helpful-text-sidebar">
+      <div class="col-xs-12">
+        <p><%= I18n.t(:search_engine_optimization, scope: [:spree, :hints, "spree/product"]) %></p>
       </div>
     </div>
 
   </div>
 
-  <div class="clear"></div>
-
-  <div data-hook="admin_product_form_additional_fields"></div>
-
-  <div class="clear"></div>
 </div>

--- a/backend/app/views/spree/admin/products/edit.html.erb
+++ b/backend/app/views/spree/admin/products/edit.html.erb
@@ -1,3 +1,5 @@
+<% admin_layout 'max-width' %>
+
 <% content_for :page_actions do %>
   <% if can?(:create, Spree::Product) %>
     <li id="new_product_link">

--- a/backend/app/views/spree/admin/products/index.html.erb
+++ b/backend/app/views/spree/admin/products/index.html.erb
@@ -48,7 +48,7 @@
   </div>
 <% end %>
 
-<div id="new_product_wrapper" data-hook></div>
+<div id="new_product_wrapper" data-hook class="max-width-form"></div>
 
 <%= paginate @collection, theme: "solidus_admin" %>
 

--- a/backend/app/views/spree/admin/products/new.html.erb
+++ b/backend/app/views/spree/admin/products/new.html.erb
@@ -6,59 +6,66 @@
 
     <legend align="center"><%= Spree.t(:new_product) %></legend>
 
-    <%= f.field_container :name do %>
-      <%= f.label :name, class: 'required' %><br />
-      <%= f.text_field :name, :class => 'fullwidth title', :required => true %>
-      <%= f.error_message_on :name %>
-    <% end %>
+    <div class="row">
+      <div class="col-xl-8 col-xs-12">
+        <div class="row">
 
-    <div data-hook="new_product_attrs" class="row">
-      <% unless @product.has_variants? %>
-        <div data-hook="new_product_sku" class="col-xs-3">
-          <%= f.field_container :sku do %>
-            <%= f.label :sku, Spree.t(:sku) %><br />
-            <%= f.text_field :sku, :size => 16, :class => 'fullwidth' %>
-            <%= f.error_message_on :sku %>
+          <% unless @product.has_variants? %>
+            <div data-hook="new_product_sku" class="col-md-6 col-xs-12">
+              <%= f.field_container :sku do %>
+                <%= f.label :sku, Spree.t(:sku) %><br />
+                <%= f.text_field :sku, :size => 16, :class => 'fullwidth' %>
+                <%= f.error_message_on :sku %>
+              <% end %>
+            </div>
+            <div class="col-md-6 hidden-sm-down"></div>
           <% end %>
+
+          <div class="col-md-6 col-xs-12">
+            <%= f.field_container :name do %>
+              <%= f.label :name, class: 'required' %><br />
+              <%= f.text_field :name, :class => 'fullwidth title', :required => true %>
+              <%= f.error_message_on :name %>
+            <% end %>
+          </div>
+          <div class="col-md-6 hidden-sm-down"></div>
+
+          <div data-hook="new_product_price" class="col-md-3 col-xs-6">
+            <%= f.field_container :price do %>
+              <%= f.label :price, class: 'required' %><br />
+              <%= f.text_field :price, :value => number_to_currency(@product.price, :unit => ''), :class => 'fullwidth', :required => true %>
+              <%= f.error_message_on :price %>
+            <% end %>
+          </div>
+
+          <div data-hook="new_product_tax_category" class="col-md-3 col-xs-6">
+            <%= f.field_container :tax_category do %>
+              <%= f.label :tax_category_id, Spree::TaxCategory.model_name.human %>
+              <%= f.field_hint :tax_category %>
+              <%= f.collection_select(:tax_category_id, @tax_categories, :id, :name, { :include_blank => Spree.t('match_choices.none') }, { :class => 'select2 fullwidth' }) %>
+              <%= f.error_message_on :tax_category %>
+            <% end %>
+          </div>
+
+          <div data-hook="new_product_available_on" class="col-md-3 col-xs-6">
+            <%= f.field_container :available_on do %>
+              <%= f.label :available_on %>
+              <%= f.error_message_on :available_on %>
+              <%= f.text_field :available_on, :class => 'datepicker fullwidth' %>
+            <% end %>
+          </div>
+
+          <div data-hook="new_product_shipping_category" class="col-md-3 col-xs-6">
+            <%= f.field_container :shipping_category do %>
+              <%= f.label :shipping_category_id, Spree::ShippingCategory.
+                    model_name.human, class: 'required' %>
+              <%= f.field_hint :shipping_category %><br />
+              <%= f.collection_select(:shipping_category_id, @shipping_categories, :id, :name, { :include_blank => Spree.t('match_choices.none') }, { :class => 'select2 fullwidth' }) %>
+              <%= f.error_message_on :shipping_category_id %>
+            <% end %>
+          </div>
+
         </div>
-      <% end %>
-
-      <div data-hook="new_product_price" class="col-xs-3">
-        <%= f.field_container :price do %>
-          <%= f.label :price, class: 'required' %><br />
-          <%= f.text_field :price, :value => number_to_currency(@product.price, :unit => ''), :class => 'fullwidth', :required => true %>
-          <%= f.error_message_on :price %>
-        <% end %>
-      </div>
-
-      <div data-hook="new_product_available_on" class="col-xs-3">
-        <%= f.field_container :available_on do %>
-          <%= f.label :available_on %>
-          <%= f.error_message_on :available_on %>
-          <%= f.text_field :available_on, :class => 'datepicker fullwidth' %>
-        <% end %>
-      </div>
-
-    </div>
-
-    <div class='row'>
-      <div data-hook="new_product_shipping_category" class="col-xs-3">
-        <%= f.field_container :shipping_category do %>
-          <%= f.label :shipping_category_id, Spree::ShippingCategory.
-                model_name.human, class: 'required' %>
-          <%= f.field_hint :shipping_category %><br />
-          <%= f.collection_select(:shipping_category_id, @shipping_categories, :id, :name, { :include_blank => Spree.t('match_choices.none') }, { :class => 'select2 fullwidth' }) %>
-          <%= f.error_message_on :shipping_category_id %>
-        <% end %>
-      </div>
-
-      <div data-hook="new_product_tax_category" class="col-xs-3">
-        <%= f.field_container :tax_category do %>
-          <%= f.label :tax_category_id, Spree::TaxCategory.model_name.human %>
-          <%= f.field_hint :tax_category %>
-          <%= f.collection_select(:tax_category_id, @tax_categories, :id, :name, { :include_blank => Spree.t('match_choices.none') }, { :class => 'select2 fullwidth' }) %>
-          <%= f.error_message_on :tax_category %>
-        <% end %>
       </div>
     </div>
 

--- a/backend/app/views/spree/layouts/admin.html.erb
+++ b/backend/app/views/spree/layouts/admin.html.erb
@@ -10,11 +10,16 @@
     <%= render "spree/admin/shared/flash" %>
     <%= render "spree/admin/shared/spinner" %>
 
+    <% if @admin_layout %>
+      <div class="content-wrapper">
+        <%= yield :tabs %>
+      </div>
+    <% end %>
+
     <div class="content-wrapper <%= @admin_layout.presence %> <%= "has-sidebar" if content_for?(:sidebar) %>" id="wrapper" data-hook>
       <% if @admin_layout %>
         <div class="content">
           <div class="content-main">
-            <%= yield :tabs %>
             <%= render "spree/admin/shared/table_filter" %>
             <%= yield %>
           </div>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1184,6 +1184,9 @@ en:
         promotionable: "This determines whether or not promotions can apply to this product.<br/>Default: Checked"
         shipping_category: "This determines what kind of shipping this product requires.<br/> Default: Default"
         tax_category: "This determines what kind of taxation is applied to this product.<br/> Default: None"
+        delay_publishing: "Leave this empty if you want this product to be available in your store right away. Set a date in the future to hide it until then."
+        variant_setup: "Does this product come in multiple variations like size and color? Set these here so you can configure them in the variants tab."
+        search_engine_optimization: "Meta descriptions can be any length, but search engines generally truncate snippets longer than 160 characters. It is best to keep meta descriptions between 150 and 160 characters."
       spree/promotion:
         starts_at: "This determines when the promotion can be applied to orders. <br/> If no value is specified, the promotion will be immediately available."
         expires_at: "This determines when the promotion expires. <br/> If no value is specified, the promotion will never expires."
@@ -1581,6 +1584,12 @@ en:
       product_source:
         group: From product group
         manual: Manually choose
+    product_sections:
+      pricing: Pricing
+      shipping: Shipping
+      search_engine_optimization: Search Engine Optimization
+      delay_publishing: Delay Publishing
+      variant_setup: Variant Setup
     products: Products
     promotion: Promotion
     promotionable: Promotable


### PR DESCRIPTION
This PR upgrades the product edit view to utilise Bootstrap grids based on designs by @Mandily. #1290 

Changes include:
- Implemented a few new styles to fulfil design requirements including form-sections, font-awesome input add-ons, and a left-aligned xl width layout.
- Rendered tabs full-width always. This will allow the tabs to remain stationary across views once they are migrated to the admin-layout styles introduced in #1114 
- Responsive Bootstrap Grid form views for the product edit view.

I've attached a few screenshots here.

Product without variants:
![fullwidth](https://cloud.githubusercontent.com/assets/12424770/19871058/7ddcd834-9f70-11e6-8742-d1eda98f55b7.png)
Product with variants:
![with_variants](https://cloud.githubusercontent.com/assets/12424770/19871060/7de07836-9f70-11e6-97ff-1ec97ad7da79.png)

Below 992px
![small_width](https://cloud.githubusercontent.com/assets/12424770/19871059/7ddf6220-9f70-11e6-9460-8557470514d9.png)