### PR TITLE
remove depth column_names check when running migration

### DIFF
--- a/core/db/migrate/20130826062534_add_depth_to_spree_taxons.rb
+++ b/core/db/migrate/20130826062534_add_depth_to_spree_taxons.rb
@@ -1,12 +1,10 @@
 class AddDepthToSpreeTaxons < ActiveRecord::Migration[4.2]
   def up
-    if !Spree::Taxon.column_names.include?('depth')
-      add_column :spree_taxons, :depth, :integer
+    add_column :spree_taxons, :depth, :integer
 
-      say_with_time 'Update depth on all taxons' do
-        Spree::Taxon.reset_column_information
-        Spree::Taxon.all.each(&:save)
-      end
+    say_with_time 'Update depth on all taxons' do
+      Spree::Taxon.reset_column_information
+      Spree::Taxon.all.each(&:save)
     end
   end
 


### PR DESCRIPTION
The column information check is added in this commit: <https://github.com/solidusio/solidus/commit/c9711aadea6f9c1b7e058db7fc5a04a254e9e544>.

However, there's no need to check the existing of `depth` field, since there's no migration adding that field in.

Additionally, if we keep the check `depth` field, there's a potential issue: when running `rake db:drop db:create db:migrate`, if spring is running, `depth` field would be cached. In that case, after this migration runs, the `depth` field wouldn't exist.