### PR TITLE
Add Spree::Admin::NavigationHelper#solidus_icon

### DIFF
--- a/backend/app/helpers/spree/admin/navigation_helper.rb
+++ b/backend/app/helpers/spree/admin/navigation_helper.rb
@@ -116,9 +116,12 @@ module Spree
         link_to(text, url, options)
       end
 
-      def icon(icon_name)
+      def solidus_icon(icon_name)
         icon_name ? content_tag(:i, '', class: icon_name) : ''
       end
+
+      alias_method :icon, :solidus_icon
+      deprecate icon: :solidus_icon, deprecator: Spree::Deprecation
 
       def button(text, icon_name = nil, button_type = 'submit', options = {})
         class_names = "button"

--- a/backend/spec/helpers/admin/navigation_helper_spec.rb
+++ b/backend/spec/helpers/admin/navigation_helper_spec.rb
@@ -110,4 +110,27 @@ describe Spree::Admin::NavigationHelper, type: :helper do
       expect(link).to include("data-confirm=\"Please confirm.\"")
     end
   end
+
+  describe "#solidus_icon" do
+    context "if given an icon_name" do
+      subject(:solidus_icon) { helper.solidus_icon('example-icon-name') }
+
+      it { is_expected.to eq "<i class=\"example-icon-name\"></i>" }
+    end
+
+    context "if not given nil icon_name" do
+      subject(:solidus_icon) { helper.solidus_icon(nil) }
+
+      it { is_expected.to eq "" }
+    end
+  end
+
+  describe "#icon" do
+    subject(:icon) { helper.icon('icon-name') }
+
+    it "is a deprecated way to use #solidus_icon" do
+      expect(Spree::Deprecation).to receive(:warn).with("icon is deprecated and will be removed from Solidus 3.0 (use solidus_icon instead)", instance_of(Array))
+      expect(subject).to eq helper.solidus_icon('icon-name')
+    end
+  end
 end


### PR DESCRIPTION
This PR deprecates Spree::Admin::NavigationHelper#icon as both solidus and font-awesome-sass uses the #icon method. By switching to to a #solidus_icon method, we avoid helper method conflict.

See issue https://github.com/solidusio/solidus/issues/610 for details.