### PR TITLE
Make AvailabilityValidator check inventory per StockLocation instead of per Shipment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@
 *   The "Stores" section of Settings in the admin now supports creating and
     editing multiple stores.
 
+*   The `AvailabilityValidator` now correctly detects out of stock when there
+    are multiple shipments from the same stock location.
+
 *   Deprecations
 
     * `cache_key_for_taxons` helper has been deprecated in favour of `cache [I18n.locale, @taxons]`

--- a/core/app/models/spree/inventory_unit.rb
+++ b/core/app/models/spree/inventory_unit.rb
@@ -21,6 +21,7 @@ module Spree
 
     before_destroy :ensure_can_destroy
 
+    scope :pending, -> { where pending: true }
     scope :backordered, -> { where state: 'backordered' }
     scope :on_hand, -> { where state: 'on_hand' }
     scope :pre_shipment, -> { where(state: PRE_SHIPMENT_STATES) }

--- a/core/app/models/spree/stock/availability_validator.rb
+++ b/core/app/models/spree/stock/availability_validator.rb
@@ -7,9 +7,8 @@ module Spree
         if quantity_by_stock_location_id.blank?
           ensure_in_stock(line_item, line_item.quantity)
         else
-          stock_locations = Spree::StockLocation.where(id: quantity_by_stock_location_id.keys).to_a
-          stock_locations.each do |stock_location|
-            ensure_in_stock(line_item, quantity_by_stock_location_id[stock_location.id], stock_location)
+          quantity_by_stock_location_id.each do |stock_location_id, quantity|
+            ensure_in_stock(line_item, quantity, stock_location_id)
           end
         end
 

--- a/core/app/models/spree/stock/availability_validator.rb
+++ b/core/app/models/spree/stock/availability_validator.rb
@@ -2,24 +2,9 @@ module Spree
   module Stock
     class AvailabilityValidator < ActiveModel::Validator
       def validate(line_item)
-        quantity_by_stock_location_id = line_item.inventory_units.pending.joins(:shipment).group(:stock_location_id).count
-
-        if quantity_by_stock_location_id.blank?
-          ensure_in_stock(line_item, line_item.quantity)
+        if is_valid?(line_item)
+          true
         else
-          quantity_by_stock_location_id.each do |stock_location_id, quantity|
-            ensure_in_stock(line_item, quantity, stock_location_id)
-          end
-        end
-
-        line_item.errors[:quantity].empty?
-      end
-
-      private
-
-      def ensure_in_stock(line_item, quantity, stock_location = nil)
-        quantifier = Stock::Quantifier.new(line_item.variant, stock_location)
-        unless quantifier.can_supply?(quantity)
           variant = line_item.variant
           display_name = variant.name.to_s
           display_name += %{ (#{variant.options_text})} unless variant.options_text.blank?
@@ -28,6 +13,20 @@ module Spree
             :selected_quantity_not_available,
             item: display_name.inspect
           )
+          false
+        end
+      end
+
+      private
+
+      def is_valid?(line_item)
+        if line_item.inventory_units.empty?
+          Stock::Quantifier.new(line_item.variant).can_supply?(line_item.quantity)
+        else
+          quantity_by_stock_location_id = line_item.inventory_units.pending.joins(:shipment).group(:stock_location_id).count
+          quantity_by_stock_location_id.all? do |stock_location_id, quantity|
+            Stock::Quantifier.new(line_item.variant, stock_location_id).can_supply?(quantity)
+          end
         end
       end
     end

--- a/core/app/models/spree/stock/quantifier.rb
+++ b/core/app/models/spree/stock/quantifier.rb
@@ -5,11 +5,11 @@ module Spree
 
       def initialize(variant, stock_location = nil)
         @variant = variant
-        @stock_items = Spree::StockItem.joins(:stock_location).where(variant_id: variant)
+        @stock_items = Spree::StockItem.where(variant_id: variant)
         if stock_location
           @stock_items.where!(stock_location: stock_location)
         else
-          @stock_items.merge!(Spree::StockLocation.active)
+          @stock_items.joins!(:stock_location).merge!(Spree::StockLocation.active)
         end
       end
 

--- a/core/app/models/spree/stock/quantifier.rb
+++ b/core/app/models/spree/stock/quantifier.rb
@@ -5,13 +5,12 @@ module Spree
 
       def initialize(variant, stock_location = nil)
         @variant = variant
-        where_args = { variant_id: @variant }
+        @stock_items = Spree::StockItem.joins(:stock_location).where(variant_id: variant)
         if stock_location
-          where_args[:stock_location] = stock_location
+          @stock_items.where!(stock_location: stock_location)
         else
-          where_args[Spree::StockLocation.table_name] = { active: true }
+          @stock_items.merge!(Spree::StockLocation.active)
         end
-        @stock_items = Spree::StockItem.joins(:stock_location).where(where_args)
       end
 
       # Returns the total number of inventory units on hand for the variant.

--- a/core/app/models/spree/stock/quantifier.rb
+++ b/core/app/models/spree/stock/quantifier.rb
@@ -3,6 +3,8 @@ module Spree
     class Quantifier
       attr_reader :stock_items
 
+      # @param [Variant] variant The variant to check inventory for.
+      # @param [StockLocation, Integer] stock_location The stock_location to check inventory in. If unspecified it will check inventory in all available StockLocations
       def initialize(variant, stock_location = nil)
         @variant = variant
         @stock_items = Spree::StockItem.where(variant_id: variant)

--- a/core/spec/models/spree/stock/availability_validator_spec.rb
+++ b/core/spec/models/spree/stock/availability_validator_spec.rb
@@ -105,12 +105,12 @@ module Spree
           include_examples "passes validation"
         end
 
-        context "and there is not enough stock", pending: true do
+        context "and there is not enough stock" do
           let(:count_on_hand) { 1 }
           include_examples "fails validation"
         end
 
-        context "and there is no available stock", skip: true do
+        context "and there is no available stock" do
           let(:count_on_hand) { 0 }
           include_examples "fails validation"
         end

--- a/core/spec/models/spree/stock/availability_validator_spec.rb
+++ b/core/spec/models/spree/stock/availability_validator_spec.rb
@@ -74,7 +74,7 @@ module Spree
             order.contents.add(variant, 1, shipment: shipment)
           end
 
-          context "but no stock in either location", skip: true do
+          context "but no stock in either location" do
             before do
               variant.stock_items.update_all(count_on_hand: 0, backorderable: false)
             end


### PR DESCRIPTION
This fixes a few issues with `AvailabilityValidator`

Stock was being checked per Shipment rather than per StockLocation. This meant that available inventory could be double counted towards the same order. Quantities is now checked per StockLocation.

If multiple Shipments (or now StockLocations) on one LineItem had insufficient inventory, the same error would be added multiple times to the line item. ex. `["Quantity selected of \"Product #20 - 5904 (Size: S)\" is not available.", "Quantity selected of \"Product #20 - 5904 (Size: S)\" is not available."]`

One Shipment record was being queried and loaded for each inventory attached to the line item, which is quite slow and unnecessary. This has been replaced with a single query per LineItem.

**Before:**

```
> Spree::Stock::AvailabilityValidator.new.validate(line_item)
SELECT "spree_inventory_units".* FROM "spree_inventory_units" WHERE "spree_inventory_units"."line_item_id" = ?  [["line_item_id", 4]]
SELECT  "spree_shipments".* FROM "spree_shipments" WHERE "spree_shipments"."id" = ? LIMIT ?  [["id", 8], ["LIMIT", 1]]
SELECT  "spree_shipments".* FROM "spree_shipments" WHERE "spree_shipments"."id" = ? LIMIT ?  [["id", 8], ["LIMIT", 1]]
SELECT  "spree_shipments".* FROM "spree_shipments" WHERE "spree_shipments"."id" = ? LIMIT ?  [["id", 9], ["LIMIT", 1]]
SELECT  "spree_shipments".* FROM "spree_shipments" WHERE "spree_shipments"."id" = ? LIMIT ?  [["id", 9], ["LIMIT", 1]]
SELECT  "spree_stock_locations".* FROM "spree_stock_locations" WHERE "spree_stock_locations"."id" = ? LIMIT ?  [["id", 1], ["LIMIT", 1]]
SELECT  "spree_variants".* FROM "spree_variants" WHERE "spree_variants"."id" = ? LIMIT ?  [["id", 1], ["LIMIT", 1]]
SELECT SUM("spree_stock_items"."count_on_hand") FROM "spree_stock_items" INNER JOIN "spree_stock_locations" ON "spree_stock_locations"."id" = "spree_stock_items"."stock_location_id" WHERE "spree_stock_items"."deleted_at" IS NULL AND "spree_stock_items"."variant_id" = 1 AND "spree_stock_items"."stock_location_id" = 1
SELECT  "spree_stock_locations".* FROM "spree_stock_locations" WHERE "spree_stock_locations"."id" = ? LIMIT ?  [["id", 1], ["LIMIT", 1]]
SELECT SUM("spree_stock_items"."count_on_hand") FROM "spree_stock_items" INNER JOIN "spree_stock_locations" ON "spree_stock_locations"."id" = "spree_stock_items"."stock_location_id" WHERE "spree_stock_items"."deleted_at" IS NULL AND "spree_stock_items"."variant_id" = 1 AND "spree_stock_items"."stock_location_id" = 1
```

**After:**

```
> Spree::Stock::AvailabilityValidator.new.validate(line_item)
SELECT  1 AS one FROM "spree_inventory_units" WHERE "spree_inventory_units"."line_item_id" = ? LIMIT ?  [["line_item_id", 4], ["LIMIT", 1]]
SELECT COUNT(*) AS count_all, "stock_location_id" AS stock_location_id FROM "spree_inventory_units" INNER JOIN "spree_shipments" ON "spree_shipments"."id" = "spree_inventory_units"."shipment_id" WHERE "spree_inventory_units"."line_item_id" = ? AND "spree_inventory_units"."pending" = ? GROUP BY "stock_location_id"  [["line_item_id", 4], ["pending", true]]
SELECT  "spree_variants".* FROM "spree_variants" WHERE "spree_variants"."id" = ? LIMIT ?  [["id", 1], ["LIMIT", 1]]
SELECT SUM("spree_stock_items"."count_on_hand") FROM "spree_stock_items" WHERE "spree_stock_items"."deleted_at" IS NULL AND "spree_stock_items"."variant_id" = 1 AND "spree_stock_items"."stock_location_id" = 1
SELECT "spree_stock_items".* FROM "spree_stock_items" WHERE "spree_stock_items"."deleted_at" IS NULL AND "spree_stock_items"."variant_id" = 1 AND "spree_stock_items"."stock_location_id" = 1
```