### PR TITLE
Re-add deprecated TaxRate#tax_category

### DIFF
--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -112,6 +112,16 @@ module Spree
       )
     end
 
+    def tax_category=(category)
+      self.tax_categories = [category]
+    end
+
+    def tax_category
+      tax_categories[0]
+    end
+
+    deprecate :tax_category => :tax_categories, :tax_category= => :tax_categories=, deprecator: Spree::Deprecation
+
     private
 
     def amount_for_adjustment_label

--- a/core/spec/models/spree/tax_rate_spec.rb
+++ b/core/spec/models/spree/tax_rate_spec.rb
@@ -334,4 +334,26 @@ describe Spree::TaxRate, type: :model do
       end
     end
   end
+
+  describe '#tax_category (deprecated)' do
+    let(:tax_rate) { create(:tax_rate, tax_categories: [tax_category]) }
+    let(:tax_category) { create(:tax_category) }
+
+    it "returns the first tax category" do
+      tax_category = Spree::Deprecation.silence { tax_rate.tax_category }
+      expect(tax_category).to eq(tax_category)
+    end
+  end
+
+  describe '#tax_category= (deprecated)' do
+    let(:tax_rate) { Spree::TaxRate.new }
+    let(:tax_category) { create(:tax_category) }
+
+    it "can assign the tax categories" do
+      Spree::Deprecation.silence {
+        tax_rate.tax_category = tax_category
+      }
+      expect(tax_rate.tax_categories).to eq([tax_category])
+    end
+  end
 end


### PR DESCRIPTION
This was removed when the association was changed to a many-to-many (#1851). It's easy enough for us to provide the basic accessors as deprecated methods.