### PR TITLE
Set Capybara.exact = true for backend specs

### DIFF
--- a/backend/app/helpers/spree/admin/base_helper.rb
+++ b/backend/app/helpers/spree/admin/base_helper.rb
@@ -101,7 +101,8 @@ module Spree
       def preference_fields(object, form)
         return unless object.respond_to?(:preferences)
         fields = object.preferences.keys.map { |key|
-          form.label("preferred_#{key}", Spree.t(key) + ": ") +
+          form.label("preferred_#{key}", Spree.t(key)) +
+            "<br />".html_safe +
             preference_field_for(form, "preferred_#{key}", type: object.preference_type(key))
         }
         safe_join(fields, "<br />".html_safe)

--- a/backend/spec/features/admin/configuration/payment_methods_spec.rb
+++ b/backend/spec/features/admin/configuration/payment_methods_spec.rb
@@ -35,7 +35,7 @@ describe "Payment Methods", type: :feature do
       expect(page).to have_content("New Payment Method")
       fill_in "payment_method_name", with: "check90"
       fill_in "payment_method_description", with: "check90 desc"
-      select "PaymentMethod::Check", from: "gtwy-type"
+      select "Spree::PaymentMethod::Check", from: "gtwy-type"
       click_button "Create"
       expect(page).to have_content("successfully created!")
     end

--- a/backend/spec/features/admin/configuration/store_spec.rb
+++ b/backend/spec/features/admin/configuration/store_spec.rb
@@ -14,7 +14,7 @@ describe "Store", type: :feature, js: true do
     visit spree.admin_path
     click_link "Settings"
     within('.admin-nav') do
-      click_link "Store"
+      click_link "Stores"
     end
   end
 

--- a/backend/spec/features/admin/orders/customer_details_spec.rb
+++ b/backend/spec/features/admin/orders/customer_details_spec.rb
@@ -41,7 +41,7 @@ describe "Customer Details", type: :feature, js: true do
       expect(page).to have_field('Street Address', with: user.bill_address.address1)
       expect(page).to have_field("Street Address (cont'd)", with: user.bill_address.address2)
       expect(page).to have_field('City', with: user.bill_address.city)
-      expect(page).to have_field('Zip', with: user.bill_address.zipcode)
+      expect(page).to have_field('Zip Code', with: user.bill_address.zipcode)
       expect(page).to have_field('Country', with: user.bill_address.country_id)
       expect(page).to have_field('State', with: user.bill_address.state_id)
       expect(page).to have_field('Phone', with: user.bill_address.phone)
@@ -172,7 +172,7 @@ describe "Customer Details", type: :feature, js: true do
     fill_in "Street Address",          with: "100 first lane"
     fill_in "Street Address (cont'd)", with: "#101"
     fill_in "City",                    with: "Bethesda"
-    fill_in "Zip",                     with: "20170"
+    fill_in "Zip Code",                with: "20170"
     targetted_select2 "Alabama",       from: "#s2id_order_#{kind}_address_attributes_state_id"
     fill_in "Phone",                   with: "123-456-7890"
   end

--- a/backend/spec/features/admin/orders/listing_spec.rb
+++ b/backend/spec/features/admin/orders/listing_spec.rb
@@ -45,7 +45,7 @@ describe "Orders Listing", type: :feature, js: true do
       within_row(1) { expect(page).to have_content("R100") }
       within_row(2) { expect(page).to have_content("R200") }
 
-      click_link "Completed At"
+      click_link "Completed At", exact: false
 
       # Completed at desc
       within_row(1) { expect(page).to have_content("R200") }

--- a/backend/spec/features/admin/orders/listing_spec.rb
+++ b/backend/spec/features/admin/orders/listing_spec.rb
@@ -72,7 +72,7 @@ describe "Orders Listing", type: :feature, js: true do
       it "can find the orders belonging to a specific store" do
         main_store, other_store = stores
 
-        click_on "Filter"
+        click_on "Filter Results"
         select2 main_store.name, from: Spree.t(:store)
         click_on "Filter Results"
 
@@ -87,7 +87,7 @@ describe "Orders Listing", type: :feature, js: true do
 
     context "when there's a single store" do
       it "should be able to search orders" do
-        click_on 'Filter'
+        click_on "Filter Results"
         fill_in "q_number_cont", with: "R200"
         click_on 'Filter Results'
         within_row(1) do
@@ -99,7 +99,7 @@ describe "Orders Listing", type: :feature, js: true do
       end
 
       it "should be able to filter on variant_id" do
-        click_on 'Filter'
+        click_on "Filter Results"
         select2_search @order1.products.first.sku, from: Spree.t(:variant)
         click_on 'Filter Results'
 
@@ -123,20 +123,20 @@ describe "Orders Listing", type: :feature, js: true do
         # Regression test for https://github.com/spree/spree/issues/4004
         it "should be able to go from page to page for incomplete orders" do
           10.times { Spree::Order.create email: "incomplete@example.com" }
-          click_on 'Filter'
+          click_on "Filter Results"
           uncheck "q_completed_at_not_null"
           click_on 'Filter Results'
           within(".pagination", match: :first) do
             click_link "2"
           end
           expect(page).to have_content("incomplete@example.com")
-          click_on 'Filter'
+          click_on "Filter Results"
           expect(find("#q_completed_at_not_null")).not_to be_checked
         end
       end
 
       it "should be able to search orders using only completed at input" do
-        click_on 'Filter'
+        click_on "Filter Results"
         fill_in "q_created_at_gt", with: Date.current
 
         # Just so the datepicker gets out of poltergeists way.
@@ -160,7 +160,7 @@ describe "Orders Listing", type: :feature, js: true do
         end
 
         it "only shows the orders with the selected promotion" do
-          click_on 'Filter'
+          click_on "Filter Results"
           fill_in "q_order_promotions_promotion_code_value_cont", with: promotion.codes.first.value
           click_on 'Filter Results'
           within_row(1) { expect(page).to have_content("R100") }
@@ -175,7 +175,7 @@ describe "Orders Listing", type: :feature, js: true do
 
         it "shows both complete and incomplete orders" do
           check "q_completed_at_not_null"
-          click_on 'Filter'
+          click_on "Filter Results"
 
           expect(page).to have_content("R200")
           expect(page).to_not have_content("R300")

--- a/backend/spec/features/admin/orders/new_order_spec.rb
+++ b/backend/spec/features/admin/orders/new_order_spec.rb
@@ -44,7 +44,7 @@ describe "New Order", type: :feature do
     expect(current_path).to eql(spree.admin_order_payments_path(Spree::Order.last))
 
     click_on "Confirm"
-    click_on "Complete"
+    click_on "Complete Order"
 
     expect(current_path).to eql(spree.edit_admin_order_path(Spree::Order.last))
 
@@ -203,7 +203,7 @@ describe "New Order", type: :feature do
     fill_in "Street Address",            with: "100 first lane"
     fill_in "Street Address (cont'd)",   with: "#101"
     fill_in "City",                      with: "Bethesda"
-    fill_in "Zip",                       with: "20170"
+    fill_in "Zip Code",                  with: "20170"
     targetted_select2_search state.name, from: "#s2id_order_#{kind}_address_attributes_state_id"
     fill_in "Phone",                     with: "123-456-7890"
   end

--- a/backend/spec/features/admin/products/edit/images_spec.rb
+++ b/backend/spec/features/admin/products/edit/images_spec.rb
@@ -50,7 +50,7 @@ describe "Product Images", type: :feature do
       visit spree.admin_product_images_path(product)
       expect(page).to have_content("No images found")
 
-      within_fieldset 'Upload Image' do
+      within_fieldset 'Upload Images' do
         # Can also pass multiple files in the array, but SQLite gives a deadlock on insert
         attach_file('image_attachment', [file_path], visible: false)
       end

--- a/backend/spec/features/admin/products/pricing_spec.rb
+++ b/backend/spec/features/admin/products/pricing_spec.rb
@@ -55,7 +55,7 @@ describe 'Pricing' do
             expect(page).to have_content("Search")
           end
         end
-        select variant.options_text, from: "q_variant_id_eq"
+        select variant.options_text, from: "q_variant_id_eq", exact: false
         click_button "Filter Results"
         expect(page).to have_content("20")
         expect(page).to_not have_content("49.99")

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -47,6 +47,7 @@ Capybara.save_path = ENV['CIRCLE_ARTIFACTS'] if ENV['CIRCLE_ARTIFACTS']
 
 require 'capybara/poltergeist'
 Capybara.javascript_driver = :poltergeist
+Capybara.exact = true
 
 ActionView::Base.raise_on_missing_translations = true
 


### PR DESCRIPTION
Capybara's default mode is to allow partial text matching of elements on the page, though it will prefer an exact match if there is one.

In a number of places we were using partial matches without realizing it.

This enforces using exact text matches throughout the admin. Previously we were using the default "smart" inexact behaviour, which would prefer exact text matches, but would allow partial text matches if no exact match existed.

As we add more dynamic content, the former behaviour can cause issues, when the exact text has not yet been added to the page, and a partial candidate is found instead.