### PR TITLE
[WIP] fix credit_card missing values when process order

### DIFF
--- a/frontend/spec/features/checkout_spec.rb
+++ b/frontend/spec/features/checkout_spec.rb
@@ -658,6 +658,12 @@ describe "Checkout", type: :feature, inaccessible: true do
       click_on "Save and Continue"
 
       expect(page).to have_current_path("/checkout/confirm")
+
+      payments = Spree::Order.last.payments
+      expect(payments.count).to eq(1)
+      expect(payments.first.source.number).to eq("4111111111111111")
+      click_button "Place Order"
+      expect(page).to have_content("Your order has been processed successfully")
     end
   end
 


### PR DESCRIPTION
Like commented in #2149 there is a problem with credit_card, when process payment it's not having `number` and `verification_value`.

I was debugging the problem and found that after the order enter to confirm state this values are not present anymore.
I added some expectations to notice the error.

I was checking in checkout controller in frontend and in order models in core (order | order/checkout | order/payments), but I couldn't figurate how to solve the problem.

I hope someone with more experience with the framework can give me some advice on where to look in order to solve this problem.