### PR TITLE
set default color to cart subtotal

### DIFF
--- a/frontend/app/assets/stylesheets/spree/frontend/screen.css.scss
+++ b/frontend/app/assets/stylesheets/spree/frontend/screen.css.scss
@@ -995,7 +995,7 @@ div[data-hook="inside_cart_form"] {
 }
 
 .cart-subtotal, .cart-total {
-  background: #00ADEE;
+  background: $link_text_color;
 
   td h5 {
     color: #fff;


### PR DESCRIPTION
Class .cart-subtotal & .cart-total color should be set as default color, not as direct color.