### PR TITLE
Add `#gallery` to `Spree::Variant` and `Spree::Product`

### DIFF
--- a/api/app/views/spree/api/line_items/_line_item.json.jbuilder
+++ b/api/app/views/spree/api/line_items/_line_item.json.jbuilder
@@ -6,7 +6,7 @@ json.cache! [I18n.locale, line_item] do
   json.variant do
     json.partial!("spree/api/variants/small", variant: line_item.variant)
     json.(line_item.variant, :product_id)
-    json.images(line_item.variant.images) do |image|
+    json.images(line_item.variant.gallery) do |image|
       json.partial!("spree/api/images/image", image: image)
     end
   end

--- a/api/app/views/spree/api/shipments/_big.json.jbuilder
+++ b/api/app/views/spree/api/shipments/_big.json.jbuilder
@@ -12,7 +12,7 @@ json.cache! [I18n.locale, shipment] do
     json.variant do
       json.partial!("spree/api/variants/small", variant: inventory_unit.variant)
       json.(inventory_unit.variant, :product_id)
-      json.images(inventory_unit.variant.images) do |image|
+      json.images(inventory_unit.variant.gallery) do |image|
         json.partial!("spree/api/images/image", image: image)
       end
     end

--- a/api/app/views/spree/api/variants/_small.json.jbuilder
+++ b/api/app/views/spree/api/variants/_small.json.jbuilder
@@ -10,7 +10,7 @@ json.cache! [I18n.locale, variant] do
   json.option_values(variant.option_values) do |option_value|
     json.(option_value, *option_value_attributes)
   end
-  json.images(variant.images) do |image|
+  json.images(variant.gallery) do |image|
     json.partial!("spree/api/images/image", image: image)
   end
 end

--- a/backend/app/views/spree/admin/images/index.html.erb
+++ b/backend/app/views/spree/admin/images/index.html.erb
@@ -35,7 +35,7 @@
   <div id="progress-zone" class="row"></div>
 </fieldset>
 
-<% no_images = @product.images.empty? && @product.variant_images.empty? %>
+<% no_images = @product.gallery.empty? %>
 
 <table class="index sortable inline-editable-table <%= 'hidden' if no_images %>" id="images-table" data-hook="images_table" data-sortable-link="<%= update_positions_admin_product_images_url(@product) %>">
   <colgroup>
@@ -61,7 +61,7 @@
   </thead>
 
   <tbody>
-    <%= render partial: 'image_row', collection: @product.variant_images, as: :image %>
+    <%= render partial: 'image_row', collection: @product.gallery, as: :image %>
   </tbody>
 </table>
 

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -280,6 +280,19 @@ module Spree
       end
     end
 
+    # An enumerable of media that goes along with a product
+    # Stores may not necessarily want to attach images to products (variants)
+    # This provides a more robust interface
+    #
+    # @return [Enumerable] of media for a product (and its variants)
+    def gallery
+      if Product.method_defined?(:variant_images)
+        association(:variant_images).reader
+      else
+        []
+      end
+    end
+
     private
 
     def any_variants_not_track_inventory?

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -350,6 +350,15 @@ module Spree
       end.flatten.compact
     end
 
+    # An enumerable of media that goes along with a variant
+    # Stores may not necessarily want to attach images to variants
+    # This provides a more robust interface
+    #
+    # @return [Enumerable] of media for a variant
+    def gallery
+      Variant.reflect_on_association(:images) ? association(:images).reader : []
+    end
+
     private
 
     def rebuild_vat_prices?

--- a/core/spec/lib/search/base_spec.rb
+++ b/core/spec/lib/search/base_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Spree::Core::Search::Base do
 
     it "returns images in correct order" do
       expect(subject.first).to eq @product1
-      expect(subject.first.images).to eq @product1.master.images
+      expect(subject.first.images).to eq @product1.master.gallery
     end
   end
 

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Spree::Product, type: :model do
         expect(clone.name).to eq('COPY OF ' + product.name)
         expect(clone.master.sku).to eq('COPY OF ' + product.master.sku)
         expect(clone.taxons).to eq(product.taxons)
-        expect(clone.images.size).to eq(product.images.size)
+        expect(clone.gallery.size).to eq(product.gallery.size)
       end
 
       it 'calls #duplicate_extra' do
@@ -441,11 +441,11 @@ RSpec.describe Spree::Product, type: :model do
     end
 
     it "only looks for variant images" do
-      expect(product.images.size).to eq(2)
+      expect(product.gallery.size).to eq(2)
     end
 
     it "should be sorted by position" do
-      expect(product.images.pluck(:alt)).to eq(["position 1", "position 2"])
+      expect(product.gallery.pluck(:alt)).to eq(["position 1", "position 2"])
     end
   end
 

--- a/frontend/app/views/spree/orders/_line_item.html.erb
+++ b/frontend/app/views/spree/orders/_line_item.html.erb
@@ -2,7 +2,7 @@
 <%= order_form.fields_for :line_items, line_item do |item_form| -%>
   <tr class="<%= cycle('', 'alt') %> line-item">
     <td class="cart-item-image" data-hook="cart_item_image">
-      <% if variant.images.length == 0 %>
+      <% if variant.gallery.empty? %>
         <%= link_to(render('spree/shared/image', image: variant.product.display_image, size: :small), variant.product) %>
       <% else %>
         <%= link_to(render('spree/shared/image', image: variant.images.first, size: :small), variant.product) %>

--- a/frontend/app/views/spree/products/_thumbnails.html.erb
+++ b/frontend/app/views/spree/products/_thumbnails.html.erb
@@ -1,19 +1,10 @@
 <%# no need for thumbnails unless there is more than one image %>
-<% if (@product.images + @product.variant_images).uniq.size > 1 %>
+<% unless @product.gallery.empty? %>
   <ul id="product-thumbnails" class="thumbnails inline" data-hook>
-    <% @product.images.each do |i| %>
-      <li class='tmb-all tmb-<%= i.viewable.id %>'>
+    <% @product.gallery.each do |i| %>
+      <li class='<%= @product.has_variants? ? 'vtmb' : 'tmb-all' %> tmb-<%= i.viewable.id %>'>
         <%= link_to(image_tag(i.attachment.url(:mini)), i.attachment.url(:product)) %>
       </li>
-    <% end %>
-
-    <% if @product.has_variants? %>
-      <% @product.variant_images.each do |i| %>
-        <% next if @product.images.include?(i) %>
-        <li class='vtmb tmb-<%= i.viewable.id %>'>
-          <%= link_to(image_tag(i.attachment.url(:mini)), i.attachment.url(:product)) %>
-        </li>
-      <% end %>
     <% end %>
   </ul>
 <% end %>

--- a/frontend/app/views/spree/shared/_order_details.html.erb
+++ b/frontend/app/views/spree/shared/_order_details.html.erb
@@ -62,7 +62,7 @@
     <% order.line_items.each do |item| %>
       <tr data-hook="order_details_line_item_row">
         <td data-hook="order_item_image">
-          <% if item.variant.images.length == 0 %>
+          <% if item.variant.gallery.empty? %>
             <%= link_to(render('spree/shared/image', image: item.variant.product.display_image, size: :small), item.variant.product) %>
           <% else %>
             <%= link_to(render('spree/shared/image', image: item.variant.images.first, size: :small), item.variant.product) %>


### PR DESCRIPTION
This is a lightweight version of #625.

Related to #2324, I think this is a good starting point to begin opening up an interface for different image upload implementations.