### PR TITLE
Allow ShipmentsController#remove on ready shipment

### DIFF
--- a/api/app/controllers/spree/api/shipments_controller.rb
+++ b/api/app/controllers/spree/api/shipments_controller.rb
@@ -70,13 +70,13 @@ module Spree
       def remove
         quantity = params[:quantity].to_i
 
-        if @shipment.pending?
+        if @shipment.shipped? || @shipment.canceled?
+          @shipment.errors.add(:base, :cannot_remove_items_shipment_state, state: @shipment.state)
+          invalid_resource!(@shipment)
+        else
           @shipment.order.contents.remove(variant, quantity, { shipment: @shipment })
           @shipment.reload if @shipment.persisted?
           respond_with(@shipment, default_template: :show)
-        else
-          @shipment.errors.add(:base, :cannot_remove_items_shipment_state, state: @shipment.state)
-          invalid_resource!(@shipment)
         end
       end
 

--- a/api/spec/requests/spree/api/shipments_controller_spec.rb
+++ b/api/spec/requests/spree/api/shipments_controller_spec.rb
@@ -134,6 +134,23 @@ describe Spree::Api::ShipmentsController, type: :request do
       end
     end
 
+    context 'for ready shipments' do
+      let(:order) { create :order_ready_to_ship, line_items_attributes: [{ variant: variant, quantity: 1 }] }
+      let(:shipment) { order.shipments.first }
+
+      it 'adds a variant to a shipment' do
+        put spree.add_api_shipment_path(shipment), params: { variant_id: variant.to_param, quantity: 1 }
+        expect(response.status).to eq(200)
+        expect(json_response['manifest'].detect { |h| h['variant']['id'] == variant.id }['quantity']).to eq(2)
+      end
+
+      it 'removes a variant from a shipment' do
+        put spree.remove_api_shipment_path(shipment), params: { variant_id: variant.to_param, quantity: 1 }
+        expect(response.status).to eq(200)
+        expect(json_response['manifest'].detect { |h| h['variant']['id'] == variant.id }).to be nil
+      end
+    end
+
     context "for shipped shipments" do
       let(:order) { create :shipped_order }
       let(:shipment) { order.shipments.first }


### PR DESCRIPTION
On the admin forms of ready shipments we have a delete button for each item.
These buttons are not working because the `ShipmentsController#remove` action is only enabled for `pending` shipments. This behaviour comes from https://github.com/solidusio/solidus/pull/97.
I don't know the reasons for that but i see that ready shipments are supposed to be editable (https://github.com/solidusio/solidus/pull/1784).

This PR enables ready shipments item deletion and thus fixes the admin delete buttons, following what was done on #1784.