### PR TITLE
Convert customer details page to backbone

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/checkouts/edit.js
+++ b/backend/app/assets/javascripts/spree/backend/checkouts/edit.js
@@ -1,54 +1,7 @@
-$(document).ready(function() {
-  if ($("#customer_search").length > 0) {
-    var customerSelect = new Spree.Views.Order.CustomerSelect({
-      el: $('#customer_search')
-    });
-
-    customerSelect.on("select", function(customer) {
-      $('#order_email').val(customer.email);
-      $('#user_id').val(customer.id);
-      $('#guest_checkout_true').prop("checked", false);
-      $('#guest_checkout_false').prop("checked", true);
-      $('#guest_checkout_false').prop("disabled", false);
-
-      var billAddress = customer.bill_address;
-      if (billAddress) {
-        $('#order_bill_address_attributes_firstname').val(billAddress.firstname);
-        $('#order_bill_address_attributes_lastname').val(billAddress.lastname);
-        $('#order_bill_address_attributes_address1').val(billAddress.address1);
-        $('#order_bill_address_attributes_address2').val(billAddress.address2);
-        $('#order_bill_address_attributes_city').val(billAddress.city);
-        $('#order_bill_address_attributes_zipcode').val(billAddress.zipcode);
-        $('#order_bill_address_attributes_phone').val(billAddress.phone);
-
-        $('#order_bill_address_attributes_country_id').select2("val", billAddress.country_id).promise().done(function () {
-          update_state('b', function () {
-            $('#order_bill_address_attributes_state_id').select2("val", billAddress.state_id);
-          });
-        });
-      }
+$(function() {
+  if($(".js-customer-details").length) {
+    new Spree.Views.Order.CustomerDetails({
+      el: $(".js-customer-details")
     });
   }
-
-  var order_use_billing_input = $('input#order_use_billing');
-
-  var order_use_billing = function () {
-    if (!order_use_billing_input.is(':checked')) {
-      $('#shipping').show();
-    } else {
-      $('#shipping').hide();
-    }
-  };
-
-  order_use_billing_input.click(function() {
-    order_use_billing();
-  });
-
-  order_use_billing();
-
-  $('#guest_checkout_true').change(function() {
-    $('#customer_search').val("");
-    $('#user_id').val("");
-    $('#checkout_email').val("");
-  });
 });

--- a/backend/app/assets/javascripts/spree/backend/checkouts/edit.js
+++ b/backend/app/assets/javascripts/spree/backend/checkouts/edit.js
@@ -50,12 +50,5 @@ $(document).ready(function() {
     $('#customer_search').val("");
     $('#user_id').val("");
     $('#checkout_email').val("");
-
-    var fields = ["firstname", "lastname", "company", "address1", "address2",
-              "city", "zipcode", "state_id", "country_id", "phone"]
-    $.each(fields, function(i, field) {
-      $('#order_bill_address_attributes' + field).val("");
-      $('#order_ship_address_attributes' + field).val("");
-    })
   });
 });

--- a/backend/app/assets/javascripts/spree/backend/checkouts/edit.js
+++ b/backend/app/assets/javascripts/spree/backend/checkouts/edit.js
@@ -1,47 +1,10 @@
-//= require_self
 $(document).ready(function() {
-  var customerTemplate = HandlebarsTemplates['orders/customer_details/autocomplete'];
-
-  var formatCustomerResult = function(customer) {
-    return customerTemplate({
-      customer: customer,
-      bill_address: customer.bill_address,
-      ship_address: customer.ship_address
-    })
-  }
-
   if ($("#customer_search").length > 0) {
-    $("#customer_search").select2({
-      placeholder: Spree.translations.choose_a_customer,
-      ajax: {
-        url: Spree.routes.users_api,
-        params: { "headers": { "X-Spree-Token": Spree.api_key } },
-        datatype: 'json',
-        data: function(term, page) {
-          return {
-            q: {
-              m: 'or',
-              email_start: term,
-              addresses_firstname_start: term,
-              addresses_lastname_start: term
-            }
-          }
-        },
-        results: function(data, page) {
-          return {
-            results: data.users,
-            more: data.current_page < data.pages
-          }
-        }
-      },
-      formatResult: formatCustomerResult,
-      formatSelection: function (customer) {
-        return Select2.util.escapeMarkup(customer.email);
-      }
-    })
+    var customerSelect = new Spree.Views.Order.CustomerSelect({
+      el: $('#customer_search')
+    });
 
-    $("#customer_search").on("select2-selecting", function(e) {
-      var customer = e.choice;
+    customerSelect.on("select", function(customer) {
       $('#order_email').val(customer.email);
       $('#user_id').val(customer.id);
       $('#guest_checkout_true').prop("checked", false);

--- a/backend/app/assets/javascripts/spree/backend/checkouts/edit.js
+++ b/backend/app/assets/javascripts/spree/backend/checkouts/edit.js
@@ -34,7 +34,6 @@ $(document).ready(function() {
           }
         }
       },
-      dropdownCssClass: 'customer_search',
       formatResult: formatCustomerResult,
       formatSelection: function (customer) {
         return Select2.util.escapeMarkup(customer.email);

--- a/backend/app/assets/javascripts/spree/backend/checkouts/edit.js
+++ b/backend/app/assets/javascripts/spree/backend/checkouts/edit.js
@@ -1,7 +1,12 @@
 $(function() {
   if($(".js-customer-details").length) {
+    var order = new Spree.Models.Order({
+      bill_address: {},
+      ship_address: {}
+    });
     new Spree.Views.Order.CustomerDetails({
-      el: $(".js-customer-details")
+      el: $(".js-customer-details"),
+      model: order
     });
   }
 });

--- a/backend/app/assets/javascripts/spree/backend/collections/index.js
+++ b/backend/app/assets/javascripts/spree/backend/collections/index.js
@@ -1,1 +1,2 @@
 //= require spree/backend/collections/line_items
+//= require spree/backend/collections/states

--- a/backend/app/assets/javascripts/spree/backend/collections/states.js
+++ b/backend/app/assets/javascripts/spree/backend/collections/states.js
@@ -1,0 +1,13 @@
+Spree.Collections.States = Backbone.Collection.extend({
+  initialize: function (models, options) {
+    this.country_id = options.country_id
+  },
+
+  url: function () {
+    return Spree.routes.states_search + "?country_id=" + this.country_id
+  },
+
+  parse: function(resp, options) {
+    return resp.states;
+  }
+})

--- a/backend/app/assets/javascripts/spree/backend/models/address.js
+++ b/backend/app/assets/javascripts/spree/backend/models/address.js
@@ -1,0 +1,2 @@
+Spree.Models.Address = Backbone.Model.extend({
+})

--- a/backend/app/assets/javascripts/spree/backend/models/order.js
+++ b/backend/app/assets/javascripts/spree/backend/models/order.js
@@ -1,5 +1,6 @@
 //= require spree/backend/routes
 //= require spree/backend/collections/line_items
+//= require spree/backend/models/address
 
 Spree.Models.Order = Backbone.Model.extend({
   urlRoot: Spree.routes.orders_api,
@@ -7,7 +8,9 @@ Spree.Models.Order = Backbone.Model.extend({
 
   relations: {
     "line_items": Spree.Collections.LineItems,
-    "shipments": Backbone.Collection
+    "shipments": Backbone.Collection,
+    "bill_address": Spree.Models.Address,
+    "ship_address": Spree.Models.Address
   },
 
   advance: function(opts) {
@@ -25,7 +28,9 @@ Spree.Models.Order.fetch = function(number, opts) {
   var model = new Spree.Models.Order({
     number: number,
     line_items: [],
-    shipments: []
+    shipments: [],
+    bill_address: {},
+    ship_address: {},
   });
   model.fetch(options);
   return model;

--- a/backend/app/assets/javascripts/spree/backend/views/index.js
+++ b/backend/app/assets/javascripts/spree/backend/views/index.js
@@ -3,4 +3,5 @@
 //= require 'spree/backend/views/cart/line_item_table'
 //= require 'spree/backend/views/order/details_adjustments'
 //= require 'spree/backend/views/order/details_total'
+//= require 'spree/backend/views/order/customer_select'
 //= require 'spree/backend/views/order/summary'

--- a/backend/app/assets/javascripts/spree/backend/views/index.js
+++ b/backend/app/assets/javascripts/spree/backend/views/index.js
@@ -1,6 +1,7 @@
 //= require 'spree/backend/views/cart/add_line_item_button'
 //= require 'spree/backend/views/cart/line_item_row'
 //= require 'spree/backend/views/cart/line_item_table'
+//= require 'spree/backend/views/order/address'
 //= require 'spree/backend/views/order/details_adjustments'
 //= require 'spree/backend/views/order/details_total'
 //= require 'spree/backend/views/order/customer_details'

--- a/backend/app/assets/javascripts/spree/backend/views/index.js
+++ b/backend/app/assets/javascripts/spree/backend/views/index.js
@@ -3,5 +3,6 @@
 //= require 'spree/backend/views/cart/line_item_table'
 //= require 'spree/backend/views/order/details_adjustments'
 //= require 'spree/backend/views/order/details_total'
+//= require 'spree/backend/views/order/customer_details'
 //= require 'spree/backend/views/order/customer_select'
 //= require 'spree/backend/views/order/summary'

--- a/backend/app/assets/javascripts/spree/backend/views/index.js
+++ b/backend/app/assets/javascripts/spree/backend/views/index.js
@@ -7,3 +7,4 @@
 //= require 'spree/backend/views/order/customer_details'
 //= require 'spree/backend/views/order/customer_select'
 //= require 'spree/backend/views/order/summary'
+//= require 'spree/backend/views/state_select'

--- a/backend/app/assets/javascripts/spree/backend/views/order/address.js
+++ b/backend/app/assets/javascripts/spree/backend/views/order/address.js
@@ -1,0 +1,52 @@
+Spree.Views.Order.Address = Backbone.View.extend({
+  initialize: function(options) {
+    this.$(".js-country_id").select2();
+
+    // read initial values from page
+    this.onChange();
+
+    this.render();
+    this.listenTo(this.model, "change", this.render);
+
+    this.stateSelect =
+      new Spree.Views.StateSelect({
+        model: this.model,
+        el: this.$el
+      });
+  },
+
+  events: {
+    "change": "onChange",
+  },
+
+  onChange: function() {
+    this.model.set(this.getValues())
+  },
+
+  eachField: function(callback){
+    var view = this;
+    var fields = ["firstname", "lastname", "company", "address1", "address2",
+      "city", "zipcode", "phone"];
+    _.each(fields, function(field) {
+      var el = view.$('[name$="[' + field + ']"]');
+      if (el.length) callback(field, el);
+    });
+  },
+
+  getValues: function() {
+    var attributes = {};
+    this.eachField(function(name, el) {
+      attributes[name] = el.val();
+    });
+    attributes['country_id'] = this.$(".js-country_id").select2("val")
+    return attributes;
+  },
+
+  render: function() {
+    var model = this.model;
+    this.eachField(function(name, el) {
+      el.val(model.get(name))
+    })
+    this.$(".js-country_id").select2("val", this.model.get("country_id"))
+  }
+});

--- a/backend/app/assets/javascripts/spree/backend/views/order/customer_details.js
+++ b/backend/app/assets/javascripts/spree/backend/views/order/customer_details.js
@@ -1,0 +1,54 @@
+Spree.Views.Order.CustomerDetails = Backbone.View.extend({
+  initialize: function() {
+    this.customerSelectView =
+      new Spree.Views.Order.CustomerSelect({
+        el: this.$('#customer_search')
+      });
+    this.listenTo(this.customerSelectView, "select", this.onSelectCustomer);
+
+    this.onUseBillingChanged();
+  },
+
+  events: {
+    "click #order_use_billing": "onUseBillingChanged",
+    "click #guest_checkout_true": "onGuestCheckoutChanged"
+  },
+
+  onGuestCheckoutChanged: function() {
+    $('#user_id').val("");
+  },
+
+  onUseBillingChanged: function() {
+    if (!this.$('#order_use_billing').is(':checked')) {
+      $('#shipping').show();
+    } else {
+      $('#shipping').hide();
+    }
+  },
+
+  onSelectCustomer: function(customer) {
+    $('#order_email').val(customer.email);
+    $('#user_id').val(customer.id);
+    $('#guest_checkout_true').prop("checked", false);
+    $('#guest_checkout_false').prop("checked", true);
+    $('#guest_checkout_false').prop("disabled", false);
+
+    var billAddress = customer.bill_address;
+    if (billAddress) {
+      $('#order_bill_address_attributes_firstname').val(billAddress.firstname);
+      $('#order_bill_address_attributes_lastname').val(billAddress.lastname);
+      $('#order_bill_address_attributes_address1').val(billAddress.address1);
+      $('#order_bill_address_attributes_address2').val(billAddress.address2);
+      $('#order_bill_address_attributes_city').val(billAddress.city);
+      $('#order_bill_address_attributes_zipcode').val(billAddress.zipcode);
+      $('#order_bill_address_attributes_phone').val(billAddress.phone);
+
+      $('#order_bill_address_attributes_country_id').select2("val", billAddress.country_id).promise().done(function () {
+        update_state('b', function () {
+          $('#order_bill_address_attributes_state_id').select2("val", billAddress.state_id);
+        });
+      });
+    }
+  },
+})
+

--- a/backend/app/assets/javascripts/spree/backend/views/order/customer_select.js
+++ b/backend/app/assets/javascripts/spree/backend/views/order/customer_select.js
@@ -1,0 +1,55 @@
+Spree.Views.Order.CustomerSelect = Backbone.View.extend({
+  initialize: function() {
+    this.render();
+  },
+
+  events: {
+    "select2-selecting": "onSelect"
+  },
+
+  onSelect: function(e) {
+    var customer = e.choice;
+    this.trigger("select", customer)
+  },
+
+  render: function() {
+    var customerTemplate = HandlebarsTemplates['orders/customer_details/autocomplete'];
+
+    var formatCustomerResult = function(customer) {
+      return customerTemplate({
+        customer: customer,
+        bill_address: customer.bill_address,
+        ship_address: customer.ship_address
+      })
+    }
+
+    this.$el.select2({
+      placeholder: Spree.translations.choose_a_customer,
+      ajax: {
+        url: Spree.routes.users_api,
+        params: { "headers": { "X-Spree-Token": Spree.api_key } },
+        datatype: 'json',
+        data: function(term, page) {
+          return {
+            q: {
+              m: 'or',
+              email_start: term,
+              addresses_firstname_start: term,
+              addresses_lastname_start: term
+            }
+          }
+        },
+        results: function(data, page) {
+          return {
+            results: data.users,
+            more: data.current_page < data.pages
+          }
+        }
+      },
+      formatResult: formatCustomerResult,
+      formatSelection: function (customer) {
+        return Select2.util.escapeMarkup(customer.email);
+      }
+    })
+  }
+});

--- a/backend/app/assets/javascripts/spree/backend/views/state_select.js
+++ b/backend/app/assets/javascripts/spree/backend/views/state_select.js
@@ -1,0 +1,66 @@
+Spree.Views.StateSelect = Backbone.View.extend({
+  initialize: function() {
+    this.states = {} // null object
+
+    this.$state_select = this.$('.js-state_id');
+    this.$state_input = this.$('.js-state_name');
+
+    // read initial values from page
+    this.model.set({
+      state_name: this.$state_input.val(),
+      state_id: this.$state_select.val()
+    })
+
+    this.updateStates();
+    this.listenTo(this.model, 'change:country_id', this.updateStates)
+    this.render();
+  },
+
+  events: {
+    "change .js-state_name": "onChange",
+    "change .js-state_id": "onChange",
+  },
+
+  onChange: function() {
+    this.model.set({
+      state_name: this.$state_input.val(),
+      state_id: this.$state_select.select2("val")
+    })
+  },
+
+  updateStates: function() {
+    this.stopListening(this.states);
+    this.pending = true;
+    var country_id = this.model.get("country_id");
+    if (country_id) {
+      this.states = new Spree.Collections.States([], {country_id: country_id});
+      this.listenTo(this.states, "reset", this.onSync);
+      this.states.fetch({reset: true});
+    }
+  },
+
+  onSync: function() {
+    this.pending = false;
+    this.render();
+  },
+
+  render: function() {
+    this.$state_select.empty().select2("destroy").hide();
+    this.$state_input.hide();
+
+    if (this.pending) {
+      this.$state_select.show().select2().select2("disable");
+    } else if (this.states.length) {
+      var $state_select = this.$state_select;
+      this.states.each(function(state) {
+        $state_select.append(
+          $('<option>').prop('value', state.id).text(state.get("name"))
+        );
+      })
+      this.$state_select.val(this.model.get("state_id"))
+      this.$state_select.show().select2().select2("enable");
+    } else {
+      this.$state_input.prop('disabled', false).show();
+    }
+  }
+})

--- a/backend/app/views/spree/admin/orders/customer_details/_form.html.erb
+++ b/backend/app/views/spree/admin/orders/customer_details/_form.html.erb
@@ -40,18 +40,20 @@
     <div class="col-xs-6" data-hook="ship_address_wrapper">
       <fieldset class="no-border-bottom">
         <legend align="center"><%= Spree.t(:shipping_address) %></legend>
-        <%= f.fields_for :ship_address do |sa_form| %>
-          <% if Spree::Config[:order_bill_address_used] %>
-            <div class="field" style="position: absolute;margin-top: -15px;left: 0;">
-              <span data-hook="use_billing">
-                <%= check_box_tag 'order[use_billing]', '1', (@order.ship_address.new_record? && @order.bill_address == @order.ship_address) %>
-                <%= label_tag 'order[use_billing]', Spree.t(:use_billing_address) %>
-              </span>
-            </div>
-          <% end %>
-
-          <%= render partial: 'spree/admin/shared/address_form', locals: { f: sa_form, type: 'shipping' } %>
+        <% if Spree::Config[:order_bill_address_used] %>
+          <div class="field" style="position: absolute;margin-top: -15px;left: 0;">
+            <span data-hook="use_billing">
+              <%= check_box_tag 'order[use_billing]', '1', (@order.ship_address.new_record? && @order.bill_address == @order.ship_address) %>
+              <%= label_tag 'order[use_billing]', Spree.t(:use_billing_address) %>
+            </span>
+          </div>
         <% end %>
+
+        <div class="js-shipping-address">
+          <%= f.fields_for :ship_address do |ba_form| %>
+            <%= render partial: 'spree/admin/shared/address_form', locals: { f: ba_form, type: "shipping" } %>
+          <% end %>
+        </div>
       </fieldset>
     </div>
 
@@ -59,9 +61,11 @@
       <div class="col-xs-6" data-hook="bill_address_wrapper">
         <fieldset class="no-border-bottom">
           <legend align="center"><%= Spree.t(:billing_address) %></legend>
-          <%= f.fields_for :bill_address do |ba_form| %>
-            <%= render partial: 'spree/admin/shared/address_form', locals: { f: ba_form, type: "billing" } %>
-          <% end %>
+          <div class="js-billing-address">
+            <%= f.fields_for :bill_address do |ba_form| %>
+              <%= render partial: 'spree/admin/shared/address_form', locals: { f: ba_form, type: "billing" } %>
+            <% end %>
+          </div>
         </fieldset>
       </div>
     <% end %>

--- a/backend/app/views/spree/admin/orders/customer_details/edit.html.erb
+++ b/backend/app/views/spree/admin/orders/customer_details/edit.html.erb
@@ -6,15 +6,17 @@
 <% content_for :page_actions do %>
 <% end %>
 
-<div id="select-customer" data-hook>
-  <fieldset class="no-border-bottom">
-    <legend align="center"><%= Spree.t(:customer_search) %></legend>
-    <%= hidden_field_tag :customer_search,  nil, class: 'fullwidth title' %>
-  </fieldset>
+<div class="js-customer-details" data-order-number="<%= @order.number %>">
+  <div id="select-customer" data-hook>
+    <fieldset class="no-border-bottom">
+      <legend align="center"><%= Spree.t(:customer_search) %></legend>
+      <%= hidden_field_tag :customer_search,  nil, class: 'fullwidth title' %>
+    </fieldset>
+  </div>
+
+  <%= render partial: 'spree/shared/error_messages', locals: { target: @order } %>
+
+  <%= form_for @order, url: admin_order_customer_url(@order) do |f| %>
+    <%= render 'form', f: f %>
+  <% end %>
 </div>
-
-<%= render partial: 'spree/shared/error_messages', locals: { target: @order } %>
-
-<%= form_for @order, url: admin_order_customer_url(@order) do |f| %>
-  <%= render 'form', f: f %>
-<% end %>

--- a/backend/app/views/spree/admin/shared/_address_form.html.erb
+++ b/backend/app/views/spree/admin/shared/_address_form.html.erb
@@ -41,7 +41,7 @@
   <div class="field <%= "#{type}-row" %>">
     <%= f.label :country_id, Spree::Country.model_name.human %>
     <span id="<%= s_or_b %>country">
-      <%= f.collection_select :country_id, available_countries, :id, :name, {}, {class: 'select2 fullwidth'} %>
+      <%= f.collection_select :country_id, available_countries, :id, :name, {}, {class: 'fullwidth js-country_id'} %>
     </span>
   </div>
 
@@ -50,8 +50,8 @@
     <span id="<%= s_or_b %>state">
       <%= f.text_field :state_name,
             style: "display: #{f.object.country.states.empty? ? 'block' : 'none' };",
-           disabled: !f.object.country.states.empty?, class: 'fullwidth state_name' %>
-      <%= f.collection_select :state_id, f.object.country.states.sort, :id, :name, {include_blank: true}, {class: 'select2 fullwidth', style: "display: #{f.object.country.states.empty? ? 'none' : 'block' };", disabled: f.object.country.states.empty?} %>
+           disabled: !f.object.country.states.empty?, class: 'fullwidth state_name js-state_name' %>
+      <%= f.collection_select :state_id, f.object.country.states.sort, :id, :name, {include_blank: true}, {class: 'fullwidth js-state_id', style: "display: #{f.object.country.states.empty? ? 'none' : 'block' };", disabled: f.object.country.states.empty?} %>
     </span>
   </div>
 
@@ -60,11 +60,3 @@
     <%= f.phone_field :phone, class: 'fullwidth' %>
   </div>
 </div>
-
-<% content_for :head do %>
-  <%= javascript_tag do -%>
-    $(document).ready(function(){
-      $('span#<%= s_or_b %>country .select2').on('change', function() { update_state('<%= s_or_b %>'); });
-    });
-  <% end -%>
-<% end %>


### PR DESCRIPTION
This PR aims to replace the jQuery soup of [checkouts/edit.js](https://github.com/solidusio/solidus/blob/master/backend/app/assets/javascripts/spree/backend/checkouts/edit.js) and [address_states.js](https://github.com/solidusio/solidus/blob/master/backend/app/assets/javascripts/spree/backend/address_states.js) with backbone models and views.

There were a number of issues with the existing code:

* A number of race conditions were possible (though somewhat unlikely because the states API is very fast). For example switching countries rapidly could result in the wrong states being shown
* "Guest checkout" toggle didn't work correctly. If it was switched from "no" to "yes" and then back, it would still be submitted to the server as a guest checkout (no associated user)
* `checkouts.js` was callback hell. Worst case was setting the `state_id`, which had to be done [inside a select2 callback, and a callback from an ajax request inside of update_state](https://github.com/solidusio/solidus/blob/master/backend/app/assets/javascripts/spree/backend/checkouts/edit.js#L64)


The conversion to backbone added a fair number of lines, which I feel I should justify. From about 135 lines between `edit.js` and `address_states.js` to about 250 lines between the four new backbone views.

This PR adds two way bindings between all the form inputs on this page. This allows our top level view to be oblivious to the details of the subview (in particular the awkwardness of state selection). Specifically I'd like to point to [the existing code when selecting a customer](https://github.com/solidusio/solidus/blob/80d63c2bcfa2f5904184e43ed1b5ba3fc9c74566/backend/app/assets/javascripts/spree/backend/checkouts/edit.js#L44-L68) vs the [new code](https://github.com/solidusio/solidus/blob/efc96579d5f326c8fd3acab259fe98b2f984e828/backend/app/assets/javascripts/spree/backend/views/order/customer_details.js#L48-L52)