### PR TITLE
Change a reference from Spree to Solidus

### DIFF
--- a/lib/solidus.rb
+++ b/lib/solidus.rb
@@ -7,8 +7,8 @@ require 'solidus_sample'
 begin
   require 'protected_attributes'
   puts "*" * 75
-  puts "[FATAL] Spree does not work with the protected_attributes gem installed!"
-  puts "You MUST remove this gem from your Gemfile. It is incompatible with Spree."
+  puts "[FATAL] Solidus does not work with the protected_attributes gem installed!"
+  puts "You MUST remove this gem from your Gemfile. It is incompatible with Solidus."
   puts "*" * 75
   exit
 rescue LoadError


### PR DESCRIPTION
This is a place where we should use Solidus instead of Spree IMO.