### PR TITLE
Emit Spree.url deprecation warning in all envs

### DIFF
--- a/core/app/assets/javascripts/spree.js.erb
+++ b/core/app/assets/javascripts/spree.js.erb
@@ -24,7 +24,7 @@ Spree.pathFor = function(path) {
 
 Spree.url = function(uri, query) {
   if (console && console.warn) {
-    console.warn('Spree.url is deprecated, please use Spree.ajax for your request instead.');
+    console.warn('Spree.url is deprecated, and will be removed from a future Solidus version.');
   }
   if (uri.path === undefined) {
     uri = new Uri(uri);

--- a/core/app/assets/javascripts/spree.js.erb
+++ b/core/app/assets/javascripts/spree.js.erb
@@ -23,7 +23,7 @@ Spree.pathFor = function(path) {
 };
 
 Spree.url = function(uri, query) {
-  if (Spree.env === 'development' || Spree.env === 'test') {
+  if (console && console.warn) {
     console.warn('Spree.url is deprecated, please use Spree.ajax for your request instead.');
   }
   if (uri.path === undefined) {

--- a/frontend/app/assets/javascripts/spree/frontend/checkout/coupon-code.js.coffee
+++ b/frontend/app/assets/javascripts/spree/frontend/checkout/coupon-code.js.coffee
@@ -6,18 +6,18 @@ Spree.onCouponCodeApply = (e) ->
   couponStatus = $("#coupon_status")
   successClass = 'success'
   errorClass = 'alert'
-  url = Spree.url(Spree.routes.apply_coupon_code(Spree.current_order_id),
-    {
-      order_token: Spree.current_order_token,
-      coupon_code: couponCode
-    }
-  )
 
   couponStatus.removeClass([successClass,errorClass].join(" "))
 
+  data =
+    order_token: Spree.current_order_token,
+    coupon_code: couponCode
+
   req = Spree.ajax
-    method: "PUT",
-    url: url
+    method: "PUT"
+    url: Spree.routes.apply_coupon_code(Spree.current_order_id)
+    data: JSON.stringify(data)
+    contentType: "application/json"
 
   req.done (data) ->
     window.location.reload()


### PR DESCRIPTION
This has been deprecated forever, but I'm still not confident enough to remove it. It's possible that it hasn't been seen by users because `Spree.env` has been unset (as it is in our default frontend).

This commit changes the warning to be issued always (so long as console and console.warn are defined).

This also removes a call to `Spree.url` from solidus_frontend.