### PR TITLE
Create JS namespaces in centralized file

### DIFF
--- a/backend/app/assets/javascripts/spree/backend.js
+++ b/backend/app/assets/javascripts/spree/backend.js
@@ -13,6 +13,7 @@
 //= require solidus_admin/bootstrap
 //= require prism
 //= require spree
+//= require spree/backend/namespaces
 //= require spree/backend/translation
 //= require spree/backend/backbone-overrides
 //= require spree/backend/spree-select2

--- a/backend/app/assets/javascripts/spree/backend/collections/line_items.js
+++ b/backend/app/assets/javascripts/spree/backend/collections/line_items.js
@@ -1,7 +1,5 @@
 //= require spree/backend/models/line_item
 
-Spree.Collections = (Spree.Collections || {})
-
 Spree.Collections.LineItems = Backbone.Collection.extend({
   model: Spree.Models.LineItem,
 

--- a/backend/app/assets/javascripts/spree/backend/models/line_item.js
+++ b/backend/app/assets/javascripts/spree/backend/models/line_item.js
@@ -1,7 +1,5 @@
 //= require spree/backend/routes
 
-Spree.Models = (Spree.Models || {})
-
 Spree.Models.LineItem = Backbone.Model.extend({
   initialize: function(options) {
     this.order = this.collection.parent;

--- a/backend/app/assets/javascripts/spree/backend/models/order.js
+++ b/backend/app/assets/javascripts/spree/backend/models/order.js
@@ -1,8 +1,6 @@
 //= require spree/backend/routes
 //= require spree/backend/collections/line_items
 
-Spree.Models || (Spree.Models = {});
-
 Spree.Models.Order = Backbone.Model.extend({
   urlRoot: Spree.routes.orders_api,
   idAttribute: "number",

--- a/backend/app/assets/javascripts/spree/backend/namespaces.js
+++ b/backend/app/assets/javascripts/spree/backend/namespaces.js
@@ -1,0 +1,8 @@
+_.extend(window.Spree, {
+  Models: {},
+  Collections: {},
+  Views: {
+    Order: {},
+    Cart: {}
+  }
+})

--- a/backend/app/assets/javascripts/spree/backend/views/cart/add_line_item_button.js
+++ b/backend/app/assets/javascripts/spree/backend/views/cart/add_line_item_button.js
@@ -1,6 +1,3 @@
-Spree.Views = (Spree.Views || {})
-Spree.Views.Cart = (Spree.Views.Cart || {})
-
 Spree.Views.Cart.AddLineItemButton = Backbone.View.extend({
   initialize: function() {
     this.listenTo(this.collection, 'update', this.render);

--- a/backend/app/assets/javascripts/spree/backend/views/cart/line_item_row.js
+++ b/backend/app/assets/javascripts/spree/backend/views/cart/line_item_row.js
@@ -1,6 +1,3 @@
-Spree.Views = (Spree.Views || {})
-Spree.Views.Cart = (Spree.Views.Cart || {})
-
 Spree.Views.Cart.LineItemRow = Backbone.View.extend({
   tagName: 'tr',
   className: 'line-item',

--- a/backend/app/assets/javascripts/spree/backend/views/cart/line_item_table.js
+++ b/backend/app/assets/javascripts/spree/backend/views/cart/line_item_table.js
@@ -1,6 +1,3 @@
-Spree.Views = (Spree.Views || {})
-Spree.Views.Cart = (Spree.Views.Cart || {})
-
 Spree.Views.Cart.LineItemTable = Backbone.View.extend({
   initialize: function() {
     this.listenTo(this.collection, 'add', this.add);

--- a/backend/app/assets/javascripts/spree/backend/views/order/details_adjustments.js
+++ b/backend/app/assets/javascripts/spree/backend/views/order/details_adjustments.js
@@ -1,6 +1,3 @@
-Spree.Views = (Spree.Views || {})
-Spree.Views.Order = (Spree.Views.Order || {})
-
 Spree.Views.Order.DetailsAdjustments = Backbone.View.extend({
   initialize: function() {
     this.listenTo(this.model, "change", this.render);

--- a/backend/app/assets/javascripts/spree/backend/views/order/details_total.js
+++ b/backend/app/assets/javascripts/spree/backend/views/order/details_total.js
@@ -1,6 +1,3 @@
-Spree.Views = (Spree.Views || {})
-Spree.Views.Order = (Spree.Views.Order || {})
-
 Spree.Views.Order.DetailsTotal = Backbone.View.extend({
   initialize: function() {
     this.listenTo(this.model, "change", this.render);

--- a/backend/app/assets/javascripts/spree/backend/views/order/summary.js
+++ b/backend/app/assets/javascripts/spree/backend/views/order/summary.js
@@ -1,6 +1,3 @@
-Spree.Views || (Spree.Views = {});
-Spree.Views.Order || (Spree.Views.Order = {});
-
 Spree.Views.Order.Summary = Backbone.View.extend({
   initialize: function () {
     this.listenTo(this.model, "change", this.render);


### PR DESCRIPTION
As suggested by @tvdeyen 

This avoids the need to cautiously prefix files with lines like:

    Spree.Models = (Spree.Models || {})