### PR TITLE
[RFC] Replace RABL with Jbuilder

### DIFF
--- a/api/app/views/spree/api/orders/_order.json.jbuilder
+++ b/api/app/views/spree/api/orders/_order.json.jbuilder
@@ -1,0 +1,10 @@
+json.cache! [I18n.locale, order] do
+  json.(order, *order_attributes)
+  json.total_quantity order.line_items.sum(:quantity)
+  json.display_total order.display_total.to_s
+  json.display_item_total order.display_item_total.to_s
+  json.display_ship_total order.display_ship_total
+  json.display_tax_total order.display_tax_total
+  json.token order.guest_token
+  json.checkout_steps order.checkout_steps
+end

--- a/api/app/views/spree/api/orders/index.json.jbuilder
+++ b/api/app/views/spree/api/orders/index.json.jbuilder
@@ -1,0 +1,8 @@
+
+json.orders(@orders) do |order|
+  json.partial!("spree/api/orders/order", order: order)
+end
+
+json.count @orders.count
+json.current_page @orders.current_page
+json.pages @orders.total_pages

--- a/api/app/views/spree/api/orders/index.v1.rabl
+++ b/api/app/views/spree/api/orders/index.v1.rabl
@@ -1,7 +1,0 @@
-object false
-child(@orders => :orders) do
-  extends "spree/api/orders/order"
-end
-node(:count) { @orders.count }
-node(:current_page) { @orders.current_page }
-node(:pages) { @orders.total_pages }

--- a/api/lib/spree_api.rb
+++ b/api/lib/spree_api.rb
@@ -1,3 +1,4 @@
 require 'spree/api'
 require 'spree/api/responders'
 require 'versioncake'
+require 'jbuilder'

--- a/api/solidus_api.gemspec
+++ b/api/solidus_api.gemspec
@@ -24,5 +24,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'rabl', '0.13.1'
   gem.add_dependency 'versioncake', '~> 3.0'
   gem.add_dependency 'responders'
+  gem.add_dependency 'jbuilder', '~> 2.6'
   gem.add_dependency 'kaminari', '>= 0.17', '< 2.0'
 end


### PR DESCRIPTION
I think we've held off making significant changes to the current API with the idea that we would have a complete replacement soon. Since it hasn't happened, and it's not actively being worked on, we should do what we can to improve the existing API.

I propose solving the most frequent complaint about working on our current API: the use of RABL as our templating language.

### Rabl

I think rabl is a little unintuitive. I've been using it for almost 5 years and still have difficulty. There's a lot of methods to remember (`child`/`node`/`glue`/`attributes`/...) and the correct usage can be tricky (which is the key vs value when calling `child` with a hash).

rabl has also fallen out of fashion in the rails community. `spree_api` and `solidus_api` are the largest actively developed gems to require rabl. This is probably in part because the default rails Gemfile ships with `jbuilder`

### Jbuilder

I think we should replace RABL with Jbuilder in `solidus_api`. It's by far the most popular JSON templating gem, since it ships with rails by default. So it's the most likely for developers to have prior experience with.

`active_model_serializers` should also be considered here, and would certainly be a likely favourite if we were rewriting the API. However it is significantly different from rabl - you declare the data and relationships your models have, rather than the structure of the output JSON - making an API-compatible change unlikely. The [Status of AMS](https://github.com/rails-api/active_model_serializers/tree/954cc174fcd04714a4ec7371ef35e335bfa39412#status-of-ams) from the README is also a little precarious.

A big advantage of going from RABL to Jbuilder is that they are 1:1, unlike AMS. They both explicitly declare the structure of the output JSON. This should allow us to rewrite all views fairly easily, and have them emit exactly the same JSON.

The most substantial difference between RABL and Jbuilder, is that RABL holds an implicit "current object" to store the data which is being rendered (used by `attributes`, `child`, etc). Jbuilder needs to be more explicit (like a standard erb view) and refer explicitly to a local or instance variable.

### Compatibility

This change would be 100% API compatible. The same request would have exactly the same JSON response.

The only compatibility concern would be stores which have overridden rabl templates (ex. to add additional data). These stores would have to rewrite their modifications. Further investigation required to see if there is some way to ease this upgrade path.

# Example
## Before

``` ruby
cache [I18n.locale, root_object]
attributes *order_attributes
node(:display_item_total) { |o| o.display_item_total.to_s }
node(:total_quantity) { |o| o.line_items.sum(:quantity) }
node(:display_total) { |o| o.display_total.to_s }
node(:display_ship_total) { |o| o.display_ship_total }
node(:display_tax_total) { |o| o.display_tax_total }
node(:token) { |o| o.guest_token }
node(:checkout_steps) { |o| o.checkout_steps }
```

## After

``` ruby
json.cache! [I18n.locale, order] do
  json.(order, *order_attributes)
  json.total_quantity order.line_items.sum(:quantity)
  json.display_total order.display_total.to_s
  json.display_item_total order.display_item_total.to_s
  json.display_ship_total order.display_ship_total
  json.display_tax_total order.display_tax_total
  json.token order.guest_token
  json.checkout_steps order.checkout_steps
end
```