### PR TITLE
Update RuboCop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -106,6 +106,17 @@ Rails/DynamicFindBy:
     - find_by_param
     - find_by_param!
 
+# We use a lot of
+#
+#     expect {
+#       something
+#     }.to { happen }
+#
+# syntax in the specs files.
+Lint/AmbiguousBlockAssociation:
+  Exclude:
+    - '*/spec/**/*'
+
 # From http://relaxed.ruby.style/
 
 Style/Alias:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -117,6 +117,12 @@ Lint/AmbiguousBlockAssociation:
   Exclude:
     - '*/spec/**/*'
 
+# We use eval to add common_spree_dependencies into the Gemfiles of each of our gems
+Security/Eval:
+  Exclude:
+    - 'Gemfile'
+    - '*/Gemfile'
+
 # From http://relaxed.ruby.style/
 
 Style/Alias:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ AllCops:
     - '*/spec/dummy/**/*'
     - 'sandbox/**/*'
     - '**/templates/**/*'
-  TargetRubyVersion: 2.1
+  TargetRubyVersion: 2.2
 
 # Sometimes I believe this reads better
 # This also causes spacing issues on multi-line fixes

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -101,6 +101,11 @@ Style/TrailingCommaInLiteral:
 Style/SymbolArray:
   Enabled: false
 
+Rails/DynamicFindBy:
+  Whitelist:
+    - find_by_param
+    - find_by_param!
+
 # From http://relaxed.ruby.style/
 
 Style/Alias:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -97,6 +97,10 @@ Style/TrailingCommaInArguments:
 Style/TrailingCommaInLiteral:
   Enabled: false
 
+# Symbol Arrays are ok and the %i syntax widely unknown
+Style/SymbolArray:
+  Enabled: false
+
 # From http://relaxed.ruby.style/
 
 Style/Alias:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -126,6 +126,10 @@ Security/Eval:
 Style/VariableNumber:
   Enabled: false
 
+# Write empty methods as you wish.
+Style/EmptyMethod:
+  Enabled: false
+
 # From http://relaxed.ruby.style/
 
 Style/Alias:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -123,6 +123,9 @@ Security/Eval:
     - 'Gemfile'
     - '*/Gemfile'
 
+Style/VariableNumber:
+  Enabled: false
+
 # From http://relaxed.ruby.style/
 
 Style/Alias:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -67,28 +67,28 @@ Style/AsciiComments:
 Lint/EndAlignment:
   Enabled: false
 
-Style/ElseAlignment:
+Layout/ElseAlignment:
   Enabled: false
 
-Style/IndentationWidth:
+Layout/IndentationWidth:
   Enabled: false
 
-Style/AlignParameters:
+Layout/AlignParameters:
   Enabled: false
 
-Style/ClosingParenthesisIndentation:
+Layout/ClosingParenthesisIndentation:
   Enabled: false
 
-Style/MultilineMethodCallIndentation:
+Layout/MultilineMethodCallIndentation:
   Enabled: false
 
-Style/IndentArray:
+Layout/IndentArray:
   Enabled: false
 
-Style/IndentHash:
+Layout/IndentHash:
   Enabled: false
 
-Style/AlignHash:
+Layout/AlignHash:
   Enabled: false
 
 Style/TrailingCommaInArguments:
@@ -115,7 +115,7 @@ Style/Documentation:
   Enabled: false
   StyleGuide: http://relaxed.ruby.style/#styledocumentation
 
-Style/DotPosition:
+Layout/DotPosition:
   Enabled: false
   StyleGuide: http://relaxed.ruby.style/#styledotposition
 
@@ -183,11 +183,11 @@ Style/SingleLineMethods:
   Enabled: false
   StyleGuide: http://relaxed.ruby.style/#stylesinglelinemethods
 
-Style/SpaceBeforeBlockBraces:
+Layout/SpaceBeforeBlockBraces:
   Enabled: false
   StyleGuide: http://relaxed.ruby.style/#stylespacebeforeblockbraces
 
-Style/SpaceInsideParens:
+Layout/SpaceInsideParens:
   Enabled: false
   StyleGuide: http://relaxed.ruby.style/#stylespaceinsideparens
 


### PR DESCRIPTION
After we merged 2c775ab24e592b3949de417712017c1adb4de3f9 we decided to enable 
the cop for `Rails/DynamicFindBy`.

Along this I updated outdated configuration syntax and disabled/relaxed some
cops.