### PR TITLE
Only remove index if index exists

### DIFF
--- a/core/db/migrate/20141217215630_update_product_slug_index.rb
+++ b/core/db/migrate/20141217215630_update_product_slug_index.rb
@@ -2,7 +2,7 @@ class UpdateProductSlugIndex < ActiveRecord::Migration[4.2]
   include Spree::MigrationHelpers
 
   def change
-    safe_remove_index :spree_products, :slug
+    safe_remove_index :spree_products, :slug if index_exists?(:spree_products, :slug)
     safe_add_index :spree_products, :slug, unique: true
   end
 end


### PR DESCRIPTION
Our app didn’t have a pre-existing index for `spree_products.slug` (and I didn’t see an earlier migration for that), so it was throwing

```ruby
ArgumentError: Index name 'index_spree_products_on_slug' on table 'spree_products' does not exist
```

when we tried to run this migration. This change will make the migration work correctly whether or not the index already exists.