### PR TITLE
Remove assert usage in checkout_spec

### DIFF
--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Spree::Order, type: :model do
 
   def assert_state_changed(order, from, to)
     state_change_exists = order.state_changes.where(previous_state: from, next_state: to).exists?
-    assert state_change_exists, "Expected order to transition from #{from} to #{to}, but didn't."
+    expect(state_change_exists).to be(true), "Expected order to transition from #{from} to #{to}, but didn't."
   end
 
   context "with default state machine" do


### PR DESCRIPTION
This isn't an rspec feature, it was provided through rspec/rails weird
bridge layer to test/unit, and its easy to re-write to rspec.