### PR TITLE
Simplify image upload UI

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/sections/_products.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/_products.scss
@@ -37,10 +37,15 @@ div[data-hook="admin_products_index_search_buttons"] {
 }
 
 #upload-zone {
-  border: 10px dashed $color-border;
+  border: 2px dashed $color-border;
   padding: 2rem 5rem;
   text-align: center;
-  margin-bottom: 1.5rem;
+  margin: 1rem auto;
+  width: 70%;
+
+  label.upload {
+    display: block;
+  }
 
   &.with-images {
     border-color: $color-success;

--- a/backend/app/assets/stylesheets/spree/backend/sections/_products.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/_products.scss
@@ -38,8 +38,7 @@ div[data-hook="admin_products_index_search_buttons"] {
 
 #upload-zone {
   border: 10px dashed $color-border;
-  min-height: 100px;
-  padding: 1rem 5rem;
+  padding: 2rem 5rem;
   text-align: center;
   margin-bottom: 1.5rem;
 

--- a/backend/app/views/spree/admin/images/index.html.erb
+++ b/backend/app/views/spree/admin/images/index.html.erb
@@ -17,8 +17,14 @@
   <div id="upload-zone">
     <%= form_for [:admin, @product, Spree::Image.new],
         :html => { :multipart => true, id: 'upload-form' } do |f| %>
-      <label>
-        <span class="button"><%= t(".drag_images_to_upload") %></span>
+      <label class="upload">
+        <i class="fa fa-5x fa-cloud-upload"></i>
+        <p>
+          <span class="button"><%= t(".choose_files") %></span>
+        </p>
+        <p>
+          <%= t(".drag_and_drop") %>
+        </p>
 
         <%= f.file_field :attachment, multiple: '', class: 'hidden' %>
         <%= f.hidden_field :viewable_id, value: @product.master.id %>

--- a/backend/app/views/spree/admin/images/index.html.erb
+++ b/backend/app/views/spree/admin/images/index.html.erb
@@ -18,8 +18,9 @@
     <%= form_for [:admin, @product, Spree::Image.new],
         :html => { :multipart => true, id: 'upload-form' } do |f| %>
       <label>
-        <p><%= t(".drag_images_to_upload") %></p>
-        <%= f.file_field :attachment, multiple: '' %>
+        <span class="button"><%= t(".drag_images_to_upload") %></span>
+
+        <%= f.file_field :attachment, multiple: '', class: 'hidden' %>
         <%= f.hidden_field :viewable_id, value: @product.master.id %>
       </label>
     <% end %>

--- a/backend/spec/features/admin/products/edit/images_spec.rb
+++ b/backend/spec/features/admin/products/edit/images_spec.rb
@@ -52,7 +52,7 @@ describe "Product Images", type: :feature do
 
       within_fieldset 'Upload Image' do
         # Can also pass multiple files in the array, but SQLite gives a deadlock on insert
-        attach_file('image_attachment', [file_path])
+        attach_file('image_attachment', [file_path], visible: false)
         expect(page).to have_css("progress", count: 1)
         expect(page).to have_text("ror_ringer")
       end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -748,7 +748,8 @@ en:
           no_cart_tax_country: "No taxes on carts without address"
       images:
         index:
-          drag_images_to_upload: Browse or drag files here to upload
+          choose_files: Choose files to upload
+          drag_and_drop: or drag and drop them here
           image_process_failed: Server failed to process the image
           upload_images: Upload Images
       payments:

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -748,7 +748,7 @@ en:
           no_cart_tax_country: "No taxes on carts without address"
       images:
         index:
-          drag_images_to_upload: Drag images from your desktop on to the drop zone to upload
+          drag_images_to_upload: Browse or drag files here to upload
           image_process_failed: Server failed to process the image
           upload_images: Upload Images
       payments:


### PR DESCRIPTION
This replaces the new image upload area (previously a paragraph of text and a file upload field) with a single button inside the drop area with the text "Browse or drag files here to upload".

The original problem I set out to fix was that after uploading an image through the file input, the filename remained. I added some javascript to clear the field after uploading, which worked great, but now there was always the text "No file selected". After this I realized the entire area was a label and we can just hide the upload field.

### After
![](http://i.hawth.ca/s/MJh91Ky4.png)

### Before
![](http://i.hawth.ca/s/D6GDCwXQ.png)