### PR TITLE
Deprecate tasks in core/lib/tasks

### DIFF
--- a/core/db/seeds.rb
+++ b/core/db/seeds.rb
@@ -1,5 +1,18 @@
 # Loads seed data out of default dir
 default_path = File.join(File.dirname(__FILE__), 'default')
 
-Rake::Task['db:load_dir'].reenable
-Rake::Task['db:load_dir'].invoke(default_path)
+%w(
+  stores
+  store_credit
+  countries
+  return_reasons
+  states
+  stock_locations
+  zones
+  refund_reasons
+  roles
+  shipping_categories
+).each do |seed|
+  puts "Loading seed file: #{seed}"
+  require_relative "default/spree/#{seed}"
+end

--- a/core/lib/generators/spree/install/install_generator.rb
+++ b/core/lib/generators/spree/install/install_generator.rb
@@ -1,5 +1,4 @@
 require 'rails/generators'
-require 'highline/import'
 require 'bundler'
 require 'bundler/cli'
 

--- a/core/lib/tasks/core.rake
+++ b/core/lib/tasks/core.rake
@@ -10,6 +10,7 @@ namespace :db do
 use rake db:load_file[/absolute/path/to/sample/filename.rb]'
 
   task :load_file, [:file, :dir] => :environment do |_t, args|
+    Spree::Deprecation.warn("load_file has been deprecated. Please load your own file.")
     file = Pathname.new(args.file)
 
     puts "loading ruby #{file}"
@@ -18,6 +19,7 @@ use rake db:load_file[/absolute/path/to/sample/filename.rb]'
 
   desc "Loads fixtures from the the dir you specify using rake db:load_dir[loadfrom]"
   task :load_dir, [:dir] => :environment do |_t, args|
+    Spree::Deprecation.warn("rake spree:load_dir has been deprecated and will be removed with Solidus 3.0. Please load your files directly.")
     dir = args.dir
     dir = File.join(Rails.root, "db", dir) if Pathname.new(dir).relative?
 
@@ -37,6 +39,8 @@ use rake db:load_file[/absolute/path/to/sample/filename.rb]'
 
   desc "Migrate schema to version 0 and back up again. WARNING: Destroys all data in tables!!"
   task remigrate: :environment do
+    Spree::Deprecation.warn("remigrate has been deprecated. Please use db:reset or other db: commands instead.")
+
     if ENV['SKIP_NAG'] || ENV['OVERWRITE'].to_s.casecmp('true') || prompt_for_agree("This task will destroy any data in the database. Are you sure you want to \ncontinue? [y/n] ")
 
       # Drop all tables
@@ -55,6 +59,8 @@ use rake db:load_file[/absolute/path/to/sample/filename.rb]'
 
   desc "Bootstrap is: migrating, loading defaults, sample data and seeding (for all extensions) and load_products tasks"
   task :bootstrap do
+    Spree::Deprecation.warn("rake bootstrap has been deprecated, please run db:setup instead.")
+
     # remigrate unless production mode (as saftey check)
     if %w[demo development test].include? Rails.env
       if ENV['AUTO_ACCEPT'] || prompt_for_agree("This task will destroy any data in the database. Are you sure you want to \ncontinue? [y/n] ")

--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'cancancan', '~> 1.10'
   s.add_dependency 'ffaker', '~> 2.0'
   s.add_dependency 'friendly_id', '~> 5.0'
-  s.add_dependency 'highline', '~> 1.7' # Necessary for the install generator
   s.add_dependency 'kaminari', '>= 0.17', '< 2.0'
   s.add_dependency 'monetize', '~> 1.1'
   s.add_dependency 'paperclip', ['>= 4.2', '< 6']


### PR DESCRIPTION
None of these tasks should be used by people.

This deprecates those tasks, and removes a dependency that exists just to support these tasks (highline).