### PR TITLE
Avoid some stubbing in payment spec

### DIFF
--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -17,12 +17,12 @@ describe Spree::Payment, type: :model do
   let(:card) { create :credit_card }
 
   let(:payment) do
-    payment = Spree::Payment.new
-    payment.source = card
-    payment.order = order
-    payment.payment_method = gateway
-    payment.amount = 5
-    payment
+    Spree::Payment.create! do |payment|
+      payment.source = card
+      payment.order = order
+      payment.payment_method = gateway
+      payment.amount = 5
+    end
   end
 
   let(:amount_in_cents) { (payment.amount * 100).round }
@@ -37,11 +37,6 @@ describe Spree::Payment, type: :model do
 
   let(:failed_response) do
     ActiveMerchant::Billing::Response.new(false, '', {}, {})
-  end
-
-  before(:each) do
-    # So it doesn't create log entries every time a processing method is called
-    allow(payment.log_entries).to receive(:create!)
   end
 
   context '.risky' do
@@ -246,8 +241,9 @@ describe Spree::Payment, type: :model do
 
       it "should log the response" do
         payment.save!
-        expect(payment.log_entries).to receive(:create!).with(details: anything)
-        payment.authorize!
+        expect {
+          payment.authorize!
+        }.to change { payment.log_entries.count }.by(1)
       end
 
       describe 'billing_address option' do
@@ -355,8 +351,9 @@ describe Spree::Payment, type: :model do
 
       it "should log the response" do
         payment.save!
-        expect(payment.log_entries).to receive(:create!).with(details: anything)
-        payment.purchase!
+        expect {
+          payment.purchase!
+        }.to change { payment.log_entries.count }.by(1)
       end
 
       context "if successful" do
@@ -532,8 +529,9 @@ describe Spree::Payment, type: :model do
       end
 
       it "should log the response" do
-        expect(payment.log_entries).to receive(:create!).with(details: anything)
-        payment.void_transaction!
+        expect {
+          payment.void_transaction!
+        }.to change { payment.log_entries.count }.by(1)
       end
 
       context "if successful" do
@@ -688,6 +686,8 @@ describe Spree::Payment, type: :model do
         let(:attributes) { attributes_for(:credit_card) }
 
         it "should not try to create profiles on old failed payment attempts" do
+          order.payments.destroy_all
+
           allow_any_instance_of(Spree::Payment).to receive(:payment_method) { gateway }
 
           Spree::PaymentCreate.new(order, {


### PR DESCRIPTION
This stubbing no longer worked under rails 5.1 and was hiding behaviour of our system under test

Part of the work on #1788