### PR TITLE
[WIP] Always use the default store

### DIFF
--- a/core/app/models/spree/current_store_selector.rb
+++ b/core/app/models/spree/current_store_selector.rb
@@ -1,5 +1,8 @@
 # Default class for deciding what the current store is, given an HTTP request
-# This is an extension point used in Spree::Core::ControllerHelpers::Store
+#
+# To use a custom version of this class just set the preference:
+#   Spree::Config.current_store_selector_class = CustomCurrentStoreSelector
+#
 # Custom versions of this class must respond to a store instance method
 module Spree
   class CurrentStoreSelector
@@ -7,22 +10,12 @@ module Spree
       @request = request
     end
 
-    # Chooses the current store based on a request.
-    # Checks request headers for HTTP_SPREE_STORE and falls back to
-    # looking up by the requesting server's name.
+    # Select the store to be used. In this basic implementation the
+    # default store will be always selected.
+    #
     # @return [Spree::Store]
     def store
-      if store_key
-        Spree::Store.current(store_key)
-      else
-        Spree::Store.default
-      end
-    end
-
-    private
-
-    def store_key
-      @request.headers['HTTP_SPREE_STORE'] || @request.env['SERVER_NAME']
+      Spree::Store.default
     end
   end
 end

--- a/core/spec/lib/spree/core/current_store_spec.rb
+++ b/core/spec/lib/spree/core/current_store_spec.rb
@@ -5,31 +5,11 @@ describe Spree::Core::CurrentStore do
     subject { Spree::Deprecation.silence { Spree::Core::CurrentStore.new(request).store } }
 
     context "with a default" do
-      let(:request) { double(headers: {}, env: {}) }
+      let(:request) { double('any request') }
       let!(:store_1) { create :store, default: true }
 
       it "returns the default store" do
         expect(subject).to eq(store_1)
-      end
-
-      context "with a domain match" do
-        let(:request) { double(headers: {}, env: { "SERVER_NAME" => url } ) }
-        let(:url) { "server-name.org" }
-        let!(:store_2) { create :store, default: false, url: url }
-
-        it "returns the store with the matching domain" do
-          expect(subject).to eq(store_2)
-        end
-
-        context "with headers" do
-          let(:request) { double(headers: { "HTTP_SPREE_STORE" => headers_code }, env: {}) }
-          let(:headers_code) { "HEADERS" }
-          let!(:store_3) { create :store, code: headers_code, default: false }
-
-          it "returns the store with the matching code" do
-            expect(subject).to eq(store_3)
-          end
-        end
       end
     end
 

--- a/core/spec/models/spree/current_store_selector_spec.rb
+++ b/core/spec/models/spree/current_store_selector_spec.rb
@@ -5,31 +5,11 @@ describe Spree::CurrentStoreSelector do
     subject { Spree::CurrentStoreSelector.new(request).store }
 
     context "with a default" do
-      let(:request) { double(headers: {}, env: {}) }
+      let(:request) { double('any request') }
       let!(:store_1) { create :store, default: true }
 
       it "returns the default store" do
         expect(subject).to eq(store_1)
-      end
-
-      context "with a domain match" do
-        let(:request) { double(headers: {}, env: { "SERVER_NAME" => url } ) }
-        let(:url) { "server-name.org" }
-        let!(:store_2) { create :store, default: false, url: url }
-
-        it "returns the store with the matching domain" do
-          expect(subject).to eq(store_2)
-        end
-
-        context "with headers" do
-          let(:request) { double(headers: { "HTTP_SPREE_STORE" => headers_code }, env: {}) }
-          let(:headers_code) { "HEADERS" }
-          let!(:store_3) { create :store, code: headers_code, default: false }
-
-          it "returns the store with the matching code" do
-            expect(subject).to eq(store_3)
-          end
-        end
       end
     end
   end


### PR DESCRIPTION
This commit avoids doing 2 extra queries for every request (#1971)
even when solidus store is not using solidus_multi_domain extension.

This logic has now been moved to the solidus_multi_domain extension
since it is needed only when multiple stores are expected
(solidusio/solidus_multi_domain#67).


*NOTE:* there's something I'm not too happy about this PR. I'm moving out to solidus_multi_domain extension a spec about filtering api orders by store. But the [code that filters api orders at the moment is still in core](https://github.com/solidusio/solidus/blob/befa551eb8bc783df94647a757fe1628e3238d27/api/app/controllers/spree/api/orders_controller.rb#L75). 
Since the new version of the "store selector class" always returns the default store, I'm not sure it makes sense to test that logic in core, even if the code is here. What about moving the controller code into the extension as it is done for [shipments](https://github.com/nebulab/solidus_multi_domain/blob/178a4b5a63fc139614bfffd1589f0057d17b085b/app/controllers/spree/api/shipments_controller_decorator.rb#L4)?


