### PR TITLE
Fix shipped_order factory

### DIFF
--- a/core/lib/spree/testing_support/factories/order_factory.rb
+++ b/core/lib/spree/testing_support/factories/order_factory.rb
@@ -119,6 +119,8 @@ FactoryGirl.define do
                   shipped_at: Time.current
                 )
               end
+              # We need to update the shipment_state after all callbacks have run
+              order.update_columns(shipment_state: 'shipped')
               order.reload
             end
           end

--- a/core/spec/lib/spree/core/testing_support/factories/order_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/order_factory_spec.rb
@@ -201,7 +201,8 @@ RSpec.describe 'order factory' do
         expect(order).to have_attributes(
           total: 110,
           payment_total: 110,
-          payment_state: "paid"
+          payment_state: "paid",
+          shipment_state: "shipped"
         )
 
         expect(order.payments.count).to eq 1


### PR DESCRIPTION
A shipped order should have a shipment state of 'shipped'.
Instead the current shipped_order factory has a shipment_state
of 'ready'.