### PR TITLE
Avoid break of Validator if DB column is missing

### DIFF
--- a/core/app/models/spree/validations/db_maximum_length_validator.rb
+++ b/core/app/models/spree/validations/db_maximum_length_validator.rb
@@ -10,7 +10,13 @@ module Spree
       end
 
       def validate(record)
-        limit = record.class.columns_hash[@field].limit
+        field = record.class.columns_hash[@field]
+        # solidus_globalize want its translated fields to be removed from the
+        # DB. Even if they are kept, they will not appear in `.columns_hash`
+        # and friends because they are added to `ignored_columns`.
+        return unless field
+
+        limit = field.limit
         value = record[@field.to_sym]
         if value && limit && value.to_s.length > limit
           record.errors.add(@field.to_sym, :too_long, count: limit)


### PR DESCRIPTION
If the gem `solidus_globalize` is loaded, the `Spree::ProductProperty#value` column cannot be found anymore - either because it was removed (as instructed by `globalize` gem) or because it is ignored and skipped by `ActiveRecord::Base.columns_hash`.

More on the discussion: https://github.com/solidusio-contrib/solidus_globalize/pull/19

Example failure: https://travis-ci.org/solidusio-contrib/solidus_globalize/jobs/182244854
