### PR TITLE
Remove tax adjustments when no zone matches

### DIFF
--- a/core/app/models/spree/tax/item_adjuster.rb
+++ b/core/app/models/spree/tax/item_adjuster.rb
@@ -23,8 +23,6 @@ module Spree
       # Deletes all existing tax adjustments and creates new adjustments for all
       # (geographically and category-wise) applicable tax rates.
       def adjust!
-        return unless order.tax_address.country_id
-
         item.adjustments.destroy(item.adjustments.select(&:tax?))
 
         rates_for_item(item).each { |rate| rate.adjust(nil, item) }

--- a/core/app/models/spree/tax/item_adjuster.rb
+++ b/core/app/models/spree/tax/item_adjuster.rb
@@ -22,14 +22,12 @@ module Spree
 
       # Deletes all existing tax adjustments and creates new adjustments for all
       # (geographically and category-wise) applicable tax rates.
-      #
-      # @return [Array<Spree::Adjustment>] newly created adjustments
       def adjust!
         return unless order.tax_address.country_id
 
         item.adjustments.destroy(item.adjustments.select(&:tax?))
 
-        rates_for_item(item).map { |rate| rate.adjust(nil, item) }
+        rates_for_item(item).each { |rate| rate.adjust(nil, item) }
       end
     end
   end

--- a/core/app/models/spree/tax/order_adjuster.rb
+++ b/core/app/models/spree/tax/order_adjuster.rb
@@ -14,8 +14,6 @@ module Spree
       # Creates tax adjustments for all taxable items (shipments and line items)
       # in the given order.
       def adjust!
-        return unless order.tax_address.country_id
-
         (order.line_items + order.shipments).each do |item|
           ItemAdjuster.new(item, order_wide_options).adjust!
         end

--- a/core/spec/models/spree/tax/item_adjuster_spec.rb
+++ b/core/spec/models/spree/tax/item_adjuster_spec.rb
@@ -5,6 +5,10 @@ RSpec.describe Spree::Tax::ItemAdjuster do
   let(:order) { create(:order) }
   let(:item) { Spree::LineItem.new(order: order) }
 
+  def tax_adjustments
+    item.adjustments.tax.to_a
+  end
+
   describe 'initialization' do
     it 'sets order to item order' do
       expect(adjuster.order).to eq(item.order)
@@ -23,12 +27,9 @@ RSpec.describe Spree::Tax::ItemAdjuster do
     context 'when the order has no tax zone' do
       let(:address) { Spree::Tax::TaxLocation.new }
 
-      before do
+      it 'creates no adjustments' do
         adjuster.adjust!
-      end
-
-      it 'returns nil early' do
-        expect(adjuster.adjust!).to be_nil
+        expect(tax_adjustments).to eq([])
       end
     end
 
@@ -44,7 +45,8 @@ RSpec.describe Spree::Tax::ItemAdjuster do
         let(:rates_for_order_zone) { [] }
 
         it 'returns no adjustments' do
-          expect(adjuster.adjust!).to eq([])
+          adjuster.adjust!
+          expect(tax_adjustments).to eq([])
         end
       end
 
@@ -58,7 +60,8 @@ RSpec.describe Spree::Tax::ItemAdjuster do
           before { allow(item).to receive(:tax_category).and_return(item_tax_category) }
 
           it 'creates an adjustment for every matching rate' do
-            expect(adjuster.adjust!.length).to eq(1)
+            adjuster.adjust!
+            expect(tax_adjustments.length).to eq(1)
           end
         end
       end

--- a/core/spec/models/spree/tax/taxation_integration_spec.rb
+++ b/core/spec/models/spree/tax/taxation_integration_spec.rb
@@ -624,6 +624,25 @@ RSpec.describe "Taxation system integration tests" do
           federal_books_tax.destroy!
           expect(line_item.adjustments.count).to eq(2)
         end
+
+        context 'when tax address is later cleared' do
+          before do
+            order.ship_address = nil
+            order.update!
+          end
+
+          it 'removes all tax adjustments' do
+            aggregate_failures do
+              expect(line_item.adjustments.tax.count).to eq(0)
+              expect(line_item).to have_attributes(
+                price: 20,
+                total: 20,
+                included_tax_total: 0,
+                additional_tax_total: 0
+              )
+            end
+          end
+        end
       end
 
       context 'an order with a book and a shipment' do


### PR DESCRIPTION
Previously when the tax_address's `country_id` was `nil`, `OrderAdjuster` and `ItemAdjuste`r's `#adjust!` would return without making any changes to tax adjustments. If the tax address had a value, and then later becomes `nil`, the order would "remember" the old taxes and not update them.

Fortunately, clearing the address from an order is an uncommon operation. AFAIK it can only be done on the console.

This commit changes the item and order adjuster to continue in this case so that the order will have taxes removed.