### PR TITLE
Display a pointer cursor hovering add variant buttons

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -224,8 +224,8 @@ var ShipmentItemView = Backbone.View.extend({
   },
 
   events: {
-    "click .delete-item": "onDelete",
-    "click .split-item": "onSplit",
+    "click button.delete-item": "onDelete",
+    "click button.split-item": "onSplit",
   },
 
   removeSplit: function() {
@@ -286,13 +286,13 @@ var ShipmentEditView = Backbone.View.extend({
   },
 
   events: {
-    "click a.edit-method": "toggleMethodEdit",
-    "click a.cancel-method": "toggleMethodEdit",
-    "click a.save-method": "saveMethod",
+    "click button.edit-method": "toggleMethodEdit",
+    "click button.cancel-method": "toggleMethodEdit",
+    "click button.save-method": "saveMethod",
 
-    "click a.edit-tracking": "toggleTrackingEdit",
-    "click a.cancel-tracking": "toggleTrackingEdit",
-    "click a.save-tracking": "saveTracking",
+    "click button.edit-tracking": "toggleTrackingEdit",
+    "click button.cancel-tracking": "toggleTrackingEdit",
+    "click button.save-tracking": "saveTracking",
   },
 
   toggleMethodEdit: function(e){

--- a/backend/app/assets/javascripts/spree/backend/templates/variants/line_items_autocomplete_stock.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/variants/line_items_autocomplete_stock.hbs
@@ -20,7 +20,7 @@
 
   <fieldset class="no-border-bottom">
     <legend align="center" class="stock-location">
-      <button class="add_variant"  title="{{ t "add" }}" data-action="add">{{ t "add" }}</button>
+      <button class="add_variant" title="{{ t "add" }}" data-action="add">{{ t "add" }}</button>
     </legend>
   </fieldset>
 </fieldset>

--- a/backend/app/assets/javascripts/spree/backend/templates/variants/split.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/variants/split.hbs
@@ -20,6 +20,6 @@
   <input class="quantity" id="item_quantity" type="number" min="1" value="1" max="{{max_quantity}}">
 </td>
 <td class='actions'>
-  <a href='#' class='save-split icon_link fa fa-ok no-text with-tip' title='Save'></a>
-  <a href='#' class='cancel-split icon_link fa fa-cancel no-text with-tip' title='Cancel'></a>
+  <button class="save-split icon_link fa fa-ok no-text with-tip" data-action="save" title="{{ t "save" }}" data-original-title="{{ t "save" }}"></button>
+  <button class="cancel-split icon_link fa fa-cancel no-text with-tip" data-action="cancel" title="{{ t "cancel" }}" data-original-title="{{ t "cancel" }}"></button>
 </td>

--- a/backend/app/assets/stylesheets/spree/backend/components/_actions.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_actions.scss
@@ -27,5 +27,9 @@ table tbody tr {
 
   td.actions {
     background-color: transparent !important;
+
+    button {
+      cursor: pointer;
+    }
   }
 }

--- a/backend/app/views/spree/admin/orders/_shipment.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment.html.erb
@@ -62,9 +62,9 @@
           </td>
           <td class="actions">
             <% if can? :update, shipment %>
-              <%= link_to '', '#', class: 'save-method fa fa-check no-text with-tip',
+              <%= button_tag '', class: 'save-method fa fa-check no-text with-ti, type: :button',
                 data: {'shipment-number' => shipment.number, action: 'save'}, title: Spree.t('actions.save') %>
-              <%= link_to '', '#', class: 'cancel-method fa fa-cancel no-text with-tip',
+              <%= button_tag '', class: 'cancel-method fa fa-cancel no-text with-ti, type: :button',
                 data: {action: 'cancel'}, title: Spree.t('actions.cancel') %>
             <% end %>
           </td>
@@ -85,7 +85,7 @@
 
           <td class="actions">
             <% if can?(:update, shipment) && !shipment.shipped? %>
-              <%= link_to '', '#', class: 'edit-method fa fa-edit no-text with-tip', data: {action: 'edit'}, title: Spree.t('actions.edit') %>
+              <%= button_tag '', class: 'edit-method fa fa-edit no-text with-tip', data: {action: 'edit'}, title: Spree.t('actions.edit'), type: :button %>
             <% end %>
           </td>
         </tr>
@@ -97,8 +97,8 @@
         </td>
         <td class="actions">
           <% if can? :update, shipment %>
-            <%= link_to '', '#', class: 'save-tracking fa fa-check no-text with-tip', data: {'shipment-number' => shipment.number, action: 'save'}, title: Spree.t('actions.save') %>
-            <%= link_to '', '#', class: 'cancel-tracking fa fa-cancel no-text with-tip', data: {action: 'cancel'}, title: Spree.t('actions.cancel') %>
+            <%= button_tag '', class: 'save-tracking fa fa-check no-text with-tip', data: { action: 'save', 'shipment-number' => shipment.number }, title: Spree.t('actions.save'), type: :button %>
+            <%= button_tag '', class: 'cancel-tracking fa fa-cancel no-text with-tip', data: { action: 'cancel' }, title: Spree.t('actions.cancel'), type: :button %>
           <% end %>
         </td>
       </tr>
@@ -121,7 +121,7 @@
         </td>
         <td class="actions">
           <% if can? :update, shipment %>
-            <%= link_to '', '#', class: 'edit-tracking fa fa-edit no-text with-tip', data: {action: 'edit'}, title: Spree.t('actions.edit') %>
+            <%= button_tag '', class: 'edit-tracking fa fa-edit no-text with-tip', data: {action: 'edit'}, title: Spree.t('actions.edit'), type: :button %>
           <% end %>
         </td>
       </tr>

--- a/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
@@ -22,8 +22,8 @@
 
     <td class="cart-item-delete actions" data-hook="cart_item_delete">
       <% if can? :update, item %>
-        <%= link_to '', '#', class: 'split-item icon_link fa fa-arrows-h no-text with-tip', data: {action: 'split', 'variant-id' => item.variant.id}, title: Spree.t('actions.split') %>
-        <%= link_to '', '#', class: 'delete-item fa fa-trash no-text with-tip', data: { 'variant-id' => item.variant.id}, title: Spree.t('actions.delete') %>
+        <%= button_tag '', class: 'split-item icon_link fa fa-arrows-h no-text with-tip', data: { action: 'split', 'variant-id' => item.variant.id }, title: Spree.t('actions.split'), type: :button %>
+        <%= button_tag '', class: 'delete-item fa fa-trash no-text with-tip', data: { 'variant-id' => item.variant.id }, title: Spree.t('actions.delete'), type: :button %>
       <% end %>
     </td>
   </tr>


### PR DESCRIPTION
The button tag does not display a pointer cursor. Using an anchor tag also uniforms the markup with other [similar buttons](https://github.com/solidusio/solidus/blob/ba852180327f1e43eb9ad9d8f9395211af0c9d7b/backend/app/assets/javascripts/spree/backend/templates/variants/split.hbs#L23-L24) present in the line items management area.

*Before*

<img width="331" alt="schermata 2017-07-05 alle 15 50 58" src="https://user-images.githubusercontent.com/167946/27868190-4a897a70-619c-11e7-9aa5-c6912bc34288.png">

*After*

<img width="281" alt="schermata 2017-07-05 alle 15 50 22" src="https://user-images.githubusercontent.com/167946/27868203-4dde1d98-619c-11e7-8b22-147fb3ad3f69.png">



