### PR TITLE
Remove Dependency on ActiveMerchant

### DIFF
--- a/backend/spec/features/admin/orders/log_entries_spec.rb
+++ b/backend/spec/features/admin/orders/log_entries_spec.rb
@@ -7,7 +7,7 @@ describe "Log entries", type: :feature do
 
   context "with a successful log entry" do
     before do
-      response = ActiveMerchant::Billing::Response.new(
+      response = Spree::BillingResponse.new(
         true,
         "Transaction successful",
         transid: "ABCD1234"
@@ -31,7 +31,7 @@ describe "Log entries", type: :feature do
 
   context "with a failed log entry" do
     before do
-      response = ActiveMerchant::Billing::Response.new(
+      response = Spree::BillingResponse.new(
         false,
         "Transaction failed",
         transid: "ABCD1234"

--- a/core/app/models/spree/avs_result.rb
+++ b/core/app/models/spree/avs_result.rb
@@ -40,24 +40,22 @@ module Spree
 
     # Map vendor's AVS result code to a postal match code
     POSTAL_MATCH_CODE = {
-      'Y' => %w( D H F H J L M P Q V W X Y Z ),
-      'N' => %w( A C K N O ),
-      'X' => %w( G S ),
-      nil => %w( B E I R T U )
-    }.inject({}) do |map, (type, codes)|
+      'Y' => %w(D H F H J L M P Q V W X Y Z),
+      'N' => %w(A C K N O),
+      'X' => %w(G S),
+      nil => %w(B E I R T U)
+    }.each_with_object({}) do |(type, codes), map|
       codes.each { |code| map[code] = type }
-      map
     end
 
     # Map vendor's AVS result code to a street match code
     STREET_MATCH_CODE = {
-      'Y' => %w( A B D H J M O Q T V X Y ),
-      'N' => %w( C K L N W Z ),
-      'X' => %w( G S ),
-      nil => %w( E F I P R U )
-    }.inject({}) do |map, (type, codes)|
+      'Y' => %w(A B D H J M O Q T V X Y),
+      'N' => %w(C K L N W Z),
+      'X' => %w(G S),
+      nil => %w(E F I P R U)
+    }.each_with_object({}) do |(type, codes), map|
       codes.each { |code| map[code] = type }
-      map
     end
 
     attr_reader :code, :message, :street_match, :postal_match
@@ -89,8 +87,7 @@ module Spree
       { 'code' => code,
         'message' => message,
         'street_match' => street_match,
-        'postal_match' => postal_match
-      }
+        'postal_match' => postal_match }
     end
   end
 end

--- a/core/app/models/spree/avs_result.rb
+++ b/core/app/models/spree/avs_result.rb
@@ -1,0 +1,96 @@
+#!ruby19
+# encoding: utf-8
+
+module Spree
+  # Implements the Address Verification System
+  # https://www.wellsfargo.com/downloads/pdf/biz/merchant/visa_avs.pdf
+  # http://en.wikipedia.org/wiki/Address_Verification_System
+  # http://apps.cybersource.com/library/documentation/dev_guides/CC_Svcs_IG/html/app_avs_cvn_codes.htm#app_AVS_CVN_codes_7891_48375
+  # http://imgserver.skipjack.com/imgServer/5293710/AVS%20and%20CVV2.pdf
+  # http://www.emsecommerce.net/avs_cvv2_response_codes.htm
+  class AVSResult
+    MESSAGES = {
+      'A' => 'Street address matches, but 5-digit and 9-digit postal code do not match.',
+      'B' => 'Street address matches, but postal code not verified.',
+      'C' => 'Street address and postal code do not match.',
+      'D' => 'Street address and postal code match.',
+      'E' => 'AVS data is invalid or AVS is not allowed for this card type.',
+      'F' => 'Card member\'s name does not match, but billing postal code matches.',
+      'G' => 'Non-U.S. issuing bank does not support AVS.',
+      'H' => 'Card member\'s name does not match. Street address and postal code match.',
+      'I' => 'Address not verified.',
+      'J' => 'Card member\'s name, billing address, and postal code match. Shipping information verified and chargeback protection guaranteed through the Fraud Protection Program.',
+      'K' => 'Card member\'s name matches but billing address and billing postal code do not match.',
+      'L' => 'Card member\'s name and billing postal code match, but billing address does not match.',
+      'M' => 'Street address and postal code match.',
+      'N' => 'Street address and postal code do not match.',
+      'O' => 'Card member\'s name and billing address match, but billing postal code does not match.',
+      'P' => 'Postal code matches, but street address not verified.',
+      'Q' => 'Card member\'s name, billing address, and postal code match. Shipping information verified but chargeback protection not guaranteed.',
+      'R' => 'System unavailable.',
+      'S' => 'U.S.-issuing bank does not support AVS.',
+      'T' => 'Card member\'s name does not match, but street address matches.',
+      'U' => 'Address information unavailable.',
+      'V' => 'Card member\'s name, billing address, and billing postal code match.',
+      'W' => 'Street address does not match, but 9-digit postal code matches.',
+      'X' => 'Street address and 9-digit postal code match.',
+      'Y' => 'Street address and 5-digit postal code match.',
+      'Z' => 'Street address does not match, but 5-digit postal code matches.'
+    }
+
+    # Map vendor's AVS result code to a postal match code
+    POSTAL_MATCH_CODE = {
+      'Y' => %w( D H F H J L M P Q V W X Y Z ),
+      'N' => %w( A C K N O ),
+      'X' => %w( G S ),
+      nil => %w( B E I R T U )
+    }.inject({}) do |map, (type, codes)|
+      codes.each { |code| map[code] = type }
+      map
+    end
+
+    # Map vendor's AVS result code to a street match code
+    STREET_MATCH_CODE = {
+      'Y' => %w( A B D H J M O Q T V X Y ),
+      'N' => %w( C K L N W Z ),
+      'X' => %w( G S ),
+      nil => %w( E F I P R U )
+    }.inject({}) do |map, (type, codes)|
+      codes.each { |code| map[code] = type }
+      map
+    end
+
+    attr_reader :code, :message, :street_match, :postal_match
+
+    def self.messages
+      MESSAGES
+    end
+
+    def initialize(attrs)
+      attrs ||= {}
+
+      @code = attrs[:code].upcase unless attrs[:code].blank?
+      @message = self.class.messages[code]
+
+      if attrs[:street_match].blank?
+        @street_match = STREET_MATCH_CODE[code]
+      else
+        @street_match = attrs[:street_match].upcase
+      end
+
+      if attrs[:postal_match].blank?
+        @postal_match = POSTAL_MATCH_CODE[code]
+      else
+        @postal_match = attrs[:postal_match].upcase
+      end
+    end
+
+    def to_hash
+      { 'code' => code,
+        'message' => message,
+        'street_match' => street_match,
+        'postal_match' => postal_match
+      }
+    end
+  end
+end

--- a/core/app/models/spree/billing_integration.rb
+++ b/core/app/models/spree/billing_integration.rb
@@ -7,7 +7,6 @@ module Spree
 
     def provider
       integration_options = options
-      ActiveMerchant::Billing::Base.integration_mode = integration_options[:server].to_sym
       integration_options[:test] = true if integration_options[:test_mode]
       @provider ||= provider_class.new(integration_options)
     end

--- a/core/app/models/spree/billing_response.rb
+++ b/core/app/models/spree/billing_response.rb
@@ -32,14 +32,14 @@ module Spree
       @emv_authorization = options[:emv_authorization]
 
       @avs_result =
-        if options[:avs_result].kind_of?(AVSResult)
+        if options[:avs_result].is_a?(AVSResult)
           options[:avs_result].to_hash
         else
           AVSResult.new(options[:avs_result]).to_hash
         end
 
       @cvv_result =
-        if options[:cvv_result].kind_of?(CVVResult)
+        if options[:cvv_result].is_a?(CVVResult)
           options[:cvv_result].to_hash
         else
           CVVResult.new(options[:cvv_result]).to_hash

--- a/core/app/models/spree/billing_response.rb
+++ b/core/app/models/spree/billing_response.rb
@@ -1,0 +1,49 @@
+module Spree
+  class BillingResponse
+    attr_reader(
+      :params,
+      :message,
+      :test,
+      :authorization,
+      :avs_result,
+      :cvv_result,
+      :error_code,
+      :emv_authorization
+    )
+
+    def success?
+      @success
+    end
+
+    def test?
+      @test
+    end
+
+    def fraud_review?
+      @fraud_review
+    end
+
+    def initialize(success, message, params = {}, options = {})
+      @success, @message, @params = success, message, params.stringify_keys
+      @test = options[:test] || false
+      @authorization = options[:authorization]
+      @fraud_review = options[:fraud_review]
+      @error_code = options[:error_code]
+      @emv_authorization = options[:emv_authorization]
+
+      @avs_result =
+        if options[:avs_result].kind_of?(AVSResult)
+          options[:avs_result].to_hash
+        else
+          AVSResult.new(options[:avs_result]).to_hash
+        end
+
+      @cvv_result =
+        if options[:cvv_result].kind_of?(CVVResult)
+          options[:cvv_result].to_hash
+        else
+          CVVResult.new(options[:cvv_result]).to_hash
+        end
+    end
+  end
+end

--- a/core/app/models/spree/cvv_result.rb
+++ b/core/app/models/spree/cvv_result.rb
@@ -1,0 +1,35 @@
+module Spree
+  # Result of the Card Verification Value check
+  # http://www.bbbonline.org/eExport/doc/MerchantGuide_cvv2.pdf
+  # Check additional codes from cybersource website
+  class CVVResult
+    MESSAGES = {
+      'D'  =>  'CVV check flagged transaction as suspicious',
+      'I'  =>  'CVV failed data validation check',
+      'M'  =>  'CVV matches',
+      'N'  =>  'CVV does not match',
+      'P'  =>  'CVV not processed',
+      'S'  =>  'CVV should have been present',
+      'U'  =>  'CVV request unable to be processed by issuer',
+      'X'  =>  'CVV check not supported for card'
+    }
+
+    def self.messages
+      MESSAGES
+    end
+
+    attr_reader :code, :message
+
+    def initialize(code)
+      @code = (code.blank? ? nil : code.upcase)
+      @message = MESSAGES[@code]
+    end
+
+    def to_hash
+      {
+        'code' => code,
+        'message' => message
+      }
+    end
+  end
+end

--- a/core/app/models/spree/gateway.rb
+++ b/core/app/models/spree/gateway.rb
@@ -18,9 +18,6 @@ module Spree
     def provider
       gateway_options = options
       gateway_options.delete :login if gateway_options.key?(:login) && gateway_options[:login].nil?
-      if gateway_options[:server]
-        ActiveMerchant::Billing::Base.mode = gateway_options[:server].to_sym
-      end
       @provider ||= provider_class.new(gateway_options)
     end
 

--- a/core/app/models/spree/gateway/bogus.rb
+++ b/core/app/models/spree/gateway/bogus.rb
@@ -24,39 +24,39 @@ module Spree
     def authorize(_money, credit_card, _options = {})
       profile_id = credit_card.gateway_customer_profile_id
       if VALID_CCS.include?(credit_card.number) || (profile_id && profile_id.starts_with?('BGS-'))
-        ActiveMerchant::Billing::Response.new(true, 'Bogus Gateway: Forced success', {}, test: true, authorization: '12345', avs_result: { code: 'D' })
+        Spree::BillingResponse.new(true, 'Bogus Gateway: Forced success', {}, test: true, authorization: '12345', avs_result: { code: 'D' })
       else
-        ActiveMerchant::Billing::Response.new(false, 'Bogus Gateway: Forced failure', { message: 'Bogus Gateway: Forced failure' }, test: true)
+        Spree::BillingResponse.new(false, 'Bogus Gateway: Forced failure', { message: 'Bogus Gateway: Forced failure' }, test: true)
       end
     end
 
     def purchase(_money, credit_card, _options = {})
       profile_id = credit_card.gateway_customer_profile_id
       if VALID_CCS.include?(credit_card.number) || (profile_id && profile_id.starts_with?('BGS-'))
-        ActiveMerchant::Billing::Response.new(true, 'Bogus Gateway: Forced success', {}, test: true, authorization: '12345', avs_result: { code: 'M' })
+        Spree::BillingResponse.new(true, 'Bogus Gateway: Forced success', {}, test: true, authorization: '12345', avs_result: { code: 'M' })
       else
-        ActiveMerchant::Billing::Response.new(false, 'Bogus Gateway: Forced failure', message: 'Bogus Gateway: Forced failure', test: true)
+        Spree::BillingResponse.new(false, 'Bogus Gateway: Forced failure', message: 'Bogus Gateway: Forced failure', test: true)
       end
     end
 
     def credit(_money, _credit_card, _response_code, _options = {})
-      ActiveMerchant::Billing::Response.new(true, 'Bogus Gateway: Forced success', {}, test: true, authorization: '12345')
+      Spree::BillingResponse.new(true, 'Bogus Gateway: Forced success', {}, test: true, authorization: '12345')
     end
 
     def capture(_money, authorization, _gateway_options)
       if authorization == '12345'
-        ActiveMerchant::Billing::Response.new(true, 'Bogus Gateway: Forced success', {}, test: true)
+        Spree::BillingResponse.new(true, 'Bogus Gateway: Forced success', {}, test: true)
       else
-        ActiveMerchant::Billing::Response.new(false, 'Bogus Gateway: Forced failure', error: 'Bogus Gateway: Forced failure', test: true)
+        Spree::BillingResponse.new(false, 'Bogus Gateway: Forced failure', error: 'Bogus Gateway: Forced failure', test: true)
       end
     end
 
     def void(_response_code, _credit_card, _options = {})
-      ActiveMerchant::Billing::Response.new(true, 'Bogus Gateway: Forced success', {}, test: true, authorization: '12345')
+      Spree::BillingResponse.new(true, 'Bogus Gateway: Forced success', {}, test: true, authorization: '12345')
     end
 
     def cancel(_response_code)
-      ActiveMerchant::Billing::Response.new(true, 'Bogus Gateway: Forced success', {}, test: true, authorization: '12345')
+      Spree::BillingResponse.new(true, 'Bogus Gateway: Forced success', {}, test: true, authorization: '12345')
     end
 
     def test?

--- a/core/app/models/spree/gateway/bogus_simple.rb
+++ b/core/app/models/spree/gateway/bogus_simple.rb
@@ -7,17 +7,17 @@ module Spree
 
     def authorize(_money, credit_card, _options = {})
       if VALID_CCS.include? credit_card.number
-        ActiveMerchant::Billing::Response.new(true, 'Bogus Gateway: Forced success', {}, test: true, authorization: '12345', avs_result: { code: 'A' })
+        Spree::BillingResponse.new(true, 'Bogus Gateway: Forced success', {}, test: true, authorization: '12345', avs_result: { code: 'A' })
       else
-        ActiveMerchant::Billing::Response.new(false, 'Bogus Gateway: Forced failure', { message: 'Bogus Gateway: Forced failure' }, test: true)
+        Spree::BillingResponse.new(false, 'Bogus Gateway: Forced failure', { message: 'Bogus Gateway: Forced failure' }, test: true)
       end
     end
 
     def purchase(_money, credit_card, _options = {})
       if VALID_CCS.include? credit_card.number
-        ActiveMerchant::Billing::Response.new(true, 'Bogus Gateway: Forced success', {}, test: true, authorization: '12345', avs_result: { code: 'A' })
+        Spree::BillingResponse.new(true, 'Bogus Gateway: Forced success', {}, test: true, authorization: '12345', avs_result: { code: 'A' })
       else
-        ActiveMerchant::Billing::Response.new(false, 'Bogus Gateway: Forced failure', message: 'Bogus Gateway: Forced failure', test: true)
+        Spree::BillingResponse.new(false, 'Bogus Gateway: Forced failure', message: 'Bogus Gateway: Forced failure', test: true)
       end
     end
   end

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -225,6 +225,14 @@ module Spree
 
       payment_method.create_profile(self)
     rescue ActiveMerchant::ConnectionError => e
+      msg =
+        'Raising ActiveMerchant::ConnectionError is deprecated. ' \
+        'Please raise Spree::BillingConnectionError instead.'
+
+      Spree::Deprecation.warn(msg, caller)
+
+      gateway_error e
+    rescue Spree::BillingConnectionError => e
       gateway_error e
     end
 

--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -203,7 +203,7 @@ module Spree
       end
 
       def gateway_error(error)
-        if error.is_a? ActiveMerchant::Billing::Response
+        if error.is_a? Spree::BillingResponse
           text = error.params['message'] || error.params['response_reason_text'] || error.message
         elsif error.is_a? ActiveMerchant::ConnectionError
           text = Spree.t(:unable_to_connect_to_gateway)

--- a/core/app/models/spree/payment_method/check.rb
+++ b/core/app/models/spree/payment_method/check.rb
@@ -33,7 +33,7 @@ module Spree
     end
 
     def simulated_successful_billing_response
-      ActiveMerchant::Billing::Response.new(true, "", {}, {})
+      Spree::BillingResponse.new(true, "", {}, {})
     end
   end
 end

--- a/core/app/models/spree/payment_method/store_credit.rb
+++ b/core/app/models/spree/payment_method/store_credit.rb
@@ -14,7 +14,7 @@ module Spree
 
     def authorize(amount_in_cents, provided_store_credit, gateway_options = {})
       if provided_store_credit.nil?
-        ActiveMerchant::Billing::Response.new(false, Spree.t('store_credit.unable_to_find'), {}, {})
+        Spree::BillingResponse.new(false, Spree.t('store_credit.unable_to_find'), {}, {})
       else
         action = -> (store_credit) {
           store_credit.authorize(
@@ -48,7 +48,7 @@ module Spree
       end
 
       if event.blank?
-        ActiveMerchant::Billing::Response.new(false, Spree.t('store_credit.unable_to_find'), {}, {})
+        Spree::BillingResponse.new(false, Spree.t('store_credit.unable_to_find'), {}, {})
       else
         capture(amount_in_cents, event.authorization_code, gateway_options)
       end
@@ -77,14 +77,14 @@ module Spree
       store_credit = store_credit_event.try(:store_credit)
 
       if store_credit_event.nil? || store_credit.nil?
-        ActiveMerchant::Billing::Response.new(false, '', {}, {})
+        Spree::BillingResponse.new(false, '', {}, {})
       elsif store_credit_event.capture_action?
         amount_in_cents = (store_credit_event.amount * 100).round
         credit(amount_in_cents, auth_code)
       elsif store_credit_event.authorization_action?
         void(auth_code)
       else
-        ActiveMerchant::Billing::Response.new(false, '', {}, {})
+        Spree::BillingResponse.new(false, '', {}, {})
       end
     end
 
@@ -98,11 +98,11 @@ module Spree
       store_credit.with_lock do
         if response = action.call(store_credit)
           # note that we only need to return the auth code on an 'auth', but it's innocuous to always return
-          ActiveMerchant::Billing::Response.new(true,
+          Spree::BillingResponse.new(true,
                                                 Spree.t('store_credit.successful_action', action: action_name),
                                                 {}, { authorization: auth_code || response })
         else
-          ActiveMerchant::Billing::Response.new(false, store_credit.errors.full_messages.join, {}, {})
+          Spree::BillingResponse.new(false, store_credit.errors.full_messages.join, {}, {})
         end
       end
     end
@@ -112,7 +112,7 @@ module Spree
       store_credit = Spree::StoreCreditEvent.find_by_authorization_code(auth_code).try(:store_credit)
 
       if store_credit.nil?
-        ActiveMerchant::Billing::Response.new(false, Spree.t('store_credit.unable_to_find_for_action', auth_code: auth_code, action: action_name), {}, {})
+        Spree::BillingResponse.new(false, Spree.t('store_credit.unable_to_find_for_action', auth_code: auth_code, action: action_name), {}, {})
       else
         handle_action_call(store_credit, action, action_name, auth_code)
       end

--- a/core/app/models/spree/refund.rb
+++ b/core/app/models/spree/refund.rb
@@ -65,6 +65,14 @@ module Spree
 
       response
     rescue ActiveMerchant::ConnectionError => e
+      msg =
+        'Raising ActiveMerchant::ConnectionError is deprecated. ' \
+        'Please raise Spree::BillingConnectionError instead.'
+
+      Spree::Deprecation.warn(msg, caller)
+      logger.error(Spree.t(:gateway_error) + "  #{e.inspect}")
+      raise Core::GatewayError.new(Spree.t(:unable_to_connect_to_gateway))
+    rescue Spree::BillingConnectionError => e
       logger.error(Spree.t(:gateway_error) + "  #{e.inspect}")
       raise Core::GatewayError.new(Spree.t(:unable_to_connect_to_gateway))
     end

--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -63,6 +63,7 @@ require 'spree/migration_helpers'
 require 'spree/core/engine'
 
 require 'spree/i18n'
+require 'spree/errors'
 require 'spree/localized_number'
 require 'spree/money'
 require 'spree/permitted_attributes'

--- a/core/lib/spree/errors.rb
+++ b/core/lib/spree/errors.rb
@@ -1,0 +1,4 @@
+module Spree
+  class SpreeError < StandardError
+  end
+end

--- a/core/lib/spree/errors.rb
+++ b/core/lib/spree/errors.rb
@@ -1,4 +1,13 @@
 module Spree
   class SpreeError < StandardError
   end
+
+  class BillingConnectionError < SpreeError
+    attr_reader :triggering_exception
+
+    def initialize(message, triggering_exception)
+      super(message)
+      @triggering_exception = triggering_exception
+    end
+  end
 end

--- a/core/spec/models/spree/avs_result_spec.rb
+++ b/core/spec/models/spree/avs_result_spec.rb
@@ -1,0 +1,65 @@
+require 'spec_helper'
+
+describe Spree::AVSResult, type: :model do
+  AVSResult = Spree::AVSResult
+
+  describe "#initialize" do
+    it "accepts nil as an arguement" do
+      AVSResult.new(nil)
+    end
+
+    it "sets flags indicating addresses don't match" do
+      result = AVSResult.new(code: 'N')
+      expect(result.code).to eq('N')
+      expect(result.street_match).to eq('N')
+      expect(result.postal_match).to eq('N')
+      expect(result.message).to eq(AVSResult.messages['N'])
+    end
+
+    it 'sets flags indicating only the street matches' do
+      result = AVSResult.new(code: 'A')
+      expect(result.code).to eq('A')
+      expect(result.street_match).to eq('Y')
+      expect(result.postal_match).to eq('N')
+      expect(result.message).to eq(AVSResult.messages['A'])
+    end
+
+    it 'sets flags indicating only the postal code matches' do
+      result = AVSResult.new(code: 'W')
+      expect(result.code).to eq('W')
+      expect(result.street_match).to eq('N')
+      expect(result.postal_match).to eq('Y')
+      expect(result.message).to eq(AVSResult.messages['W'])
+    end
+
+    it 'does nothing when the code is nil' do
+      result = AVSResult.new(code: nil)
+      result.code
+      expect(result.message).to be_nil
+    end
+
+    it 'does nothing when the code is an empty string' do
+      result = AVSResult.new(code: '')
+      expect(result.code).to be_nil
+      expect(result.message).to be_nil
+    end
+
+    it 'can override the value of street_match' do
+      avs_data = AVSResult.new(street_match: 'Y')
+      expect(avs_data.street_match).to eq('Y')
+    end
+
+    it 'can override the value of postal_match' do
+      avs_data = AVSResult.new(postal_match: 'Y')
+      expect(avs_data.postal_match).to eq('Y')
+    end
+  end
+
+  describe '#to_hash' do
+    it 'returns a hash representing the object' do
+      avs_data = AVSResult.new(code: 'X').to_hash
+      expect(avs_data['code']).to eq('X')
+      expect(avs_data['message']).to eq(AVSResult.messages['X'])
+    end
+  end
+end

--- a/core/spec/models/spree/billing_response_spec.rb
+++ b/core/spec/models/spree/billing_response_spec.rb
@@ -1,0 +1,99 @@
+require 'spec_helper'
+
+describe Spree::BillingResponse, type: :model do
+  BillingResponse = Spree::BillingResponse
+  AVSResult = Spree::AVSResult
+  CVVResult = Spree::CVVResult
+
+  describe '#initialize' do
+    it 'sets attributes' do
+      params = { foo: :bar }
+
+      options = {
+        error_code: 1,
+        emv_authorization: 2,
+        authorization: 3,
+        test: true
+      }
+
+      response =
+        BillingResponse.new(true, 'msg', params, options)
+
+      expect(response.message).to eq('msg')
+      expect(response.params).to eq({ "foo" => :bar })
+      expect(response.error_code).to eq(1)
+      expect(response.emv_authorization).to eq(2)
+      expect(response.authorization).to eq(3)
+      expect(response.test).to eq(true)
+    end
+
+    it 'setting avs_result as an AVSResult has the same result as a Hash' do
+      avs_params = {}
+      avs_result = AVSResult.new avs_params
+
+      response1 =
+        BillingResponse.new(true, "", {}, avs_result: avs_result)
+
+      response2 =
+        BillingResponse.new(true, "", {}, avs_result: avs_params)
+
+      expect(response1.avs_result).to eq(response2.avs_result)
+    end
+
+    it 'setting cvs_result as an CVVResult has the same result as a Hash' do
+      cvv_params = {}
+      cvv_result = CVVResult.new cvv_params
+
+      response1 =
+        BillingResponse.new(true, "", {}, cvv_result: cvv_result)
+
+      response2 =
+        BillingResponse.new(true, "", {}, cvv_result: cvv_params)
+
+      expect(response1.cvv_result).to eq(response2.cvv_result)
+    end
+
+    it 'sets @test to false by default' do
+      response =
+        BillingResponse.new(true, "", {}, {})
+
+      expect(response.test).to be false
+    end
+  end
+
+  describe '#success?' do
+    it 'is the same as @success' do
+      success =
+        BillingResponse.new(true, "", {}, {})
+      failure =
+        BillingResponse.new(false, "", {}, {})
+
+      expect(success.success?).to be true
+      expect(failure.success?).to be false
+    end
+  end
+
+  describe '#test?' do
+    it 'is the same as @test' do
+      test =
+        BillingResponse.new(true, "", {}, { test: true })
+      not_test =
+        BillingResponse.new(true, "", {}, { test: false })
+
+      expect(test.test?).to be true
+      expect(not_test.test?).to be false
+    end
+  end
+
+  describe '#fraud_review?' do
+    it 'is the same as @fraud_review' do
+      fraud_review =
+        BillingResponse.new(true, "", {}, { fraud_review: true })
+      not_fraud_review =
+        BillingResponse.new(true, "", {}, { fraud_review: false })
+
+      expect(fraud_review.fraud_review?).to be true
+      expect(not_fraud_review.fraud_review?).to be false
+    end
+  end
+end

--- a/core/spec/models/spree/cvv_result_spec.rb
+++ b/core/spec/models/spree/cvv_result_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe Spree::CVVResult, type: :model do
+  CVVResult = Spree::CVVResult
+
+  describe "#initialize" do
+    it "sets code and message to nil when the argument is nil" do
+      result = CVVResult.new(nil)
+      expect(result.code).to be_nil
+      expect(result.message).to be_nil
+    end
+
+    it "sets code and message to nil when the argument is an empty string" do
+      result = CVVResult.new('')
+      expect(result.code).to be_nil
+      expect(result.message).to be_nil
+    end
+
+    it 'matches a code to a message' do
+      result = CVVResult.new('M')
+      expect(result.code).to eq('M')
+      expect(result.message).to eq(CVVResult.messages['M'])
+    end
+  end
+
+  describe '#to_hash' do
+    it 'creates a hash with the attributes' do
+      result = CVVResult.new('M').to_hash
+      expect(result['code']).to eq('M')
+      expect(result['message']).to eq(CVVResult.messages['M'])
+    end
+  end
+end

--- a/core/spec/models/spree/order_capturing_spec.rb
+++ b/core/spec/models/spree/order_capturing_spec.rb
@@ -136,7 +136,7 @@ describe Spree::OrderCapturing do
 
         class ExceptionallyBogusPaymentMethod < Spree::Gateway::Bogus
           def capture(*_args)
-            raise ActiveMerchant::ConnectionError.new("foo", nil)
+            raise Spree::BillingConnectionError.new("foo", nil)
           end
         end
 

--- a/core/spec/models/spree/payment_method/store_credit_spec.rb
+++ b/core/spec/models/spree/payment_method/store_credit_spec.rb
@@ -257,8 +257,8 @@ describe Spree::PaymentMethod::StoreCredit do
     let(:captured_amount) { 10.0 }
 
     shared_examples "a spree payment method" do
-      it "returns an ActiveMerchant::Billing::Response" do
-        expect(subject).to be_instance_of(ActiveMerchant::Billing::Response)
+      it "returns an Spree::BillingResponse" do
+        expect(subject).to be_instance_of(Spree::BillingResponse)
       end
     end
 

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -670,7 +670,7 @@ describe Spree::Payment, type: :model do
 
       context "when there is an error connecting to the gateway" do
         it "should call gateway_error " do
-          expect(gateway).to receive(:create_profile).and_raise(ActiveMerchant::ConnectionError.new("foo", nil))
+          expect(gateway).to receive(:create_profile).and_raise(Spree::BillingConnectionError.new("foo", nil))
           expect do
             Spree::Payment.create(
               amount: 100,

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -28,7 +28,7 @@ describe Spree::Payment, type: :model do
   let(:amount_in_cents) { (payment.amount * 100).round }
 
   let!(:success_response) do
-    ActiveMerchant::Billing::Response.new(true, '', {}, {
+    Spree::BillingResponse.new(true, '', {}, {
       authorization: '123',
       cvv_result: cvv_code,
       avs_result: { code: avs_code }
@@ -36,7 +36,7 @@ describe Spree::Payment, type: :model do
   end
 
   let(:failed_response) do
-    ActiveMerchant::Billing::Response.new(false, '', {}, {})
+    Spree::BillingResponse.new(false, '', {}, {})
   end
 
   context '.risky' do
@@ -322,7 +322,7 @@ describe Spree::Payment, type: :model do
           expect(payment.response_code).to eq('123')
           expect(payment.avs_response).to eq(avs_code)
           expect(payment.cvv_response_code).to eq(cvv_code)
-          expect(payment.cvv_response_message).to eq(ActiveMerchant::Billing::CVVResult::MESSAGES[cvv_code])
+          expect(payment.cvv_response_message).to eq(Spree::CVVResult::MESSAGES[cvv_code])
         end
 
         it "should make payment pending" do

--- a/core/spec/models/spree/refund_spec.rb
+++ b/core/spec/models/spree/refund_spec.rb
@@ -14,7 +14,7 @@ describe Spree::Refund, type: :model do
     let(:refund_reason) { create(:refund_reason) }
 
     let(:gateway_response) {
-      ActiveMerchant::Billing::Response.new(
+      Spree::BillingResponse.new(
         gateway_response_success,
         gateway_response_message,
         gateway_response_params,

--- a/core/spec/models/spree/refund_spec.rb
+++ b/core/spec/models/spree/refund_spec.rb
@@ -136,12 +136,12 @@ describe Spree::Refund, type: :model do
       end
     end
 
-    context 'with an activemerchant gateway connection error' do
+    context 'with a connection error' do
       before do
         expect(payment.payment_method)
           .to receive(:credit)
           .with(amount_in_cents, payment.source, payment.transaction_id, { originator: an_instance_of(Spree::Refund) })
-          .and_raise(ActiveMerchant::ConnectionError.new("foo", nil))
+          .and_raise(Spree::BillingConnectionError.new("foo", nil))
       end
 
       it 'raises Spree::Core::GatewayError' do


### PR DESCRIPTION
This decouples Solidus from ActiveMerchant.

This does _NOT_ fix all existing gateways, nor does it fix their dependence on
ActiveMerchant.

The main focus of this pull request is to make core not rely on
`ActiveMerchant::Billing::Response`, and `ActiveMerchant::ConnectionError`.

A number of classes are copied from ActiveMerchant, and are available as an
analogous class under the Spree namespace:
- `ActiveMerchant::Billing::Response`  -> `Spree::BillingResponse`
- `ActiveMerchant::Billing::CVVResult`  -> `Spree::CVVResult`
- `ActiveMerchant::Billing::AVSResult`  -> `Spree::AVSResult`
- `ActiveMerchant::ConnectionError`  -> `Spree::BillingConnectionError`


Existing usages of the active merchant classes will continue to work, but
report deprecation notices.

Next steps would be to have existing Gateways return a `Spree::BillingResponse`
instead of an ActiveMerchant equivalent.