### PR TITLE
Custom to_partial_path for promotion actions and rules

### DIFF
--- a/backend/app/views/spree/admin/promotions/_promotion_action.html.erb
+++ b/backend/app/views/spree/admin/promotions/_promotion_action.html.erb
@@ -9,6 +9,6 @@
   <%= hidden_field_tag "#{param_prefix}[id]", promotion_action.id %>
 
   <%= render partial: "spree/shared/error_messages", locals: { target: promotion_action } %>
-  <%= render partial: "spree/admin/promotions/actions/#{type_name}",
+  <%= render partial: promotion_action.to_partial_path,
              locals: { promotion_action: promotion_action, param_prefix: param_prefix } %>
 </div>

--- a/backend/app/views/spree/admin/promotions/_promotion_rule.html.erb
+++ b/backend/app/views/spree/admin/promotions/_promotion_rule.html.erb
@@ -8,5 +8,5 @@
   <% param_prefix = "promotion[promotion_rules_attributes][#{promotion_rule.id}]" %>
   <%= hidden_field_tag "#{param_prefix}[id]", promotion_rule.id %>
   <%= render partial: "spree/shared/error_messages", locals: { target: promotion_rule } %>
-  <%= render partial: "spree/admin/promotions/rules/#{type_name}", locals: { promotion_rule: promotion_rule, param_prefix: param_prefix } %>
+  <%= render partial: promotion_rule.to_partial_path, locals: { promotion_rule: promotion_rule, param_prefix: param_prefix } %>
 </div>

--- a/core/app/models/spree/promotion_action.rb
+++ b/core/app/models/spree/promotion_action.rb
@@ -36,5 +36,9 @@ module Spree
         end
       end
     end
+
+    def to_partial_path
+      "spree/admin/promotions/actions/#{model_name.element}"
+    end
   end
 end

--- a/core/app/models/spree/promotion_rule.rb
+++ b/core/app/models/spree/promotion_rule.rb
@@ -30,6 +30,10 @@ module Spree
       @eligibility_errors ||= ActiveModel::Errors.new(self)
     end
 
+    def to_partial_path
+      "spree/admin/promotions/rules/#{model_name.element}"
+    end
+
     private
 
     def unique_per_promotion

--- a/core/spec/models/spree/promotion_action_spec.rb
+++ b/core/spec/models/spree/promotion_action_spec.rb
@@ -22,6 +22,10 @@ describe Spree::PromotionAction, type: :model do
       @action_adjustment = order.adjustments.where(source: action).first!
     end
 
+    it "generates its own partial path" do
+      expect(action.to_partial_path).to eq 'spree/admin/promotions/actions/my_promotion_action'
+    end
+
     it 'removes the action adjustment' do
       expect(order.adjustments).to match_array([other_adjustment, @action_adjustment])
 

--- a/core/spec/models/spree/promotion_rule_spec.rb
+++ b/core/spec/models/spree/promotion_rule_spec.rb
@@ -23,5 +23,10 @@ module Spree
       p2.promotion_id = 1
       expect(p2).not_to be_valid
     end
+
+    it "generates its own partial path" do
+      rule = TestRule.new
+      expect(rule.to_partial_path).to eq 'spree/admin/promotions/rules/test_rule'
+    end
   end
 end


### PR DESCRIPTION
We are currently hardcoding a string-interpolated path when rendering promo action/rules partials.
Because `Spree::PromotionRule` and `Spree::PromotionAction` are not namespaced to admin, calling the rails helper method `_to_partial_path` results in the incorrect path. 

Here I have added custom methods to the base classes for actions and rules, so that any action can call `#to_partial_path` on itself and return the correctly formatted path.