### PR TITLE
Fix the 'Send Mailer' checkbox selection

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -47,7 +47,7 @@ var ShipShipmentView = Backbone.View.extend({
       type: "PUT",
       url: Spree.routes.shipments_api + "/" + this.shipment_number + "/ship",
       data: {
-        send_mailer: this.$("[name='send_mailer']").val()
+        send_mailer: this.$("[name='send_mailer']").is(":checked")
       },
       success: function(){
         window.location.reload()

--- a/backend/spec/features/admin/orders/shipments_spec.rb
+++ b/backend/spec/features/admin/orders/shipments_spec.rb
@@ -37,6 +37,15 @@ describe "Shipments", type: :feature do
       expect(page).to have_content("shipped package")
       expect(order.reload.shipment_state).to eq("shipped")
     end
+
+    it "doesn't send a shipping confirmation email when ask to suppress the mailer" do
+      find("#send_mailer").set(false)
+      
+      expect {
+        find(".ship-shipment-button").click
+        wait_for_ajax
+      }.not_to change{ ActionMailer::Base.deliveries.count }
+    end
   end
 
   context "moving variants between shipments", js: true do


### PR DESCRIPTION
The user selection for suppressing the shipping confirmation email is not respected when shipping a package from the admin.  It always sends it.