### PR TITLE
Make Address.find_all_by_name_or_abbr case-insensitive

### DIFF
--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -193,7 +193,7 @@ module Spree
       # ensure state_name belongs to country without states, or that it matches a predefined state name/abbr
       if state_name.present?
         if country.states.present?
-          states = country.states.find_all_by_name_or_abbr(state_name)
+          states = country.states.with_name_or_abbr(state_name)
 
           if states.size == 1
             self.state = states.first

--- a/core/app/models/spree/state.rb
+++ b/core/app/models/spree/state.rb
@@ -6,7 +6,11 @@ module Spree
     validates :country, :name, presence: true
 
     def self.find_all_by_name_or_abbr(name_or_abbr)
-      where('name = ? OR abbr = ?', name_or_abbr, name_or_abbr)
+      where(
+        arel_table[:name].matches(name_or_abbr).or(
+          arel_table[:abbr].matches(name_or_abbr)
+        )
+      )
     end
 
     # table of { country.id => [ state.id , state.name ] }, arrays sorted by name

--- a/core/app/models/spree/state.rb
+++ b/core/app/models/spree/state.rb
@@ -5,12 +5,16 @@ module Spree
 
     validates :country, :name, presence: true
 
-    def self.find_all_by_name_or_abbr(name_or_abbr)
+    scope :with_name_or_abbr, ->(name_or_abbr) do
       where(
         arel_table[:name].matches(name_or_abbr).or(
           arel_table[:abbr].matches(name_or_abbr)
         )
       )
+    end
+    class << self
+      alias_method :find_all_by_name_or_abbr, :with_name_or_abbr
+      deprecate find_all_by_name_or_abbr: :with_name_or_abbr, deprecator: Spree::Deprecation
     end
 
     # table of { country.id => [ state.id , state.name ] }, arrays sorted by name

--- a/core/spec/models/spree/address_spec.rb
+++ b/core/spec/models/spree/address_spec.rb
@@ -21,7 +21,7 @@ describe Spree::Address, type: :model do
     let(:address) { build(:address, country: country) }
 
     before do
-      allow(country.states).to receive_messages find_all_by_name_or_abbr: [state]
+      allow(country.states).to receive_messages with_name_or_abbr: [state]
     end
 
     context 'address does not require state' do

--- a/core/spec/models/spree/state_spec.rb
+++ b/core/spec/models/spree/state_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
 describe Spree::State, type: :model do
-  describe '.find_all_by_name_or_abbr' do
+  describe '.with_name_or_abbr' do
     subject do
-      Spree::State.find_all_by_name_or_abbr(search_term)
+      Spree::State.with_name_or_abbr(search_term)
     end
 
     let!(:state) { create(:state, name: "California", abbr: "CA") }

--- a/core/spec/models/spree/state_spec.rb
+++ b/core/spec/models/spree/state_spec.rb
@@ -1,10 +1,37 @@
 require 'spec_helper'
 
 describe Spree::State, type: :model do
-  it "can find a state by name or abbr" do
-    state = create(:state, name: "California", abbr: "CA")
-    expect(Spree::State.find_all_by_name_or_abbr("California")).to include(state)
-    expect(Spree::State.find_all_by_name_or_abbr("CA")).to include(state)
+  describe '.find_all_by_name_or_abbr' do
+    subject do
+      Spree::State.find_all_by_name_or_abbr(search_term)
+    end
+
+    let!(:state) { create(:state, name: "California", abbr: "CA") }
+
+    context 'by invalid term' do
+      let(:search_term) { 'NonExistent' }
+      it { is_expected.to be_empty }
+    end
+
+    context 'by name' do
+      let(:search_term) { 'California' }
+      it { is_expected.to include(state) }
+    end
+
+    context 'by abbr' do
+      let(:search_term) { 'CA' }
+      it { is_expected.to include(state) }
+    end
+
+    context 'by case-insensitive abbr' do
+      let(:search_term) { 'CaLiFoRnIa' }
+      it { is_expected.to include(state) }
+    end
+
+    context 'by case-insensitive abbr' do
+      let(:search_term) { 'cA' }
+      it { is_expected.to include(state) }
+    end
   end
 
   it "can find all states group by country id" do


### PR DESCRIPTION
This is helpful when importing data from third parties. E.g. PayPal.

Note: I believe the spec failures are due to #2045