### PR TITLE
Generate js_locale_data using JSON.dump

### DIFF
--- a/backend/app/views/spree/admin/shared/_js_locale_data.html.erb
+++ b/backend/app/views/spree/admin/shared/_js_locale_data.html.erb
@@ -3,40 +3,42 @@
     var Spree = {}
   }
   Spree.translations = <%==
-    I18n.t("spree").merge({
-      date_picker:    Spree.t(:js_format,
-                               scope: 'date_picker',
-                               default: 'yy/mm/dd'),
-      abbr_day_names:         I18n.t(:abbr_day_names, scope: :date),
-      destroy:                Spree.t(:destroy, scope: :actions),
-      edit:                   Spree.t(:edit,    scope: :actions),
-      save:                   Spree.t(:save,    scope: :actions),
-      cancel:                 Spree.t(:cancel,  scope: :actions),
-      first_day:              Spree.t(:first_day,
-                                       scope: 'date_picker',
-                                       default: 0).to_i,
-      item_stock_placeholder: Spree.t(:choose_location),
-      month_names:            I18n.t(:month_names, scope: :date).reject(&:blank?),
-      currency_separator:     I18n.t('number.currency.format.separator'),
-      currency_delimiter:     I18n.t('number.currency.format.delimiter'),
-      activerecord:           I18n.t('activerecord')
-  }).to_json
+    JSON.dump(
+      I18n.t("spree").merge({
+        date_picker:    Spree.t(:js_format,
+                                 scope: 'date_picker',
+                                 default: 'yy/mm/dd'),
+        abbr_day_names:         I18n.t(:abbr_day_names, scope: :date),
+        destroy:                Spree.t(:destroy, scope: :actions),
+        edit:                   Spree.t(:edit,    scope: :actions),
+        save:                   Spree.t(:save,    scope: :actions),
+        cancel:                 Spree.t(:cancel,  scope: :actions),
+        first_day:              Spree.t(:first_day,
+                                         scope: 'date_picker',
+                                         default: 0).to_i,
+        item_stock_placeholder: Spree.t(:choose_location),
+        month_names:            I18n.t(:month_names, scope: :date).reject(&:blank?),
+        currency_separator:     I18n.t('number.currency.format.separator'),
+        currency_delimiter:     I18n.t('number.currency.format.delimiter'),
+        activerecord:           I18n.t('activerecord')
+    }))
 %>;
 
   Spree.currencyInfo = <%==
-    Money::Currency.all.map { |c|
-      format =
-        if c.symbol == "" || c.symbol_first
-          "%s%v"
-        else
-          "%v %s"
-        end
-      [c.id.to_s.upcase, [
-        c.symbol || "¤",
-        c.exponent,
-        format
-      ]]
-    }.to_h.to_json
+    JSON.dump(
+      Money::Currency.all.map { |c|
+        format =
+          if c.symbol == "" || c.symbol_first
+            "%s%v"
+          else
+            "%v %s"
+          end
+        [c.id.to_s.upcase, [
+          c.symbol || "¤",
+          c.exponent,
+          format
+        ]]
+    }.to_h)
 %>;
 </script>
 <script data-hook='admin-custom-translations'>


### PR DESCRIPTION
We generate some fairly large JSON here, and Rails's `to_json` is a fair bit slower than plain `JSON.generate` due to smart handling of ActiveRecord and other objects (which we are guaranteed not to have in translation data).

```
               I18n.t()  177.064k (± 4.5%) i/s
       I18n.t().to_json  155.028  (± 1.3%) i/s
JSON.generate(I18n.t())    1.045k (± 1.1%) i/s
```

So using `JSON.generate` is ~5x faster faster than using `to_json`.

It would be even faster to use [Oj](https://github.com/ohler55/oj) if available, but it's unfortunately not as easy as just using multi_json, which will call rails' to_json if Oj isn't available :disappointed:.

```
            I18n.t()               188.690k (± 1.3%) i/s
    I18n.t().to_json               165.058  (± 0.6%) i/s
JSON.generate(I18n.t())              1.149k (± 0.7%) i/s
   Oj.dump(I18n.t())                 4.417k (± 9.4%) i/s
MultiJson.dump(I18n.t()) w/ JSON   150.526  (± 1.3%) i/s
MultiJson.dump(I18n.t()) w/ Oj       4.253k (± 6.4%) i/s
```