### PR TITLE
Clone action should be a POST

### DIFF
--- a/backend/app/helpers/spree/admin/navigation_helper.rb
+++ b/backend/app/helpers/spree/admin/navigation_helper.rb
@@ -79,6 +79,7 @@ module Spree
 
       def link_to_clone(resource, options = {})
         options[:data] = { action: 'clone' }
+        options[:method] = :post
         link_to_with_icon('copy', Spree.t(:clone), clone_object_url(resource), options)
       end
 

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -45,7 +45,7 @@ Spree::Core::Engine.routes.draw do
         end
       end
       member do
-        get :clone
+        post :clone
       end
       resources :variants do
         collection do

--- a/backend/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/products_controller_spec.rb
@@ -166,6 +166,16 @@ describe Spree::Admin::ProductsController, type: :controller do
     end
   end
 
+  context "cloning a product" do
+    let!(:product) { create(:product) }
+
+    it "duplicates the product" do
+      expect do
+        post :clone, params: { id: product.id }
+      end.to change { Spree::Product.count }.by(1)
+    end
+  end
+
   # regression test for https://github.com/spree/spree/issues/801
   context "destroying a product" do
     let(:product) do


### PR DESCRIPTION
When cloning big products, specially ones with multiple variants and images, the clone action might take a lot of time to finish.

This is not a problem on itself, but it can generate 502 responses depending on the environment.

Once again, this is not a problem by itself, but in conjunction with the fact that this is done through a GET request, browsers may (and will) retry the request automatically, since GET requests are not supposed to change anything on the server side.

As a result, if a product takes too long to clone, a browser like Chrome might re-send the clone request multiple times creating several clones of the product. I've tested this locally on a particularly big product with several images (touching Google Cloud Storage, which is slow) and after a single click on "clone" I ended up with 6 clones.

Since logically a clone operation does create a new resource (similar to a create) if we use POST for this operation, this entire problem will be avoided in the future.

If people agree this is a problem I can submit a PR to fix this issue.

