### PR TITLE
Fix missing close paren in variantAutocomplete

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/variant_autocomplete.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/variant_autocomplete.js.coffee
@@ -33,7 +33,7 @@ $.fn.variantAutocomplete = (searchOptions = {}) ->
 
     formatResult: formatVariantResult
     formatSelection: (variant, container, escapeMarkup) ->
-      if !!variant.options_text
-        Select2.util.escapeMarkup("#{variant.name} (#{variant.options_text}")
+      if variant.options_text
+        Select2.util.escapeMarkup("#{variant.name} (#{variant.options_text})")
       else
         Select2.util.escapeMarkup(variant.name)


### PR DESCRIPTION
Also remove unnecessary double `!!`

Thanks to @stewart for pointing this out.