### PR TITLE
Improve selected_shipping_rate_id=

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -238,8 +238,11 @@ module Spree
         ArgumentError,
         "Could not find shipping rate id #{id} for shipment #{number}"
       ) unless new_rate
-      selected_shipping_rate.update!(selected: false) if selected_shipping_rate
-      new_rate.update!(selected: true)
+
+      transaction do
+        selected_shipping_rate.update!(selected: false) if selected_shipping_rate
+        new_rate.update!(selected: true)
+      end
     end
 
     # Determines the appropriate +state+ according to the following logic:

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -232,6 +232,7 @@ module Spree
     end
 
     def selected_shipping_rate_id=(id)
+      return if selected_shipping_rate_id == id
       selected_shipping_rate.update(selected: false) if selected_shipping_rate
       new_rate = shipping_rates.detect { |rate| rate.id == id.to_i }
       fail(

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -240,7 +240,6 @@ module Spree
       ) unless new_rate
       selected_shipping_rate.update!(selected: false) if selected_shipping_rate
       new_rate.update!(selected: true)
-      save!
     end
 
     # Determines the appropriate +state+ according to the following logic:

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -233,13 +233,13 @@ module Spree
 
     def selected_shipping_rate_id=(id)
       return if selected_shipping_rate_id == id
-      selected_shipping_rate.update(selected: false) if selected_shipping_rate
       new_rate = shipping_rates.detect { |rate| rate.id == id.to_i }
       fail(
         ArgumentError,
         "Could not find shipping rate id #{id} for shipment #{number}"
       ) unless new_rate
-      new_rate.update(selected: true)
+      selected_shipping_rate.update!(selected: false) if selected_shipping_rate
+      new_rate.update!(selected: true)
       save!
     end
 

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -808,6 +808,14 @@ RSpec.describe Spree::Shipment, type: :model do
     let!(:air_shipping_method) { create(:shipping_method, name: "Air") }
     let(:new_rate) { shipment.shipping_rates.create!(shipping_method: air_shipping_method) }
 
+    context 'selecting the same id' do
+      it 'keeps the same shipping rate selected' do
+        expect {
+          shipment.selected_shipping_rate_id = shipping_rate.id
+        }.not_to change { shipping_rate.selected }.from(true)
+      end
+    end
+
     context 'when the id exists' do
       it 'sets the new shipping rate as selected' do
         expect {

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -835,6 +835,9 @@ RSpec.describe Spree::Shipment, type: :model do
         expect {
           shipment.selected_shipping_rate_id = -1
         }.to raise_error(ArgumentError)
+
+        # Should not change selection
+        expect(shipping_rate.reload).to be_selected
       end
     end
   end


### PR DESCRIPTION
Some somewhat minor changes to `Shipment#selected_shipping_rate_id=`

* Fixes an issue where if `selected_shipping_rate_id=` was passed a bad id, the shipment would have no shipping rate selected. (It will now keep the previous selection)
* Use `update!` instead of `update`, so that exceptions are raised on any errors
* Wrap the two shipping rate updates in a transaction so that any update errors will be rolled back together
* Remove an unnecessary `save!`, all modifications are made on other records.
* Avoid preforming any updates if we re-assign the already selected rate