### PR TITLE
Use bootstrap input addon for taxon permalink.

### DIFF
--- a/backend/app/views/spree/admin/taxons/_form.html.erb
+++ b/backend/app/views/spree/admin/taxons/_form.html.erb
@@ -9,7 +9,9 @@
     <%= f.field_container :permalink_part do %>
       <%= label_tag :permalink_part, Spree::Taxon.human_attribute_name(:permalink), class: 'required' %><br />
       <div class="input-group">
-        <span class="input-group-addon"><%= @taxon.permalink.split('/')[0...-1].join('/') + '/' %></span>
+        <% if @taxon.parent %>
+          <span class="input-group-addon"><%= @taxon.permalink.split('/')[0...-1].join('/') + '/' %></span>
+        <% end %>
         <%= text_field_tag :permalink_part, @permalink_part, class: 'fullwidth form-control' %><br />
       </div>
     <% end %>

--- a/backend/app/views/spree/admin/taxons/_form.html.erb
+++ b/backend/app/views/spree/admin/taxons/_form.html.erb
@@ -8,10 +8,10 @@
 
     <%= f.field_container :permalink_part do %>
       <%= label_tag :permalink_part, Spree::Taxon.human_attribute_name(:permalink), class: 'required' %><br />
-      <%= text_field_tag :permalink_part, @permalink_part, class: 'fullwidth' %><br />
-      <span class="info" id="permalink_part_display">
-        <%= @taxon.permalink.split('/')[0...-1].join('/') + '/' %>
-      </span>
+      <div class="input-group">
+        <span class="input-group-addon"><%= @taxon.permalink.split('/')[0...-1].join('/') + '/' %></span>
+        <%= text_field_tag :permalink_part, @permalink_part, class: 'fullwidth form-control' %><br />
+      </div>
     <% end %>
 
     <%= f.field_container :icon do %>

--- a/backend/app/views/spree/admin/taxons/edit.html.erb
+++ b/backend/app/views/spree/admin/taxons/edit.html.erb
@@ -17,18 +17,3 @@
     <%= button_link_to Spree.t('actions.cancel'), edit_admin_taxonomy_url(@taxonomy) %>
   </div>
 <% end %>
-
-<% content_for :head do %>
-  <%= javascript_tag do -%>
-    $(document).ready(function() {
-      var field  = $('#permalink_part'),
-          target = $('#permalink_part_display'),
-          permalink_part_default = target.text().trim();
-
-      target.text(permalink_part_default + field.val());
-      field.on('keyup blur', function () {
-        target.text(permalink_part_default + $(this).val());
-      });
-    });
-  <% end -%>
-<% end %>


### PR DESCRIPTION
This replaces the inline javascript which showed the result of the permalink with an `input-group-addon` from bootstrap.

**After**
![](http://i.hawth.ca/s/jxHN4ReE.png)

**Before**
![](http://i.hawth.ca/s/7wT4WM2R.png)