### PR TITLE
Include completed payment amounts when summing totals for store credit

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -657,7 +657,7 @@ module Spree
 
       payments.reset
 
-      if payments.where(state: %w(checkout pending)).sum(:amount) != total
+      if payments.where(state: %w(checkout pending completed)).sum(:amount) != total
         errors.add(:base, Spree.t("store_credit.errors.unable_to_fund")) && (return false)
       end
     end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -1222,7 +1222,7 @@ describe Spree::Order, type: :model do
         context "there is a completed credit card payment" do
           let!(:cc_payment) { create(:payment, order: order, state: "completed", amount: 100) }
 
-          it "successfully creates the store credit payments", skip: "Failing example for payment bug" do
+          it "successfully creates the store credit payments" do
             expect { subject }.to change { order.payments.count }.from(1).to(2)
             expect(order.errors).to be_empty
           end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -1219,6 +1219,15 @@ describe Spree::Order, type: :model do
           end
         end
 
+        context "there is a completed credit card payment" do
+          let!(:cc_payment) { create(:payment, order: order, state: "completed", amount: 100) }
+
+          it "successfully creates the store credit payments", skip: "Failing example for payment bug" do
+            expect { subject }.to change { order.payments.count }.from(1).to(2)
+            expect(order.errors).to be_empty
+          end
+        end
+
         context "there is a credit card payment" do
           let!(:cc_payment) { create(:payment, order: order, state: "checkout") }
 


### PR DESCRIPTION
Some payment methods that redirect to a third-party site don't have the concept of "capturing" a payment. It is expected that after the user completes their checkout flow, the payment is completed. For these types of payments, we'd prefer to complete them as soon as we return to our Solidus site, since the provider considers them complete.

One example is PayBright as implemented in the `solidus_paybright` extension. When the user gets redirected back from PayBright, the payment is updated, and the order advanced to complete:
https://github.com/StemboltHQ/solidus_paybright/blob/master/app/controllers/spree/paybright_controller.rb#L39-L62

For this case, when we call `Spree::Order#add_store_credit_payments`, the store credits will be created successfully, but there is a check at the end that sums the payment amount of all `checkout` or `pending`
payments and adds an error if it doesn't match the order total:
https://github.com/solidusio/solidus/blob/master/core/app/models/spree/order.rb#L660-L662

Since our payment is `completed`, it doesn't get included and the totals don't match, which incorrectly raises an error. I couldn't think of a reason not to include completed payments here, but would appreciate if anyone can think of one.

I've worked with other payment methods with similar behaviour, such as SOFORT as implemented in [solidus-adyen](https://github.com/StemboltHQ/solidus-adyen). The workaround for this same issue there was to implement `Spree::PaymentMethod#authorize` to return a dummy `ActiveMerchant::BillingResponse`:
https://github.com/StemboltHQ/solidus-adyen/blob/master/app/models/spree/gateway/adyen_hpp.rb#L27-L33
The problem with this approach is that it's possible to end up with payments that are authorized in Solidus, but the provider already considers completed.