### PR TITLE
Improve translation missing strings visual

### DIFF
--- a/backend/app/views/spree/admin/shared/_head.html.erb
+++ b/backend/app/views/spree/admin/shared/_head.html.erb
@@ -26,13 +26,14 @@
   </style>
 <%- elsif Rails.env.development? %>
   <style>
-    .translation_missing { background: red; }
+    .translation_missing {
+      background: white;
+      color: #C60F13;
+    }
   </style>
 <%- end %>
 
-
 <%= javascript_include_tag 'spree/backend/all', data: {turbolinks_track: 'reload'} %>
-
 <%= render "spree/admin/shared/js_locale_data" %>
 
 <%= javascript_tag do -%>

--- a/backend/app/views/spree/admin/shared/_head.html.erb
+++ b/backend/app/views/spree/admin/shared/_head.html.erb
@@ -9,6 +9,7 @@
 <link href='//fonts.googleapis.com/css?family=Open+Sans:400italic,600italic,400,600&subset=latin,cyrillic,greek,vietnamese' rel='stylesheet' type='text/css'>
 
 <%= stylesheet_link_tag 'spree/backend/all', media: 'all', data: {turbolinks_track: 'reload'} %>
+<%= javascript_include_tag 'spree/backend/all', data: {turbolinks_track: 'reload'} %>
 
 <%- if Rails.env.test? %>
   <style>
@@ -31,9 +32,14 @@
       color: #C60F13;
     }
   </style>
+
+  <%= javascript_tag do %>
+    Spree.ready(function(){
+      $('.translation_missing').tooltip();
+    });
+  <% end %>
 <%- end %>
 
-<%= javascript_include_tag 'spree/backend/all', data: {turbolinks_track: 'reload'} %>
 <%= render "spree/admin/shared/js_locale_data" %>
 
 <%= javascript_tag do -%>


### PR DESCRIPTION
Text without translation is currently rendered with current element text color on a red background. This makes that text unreadable:

<img width="434" alt="schermata 2017-10-29 alle 17 17 31" src="https://user-images.githubusercontent.com/167946/32146317-c7494696-bcd5-11e7-8354-e03b22df2a0e.png">


Using our red color (#C60F13) as text color will improve readability. Also, a white background has been added if, for some reason, text is rendered over an element with red background, eg. flash errors.

<img width="388" alt="schermata 2017-10-29 alle 17 57 20" src="https://user-images.githubusercontent.com/167946/32146319-d00fedf2-bcd5-11e7-9746-85e1781ec824.png">

At almost no cost, I also added tooltips for those elements since they use element title as tooltip content:

<img width="407" alt="schermata 2017-10-29 alle 18 02 37" src="https://user-images.githubusercontent.com/167946/32146326-0f016b8a-bcd6-11e7-9805-d048e250ff29.png">


