### PR TITLE
Use constants instead of translations for `StoreCreditType` names

### DIFF
--- a/core/app/models/spree/store_credit.rb
+++ b/core/app/models/spree/store_credit.rb
@@ -284,7 +284,12 @@ class Spree::StoreCredit < Spree::PaymentSource
 
   def associate_credit_type
     unless type_id
-      credit_type_name = category.try(:non_expiring?) ? Spree.t("store_credit.non_expiring") : Spree.t("store_credit.expiring")
+      credit_type_name =
+        if category.try(:non_expiring?)
+          Spree::StoreCreditType::NON_EXPIRING
+        else
+          Spree::StoreCreditType::EXPIRING
+        end
       self.credit_type = Spree::StoreCreditType.find_by(name: credit_type_name)
     end
   end

--- a/core/app/models/spree/store_credit_category.rb
+++ b/core/app/models/spree/store_credit_category.rb
@@ -1,6 +1,6 @@
 class Spree::StoreCreditCategory < Spree::Base
   class_attribute :non_expiring_credit_types
-  self.non_expiring_credit_types = [Spree.t("store_credit.non_expiring")]
+  self.non_expiring_credit_types = [Spree::StoreCreditType::NON_EXPIRING]
 
   class_attribute :reimbursement_category_name
   self.reimbursement_category_name = Spree.t("store_credit_category.default")

--- a/core/app/models/spree/store_credit_type.rb
+++ b/core/app/models/spree/store_credit_type.rb
@@ -1,6 +1,8 @@
 module Spree
   class StoreCreditType < Spree::Base
-    DEFAULT_TYPE_NAME = Spree.t("store_credit.expiring")
+    EXPIRING = 'Expiring'
+    NON_EXPIRING = 'Non-expiring'
+    DEFAULT_TYPE_NAME = EXPIRING
     has_many :store_credits, class_name: 'Spree::StoreCredit', foreign_key: 'type_id'
   end
 end

--- a/core/db/default/spree/store_credit.rb
+++ b/core/db/default/spree/store_credit.rb
@@ -10,8 +10,8 @@ Spree::PaymentMethod.create_with(
   type: "Spree::PaymentMethod::StoreCredit"
 )
 
-Spree::StoreCreditType.create_with(priority: 1).find_or_create_by!(name: 'Expiring')
-Spree::StoreCreditType.create_with(priority: 2).find_or_create_by!(name: 'Non-expiring')
+Spree::StoreCreditType.create_with(priority: 1).find_or_create_by!(name: Spree::StoreCreditType::EXPIRING)
+Spree::StoreCreditType.create_with(priority: 2).find_or_create_by!(name: Spree::StoreCreditType::NON_EXPIRING)
 
 Spree::ReimbursementType.create_with(name: "Store Credit").find_or_create_by!(type: 'Spree::ReimbursementType::StoreCredit')
 

--- a/core/db/migrate/20150506181715_create_store_credit_types.rb
+++ b/core/db/migrate/20150506181715_create_store_credit_types.rb
@@ -11,7 +11,7 @@ class CreateStoreCreditTypes < ActiveRecord::Migration[4.2]
     add_index :spree_store_credits, :type_id
     add_index :spree_store_credit_types, :priority
 
-    Spree::StoreCreditType.create_with(priority: 1).find_or_create_by!(name: Spree.t("store_credit.expiring"))
-    Spree::StoreCreditType.create_with(priority: 2).find_or_create_by!(name: Spree.t("store_credit.non_expiring"))
+    Spree::StoreCreditType.create_with(priority: 1).find_or_create_by!(name: Spree::StoreCreditType::EXPIRING)
+    Spree::StoreCreditType.create_with(priority: 2).find_or_create_by!(name: Spree::StoreCreditType::NON_EXPIRING)
   end
 end

--- a/core/lib/spree/testing_support/factories/store_credit_type_factory.rb
+++ b/core/lib/spree/testing_support/factories/store_credit_type_factory.rb
@@ -5,7 +5,7 @@ FactoryGirl.define do
   end
 
   factory :secondary_credit_type, class: Spree::StoreCreditType do
-    name      { "Non-expiring" }
+    name      { Spree::StoreCreditType::NON_EXPIRING }
     priority  { "2" }
   end
 end


### PR DESCRIPTION
There doesn't seem to be a great reason for `StoreCreditType::DEFAULT_TYPE_NAME` to be defined with a translation. The translation isn't being used to construct error messages or sent to the frontend at all.

This PR defines two constants in `StoreCreditType`, `StoreCreditType::EXPIRING` and `StoreCreditType::NON_EXPIRING`, and uses them in the appropriate places.