### PR TITLE
Remove required attribute from address lastname

### DIFF
--- a/frontend/app/views/spree/address/_form.html.erb
+++ b/frontend/app/views/spree/address/_form.html.erb
@@ -6,8 +6,8 @@
   </p>
 
   <p class="field" id=<%="#{address_id}lastname" %>>
-    <%= form.label :lastname, t('spree.last_name') %><span class="required">*</span><br />
-    <%= form.text_field :lastname, autocomplete: address_type + ' family-name', required: true %>
+    <%= form.label :lastname, t('spree.last_name') %><br />
+    <%= form.text_field :lastname, autocomplete: address_type + ' family-name' %>
   </p>
 
   <% if Spree::Config[:company] %>


### PR DESCRIPTION
We didn't have `required` validation on address lastname before #2264. 

I'm not sure why we had the `*` symbol near `lastname` even if it wasn't required.