### PR TITLE
seed Spree::Store with valid cart_tax_country_iso value

### DIFF
--- a/core/db/default/spree/stores.rb
+++ b/core/db/default/spree/stores.rb
@@ -5,6 +5,6 @@ unless Spree::Store.where(code: 'spree').exists?
     s.name              = 'Spree Demo Site'
     s.url               = 'demo.spreecommerce.com'
     s.mail_from_address = 'spree@example.com'
-    s.cart_tax_country_iso = Spree::Config.admin_vat_location
+    s.cart_tax_country_iso = 'US'
   end.save!
 end


### PR DESCRIPTION
The current wrong value is something like `"#<Spree::Tax::TaxLocation:0x007fe12a2856a0>"` (because `Spree::Config.admin_vat_location` returns an object).
Is US a good default? :)

/cc @mamhoff 

p.s:
Will the default Store become something like "Solidus Demo Site" in the future? :)