### PR TITLE
Use transactional fixtures in frontend and backend (take 2)

### DIFF
--- a/backend/spec/features/admin/orders/shipments_spec.rb
+++ b/backend/spec/features/admin/orders/shipments_spec.rb
@@ -39,7 +39,9 @@ describe "Shipments", type: :feature do
 
     it "can ship a completed order" do
       expect {
-        ship_shipment
+        perform_enqueued_jobs {
+          ship_shipment
+        }
       }.to change{ ActionMailer::Base.deliveries.count }.by(1)
     end
 
@@ -47,7 +49,9 @@ describe "Shipments", type: :feature do
       uncheck 'Send Mailer'
 
       expect {
-        ship_shipment
+        perform_enqueued_jobs {
+          ship_shipment
+        }
       }.not_to change{ ActionMailer::Base.deliveries.count }
     end
   end

--- a/backend/spec/features/admin/promotion_adjustments_spec.rb
+++ b/backend/spec/features/admin/promotion_adjustments_spec.rb
@@ -192,8 +192,11 @@ describe "Promotion Adjustments", type: :feature, js: true do
       choose "Multiple promotion codes"
       fill_in "Base code", with: "testing"
       fill_in "Number of codes", with: "10"
-      click_button "Create"
-      expect(page).to have_title("SAVE SAVE SAVE - Promotions")
+
+      perform_enqueued_jobs {
+        click_button "Create"
+        expect(page).to have_title("SAVE SAVE SAVE - Promotions")
+      }
 
       promotion = Spree::Promotion.find_by(name: "SAVE SAVE SAVE")
       expect(promotion.path).to be_nil

--- a/backend/spec/features/admin/promotion_adjustments_spec.rb
+++ b/backend/spec/features/admin/promotion_adjustments_spec.rb
@@ -5,18 +5,16 @@ describe "Promotion Adjustments", type: :feature, js: true do
 
   context "creating a new promotion", js: true do
     before(:each) do
-      visit spree.admin_path
-      click_link "Promotions"
-      click_link "New Promotion"
+      visit spree.new_admin_promotion_path
       expect(page).to have_title("New Promotion - Promotions")
     end
 
     it "should allow an admin to create a flat rate discount coupon promo" do
-      fill_in "Name", with: "Promotion"
+      fill_in "Name", with: "SAVE SAVE SAVE"
       fill_in "Promotion Code", with: "order"
 
       click_button "Create"
-      expect(page).to have_title("Promotion - Promotions")
+      expect(page).to have_title("SAVE SAVE SAVE - Promotions")
 
       select "Item total", from: "Add rule of type"
       within('#rule_fields') { click_button "Add" }
@@ -25,14 +23,15 @@ describe "Promotion Adjustments", type: :feature, js: true do
       within('#rule_fields') { click_button "Update" }
 
       select "Create whole-order adjustment", from: "Add action of type"
-      within('#action_fields') { click_button "Add" }
-      select "Flat Rate", from: "Base Calculator"
+      within('#action_fields') do
+        click_button "Add"
+        select "Flat Rate", from: "Base Calculator"
+        fill_in "Amount", with: 5
+      end
       within('#actions_container') { click_button "Update" }
+      expect(page).to have_text 'successfully updated'
 
-      within('.calculator-fields') { fill_in "Amount", with: 5 }
-      within('#actions_container') { click_button "Update" }
-
-      promotion = Spree::Promotion.find_by(name: "Promotion")
+      promotion = Spree::Promotion.find_by(name: "SAVE SAVE SAVE")
       expect(promotion.codes.first.value).to eq("order")
 
       first_rule = promotion.rules.first
@@ -47,21 +46,23 @@ describe "Promotion Adjustments", type: :feature, js: true do
     end
 
     it "should allow an admin to create a single user coupon promo with flat rate discount" do
-      fill_in "Name", with: "Promotion"
+      fill_in "Name", with: "SAVE SAVE SAVE"
       fill_in "promotion[usage_limit]", with: "1"
       fill_in "Promotion Code", with: "single_use"
 
       click_button "Create"
-      expect(page).to have_title("Promotion - Promotions")
+      expect(page).to have_title("SAVE SAVE SAVE - Promotions")
 
       select "Create whole-order adjustment", from: "Add action of type"
-      within('#action_fields') { click_button "Add" }
-      select "Flat Rate", from: "Base Calculator"
+      within('#action_fields') do
+        click_button "Add"
+        select "Flat Rate", from: "Base Calculator"
+        fill_in "Amount", with: "5"
+      end
       within('#actions_container') { click_button "Update" }
-      within('#action_fields') { fill_in "Amount", with: "5" }
-      within('#actions_container') { click_button "Update" }
+      expect(page).to have_text 'successfully updated'
 
-      promotion = Spree::Promotion.find_by(name: "Promotion")
+      promotion = Spree::Promotion.find_by(name: "SAVE SAVE SAVE")
       expect(promotion.usage_limit).to eq(1)
       expect(promotion.codes.first.value).to eq("single_use")
 
@@ -73,10 +74,10 @@ describe "Promotion Adjustments", type: :feature, js: true do
     end
 
     it "should allow an admin to create an automatic promo with flat percent discount" do
-      fill_in "Name", with: "Promotion"
+      fill_in "Name", with: "SAVE SAVE SAVE"
       choose "Apply to all orders"
       click_button "Create"
-      expect(page).to have_title("Promotion - Promotions")
+      expect(page).to have_title("SAVE SAVE SAVE - Promotions")
 
       select "Item total", from: "Add rule of type"
       within('#rule_fields') { click_button "Add" }
@@ -85,13 +86,15 @@ describe "Promotion Adjustments", type: :feature, js: true do
       within('#rule_fields') { click_button "Update" }
 
       select "Create whole-order adjustment", from: "Add action of type"
-      within('#action_fields') { click_button "Add" }
-      select "Flat Percent", from: "Base Calculator"
+      within('#action_fields') do
+        click_button "Add"
+        select "Flat Percent", from: "Base Calculator"
+        fill_in "Flat Percent", with: "10"
+      end
       within('#actions_container') { click_button "Update" }
-      within('.calculator-fields') { fill_in "Flat Percent", with: "10" }
-      within('#actions_container') { click_button "Update" }
+      expect(page).to have_text 'successfully updated'
 
-      promotion = Spree::Promotion.find_by(name: "Promotion")
+      promotion = Spree::Promotion.find_by(name: "SAVE SAVE SAVE")
       expect(promotion.codes.first).to be_nil
 
       first_rule = promotion.rules.first
@@ -108,10 +111,10 @@ describe "Promotion Adjustments", type: :feature, js: true do
     it "should allow an admin to create an product promo with percent per item discount" do
       create(:product, name: "RoR Mug")
 
-      fill_in "Name", with: "Promotion"
+      fill_in "Name", with: "SAVE SAVE SAVE"
       choose "Apply to all orders"
       click_button "Create"
-      expect(page).to have_title("Promotion - Promotions")
+      expect(page).to have_title("SAVE SAVE SAVE - Promotions")
 
       select "Product(s)", from: "Add rule of type"
       within("#rule_fields") { click_button "Add" }
@@ -119,13 +122,15 @@ describe "Promotion Adjustments", type: :feature, js: true do
       within('#rule_fields') { click_button "Update" }
 
       select "Create per-line-item adjustment", from: "Add action of type"
-      within('#action_fields') { click_button "Add" }
-      select "Percent Per Item", from: "Base Calculator"
+      within('#action_fields') do
+        click_button "Add"
+        select "Percent Per Item", from: "Base Calculator"
+        fill_in "Percent", with: "10"
+      end
       within('#actions_container') { click_button "Update" }
-      within('.calculator-fields') { fill_in "Percent", with: "10" }
-      within('#actions_container') { click_button "Update" }
+      expect(page).to have_text 'successfully updated'
 
-      promotion = Spree::Promotion.find_by(name: "Promotion")
+      promotion = Spree::Promotion.find_by(name: "SAVE SAVE SAVE")
       expect(promotion.codes.first).to be_nil
 
       first_rule = promotion.rules.first
@@ -140,10 +145,10 @@ describe "Promotion Adjustments", type: :feature, js: true do
     end
 
     it "should allow an admin to create an automatic promotion with free shipping (no code)" do
-      fill_in "Name", with: "Promotion"
+      fill_in "Name", with: "SAVE SAVE SAVE"
       choose "Apply to all orders"
       click_button "Create"
-      expect(page).to have_title("Promotion - Promotions")
+      expect(page).to have_title("SAVE SAVE SAVE - Promotions")
 
       select "Item total", from: "Add rule of type"
       within('#rule_fields') { click_button "Add" }
@@ -154,19 +159,19 @@ describe "Promotion Adjustments", type: :feature, js: true do
       within('#action_fields') { click_button "Add" }
       expect(page).to have_content('Makes all shipments for the order free')
 
-      promotion = Spree::Promotion.find_by(name: "Promotion")
+      promotion = Spree::Promotion.find_by(name: "SAVE SAVE SAVE")
       expect(promotion.codes).to be_empty
       expect(promotion.rules.first).to be_a(Spree::Promotion::Rules::ItemTotal)
       expect(promotion.actions.first).to be_a(Spree::Promotion::Actions::FreeShipping)
     end
 
     it "should allow an admin to create an automatic promotion" do
-      fill_in "Name", with: "Promotion"
+      fill_in "Name", with: "SAVE SAVE SAVE"
       choose "Apply to all orders"
       click_button "Create"
-      expect(page).to have_title("Promotion - Promotions")
+      expect(page).to have_title("SAVE SAVE SAVE - Promotions")
 
-      promotion = Spree::Promotion.find_by(name: "Promotion")
+      promotion = Spree::Promotion.find_by(name: "SAVE SAVE SAVE")
       expect(promotion).to be_apply_automatically
       expect(promotion.path).to be_nil
       expect(promotion.codes).to be_empty
@@ -174,13 +179,13 @@ describe "Promotion Adjustments", type: :feature, js: true do
     end
 
     it "should allow an admin to create a promo requiring a landing page to be visited" do
-      fill_in "Name", with: "Promotion"
+      fill_in "Name", with: "SAVE SAVE SAVE"
       choose "URL Path"
       fill_in "Path", with: "content/cvv"
       click_button "Create"
-      expect(page).to have_title("Promotion - Promotions")
+      expect(page).to have_title("SAVE SAVE SAVE - Promotions")
 
-      promotion = Spree::Promotion.find_by(name: "Promotion")
+      promotion = Spree::Promotion.find_by(name: "SAVE SAVE SAVE")
       expect(promotion.path).to eq("content/cvv")
       expect(promotion).not_to be_apply_automatically
       expect(promotion.codes).to be_empty
@@ -207,10 +212,10 @@ describe "Promotion Adjustments", type: :feature, js: true do
     end
 
     it "ceasing to be eligible for a promotion with item total rule then becoming eligible again" do
-      fill_in "Name", with: "Promotion"
+      fill_in "Name", with: "SAVE SAVE SAVE"
       choose "Apply to all orders"
       click_button "Create"
-      expect(page).to have_title("Promotion - Promotions")
+      expect(page).to have_title("SAVE SAVE SAVE - Promotions")
 
       select "Item total", from: "Add rule of type"
       within('#rule_fields') { click_button "Add" }
@@ -218,13 +223,15 @@ describe "Promotion Adjustments", type: :feature, js: true do
       within('#rule_fields') { click_button "Update" }
 
       select "Create whole-order adjustment", from: "Add action of type"
-      within('#action_fields') { click_button "Add" }
-      select "Flat Rate", from: "Base Calculator"
+      within('#action_fields') do
+        click_button "Add"
+        select "Flat Rate", from: "Base Calculator"
+        fill_in "Amount", with: "5"
+      end
       within('#actions_container') { click_button "Update" }
-      within('.calculator-fields') { fill_in "Amount", with: "5" }
-      within('#actions_container') { click_button "Update" }
+      expect(page).to have_text 'successfully updated'
 
-      promotion = Spree::Promotion.find_by(name: "Promotion")
+      promotion = Spree::Promotion.find_by(name: "SAVE SAVE SAVE")
 
       first_rule = promotion.rules.first
       expect(first_rule.class).to eq(Spree::Promotion::Rules::ItemTotal)

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -69,6 +69,8 @@ ActionView::Base.raise_on_missing_translations = true
 
 Capybara.default_max_wait_time = ENV['DEFAULT_MAX_WAIT_TIME'].to_f if ENV['DEFAULT_MAX_WAIT_TIME'].present?
 
+ActiveJob::Base.queue_adapter = :test
+
 RSpec.configure do |config|
   config.color = true
   config.infer_spec_type_from_file_location!
@@ -129,6 +131,7 @@ RSpec.configure do |config|
   end
 
   config.include FactoryBot::Syntax::Methods
+  config.include ActiveJob::TestHelper
 
   config.include Spree::TestingSupport::Preferences
   config.include Spree::TestingSupport::UrlHelpers

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -84,7 +84,7 @@ RSpec.configure do |config|
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, comment the following line or assign false
   # instead of true.
-  config.use_transactional_fixtures = false
+  config.use_transactional_fixtures = true
 
   config.before :suite do
     DatabaseCleaner.clean_with :truncation
@@ -99,25 +99,12 @@ RSpec.configure do |config|
     end
   end
 
-  config.prepend_before(:each) do
-    if RSpec.current_example.metadata[:js]
-      DatabaseCleaner.strategy = :truncation
-    else
-      DatabaseCleaner.strategy = :transaction
-    end
-    DatabaseCleaner.start
-  end
-
   config.before do
     Rails.cache.clear
     reset_spree_preferences
     if RSpec.current_example.metadata[:js] && page.driver.browser.respond_to?(:url_blacklist)
       page.driver.browser.url_blacklist = ['http://fonts.googleapis.com']
     end
-  end
-
-  config.append_after(:each) do
-    DatabaseCleaner.clean
   end
 
   config.include BaseFeatureHelper, type: :feature

--- a/frontend/spec/spec_helper.rb
+++ b/frontend/spec/spec_helper.rb
@@ -51,6 +51,8 @@ end
 
 Capybara.default_max_wait_time = ENV['DEFAULT_MAX_WAIT_TIME'].to_f if ENV['DEFAULT_MAX_WAIT_TIME'].present?
 
+ActiveJob::Base.queue_adapter = :test
+
 RSpec.configure do |config|
   config.color = true
   config.infer_spec_type_from_file_location!

--- a/frontend/spec/spec_helper.rb
+++ b/frontend/spec/spec_helper.rb
@@ -68,7 +68,7 @@ RSpec.configure do |config|
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, comment the following line or assign false
   # instead of true.
-  config.use_transactional_fixtures = false
+  config.use_transactional_fixtures = true
 
   if ENV['WEBDRIVER'] == 'accessible'
     config.around(:each, inaccessible: true) do |example|
@@ -85,15 +85,7 @@ RSpec.configure do |config|
     reset_spree_preferences
     if RSpec.current_example.metadata[:js]
       page.driver.browser.url_blacklist = ['http://fonts.googleapis.com']
-      DatabaseCleaner.strategy = :truncation
-    else
-      DatabaseCleaner.strategy = :transaction
     end
-    DatabaseCleaner.start
-  end
-
-  config.after(:each) do
-    DatabaseCleaner.clean
   end
 
   config.after(:each, type: :feature) do |example|


### PR DESCRIPTION
A second attempt at #2320. Now with fewer deadlocks!

I believe the issue last time was that frontend also needed to switch to `queue_adapter = :test`. Now all of our projects run with this setting (I probably should have done this to begin with).