### PR TITLE
Remove ffaker

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -286,3 +286,6 @@ Metrics/PerceivedComplexity:
 
 Bundler/OrderedGems:
   Enabled: false
+
+Style/NumericLiterals:
+  Enabled: false

--- a/api/spec/spec_helper.rb
+++ b/api/spec/spec_helper.rb
@@ -19,7 +19,6 @@ require 'spree/testing_support/dummy_app'
 DummyApp::Migrations.auto_migrate
 
 require 'rspec/rails'
-require 'ffaker'
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -28,7 +28,6 @@ require 'rspec/rails'
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 
 require 'database_cleaner'
-require 'ffaker'
 require 'with_model'
 
 require 'spree/testing_support/authorization_helpers'

--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -32,7 +32,6 @@ group :test do
   gem 'with_model'
   gem 'rspec_junit_formatter'
   gem 'rails-controller-testing'
-  gem 'ffaker', require: false
   gem 'selenium-webdriver'
 end
 

--- a/core/lib/spree/testing_support/factories/address_factory.rb
+++ b/core/lib/spree/testing_support/factories/address_factory.rb
@@ -15,7 +15,7 @@ FactoryBot.define do
     address1 '10 Lovely Street'
     address2 'Northwest'
     city 'Herndon'
-    zipcode { FFaker::AddressUS.zip_code }
+    sequence(:zipcode, 10001) { |i| i.to_s }
     phone '555-555-0199'
     alternative_phone '555-555-0199'
 

--- a/core/lib/spree/testing_support/factories/promotion_code_factory.rb
+++ b/core/lib/spree/testing_support/factories/promotion_code_factory.rb
@@ -4,6 +4,6 @@ require 'spree/testing_support/factories/promotion_factory'
 FactoryBot.define do
   factory :promotion_code, class: 'Spree::PromotionCode' do
     promotion
-    value { generate(:random_code) }
+    sequence(:value) { |i| "code#{i}" }
   end
 end

--- a/core/lib/spree/testing_support/factories/tax_category_factory.rb
+++ b/core/lib/spree/testing_support/factories/tax_category_factory.rb
@@ -4,6 +4,5 @@ FactoryBot.define do
   factory :tax_category, class: 'Spree::TaxCategory' do
     name { "TaxCategory - #{rand(999_999)}" }
     tax_code { "TaxCode - #{rand(999_999)}" }
-    description { generate(:random_string) }
   end
 end

--- a/core/lib/spree/testing_support/factories/user_factory.rb
+++ b/core/lib/spree/testing_support/factories/user_factory.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
   end
 
   factory :user, class: Spree.user_class do
-    email { generate(:random_email) }
+    email { generate(:email) }
     login { email } if Spree.user_class.attribute_method? :login
     password 'secret'
     password_confirmation { password } if Spree.user_class.attribute_method? :password_confirmation

--- a/core/lib/spree/testing_support/factories/zone_factory.rb
+++ b/core/lib/spree/testing_support/factories/zone_factory.rb
@@ -13,7 +13,7 @@ FactoryBot.define do
   end
 
   factory :zone, class: 'Spree::Zone' do
-    name { generate(:random_string) }
+    sequence(:name) { |i| "Zone #{i}" }
 
     trait :with_country do
       countries { [create(:country)] }

--- a/core/lib/spree/testing_support/factories/zone_factory.rb
+++ b/core/lib/spree/testing_support/factories/zone_factory.rb
@@ -4,7 +4,6 @@ require 'spree/testing_support/factories/country_factory'
 FactoryBot.define do
   factory :global_zone, class: 'Spree::Zone' do
     name 'GlobalZone'
-    description { generate(:random_string) }
     zone_members do |proxy|
       zone = proxy.instance_eval { @instance }
       Spree::Country.all.map do |c|
@@ -15,7 +14,6 @@ FactoryBot.define do
 
   factory :zone, class: 'Spree::Zone' do
     name { generate(:random_string) }
-    description { generate(:random_string) }
 
     trait :with_country do
       countries { [create(:country)] }

--- a/core/lib/spree/testing_support/sequences.rb
+++ b/core/lib/spree/testing_support/sequences.rb
@@ -1,17 +1,6 @@
 require 'factory_bot'
 
-begin
-  require 'ffaker'
-rescue LoadError
-  abort "Solidus factories require FFaker. Please add `ffaker` to your `Gemfile`."
-end
-
 FactoryBot.define do
-  sequence(:random_code)        { FFaker::Lorem.characters(10) }
-  sequence(:random_description) { FFaker::Lorem.paragraphs(1 + Kernel.rand(5)).join("\n") }
-  sequence(:random_email)       { FFaker::Internet.email }
-  sequence(:random_string)      { FFaker::Lorem.sentence }
-
   sequence(:sku) { |n| "SKU-#{n}" }
   sequence(:email) { |n| "email#{n}@example.com" }
 end

--- a/core/lib/spree/testing_support/sequences.rb
+++ b/core/lib/spree/testing_support/sequences.rb
@@ -11,5 +11,7 @@ FactoryBot.define do
   sequence(:random_description) { FFaker::Lorem.paragraphs(1 + Kernel.rand(5)).join("\n") }
   sequence(:random_email)       { FFaker::Internet.email }
   sequence(:random_string)      { FFaker::Lorem.sentence }
+
   sequence(:sku) { |n| "SKU-#{n}" }
+  sequence(:email) { |n| "email#{n}@example.com" }
 end

--- a/core/spec/rails_helper.rb
+++ b/core/spec/rails_helper.rb
@@ -13,8 +13,6 @@ require 'timecop'
 
 Dir["./spec/support/**/*.rb"].sort.each { |f| require f }
 
-require 'ffaker'
-
 if ENV["CHECK_TRANSLATIONS"]
   require "spree/testing_support/i18n"
 end

--- a/frontend/spec/spec_helper.rb
+++ b/frontend/spec/spec_helper.rb
@@ -21,7 +21,6 @@ require 'spree/testing_support/dummy_app'
 DummyApp::Migrations.auto_migrate
 
 require 'rspec/rails'
-require 'ffaker'
 
 # Requires supporting files with custom matchers and macros, etc,
 # in ./support/ and its subdirectories.

--- a/sample/spec/spec_helper.rb
+++ b/sample/spec/spec_helper.rb
@@ -8,7 +8,6 @@ require 'spree/testing_support/dummy_app'
 DummyApp::Migrations.auto_migrate
 
 require 'rspec/rails'
-require 'ffaker'
 
 RSpec.configure do |config|
   config.color = true


### PR DESCRIPTION
We are no longer using ffaker for sample data as of #2163. So we might as well remove the dependency entirely.

The main advantage of ffaker is being able to create data that looks to a human to be somewhat real. This isn't necessary or even desirable for the factories used by our specs, which just need different data. FactoryBot's `sequence`s are totally adequate for these purposes.

This also removes a few "description" fields from factories of models where they were optional (factories should be creating minimal objects).