### PR TITLE
Removed Bundler/OrderedGems Cop.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -244,3 +244,5 @@ Metrics/ParameterLists:
 Metrics/PerceivedComplexity:
   Enabled: false
 
+Bundler/OrderedGems:
+  Enabled: false


### PR DESCRIPTION
As per the discussion in PR #1970, this is the followup PR.

"Alphabetical ordering is second to group by functionality /
ordering by importance"

Therefore removing this cop.