### PR TITLE
Deprecate default zone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
 ## Solidus 2.1.0 (master, unreleased)
+
+*   Deprecate methods related to Spree::Order#tax_zone
+
+    We're not using `Spree::Order#tax_zone`, `Spree::Zone.default_tax`,
+    `Spree::Zone.match`, or `Spree::Zone#contains?` in our code base anymore.
+    They will be removed soon. Please use `Spree::Order#tax_address`,
+    `Spree::Zone.for_address`, and `Spree::Zone.include?`, respectively,
+    instead.
+
 *   Prototypes were removed from the admin; the extension `solidus_prototype`
     provides the same functionality
 

--- a/backend/app/views/spree/admin/zones/_form.html.erb
+++ b/backend/app/views/spree/admin/zones/_form.html.erb
@@ -15,11 +15,6 @@
           <%= zone_form.text_field :description, :class => 'fullwidth' %>
         <% end %>
 
-        <div data-hook="default" class="field">
-          <%= zone_form.check_box :default_tax %>
-          <%= zone_form.label :default_tax %>
-        </div>
-
         <div data-hook="type" class="field">
           <%= label_tag Spree.t(:type) %>
           <ul>

--- a/backend/app/views/spree/admin/zones/index.html.erb
+++ b/backend/app/views/spree/admin/zones/index.html.erb
@@ -29,7 +29,6 @@
         <th>
           <%= sort_link @search,:description, Spree::Zone.human_attribute_name(:description), {}, {:title => 'zones_order_by_description_title'} %>
         </th>
-        <th><%= Spree.t(:default_tax) %></th>
         <th class="actions"></th>
       </tr>
     </thead>
@@ -38,7 +37,6 @@
         <tr id="<%= spree_dom_id zone %>" data-hook="zones_row" class="<%= cycle('odd', 'even')%>">
           <td class="align-center"><%= zone.name %></td>
           <td><%= zone.description %></td>
-          <td class="align-center"><%= zone.default_tax? ? Spree.t(:say_yes) : Spree.t(:say_no) %></td>
           <td class="actions">
             <% if can?(:update, zone) %>
               <%= link_to_edit zone, :no_text => true %>

--- a/core/app/models/spree/zone.rb
+++ b/core/app/models/spree/zone.rb
@@ -55,6 +55,8 @@ module Spree
     # A State zone wins over a country zone, and a zone with few members wins
     # over one with many members. If there is no match, returns nil.
     def self.match(address)
+      Spree::Deprecation.warn("Spree::Zone.match is deprecated. Please use Spree::Zone.for_address instead.", caller)
+
       return unless address && (matches =
                                   with_member_ids(address.state_id, address.country_id).
                                   order(:zone_members_count, :created_at, :id).

--- a/core/app/models/spree/zone.rb
+++ b/core/app/models/spree/zone.rb
@@ -166,6 +166,7 @@ module Spree
         (target.zoneables.collect(&:country).collect(&:id) - zoneables.collect(&:id)).empty?
       end
     end
+    deprecate :contains?, deprecator: Spree::Deprecation
 
     private
 

--- a/core/app/models/spree/zone.rb
+++ b/core/app/models/spree/zone.rb
@@ -41,8 +41,14 @@ module Spree
 
     self.whitelisted_ransackable_attributes = ['description']
 
+    # Returns the zone marked as `default_tax`.
+    # @deprecated Please run the `solidus:migrations:create_vat_prices` rake task
     def self.default_tax
-      where(default_tax: true).first
+      default_tax_zone = where(default_tax: true).first
+      if default_tax_zone
+        Spree::Deprecation.warn("Please run the `solidus:migrations:create_vat_prices` rake task.", caller)
+        default_tax_zone
+      end
     end
 
     # Returns the most specific matching zone for an address. Specific means:

--- a/core/spec/lib/spree/core/price_migrator_spec.rb
+++ b/core/spec/lib/spree/core/price_migrator_spec.rb
@@ -114,7 +114,9 @@ describe Spree::PriceMigrator do
     end
 
     before do
-      Spree::PriceMigrator.migrate_default_vat_prices
+      Spree::Deprecation.silence do
+        Spree::PriceMigrator.migrate_default_vat_prices
+      end
       order.contents.add(variant)
     end
 

--- a/core/spec/lib/tasks/migrations/create_vat_prices_spec.rb
+++ b/core/spec/lib/tasks/migrations/create_vat_prices_spec.rb
@@ -20,9 +20,11 @@ describe 'solidus:migrations:create_vat_prices' do
       let!(:zone) { create(:zone, :with_country, default_tax: true) }
 
       it 'runs' do
-        expect { task.invoke }.to output(
-          "Creating differentiated prices for VAT countries ... Success.\n"
-        ).to_stdout
+        Spree::Deprecation.silence do
+          expect { task.invoke }.to output(
+            "Creating differentiated prices for VAT countries ... Success.\n"
+          ).to_stdout
+        end
       end
     end
   end

--- a/core/spec/models/spree/reimbursement_spec.rb
+++ b/core/spec/models/spree/reimbursement_spec.rb
@@ -49,7 +49,7 @@ describe Spree::Reimbursement, type: :model do
     let!(:adjustments)            { [] } # placeholder to ensure it gets run prior the "before" at this level
 
     let!(:tax_rate)               { nil }
-    let!(:tax_zone)               { create :zone, :with_country, default_tax: true }
+    let!(:tax_zone)               { create :zone, :with_country }
     let(:shipping_method)         { create :shipping_method, zones: [tax_zone] }
     let(:variant)                 { create :variant }
     let(:order)                   { create(:order_with_line_items, state: 'payment', line_items_attributes: [{ variant: variant, price: line_items_price }], shipment_cost: 0, shipping_method: shipping_method) }

--- a/core/spec/models/spree/reimbursement_tax_calculator_spec.rb
+++ b/core/spec/models/spree/reimbursement_tax_calculator_spec.rb
@@ -24,7 +24,7 @@ describe Spree::ReimbursementTaxCalculator, type: :model do
 
   context 'with additional tax' do
     let!(:tax_rate) { create(:tax_rate, name: "Sales Tax", amount: 0.10, included_in_price: false, zone: tax_zone) }
-    let(:tax_zone) { create(:zone, :with_country, default_tax: true) }
+    let(:tax_zone) { create(:zone, :with_country) }
 
     it 'sets additional_tax_total on the return items' do
       subject
@@ -37,7 +37,7 @@ describe Spree::ReimbursementTaxCalculator, type: :model do
 
   context 'with included tax' do
     let!(:tax_rate) { create(:tax_rate, name: "VAT Tax", amount: 0.1, included_in_price: true, zone: tax_zone) }
-    let(:tax_zone) { create(:zone, :with_country, default_tax: true) }
+    let(:tax_zone) { create(:zone, :with_country) }
 
     it 'sets included_tax_total on the return items' do
       subject

--- a/core/spec/models/spree/shipping_rate_spec.rb
+++ b/core/spec/models/spree/shipping_rate_spec.rb
@@ -19,8 +19,9 @@ describe Spree::ShippingRate, type: :model do
   end
 
   context "#display_price" do
-    let!(:default_zone) { create :zone, countries: [address.country], default_tax: true }
+    let!(:default_zone) { create :zone, countries: [address.country], default_tax: default_tax }
     let!(:other_zone) { create :zone, countries: [foreign_address.country] }
+    let(:default_tax) { false }
 
     before do
       allow(order).to receive(:tax_address).and_return(order_address)
@@ -57,6 +58,7 @@ describe Spree::ShippingRate, type: :model do
     end
 
     context 'with one tax rate that will be refunded' do
+      let(:default_tax) { true }
       let!(:tax_rate) do
         create :tax_rate,
         included_in_price: true,
@@ -68,7 +70,9 @@ describe Spree::ShippingRate, type: :model do
       let(:order_address) { foreign_address }
 
       before do
-        Spree::Tax::ShippingRateTaxer.new.tax(shipping_rate)
+        Spree::Deprecation.silence do
+          Spree::Tax::ShippingRateTaxer.new.tax(shipping_rate)
+        end
       end
 
       it "shows correct tax amount" do

--- a/core/spec/models/spree/tax_rate_spec.rb
+++ b/core/spec/models/spree/tax_rate_spec.rb
@@ -104,7 +104,7 @@ describe Spree::TaxRate, type: :model do
       end
 
       context "when there is a default tax zone" do
-        let(:default_zone) { create(:zone, :with_country, default_tax: true) }
+        let(:default_zone) { create(:zone, :with_country) }
         let(:included_in_price) { false }
         let!(:rate) do
           create(:tax_rate, zone: default_zone, included_in_price: included_in_price)
@@ -152,7 +152,10 @@ describe Spree::TaxRate, type: :model do
 
     describe 'adjustments' do
       before do
-        tax_rate.adjust(nil, item)
+        # Please remove this silencing once we remove `Spree::Zone.default_tax`
+        Spree::Deprecation.silence do
+          tax_rate.adjust(nil, item)
+        end
       end
 
       let(:adjustment_label) { item.adjustments.tax.first.label }

--- a/core/spec/models/spree/zone_spec.rb
+++ b/core/spec/models/spree/zone_spec.rb
@@ -198,12 +198,16 @@ describe Spree::Zone, type: :model do
     end
 
     it "should contain itself" do
-      expect(@source.contains?(@source)).to be true
+      Spree::Deprecation.silence do
+        expect(@source.contains?(@source)).to be true
+      end
     end
 
     context "when both source and target have no members" do
       it "should be false" do
-        expect(@source.contains?(@target)).to be false
+        Spree::Deprecation.silence do
+          expect(@source.contains?(@target)).to be false
+        end
       end
     end
 
@@ -211,7 +215,9 @@ describe Spree::Zone, type: :model do
       before { @source.members.create(zoneable: country1) }
 
       it "should be false" do
-        expect(@source.contains?(@target)).to be false
+        Spree::Deprecation.silence do
+          expect(@source.contains?(@target)).to be false
+        end
       end
     end
 
@@ -219,7 +225,9 @@ describe Spree::Zone, type: :model do
       before { @target.members.create(zoneable: country1) }
 
       it "should be false" do
-        expect(@source.contains?(@target)).to be false
+        Spree::Deprecation.silence do
+          expect(@source.contains?(@target)).to be false
+        end
       end
     end
 
@@ -229,7 +237,9 @@ describe Spree::Zone, type: :model do
       end
 
       it "should be true" do
-        expect(@source.contains?(@target)).to be true
+        Spree::Deprecation.silence do
+          expect(@source.contains?(@target)).to be true
+        end
       end
     end
 
@@ -246,7 +256,9 @@ describe Spree::Zone, type: :model do
         end
 
         it "should be true" do
-          expect(@source.contains?(@target)).to be true
+          Spree::Deprecation.silence do
+            expect(@source.contains?(@target)).to be true
+          end
         end
       end
 
@@ -258,7 +270,9 @@ describe Spree::Zone, type: :model do
         end
 
         it "should be false" do
-          expect(@source.contains?(@target)).to be false
+          Spree::Deprecation.silence do
+            expect(@source.contains?(@target)).to be false
+          end
         end
       end
 
@@ -269,7 +283,9 @@ describe Spree::Zone, type: :model do
         end
 
         it "should be false" do
-          expect(@source.contains?(@target)).to be false
+          Spree::Deprecation.silence do
+            expect(@source.contains?(@target)).to be false
+          end
         end
       end
     end
@@ -281,7 +297,9 @@ describe Spree::Zone, type: :model do
       end
 
       it "should be false" do
-        expect(@source.contains?(@target)).to be false
+        Spree::Deprecation.silence do
+          expect(@source.contains?(@target)).to be false
+        end
       end
     end
 
@@ -295,7 +313,9 @@ describe Spree::Zone, type: :model do
         end
 
         it "should be true" do
-          expect(@source.contains?(@target)).to be true
+          Spree::Deprecation.silence do
+            expect(@source.contains?(@target)).to be true
+          end
         end
       end
 
@@ -307,7 +327,9 @@ describe Spree::Zone, type: :model do
         end
 
         it "should be false" do
-          expect(@source.contains?(@target)).to be false
+          Spree::Deprecation.silence do
+            expect(@source.contains?(@target)).to be false
+          end
         end
       end
 
@@ -318,7 +340,9 @@ describe Spree::Zone, type: :model do
         end
 
         it "should be false" do
-          expect(@source.contains?(@target)).to be false
+          Spree::Deprecation.silence do
+            expect(@source.contains?(@target)).to be false
+          end
         end
       end
     end

--- a/core/spec/models/spree/zone_spec.rb
+++ b/core/spec/models/spree/zone_spec.rb
@@ -160,7 +160,9 @@ describe Spree::Zone, type: :model do
 
       it "should be the correct zone" do
         create(:zone, name: 'foo')
-        expect(Spree::Zone.default_tax).to eq(@foo_zone)
+        Spree::Deprecation.silence do
+          expect(Spree::Zone.default_tax).to eq(@foo_zone)
+        end
       end
     end
 

--- a/core/spec/models/spree/zone_spec.rb
+++ b/core/spec/models/spree/zone_spec.rb
@@ -60,7 +60,9 @@ describe Spree::Zone, type: :model do
       let(:address) { create(:address, country: country, state: country.states.first) }
 
       it "should return the qualifying zone" do
-        expect(Spree::Zone.match(address)).to eq(country_zone)
+        Spree::Deprecation.silence do
+          expect(Spree::Zone.match(address)).to eq(country_zone)
+        end
       end
     end
 
@@ -72,7 +74,9 @@ describe Spree::Zone, type: :model do
 
       context "when both zones have the same number of members" do
         it "should return the zone that was created first" do
-          expect(Spree::Zone.match(address)).to eq(country_zone)
+          Spree::Deprecation.silence do
+            expect(Spree::Zone.match(address)).to eq(country_zone)
+          end
         end
       end
 
@@ -82,7 +86,9 @@ describe Spree::Zone, type: :model do
         before { country_zone.members.create(zoneable: country2) }
 
         it "should return the zone with fewer members" do
-          expect(Spree::Zone.match(address)).to eq(second_zone)
+          Spree::Deprecation.silence do
+            expect(Spree::Zone.match(address)).to eq(second_zone)
+          end
         end
       end
     end
@@ -94,13 +100,17 @@ describe Spree::Zone, type: :model do
       before { state_zone.members.create(zoneable: country.states.first) }
 
       it "should return the zone with the more specific member type" do
-        expect(Spree::Zone.match(address)).to eq(state_zone)
+        Spree::Deprecation.silence do
+          expect(Spree::Zone.match(address)).to eq(state_zone)
+        end
       end
     end
 
     context "when there are no qualifying zones" do
       it "should return nil" do
-        expect(Spree::Zone.match(Spree::Address.new)).to be_nil
+        Spree::Deprecation.silence do
+          expect(Spree::Zone.match(Spree::Address.new)).to be_nil
+        end
       end
     end
   end
@@ -115,7 +125,9 @@ describe Spree::Zone, type: :model do
       before { country_zone.members.create(zoneable: country) }
 
       it 'should return a list of countries' do
-        expect(country_zone.country_list).to eq([country])
+        Spree::Deprecation.silence do
+          expect(country_zone.country_list).to eq([country])
+        end
       end
     end
 
@@ -125,7 +137,9 @@ describe Spree::Zone, type: :model do
       before { state_zone.members.create(zoneable: state) }
 
       it 'should return a list of countries' do
-        expect(state_zone.country_list).to eq([state.country])
+        Spree::Deprecation.silence do
+          expect(state_zone.country_list).to eq([state.country])
+        end
       end
     end
   end


### PR DESCRIPTION
Instead of fully deleting the terrible code paths that lead to "tax reimbursements", this PR deprecates the core methods for those code paths. 

This supersedes #1537, which we'll pull through in Solidus 3. 
