### PR TITLE
Fix ShippingMethod select for MySQL 5.7 strict

### DIFF
--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -36,10 +36,12 @@ module Spree
       # cause this to return incorrect results.
       join_table = Spree::ShippingMethodCategory.arel_table
       having = join_table[:id].count(true).eq(shipping_category_ids.count)
-      joins(:shipping_method_categories).
+      subquery = joins(:shipping_method_categories).
         where(spree_shipping_method_categories: { shipping_category_id: shipping_category_ids }).
         group('spree_shipping_methods.id').
         having(having)
+
+      where(id: subquery.select(:id))
     end
 
     # @param stock_location [Spree::StockLocation] stock location


### PR DESCRIPTION
This was previously failing under MySQL 5.7 because we were grouping by only shipping_methods.id, but selecting shipping_methods.*.

This commit avoids the issue by moving the group by into a subquery.