### PR TITLE
Correctly record last_ip_address on order

### DIFF
--- a/core/lib/spree/core/controller_helpers/order.rb
+++ b/core/lib/spree/core/controller_helpers/order.rb
@@ -37,7 +37,7 @@ module Spree
           @current_order = find_order_by_token_or_user(options, true)
 
           if options[:create_order_if_necessary] && (@current_order.nil? || @current_order.completed?)
-            @current_order = Spree::Order.new(current_order_params)
+            @current_order = Spree::Order.new(new_order_params)
             @current_order.user ||= try_spree_current_user
             # See issue https://github.com/spree/spree/issues/3346 for reasons why this line is here
             @current_order.created_by ||= try_spree_current_user
@@ -45,7 +45,7 @@ module Spree
           end
 
           if @current_order
-            @current_order.last_ip_address = ip_address
+            @current_order.update(last_ip_address: ip_address)
             return @current_order
           end
         end
@@ -77,6 +77,10 @@ module Spree
 
         def current_order_params
           { currency: current_pricing_options.currency, guest_token: cookies.signed[:guest_token], store_id: current_store.id, user_id: try_spree_current_user.try(:id) }
+        end
+
+        def new_order_params
+          current_order_params.merge(last_ip_address: ip_address)
         end
 
         def find_order_by_token_or_user(options = {}, with_adjustments = false)

--- a/core/spec/lib/spree/core/controller_helpers/order_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/order_spec.rb
@@ -49,16 +49,27 @@ describe Spree::Core::ControllerHelpers::Order, type: :controller do
         expect(controller.current_order).to eq order
       end
     end
+
     context 'create_order_if_necessary option is true' do
+      subject { controller.current_order(create_order_if_necessary: true) }
+
       it 'creates new order' do
         expect {
-          controller.current_order(create_order_if_necessary: true)
-        }.to change(Spree::Order, :count).to(1)
+          subject
+        }.to change(Spree::Order, :count).from(0).to(1)
       end
 
       it 'assigns the current_store id' do
-        controller.current_order(create_order_if_necessary: true)
+        subject
         expect(Spree::Order.last.store_id).to eq store.id
+      end
+
+      it 'records last_ip_address' do
+        expect {
+          subject
+        }.to change {
+          Spree::Order.last.try!(:last_ip_address)
+        }.from(nil).to("0.0.0.0")
       end
     end
   end


### PR DESCRIPTION
The assignment of last_ip_address was not persisted where it was set.
When this module is included in a custom storefront, the assignment of
last_ip_address is lost. There was also a case in simple_current_order
where the last_ip_address was never assigned.