### PR TITLE
Fix date range filter under firefox

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/components/_date-picker.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_date-picker.scss
@@ -1,13 +1,4 @@
 .date-range-filter {
-  input {
-    /* This is necessary to override the width: 100% applied to all inputs
-     * within #table-filter.
-     *
-     * This is necessary to fix the inputs overflowing the container in
-     * firefox.
-     */
-    width: 1% !important;
-  }
   .range-divider {
     color: $gray;
   }

--- a/backend/app/assets/stylesheets/spree/backend/components/_date-picker.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_date-picker.scss
@@ -1,4 +1,13 @@
 .date-range-filter {
+  input {
+    /* This is necessary to override the width: 100% applied to all inputs
+     * within #table-filter.
+     *
+     * This is necessary to fix the inputs overflowing the container in
+     * firefox.
+     */
+    width: 1% !important;
+  }
   .range-divider {
     color: $gray;
   }

--- a/backend/app/assets/stylesheets/spree/backend/components/_table-filter.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_table-filter.scss
@@ -1,6 +1,10 @@
 #table-filter {
 
-  .field {
+  /* This is needed to avoid overriding the bootstrap's styles for
+   * .input-group, which sets the form-control's width to 1%.
+   * Without this, the date range overflows its container on firefox.
+   */
+  .field:not(.date-range-filter) {
     input[type="text"], input[type="phone"],
     input[type="email"], input[type="number"],
     input[type="url"] {


### PR DESCRIPTION
[Elsewhere we set `width: 100%` on all inputs within `#table-filter`](https://github.com/solidusio/solidus/blob/master/backend/app/assets/stylesheets/spree/backend/components/_table-filter.scss#L7). This causes issues with the date range filter because the specificity of `#table-filter` overrides the `width: 1%` we were supposed to get from bootstrap's `input-group`.

**Before**

![](http://i.hawth.ca/s/af7NpOLt.png)

**After**

![](http://i.hawth.ca/s/Z8Rkc1Z8.png)