### PR TITLE
Avoid init empty git repo for sandbox

### DIFF
--- a/lib/sandbox.sh
+++ b/lib/sandbox.sh
@@ -20,7 +20,15 @@ sqlite|'')
 esac
 
 rm -rf ./sandbox
-bundle exec rails new sandbox --skip-bundle --database="$RAILSDB"
+bundle exec rails new sandbox --database="$RAILSDB" \
+  --skip-bundle \
+  --skip-git \
+  --skip-keeps \
+  --skip-rc \
+  --skip-spring \
+  --skip-test \
+  --skip-yarn
+
 if [ ! -d "sandbox" ]; then
   echo 'sandbox rails application failed'
   exit 1


### PR DESCRIPTION
Like in PR #2010 we do not want to init an empty git repo
for the sandbox as well. I kept puma and listen as these are
needed to run the sandbox in local dev mode.