### PR TITLE
Remove unnecessary Api::Engine.root override

### DIFF
--- a/api/lib/spree/api/engine.rb
+++ b/api/lib/spree/api/engine.rb
@@ -29,10 +29,6 @@ module Spree
           config.extraction_strategy = :http_header
         end
       end
-
-      def self.root
-        @root ||= Pathname.new(File.expand_path('../../../../', __FILE__))
-      end
     end
   end
 end


### PR DESCRIPTION
Spree::Api::Engine.root returns the correct path without this.