### PR TITLE
Refactor Taxon tree to use Backbone

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/models/index.js
+++ b/backend/app/assets/javascripts/spree/backend/models/index.js
@@ -1,2 +1,3 @@
 //= require spree/backend/models/line_item
 //= require spree/backend/models/order
+//= require spree/backend/models/taxonomy

--- a/backend/app/assets/javascripts/spree/backend/models/taxonomy.js
+++ b/backend/app/assets/javascripts/spree/backend/models/taxonomy.js
@@ -1,0 +1,3 @@
+Spree.Models.Taxonomy = Backbone.Model.extend({
+  urlRoot: Spree.pathFor('api/taxonomies')
+});

--- a/backend/app/assets/javascripts/spree/backend/taxonomy.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/taxonomy.js.coffee
@@ -6,7 +6,7 @@ TaxonTreeView = Backbone.View.extend
     Spree.ajax
       type: "POST",
       dataType: "json",
-      url: Spree.routes.taxonomy_taxons_path,
+      url: "#{this.model.url()}/taxons",
       data:
         taxon: {name, parent_id, child_index}
       complete: @redraw_tree
@@ -15,7 +15,7 @@ TaxonTreeView = Backbone.View.extend
     Spree.ajax
       type: "PUT"
       dataType: "json"
-      url: "#{Spree.routes.taxonomy_taxons_path}/#{id}"
+      url: "#{this.model.url()}/taxons/#{id}",
       data:
         taxon: {parent_id, child_index}
       error: @redraw_tree
@@ -24,7 +24,7 @@ TaxonTreeView = Backbone.View.extend
     Spree.ajax
       type: "DELETE"
       dataType: "json"
-      url: "#{Spree.routes.taxonomy_taxons_path}/#{id}"
+      url: "#{this.model.url()}/taxons/#{id}",
       error: @redraw_tree
 
   render: ->

--- a/backend/app/assets/javascripts/spree/backend/taxonomy.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/taxonomy.js.coffee
@@ -45,18 +45,20 @@ TaxonTreeView = Backbone.View.extend
   redraw_tree: ->
     @get_taxonomy().done(@draw_tree)
 
-  resize_placeholder: (ui) ->
+  resize_placeholder: (e, ui) ->
     handleHeight = ui.helper.find('.sortable-handle').outerHeight()
     ui.placeholder.height(handleHeight)
 
   restore_sort_targets: ->
     $('.ui-sortable-over').removeClass('ui-sortable-over')
 
-  highlight_sort_targets: (ui) ->
+  highlight_sort_targets: (e, ui) ->
     @restore_sort_targets()
     ui.placeholder.parents('ul').addClass('ui-sortable-over')
 
-  handle_move: (el) ->
+  handle_move: (e, ui) ->
+    return if ui.sender?
+    el = ui.item
     @update_taxon
       id: el.data('taxon-id')
       parent_id: el.parent().closest('li').data('taxon-id')
@@ -85,18 +87,15 @@ TaxonTreeView = Backbone.View.extend
         @create_taxon({name, parent_id, child_index})
 
   initialize: ({taxonomy_id}) ->
-    _.bindAll(this, 'redraw_tree');
+    _.bindAll(this, 'redraw_tree', 'highlight_sort_targets', 'handle_move', 'handle_delete')
 
     this.taxonomy_id = taxonomy_id
     @redraw_tree()
     $("#taxonomy_tree").on
-      sortstart: (e, ui) ->
-        @resize_placeholder(ui)
-      sortover: (e, ui) ->
-        @highlight_sort_targets(ui)
+      sortstart: @resize_placeholder
+      sortover: @highlight_sort_targets
       sortstop: @restore_sort_targets
-      sortupdate: (e, ui) ->
-        @handle_move(ui.item) unless ui.sender?
+      sortupdate: @handle_move
     .on('click', '.js-taxon-delete', @handle_delete)
     .on('click', '.js-taxon-add-child', @handle_add_child)
     $('.add-taxon-button').on('click', @get_create_handler(taxonomy_id))

--- a/backend/app/assets/javascripts/spree/backend/taxonomy.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/taxonomy.js.coffee
@@ -77,30 +77,33 @@ TaxonTreeView = Backbone.View.extend
     child_index = 0
     @create_taxon({name, parent_id, child_index})
 
-  get_create_handler: (taxonomy_id) ->
-    handle_create = (e) =>
-      e.preventDefault()
-      @get_taxonomy().done (taxonomy) =>
-        name = 'New node'
-        parent_id = taxonomy.root.id
-        child_index = 0
-        @create_taxon({name, parent_id, child_index})
+  handle_create: (e) ->
+    e.preventDefault()
+    @get_taxonomy().done (taxonomy) =>
+      name = 'New node'
+      parent_id = taxonomy.root.id
+      child_index = 0
+      @create_taxon({name, parent_id, child_index})
+
+  events: {
+    'sortstart': 'resize_placeholder',
+    'sortover': 'highlight_sort_targets',
+    'sortstop': 'restore_sort_targets',
+    'sortupdate': 'handle_move',
+
+    'click .js-taxon-delete': 'handle_delete',
+    'click .js-taxon-add-child': 'handle_add_child',
+  }
 
   initialize: ({taxonomy_id}) ->
-    _.bindAll(this, 'redraw_tree', 'highlight_sort_targets', 'handle_move', 'handle_delete')
+    _.bindAll(this, 'redraw_tree', 'handle_create')
+    $('.add-taxon-button').on('click', @handle_create)
 
     this.taxonomy_id = taxonomy_id
     @redraw_tree()
-    $("#taxonomy_tree").on
-      sortstart: @resize_placeholder
-      sortover: @highlight_sort_targets
-      sortstop: @restore_sort_targets
-      sortupdate: @handle_move
-    .on('click', '.js-taxon-delete', @handle_delete)
-    .on('click', '.js-taxon-add-child', @handle_add_child)
-    $('.add-taxon-button').on('click', @get_create_handler(taxonomy_id))
 
 $ ->
   if $('#taxonomy_tree').length
     new TaxonTreeView
+      el: $('#taxonomy_tree')
       taxonomy_id: $('#taxonomy_tree').data("taxonomy-id")

--- a/backend/app/assets/javascripts/spree/backend/taxonomy.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/taxonomy.js.coffee
@@ -1,102 +1,107 @@
 Handlebars.registerHelper 'isRootTaxon', ->
   !@parent_id?
 
-get_taxonomy = ->
-  Spree.ajax
-    url: "#{Spree.routes.taxonomy_path}?set=nested"
+TaxonTreeView = Backbone.View.extend
+  get_taxonomy: ->
+    Spree.ajax
+      url: "#{Spree.routes.taxonomy_path}?set=nested"
 
-create_taxon = ({name, parent_id, child_index}) ->
-  Spree.ajax
-    type: "POST",
-    dataType: "json",
-    url: Spree.routes.taxonomy_taxons_path,
-    data:
-      taxon: {name, parent_id, child_index}
-    complete: redraw_tree
+  create_taxon: ({name, parent_id, child_index}) ->
+    Spree.ajax
+      type: "POST",
+      dataType: "json",
+      url: Spree.routes.taxonomy_taxons_path,
+      data:
+        taxon: {name, parent_id, child_index}
+      complete: @redraw_tree
 
-update_taxon = ({id, parent_id, child_index}) ->
-  Spree.ajax
-    type: "PUT"
-    dataType: "json"
-    url: "#{Spree.routes.taxonomy_taxons_path}/#{id}"
-    data:
-      taxon: {parent_id, child_index}
-    error: redraw_tree
+  update_taxon: ({id, parent_id, child_index}) ->
+    Spree.ajax
+      type: "PUT"
+      dataType: "json"
+      url: "#{Spree.routes.taxonomy_taxons_path}/#{id}"
+      data:
+        taxon: {parent_id, child_index}
+      error: @redraw_tree
 
-delete_taxon = ({id}) ->
-  Spree.ajax
-    type: "DELETE"
-    dataType: "json"
-    url: "#{Spree.routes.taxonomy_taxons_path}/#{id}"
-    error: redraw_tree
+  delete_taxon: ({id}) ->
+    Spree.ajax
+      type: "DELETE"
+      dataType: "json"
+      url: "#{Spree.routes.taxonomy_taxons_path}/#{id}"
+      error: @redraw_tree
 
-draw_tree = (taxonomy) ->
-  taxons_template = HandlebarsTemplates["taxons/tree"]
-  $('#taxonomy_tree')
-    .html( taxons_template({ taxons: [taxonomy.root] }) )
-    .find('ul')
-    .sortable
-      connectWith: '#taxonomy_tree ul'
-      placeholder: 'sortable-placeholder ui-state-highlight'
-      tolerance: 'pointer'
-      cursorAt: { left: 5 }
+  draw_tree: (taxonomy) ->
+    taxons_template = HandlebarsTemplates["taxons/tree"]
+    $('#taxonomy_tree')
+      .html( taxons_template({ taxons: [taxonomy.root] }) )
+      .find('ul')
+      .sortable
+        connectWith: '#taxonomy_tree ul'
+        placeholder: 'sortable-placeholder ui-state-highlight'
+        tolerance: 'pointer'
+        cursorAt: { left: 5 }
 
-redraw_tree = ->
-  get_taxonomy().done(draw_tree)
+  redraw_tree: ->
+    @get_taxonomy().done(@draw_tree)
 
-resize_placeholder = (ui) ->
-  handleHeight = ui.helper.find('.sortable-handle').outerHeight()
-  ui.placeholder.height(handleHeight)
+  resize_placeholder: (ui) ->
+    handleHeight = ui.helper.find('.sortable-handle').outerHeight()
+    ui.placeholder.height(handleHeight)
 
-restore_sort_targets = ->
-  $('.ui-sortable-over').removeClass('ui-sortable-over')
+  restore_sort_targets: ->
+    $('.ui-sortable-over').removeClass('ui-sortable-over')
 
-highlight_sort_targets = (ui) ->
-  restore_sort_targets()
-  ui.placeholder.parents('ul').addClass('ui-sortable-over')
+  highlight_sort_targets: (ui) ->
+    @restore_sort_targets()
+    ui.placeholder.parents('ul').addClass('ui-sortable-over')
 
-handle_move = (el) ->
-  update_taxon
-    id: el.data('taxon-id')
-    parent_id: el.parent().closest('li').data('taxon-id')
-    child_index: el.index()
+  handle_move: (el) ->
+    @update_taxon
+      id: el.data('taxon-id')
+      parent_id: el.parent().closest('li').data('taxon-id')
+      child_index: el.index()
 
-handle_delete = (e) ->
-  el = $(e.target).closest('li')
-  if confirm(Spree.translations.are_you_sure_delete)
-    delete_taxon({id: el.data('taxon-id')})
-    el.remove()
+  handle_delete: (e) ->
+    el = $(e.target).closest('li')
+    if confirm(Spree.translations.are_you_sure_delete)
+      @delete_taxon({id: el.data('taxon-id')})
+      el.remove()
 
-handle_add_child = (e) ->
-  el = $(e.target).closest('li')
-  parent_id = el.data('taxon-id')
-  name = 'New node'
-  child_index = 0
-  create_taxon({name, parent_id, child_index})
+  handle_add_child: (e) ->
+    el = $(e.target).closest('li')
+    parent_id = el.data('taxon-id')
+    name = 'New node'
+    child_index = 0
+    @create_taxon({name, parent_id, child_index})
 
-get_create_handler = (taxonomy_id) ->
-  handle_create = (e) ->
-    e.preventDefault()
-    get_taxonomy().done (taxonomy) ->
-      name = 'New node'
-      parent_id = taxonomy.root.id
-      child_index = 0
-      create_taxon({name, parent_id, child_index})
+  get_create_handler: (taxonomy_id) ->
+    handle_create = (e) =>
+      e.preventDefault()
+      @get_taxonomy().done (taxonomy) =>
+        name = 'New node'
+        parent_id = taxonomy.root.id
+        child_index = 0
+        @create_taxon({name, parent_id, child_index})
 
-setup_taxonomy_tree = (taxonomy_id) ->
-  redraw_tree()
-  $("#taxonomy_tree").on
-    sortstart: (e, ui) ->
-      resize_placeholder(ui)
-    sortover: (e, ui) ->
-      highlight_sort_targets(ui)
-    sortstop: restore_sort_targets
-    sortupdate: (e, ui) ->
-      handle_move(ui.item) unless ui.sender?
-  .on('click', '.js-taxon-delete', handle_delete)
-  .on('click', '.js-taxon-add-child', handle_add_child)
-  $('.add-taxon-button').on('click', get_create_handler(taxonomy_id))
+  initialize: ({taxonomy_id}) ->
+    _.bindAll(this, 'redraw_tree');
+
+    this.taxonomy_id = taxonomy_id
+    @redraw_tree()
+    $("#taxonomy_tree").on
+      sortstart: (e, ui) ->
+        @resize_placeholder(ui)
+      sortover: (e, ui) ->
+        @highlight_sort_targets(ui)
+      sortstop: @restore_sort_targets
+      sortupdate: (e, ui) ->
+        @handle_move(ui.item) unless ui.sender?
+    .on('click', '.js-taxon-delete', @handle_delete)
+    .on('click', '.js-taxon-add-child', @handle_add_child)
+    $('.add-taxon-button').on('click', @get_create_handler(taxonomy_id))
 
 $ ->
   if $('#taxonomy_tree').length
-    setup_taxonomy_tree($('#taxonomy_tree').data("taxonomy-id"))
+    new TaxonTreeView
+      taxonomy_id: $('#taxonomy_tree').data("taxonomy-id")

--- a/backend/app/assets/javascripts/spree/backend/taxonomy.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/taxonomy.js.coffee
@@ -33,7 +33,7 @@ TaxonTreeView = Backbone.View.extend
 
   draw_tree: (taxonomy) ->
     taxons_template = HandlebarsTemplates["taxons/tree"]
-    $('#taxonomy_tree')
+    this.$el
       .html( taxons_template({ taxons: [taxonomy.root] }) )
       .find('ul')
       .sortable
@@ -96,7 +96,7 @@ TaxonTreeView = Backbone.View.extend
   }
 
   initialize: ({taxonomy_id}) ->
-    _.bindAll(this, 'redraw_tree', 'handle_create')
+    _.bindAll(this, 'redraw_tree', 'draw_tree', 'handle_create')
     $('.add-taxon-button').on('click', @handle_create)
 
     this.taxonomy_id = taxonomy_id

--- a/backend/app/views/spree/admin/taxonomies/edit.erb
+++ b/backend/app/views/spree/admin/taxonomies/edit.erb
@@ -19,12 +19,5 @@
   </fieldset>
 
 
-  <div>
-    <script>
-      Spree.routes.taxonomy_path = "<%= spree.api_taxonomy_path(@taxonomy) %>";
-      Spree.routes.taxonomy_taxons_path = "<%= spree.api_taxonomy_taxons_path(@taxonomy) %>";
-      Spree.routes.admin_taxonomy_taxons_path = "<%= spree.admin_taxonomy_taxons_path(@taxonomy) %>";
-    </script>
-    <div id="taxonomy_tree" class="tree" data-taxonomy-id="<%= @taxonomy.id %>"></div>
-  </div>
+  <div id="taxonomy_tree" class="tree" data-taxonomy-id="<%= @taxonomy.id %>"></div>
 <% end %>


### PR DESCRIPTION
This is a light conversion to Backbone, not a complete conversion.

The existing code relied on setting URLs for the specific Taxonomy on the page globally in the `Spree.routes` object. This change avoids the inline javascript setting a global variable by creating a backbone model for Taxonomy, and wrapping the existing taxonomy code in a view.

This could be further improved at a later date by making a view and model for each individual taxon in the tree. The main goal here was to remove the inline script.