### PR TITLE
Fix error accessing spree_roles in rails 5.0.1.rc1

### DIFF
--- a/core/app/models/concerns/spree/user_methods.rb
+++ b/core/app/models/concerns/spree/user_methods.rb
@@ -11,7 +11,7 @@ module Spree
       extend Spree::DisplayMoney
 
       has_many :role_users, foreign_key: "user_id", class_name: "Spree::RoleUser", dependent: :destroy
-      has_many :spree_roles, through: :role_users, source: :role
+      has_many :spree_roles, through: :role_users, source: :role, class_name: "Spree::Role"
 
       has_many :user_stock_locations, foreign_key: "user_id", class_name: "Spree::UserStockLocation"
       has_many :stock_locations, through: :user_stock_locations


### PR DESCRIPTION
Accessing this through association fails because it tries to use the `Spree::LegacyUser::SpreeRole` class, which does not exist.

    NameError:
      uninitialized constant Spree::LegacyUser::SpreeRole

I'll be taking a look to see if I can fix this in Rails proper (or at least file a bug), but I'd like to get this patched in Solidus in case this isn't fixed by the Rails 5.0.1 release.