### PR TITLE
Add teaspoon javascript test runner to backend

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -4,3 +4,6 @@ gem 'solidus_core', path: '../core'
 gem 'solidus_api', path: '../api'
 
 gemspec
+
+gem 'teaspoon'
+gem 'teaspoon-mocha'

--- a/backend/Rakefile
+++ b/backend/Rakefile
@@ -6,7 +6,36 @@ require 'spree/testing_support/common_rake'
 
 RSpec::Core::RakeTask.new
 
-task default: :spec
+task :dummy_environment do
+  ENV['RAILS_ENV'] = 'test'
+  require File.expand_path("../spec/dummy/config/environment", __FILE__)
+end
+
+desc "Run the javascript specs"
+task teaspoon: :dummy_environment do
+  require "teaspoon/console"
+
+  options = {
+    files: ENV["files"].nil? ? [] : ENV["files"].split(","),
+    suite: ENV["suite"],
+    coverage: ENV["coverage"],
+    driver_options: ENV["driver_options"],
+  }
+
+  options.delete_if { |k, v| v.nil? }
+
+  abort("rake teaspoon failed") if Teaspoon::Console.new(options).failures?
+end
+
+namespace :teaspoon do
+  task server: :dummy_environment do
+    require 'teaspoon/server'
+    server = Teaspoon::Server.new
+    server.start
+    puts "#{server.url}/teaspoon"
+    sleep
+  end
+end
 
 desc "Generates a dummy app for testing"
 task :test_app do

--- a/backend/spec/javascripts/fixtures/_boot.html.erb
+++ b/backend/spec/javascripts/fixtures/_boot.html.erb
@@ -1,0 +1,8 @@
+<%= javascript_include_tag *@suite.spec_assets, debug: @suite.config.expand_assets, allow_non_precompiled: true %>
+<%= render "spree/admin/shared/js_locale_data" %>
+<%= javascript_tag do -%>
+  Spree.env = "<%= Rails.env %>";
+<% end %>
+<script type="text/javascript">
+  Teaspoon.onWindowLoad(Teaspoon.execute);
+</script>

--- a/backend/spec/javascripts/fixtures/number_with_currency/with_currency_select.html.erb
+++ b/backend/spec/javascripts/fixtures/number_with_currency/with_currency_select.html.erb
@@ -1,0 +1,3 @@
+<%= fields_for 'price', Spree::Price.new do |f| %>
+  <%= render 'spree/admin/shared/number_with_currency', f: f %>
+<% end %>

--- a/backend/spec/javascripts/fixtures/number_with_currency/without_select.html.erb
+++ b/backend/spec/javascripts/fixtures/number_with_currency/without_select.html.erb
@@ -1,0 +1,3 @@
+<%= fields_for 'price', Spree::Price.new() do |f| %>
+  <%= render 'spree/admin/shared/number_with_currency', f: f, currency: 'USD' %>
+<% end %>

--- a/backend/spec/javascripts/format_money_spec.js
+++ b/backend/spec/javascripts/format_money_spec.js
@@ -1,0 +1,48 @@
+describe('Spree.formatMoney', function() {
+  it('can format USD', function() {
+    expect(Spree.formatMoney(10, 'USD')).to.equal('$10.00');
+    expect(Spree.formatMoney('10', 'USD')).to.equal('$10.00');
+    expect(Spree.formatMoney(12.34, 'USD')).to.equal('$12.34');
+    expect(Spree.formatMoney('12.34', 'USD')).to.equal('$12.34');
+    expect(Spree.formatMoney(1000, 'USD')).to.equal('$1,000.00');
+  });
+
+  it('can format CAD', function() {
+    expect(Spree.formatMoney(1000, 'CAD')).to.equal('$1,000.00');
+  });
+
+  it('can format GBP', function() {
+    expect(Spree.formatMoney(1000, 'GBP')).to.equal('£1,000.00');
+  });
+
+  it('can format EUR', function() {
+    expect(Spree.formatMoney(1000, 'EUR')).to.equal('€1,000.00');
+  });
+
+  it('can format YEN', function() {
+    expect(Spree.formatMoney(1000, 'JPY')).to.equal('¥1,000');
+  });
+
+  describe('with comma as decimal', function() {
+    support.withTranslations({
+      currency_delimiter: ".",
+      currency_separator: ","
+    });
+
+    it('can format USD', function() {
+      expect(Spree.formatMoney(10, 'USD')).to.equal('$10,00');
+      expect(Spree.formatMoney('10', 'USD')).to.equal('$10,00');
+      expect(Spree.formatMoney(12.34, 'USD')).to.equal('$12,34');
+      expect(Spree.formatMoney('12.34', 'USD')).to.equal('$12,34');
+      expect(Spree.formatMoney(1000, 'GBP')).to.equal('£1.000,00');
+    });
+
+    it('can format EUR', function() {
+      expect(Spree.formatMoney(1000, 'EUR')).to.equal('€1.000,00');
+    });
+
+    it('can format YEN', function() {
+      expect(Spree.formatMoney(1000, 'JPY')).to.equal('¥1.000');
+    });
+  });
+});

--- a/backend/spec/javascripts/spec_helper.js
+++ b/backend/spec/javascripts/spec_helper.js
@@ -1,3 +1,4 @@
+//= require ./support/show_errors
 //= require support/sinon
 //= require support/chai
 

--- a/backend/spec/javascripts/spec_helper.js
+++ b/backend/spec/javascripts/spec_helper.js
@@ -1,0 +1,9 @@
+//= require support/sinon
+//= require support/chai
+
+//= require_self
+//= require spree/backend
+//= require_tree ./support
+
+window.support = {};
+window.expect = chai.expect;

--- a/backend/spec/javascripts/spec_helper.js
+++ b/backend/spec/javascripts/spec_helper.js
@@ -1,6 +1,7 @@
 //= require ./support/show_errors
 //= require support/sinon
 //= require support/chai
+//= require support/chai-jq-0.0.7
 
 //= require_self
 //= require spree/backend

--- a/backend/spec/javascripts/support/show_errors.js
+++ b/backend/spec/javascripts/support/show_errors.js
@@ -1,0 +1,8 @@
+/* Teaspoon doesn't show errors by default */
+window.onerror = function(message) {
+  Teaspoon.log(JSON.stringify({
+    _teaspoon: true,
+    type: "exception",
+    message:  message
+  }));
+}

--- a/backend/spec/javascripts/support/with_translations.js
+++ b/backend/spec/javascripts/support/with_translations.js
@@ -1,0 +1,11 @@
+support.withTranslations = function(translations) {
+  beforeEach(function() {
+    this._oldTranslations = Spree.translations;
+    Spree.translations = translations;
+  });
+
+  afterEach(function() {
+    Spree.translations = this._oldTranslations;
+  });
+};
+

--- a/backend/spec/javascripts/translation_spec.js
+++ b/backend/spec/javascripts/translation_spec.js
@@ -1,0 +1,50 @@
+describe('Spree.t', function() {
+  support.withTranslations({
+    simple: "simple",
+    nested: {
+      key: "nested key"
+    },
+    deeply: {
+      nested: {
+        key: "deeply nested key"
+      }
+    }
+  })
+
+  it('can get a simple key', function() {
+    expect(Spree.t('simple')).to.equal('simple');
+  });
+
+  it('can get a nested key', function() {
+    expect(Spree.t('nested.key')).to.equal('nested key');
+  });
+
+  it('can get a nested key using scope', function() {
+    expect(Spree.t('key', {scope: 'nested'})).to.equal('nested key');
+  });
+
+  it('can get a deeply nested key', function() {
+    expect(Spree.t('deeply.nested.key')).to.equal('deeply nested key');
+  });
+
+  it('can get a deeply nested key using scope', function() {
+    expect(Spree.t('nested.key', {scope: 'deeply'})).to.equal('deeply nested key');
+    expect(Spree.t('key', {scope: 'deeply.nested'})).to.equal('deeply nested key');
+  });
+});
+
+describe('Spree.human_attribute_name', function() {
+  support.withTranslations({
+    activerecord: {
+      attributes: {
+        "spree/model": {
+          "name": "Name"
+        }
+      }
+    }
+  });
+
+  it('can get attribute names', function() {
+    expect(Spree.human_attribute_name('spree/model', "name")).to.equal('Name');
+  });
+});

--- a/backend/spec/javascripts/views/number_with_currency_spec.js
+++ b/backend/spec/javascripts/views/number_with_currency_spec.js
@@ -1,0 +1,72 @@
+fixture.preload("number_with_currency/with_currency_select", "number_with_currency/without_select");
+
+describe("Spree.Views.NumberWithCurrency", function() {
+  var view, $el;
+  var $symbol, $input, $select, $addon;
+
+  var loadFixture = function(path) {
+    var fixtures = fixture.load(path, true);
+    $el = $(fixtures[0]);
+  }
+
+  var loadView = function() {
+    view = new Spree.Views.NumberWithCurrency({el: $el});
+    view.render();
+    $symbol = $el.find('.number-with-currency-symbol');
+    $input = $el.find('input');
+    $select = $el.find('select');
+    $addon = $el.find('.number-with-currency-addon');
+  }
+
+  describe("with currency selector", function() {
+    beforeEach(function() {
+      loadFixture("number_with_currency/with_currency_select");
+      loadView();
+    });
+
+    it("has no currency selected", function() {
+      expect($select).to.have.$val('');
+      expect($symbol).to.have.$text('');
+    });
+
+    it("can select USD", function() {
+      $select.val('USD').trigger('change');
+
+      expect($select).to.have.$val('USD');
+      expect($symbol).to.have.$text('$');
+    });
+
+    it("can select GBP", function() {
+      $select.val('GBP').trigger('change');
+
+      expect($select).to.have.$val('GBP');
+      expect($symbol).to.have.$text('£');
+    });
+
+    it("can select JPY", function() {
+      $select.val('JPY').trigger('change');
+
+      expect($select).to.have.$val('JPY');
+      expect($symbol).to.have.$text('¥');
+    });
+  });
+
+  describe("without currency selector", function() {
+    beforeEach(function() {
+      loadFixture("number_with_currency/without_select");
+      loadView();
+    });
+
+    it("uses USD format", function() {
+      $el.find('[data-currency]').data('currency', 'USD');
+      view.render();
+      expect($symbol).to.have.$text('$');
+    });
+
+    it("uses JPY format", function() {
+      $el.find('[data-currency]').data('currency', 'JPY');
+      view.render();
+      expect($symbol).to.have.$text('¥');
+    });
+  });
+});

--- a/backend/spec/teaspoon_env.rb
+++ b/backend/spec/teaspoon_env.rb
@@ -1,0 +1,14 @@
+Teaspoon.configure do |config|
+  config.mount_at = "/teaspoon"
+  config.root = Spree::Backend::Engine.root
+  config.asset_paths = ["spec/javascripts", "spec/javascripts/stylesheets"]
+  config.fixture_paths = ["spec/javascripts/fixtures"]
+
+  config.suite do |suite|
+    suite.use_framework :mocha, "2.3.3"
+    suite.matcher = "{spec/javascripts,app/assets}/**/*_spec.{js,js.coffee,coffee}"
+    suite.helper = "spec_helper"
+    suite.boot_partial = "/boot"
+    suite.expand_assets = true
+  end
+end

--- a/backend/spec/teaspoon_env.rb
+++ b/backend/spec/teaspoon_env.rb
@@ -1,3 +1,6 @@
+ENV['RAILS_ENV'] = 'test'
+require File.expand_path("../dummy/config/environment", __FILE__)
+
 Teaspoon.configure do |config|
   config.mount_at = "/teaspoon"
   config.root = Spree::Backend::Engine.root

--- a/build-ci.rb
+++ b/build-ci.rb
@@ -161,16 +161,40 @@ class Project
   # @return [Boolean]
   #   the success of the tests
   def run_tests
-    system(%w[bundle exec rspec] + rspec_arguments)
+    @success = true
+    run_test_cmd(%w[bundle exec rspec] + rspec_arguments)
+    if name == "backend"
+      run_test_cmd(%w[bundle exec teaspoon] + teaspoon_arguments)
+    end
+    @success
+  end
+
+  def run_test_cmd(*args)
+    puts "Run: #{args.join(' ')}"
+    result = system(*args)
+    puts(result ? "Success" : "Failed")
+    @success &&= result
+  end
+
+  def teaspoon_arguments
+    if report_dir
+      %W[--format documentation,junit>#{report_dir}/rspec/#{name}_js.xml]
+    else
+      %w[--format documentation]
+    end
   end
 
   def rspec_arguments
     args = []
     args += %w[--format documentation --profile 10]
-    if report_dir = ENV['CIRCLE_TEST_REPORTS']
+    if report_dir
       args += %W[-r rspec_junit_formatter --format RspecJunitFormatter -o #{report_dir}/rspec/#{name}.xml]
     end
     args
+  end
+
+  def report_dir
+    ENV['CIRCLE_TEST_REPORTS']
   end
 
   # Execute system command via execve

--- a/build.sh
+++ b/build.sh
@@ -26,7 +26,7 @@ cd api; set_gemfile; bundle update --quiet; bundle exec rspec spec
 echo "******************************************"
 echo "* Setup Spree Backend and running RSpec..."
 echo "******************************************"
-cd ../backend; set_gemfile; bundle update --quiet; bundle exec rspec spec
+cd ../backend; set_gemfile; bundle update --quiet; bundle exec rspec spec; bundle exec teaspoon
 
 # Spree Core
 echo "***************************************"

--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,7 @@ machine:
   services:
     - postgresql
   ruby:
-    version: 2.3.0
+    version: 2.3.4
   pre:
     - sudo curl --output /usr/local/bin/phantomjs https://s3.amazonaws.com/circle-downloads/phantomjs-2.1.1
 dependencies:

--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -40,6 +40,7 @@ end
 group :test, :development do
   gem 'rubocop'
   gem 'pry'
+  gem 'listen', '~> 3.1.5'
 
   platforms :mri do
     gem 'byebug'


### PR DESCRIPTION
Our backend JS is growing, but at the same time is becoming more structured. It was suggested by @braidn in our slack that we add JavaScript unit tests, which we should.

This PR adds the [teaspoon](https://github.com/jejacks0n/teaspoon) Javascript test runner for Rails. Mocha and chai are used, which gives us a somewhat rspec-like syntax to write specs in. When invoked on the command line specs are run in a phantomjs browser, but can also be manually run in a browser.

```
describe('Foo', function() {
  it('is foo', function() {
    expect('foo').to.equal('foo');
  });
});
```

The purpose for these tests is to test JavaScript independently from our ruby/rails code. When integration testing we should still rely on capybara.

## Todo

* [x] Run teaspoon on CI, and as part of `build.sh`
* [x] Write at least one real spec
* [x] Check that teaspoon works under sprockets 4.0 (current gem release doesn't but git master does. Good enough for now.)
* [x] Make sure teaspoon raises syntax errors
