### PR TITLE
calling remove_from when promotion is not eligible

### DIFF
--- a/core/app/models/spree/promotion_handler/cart.rb
+++ b/core/app/models/spree/promotion_handler/cart.rb
@@ -24,6 +24,12 @@ module Spree
         promotions.each do |promotion|
           if (line_item && promotion.eligible?(line_item, promotion_code: promotion_code(promotion))) || promotion.eligible?(order, promotion_code: promotion_code(promotion))
             promotion.activate(line_item: line_item, order: order, promotion_code: promotion_code(promotion))
+          else
+            op = order.order_promotions.find_by(promotion: promotion)
+            if op
+              promotion.remove_from(order)
+              op.destroy!
+            end
           end
         end
       end


### PR DESCRIPTION
This is a proof-of-concept work. Currently, although `Promotion#remove_from` is defined, and properly defined & tested in the different `PromotionActions`.. but it's not called.

Based on my understanding, the place where a promotion should be removed, are the PromotionHandlers (pls correct me if I'm wrong). Therefore, I'm putting this proof-of-concept code to ask if `remove_from` can be called this way.

If can, then other PromotionHandlers would be updated in similar ways.