### PR TITLE
Fix styling of tiered promotions delete icon

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/sections/_promotions.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/_promotions.scss
@@ -54,9 +54,14 @@
     position: relative;
     padding-bottom: 10px;
 
+    > .row {
+      margin-left: 10px;
+    }
+
     .remove {
       position: absolute;
-      left: -15px;
+      cursor: pointer;
+      left: 0;
       top: 10px;
 
       &:hover {


### PR DESCRIPTION
Required for #1776

Previously this trash icon was being partially obscured by the row next to it, and only the left half of the icon could be clicked. It was also floating outside of the parent container. This commit fixes these issues
by adding a margin to the row, and placing the icon inside.

It also changes the cursor to a pointer on hover.


| Before | After |
|---|---|
| ![](http://i.hawth.ca/s/B2XxceuZ.png) | ![](http://i.hawth.ca/s/cpOj9Dw6.png) |

Background red showing overlap. Trash can't be clicked inside the red.

![](http://i.hawth.ca/s/fLd9Mwte.png)