### PR TITLE
Remove the ffaker sample data dependency (revised)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Solidus 2.4.0 (master, unreleased)
 
+- Remove `ffaker` as a runtime dependency in production [\#2140](https://github.com/solidusio/solidus/pull/2140) ([cbrunsdon](https://github.com/cbrunsdon))
+
 - Invalidate existing non store credit payments during checkout [2075](https://github.com/solidusio/solidus/pull/2075) ([tvdeyen](https://github.com/tvdeyen))
 
 - Change HTTP Status code for `Api::ShipmentsController#transfer_to_*` to be always 202 Accepted rather than 201 Created or 500.

--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -35,6 +35,7 @@ group :test do
   gem 'with_model'
   gem 'rspec_junit_formatter'
   gem 'rails-controller-testing'
+  gem 'ffaker', require: false
 end
 
 group :test, :development do

--- a/core/lib/spree/testing_support/sequences.rb
+++ b/core/lib/spree/testing_support/sequences.rb
@@ -1,5 +1,10 @@
 require 'factory_girl'
-require 'ffaker'
+
+begin
+  require 'ffaker'
+rescue LoadError
+  abort "Solidus factories require FFaker. Please add `ffaker` to your `Gemfile`."
+end
 
 FactoryGirl.define do
   sequence(:random_code)        { FFaker::Lorem.characters(10) }

--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'awesome_nested_set', '~> 3.0', '>= 3.0.1'
   s.add_dependency 'carmen', '~> 1.0.0'
   s.add_dependency 'cancancan', '~> 1.10'
-  s.add_dependency 'ffaker', '~> 2.0'
   s.add_dependency 'friendly_id', '~> 5.0'
   s.add_dependency 'kaminari', '>= 0.17', '< 2.0'
   s.add_dependency 'monetize', '~> 1.1'

--- a/sample/db/samples/addresses.rb
+++ b/sample/db/samples/addresses.rb
@@ -1,26 +1,39 @@
 united_states = Spree::Country.find_by!(iso: "US")
 new_york = Spree::State.find_by!(name: "New York")
 
-# Billing address
-Spree::Address.create!(
-  firstname: FFaker::Name.first_name,
-  lastname: FFaker::Name.last_name,
-  address1: FFaker::Address.street_address,
-  address2: FFaker::Address.secondary_address,
-  city: FFaker::Address.city,
-  state: new_york,
-  zipcode: 16_804,
-  country: united_states,
-  phone: FFaker::PhoneNumber.phone_number)
+first_names = ["Sterling", "Jennette", "Salome", "Lyla", "Lola", "Cheree",
+               "Hettie", "Barbie", "Amelia", "Marceline", "Keeley", "Mi",
+               "Karon", "Jessika", "Emmy"]
+last_names = ["Torp", "Vandervort", "Stroman", "Lang", "Zulauf", "Bruen",
+              "Torp", "Gutmann", "Renner", "Bergstrom", "Sauer", "Gaylord",
+              "Mills", "Daugherty", "Stark"]
+street_addresses = ["7377 Jacobi Passage", "4725 Serena Ridges",
+                    "79832 Hamill Creek", "0746 Genoveva Villages",
+                    "86717 D'Amore Hollow", "8529 Delena Well",
+                    "959 Lockman Ferry", "67016 Murphy Fork",
+                    "193 Larkin Divide", "80697 Cole Parks"]
+secondary_addresses = ["Suite 918", "Suite 374", "Apt. 714", "Apt. 351",
+                       "Suite 274", "Suite 240", "Suite 892", "Apt. 176",
+                       "Apt. 986", "Apt. 583"]
+cities = ["Lake Laurenceview", "Lucilefurt", "South Jannetteport",
+          "Leannonport", "Legrosburgh", "Willmsberg", "Karoleside",
+          "Lake German", "Keeblerfort", "Lemkehaven"]
+phone_numbers = ["(392)859-7319 x670", "738-831-3210 x6047",
+                 "(441)881-8127 x030", "1-744-701-0536 x30504",
+                 "(992)432-8273 x97676", "482.249.0178 x532",
+                 "(855)317-6523", "1-529-214-7315 x90865",
+                 "(662)877-7894 x703", "689.578.8564 x72399"]
 
-# Shipping address
-Spree::Address.create!(
-  firstname: FFaker::Name.first_name,
-  lastname: FFaker::Name.last_name,
-  address1: FFaker::Address.street_address,
-  address2: FFaker::Address.secondary_address,
-  city: FFaker::Address.city,
-  state: new_york,
-  zipcode: 16_804,
-  country: united_states,
-  phone: FFaker::PhoneNumber.phone_number)
+2.times do
+  Spree::Address.create!(
+    firstname: first_names.sample,
+    lastname: last_names.sample,
+    address1: street_addresses.sample,
+    address2: secondary_addresses.sample,
+    city: cities.sample,
+    state: new_york,
+    zipcode: 16_804,
+    country: united_states,
+    phone: phone_numbers.sample
+  )
+end

--- a/sample/db/samples/products.rb
+++ b/sample/db/samples/products.rb
@@ -4,8 +4,17 @@ Spree::Sample.load_sample("shipping_categories")
 tax_category = Spree::TaxCategory.find_by!(name: "Default")
 shipping_category = Spree::ShippingCategory.find_by!(name: "Default")
 
+descriptions = [
+  "Occaecati repellendus soluta perspiciatis ea ea voluptatum alias. Dolorem possimus sunt ipsam eos aliquam voluptates. Voluptate est nemo ullam cumque ea ut molestiae iste.",
+  "Nisi dolor explicabo est fugiat alias. Asperiores sunt rerum quisquam perspiciatis quis doloremque. Autem est harum eum dolorem voluptas nihil. Nulla omnis voluptas sint cumque ad ut dignissimos reiciendis. Mollitia culpa iure libero labore nulla autem non eum.",
+  "Perferendis sed voluptatem error ipsam voluptatem esse ipsa incidunt. Doloremque quos ratione quia voluptas consequatur mollitia optio. Optio sed iure aut aliquid voluptatum facilis mollitia cum. Dignissimos in saepe consequatur et consequatur dolorem blanditiis.",
+  "Necessitatibus optio quod ullam itaque quis corporis occaecati. Saepe harum voluptates consectetur rerum dolorum. Corrupti officiis reprehenderit quo excepturi cumque. Soluta eos perspiciatis aut et ea nulla amet dolores. Dolores distinctio nesciunt libero voluptas molestiae consequatur aut veritatis.",
+  "Soluta sed error debitis repellendus et. Voluptates unde enim qui velit. Libero earum tenetur nulla similique temporibus quod repellendus quibusdam.",
+  "Recusandae animi deserunt provident dignissimos ullam harum alias et. Itaque dicta maxime consectetur ut nemo non voluptatem. Voluptatem ipsum ut culpa eaque dolores.",
+]
+
 default_attrs = {
-  description: FFaker::Lorem.paragraph,
+  description: descriptions.sample,
   available_on: Time.current
 }
 

--- a/sample/lib/tasks/sample.rake
+++ b/sample/lib/tasks/sample.rake
@@ -1,4 +1,3 @@
-require 'ffaker'
 require 'pathname'
 require 'spree/sample'
 


### PR DESCRIPTION
Addresses comments brought up in @cbrunsdon's [original PR](https://github.com/solidusio/solidus/pull/2140).

Original PR description
--------------
Continues the idea of #2082, this removes the dependency of ffaker but
also yanks it out of the sample requirement. I generated a small data
set with 15.times.map { FFaker::Name.first_name } etc.