### PR TITLE
Follow FactoryBot rename

### DIFF
--- a/api/spec/features/checkout_spec.rb
+++ b/api/spec/features/checkout_spec.rb
@@ -3,16 +3,16 @@ require 'spec_helper'
 module Spree
   describe 'Api Feature Specs', type: :request do
     before { Spree::Api::Config[:requires_authentication] = false }
-    let!(:promotion) { FactoryGirl.create(:promotion, :with_order_adjustment, code: 'foo', weighted_order_adjustment_amount: 10) }
+    let!(:promotion) { FactoryBot.create(:promotion, :with_order_adjustment, code: 'foo', weighted_order_adjustment_amount: 10) }
     let(:promotion_code) { promotion.codes.first }
-    let!(:store) { FactoryGirl.create(:store) }
-    let(:bill_address) { FactoryGirl.create(:address) }
-    let(:ship_address) { FactoryGirl.create(:address) }
-    let(:variant_1) { FactoryGirl.create(:variant, price: 100.00) }
-    let(:variant_2) { FactoryGirl.create(:variant, price: 200.00) }
-    let(:payment_method) { FactoryGirl.create(:check_payment_method) }
+    let!(:store) { FactoryBot.create(:store) }
+    let(:bill_address) { FactoryBot.create(:address) }
+    let(:ship_address) { FactoryBot.create(:address) }
+    let(:variant_1) { FactoryBot.create(:variant, price: 100.00) }
+    let(:variant_2) { FactoryBot.create(:variant, price: 200.00) }
+    let(:payment_method) { FactoryBot.create(:check_payment_method) }
     let!(:shipping_method) do
-      FactoryGirl.create(:shipping_method).tap do |shipping_method|
+      FactoryBot.create(:shipping_method).tap do |shipping_method|
         shipping_method.zones.first.zone_members.create!(zoneable: ship_address.country)
         shipping_method.calculator.set_preference(:amount, 10.0)
       end

--- a/api/spec/requests/spree/api/orders_controller_spec.rb
+++ b/api/spec/requests/spree/api/orders_controller_spec.rb
@@ -219,7 +219,7 @@ module Spree
 
     describe 'GET #show' do
       let(:order) { create :order_with_line_items }
-      let(:adjustment) { FactoryGirl.create(:adjustment, adjustable: order, order: order) }
+      let(:adjustment) { FactoryBot.create(:adjustment, adjustable: order, order: order) }
 
       subject { get spree.api_order_path(order) }
 
@@ -569,7 +569,7 @@ module Spree
 
         context "when in delivery" do
           let!(:shipping_method) do
-            FactoryGirl.create(:shipping_method).tap do |shipping_method|
+            FactoryBot.create(:shipping_method).tap do |shipping_method|
               shipping_method.calculator.preferred_amount = 10
               shipping_method.calculator.save
             end

--- a/api/spec/requests/spree/api/return_authorizations_controller_spec.rb
+++ b/api/spec/requests/spree/api/return_authorizations_controller_spec.rb
@@ -14,8 +14,8 @@ module Spree
 
     shared_examples_for 'a return authorization creator' do
       it "can create a new return authorization" do
-        stock_location = FactoryGirl.create(:stock_location)
-        reason = FactoryGirl.create(:return_reason)
+        stock_location = FactoryBot.create(:stock_location)
+        reason = FactoryBot.create(:return_reason)
         rma_params = { stock_location_id: stock_location.id,
                        return_reason_id: reason.id,
                        memo: "Defective" }
@@ -74,7 +74,7 @@ module Spree
       sign_in_as_admin!
 
       it "can show return authorization" do
-        FactoryGirl.create(:return_authorization, order: order)
+        FactoryBot.create(:return_authorization, order: order)
         return_authorization = order.return_authorizations.first
         get spree.api_order_return_authorization_path(order, return_authorization.id)
         expect(response.status).to eq(200)
@@ -83,8 +83,8 @@ module Spree
       end
 
       it "can get a list of return authorizations" do
-        FactoryGirl.create(:return_authorization, order: order)
-        FactoryGirl.create(:return_authorization, order: order)
+        FactoryBot.create(:return_authorization, order: order)
+        FactoryBot.create(:return_authorization, order: order)
         get spree.api_order_return_authorizations_path(order), params: { order_id: order.number }
         expect(response.status).to eq(200)
         return_authorizations = json_response["return_authorizations"]
@@ -93,8 +93,8 @@ module Spree
       end
 
       it 'can control the page size through a parameter' do
-        FactoryGirl.create(:return_authorization, order: order)
-        FactoryGirl.create(:return_authorization, order: order)
+        FactoryBot.create(:return_authorization, order: order)
+        FactoryBot.create(:return_authorization, order: order)
         get spree.api_order_return_authorizations_path(order), params: { order_id: order.number, per_page: 1 }
         expect(json_response['count']).to eq(1)
         expect(json_response['current_page']).to eq(1)
@@ -102,7 +102,7 @@ module Spree
       end
 
       it 'can query the results through a paramter' do
-        FactoryGirl.create(:return_authorization, order: order)
+        FactoryBot.create(:return_authorization, order: order)
         expected_result = create(:return_authorization, memo: 'damaged')
         order.return_authorizations << expected_result
         get spree.api_order_return_authorizations_path(order), params: { q: { memo_cont: 'damaged' } }
@@ -118,7 +118,7 @@ module Spree
       end
 
       it "can update a return authorization on the order" do
-        FactoryGirl.create(:return_authorization, order: order)
+        FactoryBot.create(:return_authorization, order: order)
         return_authorization = order.return_authorizations.first
         put spree.api_order_return_authorization_path(order, return_authorization.id), params: { return_authorization: { memo: "ABC" } }
         expect(response.status).to eq(200)
@@ -126,7 +126,7 @@ module Spree
       end
 
       it "can cancel a return authorization on the order" do
-        FactoryGirl.create(:new_return_authorization, order: order)
+        FactoryBot.create(:new_return_authorization, order: order)
         return_authorization = order.return_authorizations.first
         expect(return_authorization.state).to eq("authorized")
         put spree.cancel_api_order_return_authorization_path(order, return_authorization.id)
@@ -135,7 +135,7 @@ module Spree
       end
 
       it "can delete a return authorization on the order" do
-        FactoryGirl.create(:return_authorization, order: order)
+        FactoryBot.create(:return_authorization, order: order)
         return_authorization = order.return_authorizations.first
         delete spree.api_order_return_authorization_path(order, return_authorization.id)
         expect(response.status).to eq(204)
@@ -152,7 +152,7 @@ module Spree
       end
 
       it "cannot update a return authorization on the order" do
-        FactoryGirl.create(:return_authorization, order: order)
+        FactoryBot.create(:return_authorization, order: order)
         return_authorization = order.return_authorizations.first
         put spree.api_order_return_authorization_path(order, return_authorization.id), params: { return_authorization: { memo: "ABC" } }
         assert_unauthorized!
@@ -160,7 +160,7 @@ module Spree
       end
 
       it "cannot delete a return authorization on the order" do
-        FactoryGirl.create(:return_authorization, order: order)
+        FactoryBot.create(:return_authorization, order: order)
         return_authorization = order.return_authorizations.first
         delete spree.api_order_return_authorization_path(order, return_authorization.id)
         assert_unauthorized!

--- a/api/spec/spec_helper.rb
+++ b/api/spec/spec_helper.rb
@@ -49,7 +49,7 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
 
-  config.include FactoryGirl::Syntax::Methods
+  config.include FactoryBot::Syntax::Methods
   config.include Spree::Api::TestingSupport::Helpers, type: :request
   config.extend Spree::Api::TestingSupport::Setup, type: :request
   config.include Spree::Api::TestingSupport::Helpers, type: :controller

--- a/backend/spec/controllers/spree/admin/stock_locations_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/stock_locations_controller_spec.rb
@@ -29,7 +29,7 @@ module Spree
 
       context "with a country with the ISO code of 'US' existing" do
         before do
-          FactoryGirl.create(:country, iso: 'US')
+          FactoryBot.create(:country, iso: 'US')
         end
 
         it "can create a new stock location" do

--- a/backend/spec/features/admin/orders/listing_spec.rb
+++ b/backend/spec/features/admin/orders/listing_spec.rb
@@ -61,11 +61,11 @@ describe "Orders Listing", type: :feature, js: true do
 
   context "searching orders" do
     context "when there are multiple stores" do
-      let(:stores) { FactoryGirl.create_pair(:store) }
+      let(:stores) { FactoryBot.create_pair(:store) }
 
       before do
         stores.each do |store|
-          FactoryGirl.create(:completed_order_with_totals, number: "R#{store.id}999", store: store)
+          FactoryBot.create(:completed_order_with_totals, number: "R#{store.id}999", store: store)
         end
       end
 

--- a/backend/spec/features/admin/payments/store_credits_spec.rb
+++ b/backend/spec/features/admin/payments/store_credits_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 RSpec.describe 'Store credits', type: :feature do
   stub_authorization!
 
-  let(:order) { FactoryGirl.create(:completed_order_with_totals) }
+  let(:order) { FactoryBot.create(:completed_order_with_totals) }
   let(:payment) do
-    FactoryGirl.create(
+    FactoryBot.create(
       :store_credit_payment,
       order: order,
       amount: 20

--- a/backend/spec/features/admin/products/products_spec.rb
+++ b/backend/spec/features/admin/products/products_spec.rb
@@ -10,7 +10,7 @@ describe "Products", type: :feature do
     end
 
     def build_option_type_with_values(name, values)
-      ot = FactoryGirl.create(:option_type, name: name)
+      ot = FactoryBot.create(:option_type, name: name)
       values.each do |val|
         ot.option_values.create(name: val.downcase, presentation: val)
       end

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -129,7 +129,7 @@ RSpec.configure do |config|
     end
   end
 
-  config.include FactoryGirl::Syntax::Methods
+  config.include FactoryBot::Syntax::Methods
 
   config.include Spree::TestingSupport::Preferences
   config.include Spree::TestingSupport::UrlHelpers

--- a/backend/spec/views/spree/admin/shared/navigation_footer_spec.rb
+++ b/backend/spec/views/spree/admin/shared/navigation_footer_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe "spree/admin/shared/_navigation_footer", type: :view do
-  let(:user) { FactoryGirl.build_stubbed(:admin_user) }
+  let(:user) { FactoryBot.build_stubbed(:admin_user) }
   before do
     allow(view).to receive(:try_spree_current_user).and_return(user)
   end

--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -23,7 +23,7 @@ group :test do
   gem 'capybara-screenshot'
   gem 'database_cleaner', '~> 1.3'
   gem 'email_spec'
-  gem 'factory_girl_rails', '~> 4.8'
+  gem 'factory_bot_rails', '~> 4.8'
   gem 'launchy'
   gem 'rspec-activemodel-mocks', '~>1.0.2'
   gem 'rspec-rails', '~> 3.6.0'

--- a/core/lib/spree/testing_support/factories.rb
+++ b/core/lib/spree/testing_support/factories.rb
@@ -1,4 +1,4 @@
-require 'factory_girl'
+require 'factory_bot'
 
 Dir["#{File.dirname(__FILE__)}/factories/**"].each do |f|
   require File.expand_path(f)

--- a/core/lib/spree/testing_support/factories/address_factory.rb
+++ b/core/lib/spree/testing_support/factories/address_factory.rb
@@ -1,7 +1,7 @@
 require 'spree/testing_support/factories/state_factory'
 require 'spree/testing_support/factories/country_factory'
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :address, class: 'Spree::Address' do
     transient do
       # There's `Spree::Address#country_iso=`, prohibiting me from using `country_iso` here

--- a/core/lib/spree/testing_support/factories/adjustment_factory.rb
+++ b/core/lib/spree/testing_support/factories/adjustment_factory.rb
@@ -4,7 +4,7 @@ require 'spree/testing_support/factories/tax_category_factory'
 require 'spree/testing_support/factories/tax_rate_factory'
 require 'spree/testing_support/factories/zone_factory'
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :adjustment, class: 'Spree::Adjustment' do
     order
     adjustable { order }

--- a/core/lib/spree/testing_support/factories/adjustment_reason_factory.rb
+++ b/core/lib/spree/testing_support/factories/adjustment_reason_factory.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :adjustment_reason, class: 'Spree::AdjustmentReason' do
     sequence(:name) { |n| "Refund for return ##{n}" }
     sequence(:code) { |n| "Code #{n}" }

--- a/core/lib/spree/testing_support/factories/calculator_factory.rb
+++ b/core/lib/spree/testing_support/factories/calculator_factory.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :calculator, aliases: [:flat_rate_calculator], class: 'Spree::Calculator::FlatRate' do
     preferred_amount 10.0
   end

--- a/core/lib/spree/testing_support/factories/carton_factory.rb
+++ b/core/lib/spree/testing_support/factories/carton_factory.rb
@@ -1,7 +1,7 @@
 require 'spree/testing_support/factories/shipment_factory'
 require 'spree/testing_support/factories/inventory_unit_factory'
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :carton, class: 'Spree::Carton' do
     address
     stock_location

--- a/core/lib/spree/testing_support/factories/country_factory.rb
+++ b/core/lib/spree/testing_support/factories/country_factory.rb
@@ -1,6 +1,6 @@
 require 'carmen'
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :country, class: 'Spree::Country' do
     iso 'US'
 

--- a/core/lib/spree/testing_support/factories/credit_card_factory.rb
+++ b/core/lib/spree/testing_support/factories/credit_card_factory.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :credit_card, class: 'Spree::CreditCard' do
     verification_value 123
     month 12

--- a/core/lib/spree/testing_support/factories/customer_return_factory.rb
+++ b/core/lib/spree/testing_support/factories/customer_return_factory.rb
@@ -2,7 +2,7 @@ require 'spree/testing_support/factories/stock_location_factory'
 require 'spree/testing_support/factories/order_factory'
 require 'spree/testing_support/factories/return_item_factory'
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :customer_return, class: 'Spree::CustomerReturn' do
     association(:stock_location, factory: :stock_location)
 

--- a/core/lib/spree/testing_support/factories/image_factory.rb
+++ b/core/lib/spree/testing_support/factories/image_factory.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :image, class: 'Spree::Image' do
     attachment { File.new(Spree::Core::Engine.root + 'spec/fixtures/thinking-cat.jpg') }
   end

--- a/core/lib/spree/testing_support/factories/inventory_unit_factory.rb
+++ b/core/lib/spree/testing_support/factories/inventory_unit_factory.rb
@@ -3,7 +3,7 @@ require 'spree/testing_support/factories/variant_factory'
 require 'spree/testing_support/factories/order_factory'
 require 'spree/testing_support/factories/shipment_factory'
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :inventory_unit, class: 'Spree::InventoryUnit' do
     variant
     order

--- a/core/lib/spree/testing_support/factories/line_item_factory.rb
+++ b/core/lib/spree/testing_support/factories/line_item_factory.rb
@@ -1,7 +1,7 @@
 require 'spree/testing_support/factories/order_factory'
 require 'spree/testing_support/factories/product_factory'
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :line_item, class: 'Spree::LineItem' do
     quantity 1
     price { BigDecimal.new('10.00') }

--- a/core/lib/spree/testing_support/factories/option_type_factory.rb
+++ b/core/lib/spree/testing_support/factories/option_type_factory.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :option_type, class: 'Spree::OptionType' do
     sequence(:name) { |n| "foo-size-#{n}" }
     presentation 'Size'

--- a/core/lib/spree/testing_support/factories/option_value_factory.rb
+++ b/core/lib/spree/testing_support/factories/option_value_factory.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :option_value, class: 'Spree::OptionValue' do
     sequence(:name) { |n| "Size-#{n}" }
 

--- a/core/lib/spree/testing_support/factories/order_factory.rb
+++ b/core/lib/spree/testing_support/factories/order_factory.rb
@@ -5,7 +5,7 @@ require 'spree/testing_support/factories/user_factory'
 require 'spree/testing_support/factories/line_item_factory'
 require 'spree/testing_support/factories/payment_factory'
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :order, class: 'Spree::Order' do
     user
     bill_address

--- a/core/lib/spree/testing_support/factories/order_promotion_factory.rb
+++ b/core/lib/spree/testing_support/factories/order_promotion_factory.rb
@@ -1,7 +1,7 @@
 require 'spree/testing_support/factories/order_factory'
 require 'spree/testing_support/factories/promotion_factory'
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :order_promotion, class: 'Spree::OrderPromotion' do
     association :order
     association :promotion

--- a/core/lib/spree/testing_support/factories/payment_factory.rb
+++ b/core/lib/spree/testing_support/factories/payment_factory.rb
@@ -3,7 +3,7 @@ require 'spree/testing_support/factories/credit_card_factory'
 require 'spree/testing_support/factories/order_factory'
 require 'spree/testing_support/factories/store_credit_factory'
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :payment, aliases: [:credit_card_payment], class: 'Spree::Payment' do
     association(:payment_method, factory: :credit_card_payment_method)
     source { create(:credit_card, user: order.user, address: order.bill_address) }

--- a/core/lib/spree/testing_support/factories/payment_method_factory.rb
+++ b/core/lib/spree/testing_support/factories/payment_method_factory.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :payment_method, aliases: [:credit_card_payment_method], class: 'Spree::PaymentMethod::BogusCreditCard' do
     name 'Credit Card'
     available_to_admin true

--- a/core/lib/spree/testing_support/factories/price_factory.rb
+++ b/core/lib/spree/testing_support/factories/price_factory.rb
@@ -1,6 +1,6 @@
 require 'spree/testing_support/factories/variant_factory'
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :price, class: 'Spree::Price' do
     variant
     amount 19.99

--- a/core/lib/spree/testing_support/factories/product_factory.rb
+++ b/core/lib/spree/testing_support/factories/product_factory.rb
@@ -4,7 +4,7 @@ require 'spree/testing_support/factories/stock_location_factory'
 require 'spree/testing_support/factories/tax_category_factory'
 require 'spree/testing_support/factories/product_option_type_factory'
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :base_product, class: 'Spree::Product' do
     sequence(:name) { |n| "Product ##{n} - #{Kernel.rand(9999)}" }
     description "As seen on TV!"

--- a/core/lib/spree/testing_support/factories/product_option_type_factory.rb
+++ b/core/lib/spree/testing_support/factories/product_option_type_factory.rb
@@ -1,7 +1,7 @@
 require 'spree/testing_support/factories/product_factory'
 require 'spree/testing_support/factories/option_type_factory'
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :product_option_type, class: 'Spree::ProductOptionType' do
     product
     option_type

--- a/core/lib/spree/testing_support/factories/product_property_factory.rb
+++ b/core/lib/spree/testing_support/factories/product_property_factory.rb
@@ -1,7 +1,7 @@
 require 'spree/testing_support/factories/product_factory'
 require 'spree/testing_support/factories/property_factory'
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :product_property, class: 'Spree::ProductProperty' do
     product
     property

--- a/core/lib/spree/testing_support/factories/promotion_category_factory.rb
+++ b/core/lib/spree/testing_support/factories/promotion_category_factory.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :promotion_category, class: 'Spree::PromotionCategory' do
     name 'Promotion Category'
   end

--- a/core/lib/spree/testing_support/factories/promotion_code_factory.rb
+++ b/core/lib/spree/testing_support/factories/promotion_code_factory.rb
@@ -1,7 +1,7 @@
 require 'spree/testing_support/sequences'
 require 'spree/testing_support/factories/promotion_factory'
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :promotion_code, class: 'Spree::PromotionCode' do
     promotion
     value { generate(:random_code) }

--- a/core/lib/spree/testing_support/factories/promotion_factory.rb
+++ b/core/lib/spree/testing_support/factories/promotion_factory.rb
@@ -1,7 +1,7 @@
 require 'spree/testing_support/factories/promotion_code_factory'
 require 'spree/testing_support/factories/variant_factory'
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :promotion, class: 'Spree::Promotion' do
     name 'Promo'
 

--- a/core/lib/spree/testing_support/factories/property_factory.rb
+++ b/core/lib/spree/testing_support/factories/property_factory.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :property, class: 'Spree::Property' do
     name 'baseball_cap_color'
     presentation 'cap color'

--- a/core/lib/spree/testing_support/factories/refund_factory.rb
+++ b/core/lib/spree/testing_support/factories/refund_factory.rb
@@ -1,7 +1,7 @@
 require 'spree/testing_support/factories/payment_factory'
 require 'spree/testing_support/factories/refund_reason_factory'
 
-FactoryGirl.define do
+FactoryBot.define do
   sequence(:refund_transaction_id) { |n| "fake-refund-transaction-#{n}" }
 
   factory :refund, class: 'Spree::Refund' do

--- a/core/lib/spree/testing_support/factories/refund_reason_factory.rb
+++ b/core/lib/spree/testing_support/factories/refund_reason_factory.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :refund_reason, class: 'Spree::RefundReason' do
     sequence(:name) { |n| "Refund for return ##{n}" }
   end

--- a/core/lib/spree/testing_support/factories/reimbursement_factory.rb
+++ b/core/lib/spree/testing_support/factories/reimbursement_factory.rb
@@ -1,6 +1,6 @@
 require 'spree/testing_support/factories/customer_return_factory'
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :reimbursement, class: 'Spree::Reimbursement' do
     transient do
       return_items_count 1

--- a/core/lib/spree/testing_support/factories/reimbursement_type_factory.rb
+++ b/core/lib/spree/testing_support/factories/reimbursement_type_factory.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :reimbursement_type, class: 'Spree::ReimbursementType' do
     sequence(:name) { |n| "Reimbursement Type #{n}" }
     active true

--- a/core/lib/spree/testing_support/factories/return_authorization_factory.rb
+++ b/core/lib/spree/testing_support/factories/return_authorization_factory.rb
@@ -2,7 +2,7 @@ require 'spree/testing_support/factories/order_factory'
 require 'spree/testing_support/factories/stock_location_factory'
 require 'spree/testing_support/factories/return_reason_factory'
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :return_authorization, class: 'Spree::ReturnAuthorization' do
     association(:order, factory: :shipped_order)
     association(:stock_location, factory: :stock_location)

--- a/core/lib/spree/testing_support/factories/return_item_factory.rb
+++ b/core/lib/spree/testing_support/factories/return_item_factory.rb
@@ -2,7 +2,7 @@ require 'spree/testing_support/factories/inventory_unit_factory'
 require 'spree/testing_support/factories/return_reason_factory'
 require 'spree/testing_support/factories/return_authorization_factory'
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :return_item, class: 'Spree::ReturnItem' do
     association(:inventory_unit, factory: :inventory_unit, state: :shipped)
     association(:return_reason, factory: :return_reason)

--- a/core/lib/spree/testing_support/factories/return_reason_factory.rb
+++ b/core/lib/spree/testing_support/factories/return_reason_factory.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :return_reason, class: 'Spree::ReturnReason' do
     sequence(:name) { |n| "Defect ##{n}" }
   end

--- a/core/lib/spree/testing_support/factories/role_factory.rb
+++ b/core/lib/spree/testing_support/factories/role_factory.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :role, class: 'Spree::Role' do
     sequence(:name) { |n| "Role ##{n}" }
 

--- a/core/lib/spree/testing_support/factories/shipment_factory.rb
+++ b/core/lib/spree/testing_support/factories/shipment_factory.rb
@@ -2,7 +2,7 @@ require 'spree/testing_support/factories/order_factory'
 require 'spree/testing_support/factories/stock_location_factory'
 require 'spree/testing_support/factories/shipping_method_factory'
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :shipment, class: 'Spree::Shipment' do
     tracking 'U10000'
     cost 100.00

--- a/core/lib/spree/testing_support/factories/shipping_category_factory.rb
+++ b/core/lib/spree/testing_support/factories/shipping_category_factory.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :shipping_category, class: 'Spree::ShippingCategory' do
     sequence(:name) { |n| "ShippingCategory ##{n}" }
   end

--- a/core/lib/spree/testing_support/factories/shipping_method_factory.rb
+++ b/core/lib/spree/testing_support/factories/shipping_method_factory.rb
@@ -2,7 +2,7 @@ require 'spree/testing_support/factories/calculator_factory'
 require 'spree/testing_support/factories/shipping_category_factory'
 require 'spree/testing_support/factories/zone_factory'
 
-FactoryGirl.define do
+FactoryBot.define do
   factory(
     :shipping_method,
     aliases: [
@@ -11,7 +11,7 @@ FactoryGirl.define do
     class: 'Spree::ShippingMethod'
   ) do
     zones do
-      [Spree::Zone.find_by(name: 'GlobalZone') || FactoryGirl.create(:global_zone)]
+      [Spree::Zone.find_by(name: 'GlobalZone') || FactoryBot.create(:global_zone)]
     end
 
     name 'UPS Ground'

--- a/core/lib/spree/testing_support/factories/shipping_rate_factory.rb
+++ b/core/lib/spree/testing_support/factories/shipping_rate_factory.rb
@@ -1,7 +1,7 @@
 require 'spree/testing_support/factories/shipping_method_factory'
 require 'spree/testing_support/factories/shipment_factory'
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :shipping_rate, class: 'Spree::ShippingRate' do
     shipping_method
     shipment

--- a/core/lib/spree/testing_support/factories/state_factory.rb
+++ b/core/lib/spree/testing_support/factories/state_factory.rb
@@ -1,6 +1,6 @@
 require 'spree/testing_support/factories/country_factory'
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :state, class: 'Spree::State' do
     transient do
       country_iso 'US'

--- a/core/lib/spree/testing_support/factories/stock_item_factory.rb
+++ b/core/lib/spree/testing_support/factories/stock_item_factory.rb
@@ -1,7 +1,7 @@
 require 'spree/testing_support/factories/stock_location_factory'
 require 'spree/testing_support/factories/variant_factory'
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :stock_item, class: 'Spree::StockItem' do
     backorderable true
     association :stock_location, factory: :stock_location_without_variant_propagation

--- a/core/lib/spree/testing_support/factories/stock_location_factory.rb
+++ b/core/lib/spree/testing_support/factories/stock_location_factory.rb
@@ -2,7 +2,7 @@ require 'spree/testing_support/factories/country_factory'
 require 'spree/testing_support/factories/state_factory'
 require 'spree/testing_support/factories/product_factory'
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :stock_location, class: 'Spree::StockLocation' do
     name 'NY Warehouse'
     address1 '1600 Pennsylvania Ave NW'

--- a/core/lib/spree/testing_support/factories/stock_movement_factory.rb
+++ b/core/lib/spree/testing_support/factories/stock_movement_factory.rb
@@ -1,6 +1,6 @@
 require 'spree/testing_support/factories/stock_item_factory'
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :stock_movement, class: 'Spree::StockMovement' do
     quantity 1
     action 'sold'

--- a/core/lib/spree/testing_support/factories/stock_package_factory.rb
+++ b/core/lib/spree/testing_support/factories/stock_package_factory.rb
@@ -1,7 +1,7 @@
 require 'spree/testing_support/factories/inventory_unit_factory'
 require 'spree/testing_support/factories/variant_factory'
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :stock_package, class: 'Spree::Stock::Package' do
     skip_create
 

--- a/core/lib/spree/testing_support/factories/stock_transfer_factory.rb
+++ b/core/lib/spree/testing_support/factories/stock_transfer_factory.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   sequence(:source_code) { |n| "SRC#{n}" }
   sequence(:destination_code) { |n| "DEST#{n}" }
 

--- a/core/lib/spree/testing_support/factories/store_credit_category_factory.rb
+++ b/core/lib/spree/testing_support/factories/store_credit_category_factory.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :store_credit_category, class: 'Spree::StoreCreditCategory' do
     name "Exchange"
   end

--- a/core/lib/spree/testing_support/factories/store_credit_event_factory.rb
+++ b/core/lib/spree/testing_support/factories/store_credit_event_factory.rb
@@ -1,7 +1,7 @@
 require 'spree/testing_support/factories/store_credit_factory'
 require 'spree/testing_support/factories/store_credit_update_reason_factory'
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :store_credit_event, class: 'Spree::StoreCreditEvent' do
     store_credit
     amount             { 100.00 }

--- a/core/lib/spree/testing_support/factories/store_credit_factory.rb
+++ b/core/lib/spree/testing_support/factories/store_credit_factory.rb
@@ -2,7 +2,7 @@ require 'spree/testing_support/factories/store_credit_category_factory'
 require 'spree/testing_support/factories/store_credit_type_factory'
 require 'spree/testing_support/factories/user_factory'
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :store_credit, class: 'Spree::StoreCredit' do
     user
     association :created_by, factory: :user

--- a/core/lib/spree/testing_support/factories/store_credit_type_factory.rb
+++ b/core/lib/spree/testing_support/factories/store_credit_type_factory.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :primary_credit_type, class: 'Spree::StoreCreditType' do
     name      Spree::StoreCreditType::DEFAULT_TYPE_NAME
     priority  { "1" }

--- a/core/lib/spree/testing_support/factories/store_credit_update_reason_factory.rb
+++ b/core/lib/spree/testing_support/factories/store_credit_update_reason_factory.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :store_credit_update_reason, class: 'Spree::StoreCreditUpdateReason' do
     name "Input error"
   end

--- a/core/lib/spree/testing_support/factories/store_factory.rb
+++ b/core/lib/spree/testing_support/factories/store_factory.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :store, class: 'Spree::Store' do
     sequence(:code) { |i| "spree_#{i}" }
     sequence(:name) { |i| "Spree Test Store #{i}" }

--- a/core/lib/spree/testing_support/factories/tax_category_factory.rb
+++ b/core/lib/spree/testing_support/factories/tax_category_factory.rb
@@ -1,6 +1,6 @@
 require 'spree/testing_support/sequences'
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :tax_category, class: 'Spree::TaxCategory' do
     name { "TaxCategory - #{rand(999_999)}" }
     tax_code { "TaxCode - #{rand(999_999)}" }

--- a/core/lib/spree/testing_support/factories/tax_rate_factory.rb
+++ b/core/lib/spree/testing_support/factories/tax_rate_factory.rb
@@ -2,7 +2,7 @@ require 'spree/testing_support/factories/calculator_factory'
 require 'spree/testing_support/factories/tax_category_factory'
 require 'spree/testing_support/factories/zone_factory'
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :tax_rate, class: 'Spree::TaxRate' do
     zone
     amount 0.1

--- a/core/lib/spree/testing_support/factories/taxon_factory.rb
+++ b/core/lib/spree/testing_support/factories/taxon_factory.rb
@@ -1,6 +1,6 @@
 require 'spree/testing_support/factories/taxonomy_factory'
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :taxon, class: 'Spree::Taxon' do
     name 'Ruby on Rails'
     taxonomy

--- a/core/lib/spree/testing_support/factories/taxonomy_factory.rb
+++ b/core/lib/spree/testing_support/factories/taxonomy_factory.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :taxonomy, class: 'Spree::Taxonomy' do
     name 'Brand'
   end

--- a/core/lib/spree/testing_support/factories/user_factory.rb
+++ b/core/lib/spree/testing_support/factories/user_factory.rb
@@ -2,7 +2,7 @@ require 'spree/testing_support/sequences'
 require 'spree/testing_support/factories/role_factory'
 require 'spree/testing_support/factories/address_factory'
 
-FactoryGirl.define do
+FactoryBot.define do
   sequence :user_authentication_token do |n|
     "xxxx#{Time.current.to_i}#{rand(1000)}#{n}xxxxxxxxxxxxx"
   end

--- a/core/lib/spree/testing_support/factories/variant_factory.rb
+++ b/core/lib/spree/testing_support/factories/variant_factory.rb
@@ -3,7 +3,7 @@ require 'spree/testing_support/factories/option_value_factory'
 require 'spree/testing_support/factories/option_type_factory'
 require 'spree/testing_support/factories/product_factory'
 
-FactoryGirl.define do
+FactoryBot.define do
   sequence(:random_float) { BigDecimal.new("#{rand(200)}.#{rand(99)}") }
 
   factory :base_variant, class: 'Spree::Variant' do

--- a/core/lib/spree/testing_support/factories/variant_property_rule_condition_factory.rb
+++ b/core/lib/spree/testing_support/factories/variant_property_rule_condition_factory.rb
@@ -1,7 +1,7 @@
 require 'spree/testing_support/factories/option_value_factory'
 require 'spree/testing_support/factories/variant_property_rule_factory'
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :variant_property_rule_condition, class: 'Spree::VariantPropertyRuleCondition' do
     variant_property_rule
     option_value

--- a/core/lib/spree/testing_support/factories/variant_property_rule_factory.rb
+++ b/core/lib/spree/testing_support/factories/variant_property_rule_factory.rb
@@ -2,7 +2,7 @@ require 'spree/testing_support/factories/product_factory'
 require 'spree/testing_support/factories/property_factory'
 require 'spree/testing_support/factories/option_value_factory'
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :variant_property_rule, class: 'Spree::VariantPropertyRule' do
     product
 

--- a/core/lib/spree/testing_support/factories/variant_property_rule_value_factory.rb
+++ b/core/lib/spree/testing_support/factories/variant_property_rule_value_factory.rb
@@ -1,7 +1,7 @@
 require 'spree/testing_support/factories/variant_property_rule_factory'
 require 'spree/testing_support/factories/property_factory'
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :variant_property_rule_value, class: 'Spree::VariantPropertyRuleValue' do
     variant_property_rule
     property

--- a/core/lib/spree/testing_support/factories/zone_factory.rb
+++ b/core/lib/spree/testing_support/factories/zone_factory.rb
@@ -1,7 +1,7 @@
 require 'spree/testing_support/sequences'
 require 'spree/testing_support/factories/country_factory'
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :global_zone, class: 'Spree::Zone' do
     name 'GlobalZone'
     description { generate(:random_string) }

--- a/core/lib/spree/testing_support/order_walkthrough.rb
+++ b/core/lib/spree/testing_support/order_walkthrough.rb
@@ -5,14 +5,14 @@ class OrderWalkthrough
 
   def up_to(state)
     # Need to create a valid zone too...
-    @zone = FactoryGirl.create(:zone)
-    @country = FactoryGirl.create(:country)
-    @state = FactoryGirl.create(:state, country: @country)
+    @zone = FactoryBot.create(:zone)
+    @country = FactoryBot.create(:country)
+    @state = FactoryBot.create(:state, country: @country)
 
     @zone.members << Spree::ZoneMember.create(zoneable: @country)
 
     # A shipping method must exist for rates to be displayed on checkout page
-    FactoryGirl.create(:shipping_method, zones: [@zone]).tap do |sm|
+    FactoryBot.create(:shipping_method, zones: [@zone]).tap do |sm|
       sm.calculator.preferred_amount = 10
       sm.calculator.preferred_currency = Spree::Config[:currency]
       sm.calculator.save
@@ -20,7 +20,7 @@ class OrderWalkthrough
 
     order = Spree::Order.create!(
       email: "spree@example.com",
-      store: Spree::Store.first || FactoryGirl.create(:store)
+      store: Spree::Store.first || FactoryBot.create(:store)
     )
     add_line_item!(order)
     order.next!
@@ -42,13 +42,13 @@ class OrderWalkthrough
   private
 
   def add_line_item!(order)
-    FactoryGirl.create(:line_item, order: order)
+    FactoryBot.create(:line_item, order: order)
     order.reload
   end
 
   def address(order)
-    order.bill_address = FactoryGirl.create(:address, country: @country, state: @state)
-    order.ship_address = FactoryGirl.create(:address, country: @country, state: @state)
+    order.bill_address = FactoryBot.create(:address, country: @country, state: @state)
+    order.ship_address = FactoryBot.create(:address, country: @country, state: @state)
     order.next!
   end
 
@@ -57,7 +57,7 @@ class OrderWalkthrough
   end
 
   def payment(order)
-    credit_card = FactoryGirl.create(:credit_card)
+    credit_card = FactoryBot.create(:credit_card)
     order.payments.create!(payment_method: credit_card.payment_method, amount: order.total, source: credit_card)
     # TODO: maybe look at some way of making this payment_state change automatic
     order.payment_state = 'paid'

--- a/core/lib/spree/testing_support/sequences.rb
+++ b/core/lib/spree/testing_support/sequences.rb
@@ -1,4 +1,4 @@
-require 'factory_girl'
+require 'factory_bot'
 
 begin
   require 'ffaker'
@@ -6,7 +6,7 @@ rescue LoadError
   abort "Solidus factories require FFaker. Please add `ffaker` to your `Gemfile`."
 end
 
-FactoryGirl.define do
+FactoryBot.define do
   sequence(:random_code)        { FFaker::Lorem.characters(10) }
   sequence(:random_description) { FFaker::Lorem.paragraphs(1 + Kernel.rand(5)).join("\n") }
   sequence(:random_email)       { FFaker::Internet.email }

--- a/core/spec/lib/search/variant_spec.rb
+++ b/core/spec/lib/search/variant_spec.rb
@@ -10,8 +10,8 @@ module Spree
       expect(described_class.new(query_string).results).not_to include variant
     end
 
-    let(:product) { FactoryGirl.create(:product, name: "My Special Product", slug: "my-special-product") }
-    let!(:variant) { FactoryGirl.create(:variant, product: product, sku: "abc-123") }
+    let(:product) { FactoryBot.create(:product, name: "My Special Product", slug: "my-special-product") }
+    let!(:variant) { FactoryBot.create(:variant, product: product, sku: "abc-123") }
 
     context "blank string" do
       it { assert_found(nil, variant) }
@@ -103,8 +103,8 @@ module Spree
         end
       end
 
-      let!(:numeric_sku_variant) { FactoryGirl.create(:variant, product: product, sku: "123") }
-      let!(:non_numeric_sku_variant) { FactoryGirl.create(:variant, product: product, sku: "abc") }
+      let!(:numeric_sku_variant) { FactoryBot.create(:variant, product: product, sku: "123") }
+      let!(:non_numeric_sku_variant) { FactoryBot.create(:variant, product: product, sku: "abc") }
 
       it { expect(NumericSkuSearcher.new('123').results).to include numeric_sku_variant }
       it { expect(NumericSkuSearcher.new('abc').results).not_to include non_numeric_sku_variant }

--- a/core/spec/lib/spree/core/controller_helpers/pricing_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/pricing_spec.rb
@@ -20,13 +20,13 @@ RSpec.describe Spree::Core::ControllerHelpers::Pricing, type: :controller do
     end
 
     context "when the current store default_currency empty" do
-      let(:store) { FactoryGirl.create :store, default_currency: '' }
+      let(:store) { FactoryBot.create :store, default_currency: '' }
 
       it { Spree::Deprecation.silence { is_expected.to eq('USD') } }
     end
 
     context "when the current store default_currency is a currency" do
-      let(:store) { FactoryGirl.create :store, default_currency: 'EUR' }
+      let(:store) { FactoryBot.create :store, default_currency: 'EUR' }
 
       it { Spree::Deprecation.silence { is_expected.to eq('EUR') } }
     end
@@ -35,7 +35,7 @@ RSpec.describe Spree::Core::ControllerHelpers::Pricing, type: :controller do
   describe '#current_pricing_options' do
     subject { controller.current_pricing_options }
 
-    let(:store) { FactoryGirl.create(:store, default_currency: nil) }
+    let(:store) { FactoryBot.create(:store, default_currency: nil) }
 
     it { is_expected.to be_a(Spree::Config.pricing_options_class) }
 
@@ -48,13 +48,13 @@ RSpec.describe Spree::Core::ControllerHelpers::Pricing, type: :controller do
       end
 
       context "when the current store default_currency empty" do
-        let(:store) { FactoryGirl.create :store, default_currency: '' }
+        let(:store) { FactoryBot.create :store, default_currency: '' }
 
         it { is_expected.to eq('USD') }
       end
 
       context "when the current store default_currency is a currency" do
-        let(:store) { FactoryGirl.create :store, default_currency: 'EUR' }
+        let(:store) { FactoryBot.create :store, default_currency: 'EUR' }
 
         it { is_expected.to eq('EUR') }
       end
@@ -63,7 +63,7 @@ RSpec.describe Spree::Core::ControllerHelpers::Pricing, type: :controller do
     context "country_iso" do
       subject { controller.current_pricing_options.country_iso }
 
-      let(:store) { FactoryGirl.create(:store, cart_tax_country_iso: cart_tax_country_iso) }
+      let(:store) { FactoryBot.create(:store, cart_tax_country_iso: cart_tax_country_iso) }
 
       context "when the store has a cart tax country set" do
         let(:cart_tax_country_iso) { "DE" }

--- a/core/spec/lib/spree/core/testing_support/factories/reimbursement_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/reimbursement_factory_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'reimbursement factory' do
   end
 
   describe 'total' do
-    subject { FactoryGirl.create(:reimbursement).total }
+    subject { FactoryBot.create(:reimbursement).total }
 
     it { is_expected.to be_present }
   end

--- a/core/spec/mailers/order_mailer_spec.rb
+++ b/core/spec/mailers/order_mailer_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Spree::OrderMailer, type: :mailer do
     product = stub_model(Spree::Product, name: %{The "BEST" product})
     variant = stub_model(Spree::Variant, product: product)
     price = stub_model(Spree::Price, variant: variant, amount: 5.00)
-    store = FactoryGirl.build :store, mail_from_address: "store@example.com"
+    store = FactoryBot.build :store, mail_from_address: "store@example.com"
     line_item = stub_model(Spree::LineItem, variant: variant, order: order, quantity: 1, price: 4.99)
     allow(variant).to receive_messages(default_price: price)
     allow(order).to receive_messages(line_items: [line_item])

--- a/core/spec/models/spree/calculator/distributed_amount_spec.rb
+++ b/core/spec/models/spree/calculator/distributed_amount_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Spree::Calculator::DistributedAmount, type: :model do
     let(:calculator) { Spree::Calculator::DistributedAmount.new }
 
     let(:order) do
-      FactoryGirl.create(
+      FactoryBot.create(
         :order_with_line_items,
         line_items_attributes: [{ price: 50 }, { price: 50 }, { price: 50 }]
       )

--- a/core/spec/models/spree/distributed_amounts_handler_spec.rb
+++ b/core/spec/models/spree/distributed_amounts_handler_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Spree::DistributedAmountsHandler, type: :model do
   let(:order) do
-    FactoryGirl.create(
+    FactoryBot.create(
       :order_with_line_items,
       line_items_attributes: line_items_attributes
     )

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe Spree::Order, type: :model do
 
       context "with a line item" do
         before do
-          order.line_items << FactoryGirl.create(:line_item)
+          order.line_items << FactoryBot.create(:line_item)
         end
 
         it "transitions to address" do
@@ -123,7 +123,7 @@ RSpec.describe Spree::Order, type: :model do
         end
 
         context "with default addresses" do
-          let(:default_address) { FactoryGirl.create(:address) }
+          let(:default_address) { FactoryBot.create(:address) }
 
           shared_examples "it references the user's the default address" do
             it do
@@ -137,7 +137,7 @@ RSpec.describe Spree::Order, type: :model do
           it_behaves_like "it references the user's the default address" do
             let(:address_kind) { :ship }
             before do
-              order.user = FactoryGirl.create(:user)
+              order.user = FactoryBot.create(:user)
               order.user.default_address = default_address
               order.next!
               order.reload
@@ -147,7 +147,7 @@ RSpec.describe Spree::Order, type: :model do
           it_behaves_like "it references the user's the default address" do
             let(:address_kind) { :bill }
             before do
-              order.user = FactoryGirl.create(:user)
+              order.user = FactoryBot.create(:user)
               order.user.default_address = default_address
               order.next!
               order.reload
@@ -202,7 +202,7 @@ RSpec.describe Spree::Order, type: :model do
       end
 
       it "does not call persist_order_address if there is no address on the order" do
-        order.user = FactoryGirl.create(:user)
+        order.user = FactoryBot.create(:user)
         order.save!
 
         expect(order.user).to_not receive(:persist_order_address).with(order)
@@ -210,9 +210,9 @@ RSpec.describe Spree::Order, type: :model do
       end
 
       it "calls persist_order_address on the order's user" do
-        order.user = FactoryGirl.create(:user)
-        order.ship_address = FactoryGirl.create(:address)
-        order.bill_address = FactoryGirl.create(:address)
+        order.user = FactoryBot.create(:user)
+        order.ship_address = FactoryBot.create(:address)
+        order.bill_address = FactoryBot.create(:address)
         order.save!
 
         expect(order.user).to receive(:persist_order_address).with(order)
@@ -220,7 +220,7 @@ RSpec.describe Spree::Order, type: :model do
       end
 
       it "does not call persist_order_address on the order's user for a temporary address" do
-        order.user = FactoryGirl.create(:user)
+        order.user = FactoryBot.create(:user)
         order.temporary_address = true
         order.save!
 
@@ -230,7 +230,7 @@ RSpec.describe Spree::Order, type: :model do
     end
 
     context "to delivery" do
-      let(:ship_address) { FactoryGirl.create(:ship_address) }
+      let(:ship_address) { FactoryBot.create(:ship_address) }
 
       before do
         order.ship_address = ship_address
@@ -276,7 +276,7 @@ RSpec.describe Spree::Order, type: :model do
     end
 
     context "from delivery" do
-      let(:ship_address) { FactoryGirl.create(:ship_address) }
+      let(:ship_address) { FactoryBot.create(:ship_address) }
 
       before do
         order.ship_address = ship_address
@@ -315,7 +315,7 @@ RSpec.describe Spree::Order, type: :model do
 
       context "correctly determining payment required based on shipping information" do
         let(:shipment) do
-          FactoryGirl.create(:shipment)
+          FactoryBot.create(:shipment)
         end
 
         before do
@@ -446,11 +446,11 @@ RSpec.describe Spree::Order, type: :model do
 
     context "out of stock" do
       before do
-        order.user = FactoryGirl.create(:user)
+        order.user = FactoryBot.create(:user)
         order.email = 'spree@example.org'
-        order.payments << FactoryGirl.create(:payment)
+        order.payments << FactoryBot.create(:payment)
         allow(order).to receive_messages(payment_required?: true)
-        order.line_items << FactoryGirl.create(:line_item)
+        order.line_items << FactoryBot.create(:line_item)
         order.line_items.first.variant.stock_items.each do |si|
           si.set_count_on_hand(0)
           si.update_attributes(backorderable: false)
@@ -473,12 +473,12 @@ RSpec.describe Spree::Order, type: :model do
 
     context "no inventory units" do
       before do
-        order.user = FactoryGirl.create(:user)
+        order.user = FactoryBot.create(:user)
         order.email = 'spree@example.com'
-        order.payments << FactoryGirl.create(:payment)
+        order.payments << FactoryBot.create(:payment)
         allow(order).to receive_messages(payment_required?: true)
         allow(order).to receive(:ensure_available_shipping_rates) { true }
-        order.line_items << FactoryGirl.create(:line_item)
+        order.line_items << FactoryBot.create(:line_item)
 
         Spree::OrderUpdater.new(order).update
         order.save!
@@ -513,7 +513,7 @@ RSpec.describe Spree::Order, type: :model do
     context "exchange order completion" do
       before do
         order.email = 'spree@example.org'
-        order.payments << FactoryGirl.create(:payment)
+        order.payments << FactoryBot.create(:payment)
         order.shipments.create!
         allow(order).to receive_messages(payment_required?: true)
         allow(order).to receive(:ensure_available_shipping_rates).and_return(true)
@@ -521,8 +521,8 @@ RSpec.describe Spree::Order, type: :model do
 
       context 'when the line items are not available' do
         before do
-          order.line_items << FactoryGirl.create(:line_item)
-          order.store = FactoryGirl.build(:store)
+          order.line_items << FactoryBot.create(:line_item)
+          order.store = FactoryBot.build(:store)
           Spree::OrderUpdater.new(order).update
 
           order.save!
@@ -537,16 +537,16 @@ RSpec.describe Spree::Order, type: :model do
 
     context "default credit card" do
       before do
-        order.user = FactoryGirl.create(:user)
-        order.store = FactoryGirl.create(:store)
+        order.user = FactoryBot.create(:user)
+        order.store = FactoryBot.create(:store)
         order.email = 'spree@example.org'
-        order.payments << FactoryGirl.create(:payment)
+        order.payments << FactoryBot.create(:payment)
 
         # make sure we will actually capture a payment
         allow(order).to receive_messages(payment_required?: true)
         allow(order).to receive_messages(ensure_available_shipping_rates: true)
         allow(order).to receive_messages(validate_line_item_availability: true)
-        order.line_items << FactoryGirl.create(:line_item)
+        order.line_items << FactoryBot.create(:line_item)
         order.create_proposed_shipments
         Spree::OrderUpdater.new(order).update
 
@@ -568,9 +568,9 @@ RSpec.describe Spree::Order, type: :model do
 
     context "a payment fails during processing" do
       before do
-        order.user = FactoryGirl.create(:user)
+        order.user = FactoryBot.create(:user)
         order.email = 'spree@example.org'
-        payment = FactoryGirl.create(:payment)
+        payment = FactoryBot.create(:payment)
         allow(payment).to receive(:process!).and_raise(Spree::Core::GatewayError.new('processing failed'))
         order.line_items.each { |li| li.inventory_units.create! }
         order.payments << payment
@@ -579,7 +579,7 @@ RSpec.describe Spree::Order, type: :model do
         allow(order).to receive_messages(payment_required?: true)
         allow(order).to receive_messages(ensure_available_shipping_rates: true)
         allow(order).to receive_messages(validate_line_item_availability: true)
-        order.line_items << FactoryGirl.create(:line_item)
+        order.line_items << FactoryBot.create(:line_item)
         order.create_proposed_shipments
         Spree::OrderUpdater.new(order).update
       end

--- a/core/spec/models/spree/order/risk_assessment_spec.rb
+++ b/core/spec/models/spree/order/risk_assessment_spec.rb
@@ -5,37 +5,37 @@ RSpec.describe Spree::Order, type: :model do
 
   describe ".is_risky?" do
     context "Not risky order" do
-      let(:order) { FactoryGirl.create(:order, payments: [payment]) }
+      let(:order) { FactoryBot.create(:order, payments: [payment]) }
       context "with avs_response == D" do
-        let(:payment) { FactoryGirl.create(:payment, avs_response: "D") }
+        let(:payment) { FactoryBot.create(:payment, avs_response: "D") }
         it "is not considered risky" do
           expect(order.is_risky?).to eq(false)
         end
       end
 
       context "with avs_response == M" do
-        let(:payment) { FactoryGirl.create(:payment, avs_response: "M") }
+        let(:payment) { FactoryBot.create(:payment, avs_response: "M") }
         it "is not considered risky" do
           expect(order.is_risky?).to eq(false)
         end
       end
 
       context "with avs_response == ''" do
-        let(:payment) { FactoryGirl.create(:payment, avs_response: "") }
+        let(:payment) { FactoryBot.create(:payment, avs_response: "") }
         it "is not considered risky" do
           expect(order.is_risky?).to eq(false)
         end
       end
 
       context "with cvv_response_code == M" do
-        let(:payment) { FactoryGirl.create(:payment, cvv_response_code: "M") }
+        let(:payment) { FactoryBot.create(:payment, cvv_response_code: "M") }
         it "is not considered risky" do
           expect(order.is_risky?).to eq(false)
         end
       end
 
       context "with cvv_response_message == ''" do
-        let(:payment) { FactoryGirl.create(:payment, cvv_response_message: "") }
+        let(:payment) { FactoryBot.create(:payment, cvv_response_message: "") }
         it "is not considered risky" do
           expect(order.is_risky?).to eq(false)
         end
@@ -44,21 +44,21 @@ RSpec.describe Spree::Order, type: :model do
 
     context "Risky order" do
       context "AVS response message" do
-        let(:order) { FactoryGirl.create(:order, payments: [FactoryGirl.create(:payment, avs_response: "A")]) }
+        let(:order) { FactoryBot.create(:order, payments: [FactoryBot.create(:payment, avs_response: "A")]) }
         it "returns true if the order has an avs_response" do
           expect(order.is_risky?).to eq(true)
         end
       end
 
       context "CVV response code" do
-        let(:order) { FactoryGirl.create(:order, payments: [FactoryGirl.create(:payment, cvv_response_code: "N")]) }
+        let(:order) { FactoryBot.create(:order, payments: [FactoryBot.create(:payment, cvv_response_code: "N")]) }
         it "returns true if the order has an cvv_response_code" do
           expect(order.is_risky?).to eq(true)
         end
       end
 
       context "state == 'failed'" do
-        let(:order) { FactoryGirl.create(:order, payments: [FactoryGirl.create(:payment, state: 'failed')]) }
+        let(:order) { FactoryBot.create(:order, payments: [FactoryBot.create(:payment, state: 'failed')]) }
         it "returns true if the order has state == 'failed'" do
           expect(order.is_risky?).to eq(true)
         end

--- a/core/spec/models/spree/order_shipping_spec.rb
+++ b/core/spec/models/spree/order_shipping_spec.rb
@@ -223,9 +223,9 @@ RSpec.describe Spree::OrderShipping do
     end
 
     context "with stale inventory units (regression test)" do
-      let(:order) { FactoryGirl.create(:order_ready_to_ship, line_items_count: 1) }
+      let(:order) { FactoryBot.create(:order_ready_to_ship, line_items_count: 1) }
       let(:shipment) do
-        FactoryGirl.create(
+        FactoryBot.create(
           :shipment,
           order: order
         )

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Spree::Order, type: :model do
   let(:user) { create(:user, email: "spree@example.com") }
   let(:order) { create(:order, user: user, store: store) }
   let(:promotion) do
-    FactoryGirl.create(
+    FactoryBot.create(
       :promotion,
       :with_order_adjustment,
       code: "discount"
@@ -526,7 +526,7 @@ RSpec.describe Spree::Order, type: :model do
 
   # Regression tests for https://github.com/spree/spree/issues/4072
   context "#state_changed" do
-    let(:order) { FactoryGirl.create(:order) }
+    let(:order) { FactoryBot.create(:order) }
 
     it "logs state changes" do
       order.update_column(:payment_state, 'balance_due')
@@ -596,9 +596,9 @@ RSpec.describe Spree::Order, type: :model do
     context "with more than one payment method" do
       subject { order.available_payment_methods }
 
-      let!(:first_method) { FactoryGirl.create(:payment_method, available_to_users: true,
+      let!(:first_method) { FactoryBot.create(:payment_method, available_to_users: true,
                                                available_to_admin: true) }
-      let!(:second_method) { FactoryGirl.create(:payment_method, available_to_users: true,
+      let!(:second_method) { FactoryBot.create(:payment_method, available_to_users: true,
                                                available_to_admin: true) }
 
       before do
@@ -771,10 +771,10 @@ RSpec.describe Spree::Order, type: :model do
   end
 
   context "#associate_user!" do
-    let!(:user) { FactoryGirl.create(:user) }
+    let!(:user) { FactoryBot.create(:user) }
 
     it "should associate a user with a persisted order" do
-      order = FactoryGirl.create(:order_with_line_items, created_by: nil)
+      order = FactoryBot.create(:order_with_line_items, created_by: nil)
       order.user = nil
       order.email = nil
       order.associate_user!(user)
@@ -791,7 +791,7 @@ RSpec.describe Spree::Order, type: :model do
 
     it "should not overwrite the created_by if it already is set" do
       creator = create(:user)
-      order = FactoryGirl.create(:order_with_line_items, created_by: creator)
+      order = FactoryBot.create(:order_with_line_items, created_by: creator)
 
       order.user = nil
       order.email = nil

--- a/core/spec/models/spree/order_taxation_spec.rb
+++ b/core/spec/models/spree/order_taxation_spec.rb
@@ -1,15 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe Spree::OrderTaxation do
-  let(:shipping_address) { FactoryGirl.create(:address, state: new_york) }
-  let(:order) { FactoryGirl.create(:order, ship_address: shipping_address, state: "delivery") }
+  let(:shipping_address) { FactoryBot.create(:address, state: new_york) }
+  let(:order) { FactoryBot.create(:order, ship_address: shipping_address, state: "delivery") }
 
-  let(:new_york) { FactoryGirl.create(:state, state_code: "NY") }
-  let(:new_york_zone) { FactoryGirl.create(:zone, states: [new_york]) }
+  let(:new_york) { FactoryBot.create(:state, state_code: "NY") }
+  let(:new_york_zone) { FactoryBot.create(:zone, states: [new_york]) }
 
-  let(:books_category) { FactoryGirl.create(:tax_category, name: "Books") }
+  let(:books_category) { FactoryBot.create(:tax_category, name: "Books") }
   let(:book_tax_rate) do
-    FactoryGirl.create(
+    FactoryBot.create(
       :tax_rate,
       name: "New York Sales Tax",
       tax_categories: [books_category],
@@ -20,7 +20,7 @@ RSpec.describe Spree::OrderTaxation do
   end
 
   let(:book) do
-    FactoryGirl.create(
+    FactoryBot.create(
       :product,
       price: 20,
       name: "Book",

--- a/core/spec/models/spree/promotion/actions/create_quantity_adjustments_spec.rb
+++ b/core/spec/models/spree/promotion/actions/create_quantity_adjustments_spec.rb
@@ -18,13 +18,13 @@ module Spree::Promotion::Actions
     end
 
     let(:quantity) { 1 }
-    let(:promotion) { FactoryGirl.create :promotion }
+    let(:promotion) { FactoryBot.create :promotion }
 
     describe "#compute_amount" do
       subject { action.compute_amount(line_item) }
 
       context "with a flat rate adjustment" do
-        let(:calculator) { FactoryGirl.create :flat_rate_calculator, preferred_amount: 5 }
+        let(:calculator) { FactoryBot.create :flat_rate_calculator, preferred_amount: 5 }
 
         context "with a quantity group of 2" do
           let(:line_item) { order.line_items.first }
@@ -108,7 +108,7 @@ module Spree::Promotion::Actions
       end
 
       context "with a percentage based adjustment" do
-        let(:calculator) { FactoryGirl.create :percent_on_item_calculator, preferred_percent: 10 }
+        let(:calculator) { FactoryBot.create :percent_on_item_calculator, preferred_percent: 10 }
 
         let(:line_items_attributes) do
           [
@@ -216,7 +216,7 @@ module Spree::Promotion::Actions
 
     # Regression test for https://github.com/solidusio/solidus/pull/1591
     context "with unsaved line_item changes" do
-      let(:calculator) { FactoryGirl.create :flat_rate_calculator }
+      let(:calculator) { FactoryBot.create :flat_rate_calculator }
       let(:line_item) { order.line_items.first }
 
       before do
@@ -231,7 +231,7 @@ module Spree::Promotion::Actions
 
     # Regression test for https://github.com/solidusio/solidus/pull/1591
     context "applied to the order" do
-      let(:calculator) { FactoryGirl.create :flat_rate_calculator }
+      let(:calculator) { FactoryBot.create :flat_rate_calculator }
 
       before do
         action.perform(order: order, promotion: promotion)
@@ -275,7 +275,7 @@ module Spree::Promotion::Actions
     end
 
     describe Spree::Promotion::Actions::CreateQuantityAdjustments::PartialLineItem do
-      let!(:item) { FactoryGirl.create :line_item, order: order, quantity: quantity, price: 10 }
+      let!(:item) { FactoryBot.create :line_item, order: order, quantity: quantity, price: 10 }
       let(:quantity) { 5 }
 
       subject { described_class.new(item) }

--- a/core/spec/models/spree/promotion_code_spec.rb
+++ b/core/spec/models/spree/promotion_code_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Spree::PromotionCode do
           let(:usage_limit) { 1 }
           context "on a different order" do
             before do
-              FactoryGirl.create(
+              FactoryBot.create(
                 :completed_order_with_promotion,
                 promotion: promotion
               )
@@ -51,7 +51,7 @@ RSpec.describe Spree::PromotionCode do
 
     context "with an order-level adjustment" do
       let(:promotion) do
-        FactoryGirl.create(
+        FactoryBot.create(
           :promotion,
           :with_order_adjustment,
           code: "discount",
@@ -59,7 +59,7 @@ RSpec.describe Spree::PromotionCode do
         )
       end
       let(:promotable) do
-        FactoryGirl.create(
+        FactoryBot.create(
           :completed_order_with_promotion,
           promotion: promotion
         )
@@ -69,7 +69,7 @@ RSpec.describe Spree::PromotionCode do
 
     context "with an item-level adjustment" do
       let(:promotion) do
-        FactoryGirl.create(
+        FactoryBot.create(
           :promotion,
           :with_line_item_adjustment,
           code: "discount",
@@ -84,7 +84,7 @@ RSpec.describe Spree::PromotionCode do
         })
       end
       context "when there are multiple line items" do
-        let(:order) { FactoryGirl.create(:order_with_line_items, line_items_count: 2) }
+        let(:order) { FactoryBot.create(:order_with_line_items, line_items_count: 2) }
         describe "the first item" do
           let(:promotable) { order.line_items.first }
           it_behaves_like "it should"
@@ -95,7 +95,7 @@ RSpec.describe Spree::PromotionCode do
         end
       end
       context "when there is a single line item" do
-        let(:order) { FactoryGirl.create(:order_with_line_items) }
+        let(:order) { FactoryBot.create(:order_with_line_items) }
         let(:promotable) { order.line_items.first }
         it_behaves_like "it should"
       end
@@ -104,7 +104,7 @@ RSpec.describe Spree::PromotionCode do
 
   describe "#usage_count" do
     let(:promotion) do
-      FactoryGirl.create(
+      FactoryBot.create(
         :promotion,
         :with_order_adjustment,
         code: "discount"
@@ -115,13 +115,13 @@ RSpec.describe Spree::PromotionCode do
     subject { code.usage_count }
 
     context "when the code is applied to a non-complete order" do
-      let(:order) { FactoryGirl.create(:order_with_line_items) }
+      let(:order) { FactoryBot.create(:order_with_line_items) }
       before { promotion.activate(order: order, promotion_code: code) }
       it { is_expected.to eq 0 }
     end
     context "when the code is applied to a complete order" do
       let!(:order) do
-        FactoryGirl.create(
+        FactoryBot.create(
           :completed_order_with_promotion,
           promotion: promotion
         )
@@ -138,7 +138,7 @@ RSpec.describe Spree::PromotionCode do
 
   describe "completing multiple orders with the same code", slow: true do
     let(:promotion) do
-      FactoryGirl.create(
+      FactoryBot.create(
         :promotion,
         :with_order_adjustment,
         code: "discount",
@@ -148,8 +148,8 @@ RSpec.describe Spree::PromotionCode do
     end
     let(:code) { promotion.codes.first }
     let(:order) do
-      FactoryGirl.create(:order_with_line_items, line_items_price: 40, shipment_cost: 0).tap do |order|
-        FactoryGirl.create(:payment, amount: 30, order: order)
+      FactoryBot.create(:order_with_line_items, line_items_price: 40, shipment_cost: 0).tap do |order|
+        FactoryBot.create(:payment, amount: 30, order: order)
         promotion.activate(order: order, promotion_code: code)
       end
     end
@@ -157,8 +157,8 @@ RSpec.describe Spree::PromotionCode do
     before do
       order.next! until order.can_complete?
 
-      FactoryGirl.create(:order_with_line_items, line_items_price: 40, shipment_cost: 0).tap do |order|
-        FactoryGirl.create(:payment, amount: 30, order: order)
+      FactoryBot.create(:order_with_line_items, line_items_price: 40, shipment_cost: 0).tap do |order|
+        FactoryBot.create(:payment, amount: 30, order: order)
         promotion.activate(order: order, promotion_code: code)
         order.next! until order.can_complete?
         order.complete!

--- a/core/spec/models/spree/promotion_handler/coupon_spec.rb
+++ b/core/spec/models/spree/promotion_handler/coupon_spec.rb
@@ -255,7 +255,7 @@ module Spree
             end
 
             context "when the promotion exceeds its usage limit" do
-              let!(:second_order) { FactoryGirl.create(:completed_order_with_promotion, promotion: promotion) }
+              let!(:second_order) { FactoryBot.create(:completed_order_with_promotion, promotion: promotion) }
 
               before do
                 promotion.update!(usage_limit: 1)

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -232,7 +232,7 @@ RSpec.describe Spree::Promotion, type: :model do
           let(:usage_limit) { 1 }
           context "on a different order" do
             before do
-              FactoryGirl.create(
+              FactoryBot.create(
                 :completed_order_with_promotion,
                 promotion: promotion
               )
@@ -253,7 +253,7 @@ RSpec.describe Spree::Promotion, type: :model do
 
     context "with an order-level adjustment" do
       let(:promotion) do
-        FactoryGirl.create(
+        FactoryBot.create(
           :promotion,
           :with_order_adjustment,
           code: "discount",
@@ -261,7 +261,7 @@ RSpec.describe Spree::Promotion, type: :model do
         )
       end
       let(:promotable) do
-        FactoryGirl.create(
+        FactoryBot.create(
           :completed_order_with_promotion,
           promotion: promotion
         )
@@ -271,7 +271,7 @@ RSpec.describe Spree::Promotion, type: :model do
 
     context "with an item-level adjustment" do
       let(:promotion) do
-        FactoryGirl.create(
+        FactoryBot.create(
           :promotion,
           :with_line_item_adjustment,
           code: "discount",
@@ -286,7 +286,7 @@ RSpec.describe Spree::Promotion, type: :model do
         })
       end
       context "when there are multiple line items" do
-        let(:order) { FactoryGirl.create(:order_with_line_items, line_items_count: 2) }
+        let(:order) { FactoryBot.create(:order_with_line_items, line_items_count: 2) }
         describe "the first item" do
           let(:promotable) { order.line_items.first }
           it_behaves_like "it should"
@@ -297,7 +297,7 @@ RSpec.describe Spree::Promotion, type: :model do
         end
       end
       context "when there is a single line item" do
-        let(:order) { FactoryGirl.create(:order_with_line_items) }
+        let(:order) { FactoryBot.create(:order_with_line_items) }
         let(:promotable) { order.line_items.first }
         it_behaves_like "it should"
       end
@@ -306,7 +306,7 @@ RSpec.describe Spree::Promotion, type: :model do
 
   describe "#usage_count" do
     let(:promotion) do
-      FactoryGirl.create(
+      FactoryBot.create(
         :promotion,
         :with_order_adjustment,
         code: "discount"
@@ -316,13 +316,13 @@ RSpec.describe Spree::Promotion, type: :model do
     subject { promotion.usage_count }
 
     context "when the code is applied to a non-complete order" do
-      let(:order) { FactoryGirl.create(:order_with_line_items) }
+      let(:order) { FactoryBot.create(:order_with_line_items) }
       before { promotion.activate(order: order, promotion_code: promotion.codes.first) }
       it { is_expected.to eq 0 }
     end
     context "when the code is applied to a complete order" do
       let!(:order) do
-        FactoryGirl.create(
+        FactoryBot.create(
           :completed_order_with_promotion,
           promotion: promotion
         )
@@ -487,11 +487,11 @@ RSpec.describe Spree::Promotion, type: :model do
     end
 
     context "when the promotion's usage limit is exceeded" do
-      let(:order) { FactoryGirl.create(:completed_order_with_promotion, promotion: promotion) }
-      let(:promotion) { FactoryGirl.create(:promotion, :with_order_adjustment) }
+      let(:order) { FactoryBot.create(:completed_order_with_promotion, promotion: promotion) }
+      let(:promotion) { FactoryBot.create(:promotion, :with_order_adjustment) }
 
       before do
-        FactoryGirl.create(
+        FactoryBot.create(
           :completed_order_with_promotion,
           promotion: promotion
         )
@@ -504,12 +504,12 @@ RSpec.describe Spree::Promotion, type: :model do
     end
 
     context "when the promotion code's usage limit is exceeded" do
-      let(:order) { FactoryGirl.create(:completed_order_with_promotion, promotion: promotion) }
+      let(:order) { FactoryBot.create(:completed_order_with_promotion, promotion: promotion) }
       let(:promotion) { create(:promotion, :with_order_adjustment, code: 'abc123', per_code_usage_limit: 1) }
       let(:promotion_code) { promotion.codes.first }
 
       before do
-        FactoryGirl.create(
+        FactoryBot.create(
           :completed_order_with_promotion,
           promotion: promotion
         )

--- a/core/spec/models/spree/tax_calculator/default_spec.rb
+++ b/core/spec/models/spree/tax_calculator/default_spec.rb
@@ -1,15 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe Spree::TaxCalculator::Default do
-  let(:shipping_address) { FactoryGirl.create(:address, state: new_york) }
-  let(:order) { FactoryGirl.create(:order, ship_address: shipping_address, state: "delivery") }
+  let(:shipping_address) { FactoryBot.create(:address, state: new_york) }
+  let(:order) { FactoryBot.create(:order, ship_address: shipping_address, state: "delivery") }
 
-  let(:new_york) { FactoryGirl.create(:state, state_code: "NY") }
-  let(:new_york_zone) { FactoryGirl.create(:zone, states: [new_york]) }
+  let(:new_york) { FactoryBot.create(:state, state_code: "NY") }
+  let(:new_york_zone) { FactoryBot.create(:zone, states: [new_york]) }
 
-  let(:books_category) { FactoryGirl.create(:tax_category, name: "Books") }
+  let(:books_category) { FactoryBot.create(:tax_category, name: "Books") }
   let!(:book_tax_rate) do
-    FactoryGirl.create(
+    FactoryBot.create(
       :tax_rate,
       name: "New York Sales Tax",
       tax_categories: [books_category],
@@ -20,7 +20,7 @@ RSpec.describe Spree::TaxCalculator::Default do
   end
 
   before do
-    book = FactoryGirl.create(
+    book = FactoryBot.create(
       :product,
       price: 20,
       name: "Book",

--- a/core/spec/models/spree/taxon_spec.rb
+++ b/core/spec/models/spree/taxon_spec.rb
@@ -4,14 +4,14 @@ require 'rails_helper'
 
 RSpec.describe Spree::Taxon, type: :model do
   describe '#to_param' do
-    let(:taxon) { FactoryGirl.build(:taxon, name: "Ruby on Rails") }
+    let(:taxon) { FactoryBot.build(:taxon, name: "Ruby on Rails") }
 
     subject { super().to_param }
     it { is_expected.to eql taxon.permalink }
   end
 
   context "set_permalink" do
-    let(:taxon) { FactoryGirl.build(:taxon, name: "Ruby on Rails") }
+    let(:taxon) { FactoryBot.build(:taxon, name: "Ruby on Rails") }
 
     it "should set permalink correctly when no parent present" do
       taxon.set_permalink
@@ -25,7 +25,7 @@ RSpec.describe Spree::Taxon, type: :model do
     end
 
     context "with parent taxon" do
-      let(:parent) { FactoryGirl.build(:taxon, permalink: "brands") }
+      let(:parent) { FactoryBot.build(:taxon, permalink: "brands") }
       before       { allow(taxon).to receive_messages parent: parent }
 
       it "should set permalink correctly when taxon has parent" do

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe Spree::Variant, type: :model do
   context "product has other variants" do
     describe "option value accessors" do
       before {
-        @multi_variant = FactoryGirl.create :variant, product: variant.product
+        @multi_variant = FactoryBot.create :variant, product: variant.product
         variant.product.reload
       }
 

--- a/core/spec/rails_helper.rb
+++ b/core/spec/rails_helper.rb
@@ -45,5 +45,5 @@ RSpec.configure do |config|
   end
 
   config.include ActiveJob::TestHelper
-  config.include FactoryGirl::Syntax::Methods
+  config.include FactoryBot::Syntax::Methods
 end

--- a/core/spec/support/concerns/default_price.rb
+++ b/core/spec/support/concerns/default_price.rb
@@ -1,6 +1,6 @@
 RSpec.shared_examples_for "default_price" do
   let(:model)        { described_class }
-  subject(:instance) { FactoryGirl.build(model.name.demodulize.downcase.to_sym) }
+  subject(:instance) { FactoryBot.build(model.name.demodulize.downcase.to_sym) }
 
   describe '.has_one :default_price' do
     let(:default_price_association) { model.reflect_on_association(:default_price) }

--- a/frontend/spec/controllers/spree/checkout_controller_spec.rb
+++ b/frontend/spec/controllers/spree/checkout_controller_spec.rb
@@ -3,10 +3,10 @@ require 'spec_helper'
 describe Spree::CheckoutController, type: :controller do
   let(:token) { 'some_token' }
   let(:user) { create(:user) }
-  let(:order) { FactoryGirl.create(:order_with_totals) }
+  let(:order) { FactoryBot.create(:order_with_totals) }
 
   let(:address_params) do
-    address = FactoryGirl.build(:address)
+    address = FactoryBot.build(:address)
     address.attributes.except("created_at", "updated_at")
   end
 
@@ -85,7 +85,7 @@ describe Spree::CheckoutController, type: :controller do
         # Must have *a* shipping method and a payment method so updating from address works
         allow(order).to receive_messages available_payment_methods: [stub_model(Spree::PaymentMethod)]
         allow(order).to receive_messages ensure_available_shipping_rates: true
-        order.line_items << FactoryGirl.create(:line_item)
+        order.line_items << FactoryBot.create(:line_item)
       end
 
       context "with the order in the cart state" do
@@ -306,7 +306,7 @@ describe Spree::CheckoutController, type: :controller do
 
     context "fails to transition from address" do
       let(:order) do
-        FactoryGirl.create(:order_with_line_items).tap do |order|
+        FactoryBot.create(:order_with_line_items).tap do |order|
           order.next!
           expect(order.state).to eq('address')
         end
@@ -348,13 +348,13 @@ describe Spree::CheckoutController, type: :controller do
 
     context "when GatewayError is raised" do
       let(:order) do
-        FactoryGirl.create(:order_with_line_items).tap do |order|
+        FactoryBot.create(:order_with_line_items).tap do |order|
           until order.state == 'payment'
             order.next!
           end
           # So that the confirmation step is skipped and we get straight to the action.
-          payment_method = FactoryGirl.create(:simple_credit_card_payment_method)
-          payment = FactoryGirl.create(:payment, payment_method: payment_method, amount: order.total)
+          payment_method = FactoryBot.create(:simple_credit_card_payment_method)
+          payment = FactoryBot.create(:payment, payment_method: payment_method, amount: order.total)
           order.payments << payment
           order.next!
         end

--- a/frontend/spec/controllers/spree/current_order_tracking_spec.rb
+++ b/frontend/spec/controllers/spree/current_order_tracking_spec.rb
@@ -10,7 +10,7 @@ describe 'current order tracking', type: :controller do
     end
   end
 
-  let(:order) { FactoryGirl.create(:order) }
+  let(:order) { FactoryBot.create(:order) }
 
   it 'automatically tracks who the order was created by & IP address' do
     allow(controller).to receive_messages(try_spree_current_user: user)

--- a/frontend/spec/controllers/spree/orders_controller_transitions_spec.rb
+++ b/frontend/spec/controllers/spree/orders_controller_transitions_spec.rb
@@ -22,7 +22,7 @@ module Spree
 
       it "correctly calls the transition callback" do
         expect(order.did_transition).to be_nil
-        order.line_items << FactoryGirl.create(:line_item)
+        order.line_items << FactoryBot.create(:line_item)
         put :update, params: { checkout: "checkout" }
         expect(order.did_transition).to be true
       end

--- a/frontend/spec/features/checkout_spec.rb
+++ b/frontend/spec/features/checkout_spec.rb
@@ -88,7 +88,7 @@ describe "Checkout", type: :feature, inaccessible: true do
       let!(:order) do
         order = Spree::Order.create!(
           email: "spree@example.com",
-          store: Spree::Store.first || FactoryGirl.create(:store)
+          store: Spree::Store.first || FactoryBot.create(:store)
         )
 
         order.reload
@@ -365,7 +365,7 @@ describe "Checkout", type: :feature, inaccessible: true do
 
   # regression for https://github.com/spree/spree/issues/2921
   context "goes back from payment to add another item", js: true do
-    let!(:store) { FactoryGirl.create(:store) }
+    let!(:store) { FactoryBot.create(:store) }
     let!(:bag) { create(:product, name: "RoR Bag") }
 
     it "transit nicely through checkout steps again" do

--- a/frontend/spec/features/products_spec.rb
+++ b/frontend/spec/features/products_spec.rb
@@ -253,7 +253,7 @@ describe "Visiting Products", type: :feature, inaccessible: true do
   end
 
   it "should be able to put a product without a description in the cart" do
-    product = FactoryGirl.create(:base_product, description: nil, name: 'Sample', price: '19.99')
+    product = FactoryBot.create(:base_product, description: nil, name: 'Sample', price: '19.99')
     visit spree.product_path(product)
     expect(page).to have_content "This product has no description"
     click_button 'add-to-cart-button'
@@ -261,7 +261,7 @@ describe "Visiting Products", type: :feature, inaccessible: true do
   end
 
   it "shouldn't be able to put a product without a current price in the cart" do
-    product = FactoryGirl.create(:base_product, description: nil, name: 'Sample', price: '19.99')
+    product = FactoryBot.create(:base_product, description: nil, name: 'Sample', price: '19.99')
     Spree::Config.currency = "CAN"
     Spree::Config.show_products_without_price = true
     visit spree.product_path(product)

--- a/frontend/spec/features/promotion_code_invalidation_spec.rb
+++ b/frontend/spec/features/promotion_code_invalidation_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.feature "Promotion Code Invalidation" do
   given!(:promotion) do
-    FactoryGirl.create(
+    FactoryBot.create(
       :promotion_with_item_adjustment,
       code: "PROMO",
       per_code_usage_limit: 1,
@@ -12,8 +12,8 @@ RSpec.feature "Promotion Code Invalidation" do
 
   background do
     create(:store)
-    FactoryGirl.create(:product, name: "DL-44")
-    FactoryGirl.create(:product, name: "E-11")
+    FactoryBot.create(:product, name: "DL-44")
+    FactoryBot.create(:product, name: "E-11")
 
     visit spree.root_path
     click_link "DL-44"

--- a/frontend/spec/features/quantity_promotions_spec.rb
+++ b/frontend/spec/features/quantity_promotions_spec.rb
@@ -8,13 +8,13 @@ RSpec.feature "Quantity Promotions" do
     )
   end
 
-  given(:promotion) { FactoryGirl.create(:promotion, code: "PROMO") }
-  given(:calculator) { FactoryGirl.create(:calculator, preferred_amount: 5) }
+  given(:promotion) { FactoryBot.create(:promotion, code: "PROMO") }
+  given(:calculator) { FactoryBot.create(:calculator, preferred_amount: 5) }
 
   background do
     create(:store)
-    FactoryGirl.create(:product, name: "DL-44")
-    FactoryGirl.create(:product, name: "E-11")
+    FactoryBot.create(:product, name: "DL-44")
+    FactoryBot.create(:product, name: "E-11")
     promotion.actions << action
 
     visit spree.root_path
@@ -95,7 +95,7 @@ RSpec.feature "Quantity Promotions" do
       )
     end
 
-    background { FactoryGirl.create(:product, name: "DC-15A") }
+    background { FactoryBot.create(:product, name: "DC-15A") }
 
     scenario "odd number of changes to quantities" do
       fill_in "order_line_items_attributes_0_quantity", with: 3

--- a/frontend/spec/spec_helper.rb
+++ b/frontend/spec/spec_helper.rb
@@ -109,7 +109,7 @@ RSpec.configure do |config|
     end
   end
 
-  config.include FactoryGirl::Syntax::Methods
+  config.include FactoryBot::Syntax::Methods
 
   config.include Spree::TestingSupport::Preferences
   config.include Spree::TestingSupport::UrlHelpers

--- a/frontend/spec/support/shared_contexts/custom_products.rb
+++ b/frontend/spec/support/shared_contexts/custom_products.rb
@@ -1,26 +1,26 @@
 shared_context "custom products" do
   before(:each) do
     create(:store)
-    taxonomy = FactoryGirl.create(:taxonomy, name: 'Categories')
+    taxonomy = FactoryBot.create(:taxonomy, name: 'Categories')
     root = taxonomy.root
-    clothing_taxon = FactoryGirl.create(:taxon, name: 'Clothing', parent_id: root.id)
-    bags_taxon = FactoryGirl.create(:taxon, name: 'Bags', parent_id: root.id)
-    mugs_taxon = FactoryGirl.create(:taxon, name: 'Mugs', parent_id: root.id)
+    clothing_taxon = FactoryBot.create(:taxon, name: 'Clothing', parent_id: root.id)
+    bags_taxon = FactoryBot.create(:taxon, name: 'Bags', parent_id: root.id)
+    mugs_taxon = FactoryBot.create(:taxon, name: 'Mugs', parent_id: root.id)
 
-    taxonomy = FactoryGirl.create(:taxonomy, name: 'Brands')
+    taxonomy = FactoryBot.create(:taxonomy, name: 'Brands')
     root = taxonomy.root
-    apache_taxon = FactoryGirl.create(:taxon, name: 'Apache', parent_id: root.id)
-    rails_taxon = FactoryGirl.create(:taxon, name: 'Ruby on Rails', parent_id: root.id)
-    ruby_taxon = FactoryGirl.create(:taxon, name: 'Ruby', parent_id: root.id)
+    apache_taxon = FactoryBot.create(:taxon, name: 'Apache', parent_id: root.id)
+    rails_taxon = FactoryBot.create(:taxon, name: 'Ruby on Rails', parent_id: root.id)
+    ruby_taxon = FactoryBot.create(:taxon, name: 'Ruby', parent_id: root.id)
 
-    FactoryGirl.create(:custom_product, name: 'Ruby on Rails Ringer T-Shirt', price: '19.99', taxons: [rails_taxon, clothing_taxon])
-    FactoryGirl.create(:custom_product, name: 'Ruby on Rails Mug', price: '15.99', taxons: [rails_taxon, mugs_taxon])
-    FactoryGirl.create(:custom_product, name: 'Ruby on Rails Tote', price: '15.99', taxons: [rails_taxon, bags_taxon])
-    FactoryGirl.create(:custom_product, name: 'Ruby on Rails Bag', price: '22.99', taxons: [rails_taxon, bags_taxon])
-    FactoryGirl.create(:custom_product, name: 'Ruby on Rails Baseball Jersey', price: '19.99', taxons: [rails_taxon, clothing_taxon])
-    FactoryGirl.create(:custom_product, name: 'Ruby on Rails Stein', price: '16.99', taxons: [rails_taxon, mugs_taxon])
-    FactoryGirl.create(:custom_product, name: 'Ruby on Rails Jr. Spaghetti', price: '19.99', taxons: [rails_taxon, clothing_taxon])
-    FactoryGirl.create(:custom_product, name: 'Ruby Baseball Jersey', price: '19.99', taxons: [ruby_taxon, clothing_taxon])
-    FactoryGirl.create(:custom_product, name: 'Apache Baseball Jersey', price: '19.99', taxons: [apache_taxon, clothing_taxon])
+    FactoryBot.create(:custom_product, name: 'Ruby on Rails Ringer T-Shirt', price: '19.99', taxons: [rails_taxon, clothing_taxon])
+    FactoryBot.create(:custom_product, name: 'Ruby on Rails Mug', price: '15.99', taxons: [rails_taxon, mugs_taxon])
+    FactoryBot.create(:custom_product, name: 'Ruby on Rails Tote', price: '15.99', taxons: [rails_taxon, bags_taxon])
+    FactoryBot.create(:custom_product, name: 'Ruby on Rails Bag', price: '22.99', taxons: [rails_taxon, bags_taxon])
+    FactoryBot.create(:custom_product, name: 'Ruby on Rails Baseball Jersey', price: '19.99', taxons: [rails_taxon, clothing_taxon])
+    FactoryBot.create(:custom_product, name: 'Ruby on Rails Stein', price: '16.99', taxons: [rails_taxon, mugs_taxon])
+    FactoryBot.create(:custom_product, name: 'Ruby on Rails Jr. Spaghetti', price: '19.99', taxons: [rails_taxon, clothing_taxon])
+    FactoryBot.create(:custom_product, name: 'Ruby Baseball Jersey', price: '19.99', taxons: [ruby_taxon, clothing_taxon])
+    FactoryBot.create(:custom_product, name: 'Apache Baseball Jersey', price: '19.99', taxons: [apache_taxon, clothing_taxon])
   end
 end

--- a/sample/spec/spec_helper.rb
+++ b/sample/spec/spec_helper.rb
@@ -32,7 +32,7 @@ RSpec.configure do |config|
   # instead of true.
   config.use_transactional_fixtures = false
 
-  config.include FactoryGirl::Syntax::Methods
+  config.include FactoryBot::Syntax::Methods
   config.fail_fast = ENV['FAIL_FAST'] || false
 
   config.example_status_persistence_file_path = "./spec/examples.txt"


### PR DESCRIPTION
FactoryGirl has been renamed to FactoryBot. This changes all occurences of
FactoryGirl to follow their new naming convention.

This also fixes our sample app builds.