### PR TITLE
Declare test dependencies explicitly in gemspecs

### DIFF
--- a/api/solidus_api.gemspec
+++ b/api/solidus_api.gemspec
@@ -24,4 +24,14 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'responders'
   gem.add_dependency 'jbuilder', '~> 2.6'
   gem.add_dependency 'kaminari', '>= 0.17', '< 2.0'
+
+  gem.add_development_dependency 'timecop'
+  gem.add_development_dependency 'database_cleaner', '~> 1.3'
+  gem.add_development_dependency 'factory_bot', '~> 4.8'
+  gem.add_development_dependency 'rails-controller-testing'
+  gem.add_development_dependency 'rspec-activemodel-mocks', '~> 1.0.2'
+  gem.add_development_dependency 'rspec-rails', '~> 3.6.0'
+  gem.add_development_dependency 'rspec_junit_formatter'
+  gem.add_development_dependency 'simplecov'
+  gem.add_development_dependency 'with_model'
 end

--- a/api/spec/requests/spree/api/shipments_controller_spec.rb
+++ b/api/spec/requests/spree/api/shipments_controller_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'timecop'
 
 describe Spree::Api::ShipmentsController, type: :request do
   let!(:shipment) { create(:shipment, inventory_units: [build(:inventory_unit, shipment: nil)]) }

--- a/api/spec/spec_helper.rb
+++ b/api/spec/spec_helper.rb
@@ -18,11 +18,16 @@ ENV["LIB_NAME"] = 'solidus_api'
 require 'spree/testing_support/dummy_app'
 DummyApp::Migrations.auto_migrate
 
+require 'rails-controller-testing'
 require 'rspec/rails'
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
 Dir[File.dirname(__FILE__) + "/support/**/*.rb"].each { |f| require f }
+
+require 'with_model'
+require 'database_cleaner'
+require 'rspec-activemodel-mocks'
 
 require 'spree/testing_support/factories'
 require 'spree/testing_support/preferences'

--- a/backend/solidus_backend.gemspec
+++ b/backend/solidus_backend.gemspec
@@ -34,4 +34,16 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'handlebars_assets', '~> 0.23'
   s.add_dependency 'autoprefixer-rails', '~> 7.1'
+
+  s.add_development_dependency 'capybara', '~> 2.15'
+  s.add_development_dependency 'capybara-screenshot', '>= 1.0.18'
+  s.add_development_dependency 'database_cleaner', '~> 1.3'
+  s.add_development_dependency 'factory_bot', '~> 4.8'
+  s.add_development_dependency 'rails-controller-testing'
+  s.add_development_dependency 'rspec-activemodel-mocks', '~> 1.0.2'
+  s.add_development_dependency 'rspec-rails', '~> 3.6.0'
+  s.add_development_dependency 'rspec_junit_formatter'
+  s.add_development_dependency 'selenium-webdriver'
+  s.add_development_dependency 'simplecov'
+  s.add_development_dependency 'with_model'
 end

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -29,6 +29,7 @@ Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 
 require 'database_cleaner'
 require 'with_model'
+require 'rspec-activemodel-mocks'
 
 require 'spree/testing_support/authorization_helpers'
 require 'spree/testing_support/factories'

--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -18,7 +18,6 @@ end
 group :test, :development do
   gem 'rubocop'
   gem 'pry'
-  gem 'listen', '~> 3.1.5'
 
   platforms :mri do
     gem 'byebug'

--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -15,26 +15,6 @@ platforms :jruby do
   gem 'activerecord-jdbcsqlite3-adapter'
 end
 
-gem 'coffee-rails'
-gem 'sass-rails'
-
-group :test do
-  gem 'capybara', '~> 2.15'
-  gem 'capybara-screenshot', '>= 1.0.18'
-  gem 'database_cleaner', '~> 1.3'
-  gem 'factory_bot_rails', '~> 4.8'
-  gem 'launchy'
-  gem 'rspec-activemodel-mocks', '~>1.0.2'
-  gem 'rspec-rails', '~> 3.6.0'
-  gem 'simplecov'
-  gem 'poltergeist', '~> 1.9'
-  gem 'timecop'
-  gem 'with_model'
-  gem 'rspec_junit_formatter'
-  gem 'rails-controller-testing'
-  gem 'selenium-webdriver'
-end
-
 group :test, :development do
   gem 'rubocop'
   gem 'pry'

--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -16,7 +16,7 @@ platforms :jruby do
 end
 
 group :test, :development do
-  gem 'rubocop'
+  gem 'rubocop', require: false
   gem 'pry'
 
   platforms :mri do

--- a/core/config/initializers/assets.rb
+++ b/core/config/initializers/assets.rb
@@ -1,1 +1,3 @@
-Rails.application.config.assets.precompile << 'solidus_core_manifest.js'
+if Rails.application.config.respond_to?(:assets)
+  Rails.application.config.assets.precompile << 'solidus_core_manifest.js'
+end

--- a/core/lib/spree/testing_support/dummy_app.rb
+++ b/core/lib/spree/testing_support/dummy_app.rb
@@ -73,8 +73,10 @@ module DummyApp
 
     config.action_controller.include_all_helpers = false
 
-    config.assets.paths << File.expand_path('../dummy_app/assets/javascripts', __FILE__)
-    config.assets.paths << File.expand_path('../dummy_app/assets/stylesheets', __FILE__)
+    if config.respond_to?(:assets)
+      config.assets.paths << File.expand_path('../dummy_app/assets/javascripts', __FILE__)
+      config.assets.paths << File.expand_path('../dummy_app/assets/stylesheets', __FILE__)
+    end
 
     config.paths["config/database"] = File.expand_path('../dummy_app/database.yml', __FILE__)
     config.paths['app/views'] = File.expand_path('../dummy_app/views', __FILE__)

--- a/core/lib/spree/testing_support/dummy_app/rake_tasks.rb
+++ b/core/lib/spree/testing_support/dummy_app/rake_tasks.rb
@@ -40,6 +40,7 @@ task console: :dummy_environment do
   rescue LoadError
   end
 
+  require 'rails/command'
   require 'rails/commands/console/console_command'
   Rails::Console.new(Rails.application, sandbox: true, environment: "test").start
 end

--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -39,4 +39,13 @@ Gem::Specification.new do |s|
   s.add_dependency 'ransack', '~> 1.8'
   s.add_dependency 'state_machines-activerecord', '~> 0.4'
   s.add_dependency 'stringex', '~> 1.5.1'
+
+  s.add_development_dependency 'database_cleaner', '~> 1.3'
+  s.add_development_dependency 'factory_bot', '~> 4.8'
+  s.add_development_dependency 'rspec-activemodel-mocks', '~>1.0.2'
+  s.add_development_dependency 'rspec-rails', '~> 3.6.0'
+  s.add_development_dependency 'rspec_junit_formatter'
+  s.add_development_dependency 'simplecov'
+  s.add_development_dependency 'timecop'
+  s.add_development_dependency 'with_model'
 end

--- a/core/spec/spec_helper.rb
+++ b/core/spec/spec_helper.rb
@@ -12,6 +12,8 @@ if ENV["COVERAGE"]
   end
 end
 
+require 'rspec/core'
+
 require 'spree/testing_support/preferences'
 require 'spree/config'
 require 'with_model'

--- a/frontend/solidus_frontend.gemspec
+++ b/frontend/solidus_frontend.gemspec
@@ -31,5 +31,15 @@ Gem::Specification.new do |s|
   s.add_dependency 'truncate_html', '~> 0.9', '>= 0.9.2'
   s.add_dependency 'kaminari', '>= 0.17', '< 2.0'
 
+  s.add_development_dependency 'capybara', '~> 2.15'
   s.add_development_dependency 'capybara-accessible'
+  s.add_development_dependency 'capybara-screenshot', '>= 1.0.18'
+  s.add_development_dependency 'database_cleaner', '~> 1.3'
+  s.add_development_dependency 'factory_bot', '~> 4.8'
+  s.add_development_dependency 'poltergeist', '~> 1.9'
+  s.add_development_dependency 'rails-controller-testing'
+  s.add_development_dependency 'rspec-activemodel-mocks', '~> 1.0.2'
+  s.add_development_dependency 'rspec-rails', '~> 3.6.0'
+  s.add_development_dependency 'rspec_junit_formatter'
+  s.add_development_dependency 'simplecov'
 end

--- a/frontend/spec/spec_helper.rb
+++ b/frontend/spec/spec_helper.rb
@@ -20,6 +20,7 @@ require 'solidus_frontend'
 require 'spree/testing_support/dummy_app'
 DummyApp::Migrations.auto_migrate
 
+require 'rails-controller-testing'
 require 'rspec/rails'
 
 # Requires supporting files with custom matchers and macros, etc,
@@ -27,6 +28,7 @@ require 'rspec/rails'
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 
 require 'database_cleaner'
+require 'rspec-activemodel-mocks'
 
 require 'spree/testing_support/authorization_helpers'
 require 'spree/testing_support/capybara_ext'

--- a/sample/solidus_sample.gemspec
+++ b/sample/solidus_sample.gemspec
@@ -21,4 +21,9 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = '>= 1.8.23'
 
   s.add_dependency 'solidus_core', s.version
+
+  s.add_development_dependency 'database_cleaner', '~> 1.3'
+  s.add_development_dependency 'rspec-rails', '~> 3.6.0'
+  s.add_development_dependency 'rspec_junit_formatter'
+  s.add_development_dependency 'simplecov'
 end

--- a/sample/spec/spec_helper.rb
+++ b/sample/spec/spec_helper.rb
@@ -9,6 +9,8 @@ DummyApp::Migrations.auto_migrate
 
 require 'rspec/rails'
 
+require 'database_cleaner'
+
 RSpec.configure do |config|
   config.color = true
   config.infer_spec_type_from_file_location!


### PR DESCRIPTION
Build on #2358, which is split out for visibility.

This moves our spec dependencies out of `common_spree_dependencies.rb` and into the individual gemspecs for each project. This adds explicitness (good) at the expense of repetition (bad) and makes the
spec suites faster (good).