### PR TITLE
Add partial index on `spree_promotions` table

### DIFF
--- a/core/db/migrate/20170105164636_add_partial_index_apply_automatically_promotions.rb
+++ b/core/db/migrate/20170105164636_add_partial_index_apply_automatically_promotions.rb
@@ -1,0 +1,11 @@
+class AddPartialIndexApplyAutomaticallyPromotions < ActiveRecord::Migration[5.0]
+  def change
+    condition = "apply_automatically = #{connection.quoted_true}"
+    add_index(
+      :spree_promotions,
+      :apply_automatically,
+      where: condition,
+      name: "idx_apply_automatically_promotions",
+    )
+  end
+end


### PR DESCRIPTION
Add a partial index on the `apply_automatically` to catch the very frequent used case of fetching the `sale_promotions`.