### PR TITLE
Fix address spec typo

### DIFF
--- a/core/spec/models/spree/address_spec.rb
+++ b/core/spec/models/spree/address_spec.rb
@@ -151,10 +151,10 @@ describe Spree::Address, type: :model do
     context "zipcode not required" do
       before { allow(address).to receive_messages require_zipcode?: false }
 
-      it "shows no errors when phone is blank" do
+      it "shows no errors when zipcode is blank" do
         address.zipcode = ""
         address.valid?
-        expect(address.errors[:zipcode].size).to eq 0
+        expect(address.errors[:zipcode]).to be_blank
       end
     end
   end


### PR DESCRIPTION
* The `it` description was refering to "phone" instead of "zipcode"
* Use `be_blank` instead of `size == 0`