### PR TITLE
Deprecate provider in favour of payment method type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@
 - Adjustments without a source are now included in `line_item.adjustment_total`
 [\#1933](https://github.com/solidusio/solidus/pull/1933) ([alexstoick](https://github.com/alexstoick))
 
+### Deprecations
+- Deprecate `PaymentMethod.providers` in favour of `Rails.application.config.spree.payment_methods` [\#1974](https://github.com/solidusio/solidus/pull/1974) ([tvdeyen](https://github.com/tvdeyen))
+- Deprecate `Spree::Admin::PaymentMethodsController#load_providers` in favour of `load_payment_methods` [\#1974](https://github.com/solidusio/solidus/pull/1974) ([tvdeyen](https://github.com/tvdeyen))
+
 ## Solidus 2.2.1 (2017-05-09)
 
 - Fix migrating CreditCards to WalletPaymentSource [\#1898](https://github.com/solidusio/solidus/pull/1898) ([jhawthorn](https://github.com/jhawthorn))

--- a/backend/app/views/spree/admin/payment_methods/_form.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/_form.html.erb
@@ -7,7 +7,7 @@
         <div id="preference-settings">
           <div class="field">
             <%= label :payment_method, :type %>
-            <%= collection_select(:payment_method, :type, @providers, :to_s, :name, {}, {class: 'custom-select fullwidth js-gateway-type'}) %>
+            <%= collection_select(:payment_method, :type, @payment_method_types, :to_s, :name, {}, {class: 'custom-select fullwidth js-gateway-type'}) %>
           </div>
 
           <div class="field js-preference-source-wrapper">
@@ -23,7 +23,7 @@
             <% end %>
           </div>
 
-          <div class="info warning js-gateway-settings-warning"><%= Spree.t(:provider_settings_warning) %></div>
+          <div class="info warning js-gateway-settings-warning"><%= Spree.t(:payment_method_settings_warning) %></div>
         </div>
         <div data-hook="available_to_user" class="field">
           <%= label_tag nil, Spree::PaymentMethod.human_attribute_name(:available_to_users) %>

--- a/backend/spec/features/admin/configuration/payment_methods_spec.rb
+++ b/backend/spec/features/admin/configuration/payment_methods_spec.rb
@@ -16,7 +16,7 @@ describe "Payment Methods", type: :feature do
 
       within("table#listing_payment_methods") do
         expect(all("th")[1].text).to eq("Name")
-        expect(all("th")[2].text).to eq("Provider")
+        expect(all("th")[2].text).to eq("Type")
         expect(all("th")[3].text).to eq("Available to users")
         expect(all("th")[4].text).to eq("Available to admin")
         expect(all("th")[5].text).to eq("Active")
@@ -35,7 +35,7 @@ describe "Payment Methods", type: :feature do
       expect(page).to have_content("New Payment Method")
       fill_in "payment_method_name", with: "check90"
       fill_in "payment_method_description", with: "check90 desc"
-      select "Spree::PaymentMethod::Check", from: "Provider"
+      select "Spree::PaymentMethod::Check", from: "Type"
       click_button "Create"
       expect(page).to have_content("successfully created!")
     end
@@ -76,12 +76,12 @@ describe "Payment Methods", type: :feature do
       click_icon :edit
       expect(page).to have_content('Test Mode')
 
-      select 'Spree::PaymentMethod::Check', from: 'Provider'
+      select 'Spree::PaymentMethod::Check', from: 'Type'
       expect(page).to have_content('you must save first')
       expect(page).to have_no_content('Test Mode')
 
       # change back
-      select 'Spree::PaymentMethod::BogusCreditCard', from: 'Provider'
+      select 'Spree::PaymentMethod::BogusCreditCard', from: 'Type'
       expect(page).to have_no_content('you must save first')
       expect(page).to have_content('Test Mode')
     end

--- a/core/app/models/spree/payment_method.rb
+++ b/core/app/models/spree/payment_method.rb
@@ -39,6 +39,8 @@ module Spree
 
     class << self
       def providers
+        Spree::Deprecation.warn 'Spree::PaymentMethod.providers is deprecated and will be deleted in Solidus 3.0. ' \
+          'Please use Rails.application.config.spree.payment_methods instead'
         Rails.application.config.spree.payment_methods
       end
 

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -137,7 +137,7 @@ en:
         display_on: Display
         name: Name
         preference_source: Preference Source
-        type: Provider
+        type: Type
       spree/price:
         currency: Currency
         amount: Price
@@ -1357,7 +1357,7 @@ en:
     intercept_email_instructions: Override email recipient and replace with this address.
     internal_name: Internal Name
     invalid_exchange_variant: Invalid exchange variant.
-    invalid_payment_provider: Invalid payment provider.
+    invalid_payment_method_type: Invalid payment method type.
     invalid_promotion_action: Invalid promotion action.
     invalid_promotion_rule: Invalid promotion rule.
     invalidate: Invalidate
@@ -1696,7 +1696,7 @@ en:
     properties: Property Types
     property: Property Type
     provider: Provider
-    provider_settings_warning: If you are changing the provider type, you must save first before you can edit the provider settings
+    payment_method_settings_warning: If you are changing the payment method type, you must save first before you can edit the payment method settings
     qty: Qty
     quantity: Quantity
     quantity_returned: Quantity Returned


### PR DESCRIPTION
Payment method types get referenced as providers in the admin payment methods configuration.

In order to remove confusion about what a payment method and a provider actually is we rename usages of provider to payment method type.

Later on a real payment provider class will get introduced, that hold all commons for multiple payment methods, like credentials and api communication through its gateway.