### PR TITLE
Deprecate Spree::Order#has_step?

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -465,9 +465,8 @@ module Spree
       persist_totals
     end
 
-    def has_step?(step)
-      checkout_steps.include?(step)
-    end
+    alias_method :has_step?, :has_checkout_step?
+    deprecate has_step?: :has_checkout_step?, deprecator: Spree::Deprecation
 
     def state_changed(name)
       state = "#{name}_state"
@@ -785,7 +784,7 @@ module Spree
     end
 
     def ensure_inventory_units
-      if has_step?("delivery")
+      if has_checkout_step?("delivery")
         inventory_validator = Spree::Stock::InventoryValidator.new
 
         errors = line_items.map { |line_item| inventory_validator.validate(line_item) }.compact

--- a/frontend/app/views/spree/shared/_order_details.html.erb
+++ b/frontend/app/views/spree/shared/_order_details.html.erb
@@ -1,13 +1,13 @@
 <div class="row steps-data">
 
-  <% if order.has_step?("address") %>
+  <% if order.has_checkout_step?("address") %>
 
     <div class="columns alpha four" data-hook="order-bill-address">
       <h6><%= Spree.t(:billing_address) %> <%= link_to "(#{Spree.t('actions.edit')})", checkout_state_path(:address) unless order.completed? %></h6>
       <%= render :partial => 'spree/shared/address', :locals => { :address => order.bill_address } %>
     </div>
 
-    <% if order.has_step?("delivery") %>
+    <% if order.has_checkout_step?("delivery") %>
       <div class="columns alpha four" data-hook="order-ship-address">
         <h6><%= Spree.t(:shipping_address) %> <%= link_to "(#{Spree.t('actions.edit')})", checkout_state_path(:address) unless order.completed? %></h6>
         <%= render :partial => 'spree/shared/address', :locals => { :address => order.ship_address } %>
@@ -28,7 +28,7 @@
     <% end %>
   <% end %>
 
-  <% if order.has_step?("payment") %>
+  <% if order.has_checkout_step?("payment") %>
     <div class="columns omega four">
       <h6><%= Spree.t(:payment_information) %> <%= link_to "(#{Spree.t('actions.edit')})", checkout_state_path(:payment) unless order.completed? %></h6>
       <div class="payment-info">


### PR DESCRIPTION
The Spree::Order::Checkout module defines a `has_checkout_step?` method
which does exactly the same, with a better name and a check for the
`step` argument being `nil`.

This came out of pairing with @tvdeyen. 