### PR TITLE
Update highline gem version

### DIFF
--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'cancancan', '~> 1.10'
   s.add_dependency 'ffaker', '~> 2.0'
   s.add_dependency 'friendly_id', '~> 5.0'
-  s.add_dependency 'highline', '~> 1.7.8' # Necessary for the install generator
+  s.add_dependency 'highline', '~> 1.7' # Necessary for the install generator
   s.add_dependency 'kaminari', '~> 0.15', '>= 0.15.1'
   s.add_dependency 'monetize', '~> 1.1'
   s.add_dependency 'paperclip', '~> 4.2'

--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'cancancan', '~> 1.10'
   s.add_dependency 'ffaker', '~> 2.0'
   s.add_dependency 'friendly_id', '~> 5.0'
-  s.add_dependency 'highline', '~> 1.6.18' # Necessary for the install generator
+  s.add_dependency 'highline', '~> 1.7.8' # Necessary for the install generator
   s.add_dependency 'kaminari', '~> 0.15', '>= 0.15.1'
   s.add_dependency 'monetize', '~> 1.1'
   s.add_dependency 'paperclip', '~> 4.2'


### PR DESCRIPTION
Solidus [currently requires](https://github.com/solidusio/solidus/blob/master/core/solidus_core.gemspec#L30) version 1.6.x of the Highline gem. The last 1.6 release was almost 3 years ago and has [known bugs](https://github.com/JEG2/highline/blob/master/Changelog.md) that are unlikely to ever get fixed, such as backspace not working in Cyrillic.

Updating this also fixes a conflict with other libraries (such as [i18n-tasks](https://github.com/glebm/i18n-tasks)) that use a newer version of the Highline gem.