### PR TITLE
Fix LocalJumpError on ruby 2.4.0-preview3

### DIFF
--- a/core/app/models/spree/zone.rb
+++ b/core/app/models/spree/zone.rb
@@ -16,16 +16,18 @@ module Spree
     after_save :remove_previous_default
 
     scope :with_member_ids, ->(state_ids, country_ids) do
-      return none if !state_ids.present? && !country_ids.present?
-
-      spree_zone_members_table = Spree::ZoneMember.arel_table
-      matching_state =
-        spree_zone_members_table[:zoneable_type].eq("Spree::State").
-        and(spree_zone_members_table[:zoneable_id].in(state_ids))
-      matching_country =
-        spree_zone_members_table[:zoneable_type].eq("Spree::Country").
-        and(spree_zone_members_table[:zoneable_id].in(country_ids))
-      joins(:zone_members).where(matching_state.or(matching_country)).distinct
+      if !state_ids.present? && !country_ids.present?
+        none
+      else
+        spree_zone_members_table = Spree::ZoneMember.arel_table
+        matching_state =
+          spree_zone_members_table[:zoneable_type].eq("Spree::State").
+          and(spree_zone_members_table[:zoneable_id].in(state_ids))
+        matching_country =
+          spree_zone_members_table[:zoneable_type].eq("Spree::Country").
+          and(spree_zone_members_table[:zoneable_id].in(country_ids))
+        joins(:zone_members).where(matching_state.or(matching_country)).distinct
+      end
     end
 
     scope :for_address, ->(address) do


### PR DESCRIPTION
Fixes the following error on ruby `2.4.0-preview3`, which doesn't allow `return`s out of this scope proc.

```
Failure/Error: return none if !state_ids.present? && !country_ids.present?

LocalJumpError:
  unexpected return
# ./app/models/spree/zone.rb:20:in `block in <class:Zone>'
# ./app/models/spree/zone.rb:62:in `match'
```

If history is any indication, there will be a ruby 2.4.0 release on December 25 :santa:, so it would be nice to get this in our 2.1 release and backport to previous affected releases (probably back to 1.3).

## Minimal reproduction

Here's a reproduction of the issue in plain ruby. I haven't seen anything relevant in ruby's changelog about this, so I'm not sure why it changed.

```
proc = -> { return true }
o = Object.new
o.singleton_class.send(:define_method, :foo) { instance_exec(&proc) }
o.foo
#=> true on ruby 2.3.3
# LocalJumpError on ruby 2.4.0-preview3
```