### PR TITLE
Add a configurable order number generator

### DIFF
--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -397,6 +397,17 @@ module Spree
       @current_store_selector_class ||= Spree::CurrentStoreSelector
     end
 
+    # Allows providing your own class instance for generating order numbers.
+    #
+    # @!attribute [rw] order_number_generator
+    # @return [Class] a class instance with the same public interfaces as
+    #   Spree::Order::NumberGenerator
+    # @api experimental
+    attr_writer :order_number_generator
+    def order_number_generator
+      @order_number_generator ||= Spree::Order::NumberGenerator.new
+    end
+
     def static_model_preferences
       @static_model_preferences ||= Spree::Preferences::StaticModelPreferences.new
     end

--- a/core/app/models/spree/order/number_generator.rb
+++ b/core/app/models/spree/order/number_generator.rb
@@ -1,0 +1,43 @@
+module Spree
+  # Generates order numbers
+  #
+  # In order to change the way your order numbers get generated you can either
+  # set your own instance of this class in your stores configuration with different options:
+  #
+  #     Spree::Config.order_number_generator = Spree::Order::NumberGenerator.new(
+  #       prefix: 'B',
+  #       lenght: 8,
+  #       letters: false
+  #     )
+  #
+  # or create your own class:
+  #
+  #     Spree::Config.order_number_generator = My::OrderNumberGenerator.new
+  #
+  class Order::NumberGenerator
+    attr_reader :letters, :prefix
+
+    def initialize(options = {})
+      @length = options[:length] || Spree::Order::ORDER_NUMBER_LENGTH
+      @letters = options[:letters] || Spree::Order::ORDER_NUMBER_LETTERS
+      @prefix = options[:prefix] || Spree::Order::ORDER_NUMBER_PREFIX
+    end
+
+    def generate
+      possible = (0..9).to_a
+      possible += ('A'..'Z').to_a if letters
+
+      loop do
+        # Make a random number.
+        random = "#{prefix}#{(0...@length).map { possible.sample }.join}"
+        # Use the random number if no other order exists with it.
+        if Spree::Order.exists?(number: random)
+          # If over half of all possible options are taken add another digit.
+          @length += 1 if Spree::Order.count > (10**@length / 2)
+        else
+          break random
+        end
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/order/number_generator_spec.rb
+++ b/core/spec/models/spree/order/number_generator_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+RSpec.describe Spree::Order::NumberGenerator do
+  subject { described_class.new.generate }
+
+  it { is_expected.to be_a(String) }
+
+  describe 'length' do
+    let(:default_length) do
+      Spree::Order::ORDER_NUMBER_LENGTH + Spree::Order::ORDER_NUMBER_PREFIX.length
+    end
+
+    it { expect(subject.length).to eq default_length }
+
+    context "when length option is 5" do
+      let(:option_length) { 5 + Spree::Order::ORDER_NUMBER_PREFIX.length }
+
+      subject { described_class.new(length: 5).generate }
+
+      it "should be 5 plus default prefix length" do
+        expect(subject.length).to eq option_length
+      end
+    end
+  end
+
+  context "when letters option is true" do
+    subject { described_class.new(letters: true).generate }
+
+    it "generates order number including letters" do
+      is_expected.to match /[A-Z]/
+    end
+  end
+
+  describe 'prefix' do
+    it { is_expected.to match /^#{Spree::Order::ORDER_NUMBER_PREFIX}/ }
+
+    context "when prefix option is 'P'" do
+      subject { described_class.new(prefix: 'P').generate }
+
+      it "generates order number prefixed with 'P'" do
+        is_expected.to match /^P/
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -690,41 +690,52 @@ describe Spree::Order, type: :model do
     end
   end
 
-  context "#generate_order_number" do
+  describe "#generate_order_number" do
     let(:order) { build(:order) }
 
-    context "when no configure" do
-      let(:default_length) { Spree::Order::ORDER_NUMBER_LENGTH + Spree::Order::ORDER_NUMBER_PREFIX.length }
-      subject(:order_number) { order.generate_order_number }
-
-      describe '#class' do
-        subject { super().class }
-        it { is_expected.to eq String }
-      end
-
-      describe '#length' do
-        subject { super().length }
-        it { is_expected.to eq default_length }
-      end
-      it { is_expected.to match /^#{Spree::Order::ORDER_NUMBER_PREFIX}/ }
-    end
-
-    context "when length option is 5" do
-      let(:option_length) { 5 + Spree::Order::ORDER_NUMBER_PREFIX.length }
-      it "should be option length for order number" do
-        expect(order.generate_order_number(length: 5).length).to eq option_length
+    context "with default app configuration" do
+      it 'calls the default order number generator' do
+        expect_any_instance_of(Spree::Order::NumberGenerator).to receive(:generate)
+        order.generate_order_number
       end
     end
 
-    context "when letters option is true" do
-      it "generates order number include letter" do
-        expect(order.generate_order_number(length: 100, letters: true)).to match /[A-Z]/
+    context "with order number generator configured" do
+      class TruthNumberGenerator
+        def initialize(options = {}); end
+
+        def generate
+          '42'
+        end
+      end
+
+      before do
+        expect(Spree::Config).to receive(:order_number_generator) do
+          TruthNumberGenerator.new
+        end
+      end
+
+      it 'calls the configured order number generator' do
+        order.generate_order_number
+        expect(order.number).to eq '42'
       end
     end
 
-    context "when prefix option is 'P'" do
-      it "generates order number and it prefix is 'P'" do
-        expect(order.generate_order_number(prefix: 'P')).to match /^P/
+    context "with number already present" do
+      before do
+        order.number = '123'
+      end
+
+      it 'does not generate new number' do
+        order.generate_order_number
+        expect(order.number).to eq '123'
+      end
+    end
+
+    context "passing options" do
+      it 'is deprecated' do
+        expect(Spree::Deprecation).to receive(:warn)
+        order.generate_order_number(length: 2)
       end
     end
   end


### PR DESCRIPTION
The default order number generator was extracted into a class.
Provide your own class that takes an options hash and returns a
string when called for `#generate`.

    Spree::Config.order_number_generator = TrueNumberGenerator

    class TrueNumberGenerator
      def initialize(options = {})
      end

      def generate
        '42'
      end
    end