### PR TITLE
Check if deprecated method_type if overridden

### DIFF
--- a/core/app/models/spree/payment_method.rb
+++ b/core/app/models/spree/payment_method.rb
@@ -156,10 +156,22 @@ module Spree
     #     The view that represents your payment method on orders in the backend
     #
     def partial_name
-      type.demodulize.downcase
+      deprecated_method_type_override || type.demodulize.downcase
     end
-    alias_method :method_type, :partial_name
-    deprecate method_type: :partial_name, deprecator: Spree::Deprecation
+
+    # :nodoc:
+    # If method_type has been overridden, call it and return the value, otherwise return nil
+    def deprecated_method_type_override
+      if method(:method_type).owner != Spree::PaymentMethod
+        Spree::Deprecation.warn "overriding PaymentMethod#method_type is deprecated and will be removed from Solidus 3.0 (override partial_name instead)", caller
+        method_type
+      end
+    end
+
+    def method_type
+      Spree::Deprecation.warn "method_type is deprecated and will be removed from Solidus 3.0 (use partial_name instead)", caller
+      partial_name
+    end
 
     def payment_profiles_supported?
       false

--- a/core/app/models/spree/payment_method/credit_card.rb
+++ b/core/app/models/spree/payment_method/credit_card.rb
@@ -12,7 +12,7 @@ module Spree
     end
 
     def partial_name
-      'gateway'
+      deprecated_method_type_override || 'gateway'
     end
 
     def supports?(source)


### PR DESCRIPTION
method_type has been deprecated in favour of the more descriptive partial_name. There is a deprecation notice when method_type is called, but there isn't when method_type is overridden (which is very likely for
custom gateway implementations).

This commit checks if method_type has been overridden, and if so, uses that instead of the default value of partial_name.

This fixed both `solidus_gateway` and `solidus_braintree` on latest master (and provided warnings of how best to move forward), so I imagine it is likely to be helpful for users.