### PR TITLE
Remove deprecated method_missing image methods

### DIFF
--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -134,15 +134,6 @@ module Spree
        time.strftime("%l:%M %p")].join(" ")
     end
 
-    def method_missing(method_name, *args, &block)
-      if image_style = image_style_from_method_name(method_name)
-        define_image_method(image_style)
-        send(method_name, *args)
-      else
-        super
-      end
-    end
-
     def link_to_tracking(shipment, options = {})
       return unless shipment.tracking && shipment.shipping_method
 
@@ -155,39 +146,6 @@ module Spree
 
     def plural_resource_name(resource_class)
       resource_class.model_name.human(count: Spree::I18N_GENERIC_PLURAL)
-    end
-
-    private
-
-    # Returns style of image or nil
-    def image_style_from_method_name(method_name)
-      if method_name.to_s.match(/_image$/) && style = method_name.to_s.sub(/_image$/, '')
-        possible_styles = Spree::Image.attachment_definitions[:attachment][:styles]
-        style if style.in? possible_styles.with_indifferent_access
-      end
-    end
-
-    def create_product_image_tag(image, product, options, style)
-      options.reverse_merge! alt: image.alt.blank? ? product.name : image.alt
-      image_tag image.attachment.url(style), options
-    end
-
-    def define_image_method(style)
-      self.class.send :define_method, "#{style}_image" do |product, *options|
-        Spree::Deprecation.warn "Spree image helpers will be deprecated in the near future. Use the provided resource to access the intendend image directly.", caller
-        options = options.first || {}
-        if product.images.empty?
-          if !product.is_a?(Spree::Variant) && !product.variant_images.empty?
-            create_product_image_tag(product.variant_images.first, product, options, style)
-          elsif product.is_a?(Variant) && !product.product.variant_images.empty?
-            create_product_image_tag(product.product.variant_images.first, product, options, style)
-          else
-            image_tag "noimage/#{style}.png", options
-          end
-        else
-          create_product_image_tag(product.images.first, product, options, style)
-        end
-      end
     end
   end
 end

--- a/core/spec/helpers/base_helper_spec.rb
+++ b/core/spec/helpers/base_helper_spec.rb
@@ -50,26 +50,6 @@ describe Spree::BaseHelper, type: :helper do
     end
   end
 
-  # Regression test for https://github.com/spree/spree/issues/1436
-  context "defining custom image helpers" do
-    let(:product) { mock_model(Spree::Product, images: [], variant_images: []) }
-    before do
-      Spree::Image.class_eval do
-        attachment_definitions[:attachment][:styles][:very_strange] = '1x1'
-      end
-    end
-
-    it "should not raise errors when style exists" do
-      Spree::Deprecation.silence do
-        very_strange_image(product)
-      end
-    end
-
-    it "should raise NoMethodError when style is not exists" do
-      expect { another_strange_image(product) }.to raise_error(NoMethodError)
-    end
-  end
-
   # Regression test for https://github.com/spree/spree/issues/2034
   context "flash_message" do
     let(:flash) { { "notice" => "ok", "foo" => "foo", "bar" => "bar" } }
@@ -139,26 +119,6 @@ describe Spree::BaseHelper, type: :helper do
       tags = Nokogiri::HTML.parse(meta_data_tags)
       content = tags.css("meta[name=description]").first["content"]
       expect(content.length).to be <= 160
-    end
-  end
-
-  # Regression test for https://github.com/spree/spree/issues/5384
-  context "custom image helpers conflict with inproper statements" do
-    let(:product) { mock_model(Spree::Product, images: [], variant_images: []) }
-    before do
-      Spree::Image.class_eval do
-        attachment_definitions[:attachment][:styles][:foobar] = '1x1'
-      end
-    end
-
-    it "should not raise errors when helper method called" do
-      Spree::Deprecation.silence do
-        foobar_image(product)
-      end
-    end
-
-    it "should raise NoMethodError when statement with name equal to style name called" do
-      expect { foobar(product) }.to raise_error(NoMethodError)
     end
   end
 


### PR DESCRIPTION
These have been deprecated since Solidus 1.0