### PR TITLE
Added LineItem name to unavailable flash

### DIFF
--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1282,7 +1282,7 @@ en:
     inventory: Inventory
     inventory_adjustment: Inventory Adjustment
     inventory_canceled: Inventory canceled
-    inventory_error_flash_for_insufficient_quantity: An item in your cart has become unavailable.
+    inventory_error_flash_for_insufficient_quantity: "%{item} has become unavailable."
     inventory_not_available: Inventory not available for %{item}.
     inventory_state: Inventory State
     inventory_states:

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1282,7 +1282,7 @@ en:
     inventory: Inventory
     inventory_adjustment: Inventory Adjustment
     inventory_canceled: Inventory canceled
-    inventory_error_flash_for_insufficient_quantity: "%{item} has become unavailable."
+    inventory_error_flash_for_insufficient_quantity: "#{names} has become unavailable."
     inventory_not_available: Inventory not available for %{item}.
     inventory_state: Inventory State
     inventory_states:

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1282,7 +1282,7 @@ en:
     inventory: Inventory
     inventory_adjustment: Inventory Adjustment
     inventory_canceled: Inventory canceled
-    inventory_error_flash_for_insufficient_quantity: "#{names} has become unavailable."
+    inventory_error_flash_for_insufficient_quantity: "'#{names}' has become unavailable."
     inventory_not_available: Inventory not available for %{item}.
     inventory_state: Inventory State
     inventory_states:

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1282,7 +1282,7 @@ en:
     inventory: Inventory
     inventory_adjustment: Inventory Adjustment
     inventory_canceled: Inventory canceled
-    inventory_error_flash_for_insufficient_quantity: "'#{names}' has become unavailable."
+    inventory_error_flash_for_insufficient_quantity: "#{names} became unavailable."
     inventory_not_available: Inventory not available for %{item}.
     inventory_state: Inventory State
     inventory_states:

--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -150,7 +150,7 @@ module Spree
 
     def ensure_sufficient_stock_lines
       if @order.insufficient_stock_lines.present?
-        out_of_stock_items = @order.insufficient_stock_lines.map { |l| "'#{l.name}'" }.to_sentence
+        out_of_stock_items = @order.insufficient_stock_lines.collect(&:name).to_sentence
         flash[:error] = Spree.t(:inventory_error_flash_for_insufficient_quantity, names: out_of_stock_items)
         redirect_to spree.cart_path
       end

--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -150,8 +150,8 @@ module Spree
 
     def ensure_sufficient_stock_lines
       if @order.insufficient_stock_lines.present?
-        out_of_stock_items = @order.insufficient_stock_lines.map { |l| "\"#{l.name}\"" }.join(', ')
-        flash[:error] = Spree.t(:inventory_error_flash_for_insufficient_quantity, item: out_of_stock_items)
+        out_of_stock_items = @order.insufficient_stock_lines.map { |l| "'#{l.name}'" }.to_sentence
+        flash[:error] = Spree.t(:inventory_error_flash_for_insufficient_quantity, names: out_of_stock_items)
         redirect_to spree.cart_path
       end
     end

--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -150,7 +150,8 @@ module Spree
 
     def ensure_sufficient_stock_lines
       if @order.insufficient_stock_lines.present?
-        flash[:error] = Spree.t(:inventory_error_flash_for_insufficient_quantity)
+        out_of_stock_items = @order.insufficient_stock_lines.map { |l| "\"#{l.name}\"" }.join(', ')
+        flash[:error] = Spree.t(:inventory_error_flash_for_insufficient_quantity, item: out_of_stock_items)
         redirect_to spree.cart_path
       end
     end

--- a/frontend/spec/controllers/spree/checkout_controller_spec.rb
+++ b/frontend/spec/controllers/spree/checkout_controller_spec.rb
@@ -390,7 +390,7 @@ describe Spree::CheckoutController, type: :controller do
   context "When last inventory item has been purchased" do
     let(:product) { mock_model(Spree::Product, name: "Amazing Object") }
     let(:variant) { mock_model(Spree::Variant) }
-    let(:line_item) { mock_model Spree::LineItem, insufficient_stock?: true, amount: 0 }
+    let(:line_item) { mock_model Spree::LineItem, insufficient_stock?: true, amount: 0, name: "Amazing Item" }
     let(:order) { create(:order) }
 
     before do


### PR DESCRIPTION
We were seeing issues where users wouldn't know which of their
products in their cart were out of stock and causing the issue.
Adding the product name to the flash message helps them out.