### PR TITLE
Fix issue where OrderInventory creates superfluous InventoryUnits

### DIFF
--- a/core/app/models/spree/order_inventory.rb
+++ b/core/app/models/spree/order_inventory.rb
@@ -18,13 +18,13 @@ module Spree
     def verify(shipment = nil)
       if order.completed? || shipment.present?
 
-        if inventory_units.size < line_item.quantity
-          quantity = line_item.quantity - inventory_units.size
-
-          shipment = determine_target_shipment unless shipment
-          add_to_shipment(shipment, quantity)
-        elsif inventory_units.size > line_item.quantity
-          remove(inventory_units, shipment)
+        existing_quantity = inventory_units.count
+        desired_quantity = line_item.quantity - existing_quantity
+        if desired_quantity > 0
+          shipment ||= determine_target_shipment
+          add_to_shipment(shipment, desired_quantity)
+        elsif desired_quantity < 0
+          remove(-desired_quantity, shipment)
         end
       end
     end
@@ -35,9 +35,7 @@ module Spree
 
     private
 
-    def remove(item_units, shipment = nil)
-      quantity = item_units.size - line_item.quantity
-
+    def remove(quantity, shipment = nil)
       if shipment.present?
         remove_from_shipment(shipment, quantity)
       else

--- a/core/app/models/spree/order_inventory.rb
+++ b/core/app/models/spree/order_inventory.rb
@@ -98,7 +98,9 @@ module Spree
         removed_quantity += 1
       end
 
-      shipment.destroy if shipment.inventory_units.count == 0
+      if shipment.inventory_units.count.zero?
+        order.shipments.destroy(shipment)
+      end
 
       # removing this from shipment, and adding to stock_location
       if order.completed?

--- a/core/spec/models/spree/order_contents_spec.rb
+++ b/core/spec/models/spree/order_contents_spec.rb
@@ -19,11 +19,34 @@ describe Spree::OrderContents, type: :model do
     end
 
     context 'given a shipment' do
+      let!(:shipment) { create(:shipment) }
+
       it "ensure shipment calls update_amounts instead of order calling ensure_updated_shipments" do
-        shipment = create(:shipment)
         expect(subject.order).to_not receive(:ensure_updated_shipments)
         expect(shipment).to receive(:update_amounts)
         subject.add(variant, 1, shipment: shipment)
+      end
+
+      context "with quantity=1" do
+        it "creates correct inventory" do
+          subject.add(variant, 1, shipment: shipment)
+          expect(order.inventory_units.count).to eq(1)
+        end
+      end
+
+      context "with quantity=2" do
+        it "creates correct inventory" do
+          subject.add(variant, 2, shipment: shipment)
+          expect(order.inventory_units.count).to eq(2)
+        end
+      end
+
+      context "called multiple times" do
+        it "creates correct inventory" do
+          subject.add(variant, 1, shipment: shipment)
+          subject.add(variant, 1, shipment: shipment)
+          expect(order.inventory_units.count).to eq(2)
+        end
       end
     end
 

--- a/core/spec/models/spree/order_inventory_spec.rb
+++ b/core/spec/models/spree/order_inventory_spec.rb
@@ -100,6 +100,18 @@ describe Spree::OrderInventory, type: :model do
       expect(movement.originator).to eq(shipment)
       expect(movement.quantity).to eq(-5)
     end
+
+    context "calling multiple times" do
+      it "creates the correct number of inventory units" do
+        line_item.update_columns(quantity: 2)
+        subject.verify(shipment)
+        expect(line_item.inventory_units.count).to eq(2)
+
+        line_item.update_columns(quantity: 3)
+        subject.verify(shipment)
+        expect(line_item.inventory_units.count).to eq(3)
+      end
+    end
   end
 
   context "#determine_target_shipment" do

--- a/core/spec/models/spree/order_inventory_spec.rb
+++ b/core/spec/models/spree/order_inventory_spec.rb
@@ -202,9 +202,10 @@ describe Spree::OrderInventory, type: :model do
 
       it 'should destroy self if not inventory units remain' do
         allow(shipment.inventory_units).to receive_messages(count: 0)
-        expect(shipment).to receive(:destroy)
 
-        expect(subject.send(:remove_from_shipment, shipment, 1)).to eq(1)
+        expect {
+          expect(subject.send(:remove_from_shipment, shipment, 1)).to eq(1)
+        }.to change{ order.shipments.count }.from(1).to(0)
       end
 
       context "inventory unit line item and variant points to different products" do


### PR DESCRIPTION
This fixes an issue where OrderInventory would miscount the number of existing inventory_units on a line item and create extra records.

InventoryUnits exist through the line_item.inventory_units, shipment.inventory_units, and order.inventory_units associations. Because of this, their associations can't be kept up to date in memory.

OrderInventory was counting inventory using inventory_units.size, which would return the in-memory count if the line_items.inventory_units association was loaded.

This issue was exposed by adding to the same line item multiple times without reloading the order. The line_item.inventory_units association would be become `loaded?`, because ActiveRecord's `#size` [marks a record as loaded](https://github.com/rails/rails/blob/5-0-stable/activerecord/lib/active_record/associations/has_many_association.rb#L82-L85) if the count returns 0 (TIL!). On the next pass it would see the wrong size because the association was out of date, and add two inventory units instead of one.

This avoids the issue by counting inventory using inventory_units.count, which doesn't consider the in-memory association.