### PR TITLE
Add frontend login_bar_items placeholder partial

### DIFF
--- a/frontend/app/views/spree/shared/_login_bar_items.html.erb
+++ b/frontend/app/views/spree/shared/_login_bar_items.html.erb
@@ -1,0 +1,1 @@
+<%# solidus_auth_devise or a custom auth system can replace this partial %>

--- a/frontend/app/views/spree/shared/_nav_bar.html.erb
+++ b/frontend/app/views/spree/shared/_nav_bar.html.erb
@@ -1,5 +1,6 @@
 <nav id="top-nav-bar" class="columns ten">
   <ul id="nav-bar" class="inline" data-hook>
+    <%= render 'spree/shared/login_bar_items' %>
     <li id="search-bar" data-hook>
       <%= render partial: 'spree/shared/search' %>
     </li>


### PR DESCRIPTION
Similar to the overridable `admin/shared/_navigation_footer` this will allow `solidus_auth_devise` to override the partial without requiring deface.