### PR TITLE
Fix schema price (offer) by adding content attribute to price span

### DIFF
--- a/frontend/app/views/spree/products/_cart_form.html.erb
+++ b/frontend/app/views/spree/products/_cart_form.html.erb
@@ -34,7 +34,7 @@
         <div id="product-price">
           <h6 class="product-section-title"><%= Spree.t(:price) %></h6>
           <div>
-            <span class="price selling" itemprop="price">
+            <span class="price selling" itemprop="price" content="<%= @product.price_for(current_pricing_options).to_d %>">
               <%= display_price(@product) %>
             </span>
             <span itemprop="priceCurrency" content="<%= current_pricing_options.currency %>"></span>

--- a/frontend/app/views/spree/shared/_products.html.erb
+++ b/frontend/app/views/spree/shared/_products.html.erb
@@ -32,7 +32,10 @@
           </div>
           <%= link_to truncate(product.name, length: 50), url, class: 'info', itemprop: "name", title: product.name %>
           <span itemprop="offers" itemscope itemtype="http://schema.org/Offer">
-            <span class="price selling" itemprop="price"><%= display_price(product) %></span>
+            <span class="price selling" itemprop="price" content="<%= product.price_for(current_pricing_options).to_d %>">
+              <%= display_price(product) %>
+            </span>
+            <span itemprop="priceCurrency" content="<%= current_pricing_options.currency %>"></span>
           </span>
         <% end %>
       </li>

--- a/frontend/spec/features/products_spec.rb
+++ b/frontend/spec/features/products_spec.rb
@@ -78,6 +78,18 @@ describe "Visiting Products", type: :feature, inaccessible: true do
     end
   end
 
+  describe 'schema.org markup' do
+    let(:product) { Spree::Product.available.first }
+
+    it 'has correct schema.org/Offer attributes' do
+      expect(page).to have_css("#product_#{product.id} [itemprop='price'][content='19.99']")
+      expect(page).to have_css("#product_#{product.id} [itemprop='priceCurrency'][content='USD']")
+      click_link product.name
+      expect(page).to have_css("[itemprop='price'][content='19.99']")
+      expect(page).to have_css("[itemprop='priceCurrency'][content='USD']")
+    end
+  end
+
   context "using Russian Rubles as a currency" do
     before do
       Spree::Config[:currency] = "RUB"


### PR DESCRIPTION
This change makes the schemas pass the [Google Schema Markup validator](https://search.google.com/structured-data/testing-tool/u/0/).

Products were failing on the currency code being inclusive of the price when the `content` attribute is not present. The `content` attribute should contain float values.

Schema: http://schema.org/Offer