### PR TITLE
Update updated_at timestamp on eligibility change

### DIFF
--- a/core/app/models/spree/promotion_chooser.rb
+++ b/core/app/models/spree/promotion_chooser.rb
@@ -12,7 +12,7 @@ module Spree
       if best_promotion_adjustment
         @adjustments.select(&:eligible?).each do |adjustment|
           next if adjustment == best_promotion_adjustment
-          adjustment.update_columns(eligible: false)
+          adjustment.update_columns(eligible: false, updated_at: Time.current)
         end
         best_promotion_adjustment.amount
       else


### PR DESCRIPTION
The _adjustment jbuilder view caches based on the adjustment updated_at timestamp. Currently if an adjustment is made ineligible by this class and a previous call to api/orders#show has been made, a subsequent call will send back the cached view with incorrect eligibilty.

(Switched to a custom chooser class that includes this change and does the trick).