### PR TITLE
Make `Spree::Config` a singleton class

### DIFF
--- a/core/lib/spree/config.rb
+++ b/core/lib/spree/config.rb
@@ -1,0 +1,23 @@
+module Spree
+  class Config
+    def self.instance
+      @@instance || Spree::AppConfiguration.new
+    end
+
+    def self.instance=(value)
+      @@instance = value
+    end
+
+    def self.[](index)
+      Spree::Config.instance[index]
+    end
+
+    def self.[]=(index, value)
+      Spree::Config.instance[index] = value
+    end
+
+    def self.method_missing(method, *args, &block)
+      Spree::Config.instance.send(method, *args, &block)
+    end
+  end
+end

--- a/core/lib/spree/config.rb
+++ b/core/lib/spree/config.rb
@@ -17,7 +17,15 @@ module Spree
     end
 
     def self.method_missing(method, *args, &block)
-      Spree::Config.instance.send(method, *args, &block)
+      if Spree::Config.instance.respond_to?(method, true)
+        Spree::Config.instance.send(method, *args, &block)
+      else
+        super
+      end
+    end
+
+    def self.respond_to_missing?(method, include_private = true)
+      Spree::Config.instance.respond_to?(method, include_private) || super
     end
   end
 end

--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -12,6 +12,7 @@ require 'paranoia'
 require 'ransack'
 require 'state_machines-activerecord'
 
+require 'spree/config'
 require 'spree/deprecation'
 
 # This is required because ActiveModel::Validations#invalid? conflicts with the

--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -41,7 +41,7 @@ module Spree
   # This method is defined within the core gem on purpose.
   # Some people may only wish to use the Core part of Spree.
   def self.config(&_block)
-    yield(Spree::Config)
+    yield(Spree::Config.instance)
   end
 
   module Core

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -10,7 +10,7 @@ module Spree
 
       initializer "spree.environment", before: :load_config_initializers do |app|
         app.config.spree = Spree::Core::Environment.new
-        Spree::Config = app.config.spree.preferences # legacy access
+        Spree::Config.instance = app.config.spree.preferences # legacy access
       end
 
       initializer "spree.default_permissions", before: :load_config_initializers do |_app|

--- a/core/lib/spree/testing_support/preferences.rb
+++ b/core/lib/spree/testing_support/preferences.rb
@@ -15,8 +15,7 @@ module Spree
       end
 
       def configure_spree_preferences
-        config = Rails.application.config.spree.preferences
-        yield(config) if block_given?
+        yield(Spree::Config.instance) if block_given?
       end
 
       def assert_preference_unset(preference)

--- a/core/lib/spree/testing_support/preferences.rb
+++ b/core/lib/spree/testing_support/preferences.rb
@@ -9,8 +9,7 @@ module Spree
       # end
       #
       def reset_spree_preferences(&config_block)
-        Spree::Config.instance_variables.each { |iv| Spree::Config.remove_instance_variable(iv) }
-        Spree::Config.preference_store = Spree::Config.default_preferences
+        Spree::Config.instance = Spree::Core::Environment.new.preferences
 
         configure_spree_preferences(&config_block) if block_given?
       end

--- a/core/spec/models/spree/app_configuration_spec.rb
+++ b/core/spec/models/spree/app_configuration_spec.rb
@@ -13,6 +13,9 @@ describe Spree::AppConfiguration, type: :model do
   it "should be available as Spree::Config for legacy access" do
     expect(Spree::Config.instance).to be_a Spree::AppConfiguration
   end
+
+  it 'should be available for use in a block when `Spree.config` is called' do
+    expect { |some_block| Spree.config(&some_block) }.to yield_with_args Spree::AppConfiguration
   end
 
   it "uses base searcher class by default" do

--- a/core/spec/models/spree/app_configuration_spec.rb
+++ b/core/spec/models/spree/app_configuration_spec.rb
@@ -8,8 +8,11 @@ describe Spree::AppConfiguration, type: :model do
     expect(prefs.layout).to eq "my/layout"
   end
 
+  # Spree::Config#method_missing forwards calls to Spree::Config.instance
+  # Callers don't need to know about .instance
   it "should be available as Spree::Config for legacy access" do
-    expect(Spree::Config).to be_a Spree::AppConfiguration
+    expect(Spree::Config.instance).to be_a Spree::AppConfiguration
+  end
   end
 
   it "uses base searcher class by default" do


### PR DESCRIPTION
At the moment `Spree::Config` is a constant that is being assigned as an instance of `Spree::Core::Environment.new.preferences`. Using a singleton object here is a more reasonable approach. 

`Spree::Config.instance` is the actual `Spree::AppConfiguration`. Also note that `Spree::Config#method_missing` forwards calls to `Spree::Config.instance` so `Spree::Config` can continue to be used the same way as before.


