### PR TITLE
Small fix to cart URL for non-root stores

### DIFF
--- a/frontend/app/views/spree/shared/_main_nav_bar.html.erb
+++ b/frontend/app/views/spree/shared/_main_nav_bar.html.erb
@@ -3,7 +3,7 @@
     <li id="home-link" data-hook><%= link_to Spree.t(:home), spree.root_path %></li>
     <li id="link-to-cart" data-hook>
       <noscript>
-        <%= link_to Spree.t(:cart), '/cart' %>
+        <%= link_to Spree.t(:cart), spree.cart_path %>
       </noscript>
       &nbsp;
     </li>


### PR DESCRIPTION
Had a tiny issue with my store mounted at `/shop`.