### PR TITLE
Improve ShippingRate#display_price with taxes

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -7,7 +7,7 @@ module Spree
 
     has_many :adjustments, as: :adjustable, inverse_of: :adjustable, dependent: :delete_all
     has_many :inventory_units, dependent: :destroy, inverse_of: :shipment
-    has_many :shipping_rates, -> { order(:cost) }, dependent: :destroy
+    has_many :shipping_rates, -> { order(:cost) }, dependent: :destroy, inverse_of: :shipment
     has_many :shipping_methods, through: :shipping_rates
     has_many :state_changes, as: :stateful
     has_many :cartons, -> { uniq }, through: :inventory_units

--- a/core/app/models/spree/shipping_rate.rb
+++ b/core/app/models/spree/shipping_rate.rb
@@ -26,7 +26,7 @@ module Spree
     def display_price
       price = display_amount.to_s
 
-      return price if taxes.empty? || amount == 0
+      return price if taxes.to_a.empty? || amount == 0
 
       tax_explanations = taxes.map(&:label).join(tax_label_separator)
 

--- a/core/app/models/spree/shipping_rate.rb
+++ b/core/app/models/spree/shipping_rate.rb
@@ -9,6 +9,7 @@ module Spree
     has_many :taxes,
              class_name: "Spree::ShippingRateTax",
              foreign_key: "shipping_rate_id",
+             inverse_of: :shipping_rate,
              dependent: :destroy
 
     delegate :order, :currency, to: :shipment


### PR DESCRIPTION
This removes about 4 unnecessary queries when calling `ShippingRate#display_price`.

Previously, the `shipment->shipping_rates` and `shipping_rate->taxes` associations were missing inverse of, causing `ShippingRateTax#label` to re-query the shipping_rate, shipment, and order.

The `shipping_rate->taxes` association was also queried twice in `#display_price`, once to determine if there are any taxes, and a second time to determine their labels.