### PR TITLE
Fix order resend

### DIFF
--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -145,7 +145,7 @@ module Spree
       end
 
       def resend
-        OrderMailer.confirm_email(@order.id, true).deliver_later
+        OrderMailer.confirm_email(@order, true).deliver_later
         flash[:success] = Spree.t(:order_email_resent)
 
         redirect_to(spree.edit_admin_order_path(@order))

--- a/backend/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -58,6 +58,17 @@ describe Spree::Admin::OrdersController, type: :controller do
       end
     end
 
+    context "#resend" do
+      let(:order) { create(:completed_order_with_totals) }
+      it "resends order email" do
+        mail_message = double "Mail::Message"
+        expect(Spree::OrderMailer).to receive(:confirm_email).with(order, true).and_return mail_message
+        expect(mail_message).to receive :deliver_later
+        post :resend, params: { id: order.number }
+        expect(flash[:success]).to eq Spree.t(:order_email_resent)
+      end
+    end
+
     context "pagination" do
       it "can page through the orders" do
         get :index, params: { page: 2, per_page: 10 }


### PR DESCRIPTION
Resending an order from admin raises an error, as the `resend` action no longer accepts an `id` argument.

See https://github.com/solidusio/solidus/commit/89200fb7b35c2371d4d280f6ebd74ae792a41963