### PR TITLE
Prefer scope over explicit query

### DIFF
--- a/core/app/models/spree/variant/vat_price_generator.rb
+++ b/core/app/models/spree/variant/vat_price_generator.rb
@@ -54,7 +54,7 @@ module Spree
       end
 
       def variant_vat_rates
-        @variant_vat_rates ||= variant.tax_category.tax_rates.where(included_in_price: true)
+        @variant_vat_rates ||= variant.tax_category.tax_rates.included_in_price
       end
     end
   end


### PR DESCRIPTION
Scope defined in core/app/models/tax_rate.rb#66