### PR TITLE
Create multiple page states for stock transfers

### DIFF
--- a/backend/app/views/spree/admin/stock_transfers/_search.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/_search.html.erb
@@ -1,0 +1,51 @@
+<% content_for :table_filter do %>
+  <div data-hook="admin_stock_transfers_index_search">
+    <%= search_form_for [:admin, @search] do |f| %>
+      <div class="field-block alpha four columns">
+        <div class="field">
+          <%= f.label nil, Spree::StockLocation.model_name.human %>
+          <%= f.select :source_location_id_or_destination_location_id_eq, options_from_collection_for_select(@stock_locations, :id, :name, params[:q][:source_location_id_or_destination_location_id_eq]), {include_blank: true}, {class: 'select2 fullwidth'} %>
+        </div>
+      </div>
+
+      <div class="field-block alpha four columns">
+        <div class="date-range-filter field">
+          <%= f.label nil, Spree.t(:date_range) %>
+          <div class="date-range-fields">
+            <%= f.text_field :created_at_gt, class: 'datepicker datepicker-from', include_blank: true, value: params[:q][:created_at_gt], placeholder: Spree.t(:start) %>
+
+            <span class="range-divider">
+              <i class="fa fa-arrow-right"></i>
+            </span>
+
+            <%= f.text_field :created_at_lt, class: 'datepicker datepicker-to', include_blank: true, value: params[:q][:created_at_lt], placeholder: Spree.t(:stop) %>
+          </div>
+        </div>
+      </div>
+
+      <div class="field-block alpha four columns">
+        <div class="field">
+          <%= f.label nil, Spree::StockTransfer.human_attribute_name(:number) %>
+          <%= f.text_field :number_cont, value: params[:q][:number_cont] %>
+        </div>
+      </div>
+
+      <div class="field-block alpha four columns">
+        <div class="field checkbox">
+          <label>
+            <%= f.check_box :closed_at_null, { checked: @show_only_open }, '1', '0' %>
+            <%= Spree.t(:show_only_open_transfers) %>
+          </label>
+        </div>
+      </div>
+
+      <div class="clearfix"></div>
+
+      <div class="actions filter-actions">
+        <div data-hook="admin_stock_transfers_index_search_buttons">
+          <%= button Spree.t(:filter_results), 'search' %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+<% end %>

--- a/backend/app/views/spree/admin/stock_transfers/_stock_transfer_table.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/_stock_transfer_table.html.erb
@@ -1,0 +1,46 @@
+<% if @stock_transfers.any? %>
+  <%= render 'search' if @stock_transfers.size > 9 || params[:q].present? %>
+
+  <table class="index" id="listing_stock_transfers">
+    <thead>
+      <tr>
+        <th><%= sort_link @search, :number,          Spree.t(:number) %></th>
+        <th><%= sort_link @search, :from,            Spree.t(:from) %></th>
+        <th><%= sort_link @search, :to,              Spree.t(:to) %></th>
+        <th><%= sort_link @search, :expected_items,  Spree.t(:expected) %></th>
+        <th><%= sort_link @search, :received_items,  Spree.t(:received) %></th>
+        <th><%= sort_link @search, :shipped_at,      Spree.t(:shipped) %></th>
+        <th><%= sort_link @search, :status,          Spree.t(:status) %></th>
+        <th class="actions"></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @stock_transfers.each do |stock_transfer| %>
+        <tr id="<%= spree_dom_id stock_transfer %>" class="<%= cycle('odd', 'even') %>">
+          <td><%= handle_stock_transfer(stock_transfer) %></td>
+          <td><%= stock_transfer.source_location.name %></td>
+          <td><%= stock_transfer.destination_location.try(:name) %></td>
+          <td class="align-center"><%= stock_transfer.expected_item_count %></td>
+          <td class="align-center"><%= stock_transfer.received_item_count %></td>
+          <td><%= stock_transfer.shipped_at.try(:to_date) %></td>
+          <td><%= stock_transfer_status(stock_transfer) %></td>
+          <td class="actions">
+            <% if stock_transfer.receivable? && can?(:edit, stock_transfer) %>
+              <%= link_to_with_icon 'download', Spree.t('actions.receive'), receive_admin_stock_transfer_path(stock_transfer), no_text: true, data: { action: 'green' } %>
+            <% elsif !stock_transfer.closed? && can?(:edit, stock_transfer) %>
+              <%= link_to_with_icon 'edit', Spree.t('actions.edit'), stock_transfer_edit_or_ship_path(stock_transfer), no_text: true, data: { action: 'edit' } %>
+            <% elsif can?(:show, stock_transfer) %>
+              <%= link_to_with_icon 'eye', Spree.t(:show), admin_stock_transfer_path(stock_transfer), no_text: true, data: { action: 'green' } %>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <div class="alpha sixteen columns no-objects-found">
+    <%= render 'spree/admin/shared/no_objects_found',
+                  resource: Spree::StockTransfer,
+                  new_resource_url: new_object_url %>
+  </div>
+<% end %>

--- a/backend/app/views/spree/admin/stock_transfers/index.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/index.html.erb
@@ -1,7 +1,6 @@
 <% admin_breadcrumb(link_to Spree.t(:stock), spree.admin_stock_items_path) %>
 <% admin_breadcrumb(plural_resource_name(Spree::StockTransfer)) %>
 
-
 <% content_for :page_actions do %>
   <% if can? :create, Spree::StockTransfer %>
     <li>
@@ -14,105 +13,14 @@
   <%= Spree.t(:search) %>
 <% end %>
 
-<% content_for :table_filter do %>
-  <div data-hook="admin_stock_transfers_index_search">
-    <%= search_form_for [:admin, @search] do |f| %>
-      <div class="row">
-        <div class="field-block col-3">
-          <div class="field">
-            <%= f.label nil, Spree::StockLocation.model_name.human %>
-            <%= f.select :source_location_id_or_destination_location_id_eq, options_from_collection_for_select(@stock_locations, :id, :name, params[:q][:source_location_id_or_destination_location_id_eq]), {include_blank: true}, {class: 'select2 fullwidth'} %>
-          </div>
-        </div>
-
-        <div class="field-block col-3">
-          <div class="date-range-filter field">
-            <%= f.label nil, Spree.t(:date_range) %>
-            <div class="date-range-fields input-group">
-              <%= f.text_field :created_at_gt, class: 'datepicker datepicker-from form-control', include_blank: true, value: params[:q][:created_at_gt], placeholder: Spree.t(:start) %>
-
-              <span class="range-divider input-group-addon">
-                <i class="fa fa-arrow-right"></i>
-              </span>
-
-              <%= f.text_field :created_at_lt, class: 'datepicker datepicker-to form-control', include_blank: true, value: params[:q][:created_at_lt], placeholder: Spree.t(:stop) %>
-            </div>
-          </div>
-        </div>
-
-        <div class="field-block col-3">
-          <div class="field">
-            <%= f.label nil, Spree::StockTransfer.human_attribute_name(:number) %>
-            <%= f.text_field :number_cont, value: params[:q][:number_cont] %>
-          </div>
-        </div>
-
-        <div class="field-block col-3">
-          <div class="field checkbox">
-            <label>
-              <%= f.check_box :closed_at_null, { checked: @show_only_open }, '1', '0' %>
-              <%= Spree.t(:show_only_open_transfers) %>
-            </label>
-          </div>
-        </div>
-      </div>
-
-      <div class="clearfix"></div>
-
-      <div class="actions filter-actions">
-        <div data-hook="admin_stock_transfers_index_search_buttons">
-          <%= button Spree.t(:filter_results) %>
-        </div>
-      </div>
-    <% end %>
-  </div>
-<% end %>
-
 <%= paginate @stock_transfers, theme: "solidus_admin" %>
 
-
-<% if @stock_transfers.any? %>
-  <table class="index" id="listing_stock_transfers">
-    <thead>
-      <tr>
-        <th><%= sort_link @search, :number,          Spree.t(:number) %></th>
-        <th><%= sort_link @search, :from,            Spree.t(:from) %></th>
-        <th><%= sort_link @search, :to,              Spree.t(:to) %></th>
-        <th><%= sort_link @search, :expected_items,  Spree.t(:expected) %></th>
-        <th><%= sort_link @search, :received_items,  Spree.t(:received) %></th>
-        <th><%= sort_link @search, :shipped_at,      Spree.t(:shipped) %></th>
-        <th><%= sort_link @search, :status,          Spree.t(:status) %></th>
-        <th class="actions"></th>
-      </tr>
-    </thead>
-    <tbody>
-      <% @stock_transfers.each do |stock_transfer| %>
-        <tr id="<%= spree_dom_id stock_transfer %>" class="<%= cycle('odd', 'even') %>">
-          <td><%= handle_stock_transfer(stock_transfer) %></td>
-          <td><%= stock_transfer.source_location.name %></td>
-          <td><%= stock_transfer.destination_location.try(:name) %></td>
-          <td class="align-center"><%= stock_transfer.expected_item_count %></td>
-          <td class="align-center"><%= stock_transfer.received_item_count %></td>
-          <td><%= stock_transfer.shipped_at.try(:to_date) %></td>
-          <td><%= stock_transfer_status(stock_transfer) %></td>
-          <td class="actions">
-            <% if stock_transfer.receivable? && can?(:edit, stock_transfer) %>
-              <%= link_to_with_icon 'download', Spree.t('actions.receive'), receive_admin_stock_transfer_path(stock_transfer), no_text: true, data: { action: 'green' } %>
-            <% elsif !stock_transfer.closed? && can?(:edit, stock_transfer) %>
-              <%= link_to_with_icon 'edit', Spree.t('actions.edit'), stock_transfer_edit_or_ship_path(stock_transfer), no_text: true, data: { action: 'edit' } %>
-            <% elsif can?(:show, stock_transfer) %>
-              <%= link_to_with_icon 'eye', Spree.t(:show), admin_stock_transfer_path(stock_transfer), no_text: true, data: { action: 'green' } %>
-            <% end %>
-          </td>
-        </tr>
-      <% end %>
-    </tbody>
-  </table>
+<% if @stock_locations.any? %>
+  <%= render 'stock_transfer_table' %>
 <% else %>
-  <div class="col-9 no-objects-found">
-    <%= render 'spree/admin/shared/no_objects_found',
-                  resource: Spree::StockTransfer,
-                  new_resource_url: new_object_url %>
+  <div class="alpha sixteen columns no-objects-found">
+    <%= Spree.t("admin.stock_transfers.no_stock_locations_found") %>
+    <%= link_to Spree.t("admin.stock_transfers.create_additional_stock_location"), new_admin_stock_location_path %>
   </div>
 <% end %>
 

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -941,6 +941,10 @@ en:
           use_product_tax_category: Use Product Tax Category
           pricing: Pricing
           pricing_hint: These values are populated from the product details page and can be overridden below
+      stock_transfers:
+        create_additional_stock_location: Create additional stock locations.
+        create_new_stock_transfer: Create a new stock transfer.
+        no_stock_locations_found: More than one stock location must be set to transfer stock.
     administration: Administration
     agree_to_privacy_policy: Agree to Privacy Policy
     agree_to_terms_of_service: Agree to Terms of Service
@@ -1220,6 +1224,7 @@ en:
       messages:
         cannot_modify_transfer_item_closed_stock_transfer: Transfer items that are part of a closed stock transfer cannot be modified.
         cannot_delete_finalized_stock_transfer: Finalized stock transfers cannot be destroyed.
+        cannot_delete_finalized_stock_location: Stock Location cannot be destroyed if you have open stock transfers.
         cannot_delete_transfer_item_with_finalized_stock_transfer: Transfer items that are part of a finalized stock transfer cannot be destroyed.
         cannot_update_expected_transfer_item_with_finalized_stock_transfer: The expected quantity cannot be updated on transfer items that are part of a finalized stock transfer.
         could_not_create_taxon: Could not create taxon


### PR DESCRIPTION
This add the changes mentioned on #1201

**State 1: Only one stock location set**
<img width="1440" alt="screen shot 2017-05-23 at 12 01 21 pm" src="https://cloud.githubusercontent.com/assets/957520/26359630/e10fa4c4-3fcd-11e7-8e2e-2ff0e78b70b0.png">

**State 2: Multiple locations exist, no stock transfers have been created**
<img width="1440" alt="screen shot 2017-05-23 at 12 21 23 pm" src="https://cloud.githubusercontent.com/assets/957520/26359661/f8939d1c-3fcd-11e7-846e-bad48247b642.png">

**State 3: Multiple locations exist, less than 10 stock transfers exist**
<img width="1440" alt="screen shot 2017-05-23 at 3 31 40 pm" src="https://cloud.githubusercontent.com/assets/957520/26359693/0d8dc0f8-3fce-11e7-8e23-c0434d1a03ec.png">

**State 4: Multiple locations exist, 10 or more stock transfers exist**
<img width="1439" alt="screen shot 2017-05-23 at 3 32 30 pm" src="https://cloud.githubusercontent.com/assets/957520/26359723/20086f30-3fce-11e7-87f0-ad45e0d53946.png">

**State 5: Keep the search bar when search results are less than 10**
<img width="1439" alt="screen shot 2017-05-23 at 3 32 45 pm" src="https://cloud.githubusercontent.com/assets/957520/26361111/df370242-3fd1-11e7-9b02-d6a6130d35be.png">
