### PR TITLE
Harden frontend checkout spec

### DIFF
--- a/frontend/spec/features/checkout_spec.rb
+++ b/frontend/spec/features/checkout_spec.rb
@@ -341,7 +341,7 @@ describe "Checkout", type: :feature, inaccessible: true do
       }.not_to change { Spree::CreditCard.count }
 
       click_on "Place Order"
-      expect(page).to have_current_path(spree.order_path(Spree::Order.last))
+      expect(page).to have_content I18n.t(:order_processed_successfully, scope: :spree)
     end
 
     it "allows user to enter a new source" do
@@ -359,7 +359,7 @@ describe "Checkout", type: :feature, inaccessible: true do
       expect(Spree::CreditCard.last.address).to be_present
 
       click_on "Place Order"
-      expect(page).to have_current_path(spree.order_path(Spree::Order.last))
+      expect(page).to have_content I18n.t(:order_processed_successfully, scope: :spree)
     end
   end
 
@@ -389,7 +389,7 @@ describe "Checkout", type: :feature, inaccessible: true do
       click_on "Save and Continue"
       click_on "Place Order"
 
-      expect(page).to have_current_path(spree.order_path(Spree::Order.last))
+      expect(page).to have_content I18n.t(:order_processed_successfully, scope: :spree)
     end
   end
 
@@ -529,6 +529,7 @@ describe "Checkout", type: :feature, inaccessible: true do
 
       expect(current_path).to eq spree.checkout_state_path('confirm')
       click_button "Place Order"
+      expect(page).to have_content I18n.t(:order_processed_successfully, scope: :spree)
     end
   end
 


### PR DESCRIPTION
Capybara's `current_path` is not an auto-waiting matcher, that's why the
spec fails from time to time. By using a waiting matcher `has_content`
we make use of the Capybara auto-waiting and retry feature. This should
stabalize the spec.