### PR TITLE
Revert "Select all shipping rates in the Estimator"

### DIFF
--- a/core/app/models/spree/shipping_rate.rb
+++ b/core/app/models/spree/shipping_rate.rb
@@ -35,10 +35,6 @@ module Spree
     end
     alias_method :display_cost, :display_price
 
-    def available_to_user?
-      shipping_method.available_to_users? || shipment.selected_shipping_rate == self
-    end
-
     private
 
     def tax_label_separator

--- a/core/app/models/spree/stock/estimator.rb
+++ b/core/app/models/spree/stock/estimator.rb
@@ -11,16 +11,13 @@ module Spree
       #   those marked frontend if truthy
       # @return [Array<Spree::ShippingRate>] the shipping rates sorted by
       #   descending cost, with the least costly marked "selected"
-      def shipping_rates(package, frontend_only = nil)
+      def shipping_rates(package, frontend_only = true)
         raise ShipmentRequired if package.shipment.nil?
         raise OrderRequired if package.shipment.order.nil?
-        if frontend_only.present?
-          Spree::Deprecation.warn "Using frontend_only arg is deprecated. All shipping rates will always be returned.", caller
-        end
 
         rates = calculate_shipping_rates(package)
-        frontend_rates = rates.select { |rate| rate.shipping_method.available_to_users? }
-        choose_default_shipping_rate(frontend_rates)
+        rates.select! { |rate| rate.shipping_method.available_to_users? } if frontend_only
+        choose_default_shipping_rate(rates)
         Spree::Config.shipping_rate_sorter_class.new(rates).sort
       end
 

--- a/core/spec/models/spree/shipping_rate_spec.rb
+++ b/core/spec/models/spree/shipping_rate_spec.rb
@@ -8,21 +8,12 @@ describe Spree::ShippingRate, type: :model do
   let(:order) { create :order, ship_address: address }
   let(:shipment) { create(:shipment, order: order) }
   let(:shipping_method) { create(:shipping_method, tax_category: tax_category) }
-  let(:backend_shipping_method) { create(:shipping_method, tax_category: tax_category, available_to_users: false) }
   let(:tax_category) { create :tax_category }
 
   subject(:shipping_rate) do
     Spree::ShippingRate.new(
       shipment: shipment,
       shipping_method: shipping_method,
-      cost: 10
-    )
-  end
-
-  subject(:backend_shipping_rate) do
-    Spree::ShippingRate.new(
-      shipment: shipment,
-      shipping_method: backend_shipping_method,
       cost: 10
     )
   end
@@ -192,24 +183,6 @@ describe Spree::ShippingRate, type: :model do
 
     it 'should be shipping_method.code' do
       expect(shipping_rate.shipping_method_code).to eq("THE_CODE")
-    end
-  end
-
-  context "#available_to_user?" do
-    it 'should return true if shipping_method is available_to_users' do
-      expect(shipping_rate.available_to_user?).to eq(true)
-    end
-
-    context "shipping_method not available_to_users" do
-      it 'should return false if not selected' do
-        expect(backend_shipping_rate.available_to_user?).to eq(false)
-      end
-
-      it 'should return true if selected' do
-        backend_shipping_rate.save
-        shipment.selected_shipping_rate_id = backend_shipping_rate.id
-        expect(backend_shipping_rate.available_to_user?).to eq(true)
-      end
     end
   end
 end

--- a/core/spec/models/spree/stock/estimator_spec.rb
+++ b/core/spec/models/spree/stock/estimator_spec.rb
@@ -129,13 +129,13 @@ module Spree
           let!(:backend_method) { create(:shipping_method, available_to_users: false, cost: 0.00) }
           let!(:generic_method) { create(:shipping_method, cost: 5.00) }
 
-          it "returns all shipping rates" do
-            expect(subject.shipping_rates(package).map(&:shipping_method_id)).to eq([backend_method.id, generic_method.id])
+          it "does not return backend rates at all" do
+            expect(subject.shipping_rates(package).map(&:shipping_method_id)).to eq([generic_method.id])
           end
 
           # regression for https://github.com/spree/spree/issues/3287
           it "doesn't select backend rates even if they're more affordable" do
-            expect(subject.shipping_rates(package).select(&:selected).map(&:shipping_method_id)).to eq [generic_method.id]
+            expect(subject.shipping_rates(package).map(&:selected)).to eq [true]
           end
         end
 

--- a/frontend/app/views/spree/checkout/_delivery.html.erb
+++ b/frontend/app/views/spree/checkout/_delivery.html.erb
@@ -37,7 +37,7 @@
 
           <h5 class="stock-shipping-method-title"><%= Spree.t(:shipping_method) %></h5>
           <ul class="field radios shipping-methods">
-            <% ship_form.object.shipping_rates.select(&:available_to_user?).each do |rate| %>
+            <% ship_form.object.shipping_rates.each do |rate| %>
               <li class="shipping-method">
                 <label>
                   <%= ship_form.radio_button :selected_shipping_rate_id, rate.id %>


### PR DESCRIPTION
Reverts solidusio/solidus#1984

Unfortunately, this would allow (mildly) malicious customers to select backend-only rates for their others. 

Steps to reproduce:
* On a store with a (supposed to be secret) free backend-only shipping rate
* Perform a checkout as an unprivileged user up to the delivery step
* Use inspector (or similar) to change the radio button's value to the value of a backend only shipping rate (this can be guessed easily by numbers near the id of the customer-available rates)
* Submit the page, receive the free backend-only shipping rate