### PR TITLE
Use validates_email_format_of gem in EmailValidator

### DIFF
--- a/core/lib/spree/core/validators/email.rb
+++ b/core/lib/spree/core/validators/email.rb
@@ -1,7 +1,14 @@
+require 'validates_email_format_of'
+
 class EmailValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    unless value =~ /\A([^@\.]|[^@\.]([^@\s]*)[^@\.])@([^@\s]+\.)+[^@\s]+\z/
-      record.errors.add(attribute, :invalid, { value: value }.merge!(options))
-    end
+    return if email_validation_messages(value).blank?
+    record.errors.add(attribute, :invalid, { value: value }.merge!(options))
+  end
+
+  private
+
+  def email_validation_messages(value)
+    ValidatesEmailFormatOf.validate_email_format(value)
   end
 end

--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -40,6 +40,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'stringex', '~> 1.5.1'
   s.add_dependency 'truncate_html', '~> 0.9', '>= 0.9.2'
   s.add_dependency 'twitter_cldr', '>= 3.0', '< 5'
+  s.add_dependency 'validates_email_format_of'
 
   s.add_development_dependency 'email_spec', '~> 1.6'
 end

--- a/core/spec/lib/spree/core/validators/email_spec.rb
+++ b/core/spec/lib/spree/core/validators/email_spec.rb
@@ -20,6 +20,7 @@ describe EmailValidator do
   }
   let(:invalid_emails) {
     [
+    '\@email.com',
     'invalid email@email.com',
     '.invalid.email@email.com',
     'invalid.email.@email.com',


### PR DESCRIPTION
This PR replaces a simplistic regular expression that was flagging invalid emails as valid. Instead, we will now use the validates_email_format_of gem to provide more robust email validation. This gem has a superior implementation and is more thoroughly tested.

This PR resolves https://github.com/solidusio/solidus/issues/1794