### PR TITLE
Add deprecation notices to documentation

### DIFF
--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -105,11 +105,13 @@ module Spree
       value_attributes == other_address.value_attributes
     end
 
+    # @deprecated Do not use this. Use Address.== instead.
     def same_as?(other_address)
       Spree::Deprecation.warn("Address#same_as? is deprecated. It's equivalent to Address.==", caller)
       self == other_address
     end
 
+    # @deprecated Do not use this. Use Address.== instead.
     def same_as(other_address)
       Spree::Deprecation.warn("Address#same_as is deprecated. It's equivalent to Address.==", caller)
       self == other_address


### PR DESCRIPTION
same_as? and same_as are deprecated. Show the deprecation
notices and a helpful alternative in the documentation.