### PR TITLE
Update canonical-rails to 0.2.0

### DIFF
--- a/frontend/solidus_frontend.gemspec
+++ b/frontend/solidus_frontend.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'solidus_api', s.version
   s.add_dependency 'solidus_core', s.version
 
-  s.add_dependency 'canonical-rails', '~> 0.1.1'
+  s.add_dependency 'canonical-rails', '~> 0.2.0'
   s.add_dependency 'jquery-rails'
   s.add_dependency 'sass-rails'
   s.add_dependency 'coffee-rails'


### PR DESCRIPTION
canonical-rails 0.2.0 has support for Rails 5.1