### PR TITLE
[RFC] Currency aware number input

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/views/number_with_currency.js
+++ b/backend/app/assets/javascripts/spree/backend/views/number_with_currency.js
@@ -5,6 +5,8 @@ Spree.Views.NumberWithCurrency = Backbone.View.extend({
 
   initialize: function() {
     this.$currencySelector = this.$('.number-with-currency-select select');
+    this.$amount = this.$('.number-with-currency-amount');
+    this.$symbol = this.$('.number-with-currency-symbol');
   },
 
   getCurrency: function() {
@@ -26,6 +28,21 @@ Spree.Views.NumberWithCurrency = Backbone.View.extend({
   },
 
   render: function() {
-    this.$('.number-with-currency-symbol').text(this.getCurrencySymbol());
+    this.$symbol.text(this.getCurrencySymbol());
+
+    var currency = this.getCurrency();
+    if (currency) {
+      var currencyInfo = Spree.currencyInfo[currency];
+      var format = function(number) {
+        return accounting.formatNumber(number, {
+          precision: currencyInfo[1],
+          thousand: '',
+          decimal: '.',
+        })
+      }
+      this.$amount.val(format(this.$amount.val()));
+      this.$amount.prop("placeholder", format('0.00'));
+      this.$amount.prop("step", 1 / (10 ** currencyInfo[1]));
+    }
   }
 });

--- a/backend/app/assets/stylesheets/spree/backend/components/_number_with_currency.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_number_with_currency.scss
@@ -5,6 +5,14 @@
 
   &-amount {
     text-align: right;
+
+    /* Remove spinner from number input */
+    -moz-appearance: textfield;
+    &::-webkit-outer-spin-button,
+    &::-webkit-inner-spin-button {
+      -webkit-appearance: none;
+      margin: 0;
+    }
   }
 
   &-addon {

--- a/backend/app/views/spree/admin/shared/_number_with_currency.html.erb
+++ b/backend/app/views/spree/admin/shared/_number_with_currency.html.erb
@@ -5,7 +5,7 @@
 
 <div class="input-group number-with-currency js-number-with-currency">
   <div class="input-group-addon number-with-currency-symbol"></div>
-  <%= f.text_field amount_attr, value: number_to_currency(f.object.public_send(amount_attr), unit: ''), class: 'form-control number-with-currency-amount', required: required %>
+  <%= f.number_field amount_attr, value: f.object.public_send(amount_attr), class: 'form-control number-with-currency-amount', required: required, min: 0 %>
   <% if currency %>
     <div class="input-group-addon number-with-currency-addon" data-currency="<%= currency %>">
       <%= ::Money::Currency.find(currency).iso_code %>


### PR DESCRIPTION
When entering a number with a decimal, I like receiving some indication that my input has been correctly parsed (I don't want to overpay by 100x :money_with_wings:). I also like seeing the thousands separator, and I expect it to auto-update when I add/remove digits.

I have to imagine this is an even bigger concern for users outside the blue areas on [this map](https://commons.wikimedia.org/wiki/File:DecimalSeparator.svg), who don't represent currencies with period as the decimal mark.

Want users to be able to use their preferred locale in the admin, and to have confidence that Solidus understands the values that are being input.

Now that we have a dedicated interface for entering monetary amounts (#1793) we should have it validate numbers and format them for the user.

My first instinct on how to implement this is to use `<input type="number">`.  This gives us validation and formatting for free. We can pragmatically set the `step` value to match the selected currency.

The issue with this is how we handle decimal and thousands separators, and how browsers treat an `<input type="number">` w/r/t locale.

In browsers, the `value` attribute of the `<input type=number>` must always be [period separated with no thousands separator](http://w3c.github.io/html-reference/datatypes.html#common.data.float) (`1234.56`, like a valid ruby or JS number). However browsers can choose to display this however they want to a user.

Browsers are split on how to display them to the user, even the same browser across different operating systems (looking at you chrome). On chrome on Windows and Linux the input uses the settings from the *system* locale to format the input; on MacOS it uses the page's lang (as it should). [This article](https://ctrl.blog/entry/html5-input-number-localization) has a good summary and provides a [test page of the issue](https://ctrl.blog/demos/html5-input-number-l10n). Edge does the same as chrome and IE doesn't support it at all. So the behaviour is awkward if using a different locale on the page than for your system.

The second issue is how we parse numbers into our models. We have a class called [LocalizedNumber](https://github.com/solidusio/solidus/blob/master/core/lib/spree/localized_number.rb), which parses a string in the current locale. But this is only used for [`Price#amount=`](https://github.com/solidusio/solidus/blob/d62f18628c776044e18e90019cc61ed2bb1be50b/core/app/models/spree/price.rb) and [`Variant#weight=`](https://github.com/solidusio/solidus/blob/233ce7e9db32c422de561f4cf7fa87195864703f/core/app/models/spree/variant.rb#L131-L137) (but not length, width, etc.). This will incorrectly parse period-as-decimal numbers (which is what we will always receive from a number input) when we are in a comma-as-decimal locale. `Spree::Payment#amount=` also uses [totally different code](https://github.com/solidusio/solidus/blob/master/core/app/models/spree/payment.rb#L116-L127) with different behaviour (supports comma-as-decimal, but not period-as-thousands). Other models don't support localized inputs :disappointed:.

So we have a few ways we could proceed:

For taking input client-side we could:
* Use an `<input type=number`, accepting the flaws some browsers have.
* Use an `<input type=text`, and format it as the user types. This is much like how `jquery.payment` works for entering credit cards. A good example of this in the wild is [paypal.me](https://www.paypal.me/jhawthorn). This will be the most consistent, but more work, and will be a bad experience on mobile.

For parsing these server side we can:
* Remove `LocalizedNumber` and require input to always be formatted period-as-decimal (I would prefer this, but compatibility is a concern)
* `LocalizedNumber` throughout, always send numbers in the current locale's format.
* Introduce helper methods on the models which do the parsing (`localized_amount=`?)
* Introduce helper methods on the models which do *no* parsing (`unlocalized_amount=`? :confused:)

Some of the server side options might necessitate a hidden input (which I see no problem with). I would strongly prefer that models only receive period-as-decimal numbers. It's general we should keep all i18n and l10n concerns out of our models.

Really hoping to hear from @tvdeyen, @mamhoff, and others in comma-as-decimal countries, who I'm sure will know better than me what is most desirable.

_Note: Here I've only discussed period-as-decimal numbers and comma-as-decimal numbers for simplicity. It's confusing enough to talk about number representations as is. There other schemes in active use worldwide. The wikipedia article on the [decimal mark](https://en.wikipedia.org/wiki/Decimal_mark) is a good read. We should be sure with our final implementation to support them all._