### PR TITLE
Don't treat "unreturned exchanges" differently in checkout

### DIFF
--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -109,13 +109,13 @@ module Spree
             # Sequence of before_transition to: :complete
             # calls matter so that we do not process payments
             # until validations have passed
-            before_transition to: :complete, do: :validate_line_item_availability, unless: :unreturned_exchange?
+            before_transition to: :complete, do: :validate_line_item_availability
             if states[:delivery]
               before_transition to: :complete, do: :ensure_available_shipping_rates
             end
             before_transition to: :complete, do: :ensure_promotions_eligible
             before_transition to: :complete, do: :ensure_line_item_variants_are_not_deleted
-            before_transition to: :complete, do: :ensure_inventory_units, unless: :unreturned_exchange?
+            before_transition to: :complete, do: :ensure_inventory_units
             if states[:payment]
               before_transition to: :complete, do: :process_payments_before_complete
             end

--- a/core/app/models/spree/stock/availability_validator.rb
+++ b/core/app/models/spree/stock/availability_validator.rb
@@ -8,6 +8,7 @@ module Spree
           ensure_in_stock(line_item, line_item.quantity)
         else
           units_by_shipment.each do |shipment, inventory_units|
+            inventory_units.select!(&:pending?)
             ensure_in_stock(line_item, inventory_units.size, shipment.stock_location)
           end
         end

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -533,24 +533,9 @@ describe Spree::Order, type: :model do
           order.save!
         end
 
-        context 'when the exchange is for an unreturned item' do
-          before do
-            order.shipments.first.update_attributes!(created_at: order.created_at - 1.day)
-            expect(order.unreturned_exchange?).to eq true
-          end
-
-          it 'allows the order to complete' do
-            order.complete!
-
-            expect(order).to be_complete
-          end
-        end
-
-        context 'when the exchange is not for an unreturned item' do
-          it 'does not allow the order to completed' do
-            expect { order.complete! }.to raise_error Spree::Order::InsufficientStock
-            expect(order.payments.first.state).to eq('checkout')
-          end
+        it 'does not allow the order to completed' do
+          expect { order.complete! }.to raise_error Spree::Order::InsufficientStock
+          expect(order.payments.first.state).to eq('checkout')
         end
       end
     end

--- a/core/spec/models/spree/stock/availability_validator_spec.rb
+++ b/core/spec/models/spree/stock/availability_validator_spec.rb
@@ -26,6 +26,7 @@ module Spree
         end
 
         it "doesn't add a validation error" do
+          subject
           expect(line_item.errors).to be_empty
         end
       end

--- a/core/spec/models/spree/stock/availability_validator_spec.rb
+++ b/core/spec/models/spree/stock/availability_validator_spec.rb
@@ -77,6 +77,14 @@ module Spree
           end
 
           include_examples "fails validation"
+
+          context "but inventory units are finalized" do
+            before do
+              Spree::InventoryUnit.update_all(pending: false)
+            end
+
+            include_examples "passes validation"
+          end
         end
       end
     end


### PR DESCRIPTION
Previously the order's checkout state machine treated unreturned exchanges (orders created to charge for a previously cross-shipped exchange shipment) specially.

This PR removes that special treatment in favour of making the `AvailabilityValidator` smarter and understanding inventory units which have already been shipped.

"Unreturned exchanges" may be extracted into their own gem in the future, this would more easily allow that.