### PR TITLE
set_count_on_hand should use lock

### DIFF
--- a/core/app/models/spree/stock_item.rb
+++ b/core/app/models/spree/stock_item.rb
@@ -45,10 +45,12 @@ module Spree
     # @note This will cause backorders to be processed.
     # @param value [Fixnum] the desired count on hand
     def set_count_on_hand(value)
-      self.count_on_hand = value
-      process_backorders(count_on_hand - count_on_hand_was)
+      with_lock do
+        self.count_on_hand = value
+        process_backorders(count_on_hand - count_on_hand_was)
 
-      save!
+        save!
+      end
     end
 
     # @return [Boolean] true if this stock item's count on hand is not zero


### PR DESCRIPTION
This is the same pattern that was followed for adjust_count_on_hand to
avoid deadlocks.

Reopens https://github.com/solidusio/solidus/pull/1101 to see if this will now pass on master.