### PR TITLE
Fix closing thead tag on store credit table

### DIFF
--- a/backend/app/views/spree/admin/store_credits/index.html.erb
+++ b/backend/app/views/spree/admin/store_credits/index.html.erb
@@ -30,7 +30,7 @@
           <th class="wrap-text"><%= Spree::StoreCredit.human_attribute_name(:created_at) %></th>
           <th class="wrap-text"><%= Spree::StoreCredit.human_attribute_name(:invalidated_at) %></th>
           <th data-hook="admin_store_credits_index_header_actions" class="actions"></th>
-        <thead>
+        </thead>
         <tbody>
           <% credits.each do |store_credit| %>
             <tr>


### PR DESCRIPTION
Although most browsers should be able to figure this out, it's technically not valid HTML.