### PR TITLE
[RFC] Introduce preference fields partials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Solidus 2.4.0 (master, unreleased)
 
+- Deprecates several preference fields helpers in favor of preference field partials. [\#2040](https://github.com/solidusio/solidus/pull/2040) ([tvdeyen](https://github.com/tvdeyen))
+  Please render `spree/admin/shared/preference_fields/\#{preference_type}' instead
+
 - Remove `set_current_order` calls in `Spree::Core::ControllerHelpers::Order`
   [\#2185](https://github.com/solidusio/solidus/pull/2185) ([Murph33](https://github.com/murph33))
 

--- a/backend/app/assets/stylesheets/spree/backend/sections/_promotions.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/_promotions.scss
@@ -74,9 +74,11 @@
     text-align: right;
   }
 
-  .field {
+  .calculator-fields {
     padding-bottom: 10px;
+  }
 
+  .field {
     &.alpha {
       margin-left: -1px;
       padding-left: 11px;

--- a/backend/app/views/spree/admin/payment_methods/_form.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/_form.html.erb
@@ -19,7 +19,10 @@
             <% if @object.preference_source.present? %>
               <%= Spree.t :preference_source_using, name: @object.preference_source %>
             <% elsif !@object.new_record? %>
-              <%= preference_fields(@object, f) %>
+              <% @object.preferences.keys.each do |key| %>
+                <%= render "spree/admin/shared/preference_fields/#{@object.preference_type(key)}",
+                   form: f, attribute: "preferred_#{key}", label: Spree.t(key) %>
+              <% end %>
             <% end %>
           </div>
 

--- a/backend/app/views/spree/admin/promotions/actions/_promotion_calculators_with_custom_fields.html.erb
+++ b/backend/app/views/spree/admin/promotions/actions/_promotion_calculators_with_custom_fields.html.erb
@@ -12,7 +12,7 @@
     </div>
 
     <div class="col-6">
-      <div class="settings field">
+      <div class="settings">
         <% calculators.each do |calculator_class| %>
           <% calculator = promotion_action.calculator.class == calculator_class ? promotion_action.calculator : calculator_class.new %>
           <div class="js-calculator-preferences" data-calculator-type="<%= calculator_class %>">

--- a/backend/app/views/spree/admin/promotions/calculators/_default_fields.html.erb
+++ b/backend/app/views/spree/admin/promotions/calculators/_default_fields.html.erb
@@ -1,8 +1,5 @@
 <% calculator.preferences.keys.map do |key| %>
-  <% field_name = "#{prefix}[calculator_attributes][preferred_#{key}]" %>
-  <%= label_tag field_name, Spree.t(key.to_s) %>
-  <%= preference_field_tag(
-    field_name,
-    calculator.get_preference(key),
-    type: calculator.preference_type(key)) %>
+  <%= render "spree/admin/shared/preference_fields/#{calculator.preference_type(key)}",
+     name: "#{prefix}[calculator_attributes][preferred_#{key}]",
+     value: calculator.get_preference(key), label: Spree.t(key.to_s) %>
 <% end %>

--- a/backend/app/views/spree/admin/promotions/calculators/tiered_flat_rate/_fields.html.erb
+++ b/backend/app/views/spree/admin/promotions/calculators/tiered_flat_rate/_fields.html.erb
@@ -1,11 +1,6 @@
-<div class="field">
-  <%= label_tag "#{prefix}[calculator_attributes][preferred_base_amount]",
-    Spree.t(:base_amount) %>
-  <%= preference_field_tag(
-    "#{prefix}[calculator_attributes][preferred_base_amount]",
-    calculator.preferred_base_amount,
-    type: calculator.preference_type(:base_amount)) %>
-</div>
+<%= render "spree/admin/shared/preference_fields/#{calculator.preference_type(:base_amount)}",
+  name: "#{prefix}[calculator_attributes][preferred_base_amount]",
+  value: calculator.preferred_base_amount, label: Spree.t(:base_amount) %>
 
 <div class="field">
   <%= label_tag(

--- a/backend/app/views/spree/admin/promotions/calculators/tiered_percent/_fields.html.erb
+++ b/backend/app/views/spree/admin/promotions/calculators/tiered_percent/_fields.html.erb
@@ -1,11 +1,6 @@
-<div class="field">
-  <%= label_tag "#{prefix}[calculator_attributes][preferred_base_percent]",
-    Spree.t(:base_percent) %>
-  <%= preference_field_tag(
-    "#{prefix}[calculator_attributes][preferred_base_percent]",
-    calculator.preferred_base_percent,
-    type: calculator.preference_type(:base_percent)) %>
-</div>
+<%= render "spree/admin/shared/preference_fields/#{calculator.preference_type(:base_percent)}",
+  name: "#{prefix}[calculator_attributes][preferred_base_percent]",
+  value: calculator.preferred_base_percent, label: Spree.t(:base_percent) %>
 
 <div class="field">
   <%= label_tag(

--- a/backend/app/views/spree/admin/shared/_calculator_fields.html.erb
+++ b/backend/app/views/spree/admin/shared/_calculator_fields.html.erb
@@ -11,7 +11,10 @@
       <% calculator = f.object.calculator.class == calculator_class ? f.object.calculator : calculator_class.new %>
       <div class="js-calculator-preferences" data-calculator-type="<%= calculator_class %>">
         <%= f.fields_for :calculator, calculator do |calculator_form| %>
-          <%= preference_fields(calculator, calculator_form) %>
+          <% calculator.preferences.keys.each do |key| %>
+            <%= render "spree/admin/shared/preference_fields/#{calculator.preference_type(key)}",
+               form: calculator_form, attribute: "preferred_#{key}", label: Spree.t(key) %>
+          <% end %>
         <% end %>
       </div>
     <% end %>

--- a/backend/app/views/spree/admin/shared/preference_fields/_boolean.html.erb
+++ b/backend/app/views/spree/admin/shared/preference_fields/_boolean.html.erb
@@ -1,0 +1,13 @@
+<% label = local_assigns[:label].presence %>
+<% html_options = local_assigns[:html_options] || {} %>
+
+<div class="field">
+  <% if local_assigns[:form] %>
+    <%= form.check_box attribute, html_options %>
+    <%= form.label attribute, label %>
+  <% else %>
+    <%= hidden_field_tag name, 0 %>
+    <%= check_box_tag name, 1, value, html_options %>
+    <%= label_tag name, label %>
+  <% end %>
+</div>

--- a/backend/app/views/spree/admin/shared/preference_fields/_decimal.html.erb
+++ b/backend/app/views/spree/admin/shared/preference_fields/_decimal.html.erb
@@ -1,0 +1,12 @@
+<% label = local_assigns[:label].presence %>
+<% html_options = {class: 'input_decimal fullwidth'}.update(local_assigns[:html_options] || {}) %>
+
+<div class="field">
+  <% if local_assigns[:form] %>
+    <%= form.label attribute, label %>
+    <%= form.text_field attribute, html_options %>
+  <% else %>
+    <%= label_tag name, label %>
+    <%= text_field_tag name, value, html_options %>
+  <% end %>
+</div>

--- a/backend/app/views/spree/admin/shared/preference_fields/_integer.html.erb
+++ b/backend/app/views/spree/admin/shared/preference_fields/_integer.html.erb
@@ -1,0 +1,12 @@
+<% label = local_assigns[:label].presence %>
+<% html_options = {class: 'input_integer fullwidth'}.update(local_assigns[:html_options] || {}) %>
+
+<div class="field">
+  <% if local_assigns[:form] %>
+    <%= form.label attribute, label %>
+    <%= form.number_field attribute, html_options %>
+  <% else %>
+    <%= label_tag name, label %>
+    <%= number_field_tag name, value, html_options %>
+  <% end %>
+</div>

--- a/backend/app/views/spree/admin/shared/preference_fields/_password.html.erb
+++ b/backend/app/views/spree/admin/shared/preference_fields/_password.html.erb
@@ -1,0 +1,12 @@
+<% label = local_assigns[:label].presence %>
+<% html_options = {class: 'password_string fullwidth'}.update(local_assigns[:html_options] || {}) %>
+
+<div class="field">
+  <% if local_assigns[:form] %>
+    <%= form.label attribute, label %>
+    <%= form.password_field attribute, html_options %>
+  <% else %>
+    <%= label_tag name, label %>
+    <%= password_field_tag name, value, html_options %>
+  <% end %>
+</div>

--- a/backend/app/views/spree/admin/shared/preference_fields/_string.html.erb
+++ b/backend/app/views/spree/admin/shared/preference_fields/_string.html.erb
@@ -1,0 +1,12 @@
+<% label = local_assigns[:label].presence %>
+<% html_options = {class: 'input_string fullwidth'}.update(local_assigns[:html_options] || {}) %>
+
+<div class="field">
+  <% if local_assigns[:form] %>
+    <%= form.label attribute, label %>
+    <%= form.text_field attribute, html_options %>
+  <% else %>
+    <%= label_tag name, label %>
+    <%= text_field_tag name, value, html_options %>
+  <% end %>
+</div>

--- a/backend/app/views/spree/admin/shared/preference_fields/_text.html.erb
+++ b/backend/app/views/spree/admin/shared/preference_fields/_text.html.erb
@@ -1,0 +1,12 @@
+<% label = local_assigns[:label].presence %>
+<% html_options = {cols: 85, rows: 15}.update(local_assigns[:html_options] || {}) %>
+
+<div class="field">
+  <% if local_assigns[:form] %>
+    <%= form.label attribute, label %>
+    <%= form.text_area attribute, html_options %>
+  <% else %>
+    <%= label_tag name, label %>
+    <%= text_area_tag name, value, html_options %>
+  <% end %>
+</div>


### PR DESCRIPTION
Preference fields are used in several places all over the Solidus admin. Some of them are:

- Shipping and tax rate calculator fields
- Payment method preferences
- Promotion action calculator fields

Instead of using a string concatinator helper - that just concatinate the fields and labels with `<br>`
- we introduce partials that can easily be overriden by stores and extensions.

This deprecates the follwoing preference fields helpers:

- `preference_field_tag`
- `preference_field_for`
- `preference_field_options`
- `preference_fields`

### Before

![preference fields - promotion action - before](https://user-images.githubusercontent.com/42868/27479357-eda08696-5813-11e7-9a09-8410d9078a68.png)
![preference fields - payment method - before](https://user-images.githubusercontent.com/42868/27479356-ed89b344-5813-11e7-933b-0405afd7e598.png)
![preference fields - shipping rate - before](https://user-images.githubusercontent.com/42868/27479355-ed8819bc-5813-11e7-8029-68cb8365105f.png)

### After

![preference fields - promotion action - after](https://user-images.githubusercontent.com/42868/27479379-fc9556ea-5813-11e7-96ec-20dcb84ea5be.png)
![preference fields - payment method - after](https://user-images.githubusercontent.com/42868/27479381-fc9730d2-5813-11e7-9444-a552ac3a9ccf.png)
![preference fields - shipping calculator - after](https://user-images.githubusercontent.com/42868/27479382-fcb0a710-5813-11e7-85a8-2a262ff169d0.png)
