### PR TITLE
Deprecate Shipment#add_shipping_method

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -95,6 +95,7 @@ module Spree
     def add_shipping_method(shipping_method, selected = false)
       shipping_rates.create(shipping_method: shipping_method, selected: selected, cost: cost)
     end
+    deprecate :add_shipping_method, deprecator: Spree::Deprecation
 
     def after_cancel
       manifest.each { |item| manifest_restock(item) }

--- a/core/lib/spree/testing_support/factories/shipment_factory.rb
+++ b/core/lib/spree/testing_support/factories/shipment_factory.rb
@@ -16,7 +16,11 @@ FactoryGirl.define do
 
     after(:create) do |shipment, evaluator|
       shipping_method = evaluator.shipping_method || create(:shipping_method, cost: evaluator.cost)
-      shipment.add_shipping_method(shipping_method, true)
+      shipment.shipping_rates.create!(
+        shipping_method: shipping_method,
+        cost: evaluator.cost,
+        selected: true
+      )
 
       shipment.order.line_items.each do |line_item|
         line_item.quantity.times do

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -797,7 +797,7 @@ describe Spree::Shipment, type: :model do
 
   describe '#selected_shipping_rate_id=' do
     let!(:air_shipping_method) { create(:shipping_method, name: "Air") }
-    let(:new_rate) { shipment.add_shipping_method(air_shipping_method) }
+    let(:new_rate) { shipment.shipping_rates.create!(shipping_method: air_shipping_method) }
 
     context 'when the id exists' do
       it 'sets the new shipping rate as selected' do


### PR DESCRIPTION
This was a convenience method which was used in specs to add a shipping rate with a given shipping method. However it isn't suitable for use outside of specs. It doesn't handle having an existing selected rate and doesn't calculate the correct cost.

In specs it would be better just to create the shipping_rate instead of using this method, as it will be more obvious what is going on.