### PR TITLE
Don't eager load adjustments in current_order

### DIFF
--- a/core/lib/spree/core/controller_helpers/order.rb
+++ b/core/lib/spree/core/controller_helpers/order.rb
@@ -88,6 +88,7 @@ module Spree
 
           # Find any incomplete orders for the guest_token
           if with_adjustments
+            Spree::Deprecation.warn "The second argument to find_order_by_token_or_user is deprecated, and will be removed in a future version."
             order = Spree::Order.incomplete.includes(:adjustments).lock(options[:lock]).find_by(current_order_params)
           else
             order = Spree::Order.incomplete.lock(options[:lock]).find_by(current_order_params)

--- a/core/lib/spree/core/controller_helpers/order.rb
+++ b/core/lib/spree/core/controller_helpers/order.rb
@@ -34,7 +34,7 @@ module Spree
 
           return @current_order if @current_order
 
-          @current_order = find_order_by_token_or_user(options, true)
+          @current_order = find_order_by_token_or_user(options)
 
           if options[:create_order_if_necessary] && (@current_order.nil? || @current_order.completed?)
             @current_order = Spree::Order.new(new_order_params)


### PR DESCRIPTION
There's no advantage to doing this. We're only loading a single record so there's no N+1 query this is avoiding. We can just wait for the `order.adjustments` association to be accessed to load these.