### PR TITLE
Add check for eligibility to free shipping promotion handler

### DIFF
--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -85,6 +85,7 @@ module Spree
     end
 
     def activate(order:, line_item: nil, user: nil, path: nil, promotion_code: nil)
+      return unless eligible?(order)
       return unless self.class.order_activatable?(order)
 
       payload = {


### PR DESCRIPTION
### Steps to reproduce
1. Create a free shipping promotion and add a rule for item total to be greater than or equal to a certain amount.
2. Check out with an order that doesn't satisfy the minimum item total.

### Expected behavior
The free shipping promotion should not be applied to the order.

### Actual behavior
The free shipping promotion is applied to the order even when the rule isn't satisfied.

### System configuration
**Solidus Version**: 2.2.1