### PR TITLE
Convert Cart total/subtotal CSS colors to vars

### DIFF
--- a/frontend/app/assets/stylesheets/spree/frontend/_variables.scss
+++ b/frontend/app/assets/stylesheets/spree/frontend/_variables.scss
@@ -15,6 +15,9 @@ $product_body_text_color:   #404042 !default;
 $product_price_text_color:  #252525 !default;
 $product_link_text_color:   #BBBBBB !default;
 
+$cart_total_background_color: $link_text_color !default;
+$cart_total_text_color: #FFFFFF !default;
+
 /*--------------------------------------*/
 /* Fonts import from remote
 /*--------------------------------------*/

--- a/frontend/app/assets/stylesheets/spree/frontend/screen.css.scss
+++ b/frontend/app/assets/stylesheets/spree/frontend/screen.css.scss
@@ -993,10 +993,10 @@ div[data-hook="inside_cart_form"] {
 }
 
 .cart-subtotal, .cart-total {
-  background: #00ADEE;
+  background: $cart_total_background_color;
 
   td h5 {
-    color: #fff;
+    color: $cart_total_text_color;
   }
 }
 


### PR DESCRIPTION
This is for issue #2251 

Following up on the feedback for #1708, I've taken Martin's suggestion for a variable name, but opted for underscores to match the rest of the variable names. 

I've also opted to not use `$product_price_text_color` for the text - It would make it default to black, which is not inline with the current style, as well is not a fitting name for the context. Instead I've created a new var `$cart_total_text_color ` and assigned it white.