### PR TITLE
Do not run callbacks when deleting dependent inventory units

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -6,7 +6,7 @@ module Spree
     belongs_to :stock_location, class_name: 'Spree::StockLocation'
 
     has_many :adjustments, as: :adjustable, inverse_of: :adjustable, dependent: :delete_all
-    has_many :inventory_units, dependent: :destroy, inverse_of: :shipment
+    has_many :inventory_units, dependent: :delete_all, inverse_of: :shipment
     has_many :shipping_rates, -> { order(:cost) }, dependent: :destroy
     has_many :shipping_methods, through: :shipping_rates
     has_many :state_changes, as: :stateful


### PR DESCRIPTION
An inventory unit should not exist without its line item and its shipment.
The protective callbacks on `Spree::InventoryUnit` just make sure that
one can not destroy an inventory unit for a shipment that cannot be destroyed.

Added a safeguard so that we're not deleting line items with shipped inventory units.