### PR TITLE
Add missing index to spree_payments.number

### DIFF
--- a/core/db/migrate/20161129035810_add_index_to_spree_payments_number.rb
+++ b/core/db/migrate/20161129035810_add_index_to_spree_payments_number.rb
@@ -1,0 +1,5 @@
+class AddIndexToSpreePaymentsNumber < ActiveRecord::Migration[5.0]
+  def change
+    add_index 'spree_payments', ['number'], unique: true
+  end
+end


### PR DESCRIPTION
We ensure uniqueness and we query by number inside of
[Payment#set_unique_identifier](https://github.com/solidusio/solidus/blob/v2.0.0/core/app/models/spree/payment.rb#L266-L271).  This should have an index.