### PR TITLE
Add headers to shipment method and tracking number

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -332,10 +332,8 @@ var ShipmentEditView = Backbone.View.extend({
 
       var show = _this.$('tr.show-tracking');
       show.toggle()
-          .find('.tracking-value')
-          .html($("<strong>")
-          .html(Spree.translations.tracking + ": "))
-          .append(document.createTextNode(data.tracking));
+        .find('.tracking-value')
+        .text(data.tracking);
     });
   }
 });

--- a/backend/app/assets/stylesheets/spree/backend/components/_actions.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_actions.scss
@@ -17,14 +17,6 @@ table tbody tr {
     }
   }
 
-  &.before-highlight {
-    @each $action in $actions {
-      &.action-#{$action} td {
-        border-bottom-color: get-value($actions, $actions-brd-colors, $action);
-      }
-    }
-  }
-
   td.actions {
     button {
       cursor: pointer;

--- a/backend/app/assets/stylesheets/spree/backend/components/_actions.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_actions.scss
@@ -2,16 +2,20 @@ table tbody tr {
   &.highlight {
 
     @each $action in $actions {
-      &.action-#{$action} td {
-        background-color: get-value($actions, $actions-bg-colors, $action);
-        border-color: get-value($actions, $actions-brd-colors, $action);
+      &.action-#{$action} {
+        td, th {
+          background-color: get-value($actions, $actions-bg-colors, $action);
+          border-color: get-value($actions, $actions-brd-colors, $action);
+        }
       }
     }
 
-    &.action-remove td, &.action-void td, &.action-failure td {
-      text-decoration: line-through;
+    &.action-remove, &.action-void, &.action-failure {
+      td, th {
+        text-decoration: line-through;
+      }
 
-      &.actions {
+      td.actions {
         text-decoration: none;
       }
     }

--- a/backend/app/views/spree/admin/orders/_shipment.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment.html.erb
@@ -25,12 +25,12 @@
 
   <table class="stock-contents shipment index" data-hook="stock-contents">
     <colgroup>
-      <col style="width: 10%;" />
+      <col style="width: 17.5%;" />
       <col style="width: 30%;" />
+      <col style="width: 12.5%;" />
       <col style="width: 15%;" />
       <col style="width: 15%;" />
-      <col style="width: 15%;" />
-      <col style="width: 15%;" />
+      <col style="width: 10%;" />
     </colgroup>
 
     <thead>
@@ -48,17 +48,11 @@
 
       <% unless shipment.shipped? %>
         <tr class="edit-method hidden total">
-          <td colspan="5">
-            <div class="row">
-              <div class="col-12">
-                <div class="field">
-                  <%= label_tag 'selected_shipping_rate_id', Spree::ShippingMethod.model_name.human %>
-                  <%= select_tag :selected_shipping_rate_id,
-                        options_for_select(shipment.shipping_rates.map {|sr| ["#{sr.name} #{sr.display_price}", sr.id] }, shipment.selected_shipping_rate_id),
-                        {class: 'custom-select fullwidth', data: {'shipment-number' => shipment.number } } %>
-                </div>
-              </div>
-            </div>
+          <th><%= Spree::ShippingMethod.model_name.human %></th>
+          <td colspan="4">
+            <%= select_tag :selected_shipping_rate_id,
+              options_for_select(shipment.shipping_rates.map {|sr| ["#{sr.name} #{sr.display_price}", sr.id] }, shipment.selected_shipping_rate_id),
+              {class: 'custom-select fullwidth', data: {'shipment-number' => shipment.number } } %>
           </td>
           <td class="actions">
             <% if can? :update, shipment %>
@@ -73,14 +67,15 @@
 
         <tr class="show-method total">
           <% if rate = shipment.selected_shipping_rate %>
-            <td colspan="4">
+            <th><%= Spree::ShippingMethod.model_name.human %></th>
+            <td colspan="3">
               <%= rate.name %>
             </td>
             <td class="total">
               <%= shipment.display_cost %>
             </td>
           <% else %>
-            <td colspan='5'><%= Spree.t(:no_shipping_method_selected) %></td>
+            <td colspan="5"><%= Spree.t(:no_shipping_method_selected) %></td>
           <% end %>
 
           <td class="actions">
@@ -91,8 +86,8 @@
         </tr>
 
       <tr class="edit-tracking hidden total">
-        <td colspan="5">
-          <label><%= Spree::Shipment.human_attribute_name(:tracking) %>:</label>
+        <th><%= Spree::Shipment.human_attribute_name(:tracking) %></th>
+        <td colspan="4">
           <%= text_field_tag :tracking, shipment.tracking, id: nil %>
         </td>
         <td class="actions">
@@ -112,9 +107,10 @@
       <% end %>
 
       <tr class="show-tracking total">
-        <td colspan="5" class="tracking-value">
+        <th><%= Spree::Shipment.human_attribute_name(:tracking) %></th>
+        <td colspan="4" class="tracking-value">
           <% if shipment.tracking.present? %>
-            <strong><%= Spree::Shipment.human_attribute_name(:tracking) %>:</strong> <%= shipment.tracking %>
+            <%= shipment.tracking %>
           <% else %>
             <i><%= Spree.t(:no_tracking_present) %></i>
           <% end %>

--- a/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
@@ -3,7 +3,7 @@
       data-item-quantity="<%= item.quantity %>"
       data-variant-id="<%= item.variant.id %>"
       >
-    <td class="item-image">
+    <td class="item-image align-center">
       <%= render 'spree/admin/shared/image', image: item.variant.display_image, size: :mini %>
     </td>
     <td class="item-name">

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -90,7 +90,7 @@ describe "Order Details", type: :feature, js: true do
         click_icon :check
 
         expect(page).not_to have_css("input[name=tracking]")
-        expect(page).to have_content("Tracking: FOOBAR")
+        expect(page).to have_content("Tracking Number FOOBAR")
       end
 
       it "can change the shipping method" do
@@ -99,7 +99,7 @@ describe "Order Details", type: :feature, js: true do
         within("table.index tr.show-method") do
           click_icon :edit
         end
-        select "UPS Ground $100.00", from: "Shipping Method"
+        select "UPS Ground $100.00", from: "selected_shipping_rate_id"
         click_icon :check
 
         expect(page).not_to have_css('#selected_shipping_rate_id')
@@ -511,7 +511,7 @@ describe "Order Details", type: :feature, js: true do
       within("table.index tr.show-method") do
         click_icon :edit
       end
-      select "UPS Ground $100.00", from: "Shipping Method"
+      select "UPS Ground $100.00", from: "selected_shipping_rate_id"
       click_icon :check
 
       expect(page).not_to have_css('#selected_shipping_rate_id')


### PR DESCRIPTION
Without headers it is hard to guess what "UPS same day" on a order shiments
table actually means.

Even more important, when in edit mode a form label is displayed in top of
the form field what leads to jumpy and confusing UI.

By adding headers to all view states this table row can have, we get a more
consistent UI.

### Before

![shipping-edit-before](https://user-images.githubusercontent.com/42868/29455093-1dd8c99a-8410-11e7-90f7-fb30f65f5aa9.gif)

### After

![shipping-edit-after](https://user-images.githubusercontent.com/42868/29455101-243ba898-8410-11e7-9d81-288b30d012e0.gif)
