### PR TITLE
Set belongs_to_required_by_default = false

### DIFF
--- a/core/app/models/spree/base.rb
+++ b/core/app/models/spree/base.rb
@@ -4,6 +4,8 @@ class Spree::Base < ActiveRecord::Base
 
   include Spree::RansackableAttributes
 
+  self.belongs_to_required_by_default = false
+
   def initialize_preference_defaults
     if has_attribute?(:preferences)
       self.preferences = default_preferences.merge(preferences)


### PR DESCRIPTION
As of Rails 5, belongs_to is now required by default. Our models, including those in extensions and applications, aren't ready for this.

In Rails 5.0 there seems to be some bug that was preventing this new default from affecting Spree::Base models.

    > Spree::Base.belongs_to_required_by_default
    => nil
    > config.active_record.belongs_to_required_by_default
    => true

In Rails 5.1 this seems to be fixed so we need to be explicit about what we use. We might as well be explicit in Rails 5.0 anyways.

cc @tvdeyen 