### PR TITLE
make it consistence with OPERATORS.

### DIFF
--- a/core/app/models/spree/promotion/rules/item_total.rb
+++ b/core/app/models/spree/promotion/rules/item_total.rb
@@ -6,7 +6,7 @@ module Spree
       class ItemTotal < PromotionRule
         preference :amount, :decimal, default: 100.00
         preference :currency, :string, default: ->{ Spree::Config[:currency] }
-        preference :operator, :string, default: '>'
+        preference :operator, :string, default: 'gt'
 
         OPERATORS = ['gt', 'gte']
 

--- a/core/spec/models/spree/promotion/rules/item_total_spec.rb
+++ b/core/spec/models/spree/promotion/rules/item_total_spec.rb
@@ -6,7 +6,7 @@ describe Spree::Promotion::Rules::ItemTotal, type: :model do
   end
 
   context "preferred operator default value should be 'gt'" do
-    it { expect(default_rule.preferred_operator).to eq('gt')}
+    it { expect(default_rule.preferred_operator).to eq('gt') }
   end
 
   let(:rule) do

--- a/core/spec/models/spree/promotion/rules/item_total_spec.rb
+++ b/core/spec/models/spree/promotion/rules/item_total_spec.rb
@@ -1,6 +1,14 @@
 require 'spec_helper'
 
 describe Spree::Promotion::Rules::ItemTotal, type: :model do
+  let(:default_rule) do
+    Spree::Promotion::Rules::ItemTotal.new
+  end
+
+  context "preferred operator default value should be 'gt'" do
+    it { expect(default_rule.preferred_operator).to eq('gt')}
+  end
+
   let(:rule) do
     Spree::Promotion::Rules::ItemTotal.new(
       preferred_amount: preferred_amount,


### PR DESCRIPTION
In file: backend/app/views/spree/admin/promotions/rules/_item_total.html.erb line 5, it used ItemTotal::OPERATORS to render the form key of preferred_operator, and only can be 'gt' or 'gte'. but in the model item_total.rb, the default value of preferred_operator is '>', that's inconsistence and we'd better keep it same.