### PR TITLE
Add form submit events to several backbone views

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -3,7 +3,8 @@
 var ShipmentAddVariantView = Backbone.View.extend({
   events: {
     "change #add_variant_id": "onSelect",
-    "click .add_variant": "onAdd"
+    "click .add_variant": "onAdd",
+    "submit form": "onAdd"
   },
   onSelect: function(e) {
     var variant_id = this.$("#add_variant_id").val();
@@ -132,6 +133,7 @@ var ShipmentSplitItemView = Backbone.View.extend({
   events: {
     "click .cancel-split": "cancelItemSplit",
     "click .save-split": "completeItemSplit",
+    "submit form": "completeItemSplit",
   },
 
   cancelItemSplit: function(e){

--- a/backend/app/assets/javascripts/spree/backend/stock_management/index_update_forms.coffee
+++ b/backend/app/assets/javascripts/spree/backend/stock_management/index_update_forms.coffee
@@ -12,6 +12,7 @@ Spree.EditStockItemView = Backbone.View.extend
   events:
     "click .edit": "onEdit"
     "click .submit": "onSubmit"
+    "submit form": "onSubmit"
     "click .cancel": "onCancel"
 
   template: HandlebarsTemplates['stock_items/stock_location_stock_item']

--- a/backend/app/assets/javascripts/spree/backend/templates/orders/line_item.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/orders/line_item.hbs
@@ -19,7 +19,9 @@
 </td>
 {{#if editing}}
   <td class="line-item-qty-edit">
-    <input type="number" name="quantity" value="{{ line_item.quantity }}" min="0" class="line_item_quantity" size="5">
+    <form>
+      <input type="number" name="quantity" value="{{ line_item.quantity }}" min="0" class="line_item_quantity" size="5">
+    </form>
   </td>
 {{else}}
   <td class="line-item-qty-show">

--- a/backend/app/assets/javascripts/spree/backend/templates/stock_items/stock_location_stock_item.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/stock_items/stock_location_stock_item.hbs
@@ -10,7 +10,9 @@
 </td>
 <td>
   {{#if editing}}
-    <input class="fullwidth" name="count_on_hand" type="number" value="{{count_on_hand}}">
+    <form>
+      <input class="fullwidth" name="count_on_hand" type="number" value="{{count_on_hand}}">
+    </form>
   {{else}}
     <span>{{count_on_hand}}</span>
   {{/if}}

--- a/backend/app/assets/javascripts/spree/backend/templates/variants/autocomplete_stock.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/variants/autocomplete_stock.hbs
@@ -22,7 +22,9 @@
                 It doesn't track inventory
               </td>
               <td>
-                <input class="quantity" id="stock_item_quantity" data-stock-location-id="{{this.stock_location_id}}" type="number" min="1" value="1">
+                <form>
+                  <input class="quantity" id="stock_item_quantity" data-stock-location-id="{{this.stock_location_id}}" type="number" min="1" value="1">
+                </form>
               </td>
               <td class="actions">
                 <button class="add_variant no-text fa fa-plus icon_link with-tip" data-stock-location-id="{{this.stock_location_id}}" title="{{ t "add" }}" data-action="add"></button>
@@ -34,7 +36,9 @@
                   {{#if this.backorderable}} ({{ t "backorders_allowed" }}) {{/if}}
                 </td>
                 <td>
-                  <input class="quantity" id="stock_item_quantity" data-stock-location-id="{{this.stock_location_id}}" type="number" min="1" value="1">
+                  <form>
+                    <input class="quantity" id="stock_item_quantity" data-stock-location-id="{{this.stock_location_id}}" type="number" min="1" value="1">
+                  </form>
                 </td>
                 <td class="actions">
                   <button class="add_variant no-text fa fa-plus icon_link with-tip" data-stock-location-id="{{this.stock_location_id}}" title="{{ t "add" }}" data-action="add"></button>

--- a/backend/app/assets/javascripts/spree/backend/templates/variants/split.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/variants/split.hbs
@@ -17,7 +17,9 @@
   </select>
 </td>
 <td>
-  <input class="quantity" id="item_quantity" type="number" min="1" value="1" max="{{max_quantity}}">
+  <form>
+    <input class="quantity" id="item_quantity" type="number" min="1" value="1" max="{{max_quantity}}">
+  </form>
 </td>
 <td class='actions'>
   <button class="save-split icon_link fa fa-ok no-text with-tip" data-action="save" title="{{ t "actions.save" }}"></button>

--- a/backend/app/assets/javascripts/spree/backend/views/cart/line_item_row.js
+++ b/backend/app/assets/javascripts/spree/backend/views/cart/line_item_row.js
@@ -11,6 +11,7 @@ Spree.Views.Cart.LineItemRow = Backbone.View.extend({
     'click .edit-line-item': 'onEdit',
     'click .cancel-line-item': 'onCancel',
     'click .save-line-item': 'onSave',
+    'submit form': 'onSave',
     'click .delete-line-item': 'onDelete',
     'change .js-select-variant': 'onChangeVariant',
   },

--- a/backend/app/assets/javascripts/spree/backend/views/payment/payment_row.js
+++ b/backend/app/assets/javascripts/spree/backend/views/payment/payment_row.js
@@ -2,6 +2,7 @@ Spree.Views.Payment.PaymentRow = Backbone.View.extend({
   events: {
     "click .js-edit": "onEdit",
     "click .js-save": "onSave",
+    "submit form": "onSave",
     "click .js-cancel": "onCancel"
   },
 

--- a/backend/app/views/spree/admin/payments/_list.html.erb
+++ b/backend/app/views/spree/admin/payments/_list.html.erb
@@ -37,7 +37,9 @@
               <div class="input-group-addon number-with-currency-symbol">
                 <%= ::Money::Currency.find(@order.currency).symbol %>
               </div>
-              <%= text_field_tag :amount, payment.amount, class: 'js-edit-amount align-right form-control' %>
+              <form class="editing-show">
+                <%= text_field_tag :amount, payment.amount, class: 'js-edit-amount align-right form-control' %>
+              </form>
             </div>
           </div>
           <span class="js-display-amount editing-hide"><%= payment.display_amount.to_html %></span>

--- a/backend/app/views/spree/admin/promotions/calculators/tiered_flat_rate/_fields.html.erb
+++ b/backend/app/views/spree/admin/promotions/calculators/tiered_flat_rate/_fields.html.erb
@@ -25,6 +25,6 @@
       'form-prefix' => prefix,
       'calculator' => 'tiered_flat_rate'
     } %>
-    <button class="button js-add-tier"><%= t('spree.actions.add') %></button>
+    <a class="button js-add-tier"><%= t('spree.actions.add') %></a>
   </div>
 </div>

--- a/backend/app/views/spree/admin/promotions/calculators/tiered_percent/_fields.html.erb
+++ b/backend/app/views/spree/admin/promotions/calculators/tiered_percent/_fields.html.erb
@@ -25,6 +25,6 @@
       'form-prefix' => prefix,
       'calculator' => 'tiered_percent'
     } %>
-    <button class="button js-add-tier"><%= t('spree.actions.add') %></button>
+    <a class="button js-add-tier"><%= t('spree.actions.add') %></a>
   </div>
 </div>

--- a/backend/spec/features/admin/promotions/tiered_calculator_spec.rb
+++ b/backend/spec/features/admin/promotions/tiered_calculator_spec.rb
@@ -20,7 +20,7 @@ feature "Tiered Calculator Promotions" do
       expect(page).to have_content("Base Percent")
       expect(page).to have_content("Tiers")
 
-      click_button "Add"
+      page.find('a.button').click
     end
 
     fill_in "Base Percent", with: 5


### PR DESCRIPTION
Lots of our backbone based table rows do have input fields. Users are used to be able to submit changes by hitting the enter key inside a form field.
This is default browser behaviour and should be supported by all our backbone based table row views.