### PR TITLE
Use UserClassHandle for WalletPaymentSource

### DIFF
--- a/core/app/models/spree/wallet_payment_source.rb
+++ b/core/app/models/spree/wallet_payment_source.rb
@@ -1,5 +1,5 @@
 class Spree::WalletPaymentSource < ActiveRecord::Base
-  belongs_to :user, class_name: Spree.user_class, foreign_key: 'user_id', inverse_of: :wallet_payment_sources
+  belongs_to :user, class_name: Spree::UserClassHandle.new, foreign_key: 'user_id', inverse_of: :wallet_payment_sources
   belongs_to :payment_source, polymorphic: true, inverse_of: :wallet_payment_sources
 
   validates_presence_of :user


### PR DESCRIPTION
We should always use `UserClassHandle` to avoid load order issues.

This works around a warning on Rails 5.1, spotted in the work on #1788