### PR TITLE
Capitalize event buttons in `OrdersHelper`

### DIFF
--- a/backend/spec/features/admin/orders/cancelling_and_resuming_spec.rb
+++ b/backend/spec/features/admin/orders/cancelling_and_resuming_spec.rb
@@ -21,7 +21,7 @@ describe "Cancelling + Resuming", type: :feature do
 
   it "can cancel an order" do
     visit spree.edit_admin_order_path(order.number)
-    click_button 'cancel'
+    click_button 'Cancel'
     within(".additional-info") do
       expect(find('dt#order_status + dd')).to have_content("Canceled")
     end
@@ -34,7 +34,7 @@ describe "Cancelling + Resuming", type: :feature do
 
     it "can resume an order" do
       visit spree.edit_admin_order_path(order.number)
-      click_button 'resume'
+      click_button 'Resume'
       within(".additional-info") do
         expect(find('dt#order_status + dd')).to have_content("Resumed")
       end

--- a/backend/spec/features/admin/orders/risk_analysis_spec.rb
+++ b/backend/spec/features/admin/orders/risk_analysis_spec.rb
@@ -28,7 +28,7 @@ describe 'Order Risk Analysis', type: :feature do
     end
 
     it "can be approved" do
-      click_button('approve')
+      click_button('Approve')
       expect(page).to have_content 'Approver'
       expect(page).to have_content 'Approved at'
       expect(page).to have_content 'Status: Complete'

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -982,7 +982,7 @@ en:
     analytics_trackers: Analytics Trackers
     and: and
     apply_code: Apply Code
-    approve: approve
+    approve: Approve
     approver: Approver
     approved_at: Approved at
     are_you_sure: Are you sure?
@@ -1046,7 +1046,7 @@ en:
     calculated_reimbursements: Calculated Reimbursements
     calculator: Calculator
     calculator_settings_warning: If you are changing the calculator type or preference source, you must save first before you can edit the calculator settings
-    cancel: cancel
+    cancel: Cancel
     cancel_inventory: 'Cancel Items'
     canceled: canceled
     canceled_at: Canceled at
@@ -1772,7 +1772,7 @@ en:
     reset_password: Reset my password
     response_code: Response Code
     restock_inventory: Restock Inventory
-    resume: resume
+    resume: Resume
     resumed: Resumed
     return: return
     return_authorization: Return Merchandise Authorization


### PR DESCRIPTION
![lowercase-order-buttons](https://user-images.githubusercontent.com/11495200/29583096-d1a4485c-8733-11e7-83d6-30e5be21c8db.png)

These seem to be the only buttons that are not capitalized in the
backend. They look especially weird since they can sit beside the
"Resend" button which is capitalized.

**Edit**: This only changes the translation values in `en.yml`. They don't appear to be used anywhere else. The one problem with this approach is that the [alert text that is generated](https://github.com/solidusio/solidus/blob/master/backend/app/helpers/spree/admin/orders_helper.rb#L11) will have the order event capitalized (e.g "Are you sure you want to Cancel this order?"). I think having an "errant" capitalization in the alert text is more desirable than lowercase button text.