### PR TITLE
Fix shipping method factory for stores with alternate currency

### DIFF
--- a/core/lib/spree/testing_support/factories/shipping_method_factory.rb
+++ b/core/lib/spree/testing_support/factories/shipping_method_factory.rb
@@ -23,7 +23,7 @@ FactoryGirl.define do
 
     transient do
       cost 10.0
-      currency 'USD'
+      currency { Spree::Config[:currency] }
     end
 
     before(:create) do |shipping_method, _evaluator|

--- a/core/spec/lib/spree/core/testing_support/factories/shipping_method_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/shipping_method_factory_spec.rb
@@ -13,6 +13,15 @@ RSpec.describe 'shipping method factory' do
       shipping_method = create(factory)
       expect(shipping_method.calculator.calculable).to eq(shipping_method)
     end
+
+    context 'store using alternate currency' do
+      before { Spree::Config[:currency] = 'CAD' }
+
+      it "should configure the calculator correctly" do
+        shipping_method = create(factory)
+        expect(shipping_method.calculator.preferences[:currency]).to eq('CAD')
+      end
+    end
   end
 
   describe 'base shipping method' do


### PR DESCRIPTION
Without this change, a store with an alternate default currency will not find shipping rates for it's orders and shipments for those orders won't be shipable.