### PR TITLE
Restrict rspec-rails to ~> 3.6.0

### DIFF
--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -27,7 +27,7 @@ group :test do
   gem 'launchy'
   gem 'rspec-activemodel-mocks', '~>1.0.2'
   gem 'rspec-its'
-  gem 'rspec-rails', '~> 3.5'
+  gem 'rspec-rails', '~> 3.6.0'
   gem 'simplecov'
   gem 'poltergeist', '~> 1.9'
   gem 'timecop'


### PR DESCRIPTION
rspec-rails 3.7.0 attempts to require puma, which will fail.