### PR TITLE
Fixes padding of lists in form fields

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
@@ -117,19 +117,19 @@ span.info {
   }
 
   ul {
-    border-top: 1px solid $color-border;
     list-style: none;
-    padding-top: 5px;
+    margin: 5px 0;
+    padding-left: 0;
 
     li {
       display: inline-block;
       padding-right: 10px;
 
-
       label {
         font-weight: normal;
         text-transform: none;
       }
+
       &.white-space-nowrap {
         white-space: nowrap;
       }


### PR DESCRIPTION
Lists items in form fields are used for inline checkboxes (ie. order payment form or user roles select).

Somehow a left padding sneaked into that some while ago. This removes the padding as well as the top border, so it suites better for our form style.

### Before

![users roles - before](https://user-images.githubusercontent.com/42868/29458289-a07943da-841e-11e7-9a01-5afabc47f915.png)

![customer details - r987654321 - orders 2017-08-18 14-01-44](https://user-images.githubusercontent.com/42868/29458313-b86f3936-841e-11e7-9d6c-0a5912e53a47.png)

![new payment - payments - r987654321 - orders 2017-08-18 14-03-08](https://user-images.githubusercontent.com/42868/29458329-ce892d30-841e-11e7-9f71-f40dbd86e549.png)

### After

![users roles - after](https://user-images.githubusercontent.com/42868/29458291-a2bd80c0-841e-11e7-9d48-81a7ba2dea13.png)

![customer details - r987654321 - orders 2017-08-18 14-02-22](https://user-images.githubusercontent.com/42868/29458304-b074c034-841e-11e7-86e0-16eae050ba8f.png)

![new payment - payments - r987654321 - orders 2017-08-18 14-03-36](https://user-images.githubusercontent.com/42868/29458337-d53283d4-841e-11e7-9f2a-111aea01f4ae.png)
