### PR TITLE
Cancel authorized (pending) payments when cancelling an order

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -852,8 +852,9 @@ module Spree
 
     def after_cancel
       shipments.each(&:cancel!)
-      payments.completed.each { |payment| payment.cancel! unless payment.fully_refunded? }
-      payments.store_credits.pending.each(&:void_transaction!)
+      payments.select do |payment|
+        (p.pending? || p.completed?) && !payment.fully_refunded?
+      end.each(&:cancel!)
 
       send_cancel_email
       recalculate

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -1477,6 +1477,19 @@ RSpec.describe Spree::Order, type: :model do
 
     describe '#cancel' do
       context 'with a credit card payment' do
+        context 'when the payment is pending' do
+          let(:order) { create(:completed_order_with_pending_payment) }
+          let(:payment) { order.payments[0] }
+
+          it 'voids the pending payment' do
+            expect {
+              order.cancel!
+            }.to change {
+              payment.reload.state
+            }.from('pending').to('void')
+          end
+        end
+
         context 'when the payment is completed' do
           let(:order) { create(:order_ready_to_ship) }
           let(:payment) { order.payments[0] }


### PR DESCRIPTION
E.g., release funds on a credit card auth for cancelled orders whose
payments have been authorized but not yet captured.

This was already happening for store credit payments.

I tried to think of a reason not to void `pending` payments when cancelling an order and couldn't think of any reason.  Perhaps most people simply capture at order complete so this hasn't been an issue? And/or they don't worry about releasing authorizations on people's credit cards?

Closes #1529

This is a rebased version of #1529