### PR TITLE
Use HTML5 to prevent spaces in promotion codes

### DIFF
--- a/backend/app/views/spree/admin/promotions/_activations_new.html.erb
+++ b/backend/app/views/spree/admin/promotions/_activations_new.html.erb
@@ -35,7 +35,7 @@
     <div data-activation-type="single_code">
       <div class="field">
         <%= label_tag :single_code, Spree::PromotionCode.model_name.human, class: "required" %>
-        <%= text_field_tag :single_code, @promotion.codes.first.try!(:value), class: "fullwidth", required: true %>
+        <%= text_field_tag :single_code, @promotion.codes.first.try!(:value), class: "fullwidth", required: true, pattern: '[^\s]*', title: t(".single_code_title") %>
       </div>
     </div>
 

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -864,6 +864,7 @@ en:
           multiple_codes: Multiple promotion codes
           path: URL Path
           single_code: Single promotion code
+          single_code_title: Can't contain spaces
         activations_edit:
           auto: All orders will attempt to use this promotion
           single_code_html: "This promotion uses the promotion code: <code>%{code}</code>"


### PR DESCRIPTION
Alternative to #1796

This prevents promotions from being created with an accidental whitespace.

This is a UX concern rather than a business logic/technical/security constraint, to it makes sense to keep the solution as close to that level as possible (in the HTML).

This could be made even nicer by listening to keydown events on this input and preventing spaces from being entered, but I think this is a minor and infrequent enough issue for users that that isn't worth the effort.