### PR TITLE
Remove click event from payments diplay amount

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/payments/edit.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/payments/edit.js.coffee
@@ -3,7 +3,6 @@ PaymentRowView = Backbone.View.extend
     "click .js-edit": "onEdit"
     "click .js-save": "onSave"
     "click .js-cancel": "onCancel"
-    "click .js-display-amount": "onEdit"
 
   onEdit: (e) ->
     e.preventDefault()

--- a/backend/spec/features/admin/orders/payments_spec.rb
+++ b/backend/spec/features/admin/orders/payments_spec.rb
@@ -113,16 +113,6 @@ describe 'Payments', type: :feature do
         end
       end
 
-      it 'allows the amount to be edited by clicking on the amount then saving' do
-        within_row(1) do
-          find('td.amount span').click
-          fill_in('amount', with: '$1.01')
-          click_icon(:save)
-          expect(page).to have_selector('td.amount span', text: '$1.01')
-          expect(payment.reload.amount).to eq(1.01)
-        end
-      end
-
       it 'allows the amount change to be cancelled by clicking on the cancel button' do
         within_row(1) do
           click_icon(:edit)


### PR DESCRIPTION
In order payments table the amounts are currently clickable.
As the edit icon is only displayed if the payment is pending,
the amount is always clickable.

Instead of making this conditional I removed this feature all together
as I don't see any of this behaviour in any other admin table.