### PR TITLE
Table header fixes

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/sections/_return_authorizations.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/_return_authorizations.scss
@@ -1,6 +1,4 @@
 .return-items-table {
-  table-layout: fixed;
-
   .refund-amount-input {
     width: 80px;
   }

--- a/backend/app/assets/stylesheets/spree/backend/shared/_tables.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_tables.scss
@@ -138,6 +138,7 @@ table {
       background-color: $color-tbl-thead;
       text-align: center;
       font-weight: $font-weight-bold;
+      vertical-align: top;
     }
   }
 

--- a/backend/app/assets/stylesheets/spree/backend/shared/_tables.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_tables.scss
@@ -127,7 +127,7 @@ table {
 
   }
 
-  th, td.actions, td.no-wrap, .state {
+  th:not(.wrap-text), td.actions, td.no-wrap, .state {
     white-space: nowrap;
   }
 

--- a/backend/app/views/spree/admin/customer_returns/_return_item_decision.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/_return_item_decision.html.erb
@@ -3,13 +3,13 @@
     <tr>
       <th><%= Spree::Product.model_name.human %></th>
       <th><%= Spree::Variant.human_attribute_name(:sku) %></th>
-      <th><%= Spree::ReturnItem.human_attribute_name(:amount) %></th>
-      <th><%= Spree::ReturnItem.human_attribute_name(:preferred_reimbursement_type) %></th>
-      <th><%= Spree::ReturnItem.human_attribute_name(:exchange_variant) %></th>
-      <th><%= Spree::ReturnItem.human_attribute_name(:acceptance_status_errors) %></th>
-      <th><%= Spree::ReturnItem.human_attribute_name(:reception_status) %></th>
+      <th class="wrap-text"><%= Spree::ReturnItem.human_attribute_name(:amount) %></th>
+      <th class="wrap-text"><%= Spree::ReturnItem.human_attribute_name(:preferred_reimbursement_type) %></th>
+      <th class="wrap-text"><%= Spree::ReturnItem.human_attribute_name(:exchange_variant) %></th>
+      <th class="wrap-text"><%= Spree::ReturnItem.human_attribute_name(:acceptance_status_errors) %></th>
+      <th class="wrap-text"><%= Spree::ReturnItem.human_attribute_name(:reception_status) %></th>
       <% unless return_items.all?(&:received?)%>
-        <th><%= Spree::ReturnItem.human_attribute_name(:item_received?) %></th>
+        <th class="wrap-text"><%= Spree::ReturnItem.human_attribute_name(:item_received?) %></th>
       <% end %>
       <% if show_decision %>
         <th class="actions"></th>

--- a/backend/app/views/spree/admin/customer_returns/_return_item_selection.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/_return_item_selection.html.erb
@@ -6,12 +6,12 @@
       </th>
       <th><%= Spree::Product.model_name.human %></th>
       <th><%= Spree::Variant.human_attribute_name(:sku) %></th>
-      <th><%= Spree::ReturnItem.human_attribute_name(:amount) %></th>
-      <th><%= Spree::ReturnItem.human_attribute_name(:inventory_unit_state) %></th>
-      <th><%= Spree::ReturnItem.human_attribute_name(:exchange_variant) %></th>
+      <th class="wrap-text"><%= Spree::ReturnItem.human_attribute_name(:amount) %></th>
+      <th class="wrap-text"><%= Spree::ReturnItem.human_attribute_name(:inventory_unit_state) %></th>
+      <th class="wrap-text"><%= Spree::ReturnItem.human_attribute_name(:exchange_variant) %></th>
       <th><%= Spree::ReturnItem.human_attribute_name(:resellable) %></th>
-      <th><%= Spree::ReturnItem.human_attribute_name(:reception_status) %></th>
-      <th><%= Spree::ReturnItem.human_attribute_name(:return_reason) %></th>
+      <th class="wrap-text"><%= Spree::ReturnItem.human_attribute_name(:reception_status) %></th>
+      <th class="wrap-text"><%= Spree::ReturnItem.human_attribute_name(:return_reason) %></th>
     </tr>
   </thead>
   <tbody>

--- a/backend/app/views/spree/admin/reimbursements/edit.html.erb
+++ b/backend/app/views/spree/admin/reimbursements/edit.html.erb
@@ -16,11 +16,11 @@
       <thead>
         <tr>
           <th><%= Spree::Product.model_name.human %></th>
-          <th><%= Spree::ReturnItem.human_attribute_name(:preferred_reimbursement_type_id) %></th>
-          <th><%= Spree::ReturnItem.human_attribute_name(:override_reimbursement_type_id) %></th>
-          <th><%= Spree::ReturnItem.human_attribute_name(:amount) %></th>
+          <th class="wrap-text"><%= Spree::ReturnItem.human_attribute_name(:preferred_reimbursement_type_id) %></th>
+          <th class="wrap-text"><%= Spree::ReturnItem.human_attribute_name(:override_reimbursement_type_id) %></th>
+          <th class="wrap-text"><%= Spree::ReturnItem.human_attribute_name(:amount) %></th>
           <th><%= Spree::ReturnItem.human_attribute_name(:total) %></th>
-          <th><%= Spree::ReturnItem.human_attribute_name(:exchange_variant) %></th>
+          <th class="wrap-text"><%= Spree::ReturnItem.human_attribute_name(:exchange_variant) %></th>
         </tr>
       </thead>
       <tbody>

--- a/backend/app/views/spree/admin/reimbursements/show.html.erb
+++ b/backend/app/views/spree/admin/reimbursements/show.html.erb
@@ -15,10 +15,10 @@
     <thead>
       <tr>
         <th><%= Spree::Product.model_name.human %></th>
-        <th><%= Spree::ReturnItem.human_attribute_name(:preferred_reimbursement_type_id) %></th>
-        <th><%= Spree::ReturnItem.human_attribute_name(:override_reimbursement_type_id) %></th>
-        <th><%= Spree::ReturnItem.human_attribute_name(:exchange_variant) %></th>
-        <th><%= Spree::ReturnItem.human_attribute_name(:amount) %></th>
+        <th class="wrap-text"><%= Spree::ReturnItem.human_attribute_name(:preferred_reimbursement_type_id) %></th>
+        <th class="wrap-text"><%= Spree::ReturnItem.human_attribute_name(:override_reimbursement_type_id) %></th>
+        <th class="wrap-text"><%= Spree::ReturnItem.human_attribute_name(:exchange_variant) %></th>
+        <th class="wrap-text"><%= Spree::ReturnItem.human_attribute_name(:amount) %></th>
         <th><%= Spree::ReturnItem.human_attribute_name(:total) %></th>
       </tr>
     </thead>

--- a/backend/app/views/spree/admin/return_authorizations/_form.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/_form.html.erb
@@ -12,8 +12,8 @@
         <th class="return-item-product"><%= Spree::Product.model_name.human %></th>
         <th class="return-item-state"><%= Spree::ReturnAuthorization.human_attribute_name(:state) %></th>
         <th class="return-item-charged"><%= Spree::ReturnItem.human_attribute_name(:charged) %></th>
-        <th class="return-item-pre-tax-refund-amount"><%= Spree::ReturnItem.human_attribute_name(:amount) %></th>
-        <th class="return-item-reimbursement-type"><%= Spree::ReimbursementType.model_name.human %></th>
+        <th class="return-item-pre-tax-refund-amount wrap-text"><%= Spree::ReturnItem.human_attribute_name(:amount) %></th>
+        <th class="return-item-reimbursement-type wrap-text"><%= Spree::ReimbursementType.model_name.human %></th>
         <th class="return-item-exchange-for"><%= Spree::ReturnItem.human_attribute_name(:exchange_variant) %></th>
         <th class="return-item-reason"><%= Spree::ReturnItem.human_attribute_name(:return_reason) %></th>
       </tr>

--- a/backend/app/views/spree/admin/store_credits/index.html.erb
+++ b/backend/app/views/spree/admin/store_credits/index.html.erb
@@ -18,13 +18,13 @@
 
   <table id="sc-table">
     <thead>
-      <th><%= Spree::StoreCredit.human_attribute_name(:amount_credited) %></th>
-      <th><%= Spree::StoreCredit.human_attribute_name(:amount_used) %></th>
-      <th><%= Spree::StoreCredit.human_attribute_name(:amount_authorized) %></th>
-      <th><%= Spree::StoreCredit.human_attribute_name(:category_id) %></th>
-      <th><%= Spree::StoreCredit.human_attribute_name(:created_by_id) %></th>
-      <th><%= Spree::StoreCredit.human_attribute_name(:created_at) %></th>
-      <th><%= Spree::StoreCredit.human_attribute_name(:invalidated_at) %></th>
+      <th class="wrap-text"><%= Spree::StoreCredit.human_attribute_name(:amount_credited) %></th>
+      <th class="wrap-text"><%= Spree::StoreCredit.human_attribute_name(:amount_used) %></th>
+      <th class="wrap-text"><%= Spree::StoreCredit.human_attribute_name(:amount_authorized) %></th>
+      <th class="wrap-text"><%= Spree::StoreCredit.human_attribute_name(:category_id) %></th>
+      <th class="wrap-text"><%= Spree::StoreCredit.human_attribute_name(:created_by_id) %></th>
+      <th class="wrap-text"><%= Spree::StoreCredit.human_attribute_name(:created_at) %></th>
+      <th class="wrap-text"><%= Spree::StoreCredit.human_attribute_name(:invalidated_at) %></th>
       <th data-hook="admin_store_credits_index_header_actions" class="actions"></th>
     <thead>
     <tbody>


### PR DESCRIPTION
With the recent changes to table headers in 0dcc028 text doesn’t wrap.

The reimbursement and customer returns table headers carry too much information in them. Instead of rewriting these tables into forms right now, we re-enable text wrapping for this headers by using the newly introduced .wrap-text class.
