### PR TITLE
Change product's price color away from link color

### DIFF
--- a/frontend/app/assets/stylesheets/spree/frontend/_variables.scss
+++ b/frontend/app/assets/stylesheets/spree/frontend/_variables.scss
@@ -12,6 +12,7 @@ $link_text_color:           #00ADEE !default;
 $product_background_color:  #FFFFFF !default;
 $product_title_text_color:  #404042 !default;
 $product_body_text_color:   #404042 !default;
+$product_price_text_color:  #252525 !default;
 $product_link_text_color:   #BBBBBB !default;
 
 /*--------------------------------------*/

--- a/frontend/app/assets/stylesheets/spree/frontend/screen.css.scss
+++ b/frontend/app/assets/stylesheets/spree/frontend/screen.css.scss
@@ -452,7 +452,7 @@ nav#taxonomies {
 
 %price_text {
   font-weight: bold;
-  color: $link_text_color;
+  color: $product_price_text_color;
 }
 
 span.price {
@@ -520,7 +520,7 @@ ul#products {
     }
 
     .price {
-      color: $link_text_color;
+      color: $product_price_text_color;
       font-size: $product_list_price_font_size;
       padding-top: 5px;
       display: block;


### PR DESCRIPTION
  - price on products page has a link color but it is not a link
  - links should be distinct to improve usability
  - chosen color variable product_body_text_color



