### PR TITLE
Use number field for decimal preference field

### DIFF
--- a/backend/app/views/spree/admin/shared/preference_fields/_decimal.html.erb
+++ b/backend/app/views/spree/admin/shared/preference_fields/_decimal.html.erb
@@ -1,12 +1,12 @@
 <% label = local_assigns[:label].presence %>
-<% html_options = {class: 'input_decimal fullwidth'}.update(local_assigns[:html_options] || {}) %>
+<% html_options = {class: 'input_decimal fullwidth', step: :any}.update(local_assigns[:html_options] || {}) %>
 
 <div class="field">
   <% if local_assigns[:form] %>
     <%= form.label attribute, label %>
-    <%= form.text_field attribute, html_options %>
+    <%= form.number_field attribute, html_options %>
   <% else %>
     <%= label_tag name, label %>
-    <%= text_field_tag name, value, html_options %>
+    <%= number_field_tag name, value, html_options %>
   <% end %>
 </div>


### PR DESCRIPTION
There are two benefits to this. The UX benefit of the
increment/decrement widget on the input field itself, and now a user can
no longer enter text into this field (which is rejected upon submit and
the preference value can be reset to 0).

Adding `step: :any` allows both integers and floats to be entered, with the widget stepping up and down by 1.

I know that the preference_field_tag is deprecated, but this threw me off when I was testing something related.