### PR TITLE
Display Backend only rates in the backend

### DIFF
--- a/backend/app/controllers/spree/admin/orders/customer_details_controller.rb
+++ b/backend/app/controllers/spree/admin/orders/customer_details_controller.rb
@@ -29,7 +29,7 @@ module Spree
 
             unless @order.completed?
               @order.next
-              @order.refresh_shipment_rates
+              @order.refresh_shipment_rates(frontend_only: false)
             end
 
             flash[:success] = Spree.t('customer_details_updated')

--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -76,13 +76,13 @@ module Spree
         require_ship_address
 
         unless @order.completed?
-          @order.refresh_shipment_rates
+          @order.refresh_shipment_rates(frontend_only: false)
         end
       end
 
       def cart
         unless @order.completed?
-          @order.refresh_shipment_rates
+          @order.refresh_shipment_rates(frontend_only: false)
         end
         if @order.shipped_shipments.count > 0
           redirect_to edit_admin_order_url(@order)

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -111,6 +111,23 @@ describe "Order Details", type: :feature, js: true do
         expect(page).to have_content("Default")
       end
 
+      context "with a backend only shipping method" do
+        let!(:backend_only_shipping_method) { create(:shipping_method, name: "Backend Shipping", display_on: "back_end") }
+
+        it "can change the shipping method for a backend only one" do
+          order = create(:order_with_line_items)
+          visit spree.edit_admin_order_path(order)
+          within("table.index tr.show-method") do
+            click_icon :edit
+          end
+          select2 "Backend Shipping", from: "Shipping Method"
+          click_icon :check
+
+          expect(page).not_to have_css('#selected_shipping_rate_id')
+          expect(page).to have_content("Backend Shipping")
+        end
+      end
+
       it "will show the variant sku" do
         order = create(:completed_order_with_totals)
         visit spree.edit_admin_order_path(order)

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -536,8 +536,8 @@ module Spree
       next! if line_items.size > 0
     end
 
-    def refresh_shipment_rates
-      shipments.map(&:refresh_rates)
+    def refresh_shipment_rates(frontend_only: true)
+      shipments.map { |s| s.refresh_rates(frontend_only: frontend_only) }
     end
 
     def shipping_eq_billing_address?

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -168,14 +168,14 @@ module Spree
       ready? || pending?
     end
 
-    def refresh_rates
+    def refresh_rates(frontend_only: true)
       return shipping_rates if shipped? || order.completed?
       return [] unless can_get_rates?
 
       # StockEstimator.new assigment below will replace the current shipping_method
       original_shipping_method_id = shipping_method.try!(:id)
 
-      new_rates = Spree::Config.stock.estimator_class.new.shipping_rates(to_package)
+      new_rates = Spree::Config.stock.estimator_class.new.shipping_rates(to_package, frontend_only)
 
       # If one of the new rates matches the previously selected shipping
       # method, select that instead of the default provided by the estimator.

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -1488,4 +1488,23 @@ describe Spree::Order, type: :model do
       end
     end
   end
+
+  describe "#refresh_shipment_rates" do
+    let(:order) { Spree::Order.new(shipments: [shipment]) }
+    let(:shipment) { Spree::Shipment.new }
+
+    context "when called with no arguments" do
+      it "calls refresh rates with frontend_only set to true" do
+        expect(shipment).to receive(:refresh_rates).with(frontend_only: true)
+        order.refresh_shipment_rates
+      end
+    end
+
+    context "when called with frontend_only set to false" do
+      it "calls shipment#refresh_rates with frontend_only set to false" do
+        expect(shipment).to receive(:refresh_rates).with(frontend_only: false)
+        order.refresh_shipment_rates(frontend_only: false)
+      end
+    end
+  end
 end

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -248,6 +248,30 @@ describe Spree::Shipment, type: :model do
           expect(shipment.to_package.shipment).to eq(shipment)
         end
       end
+
+      describe "passing arguments to the estimator" do
+        let(:shipment) { build_stubbed(:shipment) }
+        let(:package) { Spree::Stock::Package.new(shipment.stock_location) }
+
+        before do
+          expect(Spree::Stock::Estimator).to receive(:new).with(no_args).and_return(mock_estimator)
+          allow(shipment).to receive(:to_package).and_return(package)
+        end
+
+        context "when called with no arguments" do
+          it "calls estimator with frontend_only set to true" do
+            expect(mock_estimator).to receive(:shipping_rates).with(package, true) { shipping_rates }
+            shipment.refresh_rates
+          end
+        end
+
+        context "when called with frontend_only set to false" do
+          it "calls shipment#refresh_rates with frontend_only set to false" do
+            expect(mock_estimator).to receive(:shipping_rates).with(package, false) { shipping_rates }
+            shipment.refresh_rates(frontend_only: false)
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Prior to the commit, shipping methods that had `display_on` set to
`back_end` or `available_to_users`set to `false` would not be displayed
in the backend. This commit changes `Spree::Order#refresh_shipment_rates`
and `Spree::Shipment#refresh_rates` to accept an optional argument
`frontend_only`. If that is set to `false`, the estimator will also
take into account backend only rates.

Also, the places where `@order.refresh_shipment_rates` are called
in the backend now pass `frontend_only: false` to those methods.

This is the same as https://github.com/solidusio/solidus/pull/1739, but for Solidus 1.4.