### PR TITLE
Add hidden seeds from migrations

### DIFF
--- a/core/db/default/spree/refund_reasons.rb
+++ b/core/db/default/spree/refund_reasons.rb
@@ -1,0 +1,1 @@
+Spree::RefundReason.find_or_create_by(name: "Return processing")

--- a/core/db/default/spree/shipping_categories.rb
+++ b/core/db/default/spree/shipping_categories.rb
@@ -1,0 +1,1 @@
+Spree::ShippingCategory.find_or_create_by(name: "Default")

--- a/core/db/default/spree/stock_locations.rb
+++ b/core/db/default/spree/stock_locations.rb
@@ -1,0 +1,2 @@
+Spree::StockLocation.create_with(backorderable_default: true)
+                    .find_or_create_by!(name: 'default')

--- a/core/db/default/spree/stores.rb
+++ b/core/db/default/spree/stores.rb
@@ -2,9 +2,8 @@
 unless Spree::Store.where(code: 'spree').exists?
   Spree::Store.new do |s|
     s.code              = 'spree'
-    s.name              = 'Spree Demo Site'
-    s.url               = 'demo.spreecommerce.com'
-    s.mail_from_address = 'spree@example.com'
-    s.cart_tax_country_iso = 'US'
+    s.name              = 'Sample Store'
+    s.url               = 'example.com'
+    s.mail_from_address = 'store@example.com'
   end.save!
 end


### PR DESCRIPTION
As requested in issue #1502 I'm adding seeds for data previously created only in migrations.
I've added only what I thought would be necessary, see the [comment](https://github.com/solidusio/solidus/issues/1502#issuecomment-303378552) for the complete list