### PR TITLE
Tweak font styles on admin shipments page

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/templates/orders/details_adjustment_row.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/orders/details_adjustment_row.hbs
@@ -1,4 +1,4 @@
 <tr>
-  <td><strong>{{ label }}:</strong></td>
+  <td>{{ label }}:</td>
   <td class="total"><span>{{ amount }}</span></td>
 </tr>

--- a/backend/app/views/spree/admin/orders/_adjustments.html.erb
+++ b/backend/app/views/spree/admin/orders/_adjustments.html.erb
@@ -10,7 +10,7 @@
     <tbody data-hook="order_details_adjustments">
       <% adjustments.eligible.group_by(&:label).each do |label, adjustments| %>
         <tr class="total">
-          <td><strong><%= label %>:</strong></td>
+          <td><%= label %>:</td>
           <td class="total"><span><%= Spree::Money.new(adjustments.sum(&:amount), currency: adjustments.first.order.try(:currency)) %></span></td>
         </tr>
       <% end %>

--- a/backend/app/views/spree/admin/orders/_carton.html.erb
+++ b/backend/app/views/spree/admin/orders/_carton.html.erb
@@ -52,7 +52,7 @@
           <% if carton.tracking.present? %>
             <strong><%= Spree::Carton.human_attribute_name(:tracking) %>:</strong> <%= carton.tracking %>
           <% else %>
-            <%= Spree.t(:no_tracking_present) %>
+            <i><%= Spree.t(:no_tracking_present) %></i>
           <% end %>
         </td>
       </tr>

--- a/backend/app/views/spree/admin/orders/_shipment.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment.html.erb
@@ -116,7 +116,7 @@
           <% if shipment.tracking.present? %>
             <strong><%= Spree::Shipment.human_attribute_name(:tracking) %>:</strong> <%= shipment.tracking %>
           <% else %>
-            <%= Spree.t(:no_tracking_present) %>
+            <i><%= Spree.t(:no_tracking_present) %></i>
           <% end %>
         </td>
         <td class="actions">

--- a/backend/app/views/spree/admin/orders/_shipment.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment.html.erb
@@ -62,9 +62,9 @@
           </td>
           <td class="actions">
             <% if can? :update, shipment %>
-              <%= button_tag '', class: 'save-method fa fa-check no-text with-ti, type: :button',
+              <%= button_tag '', class: 'save-method fa fa-check no-text with-tip',
                 data: {'shipment-number' => shipment.number, action: 'save'}, title: Spree.t('actions.save') %>
-              <%= button_tag '', class: 'cancel-method fa fa-cancel no-text with-ti, type: :button',
+              <%= button_tag '', class: 'cancel-method fa fa-cancel no-text with-tip',
                 data: {action: 'cancel'}, title: Spree.t('actions.cancel') %>
             <% end %>
           </td>
@@ -74,10 +74,10 @@
         <tr class="show-method total">
           <% if rate = shipment.selected_shipping_rate %>
             <td colspan="4">
-              <strong><%= rate.name %></strong>
+              <%= rate.name %>
             </td>
             <td class="total">
-              <span><%= shipment.display_cost %></span>
+              <%= shipment.display_cost %>
             </td>
           <% else %>
             <td colspan='5'><%= Spree.t(:no_shipping_method_selected) %></td>


### PR DESCRIPTION
This PR:
* Removes **bold** from shipping method name (this is a value, not a heading)
* Removes **bold** from adjustment name values (this is a value, not a heading)
* *Italicizes* "No tracking details provided." (to make it clearer this is a placeholder)


**Before**
![](http://i.hawth.ca/s/ec2yvQnd.png)

**After**
![](http://i.hawth.ca/s/vxgk6aZq.png)