### PR TITLE
Fix for duplicate prices

### DIFF
--- a/core/app/models/spree/variant/vat_price_generator.rb
+++ b/core/app/models/spree/variant/vat_price_generator.rb
@@ -28,16 +28,19 @@ module Spree
           # Don't re-create the default price
           next if variant.default_price && variant.default_price.country_iso == country_iso
 
-          foreign_price = variant.prices.find_or_initialize_by(
-            country_iso: country_iso,
-            currency: variant.default_price.currency,
-          )
+          foreign_price = find_or_initialize_price_by(country_iso, variant.default_price.currency)
 
           foreign_price.amount = variant.default_price.net_amount * (1 + vat_for_country_iso(country_iso))
         end
       end
 
       private
+
+      def find_or_initialize_price_by(country_iso, currency)
+        variant.prices.detect do |price|
+          price.country_iso == country_iso && price.currency == currency
+        end || variant.prices.build(country_iso: country_iso, currency: currency)
+      end
 
       # nil is added to the array so we always have an export price.
       def country_isos_requiring_price

--- a/core/spec/models/spree/variant/vat_price_generator_spec.rb
+++ b/core/spec/models/spree/variant/vat_price_generator_spec.rb
@@ -30,9 +30,15 @@ describe Spree::Variant::VatPriceGenerator do
     end
 
     it "will not build prices that are already present" do
-      variant.prices.build(amount: 11, country_iso: "FR")
-      variant.prices.build(amount: 11, country_iso: nil)
       expect { subject }.not_to change { variant.prices.length }
+    end
+
+    # We need to remove the price for FR from the database so it is created in memory, and then run VatPriceGenerator twice to trigger the duplicate price issue.
+    it "will not build duplicate prices on multiple runs" do
+      variant.prices.where(country_iso: "FR").destroy_all
+      variant.reload
+      described_class.new(variant).run
+      expect { subject }.not_to change { variant.prices.size }
     end
   end
 

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -66,17 +66,19 @@ describe Spree::Variant, type: :model do
       let!(:high_vat) { create(:tax_rate, included_in_price: true, amount: 0.25, zone: high_vat_zone, tax_category: tax_category) }
       let!(:low_vat) { create(:tax_rate, included_in_price: true, amount: 0.15, zone: low_vat_zone, tax_category: tax_category) }
 
-      let(:product) { create(:product, tax_category: tax_category) }
+      let(:product) { build(:product, tax_category: tax_category) }
 
-      subject(:new_variant) { create(:variant, price: 15, product: product) }
+      subject(:new_variant) { build(:variant, price: 15) }
 
       it "creates the appropriate prices for them" do
-        # default price + FR, DE, DK
-        expect { new_variant }.to change { Spree::Price.count }.by(4)
+        product.variants << new_variant
+        product.save!
         expect(new_variant.prices.find_by(country_iso: "FR").amount).to eq(17.25)
         expect(new_variant.prices.find_by(country_iso: "DE").amount).to eq(18.75)
         expect(new_variant.prices.find_by(country_iso: "DK").amount).to eq(18.75)
         expect(new_variant.prices.find_by(country_iso: nil).amount).to eq(15.00)
+        # default price + FR, DE, DK
+        expect(new_variant.prices.count).to eq(4)
       end
 
       context "when the products price changes" do


### PR DESCRIPTION
This is a failing spec, and a solution for `Variant#build_vat_prices` running several times for variants and subsequently creating duplicate prices (see #1634).

As mentioned in the issue I'm not sure the solution is right (eg. what happens if validations are run several times on purpose while changing tax categories?), but it was the easiest to implement.