### PR TITLE
Use an icon as missing image placeholder

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/templates/orders/line_item.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/orders/line_item.hbs
@@ -4,7 +4,11 @@
   </td>
 {{else}}
   <td class="line-item-image">
-    <img src="{{ image.mini_url }}">
+    {{#if image }}
+      <img src="{{ image.mini_url }}">
+    {{else}}
+      <span class="image-placeholder mini"></span>
+    {{/if}}
   </td>
   <td class="line-item-name">
     {{ line_item.variant.name }}<br>

--- a/backend/app/assets/javascripts/spree/backend/templates/stock_transfers/transfer_item.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/stock_transfers/transfer_item.hbs
@@ -5,7 +5,7 @@
         {{#if variantImageURL }}
           <img alt="{{variantName}}" src="{{variantImageURL}}">
         {{ else }}
-          <img alt='{{variant.name}}' src='<%= image_path("noimage/small.png") %>' />
+          <span class="image-placeholder small"></span>
         {{/if}}
       </div>
       <div class='variant-details'>

--- a/backend/app/assets/javascripts/spree/backend/templates/variants/autocomplete.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/variants/autocomplete.hbs
@@ -1,9 +1,9 @@
 <div class="variant-autocomplete-item media">
   <div class="media-left">
-    {{#if variant.image }}
+    {{#if image }}
       <img class="media-object" src='{{variant.image}}' />
     {{ else }}
-      <img class="media-object" src='<%= image_path("noimage/mini.png") %>' />
+      <span class="image-placeholder mini"></span>
     {{/if}}
   </div>
 

--- a/backend/app/assets/javascripts/spree/backend/variant_autocomplete.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/variant_autocomplete.js.coffee
@@ -3,8 +3,11 @@
 variantTemplate = HandlebarsTemplates["variants/autocomplete"]
 
 formatVariantResult = (variant) ->
-  variant.image = variant.images[0].mini_url  if variant["images"][0] isnt undefined and variant["images"][0].mini_url isnt undefined
-  variantTemplate variant: variant
+  image = variant.images[0].mini_url if variant["images"][0] isnt undefined and variant["images"][0].mini_url isnt undefined
+  variantTemplate(
+    variant: variant
+    image: image
+  )
 
 $.fn.variantAutocomplete = (searchOptions = {}) ->
   @select2

--- a/backend/app/assets/stylesheets/spree/backend/components/_image_placeholder.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_image_placeholder.scss
@@ -1,0 +1,24 @@
+.image-placeholder {
+  &.mini {
+    width: 50px;
+    height: 50px;
+    line-height: 48px;
+  }
+
+  &.small {
+    width: 102px;
+    height: 102px;
+    line-height: 100px;
+  }
+
+  display: inline-block;
+  margin: auto;
+  text-align: center;
+  border: 1px solid #ddd;
+  color: #aaa;
+
+  &:before {
+    font: normal normal normal 14px/1 FontAwesome;
+    content: "\f03e"; /* fa-picture-o */
+  }
+}

--- a/backend/app/assets/stylesheets/spree/backend/spree_admin.scss
+++ b/backend/app/assets/stylesheets/spree/backend/spree_admin.scss
@@ -23,6 +23,7 @@
 @import 'spree/backend/components/breadcrumb';
 @import 'spree/backend/components/date-picker';
 @import 'spree/backend/components/hint';
+@import 'spree/backend/components/image_placeholder';
 @import 'spree/backend/components/list_group';
 @import 'spree/backend/components/messages';
 @import 'spree/backend/components/progress';

--- a/backend/app/views/spree/admin/cancellations/index.html.erb
+++ b/backend/app/views/spree/admin/cancellations/index.html.erb
@@ -25,7 +25,7 @@
       <% @inventory_units.each do |inventory_unit| %>
         <tr class="inventory-unit">
           <td class="inventory-unit-image">
-            <%= image_tag inventory_unit.variant.display_image.attachment(:mini) %>
+            <%= render 'spree/admin/shared/image', image: inventory_unit.variant.display_image, size: :mini %>
           </td>
           <td class="inventory-unit-name">
             <%= inventory_unit.variant.product.name %><br><%= "(" + variant_options(inventory_unit.variant) + ")" unless inventory_unit.variant.option_values.empty? %>

--- a/backend/app/views/spree/admin/images/_image_row.html.erb
+++ b/backend/app/views/spree/admin/images/_image_row.html.erb
@@ -5,7 +5,9 @@
     <% end %>
   </td>
   <td>
-    <%= link_to image_tag(image.attachment.url(:mini)), image.attachment.url(:product) %>
+    <%= link_to image.attachment.url(:product) do %>
+      <%= render 'spree/admin/shared/image', image: image, size: :mini %>
+    <% end %>
   </td>
   <% if @product.has_variants? %>
     <td><%= options_text_for(image) %></td>

--- a/backend/app/views/spree/admin/orders/_carton_manifest.html.erb
+++ b/backend/app/views/spree/admin/orders/_carton_manifest.html.erb
@@ -1,7 +1,7 @@
 <% carton.manifest_for_order(order).each do |item| %>
   <tr class="stock-item" data-item-quantity="<%= item.quantity %>">
     <td class="item-image">
-      <%= image_tag item.variant.display_image.attachment(:mini) %>
+      <%= render 'spree/admin/shared/image', image: item.variant.display_image, size: :mini %>
     </td>
     <td class="item-name">
       <%= item.variant.product.name %><br><%= "(" + variant_options(item.variant) + ")" unless item.variant.option_values.empty? %>

--- a/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
@@ -4,7 +4,7 @@
       data-variant-id="<%= item.variant.id %>"
       >
     <td class="item-image">
-      <%= image_tag item.variant.display_image.attachment(:mini) %>
+      <%= render 'spree/admin/shared/image', image: item.variant.display_image, size: :mini %>
     </td>
     <td class="item-name">
       <%= item.variant.product.name %><br><%= "(" + variant_options(item.variant) + ")" unless item.variant.option_values.empty? %>

--- a/backend/app/views/spree/admin/orders/confirm/_shipment_manifest.html.erb
+++ b/backend/app/views/spree/admin/orders/confirm/_shipment_manifest.html.erb
@@ -1,7 +1,7 @@
 <% shipment.manifest.each do |item| %>
   <tr class="stock-item" data-item-quantity="<%= item.quantity %>">
     <td class="item-image">
-      <%= image_tag item.variant.display_image.attachment(:mini) %>
+      <%= render 'spree/admin/shared/image', image: item.variant.display_image, size: :mini %>
     </td>
     <td class="item-name">
       <%= item.variant.product.name %><br><%= "(" + variant_options(item.variant) + ")" unless item.variant.option_values.empty? %>

--- a/backend/app/views/spree/admin/products/index.html.erb
+++ b/backend/app/views/spree/admin/products/index.html.erb
@@ -73,7 +73,7 @@
       <% @collection.each do |product| %>
           <tr <%== "style='color: red;'" if product.deleted? %> id="<%= spree_dom_id product %>" data-hook="admin_products_index_rows" class="<%= cycle('odd', 'even') %>">
             <td class="align-center"><%= product.sku %></td>
-            <td class="align-center"><%= image_tag product.display_image.attachment(:mini) %></td>
+            <td class="align-center"><%= render 'spree/admin/shared/image', image: product.display_image, size: :mini %></td>
             <td><%= link_to product.try(:name), edit_admin_product_path(product) %></td>
             <td class="align-center"><%= product.display_price.to_html %></td>
             <td class="actions" data-hook="admin_products_index_row_actions">

--- a/backend/app/views/spree/admin/shared/_image.html.erb
+++ b/backend/app/views/spree/admin/shared/_image.html.erb
@@ -1,0 +1,7 @@
+<% size ||= :mini %>
+
+<% if image && image.attachment? %>
+  <%= image_tag image.attachment(size) %>
+<% else %>
+  <span class="image-placeholder <%= size %>"></span>
+<% end %>

--- a/backend/app/views/spree/admin/stock_items/_stock_management.html.erb
+++ b/backend/app/views/spree/admin/stock_items/_stock_management.html.erb
@@ -28,7 +28,7 @@
         <td class="align-center no-padding" rowspan="<%= row_count %>">
           <div class='variant-container'>
             <div class='variant-image'>
-              <%= image_tag(variant.display_image(fallback: false).attachment(:small)) %>
+              <%= render 'spree/admin/shared/image', image: variant.display_image(fallback: false), size: :small %>
             </div>
             <div class='variant-details'>
               <table class='stock-variant-field-table'>

--- a/backend/app/views/spree/admin/stock_transfers/_transfer_item_table.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/_transfer_item_table.html.erb
@@ -22,7 +22,7 @@
           <td class="align-center no-padding">
             <div class='variant-container' data-variant-id="<%= variant.id %>">
               <div class='variant-image'>
-                <%= image_tag(variant.display_image(fallback: false).attachment(:small)) %>
+                <%= render 'spree/admin/shared/image', image: variant.display_image(fallback: false), size: :small %>
               </div>
               <div class='variant-details'>
 

--- a/backend/app/views/spree/admin/users/items.html.erb
+++ b/backend/app/views/spree/admin/users/items.html.erb
@@ -41,7 +41,7 @@
             <tr class="stock-item" data-item-quantity="<%= item.quantity %>">
               <td class="align-center order-completed-at"><%= l(order.completed_at.to_date) if order.completed_at %></td>
               <td class="item-image">
-                <%= image_tag item.variant.display_image.attachment(:mini) %>
+                <%= render 'spree/admin/shared/image', image: item.variant.display_image, size: :mini %>
               </td>
               <td class="item-name">
                 <%= item.product.name %><br><%= "(" + variant_options(item.variant) + ")" unless item.variant.option_values.empty? %>


### PR DESCRIPTION
This displays a nicer placeholder for representing a missing image on products or variants. It uses a font icon instead of linking to a PNG asset.

This has the advantage of being i18n friendly (the previous PNG was english), and is slightly more convenient to use technically (doesn't require sprockets resolving the image path). It also looks nicer.

Before:
![](http://i.hawth.ca/s/fFGSQY6M.png)

After:
![](http://i.hawth.ca/s/4jDu3bTT.png)