### PR TITLE
Methods for Spree::Taxon for all products/variants from descendants

### DIFF
--- a/core/app/models/spree/taxon.rb
+++ b/core/app/models/spree/taxon.rb
@@ -87,6 +87,19 @@ module Spree
       products.not_deleted.available
     end
 
+    # @return [ActiveRecord::Relation<Spree::Product>] all self and descendant products
+    def all_products
+      scope = Product.joins(:taxons)
+      scope.where(
+        spree_taxons: { id: self_and_descendants.select(:id) }
+      )
+    end
+
+    # @return [ActiveRecord::Relation<Spree::Variant>] all self and descendant variants, including master variants.
+    def all_variants
+      Variant.where(product_id: all_products.select(:id))
+    end
+
     # @return [String] this taxon's ancestors names followed by its own name,
     #   separated by arrows
     def pretty_name

--- a/core/spec/models/spree/taxon_spec.rb
+++ b/core/spec/models/spree/taxon_spec.rb
@@ -135,4 +135,39 @@ RSpec.describe Spree::Taxon, type: :model do
       taxonomy.root.children.unscoped.where(name: "Some name").first_or_create
     end
   end
+
+  context 'leaves of the taxon tree' do
+    let(:taxonomy) { create(:taxonomy, name: 't') }
+    let(:root) { taxonomy.root }
+    let(:taxon) { create(:taxon, name: 't1', taxonomy: taxonomy, parent: root) }
+    let(:child) { create(:taxon, name: 'child taxon', taxonomy: taxonomy, parent: taxon) }
+    let(:grandchild) { create(:taxon, name: 'grandchild taxon', taxonomy: taxonomy, parent: child) }
+    let(:product1) { create(:product) }
+    let(:product2) { create(:product) }
+    let(:product3) { create(:product) }
+    before do
+      product1.taxons << taxon
+      product2.taxons << child
+      product3.taxons << grandchild
+      taxon.reload
+
+      [product1, product2, product3].each { |p| 2.times.each { create(:variant, product: p) } }
+    end
+
+    describe '#all_products' do
+      it 'returns all descendant products' do
+        products = taxon.all_products
+        expect(products.count).to eq(3)
+        expect(products).to match_array([product1, product2, product3])
+      end
+    end
+
+    describe '#all_variants' do
+      it 'returns all descendant variants' do
+        variants = taxon.all_variants
+        expect(variants.count).to eq(9)
+        expect(variants).to match_array([product1, product2, product3].map{ |p| p.variants_including_master }.flatten)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This adds 2 primary methods to Spree::Taxon to allow users to retreive
all products and all variants that are under the taxon instance. Helpful for
a taxon page to show an overview of everything that is under that
taxon. Also, included is a shortcut method for
`taxon.descendants.pluck(:id)`.