### PR TITLE
Add an issue_template.md for github

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,14 @@
+### Steps to reproduce
+How can we make this happen
+
+### Expected behavior
+Tell us what should happen
+
+### Actual behavior
+Tell us what happens instead
+
+### System configuration
+**Solidus Version**:
+
+**Extensions in use**:
+


### PR DESCRIPTION
This adds an `issue_template.md`.

I don't want this to be a hindrance to anyone filing an issue. Especially since overall the quality of issues filed on this project has already been :ok_hand:.

However, it would be nice to have with the issue the exact Solidus version used, as well as which extensions are in use, to save some guesswork. Other headings should be in any good bug report, and were borrowed from [rails' issue_template.md](https://github.com/rails/rails/blob/master/.github/issue_template.md)