### PR TITLE
[RFC] New users table layout

### DIFF
--- a/backend/app/controllers/spree/admin/users_controller.rb
+++ b/backend/app/controllers/spree/admin/users_controller.rb
@@ -110,6 +110,7 @@ module Spree
         else
           @search = Spree.user_class.ransack(params[:q])
           @collection = @search.result.includes(:spree_roles)
+          @collection = @collection.includes(:spree_orders)
           @collection = @collection.page(params[:page]).per(Spree::Config[:admin_products_per_page])
         end
       end

--- a/backend/app/controllers/spree/admin/users_controller.rb
+++ b/backend/app/controllers/spree/admin/users_controller.rb
@@ -5,7 +5,8 @@ module Spree
 
       after_action :sign_in_if_change_own_password, only: :update
 
-      before_action :load_roles, :load_stock_locations, only: [:edit, :new]
+      before_action :load_roles, only: [:index, :edit, :new]
+      before_action :load_stock_locations, only: [:edit, :new]
 
       def index
         respond_with(@collection) do |format|
@@ -108,7 +109,8 @@ module Spree
                             .limit(params[:limit] || 100)
         else
           @search = Spree.user_class.ransack(params[:q])
-          @collection = @search.result.page(params[:page]).per(Spree::Config[:admin_products_per_page])
+          @collection = @search.result.includes(:spree_roles)
+          @collection = @collection.page(params[:page]).per(Spree::Config[:admin_products_per_page])
         end
       end
 
@@ -140,7 +142,9 @@ module Spree
 
       def load_roles
         @roles = Spree::Role.all
-        @user_roles = @user.spree_roles
+        if @user
+          @user_roles = @user.spree_roles
+        end
       end
 
       def load_stock_locations

--- a/backend/app/views/spree/admin/users/index.html.erb
+++ b/backend/app/views/spree/admin/users/index.html.erb
@@ -27,6 +27,8 @@
   </div>
 <% end %>
 
+<%= paginate @users, theme: "solidus_admin" %>
+
 <table class="index" id="listing_users" data-hook>
   <colgroup>
     <col style="width: 90%">

--- a/backend/app/views/spree/admin/users/index.html.erb
+++ b/backend/app/views/spree/admin/users/index.html.erb
@@ -15,9 +15,20 @@
 <% content_for :table_filter do %>
   <div data-hook="admin_users_index_search">
     <%= search_form_for [:admin, @search], url: admin_users_url do |f| %>
-      <div class="form-group">
-        <%= f.label :email_cont, Spree.t(:email) %>
-        <%= f.text_field :email_cont, class: "form-control" %>
+      <div class="row">
+        <div class="col-xs-12 col-md-6">
+          <div class="form-group">
+            <%= f.label :email_cont, Spree.t(:email) %>
+            <%= f.text_field :email_cont, class: "form-control" %>
+          </div>
+        </div>
+        <div class="col-xs-12 col-md-6">
+          <div class="form-group">
+            <%= f.label :spree_roles_id_in, Spree.user_class.human_attribute_name(:spree_roles) %>
+            <%= f.collection_select :spree_roles_id_in, @roles, :id, :name, {},
+              multiple: true, class: 'select2 fullwidth' %>
+          </div>
+        </div>
       </div>
 
       <div class="actions filter-actions" data-hook="admin_users_index_search_buttons">
@@ -31,12 +42,14 @@
 
 <table class="index" id="listing_users" data-hook>
   <colgroup>
-    <col style="width: 90%">
+    <col style="width: 45%">
+    <col style="width: 45%">
     <col style="width: 10%">
   </colgroup>
   <thead>
     <tr data-hook="admin_users_index_headers">
       <th><%= sort_link @search,:email, Spree::LegacyUser.model_name.human, {}, {title: 'users_email_title'} %></th>
+      <th><%= Spree.user_class.human_attribute_name(:spree_roles) %></th>
       <th data-hook="admin_users_index_header_actions" class="actions"></th>
     </tr>
   </thead>
@@ -44,6 +57,7 @@
     <% @users.each do |user|%>
       <tr id="<%= spree_dom_id user %>" data-hook="admin_users_index_rows">
         <td class='user_email'><%=link_to user.email, edit_admin_user_url(user) %></td>
+        <td><%= user.spree_roles.map(&:name).to_sentence %></td>
         <td data-hook="admin_users_index_row_actions" class="actions">
           <% if can?(:edit, user) %>
             <%= link_to_edit user, no_text: true %>

--- a/backend/app/views/spree/admin/users/index.html.erb
+++ b/backend/app/views/spree/admin/users/index.html.erb
@@ -65,7 +65,7 @@
   </colgroup>
   <thead>
     <tr data-hook="admin_users_index_headers">
-      <th><%= sort_link @search, :email, Spree::LegacyUser.model_name.human, {}, {title: 'users_email_title'} %></th>
+      <th><%= sort_link @search, :email, Spree.user_class.human_attribute_name(:email), {}, {title: 'users_email_title'} %></th>
       <th><%= Spree.user_class.human_attribute_name(:spree_roles) %></th>
       <th><%= sort_link @search, :created_at, Spree.t(:member_since) %></th>
       <th data-hook="admin_users_index_header_actions" class="actions"></th>

--- a/backend/app/views/spree/admin/users/index.html.erb
+++ b/backend/app/views/spree/admin/users/index.html.erb
@@ -58,16 +58,18 @@
 
 <table class="index" id="listing_users" data-hook>
   <colgroup>
-    <col style="width: 50%">
+    <col style="width: 40%">
     <col style="width: 20%">
     <col style="width: 20%">
+    <col style="width: 10%">
     <col style="width: 10%">
   </colgroup>
   <thead>
     <tr data-hook="admin_users_index_headers">
       <th><%= sort_link @search, :email, Spree.user_class.human_attribute_name(:email), {}, {title: 'users_email_title'} %></th>
       <th><%= Spree.user_class.human_attribute_name(:spree_roles) %></th>
-      <th><%= sort_link @search, :created_at, Spree.t(:member_since) %></th>
+      <th class="align-center"><%= Spree.t(:num_orders) %></th>
+      <th class="align-center"><%= sort_link @search, :created_at, Spree.t(:member_since) %></th>
       <th data-hook="admin_users_index_header_actions" class="actions"></th>
     </tr>
   </thead>
@@ -76,6 +78,7 @@
       <tr id="<%= spree_dom_id user %>" data-hook="admin_users_index_rows">
         <td class='user_email'><%=link_to user.email, edit_admin_user_url(user) %></td>
         <td><%= user.spree_roles.map(&:name).to_sentence %></td>
+        <td class="align-center"><%= link_to user.orders.count, spree.orders_admin_user_path(user) %></td>
         <td class="align-center"><%= l user.created_at.to_date %></td>
         <td data-hook="admin_users_index_row_actions" class="actions">
           <% if can?(:edit, user) %>

--- a/backend/app/views/spree/admin/users/index.html.erb
+++ b/backend/app/views/spree/admin/users/index.html.erb
@@ -60,7 +60,8 @@
   <colgroup>
     <col style="width: 40%">
     <col style="width: 20%">
-    <col style="width: 20%">
+    <col style="width: 10%">
+    <col style="width: 10%">
     <col style="width: 10%">
     <col style="width: 10%">
   </colgroup>
@@ -69,6 +70,7 @@
       <th><%= sort_link @search, :email, Spree.user_class.human_attribute_name(:email), {}, {title: 'users_email_title'} %></th>
       <th><%= Spree.user_class.human_attribute_name(:spree_roles) %></th>
       <th class="align-center"><%= Spree.t(:num_orders) %></th>
+      <th class="align-center"><%= Spree.user_class.human_attribute_name(:lifetime_value) %></th>
       <th class="align-center"><%= sort_link @search, :created_at, Spree.t(:member_since) %></th>
       <th data-hook="admin_users_index_header_actions" class="actions"></th>
     </tr>
@@ -79,6 +81,7 @@
         <td class='user_email'><%=link_to user.email, edit_admin_user_url(user) %></td>
         <td><%= user.spree_roles.map(&:name).to_sentence %></td>
         <td class="align-center"><%= link_to user.orders.count, spree.orders_admin_user_path(user) %></td>
+        <td class="align-center"><%= link_to user.display_lifetime_value, spree.items_admin_user_path(user) %></td>
         <td class="align-center"><%= l user.created_at.to_date %></td>
         <td data-hook="admin_users_index_row_actions" class="actions">
           <% if can?(:edit, user) %>

--- a/backend/app/views/spree/admin/users/index.html.erb
+++ b/backend/app/views/spree/admin/users/index.html.erb
@@ -16,17 +16,33 @@
   <div data-hook="admin_users_index_search">
     <%= search_form_for [:admin, @search], url: admin_users_url do |f| %>
       <div class="row">
-        <div class="col-xs-12 col-md-6">
+        <div class="col-xs-12 col-md-5">
           <div class="form-group">
             <%= f.label :email_cont, Spree.t(:email) %>
             <%= f.text_field :email_cont, class: "form-control" %>
           </div>
         </div>
-        <div class="col-xs-12 col-md-6">
+        <div class="col-xs-12 col-md-3">
           <div class="form-group">
             <%= f.label :spree_roles_id_in, Spree.user_class.human_attribute_name(:spree_roles) %>
             <%= f.collection_select :spree_roles_id_in, @roles, :id, :name, {},
               multiple: true, class: 'select2 fullwidth' %>
+          </div>
+        </div>
+        <div class="col-xs-12 col-md-4">
+          <div class="date-range-filter form-group">
+            <%= label_tag :q_created_at_gt, Spree.t(:member_since) %>
+            <div class="date-range-fields input-group">
+              <%= f.text_field :created_at_gt, class: 'datepicker form-control datepicker-from',
+                value: params[:q].try!("[]", :created_at_gt), placeholder: Spree.t(:start) %>
+
+              <span class="range-divider input-group-addon">
+                <i class="fa fa-arrow-right"></i>
+              </span>
+
+              <%= f.text_field :created_at_lt, class: 'datepicker form-control datepicker-to',
+                value: params[:q].try!("[]", :created_at_lt), placeholder: Spree.t(:stop) %>
+            </div>
           </div>
         </div>
       </div>
@@ -42,14 +58,16 @@
 
 <table class="index" id="listing_users" data-hook>
   <colgroup>
-    <col style="width: 45%">
-    <col style="width: 45%">
+    <col style="width: 50%">
+    <col style="width: 20%">
+    <col style="width: 20%">
     <col style="width: 10%">
   </colgroup>
   <thead>
     <tr data-hook="admin_users_index_headers">
-      <th><%= sort_link @search,:email, Spree::LegacyUser.model_name.human, {}, {title: 'users_email_title'} %></th>
+      <th><%= sort_link @search, :email, Spree::LegacyUser.model_name.human, {}, {title: 'users_email_title'} %></th>
       <th><%= Spree.user_class.human_attribute_name(:spree_roles) %></th>
+      <th><%= sort_link @search, :created_at, Spree.t(:member_since) %></th>
       <th data-hook="admin_users_index_header_actions" class="actions"></th>
     </tr>
   </thead>
@@ -58,6 +76,7 @@
       <tr id="<%= spree_dom_id user %>" data-hook="admin_users_index_rows">
         <td class='user_email'><%=link_to user.email, edit_admin_user_url(user) %></td>
         <td><%= user.spree_roles.map(&:name).to_sentence %></td>
+        <td class="align-center"><%= l user.created_at.to_date %></td>
         <td data-hook="admin_users_index_row_actions" class="actions">
           <% if can?(:edit, user) %>
             <%= link_to_edit user, no_text: true %>

--- a/backend/spec/features/admin/users_spec.rb
+++ b/backend/spec/features/admin/users_spec.rb
@@ -64,7 +64,8 @@ describe 'Users', type: :feature do
 
     it "can sort desc" do
       within_table(table_id) do
-        click_link sort_link
+        # Ransack adds a ▲ to the sort link. With exact match Capybara is not able to find that link
+        click_link sort_link, exact: false
 
         expect(page).to have_text text_match_1
         expect(page).to have_text text_match_2
@@ -94,6 +95,25 @@ describe 'Users', type: :feature do
       within_table('listing_users') do
         expect(page).to have_text user_a.email
         expect(page).not_to have_text user_b.email
+      end
+    end
+
+    context "member since" do
+      it_behaves_like "a sortable attribute" do
+        let(:text_match_1) { user_a.email }
+        let(:text_match_2) { user_b.email }
+        let(:table_id) { "listing_users" }
+        let(:sort_link) { Spree.t(:member_since) }
+      end
+
+      it 'displays the correct results for a user search by creation date' do
+        user_a.update_column(:created_at, 2.weeks.ago)
+        fill_in 'q_created_at_lt', with: 1.week.ago
+        click_button 'Search'
+        within_table('listing_users') do
+          expect(page).to have_text user_a.email
+          expect(page).not_to have_text user_b.email
+        end
       end
     end
 

--- a/core/app/models/concerns/spree/user_methods.rb
+++ b/core/app/models/concerns/spree/user_methods.rb
@@ -30,7 +30,7 @@ module Spree
 
       include Spree::RansackableAttributes unless included_modules.include?(Spree::RansackableAttributes)
 
-      self.whitelisted_ransackable_associations = %w[addresses]
+      self.whitelisted_ransackable_associations = %w[addresses spree_roles]
       self.whitelisted_ransackable_attributes = %w[id email]
     end
 

--- a/core/app/models/concerns/spree/user_methods.rb
+++ b/core/app/models/concerns/spree/user_methods.rb
@@ -31,7 +31,7 @@ module Spree
       include Spree::RansackableAttributes unless included_modules.include?(Spree::RansackableAttributes)
 
       self.whitelisted_ransackable_associations = %w[addresses spree_roles]
-      self.whitelisted_ransackable_attributes = %w[id email]
+      self.whitelisted_ransackable_attributes = %w[id email created_at]
     end
 
     def wallet

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -382,6 +382,7 @@ en:
         password: Password
         password_confirmation: Password Confirmation
         spree_roles: Roles
+        lifetime_value: Total spent
       spree/variant:
         cost_currency: Cost Currency
         cost_price: Cost Price

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -84,6 +84,7 @@ en:
         email: Email
         password: Password
         password_confirmation: Password Confirmation
+        spree_roles: Roles
       spree/line_item:
         description: Item Description
         name: Name
@@ -380,6 +381,7 @@ en:
         email: Email
         password: Password
         password_confirmation: Password Confirmation
+        spree_roles: Roles
       spree/variant:
         cost_currency: Cost Currency
         cost_price: Cost Price


### PR DESCRIPTION
### The current admin users table looks like this

![solidus users - before](https://cloud.githubusercontent.com/assets/42868/24975525/49928a98-1fc6-11e7-89e1-3a7135d7a056.png)

### I think we can do better

1. This table does not look like any other table we have in the admin
2. We actually have more information available to display

But we can't know 100% what attributes a user has. Stores can define their own user classes. What all user classes have in common is defined in the [`UserMethods`](https://github.com/solidusio/solidus/blob/86ae333b39b33b5b0b816ec328cd7db78bc84b53/core/app/models/concerns/spree/user_methods.rb) module that all stores need to include in their user class in order to work with Solidus. 

#### The commonalities are:

- An email address
- A user role
- Orders
- Addresses
- Payment sources
- Rails timestamps `created_at` & `updated_at`

#### The user sidebar ("Lifetime Stats") displays following data:

- "Member Since" - the `created_at` timestamp
- "Order Count" - count of all completed orders
- "Average Order value" - mean of all completed order totals
- "Total Sales" - total of all completed orders

I think displaying all of these values in the table does not provide much value and the data is costly to gather. For a table of 20 users this could lead to lots of database queries. 

### So, I went with this approach

- [x] Move the search form to the top of the table
- [x] Add user roles column and filter
- [x] Add "Member Since" column and date range filter
- [x] link to last order
- [x] total number of orders
- [x] total number of dollars spent in the store

![users 2017-07-19 16-23-10](https://user-images.githubusercontent.com/42868/28371945-b198b35e-6c9e-11e7-971b-38bdfafc91c5.png)

Please let me know what you think. 

/c @Mandily @jhawthorn