### PR TITLE
Add `#gallery` to `Variant` and `Product`

### DIFF
--- a/api/app/views/spree/api/line_items/_line_item.json.jbuilder
+++ b/api/app/views/spree/api/line_items/_line_item.json.jbuilder
@@ -8,7 +8,7 @@ json.cache! [I18n.locale, line_item] do
   json.variant do
     json.partial!("spree/api/variants/small", variant: line_item.variant)
     json.(line_item.variant, :product_id)
-    json.images(line_item.variant.images) do |image|
+    json.images(line_item.variant.gallery.images) do |image|
       json.partial!("spree/api/images/image", image: image)
     end
   end

--- a/api/app/views/spree/api/shipments/_big.json.jbuilder
+++ b/api/app/views/spree/api/shipments/_big.json.jbuilder
@@ -14,7 +14,7 @@ json.cache! [I18n.locale, shipment] do
     json.variant do
       json.partial!("spree/api/variants/small", variant: inventory_unit.variant)
       json.(inventory_unit.variant, :product_id)
-      json.images(inventory_unit.variant.images) do |image|
+      json.images(inventory_unit.variant.gallery.images) do |image|
         json.partial!("spree/api/images/image", image: image)
       end
     end

--- a/api/app/views/spree/api/variants/_small.json.jbuilder
+++ b/api/app/views/spree/api/variants/_small.json.jbuilder
@@ -17,7 +17,7 @@ json.cache! [I18n.locale, variant] do
   json.option_values(variant.option_values) do |option_value|
     json.(option_value, *option_value_attributes)
   end
-  json.images(variant.images) do |image|
+  json.images(variant.gallery.images) do |image|
     json.partial!("spree/api/images/image", image: image)
   end
 end

--- a/backend/app/views/spree/admin/cancellations/index.html.erb
+++ b/backend/app/views/spree/admin/cancellations/index.html.erb
@@ -25,7 +25,9 @@
       <% @inventory_units.each do |inventory_unit| %>
         <tr class="inventory-unit">
           <td class="inventory-unit-image">
-            <%= render 'spree/admin/shared/image', image: inventory_unit.variant.display_image, size: :mini %>
+            <%= render 'spree/admin/shared/image',
+              image: (inventory_unit.variant.gallery.images.first || inventory_unit.variant.product.gallery.images.first),
+              size: :mini %>
           </td>
           <td class="inventory-unit-name">
             <%= inventory_unit.variant.product.name %><br><%= "(" + variant_options(inventory_unit.variant) + ")" unless inventory_unit.variant.option_values.empty? %>

--- a/backend/app/views/spree/admin/images/_image_row.html.erb
+++ b/backend/app/views/spree/admin/images/_image_row.html.erb
@@ -16,7 +16,7 @@
       title: image.alt,
       content: %{
         <div class='align-center'>
-          #{image_tag(image.attachment.url(:large))}
+          #{image_tag(image.url(:large))}
         </div>
       }.html_safe
     ) %>

--- a/backend/app/views/spree/admin/images/edit.html.erb
+++ b/backend/app/views/spree/admin/images/edit.html.erb
@@ -3,7 +3,7 @@
 <%= render partial: 'spree/shared/error_messages', locals: { target: @image } %>
 
 <% admin_breadcrumb(link_to plural_resource_name(Spree::Image), admin_product_images_path(@product)) %>
-<% admin_breadcrumb(@image.attachment_file_name) %>
+<% admin_breadcrumb(@image.filename) %>
 
 
 <% content_for :page_actions do %>
@@ -12,12 +12,12 @@
 
 <%= form_for [:admin, @product, @image], html: { multipart: true } do |f| %>
   <fieldset data-hook="edit_image">
-    <legend align="center"><%= @image.attachment_file_name%></legend>
+    <legend align="center"><%= @image.filename %></legend>
 
     <div class="row">
       <div data-hook="thumbnail" class="field col-2 align-center">
         <%= f.label t('spree.thumbnail') %><br>
-        <%= link_to image_tag(@image.attachment.url(:small)), @image.attachment.url(:product) %>
+        <%= link_to image_tag(@image.url(:small)), @image.url(:product) %>
       </div>
       <div class="col-10">
         <%= render partial: 'form', locals: { f: f } %>

--- a/backend/app/views/spree/admin/images/index.html.erb
+++ b/backend/app/views/spree/admin/images/index.html.erb
@@ -37,7 +37,7 @@
   <div id="progress-zone" class="row"></div>
 </fieldset>
 
-<% no_images = @product.images.empty? && @product.variant_images.empty? %>
+<% no_images = @product.gallery.images.empty? %>
 
 <table class="index sortable inline-editable-table <%= 'hidden' if no_images %>" id="images-table" data-hook="images_table" data-sortable-link="<%= update_positions_admin_product_images_url(@product) %>">
   <colgroup>
@@ -63,7 +63,7 @@
   </thead>
 
   <tbody>
-    <%= render partial: 'image_row', collection: @product.variant_images, as: :image %>
+    <%= render partial: 'image_row', collection: @product.gallery.images, as: :image %>
   </tbody>
 </table>
 

--- a/backend/app/views/spree/admin/orders/_carton_manifest.html.erb
+++ b/backend/app/views/spree/admin/orders/_carton_manifest.html.erb
@@ -1,7 +1,9 @@
 <% carton.manifest_for_order(order).each do |item| %>
   <tr class="stock-item" data-item-quantity="<%= item.quantity %>">
     <td class="item-image">
-      <%= render 'spree/admin/shared/image', image: item.variant.display_image, size: :mini %>
+      <%= render 'spree/admin/shared/image',
+        image: (item.variant.gallery.images.first || item.variant.product.gallery.images.first),
+        size: :mini %>
     </td>
     <td class="item-name">
       <%= link_to item.variant.product.name, edit_admin_product_path(item.variant.product) %><br><%= "(" + variant_options(item.variant) + ")" unless item.variant.option_values.empty? %>

--- a/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
@@ -4,7 +4,9 @@
       data-variant-id="<%= item.variant.id %>"
       >
     <td class="item-image align-center">
-      <%= render 'spree/admin/shared/image', image: item.variant.display_image, size: :mini %>
+      <%= render 'spree/admin/shared/image',
+        image: (item.variant.gallery.images.first || item.variant.product.gallery.images.first),
+        size: :mini %>
     </td>
     <td class="item-name">
       <%= link_to item.variant.product.name, edit_admin_product_path(item.variant.product) %><br><%= "(" + variant_options(item.variant) + ")" unless item.variant.option_values.empty? %>

--- a/backend/app/views/spree/admin/orders/confirm/_shipment_manifest.html.erb
+++ b/backend/app/views/spree/admin/orders/confirm/_shipment_manifest.html.erb
@@ -1,7 +1,9 @@
 <% shipment.manifest.each do |item| %>
   <tr class="stock-item" data-item-quantity="<%= item.quantity %>">
     <td class="item-image">
-      <%= render 'spree/admin/shared/image', image: item.variant.display_image, size: :mini %>
+      <%= render 'spree/admin/shared/image',
+        image: (item.variant.gallery.images.first || item.variant.product.gallery.images.first),
+        size: :mini %>
     </td>
     <td class="item-name">
       <%= item.variant.product.name %><br><%= "(" + variant_options(item.variant) + ")" unless item.variant.option_values.empty? %>

--- a/backend/app/views/spree/admin/products/index.html.erb
+++ b/backend/app/views/spree/admin/products/index.html.erb
@@ -74,7 +74,9 @@
       <% @collection.each do |product| %>
           <tr <%== "style='color: red;'" if product.deleted? %> id="<%= spree_dom_id product %>" data-hook="admin_products_index_rows">
             <td><%= product.sku %></td>
-            <td class="align-center"><%= render 'spree/admin/shared/image', image: product.display_image, size: :mini %></td>
+            <td class="align-center">
+              <%= render 'spree/admin/shared/image', image: product.gallery.images.first, size: :mini %>
+            </td>
             <td><%= link_to product.try(:name), edit_admin_product_path(product) %></td>
             <td class="align-right"><%= product.display_price.to_html %></td>
             <td class="actions" data-hook="admin_products_index_row_actions">

--- a/backend/app/views/spree/admin/shared/_image.html.erb
+++ b/backend/app/views/spree/admin/shared/_image.html.erb
@@ -1,7 +1,7 @@
 <% size ||= :mini %>
 
-<% if image && image.attachment? %>
-  <%= image_tag image.attachment(size) %>
+<% if image_url = image.try(:url, size) %>
+  <%= image_tag image_url %>
 <% else %>
   <span class="image-placeholder <%= size %>"></span>
 <% end %>

--- a/backend/app/views/spree/admin/stock_items/_stock_management.html.erb
+++ b/backend/app/views/spree/admin/stock_items/_stock_management.html.erb
@@ -28,7 +28,9 @@
         <td class="no-padding" rowspan="<%= row_count %>">
           <div class='variant-container'>
             <div class='variant-image'>
-              <%= render 'spree/admin/shared/image', image: variant.display_image(fallback: false), size: :small %>
+              <%= render 'spree/admin/shared/image',
+                image: variant.gallery.images.first,
+                size: :small %>
             </div>
             <div class='variant-details'>
               <table class='stock-variant-field-table'>

--- a/backend/app/views/spree/admin/users/items.html.erb
+++ b/backend/app/views/spree/admin/users/items.html.erb
@@ -41,7 +41,9 @@
             <tr class="stock-item" data-item-quantity="<%= item.quantity %>">
               <td class="order-completed-at"><%= l(order.completed_at.to_date) if order.completed_at %></td>
               <td class="item-image">
-                <%= render 'spree/admin/shared/image', image: item.variant.display_image, size: :mini %>
+                <%= render 'spree/admin/shared/image',
+                  image: (item.variant.gallery.images.first || item.variant.product.gallery.images.first),
+                  size: :mini %>
               </td>
               <td class="item-name">
                 <%= item.product.name %><br><%= "(" + variant_options(item.variant) + ")" unless item.variant.option_values.empty? %>

--- a/core/app/models/spree/gallery/product_gallery.rb
+++ b/core/app/models/spree/gallery/product_gallery.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Spree
+  module Gallery
+    class ProductGallery
+      def initialize(product)
+        @product = product
+      end
+
+      # A list of all images associated with this gallery
+      #
+      # @return [Enumerable<Spree::Image>] all images in the gallery
+      def images
+        @images ||= @product.variant_images
+      end
+    end
+  end
+end

--- a/core/app/models/spree/gallery/variant_gallery.rb
+++ b/core/app/models/spree/gallery/variant_gallery.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Spree
+  module Gallery
+    class VariantGallery
+      def initialize(variant)
+        @variant = variant
+      end
+
+      # A list of all images associated with this gallery
+      #
+      # @return [Enumerable<Spree::Image>] all images in the gallery
+      def images
+        @images ||= @variant.images
+      end
+    end
+  end
+end

--- a/core/app/models/spree/image.rb
+++ b/core/app/models/spree/image.rb
@@ -19,8 +19,10 @@ module Spree
     # we need to look at the write-queue for images which have not been saved yet
     after_post_process :find_dimensions, if: :valid?
 
-    # used by admin products autocomplete
     def mini_url
+      Spree::Deprecation.warn(
+        'Spree::Image#mini_url is DEPRECATED. Use Spree::Image#url(:mini) instead.'
+      )
       attachment.url(:mini, false)
     end
 

--- a/core/app/models/spree/image.rb
+++ b/core/app/models/spree/image.rb
@@ -24,6 +24,14 @@ module Spree
       attachment.url(:mini, false)
     end
 
+    def url(size)
+      attachment.url(size)
+    end
+
+    def filename
+      attachment_file_name
+    end
+
     def find_dimensions
       temporary = attachment.queued_for_write[:original]
       filename = temporary.path unless temporary.nil?

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -297,6 +297,7 @@ module Spree
     # variants. If all else fails, will return a new image object.
     # @return [Spree::Image] the image to display
     def display_image
+      Spree::Deprecation.warn('Spree::Product#display_image is DEPRECATED. Choose an image from Spree::Product#gallery instead.')
       images.first || variant_images.first || Spree::Image.new
     end
 

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -310,6 +310,14 @@ module Spree
       end
     end
 
+    # The gallery for the product, which represents all the images
+    # associated with it, including those on its variants
+    #
+    # @return [Spree::Gallery] the media for a variant
+    def gallery
+      @gallery ||= Spree::Config.product_gallery_class.new(self)
+    end
+
     private
 
     def any_variants_not_track_inventory?

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -381,6 +381,7 @@ module Spree
     #   not from this variant
     # @return [Spree::Image] the image to display
     def display_image(fallback: true)
+      Spree::Deprecation.warn('Spree::Variant#display_image is DEPRECATED. Choose an image from Spree::Variant#gallery instead')
       images.first || (fallback && product.variant_images.first) || Spree::Image.new
     end
 

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -394,6 +394,14 @@ module Spree
       end.flatten.compact
     end
 
+    # The gallery for the variant, which represents all the images
+    # associated with it
+    #
+    # @return [Spree::Gallery] the media for a variant
+    def gallery
+      @gallery ||= Spree::Config.variant_gallery_class.new(self)
+    end
+
     private
 
     def rebuild_vat_prices?

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -381,6 +381,20 @@ module Spree
     # returns a String
     class_name_attribute :taxon_url_parametizer_class, default: 'ActiveSupport::Inflector'
 
+    # Allows providing your own class for image galleries on Variants
+    #
+    # @!attribute [rw] variant_gallery_class
+    # @return [Class] a class that implements an `images` method and returns an
+    # Enumerable of images adhering to the present_image_class interface
+    class_name_attribute :variant_gallery_class, default: 'Spree::Gallery::VariantGallery'
+
+    # Allows providing your own class for image galleries on Products
+    #
+    # @!attribute [rw] product_gallery_class
+    # @return [Class] a class that implements an `images` method and returns an
+    # Enumerable of images adhering to the present_image_class interface
+    class_name_attribute :product_gallery_class, default: 'Spree::Gallery::ProductGallery'
+
     # Allows providing your own class instance for generating order numbers.
     #
     # @!attribute [rw] order_number_generator

--- a/core/lib/spree/testing_support/shared_examples/gallery.rb
+++ b/core/lib/spree/testing_support/shared_examples/gallery.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'a gallery' do
+  describe '#images' do
+    subject { gallery.images }
+
+    it { is_expected.to be_empty }
+
+    context 'there are images' do
+      include_context 'has multiple images'
+
+      it 'has the associated images' do
+        expect(subject.map { |picture| picture.id }).
+          to match_array([first_image.id, second_image.id])
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/gallery/product_gallery_spec.rb
+++ b/core/spec/models/spree/gallery/product_gallery_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'spree/testing_support/shared_examples/gallery'
+
+RSpec.describe Spree::Gallery::ProductGallery do
+  let(:gallery) { described_class.new(product) }
+  let(:product) { create(:product) }
+
+  shared_context 'has multiple images' do
+    let(:first_image) { build(:image) }
+    let(:second_image) { build(:image) }
+
+    before do
+      product.images << first_image
+      product.images << second_image
+    end
+  end
+
+  it_behaves_like 'a gallery'
+end

--- a/core/spec/models/spree/gallery/variant_gallery_spec.rb
+++ b/core/spec/models/spree/gallery/variant_gallery_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'spree/testing_support/shared_examples/gallery'
+
+RSpec.describe Spree::Gallery::VariantGallery do
+  let(:gallery) { described_class.new(variant) }
+  let(:variant) { Spree::Variant.new }
+
+  shared_context 'has multiple images' do
+    let(:first_image) { build(:image) }
+    let(:second_image) { build(:image) }
+
+    before do
+      variant.images << first_image
+      variant.images << second_image
+    end
+  end
+
+  it_behaves_like 'a gallery'
+end

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -572,4 +572,13 @@ RSpec.describe Spree::Product, type: :model do
       end
     end
   end
+
+  describe '#gallery' do
+    let(:product) { Spree::Product.new }
+    subject { product.gallery }
+
+    it 'responds to #images' do
+      expect(subject).to respond_to(:images)
+    end
+  end
 end

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -834,4 +834,13 @@ RSpec.describe Spree::Variant, type: :model do
       end
     end
   end
+
+  describe '#gallery' do
+    let(:product) { Spree::Variant.new }
+    subject { product.gallery }
+
+    it 'responds to #images' do
+      expect(subject).to respond_to(:images)
+    end
+  end
 end

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -788,30 +788,6 @@ RSpec.describe Spree::Variant, type: :model do
     end
   end
 
-  describe "#display_image" do
-    subject { variant.display_image }
-
-    context "variant has associated images" do
-      let(:attachment) { File.open(File.expand_path('../../fixtures/thinking-cat.jpg', __dir__)) }
-      let(:image_params) { { viewable_id: variant.id, viewable_type: 'Spree::Variant', attachment: attachment, alt: "position 1", position: 1 } }
-      let!(:first_image) { Spree::Image.create(image_params) }
-      let!(:second_image) { image_params.merge(alt: "position 2", position: 2) }
-
-      it "returns the first image" do
-        expect(subject).to eq first_image
-      end
-    end
-
-    context "variant does not have any associated images" do
-      it "returns an image" do
-        expect(subject).to be_a(Spree::Image)
-      end
-      it "returns unpersisted record" do
-        expect(subject).to be_new_record
-      end
-    end
-  end
-
   describe "#variant_properties" do
     let(:option_value_1) { create(:option_value) }
     let(:option_value_2) { create(:option_value) }

--- a/frontend/app/views/spree/checkout/_delivery.html.erb
+++ b/frontend/app/views/spree/checkout/_delivery.html.erb
@@ -27,7 +27,9 @@
               <% ship_form.object.manifest.each do |item| %>
                 <tr class="stock-item">
                   <td class="item-image">
-                    <%= render 'spree/shared/image', image: item.variant.display_image, size: :mini %>
+                    <%= render 'spree/shared/image',
+                      image: (item.variant.gallery.images.first || item.variant.product.gallery.images.first),
+                      size: :mini %>
                   </td>
                   <td class="item-name"><%= item.variant.name %></td>
                   <td class="item-qty"><%= item.quantity %></td>
@@ -75,7 +77,9 @@
               <% @differentiator.missing.each do |variant, quantity| %>
                 <tr class="stock-item">
                   <td class="item-image">
-                    <%= render 'spree/shared/image', image: variant.display_image, size: :mini %>
+                    <%= render 'spree/shared/image',
+                      image: (variant.gallery.images.first || variant.product.gallery.images.first),
+                      size: :mini %>
                   </td>
                   <td class="item-name"><%= variant.name %></td>
                   <td class="item-qty"><%= quantity %></td>

--- a/frontend/app/views/spree/orders/_line_item.html.erb
+++ b/frontend/app/views/spree/orders/_line_item.html.erb
@@ -2,11 +2,9 @@
 <%= order_form.fields_for :line_items, line_item do |item_form| -%>
   <tr class="<%= cycle('', 'alt') %> line-item">
     <td class="cart-item-image" data-hook="cart_item_image">
-      <% if variant.images.empty? %>
-        <%= link_to(render('spree/shared/image', image: variant.product.display_image, size: :small), variant.product) %>
-      <% else %>
-        <%= link_to(render('spree/shared/image', image: variant.images.first, size: :small), variant.product) %>
-      <% end %>
+      <%= link_to(render('spree/shared/image',
+                         image: (variant.gallery.images.first || variant.product.gallery.images.first),
+                         size: :small), variant.product) %>
     </td>
     <td class="cart-item-description" data-hook="cart_item_description">
       <h4><%= link_to line_item.name, product_path(variant.product) %></h4>

--- a/frontend/app/views/spree/products/_image.html.erb
+++ b/frontend/app/views/spree/products/_image.html.erb
@@ -1,5 +1,8 @@
 <% if defined?(image) && image %>
   <%= render 'spree/shared/image', image: image, size: :product, itemprop: "image" %>
 <% else %>
-  <%= render 'spree/shared/image', image: @product.display_image, size: :product, itemprop: "image" %>
+  <%= render 'spree/shared/image',
+    image: @product.gallery.images.first,
+    size: :product,
+    itemprop: "image" %>
 <% end %>

--- a/frontend/app/views/spree/products/_thumbnails.html.erb
+++ b/frontend/app/views/spree/products/_thumbnails.html.erb
@@ -1,17 +1,19 @@
 <%# no need for thumbnails unless there is more than one image %>
-<% if (@product.images + @product.variant_images).uniq.size > 1 %>
+<% if @product.gallery.images.size > 1 %>
   <ul id="product-thumbnails" class="thumbnails inline" data-hook>
-    <% @product.images.each do |i| %>
-      <li class='tmb-all tmb-<%= i.viewable.id %>'>
-        <%= link_to(image_tag(i.attachment.url(:mini)), i.attachment.url(:product)) %>
+
+    <% @product.gallery.images.each do |image| %>
+      <% next if image.viewable_id != @product.master.id %>
+      <li class='tmb-all tmb-<%= image.viewable_id %>'>
+        <%= link_to(image_tag(image.url(:mini)), image.url(:product)) %>
       </li>
     <% end %>
 
     <% if @product.has_variants? %>
-      <% @product.variant_images.each do |i| %>
-        <% next if @product.images.include?(i) %>
-        <li class='vtmb tmb-<%= i.viewable.id %>'>
-          <%= link_to(image_tag(i.attachment.url(:mini)), i.attachment.url(:product)) %>
+      <% @product.gallery.images.each do |image| %>
+        <% next if image.viewable_id == @product.master.id %>
+        <li class='vtmb tmb-<%= image.viewable_id %>'>
+          <%= link_to(image_tag(image.url(:mini)), image.url(:product)) %>
         </li>
       <% end %>
     <% end %>

--- a/frontend/app/views/spree/shared/_image.html.erb
+++ b/frontend/app/views/spree/shared/_image.html.erb
@@ -1,11 +1,11 @@
 <% size ||= :mini %>
 <% itemprop ||= nil %>
 
-<% if image && image.attachment? %>
-  <% if itemprop %>
-    <%= image_tag image.attachment(size), itemprop: itemprop %>
+<% if image_url = image.try(:url, size)  %>
+  <% if image_alt = image.try(:alt) %>
+    <%= image_tag image_url, alt: image_alt, itemprop: itemprop %>
   <% else %>
-    <%= image_tag image.attachment(size) %>
+    <%= image_tag image_url, itemprop: itemprop %>
   <% end %>
 <% else %>
   <span class="image-placeholder <%= size %>"></span>

--- a/frontend/app/views/spree/shared/_order_details.html.erb
+++ b/frontend/app/views/spree/shared/_order_details.html.erb
@@ -62,11 +62,9 @@
     <% order.line_items.each do |item| %>
       <tr data-hook="order_details_line_item_row">
         <td data-hook="order_item_image">
-          <% if item.variant.images.empty? %>
-            <%= link_to(render('spree/shared/image', image: item.variant.product.display_image, size: :small), item.variant.product) %>
-          <% else %>
-            <%= link_to(render('spree/shared/image', image: item.variant.images.first, size: :small), item.variant.product) %>
-          <% end %>
+          <%= link_to(render('spree/shared/image',
+                             image: (item.variant.gallery.images.first || item.variant.product.gallery.images.first),
+                             size: :small), item.variant.product) %>
         </td>
         <td data-hook="order_item_description">
           <h4><%= item.variant.product.name %></h4>

--- a/frontend/app/views/spree/shared/_products.html.erb
+++ b/frontend/app/views/spree/shared/_products.html.erb
@@ -28,7 +28,7 @@
       <li id="product_<%= product.id %>" class="columns three <%= cycle("alpha", "secondary", "", "omega secondary", name: "classes") %>" data-hook="products_list_item" itemscope itemtype="http://schema.org/Product">
         <% cache(@taxon.present? ? [I18n.locale, current_pricing_options, @taxon, product] : [I18n.locale, current_pricing_options, product]) do %>
           <div class="product-image">
-            <%= link_to(render('spree/shared/image', image: product.display_image, size: :small, itemprop: "image"), url, itemprop: 'url') %>
+            <%= link_to(render('spree/shared/image', image: product.gallery.images.first, size: :small, itemprop: "image"), url, itemprop: 'url') %>
           </div>
           <%= link_to truncate(product.name, length: 50), url, class: 'info', itemprop: "name", title: product.name %>
           <span itemprop="offers" itemscope itemtype="http://schema.org/Offer">


### PR DESCRIPTION
[Paperclip is deprecated](https://robots.thoughtbot.com/closing-the-trombone) and we need to remove it from stock Solidus.

In order to remove Paperclip properly we need to add extension points so that we can plug a different image uploading library (like Active Storage). Adding galleries to `Product` and `Variant` will give us more control over what we send to the view layer, and protect our core models from image implementation details.

To plug this interface a developer needs to create custom galleries for both `Variant` and `Product` and make sure that the `#images` method of those return a collection of images that respond to the new "presentational" image interface the frontend expects. This PR includes changes to `Spree::Image` which transitions it into a presentation role for Paperclip. Specifically, the presentational image interface that the view layer expects is:

```
id: int
url(:size): string
filename: string
viewable_id: int # the ID of the variant this is "attached" to
```

Before Paperclip can be extracted into its own extension properly we need this PR to be merged.

Much of the work around the the `Gallery` classes are heavily influenced by/verbatim the work Clarke did in #625. 