### PR TITLE
Support a Gemfile-custom for per-developer gems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 bin/*
 doc
 Gemfile.lock
+Gemfile-custom
 log
 pkg
 sandbox

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -125,6 +125,7 @@ Lint/AmbiguousBlockAssociation:
 Security/Eval:
   Exclude:
     - 'Gemfile'
+    - 'common_spree_dependencies.rb'
     - '*/Gemfile'
 
 Naming/VariableNumber:

--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -44,3 +44,6 @@ group :test, :development do
     gem 'byebug'
   end
 end
+
+custom_gemfile = File.expand_path("../Gemfile-custom", __FILE__)
+eval File.read(custom_gemfile) if File.exist?(custom_gemfile)


### PR DESCRIPTION
I regularly am adding gems (like stackprof, flamegraph, benchmark-ips) and then stashing or removing them before pushing. I almost always want these around, but there's no reason for them to show up for other devs or for CI.

This allows me to leave them in a local files that isn't checked in.

Idea borrowed from rspec: [Gemfile](https://github.com/rspec/rspec-core/blob/master/Gemfile#L49), [Gemfile-custom.sample](https://github.com/rspec/rspec-core/blob/master/Gemfile-custom.sample).