### PR TITLE
Move role configuration into Spree::Config

### DIFF
--- a/core/app/models/spree/ability.rb
+++ b/core/app/models/spree/ability.rb
@@ -56,7 +56,7 @@ module Spree
     end
 
     def activate_permission_sets
-      Spree::RoleConfiguration.instance.activate_permissions! self, user
+      Spree::Config.roles.activate_permissions! self, user
     end
   end
 end

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -382,6 +382,13 @@ module Spree
       @stock_configuration ||= Spree::Core::StockConfiguration.new
     end
 
+    def roles
+      @roles ||= Spree::RoleConfiguration.new.tap do |roles|
+        roles.assign_permissions :default, ['Spree::PermissionSets::DefaultCustomer']
+        roles.assign_permissions :admin, ['Spree::PermissionSets::SuperUser']
+      end
+    end
+
     def environment
       @environment ||= Spree::Core::Environment.new(self).tap do |env|
         env.calculators.shipping_methods = %w[

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -16,8 +16,8 @@ module Spree
 
       initializer "spree.default_permissions", before: :load_config_initializers do |_app|
         Spree::RoleConfiguration.configure do |config|
-          config.assign_permissions :default, [Spree::PermissionSets::DefaultCustomer]
-          config.assign_permissions :admin, [Spree::PermissionSets::SuperUser]
+          config.assign_permissions :default, ['Spree::PermissionSets::DefaultCustomer']
+          config.assign_permissions :admin, ['Spree::PermissionSets::SuperUser']
         end
       end
 

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -14,14 +14,8 @@ module Spree
         app.config.spree = Spree::Config.environment
       end
 
-      initializer "spree.default_permissions", before: :load_config_initializers do |_app|
-        Spree::RoleConfiguration.configure do |config|
-          config.assign_permissions :default, ['Spree::PermissionSets::DefaultCustomer']
-          config.assign_permissions :admin, ['Spree::PermissionSets::SuperUser']
-        end
-      end
-
       # leave empty initializers for backwards-compatability. Other apps might still rely on these events
+      initializer "spree.default_permissions", before: :load_config_initializers do; end
       initializer "spree.register.calculators", before: :load_config_initializers do; end
       initializer "spree.register.stock_splitters", before: :load_config_initializers do; end
       initializer "spree.register.payment_methods", before: :load_config_initializers do; end

--- a/core/lib/spree/core/role_configuration.rb
+++ b/core/lib/spree/core/role_configuration.rb
@@ -27,13 +27,20 @@ module Spree
       end
     end
 
-    include Singleton
     attr_accessor :roles
 
-    # Yields the instance of the singleton, used for configuration
-    # @yield_param instance [Spree::RoleConfiguration]
-    def self.configure
-      yield(instance)
+    class << self
+      def instance
+        Spree::Deprecation.warn "Spree::RoleConfiguration.instance is DEPRECATED use Spree::Config.roles instead"
+        Spree::Config.roles
+      end
+
+      # Yields the instance of the singleton, used for configuration
+      # @yield_param instance [Spree::RoleConfiguration]
+      def configure
+        Spree::Deprecation.warn "Spree::RoleConfiguration.configure is deprecated. Call Spree::Config.roles.assign_permissions instead"
+        yield(Spree::Config.roles)
+      end
     end
 
     # Given a CanCan::Ability, and a user, determine what permissions sets can

--- a/core/lib/spree/core/role_configuration.rb
+++ b/core/lib/spree/core/role_configuration.rb
@@ -1,4 +1,5 @@
 require 'singleton'
+require 'spree/core/class_constantizer'
 
 module Spree
   # A class responsible for associating {Spree::Role} with a list of permission sets.
@@ -16,7 +17,15 @@ module Spree
   class RoleConfiguration
     # An internal structure for the association between a role and a
     # set of permissions.
-    Role = Struct.new(:name, :permission_sets)
+    class Role
+      attr_reader :name, :permission_sets
+
+      def initialize(name, permission_sets)
+        @name = name
+        @permission_sets = Spree::Core::ClassConstantizer::Set.new
+        @permission_sets.concat permission_sets
+      end
+    end
 
     include Singleton
     attr_accessor :roles
@@ -63,7 +72,7 @@ module Spree
     def assign_permissions(role_name, permission_sets)
       name = role_name.to_s
 
-      roles[name].permission_sets |= permission_sets
+      roles[name].permission_sets.concat permission_sets
       roles[name]
     end
   end

--- a/core/spec/lib/spree/core/role_configuration_spec.rb
+++ b/core/spec/lib/spree/core/role_configuration_spec.rb
@@ -8,16 +8,13 @@ RSpec.describe Spree::RoleConfiguration do
   end
   class OtherDummyPermissionSet < Spree::PermissionSets::Base; end
 
-  let(:instance) { described_class.instance }
-
-  around do |example|
-    @original_roles = instance.roles.dup
-    instance.roles.clear
-    example.run
-    instance.roles = @original_roles
-  end
+  let(:instance) { Spree::RoleConfiguration.new }
 
   describe ".configure" do
+    around(:each) do |example|
+      Spree::Deprecation.silence { example.run }
+    end
+
     it "yields with the instance" do
       expect { |b| described_class.configure(&b) }.to yield_with_args(described_class.instance)
     end
@@ -93,7 +90,7 @@ RSpec.describe Spree::RoleConfiguration do
       end
     end
 
-    subject { described_class.instance.activate_permissions! ability, user }
+    subject { instance.activate_permissions! ability, user }
 
     context "when the configuration has roles" do
       before do

--- a/core/spec/models/spree/ability_spec.rb
+++ b/core/spec/models/spree/ability_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Spree::Ability, type: :model do
     subject { Spree::Ability.new(user) }
 
     it "activates permissions from the role configuration" do
-      expect(Spree::RoleConfiguration.instance).to receive(:activate_permissions!).
+      expect(Spree::Config.roles).to receive(:activate_permissions!).
         once
 
       subject


### PR DESCRIPTION
Previously, `RoleConfiguration` was a singleton class, which was configured by engine initialization.

Instead, we can configure it like the rest of our configuration by moving it to `AppConfiguration` (and therefore `Spree:Config`). It is also no longer a Singleton class, which makes testing it simpler.

This deprecates `RoleConfiguration.instance` and `RoleConfiguration.configure` and has them use `Spree::Config.roles` instead