### PR TITLE
Add a frontend views override generator

### DIFF
--- a/frontend/Gemfile
+++ b/frontend/Gemfile
@@ -2,5 +2,6 @@ eval(File.read(File.dirname(__FILE__) + '/../common_spree_dependencies.rb'))
 
 gem 'solidus_core', path: '../core'
 gem 'solidus_api', path: '../api'
+gem 'generator_spec', group: :test
 
 gemspec

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -2,6 +2,36 @@
 
 Frontend contains controllers and views implementing a storefront and cart for Solidus.
 
+## Override views
+
+In order to customize a view you should copy the file into your host app. Using Deface is not
+recommended as it provides lots of headaches while debugging and degrades your shops performance.
+
+Solidus provides a generator to help with copying the right view into your host app.
+
+Simply call the generator to copy all views into your host app.
+
+```shell
+$ bundle exec rails g solidus:views:override
+```
+
+If you only want to copy certain views into your host app, you can provide the `--only` argument:
+
+```shell
+$ bundle exec rails g solidus:views:override --only products/show
+```
+
+The argument to `--only` can also be a substring of the name of the view from the `app/views/spree` folder:
+
+```shell
+$ bundle exec rails g solidus:views:override --only product
+```
+
+This will copy all views whose directory or filename contains the string "product".
+
+### Handle upgrades
+
+After upgrading solidus to a new version run the generator again and follow on screen instructions.
 
 ## Testing
 

--- a/frontend/lib/generators/solidus/views/override_generator.rb
+++ b/frontend/lib/generators/solidus/views/override_generator.rb
@@ -1,0 +1,46 @@
+require 'rails'
+
+module Solidus
+  module Views
+    class OverrideGenerator < ::Rails::Generators::Base
+      def self.views_folder
+        Spree::Frontend::Engine.root.join('app', 'views', 'spree')
+      end
+
+      VIEWS = Dir.glob(views_folder.join('**', '*'))
+
+      desc "Override solidus frontend views in your app. You can either provide single files or complete folders."
+
+      class_option :only,
+        type: :string,
+        default: nil,
+        desc: "Name of file or folder to copy exclusively. Can be a substring."
+
+      source_root views_folder
+
+      def copy_views
+        views_to_copy.each do |file|
+          next if File.directory?(file)
+          dest_file = Pathname.new(file).relative_path_from(source_dir)
+          copy_file file, Rails.root.join('app', 'views', 'spree', dest_file)
+        end
+      end
+
+      private
+
+      def views_to_copy
+        if @options['only']
+          VIEWS.select do |v|
+            Pathname.new(v).relative_path_from(source_dir).to_s.include?(@options['only'])
+          end
+        else
+          VIEWS
+        end
+      end
+
+      def source_dir
+        self.class.views_folder
+      end
+    end
+  end
+end

--- a/frontend/spec/generators/solidus/views/override_generator_spec.rb
+++ b/frontend/spec/generators/solidus/views/override_generator_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+require_relative '../../../../lib/generators/solidus/views/override_generator'
+
+RSpec.describe Solidus::Views::OverrideGenerator, type: :generator do
+  destination Rails.root.join('app', 'views', 'spree')
+
+  before(:all) do
+    prepare_destination
+  end
+
+  subject! do
+    run_generator arguments
+  end
+
+  let(:src) do
+    Spree::Frontend::Engine.root.join('app', 'views', 'spree')
+  end
+
+  let(:dest) do
+    Rails.root.join('app', 'views', 'spree')
+  end
+
+  context 'without any arguments' do
+    let(:arguments) { %w() }
+
+    it 'copies all views into the host app' do
+      expect(src.entries).to match_array(dest.entries)
+    end
+  end
+
+  context 'when "products" is passed as --only argument' do
+    let(:arguments) { %w(--only products) }
+
+    context 'as folder' do
+      it 'exclusively copies views whose name contains "products"' do
+        Dir.glob(dest.join("**", "*")).each do |file|
+          next if File.directory?(file)
+          expect(file.to_s).to match("products")
+        end
+      end
+    end
+  end
+
+  after do
+    FileUtils.rm_rf destination_root
+  end
+end


### PR DESCRIPTION
We promote overriding views instead of using Deface. This is great, but manually copying the views from GitHub or your local gem folder is tedious and error prone.

By providing a generator we help our users to get the right views into their app.