### PR TITLE
Fix action button hover style

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/shared/_tables.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_tables.scss
@@ -50,6 +50,10 @@ table {
         background-color: transparent;
         border: 0 none;
         padding: 0 !important;
+
+        &:hover {
+          background-color: transparent;
+        }
       }
 
       .fa-envelope-alt, .fa-eye-open {
@@ -69,7 +73,8 @@ table {
         color: theme-color("warning");
       }
 
-      .fa-edit:hover, .fa-capture:hover, .fa-ok:hover, .fa-plus:hover, .fa-save:hover {
+      .fa-edit:hover, .fa-capture:hover, .fa-ok:hover, .fa-plus:hover,
+      .fa-save:hover, .fa-arrows-h:hover, .fa-check:hover {
         color: theme-color("success");
       }
 

--- a/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
@@ -22,8 +22,8 @@
 
     <td class="cart-item-delete actions" data-hook="cart_item_delete">
       <% if can? :update, item %>
-        <%= button_tag '', class: 'split-item icon_link fa fa-arrows-h no-text with-tip', data: { action: 'split', 'variant-id' => item.variant.id }, title: Spree.t('actions.split'), type: :button %>
-        <%= button_tag '', class: 'delete-item fa fa-trash no-text with-tip', data: { 'variant-id' => item.variant.id }, title: Spree.t('actions.delete'), type: :button %>
+        <%= button_tag '', class: 'split-item icon_link fa fa-arrows-h no-text with-tip', data: { action: 'edit', 'variant-id' => item.variant.id }, title: Spree.t('actions.split'), type: :button %>
+        <%= button_tag '', class: 'delete-item fa fa-trash no-text with-tip', data: { action: 'remove', 'variant-id' => item.variant.id }, title: Spree.t('actions.delete'), type: :button %>
       <% end %>
     </td>
   </tr>


### PR DESCRIPTION
The action button elements must not have a backgorund color on mosue hover. Also fixes the icon hover color for shippment table action buttons.

### Before

![monosnap 2017-08-17 23-07-57](https://user-images.githubusercontent.com/42868/29433927-6481cdd4-83a1-11e7-98a3-ecd4c7f03964.png)

### After

![monosnap 2017-08-17 23-06-58](https://user-images.githubusercontent.com/42868/29433935-6c61a0ce-83a1-11e7-8b2e-f4273515bad2.png)

- [x] Fix the tooltips color for split shipment action