### PR TITLE
Remove responders dependency from core

### DIFF
--- a/api/lib/spree/api.rb
+++ b/api/lib/spree/api.rb
@@ -1,6 +1,7 @@
 require 'spree/core'
 
 require 'rabl'
+require 'responders'
 
 module Spree
   module Api

--- a/api/solidus_api.gemspec
+++ b/api/solidus_api.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'solidus_core', gem.version
   gem.add_dependency 'rabl', '0.13.0' # FIXME: update for proper rails 5 support
   gem.add_dependency 'versioncake', '~> 3.0'
+  gem.add_dependency 'responders'
 end

--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -11,7 +11,6 @@ require 'paperclip'
 require 'paranoia'
 require 'ransack'
 require 'state_machines-activerecord'
-require 'responders'
 
 # This is required because ActiveModel::Validations#invalid? conflicts with the
 # invalid state of a Payment. In the future this should be removed.

--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -34,7 +34,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'paranoia', '~> 2.3'
   s.add_dependency 'rails', '~> 5.1.0'
   s.add_dependency 'ransack', '~> 1.8'
-  s.add_dependency 'responders'
   s.add_dependency 'state_machines-activerecord', '~> 0.4'
   s.add_dependency 'stringex', '~> 1.5.1'
   s.add_dependency 'truncate_html', '~> 0.9', '>= 0.9.2'


### PR DESCRIPTION
Moves the responders dependency to the API, the place where we actually use it.

I'll rebase this once #1956 is merged, I just want to run tests.