### PR TITLE
Remove email_spec from the project

### DIFF
--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -22,7 +22,6 @@ group :test do
   gem 'capybara', '~> 2.7'
   gem 'capybara-screenshot'
   gem 'database_cleaner', '~> 1.3'
-  gem 'email_spec'
   gem 'factory_bot_rails', '~> 4.8'
   gem 'launchy'
   gem 'rspec-activemodel-mocks', '~>1.0.2'

--- a/core/spec/mailers/carton_mailer_spec.rb
+++ b/core/spec/mailers/carton_mailer_spec.rb
@@ -1,18 +1,14 @@
 require 'rails_helper'
-require 'email_spec'
 
 RSpec.describe Spree::CartonMailer do
-  include EmailSpec::Helpers
-  include EmailSpec::Matchers
-
   let(:carton) { create(:carton) }
   let(:order) { carton.orders.first }
 
   # Regression test for https://github.com/spree/spree/issues/2196
   it "doesn't include out of stock in the email body" do
     shipment_email = Spree::CartonMailer.shipped_email(order: order, carton: carton)
-    expect(shipment_email).not_to have_body_text(%{Out of Stock})
-    expect(shipment_email).to have_body_text(%{Your order has been shipped})
+    expect(shipment_email.parts.first.body).not_to include(%{Out of Stock})
+    expect(shipment_email.parts.first.body).to include(%{Your order has been shipped})
     expect(shipment_email.subject).to eq "#{order.store.name} Shipment Notification ##{order.number}"
   end
 
@@ -38,7 +34,7 @@ RSpec.describe Spree::CartonMailer do
 
         specify do
           shipped_email = Spree::CartonMailer.shipped_email(order: order, carton: carton)
-          expect(shipped_email).to have_body_text("Caro Cliente,")
+          expect(shipped_email.parts.first.body).to include("Caro Cliente,")
         end
       end
     end

--- a/core/spec/mailers/order_mailer_spec.rb
+++ b/core/spec/mailers/order_mailer_spec.rb
@@ -1,10 +1,6 @@
 require 'rails_helper'
-require 'email_spec'
 
 RSpec.describe Spree::OrderMailer, type: :mailer do
-  include EmailSpec::Helpers
-  include EmailSpec::Matchers
-
   let(:order) do
     order = create(:order)
     product = stub_model(Spree::Product, name: %{The "BEST" product})
@@ -65,15 +61,15 @@ RSpec.describe Spree::OrderMailer, type: :mailer do
     # Tests mailer view spree/order_mailer/confirm_email.text.erb
     specify do
       confirmation_email = Spree::OrderMailer.confirm_email(order)
-      expect(confirmation_email).to have_body_text("4.99")
-      expect(confirmation_email).to_not have_body_text("5.00")
+      expect(confirmation_email.parts.first.body).to include("4.99")
+      expect(confirmation_email.parts.first.body).to_not include("5.00")
     end
 
     # Tests mailer view spree/order_mailer/cancel_email.text.erb
     specify do
       cancel_email = Spree::OrderMailer.cancel_email(order)
-      expect(cancel_email).to have_body_text("4.99")
-      expect(cancel_email).to_not have_body_text("5.00")
+      expect(cancel_email.parts.first.body).to include("4.99")
+      expect(cancel_email.parts.first.body).to_not include("5.00")
     end
   end
 
@@ -96,14 +92,14 @@ RSpec.describe Spree::OrderMailer, type: :mailer do
       context "confirm_email" do
         specify do
           confirmation_email = Spree::OrderMailer.confirm_email(order)
-          expect(confirmation_email).to have_body_text("Caro Cliente,")
+          expect(confirmation_email.parts.first.body).to include("Caro Cliente,")
         end
       end
 
       context "cancel_email" do
         specify do
           cancel_email = Spree::OrderMailer.cancel_email(order)
-          expect(cancel_email).to have_body_text("Resumo da Pedido [CANCELADA]")
+          expect(cancel_email.parts.first.body).to include("Resumo da Pedido [CANCELADA]")
         end
       end
     end

--- a/core/spec/mailers/reimbursement_mailer_spec.rb
+++ b/core/spec/mailers/reimbursement_mailer_spec.rb
@@ -1,10 +1,6 @@
 require 'rails_helper'
-require 'email_spec'
 
 RSpec.describe Spree::ReimbursementMailer, type: :mailer do
-  include EmailSpec::Helpers
-  include EmailSpec::Matchers
-
   let(:reimbursement) { create(:reimbursement) }
 
   it "accepts a reimbursement id as an alternative to a Reimbursement object" do
@@ -30,7 +26,7 @@ RSpec.describe Spree::ReimbursementMailer, type: :mailer do
 
         specify do
           reimbursement_email = Spree::ReimbursementMailer.reimbursement_email(reimbursement)
-          expect(reimbursement_email).to have_body_text("Caro Cliente,")
+          expect(reimbursement_email.parts.first.body).to include("Caro Cliente,")
         end
       end
     end

--- a/core/spec/mailers/test_mailer_spec.rb
+++ b/core/spec/mailers/test_mailer_spec.rb
@@ -1,10 +1,6 @@
 require 'rails_helper'
-require 'email_spec'
 
 RSpec.describe Spree::TestMailer, type: :mailer do
-  include EmailSpec::Helpers
-  include EmailSpec::Matchers
-
   let(:user) { create(:user) }
 
   it "confirm_email accepts a user id as an alternative to a User object" do


### PR DESCRIPTION
I don't beleive its worth including as a dependency. have_body_text
isn't worth keeping the extra gem around when we can look at it so
easily ourselves.