### PR TITLE
Make PromotionCodeBatchMailer use BaseMailer

### DIFF
--- a/core/app/mailers/spree/promotion_code_batch_mailer.rb
+++ b/core/app/mailers/spree/promotion_code_batch_mailer.rb
@@ -1,5 +1,5 @@
 module Spree
-  class PromotionCodeBatchMailer < ApplicationMailer
+  class PromotionCodeBatchMailer < Spree::BaseMailer
     def promotion_code_batch_finished(promotion_code_batch)
       @promotion_code_batch = promotion_code_batch
       mail(to: promotion_code_batch.email)


### PR DESCRIPTION
All our other mailers inherit from `Spree::BaseMailer`. `ApplicationMailer` is created by default in new rails apps, so it might make sense for `BaseMailer` to inherit from that, but I'm not certain it will be defined
in all stores (those upgrading from Rails 4.2). In any case we should be consistent.

Fixes #1849