### PR TITLE
Invalidate existing non store credit payments during checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Solidus 2.4.0 (master, unreleased)
 
+- Invalidate existing non store credit payments during checkout [2075](https://github.com/solidusio/solidus/pull/2075) ([tvdeyen](https://github.com/tvdeyen))
+
 - Change HTTP Status code for `Api::ShipmentsController#transfer_to_*` to be always 202 Accepted rather than 201 Created or 500.
   Speed up changing fulfilment for parts of a shipment [\#2070](https://github.com/solidusio/solidus/pull/2070) ([mamhoff](https://github.com/mamhoff))
 

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -230,9 +230,9 @@ module Spree
 
     def invalidate_old_payments
       if !store_credit? && !['invalid', 'failed'].include?(state)
-        order.payments.select do |payment|
+        order.payments.select { |payment|
           payment.state == 'checkout' && !payment.store_credit? && payment.id != id
-        end.each(&:invalidate!)
+        }.each(&:invalidate!)
       end
     end
 

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -231,9 +231,7 @@ module Spree
     def invalidate_old_payments
       if !store_credit? && !['invalid', 'failed'].include?(state)
         order.payments.select do |payment|
-          payment.state == 'checkout' &&
-            payment.payment_method_id == payment_method.try!(:id) &&
-            payment.id != id
+          payment.state == 'checkout' && !payment.store_credit? && payment.id != id
         end.each(&:invalidate!)
       end
     end

--- a/core/spec/models/spree/order/payment_spec.rb
+++ b/core/spec/models/spree/order/payment_spec.rb
@@ -36,8 +36,8 @@ module Spree
         end
       end
 
-      context 'with different payment methods' do
-        let!(:payment_2) { create(:payment, order: order, amount: 50) }
+      context 'with different payment methods that are store credit' do
+        let!(:payment_2) { create(:store_credit_payment, order: order, amount: 50) }
 
         it 'processes all checkout payments' do
           order.process_payments!
@@ -51,7 +51,7 @@ module Spree
         end
 
         context 'with over paid payments' do
-          let!(:payment_3) { create(:payment, order: order, amount: 50) }
+          let!(:payment_3) { create(:store_credit_payment, order: order, amount: 50) }
 
           it 'does not go over total for order' do
             order.process_payments!

--- a/core/spec/models/spree/order/payment_spec.rb
+++ b/core/spec/models/spree/order/payment_spec.rb
@@ -7,51 +7,82 @@ module Spree
 
     context "processing payments" do
       let(:order) { create(:order_with_line_items, shipment_cost: 0, line_items_price: 100) }
+
       before do
         # So that Payment#purchase! is called during processing
         Spree::Config[:auto_capture] = true
       end
 
-      it 'processes all checkout payments' do
-        payment_1 = create(:payment, order: order, amount: 50)
-        payment_2 = create(:payment, order: order, amount: 50)
+      let(:payment_method) { create(:credit_card_payment_method) }
 
-        order.process_payments!
-        updater.update_payment_state
-
-        expect(order.payment_state).to eq('paid')
-        expect(order.payment_total).to eq(100)
-
-        expect(payment_1).to be_completed
-        expect(payment_2).to be_completed
+      let!(:payment_1) do
+        create(:payment, payment_method: payment_method, order: order, amount: 50)
       end
 
-      it 'does not go over total for order' do
-        payment_1 = create(:payment, order: order, amount: 50)
-        payment_2 = create(:payment, order: order, amount: 50)
-        payment_3 = create(:payment, order: order, amount: 50)
+      context 'sharing the same payment method' do
+        let!(:payment_2) do
+          create(:payment, payment_method: payment_method, order: order, amount: 50)
+        end
 
-        order.process_payments!
-        updater.update_payment_state
+        it 'processes only new payments' do
+          order.process_payments!
+          updater.update_payment_state
 
-        expect(order.payment_state).to eq('paid')
-        expect(order.payment_total).to eq(100)
+          expect(order.payment_state).to eq('balance_due')
+          expect(order.payment_total).to eq(50)
 
-        expect(payment_1).to be_completed
-        expect(payment_2).to be_completed
-        expect(payment_3).to be_checkout
+          expect(payment_1).to be_invalid
+          expect(payment_2).to be_completed
+        end
       end
 
-      it "does not use failed payments" do
-        payment1 = create(:payment, order: order, amount: 50)
-        payment2 = create(:payment, order: order, amount: 50, state: 'failed')
+      context 'with different payment methods' do
+        let!(:payment_2) { create(:payment, order: order, amount: 50) }
 
-        expect(payment1).to receive(:process!).and_call_original
-        expect(payment2).not_to receive(:process!)
+        it 'processes all checkout payments' do
+          order.process_payments!
+          updater.update_payment_state
 
-        order.process_payments!
+          expect(order.payment_state).to eq('paid')
+          expect(order.payment_total).to eq(100)
 
-        expect(order.payment_total).to eq(50)
+          expect(payment_1).to be_completed
+          expect(payment_2).to be_completed
+        end
+
+        context 'with over paid payments' do
+          let!(:payment_3) { create(:payment, order: order, amount: 50) }
+
+          it 'does not go over total for order' do
+            order.process_payments!
+            updater.update_payment_state
+
+            expect(order.payment_state).to eq('paid')
+            expect(order.payment_total).to eq(100)
+            expect(payment_1).to be_completed
+            expect(payment_2).to be_completed
+            expect(payment_3).to be_checkout
+          end
+        end
+      end
+
+      context 'with failed payments' do
+        let!(:payment_2) do
+          create(:payment,
+            payment_method: payment_method,
+            order: order,
+            amount: 50,
+            state: 'failed')
+        end
+
+        it "does not use failed payments" do
+          expect(payment_1).to receive(:process!).and_call_original
+          expect(payment_2).not_to receive(:process!)
+
+          order.process_payments!
+
+          expect(order.payment_total).to eq(50)
+        end
       end
     end
 

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -741,6 +741,43 @@ describe Spree::Payment, type: :model do
       expect(payment.reload.state).to eq('checkout')
     end
 
+    context 'with order having other payments' do
+      let(:existing_payment_method) { create(:store_credit_payment_method) }
+      let(:existing_payment_source) { create(:store_credit) }
+      let!(:existing_payment) do
+        create(:payment,
+          payment_method: existing_payment_method,
+          source: existing_payment_source,
+          order: order,
+          amount: 5)
+      end
+
+      let(:payment_method) { create(:payment_method) }
+      let(:payment_source) { create(:credit_card) }
+      let(:payment) do
+        build(:payment,
+          payment_method: payment_method,
+          source: payment_source,
+          order: order,
+          amount: 5)
+      end
+
+      context 'that are store credit payments' do
+        it 'does not invalidate existing payments' do
+          expect { payment.save! }.to_not change { order.payments.with_state(:invalid).count }
+        end
+      end
+
+      context 'when payment is a store credit payment' do
+        let(:payment_method) { existing_payment_method }
+        let(:payment_source) { existing_payment_source }
+
+        it 'does not invalidate existing payments' do
+          expect { payment.save! }.to_not change { order.payments.with_state(:invalid).count }
+        end
+      end
+    end
+
     describe "invalidating payments updates in memory objects" do
       before do
         Spree::PaymentCreate.new(order, amount: 1).build.save!

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -742,8 +742,6 @@ describe Spree::Payment, type: :model do
     end
 
     context 'with order having other payments' do
-      let(:existing_payment_method) { create(:store_credit_payment_method) }
-      let(:existing_payment_source) { create(:store_credit) }
       let!(:existing_payment) do
         create(:payment,
           payment_method: existing_payment_method,
@@ -763,17 +761,29 @@ describe Spree::Payment, type: :model do
       end
 
       context 'that are store credit payments' do
+        let(:existing_payment_method) { create(:store_credit_payment_method) }
+        let(:existing_payment_source) { create(:store_credit) }
+
         it 'does not invalidate existing payments' do
           expect { payment.save! }.to_not change { order.payments.with_state(:invalid).count }
         end
+
+        context 'when payment itself is a store credit payment' do
+          let(:payment_method) { existing_payment_method }
+          let(:payment_source) { existing_payment_source }
+
+          it 'does not invalidate existing payments' do
+            expect { payment.save! }.to_not change { order.payments.with_state(:invalid).count }
+          end
+        end
       end
 
-      context 'when payment is a store credit payment' do
-        let(:payment_method) { existing_payment_method }
-        let(:payment_source) { existing_payment_source }
+      context 'that are not store credit payments' do
+        let(:existing_payment_method) { create(:payment_method) }
+        let(:existing_payment_source) { create(:credit_card) }
 
-        it 'does not invalidate existing payments' do
-          expect { payment.save! }.to_not change { order.payments.with_state(:invalid).count }
+        it 'invalidates existing payments', :pending do
+          expect { payment.save! }.to change { order.payments.with_state(:invalid).count }
         end
       end
     end

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -782,7 +782,7 @@ describe Spree::Payment, type: :model do
         let(:existing_payment_method) { create(:payment_method) }
         let(:existing_payment_source) { create(:credit_card) }
 
-        it 'invalidates existing payments', :pending do
+        it 'invalidates existing payments' do
           expect { payment.save! }.to change { order.payments.with_state(:invalid).count }
         end
       end


### PR DESCRIPTION
When creating a new payment for an order having existing payments
we want all previous payments in checkout state to be invalidated; except
if they are store credit payments.
                        
Former implementation only invalidated payments with same payment method.
That led to multiple valid payments per order for stores having more then
one payment method available for customers to choose from.