### PR TITLE
Remove js.erb response for prices#new and add breadcrumbs

### DIFF
--- a/backend/app/views/spree/admin/prices/edit.html.erb
+++ b/backend/app/views/spree/admin/prices/edit.html.erb
@@ -1,4 +1,6 @@
 <%= render 'spree/admin/shared/product_tabs', current: 'Prices' %>
+<% admin_breadcrumb(link_to(plural_resource_name(Spree::Price), spree.admin_product_prices_url(@product))) %>
+<% admin_breadcrumb(Spree.t('actions.edit')) %>
 
 <%= form_for @price, url: spree.admin_product_price_path(@product, @price) do |f| %>
   <fieldset>

--- a/backend/app/views/spree/admin/prices/index.html.erb
+++ b/backend/app/views/spree/admin/prices/index.html.erb
@@ -1,4 +1,5 @@
 <%= render 'spree/admin/shared/product_tabs', current: 'Prices' %>
+<% admin_breadcrumb(plural_resource_name(Spree::Price)) %>
 
 <% content_for :page_actions do %>
   <li id="new_price_link">

--- a/backend/app/views/spree/admin/prices/index.html.erb
+++ b/backend/app/views/spree/admin/prices/index.html.erb
@@ -3,7 +3,7 @@
 
 <% content_for :page_actions do %>
   <li id="new_price_link">
-    <%= button_link_to t(".new_price"), new_object_url, { remote: true, id: 'admin_new_product' } %>
+    <%= button_link_to t(".new_price"), new_object_url %>
   </li>
 <% end if can?(:create, Spree::Product) %>
 

--- a/backend/app/views/spree/admin/prices/new.html.erb
+++ b/backend/app/views/spree/admin/prices/new.html.erb
@@ -1,3 +1,7 @@
+<%= render 'spree/admin/shared/product_tabs', current: 'Prices' %>
+<% admin_breadcrumb(link_to(plural_resource_name(Spree::Price), spree.admin_product_prices_url(@product))) %>
+<% admin_breadcrumb(Spree.t('actions.new')) %>
+
 <%= form_for [:admin, @product, @product.prices.build] do |f| %>
   <fieldset data-hook="admin_product_price_new_form">
     <legend><%= t('.new_price') %></legend>

--- a/backend/app/views/spree/admin/prices/new.js.erb
+++ b/backend/app/views/spree/admin/prices/new.js.erb
@@ -1,2 +1,0 @@
-$(".js-content-below-tabs").html('<%= escape_javascript(render template: 'spree/admin/prices/new', formats: [:html], handlers: [:erb]) %>');
-$(".js-content-below-tabs .select2").select2();


### PR DESCRIPTION
The new link was previously using `remote: true` and a `js.erb` template which replaced the main body of the page with the new form. This PR changes it to link to the new url normally.

This fixes a minor bug where the NumberWithCurrency JS component wasn't being initialized on the dynamically added content. It also allows having the breadcrumbs and title change correctly.

If we wanted the benefits of the old behaviour (avoiding full page load), we should use turbolinks.