### PR TITLE
Rename Adjustment#update! to Adjustment#recalculate

### DIFF
--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -96,7 +96,7 @@ module Spree
     # admin) or is closed, this is a noop.
     #
     # @return [BigDecimal] New amount of this adjustment
-    def update!
+    def recalculate
       if finalized? && !tax?
         return amount
       end
@@ -116,6 +116,15 @@ module Spree
         update_columns(eligible: eligible, amount: amount, updated_at: Time.current) if changed?
       end
       amount
+    end
+
+    def update!(*args)
+      if args.empty?
+        Spree::Deprecation.warn "Calling adjustment.update! with no arguments to recalculate amounts and eligibility is deprecated, since it conflicts with AR::Base#update! Please use adjustment.recalculate instead"
+        recalculate
+      else
+        super
+      end
     end
 
     # Calculates based on attached promotion (if this is a promotion

--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -208,7 +208,7 @@ module Spree
       [*line_items, *shipments].each do |item|
         promotion_adjustments = item.adjustments.select(&:promotion?)
 
-        promotion_adjustments.each(&:update!)
+        promotion_adjustments.each(&:recalculate)
         Spree::Config.promotion_chooser_class.new(promotion_adjustments).update
 
         item.promo_total = promotion_adjustments.select(&:eligible?).sum(&:amount)
@@ -221,7 +221,7 @@ module Spree
     # line items and/or shipments.
     def update_order_promotions
       promotion_adjustments = order.adjustments.select(&:promotion?)
-      promotion_adjustments.each(&:update!)
+      promotion_adjustments.each(&:recalculate)
       Spree::Config.promotion_chooser_class.new(promotion_adjustments).update
     end
 
@@ -244,7 +244,7 @@ module Spree
 
     def update_cancellations
       line_items.each do |line_item|
-        line_item.adjustments.select(&:cancellation?).each(&:update!)
+        line_item.adjustments.select(&:cancellation?).each(&:recalculate)
       end
     end
 

--- a/core/lib/spree/testing_support/factories/adjustment_factory.rb
+++ b/core/lib/spree/testing_support/factories/adjustment_factory.rb
@@ -35,7 +35,7 @@ FactoryGirl.define do
             adjustment.source.tax_categories = []
           end
           adjustment.source.save
-          adjustment.update!
+          adjustment.recalculate
         end
       end
     end

--- a/core/spec/models/spree/adjustment_spec.rb
+++ b/core/spec/models/spree/adjustment_spec.rb
@@ -78,8 +78,8 @@ describe Spree::Adjustment, type: :model do
     end
   end
 
-  context '#update!' do
-    subject { adjustment.update! }
+  context '#recalculate' do
+    subject { adjustment.recalculate }
     let(:adjustment) do
       line_item.adjustments.create!(
         label: 'Adjustment',


### PR DESCRIPTION
Overriding `Adjustment#update!` prevented us from calling `AR::Base#update!` on an `Adjustment`. This renames `Adjustment#update!` to `Adjustment#recalculate` and deprecates calling `Adjustment#update!` with no arguments.

Follow up to #2072