### PR TITLE
Fix complete order factory to have non-pending inventory units

### DIFF
--- a/core/lib/spree/testing_support/factories/order_factory.rb
+++ b/core/lib/spree/testing_support/factories/order_factory.rb
@@ -76,6 +76,9 @@ FactoryGirl.define do
 
         after(:create) do |order|
           order.refresh_shipment_rates
+          order.shipments.each do |shipment|
+            shipment.inventory_units.update_all state: 'on_hand', pending: false
+          end
           order.update_column(:completed_at, Time.current)
         end
 
@@ -96,7 +99,6 @@ FactoryGirl.define do
           after(:create) do |order, evaluator|
             create(evaluator.payment_type, amount: order.total, order: order, state: 'completed')
             order.shipments.each do |shipment|
-              shipment.inventory_units.update_all state: 'on_hand'
               shipment.update_column('state', 'ready')
             end
             order.reload

--- a/core/spec/lib/spree/core/testing_support/factories/order_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/order_factory_spec.rb
@@ -122,6 +122,8 @@ RSpec.describe 'order factory' do
           total: 110,
           state: 'complete'
         )
+        expect(order.inventory_units.where(pending: true)).to be_empty
+        expect(order.inventory_units.where(pending: false)).to_not be_empty
       end
     end
   end

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -753,6 +753,7 @@ describe Spree::Shipment, type: :model do
     before do
       stock_item.set_count_on_hand(10)
       stock_item.update_attributes!(backorderable: false)
+      inventory_unit.update_attributes!(pending: true)
     end
 
     subject { shipment.finalize! }


### PR DESCRIPTION
When an order is completed, all its inventory units are by default
set to `pending: false`. The factory should reflect that.