### PR TITLE
Run validations in order updater

### DIFF
--- a/core/app/models/spree/order_merger.rb
+++ b/core/app/models/spree/order_merger.rb
@@ -54,11 +54,13 @@ module Spree
       end
 
       set_user(user)
-      persist_merge
+      if order.valid?
+        persist_merge
 
-      # So that the destroy doesn't take out line items which may have been re-assigned
-      other_order.line_items.reload
-      other_order.destroy
+        # So that the destroy doesn't take out line items which may have been re-assigned
+        other_order.line_items.reload
+        other_order.destroy
+      end
     end
 
     private

--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -182,7 +182,7 @@ module Spree
     end
 
     def persist_totals
-      order.save!(validate: false)
+      order.save!
     end
 
     def log_state_change(name)

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -522,7 +522,7 @@ describe Spree::Order, type: :model do
       context 'when the line items are not available' do
         before do
           order.line_items << FactoryGirl.create(:line_item)
-          order.store = FactoryGirl.build(:store)
+          order.store = FactoryGirl.create(:store)
           Spree::OrderUpdater.new(order).update
 
           order.save!

--- a/core/spec/models/spree/order_contents_spec.rb
+++ b/core/spec/models/spree/order_contents_spec.rb
@@ -307,7 +307,13 @@ describe Spree::OrderContents, type: :model do
   end
 
   context "completed order" do
-    let(:order) { Spree::Order.create! state: 'complete', completed_at: Time.current }
+    let(:order) do
+      Spree::Order.create!(
+        state: 'complete',
+        completed_at: Time.current,
+        email: "test@example.com"
+      )
+    end
 
     before { order.shipments.create! stock_location_id: variant.stock_location_ids.first }
 

--- a/core/spec/models/spree/order_updater_spec.rb
+++ b/core/spec/models/spree/order_updater_spec.rb
@@ -552,5 +552,15 @@ module Spree
         }.to change { line_item.reload.adjustment_total }.from(100).to(0)
       end
     end
+
+    context "with invalid associated objects" do
+      let(:order) { Spree::Order.create(ship_address: Spree::Address.new) }
+
+      subject { updater.update }
+
+      it "raises because of the invalid object" do
+        expect { subject }.to raise_exception(ActiveRecord::RecordInvalid)
+      end
+    end
   end
 end

--- a/core/spec/models/spree/order_updater_spec.rb
+++ b/core/spec/models/spree/order_updater_spec.rb
@@ -367,7 +367,7 @@ module Spree
     end
 
     context "updating payment state" do
-      let(:order) { Order.new }
+      let(:order) { build(:order) }
       let(:updater) { order.updater }
       before { allow(order).to receive(:refund_total).and_return(0) }
 

--- a/frontend/app/controllers/spree/orders_controller.rb
+++ b/frontend/app/controllers/spree/orders_controller.rb
@@ -49,12 +49,12 @@ module Spree
       # 2,147,483,647 is crazy. See issue https://github.com/spree/spree/issues/2695.
       if !quantity.between?(1, 2_147_483_647)
         @order.errors.add(:base, Spree.t(:please_enter_reasonable_quantity))
-      end
-
-      begin
-        @line_item = @order.contents.add(variant, quantity)
-      rescue ActiveRecord::RecordInvalid => e
-        @order.errors.add(:base, e.record.errors.full_messages.join(", "))
+      else
+        begin
+          @line_item = @order.contents.add(variant, quantity)
+        rescue ActiveRecord::RecordInvalid => e
+          @order.errors.add(:base, e.record.errors.full_messages.join(", "))
+        end
       end
 
       respond_with(@order) do |format|


### PR DESCRIPTION
We don't validate when we save orders in the order updater. This is problematic because we save associated records, even if they're invalid - leading to validation errors down the line, i.e. when advancing to checkout or trying to modify an order made invalid by its associated records. 

This shows what is necessary in order to run validations in the order updater, which I think would be a good thing.