### PR TITLE
Calculating the adjustment total including null source adjustments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
   This fixes issue [\#1836](https://github.com/solidusio/solidus/issues/1836). By allowing a TaxRate to tax multiple categories, stores don't have to create multiple TaxRates with the same value if a zone doesn't have different tax rates for some tax categories.
 
+- Adjustments without a source are now included in `line_item.adjustment_total`
+[\#1933](https://github.com/solidusio/solidus/pull/1933) ([alexstoick](https://github.com/alexstoick))
 
 ## Solidus 2.2.1 (2017-05-09)
 

--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -252,11 +252,10 @@ module Spree
       [*line_items, *shipments].each do |item|
         # The cancellation_total isn't persisted anywhere but is included in
         # the adjustment_total
-        item_cancellation_total = item.adjustments.select(&:cancellation?).sum(&:amount)
-
-        item.adjustment_total = item.promo_total +
-                                item.additional_tax_total +
-                                item_cancellation_total
+        item.adjustment_total = item.adjustments.
+          select(&:eligible?).
+          reject(&:included?).
+          sum(&:amount)
 
         if item.changed?
           item.update_columns(

--- a/core/spec/models/spree/order_updater_spec.rb
+++ b/core/spec/models/spree/order_updater_spec.rb
@@ -34,6 +34,17 @@ module Spree
         }.to change { order.shipment_total }.to 10
       end
 
+      context 'with a source-less line item adjustment' do
+        let(:line_item) { create(:line_item, order: order, price: 10) }
+        before do
+          create(:adjustment, source: nil, adjustable: line_item, order: order, amount: -5)
+        end
+
+        it "updates the line item total" do
+          expect { updater.update }.to change { line_item.reload.adjustment_total }.from(0).to(-5)
+        end
+      end
+
       context 'with order promotion followed by line item addition' do
         let(:promotion) { Spree::Promotion.create!(name: "10% off") }
         let(:calculator) { Calculator::FlatPercentItemTotal.new(preferred_flat_percent: 10) }


### PR DESCRIPTION
This is to help achieve #1913 - enabling admins to do refunds at line
item level instead of at order level. There is no UI for this yet, but
the functionality exists.