### PR TITLE
Remove unused variable from promotion action partial

### DIFF
--- a/backend/app/views/spree/admin/promotions/_promotion_action.html.erb
+++ b/backend/app/views/spree/admin/promotions/_promotion_action.html.erb
@@ -1,5 +1,4 @@
 <div class="promotion_action promotion-block <%= promotion_action.model_name.element %>" id="<%= dom_id promotion_action %>">
-  <% type_name = promotion_action.model_name.element %>
   <h6 class="promotion-title"><%= promotion_action.class.human_attribute_name(:description) %></h6>
   <% if can?(:destroy, promotion_action) %>
     <%= link_to_with_icon 'trash', '', spree.admin_promotion_promotion_action_path(@promotion, promotion_action), remote: true, method: :delete, class: 'delete' %>


### PR DESCRIPTION
Addendum to https://github.com/solidusio/solidus/pull/1950

The `type_name` variable is no longer used now that partials are rendered
via the `#to_partial_path` method. 