### PR TITLE
Touch shipment when updating shipment rate

### DIFF
--- a/core/app/models/spree/shipping_rate.rb
+++ b/core/app/models/spree/shipping_rate.rb
@@ -3,7 +3,7 @@ module Spree
   # method has been selected to deliver the shipment.
   #
   class ShippingRate < Spree::Base
-    belongs_to :shipment, class_name: 'Spree::Shipment'
+    belongs_to :shipment, class_name: 'Spree::Shipment', touch: true
     belongs_to :shipping_method, -> { with_deleted }, class_name: 'Spree::ShippingMethod', inverse_of: :shipping_rates
 
     has_many :taxes,


### PR DESCRIPTION
Fixes #1909
If shipment rate is updated it does not touch shipments, and shipments
won't touch the order, leading to a out of sync cached order