### PR TITLE
Set SOLIDUS_RAISE_DEPRECATIONS in circle.yml

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,6 +3,7 @@ machine:
   environment:
     DB: postgresql
     DEFAULT_MAX_WAIT_TIME: 10
+    SOLIDUS_RAISE_DEPRECATIONS: true
   services:
     - postgresql
   ruby:


### PR DESCRIPTION
This was previously set in our CircleCI project config, but this didn't work when users enabled CircleCI on their own forks (as it would use their settings for environment variables).

This ensures that we will always be testing on CI with `SOLIDUS_RAISE_DEPRECATIONS`