### PR TITLE
Deprecate simple_current_order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Solidus 2.3.0 (master, unreleased)
 
+- Deprecate `#simple_current_order`
+[\#1915](https://github.com/solidusio/solidus/pull/1915) ([ericsaupe](https://github.com/ericsaupe))
+
 ## Solidus 2.2.1 (2017-05-09)
 
 - Fix migrating CreditCards to WalletPaymentSource [\#1898](https://github.com/solidusio/solidus/pull/1898) ([jhawthorn](https://github.com/jhawthorn))

--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -4,11 +4,11 @@ module Spree
       text = text ? h(text) : Spree.t(:cart)
       css_class = nil
 
-      if simple_current_order.nil? || simple_current_order.item_count.zero?
+      if current_order.nil? || current_order.item_count.zero?
         text = "#{text}: (#{Spree.t(:empty)})"
         css_class = 'empty'
       else
-        text = "#{text}: (#{simple_current_order.item_count})  <span class='amount'>#{simple_current_order.display_total.to_html}</span>"
+        text = "#{text}: (#{current_order.item_count})  <span class='amount'>#{current_order.display_total.to_html}</span>"
         css_class = 'full'
       end
 

--- a/core/lib/spree/core/controller_helpers/order.rb
+++ b/core/lib/spree/core/controller_helpers/order.rb
@@ -24,7 +24,7 @@ module Spree
             @simple_current_order.last_ip_address = ip_address
             return @simple_current_order
           else
-            @simple_current_order = Spree::Order.new
+            @simple_current_order = Spree::Order.new(current_order_params)
           end
         end
 

--- a/core/lib/spree/core/controller_helpers/order.rb
+++ b/core/lib/spree/core/controller_helpers/order.rb
@@ -14,7 +14,6 @@ module Spree
           helper_method :simple_current_order
         end
 
-        # Used in the link_to_cart helper.
         def simple_current_order
           return @simple_current_order if @simple_current_order
 
@@ -27,6 +26,7 @@ module Spree
             @simple_current_order = Spree::Order.new(current_order_params)
           end
         end
+        deprecate simple_current_order: :current_order, deprecator: Spree::Deprecation
 
         # The current incomplete order from the guest_token for use in cart and during checkout
         def current_order(options = {})

--- a/core/spec/lib/spree/core/controller_helpers/order_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/order_spec.rb
@@ -19,14 +19,26 @@ describe Spree::Core::ControllerHelpers::Order, type: :controller do
 
   describe '#simple_current_order' do
     it "returns an empty order" do
-      expect(controller.simple_current_order.item_count).to eq 0
+      Spree::Deprecation.silence do
+        expect(controller.simple_current_order.item_count).to eq 0
+      end
     end
     it 'returns Spree::Order instance' do
-      allow(controller).to receive_messages(cookies: double(signed: { guest_token: order.guest_token }))
-      expect(controller.simple_current_order).to eq order
+      Spree::Deprecation.silence do
+        allow(controller).to receive_messages(cookies: double(signed: { guest_token: order.guest_token }))
+        expect(controller.simple_current_order).to eq order
+      end
     end
     it 'assigns the current_store id' do
-      expect(controller.simple_current_order.store_id).to eq store.id
+      Spree::Deprecation.silence do
+        expect(controller.simple_current_order.store_id).to eq store.id
+      end
+    end
+    it 'is deprecated' do
+      Spree::Deprecation.silence do
+        expect(Spree::Deprecation).to(receive(:warn))
+        controller.simple_current_order
+      end
     end
   end
 

--- a/core/spec/lib/spree/core/controller_helpers/order_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/order_spec.rb
@@ -25,6 +25,9 @@ describe Spree::Core::ControllerHelpers::Order, type: :controller do
       allow(controller).to receive_messages(cookies: double(signed: { guest_token: order.guest_token }))
       expect(controller.simple_current_order).to eq order
     end
+    it 'assigns the current_store id' do
+      expect(controller.simple_current_order.store_id).to eq store.id
+    end
   end
 
   describe '#current_order' do

--- a/frontend/app/controllers/spree/store_controller.rb
+++ b/frontend/app/controllers/spree/store_controller.rb
@@ -11,7 +11,7 @@ module Spree
 
     def cart_link
       render partial: 'spree/shared/link_to_cart'
-      fresh_when(simple_current_order, template: 'spree/shared/_link_to_cart')
+      fresh_when(current_order, template: 'spree/shared/_link_to_cart')
     end
 
     private


### PR DESCRIPTION
Fixes the bug found in #1700 and deprecates `simple_current_order` because it's function is duplicated with `current_order`