### PR TITLE
Avoid duplicate queries when running estimator taxation.

### DIFF
--- a/core/app/models/spree/tax/shipping_rate_taxer.rb
+++ b/core/app/models/spree/tax/shipping_rate_taxer.rb
@@ -8,7 +8,7 @@ module Spree
       #   This parameter will be modified.
       # @return [Spree::ShippingRate] The shipping rate with associated tax objects
       def tax(shipping_rate)
-        taxes = Spree::Config.shipping_rate_tax_calculator_class.new(shipping_rate).calculate
+        taxes = Spree::Config.shipping_rate_tax_calculator_class.new(shipping_rate.order).calculate(shipping_rate)
         taxes.each do |tax|
           shipping_rate.taxes.build(
             amount: tax.amount,

--- a/core/app/models/spree/tax_calculator/shipping_rate.rb
+++ b/core/app/models/spree/tax_calculator/shipping_rate.rb
@@ -21,15 +21,24 @@ module Spree
       # @param [Spree::ShippingRate] shipping_rate the shipping rate to
       #   calculate taxes on
       # @return [Spree::TaxCalculator::ShippingRate]
-      def initialize(shipping_rate)
-        @shipping_rate = shipping_rate
+      def initialize(order)
+        if order.is_a?(::Spree::ShippingRate)
+          Spree::Deprecation.warn "passing a single shipping rate to Spree::TaxCalculator::ShippingRate is DEPRECATED. It now expects an order"
+          shipping_rate = order
+          @order = shipping_rate.order
+          @shipping_rate = shipping_rate
+        else
+          @order = order
+          @shipping_rate = nil
+        end
       end
 
       # Calculate taxes for a shipping rate.
       #
       # @return [Array<Spree::Tax::ItemTax>] the calculated taxes for the
       #   shipping rate
-      def calculate
+      def calculate(shipping_rate)
+        shipping_rate ||= @shipping_rate
         rates_for_item(shipping_rate).map do |rate|
           amount = rate.compute_amount(shipping_rate)
 

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -287,8 +287,6 @@ module Spree
 
     class_name_attribute :shipping_rate_selector_class, default: 'Spree::Stock::ShippingRateSelector'
 
-    class_name_attribute :shipping_rate_taxer_class, default: 'Spree::Tax::ShippingRateTaxer'
-
     # Allows providing your own class for calculating taxes on a shipping rate.
     #
     # @!attribute [rw] shipping_rate_tax_calculator_class

--- a/core/spec/models/spree/stock/estimator_spec.rb
+++ b/core/spec/models/spree/stock/estimator_spec.rb
@@ -189,20 +189,19 @@ module Spree
         end
 
         it 'uses the configured shipping rate taxer' do
-          class Spree::Tax::TestTaxer
-            def initialize
+          class Spree::Tax::TestTaxCalculator
+            def initialize(_order)
             end
 
-            def tax(_)
-              Spree::ShippingRate.new
+            def calculate(_shipping_rate)
+              [
+                Spree::Tax::ItemTax.new(label: "TAX", amount: 5)
+              ]
             end
           end
-          Spree::Config.shipping_rate_taxer_class = Spree::Tax::TestTaxer
+          Spree::Config.shipping_rate_tax_calculator_class = Spree::Tax::TestTaxCalculator
 
-          shipping_rate = Spree::ShippingRate.new
-          allow(Spree::ShippingRate).to receive(:new).and_return(shipping_rate)
-
-          expect(Spree::Tax::TestTaxer).to receive(:new).and_call_original
+          expect(Spree::Tax::TestTaxCalculator).to receive(:new).and_call_original
           subject.shipping_rates(package)
         end
       end


### PR DESCRIPTION
Fix for #2204

Instead of loading the tax rates for the order for each rate which needs taxing, we can perform the SQL queries only once.

This is done by building a single instance of the shipping_rate_tax_calculator_class for a shipment, and calling `calculate` on that object for each rate, allowing it to cache the order rates.

This removes the `shipping_rate_taxer_class` config option, which was necessary to use `shipping_rate_tax_calculator_class` directly from the estimator.

I'm not sure this is the best way to achieve this, but I hope it illustrates the issue and one solution to it.