### PR TITLE
Remove stringex as a dependency of core

### DIFF
--- a/core/app/models/spree/taxon.rb
+++ b/core/app/models/spree/taxon.rb
@@ -59,7 +59,7 @@ module Spree
     # name and its parents permalink (if present.)
     def set_permalink
       permalink_tail = permalink.split('/').last if permalink.present?
-      permalink_tail ||= name.to_url
+      permalink_tail ||= Spree::Config.taxon_url_parametizer_class.parameterize(name)
       self.permalink_part = permalink_tail
     end
 

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -363,6 +363,13 @@ module Spree
     #   Spree::CurrentStoreSelector
     class_name_attribute :current_store_selector_class, default: 'Spree::StoreSelector::ByServerName'
 
+    # Allows providing your own class for creating urls on taxons
+    #
+    # @!attribute [rw] taxon_url_parametizer_class
+    # @return [Class] a class that provides a `#parameterize` method that
+    # returns a String
+    class_name_attribute :taxon_url_parametizer_class, default: 'ActiveSupport::Inflector'
+
     # Allows providing your own class instance for generating order numbers.
     #
     # @!attribute [rw] order_number_generator

--- a/core/lib/spree/core/permalinks.rb
+++ b/core/lib/spree/core/permalinks.rb
@@ -1,5 +1,3 @@
-require 'stringex'
-
 module Spree
   module Core
     module Permalinks

--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -38,5 +38,4 @@ Gem::Specification.new do |s|
   s.add_dependency 'paranoia', '~> 2.3'
   s.add_dependency 'ransack', '~> 1.8'
   s.add_dependency 'state_machines-activerecord', '~> 0.4'
-  s.add_dependency 'stringex', '~> 1.5.1'
 end

--- a/core/spec/models/spree/taxon_spec.rb
+++ b/core/spec/models/spree/taxon_spec.rb
@@ -18,12 +18,6 @@ RSpec.describe Spree::Taxon, type: :model do
       expect(taxon.permalink).to eql "ruby-on-rails"
     end
 
-    it "should support Chinese characters" do
-      taxon.name = "你好"
-      taxon.set_permalink
-      expect(taxon.permalink).to eql 'ni-hao'
-    end
-
     context "with parent taxon" do
       let(:parent) { FactoryBot.build(:taxon, permalink: "brands") }
       before       { allow(taxon).to receive_messages parent: parent }
@@ -37,12 +31,6 @@ RSpec.describe Spree::Taxon, type: :model do
         taxon.permalink = "b/rubyonrails"
         taxon.set_permalink
         expect(taxon.permalink).to eql "brands/rubyonrails"
-      end
-
-      it "should support Chinese characters" do
-        taxon.name = "我"
-        taxon.set_permalink
-        expect(taxon.permalink).to eql "brands/wo"
       end
 
       # Regression test for https://github.com/spree/spree/issues/3390
@@ -80,7 +68,7 @@ RSpec.describe Spree::Taxon, type: :model do
       end
 
       it "changes child's permalink" do
-        is_expected.to change{ taxon2_child.reload.permalink }.from('t/t2/t2-child').to('t/t1/t2/t2-child')
+        is_expected.to change{ taxon2_child.reload.permalink }.from('t/t2/t2_child').to('t/t1/t2/t2_child')
       end
     end
 
@@ -94,7 +82,7 @@ RSpec.describe Spree::Taxon, type: :model do
       end
 
       it "changes child's permalink" do
-        is_expected.to change{ taxon2_child.reload.permalink }.from('t/t2/t2-child').to('t/foo/t2-child')
+        is_expected.to change{ taxon2_child.reload.permalink }.from('t/t2/t2_child').to('t/foo/t2_child')
       end
     end
 
@@ -108,7 +96,7 @@ RSpec.describe Spree::Taxon, type: :model do
       end
 
       it "changes child's permalink" do
-        is_expected.to change{ taxon2_child.reload.permalink }.from('t/t2/t2-child').to('t/foo/t2-child')
+        is_expected.to change{ taxon2_child.reload.permalink }.from('t/t2/t2_child').to('t/foo/t2_child')
       end
     end
 
@@ -122,7 +110,7 @@ RSpec.describe Spree::Taxon, type: :model do
       end
 
       it "changes child's permalink" do
-        is_expected.to change{ taxon2_child.reload.permalink }.from('t/t2/t2-child').to('t/t1/foo/t2-child')
+        is_expected.to change{ taxon2_child.reload.permalink }.from('t/t2/t2_child').to('t/t1/foo/t2_child')
       end
     end
   end


### PR DESCRIPTION
We already have ActiveSupport as part of Solidus, and stringex doesn't
do much else that ActiveSupport doesn't already do. We lose support for
translating non-ascii characters, but `ActiveSupport#parameterize` does
a pretty good job of replacing special characters for ones that can be
used in a valid URL.

This PR also introduces a pluggable `taxon_url_parametizer_class` that defaults to [`ActiveSupport::Inflector`](http://api.rubyonrails.org/classes/ActiveSupport/Inflector.html).
