### PR TITLE
Override model_name.human for PaymentMethod

### DIFF
--- a/core/spec/models/spree/payment_method_spec.rb
+++ b/core/spec/models/spree/payment_method_spec.rb
@@ -354,4 +354,20 @@ describe Spree::PaymentMethod, type: :model do
       expect(payment_method.credit).to eq 'credit'
     end
   end
+
+  describe 'model_name.human' do
+    context 'PaymentMethod itself' do
+      it "returns i18n value" do
+        expect(Spree::PaymentMethod.model_name.human).to eq('Payment Method')
+      end
+    end
+
+    context 'A subclass with no i18n key' do
+      let!(:klass) { stub_const("MyGem::SomeClass", Class.new(described_class)) }
+
+      it "returns default humanized value" do
+        expect(klass.model_name.human).to eq('Some class')
+      end
+    end
+  end
 end


### PR DESCRIPTION
Recently we started using `model_name.human` instead of the raw class name when displaying the names of payment methods.

Unfortunately, if there isn't an i18n key for that specific payment method, model_name.human will fall back to "Payment Method", which is not at all helpful in distinguishing it.

This commit changes `PaymentMethod.model_name` to return a custom `ActiveModel::Name` subclass, which will use exact matches for translations but doesn't fall back to "Payment Method", and instead will
use the "humanized" class name if there is no key.

Fixes #2106