### PR TITLE
Fix outstanding balance calculation with refunds

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -365,14 +365,10 @@ module Spree
     deprecate create_tax_charge!: :update!, deprecator: Spree::Deprecation
 
     def outstanding_balance
-      # If reimbursement has happened add it back to total to prevent balance_due payment state
-      # See: https://github.com/spree/spree/issues/6229
-      adjusted_payment_total = payment_total + refund_total
-
       if state == 'canceled'
-        -1 * adjusted_payment_total
+        -1 * payment_total
       else
-        total - adjusted_payment_total
+        total - payment_total
       end
     end
 

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -368,7 +368,7 @@ module Spree
       if state == 'canceled'
         -1 * payment_total
       else
-        total - payment_total
+        total - payment_total - refund_total
       end
     end
 

--- a/core/spec/models/spree/order/payment_spec.rb
+++ b/core/spec/models/spree/order/payment_spec.rb
@@ -188,9 +188,9 @@ module Spree
 
         context "for non-canceled orders" do
           it 'should incorporate refund reimbursements' do
-            # Order Total - Payment Total
-            # 110 - 100 = 10
-            expect(order.outstanding_balance).to eq 10
+            # Order Total - Payment Total - Refund Total
+            # 110 - 100 - 10 = 0
+            expect(order.outstanding_balance).to eq 0
           end
         end
       end

--- a/core/spec/models/spree/order/payment_spec.rb
+++ b/core/spec/models/spree/order/payment_spec.rb
@@ -169,9 +169,7 @@ module Spree
         let(:order) { reimbursement.order.reload }
 
         before do
-          # Set the payment amount to actually be the order total of 110
-          reimbursement.order.payments.first.update_column :amount, amount
-          # Creates a refund of 110
+          # Creates a refund of 10
           create :refund, amount: amount,
                           payment: reimbursement.order.payments.first,
                           reimbursement: reimbursement
@@ -183,15 +181,16 @@ module Spree
           before { order.update_attributes(state: 'canceled') }
 
           it "it should be a negative amount incorporating reimbursements" do
-            expect(order.outstanding_balance).to eq(-10)
+            # -1 * Payment Total
+            expect(order.outstanding_balance).to eq(-100)
           end
         end
 
         context "for non-canceled orders" do
           it 'should incorporate refund reimbursements' do
-            # Order Total - (Payment Total + Reimbursed)
-            # 110 - (0 + 10) = 100
-            expect(order.outstanding_balance).to eq 100
+            # Order Total - Payment Total
+            # 110 - 100 = 10
+            expect(order.outstanding_balance).to eq 10
           end
         end
       end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -215,6 +215,7 @@ describe Spree::Order, type: :model do
       expect(order.outstanding_balance).to be_negative
       expect(order.payment_state).to eq('credit_owed')
       create(:refund, amount: order.outstanding_balance.abs, payment: payment, transaction_id: nil)
+      order.reload
       expect(order.outstanding_balance).to eq(0)
       expect(order.payment_state).to eq('paid')
     end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -215,7 +215,7 @@ describe Spree::Order, type: :model do
       expect(order.outstanding_balance).to be_negative
       expect(order.payment_state).to eq('credit_owed')
       create(:refund, amount: order.outstanding_balance.abs, payment: payment, transaction_id: nil)
-      order.reload
+      order.update!
       expect(order.outstanding_balance).to eq(0)
       expect(order.payment_state).to eq('paid')
     end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -206,6 +206,20 @@ describe Spree::Order, type: :model do
     end
   end
 
+  context '#outstanding_balance' do
+    let(:order) { create(:order_ready_to_ship, line_items_count: 3) }
+    let(:payment) { order.payments.first }
+
+    it "should handle refunds properly" do
+      order.cancellations.short_ship([order.inventory_units.first])
+      expect(order.outstanding_balance).to be_negative
+      expect(order.payment_state).to eq('credit_owed')
+      create(:refund, amount: order.outstanding_balance.abs, payment: payment, transaction_id: nil)
+      expect(order.outstanding_balance).to eq(0)
+      expect(order.payment_state).to eq('paid')
+    end
+  end
+
   context "#display_outstanding_balance" do
     it "returns the value as a spree money" do
       allow(order).to receive(:outstanding_balance) { 10.55 }


### PR DESCRIPTION
payment_total includes all refunds on the payments as well so there
is no reason to recalculate that in #outstanding_balance

Fixes #1475 