### PR TITLE
Cancelled Items totalling issue

### DIFF
--- a/core/app/models/spree/unit_cancel.rb
+++ b/core/app/models/spree/unit_cancel.rb
@@ -29,6 +29,8 @@ class Spree::UnitCancel < Spree::Base
   # This method is used by Adjustment#update to recalculate the cost.
   def compute_amount(line_item)
     raise "Adjustable does not match line item" unless line_item == inventory_unit.line_item
+    line_item.order.update!
+    line_item = Spree::LineItem.find(line_item.id)
     -(line_item.total.to_d / line_item.inventory_units.not_canceled.reject(&:original_return_item ).size)
   end
 end


### PR DESCRIPTION
Steps to reproduce the issue : 
1. Place an order, say, containing 1 line item & quantity 4, & the price of item being 100 $, hence the total cost becomes 400 $.

2. Now, go to the Cancel Items tab in the corresponding orders edit page & select all the 4 inventory units & cancel them, together.

3. The final order price should be 
400 - (400/4) - (300/3) - (200/2) - (100/1), which is 0 $, 
but the total comes out to be 
400 - (400/4) - (400/3) - (400/2) - (400/1), which is not 0 $.

4. ALSO, if we cancel all the items, one by one, it works fine.

5. On top of it, there's this open issue as well : https://github.com/solidusio/solidus/issues/1837#issue-220715796