### PR TITLE
Correctly set viewable_id in image upload (2.2.0 regression)

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/views/images/upload_zone.js
+++ b/backend/app/assets/javascripts/spree/backend/views/images/upload_zone.js
@@ -8,10 +8,11 @@ Spree.Views.Images.UploadZone = Backbone.View.extend({
 
   upload: function(file) {
     var progressModel = new Spree.Models.ImageUpload({file: file});
-    progressModel.previewFile();
-    progressModel.uploadFile();
 
     this.collection.add(progressModel);
+
+    progressModel.previewFile();
+    progressModel.uploadFile();
   },
 
   dragClass: 'with-images',

--- a/backend/spec/features/admin/products/edit/images_spec.rb
+++ b/backend/spec/features/admin/products/edit/images_spec.rb
@@ -64,6 +64,8 @@ describe "Product Images", type: :feature do
           expect(page).to have_xpath("//img[contains(@src,'ror_ringer')]")
         end
       end
+
+      expect(Spree::Image.last.viewable).to eq(product.master)
     end
   end
 


### PR DESCRIPTION
viewable_id was being set when the ImageUpload was added to the collection, but the upload was started before adding the item leaving `viewable_id` unset.

Fixes #1875