### PR TITLE
add Product Orders admin tab

### DIFF
--- a/backend/app/controllers/spree/admin/products/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/products/orders_controller.rb
@@ -1,0 +1,25 @@
+module Spree
+  module Admin
+    module Products
+      class OrdersController < Spree::Admin::BaseController
+        before_action :load_product
+
+        def index
+          @search = @product.orders.complete.reorder(completed_at: :desc).ransack
+          @orders = @search.result(distinct: true)
+                           .page(params[:page])
+                           .per(params[:per_page] || Spree::Config[:orders_per_page])
+          respond_to do |format|
+            format.html
+          end
+        end
+
+        private
+
+        def load_product
+          @product = Product.with_deleted.friendly.find(params[:product_id])
+        end
+      end
+    end
+  end
+end

--- a/backend/app/views/spree/admin/products/orders/index.html.erb
+++ b/backend/app/views/spree/admin/products/orders/index.html.erb
@@ -1,0 +1,61 @@
+<%= render partial: 'spree/admin/shared/product_tabs', locals: { current: 'Orders' } %>
+
+<% admin_breadcrumb(Spree.t(:orders)) %>
+
+<%= paginate @orders, theme: "solidus_admin" %>
+
+<% if @orders.any? %>
+  <table class="index responsive" id="listing_orders" data-hook>
+    <colgroup>
+       <col style="width: 13%;">
+       <col style="width: 10%;">
+       <col style="width: 10%;">
+       <col style="width: 12%;">
+       <% if Spree::Order.checkout_step_names.include?(:delivery) %>
+         <col style="width: 12%;">
+       <% end %>
+       <col style="width: 25%;">
+       <col style="width: 10%;">
+       <col style="width: 8%;">
+    </colgroup>
+    <thead>
+      <tr data-hook="admin_orders_index_headers">
+        <th><%= sort_link @search, :completed_at, Spree::Order.human_attribute_name(:completed_at) %></th>
+        <th><%= sort_link @search, :number, Spree::Order.human_attribute_name(:number) %></th>
+        <th><%= sort_link @search, :state, Spree::Order.human_attribute_name(:state) %></th>
+        <th><%= sort_link @search, :payment_state, Spree::Order.human_attribute_name(:payment_state) %></th>
+         <% if Spree::Order.checkout_step_names.include?(:delivery) %>
+          <th><%= sort_link @search, :shipment_state, Spree::Order.human_attribute_name(:shipment_state) %></th>
+         <% end %>
+        <th><%= sort_link @search, :email,  Spree::Order.human_attribute_name(:email) %></th>
+        <th><%= sort_link @search, :total,  Spree::Order.human_attribute_name(:total) %></th>
+        <th data-hook="admin_orders_index_header_actions" class="actions"></th>
+      </tr>
+    </thead>
+    <tbody>
+    <% @orders.each do |order| %>
+      <tr data-hook="admin_orders_index_rows" class="state-<%= order.state.downcase %> <%= cycle('odd', 'even') %>">
+        <td class="align-center"><%= l order.completed_at.to_date %></td>
+        <td class="align-center"><%= link_to order.number, edit_admin_order_path(order) %></td>
+        <td class="align-center"><span class="state <%= order.state.downcase %>"><%= Spree.t("order_state.#{order.state.downcase}") %></span></td>
+        <td class="align-center"><span class="state <%= order.payment_state %>"><%= link_to Spree.t("payment_states.#{order.payment_state}"), admin_order_payments_path(order) if order.payment_state %></span></td>
+          <% if Spree::Order.checkout_step_names.include?(:delivery) %>
+            <td class="align-center"><span class="state <%= order.shipment_state %>"><%= Spree.t("shipment_states.#{order.shipment_state}") if order.shipment_state %></span></td>
+          <% end %>
+        <td><%= mail_to order.email %></td>
+        <td class="align-center"><%= order.display_total.to_html %></td>
+        <td class='actions align-center' data-hook="admin_orders_index_row_actions">
+          <%= link_to_edit_url edit_admin_order_path(order), title: "edit_admin_#{dom_id(order)}", no_text: true %>
+        </td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <div class="alpha twelve columns no-objects-found">
+    <%= Spree.t(:no_resource_found, resource: Spree.t(:other, scope: 'activerecord.models.spree/order')) %>,
+    <%= link_to Spree.t(:add_one), spree.new_admin_order_path %>!
+  </div>
+<% end %>
+
+<%= paginate @orders, theme: "solidus_admin" %>

--- a/backend/app/views/spree/admin/shared/_product_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_product_tabs.html.erb
@@ -22,6 +22,9 @@
       <%= content_tag :li, class: ('active' if current == 'Stock Management') do %>
         <%= link_to Spree.t(:stock_management), spree.admin_product_stock_url(@product) %>
       <% end if can?(:admin, Spree::StockItem) && !@product.deleted? %>
+      <%= content_tag :li, class: ('active' if current == 'Orders') do %>
+        <%= link_to Spree.t(:orders), spree.admin_product_orders_url(@product) %>
+      <% end %>
     </ul>
   </nav>
 <% end %>

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -50,6 +50,7 @@ Spree::Core::Engine.routes.draw do
       end
       resources :variants_including_master, only: [:update]
       resources :prices, only: [:destroy, :index, :edit, :update, :new, :create]
+      resources :orders, controller: "products/orders", only: [:index]
     end
     get '/products/:product_slug/stock', to: "stock_items#index", as: :product_stock
 


### PR DESCRIPTION
At our company we’ve found that a frequent use case is wanting to know which orders contained a given product. Solidus already has a helpful [`Product#orders`](https://github.com/solidusio/solidus/blob/master/core/app/models/spree/product.rb#L56) association, so this PR adds backend views via a tab for seeing all of the completed orders of a given product.

If this functionality seems like it would be helpful to other stores in similar situations, I’m happy to contribute it here as a PR to the backend.