### PR TITLE
Change how we log state_changes from OrderUpdater

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -497,6 +497,7 @@ module Spree
         end
       end
     end
+    deprecate :state_changed, deprecator: Spree::Deprecation
 
     def coupon_code=(code)
       @coupon_code = begin

--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -78,9 +78,9 @@ module Spree
     # The +payment_state+ value helps with reporting, etc. since it provides a quick and easy way to locate Orders needing attention.
     def update_payment_state
       log_state_change('payment') do
-        if payments.present? && payments.valid.size == 0 && order.outstanding_balance != 0
+        if payments.present? && payments.valid.empty? && order.outstanding_balance != 0
           order.payment_state = 'failed'
-        elsif order.state == 'canceled' && order.payment_total == 0
+        elsif order.state == 'canceled' && order.payment_total.zero?
           order.payment_state = 'void'
         else
           order.payment_state = 'balance_due' if order.outstanding_balance > 0

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -491,7 +491,9 @@ describe Spree::Order, type: :model do
       order.update_column(:payment_state, 'balance_due')
       order.payment_state = 'paid'
       expect(order.state_changes).to be_empty
-      order.state_changed('payment')
+      Spree::Deprecation.silence do
+        order.state_changed('payment')
+      end
       state_change = order.state_changes.find_by(name: 'payment')
       expect(state_change.previous_state).to eq('balance_due')
       expect(state_change.next_state).to eq('paid')
@@ -500,7 +502,9 @@ describe Spree::Order, type: :model do
     it "does not do anything if state does not change" do
       order.update_column(:payment_state, 'balance_due')
       expect(order.state_changes).to be_empty
-      order.state_changed('payment')
+      Spree::Deprecation.silence do
+        order.state_changed('payment')
+      end
       expect(order.state_changes).to be_empty
     end
   end

--- a/core/spec/models/spree/order_updater_spec.rb
+++ b/core/spec/models/spree/order_updater_spec.rb
@@ -452,20 +452,6 @@ module Spree
       end
     end
 
-    it "state change" do
-      order.shipment_state = 'shipped'
-      state_changes = double
-      allow(order).to receive_messages state_changes: state_changes
-      expect(state_changes).to receive(:create).with(
-        previous_state: nil,
-        next_state: 'shipped',
-        name: 'shipment',
-        user_id: nil
-      )
-
-      order.state_changed('shipment')
-    end
-
     context "completed order" do
       before { allow(order).to receive_messages completed?: true }
 


### PR DESCRIPTION
Previously we used [`Order#state_changed`](https://github.com/solidusio/solidus/blob/84213ccb45010c748aa4d004787fd79d58f5367f/core/app/models/spree/order.rb#L484-L498) which relied on the behaviour of ActiveRecord's `attribute_was`. This behaviour is changing in a future version of rails, and is generating warnings on Rails 5.1.

Using a block is more clear and exactly how it works and doesn't rely on ActiveRecord's dirty API.

Part of the work towards #1788 