### PR TITLE
Translate reception states and fix translation key

### DIFF
--- a/core/app/models/spree/return_item.rb
+++ b/core/app/models/spree/return_item.rb
@@ -212,7 +212,7 @@ module Spree
       event_paths.delete(:expired)
       event_paths.delete(:unexchange)
 
-      status_paths.map{ |s| s.to_s.humanize }.zip(event_paths)
+      status_paths.map{ |s| I18n.t("spree.reception_states.#{s}", default: s.to_s.humanize) }.zip(event_paths)
     end
 
     def part_of_exchange?

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1735,7 +1735,7 @@ en:
     receiving_match: Receiving match
     reception_states:
       awaiting: Awaiting
-      canceled: Canceled
+      cancelled: Canceled
       expired: Expired
       given_to_customer: Given to customer
       in_transit: In transit


### PR DESCRIPTION
Screen capture:

![captura de pantalla 2017-10-13 a las 8 11 27](https://user-images.githubusercontent.com/2051199/31532535-28ffb284-afee-11e7-86f2-5f830370f0fb.png)

And the translation key for `Canceled` state is with double `l`: https://github.com/solidusio/solidus/blob/master/core/app/models/spree/return_item.rb#L83


