### PR TITLE
Rename assign_default_addresses! to assign_default_user_addresses!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Solidus 2.3.0 (master, unreleased)
 
+- Deprecate `Spree::Order#assign_default_addresses!` in favor of `Order.new.assign_default_user_addresses`. [\#1954](https://github.com/solidusio/solidus/pull/1954) ([kennyadsl](https://github.com/kennyadsl))
 - Change how line item options are allowed in line items controller. [\#1943](https://github.com/solidusio/solidus/pull/1943)
 - Allow custom separator between a promotion's `base_code` and `suffix` [\#1951](https://github.com/solidusio/solidus/pull/1951) ([ericgross](https://github.com/ericgross))
 - Ignore `adjustment.finalized` on tax adjustments. [\#1936](https://github.com/solidusio/solidus/pull/1936) ([jordan-brough](https://github.com/jordan-brough))

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -707,6 +707,8 @@ module Spree
         self.ship_address ||= user.ship_address if user.ship_address.try!(:valid?) && checkout_steps.include?("delivery")
       end
     end
+    alias_method :assign_default_addresses!, :assign_default_user_addresses!
+    deprecate assign_default_addresses!: :assign_default_user_addresses!, deprecator: Spree::Deprecation
 
     def persist_user_address!
       if !temporary_address && user && user.respond_to?(:persist_order_address) && bill_address_id

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -698,7 +698,7 @@ module Spree
       self.ship_address = Spree::Address.immutable_merge(ship_address, attributes)
     end
 
-    def assign_default_addresses!
+    def assign_default_user_addresses!
       if user
         # this is one of 2 places still using User#bill_address
         self.bill_address ||= user.bill_address if user.bill_address.try!(:valid?)

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -90,7 +90,7 @@ module Spree
             before_transition from: :cart, do: :ensure_line_items_present
 
             if states[:address]
-              before_transition to: :address, do: :assign_default_addresses!
+              before_transition to: :address, do: :assign_default_user_addresses!
               before_transition from: :address, do: :persist_user_address!
             end
 

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -785,10 +785,10 @@ describe Spree::Order, type: :model do
     end
   end
 
-  context "#assign_default_addresses!" do
+  context "#assign_default_user_addresses!" do
     let(:order) { Spree::Order.new }
 
-    subject { order.assign_default_addresses! }
+    subject { order.assign_default_user_addresses! }
 
     context "when no user is associated to the order" do
       it "does not associate any bill address" do


### PR DESCRIPTION
This one is just for better documenting code via a method name. I think it makes more clear that we are taking addresses from the user and not building a generic (empty) address like it happens [here](https://github.com/solidusio/solidus/blob/9c503a42c2adbf822ef2923bc58caf8344ffbcd4/frontend/app/controllers/spree/checkout_controller.rb#L173-L179).

This PR is related to #1811 