### PR TITLE
Revert "Use ducktyping in wallet payment source validation"

### DIFF
--- a/core/app/models/spree/wallet_payment_source.rb
+++ b/core/app/models/spree/wallet_payment_source.rb
@@ -10,7 +10,7 @@ class Spree::WalletPaymentSource < ActiveRecord::Base
   private
 
   def check_for_payment_source_class
-    if !payment_source.respond_to?(:reusable?)
+    if !payment_source.is_a?(Spree::PaymentSource)
       errors.add(:payment_source, :has_to_be_payment_source_class)
     end
   end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -711,7 +711,7 @@ en:
         spree/wallet_payment_source:
           attributes:
             payment_source:
-              has_to_be_payment_source_class: "has to implement `reusable?`"
+              has_to_be_payment_source_class: "has to be a Spree::PaymentSource"
 
   devise:
     confirmations:

--- a/core/spec/models/spree/wallet_payment_source_spec.rb
+++ b/core/spec/models/spree/wallet_payment_source_spec.rb
@@ -14,7 +14,7 @@ describe Spree::WalletPaymentSource, type: :model do
 
       let(:payment_source) { NonPaymentSource.create! }
 
-      it "errors when `payment_source` does not implement `reusable`" do
+      it "errors when `payment_source` is not a `Spree::PaymentSource`" do
         wallet_payment_source = Spree::WalletPaymentSource.new(
           payment_source: payment_source,
           user: create(:user)
@@ -22,7 +22,7 @@ describe Spree::WalletPaymentSource, type: :model do
 
         expect(wallet_payment_source).not_to be_valid
         expect(wallet_payment_source.errors.messages).to eq(
-          { payment_source: ["has to implement `reusable?`"] }
+          { payment_source: ["has to be a Spree::PaymentSource"] }
         )
       end
     end


### PR DESCRIPTION
This reverts commit 6b25197b3b0ae50ef676168a6dd25d50f3807bac.