### PR TITLE
Clarify that we prefer new files to be in JS, not coffee

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -8,12 +8,12 @@ Backend contains the controllers, views, and assets making up the admin interfac
 
 Can be found in [app/assets/javascripts/spree/backend/](./app/assets/javascripts/spree/backend/)
 
-Out scripts are written in a mix of coffeescript and javascript. We can't
+Our scripts are written in a mix of coffeescript and javascript (ES5). We can't
 easily use a transpiler for ECMAScript >= 6 without adding additional steps for
 applications using solidus\_admin.
 
-As a result, we accept contributions in either plain-ol javascript or
-CoffeeScript, and discourage converting existing files.
+Though we have existing CoffeeScript files, any new files should be in
+javascript (ES5).
 
 ### Stylesheets
 


### PR DESCRIPTION
Without wanting to get into a language debate...

I think it's safe to say coffeescript isn't the future. It never took off in the larger JS community (which has firmly settled on es6 + babel) in the same way it did in the ruby community. As a result javascript now has much better tools (linting, formatting, etc) than coffee ever will.

This also removes our previous stance of discouraging converting existing files to JS. We have converted a few files to JS (noteably `spree.js` from core) and it makes sense to do so if making significant changes to a file (but shouldn't be required).

Unfortunately our lack of easy es6 support still hasn't changed. We're still waiting on Sprockets 4 (which looks great, and beta6 was just released) and people still use IE11.