### PR TITLE
Do not refresh shipping rates everytime the order is viewed in the admin

### DIFF
--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -76,16 +76,9 @@ module Spree
 
       def edit
         require_ship_address
-
-        unless @order.completed?
-          @order.refresh_shipment_rates
-        end
       end
 
       def cart
-        unless @order.completed?
-          @order.refresh_shipment_rates
-        end
         if @order.shipped_shipments.count > 0
           redirect_to edit_admin_order_url(@order)
         end

--- a/backend/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -113,6 +113,7 @@ describe Spree::Admin::OrdersController, type: :controller do
     end
 
     # Regression test for https://github.com/spree/spree/issues/3684
+    # Rendering a form should under no circumstance mutate the order
     context "#edit" do
       it "does not refresh rates if the order is completed" do
         allow(order).to receive_messages completed?: true
@@ -120,9 +121,9 @@ describe Spree::Admin::OrdersController, type: :controller do
         get :edit, params: { id: order.number }
       end
 
-      it "does refresh the rates if the order is incomplete" do
+      it "does not refresh the rates if the order is incomplete" do
         allow(order).to receive_messages completed?: false
-        expect(order).to receive :refresh_shipment_rates
+        expect(order).not_to receive :refresh_shipment_rates
         get :edit, params: { id: order.number }
       end
 


### PR DESCRIPTION
Mutating the order before rendering the edit form is strange. Also,
rates are refreshed when customer details are changed[1] as well as before the payment step.

[1] https://github.com/solidusio/solidus/blob/master/backend/app/controllers/spree/admin/orders/customer_details_controller.rb#L32