### PR TITLE
Make :class_name a string in TaxCategory

### DIFF
--- a/core/app/models/spree/tax_category.rb
+++ b/core/app/models/spree/tax_category.rb
@@ -5,12 +5,12 @@ module Spree
     validates_uniqueness_of :name, unless: :deleted_at
 
     has_many :tax_rate_tax_categories,
-      class_name: Spree::TaxRateTaxCategory,
+      class_name: 'Spree::TaxRateTaxCategory',
       dependent: :destroy,
       inverse_of: :tax_category
     has_many :tax_rates,
       through: :tax_rate_tax_categories,
-      class_name: Spree::TaxRate,
+      class_name: 'Spree::TaxRate',
       inverse_of: :tax_categories
 
     after_save :ensure_one_default

--- a/core/app/models/spree/tax_rate_tax_category.rb
+++ b/core/app/models/spree/tax_rate_tax_category.rb
@@ -1,6 +1,6 @@
 module Spree
   class TaxRateTaxCategory < Spree::Base
-    belongs_to :tax_rate, class_name: Spree::TaxRate, inverse_of: :tax_rate_tax_categories
-    belongs_to :tax_category, class_name: Spree::TaxCategory, inverse_of: :tax_rate_tax_categories
+    belongs_to :tax_rate, class_name: 'Spree::TaxRate', inverse_of: :tax_rate_tax_categories
+    belongs_to :tax_category, class_name: 'Spree::TaxCategory', inverse_of: :tax_rate_tax_categories
   end
 end


### PR DESCRIPTION
Fixes the warning:

    DEPRECATION WARNING: Passing a class to the `class_name` is deprecated and will raise 
    an ArgumentError in Rails 5.2.