### PR TITLE
Remove fallback first shipping method on shipments

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -250,7 +250,7 @@ module Spree
     end
 
     def shipping_method
-      selected_shipping_rate.try(:shipping_method) || shipping_rates.first.try(:shipping_method)
+      selected_shipping_rate.try(:shipping_method)
     end
 
     # Only one of either included_tax_total or additional_tax_total is set

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -821,4 +821,25 @@ describe Spree::Shipment, type: :model do
       end
     end
   end
+
+  describe "#shipping_method" do
+    let(:shipment) { create(:shipment) }
+
+    subject { shipment.shipping_method }
+
+    context "when no shipping rate is selected" do
+      before do
+        shipment.shipping_rates.update_all(selected: false)
+        shipment.reload
+      end
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when a shipping rate is selected" do
+      it "is expected to be the shipping rate's shipping method" do
+        expect(shipment.shipping_method).to eq(shipment.selected_shipping_rate.shipping_method)
+      end
+    end
+  end
 end


### PR DESCRIPTION
In the case where the system has not picked a shipping rate, or
the user has not picked one, we can not just fall back on the first
shipping rate. In this case, the "selected" shipping rate's amount
and the shipment's amount will be out of sync, which is inconsistent.

This commit removes the fallback.