### PR TITLE
Store default currency used when editing a product

### DIFF
--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -32,7 +32,8 @@
       <div data-hook="admin_product_form_price">
         <%= f.field_container :price do %>
           <%= f.label :price, class: 'required' %>
-          <%= render "spree/admin/shared/number_with_currency", f: f, amount_attr: :price, currency: @product.find_or_build_master.default_price.currency %>
+          <%= render "spree/admin/shared/number_with_currency", f: f, amount_attr: :price,
+                     currency: Spree::Config.default_pricing_options.currency %>
           <%= f.error_message_on :price %>
         <% end %>
       </div>

--- a/backend/spec/features/admin/products/products_spec.rb
+++ b/backend/spec/features/admin/products/products_spec.rb
@@ -69,6 +69,23 @@ describe "Products", type: :feature do
           end
         end
       end
+      context "when none of the product prices are in the same currency as the default in the store" do
+        before do
+          Spree::Config[:currency] = "MXN"
+        end
+
+        let!(:product) do
+          create(:product, name: "Just a product", price: 19.99)
+        end
+
+        it 'defaults it to Spree::Config.currency and sets the price as blank' do
+          Spree::Config[:currency] = "USD"
+          visit spree.admin_product_path(product)
+          within("#product_price_field") do
+            expect(page).to have_content("USD")
+          end
+        end
+      end
     end
 
     context "searching products" do


### PR DESCRIPTION
Fixes #1859
If a product has prices in other currencies except in Store default
currency, it defaults it to that currency and sets the price to blank