### PR TITLE
Mark ffaker as a common Spree dependency

### DIFF
--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -25,6 +25,7 @@ group :test do
   gem 'email_spec'
   gem 'factory_girl_rails', '~> 4.8'
   gem 'launchy'
+  gem 'ffaker', '~> 2.0'
   gem 'rspec-activemodel-mocks', '~>1.0.2'
   gem 'rspec-collection_matchers'
   gem 'rspec-its'

--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'awesome_nested_set', '~> 3.0', '>= 3.0.1'
   s.add_dependency 'carmen', '~> 1.0.0'
   s.add_dependency 'cancancan', '~> 1.10'
-  s.add_dependency 'ffaker', '~> 2.0'
   s.add_dependency 'friendly_id', '~> 5.0'
   s.add_dependency 'highline', '~> 1.7' # Necessary for the install generator
   s.add_dependency 'kaminari', '>= 0.17', '< 2.0'


### PR DESCRIPTION
FFaker is used by the test suite and should not be a production
dependency.