### PR TITLE
Fix spurious image upload test failure

### DIFF
--- a/backend/spec/features/admin/products/edit/images_spec.rb
+++ b/backend/spec/features/admin/products/edit/images_spec.rb
@@ -53,8 +53,6 @@ describe "Product Images", type: :feature do
       within_fieldset 'Upload Image' do
         # Can also pass multiple files in the array, but SQLite gives a deadlock on insert
         attach_file('image_attachment', [file_path], visible: false)
-        expect(page).to have_css("progress", count: 1)
-        expect(page).to have_text("ror_ringer")
       end
 
       expect(page).not_to have_content("No images found")


### PR DESCRIPTION
It's possible for the image to be uploaded before these assertions were run. We can't reliably test the progress of the upload, but it should be sufficient to test the final result of the upload.

The failure can be seen in [this TravisCI build](https://travis-ci.org/jhawthorn/solidus/jobs/189278481)