### PR TITLE
Use `order` instead of `sort_by` when getting available payment methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Solidus 2.2.0 (master, unreleased)
 
+*   `Spree::Order#available_payment_methods now returns an `ActiveRecord::Relation`
+    object instead of an array.
+    [#1802](https://github.com/solidusio/solidus/pull/1802)
+
 *   Promotion and Shipping calculators can be created or have their type
     changed without saving and reloading the page.
     [#1618](https://github.com/solidusio/solidus/pull/1618)

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -446,7 +446,7 @@ module Spree
       @available_payment_methods ||= Spree::PaymentMethod
         .available_to_store(store)
         .available_to_users
-        .sort_by(&:position)
+        .order(:position)
     end
 
     def insufficient_stock_lines

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -551,7 +551,7 @@ describe Spree::Order, type: :model do
       end
 
       it "respects the order of methods based on position" do
-        expect(subject).to eql([second_method, first_method])
+        expect(subject).to eq([second_method, first_method])
       end
     end
 


### PR DESCRIPTION
The original implementation of `Spree::PaymentMethod.available` used `.select` which would turn the ActiveRecord::Relation object into an array and meant we had to use `sort_by` here.

In #1540 `available` was deprecated in favour of `available_to_users` and `available_to_admin`, each of which returns an ActiveRecord::Relation object. That means we can use `order` to do the sorting in SQL, which also allows users to chain more scopes onto the return value if they wish.

Note: I had to change the spec to use `eq` instead of `eql`, since the latter won't do type conversions and the spec will fail because we get an ActiveRecord::Relation instead of an Array.