### PR TITLE
Modify getting started guide use Spree::User class

### DIFF
--- a/guides/getting_started.md
+++ b/guides/getting_started.md
@@ -90,7 +90,7 @@ Now, run `bundle install` to download `solidus` and `solidus_auth_devise` into y
 the following generators to get started:
 
 ```
-bundle exec rails g spree:install
+bundle exec rails g spree:install --user_class=Spree::User
 bundle exec rails g solidus:auth:install
 ```
 


### PR DESCRIPTION
Previously, the beginner following this guide would end up with
the `Spree::LegacyUser` instead of the `Spree::User` as her user
class configuration.