### PR TITLE
WIP: Order not triggering callbacks on shipments

### DIFF
--- a/core/spec/models/spree/order/finalizing_spec.rb
+++ b/core/spec/models/spree/order/finalizing_spec.rb
@@ -32,7 +32,10 @@ describe Spree::Order, type: :model do
     end
 
     it "should change the shipment state to ready if order is paid" do
-      Spree::Shipment.create(order: order)
+      Spree::Shipment.state_machine.after_transition to: :ready, do: :callback
+      shipment = Spree::Shipment.create(order: order)
+      expect(shipment).to receive(:callback)
+
       order.shipments.reload
 
       allow(order).to receive_messages(paid?: true, complete?: true)


### PR DESCRIPTION
When `complete!` is called on order, it then updates all the shipments
to `ready`. The problem is that this update skips state_machine
transition callbacks. Write spec to show this behavior.