### PR TITLE
Add a reference to solidus_cmd in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,8 @@ features to your store that are not (or not yet) part of the core project.
 
 A list can be found at [extensions.solidus.io](http://extensions.solidus.io/).
 
+If you want to write an extension for Solidus, you can use the [solidus\_cmd](https://www.github.com/solidusio/solidus_cmd.git) gem.
+
 Contributing
 ------------
 


### PR DESCRIPTION
Add a reference to solidus_cmd in README.
 I will add more details about how to write extensions in the README of that gem.