### PR TITLE
Default to static preferences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 ## Solidus 2.4.0 (master, unreleased)
 
-- Change HTTP Status code for Api::ShipmentsController#transfer_to_* to be always 202 Accepted rather than 201 Created or 500.
+- Change HTTP Status code for `Api::ShipmentsController#transfer_to_*` to be always 202 Accepted rather than 201 Created or 500.
   Speed up changing fulfilment for parts of a shipment [\#2070](https://github.com/solidusio/solidus/pull/2070) ([mamhoff](https://github.com/mamhoff))
 
 - Customized responders have been removed. They are available in the `solidus_responders` extension
 
+- The all configuration objects now use static preferences by default. It's no longer necessary to call `use_static_preferences!`, as that is the new default. For the old behaviour of loading preferences from the DB, call `config.use_legacy_db_preferences!`. [\#2112](https://github.com/solidusio/solidus/pull/2112) ([jhawthorn](https://github.com/jhawthorn))
 
 ## Solidus 2.3.0 (unreleased)
 

--- a/core/app/models/spree/preferences/configuration.rb
+++ b/core/app/models/spree/preferences/configuration.rb
@@ -31,10 +31,10 @@ module Spree::Preferences
     end
 
     # @!attribute preference_store
-    # Storage method for preferences. Default is {ScopedStore}
+    # Storage method for preferences.
     attr_writer :preference_store
     def preference_store
-      @preference_store ||= ScopedStore.new(self.class.name.underscore)
+      @preference_store ||= default_preferences
     end
 
     # Replace the default legacy preference store, which stores preferences in
@@ -48,6 +48,12 @@ module Spree::Preferences
     # initializer.
     def use_static_preferences!
       @preference_store = default_preferences
+    end
+
+    # Replace the new static preference store with the legacy store which
+    # fetches preferences from the DB.
+    def use_legacy_db_preferences!
+      @preference_store = ScopedStore.new(self.class.name.underscore)
     end
 
     alias_method :preferences, :preference_store

--- a/core/lib/generators/spree/install/templates/config/initializers/spree.rb
+++ b/core/lib/generators/spree/install/templates/config/initializers/spree.rb
@@ -2,12 +2,6 @@
 # See http://docs.solidus.io/Spree/AppConfiguration.html for details
 
 Spree.config do |config|
-  # Without this preferences are loaded and persisted to the database. This
-  # changes them to be stored in memory.
-  # This will be the default in a future version.
-  # This line resets all preferences! It should be the first line in the block
-  config.use_static_preferences!
-
   # Core:
 
   # Default currency for new sites
@@ -54,24 +48,18 @@ end
 
 <% if defined?(Spree::Frontend::Engine) -%>
 Spree::Frontend::Config.configure do |config|
-  config.use_static_preferences!
-
   config.locale = 'en'
 end
 <% end -%>
 
 <% if defined?(Spree::Backend::Engine) -%>
 Spree::Backend::Config.configure do |config|
-  config.use_static_preferences!
-
   config.locale = 'en'
 end
 <% end -%>
 
 <% if defined?(Spree::Api::Engine) -%>
 Spree::Api::Config.configure do |config|
-  config.use_static_preferences!
-
   config.requires_authentication = true
 end
 <% end -%>


### PR DESCRIPTION
We've included static preferences for a while, and they've been default for new stores, but required a call to `use_static_preferences!`

This commit makes the static preferences store the default with no additional configuration. It also adds a way for stores to opt-in to the legacy DB-driven behaviour.

If accepted this should have a prominent changelog entry.