### PR TITLE
Fix rake teaspoon:server in backend

### DIFF
--- a/backend/Rakefile
+++ b/backend/Rakefile
@@ -29,6 +29,10 @@ end
 
 namespace :teaspoon do
   task :server  do
+    require 'teaspoon'
+    require 'spree/testing_support/dummy_app'
+    require 'teaspoon/server'
+
     server = Teaspoon::Server.new
     server.start
     puts "#{server.url}/teaspoon"

--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -38,7 +38,6 @@ end
 group :test, :development do
   gem 'rubocop'
   gem 'pry'
-  gem 'listen', '~> 3.1.5'
 
   platforms :mri do
     gem 'byebug'


### PR DESCRIPTION
`rake teaspoon:server` starts up a server so we can run our JS tests against any web browser.

I broke this when introducing the new dummy_app (sorry).

In fixing it I've also removed the `listen` gem, which is no longer required.