### PR TITLE
Remove unused Paperclip spec matchers

### DIFF
--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -40,8 +40,6 @@ require 'spree/testing_support/url_helpers'
 require 'spree/testing_support/order_walkthrough'
 require 'spree/testing_support/capybara_ext'
 
-require 'paperclip/matchers'
-
 require 'capybara-screenshot/rspec'
 Capybara.save_path = ENV['CIRCLE_ARTIFACTS'] if ENV['CIRCLE_ARTIFACTS']
 
@@ -118,8 +116,6 @@ RSpec.configure do |config|
   config.include Spree::TestingSupport::UrlHelpers
   config.include Spree::TestingSupport::ControllerRequests, type: :controller
   config.include Spree::TestingSupport::Flash
-
-  config.include Paperclip::Shoulda::Matchers
 
   config.extend WithModel
 

--- a/frontend/spec/spec_helper.rb
+++ b/frontend/spec/spec_helper.rb
@@ -45,8 +45,6 @@ require 'spree/testing_support/url_helpers'
 require 'spree/testing_support/order_walkthrough'
 require 'spree/testing_support/caching'
 
-require 'paperclip/matchers'
-
 require 'capybara-screenshot/rspec'
 Capybara.save_path = ENV['CIRCLE_ARTIFACTS'] if ENV['CIRCLE_ARTIFACTS']
 
@@ -117,8 +115,6 @@ RSpec.configure do |config|
   config.include Spree::TestingSupport::UrlHelpers
   config.include Spree::TestingSupport::ControllerRequests, type: :controller
   config.include Spree::TestingSupport::Flash
-
-  config.include Paperclip::Shoulda::Matchers
 
   config.fail_fast = ENV['FAIL_FAST'] || false
 


### PR DESCRIPTION
These appear to be as old as time and not used anywhere in the project.