### PR TITLE
Improve page titles in admin

### DIFF
--- a/backend/app/helpers/spree/admin/navigation_helper.rb
+++ b/backend/app/helpers/spree/admin/navigation_helper.rb
@@ -30,7 +30,7 @@ module Spree
         elsif content_for?(:page_title)
           content_for(:page_title)
         elsif admin_breadcrumbs.any?
-          strip_tags(admin_breadcrumbs.last)
+          admin_breadcrumbs.map{ |x| strip_tags(x) }.reverse.join(' - ')
         else
           Spree.t(controller.controller_name, default: controller.controller_name.titleize)
         end


### PR DESCRIPTION
When we introduced breadcrumbs in the admin, we used the last breadcrumb as the page title, unless one was otherwise specified.

This commit changes the title to it to use all of the breadcrumbs, in reverse order, dash-separated.

Before:

    Shipments

After:

    Shipments - #R9876543421 - Orders