### PR TITLE
Fix references to nonexistent API attributes

### DIFF
--- a/api/app/helpers/spree/api/api_helpers.rb
+++ b/api/app/helpers/spree/api/api_helpers.rb
@@ -136,7 +136,7 @@ module Spree
       @@adjustment_attributes = [
         :id, :source_type, :source_id, :adjustable_type, :adjustable_id,
         :amount, :label, :promotion_code,
-        :locked, :eligible, :created_at, :updated_at
+        :finalized, :eligible, :created_at, :updated_at
       ]
 
       @@creditcard_attributes = [

--- a/api/app/helpers/spree/api/api_helpers.rb
+++ b/api/app/helpers/spree/api/api_helpers.rb
@@ -115,8 +115,7 @@ module Spree
       ]
 
       @@inventory_unit_attributes = [
-        :id, :state, :variant_id, :shipment_id,
-        :return_authorization_id
+        :id, :state, :variant_id, :shipment_id
       ]
 
       @@return_authorization_attributes = [

--- a/api/app/helpers/spree/api/api_helpers.rb
+++ b/api/app/helpers/spree/api/api_helpers.rb
@@ -115,7 +115,7 @@ module Spree
       ]
 
       @@inventory_unit_attributes = [
-        :id, :lock_version, :state, :variant_id, :shipment_id,
+        :id, :state, :variant_id, :shipment_id,
         :return_authorization_id
       ]
 
@@ -159,7 +159,7 @@ module Spree
       @@stock_movement_attributes = [:id, :quantity, :stock_item_id]
 
       @@stock_item_attributes = [
-        :id, :count_on_hand, :backorderable, :lock_version, :stock_location_id,
+        :id, :count_on_hand, :backorderable, :stock_location_id,
         :variant_id
       ]
 

--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -171,6 +171,10 @@ module Spree
       self.country = Spree::Country.find_by!(iso: iso)
     end
 
+    def country_iso
+      country && country.iso
+    end
+
     private
 
     def state_validate


### PR DESCRIPTION
RABL silently ignores attributes which don't exist. Whoops!

This makes the following changes to attributes:
* Remove `return_authorization_id` from `inventory_unit`
* Add `finalized` adjustment (replacing now nonexistent `locked`)
* Remove `lock_version` from `inventory_unit` and `stock_item`
* Add `country_iso` to address (which should exist since `country_iso=` does)

(extracted from #2147)