### PR TITLE
[RFC] Rename order.update! to order.recalculate

### DIFF
--- a/backend/app/controllers/spree/admin/adjustments_controller.rb
+++ b/backend/app/controllers/spree/admin/adjustments_controller.rb
@@ -25,7 +25,7 @@ module Spree
       end
 
       def update_totals
-        @order.reload.update!
+        @order.reload.recalculate
       end
 
       # Override method used to create a new instance to correctly

--- a/backend/spec/features/admin/orders/adjustments_spec.rb
+++ b/backend/spec/features/admin/orders/adjustments_spec.rb
@@ -22,7 +22,7 @@ describe "Adjustments", type: :feature do
   let!(:adjustment) { order.adjustments.create!(order: order, label: 'Rebate', amount: 10) }
 
   before(:each) do
-    order.update!
+    order.recalculate
 
     visit spree.admin_path
     click_link "Orders"

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -254,8 +254,17 @@ module Spree
       @updater ||= Spree::OrderUpdater.new(self)
     end
 
-    def update!
+    def recalculate
       updater.update
+    end
+
+    def update!(*args)
+      if args.empty?
+        Spree::Deprecation.warn "Calling order.update! with no arguments as a way to invoke the OrderUpdater is deprecated, since it conflicts with AR::Base#update! Please use order.recalculate instead"
+        recalculate
+      else
+        super
+      end
     end
 
     def assign_billing_to_shipping_address
@@ -471,7 +480,7 @@ module Spree
       shipments.destroy_all
       order_promotions.destroy_all
 
-      update!
+      recalculate
     end
 
     alias_method :has_step?, :has_checkout_step?
@@ -529,7 +538,7 @@ module Spree
 
     def apply_free_shipping_promotions
       Spree::PromotionHandler::FreeShipping.new(self).activate
-      update!
+      recalculate
     end
 
     # Clean shipments and make order back to address state
@@ -565,7 +574,7 @@ module Spree
 
     def set_shipments_cost
       shipments.each(&:update_amounts)
-      update!
+      recalculate
     end
     deprecate set_shipments_cost: :update!, deprecator: Spree::Deprecation
 
@@ -806,7 +815,7 @@ module Spree
       end
       if adjustment_changed
         restart_checkout_flow
-        update!
+        recalculate
         errors.add(:base, Spree.t(:promotion_total_changed_before_complete))
       end
       errors.empty?
@@ -838,7 +847,7 @@ module Spree
       payments.store_credits.pending.each(&:void_transaction!)
 
       send_cancel_email
-      update!
+      recalculate
     end
 
     def send_cancel_email

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -120,7 +120,7 @@ module Spree
             after_transition to: :canceled, do: :after_cancel
 
             after_transition from: any - :cart, to: any - [:confirm, :complete] do |order|
-              order.update!
+              order.recalculate
             end
 
             after_transition do |order, transition|

--- a/core/app/models/spree/order_cancellations.rb
+++ b/core/app/models/spree/order_cancellations.rb
@@ -41,7 +41,7 @@ class Spree::OrderCancellations
         Spree::OrderMailer.inventory_cancellation_email(@order, inventory_units.to_a).deliver_later if Spree::OrderCancellations.send_cancellation_mailer
       end
 
-      @order.update!
+      @order.recalculate
 
       if short_ship_tax_notifier
         short_ship_tax_notifier.call(unit_cancels)

--- a/core/app/models/spree/order_shipping.rb
+++ b/core/app/models/spree/order_shipping.rb
@@ -73,7 +73,7 @@ class Spree::OrderShipping
 
     send_shipment_emails(carton) if stock_location.fulfillable? && !suppress_mailer # e.g. digital gift cards that aren't actually shipped
     fulfill_order_stock_locations(stock_location)
-    @order.update!
+    @order.recalculate
 
     carton
   end

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -240,7 +240,7 @@ module Spree
 
     def update_order
       if order.completed? || completed? || void?
-        order.update!
+        order.recalculate
       end
     end
 

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -119,7 +119,7 @@ module Spree
       action_taken
     end
 
-    # called anytime order.update! happens
+    # called anytime order.recalculate happens
     def eligible?(promotable, promotion_code: nil)
       return false if inactive?
       return false if usage_limit_exceeded?

--- a/core/app/models/spree/promotion_handler/coupon.rb
+++ b/core/app/models/spree/promotion_handler/coupon.rb
@@ -95,7 +95,7 @@ module Spree
         discount ||= order.adjustments.promotion.detect(&detector)
 
         if discount && discount.eligible
-          order.update!
+          order.recalculate
           set_success_code :coupon_code_applied
         elsif order.promotions.with_coupon_code(order.coupon_code)
           # if the promotion exists on an order, but wasn't found above,

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -297,9 +297,9 @@ module Spree
       if update_attributes params
         if params.key? :selected_shipping_rate_id
           # Changing the selected Shipping Rate won't update the cost (for now)
-          # so we persist the Shipment#cost before running `order.update!`
+          # so we persist the Shipment#cost before running `order.recalculate`
           update_amounts
-          order.update!
+          order.recalculate
         end
 
         true

--- a/core/lib/spree/testing_support/factories/order_factory.rb
+++ b/core/lib/spree/testing_support/factories/order_factory.rb
@@ -53,7 +53,7 @@ FactoryGirl.define do
         create(:shipment, order: order, cost: evaluator.shipment_cost, shipping_method: evaluator.shipping_method, stock_location: evaluator.stock_location)
         order.shipments.reload
 
-        order.update!
+        order.recalculate
       end
 
       factory :completed_order_with_promotion do

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -328,7 +328,7 @@ describe Spree::Order, type: :model do
         context "with a shipment that has a price" do
           before do
             shipment.shipping_rates.first.update_column(:cost, 10)
-            order.update!
+            order.recalculate
           end
 
           it "transitions to payment" do
@@ -595,7 +595,7 @@ describe Spree::Order, type: :model do
 
       it 'can complete the order' do
         create(:payment, state: 'completed', order: order, amount: order.total)
-        order.update!
+        order.recalculate
         expect(order.complete).to eq(true)
       end
     end

--- a/core/spec/models/spree/order/outstanding_balance_integration_spec.rb
+++ b/core/spec/models/spree/order/outstanding_balance_integration_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Outstanding balance integration tests" do
 
   subject do
     order.reload
-    order.update!
+    order.recalculate
     order.outstanding_balance
   end
 

--- a/core/spec/models/spree/order/payment_spec.rb
+++ b/core/spec/models/spree/order/payment_spec.rb
@@ -176,7 +176,7 @@ module Spree
                           payment: reimbursement.order.payments.first,
                           reimbursement: reimbursement
           # Update the order totals so payment_total goes to 0 reflecting the refund..
-          order.update!
+          order.recalculate
         end
 
         context "for canceled orders" do

--- a/core/spec/models/spree/order/updating_spec.rb
+++ b/core/spec/models/spree/order/updating_spec.rb
@@ -9,7 +9,7 @@ describe Spree::Order, type: :model do
       after { Spree::Order.update_hooks.clear }
       it "should call each of the update hooks" do
         expect(order).to receive :foo
-        order.update!
+        order.recalculate
       end
     end
   end

--- a/core/spec/models/spree/order_cancellations_spec.rb
+++ b/core/spec/models/spree/order_cancellations_spec.rb
@@ -148,7 +148,7 @@ describe Spree::OrderCancellations do
           source: promotion_action,
           finalized: true,
         )
-        order.update!
+        order.recalculate
       end
 
       it "generates the correct total amount" do

--- a/core/spec/models/spree/order_capturing_spec.rb
+++ b/core/spec/models/spree/order_capturing_spec.rb
@@ -47,7 +47,7 @@ describe Spree::OrderCapturing do
 
       before do
         order.contents.add(variant, 3)
-        order.update!
+        order.recalculate
         @secondary_bogus_payment = create(:payment, order: order, amount: secondary_total, payment_method: secondary_payment_method.create!(name: 'So bogus'))
         @bogus_payment = create(:payment, order: order, amount: bogus_total)
         order.contents.advance

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -180,7 +180,7 @@ describe Spree::Order, type: :model do
       create(:shipment, order: order)
       create(:adjustment, adjustable: order, order: order)
       promotion.activate(order: order, promotion_code: code)
-      order.update!
+      order.recalculate
 
       # Make sure we are asserting changes
       expect(order.line_items).not_to be_empty
@@ -313,7 +313,7 @@ describe Spree::Order, type: :model do
     it "calls hook during update" do
       order = create(:order)
       expect(order).to receive(:add_awesome_sauce)
-      order.update!
+      order.recalculate
     end
 
     it "calls hook during finalize" do
@@ -1182,7 +1182,7 @@ describe Spree::Order, type: :model do
 
       context "there is enough store credit to pay for the entire order" do
         let(:store_credit) { create(:store_credit, amount: order_total) }
-        let(:order) { create(:order_with_totals, user: store_credit.user, line_items_price: order_total).tap(&:update!) }
+        let(:order) { create(:order_with_totals, user: store_credit.user, line_items_price: order_total).tap(&:recalculate) }
 
         context "there are no other payments" do
           before do
@@ -1210,7 +1210,7 @@ describe Spree::Order, type: :model do
         let(:order_total) { 500 }
         let(:store_credit_total) { order_total - 100 }
         let(:store_credit)       { create(:store_credit, amount: store_credit_total) }
-        let(:order) { create(:order_with_totals, user: store_credit.user, line_items_price: order_total).tap(&:update!) }
+        let(:order) { create(:order_with_totals, user: store_credit.user, line_items_price: order_total).tap(&:recalculate) }
 
         context "there are no other payments" do
           it "adds an error to the model" do
@@ -1255,7 +1255,7 @@ describe Spree::Order, type: :model do
           let(:amount_difference)       { 100 }
           let!(:primary_store_credit)   { create(:store_credit, amount: (order_total - amount_difference)) }
           let!(:secondary_store_credit) { create(:store_credit, amount: order_total, user: primary_store_credit.user, credit_type: create(:secondary_credit_type)) }
-          let(:order) { create(:order_with_totals, user: primary_store_credit.user, line_items_price: order_total).tap(&:update!) }
+          let(:order) { create(:order_with_totals, user: primary_store_credit.user, line_items_price: order_total).tap(&:recalculate) }
 
           before do
             subject

--- a/core/spec/models/spree/order_updater_spec.rb
+++ b/core/spec/models/spree/order_updater_spec.rb
@@ -92,13 +92,13 @@ module Spree
 
           before do
             promotion.activate(order: order)
-            order.update!
+            order.recalculate
             line_item.update!(quantity: 2)
           end
 
           it 'updates the promotion amount' do
             expect {
-              order.update!
+              order.recalculate
             }.to change {
               line_item.promo_total
             }.from(-1).to(-2)
@@ -117,7 +117,7 @@ module Spree
           end
 
           it 'uses the defined promotion chooser' do
-            expect { order.update! }.to raise_error('Custom promotion chooser')
+            expect { order.recalculate }.to raise_error('Custom promotion chooser')
           end
         end
 
@@ -156,7 +156,7 @@ module Spree
                                 label: 'Some other credit')
             line_item.adjustments.each { |a| a.update_column(:eligible, true) }
 
-            order.update!
+            order.recalculate
 
             expect(line_item.adjustments.promotion.eligible.count).to eq(1)
             expect(line_item.adjustments.promotion.eligible.first.label).to eq('Promotion C')
@@ -170,7 +170,7 @@ module Spree
             end
             line_item.adjustments.each { |a| a.update_column(:eligible, true) }
 
-            order.update!
+            order.recalculate
 
             expect(line_item.adjustments.promotion.eligible.count).to eq(1)
             expect(line_item.adjustments.promotion.eligible.first.label).to eq('Promotion B')
@@ -184,7 +184,7 @@ module Spree
             end
             line_item.adjustments.each { |a| a.update_column(:eligible, true) }
 
-            order.update!
+            order.recalculate
 
             expect(line_item.adjustments.promotion.eligible.count).to eq(1)
             expect(line_item.adjustments.promotion.eligible.first.label).to eq('Promotion B')
@@ -212,7 +212,7 @@ module Spree
                   order_promos[promo_sequence[0]].activate order: order
                   order_promos[promo_sequence[1]].activate order: order
 
-                  order.update!
+                  order.recalculate
                   order.reload
                   expect(order.all_adjustments.count).to eq(2), 'Expected two adjustments'
                   expect(order.all_adjustments.eligible.count).to eq(1), 'Expected one elegible adjustment'
@@ -263,7 +263,7 @@ module Spree
 
             # regression for https://github.com/spree/spree/issues/3274
             it 'still makes the previous best eligible adjustment valid' do
-              order.update!
+              order.recalculate
               expect(line_item.adjustments.promotion.eligible.first.label).to eq('Promotion A')
             end
           end
@@ -273,7 +273,7 @@ module Spree
             create_adjustment('Promotion B', -200)
             create_adjustment('Promotion C', -200)
 
-            order.update!
+            order.recalculate
 
             expect(line_item.adjustments.promotion.eligible.count).to eq(1)
             expect(line_item.adjustments.promotion.eligible.first.amount.to_i).to eq(-200)
@@ -305,7 +305,7 @@ module Spree
 
           it 'updates the promotion amount' do
             expect {
-              order.update!
+              order.recalculate
             }.to change {
               line_item.additional_tax_total
             }.from(1).to(2)
@@ -327,7 +327,7 @@ module Spree
               Spree::Tax::OrderTax.new(order_id: order.id, line_item_taxes: [], shipment_taxes: [])
             )
 
-            order.update!
+            order.recalculate
           end
         end
       end
@@ -535,7 +535,7 @@ module Spree
         expect(line_item.promo_total).to eq(0)
         expect(order.promo_total).to eq(0)
 
-        order.update!
+        order.recalculate
 
         expect(line_item.promo_total).to eq(-1)
         expect(order.promo_total).to eq(-1)
@@ -548,7 +548,7 @@ module Spree
       it "updates the totals" do
         line_item.update!(adjustment_total: 100)
         expect {
-          order.update!
+          order.recalculate
         }.to change { line_item.reload.adjustment_total }.from(100).to(0)
       end
     end

--- a/core/spec/models/spree/promotion/actions/create_quantity_adjustments_spec.rb
+++ b/core/spec/models/spree/promotion/actions/create_quantity_adjustments_spec.rb
@@ -235,7 +235,7 @@ module Spree::Promotion::Actions
 
       before do
         action.perform(order: order, promotion: promotion)
-        order.update!
+        order.recalculate
       end
 
       it 'updates the order totals' do
@@ -248,7 +248,7 @@ module Spree::Promotion::Actions
       context "after updating item quantity" do
         before do
           order.line_items.first.update!(quantity: 2, price: 30)
-          order.update!
+          order.recalculate
         end
 
         it 'updates the order totals' do
@@ -262,7 +262,7 @@ module Spree::Promotion::Actions
       context "after updating promotion amount" do
         before do
           calculator.update!(preferred_amount: 5)
-          order.update!
+          order.recalculate
         end
 
         it 'updates the order totals' do

--- a/core/spec/models/spree/promotion_handler/cart_spec.rb
+++ b/core/spec/models/spree/promotion_handler/cart_spec.rb
@@ -110,7 +110,7 @@ module Spree
 
         before do
           Spree::OrderPromotion.create!(promotion: promotion, order: order, promotion_code: promotion_code)
-          order.update!
+          order.recalculate
         end
 
         include_context "creates the adjustment"

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -764,7 +764,7 @@ describe Spree::Promotion, type: :model do
     context 'when the user has used this promo' do
       before do
         promotion.activate(order: order)
-        order.update!
+        order.recalculate
         order.completed_at = Time.current
         order.save!
       end
@@ -817,7 +817,7 @@ describe Spree::Promotion, type: :model do
       expect(order.adjustment_total).to eq 0
 
       promo.activate order: order, promotion_code: promotion_code
-      order.update!
+      order.recalculate
 
       expect(line_item.adjustments.size).to eq(1)
       expect(order.adjustment_total).to eq(-5)

--- a/core/spec/models/spree/reimbursement_spec.rb
+++ b/core/spec/models/spree/reimbursement_spec.rb
@@ -73,7 +73,7 @@ describe Spree::Reimbursement, type: :model do
         shipment.update_column('state', 'shipped')
       end
       order.reload
-      order.update!
+      order.recalculate
       if payment
         payment.save!
         order.next! # confirm

--- a/core/spec/models/spree/stock/coordinator_spec.rb
+++ b/core/spec/models/spree/stock/coordinator_spec.rb
@@ -41,7 +41,7 @@ module Spree
         it "does not unintentionally add shipments to the order" do
           subject.shipments
           expect {
-            order.update!
+            order.recalculate
           }.not_to change {
             order.shipments.count
           }

--- a/core/spec/models/spree/tax/taxation_integration_spec.rb
+++ b/core/spec/models/spree/tax/taxation_integration_spec.rb
@@ -663,7 +663,7 @@ RSpec.describe "Taxation system integration tests" do
         context 'when tax address is later cleared' do
           before do
             order.ship_address = nil
-            order.update!
+            order.recalculate
           end
 
           it 'removes all tax adjustments' do

--- a/frontend/spec/features/checkout_spec.rb
+++ b/frontend/spec/features/checkout_spec.rb
@@ -93,7 +93,7 @@ describe "Checkout", type: :feature, inaccessible: true do
 
         order.reload
         order.user = user
-        order.update!
+        order.recalculate
         order
       end
 
@@ -217,7 +217,7 @@ describe "Checkout", type: :feature, inaccessible: true do
 
       user = create(:user)
       order.user = user
-      order.update!
+      order.recalculate
 
       allow_any_instance_of(Spree::CheckoutController).to receive_messages(current_order: order)
       allow_any_instance_of(Spree::CheckoutController).to receive_messages(try_spree_current_user: user)
@@ -245,7 +245,7 @@ describe "Checkout", type: :feature, inaccessible: true do
 
       order.reload
       order.user = user
-      order.update!
+      order.recalculate
       order
     end
 
@@ -292,7 +292,7 @@ describe "Checkout", type: :feature, inaccessible: true do
       order = OrderWalkthrough.up_to(:delivery)
       allow(order).to receive_messages(available_payment_methods: [check_payment, credit_cart_payment])
       order.user = create(:user)
-      order.update!
+      order.recalculate
 
       allow_any_instance_of(Spree::CheckoutController).to receive_messages(current_order: order)
       allow_any_instance_of(Spree::CheckoutController).to receive_messages(try_spree_current_user: order.user)

--- a/frontend/spec/features/checkout_unshippable_spec.rb
+++ b/frontend/spec/features/checkout_unshippable_spec.rb
@@ -15,7 +15,7 @@ describe "checkout with unshippable items", type: :feature, inaccessible: true d
 
     user = create(:user)
     order.user = user
-    order.update!
+    order.recalculate
 
     allow_any_instance_of(Spree::CheckoutController).to receive_messages(current_order: order)
     allow_any_instance_of(Spree::CheckoutController).to receive_messages(try_spree_current_user: user)

--- a/sample/db/samples/payments.rb
+++ b/sample/db/samples/payments.rb
@@ -9,7 +9,7 @@ creditcard = Spree::CreditCard.create(cc_type: 'visa', month: 12, year: 2.years.
                                       name: 'Sean Schofield', gateway_customer_profile_id: 'BGS-1234')
 
 Spree::Order.all.each_with_index do |order, _index|
-  order.update!
+  order.recalculate
   payment = order.payments.create!(amount: order.total, source: creditcard.clone, payment_method: method)
   payment.update_columns(state: 'pending', response_code: '12345')
 end


### PR DESCRIPTION
I expect this to be contentious, and it definitely introduces some work for users upgrading, which I'm always cautious of.

`ActiveRecord::Base` has an `update!(attributes)` which as of Rails 4.0 is the recommended way to update the attributes on a model. [The PR introducing it](https://github.com/rails/rails/pull/8705) describes the older `update_attributes!` as "soft-deprecated".

Because we've overridden `update!`, we can't use that method to update the the attributes on order (as `update!` does for every other model), and have to use `update_attributes!`.

This isn't great because Rails devs (as well as documentation) are going to expect `update!` to work and might not even be aware of `update_attributes!`. This is doubly confusing because we have access to ActiveRecord's `order.update`, and one really expects that to do approximately the same thing as the `!` version.

This PR adds `Order#recalculate`, which does exactly what `Order#update!` did, invoking the `OrderUpdater`.

`Order#update!` will now, if given attributes, will behave like AR's `update!`. If given no attributes it will emit a deprecation warning and call `recalculate`.

If we decide to do this, we should probably do the same for `Adjustment#update!` and `Shipment#update!`