### PR TITLE
Show table borders on action columns

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/components/_actions.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_actions.scss
@@ -26,8 +26,6 @@ table tbody tr {
   }
 
   td.actions {
-    background-color: transparent !important;
-
     button {
       cursor: pointer;
     }

--- a/backend/app/assets/stylesheets/spree/backend/shared/_tables.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_tables.scss
@@ -20,9 +20,7 @@ table {
     }
 
     &.actions {
-      background-color: transparent;
-      border: none !important;
-      text-align: left;
+      text-align: right;
       padding-left: 1.25rem;
 
       span.text {


### PR DESCRIPTION
Previously, the action icons were shown clearly outside the table row they belonged to. I suspect this is just because it looked bad.

With the new table design, I believe it looks better to group the actions under the same row separator as the rest of the row, and it makes it more obvious what it is operating on.

This also right-aligns the action cells.

**Before**
![](http://i.hawth.ca/s/2skXKtD4.png)
*Note extra whitespace at right*

**After**
![](http://i.hawth.ca/s/WJsKjk0e.png)