### PR TITLE
Fix evaluator typo in ShipmentFactory

### DIFF
--- a/core/lib/spree/testing_support/factories/shipment_factory.rb
+++ b/core/lib/spree/testing_support/factories/shipment_factory.rb
@@ -14,8 +14,8 @@ FactoryGirl.define do
       shipping_method nil
     end
 
-    after(:create) do |shipment, evalulator|
-      shipping_method = evalulator.shipping_method || create(:shipping_method, cost: evalulator.cost)
+    after(:create) do |shipment, evaluator|
+      shipping_method = evaluator.shipping_method || create(:shipping_method, cost: evaluator.cost)
       shipment.add_shipping_method(shipping_method, true)
 
       shipment.order.line_items.each do |line_item|


### PR DESCRIPTION
Replace `evalulator` with `evaluator`