### PR TITLE
Deprecate .calculators

### DIFF
--- a/backend/app/controllers/spree/admin/promotion_actions_controller.rb
+++ b/backend/app/controllers/spree/admin/promotion_actions_controller.rb
@@ -3,7 +3,7 @@ class Spree::Admin::PromotionActionsController < Spree::Admin::BaseController
   before_action :validate_promotion_action_type, only: :create
 
   def create
-    @calculators = Spree::Promotion::Actions::CreateAdjustment.calculators
+    @calculators = Rails.application.config.spree.calculators.promotion_actions_create_adjustments
     @promotion_action = @promotion_action_type.new(params[:promotion_action])
     @promotion_action.promotion = @promotion
     if @promotion_action.save

--- a/backend/app/controllers/spree/admin/shipping_methods_controller.rb
+++ b/backend/app/controllers/spree/admin/shipping_methods_controller.rb
@@ -39,7 +39,7 @@ module Spree
       def load_data
         @available_zones = Spree::Zone.order(:name)
         @tax_categories = Spree::TaxCategory.order(:name)
-        @calculators = Spree::ShippingMethod.calculators.sort_by(&:name)
+        @calculators = Rails.application.config.spree.calculators.shipping_methods
       end
     end
   end

--- a/backend/app/controllers/spree/admin/tax_rates_controller.rb
+++ b/backend/app/controllers/spree/admin/tax_rates_controller.rb
@@ -8,7 +8,7 @@ module Spree
       def load_data
         @available_zones = Spree::Zone.order(:name)
         @available_categories = Spree::TaxCategory.order(:name)
-        @calculators = Spree::TaxRate.calculators.sort_by(&:name)
+        @calculators = Rails.application.config.spree.calculators.tax_rates
       end
     end
   end

--- a/backend/app/views/spree/admin/promotions/actions/_create_item_adjustments.html.erb
+++ b/backend/app/views/spree/admin/promotions/actions/_create_item_adjustments.html.erb
@@ -1,6 +1,6 @@
 <%= render(
   "spree/admin/promotions/actions/promotion_calculators_with_custom_fields",
-  calculators: Spree::Promotion::Actions::CreateItemAdjustments.calculators,
+  calculators: Rails.application.config.spree.calculators.promotion_actions_create_item_adjustments,
   promotion_action: promotion_action,
   param_prefix: param_prefix
 ) %>

--- a/core/app/models/concerns/spree/calculated_adjustments.rb
+++ b/core/app/models/concerns/spree/calculated_adjustments.rb
@@ -10,6 +10,8 @@ module Spree
 
     class_methods do
       def calculators
+        Spree::Deprecation.warn("Calling .calculators is deprecated. Please access through Rails.application.config.spree.calculators")
+
         spree_calculators.send model_name_without_spree_namespace
       end
 

--- a/core/app/models/spree/calculator.rb
+++ b/core/app/models/spree/calculator.rb
@@ -27,6 +27,8 @@ module Spree
 
     # Returns all calculators applicable for kind of work
     def self.calculators
+      Spree::Deprecation.warn("Calling .calculators is deprecated. Please access through Rails.application.config.spree.calculators")
+
       Rails.application.config.spree.calculators
     end
 

--- a/core/spec/models/spree/calculator_spec.rb
+++ b/core/spec/models/spree/calculator_spec.rb
@@ -10,6 +10,16 @@ describe Spree::Calculator, type: :model do
   class SimpleComputable
   end
 
+  describe "#calculators" do
+    subject { Spree::Calculator.calculators }
+
+    it 'returns the (deprecated) calculator step' do
+      Spree::Deprecation.silence do
+        expect(subject).to be_a Spree::Core::Environment::Calculators
+      end
+    end
+  end
+
   context "with computable" do
     let(:calculator) { SimpleCalculator.new }
     let(:computable) { SimpleComputable.new }


### PR DESCRIPTION
There are almost no reasonable reasons why these should be called
through the class models the way they are, near as I can tell they're
only ever used for display/form purposes in the backend.