### PR TITLE
Better restrict deleting users with orders

### DIFF
--- a/api/app/controllers/spree/api/resource_controller.rb
+++ b/api/app/controllers/spree/api/resource_controller.rb
@@ -56,6 +56,8 @@ class Spree::Api::ResourceController < Spree::Api::BaseController
     else
       invalid_resource!(@object)
     end
+  rescue ActiveRecord::DeleteRestrictionError
+    render "spree/api/errors/delete_restriction", status: 422
   end
 
   protected

--- a/api/app/views/spree/api/errors/delete_restriction.v1.rabl
+++ b/api/app/views/spree/api/errors/delete_restriction.v1.rabl
@@ -1,0 +1,2 @@
+object false
+node(:error) { I18n.t(:delete_restriction_error, scope: "spree.api") }

--- a/api/config/locales/en.yml
+++ b/api/config/locales/en.yml
@@ -7,6 +7,7 @@ en:
       invalid_resource: "Invalid resource. Please fix errors and try again."
       resource_not_found: "The resource you were looking for could not be found."
       gateway_error: "There was a problem with the payment gateway: %{text}"
+      delete_restriction_error: "Cannot delete record."
       access: "API Access"
       key: "Key"
       clear_key: "Clear key"

--- a/api/spec/requests/spree/api/users_controller_spec.rb
+++ b/api/spec/requests/spree/api/users_controller_spec.rb
@@ -142,8 +142,8 @@ module Spree
       it "cannot destroy user with orders" do
         create(:completed_order_with_totals, user: user)
         delete spree.api_user_path(user)
-        expect(json_response["exception"]).to eq "Spree::Core::DestroyWithOrdersError"
         expect(response.status).to eq(422)
+        expect(json_response).to eq({ "error" => "Cannot delete record." })
       end
     end
   end

--- a/backend/app/controllers/spree/admin/users_controller.rb
+++ b/backend/app/controllers/spree/admin/users_controller.rb
@@ -1,7 +1,7 @@
 module Spree
   module Admin
     class UsersController < ResourceController
-      rescue_from Spree::Core::DestroyWithOrdersError, with: :user_destroy_with_orders_error
+      rescue_from ActiveRecord::DeleteRestrictionError, with: :user_destroy_with_orders_error
 
       after_action :sign_in_if_change_own_password, only: :update
 

--- a/core/app/models/concerns/spree/user_methods.rb
+++ b/core/app/models/concerns/spree/user_methods.rb
@@ -17,7 +17,7 @@ module Spree
       has_many :stock_locations, through: :user_stock_locations
 
       has_many :spree_orders, foreign_key: "user_id", class_name: "Spree::Order"
-      has_many :orders, foreign_key: "user_id", class_name: "Spree::Order"
+      has_many :orders, foreign_key: "user_id", class_name: "Spree::Order", dependent: :restrict_with_exception
 
       has_many :store_credits, -> { includes(:credit_type) }, foreign_key: "user_id", class_name: "Spree::StoreCredit"
       has_many :store_credit_events, through: :store_credits

--- a/core/app/models/spree/legacy_user.rb
+++ b/core/app/models/spree/legacy_user.rb
@@ -8,19 +8,11 @@ module Spree
 
     self.table_name = 'spree_users'
 
-    before_destroy :check_completed_orders
-
     def self.model_name
       ActiveModel::Name.new Spree::LegacyUser, Spree, 'user'
     end
 
     attr_accessor :password
     attr_accessor :password_confirmation
-
-    private
-
-    def check_completed_orders
-      raise Spree::Core::DestroyWithOrdersError if orders.complete.present?
-    end
   end
 end

--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -12,6 +12,8 @@ require 'paranoia'
 require 'ransack'
 require 'state_machines-activerecord'
 
+require 'spree/deprecation'
+
 # This is required because ActiveModel::Validations#invalid? conflicts with the
 # invalid state of a Payment. In the future this should be removed.
 StateMachines::Machine.ignore_method_conflicts = true
@@ -45,7 +47,9 @@ module Spree
     autoload :ProductFilters, "spree/core/product_filters"
 
     class GatewayError < RuntimeError; end
-    class DestroyWithOrdersError < StandardError; end
+
+    include ActiveSupport::Deprecation::DeprecatedConstantAccessor
+    deprecate_constant 'DestroyWithOrdersError', ActiveRecord::DeleteRestrictionError, deprecator: Spree::Deprecation
   end
 end
 
@@ -80,6 +84,5 @@ require 'spree/core/controller_helpers/strong_parameters'
 require 'spree/core/role_configuration'
 require 'spree/core/stock_configuration'
 require 'spree/permission_sets'
-require 'spree/deprecation'
 
 require 'spree/core/price_migrator'

--- a/core/spec/models/spree/concerns/user_methods_spec.rb
+++ b/core/spec/models/spree/concerns/user_methods_spec.rb
@@ -38,4 +38,23 @@ describe Spree::UserMethods do
       it { is_expected.to be_nil }
     end
   end
+
+  describe "deleting user" do
+    context "with no orders" do
+      it "fails validation" do
+        test_user.destroy!
+        expect(test_user).to be_destroyed
+      end
+    end
+
+    context "with an order" do
+      let!(:order) { create(:order, user: test_user) }
+
+      it "fails validation" do
+        expect {
+          test_user.destroy!
+        }.to raise_error(ActiveRecord::DeleteRestrictionError)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Previously, there was a before_destroy on `LegacyUser` which would prevent deleting users which had an attached order by raising `DestroyWithOrdersError`.

`LegacyUser` shouldn't be used in real stores, so this is pointless.

This replaces that check with `dependent: :restrict_with_exception` inside of `UserMethods,` which will restrict deletions of any user model (like `Spree::User` from `solidus_auth_devise`). This also updates the API (the only place which handled this) to understand `DeleteRestrictionError` instead, and to return a better error response.