### PR TITLE
Fix stubbing in promotion_spec for Rails 5.1

### DIFF
--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -597,7 +597,8 @@ describe Spree::Promotion, type: :model do
           allow(rule2).to receive_messages(eligible?: true, applicable?: true)
 
           promotion.promotion_rules = [rule1, rule2]
-          allow(promotion.promotion_rules).to receive(:for).and_return(promotion.promotion_rules)
+          allow(promotion).to receive_message_chain(:rules, :none?).and_return(false)
+          allow(promotion).to receive_message_chain(:rules, :for).and_return(promotion.promotion_rules)
         end
         it "returns the eligible rules" do
           expect(promotion.eligible_rules(promotable)).to eq [rule1, rule2]
@@ -615,7 +616,8 @@ describe Spree::Promotion, type: :model do
           allow(rule2).to receive_messages(eligible?: false, applicable?: true, eligibility_errors: errors)
 
           promotion.promotion_rules = [rule1, rule2]
-          allow(promotion.promotion_rules).to receive(:for).and_return(promotion.promotion_rules)
+          allow(promotion).to receive_message_chain(:rules, :none?).and_return(false)
+          allow(promotion).to receive_message_chain(:rules, :for).and_return(promotion.promotion_rules)
         end
         it "returns nil" do
           expect(promotion.eligible_rules(promotable)).to be_nil
@@ -647,7 +649,8 @@ describe Spree::Promotion, type: :model do
           allow(rule).to receive_messages(eligible?: false, applicable?: true, eligibility_errors: errors)
 
           promotion.promotion_rules = [rule]
-          allow(promotion.promotion_rules).to receive(:for).and_return(promotion.promotion_rules)
+          allow(promotion).to receive_message_chain(:rules, :for).and_return(promotion.promotion_rules)
+          allow(promotion).to receive_message_chain(:rules, :none?).and_return(false)
         end
         it "returns nil" do
           expect(promotion.eligible_rules(promotable)).to be_nil


### PR DESCRIPTION
In Rails 5.1, each call to promotion.promotion_rules returns a different instance of the association, so the existing stub didn't work.