### PR TITLE
Make our form/button styles match bootstrap's

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/_bootstrap_custom.scss
+++ b/backend/app/assets/stylesheets/spree/backend/_bootstrap_custom.scss
@@ -289,8 +289,8 @@ $input-padding-y:                .375rem !default;
 $input-bg:                       #fff !default;
 $input-bg-disabled:              $gray-lighter !default;
 
-$input-color:                    $gray !default;
-$input-border-color:             #ccc !default;
+$input-color:                    $color-txt-text !default;
+$input-border-color:             $color-txt-brd !default;
 $input-btn-border-width:         $border-width !default; // For form controls and buttons
 $input-box-shadow:               inset 0 1px 1px rgba(0,0,0,.075) !default;
 
@@ -298,7 +298,7 @@ $input-border-radius:            $border-radius !default;
 $input-border-radius-lg:         $border-radius-lg !default;
 $input-border-radius-sm:         $border-radius-sm !default;
 
-$input-border-focus:             #66afe9 !default;
+$input-border-focus:             $color-txt-hover-brd !default;
 $input-box-shadow-focus:         rgba(102,175,233,.6) !default;
 
 $input-color-placeholder:        #999 !default;

--- a/backend/app/assets/stylesheets/spree/backend/globals/_variables.scss
+++ b/backend/app/assets/stylesheets/spree/backend/globals/_variables.scss
@@ -104,8 +104,11 @@ $color-sel-disabled-bg:          $color-7 !default;
 $color-sel-disabled-text:        $color-4 !default;
 
 // Text inputs colors
+@include solidus-deprecated-variable("color-txt-brd", "input-border-color");
 $color-txt-brd:                  $color-border !default;
+@include solidus-deprecated-variable("color-txt-text", "input-color");
 $color-txt-text:                 $color-3 !default;
+@include solidus-deprecated-variable("color-txt-hover-brd", "input-border-focus");
 $color-txt-hover-brd:            $color-2 !default;
 
 // States label colors

--- a/backend/app/assets/stylesheets/spree/backend/globals/_variables.scss
+++ b/backend/app/assets/stylesheets/spree/backend/globals/_variables.scss
@@ -33,9 +33,8 @@ $color-headers:                  $color-4 !default;
 $color-link:                     $color-3 !default;
 @include solidus-deprecated-variable("color-link-hover", "link-hover-color");
 $color-link-hover:               $color-2 !default;
-$color-link-active:              $color-2 !default;
+@include solidus-deprecated-variable("color-link-focus", "link-hover-color");
 $color-link-focus:               $color-2 !default;
-$color-link-visited:             $color-3 !default;
 $color-border:                   very-light($color-3, 12) !default;
 
 // Basic navigation colors

--- a/backend/app/assets/stylesheets/spree/backend/globals/mixins/_line_through.scss
+++ b/backend/app/assets/stylesheets/spree/backend/globals/mixins/_line_through.scss
@@ -1,4 +1,4 @@
-@mixin line-through($color: $color-2, $background: $color-1) {
+@mixin line-through($color: $color-2, $background: $body-bg) {
   position: relative;
   text-align: center;
 

--- a/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
@@ -196,12 +196,7 @@ fieldset {
     }
 
     button, .button, input[type="submit"], input[type="button"] {
-      border-radius: $border-radius;
       box-shadow: 0 0 0 15px $body-bg;
-
-      &:hover {
-        border-color: $color-1;
-      }
     }
 
     // Always make sure the choices at the bottom of a fieldset are spaced out

--- a/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
@@ -13,7 +13,6 @@ textarea {
   border: $input-btn-border-width solid $input-border-color;
   border-radius: $input-border-radius;
   background: $input-bg;
-  font-size: 90%;
 
   &:focus {
     border-color: $input-border-focus;

--- a/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
@@ -32,45 +32,6 @@ textarea {
   width: 100%;
 }
 
-.input-group {
-  position: relative;
-  display: table;
-  border-collapse: separate;
-
-  .form-control,
-  .input-group-addon {
-    display: table-cell;
-
-    &:first-child {
-      border-top-right-radius: 0;
-      border-bottom-right-radius: 0;
-    }
-    &:last-child {
-      border-top-left-radius: 0;
-      border-bottom-left-radius: 0;
-    }
-  }
-
-  .form-control {
-    width: 100%;
-  }
-
-  .input-group-addon {
-    padding: 6px 10px;
-    border: 1px solid #cee1f4;
-    background: #eff5fc;
-    border-radius: 3px;
-
-    &:first-child {
-      border-right: none;
-    }
-
-    &:last-child {
-      border-left: none;
-    }
-  }
-}
-
 label {
   font-weight: $font-weight-bold;
   font-size: 90%;

--- a/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
@@ -214,31 +214,6 @@ fieldset {
       margin-left: 2em;
     }
   }
-
-  &.labels-inline {
-    .field {
-      margin-bottom: 0;
-      display: table;
-      width: 100%;
-
-      label, input {
-        display: table-cell !important;
-      }
-      input {
-        width: 100%;
-      }
-
-      &.checkbox {
-        input {
-          width: auto !important
-        }
-      }
-    }
-    .actions {
-      padding: 0;
-      text-align: right;
-    }
-  }
 }
 
 .form-actions {

--- a/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
@@ -63,39 +63,16 @@ label {
 input[type="submit"],
 input[type="button"],
 button, .button {
-  display: inline-block;
-  padding: 6px 15px;
-  border: none;
-  border-radius: $border-radius;
-  background-color: $color-btn-bg;
-  color: $color-btn-text;
-  font-weight: $font-weight-bold !important;
-  white-space: nowrap;
-  line-height: $line-height;
+  @extend .btn;
+  @include button-variant($btn-primary-color, $btn-primary-bg, $btn-primary-border);
 
   &:before {
     font-weight: normal !important;
   }
 
-  &:visited, &:active, &:focus { color: $color-btn-text }
-
-  &:hover {
-    background-color: $color-btn-hover-bg;
-    color: $color-btn-hover-text;
-  }
-
-  &:active:focus {
-    box-shadow: 0 0 8px 0 darken($color-btn-hover-bg, 5) inset;
-  }
-
   &.fullwidth {
     width: 100%;
     text-align: center;
-  }
-
-  &[disabled], &.disabled {
-    background-color: #c2c4c7;
-    cursor: default;
   }
 }
 

--- a/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
@@ -9,17 +9,18 @@ input[type="number"],
 input[type="tel"],
 textarea {
   padding: 7px 10px;
-  border: 1px solid $color-txt-brd;
-  border-radius: $border-radius;
-  color: $color-txt-text;
+  color: $input-color;
+  border: 1px solid $input-border-color;
+  border-radius: $input-border-radius;
+  background: $input-bg;
   font-size: 90%;
 
   &:focus {
-    border-color: $color-txt-hover-brd;
+    border-color: $input-border-focus;
   }
 
-  &[disabled] {
-    opacity: 0.7;
+  &:disabled {
+    background: $input-bg-disabled;
   }
 }
 

--- a/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
@@ -8,15 +8,16 @@ input[type="url"],
 input[type="number"],
 input[type="tel"],
 textarea {
-  padding: 7px 10px;
+  padding: $input-padding-y $input-padding-x;
   color: $input-color;
-  border: 1px solid $input-border-color;
+  border: $input-btn-border-width solid $input-border-color;
   border-radius: $input-border-radius;
   background: $input-bg;
   font-size: 90%;
 
   &:focus {
     border-color: $input-border-focus;
+    outline: 0;
   }
 
   &:disabled {

--- a/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
@@ -197,12 +197,7 @@ fieldset {
 
     button, .button, input[type="submit"], input[type="button"] {
       border-radius: $border-radius;
-
-      -webkit-box-shadow: 0 0 0 15px $body-bg;
-         -moz-box-shadow: 0 0 0 15px $body-bg;
-          -ms-box-shadow: 0 0 0 15px $body-bg;
-           -o-box-shadow: 0 0 0 15px $body-bg;
-              box-shadow: 0 0 0 15px $body-bg;
+      box-shadow: 0 0 0 15px $body-bg;
 
       &:hover {
         border-color: $color-1;

--- a/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
@@ -22,6 +22,12 @@ textarea {
   &:disabled {
     background: $input-bg-disabled;
   }
+
+  &::placeholder {
+    color: $input-color-placeholder;
+    // Override Firefox's unusual default opacity; see https://github.com/twbs/bootstrap/pull/11526.
+    opacity: 1;
+  }
 }
 
 textarea {

--- a/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
@@ -253,11 +253,11 @@ fieldset {
     button, .button, input[type="submit"], input[type="button"] {
       border-radius: $border-radius;
 
-      -webkit-box-shadow: 0 0 0 15px $color-1;
-         -moz-box-shadow: 0 0 0 15px $color-1;
-          -ms-box-shadow: 0 0 0 15px $color-1;
-           -o-box-shadow: 0 0 0 15px $color-1;
-              box-shadow: 0 0 0 15px $color-1;
+      -webkit-box-shadow: 0 0 0 15px $body-bg;
+         -moz-box-shadow: 0 0 0 15px $body-bg;
+          -ms-box-shadow: 0 0 0 15px $body-bg;
+           -o-box-shadow: 0 0 0 15px $body-bg;
+              box-shadow: 0 0 0 15px $body-bg;
 
       &:hover {
         border-color: $color-1;

--- a/backend/app/assets/stylesheets/spree/backend/shared/_layout.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_layout.scss
@@ -56,7 +56,6 @@ body {
 }
 
 #content {
-  background-color: $color-1;
   position: relative;
   z-index: 0;
   padding: 0;

--- a/backend/app/assets/stylesheets/spree/backend/shared/_tables.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_tables.scss
@@ -197,18 +197,5 @@ table {
     &.no-border-top tr:first-child td {
       border-top: none;
     }
-
-    &.grand-total {
-      td {
-        border-color: $color-2 !important;
-        font-size: 110%;
-        font-weight: $font-weight-bold;
-        background-color: lighten($color-2, 50);
-      }
-      .total {
-        background-color: $color-2;
-        color: $color-1;
-      }
-    }
   }
 }

--- a/backend/app/assets/stylesheets/spree/backend/shared/_typography.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_typography.scss
@@ -12,25 +12,6 @@ hr {
   border-left: none;
 }
 
-// links
-//--------------------------------------------------------------
-a {
-  line-height: inherit;
-
-  &:active {
-    text-decoration: none;
-  }
-  &:visited {
-    color: $color-link-visited;
-  }
-  &:focus {
-    color: $color-link-focus;
-  }
-  &:active {
-    color: $color-link-active;
-  }
-}
-
 // Headings
 //--------------------------------------------------------------
 


### PR DESCRIPTION
This makes our forms (inputs and buttons) match those using bootstrap classes (`.btn` and `.form-control`). This should allow us to progressively change our current forms markup to bootstrap.

Similar to the changes in #1780, bootstrap variables are set to the legacy styles' values.

Buttons are styled as bootstrap buttons using `@extend`. `@extend` isn't an ideal tool to use, but I looked at the CSS products and it was okay here.

This necessitated one change: buttons hover color is now dark blue as it's [hardcoded in bootstrap](https://github.com/twbs/bootstrap/blob/v4-dev/scss/mixins/_buttons.scss#L7) to be 10% darker than the non-hovered BG. I hope this is okay. The new style is nicer. It currently disagrees with the select2 colours, but that will be fixed by #1797 

I tried using `@extend` for the form inputs, but the CSS produced was ridiculous. We also don't want some of the styles that would imply (like `width: 100%`). Instead I've just used the bootstrap variables here and pulled in their `placeholder` pseudo-element styling.