### PR TITLE
Cast string values from params into boolean.

### DIFF
--- a/api/app/controllers/spree/api/variants_controller.rb
+++ b/api/app/controllers/spree/api/variants_controller.rb
@@ -65,8 +65,9 @@ module Spree
           variants = variants.with_deleted
         end
 
+        in_stock_only = ActiveRecord::Type::Boolean.new.cast(params[:in_stock_only])
         variants = variants.accessible_by(current_ability, :read)
-        variants = variants.in_stock if params[:in_stock_only] || cannot?(:view_out_of_stock, Spree::Variant)
+        variants = variants.in_stock if in_stock_only || cannot?(:view_out_of_stock, Spree::Variant)
         variants
       end
 

--- a/api/spec/controllers/spree/api/variants_controller_spec.rb
+++ b/api/spec/controllers/spree/api/variants_controller_spec.rb
@@ -88,27 +88,56 @@ module Spree
       end
 
       context "stock filtering" do
-        subject { api_get :index, in_stock_only: true }
 
-        context "variant is out of stock" do
-          before do
-            variant.stock_items.update_all(count_on_hand: 0)
+        context "only variants in stock" do
+          subject { api_get :index, in_stock_only: "true" }
+
+          context "variant is out of stock" do
+            before do
+              variant.stock_items.update_all(count_on_hand: 0)
+            end
+
+            it "is not returned in the results" do
+              subject
+              expect(json_response["variants"].count).to eq 0
+            end
           end
 
-          it "is not returned in the results" do
-            subject
-            expect(json_response["variants"].count).to eq 0
+          context "variant is in stock" do
+            before do
+              variant.stock_items.update_all(count_on_hand: 10)
+            end
+
+            it "is returned in the results" do
+              subject
+              expect(json_response["variants"].count).to eq 1
+            end
           end
         end
 
-        context "variant is in stock" do
-          before do
-            variant.stock_items.update_all(count_on_hand: 10)
+        context "all variants" do
+          subject { api_get :index, in_stock_only: "false" }
+
+          context "variant is out of stock" do
+            before do
+              variant.stock_items.update_all(count_on_hand: 0)
+            end
+
+            it "is returned in the results" do
+              subject
+              expect(json_response["variants"].count).to eq 1
+            end
           end
 
-          it "is returned in the results" do
-            subject
-            expect(json_response["variants"].count).to eq 1
+          context "variant is in stock" do
+            before do
+              variant.stock_items.update_all(count_on_hand: 10)
+            end
+
+            it "is returned in the results" do
+              subject
+              expect(json_response["variants"].count).to eq 1
+            end
           end
         end
       end


### PR DESCRIPTION
This fixes #1737 

The issue was that the param was being set at `"false"` which is would add the `in_stock` scope to the variants because `"false" != false`.

So @jtapia and I ended up adding the query string param only if the condition was true. 

