### PR TITLE
Inline Table Editing

### DIFF
--- a/api/app/controllers/spree/api/tax_categories_controller.rb
+++ b/api/app/controllers/spree/api/tax_categories_controller.rb
@@ -1,0 +1,25 @@
+module Spree
+  module Api
+    class TaxCategoriesController < Spree::Api::BaseController
+      skip_before_action :authenticate_user
+
+      def update
+        @tax_category = Spree::TaxCategory.
+          accessible_by(current_ability, :update).
+          find(params[:id])
+
+        if @tax_category.update_attributes(tax_category_params)
+          respond_with(@tax_category, default_template: :show)
+        else
+          invalid_resource!(@tax_category)
+        end
+      end
+
+      private
+
+      def tax_category_params
+        params.require(:tax_category).permit(permitted_tax_category_attributes)
+      end
+    end
+  end
+end

--- a/api/app/helpers/spree/api/api_helpers.rb
+++ b/api/app/helpers/spree/api/api_helpers.rb
@@ -32,6 +32,7 @@ module Spree
         :store_attributes,
         :store_credit_history_attributes,
         :stock_transfer_attributes,
+        :tax_category_attributes,
         :transfer_item_attributes,
         :transfer_item_variant_attributes,
         :variant_property_attributes
@@ -179,6 +180,8 @@ module Spree
       ]
 
       @@stock_transfer_attributes = [:id, :number]
+
+      @@tax_category_attributes = [:name, :description, :is_default, :tax_code]
 
       @@transfer_item_attributes = [:id, :expected_quantity, :received_quantity]
 

--- a/api/app/views/spree/api/tax_categories/show.v1.rabl
+++ b/api/app/views/spree/api/tax_categories/show.v1.rabl
@@ -1,0 +1,2 @@
+object @tax_category
+attributes *tax_category_attributes

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -135,6 +135,8 @@ Spree::Core::Engine.routes.draw do
       end
     end
 
+    resources :tax_categories, only: :update
+
     get '/config/money', to: 'config#money'
     get '/config', to: 'config#show'
     put '/classifications', to: 'classifications#update', as: :classifications

--- a/backend/app/assets/javascripts/spree/backend/views/tables/editable_table_row.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/views/tables/editable_table_row.js.coffee
@@ -26,8 +26,11 @@ Spree.Views.Tables.EditableTableRow = Backbone.View.extend
       method: 'put'
       success: (response) =>
         @$el.removeClass("editing")
+        $(".has-danger", @$el).removeClass("has-danger")
         @storeValues()
       error: (response) =>
+        for field, errors of response.responseJSON.errors
+          $("input[name*='[#{field}]']", @$el).parent().addClass("has-danger")
         show_flash 'error', response.responseJSON.error
 
   ENTER_KEY: 13

--- a/backend/app/assets/javascripts/spree/backend/views/tables/editable_table_row.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/views/tables/editable_table_row.js.coffee
@@ -1,6 +1,7 @@
 Spree.Views.Tables.EditableTableRow = Backbone.View.extend
   events:
     "focus :input": "onEdit"
+    "blur :input": "onBlur"
     "click [data-action=save]": "onSave"
     "click [data-action=cancel]": "onCancel"
     'keyup input': 'onKeypress'
@@ -10,6 +11,10 @@ Spree.Views.Tables.EditableTableRow = Backbone.View.extend
 
   onEdit: ->
     @$el.addClass('editing')
+
+  onBlur: (e) ->
+    if $(":input", @$el).serialize() == @originalFormData
+      @onCancel(e)
 
   onCancel: (e) ->
     e.preventDefault()
@@ -43,6 +48,8 @@ Spree.Views.Tables.EditableTableRow = Backbone.View.extend
       when @ESC_KEY then @onCancel(e)
 
   storeValues: ->
+    @originalFormData = $(":input", @$el).serialize()
+
     $(":input", @$el).each ->
       $input = $(this)
       $input.data 'original-value', $input.val()

--- a/backend/app/assets/javascripts/spree/backend/views/tables/editable_table_row.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/views/tables/editable_table_row.js.coffee
@@ -1,7 +1,6 @@
 Spree.Views.Tables.EditableTableRow = Backbone.View.extend
   events:
-    "select2-open": "onEdit"
-    "focus input": "onEdit"
+    "focus :input": "onEdit"
     "click [data-action=save]": "onSave"
     "click [data-action=cancel]": "onCancel"
     'keyup input': 'onKeypress'
@@ -21,7 +20,7 @@ Spree.Views.Tables.EditableTableRow = Backbone.View.extend
     e.preventDefault()
 
     Spree.ajax @$el.find('.actions [data-action=save]').attr('href'),
-      data: @$el.find('select, input').serialize()
+      data: $(":input", @$el).serializeArray()
       dataType: 'json'
       method: 'put'
       success: (response) =>

--- a/backend/app/assets/javascripts/spree/backend/views/tables/editable_table_row.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/views/tables/editable_table_row.js.coffee
@@ -27,6 +27,7 @@ Spree.Views.Tables.EditableTableRow = Backbone.View.extend
         @$el.removeClass("editing")
         $(".has-danger", @$el).removeClass("has-danger")
         @storeValues()
+        show_flash "success", Spree.translations.updated_successfully
       error: (response) =>
         for field, errors of response.responseJSON.errors
           $("input[name*='[#{field}]']", @$el).parent().addClass("has-danger")

--- a/backend/app/assets/javascripts/spree/backend/views/tables/editable_table_row.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/views/tables/editable_table_row.js.coffee
@@ -6,22 +6,16 @@ Spree.Views.Tables.EditableTableRow = Backbone.View.extend
     "click [data-action=cancel]": "onCancel"
     'keyup input': 'onKeypress'
 
-  onEdit: (e) ->
-    return if @$el.hasClass('editing')
-    @$el.addClass('editing')
+  initialize: ->
+    @storeValues()
 
-    @$el.find('input, select').each ->
-      $input = $(this)
-      $input.data 'original-value', $input.val()
+  onEdit: ->
+    @$el.addClass('editing')
 
   onCancel: (e) ->
     e.preventDefault()
     @$el.removeClass("editing")
-
-    @$el.find('input, select').each ->
-      $input = $(this)
-      originalValue = $input.data('original-value')
-      $input.val(originalValue).change()
+    @restoreOriginalValues()
 
   onSave: (e) ->
     e.preventDefault()
@@ -32,6 +26,7 @@ Spree.Views.Tables.EditableTableRow = Backbone.View.extend
       method: 'put'
       success: (response) =>
         @$el.removeClass("editing")
+        @storeValues()
       error: (response) =>
         show_flash 'error', response.responseJSON.error
 
@@ -43,3 +38,14 @@ Spree.Views.Tables.EditableTableRow = Backbone.View.extend
     switch key
       when @ENTER_KEY then @onSave(e)
       when @ESC_KEY then @onCancel(e)
+
+  storeValues: ->
+    $(":input", @$el).each ->
+      $input = $(this)
+      $input.data 'original-value', $input.val()
+
+  restoreOriginalValues: ->
+    $(":input", @$el).each ->
+      $input = $(this)
+      originalValue = $input.data('original-value')
+      $input.val(originalValue).change()

--- a/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
@@ -8,27 +8,29 @@ input[type="url"],
 input[type="number"],
 input[type="tel"],
 textarea {
-  padding: $input-padding-y $input-padding-x;
-  color: $input-color;
-  border: $input-btn-border-width solid $input-border-color;
-  border-radius: $input-border-radius;
-  background: $input-bg;
-  font-size: $font-size-base;
-  line-height: $input-line-height;
+  &:not(.form-control) {
+    padding: $input-padding-y $input-padding-x;
+    color: $input-color;
+    border: $input-btn-border-width solid $input-border-color;
+    border-radius: $input-border-radius;
+    background: $input-bg;
+    font-size: $font-size-base;
+    line-height: $input-line-height;
 
-  &:focus {
-    border-color: $input-border-focus;
-    outline: 0;
-  }
+    &:focus {
+      border-color: $input-border-focus;
+      outline: 0;
+    }
 
-  &:disabled {
-    background: $input-bg-disabled;
-  }
+    &:disabled {
+      background: $input-bg-disabled;
+    }
 
-  &::placeholder {
-    color: $input-color-placeholder;
-    // Override Firefox's unusual default opacity; see https://github.com/twbs/bootstrap/pull/11526.
-    opacity: 1;
+    &::placeholder {
+      color: $input-color-placeholder;
+      // Override Firefox's unusual default opacity; see https://github.com/twbs/bootstrap/pull/11526.
+      opacity: 1;
+    }
   }
 }
 

--- a/backend/app/views/spree/admin/images/_image_row.html.erb
+++ b/backend/app/views/spree/admin/images/_image_row.html.erb
@@ -15,10 +15,10 @@
   <% if @product.has_variants? %>
     <td>
       <%= fields_for image do |f| %>
-        <%= f.select :viewable_id, options_for_select(@variants, image.viewable_id), {}, class: 'select2 fullwidth', autocomplete: "off" %>
+        <%= f.select :viewable_id, options_for_select(@variants, image.viewable_id), {}, class: 'custom-select fullwidth', autocomplete: "off" %>
       <% end %>
     </td>
-  <% end # @product.has_variants? %>
+  <% end %>
 
   <td>
     <%= fields_for image do |f| %>

--- a/backend/app/views/spree/admin/tax_categories/index.html.erb
+++ b/backend/app/views/spree/admin/tax_categories/index.html.erb
@@ -4,7 +4,6 @@
 <% admin_breadcrumb(Spree.t('admin.tab.taxes')) %>
 <% admin_breadcrumb(plural_resource_name(Spree::TaxCategory)) %>
 
-
 <% content_for :page_actions do %>
   <ul class="actions inline-menu">
     <% if can?(:create, Spree::TaxCategory) %>
@@ -16,13 +15,13 @@
 <% end %>
 
 <% if @tax_categories.any? %>
-<table class="index" id='listing_tax_categories' data-hook>
+<table class="index inline-editable-table" id='listing_tax_categories' data-hook>
   <colgroup>
-    <col style="width: 20%" />
-    <col style="width: 10%" />
+    <col style="width: 25%" />
+    <col style="width: 15%" />
     <col style="width: 40%" />
-    <col style="width: 15%" />
-    <col style="width: 15%" />
+    <col style="width: 10%" />
+    <col style="width: 10%" />
   </colgroup>
   <thead>
     <tr data-hook="tax_header">
@@ -34,18 +33,47 @@
     </tr>
   </thead>
   <tbody>
-    <% @tax_categories.each do |tax_category|
-         @edit_url = edit_admin_tax_category_path(tax_category)
-         @delete_url = admin_tax_category_path(tax_category)
-    %>
+    <% @tax_categories.each do |tax_category| %>
       <tr id="<%= spree_dom_id tax_category %>" data-hook="tax_row" class="<%= cycle('odd', 'even')%>">
-        <td class="align-center"><%= tax_category.name %></td>
-        <td class="align-center"><%= tax_category.tax_code %></td>
-        <td class="align-center"><%= tax_category.description %></td>
-        <td class="align-center"><%= tax_category.is_default? ? Spree.t(:say_yes) : Spree.t(:say_no) %></td>
+        <td class="align-center">
+          <%= fields_for tax_category do |f| %>
+            <%= f.text_field :name, class: "form-control" %>
+          <% end %>
+        </td>
+        <td class="align-center">
+          <%= fields_for tax_category do |f| %>
+            <%= f.text_field :tax_code, class: "form-control" %>
+          <% end %>
+        </td>
+        <td class="align-center">
+          <%= fields_for tax_category do |f| %>
+            <%= f.text_field :description, class: "form-control" %>
+          <% end %>
+        </td>
+        <td class="align-center">
+          <%= fields_for tax_category do |f| %>
+            <%= f.check_box(
+              :is_default,
+              class: "form-control"
+            ) %>
+          <% end %>
+        </td>
         <td class="actions">
           <% if can?(:update, tax_category) %>
-            <%= link_to_edit tax_category, no_text: true %>
+            <%= link_to_with_icon(
+              'check',
+              Spree.t('actions.save'),
+              api_tax_category_path(tax_category),
+              no_text: true,
+              data: { action: 'save' }
+            ) %>
+            <%= link_to_with_icon(
+              'cancel',
+              Spree.t('actions.cancel'),
+              nil,
+              no_text: true,
+              data: { action: 'cancel' }
+            ) %>
           <% end %>
           <% if can?(:destroy, tax_category) %>
             <%= link_to_delete tax_category, no_text: true %>

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -26,7 +26,7 @@ Spree::Core::Engine.routes.draw do
       resources :states
     end
     resources :states
-    resources :tax_categories
+    resources :tax_categories, only: [:index, :new, :create, :destroy]
 
     resources :products do
       resources :product_properties do

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -25,6 +25,7 @@ module Spree
       :stock_location_attributes,
       :stock_movement_attributes,
       :store_attributes,
+      :tax_category_attributes,
       :taxon_attributes,
       :taxonomy_attributes,
       :transfer_item_attributes,
@@ -123,6 +124,8 @@ module Spree
     # admin owns. creating a user with an email is handled separate at the
     # controller level
     @@user_attributes = [:password, :password_confirmation]
+
+    @@tax_category_attributes = [:name, :description, :is_default, :tax_code]
 
     @@variant_attributes = [
       :name, :presentation, :cost_price, :lock_version,


### PR DESCRIPTION
This PR does a few different things:

1. Refactors the inline editable table row JS to handle a few different scenarios of editing (like removing the save/cancel buttons if no fields have changed).
2. Only apply our custom form styling to elements that aren't already using Bootstrap classes (e.g. `form-control`)
  - A note about this change: this is likely something that we'll want to do throughout the admin so we do not have selector specificity collisions. https://github.com/graygilmore/solidus/commit/8777e5f78ec6c92899a89190d5b03e62ea1f0026
3. Add an API endpoint for updating tax categories and implement the inline editable table to the index page as another example implementation (the first being the product images table)

This PR addresses but does not complete https://github.com/solidusio/solidus/issues/2042. There are quite a few more tables to go which I will be opening up later PRs for.

## TODO

- [x] fix spec failures
- [ ] remove skip auth
- [ ] fix checkbox reset
- [ ] ~~investigate moving this functionality to Backbone~~