### PR TITLE
Switch order search to using starts over cont

### DIFF
--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -38,12 +38,12 @@
 
           <div class="field">
             <%= label_tag nil, Spree.t(:promotion) %>
-            <%= f.text_field :order_promotions_promotion_code_value_cont, size: 25 %>
+            <%= f.text_field :order_promotions_promotion_code_value_start, size: 25 %>
           </div>
 
           <div class="field">
             <%= label_tag nil, Spree.t(:shipment_number) %>
-            <%= f.text_field :shipments_number_cont %>
+            <%= f.text_field :shipments_number_start %>
           </div>
 
         </div>
@@ -52,13 +52,13 @@
           <div class="row">
             <div class="col-12 col-xl-6">
               <div class="field">
-                <%= label_tag :q_number_cont, Spree.t(:order_number, number: '') %>
-                <%= f.text_field :number_cont %>
+                <%= label_tag :q_number_start, Spree.t(:order_number, number: '') %>
+                <%= f.text_field :number_start %>
               </div>
 
               <div class="field">
-                <%= label_tag :q_email_cont, Spree.t(:email) %>
-                <%= f.text_field :email_cont %>
+                <%= label_tag :q_email_start, Spree.t(:email) %>
+                <%= f.text_field :email_start %>
               </div>
             </div>
 

--- a/backend/spec/features/admin/orders/listing_spec.rb
+++ b/backend/spec/features/admin/orders/listing_spec.rb
@@ -88,7 +88,7 @@ describe "Orders Listing", type: :feature, js: true do
     context "when there's a single store" do
       it "should be able to search orders" do
         click_on "Filter Results"
-        fill_in "q_number_cont", with: "R200"
+        fill_in "q_number_start", with: "R200"
         click_on 'Filter Results'
         within_row(1) do
           expect(page).to have_content("R200")
@@ -161,7 +161,7 @@ describe "Orders Listing", type: :feature, js: true do
 
         it "only shows the orders with the selected promotion" do
           click_on "Filter Results"
-          fill_in "q_order_promotions_promotion_code_value_cont", with: promotion.codes.first.value
+          fill_in "q_order_promotions_promotion_code_value_start", with: promotion.codes.first.value
           click_on 'Filter Results'
           within_row(1) { expect(page).to have_content("R100") }
           within("table#listing_orders") { expect(page).not_to have_content("R200") }


### PR DESCRIPTION
Due to the way that standard indexes work in modern databases. Use of
contains to find a string is very inefficient. Instead, if we find
things that start with the string, the index can find the records it is
looking for very efficiently.

This turns a table sequential scan into a simple index lookup
signifncantly speeding things up, or avoiding timeouts on stores with
millions of orders.

Example:

```
mysql> SELECT COUNT(`spree_orders`.`id`) FROM `spree_orders` WHERE (`spree_orders` .`email` LIKE '%foo@bar\\.com%' AND `spree_orders`.`completed_at` IS NULL);
+----------------------------+
| COUNT(`spree_orders`.`id`) |
+----------------------------+
|                          1 |
+----------------------------+
1 row in set (20.27 sec)

mysql> SELECT COUNT(`spree_orders`.`id`) FROM `spree_orders` WHERE (`spree_orders` .`email` LIKE 'foo@bar\\.com%' AND `spree_orders`.`completed_at` IS NULL);
+----------------------------+
| COUNT(`spree_orders`.`id`) |
+----------------------------+
|                          1 |
+----------------------------+
1 row in set (0.00 sec)
```