### PR TITLE
Remove ! from assign_default_user_addresses!

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -698,6 +698,9 @@ module Spree
       self.ship_address = Spree::Address.immutable_merge(ship_address, attributes)
     end
 
+    # Assigns a default bill_address and ship_address to the order based on the
+    # associated user's bill_address and ship_address.
+    # @note This doesn't persist the change bill_address or ship_address
     def assign_default_user_addresses!
       if user
         # this is one of 2 places still using User#bill_address

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -701,7 +701,7 @@ module Spree
     # Assigns a default bill_address and ship_address to the order based on the
     # associated user's bill_address and ship_address.
     # @note This doesn't persist the change bill_address or ship_address
-    def assign_default_user_addresses!
+    def assign_default_user_addresses
       if user
         # this is one of 2 places still using User#bill_address
         self.bill_address ||= user.bill_address if user.bill_address.try!(:valid?)
@@ -710,8 +710,11 @@ module Spree
         self.ship_address ||= user.ship_address if user.ship_address.try!(:valid?) && checkout_steps.include?("delivery")
       end
     end
-    alias_method :assign_default_addresses!, :assign_default_user_addresses!
-    deprecate assign_default_addresses!: :assign_default_user_addresses!, deprecator: Spree::Deprecation
+
+    alias_method :assign_default_user_addresses!, :assign_default_user_addresses
+    deprecate assign_default_user_addresses!: :assign_default_user_addresses, deprecator: Spree::Deprecation
+    alias_method :assign_default_addresses!, :assign_default_user_addresses
+    deprecate assign_default_addresses!: :assign_default_user_addresses, deprecator: Spree::Deprecation
 
     def persist_user_address!
       if !temporary_address && user && user.respond_to?(:persist_order_address) && bill_address_id

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -90,7 +90,7 @@ module Spree
             before_transition from: :cart, do: :ensure_line_items_present
 
             if states[:address]
-              before_transition to: :address, do: :assign_default_user_addresses!
+              before_transition to: :address, do: :assign_default_user_addresses
               before_transition from: :address, do: :persist_user_address!
             end
 

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -785,10 +785,10 @@ describe Spree::Order, type: :model do
     end
   end
 
-  context "#assign_default_user_addresses!" do
+  context "#assign_default_user_addresses" do
     let(:order) { Spree::Order.new }
 
-    subject { order.assign_default_user_addresses! }
+    subject { order.assign_default_user_addresses }
 
     context "when no user is associated to the order" do
       it "does not associate any bill address" do

--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -171,7 +171,7 @@ module Spree
     end
 
     def before_address
-      @order.assign_default_user_addresses!
+      @order.assign_default_user_addresses
       # If the user has a default address, the previous method call takes care
       # of setting that; but if he doesn't, we need to build an empty one here
       default = {country_id: Spree::Country.default.id}

--- a/frontend/spec/controllers/spree/checkout_controller_spec.rb
+++ b/frontend/spec/controllers/spree/checkout_controller_spec.rb
@@ -145,7 +145,7 @@ describe Spree::CheckoutController, type: :controller do
 
         context 'landing to address page' do
           it "tries to associate user addresses to order" do
-            expect(order).to receive(:assign_default_user_addresses!)
+            expect(order).to receive(:assign_default_user_addresses)
             get :edit
           end
         end


### PR DESCRIPTION
There was some confusion when reviewing #1967 about whether `assign_default_user_addresses!` would persist changes or not. It doesn't, but the `!` suggests that it might.

There's no version of this method without an exclamation mark. Additionally, this doesn't have any of the normal tells of a ! method, it doesn't make changes to the database, shouldn't raise exceptions, and
doesn't do anything "dangerous".

This commit renames the method to `assign_default_user_addresses`, and keeps `assign_default_user_addresses!` as a deprecated alias. It also adds some YARD docs to the method.