### PR TITLE
Fix background of nav header

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/components/_navigation.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_navigation.scss
@@ -32,6 +32,7 @@ nav.menu {
 }
 
 .admin-nav-header {
+  background-color: $color-1;
   border-bottom: 1px solid $color-border;
   text-align: center;
   // Using line height for proper vertical centering.


### PR DESCRIPTION
In #1838 we lost the background colour of the nav header.

**Before**

![](http://i.hawth.ca/s/53MWZY8H.png)

**After**
![](http://i.hawth.ca/s/f9BbzRmE.png)