### PR TITLE
Clean up Ransack query to find orders by promotion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 *   Product slugs no longer have a minimum length validation to match the Product name validation.
     [#1616](https://github.com/solidusio/solidus/pull/1616)
 
+*   Changed the promotion field in the admin order search to only find orders
+    which used the specified promotion code, instead of any code on an applied
+    promotion. [#1662](https://github.com/solidusio/solidus/pull/1662)
+
 ## Solidus 2.1.0 (unreleased)
 
 *   The OrderUpdater (as used by `order.update!`) now fully updates taxes.

--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -36,7 +36,7 @@
 
           <div class="field">
             <%= label_tag nil, Spree.t(:promotion) %>
-            <%= f.text_field :promotions_codes_value_cont, :size => 25 %>
+            <%= f.text_field :order_promotions_promotion_code_value_cont, :size => 25 %>
           </div>
 
           <div class="field">

--- a/backend/spec/features/admin/orders/listing_spec.rb
+++ b/backend/spec/features/admin/orders/listing_spec.rb
@@ -161,7 +161,7 @@ describe "Orders Listing", type: :feature, js: true do
 
         it "only shows the orders with the selected promotion" do
           click_on 'Filter'
-          fill_in "q_promotions_codes_value_cont", with: promotion.codes.first.value
+          fill_in "q_order_promotions_promotion_code_value_cont", with: promotion.codes.first.value
           click_on 'Filter Results'
           within_row(1) { expect(page).to have_content("R100") }
           within("table#listing_orders") { expect(page).not_to have_content("R200") }

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -43,7 +43,7 @@ module Spree
       go_to_state :confirm
     end
 
-    self.whitelisted_ransackable_associations = %w[shipments user promotions bill_address ship_address line_items]
+    self.whitelisted_ransackable_associations = %w[shipments user order_promotions promotions bill_address ship_address line_items]
     self.whitelisted_ransackable_attributes = %w[completed_at created_at email number state payment_state shipment_state total store_id]
 
     attr_reader :coupon_code

--- a/core/app/models/spree/order_promotion.rb
+++ b/core/app/models/spree/order_promotion.rb
@@ -14,6 +14,8 @@ module Spree
     validates :promotion, presence: true
     validates :promotion_code, presence: true, if: :require_promotion_code?
 
+    self.whitelisted_ransackable_associations = %w[promotion_code]
+
     private
 
     def require_promotion_code?


### PR DESCRIPTION
This commit optimizes the query used when attempting to find orders that
used a promotion code, by going directly through the
`spree_orders_promotions` table, resulting in one fewer JOIN in the
resulting query.

As the `spree_orders`, `spree_promotions`, and `spree_promotion_codes`
tables can be quite large for some stores, skipping a JOIN significantly
increase performance for these sorts of queries.