### PR TITLE
Ensure helper is specified in VariantsController

### DIFF
--- a/backend/app/controllers/spree/admin/variants_controller.rb
+++ b/backend/app/controllers/spree/admin/variants_controller.rb
@@ -1,6 +1,8 @@
 module Spree
   module Admin
     class VariantsController < ResourceController
+      helper 'spree/admin/products'
+
       belongs_to 'spree/product', find_by: :slug
       new_action.before :new_before
       before_action :redirect_on_empty_option_values, only: [:new]


### PR DESCRIPTION
The [backend/app/views/spree/admin/variants/_form.html.erb](https://github.com/solidusio/solidus/blob/master/backend/app/views/spree/admin/variants/_form.html.erb#L73) now uses a helper method called `show_rebuild_vat_checkbox?` which is defined in [Spree::Admin::ProductsHelper](https://github.com/solidusio/solidus/blob/master/backend/app/helpers/spree/admin/products_helper.rb#L28).

This helper is not automatically included if `config.action_controller.include_all_helpers` is configured to false. See [PR #1496](https://github.com/solidusio/solidus/pull/1496) for rational and previous discussion on this topic.