### PR TITLE
Change admin logo height to match breadcrumbs height

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/components/_navigation.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_navigation.scss
@@ -32,22 +32,9 @@ nav.menu {
 }
 
 .admin-nav-header {
-  padding: 15px;
-  height: 58px; // height of .page-title
-  box-sizing: content-box;
-  background-color: $color-1;
+  padding: 14px 0 8px;
   border-bottom: 1px solid $color-border;
-
-  a {
-    display: inline-block;
-    line-height: 58px;
-  }
-
-  img {
-    vertical-align: middle;
-    max-width: 100%;
-    max-height: 100%;
-  }
+  text-align: center;
 }
 
 .admin-nav-menu {

--- a/backend/app/assets/stylesheets/spree/backend/components/_navigation.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_navigation.scss
@@ -32,9 +32,11 @@ nav.menu {
 }
 
 .admin-nav-header {
-  padding: 14px 0 8px;
   border-bottom: 1px solid $color-border;
   text-align: center;
+  // Using line height for proper vertical centering.
+  // As line height does not take the border width into account we need to subtract it.
+  line-height: $main-header-height - 1px;
 }
 
 .admin-nav-menu {

--- a/backend/app/assets/stylesheets/spree/backend/globals/_variables.scss
+++ b/backend/app/assets/stylesheets/spree/backend/globals/_variables.scss
@@ -223,3 +223,7 @@ $z-index-navbar-flyout:          1000 !default;
 // Sidebar
 //--------------------------------------------------------------
 $border-sidebar:                 1px solid $color-sidebar-border !default;
+
+// Main
+//--------------------------------------------------------------
+$main-header-height:             75px !default;

--- a/backend/app/assets/stylesheets/spree/backend/shared/_header.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_header.scss
@@ -4,6 +4,7 @@
   padding: 15px $grid-gutter-width;
   background-color: very-light($color-3, 4);
   border-bottom: 1px solid $color-border;
+  height: $main-header-height;
 
   body:not(.new-layout) & {
     margin-left: $width-sidebar;

--- a/backend/app/assets/stylesheets/spree/backend/shared/_images.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_images.scss
@@ -1,0 +1,7 @@
+// Have all images be responsive by default
+img {
+  display: inline-block;
+  max-width: 100%;
+  height: auto;
+  -ms-interpolation-mode: bicubic;
+}

--- a/backend/app/assets/stylesheets/spree/backend/shared/_layout.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_layout.scss
@@ -14,9 +14,6 @@ body {
 .admin-nav {
   @include position(absolute, 0 null 0 0);
   width: $width-sidebar;
-  img {
-    max-width: 100%;
-  }
   @media print { display: none }
 }
 

--- a/backend/app/assets/stylesheets/spree/backend/spree_admin.scss
+++ b/backend/app/assets/stylesheets/spree/backend/spree_admin.scss
@@ -12,6 +12,7 @@
 
 @import 'spree/backend/shared/skeleton';
 @import 'spree/backend/shared/typography';
+@import 'spree/backend/shared/images';
 @import 'spree/backend/shared/tables';
 @import 'spree/backend/shared/icons';
 @import 'spree/backend/shared/forms';

--- a/backend/app/views/spree/admin/shared/_navigation_header.html.erb
+++ b/backend/app/views/spree/admin/shared/_navigation_header.html.erb
@@ -1,5 +1,5 @@
 <header class="admin-nav-header">
-  <%= link_to spree.admin_path do %>
+  <%= link_to spree.admin_path, class: 'brand-link' do %>
     <%= image_tag(Spree::Config[:admin_interface_logo]) %>
   <%- end %>
 </header>

--- a/backend/app/views/spree/admin/shared/_navigation_header.html.erb
+++ b/backend/app/views/spree/admin/shared/_navigation_header.html.erb
@@ -1,5 +1,5 @@
 <header class="admin-nav-header">
-  <%= link_to spree.admin_path, class: 'brand-link' do %>
+  <%= link_to spree.admin_path do %>
     <%= image_tag(Spree::Config[:admin_interface_logo]) %>
   <%- end %>
 </header>


### PR DESCRIPTION
~~The image itself seemed to contain white space underneath, so have modified the padding values accordingly to vertically center it.~~

_edit_: uses _line-height_ now, see conversation.

Removed a bit of css as well. 

- _Before_
  ![admin logo before](https://cloud.githubusercontent.com/assets/1651750/24704289/eb333abe-19fe-11e7-806a-051061ec366e.png)

- _After_
  ![admin logo - after](https://cloud.githubusercontent.com/assets/1651750/24704288/eb33152a-19fe-11e7-9c08-cc093a5cca5c.png)



Still looks a bit boxed, but oh well : ) 