### PR TITLE
adds spree token to users api request

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/user_picker.js
+++ b/backend/app/assets/javascripts/spree/backend/user_picker.js
@@ -12,7 +12,8 @@ $.fn.userAutocomplete = function () {
       Spree.ajax({
         url: Spree.routes.users_api,
         data: {
-          ids: element.val()
+          ids: element.val(),
+          token: Spree.api_key
         },
         success: function(data) {
           callback(data.users);


### PR DESCRIPTION
Without this, promotion rule for users is consistently failing in the admin when select2 tries to fetch the list of the users from the api; something similar could be needed at other places as well, such as around line #34