### PR TITLE
Remove useless before-highlight class from table lines

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/admin.js
+++ b/backend/app/assets/javascripts/spree/backend/admin.js
@@ -20,13 +20,11 @@ Spree.ready(function() {
     var tr = $(this).closest('tr');
     var klass = 'highlight action-' + $(this).data('action')
     tr.addClass(klass)
-    tr.prev().addClass('before-' + klass);
   });
   $('table').on("mouseleave", 'td.actions a, td.actions button', function(){
     var tr = $(this).closest('tr');
     var klass = 'highlight action-' + $(this).data('action')
     tr.removeClass(klass)
-    tr.prev().removeClass('before-' + klass);
   });
 });
 


### PR DESCRIPTION
Hovering tables actions some JS was adding extra classes on the previous line of the hovered line. There's no need for that class since we have no styles or behaviors related to it.

<img width="1425" alt="schermata 2017-10-29 alle 20 07 18" src="https://user-images.githubusercontent.com/167946/32147323-c49d21dc-bce5-11e7-90fc-ad69c567528a.png">

This comes from this [Spree PR](https://github.com/spree/spree/pull/2084/files) and it is a follow up of this [@tvdeyen commit](https://github.com/nebulab/solidus/commit/6c0a0553245d61758968f0be67c4fea92aa3624e#diff-10b448f18ba98e63b56de0de4ae4b834).