### PR TITLE
Do not show broken links in admin product view when product is deleted

### DIFF
--- a/backend/app/views/spree/admin/shared/_product_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_product_tabs.html.erb
@@ -9,19 +9,19 @@
       <% end if can?(:admin, Spree::Product) %>
       <%= content_tag :li, class: ('active' if current == 'Images') do %>
         <%= link_to Spree.t(:images), spree.admin_product_images_url(@product) %>
-      <% end if can?(:admin, Spree::Image) %>
+      <% end if can?(:admin, Spree::Image) && !@product.deleted? %>
       <%= content_tag :li, class: ('active' if current == 'Variants') do %>
         <%= link_to plural_resource_name(Spree::Variant), spree.admin_product_variants_url(@product) %>
       <% end if can?(:admin, Spree::Variant) %>
       <%= content_tag :li, class: ('active' if current == 'Prices') do %>
         <%= link_to plural_resource_name(Spree::Price), spree.admin_product_prices_url(@product) %>
-      <% end if can?(:admin, Spree::Price) %>
+      <% end if can?(:admin, Spree::Price) && !@product.deleted? %>
       <%= content_tag :li, class: ('active' if current == 'Product Properties') do %>
         <%= link_to plural_resource_name(Spree::ProductProperty), spree.admin_product_product_properties_url(@product) %>
-      <% end if can?(:admin, Spree::ProductProperty) %>
+      <% end if can?(:admin, Spree::ProductProperty) && !@product.deleted? %>
       <%= content_tag :li, class: ('active' if current == 'Stock Management') do %>
         <%= link_to Spree.t(:stock_management), spree.admin_product_stock_url(@product) %>
-      <% end if can?(:admin, Spree::StockItem) %>
+      <% end if can?(:admin, Spree::StockItem) && !@product.deleted? %>
     </ul>
   </nav>
 <% end %>

--- a/backend/spec/features/admin/products/products_spec.rb
+++ b/backend/spec/features/admin/products/products_spec.rb
@@ -252,7 +252,7 @@ describe "Products", type: :feature do
     context 'deleting a product', js: true do
       let!(:product) { create(:product) }
 
-      it "is still viewable" do
+      it "product details are still viewable" do
         visit spree.admin_products_path
 
         expect(page).to have_content(product.name)
@@ -267,6 +267,9 @@ describe "Products", type: :feature do
         click_button "Search"
         click_link product.name
         expect(page).to have_field('Master Price', with: product.price.to_f)
+        expect(page).to_not have_content('Images')
+        expect(page).to_not have_content('Prices')
+        expect(page).to_not have_content('Product Properties')
       end
     end
   end


### PR DESCRIPTION
Fixes #1987 - Admin product page for a deleted item shows errors when clicking around.

Hides broken tabs (Images, Variants, Prices, Product Stock) in Admin Product View if the product is deleted.