### PR TITLE
Fix centering of pagination under bootstrap 4.0.0.alpha6

### DIFF
--- a/backend/app/views/kaminari/solidus_admin/_paginator.html.erb
+++ b/backend/app/views/kaminari/solidus_admin/_paginator.html.erb
@@ -1,6 +1,6 @@
 <%= paginator.render do %>
-  <nav class="text-xs-center">
-    <ul class="pagination">
+  <nav>
+    <ul class="pagination justify-content-center">
       <%= first_page_tag unless current_page.first? %>
       <%= prev_page_tag unless current_page.first? %>
       <% each_page do |page| %>


### PR DESCRIPTION
Previously our pagination was centered, but this was broken in the upgrade to bootstrap 4.0.0.alpha6 because text-xs-center was removed.