### PR TITLE
Check if user_id is already set (with regression spec)

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/views/order/customer_details.js
+++ b/backend/app/assets/javascripts/spree/backend/views/order/customer_details.js
@@ -53,7 +53,7 @@ Spree.Views.Order.CustomerDetails = Backbone.View.extend({
   },
 
   render: function() {
-    var user_id = this.model.get("user_id")
+    var user_id = this.model.get("user_id") || $("#user_id").val()
     this.$("#user_id").val(user_id);
     this.$('#guest_checkout_true')
       .prop("checked", !user_id);
@@ -65,4 +65,3 @@ Spree.Views.Order.CustomerDetails = Backbone.View.extend({
     this.$('#order_email').val(this.model.get("email"))
   }
 })
-

--- a/backend/spec/features/admin/orders/customer_details_spec.rb
+++ b/backend/spec/features/admin/orders/customer_details_spec.rb
@@ -48,6 +48,13 @@ describe "Customer Details", type: :feature, js: true do
       expect(Spree::Order.last.user).not_to be_nil
     end
 
+    # Regression test for https://github.com/solidusio/solidus/pull/2176
+    it "does not reset guest checkout to true when returning to customer tab" do
+      click_button "Update"
+      click_link "Customer"
+      expect(find('#guest_checkout_true')).not_to be_checked
+    end
+
     context "when required quantity is more than available" do
       let(:quantity) { 11 }
       let!(:product) { create(:product_not_backorderable) }


### PR DESCRIPTION
From #2145. This is @ericsaupe's commit modified to include the regression spec.


Original PR
----------------
When the page is rendered the value of #user_id is set and the Backbone
render was resetting that. This changes the render to fallback to that
value if the model doesn't have the user_id already present.