### PR TITLE
Ensure validation error is returned when creating a refund without a …

### DIFF
--- a/core/app/models/spree/refund.rb
+++ b/core/app/models/spree/refund.rb
@@ -76,7 +76,7 @@ module Spree
     end
 
     def amount_is_less_than_or_equal_to_allowed_amount
-      if amount > payment.credit_allowed
+      if payment && amount > payment.credit_allowed
         errors.add(:amount, :greater_than_allowed)
       end
     end

--- a/core/spec/models/spree/refund_spec.rb
+++ b/core/spec/models/spree/refund_spec.rb
@@ -160,6 +160,14 @@ describe Spree::Refund, type: :model do
         }
       end
     end
+
+    context 'when payment is not present' do
+      let(:refund) { build(:refund, payment: nil) }
+
+      it 'returns a validation error' do
+        expect { refund.save! }.to raise_error 'Validation failed: Payment can\'t be blank'
+      end
+    end
   end
 
   describe 'total_amount_reimbursed_for' do


### PR DESCRIPTION
…payment

Without this change, when a refund is saved with no payment it raises: 
```NoMethodError: undefined method `credit_allowed' for nil:NilClass``` 
from: 
```app/models/spree/refund.rb:77:in `amount_is_less_than_or_equal_to_allowed_amount'```