### PR TITLE
update no_objects_found partial to allow not show new resource link

### DIFF
--- a/backend/app/views/spree/admin/shared/_no_objects_found.html.erb
+++ b/backend/app/views/spree/admin/shared/_no_objects_found.html.erb
@@ -1,4 +1,4 @@
 <%= t('spree.no_resource', resource: plural_resource_name(resource)) %>
-<% if can? :create, resource %>
+<% if can? :create, resource and local_assigns[:new_resource_url] %>
   <%= link_to t('spree.create_one'), new_resource_url %>
 <% end %>

--- a/backend/app/views/spree/admin/stock_movements/index.html.erb
+++ b/backend/app/views/spree/admin/stock_movements/index.html.erb
@@ -40,8 +40,7 @@
 <% else %>
   <div class="col-9 no-objects-found">
     <%= render 'spree/admin/shared/no_objects_found',
-                 resource: Spree::StockMovement,
-                 new_resource_url: new_object_url %>
+                 resource: Spree::StockMovement %>
   </div>
 <% end %>
 


### PR DESCRIPTION
Fix #2150 

Like described in the issue mentioned above there is an error when we try to generate a `new_object_url` for stock movements, this because stock movements only allow [index route](https://github.com/solidusio/solidus/blob/09b0d748b9e3f94f05fb8768a25673f9941d10d6/backend/config/routes.rb#L170).