### PR TITLE
Re-enable bootstrap tooltips animations

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/components/tooltips.js
+++ b/backend/app/assets/javascripts/spree/backend/components/tooltips.js
@@ -1,8 +1,7 @@
 Spree.ready(function(){
   $('body').popover({selector: '.hint-tooltip', html: true, trigger: 'hover', placement: 'top'});
 
-  /* Animation has to be off to work around a bug in bootstrap 4.0.0.alpha6 */
-  $('body').tooltip({selector: '.with-tip', animation: false});
+  $('body').tooltip({selector: '.with-tip'});
 
   /*
    * Poll tooltips to hide them if they are no longer being hovered.


### PR DESCRIPTION
This commit reverts a6837799131a2c9a3184c0bc0d281c870e74a96e. Issue described in that commit seems to be solved.

I know we don't need that animation but I think it's better to do not have that option set if is not needed anymore.