### PR TITLE
Update en.yml

### DIFF
--- a/backend/spec/features/admin/orders/new_order_spec.rb
+++ b/backend/spec/features/admin/orders/new_order_spec.rb
@@ -53,7 +53,7 @@ describe "New Order", type: :feature do
     click_icon "capture"
 
     click_on "Shipments"
-    click_on "ship"
+    click_on "Ship"
 
     within '.carton-state' do
       expect(page).to have_content('shipped')

--- a/backend/spec/features/admin/stock_transfer_spec.rb
+++ b/backend/spec/features/admin/stock_transfer_spec.rb
@@ -85,7 +85,7 @@ describe 'Stock Transfers', type: :feature, js: true do
     describe 'with enough stock' do
       it 'ships stock transfer' do
         visit spree.tracking_info_admin_stock_transfer_path(stock_transfer)
-        click_on 'ship'
+        click_on 'Ship'
 
         expect(page).to have_current_path(spree.admin_stock_transfers_path)
         expect(stock_transfer.reload.shipped_at).to_not be_nil
@@ -102,7 +102,7 @@ describe 'Stock Transfers', type: :feature, js: true do
       it 'does not ship stock transfer' do
         visit spree.tracking_info_admin_stock_transfer_path(stock_transfer)
 
-        click_on 'ship'
+        click_on 'Ship'
 
         expect(page).to have_current_path(spree.tracking_info_admin_stock_transfer_path(stock_transfer))
         expect(stock_transfer.reload.shipped_at).to be_nil

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -688,7 +688,7 @@ en:
       list: List
       listing: Listing
       new: New
-      receive: Receive      
+      receive: Receive
       refund: Refund
       remove: Remove
       save: Save

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -642,7 +642,7 @@ en:
       unlock_instructions:
         subject: Unlock Instructions
     oauth_callbacks:
-      failure: Could not authorize you from %{kind} because "%{reason}".
+      failure: "Could not authorize you from %{kind} because %{reason}."
       success: Successfully authorized from %{kind} account.
     unlocks:
       send_instructions: You will receive an email with instructions about how to unlock your account in a few minutes.
@@ -688,14 +688,13 @@ en:
       list: List
       listing: Listing
       new: New
+      receive: Receive      
       refund: Refund
-      receive: Receive
       remove: Remove
       save: Save
-      ship: ship
-      update: Update
+      ship: Ship
       split: Split
-      ship: ship
+      update: Update
     activate: Activate
     active: Active
     add: Add


### PR DESCRIPTION
- Correct syntax in devise/oauth_callbacks/failure
- Reorder action verbs in spree / actions and remove duplicated "ship" verb