### PR TITLE
Use `@collection` instead of `@collection.present?` in some admin controllers

### DIFF
--- a/backend/app/controllers/spree/admin/products_controller.rb
+++ b/backend/app/controllers/spree/admin/products_controller.rb
@@ -96,7 +96,7 @@ module Spree
       end
 
       def collection
-        return @collection if @collection.present?
+        return @collection if defined?(@collection)
         params[:q] ||= {}
         params[:q][:s] ||= "name asc"
         # @search needs to be defined as this is passed to search_form_for

--- a/backend/app/controllers/spree/admin/products_controller.rb
+++ b/backend/app/controllers/spree/admin/products_controller.rb
@@ -96,7 +96,7 @@ module Spree
       end
 
       def collection
-        return @collection if defined?(@collection)
+        return @collection if @collection
         params[:q] ||= {}
         params[:q][:s] ||= "name asc"
         # @search needs to be defined as this is passed to search_form_for

--- a/backend/app/controllers/spree/admin/promotions_controller.rb
+++ b/backend/app/controllers/spree/admin/promotions_controller.rb
@@ -35,7 +35,7 @@ module Spree
       end
 
       def collection
-        return @collection if defined?(@collection)
+        return @collection if @collection
         params[:q] ||= HashWithIndifferentAccess.new
         params[:q][:s] ||= 'id desc'
 

--- a/backend/app/controllers/spree/admin/properties_controller.rb
+++ b/backend/app/controllers/spree/admin/properties_controller.rb
@@ -8,7 +8,7 @@ module Spree
       private
 
       def collection
-        return @collection if @collection.present?
+        return @collection if defined?(@collection)
         # params[:q] can be blank upon pagination
         params[:q] = {} if params[:q].blank?
 

--- a/backend/app/controllers/spree/admin/properties_controller.rb
+++ b/backend/app/controllers/spree/admin/properties_controller.rb
@@ -8,7 +8,7 @@ module Spree
       private
 
       def collection
-        return @collection if defined?(@collection)
+        return @collection if @collection
         # params[:q] can be blank upon pagination
         params[:q] = {} if params[:q].blank?
 

--- a/backend/app/controllers/spree/admin/users_controller.rb
+++ b/backend/app/controllers/spree/admin/users_controller.rb
@@ -96,7 +96,7 @@ module Spree
       private
 
       def collection
-        return @collection if @collection.present?
+        return @collection if defined?(@collection)
         if request.xhr? && params[:q].present?
           @collection = Spree.user_class.includes(:bill_address, :ship_address)
                             .where("spree_users.email #{LIKE} :search

--- a/backend/app/controllers/spree/admin/users_controller.rb
+++ b/backend/app/controllers/spree/admin/users_controller.rb
@@ -96,7 +96,7 @@ module Spree
       private
 
       def collection
-        return @collection if defined?(@collection)
+        return @collection if @collection
         if request.xhr? && params[:q].present?
           @collection = Spree.user_class.includes(:bill_address, :ship_address)
                             .where("spree_users.email #{LIKE} :search


### PR DESCRIPTION
I'm pretty sure `defined?` was the intended behavior.

Using `present?` can generate an extra query for the presence check, and will
also prevent the instance-variable caching from working when the query returns
no results.