### PR TITLE
Raise font-size

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/components/_navigation.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_navigation.scss
@@ -14,7 +14,6 @@ nav.menu {
         text-align: left;
         border: 1px solid transparent;
         font-weight: $font-weight-bold;
-        font-size: 90%;
       }
 
       &.active a {

--- a/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
@@ -7,7 +7,7 @@ input[type="time"],
 input[type="url"],
 input[type="number"],
 input[type="tel"],
-textarea, fieldset {
+textarea {
   padding: 7px 10px;
   border: 1px solid $color-txt-brd;
   border-radius: $border-radius;
@@ -204,20 +204,12 @@ span.info {
 }
 
 fieldset {
-  box-shadow: none;
-  box-sizing: border-box;
-  border-color: $color-border;
-  -webkit-box-sizing: border-box;
-  -moz-box-sizing: border-box;
-  margin-left: 0;
-  margin-right: 0;
+  border: 1px solid $color-border;
   position: relative;
   margin-bottom: 35px;
   padding: 10px 0 15px 0;
-  background-color: transparent;
   border-left: none;
   border-right: none;
-  border-radius: 0;
 
   &.no-border-bottom {
     border-bottom: none;
@@ -230,7 +222,6 @@ fieldset {
   }
 
   legend {
-    background-color: $color-1;
     color: $color-2;
     font-size: 16px;
     font-weight: $font-weight-bold;


### PR DESCRIPTION
All our forms are nested in field sets, which have a font-size of 90%. Also our form field font sizes are reduced by 10%. With our base font size of 13px this leads to a 10.5px font size. This is definitely too small for modern screen sizes.

### Before

![solidus 13px](https://cloud.githubusercontent.com/assets/42868/24021022/1d5f8688-0a9f-11e7-8eac-2b306be4d46b.png)

### After

![orders 2017-03-19 21-49-48](https://cloud.githubusercontent.com/assets/42868/24084641/0f9cfe4e-0cee-11e7-87ab-aa485eb374d2.png)


