### PR TITLE
Remove unnecessary shipping rates callback

### DIFF
--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -108,9 +108,6 @@ module Spree
             # calls matter so that we do not process payments
             # until validations have passed
             before_transition to: :complete, do: :validate_line_item_availability
-            if states[:delivery]
-              before_transition to: :complete, do: :ensure_available_shipping_rates
-            end
             before_transition to: :complete, do: :ensure_promotions_eligible
             before_transition to: :complete, do: :ensure_line_item_variants_are_not_deleted
             before_transition to: :complete, do: :ensure_inventory_units

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -589,22 +589,6 @@ describe Spree::Order, type: :model do
       end
     end
 
-    context 'a shipment has no shipping rates' do
-      let(:order) { create(:order_with_line_items, state: 'confirm') }
-      let(:shipment) { order.shipments.first }
-
-      before do
-        shipment.shipping_rates.destroy_all
-      end
-
-      it 'clears the shipments and fails the transition' do
-        expect(order.complete).to eq(false)
-        expect(order.errors[:base]).to include(Spree.t(:items_cannot_be_shipped))
-        expect(order.shipments.count).to eq(0)
-        expect(Spree::InventoryUnit.where(shipment_id: shipment.id).count).to eq(0)
-      end
-    end
-
     context 'the order is already paid' do
       let(:order) { create(:order_with_line_items) }
 


### PR DESCRIPTION
The callback `Spree::Order#ensure_available_shipping_rates` was
explicitly written to be run before delivery. Running it before the
`complete` step leaves the order in the `confirm` state, but without
any shipments, and results in an error message does not make sense
in that context ("We were unable to calculate shipping rates"). In fact,
we have not even tried.

It's almost impossible to setup an order such that this callback would
actually trigger in a standard Solidus installation.

The commit that introduced the callback, 7ba53b2c, intends to move line
item availability validations to the before complete callback, instead
of "all the time". That makes sense, but this callback has somehow sneaked
in there without any explanation of why its necessary.

I delete a model spec that was introduced in e7450ec, testing the behaviour
in question. The spec set the order up in a way that a normal checkout never would.
If you get through delivery and payment to the confirm step, and then
do literally anything to the order, it will be reset to either cart or address
state.

I edit another spec to test what the callback should actually do: Alert the user
that for their recently entered shipping address, no shipping rates can be calculated.