### PR TITLE
Pass params[:options] through Spree::OrderContents#add

### DIFF
--- a/frontend/app/controllers/spree/orders_controller.rb
+++ b/frontend/app/controllers/spree/orders_controller.rb
@@ -45,6 +45,7 @@ module Spree
       @order   = current_order(create_order_if_necessary: true)
       variant  = Spree::Variant.find(params[:variant_id])
       quantity = params[:quantity].present? ? params[:quantity].to_i : 1
+      options = params[:options] || {}
 
       # 2,147,483,647 is crazy. See issue https://github.com/spree/spree/issues/2695.
       if !quantity.between?(1, 2_147_483_647)
@@ -52,7 +53,7 @@ module Spree
       end
 
       begin
-        @line_item = @order.contents.add(variant, quantity)
+        @line_item = @order.contents.add(variant, quantity, options)
       rescue ActiveRecord::RecordInvalid => e
         @order.errors.add(:base, e.record.errors.full_messages.join(", "))
       end


### PR DESCRIPTION
Now options can be passed to Spree::OrderContents#add which passes to Spree::OrderContents#add_to_line_item
#721 
