### PR TITLE
Remove rspec-its

### DIFF
--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -26,7 +26,6 @@ group :test do
   gem 'factory_girl_rails', '~> 4.8'
   gem 'launchy'
   gem 'rspec-activemodel-mocks', '~>1.0.2'
-  gem 'rspec-its'
   gem 'rspec-rails', '~> 3.6.0'
   gem 'simplecov'
   gem 'poltergeist', '~> 1.9'


### PR DESCRIPTION
![](http://i.hawth.ca/u/its.jpg)

We haven't needed rspec-its since [`transpec`](https://github.com/yujinakayama/transpec) (the greatest thing ever) removed them all for us in #226