### PR TITLE
Checkout email input field should use email_field (revised)

### DIFF
--- a/frontend/app/views/spree/checkout/edit.html.erb
+++ b/frontend/app/views/spree/checkout/edit.html.erb
@@ -12,7 +12,7 @@
         <% if @order.state == 'address' || !@order.email? %>
           <p class="field" style='clear: both'>
             <%= form.label :email %><br />
-            <%= form.text_field :email %>
+            <%= form.email_field :email %>
           </p>
         <% end %>
         <%= render @order.state, form: form %>


### PR DESCRIPTION
Rebasing and pushing @notapatch's [original PR](https://github.com/solidusio/solidus/pull/2120). CircleCI was [giving a phantom failure](https://github.com/solidusio/solidus/pull/2120#issuecomment-318725277), but that should be resolved now.

Also very subtly changes the commit message (get rid of a period and change "none" to "non").

Original PR description
---------------

- on frontend checkout/edit
 - mobile users will have a virtual keyboard that now includes
   an @ symbol
 - fallback for non HTML 5 browsers is to text type