### PR TITLE
Use dismiss_confirm

### DIFF
--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -77,7 +77,7 @@ describe "Order Details", type: :feature, js: true do
 
         within_row(1) do
           # Click "cancel" on confirmation dialog
-          dismiss_prompt do
+          dismiss_confirm do
             click_icon :trash
           end
         end


### PR DESCRIPTION
This PR uses capybara's `dismiss_confirm` in a feature spec, rather than `dismiss_prompt` as the modal is an alert not a prompt.