### PR TITLE
Fix error when passing coupon_code to api/checkouts#update

### DIFF
--- a/api/app/controllers/spree/api/checkouts_controller.rb
+++ b/api/app/controllers/spree/api/checkouts_controller.rb
@@ -115,7 +115,8 @@ module Spree
 
       def after_update_attributes
         if params[:order] && params[:order][:coupon_code].present?
-          handler = PromotionHandler::Coupon.new(@order).apply
+          handler = PromotionHandler::Coupon.new(@order)
+          handler.apply
 
           if handler.error.present?
             @coupon_message = handler.error

--- a/api/app/controllers/spree/api/checkouts_controller.rb
+++ b/api/app/controllers/spree/api/checkouts_controller.rb
@@ -120,7 +120,7 @@ module Spree
 
           if handler.error.present?
             @coupon_message = handler.error
-            respond_with(@order, default_template: 'spree/api/orders/could_not_apply_coupon')
+            respond_with(@order, default_template: 'spree/api/orders/could_not_apply_coupon', status: 422)
             return true
           end
         end

--- a/api/spec/requests/spree/api/checkouts_controller_spec.rb
+++ b/api/spec/requests/spree/api/checkouts_controller_spec.rb
@@ -349,6 +349,7 @@ module Spree
         expect(PromotionHandler::Coupon).to receive(:new).with(order).and_call_original
         expect_any_instance_of(PromotionHandler::Coupon).to receive(:apply).and_return({ coupon_applied?: true })
         put spree.api_checkout_path(order.to_param), params: { order_token: order.guest_token, order: { coupon_code: "foobar" } }
+        expect(response.status).to eq(200)
       end
     end
 

--- a/api/spec/requests/spree/api/checkouts_controller_spec.rb
+++ b/api/spec/requests/spree/api/checkouts_controller_spec.rb
@@ -351,6 +351,13 @@ module Spree
         put spree.api_checkout_path(order.to_param), params: { order_token: order.guest_token, order: { coupon_code: "foobar" } }
         expect(response.status).to eq(200)
       end
+
+      it "renders error failing to apply coupon" do
+        order.update_column(:state, "payment")
+        put spree.api_checkout_path(order.to_param), params: { order_token: order.guest_token, order: { coupon_code: "foobar" } }
+        expect(response.status).to eq(422)
+        expect(json_response).to eq({ "error" => "The coupon code you entered doesn't exist. Please try again." })
+      end
     end
 
     context "PUT 'next'" do


### PR DESCRIPTION
Previously, when given a `coupon_code`, this action would always error. `handler` wasn't the `PromotionHandler`, but the return value of `apply` (a hash). This has been the case since Spree 2.2.

The error wasn't noticed in specs because of the [rescue_from in BaseController](https://github.com/solidusio/solidus/blob/master/api/app/controllers/spree/api/base_controller.rb#L26), which I am working on removing.

This also makes the return status of a _real_ coupon application error (which previously was inaccessible) 422.