### PR TITLE
Fix sidebar alignment

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/components/_sidebar.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_sidebar.scss
@@ -1,13 +1,13 @@
 body:not(.new-layout) #sidebar {
   overflow: visible;
-  border-top: 1px solid $color-border;
-  margin-top: 17px;
+  margin-top: 1.5rem;
 
   .sidebar-title {
     color: $color-2;
     text-align: center;
     font-size: 16px;
     font-weight: $font-weight-bold;
+    border-top: 1px solid $color-border;
 
     > span {
       display: inline;

--- a/backend/app/assets/stylesheets/spree/backend/shared/_typography.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_typography.scss
@@ -62,7 +62,6 @@ dl {
     float: left;
     line-height: 16px;
     padding: 5px;
-    text-align: justify;
   }
 
   dt {


### PR DESCRIPTION
The sidebar is currently not correctly vertically aligned to the fieldset
it most of the time is displayed with (ie. in the order detail views and
the user detail views).

Use a relatively unit for top margin instead and move the top border to the
heading to respect the column gutter.

### Before

![order sidebar - before](https://cloud.githubusercontent.com/assets/42868/24980265/cd0260ea-1fd7-11e7-8c9f-c10515fe1c32.png)

![users sidebar - before](https://cloud.githubusercontent.com/assets/42868/24980275/d4f3a6b0-1fd7-11e7-8c05-cb1d24a5beb2.png)

### After

![order sidebar - after](https://cloud.githubusercontent.com/assets/42868/24980278/dc473602-1fd7-11e7-8930-33c03763f4e9.png)

![users sidebar - after](https://cloud.githubusercontent.com/assets/42868/24980283/e168d82a-1fd7-11e7-91d7-76a9070cf0b8.png)
