### PR TITLE
Use `.all` instead of `.where(nil)`

### DIFF
--- a/backend/app/controllers/spree/admin/resource_controller.rb
+++ b/backend/app/controllers/spree/admin/resource_controller.rb
@@ -201,7 +201,7 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
     if model_class.respond_to?(:accessible_by) && !current_ability.has_block?(params[:action], model_class)
       model_class.accessible_by(current_ability, action)
     else
-      model_class.where(nil)
+      model_class.all
     end
   end
 


### PR DESCRIPTION
This is more readable IMO