### PR TITLE
Add the v2.3 release date in the CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@
 
 - Move preferences namespace to /lib. Initializes the Spree::Config object in its own file. [\#2178](https://github.com/solidusio/solidus/pull/2178) ([cbrunsdon](https://github.com/cbrunsdon))
 
-## Solidus 2.3.0 (unreleased)
+## Solidus 2.3.0 (2017-07-31)
 
 - Rails 5.1 [\#1895](https://github.com/solidusio/solidus/pull/1895) ([jhawthorn](https://github.com/jhawthorn))
 


### PR DESCRIPTION
v2.3 was released July 31. There was some confusion about this in the Solidus slack.