### PR TITLE
Fix issue loading select2 locale for es-MX

### DIFF
--- a/backend/vendor/assets/javascripts/solidus_admin/select2_locales/select2_locale_es-MX.js
+++ b/backend/vendor/assets/javascripts/solidus_admin/select2_locales/select2_locale_es-MX.js
@@ -1,0 +1,19 @@
+/**
+ * Select2 MX Spanish translation
+ */
+(function ($) {
+    "use strict";
+
+    $.fn.select2.locales['es-MX'] = {
+      formatMatches: function (matches) { if (matches === 1) { return "Un resultado disponible, presione enter para seleccionarlo."; } return matches + " resultados disponibles, use las teclas de dirección para navegar."; },
+        formatNoMatches: function () { return "No se encontraron resultados"; },
+        formatInputTooShort: function (input, min) { var n = min - input.length; return "Por favor, introduzca " + n + " car" + (n == 1? "ácter" : "acteres"); },
+        formatInputTooLong: function (input, max) { var n = input.length - max; return "Por favor, elimine " + n + " car" + (n == 1? "ácter" : "acteres"); },
+        formatSelectionTooBig: function (limit) { return "Sólo puede seleccionar " + limit + " elemento" + (limit == 1 ? "" : "s"); },
+        formatLoadMore: function (pageNumber) { return "Cargando más resultados…"; },
+        formatSearching: function () { return "Buscando…"; },
+        formatAjaxError: function() { return "La carga a fallado"; }
+    };
+
+    $.extend($.fn.select2.defaults, $.fn.select2.locales['es-MX']);
+})(jQuery);


### PR DESCRIPTION
Fix issue loading `es-MX` locale

```
ActionView::Template::Error (The asset "solidus_admin/select2_locales/select2_locale_es-MX.js" is not present in the asset pipeline.):
    43: </script>
    44:
    45: <% if I18n.locale != :en %>
    46:   <%= javascript_include_tag "solidus_admin/select2_locales/select2_locale_#{I18n.locale}" %>
    47: <% end %>
```