### PR TITLE
Update wallet payment source method names.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,8 +129,8 @@
 
 - Deprecate `Order#has_step?` in favour of `has_checkout_step?` [#1667](https://github.com/solidusio/solidus/pull/1667) ([mamhoff](https://github.com/mamhoff))
 - Deprecate `Order#set_shipments_cost`, which is now done in `Order#update!` [\#1689](https://github.com/solidusio/solidus/pull/1689) ([jhawthorn](https://github.com/jhawthorn))
-- Deprecate `user.default_credit_card`, `user.payment_sources` for `user.wallet.default_wallet_payment_source` and `user.wallet.wallet_payment_sources`
-- Deprecate `CreditCard#default` in favour of `user.wallet.default_wallet_payment_source`
+- Deprecate `user.default_credit_card`, `user.payment_sources` for `user.wallet.default_payment_source` and `user.wallet.payment_sources`
+- Deprecate `CreditCard#default` in favour of `user.wallet.default_payment_source`
 - Deprecate `cache_key_for_taxons` helper favour of `cache [I18n.locale, @taxons]`
 - Deprecate admin sass variables in favour of bootstrap alternatives [\#1780](https://github.com/solidusio/solidus/pull/1780) ([tvdeyen](https://github.com/tvdeyen))
 - Deprecate Address\#empty? [\#1686](https://github.com/solidusio/solidus/pull/1686) ([jhawthorn](https://github.com/jhawthorn))

--- a/core/app/models/concerns/spree/user_payment_source.rb
+++ b/core/app/models/concerns/spree/user_payment_source.rb
@@ -4,10 +4,10 @@ module Spree
 
     def default_credit_card
       Spree::Deprecation.warn(
-        "user.default_credit_card is deprecated. Please use user.wallet.default_wallet_payment_source instead.",
+        "user.default_credit_card is deprecated. Please use user.wallet.default_payment_source instead.",
         caller
       )
-      default = wallet.default_wallet_payment_source
+      default = wallet.default_payment_source
       if default && default.payment_source.is_a?(Spree::CreditCard)
         default.payment_source
       end
@@ -15,7 +15,7 @@ module Spree
 
     def payment_sources
       Spree::Deprecation.warn(
-        "user.payment_sources is deprecated. Please use user.wallet.wallet_payment_sources instead.",
+        "user.payment_sources is deprecated. Please use user.wallet.payment_sources instead.",
         caller
       )
       credit_cards.with_payment_profile

--- a/core/app/models/spree/credit_card.rb
+++ b/core/app/models/spree/credit_card.rb
@@ -45,22 +45,22 @@ module Spree
     }.freeze
 
     def default
-      Spree::Deprecation.warn("CreditCard.default is deprecated. Please use user.wallet.default_wallet_payment_source instead.", caller)
+      Spree::Deprecation.warn("CreditCard.default is deprecated. Please use user.wallet.default_payment_source instead.", caller)
       return false if user.nil?
-      user.wallet.default_wallet_payment_source.try!(:payment_source) == self
+      user.wallet.default_payment_source.try!(:payment_source) == self
     end
 
     def default=(set_as_default)
-      Spree::Deprecation.warn("CreditCard.default= is deprecated. Please use user.wallet.default_wallet_payment_source= instead.", caller)
+      Spree::Deprecation.warn("CreditCard.default= is deprecated. Please use user.wallet.default_payment_source= instead.", caller)
       if user.nil?
         raise "Cannot set 'default' on a credit card without a user"
       elsif set_as_default # setting this card as default
         wallet_payment_source = user.wallet.add(self)
-        user.wallet.default_wallet_payment_source = wallet_payment_source
+        user.wallet.default_payment_source = wallet_payment_source
         true
       else # removing this card as default
-        if user.wallet.default_wallet_payment_source.try!(:payment_source) == self
-          user.wallet.default_wallet_payment_source = nil
+        if user.wallet.default_payment_source.try!(:payment_source) == self
+          user.wallet.default_payment_source = nil
         end
         false
       end

--- a/core/app/models/spree/gateway.rb
+++ b/core/app/models/spree/gateway.rb
@@ -53,7 +53,7 @@ module Spree
       if order.completed?
         reusable_sources_by_order(order)
       elsif order.user_id
-        order.user.wallet.wallet_payment_sources.map(&:payment_source).select(&:reusable?)
+        order.user.wallet.payment_sources.map(&:payment_source).select(&:reusable?)
       else
         []
       end

--- a/core/app/models/spree/wallet.rb
+++ b/core/app/models/spree/wallet.rb
@@ -17,9 +17,10 @@ class Spree::Wallet
   # Returns an array of the WalletPaymentSources in this wallet.
   #
   # @return [Array<WalletPaymentSource>]
-  def wallet_payment_sources
+  def payment_sources
     user.wallet_payment_sources.to_a
   end
+  alias_method :wallet_payment_sources, :payment_sources # Backward Compatibility
 
   # Add a PaymentSource to the wallet.
   #
@@ -48,29 +49,31 @@ class Spree::Wallet
 
   # Find the default WalletPaymentSource for this wallet, if any.
   # @return [WalletPaymentSource]
-  def default_wallet_payment_source
+  def default_payment_source
     user.wallet_payment_sources.find_by(default: true)
   end
+  alias_method :default_wallet_payment_source, :default_payment_source # Backward Compatibility
 
   # Change the default WalletPaymentSource for this wallet.
   # @param source [WalletPaymentSource] The payment source to set as the default.
   #   It must be in the wallet already. Pass nil to clear the default.
   # @return [void]
-  def default_wallet_payment_source=(wallet_payment_source)
+  def default_payment_source=(wallet_payment_source)
     if wallet_payment_source && !find(wallet_payment_source.id)
-      raise Unauthorized, "wallet_payment_source #{wallet_payment_source.id} does not belong to wallet of user #{user.id}"
+      raise Unauthorized, "payment_source #{wallet_payment_source.id} does not belong to wallet of user #{user.id}"
     end
 
     # Do not update the payment source if the passed source is already default
-    if default_wallet_payment_source == wallet_payment_source
+    if default_payment_source == wallet_payment_source
       return
     end
 
     Spree::WalletPaymentSource.transaction do
       # Unset old default
-      default_wallet_payment_source.try!(:update!, default: false)
+      default_payment_source.try!(:update!, default: false)
       # Set new default
       wallet_payment_source.try!(:update!, default: true)
     end
   end
+  alias_method :default_wallet_payment_source=, :default_payment_source= # Backward Compatibility
 end

--- a/core/app/models/spree/wallet/add_payment_sources_to_wallet.rb
+++ b/core/app/models/spree/wallet/add_payment_sources_to_wallet.rb
@@ -26,7 +26,7 @@ class Spree::Wallet::AddPaymentSourcesToWallet
           order.user.wallet.add(source)
         end
 
-        order.user.wallet.default_wallet_payment_source =
+        order.user.wallet.default_payment_source =
           wallet_payment_sources.last
       end
     end

--- a/core/spec/models/spree/credit_card_spec.rb
+++ b/core/spec/models/spree/credit_card_spec.rb
@@ -286,7 +286,7 @@ describe Spree::CreditCard, type: :model do
 
       it 'uses the wallet information' do
         wallet_payment_source = user.wallet.add(credit_card)
-        user.wallet.default_wallet_payment_source = wallet_payment_source
+        user.wallet.default_payment_source = wallet_payment_source
 
         expect(default_with_silence(credit_card)).to be_truthy
       end
@@ -315,7 +315,7 @@ describe Spree::CreditCard, type: :model do
         Spree::Deprecation.silence do
           credit_card.default = true
         end
-        expect(user.wallet.default_wallet_payment_source.payment_source).to eq(credit_card)
+        expect(user.wallet.default_payment_source.payment_source).to eq(credit_card)
       end
     end
 

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -357,7 +357,7 @@ describe Spree::Order, type: :model do
       before do
         user = create(:user, email: 'spree@example.org', bill_address: user_bill_address)
         wallet_payment_source = user.wallet.add(default_credit_card)
-        user.wallet.default_wallet_payment_source = wallet_payment_source
+        user.wallet.default_payment_source = wallet_payment_source
         order.user = user
 
         allow(order).to receive_messages(payment_required?: true)
@@ -555,13 +555,13 @@ describe Spree::Order, type: :model do
       it "makes the current credit card a user's default credit card" do
         order.complete!
         expect(order.state).to eq 'complete'
-        expect(order.user.reload.wallet.default_wallet_payment_source.payment_source).to eq(order.credit_cards.first)
+        expect(order.user.reload.wallet.default_payment_source.payment_source).to eq(order.credit_cards.first)
       end
 
       it "does not assign a default credit card if temporary_payment_source is set" do
         order.temporary_payment_source = true
         order.complete!
-        expect(order.user.reload.wallet.default_wallet_payment_source).to be_nil
+        expect(order.user.reload.wallet.default_payment_source).to be_nil
       end
     end
 

--- a/core/spec/models/spree/wallet_spec.rb
+++ b/core/spec/models/spree/wallet_spec.rb
@@ -128,7 +128,7 @@ describe Spree::Wallet, type: :model do
 
       it 'raises an error' do
         expect {
-          wallet.default_wallet_payment_source = other_wallet_credit_card
+          wallet.default_payment_source = other_wallet_credit_card
         }.to raise_error(Spree::Wallet::Unauthorized)
       end
     end

--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -195,12 +195,12 @@ module Spree
       end
 
       if try_spree_current_user && try_spree_current_user.respond_to?(:wallet)
-        @wallet_payment_sources = try_spree_current_user.wallet.wallet_payment_sources
+        @wallet_payment_sources = try_spree_current_user.wallet.payment_sources
         @default_wallet_payment_source = @wallet_payment_sources.detect(&:default) ||
                                          @wallet_payment_sources.first
         # TODO: How can we deprecate this instance variable?  We could try
         # wrapping it in a delegating object that produces deprecation warnings.
-        @payment_sources = try_spree_current_user.wallet.wallet_payment_sources.map(&:payment_source).select { |ps| ps.is_a?(Spree::CreditCard) }
+        @payment_sources = try_spree_current_user.wallet.payment_sources.map(&:payment_source).select { |ps| ps.is_a?(Spree::CreditCard) }
       end
     end
 


### PR DESCRIPTION
Being inside the wallet, it should be expected that all methods adhere
to the wallet class. Therefore, having method names such as below should
be considered redundant.

```ruby
wallet.wallet_payment_sources
wallet.default_wallet_payment_source
```

This would read much better as
```ruby
wallet.payment_sources
wallet.default_payment_source
```

Being inside the wallet class should be enough to know that the payment
sources you are obtaining are the wallet payment sources.