### PR TITLE
Finalize shipment after inventory units are added to completed order

### DIFF
--- a/core/app/models/spree/inventory_unit.rb
+++ b/core/app/models/spree/inventory_unit.rb
@@ -81,9 +81,17 @@ module Spree
 
     # Updates the given inventory units to not be pending.
     #
+    # @deprecated do not use this, use
+    #   Spree::Stock::InventoryUnitsFinalizer.new(inventory_units).run!
     # @param inventory_units [<Spree::InventoryUnit>] the inventory to be
     #   finalized
     def self.finalize_units!(inventory_units)
+      Spree::Deprecation.warn(
+        "inventory_units.finalize_units!(inventory_units) is deprecated. Please
+        use Spree::Stock::InventoryUnitsFinalizer.new(inventory_units).run!",
+        caller
+      )
+
       inventory_units.map do |iu|
         iu.update_columns(
           pending: false,

--- a/core/app/models/spree/order_inventory.rb
+++ b/core/app/models/spree/order_inventory.rb
@@ -60,18 +60,19 @@ module Spree
     end
 
     def add_to_shipment(shipment, quantity)
+      pending_units = []
       if variant.should_track_inventory?
         on_hand, back_order = shipment.stock_location.fill_status(variant, quantity)
 
-        on_hand.times { shipment.set_up_inventory('on_hand', variant, order, line_item) }
-        back_order.times { shipment.set_up_inventory('backordered', variant, order, line_item) }
+        on_hand.times { pending_units << shipment.set_up_inventory('on_hand', variant, order, line_item) }
+        back_order.times { pending_units << shipment.set_up_inventory('backordered', variant, order, line_item) }
       else
-        quantity.times { shipment.set_up_inventory('on_hand', variant, order, line_item) }
+        quantity.times { pending_units << shipment.set_up_inventory('on_hand', variant, order, line_item) }
       end
 
       # adding to this shipment, and removing from stock_location
       if order.completed?
-        shipment.stock_location.unstock(variant, quantity, shipment)
+        Spree::Stock::InventoryUnitsFinalizer.new(pending_units).run!
       end
 
       quantity

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -165,12 +165,7 @@ module Spree
     # Any previous non-pending inventory units are skipped as their stock had
     # already been allocated.
     def finalize!
-      transaction do
-        pending_units = inventory_units.select(&:pending?)
-        pending_manifest = Spree::ShippingManifest.new(inventory_units: pending_units)
-        pending_manifest.items.each { |item| manifest_unstock(item) }
-        Spree::InventoryUnit.finalize_units!(pending_units)
-      end
+      finalize_pending_inventory_units
     end
 
     def include?(variant)
@@ -394,6 +389,11 @@ module Spree
     end
 
     private
+
+    def finalize_pending_inventory_units
+      pending_units = inventory_units.select(&:pending?)
+      Spree::Stock::InventoryUnitsFinalizer.new(pending_units).run!
+    end
 
     def after_ship
       order.shipping.ship_shipment(self, suppress_mailer: suppress_mailer)

--- a/core/app/models/spree/stock/inventory_units_finalizer.rb
+++ b/core/app/models/spree/stock/inventory_units_finalizer.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Spree
+  module Stock
+    # Service class to finalize inventory units, it means unstock the desired
+    # quantity from related stock item and updates the given inventory units to
+    # not be pending.
+    class InventoryUnitsFinalizer
+      # @attr_reader [Spree::InventoryUnit] inventory_units to be finalized
+      attr_reader :inventory_units
+
+      # @param [Spree::InventoryUnit] inventory_units to be finalized
+      def initialize(inventory_units)
+        @inventory_units = inventory_units
+      end
+
+      # Finalize the inventory units, unstock and mark them as not pending.
+      def run!
+        Spree::InventoryUnit.transaction do
+          unstock_inventory_units
+          finalize_inventory_units
+        end
+      end
+
+      private
+
+      def finalize_inventory_units
+        inventory_units.map do |iu|
+          iu.update_columns(
+            pending: false,
+            updated_at: Time.current
+          )
+        end
+      end
+
+      def unstock_inventory_units
+        inventory_units.group_by(&:shipment_id).each_value do |inventory_units_for_shipment|
+          inventory_units_for_shipment.group_by(&:line_item_id).each_value do |units|
+            shipment = units.first.shipment
+            line_item = units.first.line_item
+            shipment.stock_location.unstock line_item.variant, inventory_units.count, shipment
+          end
+        end
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/inventory_unit_spec.rb
+++ b/core/spec/models/spree/inventory_unit_spec.rb
@@ -142,6 +142,7 @@ RSpec.describe Spree::InventoryUnit, type: :model do
     }
 
     it "should create a stock movement" do
+      expect(Spree::Deprecation).to receive(:warn)
       Spree::InventoryUnit.finalize_units!(inventory_units)
       expect(inventory_units.any?(&:pending)).to be false
     end

--- a/core/spec/models/spree/order_inventory_spec.rb
+++ b/core/spec/models/spree/order_inventory_spec.rb
@@ -35,12 +35,19 @@ RSpec.describe Spree::OrderInventory, type: :model do
     end
 
     context "order is not completed" do
-      before { order.update_columns completed_at: nil }
+      let(:inventory_unit_finalizer) { double(:inventory_unit_finalizer, run!: [true]) }
 
-      it "doesn't unstock items" do
-        expect {
-          subject.verify(shipment)
-        }.not_to change { stock_item.reload.count_on_hand }
+      before do
+        allow(Spree::Stock::InventoryUnitsFinalizer)
+          .to receive(:new).and_return(inventory_unit_finalizer)
+
+        order.update_columns completed_at: nil
+      end
+
+      it "doesn't finalize the items" do
+        expect(inventory_unit_finalizer).to_not receive(:run!)
+
+        subject.verify(shipment)
       end
     end
 

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -760,8 +760,12 @@ RSpec.describe Spree::Shipment, type: :model do
   describe "#finalize!" do
     let(:inventory_unit) { shipment.inventory_units.first }
     let(:stock_item) { inventory_unit.variant.stock_items.find_by(stock_location: stock_location) }
+    let(:inventory_unit_finalizer) { double(:inventory_unit_finalizer, run!: [true]) }
 
     before do
+      allow(Spree::Stock::InventoryUnitsFinalizer)
+        .to receive(:new).and_return(inventory_unit_finalizer)
+
       stock_item.set_count_on_hand(10)
       stock_item.update_attributes!(backorderable: false)
       inventory_unit.update_attributes!(pending: true)
@@ -769,18 +773,20 @@ RSpec.describe Spree::Shipment, type: :model do
 
     subject { shipment.finalize! }
 
-    it "updates the associated inventory units" do
-      inventory_unit.update_columns(updated_at: 1.hour.ago)
-      expect { subject }.to change { inventory_unit.reload.updated_at }
-    end
+    it "call run! on Spree::Stock::InventoryUnitsFinalizer" do
+      expect(inventory_unit_finalizer).to receive(:run!)
 
-    it "unstocks the variant" do
-      expect { subject }.to change { stock_item.reload.count_on_hand }.from(10).to(9)
+      subject
     end
 
     context "inventory unit already finalized" do
-      before do
-        inventory_unit.update_attributes!(pending: false)
+      let(:inventory_unit) { build(:inventory_unit, pending: false) }
+
+      it "doesn't pass the inventory unit" do
+        expect(Spree::Stock::InventoryUnitsFinalizer)
+          .to receive(:new).with([])
+
+        subject
       end
 
       it "doesn't update the associated inventory units" do

--- a/core/spec/models/spree/stock/inventory_units_finalizer_spec.rb
+++ b/core/spec/models/spree/stock/inventory_units_finalizer_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module Spree
+  module Stock
+    RSpec.describe InventoryUnitsFinalizer, type: :model do
+      let(:order)          { build(:order_with_line_items) }
+      let(:inventory_unit) { build(:inventory_unit, order: order, variant: order.line_items.first.variant, shipment: order.shipments.first) }
+      let(:stock_item) { inventory_unit.variant.stock_items.first }
+
+      before do
+        stock_item.set_count_on_hand(10)
+        stock_item.update_attributes!(backorderable: false)
+        inventory_unit.update_attributes!(pending: true)
+      end
+
+      subject { described_class.new([inventory_unit]).run! }
+
+      it "updates the associated inventory units" do
+        inventory_unit.update_columns(updated_at: 1.hour.ago)
+        expect { subject }.to change { inventory_unit.reload.updated_at }
+      end
+
+      it "updates the inventory units to not be pending" do
+        expect { subject }.to change { inventory_unit.reload.pending }.to(false)
+      end
+
+      it "unstocks the variant" do
+        expect { subject }.to change { stock_item.reload.count_on_hand }.from(10).to(9)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR is going to fix the issue https://github.com/solidusio/solidus/issues/2141 .

Create a new class Spree::Stock::InventoryUnitsFinalizer
to finalize the inventory units provided.
It unstocks the desired quantity and marks as not pending the inventory units processed.
To fix the issue we run it, both when a shipment is finalized and when a variant is added to a shipment in a completed order.