### PR TITLE
don't set webkit-tap-highlight-color

### DIFF
--- a/frontend/app/assets/stylesheets/spree/frontend/screen.css.scss
+++ b/frontend/app/assets/stylesheets/spree/frontend/screen.css.scss
@@ -30,9 +30,6 @@ hr {
   border-bottom: $default_border;
 }
 
-/*  j.mp/webkit-tap-highlight-color */
-a:link {-webkit-tap-highlight-color: $link_text_color;}
-
 ins {background-color: $link_text_color; color: $layout_background_color; text-decoration: none;}
 mark {background-color: $link_text_color; color: $layout_background_color; font-style: italic; font-weight: bold;}
 


### PR DESCRIPTION
Similar to the thinking behind https://github.com/solidusio/solidus/pull/1738, this removes customization of the experimental and non-standard `webkit-tap-highlight-color`, which can be nontrivial to override, in favor of simply keeping with browser defaults.