### PR TITLE
Deprecate AdjustmentSource#deals_with_adjustments_for_deleted_source

### DIFF
--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -101,8 +101,12 @@ module Spree
         return amount
       end
 
-      # If the adjustment has no source, do not attempt to re-calculate the amount.
-      # Chances are likely that this was a manually created adjustment in the admin backend.
+      # If the adjustment has no source, do not attempt to re-calculate the
+      # amount.
+      # Some scenarios where this happens:
+      #   - Adjustments that are manually created via the admin backend
+      #   - PromotionAction adjustments where the PromotionAction was deleted
+      #     after the order was completed.
       if source.present?
         self.amount = source.compute_amount(adjustable)
 

--- a/core/app/models/spree/promotion/actions/create_adjustment.rb
+++ b/core/app/models/spree/promotion/actions/create_adjustment.rb
@@ -10,7 +10,7 @@ module Spree
         delegate :eligible?, to: :promotion
 
         before_validation :ensure_action_has_calculator
-        before_destroy :deals_with_adjustments_for_deleted_source
+        before_destroy :remove_adjustments_from_incomplete_orders
 
         # Creates the adjustment related to a promotion for the order passed
         # through options hash

--- a/core/app/models/spree/promotion/actions/create_item_adjustments.rb
+++ b/core/app/models/spree/promotion/actions/create_item_adjustments.rb
@@ -10,7 +10,7 @@ module Spree
         delegate :eligible?, to: :promotion
 
         before_validation :ensure_action_has_calculator
-        before_destroy :deals_with_adjustments_for_deleted_source
+        before_destroy :remove_adjustments_from_incomplete_orders
 
         def perform(payload = {})
           order = payload[:order]

--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -3,7 +3,7 @@ module Spree
     acts_as_paranoid
 
     # Need to deal with adjustments before calculator is destroyed.
-    before_destroy :deals_with_adjustments_for_deleted_source
+    before_destroy :remove_adjustments_from_incomplete_orders
 
     include Spree::CalculatedAdjustments
     include Spree::AdjustmentSource

--- a/core/spec/models/spree/promotion/actions/create_item_adjustments_spec.rb
+++ b/core/spec/models/spree/promotion/actions/create_item_adjustments_spec.rb
@@ -161,21 +161,27 @@ module Spree
           context 'with complete orders' do
             let(:order) { create(:completed_order_with_totals) }
 
-            it 'nullifies adjustments for completed orders' do
-              adjustment = order.adjustments.create!(label: 'Check', amount: 0, order: order, source: action)
+            it "does not change adjustments for completed orders" do
+              order = create :order, completed_at: Time.current
+              adjustment = action.adjustments.create!(label: "Check", amount: 0, order: order, adjustable: order)
+
+              expect {
+                expect {
+                  action.destroy
+                }.not_to change { adjustment.reload.source_id }
+              }.not_to change { Spree::Adjustment.count }
+
+              expect(adjustment.source).to eq(nil)
+              expect(Spree::PromotionAction.with_deleted.find(adjustment.source_id)).to be_present
+            end
+
+            it "doesnt mess with unrelated adjustments" do
+              order.adjustments.create!(label: "Check", amount: 0, order: order, source: action)
 
               expect {
                 action.destroy
-              }.to change { adjustment.reload.source_id }.from(action.id).to nil
+              }.not_to change { other_action.adjustments.count }
             end
-          end
-
-          it "doesnt mess with unrelated adjustments" do
-            order.adjustments.create!(label: "Check", amount: 0, order: order, source: action)
-
-            expect {
-              action.destroy
-            }.not_to change { other_action.adjustments.count }
           end
         end
       end


### PR DESCRIPTION
Stop setting spree_adjustments.source_id to null on completed orders
when deleting an adjustment source.

This shouldn't be necessary since in either case `adjustment.source`
will be nil. Also, the two sources using this within Solidus itself
(PromotionAction and TaxRate) both use `acts_as_paranoid` so deleting
the source_id deletes data that could still be useful because the
record is still actually in the database.

Rebase of #1419