### PR TITLE
delete spree_shipping_rate_taxes when a shipment is destroyed

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -7,7 +7,7 @@ module Spree
 
     has_many :adjustments, as: :adjustable, inverse_of: :adjustable, dependent: :delete_all
     has_many :inventory_units, dependent: :destroy, inverse_of: :shipment
-    has_many :shipping_rates, -> { order(:cost) }, dependent: :delete_all
+    has_many :shipping_rates, -> { order(:cost) }, dependent: :destroy
     has_many :shipping_methods, through: :shipping_rates
     has_many :state_changes, as: :stateful
     has_many :cartons, -> { uniq }, through: :inventory_units

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -637,9 +637,21 @@ describe Spree::Shipment, type: :model do
 
   # Regression test for https://github.com/spree/spree/issues/3349
   context "#destroy" do
-    it "destroys linked shipping_rates" do
-      reflection = Spree::Shipment.reflect_on_association(:shipping_rates)
-      expect(reflection.options[:dependent]).to be(:delete_all)
+    let(:shipping_rate) do
+      Spree::ShippingRate.create!(
+        shipping_method: shipping_method,
+        selected: true,
+        taxes: [Spree::ShippingRateTax.new(amount: 20)]
+      )
+    end
+    it "destroys linked shipping_rates and shipping_rate_taxes" do
+      shipping_rate = shipment.shipping_rates.first
+      shipping_rate_tax = shipping_rate.taxes.first
+
+      shipment.destroy
+
+      expect{shipping_rate.reload}.to raise_error(ActiveRecord::RecordNotFound)
+      expect{shipping_rate_tax.reload}.to raise_error(ActiveRecord::RecordNotFound)
     end
   end
 


### PR DESCRIPTION
If you make a `Spree::ShippingMethod` taxable (by assigning a tax category), generated `#shipping rates` will have associated tax (`Spree::ShippingRate#tax`) in `spree_shipping_rate_taxes`

Destroying a shipment destroys the rates, but not the rates' associated taxes.