### PR TITLE
Remove redundant ruby version lines in gemspecs

### DIFF
--- a/backend/solidus_backend.gemspec
+++ b/backend/solidus_backend.gemspec
@@ -8,7 +8,6 @@ Gem::Specification.new do |s|
   s.summary     = 'Admin interface for the Solidus e-commerce framework.'
   s.description = s.summary
 
-  s.required_ruby_version = '>= 2.1.0'
   s.author      = 'Solidus Team'
   s.email       = 'contact@solidus.io'
   s.homepage    = 'http://solidus.io'

--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -8,7 +8,6 @@ Gem::Specification.new do |s|
   s.summary     = 'Essential models, mailers, and classes for the Solidus e-commerce project.'
   s.description = s.summary
 
-  s.required_ruby_version = '>= 2.1.0'
   s.author      = 'Solidus Team'
   s.email       = 'contact@solidus.io'
   s.homepage    = 'http://solidus.io'

--- a/frontend/solidus_frontend.gemspec
+++ b/frontend/solidus_frontend.gemspec
@@ -8,7 +8,6 @@ Gem::Specification.new do |s|
   s.summary     = 'Cart and storefront for the Solidus e-commerce project.'
   s.description = s.summary
 
-  s.required_ruby_version = '>= 2.1.0'
   s.author      = 'Solidus Team'
   s.email       = 'contact@solidus.io'
   s.homepage    = 'http://solidus.io/'

--- a/sample/solidus_sample.gemspec
+++ b/sample/solidus_sample.gemspec
@@ -8,7 +8,6 @@ Gem::Specification.new do |s|
   s.summary     = 'Sample data (including images) for use with Solidus.'
   s.description = s.summary
 
-  s.required_ruby_version = '>= 2.1.0'
   s.author      = 'Solidus Team'
   s.email       = 'contact@solidus.io'
   s.homepage    = 'http://solidus.io/'


### PR DESCRIPTION
The required ruby version was bumped in a69257b. Some of the previous
ruby version declarations were left behind.