### PR TITLE
remove unnecessary rows property on textfield

### DIFF
--- a/backend/app/views/spree/admin/taxons/_form.html.erb
+++ b/backend/app/views/spree/admin/taxons/_form.html.erb
@@ -31,17 +31,17 @@
   <div class="col-xs-10">
     <%= f.field_container :meta_title do %>
       <%= f.label :meta_title %><br />
-      <%= f.text_field :meta_title, :class => 'fullwidth', :rows => 6 %>
+      <%= f.text_field :meta_title, :class => 'fullwidth' %>
     <% end %>
 
     <%= f.field_container :meta_description do %>
       <%= f.label :meta_description %><br />
-      <%= f.text_field :meta_description, :class => 'fullwidth', :rows => 6 %>
+      <%= f.text_field :meta_description, :class => 'fullwidth' %>
     <% end %>
 
     <%= f.field_container :meta_keywords do %>
       <%= f.label :meta_keywords %><br />
-      <%= f.text_field :meta_keywords, :class => 'fullwidth', :rows => 6 %>
+      <%= f.text_field :meta_keywords, :class => 'fullwidth' %>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
TextField doesn't need rows property. The existing rows property seems to be copied over from the text-area above.