### PR TITLE
Fix typo on the new promotions form

### DIFF
--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1268,7 +1268,7 @@ en:
         tax_category: "This determines what kind of taxation is applied to this product.<br/> Default: None"
       spree/promotion:
         starts_at: "This determines when the promotion can be applied to orders. <br/> If no value is specified, the promotion will be immediately available."
-        expires_at: "This determines when the promotion expires. <br/> If no value is specified, the promotion will never expires."
+        expires_at: "This determines when the promotion expires. <br/> If no value is specified, the promotion will never expire."
       spree/store:
         cart_tax_country_iso: "This determines which country is used for taxes on carts (orders which don't yet have an address).<br/> Default: None."
       spree/variant:


### PR DESCRIPTION
The hint for the expiration date field had an extra "s" at the end of
the sentence. The hint used to read, "If no value is specified, the
promotion will never expires."

This commit removes the extra "s" in "expires".