### PR TITLE
Require only part of activemerchant

### DIFF
--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -1,5 +1,4 @@
 require 'rails/all'
-require 'active_merchant'
 require 'acts_as_list'
 require 'awesome_nested_set'
 require 'cancan'
@@ -53,6 +52,7 @@ end
 
 require 'spree/core/version'
 
+require 'spree/core/active_merchant_dependencies'
 require 'spree/core/class_constantizer'
 require 'spree/core/environment_extension'
 require 'spree/core/environment/calculators'

--- a/core/lib/spree/core/active_merchant_dependencies.rb
+++ b/core/lib/spree/core/active_merchant_dependencies.rb
@@ -1,0 +1,11 @@
+require 'active_merchant/errors'
+
+require 'active_merchant/billing/base'
+
+require 'active_merchant/billing/avs_result'
+require 'active_merchant/billing/cvv_result'
+require 'active_merchant/billing/response'
+
+require 'active_merchant/billing/credit_card_methods'
+require 'active_merchant/billing/credit_card_formatting'
+require 'active_merchant/billing/credit_card'

--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
     s.add_dependency rails_dep, '~> 5.1.0'
   end
 
-  s.add_dependency 'activemerchant', '~> 1.48'
+  s.add_dependency 'activemerchant', '~> 1.66'
   s.add_dependency 'acts_as_list', '~> 0.3'
   s.add_dependency 'awesome_nested_set', '~> 3.0', '>= 3.0.1'
   s.add_dependency 'carmen', '~> 1.0.0'


### PR DESCRIPTION
ActiveMerchant is 2.5 megs of glue code that we don't need. This PR only requires those files of ActiveMerchant that we do need: Errors, Billing Response and Credit Card. 

It also bumps the required ActiveMerchant Version to 1.66, as that is the first version that works with Rails 5.1.