### PR TITLE
Include database requirement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Getting started
 
 Begin by making sure you have [Imagemagick](http://imagemagick.org/script/download.php) installed, which is required for Paperclip. (You can install it using [Homebrew](https://brew.sh) if you're on a Mac.)
 
-To add solidus, begin with a Rails 5 application. Add the following to your
+To add solidus, begin with a Rails 5 application and a database configured and created. Add the following to your
 Gemfile.
 
 ```ruby


### PR DESCRIPTION
Following these steps, it'd be easy to miss that you need a valid database for `bundle exec rails g spree:install` to work properly. You'd get this error otherwise: `bin/rails: FATAL:  database "solidus_demo_development" does not exist (ActiveRecord::NoDatabaseError)`