### PR TITLE
[RFC] Cancel payments refunds correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Solidus 2.4.0 (master, unreleased)
 
+- Added a configurable `Spree::Payment::Cancellation` class [\#2111](https://github.com/solidusio/solidus/pull/2111) ([tvdeyen](https://github.com/tvdeyen))
+
+- Deprecated `Spree::PaymentMethod#cancel` [\#2111](https://github.com/solidusio/solidus/pull/2111) ([tvdeyen](https://github.com/tvdeyen))
+  Please implement a `try_void` method on your payment method instead that returns a response object if void succeeds or false if not. Solidus will refund the payment then.
+
 - Deprecates several preference fields helpers in favor of preference field partials. [\#2040](https://github.com/solidusio/solidus/pull/2040) ([tvdeyen](https://github.com/tvdeyen))
   Please render `spree/admin/shared/preference_fields/\#{preference_type}' instead
 

--- a/core/app/models/spree/payment/cancellation.rb
+++ b/core/app/models/spree/payment/cancellation.rb
@@ -1,0 +1,60 @@
+module Spree
+  class Payment
+    # Payment cancellation handler
+    #
+    # Cancels a payment by trying to void first and if that fails
+    # creating a refund about the full amount instead.
+    #
+    class Cancellation
+      DEFAULT_REASON = 'Order canceled'.freeze
+
+      attr_reader :reason
+
+      # @param reason [String] (DEFAULT_REASON) -
+      #   The reason used to create the Spree::RefundReason
+      def initialize(reason: DEFAULT_REASON)
+        @reason = reason
+      end
+
+      # Cancels a payment
+      #
+      # Tries to void the payment by asking the payment method to try a void,
+      # if that fails create a refund about the allowed credit amount instead.
+      #
+      # @param payment [Spree::Payment] - the payment that should be canceled
+      #
+      def cancel!(payment)
+        # For payment methods already implemeting `try_void`
+        if try_void_available?(payment.payment_method)
+          if response = payment.payment_method.try_void(payment)
+            payment.send(:handle_void_response, response)
+          else
+            payment.refunds.create!(amount: payment.credit_allowed, reason: refund_reason)
+          end
+        else
+          # For payment methods not yet implemeting `try_void`
+          deprecated_behavior(payment)
+        end
+      end
+
+      private
+
+      def refund_reason
+        Spree::RefundReason.where(name: reason).first_or_create
+      end
+
+      def try_void_available?(payment_method)
+        payment_method.respond_to?(:try_void) &&
+          payment_method.method(:try_void).owner != Spree::PaymentMethod
+      end
+
+      def deprecated_behavior(payment)
+        Spree::Deprecation.warn "#{payment.payment_method.class.name}#cancel is deprecated and will be removed. " \
+          'Please implement a `try_void` method instead that returns a response object if void succeeds ' \
+          'or `false|nil` if not. Solidus will refund the full amount of the payment then.'
+        response = payment.payment_method.cancel(payment.response_code)
+        payment.send(:handle_void_response, response)
+      end
+    end
+  end
+end

--- a/core/app/models/spree/payment/cancellation.rb
+++ b/core/app/models/spree/payment/cancellation.rb
@@ -23,7 +23,7 @@ module Spree
       #
       # @param payment [Spree::Payment] - the payment that should be canceled
       #
-      def cancel!(payment)
+      def cancel(payment)
         # For payment methods already implemeting `try_void`
         if try_void_available?(payment.payment_method)
           if response = payment.payment_method.try_void(payment)
@@ -51,7 +51,7 @@ module Spree
       def deprecated_behavior(payment)
         Spree::Deprecation.warn "#{payment.payment_method.class.name}#cancel is deprecated and will be removed. " \
           'Please implement a `try_void` method instead that returns a response object if void succeeds ' \
-          'or `false|nil` if not. Solidus will refund the full amount of the payment then.'
+          'or `false|nil` if not. Solidus will refund the payment then.'
         response = payment.payment_method.cancel(payment.response_code)
         payment.send(:handle_void_response, response)
       end

--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -79,8 +79,9 @@ module Spree
       end
 
       def cancel!
-        response = payment_method.cancel(response_code)
-        handle_void_response(response)
+        Spree::Payment::Cancellation.new(
+          reason: Spree::Payment::Cancellation::DEFAULT_REASON
+        ).cancel!(self)
       end
 
       def gateway_options

--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -79,9 +79,7 @@ module Spree
       end
 
       def cancel!
-        Spree::Payment::Cancellation.new(
-          reason: Spree::Payment::Cancellation::DEFAULT_REASON
-        ).cancel!(self)
+        Spree::Config.payment_canceller.cancel(self)
       end
 
       def gateway_options

--- a/core/app/models/spree/payment_method.rb
+++ b/core/app/models/spree/payment_method.rb
@@ -221,8 +221,23 @@ module Spree
       true
     end
 
-    def cancel(_response)
-      raise ::NotImplementedError, 'You must implement cancel method for this payment method.'
+    # Used by Spree::Payment#cancel!
+    #
+    # Implement `try_void` on your payment method implementation to handle void attempts.
+    # In that method return a ActiveMerchant::Billing::Response object if the void succeeds.
+    # Return +false+ or +nil+ if the void is not possible anymore - because it was already processed by the bank.
+    # Solidus will refund the amount of the payment in this case.
+    #
+    # @return [ActiveMerchant::Billing::Response] with +true+ if the void succeeded
+    # @return [ActiveMerchant::Billing::Response] with +false+ if the void failed
+    # @return [false] if it can't be voided at this time
+    #
+    def try_void(_payment)
+      raise ::NotImplementedError,
+        "You need to implement `try_void` for #{self.class.name}. In that " \
+        'return a ActiveMerchant::Billing::Response object if the void succeeds '\
+        'or `false|nil` if the void is not possible anymore. ' \
+        'Solidus will refund the amount of the payment then.'
     end
 
     def store_credit?

--- a/core/app/models/spree/payment_method/bogus_credit_card.rb
+++ b/core/app/models/spree/payment_method/bogus_credit_card.rb
@@ -55,7 +55,8 @@ module Spree
       ActiveMerchant::Billing::Response.new(true, 'Bogus Gateway: Forced success', {}, test: true, authorization: '12345')
     end
 
-    def cancel(_response_code)
+    # @see Spree::PaymentMethod#try_void
+    def try_void(_payment)
       ActiveMerchant::Billing::Response.new(true, 'Bogus Gateway: Forced success', {}, test: true, authorization: '12345')
     end
 

--- a/core/app/models/spree/payment_method/check.rb
+++ b/core/app/models/spree/payment_method/check.rb
@@ -18,11 +18,10 @@ module Spree
       simulated_successful_billing_response
     end
 
-    def cancel(*); end
-
     def void(*)
       simulated_successful_billing_response
     end
+    alias_method :try_void, :void
 
     def credit(*)
       simulated_successful_billing_response

--- a/core/app/models/spree/payment_method/store_credit.rb
+++ b/core/app/models/spree/payment_method/store_credit.rb
@@ -64,15 +64,16 @@ module Spree
       handle_action(action, :credit, auth_code)
     end
 
-    def cancel(auth_code)
+    # @see Spree::PaymentMethod#try_void
+    def try_void(payment)
+      auth_code = payment.response_code
       store_credit_event = auth_or_capture_event(auth_code)
       store_credit = store_credit_event.try(:store_credit)
 
       if store_credit_event.nil? || store_credit.nil?
         ActiveMerchant::Billing::Response.new(false, '', {}, {})
       elsif store_credit_event.capture_action?
-        amount_in_cents = (store_credit_event.amount * 100).round
-        credit(amount_in_cents, auth_code)
+        false # payment#cancel! handles the refund
       elsif store_credit_event.authorization_action?
         void(auth_code)
       else

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -320,6 +320,17 @@ module Spree
     #   Spree::Wallet::DefaultPaymentBuilder.
     class_name_attribute :default_payment_builder_class, default: 'Spree::Wallet::DefaultPaymentBuilder'
 
+    # Allows providing your own class for canceling payments.
+    #
+    # @!attribute [rw] payment_canceller
+    # @return [Class] a class instance that responds to `cancel!(payment)`
+    attr_writer :payment_canceller
+    def payment_canceller
+      @payment_canceller ||= Spree::Payment::Cancellation.new(
+        reason: Spree::Payment::Cancellation::DEFAULT_REASON
+      )
+    end
+
     # Allows providing your own class for adding payment sources to a user's
     # "wallet" after an order moves to the complete state.
     #

--- a/core/spec/models/spree/payment/cancellation_spec.rb
+++ b/core/spec/models/spree/payment/cancellation_spec.rb
@@ -1,0 +1,81 @@
+require 'spec_helper'
+
+RSpec.describe Spree::Payment::Cancellation do
+  describe '#initialize' do
+    it 'has default refund reason' do
+      expect(subject.reason).to eq Spree::Payment::Cancellation::DEFAULT_REASON
+    end
+
+    context 'with reason given' do
+      subject { described_class.new(reason: 'My custom reason') }
+
+      it 'has this as refund reason' do
+        expect(subject.reason).to eq 'My custom reason'
+      end
+    end
+  end
+
+  describe '#cancel!' do
+    subject { described_class.new.cancel!(payment) }
+
+    let(:payment_method) { create(:payment_method) }
+    let(:payment) { create(:payment, payment_method: payment_method, amount: 10) }
+
+    context 'if the payment_method responds to `try_void`' do
+      context 'if payment method returns void response' do
+        before do
+          expect(payment_method).to receive(:try_void).with(payment) { double }
+        end
+
+        it 'handles the void' do
+          expect(payment).to receive(:handle_void_response)
+          subject
+        end
+      end
+
+      context 'if payment method rejects the void' do
+        before do
+          expect(payment_method).to receive(:try_void).with(payment) { false }
+        end
+
+        it 'refunds the payment' do
+          expect { subject }.to change { payment.refunds.count }.from(0).to(1)
+        end
+
+        context 'if payment has partial refunds' do
+          let(:credit_amount) { payment.amount / 2 }
+
+          before do
+            payment.refunds.create!(
+              amount: credit_amount,
+              reason: Spree::RefundReason.where(name: 'test').first_or_create
+            )
+          end
+
+          it 'only refunds the allowed credit amount' do
+            subject
+            refund = payment.refunds.last
+            expect(refund.amount).to eq(credit_amount)
+          end
+        end
+      end
+    end
+
+    context 'if the payment_method does not respond to `try_void`' do
+      before do
+        allow(payment_method).to receive(:respond_to?) { false }
+        expect(payment_method).to receive(:cancel) { double }
+        expect(payment).to receive(:handle_void_response)
+      end
+
+      it 'calls cancel instead' do
+        Spree::Deprecation.silence { subject }
+      end
+
+      it 'prints depcrecation warning' do
+        expect(Spree::Deprecation).to receive(:warn)
+        subject
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/payment/cancellation_spec.rb
+++ b/core/spec/models/spree/payment/cancellation_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe Spree::Payment::Cancellation do
     end
   end
 
-  describe '#cancel!' do
-    subject { described_class.new.cancel!(payment) }
+  describe '#cancel' do
+    subject { described_class.new.cancel(payment) }
 
     let(:payment_method) { create(:payment_method) }
     let(:payment) { create(:payment, payment_method: payment_method, amount: 10) }

--- a/core/spec/models/spree/payment_method/check_spec.rb
+++ b/core/spec/models/spree/payment_method/check_spec.rb
@@ -53,25 +53,25 @@ describe Spree::PaymentMethod::Check do
   end
 
   context "#capture" do
-    it "succeds" do
+    it "succeeds" do
       expect(subject.capture).to be_success
     end
   end
 
-  context "#cancel" do
-    it "returns nil" do
-      expect(subject.cancel).to be_nil
+  context "#try_void" do
+    it "succeeds" do
+      expect(subject.try_void).to be_success
     end
   end
 
   context "#void" do
-    it "succeds" do
+    it "succeeds" do
       expect(subject.void).to be_success
     end
   end
 
   context "#credit" do
-    it "succeds" do
+    it "succeeds" do
       expect(subject.credit).to be_success
     end
   end

--- a/core/spec/models/spree/payment_method/store_credit_spec.rb
+++ b/core/spec/models/spree/payment_method/store_credit_spec.rb
@@ -246,13 +246,14 @@ describe Spree::PaymentMethod::StoreCredit do
     end
   end
 
-  context "#cancel" do
+  context "#try_void" do
     subject do
-      Spree::PaymentMethod::StoreCredit.new.cancel(auth_code)
+      payment_method.try_void(double(response_code: auth_code))
     end
 
-    let(:store_credit) { create(:store_credit, amount: original_amount, amount_used: captured_amount) }
-    let(:auth_code)    { "1-SC-20141111111111" }
+    let(:payment_method)  { described_class.create!(name: 'Store Credit') }
+    let(:store_credit)    { create(:store_credit, amount: original_amount, amount_used: captured_amount) }
+    let(:auth_code)       { "1-SC-20141111111111" }
     let(:original_amount) { 100.0 }
     let(:captured_amount) { 10.0 }
 
@@ -263,48 +264,59 @@ describe Spree::PaymentMethod::StoreCredit do
     end
 
     context "capture event found" do
-      let!(:store_credit_event) {
+      let!(:store_credit_event) do
         create(:store_credit_capture_event,
-                                        authorization_code: auth_code,
-                                        amount: captured_amount,
-                                        store_credit: store_credit)
-      }
+          authorization_code: auth_code,
+          amount: captured_amount,
+          store_credit: store_credit)
+      end
 
-      it_behaves_like "a spree payment method"
+      it { is_expected.to be(false) }
 
-      it "refunds the capture amount" do
-        expect { subject }.to change{ store_credit.reload.amount_remaining }.
-                              from(original_amount - captured_amount).
-                              to(original_amount)
+      describe "called from payment#cancel!" do
+        subject { payment.cancel! }
+
+        let!(:payment) do
+          create(:payment,
+            order: order,
+            payment_method: payment_method,
+            source: store_credit,
+            amount: captured_amount,
+            response_code: auth_code)
+        end
+
+        it "refunds the capture amount" do
+          expect { subject }.to change { store_credit.reload.amount_remaining }.
+                                from(original_amount - captured_amount).
+                                to(original_amount)
+        end
       end
     end
 
     context "capture event not found" do
       context "auth event found" do
-        let!(:store_credit_event) {
+        let!(:store_credit_event) do
           create(:store_credit_auth_event,
-                                          authorization_code: auth_code,
-                                          amount: captured_amount,
-                                          store_credit: store_credit)
-        }
+            authorization_code: auth_code,
+            amount: captured_amount,
+            store_credit: store_credit)
+        end
 
         it_behaves_like "a spree payment method"
 
-        it "refunds the capture amount" do
-          expect { subject }.to change{ store_credit.reload.amount_remaining }.
+        it "voids the capture amount" do
+          expect { subject }.to change { store_credit.reload.amount_remaining }.
                                 from(original_amount - captured_amount).
                                 to(original_amount)
         end
       end
 
       context "store credit event not found" do
-        subject do
-          Spree::PaymentMethod::StoreCredit.new.cancel('INVALID')
-        end
+        let(:auth_code) { 'INVALID' }
 
         it_behaves_like "a spree payment method"
 
-        it { expect(subject.success?).to be(false) }
+        it { is_expected.to_not be_success }
       end
     end
   end


### PR DESCRIPTION
## The problem

When canceling payments Solidus handles all response as a void response.

That assumption is unfortunate. Lots of payment providers only allow voiding payments if they are not settled yet. Braintree is such a provider. After a transaction has settled you cannot void anymore but have to refund instead.

The `solidus_braintree` and `solidus_paypal_braintree` integrations handle this by checking the status of the transaction first and refund if the transaction cannot be voided anymore. Although this seems correct gateway wise, it is not for Solidus.

For a refunded payment we need to have a `Spree::Refund` object. Handling every response as a void and not as refund - if it should - is wrong and leads to incorrect payment state.

## Solution

A new method `Spree::PaymentMethod#try_void`

`Spree::Payment#cancel!` has changed to tell the payment method to try a void. If that succeeds we handle the response as a void - like we do currently -, but if that fails we create a refund with the full amount and a "Order canceled" reason. `Spree::Refund` already talks with the gateway and credits accordingly.

Fixes #2104 