### PR TITLE
Replace `find_by_permalink!` with `find_by!`

### DIFF
--- a/frontend/app/controllers/spree/taxons_controller.rb
+++ b/frontend/app/controllers/spree/taxons_controller.rb
@@ -6,7 +6,7 @@ module Spree
     respond_to :html
 
     def show
-      @taxon = Spree::Taxon.find_by_permalink!(params[:id])
+      @taxon = Spree::Taxon.find_by!(permalink: params[:id])
       return unless @taxon
 
       @searcher = build_searcher(params.merge(taxon: @taxon.id, include_images: true))


### PR DESCRIPTION
find_by_permalink breaks when solidus_globalize is
being used. This removes necessity to create a path 
for this method.