### PR TITLE
Fix module/class nesting in calculator/*

### DIFF
--- a/core/app/models/spree/calculator/free_shipping.rb
+++ b/core/app/models/spree/calculator/free_shipping.rb
@@ -1,3 +1,5 @@
+require_dependency 'spree/calculator'
+
 module Spree
   # @deprecated This calculator will be removed in future versions of Spree.
   #   The only case where it was used was for Free Shipping Promotions.  There is

--- a/core/app/models/spree/calculator/percent_on_line_item.rb
+++ b/core/app/models/spree/calculator/percent_on_line_item.rb
@@ -1,3 +1,5 @@
+require_dependency 'spree/calculator'
+
 module Spree
   class Calculator
     class PercentOnLineItem < Calculator

--- a/core/app/models/spree/calculator/percent_per_item.rb
+++ b/core/app/models/spree/calculator/percent_per_item.rb
@@ -1,3 +1,5 @@
+require_dependency 'spree/calculator'
+
 module Spree
   # A calculator for promotions that calculates a percent-off discount
   # for all matching products in an order. This should not be used as a

--- a/core/app/models/spree/calculator/returns/default_refund_amount.rb
+++ b/core/app/models/spree/calculator/returns/default_refund_amount.rb
@@ -1,3 +1,4 @@
+require_dependency 'spree/calculator'
 require_dependency 'spree/returns_calculator'
 
 module Spree

--- a/core/app/models/spree/calculator/shipping/flat_percent_item_total.rb
+++ b/core/app/models/spree/calculator/shipping/flat_percent_item_total.rb
@@ -1,3 +1,4 @@
+require_dependency 'spree/calculator'
 require_dependency 'spree/shipping_calculator'
 
 module Spree

--- a/core/app/models/spree/calculator/shipping/flat_rate.rb
+++ b/core/app/models/spree/calculator/shipping/flat_rate.rb
@@ -1,3 +1,4 @@
+require_dependency 'spree/calculator'
 require_dependency 'spree/shipping_calculator'
 
 module Spree

--- a/core/app/models/spree/calculator/shipping/flexi_rate.rb
+++ b/core/app/models/spree/calculator/shipping/flexi_rate.rb
@@ -1,3 +1,4 @@
+require_dependency 'spree/calculator'
 require_dependency 'spree/shipping_calculator'
 
 module Spree

--- a/core/app/models/spree/calculator/shipping/per_item.rb
+++ b/core/app/models/spree/calculator/shipping/per_item.rb
@@ -1,3 +1,4 @@
+require_dependency 'spree/calculator'
 require_dependency 'spree/shipping_calculator'
 
 module Spree

--- a/core/app/models/spree/calculator/shipping/price_sack.rb
+++ b/core/app/models/spree/calculator/shipping/price_sack.rb
@@ -1,3 +1,4 @@
+require_dependency 'spree/calculator'
 require_dependency 'spree/shipping_calculator'
 
 module Spree

--- a/core/spec/models/spree/calculator/percent_per_item_spec.rb
+++ b/core/spec/models/spree/calculator/percent_per_item_spec.rb
@@ -1,3 +1,5 @@
+require_dependency 'spree/calculator'
+
 require 'rails_helper'
 require 'shared_examples/calculator_shared_examples'
 


### PR DESCRIPTION
Spree::Calculator is a class (that inherits from Spree::Base), but in
these definitions we don't clarify it as such.