### PR TITLE
Fix datepicker style

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/components/_date-picker.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_date-picker.scss
@@ -9,6 +9,7 @@
   border-radius: $border-radius;
   padding: 0;
   margin-top: 10px;
+  width: auto;
 
   &:before {
     content: '';
@@ -51,7 +52,7 @@
         background-image: none;
         text-indent: 0;
         color: $color-1;
-        width: 10px;
+        width: 13px;
         margin-left: -5px;
 
         &:hover {


### PR DESCRIPTION
Probably #1777 introduced some date-picker visual bugs.

This PR:

- adjusts width of the whole datepicker to adapt to its content, was: [`width: 17em`](https://github.com/solidusio/solidus/blame/master/backend/vendor/assets/stylesheets/jquery-ui.datepicker.css.erb#L299);
- gives more spaces to arrows that currently are not completely shown. Changes width from 10px to 13px.

**Before**

<img width="347" alt="datepicker-before" src="https://cloud.githubusercontent.com/assets/167946/24749291/cd52d22e-1ac2-11e7-8234-c65ce11d49e5.png">


**After**

<img width="377" alt="datepicker-after" src="https://cloud.githubusercontent.com/assets/167946/24749294/d4ce759e-1ac2-11e7-8780-763b111d5b5c.png">

