### PR TITLE
Move API pagination into a common partial

### DIFF
--- a/api/app/views/spree/api/countries/index.json.jbuilder
+++ b/api/app/views/spree/api/countries/index.json.jbuilder
@@ -1,4 +1,2 @@
 json.countries(@countries) { |country| json.(country, *country_attributes) }
-json.count(@countries.count)
-json.current_page(@countries.current_page)
-json.pages(@countries.total_pages)
+json.partial! 'spree/api/shared/pagination', pagination: @countries

--- a/api/app/views/spree/api/credit_cards/index.json.jbuilder
+++ b/api/app/views/spree/api/credit_cards/index.json.jbuilder
@@ -1,6 +1,4 @@
 json.credit_cards(@credit_cards) do |credit_card|
   json.partial!("spree/api/credit_cards/credit_card", credit_card: credit_card)
 end
-json.count(@credit_cards.count)
-json.current_page(@credit_cards.current_page)
-json.pages(@credit_cards.total_pages)
+json.partial! 'spree/api/shared/pagination', pagination: @credit_cards

--- a/api/app/views/spree/api/orders/index.json.jbuilder
+++ b/api/app/views/spree/api/orders/index.json.jbuilder
@@ -1,6 +1,4 @@
 json.orders(@orders) do |order|
   json.partial!("spree/api/orders/order", order: order)
 end
-json.count(@orders.count)
-json.current_page(@orders.current_page)
-json.pages(@orders.total_pages)
+json.partial! 'spree/api/shared/pagination', pagination: @orders

--- a/api/app/views/spree/api/orders/mine.json.jbuilder
+++ b/api/app/views/spree/api/orders/mine.json.jbuilder
@@ -1,6 +1,4 @@
 json.orders(@orders) do |order|
   json.partial!("spree/api/orders/big", order: order)
 end
-json.count(@orders.count)
-json.current_page(@orders.current_page)
-json.pages(@orders.total_pages)
+json.partial! 'spree/api/shared/pagination', pagination: @orders

--- a/api/app/views/spree/api/payments/index.json.jbuilder
+++ b/api/app/views/spree/api/payments/index.json.jbuilder
@@ -1,4 +1,2 @@
 json.payments(@payments) { |payment| json.(payment, *payment_attributes) }
-json.count(@payments.count)
-json.current_page(@payments.current_page)
-json.pages(@payments.total_pages)
+json.partial! 'spree/api/shared/pagination', pagination: @payments

--- a/api/app/views/spree/api/product_properties/index.json.jbuilder
+++ b/api/app/views/spree/api/product_properties/index.json.jbuilder
@@ -1,6 +1,4 @@
 json.product_properties(@product_properties) do |product_property|
   json.(product_property, *product_property_attributes)
 end
-json.count(@product_properties.count)
-json.current_page(@product_properties.current_page)
-json.pages(@product_properties.total_pages)
+json.partial! 'spree/api/shared/pagination', pagination: @product_properties

--- a/api/app/views/spree/api/products/index.json.jbuilder
+++ b/api/app/views/spree/api/products/index.json.jbuilder
@@ -1,8 +1,4 @@
-json.count(@products.size)
-json.total_count(@products.total_count)
-json.current_page(@products.current_page)
-json.per_page(@products.limit_value)
-json.pages(@products.total_pages)
+json.partial! 'spree/api/shared/pagination', pagination: @products
 json.products(@products) do |product|
   json.partial!("spree/api/products/product", product: product)
 end

--- a/api/app/views/spree/api/properties/index.json.jbuilder
+++ b/api/app/views/spree/api/properties/index.json.jbuilder
@@ -1,6 +1,4 @@
 json.properties(@properties) do |property|
   json.(property, *property_attributes)
 end
-json.count(@properties.count)
-json.current_page(@properties.current_page)
-json.pages(@properties.total_pages)
+json.partial! 'spree/api/shared/pagination', pagination: @properties

--- a/api/app/views/spree/api/return_authorizations/index.json.jbuilder
+++ b/api/app/views/spree/api/return_authorizations/index.json.jbuilder
@@ -1,6 +1,4 @@
 json.return_authorizations(@return_authorizations) do |return_authorization|
   json.(return_authorization, *return_authorization_attributes)
 end
-json.count(@return_authorizations.count)
-json.current_page(@return_authorizations.current_page)
-json.pages(@return_authorizations.total_pages)
+json.partial! 'spree/api/shared/pagination', pagination: @return_authorizations

--- a/api/app/views/spree/api/shared/_pagination.json.jbuilder
+++ b/api/app/views/spree/api/shared/_pagination.json.jbuilder
@@ -1,0 +1,5 @@
+json.count        pagination.count
+json.total_count  pagination.total_count
+json.current_page pagination.current_page
+json.pages        pagination.total_pages
+json.per_page     pagination.limit_value

--- a/api/app/views/spree/api/shipments/mine.json.jbuilder
+++ b/api/app/views/spree/api/shipments/mine.json.jbuilder
@@ -1,6 +1,4 @@
-json.count(@shipments.count)
-json.current_page(@shipments.current_page)
-json.pages(@shipments.total_pages)
+json.partial! 'spree/api/shared/pagination', pagination: @shipments
 json.shipments(@shipments) do |shipment|
   json.partial!("spree/api/shipments/big", shipment: shipment)
 end

--- a/api/app/views/spree/api/states/index.json.jbuilder
+++ b/api/app/views/spree/api/states/index.json.jbuilder
@@ -1,7 +1,5 @@
 json.states_required(@country.states_required) if @country
 json.states(@states) { |state| json.(state, *state_attributes) }
 if @states.respond_to?(:total_pages)
-  json.count(@states.count)
-  json.current_page(@states.current_page)
-  json.pages(@states.total_pages)
+  json.partial! 'spree/api/shared/pagination', pagination: @states
 end

--- a/api/app/views/spree/api/stock_items/index.json.jbuilder
+++ b/api/app/views/spree/api/stock_items/index.json.jbuilder
@@ -1,6 +1,4 @@
 json.stock_items(@stock_items) do |stock_item|
   json.partial!("spree/api/stock_items/stock_item", stock_item: stock_item)
 end
-json.count(@stock_items.count)
-json.current_page(@stock_items.current_page)
-json.pages(@stock_items.total_pages)
+json.partial! 'spree/api/shared/pagination', pagination: @stock_items

--- a/api/app/views/spree/api/stock_locations/index.json.jbuilder
+++ b/api/app/views/spree/api/stock_locations/index.json.jbuilder
@@ -1,6 +1,4 @@
 json.stock_locations(@stock_locations) do |stock_location|
   json.partial!("spree/api/stock_locations/stock_location", stock_location: stock_location)
 end
-json.count(@stock_locations.count)
-json.current_page(@stock_locations.current_page)
-json.pages(@stock_locations.total_pages)
+json.partial! 'spree/api/shared/pagination', pagination: @stock_locations

--- a/api/app/views/spree/api/stock_movements/index.json.jbuilder
+++ b/api/app/views/spree/api/stock_movements/index.json.jbuilder
@@ -1,6 +1,4 @@
 json.stock_movements(@stock_movements) do |stock_movement|
   json.partial!("spree/api/stock_movements/stock_movement", stock_movement: stock_movement)
 end
-json.count(@stock_movements.count)
-json.current_page(@stock_movements.current_page)
-json.pages(@stock_movements.total_pages)
+json.partial! 'spree/api/shared/pagination', pagination: @stock_movements

--- a/api/app/views/spree/api/store_credit_events/mine.json.jbuilder
+++ b/api/app/views/spree/api/store_credit_events/mine.json.jbuilder
@@ -2,6 +2,4 @@ json.store_credit_events(@store_credit_events) do |store_credit_event|
   json.(store_credit_event, *store_credit_history_attributes)
   json.order_number(store_credit_event.order.try(:number))
 end
-json.count(@store_credit_events.count)
-json.current_page(@store_credit_events.current_page)
-json.pages(@store_credit_events.total_pages)
+json.partial! 'spree/api/shared/pagination', pagination: @store_credit_events

--- a/api/app/views/spree/api/taxonomies/index.json.jbuilder
+++ b/api/app/views/spree/api/taxonomies/index.json.jbuilder
@@ -1,6 +1,4 @@
 json.taxonomies(@taxonomies) do |taxonomy|
   json.partial!("spree/api/taxonomies/taxonomy", taxonomy: taxonomy)
 end
-json.count(@taxonomies.count)
-json.current_page(@taxonomies.current_page)
-json.pages(@taxonomies.total_pages)
+json.partial! 'spree/api/shared/pagination', pagination: @taxonomies

--- a/api/app/views/spree/api/taxons/index.json.jbuilder
+++ b/api/app/views/spree/api/taxons/index.json.jbuilder
@@ -1,8 +1,4 @@
-json.count(@taxons.count)
-json.total_count(@taxons.total_count)
-json.current_page(@taxons.current_page)
-json.per_page(@taxons.limit_value)
-json.pages(@taxons.total_pages)
+json.partial! 'spree/api/shared/pagination', pagination: @taxons
 json.taxons(@taxons) do |taxon|
   json.(taxon, *taxon_attributes)
   unless params[:without_children]

--- a/api/app/views/spree/api/users/index.json.jbuilder
+++ b/api/app/views/spree/api/users/index.json.jbuilder
@@ -1,6 +1,4 @@
 json.users(@users) do |user|
   json.partial!("spree/api/users/user", user: user)
 end
-json.count(@users.count)
-json.current_page(@users.current_page)
-json.pages(@users.total_pages)
+json.partial! 'spree/api/shared/pagination', pagination: @users

--- a/api/app/views/spree/api/variants/index.json.jbuilder
+++ b/api/app/views/spree/api/variants/index.json.jbuilder
@@ -1,7 +1,4 @@
-json.count(@variants.count)
-json.total_count(@variants.total_count)
-json.current_page(@variants.current_page)
-json.pages(@variants.total_pages)
+json.partial! 'spree/api/shared/pagination', pagination: @variants
 json.variants(@variants) do |variant|
   json.partial!("spree/api/variants/big", variant: variant)
 end

--- a/api/app/views/spree/api/zones/index.json.jbuilder
+++ b/api/app/views/spree/api/zones/index.json.jbuilder
@@ -1,6 +1,4 @@
 json.zones(@zones) do |zone|
   json.partial!("spree/api/zones/zone", zone: zone)
 end
-json.count(@zones.count)
-json.current_page(@zones.current_page)
-json.pages(@zones.total_pages)
+json.partial! 'spree/api/shared/pagination', pagination: @zones

--- a/api/spec/requests/spree/api/states_controller_spec.rb
+++ b/api/spec/requests/spree/api/states_controller_spec.rb
@@ -27,6 +27,7 @@ module Spree
         create(:state)
         get spree.api_states_path, params: { page: 2, per_page: 1 }
 
+        expect(json_response).to be_paginated
         expect(json_response["states"].size).to eq(1)
         expect(json_response["pages"]).to eq(2)
         expect(json_response["current_page"]).to eq(2)

--- a/api/spec/support/be_paginated_matcher.rb
+++ b/api/spec/support/be_paginated_matcher.rb
@@ -1,0 +1,7 @@
+RSpec::Matchers.define :be_paginated do
+  match do |actual|
+    %w[count total_count current_page pages per_page].all? do |attr|
+      actual[attr].is_a?(Integer)
+    end
+  end
+end


### PR DESCRIPTION
Previously, pagination was handled individually by each index partial, which led to some inconsistencies.

This PR adds a `spree/api/shared/pagination.json.jbuilder` partial which is passed a paginated collection and renders the pagination attributes.

This doesn't change any existing attributes, but some endpoints will now have `per_page` and `total_count`, which were missing previously.