### PR TITLE
Disable Style/NumericPredicate cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -41,6 +41,9 @@ Style/GuardClause:
 Style/Next:
   Enabled: false
 
+Style/NumericPredicate:
+  Enabled: false
+
 Style/WordArray:
   Enabled: false
 


### PR DESCRIPTION
We do not want to force anyone to write

```
something.zero?
```

over

```
something == 0
```