### PR TITLE
Remove Postal Code Format Validation (and Twitter CLDR dependency)

### DIFF
--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -1,5 +1,3 @@
-require 'twitter_cldr'
-
 module Spree
   # `Spree::Address` provides the foundational ActiveRecord model for recording and
   # validating address information for `Spree::Order`, `Spree::Shipment`,
@@ -15,7 +13,7 @@ module Spree
     validates :zipcode, presence: true, if: :require_zipcode?
     validates :phone, presence: true, if: :require_phone?
 
-    validate :state_validate, :postal_code_validate
+    validate :state_validate
 
     alias_attribute :first_name, :firstname
     alias_attribute :last_name, :lastname
@@ -210,14 +208,6 @@ module Spree
 
       # ensure at least one state field is populated
       errors.add :state, :blank if state.blank? && state_name.blank?
-    end
-
-    def postal_code_validate
-      return if country.blank? || country.iso.blank? || !require_zipcode?
-      return if !TwitterCldr::Shared::PostalCodes.territories.include?(country.iso.downcase.to_sym)
-
-      postal_code = TwitterCldr::Shared::PostalCodes.for_territory(country.iso)
-      errors.add(:zipcode, :invalid) if !postal_code.valid?(zipcode.to_s)
     end
   end
 end

--- a/core/lib/spree/testing_support/factories/address_factory.rb
+++ b/core/lib/spree/testing_support/factories/address_factory.rb
@@ -1,6 +1,5 @@
 require 'spree/testing_support/factories/state_factory'
 require 'spree/testing_support/factories/country_factory'
-require 'twitter_cldr'
 
 FactoryGirl.define do
   factory :address, class: Spree::Address do
@@ -16,7 +15,7 @@ FactoryGirl.define do
     address1 '10 Lovely Street'
     address2 'Northwest'
     city 'Herndon'
-    zipcode { TwitterCldr::Shared::PostalCodes.for_territory(country_iso_code).sample.first }
+    zipcode { FFaker::AddressUS.zip_code }
     phone '555-555-0199'
     alternative_phone '555-555-0199'
 

--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -34,7 +34,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'ransack', '~> 1.8'
   s.add_dependency 'state_machines-activerecord', '~> 0.4'
   s.add_dependency 'stringex', '~> 1.5.1'
-  s.add_dependency 'twitter_cldr', '>= 3.0', '< 5'
 
   s.add_development_dependency 'email_spec', '~> 1.6'
 end

--- a/core/spec/models/spree/address_spec.rb
+++ b/core/spec/models/spree/address_spec.rb
@@ -103,41 +103,6 @@ describe Spree::Address, type: :model do
       expect(address.errors['zipcode']).to include("can't be blank")
     end
 
-    context "zipcode validation" do
-      it "validates the zipcode" do
-        allow(address.country).to receive(:iso).and_return('US')
-        address.zipcode = 'abc'
-        address.valid?
-        expect(address.errors['zipcode']).to include('is invalid')
-      end
-
-      context 'does not validate' do
-        it 'does not have a country' do
-          address.country = nil
-          address.valid?
-          expect(address.errors['zipcode']).not_to include('is invalid')
-        end
-
-        it 'does not have an iso' do
-          allow(address.country).to receive(:iso).and_return(nil)
-          address.valid?
-          expect(address.errors['zipcode']).not_to include('is invalid')
-        end
-
-        it 'does not have a zipcode' do
-          address.zipcode = ""
-          address.valid?
-          expect(address.errors['zipcode']).not_to include('is invalid')
-        end
-
-        it 'does not have a supported country iso' do
-          allow(address.country).to receive(:iso).and_return('BO')
-          address.valid?
-          expect(address.errors['zipcode']).not_to include('is invalid')
-        end
-      end
-    end
-
     context "phone not required" do
       before { allow(address).to receive_messages require_phone?: false }
 


### PR DESCRIPTION
The removes the validation of postal code format. 

This validation is done through a pretty expensive dependency, `twitter_cldr`, and actually provides little tangible benefit: We don't know whether the postal code enters actually exists if it passes, we only check the format through a regular expression. 

Stores that rely on this functionality are encouraged to validate the zipcode through something like https://github.com/dgilperez/validates_zipcode, which is a much smaller dependency. We could add that to core, and it would keep the functionality and reduce the size of our bundle, but really I question the benefit of this validation entirely.