### PR TITLE
Remove spree_store_credits column

### DIFF
--- a/core/db/migrate/20170223235001_remove_spree_store_credits_column.rb
+++ b/core/db/migrate/20170223235001_remove_spree_store_credits_column.rb
@@ -1,0 +1,5 @@
+class RemoveSpreeStoreCreditsColumn < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :spree_store_credits, :spree_store_credits, :datetime
+  end
+end


### PR DESCRIPTION
There was a `spree_store_credits column` on the `spree_store_credits` table because of a mistake in the original store credits migration. This removes that column.

The [line in question](https://github.com/solidusio/solidus/blob/f297c58d78b7dfb2b73bd97d8869f63e896cbd93/core/db/migrate/20150506181244_create_spree_store_credits.rb#L12):

```
create_table :spree_store_credits do |t|
  ...
  t.datetime :spree_store_credits, :deleted_at
```