### PR TITLE
Increase admin central area by 180px

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/shared/_skeleton.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_skeleton.scss
@@ -204,27 +204,6 @@
 
 /* #Clearing
 ================================================== */
-
-    /* Self Clearing Goodness */
-
-    /* Use clearfix class on parent to clear nested columns,
-    or wrap each row of columns in a <div class="row"> */
-    .clearfix:before,
-    .clearfix:after {
-      content: '\0020';
-      display: block;
-      overflow: hidden;
-      visibility: hidden;
-      width: 0;
-      height: 0;
-    }
-    .clearfix:after {
-      clear: both;
-    }
-    .clearfix {
-      zoom: 1;
-    }
-
     /* You can also use a <br class="clear" /> to clear columns */
     .clear {
       clear: both;

--- a/backend/app/assets/stylesheets/spree/backend/shared/_skeleton.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_skeleton.scss
@@ -21,7 +21,6 @@
 /* #Base 960 Grid
 ================================================== */
 
-    .container                                  { position: relative; width: 960px; margin: 0 auto; padding: 0; }
     .container .column,
     .container .columns                         { float: left; display: inline; margin-left: 10px; margin-right: 10px; }
     .row                                        { margin-bottom: 20px; }
@@ -77,7 +76,6 @@
     /* Note: Design for a width of 768px */
 
     @media only screen and (min-width: 768px + $width-sidebar) and (max-width: 959px + $width-sidebar) {
-        .container                                  { width: 768px; }
         .container .column,
         .container .columns                         { margin-left: 10px; margin-right: 10px;  }
         .column.alpha, .columns.alpha               { margin-left: 0; margin-right: 10px; }
@@ -130,7 +128,6 @@
     /* Note: Design for a width of 320px */
 
     @media only screen and (max-width: 767px + $width-sidebar) {
-        .container { width: 300px; }
         .container .columns,
         .container .column { margin: 0; }
 
@@ -180,7 +177,6 @@
     /* Note: Design for a width of 480px */
 
     @media only screen and (min-width: 480px + $width-sidebar) and (max-width: 767px + $width-sidebar) {
-        .container { width: 420px; }
         .container .columns,
         .container .column { margin: 0; }
 
@@ -210,26 +206,24 @@
 ================================================== */
 
     /* Self Clearing Goodness */
-    .container:after { content: "\0020"; display: block; height: 0; clear: both; visibility: hidden; }
 
     /* Use clearfix class on parent to clear nested columns,
     or wrap each row of columns in a <div class="row"> */
     .clearfix:before,
-    .clearfix:after,
-    .row:before,
-    .row:after {
+    .clearfix:after {
       content: '\0020';
       display: block;
       overflow: hidden;
       visibility: hidden;
       width: 0;
-      height: 0; }
-    .row:after,
+      height: 0;
+    }
     .clearfix:after {
-      clear: both; }
-    .row,
+      clear: both;
+    }
     .clearfix {
-      zoom: 1; }
+      zoom: 1;
+    }
 
     /* You can also use a <br class="clear" /> to clear columns */
     .clear {


### PR DESCRIPTION
  by removing the container css specifications from Skeleton
  in favour of using Bootstrap's definition.

  This change will increase the width of the admin central area
  by 180px - from 960px to 1140px

  This will not have adversary effects to any part of the Solidus admin,
  as it has been fully converted to use the Bootstrap column classes,
  which are percentage based.

  Old Skeleton layouts might be negatively effected only in the following
  case:

   > 2 rows of form fields on large - the first row leaves 3 or more Skeleton
      columns empty (as 3 columns are 160px defined in [Skeleton](https://github.com/mtomov/solidus/blob/f8d32db1401dd8a9fc446a4adada70cc79d7445f/backend/app/assets/stylesheets/spree/backend/shared/_skeleton.scss#L36)), and 
      the second row starts with a field, which is 3
      or less columns wide. Then, the field from the second column would
      jump up on the previous line.

  As this is a very unlikely and minor regression, it is better to have it,
  then to re-calculate the Skeleton column widths, as doing so might cause
  in itself more trouble.


   Widths smaller than large are unaffected, as the Skeleton container widths 
match  with Bootstrap's


- _Before_

  ![increase container width - before](https://cloud.githubusercontent.com/assets/1651750/24706964/b199f18e-1a09-11e7-8009-20e9acadcddf.png)



- _After_

  ![increase container width - after](https://cloud.githubusercontent.com/assets/1651750/24706970/b84a3a48-1a09-11e7-8c09-c5d19e726df1.png)

