### PR TITLE
Use Rails i18n for promotion rules and actions

### DIFF
--- a/backend/app/helpers/spree/promotion_rules_helper.rb
+++ b/backend/app/helpers/spree/promotion_rules_helper.rb
@@ -2,8 +2,8 @@ module Spree
   module PromotionRulesHelper
     def options_for_promotion_rule_types(promotion)
       existing = promotion.rules.map { |rule| rule.class.name }
-      rule_names = Rails.application.config.spree.promotions.rules.map(&:name).reject{ |r| existing.include? r }
-      options = rule_names.map { |name| [Spree.t("promotion_rule_types.#{name.demodulize.underscore}.name"), name] }
+      rules = Rails.application.config.spree.promotions.rules.reject { |r| existing.include? r.name }
+      options = rules.map { |rule| [rule.model_name.human, rule.name] }
       options_for_select(options)
     end
   end

--- a/backend/app/views/spree/admin/promotions/_actions.html.erb
+++ b/backend/app/views/spree/admin/promotions/_actions.html.erb
@@ -1,7 +1,7 @@
 <fieldset id="action_fields" class="no-border-top">
 
   <%= form_tag spree.admin_promotion_promotion_actions_path(@promotion), remote: true, id: 'new_promotion_action_form' do %>
-    <% options = options_for_select(  Rails.application.config.spree.promotions.actions.map(&:name).map {|name| [ Spree.t("promotion_action_types.#{name.demodulize.underscore}.name"), name] } ) %>
+    <% options = options_for_select(  Rails.application.config.spree.promotions.actions.map {|action| [ action.model_name.human, action.name] } ) %>
     <fieldset>
       <legend align="center"><%= plural_resource_name(Spree::PromotionAction) %></legend>
       <% if can?(:update, @promotion) %>

--- a/backend/app/views/spree/admin/promotions/_promotion_action.html.erb
+++ b/backend/app/views/spree/admin/promotions/_promotion_action.html.erb
@@ -1,6 +1,6 @@
 <div class="promotion_action promotion-block <%= promotion_action.type.to_s.demodulize.underscore %>" id="<%= dom_id promotion_action %>">
   <% type_name = promotion_action.class.name.demodulize.underscore %>
-  <h6 class="promotion-title"><%= Spree.t("promotion_action_types.#{type_name}.description") %></h6>
+  <h6 class="promotion-title"><%= promotion_action.class.human_attribute_name(:description) %></h6>
   <% if can?(:destroy, promotion_action) %>
     <%= link_to_with_icon 'trash', '', spree.admin_promotion_promotion_action_path(@promotion, promotion_action), remote: true, method: :delete, class: 'delete' %>
   <% end %>

--- a/backend/app/views/spree/admin/promotions/_promotion_action.html.erb
+++ b/backend/app/views/spree/admin/promotions/_promotion_action.html.erb
@@ -1,5 +1,5 @@
-<div class="promotion_action promotion-block <%= promotion_action.type.to_s.demodulize.underscore %>" id="<%= dom_id promotion_action %>">
-  <% type_name = promotion_action.class.name.demodulize.underscore %>
+<div class="promotion_action promotion-block <%= promotion_action.model_name.element %>" id="<%= dom_id promotion_action %>">
+  <% type_name = promotion_action.model_name.element %>
   <h6 class="promotion-title"><%= promotion_action.class.human_attribute_name(:description) %></h6>
   <% if can?(:destroy, promotion_action) %>
     <%= link_to_with_icon 'trash', '', spree.admin_promotion_promotion_action_path(@promotion, promotion_action), remote: true, method: :delete, class: 'delete' %>

--- a/backend/app/views/spree/admin/promotions/_promotion_rule.html.erb
+++ b/backend/app/views/spree/admin/promotions/_promotion_rule.html.erb
@@ -1,6 +1,6 @@
 <div class="promotion_rule promotion-block col-12" id="<%= dom_id promotion_rule %>">
   <% type_name = promotion_rule.class.name.demodulize.underscore %>
-  <h6 class='promotion-title <%= 'no-text' if type_name == 'user_logged_in' || type_name == 'first_order'%>'><%= Spree.t("promotion_rule_types.#{type_name}.description") %></h6>
+  <h6 class='promotion-title <%= 'no-text' if type_name == 'user_logged_in' || type_name == 'first_order'%>'><%= promotion_rule.class.human_attribute_name(:description) %></h6>
   <% if can?(:destroy, promotion_rule) %>
     <%= link_to_with_icon 'trash', '', spree.admin_promotion_promotion_rule_path(@promotion, promotion_rule), remote: true, method: :delete, class: 'delete' %>
   <% end %>

--- a/backend/app/views/spree/admin/promotions/_promotion_rule.html.erb
+++ b/backend/app/views/spree/admin/promotions/_promotion_rule.html.erb
@@ -1,5 +1,5 @@
 <div class="promotion_rule promotion-block col-12" id="<%= dom_id promotion_rule %>">
-  <% type_name = promotion_rule.class.name.demodulize.underscore %>
+  <% type_name = promotion_rule.model_name.element %>
   <h6 class='promotion-title <%= 'no-text' if type_name == 'user_logged_in' || type_name == 'first_order'%>'><%= promotion_rule.class.human_attribute_name(:description) %></h6>
   <% if can?(:destroy, promotion_rule) %>
     <%= link_to_with_icon 'trash', '', spree.admin_promotion_promotion_rule_path(@promotion, promotion_rule), remote: true, method: :delete, class: 'delete' %>

--- a/backend/app/views/spree/admin/promotions/rules/_first_repeat_purchase_since.html.erb
+++ b/backend/app/views/spree/admin/promotions/rules/_first_repeat_purchase_since.html.erb
@@ -1,7 +1,7 @@
 <div class="row">
   <div class="col-6">
     <div class="field">
-      <%= Spree.t(:form_text, scope: "promotion_rule_types.first_repeat_purchase_since")  %>
+      <%= Spree::Promotion::Rules::FirstRepeatPurchaseSince.human_attribute_name(:form_text) %>
     </div>
   </div>
 

--- a/backend/app/views/spree/admin/promotions/rules/_landing_page.html.erb
+++ b/backend/app/views/spree/admin/promotions/rules/_landing_page.html.erb
@@ -1,6 +1,6 @@
 <div class="col-12">
   <div class="field">
-    <label for="<%= "#{param_prefix}_preferred_path" %>"><%= Spree.t('promotion_rule_types.landing_page.description') %>:</label>  
+    <label for="<%= "#{param_prefix}_preferred_path" %>"><%= Spree::Promotion::Rules::LandingPage.human_attribute_name(:description) %>:</label>
     <%= text_field_tag "#{param_prefix}[preferred_path]", promotion_rule.preferred_path, class: 'fullwidth' %>  
     <span class="info"><%= Spree.t('landing_page_rule.must_have_visited_path') %></span>
   </div>

--- a/backend/app/views/spree/admin/promotions/rules/_nth_order.html.erb
+++ b/backend/app/views/spree/admin/promotions/rules/_nth_order.html.erb
@@ -2,7 +2,7 @@
   <div class="row">
     <div class="col-6">
       <div class="field">
-        <%= Spree.t(:form_text, scope: "promotion_rule_types.nth_order")  %>
+        <%= Spree::Promotion::Rules::NthOrder.human_attribute_name(:form_text) %>
       </div>
     </div>
     <div class="col-6">

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -175,6 +175,14 @@ en:
         promotion_uses: Promotion Uses
         starts_at: Start date
         usage_limit: Overall Usage Limit
+      spree/promotion/actions/create_adjustment:
+        description: Creates a promotion credit adjustment on the order
+      spree/promotion/actions/create_item_adjustments:
+        description: Creates a promotion credit adjustment on a line item
+      spree/promotion/actions/create_quantity_adjustments:
+        description: Creates an adjustment on a line item based on quantity
+      spree/promotion/actions/free_shipping:
+        description: Makes all shipments for the order free
       spree/promotion/rules/item_total:
         description: Order total meets these criteria
       spree/promotion/rules/first_order:
@@ -493,6 +501,10 @@ en:
       spree/promotion:
         one: Promotion
         other: Promotions
+      spree/promotion/actions/create_adjustment: Create whole-order adjustment
+      spree/promotion/actions/create_item_adjustments: Create per-line-item adjustment
+      spree/promotion/actions/create_quantity_adjustments: Create per-quantity adjustment
+      spree/promotion/actions/free_shipping: Free shipping
       spree/promotion/rules/first_order: First order
       spree/promotion/rules/item_total: Item total
       spree/promotion/rules/landing_page: Landing Page
@@ -1650,19 +1662,6 @@ en:
     promotion: Promotion
     promotionable: Promotable
     promotion_action: Promotion Action
-    promotion_action_types:
-      create_adjustment:
-        description: Creates a promotion credit adjustment on the order
-        name: Create whole-order adjustment
-      create_item_adjustments:
-        description: Creates a promotion credit adjustment on a line item
-        name: Create per-line-item adjustment
-      create_quantity_adjustments:
-        description: Creates an adjustment on a line item based on quantity
-        name: Create per-quantity adjustment
-      free_shipping:
-        description: Makes all shipments for the order free
-        name: Free shipping
     promotion_actions: Actions
     promotion_code_batch_mailer:
       promotion_code_batch_finished:

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -175,6 +175,32 @@ en:
         promotion_uses: Promotion Uses
         starts_at: Start date
         usage_limit: Overall Usage Limit
+      spree/promotion/rules/item_total:
+        description: Order total meets these criteria
+      spree/promotion/rules/first_order:
+        description: Must be the customer's first order
+      spree/promotion/rules/landing_page:
+          description: Customer must have visited the specified page
+      spree/promotion/rules/one_use_per_user:
+        description: Only One Use Per User
+      spree/promotion/rules/option_value:
+        description: Order includes specified product(s) with matching option value(s)
+      spree/promotion/rules/product:
+        description: Order includes specified product(s)
+      spree/promotion/rules/user:
+        description: Available only to the specified users
+      spree/promotion/rules/user_logged_in:
+        description: Available only to logged in users
+      spree/promotion/rules/taxon:
+        description: Order includes products with specified taxon(s)
+      spree/promotion/rules/nth_order:
+        description: Apply a promotion to every nth order a user has completed.
+        form_text: "Apply this promotion on the users Nth order: "
+      spree/promotion/rules/first_repeat_purchase_since:
+        description: Available only to user who have not purchased in a while
+        form_text: "Apply this promotion to users whose last order was more than X days ago: "
+      spree/promotion/rules/user_role:
+        description: Order includes User with specified Role(s)
       spree/promotion_category:
         name: Name
       spree/property:
@@ -467,6 +493,18 @@ en:
       spree/promotion:
         one: Promotion
         other: Promotions
+      spree/promotion/rules/first_order: First order
+      spree/promotion/rules/item_total: Item total
+      spree/promotion/rules/landing_page: Landing Page
+      spree/promotion/rules/one_use_per_user: One Use Per User
+      spree/promotion/rules/option_value: Option Value(s)
+      spree/promotion/rules/product: Product(s)
+      spree/promotion/rules/user: User
+      spree/promotion/rules/user_logged_in: User Logged In
+      spree/promotion/rules/taxon: Taxon(s)
+      spree/promotion/rules/nth_order: Nth Order
+      spree/promotion/rules/first_repeat_purchase_since: First Repeat Purchase Since
+      spree/promotion/rules/user_role: User Role(s)
       spree/promotion_category:
         one: Promotion Category
         other: Promotion Categories
@@ -1642,45 +1680,6 @@ en:
         all: Match all of these rules
         any: Match any of these rules
     promotion_rule: Promotion Rule
-    promotion_rule_types:
-      first_order:
-        description: Must be the customer's first order
-        name: First order
-      item_total:
-        description: Order total meets these criteria
-        name: Item total
-      landing_page:
-        description: Customer must have visited the specified page
-        name: Landing Page
-      one_use_per_user:
-        description: Only One Use Per User
-        name: One Use Per User
-      option_value:
-        description: Order includes specified product(s) with matching option value(s)
-        name: Option Value(s)
-      product:
-        description: Order includes specified product(s)
-        name: Product(s)
-      user:
-        description: Available only to the specified users
-        name: User
-      user_logged_in:
-        description: Available only to logged in users
-        name: User Logged In
-      taxon:
-        description: Order includes products with specified taxon(s)
-        name: Taxon(s)
-      nth_order:
-        description: Apply a promotion to every nth order a user has completed.
-        name: Nth Order
-        form_text: "Apply this promotion on the users Nth order: "
-      first_repeat_purchase_since:
-        description: Available only to user who have not purchased in a while
-        name: First Repeat Purchase Since
-        form_text: "Apply this promotion to users whose last order was more than X days ago: "
-      user_role:
-        description: Order includes User with specified Role(s)
-        name: User Role(s)
     promotions: Promotions
     promotion_successfully_created: Promotion has been successfully created!
     promotion_total_changed_before_complete: "One or more of the promotions on your order have become ineligible and were removed. Please check the new order amounts and try again."


### PR DESCRIPTION
Addresses https://github.com/solidusio/solidus/issues/1899

Previously, we were using a custom i18n namespace to provide user-friendly names for promotion rules and actions, forcing us to use a convoluted method involving `demodulize` in order to produce the translation key.

This was changed to use the classical `rule.model_name.human` syntax for short class names and descriptions. 

To effectively use the `human_attribute_name` method to grab description translations, entries for each of the promotion rules and actions were added under the `attributes` namespace in the `en.yml` file.
