### PR TITLE
Add a .eslintrc and lint our JS

### DIFF
--- a/backend/.eslintrc
+++ b/backend/.eslintrc
@@ -1,0 +1,21 @@
+{
+  "rules": {
+    "no-unused-vars": ["error", { "vars": "all", "args": "none" }],
+    "linebreak-style": ["error", "unix"]
+  },
+  "env": {
+    "es6": false,
+    "browser": true,
+    "jquery": true
+  },
+  "globals": {
+    "Spree": true,
+    "Backbone": true,
+    "HandlebarsTemplates": true,
+    "_": true,
+    "Select2": true,
+    "show_flash": true,
+    "update_state": true,
+  },
+  "extends": "eslint:recommended"
+}

--- a/backend/app/assets/javascripts/spree/backend/address_states.js
+++ b/backend/app/assets/javascripts/spree/backend/address_states.js
@@ -1,4 +1,4 @@
-var update_state = function (region, done) {
+window.update_state = function (region, done) {
   'use strict';
 
   var country = $('span#' + region + 'country .select2').select2('val');

--- a/backend/app/assets/javascripts/spree/backend/admin.js
+++ b/backend/app/assets/javascripts/spree/backend/admin.js
@@ -36,8 +36,8 @@ $.fn.visible = function(cond) { this[cond ? 'show' : 'hide' ]() };
 // Apply to individual radio button that makes another element visible when checked
 $.fn.radioControlsVisibilityOfElement = function(dependentElementSelector){
   if(!this.get(0)){ return  }
-  showValue = this.get(0).value;
-  radioGroup = $("input[name='" + this.get(0).name + "']");
+  var showValue = this.get(0).value;
+  var radioGroup = $("input[name='" + this.get(0).name + "']");
   radioGroup.each(function(){
     $(this).click(function(){
       $(dependentElementSelector).visible(this.checked && this.value == showValue)
@@ -46,7 +46,7 @@ $.fn.radioControlsVisibilityOfElement = function(dependentElementSelector){
   });
 }
 
-handle_date_picker_fields = function(){
+var handle_date_picker_fields = function(){
   $('.datepicker').datepicker({
     dateFormat: Spree.translations.date_picker,
     dayNames: Spree.translations.abbr_day_names,
@@ -70,7 +70,7 @@ handle_date_picker_fields = function(){
 $(document).ready(function(){
   handle_date_picker_fields();
   $(".observe_field").on('change', function() {
-    target = $(this).data("update");
+    var target = $(this).data("update");
     $(target).hide();
     Spree.ajax({ dataType: 'html',
              url: $(this).data("base-url")+encodeURIComponent($(this).val()),
@@ -127,7 +127,7 @@ $(document).ready(function(){
   });
 
   $('body').on('click', 'a.spree_remove_fields', function() {
-    el = $(this);
+    var el = $(this);
     el.prev("input[type=hidden]").val("1");
     el.closest(".fields").hide();
     if (el.prop("href").substr(-1) == '#') {
@@ -168,12 +168,12 @@ $(document).ready(function(){
         placeholder: 'ui-sortable-placeholder',
         update: function(event, ui) {
           $("#progress").show();
-          tableEl = $(ui.item).closest("table.sortable")
-          positions = {};
+          var tableEl = $(ui.item).closest("table.sortable")
+          var positions = {};
           $.each(tableEl.find('tbody tr'), function(position, obj){
-            idAttr = $(obj).prop('id');
+            var idAttr = $(obj).prop('id');
             if (idAttr) {
-              objId = idAttr.split('_').slice(-1);
+              var objId = idAttr.split('_').slice(-1);
               if (!isNaN(objId)) {
                 positions['positions['+objId+']'] = position+1;
               }
@@ -194,7 +194,7 @@ $(document).ready(function(){
           ui.placeholder.html("<td colspan='"+(td_count-1)+"'></td><td class='actions'></td>")
         },
         stop: function (event, ui) {
-          tableEl = $(ui.item).closest("table.sortable")
+          var tableEl = $(ui.item).closest("table.sortable")
           // Fix odd/even classes after reorder
           tableEl.find("tr:even").removeClass("odd even").addClass("even");
           tableEl.find("tr:odd").removeClass("odd even").addClass("odd");

--- a/backend/app/assets/javascripts/spree/backend/admin.js
+++ b/backend/app/assets/javascripts/spree/backend/admin.js
@@ -210,7 +210,7 @@ $(document).ready(function(){
       data: {
         token: Spree.api_key
       },
-      url: Spree.routes.checkouts_api + "/" + order_number + "/advance"
+      url: Spree.routes.checkouts_api + "/" + window.order_number + "/advance"
     }).done(function() {
       window.location.reload();
     });

--- a/backend/app/assets/javascripts/spree/backend/checkouts/edit.js
+++ b/backend/app/assets/javascripts/spree/backend/checkouts/edit.js
@@ -1,8 +1,8 @@
 //= require_self
 $(document).ready(function() {
-  window.customerTemplate = HandlebarsTemplates['orders/customer_details/autocomplete'];
+  var customerTemplate = HandlebarsTemplates['orders/customer_details/autocomplete'];
 
-  formatCustomerResult = function(customer) {
+  var formatCustomerResult = function(customer) {
     return customerTemplate({
       customer: customer,
       bill_address: customer.bill_address,

--- a/backend/app/assets/javascripts/spree/backend/images/upload.js
+++ b/backend/app/assets/javascripts/spree/backend/images/upload.js
@@ -126,7 +126,7 @@ Spree.prepareImageUploader = function () {
         processData: false,  // tell jQuery not to process the data
         contentType: false,  // tell jQuery not to set contentType
         xhr: function () {
-          xhr = $.ajaxSettings.xhr();
+          var xhr = $.ajaxSettings.xhr();
           if (xhr.upload) {
             xhr.upload.onprogress = function (event) {
               if (event.lengthComputable) {

--- a/backend/app/assets/javascripts/spree/backend/line_items_on_order_edit.js
+++ b/backend/app/assets/javascripts/spree/backend/line_items_on_order_edit.js
@@ -24,7 +24,7 @@ addVariant = function() {
     var variant_id = $('input.variant_autocomplete').val();
     var total_quantity = $("input#variant_quantity").val();
 
-    adjustLineItems(order_number, variant_id, total_quantity);
+    adjustLineItems(window.order_number, variant_id, total_quantity);
     return 1
 }
 

--- a/backend/app/assets/javascripts/spree/backend/returns/return_item_selection.js
+++ b/backend/app/assets/javascripts/spree/backend/returns/return_item_selection.js
@@ -1,24 +1,24 @@
 $(document).ready(function() {
+  function checkAddItemBox() {
+    $(this).closest('tr').find('input.add-item').attr('checked', 'checked');
+    updateSuggestedAmount();
+  }
+
+  function updateSuggestedAmount() {
+    var totalPretaxRefund = 0;
+    var checkedItems = formFields.find('input.add-item:checked');
+    $.each(checkedItems, function(i, checkbox) {
+      totalPretaxRefund += parseFloat($(checkbox).parents('tr').find('.refund-amount-input').val());
+    });
+
+    var displayTotal = isNaN(totalPretaxRefund) ? '' : totalPretaxRefund.toFixed(2);
+    formFields.find('span#total_pre_tax_refund').html(displayTotal);
+  }
+
   var formFields = $("[data-hook='admin_customer_return_form_fields'], \
                      [data-hook='admin_return_authorization_form_fields']");
 
   if(formFields.length > 0) {
-    function checkAddItemBox() {
-      $(this).closest('tr').find('input.add-item').attr('checked', 'checked');
-      updateSuggestedAmount();
-    }
-
-    function updateSuggestedAmount() {
-      var totalPretaxRefund = 0;
-      var checkedItems = formFields.find('input.add-item:checked');
-      $.each(checkedItems, function(i, checkbox) {
-        totalPretaxRefund += parseFloat($(checkbox).parents('tr').find('.refund-amount-input').val());
-      });
-
-      var displayTotal = isNaN(totalPretaxRefund) ? '' : totalPretaxRefund.toFixed(2);
-      formFields.find('span#total_pre_tax_refund').html(displayTotal);
-    }
-
     updateSuggestedAmount();
 
     formFields.find('input#select-all').on('change', function(ev) {

--- a/backend/app/assets/javascripts/spree/backend/spree-select2.js
+++ b/backend/app/assets/javascripts/spree/backend/spree-select2.js
@@ -6,9 +6,4 @@ jQuery(function($) {
     dropdownAutoWidth: true,
     minimumResultsForSearch: 8
   });
-
-  function format_taxons(taxon) {
-    new_taxon = taxon.text.replace('->', '<i class="fa fa-arrow-right">')
-    return new_taxon;
-  }
 })

--- a/backend/app/assets/javascripts/spree/backend/taxon_autocomplete.js
+++ b/backend/app/assets/javascripts/spree/backend/taxon_autocomplete.js
@@ -55,8 +55,3 @@ $.fn.taxonAutocomplete = function () {
 $(document).ready(function () {
   $('#product_taxon_ids, .taxon_picker').taxonAutocomplete();
 });
-
-// for backwards compat...
-var set_taxon_select = function() {
-  $('#product_taxon_ids, .taxon_picker').taxonAutocomplete();
-}


### PR DESCRIPTION
This adds a fairly relaxed `eslintrc` for linting our JS.

This adds very few rules, as I'd like to avoid bikeshedding at this point in time, and instead relies on the [eslint:recommended](http://eslint.org/docs/rules/) rule which covers the most important rules. Notably, these rules will catch missed `var` declarations :tada:.

This works around two ugly globals we have `show_flash` and `update_state`, which should be removed at a later date, but are outside the scope of this PR.

I skipped a few files, which are addressed in my other open PRs
```
spree/backend/line_items_on_order_edit.js
spree/backend/payments/new.js
spree/backend/shipments.js
```