### PR TITLE
Really remove email_spec

### DIFF
--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -39,6 +39,4 @@ Gem::Specification.new do |s|
   s.add_dependency 'ransack', '~> 1.8'
   s.add_dependency 'state_machines-activerecord', '~> 0.4'
   s.add_dependency 'stringex', '~> 1.5.1'
-
-  s.add_development_dependency 'email_spec', '~> 1.6'
 end


### PR DESCRIPTION
We removed all references but it was still required as a development dependency by the gemspec.

Related to #2326