### PR TITLE
Use ducktyping in wallet payment source validation

### DIFF
--- a/core/app/models/spree/wallet_payment_source.rb
+++ b/core/app/models/spree/wallet_payment_source.rb
@@ -10,7 +10,7 @@ class Spree::WalletPaymentSource < ActiveRecord::Base
   private
 
   def check_for_payment_source_class
-    if !payment_source.is_a?(Spree::PaymentSource)
+    if !payment_source.respond_to?(:reusable?)
       errors.add(:payment_source, :has_to_be_payment_source_class)
     end
   end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -710,7 +710,7 @@ en:
         spree/wallet_payment_source:
           attributes:
             payment_source:
-              has_to_be_payment_source_class: "has to be a Spree::PaymentSource"
+              has_to_be_payment_source_class: "has to implement `reusable?`"
 
   devise:
     confirmations:

--- a/core/spec/models/spree/wallet_payment_source_spec.rb
+++ b/core/spec/models/spree/wallet_payment_source_spec.rb
@@ -14,7 +14,7 @@ describe Spree::WalletPaymentSource, type: :model do
 
       let(:payment_source) { NonPaymentSource.create! }
 
-      it "errors when `payment_source` is not a `Spree::PaymentSource`" do
+      it "errors when `payment_source` does not implement `reusable`" do
         wallet_payment_source = Spree::WalletPaymentSource.new(
           payment_source: payment_source,
           user: create(:user)
@@ -22,7 +22,7 @@ describe Spree::WalletPaymentSource, type: :model do
 
         expect(wallet_payment_source).not_to be_valid
         expect(wallet_payment_source.errors.messages).to eq(
-          { payment_source: ["has to be a Spree::PaymentSource"] }
+          { payment_source: ["has to implement `reusable?`"] }
         )
       end
     end


### PR DESCRIPTION
Instead of asking for the source class to be a `Spree::PaymentSource`
we should only ask if it responds to `reusable?`; as this method is actually
the only method we expect to be implemented on the source (in `Spree::Wallet::AddPaymentSourcesToWallet`).

Otherwise payment sources that do not inherit from `Spree::PaymentSource`
(a class we first introduced with Solidus 2.2) cannot be used with the wallet.

See https://github.com/solidusio/solidus_paypal_braintree/pull/123