### PR TITLE
[#2050] Refactor Countries Seed Script to use Fewer SQL Statements

### DIFF
--- a/core/db/default/spree/countries.rb
+++ b/core/db/default/spree/countries.rb
@@ -1,13 +1,43 @@
 require 'carmen'
 
-ActiveRecord::Base.transaction do
-  Carmen::Country.all.each do |country|
-    Spree::Country.where(iso: country.alpha_2_code).first_or_create!(
-      name: country.name,
-      iso3: country.alpha_3_code,
-      iso_name: country.name.upcase,
-      numcode: country.numeric_code,
-      states_required: country.subregions?
-    )
-  end
+# Insert Countries into the spree_countries table, checking to ensure that no
+# duplicates are created, using as few SQL statements as possible (2)
+
+connection = ApplicationRecord.connection
+
+country_mapper = ->(country) do
+  name            = connection.quote country.name
+  iso3            = connection.quote country.alpha_3_code
+  iso             = connection.quote country.alpha_2_code
+  iso_name        = connection.quote country.name.upcase
+  numcode         = connection.quote country.numeric_code
+  states_required = connection.quote country.subregions?
+
+  [name, iso3, iso, iso_name, numcode, states_required].join(", ")
+end
+
+country_values = -> do
+  carmen_countries = Carmen::Country.all
+
+  # find entires already in the database (so that we may ignore them)
+  existing_country_isos =
+    Spree::Country.where(iso: carmen_countries.map(&:alpha_2_code)).pluck(:iso)
+
+  # create VALUES statements for each country _not_ already in the database
+  carmen_countries
+    .reject { |c| existing_country_isos.include?(c.alpha_2_code) }
+    .map(&country_mapper)
+    .join("), (")
+end
+
+country_columns = %w(name iso3 iso iso_name numcode states_required).join(', ')
+country_vals = country_values.call
+
+if country_vals.present?
+  # execute raw SQL (insted of ActiveRecord.create) to use a single
+  # INSERT statement, and to avoid any validations or callbacks
+  connection.execute <<-SQL
+    INSERT INTO spree_countries (#{country_columns})
+    VALUES (#{country_vals});
+  SQL
 end


### PR DESCRIPTION
RE: Issue #2050 - `countries.rb`

This PR eliminates between 246 and 990* _(explained below)_ SQL statements in the database seed process.
The resulting code queries the database for all existing entries and then crafts an insert statement for the ones that remain. The `INSERT` statement allows us to skip ActiveRecord hooks/validations, and since we are reasonably sure that there will not be a conflict, I think this is ok. (LMK if this is a bad assumption and I will add the extra checks)


I plan to refactor the `states.rb` and `zones.rb` assuming this passes your code review process.


* - 246 queries: 1 for each country to determine whether it is already in the database
if all countries already exist, that is the end of the script.
if any country does not exist, two additional uniqueness queries are performed, on the new countries `name` and `iso_name`, before the insert statement is performed.