### PR TITLE
Display Backend only rates in the backend

### DIFF
--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -118,6 +118,24 @@ describe "Order Details", type: :feature, js: true do
         end
       end
 
+      context "with a backend only shipping method" do
+        let!(:backend_only_shipping_method) { create(:shipping_method, name: "Backend Shipping", available_to_users: false) }
+
+        it "can change the shipping method for a backend only one" do
+          order = create(:completed_order_with_totals, frontend_viewable: false)
+          visit spree.edit_admin_order_path(order)
+          within("table.index tr.show-method") do
+            click_icon :edit
+          end
+
+          select2 "Backend Shipping", from: "Shipping Method"
+          click_icon :check
+
+          expect(page).not_to have_css('#selected_shipping_rate_id')
+          expect(page).to have_content("Backend Shipping")
+        end
+      end
+
       context "with special_instructions present" do
         let(:order) { create(:order, state: 'complete', completed_at: "2011-02-01 12:36:15", number: "R100", special_instructions: "Very special instructions here") }
         it "will show the special_instructions" do

--- a/core/app/models/spree/stock/estimator.rb
+++ b/core/app/models/spree/stock/estimator.rb
@@ -11,12 +11,14 @@ module Spree
       #   those marked frontend if truthy
       # @return [Array<Spree::ShippingRate>] the shipping rates sorted by
       #   descending cost, with the least costly marked "selected"
-      def shipping_rates(package, frontend_only = true)
+      def shipping_rates(package, _frontend_only = true)
         raise ShipmentRequired if package.shipment.nil?
         raise OrderRequired if package.shipment.order.nil?
 
         rates = calculate_shipping_rates(package)
-        rates.select! { |rate| rate.shipping_method.available_to_users? } if frontend_only
+        if package.shipment.order.frontend_viewable?
+          rates.select! { |rate| rate.shipping_method.available_to_users? }
+        end
         choose_default_shipping_rate(rates)
         Spree::Config.shipping_rate_sorter_class.new(rates).sort
       end


### PR DESCRIPTION
Prior to the commit, shipping methods that had `display_on` set to
`back_end` would not be displayed in the backend. This commit changes
`Spree::Order#refresh_shipment_rates` and `Spree::Shipment#refresh_rates`
to accept an optional argument `frontend_only`. If that is set to `false`,
the estimator will also take into account backend only rates.

Also, the places where `@order.refresh_shipment_rates` are called
in the backend now pass `frontend_only: false` to those methods.