### PR TITLE
Cleanup - Specify Spree:: namespace in all Product calls

### DIFF
--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -116,13 +116,13 @@ module Spree
 
       def product_scope
         if can?(:admin, Spree::Product)
-          scope = Product.with_deleted.accessible_by(current_ability, :read).includes(*product_includes)
+          scope = Spree::Product.with_deleted.accessible_by(current_ability, :read).includes(*product_includes)
 
           unless params[:show_deleted]
             scope = scope.not_deleted
           end
         else
-          scope = Product.accessible_by(current_ability, :read).available.includes(*product_includes)
+          scope = Spree::Product.accessible_by(current_ability, :read).available.includes(*product_includes)
         end
 
         scope

--- a/api/app/controllers/spree/api/countries_controller.rb
+++ b/api/app/controllers/spree/api/countries_controller.rb
@@ -4,13 +4,13 @@ module Spree
       skip_before_action :authenticate_user
 
       def index
-        @countries = Country.
+        @countries = Spree::Country.
           accessible_by(current_ability, :read).
           ransack(params[:q]).
           result.
           order('name ASC')
 
-        country = Country.order("updated_at ASC").last
+        country = Spree::Country.order("updated_at ASC").last
 
         if stale?(country)
           @countries = paginate(@countries)
@@ -19,7 +19,7 @@ module Spree
       end
 
       def show
-        @country = Country.accessible_by(current_ability, :read).find(params[:id])
+        @country = Spree::Country.accessible_by(current_ability, :read).find(params[:id])
         respond_with(@country)
       end
     end

--- a/api/app/controllers/spree/api/images_controller.rb
+++ b/api/app/controllers/spree/api/images_controller.rb
@@ -7,7 +7,7 @@ module Spree
       end
 
       def show
-        @image = Image.accessible_by(current_ability, :read).find(params[:id])
+        @image = Spree::Image.accessible_by(current_ability, :read).find(params[:id])
         respond_with(@image)
       end
 

--- a/api/app/controllers/spree/api/inventory_units_controller.rb
+++ b/api/app/controllers/spree/api/inventory_units_controller.rb
@@ -24,7 +24,7 @@ module Spree
       private
 
       def inventory_unit
-        @inventory_unit ||= InventoryUnit.accessible_by(current_ability, :read).find(params[:id])
+        @inventory_unit ||= Spree::InventoryUnit.accessible_by(current_ability, :read).find(params[:id])
       end
 
       def prepare_event

--- a/api/app/controllers/spree/api/orders_controller.rb
+++ b/api/app/controllers/spree/api/orders_controller.rb
@@ -13,7 +13,7 @@ module Spree
       around_action :lock_order, except: [:create, :mine, :current, :index]
 
       # Dynamically defines our stores checkout steps to ensure we check authorization on each step.
-      Order.checkout_steps.keys.each do |step|
+      Spree::Order.checkout_steps.keys.each do |step|
         define_method step do
           authorize! :update, @order, params[:token]
         end
@@ -39,7 +39,7 @@ module Spree
 
       def index
         authorize! :index, Order
-        @orders = paginate(Order.ransack(params[:q]).result)
+        @orders = paginate(Spree::Order.ransack(params[:q]).result)
         respond_with(@orders)
       end
 

--- a/api/app/controllers/spree/api/products_controller.rb
+++ b/api/app/controllers/spree/api/products_controller.rb
@@ -123,7 +123,7 @@ module Spree
 
       def set_up_shipping_category
         if shipping_category = params[:product].delete(:shipping_category)
-          id = ShippingCategory.find_or_create_by(name: shipping_category).id
+          id = Spree::ShippingCategory.find_or_create_by(name: shipping_category).id
           params[:product][:shipping_category_id] = id
         end
       end

--- a/api/app/controllers/spree/api/states_controller.rb
+++ b/api/app/controllers/spree/api/states_controller.rb
@@ -23,10 +23,10 @@ module Spree
 
       def scope
         if params[:country_id]
-          @country = Country.accessible_by(current_ability, :read).find(params[:country_id])
+          @country = Spree::Country.accessible_by(current_ability, :read).find(params[:country_id])
           return @country.states.accessible_by(current_ability, :read)
         else
-          return State.accessible_by(current_ability, :read)
+          return Spree::State.accessible_by(current_ability, :read)
         end
       end
     end

--- a/api/app/controllers/spree/api/stock_items_controller.rb
+++ b/api/app/controllers/spree/api/stock_items_controller.rb
@@ -28,7 +28,7 @@ module Spree
       end
 
       def update
-        @stock_item = StockItem.accessible_by(current_ability, :update).find(params[:id])
+        @stock_item = Spree::StockItem.accessible_by(current_ability, :update).find(params[:id])
         @stock_location = @stock_item.stock_location
 
         adjustment = count_on_hand_adjustment
@@ -46,7 +46,7 @@ module Spree
       end
 
       def destroy
-        @stock_item = StockItem.accessible_by(current_ability, :destroy).find(params[:id])
+        @stock_item = Spree::StockItem.accessible_by(current_ability, :destroy).find(params[:id])
         @stock_item.destroy
         respond_with(@stock_item, status: 204)
       end
@@ -54,7 +54,7 @@ module Spree
       private
 
       def load_stock_location
-        @stock_location ||= StockLocation.accessible_by(current_ability).find(params.fetch(:stock_location_id))
+        @stock_location ||= Spree::StockLocation.accessible_by(current_ability).find(params.fetch(:stock_location_id))
       end
 
       def scope

--- a/api/app/controllers/spree/api/stock_locations_controller.rb
+++ b/api/app/controllers/spree/api/stock_locations_controller.rb
@@ -21,7 +21,7 @@ module Spree
 
       def create
         authorize! :create, StockLocation
-        @stock_location = StockLocation.new(stock_location_params)
+        @stock_location = Spree::StockLocation.new(stock_location_params)
         if @stock_location.save
           respond_with(@stock_location, status: 201, default_template: :show)
         else
@@ -47,7 +47,7 @@ module Spree
       private
 
       def stock_location
-        @stock_location ||= StockLocation.accessible_by(current_ability, :read).find(params[:id])
+        @stock_location ||= Spree::StockLocation.accessible_by(current_ability, :read).find(params[:id])
       end
 
       def stock_location_params

--- a/api/app/controllers/spree/api/stock_movements_controller.rb
+++ b/api/app/controllers/spree/api/stock_movements_controller.rb
@@ -27,7 +27,7 @@ module Spree
       private
 
       def stock_location
-        @stock_location ||= StockLocation.accessible_by(current_ability, :read).find(params[:stock_location_id])
+        @stock_location ||= Spree::StockLocation.accessible_by(current_ability, :read).find(params[:stock_location_id])
       end
 
       def scope

--- a/api/app/controllers/spree/api/stores_controller.rb
+++ b/api/app/controllers/spree/api/stores_controller.rb
@@ -5,13 +5,13 @@ module Spree
 
       def index
         authorize! :read, Store
-        @stores = Store.accessible_by(current_ability, :read).all
+        @stores = Spree::Store.accessible_by(current_ability, :read).all
         respond_with(@stores)
       end
 
       def create
         authorize! :create, Store
-        @store = Store.new(store_params)
+        @store = Spree::Store.new(store_params)
         @store.code = params[:store][:code]
         if @store.save
           respond_with(@store, status: 201, default_template: :show)
@@ -43,7 +43,7 @@ module Spree
       private
 
       def get_store
-        @store = Store.find(params[:id])
+        @store = Spree::Store.find(params[:id])
       end
 
       def store_params

--- a/api/app/controllers/spree/api/taxonomies_controller.rb
+++ b/api/app/controllers/spree/api/taxonomies_controller.rb
@@ -20,7 +20,7 @@ module Spree
 
       def create
         authorize! :create, Taxonomy
-        @taxonomy = Taxonomy.new(taxonomy_params)
+        @taxonomy = Spree::Taxonomy.new(taxonomy_params)
         if @taxonomy.save
           respond_with(@taxonomy, status: 201, default_template: :show)
         else
@@ -55,7 +55,7 @@ module Spree
       end
 
       def taxonomy
-        @taxonomy ||= Taxonomy.accessible_by(current_ability, :read).find(params[:id])
+        @taxonomy ||= Spree::Taxonomy.accessible_by(current_ability, :read).find(params[:id])
       end
 
       def taxonomy_params

--- a/api/app/controllers/spree/api/transfer_items_controller.rb
+++ b/api/app/controllers/spree/api/transfer_items_controller.rb
@@ -3,7 +3,7 @@ module Spree
     class TransferItemsController < Spree::Api::BaseController
       def create
         authorize! :create, TransferItem
-        stock_transfer = StockTransfer.accessible_by(current_ability, :update).find_by(number: params[:stock_transfer_id])
+        stock_transfer = Spree::StockTransfer.accessible_by(current_ability, :update).find_by(number: params[:stock_transfer_id])
         @transfer_item = stock_transfer.transfer_items.build(transfer_item_params)
         if @transfer_item.save
           respond_with(@transfer_item, status: 201, default_template: :show)
@@ -14,7 +14,7 @@ module Spree
 
       def update
         authorize! :update, TransferItem
-        @transfer_item = TransferItem.accessible_by(current_ability, :update).find(params[:id])
+        @transfer_item = Spree::TransferItem.accessible_by(current_ability, :update).find(params[:id])
         if @transfer_item.update_attributes(transfer_item_params)
           respond_with(@transfer_item, status: 200, default_template: :show)
         else
@@ -24,7 +24,7 @@ module Spree
 
       def destroy
         authorize! :destroy, TransferItem
-        @transfer_item = TransferItem.accessible_by(current_ability, :destroy).find(params[:id])
+        @transfer_item = Spree::TransferItem.accessible_by(current_ability, :destroy).find(params[:id])
         if @transfer_item.destroy
           respond_with(@transfer_item, status: 200, default_template: :show)
         else

--- a/api/app/controllers/spree/api/variants_controller.rb
+++ b/api/app/controllers/spree/api/variants_controller.rb
@@ -58,7 +58,7 @@ module Spree
         if @product
           variants = @product.variants_including_master
         else
-          variants = Variant
+          variants = Spree::Variant
         end
 
         if current_ability.can?(:manage, Variant) && params[:show_deleted]

--- a/api/app/controllers/spree/api/zones_controller.rb
+++ b/api/app/controllers/spree/api/zones_controller.rb
@@ -3,7 +3,7 @@ module Spree
     class ZonesController < Spree::Api::BaseController
       def create
         authorize! :create, Zone
-        @zone = Zone.new(zone_params)
+        @zone = Spree::Zone.new(zone_params)
         if @zone.save
           respond_with(@zone, status: 201, default_template: :show)
         else
@@ -18,7 +18,7 @@ module Spree
       end
 
       def index
-        @zones = Zone.
+        @zones = Spree::Zone.
           accessible_by(current_ability, :read).
           order('name ASC').
           ransack(params[:q]).

--- a/backend/app/controllers/spree/admin/adjustments_controller.rb
+++ b/backend/app/controllers/spree/admin/adjustments_controller.rb
@@ -36,7 +36,7 @@ module Spree
 
       def reasons_for(_adjustment)
         [
-          AdjustmentReason.active.to_a,
+          Spree::AdjustmentReason.active.to_a,
           @adjustment.adjustment_reason
         ].flatten.compact.uniq.sort_by { |r| r.name.downcase }
       end

--- a/backend/app/controllers/spree/admin/base_controller.rb
+++ b/backend/app/controllers/spree/admin/base_controller.rb
@@ -46,7 +46,7 @@ module Spree
       end
 
       def lock_order
-        OrderMutex.with_lock!(@order) { yield }
+        Spree::OrderMutex.with_lock!(@order) { yield }
       rescue Spree::OrderMutex::LockFailed
         flash[:error] = Spree.t(:order_mutex_admin_error)
         redirect_to order_mutex_redirect_path

--- a/backend/app/controllers/spree/admin/cancellations_controller.rb
+++ b/backend/app/controllers/spree/admin/cancellations_controller.rb
@@ -32,7 +32,7 @@ module Spree
       end
 
       def load_order
-        @order = Order.find_by_number!(params[:order_id])
+        @order = Spree::Order.find_by_number!(params[:order_id])
         authorize! action, @order
       end
 

--- a/backend/app/controllers/spree/admin/images_controller.rb
+++ b/backend/app/controllers/spree/admin/images_controller.rb
@@ -17,7 +17,7 @@ module Spree
       end
 
       def load_data
-        @product = Product.friendly.find(params[:product_id])
+        @product = Spree::Product.friendly.find(params[:product_id])
         @variants = @product.variants.collect do |variant|
           [variant.sku_and_options_text, variant.id]
         end

--- a/backend/app/controllers/spree/admin/option_types_controller.rb
+++ b/backend/app/controllers/spree/admin/option_types_controller.rb
@@ -5,7 +5,7 @@ module Spree
 
       def update_values_positions
         params[:positions].each do |id, index|
-          OptionValue.where(id: id).update_all(position: index)
+          Spree::OptionValue.where(id: id).update_all(position: index)
         end
 
         respond_to do |format|
@@ -21,7 +21,7 @@ module Spree
       end
 
       def load_product
-        @product = Product.find_by_param!(params[:product_id])
+        @product = Spree::Product.find_by_param!(params[:product_id])
       end
 
       def setup_new_option_value
@@ -30,9 +30,9 @@ module Spree
 
       def set_available_option_types
         @available_option_types = if @product.option_type_ids.any?
-          OptionType.where('id NOT IN (?)', @product.option_type_ids)
+          Spree::OptionType.where('id NOT IN (?)', @product.option_type_ids)
         else
-          OptionType.all
+          Spree::OptionType.all
         end
       end
     end

--- a/backend/app/controllers/spree/admin/orders/customer_details_controller.rb
+++ b/backend/app/controllers/spree/admin/orders/customer_details_controller.rb
@@ -11,7 +11,7 @@ module Spree
         end
 
         def edit
-          country_id = Country.default.id
+          country_id = Spree::Country.default.id
           @order.build_bill_address(country_id: country_id) if @order.bill_address.nil?
           @order.build_ship_address(country_id: country_id) if @order.ship_address.nil?
 
@@ -51,7 +51,7 @@ module Spree
         end
 
         def load_order
-          @order = Order.includes(:adjustments).find_by_number!(params[:order_id])
+          @order = Spree::Order.includes(:adjustments).find_by_number!(params[:order_id])
         end
 
         def model_class

--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -48,7 +48,7 @@ module Spree
           params[:q][:completed_at_lt] = params[:q].delete(:created_at_lt)
         end
 
-        @search = Order.accessible_by(current_ability, :index).ransack(params[:q])
+        @search = Spree::Order.accessible_by(current_ability, :index).ransack(params[:q])
 
         # lazy loading other models here (via includes) may result in an invalid query
         # e.g. SELECT  DISTINCT DISTINCT "spree_orders".id, "spree_orders"."created_at" AS alias_0 FROM "spree_orders"
@@ -178,7 +178,7 @@ module Spree
       end
 
       def load_order
-        @order = Order.includes(:adjustments).find_by_number!(params[:id])
+        @order = Spree::Order.includes(:adjustments).find_by_number!(params[:id])
         authorize! action, @order
       end
 

--- a/backend/app/controllers/spree/admin/payment_methods_controller.rb
+++ b/backend/app/controllers/spree/admin/payment_methods_controller.rb
@@ -49,7 +49,7 @@ module Spree
       end
 
       def load_providers
-        @providers = PaymentMethod.providers.sort_by(&:name)
+        @providers = Spree::PaymentMethod.providers.sort_by(&:name)
       end
 
       def validate_payment_method_provider

--- a/backend/app/controllers/spree/admin/payments_controller.rb
+++ b/backend/app/controllers/spree/admin/payments_controller.rb
@@ -78,7 +78,7 @@ module Spree
 
       def load_data
         @amount = params[:amount] || load_order.total
-        @payment_methods = PaymentMethod.available_to_admin
+        @payment_methods = Spree::PaymentMethod.available_to_admin
         if @payment && @payment.payment_method
           @payment_method = @payment.payment_method
         else
@@ -87,13 +87,13 @@ module Spree
       end
 
       def load_order
-        @order = Order.find_by_number!(params[:order_id])
+        @order = Spree::Order.find_by_number!(params[:order_id])
         authorize! action, @order
         @order
       end
 
       def load_payment
-        @payment = Payment.find(params[:id])
+        @payment = Spree::Payment.find(params[:id])
       end
 
       def load_payment_for_fire

--- a/backend/app/controllers/spree/admin/products_controller.rb
+++ b/backend/app/controllers/spree/admin/products_controller.rb
@@ -46,7 +46,7 @@ module Spree
       end
 
       def destroy
-        @product = Product.friendly.find(params[:id])
+        @product = Spree::Product.friendly.find(params[:id])
         @product.destroy
 
         flash[:success] = Spree.t('notice_messages.product_deleted')
@@ -72,7 +72,7 @@ module Spree
       private
 
       def find_resource
-        Product.with_deleted.friendly.find(params[:id])
+        Spree::Product.with_deleted.friendly.find(params[:id])
       end
 
       def location_after_save
@@ -89,10 +89,10 @@ module Spree
       end
 
       def load_data
-        @taxons = Taxon.order(:name)
-        @option_types = OptionType.order(:name)
-        @tax_categories = TaxCategory.order(:name)
-        @shipping_categories = ShippingCategory.order(:name)
+        @taxons = Spree::Taxon.order(:name)
+        @option_types = Spree::OptionType.order(:name)
+        @tax_categories = Spree::TaxCategory.order(:name)
+        @shipping_categories = Spree::ShippingCategory.order(:name)
       end
 
       def collection

--- a/backend/app/controllers/spree/admin/refunds_controller.rb
+++ b/backend/app/controllers/spree/admin/refunds_controller.rb
@@ -20,7 +20,7 @@ module Spree
       end
 
       def refund_reasons
-        @refund_reasons ||= RefundReason.active.all
+        @refund_reasons ||= Spree::RefundReason.active.all
       end
 
       def build_resource

--- a/backend/app/controllers/spree/admin/reimbursements_controller.rb
+++ b/backend/app/controllers/spree/admin/reimbursements_controller.rb
@@ -17,9 +17,9 @@ module Spree
 
       def build_resource
         if params[:build_from_customer_return_id].present?
-          customer_return = CustomerReturn.find(params[:build_from_customer_return_id])
+          customer_return = Spree::CustomerReturn.find(params[:build_from_customer_return_id])
 
-          Reimbursement.build_from_customer_return(customer_return)
+          Spree::Reimbursement.build_from_customer_return(customer_return)
         else
           super
         end

--- a/backend/app/controllers/spree/admin/search_controller.rb
+++ b/backend/app/controllers/spree/admin/search_controller.rb
@@ -23,9 +23,9 @@ module Spree
       def products
         if params[:ids]
           # split here may be String#split or Array#split, so we must flatten the results
-          @products = Product.where(id: params[:ids].split(",").flatten)
+          @products = Spree::Product.where(id: params[:ids].split(",").flatten)
         else
-          @products = Product.ransack(params[:q]).result
+          @products = Spree::Product.ransack(params[:q]).result
         end
 
         @products = @products.distinct.page(params[:page]).per(params[:per_page])

--- a/backend/app/controllers/spree/admin/shipping_methods_controller.rb
+++ b/backend/app/controllers/spree/admin/shipping_methods_controller.rb
@@ -37,9 +37,9 @@ module Spree
       end
 
       def load_data
-        @available_zones = Zone.order(:name)
+        @available_zones = Spree::Zone.order(:name)
         @tax_categories = Spree::TaxCategory.order(:name)
-        @calculators = ShippingMethod.calculators.sort_by(&:name)
+        @calculators = Spree::ShippingMethod.calculators.sort_by(&:name)
       end
     end
   end

--- a/backend/app/controllers/spree/admin/states_controller.rb
+++ b/backend/app/controllers/spree/admin/states_controller.rb
@@ -22,7 +22,7 @@ module Spree
       end
 
       def load_data
-        @countries = Country.order(:name)
+        @countries = Spree::Country.order(:name)
       end
     end
   end

--- a/backend/app/controllers/spree/admin/stock_items_controller.rb
+++ b/backend/app/controllers/spree/admin/stock_items_controller.rb
@@ -13,8 +13,8 @@ module Spree
       private
 
       def build_resource
-        variant = Variant.accessible_by(current_ability, :read).find(params[:variant_id])
-        stock_location = StockLocation.accessible_by(current_ability, :read).find(params[:stock_location_id])
+        variant = Spree::Variant.accessible_by(current_ability, :read).find(params[:variant_id])
+        stock_location = Spree::StockLocation.accessible_by(current_ability, :read).find(params[:stock_location_id])
         stock_location.stock_movements.build(stock_movement_params).tap do |stock_movement|
           stock_movement.originator = try_spree_current_user
           stock_movement.stock_item = stock_location.set_up_stock_item(variant)
@@ -34,7 +34,7 @@ module Spree
       end
 
       def load_product
-        @product = Product.accessible_by(current_ability, :read).friendly.find(params[:product_slug]) if params[:product_slug]
+        @product = Spree::Product.accessible_by(current_ability, :read).friendly.find(params[:product_slug]) if params[:product_slug]
       end
 
       def load_stock_management_data

--- a/backend/app/controllers/spree/admin/stock_transfers_controller.rb
+++ b/backend/app/controllers/spree/admin/stock_transfers_controller.rb
@@ -133,12 +133,12 @@ module Spree
         @source_location ||= if params.key?(:transfer_receive_stock)
                                nil
                              else
-                               StockLocation.find(params[:transfer_source_location_id])
+                               Spree::StockLocation.find(params[:transfer_source_location_id])
                              end
       end
 
       def destination_location
-        @destination_location ||= StockLocation.find(params[:transfer_destination_location_id])
+        @destination_location ||= Spree::StockLocation.find(params[:transfer_destination_location_id])
       end
 
       def adjust_inventory

--- a/backend/app/controllers/spree/admin/tax_rates_controller.rb
+++ b/backend/app/controllers/spree/admin/tax_rates_controller.rb
@@ -6,9 +6,9 @@ module Spree
       private
 
       def load_data
-        @available_zones = Zone.order(:name)
-        @available_categories = TaxCategory.order(:name)
-        @calculators = TaxRate.calculators.sort_by(&:name)
+        @available_zones = Spree::Zone.order(:name)
+        @available_categories = Spree::TaxCategory.order(:name)
+        @calculators = Spree::TaxRate.calculators.sort_by(&:name)
       end
     end
   end

--- a/backend/app/controllers/spree/admin/taxons_controller.rb
+++ b/backend/app/controllers/spree/admin/taxons_controller.rb
@@ -15,7 +15,7 @@ module Spree
       end
 
       def create
-        @taxonomy = Taxonomy.find(params[:taxonomy_id])
+        @taxonomy = Spree::Taxonomy.find(params[:taxonomy_id])
         @taxon = @taxonomy.taxons.build(params[:taxon])
         if @taxon.save
           respond_with(@taxon) do |format|
@@ -30,19 +30,19 @@ module Spree
       end
 
       def edit
-        @taxonomy = Taxonomy.find(params[:taxonomy_id])
+        @taxonomy = Spree::Taxonomy.find(params[:taxonomy_id])
         @taxon = @taxonomy.taxons.find(params[:id])
         @permalink_part = @taxon.permalink.split("/").last
       end
 
       def update
-        @taxonomy = Taxonomy.find(params[:taxonomy_id])
+        @taxonomy = Spree::Taxonomy.find(params[:taxonomy_id])
         @taxon = @taxonomy.taxons.find(params[:id])
         parent_id = params[:taxon][:parent_id]
         new_position = params[:taxon][:position]
 
         if parent_id
-          @taxon.parent = Taxon.find(parent_id.to_i)
+          @taxon.parent = Spree::Taxon.find(parent_id.to_i)
         end
 
         if new_position
@@ -65,7 +65,7 @@ module Spree
       end
 
       def destroy
-        @taxon = Taxon.find(params[:id])
+        @taxon = Spree::Taxon.find(params[:id])
         @taxon.destroy
         respond_with(@taxon) { |format| format.json { render json: '' } }
       end

--- a/backend/app/controllers/spree/admin/variants_controller.rb
+++ b/backend/app/controllers/spree/admin/variants_controller.rb
@@ -8,7 +8,7 @@ module Spree
       # override the destroy method to set deleted_at value
       # instead of actually deleting the product.
       def destroy
-        @variant = Variant.find(params[:id])
+        @variant = Spree::Variant.find(params[:id])
         if @variant.destroy
           flash[:success] = Spree.t('notice_messages.variant_deleted')
         else
@@ -42,7 +42,7 @@ module Spree
       end
 
       def load_data
-        @tax_categories = TaxCategory.order(:name)
+        @tax_categories = Spree::TaxCategory.order(:name)
       end
 
       def variant_includes

--- a/backend/app/controllers/spree/admin/zones_controller.rb
+++ b/backend/app/controllers/spree/admin/zones_controller.rb
@@ -17,9 +17,9 @@ module Spree
       end
 
       def load_data
-        @countries = Country.order(:name)
-        @states = State.order(:name)
-        @zones = Zone.order(:name)
+        @countries = Spree::Country.order(:name)
+        @states = Spree::State.order(:name)
+        @zones = Spree::Zone.order(:name)
       end
     end
   end

--- a/core/app/models/concerns/spree/ordered_property_value_list.rb
+++ b/core/app/models/concerns/spree/ordered_property_value_list.rb
@@ -16,8 +16,8 @@ module Spree
 
     def property_name=(name)
       unless name.blank?
-        unless property = Property.find_by(name: name)
-          property = Property.create(name: name, presentation: name)
+        unless property = Spree::Property.find_by(name: name)
+          property = Spree::Property.create(name: name, presentation: name)
         end
         self.property = property
       end

--- a/core/app/models/concerns/spree/user_address_book.rb
+++ b/core/app/models/concerns/spree/user_address_book.rb
@@ -5,7 +5,7 @@ module Spree
     included do
       has_many :user_addresses, -> { active }, { foreign_key: "user_id", class_name: "Spree::UserAddress" } do
         def find_first_by_address_values(address_attrs)
-          detect { |ua| ua.address == Address.new(address_attrs) }
+          detect { |ua| ua.address == Spree::Address.new(address_attrs) }
         end
 
         # @note this method enforces only one default address per user
@@ -37,7 +37,7 @@ module Spree
     end
 
     def bill_address_attributes=(attributes)
-      self.bill_address = Address.immutable_merge(bill_address, attributes)
+      self.bill_address = Spree::Address.immutable_merge(bill_address, attributes)
     end
 
     def default_address=(address)
@@ -48,7 +48,7 @@ module Spree
       # see "Nested Attributes Examples" section of http://apidock.com/rails/ActionView/Helpers/FormHelper/fields_for
       # this #{fieldname}_attributes= method works with fields_for in the views
       # even without declaring accepts_nested_attributes_for
-      self.default_address = Address.immutable_merge(default_address, attributes)
+      self.default_address = Spree::Address.immutable_merge(default_address, attributes)
     end
 
     alias_method :ship_address_attributes=, :default_address_attributes=
@@ -94,7 +94,7 @@ module Spree
       return nil unless address_attributes.present?
       address_attributes = address_attributes.to_h.with_indifferent_access
 
-      new_address = Address.factory(address_attributes)
+      new_address = Spree::Address.factory(address_attributes)
       return new_address unless new_address.valid?
 
       first_one = user_addresses.empty?

--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -166,7 +166,7 @@ module Spree
     # @return [Country] setter that sets self.country to the Country with a matching 2 letter iso
     # @raise [ActiveRecord::RecordNotFound] if country with the iso doesn't exist
     def country_iso=(iso)
-      self.country = Country.find_by!(iso: iso)
+      self.country = Spree::Country.find_by!(iso: iso)
     end
 
     private

--- a/core/app/models/spree/credit_card.rb
+++ b/core/app/models/spree/credit_card.rb
@@ -45,7 +45,7 @@ module Spree
     }.freeze
 
     def address_attributes=(attributes)
-      self.address = Address.immutable_merge(address, attributes)
+      self.address = Spree::Address.immutable_merge(address, attributes)
     end
 
     # Sets the expiry date on this credit card.
@@ -195,7 +195,7 @@ module Spree
 
     def ensure_one_default
       if user_id && default
-        CreditCard.where(default: true).where.not(id: id).where(user_id: user_id).each do |ucc|
+        Spree::CreditCard.where(default: true).where.not(id: id).where(user_id: user_id).each do |ucc|
           ucc.update_columns(default: false, updated_at: Time.current)
         end
       end

--- a/core/app/models/spree/gateway.rb
+++ b/core/app/models/spree/gateway.rb
@@ -44,7 +44,7 @@ module Spree
 
     def disable_customer_profile(source)
       Spree::Deprecation.warn("Gateway#disable_customer_profile is deprecated")
-      if source.is_a? CreditCard
+      if source.is_a? Spree::CreditCard
         source.update_column :gateway_customer_profile_id, nil
       else
         raise 'You must implement disable_customer_profile method for this gateway.'

--- a/core/app/models/spree/gateway/bogus.rb
+++ b/core/app/models/spree/gateway/bogus.rb
@@ -79,7 +79,7 @@ module Spree
       prefix = success ? 'BGS' : 'FAIL'
       while record
         random = "#{prefix}-#{Array.new(6){ rand(6) }.join}"
-        record = CreditCard.where(gateway_customer_profile_id: random).first
+        record = Spree::CreditCard.where(gateway_customer_profile_id: random).first
       end
       random
     end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -227,7 +227,7 @@ module Spree
     # Returns the relevant zone (if any) to be used for taxation purposes.
     # Uses default tax zone unless there is a specific match
     def tax_zone
-      Zone.match(tax_address) || Zone.default_tax
+      Spree::Zone.match(tax_address) || Spree::Zone.default_tax
     end
     deprecate tax_zone: "Please use Spree::Order#tax_address instead.",
               deprecator: Spree::Deprecation
@@ -242,7 +242,7 @@ module Spree
     end
 
     def updater
-      @updater ||= OrderUpdater.new(self)
+      @updater ||= Spree::OrderUpdater.new(self)
     end
 
     def update!
@@ -388,12 +388,12 @@ module Spree
 
     def credit_cards
       credit_card_ids = payments.from_credit_card.pluck(:source_id).uniq
-      CreditCard.where(id: credit_card_ids)
+      Spree::CreditCard.where(id: credit_card_ids)
     end
 
     def valid_credit_cards
       credit_card_ids = payments.from_credit_card.valid.pluck(:source_id).uniq
-      CreditCard.where(id: credit_card_ids)
+      Spree::CreditCard.where(id: credit_card_ids)
     end
 
     # Finalizes an in progress order after checkout is complete.
@@ -425,7 +425,7 @@ module Spree
     end
 
     def deliver_order_confirmation_email
-      OrderMailer.confirm_email(self).deliver_later
+      Spree::OrderMailer.confirm_email(self).deliver_later
       update_column(:confirmation_delivered, true)
     end
 
@@ -766,7 +766,7 @@ module Spree
     end
 
     def send_cancel_email
-      OrderMailer.cancel_email(self).deliver_later
+      Spree::OrderMailer.cancel_email(self).deliver_later
     end
 
     def after_resume

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -259,7 +259,7 @@ module Spree
               existing_card_id = @updating_params[:order] ? @updating_params[:order][:existing_card] : nil
 
               if existing_card_id.present?
-                credit_card = CreditCard.find existing_card_id
+                credit_card = Spree::CreditCard.find existing_card_id
                 if credit_card.user_id != user_id || credit_card.user_id.blank?
                   raise Core::GatewayError.new Spree.t(:invalid_credit_card)
                 end
@@ -275,7 +275,7 @@ module Spree
                 attributes[:payments_attributes].first[:request_env] = request_env
               end
 
-              update = OrderUpdateAttributes.new(self, attributes, request_env: request_env)
+              update = Spree::OrderUpdateAttributes.new(self, attributes, request_env: request_env)
               success = update.apply
             end
 
@@ -284,11 +284,11 @@ module Spree
           end
 
           def bill_address_attributes=(attributes)
-            self.bill_address = Address.immutable_merge(bill_address, attributes)
+            self.bill_address = Spree::Address.immutable_merge(bill_address, attributes)
           end
 
           def ship_address_attributes=(attributes)
-            self.ship_address = Address.immutable_merge(ship_address, attributes)
+            self.ship_address = Spree::Address.immutable_merge(ship_address, attributes)
           end
 
           def assign_default_addresses!

--- a/core/app/models/spree/order_contents.rb
+++ b/core/app/models/spree/order_contents.rb
@@ -80,7 +80,7 @@ module Spree
     end
 
     def order_updater
-      @updater ||= OrderUpdater.new(order)
+      @updater ||= Spree::OrderUpdater.new(order)
     end
 
     def reload_totals

--- a/core/app/models/spree/payment_create.rb
+++ b/core/app/models/spree/payment_create.rb
@@ -62,9 +62,9 @@ module Spree
 
     def available_cards
       if user_id = order.user_id
-        CreditCard.where(user_id: user_id)
+        Spree::CreditCard.where(user_id: user_id)
       else
-        CreditCard.none
+        Spree::CreditCard.none
       end
     end
   end

--- a/core/app/models/spree/payment_method/store_credit.rb
+++ b/core/app/models/spree/payment_method/store_credit.rb
@@ -109,7 +109,7 @@ module Spree
 
     def handle_action(action, action_name, auth_code)
       # Find first event with provided auth_code
-      store_credit = StoreCreditEvent.find_by_authorization_code(auth_code).try(:store_credit)
+      store_credit = Spree::StoreCreditEvent.find_by_authorization_code(auth_code).try(:store_credit)
 
       if store_credit.nil?
         ActiveMerchant::Billing::Response.new(false, Spree.t('store_credit.unable_to_find_for_action', auth_code: auth_code, action: action_name), {}, {})
@@ -119,8 +119,8 @@ module Spree
     end
 
     def auth_or_capture_event(auth_code)
-      capture_event = StoreCreditEvent.find_by(authorization_code: auth_code, action: Spree::StoreCredit::CAPTURE_ACTION)
-      auth_event = StoreCreditEvent.find_by(authorization_code: auth_code, action: Spree::StoreCredit::AUTHORIZE_ACTION)
+      capture_event = Spree::StoreCreditEvent.find_by(authorization_code: auth_code, action: Spree::StoreCredit::CAPTURE_ACTION)
+      auth_event = Spree::StoreCreditEvent.find_by(authorization_code: auth_code, action: Spree::StoreCredit::AUTHORIZE_ACTION)
       capture_event || auth_event
     end
   end

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -110,7 +110,7 @@ module Spree
 
     # @return [Spree::TaxCategory] tax category for this product, or the default tax category
     def tax_category
-      super || TaxCategory.find_by(is_default: true)
+      super || Spree::TaxCategory.find_by(is_default: true)
     end
 
     # Ensures option_types and product_option_types exist for keys in
@@ -232,8 +232,8 @@ module Spree
     def set_property(property_name, property_value)
       ActiveRecord::Base.transaction do
         # Works around spree_i18n https://github.com/spree/spree/issues/301
-        property = Property.create_with(presentation: property_name).find_or_create_by(name: property_name)
-        product_property = ProductProperty.where(product: self, property: property).first_or_initialize
+        property = Spree::Property.create_with(presentation: property_name).find_or_create_by(name: property_name)
+        product_property = Spree::ProductProperty.where(product: self, property: property).first_or_initialize
         product_property.value = property_value
         product_property.save!
       end

--- a/core/app/models/spree/product/scopes.rb
+++ b/core/app/models/spree/product/scopes.rb
@@ -84,12 +84,12 @@ module Spree
     # note that it can test for properties with NULL values, but not for absent values
     add_search_scope :with_property_value do |property, value|
       joins(:properties)
-        .where("#{ProductProperty.table_name}.value = ?", value)
+        .where("#{Spree::ProductProperty.table_name}.value = ?", value)
         .where(property_conditions(property))
     end
 
     add_search_scope :with_option do |option|
-      option_types = OptionType.table_name
+      option_types = Spree::OptionType.table_name
       conditions = case option
                    when String     then { "#{option_types}.name" => option }
                    when OptionType then { "#{option_types}.id" => option.id }
@@ -100,10 +100,10 @@ module Spree
     end
 
     add_search_scope :with_option_value do |option, value|
-      option_values = OptionValue.table_name
+      option_values = Spree::OptionValue.table_name
       option_type_id = case option
-                       when String then OptionType.find_by(name: option) || option.to_i
-                       when OptionType then option.id
+                       when String then Spree::OptionType.find_by(name: option) || option.to_i
+                       when Spree::OptionType then option.id
         else option.to_i
       end
 
@@ -117,7 +117,7 @@ module Spree
     add_search_scope :with do |value|
       includes(variants_including_master: :option_values).
       includes(:product_properties).
-      where("#{OptionValue.table_name}.name = ? OR #{ProductProperty.table_name}.value = ?", value, value)
+      where("#{Spree::OptionValue.table_name}.name = ? OR #{Spree::ProductProperty.table_name}.value = ?", value, value)
     end
 
     # Finds all products that have a name containing the given words.
@@ -154,27 +154,27 @@ module Spree
       order(%{
            COALESCE((
              SELECT
-               COUNT(#{LineItem.quoted_table_name}.id)
+               COUNT(#{Spree::LineItem.quoted_table_name}.id)
              FROM
-               #{LineItem.quoted_table_name}
+               #{Spree::LineItem.quoted_table_name}
              JOIN
-               #{Variant.quoted_table_name} AS popular_variants
+               #{Spree::Variant.quoted_table_name} AS popular_variants
              ON
-               popular_variants.id = #{LineItem.quoted_table_name}.variant_id
+               popular_variants.id = #{Spree::LineItem.quoted_table_name}.variant_id
              WHERE
-               popular_variants.product_id = #{Product.quoted_table_name}.id
+               popular_variants.product_id = #{Spree::Product.quoted_table_name}.id
            ), 0) DESC
         })
     end
 
     add_search_scope :not_deleted do
-      where("#{Product.quoted_table_name}.deleted_at IS NULL or #{Product.quoted_table_name}.deleted_at >= ?", Time.current)
+      where("#{Spree::Product.quoted_table_name}.deleted_at IS NULL or #{Spree::Product.quoted_table_name}.deleted_at >= ?", Time.current)
     end
 
     # Can't use add_search_scope for this as it needs a default argument
     def self.available(available_on = nil, currency = nil)
       Spree::Deprecation.warn("The second currency argument on Product.available has no effect, and is deprecated", caller) if currency
-      joins(master: :prices).where("#{Product.quoted_table_name}.available_on <= ?", available_on || Time.current)
+      joins(master: :prices).where("#{Spree::Product.quoted_table_name}.available_on <= ?", available_on || Time.current)
     end
     search_scopes << :available
 
@@ -185,7 +185,7 @@ module Spree
     search_scopes << :active
 
     add_search_scope :taxons_name_eq do |name|
-      group("spree_products.id").joins(:taxons).where(Taxon.arel_table[:name].eq(name))
+      group("spree_products.id").joins(:taxons).where(Spree::Taxon.arel_table[:name].eq(name))
     end
 
     def self.distinct_by_product_ids(sort_order = nil)
@@ -217,13 +217,13 @@ module Spree
       private
 
       def price_table_name
-        Price.quoted_table_name
+        Spree::Price.quoted_table_name
       end
 
       # specifically avoid having an order for taxon search (conflicts with main order)
       def prepare_taxon_conditions(taxons)
         ids = taxons.map { |taxon| taxon.self_and_descendants.pluck(:id) }.flatten.uniq
-        joins(:taxons).where("#{Taxon.table_name}.id" => ids)
+        joins(:taxons).where("#{Spree::Taxon.table_name}.id" => ids)
       end
 
       # Produce an array of keywords for use in scopes.
@@ -235,14 +235,14 @@ module Spree
       end
 
       def get_taxons(*ids_or_records_or_names)
-        taxons = Taxon.table_name
+        taxons = Spree::Taxon.table_name
         ids_or_records_or_names.flatten.map { |t|
           case t
-          when Integer then Taxon.find_by(id: t)
+          when Integer then Spree::Taxon.find_by(id: t)
           when ActiveRecord::Base then t
           when String
-            Taxon.find_by(name: t) ||
-              Taxon.where("#{taxons}.permalink LIKE ? OR #{taxons}.permalink = ?", "%/#{t}/", "#{t}/").first
+            Spree::Taxon.find_by(name: t) ||
+              Spree::Taxon.where("#{taxons}.permalink LIKE ? OR #{taxons}.permalink = ?", "%/#{t}/", "#{t}/").first
           end
         }.compact.flatten.uniq
       end

--- a/core/app/models/spree/promotion_handler/cart.rb
+++ b/core/app/models/spree/promotion_handler/cart.rb
@@ -35,13 +35,13 @@ module Spree
       end
 
       def connected_order_promotions
-        Promotion.active.includes(:promotion_rules).
+        Spree::Promotion.active.includes(:promotion_rules).
           joins(:order_promotions).
           where(spree_orders_promotions: { order_id: order.id }).readonly(false).to_a
       end
 
       def sale_promotions
-        Promotion.where(apply_automatically: true).active.includes(:promotion_rules)
+        Spree::Promotion.where(apply_automatically: true).active.includes(:promotion_rules)
       end
 
       def promotion_code(promotion)

--- a/core/app/models/spree/promotion_handler/page.rb
+++ b/core/app/models/spree/promotion_handler/page.rb
@@ -17,7 +17,7 @@ module Spree
       private
 
       def promotion
-        @promotion ||= Promotion.active.find_by(path: path)
+        @promotion ||= Spree::Promotion.active.find_by(path: path)
       end
     end
   end

--- a/core/app/models/spree/reimbursement.rb
+++ b/core/app/models/spree/reimbursement.rb
@@ -38,7 +38,7 @@ module Spree
     #   Refund.total_amount_reimbursed_for(reimbursement)
     # See the `reimbursement_generator` property regarding the generation of custom reimbursements.
     class_attribute :reimbursement_models
-    self.reimbursement_models = [Refund, Reimbursement::Credit]
+    self.reimbursement_models = [Spree::Refund, Spree::Reimbursement::Credit]
 
     # The reimbursement_performer property should be set to an object that responds to the following methods:
     # - #perform

--- a/core/app/models/spree/return_authorization.rb
+++ b/core/app/models/spree/return_authorization.rb
@@ -100,7 +100,7 @@ module Spree
 
       pre_expedited_exchange_hooks.each { |h| h.call items_to_exchange }
 
-      reimbursement = Reimbursement.new(return_items: items_to_exchange, order: order)
+      reimbursement = Spree::Reimbursement.new(return_items: items_to_exchange, order: order)
 
       if reimbursement.save
         reimbursement.perform!

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -136,9 +136,9 @@ module Spree
     def finalize!
       transaction do
         pending_units = inventory_units.select(&:pending?)
-        pending_manifest = ShippingManifest.new(inventory_units: pending_units)
+        pending_manifest = Spree::ShippingManifest.new(inventory_units: pending_units)
         pending_manifest.items.each { |item| manifest_unstock(item) }
-        InventoryUnit.finalize_units!(pending_units)
+        Spree::InventoryUnit.finalize_units!(pending_units)
       end
     end
 

--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -34,7 +34,7 @@ module Spree
       # Some extra care is needed with the having clause to ensure we are
       # counting distinct records of the join table. Otherwise a join could
       # cause this to return incorrect results.
-      join_table = ShippingMethodCategory.arel_table
+      join_table = Spree::ShippingMethodCategory.arel_table
       having = join_table[:id].count(true).eq(shipping_category_ids.count)
       joins(:shipping_method_categories).
         where(spree_shipping_method_categories: { shipping_category_id: shipping_category_ids }).
@@ -46,7 +46,7 @@ module Spree
     # @return [ActiveRecord::Relation] shipping methods which are available
     #   with the stock location or are marked available_to_all
     def self.available_in_stock_location(stock_location)
-      smsl_table = ShippingMethodStockLocation.arel_table
+      smsl_table = Spree::ShippingMethodStockLocation.arel_table
 
       # We are searching for either a matching entry in the stock location join
       # table or available_to_all being true.

--- a/core/app/models/spree/stock/coordinator.rb
+++ b/core/app/models/spree/stock/coordinator.rb
@@ -80,10 +80,10 @@ module Spree
       # minimum required ActiveRecord objects.
       def stock_location_variant_ids
         # associate the variant ids we're interested in with stock location ids
-        location_variant_ids = StockItem.
+        location_variant_ids = Spree::StockItem.
           where(variant_id: unallocated_variant_ids).
           joins(:stock_location).
-          merge(StockLocation.active).
+          merge(Spree::StockLocation.active).
           pluck(:stock_location_id, :variant_id)
 
         # load activerecord objects for the stock location ids and turn them
@@ -92,7 +92,7 @@ module Spree
         #     <stock location id> => <stock location>,
         #     ...,
         #   }
-        location_lookup = StockLocation.
+        location_lookup = Spree::StockLocation.
           where(id: location_variant_ids.map(&:first).uniq).
           map { |l| [l.id, l] }.
           to_h

--- a/core/app/models/spree/stock/package.rb
+++ b/core/app/models/spree/stock/package.rb
@@ -101,7 +101,7 @@ module Spree
       # @return [Array<Spree::ShippingCategory>] the shipping categories of the
       #   variants in this package
       def shipping_categories
-        ShippingCategory.where(id: shipping_category_ids)
+        Spree::ShippingCategory.where(id: shipping_category_ids)
       end
 
       # @return [ActiveRecord::Relation] the [Spree::ShippingMethod]s available

--- a/core/app/models/spree/stock_location.rb
+++ b/core/app/models/spree/stock_location.rb
@@ -110,12 +110,12 @@ module Spree
     private
 
     def create_stock_items
-      Variant.find_each { |variant| propagate_variant(variant) }
+      Spree::Variant.find_each { |variant| propagate_variant(variant) }
     end
 
     def ensure_one_default
       if default
-        StockLocation.where(default: true).where.not(id: id).each do |stock_location|
+        Spree::StockLocation.where(default: true).where.not(id: id).each do |stock_location|
           stock_location.default = false
           stock_location.save!
         end

--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -40,8 +40,8 @@ module Spree
 
     def ensure_default_exists_and_is_unique
       if default
-        Store.where.not(id: id).update_all(default: false)
-      elsif Store.where(default: true).count == 0
+        Spree::Store.where.not(id: id).update_all(default: false)
+      elsif Spree::Store.where(default: true).count == 0
         self.default = true
       end
     end

--- a/core/app/models/spree/taxonomy.rb
+++ b/core/app/models/spree/taxonomy.rb
@@ -20,7 +20,7 @@ module Spree
           updated_at: Time.current
         )
       else
-        self.root = Taxon.create!(taxonomy_id: id, name: name)
+        self.root = Spree::Taxon.create!(taxonomy_id: id, name: name)
       end
     end
   end

--- a/core/app/models/spree/variant/scopes.rb
+++ b/core/app/models/spree/variant/scopes.rb
@@ -2,7 +2,7 @@ module Spree
   class Variant < Spree::Base
     # FIXME: WARNING tested only under sqlite and postgresql
     scope :descend_by_popularity, -> {
-      order("COALESCE((SELECT COUNT(*) FROM  #{LineItem.quoted_table_name} GROUP BY #{LineItem.quoted_table_name}.variant_id HAVING #{LineItem.quoted_table_name}.variant_id = #{Variant.quoted_table_name}.id), 0) DESC")
+      order("COALESCE((SELECT COUNT(*) FROM  #{Spree::LineItem.quoted_table_name} GROUP BY #{Spree::LineItem.quoted_table_name}.variant_id HAVING #{Spree::LineItem.quoted_table_name}.variant_id = #{Spree::Variant.quoted_table_name}.id), 0) DESC")
     }
 
     class << self
@@ -12,7 +12,7 @@ module Spree
       #
       # product.variants_including_master.has_option(OptionType.find_by(name: 'shoe-size'), OptionValue.find_by(name: '8'))
       def has_option(option_type, *option_values)
-        option_types = OptionType.table_name
+        option_types = Spree::OptionType.table_name
 
         option_type_conditions = case option_type
                                  when OptionType then { "#{option_types}.name" => option_type.name }
@@ -24,9 +24,9 @@ module Spree
 
         option_values.each do |option_value|
           option_value_conditions = case option_value
-                                    when OptionValue then { "#{OptionValue.table_name}.name" => option_value.name }
-                                    when String      then { "#{OptionValue.table_name}.name" => option_value }
-          else { "#{OptionValue.table_name}.id" => option_value }
+                                    when OptionValue then { "#{Spree::OptionValue.table_name}.name" => option_value.name }
+                                    when String      then { "#{Spree::OptionValue.table_name}.name" => option_value }
+          else { "#{Spree::OptionValue.table_name}.id" => option_value }
           end
           relation = relation.where(option_value_conditions)
         end

--- a/core/app/models/spree/zone.rb
+++ b/core/app/models/spree/zone.rb
@@ -185,7 +185,7 @@ module Spree
     def set_zone_members(ids, type)
       zone_members.destroy_all
       ids.reject(&:blank?).map do |id|
-        member = ZoneMember.new
+        member = Spree::ZoneMember.new
         member.zoneable_type = type
         member.zoneable_id = id
         members << member

--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -168,7 +168,7 @@ module Spree
     def before_address
       # if the user has a default address, a callback takes care of setting
       # that; but if he doesn't, we need to build an empty one here
-      default = {country_id: Country.default.id}
+      default = {country_id: Spree::Country.default.id}
       @order.build_bill_address(default) unless @order.bill_address
       @order.build_ship_address(default) if @order.checkout_steps.include?('delivery') && !@order.ship_address
     end

--- a/frontend/app/controllers/spree/orders_controller.rb
+++ b/frontend/app/controllers/spree/orders_controller.rb
@@ -13,7 +13,7 @@ module Spree
     skip_before_action :verify_authenticity_token, only: [:populate]
 
     def show
-      @order = Order.find_by_number!(params[:id])
+      @order = Spree::Order.find_by_number!(params[:id])
     end
 
     def update
@@ -36,7 +36,7 @@ module Spree
 
     # Shows the current incomplete order from the session
     def edit
-      @order = current_order || Order.incomplete.find_or_initialize_by(guest_token: cookies.signed[:guest_token])
+      @order = current_order || Spree::Order.incomplete.find_or_initialize_by(guest_token: cookies.signed[:guest_token])
       associate_user
     end
 

--- a/frontend/app/controllers/spree/products_controller.rb
+++ b/frontend/app/controllers/spree/products_controller.rb
@@ -37,9 +37,9 @@ module Spree
 
     def load_product
       if try_spree_current_user.try(:has_spree_role?, "admin")
-        @products = Product.with_deleted
+        @products = Spree::Product.with_deleted
       else
-        @products = Product.available
+        @products = Spree::Product.available
       end
       @product = @products.friendly.find(params[:id])
     end

--- a/frontend/app/controllers/spree/store_controller.rb
+++ b/frontend/app/controllers/spree/store_controller.rb
@@ -39,7 +39,7 @@ module Spree
     end
 
     def lock_order
-      OrderMutex.with_lock!(@order) { yield }
+      Spree::OrderMutex.with_lock!(@order) { yield }
     rescue Spree::OrderMutex::LockFailed
       flash[:error] = Spree.t(:order_mutex_error)
       redirect_to spree.cart_path

--- a/frontend/app/controllers/spree/taxons_controller.rb
+++ b/frontend/app/controllers/spree/taxons_controller.rb
@@ -6,7 +6,7 @@ module Spree
     respond_to :html
 
     def show
-      @taxon = Taxon.find_by_permalink!(params[:id])
+      @taxon = Spree::Taxon.find_by_permalink!(params[:id])
       return unless @taxon
 
       @searcher = build_searcher(params.merge(taxon: @taxon.id, include_images: true))


### PR DESCRIPTION
Some calls to Product are not namespaced with Spree::. This leads to a collision if the including application has an existing Product model defined. 