### PR TITLE
[WIP]: Fix setting checkout steps context applying coupon codes

### DIFF
--- a/frontend/app/controllers/spree/store_controller.rb
+++ b/frontend/app/controllers/spree/store_controller.rb
@@ -19,6 +19,7 @@ module Spree
     # which needs it)
     def apply_coupon_code
       if params[:order] && params[:order][:coupon_code]
+        Spree::Deprecation.warn("Passing params[:order][:coupon_code] is deprecated and will have no effect in a future version.", caller)
         @order.coupon_code = params[:order][:coupon_code]
 
         handler = PromotionHandler::Coupon.new(@order).apply

--- a/frontend/app/controllers/spree/store_controller.rb
+++ b/frontend/app/controllers/spree/store_controller.rb
@@ -24,6 +24,11 @@ module Spree
         handler = PromotionHandler::Coupon.new(@order).apply
 
         if handler.error.present?
+          # If there are errors applying the coupon code we need to render the
+          # edit view and stop the request execution. Checkout steps need a
+          # setup before rendering the edit view or they will miss some ivars.
+          send(:setup_for_current_state) if respond_to?(:setup_for_current_state, true)
+
           flash.now[:error] = handler.error
           respond_with(@order) { |format| format.html { render :edit } } && return
         elsif handler.success

--- a/frontend/spec/controllers/spree/checkout_controller_spec.rb
+++ b/frontend/spec/controllers/spree/checkout_controller_spec.rb
@@ -429,4 +429,33 @@ describe Spree::CheckoutController, type: :controller do
       post :update, params: { state: "payment" }
     }.to change { order.line_items.to_a.size }.from(1).to(0)
   end
+
+  context 'trying to apply a coupon code' do
+    let(:order) { create(:order_with_line_items, state: 'payment', guest_token: 'a token') }
+    before { cookies.signed[:guest_token] = order.guest_token }
+
+    context "when coupon code is applied" do
+      let(:coupon_code) { "coupon_code" }
+      before { create(:promotion, :with_order_adjustment, code: coupon_code) }
+
+      it "continues checkout flow normally" do
+        put :update, params: { state: order.state, order: { coupon_code: coupon_code } }
+
+        expect(response).to redirect_to(spree.checkout_state_path('confirm'))
+        expect(flash.now[:success]).to eq(Spree.t(:coupon_code_applied))
+      end
+    end
+
+    context 'when coupon code is not applied' do
+      let(:coupon_code) { 'wrong_coupon_code' }
+
+      it "renders edit view and setups current checkout step correctly" do
+        put :update, params: { state: order.state, order: { coupon_code: coupon_code } }
+
+        expect(response).to render_template :edit
+        expect(flash.now[:error]).to eq(Spree.t(:coupon_code_not_found))
+        expect(assigns(:wallet_payment_sources)).to eq [] # empty since user wallet has no saved payment source
+      end
+    end
+  end
 end

--- a/frontend/spec/features/coupon_code_spec.rb
+++ b/frontend/spec/features/coupon_code_spec.rb
@@ -9,7 +9,7 @@ describe "Coupon code promotions", type: :feature, js: true do
   let!(:payment_method) { create(:check_payment_method) }
   let!(:product) { create(:product, name: "RoR Mug", price: 20) }
 
-  context "visitor makes checkout as guest without registration" do
+  context "visitor makes checkout" do
     def create_basic_coupon_promotion(code)
       promotion = create(
         :promotion,
@@ -32,49 +32,50 @@ describe "Coupon code promotions", type: :feature, js: true do
 
     let!(:promotion) { create_basic_coupon_promotion("onetwo") }
 
-    # OrdersController
     context "on the payment page" do
-      before do
-        visit spree.root_path
-        click_link "RoR Mug"
-        click_button "add-to-cart-button"
-        click_button "Checkout"
-        fill_in "order_email", with: "spree@example.com"
-        fill_in "First Name", with: "John"
-        fill_in "Last Name", with: "Smith"
-        fill_in "Street Address", with: "1 John Street"
-        fill_in "City", with: "City of John"
-        fill_in "Zip", with: "01337"
-        select country.name, from: "Country"
-        select state.name, from: "order[bill_address_attributes][state_id]"
-        fill_in "Phone", with: "555-555-5555"
+      context "as guest without registration" do
+        before do
+          visit spree.root_path
+          click_link "RoR Mug"
+          click_button "add-to-cart-button"
+          click_button "Checkout"
+          fill_in "order_email", with: "spree@example.com"
+          fill_in "First Name", with: "John"
+          fill_in "Last Name", with: "Smith"
+          fill_in "Street Address", with: "1 John Street"
+          fill_in "City", with: "City of John"
+          fill_in "Zip", with: "01337"
+          select country.name, from: "Country"
+          select state.name, from: "order[bill_address_attributes][state_id]"
+          fill_in "Phone", with: "555-555-5555"
 
-        # To shipping method screen
-        click_button "Save and Continue"
-        # To payment screen
-        click_button "Save and Continue"
-      end
+          # To shipping method screen
+          click_button "Save and Continue"
+          # To payment screen
+          click_button "Save and Continue"
+        end
 
-      it "informs about an invalid coupon code" do
-        fill_in "order_coupon_code", with: "coupon_codes_rule_man"
-        click_button "Save and Continue"
-        expect(page).to have_content(Spree.t(:coupon_code_not_found))
-      end
+        it "informs about an invalid coupon code" do
+          fill_in "order_coupon_code", with: "coupon_codes_rule_man"
+          click_button "Save and Continue"
+          expect(page).to have_content(Spree.t(:coupon_code_not_found))
+        end
 
-      it "can enter an invalid coupon code, then a real one" do
-        fill_in "order_coupon_code", with: "coupon_codes_rule_man"
-        click_button "Save and Continue"
-        expect(page).to have_content(Spree.t(:coupon_code_not_found))
-        fill_in "order_coupon_code", with: "onetwo"
-        click_button "Save and Continue"
-        expect(page).to have_content("Promotion (Onetwo)   -$10.00")
-      end
-
-      context "with a promotion" do
-        it "applies a promotion to an order" do
+        it "can enter an invalid coupon code, then a real one" do
+          fill_in "order_coupon_code", with: "coupon_codes_rule_man"
+          click_button "Save and Continue"
+          expect(page).to have_content(Spree.t(:coupon_code_not_found))
           fill_in "order_coupon_code", with: "onetwo"
           click_button "Save and Continue"
           expect(page).to have_content("Promotion (Onetwo)   -$10.00")
+        end
+
+        context "with a promotion" do
+          it "applies a promotion to an order" do
+            fill_in "order_coupon_code", with: "onetwo"
+            click_button "Save and Continue"
+            expect(page).to have_content("Promotion (Onetwo)   -$10.00")
+          end
         end
       end
     end


### PR DESCRIPTION
Ref: #2155  

In case of errors applying coupon codes, [the edit view is rendered and controller callbacks execution ends](https://github.com/solidusio/solidus/blob/548b54f4744696ef3c4dcc774639a7f8911583dd/frontend/app/controllers/spree/store_controller.rb#L30). 

But checkout steps specific ivars are set with `setup_for_current_state` callbacks which happens after coupon code application, for example [wallet payments options are set before payment](https://github.com/solidusio/solidus/blob/4ade94e2c9f45bcccd93794336823f9f05bb8ab8/frontend/app/controllers/spree/checkout_controller.rb#L199). 

This PR forces calling `setup_for_current_state` if we are stopping callbacks execution after a coupon application error.  

Since apply_coupon_code is also called from `OrdersController` a `respond_to?` is required to be sure we only call it when needed.
