### PR TITLE
Fix admin user order history table

### DIFF
--- a/backend/app/views/spree/admin/users/orders.html.erb
+++ b/backend/app/views/spree/admin/users/orders.html.erb
@@ -60,7 +60,7 @@
             <td>
               <% if order.shipment_state %>
                 <span class="pill pill-<%= order.shipment_state %>">
-                  <%= Spree.t(@order.shipment_state, scope: :shipment_states) %>
+                  <%= Spree.t(order.shipment_state, scope: :shipment_states) %>
                 </span>
               <% end %>
             </td>


### PR DESCRIPTION
A small typo results in an error when viewing this table if the user has
any orders.

I don't see any backend request specs and I can't get a solidus test app running, so I appollogise but I'm submitting this one blind ;)