### PR TITLE
Issue with Transactional Rollbacks during Test Environments with Spree Log Entries

### DIFF
--- a/core/app/models/spree/log_entry.rb
+++ b/core/app/models/spree/log_entry.rb
@@ -4,7 +4,7 @@ module Spree
 
     # Fix for https://github.com/spree/spree/issues/1767
     # If a payment fails, we want to make sure we keep the record of it failing
-    after_rollback :save_anyway, if: Proc.new { !Rails.env.test? }
+    after_rollback :save_anyway, if: proc { !Rails.env.test? }
 
     def save_anyway
       log = Spree::LogEntry.new

--- a/core/app/models/spree/log_entry.rb
+++ b/core/app/models/spree/log_entry.rb
@@ -4,7 +4,7 @@ module Spree
 
     # Fix for https://github.com/spree/spree/issues/1767
     # If a payment fails, we want to make sure we keep the record of it failing
-    after_rollback :save_anyway
+    after_rollback :save_anyway, if: Proc.new { !Rails.env.test? }
 
     def save_anyway
       log = Spree::LogEntry.new


### PR DESCRIPTION
I am proposing this fix to the `Spree::LogEntry` model. 

When running my tests with DatabaseCleaner (using `:transaction`), after it asserts my first example using `rspec`, DatabaseCleaner kicks in to transactionally rollback all my test data. Unfortunately, due to this feature, I run into issues where the `after_rollback` is called on the `Spree::LogEntry` model which in turn tries to append some information that does not exist anymore since DatabaseCleaner had its way and cleared out my test data. This causes an issue where the record of a variant is not found anymore. 

For those who use DatabaseCleaner, to ignore trying to create new Spree::LogEntries during test environments. I have attached a gist of a log with a backtrace of my `byebug` statement. Notice at the top of the gist, `BEFORE @lpes_calculator; AFTER @lpes_calculator` is wrapped around my `expect` statement.

I am open to potentially better solutions.

https://gist.github.com/reidcooper/2e09d5dc21f5783b26d0ae7a633a22f5