### PR TITLE
Include slash when filling in expiration in frontend checkout_spec

### DIFF
--- a/frontend/spec/features/checkout_spec.rb
+++ b/frontend/spec/features/checkout_spec.rb
@@ -663,7 +663,7 @@ describe "Checkout", type: :feature, inaccessible: true do
 
   def fill_in_credit_card(number:)
     fill_in "Card Number", with: number
-    fill_in "Expiration", with: "1224"
+    fill_in "Expiration", with: "12 / 24"
     fill_in "Card Code", with: "123"
   end
 


### PR DESCRIPTION
Previously, this would fail _very_ occasionally.

This is supposed to fill in the expiration like:
![](http://i.hawth.ca/u/screenshot_2017-11-20-14-06-19.718.png)

But occasionally it would eat the second `2`
![](http://i.hawth.ca/u/screenshot_2017-11-20-14-06-30.207.png)

This happens very rarely on CI (~1%) but somewhat often locally (~10-20%). It never happens when explicitly inputting a `/`.

I would guess this is an issue with [jquery.payment](https://github.com/stripe/jquery.payment), and it's possible that this only works by virtue that it fills in the field slightly slower. jquery.payment is no longer maintained :cry: and this patch makes the spec 100% reliable locally, so I think this (slight) hack is the best solution.

For reference I made [a commit to run a problematic spec 100 times and ensure we filled in the field correctly](https://github.com/jhawthorn/solidus/commit/e0dbe1ddc6e43c7b628f0cf02de64672db4ee86a).
Here it is [failing on CI](https://circleci.com/gh/jhawthorn/solidus/1410) and [fixed with this patch](https://circleci.com/gh/jhawthorn/solidus/1411) 