### PR TITLE
Remove any whitespace from a promo code.

### DIFF
--- a/core/app/models/spree/promotion_code.rb
+++ b/core/app/models/spree/promotion_code.rb
@@ -6,7 +6,7 @@ class Spree::PromotionCode < Spree::Base
   validates :value, presence: true, uniqueness: { allow_blank: true }
   validates :promotion, presence: true
 
-  before_save :downcase_value
+  before_save :normalize_code
 
   self.whitelisted_ransackable_attributes = ['value']
 
@@ -36,7 +36,7 @@ class Spree::PromotionCode < Spree::Base
 
   private
 
-  def downcase_value
-    self.value = value.downcase
+  def normalize_code
+    self.value = value.downcase.strip
   end
 end

--- a/core/spec/models/spree/promotion_code_spec.rb
+++ b/core/spec/models/spree/promotion_code_spec.rb
@@ -4,13 +4,25 @@ RSpec.describe Spree::PromotionCode do
   context 'callbacks' do
     subject { promotion_code.save }
 
-    describe '#downcase_value' do
-      let(:promotion) { create(:promotion, code: 'NewCoDe') }
+    describe '#normalize_code' do
+      let(:promotion) { create(:promotion, code: code) }
       let(:promotion_code) { promotion.codes.first }
 
-      it 'downcases the value before saving' do
-        subject
-        expect(promotion_code.value).to eq('newcode')
+      before { subject }
+
+      context 'with mixed case' do
+        let(:code) { 'NewCoDe' }
+
+        it 'downcases the value before saving' do
+          expect(promotion_code.value).to eq('newcode')
+        end
+      end
+
+      context 'with extra spacing' do
+        let(:code) { ' new code ' }
+        it 'removes surrounding whitespace' do
+          expect(promotion_code.value).to eq 'new code'
+        end
       end
     end
   end


### PR DESCRIPTION
There is no legit reason to have spaces in codes as the user would have to duplicate the spacing when they entered the code during checkout.

I have gotten real world cases where a store admin has inadvertently included a space before/after the code (due to a copy/paste error), as well as space within the code (due to font size making it hard to
see the space).

I considered putting a validation in place to correct the user rather than silently modifying their code but we are already silently modifying by downcasing the code. Even after being told of a spacing problems,
some users might have difficultly determing where the space is or understanding the error message. In the interest of just doing what they likely mean, I think silently modifying is the lesser of two evils.