### PR TITLE
Prepare for turbolinks

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/adjustments.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/adjustments.js.coffee
@@ -1,4 +1,4 @@
-$(@).ready( ->
+Spree.ready( ->
   $('[data-hook=adjustments_new_coupon_code] #add_coupon_code').click ->
     return if $("#coupon_code").val().length == 0
     Spree.ajax

--- a/backend/app/assets/javascripts/spree/backend/admin.js
+++ b/backend/app/assets/javascripts/spree/backend/admin.js
@@ -14,7 +14,7 @@ under the spree namespace that do stuff we find helpful.
 Hopefully, this will evolve into a propper class.
 **/
 
-jQuery(function($) {
+Spree.ready(function() {
   // Highlight hovered table column
   $('table').on("mouseenter", 'td.actions a, td.actions button', function(){
     var tr = $(this).closest('tr');

--- a/backend/app/assets/javascripts/spree/backend/admin.js
+++ b/backend/app/assets/javascripts/spree/backend/admin.js
@@ -159,48 +159,44 @@ $(document).ready(function(){
       return ui;
   };
 
-  $('table.sortable').ready(function(){
-    var td_count = $(this).find('tbody tr:first-child td').length
-    $('table.sortable tbody').sortable(
-      {
-        handle: '.handle',
-        helper: fixHelper,
-        placeholder: 'ui-sortable-placeholder',
-        update: function(event, ui) {
-          $("#progress").show();
-          var tableEl = $(ui.item).closest("table.sortable")
-          var positions = {};
-          $.each(tableEl.find('tbody tr'), function(position, obj){
-            var idAttr = $(obj).prop('id');
-            if (idAttr) {
-              var objId = idAttr.split('_').slice(-1);
-              if (!isNaN(objId)) {
-                positions['positions['+objId+']'] = position+1;
-              }
-            }
-          });
-          Spree.ajax({
-            type: 'POST',
-            dataType: 'script',
-            url: tableEl.data("sortable-link"),
-            data: positions,
-            success: function(data){ $("#progress").hide(); }
-          });
-        },
-        start: function (event, ui) {
-          // Set correct height for placehoder (from dragged tr)
-          ui.placeholder.height(ui.item.height())
-          // Fix placeholder content to make it correct width
-          ui.placeholder.html("<td colspan='"+(td_count-1)+"'></td><td class='actions'></td>")
-        },
-        stop: function (event, ui) {
-          var tableEl = $(ui.item).closest("table.sortable")
-          // Fix odd/even classes after reorder
-          tableEl.find("tr:even").removeClass("odd even").addClass("even");
-          tableEl.find("tr:odd").removeClass("odd even").addClass("odd");
+  var td_count = $(this).find('tbody tr:first-child td').length
+  $('table.sortable tbody').sortable({
+    handle: '.handle',
+    helper: fixHelper,
+    placeholder: 'ui-sortable-placeholder',
+    update: function(event, ui) {
+      $("#progress").show();
+      var tableEl = $(ui.item).closest("table.sortable")
+      var positions = {};
+      $.each(tableEl.find('tbody tr'), function(position, obj){
+        var idAttr = $(obj).prop('id');
+        if (idAttr) {
+          var objId = idAttr.split('_').slice(-1);
+          if (!isNaN(objId)) {
+            positions['positions['+objId+']'] = position+1;
+          }
         }
-
       });
+      Spree.ajax({
+        type: 'POST',
+        dataType: 'script',
+        url: tableEl.data("sortable-link"),
+        data: positions,
+        success: function(data){ $("#progress").hide(); }
+      });
+    },
+    start: function (event, ui) {
+      // Set correct height for placehoder (from dragged tr)
+      ui.placeholder.height(ui.item.height())
+      // Fix placeholder content to make it correct width
+      ui.placeholder.html("<td colspan='"+(td_count-1)+"'></td><td class='actions'></td>")
+    },
+    stop: function (event, ui) {
+      var tableEl = $(ui.item).closest("table.sortable")
+      // Fix odd/even classes after reorder
+      tableEl.find("tr:even").removeClass("odd even").addClass("even");
+      tableEl.find("tr:odd").removeClass("odd even").addClass("odd");
+    }
   });
 
   window.Spree.advanceOrder = function() {

--- a/backend/app/assets/javascripts/spree/backend/promotions.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/promotions.js.coffee
@@ -96,4 +96,4 @@ window.initPromotionActions = ->
 
   initTieredCalculators()
 
-$ initPromotionActions
+Spree.ready(initPromotionActions)

--- a/backend/app/assets/javascripts/spree/backend/spree-select2.js
+++ b/backend/app/assets/javascripts/spree/backend/spree-select2.js
@@ -1,5 +1,5 @@
 //= require solidus_admin/select2
-jQuery(function($) {
+Spree.ready(function() {
   // Make select beautiful
   $('select.select2').select2({
     allowClear: true,

--- a/backend/app/views/spree/admin/promotion_actions/create.js.erb
+++ b/backend/app/views/spree/admin/promotion_actions/create.js.erb
@@ -1,10 +1,9 @@
 $('#actions').append('<%= escape_javascript( render(partial: 'spree/admin/promotions/promotion_action', object: @promotion_action) ) %>');
 $('#actions .no-objects-found').hide();
-$(document).ready(function(){
-  $(".variant_autocomplete").variantAutocomplete();
-  //enable select2 functions for recently added box
-  $('.type-select.select2').last().select2();
-});
+$(".variant_autocomplete").variantAutocomplete();
+//enable select2 functions for recently added box
+$('.type-select.select2').last().select2();
+
 initPromotionActions();
 
 

--- a/backend/spec/features/admin/orders/customer_details_spec.rb
+++ b/backend/spec/features/admin/orders/customer_details_spec.rb
@@ -24,7 +24,6 @@ describe "Customer Details", type: :feature, js: true do
       visit spree.admin_path
       click_link "Orders"
       click_link "New Order"
-      click_on 'Cart'
 
       add_line_item product.name, quantity: quantity
 
@@ -136,6 +135,7 @@ describe "Customer Details", type: :feature, js: true do
       end
 
       it "sets default country when displaying form" do
+        click_link "Cart"
         click_link "Customer"
         expect(page).to have_field("order_bill_address_attributes_country_id", with: brazil.id, visible: false)
       end

--- a/backend/spec/features/admin/orders/new_order_spec.rb
+++ b/backend/spec/features/admin/orders/new_order_spec.rb
@@ -25,7 +25,6 @@ describe "New Order", type: :feature do
   end
 
   it "completes new order succesfully without using the cart", js: true do
-    click_on 'Cart'
     add_line_item product.name
 
     click_on "Customer"
@@ -60,7 +59,6 @@ describe "New Order", type: :feature do
   end
 
   it 'can create split payments', js: true do
-    click_on 'Cart'
     add_line_item product.name
 
     click_on "Customer"
@@ -87,7 +85,6 @@ describe "New Order", type: :feature do
 
   context "adding new item to the order", js: true do
     it "inventory items show up just fine and are also registered as shipments" do
-      click_on 'Cart'
       add_line_item product.name
 
       within(".line-items") do
@@ -119,7 +116,6 @@ describe "New Order", type: :feature do
     end
 
     it "can still see line items" do
-      click_on 'Cart'
       add_line_item product.name
 
       within(".line-items") do
@@ -149,8 +145,7 @@ describe "New Order", type: :feature do
       fill_in_address
       click_on "Update"
 
-      click_on "Shipments"
-
+      # Automatically redirected to Shipments page
       select2_search product.name, from: Spree.t(:name_or_sku)
 
       click_icon :plus
@@ -175,8 +170,6 @@ describe "New Order", type: :feature do
     end
 
     it "transitions to delivery not to complete" do
-      click_on 'Cart'
-
       add_line_item product.name
 
       expect(page).to have_css('.line-item')

--- a/backend/spec/features/admin/promotion_adjustments_spec.rb
+++ b/backend/spec/features/admin/promotion_adjustments_spec.rb
@@ -8,6 +8,7 @@ describe "Promotion Adjustments", type: :feature, js: true do
       visit spree.admin_path
       click_link "Promotions"
       click_link "New Promotion"
+      expect(page).to have_title("New Promotion - Promotions")
     end
 
     it "should allow an admin to create a flat rate discount coupon promo" do
@@ -15,7 +16,7 @@ describe "Promotion Adjustments", type: :feature, js: true do
       fill_in "Promotion Code", with: "order"
 
       click_button "Create"
-      expect(page).to have_content("PromotionsPromotion")
+      expect(page).to have_title("Promotion - Promotions")
 
       select2 "Item total", from: "Add rule of type"
       within('#rule_fields') { click_button "Add" }
@@ -51,7 +52,7 @@ describe "Promotion Adjustments", type: :feature, js: true do
       fill_in "Promotion Code", with: "single_use"
 
       click_button "Create"
-      expect(page).to have_content("PromotionsPromotion")
+      expect(page).to have_title("Promotion - Promotions")
 
       select2 "Create whole-order adjustment", from: "Add action of type"
       within('#action_fields') { click_button "Add" }
@@ -75,7 +76,7 @@ describe "Promotion Adjustments", type: :feature, js: true do
       fill_in "Name", with: "Promotion"
       choose "Apply to all orders"
       click_button "Create"
-      expect(page).to have_content("PromotionsPromotion")
+      expect(page).to have_title("Promotion - Promotions")
 
       select2 "Item total", from: "Add rule of type"
       within('#rule_fields') { click_button "Add" }
@@ -110,7 +111,7 @@ describe "Promotion Adjustments", type: :feature, js: true do
       fill_in "Name", with: "Promotion"
       choose "Apply to all orders"
       click_button "Create"
-      expect(page).to have_content("PromotionsPromotion")
+      expect(page).to have_title("Promotion - Promotions")
 
       select2 "Product(s)", from: "Add rule of type"
       within("#rule_fields") { click_button "Add" }
@@ -142,7 +143,7 @@ describe "Promotion Adjustments", type: :feature, js: true do
       fill_in "Name", with: "Promotion"
       choose "Apply to all orders"
       click_button "Create"
-      expect(page).to have_content("PromotionsPromotion")
+      expect(page).to have_title("Promotion - Promotions")
 
       select2 "Item total", from: "Add rule of type"
       within('#rule_fields') { click_button "Add" }
@@ -163,7 +164,7 @@ describe "Promotion Adjustments", type: :feature, js: true do
       fill_in "Name", with: "Promotion"
       choose "Apply to all orders"
       click_button "Create"
-      expect(page).to have_content("PromotionsPromotion")
+      expect(page).to have_title("Promotion - Promotions")
 
       promotion = Spree::Promotion.find_by_name("Promotion")
       expect(promotion).to be_apply_automatically
@@ -177,7 +178,7 @@ describe "Promotion Adjustments", type: :feature, js: true do
       choose "URL Path"
       fill_in "Path", with: "content/cvv"
       click_button "Create"
-      expect(page).to have_content("PromotionsPromotion")
+      expect(page).to have_title("Promotion - Promotions")
 
       promotion = Spree::Promotion.find_by_name("Promotion")
       expect(promotion.path).to eq("content/cvv")
@@ -192,7 +193,7 @@ describe "Promotion Adjustments", type: :feature, js: true do
       fill_in "Base code", with: "testing"
       fill_in "Number of codes", with: "10"
       click_button "Create"
-      expect(page).to have_content("PromotionsPromotion")
+      expect(page).to have_title("Promotion - Promotions")
 
       promotion = Spree::Promotion.find_by_name("Promotion")
       expect(promotion.path).to be_nil
@@ -206,7 +207,7 @@ describe "Promotion Adjustments", type: :feature, js: true do
       fill_in "Name", with: "Promotion"
       choose "Apply to all orders"
       click_button "Create"
-      expect(page).to have_content("PromotionsPromotion")
+      expect(page).to have_title("Promotion - Promotions")
 
       select2 "Item total", from: "Add rule of type"
       within('#rule_fields') { click_button "Add" }


### PR DESCRIPTION
- Corrects minor duplications in Capybara page visits
- Removes unnecessary calls to jQuery.ready
- Change to Spree.ready from jQuery.ready on a few places only

Towards #1863

based on suggestions from #1882 

_note: I have not fixed the indentation in `admin.js` not to introduce noise._