### PR TITLE
Deprecate pagination in searcher

### DIFF
--- a/api/solidus_api.gemspec
+++ b/api/solidus_api.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'rabl', '0.13.0' # FIXME: update for proper rails 5 support
   gem.add_dependency 'versioncake', '~> 3.0'
   gem.add_dependency 'responders'
+  gem.add_dependency 'kaminari', '>= 0.17', '< 2.0'
 end

--- a/backend/solidus_backend.gemspec
+++ b/backend/solidus_backend.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'jquery-rails'
   s.add_dependency 'jquery-ui-rails', '~> 5.0.0'
   s.add_dependency 'font-awesome-rails', '~> 4.0'
+  s.add_dependency 'kaminari', '>= 0.17', '< 2.0'
 
   s.add_dependency 'handlebars_assets', '~> 0.23'
 end

--- a/core/lib/spree/core/search/base.rb
+++ b/core/lib/spree/core/search/base.rb
@@ -27,12 +27,15 @@ module Spree
 
         def retrieve_products
           @products = get_base_scope
-          curr_page = page || 1
 
           unless Spree::Config.show_products_without_price
             @products = @products.joins(:prices).merge(Spree::Price.where(pricing_options.search_arguments)).distinct
           end
-          @products = @products.page(curr_page).per(per_page)
+          if @properties[:page]
+            curr_page = @properties[:page] || 1
+            @products = @products.page(curr_page).per(@properties[:per_page])
+          end
+          @products
         end
 
         def method_missing(name)
@@ -101,9 +104,14 @@ module Spree
           @properties[:search] = params[:search]
           @properties[:include_images] = params[:include_images]
 
-          per_page = params[:per_page].to_i
-          @properties[:per_page] = per_page > 0 ? per_page : Spree::Config[:products_per_page]
-          @properties[:page] = (params[:page].to_i <= 0) ? 1 : params[:page].to_i
+          if params[:per_page].present? || params[:page].present?
+            Spree::Deprecation.warn "Pagination inside the searcher is no longer supported." \
+              "Please paginate the results of the searcher yourself."
+
+            per_page = params[:per_page].to_i
+            @properties[:per_page] = per_page > 0 ? per_page : Spree::Config[:products_per_page]
+            @properties[:page] = (params[:page].to_i <= 0) ? 1 : params[:page].to_i
+          end
         end
       end
     end

--- a/core/spec/lib/search/base_spec.rb
+++ b/core/spec/lib/search/base_spec.rb
@@ -35,13 +35,15 @@ describe Spree::Core::Search::Base do
   it "switches to next page according to the page parameter" do
     @product3 = create(:product, name: "RoR Pants", price: 14.00)
 
-    params = { per_page: "2" }
-    searcher = Spree::Core::Search::Base.new(params)
-    expect(searcher.retrieve_products.count).to eq(2)
+    Spree::Deprecation.silence do
+      params = { per_page: "2" }
+      searcher = Spree::Core::Search::Base.new(params)
+      expect(searcher.retrieve_products.count).to eq(2)
 
-    params[:page] = "2"
-    searcher = Spree::Core::Search::Base.new(params)
-    expect(searcher.retrieve_products.count).to eq(1)
+      params[:page] = "2"
+      searcher = Spree::Core::Search::Base.new(params)
+      expect(searcher.retrieve_products.count).to eq(1)
+    end
   end
 
   it "maps search params to named scopes" do

--- a/frontend/app/controllers/spree/products_controller.rb
+++ b/frontend/app/controllers/spree/products_controller.rb
@@ -9,8 +9,8 @@ module Spree
     respond_to :html
 
     def index
-      @searcher = build_searcher(params.merge(include_images: true))
-      @products = @searcher.retrieve_products
+      @searcher = build_searcher(params.merge(include_images: true).reject { |k, _| ["per_page", "page"].include?(k) } )
+      @products = @searcher.retrieve_products.page(params[:page] || 1).per(params[:per_page].presence || Spree::Config[:products_per_page])
       @taxonomies = Spree::Taxonomy.includes(root: :children)
     end
 

--- a/frontend/app/controllers/spree/taxons_controller.rb
+++ b/frontend/app/controllers/spree/taxons_controller.rb
@@ -9,8 +9,8 @@ module Spree
       @taxon = Spree::Taxon.find_by!(permalink: params[:id])
       return unless @taxon
 
-      @searcher = build_searcher(params.merge(taxon: @taxon.id, include_images: true))
-      @products = @searcher.retrieve_products
+      @searcher = build_searcher(params.merge(taxon: @taxon.id, include_images: true).reject { |k, _| ["per_page", "page"].include?(k) } )
+      @products = @searcher.retrieve_products.page(params[:page] || 1).per(params[:per_page].presence || Spree::Config[:products_per_page])
       @taxonomies = Spree::Taxonomy.includes(root: :children)
     end
 

--- a/frontend/solidus_frontend.gemspec
+++ b/frontend/solidus_frontend.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'coffee-rails'
   s.add_dependency 'font-awesome-rails', '~> 4.0'
   s.add_dependency 'truncate_html', '~> 0.9', '>= 0.9.2'
+  s.add_dependency 'kaminari', '>= 0.17', '< 2.0'
 
   s.add_development_dependency 'capybara-accessible'
 end


### PR DESCRIPTION
This deprecates doing pagination in the base searcher and instead pushes the responsibility onto the caller (in our cases the controllers).

We don't gain anything from doing the pagination inside the searcher, and it doesn't have anything to do with the core goal of it (searching).

Also throws the explicit dependencies on kaminari on frontend and backend (as they call kaminari functions).