### PR TITLE
Change how line item options are allowed in line items controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Solidus 2.3.0 (master, unreleased)
 
+- Change how line item options are allowed in line items controller. [\#1943](https://github.com/solidusio/solidus/pull/1943)
 - Allow custom separator between a promotion's `base_code` and `suffix` [\#1951](https://github.com/solidusio/solidus/pull/1951) ([ericgross](https://github.com/ericgross))
 - Ignore `adjustment.finalized` on tax adjustments. [\#1936](https://github.com/solidusio/solidus/pull/1936) ([jordan-brough](https://github.com/jordan-brough))
 - Deprecate `#simple_current_order`

--- a/api/app/controllers/spree/api/line_items_controller.rb
+++ b/api/app/controllers/spree/api/line_items_controller.rb
@@ -1,10 +1,6 @@
 module Spree
   module Api
     class LineItemsController < Spree::Api::BaseController
-      class_attribute :line_item_options
-
-      self.line_item_options = []
-
       before_action :load_order, only: [:create, :update, :destroy]
       around_action :lock_order, only: [:create, :update, :destroy]
 
@@ -18,7 +14,7 @@ module Spree
           params[:line_item][:quantity] || 1,
           {
             stock_location_quantities: params[:line_item][:stock_location_quantities]
-          }.merge(line_item_params[:options].to_h || {})
+          }.merge({ options: line_item_params[:options].to_h })
         )
 
         if @line_item.errors.empty?
@@ -66,11 +62,7 @@ module Spree
       end
 
       def line_item_params
-        params.require(:line_item).permit(
-          :quantity,
-            :variant_id,
-            options: line_item_options
-        )
+        params.require(:line_item).permit(permitted_line_item_attributes)
       end
     end
   end

--- a/api/spec/controllers/spree/api/line_items_controller_spec.rb
+++ b/api/spec/controllers/spree/api/line_items_controller_spec.rb
@@ -5,12 +5,9 @@ module Spree
     mattr_writer :line_item_attributes
   end
 
-  unless PermittedAttributes.line_item_attributes.include? :some_option
-    PermittedAttributes.line_item_attributes += [:some_option]
+  unless PermittedAttributes.line_item_attributes.include? :options
+    PermittedAttributes.line_item_attributes << { options: [:some_option] }
   end
-
-  # This should go in an initializer
-  Spree::Api::LineItemsController.line_item_options += [:some_option]
 
   describe Api::LineItemsController, type: :controller do
     render_views

--- a/api/spec/controllers/spree/api/orders_controller_spec.rb
+++ b/api/spec/controllers/spree/api/orders_controller_spec.rb
@@ -65,6 +65,17 @@ module Spree
 
         it { is_expected.to be_success }
       end
+
+      context 'when the line items have custom attributes' do
+        it "can create an order with line items that have custom permitted attributes" do
+          PermittedAttributes.line_item_attributes << { options: [:some_option] }
+          expect_any_instance_of(Spree::LineItem).to receive(:some_option=).once.with('4')
+          api_post :create, order: { line_items: { "0" => { variant_id: variant.to_param, quantity: 5, options: { some_option: 4 } } } }
+          expect(response.status).to eq(201)
+          order = Order.last
+          expect(order.line_items.count).to eq(1)
+        end
+      end
     end
 
     describe "PUT update" do


### PR DESCRIPTION
#1131 

Don't really know if this is the right way.. but old logic and issue reported seemed confusing to me, apparently it was just a bad setup of permitted attributes.

I just had the line items controller changed to make more sense, and got rid of that class attribute.

Permitted controllers are working now, old test are still green and I added a new test to confirm that orders are being created properly with line items with options.