### PR TITLE
Update Tiered* Calculators to use BigDecimal instead of Float

### DIFF
--- a/backend/spec/features/admin/promotions/tiered_calculator_spec.rb
+++ b/backend/spec/features/admin/promotions/tiered_calculator_spec.rb
@@ -38,7 +38,7 @@ feature "Tiered Calculator Promotions" do
     first_action_calculator = first_action.calculator
     expect(first_action_calculator.class).to eq Spree::Calculator::TieredPercent
     expect(first_action_calculator.preferred_base_percent).to eq 5
-    expect(first_action_calculator.preferred_tiers).to eq Hash[100.0 => 10.0]
+    expect(first_action_calculator.preferred_tiers).to eq(BigDecimal.new(100) => BigDecimal.new(10))
   end
 
   context "with an existing tiered flat rate calculator" do
@@ -49,7 +49,7 @@ feature "Tiered Calculator Promotions" do
 
       action.calculator = Spree::Calculator::TieredFlatRate.new
       action.calculator.preferred_base_amount = 5
-      action.calculator.preferred_tiers = Hash[100 => 10, 200 => 15, 300 => 20]
+      action.calculator.preferred_tiers = {100 => 10, 200 => 15, 300 => 20}
       action.calculator.save!
 
       visit spree.edit_admin_promotion_path(promotion)
@@ -63,7 +63,10 @@ feature "Tiered Calculator Promotions" do
       within('#actions_container') { click_button "Update" }
 
       calculator = promotion.actions.first.calculator
-      expect(calculator.preferred_tiers).to eq Hash[100.0 => 10.0, 300.0 => 20.0]
+      expect(calculator.preferred_tiers).to eq({
+        BigDecimal.new(100) => 10,
+        BigDecimal.new(300) => 20
+      })
     end
   end
 end

--- a/core/app/models/spree/calculator/tiered_flat_rate.rb
+++ b/core/app/models/spree/calculator/tiered_flat_rate.rb
@@ -8,7 +8,9 @@ module Spree
     before_validation do
       # Convert tier values to decimals. Strings don't do us much good.
       if preferred_tiers.is_a?(Hash)
-        self.preferred_tiers = Hash[*preferred_tiers.flatten.map(&:to_f)]
+        self.preferred_tiers = preferred_tiers.map do |k, v|
+          [BigDecimal.new(k.to_s), BigDecimal.new(v.to_s)]
+        end.to_h
       end
     end
 

--- a/core/app/models/spree/calculator/tiered_percent.rb
+++ b/core/app/models/spree/calculator/tiered_percent.rb
@@ -8,7 +8,9 @@ module Spree
     before_validation do
       # Convert tier values to decimals. Strings don't do us much good.
       if preferred_tiers.is_a?(Hash)
-        self.preferred_tiers = Hash[*preferred_tiers.flatten.map(&:to_f)]
+        self.preferred_tiers = preferred_tiers.map do |k, v|
+          [BigDecimal.new(k.to_s), BigDecimal.new(v.to_s)]
+        end.to_h
       end
     end
 

--- a/core/spec/models/spree/calculator/tiered_flat_rate_spec.rb
+++ b/core/spec/models/spree/calculator/tiered_flat_rate_spec.rb
@@ -9,9 +9,49 @@ describe Spree::Calculator::TieredFlatRate, type: :model do
   describe "#valid?" do
     subject { calculator.valid? }
     context "when tiers is a hash" do
-      context "and one of the keys is not a positive number" do
+      context "and the key is not a positive number" do
         before { calculator.preferred_tiers = { "nope" => 20 } }
         it { is_expected.to be false }
+      end
+
+      context "and the key is an integer" do
+        before { calculator.preferred_tiers = { 20 => 20 } }
+        it "converts successfully" do
+          is_expected.to be true
+          expect(calculator.preferred_tiers).to eq({ BigDecimal.new('20') => BigDecimal.new('20') })
+        end
+      end
+
+      context "and the key is a float" do
+        before { calculator.preferred_tiers = { 20.5 => 20.5 } }
+        it "converts successfully" do
+          is_expected.to be true
+          expect(calculator.preferred_tiers).to eq({ BigDecimal.new('20.5') => BigDecimal.new('20.5') })
+        end
+      end
+
+      context "and the key is a string number" do
+        before { calculator.preferred_tiers = { "20" => 20 } }
+        it "converts successfully" do
+          is_expected.to be true
+          expect(calculator.preferred_tiers).to eq({ BigDecimal.new('20') => BigDecimal.new('20') })
+        end
+      end
+
+      context "and the key is a numeric string with spaces" do
+        before { calculator.preferred_tiers = { "  20 " => 20 } }
+        it "converts successfully" do
+          is_expected.to be true
+          expect(calculator.preferred_tiers).to eq({ BigDecimal.new('20') => BigDecimal.new('20') })
+        end
+      end
+
+      context "and the key is a string number with decimals" do
+        before { calculator.preferred_tiers = { "20.5" => "20.5" } }
+        it "converts successfully" do
+          is_expected.to be true
+          expect(calculator.preferred_tiers).to eq({ BigDecimal.new('20.5') => BigDecimal.new('20.5') })
+        end
       end
     end
   end

--- a/core/spec/models/spree/calculator/tiered_percent_spec.rb
+++ b/core/spec/models/spree/calculator/tiered_percent_spec.rb
@@ -8,22 +8,66 @@ describe Spree::Calculator::TieredPercent, type: :model do
 
   describe "#valid?" do
     subject { calculator.valid? }
+
     context "when base percent is less than zero" do
       before { calculator.preferred_base_percent = -1 }
       it { is_expected.to be false }
     end
+
     context "when base percent is greater than 100" do
       before { calculator.preferred_base_percent = 110 }
       it { is_expected.to be false }
     end
+
     context "when tiers is a hash" do
-      context "and one of the keys is not a positive number" do
+      context "and the key is not a positive number" do
         before { calculator.preferred_tiers = { "nope" => 20 } }
         it { is_expected.to be false }
       end
+
       context "and one of the values is not a percent" do
         before { calculator.preferred_tiers = { 10 => 110 } }
         it { is_expected.to be false }
+      end
+
+      context "and the key is an integer" do
+        before { calculator.preferred_tiers = { 20 => 20 } }
+        it "converts successfully" do
+          is_expected.to be true
+          expect(calculator.preferred_tiers).to eq({ BigDecimal.new('20') => BigDecimal.new('20') })
+        end
+      end
+
+      context "and the key is a float" do
+        before { calculator.preferred_tiers = { 20.5 => 20.5 } }
+        it "converts successfully" do
+          is_expected.to be true
+          expect(calculator.preferred_tiers).to eq({ BigDecimal.new('20.5') => BigDecimal.new('20.5') })
+        end
+      end
+
+      context "and the key is a string number" do
+        before { calculator.preferred_tiers = { "20" => 20 } }
+        it "converts successfully" do
+          is_expected.to be true
+          expect(calculator.preferred_tiers).to eq({ BigDecimal.new('20') => BigDecimal.new('20') })
+        end
+      end
+
+      context "and the key is a numeric string with spaces" do
+        before { calculator.preferred_tiers = { "  20 " => 20 } }
+        it "converts successfully" do
+          is_expected.to be true
+          expect(calculator.preferred_tiers).to eq({ BigDecimal.new('20') => BigDecimal.new('20') })
+        end
+      end
+
+      context "and the key is a string number with decimals" do
+        before { calculator.preferred_tiers = { "20.5" => "20.5" } }
+        it "converts successfully" do
+          is_expected.to be true
+          expect(calculator.preferred_tiers).to eq({ BigDecimal.new('20.5') => BigDecimal.new('20.5') })
+        end
       end
     end
   end


### PR DESCRIPTION
This changes both the TieredFlatRate and TieredPercent calculators to use BigDecimal instead of Float.

I did the conversion here using `BigDecimal.new(old_value.to_s)` to get around awkwardness if the existing value was a float (`BigDecimal.new(1.0)` errors with `ArgumentError: can't omit precision for a Float.`).

This is a continuation of #1645