### PR TITLE
tax_rate amount should not affect `included` property

### DIFF
--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -70,14 +70,12 @@ module Spree
       amount = compute_amount(item)
       return if amount == 0
 
-      included = included_in_price && amount > 0
-
       item.adjustments.create!(
         source: self,
         amount: amount,
         order_id: item.order_id,
         label: adjustment_label(amount),
-        included: included
+        included: included_in_price
       )
     end
 


### PR DESCRIPTION
I don't understand why the `amount < 0` is needed when setting `included in price` property here.. if we have such property set, the discount (with value > line_item) would result in a extra tax not included in tax, even when the `included in price` is set to true.