### PR TITLE
Allow custom join character separator for promotion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Transform the relation between TaxRate and TaxCategory to a Many to Many [\#1851](https://github.com/solidusio/solidus/pull/1851) ([vladstoick](https://github.com/vladstoick))
 
   This fixes issue [\#1836](https://github.com/solidusio/solidus/issues/1836). By allowing a TaxRate to tax multiple categories, stores don't have to create multiple TaxRates with the same value if a zone doesn't have different tax rates for some tax categories.
+- Allow custom join character separator for promotion [\#1947](https://github.com/solidusio/solidus/pull/1947) ([vladstoick](https://github.com/vladstoick))
 
 
 ## Solidus 2.2.1 (2017-05-09)

--- a/core/app/models/spree/promotion_code/batch_builder.rb
+++ b/core/app/models/spree/promotion_code/batch_builder.rb
@@ -2,10 +2,11 @@ class ::Spree::PromotionCode::BatchBuilder
   attr_reader :promotion_code_batch
   delegate :promotion, :number_of_codes, :base_code, to: :promotion_code_batch
 
-  class_attribute :random_code_length, :batch_size, :sample_characters
+  class_attribute :random_code_length, :batch_size, :sample_characters, :join_character
   self.random_code_length = 6
   self.batch_size = 1_000
   self.sample_characters = ('a'..'z').to_a + (2..9).to_a.map(&:to_s)
+  self.join_character = "_"
 
   def initialize(promotion_code_batch)
     @promotion_code_batch = promotion_code_batch
@@ -54,7 +55,7 @@ class ::Spree::PromotionCode::BatchBuilder
       sample_characters.sample
     end.join
 
-    "#{base_code}_#{suffix}"
+    "#{base_code}#{join_character}#{suffix}"
   end
 
   def get_unique_codes(code_set)


### PR DESCRIPTION
Implements #1946 by setting a class variable that for the join_character that connects the base code with the suffix in the code creation process