### PR TITLE
Fix failing checkout_controller_spec

### DIFF
--- a/frontend/spec/controllers/spree/checkout_controller_spec.rb
+++ b/frontend/spec/controllers/spree/checkout_controller_spec.rb
@@ -397,7 +397,7 @@ describe Spree::CheckoutController, type: :controller do
       end
 
       it "should set flash message for no inventory" do
-        expect(flash[:error]).to eq(Spree.t(:inventory_error_flash_for_insufficient_quantity, names: "'#{product.name}'" ))
+        expect(flash[:error]).to eq("Amazing Item became unavailable.")
       end
     end
   end


### PR DESCRIPTION
Previous this spec passed because

``` ruby
"\#{names} became unavailable." == "\#{names} became unavailable."
```

74d7b940629a43e3180aa030514a443c375b746b fixed the error message, but didn't fix the spec.

This commit replaces the expectation with a hardcoded message, to avoid hiding errors.