### PR TITLE
Configure admin turbolinks

### DIFF
--- a/backend/app/assets/javascripts/spree/backend.js
+++ b/backend/app/assets/javascripts/spree/backend.js
@@ -18,6 +18,7 @@
 //= require spree/backend/namespaces
 //= require spree/backend/translation
 //= require spree/backend/backbone-overrides
+//= require spree/backend/turbolinks-configuration
 //= require spree/backend/format_money
 //
 //= require spree/backend/templates

--- a/backend/app/assets/javascripts/spree/backend/turbolinks-configuration.js.erb
+++ b/backend/app/assets/javascripts/spree/backend/turbolinks-configuration.js.erb
@@ -1,0 +1,20 @@
+// comment line necessary for correct interpolation of use_turbolinks
+Turbolinks.supported = <%= Spree::Backend::Config.use_turbolinks %>;
+
+Spree.jQueryReady = $.fn.ready;
+
+// override jQuery.ready to use Spree.ready even if it was not used explicitly
+$.fn.ready = function (callback) {
+  console.warn("jQuery.ready() is deprecated. Use Spree.ready() instead. Called from:", callback );
+  Spree.ready(callback);
+};
+
+Spree.ready = function(callback) {
+  if (Turbolinks.supported) {
+    jQuery(document).on('turbolinks:load', function() {
+      callback(jQuery);
+    });
+  } else {
+    Spree.jQueryReady(callback);
+  }
+};

--- a/backend/app/models/spree/backend_configuration.rb
+++ b/backend/app/models/spree/backend_configuration.rb
@@ -2,6 +2,9 @@ module Spree
   class BackendConfiguration < Preferences::Configuration
     preference :locale, :string, default: Rails.application.config.i18n.default_locale
 
+    # @!attribute [rw] use_turbolinks
+    preference :use_turbolinks, :boolean, default: false
+
     ORDER_TABS         ||= [:orders, :payments, :creditcard_payments,
                             :shipments, :credit_cards, :return_authorizations,
                             :customer_returns, :adjustments, :customer_details]

--- a/backend/spec/models/spree/backend_configuration_spec.rb
+++ b/backend/spec/models/spree/backend_configuration_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe Spree::BackendConfiguration, type: :model do
+  let(:prefs) { Spree::Backend::Config }
+
+  describe '#use_turbolinks' do
+    specify { expect(prefs).to respond_to(:use_turbolinks) }
+  end
+end

--- a/core/lib/generators/spree/install/templates/config/initializers/solidus.rb
+++ b/core/lib/generators/spree/install/templates/config/initializers/solidus.rb
@@ -65,6 +65,7 @@ Spree::Backend::Config.configure do |config|
   config.use_static_preferences!
 
   config.locale = 'en'
+  config.use_turbolinks = true
 end
 <% end -%>
 


### PR DESCRIPTION
- Enabled for new applications

- Disabled for existing applications. Enable in an initializer with:
  ```ruby
  # config/initializers/spree.rb
  Spree::Backend::Config.configure do |config|
    config.use_turbolinks = true
  end
  ```

- Handles gracefully existing javascript code, which still uses
    jQuery.ready and gives a warning of the location of those functions

Towards #1863 

_edit_: *I will see to fix the 18 test failures* .. *tests fixed!*