### PR TITLE
Remove duplicated require in shipment factory

### DIFF
--- a/core/lib/spree/testing_support/factories/shipment_factory.rb
+++ b/core/lib/spree/testing_support/factories/shipment_factory.rb
@@ -1,7 +1,6 @@
 require 'spree/testing_support/factories/order_factory'
 require 'spree/testing_support/factories/stock_location_factory'
 require 'spree/testing_support/factories/shipping_method_factory'
-require 'spree/testing_support/factories/stock_location_factory'
 
 FactoryGirl.define do
   factory :shipment, class: Spree::Shipment do


### PR DESCRIPTION
It seems to be duplicated with the [line 2](https://github.com/solidusio/solidus/pull/1769/files#diff-bea03bb04c027c609b47ff3987fd9046R2).