### PR TITLE
Exclude canceled orders from sales report

### DIFF
--- a/backend/app/controllers/spree/admin/reports_controller.rb
+++ b/backend/app/controllers/spree/admin/reports_controller.rb
@@ -28,7 +28,7 @@ module Spree
       def sales_total
         params[:q] = search_params
 
-        @search = Order.complete.ransack(params[:q])
+        @search = Order.complete.not_canceled.ransack(params[:q])
         @orders = @search.result
 
         @totals = {}

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -175,6 +175,14 @@ module Spree
       where(completed_at: nil)
     end
 
+    def self.canceled
+      where(state: 'canceled')
+    end
+
+    def self.not_canceled
+      where.not(state: 'canceled')
+    end
+
     # Use this method in other gems that wish to register their own custom logic
     # that should be called after Order#update
     def self.register_update_hook(hook)

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -61,6 +61,14 @@ RSpec.describe Spree::Order, type: :model do
         expect{ subject }.to change{ order.can_cancel? }.from(true).to(false)
         expect(order).to be_canceled
       end
+
+      it "places the order into the canceled scope" do
+        expect{ subject }.to change{ Spree::Order.canceled.include?(order) }.from(false).to(true)
+      end
+
+      it "removes the order from the not_canceled scope" do
+        expect{ subject }.to change{ Spree::Order.not_canceled.include?(order) }.from(true).to(false)
+      end
     end
 
     context "with fully refunded payment" do


### PR DESCRIPTION
As I mentioned in issue #2099, by default the Sales Total report does not exclude canceled orders from the sales totals. This is the "minimum viable PR" to fix that issue.

I’m open to further discussion from the Solidus community around the following:

1. Should we make proper `canceled` and `not_canceled` scopes for the `Order` model, to go along with frequently used scopes like `complete`?

2. Should the `complete` scope by _default_ exclude canceled orders unless explicitly called for `complete_including_canceled`, the way that `Product#variants` by default excludes the master variant unless and we specify `variants_including_master`, or how various scopes exclude deleted objects unless we use `with_deleted` scopes?

If "yes" to either (1) or (2), chime in on this thread and I’m happy to whip up another easy PR.