### PR TITLE
Fix sometimes unpredictable MySQL default_price

### DIFF
--- a/core/app/models/spree/price.rb
+++ b/core/app/models/spree/price.rb
@@ -18,7 +18,7 @@ module Spree
     validates :currency, inclusion: { in: ::Money::Currency.all.map(&:iso_code), message: :invalid_code }
     validates :country, presence: true, unless: -> { for_any_country? }
 
-    scope :currently_valid, -> { order("country_iso IS NULL, updated_at DESC") }
+    scope :currently_valid, -> { order("country_iso IS NULL, updated_at DESC, id DESC") }
     scope :for_master, -> { joins(:variant).where(spree_variants: { is_master: true }) }
     scope :for_variant, -> { joins(:variant).where(spree_variants: { is_master: false }) }
     scope :for_any_country, -> { where(country: nil) }


### PR DESCRIPTION
MySQL databases may only support 1 second resolution for timestamp columns. This means that if two prices were created at approximately the same time, the one chosen as "default" would be arbitrary.

This solves the issue by sorting by `id` after `updated_at`

An the failure can be seen on [this TravisCI build](https://travis-ci.org/jhawthorn/solidus/jobs/189278483)