### PR TITLE
[RFC] Allow use of Turbolinks in admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Solidus 2.5.0 (master, unreleased)
 
+- Add support for using Tubolinks in Solidus admin [#1863](https://github.com/solidusio/solidus/pull/1863) ([tvdeyen](https://github.com/tvdeyen))
+
 ## Solidus 2.4.0 (unreleased)
 
 ### Major changes

--- a/README.md
+++ b/README.md
@@ -139,6 +139,20 @@ include. This can be disabled by adding the following to
 config.assets.debug = false
 ```
 
+### Turbolinks
+
+To gain some extra speed you may enable Turbolinks inside of Solidus admin.
+
+Add `gem 'turbolinks', '~> 5.0.0'` into your `Gemfile` (if not already present) and append these lines to `vendor/assets/spree/backend/all.js`:
+
+```js
+//= require turbolinks
+//= require backend/app/assets/javascripts/spree/backend/turbolinks-integration.js
+```
+
+**CAUTION** Please be aware that Turbolinks can break extensions and/or customizations to the Solidus admin.
+Use at own risk.
+
 Developing Solidus
 ------------------
 

--- a/backend/app/assets/javascripts/spree/backend/admin.js
+++ b/backend/app/assets/javascripts/spree/backend/admin.js
@@ -67,7 +67,7 @@ var handle_date_picker_fields = function(){
   });
 }
 
-$(document).ready(function(){
+Spree.ready(function(){
   handle_date_picker_fields();
   var uniqueId = 1;
   $('.spree_add_fields').click(function() {

--- a/backend/app/assets/javascripts/spree/backend/calculator.js
+++ b/backend/app/assets/javascripts/spree/backend/calculator.js
@@ -17,7 +17,7 @@ Spree.CalculatorEditView = Backbone.View.extend({
   }
 })
 
-$(function() {
+Spree.ready(function() {
   $('.js-calculator-fields').each(function() {
     new Spree.CalculatorEditView({
       el: this

--- a/backend/app/assets/javascripts/spree/backend/checkouts/edit.js
+++ b/backend/app/assets/javascripts/spree/backend/checkouts/edit.js
@@ -1,4 +1,4 @@
-$(function() {
+Spree.ready(function() {
   if($(".js-customer-details").length) {
     var order = new Spree.Models.Order({
       bill_address: {},

--- a/backend/app/assets/javascripts/spree/backend/components/number_with_currency.js
+++ b/backend/app/assets/javascripts/spree/backend/components/number_with_currency.js
@@ -7,6 +7,6 @@ Spree.initNumberWithCurrency = function() {
   });
 }
 
-$(function() {
+Spree.ready(function() {
   Spree.initNumberWithCurrency()
 })

--- a/backend/app/assets/javascripts/spree/backend/components/tooltips.js
+++ b/backend/app/assets/javascripts/spree/backend/components/tooltips.js
@@ -1,4 +1,4 @@
-$(function(){
+Spree.ready(function(){
   $('body').popover({selector: '.hint-tooltip', html: true, trigger: 'hover', placement: 'top'});
 
   /* Animation has to be off to work around a bug in bootstrap 4.0.0.alpha6 */

--- a/backend/app/assets/javascripts/spree/backend/flash.coffee
+++ b/backend/app/assets/javascripts/spree/backend/flash.coffee
@@ -1,7 +1,7 @@
 showTime = 5000
 fadeOutTime = 500
 
-$ ->
+Spree.ready ->
   # Make flash messages dissapear
   # We only want to target the flash messages which are initially on the page.
   # Otherwise we risk hiding messages added by show_flash

--- a/backend/app/assets/javascripts/spree/backend/gateway.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/gateway.js.coffee
@@ -1,4 +1,4 @@
-$ ->
+Spree.ready ->
   $gateway_type = $('select.js-gateway-type')
   $preference_source = $('select.js-preference-source')
 

--- a/backend/app/assets/javascripts/spree/backend/images/index.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/images/index.js.coffee
@@ -1,4 +1,4 @@
-$ ->
+Spree.ready ->
   ($ '#new_image_link').click (event) ->
     event.preventDefault()
 

--- a/backend/app/assets/javascripts/spree/backend/navigation.coffee
+++ b/backend/app/assets/javascripts/spree/backend/navigation.coffee
@@ -4,7 +4,7 @@ navHeight = ->
 checkSideBarFit = ->
   $('.admin-nav').toggleClass('fits', navHeight() < $(window).height())
 
-$ ->
+Spree.ready ->
   $(".admin-nav-sticky, .admin-nav").stick_in_parent()
   checkSideBarFit()
   $(window).on('resize', checkSideBarFit)

--- a/backend/app/assets/javascripts/spree/backend/option_type_autocomplete.js
+++ b/backend/app/assets/javascripts/spree/backend/option_type_autocomplete.js
@@ -1,4 +1,4 @@
-$(document).ready(function () {
+Spree.ready(function () {
   'use strict';
 
   function formatOptionType(option_type) {

--- a/backend/app/assets/javascripts/spree/backend/orders/cart.js
+++ b/backend/app/assets/javascripts/spree/backend/orders/cart.js
@@ -48,7 +48,7 @@ Spree.Order.initCartPage = function(order_number) {
   })
 }
 
-$(function() {
+Spree.ready(function() {
   if ($(".js-order-cart-page").length) {
     Spree.Order.initCartPage($(".js-order-cart-page").data("order-number"));
   }

--- a/backend/app/assets/javascripts/spree/backend/orders/edit.js
+++ b/backend/app/assets/javascripts/spree/backend/orders/edit.js
@@ -1,4 +1,4 @@
-$(document).ready(function () {
+Spree.ready(function () {
   'use strict';
 
   $('[data-hook="add_product_name"]').find('.variant_autocomplete').variantAutocomplete({ in_stock_only: true });

--- a/backend/app/assets/javascripts/spree/backend/payments/edit.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/payments/edit.js.coffee
@@ -23,7 +23,7 @@ PaymentRowView = Backbone.View.extend
         show_flash 'error', response.responseJSON.error
     @model.save({ amount: amount }, options)
 
-$ ->
+Spree.ready ->
   order_id = $('#payments').data('order-id')
   Payment = Backbone.Model.extend
     urlRoot: Spree.routes.payments_api(order_id)

--- a/backend/app/assets/javascripts/spree/backend/payments/new.js
+++ b/backend/app/assets/javascripts/spree/backend/payments/new.js
@@ -1,4 +1,4 @@
-$(function() {
+Spree.ready(function() {
   if ($("#new_payment").length) {
     new Spree.Views.Payment.New({
       el: $('#new_payment')

--- a/backend/app/assets/javascripts/spree/backend/product_picker.js
+++ b/backend/app/assets/javascripts/spree/backend/product_picker.js
@@ -48,6 +48,6 @@ $.fn.productAutocomplete = function (options) {
   });
 };
 
-$(document).ready(function () {
+Spree.ready(function () {
   $('.product_picker').productAutocomplete();
 });

--- a/backend/app/assets/javascripts/spree/backend/progress.coffee
+++ b/backend/app/assets/javascripts/spree/backend/progress.coffee
@@ -1,4 +1,4 @@
-$ ->
+Spree.ready ->
   $(document).ajaxStart ->
     $("#progress").show()
 

--- a/backend/app/assets/javascripts/spree/backend/promotions/activation.js
+++ b/backend/app/assets/javascripts/spree/backend/promotions/activation.js
@@ -17,7 +17,7 @@ Spree.PromotionActivationView = Backbone.View.extend({
   }
 });
 
-$(function(){
+Spree.ready(function(){
   if($("#js_promotion_activation").length) {
     new Spree.PromotionActivationView({
       el: $("#js_promotion_activation")

--- a/backend/app/assets/javascripts/spree/backend/returns/return_item_selection.js
+++ b/backend/app/assets/javascripts/spree/backend/returns/return_item_selection.js
@@ -1,4 +1,4 @@
-$(document).ready(function() {
+Spree.ready(function() {
   function checkAddItemBox() {
     $(this).closest('tr').find('input.add-item').attr('checked', 'checked');
     updateSuggestedAmount();

--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -29,7 +29,7 @@ var ShipmentAddVariantView = Backbone.View.extend({
   }
 });
 
-$(function(){
+Spree.ready(function(){
   $(".js-shipment-add-variant").each(function(){
     new ShipmentAddVariantView({el: this});
   });
@@ -292,7 +292,7 @@ var ShipmentEditView = Backbone.View.extend({
   }
 });
 
-$(function(){
+Spree.ready(function(){
   if($('.js-shipment-edit [data-order-number]').length) {
     $('.js-shipment-edit').hide();
     var orderNumber = $('.js-shipment-edit [data-order-number]').data('orderNumber');

--- a/backend/app/assets/javascripts/spree/backend/states.coffee
+++ b/backend/app/assets/javascripts/spree/backend/states.coffee
@@ -1,4 +1,4 @@
-$ ->
+Spree.ready ->
   $new_state = $("#new_state")
   if $new_state.length
     $new_state_link = $("#new_state_link")

--- a/backend/app/assets/javascripts/spree/backend/stock_management/index_add_forms.coffee
+++ b/backend/app/assets/javascripts/spree/backend/stock_management/index_add_forms.coffee
@@ -51,7 +51,7 @@ Spree.AddStockItemView = Backbone.View.extend
         show_flash("error", response.responseText)
     @model.save(null, options)
 
-$ ->
+Spree.ready ->
   $('.js-add-stock-item').each ->
     $el = $(this)
     model = new Spree.StockItem

--- a/backend/app/assets/javascripts/spree/backend/stock_management/index_update_forms.coffee
+++ b/backend/app/assets/javascripts/spree/backend/stock_management/index_update_forms.coffee
@@ -56,7 +56,7 @@ Spree.EditStockItemView = Backbone.View.extend
       error: errorHandler
     @model.save(force: true, options)
 
-$ ->
+Spree.ready ->
   $('.js-edit-stock-item').each ->
     $el = $(this)
     model = new Spree.StockItem($el.data('stock-item'))

--- a/backend/app/assets/javascripts/spree/backend/stock_transfers/edit.coffee
+++ b/backend/app/assets/javascripts/spree/backend/stock_transfers/edit.coffee
@@ -1,4 +1,4 @@
-$(document).ready ->
+Spree.ready ->
   if $('#stock-transfer-transfer-items').length > 0
     Spree.StockTransfers.VariantForm.initializeForm(true)
     Spree.StockTransfers.VariantForm.beginListeningForAdd()

--- a/backend/app/assets/javascripts/spree/backend/stock_transfers/receive.coffee
+++ b/backend/app/assets/javascripts/spree/backend/stock_transfers/receive.coffee
@@ -1,4 +1,4 @@
-$(document).ready ->
+Spree.ready ->
   if $('#received-transfer-items').length > 0
     Spree.StockTransfers.VariantForm.initializeForm(false)
     Spree.StockTransfers.VariantForm.beginListeningForReceive()

--- a/backend/app/assets/javascripts/spree/backend/store_credits.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/store_credits.js.coffee
@@ -1,4 +1,4 @@
-$(document).ready ->
+Spree.ready ->
   return unless $('#sc_memo_edit_form').length > 0
 
   $('.js-edit-memo').on('click', (ev) =>

--- a/backend/app/assets/javascripts/spree/backend/style_guide.coffee
+++ b/backend/app/assets/javascripts/spree/backend/style_guide.coffee
@@ -1,2 +1,2 @@
-$ ->
+Spree.ready ->
   $(".style-guide-nav, .style-guide-sidebar").stick_in_parent()

--- a/backend/app/assets/javascripts/spree/backend/taxon_autocomplete.js
+++ b/backend/app/assets/javascripts/spree/backend/taxon_autocomplete.js
@@ -52,6 +52,6 @@ $.fn.taxonAutocomplete = function () {
     });
 };
 
-$(document).ready(function () {
+Spree.ready(function () {
   $('#product_taxon_ids, .taxon_picker').taxonAutocomplete();
 });

--- a/backend/app/assets/javascripts/spree/backend/taxonomy.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/taxonomy.js.coffee
@@ -100,7 +100,7 @@ TaxonTreeView = Backbone.View.extend
 
     @redraw_tree()
 
-$ ->
+Spree.ready ->
   if $('#taxonomy_tree').length
     model = new Spree.Models.Taxonomy({id: $('#taxonomy_tree').data("taxonomy-id")})
     new TaxonTreeView

--- a/backend/app/assets/javascripts/spree/backend/taxons.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/taxons.js.coffee
@@ -1,4 +1,4 @@
-$ ->
+Spree.ready ->
   productTemplate = HandlebarsTemplates['products/sortable']
 
   productListTemplate = (products) ->

--- a/backend/app/assets/javascripts/spree/backend/turbolinks-integration.js
+++ b/backend/app/assets/javascripts/spree/backend/turbolinks-integration.js
@@ -1,0 +1,21 @@
+// Require this file if you plan to use Turbolinks in the Solidus admin
+// It is necessary because extensions may use JS libs that make use of
+// jQuery.ready instead of Spree.ready
+
+Spree.jQueryReady = $.fn.ready;
+
+// override jQuery.ready to use Spree.ready even if it was not used explicitly
+$.fn.ready = function (callback) {
+  console.warn("Using jQuery.ready() in Solidus is deprecated. Use Spree.ready() instead. Called from: ", callback);
+  Spree.ready(callback);
+};
+
+Spree.ready = function(callback) {
+  if (Turbolinks.supported) {
+    jQuery(document).on('turbolinks:load', function() {
+      callback(jQuery);
+    });
+  } else {
+    Spree.jQueryReady(callback);
+  }
+};

--- a/backend/app/assets/javascripts/spree/backend/user_picker.js
+++ b/backend/app/assets/javascripts/spree/backend/user_picker.js
@@ -45,6 +45,6 @@ $.fn.userAutocomplete = function () {
   });
 };
 
-$(document).ready(function () {
+Spree.ready(function () {
   $('.user_picker').userAutocomplete();
 });

--- a/backend/app/assets/javascripts/spree/backend/zone.js
+++ b/backend/app/assets/javascripts/spree/backend/zone.js
@@ -1,4 +1,4 @@
-$(function(){
+Spree.ready(function(){
   if($('.js-zones-form').length) {
     var view = new Spree.Views.Zones.Form({
       el: $('.js-zones-form')

--- a/backend/app/assets/stylesheets/spree/backend/components/_progress.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_progress.scss
@@ -1,3 +1,7 @@
+.turbolinks-progress-bar {
+  background-color: $color-3;
+}
+
 #progress {
   display: none;
   position: fixed;

--- a/backend/app/views/spree/admin/shared/_head.html.erb
+++ b/backend/app/views/spree/admin/shared/_head.html.erb
@@ -7,7 +7,7 @@
 <!-- Get "Open Sans" font from Google -->
 <link href='//fonts.googleapis.com/css?family=Open+Sans:400italic,600italic,400,600&subset=latin,cyrillic,greek,vietnamese' rel='stylesheet' type='text/css'>
 
-<%= stylesheet_link_tag 'spree/backend/all', media: 'all' %>
+<%= stylesheet_link_tag 'spree/backend/all', media: 'all', data: {turbolinks_track: 'reload'} %>
 
 <%- if Rails.env.test? %>
   <style>
@@ -30,7 +30,7 @@
 <%- end %>
 
 
-<%= javascript_include_tag 'spree/backend/all' %>
+<%= javascript_include_tag 'spree/backend/all', data: {turbolinks_track: 'reload'} %>
 
 <%= render "spree/admin/shared/js_locale_data" %>
 

--- a/backend/app/views/spree/admin/shared/_head.html.erb
+++ b/backend/app/views/spree/admin/shared/_head.html.erb
@@ -1,4 +1,5 @@
 <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
+<meta name="turbolinks-cache-control" content="no-cache">
 
 <%= csrf_meta_tags %>
 

--- a/backend/app/views/spree/admin/shared/_js_locale_data.html.erb
+++ b/backend/app/views/spree/admin/shared/_js_locale_data.html.erb
@@ -43,5 +43,6 @@
 </script>
 
 <% if I18n.locale != :en %>
-  <%= javascript_include_tag "solidus_admin/select2_locales/select2_locale_#{I18n.locale}" %>
+  <%= javascript_include_tag "solidus_admin/select2_locales/select2_locale_#{I18n.locale}",
+    data: {turbolinks_track: 'reload'} %>
 <% end %>

--- a/backend/app/views/spree/admin/stock_locations/_form.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/_form.html.erb
@@ -113,7 +113,7 @@
 
 <% content_for :head do %>
   <%= javascript_tag do -%>
-    $(document).ready(function(){
+    Spree.ready(function(){
       $('span#country select.select2').on('change', function() { update_state(''); });
     });
   <% end -%>

--- a/backend/app/views/spree/layouts/admin_style_guide.html.erb
+++ b/backend/app/views/spree/layouts/admin_style_guide.html.erb
@@ -4,8 +4,8 @@
     <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
     <title>Solidus Style Guide</title>
 
-    <%= stylesheet_link_tag "spree/backend/all" %>
-    <%= javascript_include_tag "spree/backend/all" %>
+    <%= stylesheet_link_tag "spree/backend/all", data: {turbolinks_track: 'reload'} %>
+    <%= javascript_include_tag "spree/backend/all", data: {turbolinks_track: 'reload'} %>
     <%= render "spree/admin/shared/js_locale_data" %>
   </head>
 

--- a/backend/spec/features/admin/configuration/payment_methods_spec.rb
+++ b/backend/spec/features/admin/configuration/payment_methods_spec.rb
@@ -6,14 +6,16 @@ describe "Payment Methods", type: :feature do
   before(:each) do
     visit spree.admin_path
     click_link "Settings"
-    click_link "Payments"
   end
 
   context "admin visiting payment methods listing page" do
-    it "should display existing payment methods" do
+    before do
       create(:check_payment_method)
-      click_link "Payment Methods"
+    end
 
+    it "should display existing payment methods" do
+      click_link "Payments"
+      expect(page).to have_link 'Payment Methods'
       within("table#listing_payment_methods") do
         expect(all("th")[1].text).to eq("Name")
         expect(all("th")[2].text).to eq("Type")
@@ -30,7 +32,8 @@ describe "Payment Methods", type: :feature do
 
   context "admin creating a new payment method" do
     it "should be able to create a new payment method" do
-      click_link "Payment Methods"
+      click_link "Payments"
+      expect(page).to have_link 'Payment Methods'
       click_link "admin_new_payment_methods_link"
       expect(page).to have_content("New Payment Method")
       fill_in "payment_method_name", with: "check90"
@@ -44,7 +47,8 @@ describe "Payment Methods", type: :feature do
   context "admin editing a payment method" do
     before(:each) do
       create(:check_payment_method)
-      click_link "Payment Methods"
+      click_link "Payments"
+      expect(page).to have_link 'Payment Methods'
       within("table#listing_payment_methods") do
         click_icon(:edit)
       end
@@ -65,14 +69,13 @@ describe "Payment Methods", type: :feature do
   end
 
   context "changing type and payment_source", js: true do
-    after do
-      # cleanup
-      Spree::Config.static_model_preferences.for_class(Spree::PaymentMethod::BogusCreditCard).clear
+    before do
+      create(:credit_card_payment_method)
     end
 
     it "displays message when changing type" do
-      create(:credit_card_payment_method)
-      click_link "Payment Methods"
+      click_link "Payments"
+      expect(page).to have_link 'Payment Methods'
       click_icon :edit
       expect(page).to have_content('Test Mode')
 
@@ -89,8 +92,8 @@ describe "Payment Methods", type: :feature do
     it "displays message when changing preference source" do
       Spree::Config.static_model_preferences.add(Spree::PaymentMethod::BogusCreditCard, 'my_prefs', {})
 
-      create(:credit_card_payment_method)
-      click_link "Payment Methods"
+      click_link "Payments"
+      expect(page).to have_link 'Payment Methods'
       click_icon :edit
       expect(page).to have_content('Test Mode')
 
@@ -107,8 +110,8 @@ describe "Payment Methods", type: :feature do
     it "updates successfully and keeps secrets" do
       Spree::Config.static_model_preferences.add(Spree::PaymentMethod::BogusCreditCard, 'my_prefs', { server: 'secret' })
 
-      create(:credit_card_payment_method)
-      click_link "Payment Methods"
+      click_link "Payments"
+      expect(page).to have_link 'Payment Methods'
       click_icon :edit
 
       select 'my_prefs', from: 'Preference Source'
@@ -121,6 +124,11 @@ describe "Payment Methods", type: :feature do
       click_on 'Update'
       expect(page).to have_content('Test Mode')
       expect(page).to have_no_content('secret')
+    end
+
+    after do
+      # cleanup
+      Spree::Config.static_model_preferences.for_class(Spree::PaymentMethod::BogusCreditCard).clear
     end
   end
 end

--- a/backend/spec/features/admin/orders/customer_details_spec.rb
+++ b/backend/spec/features/admin/orders/customer_details_spec.rb
@@ -121,14 +121,29 @@ describe "Customer Details", type: :feature, js: true do
       expect(page).to have_content("Shipping address first name can't be blank")
     end
 
-    it "updates order email for an existing order with a user" do
-      order.update_columns(ship_address_id: ship_address.id, bill_address_id: bill_address.id, state: "confirm", completed_at: nil)
-      previous_user = order.user
-      click_link "Customer"
-      fill_in "order_email", with: "newemail@example.com"
-      expect { click_button "Update" }.to change { order.reload.email }.to "newemail@example.com"
-      expect(order.user_id).to eq previous_user.id
-      expect(order.user.email).to eq previous_user.email
+    context "for an order in confirm state with a user" do
+      let(:user) { order.user }
+
+      before do
+        order.update_columns(
+          ship_address_id: ship_address.id,
+          bill_address_id: bill_address.id,
+          state: "confirm",
+          completed_at: nil
+        )
+      end
+
+      it "updating order email works" do
+        click_link "Customer"
+        fill_in "order_email", with: "newemail@example.com"
+        click_button "Update"
+        expect(page).to have_content 'Customer Details Updated'
+        click_link "Customer"
+        expect(page).to have_field 'Customer E-Mail', with: order.reload.email
+        within '#order_user_link' do
+          expect(page).to have_link user.email
+        end
+      end
     end
 
     context "country associated was removed" do


### PR DESCRIPTION
Using Turbolinks for navigating admin should give us a nice little speed gain.

For getting this to work it was needed to use `Spree.ready` instead of `jQuery.ready` to initialize the various JS modules we have.

Luckily `Spree.ready` already takes care of the `turbolinks:load` event, so this was easy for our own admin, for extensions we overwrote `jQuery.ready` to use `Spree.ready` instead (the same trick that `jquery-turbolinks` uses).

- [x] Disable Turbolinks per default and enable it only for new Stores
- [x] Override `jQuery.ready` and log deprecation notices to the JS console