### PR TITLE
Allow loading solidus_core without Sprockets

### DIFF
--- a/core/config/initializers/assets.rb
+++ b/core/config/initializers/assets.rb
@@ -1,1 +1,3 @@
-Rails.application.config.assets.precompile << 'solidus_core_manifest.js'
+if Rails.application.config.respond_to?(:assets)
+  Rails.application.config.assets.precompile << 'solidus_core_manifest.js'
+end

--- a/core/lib/spree/testing_support/dummy_app.rb
+++ b/core/lib/spree/testing_support/dummy_app.rb
@@ -73,8 +73,10 @@ module DummyApp
 
     config.action_controller.include_all_helpers = false
 
-    config.assets.paths << File.expand_path('../dummy_app/assets/javascripts', __FILE__)
-    config.assets.paths << File.expand_path('../dummy_app/assets/stylesheets', __FILE__)
+    if config.respond_to?(:assets)
+      config.assets.paths << File.expand_path('../dummy_app/assets/javascripts', __FILE__)
+      config.assets.paths << File.expand_path('../dummy_app/assets/stylesheets', __FILE__)
+    end
 
     config.paths["config/database"] = File.expand_path('../dummy_app/database.yml', __FILE__)
     config.paths['app/views'] = File.expand_path('../dummy_app/views', __FILE__)


### PR DESCRIPTION
Sprockets isn't a dependency of `solidus_core` (and it shouldn't be), but our initializer errors if it isn't available.

This fixes it by only configuring sprockets if it is available.