### PR TITLE
[RFC] New action icons style

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/shared/_tables.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_tables.scss
@@ -34,7 +34,8 @@ table {
     &.actions {
       background-color: transparent;
       border: none !important;
-      text-align: center;
+      text-align: left;
+      padding-left: 1.25rem;
 
       span.text {
         font-size: $font-size-base;
@@ -42,23 +43,17 @@ table {
 
       .fa {
         font-size: 120%;
-        background-color: very-light($color-3);
-        border: 1px solid $color-border;
-        border-radius: 15px;
-        width: 29px;
-        height: 29px;
         display: inline-block;
-        padding-top: 6px;
+        padding: 2px 0;
+        text-align: center;
+        border-bottom: none;
+        vertical-align: middle;
 
         &:before {
-          text-align: center !important;
           padding: 0;
           width: 27px;
           display: inline-block;
-        }
-
-        &:hover {
-          border-color: transparent;
+          vertical-align: middle;
         }
       }
 
@@ -72,33 +67,32 @@ table {
         padding-left: 0px;
 
         &:hover {
-          background-color: $color-3;
-          color: $color-1;
+          color: $color-3;
         }
       }
+
       .fa-trash:hover, .fa-void:hover, .fa-failure:hover {
-        background-color: $brand-danger;
-        color: $color-1;
+        color: $brand-danger;
       }
+
       .fa-cancel:hover {
-        background-color: $brand-warning;
-        color: $color-1;
+        color: $brand-warning;
       }
+
       .fa-edit:hover, .fa-capture:hover, .fa-ok:hover, .fa-plus:hover, .fa-save:hover {
-        background-color: $brand-success;
-        color: $color-1;
+        color: $brand-success;
       }
+
       .fa-copy:hover {
-        background-color: $brand-warning;
-        color: $color-1;
+        color: $brand-warning;
       }
+
       .fa-thumbs-up:hover {
-        background-color: $brand-success;
-        color: $color-1;
+        color: $brand-success;
       }
+
       .fa-thumbs-down:hover {
-        background-color: $brand-danger;
-        color: $color-1;
+        color: $brand-danger;
       }
     }
 
@@ -123,7 +117,6 @@ table {
     td, th {
       border: none !important;
     }
-
   }
 
   th:not(.wrap-text), td.actions, td.no-wrap, .state {


### PR DESCRIPTION
No more background and rounded corner. Using the icon only.
More cleaner and reduced interface.

![new action buttons](https://user-images.githubusercontent.com/42868/28387428-5fb6400c-6ccf-11e7-8b42-d8990ffdee62.png)

In preparation for #2092 

## Even more beautiful with the new table style

![orders with new action buttons](https://user-images.githubusercontent.com/42868/28405248-d0913798-6d2c-11e7-8e91-04f88530f6bb.png)

![products with new action buttons](https://user-images.githubusercontent.com/42868/28405250-d209df6c-6d2c-11e7-8bc7-3529bbc2d77b.png)

/c @Mandily 