### PR TITLE
Use line_item_adjustments inside line_item_adjustments.exists?

### DIFF
--- a/frontend/app/views/spree/shared/_order_details.html.erb
+++ b/frontend/app/views/spree/shared/_order_details.html.erb
@@ -94,9 +94,9 @@
   </tfoot>
 
   <% if order.line_item_adjustments.exists? %>
-    <% if order.all_adjustments.promotion.eligible.exists? %>
+    <% if order.line_item_adjustments.promotion.eligible.exists? %>
       <tfoot id="price-adjustments" data-hook="order_details_price_adjustments">
-        <% order.all_adjustments.promotion.eligible.group_by(&:label).each do |label, adjustments| %>
+        <% order.line_item_adjustments.promotion.eligible.group_by(&:label).each do |label, adjustments| %>
           <tr class="total">
             <td colspan="4"><%= Spree.t(:promotion) %>: <strong><%= label %></strong></td>
             <td class="total"><span><%= Spree::Money.new(adjustments.sum(&:amount), currency: order.currency) %></span></td>


### PR DESCRIPTION
Usage of all_adjustments was showing duplicate promotions.

Rebase of #1301, decided the view specs would be nice but having this in would be nicer.