### PR TITLE
Bug fix: Don't update wallet default payment method if the default is already …

### DIFF
--- a/core/app/models/spree/wallet.rb
+++ b/core/app/models/spree/wallet.rb
@@ -61,6 +61,11 @@ class Spree::Wallet
       raise Unauthorized, "wallet_payment_source #{wallet_payment_source.id} does not belong to wallet of user #{user.id}"
     end
 
+    # Do not update the payment source if the passed source is already default
+    if default_wallet_payment_source.try(:id) == wallet_payment_source.id
+      return
+    end
+
     wallet_payment_source.transaction do
       # Unset old default
       default_wallet_payment_source.try!(:update!, default: false)

--- a/core/app/models/spree/wallet.rb
+++ b/core/app/models/spree/wallet.rb
@@ -62,7 +62,7 @@ class Spree::Wallet
     end
 
     # Do not update the payment source if the passed source is already default
-    if default_wallet_payment_source.try(:id) == wallet_payment_source.id
+    if default_wallet_payment_source.try(:id) == wallet_payment_source.try(:id)
       return
     end
 

--- a/core/app/models/spree/wallet.rb
+++ b/core/app/models/spree/wallet.rb
@@ -62,7 +62,7 @@ class Spree::Wallet
     end
 
     # Do not update the payment source if the passed source is already default
-    if default_wallet_payment_source.try(:id) == wallet_payment_source.try(:id)
+    if default_wallet_payment_source == wallet_payment_source
       return
     end
 

--- a/core/spec/models/spree/wallet_spec.rb
+++ b/core/spec/models/spree/wallet_spec.rb
@@ -95,6 +95,18 @@ describe Spree::Wallet, type: :model do
       end
     end
 
+    context "with the same payment source already set to default" do
+      let!(:wallet_credit_card) { subject.add(credit_card) }
+
+      before { subject.default_wallet_payment_source = wallet_credit_card }
+
+      it "does not change the default payment source" do
+        expect { subject.default_wallet_payment_source = wallet_credit_card }.not_to(
+          change(subject, :default_wallet_payment_source)
+        )
+      end
+    end
+
     context 'with a wallet payment source that does not belong to the wallet' do
       let(:other_wallet_credit_card) { other_wallet.add(credit_card) }
       let(:other_wallet) { Spree::Wallet.new(other_user) }


### PR DESCRIPTION
…set to the same value

This fixes a bug where if the app tried to set the default payment method to the existing default, the wallet would end up with no default payment method