### PR TITLE
Disable rubocop Metrics/BlockLength

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -226,6 +226,9 @@ Metrics/ClassLength:
 Metrics/ModuleLength:
   Enabled: false
 
+Metrics/BlockLength:
+  Enabled: false
+
 Metrics/CyclomaticComplexity:
   Enabled: false
 


### PR DESCRIPTION
This cop was added to rubocop a few months ago.  I agree shorter blocks are
usually better but this doesn't seem like it's something we need in rubocop and
it also has [some issues with specs](https://github.com/bbatsov/rubocop/issues/3664#issuecomment-255481296) apparently.

I noticed because it started spamming this PR: https://github.com/solidusio/solidus/pull/1707