### PR TITLE
Replace select2 styling

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/_bootstrap_custom.scss
+++ b/backend/app/assets/stylesheets/spree/backend/_bootstrap_custom.scss
@@ -336,8 +336,8 @@ $dropdown-border-width:          $border-width !default;
 $dropdown-divider-bg:            #e5e5e5 !default;
 
 $dropdown-link-color:            $gray-dark !default;
-$dropdown-link-hover-color:      darken($gray-dark, 5%) !default;
-$dropdown-link-hover-bg:         #f5f5f5 !default;
+$dropdown-link-hover-color:      #fff !default;
+$dropdown-link-hover-bg:         $color-3 !default;
 
 $dropdown-link-active-color:     $component-active-color !default;
 $dropdown-link-active-bg:        $component-active-bg !default;
@@ -516,7 +516,7 @@ $popover-arrow-outer-color:           fade-in($popover-border-color, 0.05) !defa
 
 // Labels
 
-$label-default-bg:            $gray-light !default;
+$label-default-bg:            $color-7 !default;
 $label-primary-bg:            $brand-primary !default;
 $label-success-bg:            $brand-success !default;
 $label-info-bg:               $brand-info !default;

--- a/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
+++ b/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
@@ -1,215 +1,38 @@
 .select2-container {
-  &:hover .select2-choice, &.select2-container-active .select2-choice {
-    background-color: $color-sel-hover-bg !important;
-    border-color: $color-sel-hover-bg !important;
-  }
-
-  &.select2-container-disabled .select2-choice {
-    background-color: $color-sel-disabled-bg !important;
-    border-color: $color-sel-disabled-bg !important;
-    color: $color-sel-disabled-text !important;
-  }
-
   .select2-choice {
-    background-image: none !important;
-    background-color: $color-sel-bg;
-    border: none !important;
-    border-radius: $border-radius;
-    box-shadow: none !important;
-    color: $color-1 !important;
-    font-size: 90%;
+    border: 1px solid $color-txt-brd;
+    border-radius: 2px;
+    background: white;
     height: 31px;
-    line-height: inherit !important;
-    padding: 5px 15px 7px;
 
-    span {
-      display: block;
-      padding: 2px;
+    .select2-arrow {
+      background: transparent;
+      border-left: 0;
     }
 
-    .select2-search-choice-close {
-      @extend .fa;
-      @extend .fa-times;
-      display: none;
-      margin-top: 2px;
-      font-size: 100% !important;
-      background-image: none !important;
-    }
-  }
-
-  &.select2-container-active {
-    .select2-choice {
-      box-shadow: none !important;
-    }
-
-    &.select2-dropdown-open .select2-choice div b {
-      @extend .fa-caret-up
+    >.select2-chosen {
+      color: $color-txt-text;
     }
   }
 }
 
+.select2-search input {
+  background: white;
+}
 
 .select2-drop {
-  box-shadow: none !important;
-  z-index: 1000000;
-  max-width: auto !important;
-  border-top: 1px solid;
-  border-color: $color-sel-hover-bg;
-
-  &.select2-drop-above {
-    border-color: $color-sel-hover-bg;
-  }
+  /* Remove default shadow */
+  box-shadow: none;
 }
 
-.select2-search {
-  @extend .fa;
-  @extend .fa-search;
-
-  font-size: 100%;
-  color: darken($color-border, 15);
-  padding: 0 9px 0 0;
-
-  &:before {
-    @extend [class^="icon-"]:before;
-
-    position: absolute;
-    top: 16px;
-    left: 13px;
-  }
-
-  input {
-    @extend input[type="text"];
-    margin-top: 5px;
-    margin-left: 4px;
-    padding-left: 25px;
-    padding-top: 6px;
-    padding-bottom: 6px;
-    font-family: $font-family-base;
-    font-size: 90%;
-    box-shadow: none;
-    background-image: none;
-  }
-}
-
-.select2-container .select2-choice .select2-arrow {
-  background-image: none;
-  background: transparent;
-  border: 0;
-
-  b {
-    padding-top: 7px;
-    display: block;
-    width: 100%;
-    height: 100%;
-    background: none !important;
-    font-family: FontAwesome;
-    font-weight: 200 !important;
-
-    &:before {
-      content: "\f0d7";
-    }
-  }
+.select2-drop-active {
+  border: 1px solid $color-txt-brd;
+  border-top: 0;
 }
 
 .select2-results {
-  margin: 4px 0;
-  padding: 0 4px;
-
-  li {
-    font-size: 85% !important;
-
-
-    &:nth-child(odd) {
-      background: #efefef;
-    }
-
-    &.select2-highlighted {
-      .select2-result-label {
-        &, .media-heading, .media-content, .customer-email {
-          color: $color-1 !important;
-        }
-      }
-    }
-
-    .select2-result-label {
-      color: $body-color;
-      min-height: 22px;
-      clear: both;
-      overflow: auto;
-
-      .variant-autocomplete-item {
-        .media-content {
-          dd {
-            margin: 0;
-          }
-        }
-      }
-    }
-
-    &.select2-no-results, &.select2-searching {
-      padding: 5px;
-      background-color: transparent;
-      color: $body-color;
-      text-align: center;
-      font-weight: $font-weight-bold;
-    }
-  }
-
-  .select2-highlighted {
-    background-color: $color-sel-bg !important;
-  }
-}
-
-.select2-container-multi {
-  &.select2-container-active, &.select2-dropdown-open {
-    .select2-choices {
-      border-color: $color-sel-hover-bg !important;
-      box-shadow: none;
-      border-bottom-left-radius: 0;
-      border-bottom-right-radius: 0;
-    }
-  }
-  .select2-choices {
-    @extend input[type="text"];
-    padding: 6px 3px 3px 3px;
-    box-shadow: none;
-    background-image: none !important;
-
-    .select2-search-choice {
-      margin: 0 0 3px 3px;
-      background-image: none;
-      background-color: $color-sel-bg;
-      border: none;
-      border-radius: $border-radius;
-      box-shadow: none;
-      color: $color-1 !important;
-      font-size: 85%;
-
-      &:hover {
-        background-color: $color-sel-hover-bg;
-      }
-
-      .select2-search-choice-close {
-        background-image: none !important;
-        font-size: 85% !important;
-        @extend .fa;
-        @extend .fa-times;
-        margin-left: 2px;
-        color: $color-1;
-        &:before {
-          font-size: 11px;
-        }
-      }
-    }
-  }
-}
-
-label .select2-container {
-  margin-top: -6px;
-  .select2-choice {
-    span {
-      text-transform: none;
-      font-weight: normal;
-    }
+  .select2-no-results, .select2-searching {
+    /* Remove light grey background */
+    background: transparent;
   }
 }

--- a/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
+++ b/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
@@ -8,6 +8,11 @@
     .select2-arrow {
       background: transparent;
       border-left: 0;
+      b {
+        // Inline icon taken from bootstrap's custom-select class
+        background: #fff url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAUCAMAAACzvE1FAAAADFBMVEUzMzMzMzMzMzMzMzMKAG/3AAAAA3RSTlMAf4C/aSLHAAAAPElEQVR42q3NMQ4AIAgEQTn//2cLdRKppSGzBYwzVXvznNWs8C58CiussPJj8h6NwgorrKRdTvuV9v16Afn0AYFOB7aYAAAAAElFTkSuQmCC) no-repeat right .75rem center;
+        background-size: 8px 10px;
+      }
     }
 
     >.select2-chosen {

--- a/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
+++ b/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
@@ -3,7 +3,7 @@
     border: $input-btn-border-width solid $input-border-color;
     @include border-radius($input-border-radius);
     background: $input-bg;
-    height: $input-height;
+    height: calc(#{$input-height} + #{2*$input-btn-border-width});
 
     .select2-arrow {
       background: transparent;
@@ -17,6 +17,7 @@
     }
 
     >.select2-chosen {
+      line-height: $input-height;
       color: $input-color;
     }
   }
@@ -42,14 +43,23 @@
   }
 }
 
-.select2-container-multi .select2-choices .select2-search-choice {
-  background: #e4e4e4;
-  border: 0;
-  line-height: 17px; /* Fill height of input */
+.select2-container-multi .select2-choices {
+  .select2-search-choice, .select2-search-field {
+    line-height: 1.35; /* Fill height of input */
+  }
+
+  .select2-search-choice {
+    background: $label-default-bg;
+    border: 0;
+    margin: 2px 0 3px 5px; // adjust the margin to respect the adjusted line height
+  }
 }
 
 .select2-search-choice-close {
-  top: 5px; /* Re-center with our increased line-height*/
+  height: 12px; // fix the height to fit the actual content
+  /* Making the vertical position always respect the height of parent */
+  top: 50%;
+  transform: translateY(-50%);
 }
 
 .select2-search input {
@@ -70,5 +80,13 @@
   .select2-no-results, .select2-searching {
     /* Remove light grey background */
     background: transparent;
+    line-height: 2.5;
+  }
+
+  .select2-highlighted {
+    background-color: $dropdown-link-hover-bg;
+
+    // Ensure all remote results have correct colors on hover
+    * { color: $dropdown-link-hover-color }
   }
 }

--- a/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
+++ b/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
@@ -21,6 +21,14 @@
   }
 }
 
+.select2-container-active, .select2-dropdown-open {
+  .select2-choices.select2-choices, /* Needs extra specificity */
+  .select2-choice {
+    box-shadow: none; /* Remove default outline */
+    border-color: $input-border-focus;
+  }
+}
+
 .select2-container-multi .select2-choices .select2-search-choice {
   background: #e4e4e4;
   border: 0;
@@ -41,7 +49,7 @@
 }
 
 .select2-drop-active {
-  border: 1px solid $color-txt-brd;
+  border: 1px solid $input-border-focus;
   border-top: 0;
 }
 

--- a/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
+++ b/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
@@ -1,5 +1,5 @@
 .select2-container {
-  .select2-choice {
+  .select2-choice, .select2-choices {
     border: 1px solid $color-txt-brd;
     border-radius: 2px;
     background: white;
@@ -14,6 +14,16 @@
       color: $color-txt-text;
     }
   }
+}
+
+.select2-container-multi .select2-choices .select2-search-choice {
+  background: #e4e4e4;
+  border: 0;
+  line-height: 17px; /* Fill height of input */
+}
+
+.select2-search-choice-close {
+  top: 5px; /* Re-center with our increased line-height*/
 }
 
 .select2-search input {

--- a/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
+++ b/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
@@ -9,9 +9,10 @@
       background: transparent;
       border-left: 0;
       b {
+        // Need to be !important to override media query select2 defaults
         // Inline icon taken from bootstrap's custom-select class
-        background: #fff url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAUCAMAAACzvE1FAAAADFBMVEUzMzMzMzMzMzMzMzMKAG/3AAAAA3RSTlMAf4C/aSLHAAAAPElEQVR42q3NMQ4AIAgEQTn//2cLdRKppSGzBYwzVXvznNWs8C58CiussPJj8h6NwgorrKRdTvuV9v16Afn0AYFOB7aYAAAAAElFTkSuQmCC) no-repeat right .75rem center;
-        background-size: 8px 10px;
+        background: #fff url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAUCAMAAACzvE1FAAAADFBMVEUzMzMzMzMzMzMzMzMKAG/3AAAAA3RSTlMAf4C/aSLHAAAAPElEQVR42q3NMQ4AIAgEQTn//2cLdRKppSGzBYwzVXvznNWs8C58CiussPJj8h6NwgorrKRdTvuV9v16Afn0AYFOB7aYAAAAAElFTkSuQmCC) no-repeat right .75rem center !important;
+        background-size: 8px 10px !important;
       }
     }
 

--- a/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
+++ b/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
@@ -1,9 +1,9 @@
 .select2-container {
   .select2-choice, .select2-choices {
-    border: 1px solid $color-txt-brd;
-    border-radius: 2px;
-    background: white;
-    height: 31px;
+    border: $input-btn-border-width solid $input-border-color;
+    @include border-radius($input-border-radius);
+    background: $input-bg;
+    height: $input-height;
 
     .select2-arrow {
       background: transparent;
@@ -16,7 +16,7 @@
     }
 
     >.select2-chosen {
-      color: $color-txt-text;
+      color: $input-color;
     }
   }
 }
@@ -49,7 +49,7 @@
 }
 
 .select2-drop-active {
-  border: 1px solid $input-border-focus;
+  border: $input-btn-border-width solid $input-border-focus;
   border-top: 0;
 }
 

--- a/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
+++ b/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
@@ -22,6 +22,18 @@
   }
 }
 
+.select2-container .select2-choice .select2-search-choice-close {
+  @extend .fa;
+  @extend .fa-times;
+  color: #333; /* matches bootstrap's custom-select arrow */
+
+  /* See https://github.com/solidusio/solidus/pull/1314 */
+  display: none;
+
+  /* Hide the default icon */
+  background-image: none;
+}
+
 .select2-container-active, .select2-dropdown-open {
   .select2-choices.select2-choices, /* Needs extra specificity */
   .select2-choice {

--- a/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
+++ b/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
@@ -55,7 +55,7 @@
   }
 }
 
-.select2-search-choice-close {
+.select2-container-multi .select2-search-choice-close {
   height: 12px; // fix the height to fit the actual content
   /* Making the vertical position always respect the height of parent */
   top: 50%;


### PR DESCRIPTION
A year ago I submitted a similar PR (#861) which removed the select2 styling. At the time we tabled it because we intended to upgrade to select2 4.0, from which we preferred the styles. I no longer think we will be performing that upgrade (see #763), so giving this another shot.

The existing styles we had don't match the visual language we used for the rest of our inputs (flat, thin border, white background) and instead more closely matched buttons (solid blue background) which have a different purpose.

This replaces our existing custom select2 styles with much simpler styles intended to better match our other input elements. This also matches the look of [bootstrap-styled select elements](https://v4-alpha.getbootstrap.com/components/forms/#form-controls), which would allow us to use those in the future.

## After
![](http://i.hawth.ca/s/2XTmBuls.png)

## Before
![](http://i.hawth.ca/s/7yWGf1uH.png)

## Todo

* [x] Improve styling of multi-selects (ex. taxons and option types on a product)
* [x] Improve use of icons (search, clear, spinner). Old styles used font awesome, maybe bring those back