### PR TITLE
use class instead data-hook for gateway partial

### DIFF
--- a/frontend/app/views/spree/checkout/payment/_gateway.html.erb
+++ b/frontend/app/views/spree/checkout/payment/_gateway.html.erb
@@ -1,12 +1,12 @@
 <%= image_tag 'credit_cards/credit_card.gif', id: 'credit-card-image' %>
 <% param_prefix = "payment_source[#{payment_method.id}]" %>
 
-<p class="field">
+<p class="field card_name">
   <%= label_tag "name_on_card_#{payment_method.id}", Spree.t(:name_on_card) %><span class="required">*</span><br />
-  <%= text_field_tag "#{param_prefix}[name]", "#{@order.billing_firstname} #{@order.billing_lastname}", { id: "name_on_card_#{payment_method.id}", autocomplete: "cc-name" } %>
+  <%= text_field_tag "#{param_prefix}[name]", "#{@order.billing_firstname} #{@order.billing_lastname}", { id: "name_on_card_#{payment_method.id}", autocomplete: "cc-name", class: 'cardName' } %>
 </p>
 
-<p class="field" data-hook="card_number">
+<p class="field card_number">
   <%= label_tag "card_number", Spree.t(:card_number) %><span class="required">*</span><br />
   <%= text_field_tag "#{param_prefix}[number]", '', {id: 'card_number', class: 'required cardNumber', size: 19, maxlength: 19, autocomplete: "cc-number", type: "tel"} %>
   &nbsp;
@@ -17,12 +17,12 @@
   </span>
 </p>
 
-<p class="field" data-hook="card_expiration">
+<p class="field card_expiration">
   <%= label_tag "card_expiry", Spree.t(:expiration) %><span class="required">*</span><br />
   <%= text_field_tag "#{param_prefix}[expiry]", '', id: 'card_expiry', class: "required cardExpiry", placeholder: "MM / YY", type: "tel" %>
 </p>
 
-<p class="field" data-hook="card_code">
+<p class="field card_code">
   <%= label_tag "card_code", Spree.t(:card_code) %><span class="required">*</span><br />
   <%= text_field_tag "#{param_prefix}[verification_value]", '', {id: 'card_code', class: 'required cardCode', size: 5, type: "tel", autocomplete: "off"} %>
   <%= link_to "(#{Spree.t(:what_is_this)})", spree.cvv_path, target: '_blank', "data-hook" => "cvv_link", id: "cvv_link" %>


### PR DESCRIPTION
Given that other fields in the partial have a data-hook and class to allow easy customization, I think will be good that `card name` field have the same