### PR TITLE
Use HEREDOC to install routes in generator

### DIFF
--- a/core/lib/generators/spree/install/install_generator.rb
+++ b/core/lib/generators/spree/install/install_generator.rb
@@ -149,16 +149,17 @@ Spree::Auth::Engine.load_seed if defined?(Spree::Auth)
       end
     end
 
-    def notify_about_routes
+    def install_routes
       insert_into_file File.join('config', 'routes.rb'), after: "Rails.application.routes.draw do\n" do
-        %{
+        <<-ROUTES
   # This line mounts Spree's routes at the root of your application.
   # This means, any requests to URLs such as /products, will go to Spree::ProductsController.
   # If you would like to change where this engine is mounted, simply change the :at option to something different.
   #
   # We ask that you don't use the :as option here, as Spree relies on it being the default of "spree"
   mount Spree::Core::Engine, :at => '/'
-        }
+
+        ROUTES
       end
 
       unless options[:quiet]


### PR DESCRIPTION
The previous code installed unnecessary spaces into the routes file, so
in an empty app we ended up with the badly indented:

``` ruby
  mount Spree::Core::Engine, :at => '/'
        end
```

Instead we can use a heredoc, which doesn't insert unnecessary spaces
while still reading well. I've also renamed the method in the generator
to be more accurate.