### PR TITLE
Disable Rubocop Style/TernaryParentheses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -236,6 +236,9 @@ Style/StringLiterals:
 Style/SymbolProc:
   Enabled: false
 
+Style/TernaryParentheses:
+  Enabled: false
+
 Style/WhileUntilModifier:
   Enabled: false
   StyleGuide: http://relaxed.ruby.style/#stylewhileuntilmodifier


### PR DESCRIPTION
This is sometimes more readable and doesn't seem worth complaining about.

e.g.:
```
core/lib/spree/core/search/base.rb:113:34: C: Omit parentheses for ternary conditions.
@properties[:page] = (params[:page].to_i <= 0) ? 1 : params[:page].to_i
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```
