### PR TITLE
Remove session: { order_id: 1 } in frontend specs

### DIFF
--- a/frontend/spec/controllers/spree/checkout_controller_spec.rb
+++ b/frontend/spec/controllers/spree/checkout_controller_spec.rb
@@ -58,7 +58,7 @@ describe Spree::CheckoutController, type: :controller do
       it "should associate the order with a user" do
         order.update_column :user_id, nil
         expect(order).to receive(:associate_user!).with(user)
-        get :edit, session: { order_id: 1 }
+        get :edit
       end
     end
   end
@@ -241,7 +241,7 @@ describe Spree::CheckoutController, type: :controller do
         end
 
         it "should remove completed order from current_order" do
-          post :update, params: { state: "confirm" }, session: { order_id: "foofah" }
+          post :update, params: { state: "confirm" }
           expect(assigns(:current_order)).to be_nil
           expect(assigns(:order)).to eql controller.current_order
         end

--- a/frontend/spec/controllers/spree/orders_controller_spec.rb
+++ b/frontend/spec/controllers/spree/orders_controller_spec.rb
@@ -81,20 +81,20 @@ describe Spree::OrdersController, type: :controller do
         it "should render the edit view (on failure)" do
           # email validation is only after address state
           order.update_column(:state, "delivery")
-          put :update, params: { order: { email: "" } }, session: { order_id: order.id }
+          put :update, params: { order: { email: "" } }
           expect(response).to render_template :edit
         end
 
         it "should redirect to cart path (on success)" do
           allow(order).to receive(:update_attributes).and_return true
-          put :update, session: { order_id: 1 }
+          put :update
           expect(response).to redirect_to(spree.cart_path)
         end
 
         it "should advance the order if :checkout button is pressed" do
           allow(order).to receive(:update_attributes).and_return true
           expect(order).to receive(:next)
-          put :update, { checkout: true }, { order_id: 1 }
+          put :update, params: { checkout: true }
           expect(response).to redirect_to checkout_state_path('address')
         end
       end

--- a/frontend/spec/controllers/spree/orders_controller_transitions_spec.rb
+++ b/frontend/spec/controllers/spree/orders_controller_transitions_spec.rb
@@ -23,7 +23,7 @@ module Spree
       it "correctly calls the transition callback" do
         expect(order.did_transition).to be_nil
         order.line_items << FactoryGirl.create(:line_item)
-        put :update, params: { checkout: "checkout" }, session: { order_id: 1 }
+        put :update, params: { checkout: "checkout" }
         expect(order.did_transition).to be true
       end
     end


### PR DESCRIPTION
This value in the session isn't used anywhere.