### PR TITLE
Use ActiveJob :test queue adapter

### DIFF
--- a/api/spec/controllers/spree/api/shipments_controller_spec.rb
+++ b/api/spec/controllers/spree/api/shipments_controller_spec.rb
@@ -237,25 +237,29 @@ describe Spree::Api::ShipmentsController, type: :controller do
         end
       end
 
-      context "send_mailer not present" do
-        it "sends the shipped shipments mailer" do
-          expect { subject }.to change { ActionMailer::Base.deliveries.size }.by(1)
-          expect(ActionMailer::Base.deliveries.last.subject).to match /Shipment Notification/
-        end
-      end
+      describe 'sent emails' do
+        subject { perform_enqueued_jobs { super() } }
 
-      context "send_mailer set to false" do
-        let(:send_mailer) { 'false' }
-        it "does not send the shipped shipments mailer" do
-          expect { subject }.to_not change { ActionMailer::Base.deliveries.size }
+        context "send_mailer not present" do
+          it "sends the shipped shipments mailer" do
+            expect { subject }.to change { ActionMailer::Base.deliveries.size }.by(1)
+            expect(ActionMailer::Base.deliveries.last.subject).to match /Shipment Notification/
+          end
         end
-      end
 
-      context "send_mailer set to true" do
-        let(:send_mailer) { 'true' }
-        it "sends the shipped shipments mailer" do
-          expect { subject }.to change { ActionMailer::Base.deliveries.size }.by(1)
-          expect(ActionMailer::Base.deliveries.last.subject).to match /Shipment Notification/
+        context "send_mailer set to false" do
+          let(:send_mailer) { 'false' }
+          it "does not send the shipped shipments mailer" do
+            expect { subject }.to_not change { ActionMailer::Base.deliveries.size }
+          end
+        end
+
+        context "send_mailer set to true" do
+          let(:send_mailer) { 'true' }
+          it "sends the shipped shipments mailer" do
+            expect { subject }.to change { ActionMailer::Base.deliveries.size }.by(1)
+            expect(ActionMailer::Base.deliveries.last.subject).to match /Shipment Notification/
+          end
         end
       end
     end

--- a/api/spec/spec_helper.rb
+++ b/api/spec/spec_helper.rb
@@ -36,7 +36,7 @@ require 'spree/api/testing_support/caching'
 require 'spree/api/testing_support/helpers'
 require 'spree/api/testing_support/setup'
 
-ActiveJob::Base.queue_adapter = :inline
+ActiveJob::Base.queue_adapter = :test
 
 RSpec.configure do |config|
   config.backtrace_exclusion_patterns = [/gems\/activesupport/, /gems\/actionpack/, /gems\/rspec/]
@@ -64,6 +64,7 @@ RSpec.configure do |config|
     Spree::Api::Config[:requires_authentication] = true
   end
 
+  config.include ActiveJob::TestHelper
   config.include VersionCake::TestHelpers, type: :controller
   config.before(:each, type: :controller) do
     set_request_version('', 1)

--- a/core/spec/models/spree/order/state_machine_spec.rb
+++ b/core/spec/models/spree/order/state_machine_spec.rb
@@ -82,7 +82,9 @@ describe Spree::Order, type: :model do
     end
 
     it "should send a cancel email" do
-      order.cancel!
+      perform_enqueued_jobs do
+        order.cancel!
+      end
 
       mail = ActionMailer::Base.deliveries.last
       expect(mail.subject).to include "Cancellation"

--- a/core/spec/models/spree/order_shipping_spec.rb
+++ b/core/spec/models/spree/order_shipping_spec.rb
@@ -19,7 +19,11 @@ describe Spree::OrderShipping do
 
     describe "shipment email" do
       it "should send a shipment email" do
-        expect { subject }.to change { emails.size }.by(1)
+        expect {
+          perform_enqueued_jobs {
+            subject
+          }
+        }.to change { emails.size }.by(1)
         expect(emails.last.subject).to eq("#{order.store.name} Shipment Notification ##{order.number}")
       end
     end

--- a/core/spec/models/spree/promotion_code_batch_spec.rb
+++ b/core/spec/models/spree/promotion_code_batch_spec.rb
@@ -1,8 +1,6 @@
 require "spec_helper"
 
 describe Spree::PromotionCodeBatch, type: :model do
-  include ActiveJob::TestHelper
-
   subject do
     described_class.create!(
       promotion_id: create(:promotion).id,
@@ -16,12 +14,8 @@ describe Spree::PromotionCodeBatch, type: :model do
   describe "#process" do
     context "with a pending code batch" do
       it "should call the worker" do
-        ActiveJob::Base.queue_adapter = :test
-
         expect { subject.process }
           .to have_enqueued_job(Spree::PromotionCodeBatchJob)
-
-        clear_enqueued_jobs
       end
 
       it "should update the state to processing" do

--- a/core/spec/spec_helper.rb
+++ b/core/spec/spec_helper.rb
@@ -37,7 +37,7 @@ require 'spree/testing_support/factories'
 require 'spree/testing_support/preferences'
 require 'cancan/matchers'
 
-ActiveJob::Base.queue_adapter = :inline
+ActiveJob::Base.queue_adapter = :test
 
 RSpec.configure do |config|
   config.color = true
@@ -65,6 +65,7 @@ RSpec.configure do |config|
     reset_spree_preferences
   end
 
+  config.include ActiveJob::TestHelper
   config.include FactoryGirl::Syntax::Methods
   config.include Spree::TestingSupport::Preferences
   config.extend WithModel


### PR DESCRIPTION
Previously, we used the `:inline` queue adapter by default. We had one test where the queue adapter was switched to `:test`, and not switched back, which causes a test order dependency issue.

The :test queue adapter is great, faster (since it isn't being run by default), and gives us better control over our test suite. This commit uses the `:test` adapter for the entire test suite, clearing the performed
and enqueued jobs after each test.