### PR TITLE
Fix spurious failures in order_factory_spec

### DIFF
--- a/core/spec/lib/spree/core/testing_support/factories/order_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/order_factory_spec.rb
@@ -44,22 +44,26 @@ RSpec.shared_examples "an order with line items factory" do |expected_order_stat
 
         expect(order.shipments[0].shipping_method).to eq(shipping_method)
 
-        expect(order.shipments[0].inventory_units.count).to eq(3)
-        expect(order.shipments[0].inventory_units[0]).to have_attributes(
+        # Explicitly order by line item id, because otherwise these can be in
+        # an arbitrary order.
+        inventory_units = order.shipments[0].inventory_units.sort_by(&:line_item_id)
+
+        expect(inventory_units.count).to eq(3)
+        expect(inventory_units[0]).to have_attributes(
           order: order,
           shipment: order.shipments[0],
           line_item: order.line_items[0],
           variant: order.line_items[0].variant,
           state: expected_inventory_unit_state
         )
-        expect(order.shipments[0].inventory_units[1]).to have_attributes(
+        expect(inventory_units[1]).to have_attributes(
           order: order,
           shipment: order.shipments[0],
           line_item: order.line_items[1],
           variant: order.line_items[1].variant,
           state: expected_inventory_unit_state
         )
-        expect(order.shipments[0].inventory_units[2]).to have_attributes(
+        expect(inventory_units[2]).to have_attributes(
           order: order,
           shipment: order.shipments[0],
           line_item: order.line_items[1],


### PR DESCRIPTION
It's valid for the DB to return the inventory units in any order, resulting in some spurious failures in this test.