### PR TITLE
Fix customer_details Backbone always setting Guest checkout True

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/views/order/customer_details.js
+++ b/backend/app/assets/javascripts/spree/backend/views/order/customer_details.js
@@ -53,7 +53,7 @@ Spree.Views.Order.CustomerDetails = Backbone.View.extend({
   },
 
   render: function() {
-    var user_id = this.model.get("user_id")
+    var user_id = this.model.get("user_id") || $("#user_id").val()
     this.$("#user_id").val(user_id);
     this.$('#guest_checkout_true')
       .prop("checked", !user_id);
@@ -65,4 +65,3 @@ Spree.Views.Order.CustomerDetails = Backbone.View.extend({
     this.$('#order_email').val(this.model.get("email"))
   }
 })
-


### PR DESCRIPTION
When the page is rendered the value of #user_id is set and the Backbone
render was resetting that. This changes the render to fallback to that
value if the model doesn't have the user_id already present.

**Steps to Recreate:**
Create order in Admin
Get to address step
Use Customer Search to add a User to the order
Notice Guest Checkout is now No
Complete Address Step
Go back to Address Step
Guest Checkout is now Yes even though a user is attached to order