### PR TITLE
Reorganize Image upload JS

### DIFF
--- a/backend/app/assets/javascripts/spree/backend.js
+++ b/backend/app/assets/javascripts/spree/backend.js
@@ -36,7 +36,6 @@
 //= require spree/backend/gateway
 //= require spree/backend/handlebars_extensions
 //= require spree/backend/images/index
-//= require spree/backend/images/new
 //= require spree/backend/images/upload
 //= require spree/backend/navigation
 //= require spree/backend/number_field_updater

--- a/backend/app/assets/javascripts/spree/backend/images/new.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/images/new.js.coffee
@@ -1,7 +1,0 @@
-($ '#cancel_link').click (event) ->
-  event.preventDefault()
-
-  ($ '.no-objects-found').show()
-
-  ($ '#new_image_link').show()
-  ($ '#images').html('')

--- a/backend/app/assets/javascripts/spree/backend/images/upload.js
+++ b/backend/app/assets/javascripts/spree/backend/images/upload.js
@@ -4,8 +4,6 @@ Spree.prepareImageUploader = function () {
   if(!uploadZone) return;
 
   var UploadZone = Backbone.View.extend({
-    el: uploadZone,
-
     events: {
       "dragover" : "onDragOver",
       "dragleave" : "onDragLeave",
@@ -13,15 +11,12 @@ Spree.prepareImageUploader = function () {
       'change input[type="file"]' : "onFileBrowserSelect"
     },
 
-    progressZone: document.getElementById('progress-zone'),
-
     upload: function(file) {
       var progressModel = new ProgressModel({file: file});
       progressModel.previewFile();
       progressModel.uploadFile();
 
-      var progressView = new ProgressView({model: progressModel});
-      this.progressZone.appendChild(progressView.render().el);
+      this.collection.add(progressModel);
     },
 
     dragClass: 'with-images',
@@ -177,7 +172,20 @@ Spree.prepareImageUploader = function () {
 
 
   // Kick off by binding the events on the upload zone
-  new UploadZone();
+  var imageUploads = new Backbone.Collection();
+  var progressZone = document.getElementById('progress-zone');
+
+  new UploadZone({
+    el: uploadZone,
+    collection: imageUploads
+  });
+
+  imageUploads.on('add', function(progressModel) {
+    console.log(progressModel)
+    var progressView = new ProgressView({model: progressModel});
+    progressZone.appendChild(progressView.render().el);
+  });
+
 
 }; // end prepareImageUploader
 

--- a/backend/app/assets/javascripts/spree/backend/images/upload.js
+++ b/backend/app/assets/javascripts/spree/backend/images/upload.js
@@ -68,7 +68,6 @@ Spree.prepareImageUploader = function () {
       'image/gif': true
     },
 
-    variantId: document.querySelector('input[name="image[viewable_id]"]').value,
 
     previewFile: function () {
       var file = this.get('file'),
@@ -89,7 +88,7 @@ Spree.prepareImageUploader = function () {
           that = this;
 
       formData.append('image[attachment]', this.get('file'));
-      formData.append('image[viewable_id]', this.variantId);
+      formData.append('image[viewable_id]', this.get('variant_id'));
       formData.append('upload_id', this.cid);
 
       // send the image to the server
@@ -174,6 +173,7 @@ Spree.prepareImageUploader = function () {
   // Kick off by binding the events on the upload zone
   var imageUploads = new Backbone.Collection();
   var progressZone = document.getElementById('progress-zone');
+  var variantId = document.querySelector('input[name="image[viewable_id]"]').value;
 
   new UploadZone({
     el: uploadZone,
@@ -181,7 +181,8 @@ Spree.prepareImageUploader = function () {
   });
 
   imageUploads.on('add', function(progressModel) {
-    console.log(progressModel)
+    progressModel.set({variant_id: variantId});
+
     var progressView = new ProgressView({model: progressModel});
     progressZone.appendChild(progressView.render().el);
   });

--- a/backend/app/assets/javascripts/spree/backend/images/upload.js
+++ b/backend/app/assets/javascripts/spree/backend/images/upload.js
@@ -49,7 +49,11 @@ Spree.prepareImageUploader = function () {
 
   var ProgressModel = Backbone.Model.extend({
     initialize: function() {
-      this.set({summary: this.get("file").name});
+      var file = this.get("file");
+      this.set({
+        filename: file.name,
+        size: file.size ? (file.size/1024|0) + 'K' : ''
+      });
     },
 
     defaults: function() {
@@ -58,7 +62,8 @@ Spree.prepareImageUploader = function () {
         imgSrc: '',
         progress: 0,
         serverError: false,
-        summary: ''
+        filename: '',
+        size: ''
       }
     },
 
@@ -81,9 +86,6 @@ Spree.prepareImageUploader = function () {
         };
 
         reader.readAsDataURL(file);
-      } else {
-        var summary = 'Uploading ' + file.name + ' ' + (file.size ? (file.size/1024|0) + 'K' : '');
-        this.set({summary: summary});
       }
     },
 
@@ -153,7 +155,8 @@ Spree.prepareImageUploader = function () {
       var changedAttrs = Object.keys(this.model.changed);
       if(changedAttrs.length === 1 && changedAttrs[0] == 'progress') return this;
 
-      this.el.innerHTML = this.template(this.model.attributes);
+      this.el.innerHTML = this.template(this.model.toJSON());
+      this.updateProgressBar();
       return this;
     },
 

--- a/backend/app/assets/javascripts/spree/backend/images/upload.js
+++ b/backend/app/assets/javascripts/spree/backend/images/upload.js
@@ -3,179 +3,12 @@ Spree.prepareImageUploader = function () {
   var uploadZone = document.getElementById('upload-zone');
   if(!uploadZone) return;
 
-  var UploadZone = Backbone.View.extend({
-    events: {
-      "dragover" : "onDragOver",
-      "dragleave" : "onDragLeave",
-      "drop" : "onDrop",
-      'change input[type="file"]' : "onFileBrowserSelect"
-    },
-
-    upload: function(file) {
-      var progressModel = new ProgressModel({file: file});
-      progressModel.previewFile();
-      progressModel.uploadFile();
-
-      this.collection.add(progressModel);
-    },
-
-    dragClass: 'with-images',
-
-    onDragOver: function(e) {
-      this.el.classList.add(this.dragClass);
-      e.preventDefault();
-    },
-
-    onDragLeave: function() {
-      this.el.classList.remove(this.dragClass);
-    },
-
-    onDrop: function(e) {
-      this.el.classList.remove(this.dragClass);
-      e.preventDefault();
-
-      _.each(e.originalEvent.dataTransfer.files, this.upload, this);
-    },
-
-    onFileBrowserSelect: function(e) {
-      _.each(e.target.files, this.upload, this);
-    }
-  });
-
-  var ProgressModel = Backbone.Model.extend({
-    initialize: function() {
-      var file = this.get("file");
-      this.set({
-        filename: file.name,
-        size: file.size ? (file.size/1024|0) + 'K' : ''
-      });
-    },
-
-    defaults: function() {
-      return {
-        file: null,
-        imgSrc: '',
-        progress: 0,
-        serverError: false,
-        filename: '',
-        size: ''
-      }
-    },
-
-    acceptedTypes: {
-      'image/png': true,
-      'image/jpeg': true,
-      'image/gif': true
-    },
-
-
-    previewFile: function () {
-      var file = this.get('file'),
-          that = this;
-
-      if (FileReader && this.acceptedTypes[file.type] === true) {
-        var reader = new FileReader();
-        reader.onload = function (event) {
-          that.set({imgSrc: event.target.result});
-        };
-
-        reader.readAsDataURL(file);
-      }
-    },
-
-    uploadFile: function () {
-      var formData = new FormData(),
-          that = this;
-
-      formData.append('image[attachment]', this.get('file'));
-      formData.append('image[viewable_id]', this.get('variant_id'));
-      formData.append('upload_id', this.cid);
-
-      // send the image to the server
-      Spree.ajax({
-        url: window.location.pathname,
-        type: "POST",
-        dataType: 'script',
-        data: formData,
-        processData: false,  // tell jQuery not to process the data
-        contentType: false,  // tell jQuery not to set contentType
-        xhr: function () {
-          var xhr = $.ajaxSettings.xhr();
-          if (xhr.upload) {
-            xhr.upload.onprogress = function (event) {
-              if (event.lengthComputable) {
-                var complete = (event.loaded / event.total * 100 | 0);
-                that.set({progress: complete})
-              }
-            };
-          }
-          return xhr;
-        }
-      }).done(function() {
-        that.set({progress: 100})
-      }).error(function(jqXHR, textStatus, errorThrown) {
-        that.set({serverError: true});
-      });
-    }
-  }); // end ProgressModel
-
-
-  var ProgressView = Backbone.View.extend({
-    tagName: "div",
-
-    // Cache the template function for a single item.
-    template: HandlebarsTemplates["products/upload_progress"],
-
-    initialize: function() {
-      this.listenTo(this.model, 'change:progress', this.updateProgressBar);
-      this.listenTo(this.model, 'change', this.render);
-      this.listenTo(this.model, 'destroy', this.remove);
-    },
-
-    events: {
-      "clear" : "clear"
-    },
-
-    className: 'col-sm-6 col-md-4 mb-3',
-
-    attributes: function() {
-      return {
-        "data-upload-id": this.model.cid
-      }
-    },
-
-    render: function() {
-      // Skip progress bar update for better performance
-      var changedAttrs = Object.keys(this.model.changed);
-      if(changedAttrs.length === 1 && changedAttrs[0] == 'progress') return this;
-
-      this.el.innerHTML = this.template(this.model.toJSON());
-      this.updateProgressBar();
-      return this;
-    },
-
-    updateProgressBar: function() {
-      var progressBar = this.el.querySelector('.progress-bar');
-      var percent = this.model.get('progress');
-      progressBar.setAttribute('aria-valuenow', percent);
-      progressBar.style.width = percent + '%';
-      progressBar.innerHTML = percent + '%';
-      return this;
-    },
-
-    // Remove the item, destroy the model
-    clear: function() {
-      this.model.destroy();
-    }
-  }); // end ProgressView
-
-
   // Kick off by binding the events on the upload zone
   var imageUploads = new Backbone.Collection();
   var progressZone = document.getElementById('progress-zone');
   var variantId = document.querySelector('input[name="image[viewable_id]"]').value;
 
-  new UploadZone({
+  new Spree.Views.Images.UploadZone({
     el: uploadZone,
     collection: imageUploads
   });
@@ -183,12 +16,10 @@ Spree.prepareImageUploader = function () {
   imageUploads.on('add', function(progressModel) {
     progressModel.set({variant_id: variantId});
 
-    var progressView = new ProgressView({model: progressModel});
+    var progressView = new Spree.Views.Images.UploadProgress({model: progressModel});
     progressZone.appendChild(progressView.render().el);
   });
-
-
-}; // end prepareImageUploader
+};
 
 
 Spree.ready(function () {

--- a/backend/app/assets/javascripts/spree/backend/images/upload.js
+++ b/backend/app/assets/javascripts/spree/backend/images/upload.js
@@ -140,7 +140,7 @@ Spree.prepareImageUploader = function () {
       "clear" : "clear"
     },
 
-    className: 'col-sm-6 col-md-4 margin-bottom-one',
+    className: 'col-sm-6 col-md-4 mb-3',
 
     attributes: function() {
       return {
@@ -158,8 +158,11 @@ Spree.prepareImageUploader = function () {
     },
 
     updateProgressBar: function() {
-      var progressBar = this.el.querySelector('progress');
-      progressBar.value = progressBar.innerHTML = this.model.get('progress');
+      var progressBar = this.el.querySelector('.progress-bar');
+      var percent = this.model.get('progress');
+      progressBar.setAttribute('aria-valuenow', percent);
+      progressBar.style.width = percent + '%';
+      progressBar.innerHTML = percent + '%';
       return this;
     },
 

--- a/backend/app/assets/javascripts/spree/backend/images/upload.js
+++ b/backend/app/assets/javascripts/spree/backend/images/upload.js
@@ -15,16 +15,7 @@ Spree.prepareImageUploader = function () {
 
     progressZone: document.getElementById('progress-zone'),
 
-    // Hide or highlight supported browser features
-    initialize: function() {
-      "filereader formdata progress".split(' ').forEach(function (api) {
-        this.support[api].className = (this.tests[api] === false) ? 'red' : 'hidden'
-      }, this);
-    },
-
     upload: function(file) {
-      if (!FormData) return;
-
       var progressModel = new ProgressModel({file: file});
       progressModel.previewFile();
       progressModel.uploadFile();
@@ -53,19 +44,6 @@ Spree.prepareImageUploader = function () {
 
     onFileBrowserSelect: function(e) {
       _.each(e.target.files, this.upload, this);
-    },
-
-    tests: {
-      filereader: typeof FileReader != 'undefined',
-      dnd: 'draggable' in document.createElement('span'),
-      formdata: !!window.FormData,
-      progress: "upload" in new XMLHttpRequest
-    },
-
-    support: {
-      filereader: document.getElementById('filereader'),
-      formdata:   document.getElementById('formdata'),
-      progress:   document.getElementById('progress')
     }
   });
 

--- a/backend/app/assets/javascripts/spree/backend/models/image_upload.js
+++ b/backend/app/assets/javascripts/spree/backend/models/image_upload.js
@@ -1,0 +1,76 @@
+Spree.Models.ImageUpload = Backbone.Model.extend({
+  initialize: function() {
+    var file = this.get("file");
+    this.set({
+      filename: file.name,
+      size: file.size ? (file.size/1024|0) + 'K' : ''
+    });
+  },
+
+  defaults: function() {
+    return {
+      file: null,
+      imgSrc: '',
+      progress: 0,
+      serverError: false,
+      filename: '',
+      size: ''
+    }
+  },
+
+  acceptedTypes: {
+    'image/png': true,
+    'image/jpeg': true,
+    'image/gif': true
+  },
+
+
+  previewFile: function () {
+    var file = this.get('file'),
+      that = this;
+
+    if (FileReader && this.acceptedTypes[file.type] === true) {
+      var reader = new FileReader();
+      reader.onload = function (event) {
+        that.set({imgSrc: event.target.result});
+      };
+
+      reader.readAsDataURL(file);
+    }
+  },
+
+  uploadFile: function () {
+    var formData = new FormData(),
+      that = this;
+
+    formData.append('image[attachment]', this.get('file'));
+    formData.append('image[viewable_id]', this.get('variant_id'));
+    formData.append('upload_id', this.cid);
+
+    // send the image to the server
+    Spree.ajax({
+      url: window.location.pathname,
+      type: "POST",
+      dataType: 'script',
+      data: formData,
+      processData: false,  // tell jQuery not to process the data
+      contentType: false,  // tell jQuery not to set contentType
+      xhr: function () {
+        var xhr = $.ajaxSettings.xhr();
+        if (xhr.upload) {
+          xhr.upload.onprogress = function (event) {
+            if (event.lengthComputable) {
+              var complete = (event.loaded / event.total * 100 | 0);
+              that.set({progress: complete})
+            }
+          };
+        }
+        return xhr;
+      }
+    }).done(function() {
+      that.set({progress: 100})
+    }).error(function(jqXHR, textStatus, errorThrown) {
+      that.set({serverError: true});
+    });
+  }
+});

--- a/backend/app/assets/javascripts/spree/backend/models/index.js
+++ b/backend/app/assets/javascripts/spree/backend/models/index.js
@@ -1,2 +1,3 @@
+//= require spree/backend/models/image_upload
 //= require spree/backend/models/line_item
 //= require spree/backend/models/order

--- a/backend/app/assets/javascripts/spree/backend/namespaces.js
+++ b/backend/app/assets/javascripts/spree/backend/namespaces.js
@@ -2,6 +2,7 @@ _.extend(window.Spree, {
   Models: {},
   Collections: {},
   Views: {
+    Images: {},
     Order: {},
     Cart: {},
     Zones: {}

--- a/backend/app/assets/javascripts/spree/backend/templates/products/upload_progress.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/products/upload_progress.hbs
@@ -2,7 +2,9 @@
   <img src="{{ imgSrc }}" class="card-img-top img-fluid">
 
   <div class="card-block">
-    <progress min="0" max="100" value="{{ progress }}">{{ progress }}</progress>
+    <div class="progress">
+      <div class="progress-bar progress-bar-animated" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
+    </div>
 
     <summary>{{ summary }}</summary>
     <br>

--- a/backend/app/assets/javascripts/spree/backend/templates/products/upload_progress.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/products/upload_progress.hbs
@@ -6,8 +6,8 @@
       <div class="progress-bar progress-bar-animated" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
     </div>
 
-    <summary>{{ summary }}</summary>
-    <br>
+    <div class="filename">{{ filename }}</div>
+    <div class="size">{{ size }}B</div>
 
     <error class="text-danger {{#unless serverError}} hidden {{/unless}}">{{t 'admin.images.index.image_process_failed' }}</error>
   </div>

--- a/backend/app/assets/javascripts/spree/backend/views/images/upload_progress.js
+++ b/backend/app/assets/javascripts/spree/backend/views/images/upload_progress.js
@@ -1,0 +1,48 @@
+Spree.Views.Images.UploadProgress = Backbone.View.extend({
+  tagName: "div",
+
+  // Cache the template function for a single item.
+  template: HandlebarsTemplates["products/upload_progress"],
+
+  initialize: function() {
+    this.listenTo(this.model, 'change:progress', this.updateProgressBar);
+    this.listenTo(this.model, 'change', this.render);
+    this.listenTo(this.model, 'destroy', this.remove);
+  },
+
+  events: {
+    "clear" : "clear"
+  },
+
+  className: 'col-sm-6 col-md-4 mb-3',
+
+  attributes: function() {
+    return {
+      "data-upload-id": this.model.cid
+    }
+  },
+
+  render: function() {
+    // Skip progress bar update for better performance
+    var changedAttrs = Object.keys(this.model.changed);
+    if(changedAttrs.length === 1 && changedAttrs[0] == 'progress') return this;
+
+    this.el.innerHTML = this.template(this.model.toJSON());
+    this.updateProgressBar();
+    return this;
+  },
+
+  updateProgressBar: function() {
+    var progressBar = this.el.querySelector('.progress-bar');
+    var percent = this.model.get('progress');
+    progressBar.setAttribute('aria-valuenow', percent);
+    progressBar.style.width = percent + '%';
+    progressBar.innerHTML = percent + '%';
+    return this;
+  },
+
+  // Remove the item, destroy the model
+  clear: function() {
+    this.model.destroy();
+  }
+});

--- a/backend/app/assets/javascripts/spree/backend/views/images/upload_zone.js
+++ b/backend/app/assets/javascripts/spree/backend/views/images/upload_zone.js
@@ -1,0 +1,38 @@
+Spree.Views.Images.UploadZone = Backbone.View.extend({
+  events: {
+    "dragover" : "onDragOver",
+    "dragleave" : "onDragLeave",
+    "drop" : "onDrop",
+    'change input[type="file"]' : "onFileBrowserSelect"
+  },
+
+  upload: function(file) {
+    var progressModel = new Spree.Models.ImageUpload({file: file});
+    progressModel.previewFile();
+    progressModel.uploadFile();
+
+    this.collection.add(progressModel);
+  },
+
+  dragClass: 'with-images',
+
+  onDragOver: function(e) {
+    this.el.classList.add(this.dragClass);
+    e.preventDefault();
+  },
+
+  onDragLeave: function() {
+    this.el.classList.remove(this.dragClass);
+  },
+
+  onDrop: function(e) {
+    this.el.classList.remove(this.dragClass);
+    e.preventDefault();
+
+    _.each(e.originalEvent.dataTransfer.files, this.upload, this);
+  },
+
+  onFileBrowserSelect: function(e) {
+    _.each(e.target.files, this.upload, this);
+  }
+});

--- a/backend/app/assets/javascripts/spree/backend/views/index.js
+++ b/backend/app/assets/javascripts/spree/backend/views/index.js
@@ -1,6 +1,8 @@
 //= require 'spree/backend/views/cart/add_line_item_button'
 //= require 'spree/backend/views/cart/line_item_row'
 //= require 'spree/backend/views/cart/line_item_table'
+//= require 'spree/backend/views/images/upload_zone'
+//= require 'spree/backend/views/images/upload_progress'
 //= require 'spree/backend/views/order/address'
 //= require 'spree/backend/views/order/details_adjustments'
 //= require 'spree/backend/views/order/details_total'

--- a/backend/app/assets/stylesheets/spree/backend/sections/_products.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/_products.scss
@@ -52,14 +52,6 @@ div[data-hook="admin_products_index_search_buttons"] {
   }
 }
 
-progress {
-  width: 100%;
-}
-
-.margin-bottom-one {
-  margin-bottom: 1rem;
-}
-
 .progress-card {
   height: 100%;
   padding: 1rem;

--- a/backend/app/views/spree/admin/images/index.html.erb
+++ b/backend/app/views/spree/admin/images/index.html.erb
@@ -32,11 +32,6 @@
     <% end %>
   </div>
 
-
-  <p id="filereader">File API &amp; FileReader API not supported</p>
-  <p id="formdata">XHR2's FormData is not supported</p>
-  <p id="progress">XHR2's upload progress isn't supported</p>
-
   <div id="progress-zone" class="row"></div>
 </fieldset>
 


### PR DESCRIPTION
This converts the image upload . The existing code was quite good so the changes required weren't too substantial.

The most important change was to decouple the Backbone views from the DOM (ourside of their `el`) and from each other, instead communicating through models and collections. This allows the Backbone Model and Views to be defined before the dom is loaded, which is considered the best practice.

This also includes some tweaks:
* Swap out `<progress>` element for bootstrap's progress, which looks better and is more consistent.
* Always display filename and upload size (was inconsistent previously)
* Remove browser feature tests since we only support modern browsers. Detecting these failures doesn't improve user experience.
* Use bootstrap utility class instead of custom `margin-bottom-one`

Look is changed very slightly (progress bar look and file size)
![](http://i.hawth.ca/s/lR0D7jse.png)