### PR TITLE
Fix class definition of variant

### DIFF
--- a/core/app/models/spree/variant/price_selector.rb
+++ b/core/app/models/spree/variant/price_selector.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Variant
+  class Variant < Spree::Base
     # This class is responsible for selecting a price for a variant given certain pricing options.
     # A variant can have multiple or even dynamic prices. The `price_for`
     # method determines which price applies under the given circumstances.

--- a/core/app/models/spree/variant/pricing_options.rb
+++ b/core/app/models/spree/variant/pricing_options.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Variant
+  class Variant < Spree::Base
     # Instances of this class represent the set of circumstances that influence how expensive a
     # variant is. For this particular pricing options class, country_iso and currency influence
     # the price of a variant.

--- a/core/app/models/spree/variant/vat_price_generator.rb
+++ b/core/app/models/spree/variant/vat_price_generator.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Variant
+  class Variant < Spree::Base
     # This class generates gross prices for all countries that have VAT configured.
     # The prices will include their respective VAT rates. It will also generate an
     # export (net) price for any country that doesn't have VAT.


### PR DESCRIPTION
We shouldn't have multiple inconsistent definitions of the same class.