### PR TITLE
Add validity period for Spree::TaxRate

### DIFF
--- a/backend/app/views/spree/admin/tax_rates/_form.html.erb
+++ b/backend/app/views/spree/admin/tax_rates/_form.html.erb
@@ -32,6 +32,20 @@
             <%= f.check_box :show_rate_in_label %>
             <%= f.label :show_rate_in_label, Spree.t(:show_rate_in_label) %>
           </div>
+
+          <div class="date-range-filter field">
+            <%= label_tag :validity_period, Spree.t(:validity_period) %>
+            <%= admin_hint Spree.t(:validity_period), Spree.t(:validity_period, scope: [:hints, "spree/tax_rate"]) %>
+            <div class="date-range-fields input-group">
+              <%= f.text_field :starts_at, class: 'datepicker form-control datepicker-from', value: datepicker_field_value(f.object.starts_at), placeholder: Spree::TaxRate.human_attribute_name(:starts_at) %>
+
+              <span class="range-divider input-group-addon">
+                <i class="fa fa-arrow-right"></i>
+              </span>
+
+              <%= f.text_field :expires_at, class: 'datepicker form-control datepicker-to', value: datepicker_field_value(f.object.expires_at), placeholder: Spree::TaxRate.human_attribute_name(:expires_at) %>
+            </div>
+          </div>
         </div>
       </div>
     </fieldset>

--- a/backend/app/views/spree/admin/tax_rates/index.html.erb
+++ b/backend/app/views/spree/admin/tax_rates/index.html.erb
@@ -20,7 +20,8 @@
       <col style="width: 15%">
       <col style="width: 10%">
       <col style="width: 10%">
-      <col style="width: 10%">
+      <col style="width: 5%">
+      <col style="width: 5%">
       <col style="width: 10%">
       <col style="width: 15%">
       <col style="width: 15%">
@@ -33,6 +34,7 @@
         <th><%= Spree::TaxRate.human_attribute_name(:amount) %></th>
         <th><%= Spree::TaxRate.human_attribute_name(:included_in_price) %></th>
         <th><%= Spree::TaxRate.human_attribute_name(:show_rate_in_label) %></th>
+        <th><%= Spree::TaxRate.human_attribute_name(:expires_at) %></th>
         <th><%= Spree::Calculator.model_name.human %></th>
         <th class="actions"></th>
       </tr>
@@ -52,6 +54,7 @@
         <td class="align-center"><%=tax_rate.amount %></td>
         <td class="align-center"><%=tax_rate.included_in_price? ? Spree.t(:say_yes) : Spree.t(:say_no) %></td>
         <td class="align-center"><%=tax_rate.show_rate_in_label? ? Spree.t(:say_yes) : Spree.t(:say_no) %></td>
+        <td class="align-center"><%=tax_rate.expires_at.to_date.to_s(:short_date) if tax_rate.expires_at %></td>
         <td class="align-center"><%=tax_rate.calculator.to_s %></td>
         <td class="actions">
           <% if can?(:update, tax_rate) %>

--- a/core/app/models/spree/calculator/default_tax.rb
+++ b/core/app/models/spree/calculator/default_tax.rb
@@ -8,6 +8,7 @@ module Spree
     # Orders created before Spree 2.1 had tax adjustments applied to the order, as a whole.
     # Orders created with Spree 2.2 and after, have them applied to the line items individually.
     def compute_order(order)
+      return 0 unless rate.active?
       matched_line_items = order.line_items.select do |line_item|
         rate.tax_categories.include?(line_item.tax_category)
       end
@@ -23,6 +24,7 @@ module Spree
 
     # When it comes to computing shipments or line items: same same.
     def compute_item(item)
+      return 0 unless rate.active?
       if rate.included_in_price
         deduced_total_by_rate(item, rate)
       else

--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -98,6 +98,11 @@ module Spree
       calculator.compute(item)
     end
 
+    def active?
+      (starts_at.nil? || starts_at < Time.current) &&
+        (expires_at.nil? || expires_at > Time.current)
+    end
+
     def adjustment_label(amount)
       Spree.t(
         translation_key(amount),

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -349,6 +349,8 @@ en:
         included_in_price: Included In Price
         name: Name
         show_rate_in_label: Show Rate In Label
+        starts_at: Start date
+        expires_at: Expiration date
       spree/taxon:
         description: Description
         icon: Icon
@@ -1271,6 +1273,8 @@ en:
         deleted: "Deleted Variant"
         deleted_explanation: "This variant was deleted on %{date}."
         deleted_explanation_with_replacement: "This variant was deleted on %{date}. It has since been replaced by another with the same SKU."
+      spree/tax_rate:
+        validity_period: "This determines the validity period within which the tax rate is valid and will be applied to eligible items. <br /> If no start date value is specified, the tax rate will be immediately available. <br /> If no expiration date value is specified, the tax rate will never expire"
     failed_payment_attempts: Failed Payment Attempts
     failure: Failure
     filename: Filename
@@ -2031,6 +2035,7 @@ en:
       is_too_large: is too large -- stock on hand cannot cover requested quantity!
       must_be_int: must be an integer
       must_be_non_negative: must be a non-negative value
+    validity_period: Validity Period
     value: Value
     variant: Variant
     variant_placeholder: Choose a variant

--- a/core/db/migrate/20170522143442_add_time_range_to_tax_rate.rb
+++ b/core/db/migrate/20170522143442_add_time_range_to_tax_rate.rb
@@ -1,0 +1,6 @@
+class AddTimeRangeToTaxRate < ActiveRecord::Migration[5.0]
+  def change
+    add_column :spree_tax_rates, :starts_at, :datetime
+    add_column :spree_tax_rates, :expires_at, :datetime
+  end
+end

--- a/core/spec/models/spree/tax_rate_spec.rb
+++ b/core/spec/models/spree/tax_rate_spec.rb
@@ -264,4 +264,74 @@ describe Spree::TaxRate, type: :model do
       end
     end
   end
+
+  describe "#active?" do
+    subject(:rate) { create(:tax_rate, validity).active? }
+
+    context "when validity is not set" do
+      let(:validity) { {} }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context "when starts_at is set" do
+      context "now" do
+        let(:validity) { { starts_at: DateTime.now } }
+
+        it { is_expected.to eq(true) }
+      end
+
+      context "in the past" do
+        let(:validity) { { starts_at: 1.day.ago } }
+
+        it { is_expected.to eq(true) }
+      end
+
+      context "in the future" do
+        let(:validity) { { starts_at: 1.day.from_now } }
+
+        it { is_expected.to eq(false) }
+      end
+    end
+
+    context "when expires_at is set" do
+      context "now" do
+        let(:validity) { { expires_at: DateTime.now } }
+
+        it { is_expected.to eq(false) }
+      end
+
+      context "in the past" do
+        let(:validity) { { expires_at: 1.day.ago } }
+
+        it { is_expected.to eq(false) }
+      end
+
+      context "in the future" do
+        let(:validity) { { expires_at: 1.day.from_now } }
+
+        it { is_expected.to eq(true) }
+      end
+    end
+
+    context "when starts_at and expires_at are set" do
+      context "so that today is in range" do
+        let(:validity) { { starts_at: 1.day.ago, expires_at: 1.day.from_now } }
+
+        it { is_expected.to eq(true) }
+      end
+
+      context "both in the past" do
+        let(:validity) { { starts_at: 2.days.ago, expires_at: 1.day.ago } }
+
+        it { is_expected.to eq(false) }
+      end
+
+      context "both in the future" do
+        let(:validity) { { starts_at: 1.day.from_now, expires_at: 2.days.from_now } }
+
+        it { is_expected.to eq(false) }
+      end
+    end
+  end
 end


### PR DESCRIPTION
This code adds a valid_from and valid_until datetime field to `Spree::TaxRate` so that tax rates can be scoped in time.

Null values will be treated as valid so that a tax rate is valid by default and you can just ignore this feature if you don't need it.

The `Spree::Calculator::DefaultTax` will always return 0 in case the tax rate is not in its validity period.

I was unsure how to implement it so I started with a scope but ended up thinking it's not really needed. @mamhoff if you could point me in the right direction I'd refactor it.

Ref. #1857