### PR TITLE
Preload assets before backend specs

### DIFF
--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -72,6 +72,15 @@ RSpec.configure do |config|
     DatabaseCleaner.clean_with :truncation
   end
 
+  config.when_first_matching_example_defined(type: :feature) do
+    config.before :suite do
+      # Preload assets
+      # This should avoid capybara timeouts, and avoid counting asset compilation
+      # towards the timing of the first feature spec.
+      Rails.application.precompiled_assets
+    end
+  end
+
   config.prepend_before(:each) do
     if RSpec.current_example.metadata[:js]
       DatabaseCleaner.strategy = :truncation


### PR DESCRIPTION
We've been seeing some builds fail with "Request failed to reach server" on the first request.

This happens because we have quite a few assets and it can take some time to compile them. Since this was done on the first request, this sometimes caused poltergeist to error.

This commit gets sprockets-rails to preload the assets before the suite is run (if there is a feature spec included in the run).

This has the added advantage of not including the time to precompile specs as part of the first spec's run time. Running `rspec --profile=10` should now be more useful in showing actually slow specs.

Alternative to #2116