### PR TITLE
Fix duplicated Shipments breadcrumb

### DIFF
--- a/backend/app/views/spree/admin/orders/_shipment.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment.html.erb
@@ -1,6 +1,3 @@
-<% admin_breadcrumb(plural_resource_name(Spree::Shipment)) %>
-
-
 <%
   manifest_items = Spree::ShippingManifest.new(
     inventory_units: shipment.inventory_units.where(carton_id: nil),

--- a/backend/app/views/spree/admin/orders/edit.html.erb
+++ b/backend/app/views/spree/admin/orders/edit.html.erb
@@ -1,3 +1,5 @@
+<% admin_breadcrumb(plural_resource_name(Spree::Shipment)) %>
+
 <% content_for :page_actions do %>
   <% if can?(:fire, @order) %>
     <li><%= event_links %></li>


### PR DESCRIPTION
:rofl: This is a silly one

We had the `admin_breadcrumb` declaration too deep within our partials, so it was called once per shipment, rather than a single time.

This moves the call so it is added only once.

## Before
![](http://i.hawth.ca/s/z26PdlrM.png)

## After
![](http://i.hawth.ca/s/X5VH7T63.png)
