### PR TITLE
Assign default user addresses in checkout controller

### DIFF
--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -171,8 +171,9 @@ module Spree
     end
 
     def before_address
-      # if the user has a default address, a callback takes care of setting
-      # that; but if he doesn't, we need to build an empty one here
+      @order.assign_default_user_addresses!
+      # If the user has a default address, the previous method call takes care
+      # of setting that; but if he doesn't, we need to build an empty one here
       default = {country_id: Spree::Country.default.id}
       @order.build_bill_address(default) unless @order.bill_address
       @order.build_ship_address(default) if @order.checkout_steps.include?('delivery') && !@order.ship_address

--- a/frontend/spec/controllers/spree/checkout_controller_spec.rb
+++ b/frontend/spec/controllers/spree/checkout_controller_spec.rb
@@ -143,6 +143,13 @@ describe Spree::CheckoutController, type: :controller do
           order.update_columns(ship_address_id: create(:address).id, state: "address")
         end
 
+        context 'landing to address page' do
+          it "tries to associate user addresses to order" do
+            expect(order).to receive(:assign_default_user_addresses!)
+            get :edit
+          end
+        end
+
         context "with a billing and shipping address" do
           subject do
             post :update, params: {

--- a/frontend/spec/features/checkout_spec.rb
+++ b/frontend/spec/features/checkout_spec.rb
@@ -75,6 +75,140 @@ describe "Checkout", type: :feature, inaccessible: true do
     end
   end
 
+  context "displays default user addresses on address step" do
+    before do
+      stock_location.stock_items.update_all(count_on_hand: 1)
+    end
+
+    context "when user is logged in" do
+      let!(:user) do
+        create(:user, bill_address: saved_bill_address, ship_address: saved_ship_address)
+      end
+
+      let!(:order) do
+        order = Spree::Order.create!(
+          email: "spree@example.com",
+          store: Spree::Store.first || FactoryGirl.create(:store)
+        )
+
+        order.reload
+        order.user = user
+        order.update!
+        order
+      end
+
+      before do
+        allow_any_instance_of(Spree::CheckoutController).to receive_messages(current_order: order)
+        allow_any_instance_of(Spree::CheckoutController).to receive_messages(try_spree_current_user: user)
+        allow_any_instance_of(Spree::OrdersController).to receive_messages(try_spree_current_user: user)
+
+        add_mug_to_cart
+        click_button "Checkout"
+        # We need an order reload here to get newly associated addresses.
+        # Then we go back to address where we are supposed to be redirected.
+        order.reload
+        visit spree.checkout_state_path(:address)
+      end
+
+      context "when user has default addresses saved" do
+        let(:saved_bill_address) { create(:address, firstname: 'Bill') }
+        let(:saved_ship_address) { create(:address, firstname: 'Steve') }
+
+        it "shows the saved addresses" do
+          within("#billing") do
+            expect(find_field('First Name').value).to eq 'Bill'
+          end
+
+          within("#shipping") do
+            expect(find_field('First Name').value).to eq 'Steve'
+          end
+        end
+      end
+
+      context "when user does not have default addresses saved" do
+        let(:saved_bill_address) { nil }
+        let(:saved_ship_address) { nil }
+
+        it 'shows an empty address' do
+          within("#billing") do
+            expect(find_field('First Name').value).to be_nil
+          end
+
+          within("#shipping") do
+            expect(find_field('First Name').value).to be_nil
+          end
+        end
+      end
+    end
+
+    context "when user is not logged in" do
+      context "and proceeds with guest checkout" do
+        it 'shows empty addresses' do
+          add_mug_to_cart
+          click_button "Checkout"
+
+          within("#billing") do
+            expect(find_field('First Name').value).to be_nil
+          end
+
+          within("#shipping") do
+            expect(find_field('First Name').value).to be_nil
+          end
+        end
+      end
+
+      context "and proceeds logging in" do
+        let!(:user) do
+          create(:user, bill_address: saved_bill_address, ship_address: saved_ship_address)
+        end
+
+        before do
+          add_mug_to_cart
+          click_button "Checkout"
+
+          # Simulate user login
+          Spree::Order.last.associate_user!(user)
+          allow_any_instance_of(Spree::CheckoutController).to receive_messages(try_spree_current_user: user)
+          allow_any_instance_of(Spree::OrdersController).to receive_messages(try_spree_current_user: user)
+
+          # Simulate redirect back to address after login
+          visit spree.checkout_state_path(:address)
+        end
+
+        context "when does not have saved addresses" do
+          let(:saved_bill_address) { nil }
+          let(:saved_ship_address) { nil }
+
+          it 'shows empty addresses' do
+            within("#billing") do
+              expect(find_field('First Name').value).to be_nil
+            end
+
+            within("#shipping") do
+              expect(find_field('First Name').value).to be_nil
+            end
+          end
+        end
+
+        # Regression test for https://github.com/solidusio/solidus/issues/1811
+        context "when does have saved addresses" do
+          let(:saved_bill_address) { create(:address, firstname: 'Bill') }
+          let(:saved_ship_address) { create(:address, firstname: 'Steve') }
+
+          it 'shows empty addresses' do
+            within("#billing") do
+              expect(find_field('First Name').value).to eq 'Bill'
+            end
+
+            within("#shipping") do
+              expect(find_field('First Name').value).to eq 'Steve'
+            end
+          end
+        end
+      end
+    end
+  end
+
   # Regression test for https://github.com/spree/spree/issues/2694 and https://github.com/spree/spree/issues/4117
   context "doesn't allow bad credit card numbers" do
     before(:each) do


### PR DESCRIPTION
It fixes #1811:

When **cart -> address** state change happens and user is not yet logged in, the `assign_default_addresses!` callback will not associate any address to the order regardless if the user will immediately later perform a login and had some address associated.
By calling `assign_default_addresses!` method in the `before_address` checkout controller's callback we'll be sure we always set addresses correctly before entering the address step.

The only cons I see is that we call this method much often (every time we hit the checkout address page) but it should be safe since, as @aaronrussell pointed out, it does nothing when the order has no user or when the order already has addresses associated.

I'm not sure if we want to remove the state machine callback now and move this functionality at a controller level, but we'll probably want to add `assign_default_addresses!` to backend and api controllers as well.

This PR also adds checkout feature specs that allows to reproduce this issue.