### PR TITLE
Avoid running validations in current_order

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -742,6 +742,12 @@ module Spree
     alias_method :assign_default_credit_card, :add_default_payment_from_wallet
     deprecate assign_default_credit_card: :add_default_payment_from_wallet, deprecator: Spree::Deprecation
 
+    def record_ip_address(ip_address)
+      if last_ip_address != ip_address
+        update_attributes!(last_ip_address: ip_address)
+      end
+    end
+
     private
 
     def process_payments_before_complete

--- a/core/lib/spree/core/controller_helpers/order.rb
+++ b/core/lib/spree/core/controller_helpers/order.rb
@@ -45,7 +45,7 @@ module Spree
           end
 
           if @current_order
-            @current_order.update(last_ip_address: ip_address)
+            @current_order.record_ip_address(ip_address)
             return @current_order
           end
         end


### PR DESCRIPTION
Previously we updated the IP address on each request by calling

``` ruby
update(last_ip_address: ip_address)
```

Though this doesn't run a SQL `UPDATE` if not necessary, it will still run validations (resulting in two `SELECT`s).

This commit adds a new `record_ip_address(ip_address)` method to `Spree::Order`, which will only update the ip_address if it has changed.

This also switches `update` to `update_attributes!`, so that any errors will be raised.

**Before**

```
  Spree::Order Load (0.2ms)  SELECT  "spree_orders".* FROM "spree_orders" WHERE "spree_orders"."completed_at" IS NULL AND "spree_orders"."currency" = ? AND "spree_orders"."guest_token" = ? AND "spree_orders"."store_id" = ? AND "spree_orders"."user_id" = ? LIMIT ?  [["currency", "USD"], ["guest_token", "aCYxT9EsjJSLEoxCaFLCmA"], ["store_id", 1], ["user_id", 1], ["LIMIT", 1]]
  Spree::Adjustment Load (0.1ms)  SELECT "spree_adjustments".* FROM "spree_adjustments" WHERE "spree_adjustments"."adjustable_type" = ? AND "spree_adjustments"."adjustable_id" = 5 ORDER BY "spree_adjustments"."created_at" ASC  [["adjustable_type", "Spree::Order"]]
   (0.0ms)  begin transaction
  Spree::Store Load (0.0ms)  SELECT  "spree_stores".* FROM "spree_stores" WHERE "spree_stores"."id" = ? LIMIT ?  [["id", 1], ["LIMIT", 1]]
  Spree::Order Exists (0.1ms)  SELECT  1 AS one FROM "spree_orders" WHERE "spree_orders"."number" = ? AND ("spree_orders"."id" != ?) LIMIT ?  [["number", "R097935381"], ["id", 5], ["LIMIT", 1]]
   (0.0ms)  commit transaction
```

**After**

```
  Spree::Order Load (0.2ms)  SELECT  "spree_orders".* FROM "spree_orders" WHERE "spree_orders"."completed_at" IS NULL AND "spree_orders"."currency" = ? AND "spree_orders"."guest_token" = ? AND "spree_orders"."store_id" = ? AND "spree_orders"."user_id" = ? LIMIT ?  [["currency", "USD"], ["guest_token", "aCYxT9EsjJSLEoxCaFLCmA"], ["store_id", 1], ["user_id", 1], ["LIMIT", 1]]
  Spree::Adjustment Load (0.2ms)  SELECT "spree_adjustments".* FROM "spree_adjustments" WHERE "spree_adjustments"."adjustable_type" = ? AND "spree_adjustments"."adjustable_id" = 5 ORDER BY "spree_adjustments"."created_at" ASC  [["adjustable_type", "Spree::Order"]]

```