### PR TITLE
Specify helper used in CustomerReturnsController

### DIFF
--- a/backend/app/controllers/spree/admin/customer_returns_controller.rb
+++ b/backend/app/controllers/spree/admin/customer_returns_controller.rb
@@ -1,6 +1,7 @@
 module Spree
   module Admin
     class CustomerReturnsController < ResourceController
+      helper 'spree/admin/reimbursement_type'
       belongs_to 'spree/order', find_by: :number
 
       before_action :parent # ensure order gets loaded to support our pseudo parent-child relationship

--- a/backend/app/controllers/spree/admin/customer_returns_controller.rb
+++ b/backend/app/controllers/spree/admin/customer_returns_controller.rb
@@ -1,6 +1,7 @@
 module Spree
   module Admin
     class CustomerReturnsController < ResourceController
+      helper 'spree/admin/reimbursements'
       helper 'spree/admin/reimbursement_type'
       belongs_to 'spree/order', find_by: :number
 

--- a/backend/app/controllers/spree/admin/reimbursements_controller.rb
+++ b/backend/app/controllers/spree/admin/reimbursements_controller.rb
@@ -1,6 +1,8 @@
 module Spree
   module Admin
     class ReimbursementsController < ResourceController
+      helper 'spree/admin/reimbursement_type'
+      helper 'spree/admin/customer_returns'
       belongs_to 'spree/order', find_by: :number
 
       before_action :load_stock_locations, only: :edit


### PR DESCRIPTION
Another fix to make Solidus `config.action_controller.include_all_helpers = false` compatible.

See PR #1496 and PR #1714 for background.