### PR TITLE
Deprecate JSTree api routes

### DIFF
--- a/api/app/controllers/spree/api/taxonomies_controller.rb
+++ b/api/app/controllers/spree/api/taxonomies_controller.rb
@@ -15,6 +15,7 @@ module Spree
 
       # Because JSTree wants parameters in a *slightly* different format
       def jstree
+        Spree::Deprecation.warn("Please don't use `/api/taxonomies/:taxonomy_id/jstree` endpoint. It is deprecated and will be removed in the next future.", caller)
         show
       end
 

--- a/api/app/controllers/spree/api/taxons_controller.rb
+++ b/api/app/controllers/spree/api/taxons_controller.rb
@@ -23,6 +23,7 @@ module Spree
       end
 
       def jstree
+        Spree::Deprecation.warn("Please don't use `/api/taxonomies/:taxonomy_id/taxons/:taxon_id/jstree` endpoint. It is deprecated and will be removed in the next future.", caller)
         show
       end
 

--- a/api/spec/requests/spree/api/taxonomies_controller_spec.rb
+++ b/api/spec/requests/spree/api/taxonomies_controller_spec.rb
@@ -59,6 +59,7 @@ module Spree
       end
 
       it "gets the jstree-friendly version of a taxonomy" do
+        expect(Spree::Deprecation).to(receive(:warn))
         get spree.jstree_api_taxonomy_path(taxonomy.id)
         expect(json_response["data"]).to eq(taxonomy.root.name)
         expect(json_response["attr"]).to eq({ "id" => taxonomy.root.id, "name" => taxonomy.root.name })

--- a/api/spec/requests/spree/api/taxons_controller_spec.rb
+++ b/api/spec/requests/spree/api/taxons_controller_spec.rb
@@ -92,6 +92,7 @@ module Spree
       end
 
       it "gets all taxons in JSTree form" do
+        expect(Spree::Deprecation).to(receive(:warn))
         get spree.jstree_api_taxonomy_taxon_path(taxonomy, taxon.id)
         response = json_response.first
         expect(response["data"]).to eq(taxon2.name)


### PR DESCRIPTION
We are not using JSTree anymore (#569) but we still have these routes available for stores that used it outside JSTree scopes.

We decided to deprecate these routes long time ago but we never did it. See also #194.

Once we've deprecated this enough we can probably just resurrect #664.