### PR TITLE
Fixes for custom user generator

### DIFF
--- a/core/lib/generators/spree/custom_user/custom_user_generator.rb
+++ b/core/lib/generators/spree/custom_user/custom_user_generator.rb
@@ -12,10 +12,10 @@ module Spree
     end
 
     def check_for_constant
-        klass
+      klass
     rescue NameError
-        @shell.say "Couldn't find #{class_name}. Are you sure that this class exists within your application and is loaded?", :red
-        exit(1)
+      @shell.say "Couldn't find #{class_name}. Are you sure that this class exists within your application and is loaded?", :red
+      exit(1)
     end
 
     def generate

--- a/core/lib/generators/spree/custom_user/custom_user_generator.rb
+++ b/core/lib/generators/spree/custom_user/custom_user_generator.rb
@@ -21,11 +21,10 @@ module Spree
 
       file_action = File.exist?('config/initializers/spree.rb') ? :append_file : :create_file
       send(file_action, 'config/initializers/spree.rb') do
-        %{
-          Rails.application.config.to_prepare do
-            require_dependency 'spree/authentication_helpers'
-          end\n}
+        "Rails.application.config.to_prepare do\n  require_dependency 'spree/authentication_helpers'\nend\n"
       end
+
+      gsub_file 'config/initializers/spree.rb', /Spree\.user_class.?=.?.+$/, %{Spree.user_class = "#{class_name}"}
     end
 
     private

--- a/core/lib/generators/spree/custom_user/custom_user_generator.rb
+++ b/core/lib/generators/spree/custom_user/custom_user_generator.rb
@@ -2,7 +2,6 @@ require 'rails/generators/active_record/migration'
 
 module Spree
   class CustomUserGenerator < Rails::Generators::NamedBase
-    include Rails::Generators::ResourceHelpers
     include ActiveRecord::Generators::Migration
 
     desc "Set up a Solidus installation with a custom User class"

--- a/core/lib/generators/spree/custom_user/custom_user_generator.rb
+++ b/core/lib/generators/spree/custom_user/custom_user_generator.rb
@@ -32,6 +32,7 @@ module Spree
       end
     end
 
+    private
 
     def klass
       class_name.constantize

--- a/core/lib/generators/spree/custom_user/custom_user_generator.rb
+++ b/core/lib/generators/spree/custom_user/custom_user_generator.rb
@@ -1,7 +1,9 @@
+require 'rails/generators/active_record/migration'
+
 module Spree
   class CustomUserGenerator < Rails::Generators::NamedBase
     include Rails::Generators::ResourceHelpers
-    include Rails::Generators::Migration
+    include ActiveRecord::Generators::Migration
 
     desc "Set up a Solidus installation with a custom User class"
 
@@ -31,14 +33,6 @@ module Spree
       end
     end
 
-    def self.next_migration_number(dirname)
-      if ActiveRecord::Base.timestamped_migrations
-        sleep 1 # make sure to get a different migration every time
-        Time.new.utc.strftime("%Y%m%d%H%M%S")
-      else
-        "%.3d" % (current_migration_number(dirname) + 1)
-      end
-    end
 
     def klass
       class_name.constantize

--- a/core/lib/generators/spree/custom_user/custom_user_generator.rb
+++ b/core/lib/generators/spree/custom_user/custom_user_generator.rb
@@ -6,11 +6,7 @@ module Spree
 
     desc "Set up a Solidus installation with a custom User class"
 
-    def self.source_paths
-      paths = superclass.source_paths
-      paths << File.expand_path('../templates', __FILE__)
-      paths.flatten
-    end
+    source_root File.expand_path('templates', File.dirname(__FILE__))
 
     def check_for_constant
       klass

--- a/core/lib/generators/spree/custom_user/templates/initializer.rb.tt
+++ b/core/lib/generators/spree/custom_user/templates/initializer.rb.tt
@@ -1,1 +1,0 @@
-Spree.user_class = "<%= class_name %>"


### PR DESCRIPTION
While building an install generator for [alchemy-solidus](https://github.com/AlchemyCMS/alchemy-solidus)
I came across some quirks in the current custom user generator.

First the migration generator does not use the active record migration generator but its super class.
This made is necessary to write our own `next_migration_number` generator. This implementation had some
flaws that lead to duplicated migrations problems. We now use the active record migration generator and
do not need to ship our own custom migration number generator anymore.

Also the generator used to inject the spree initializer and set the `Spree.user_class` to the generated 
custom user. Somehow this got lost. Replaced this by an gsub that ensures that the `Spree.user_class` 
is never set twice.

This removes an unused module (`Rails::Generators::ResourceHelpers`) that was used to deal with controller names
what we do not do anymore in this generator.

On the way I made some code cleanups.

Unfortunately it is not super easy to write generator specs as we do not have a dummy test app anymore. 
We do not have tests for any generator actually. We should, but this is not purpose if this PR.

I hope [the test suite of alchemy-solidus](https://travis-ci.org/AlchemyCMS/alchemy-solidus) is proof enough 
that this generator works. In [its own generator we use the solidus custom user generator](https://github.com/tvdeyen/alchemy-solidus/blob/solidus-2/lib/generators/alchemy/solidus/install/install_generator.rb#L43) to setup the dummy app and test the integration
of Alchemy and Solidus. Would this generator fail, the builds of alchemy-solidus would fail.