### PR TITLE
Do not consider pending inventory units cancelable

### DIFF
--- a/core/app/models/spree/inventory_unit.rb
+++ b/core/app/models/spree/inventory_unit.rb
@@ -30,7 +30,7 @@ module Spree
     scope :returned, -> { where state: 'returned' }
     scope :canceled, -> { where(state: 'canceled') }
     scope :not_canceled, -> { where.not(state: 'canceled') }
-    scope :cancelable, -> { where(state: Spree::InventoryUnit::CANCELABLE_STATES) }
+    scope :cancelable, -> { where(state: Spree::InventoryUnit::CANCELABLE_STATES, pending: false) }
     scope :backordered_per_variant, ->(stock_item) do
       includes(:shipment, :order)
         .where("spree_shipments.state != 'canceled'").references(:shipment)

--- a/core/spec/models/spree/inventory_unit_spec.rb
+++ b/core/spec/models/spree/inventory_unit_spec.rb
@@ -5,6 +5,15 @@ describe Spree::InventoryUnit, type: :model do
   let(:stock_item) { stock_location.stock_items.order(:id).first }
   let(:line_item) { create(:line_item, variant: stock_item.variant) }
 
+  describe ".cancelable" do
+    let!(:pending_unit) { create(:inventory_unit, pending: true) }
+    let!(:non_pending_unit) { create(:inventory_unit, pending: false) }
+
+    subject { described_class.cancelable }
+
+    it { is_expected.to contain_exactly(non_pending_unit) }
+  end
+
   context "#backordered_for_stock_item" do
     let(:order) do
       order = create(:order, state: 'complete', ship_address: create(:ship_address))


### PR DESCRIPTION
Before an order is complete, all its inventory units are marked as "pending". Once
the order passes the `complete` step, the inventory units' `pending` attribute is
set to false.

Item cancelations were designed for completed orders only, as before that, one could
just change inventory on line items. Therefore, we should not consider pending inventory
units as cancelable.