### PR TITLE
Fixed caching of taxon menu.

### DIFF
--- a/frontend/app/views/spree/shared/_taxonomies.html.erb
+++ b/frontend/app/views/spree/shared/_taxonomies.html.erb
@@ -1,7 +1,7 @@
 <% max_level = Spree::Config[:max_level_in_taxons_menu] || 1 %>
 <nav id="taxonomies" class="sidebar-item" data-hook>
   <% @taxonomies.each do |taxonomy| %>
-    <% cache [I18n.locale, taxonomy, max_level] do %>
+    <% cache [I18n.locale, taxonomy, @taxon, max_level] do %>
       <h6 class='taxonomy-root'><%= Spree.t(:shop_by_taxonomy, taxonomy: taxonomy.name) %></h6>
       <%= taxons_tree(taxonomy.root, @taxon, max_level) %>
     <% end %>


### PR DESCRIPTION
The caching key have to include the selected taxon. This becomes apparent once the styling of pull request #2316 is merged.