### PR TITLE
Add data-action classes to admin orders cart templates

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/templates/orders/line_item.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/orders/line_item.hbs
@@ -31,12 +31,12 @@
 </td>
 <td class="cart-line-item-delete actions" data-hook="cart_line_item_delete">
   {{#if editing}}
-    <a class="save-line-item fa fa-ok no-text with-tip" href="#" title="{{ t "actions.save" }}"></a>
+    <a class="save-line-item fa fa-ok no-text with-tip" data-action="save" href="#" title="{{ t "actions.save" }}"></a>
     {{#unless noCancel}}
-      <a class="cancel-line-item fa fa-cancel no-text with-tip" href="#" title="{{ t "actions.cancel" }}"></a>
+      <a class="cancel-line-item fa fa-cancel no-text with-tip" data-action="cancel" href="#" title="{{ t "actions.cancel" }}"></a>
     {{/unless}}
   {{else}}
-    <a class="edit-line-item fa fa-edit no-text with-tip" href="#" title="{{ t "actions.edit" }}"></a>
-    <a class="delete-line-item fa fa-trash no-text with-tip" href="#" title="{{ t "actions.delete" }}"></a>
+    <a class="edit-line-item fa fa-edit no-text with-tip" data-action="edit" href="#" title="{{ t "actions.edit" }}"></a>
+    <a class="delete-line-item fa fa-trash no-text with-tip" data-action="remove" href="#" title="{{ t "actions.delete" }}"></a>
   {{/if}}
 </td>


### PR DESCRIPTION
This allows to show highlight background colors on hovered rows as we do in all other admin tables.

From:

<img width="854" alt="schermata 2017-11-18 alle 15 12 26" src="https://user-images.githubusercontent.com/167946/32981187-75dc1e02-cc73-11e7-9823-64f1a78d87ef.png">

To:

<img width="691" alt="schermata 2017-11-18 alle 15 16 44" src="https://user-images.githubusercontent.com/167946/32981191-847f5c8a-cc73-11e7-8969-1bb6eeda03c4.png">
