### PR TITLE
Indent nested taxon menues and highlight the selected taxons.

### DIFF
--- a/frontend/app/assets/stylesheets/spree/frontend/screen.css.scss
+++ b/frontend/app/assets/stylesheets/spree/frontend/screen.css.scss
@@ -359,9 +359,14 @@ nav#taxonomies {
   }
 
   .taxons-list {
+    ul {
+      margin-left: 1em;
+    }
     li {
-      a {
-        font-size: $main_navigation_font_size
+      font-size: $main_navigation_font_size;
+      font-weight: normal;
+      &.current {
+        font-weight: bold;
       }
     }
   }


### PR DESCRIPTION
To see this in action you need:
* Create multiple nested taxons in the backend.
* `  config.max_level_in_taxons_menu = 3` in `config/initializers/spree.rb`
