### PR TITLE
Remove unhelpful preload in Stock::Estimator

### DIFF
--- a/core/app/models/spree/stock/estimator.rb
+++ b/core/app/models/spree/stock/estimator.rb
@@ -46,7 +46,7 @@ module Spree
       def shipping_methods(package)
         package.shipping_methods
           .available_for_address(package.shipment.order.ship_address)
-          .includes(:calculator, tax_category: :tax_rates)
+          .includes(:calculator)
           .to_a
           .select do |ship_method|
           calculator = ship_method.calculator


### PR DESCRIPTION
These included records aren't being used by the taxation classes, which do their own querying.

The include was introduced by me in 17e8ea57aa94afe22d1114176ad3967c9f6ff340, at the time the includes were used, but are no longer as of 2426c37a78ca0abaa9389e439c0ce876de45bb98.