### PR TITLE
Simplified cart link url

### DIFF
--- a/frontend/app/views/spree/shared/_main_nav_bar.html.erb
+++ b/frontend/app/views/spree/shared/_main_nav_bar.html.erb
@@ -7,6 +7,6 @@
       </noscript>
       &nbsp;
     </li>
-    <script>Spree.fetch_cart('<%= j spree.cart_link_url %>')</script>
+    <script>Spree.fetch_cart('<%= j spree.cart_link_path %>')</script>
   </ul>
 </nav>

--- a/frontend/app/views/spree/shared/_main_nav_bar.html.erb
+++ b/frontend/app/views/spree/shared/_main_nav_bar.html.erb
@@ -7,6 +7,6 @@
       </noscript>
       &nbsp;
     </li>
-    <script>Spree.fetch_cart('<%= j spree.cart_link_path %>')</script>
   </ul>
+  <script>Spree.fetch_cart('<%= j spree.cart_link_path %>')</script>
 </nav>


### PR DESCRIPTION
There is no need for the link to include protocol and hostname.

Scenario: A setup with a reverse proxy server in front the the application server.
The Application server runs HTTP. The reverse proxy server runs HTTPS.
When the reverse proxy server serves it as https, it will not load the XHR from a http: location.