### PR TITLE
Code cleanup - Spree::Promotion::Actions::CreateLineItems

### DIFF
--- a/core/app/models/spree/promotion_handler/coupon.rb
+++ b/core/app/models/spree/promotion_handler/coupon.rb
@@ -94,10 +94,7 @@ module Spree
         discount ||= order.shipment_adjustments.promotion.detect(&detector)
         discount ||= order.adjustments.promotion.detect(&detector)
 
-        # Check for applied line items.
-        created_line_items = promotion.actions.detect { |a| a.type == 'Spree::Promotion::Actions::CreateLineItems' }
-
-        if (discount && discount.eligible) || created_line_items
+        if discount && discount.eligible
           order.update_totals
           order.persist_totals
           set_success_code :coupon_code_applied


### PR DESCRIPTION
this `Spree::Promotion::Actions::CreateLineItems` referenced in `Spree::PromotionHandler::Coupon` has been removed. Therefore, we need to remove the condition check correspondingly.