### PR TITLE
Check "create" ability for the New Order button

### DIFF
--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -5,7 +5,7 @@
   <li>
     <%= button_link_to Spree.t(:new_order), new_admin_order_url, :id => 'admin_new_order' %>
   </li>
-<% end if can? :edit, Spree::Order.new %>
+<% end if can? :create, Spree::Order %>
 
 <% content_for :table_filter_title do %>
   <%= Spree.t(:search) %>

--- a/backend/spec/features/admin/orders/listing_spec.rb
+++ b/backend/spec/features/admin/orders/listing_spec.rb
@@ -13,6 +13,21 @@ describe "Orders Listing", type: :feature, js: true do
     visit spree.admin_orders_path
   end
 
+  it 'displays the new order button' do
+    expect(page).to have_link('New Order')
+  end
+
+  context 'without create permission' do
+    custom_authorization! do |_user|
+      can :manage, Spree::Order
+      cannot :create, Spree::Order
+    end
+
+    it 'does not display the new order button' do
+      expect(page).to_not have_link('New Order')
+    end
+  end
+
   context "listing orders" do
     it "should list existing orders" do
       within_row(1) do


### PR DESCRIPTION
The New Order button on the List Orders page should check for the "create" ability, not the "edit" ability.