### PR TITLE
Allow twitter_cldr 4.x

### DIFF
--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'state_machines-activerecord', '~> 0.4'
   s.add_dependency 'stringex', '~> 1.5.1'
   s.add_dependency 'truncate_html', '~> 0.9', '>= 0.9.2'
-  s.add_dependency 'twitter_cldr', '~> 3.0'
+  s.add_dependency 'twitter_cldr', '>= 3.0', '< 5'
 
   s.add_development_dependency 'email_spec', '~> 1.6'
 end


### PR DESCRIPTION
Has updated unicode information, and may be kept more up to date
with ruby 2.4 deprecations in the future. Should otherwise be
backwards compatible. https://github.com/twitter/twitter-cldr-rb/blob/master/CHANGELOG.md

I chose to keep allowing twitter_cldr 3.x too, for backwards compat,
in case there's an incompatible dependency somewhere. But an alternate
choice would be to allow only ~> 4.0.