### PR TITLE
Remove extra error on StoreCredit

### DIFF
--- a/core/app/models/spree/store_credit.rb
+++ b/core/app/models/spree/store_credit.rb
@@ -66,7 +66,6 @@ class Spree::StoreCredit < Spree::PaymentSource
       })
       authorization_code
     else
-      errors.add(:base, Spree.t('store_credit.insufficient_authorized_amount'))
       false
     end
   end


### PR DESCRIPTION
The code in `StoreCredit#validate_authorization` already adds errors to the
StoreCredit, so this error is not needed and it may be incorrect if the error
was for something else (like a mismatched currency).