### PR TITLE
Run mysql builds as root on TravisCI

### DIFF
--- a/core/lib/generators/spree/dummy/templates/rails/database.yml
+++ b/core/lib/generators/spree/dummy/templates/rails/database.yml
@@ -20,6 +20,10 @@ development:
   encoding: utf8
 test:
   adapter: mysql2
+  <% if ENV['TRAVIS'] %>
+  username: root
+  password:
+  <% end %>
   database: <%= database_prefix %><%= options[:lib_name] %>_solidus_test
   encoding: utf8
 production:


### PR DESCRIPTION
If running our builds (including extensions) we need to run our MySQL builds with root user.
This is necessary because of latest changes to the build environment.

See: https://github.com/travis-ci/travis-ci/issues/8331