### PR TITLE
Fix action classes on admin tables

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/admin.js
+++ b/backend/app/assets/javascripts/spree/backend/admin.js
@@ -20,11 +20,19 @@ Spree.ready(function() {
     var tr = $(this).closest('tr');
     var klass = 'highlight action-' + $(this).data('action')
     tr.addClass(klass)
-  });
-  $('table').on("mouseleave", 'td.actions a, td.actions button', function(){
-    var tr = $(this).closest('tr');
-    var klass = 'highlight action-' + $(this).data('action')
-    tr.removeClass(klass)
+
+    var observer = new MutationObserver(function(mutations) {
+      tr.removeClass(klass);
+      this.disconnect();
+    });
+    observer.observe(tr.get(0), { childList: true });
+
+    // Using .one() instead of .on() prevents multiple callbacks to be attached
+    // to this event if mouseentered multiple times.
+    $(this).one("mouseleave", function() {
+      tr.removeClass(klass);
+      observer.disconnect();
+    });
   });
 });
 


### PR DESCRIPTION
Hovering on any tables actions link/button, for example into:

/admin/products/:slug/stock

will trigger [a JS code that adds a class to the closest row](https://github.com/solidusio/solidus/blob/3fe329d0b3862ccc9f0145e494bfd4e2b2af7a08/backend/app/assets/javascripts/spree/backend/admin.js#L17-L31
) (the row where that action link is):

<img width="1218" alt="before-click" src="https://user-images.githubusercontent.com/167946/32163005-226174c4-bd5b-11e7-877f-433ca2b403d1.png">

But when clicking on that link, a new template is rendered to show a new form that reflects the action needed. When this happens no `mouseleave` event is called on the link/button so it cannot restore the right state of the row.

<img width="1223" alt="edit" src="https://user-images.githubusercontent.com/167946/32163052-4db955e2-bd5b-11e7-81c5-3c880b0acc1e.png">

In this screenshot we can see there are 2 events classes (`action-edit` e `action-cancel`) but only the `action-cancel` class should be present.

The real UX issue happens clicking on the cancel button. The `action-cancel` class will remain on that div, even if we have done editing, this will change the stock form state color hovering for edit again:

<img width="1216" alt="after-click" src="https://user-images.githubusercontent.com/167946/32163214-e0a9546a-bd5b-11e7-9285-a562530f98d8.png">

This PR fixes this behavior by programmatically triggering `mouseleave` event each time we render the product stock template.

I feel like we have the same problem elsewhere but, before investigate further, I'd like to have some feedback on this solution since it seems a bit hacky to me. Unfortunately I cannot find a better one at the moment.


**EDIT**

At the end I've used [MutationObserver](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver) to understand when inner elements of the `tr` change (so when it is replaced with content of the new template rendered).

MutationObserver is pretty new. It's the first time I use it but it seems like it's [fully supported by browsers we should care for admin](https://caniuse.com/#feat=mutationobserver).
