### PR TITLE
Add missing default_currency field on admin/stores

### DIFF
--- a/backend/app/views/spree/admin/stores/_form.html.erb
+++ b/backend/app/views/spree/admin/stores/_form.html.erb
@@ -40,6 +40,15 @@
   <%= f.error_message_on :mail_from_address %>
 <% end %>
 
+<%= f.field_container :default_currency do %>
+  <%= f.label :default_currency %>
+  <%= f.select :default_currency,
+    ::Money::Currency.all.map(&:iso_code),
+    { include_blank: true },
+    { class: 'select2 fullwidth' } %>
+  <%= f.error_message_on :default_currency %>
+<% end %>
+
 <%= f.field_container :cart_tax_country_iso do %>
   <%= f.label :cart_tax_country_iso %>
   <%= f.field_hint :cart_tax_country_iso %>

--- a/backend/spec/features/admin/stores_spec.rb
+++ b/backend/spec/features/admin/stores_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe 'Stores', type: :feature do
+  stub_authorization!
+
+  context 'when adding a store' do
+    before { visit spree.new_admin_store_path }
+
+    it 'admin should be able to set the default_currency' do
+      expect(find('#store_default_currency').value).to eq ''
+
+      fill_in 'store_name', with: 'Solidus Store'
+      fill_in 'store_code', with: 'solidus'
+      fill_in 'store_url', with: 'example.solidus.io'
+      fill_in 'store_mail_from_address', with: 'from@solidus.io'
+      select 'EUR', from: 'store_default_currency'
+      click_button 'Create'
+
+      @store = Spree::Store.last
+
+      expect(@store.default_currency).to eq 'EUR'
+    end
+  end
+
+  context 'when editing a store' do
+    let(:store) { create :store, default_currency: 'AUD' }
+    before { visit spree.edit_admin_store_path(store) }
+
+    it 'admin should be able to change the default_currency' do
+      select 'EUR', from: 'store_default_currency'
+      click_button 'Update'
+      expect(store.reload.default_currency).to eq 'EUR'
+    end
+  end
+end


### PR DESCRIPTION
The Spree::Store have a default_currency field that is used in
`core/lib/spree/core/controller_helpers/pricing.rb` but never valorized
because the field was missing from the store form.