### PR TITLE
Use translated model names in admin payment methods form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@
 - Fix path for distributed amount fields partial [\#2023](https://github.com/solidusio/solidus/pull/2023) ([graygilmore](https://github.com/graygilmore))
 - Use `.all` instead of `.where\(nil\)` in Admin::ResourceController [\#2047](https://github.com/solidusio/solidus/pull/2047) ([jordan-brough](https://github.com/jordan-brough))
 - Fix typo on the new promotions form [\#2035](https://github.com/solidusio/solidus/pull/2035) ([swcraig](https://github.com/swcraig))
+- Use translated model name in admin payment methods form [\#1975](https://github/com/solidusio/solidus/pull/1975) ([tvdeyen](https://github.com/tvdeyen))
+
 
 ### Deprecations
 - Renamed `Spree::Gateway` payment method into `Spree::PaymentMethod::CreditCard` [\#2001](https://github.com/solidusio/solidus/pull/2001) ([tvdeyen](https://github.com/tvdeyen))

--- a/backend/app/controllers/spree/admin/payment_methods_controller.rb
+++ b/backend/app/controllers/spree/admin/payment_methods_controller.rb
@@ -77,13 +77,7 @@ module Spree
       end
 
       def payment_method_params
-        superclass_params = params.require(:payment_method).permit!
-        subclass_params = params[ActiveModel::Naming.param_key(@payment_method_type)] || ActionController::Parameters.new
-
-        superclass_params = superclass_params.permit!
-        subclass_params = subclass_params.permit!
-
-        superclass_params.to_h.merge(subclass_params.to_h)
+        params.require(:payment_method).permit!
       end
     end
   end

--- a/backend/app/views/spree/admin/payment_methods/_form.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/_form.html.erb
@@ -3,11 +3,11 @@
   <div data-hook="payment_method">
 
     <div class="row">
-      <div class="col-3">
+      <div class="col-4">
         <div id="preference-settings">
           <div class="field">
             <%= f.label :type %>
-            <%= f.collection_select :type, @payment_method_types, :to_s, :name, {}, {class: 'custom-select fullwidth js-gateway-type'} %>
+            <%= f.select :type, @payment_method_types.map { |p| [p.model_name.human, p.to_s] }, {}, {class: 'custom-select fullwidth js-gateway-type'} %>
           </div>
 
           <div class="field js-preference-source-wrapper">
@@ -25,34 +25,25 @@
 
           <div class="info warning js-gateway-settings-warning"><%= Spree.t(:payment_method_settings_warning) %></div>
         </div>
-        <div data-hook="available_to_user" class="field">
-          <%= label_tag nil, Spree::PaymentMethod.human_attribute_name(:available_to_users) %>
-          <%= f.check_box :available_to_users %>
-        </div>
-        <div data-hook="available_to_user" class="field">
-          <%= label_tag nil, Spree::PaymentMethod.human_attribute_name(:available_to_admin) %>
-          <%= f.check_box :available_to_admin %>
-        </div>
         <div data-hook="auto_capture" class="field">
           <%= f.label :auto_capture %>
           <%= f.select :auto_capture, [["#{Spree.t(:use_app_default)} (#{Spree::Config[:auto_capture]})", ''], [Spree.t(:say_yes), true], [Spree.t(:say_no), false]], {}, {class: 'custom-select fullwidth'} %>
         </div>
+        <div data-hook="available_to_user" class="field">
+          <%= f.check_box :available_to_users %>
+          <%= f.label :available_to_users %>
+        </div>
+        <div data-hook="available_to_user" class="field">
+          <%= f.check_box :available_to_admin %>
+          <%= f.label :available_to_admin %>
+        </div>
         <div data-hook="active" class="field">
-          <%= label_tag nil, Spree::PaymentMethod.human_attribute_name(:active) %>
-          <ul>
-            <li>
-              <%= f.radio_button :active, true %>
-              <%= label_tag :payment_method_active_true, Spree.t(:say_yes) %>
-            </li>
-            <li>
-              <%= f.radio_button :active, false %>
-              <%= label_tag :payment_method_active_false, Spree.t(:say_no) %>
-            </li>
-          </ul>
+          <%= f.check_box :active %>
+          <%= f.label :active %>
         </div>
       </div>
 
-      <div class="col-6">
+      <div class="col-8">
         <div data-hook="name" class="field">
           <%= f.label :name %>
           <%= f.text_field :name, class: 'fullwidth' %>

--- a/backend/app/views/spree/admin/payment_methods/_form.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/_form.html.erb
@@ -6,8 +6,8 @@
       <div class="col-3">
         <div id="preference-settings">
           <div class="field">
-            <%= label :payment_method, :type %>
-            <%= collection_select(:payment_method, :type, @payment_method_types, :to_s, :name, {}, {class: 'custom-select fullwidth js-gateway-type'}) %>
+            <%= f.label :type %>
+            <%= f.collection_select :type, @payment_method_types, :to_s, :name, {}, {class: 'custom-select fullwidth js-gateway-type'} %>
           </div>
 
           <div class="field js-preference-source-wrapper">
@@ -35,17 +35,17 @@
         </div>
         <div data-hook="auto_capture" class="field">
           <%= f.label :auto_capture %>
-          <%= select(:payment_method, :auto_capture, [["#{Spree.t(:use_app_default)} (#{Spree::Config[:auto_capture]})", ''], [Spree.t(:say_yes), true], [Spree.t(:say_no), false]], {}, {class: 'custom-select fullwidth'}) %>
+          <%= f.select :auto_capture, [["#{Spree.t(:use_app_default)} (#{Spree::Config[:auto_capture]})", ''], [Spree.t(:say_yes), true], [Spree.t(:say_no), false]], {}, {class: 'custom-select fullwidth'} %>
         </div>
         <div data-hook="active" class="field">
           <%= label_tag nil, Spree::PaymentMethod.human_attribute_name(:active) %>
           <ul>
             <li>
-              <%= radio_button :payment_method, :active, true %>
+              <%= f.radio_button :active, true %>
               <%= label_tag :payment_method_active_true, Spree.t(:say_yes) %>
             </li>
             <li>
-              <%= radio_button :payment_method, :active, false %>
+              <%= f.radio_button :active, false %>
               <%= label_tag :payment_method_active_false, Spree.t(:say_no) %>
             </li>
           </ul>

--- a/backend/app/views/spree/admin/payment_methods/edit.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/edit.html.erb
@@ -10,7 +10,7 @@
 
 <%= render partial: 'spree/shared/error_messages', locals: { target: @payment_method } %>
 
-<%= form_for @payment_method, url: admin_payment_method_path(@payment_method) do |f| %>
+<%= form_for @payment_method, as: :payment_method, url: admin_payment_method_path(@payment_method) do |f| %>
   <fieldset class="no-border-top">
     <%= render partial: 'form', locals: { f: f } %>
     <div data-hook="buttons" class="filter-actions actions">

--- a/backend/app/views/spree/admin/payment_methods/index.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/index.html.erb
@@ -40,7 +40,7 @@
         <tr id="<%= spree_dom_id method %>" data-hook="admin_payment_methods_index_rows" class="<%= cycle('odd', 'even')%>">
           <td class="no-border"><span class="handle"></span></td>
           <td class="align-center"><%= method.name %></td>
-          <td class="align-center"><%= method.type %></td>
+          <td class="align-center"><%= method.model_name.human %></td>
           <td class="align-center"><%= method.available_to_users ? Spree.t(:say_yes) : Spree.t(:say_no) %></td>
           <td class="align-center"><%= method.available_to_admin ? Spree.t(:say_yes) : Spree.t(:say_no) %></td>
           <td class="align-center"><%= method.active ? Spree.t(:say_yes) : Spree.t(:say_no) %></td>

--- a/backend/app/views/spree/admin/payment_methods/new.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/new.html.erb
@@ -11,7 +11,7 @@
 
 <%= render partial: 'spree/shared/error_messages', locals: { target: @payment_method } %>
 
-<%= form_for @payment_method, url: collection_url do |f| %>
+<%= form_for @payment_method, as: :payment_method, url: collection_url do |f| %>
   <fieldset class="no-border-top">
     <%= render partial: 'form', locals: { f: f } %>
     <div data-hook="buttons" class="filter-actions actions">

--- a/backend/spec/features/admin/configuration/payment_methods_spec.rb
+++ b/backend/spec/features/admin/configuration/payment_methods_spec.rb
@@ -51,14 +51,14 @@ describe "Payment Methods", type: :feature do
     end
 
     it "should be able to edit an existing payment method" do
-      fill_in "payment_method_check_name", with: "Payment 99"
+      fill_in "payment_method_name", with: "Payment 99"
       click_button "Update"
       expect(page).to have_content("successfully updated!")
-      expect(page).to have_field("payment_method_check_name", with: "Payment 99")
+      expect(page).to have_field("payment_method_name", with: "Payment 99")
     end
 
     it "should display validation errors" do
-      fill_in "payment_method_check_name", with: ""
+      fill_in "payment_method_name", with: ""
       click_button "Update"
       expect(page).to have_content("Name can't be blank")
     end

--- a/backend/spec/features/admin/configuration/payment_methods_spec.rb
+++ b/backend/spec/features/admin/configuration/payment_methods_spec.rb
@@ -23,7 +23,7 @@ describe "Payment Methods", type: :feature do
       end
 
       within('table#listing_payment_methods') do
-        expect(page).to have_content("Spree::PaymentMethod::Check")
+        expect(page).to have_content(Spree::PaymentMethod::Check.model_name.human)
       end
     end
   end
@@ -35,7 +35,7 @@ describe "Payment Methods", type: :feature do
       expect(page).to have_content("New Payment Method")
       fill_in "payment_method_name", with: "check90"
       fill_in "payment_method_description", with: "check90 desc"
-      select "Spree::PaymentMethod::Check", from: "Type"
+      select Spree::PaymentMethod::Check.model_name.human, from: "Type"
       click_button "Create"
       expect(page).to have_content("successfully created!")
     end
@@ -76,12 +76,12 @@ describe "Payment Methods", type: :feature do
       click_icon :edit
       expect(page).to have_content('Test Mode')
 
-      select 'Spree::PaymentMethod::Check', from: 'Type'
+      select Spree::PaymentMethod::Check.model_name.human, from: 'Type'
       expect(page).to have_content('you must save first')
       expect(page).to have_no_content('Test Mode')
 
       # change back
-      select 'Spree::PaymentMethod::BogusCreditCard', from: 'Type'
+      select Spree::PaymentMethod::BogusCreditCard.model_name.human, from: 'Type'
       expect(page).to have_no_content('you must save first')
       expect(page).to have_content('Test Mode')
     end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -496,6 +496,10 @@ en:
       spree/payment_method:
         one: Payment Method
         other: Payment Methods
+      spree/payment_method/check: Check Payments
+      spree/payment_method/store_credit: Store Credit Payments
+      spree/payment_method/bogus_credit_card: Bogus Credit Card Payments
+      spree/payment_method/simple_bogus_credit_card: Simple Bogus Credit Card Payments
       spree/price:
         one: Price
         other: Prices


### PR DESCRIPTION
This PR is one of many that follow to remove the confusion around payment methods, payment providers and gateways we have for a long time in our code base.

There is lots of confusing parts in administrating payment methods:

- The payment method type is called a provider (although it may be only one payment method implementation of many from the same provider) 
- The payment method classes listed as providers are represented by its class names instead of a meaningful human readable name
- Form params passed to the controller are confused by the STI nature of payment method classes instead of using one concise name
- The active flag is represented by two radio buttons instead of a checkbox

### Before

![store credit - payment methods - before](https://user-images.githubusercontent.com/42868/27450810-3f110fa0-578d-11e7-8124-3d73c6e213d4.png)

### After

![store credit - payment methods - after](https://user-images.githubusercontent.com/42868/27450826-4b3efaee-578d-11e7-9026-59ab256fe302.png)
