### PR TITLE
Improve master_variant factory

### DIFF
--- a/core/lib/spree/testing_support/factories/variant_factory.rb
+++ b/core/lib/spree/testing_support/factories/variant_factory.rb
@@ -14,7 +14,6 @@ FactoryGirl.define do
     track_inventory true
 
     product { |p| p.association(:base_product) }
-    option_values { [create(:option_value)] }
 
     # ensure stock item will be created for this variant
     before(:create) { create(:stock_location) if Spree::StockLocation.count == 0 }
@@ -22,6 +21,7 @@ FactoryGirl.define do
     factory :variant do
       # on_hand 5
       product { |p| p.association(:product) }
+      option_values { [create(:option_value)] }
     end
 
     factory :master_variant do

--- a/core/lib/spree/testing_support/factories/variant_factory.rb
+++ b/core/lib/spree/testing_support/factories/variant_factory.rb
@@ -26,6 +26,8 @@ FactoryGirl.define do
 
     factory :master_variant do
       is_master 1
+      before(:create){ |variant| variant.product.master = variant }
+      product { build(:base_product) }
     end
 
     factory :on_demand_variant do

--- a/core/spec/lib/spree/core/testing_support/factories/variant_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/variant_factory_spec.rb
@@ -20,6 +20,24 @@ RSpec.describe 'variant factory' do
     let(:factory) { :master_variant }
 
     it_behaves_like 'a working factory'
+
+    it "builds a master variant properly" do
+      variant = create(factory)
+      expect(variant).to be_is_master
+      expect(variant.option_values).to be_empty
+
+      product = variant.product
+      expect(product.master).to be(variant)
+      expect(product.variants).to be_empty
+      expect(product.variants_including_master).to eq [variant]
+      expect(product.option_types).to be_empty
+    end
+
+    it "creates only one variant" do
+      expect {
+        create(factory)
+      }.to change { Spree::Variant.count }.from(0).to(1)
+    end
   end
 
   describe 'on demand variant' do


### PR DESCRIPTION
Previously the master_variant factory would create two master variants. The one we actually requested, and one created implicitly by the product factory.

This PR updates the master variant factory so that it only creates a single variant. This should be a bit faster and more correct.

This also avoids creating option_values on the master variant.