### PR TITLE
Only load active payment methods in the backend

### DIFF
--- a/backend/app/controllers/spree/admin/payments_controller.rb
+++ b/backend/app/controllers/spree/admin/payments_controller.rb
@@ -78,7 +78,7 @@ module Spree
 
       def load_data
         @amount = params[:amount] || load_order.total
-        @payment_methods = Spree::PaymentMethod.available_to_admin
+        @payment_methods = Spree::PaymentMethod.active.available_to_admin
         if @payment && @payment.payment_method
           @payment_method = @payment.payment_method
         else

--- a/backend/spec/controllers/spree/admin/payments_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/payments_controller_spec.rb
@@ -75,14 +75,28 @@ module Spree
       describe '#new' do
         # Regression test for https://github.com/spree/spree/issues/3233
         context "with a backend payment method" do
-          before do
-            @payment_method = create(:check_payment_method, available_to_admin: true)
+          context "and the payment method is active" do
+            before do
+              @payment_method = create(:check_payment_method, available_to_admin: true)
+            end
+
+            it "loads the payment method" do
+              get :new, params: { order_id: order.number }
+              expect(response.status).to eq(200)
+              expect(assigns[:payment_methods]).to include(@payment_method)
+            end
           end
 
-          it "loads backend payment methods" do
-            get :new, params: { order_id: order.number }
-            expect(response.status).to eq(200)
-            expect(assigns[:payment_methods]).to include(@payment_method)
+          context "and the payment method is inactive" do
+            before do
+              @payment_method = create(:check_payment_method, available_to_admin: true, active: false)
+            end
+
+            it "does not load the payment method" do
+              get :new, params: { order_id: order.number }
+              expect(response.status).to eq(200)
+              expect(assigns[:payment_methods]).to be_empty
+            end
           end
         end
       end


### PR DESCRIPTION
When the `display_on` column was removed and we switched to `available_to_users`/`available_to_admin`, we stopped using the `available` scope, which was restricted to active payment methods only.

The new scopes corresponding to the `available_to_*` columns are not restricted to active payment methods only, so we need to explicitly add that scope now.