### PR TITLE
Add eligibility checking to automatic free shipping promotions

### DIFF
--- a/core/app/models/spree/promotion_handler/shipping.rb
+++ b/core/app/models/spree/promotion_handler/shipping.rb
@@ -11,10 +11,12 @@ module Spree
 
       def activate
         connected_promotions.each do |order_promotion|
-          order_promotion.promotion.activate(
-            order: order,
-            promotion_code: order_promotion.promotion_code,
-          )
+          if order_promotion.promotion.eligible?(order)
+            order_promotion.promotion.activate(
+              order: order,
+              promotion_code: order_promotion.promotion_code,
+            )
+          end
         end
 
         not_connected_automatic_promotions.each do |promotion|

--- a/core/app/models/spree/promotion_handler/shipping.rb
+++ b/core/app/models/spree/promotion_handler/shipping.rb
@@ -18,7 +18,9 @@ module Spree
         end
 
         not_connected_automatic_promotions.each do |promotion|
-          promotion.activate(order: order)
+          if promotion.eligible?(order)
+            promotion.activate(order: order)
+          end
         end
       end
 

--- a/core/spec/models/spree/promotion_handler/shipping_spec.rb
+++ b/core/spec/models/spree/promotion_handler/shipping_spec.rb
@@ -13,8 +13,20 @@ module Spree
       context 'with apply_automatically' do
         let!(:promotion) { create(:promotion, apply_automatically: true, promotion_actions: [action]) }
 
-        it "creates the adjustment" do
-          expect { subject.activate }.to change { shipment.adjustments.count }.by(1)
+        context 'for eligible promotion' do
+          it "creates the adjustment" do
+            expect { subject.activate }.to change { shipment.adjustments.count }.by(1)
+          end
+        end
+
+        context 'for ineligible promotion' do
+          let!(:promotion) do
+            create(:promotion, :with_item_total_rule, item_total_threshold_amount: 1_000, apply_automatically: true, promotion_actions: [action])
+          end
+
+          it "does not create the adjustment" do
+            expect { subject.activate }.to change { shipment.adjustments.count }.by(0)
+          end
         end
       end
 

--- a/core/spec/models/spree/promotion_handler/shipping_spec.rb
+++ b/core/spec/models/spree/promotion_handler/shipping_spec.rb
@@ -43,6 +43,22 @@ module Spree
               subject.activate
             }.to change { shipment.adjustments.count }
           end
+
+          context 'when currently ineligible' do
+            let(:promotion) do
+              create(:promotion, :with_item_total_rule, item_total_threshold_amount: 1_000, code: 'freeshipping', promotion_actions: [action])
+            end
+
+            before do
+              order.order_promotions.create!(promotion: promotion, promotion_code: promotion.codes.first)
+            end
+
+            it 'does not adjust the shipment' do
+              expect {
+                subject.activate
+              }.to_not change { shipment.adjustments.count }
+            end
+          end
         end
 
         context 'when not already applied' do


### PR DESCRIPTION
This PR is an alternate fix for issue #1999 since the original one seems to have stalled. 

`Spree::PromotionHandler::FreeShipping` currently does not check whether the promotion is eligible before activating it. This is an issue for automatic promotions as any associated promotion rules (eg. minimum order total) are ignored. 

No problem for non-automatic promotions as they are validated upon activation by other handlers. 