### PR TITLE
Fix avs response admin area tablesplosion

### DIFF
--- a/backend/app/views/spree/admin/orders/_risk_analysis.html.erb
+++ b/backend/app/views/spree/admin/orders/_risk_analysis.html.erb
@@ -22,13 +22,12 @@
       <tr>
         <td><strong><%= Spree.t(:avs_response) %>:</strong></td>
         <td class="align-center">
-          <span class="<%= latest_payment.is_avs_risky? ? 'state void' : 'state complete' %>">
-            <% if latest_payment.is_avs_risky? %>
-              <%= "#{Spree.t(:error)}: #{avs_response_code[latest_payment.avs_response]}" %>
-            <% else %>
-              <%= Spree.t(:success) %>
-            <% end %>
-          </span>
+          <% if latest_payment.is_avs_risky? %>
+            <span class="state void"><%= Spree.t(:error) %>:</span>
+            <%= avs_response_code[latest_payment.avs_response] %>
+          <% else %>
+            <span class="state complete"><%= Spree.t(:success) %></span>
+          <% end %>
         </td>
       </tr>
 


### PR DESCRIPTION
@tvdeyen improved the look of the table headers in https://github.com/solidusio/solidus/commit/0dcc02823fd73989eeca24a89b212c4027976a8e but also created a problem for long "state" fields (eg: order payment AVS response). If we break the body of the avs response out of the `%span.state` we can keep the `table .state { white-space: nowrap; }` which usually helps and avoid this one case where we send lots of words.

## Before
![screen shot 2017-06-05 at 1 27 04 pm](https://cloud.githubusercontent.com/assets/1529452/26801837/fe75e918-49f2-11e7-8945-3f7e835aa913.png)


## After
![screen shot 2017-06-05 at 1 27 25 pm](https://cloud.githubusercontent.com/assets/1529452/26801840/00f01fc4-49f3-11e7-90be-d19ecba54a42.png)
