### PR TITLE
remove unnecessary order.line_item reload

### DIFF
--- a/core/app/models/spree/promotion/actions/create_quantity_adjustments.rb
+++ b/core/app/models/spree/promotion/actions/create_quantity_adjustments.rb
@@ -78,7 +78,7 @@ module Spree::Promotion::Actions
     private
 
     def actionable_line_items(order)
-      order.line_items.reload.select do |item|
+      order.line_items.select do |item|
         promotion.line_item_actionable? order, item
       end
     end

--- a/core/spec/models/spree/promotion/actions/create_quantity_adjustments_spec.rb
+++ b/core/spec/models/spree/promotion/actions/create_quantity_adjustments_spec.rb
@@ -214,17 +214,64 @@ module Spree::Promotion::Actions
       end
     end
 
-
-    context "with pre-set line_item changes" do
+    # Regression test for https://github.com/solidusio/solidus/pull/1591
+    context "with unsaved line_item changes" do
       let(:calculator) { FactoryGirl.create :flat_rate_calculator }
       let(:line_item) { order.line_items.first }
 
-      before {
+      before do
         order.line_items.first.promo_total = -11
         action.compute_amount(line_item)
-      }
+      end
 
-      it { expect(order.line_items.first.promo_total).to eq -11 }
+      it "doesn't reload the line_items association" do
+        expect(order.line_items.first.promo_total).to eq -11
+      end
+    end
+
+    # Regression test for https://github.com/solidusio/solidus/pull/1591
+    context "applied to the order" do
+      let(:calculator) { FactoryGirl.create :flat_rate_calculator }
+
+      before do
+        action.perform(order: order, promotion: promotion)
+        order.update!
+      end
+
+      it 'updates the order totals' do
+        expect(order).to have_attributes(
+          total: 100,
+          adjustment_total: -10
+        )
+      end
+
+      context "after updating item quantity" do
+        before do
+          order.line_items.first.update!(quantity: 2, price: 30)
+          order.update!
+        end
+
+        it 'updates the order totals' do
+          expect(order).to have_attributes(
+            total: 140,
+            adjustment_total: -20
+          )
+        end
+      end
+
+      context "after updating promotion amount" do
+        before do
+          calculator.update!(preferred_amount: 5)
+          order.update!
+        end
+
+        it 'updates the order totals' do
+          expect(order).to have_attributes(
+            total: 105,
+            adjustment_total: -5
+          )
+        end
+      end
     end
 
     describe Spree::Promotion::Actions::CreateQuantityAdjustments::PartialLineItem do

--- a/core/spec/models/spree/promotion/actions/create_quantity_adjustments_spec.rb
+++ b/core/spec/models/spree/promotion/actions/create_quantity_adjustments_spec.rb
@@ -214,6 +214,19 @@ module Spree::Promotion::Actions
       end
     end
 
+
+    context "with pre-set line_item changes" do
+      let(:calculator) { FactoryGirl.create :flat_rate_calculator }
+      let(:line_item) { order.line_items.first }
+
+      before {
+        order.line_items.first.promo_total = -11
+        action.compute_amount(line_item)
+      }
+
+      it { expect(order.line_items.first.promo_total).to eq -11 }
+    end
+
     describe Spree::Promotion::Actions::CreateQuantityAdjustments::PartialLineItem do
       let!(:item) { FactoryGirl.create :line_item, order: order, quantity: quantity, price: 10 }
       let(:quantity) { 5 }


### PR DESCRIPTION
remove unnecessary order.line_item reload for quantity adjustment. This is
necessary because the `order.update` is in-memory. If order.line_item reload
happened, it would overwrite the line_item update.