### PR TITLE
Fix method missing error

### DIFF
--- a/core/app/models/spree/return_authorization.rb
+++ b/core/app/models/spree/return_authorization.rb
@@ -38,7 +38,7 @@ module Spree
     end
 
     def amount
-      return_item.sum(:amount)
+      return_items.sum(:amount)
     end
 
     def currency

--- a/core/spec/models/spree/return_authorization_spec.rb
+++ b/core/spec/models/spree/return_authorization_spec.rb
@@ -108,7 +108,7 @@ describe Spree::ReturnAuthorization, type: :model do
 
     subject { return_authorization.amount }
 
-    it "sums the return items' amounts", skip: "failing test to demonstrate bug" do
+    it "sums the return items' amounts" do
       expect(subject).to eq(15)
     end
   end

--- a/core/spec/models/spree/return_authorization_spec.rb
+++ b/core/spec/models/spree/return_authorization_spec.rb
@@ -101,6 +101,18 @@ describe Spree::ReturnAuthorization, type: :model do
     end
   end
 
+  describe "#amount" do
+    let(:return_item1) { create(:return_item, amount: 10) }
+    let(:return_item2) { create(:return_item, amount: 5) }
+    let(:return_authorization) { create(:return_authorization, return_items: [return_item1, return_item2]) }
+
+    subject { return_authorization.amount }
+
+    it "sums the return items' amounts", skip: "failing test to demonstrate bug" do
+      expect(subject).to eq(15)
+    end
+  end
+
   describe "#refundable_amount" do
     let(:line_item_price) { 5.0 }
     let(:line_item_count) { return_authorization.order.line_items.count }


### PR DESCRIPTION
`return_items` is a `has_many` association, but we're currently calling `return_item.sum(:amount)` which raises a method missing error.