### PR TITLE
Fix Spree::Admin::VariantsController#index for deleted products

### DIFF
--- a/backend/app/controllers/spree/admin/variants_controller.rb
+++ b/backend/app/controllers/spree/admin/variants_controller.rb
@@ -55,6 +55,11 @@ module Spree
       def redirect_on_empty_option_values
         redirect_to admin_product_variants_url(params[:product_id]) if @product.empty_option_values?
       end
+
+      def parent
+        @parent ||= Spree::Product.with_deleted.find_by(slug: params[:product_id])
+        @product = @parent
+      end
     end
   end
 end

--- a/backend/spec/controllers/spree/admin/variants_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/variants_controller_spec.rb
@@ -27,25 +27,25 @@ module Spree
           end
         end
 
-        context "assigning @collection" do
+        context "the value of @collection" do
           let!(:variant) { create(:variant, product: product) }
           let!(:deleted_variant) { create(:variant, product: product) }
 
           context "with deleted variants" do
             before { deleted_variant.destroy }
 
-            context "deleted is not requested" do
-              it "does not assign deleted variants for a requested product" do
+            context "when deleted is not requested" do
+              it "excludes deleted variants" do
                 subject
                 expect(assigns(:collection)).to include variant
                 expect(assigns(:collection)).not_to include deleted_variant
               end
             end
 
-            context "deleted is requested" do
+            context "when deleted is requested" do
               let(:params) { { product_id: product.slug, deleted: "on" } }
 
-              it "assigns deleted along with non-deleted variants for a requested product" do
+              it "includes deleted variants" do
                 subject
                 expect(assigns(:collection)).to include variant
                 expect(assigns(:collection)).to include deleted_variant

--- a/backend/spec/controllers/spree/admin/variants_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/variants_controller_spec.rb
@@ -9,20 +9,24 @@ module Spree
         let(:product) { create(:product) }
         let!(:variant_1) { create(:variant, product: product) }
         let!(:variant_2) { create(:variant, product: product) }
+        let(:params) { { product_id: product.slug } }
 
         before { variant_2.destroy }
 
+        subject { get :index, params: params }
+
         context "deleted is not requested" do
           it "does not assign deleted variants for a requested product" do
-            get :index, params: { product_id: product.slug }
+            subject
             expect(assigns(:collection)).to include variant_1
             expect(assigns(:collection)).not_to include variant_2
           end
         end
 
         context "deleted is requested" do
+          let(:params) { { product_id: product.slug, deleted: "on" } }
           it "assigns deleted along with non-deleted variants for a requested product" do
-            get :index, params: { product_id: product.slug, deleted: "on" }
+            subject
             expect(assigns(:collection)).to include variant_1
             expect(assigns(:collection)).to include variant_2
           end

--- a/backend/spec/controllers/spree/admin/variants_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/variants_controller_spec.rb
@@ -7,28 +7,34 @@ module Spree
 
       describe "#index" do
         let(:product) { create(:product) }
-        let!(:variant_1) { create(:variant, product: product) }
-        let!(:variant_2) { create(:variant, product: product) }
         let(:params) { { product_id: product.slug } }
-
-        before { variant_2.destroy }
 
         subject { get :index, params: params }
 
-        context "deleted is not requested" do
-          it "does not assign deleted variants for a requested product" do
-            subject
-            expect(assigns(:collection)).to include variant_1
-            expect(assigns(:collection)).not_to include variant_2
-          end
-        end
+        context "assigning @collection" do
+          let!(:variant) { create(:variant, product: product) }
+          let!(:deleted_variant) { create(:variant, product: product) }
 
-        context "deleted is requested" do
-          let(:params) { { product_id: product.slug, deleted: "on" } }
-          it "assigns deleted along with non-deleted variants for a requested product" do
-            subject
-            expect(assigns(:collection)).to include variant_1
-            expect(assigns(:collection)).to include variant_2
+          context "with deleted variants" do
+            before { deleted_variant.destroy }
+
+            context "deleted is not requested" do
+              it "does not assign deleted variants for a requested product" do
+                subject
+                expect(assigns(:collection)).to include variant
+                expect(assigns(:collection)).not_to include deleted_variant
+              end
+            end
+
+            context "deleted is requested" do
+              let(:params) { { product_id: product.slug, deleted: "on" } }
+
+              it "assigns deleted along with non-deleted variants for a requested product" do
+                subject
+                expect(assigns(:collection)).to include variant
+                expect(assigns(:collection)).to include deleted_variant
+              end
+            end
           end
         end
       end

--- a/backend/spec/controllers/spree/admin/variants_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/variants_controller_spec.rb
@@ -11,6 +11,22 @@ module Spree
 
         subject { get :index, params: params }
 
+        context "the value of @parent" do
+          it "is the product" do
+            subject
+            expect(assigns(:parent)).to eq product
+          end
+
+          context "with a deleted product" do
+            before { product.destroy! }
+
+            it "is the product" do
+              subject
+              expect(assigns(:parent)).to eq product
+            end
+          end
+        end
+
         context "assigning @collection" do
           let!(:variant) { create(:variant, product: product) }
           let!(:deleted_variant) { create(:variant, product: product) }


### PR DESCRIPTION
Fixes https://github.com/solidusio/solidus/issues/1803

When a `Product` was deleted, `@parent` would not be set correctly when accessing `Spree::Admin::VariantsController#index`. Adding the `with_deleted` scope for the assignment to `Spree::Admin::ResourceController#parent` addresses this problem.

The heart of the change happens in https://github.com/solidusio/solidus/pull/1804/commits/dec876c158abd343fcd2c41b3153744a0f724e7d while the rest of the commits clean up the specs for `Spree::Admin::VariantsController`.