### PR TITLE
Don't display inactive payment methods on frontend or backend

### DIFF
--- a/backend/app/controllers/spree/admin/payments_controller.rb
+++ b/backend/app/controllers/spree/admin/payments_controller.rb
@@ -78,7 +78,7 @@ module Spree
 
       def load_data
         @amount = params[:amount] || load_order.total
-        @payment_methods = Spree::PaymentMethod.available_to_admin
+        @payment_methods = Spree::PaymentMethod.active.available_to_admin
         if @payment && @payment.payment_method
           @payment_method = @payment.payment_method
         else

--- a/backend/spec/controllers/spree/admin/payments_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/payments_controller_spec.rb
@@ -75,14 +75,28 @@ module Spree
       describe '#new' do
         # Regression test for https://github.com/spree/spree/issues/3233
         context "with a backend payment method" do
-          before do
-            @payment_method = create(:check_payment_method, available_to_admin: true)
+          context "and the payment method is active" do
+            before do
+              @payment_method = create(:check_payment_method, available_to_admin: true)
+            end
+
+            it "loads the payment method" do
+              get :new, params: { order_id: order.number }
+              expect(response.status).to eq(200)
+              expect(assigns[:payment_methods]).to include(@payment_method)
+            end
           end
 
-          it "loads backend payment methods" do
-            get :new, params: { order_id: order.number }
-            expect(response.status).to eq(200)
-            expect(assigns[:payment_methods]).to include(@payment_method)
+          context "and the payment method is inactive" do
+            before do
+              @payment_method = create(:check_payment_method, available_to_admin: true, active: false)
+            end
+
+            it "does not load the payment method", :pending do
+              get :new, params: { order_id: order.number }
+              expect(response.status).to eq(200)
+              expect(assigns[:payment_methods]).to be_empty
+            end
           end
         end
       end

--- a/backend/spec/controllers/spree/admin/payments_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/payments_controller_spec.rb
@@ -92,7 +92,7 @@ module Spree
               @payment_method = create(:check_payment_method, available_to_admin: true, active: false)
             end
 
-            it "does not load the payment method", :pending do
+            it "does not load the payment method" do
               get :new, params: { order_id: order.number }
               expect(response.status).to eq(200)
               expect(assigns[:payment_methods]).to be_empty

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -444,6 +444,7 @@ module Spree
 
     def available_payment_methods
       @available_payment_methods ||= Spree::PaymentMethod
+        .active
         .available_to_store(store)
         .available_to_users
         .order(:position)

--- a/core/app/models/spree/payment_method.rb
+++ b/core/app/models/spree/payment_method.rb
@@ -17,7 +17,10 @@ module Spree
     scope :active, -> { where(active: true) }
     scope :available_to_users, -> { where(available_to_users: true) }
     scope :available_to_admin, -> { where(available_to_admin: true) }
-    scope :available_to_store, -> (store) { (store.present? && store.payment_methods.empty?) ? self : store.payment_methods }
+    scope :available_to_store, ->(store) do
+      raise ArgumentError, "You must provide a store" if store.nil?
+      store.payment_methods.empty? ? all : where(id: store.payment_method_ids)
+    end
 
     include Spree::Preferences::StaticallyConfigurable
 

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -538,7 +538,7 @@ describe Spree::Order, type: :model do
       expect(order.available_payment_methods).to include(payment_method)
     end
 
-    it "does not include inactive payment methods", :pending do
+    it "does not include inactive payment methods" do
       Spree::PaymentMethod.create!({
         name: "Fake",
         active: false,

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -538,6 +538,16 @@ describe Spree::Order, type: :model do
       expect(order.available_payment_methods).to include(payment_method)
     end
 
+    it "does not include inactive payment methods", :pending do
+      Spree::PaymentMethod.create!({
+        name: "Fake",
+        active: false,
+        available_to_users: true,
+        available_to_admin: true
+      })
+      expect(order.available_payment_methods.count).to eq(0)
+    end
+
     context "with more than one payment method" do
       subject { order.available_payment_methods }
 

--- a/core/spec/models/spree/payment_method_spec.rb
+++ b/core/spec/models/spree/payment_method_spec.rb
@@ -67,6 +67,22 @@ describe Spree::PaymentMethod, type: :model do
 
       it { is_expected.to contain_exactly(payment_method_back_display, payment_method_both_display, payment_method_nil_display)}
     end
+
+    context "when searching for payment methods available to a store" do
+      subject { Spree::PaymentMethod.available_to_store(store) }
+
+      context "when the store is nil" do
+        let(:store) { nil }
+        it "raises an argument error" do
+          expect { subject }.to raise_error(ArgumentError, "You must provide a store")
+        end
+      end
+
+      context "when the store exists" do
+        let(:store) { create(:store, payment_methods: [payment_method_back_display]) }
+        it { is_expected.to contain_exactly(payment_method_back_display) }
+      end
+    end
   end
 
   describe ".available" do


### PR DESCRIPTION
## The issue
After upgrading to Solidus 2.1, I noticed that my inactive payment methods were being displayed on the payment page in checkout and the `payments#new` page in the admin. The issue was introduced in #1540 because the `Spree::PaymentMethod.available` scope used to filter payment methods by `active`, but the new `available_to_users` and `available_to_admin` scopes only look at their respective attributes on the payment method. The `Spree::Order#available_payment_methods` method wasn't updated to include the `active` scope accordingly. Similarly, the `load_data` method in the admin payment methods controller is missing the `active` scope.

While writing the failing spec for this, I noticed that the `available_to_store` scope was not behaving as expected. It returned `self` if the store did not have any payment methods, which presumably was expected to return the current scope, but actually returns the `Spree::PaymentMethod` class constant. This wasn't breaking specs because we chained other scopes that would return payment methods as expected.

## The fix
I've added the `active` scope to `#available_payment_methods` and in `#load_data` to ensure we don't include inactive payment methods.

I also updated the `available_to_store` scope to raise an `ArgumentError` if the store provided is nil, and return all payment methods in the current scope if the store doesn't have any payment methods. I added specs that should catch this issue in the future.