### PR TITLE
Remove stock location configuration from admin "cart" page

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/line_items_on_order_edit.js
+++ b/backend/app/assets/javascripts/spree/backend/line_items_on_order_edit.js
@@ -22,26 +22,13 @@ addVariant = function() {
     $('#stock_details').hide();
 
     var variant_id = $('input.variant_autocomplete').val();
-    var total_quantity = 0;
-    var stock_location_quantities = {};
+    var total_quantity = $("input#variant_quantity").val();
 
-    if ($(".stock-levels.untracked-inventory").length > 0) {
-        total_quantity = $("input#variant_quantity").val();
-    }
-    else {
-        var quantities = $("input.quantity[data-variant-id='" + variant_id + "']");
-
-        quantities.each(function() {
-            total_quantity += Number($(this).val());
-            stock_location_quantities[$(this).attr('data-stock-location-id')] = $(this).val();
-        });
-    }
-
-    adjustLineItems(order_number, variant_id, total_quantity, stock_location_quantities);
+    adjustLineItems(order_number, variant_id, total_quantity);
     return 1
 }
 
-adjustLineItems = function(order_number, variant_id, quantity, stock_location_quantities){
+adjustLineItems = function(order_number, variant_id, quantity){
     var url = Spree.routes.orders_api + "/" + order_number + '/line_items';
 
     Spree.ajax({
@@ -50,8 +37,7 @@ adjustLineItems = function(order_number, variant_id, quantity, stock_location_qu
         data: {
           line_item: {
             variant_id: variant_id,
-            quantity: quantity,
-            stock_location_quantities: stock_location_quantities
+            quantity: quantity
           },
         }
     }).done(function( msg ) {

--- a/backend/app/assets/javascripts/spree/backend/templates/variants/line_items_autocomplete_stock.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/variants/line_items_autocomplete_stock.hbs
@@ -1,63 +1,22 @@
 <fieldset>
-  <legend align="center">{{ t "select_stock" }}</legend>
-  {{#if variant.track_inventory}}
-    <table class="stock-levels" data-hook="stock-levels">
-      <colgroup>
-        <col style="width: 30%;" />
-        <col style="width: 40%;" />
-        <col style="width: 30%;" />
-      </colgroup>
-      <thead>
-        <th>{{ t "name" }}</th>
-        <th>{{ t "location" }}</th>
-        <th>{{ t "count_on_hand" }}</th>
-        <th>{{ t "quantity" }}</th>
-      </thead>
-      <tbody>
-        {{#each variant.stock_items}}
-          <tr>
-            <td>{{#unless @index}}{{../../variant.name}}{{/unless}}</td>
-            <td>
-              {{stock_location_name}}
-            </td>
-            <td>
-              {{count_on_hand}}
-            </td>
-            <td>
-              <input class="quantity variant_quantity" id="quantity_{{@index}}" data-variant-id="{{../variant.id}}" data-stock-location-id="{{stock_location_id}}" type="number" min="0" value="0">
-            </td>
-            </tr>
-        {{/each}}
-      </tbody>
-    </table>
-  {{else}}
-    <table class="stock-levels untracked-inventory" data-hook="stock-levels">
-      <colgroup>
-        <col style="width: 30%;" />
-        <col style="width: 40%;" />
-        <col style="width: 30%;" />
-      </colgroup>
-      <thead>
-        <th>{{ t "name" }}</th>
-        <th>{{ t "count_on_hand" }}</th>
-        <th>{{ t "quantity" }}</th>
-      </thead>
-      <tbody>
-        <tr>
-          <td>
-            {{variant.name}}
-          </td>
-          <td>
-            No inventory necessary
-          </td>
-          <td>
-            <input class="quantity" id="variant_quantity" data-variant-id="{{variant.id}}" type="number" min="0" value="0">
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  {{/if}}
-
+  <table class="stock-levels" data-hook="stock-levels">
+    <colgroup>
+      <col style="width: 50%;" />
+      <col style="width: 50%;" />
+    </colgroup>
+    <thead>
+      <th>{{ t "name" }}</th>
+      <th><label for="variant_quantity">{{ t "quantity" }}</label></th>
+    </thead>
+    <tbody>
+      <tr>
+        <td>{{variant.name}}</td>
+        <td>
+          <input class="quantity variant_quantity" id="variant_quantity" data-variant-id="{{../variant.id}}" type="number" min="0" value="0">
+        </td>
+      </tr>
+    </tbody>
+  </table>
 
   <fieldset class="no-border-bottom">
     <legend align="center" class="stock-location">

--- a/backend/spec/features/admin/orders/new_order_spec.rb
+++ b/backend/spec/features/admin/orders/new_order_spec.rb
@@ -26,7 +26,7 @@ describe "New Order", type: :feature do
     click_on 'Cart'
     select2_search product.name, from: Spree.t(:name_or_sku)
 
-    fill_in_quantity("table.stock-levels", "quantity_0", 2)
+    fill_in "variant_quantity", with: 2
 
     click_button 'Add'
     click_on "Customer"
@@ -64,7 +64,7 @@ describe "New Order", type: :feature do
     click_on 'Cart'
     select2_search product.name, from: Spree.t(:name_or_sku)
 
-    fill_in_quantity("table.stock-levels", "quantity_0", 2)
+    fill_in "variant_quantity", with: 2
 
     click_button 'Add'
     click_on "Customer"
@@ -94,7 +94,7 @@ describe "New Order", type: :feature do
       click_on 'Cart'
       select2_search product.name, from: Spree.t(:name_or_sku)
 
-      fill_in_quantity('table.stock-levels', 'quantity_0', 2)
+      fill_in "variant_quantity", with: 2
 
       click_button 'Add'
 
@@ -130,7 +130,7 @@ describe "New Order", type: :feature do
       click_on 'Cart'
       select2_search product.name, from: Spree.t(:name_or_sku)
 
-      fill_in_quantity('table.stock-levels', 'quantity_0', 1)
+      fill_in "variant_quantity", with: 1
 
       click_button 'Add'
 

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -48,7 +48,7 @@ describe "Order Details", type: :feature, js: true do
       it "can add an item to a shipment" do
         select2_search "spree t-shirt", from: Spree.t(:name_or_sku)
         within("table.stock-levels") do
-          fill_in "quantity_0", with: 2
+          fill_in "variant_quantity", with: 2
         end
 
         click_button "Add"


### PR DESCRIPTION
For the reasons discussed in #1696.

This removes the stock location in the simplest way possible. A follow up PR will have UI improvements to the page which this allows.

Before:
![](http://i.hawth.ca/s/5s8ssaSq.png)

After:
![](http://i.hawth.ca/s/6RFfG9y3.png)