### PR TITLE
Remove redundant methods on Spree::PaymentMethod::StoreCredit

### DIFF
--- a/core/app/models/spree/payment_method/store_credit.rb
+++ b/core/app/models/spree/payment_method/store_credit.rb
@@ -4,14 +4,6 @@ module Spree
       ::Spree::StoreCredit
     end
 
-    def can_capture?(payment)
-      ['checkout', 'pending'].include?(payment.state)
-    end
-
-    def can_void?(payment)
-      payment.pending?
-    end
-
     def authorize(amount_in_cents, provided_store_credit, gateway_options = {})
       if provided_store_credit.nil?
         ActiveMerchant::Billing::Response.new(false, Spree.t('store_credit.unable_to_find'), {}, {})


### PR DESCRIPTION
When a payment source is required, then `can_capture?` and `can_void?`
etc; methods are not needed on the payment method class.

See:
https://github.com/solidusio/solidus/blob/master/core/app/models/spree/payment.rb#L157-L160

When a payment source is present then these methods are delegated to the
payment source class.