### PR TITLE
Fix in_stock cache clearing after update

### DIFF
--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -69,6 +69,7 @@ module Spree
     after_create :set_position
     after_create :set_master_out_of_stock, unless: :is_master?
 
+    after_save :clear_in_stock_cache
     after_touch :clear_in_stock_cache
 
     after_real_destroy :destroy_option_values_variants

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -569,6 +569,16 @@ describe Spree::Variant, type: :model do
         end
       end
     end
+
+    describe "cache clearing on update" do
+      it "correctly reports after updating track_inventory" do
+        variant.stock_items.first.set_count_on_hand 0
+        expect(variant).not_to be_in_stock
+
+        variant.update!(track_inventory: false)
+        expect(variant).to be_in_stock
+      end
+    end
   end
 
   describe '#is_backorderable' do


### PR DESCRIPTION
There's an issue with the caching on `Spree::Variant#in_stock?` in which it won't be cleared after the variant is updated. Only after it is touched.

As a result, changes to `Spree::Variant#track_inventory` do not correctly update `Spree::Variant#in_stock?` when they should.

The simplest solution is to ensure we clear the cache on save in addition to touch.