### PR TITLE
Improve JS i18n

### DIFF
--- a/backend/app/assets/javascripts/spree/backend.js
+++ b/backend/app/assets/javascripts/spree/backend.js
@@ -12,6 +12,7 @@
 //= require solidus_admin/bootstrap
 //= require prism
 //= require spree
+//= require spree/backend/translation
 //= require spree/backend/backbone-overrides
 //= require spree/backend/spree-select2
 //

--- a/backend/app/assets/javascripts/spree/backend/handlebars_extensions.coffee
+++ b/backend/app/assets/javascripts/spree/backend/handlebars_extensions.coffee
@@ -4,5 +4,8 @@
 Handlebars.registerHelper "t", (key) ->
   Spree.t(key)
 
+Handlebars.registerHelper "human_attribute_name", (model, attr) ->
+  Spree.human_attribute_name(model, attr)
+
 Handlebars.registerHelper "admin_url", ->
   Spree.pathFor("admin")

--- a/backend/app/assets/javascripts/spree/backend/handlebars_extensions.coffee
+++ b/backend/app/assets/javascripts/spree/backend/handlebars_extensions.coffee
@@ -1,8 +1,8 @@
 #= require handlebars
 #= require spree/backend/translation
 
-Handlebars.registerHelper "t", (key) ->
-  Spree.t(key)
+Handlebars.registerHelper "t", (key, options) ->
+  Spree.t(key, options.hash)
 
 Handlebars.registerHelper "human_attribute_name", (model, attr) ->
   Spree.human_attribute_name(model, attr)

--- a/backend/app/assets/javascripts/spree/backend/handlebars_extensions.coffee
+++ b/backend/app/assets/javascripts/spree/backend/handlebars_extensions.coffee
@@ -1,19 +1,8 @@
 #= require handlebars
-
-# Resolves string keys with dots in a deeply nested object
-# http://stackoverflow.com/a/22129960/4405214
-resolveObject = (path, obj) ->
-  path.split('.').reduce ((prev, curr) ->
-    if prev then prev[curr] else undefined
-  ), obj || self
-
+#= require spree/backend/translation
 
 Handlebars.registerHelper "t", (key) ->
-  translation = resolveObject key, Spree.translations
-  return translation if translation
-
-  console.error "No translation found for #{key}."
-  key
+  Spree.t(key)
 
 Handlebars.registerHelper "admin_url", ->
   Spree.pathFor("admin")

--- a/backend/app/assets/javascripts/spree/backend/translation.js
+++ b/backend/app/assets/javascripts/spree/backend/translation.js
@@ -18,4 +18,8 @@
       return key;
     }
   }
+
+  Spree.human_attribute_name = function(model, attr) {
+    return Spree.t("activerecord.attributes." + model + '.' + attr);
+  }
 })();

--- a/backend/app/assets/javascripts/spree/backend/translation.js
+++ b/backend/app/assets/javascripts/spree/backend/translation.js
@@ -9,7 +9,11 @@
       }, obj || self);
   }
 
-  Spree.t = function(key) {
+  Spree.t = function(key, options) {
+    options = (options || {});
+    if(options.scope) {
+      key = options.scope + "." + key;
+    }
     var translation = resolveObject(key, Spree.translations);
     if (translation) {
       return translation;

--- a/backend/app/assets/javascripts/spree/backend/translation.js
+++ b/backend/app/assets/javascripts/spree/backend/translation.js
@@ -1,0 +1,21 @@
+(function() {
+  // Resolves string keys with dots in a deeply nested object
+  // http://stackoverflow.com/a/22129960/4405214
+  var resolveObject = function(path, obj) {
+    return path
+      .split('.')
+      .reduce(function(prev, curr) {
+        return prev && prev[curr];
+      }, obj || self);
+  }
+
+  Spree.t = function(key) {
+    var translation = resolveObject(key, Spree.translations);
+    if (translation) {
+      return translation;
+    } else {
+      console.error("No translation found for " + key + ".");
+      return key;
+    }
+  }
+})();

--- a/backend/app/assets/javascripts/spree/backend/translation.js
+++ b/backend/app/assets/javascripts/spree/backend/translation.js
@@ -18,7 +18,7 @@
     if (translation) {
       return translation;
     } else {
-      console.error("No translation found for " + key + ".");
+      console.warn("No translation found for " + key + ".");
       return key;
     }
   }

--- a/backend/app/views/spree/admin/shared/_translations.html.erb
+++ b/backend/app/views/spree/admin/shared/_translations.html.erb
@@ -18,6 +18,7 @@
     :item_stock_placeholder   => Spree.t(:choose_location),
     :month_names              => I18n.t(:month_names, :scope => :date).reject(&:blank?),
     :currency_separator       => I18n.t('number.currency.format.separator'),
+    :activerecord             => I18n.t('activerecord')
   }).to_json
 %>
 </script>


### PR DESCRIPTION
A few improvements to our (very basic) JS i18n

In c871eea69c6769140255be3a5c0c1e183133db33 @mtomov made the Handlebars `t` helper understand the dot-separated paths. :+1:

This extracts that functionality to a `Spree.t`, helper, so that JS doesn't need to dig through the `Spree.translations` object manually.

``` js
Spree.t("thing.one.two")
```

This also adds a `scope` option similar to the one ruby's `18n.t` accepts. This is especially useful from handlebars templates, which can't themselves concatenate the string keys.

``` js
Spree.t(order.state, {scope: "order_state"})
```

``` handlebars
{{ t order.state scope="order_state" }}
```

Finally, this adds `Spree.human_attribute_name`, as well as ships the activerecord attribute translations to our JS.

``` js
Spree.human_attribute_name("spree/line_item", "description")
```