### PR TITLE
Move checkout coupon code section into summary

### DIFF
--- a/frontend/app/assets/javascripts/spree/frontend/checkout/coupon-code.js
+++ b/frontend/app/assets/javascripts/spree/frontend/checkout/coupon-code.js
@@ -1,4 +1,5 @@
 Spree.onCouponCodeApply = function(e) {
+  e.preventDefault();
   var couponCodeField = $("#order_coupon_code");
   var couponCode = $.trim(couponCodeField.val());
   if (couponCode === "") {

--- a/frontend/app/assets/stylesheets/spree/frontend/screen.css.scss
+++ b/frontend/app/assets/stylesheets/spree/frontend/screen.css.scss
@@ -948,9 +948,35 @@ p[data-hook="use_billing"] {
   padding: 5px;
 }
 
+.coupon-code {
+  margin-top: 20px;
+  padding: 10px;
+
+  form {
+    display: flex;
+    flex-flow: row wrap;
+  }
+
+  label {
+    flex: 1 100%;
+    text-align: left;
+  }
+
+  input[type="text"] {
+    flex: 3 0;
+    width: 100%;
+    margin-right: 5px;
+  }
+
+  &-apply-button {
+    white-space: nowrap;
+  }
+}
+
 #coupon_status {
+  margin-top: 10px;
   font-weight: bold;
-  font-size: 125%;
+  font-size: 100%;
   &.success {
     color: $c_green;
   }

--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -173,12 +173,13 @@ module Spree
         handler = PromotionHandler::Coupon.new(@order).apply
 
         if handler.error.present?
-          setup_for_current_state
           flash.now[:error] = handler.error
-          respond_with(@order) { |format| format.html { render :edit } } && return
         elsif handler.success
           flash[:success] = handler.success
         end
+
+        setup_for_current_state
+        respond_with(@order) { |format| format.html { render :edit } } && return
       end
     end
 

--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -173,6 +173,7 @@ module Spree
         handler = PromotionHandler::Coupon.new(@order).apply
 
         if handler.error.present?
+          setup_for_current_state
           flash.now[:error] = handler.error
           respond_with(@order) { |format| format.html { render :edit } } && return
         elsif handler.success

--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -166,6 +166,21 @@ module Spree
       spree.order_path(@order)
     end
 
+    def apply_coupon_code
+      if params[:order] && params[:order][:coupon_code].present?
+        @order.coupon_code = params[:order][:coupon_code]
+
+        handler = PromotionHandler::Coupon.new(@order).apply
+
+        if handler.error.present?
+          flash.now[:error] = handler.error
+          respond_with(@order) { |format| format.html { render :edit } } && return
+        elsif handler.success
+          flash[:success] = handler.success
+        end
+      end
+    end
+
     def setup_for_current_state
       method_name = :"before_#{@order.state}"
       send(method_name) if respond_to?(method_name, true)

--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -167,8 +167,8 @@ module Spree
     end
 
     def apply_coupon_code
-      if params[:order] && params[:order][:coupon_code].present?
-        @order.coupon_code = params[:order][:coupon_code]
+      if update_params[:coupon_code].present?
+        @order.coupon_code = update_params[:coupon_code]
 
         handler = PromotionHandler::Coupon.new(@order).apply
 

--- a/frontend/app/controllers/spree/orders_controller.rb
+++ b/frontend/app/controllers/spree/orders_controller.rb
@@ -120,5 +120,20 @@ module Spree
         redirect_to(root_path) && return
       end
     end
+
+    def apply_coupon_code
+      if params[:order] && params[:order][:coupon_code].present?
+        @order.coupon_code = params[:order][:coupon_code]
+
+        handler = PromotionHandler::Coupon.new(@order).apply
+
+        if handler.error.present?
+          flash.now[:error] = handler.error
+          respond_with(@order) { |format| format.html { render :edit } } && return
+        elsif handler.success
+          flash[:success] = handler.success
+        end
+      end
+    end
   end
 end

--- a/frontend/app/controllers/spree/orders_controller.rb
+++ b/frontend/app/controllers/spree/orders_controller.rb
@@ -122,8 +122,8 @@ module Spree
     end
 
     def apply_coupon_code
-      if params[:order] && params[:order][:coupon_code].present?
-        @order.coupon_code = params[:order][:coupon_code]
+      if order_params[:coupon_code].present?
+        @order.coupon_code = order_params[:coupon_code]
 
         handler = PromotionHandler::Coupon.new(@order).apply
 

--- a/frontend/app/controllers/spree/store_controller.rb
+++ b/frontend/app/controllers/spree/store_controller.rb
@@ -16,24 +16,6 @@ module Spree
 
     private
 
-    # This method is placed here so that the CheckoutController
-    # and OrdersController can both reference it (or any other controller
-    # which needs it)
-    def apply_coupon_code
-      if params[:order] && params[:order][:coupon_code].present?
-        @order.coupon_code = params[:order][:coupon_code]
-
-        handler = PromotionHandler::Coupon.new(@order).apply
-
-        if handler.error.present?
-          flash.now[:error] = handler.error
-          respond_with(@order) { |format| format.html { render :edit } } && return
-        elsif handler.success
-          flash[:success] = handler.success
-        end
-      end
-    end
-
     def config_locale
       Spree::Frontend::Config[:locale]
     end

--- a/frontend/app/controllers/spree/store_controller.rb
+++ b/frontend/app/controllers/spree/store_controller.rb
@@ -20,7 +20,7 @@ module Spree
     # and OrdersController can both reference it (or any other controller
     # which needs it)
     def apply_coupon_code
-      if params[:order] && params[:order][:coupon_code]
+      if params[:order] && params[:order][:coupon_code].present?
         @order.coupon_code = params[:order][:coupon_code]
 
         handler = PromotionHandler::Coupon.new(@order).apply

--- a/frontend/app/views/spree/checkout/_coupon_code.html.erb
+++ b/frontend/app/views/spree/checkout/_coupon_code.html.erb
@@ -1,0 +1,12 @@
+<div class="coupon-code" data-hook='coupon_code'>
+  <%= form_for order, url: update_checkout_path(order.state) do |form| %>
+    <%= form.label :coupon_code %>
+    <%= form.text_field :coupon_code, placeholder: :coupon_code %>
+
+    <button type="submit" class="button coupon-code-apply-button" id="coupon-code-apply-button">
+      <%= t('spree.apply_code') %>
+    </button>
+  <% end %>
+
+  <div id='coupon_status'></div>
+</div>

--- a/frontend/app/views/spree/checkout/_payment.html.erb
+++ b/frontend/app/views/spree/checkout/_payment.html.erb
@@ -56,16 +56,6 @@
       <% end %>
     </ul>
     <br style="clear:both;" />
-    <p class='field' data-hook='coupon_code'>
-      <%= form.label :coupon_code %>
-      <%= form.text_field :coupon_code %>
-      <button type="button" class="button" id="coupon-code-apply-button">
-        <%= t('spree.apply_code') %>
-      </button>
-
-    </p>
-    <div id='coupon_status'></div>
-
   </div>
 </fieldset>
 

--- a/frontend/app/views/spree/checkout/_summary.html.erb
+++ b/frontend/app/views/spree/checkout/_summary.html.erb
@@ -70,3 +70,7 @@
     </tr>
   </tbody>
 </table>
+
+<% if order.state == 'payment' %>
+  <%= render 'coupon_code', order: order %>
+<% end %>

--- a/frontend/spec/controllers/spree/checkout_controller_spec.rb
+++ b/frontend/spec/controllers/spree/checkout_controller_spec.rb
@@ -485,6 +485,18 @@ describe Spree::CheckoutController, type: :controller do
 
     before { cookies.signed[:guest_token] = order.guest_token }
 
+    context "when coupon code is empty" do
+      let(:coupon_code) { "" }
+
+      it 'does not try to apply coupon code' do
+        expect(Spree::PromotionHandler::Coupon).not_to receive :new
+
+        put :update, params: { state: order.state, order: { coupon_code: coupon_code } }
+
+        expect(response).to redirect_to(spree.checkout_state_path('confirm'))
+      end
+    end
+
     context "when coupon code is applied" do
       let(:promotion_handler) { instance_double('Spree::PromotionHandler::Coupon', error: nil, success: 'Coupon Applied!') }
 

--- a/frontend/spec/controllers/spree/checkout_controller_spec.rb
+++ b/frontend/spec/controllers/spree/checkout_controller_spec.rb
@@ -514,6 +514,15 @@ describe Spree::CheckoutController, type: :controller do
       context "when coupon code is not applied" do
         let(:promotion_handler) { instance_double('Spree::PromotionHandler::Coupon', error: 'Some error', success: false) }
 
+        it "setups the current step correctly before rendering" do
+          expect(Spree::PromotionHandler::Coupon)
+            .to receive_message_chain(:new, :apply)
+            .and_return(promotion_handler)
+          expect(controller).to receive(:setup_for_current_state)
+
+          put :update, params: { state: order.state, order: { coupon_code: coupon_code } }
+        end
+
         it "render cart with coupon error" do
           expect(Spree::PromotionHandler::Coupon)
             .to receive_message_chain(:new, :apply)

--- a/frontend/spec/controllers/spree/checkout_controller_spec.rb
+++ b/frontend/spec/controllers/spree/checkout_controller_spec.rb
@@ -507,7 +507,7 @@ describe Spree::CheckoutController, type: :controller do
 
         put :update, params: { state: order.state, order: { coupon_code: coupon_code } }
 
-        expect(response).to redirect_to(spree.checkout_state_path('confirm'))
+        expect(response).to render_template :edit
         expect(flash.now[:success]).to eq('Coupon Applied!')
       end
 

--- a/frontend/spec/controllers/spree/orders_controller_spec.rb
+++ b/frontend/spec/controllers/spree/orders_controller_spec.rb
@@ -133,6 +133,18 @@ describe Spree::OrdersController, type: :controller do
           let(:order) { create(:order_with_line_items, state: 'cart') }
           let(:coupon_code) { "coupon_code" }
 
+          context "when coupon code is empty" do
+            let(:coupon_code) { "" }
+
+            it 'does not try to apply coupon code' do
+              expect(Spree::PromotionHandler::Coupon).not_to receive :new
+
+              put :update, params: { state: order.state, order: { coupon_code: coupon_code } }
+
+              expect(response).to redirect_to(spree.cart_path)
+            end
+          end
+
           context "when coupon code is applied" do
             let(:promotion_handler) { instance_double('Spree::PromotionHandler::Coupon', error: nil, success: 'Coupon Applied!') }
 

--- a/frontend/spec/controllers/spree/orders_controller_spec.rb
+++ b/frontend/spec/controllers/spree/orders_controller_spec.rb
@@ -128,6 +128,41 @@ describe Spree::OrdersController, type: :controller do
           put :update, params: { checkout: true }
           expect(response).to redirect_to checkout_state_path('address')
         end
+
+        context 'trying to apply a coupon code' do
+          let(:order) { create(:order_with_line_items, state: 'cart') }
+          let(:coupon_code) { "coupon_code" }
+
+          context "when coupon code is applied" do
+            let(:promotion_handler) { instance_double('Spree::PromotionHandler::Coupon', error: nil, success: 'Coupon Applied!') }
+
+            it "continues checkout flow normally" do
+              expect(Spree::PromotionHandler::Coupon)
+                .to receive_message_chain(:new, :apply)
+                .and_return(promotion_handler)
+
+              put :update, params: { state: order.state, order: { coupon_code: coupon_code } }
+
+              expect(response).to redirect_to(spree.cart_path)
+              expect(flash.now[:success]).to eq('Coupon Applied!')
+            end
+
+            context "when coupon code is not applied" do
+              let(:promotion_handler) { instance_double('Spree::PromotionHandler::Coupon', error: 'Some error', success: false) }
+
+              it "render cart with coupon error" do
+                expect(Spree::PromotionHandler::Coupon)
+                  .to receive_message_chain(:new, :apply)
+                  .and_return(promotion_handler)
+
+                put :update, params: { state: order.state, order: { coupon_code: coupon_code } }
+
+                expect(response).to render_template :edit
+                expect(flash.now[:error]).to eq('Some error')
+              end
+            end
+          end
+        end
       end
     end
 

--- a/frontend/spec/features/coupon_code_spec.rb
+++ b/frontend/spec/features/coupon_code_spec.rb
@@ -80,6 +80,45 @@ describe "Coupon code promotions", type: :feature, js: true do
           end
         end
       end
+
+      context 'as logged user' do
+        let!(:user) { create(:user, bill_address: create(:address), ship_address: create(:address)) }
+
+        before do
+          allow_any_instance_of(Spree::CheckoutController).to receive_messages(try_spree_current_user: user)
+          allow_any_instance_of(Spree::OrdersController).to receive_messages(try_spree_current_user: user)
+        end
+
+        context 'with saved credit card' do
+          let(:bogus) { create(:credit_card_payment_method) }
+          let!(:credit_card) do
+            create(:credit_card, user_id: user.id, payment_method: bogus, gateway_customer_profile_id: "BGS-WEFWF")
+          end
+
+          before do
+            user.wallet.add(credit_card)
+
+            visit spree.root_path
+            click_link "RoR Mug"
+            click_button "add-to-cart-button"
+            # To Cart
+            click_button "Checkout"
+            # To shipping method screen, address is auto-populated
+            # with user's saved addresses
+            click_button "Save and Continue"
+            # To payment screen
+            click_button "Save and Continue"
+          end
+
+          it "shows wallet payments on coupon code errors" do
+            fill_in "order_coupon_code", with: "coupon_codes_rule_man"
+            click_button "Save and Continue"
+
+            expect(page).to have_content("The coupon code you entered doesn't exist. Please try again.")
+            expect(page).to have_content("Use an existing card")
+          end
+        end
+      end
     end
 
     # CheckoutController

--- a/frontend/spec/features/coupon_code_spec.rb
+++ b/frontend/spec/features/coupon_code_spec.rb
@@ -59,23 +59,23 @@ describe "Coupon code promotions", type: :feature, js: true do
 
         it "informs about an invalid coupon code" do
           fill_in "order_coupon_code", with: "coupon_codes_rule_man"
-          click_button "Save and Continue"
+          click_button "Apply Code"
           expect(page).to have_content(I18n.t('spree.coupon_code_not_found'))
         end
 
         it "can enter an invalid coupon code, then a real one" do
           fill_in "order_coupon_code", with: "coupon_codes_rule_man"
-          click_button "Save and Continue"
+          click_button "Apply Code"
           expect(page).to have_content(I18n.t('spree.coupon_code_not_found'))
           fill_in "order_coupon_code", with: "onetwo"
-          click_button "Save and Continue"
+          click_button "Apply Code"
           expect(page).to have_content("Promotion (Onetwo)   -$10.00")
         end
 
         context "with a promotion" do
           it "applies a promotion to an order" do
             fill_in "order_coupon_code", with: "onetwo"
-            click_button "Save and Continue"
+            click_button "Apply Code"
             expect(page).to have_content("Promotion (Onetwo)   -$10.00")
           end
         end
@@ -112,7 +112,7 @@ describe "Coupon code promotions", type: :feature, js: true do
 
           it "shows wallet payments on coupon code errors" do
             fill_in "order_coupon_code", with: "coupon_codes_rule_man"
-            click_button "Save and Continue"
+            click_button "Apply Code"
 
             expect(page).to have_content("The coupon code you entered doesn't exist. Please try again.")
             expect(page).to have_content("Use an existing card")

--- a/frontend/spec/features/coupon_code_spec.rb
+++ b/frontend/spec/features/coupon_code_spec.rb
@@ -11,7 +11,7 @@ describe "Coupon code promotions", type: :feature, js: true do
   let!(:payment_method) { create(:check_payment_method) }
   let!(:product) { create(:product, name: "RoR Mug", price: 20) }
 
-  context "visitor makes checkout as guest without registration" do
+  context "visitor makes checkout" do
     def create_basic_coupon_promotion(code)
       promotion = create(
         :promotion,
@@ -34,49 +34,50 @@ describe "Coupon code promotions", type: :feature, js: true do
 
     let!(:promotion) { create_basic_coupon_promotion("onetwo") }
 
-    # OrdersController
     context "on the payment page" do
-      before do
-        visit spree.root_path
-        click_link "RoR Mug"
-        click_button "add-to-cart-button"
-        click_button "Checkout"
-        fill_in "order_email", with: "spree@example.com"
-        fill_in "First Name", with: "John"
-        fill_in "Last Name", with: "Smith"
-        fill_in "Street Address", with: "1 John Street"
-        fill_in "City", with: "City of John"
-        fill_in "Zip", with: "01337"
-        select country.name, from: "Country"
-        select state.name, from: "order[bill_address_attributes][state_id]"
-        fill_in "Phone", with: "555-555-5555"
+      context "as guest without registration" do
+        before do
+          visit spree.root_path
+          click_link "RoR Mug"
+          click_button "add-to-cart-button"
+          click_button "Checkout"
+          fill_in "order_email", with: "spree@example.com"
+          fill_in "First Name", with: "John"
+          fill_in "Last Name", with: "Smith"
+          fill_in "Street Address", with: "1 John Street"
+          fill_in "City", with: "City of John"
+          fill_in "Zip", with: "01337"
+          select country.name, from: "Country"
+          select state.name, from: "order[bill_address_attributes][state_id]"
+          fill_in "Phone", with: "555-555-5555"
 
-        # To shipping method screen
-        click_button "Save and Continue"
-        # To payment screen
-        click_button "Save and Continue"
-      end
+          # To shipping method screen
+          click_button "Save and Continue"
+          # To payment screen
+          click_button "Save and Continue"
+        end
 
-      it "informs about an invalid coupon code" do
-        fill_in "order_coupon_code", with: "coupon_codes_rule_man"
-        click_button "Save and Continue"
-        expect(page).to have_content(I18n.t('spree.coupon_code_not_found'))
-      end
+        it "informs about an invalid coupon code" do
+          fill_in "order_coupon_code", with: "coupon_codes_rule_man"
+          click_button "Save and Continue"
+          expect(page).to have_content(I18n.t('spree.coupon_code_not_found'))
+        end
 
-      it "can enter an invalid coupon code, then a real one" do
-        fill_in "order_coupon_code", with: "coupon_codes_rule_man"
-        click_button "Save and Continue"
-        expect(page).to have_content(I18n.t('spree.coupon_code_not_found'))
-        fill_in "order_coupon_code", with: "onetwo"
-        click_button "Save and Continue"
-        expect(page).to have_content("Promotion (Onetwo)   -$10.00")
-      end
-
-      context "with a promotion" do
-        it "applies a promotion to an order" do
+        it "can enter an invalid coupon code, then a real one" do
+          fill_in "order_coupon_code", with: "coupon_codes_rule_man"
+          click_button "Save and Continue"
+          expect(page).to have_content(I18n.t('spree.coupon_code_not_found'))
           fill_in "order_coupon_code", with: "onetwo"
           click_button "Save and Continue"
           expect(page).to have_content("Promotion (Onetwo)   -$10.00")
+        end
+
+        context "with a promotion" do
+          it "applies a promotion to an order" do
+            fill_in "order_coupon_code", with: "onetwo"
+            click_button "Save and Continue"
+            expect(page).to have_content("Promotion (Onetwo)   -$10.00")
+          end
         end
       end
     end


### PR DESCRIPTION
This change is needed if we want to stop passing from checkout controller to apply coupon codes.

At the moment we have several issues with this behavior:

- apply_coupon_code is defined into frontend store_controller. This potentially allows all controllers' actions to apply coupon code, just passing `[:order][:coupon_code]` along with other params. We don't want this anymore since those actions are designed to work for orders and checkout controllers only. See [`render :edit`](https://github.com/solidusio/solidus/blob/88f531a2f0568967c28de2ccf591ba5b066fbc2f/frontend/app/controllers/spree/store_controller.rb#L17-L33) for example, it could not work in all scenarios. To fix this issue I duplicated this method in both orders and checkout controllers, I think in this case duplication is not bad, since real shared logic is handled by `PromotionHandler::Coupon.new(@order).apply` and we'll need a different behavior in those controllers;
- #2155 : Checkout controller needs extra ivars setup before rendering, after coupon code is applied with errors. This is now fixed since we can add this setup into the checkout-specific code that applies coupon code.
- Coupon Code application UX is "strange". We have the coupon code field and submit button into the payment form. If we add an invalid code and submit the payment form with payment data, we'll lost all payment data we just added. If we add a valid coupon code and submit with ajaxy Apply Button behavior page will reload and we'll lost all payment data we just added. I think we need to make clear that those forms are separated so user would not fill  both of them uselessy. To improve UX I moved the coupon code form into the summary box. Also, I made the coupon code a real form, even if it is always submitted with JS, both for semantic and to have a real working  fallback if for some reason JS is not working.



In my plans next steps will be:

- Deprecate accepting `[:order][:coupon_code]` param in checkout controller. If this PR is merged we'll just have this behavior called as a fallback if for some reason JS is not working.
- Investigate if we can/makes sense to move the coupon code into a separate form also for the cart. I feel like it's not that terrible to have it in a single form there in terms on UX.
- If we want to deprecate, we'll need another fallback endpoint, so I was thinking about creating a separate controller that will only handle coupon code application, maybe also for the api. 