### PR TITLE
Only credit back allowed amount

### DIFF
--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -141,6 +141,17 @@ module Spree
       amount - (offsets_total.abs + refunds.sum(:amount))
     end
 
+    # The total amount this payment can be credited as a Spree::Money object
+    #
+    # @return [Spree::Money] The amount of this payment minus offets and refunds
+    #   as a money object with the associated currency.
+    def credit_allowed_money
+      Spree::Money.new(
+        credit_allowed,
+        currency: currency
+      )
+    end
+
     # @return [Boolean] true when this payment can be credited
     def can_credit?
       credit_allowed > 0

--- a/core/app/models/spree/payment_method/store_credit.rb
+++ b/core/app/models/spree/payment_method/store_credit.rb
@@ -58,7 +58,12 @@ module Spree
         currency = gateway_options[:currency] || store_credit.currency
         originator = gateway_options[:originator]
 
-        store_credit.credit(amount_in_cents / 100.0.to_d, auth_code, currency, action_originator: originator)
+        store_credit.credit(
+          amount_in_cents / 100.0.to_d,
+          auth_code,
+          currency,
+          action_originator: originator
+        ) if amount_in_cents > 0
       end
 
       handle_action(action, :credit, auth_code)

--- a/core/spec/models/spree/payment_method/store_credit_spec.rb
+++ b/core/spec/models/spree/payment_method/store_credit_spec.rb
@@ -218,6 +218,19 @@ describe Spree::PaymentMethod::StoreCredit do
       end
     end
 
+    context "when attempting to credit for zero" do
+      let(:credit_amount) { 0 }
+
+      it "does not credit the store credit" do
+        expect_any_instance_of(Spree::StoreCredit).to_not receive(:credit)
+        subject
+      end
+
+      it "returns a success response" do
+        expect(subject.success?).to be true
+      end
+    end
+
     context "when the store credit isn't credited successfully" do
       before { allow_any_instance_of(Spree::StoreCredit).to receive_messages(credit: false) }
 
@@ -263,19 +276,34 @@ describe Spree::PaymentMethod::StoreCredit do
     end
 
     context "capture event found" do
-      let!(:store_credit_event) {
-        create(:store_credit_capture_event,
-                                        authorization_code: auth_code,
-                                        amount: captured_amount,
-                                        store_credit: store_credit)
-      }
+      let!(:store_credit_event) do
+        create(
+          :store_credit_capture_event,
+          authorization_code: auth_code,
+          amount: captured_amount,
+          store_credit: store_credit,
+          originator: originator
+        )
+      end
+      let(:payment) { create(:payment, order: order, amount: 5) }
+      let(:originator) { nil }
 
       it_behaves_like "a spree payment method"
 
-      it "refunds the capture amount" do
-        expect { subject }.to change{ store_credit.reload.amount_remaining }.
-                              from(original_amount - captured_amount).
-                              to(original_amount)
+      context "when originator is nil" do
+        it "refunds the event amount" do
+          expect { subject }.to change{ store_credit.reload.amount_remaining }.
+            from(90).to(100)
+        end
+      end
+
+      context "when the originator is the payment" do
+        let(:originator) { payment }
+
+        it "refunds the payment credit allowed amount" do
+          expect { subject }.to change{ store_credit.reload.amount_remaining }.
+            from(90).to(95)
+        end
       end
     end
 


### PR DESCRIPTION
This fixes an issue with payment refunding. To reproduce:

1. Give a user $100 in store credit
2. Purchase an item with the user for less than $100.
3. Refund a portion of the payment through the admin
4. Attempt to cancel the order

This will result in an exception as it will attempt to give the user more
store credit than they could potentially have available.

This modifies the store credit payment cancel to give back the maximum allowed
rather than the full amount.

Additionally, this gets rid of some terrible logic which only works with currencies
that have two decimal places which multiplies and divides things by 100.