### PR TITLE
Don't delete new_framework_defaults.rb in dummy app

### DIFF
--- a/core/lib/generators/spree/dummy/dummy_generator.rb
+++ b/core/lib/generators/spree/dummy/dummy_generator.rb
@@ -46,9 +46,6 @@ module Spree
       template "rails/routes.rb", "#{dummy_path}/config/routes.rb", force: true
       template "rails/test.rb", "#{dummy_path}/config/environments/test.rb", force: true
       template "rails/script/rails", "#{dummy_path}/spec/dummy/script/rails", force: true
-
-      # FIXME: We aren't ready for rails 5 defaults
-      remove_file "#{dummy_path}/config/initializers/new_framework_defaults.rb"
     end
 
     def test_dummy_inject_extension_requirements


### PR DESCRIPTION
This was necessary when we were first updating Solidus for Rails 5.0, but hasn't been necessary since Solidus 2.0.0 release.

It should have probably been removed a while ago.