### PR TITLE
Fix the last factories lint offences.

### DIFF
--- a/core/lib/spree/testing_support/factories/factories_linter.rb
+++ b/core/lib/spree/testing_support/factories/factories_linter.rb
@@ -2,7 +2,7 @@ RSpec.configure do |config|
   config.before(:suite) do |example|
     DatabaseCleaner.start
     factories_to_lint = FactoryGirl.factories.reject do |factory|
-     [:stock_packer, :customer_return_without_return_items].include?(factory.name)
+      [:stock_packer, :customer_return_without_return_items].include?(factory.name)
     end
 
     FactoryGirl.lint factories_to_lint

--- a/core/lib/spree/testing_support/factories/stock_transfer_factory.rb
+++ b/core/lib/spree/testing_support/factories/stock_transfer_factory.rb
@@ -1,9 +1,12 @@
 FactoryGirl.define do
+  sequence(:source_code) { |n| "SRC#{n}" }
+  sequence(:destination_code) { |n| "DEST#{n}" }
+
   factory :stock_transfer, class: Spree::StockTransfer do
-    source_location { Spree::StockLocation.create!(name: "Source Location", code: "SRC", admin_name: "Source") }
+    source_location { Spree::StockLocation.create!(name: "Source Location", code: generate(:source_code), admin_name: "Source") }
 
     factory :stock_transfer_with_items do
-      destination_location { Spree::StockLocation.create!(name: "Destination Location", code: "DEST", admin_name: "Destination") }
+      destination_location { Spree::StockLocation.create!(name: "Destination Location", code: generate(:destination_code), admin_name: "Destination") }
 
       after(:create) do |stock_transfer, _evaluator|
         variant_1 = create(:variant)

--- a/core/lib/spree/testing_support/factories/store_credit_event_factory.rb
+++ b/core/lib/spree/testing_support/factories/store_credit_event_factory.rb
@@ -4,6 +4,7 @@ require 'spree/testing_support/factories/store_credit_update_reason_factory'
 FactoryGirl.define do
   factory :store_credit_event, class: Spree::StoreCreditEvent do
     store_credit
+    action             { Spree::StoreCredit::VOID_ACTION }
     amount             { 100.00 }
     authorization_code { "#{store_credit.id}-SC-20140602164814476128" }
 

--- a/core/spec/support/lint_factories.rb
+++ b/core/spec/support/lint_factories.rb
@@ -1,7 +1,11 @@
 RSpec.configure do |config|
   config.before(:suite) do |example|
     DatabaseCleaner.start
-    FactoryGirl.lint
+    factories_to_lint = FactoryGirl.factories.reject do |factory|
+      factory.name =~ /^stock_packer$/
+    end
+
+    FactoryGirl.lint factories_to_lint
     DatabaseCleaner.clean
   end
 end

--- a/core/spec/support/lint_factories.rb
+++ b/core/spec/support/lint_factories.rb
@@ -1,0 +1,7 @@
+RSpec.configure do |config|
+  config.before(:suite) do |example|
+    DatabaseCleaner.start
+    FactoryGirl.lint
+    DatabaseCleaner.clean
+  end
+end

--- a/core/spec/support/lint_factories.rb
+++ b/core/spec/support/lint_factories.rb
@@ -2,7 +2,7 @@ RSpec.configure do |config|
   config.before(:suite) do |example|
     DatabaseCleaner.start
     factories_to_lint = FactoryGirl.factories.reject do |factory|
-      factory.name =~ /^stock_packer$/
+     [:stock_packer, :customer_return_without_return_items].include?(factory.name)
     end
 
     FactoryGirl.lint factories_to_lint


### PR DESCRIPTION
Related to this issue https://github.com/solidusio/solidus/issues/568.

I'm not sure we want the linter run at the beginning of each spec suite, for now I've put it here https://github.com/nebulab/solidus/blob/908cf3859140aae6077dab2af4623d1133ae5f93/core/lib/spree/testing_support/factories/factories_linter.rb.
I've also skip `stock_packer` factory because it's not an Active Record type, and `customer_return_without_return_items` because it's a wanted "wrong" factory, `customer_return` can't be without `return_items` due a validation.