### PR TITLE
Update translation for Adjustment Label

### DIFF
--- a/backend/spec/features/admin/orders/adjustments_spec.rb
+++ b/backend/spec/features/admin/orders/adjustments_spec.rb
@@ -65,7 +65,7 @@ describe "Adjustments", type: :feature do
         fill_in "adjustment_amount", with: ""
         fill_in "adjustment_label", with: ""
         click_button "Continue"
-        expect(page).to have_content("Description can't be blank")
+        expect(page).to have_content("Label can't be blank")
         expect(page).to have_content("Amount is not a number")
       end
     end
@@ -98,7 +98,7 @@ describe "Adjustments", type: :feature do
         fill_in "adjustment_amount", with: ""
         fill_in "adjustment_label", with: ""
         click_button "Continue"
-        expect(page).to have_content("Description can't be blank")
+        expect(page).to have_content("Label can't be blank")
         expect(page).to have_content("Amount is not a number")
       end
     end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -30,7 +30,7 @@ en:
       spree/adjustment:
         adjustable: Adjustable
         amount: Amount
-        label: Description
+        label: Label
         name: Name
         state: State
         adjustment_reason_id: Reason


### PR DESCRIPTION
Updating the translation to reflect what the attribute is called to correct the error message when providing attributes to create. `Spree::Adjustment.create!` requires a description with message
'Description can't be blank', providing it using `description: 'string'` outputs "unknown attribute 'description' for Spree::Adjustment."