### PR TITLE
Rename method_type into partial_name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Solidus 2.3.0 (master, unreleased)
 
+- Renamed `PaymentMethod#method_type` into `partial_name` [\#1978](https://github.com/solidusio/solidus/pull/1978) ([tvdeyen](https://github.com/tvdeyen))
 - Order#outstanding_balance now uses reimbursements instead of refunds to calculate the amount that should be paid on an order. [#2002](https://github.com/solidusio/solidus/pull/2002) (many contributors :heart:)
 
 - Renamed `Spree::Gateway` payment method into `Spree::PaymentMethod::CreditCard` [\#2001](https://github/com/solidusio/solidus/pull/2001) ([tvdeyen](https://github.com/tvdeyen))

--- a/api/app/views/spree/api/orders/show.v1.rabl
+++ b/api/app/views/spree/api/orders/show.v1.rabl
@@ -2,7 +2,7 @@ object @order
 extends "spree/api/orders/order"
 
 child :available_payment_methods => :payment_methods do
-  attributes :id, :name, :method_type
+  attributes :id, :name, :method_type, :partial_name
 end
 
 child :billing_address => :bill_address do

--- a/backend/app/views/spree/admin/payments/_form.html.erb
+++ b/backend/app/views/spree/admin/payments/_form.html.erb
@@ -27,7 +27,7 @@
           <div class="payment-methods" id="payment_method_<%= method.id %>" data-payment-method-id="<%= method.id %>">
             <% if method.source_required? %>
               <br />
-              <%= render partial: "spree/admin/payments/source_forms/#{method.method_type}",
+              <%= render partial: "spree/admin/payments/source_forms/#{method.partial_name}",
                          locals: { payment_method: method, previous_cards: method.reusable_sources(@order) } %>
             <% end %>
           </div>

--- a/backend/app/views/spree/admin/payments/show.html.erb
+++ b/backend/app/views/spree/admin/payments/show.html.erb
@@ -13,7 +13,7 @@
   <li><%= button_link_to Spree.t(:logs), spree.admin_order_payment_log_entries_url(@order, @payment) %></li>
 <% end %>
 
-<%= render partial: "spree/admin/payments/source_views/#{@payment.payment_method.method_type}", locals: { payment: @payment.source.is_a?(Spree::Payment) ? @payment.source : @payment } %>
+<%= render partial: "spree/admin/payments/source_views/#{@payment.payment_method.partial_name}", locals: { payment: @payment.source.is_a?(Spree::Payment) ? @payment.source : @payment } %>
 
 <div data-hook="amount" class="align-center">
   <h5><%= label_tag nil, Spree::Payment.human_attribute_name(:amount) %>: <span class="green"><%= @payment.display_amount.to_html %></span> </h5>

--- a/core/app/models/spree/payment_method.rb
+++ b/core/app/models/spree/payment_method.rb
@@ -141,21 +141,23 @@ module Spree
     #
     # Currently your payment method needs to provide these partials:
     #
-    #     1. app/views/spree/checkout/payment/_{method_type}.html.erb
+    #     1. app/views/spree/checkout/payment/_{partial_name}.html.erb
     #     The form your customer enters the payment information in during checkout
     #
-    #     2. app/views/spree/checkout/existing_payment/_{method_type}.html.erb
+    #     2. app/views/spree/checkout/existing_payment/_{partial_name}.html.erb
     #     The payment information of your customers reusable sources during checkout
     #
-    #     3. app/views/spree/admin/payments/source_forms/_{method_type}.html.erb
+    #     3. app/views/spree/admin/payments/source_forms/_{partial_name}.html.erb
     #     The form an admin enters payment information in when creating orders in the backend
     #
-    #     4. app/views/spree/admin/payments/source_views/_{method_type}.html.erb
+    #     4. app/views/spree/admin/payments/source_views/_{partial_name}.html.erb
     #     The view that represents your payment method on orders in the backend
     #
-    def method_type
+    def partial_name
       type.demodulize.downcase
     end
+    alias_method :method_type, :partial_name
+    deprecate method_type: :partial_name, deprecator: Spree::Deprecation
 
     def payment_profiles_supported?
       false

--- a/core/app/models/spree/payment_method/credit_card.rb
+++ b/core/app/models/spree/payment_method/credit_card.rb
@@ -11,7 +11,7 @@ module Spree
       CreditCard
     end
 
-    def method_type
+    def partial_name
       'gateway'
     end
 

--- a/frontend/app/views/spree/checkout/_payment.html.erb
+++ b/frontend/app/views/spree/checkout/_payment.html.erb
@@ -21,7 +21,7 @@
               <% @wallet_payment_sources.each do |wallet_payment_source| %>
                 <%=
                   render(
-                    partial: "spree/checkout/existing_payment/#{wallet_payment_source.payment_source.payment_method.method_type}",
+                    partial: "spree/checkout/existing_payment/#{wallet_payment_source.payment_source.payment_method.partial_name}",
                     locals: {
                       wallet_payment_source: wallet_payment_source,
                       default: wallet_payment_source == @default_wallet_payment_source,
@@ -50,7 +50,7 @@
       <% @order.available_payment_methods.each do |method| %>
         <li id="payment_method_<%= method.id %>" class="<%= 'last' if method == @order.available_payment_methods.last %>" data-hook>
           <fieldset>
-            <%= render partial: "spree/checkout/payment/#{method.method_type}", locals: { payment_method: method } %>
+            <%= render partial: "spree/checkout/payment/#{method.partial_name}", locals: { payment_method: method } %>
           </fieldset>
         </li>
       <% end %>


### PR DESCRIPTION
`PaymentMethod#method_type` is a confusing name for a method returning the name of the partial to use.

As we cannot use `to_partial_path` (we use it in four different places), we use `partial_name` as more descriptive name.

This removes the key from the `/api/orders/:id` API (How ever this landed up there). As I can't imagine a good approach for deprecating API keys renaming is the only option I have.