### PR TITLE
Add missing indexes for Spree::Taxon lft and rgt columns

### DIFF
--- a/core/db/migrate/20170317035819_add_lft_and_rgt_indexes_to_taxons.rb
+++ b/core/db/migrate/20170317035819_add_lft_and_rgt_indexes_to_taxons.rb
@@ -1,0 +1,6 @@
+class AddLftAndRgtIndexesToTaxons < ActiveRecord::Migration[5.0]
+  def change
+    add_index :spree_taxons, :lft
+    add_index :spree_taxons, :rgt
+  end
+end


### PR DESCRIPTION
* These are used by `awesome_nested_set` to perform ordering and
  therefore indexes should be added to them