### PR TITLE
Remove some payment cruft

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/payments/new.js
+++ b/backend/app/assets/javascripts/spree/backend/payments/new.js
@@ -35,12 +35,5 @@ $(document).ready(function() {
         }
       }
     );
-
-    $('.cvvLink').click(function(event){
-      window_name = 'cvv_info';
-      window_options = 'left=20,top=20,width=500,height=500,toolbar=0,resizable=0,scrollbars=1';
-      window.open($(this).prop('href'), window_name, window_options);
-      event.preventDefault();
-    });
   }
 });

--- a/backend/app/assets/javascripts/spree/backend/payments/new.js
+++ b/backend/app/assets/javascripts/spree/backend/payments/new.js
@@ -42,9 +42,5 @@ $(document).ready(function() {
       window.open($(this).prop('href'), window_name, window_options);
       event.preventDefault();
     });
-
-    $('select.jump_menu').change(function(){
-      window.location = this.options[this.selectedIndex].value;
-    });
   }
 });

--- a/backend/app/views/spree/admin/payments/source_forms/_gateway.html.erb
+++ b/backend/app/views/spree/admin/payments/source_forms/_gateway.html.erb
@@ -46,9 +46,6 @@
         <div data-hook="card_code" class="field">
           <%= label_tag "card_code#{payment_method.id}", Spree::CreditCard.human_attribute_name(:card_code), class: 'required' %>
           <%= text_field_tag "#{param_prefix}[verification_value]", '', id: "card_code#{payment_method.id}", class: 'required fullwidth cardCode', size: 5 %>
-          <a href="/content/cvv" class="info cvvLink" target="_blank">
-            (<%= Spree.t(:what_is_this) %>)
-          </a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This removes a few lines from our payment JS that weren't used. Also removes an awkward and unnecessary link from solidus_backend to solidus_frontend.