### PR TITLE
Remove render_404 from frontend

### DIFF
--- a/core/lib/spree/core/controller_helpers/common.rb
+++ b/core/lib/spree/core/controller_helpers/common.rb
@@ -41,13 +41,6 @@ module Spree
           current_store.seo_title
         end
 
-        def render_404(_exception = nil)
-          respond_to do |type|
-            type.html { render status: :not_found, file: "#{::Rails.root}/public/404", formats: [:html], layout: nil }
-            type.all  { render status: :not_found, nothing: true }
-          end
-        end
-
         private
 
         def set_user_language

--- a/frontend/app/controllers/spree/orders_controller.rb
+++ b/frontend/app/controllers/spree/orders_controller.rb
@@ -1,7 +1,6 @@
 module Spree
   class OrdersController < Spree::StoreController
     before_action :check_authorization
-    rescue_from ActiveRecord::RecordNotFound, with: :render_404
     helper 'spree/products', 'spree/orders'
 
     respond_to :html

--- a/frontend/app/controllers/spree/products_controller.rb
+++ b/frontend/app/controllers/spree/products_controller.rb
@@ -3,7 +3,6 @@ module Spree
     before_action :load_product, only: :show
     before_action :load_taxon, only: :index
 
-    rescue_from ActiveRecord::RecordNotFound, with: :render_404
     helper 'spree/taxons'
 
     respond_to :html

--- a/frontend/app/controllers/spree/taxons_controller.rb
+++ b/frontend/app/controllers/spree/taxons_controller.rb
@@ -1,6 +1,5 @@
 module Spree
   class TaxonsController < Spree::StoreController
-    rescue_from ActiveRecord::RecordNotFound, with: :render_404
     helper 'spree/products'
 
     respond_to :html

--- a/frontend/spec/controllers/spree/orders_controller_ability_spec.rb
+++ b/frontend/spec/controllers/spree/orders_controller_ability_spec.rb
@@ -8,6 +8,7 @@ module Spree
     let(:user) { create(:user) }
     let(:guest_user) { create(:user) }
     let(:order) { Spree::Order.create }
+    let(:variant) { create(:variant) }
 
     it 'should understand order routes with token' do
       expect(spree.token_order_path('R123456', 'ABCDEF')).to eq('/orders/R123456/token/ABCDEF')
@@ -25,11 +26,11 @@ module Spree
       context '#populate' do
         it 'should check if user is authorized for :edit' do
           expect(controller).to receive(:authorize!).with(:edit, order, token)
-          post :populate, params: { token: token }
+          post :populate, params: { variant_id: variant.id, token: token }
         end
         it "should check against the specified order" do
           expect(controller).to receive(:authorize!).with(:edit, specified_order, token)
-          post :populate, params: { id: specified_order.number, token: token }
+          post :populate, params: { id: specified_order.number, variant_id: variant.id, token: token }
         end
       end
 
@@ -95,8 +96,9 @@ module Spree
 
         context 'when no token present' do
           it 'should respond with 404' do
-            get :show, params: { id: 'R123' }
-            expect(response.code).to eq('404')
+            expect {
+              get :show, params: { id: 'R123' }
+            }.to raise_error(ActiveRecord::RecordNotFound)
           end
         end
       end

--- a/frontend/spec/controllers/spree/orders_controller_spec.rb
+++ b/frontend/spec/controllers/spree/orders_controller_spec.rb
@@ -16,7 +16,8 @@ describe Spree::OrdersController, type: :controller do
 
     context "#populate" do
       it "should create a new order when none specified" do
-        post :populate
+        post :populate, params: { variant_id: variant.id }
+        expect(response).to be_redirect
         expect(cookies.signed[:guest_token]).not_to be_blank
 
         order_by_token = Spree::Order.find_by(guest_token: cookies.signed[:guest_token])

--- a/frontend/spec/controllers/spree/products_controller_spec.rb
+++ b/frontend/spec/controllers/spree/products_controller_spec.rb
@@ -11,8 +11,9 @@ describe Spree::ProductsController, type: :controller do
   end
 
   it "cannot view non-active products" do
-    get :show, params: { id: product.to_param }
-    expect(response.status).to eq(404)
+    expect {
+      get :show, params: { id: product.to_param }
+    }.to raise_error(ActiveRecord::RecordNotFound)
   end
 
   it "should provide the current user to the searcher class" do


### PR DESCRIPTION
Extracted from #2281

Rails knows how to render a 404, so this is unnecessary and can hide errors.

Some users will have used this to override the behaviour. These users can either re-add the `rescue_from`s in their own app, or use Rails's `config.exception_app`.
