### PR TITLE
Deprecate class method in `Calculator::FlexiRate`

### DIFF
--- a/core/app/models/spree/calculator/flexi_rate.rb
+++ b/core/app/models/spree/calculator/flexi_rate.rb
@@ -8,6 +8,7 @@ module Spree
     preference :currency,        :string,  default: ->{ Spree::Config[:currency] }
 
     def self.available?(_object)
+      Spree::Deprecation.warn('Spree::Calculator::FlexiRate::available is DEPRECATED. Use the instance method instead.')
       true
     end
 


### PR DESCRIPTION
This class method is not used anywhere in the code base. As a
calculator, the `available?` method should in general be an instance
method (which defaults to `true` from the inherited base calculator class).

I can't go back far enough in the history of the source code to find out
why this method was added in the first place.