### PR TITLE
Sample test_app fixes

### DIFF
--- a/core/db/default/spree/store_credit.rb
+++ b/core/db/default/spree/store_credit.rb
@@ -4,7 +4,8 @@ Spree::PaymentMethod.create_with(
   name: "Store Credit",
   description: "Store credit",
   active: true,
-  display_on: 'none'
+  available_to_admin: false,
+  available_to_users: false
 ).find_or_create_by!(
   type: "Spree::PaymentMethod::StoreCredit"
 )

--- a/sample/Rakefile
+++ b/sample/Rakefile
@@ -7,7 +7,6 @@ desc "Generates a dummy app for testing"
 task :test_app do
   ENV['LIB_NAME'] = 'spree/sample'
   Rake::Task['common:test_app'].invoke
-  Rake::Task['common:seed'].invoke
 end
 
 RSpec::Core::RakeTask.new

--- a/sample/spec/lib/load_sample_spec.rb
+++ b/sample/spec/lib/load_sample_spec.rb
@@ -3,12 +3,8 @@ require 'spec_helper'
 describe "Load samples" do
   it "doesn't raise any error" do
     expect {
-      # Seeds are only run for rake test_app so to allow this spec to pass without
-      # rerunning rake test_app every time we must load them in if not already.
-      unless Spree::Zone.find_by_name("North America")
-        load Rails.root + 'Rakefile'
-        load Rails.root + 'db/seeds.rb'
-      end
+      load Rails.root + 'Rakefile'
+      load Rails.root + 'db/seeds.rb'
 
       SpreeSample::Engine.load_samples
     }.to output.to_stdout

--- a/sample/spec/spec_helper.rb
+++ b/sample/spec/spec_helper.rb
@@ -23,6 +23,10 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
 
+  config.before(:suite) do
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, comment the following line or assign false
   # instead of true.


### PR DESCRIPTION
Instead of running seeds inside of `rake test_app` (which no other projects do), load seeds inside of the spec run.

This should fix some users were having running `build.sh` on the latest versions of bundler.

cc @bbuchalter 