### PR TITLE
Unfinalize tax adjustments before updating them

### DIFF
--- a/core/app/models/spree/tax/item_adjuster.rb
+++ b/core/app/models/spree/tax/item_adjuster.rb
@@ -31,7 +31,7 @@ module Spree
           # Find an existing adjustment from the same source.
           # All tax adjustments already have source_type == 'Spree::TaxRate' so
           # we need only check source_id.
-          adjustment = tax_adjustments.detect{|a| a.source_id == rate.id }
+          adjustment = tax_adjustments.detect { |a| a.source_id == rate.id }
           if adjustment
             adjustment.update!
             adjustment

--- a/core/app/models/spree/tax/item_adjuster.rb
+++ b/core/app/models/spree/tax/item_adjuster.rb
@@ -33,6 +33,7 @@ module Spree
           # we need only check source_id.
           adjustment = tax_adjustments.detect { |a| a.source_id == rate.id }
           if adjustment
+            adjustment.unfinalize!
             adjustment.update!
             adjustment
           else

--- a/core/spec/models/spree/tax/item_adjuster_spec.rb
+++ b/core/spec/models/spree/tax/item_adjuster_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Spree::Tax::ItemAdjuster do
   let(:item) { create(:line_item, order: order) }
 
   def tax_adjustments
-    item.adjustments.tax.to_a
+    item.adjustments.select(&:tax?).to_a
   end
 
   describe 'initialization' do

--- a/core/spec/models/spree/tax/item_adjuster_spec.rb
+++ b/core/spec/models/spree/tax/item_adjuster_spec.rb
@@ -67,13 +67,32 @@ RSpec.describe Spree::Tax::ItemAdjuster do
         context 'and all rates have the same tax category as the item' do
           let(:item) { create :line_item, order: order, tax_category: item_tax_category }
           let(:item_tax_category) { create(:tax_category) }
-          let(:rate_1) { create :tax_rate, tax_category: item_tax_category }
+          let(:rate_1) { create :tax_rate, tax_category: item_tax_category, amount: 0.1 }
           let(:rate_2) { create :tax_rate }
           let(:rates_for_order_zone) { [rate_1, rate_2] }
 
           it 'creates an adjustment for every matching rate' do
             adjuster.adjust!
             expect(tax_adjustments.length).to eq(1)
+          end
+
+          context 'when the adjustment exists' do
+            before do
+              adjuster.adjust!
+            end
+
+            context 'when the existing adjustment is finalized' do
+              before do
+                tax_adjustments.first.finalize!
+              end
+
+              it 'updates the adjustment' do
+                item.update_columns(price: item.price * 2)
+                adjuster.adjust!
+                expect(tax_adjustments.length).to eq(1)
+                expect(tax_adjustments.first.amount).to eq(0.1 * item.price)
+              end
+            end
           end
         end
       end


### PR DESCRIPTION
For #1916.

Also related to #1894.

Otherwise taxes don't get updated after an order completes (because all
adjustments are finalized when an order completes).

A different option:  Ignore `finalized` for all tax adjustments in `Adjustment#update!`?