### PR TITLE
Update product slug validation

### DIFF
--- a/backend/spec/features/admin/products/edit/products_spec.rb
+++ b/backend/spec/features/admin/products/edit/products_spec.rb
@@ -41,9 +41,9 @@ describe 'Product Details', type: :feature do
 
       fill_in "product_slug", with: ''
       click_button "Update"
-      within('#product_slug_field') { expect(page).to have_content("is too short") }
+      within('#product_slug_field') { expect(page).to have_content("can't be blank") }
 
-      fill_in "product_slug", with: 'another-random-slug-value'
+      fill_in "product_slug", with: 'x'
       click_button "Update"
       expect(page).to have_content("successfully updated!")
     end

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -91,7 +91,7 @@ module Spree
     validates :name, presence: true
     validates :price, presence: true, if: proc { Spree::Config[:require_master_price] }
     validates :shipping_category_id, presence: true
-    validates :slug, length: { minimum: 3 }, uniqueness: { allow_blank: true }
+    validates :slug, presence: true, uniqueness: { allow_blank: true }
 
     attr_accessor :option_values_hash
 


### PR DESCRIPTION
Replace the existing length validation with a presence validation, because the length validation could lead to errors with short product names (see #1608 for more information).

Should I add a model spec for creating products with short names?

One more thing I noticed is the uniqueness validation, I think it's unnecessary because that's essentially what friendly_id handles. At least the `allow_blank: true` is unnecessary because we validate the length / presence, so this can never happen.