### PR TITLE
Remove "TODO" comment for Carmen

### DIFF
--- a/core/lib/spree/testing_support/factories/state_factory.rb
+++ b/core/lib/spree/testing_support/factories/state_factory.rb
@@ -9,12 +9,6 @@ FactoryBot.define do
       carmen_subregion do
         carmen_country = Carmen::Country.coded(country.iso)
 
-        # TODO: This condition can be removed after this carmen update is
-        # available: https://github.com/jim/carmen/pull/177
-        if !carmen_country.subregions?
-          fail("Country #{country.iso} has no subregions")
-        end
-
         carmen_country.subregions.coded(state_code) ||
           carmen_country.subregions.sort_by(&:name).first ||
           fail("Country #{country.iso} has no subregions")

--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'activemerchant', '~> 1.66'
   s.add_dependency 'acts_as_list', '~> 0.3'
   s.add_dependency 'awesome_nested_set', '~> 3.0', '>= 3.0.1'
-  s.add_dependency 'carmen', '~> 1.0.0'
+  s.add_dependency 'carmen', '~> 1.1.0'
   s.add_dependency 'cancancan', '~> 1.10'
   s.add_dependency 'friendly_id', '~> 5.0'
   s.add_dependency 'kaminari', '>= 0.17', '< 2.0'


### PR DESCRIPTION
[Carmen](https://github.com/carmen-ruby/carmen) has released v1.1.0 which includes the code change that the "TODO" comment is referring to.