### PR TITLE
Don't refresh rates in completed_order_with_promotion

### DIFF
--- a/core/lib/spree/testing_support/factories/order_factory.rb
+++ b/core/lib/spree/testing_support/factories/order_factory.rb
@@ -69,7 +69,6 @@ FactoryGirl.define do
           order.order_promotions.create!(promotion: promotion, promotion_code: promotion_code)
 
           # Complete the order after the promotion has been activated
-          order.refresh_shipment_rates
           order.update_column(:completed_at, Time.current)
           order.update_column(:state, "complete")
         end

--- a/core/spec/lib/spree/core/testing_support/factories/order_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/order_factory_spec.rb
@@ -1,6 +1,30 @@
 require 'spec_helper'
 require 'spree/testing_support/factories/order_factory'
 
+shared_examples "shipping methods are assigned" do
+  context "given a shipping method" do
+    let(:shipping_method) { create(:shipping_method) }
+
+    it "assigns the shipping method when created" do
+      expect(
+        create(
+          factory,
+          shipping_method: shipping_method
+        ).shipments.map(&:shipping_method)
+      ).to all(eq(shipping_method))
+    end
+
+    it "assigns the shipping method when built" do
+      expect(
+        build(
+          factory,
+          shipping_method: shipping_method
+        ).shipments.map(&:shipping_method)
+      ).to all(eq(shipping_method))
+    end
+  end
+end
+
 RSpec.shared_examples "an order with line items factory" do |expected_order_state, expected_inventory_unit_state|
   # This factory cannot be built correctly because Shipment#set_up_inventory
   # requires records to be saved.
@@ -162,6 +186,7 @@ RSpec.describe 'order factory' do
 
     it_behaves_like 'a working factory'
     it_behaves_like 'an order with line items factory', "cart", "on_hand"
+    it_behaves_like 'shipping methods are assigned'
   end
 
   describe 'completed order with promotion' do
@@ -169,6 +194,7 @@ RSpec.describe 'order factory' do
 
     it_behaves_like 'a working factory'
     it_behaves_like 'an order with line items factory', "complete", "on_hand"
+    it_behaves_like 'shipping methods are assigned'
 
     it "has the expected attributes" do
       order = create(factory)
@@ -207,6 +233,7 @@ RSpec.describe 'order factory' do
 
     it_behaves_like 'a working factory'
     it_behaves_like 'an order with line items factory', "confirm", "on_hand"
+    it_behaves_like 'shipping methods are assigned'
 
     it "is completable" do
       order = create(factory)
@@ -222,6 +249,7 @@ RSpec.describe 'order factory' do
 
     it_behaves_like 'a working factory'
     it_behaves_like 'an order with line items factory', "complete", "on_hand"
+    it_behaves_like 'shipping methods are assigned'
 
     it "has the expected attributes" do
       order = create(factory)
@@ -244,6 +272,7 @@ RSpec.describe 'order factory' do
 
     it_behaves_like 'a working factory'
     it_behaves_like 'an order with line items factory', "complete", "on_hand"
+    it_behaves_like 'shipping methods are assigned'
 
     it "has the expected attributes" do
       order = create(factory)
@@ -269,6 +298,7 @@ RSpec.describe 'order factory' do
 
     it_behaves_like 'a working factory'
     it_behaves_like 'an order with line items factory', "complete", "on_hand"
+    it_behaves_like 'shipping methods are assigned'
 
     it "has the expected attributes" do
       order = create(factory)
@@ -309,6 +339,7 @@ RSpec.describe 'order factory' do
 
     it_behaves_like 'a working factory'
     it_behaves_like 'an order with line items factory', "complete", "shipped"
+    it_behaves_like 'shipping methods are assigned'
 
     it "has the expected attributes" do
       order = create(factory)


### PR DESCRIPTION
Fixes #1979

This includes Brian's added tests to `order_factory_spec.rb` :heart: . With those added, there was only one failure: when using the `completed_order_with_promotion` factory. This failure was fixed by removing the call to `refresh_shipment_rates`

cc @bbuchalter 