### PR TITLE
Make _report_order_criteria more shareable

### DIFF
--- a/backend/app/views/spree/admin/reports/sales_total.html.erb
+++ b/backend/app/views/spree/admin/reports/sales_total.html.erb
@@ -10,7 +10,7 @@
 <% end %>
 
 <% content_for :table_filter do %>
-  <%= render partial: 'spree/admin/shared/report_order_criteria', locals: {} %>
+  <%= render partial: 'spree/admin/shared/report_order_criteria', locals: { action: :sales_total } %>
 <% end %>
 
 <table class="admin-report" data-hook="sales_total">

--- a/backend/app/views/spree/admin/shared/_report_order_criteria.html.erb
+++ b/backend/app/views/spree/admin/shared/_report_order_criteria.html.erb
@@ -1,4 +1,4 @@
-<%= search_form_for @search, url: spree.sales_total_admin_reports_path  do |s| %>
+<%= search_form_for @search, url: spree.url_for(controller: 'admin/reports', action: action)  do |s| %>
   <div class="date-range-filter field">
     <div class="date-range-fields input-group">
       <%= s.text_field :completed_at_gt, class: 'datepicker datepicker-from form-control', value: datepicker_field_value(params[:q][:completed_at_gt]), placeholder: Spree.t(:start) %>


### PR DESCRIPTION
When creating a custom report on the reports controller, I noticed
that this shared form would always post the the :sales_total action of
the reports controller (`Spree::Admin::ReportsController`).

See
https://github.com/solidusio/solidus/blob/v2.1/backend/app/views/spree/admin/shared/_report_order_criteria.html.erb#L1

In order to allow future/custom reports be able to actually share this partial,
pass the key into the partial so that the partial will post to the right
action.