### PR TITLE
Fix migrate_credit_cards_to_wallet_payment_sources

### DIFF
--- a/core/db/migrate/20160420181916_migrate_credit_cards_to_wallet_payment_sources.rb
+++ b/core/db/migrate/20160420181916_migrate_credit_cards_to_wallet_payment_sources.rb
@@ -14,7 +14,8 @@ class MigrateCreditCardsToWalletPaymentSources < ActiveRecord::Migration[4.2]
     credit_cards.find_each do |credit_card|
       WalletPaymentSource.find_or_create_by!(
         user_id: credit_card.user_id,
-        payment_source: credit_card
+        payment_source_id: credit_card.id,
+        payment_source_type: 'Spree::CreditCard'
       ) do |wallet_source|
         wallet_source.default = credit_card.default
       end


### PR DESCRIPTION
Fixes #1897 

Tested manually and this seems to be working. Previously this migration failed because we didn't have a `payment_source` association defined.

This sets the `_id` and `_type` fields directly because we want to reference the `Spree::CreditCard` model without using the model itself.