### PR TITLE
Avoid loading models when requiring factories

### DIFF
--- a/core/lib/spree/testing_support/factories/adjustment_factory.rb
+++ b/core/lib/spree/testing_support/factories/adjustment_factory.rb
@@ -20,7 +20,7 @@ FactoryBot.define do
       end
     end
 
-    factory :tax_adjustment, class: Spree::Adjustment do
+    factory :tax_adjustment, class: 'Spree::Adjustment' do
       order { adjustable.order }
       association(:adjustable, factory: :line_item)
       amount 10.0

--- a/core/lib/spree/testing_support/factories/customer_return_factory.rb
+++ b/core/lib/spree/testing_support/factories/customer_return_factory.rb
@@ -27,7 +27,7 @@ FactoryBot.define do
   end
 
   # for the case when you want to supply existing return items instead of generating some
-  factory :customer_return_without_return_items, class: Spree::CustomerReturn do
+  factory :customer_return_without_return_items, class: 'Spree::CustomerReturn' do
     association(:stock_location, factory: :stock_location)
   end
 end

--- a/core/lib/spree/testing_support/factories/stock_transfer_factory.rb
+++ b/core/lib/spree/testing_support/factories/stock_transfer_factory.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   sequence(:source_code) { |n| "SRC#{n}" }
   sequence(:destination_code) { |n| "DEST#{n}" }
 
-  factory :stock_transfer, class: Spree::StockTransfer do
+  factory :stock_transfer, class: 'Spree::StockTransfer' do
     source_location { Spree::StockLocation.create!(name: "Source Location", code: generate(:source_code), admin_name: "Source") }
 
     factory :stock_transfer_with_items do

--- a/core/lib/spree/testing_support/factories/store_credit_type_factory.rb
+++ b/core/lib/spree/testing_support/factories/store_credit_type_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :primary_credit_type, class: 'Spree::StoreCreditType' do
-    name      Spree::StoreCreditType::DEFAULT_TYPE_NAME
+    name      { Spree::StoreCreditType::DEFAULT_TYPE_NAME }
     priority  { "1" }
   end
 

--- a/core/lib/spree/testing_support/factories/user_factory.rb
+++ b/core/lib/spree/testing_support/factories/user_factory.rb
@@ -3,16 +3,10 @@ require 'spree/testing_support/factories/role_factory'
 require 'spree/testing_support/factories/address_factory'
 
 FactoryBot.define do
-  sequence :user_authentication_token do |n|
-    "xxxx#{Time.current.to_i}#{rand(1000)}#{n}xxxxxxxxxxxxx"
-  end
-
-  factory :user, class: Spree.user_class do
+  factory :user, class: Spree::UserClassHandle.new do
     email { generate(:email) }
-    login { email } if Spree.user_class.attribute_method? :login
     password 'secret'
-    password_confirmation { password } if Spree.user_class.attribute_method? :password_confirmation
-    authentication_token { generate(:user_authentication_token) } if Spree.user_class.attribute_method? :authentication_token
+    password_confirmation { password }
 
     trait :with_api_key do
       after(:create) do |user, _|


### PR DESCRIPTION
This makes some minor changes to the adjustment, customer_return, stock, and store_credit_type factories so that they don't need their models autoloaded in order to be used.

It also makes some more substatial changes to the user model for the same purpose.