### PR TITLE
Add shipped state to shipped order factory

### DIFF
--- a/core/lib/spree/testing_support/factories/order_factory.rb
+++ b/core/lib/spree/testing_support/factories/order_factory.rb
@@ -104,6 +104,8 @@ FactoryGirl.define do
           end
 
           factory :shipped_order do
+            shipment_state 'shipped'
+
             transient do
               with_cartons true
             end

--- a/core/spec/lib/spree/core/testing_support/factories/order_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/order_factory_spec.rb
@@ -185,7 +185,8 @@ RSpec.describe 'order factory' do
         expect(order).to have_attributes(
           total: 110,
           payment_total: 110,
-          payment_state: "paid"
+          payment_state: "paid",
+          shipment_state: "shipped"
         )
 
         expect(order.payments.count).to eq 1


### PR DESCRIPTION
This adds the `shipped` shipment state to the shipped order factory (say 3 times fast)