### PR TITLE
Checkout email input field should use email_field

### DIFF
--- a/frontend/app/views/spree/checkout/edit.html.erb
+++ b/frontend/app/views/spree/checkout/edit.html.erb
@@ -12,7 +12,7 @@
         <% if @order.state == 'address' || !@order.email? %>
           <p class="field" style='clear: both'>
             <%= form.label :email %><br />
-            <%= form.text_field :email %>
+            <%= form.email_field :email %>
           </p>
         <% end %>
         <%= render @order.state, form: form %>


### PR DESCRIPTION
 - on frontend checkout/edit
 - mobile users will have a virtual keyboard that now includes
   an @ symbol.
 - fallback for none HTML 5 browsers is to text type