### PR TITLE
Redesign product details page in admin

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/_bootstrap_custom.scss
+++ b/backend/app/assets/stylesheets/spree/backend/_bootstrap_custom.scss
@@ -34,7 +34,7 @@ $gray-lightest:             #f7f7f9 !default;
 
 $brand-primary:             $color-3 !default;
 $brand-success:             $color-2 !default;
-$brand-info:                #5bc0de !default;
+$brand-info:                #eff5fc !default;
 $brand-warning:             $color-6 !default;
 $brand-danger:              $color-5 !default;
 

--- a/backend/app/assets/stylesheets/spree/backend/components/_navigation.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_navigation.scss
@@ -32,7 +32,7 @@ nav.menu {
 }
 
 .admin-nav-header {
-  padding: 15px;
+  padding: 8px 25px;
   height: 58px; // height of .page-title
   box-sizing: content-box;
   background-color: $color-1;

--- a/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
+++ b/backend/app/assets/stylesheets/spree/backend/plugins/_select2.scss
@@ -90,3 +90,12 @@
     * { color: $dropdown-link-hover-color }
   }
 }
+
+.select2-choices::after {
+  content: "\f0d7"; // fa-caret-down
+  position: absolute;
+  font-family: "FontAwesome";
+  right: 10px;
+  bottom: 5px;
+  cursor: pointer;
+}

--- a/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
@@ -212,3 +212,15 @@ fieldset {
 .form-buttons {
   text-align: center;
 }
+
+.card.card-info {
+  border-color: darken($brand-info, 5%);
+}
+
+.input-group-addon {
+  line-height: initial;
+}
+
+.card-outline-none {
+  border: 0;
+}

--- a/backend/app/assets/stylesheets/spree/backend/shared/_layout.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_layout.scss
@@ -29,11 +29,6 @@ body {
   body.new-layout & {
     @include padding(1rem $grid-gutter-width null);
   }
-
-  &.centered {
-    @include margin(null auto);
-    max-width: map-get($container-max-widths, "xl");
-  }
 }
 
 .content {

--- a/backend/app/assets/stylesheets/spree/backend/shared/_skeleton.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_skeleton.scss
@@ -21,7 +21,6 @@
 /* #Base 960 Grid
 ================================================== */
 
-    .container                                  { position: relative; width: 960px; margin: 0 auto; padding: 0; }
     .container .column,
     .container .columns                         { float: left; display: inline; margin-left: 10px; margin-right: 10px; }
     .row                                        { margin-bottom: 20px; }
@@ -77,7 +76,6 @@
     /* Note: Design for a width of 768px */
 
     @media only screen and (min-width: 768px + $width-sidebar) and (max-width: 959px + $width-sidebar) {
-        .container                                  { width: 768px; }
         .container .column,
         .container .columns                         { margin-left: 10px; margin-right: 10px;  }
         .column.alpha, .columns.alpha               { margin-left: 0; margin-right: 10px; }
@@ -130,7 +128,6 @@
     /* Note: Design for a width of 320px */
 
     @media only screen and (max-width: 767px + $width-sidebar) {
-        .container { width: 300px; }
         .container .columns,
         .container .column { margin: 0; }
 
@@ -180,7 +177,6 @@
     /* Note: Design for a width of 480px */
 
     @media only screen and (min-width: 480px + $width-sidebar) and (max-width: 767px + $width-sidebar) {
-        .container { width: 420px; }
         .container .columns,
         .container .column { margin: 0; }
 
@@ -210,26 +206,24 @@
 ================================================== */
 
     /* Self Clearing Goodness */
-    .container:after { content: "\0020"; display: block; height: 0; clear: both; visibility: hidden; }
 
     /* Use clearfix class on parent to clear nested columns,
     or wrap each row of columns in a <div class="row"> */
     .clearfix:before,
-    .clearfix:after,
-    .row:before,
-    .row:after {
+    .clearfix:after {
       content: '\0020';
       display: block;
       overflow: hidden;
       visibility: hidden;
       width: 0;
-      height: 0; }
-    .row:after,
+      height: 0;
+    }
     .clearfix:after {
-      clear: both; }
-    .row,
+      clear: both;
+    }
     .clearfix {
-      zoom: 1; }
+      zoom: 1;
+    }
 
     /* You can also use a <br class="clear" /> to clear columns */
     .clear {

--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -1,23 +1,36 @@
-<div data-hook="admin_product_form_fields">
+<div data-hook="admin_product_form_fields" class="row">
 
-  <div class="row">
+  <div data-hook="admin_product_form_left" class="col-lg-8 col-xs-12">
 
-    <div class="left col-xs-9" data-hook="admin_product_form_left">
-      <div data-hook="admin_product_form_name">
-        <%= f.field_container :name do %>
-          <%= f.label :name, class: 'required' %>
-          <%= f.text_field :name, class: 'fullwidth title', required: true %>
-          <%= f.error_message_on :name %>
-        <% end %>
+    <div class="card card-block card-info">
+      <div class="row">
+        <div data-hook="admin_product_form_name" class="col-md-6 col-xs-12">
+          <%= f.field_container :name do %>
+            <%= f.label :name, class: 'required' %>
+            <%= f.text_field :name, class: 'fullwidth title', required: true %>
+            <%= f.error_message_on :name %>
+          <% end %>
+        </div>
+
+        <div data-hook="admin_product_form_slug" class="col-md-6 col-xs-12">
+          <%= f.field_container :slug do %>
+            <%= f.label :slug, class: 'required' %>
+            <%= f.text_field :slug, class: 'fullwidth title', required: true %>
+            <%= f.error_message_on :slug %>
+          <% end %>
+        </div>
       </div>
 
-      <div data-hook="admin_product_form_slug">
-        <%= f.field_container :slug do %>
-          <%= f.label :slug, class: 'required' %>
-          <%= f.text_field :slug, class: 'fullwidth title', required: true %>
-          <%= f.error_message_on :slug %>
-        <% end %>
-      </div>
+      <% if !@product.has_variants? %>
+        <div class="row">
+          <div data-hook="admin_product_form_sku" class="col-xs-12 col-md-6">
+            <%= f.field_container :sku do %>
+              <%= f.label :sku, Spree::Variant.human_attribute_name(:sku) %>
+              <%= f.text_field :sku, size: 16 %>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
 
       <div data-hook="admin_product_form_description">
         <%= f.field_container :description do %>
@@ -26,25 +39,29 @@
           <%= f.error_message_on :description %>
         <% end %>
       </div>
-    </div>
 
-    <div class="right col-xs-3" data-hook="admin_product_form_right">
-      <div data-hook="admin_product_form_price">
-        <%= f.field_container :price do %>
-          <%= f.label :price, class: 'required' %>
-          <%= render "spree/admin/shared/number_with_currency", f: f, amount_attr: :price, currency: @product.find_or_build_master.default_price.currency %>
-          <%= f.error_message_on :price %>
+      <div data-hook="admin_product_form_taxons">
+        <%= f.field_container :taxons do %>
+          <%= f.label :taxon_ids, plural_resource_name(Spree::Taxon) %><br />
+          <%= f.hidden_field :taxon_ids, :value => @product.taxon_ids.join(',') %>
         <% end %>
       </div>
+    </div>
 
-      <% if show_rebuild_vat_checkbox? %>
-        <%= render "spree/admin/shared/rebuild_vat_prices_checkbox", form: f, model_name: "product" %>
-        <div class="clearfix"></div>
-      <% end %>
+
+    <div class="card card-block card-info">
+      <h4><%= I18n.t(:pricing, scope: [:spree, :product_sections]) %></h4>
 
       <div class="row">
+        <div data-hook="admin_product_form_price" class="col-lg-6 col-xs-6">
+          <%= f.field_container :price do %>
+            <%= f.label :price, class: 'required' %>
+            <%= render "spree/admin/shared/number_with_currency", f: f, amount_attr: :price, currency: @product.find_or_build_master.default_price.currency %>
+            <%= f.error_message_on :price %>
+          <% end %>
+        </div>
 
-        <div data-hook="admin_product_form_cost_price" class="col-xs-12">
+        <div data-hook="admin_product_form_cost_price" class="col-lg-6 col-xs-6">
           <%= f.field_container :cost_price do %>
             <%= f.label :cost_price %>
 
@@ -56,7 +73,71 @@
         </div>
       </div>
 
-      <div class="clear"></div>
+      <div class="row">
+        <div data-hook="admin_product_form_tax_category" class="col-md-6 col-xs-12">
+          <%= f.field_container :tax_category do %>
+            <%= f.label :tax_category_id, Spree::TaxCategory.model_name.human %>
+            <%= f.field_hint :tax_category %>
+            <%= f.collection_select(:tax_category_id, @tax_categories, :id, :name, { :include_blank => Spree.t('match_choices.none') }, { :class => 'select2' }) %>
+            <%= f.error_message_on :tax_category %>
+          <% end %>
+        </div>
+      </div>
+
+      <div class="row">
+        <div data-hook="admin_product_form_promotionable" class="col-md-4 col-xs-12">
+          <%= f.field_container :promotionable do %>
+            <%= f.label :promotionable do %>
+              <%= f.check_box :promotionable %> <%= Spree::Product.human_attribute_name(:promotionable) %>
+            <% end %>
+            <%= f.field_hint :promotionable %>
+          <% end %>
+        </div>
+
+        <% if show_rebuild_vat_checkbox? %>
+          <div class="col-md-4 col-xs-12">
+            <%= render "spree/admin/shared/rebuild_vat_prices_checkbox", form: f, model_name: "product"%>
+          </div>
+        <% end %>
+      </div>
+    </div>
+
+
+    <div class="card card-block card-info">
+      <h4><%= I18n.t(:shipping, scope: [:spree, :product_sections]) %></h4>
+
+      <div class="row">
+        <div data-hook="admin_product_form_shipping_categories" class="col-md-6 col-xs-12">
+          <%= f.field_container :shipping_categories do %>
+            <%= f.label :shipping_category_id, Spree::ShippingCategory.model_name.human %>
+            <%= f.field_hint :shipping_category %>
+            <%= f.collection_select(:shipping_category_id, @shipping_categories, :id, :name, { include_blank: Spree.t('match_choices.none') }, { class: 'select2' }) %>
+            <%= f.error_message_on :shipping_category %>
+          <% end %>
+        </div>
+      </div>
+
+
+      <div class="row">
+        <% if !@product.has_variants? %>
+          <% [:height, :width, :depth, :weight].each_with_index do |field, index| %>
+            <div id="shipping_specs_<%= field %>_field" class="col-md-3 col-xs-6">
+              <div class="field">
+                <%= f.label field %>
+                <%= f.text_field field, value: number_with_precision(@product.send(field), precision: 2) %>
+              </div>
+            </div>
+          <% end %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+
+  <!-- Right side -->
+  <div data-hook="admin_product_form_right" class="col-lg-4 col-xs-12">
+    <div class="card card-block card-info">
+      <h4><%= I18n.t(:delay_publishing, scope: [:spree, :product_sections]) %></h4>
+      <p><%= I18n.t(:delay_publishing, scope: [:spree, :hints, "spree/product"]) %></p>
 
       <div data-hook="admin_product_form_available_on">
         <%= f.field_container :available_on do %>
@@ -66,18 +147,19 @@
         <% end %>
       </div>
 
-      <div data-hook="admin_product_form_promotionable">
-        <%= f.field_container :promotionable do %>
-          <%= f.label :promotionable do %>
-            <%= f.check_box :promotionable %> <%= Spree::Product.human_attribute_name(:promotionable) %>
-          <% end %>
-          <%= f.field_hint :promotionable %>
+      <br>
+      <h4><%= I18n.t(:variant_setup, scope: [:spree, :product_sections]) %></h4>
+      <p><%= I18n.t(:variant_setup, scope: [:spree, :hints, "spree/product"]) %></p>
+
+      <div data-hook="admin_product_form_option_types">
+        <%= f.field_container :option_types do %>
+          <%= f.label :option_type_ids, plural_resource_name(Spree::OptionType) %>
+          <%= f.hidden_field :option_type_ids, :value => @product.option_type_ids.join(',') %>
         <% end %>
       </div>
 
       <% if @product.has_variants? %>
         <div data-hook="admin_product_form_multiple_variants">
-          <%= f.label :skus, Spree.t(:skus) %>
           <span class="info">
             <%= Spree.t(:info_product_has_multiple_skus, count: @product.variants.count) %>
             <ul class="text_list">
@@ -89,69 +171,24 @@
               <%= Spree.t(:info_number_of_skus_not_shown, count: @product.variants.count - 5) %>
             <% end %>
           </span>
+
           <div class="info-actions">
             <% if can?(:admin, Spree::Variant) %>
               <%= link_to_with_icon 'th-large', Spree.t(:manage_variants), admin_product_variants_url(@product) %>
             <% end %>
           </div>
         </div>
-      <% else %>
-        <div data-hook="admin_product_form_sku">
-          <%= f.field_container :sku do %>
-            <%= f.label :sku, Spree::Variant.human_attribute_name(:sku) %>
-            <%= f.text_field :sku, size: 16 %>
-          <% end %>
-        </div>
-
-        <div id="shipping_specs" class="row">
-          <% [:height, :width, :depth, :weight].each_with_index do |field, index| %>
-            <div id="shipping_specs_<%= field %>_field" class="col-xs-6">
-              <div class="field">
-                <%= f.label field %>
-                <%= f.text_field field, value: number_with_precision(@product.send(field), precision: 2) %>
-              </div>
-            </div>
-          <% end %>
-        </div>
-
       <% end %>
-
-      <div data-hook="admin_product_form_shipping_categories">
-        <%= f.field_container :shipping_categories do %>
-          <%= f.label :shipping_category_id, Spree::ShippingCategory.model_name.human %>
-          <%= f.field_hint :shipping_category %>
-          <%= f.collection_select(:shipping_category_id, @shipping_categories, :id, :name, { include_blank: Spree.t('match_choices.none') }, { class: 'select2' }) %>
-          <%= f.error_message_on :shipping_category %>
-        <% end %>
-      </div>
-
-      <div data-hook="admin_product_form_tax_category">
-        <%= f.field_container :tax_category do %>
-          <%= f.label :tax_category_id, Spree::TaxCategory.model_name.human %>
-          <%= f.field_hint :tax_category %>
-          <%= f.collection_select(:tax_category_id, @tax_categories, :id, :name, { include_blank: Spree.t('match_choices.none') }, { class: 'select2' }) %>
-          <%= f.error_message_on :tax_category %>
-        <% end %>
-      </div>
     </div>
-
   </div>
 
-  <div class="row">
+  <!-- Left side -->
+  <div class="col-lg-8 col-xs-12" >
+    <div class="card card-block card-info">
+      <h4><%= I18n.t(:search_engine_optimization, scope: [:spree, :product_sections]) %></h4>
 
-    <div class="col-xs-9">
-      <div data-hook="admin_product_form_taxons">
-        <%= f.field_container :taxons do %>
-          <%= f.label :taxon_ids, plural_resource_name(Spree::Taxon) %><br />
-          <%= f.hidden_field :taxon_ids, value: @product.taxon_ids.join(',') %>
-        <% end %>
-      </div>
-
-      <div data-hook="admin_product_form_option_types">
-        <%= f.field_container :option_types do %>
-          <%= f.label :option_type_ids, plural_resource_name(Spree::OptionType) %>
-          <%= f.hidden_field :option_type_ids, value: @product.option_type_ids.join(',') %>
-        <% end %>
+      <div class="hidden-lg-up">
+        <p><%= I18n.t(:search_engine_optimization, scope: [:spree, :hints, "spree/product"]) %></p>
       </div>
 
       <div data-hook="admin_product_form_meta">
@@ -172,17 +209,20 @@
         <div data-hook="admin_product_form_meta_description">
           <%= f.field_container :meta_description do %>
             <%= f.label :meta_description %>
-            <%= f.text_field :meta_description, class: 'fullwidth' %>
+            <%= f.text_area :meta_description, rows: 3, class: 'fullwidth' %>
           <% end %>
         </div>
       </div>
     </div>
 
+    <div data-hook="admin_product_form_additional_fields"></div>
   </div>
 
-  <div class="clear"></div>
+  <!-- Right side -->
+  <div class="col-lg-4 hidden-md-down">
+    <div class="card card-block card-outline-none">
+      <p><%= I18n.t(:search_engine_optimization, scope: [:spree, :hints, "spree/product"]) %></p>
+    </div>
+  </div>
 
-  <div data-hook="admin_product_form_additional_fields"></div>
-
-  <div class="clear"></div>
 </div>

--- a/backend/app/views/spree/admin/products/index.html.erb
+++ b/backend/app/views/spree/admin/products/index.html.erb
@@ -48,7 +48,7 @@
   </div>
 <% end %>
 
-<div id="new_product_wrapper" data-hook></div>
+<div id="new_product_wrapper" data-hook class="container"></div>
 
 <%= paginate @collection, theme: "solidus_admin" %>
 

--- a/backend/app/views/spree/layouts/admin.html.erb
+++ b/backend/app/views/spree/layouts/admin.html.erb
@@ -12,6 +12,7 @@
 
     <div class="content-wrapper <%= @admin_layout.presence %> <%= "has-sidebar" if content_for?(:sidebar) %>" id="wrapper" data-hook>
       <% if @admin_layout %>
+        <% # Full width layout %>
         <div class="content">
           <div class="content-main">
             <%= yield :tabs %>
@@ -22,7 +23,7 @@
           <%= render "spree/admin/shared/sidebar" %>
         </div>
       <% else %>
-        <% # Legacy layout %>
+        <% # Centered layout %>
         <div class="container">
           <div class="<%= 'with-sidebar ' if content_for?(:sidebar) %>" id="content" data-hook>
             <div class="row">

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1209,6 +1209,9 @@ en:
         promotionable: "This determines whether or not promotions can apply to this product.<br/>Default: Checked"
         shipping_category: "This determines what kind of shipping this product requires.<br/> Default: Default"
         tax_category: "This determines what kind of taxation is applied to this product.<br/> Default: None"
+        delay_publishing: "Leave this empty if you want this product to be available in your store right away. Set a date in the future to hide it until then."
+        variant_setup: "Does this product come in multiple variations like size and color? Set these here so you can configure them in the variants tab."
+        search_engine_optimization: "Meta descriptions can be any length, but search engines generally truncate snippets longer than 160 characters. It is best to keep meta descriptions between 150 and 160 characters."
       spree/promotion:
         starts_at: "This determines when the promotion can be applied to orders. <br/> If no value is specified, the promotion will be immediately available."
         expires_at: "This determines when the promotion expires. <br/> If no value is specified, the promotion will never expires."
@@ -1608,6 +1611,12 @@ en:
       product_source:
         group: From product group
         manual: Manually choose
+    product_sections:
+      pricing: Pricing
+      shipping: Shipping
+      search_engine_optimization: Search Engine Optimization
+      delay_publishing: Delay publishing
+      variant_setup: Variant setup
     products: Products
     promotion: Promotion
     promotionable: Promotable


### PR DESCRIPTION
Hello, 

I've gone about to try out to implement #1290 instead of just criticizing on #1574. Initially, I went about to adjust what Graham had achieved thus far, but I ended up deleting and re-organizing most of the code, so have squashed, and only 2 commits are from the original.

The changes I've done reflect my following thoughts:

1. When introducing a new component, such as the admin section background, it is great to be able to associate it with an already existent component from Bootstrap, as this reduces the "learning curve" for other developers. So, instead of creating a new class `.form-section`, it's better to assign a default class from bootstrap and a custom one - `.card .card-spacial`. That way, a developer knows that what they are looking at is just a modification of an already known component.

    So, I've re-use the bootstrap class `.card-info`, as we have a light blue background color for the forms, though this might change, and we can go for a different name. I've gone to create a `card-outline-none`, to follow the logic for their other [`card-outline-*` classes](https://v4-alpha.getbootstrap.com/components/card/#outline-cards). `.input-group-addon` is actually unrelated, but fixes a horizontal alignment issue with those - can go in a separate PR.

2. I think that specifying a layout for every "new" form is not sustainable, and we should instead try to adapt the existing "old" layout to fit out case. 

    I've gone about to do just that, and there's actually not too much to do there. I've only deleted the `.container` specifications from Skeleton, so to rely on those provided by Bootstrap. This has the effect of increasing our container width from `960px` -> `1140px`, which has no negative consequences on any part of solidus backend, which uses the new bootstrap classes. I haven't checked any extension using the Skeleton classes, but I'd think that the `180px` difference would at large cause a very small input box to go a line up, which would be an insignificant "regression" in my opinion. Furthermore, we can prevent this "regression" by adjusting the skeleton widths (re-doing the column calculations with the new width).

    The existing "old" layout is actually meant to be our default layout, which I guess should be the  "max-width" version, and not the full-width one.

3. The specification says to align the "max-width" layout to the left due to tabs mis-behaviour, but I've discovered that this is questionable decision at this point:

    - left-aligned concentrates too much content on the left side where the Menu is located. The space between the Menu is not enough in my opinion.

    - on wide screen monitors, left-aligned, there's a huge space gap on the right, and the top right buttons are very disconnected. 

    - there's plenty of alternatives for the tabs - they can span full width and be centered; their border can span full width, but the tabs themselves can start from the content area.

    - I don't think that tabs will actually be present on any _full-width_ page, as tabs are generally Item edit specific, and full width pages are likely to be for an index page. See the Promotions#edit page - it's content is spread all over the place; in my view it's a mess, and needs to be put back to a _max-width_ one;
     In fact, I'd argue that there's not much advantage to having any full-width pages - looking at the orders index or the products index, which should be the heaviest tables of them all, they look better to me when _max-width_;

    Due to the possible controversy of the topic, I have left it to be implemented at any future PR, which would not have a negative impact on the currently implemented changes.

    It's actually very easy to play around to see how each options looks like. Just add `.container { margin-left: 0; }` in almost any css, and you'd see the left-aligned effect; personally, I really like the white space left and right of a _max-width_ container.

4. Unrelated directly, but I think that the [`admin_layout` feature](https://github.com/solidusio/solidus/blob/master/backend/app/views/spree/layouts/admin.html.erb#L7-L14) has already gone to be too complicated. It currently has a triple meaning of causing a "new-layout" class to come up, along with the specified class name of the "admin-layout", along with an `if` condition if the admin layout is specified or not, irrespective of its value. `new-layout` is a bit inappropriate, as when we do a v3 redesign, what would we call it then - `new-new-layout`?

    Unless I oversimplify, I think that this should be reduced to a boolean for `full-width`.

    In that respect, it's really great that you guys have not been rushing the UI changes, so that the "html api" can be polished up. Thanks for that!

5. I have moved the SKU to be below the Name and the Slug, contrary to the design, as it seems strange to me not to have the name on the upper row. Happy to change around.

6. I have followed the color implementations from the original PR #1574, and I don't have any color preferences, happy to even invert the colors completely as it is on the original design specs.

7. Have reduced the height around the logo a bit to make it match the breadcrumbs height.

8. Have added a carret down icon to all select2 input fields using a `before` css selector. I think the same approach should be used for the "calendar" icon.

Finally the screenhosts of a product without and with variants.

![product details apache baseball jersey products 1](https://cloud.githubusercontent.com/assets/1651750/24631672/188f587c-18b9-11e7-89a9-30652e659127.png)

![product details ruby on rails baseball jersey](https://cloud.githubusercontent.com/assets/1651750/24631693/294233a6-18b9-11e7-88dd-ece37e849c23.png)


  