### PR TITLE
Fix sensitive params filtering

### DIFF
--- a/backend/lib/spree/backend/engine.rb
+++ b/backend/lib/spree/backend/engine.rb
@@ -6,11 +6,6 @@ module Spree
       initializer "spree.backend.environment", before: :load_config_initializers do |_app|
         Spree::Backend::Config = Spree::BackendConfiguration.new
       end
-
-      # filter sensitive information during logging
-      initializer "spree.params.filter" do |app|
-        app.config.filter_parameters += [:password, :password_confirmation, :number]
-      end
     end
   end
 end

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -104,13 +104,14 @@ module Spree
         ]
       end
 
-      # filter sensitive information during logging
+      # Filter sensitive information during logging
       initializer "spree.params.filter", before: :load_config_initializers do |app|
         app.config.filter_parameters += [
-          :password,
-          :password_confirmation,
-          :number,
-          :verification_value]
+          %r{^password$},
+          %r{^password_confirmation$},
+          %r{^number$}, # Credit Card number
+          %r{^verification_value$} # Credit Card verification value
+        ]
       end
 
       initializer "spree.core.checking_migrations", before: :load_config_initializers do |_app|


### PR DESCRIPTION
- Use a regular expression to filter only parameters that start and end
  with sensitive keywords.
- Remove useless assignment of filter_parameters in backend since it's
  already defined in core engine.

ref #1752 

Not sure if it makes sense to add some specs here since we are just using the a rails configuration. I'm open to suggestions anyway.