### PR TITLE
Improve style guide flash messages UX

### DIFF
--- a/backend/app/views/spree/admin/style_guide/topics/messaging/_flashes.html.erb
+++ b/backend/app/views/spree/admin/style_guide/topics/messaging/_flashes.html.erb
@@ -5,9 +5,15 @@
 <script>
   $('.trigger-flash').on('click', function(){
     type = $(this).data('flashType');
-    flash = $("<div class='flash'>")
-      .text(type)
-      .addClass(type)
-      .appendTo('.js-flash-wrapper');
+
+    if (!$('.flash.' + type).is('*')) {
+      flash = $("<div class='flash'>")
+        .text(type)
+        .addClass(type)
+        .appendTo('.js-flash-wrapper')
+        .on('click', function() {
+          $(this).remove();
+        });
+    }
   });
 </script>


### PR DESCRIPTION
Make flash messages in the style guide disappear when clicked upon and
avoid showing multiple flash messages of the same instance if clicked
multiple times.

Ref. #1958