### PR TITLE
Inherit body colour for labels

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
@@ -192,10 +192,6 @@ fieldset {
     }
   }
 
-  label {
-    color: lighten($body-color, 8);
-  }
-
   .filter-actions {
     margin-bottom: -32px;
     margin-top: 15px;

--- a/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
@@ -45,7 +45,6 @@ label {
   font-size: 90%;
   display: inline;
   margin-bottom: 5px;
-  color: $color-4;
 
   &.inline {
     display: inline-block !important;


### PR DESCRIPTION
This removes the `fieldset label` style, which I believe has caused fieldsets to be overused for consistency. This also removes the `color` style on labels, which in most cases will have no effect

The final effect of this is that labels will match the colour of the body text on the page: a bit darker than before.

*Before*
![](http://i.hawth.ca/s/3y7T7WLG.png)

*After*
![](http://i.hawth.ca/s/lwFwkC38.png)