### PR TITLE
Add ResourceController#parent? and rename model_name to parent_model_name

### DIFF
--- a/backend/app/controllers/spree/admin/resource_controller.rb
+++ b/backend/app/controllers/spree/admin/resource_controller.rb
@@ -123,7 +123,7 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
   end
 
   def parent_model_name
-    parent_data[:model_name].gsub('spree/', '')
+    self.class.parent_data[:model_name].gsub('spree/', '')
   end
 
   alias_method :model_name, :parent_model_name
@@ -164,16 +164,17 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
   def parent_data
     self.class.parent_data
   end
+  deprecate :parent_data, deprecator: Spree::Deprecation
 
   def parent
     if parent?
-      @parent ||= parent_data[:model_class].find_by(parent_data[:find_by] => params["#{parent_model_name}_id"])
+      @parent ||= self.class.parent_data[:model_class].find_by(self.class.parent_data[:find_by] => params["#{parent_model_name}_id"])
       instance_variable_set("@#{parent_model_name}", @parent)
     end
   end
 
   def parent?
-    parent_data.present?
+    self.class.parent_data.present?
   end
 
   def find_resource

--- a/backend/app/controllers/spree/admin/resource_controller.rb
+++ b/backend/app/controllers/spree/admin/resource_controller.rb
@@ -122,9 +122,12 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
     "Spree::#{controller_name.classify}".constantize
   end
 
-  def model_name
+  def parent_model_name
     parent_data[:model_name].gsub('spree/', '')
   end
+
+  alias_method :model_name, :parent_model_name
+  deprecate model_name: :parent_model_name, deprecator: Spree::Deprecation
 
   def object_name
     controller_name.singularize
@@ -164,8 +167,8 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
 
   def parent
     if parent_data.present?
-      @parent ||= parent_data[:model_class].send("find_by_#{parent_data[:find_by]}", params["#{model_name}_id"])
-      instance_variable_set("@#{model_name}", @parent)
+      @parent ||= parent_data[:model_class].send("find_by_#{parent_data[:find_by]}", params["#{parent_model_name}_id"])
+      instance_variable_set("@#{parent_model_name}", @parent)
     end
   end
 

--- a/backend/app/controllers/spree/admin/resource_controller.rb
+++ b/backend/app/controllers/spree/admin/resource_controller.rb
@@ -167,7 +167,7 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
 
   def parent
     if parent_data.present?
-      @parent ||= parent_data[:model_class].send("find_by_#{parent_data[:find_by]}", params["#{parent_model_name}_id"])
+      @parent ||= parent_data[:model_class].find_by(parent_data[:find_by] => params["#{parent_model_name}_id"])
       instance_variable_set("@#{parent_model_name}", @parent)
     end
   end

--- a/backend/app/controllers/spree/admin/resource_controller.rb
+++ b/backend/app/controllers/spree/admin/resource_controller.rb
@@ -170,6 +170,9 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
     if parent?
       @parent ||= self.class.parent_data[:model_class].find_by(self.class.parent_data[:find_by] => params["#{parent_model_name}_id"])
       instance_variable_set("@#{parent_model_name}", @parent)
+    else
+      Spree::Deprecation.warn "Calling #parent is deprecated on a ResourceController which has not defined a belongs_to"
+      nil
     end
   end
 

--- a/backend/app/controllers/spree/admin/resource_controller.rb
+++ b/backend/app/controllers/spree/admin/resource_controller.rb
@@ -166,14 +166,18 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
   end
 
   def parent
-    if parent_data.present?
+    if parent?
       @parent ||= parent_data[:model_class].find_by(parent_data[:find_by] => params["#{parent_model_name}_id"])
       instance_variable_set("@#{parent_model_name}", @parent)
     end
   end
 
+  def parent?
+    parent_data.parent?
+  end
+
   def find_resource
-    if parent_data.present?
+    if parent?
       parent.send(controller_name).find(params[:id])
     else
       model_class.find(params[:id])
@@ -181,7 +185,7 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
   end
 
   def build_resource
-    if parent_data.present?
+    if parent?
       parent.send(controller_name).build
     else
       model_class.new
@@ -189,7 +193,7 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
   end
 
   def collection
-    return parent.send(controller_name) if parent_data.present?
+    return parent.send(controller_name) if parent?
     if model_class.respond_to?(:accessible_by) && !current_ability.has_block?(params[:action], model_class)
       model_class.accessible_by(current_ability, action)
     else
@@ -208,7 +212,7 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
   # URL helpers
 
   def new_object_url(options = {})
-    if parent_data.present?
+    if parent?
       spree.new_polymorphic_url([:admin, parent, model_class], options)
     else
       spree.new_polymorphic_url([:admin, model_class], options)
@@ -216,7 +220,7 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
   end
 
   def edit_object_url(object, options = {})
-    if parent_data.present?
+    if parent?
       spree.polymorphic_url([:edit, :admin, parent, object], options)
     else
       spree.polymorphic_url([:edit, :admin, object], options)
@@ -226,7 +230,7 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
   def object_url(object = nil, options = {})
     target = object ? object : @object
 
-    if parent_data.present?
+    if parent?
       spree.polymorphic_url([:admin, parent, target], options)
     else
       spree.polymorphic_url([:admin, target], options)
@@ -234,7 +238,7 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
   end
 
   def collection_url(options = {})
-    if parent_data.present?
+    if parent?
       spree.polymorphic_url([:admin, parent, model_class], options)
     else
       spree.polymorphic_url([:admin, model_class], options)

--- a/backend/app/controllers/spree/admin/resource_controller.rb
+++ b/backend/app/controllers/spree/admin/resource_controller.rb
@@ -173,7 +173,7 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
   end
 
   def parent?
-    parent_data.parent?
+    parent_data.present?
   end
 
   def find_resource


### PR DESCRIPTION
Previously `parent_data.present?` was used to test if the controller's model had a parent, which wasn't very idiomatic.

This PR adds `ResourceController#parent?` which returns whether the controller has a parent defined. `#parent_data`, which is an implementation details, is deprecated as an instance method to discourage its use

This also renames `ResourceController#model_name` to `#parent_model_name`, to better describe what it is.