### PR TITLE
Select current store using a standard Config preference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Solidus 2.3.0 (master, unreleased)
 
+- Deprecate `Spree::Core::CurrentStore` in favor of `Spree::CurrentStoreSelector`. [\#1993](https://github.com/solidusio/solidus/pull/1993)
 - Deprecate `Spree::Order#assign_default_addresses!` in favor of `Order.new.assign_default_user_addresses`. [\#1954](https://github.com/solidusio/solidus/pull/1954) ([kennyadsl](https://github.com/kennyadsl))
 - Change how line item options are allowed in line items controller. [\#1943](https://github.com/solidusio/solidus/pull/1943)
 - Allow custom separator between a promotion's `base_code` and `suffix` [\#1951](https://github.com/solidusio/solidus/pull/1951) ([ericgross](https://github.com/ericgross))

--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -387,6 +387,16 @@ module Spree
       @tax_calculator_class ||= Spree::TaxCalculator::Default
     end
 
+    # Allows providing your own class for choosing which store to use.
+    #
+    # @!attribute [rw] current_store_selector_class
+    # @return [Class] a class with the same public interfaces as
+    #   Spree::CurrentStoreSelector
+    attr_writer :current_store_selector_class
+    def current_store_selector_class
+      @current_store_selector_class ||= Spree::CurrentStoreSelector
+    end
+
     def static_model_preferences
       @static_model_preferences ||= Spree::Preferences::StaticModelPreferences.new
     end

--- a/core/app/models/spree/current_store_selector.rb
+++ b/core/app/models/spree/current_store_selector.rb
@@ -1,0 +1,28 @@
+# Default class for deciding what the current store is, given an HTTP request
+# This is an extension point used in Spree::Core::ControllerHelpers::Store
+# Custom versions of this class must respond to a store instance method
+module Spree
+  class CurrentStoreSelector
+    def initialize(request)
+      @request = request
+    end
+
+    # Chooses the current store based on a request.
+    # Checks request headers for HTTP_SPREE_STORE and falls back to
+    # looking up by the requesting server's name.
+    # @return [Spree::Store]
+    def store
+      if store_key
+        Spree::Store.current(store_key)
+      else
+        Spree::Store.default
+      end
+    end
+
+    private
+
+    def store_key
+      @request.headers['HTTP_SPREE_STORE'] || @request.env['SERVER_NAME']
+    end
+  end
+end

--- a/core/lib/spree/core/controller_helpers/store.rb
+++ b/core/lib/spree/core/controller_helpers/store.rb
@@ -4,20 +4,12 @@ module Spree
       module Store
         extend ActiveSupport::Concern
 
-        # @!attribute [rw] current_store_class
-        #   @!scope class
-        #   Extension point for overriding how the current store is chosen.
-        #   Defaults to checking headers and server name
-        #   @return [#store] class used to help find the current store
         included do
-          class_attribute :current_store_class
-          self.current_store_class = Spree::Core::CurrentStore
-
           helper_method :current_store
         end
 
         def current_store
-          @current_store ||= current_store_class.new(request).store
+          @current_store ||= Spree::Config.current_store_selector_class.new(request).store
         end
       end
     end

--- a/core/lib/spree/core/current_store.rb
+++ b/core/lib/spree/core/current_store.rb
@@ -6,24 +6,16 @@ module Spree
     class CurrentStore
       def initialize(request)
         @request = request
+        @current_store_selector = Spree::Config.current_store_selector_class.new(request)
+        Spree::Deprecation.warn "Using Spree::Core::CurrentStore is deprecated. Use Spree::CurrentStoreSelector instead", caller
       end
 
-      # Chooses the current store based on a request.
-      # Checks request headers for HTTP_SPREE_STORE and falls back to
-      # looking up by the requesting server's name.
+      # Delegate store selection to Spree::Config.current_store_selector_class
+      # Using this class is deprecated.
+      #
       # @return [Spree::Store]
       def store
-        if store_key
-          Spree::Store.current(store_key)
-        else
-          Spree::Store.default
-        end
-      end
-
-      private
-
-      def store_key
-        @request.headers['HTTP_SPREE_STORE'] || @request.env['SERVER_NAME']
+        @current_store_selector.store
       end
     end
   end

--- a/core/spec/lib/spree/core/current_store_spec.rb
+++ b/core/spec/lib/spree/core/current_store_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Spree::Core::CurrentStore do
   describe "#store" do
-    subject { Spree::Core::CurrentStore.new(request).store }
+    subject { Spree::Deprecation.silence { Spree::Core::CurrentStore.new(request).store } }
 
     context "with a default" do
       let(:request) { double(headers: {}, env: {}) }
@@ -31,6 +31,11 @@ describe Spree::Core::CurrentStore do
           end
         end
       end
+    end
+
+    it 'is deprecated' do
+      expect(Spree::Deprecation).to(receive(:warn))
+      Spree::Core::CurrentStore.new(double)
     end
   end
 end

--- a/core/spec/models/spree/current_store_selector_spec.rb
+++ b/core/spec/models/spree/current_store_selector_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe Spree::CurrentStoreSelector do
+  describe "#store" do
+    subject { Spree::CurrentStoreSelector.new(request).store }
+
+    context "with a default" do
+      let(:request) { double(headers: {}, env: {}) }
+      let!(:store_1) { create :store, default: true }
+
+      it "returns the default store" do
+        expect(subject).to eq(store_1)
+      end
+
+      context "with a domain match" do
+        let(:request) { double(headers: {}, env: { "SERVER_NAME" => url } ) }
+        let(:url) { "server-name.org" }
+        let!(:store_2) { create :store, default: false, url: url }
+
+        it "returns the store with the matching domain" do
+          expect(subject).to eq(store_2)
+        end
+
+        context "with headers" do
+          let(:request) { double(headers: { "HTTP_SPREE_STORE" => headers_code }, env: {}) }
+          let(:headers_code) { "HEADERS" }
+          let!(:store_3) { create :store, code: headers_code, default: false }
+
+          it "returns the store with the matching code" do
+            expect(subject).to eq(store_3)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a first step in the attempt of reducing the queries made at each request in a default solidus store that doesn't use multiple stores, as for #1971 .

The goal here is to:

1. make it more standard/easier to use another class to determine which store to use (this PR)
2. move out of core [the logic that checks requests info](https://github.com/solidusio/solidus/blob/befa551eb8bc783df94647a757fe1628e3238d27/core/lib/spree/core/current_store.rb#L25-L27) to determine if another store has to be used. This will be moved to [solidus_multi_domain](https://github.com/solidusio/solidus_multi_domain).
3. just use the `Spree::Store.default` on a solidus store without solidus_multi_domain avoiding multiple queries for each request.
