### PR TITLE
Update code styles for /cart

### DIFF
--- a/frontend/app/views/spree/orders/_form.html.erb
+++ b/frontend/app/views/spree/orders/_form.html.erb
@@ -1,4 +1,5 @@
-<%= render partial: 'spree/shared/error_messages', locals: { target: @order } %>
+<% order = order_form.object %>
+<%= render 'spree/shared/error_messages', target: order %>
 <table id="cart-detail" data-hook>
   <thead>
     <tr data-hook="cart_items_headers">
@@ -10,19 +11,19 @@
     </tr>
   </thead>
   <tbody id="line_items" data-hook>
-    <%= render partial: 'spree/orders/line_item', collection: order_form.object.line_items, locals: {order_form: order_form} %>
+    <%= render partial: 'spree/orders/line_item', collection: order.line_items, locals: { order_form: order_form } %>
   </tbody>
-  <% if @order.adjustments.nonzero.exists? || @order.line_item_adjustments.nonzero.exists? || @order.shipment_adjustments.nonzero.exists? || @order.shipments.any? %>
+  <% if order.adjustments.nonzero.exists? || order.line_item_adjustments.nonzero.exists? || order.shipment_adjustments.nonzero.exists? || order.shipments.any? %>
     <tr class="cart-subtotal">
-      <td colspan="4" align='right'><h5><%= Spree.t(:cart_subtotal, count: @order.line_items.sum(:quantity)) %></h5></th>
-      <td colspan><h5><%= order_form.object.display_item_total %></h5></td>
+      <td colspan="4" align='right'><h5><%= Spree.t(:cart_subtotal, count: order.line_items.sum(:quantity)) %></h5></th>
+      <td colspan><h5><%= order.display_item_total %></h5></td>
       <td></td>
     </tr>
     <%= render "spree/orders/adjustments" %>
   <% end %>
   <tr class="cart-total">
     <td colspan="4" align='right'><h5><%= Spree.t(:total) %></h5></th>
-    <td colspan><h5><%= order_form.object.display_total %></h5></td>
+    <td colspan><h5><%= order.display_total %></h5></td>
     <td></td>
   </tr>
 </table>

--- a/frontend/app/views/spree/orders/edit.html.erb
+++ b/frontend/app/views/spree/orders/edit.html.erb
@@ -16,7 +16,7 @@
         <div data-hook="inside_cart_form">
 
           <div data-hook="cart_items">
-            <%= render partial: 'form', locals: { order_form: order_form } %>
+            <%= render 'form', order_form: order_form %>
           </div>
 
           <div class="links columns sixteen alpha omega" data-hook="cart_buttons">


### PR DESCRIPTION
* Use ruby 1.9 hash style
* Don't use @ instance variable in partial
* Replace `order_form.object` with `order`
* Replace
`render :partial => '...', :locals => { ... }`
with
`render '...', { ... }`