### PR TITLE
Fix deleting a line item when asked to remove more than its quantity

### DIFF
--- a/core/app/models/spree/order_contents.rb
+++ b/core/app/models/spree/order_contents.rb
@@ -112,7 +112,7 @@ module Spree
       line_item.quantity -= quantity
       line_item.target_shipment = options[:shipment]
 
-      if line_item.quantity == 0
+      if line_item.quantity <= 0
         order.line_items.destroy(line_item)
       else
         line_item.save!

--- a/core/spec/models/spree/order_contents_spec.rb
+++ b/core/spec/models/spree/order_contents_spec.rb
@@ -203,6 +203,13 @@ describe Spree::OrderContents, type: :model do
       expect(order.reload.find_line_item_by_variant(variant)).to be_nil
     end
 
+    it 'should remove line_item if quantity is greater than line_item quantity' do
+      subject.add(variant, 1)
+      subject.remove(variant, 2)
+
+      expect(order.reload.find_line_item_by_variant(variant)).to be_nil
+    end
+
     it "should update order totals" do
       expect(order.item_total.to_f).to eq(0.00)
       expect(order.total.to_f).to eq(0.00)


### PR DESCRIPTION
This PR addresses a small issue I found in `OrderContents#remove`.

In cases where `#remove` is called with a `quantity` greater than the `line_item.quantity`, the order would be left with a `line_item` with 0 quantity. It seems like the expected behaviour here would be to remove the line item if more than the current quantity is requested to be removed.

I addressed this simply by using `<=` instead of `==` for determining whether or not to destroy the `line_item`.

I'm also included a test that fails without the change.