### PR TITLE
Order total not updated when using CreateQuantityAdjustments

### DIFF
--- a/core/app/models/spree/order_inventory.rb
+++ b/core/app/models/spree/order_inventory.rb
@@ -74,6 +74,8 @@ module Spree
         shipment.stock_location.unstock(variant, quantity, shipment)
       end
 
+      line_item.reload
+
       quantity
     end
 

--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -183,7 +183,7 @@ module Spree
         Spree::Config.promotion_chooser_class.new(promotion_adjustments).update
 
         item.promo_total = promotion_adjustments.select(&:eligible?).sum(&:amount)
-        item.save! if item.persisted?
+        item.save
       end
     end
 

--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -183,6 +183,7 @@ module Spree
         Spree::Config.promotion_chooser_class.new(promotion_adjustments).update
 
         item.promo_total = promotion_adjustments.select(&:eligible?).sum(&:amount)
+        item.save! if item.persisted?
       end
     end
 

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -64,6 +64,8 @@ describe Spree::LineItem, type: :model do
 
     # Specs for https://github.com/solidusio/solidus/pull/522#issuecomment-170668125
     context "with `#copy_price` defined" do
+      let(:order) { create :order }
+
       before(:context) do
         Spree::LineItem.class_eval do
           def copy_price
@@ -81,16 +83,17 @@ describe Spree::LineItem, type: :model do
 
       it 'should display a deprecation warning' do
         expect(Spree::Deprecation).to receive(:warn)
-        Spree::LineItem.new(variant: variant, order: order)
+        Spree::LineItem.new(variant: variant, order: order).save
       end
 
       it 'should run the user-defined copy_price method' do
         expect_any_instance_of(Spree::LineItem).to receive(:copy_price).and_call_original
         Spree::Deprecation.silence do
-          Spree::LineItem.new(variant: variant, order: order)
+          Spree::LineItem.new(variant: variant, order: order).save
         end
       end
     end
+
   end
 
   describe '.discounted_amount' do


### PR DESCRIPTION
# How to reproduce the bug:

1. create an item-level promotion, make it `auto-apply` to make things easier
2. in the frontend, try to add a few elements into cart
3. update the item-level promotion. We can see that the promotion has been successfully applied.
4. update the promotion / add in another item-level promotion (so that it can trigger a change in the current one)
5. refresh the cart page, we can see that the promotion price has been updated successfully, but the final price is not.

# ScreenShot

Cart Page: 
![image](https://cloud.githubusercontent.com/assets/1553760/20343450/5a1dfb38-ac29-11e6-9cf8-aa8cb8cbc826.png)

Promotion Setting Page:
![image](https://cloud.githubusercontent.com/assets/1553760/20343476/70f4911e-ac29-11e6-8e75-9846ab821d7e.png)


# Cause of the bug:

in `core/app/models/spree/order_updater.rb#185`, after the `promo_total` has been computed, it's not saved.

# Some more changes
This pull request also fix:

1. `core/spec/models/spree/line_item_spec.rb` "with `#copy_price` defined": initially, it's actually relaying on the evaluation of order object, but not the ` Spree::LineItem.new` to trigger the method call.
2. `core/app/models/spree/order_inventory.rb` reload the `line_item` after add_to_shipment; if not reload, when 'Spree::OrderInventory#verify' called, the `inventory_units.size` would always be 0 (because that.. although the inventory is added, but the line_item is unaware because it's still holding the old object)
