### PR TITLE
Fix BigDecimal error in LocalizedNumber in ruby 2.4

### DIFF
--- a/core/lib/spree/localized_number.rb
+++ b/core/lib/spree/localized_number.rb
@@ -21,7 +21,8 @@ module Spree
       # then replace the locale-specific decimal separator with the standard separator if necessary
       number = number.gsub(separator, '.') unless separator == '.'
 
-      number.to_d
+      # Handle empty string for ruby 2.4 compatibility
+      BigDecimal.new(number.presence || 0)
     end
   end
 end

--- a/core/spec/lib/spree/localized_number_spec.rb
+++ b/core/spec/lib/spree/localized_number_spec.rb
@@ -13,6 +13,12 @@ describe Spree::LocalizedNumber do
       I18n.enforce_available_locales = true
     end
 
+    context "with an empty string" do
+      it "parses to 0" do
+        expect(subject.class.parse("")).to eq 0.0
+      end
+    end
+
     context "with decimal point" do
       it "captures the proper amount for a formatted price" do
         expect(subject.class.parse('1,599.99')).to eql 1599.99


### PR DESCRIPTION
In ruby 2.4, calling `to_d` on an empty string raises an ArgumentError. Before it would return `0.0`. This commit rescues from the error and returns zero.

See also:
https://github.com/solidusio/solidus/pull/1872