### PR TITLE
Remove conversions to floating point

### DIFF
--- a/core/app/models/spree/calculator/flexi_rate.rb
+++ b/core/app/models/spree/calculator/flexi_rate.rb
@@ -2,8 +2,8 @@ require_dependency 'spree/calculator'
 
 module Spree
   class Calculator::FlexiRate < Calculator
-    preference :first_item,      :decimal, default: 0.0
-    preference :additional_item, :decimal, default: 0.0
+    preference :first_item,      :decimal, default: 0
+    preference :additional_item, :decimal, default: 0
     preference :max_items,       :integer, default: 0
     preference :currency,        :string,  default: ->{ Spree::Config[:currency] }
 
@@ -12,18 +12,13 @@ module Spree
     end
 
     def compute(object)
-      sum = 0
-      max = preferred_max_items.to_i
       items_count = object.quantity
-      items_count.times do |i|
-        if i == 0
-          sum += preferred_first_item.to_f
-        elsif ((max > 0) && (i <= (max - 1))) || (max == 0)
-          sum += preferred_additional_item.to_f
-        end
-      end
+      items_count = [items_count, preferred_max_items].min unless preferred_max_items.zero?
 
-      sum
+      return BigDecimal.new(0) if items_count == 0
+
+      additional_items_count = items_count - 1
+      preferred_first_item + preferred_additional_item * additional_items_count
     end
   end
 end

--- a/core/app/models/spree/calculator/shipping/flat_percent_item_total.rb
+++ b/core/app/models/spree/calculator/shipping/flat_percent_item_total.rb
@@ -11,7 +11,7 @@ module Spree
 
       def compute_from_price(price)
         value = price * BigDecimal(preferred_flat_percent.to_s) / 100.0
-        (value * 100).round.to_f / 100
+        value.round(2)
       end
     end
   end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -212,7 +212,7 @@ module Spree
 
     # Is this a free order in which case the payment step should be skipped
     def payment_required?
-      total.to_f > 0.0
+      total > 0
     end
 
     def confirmation_required?

--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -56,7 +56,7 @@ module Spree
             gateway_options
           )
           money = ::Money.new(amount, currency)
-          capture_events.create!(amount: money.to_f)
+          capture_events.create!(amount: money.to_d)
           update_attributes!(amount: captured_amount)
           handle_response(response, :complete, :failure)
         end

--- a/core/app/models/spree/promotion/actions/create_adjustment.rb
+++ b/core/app/models/spree/promotion/actions/create_adjustment.rb
@@ -35,7 +35,12 @@ module Spree
         # Ensure a negative amount which does not exceed the sum of the order's
         # item_total and ship_total
         def compute_amount(calculable)
-          amount = calculator.compute(calculable).to_f.abs
+          amount = calculator.compute(calculable)
+          if !amount.is_a?(BigDecimal)
+            Spree::Deprecation.warn "#{calculator.class.name}#compute returned #{amount.inspect}, it should return a BigDecimal"
+          end
+          amount ||= BigDecimal.new(0)
+          amount = amount.abs
           [(calculable.item_total + calculable.ship_total), amount].min * -1
         end
 

--- a/core/app/models/spree/promotion/actions/create_item_adjustments.rb
+++ b/core/app/models/spree/promotion/actions/create_item_adjustments.rb
@@ -31,7 +31,12 @@ module Spree
         def compute_amount(adjustable)
           order = adjustable.is_a?(Order) ? adjustable : adjustable.order
           return 0 unless promotion.line_item_actionable?(order, adjustable)
-          promotion_amount = calculator.compute(adjustable).to_f.abs
+          promotion_amount = calculator.compute(adjustable)
+          if !promotion_amount.is_a?(BigDecimal)
+            Spree::Deprecation.warn "#{calculator.class.name}#compute returned #{promotion_amount.inspect}, it should return a BigDecimal"
+          end
+          promotion_amount ||= BigDecimal.new(0)
+          promotion_amount = promotion_amount.abs
           [adjustable.amount, promotion_amount].min * -1
         end
 

--- a/core/app/models/spree/promotion/actions/create_quantity_adjustments.rb
+++ b/core/app/models/spree/promotion/actions/create_quantity_adjustments.rb
@@ -52,7 +52,12 @@ module Spree::Promotion::Actions
     # adjustment. +adjustment_amount * 3+ or $15.
     #
     def compute_amount(line_item)
-      adjustment_amount = calculator.compute(PartialLineItem.new(line_item)).to_f.abs
+      adjustment_amount = calculator.compute(PartialLineItem.new(line_item))
+      if !adjustment_amount.is_a?(BigDecimal)
+        Spree::Deprecation.warn "#{calculator.class.name}#compute returned #{adjustment_amount.inspect}, it should return a BigDecimal"
+      end
+      adjustment_amount ||= BigDecimal.new(0)
+      adjustment_amount = adjustment_amount.abs
 
       order = line_item.order
       line_items = actionable_line_items(order)

--- a/core/app/models/spree/refund.rb
+++ b/core/app/models/spree/refund.rb
@@ -40,7 +40,7 @@ module Spree
     def perform!
       return true if transaction_id.present?
 
-      credit_cents = Spree::Money.new(amount.to_f, currency: payment.currency).money.cents
+      credit_cents = money.cents
 
       @response = process!(credit_cents)
 

--- a/core/spec/models/spree/calculator/flexi_rate_spec.rb
+++ b/core/spec/models/spree/calculator/flexi_rate_spec.rb
@@ -2,43 +2,155 @@ require 'spec_helper'
 require 'shared_examples/calculator_shared_examples'
 
 describe Spree::Calculator::FlexiRate, type: :model do
-  let(:calculator) { Spree::Calculator::FlexiRate.new }
+  let(:calculator) do
+    Spree::Calculator::FlexiRate.new(
+      preferred_first_item: first_item,
+      preferred_additional_item: additional_item,
+      preferred_max_items: max_items
+    )
+  end
+  let(:first_item) { 0 }
+  let(:additional_item) { 0 }
+  let(:max_items) { 0 }
 
   it_behaves_like 'a calculator with a description'
 
   let(:order) do
     mock_model(
-      Spree::Order, quantity: 10
+      Spree::Order, quantity: quantity
     )
   end
 
   context "compute" do
-    it "should compute amount correctly when all fees are 0" do
-      expect(calculator.compute(order).round(2)).to eq(0.0)
+    subject { calculator.compute(order) }
+    context "with all amounts 0" do
+      context "with quantity 0" do
+        let(:quantity) { 0 }
+        it { should eq 0 }
+      end
+
+      context "with quantity 1" do
+        let(:quantity) { 1 }
+        it { should eq 0 }
+      end
+
+      context "with quantity 2" do
+        let(:quantity) { 2 }
+        it { should eq 0 }
+      end
+
+      context "with quantity 10" do
+        let(:quantity) { 10 }
+        it { should eq 0 }
+      end
     end
 
-    it "should compute amount correctly when first_item has a value" do
-      allow(calculator).to receive_messages preferred_first_item: 1.0
-      expect(calculator.compute(order).round(2)).to eq(1.0)
+    context "when first_item has a value" do
+      let(:first_item) { 1.23 }
+
+      context "with quantity 0" do
+        let(:quantity) { 0 }
+        it { should eq 0 }
+      end
+
+      context "with quantity 1" do
+        let(:quantity) { 1 }
+        it { should eq 1.23 }
+      end
+
+      context "with quantity 2" do
+        let(:quantity) { 2 }
+        it { should eq 1.23 }
+      end
+
+      context "with quantity 10" do
+        let(:quantity) { 10 }
+        it { should eq 1.23 }
+      end
     end
 
-    it "should compute amount correctly when additional_items has a value" do
-      allow(calculator).to receive_messages preferred_additional_item: 1.0
-      expect(calculator.compute(order).round(2)).to eq(9.0)
+    context "when additional_items has a value" do
+      let(:additional_item) { 1.23 }
+
+      context "with quantity 0" do
+        let(:quantity) { 0 }
+        it { should eq 0 }
+      end
+
+      context "with quantity 1" do
+        let(:quantity) { 1 }
+        it { should eq 0 }
+      end
+
+      context "with quantity 2" do
+        let(:quantity) { 2 }
+        it { should eq 1.23 }
+      end
+
+      context "with quantity 10" do
+        let(:quantity) { 10 }
+        it { should eq 11.07 }
+      end
     end
 
-    it "should compute amount correctly when additional_items and first_item have values" do
-      allow(calculator).to receive_messages preferred_first_item: 5.0, preferred_additional_item: 1.0
-      expect(calculator.compute(order).round(2)).to eq(14.0)
-    end
+    context "when first_item and additional_items has a value" do
+      let(:first_item) { 1.13 }
+      let(:additional_item) { 2.11 }
 
-    it "should compute amount correctly when additional_items and first_item have values AND max items has value" do
-      allow(calculator).to receive_messages preferred_first_item: 5.0, preferred_additional_item: 1.0, preferred_max_items: 3
-      expect(calculator.compute(order).round(2)).to eq(7.0)
-    end
+      context "with quantity 0" do
+        let(:quantity) { 0 }
+        it { should eq 0 }
+      end
 
-    it "should allow creation of new object with all the attributes" do
-      Spree::Calculator::FlexiRate.new(preferred_first_item: 1, preferred_additional_item: 1, preferred_max_items: 1)
+      context "with quantity 1" do
+        let(:quantity) { 1 }
+        it { should eq 1.13 }
+      end
+
+      context "with quantity 2" do
+        let(:quantity) { 2 }
+        it { should eq 3.24 }
+      end
+
+      context "with quantity 10" do
+        let(:quantity) { 10 }
+        it { should eq 20.12 }
+      end
+
+      context "with max_items 5" do
+        let(:max_items) { 5 }
+
+        context "with quantity 0" do
+          let(:quantity) { 0 }
+          it { should eq 0 }
+        end
+
+        context "with quantity 1" do
+          let(:quantity) { 1 }
+          it { should eq 1.13 }
+        end
+
+        context "with quantity 2" do
+          let(:quantity) { 2 }
+          it { should eq 3.24 }
+        end
+
+        context "with quantity 5" do
+          let(:quantity) { 5 }
+          it { should eq 9.57 }
+        end
+
+        context "with quantity 10" do
+          let(:quantity) { 10 }
+          it { should eq 9.57 }
+        end
+      end
     end
+  end
+
+  it "should allow creation of new object with all the attributes" do
+    attributes = {preferred_first_item: 1, preferred_additional_item: 1, preferred_max_items: 1}
+    calculator = Spree::Calculator::FlexiRate.new(attributes)
+    expect(calculator).to have_attributes(attributes)
   end
 end

--- a/core/spec/models/spree/calculator/shipping/flat_percent_item_total_spec.rb
+++ b/core/spec/models/spree/calculator/shipping/flat_percent_item_total_spec.rb
@@ -21,6 +21,10 @@ module Spree
       it "should round result correctly" do
         expect(subject.compute(package)).to eq(4.04)
       end
+
+      it "should return a bigdecimal" do
+        expect(subject.compute(package)).to be_a(BigDecimal)
+      end
     end
   end
 end

--- a/core/spec/models/spree/order/payment_spec.rb
+++ b/core/spec/models/spree/order/payment_spec.rb
@@ -218,15 +218,27 @@ module Spree
       end
     end
 
-    context "payment required?" do
+    context "payment_required?" do
+      before { order.total = total }
+
       context "total is zero" do
-        before { allow(order).to receive_messages(total: 0) }
-        it { expect(order.payment_required?).to be false }
+        let(:total) { 0 }
+        it { expect(order).not_to be_payment_required }
       end
 
-      context "total > zero" do
-        before { allow(order).to receive_messages(total: 1) }
-        it { expect(order.payment_required?).to be true }
+      context "total is once cent" do
+        let(:total) { 1 }
+        it { expect(order).to be_payment_required }
+      end
+
+      context "total is once dollar" do
+        let(:total) { 1 }
+        it { expect(order).to be_payment_required }
+      end
+
+      context "total is huge" do
+        let(:total) { 2**32 }
+        it { expect(order).to be_payment_required }
       end
     end
   end

--- a/core/spec/models/spree/promotion/actions/create_item_adjustments_spec.rb
+++ b/core/spec/models/spree/promotion/actions/create_item_adjustments_spec.rb
@@ -97,13 +97,13 @@ module Spree
 
           context "when the adjustable is actionable" do
             it "calls compute on the calculator" do
-              expect(action.calculator).to receive(:compute).with(line_item)
+              expect(action.calculator).to receive(:compute).with(line_item).and_call_original
               action.compute_amount(line_item)
             end
 
             context "calculator returns amount greater than item total" do
               before do
-                expect(action.calculator).to receive(:compute).with(line_item).and_return(300)
+                action.calculator.preferred_amount = 300
                 allow(line_item).to receive_messages(amount: 100)
               end
 


### PR DESCRIPTION
Floating point should never be used for money, or really any number you're uncomfortable with being described as "about".

A quick example why:
```
> 0.1 + 0.1 + 0.1
=> 0.30000000000000004
```

We use `BigDecimal` extensively, and have done pretty good job at ensuring all new code doesn't do float math. However there are still a few pieces of older code which convert to or back from floats. It's time to remove these.

Ruby 2.4 has [changed the default round mode](https://bugs.ruby-lang.org/issues/12548) for floating point, so we want to make especially sure we aren't rounding any floats.

## Places `to_f` is found in models
 * [x] refund.rb
 * [ ] calculator/tiered_percent.rb
 * [x] calculator/flexi_rate.rb
 * [ ] calculator/tiered_flat_rate.rb
 * [ ] calculator/shipping/flexi_rate.rb
 * [x] calculator/shipping/flat_percent_item_total.rb
 * [x] order.rb
 * [x] promotion/actions/create_quantity_adjustments.rb
 * [x] promotion/actions/create_item_adjustments.rb
 * [x] promotion/actions/create_adjustment.rb
 * [x] payment/processing.rb