### PR TITLE
remove unused methods in stock_transfers_controller

### DIFF
--- a/backend/app/controllers/spree/admin/stock_transfers_controller.rb
+++ b/backend/app/controllers/spree/admin/stock_transfers_controller.rb
@@ -129,18 +129,6 @@ module Spree
         authorize! :read, Spree::StockLocation.find(permitted_resource_params[:source_location_id])
       end
 
-      def source_location
-        @source_location ||= if params.key?(:transfer_receive_stock)
-                               nil
-                             else
-                               Spree::StockLocation.find(params[:transfer_source_location_id])
-                             end
-      end
-
-      def destination_location
-        @destination_location ||= Spree::StockLocation.find(params[:transfer_destination_location_id])
-      end
-
       def adjust_inventory
         @stock_movements = @stock_transfer.transfer_items.received.map do |transfer_item|
           @stock_transfer.destination_location.move(transfer_item.variant, transfer_item.received_quantity, @stock_transfer)


### PR DESCRIPTION
`source_location` and `destination_location` methods in `stocks_transfers_controller` seems to be unused.

Judging for the parameters that use, I think was used for the old stock transfers views but not anymore.