### PR TITLE
Change make_permalink behaviour

### DIFF
--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -256,7 +256,7 @@ describe "Order Details", type: :feature, js: true do
 
           context 'A shipment has shipped' do
             it 'should not show or let me back to the cart page, nor show the shipment edit buttons' do
-              order = create(:order, state: 'payment', number: "R100")
+              order = create(:order, state: 'payment')
               order.shipments.create!(stock_location_id: stock_location.id, state: 'shipped')
 
               visit spree.cart_admin_order_path(order)

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -131,7 +131,13 @@ module Spree
     validates :number, presence: true, uniqueness: { allow_blank: true }
     validates :store_id, presence: true
 
-    make_permalink field: :number
+    def self.find_by_param(value)
+      find_by number: value
+    end
+
+    def self.find_by_param!(value)
+      find_by! number: value
+    end
 
     delegate :update_totals, :persist_totals, to: :updater
     delegate :firstname, :lastname, to: :bill_address, prefix: true, allow_nil: true

--- a/core/lib/spree/core/permalinks.rb
+++ b/core/lib/spree/core/permalinks.rb
@@ -48,19 +48,17 @@ module Spree
       end
 
       def save_permalink(permalink_value = to_param)
-        with_lock do
-          permalink_value ||= generate_permalink
-          permalink_field = self.class.permalink_field
+        permalink_value ||= generate_permalink
+        permalink_field = self.class.permalink_field
 
-          loop do
-            other = self.class.where(permalink_field => permalink_value)
-            break unless other.exists?
+        loop do
+          other = self.class.where(permalink_field => permalink_value)
+          break unless other.exists?
 
-            # Try again with a new value
-            permalink_value = generate_permalink
-          end
-          write_attribute(permalink_field, permalink_value)
+          # Try again with a new value
+          permalink_value = generate_permalink
         end
+        write_attribute(permalink_field, permalink_value)
       end
     end
   end

--- a/core/lib/spree/core/permalinks.rb
+++ b/core/lib/spree/core/permalinks.rb
@@ -68,4 +68,3 @@ module Spree
 end
 
 ActiveRecord::Base.send :include, Spree::Core::Permalinks
-ActiveRecord::Relation.send :include, Spree::Core::Permalinks


### PR DESCRIPTION
The behaviour here wasn't what anyone wanted (fixing duplicate generated identifiers by appending `-1`, `-2`, etc) and had major performance issues (selecting orders `LIKE "R123123%"` inside of a lock).

This removes `make_permalink` from Order, which has its own number generator, which we should use exclusively.

This replaces the old `make_permalink` behaviour in favour of generating a brand new permalink if one already exists.

Thanks @jarednorman for discovering the performance issue.