### PR TITLE
Allow refreshing rates for unshipped complete orders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Solidus 2.3.0 (master, unreleased)
 
+- Allow refreshing shipping rates for unshipped shipments on completed orders [\#1906](https://github.com/solidusio/solidus/pull/1906) ([mamhoff](https://github.com/mamhoff))
 - Renamed `PaymentMethod#method_type` into `partial_name` [\#1978](https://github.com/solidusio/solidus/pull/1978) ([tvdeyen](https://github.com/tvdeyen))
 - Order#outstanding_balance now uses reimbursements instead of refunds to calculate the amount that should be paid on an order. [#2002](https://github.com/solidusio/solidus/pull/2002) (many contributors :heart:)
 

--- a/backend/spec/features/admin/orders/shipments_spec.rb
+++ b/backend/spec/features/admin/orders/shipments_spec.rb
@@ -73,11 +73,18 @@ describe "Shipments", type: :feature do
       expect(page).to have_css("#shipment_#{shipment1.id} tr.stock-item", count: 4)
       shipment2 = (order.reload.shipments.to_a - [shipment1]).first
       expect(page).to have_css("#shipment_#{shipment2.id} tr.stock-item", count: 1)
+      within "#shipment_#{shipment2.id}" do
+        expect(page).to have_content("UPS Ground")
+      end
 
       within_row(2) { click_icon 'arrows-h' }
       complete_split_to("LA(#{shipment2.number})")
       expect(page).to have_css("#shipment_#{shipment2.id} tr.stock-item", count: 2)
       expect(page).to have_css("#shipment_#{shipment1.id} tr.stock-item", count: 3)
+
+      within "#shipment_#{shipment2.id}" do
+        expect(page).to have_content("UPS Ground")
+      end
     end
 
     context "with a ready-to-ship order" do

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -172,7 +172,7 @@ module Spree
     end
 
     def refresh_rates
-      return shipping_rates if shipped? || order.completed?
+      return shipping_rates if shipped?
       return [] unless can_get_rates?
 
       # StockEstimator.new assigment below will replace the current shipping_method
@@ -333,6 +333,7 @@ module Spree
         order.contents.add(variant, quantity, { shipment: new_shipment })
 
         refresh_rates
+        new_shipment.refresh_rates
         save!
         new_shipment.save!
       end


### PR DESCRIPTION
When an order is complete, but not shipped yet, admins need to be able
to refresh rates for a shipment.

This is especially the case when splitting shipments to a new location.
This will create a new shipment with no rates, and refreshing them is the
only way to get any.