### PR TITLE
Add default lastname in address factory

### DIFF
--- a/core/lib/spree/testing_support/factories/address_factory.rb
+++ b/core/lib/spree/testing_support/factories/address_factory.rb
@@ -11,7 +11,7 @@ FactoryGirl.define do
     end
 
     firstname 'John'
-    lastname nil
+    lastname 'Doe'
     company 'Company'
     address1 '10 Lovely Street'
     address2 'Northwest'


### PR DESCRIPTION
* Allows easier creation of factories where `lastname` is used in specs