### PR TITLE
Invalidate old payments done with different payment method

### DIFF
--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -230,9 +230,8 @@ module Spree
 
     def invalidate_old_payments
       if !store_credit? && !['invalid', 'failed'].include?(state)
-        order.payments.select do |payment|
+        order.reload.payments.select do |payment|
           payment.state == 'checkout' &&
-            payment.payment_method_id == payment_method.try!(:id) &&
             payment.id != id
         end.each(&:invalidate!)
       end

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -757,6 +757,13 @@ describe Spree::Payment, type: :model do
         )
       end
     end
+
+    it 'invalidates old payments that have a different payment method' do
+      expect {
+        another_gateway = Spree::PaymentMethod::BogusCreditCard.new(active: true, name: 'Bogus gateway')
+        Spree::Payment.create!(source: card, order: order, payment_method: another_gateway, amount: 5)
+      }.to change { payment.reload.state }.from('checkout').to('invalid')
+    end
   end
 
   # This used to describe #apply_source_attributes, whose behaviour is now part of PaymentCreate


### PR DESCRIPTION
Previously if a user makes a payment with payment method A, go to confirm, go back to payment and makes another payment with payment method B, both payments remains in 'checkout' state.

The correct behavior should be invalidating old payments whatever payment method they were created with.

I have some doubt about the in memory `order` object, which need a `.reload` to have both payments available. In fact when the `after_create :invalidate_old_payments` is called, it only contains the old payments without the newly added one.