### PR TITLE
Add expiration to Spree::StoreCredit

### DIFF
--- a/backend/app/controllers/spree/admin/store_credits_controller.rb
+++ b/backend/app/controllers/spree/admin/store_credits_controller.rb
@@ -68,7 +68,7 @@ module Spree
       private
 
       def permitted_resource_params
-        params.require(:store_credit).permit([:amount, :currency, :category_id, :memo]).
+        params.require(:store_credit).permit(%i[amount currency category_id memo expires_at]).
           merge(created_by: try_spree_current_user)
       end
 

--- a/backend/app/views/spree/admin/store_credits/_form.html.erb
+++ b/backend/app/views/spree/admin/store_credits/_form.html.erb
@@ -1,10 +1,17 @@
 <div data-hook="admin_store_credit_form_fields" class="row">
-  <div class="col-12">
+  <div class="col-6">
     <%= f.field_container :amount do %>
       <%= f.label :amount, class: 'required' %><br />
       <%= render "spree/admin/shared/number_with_currency", f: f, amount_attr: :amount, currency_attr: :currency, required: true %>
       <%= f.error_message_on :amount %>
       <%= f.error_message_on :currency %>
+    <% end %>
+  </div>
+  <div class="col-6">
+    <%= f.field_container :expires_at do %>
+      <%= f.label :expires_at %>
+      <%= f.field_hint :expires_at %>
+      <%= f.text_field :expires_at, class: 'datepicker fullwidth' %>
     <% end %>
   </div>
   <div class="col-12">

--- a/backend/app/views/spree/admin/store_credits/index.html.erb
+++ b/backend/app/views/spree/admin/store_credits/index.html.erb
@@ -26,6 +26,7 @@
       <th class="wrap-text"><%= Spree::StoreCredit.human_attribute_name(:category_id) %></th>
       <th class="wrap-text"><%= Spree::StoreCredit.human_attribute_name(:created_by_id) %></th>
       <th class="wrap-text"><%= Spree::StoreCredit.human_attribute_name(:created_at) %></th>
+      <th class="wrap-text"><%= Spree::StoreCredit.human_attribute_name(:expires_at) %></th>
       <th class="wrap-text"><%= Spree::StoreCredit.human_attribute_name(:invalidated_at) %></th>
       <th data-hook="admin_store_credits_index_header_actions" class="actions"></th>
     <thead>
@@ -49,6 +50,9 @@
           </td>
           <td class='align-center'>
             <span><%= l store_credit.created_at.to_date %></span>
+          </td>
+          <td class='align-center'>
+            <span><%= l store_credit.expires_at.to_date if store_credit.expires_at %></span>
           </td>
           <td class='align-center'>
             <span><%= store_credit.invalidated? %></span>

--- a/backend/app/views/spree/admin/store_credits/show.html.erb
+++ b/backend/app/views/spree/admin/store_credits/show.html.erb
@@ -42,6 +42,13 @@
     <td><%= @store_credit.category_name %></td>
     <td class='actions'></td>
   </tr>
+  <tr>
+    <td>
+      <strong><%= Spree.t(:expires_at) %>:</strong>
+    </td>
+    <td><%= pretty_time(@store_credit.expires_at) if @store_credit.expires_at %></td>
+    <td class='actions'></td>
+  </tr>
   <tr id='memo-display-row'>
     <td>
       <strong><%= Spree::StoreCredit.human_attribute_name(:memo) %>:</strong>

--- a/backend/spec/controllers/spree/admin/store_credits_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/store_credits_controller_spec.rb
@@ -16,6 +16,13 @@ describe Spree::Admin::StoreCreditsController do
   let!(:a_credit_category) { create(:store_credit_category, name: "A category") }
   let!(:update_reason)     { create(:store_credit_update_reason) }
 
+  before do
+    Spree::StoreCreditCategory.non_expiring_credit_categories |= [
+      b_credit_category.name,
+      a_credit_category.name
+    ]
+  end
+
   describe "#show" do
     let!(:store_credit) { create(:store_credit, user: user, category: a_credit_category) }
     let!(:event)        { create(:store_credit_auth_event, store_credit: store_credit, created_at: 5.days.ago) }

--- a/backend/spec/features/admin/store_credits_spec.rb
+++ b/backend/spec/features/admin/store_credits_spec.rb
@@ -44,7 +44,7 @@ describe "Store credits admin" do
     it "should create store credit and associate it with the user" do
       click_link "Add store credit"
       page.fill_in "store_credit_amount", with: "102.00"
-      select "Exchange", from: "store_credit_category_id"
+      select "Default", from: "store_credit_category_id"
       click_button "Create"
 
       expect(page.current_path).to eq spree.admin_user_store_credits_path(store_credit.user)

--- a/core/app/models/concerns/spree/user_methods.rb
+++ b/core/app/models/concerns/spree/user_methods.rb
@@ -64,7 +64,7 @@ module Spree
     end
 
     def total_available_store_credit
-      store_credits.reload.to_a.sum(&:amount_remaining)
+      store_credits.reload.active.to_a.sum(&:amount_remaining)
     end
   end
 end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -626,10 +626,10 @@ module Spree
 
       remaining_total = outstanding_balance - authorized_total
 
-      if user.store_credits.any?
+      if store_credits = user.store_credits.active.presence
         payment_method = Spree::PaymentMethod::StoreCredit.first
 
-        user.store_credits.order_by_priority.each do |credit|
+        store_credits.order_by_priority.each do |credit|
           break if remaining_total.zero?
           next if credit.amount_remaining.zero?
 

--- a/core/app/models/spree/reimbursement/credit.rb
+++ b/core/app/models/spree/reimbursement/credit.rb
@@ -4,7 +4,7 @@ module Spree
     self.default_creditable_class = Spree::StoreCredit
 
     belongs_to :reimbursement, inverse_of: :credits
-    belongs_to :creditable, polymorphic: true
+    belongs_to :creditable, polymorphic: true, autosave: true
 
     validates :creditable, presence: true
 

--- a/core/app/models/spree/store_credit.rb
+++ b/core/app/models/spree/store_credit.rb
@@ -23,6 +23,7 @@ class Spree::StoreCredit < Spree::PaymentSource
   validates_numericality_of :amount_used, { greater_than_or_equal_to: 0 }
   validate :amount_used_less_than_or_equal_to_amount
   validate :amount_authorized_less_than_or_equal_to_amount
+  validates :expires_at, presence: true, unless: ->(credit) { credit.category.non_expiring? }
 
   delegate :name, to: :category, prefix: true
   delegate :email, to: :created_by, prefix: true
@@ -231,6 +232,7 @@ class Spree::StoreCredit < Spree::PaymentSource
       created_by_id: created_by_id,
       currency: currency,
       type_id: type_id,
+      expires_at: expires_at,
       memo: credit_allocation_memo
     }
   end

--- a/core/app/models/spree/store_credit.rb
+++ b/core/app/models/spree/store_credit.rb
@@ -27,6 +27,7 @@ class Spree::StoreCredit < Spree::PaymentSource
   delegate :name, to: :category, prefix: true
   delegate :email, to: :created_by, prefix: true
 
+  scope :active, -> { where(expires_at: nil).or(where("expires_at > ?", DateTime.current)) }
   scope :order_by_priority, -> { includes(:credit_type).order('spree_store_credit_types.priority ASC') }
 
   after_save :store_event

--- a/core/app/models/spree/store_credit.rb
+++ b/core/app/models/spree/store_credit.rb
@@ -171,6 +171,10 @@ class Spree::StoreCredit < Spree::PaymentSource
     !amount_remaining.zero?
   end
 
+  def expired?
+    expires_at.present? && expires_at < Time.current
+  end
+
   def invalidateable?
     !invalidated? && amount_authorized.zero?
   end

--- a/core/app/models/spree/store_credit_category.rb
+++ b/core/app/models/spree/store_credit_category.rb
@@ -1,6 +1,12 @@
 class Spree::StoreCreditCategory < Spree::Base
-  class_attribute :non_expiring_credit_types
-  self.non_expiring_credit_types = [Spree.t("store_credit.non_expiring")]
+  class_attribute :non_expiring_credit_categories
+  self.non_expiring_credit_categories = [Spree.t("store_credit_category.default")]
+
+  class << self
+    alias_attribute :non_expiring_credit_types, :non_expiring_credit_categories
+    deprecate non_expiring_credit_types: :non_expiring_credit_categories, deprecator: Spree::Deprecation
+    deprecate :non_expiring_credit_types= => :non_expiring_credit_categories=, deprecator: Spree::Deprecation
+  end
 
   class_attribute :reimbursement_category_name
   self.reimbursement_category_name = Spree.t("store_credit_category.default")
@@ -11,6 +17,6 @@ class Spree::StoreCreditCategory < Spree::Base
   end
 
   def non_expiring?
-    self.class.non_expiring_credit_types.include? name
+    self.class.non_expiring_credit_categories.include?(name)
   end
 end

--- a/core/app/models/spree/store_credit_type.rb
+++ b/core/app/models/spree/store_credit_type.rb
@@ -1,6 +1,6 @@
 module Spree
   class StoreCreditType < Spree::Base
-    DEFAULT_TYPE_NAME = Spree.t("store_credit.expiring")
+    DEFAULT_TYPE_NAME = Spree.t("store_credit.non_expiring")
     has_many :store_credits, class_name: 'Spree::StoreCredit', foreign_key: 'type_id'
   end
 end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -628,6 +628,10 @@ en:
           attributes:
             base:
               cannot_destroy_default_store: Cannot destroy the default Store.
+        spree/store_credit:
+            attributes:
+              expires_at:
+                blank: "is required for expiring credit types"
         spree/user_address:
           attributes:
             user_id:

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1214,6 +1214,8 @@ en:
         expires_at: "This determines when the promotion expires. <br/> If no value is specified, the promotion will never expires."
       spree/store:
         cart_tax_country_iso: "This determines which country is used for taxes on carts (orders which don't yet have an address).<br/> Default: None."
+      spree/store_credit:
+        expires_at: "This determines when the store credit expires. <br/> If no value is specified, the store credit will never expire."
       spree/variant:
         tax_category: "This determines what kind of taxation is applied to this variant.<br/> Default: Use tax category of the product associated with this variant"
         deleted: "Deleted Variant"

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1198,6 +1198,7 @@ en:
     expected: Expected
     expected_items: Expected Items
     expiration: Expiration
+    expires_at: Expires at
     extension: Extension
     existing_shipments: Existing shipments
     hints:

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1932,6 +1932,7 @@ en:
       user_has_no_store_credits: "User does not have any available store credit"
     store_credit_category:
       default: Default
+    store_credits_expired_error: "Your store credit expired and has been removed. Please check the new order amounts and try again."
     street_address: Street Address
     street_address_2: Street Address (cont'd)
     subtotal: Subtotal

--- a/core/db/migrate/20170419234001_add_expires_at_to_spree_store_credits.rb
+++ b/core/db/migrate/20170419234001_add_expires_at_to_spree_store_credits.rb
@@ -1,0 +1,5 @@
+class AddExpiresAtToSpreeStoreCredits < ActiveRecord::Migration[5.0]
+  def change
+    add_column :spree_store_credits, :expires_at, :datetime
+  end
+end

--- a/core/lib/spree/testing_support/factories/store_credit_category_factory.rb
+++ b/core/lib/spree/testing_support/factories/store_credit_category_factory.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
   factory :store_credit_category, class: Spree::StoreCreditCategory do
-    name "Exchange"
+    name "Default"
   end
 end

--- a/core/lib/spree/testing_support/factories/store_credit_factory.rb
+++ b/core/lib/spree/testing_support/factories/store_credit_factory.rb
@@ -9,7 +9,6 @@ FactoryGirl.define do
     association :category, factory: :store_credit_category
     amount 150.00
     currency "USD"
-    expires_at 1.day.from_now
     association :credit_type, factory: :primary_credit_type
   end
 end

--- a/core/lib/spree/testing_support/factories/store_credit_factory.rb
+++ b/core/lib/spree/testing_support/factories/store_credit_factory.rb
@@ -9,6 +9,7 @@ FactoryGirl.define do
     association :category, factory: :store_credit_category
     amount 150.00
     currency "USD"
+    expires_at 1.day.from_now
     association :credit_type, factory: :primary_credit_type
   end
 end

--- a/core/lib/spree/testing_support/factories/store_credit_type_factory.rb
+++ b/core/lib/spree/testing_support/factories/store_credit_type_factory.rb
@@ -5,7 +5,7 @@ FactoryGirl.define do
   end
 
   factory :secondary_credit_type, class: Spree::StoreCreditType do
-    name      { "Non-expiring" }
+    name      { "Expiring" }
     priority  { "2" }
   end
 end

--- a/core/spec/models/spree/store_credit_category_spec.rb
+++ b/core/spec/models/spree/store_credit_category_spec.rb
@@ -5,7 +5,7 @@ describe Spree::StoreCreditCategory, type: :model do
     let(:store_credit_category) { build(:store_credit_category, name: category_name) }
 
     context "non-expiring type store credit" do
-      let(:category_name) { "Non-expiring" }
+      let(:category_name) { "Default" }
       it { expect(store_credit_category).to be_non_expiring }
     end
 

--- a/core/spec/models/spree/store_credit_spec.rb
+++ b/core/spec/models/spree/store_credit_spec.rb
@@ -20,27 +20,25 @@ describe Spree::StoreCredit do
     end
 
     context "category is a non-expiring type" do
-      let!(:secondary_credit_type) { create(:secondary_credit_type) }
-      let(:store_credit) { build(:store_credit, credit_type: nil) }
-
-      before do
-        allow(store_credit.category).to receive(:non_expiring?).and_return(true)
-      end
+      let(:store_credit_attrs) { { credit_type: nil } }
+      let!(:primary_credit_type) { create(:primary_credit_type) }
 
       it "sets the credit type to non-expiring" do
         subject
-        expect(store_credit.credit_type.name).to eq secondary_credit_type.name
+        expect(store_credit.credit_type.name).to eq primary_credit_type.name
       end
     end
 
     context "category is an expiring type" do
+      let(:store_credit_attrs) { { credit_type: nil } }
+      let!(:secondary_credit_type) { create(:secondary_credit_type) }
       before do
         allow(store_credit.category).to receive(:non_expiring?).and_return(false)
       end
 
       it "sets the credit type to expiring" do
         subject
-        expect(store_credit.credit_type.name).to eq "Expiring"
+        expect(store_credit.credit_type.name).to eq secondary_credit_type.name
       end
     end
 
@@ -112,12 +110,12 @@ describe Spree::StoreCredit do
       subject { build(:store_credit, amount: 100.0, expires_at: nil) }
 
       context "the credit has a non-expiring category" do
-        before { allow(subject.category).to receive(:non_expiring?) { true } }
-
         it { is_expected.to be_valid }
       end
 
       context "the credit has an expiring category" do
+        before { allow(subject.category).to receive(:non_expiring?) { false } }
+
         it { is_expected.to_not be_valid }
 
         it "sets a custom error message" do

--- a/core/spec/models/spree/store_credit_spec.rb
+++ b/core/spec/models/spree/store_credit_spec.rb
@@ -802,6 +802,24 @@ describe Spree::StoreCredit do
     end
   end
 
+  describe "#expired?" do
+    subject { store_credit.expired? }
+
+    context "expires_at is nil" do
+      it { is_expected.to be false }
+    end
+
+    context "expires_at is in the future" do
+      let(:store_credit_attrs) { { expires_at: 2.minutes.from_now } }
+      it { is_expected.to be false }
+    end
+
+    context "expires_at is in the past" do
+      let(:store_credit_attrs) { { expires_at: 2.minutes.ago } }
+      it { is_expected.to be true }
+    end
+  end
+
   describe "#update_amount" do
     let(:invalidation_user) { create(:user) }
     let(:invalidation_reason) { create(:store_credit_update_reason) }

--- a/core/spec/models/spree/store_credit_spec.rb
+++ b/core/spec/models/spree/store_credit_spec.rb
@@ -108,6 +108,26 @@ describe Spree::StoreCredit do
       end
     end
 
+    describe "expiring credits require an expiration date" do
+      subject { build(:store_credit, amount: 100.0, expires_at: nil) }
+
+      context "the credit has a non-expiring category" do
+        before { allow(subject.category).to receive(:non_expiring?) { true } }
+
+        it { is_expected.to be_valid }
+      end
+
+      context "the credit has an expiring category" do
+        it { is_expected.to_not be_valid }
+
+        it "sets a custom error message" do
+          subject.validate
+          expect(subject.errors.full_messages).
+            to eq ["Expires at is required for expiring credit types"]
+        end
+      end
+    end
+
     describe "editing category" do
       let!(:store_credit) { create(:store_credit) }
       let!(:test_category) { create(:store_credit_category, name: "Testing") }

--- a/core/spec/models/spree/user_spec.rb
+++ b/core/spec/models/spree/user_spec.rb
@@ -181,10 +181,19 @@ describe Spree.user_class, type: :model do
       let(:user)                     { create(:user) }
       let(:amount)                   { 120.25 }
       let(:additional_amount)        { 55.75 }
-      let(:store_credit)             { create(:store_credit, user: user, amount: amount, amount_used: 0.0) }
+      let(:expires_at)               { 2.days.from_now }
+      let(:store_credit)             { create(:store_credit, user: user, amount: amount, amount_used: 0.0, expires_at: expires_at) }
       let!(:additional_store_credit) { create(:store_credit, user: user, amount: additional_amount, amount_used: 0.0) }
 
       subject { store_credit.user }
+
+      context "store credit has expired" do
+        let(:expires_at) { 2.days.ago }
+
+        it "does not include expired credits in the total" do
+          expect(subject.total_available_store_credit).to eq(additional_amount)
+        end
+      end
 
       context "part of the store credit has been used" do
         let(:amount_used) { 35.00 }


### PR DESCRIPTION
We currently have the notion of `expiring` and `non-expiring` store credits, but no means of telling whether a store credit _has_ expired. This PR adds an `expires_at` column to store credits and ensures only non-expired store credits are applied during checkout.

I tried to tie this in to the current system by adding a validation that requires the expiration date be set if the store credit has an expiring `Spree::StoreCreditCategory`. If the store credit is a non-expiring type, the validation is skipped and `nil` expiration values are treated as "never expires".

I added a datepicker to the store credit form to set the expiry:
![store_credit_new](https://cloud.githubusercontent.com/assets/4382781/25289915/78e4c8a4-2680-11e7-832c-e518602f452f.png)

example of the validation error:
![store_credit_error](https://cloud.githubusercontent.com/assets/4382781/25289929/8fa73f36-2680-11e7-8b1f-efd8aca716a8.png)

I also displayed the expiration on the index/show pages:
![store_credit_index_expiration](https://cloud.githubusercontent.com/assets/4382781/25289957/b3d6347a-2680-11e7-9ee5-83b991cf3fe8.png)

![store_credit_edit_expiration](https://cloud.githubusercontent.com/assets/4382781/25289966/bc0b7f06-2680-11e7-8c98-40199b2c6f10.png)
