### PR TITLE
Preview Images in a Modal

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/sections/_products.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/_products.scss
@@ -56,3 +56,7 @@ div[data-hook="admin_products_index_search_buttons"] {
   height: 100%;
   padding: 1rem;
 }
+
+.modal-image-trigger {
+  cursor: zoom-in;
+}

--- a/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
@@ -64,9 +64,12 @@ label {
 
 input[type="submit"],
 input[type="button"],
-button, .button {
-  @extend .btn;
-  @include button-variant($btn-primary-color, $btn-primary-bg, $btn-primary-border);
+button,
+.button {
+  &:not(.close) {
+    @extend .btn;
+    @include button-variant($btn-primary-color, $btn-primary-bg, $btn-primary-border);
+  }
 
   &:before {
     font-weight: normal !important;

--- a/backend/app/assets/stylesheets/spree/backend/shared/_layout.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_layout.scss
@@ -29,7 +29,6 @@ body {
 
 #content {
   position: relative;
-  z-index: 0;
   padding: 0;
   margin-top: 15px;
 }

--- a/backend/app/controllers/spree/admin/style_guide_controller.rb
+++ b/backend/app/controllers/spree/admin/style_guide_controller.rb
@@ -23,6 +23,7 @@ module Spree
           ],
           components: [
             'pills',
+            'modals',
             'tabs'
           ],
           messaging: [

--- a/backend/app/views/spree/admin/images/_image_row.html.erb
+++ b/backend/app/views/spree/admin/images/_image_row.html.erb
@@ -7,9 +7,19 @@
   </td>
 
   <td>
-    <%= link_to image.attachment.url(:product) do %>
+    <span class="modal-image-trigger" data-toggle="modal" data-target="#modal-image-<%= image.id %>">
       <%= render 'spree/admin/shared/image', image: image, size: :mini %>
-    <% end %>
+    </span>
+    <%= render(
+      "spree/admin/shared/modal",
+      target: "modal-image-#{image.id}",
+      title: image.alt,
+      content: %{
+        <div class='align-center'>
+          #{image_tag(image.attachment.url(:large))}
+        </div>
+      }.html_safe
+    ) %>
   </td>
 
   <% if @product.has_variants? %>

--- a/backend/app/views/spree/admin/shared/_modal.html.erb
+++ b/backend/app/views/spree/admin/shared/_modal.html.erb
@@ -1,0 +1,18 @@
+<div class="modal fade" id="<%= target %>" role="dialog" aria-labelledby="<%= target %>" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="<%= target %>"><%= title %></h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <%= content %>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/backend/app/views/spree/admin/style_guide/topics/components/_modals.html.erb
+++ b/backend/app/views/spree/admin/style_guide/topics/components/_modals.html.erb
@@ -1,0 +1,50 @@
+<p>
+  Bootstrap modals are ready to use by rendering the shared partial and creating
+  a trigger.
+</p>
+
+<p>The partial requires three locals:</p>
+
+<ul>
+  <li>
+    <code>target</code>: this should match the <code>data-target</code> in your
+    trigger
+  </li>
+  <li>
+    <code>title</code>: this will appear in the modal's header
+  </li>
+  <li>
+    <code>content</code>: this will appear in the modal's body. This content can
+    be whatever you like – even another partial.
+  </li>
+</ul>
+
+<%- snippet = capture do %>
+  <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#your-target">
+    Launch demo modal
+  </button>
+
+  &lt;%= render(
+    "spree/admin/shared/modal",
+    target: "your-target",
+    title: "Your Title",
+    content: "The modal's content, could be another partial"
+  ) %&gt;
+<%- end %>
+
+<div class="style-guide-code half">
+  <pre><code class="language-html"><%= escape_once snippet %></code></pre>
+</div>
+
+<div class="style-guide-result half">
+  <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#your-target">
+    Demo Modal
+  </button>
+
+  <%= render(
+    "spree/admin/shared/modal",
+    target: "your-target",
+    title: "Your Title",
+    content: "The modal's content, could be another partial"
+  ) %>
+</div>


### PR DESCRIPTION
Additionally this PR adds a shared modal partial for the admin and instructions on its usage to the style guide.

![modal](https://user-images.githubusercontent.com/836758/28392722-fee9ed5a-6c97-11e7-8a58-1f87f09e5840.gif)
