### PR TITLE
Fix admin SQL issues with DISTINCT products

### DIFF
--- a/backend/app/controllers/spree/admin/products_controller.rb
+++ b/backend/app/controllers/spree/admin/products_controller.rb
@@ -102,7 +102,6 @@ module Spree
         # @search needs to be defined as this is passed to search_form_for
         @search = super.ransack(params[:q])
         @collection = @search.result.
-              distinct_by_product_ids(params[:q][:s]).
               includes(product_includes).
               page(params[:page]).
               per(Spree::Config[:admin_products_per_page])

--- a/backend/app/views/spree/admin/products/index.html.erb
+++ b/backend/app/views/spree/admin/products/index.html.erb
@@ -26,8 +26,8 @@
 
           <div class="col-4">
             <div class="field">
-              <%= f.label :variants_including_master_sku_cont, Spree::Variant.human_attribute_name(:sku) %>
-              <%= f.text_field :variants_including_master_sku_cont, size: 15 %>
+              <%= f.label :with_variant_sku_cont, Spree::Variant.human_attribute_name(:sku) %>
+              <%= f.text_field :with_variant_sku_cont, size: 15 %>
             </div>
           </div>
 

--- a/backend/spec/features/admin/products/products_spec.rb
+++ b/backend/spec/features/admin/products/products_spec.rb
@@ -113,17 +113,42 @@ describe "Products", type: :feature do
         create(:product, name: 'zomg shirt')
 
         click_nav "Products"
-        fill_in "q_name_cont", with: "ap"
+        fill_in "Name", with: "ap"
         click_button 'Search'
         expect(page).to have_content("apache baseball cap")
         expect(page).to have_content("apache baseball cap2")
         expect(page).not_to have_content("zomg shirt")
 
-        fill_in "q_variants_including_master_sku_cont", with: "A1"
+        fill_in "SKU", with: "A1"
         click_button "Search"
         expect(page).to have_content("apache baseball cap")
         expect(page).not_to have_content("apache baseball cap2")
         expect(page).not_to have_content("zomg shirt")
+      end
+
+      # Regression test for https://github.com/solidusio/solidus/issues/2016
+      it "should be able to search and sort by price" do
+        product = create(:product, name: 'apache baseball cap', sku: "A001")
+        create(:variant, product: product, sku: "A002")
+        create(:product, name: 'zomg shirt', sku: "Z001")
+
+        click_nav "Products"
+        expect(page).to have_content("apache baseball cap")
+        expect(page).to have_content("zomg shirt")
+        expect(page).to have_css('#listing_products > tbody > tr', count: 2)
+
+        fill_in "SKU", with: "A"
+        click_button 'Search'
+        expect(page).to have_content("apache baseball cap")
+        expect(page).not_to have_content("zomg shirt")
+        expect(page).to have_css('#listing_products > tbody > tr', count: 1)
+
+        # Sort by master price
+        click_on 'Master Price'
+        expect(page).to have_css('.sort_link.asc', text: 'Master Price')
+        expect(page).to have_content("apache baseball cap")
+        expect(page).not_to have_content("zomg shirt")
+        expect(page).to have_css('#listing_products > tbody > tr', count: 1)
       end
     end
 

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -104,7 +104,7 @@ module Spree
     self.whitelisted_ransackable_attributes = %w[slug]
 
     def self.ransackable_scopes(_auth_object = nil)
-      %i(with_deleted)
+      %i(with_deleted with_variant_sku_cont)
     end
 
     # @return [Boolean] true if there are any variants

--- a/core/app/models/spree/product/scopes.rb
+++ b/core/app/models/spree/product/scopes.rb
@@ -189,6 +189,8 @@ module Spree
     end
 
     def self.distinct_by_product_ids(sort_order = nil)
+      Spree::Deprecation.warn "Product.distinct_by_product_ids is deprecated and should not be used"
+
       sort_column = sort_order.split(" ").first
 
       # Postgres will complain when using ordering by expressions not present in

--- a/core/app/models/spree/product/scopes.rb
+++ b/core/app/models/spree/product/scopes.rb
@@ -181,6 +181,13 @@ module Spree
       group("spree_products.id").joins(:taxons).where(Spree::Taxon.arel_table[:name].eq(name))
     end
 
+    def self.with_variant_sku_cont(sku)
+      sku_match = "%#{sku}%"
+      variant_table = Spree::Variant.arel_table
+      subquery = Spree::Variant.where(variant_table[:sku].matches(sku_match).and(variant_table[:product_id].eq(arel_table[:id])))
+      where(subquery.exists)
+    end
+
     def self.distinct_by_product_ids(sort_order = nil)
       sort_column = sort_order.split(" ").first
 


### PR DESCRIPTION
Fixes #2016

MySQL 5.7+ previously errored when trying to sort products by price.

> ORDER BY clause is not in SELECT list,
> references column 'spree_prices.amount' which is not in SELECT list;
> this is incompatible with DISTINCT

Additionally, under PostgreSQL, searching for an SKU which matches multiple variants of the same product and then sorting by price, multiple of the same Product would be returned in the search.

This commit removes the Product.distinct_by_product_ids hack replaces the join search on products->variants with a WHERE EXISTS subquery.