### PR TITLE
Remove the border from images in tables

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/shared/_tables.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_tables.scss
@@ -9,10 +9,6 @@ table {
     vertical-align: middle;
     text-overflow: ellipsis;
 
-    img {
-      border: 1px solid transparent;
-    }
-
     &:first-child {
       border-left: 1px solid $color-border;
     }
@@ -149,18 +145,10 @@ table {
       }
       &.even td {
         background-color: $color-tbl-even;
-
-        img {
-          border: 1px solid very-light($color-3, 6);
-        }
       }
 
       &:hover td {
         background-color: very-light($color-3, 5);
-
-        img {
-          border: 1px solid $color-border;
-        }
       }
 
       &.deleted td {


### PR DESCRIPTION
As prerequisite to #2092 and #2101 we remove the border from images in tables.