### PR TITLE
Fix BigDecimal errors under ruby 2.4

### DIFF
--- a/core/app/models/spree/calculator/tiered_flat_rate.rb
+++ b/core/app/models/spree/calculator/tiered_flat_rate.rb
@@ -9,7 +9,7 @@ module Spree
       # Convert tier values to decimals. Strings don't do us much good.
       if preferred_tiers.is_a?(Hash)
         self.preferred_tiers = preferred_tiers.map do |k, v|
-          [BigDecimal.new(k.to_s), BigDecimal.new(v.to_s)]
+          [cast_to_d(k.to_s), cast_to_d(v.to_s)]
         end.to_h
       end
     end
@@ -22,6 +22,12 @@ module Spree
     end
 
     private
+
+    def cast_to_d(value)
+      value.to_s.to_d
+    rescue ArgumentError
+      BigDecimal.new(0)
+    end
 
     def preferred_tiers_content
       if preferred_tiers.is_a? Hash

--- a/core/app/models/spree/calculator/tiered_percent.rb
+++ b/core/app/models/spree/calculator/tiered_percent.rb
@@ -9,7 +9,7 @@ module Spree
       # Convert tier values to decimals. Strings don't do us much good.
       if preferred_tiers.is_a?(Hash)
         self.preferred_tiers = preferred_tiers.map do |k, v|
-          [BigDecimal.new(k.to_s), BigDecimal.new(v.to_s)]
+          [cast_to_d(k.to_s), cast_to_d(v.to_s)]
         end.to_h
       end
     end
@@ -27,6 +27,12 @@ module Spree
     end
 
     private
+
+    def cast_to_d(value)
+      value.to_s.to_d
+    rescue ArgumentError
+      BigDecimal.new(0)
+    end
 
     def preferred_tiers_content
       if preferred_tiers.is_a? Hash

--- a/core/app/models/spree/preferences/preferable.rb
+++ b/core/app/models/spree/preferences/preferable.rb
@@ -104,7 +104,11 @@ module Spree::Preferences::Preferable
     when :password
       value.to_s
     when :decimal
-      BigDecimal.new(value.to_s)
+      begin
+        value.to_s.to_d
+      rescue ArgumentError
+        BigDecimal.new(0)
+      end
     when :integer
       value.to_i
     when :boolean


### PR DESCRIPTION
Under ruby 2.4, `BigDecimal.new` raises an `ArgumentError` when casting an invalid value (it used to return 0). Unfortunately, `#to_d` also (probably incorrectly) raises a `ArgumentError`, unlike `#to_i` and friends.

This works around this issue by capturing `ArgumentError` and returning 0 in that case.

With this change the test suite passes under ruby 2.4 (but still has a fair number of warnings from versioncake)