### PR TITLE
Specify Rails 5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Getting started
 
 Begin by making sure you have [Imagemagick](http://imagemagick.org/script/download.php) installed, which is required for Paperclip. (You can install it using [Homebrew](https://brew.sh) if you're on a Mac.)
 
-To add solidus, begin with a Rails 5 application. Add the following to your
+To add solidus, begin with a Rails 5.0 application. Add the following to your
 Gemfile.
 
 ```ruby


### PR DESCRIPTION
Rails 5.1 is currently incompatible with any gem release of Solidus, so I think it makes sense to specify Rails 5.0.x in the guide.