### PR TITLE
Add bundler version warning to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@
 * [#solidus.io](http://webchat.freenode.net/?channels=solidus.io) on freenode
 * [solidus-security](https://groups.google.com/forum/#!forum/solidus-security) mailing list
 
+Bundler Issues
+--------------
+
+Having bundler problems? Try downgrading to bundler 1.13.7 or earlier.
+[Gem resolution is seriously broken in bundler versions since 1.14](https://github.com/bundler/bundler/issues/5633).
+
 Summary
 -------
 


### PR DESCRIPTION
Bundler is crazy broken and users (especially extension developers) are regularly running into this. The best I can do is warn users about the problem.