### PR TITLE
Use the order bill address for credit card address

### DIFF
--- a/core/lib/spree/testing_support/factories/payment_factory.rb
+++ b/core/lib/spree/testing_support/factories/payment_factory.rb
@@ -6,7 +6,7 @@ require 'spree/testing_support/factories/store_credit_factory'
 FactoryGirl.define do
   factory :payment, aliases: [:credit_card_payment], class: Spree::Payment do
     association(:payment_method, factory: :credit_card_payment_method)
-    source { create(:credit_card, user: order.user) }
+    source { create(:credit_card, user: order.user, address: order.bill_address) }
     order
     state 'checkout'
     response_code '12345'

--- a/core/spec/lib/spree/core/testing_support/factories/payment_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/payment_factory_spec.rb
@@ -14,6 +14,14 @@ RSpec.describe 'payment factory' do
       expect(payment.source.user).to be_present
       expect(payment.source.user).to eq payment.order.user
     end
+
+    it 'uses the orders bill address for the credit card' do
+      address = create(:address)
+      order = create(:order, bill_address: address)
+      payment = create(factory, order: order)
+
+      expect(payment.source.address).to eq address
+    end
   end
 
   describe 'check payment' do


### PR DESCRIPTION
Previously, a new address would be created and associated with the
credit card. I believe it makes more sense for the factories to use the
bill address associated with the order, if it exists.

In addition to being more sound logic, it will create less addresses
during testing.