### PR TITLE
[RFC] Do not render complex preference types as form fields

### DIFF
--- a/backend/app/views/spree/admin/payment_methods/_form.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/_form.html.erb
@@ -19,9 +19,10 @@
             <% if @object.preference_source.present? %>
               <%= t('spree.preference_source_using', name: @object.preference_source) %>
             <% elsif !@object.new_record? %>
-              <% @object.preferences.keys.each do |key| %>
-                <%= render "spree/admin/shared/preference_fields/#{@object.preference_type(key)}",
-                   form: f, attribute: "preferred_#{key}", label: t(key, scope: 'spree') %>
+              <% @object.admin_form_preference_names.each do |name| %>
+                <%= render "spree/admin/shared/preference_fields/#{@object.preference_type(name)}",
+                  form: f, attribute: "preferred_#{name}",
+                  label: t(name, scope: 'spree', default: name.to_s.humanize) %>
               <% end %>
             <% end %>
           </div>

--- a/backend/app/views/spree/admin/promotions/calculators/_default_fields.html.erb
+++ b/backend/app/views/spree/admin/promotions/calculators/_default_fields.html.erb
@@ -1,5 +1,6 @@
-<% calculator.preferences.keys.map do |key| %>
-  <%= render "spree/admin/shared/preference_fields/#{calculator.preference_type(key)}",
-     name: "#{prefix}[calculator_attributes][preferred_#{key}]",
-     value: calculator.get_preference(key), label: t(key.to_s, scope: 'spree') %>
+<% calculator.admin_form_preference_names.map do |name| %>
+  <%= render "spree/admin/shared/preference_fields/#{calculator.preference_type(name)}",
+    name: "#{prefix}[calculator_attributes][preferred_#{name}]",
+    value: calculator.get_preference(name),
+    label: t(name.to_s, scope: 'spree', default: name.to_s.humanize) %>
 <% end %>

--- a/backend/app/views/spree/admin/shared/_calculator_fields.html.erb
+++ b/backend/app/views/spree/admin/shared/_calculator_fields.html.erb
@@ -11,9 +11,10 @@
       <% calculator = f.object.calculator.class == calculator_class ? f.object.calculator : calculator_class.new %>
       <div class="js-calculator-preferences" data-calculator-type="<%= calculator_class %>">
         <%= f.fields_for :calculator, calculator do |calculator_form| %>
-          <% calculator.preferences.keys.each do |key| %>
-            <%= render "spree/admin/shared/preference_fields/#{calculator.preference_type(key)}",
-               form: calculator_form, attribute: "preferred_#{key}", label: t(key, scope: 'spree') %>
+          <% calculator.admin_form_preference_names.each do |name| %>
+            <%= render "spree/admin/shared/preference_fields/#{calculator.preference_type(name)}",
+              form: calculator_form, attribute: "preferred_#{name}",
+              label: t(name, scope: 'spree', default: name.to_s.humanize) %>
           <% end %>
         <% end %>
       </div>

--- a/backend/spec/features/admin/configuration/payment_methods_spec.rb
+++ b/backend/spec/features/admin/configuration/payment_methods_spec.rb
@@ -45,8 +45,9 @@ describe "Payment Methods", type: :feature do
   end
 
   context "admin editing a payment method" do
-    before(:each) do
-      create(:check_payment_method)
+    let!(:payment_method) { create(:check_payment_method) }
+
+    before do
       click_link "Payments"
       expect(page).to have_link 'Payment Methods'
       within("table#listing_payment_methods") do
@@ -65,6 +66,22 @@ describe "Payment Methods", type: :feature do
       fill_in "payment_method_name", with: ""
       click_button "Update"
       expect(page).to have_content("Name can't be blank")
+    end
+
+    context 'with payment method having hash and array as preference' do
+      class ComplexPayments < Spree::PaymentMethod
+        preference :name, :string
+        preference :mapping, :hash
+        preference :recipients, :array
+      end
+
+      let!(:payment_method) { ComplexPayments.create!(name: 'Complex Payments') }
+
+      it "does not display preference fields that are hash or array" do
+        expect(page).to have_field("Name")
+        expect(page).to_not have_field("Mapping")
+        expect(page).to_not have_field("Recipients")
+      end
     end
   end
 

--- a/core/lib/spree/preferences/preferable_class_methods.rb
+++ b/core/lib/spree/preferences/preferable_class_methods.rb
@@ -1,5 +1,14 @@
 module Spree::Preferences
   module PreferableClassMethods
+    DEFAULT_ADMIN_FORM_PREFERENCE_TYPES = %i(
+      boolean
+      decimal
+      integer
+      password
+      string
+      text
+    )
+
     def defined_preferences
       []
     end
@@ -59,6 +68,19 @@ module Spree::Preferences
 
     def preference_type_getter_method(name)
       "preferred_#{name}_type".to_sym
+    end
+
+    # List of preference types allowed as form fields in the Solidus admin
+    #
+    # Overwrite this method in your class that includes +Spree::Preferable+
+    # if you want to provide more fields. If you do so, you also need to provide
+    # a preference field partial that lives in:
+    #
+    # +app/views/spree/admin/shared/preference_fields/+
+    #
+    # @return [Array]
+    def allowed_admin_form_preference_types
+      DEFAULT_ADMIN_FORM_PREFERENCE_TYPES
     end
   end
 end

--- a/core/spec/models/spree/preferences/preferable_spec.rb
+++ b/core/spec/models/spree/preferences/preferable_spec.rb
@@ -105,6 +105,50 @@ RSpec.describe Spree::Preferences::Preferable, type: :model do
       })
     end
 
+    describe '#admin_form_preference_names' do
+      subject do
+        ComplexPreferableClass.new.admin_form_preference_names
+      end
+
+      before do
+        class ComplexPreferableClass
+          include Spree::Preferences::Preferable
+          preference :name, :string
+          preference :password, :password
+          preference :mapping, :hash
+          preference :recipients, :array
+        end
+      end
+
+      it "returns an array of preference names excluding preferences not presentable as form field" do
+        is_expected.to contain_exactly(:name, :password)
+      end
+
+      context 'with overwritten allowed_admin_form_preference_types class method' do
+        subject do
+          ComplexOverwrittenPreferableClass.new.admin_form_preference_names
+        end
+
+        before do
+          class ComplexOverwrittenPreferableClass
+            include Spree::Preferences::Preferable
+            preference :name, :string
+            preference :password, :password
+            preference :mapping, :hash
+            preference :recipients, :array
+
+            def self.allowed_admin_form_preference_types
+              %i(string password hash array)
+            end
+          end
+        end
+
+        it 'returns these types instead' do
+          is_expected.to contain_exactly(:name, :password, :mapping, :recipients)
+        end
+      end
+    end
+
     context "converts integer preferences to integer values" do
       before do
         A.preference :is_integer, :integer


### PR DESCRIPTION
When rendering preference form fields we currently just render every
preference type defined on the preferable class. 

Some classes - like [solidus_paypal_braintree's Gateway](https://github.com/solidusio/solidus_paypal_braintree/blob/e7d8be0443465f686201f2b0b0455d7ff5e72f23/app/models/solidus_paypal_braintree/gateway.rb#L34-L35) - use complex types (`Array` and `Hash`) to store developer facing preferences.

Currently this [leads to bugs](https://github.com/solidusio/solidus_paypal_braintree/issues/132) because these preference field partials are not available.

As arrays and hashes won't represent well in a form field, we should not render them IMO. 
The settings stored in these preferences are considered developer facing only. 
Admins should not change these kind of values.