### PR TITLE
Allow access to Spree::Core::Environment through Spree::Config

### DIFF
--- a/core/app/models/concerns/spree/calculated_adjustments.rb
+++ b/core/app/models/concerns/spree/calculated_adjustments.rb
@@ -22,7 +22,7 @@ module Spree
       end
 
       def spree_calculators
-        Rails.application.config.spree.calculators
+        Spree::Config.environment.calculators
       end
     end
 

--- a/core/app/models/spree/calculator.rb
+++ b/core/app/models/spree/calculator.rb
@@ -29,7 +29,7 @@ module Spree
     def self.calculators
       Spree::Deprecation.warn("Calling .calculators is deprecated. Please access through Rails.application.config.spree.calculators")
 
-      Rails.application.config.spree.calculators
+      Spree::Config.environment.calculators
     end
 
     def to_s

--- a/core/app/models/spree/payment_method.rb
+++ b/core/app/models/spree/payment_method.rb
@@ -58,7 +58,7 @@ module Spree
       def providers
         Spree::Deprecation.warn 'Spree::PaymentMethod.providers is deprecated and will be deleted in Solidus 3.0. ' \
           'Please use Rails.application.config.spree.payment_methods instead'
-        Rails.application.config.spree.payment_methods
+        Spree::Config.environment.payment_methods
       end
 
       def available(display_on = nil, store: nil)

--- a/core/app/models/spree/promotion_action.rb
+++ b/core/app/models/spree/promotion_action.rb
@@ -9,7 +9,7 @@ module Spree
     belongs_to :promotion, class_name: 'Spree::Promotion', inverse_of: :promotion_actions
 
     scope :of_type, ->(t) { where(type: Array.wrap(t).map(&:to_s)) }
-    scope :shipping, -> { of_type(Rails.application.config.spree.promotions.shipping_actions.to_a) }
+    scope :shipping, -> { of_type(Spree::Config.environment.promotions.shipping_actions.to_a) }
 
     # Updates the state of the order or performs some other action depending on
     # the subclass options will contain the payload from the event that

--- a/core/app/models/spree/stock/simple_coordinator.rb
+++ b/core/app/models/spree/stock/simple_coordinator.rb
@@ -10,7 +10,7 @@ module Spree
     #   * Combine allocated and on hand inventory into a single shipment per-location
     #
     # After allocation, splitters are run on each Package (as configured in
-    # Rails.application.config.spree.stock_splitters)
+    # Spree::Config.environment.stock_splitters)
     #
     # Finally, shipping rates are calculated using the class configured as
     # Spree::Config.stock.estimator_class.
@@ -20,7 +20,7 @@ module Spree
       def initialize(order, inventory_units = nil)
         @order = order
         @inventory_units = inventory_units || InventoryUnitBuilder.new(order).units
-        @splitters = Rails.application.config.spree.stock_splitters
+        @splitters = Spree::Config.environment.stock_splitters
         @stock_locations = Spree::StockLocation.active
 
         @inventory_units_by_variant = @inventory_units.group_by(&:variant)

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -383,7 +383,79 @@ module Spree
     end
 
     def environment
-      @environment ||= Spree::Core::Environment.new(self)
+      @environment ||= Spree::Core::Environment.new(self).tap do |env|
+        env.calculators.shipping_methods = %w[
+          Spree::Calculator::Shipping::FlatPercentItemTotal
+          Spree::Calculator::Shipping::FlatRate
+          Spree::Calculator::Shipping::FlexiRate
+          Spree::Calculator::Shipping::PerItem
+          Spree::Calculator::Shipping::PriceSack
+        ]
+
+        env.calculators.tax_rates = %w[
+          Spree::Calculator::DefaultTax
+        ]
+
+        env.stock_splitters = %w[
+          Spree::Stock::Splitter::ShippingCategory
+          Spree::Stock::Splitter::Backordered
+        ]
+
+        env.payment_methods = %w[
+          Spree::PaymentMethod::BogusCreditCard
+          Spree::PaymentMethod::SimpleBogusCreditCard
+          Spree::PaymentMethod::StoreCredit
+          Spree::PaymentMethod::Check
+        ]
+
+        env.promotions = Spree::Promo::Environment.new.tap do |promos|
+          promos.rules = %w[
+            Spree::Promotion::Rules::ItemTotal
+            Spree::Promotion::Rules::Product
+            Spree::Promotion::Rules::User
+            Spree::Promotion::Rules::FirstOrder
+            Spree::Promotion::Rules::UserLoggedIn
+            Spree::Promotion::Rules::OneUsePerUser
+            Spree::Promotion::Rules::Taxon
+            Spree::Promotion::Rules::NthOrder
+            Spree::Promotion::Rules::OptionValue
+            Spree::Promotion::Rules::FirstRepeatPurchaseSince
+            Spree::Promotion::Rules::UserRole
+          ]
+
+          promos.actions = %w[
+            Spree::Promotion::Actions::CreateAdjustment
+            Spree::Promotion::Actions::CreateItemAdjustments
+            Spree::Promotion::Actions::CreateQuantityAdjustments
+            Spree::Promotion::Actions::FreeShipping
+          ]
+
+          promos.shipping_actions = %w[
+            Spree::Promotion::Actions::FreeShipping
+          ]
+        end
+
+        env.calculators.promotion_actions_create_adjustments = %w[
+          Spree::Calculator::FlatPercentItemTotal
+          Spree::Calculator::FlatRate
+          Spree::Calculator::FlexiRate
+          Spree::Calculator::TieredPercent
+          Spree::Calculator::TieredFlatRate
+        ]
+
+        env.calculators.promotion_actions_create_item_adjustments = %w[
+          Spree::Calculator::DistributedAmount
+          Spree::Calculator::FlatRate
+          Spree::Calculator::FlexiRate
+          Spree::Calculator::PercentOnLineItem
+          Spree::Calculator::TieredPercent
+        ]
+
+        env.calculators.promotion_actions_create_quantity_adjustments = %w[
+          Spree::Calculator::PercentOnLineItem
+          Spree::Calculator::FlatRate
+        ]
+      end
     end
 
     # Default admin VAT location

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -18,6 +18,7 @@
 require "spree/core/search/base"
 require "spree/core/search/variant"
 require 'spree/preferences/configuration'
+require 'spree/core/environment'
 
 module Spree
   class AppConfiguration < Preferences::Configuration
@@ -379,6 +380,10 @@ module Spree
 
     def stock
       @stock_configuration ||= Spree::Core::StockConfiguration.new
+    end
+
+    def environment
+      @environment ||= Spree::Core::Environment.new(self)
     end
 
     # Default admin VAT location

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -21,96 +21,15 @@ module Spree
         end
       end
 
-      initializer "spree.register.calculators", before: :load_config_initializers do |app|
-        app.config.spree.calculators.shipping_methods = %w[
-          Spree::Calculator::Shipping::FlatPercentItemTotal
-          Spree::Calculator::Shipping::FlatRate
-          Spree::Calculator::Shipping::FlexiRate
-          Spree::Calculator::Shipping::PerItem
-          Spree::Calculator::Shipping::PriceSack
-        ]
-
-        app.config.spree.calculators.tax_rates = %w[
-          Spree::Calculator::DefaultTax
-        ]
-      end
-
-      initializer "spree.register.stock_splitters", before: :load_config_initializers do |app|
-        app.config.spree.stock_splitters = %w[
-          Spree::Stock::Splitter::ShippingCategory
-          Spree::Stock::Splitter::Backordered
-        ]
-      end
-
-      initializer "spree.register.payment_methods", before: :load_config_initializers do |app|
-        app.config.spree.payment_methods = %w[
-          Spree::PaymentMethod::BogusCreditCard
-          Spree::PaymentMethod::SimpleBogusCreditCard
-          Spree::PaymentMethod::StoreCredit
-          Spree::PaymentMethod::Check
-        ]
-      end
-
-      # We need to define promotions rules here so extensions and existing apps
-      # can add their custom classes on their initializer files
-      initializer 'spree.promo.environment', before: :load_config_initializers do |app|
-        app.config.spree.promotions = Spree::Promo::Environment.new
-        app.config.spree.promotions.rules = []
-      end
-
-      initializer 'spree.promo.register.promotion.calculators', before: :load_config_initializers do |app|
-        app.config.spree.calculators.promotion_actions_create_adjustments = %w[
-          Spree::Calculator::FlatPercentItemTotal
-          Spree::Calculator::FlatRate
-          Spree::Calculator::FlexiRate
-          Spree::Calculator::TieredPercent
-          Spree::Calculator::TieredFlatRate
-        ]
-
-        app.config.spree.calculators.promotion_actions_create_item_adjustments = %w[
-          Spree::Calculator::DistributedAmount
-          Spree::Calculator::FlatRate
-          Spree::Calculator::FlexiRate
-          Spree::Calculator::PercentOnLineItem
-          Spree::Calculator::TieredPercent
-        ]
-
-        app.config.spree.calculators.promotion_actions_create_quantity_adjustments = %w[
-          Spree::Calculator::PercentOnLineItem
-          Spree::Calculator::FlatRate
-        ]
-      end
-
-      initializer 'spree.promo.register.promotion.rules', before: :load_config_initializers do |app|
-        app.config.spree.promotions.rules = %w[
-          Spree::Promotion::Rules::ItemTotal
-          Spree::Promotion::Rules::Product
-          Spree::Promotion::Rules::User
-          Spree::Promotion::Rules::FirstOrder
-          Spree::Promotion::Rules::UserLoggedIn
-          Spree::Promotion::Rules::OneUsePerUser
-          Spree::Promotion::Rules::Taxon
-          Spree::Promotion::Rules::NthOrder
-          Spree::Promotion::Rules::OptionValue
-          Spree::Promotion::Rules::FirstRepeatPurchaseSince
-          Spree::Promotion::Rules::UserRole
-        ]
-      end
-
-      initializer 'spree.promo.register.promotions.actions', before: :load_config_initializers do |app|
-        app.config.spree.promotions.actions = %w[
-          Spree::Promotion::Actions::CreateAdjustment
-          Spree::Promotion::Actions::CreateItemAdjustments
-          Spree::Promotion::Actions::CreateQuantityAdjustments
-          Spree::Promotion::Actions::FreeShipping
-        ]
-      end
-
-      initializer 'spree.promo.register.promotions.shipping_actions', before: :load_config_initializers do |app|
-        app.config.spree.promotions.shipping_actions = %w[
-          Spree::Promotion::Actions::FreeShipping
-        ]
-      end
+      # leave empty initializers for backwards-compatability. Other apps might still rely on these events
+      initializer "spree.register.calculators", before: :load_config_initializers do; end
+      initializer "spree.register.stock_splitters", before: :load_config_initializers do; end
+      initializer "spree.register.payment_methods", before: :load_config_initializers do; end
+      initializer 'spree.promo.environment', before: :load_config_initializers do; end
+      initializer 'spree.promo.register.promotion.calculators', before: :load_config_initializers do; end
+      initializer 'spree.promo.register.promotion.rules', before: :load_config_initializers do; end
+      initializer 'spree.promo.register.promotions.actions', before: :load_config_initializers do; end
+      initializer 'spree.promo.register.promotions.shipping_actions', before: :load_config_initializers do; end
 
       # Filter sensitive information during logging
       initializer "spree.params.filter", before: :load_config_initializers do |app|

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -1,3 +1,5 @@
+require 'spree/config'
+
 module Spree
   module Core
     class Engine < ::Rails::Engine
@@ -9,7 +11,7 @@ module Spree
       end
 
       initializer "spree.environment", before: :load_config_initializers do |app|
-        app.config.spree = Spree::Core::Environment.new
+        app.config.spree = Spree::Config.environment
       end
 
       initializer "spree.default_permissions", before: :load_config_initializers do |_app|

--- a/core/lib/spree/core/environment.rb
+++ b/core/lib/spree/core/environment.rb
@@ -1,4 +1,4 @@
-require 'spree/config'
+require 'spree/core/environment_extension'
 
 module Spree
   module Core
@@ -10,9 +10,9 @@ module Spree
 
       attr_accessor :calculators, :preferences, :promotions
 
-      def initialize
+      def initialize(spree_config)
         @calculators = Calculators.new
-        @preferences = Spree::Config
+        @preferences = spree_config
         @promotions = Spree::Promo::Environment.new
       end
     end

--- a/core/lib/spree/testing_support/preferences.rb
+++ b/core/lib/spree/testing_support/preferences.rb
@@ -11,6 +11,7 @@ module Spree
       def reset_spree_preferences(&config_block)
         Spree::Config.instance_variables.each { |iv| Spree::Config.remove_instance_variable(iv) }
         Spree::Config.preference_store = Spree::Config.default_preferences
+        Rails.application.config.spree = Spree::Config.environment
 
         configure_spree_preferences(&config_block) if block_given?
       end

--- a/core/spec/models/spree/app_configuration_spec.rb
+++ b/core/spec/models/spree/app_configuration_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Spree::AppConfiguration, type: :model do
-  let(:prefs) { Rails.application.config.spree.preferences }
+  let(:prefs) { Spree::Config }
 
   it "should be available from the environment" do
     prefs.layout = "my/layout"

--- a/core/spec/models/spree/promotion_handler/shipping_spec.rb
+++ b/core/spec/models/spree/promotion_handler/shipping_spec.rb
@@ -74,14 +74,9 @@ module Spree
         before do
           stub_const('CustomShippingAction', custom_klass)
 
-          @old_shipping_actions = Rails.application.config.spree.promotions.shipping_actions
-          Rails.application.config.spree.promotions.shipping_actions = ['CustomShippingAction']
+          Spree::Config.environment.promotions.shipping_actions = ['CustomShippingAction']
 
           order.order_promotions.create!(promotion: promotion, promotion_code: promotion.codes.first)
-        end
-
-        after do
-          Rails.application.config.spree.promotions.shipping_actions = @old_shipping_actions
         end
 
         let(:action) { custom_klass.new }


### PR DESCRIPTION
This PR makes the Spree::Core::Environment (previously only accessible through Rails.application.config.spree) available via the Spree::Config.

This makes configuring Solidus easier in a few ways:
- We no longer need to understand or rely on rails initializers (which are very confusing, even for long-time rails users)
- Providing access via Spree::Config.environment is clearer than telling people to set some things on config, and others on rails environment (see doc changes to simple_coordinator)
- The environment works more like the other preferences, and can be reset through reset_spree_preferences (no need to keep the "old" configs around)

I've left the initializers in in case applications or gems are still using them, and they should be able to continue using them as before, but I think we should think about deprecating them in the future.