### PR TITLE
Quick Switch

### DIFF
--- a/backend/app/assets/javascripts/spree/backend.js
+++ b/backend/app/assets/javascripts/spree/backend.js
@@ -33,6 +33,7 @@
 //= require spree/backend/components/tabs
 //= require spree/backend/components/tooltips
 //= require spree/backend/components/editable_table
+//= require spree/backend/components/shortcuts
 //= require spree/backend/flash
 //= require spree/backend/gateway
 //= require spree/backend/handlebars_extensions

--- a/backend/app/assets/javascripts/spree/backend/components/shortcuts.js
+++ b/backend/app/assets/javascripts/spree/backend/components/shortcuts.js
@@ -1,0 +1,19 @@
+$(function() {
+  var quickSwitch = new Spree.Views.QuickSwitch({
+    el: $("[data-js='quick-switch']")
+  });
+
+  var onKeypress = function(e) {
+    if(
+      e.target.tagName === "INPUT" ||
+      e.target.tagName === "SELECT" ||
+      e.target.tagName === "TEXTAREA"
+    ) {
+      return
+    } else if(e.key === "@") {
+      quickSwitch.triggerShortcut()
+    }
+  };
+
+  $(document.body).on("keypress", onKeypress);
+});

--- a/backend/app/assets/javascripts/spree/backend/views/index.js
+++ b/backend/app/assets/javascripts/spree/backend/views/index.js
@@ -18,3 +18,4 @@
 //= require 'spree/backend/views/payment/edit_credit_card'
 //= require 'spree/backend/views/tables/editable_table'
 //= require 'spree/backend/views/tables/editable_table_row'
+//= require 'spree/backend/views/quick_switch'

--- a/backend/app/assets/javascripts/spree/backend/views/quick_switch.js
+++ b/backend/app/assets/javascripts/spree/backend/views/quick_switch.js
@@ -1,0 +1,71 @@
+Spree.Views.QuickSwitch = Backbone.View.extend({
+  events: {
+    "shown.bs.modal": "onShow",
+    "hidden.bs.modal": "onHide",
+    "submit form": "onSubmit"
+  },
+
+  initialize: function() {
+    this.$el = $(this.el);
+    this.$dialog = $("[data-js='quick-switch-dialog']", this.$el);
+    this.$form = $("form", this.$el);
+    this.$input = $("[data-js='quick-switch-input']", this.$el);
+    this.$tooltip = $("[data-js='quick-switch-tooltip']", this.$el);
+		this.render();
+  },
+
+  triggerShortcut: function() {
+    this.onShortcut();
+  },
+
+  onShortcut: function() {
+    this.$el.modal("toggle");
+  },
+
+  onShow: function() {
+    this.$input.focus();
+  },
+
+  onHide: function() {
+    this.$input.val("");
+    $(".alert", this.$dialog).remove();
+  },
+
+  onSubmit: function(e) {
+    e.preventDefault();
+    this.toggleSearchClass();
+    this.sendQuery();
+  },
+
+  toggleSearchClass: function() {
+    this.$form.toggleClass("searching");
+  },
+
+  sendQuery: function() {
+    var view = this;
+    Spree.ajax({
+      dataType: "json",
+      url: this.$form.attr("action"),
+      type: "GET",
+      data: this.$form.serializeArray(),
+      global: false, // disable the backend's default loading messaging
+      success: function(response) {
+        if(response.redirect_url) {
+          window.location = response.redirect_url;
+        }
+      },
+      error: function(response) {
+        var message = JSON.parse(response.responseText).message;
+        view.toggleSearchClass();
+        if($(".alert", view.$el).length) {
+          $(".alert", view.$el).text(message);
+        } else {
+          view.$dialog.append("<div class='alert alert-warning'>" + message + "</div>");
+        }
+      }
+    });
+  },
+
+  render: function() {
+  }
+});

--- a/backend/app/assets/stylesheets/spree/backend/_bootstrap_custom.scss
+++ b/backend/app/assets/stylesheets/spree/backend/_bootstrap_custom.scss
@@ -67,6 +67,7 @@ $border-radius:          3px !default;
 $input-color:                    $color-3 !default;
 $input-border-color:             $color-border !default;
 $input-focus-border-color:       $color-2 !default;
+$input-placeholder-color:        #aaa !default;
 
 $custom-select-focus-border-color: $input-focus-border-color !default;
 

--- a/backend/app/assets/stylesheets/spree/backend/components/_quick-switch.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_quick-switch.scss
@@ -1,0 +1,56 @@
+.quick-switch-form {
+  position: relative;
+  display: flex;
+}
+
+.quick-switch-query-input {
+  flex: 1;
+}
+
+.quick-switch-button,
+.quick-switch-spinner {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+}
+
+.quick-switch-spinner {
+  position: absolute;
+  top: 50%;
+  right: 8px;
+  width: 20px;
+  height: 20px;
+  margin-top: -10px;
+  border-width: 2px;
+  border-left-color: $color-3;
+  background: $color-1;
+
+  .quick-switch-form:not(.searching) & {
+    display: none;
+  }
+}
+
+.quick-switch-help {
+  font-size: 0.8rem;
+}
+
+.quick-switch-help button {
+  padding-left: 0;
+  box-shadow: none;
+  font-size: inherit;
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.quick-switch-help ul {
+  margin: 0.5rem 0 0;
+  padding-left: 2rem;
+}
+
+.quick-switch-dialog .alert {
+  margin-top: 1rem;
+}

--- a/backend/app/assets/stylesheets/spree/backend/spree_admin.scss
+++ b/backend/app/assets/stylesheets/spree/backend/spree_admin.scss
@@ -36,6 +36,7 @@
 @import 'spree/backend/components/editable_table';
 @import 'spree/backend/components/pills';
 @import 'spree/backend/components/tabs';
+@import 'spree/backend/components/quick-switch';
 
 @import 'font-awesome';
 @import 'spree/backend/plugins/select2';

--- a/backend/app/controllers/spree/admin/quick_switch_controller.rb
+++ b/backend/app/controllers/spree/admin/quick_switch_controller.rb
@@ -1,0 +1,48 @@
+module Spree
+  module Admin
+    class QuickSwitchController < Spree::Admin::BaseController
+      layout false
+
+      def find_object
+        quick_switch_item = Spree::Backend::Config.quick_switch_items.detect do |item|
+          item.search_triggers.include? searched_key.to_sym
+        end
+
+        if quick_switch_item
+          if object = quick_switch_item.finder.call(searched_value)
+            render(
+              json: {
+                redirect_url: quick_switch_item.url.call(object)
+              },
+              status: :ok
+            )
+          else
+            render(
+              json: {
+                message: quick_switch_item.not_found_text(searched_value)
+              },
+              status: :not_found
+            )
+          end
+        else
+          render(
+            json: {
+              message: I18n.t("invalid_query", scope: "spree.quick_switch")
+            },
+            status: :bad_request
+          )
+        end
+      end
+
+      private
+
+      def searched_key
+        params[:quick_switch_query].split(" ")[0]
+      end
+
+      def searched_value
+        params[:quick_switch_query].split(" ")[1]
+      end
+    end
+  end
+end

--- a/backend/app/models/spree/backend_configuration.rb
+++ b/backend/app/models/spree/backend_configuration.rb
@@ -84,5 +84,85 @@ module Spree
         )
       ]
     end
+
+    # New quick switch items can be added to the admin:
+    #
+    # Spree::Backend::Config.configure do |config|
+    #   config.quick_switch_items << config.class::QuickSwitchItem.new(
+    #     search_triggers: [:o, :order],
+    #     finder: ->(searched_value) do
+    #       Spree::Order.find_by(number: searched_value)
+    #     end,
+    #     url: ->(order) do
+    #       Spree::Core::Engine.routes.url_helpers.edit_admin_order_path(order)
+    #     end,
+    #     help_text_key: :order_help,
+    #     not_found_text_key: :order_not_found
+    #   )
+    # end
+    #
+    # @!attribute quick_switch_items
+    #   @return [Array<Spree::QuickSwitchItem>]
+    attr_writer :quick_switch_items
+
+    # Return the quick switch items that administrators can search by
+    #
+    # @api public
+    # @return [Array<Spree::QuickSwitchItem>]
+    def quick_switch_items
+      @quick_switch_items ||= [
+        Spree::QuickSwitchItem.new(
+          search_triggers: [:o, :order],
+          finder: ->(searched_value) do
+            Spree::Order.find_by(number: searched_value)
+          end,
+          url: ->(order) do
+            Spree::Core::Engine.routes.url_helpers.edit_admin_order_path(order)
+          end,
+          help_text_key: :order_help,
+          not_found_text_key: :order_not_found
+        ),
+        Spree::QuickSwitchItem.new(
+          search_triggers: [:s, :shipment],
+          finder: ->(searched_value) do
+            Spree::Shipment.find_by(number: searched_value)
+          end,
+          url: ->(shipment) do
+            Spree::Core::Engine.routes.url_helpers.
+              edit_admin_order_path(shipment.order)
+          end,
+          help_text_key: :shipment_help,
+          not_found_text_key: :shipment_not_found
+        ),
+        Spree::QuickSwitchItem.new(
+          search_triggers: [:email, :u, :user],
+          finder: ->(searched_value) do
+            Spree.user_class.find_by(email: searched_value)
+          end,
+          url: ->(user) do
+            Spree::Core::Engine.routes.url_helpers.edit_admin_user_path(user)
+          end,
+          help_text_key: :user_help,
+          not_found_text_key: :user_not_found
+        ),
+        Spree::QuickSwitchItem.new(
+          search_triggers: [:p, :product, :sku, :v, :variant],
+          finder: ->(searched_value) do
+            Spree::Variant.find_by(sku: searched_value)
+          end,
+          url: ->(variant) do
+            if variant.is_master?
+              Spree::Core::Engine.routes.url_helpers.
+                edit_admin_product_path(variant.product)
+            else
+              Spree::Core::Engine.routes.url_helpers.
+                edit_admin_product_variant_path(variant.product, variant)
+            end
+          end,
+          help_text_key: :variant_help,
+          not_found_text_key: :variant_not_found
+        )
+      ]
+    end
   end
 end

--- a/backend/app/models/spree/backend_configuration.rb
+++ b/backend/app/models/spree/backend_configuration.rb
@@ -18,39 +18,6 @@ module Spree
     STOCK_TABS         ||= [:stock_items]
     USER_TABS          ||= [:users, :store_credits]
 
-    # An item which should be drawn in the admin menu
-    class MenuItem
-      attr_reader :icon, :label, :partial, :condition, :sections, :url
-
-      # @param sections [Array<Symbol>] The sections which are contained within
-      #   this admin menu section.
-      # @param icon [String] The icon to draw for this menu item
-      # @param condition [Proc] A proc which returns true if this menu item
-      #   should be drawn. If nil, it will be replaced with a proc which always
-      #   returns true.
-      # @param label [Symbol] The translation key for a label to use for this
-      #   menu item.
-      # @param partial [String] A partial to draw within this menu item for use
-      #   in declaring a submenu
-      # @param url [String] A url where this link should send the user to
-      def initialize(
-        sections,
-        icon,
-        condition: nil,
-        label: nil,
-        partial: nil,
-        url: nil
-      )
-
-        @condition = condition || -> { true }
-        @sections = sections
-        @icon = icon
-        @label = label || sections.first
-        @partial = partial
-        @url = url
-      end
-    end
-
     # Items can be added to the menu by using code like the following:
     #
     # Spree::Backend::Config.configure do |config|
@@ -62,32 +29,32 @@ module Spree
     # end
     #
     # @!attribute menu_items
-    #   @return [Array<Spree::BackendConfiguration::MenuItem>]
+    #   @return [Array<Spree::MenuItem>]
     attr_writer :menu_items
 
     # Return the menu items which should be drawn in the menu
     #
     # @api public
-    # @return [Array<Spree::BackendConfiguration::MenuItem>]
+    # @return [Array<Spree::MenuItem>]
     def menu_items
       @menu_items ||= [
-        MenuItem.new(
+        Spree::MenuItem.new(
           ORDER_TABS,
           'shopping-cart',
           condition: -> { can?(:admin, Spree::Order) },
         ),
-        MenuItem.new(
+        Spree::MenuItem.new(
           PRODUCT_TABS,
           'th-large',
           condition: -> { can?(:admin, Spree::Product) },
           partial: 'spree/admin/shared/product_sub_menu'
         ),
-        MenuItem.new(
+        Spree::MenuItem.new(
           REPORT_TABS,
           'file',
           condition: -> { can?(:admin, :reports) },
         ),
-        MenuItem.new(
+        Spree::MenuItem.new(
           CONFIGURATION_TABS,
           'wrench',
           condition: -> { can?(:admin, Spree::Store) },
@@ -95,21 +62,21 @@ module Spree
           partial: 'spree/admin/shared/settings_sub_menu',
           url: :admin_stores_path
         ),
-        MenuItem.new(
+        Spree::MenuItem.new(
           PROMOTION_TABS,
           'bullhorn',
           partial: 'spree/admin/shared/promotion_sub_menu',
           condition: -> { can?(:admin, Spree::Promotion) },
           url: :admin_promotions_path
         ),
-        MenuItem.new(
+        Spree::MenuItem.new(
           STOCK_TABS,
           'cubes',
           condition: -> { can?(:admin, Spree::StockItem) },
           label: :stock,
           url: :admin_stock_items_path
         ),
-        MenuItem.new(
+        Spree::MenuItem.new(
           USER_TABS,
           'user',
           condition: -> { Spree.user_class && can?(:admin, Spree.user_class) },

--- a/backend/app/models/spree/menu_item.rb
+++ b/backend/app/models/spree/menu_item.rb
@@ -1,0 +1,34 @@
+# An item which should be drawn in the admin menu
+module Spree
+  class MenuItem
+    attr_reader :icon, :label, :partial, :condition, :sections, :url
+
+    # @param sections [Array<Symbol>] The sections which are contained within
+    #   this admin menu section.
+    # @param icon [String] The icon to draw for this menu item
+    # @param condition [Proc] A proc which returns true if this menu item
+    #   should be drawn. If nil, it will be replaced with a proc which always
+    #   returns true.
+    # @param label [Symbol] The translation key for a label to use for this
+    #   menu item.
+    # @param partial [String] A partial to draw within this menu item for use
+    #   in declaring a submenu
+    # @param url [String] A url where this link should send the user to
+    def initialize(
+      sections,
+      icon,
+      condition: nil,
+      label: nil,
+      partial: nil,
+      url: nil
+    )
+
+      @condition = condition || -> { true }
+      @sections = sections
+      @icon = icon
+      @label = label || sections.first
+      @partial = partial
+      @url = url
+    end
+  end
+end

--- a/backend/app/models/spree/quick_switch_item.rb
+++ b/backend/app/models/spree/quick_switch_item.rb
@@ -1,0 +1,47 @@
+module Spree
+  class QuickSwitchItem
+    attr_reader :search_triggers, :finder, :url, :help_text_key, :not_found_text_key
+
+    # @param search_triggers [Array<Symbol>] An array of symbols that will be
+    #   entered as a part the administrators search that will trigger this
+    #   particular search query to run
+    # @param finder [Proc] A function to find the resource
+    # @param url [Proc] A function to return the URL we should redirect to
+    # @param help_text_key [Symbol] The key for the help text defined in i18n
+    # @param not_found_text_key [Symbol] The key for the 404 text defined in i18n
+    #
+    # @example
+    #   Spree::QuickSwitchItem.new(
+    #     search_triggers: [:o, :order],
+    #     finder: ->(searched_value) do
+    #       Spree::Order.find_by(number: searched_value)
+    #     end,
+    #     url: ->(order) do
+    #       Spree::Core::Engine.routes.url_helpers.edit_admin_order_path(order)
+    #     end,
+    #     help_text_key: :order_help,
+    #     not_found_text_key: :order_not_found
+    #   )
+    def initialize(
+      search_triggers:,
+      finder:,
+      url:,
+      help_text_key:,
+      not_found_text_key:
+    )
+      @search_triggers = search_triggers
+      @finder = finder
+      @url = url
+      @help_text_key = help_text_key
+      @not_found_text_key = not_found_text_key
+    end
+
+    def help_text
+      I18n.t(@help_text_key, scope: "spree.quick_switch")
+    end
+
+    def not_found_text(value)
+      I18n.t(@not_found_text_key, scope: "spree.quick_switch", value: value)
+    end
+  end
+end

--- a/backend/app/views/spree/admin/shared/_quick_switch.html.erb
+++ b/backend/app/views/spree/admin/shared/_quick_switch.html.erb
@@ -1,0 +1,37 @@
+<div class="modal fade" id="quick-switch" tabindex="-1" role="dialog" aria-hidden="true" data-js="quick-switch">
+  <div class="modal-dialog quick-switch-dialog" role="document" data-js="quick-switch-dialog">
+    <div class="modal-content">
+      <div class="modal-body">
+        <%= form_tag spree.admin_quick_switch_path, method: "get", class: "quick-switch-form" do %>
+          <input class="form-control quick-switch-query-input" type="text" name="quick_switch_query" placeholder="o R1234" data-js="quick-switch-input">
+
+          <button class="quick-switch-button btn btn-link">
+            <svg width="15" viewBox="0 0 25 25" xmlns="http://www.w3.org/2000/svg"><g fill-rule="nonzero" fill="#5498DA"><path d="M10.49 20.886c-4.228.02-8.05-2.513-9.68-6.414-1.633-3.9-.75-8.4 2.233-11.397C6.027.08 10.523-.823 14.43.79c3.91 1.616 6.457 5.427 6.456 9.656.006 5.75-4.645 10.42-10.396 10.44zm0-17.84c-2.996-.02-5.71 1.77-6.87 4.534-1.16 2.763-.54 5.953 1.572 8.08 2.112 2.126 5.298 2.768 8.07 1.626 2.77-1.142 4.577-3.843 4.577-6.84.01-4.07-3.28-7.38-7.35-7.4z"/><path d="M22.696 24.755l-6.577-6.537 2.153-2.156 6.574 6.537"/></g></svg>
+          </button>
+
+          <span class="quick-switch-spinner spinner"></span>
+        <% end %>
+
+        <div class="quick-switch-help">
+          <button class="btn btn-link" data-toggle="collapse" data-toggle="collapse" data-target="#quick-switch-help-content" aria-expanded="false" aria-controls="quick-switch-help-content">
+            <%= I18n.t("help_button", scope: "spree.quick_switch") %>
+          </button>
+
+          <div id="quick-switch-help-content" class="collapse">
+            <div class="card">
+              <div class="card-body">
+                <%= I18n.t("help_intro", scope: "spree.quick_switch") %>
+
+                <ul>
+                  <% Spree::Backend::Config.quick_switch_items.each do |item| %>
+                    <li><%= item.help_text %></li>
+                  <% end %>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/backend/app/views/spree/layouts/admin.html.erb
+++ b/backend/app/views/spree/layouts/admin.html.erb
@@ -22,6 +22,8 @@
       </div>
     </div>
 
+    <%= render "spree/admin/shared/quick_switch" %>
+
     <div data-hook="admin_footer_scripts"></div>
   </body>
 </html>

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -2,6 +2,7 @@ Spree::Core::Engine.routes.draw do
   namespace :admin do
     get '/search/users', to: "search#users", as: :search_users
     get '/search/products', to: "search#products", as: :search_products
+    get "/quick-switch", to: "quick_switch#find_object", as: :quick_switch
 
     resources :dashboards, only: [] do
       collection do

--- a/backend/spec/requests/spree/admin/quick_switch_spec.rb
+++ b/backend/spec/requests/spree/admin/quick_switch_spec.rb
@@ -1,0 +1,67 @@
+require "spec_helper"
+
+RSpec.describe "Quick switch", type: :request do
+  stub_authorization!
+
+  let!(:order) { FactoryBot.create :order, number: "R1234" }
+  let!(:product) { FactoryBot.create :product, sku: "SKU123" }
+  let!(:shipment) { FactoryBot.create :shipment, number: "S1234" }
+  let!(:user) { FactoryBot.create :user, email: "jessicajones@example.com" }
+  let!(:variant) { FactoryBot.create :variant, sku: "SKU456" }
+
+  context "with valid parameters" do
+    it "returns an order's edit URL when we query orders" do
+      get spree.admin_quick_switch_path, params: { quick_switch_query: "o R1234" }
+
+      expect(response.status).to eq 200
+      expect(json_response["redirect_url"]).to eq(
+        spree.edit_admin_order_path(order)
+      )
+    end
+
+    it "returns an order's edit URL when we query shipments" do
+      get spree.admin_quick_switch_path, params: { quick_switch_query: "s S1234" }
+
+      expect(response.status).to eq 200
+      expect(json_response["redirect_url"]).to eq(
+        spree.edit_admin_order_path(shipment.order)
+      )
+    end
+
+    it "returns a user's edit URL when we query users" do
+      get spree.admin_quick_switch_path, params: { quick_switch_query: "u jessicajones@example.com" }
+
+      expect(response.status).to eq 200
+      expect(json_response["redirect_url"]).to eq(
+        spree.edit_admin_user_path(user)
+      )
+    end
+
+    it "returns a variant's edit URL when we query variants" do
+      get spree.admin_quick_switch_path, params: { quick_switch_query: "v SKU456" }
+
+      expect(response.status).to eq 200
+      expect(json_response["redirect_url"]).to eq(
+        spree.edit_admin_product_variant_path(
+          variant.product,
+          variant
+        )
+      )
+    end
+
+    it "returns a product's edit URL when our query is a master variant" do
+      get spree.admin_quick_switch_path, params: { quick_switch_query: "p SKU123" }
+
+      expect(response.status).to eq 200
+      expect(json_response["redirect_url"]).to eq(
+        spree.edit_admin_product_path(product)
+      )
+    end
+  end
+
+  private
+
+  def json_response
+    JSON.parse(response.body)
+  end
+end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1710,6 +1710,18 @@ en:
     quantity: Quantity
     quantity_returned: Quantity Returned
     quantity_shipped: Quantity Shipped
+    quick_switch:
+      help_button: How do I use this?
+      help_intro: "Use shortcodes to quickly access specific resources:"
+      invalid_query: Invalid or missing search key.
+      order_help: o ORDER_NUMBER
+      order_not_found: Order %{value} could not be found.
+      shipment_help: s SHIPMENT_NUMBER
+      shipment_not_found: Shipment %{value} could not be found.
+      user_help: u USER_EMAIL
+      user_not_found: Unable to find a user with an email matching %{value}.
+      variant_help: v VARIANT_SKU
+      variant_not_found: Unable to find a variant with a SKU matching %{value}.
     rate: Rate
     ready_to_ship: Ready to ship
     reason: Reason

--- a/core/lib/spree/testing_support/authorization_helpers.rb
+++ b/core/lib/spree/testing_support/authorization_helpers.rb
@@ -39,9 +39,14 @@ module Spree
           end
 
           before do
-            allow(Spree.user_class).to receive(:find_by).
-                                         with(hash_including(:spree_api_key)).
-                                         and_return(Spree.user_class.new)
+            original_find = Spree.user_class.method(:find_by)
+            allow(Spree.user_class).to receive(:find_by) do |hash|
+              if hash[:spree_api_key]
+                Spree.user_class.new
+              else
+                original_find.call(hash)
+              end
+            end
           end
         end
 


### PR DESCRIPTION
This component allows power user admins to navigate directly to a resource if they already know the primary key for it (an order's number, for example). This is heavily inspired both by how developers navigate to particular files or the Spotlight in macOS (though both of those use fuzzy searching which makes them much more powerful).

Example:

![quick-switch](https://user-images.githubusercontent.com/836758/29143385-c35b292a-7d09-11e7-9975-301886711e6b.gif)

## TODO

- [x] Allow this component to be extended – this might not be necessary as a first step but I imagine stores would want a way to be able to hook into this.
- [x] Add a visual indication that a resource has been found and that the admin is being redirected.
- [x] Explore new way of making this extendable and reducing controller complexity (see WIP commit)