### PR TITLE
Don’t set default text highlight colors

### DIFF
--- a/frontend/app/assets/stylesheets/spree/frontend/screen.css.scss
+++ b/frontend/app/assets/stylesheets/spree/frontend/screen.css.scss
@@ -30,10 +30,6 @@ hr {
   border-bottom: $default_border;
 }
 
-/* Custom text-selection colors (remove any text shadows: twitter.com/miketaylr/status/12228805301) */
-::-moz-selection{background: $link_text_color; color: $layout_background_color; text-shadow: none;}
-::selection {background: $link_text_color; color: $layout_background_color; text-shadow: none;}
-
 /*  j.mp/webkit-tap-highlight-color */
 a:link {-webkit-tap-highlight-color: $link_text_color;}
 


### PR DESCRIPTION
One of the problems with setting `::selection` colors is that it’s nontrivial for people who actually _want_ to use the browser-default selection colors to override the setting in a way that reverts to the browser default. For this reason I think it would be better to simply leave them out of the default `frontend` style and let individual site owners make their own decisions.