### PR TITLE
Improve order factories

### DIFF
--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -9,8 +9,6 @@ describe "Order Details", type: :feature, js: true do
   let!(:tote) { create(:product, name: "Tote", price: 15.00) }
   let(:order) { create(:order, state: 'complete', completed_at: "2011-02-01 12:36:15", number: "R100") }
   let(:state) { create(:state) }
-  # let(:shipment) { create(:shipment, order: order, stock_location: stock_location) }
-  let!(:shipping_method) { create(:shipping_method, name: "Default") }
 
   before do
     @shipment1 = order.shipments.create(stock_location_id: stock_location.id)
@@ -101,11 +99,11 @@ describe "Order Details", type: :feature, js: true do
         within("table.index tr.show-method") do
           click_icon :edit
         end
-        select2 "Default", from: "Shipping Method"
+        select2 "UPS Ground", from: "Shipping Method"
         click_icon :check
 
         expect(page).not_to have_css('#selected_shipping_rate_id')
-        expect(page).to have_content("Default")
+        expect(page).to have_content("UPS Ground")
       end
 
       context "with a completed order" do
@@ -520,11 +518,11 @@ describe "Order Details", type: :feature, js: true do
       within("table.index tr.show-method") do
         click_icon :edit
       end
-      select2 "Default", from: "Shipping Method"
+      select2 "UPS Ground", from: "Shipping Method"
       click_icon :check
 
       expect(page).not_to have_css('#selected_shipping_rate_id')
-      expect(page).to have_content("Default")
+      expect(page).to have_content("UPS Ground")
     end
 
     it 'can ship' do

--- a/core/lib/spree/testing_support/factories/order_factory.rb
+++ b/core/lib/spree/testing_support/factories/order_factory.rb
@@ -18,10 +18,14 @@ FactoryGirl.define do
       line_items_price BigDecimal.new(10)
     end
 
+    # TODO: Improve the name of order_with_totals factory.
     factory :order_with_totals do
-      after(:create) do |order, evaluator|
-        create(:line_item, order: order, price: evaluator.line_items_price)
-        order.line_items.reload # to ensure order.line_items is accessible after
+      after(:build) do |order, evaluator|
+        order.line_items << build(
+          :line_item,
+          order: order,
+          price: evaluator.line_items_price
+        )
       end
     end
 
@@ -37,7 +41,7 @@ FactoryGirl.define do
         stock_location { create(:stock_location) }
       end
 
-      after(:create) do |order, evaluator|
+      after(:build) do |order, evaluator|
         evaluator.stock_location # must evaluate before creating line items
 
         evaluator.line_items_attributes.each do |attributes|
@@ -50,6 +54,25 @@ FactoryGirl.define do
         order.shipments.reload
 
         order.update!
+      end
+
+      factory :completed_order_with_promotion do
+        transient do
+          promotion nil
+        end
+
+        after(:create) do |order, evaluator|
+          promotion = evaluator.promotion || create(:promotion, code: "test")
+          promotion_code = promotion.codes.first || create(:promotion_code, promotion: promotion)
+
+          promotion.activate(order: order, promotion_code: promotion_code)
+          order.order_promotions.create!(promotion: promotion, promotion_code: promotion_code)
+
+          # Complete the order after the promotion has been activated
+          order.refresh_shipment_rates
+          order.update_column(:completed_at, Time.current)
+          order.update_column(:state, "complete")
+        end
       end
 
       factory :order_ready_to_complete do
@@ -75,7 +98,6 @@ FactoryGirl.define do
         state 'complete'
 
         after(:create) do |order|
-          order.refresh_shipment_rates
           order.shipments.each do |shipment|
             shipment.inventory_units.update_all state: 'on_hand', pending: false
           end
@@ -128,25 +150,6 @@ FactoryGirl.define do
           end
         end
       end
-    end
-  end
-
-  factory :completed_order_with_promotion, parent: :order_with_line_items, class: "Spree::Order" do
-    transient do
-      promotion nil
-    end
-
-    after(:create) do |order, evaluator|
-      promotion = evaluator.promotion || create(:promotion, code: "test")
-      promotion_code = promotion.codes.first || create(:promotion_code, promotion: promotion)
-
-      promotion.activate(order: order, promotion_code: promotion_code)
-      order.order_promotions.create!(promotion: promotion, promotion_code: promotion_code)
-
-      # Complete the order after the promotion has been activated
-      order.refresh_shipment_rates
-      order.update_column(:completed_at, Time.current)
-      order.update_column(:state, "complete")
     end
   end
 end

--- a/core/spec/lib/spree/core/testing_support/factories/order_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/order_factory_spec.rb
@@ -1,6 +1,98 @@
 require 'spec_helper'
 require 'spree/testing_support/factories/order_factory'
 
+RSpec.shared_examples "an order with line items factory" do |expected_order_state, expected_inventory_unit_state|
+  # This factory cannot be built correctly because Shipment#set_up_inventory
+  # requires records to be saved.
+  context "when created" do
+    let(:stock_location) { create(:stock_location) }
+    let(:first_variant) { create(:variant) }
+    let(:second_variant) { create(:variant) }
+    let(:shipping_method) { create(:shipping_method) }
+    let(:order) do
+      create(
+        factory,
+        stock_location: stock_location,
+        line_items_attributes: [
+          { variant: first_variant, quantity: 1, price: 1 },
+          { variant: second_variant, quantity: 2, price: 2 }
+        ],
+        shipment_cost: 3,
+        shipping_method: shipping_method
+      )
+    end
+
+    it "has the expected attributes" do
+      aggregate_failures "for line items" do
+        expect(order.line_items.count).to eq 2
+        expect(order.line_items[0]).to have_attributes(
+          quantity: 1,
+          price: 1.0
+        )
+        expect(order.line_items[1]).to have_attributes(
+          price: 2.0,
+          quantity: 2
+        )
+      end
+
+      aggregate_failures "for shipments" do
+        expect(order.shipments.count).to eq 1
+        expect(order.shipments[0]).to have_attributes(
+          amount: 3.0,
+          stock_location: stock_location
+        )
+
+        expect(order.shipments[0].shipping_method).to eq(shipping_method)
+
+        expect(order.shipments[0].inventory_units.count).to eq(3)
+        expect(order.shipments[0].inventory_units[0]).to have_attributes(
+          order: order,
+          shipment: order.shipments[0],
+          line_item: order.line_items[0],
+          variant: order.line_items[0].variant,
+          state: expected_inventory_unit_state
+        )
+        expect(order.shipments[0].inventory_units[1]).to have_attributes(
+          order: order,
+          shipment: order.shipments[0],
+          line_item: order.line_items[1],
+          variant: order.line_items[1].variant,
+          state: expected_inventory_unit_state
+        )
+        expect(order.shipments[0].inventory_units[2]).to have_attributes(
+          order: order,
+          shipment: order.shipments[0],
+          line_item: order.line_items[1],
+          variant: order.line_items[1].variant,
+          state: expected_inventory_unit_state
+        )
+      end
+
+      expect(order).to have_attributes(
+        item_total: 5.0,
+        ship_total: 3.0,
+        total: 8.0,
+        state: expected_order_state
+      )
+    end
+  end
+
+  context 'when shipments should be taxed' do
+    let!(:ship_address) { create(:address) }
+    let!(:tax_zone) { create(:global_zone) } # will include the above address
+    let!(:tax_rate) { create(:tax_rate, amount: 0.10, zone: tax_zone, tax_categories: [tax_category]) }
+
+    let(:tax_category) { create(:tax_category) }
+    let(:shipping_method) { create(:shipping_method, tax_category: tax_category, zones: [tax_zone]) }
+
+    it 'shipments get a tax adjustment' do
+      order = create(factory, ship_address: ship_address, shipping_method: shipping_method)
+      shipment = order.shipments[0]
+
+      expect(shipment.additional_tax_total).to be > 0
+    end
+  end
+end
 RSpec.describe 'order factory' do
   let(:factory_class) { Spree::Order }
 
@@ -9,18 +101,29 @@ RSpec.describe 'order factory' do
 
     it_behaves_like 'a working factory'
 
-    it "has the expected attributes" do
-      order = create(factory)
-      aggregate_failures do
-        expect(order.bill_address).to be_present
-        expect(order.ship_address).to be_present
-        expect(order.user).to be_present
-        expect(order.email).to be_present
-        expect(order.email).to eq(order.user.email)
-        expect(order.state).to eq "cart"
-        expect(order.store).to be_present
-        expect(order).not_to be_completed
+    shared_examples "it has the expected attributes" do
+      it do
+        aggregate_failures do
+          expect(order.bill_address).to be_present
+          expect(order.ship_address).to be_present
+          expect(order.user).to be_present
+          expect(order.email).to be_present
+          expect(order.email).to eq(order.user.email)
+          expect(order.state).to eq "cart"
+          expect(order.store).to be_present
+          expect(order).not_to be_completed
+        end
       end
+    end
+
+    context "when built" do
+      let(:order) { build(factory) }
+      it_behaves_like "it has the expected attributes"
+    end
+
+    context "when created" do
+      let(:order) { create(factory) }
+      it_behaves_like "it has the expected attributes"
     end
   end
 
@@ -29,13 +132,24 @@ RSpec.describe 'order factory' do
 
     it_behaves_like 'a working factory'
 
-    it "has the expected attributes" do
-      order = create(factory)
-      aggregate_failures do
-        # This factory is terrbily named
-        expect(order.total).to eq 0
-        expect(order.line_items.count).to eq 1
+    shared_examples "it has the expected attributes" do
+      it do
+        aggregate_failures do
+          expect(order.total).to eq 0
+          expect(order.line_items.length).to eq 1
+          expect(order.line_items.first.price).to eq 77
+        end
       end
+    end
+
+    context "when built" do
+      let(:order) { build(factory, line_items_price: 77) }
+      it_behaves_like "it has the expected attributes"
+    end
+
+    context "when created" do
+      let(:order) { create(factory, line_items_price: 77) }
+      it_behaves_like "it has the expected attributes"
     end
   end
 
@@ -43,52 +157,43 @@ RSpec.describe 'order factory' do
     let(:factory) { :order_with_line_items }
 
     it_behaves_like 'a working factory'
+    it_behaves_like 'an order with line items factory', "cart", "on_hand"
+  end
+
+  describe 'completed order with promotion' do
+    let(:factory) { :completed_order_with_promotion }
+
+    it_behaves_like 'a working factory'
+    it_behaves_like 'an order with line items factory', "complete", "on_hand"
 
     it "has the expected attributes" do
       order = create(factory)
       aggregate_failures do
-        expect(order.line_items.count).to eq 1
-        expect(order.line_items[0]).to have_attributes(
-          quantity: 1,
-          price: 10
-        )
+        expect(order).to be_completed
+        expect(order).to be_complete
 
-        expect(order.shipments.count).to eq 1
-        expect(order.shipments[0]).to have_attributes(
-          amount: 100
-        )
-
-        expect(order.shipments[0].inventory_units.count).to eq(1)
-        expect(order.shipments[0].inventory_units[0]).to have_attributes(
-          order: order,
-          shipment: order.shipments[0],
-          line_item: order.line_items[0],
-          variant: order.line_items[0].variant,
-          state: 'on_hand'
-        )
-
-        expect(order).to have_attributes(
-          item_total: 10,
-          ship_total: 100,
-          total: 110,
-          state: 'cart' # this isn't realistic
-        )
+        expect(order.order_promotions.count).to eq(1)
+        order_promotion = order.order_promotions[0]
+        expect(order_promotion.promotion_code.promotion).to eq order_promotion.promotion
       end
     end
 
-    context 'when shipments should be taxed' do
-      let!(:ship_address) { create(:address) }
-      let!(:tax_zone) { create(:global_zone) } # will include the above address
-      let!(:tax_rate) { create(:tax_rate, amount: 0.10, zone: tax_zone, tax_categories: [tax_category]) }
+    context 'with a promotion with an action' do
+      let(:promotion) { create(:promotion, :with_line_item_adjustment) }
+      it "has the expected attributes" do
+        order = create(factory, promotion: promotion)
+        aggregate_failures do
+          expect(order).to be_completed
+          expect(order).to be_complete
 
-      let(:tax_category) { create(:tax_category) }
-      let(:shipping_method) { create(:shipping_method, tax_category: tax_category, zones: [tax_zone]) }
-
-      it 'shipments get a tax adjustment' do
-        order = create(factory, ship_address: ship_address, shipping_method: shipping_method)
-        shipment = order.shipments[0]
-
-        expect(shipment.additional_tax_total).to be > 0
+          expect(order.line_items[0].adjustments.count).to eq 1
+          adjustment = order.line_items[0].adjustments[0]
+          expect(adjustment).to have_attributes(
+            amount: -10,
+            eligible: true,
+            order_id: order.id
+          )
+        end
       end
     end
   end
@@ -97,6 +202,7 @@ RSpec.describe 'order factory' do
     let(:factory) { :order_ready_to_complete }
 
     it_behaves_like 'a working factory'
+    it_behaves_like 'an order with line items factory', "confirm", "on_hand"
 
     it "is completable" do
       order = create(factory)
@@ -111,6 +217,7 @@ RSpec.describe 'order factory' do
     let(:factory) { :completed_order_with_totals }
 
     it_behaves_like 'a working factory'
+    it_behaves_like 'an order with line items factory', "complete", "on_hand"
 
     it "has the expected attributes" do
       order = create(factory)
@@ -132,6 +239,7 @@ RSpec.describe 'order factory' do
     let(:factory) { :completed_order_with_pending_payment }
 
     it_behaves_like 'a working factory'
+    it_behaves_like 'an order with line items factory', "complete", "on_hand"
 
     it "has the expected attributes" do
       order = create(factory)
@@ -156,6 +264,7 @@ RSpec.describe 'order factory' do
     let(:factory) { :order_ready_to_ship }
 
     it_behaves_like 'a working factory'
+    it_behaves_like 'an order with line items factory', "complete", "on_hand"
 
     it "has the expected attributes" do
       order = create(factory)
@@ -195,6 +304,7 @@ RSpec.describe 'order factory' do
     let(:factory) { :shipped_order }
 
     it_behaves_like 'a working factory'
+    it_behaves_like 'an order with line items factory', "complete", "shipped"
 
     it "has the expected attributes" do
       order = create(factory)
@@ -219,43 +329,6 @@ RSpec.describe 'order factory' do
         )
 
         expect(order.cartons.count).to eq 1
-      end
-    end
-  end
-
-  describe 'completed order with promotion' do
-    let(:factory) { :completed_order_with_promotion }
-
-    it_behaves_like 'a working factory'
-
-    it "has the expected attributes" do
-      order = create(factory)
-      aggregate_failures do
-        expect(order).to be_completed
-        expect(order).to be_complete
-
-        expect(order.order_promotions.count).to eq(1)
-        order_promotion = order.order_promotions[0]
-        expect(order_promotion.promotion_code.promotion).to eq order_promotion.promotion
-      end
-    end
-
-    context 'with a promotion with an action' do
-      let(:promotion) { create(:promotion, :with_line_item_adjustment) }
-      it "has the expected attributes" do
-        order = create(factory, promotion: promotion)
-        aggregate_failures do
-          expect(order).to be_completed
-          expect(order).to be_complete
-
-          expect(order.line_items[0].adjustments.count).to eq 1
-          adjustment = order.line_items[0].adjustments[0]
-          expect(adjustment).to have_attributes(
-            amount: -10,
-            eligible: true,
-            order_id: order.id
-          )
-        end
       end
     end
   end


### PR DESCRIPTION
This change mostly adds improved test coverage for the order factories, but does modify the behavior of the order factories as well:
* `order_with_totals` can now be built instead of just being created
* `completed_order_with_totals` was calling `refresh_shipment_rates` which was causing the `shipping_method` argument passed to the factory to be ignored. Removing that call resulted in no test failures and the requested `shipping_method` to be assigned correctly.

One question this PR raises for me is building the factories does not result in the same output as creating. If we don't care about being able to build, I would like to find some way to raise an exception when we call build on a factory known not to produce the expected outputs. I'm not sure how to do this.