### PR TITLE
Default backend navigation footer

### DIFF
--- a/backend/app/views/spree/admin/shared/_navigation_footer.html.erb
+++ b/backend/app/views/spree/admin/shared/_navigation_footer.html.erb
@@ -1,5 +1,5 @@
 <!-- solidus_auth_devise replaces this partial with it's own login_nav.
-     But we provide a defaut implementation below that should work with
+     But we provide a default implementation below that should work with
      any typical `rails generate spree:custom_user` auth, if you need something
      else you can override it like solidus_auth_devise does.
 -->

--- a/backend/spec/views/spree/admin/shared/navigation_footer_spec.rb
+++ b/backend/spec/views/spree/admin/shared/navigation_footer_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe "spree/admin/shared/_navigation_footer", type: :view do
-  let(:user) { create(:admin_user) }
+  let(:user) { FactoryGirl.build_stubbed(:admin_user) }
   before do
     allow(view).to receive(:try_spree_current_user).and_return(user)
   end


### PR DESCRIPTION
Adding missed nice to haves mentioned in the review of https://github.com/solidusio/solidus/pull/1450

Fixes a typo in `backend/app/views/spree/admin/shared/_navigation_footer.html.erb`

Replaces `create(:admin_user)` with `FactoryGirl.build_stubbed(:admin_user)`
