### PR TITLE
Tax fix for finalized adjustments v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Solidus 2.3.0 (master, unreleased)
 
+- Ignore `adjustment.finalized` on tax adjustments. [\#1936](https://github.com/solidusio/solidus/pull/1936) ([jordan-brough](https://github.com/jordan-brough))
 - Deprecate `#simple_current_order`
 [\#1915](https://github.com/solidusio/solidus/pull/1915) ([ericsaupe](https://github.com/ericsaupe))
 

--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -97,7 +97,9 @@ module Spree
     #
     # @return [BigDecimal] New amount of this adjustment
     def update!
-      return amount if finalized?
+      if finalized? && !tax?
+        return amount
+      end
 
       # If the adjustment has no source, do not attempt to re-calculate the amount.
       # Chances are likely that this was a manually created adjustment in the admin backend.

--- a/core/app/models/spree/tax/item_adjuster.rb
+++ b/core/app/models/spree/tax/item_adjuster.rb
@@ -31,7 +31,7 @@ module Spree
           # Find an existing adjustment from the same source.
           # All tax adjustments already have source_type == 'Spree::TaxRate' so
           # we need only check source_id.
-          adjustment = tax_adjustments.detect{|a| a.source_id == rate.id }
+          adjustment = tax_adjustments.detect { |a| a.source_id == rate.id }
           if adjustment
             adjustment.update!
             adjustment

--- a/core/spec/models/spree/tax/item_adjuster_spec.rb
+++ b/core/spec/models/spree/tax/item_adjuster_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Spree::Tax::ItemAdjuster do
   let(:item) { create(:line_item, order: order) }
 
   def tax_adjustments
-    item.adjustments.tax.to_a
+    item.adjustments.select(&:tax?).to_a
   end
 
   describe 'initialization' do

--- a/core/spec/models/spree/tax/item_adjuster_spec.rb
+++ b/core/spec/models/spree/tax/item_adjuster_spec.rb
@@ -67,13 +67,32 @@ RSpec.describe Spree::Tax::ItemAdjuster do
         context 'and all rates have the same tax category as the item' do
           let(:item) { create :line_item, order: order, tax_category: item_tax_category }
           let(:item_tax_category) { create(:tax_category) }
-          let(:rate_1) { create :tax_rate, tax_category: item_tax_category }
+          let(:rate_1) { create :tax_rate, tax_category: item_tax_category, amount: 0.1 }
           let(:rate_2) { create :tax_rate }
           let(:rates_for_order_zone) { [rate_1, rate_2] }
 
           it 'creates an adjustment for every matching rate' do
             adjuster.adjust!
             expect(tax_adjustments.length).to eq(1)
+          end
+
+          context 'when the adjustment exists' do
+            before do
+              adjuster.adjust!
+            end
+
+            context 'when the existing adjustment is finalized' do
+              before do
+                tax_adjustments.first.finalize!
+              end
+
+              it 'updates the adjustment' do
+                item.update_columns(price: item.price * 2)
+                adjuster.adjust!
+                expect(tax_adjustments.length).to eq(1)
+                expect(tax_adjustments.first.amount).to eq(0.1 * item.price)
+              end
+            end
           end
         end
       end


### PR DESCRIPTION
Alternative to #1917.  Fixes #1916.  Also related to #1894 and #1892.

Ignore adjustment.finalized on Tax adjustments

Otherwise taxes don't get updated after an order completes (because all
adjustments are finalized when an order completes).
