### PR TITLE
Specify countries that don’t require states

### DIFF
--- a/core/db/default/spree/countries.rb
+++ b/core/db/default/spree/countries.rb
@@ -1,5 +1,14 @@
 require 'carmen'
 
+# These countries have subregions, but typically don't use them in postal
+# addresses.
+COUNTRIES_THAT_DONT_REQUIRE_STATES = %w(NZ)
+
+def require_states?(country)
+  return false if COUNTRIES_THAT_DONT_REQUIRE_STATES.include? country.alpha_2_code
+  country.subregions?
+end
+
 ActiveRecord::Base.transaction do
   Carmen::Country.all.each do |country|
     Spree::Country.where(iso: country.alpha_2_code).first_or_create!(
@@ -7,7 +16,7 @@ ActiveRecord::Base.transaction do
       iso3: country.alpha_3_code,
       iso_name: country.name.upcase,
       numcode: country.numeric_code,
-      states_required: country.subregions?
+      states_required: require_states?(country)
     )
   end
 end


### PR DESCRIPTION
Some countries have subregions recorded in Carmen data, but people typically don’t use them in postal addresses. This adds an array of such countries to check before we assume that subregions are required.

For New Zealand, Carmen data includes provinces, and groups them by island, so Solidus checkout requires customers to choose "North Island", "South Island" or "Chatham Islands". This is not customary practice and is specifically recommended against in New Zealand Post's address standards (https://www.nzpost.co.nz/sites/default/files/uploads/shared/standards-guides/adv358-address-standards.pdf).

No doubt there are other countries where a similar situation applies, and which could be included in this pull request.