### PR TITLE
Explicitly define backend/promotions routes

### DIFF
--- a/backend/app/controllers/spree/admin/promotions_controller.rb
+++ b/backend/app/controllers/spree/admin/promotions_controller.rb
@@ -5,6 +5,10 @@ module Spree
 
       helper 'spree/promotion_rules'
 
+      def show
+        redirect_to action: :edit
+      end
+
       def create
         @promotion = Spree::Promotion.new(permitted_resource_params)
         @promotion.codes.new(value: params[:single_code]) if params[:single_code].present?

--- a/backend/spec/controllers/spree/admin/promotions_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/promotions_controller_spec.rb
@@ -7,6 +7,13 @@ describe Spree::Admin::PromotionsController, type: :controller do
   let!(:promotion2) { create(:promotion, name: "name2", code: "code2", path: "path2") }
   let!(:category) { create :promotion_category }
 
+  describe "#show" do
+    it "redirects to edit" do
+      expect(get(:show, params: { id: promotion1.id }))
+        .to redirect_to(action: :edit, id: promotion1.id )
+    end
+  end
+
   describe "#index" do
     it "succeeds" do
       get :index


### PR DESCRIPTION
Currently the `show` route is also include but it's never defined which leads to a
`AbstractController::ActionNotFound` being thrown in case someone reaches
that page