### PR TITLE
Deprecate Address#empty?

### DIFF
--- a/backend/app/views/spree/admin/orders/customer_details/_form.html.erb
+++ b/backend/app/views/spree/admin/orders/customer_details/_form.html.erb
@@ -44,7 +44,7 @@
           <% if Spree::Config[:order_bill_address_used] %>
             <div class="field" style="position: absolute;margin-top: -15px;left: 0;">
               <span data-hook="use_billing">
-                <%= check_box_tag 'order[use_billing]', '1', ((@order.bill_address.empty? && @order.ship_address.empty?) && @order.bill_address == @order.ship_address) %>
+                <%= check_box_tag 'order[use_billing]', '1', (@order.ship_address.new_record? && @order.bill_address == @order.ship_address) %>
                 <%= label_tag 'order[use_billing]', Spree.t(:use_billing_address) %>
               </span>
             </div>

--- a/backend/spec/features/admin/orders/new_order_spec.rb
+++ b/backend/spec/features/admin/orders/new_order_spec.rb
@@ -35,7 +35,7 @@ describe "New Order", type: :feature do
       targetted_select2_search user.email, from: "#s2id_customer_search"
     end
 
-    check "order_use_billing"
+    expect(page).to have_checked_field('order_use_billing')
     fill_in_address
     click_on "Update"
 
@@ -73,7 +73,7 @@ describe "New Order", type: :feature do
       targetted_select2_search user.email, from: "#s2id_customer_search"
     end
 
-    check "order_use_billing"
+    expect(page).to have_checked_field('order_use_billing')
     fill_in_address
     click_on "Update"
 
@@ -108,7 +108,7 @@ describe "New Order", type: :feature do
         targetted_select2_search user.email, from: "#s2id_customer_search"
       end
 
-      check "order_use_billing"
+      expect(page).to have_checked_field('order_use_billing')
       fill_in_address
       click_on "Update"
 
@@ -157,7 +157,7 @@ describe "New Order", type: :feature do
         targetted_select2_search user.email, from: "#s2id_customer_search"
       end
 
-      check "order_use_billing"
+      expect(page).to have_checked_field('order_use_billing')
       fill_in_address
       click_on "Update"
 

--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -106,16 +106,17 @@ module Spree
     end
 
     def same_as?(other_address)
-      Spree::Deprecation.warn("Address.same_as? is deprecated. It's equivalent to Address.==", caller)
+      Spree::Deprecation.warn("Address#same_as? is deprecated. It's equivalent to Address.==", caller)
       self == other_address
     end
 
     def same_as(other_address)
-      Spree::Deprecation.warn("Address.same_as is deprecated. It's equivalent to Address.==", caller)
+      Spree::Deprecation.warn("Address#same_as is deprecated. It's equivalent to Address.==", caller)
       self == other_address
     end
 
     def empty?
+      Spree::Deprecation.warn("Address#empty? is deprecated.", caller)
       attributes.except('id', 'created_at', 'updated_at', 'country_id').all? { |_, v| v.nil? }
     end
 

--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -115,9 +115,17 @@ module Spree
       self == other_address
     end
 
+    # @deprecated Do not use this
     def empty?
       Spree::Deprecation.warn("Address#empty? is deprecated.", caller)
       attributes.except('id', 'created_at', 'updated_at', 'country_id').all? { |_, v| v.nil? }
+    end
+
+    # This exists because the default Object#blank?, checks empty? if it is
+    # defined, and we have defined empty.
+    # This should be removed once empty? is removed
+    def blank?
+      false
     end
 
     # @return [Hash] an ActiveMerchant compatible address hash


### PR DESCRIPTION
_Previous PR #1685 was reverted. It was causing errors due to a deprecation (which wasn't caught due to CircleCI configuration)._

In addition to deprecating `Address#empty?` this changes the "Use billing" checkbox in the admin to be checked any time the two addresses are equal, and the `ship_address` is a new record. I think this was probably the original intention of checking `empty?` (only new records can be empty because of Address's validations).

Test changes aren't required, but make more specific assertions about our app's behaviour.