### PR TITLE
Fix check for `order.guest_token` presence

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -2,11 +2,11 @@ require 'spree/core/validators/email'
 require 'spree/order/checkout'
 
 module Spree
-  # The customers cart until completed, then acts as permenent record of the transaction.
+  # The customers cart until completed, then acts as permanent record of the transaction.
   #
   # `Spree::Order` is the heart of the Solidus system, as it acts as the customer's
   # cart as they shop. Once an order is complete, it serves as the
-  # permenent record of their purchase. It has many responsibilities:
+  # permanent record of their purchase. It has many responsibilities:
   #
   # * Records and validates attributes like `total` and relationships like
   # `Spree::LineItem` as an ActiveRecord model.

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -111,6 +111,7 @@ module Spree
 
     validates :email, presence: true, if: :require_email
     validates :email, email: true, allow_blank: true
+    validates :guest_token, presence: { allow_nil: true }
     validates :number, presence: true, uniqueness: { allow_blank: true }
     validates :store_id, presence: true
 

--- a/core/lib/spree/permission_sets/default_customer.rb
+++ b/core/lib/spree/permission_sets/default_customer.rb
@@ -7,7 +7,7 @@ module Spree
         can :display, OptionValue
         can :create, Order
         can [:read, :update], Order do |order, token|
-          order.user == user || order.guest_token && token == order.guest_token
+          order.user == user || (order.guest_token.present? && token == order.guest_token)
         end
         can :create, ReturnAuthorization do |return_authorization|
           return_authorization.order.user == user

--- a/core/spec/lib/spree/permission_sets/default_customer_spec.rb
+++ b/core/spec/lib/spree/permission_sets/default_customer_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe Spree::PermissionSets::DefaultCustomer do
+  context 'as Guest User' do
+    context 'for Order' do
+      context 'guest_token is empty string' do
+        let(:ability) { Spree::Ability.new(nil) }
+        let(:resource) { build(:order) }
+        let(:token) { '' }
+
+        it 'should not be allowed to read or update the order' do
+          allow(resource).to receive_messages(guest_token: '')
+
+          expect(ability).to_not be_able_to(:read, resource, token)
+          expect(ability).to_not be_able_to(:update, resource, token)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
* In case the `order.guest_token` is an empty string, we don't want
  everyone to be able to view or update the order by passing empty
  `token=` parameter