### PR TITLE
Replace cache_key_for_taxons with cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
     comparisons. A comparison will fail if the two objects do not use the same
     currency. [#1682](https://github.com/solidusio/solidus/pull/1682)
 
+*   Deprecations
+
+    * `cache_key_for_taxons` helper has been deprecated in favour of `cache [I18n.locale, @taxons]`
+
 ## Solidus 2.1.0 (unreleased)
 
 *   The OrderUpdater (as used by `order.update!`) now fully updates taxes.

--- a/core/app/helpers/spree/store_helper.rb
+++ b/core/app/helpers/spree/store_helper.rb
@@ -8,6 +8,11 @@ module Spree
     end
 
     def cache_key_for_taxons
+      Spree::Deprecation.warn <<-WARN.strip_heredoc
+        cache_key_for_taxons is deprecated. Rails >= 5 has built-in support for collection cache keys.
+        Instead in your view use:
+        cache [I18n.locale, @taxons] do
+      WARN
       max_updated_at = @taxons.maximum(:updated_at).to_i
       parts = [@taxon.try(:id), max_updated_at].compact.join("-")
       "#{I18n.locale}/taxons/#{parts}"

--- a/frontend/app/views/spree/shared/_search.html.erb
+++ b/frontend/app/views/spree/shared/_search.html.erb
@@ -1,6 +1,6 @@
 <% @taxons = @taxon && @taxon.parent ? @taxon.parent.children : Spree::Taxon.roots %>
 <%= form_tag spree.products_path, :method => :get do %>
-  <% cache(cache_key_for_taxons) do %>
+  <% cache [I18n.locale, @taxons] do %>
     <%= select_tag :taxon,
           options_for_select([[Spree.t(:all_departments), '']] +
                                 @taxons.map {|t| [t.name, t.id]},

--- a/frontend/spec/features/caching/products_spec.rb
+++ b/frontend/spec/features/caching/products_spec.rb
@@ -13,7 +13,6 @@ describe 'products', type: :feature, caching: true do
     assert_written_to_cache("views/en/USD/spree/products/all--#{product.updated_at.utc.to_s(:number)}")
     assert_written_to_cache("views/en/USD/spree/products/#{product.id}-#{product.updated_at.utc.to_s(:number)}")
     assert_written_to_cache("views/en/spree/taxonomies/#{taxonomy.id}")
-    assert_written_to_cache("views/en/taxons/#{taxon.updated_at.utc.to_i}")
 
     clear_cache_events
   end

--- a/frontend/spec/features/caching/taxons_spec.rb
+++ b/frontend/spec/features/caching/taxons_spec.rb
@@ -8,7 +8,6 @@ describe 'taxons', type: :feature, caching: true do
     # warm up the cache
     visit spree.root_path
     assert_written_to_cache("views/en/spree/taxonomies/#{taxonomy.id}")
-    assert_written_to_cache("views/en/taxons/#{taxon.updated_at.utc.to_i}")
 
     clear_cache_events
   end


### PR DESCRIPTION
Rails 5.0 supports generating a cache key from a scope, using a similar technique to what `cache_key_for_taxons` was using. This commit deprecates `cache_key_for_taxons` favour of using cache with a scope directly.

Passing a scope or collection to `cache` will generate a hash based on the scope and `MAX(updated_at)` and `COUNT(*)`. This is better than the existing helper because it takes the full scope into account and finds the max_updated_at and count values in a single query.


I'd like to have done the same for `cache_key_for_products`, but can't because that query is constantly changing due to querying on `available_on <= Time.current`. I may investigate rounding this timestamp for a different PR.