### PR TITLE
Fix Admin Homepage Spec Link Expectations

### DIFF
--- a/backend/spec/features/admin/homepage_spec.rb
+++ b/backend/spec/features/admin/homepage_spec.rb
@@ -10,23 +10,27 @@ describe "Homepage", type: :feature do
       end
 
       it "should have a link to overview" do
-        within(".admin-nav-header") { page.find(:xpath, "a[@href='/admin']") }
+        within(".admin-nav-header") { expect(page).to have_link(nil, href: "/admin") }
       end
 
       it "should have a link to orders" do
-        page.find_link("Orders")['/admin/orders']
+        expect(page).to have_link("Orders", href: "/admin/orders")
       end
 
       it "should have a link to products" do
-        page.assert_selector(:link, text: "Products", count: 2)
+        expect(page).to have_link("Products", href: "/admin/products", count: 2)
       end
 
       it "should have a link to reports" do
-        page.find_link("Reports")['/admin/reports']
+        expect(page).to have_link("Reports", href: "/admin/reports")
       end
 
       it "should have a link to configuration" do
-        page.find_link("Settings")['/admin/configurations']
+        expect(page).to have_link("Settings", href: "/admin/stores")
+      end
+
+      it "should have a link to promotions" do
+        expect(page).to have_link("Promotions", href: "/admin/promotions", count: 2)
       end
     end
 
@@ -36,17 +40,30 @@ describe "Homepage", type: :feature do
       end
 
       it "should have a link to products" do
-        within('.selected .admin-subnav') { page.find_link("Products")['/admin/products'] }
+        within('.selected .admin-subnav') { expect(page).to have_link("Products", href: "/admin/products") }
       end
 
       it "should have a link to option types" do
-        within('.selected .admin-subnav') { page.find_link("Option Types")['/admin/option_types'] }
+        within('.selected .admin-subnav') { expect(page).to have_link("Option Types", href: "/admin/option_types") }
       end
 
       it "should have a link to property types" do
-        within('.selected .admin-subnav') { page.find_link("Property Types")['/admin/properties'] }
+        within('.selected .admin-subnav') { expect(page).to have_link("Property Types", href: "/admin/properties") }
+      end
+    end
+
+    context "visiting the promotions tab" do
+      before(:each) do
+        visit spree.admin_promotions_path
       end
 
+      it "should have a link to promotions" do
+        within('.selected .admin-subnav') { expect(page).to have_link("Promotions", href: "/admin/promotions") }
+      end
+
+      it "should have a link to promotion categories" do
+        within('.selected .admin-subnav') { expect(page).to have_link("Promotion Categories", href: "/admin/promotion_categories") }
+      end
     end
   end
 


### PR DESCRIPTION
Prior to this commit, we were using a terse syntax for
testing the admin navigation that also did not work.

This changes the syntax to be more readable and actually
testing the links in question.

This is extracted from #1402 by @mgharbik.