### PR TITLE
Require credit card dependency in gateway class

### DIFF
--- a/core/app/models/spree/gateway.rb
+++ b/core/app/models/spree/gateway.rb
@@ -1,3 +1,5 @@
+require_dependency 'spree/credit_card'
+
 module Spree
   # A concrete implementation of `Spree::PaymentMethod` intended to provide a
   # base for extension. See https://github.com/solidusio/solidus_gateway/ for


### PR DESCRIPTION
Without requiring the spree/credit_card dependency in the Spree::Gateway class
Rails cannot lookup the constants correctly and will return Spree::CreditCard
when loading the not-even-existing Spree::Gateway::CreditCard constant.

This leads to strange errors with all payment methods inheriting from Spree::Gateway

Without this change:

    Spree::Gateway::CreditCard
    => Spree::CreditCard # Wrong Constant returned
    Spree::CreditCard
    => Spree::CreditCard # Constant now loaded
    Spree::Gateway::CreditCard
    => NameError: uninitialized constant Spree::Gateway::CreditCard

With this change:

    Spree::Gateway::CreditCard
    => NameError: uninitialized constant Spree::Gateway::CreditCard