### PR TITLE
Allow flexible separator for promotion code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Transform the relation between TaxRate and TaxCategory to a Many to Many [\#1851](https://github.com/solidusio/solidus/pull/1851) ([vladstoick](https://github.com/vladstoick))
 
   This fixes issue [\#1836](https://github.com/solidusio/solidus/issues/1836). By allowing a TaxRate to tax multiple categories, stores don't have to create multiple TaxRates with the same value if a zone doesn't have different tax rates for some tax categories.
-
+- [\#1951](https://github.com/solidusio/solidus/pull/1951) Allow custom separator between a promotion's `base_code` and `suffix` 
 
 ## Solidus 2.2.1 (2017-05-09)
 

--- a/core/app/models/spree/promotion_code/batch_builder.rb
+++ b/core/app/models/spree/promotion_code/batch_builder.rb
@@ -2,10 +2,11 @@ class ::Spree::PromotionCode::BatchBuilder
   attr_reader :promotion_code_batch
   delegate :promotion, :number_of_codes, :base_code, to: :promotion_code_batch
 
-  class_attribute :random_code_length, :batch_size, :sample_characters
+  class_attribute :random_code_length, :batch_size, :sample_characters, :join_characters
   self.random_code_length = 6
   self.batch_size = 1_000
   self.sample_characters = ('a'..'z').to_a + (2..9).to_a.map(&:to_s)
+  self.join_characters = "_"
 
   def initialize(promotion_code_batch)
     @promotion_code_batch = promotion_code_batch
@@ -54,7 +55,7 @@ class ::Spree::PromotionCode::BatchBuilder
       sample_characters.sample
     end.join
 
-    "#{base_code}_#{suffix}"
+    "#{base_code}#{join_characters}#{suffix}"
   end
 
   def get_unique_codes(code_set)

--- a/core/spec/models/spree/promotion_code/batch_builder_spec.rb
+++ b/core/spec/models/spree/promotion_code/batch_builder_spec.rb
@@ -12,7 +12,7 @@ describe Spree::PromotionCode::BatchBuilder do
     )
   end
 
-  subject { described_class.new promotion_code_batch }
+  subject { described_class.new(promotion_code_batch) }
 
   describe "#build_promotion_codes" do
     context "with a failed build" do
@@ -27,6 +27,7 @@ describe Spree::PromotionCode::BatchBuilder do
         expect(promotion_code_batch.reload.state).to eq("failed")
       end
     end
+
     context "with a successful build" do
       before do
         allow(Spree::PromotionCodeBatchMailer)
@@ -48,13 +49,34 @@ describe Spree::PromotionCode::BatchBuilder do
         expect(subject.promotion.codes.map(&:value).uniq.size).to eq(10)
       end
 
+      it "updates the promotion code batch state to completed" do
+        expect(promotion_code_batch.state).to eq("completed")
+      end
+    end
+  end
+
+  describe "#join_character" do
+    context "with the default join charachter _" do
       it "builds codes with the same base prefix" do
+        subject.build_promotion_codes
+
         values = subject.promotion.codes.map(&:value)
         expect(values.all? { |val| val.starts_with?("#{base_code}_") }).to be true
       end
+    end
 
-      it "updates the promotion code batch state to completed" do
-        expect(promotion_code_batch.state).to eq("completed")
+    context "with a custom join separator" do
+      around do |example|
+        Spree::PromotionCode::BatchBuilder.join_characters = "x"
+        example.run
+        Spree::PromotionCode::BatchBuilder.join_characters = "_"
+      end
+
+      it "builds codes with the same base prefix" do
+        subject.build_promotion_codes
+
+        values = subject.promotion.codes.map(&:value)
+        expect(values.all? { |val| val.starts_with?("#{base_code}x") }).to be true
       end
     end
   end


### PR DESCRIPTION
Rather than always seperating the promotion base_code from the suffix
with an underscore (_), allow a seperator to be specified.