### PR TITLE
UI Fixes for taxons tree

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/taxonomy.js.coffee
+++ b/backend/app/assets/javascripts/spree/backend/taxonomy.js.coffee
@@ -44,7 +44,7 @@ TaxonTreeView = Backbone.View.extend
     })
 
   resize_placeholder: (e, ui) ->
-    handleHeight = ui.helper.find('.sortable-handle').outerHeight()
+    handleHeight = ui.helper.find('.taxon').outerHeight()
     ui.placeholder.height(handleHeight)
 
   restore_sort_targets: ->

--- a/backend/app/assets/javascripts/spree/backend/templates/taxons/_tree.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/taxons/_tree.hbs
@@ -7,7 +7,7 @@
       <i class="fa fa-arrows"></i>
     {{/if}}
       {{name}}
-      <div class="actions right">
+      <div class="actions float-right">
         <a href="#" class="js-taxon-add-child fa fa-plus icon_link no-text"></a>
         <a href="{{admin_url}}/taxonomies/{{taxonomy_id}}/taxons/{{id}}/edit" class="fa fa-edit icon_link no-text"></a>
         <a href="#" class="js-taxon-delete fa fa-trash icon_link no-text"></a>

--- a/backend/app/assets/javascripts/spree/backend/templates/taxons/_tree.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/taxons/_tree.hbs
@@ -1,7 +1,11 @@
 {{#each taxons}}
   <li data-taxon-id="{{id}}" data-taxon-taxonomy-id="{{taxonomy_id}}">
-    <div  class="sortable-handle">
-      {{#if (isRootTaxon) }}{{else}}<i class="fa fa-arrows"></i>{{/if}}
+    {{#if (isRootTaxon) }}
+    <div class="taxon">
+    {{else}}
+    <div class="taxon sortable">
+      <i class="fa fa-arrows"></i>
+    {{/if}}
       {{name}}
       <div class="actions right">
         <a href="#" class="js-taxon-add-child fa fa-plus icon_link no-text"></a>

--- a/backend/app/assets/stylesheets/spree/backend/sections/_taxonomies.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/_taxonomies.scss
@@ -14,32 +14,25 @@
     margin-bottom: 0.5em;
   }
 
-  > li {
-    > .sortable-handle {
-      text-indent: 2em;
-
-      * {
-        text-indent: 0;
-      }
-    }
-
-    > .ui-sortable {
-      padding-bottom: 5em;
-    }
-  }
-
-  .sortable-handle ,
+  .taxon,
   .sortable-placeholder {
     border-radius: $border-radius;
   }
 
-  .sortable-handle {
+  .sortable-placeholder {
+    margin: 0.5em 0;
+  }
+
+  .taxon {
     background-color: very-light($color-3);
     border: 1px solid $color-border;
     color: $body-color;
     font-weight: $font-weight-bold;
     padding: 0.5em;
-    cursor: move;
+
+    &.sortable {
+      cursor: move;
+    }
 
     i {
       @include margin(null 4px 0 6px);


### PR DESCRIPTION
Since we removed `skeleton.css` from them admin we need to fix the taxons tree action buttons
position. We need to use Bootstraps `float-right` instead of Skeletons `right`.

Also fixes the visual appearance of the root taxon so it does not look like it were sortable.