### PR TITLE
Remove action button background color

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/shared/_tables.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_tables.scss
@@ -59,6 +59,8 @@ table {
 
       button[class*='fa-'] {
         color: $link-color;
+        background-color: transparent;
+        border: 0 none;
         padding: 0 !important;
       }
 


### PR DESCRIPTION
Buttons inside of `.actions` table cells should not have any background nor border.

Hotfix for #2100 after we merged #2062 