### PR TITLE
Add failing spec for location configured package

### DIFF
--- a/core/spec/models/spree/stock/coordinator_spec.rb
+++ b/core/spec/models/spree/stock/coordinator_spec.rb
@@ -194,6 +194,30 @@ module Spree
             let(:location_2_inventory) { 5 }
             it_behaves_like "a fulfillable package"
           end
+
+          context "with a location configured package" do
+            before do
+              order.order_stock_locations.create(
+                stock_location: stock_location_2,
+                quantity: 3,
+                variant: variant
+              )
+            end
+            let(:location_quantity) { 3 }
+
+            context "and sufficient inventory" do
+              let(:location_1_inventory) { 5 }
+              let(:location_2_inventory) { 5 }
+              it_behaves_like "a fulfillable package"
+            end
+
+            context "and insufficient inventory" do
+              let(:location_1_inventory) { 0 }
+              let(:location_2_inventory) { 3 }
+              before { pending "This is broken. The coordinator packages this incorrectly" }
+              it_behaves_like "an unfulfillable package"
+            end
+          end
         end
       end
 


### PR DESCRIPTION
The coordinator doesn't properly check stock levels, since stock can be double-counted towards location configured packages and normal packages.