### PR TITLE
[core] remove rails and use only actionmailer and activerecord

### DIFF
--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -19,6 +19,10 @@ Gem::Specification.new do |s|
   s.required_ruby_version     = '>= 2.2.2'
   s.required_rubygems_version = '>= 1.8.23'
 
+  %w[activerecord actionmailer].each do |rails_dep|
+    s.add_dependency rails_dep, '~> 5.1.0'
+  end
+
   s.add_dependency 'activemerchant', '~> 1.48'
   s.add_dependency 'acts_as_list', '~> 0.3'
   s.add_dependency 'awesome_nested_set', '~> 3.0', '>= 3.0.1'
@@ -29,7 +33,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'monetize', '~> 1.1'
   s.add_dependency 'paperclip', ['>= 4.2', '< 6']
   s.add_dependency 'paranoia', '~> 2.3'
-  s.add_dependency 'rails', '~> 5.1.0'
   s.add_dependency 'ransack', '~> 1.8'
   s.add_dependency 'state_machines-activerecord', '~> 0.4'
   s.add_dependency 'stringex', '~> 1.5.1'


### PR DESCRIPTION
Before:

```shell
$ bundle
Bundle complete! 30 Gemfile dependencies, 126 gems now installed.
```

After:

```shell
$ bundle
Bundle complete! 30 Gemfile dependencies, 123 gems now installed.
```

---

What I particularly like about this change is that when we move to 5.2, we won't get active storage out of anywhere. We'll get to add it in when we're ready.