### PR TITLE
Deprecate Spree::Address#empty?

### DIFF
--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -106,16 +106,17 @@ module Spree
     end
 
     def same_as?(other_address)
-      Spree::Deprecation.warn("Address.same_as? is deprecated. It's equivalent to Address.==", caller)
+      Spree::Deprecation.warn("Address#same_as? is deprecated. It's equivalent to Address.==", caller)
       self == other_address
     end
 
     def same_as(other_address)
-      Spree::Deprecation.warn("Address.same_as is deprecated. It's equivalent to Address.==", caller)
+      Spree::Deprecation.warn("Address#same_as is deprecated. It's equivalent to Address.==", caller)
       self == other_address
     end
 
     def empty?
+      Spree::Deprecation.warn("Address#empty? is deprecated.", caller)
       attributes.except('id', 'created_at', 'updated_at', 'country_id').all? { |_, v| v.nil? }
     end
 

--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -115,9 +115,17 @@ module Spree
       self == other_address
     end
 
+    # @deprecated Do not use this
     def empty?
       Spree::Deprecation.warn("Address#empty? is deprecated.", caller)
       attributes.except('id', 'created_at', 'updated_at', 'country_id').all? { |_, v| v.nil? }
+    end
+
+    # This exists because the default Object#blank?, checks empty? if it is
+    # defined, and we have defined empty.
+    # This should be removed once empty? is removed
+    def blank?
+      false
     end
 
     # @return [Hash] an ActiveMerchant compatible address hash


### PR DESCRIPTION
Empty is a confusing method to have on an object because it affects the behaviour of `blank?` and `present?`

``` ruby
> Spree::Address.new.present?
false
```

We should remove empty to avoid this confusion

It's currently defined as

``` ruby
def empty?
  attributes.except('id', 'created_at', 'updated_at', 'country_id').all? { |_, v| v.nil? }
end
```

Which is basically the same as `new_record? && country_id.nil?`

This fixes #416