### PR TITLE
Explicitly require cancan where used

### DIFF
--- a/core/lib/spree/core/controller_helpers/auth.rb
+++ b/core/lib/spree/core/controller_helpers/auth.rb
@@ -1,3 +1,5 @@
+require 'cancan'
+
 module Spree
   module Core
     module ControllerHelpers

--- a/core/lib/spree/testing_support/authorization_helpers.rb
+++ b/core/lib/spree/testing_support/authorization_helpers.rb
@@ -1,3 +1,5 @@
+require 'cancan'
+
 module Spree
   module TestingSupport
     module AuthorizationHelpers

--- a/core/spec/models/spree/ability_spec.rb
+++ b/core/spec/models/spree/ability_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'cancan'
 require 'cancan/matchers'
 require 'spree/testing_support/ability_helpers'
 require 'spree/testing_support/bar_ability'

--- a/core/spec/support/dummy_ability.rb
+++ b/core/spec/support/dummy_ability.rb
@@ -1,3 +1,5 @@
+require 'cancan'
+
 class DummyAbility
   include CanCan::Ability
 end


### PR DESCRIPTION
These files all use CanCan, so no harm in explicitily requiring it.