### PR TITLE
[WIP] fix Importer::Order to allow create a shipments

### DIFF
--- a/api/spec/requests/spree/api/orders_controller_spec.rb
+++ b/api/spec/requests/spree/api/orders_controller_spec.rb
@@ -732,6 +732,20 @@ module Spree
           expect(response.status).to eq 201
           expect(json_response["user_id"]).to eq(user.id)
         end
+
+        it "with a item and shipment" do
+          stock_location = create(:stock_location)
+          post spree.api_orders_path, params: {
+            order: {
+              line_items: {
+                "0" => { variant_id: variant.to_param, quantity: 5 }
+              },
+              shipments_attributes: [{ stock_location_id: stock_location.id }]
+            }
+          }
+          expect(response.status).to eq 201
+          expect(Spree::Order.last.shipments.first).to_not eq(nil)
+        end
       end
 
       context "updating" do


### PR DESCRIPTION
I found some problems when trying to create and order with shipment through api.

The errors comes from `Importer::Order`, that the api use for [create orders](https://github.com/solidusio/solidus/blob/master/api/app/controllers/spree/api/orders_controller.rb#L30)

The first error comes from the [shipment creation](https://github.com/solidusio/solidus/blob/master/core/lib/spree/core/importer/order.rb#L51-L84), that was using parameters that are [not permitted](https://github.com/solidusio/solidus/blob/master/core/lib/spree/permitted_attributes.rb#L82)

And other problem was that when create line items, how this call [order.contents.add](https://github.com/solidusio/solidus/blob/master/core/lib/spree/core/importer/order.rb#L102), after item is [added](https://github.com/solidusio/solidus/blob/master/core/app/models/spree/order_contents.rb#L74) the  order [finish destroying all shipments](https://github.com/solidusio/solidus/blob/master/core/app/models/spree/order.rb#L556)

This update `create_shipments_from_params` to use permitted parameters and move the method to be called just after line items to avoid be deleted.