### PR TITLE
Remove rspec-collection-matchers.

### DIFF
--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -26,7 +26,6 @@ group :test do
   gem 'factory_girl_rails', '~> 4.8'
   gem 'launchy'
   gem 'rspec-activemodel-mocks', '~>1.0.2'
-  gem 'rspec-collection_matchers'
   gem 'rspec-its'
   gem 'rspec-rails', '~> 3.5'
   gem 'simplecov'

--- a/core/spec/models/spree/credit_card_spec.rb
+++ b/core/spec/models/spree/credit_card_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Spree::CreditCard, type: :model do
 
     it "validates name presence" do
       credit_card.valid?
-      expect(credit_card.error_on(:name).size).to eq(1)
+      expect(credit_card.errors[:name].size).to eq(1)
     end
 
     it "should only validate on create" do

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe Spree::LineItem, type: :model do
 
       it "is a valid line item" do
         expect(line_item.valid?).to be_truthy
-        expect(line_item.error_on(:price).size).to eq(0)
+        expect(line_item.errors[:price].size).to eq(0)
       end
     end
 
@@ -166,7 +166,7 @@ RSpec.describe Spree::LineItem, type: :model do
 
       it "is not a valid line item" do
         expect(line_item.valid?).to be_falsey
-        expect(line_item.error_on(:price).size).to eq(1)
+        expect(line_item.errors[:price].size).to eq(1)
       end
     end
   end

--- a/core/spec/models/spree/order/callbacks_spec.rb
+++ b/core/spec/models/spree/order/callbacks_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Spree::Order, type: :model do
       it "o'brien@gmail.com is a valid email address" do
         order.state = 'address'
         order.email = "o'brien@gmail.com"
-        expect(order.error_on(:email).size).to eq(0)
+        expect(order.errors[:email].size).to eq(0)
       end
     end
   end
@@ -36,7 +36,7 @@ RSpec.describe Spree::Order, type: :model do
     it "should not validate email address" do
       order.state = "cart"
       order.email = nil
-      expect(order.error_on(:email).size).to eq(0)
+      expect(order.errors[:email].size).to eq(0)
     end
   end
 end

--- a/core/spec/models/spree/payment_create_spec.rb
+++ b/core/spec/models/spree/payment_create_spec.rb
@@ -62,8 +62,8 @@ module Spree
           expect(new_payment).not_to be_persisted
           expect(new_payment.source).not_to be_persisted
           expect(new_payment.source).not_to be_valid
-          expect(new_payment.source.error_on(:number)).to be_present
-          expect(new_payment.source.error_on(:verification_value).size).to be_present
+          expect(new_payment.source.errors[:number]).to be_present
+          expect(new_payment.source.errors[:verification_value].size).to be_present
         end
       end
     end

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -872,8 +872,8 @@ RSpec.describe Spree::Payment, type: :model do
         payment = Spree::PaymentCreate.new(order, params).build
         expect(payment).not_to be_valid
         expect(payment.source).not_to be_nil
-        expect(payment.source.error_on(:number).size).to eq(1)
-        expect(payment.source.error_on(:verification_value).size).to eq(1)
+        expect(payment.source.errors[:number].size).to eq(1)
+        expect(payment.source.errors[:verification_value].size).to eq(1)
       end
     end
 

--- a/core/spec/models/spree/price_spec.rb
+++ b/core/spec/models/spree/price_spec.rb
@@ -20,8 +20,9 @@ RSpec.describe Spree::Price, type: :model do
     context 'when the amount is less than 0' do
       let(:amount) { -1 }
 
-      it 'has 1 error_on' do
-        expect(subject.error_on(:amount).size).to eq(1)
+      it 'has 1 error on amount' do
+        subject.valid?
+        expect(subject.errors[:amount].size).to eq(1)
       end
       it 'populates errors' do
         subject.valid?
@@ -32,8 +33,9 @@ RSpec.describe Spree::Price, type: :model do
     context 'when the amount is greater than maximum amount' do
       let(:amount) { Spree::Price::MAXIMUM_AMOUNT + 1 }
 
-      it 'has 1 error_on' do
-        expect(subject.error_on(:amount).size).to eq(1)
+      it 'has 1 error on amount' do
+        subject.valid?
+        expect(subject.errors[:amount].size).to eq(1)
       end
       it 'populates errors' do
         subject.valid?

--- a/core/spec/models/spree/shipping_method_spec.rb
+++ b/core/spec/models/spree/shipping_method_spec.rb
@@ -22,17 +22,21 @@ RSpec.describe Spree::ShippingMethod, type: :model do
     before { subject.valid? }
 
     it "validates presence of name" do
-      expect(subject.error_on(:name).size).to eq(1)
+      expect(subject.errors[:name].size).to eq(1)
     end
 
     context "shipping category" do
       it "validates presence of at least one" do
-        expect(subject.error_on(:base).size).to eq(1)
+        expect(subject.errors[:base].size).to eq(1)
       end
 
       context "one associated" do
-        before { subject.shipping_categories.push create(:shipping_category) }
-        it { expect(subject.error_on(:base).size).to eq(0) }
+        before do
+          subject.shipping_categories.push create(:shipping_category)
+          subject.valid?
+        end
+
+        it { expect(subject.errors[:base].size).to eq(0) }
       end
     end
   end

--- a/core/spec/models/spree/stock_item_spec.rb
+++ b/core/spec/models/spree/stock_item_spec.rb
@@ -293,14 +293,14 @@ RSpec.describe Spree::StockItem, type: :model do
       shared_examples_for 'valid count_on_hand' do
         it 'has :no errors_on' do
           expect(subject).to be_valid
-          expect(subject.errors_on(:count_on_hand).size).to eq(0)
+          expect(subject.errors[:count_on_hand].size).to eq(0)
         end
       end
 
       shared_examples_for 'invalid count_on_hand' do
         it 'has the correct error on count_on_hand' do
           expect(subject).not_to be_valid
-          expect(subject.error_on(:count_on_hand).size).to eq(1)
+          expect(subject.errors[:count_on_hand].size).to eq(1)
           expect(subject.errors[:count_on_hand]).to include('must be greater than or equal to 0')
         end
       end


### PR DESCRIPTION
The only functionality we were using from it was error_on, which can be
just as easily replaced with slightly different syntax.