### PR TITLE
Only run setup_for_current_state in edit, update

### DIFF
--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -17,7 +17,7 @@ module Spree
     before_action :check_authorization
     before_action :apply_coupon_code
 
-    before_action :setup_for_current_state
+    before_action :setup_for_current_state, only: [:edit, :update]
 
     helper 'spree/orders'
 


### PR DESCRIPTION
See also https://github.com/solidusio/solidus_auth_devise/pull/76 and https://github.com/solidusio/solidus/issues/1588

Because that before_action was running on all actions of the controller,
the extra actions added by solidus_auth_devise had this run before them,
which wasn't desirable.

This has been fixed via a skip_before_action in solidus_auth_devise, but
we might as well restrict it here as well, since it only makes sense for
these two specific actions.
