### PR TITLE
Fix RMA amount calculator

### DIFF
--- a/core/app/models/spree/calculator/returns/default_refund_amount.rb
+++ b/core/app/models/spree/calculator/returns/default_refund_amount.rb
@@ -3,7 +3,6 @@ require_dependency 'spree/returns_calculator'
 module Spree
   module Calculator::Returns
     class DefaultRefundAmount < ReturnsCalculator
-
       def compute(return_item)
         return 0.0.to_d if return_item.part_of_exchange?
         weighted_order_adjustment_amount(return_item.inventory_unit) + weighted_line_item_amount(return_item.inventory_unit)
@@ -16,7 +15,7 @@ module Spree
       end
 
       def weighted_line_item_amount(inventory_unit)
-        inventory_unit.line_item.total_before_tax * percentage_of_line_item(inventory_unit)
+        inventory_unit.line_item.total_before_tax / quantity_of_line_item(inventory_unit)
       end
 
       def percentage_of_order_total(inventory_unit)
@@ -24,8 +23,8 @@ module Spree
         weighted_line_item_amount(inventory_unit) / inventory_unit.order.item_total_before_tax
       end
 
-      def percentage_of_line_item(inventory_unit)
-        1 / BigDecimal.new(inventory_unit.line_item.quantity)
+      def quantity_of_line_item(inventory_unit)
+        BigDecimal.new(inventory_unit.line_item.quantity)
       end
     end
   end

--- a/core/spec/models/spree/calculator/refunds/default_refund_amount_spec.rb
+++ b/core/spec/models/spree/calculator/refunds/default_refund_amount_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 require 'shared_examples/calculator_shared_examples'
 
 RSpec.describe Spree::Calculator::Returns::DefaultRefundAmount, type: :model do
-  let(:line_item_quantity) { 2 }
+  let(:line_item_quantity) { 3 }
   let(:line_item_price) { 100.0 }
   let(:line_item) { create(:line_item, price: line_item_price, quantity: line_item_quantity) }
   let(:inventory_unit) { build(:inventory_unit, order: order, line_item: line_item) }
@@ -36,7 +36,13 @@ RSpec.describe Spree::Calculator::Returns::DefaultRefundAmount, type: :model do
         order.adjustments.first.update_attributes(amount: adjustment_amount)
       end
 
-      it { is_expected.to eq line_item_price - (adjustment_amount.abs / line_item_quantity) }
+      it 'will return the line item amount deducted of refund' do
+        # line_item_price    = 100
+        # line_item_quantity = 3
+        # adjustment_amount  = 10
+        # 100 - (10 / 3)     = 96.66666666666666667
+        expect(subject).to eq BigDecimal.new('96.66666666666666667')
+      end
     end
 
     context "shipping adjustments" do


### PR DESCRIPTION
RMA calculator use the percentage to calculate the weighted line item
amount, but when the percentage is a repeating decimal the calculator
makes an error. Replaced the percentage calculation with a division.

ref #1564