### PR TITLE
Fit logo to available space by default

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/components/_navigation.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_navigation.scss
@@ -46,6 +46,8 @@ nav.menu {
 
   img {
     vertical-align: middle;
+    max-width: 100%;
+    max-height: 100%;
   }
 }
 


### PR DESCRIPTION
I think it would make sense to fit the backend logo to the available div by default, instead of requiring stores to supply appropriately-sized images.