### PR TITLE
Fix backend data-action across multiple files

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/number_field_updater.coffee
+++ b/backend/app/assets/javascripts/spree/backend/number_field_updater.coffee
@@ -24,7 +24,7 @@ class NumberFieldUpdater
     $("#number-update-#{id} span").css('display', cssDisplay)
 
   toggleForm = (id, show) ->
-    toggleButtonVisibility('void', id, show)
+    toggleButtonVisibility('cancel', id, show)
     toggleButtonVisibility('check', id, show)
     cssDisplay = if show then 'block' else 'none'
     $("#number-update-#{id} input[type='number']").css('display', cssDisplay)

--- a/backend/app/assets/javascripts/spree/backend/number_field_updater.coffee
+++ b/backend/app/assets/javascripts/spree/backend/number_field_updater.coffee
@@ -19,19 +19,19 @@ class NumberFieldUpdater
 
   toggleReadOnly = (id, show) ->
     toggleButtonVisibility('edit', id, show)
-    toggleButtonVisibility('trash', id, show)
+    toggleButtonVisibility('remove', id, show)
     cssDisplay = if show then 'block' else 'none'
     $("#number-update-#{id} span").css('display', cssDisplay)
 
   toggleForm = (id, show) ->
     toggleButtonVisibility('cancel', id, show)
-    toggleButtonVisibility('check', id, show)
+    toggleButtonVisibility('save', id, show)
     cssDisplay = if show then 'block' else 'none'
     $("#number-update-#{id} input[type='number']").css('display', cssDisplay)
 
-  toggleButtonVisibility = (buttonIcon, id, show) ->
+  toggleButtonVisibility = (buttonAction, id, show) ->
     cssDisplay = if show then 'inline-block' else 'none'
-    $(".fa-#{buttonIcon}[data-id='#{id}']").css('display', cssDisplay)
+    $("[data-action='#{buttonAction}'][data-id='#{id}']").css('display', cssDisplay)
 
   resetInput = (id) ->
     tableCell = $("#number-update-#{id}")

--- a/backend/app/assets/javascripts/spree/backend/stock_transfers/count_update_forms.coffee
+++ b/backend/app/assets/javascripts/spree/backend/stock_transfers/count_update_forms.coffee
@@ -1,21 +1,21 @@
 class CountUpdateForms
   @beginListening: (isReceiving) ->
     # Edit
-    $('body').on 'click', '#listing_transfer_items .fa-edit', (ev) =>
+    $('body').on 'click', '#listing_transfer_items [data-action="edit"]', (ev) =>
       ev.preventDefault()
       transferItemId = $(ev.currentTarget).data('id')
       Spree.NumberFieldUpdater.hideReadOnly(transferItemId)
       Spree.NumberFieldUpdater.showForm(transferItemId)
 
     # Cancel
-    $('body').on 'click', '#listing_transfer_items .fa-void', (ev) =>
+    $('body').on 'click', '#listing_transfer_items [data-action="cancel"]', (ev) =>
       ev.preventDefault()
       transferItemId = $(ev.currentTarget).data('id')
       Spree.NumberFieldUpdater.hideForm(transferItemId)
       Spree.NumberFieldUpdater.showReadOnly(transferItemId)
 
     # Submit
-    $('body').on 'click', '#listing_transfer_items .fa-check', (ev) =>
+    $('body').on 'click', '#listing_transfer_items [data-action="save"]', (ev) =>
       ev.preventDefault()
       transferItemId = $(ev.currentTarget).data('id')
       stockTransferNumber = $("#stock_transfer_number").val()

--- a/backend/app/assets/javascripts/spree/backend/stock_transfers/transfer_item_deleting.coffee
+++ b/backend/app/assets/javascripts/spree/backend/stock_transfers/transfer_item_deleting.coffee
@@ -1,6 +1,6 @@
 class TransferItemDeleting
   @beginListening: ->
-    $('body').on 'click', '#listing_transfer_items .fa-trash', (ev) =>
+    $('body').on 'click', '#listing_transfer_items [data-action="remove"]', (ev) =>
       ev.preventDefault()
       if confirm(Spree.translations.are_you_sure_delete)
         transferItemId = $(ev.currentTarget).data('id')

--- a/backend/app/assets/javascripts/spree/backend/templates/stock_items/stock_location_stock_item.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/stock_items/stock_location_stock_item.hbs
@@ -18,7 +18,7 @@
 <td class="actions">
   {{#if editing}}
     <a class="submit fa fa-check icon_link with-tip no-text" data-action="green" href="#"></a>
-    <a class="cancel fa fa-void icon_link with-tip no-text" data-action="red" href="#"></a>
+    <a class="cancel fa fa-cancel icon_link with-tip no-text" data-action="red" href="#"></a>
   {{else}}
     <a class="edit fa fa-edit icon_link with-tip no-text" data-action="edit" href="#"></a>
   {{/if}}

--- a/backend/app/assets/javascripts/spree/backend/templates/stock_items/stock_location_stock_item.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/stock_items/stock_location_stock_item.hbs
@@ -17,8 +17,8 @@
 </td>
 <td class="actions">
   {{#if editing}}
-    <a class="submit fa fa-check icon_link with-tip no-text" data-action="green" href="#"></a>
-    <a class="cancel fa fa-cancel icon_link with-tip no-text" data-action="red" href="#"></a>
+    <a class="submit fa fa-check icon_link with-tip no-text" data-action="save" href="#"></a>
+    <a class="cancel fa fa-cancel icon_link with-tip no-text" data-action="cancel" href="#"></a>
   {{else}}
     <a class="edit fa fa-edit icon_link with-tip no-text" data-action="edit" href="#"></a>
   {{/if}}

--- a/backend/app/assets/javascripts/spree/backend/templates/stock_transfers/transfer_item.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/stock_transfers/transfer_item.hbs
@@ -40,7 +40,7 @@
   <td class="actions">
     <a class="fa fa-edit icon_link with-tip no-text" data-action="edit" data-id="{{id}}" href="#"></a>
     <a class="fa fa-check icon_link with-tip no-text" data-action="green" data-id="{{id}}" href="#"></a>
-    <a class="fa fa-void icon_link with-tip no-text" data-action="red" data-id="{{id}}" href="#"></a>
+    <a class="fa fa-cancel icon_link with-tip no-text" data-action="red" data-id="{{id}}" href="#"></a>
     {{#unless isReceiving }}
       <a class="fa fa-trash icon_link with-tip no-text" data-action="remove" data-id="{{id}}" href="#"></a>
     {{/unless}}

--- a/backend/app/assets/javascripts/spree/backend/templates/stock_transfers/transfer_item.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/stock_transfers/transfer_item.hbs
@@ -39,8 +39,8 @@
   </td>
   <td class="actions">
     <a class="fa fa-edit icon_link with-tip no-text" data-action="edit" data-id="{{id}}" href="#"></a>
-    <a class="fa fa-check icon_link with-tip no-text" data-action="green" data-id="{{id}}" href="#"></a>
-    <a class="fa fa-cancel icon_link with-tip no-text" data-action="red" data-id="{{id}}" href="#"></a>
+    <a class="fa fa-check icon_link with-tip no-text" data-action="save" data-id="{{id}}" href="#"></a>
+    <a class="fa fa-cancel icon_link with-tip no-text" data-action="cancel" data-id="{{id}}" href="#"></a>
     {{#unless isReceiving }}
       <a class="fa fa-trash icon_link with-tip no-text" data-action="remove" data-id="{{id}}" href="#"></a>
     {{/unless}}

--- a/backend/app/assets/stylesheets/spree/backend/components/_number_field_update.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_number_field_update.scss
@@ -1,6 +1,6 @@
 .number-field-update-table {
   td.actions {
-    a.fa-void,
+    a.fa-cancel,
     a.fa-check {
       display: none;
     }

--- a/backend/app/views/spree/admin/shared/_number_field_update_actions.html.erb
+++ b/backend/app/views/spree/admin/shared/_number_field_update_actions.html.erb
@@ -1,5 +1,5 @@
 <% if can?(:update, resource) %>
   <%= link_to_with_icon 'edit', Spree.t('actions.edit'), '#', no_text: true, data: { action: 'edit', id: resource.id } %>
   <%= link_to_with_icon 'check', Spree.t('actions.update'), '#', no_text: true, data: update_data.merge(action: 'green', id: resource.id) %>
-  <%= link_to_with_icon 'void', Spree.t('actions.cancel'), '#', no_text: true, data: { action: 'red', id: resource.id } %>
+  <%= link_to_with_icon 'cancel', Spree.t('actions.cancel'), '#', no_text: true, data: { action: 'red', id: resource.id } %>
 <% end %>

--- a/backend/app/views/spree/admin/shared/_number_field_update_actions.html.erb
+++ b/backend/app/views/spree/admin/shared/_number_field_update_actions.html.erb
@@ -1,5 +1,5 @@
 <% if can?(:update, resource) %>
   <%= link_to_with_icon 'edit', Spree.t('actions.edit'), '#', no_text: true, data: { action: 'edit', id: resource.id } %>
-  <%= link_to_with_icon 'check', Spree.t('actions.update'), '#', no_text: true, data: update_data.merge(action: 'green', id: resource.id) %>
-  <%= link_to_with_icon 'cancel', Spree.t('actions.cancel'), '#', no_text: true, data: { action: 'red', id: resource.id } %>
+  <%= link_to_with_icon 'check', Spree.t('actions.update'), '#', no_text: true, data: update_data.merge(action: 'save', id: resource.id) %>
+  <%= link_to_with_icon 'cancel', Spree.t('actions.cancel'), '#', no_text: true, data: { action: 'cancel', id: resource.id } %>
 <% end %>

--- a/backend/app/views/spree/admin/stock_items/_stock_management.html.erb
+++ b/backend/app/views/spree/admin/stock_items/_stock_management.html.erb
@@ -78,7 +78,7 @@
             <%= number_field_tag :count_on_hand, "", class: 'fullwidth', id: "variant-count-on-hand-#{variant.id}" %>
           </td>
           <td class="actions">
-            <%= link_to_with_icon 'plus', Spree.t('actions.create'), '#', no_text: true, data: {action: 'green' }, class: "submit" %>
+            <%= link_to_with_icon 'plus', Spree.t('actions.create'), '#', no_text: true, data: { action: 'add' }, class: "submit" %>
           </td>
         </tr>
       <% end %>

--- a/backend/app/views/spree/admin/stock_transfers/index.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/index.html.erb
@@ -101,11 +101,11 @@
           </td>
           <td class="actions">
             <% if stock_transfer.receivable? && can?(:edit, stock_transfer) %>
-              <%= link_to_with_icon 'download', Spree.t('actions.receive'), receive_admin_stock_transfer_path(stock_transfer), no_text: true, data: { action: 'green' } %>
+              <%= link_to_with_icon 'download', Spree.t('actions.receive'), receive_admin_stock_transfer_path(stock_transfer), no_text: true, data: { action: 'receive' } %>
             <% elsif !stock_transfer.closed? && can?(:edit, stock_transfer) %>
               <%= link_to_with_icon 'edit', Spree.t('actions.edit'), stock_transfer_edit_or_ship_path(stock_transfer), no_text: true, data: { action: 'edit' } %>
             <% elsif can?(:show, stock_transfer) %>
-              <%= link_to_with_icon 'eye', Spree.t(:show), admin_stock_transfer_path(stock_transfer), no_text: true, data: { action: 'green' } %>
+              <%= link_to_with_icon 'eye', Spree.t(:show), admin_stock_transfer_path(stock_transfer), no_text: true, data: { action: 'show' } %>
             <% end %>
           </td>
         </tr>

--- a/backend/app/views/spree/admin/store_credits/show.html.erb
+++ b/backend/app/views/spree/admin/store_credits/show.html.erb
@@ -67,7 +67,7 @@
     <td class='actions'>
       <% if can?(:update, @store_credit) %>
         <%= link_to '', '#', class: 'js-save-memo fa fa-check no-text with-tip', data: { user_id: @user.id, store_credit_id: @store_credit.id, action: 'save' }, title: Spree.t('actions.save') %>
-        <%= link_to '', '#', class: 'js-cancel-memo fa fa-void no-text with-tip', data: { action: 'void' }, title: Spree.t('actions.cancel') %>
+        <%= link_to '', '#', class: 'js-cancel-memo fa fa-cancel no-text with-tip', data: { action: 'cancel' }, title: Spree.t('actions.cancel') %>
       <% end %>
     </td>
   </tr>


### PR DESCRIPTION
In backend there are multiple links with inconsistent `data-action` attributes. 

For example `data-action="red"` or `data-action="green"`, which are both not semantic and do not change tooltip colors when needed (tooltip colors are defined with [actions names](https://github.com/solidusio/solidus/blob/96b30d6f4e644383cfa13fb2dd208bcd3589cb81/backend/app/assets/stylesheets/spree/backend/plugins/_bootstrap_tooltip.scss#L34-L42), not color).

With this PR we also start using these semantic `data-action` into js to target buttons instead of rely on class names that can change in the future, like icons ones (`fa-something`).

The only real effect of this PR on the UI is that buttons and tooltips use the right color now:

### Stock Management

##### Before

<img width="919" alt="stock_cancel_before" src="https://user-images.githubusercontent.com/167946/29637761-6dad87fa-8855-11e7-9533-8f296b995032.png">

##### After

<img width="939" alt="stock_cancel_after" src="https://user-images.githubusercontent.com/167946/29637763-6fb00992-8855-11e7-870e-9462e7071ad4.png">

### Stock Transfer

##### Before

<img width="1161" alt="stock_transfer_cancel_before" src="https://user-images.githubusercontent.com/167946/29637809-98b549e2-8855-11e7-8915-0caf098ba69b.png">
<img width="1174" alt="stock_transfer_save_before" src="https://user-images.githubusercontent.com/167946/29637823-a66add86-8855-11e7-976e-6d1c25a62be1.png">

##### After

<img width="1172" alt="stock_transfer_cancel_after" src="https://user-images.githubusercontent.com/167946/29637832-af242914-8855-11e7-85e0-48a4ac2249c0.png">
<img width="1160" alt="stock_transfer_save_after" src="https://user-images.githubusercontent.com/167946/29637835-b24d043a-8855-11e7-81c3-9cde98950d43.png">



### Store Credits

##### Before

<img width="880" alt="store_credit_cancel_before" src="https://user-images.githubusercontent.com/167946/29637853-c21516d2-8855-11e7-95f3-a97f2fbca322.png">

##### After

<img width="893" alt="store_credit_cancel_after" src="https://user-images.githubusercontent.com/167946/29637863-c6383f14-8855-11e7-8168-193d0d3cd00f.png">
