### PR TITLE
Remove hint which doesn't exist from view

### DIFF
--- a/backend/app/views/spree/admin/stores/_form.html.erb
+++ b/backend/app/views/spree/admin/stores/_form.html.erb
@@ -12,7 +12,6 @@
 
 <%= f.field_container :seo_title do %>
   <%= f.label :seo_title %>
-  <%= f.field_hint :seo_title %>
   <%= f.text_field :seo_title, class: 'fullwidth'  %>
   <%= f.error_message_on :seo_title %>
 <% end %>


### PR DESCRIPTION
Accidentally added this in 60ea59a0dc without actually adding the hint to translations.