### PR TITLE
Add required to product master price field

### DIFF
--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -31,8 +31,10 @@
     <div class="right col-3" data-hook="admin_product_form_right">
       <div data-hook="admin_product_form_price">
         <%= f.field_container :price do %>
-          <%= f.label :price, class: 'required' %>
-          <%= render "spree/admin/shared/number_with_currency", f: f, amount_attr: :price,
+          <%= f.label :price, class: Spree::Config.require_master_price ? 'required' : '' %>
+          <%= render "spree/admin/shared/number_with_currency", f: f,
+                     amount_attr: :price,
+                     required: Spree::Config.require_master_price,
                      currency: Spree::Config.default_pricing_options.currency %>
           <%= f.error_message_on :price %>
         <% end %>


### PR DESCRIPTION
This adds `required: true` to the master price field on the products
form. The label for the field indicates that it is required, but the
field can be cleared, and the form submitted - resulting in the price
being defaulted to `0.00`

This is part of issue #1861. Though in the issue report it talks of the
product price showing a deleted value when removed (which has been
resolved). This further makes it a conscious decision to set the price
to `0`.