### PR TITLE
Wrap Splitter chaining behaviour in new Stock::SplitterChain class

### DIFF
--- a/core/app/models/spree/stock/packer.rb
+++ b/core/app/models/spree/stock/packer.rb
@@ -10,11 +10,7 @@ module Spree
       end
 
       def packages
-        if splitters.empty?
-          [default_package]
-        else
-          build_splitter.split [default_package]
-        end
+        Spree::Stock::SplitterChain.new(stock_location, splitters).split([default_package])
       end
 
       def default_package
@@ -49,14 +45,6 @@ module Spree
           where(stock_location_id: stock_location.id).
           map { |stock_item| [stock_item.variant_id, stock_item] }.
           to_h # there is only one stock item per variant in a stock location
-      end
-
-      def build_splitter
-        splitter = nil
-        splitters.reverse_each do |klass|
-          splitter = klass.new(self, splitter)
-        end
-        splitter
       end
     end
   end

--- a/core/app/models/spree/stock/splitter/base.rb
+++ b/core/app/models/spree/stock/splitter/base.rb
@@ -2,13 +2,17 @@ module Spree
   module Stock
     module Splitter
       class Base
-        attr_reader :packer, :next_splitter
+        attr_reader :stock_location, :next_splitter
 
-        def initialize(packer, next_splitter = nil)
-          @packer = packer
+        def initialize(stock_location_or_packer, next_splitter = nil)
+          if stock_location_or_packer.is_a?(Spree::StockLocation)
+            @stock_location = stock_location_or_packer
+          else
+            Spree::Deprecation.warn("Initializing Splitters with a Packer is DEPRECATED. Pass a StockLocation instead.")
+            @stock_location = stock_location_or_packer.stock_location
+          end
           @next_splitter = next_splitter
         end
-        delegate :stock_location, to: :packer
 
         def split(packages)
           return_next(packages)

--- a/core/app/models/spree/stock/splitter/weight.rb
+++ b/core/app/models/spree/stock/splitter/weight.rb
@@ -2,8 +2,6 @@ module Spree
   module Stock
     module Splitter
       class Weight < Spree::Stock::Splitter::Base
-        attr_reader :packer, :next_splitter
-
         cattr_accessor :threshold do
           150
         end

--- a/core/app/models/spree/stock/splitter_chain.rb
+++ b/core/app/models/spree/stock/splitter_chain.rb
@@ -1,0 +1,32 @@
+module Spree
+  module Stock
+    class SplitterChain
+      attr_reader :stock_location
+
+      def initialize(stock_location, splitter_classes = [])
+        @stock_location = stock_location
+        @splitter_classes = splitter_classes
+      end
+
+      def split(initial_packages)
+        initial_packages = Array(initial_packages)
+
+        if @splitter_classes.empty?
+          initial_packages
+        else
+          build_splitter.split(initial_packages)
+        end
+      end
+
+      private
+
+      def build_splitter
+        splitter = nil
+        @splitter_classes.reverse_each do |klass|
+          splitter = klass.new(self, splitter)
+        end
+        splitter
+      end
+    end
+  end
+end

--- a/core/app/models/spree/stock/splitter_chain.rb
+++ b/core/app/models/spree/stock/splitter_chain.rb
@@ -23,7 +23,7 @@ module Spree
       def build_splitter
         splitter = nil
         @splitter_classes.reverse_each do |klass|
-          splitter = klass.new(self, splitter)
+          splitter = klass.new(stock_location, splitter)
         end
         splitter
       end

--- a/core/spec/models/spree/stock/splitter/backordered_spec.rb
+++ b/core/spec/models/spree/stock/splitter/backordered_spec.rb
@@ -6,12 +6,12 @@ module Spree
       describe Backordered, type: :model do
         let(:variant) { build(:variant) }
 
-        let(:packer) { build(:stock_packer) }
+        let(:stock_location) { mock_model(Spree::StockLocation) }
 
-        subject { Backordered.new(packer) }
+        subject { Backordered.new(stock_location) }
 
         it 'splits packages by status' do
-          package = Package.new(packer.stock_location)
+          package = Package.new(stock_location)
           4.times { package.add build(:inventory_unit, variant: variant) }
           5.times { package.add build(:inventory_unit, variant: variant), :backordered }
 

--- a/core/spec/models/spree/stock/splitter/base_spec.rb
+++ b/core/spec/models/spree/stock/splitter/base_spec.rb
@@ -5,14 +5,21 @@ module Spree
     module Splitter
       describe Base, type: :model do
         let(:packer) { build(:stock_packer) }
+        let(:stock_location) { mock_model(Spree::StockLocation) }
 
         it 'continues to splitter chain' do
-          splitter1 = Base.new(packer)
-          splitter2 = Base.new(packer, splitter1)
+          splitter1 = Base.new(stock_location)
+          splitter2 = Base.new(stock_location, splitter1)
           packages = []
 
           expect(splitter1).to receive(:split).with(packages)
           splitter2.split(packages)
+        end
+
+        it 'accepts a packer (deprecated)' do
+          splitter = Spree::Deprecation.silence { Base.new(packer) }
+
+          expect(splitter.stock_location).to eq(packer.stock_location)
         end
       end
     end

--- a/core/spec/models/spree/stock/splitter/shipping_category_spec.rb
+++ b/core/spec/models/spree/stock/splitter/shipping_category_spec.rb
@@ -22,16 +22,16 @@ module Spree
         end
       end
 
-      let(:packer) { build(:stock_packer) }
+      let(:stock_location) { mock_model(Spree::StockLocation) }
 
-      subject { described_class.new(packer) }
+      subject { described_class.new(stock_location) }
 
       it 'splits each package by shipping category' do
-        package1 = Package.new(packer.stock_location)
+        package1 = Package.new(stock_location)
         4.times { package1.add inventory_unit1 }
         8.times { package1.add inventory_unit2 }
 
-        package2 = Package.new(packer.stock_location)
+        package2 = Package.new(stock_location)
         6.times { package2.add inventory_unit1 }
         9.times { package2.add inventory_unit2, :backordered }
 

--- a/core/spec/models/spree/stock/splitter/weight_spec.rb
+++ b/core/spec/models/spree/stock/splitter/weight_spec.rb
@@ -4,20 +4,20 @@ module Spree
   module Stock
     module Splitter
       describe Weight, type: :model do
-        let(:packer) { build(:stock_packer) }
+        let(:stock_location) { mock_model(Spree::StockLocation) }
         let(:variant) { build(:base_variant, weight: 100) }
 
-        subject { Weight.new(packer) }
+        subject { Weight.new(stock_location) }
 
         it 'splits and keeps splitting until all packages are underweight' do
-          package = Package.new(packer.stock_location)
+          package = Package.new(stock_location)
           4.times { package.add build(:inventory_unit, variant: variant) }
           packages = subject.split([package])
           expect(packages.size).to eq 4
         end
 
         it 'handles packages that can not be reduced' do
-          package = Package.new(packer.stock_location)
+          package = Package.new(stock_location)
           allow(variant).to receive_messages(weight: 200)
           2.times { package.add build(:inventory_unit, variant: variant) }
           packages = subject.split([package])

--- a/core/spec/models/spree/stock/splitter_chain_spec.rb
+++ b/core/spec/models/spree/stock/splitter_chain_spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper'
+
+module Spree::Stock
+  describe SplitterChain, type: :model do
+    let(:stock_location) { mock_model(Spree::StockLocation) }
+    let(:splitter1) { Class.new(Splitter::Base) }
+    let(:splitter2) { Class.new(Splitter::Base) }
+
+    let(:package) { double(:package) }
+    let(:packages) { [package] }
+
+    subject { described_class.new(stock_location, splitters) }
+
+    context 'with no splitters' do
+      let(:splitters) { [] }
+
+      it "returns the packages unchanged" do
+        expect(subject.split(packages)).to eq packages
+      end
+    end
+
+    context 'with one splitter' do
+      let(:splitters) { [splitter1] }
+
+      it 'returns the result form the splitter' do
+        expected = double(:expected_packages)
+        expect_any_instance_of(splitter1).to receive(:split).with(packages).and_return(expected)
+
+        expect(subject.split(packages)).to be expected
+      end
+
+      it 'builds the splitters correctly' do
+        expect(splitter1).to receive(:new).with(subject, nil).and_call_original
+
+        subject.split(packages)
+      end
+    end
+
+    context 'with multiple splitters' do
+      let(:splitters) { [splitter1, splitter2] }
+
+      it 'builds the splitters in order' do
+        expect(splitter1).to receive(:new).with(subject, splitter2).and_call_original
+        expect(splitter2).to receive(:new).with(subject, nil).and_call_original
+
+        subject.split(packages)
+      end
+
+      it 'calls the splitters in order' do
+        expect_any_instance_of(splitter1).to receive(:split).with(packages).and_call_original
+        expect_any_instance_of(splitter2).to receive(:split).with(packages).and_call_original
+
+        subject.split(packages)
+      end
+
+      it 'returns the final result' do
+        expected = double(:expected_packages)
+        expect_any_instance_of(splitter2).to receive(:split).with(packages).and_return(expected)
+
+        expect(subject.split(packages)).to be expected
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/stock/splitter_chain_spec.rb
+++ b/core/spec/models/spree/stock/splitter_chain_spec.rb
@@ -30,7 +30,7 @@ module Spree::Stock
       end
 
       it 'builds the splitters correctly' do
-        expect(splitter1).to receive(:new).with(subject, nil).and_call_original
+        expect(splitter1).to receive(:new).with(stock_location, nil).and_call_original
 
         subject.split(packages)
       end
@@ -40,8 +40,8 @@ module Spree::Stock
       let(:splitters) { [splitter1, splitter2] }
 
       it 'builds the splitters in order' do
-        expect(splitter1).to receive(:new).with(subject, splitter2).and_call_original
-        expect(splitter2).to receive(:new).with(subject, nil).and_call_original
+        expect(splitter1).to receive(:new).with(stock_location, splitter2).and_call_original
+        expect(splitter2).to receive(:new).with(stock_location, nil).and_call_original
 
         subject.split(packages)
       end


### PR DESCRIPTION
Previously the `Stock::Packer` was responsible for building a chain of `Stock::Splitter` objects to split objects after packaging. This required some precise behaviour (like order of initialization) as well as edgecase handling (empty array of splitters) which wasn't well tested and should be outside the responsibilities of the Packer itself.

This extracts the behaviour to `Spree::Stock::SplitterChain`, which handles building and calling the splitters.

This also changes the first argument to `Splitter::Base#initialize` from a `Stock::Packer` to a `Spree::StockLocation` (with a deprecation notice).