### PR TITLE
Avoid loading TaxCategory in tax calculations

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -72,7 +72,7 @@ module Spree
     self.whitelisted_ransackable_associations = ['order']
     self.whitelisted_ransackable_attributes = ['number']
 
-    delegate :tax_category, to: :selected_shipping_rate, allow_nil: true
+    delegate :tax_category, :tax_category_id, to: :selected_shipping_rate, allow_nil: true
 
     def can_transition_from_pending_to_shipped?
       !requires_shipment?

--- a/core/app/models/spree/shipping_rate.rb
+++ b/core/app/models/spree/shipping_rate.rb
@@ -12,7 +12,7 @@ module Spree
              dependent: :destroy
 
     delegate :order, :currency, to: :shipment
-    delegate :name, :tax_category, to: :shipping_method
+    delegate :name, :tax_category, :tax_category_id, to: :shipping_method
     delegate :code, to: :shipping_method, prefix: true
     alias_attribute :amount, :cost
 

--- a/core/app/models/spree/tax/tax_helpers.rb
+++ b/core/app/models/spree/tax/tax_helpers.rb
@@ -17,9 +17,9 @@ module Spree
       #
       # For further discussion, see https://github.com/spree/spree/issues/4397 and https://github.com/spree/spree/issues/4327.
       def applicable_rates(order)
-        order_zone_tax_categories = rates_for_order(order).map(&:tax_category)
+        order_zone_tax_category_ids = rates_for_order(order).map(&:tax_category_id)
         default_rates_with_unmatched_tax_category = rates_for_default_zone.to_a.delete_if do |default_rate|
-          order_zone_tax_categories.include?(default_rate.tax_category)
+          order_zone_tax_category_ids.include?(default_rate.tax_category_id)
         end
 
         (rates_for_order(order) + default_rates_with_unmatched_tax_category).uniq
@@ -38,7 +38,7 @@ module Spree
       end
 
       def rates_for_item(item)
-        applicable_rates(item.order).select { |rate| rate.tax_category == item.tax_category }
+        applicable_rates(item.order).select { |rate| rate.tax_category_id == item.tax_category_id }
       end
     end
   end

--- a/core/spec/models/spree/tax/item_adjuster_spec.rb
+++ b/core/spec/models/spree/tax/item_adjuster_spec.rb
@@ -65,12 +65,11 @@ RSpec.describe Spree::Tax::ItemAdjuster do
 
       context 'when there are matching rates for the zone' do
         context 'and all rates have the same tax category as the item' do
+          let(:item) { build_stubbed :line_item, order: order, tax_category: item_tax_category }
           let(:item_tax_category) { build_stubbed(:tax_category) }
           let(:rate_1) { create :tax_rate, tax_category: item_tax_category }
           let(:rate_2) { create :tax_rate }
           let(:rates_for_order_zone) { [rate_1, rate_2] }
-
-          before { allow(item).to receive(:tax_category).and_return(item_tax_category) }
 
           it 'creates an adjustment for every matching rate' do
             adjuster.adjust!


### PR DESCRIPTION
We only want to test that the tax categories are matching, so it should be sufficient to just compare ids. This should avoid one query per-item and one per tax rate matching the order's tax address.

## Changes in sandbox on a `Spree::Order.last.update!`

### After:
```
> Spree::Order.last.update!
  Spree::Order Load (0.2ms)  SELECT  "spree_orders".* FROM "spree_orders" ORDER BY "spree_orders"."id" DESC LIMIT ?  [["LIMIT", 1]]
   (0.1ms)  begin transaction
  Spree::LineItem Load (0.1ms)  SELECT "spree_line_items".* FROM "spree_line_items" WHERE "spree_line_items"."order_id" = ? ORDER BY "spree_line_items"."created_at" ASC, "spree_line_items"."id" ASC  [["order_id", 2]]
  Spree::Payment Load (0.1ms)  SELECT "spree_payments".* FROM "spree_payments" WHERE "spree_payments"."order_id" = ? AND "spree_payments"."state" = ? ORDER BY "spree_payments"."created_at" ASC  [["order_id", 2], ["state", "completed"]]
  Spree::Shipment Load (0.1ms)  SELECT "spree_shipments".* FROM "spree_shipments" WHERE "spree_shipments"."order_id" = ?  [["order_id", 2]]
  Spree::Adjustment Load (0.1ms)  SELECT "spree_adjustments".* FROM "spree_adjustments" WHERE "spree_adjustments"."adjustable_id" = ? AND "spree_adjustments"."adjustable_type" = ?  [["adjustable_id", 2], ["adjustable_type", "Spree::LineIte
m"]]
  Spree::Adjustment Load (0.0ms)  SELECT "spree_adjustments".* FROM "spree_adjustments" WHERE "spree_adjustments"."adjustable_id" = ? AND "spree_adjustments"."adjustable_type" = ?  [["adjustable_id", 2], ["adjustable_type", "Spree::Shipmen
t"]]
  Spree::Adjustment Load (0.1ms)  SELECT "spree_adjustments".* FROM "spree_adjustments" WHERE "spree_adjustments"."adjustable_id" = ? AND "spree_adjustments"."adjustable_type" = ? ORDER BY "spree_adjustments"."created_at" ASC  [["adjustabl
e_id", 2], ["adjustable_type", "Spree::Order"]]
  Spree::Address Load (0.1ms)  SELECT  "spree_addresses".* FROM "spree_addresses" WHERE "spree_addresses"."id" = ? LIMIT ?  [["id", 1], ["LIMIT", 1]]
  Spree::Zone Load (0.1ms)  SELECT  "spree_zones".* FROM "spree_zones" WHERE "spree_zones"."default_tax" = ? ORDER BY "spree_zones"."id" ASC LIMIT ?  [["default_tax", true], ["LIMIT", 1]]
  Spree::TaxRate Load (0.2ms)  SELECT DISTINCT "spree_tax_rates".* FROM "spree_tax_rates" INNER JOIN "spree_zones" ON "spree_zones"."id" = "spree_tax_rates"."zone_id" LEFT OUTER JOIN "spree_zone_members" ON "spree_zone_members"."zone_id" =
 "spree_zones"."id" WHERE "spree_tax_rates"."deleted_at" IS NULL AND ("spree_zone_members"."zoneable_type" = 'Spree::State' AND "spree_zone_members"."zoneable_id" IN (3561) OR "spree_zone_members"."zoneable_type" = 'Spree::Country' AND "sp
ree_zone_members"."zoneable_id" IN (232))
  Spree::ShippingRate Load (0.1ms)  SELECT "spree_shipping_rates".* FROM "spree_shipping_rates" WHERE "spree_shipping_rates"."shipment_id" = ? ORDER BY "spree_shipping_rates"."cost" ASC  [["shipment_id", 2]]
  Spree::ShippingMethod Load (0.1ms)  SELECT  "spree_shipping_methods".* FROM "spree_shipping_methods" WHERE "spree_shipping_methods"."id" = ? LIMIT ?  [["id", 1], ["LIMIT", 1]]
  Spree::Payment Load (0.1ms)  SELECT "spree_payments".* FROM "spree_payments" WHERE "spree_payments"."order_id" = ? ORDER BY "spree_payments"."created_at" ASC  [["order_id", 2]]
   (0.1ms)  SELECT COUNT(*) FROM "spree_payments" WHERE "spree_payments"."order_id" = ? AND ("spree_payments"."state" NOT IN ('failed', 'invalid'))  [["order_id", 2]]
  Spree::Refund Load (0.1ms)  SELECT "spree_refunds".* FROM "spree_refunds" WHERE "spree_refunds"."payment_id" = ?  [["payment_id", 2]]
  Spree::Refund Load (0.0ms)  SELECT "spree_refunds".* FROM "spree_refunds" WHERE "spree_refunds"."payment_id" = ?  [["payment_id", 4]]
  Spree::InventoryUnit Load (0.1ms)  SELECT "spree_inventory_units".* FROM "spree_inventory_units" WHERE "spree_inventory_units"."shipment_id" = ?  [["shipment_id", 2]]
   (0.0ms)  commit transaction
```

### Before:
```
> Spree::Order.last.update!
  Spree::Order Load (0.2ms)  SELECT  "spree_orders".* FROM "spree_orders" ORDER BY "spree_orders"."id" DESC LIMIT ?  [["LIMIT", 1]]
   (0.1ms)  begin transaction
  Spree::LineItem Load (0.1ms)  SELECT "spree_line_items".* FROM "spree_line_items" WHERE "spree_line_items"."order_id" = ? ORDER BY "spree_line_items"."created_at" ASC, "spree_line_items"."id" ASC  [["order_id", 2]]
  Spree::Payment Load (0.1ms)  SELECT "spree_payments".* FROM "spree_payments" WHERE "spree_payments"."order_id" = ? AND "spree_payments"."state" = ? ORDER BY "spree_payments"."created_at" ASC  [["order_id", 2], ["state", "completed"]]
  Spree::Shipment Load (0.1ms)  SELECT "spree_shipments".* FROM "spree_shipments" WHERE "spree_shipments"."order_id" = ?  [["order_id", 2]]
  Spree::Adjustment Load (0.1ms)  SELECT "spree_adjustments".* FROM "spree_adjustments" WHERE "spree_adjustments"."adjustable_id" = ? AND "spree_adjustments"."adjustable_type" = ?  [["adjustable_id", 2], ["adjustable_type", "Spree::LineIte
m"]]
  Spree::Adjustment Load (0.0ms)  SELECT "spree_adjustments".* FROM "spree_adjustments" WHERE "spree_adjustments"."adjustable_id" = ? AND "spree_adjustments"."adjustable_type" = ?  [["adjustable_id", 2], ["adjustable_type", "Spree::Shipmen
t"]]
  Spree::Adjustment Load (0.1ms)  SELECT "spree_adjustments".* FROM "spree_adjustments" WHERE "spree_adjustments"."adjustable_id" = ? AND "spree_adjustments"."adjustable_type" = ? ORDER BY "spree_adjustments"."created_at" ASC  [["adjustabl
e_id", 2], ["adjustable_type", "Spree::Order"]]
  Spree::Address Load (0.1ms)  SELECT  "spree_addresses".* FROM "spree_addresses" WHERE "spree_addresses"."id" = ? LIMIT ?  [["id", 1], ["LIMIT", 1]]
  Spree::Zone Load (0.1ms)  SELECT  "spree_zones".* FROM "spree_zones" WHERE "spree_zones"."default_tax" = ? ORDER BY "spree_zones"."id" ASC LIMIT ?  [["default_tax", true], ["LIMIT", 1]]
  Spree::TaxRate Load (0.2ms)  SELECT DISTINCT "spree_tax_rates".* FROM "spree_tax_rates" INNER JOIN "spree_zones" ON "spree_zones"."id" = "spree_tax_rates"."zone_id" LEFT OUTER JOIN "spree_zone_members" ON "spree_zone_members"."zone_id" =
 "spree_zones"."id" WHERE "spree_tax_rates"."deleted_at" IS NULL AND ("spree_zone_members"."zoneable_type" = 'Spree::State' AND "spree_zone_members"."zoneable_id" IN (3561) OR "spree_zone_members"."zoneable_type" = 'Spree::Country' AND "sp
ree_zone_members"."zoneable_id" IN (232))
  Spree::TaxCategory Load (0.1ms)  SELECT  "spree_tax_categories".* FROM "spree_tax_categories" WHERE "spree_tax_categories"."deleted_at" IS NULL AND "spree_tax_categories"."id" = ? LIMIT ?  [["id", 1], ["LIMIT", 1]]
  Spree::TaxCategory Load (0.0ms)  SELECT  "spree_tax_categories".* FROM "spree_tax_categories" WHERE "spree_tax_categories"."deleted_at" IS NULL AND "spree_tax_categories"."id" = ? LIMIT ?  [["id", 1], ["LIMIT", 1]]
  Spree::ShippingRate Load (0.1ms)  SELECT "spree_shipping_rates".* FROM "spree_shipping_rates" WHERE "spree_shipping_rates"."shipment_id" = ? ORDER BY "spree_shipping_rates"."cost" ASC  [["shipment_id", 2]]
  Spree::ShippingMethod Load (0.1ms)  SELECT  "spree_shipping_methods".* FROM "spree_shipping_methods" WHERE "spree_shipping_methods"."id" = ? LIMIT ?  [["id", 1], ["LIMIT", 1]]
  Spree::TaxCategory Load (0.1ms)  SELECT  "spree_tax_categories".* FROM "spree_tax_categories" WHERE "spree_tax_categories"."id" = ? LIMIT ?  [["id", 1], ["LIMIT", 1]]
  Spree::Payment Load (0.1ms)  SELECT "spree_payments".* FROM "spree_payments" WHERE "spree_payments"."order_id" = ? ORDER BY "spree_payments"."created_at" ASC  [["order_id", 2]]
   (0.1ms)  SELECT COUNT(*) FROM "spree_payments" WHERE "spree_payments"."order_id" = ? AND ("spree_payments"."state" NOT IN ('failed', 'invalid'))  [["order_id", 2]]
  Spree::Refund Load (0.1ms)  SELECT "spree_refunds".* FROM "spree_refunds" WHERE "spree_refunds"."payment_id" = ?  [["payment_id", 2]]
  Spree::Refund Load (0.0ms)  SELECT "spree_refunds".* FROM "spree_refunds" WHERE "spree_refunds"."payment_id" = ?  [["payment_id", 4]]
  Spree::InventoryUnit Load (0.1ms)  SELECT "spree_inventory_units".* FROM "spree_inventory_units" WHERE "spree_inventory_units"."shipment_id" = ?  [["shipment_id", 2]]
   (0.0ms)  commit transaction
```
