### PR TITLE
Remove extra set_current_order calls (updated CHANGELOG and rebase)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## Solidus 2.4.0 (master, unreleased)
 
+- Remove `set_current_order` calls in `Spree::Core::ControllerHelpers::Order`
+  [\#2185](https://github.com/solidusio/solidus/pull/2185) ([Murph33](https://github.com/murph33))
+
+  Previously a before filter added in
+  `core/lib/spree/core/controller_helpers/order.rb` would cause SQL queries to
+  be used on almost every request in the frontend. If you do not use Solidus
+  Auth you will need to hook into this helper and call `set_current_order` where
+  your user signs in. This merges incomplete orders a user has going with their
+  current cart. If you do use Solidus Auth you will need to make sure you use a
+  current enough version (>= v1.5.0) that includes this explicit call. This
+  addresses [\#1116](https://github.com/solidusio/solidus/issues/1116).
+
 - Remove `ffaker` as a runtime dependency in production [\#2140](https://github.com/solidusio/solidus/pull/2140) ([cbrunsdon](https://github.com/cbrunsdon))
 
 - Invalidate existing non store credit payments during checkout [2075](https://github.com/solidusio/solidus/pull/2075) ([tvdeyen](https://github.com/tvdeyen))

--- a/api/app/controllers/spree/api/checkouts_controller.rb
+++ b/api/app/controllers/spree/api/checkouts_controller.rb
@@ -12,9 +12,6 @@ module Spree
       # TODO: Remove this after deprecated usage in #update is removed
       include Spree::Core::ControllerHelpers::PaymentParameters
 
-      # This before_action comes from Spree::Core::ControllerHelpers::Order
-      skip_before_action :set_current_order
-
       def next
         authorize! :update, @order, order_token
         if !expected_total_ok?(params[:expected_total])

--- a/core/lib/spree/core/controller_helpers/order.rb
+++ b/core/lib/spree/core/controller_helpers/order.rb
@@ -8,8 +8,6 @@ module Spree
         include ControllerHelpers::Pricing
 
         included do
-          before_action :set_current_order
-
           helper_method :current_order
           helper_method :simple_current_order
         end

--- a/frontend/app/controllers/spree/store_controller.rb
+++ b/frontend/app/controllers/spree/store_controller.rb
@@ -3,8 +3,6 @@ module Spree
     include Spree::Core::ControllerHelpers::Pricing
     include Spree::Core::ControllerHelpers::Order
 
-    skip_before_action :set_current_order, only: :cart_link
-
     def unauthorized
       render 'spree/shared/unauthorized', layout: Spree::Config[:layout], status: 401
     end


### PR DESCRIPTION
This rebases and updates the CHANGELOG entry for @Murph33's #1137.

In the CHANGELOG entry I've included what the "current enough version" of solidus_auth_devise is (the `set_current_order` call was [added in v1.5.0](https://github.com/solidusio/solidus_auth_devise/blob/master/CHANGELOG.md#solidus-auth-devise-v150-2016-07-18). I've also included [the issue it addressed](https://github.com/solidusio/solidus/issues/1116).

Original PR
---------------
Currently this is calling on almost every request in the front end.  We
want to push this to where it should be which is just when we sign in
authentication systems.