### PR TITLE
Mark tax_adjuster_class as @api experimental

### DIFF
--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -373,9 +373,12 @@ module Spree
 
     # Allows providing your own class for calculating taxes on an order.
     #
+    # This extension point is under development and may change in a future minor release.
+    #
     # @!attribute [rw] tax_adjuster_class
     # @return [Class] a class with the same public interfaces as
     #   Spree::Tax::OrderAdjuster
+    # @api experimental
     attr_writer :tax_adjuster_class
     def tax_adjuster_class
       @tax_adjuster_class ||= Spree::Tax::OrderAdjuster


### PR DESCRIPTION
This will hide tax_adjuster_class in our generated docs (for now).

We're planning to make some changes to this API to reduce the work needing to be done on the tax integration. We don't know right now if this interface will be a good fit when we are done, but we would like to include it in some way for now.

Adding `@api experimental` allows us to have this extension point in the next release, but not be locked into supporting it until Solidus 3.0.

cc @jordan-brough 