### PR TITLE
Remove `Spree::OrderUpdater#round_money`

### DIFF
--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -200,10 +200,6 @@ module Spree
       end
     end
 
-    def round_money(n)
-      (n * 100).round / 100.0
-    end
-
     def update_item_promotions
       [*line_items, *shipments].each do |item|
         promotion_adjustments = item.adjustments.select(&:promotion?)


### PR DESCRIPTION
This method used to be called until 3 years ago when 5483c02 removed all
the references to it.

If this should be deprecated instead, please let me know and I'll make the changes.