### PR TITLE
ActionController::Parameters fixes for Rails 5.1

### DIFF
--- a/backend/app/controllers/spree/admin/promotion_rules_controller.rb
+++ b/backend/app/controllers/spree/admin/promotion_rules_controller.rb
@@ -5,7 +5,7 @@ class Spree::Admin::PromotionRulesController < Spree::Admin::BaseController
   before_action :validate_promotion_rule_type, only: :create
 
   def create
-    @promotion_rule = @promotion_rule_type.new(params[:promotion_rule])
+    @promotion_rule = @promotion_rule_type.new(promotion_rule_params)
     @promotion_rule.promotion = @promotion
     if @promotion_rule.save
       flash[:success] = Spree.t(:successfully_created, resource: Spree.t(:promotion_rule))
@@ -46,5 +46,9 @@ class Spree::Admin::PromotionRulesController < Spree::Admin::BaseController
         format.js   { render layout: false }
       end
     end
+  end
+
+  def promotion_rule_params
+    params[:promotion_rule].permit!
   end
 end

--- a/backend/app/controllers/spree/admin/resource_controller.rb
+++ b/backend/app/controllers/spree/admin/resource_controller.rb
@@ -253,7 +253,7 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
   #
   # Other controllers can, should, override it to set custom logic
   def permitted_resource_params
-    params[object_name].present? ? params.require(object_name).permit! : ActionController::Parameters.new
+    params[object_name].present? ? params.require(object_name).permit! : ActionController::Parameters.new.permit!
   end
 
   def collection_actions

--- a/core/spec/lib/spree/core/controller_helpers/payment_parameters_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/payment_parameters_spec.rb
@@ -11,7 +11,6 @@ describe Spree::Core::ControllerHelpers::PaymentParameters, type: :controller do
     it "is unpermitted ActionController::Parameters" do
       expect(subject).to be_a(ActionController::Parameters)
       expect(subject).not_to be_permitted
-      expect(subject.to_h).to eq({})
     end
   end
 

--- a/core/spec/models/spree/payment_create_spec.rb
+++ b/core/spec/models/spree/payment_create_spec.rb
@@ -154,12 +154,20 @@ module Spree
       context "unpermitted" do
         let(:attributes) { ActionController::Parameters.new(valid_attributes) }
 
-        it "ignores all attributes" do
-          expect(new_payment).to have_attributes(
-            amount: 0,
-            payment_method: nil,
-            source: nil
-          )
+        if Rails.gem_version < Gem::Version.new('5.1')
+          it "ignores all attributes" do
+            expect(new_payment).to have_attributes(
+              amount: 0,
+              payment_method: nil,
+              source: nil
+            )
+          end
+        else
+          it "raises an exception" do
+            expect {
+              new_payment
+            }.to raise_exception(ActionController::UnfilteredParameters)
+          end
         end
       end
 


### PR DESCRIPTION
From the [Rails 5.1 release notes](https://github.com/rails/rails/blob/5-1-stable/actionpack/CHANGELOG.md):


> *   Raise exception when calling `to_h` and `to_hash` in an unpermitted Parameters.
>
>     Before we returned either an empty hash or only the always permitted parameters
>    (`:controller` and `:action` by default).
>
>    The previous behavior was dangerous because in order to get the attributes users
>    usually fallback to use `to_unsafe_h that` could potentially introduce security issues.
>
>    *Rafael Mendonça França*

This makes our usage of ActionController::Parameters compatible with both Rails 5.0 and Rails 5.1
