### PR TITLE
Remove wait_for_ajax calls and deprecate

### DIFF
--- a/backend/spec/features/admin/configuration/stock_locations_spec.rb
+++ b/backend/spec/features/admin/configuration/stock_locations_spec.rb
@@ -29,8 +29,9 @@ describe "Stock Locations", type: :feature do
     accept_alert do
       click_icon :trash
     end
-    # Wait for API request to complete.
-    wait_for_ajax
+
+    expect(page).to have_content('Stock Location "NY Warehouse" has been successfully removed')
+
     visit current_path
     expect(page).to have_content("No Stock Locations found")
   end

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -537,7 +537,6 @@ describe "Order Details", type: :feature, js: true do
       visit spree.edit_admin_order_path(order)
 
       find(".ship-shipment-button").click
-      wait_for_ajax
 
       within '.carton-state' do
         expect(page).to have_content('shipped')

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -229,7 +229,7 @@ describe "Order Details", type: :feature, js: true do
             within_row(1) { click_icon 'arrows-h' }
             complete_split_to(stock_location2, quantity: 'ff')
 
-            wait_for_ajax
+            accept_alert "undefined"
 
             expect(order.shipments.count).to eq(1)
             expect(order.shipments.first.inventory_units_for(product.master).count).to eq(2)
@@ -242,7 +242,7 @@ describe "Order Details", type: :feature, js: true do
             within_row(1) { click_icon 'arrows-h' }
             complete_split_to(stock_location2, quantity: 0)
 
-            wait_for_ajax
+            accept_alert "undefined"
 
             expect(order.shipments.count).to eq(1)
             expect(order.shipments.first.inventory_units_for(product.master).count).to eq(2)
@@ -251,7 +251,7 @@ describe "Order Details", type: :feature, js: true do
             fill_in 'item_quantity', with: -1
             click_icon :ok
 
-            wait_for_ajax
+            accept_alert "undefined"
 
             expect(order.shipments.count).to eq(1)
             expect(order.shipments.first.inventory_units_for(product.master).count).to eq(2)
@@ -282,7 +282,7 @@ describe "Order Details", type: :feature, js: true do
               within_row(1) { click_icon 'arrows-h' }
               complete_split_to(stock_location2, quantity: 2)
 
-              wait_for_ajax
+              accept_alert "undefined"
 
               expect(order.shipments.count).to eq(1)
               expect(order.shipments.first.inventory_units_for(product.master).count).to eq(2)
@@ -381,7 +381,7 @@ describe "Order Details", type: :feature, js: true do
               complete_split_to(@shipment2, quantity: 200)
             end
 
-            wait_for_ajax
+            accept_alert "undefined"
 
             expect(order.shipments.count).to eq(2)
             expect(order.shipments.first.inventory_units_for(product.master).count).to eq(1)

--- a/backend/spec/features/admin/orders/shipments_spec.rb
+++ b/backend/spec/features/admin/orders/shipments_spec.rb
@@ -32,7 +32,6 @@ describe "Shipments", type: :feature do
 
     it "can ship a completed order" do
       find(".ship-shipment-button").click
-      wait_for_ajax
 
       expect(page).to have_content("shipped package")
       expect(order.reload.shipment_state).to eq("shipped")

--- a/backend/spec/features/admin/products/edit/products_spec.rb
+++ b/backend/spec/features/admin/products/edit/products_spec.rb
@@ -60,7 +60,7 @@ describe 'Product Details', type: :feature do
           click_icon :trash
         end
       end
-      wait_for_ajax
+      expect(page).to have_content('Product has been deleted')
     end
   end
 end

--- a/core/lib/spree/testing_support/capybara_ext.rb
+++ b/core/lib/spree/testing_support/capybara_ext.rb
@@ -100,6 +100,13 @@ module CapybaraExt
   end
 
   def wait_for_ajax
+
+    Spree::Deprecation.warn <<-WARN.squish, caller
+      wait_for_ajax has been deprecated.
+      Please refer to the capybara documentation on how to properly wait for asyncronous behavior:
+      https://github.com/teamcapybara/capybara#asynchronous-javascript-ajax-and-friends
+    WARN
+
     counter = 0
     while page.evaluate_script("typeof($) === 'undefined' || $.active > 0")
       counter += 1


### PR DESCRIPTION
wait_for_ajax is a relic left over from the spree codebase when people
had a poor understanding of how capybara worked (and it was harder to
understand what and how matchers waited).

We can now mark it deprecated in the hopes people fix up their test
suites.