### PR TITLE
Make rubocop inherit_from-friendly

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -116,6 +116,7 @@ Rails/DynamicFindBy:
 Lint/AmbiguousBlockAssociation:
   Exclude:
     - '*/spec/**/*'
+    - 'spec/**/*' # For the benefit of apps that inherit from this config
 
 # We use eval to add common_spree_dependencies into the Gemfiles of each of our gems
 Security/Eval:


### PR DESCRIPTION
I inherit from Solidus rubocop rules in my Solidus application.
This change makes this rule work in my app as well as in Solidus.
