### PR TITLE
Exclude Bootstrap buttons from our button styling

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
@@ -66,7 +66,12 @@ input[type="submit"],
 input[type="button"],
 button,
 .button {
-  &:not(.close) {
+  &:not(.close):not([class*="btn"]) {
+    // We want to apply the primary button coloring to all buttons that do not
+    // currently use the Bootstrap class naming convention (`btn`).
+    //
+    // In order to avoid the clashing between using `:not(.btn)` and
+    // `@extend .btn` we need to use an attribute selector of `[class*="btn"]`.
     @extend .btn;
     @include button-variant(theme-color("primary"), theme-color("primary"));
   }


### PR DESCRIPTION
Unfortunately we cannot currently use the Bootstrap classes on button or
input elements. This change allows us to do that by adding another
`:not()` selector to our custom button styles.

We want to keep the `@extend` so that our extensions and other legacy
content continue to have appropriately styled buttons.

Unfortunatley we cannot simply add `:not(.btn)` because we then
`@extend .btn` and Sass very quickly gets confused as to what we're
asking it to do. Therefor we need to use `:not([class*="btn"])` to
essentially trick Sass into ignoring our rather unique use case.