### PR TITLE
Provide a consistent sort order in admin for shipment contents

### DIFF
--- a/backend/app/views/spree/admin/orders/_shipment.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment.html.erb
@@ -1,7 +1,11 @@
 <% admin_breadcrumb(plural_resource_name(Spree::Shipment)) %>
 
 
-<% manifest_items = Spree::ShippingManifest.new(inventory_units: shipment.inventory_units.where(carton_id: nil)).items %>
+<%
+  manifest_items = Spree::ShippingManifest.new(
+    inventory_units: shipment.inventory_units.where(carton_id: nil),
+  ).items.sort_by { |item| item.line_item.created_at }
+%>
 
 <div id="<%= "shipment_#{shipment.id}" %>" class="js-shipment-edit" data-hook="admin_shipment_form">
   <fieldset class="no-border-bottom">

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -438,6 +438,32 @@ describe "Order Details", type: :feature, js: true do
           end
         end
       end
+
+      describe 'line item sort order' do
+        let(:product2) { create(:product) }
+        let(:product3) { create(:product) }
+
+        before do
+          # grab this one first and then create others that should end up before
+          # and after
+          @middle_line_item = order.line_items[0]
+
+          @first_line_item  = order.contents.add(product2.master)
+          @first_line_item.update_columns(created_at: 1.day.ago)
+          @last_line_item  = order.contents.add(product3.master)
+          @last_line_item.update_columns(created_at: 1.day.from_now)
+        end
+
+        it 'orders the items in a shipment by created_at' do
+          visit spree.edit_admin_order_path(order)
+
+          stock_items = page.all(:css, '.stock-item', count: 3)
+
+          expect(stock_items[0]).to have_text(@first_line_item.variant.sku)
+          expect(stock_items[1]).to have_text(@middle_line_item.variant.sku)
+          expect(stock_items[2]).to have_text(@last_line_item.variant.sku)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
This adds a `sort_by` so that line items in each shipment are listed
in a consistent sort order in the admin.

The shipments themselves already have a consistent sort order (for
multiple shipments in a single order).