### PR TITLE
Allow admin to edit variant option values

### DIFF
--- a/backend/app/views/spree/admin/variants/_form.html.erb
+++ b/backend/app/views/spree/admin/variants/_form.html.erb
@@ -18,20 +18,24 @@
     </div>
   </fieldset>
   <fieldset class="no-border-top no-border-bottom">
-    <% @product.option_types.each_with_index do |option_type, index| %>
-      <div class="field four columns <%= 'alpha' if index % 3 == 0 %><%= 'omega' if index % 3 == 2 %>" data-hook="presentation">
-        <%= label :new_variant, option_type.presentation %>
-        <%= f.collection_select 'option_value_ids',
-                                option_type.option_values,
-                                :id,
-                                :presentation,
-                                { include_blank: true },
-                                {
-                                  name: 'variant[option_value_ids][]',
-                                  class: "select2 fullwidth"
-                                } %>
-      </div>
-    <% end %>
+    <div class="row">
+      <% @product.option_types.each_with_index do |option_type, index| %>
+          <div class="col-3">
+            <div class="field" data-hook="presentation">
+              <%= label :new_variant, option_type.presentation %>
+              <%= f.collection_select 'option_value_ids',
+                                      option_type.option_values,
+                                      :id,
+                                      :presentation,
+                                      { include_blank: true },
+                                      {
+                                        name: 'variant[option_value_ids][]',
+                                        class: "select2 fullwidth"
+                                      } %>
+            </div>
+          </div>
+      <% end %>
+    </div>
   </fieldset>
 </div>
 

--- a/backend/app/views/spree/admin/variants/_form.html.erb
+++ b/backend/app/views/spree/admin/variants/_form.html.erb
@@ -17,28 +17,22 @@
       </div>
     </div>
   </fieldset>
-  <% if f.object.new_record? %>
-    <fieldset class="no-border-top no-border-bottom">
-      <div class="row">
-      <% @product.option_types.each_with_index do |option_type, index| %>
-          <div class="col-3">
-            <div class="field" data-hook="presentation">
-              <%= label :new_variant, option_type.presentation %>
-              <%= f.collection_select 'option_value_ids',
-                                      option_type.option_values,
-                                      :id,
-                                      :presentation,
-                                      { include_blank: true },
-                                      {
-                                        name: 'variant[option_value_ids][]',
-                                        class: "select2 fullwidth"
-                                      } %>
-            </div>
-          </div>
-      <% end %>
+  <fieldset class="no-border-top no-border-bottom">
+    <% @product.option_types.each_with_index do |option_type, index| %>
+      <div class="field four columns <%= 'alpha' if index % 3 == 0 %><%= 'omega' if index % 3 == 2 %>" data-hook="presentation">
+        <%= label :new_variant, option_type.presentation %>
+        <%= f.collection_select 'option_value_ids',
+                                option_type.option_values,
+                                :id,
+                                :presentation,
+                                { include_blank: true },
+                                {
+                                  name: 'variant[option_value_ids][]',
+                                  class: "select2 fullwidth"
+                                } %>
       </div>
-    </fieldset>
-  <% end %>
+    <% end %>
+  </fieldset>
 </div>
 
 <div data-hook="admin_variant_form_additional_fields">

--- a/backend/spec/features/admin/products/variant_spec.rb
+++ b/backend/spec/features/admin/products/variant_spec.rb
@@ -48,4 +48,24 @@ describe "Variants", type: :feature do
       end
     end
   end
+
+  context "editing existent variant" do
+    let!(:variant) { create(:variant, product: product) }
+
+    context "if product has an option type" do
+      let!(:option_type) { create(:option_type) }
+      let!(:option_value) { create(:option_value, option_type: option_type) }
+
+      before do
+        product.option_types << option_type
+        variant.option_values << option_value
+      end
+
+      it "page has a field for editing the option value", js: true do
+        visit spree.edit_admin_product_variant_path(product, variant)
+        expect(page).to have_css("label", text: option_type.presentation)
+        expect(page).to have_css(".select2-chosen", text: option_value.presentation)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR reverts ce10040a which, on the edit admin product variants form, hid the ability to edit an existent variant's option value from the admin. However, we want maximize the flexibility for admins to edit variants. Thus, we should display this fieldset to the admin.