### PR TITLE
Use selenium_chrome_headless capybara driver name

### DIFF
--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -45,25 +45,15 @@ Capybara.exact = true
 
 require "selenium/webdriver"
 
-Capybara.register_driver :chrome do |app|
-  Capybara::Selenium::Driver.new(app, browser: :chrome)
+Capybara.register_driver :selenium_chrome_headless do |app|
+  browser_options = ::Selenium::WebDriver::Chrome::Options.new
+  browser_options.args << '--headless'
+  browser_options.args << '--disable-gpu'
+  browser_options.args << '--window-size=1440,1080'
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
 end
 
-Capybara.register_driver :chrome_headless do |app|
-  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-    chromeOptions: { args: %w(headless disable-gpu window-size=1440,1080) }
-  )
-
-  Capybara::Selenium::Driver.new app,
-    browser: :chrome,
-    desired_capabilities: capabilities
-end
-
-Capybara::Screenshot.register_driver(:chrome_headless) do |driver, path|
-  driver.browser.save_screenshot(path)
-end
-
-Capybara.javascript_driver = (ENV['CAPYBARA_DRIVER'] || :chrome_headless).to_sym
+Capybara.javascript_driver = (ENV['CAPYBARA_DRIVER'] || :selenium_chrome_headless).to_sym
 
 ActionView::Base.raise_on_missing_translations = true
 

--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -19,8 +19,8 @@ gem 'coffee-rails'
 gem 'sass-rails'
 
 group :test do
-  gem 'capybara', '~> 2.7'
-  gem 'capybara-screenshot'
+  gem 'capybara', '~> 2.15'
+  gem 'capybara-screenshot', '>= 1.0.18'
   gem 'database_cleaner', '~> 1.3'
   gem 'factory_bot_rails', '~> 4.8'
   gem 'launchy'


### PR DESCRIPTION
We still need to customize it for our desired window size, but this is the name capybara provides, and capybara-screenshot [now understands that name](https://github.com/mattheworiordan/capybara-screenshot/pull/219), so we should use it for consistency with other projects.