### PR TITLE
Remove versioncake

### DIFF
--- a/api/lib/spree/api/engine.rb
+++ b/api/lib/spree/api/engine.rb
@@ -9,16 +9,6 @@ module Spree
       initializer "spree.api.environment", before: :load_config_initializers do |_app|
         Spree::Api::Config = Spree::ApiConfiguration.new
       end
-
-      initializer "spree.api.versioncake" do |_app|
-        VersionCake.setup do |config|
-          config.resources do |r|
-            r.resource %r{.*}, [], [], [1]
-          end
-          config.missing_version = 1
-          config.extraction_strategy = :http_header
-        end
-      end
     end
   end
 end

--- a/api/lib/spree_api.rb
+++ b/api/lib/spree_api.rb
@@ -1,4 +1,3 @@
 require 'spree/api'
 require 'spree/api/responders'
-require 'versioncake'
 require 'jbuilder'

--- a/api/solidus_api.gemspec
+++ b/api/solidus_api.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |gem|
   gem.required_rubygems_version = '>= 1.8.23'
 
   gem.add_dependency 'solidus_core', gem.version
-  gem.add_dependency 'versioncake', '~> 3.0'
   gem.add_dependency 'responders'
   gem.add_dependency 'jbuilder', '~> 2.6'
   gem.add_dependency 'kaminari', '>= 0.17', '< 2.0'

--- a/api/spec/spec_helper.rb
+++ b/api/spec/spec_helper.rb
@@ -67,10 +67,6 @@ RSpec.configure do |config|
   end
 
   config.include ActiveJob::TestHelper
-  config.include VersionCake::TestHelpers, type: :controller
-  config.before(:each, type: :controller) do
-    set_request_version('', 1)
-  end
 
   config.use_transactional_fixtures = true
 


### PR DESCRIPTION
We stopped using versioncake (which we were never really using) since the replacement of RABL with JBuilder. We should remove the dependency entirely.