### PR TITLE
Switch factories to strings instead of constants

### DIFF
--- a/core/lib/spree/testing_support/factories/address_factory.rb
+++ b/core/lib/spree/testing_support/factories/address_factory.rb
@@ -3,7 +3,7 @@ require 'spree/testing_support/factories/country_factory'
 require 'twitter_cldr'
 
 FactoryGirl.define do
-  factory :address, class: Spree::Address do
+  factory :address, class: 'Spree::Address' do
     transient do
       # There's `Spree::Address#country_iso=`, prohibiting me from using `country_iso` here
       country_iso_code 'US'

--- a/core/lib/spree/testing_support/factories/adjustment_factory.rb
+++ b/core/lib/spree/testing_support/factories/adjustment_factory.rb
@@ -5,7 +5,7 @@ require 'spree/testing_support/factories/tax_rate_factory'
 require 'spree/testing_support/factories/zone_factory'
 
 FactoryGirl.define do
-  factory :adjustment, class: Spree::Adjustment do
+  factory :adjustment, class: 'Spree::Adjustment' do
     order
     adjustable { order }
     amount 100.0

--- a/core/lib/spree/testing_support/factories/adjustment_reason_factory.rb
+++ b/core/lib/spree/testing_support/factories/adjustment_reason_factory.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
-  factory :adjustment_reason, class: Spree::AdjustmentReason do
+  factory :adjustment_reason, class: 'Spree::AdjustmentReason' do
     sequence(:name) { |n| "Refund for return ##{n}" }
     sequence(:code) { |n| "Code #{n}" }
   end

--- a/core/lib/spree/testing_support/factories/calculator_factory.rb
+++ b/core/lib/spree/testing_support/factories/calculator_factory.rb
@@ -1,24 +1,24 @@
 FactoryGirl.define do
-  factory :calculator, aliases: [:flat_rate_calculator], class: Spree::Calculator::FlatRate do
+  factory :calculator, aliases: [:flat_rate_calculator], class: 'Spree::Calculator::FlatRate' do
     preferred_amount 10.0
   end
 
-  factory :no_amount_calculator, class: Spree::Calculator::FlatRate do
+  factory :no_amount_calculator, class: 'Spree::Calculator::FlatRate' do
     preferred_amount 0
   end
 
-  factory :default_tax_calculator, class: Spree::Calculator::DefaultTax do
+  factory :default_tax_calculator, class: 'Spree::Calculator::DefaultTax' do
   end
 
-  factory :shipping_calculator, class: Spree::Calculator::Shipping::FlatRate do
+  factory :shipping_calculator, class: 'Spree::Calculator::Shipping::FlatRate' do
     preferred_amount 10.0
   end
 
-  factory :shipping_no_amount_calculator, class: Spree::Calculator::Shipping::FlatRate do
+  factory :shipping_no_amount_calculator, class: 'Spree::Calculator::Shipping::FlatRate' do
     preferred_amount 0
   end
 
-  factory :percent_on_item_calculator, class: Spree::Calculator::PercentOnLineItem do
+  factory :percent_on_item_calculator, class: 'Spree::Calculator::PercentOnLineItem' do
     preferred_percent 10
   end
 end

--- a/core/lib/spree/testing_support/factories/carton_factory.rb
+++ b/core/lib/spree/testing_support/factories/carton_factory.rb
@@ -2,7 +2,7 @@ require 'spree/testing_support/factories/shipment_factory'
 require 'spree/testing_support/factories/inventory_unit_factory'
 
 FactoryGirl.define do
-  factory :carton, class: Spree::Carton do
+  factory :carton, class: 'Spree::Carton' do
     address
     stock_location
     shipping_method

--- a/core/lib/spree/testing_support/factories/country_factory.rb
+++ b/core/lib/spree/testing_support/factories/country_factory.rb
@@ -1,7 +1,7 @@
 require 'carmen'
 
 FactoryGirl.define do
-  factory :country, class: Spree::Country do
+  factory :country, class: 'Spree::Country' do
     iso 'US'
 
     transient do

--- a/core/lib/spree/testing_support/factories/credit_card_factory.rb
+++ b/core/lib/spree/testing_support/factories/credit_card_factory.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
-  factory :credit_card, class: Spree::CreditCard do
+  factory :credit_card, class: 'Spree::CreditCard' do
     verification_value 123
     month 12
     year { 1.year.from_now.year }

--- a/core/lib/spree/testing_support/factories/customer_return_factory.rb
+++ b/core/lib/spree/testing_support/factories/customer_return_factory.rb
@@ -3,7 +3,7 @@ require 'spree/testing_support/factories/order_factory'
 require 'spree/testing_support/factories/return_item_factory'
 
 FactoryGirl.define do
-  factory :customer_return, class: Spree::CustomerReturn do
+  factory :customer_return, class: 'Spree::CustomerReturn' do
     association(:stock_location, factory: :stock_location)
 
     transient do

--- a/core/lib/spree/testing_support/factories/image_factory.rb
+++ b/core/lib/spree/testing_support/factories/image_factory.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
-  factory :image, class: Spree::Image do
+  factory :image, class: 'Spree::Image' do
     attachment { File.new(Spree::Core::Engine.root + 'spec/fixtures/thinking-cat.jpg') }
   end
 end

--- a/core/lib/spree/testing_support/factories/inventory_unit_factory.rb
+++ b/core/lib/spree/testing_support/factories/inventory_unit_factory.rb
@@ -4,7 +4,7 @@ require 'spree/testing_support/factories/order_factory'
 require 'spree/testing_support/factories/shipment_factory'
 
 FactoryGirl.define do
-  factory :inventory_unit, class: Spree::InventoryUnit do
+  factory :inventory_unit, class: 'Spree::InventoryUnit' do
     variant
     order
     line_item { build(:line_item, order: order, variant: variant) }

--- a/core/lib/spree/testing_support/factories/line_item_factory.rb
+++ b/core/lib/spree/testing_support/factories/line_item_factory.rb
@@ -2,7 +2,7 @@ require 'spree/testing_support/factories/order_factory'
 require 'spree/testing_support/factories/product_factory'
 
 FactoryGirl.define do
-  factory :line_item, class: Spree::LineItem do
+  factory :line_item, class: 'Spree::LineItem' do
     quantity 1
     price { BigDecimal.new('10.00') }
     order

--- a/core/lib/spree/testing_support/factories/option_type_factory.rb
+++ b/core/lib/spree/testing_support/factories/option_type_factory.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
-  factory :option_type, class: Spree::OptionType do
+  factory :option_type, class: 'Spree::OptionType' do
     sequence(:name) { |n| "foo-size-#{n}" }
     presentation 'Size'
   end

--- a/core/lib/spree/testing_support/factories/option_value_factory.rb
+++ b/core/lib/spree/testing_support/factories/option_value_factory.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
-  factory :option_value, class: Spree::OptionValue do
+  factory :option_value, class: 'Spree::OptionValue' do
     sequence(:name) { |n| "Size-#{n}" }
 
     presentation 'S'

--- a/core/lib/spree/testing_support/factories/order_factory.rb
+++ b/core/lib/spree/testing_support/factories/order_factory.rb
@@ -6,7 +6,7 @@ require 'spree/testing_support/factories/line_item_factory'
 require 'spree/testing_support/factories/payment_factory'
 
 FactoryGirl.define do
-  factory :order, class: Spree::Order do
+  factory :order, class: 'Spree::Order' do
     user
     bill_address
     ship_address

--- a/core/lib/spree/testing_support/factories/order_promotion_factory.rb
+++ b/core/lib/spree/testing_support/factories/order_promotion_factory.rb
@@ -2,7 +2,7 @@ require 'spree/testing_support/factories/order_factory'
 require 'spree/testing_support/factories/promotion_factory'
 
 FactoryGirl.define do
-  factory :order_promotion, class: Spree::OrderPromotion do
+  factory :order_promotion, class: 'Spree::OrderPromotion' do
     association :order
     association :promotion
   end

--- a/core/lib/spree/testing_support/factories/payment_factory.rb
+++ b/core/lib/spree/testing_support/factories/payment_factory.rb
@@ -4,7 +4,7 @@ require 'spree/testing_support/factories/order_factory'
 require 'spree/testing_support/factories/store_credit_factory'
 
 FactoryGirl.define do
-  factory :payment, aliases: [:credit_card_payment], class: Spree::Payment do
+  factory :payment, aliases: [:credit_card_payment], class: 'Spree::Payment' do
     association(:payment_method, factory: :credit_card_payment_method)
     source { create(:credit_card, user: order.user, address: order.bill_address) }
     order
@@ -37,12 +37,12 @@ FactoryGirl.define do
     end
   end
 
-  factory :check_payment, class: Spree::Payment do
+  factory :check_payment, class: 'Spree::Payment' do
     association(:payment_method, factory: :check_payment_method)
     order
   end
 
-  factory :store_credit_payment, class: Spree::Payment, parent: :payment do
+  factory :store_credit_payment, class: 'Spree::Payment', parent: :payment do
     association(:payment_method, factory: :store_credit_payment_method)
     association(:source, factory: :store_credit)
   end

--- a/core/lib/spree/testing_support/factories/payment_method_factory.rb
+++ b/core/lib/spree/testing_support/factories/payment_method_factory.rb
@@ -1,11 +1,11 @@
 FactoryGirl.define do
-  factory :payment_method, aliases: [:credit_card_payment_method], class: Spree::PaymentMethod::BogusCreditCard do
+  factory :payment_method, aliases: [:credit_card_payment_method], class: 'Spree::PaymentMethod::BogusCreditCard' do
     name 'Credit Card'
     available_to_admin true
     available_to_users true
   end
 
-  factory :check_payment_method, class: Spree::PaymentMethod::Check do
+  factory :check_payment_method, class: 'Spree::PaymentMethod::Check' do
     name 'Check'
     available_to_admin true
     available_to_users true
@@ -13,13 +13,13 @@ FactoryGirl.define do
 
   # authorize.net was moved to spree_gateway.
   # Leaving this factory in place with bogus in case anyone is using it.
-  factory :simple_credit_card_payment_method, class: Spree::PaymentMethod::SimpleBogusCreditCard do
+  factory :simple_credit_card_payment_method, class: 'Spree::PaymentMethod::SimpleBogusCreditCard' do
     name 'Credit Card'
     available_to_admin true
     available_to_users true
   end
 
-  factory :store_credit_payment_method, class: Spree::PaymentMethod::StoreCredit do
+  factory :store_credit_payment_method, class: 'Spree::PaymentMethod::StoreCredit' do
     name          "Store Credit"
     description   "Store Credit"
     active        true

--- a/core/lib/spree/testing_support/factories/price_factory.rb
+++ b/core/lib/spree/testing_support/factories/price_factory.rb
@@ -1,7 +1,7 @@
 require 'spree/testing_support/factories/variant_factory'
 
 FactoryGirl.define do
-  factory :price, class: Spree::Price do
+  factory :price, class: 'Spree::Price' do
     variant
     amount 19.99
     currency 'USD'

--- a/core/lib/spree/testing_support/factories/product_factory.rb
+++ b/core/lib/spree/testing_support/factories/product_factory.rb
@@ -5,7 +5,7 @@ require 'spree/testing_support/factories/tax_category_factory'
 require 'spree/testing_support/factories/product_option_type_factory'
 
 FactoryGirl.define do
-  factory :base_product, class: Spree::Product do
+  factory :base_product, class: 'Spree::Product' do
     sequence(:name) { |n| "Product ##{n} - #{Kernel.rand(9999)}" }
     description "As seen on TV!"
     price 19.99

--- a/core/lib/spree/testing_support/factories/product_option_type_factory.rb
+++ b/core/lib/spree/testing_support/factories/product_option_type_factory.rb
@@ -2,7 +2,7 @@ require 'spree/testing_support/factories/product_factory'
 require 'spree/testing_support/factories/option_type_factory'
 
 FactoryGirl.define do
-  factory :product_option_type, class: Spree::ProductOptionType do
+  factory :product_option_type, class: 'Spree::ProductOptionType' do
     product
     option_type
   end

--- a/core/lib/spree/testing_support/factories/product_property_factory.rb
+++ b/core/lib/spree/testing_support/factories/product_property_factory.rb
@@ -2,7 +2,7 @@ require 'spree/testing_support/factories/product_factory'
 require 'spree/testing_support/factories/property_factory'
 
 FactoryGirl.define do
-  factory :product_property, class: Spree::ProductProperty do
+  factory :product_property, class: 'Spree::ProductProperty' do
     product
     property
   end

--- a/core/lib/spree/testing_support/factories/promotion_category_factory.rb
+++ b/core/lib/spree/testing_support/factories/promotion_category_factory.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
-  factory :promotion_category, class: Spree::PromotionCategory do
+  factory :promotion_category, class: 'Spree::PromotionCategory' do
     name 'Promotion Category'
   end
 end

--- a/core/lib/spree/testing_support/factories/promotion_factory.rb
+++ b/core/lib/spree/testing_support/factories/promotion_factory.rb
@@ -2,7 +2,7 @@ require 'spree/testing_support/factories/promotion_code_factory'
 require 'spree/testing_support/factories/variant_factory'
 
 FactoryGirl.define do
-  factory :promotion, class: Spree::Promotion do
+  factory :promotion, class: 'Spree::Promotion' do
     name 'Promo'
 
     transient do

--- a/core/lib/spree/testing_support/factories/property_factory.rb
+++ b/core/lib/spree/testing_support/factories/property_factory.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
-  factory :property, class: Spree::Property do
+  factory :property, class: 'Spree::Property' do
     name 'baseball_cap_color'
     presentation 'cap color'
   end

--- a/core/lib/spree/testing_support/factories/refund_factory.rb
+++ b/core/lib/spree/testing_support/factories/refund_factory.rb
@@ -4,7 +4,7 @@ require 'spree/testing_support/factories/refund_reason_factory'
 FactoryGirl.define do
   sequence(:refund_transaction_id) { |n| "fake-refund-transaction-#{n}" }
 
-  factory :refund, class: Spree::Refund do
+  factory :refund, class: 'Spree::Refund' do
     transient do
       payment_amount 100
     end

--- a/core/lib/spree/testing_support/factories/refund_reason_factory.rb
+++ b/core/lib/spree/testing_support/factories/refund_reason_factory.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
-  factory :refund_reason, class: Spree::RefundReason do
+  factory :refund_reason, class: 'Spree::RefundReason' do
     sequence(:name) { |n| "Refund for return ##{n}" }
   end
 end

--- a/core/lib/spree/testing_support/factories/reimbursement_factory.rb
+++ b/core/lib/spree/testing_support/factories/reimbursement_factory.rb
@@ -1,7 +1,7 @@
 require 'spree/testing_support/factories/customer_return_factory'
 
 FactoryGirl.define do
-  factory :reimbursement, class: Spree::Reimbursement do
+  factory :reimbursement, class: 'Spree::Reimbursement' do
     transient do
       return_items_count 1
     end

--- a/core/lib/spree/testing_support/factories/reimbursement_type_factory.rb
+++ b/core/lib/spree/testing_support/factories/reimbursement_type_factory.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
-  factory :reimbursement_type, class: Spree::ReimbursementType do
+  factory :reimbursement_type, class: 'Spree::ReimbursementType' do
     sequence(:name) { |n| "Reimbursement Type #{n}" }
     active true
     mutable true

--- a/core/lib/spree/testing_support/factories/return_authorization_factory.rb
+++ b/core/lib/spree/testing_support/factories/return_authorization_factory.rb
@@ -3,14 +3,14 @@ require 'spree/testing_support/factories/stock_location_factory'
 require 'spree/testing_support/factories/return_reason_factory'
 
 FactoryGirl.define do
-  factory :return_authorization, class: Spree::ReturnAuthorization do
+  factory :return_authorization, class: 'Spree::ReturnAuthorization' do
     association(:order, factory: :shipped_order)
     association(:stock_location, factory: :stock_location)
     association(:reason, factory: :return_reason)
     memo 'Items were broken'
   end
 
-  factory :new_return_authorization, class: Spree::ReturnAuthorization do
+  factory :new_return_authorization, class: 'Spree::ReturnAuthorization' do
     association(:order, factory: :shipped_order)
     association(:stock_location, factory: :stock_location)
     association(:reason, factory: :return_reason)

--- a/core/lib/spree/testing_support/factories/return_item_factory.rb
+++ b/core/lib/spree/testing_support/factories/return_item_factory.rb
@@ -3,7 +3,7 @@ require 'spree/testing_support/factories/return_reason_factory'
 require 'spree/testing_support/factories/return_authorization_factory'
 
 FactoryGirl.define do
-  factory :return_item, class: Spree::ReturnItem do
+  factory :return_item, class: 'Spree::ReturnItem' do
     association(:inventory_unit, factory: :inventory_unit, state: :shipped)
     association(:return_reason, factory: :return_reason)
     return_authorization do |_return_item|

--- a/core/lib/spree/testing_support/factories/return_reason_factory.rb
+++ b/core/lib/spree/testing_support/factories/return_reason_factory.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
-  factory :return_reason, class: Spree::ReturnReason do
+  factory :return_reason, class: 'Spree::ReturnReason' do
     sequence(:name) { |n| "Defect ##{n}" }
   end
 end

--- a/core/lib/spree/testing_support/factories/role_factory.rb
+++ b/core/lib/spree/testing_support/factories/role_factory.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
-  factory :role, class: Spree::Role do
+  factory :role, class: 'Spree::Role' do
     sequence(:name) { |n| "Role ##{n}" }
 
     factory :admin_role do

--- a/core/lib/spree/testing_support/factories/shipment_factory.rb
+++ b/core/lib/spree/testing_support/factories/shipment_factory.rb
@@ -3,7 +3,7 @@ require 'spree/testing_support/factories/stock_location_factory'
 require 'spree/testing_support/factories/shipping_method_factory'
 
 FactoryGirl.define do
-  factory :shipment, class: Spree::Shipment do
+  factory :shipment, class: 'Spree::Shipment' do
     tracking 'U10000'
     cost 100.00
     state 'pending'

--- a/core/lib/spree/testing_support/factories/shipping_category_factory.rb
+++ b/core/lib/spree/testing_support/factories/shipping_category_factory.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
-  factory :shipping_category, class: Spree::ShippingCategory do
+  factory :shipping_category, class: 'Spree::ShippingCategory' do
     sequence(:name) { |n| "ShippingCategory ##{n}" }
   end
 end

--- a/core/lib/spree/testing_support/factories/shipping_method_factory.rb
+++ b/core/lib/spree/testing_support/factories/shipping_method_factory.rb
@@ -8,7 +8,7 @@ FactoryGirl.define do
     aliases: [
       :base_shipping_method
     ],
-    class: Spree::ShippingMethod
+    class: 'Spree::ShippingMethod'
   ) do
     zones do
       [Spree::Zone.find_by(name: 'GlobalZone') || FactoryGirl.create(:global_zone)]
@@ -32,7 +32,7 @@ FactoryGirl.define do
       end
     end
 
-    factory :free_shipping_method, class: Spree::ShippingMethod do
+    factory :free_shipping_method, class: 'Spree::ShippingMethod' do
       cost nil
       association(:calculator, factory: :shipping_no_amount_calculator, strategy: :build)
     end

--- a/core/lib/spree/testing_support/factories/shipping_rate_factory.rb
+++ b/core/lib/spree/testing_support/factories/shipping_rate_factory.rb
@@ -2,7 +2,7 @@ require 'spree/testing_support/factories/shipping_method_factory'
 require 'spree/testing_support/factories/shipment_factory'
 
 FactoryGirl.define do
-  factory :shipping_rate, class: Spree::ShippingRate do
+  factory :shipping_rate, class: 'Spree::ShippingRate' do
     shipping_method
     shipment
   end

--- a/core/lib/spree/testing_support/factories/state_factory.rb
+++ b/core/lib/spree/testing_support/factories/state_factory.rb
@@ -1,7 +1,7 @@
 require 'spree/testing_support/factories/country_factory'
 
 FactoryGirl.define do
-  factory :state, class: Spree::State do
+  factory :state, class: 'Spree::State' do
     transient do
       country_iso 'US'
       state_code 'AL'

--- a/core/lib/spree/testing_support/factories/stock_item_factory.rb
+++ b/core/lib/spree/testing_support/factories/stock_item_factory.rb
@@ -2,7 +2,7 @@ require 'spree/testing_support/factories/stock_location_factory'
 require 'spree/testing_support/factories/variant_factory'
 
 FactoryGirl.define do
-  factory :stock_item, class: Spree::StockItem do
+  factory :stock_item, class: 'Spree::StockItem' do
     backorderable true
     association :stock_location, factory: :stock_location_without_variant_propagation
     variant

--- a/core/lib/spree/testing_support/factories/stock_location_factory.rb
+++ b/core/lib/spree/testing_support/factories/stock_location_factory.rb
@@ -3,7 +3,7 @@ require 'spree/testing_support/factories/state_factory'
 require 'spree/testing_support/factories/product_factory'
 
 FactoryGirl.define do
-  factory :stock_location, class: Spree::StockLocation do
+  factory :stock_location, class: 'Spree::StockLocation' do
     name 'NY Warehouse'
     address1 '1600 Pennsylvania Ave NW'
     city 'Washington'

--- a/core/lib/spree/testing_support/factories/stock_movement_factory.rb
+++ b/core/lib/spree/testing_support/factories/stock_movement_factory.rb
@@ -1,7 +1,7 @@
 require 'spree/testing_support/factories/stock_item_factory'
 
 FactoryGirl.define do
-  factory :stock_movement, class: Spree::StockMovement do
+  factory :stock_movement, class: 'Spree::StockMovement' do
     quantity 1
     action 'sold'
     stock_item

--- a/core/lib/spree/testing_support/factories/stock_package_factory.rb
+++ b/core/lib/spree/testing_support/factories/stock_package_factory.rb
@@ -2,7 +2,7 @@ require 'spree/testing_support/factories/inventory_unit_factory'
 require 'spree/testing_support/factories/variant_factory'
 
 FactoryGirl.define do
-  factory :stock_package, class: Spree::Stock::Package do
+  factory :stock_package, class: 'Spree::Stock::Package' do
     skip_create
 
     transient do

--- a/core/lib/spree/testing_support/factories/stock_transfer_factory.rb
+++ b/core/lib/spree/testing_support/factories/stock_transfer_factory.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
-  factory :stock_transfer, class: Spree::StockTransfer do
+  factory :stock_transfer, class: 'Spree::StockTransfer' do
     source_location { Spree::StockLocation.create!(name: "Source Location", code: "SRC", admin_name: "Source") }
 
     factory :stock_transfer_with_items do

--- a/core/lib/spree/testing_support/factories/store_credit_category_factory.rb
+++ b/core/lib/spree/testing_support/factories/store_credit_category_factory.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
-  factory :store_credit_category, class: Spree::StoreCreditCategory do
+  factory :store_credit_category, class: 'Spree::StoreCreditCategory' do
     name "Exchange"
   end
 end

--- a/core/lib/spree/testing_support/factories/store_credit_event_factory.rb
+++ b/core/lib/spree/testing_support/factories/store_credit_event_factory.rb
@@ -2,12 +2,12 @@ require 'spree/testing_support/factories/store_credit_factory'
 require 'spree/testing_support/factories/store_credit_update_reason_factory'
 
 FactoryGirl.define do
-  factory :store_credit_event, class: Spree::StoreCreditEvent do
+  factory :store_credit_event, class: 'Spree::StoreCreditEvent' do
     store_credit
     amount             { 100.00 }
     authorization_code { "#{store_credit.id}-SC-20140602164814476128" }
 
-    factory :store_credit_auth_event, class: Spree::StoreCreditEvent do
+    factory :store_credit_auth_event, class: 'Spree::StoreCreditEvent' do
       action             { Spree::StoreCredit::AUTHORIZE_ACTION }
     end
 

--- a/core/lib/spree/testing_support/factories/store_credit_factory.rb
+++ b/core/lib/spree/testing_support/factories/store_credit_factory.rb
@@ -3,7 +3,7 @@ require 'spree/testing_support/factories/store_credit_type_factory'
 require 'spree/testing_support/factories/user_factory'
 
 FactoryGirl.define do
-  factory :store_credit, class: Spree::StoreCredit do
+  factory :store_credit, class: 'Spree::StoreCredit' do
     user
     association :created_by, factory: :user
     association :category, factory: :store_credit_category

--- a/core/lib/spree/testing_support/factories/store_credit_type_factory.rb
+++ b/core/lib/spree/testing_support/factories/store_credit_type_factory.rb
@@ -1,10 +1,10 @@
 FactoryGirl.define do
-  factory :primary_credit_type, class: Spree::StoreCreditType do
+  factory :primary_credit_type, class: 'Spree::StoreCreditType' do
     name      Spree::StoreCreditType::DEFAULT_TYPE_NAME
     priority  { "1" }
   end
 
-  factory :secondary_credit_type, class: Spree::StoreCreditType do
+  factory :secondary_credit_type, class: 'Spree::StoreCreditType' do
     name      { Spree::StoreCreditType::NON_EXPIRING }
     priority  { "2" }
   end

--- a/core/lib/spree/testing_support/factories/store_credit_update_reason_factory.rb
+++ b/core/lib/spree/testing_support/factories/store_credit_update_reason_factory.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
-  factory :store_credit_update_reason, class: Spree::StoreCreditUpdateReason do
+  factory :store_credit_update_reason, class: 'Spree::StoreCreditUpdateReason' do
     name "Input error"
   end
 end

--- a/core/lib/spree/testing_support/factories/store_factory.rb
+++ b/core/lib/spree/testing_support/factories/store_factory.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
-  factory :store, class: Spree::Store do
+  factory :store, class: 'Spree::Store' do
     sequence(:code) { |i| "spree_#{i}" }
     sequence(:name) { |i| "Spree Test Store #{i}" }
     sequence(:url) { |i| "www.example#{i}.com" }

--- a/core/lib/spree/testing_support/factories/tax_category_factory.rb
+++ b/core/lib/spree/testing_support/factories/tax_category_factory.rb
@@ -1,7 +1,7 @@
 require 'spree/testing_support/sequences'
 
 FactoryGirl.define do
-  factory :tax_category, class: Spree::TaxCategory do
+  factory :tax_category, class: 'Spree::TaxCategory' do
     name { "TaxCategory - #{rand(999_999)}" }
     tax_code { "TaxCode - #{rand(999_999)}" }
     description { generate(:random_string) }

--- a/core/lib/spree/testing_support/factories/tax_rate_factory.rb
+++ b/core/lib/spree/testing_support/factories/tax_rate_factory.rb
@@ -3,7 +3,7 @@ require 'spree/testing_support/factories/tax_category_factory'
 require 'spree/testing_support/factories/zone_factory'
 
 FactoryGirl.define do
-  factory :tax_rate, class: Spree::TaxRate do
+  factory :tax_rate, class: 'Spree::TaxRate' do
     zone
     amount 0.1
     association(:calculator, factory: :default_tax_calculator)

--- a/core/lib/spree/testing_support/factories/taxon_factory.rb
+++ b/core/lib/spree/testing_support/factories/taxon_factory.rb
@@ -1,7 +1,7 @@
 require 'spree/testing_support/factories/taxonomy_factory'
 
 FactoryGirl.define do
-  factory :taxon, class: Spree::Taxon do
+  factory :taxon, class: 'Spree::Taxon' do
     name 'Ruby on Rails'
     taxonomy
     parent_id nil

--- a/core/lib/spree/testing_support/factories/taxonomy_factory.rb
+++ b/core/lib/spree/testing_support/factories/taxonomy_factory.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
-  factory :taxonomy, class: Spree::Taxonomy do
+  factory :taxonomy, class: 'Spree::Taxonomy' do
     name 'Brand'
   end
 end

--- a/core/lib/spree/testing_support/factories/variant_factory.rb
+++ b/core/lib/spree/testing_support/factories/variant_factory.rb
@@ -6,7 +6,7 @@ require 'spree/testing_support/factories/product_factory'
 FactoryGirl.define do
   sequence(:random_float) { BigDecimal.new("#{rand(200)}.#{rand(99)}") }
 
-  factory :base_variant, class: Spree::Variant do
+  factory :base_variant, class: 'Spree::Variant' do
     price 19.99
     cost_price 17.00
     sku { generate(:sku) }

--- a/core/lib/spree/testing_support/factories/variant_property_rule_condition_factory.rb
+++ b/core/lib/spree/testing_support/factories/variant_property_rule_condition_factory.rb
@@ -2,7 +2,7 @@ require 'spree/testing_support/factories/option_value_factory'
 require 'spree/testing_support/factories/variant_property_rule_factory'
 
 FactoryGirl.define do
-  factory :variant_property_rule_condition, class: Spree::VariantPropertyRuleCondition do
+  factory :variant_property_rule_condition, class: 'Spree::VariantPropertyRuleCondition' do
     variant_property_rule
     option_value
   end

--- a/core/lib/spree/testing_support/factories/variant_property_rule_factory.rb
+++ b/core/lib/spree/testing_support/factories/variant_property_rule_factory.rb
@@ -3,7 +3,7 @@ require 'spree/testing_support/factories/property_factory'
 require 'spree/testing_support/factories/option_value_factory'
 
 FactoryGirl.define do
-  factory :variant_property_rule, class: Spree::VariantPropertyRule do
+  factory :variant_property_rule, class: 'Spree::VariantPropertyRule' do
     product
 
     transient do

--- a/core/lib/spree/testing_support/factories/variant_property_rule_value_factory.rb
+++ b/core/lib/spree/testing_support/factories/variant_property_rule_value_factory.rb
@@ -2,7 +2,7 @@ require 'spree/testing_support/factories/variant_property_rule_factory'
 require 'spree/testing_support/factories/property_factory'
 
 FactoryGirl.define do
-  factory :variant_property_rule_value, class: Spree::VariantPropertyRuleValue do
+  factory :variant_property_rule_value, class: 'Spree::VariantPropertyRuleValue' do
     variant_property_rule
     property
   end

--- a/core/lib/spree/testing_support/factories/zone_factory.rb
+++ b/core/lib/spree/testing_support/factories/zone_factory.rb
@@ -2,7 +2,7 @@ require 'spree/testing_support/sequences'
 require 'spree/testing_support/factories/country_factory'
 
 FactoryGirl.define do
-  factory :global_zone, class: Spree::Zone do
+  factory :global_zone, class: 'Spree::Zone' do
     name 'GlobalZone'
     description { generate(:random_string) }
     zone_members do |proxy|
@@ -13,7 +13,7 @@ FactoryGirl.define do
     end
   end
 
-  factory :zone, class: Spree::Zone do
+  factory :zone, class: 'Spree::Zone' do
     name { generate(:random_string) }
     description { generate(:random_string) }
 

--- a/core/spec/lib/spree/core/validators/email_spec.rb
+++ b/core/spec/lib/spree/core/validators/email_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'spree/core/validators/email'
 
 describe EmailValidator do
   class Tester


### PR DESCRIPTION
When we define the factories we don't actually care if the constants are
resolved to real objects or not