### PR TITLE
Rename bogus gateways into payment methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Solidus 2.3.0 (master, unreleased)
 
+- Renamed bogus payment methods
+  `Spree::Gateway::BogusSimple` and `Spree::Gateway::Bogus` were renamed to `Spree::PaymentMethod::SimpleBogusCreditCard` and `Spree::PaymentMethod::BogusCreditCard`
+
 - Allow custom separator between a promotion's `base_code` and `suffix` [\#1951](https://github.com/solidusio/solidus/pull/1951) ([ericgross](https://github.com/ericgross))
 - Ignore `adjustment.finalized` on tax adjustments. [\#1936](https://github.com/solidusio/solidus/pull/1936) ([jordan-brough](https://github.com/jordan-brough))
 - Deprecate `#simple_current_order`

--- a/api/spec/controllers/spree/api/checkouts_controller_spec.rb
+++ b/api/spec/controllers/spree/api/checkouts_controller_spec.rb
@@ -154,7 +154,7 @@ module Spree
 
       it "can update payment method and transition from payment to confirm" do
         order.update_column(:state, "payment")
-        allow_any_instance_of(Spree::Gateway::Bogus).to receive(:source_required?).and_return(false)
+        allow_any_instance_of(Spree::PaymentMethod::BogusCreditCard).to receive(:source_required?).and_return(false)
         api_put :update, id: order.to_param, order_token: order.guest_token,
           order: { payments_attributes: [{ payment_method_id: @payment_method.id }] }
         expect(json_response['state']).to eq('confirm')

--- a/api/spec/controllers/spree/api/payments_controller_spec.rb
+++ b/api/spec/controllers/spree/api/payments_controller_spec.rb
@@ -37,7 +37,7 @@ module Spree
 
         context "payment source is not required" do
           before do
-            allow_any_instance_of(Spree::Gateway::Bogus).to receive(:source_required?).and_return(false)
+            allow_any_instance_of(Spree::PaymentMethod::BogusCreditCard).to receive(:source_required?).and_return(false)
           end
 
           it "can create a new payment" do
@@ -160,7 +160,7 @@ module Spree
           context "authorization fails" do
             before do
               fake_response = double(success?: false, to_s: "Could not authorize card")
-              expect_any_instance_of(Spree::Gateway::Bogus).to receive(:authorize).and_return(fake_response)
+              expect_any_instance_of(Spree::PaymentMethod::BogusCreditCard).to receive(:authorize).and_return(fake_response)
               api_put :authorize, id: payment.to_param
             end
 
@@ -187,7 +187,7 @@ module Spree
           context "capturing fails" do
             before do
               fake_response = double(success?: false, to_s: "Insufficient funds")
-              expect_any_instance_of(Spree::Gateway::Bogus).to receive(:capture).and_return(fake_response)
+              expect_any_instance_of(Spree::PaymentMethod::BogusCreditCard).to receive(:capture).and_return(fake_response)
             end
 
             it "returns a 422 status" do
@@ -209,7 +209,7 @@ module Spree
           context "purchasing fails" do
             before do
               fake_response = double(success?: false, to_s: "Insufficient funds")
-              expect_any_instance_of(Spree::Gateway::Bogus).to receive(:purchase).and_return(fake_response)
+              expect_any_instance_of(Spree::PaymentMethod::BogusCreditCard).to receive(:purchase).and_return(fake_response)
             end
 
             it "returns a 422 status" do
@@ -231,7 +231,7 @@ module Spree
           context "voiding fails" do
             before do
               fake_response = double(success?: false, to_s: "NO REFUNDS")
-              expect_any_instance_of(Spree::Gateway::Bogus).to receive(:void).and_return(fake_response)
+              expect_any_instance_of(Spree::PaymentMethod::BogusCreditCard).to receive(:void).and_return(fake_response)
             end
 
             it "returns a 422 status" do

--- a/backend/spec/controllers/spree/admin/payment_methods_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/payment_methods_controller_spec.rb
@@ -28,13 +28,13 @@ module Spree
 
     context "tries to save invalid payment" do
       it "doesn't break, responds nicely" do
-        post :create, params: { payment_method: { name: "", type: "Spree::Gateway::Bogus" } }
+        post :create, params: { payment_method: { name: "", type: "Spree::PaymentMethod::BogusCreditCard" } }
       end
     end
 
     it "can create a payment method of a valid type" do
       expect {
-        post :create, params: { payment_method: { name: "Test Method", type: "Spree::Gateway::Bogus" } }
+        post :create, params: { payment_method: { name: "Test Method", type: "Spree::PaymentMethod::BogusCreditCard" } }
       }.to change(Spree::PaymentMethod, :count).by(1)
 
       expect(response).to be_redirect

--- a/backend/spec/features/admin/configuration/payment_methods_spec.rb
+++ b/backend/spec/features/admin/configuration/payment_methods_spec.rb
@@ -67,7 +67,7 @@ describe "Payment Methods", type: :feature do
   context "changing type and payment_source", js: true do
     after do
       # cleanup
-      Spree::Config.static_model_preferences.for_class(Spree::Gateway::Bogus).clear
+      Spree::Config.static_model_preferences.for_class(Spree::PaymentMethod::BogusCreditCard).clear
     end
 
     it "displays message when changing type" do
@@ -81,13 +81,13 @@ describe "Payment Methods", type: :feature do
       expect(page).to have_no_content('Test Mode')
 
       # change back
-      select2_search 'Spree::Gateway::Bogus', from: 'Provider'
+      select2_search 'Spree::PaymentMethod::BogusCreditCard', from: 'Provider'
       expect(page).to have_no_content('you must save first')
       expect(page).to have_content('Test Mode')
     end
 
     it "displays message when changing preference source" do
-      Spree::Config.static_model_preferences.add(Spree::Gateway::Bogus, 'my_prefs', {})
+      Spree::Config.static_model_preferences.add(Spree::PaymentMethod::BogusCreditCard, 'my_prefs', {})
 
       create(:credit_card_payment_method)
       click_link "Payment Methods"
@@ -105,7 +105,7 @@ describe "Payment Methods", type: :feature do
     end
 
     it "updates successfully and keeps secrets" do
-      Spree::Config.static_model_preferences.add(Spree::Gateway::Bogus, 'my_prefs', { server: 'secret' })
+      Spree::Config.static_model_preferences.add(Spree::PaymentMethod::BogusCreditCard, 'my_prefs', { server: 'secret' })
 
       create(:credit_card_payment_method)
       click_link "Payment Methods"

--- a/core/app/models/spree/payment_method/bogus_credit_card.rb
+++ b/core/app/models/spree/payment_method/bogus_credit_card.rb
@@ -1,5 +1,14 @@
 module Spree
-  class Gateway::Bogus < Gateway
+  # @deprecated Use Spree::PaymentMethod::BogusCreditCard instead
+  class Gateway::Bogus
+    def initialize
+      Spree::Deprecation.warn \
+        'Spree::Gateway::Bogus is deprecated. ' \
+          'Please use Spree::PaymentMethod::BogusCreditCard instead'
+    end
+  end
+
+  class PaymentMethod::BogusCreditCard < Gateway
     TEST_VISA = ['4111111111111111', '4012888888881881', '4222222222222']
     TEST_MC   = ['5500000000000004', '5555555555554444', '5105105105105100']
     TEST_AMEX = ['378282246310005', '371449635398431', '378734493671000', '340000000000009']

--- a/core/app/models/spree/payment_method/simple_bogus_credit_card.rb
+++ b/core/app/models/spree/payment_method/simple_bogus_credit_card.rb
@@ -1,6 +1,15 @@
 module Spree
+  # @deprecated Use Spree::PaymentMethod::SimpleBogusCreditCard instead
+  class Gateway::BogusSimple
+    def initialize
+      Spree::Deprecation.warn \
+        'Spree::Gateway::BogusSimple is deprecated. ' \
+          'Please use Spree::PaymentMethod::SimpleBogusCreditCard instead'
+    end
+  end
+
   # Bogus Gateway that doesn't support payment profiles.
-  class Gateway::BogusSimple < Gateway::Bogus
+  class PaymentMethod::SimpleBogusCreditCard < PaymentMethod::BogusCreditCard
     def payment_profiles_supported?
       false
     end

--- a/core/db/migrate/20170529124708_rename_bogus_gateways.rb
+++ b/core/db/migrate/20170529124708_rename_bogus_gateways.rb
@@ -1,0 +1,15 @@
+class RenameBogusGateways < ActiveRecord::Migration[5.0]
+  def up
+    ActiveRecord::Base.connection.execute <<-SQL.strip_heredoc
+UPDATE spree_payment_methods SET type = 'Spree::PaymentMethod::BogusCreditCard' WHERE type = 'Spree::Gateway::Bogus';
+UPDATE spree_payment_methods SET type = 'Spree::PaymentMethod::SimpleBogusCreditCard' WHERE type = 'Spree::Gateway::BogusSimple';
+SQL
+  end
+
+  def up
+    ActiveRecord::Base.connection.execute <<-SQL.strip_heredoc
+UPDATE spree_payment_methods SET type = 'Spree::Gateway::Bogus' WHERE type = 'Spree::PaymentMethod::BogusCreditCard';
+UPDATE spree_payment_methods SET type = 'Spree::Gateway::BogusSimple' WHERE type = 'Spree::PaymentMethod::SimpleBogusCreditCard';
+SQL
+  end
+end

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -43,8 +43,8 @@ module Spree
 
       initializer "spree.register.payment_methods", before: :load_config_initializers do |app|
         app.config.spree.payment_methods = %w[
-          Spree::Gateway::Bogus
-          Spree::Gateway::BogusSimple
+          Spree::PaymentMethod::BogusCreditCard
+          Spree::PaymentMethod::SimpleBogusCreditCard
           Spree::PaymentMethod::StoreCredit
           Spree::PaymentMethod::Check
         ]

--- a/core/lib/spree/testing_support/factories/payment_method_factory.rb
+++ b/core/lib/spree/testing_support/factories/payment_method_factory.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
-  factory :payment_method, aliases: [:credit_card_payment_method], class: Spree::Gateway::Bogus do
+  factory :payment_method, aliases: [:credit_card_payment_method], class: Spree::PaymentMethod::BogusCreditCard do
     name 'Credit Card'
     available_to_admin true
     available_to_users true
@@ -13,7 +13,7 @@ FactoryGirl.define do
 
   # authorize.net was moved to spree_gateway.
   # Leaving this factory in place with bogus in case anyone is using it.
-  factory :simple_credit_card_payment_method, class: Spree::Gateway::BogusSimple do
+  factory :simple_credit_card_payment_method, class: Spree::PaymentMethod::SimpleBogusCreditCard do
     name 'Credit Card'
     available_to_admin true
     available_to_users true

--- a/core/spec/models/spree/gateway/bogus_simple.rb
+++ b/core/spec/models/spree/gateway/bogus_simple.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
-describe Spree::Gateway::BogusSimple, type: :model do
-  subject { Spree::Gateway::BogusSimple.new }
+describe Spree::PaymentMethod::SimpleBogusCreditCard, type: :model do
+  subject { Spree::PaymentMethod::SimpleBogusCreditCard.new }
 
   # regression test for https://github.com/spree/spree/issues/3824
   describe "#capture" do

--- a/core/spec/models/spree/gateway/bogus_spec.rb
+++ b/core/spec/models/spree/gateway/bogus_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 module Spree
-  describe Gateway::Bogus, type: :model do
+  describe PaymentMethod::BogusCreditCard, type: :model do
     let(:bogus) { create(:credit_card_payment_method) }
     let!(:cc) { create(:credit_card, payment_method: bogus, gateway_customer_profile_id: "BGS-RERTERT") }
   end

--- a/core/spec/models/spree/gateway_spec.rb
+++ b/core/spec/models/spree/gateway_spec.rb
@@ -95,7 +95,7 @@ describe Spree::Gateway, type: :model do
   end
 
   context 'using preference_source' do
-    let(:klass){ Spree::Gateway::Bogus }
+    let(:klass){ Spree::PaymentMethod::BogusCreditCard }
     before do
       Spree::Config.static_model_preferences.add(klass, 'test_preference_source', server: 'bar')
     end

--- a/core/spec/models/spree/order_capturing_spec.rb
+++ b/core/spec/models/spree/order_capturing_spec.rb
@@ -58,10 +58,10 @@ describe Spree::OrderCapturing do
       context "payment method ordering" do
         let(:secondary_payment_method) { SecondaryBogusPaymentMethod }
 
-        class SecondaryBogusPaymentMethod < Spree::Gateway::Bogus; end
+        class SecondaryBogusPaymentMethod < Spree::PaymentMethod::BogusCreditCard; end
 
         context "SecondaryBogusPaymentMethod payments are prioritized" do
-          let(:payment_methods) { [SecondaryBogusPaymentMethod, Spree::Gateway::Bogus] }
+          let(:payment_methods) { [SecondaryBogusPaymentMethod, Spree::PaymentMethod::BogusCreditCard] }
 
           it "captures SecondaryBogusPaymentMethod payments first" do
             @bogus_payment.update!(amount: bogus_total + 100)
@@ -72,7 +72,7 @@ describe Spree::OrderCapturing do
         end
 
         context "Bogus payments are prioritized" do
-          let(:payment_methods) { [Spree::Gateway::Bogus, SecondaryBogusPaymentMethod] }
+          let(:payment_methods) { [Spree::PaymentMethod::BogusCreditCard, SecondaryBogusPaymentMethod] }
 
           it "captures Bogus payments first" do
             @secondary_bogus_payment.update!(amount: secondary_total + 100)
@@ -89,7 +89,7 @@ describe Spree::OrderCapturing do
 
           before do
             allow(Spree::OrderCapturing).to receive(:sorted_payment_method_classes).and_return(
-              [SecondaryBogusPaymentMethod, Spree::Gateway::Bogus]
+              [SecondaryBogusPaymentMethod, Spree::PaymentMethod::BogusCreditCard]
             )
           end
 
@@ -103,7 +103,7 @@ describe Spree::OrderCapturing do
 
       context "when a payment is not needed to capture the entire order" do
         let(:secondary_payment_method) { SecondaryBogusPaymentMethod }
-        let(:payment_methods) { [Spree::Gateway::Bogus, SecondaryBogusPaymentMethod] }
+        let(:payment_methods) { [Spree::PaymentMethod::BogusCreditCard, SecondaryBogusPaymentMethod] }
 
         before do
           @bogus_payment.update!(amount: order.total)
@@ -132,9 +132,9 @@ describe Spree::OrderCapturing do
         let(:secondary_payment_method) { ExceptionallyBogusPaymentMethod }
         let(:bogus_total) { order.total - 1 }
         let(:secondary_total) { 1 }
-        let(:payment_methods) { [Spree::Gateway::Bogus, ExceptionallyBogusPaymentMethod] }
+        let(:payment_methods) { [Spree::PaymentMethod::BogusCreditCard, ExceptionallyBogusPaymentMethod] }
 
-        class ExceptionallyBogusPaymentMethod < Spree::Gateway::Bogus
+        class ExceptionallyBogusPaymentMethod < Spree::PaymentMethod::BogusCreditCard
           def capture(*_args)
             raise ActiveMerchant::ConnectionError.new("foo", nil)
           end

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -6,7 +6,7 @@ describe Spree::Payment, type: :model do
   let(:refund_reason) { create(:refund_reason) }
 
   let(:gateway) do
-    gateway = Spree::Gateway::Bogus.new(active: true, name: 'Bogus gateway')
+    gateway = Spree::PaymentMethod::BogusCreditCard.new(active: true, name: 'Bogus gateway')
     allow(gateway).to receive_messages source_required: true
     gateway
   end

--- a/core/spec/models/spree/reimbursement_type/original_payment_spec.rb
+++ b/core/spec/models/spree/reimbursement_type/original_payment_spec.rb
@@ -54,7 +54,7 @@ module Spree
       context "multiple payment methods" do
         let(:simulate) { true }
         let!(:check_payment) { create(:check_payment, order: reimbursement.order, amount: 5.0, state: "completed") }
-        let(:payment) { reimbursement.order.payments.detect { |p| p.payment_method.is_a? Spree::Gateway::Bogus } }
+        let(:payment) { reimbursement.order.payments.detect { |p| p.payment_method.is_a? Spree::PaymentMethod::BogusCreditCard } }
         let(:refund_amount) { 10.0 }
 
         let(:refund_payment_methods) { subject.map { |refund| refund.payment.payment_method } }

--- a/sample/db/samples/payment_methods.rb
+++ b/sample/db/samples/payment_methods.rb
@@ -1,4 +1,4 @@
-Spree::Gateway::Bogus.create!(
+Spree::PaymentMethod::BogusCreditCard.create!(
   {
     name: "Credit Card",
     description: "Bogus payment gateway",


### PR DESCRIPTION
In the ongoing effort to remove confusion around payment methods, gateways and providers we rename:

- `Spree::Gateway::Bogus` into `Spree::PaymentMethod::BogusCreditCard` 
- `Spree::Gateway::BogusSimple` into `Spree::PaymentMethod::SimpleBogusCreditCard`