### PR TITLE
Use number_with_currency widget on new refund page

### DIFF
--- a/backend/app/views/spree/admin/refunds/new.html.erb
+++ b/backend/app/views/spree/admin/refunds/new.html.erb
@@ -23,7 +23,7 @@
       <div class="col-3">
         <div class="field">
           <%= f.label :amount %><br/>
-          <%= f.text_field :amount, class: 'fullwidth' %>
+          <%= render "spree/admin/shared/number_with_currency", f: f, amount_attr: :amount, currency: @refund.currency, required: true %>
         </div>
       </div>
       <div class="col-3">

--- a/core/app/models/spree/refund.rb
+++ b/core/app/models/spree/refund.rb
@@ -18,8 +18,10 @@ module Spree
 
     scope :non_reimbursement, -> { where(reimbursement_id: nil) }
 
+    delegate :currency, to: :payment
+
     def money
-      Spree::Money.new(amount, { currency: payment.currency })
+      Spree::Money.new(amount, { currency: currency })
     end
     alias display_amount money
 


### PR DESCRIPTION
Also adds `Refund#currency`, which delegates to `Payment`