### PR TITLE
refactor length == 0 to use empty? method

### DIFF
--- a/frontend/app/views/spree/orders/_line_item.html.erb
+++ b/frontend/app/views/spree/orders/_line_item.html.erb
@@ -2,7 +2,7 @@
 <%= order_form.fields_for :line_items, line_item do |item_form| -%>
   <tr class="<%= cycle('', 'alt') %> line-item">
     <td class="cart-item-image" data-hook="cart_item_image">
-      <% if variant.images.length == 0 %>
+      <% if variant.images.empty? %>
         <%= link_to(render('spree/shared/image', image: variant.product.display_image, size: :small), variant.product) %>
       <% else %>
         <%= link_to(render('spree/shared/image', image: variant.images.first, size: :small), variant.product) %>

--- a/frontend/app/views/spree/shared/_order_details.html.erb
+++ b/frontend/app/views/spree/shared/_order_details.html.erb
@@ -62,7 +62,7 @@
     <% order.line_items.each do |item| %>
       <tr data-hook="order_details_line_item_row">
         <td data-hook="order_item_image">
-          <% if item.variant.images.length == 0 %>
+          <% if item.variant.images.empty? %>
             <%= link_to(render('spree/shared/image', image: item.variant.product.display_image, size: :small), item.variant.product) %>
           <% else %>
             <%= link_to(render('spree/shared/image', image: item.variant.images.first, size: :small), item.variant.product) %>


### PR DESCRIPTION
This PR refactors two lines in the frontend views that were using `.length == 0`. I think that `.empty?` (or `.blank?`, or alternately reversing the conditional branches and using `.present?`) is significantly cleaner!