### PR TITLE
Update Solidus to work correctly with non-promotion line-level adjustments

### DIFF
--- a/backend/app/views/spree/admin/customer_returns/index.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/index.html.erb
@@ -15,7 +15,7 @@
     <thead data-hook="customer_return_header">
       <tr>
         <th><%= Spree::CustomerReturn.human_attribute_name(:number) %></th>
-        <th><%= Spree::CustomerReturn.human_attribute_name(:pre_tax_total) %></th>
+        <th><%= Spree::CustomerReturn.human_attribute_name(:total_excluding_vat) %></th>
         <th><%= Spree::CustomerReturn.human_attribute_name(:total) %></th>
         <th><%= Spree::CustomerReturn.human_attribute_name(:created_at) %></th>
         <th><%= Spree::CustomerReturn.human_attribute_name(:reimbursement_status) %></th>
@@ -26,7 +26,7 @@
       <% @customer_returns.each do |customer_return| %>
         <tr id="<%= spree_dom_id(customer_return) %>" data-hook="customer_return_row">
           <td><%= link_to customer_return.number, edit_admin_order_customer_return_path(@order, customer_return) %></td>
-          <td><%= customer_return.display_pre_tax_total.to_html %></td>
+          <td><%= customer_return.display_total_excluding_vat.to_html %></td>
           <td><%= customer_return.display_total.to_html %></td>
           <td><%= pretty_time(customer_return.created_at) %></td>
           <td>

--- a/backend/app/views/spree/admin/return_authorizations/index.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/index.html.erb
@@ -19,7 +19,7 @@
       <tr>
         <th><%= Spree::ReturnAuthorization.human_attribute_name(:number) %></th>
         <th><%= Spree::ReturnAuthorization.human_attribute_name(:state) %></th>
-        <th><%= Spree::ReturnAuthorization.human_attribute_name(:pre_tax_total) %></th>
+        <th><%= Spree::ReturnAuthorization.human_attribute_name(:total_excluding_vat) %></th>
         <th><%= Spree::ReturnAuthorization.human_attribute_name(:created_at) %></th>
         <th class="actions"></th>
       </tr>
@@ -36,7 +36,7 @@
               ) %>
             </span>
           </td>
-          <td><%= return_authorization.display_pre_tax_total.to_html %></td>
+          <td><%= return_authorization.display_total_excluding_vat.to_html %></td>
           <td><%= pretty_time(return_authorization.created_at) %></td>
           <td class="actions">
             <% if can? :update, return_authorization %>

--- a/core/app/models/spree/calculator/default_tax.rb
+++ b/core/app/models/spree/calculator/default_tax.rb
@@ -13,7 +13,7 @@ module Spree
         rate.tax_categories.include?(line_item.tax_category)
       end
 
-      line_items_total = matched_line_items.sum(&:discounted_amount)
+      line_items_total = matched_line_items.sum(&:total_before_tax)
       if rate.included_in_price
         round_to_two_places(line_items_total - ( line_items_total / (1 + rate.amount) ) )
       else
@@ -27,7 +27,7 @@ module Spree
       if rate.included_in_price
         deduced_total_by_rate(item, rate)
       else
-        round_to_two_places(item.discounted_amount * rate.amount)
+        round_to_two_places(item.total_before_tax * rate.amount)
       end
     end
 
@@ -47,7 +47,7 @@ module Spree
 
     def deduced_total_by_rate(item, rate)
       round_to_two_places(
-        rate.amount * item.discounted_amount / (1 + sum_of_included_tax_rates(item))
+        rate.amount * item.total_before_tax / (1 + sum_of_included_tax_rates(item))
       )
     end
 

--- a/core/app/models/spree/calculator/returns/default_refund_amount.rb
+++ b/core/app/models/spree/calculator/returns/default_refund_amount.rb
@@ -16,12 +16,12 @@ module Spree
       end
 
       def weighted_line_item_amount(inventory_unit)
-        inventory_unit.line_item.discounted_amount * percentage_of_line_item(inventory_unit)
+        inventory_unit.line_item.total_before_tax * percentage_of_line_item(inventory_unit)
       end
 
       def percentage_of_order_total(inventory_unit)
-        return 0.0 if inventory_unit.order.discounted_item_amount.zero?
-        weighted_line_item_amount(inventory_unit) / inventory_unit.order.discounted_item_amount
+        return 0.0 if inventory_unit.order.item_total_before_tax.zero?
+        weighted_line_item_amount(inventory_unit) / inventory_unit.order.item_total_before_tax
       end
 
       def percentage_of_line_item(inventory_unit)

--- a/core/app/models/spree/customer_return.rb
+++ b/core/app/models/spree/customer_return.rb
@@ -16,7 +16,8 @@ module Spree
     accepts_nested_attributes_for :return_items
 
     extend DisplayMoney
-    money_methods :pre_tax_total, :total, :amount
+    money_methods :pre_tax_total, :total, :total_excluding_vat, :amount
+    deprecate display_pre_tax_total: :display_total_excluding_vat, deprecator: Spree::Deprecation
 
     delegate :currency, to: :order
     delegate :id, to: :order, prefix: true, allow_nil: true
@@ -25,9 +26,11 @@ module Spree
       return_items.map(&:total).sum
     end
 
-    def pre_tax_total
-      return_items.map(&:pre_tax_amount).sum
+    def total_excluding_vat
+      return_items.map(&:total_excluding_vat).sum
     end
+    alias pre_tax_total total_excluding_vat
+    deprecate pre_tax_total: :total_excluding_vat, deprecator: Spree::Deprecation
 
     def amount
       return_items.sum(:amount)

--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -59,30 +59,37 @@ module Spree
     end
     deprecate discounted_amount: :total_before_tax, deprecator: Spree::Deprecation
 
+    # @return [BigDecimal] the amount of this line item, taking into
+    #   consideration all its adjustments.
+    def total
+      amount + adjustment_total
+    end
+    alias final_amount total
+    deprecate final_amount: :total, deprecator: Spree::Deprecation
+
     # @return [BigDecimal] the amount of this item, taking into consideration
     #   all non-tax adjustments.
     def total_before_tax
       amount + adjustments.select { |a| !a.tax? && a.eligible? }.sum(&:amount)
     end
 
-    # @return [BigDecimal] the amount of this line item, taking into
-    #   consideration all its adjustments.
-    def final_amount
-      amount + adjustment_total
-    end
-    alias total final_amount
-
-    # @return [BigDecimal] the amount of this line item before included tax
+    # @return [BigDecimal] the amount of this line item before VAT tax
     # @note just like `amount`, this does not include any additional tax
-    def pre_tax_amount
+    def total_excluding_vat
       total_before_tax - included_tax_total
     end
+    alias pre_tax_amount total_excluding_vat
+    deprecate pre_tax_amount: :total_excluding_vat, deprecator: Spree::Deprecation
 
     extend Spree::DisplayMoney
-    money_methods :amount, :discounted_amount, :final_amount, :pre_tax_amount, :price,
+    money_methods :amount, :discounted_amount, :price,
                   :included_tax_total, :additional_tax_total,
-                  :total_before_tax
+                  :total, :total_before_tax, :total_excluding_vat
     deprecate display_discounted_amount: :display_total_before_tax, deprecator: Spree::Deprecation
+    alias display_final_amount display_total
+    deprecate display_final_amount: :display_total, deprecator: Spree::Deprecation
+    alias display_pre_tax_amount display_total_excluding_vat
+    deprecate display_pre_tax_amount: :display_total_excluding_vat, deprecator: Spree::Deprecation
     alias discounted_money display_discounted_amount
     deprecate discounted_money: :display_total_before_tax, deprecator: Spree::Deprecation
 

--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -57,6 +57,13 @@ module Spree
     def discounted_amount
       amount + promo_total
     end
+    deprecate discounted_amount: :total_before_tax, deprecator: Spree::Deprecation
+
+    # @return [BigDecimal] the amount of this item, taking into consideration
+    #   all non-tax adjustments.
+    def total_before_tax
+      amount + adjustments.select { |a| !a.tax? && a.eligible? }.sum(&:amount)
+    end
 
     # @return [BigDecimal] the amount of this line item, taking into
     #   consideration all its adjustments.
@@ -68,13 +75,16 @@ module Spree
     # @return [BigDecimal] the amount of this line item before included tax
     # @note just like `amount`, this does not include any additional tax
     def pre_tax_amount
-      discounted_amount - included_tax_total
+      total_before_tax - included_tax_total
     end
 
     extend Spree::DisplayMoney
     money_methods :amount, :discounted_amount, :final_amount, :pre_tax_amount, :price,
-                  :included_tax_total, :additional_tax_total
+                  :included_tax_total, :additional_tax_total,
+                  :total_before_tax
+    deprecate display_discounted_amount: :display_total_before_tax, deprecator: Spree::Deprecation
     alias discounted_money display_discounted_amount
+    deprecate discounted_money: :display_total_before_tax, deprecator: Spree::Deprecation
 
     # @return [Spree::Money] the price of this line item
     alias money_price display_price

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -194,6 +194,11 @@ module Spree
     def discounted_item_amount
       line_items.to_a.sum(&:discounted_amount)
     end
+    deprecate discounted_item_amount: :item_total_before_tax, deprecator: Spree::Deprecation
+
+    def item_total_before_tax
+      line_items.to_a.sum(&:total_before_tax)
+    end
 
     def currency
       self[:currency] || Spree::Config[:currency]

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -185,11 +185,6 @@ module Spree
       line_items.map(&:amount).sum
     end
 
-    # Sum of all line item amounts pre-tax
-    def pre_tax_item_amount
-      line_items.to_a.sum(&:pre_tax_amount)
-    end
-
     # Sum of all line item amounts after promotions, before added tax
     def discounted_item_amount
       line_items.to_a.sum(&:discounted_amount)
@@ -199,6 +194,13 @@ module Spree
     def item_total_before_tax
       line_items.to_a.sum(&:total_before_tax)
     end
+
+    # Sum of all line item amounts pre-tax
+    def item_total_excluding_vat
+      line_items.to_a.sum(&:total_excluding_vat)
+    end
+    alias pre_tax_item_amount item_total_excluding_vat
+    deprecate pre_tax_item_amount: :item_total_excluding_vat, deprecator: Spree::Deprecation
 
     def currency
       self[:currency] || Spree::Config[:currency]

--- a/core/app/models/spree/return_authorization.rb
+++ b/core/app/models/spree/return_authorization.rb
@@ -46,7 +46,7 @@ module Spree
     end
 
     def refundable_amount
-      order.discounted_item_amount + order.promo_total
+      order.item_total_before_tax + order.promo_total
     end
 
     def customer_returned_items?

--- a/core/app/models/spree/return_authorization.rb
+++ b/core/app/models/spree/return_authorization.rb
@@ -29,13 +29,16 @@ module Spree
     end
 
     extend DisplayMoney
-    money_methods :pre_tax_total, :amount
+    money_methods :pre_tax_total, :amount, :total_excluding_vat
+    deprecate display_pre_tax_total: :display_total_excluding_vat, deprecator: Spree::Deprecation
 
     self.whitelisted_ransackable_attributes = ['memo']
 
-    def pre_tax_total
-      return_items.map(&:pre_tax_amount).sum
+    def total_excluding_vat
+      return_items.map(&:total_excluding_vat).sum
     end
+    alias pre_tax_total total_excluding_vat
+    deprecate pre_tax_total: :total_excluding_vat, deprecator: Spree::Deprecation
 
     def amount
       return_items.sum(:amount)

--- a/core/app/models/spree/return_item.rb
+++ b/core/app/models/spree/return_item.rb
@@ -93,7 +93,8 @@ module Spree
     end
 
     extend DisplayMoney
-    money_methods :pre_tax_amount, :amount, :total
+    money_methods :pre_tax_amount, :amount, :total, :total_excluding_vat
+    deprecate display_pre_tax_amount: :display_total_excluding_vat, deprecator: Spree::Deprecation
 
     # @return [Boolean] true when this retur item is in a complete reception
     #   state
@@ -159,10 +160,12 @@ module Spree
       amount + additional_tax_total
     end
 
-    # @return [BigDecimal] the cost of the item before tax
-    def pre_tax_amount
+    # @return [BigDecimal] the cost of the item before VAT tax
+    def total_excluding_vat
       amount - included_tax_total
     end
+    alias pre_tax_amount total_excluding_vat
+    deprecate pre_tax_amount: :total_excluding_vat, deprecator: Spree::Deprecation
 
     # @note This uses the exchange_variant_engine configured on the class.
     # @param stock_locations [Array<Spree::StockLocation>] the stock locations to check

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -91,9 +91,10 @@ module Spree
     extend DisplayMoney
     money_methods(
       :cost, :amount, :discounted_cost, :final_price, :item_cost,
-      :total_before_tax,
+      :total, :total_before_tax,
     )
     deprecate display_discounted_cost: :display_total_before_tax, deprecator: Spree::Deprecation
+    deprecate display_final_price: :display_total, deprecator: Spree::Deprecation
     alias_attribute :amount, :cost
 
     def add_shipping_method(shipping_method, selected = false)
@@ -124,19 +125,33 @@ module Spree
     alias discounted_amount discounted_cost
     deprecate discounted_amount: :total_before_tax, deprecator: Spree::Deprecation
 
+    # @return [BigDecimal] the amount of this shipment, taking into
+    #   consideration all its adjustments.
+    def total
+      cost + adjustment_total
+    end
+    alias final_price total
+    deprecate final_price: :total, deprecator: Spree::Deprecation
+
     # @return [BigDecimal] the amount of this item, taking into consideration
     #   all non-tax adjustments.
     def total_before_tax
       amount + adjustments.select { |a| !a.tax? && a.eligible? }.sum(&:amount)
     end
 
-    def final_price
-      cost + adjustment_total
+    # @return [BigDecimal] the amount of this shipment before VAT tax
+    # @note just like `cost`, this does not include any additional tax
+    def total_excluding_vat
+      total_before_tax - included_tax_total
     end
+    alias pre_tax_amount total_excluding_vat
+    deprecate pre_tax_amount: :total_excluding_vat, deprecator: Spree::Deprecation
 
-    def final_price_with_items
-      item_cost + final_price
+    def total_with_items
+      total + item_cost
     end
+    alias final_price_with_items total_with_items
+    deprecate final_price_with_items: :total_with_items, deprecator: Spree::Deprecation
 
     def editable_by?(_user)
       !shipped?
@@ -168,15 +183,11 @@ module Spree
     end
 
     def item_cost
-      line_items.map(&:final_amount).sum
+      line_items.map(&:total).sum
     end
 
     def line_items
       inventory_units.includes(:line_item).map(&:line_item).uniq
-    end
-
-    def pre_tax_amount
-      total_before_tax - included_tax_total
     end
 
     def ready_or_pending?

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -89,7 +89,11 @@ module Spree
     end
 
     extend DisplayMoney
-    money_methods :cost, :amount, :discounted_cost, :final_price, :item_cost
+    money_methods(
+      :cost, :amount, :discounted_cost, :final_price, :item_cost,
+      :total_before_tax,
+    )
+    deprecate display_discounted_cost: :display_total_before_tax, deprecator: Spree::Deprecation
     alias_attribute :amount, :cost
 
     def add_shipping_method(shipping_method, selected = false)
@@ -116,10 +120,14 @@ module Spree
     def discounted_cost
       cost + promo_total
     end
+    deprecate discounted_cost: :total_before_tax, deprecator: Spree::Deprecation
     alias discounted_amount discounted_cost
+    deprecate discounted_amount: :total_before_tax, deprecator: Spree::Deprecation
 
-    def editable_by?(_user)
-      !shipped?
+    # @return [BigDecimal] the amount of this item, taking into consideration
+    #   all non-tax adjustments.
+    def total_before_tax
+      amount + adjustments.select { |a| !a.tax? && a.eligible? }.sum(&:amount)
     end
 
     def final_price
@@ -128,6 +136,10 @@ module Spree
 
     def final_price_with_items
       item_cost + final_price
+    end
+
+    def editable_by?(_user)
+      !shipped?
     end
 
     # Decrement the stock counts for all pending inventory units in this
@@ -164,7 +176,7 @@ module Spree
     end
 
     def pre_tax_amount
-      discounted_amount - included_tax_total
+      total_before_tax - included_tax_total
     end
 
     def ready_or_pending?

--- a/core/app/models/spree/shipping_rate.rb
+++ b/core/app/models/spree/shipping_rate.rb
@@ -17,6 +17,8 @@ module Spree
     alias_attribute :amount, :cost
 
     alias_method :discounted_amount, :amount
+    deprecate discounted_amount: :total_before_tax, deprecator: Spree::Deprecation
+    alias_method :total_before_tax, :amount
 
     extend DisplayMoney
     money_methods :amount

--- a/core/app/views/spree/order_mailer/confirm_email.html.erb
+++ b/core/app/views/spree/order_mailer/confirm_email.html.erb
@@ -45,7 +45,7 @@
           <tr>
             <td></td>
             <td><%= Spree.t(:shipping) %> <%= name %>:</td>
-            <td><%= Spree::Money.new(shipments.sum(&:discounted_cost), currency: @order.currency) %></td>
+            <td><%= Spree::Money.new(shipments.sum(&:total_before_tax), currency: @order.currency) %></td>
           </tr>
         <% end %>
         <% if @order.all_adjustments.eligible.tax.exists? %>

--- a/core/app/views/spree/order_mailer/confirm_email.text.erb
+++ b/core/app/views/spree/order_mailer/confirm_email.text.erb
@@ -19,7 +19,7 @@
 <% end %>
 
 <% @order.shipments.group_by { |s| s.selected_shipping_rate.try(:name) }.each do |name, shipments| %>
-<%= Spree.t(:shipping) %>: <%= name %> <%= Spree::Money.new(shipments.sum(&:discounted_cost), currency: @order.currency) %>
+<%= Spree.t(:shipping) %>: <%= name %> <%= Spree::Money.new(shipments.sum(&:total_before_tax), currency: @order.currency) %>
 <% end %>
 
 <% if @order.all_adjustments.eligible.tax.exists? %>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -72,6 +72,7 @@ en:
         number: Return Number
         pre_tax_total: Pre-Tax Total
         total: Total
+        total_excluding_vat: Pre-Tax Total
         created_at: "Date/Time"
         reimbursement_status: Reimbursement status
         name: Name
@@ -250,6 +251,7 @@ en:
       spree/return_authorization:
         amount: Amount
         pre_tax_total: Pre-Tax Total
+        total_excluding_vat: Pre-Tax Total
       spree/return_item:
         acceptance_status: Acceptance status
         acceptance_status_errors: Acceptance errors
@@ -2017,6 +2019,7 @@ en:
     to: to
     to_add_variants_you_must_first_define: To add variants, you must first define
     total: Total
+    total_excluding_vat: Pre-Tax Total
     total_per_item: Total per item
     total_pre_tax_refund: Total Pre-Tax Refund
     total_price: Total price

--- a/core/spec/models/spree/calculator/default_tax_spec.rb
+++ b/core/spec/models/spree/calculator/default_tax_spec.rb
@@ -109,7 +109,14 @@ describe Spree::Calculator::DefaultTax, type: :model do
   end
 
   shared_examples_for 'computing any item' do
-    let(:promo_total) { 0 }
+    let(:adjustment_total) { 0 }
+    let(:adjustments) do
+      if adjustment_total.zero?
+        []
+      else
+       [Spree::Adjustment.new(included: false, source: nil, amount: adjustment_total)]
+      end
+    end
     let(:order) { build_stubbed(:order, ship_address: address) }
 
     context "when tax is included in price" do
@@ -129,10 +136,10 @@ describe Spree::Calculator::DefaultTax, type: :model do
           end
         end
 
-        context "when line item is discounted" do
-          let(:promo_total) { -1 }
+        context "when line item is adjusted" do
+          let(:adjustment_total) { -1 }
 
-          it "should be equal to the item's discounted total * rate" do
+          it "should be equal to the item's adjusted total * rate" do
             expect(calculator.compute(item)).to eql 1.38
           end
         end
@@ -140,8 +147,8 @@ describe Spree::Calculator::DefaultTax, type: :model do
     end
 
     context "when tax is not included in price" do
-      context "when the line item is discounted" do
-        let(:promo_total) { -1 }
+      context "when the item has an adjustment" do
+        let(:adjustment_total) { -1 }
 
         it "should be equal to the item's pre-tax total * rate" do
           expect(calculator.compute(item)).to eq(1.45)
@@ -180,7 +187,7 @@ describe Spree::Calculator::DefaultTax, type: :model do
         :line_item,
         price: 10,
         quantity: 3,
-        promo_total: promo_total,
+        adjustments: adjustments,
         order: order,
         tax_category: tax_category
       )
@@ -209,7 +216,7 @@ describe Spree::Calculator::DefaultTax, type: :model do
       build_stubbed(
         :shipment,
         cost: 30,
-        promo_total: promo_total,
+        adjustments: adjustments,
         order: order,
         shipping_rates: [shipping_rate]
       )
@@ -234,12 +241,12 @@ describe Spree::Calculator::DefaultTax, type: :model do
     end
 
     let(:item) do
-      # cost and discounted_amount for shipping rates are the same as they
-      # can not be discounted. for the sake of passing tests, the cost is
+      # cost and adjusted amount for shipping rates are the same as they
+      # can not be adjusted. for the sake of passing tests, the cost is
       # adjusted here.
       build_stubbed(
         :shipping_rate,
-        cost: 30 + promo_total,
+        cost: 30 + adjustment_total,
         selected: true,
         shipping_method: shipping_method,
         shipment: shipment

--- a/core/spec/models/spree/inventory_unit_spec.rb
+++ b/core/spec/models/spree/inventory_unit_spec.rb
@@ -150,7 +150,7 @@ describe Spree::InventoryUnit, type: :model do
   end
 
   describe "#current_or_new_return_item" do
-    before { allow(inventory_unit).to receive_messages(pre_tax_amount: 100.0) }
+    before { allow(inventory_unit).to receive_messages(total_excluding_vat: 100.0) }
 
     subject { inventory_unit.current_or_new_return_item }
 

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -93,19 +93,36 @@ describe Spree::LineItem, type: :model do
     end
   end
 
-  describe '.discounted_amount' do
+  # TODO: Remove this spec after the method has been removed.
+  describe '#discounted_amount' do
     it "returns the amount minus any discounts" do
       line_item.price = 10
       line_item.quantity = 2
       line_item.promo_total = -5
-      expect(line_item.discounted_amount).to eq(15)
+      expect(Spree::Deprecation.silence { line_item.discounted_amount }).to eq(15)
     end
   end
 
+  # TODO: Remove this spec after the method has been removed.
   describe "#discounted_money" do
     it "should return a money object with the discounted amount" do
-      expect(line_item.discounted_amount).to eq(10.00)
-      expect(line_item.discounted_money.to_s).to eq "$10.00"
+      expect(Spree::Deprecation.silence { line_item.discounted_amount }).to eq(10.00)
+      expect(Spree::Deprecation.silence { line_item.discounted_money.to_s }).to eq "$10.00"
+    end
+  end
+
+  describe '#total_before_tax' do
+    before do
+      line_item.update!(price: 10, quantity: 2)
+    end
+    let!(:admin_adjustment) { create(:adjustment, adjustable: line_item, order: line_item.order, amount: -1, source: nil) }
+    let!(:promo_adjustment) { create(:adjustment, adjustable: line_item, order: line_item.order, amount: -2, source: promo_action) }
+    let!(:ineligible_promo_adjustment) { create(:adjustment, eligible: false, adjustable: line_item, order: line_item.order, amount: -4, source: promo_action) }
+    let(:promo_action) { promo.actions[0] }
+    let(:promo) { create(:promotion, :with_line_item_adjustment) }
+
+    it 'returns the amount minus any adjustments' do
+      expect(line_item.total_before_tax).to eq(20 - 1 - 2)
     end
   end
 

--- a/core/spec/models/spree/order/outstanding_balance_integration_spec.rb
+++ b/core/spec/models/spree/order/outstanding_balance_integration_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe "Outstanding balance integration tests" do
 
     context 'with a removed item' do
       before do
-        item_amount = item_1.final_amount
+        item_amount = item_1.total
         order.contents.remove(item_1.variant)
         create(:refund, payment: payment, amount: item_amount)
       end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -995,14 +995,14 @@ describe Spree::Order, type: :model do
     end
   end
 
-  describe "#pre_tax_item_amount" do
+  describe "#item_total_excluding_vat" do
     it "sums all of the line items' pre tax amounts" do
       subject.line_items = [
         Spree::LineItem.new(price: 10, quantity: 2, included_tax_total: 15.0),
         Spree::LineItem.new(price: 30, quantity: 1, included_tax_total: 16.0)
       ]
       # (2*10)-15 + 30-16 = 5 + 14 = 19
-      expect(subject.pre_tax_item_amount).to eq 19.0
+      expect(subject.item_total_excluding_vat).to eq 19.0
     end
   end
 

--- a/core/spec/models/spree/reimbursement_spec.rb
+++ b/core/spec/models/spree/reimbursement_spec.rb
@@ -121,8 +121,8 @@ describe Spree::Reimbursement, type: :model do
         return_item.reload
         expect(return_item.included_tax_total).to be > 0
         expect(return_item.included_tax_total).to eq line_item.included_tax_total
-        expect(reimbursement.total).to eq((line_item.pre_tax_amount + line_item.included_tax_total).round(2, :down))
-        expect(Spree::Refund.last.amount).to eq((line_item.pre_tax_amount + line_item.included_tax_total).round(2, :down))
+        expect(reimbursement.total).to eq((line_item.total_excluding_vat + line_item.included_tax_total).round(2, :down))
+        expect(Spree::Refund.last.amount).to eq((line_item.total_excluding_vat + line_item.included_tax_total).round(2, :down))
       end
     end
 

--- a/core/spec/models/spree/return_authorization_spec.rb
+++ b/core/spec/models/spree/return_authorization_spec.rb
@@ -77,7 +77,7 @@ describe Spree::ReturnAuthorization, type: :model do
     end
   end
 
-  describe "#pre_tax_total" do
+  describe "#total_excluding_vat" do
     let(:amount_1) { 15.0 }
     let!(:return_item_1) { create(:return_item, return_authorization: return_authorization, amount: amount_1) }
 
@@ -87,17 +87,17 @@ describe Spree::ReturnAuthorization, type: :model do
     let(:amount_3) { 5.0 }
     let!(:return_item_3) { create(:return_item, return_authorization: return_authorization, amount: amount_3) }
 
-    subject { return_authorization.reload.pre_tax_total }
+    subject { return_authorization.reload.total_excluding_vat }
 
     it "sums it's associated return_item's amounts" do
       expect(subject).to eq(amount_1 + amount_2 + amount_3)
     end
   end
 
-  describe "#display_pre_tax_total" do
+  describe "#display_total_excluding_vat" do
     it "returns a Spree::Money" do
-      allow(return_authorization).to receive_messages(pre_tax_total: 21.22)
-      expect(return_authorization.display_pre_tax_total).to eq(Spree::Money.new(21.22))
+      allow(return_authorization).to receive_messages(total_excluding_vat: 21.22)
+      expect(return_authorization.display_total_excluding_vat).to eq(Spree::Money.new(21.22))
     end
   end
 

--- a/core/spec/models/spree/return_item_spec.rb
+++ b/core/spec/models/spree/return_item_spec.rb
@@ -140,13 +140,13 @@ describe Spree::ReturnItem, type: :model do
     end
   end
 
-  describe "#display_pre_tax_amount" do
+  describe "#display_total_excluding_vat" do
     let(:amount) { 21.22 }
     let(:included_tax_total) { 1.22 }
     let(:return_item) { build(:return_item, amount: amount, included_tax_total: included_tax_total) }
 
     it "returns a Spree::Money" do
-      expect(return_item.display_pre_tax_amount).to eq Spree::Money.new(amount - included_tax_total)
+      expect(return_item.display_total_excluding_vat).to eq Spree::Money.new(amount - included_tax_total)
     end
   end
 
@@ -558,7 +558,7 @@ describe Spree::ReturnItem, type: :model do
     end
   end
 
-  describe "exchange pre_tax_amount" do
+  describe "exchange amount" do
     let(:return_item) { build(:return_item) }
 
     context "the return item is intended to be exchanged" do

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -145,7 +145,22 @@ describe Spree::Shipment, type: :model do
     shipment = create(:shipment)
     shipment.cost = 10
     shipment.promo_total = -1
-    expect(shipment.discounted_cost).to eq(9)
+    expect(Spree::Deprecation.silence { shipment.discounted_cost }).to eq(9)
+  end
+
+  describe '#total_before_tax' do
+    before do
+      shipment.update_attributes!(cost: 10)
+    end
+    let!(:admin_adjustment) { create(:adjustment, adjustable: shipment, order: shipment.order, amount: -1, source: nil) }
+    let!(:promo_adjustment) { create(:adjustment, adjustable: shipment, order: shipment.order, amount: -2, source: promo_action) }
+    let!(:ineligible_promo_adjustment) { create(:adjustment, eligible: false, adjustable: shipment, order: shipment.order, amount: -4, source: promo_action) }
+    let(:promo_action) { promo.actions[0] }
+    let(:promo) { create(:promotion, :with_line_item_adjustment) }
+
+    it 'returns the amount minus any adjustments' do
+      expect(shipment.total_before_tax).to eq(10 - 1 - 2)
+    end
   end
 
   it "#tax_total with included taxes" do

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -105,10 +105,10 @@ describe Spree::Shipment, type: :model do
     end
   end
 
-  context "display_final_price" do
+  context "display_total" do
     it "retuns a Spree::Money" do
-      allow(shipment).to receive(:final_price) { 21.22 }
-      expect(shipment.display_final_price).to eq(Spree::Money.new(21.22))
+      allow(shipment).to receive(:total) { 21.22 }
+      expect(shipment.display_total).to eq(Spree::Money.new(21.22))
     end
   end
 
@@ -177,12 +177,12 @@ describe Spree::Shipment, type: :model do
     expect(shipment.tax_total).to eq(10)
   end
 
-  it "#final_price" do
+  it "#total" do
     shipment = Spree::Shipment.new
     shipment.cost = 10
     shipment.adjustment_total = -2
     shipment.included_tax_total = 1
-    expect(shipment.final_price).to eq(8)
+    expect(shipment.total).to eq(8)
   end
 
   context "manifest" do

--- a/core/spec/models/spree/tax/taxation_integration_spec.rb
+++ b/core/spec/models/spree/tax/taxation_integration_spec.rb
@@ -282,7 +282,7 @@ RSpec.describe "Taxation system integration tests" do
         end
 
         it 'has a constant amount pre tax' do
-          expect(line_item.discounted_amount - line_item.included_tax_total).to eq(18.69)
+          expect(line_item.total_before_tax - line_item.included_tax_total).to eq(18.69)
         end
       end
 
@@ -320,7 +320,7 @@ RSpec.describe "Taxation system integration tests" do
         end
 
         it 'has a constant amount pre tax' do
-          expect(line_item.discounted_amount - line_item.included_tax_total).to eq(25.21)
+          expect(line_item.total_before_tax - line_item.included_tax_total).to eq(25.21)
         end
       end
 
@@ -358,7 +358,7 @@ RSpec.describe "Taxation system integration tests" do
         end
 
         it 'has a constant amount pre tax' do
-          expect(line_item.discounted_amount - line_item.included_tax_total).to eq(8.40)
+          expect(line_item.total_before_tax - line_item.included_tax_total).to eq(8.40)
         end
       end
 
@@ -409,7 +409,7 @@ RSpec.describe "Taxation system integration tests" do
         end
 
         it 'has a constant amount pre tax' do
-          expect(line_item.discounted_amount - line_item.included_tax_total).to eq(18.69)
+          expect(line_item.total_before_tax - line_item.included_tax_total).to eq(18.69)
         end
       end
     end
@@ -442,7 +442,7 @@ RSpec.describe "Taxation system integration tests" do
         end
 
         it 'has a constant amount pre tax' do
-          expect(line_item.discounted_amount - line_item.included_tax_total).to eq(18.69)
+          expect(line_item.total_before_tax - line_item.included_tax_total).to eq(18.69)
         end
 
         context 'an order with a book and a shipment' do
@@ -484,7 +484,7 @@ RSpec.describe "Taxation system integration tests" do
         end
 
         it 'has a constant amount pre tax' do
-          expect(line_item.discounted_amount - line_item.included_tax_total).to eq(25.21)
+          expect(line_item.total_before_tax - line_item.included_tax_total).to eq(25.21)
         end
 
         context 'an order with a sweater and a shipment' do
@@ -526,7 +526,7 @@ RSpec.describe "Taxation system integration tests" do
         end
 
         it 'has a constant amount pre tax' do
-          expect(line_item.discounted_amount - line_item.included_tax_total).to eq(8.40)
+          expect(line_item.total_before_tax - line_item.included_tax_total).to eq(8.40)
         end
       end
 

--- a/frontend/app/views/spree/orders/_adjustments.html.erb
+++ b/frontend/app/views/spree/orders/_adjustments.html.erb
@@ -13,7 +13,7 @@
     <tr>
       <td colspan="4" align='right'><h5><%= Spree.t(:shipping) %>: <%= shipment.shipping_method.name %></h5></td>
       <td colspan='2'>
-        <h5><%= shipment.display_discounted_cost %></h5>
+        <h5><%= shipment.display_total_before_tax %></h5>
       </td>
     </tr>
   <% end %>

--- a/frontend/app/views/spree/shared/_order_details.html.erb
+++ b/frontend/app/views/spree/shared/_order_details.html.erb
@@ -110,7 +110,7 @@
     <% order.shipments.group_by { |s| s.selected_shipping_rate.name }.each do |name, shipments| %>
       <tr class="total" data-hook='shipment-row'>
         <td colspan="4"><%= Spree.t(:shipping) %>: <strong><%= name %></strong></td>
-        <td class="total"><span><%= Spree::Money.new(shipments.sum(&:discounted_cost), currency: order.currency).to_html %></span></td>
+        <td class="total"><span><%= Spree::Money.new(shipments.sum(&:total_before_tax), currency: order.currency).to_html %></span></td>
       </tr>
     <% end %>
   </tfoot>


### PR DESCRIPTION
In #1933 we starting allowing non-promotion adjustments on line items
and shipments.  However, we didn't update some other important code (including
the DefaultTax calculator) to consider these adjustments.

This PR fixes the above issue in its first commit and renames several existing methods in its second commit.

Please see individual commits.