### PR TITLE
Avoid returning duplicate products from Product.available

### DIFF
--- a/core/app/models/spree/product/scopes.rb
+++ b/core/app/models/spree/product/scopes.rb
@@ -171,9 +171,13 @@ module Spree
       where("#{Spree::Product.quoted_table_name}.deleted_at IS NULL or #{Spree::Product.quoted_table_name}.deleted_at >= ?", Time.current)
     end
 
+    scope :with_master_price, -> do
+      joins(:master).where(Spree::Price.where(Spree::Variant.arel_table[:id].eq(Spree::Price.arel_table[:variant_id])).exists)
+    end
+
     # Can't use add_search_scope for this as it needs a default argument
     def self.available(available_on = nil)
-      joins(master: :prices).where("#{Spree::Product.quoted_table_name}.available_on <= ?", available_on || Time.current)
+      with_master_price.where("#{Spree::Product.quoted_table_name}.available_on <= ?", available_on || Time.current)
     end
     search_scopes << :available
 

--- a/core/spec/models/spree/product/scopes_spec.rb
+++ b/core/spec/models/spree/product/scopes_spec.rb
@@ -113,4 +113,50 @@ describe "Product scopes", type: :model do
       end
     end
   end
+
+  describe '.available' do
+    context "a product with past available_on" do
+      let!(:product) { create(:product, available_on: 1.day.ago) }
+
+      it "includes the product" do
+        expect(Spree::Product.available).to match_array([product])
+      end
+
+      context "with no master price" do
+        before { product.master.prices.delete_all }
+
+        it "doesn't include the product" do
+          expect(Spree::Product.available).to match_array([])
+        end
+      end
+
+      context "with soft-deleted master price" do
+        before { product.master.prices.destroy_all }
+
+        it "doesn't include the product" do
+          expect(Spree::Product.available).to match_array([])
+        end
+      end
+
+      context "with multiple prices", pending: true do
+        let!(:second_price) { create(:price, variant: product.master) }
+
+        it "includes the product only once" do
+          expect(Spree::Product.available).to match_array([product])
+        end
+
+        it "has a count of 1" do
+          expect(Spree::Product.available.count).to eq(1)
+        end
+      end
+    end
+
+    context "a product with future available_on" do
+      let!(:product) { create(:product, available_on: 1.day.from_now) }
+
+      it "doesn't include the product" do
+        expect(Spree::Product.available).to match_array([])
+      end
+    end
+  end
 end

--- a/core/spec/models/spree/product/scopes_spec.rb
+++ b/core/spec/models/spree/product/scopes_spec.rb
@@ -138,7 +138,7 @@ describe "Product scopes", type: :model do
         end
       end
 
-      context "with multiple prices", pending: true do
+      context "with multiple prices" do
         let!(:second_price) { create(:price, variant: product.master) }
 
         it "includes the product only once" do


### PR DESCRIPTION
Previously a product would be returned multiple times from the `Product.available` scope if it had multiple prices on its master variant.

This wasn't an issue when products were returned from a search or on the default frontend because `.distinct` was used, but it was confusing when `.available` was used directly.

This replaces the `INNER JOIN` to prices with a `WHERE EXISTS` subquery.