### PR TITLE
Fix Solidus' behaviour when confirm state does not exist

### DIFF
--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -98,7 +98,7 @@ module Spree
         else
           @order.contents.advance
 
-          if @order.confirm?
+          if @order.can_complete?
             flash[:success] = Spree.t('order_ready_for_confirm')
           else
             flash[:error] = @order.errors.full_messages
@@ -111,7 +111,7 @@ module Spree
       def confirm
         if @order.completed?
           redirect_to edit_admin_order_url(@order)
-        elsif !@order.confirm?
+        elsif !@order.can_complete?
           render template: 'spree/admin/orders/confirm_advance'
         end
       end

--- a/backend/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -163,7 +163,7 @@ describe Spree::Admin::OrdersController, type: :controller do
         end
 
         context 'when successful' do
-          before { allow(order).to receive(:confirm?).and_return(true) }
+          before { allow(order).to receive(:can_complete?).and_return(true) }
 
           it 'messages and redirects' do
             subject
@@ -174,7 +174,7 @@ describe Spree::Admin::OrdersController, type: :controller do
 
         context 'when unsuccessful' do
           before do
-            allow(order).to receive(:confirm?).and_return(false)
+            allow(order).to receive(:can_complete?).and_return(false)
             allow(order).to receive(:errors).and_return(double(full_messages: ['failed']))
           end
 
@@ -203,7 +203,7 @@ describe Spree::Admin::OrdersController, type: :controller do
       end
 
       context 'when in confirm' do
-        before { allow(order).to receive_messages completed?: false, confirm?: true }
+        before { allow(order).to receive_messages completed?: false, can_complete?: true }
 
         it 'renders the confirm page' do
           subject
@@ -213,7 +213,7 @@ describe Spree::Admin::OrdersController, type: :controller do
       end
 
       context 'when before confirm' do
-        before { allow(order).to receive_messages completed?: false, confirm?: false }
+        before { allow(order).to receive_messages completed?: false, can_complete?: false }
 
         it 'renders the confirm_advance template (to allow refreshing of the order)' do
           subject

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -672,7 +672,7 @@ module Spree
     end
 
     def total_applicable_store_credit
-      if confirm? || complete?
+      if can_complete? || complete?
         payments.store_credits.valid.sum(:amount)
       else
         [total, (user.try(:total_available_store_credit) || 0.0)].min

--- a/core/spec/models/spree/promotion_code_spec.rb
+++ b/core/spec/models/spree/promotion_code_spec.rb
@@ -155,12 +155,12 @@ RSpec.describe Spree::PromotionCode do
     end
     let(:promo_adjustment) { order.adjustments.promotion.first }
     before do
-      order.next! until order.confirm?
+      order.next! until order.can_complete?
 
       FactoryGirl.create(:order_with_line_items, line_items_price: 40, shipment_cost: 0).tap do |order|
         FactoryGirl.create(:payment, amount: 30, order: order)
         promotion.activate(order: order, promotion_code: code)
-        order.next! until order.confirm?
+        order.next! until order.can_complete?
         order.complete!
       end
     end

--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -62,7 +62,7 @@ module Spree
     end
 
     def transition_forward
-      if @order.confirm?
+      if @order.can_complete?
         @order.complete
       else
         @order.next


### PR DESCRIPTION
For stores that redefine their state machine in such a way that you can
transition to complete from other states than confirm (a requirement
that happens e.g. when not having a confirm step, and orders transition
directly from payment), we can not rely on the order's confirm state.
Instead, we can use state machines' `can_complete?` method, which
checks whether the `complete` transition can be executed from the
current state.

For Solidus' default state machine, this change does not change anything.