### PR TITLE
Remove FactoryBot from sample spec_helper

### DIFF
--- a/sample/spec/spec_helper.rb
+++ b/sample/spec/spec_helper.rb
@@ -32,7 +32,6 @@ RSpec.configure do |config|
   # instead of true.
   config.use_transactional_fixtures = false
 
-  config.include FactoryBot::Syntax::Methods
   config.fail_fast = ENV['FAIL_FAST'] || false
 
   config.example_status_persistence_file_path = "./spec/examples.txt"


### PR DESCRIPTION
We don't currently need factories to test the sample project, and I can't see any reason we ever would.