### PR TITLE
Use payment.number instead of payment.identifier in admin view

### DIFF
--- a/backend/app/views/spree/admin/shared/_refunds.html.erb
+++ b/backend/app/views/spree/admin/shared/_refunds.html.erb
@@ -16,7 +16,7 @@
     <% refunds.each do |refund| %>
       <tr id="<%= dom_id(refund) %>" data-hook="refunds_row">
         <td><%= pretty_time(refund.created_at) %></td>
-        <td><%= refund.payment.identifier %></td>
+        <td><%= refund.payment.number %></td>
         <td class="amount"><%= refund.display_amount %></td>
         <td><%= payment_method_name(refund.payment) %></td>
         <td><%= refund.transaction_id %></td>


### PR DESCRIPTION
"identifier" was deprecated in https://github.com/solidusio/solidus/pull/444