### PR TITLE
Revert "Deprecate Spree::Address#empty?"

### DIFF
--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -106,26 +106,17 @@ module Spree
     end
 
     def same_as?(other_address)
-      Spree::Deprecation.warn("Address#same_as? is deprecated. It's equivalent to Address.==", caller)
+      Spree::Deprecation.warn("Address.same_as? is deprecated. It's equivalent to Address.==", caller)
       self == other_address
     end
 
     def same_as(other_address)
-      Spree::Deprecation.warn("Address#same_as is deprecated. It's equivalent to Address.==", caller)
+      Spree::Deprecation.warn("Address.same_as is deprecated. It's equivalent to Address.==", caller)
       self == other_address
     end
 
-    # @deprecated Do not use this
     def empty?
-      Spree::Deprecation.warn("Address#empty? is deprecated.", caller)
       attributes.except('id', 'created_at', 'updated_at', 'country_id').all? { |_, v| v.nil? }
-    end
-
-    # This exists because the default Object#blank?, checks empty? if it is
-    # defined, and we have defined empty.
-    # This should be removed once empty? is removed
-    def blank?
-      false
     end
 
     # @return [Hash] an ActiveMerchant compatible address hash


### PR DESCRIPTION
Reverts solidusio/solidus#1680

This caused test failures which were for some reason not caught in the PR.