### PR TITLE
Make frontend prices depend on `store.cart_tax_country_iso`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Solidus 2.1.0 (master, unreleased)
 
+*   Make frontend prices depend on `store.cart_tax_country_iso`
+
+    Prices in the frontend now depend on `store.cart_tax_country_iso` instead of `Spree::Config.admin_vat_country_iso`.
+
 *   Deprecate methods related to Spree::Order#tax_zone
 
     We're not using `Spree::Order#tax_zone`, `Spree::Zone.default_tax`,

--- a/core/lib/spree/core/controller_helpers/pricing.rb
+++ b/core/lib/spree/core/controller_helpers/pricing.rb
@@ -13,7 +13,8 @@ module Spree
 
         def current_pricing_options
           Spree::Config.pricing_options_class.new(
-            currency: current_store.try!(:default_currency).presence || Spree::Config[:currency]
+            currency: current_store.try!(:default_currency).presence || Spree::Config[:currency],
+            country_iso: current_store.try!(:cart_tax_country_iso).presence
           )
         end
 

--- a/core/spec/lib/spree/core/controller_helpers/pricing_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/pricing_spec.rb
@@ -59,5 +59,21 @@ describe Spree::Core::ControllerHelpers::Pricing, type: :controller do
         it { is_expected.to eq('EUR') }
       end
     end
+
+    context "country_iso" do
+      subject { controller.current_pricing_options.country_iso }
+
+      let(:store) { FactoryGirl.create(:store, cart_tax_country_iso: cart_tax_country_iso) }
+
+      context "when the store has a cart tax country set" do
+        let(:cart_tax_country_iso) { "DE" }
+        it { is_expected.to eq("DE") }
+      end
+
+      context "when the store has no cart tax country set" do
+        let(:cart_tax_country_iso) { nil }
+        it { is_expected.to be_nil }
+      end
+    end
   end
 end


### PR DESCRIPTION
Prior to this change, prices in the frontend portion of Solidus would
depend on the setting for selecting prices in the backend, which is not
store-specific, but global. However, we want prices to be different in the
frontend if we change store and there are different prices.