### PR TITLE
Improve API key on user edit page

### DIFF
--- a/api/config/locales/en.yml
+++ b/api/config/locales/en.yml
@@ -8,12 +8,6 @@ en:
       resource_not_found: "The resource you were looking for could not be found."
       gateway_error: "There was a problem with the payment gateway: %{text}"
       delete_restriction_error: "Cannot delete record."
-      access: "API Access"
-      key: "Key"
-      clear_key: "Clear key"
-      regenerate_key: "Regenerate Key"
-      no_key: "No key"
-      generate_key: "Generate API key"
       key_generated: "Key generated"
       key_cleared: "Key cleared"
       order:

--- a/backend/app/views/spree/admin/users/edit.html.erb
+++ b/backend/app/views/spree/admin/users/edit.html.erb
@@ -35,13 +35,8 @@
         <div id="current-api-key"><%= t('.key') %>: (<%= Spree.t('.hidden') %>)</div>
       </div>
       <div class="filter-actions actions">
-        <%= form_tag spree.clear_api_key_admin_user_path(@user), method: :put do %>
-          <%= button t('.clear_key') %>
-        <% end %>
-
-        <%= form_tag spree.generate_api_key_admin_user_path(@user), method: :put do %>
-          <%= button t('.regenerate_key') %>
-        <% end %>
+        <%= button_link_to t('.clear_key'), spree.clear_api_key_admin_user_path(@user), method: :put, data: { confirm: t('.confirm_clear_key') }, class: 'btn btn-primary' %>
+        <%= button_link_to t('.regenerate_key'), spree.generate_api_key_admin_user_path(@user), method: :put, data: { confirm: t('.confirm_regenerate_key') }, class: 'btn btn-primary' %>
       </div>
 
     <% else %>
@@ -49,9 +44,7 @@
       <div class="no-objects-found"><%= t('.no_key') %></div>
 
       <div class="filter-actions actions">
-        <%= form_tag spree.generate_api_key_admin_user_path(@user), method: :put do %>
-          <%= button t('.generate_key') %>
-        <% end %>
+        <%= button_link_to t('.generate_key'), spree.generate_api_key_admin_user_path(@user), method: :put, class: 'btn btn-primary' %>
       </div>
     <% end %>
   </fieldset>

--- a/backend/app/views/spree/admin/users/edit.html.erb
+++ b/backend/app/views/spree/admin/users/edit.html.erb
@@ -7,7 +7,7 @@
 <%= render partial: 'spree/admin/users/user_page_actions' %>
 
 <fieldset data-hook="admin_user_edit_general_settings">
-  <legend><%= Spree.t(:general_settings) %></legend>
+  <legend><%= Spree.user_class.model_name.human %></legend>
 
   <div data-hook="admin_user_edit_form_header">
     <%= render partial: 'spree/shared/error_messages', locals: { target: @user } %>

--- a/backend/app/views/spree/admin/users/edit.html.erb
+++ b/backend/app/views/spree/admin/users/edit.html.erb
@@ -28,29 +28,29 @@
 
 <% if can?(:update, @user) %>
   <fieldset data-hook="admin_user_api_key" id="admin_user_edit_api_key">
-    <legend><%= Spree.t('access', scope: 'api') %></legend>
+    <legend><%= t('.api_access') %></legend>
 
     <% if @user.spree_api_key.present? %>
       <div class="field">
-        <div id="current-api-key"><%= Spree.t('key', scope: 'api') %>: (<%= Spree.t('hidden') %>)</div>
+        <div id="current-api-key"><%= t('.key') %>: (<%= Spree.t('.hidden') %>)</div>
       </div>
       <div class="filter-actions actions">
         <%= form_tag spree.clear_api_key_admin_user_path(@user), method: :put do %>
-          <%= button Spree.t('clear_key', scope: 'api') %>
+          <%= button t('.clear_key') %>
         <% end %>
 
         <%= form_tag spree.generate_api_key_admin_user_path(@user), method: :put do %>
-          <%= button Spree.t('regenerate_key', scope: 'api') %>
+          <%= button t('.regenerate_key') %>
         <% end %>
       </div>
 
     <% else %>
 
-      <div class="no-objects-found"><%= Spree.t('no_key', scope: 'api') %></div>
+      <div class="no-objects-found"><%= t('.no_key') %></div>
 
       <div class="filter-actions actions">
         <%= form_tag spree.generate_api_key_admin_user_path(@user), method: :put do %>
-          <%= button Spree.t('generate_key', scope: 'api') %>
+          <%= button t('.generate_key') %>
         <% end %>
       </div>
     <% end %>

--- a/backend/app/views/spree/admin/users/edit.html.erb
+++ b/backend/app/views/spree/admin/users/edit.html.erb
@@ -31,8 +31,14 @@
     <legend><%= t('.api_access') %></legend>
 
     <% if @user.spree_api_key.present? %>
-      <div class="field">
-        <div id="current-api-key"><%= t('.key') %>: (<%= Spree.t('.hidden') %>)</div>
+      <div id="current-api-key">
+        <strong><%= t('.key') %>: </strong>
+        <% if @user == try_spree_current_user %>
+          <%= @user.spree_api_key %>
+        <% else %>
+          <i>(<%= Spree.t('hidden') %>)</i>
+        <% end %>
+
       </div>
       <div class="filter-actions actions">
         <%= button_link_to t('.clear_key'), spree.clear_api_key_admin_user_path(@user), method: :put, data: { confirm: t('.confirm_clear_key') }, class: 'btn btn-primary' %>

--- a/backend/spec/features/admin/users_spec.rb
+++ b/backend/spec/features/admin/users_spec.rb
@@ -238,7 +238,7 @@ describe 'Users', type: :feature do
       it 'can generate a new api key' do
         within("#admin_user_edit_api_key") do
           expect(user_a.spree_api_key).to be_blank
-          click_button Spree.t('generate_key', scope: 'api')
+          click_button "Generate API key"
         end
 
         expect(user_a.reload.spree_api_key).to be_present
@@ -257,7 +257,7 @@ describe 'Users', type: :feature do
       it 'can clear an api key' do
         expect(page).to have_css('#current-api-key')
 
-        click_button Spree.t('clear_key', scope: 'api')
+        click_button "Clear key"
 
         expect(page).to have_no_css('#current-api-key')
 
@@ -268,7 +268,7 @@ describe 'Users', type: :feature do
         old_key = user_a.spree_api_key
 
         within("#admin_user_edit_api_key") do
-          click_button Spree.t('regenerate_key', scope: 'api')
+          click_button "Regenerate key"
         end
 
         expect(user_a.reload.spree_api_key).to be_present

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -952,6 +952,8 @@ en:
         edit:
           api_access: "API Access"
           clear_key: "Clear key"
+          confirm_clear_key: "Are you sure you want to clear this user's API key? It will invalidate the existing key."
+          confirm_regenerate_key: "Are you sure you want to regenerate this user's API key? It will invalidate the existing key."
           generate_key: "Generate API key"
           key: "Key"
           no_key: "No key"

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -949,6 +949,13 @@ en:
       users:
         user_page_actions:
           create_order: Create order for this user
+        edit:
+          api_access: "API Access"
+          clear_key: "Clear key"
+          generate_key: "Generate API key"
+          key: "Key"
+          no_key: "No key"
+          regenerate_key: "Regenerate key"
       variants:
         table_filter:
           show_deleted: Show deleted variants


### PR DESCRIPTION
This improves a few aspects of how API keys are handled and displayed on the user edit page.

* I18n translations for this page moved out of the API gem, and keys named relative to the view.
* Confirmation dialogs added for clearing or regenerating the key.
* API key is displayed for admins viewing their own user page
* Fixed changed bad heading translation ("Stores -> User")
* Embolden "**Key:**" and italicize "_(hidden)_"