### PR TITLE
Remove hacked support for kaminari page name

### DIFF
--- a/core/app/models/spree/base.rb
+++ b/core/app/models/spree/base.rb
@@ -23,6 +23,10 @@ class Spree::Base < ActiveRecord::Base
 
   if Kaminari.config.page_method_name != :page
     def self.page(num)
+      Spree::Deprecation.warn \
+        "Redefining Spree::Base.page for a different kaminari page name is better done inside " \
+        "your own app. This will be removed from future versions of solidus."
+
       send Kaminari.config.page_method_name, num
     end
   end


### PR DESCRIPTION
Historically this looks like it is to support kaminari and will_paginate
side-by-side, which doesn't seem like a reasonable thing for us to care
about inside of core.

Anyone that wanted this functionality can use it inside their own app.

Also it wasn't tested.

Came from: spree/spree#5035