### PR TITLE
Don't send email if PromotionCodeBatch email is unset

### DIFF
--- a/core/app/jobs/spree/promotion_code_batch_job.rb
+++ b/core/app/jobs/spree/promotion_code_batch_job.rb
@@ -7,13 +7,17 @@ module Spree
         promotion_code_batch
       ).build_promotion_codes
 
-      Spree::PromotionCodeBatchMailer
-        .promotion_code_batch_finished(promotion_code_batch)
-        .deliver_now
+      if promotion_code_batch.email?
+        Spree::PromotionCodeBatchMailer
+          .promotion_code_batch_finished(promotion_code_batch)
+          .deliver_now
+      end
     rescue => e
-      Spree::PromotionCodeBatchMailer
-        .promotion_code_batch_errored(promotion_code_batch)
-        .deliver_now
+      if promotion_code_batch.email?
+        Spree::PromotionCodeBatchMailer
+          .promotion_code_batch_errored(promotion_code_batch)
+          .deliver_now
+      end
       raise e
     end
   end

--- a/core/spec/jobs/promotion_code_batch_job_spec.rb
+++ b/core/spec/jobs/promotion_code_batch_job_spec.rb
@@ -1,11 +1,12 @@
 require 'spec_helper'
 describe Spree::PromotionCodeBatchJob, type: :job do
+  let(:email) { "test@email.com" }
   let(:promotion_code_batch) do
     Spree::PromotionCodeBatch.create!(
       promotion_id: create(:promotion).id,
       base_code: "test",
       number_of_codes: 10,
-      email: "test@email.com"
+      email: email
     )
   end
 
@@ -15,10 +16,20 @@ describe Spree::PromotionCodeBatchJob, type: :job do
         .to receive(:promotion_code_batch_finished)
         .and_call_original
     end
-    it "sends an email" do
-      subject.perform(promotion_code_batch)
-      expect(Spree::PromotionCodeBatchMailer)
-        .to have_received(:promotion_code_batch_finished)
+    context "with an email address" do
+      it "sends an email" do
+        subject.perform(promotion_code_batch)
+        expect(Spree::PromotionCodeBatchMailer)
+          .to have_received(:promotion_code_batch_finished)
+      end
+    end
+    context "with no email address" do
+      let(:email) { nil }
+      it "sends an email" do
+        subject.perform(promotion_code_batch)
+        expect(Spree::PromotionCodeBatchMailer)
+          .to_not have_received(:promotion_code_batch_finished)
+      end
     end
   end
 
@@ -36,9 +47,19 @@ describe Spree::PromotionCodeBatchJob, type: :job do
         .to raise_error RuntimeError
     end
 
-    it "sends an email" do
-      expect(Spree::PromotionCodeBatchMailer)
-        .to have_received(:promotion_code_batch_errored)
+    context "with an email address" do
+      it "sends an email" do
+        expect(Spree::PromotionCodeBatchMailer)
+          .to have_received(:promotion_code_batch_errored)
+      end
+    end
+
+    context "with no email address" do
+      let(:email) { nil }
+      it "sends an email" do
+        expect(Spree::PromotionCodeBatchMailer)
+          .to_not have_received(:promotion_code_batch_errored)
+      end
     end
   end
 end


### PR DESCRIPTION
PromotionCodeBatch has an email attribute, an email address which will
receive a notification when the batch job has completed.

Previously if this email field was empty, it would fail with

    An SMTP To address is required to send a message. Set the message smtp_envelope_to, to, cc, or bcc address.

Instead, we should not send an email if the email field is blank