### PR TITLE
fix changelog for update_params_payment_source method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,7 +151,6 @@
 - Remove identical inheritied methods in `Spree::StoreCredit` [#2200](https://github.com/solidusio/solidus/pull/2200) ([swcraig](https://github.com/swcraig))
 - Remove custom responders. They are now available in the `solidus_responders` extension. [#1956](https://github.com/solidusio/solidus/pull/1956) ([omnistegan](https://github.com/omnistegan))
 - Remove responders dependency from core [#2090](https://github.com/solidusio/solidus/pull/2090) ([cbrunsdon](https://github.com/cbrunsdon))
-- Remove unused update_params_payment_source method [#2227](https://github.com/solidusio/solidus/pull/2227) ([ccarruitero](https://github.com/ccarruitero))
 
 ### Deprecations
 
@@ -165,6 +164,7 @@
   Please render `spree/admin/shared/preference_fields/#{preference_type}` instead
 - Check if deprecated method_type is overridden [#2093](https://github.com/solidusio/solidus/pull/2093) ([jhawthorn](https://github.com/jhawthorn))
 - Deprecate support for alternate Kaminari page_method_name [#2115](https://github.com/solidusio/solidus/pull/2115) ([cbrunsdon](https://github.com/cbrunsdon))
+- Deprecate update_params_payment_source method [#2227](https://github.com/solidusio/solidus/pull/2227) ([ccarruitero](https://github.com/ccarruitero))
 
 
 


### PR DESCRIPTION
`update_params_payment_source` method is just [deprecated](https://github.com/solidusio/solidus/blob/master/core/app/models/spree/order.rb#L797) right now.

When I stated #2227 I was planing to remove the method. Then after discussion we decide to deprecate first and remove later, but I forgot to update the pull request title. Sorry for the confusion.