### PR TITLE
remove unused update_params_payment_source method

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -787,6 +787,7 @@ module Spree
         @updating_params[:order][:payments_attributes].first[:amount] = total
       end
     end
+    deprecate update_params_payment_source: :set_payment_parameters_amount, deprecator: Spree::Deprecation
 
     def associate_store
       self.store ||= Spree::Store.default

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -1538,4 +1538,14 @@ describe Spree::Order, type: :model do
       end
     end
   end
+
+  context 'update_params_payment_source' do
+    subject { described_class.new }
+
+    it 'is deprecated' do
+      subject.instance_variable_set('@updating_params', {})
+      expect(Spree::Deprecation).to receive(:warn)
+      subject.update_params_payment_source
+    end
+  end
 end


### PR DESCRIPTION
This method [was moved from `Spree::Order::Checkout`](https://github.com/solidusio/solidus/commit/7ec8e0b82d6d9d6c127a9267bd757d949bb04a52), and seems to be unused now that we use [`set_payment_parameters_amount`](https://github.com/solidusio/solidus/blob/7289efd2a2cd112665c03fa5ff360a6d75adbc35/core/lib/spree/core/controller_helpers/payment_parameters.rb#L210) method for the same.