### PR TITLE
Move editing of shipment method and tracking into JS views and templates

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/collections/index.js
+++ b/backend/app/assets/javascripts/spree/backend/collections/index.js
@@ -1,2 +1,3 @@
 //= require spree/backend/collections/line_items
+//= require spree/backend/collections/shipments
 //= require spree/backend/collections/states

--- a/backend/app/assets/javascripts/spree/backend/collections/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/collections/shipments.js
@@ -1,0 +1,10 @@
+//= require spree/backend/routes
+//= require spree/backend/models/shipment
+
+Spree.Collections.Shipments = Backbone.Collection.extend({
+  model: Spree.Models.Shipment,
+
+  url: function () {
+    return Spree.routes.shipments_api;
+  }
+})

--- a/backend/app/assets/javascripts/spree/backend/collections/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/collections/shipments.js
@@ -2,9 +2,5 @@
 //= require spree/backend/models/shipment
 
 Spree.Collections.Shipments = Backbone.Collection.extend({
-  model: Spree.Models.Shipment,
-
-  url: function () {
-    return Spree.routes.shipments_api;
-  }
+  model: Spree.Models.Shipment
 })

--- a/backend/app/assets/javascripts/spree/backend/handlebars_extensions.js
+++ b/backend/app/assets/javascripts/spree/backend/handlebars_extensions.js
@@ -9,6 +9,10 @@ Handlebars.registerHelper("human_attribute_name", function(model, attr) {
   return Spree.human_attribute_name(model, attr);
 });
 
+Handlebars.registerHelper("human_model_name", function(model) {
+  return Spree.human_model_name(model);
+});
+
 Handlebars.registerHelper("admin_url", function() {
   return Spree.pathFor("admin")
 });

--- a/backend/app/assets/javascripts/spree/backend/handlebars_extensions.js
+++ b/backend/app/assets/javascripts/spree/backend/handlebars_extensions.js
@@ -20,3 +20,7 @@ Handlebars.registerHelper("admin_url", function() {
 Handlebars.registerHelper("concat", function() {
   return Array.prototype.slice.call(arguments, 0, -1).join('');
 });
+
+Handlebars.registerHelper("format_money", function(amount, currency) {
+  return Spree.formatMoney(amount, currency);
+});

--- a/backend/app/assets/javascripts/spree/backend/models/index.js
+++ b/backend/app/assets/javascripts/spree/backend/models/index.js
@@ -1,4 +1,5 @@
 //= require spree/backend/models/image_upload
 //= require spree/backend/models/line_item
 //= require spree/backend/models/order
+//= require spree/backend/models/shipment
 //= require spree/backend/models/taxonomy

--- a/backend/app/assets/javascripts/spree/backend/models/order.js
+++ b/backend/app/assets/javascripts/spree/backend/models/order.js
@@ -1,5 +1,6 @@
 //= require spree/backend/routes
 //= require spree/backend/collections/line_items
+//= require spree/backend/collections/shipments
 //= require spree/backend/models/address
 
 Spree.Models.Order = Backbone.Model.extend({
@@ -8,7 +9,7 @@ Spree.Models.Order = Backbone.Model.extend({
 
   relations: {
     "line_items": Spree.Collections.LineItems,
-    "shipments": Backbone.Collection,
+    "shipments": Spree.Collections.Shipments,
     "bill_address": Spree.Models.Address,
     "ship_address": Spree.Models.Address
   },

--- a/backend/app/assets/javascripts/spree/backend/models/shipment.js
+++ b/backend/app/assets/javascripts/spree/backend/models/shipment.js
@@ -1,0 +1,8 @@
+Spree.Models.Shipment = Backbone.Model.extend({
+  idAttribute: "number",
+
+  relations: {
+    "selected_shipping_rate": Backbone.Model,
+    "shipping_rates": Backbone.Collection,
+  }
+})

--- a/backend/app/assets/javascripts/spree/backend/models/shipment.js
+++ b/backend/app/assets/javascripts/spree/backend/models/shipment.js
@@ -1,5 +1,7 @@
 Spree.Models.Shipment = Backbone.Model.extend({
   idAttribute: "number",
+  paramRoot: "shipment",
+  urlRoot: Spree.routes.shipments_api,
 
   relations: {
     "selected_shipping_rate": Backbone.Model,

--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -269,9 +269,8 @@ var ShipmentItemView = Backbone.View.extend({
 
 var ShipmentEditView = Backbone.View.extend({
   initialize: function(){
-    var tbody = this.$("tbody[data-order-number][data-shipment-number]");
-    this.shipment_number = tbody.data("shipment-number");
-    this.order_number = tbody.data("order-number");
+    this.shipment_number = this.model.get('number')
+    this.order_number = this.model.collection.parent.get('number')
 
     var shipmentView = this;
     this.$("form.admin-ship-shipment").each(function(el){

--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -339,7 +339,18 @@ var ShipmentEditView = Backbone.View.extend({
 });
 
 $(function(){
-  $(".js-shipment-edit").each(function(){
-    new ShipmentEditView({ el: this });
-  });
+  if($('.js-shipment-edit [data-order-number]').length) {
+    $('.js-shipment-edit').hide();
+    var orderNumber = $('.js-shipment-edit [data-order-number]').data('orderNumber');
+    var order = Spree.Models.Order.fetch(orderNumber, {
+      success: function(order){
+        $('.js-shipment-edit').show();
+        $(".js-shipment-edit").each(function(){
+          var shipmentNumber = $('[data-shipment-number]', this).data('shipmentNumber')
+          var shipment = order.get("shipments").find({number: shipmentNumber})
+          new ShipmentEditView({ el: this, model: shipment });
+        });
+      }
+    });
+  }
 });

--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -272,6 +272,8 @@ var ShipmentEditView = Backbone.View.extend({
     this.shipment_number = this.model.get('number')
     this.order_number = this.model.collection.parent.get('number')
 
+    var shipment = this.model;
+
     var shipmentView = this;
     this.$("form.admin-ship-shipment").each(function(el){
       new ShipShipmentView({
@@ -286,32 +288,19 @@ var ShipmentEditView = Backbone.View.extend({
         order_number: shipmentView.order_number
       });
     });
+    this.$(".edit-shipping-method").each(function(el){
+      new Spree.Views.Order.ShippingMethod({
+        el: this,
+        model: shipment,
+        shipment_number: shipmentView.shipment_number
+      });
+    });
   },
 
   events: {
-    "click button.edit-method": "toggleMethodEdit",
-    "click button.cancel-method": "toggleMethodEdit",
-    "click button.save-method": "saveMethod",
-
     "click button.edit-tracking": "toggleTrackingEdit",
     "click button.cancel-tracking": "toggleTrackingEdit",
     "click button.save-tracking": "saveTracking",
-  },
-
-  toggleMethodEdit: function(e){
-    e.preventDefault();
-    this.$('tr.edit-method').toggle();
-    this.$('tr.show-method').toggle();
-  },
-
-  saveMethod: function(e) {
-    e.preventDefault();
-    var selected_shipping_rate_id = this.$("select#selected_shipping_rate_id").val();
-    updateShipment(this.shipment_number, {
-      selected_shipping_rate_id: selected_shipping_rate_id
-    }).done(function () {
-      window.location.reload();
-    });
   },
 
   toggleTrackingEdit: function(e) {

--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -57,18 +57,6 @@ var ShipShipmentView = Backbone.View.extend({
   }
 });
 
-updateShipment = function(shipment_number, attributes) {
-  var url = Spree.routes.shipments_api + '/' + shipment_number;
-
-  return Spree.ajax({
-    type: 'PUT',
-    url: url,
-    data: {
-      shipment: attributes
-    }
-  });
-};
-
 adjustShipmentItems = function(shipment_number, variant_id, quantity){
   var shipment = _.findWhere(shipments, {number: shipment_number});
   var inventory_units = _.where(shipment.inventory_units, {variant_id: variant_id});
@@ -295,33 +283,11 @@ var ShipmentEditView = Backbone.View.extend({
         shipment_number: shipmentView.shipment_number
       });
     });
-  },
-
-  events: {
-    "click button.edit-tracking": "toggleTrackingEdit",
-    "click button.cancel-tracking": "toggleTrackingEdit",
-    "click button.save-tracking": "saveTracking",
-  },
-
-  toggleTrackingEdit: function(e) {
-    e.preventDefault();
-    this.$("tr.edit-tracking").toggle();
-    this.$("tr.show-tracking").toggle();
-  },
-
-  saveTracking: function(e) {
-    e.preventDefault();
-    var tracking = this.$('[name="tracking"]').val();
-    var _this = this;
-    updateShipment(this.shipment_number, {
-      tracking: tracking
-    }).done(function (data) {
-      _this.$('tr.edit-tracking').toggle();
-
-      var show = _this.$('tr.show-tracking');
-      show.toggle()
-        .find('.tracking-value')
-        .text(data.tracking);
+    this.$(".edit-tracking").each(function(el){
+      new Spree.Views.Order.ShipmentTracking({
+        el: this,
+        model: shipment
+      });
     });
   }
 });

--- a/backend/app/assets/javascripts/spree/backend/templates/index.js
+++ b/backend/app/assets/javascripts/spree/backend/templates/index.js
@@ -2,6 +2,7 @@
 //= require spree/backend/templates/orders/customer_details/autocomplete
 //= require spree/backend/templates/orders/details_adjustment_row
 //= require spree/backend/templates/orders/line_item
+//= require spree/backend/templates/orders/shipping_method
 //= require spree/backend/templates/products/sortable
 //= require spree/backend/templates/products/upload_progress
 //= require spree/backend/templates/promotions/calculators/fields/tiered_flat_rate

--- a/backend/app/assets/javascripts/spree/backend/templates/index.js
+++ b/backend/app/assets/javascripts/spree/backend/templates/index.js
@@ -2,6 +2,7 @@
 //= require spree/backend/templates/orders/customer_details/autocomplete
 //= require spree/backend/templates/orders/details_adjustment_row
 //= require spree/backend/templates/orders/line_item
+//= require spree/backend/templates/orders/shipment_tracking
 //= require spree/backend/templates/orders/shipping_method
 //= require spree/backend/templates/products/sortable
 //= require spree/backend/templates/products/upload_progress

--- a/backend/app/assets/javascripts/spree/backend/templates/orders/shipment_tracking.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/orders/shipment_tracking.hbs
@@ -1,0 +1,22 @@
+<th>
+  {{ human_attribute_name "spree/shipment" "tracking" }}
+</th>
+<td colspan="4">
+  {{#if editing}}
+    <input type="text" name="tracking" class="fullwidth" value="{{tracking}}">
+  {{else}}
+    {{#if tracking}}
+      {{ tracking }}
+    {{else}}
+      {{ t "no_tracking_present" }}
+    {{/if}}
+  {{/if}}
+</td>
+<td class="actions">
+  {{#if editing}}
+    <button class="js-save fa fa-check no-text with-tip" data-action="save" title="{{ t "actions.save" }}"></button>
+    <button class="js-cancel fa fa-cancel no-text with-tip" data-action="cancel" title="{{ t "actions.cancel" }}"></button>
+  {{else}}
+    <button class="js-edit fa fa-edit no-text with-tip" data-action="edit" title=""{{ t "actions.edit" }}"></button>
+  {{/if}}
+</td>

--- a/backend/app/assets/javascripts/spree/backend/templates/orders/shipment_tracking.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/orders/shipment_tracking.hbs
@@ -3,7 +3,9 @@
 </th>
 <td colspan="4">
   {{#if editing}}
-    <input type="text" name="tracking" class="fullwidth" value="{{tracking}}">
+    <form>
+      <input type="text" name="tracking" class="fullwidth" value="{{tracking}}">
+    </form>
   {{else}}
     {{#if tracking}}
       {{ tracking }}

--- a/backend/app/assets/javascripts/spree/backend/templates/orders/shipping_method.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/orders/shipping_method.hbs
@@ -1,0 +1,28 @@
+<th>
+  {{ human_model_name "spree/shipping_method" }}
+</th>
+{{#if editing}}
+<td colspan="4">
+  <select class="custom-select fullwidth" name="selected_shipping_rate_id">
+    {{#each shipping_rates}}
+    <option value="{{ id }}">{{name}} {{display_cost}}</option>
+    {{/each}}
+  </select>
+</td>
+{{else}}
+<td colspan="3">
+  {{ selected_shipping_rate.name }}
+</td>
+<td class="total">
+  {{ format_money selected_shipping_rate.cost order.currency }}
+</td>
+{{/if}}
+
+<td class="actions">
+  {{#if editing}}
+    <button class="js-save fa fa-check no-text with-tip" data-action="save" title="{{ t "actions.save" }}"></button>
+    <button class="js-cancel fa fa-cancel no-text with-tip" data-action="cancel" title="{{ t "actions.cancel" }}"></button>
+  {{else}}
+    <button class="js-edit fa fa-edit no-text with-tip" data-action="edit" title=""{{ t "actions.edit" }}"></button>
+  {{/if}}
+</td>

--- a/backend/app/assets/javascripts/spree/backend/templates/orders/shipping_method.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/orders/shipping_method.hbs
@@ -3,11 +3,13 @@
 </th>
 {{#if editing}}
 <td colspan="4">
-  <select class="custom-select fullwidth" name="selected_shipping_rate_id">
-    {{#each shipping_rates}}
-    <option value="{{ id }}">{{name}} {{display_cost}}</option>
-    {{/each}}
-  </select>
+  <form>
+    <select class="custom-select fullwidth" name="selected_shipping_rate_id">
+      {{#each shipping_rates}}
+      <option value="{{ id }}">{{name}} {{display_cost}}</option>
+      {{/each}}
+    </select>
+  </form>
 </td>
 {{else}}
 <td colspan="3">

--- a/backend/app/assets/javascripts/spree/backend/translation.js
+++ b/backend/app/assets/javascripts/spree/backend/translation.js
@@ -26,4 +26,13 @@
   Spree.human_attribute_name = function(model, attr) {
     return Spree.t("activerecord.attributes." + model + '.' + attr);
   }
+
+  Spree.human_model_name = function(model) {
+    var model_name = Spree.t("activerecord.models." + model);
+    if(_.isString(model_name)) {
+      return model_name;
+    } else {
+      return model_name.one;
+    }
+  }
 })();

--- a/backend/app/assets/javascripts/spree/backend/views/index.js
+++ b/backend/app/assets/javascripts/spree/backend/views/index.js
@@ -8,6 +8,7 @@
 //= require 'spree/backend/views/order/details_total'
 //= require 'spree/backend/views/order/customer_details'
 //= require 'spree/backend/views/order/customer_select'
+//= require 'spree/backend/views/order/shipment_tracking'
 //= require 'spree/backend/views/order/shipping_method'
 //= require 'spree/backend/views/order/summary'
 //= require 'spree/backend/views/state_select'

--- a/backend/app/assets/javascripts/spree/backend/views/index.js
+++ b/backend/app/assets/javascripts/spree/backend/views/index.js
@@ -8,6 +8,7 @@
 //= require 'spree/backend/views/order/details_total'
 //= require 'spree/backend/views/order/customer_details'
 //= require 'spree/backend/views/order/customer_select'
+//= require 'spree/backend/views/order/shipping_method'
 //= require 'spree/backend/views/order/summary'
 //= require 'spree/backend/views/state_select'
 //= require 'spree/backend/views/zones/form'

--- a/backend/app/assets/javascripts/spree/backend/views/order/shipment_tracking.js
+++ b/backend/app/assets/javascripts/spree/backend/views/order/shipment_tracking.js
@@ -1,0 +1,43 @@
+Spree.Views.Order.ShipmentTracking = Backbone.View.extend({
+  tagName: 'tr',
+  className: 'edit-tracking',
+
+  events: {
+    "click .js-edit":   "onEdit",
+    "click .js-save":   "onSave",
+    "click .js-cancel": "onCancel",
+  },
+
+  initialize: function(options) {
+    this.render();
+  },
+
+  onEdit: function(event) {
+    this.editing = true;
+    this.render();
+  },
+
+  onSave: function(event) {
+    this.editing = false;
+    this.model.save({
+      tracking: this.$('input[type="text"]').val()
+    }, {
+      patch: true
+    });
+    this.render();
+  },
+
+  onCancel: function(event) {
+    this.editing = false;
+    this.render();
+  },
+
+  render: function() {
+    var html = HandlebarsTemplates['orders/shipment_tracking']({
+      editing: this.editing,
+      tracking: this.model.get("tracking"),
+    });
+
+    this.$el.html(html);
+  }
+});

--- a/backend/app/assets/javascripts/spree/backend/views/order/shipment_tracking.js
+++ b/backend/app/assets/javascripts/spree/backend/views/order/shipment_tracking.js
@@ -5,6 +5,7 @@ Spree.Views.Order.ShipmentTracking = Backbone.View.extend({
   events: {
     "click .js-edit":   "onEdit",
     "click .js-save":   "onSave",
+    "submit form":      "onSave",
     "click .js-cancel": "onCancel",
   },
 
@@ -25,6 +26,8 @@ Spree.Views.Order.ShipmentTracking = Backbone.View.extend({
       patch: true
     });
     this.render();
+
+    return false;
   },
 
   onCancel: function(event) {

--- a/backend/app/assets/javascripts/spree/backend/views/order/shipping_method.js
+++ b/backend/app/assets/javascripts/spree/backend/views/order/shipping_method.js
@@ -1,0 +1,51 @@
+Spree.Views.Order.ShippingMethod = Backbone.View.extend({
+  tagName: 'tr',
+  className: 'edit-shipping-method',
+
+  events: {
+    "click .js-edit":   "onEdit",
+    "click .js-save":   "onSave",
+    "click .js-cancel": "onCancel",
+  },
+
+  initialize: function(options) {
+    this.shippingRateId = this.model.get('selected_shipping_rate').get('id')
+    this.render();
+  },
+
+  onEdit: function(event) {
+    this.editing = true;
+    this.render();
+  },
+
+  onSave: function(event) {
+    this.editing = false;
+    this.model.save({
+      selected_shipping_rate_id: this.$('select').val()
+    }, {
+      patch: true,
+      success: function() {
+        // FIXME: should update page without reloading
+        window.location.reload();
+      }
+    });
+  },
+
+  onCancel: function(event) {
+    this.editing = false;
+    this.render();
+  },
+
+  render: function() {
+    var html = HandlebarsTemplates['orders/shipping_method']({
+      editing: this.editing,
+      order: this.model.collection.parent.toJSON(),
+      shipment: this.model.toJSON(),
+      selected_shipping_rate: this.model.get("selected_shipping_rate").toJSON(),
+      shipping_rates: this.model.get("shipping_rates").toJSON()
+    });
+
+    this.$el.html(html);
+    this.$('select').val(this.shippingRateId);
+  }
+})

--- a/backend/app/assets/javascripts/spree/backend/views/order/shipping_method.js
+++ b/backend/app/assets/javascripts/spree/backend/views/order/shipping_method.js
@@ -5,7 +5,8 @@ Spree.Views.Order.ShippingMethod = Backbone.View.extend({
   events: {
     "click .js-edit":   "onEdit",
     "click .js-save":   "onSave",
-    "click .js-cancel": "onCancel",
+    "submit form":      "onSave",
+    "click .js-cancel": "onCancel"
   },
 
   initialize: function(options) {
@@ -29,6 +30,8 @@ Spree.Views.Order.ShippingMethod = Backbone.View.extend({
         window.location.reload();
       }
     });
+
+    return false;
   },
 
   onCancel: function(event) {

--- a/backend/app/views/spree/admin/orders/_shipment.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment.html.erb
@@ -47,43 +47,9 @@
       <%= render 'spree/admin/orders/shipment_manifest', { shipment_number: shipment.number, shipment_manifest: manifest_items } %>
 
       <% unless shipment.shipped? %>
-        <tr class="edit-method hidden total">
-          <th><%= Spree::ShippingMethod.model_name.human %></th>
-          <td colspan="4">
-            <%= select_tag :selected_shipping_rate_id,
-              options_for_select(shipment.shipping_rates.map {|sr| ["#{sr.name} #{sr.display_price}", sr.id] }, shipment.selected_shipping_rate_id),
-              {class: 'custom-select fullwidth', data: {'shipment-number' => shipment.number } } %>
-          </td>
-          <td class="actions">
-            <% if can? :update, shipment %>
-              <%= button_tag '', class: 'save-method fa fa-check no-text with-tip',
-                data: {'shipment-number' => shipment.number, action: 'save'}, title: Spree.t('actions.save') %>
-              <%= button_tag '', class: 'cancel-method fa fa-cancel no-text with-tip',
-                data: {action: 'cancel'}, title: Spree.t('actions.cancel') %>
-            <% end %>
-          </td>
+        <tr class="edit-shipping-method">
         </tr>
-        <% end %>
-
-        <tr class="show-method total">
-          <% if rate = shipment.selected_shipping_rate %>
-            <th><%= Spree::ShippingMethod.model_name.human %></th>
-            <td colspan="3">
-              <%= rate.name %>
-            </td>
-            <td class="total">
-              <%= shipment.display_cost %>
-            </td>
-          <% else %>
-            <td colspan="5"><%= Spree.t(:no_shipping_method_selected) %></td>
-          <% end %>
-
-          <td class="actions">
-            <% if can?(:update, shipment) && !shipment.shipped? %>
-              <%= button_tag '', class: 'edit-method fa fa-edit no-text with-tip', data: {action: 'edit'}, title: Spree.t('actions.edit'), type: :button %>
-            <% end %>
-          </td>
-        </tr>
+      <% end %>
 
       <tr class="edit-tracking hidden total">
         <th><%= Spree::Shipment.human_attribute_name(:tracking) %></th>

--- a/backend/app/views/spree/admin/orders/_shipment.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment.html.erb
@@ -51,17 +51,7 @@
         </tr>
       <% end %>
 
-      <tr class="edit-tracking hidden total">
-        <th><%= Spree::Shipment.human_attribute_name(:tracking) %></th>
-        <td colspan="4">
-          <%= text_field_tag :tracking, shipment.tracking, id: nil %>
-        </td>
-        <td class="actions">
-          <% if can? :update, shipment %>
-            <%= button_tag '', class: 'save-tracking fa fa-check no-text with-tip', data: { action: 'save', 'shipment-number' => shipment.number }, title: Spree.t('actions.save'), type: :button %>
-            <%= button_tag '', class: 'cancel-tracking fa fa-cancel no-text with-tip', data: { action: 'cancel' }, title: Spree.t('actions.cancel'), type: :button %>
-          <% end %>
-        </td>
+      <tr class="edit-tracking">
       </tr>
 
       <% if order.special_instructions.present? %>
@@ -71,22 +61,6 @@
           </td>
         </tr>
       <% end %>
-
-      <tr class="show-tracking total">
-        <th><%= Spree::Shipment.human_attribute_name(:tracking) %></th>
-        <td colspan="4" class="tracking-value">
-          <% if shipment.tracking.present? %>
-            <%= shipment.tracking %>
-          <% else %>
-            <i><%= Spree.t(:no_tracking_present) %></i>
-          <% end %>
-        </td>
-        <td class="actions">
-          <% if can? :update, shipment %>
-            <%= button_tag '', class: 'edit-tracking fa fa-edit no-text with-tip', data: {action: 'edit'}, title: Spree.t('actions.edit'), type: :button %>
-          <% end %>
-        </td>
-      </tr>
     </tbody>
   </table>
 </div>

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -9,9 +9,13 @@ describe "Order Details", type: :feature, js: true do
   let!(:tote) { create(:product, name: "Tote", price: 15.00) }
   let(:order) { create(:order, state: 'complete', completed_at: "2011-02-01 12:36:15", number: "R100") }
   let(:state) { create(:state) }
+  let(:line_item) { order.line_items.first }
+
+  let!(:shipment1) do
+    order.shipments.create(stock_location_id: stock_location.id)
+  end
 
   before do
-    @shipment1 = order.shipments.create(stock_location_id: stock_location.id)
     order.contents.add(product.master, 2)
     # order.contents.add causes things (like line items & shipments) to get
     # cached, and these are going to change during this spec so we go ahead and
@@ -32,7 +36,7 @@ describe "Order Details", type: :feature, js: true do
         expect(page).to have_content("spree t-shirt")
         expect(page).to have_content("$40.00")
 
-        within_row(1) do
+        within('tr', text: line_item.sku) do
           click_icon :edit
           fill_in "quantity", with: "1"
         end
@@ -54,7 +58,7 @@ describe "Order Details", type: :feature, js: true do
       it "can remove an item from a shipment" do
         expect(page).to have_content("spree t-shirt")
 
-        within_row(1) do
+        within('tr', text: line_item.sku) do
           accept_confirm "Are you sure you want to delete this record?" do
             click_icon :trash
           end
@@ -70,7 +74,7 @@ describe "Order Details", type: :feature, js: true do
       it "can cancel removing an item from a shipment" do
         expect(page).to have_content("spree t-shirt")
 
-        within_row(1) do
+        within('tr', text: line_item.sku) do
           # Click "cancel" on confirmation dialog
           dismiss_confirm "Are you sure you want to delete this record?" do
             click_icon :trash
@@ -83,31 +87,32 @@ describe "Order Details", type: :feature, js: true do
       it "can add tracking information" do
         visit spree.edit_admin_order_path(order)
 
-        within(".show-tracking") do
+        within("tr", text: "Tracking Number") do
           click_icon :edit
+          fill_in "tracking", with: "FOOBAR"
+          click_icon :check
+
+          expect(page).not_to have_css("input")
+          expect(page).to have_content("Tracking Number FOOBAR")
         end
-        fill_in "tracking", with: "FOOBAR"
-        click_icon :check
-
-        expect(page).not_to have_css("input[name=tracking]")
-        expect(page).to have_content("Tracking Number FOOBAR")
-      end
-
-      it "can change the shipping method" do
-        order = create(:completed_order_with_totals)
-        visit spree.edit_admin_order_path(order)
-        within("table.index tr.show-method") do
-          click_icon :edit
-        end
-        select "UPS Ground $100.00", from: "selected_shipping_rate_id"
-        click_icon :check
-
-        expect(page).not_to have_css('#selected_shipping_rate_id')
-        expect(page).to have_content("UPS Ground")
       end
 
       context "with a completed order" do
         let!(:order) { create(:completed_order_with_totals) }
+        let(:shipment1) { order.shipments[0] }
+
+        it "can change the shipping method" do
+          visit spree.edit_admin_order_path(order)
+
+          within("tr", text: "Shipping Method") do
+            click_icon :edit
+            select "UPS Ground $100.00"
+            click_icon :check
+          end
+
+          expect(page).not_to have_css('#selected_shipping_rate_id')
+          expect(page).to have_content("UPS Ground")
+        end
 
         it "will show the variant sku" do
           visit spree.edit_admin_order_path(order)
@@ -178,7 +183,7 @@ describe "Order Details", type: :feature, js: true do
             expect(order.shipments.count).to eq(1)
             expect(order.shipments.first.inventory_units_for(product.master).count).to eq(2)
 
-            within_row(1) { click_icon 'arrows-h' }
+            within('tr', text: line_item.sku) { click_icon 'arrows-h' }
             complete_split_to(stock_location2)
 
             expect(page).to have_css('.shipment', count: 2)
@@ -192,7 +197,7 @@ describe "Order Details", type: :feature, js: true do
           it 'should allow me to make a transfer via splitting off all stock' do
             expect(order.shipments.first.stock_location.id).to eq(stock_location.id)
 
-            within_row(1) { click_icon 'arrows-h' }
+            within('tr', text: line_item.sku) { click_icon 'arrows-h' }
             complete_split_to(stock_location2, quantity: 2)
 
             expect(page).to have_content("Pending package from 'Clarksville'")
@@ -206,7 +211,7 @@ describe "Order Details", type: :feature, js: true do
           it 'should not allow me to split more than I had in the original shipment' do
             expect(order.shipments.first.stock_location.id).to eq(stock_location.id)
 
-            within_row(1) { click_icon 'arrows-h' }
+            within('tr', text: line_item.sku) { click_icon 'arrows-h' }
             complete_split_to(stock_location2, quantity: 5)
 
             expect(page).to have_content("Pending package from 'Clarksville'")
@@ -220,7 +225,7 @@ describe "Order Details", type: :feature, js: true do
           it 'should not allow less than or equal to zero qty' do
             expect(order.shipments.first.stock_location.id).to eq(stock_location.id)
 
-            within_row(1) { click_icon 'arrows-h' }
+            within('tr', text: line_item.sku) { click_icon 'arrows-h' }
 
             accept_alert "Quantity must be greater than 0" do
               complete_split_to(stock_location2, quantity: 0)
@@ -262,7 +267,7 @@ describe "Order Details", type: :feature, js: true do
               product.master.stock_items.last.update_column(:backorderable, false)
               product.master.stock_items.last.update_column(:count_on_hand, 0)
 
-              within_row(1) { click_icon 'arrows-h' }
+              within('tr', text: line_item.sku) { click_icon 'arrows-h' }
               complete_split_to(stock_location2, quantity: 2)
 
               accept_alert "Desired shipment not enough stock in desired stock location"
@@ -278,7 +283,7 @@ describe "Order Details", type: :feature, js: true do
               product.master.stock_items.last.update_column(:count_on_hand, 0)
               product.master.stock_items.last.update_column(:backorderable, true)
 
-              within_row(1) { click_icon 'arrows-h' }
+              within('tr', text: line_item.sku) { click_icon 'arrows-h' }
               complete_split_to(stock_location2, quantity: 2)
 
               expect(page).to have_content("Pending package from 'Clarksville'")
@@ -298,7 +303,7 @@ describe "Order Details", type: :feature, js: true do
             expect(order.shipments.count).to eq(1)
             expect(order.shipments.first.manifest.count).to eq(2)
 
-            within_row(1) { click_icon 'arrows-h' }
+            within('tr', text: line_item.sku) { click_icon 'arrows-h' }
             complete_split_to(stock_location2)
 
             expect(page).to have_css('.shipment', count: 2)
@@ -312,14 +317,15 @@ describe "Order Details", type: :feature, js: true do
       end
 
       context 'removing an item' do
+        let!(:shipment2) { order.shipments.create(stock_location_id: stock_location2.id) }
+
         it "removes only the one item" do
-          @shipment2 = order.shipments.create(stock_location_id: stock_location2.id)
-          order.line_items[0].inventory_units[0].update!(shipment: @shipment2)
+          order.line_items[0].inventory_units[0].update!(shipment: shipment2)
           visit spree.edit_admin_order_path(order)
 
           expect(page).to have_css('.stock-item', count: 2)
 
-          within '[data-hook=admin_shipment_form]', text: @shipment2.number do
+          within '[data-hook=admin_shipment_form]', text: shipment2.number do
             accept_confirm "Are you sure you want to delete this record?" do
               click_icon :trash
             end
@@ -330,20 +336,21 @@ describe "Order Details", type: :feature, js: true do
       end
 
       context 'splitting to shipment' do
+        let!(:shipment2) { order.shipments.create(stock_location_id: stock_location2.id) }
+
         before do
-          @shipment2 = order.shipments.create(stock_location_id: stock_location2.id)
           visit spree.edit_admin_order_path(order)
         end
 
         it 'should delete the old shipment if enough are split off' do
           expect(order.shipments.count).to eq(2)
 
-          within_row(1) { click_icon 'arrows-h' }
-          complete_split_to(@shipment2, quantity: 2)
+          within('tr', text: line_item.sku) { click_icon 'arrows-h' }
+          complete_split_to(shipment2, quantity: 2)
 
           expect(page).not_to have_content(/Move .* to/)
 
-          expect(page).to have_css("#shipment_#{@shipment2.id}", count: 1)
+          expect(page).to have_css("#shipment_#{shipment2.id}", count: 1)
 
           expect(order.shipments.count).to eq(1)
           expect(order.shipments.last.inventory_units_for(product.master).count).to eq(2)
@@ -356,16 +363,16 @@ describe "Order Details", type: :feature, js: true do
             expect(order.shipments.count).to eq(2)
             expect(page).to have_css('.item-name', text: product.name, count: 1)
 
-            within_row(1) { click_icon 'arrows-h' }
-            complete_split_to(@shipment2, quantity: 1)
+            within('tr', text: line_item.sku) { click_icon 'arrows-h' }
+            complete_split_to(shipment2, quantity: 1)
 
             expect(page).to have_css('.item-name', text: product.name, count: 2)
 
             within(all('.stock-contents', count: 2).first) do
-              within_row(1) { click_icon 'arrows-h' }
+              within('tr', text: line_item.sku) { click_icon 'arrows-h' }
 
               accept_alert("Desired shipment not enough stock in desired stock location") do
-                complete_split_to(@shipment2, quantity: 200)
+                complete_split_to(shipment2, quantity: 200)
               end
             end
 
@@ -375,21 +382,21 @@ describe "Order Details", type: :feature, js: true do
           end
 
           it 'should not allow a shipment to split stock to itself' do
-            within_row(1) { click_icon 'arrows-h' }
+            within('tr', text: line_item.sku) { click_icon 'arrows-h' }
             click_on 'Choose location'
             within '.select2-results' do
-              expect(page).to have_content(@shipment2.number)
-              expect(page).not_to have_content(@shipment1.number)
+              expect(page).to have_content(shipment2.number)
+              expect(page).not_to have_content(shipment1.number)
             end
           end
 
           it 'should split fine if more than one line_item is in the receiving shipment' do
             variant2 = create(:variant)
-            order.contents.add(variant2, 2, shipment: @shipment2)
+            order.contents.add(variant2, 2, shipment: shipment2)
             order.reload
 
-            within_row(1) { click_icon 'arrows-h' }
-            complete_split_to(@shipment2, quantity: 1)
+            within('tr', text: line_item.sku) { click_icon 'arrows-h' }
+            complete_split_to(shipment2, quantity: 1)
 
             expect(page).not_to have_content(/Move .* to/)
             expect(page).to have_css('.shipment', count: 2)
@@ -404,19 +411,19 @@ describe "Order Details", type: :feature, js: true do
 
         context 'receiving shipment can backorder' do
           it 'should add more to the backorder' do
-            @shipment1.inventory_units.update_all(state: :on_hand)
+            shipment1.inventory_units.update_all(state: :on_hand)
             product.master.stock_items.last.update_column(:backorderable, true)
             product.master.stock_items.last.update_column(:count_on_hand, 0)
-            expect(@shipment2.reload.backordered?).to eq(false)
+            expect(shipment2.reload.backordered?).to eq(false)
 
-            within_row(1) { click_icon 'arrows-h' }
-            complete_split_to(@shipment2, quantity: 1)
+            within('tr', text: line_item.sku) { click_icon 'arrows-h' }
+            complete_split_to(shipment2, quantity: 1)
 
             expect(page).to have_content("1 x Backordered")
 
             within('.stock-contents', text: "1 x On hand") do
-              within_row(1) { click_icon 'arrows-h' }
-              complete_split_to(@shipment2, quantity: 1)
+              within('tr', text: line_item.sku) { click_icon 'arrows-h' }
+              complete_split_to(shipment2, quantity: 1)
             end
 
             # Empty shipment should be removed
@@ -508,7 +515,7 @@ describe "Order Details", type: :feature, js: true do
     it "can change the shipping method" do
       order = create(:completed_order_with_totals)
       visit spree.edit_admin_order_path(order)
-      within("table.index tr.show-method") do
+      within("tr", text: "Shipping Method") do
         click_icon :edit
       end
       select "UPS Ground $100.00", from: "selected_shipping_rate_id"

--- a/backend/spec/features/admin/orders/shipments_spec.rb
+++ b/backend/spec/features/admin/orders/shipments_spec.rb
@@ -67,7 +67,7 @@ describe "Shipments", type: :feature do
       expect(order.shipments.count).to eq(1)
       shipment1 = order.shipments[0]
 
-      within_row(1) { click_icon 'arrows-h' }
+      within('tr', text: order.line_items[0].sku) { click_icon 'arrows-h' }
       complete_split_to('LA')
 
       expect(page).to have_css("#shipment_#{shipment1.id} tr.stock-item", count: 4)
@@ -77,7 +77,7 @@ describe "Shipments", type: :feature do
         expect(page).to have_content("UPS Ground")
       end
 
-      within_row(2) { click_icon 'arrows-h' }
+      within('tr', text: order.line_items[1].sku) { click_icon 'arrows-h' }
       complete_split_to("LA(#{shipment2.number})")
       expect(page).to have_css("#shipment_#{shipment2.id} tr.stock-item", count: 2)
       expect(page).to have_css("#shipment_#{shipment1.id} tr.stock-item", count: 3)
@@ -100,7 +100,7 @@ describe "Shipments", type: :feature do
       it "can transfer all items to a new location" do
         expect(order.shipments.count).to eq(1)
 
-        within_row(1) { click_icon 'arrows-h' }
+        within('tr', text: order.line_items[0].sku) { click_icon 'arrows-h' }
         complete_split_to('LA', quantity: 5)
 
         expect(page).to_not have_content("package from 'NY Warehouse'")


### PR DESCRIPTION
This is the first step towards future work on two separate goals:
* Allowing editing shipments fully through ajax without the page being refreshed
* Allowing backend-only shipping methods to be used by admins #1711

For both of these, we need the editing of shipping methods to be renderable by JS (it was previously an ERB view). This also does the same to he tracking method, which made sense to do at the same time since they used to share code.

This creates a Shipment backbone model and collection, and fetches it from the order API endpoint when loading the shipments page.

Two new handlebars helpers were needed to allow this: `human_model_name` which works like `model_name.human` in ruby (but only supports the singular translation for now), and `format_money` which gives access to the existing `Spree.formatMoney` function.