### PR TITLE
Promotions admin UI fixes

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/templates/promotions/calculators/fields/tiered_flat_rate.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/promotions/calculators/fields/tiered_flat_rate.hbs
@@ -1,7 +1,7 @@
 <div class="fullwidth tier">
+  <a class="fa fa-trash remove js-remove-tier"></a>
   <div class="row">
     <div class="col-6">
-      <a class="fa fa-trash remove js-remove-tier"></a>
       <div class="input-group">
         <span class="input-group-addon">$</span>
         <input class="js-base-input form-control" type="text" value={{baseField.value}}>

--- a/backend/app/assets/stylesheets/spree/backend/sections/_promotions.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/_promotions.scss
@@ -18,7 +18,7 @@
   }
 }
 
-#promotion-pilicy-select {
+#promotion-policy-select {
   overflow: auto;
 }
 

--- a/backend/app/assets/stylesheets/spree/backend/sections/_promotions.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/_promotions.scss
@@ -35,6 +35,11 @@
     margin-bottom: 0;
   }
 
+  // Fix the padding added by the .fa icon rule
+  .fa:before {
+    padding-right: 0;
+  }
+
   .promo-rule-option-value {
     position: relative;
     padding-bottom: 10px;
@@ -42,7 +47,7 @@
     .remove {
       cursor: pointer;
       position: absolute;
-      right: 10px;
+      right: 0;
       top: 10px;
 
       &:hover {
@@ -120,7 +125,7 @@
   a.delete {
     position: absolute;
     top: 1.25rem;
-    right: 0.75rem;
+    right: 1.25rem;
     cursor: pointer;
 
     &:hover {

--- a/backend/app/assets/stylesheets/spree/backend/sections/_promotions.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/_promotions.scss
@@ -139,6 +139,7 @@
   font-size: 1rem;
   border-bottom: 1px solid $color-border;
   padding: 0.75rem 0;
+  margin-bottom: 0.75rem;
 
   &.no-text {
     border: none;

--- a/backend/app/assets/stylesheets/spree/backend/sections/_promotions.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/_promotions.scss
@@ -20,6 +20,7 @@
 
 #promotion-policy-select {
   overflow: auto;
+  margin-bottom: 1.5rem;
 }
 
 .promotion-block {

--- a/backend/app/assets/stylesheets/spree/backend/sections/_promotions.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/_promotions.scss
@@ -24,7 +24,7 @@
 }
 
 .promotion-block {
-  padding: 0 1.25rem;
+  padding: 0 1.25rem 0.5rem;
   background-color: lighten($color-border, 5);
   border: 1px solid $color-border;
   border-radius: 3px;
@@ -144,5 +144,6 @@
   &.no-text {
     border: none;
     padding-bottom: 0;
+    margin-bottom: 0.25rem;
   }
 }

--- a/backend/app/assets/stylesheets/spree/backend/sections/_promotions.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/_promotions.scss
@@ -24,7 +24,7 @@
 }
 
 .promotion-block {
-  // padding: 0 5px 5px;
+  padding: 0 1.25rem;
   background-color: lighten($color-border, 5);
   border: 1px solid $color-border;
   border-radius: 3px;
@@ -119,8 +119,8 @@
 
   a.delete {
     position: absolute;
-    top: 3px;
-    right: 5px;
+    top: 1.25rem;
+    right: 0.75rem;
     cursor: pointer;
 
     &:hover {
@@ -131,9 +131,9 @@
 
 .promotion-title {
   text-align: left;
-  font-size: 85%;
+  font-size: 1rem;
   border-bottom: 1px solid $color-border;
-  padding: 0 10px;
+  padding: 0.75rem 0;
 
   &.no-text {
     border: none;

--- a/backend/app/views/spree/admin/promotions/_actions.html.erb
+++ b/backend/app/views/spree/admin/promotions/_actions.html.erb
@@ -7,7 +7,7 @@
       <% if can?(:update, @promotion) %>
         <div class="field">
           <%= label_tag :action_type, t('spree.add_action_of_type')%>
-          <%= select_tag 'action_type', options, class: 'custom-select fullwidth' %>
+          <%= select_tag 'action_type', options, include_blank: t(:choose_promotion_action, scope: 'spree'), class: 'custom-select fullwidth' %>
         </div>
         <div class="filter-actions actions">
           <%= button t('spree.actions.add') %>

--- a/backend/app/views/spree/admin/promotions/_actions.html.erb
+++ b/backend/app/views/spree/admin/promotions/_actions.html.erb
@@ -3,7 +3,7 @@
   <%= form_tag spree.admin_promotion_promotion_actions_path(@promotion), remote: true, id: 'new_promotion_action_form' do %>
     <% options = options_for_select(  Rails.application.config.spree.promotions.actions.map {|action| [ action.model_name.human, action.name] } ) %>
     <fieldset>
-      <legend align="center"><%= plural_resource_name(Spree::PromotionAction) %></legend>
+      <legend align="center"><%= t('spree.promotion_actions') %></legend>
       <% if can?(:update, @promotion) %>
         <div class="field">
           <%= label_tag :action_type, t('spree.add_action_of_type')%>

--- a/backend/app/views/spree/admin/promotions/_form.html.erb
+++ b/backend/app/views/spree/admin/promotions/_form.html.erb
@@ -12,8 +12,10 @@
           <% end %>
 
           <%= f.field_container :advertise do %>
-            <%= f.check_box :advertise %>
-            <%= f.label :advertise %>
+            <%= label_tag do %>
+              <%= f.check_box :advertise %>
+              <%= Spree::Promotion.human_attribute_name(:advertise) %>
+            <% end %>
           <% end %>
         </div>
 

--- a/backend/app/views/spree/admin/promotions/_promotion_rule.html.erb
+++ b/backend/app/views/spree/admin/promotions/_promotion_rule.html.erb
@@ -1,6 +1,6 @@
 <div class="promotion_rule promotion-block col-12" id="<%= dom_id promotion_rule %>">
   <% type_name = promotion_rule.model_name.element %>
-  <h6 class='promotion-title <%= 'no-text' if type_name == 'user_logged_in' || type_name == 'first_order'%>'><%= promotion_rule.class.human_attribute_name(:description) %></h6>
+  <h6 class='promotion-title <%= 'no-text' if type_name.in? %w(user_logged_in first_order one_use_per_user) %>'><%= promotion_rule.class.human_attribute_name(:description) %></h6>
   <% if can?(:destroy, promotion_rule) %>
     <%= link_to_with_icon 'trash', '', spree.admin_promotion_promotion_rule_path(@promotion, promotion_rule), remote: true, method: :delete, class: 'delete' %>
   <% end %>

--- a/backend/app/views/spree/admin/promotions/_rules.html.erb
+++ b/backend/app/views/spree/admin/promotions/_rules.html.erb
@@ -19,7 +19,7 @@
 
     <%= form_for @promotion, url: object_url, method: :put do |f| %>
       <fieldset class="no-border-top">
-        <div id="promotion-pilicy-select" class="align-center row">
+        <div id="promotion-policy-select" class="align-center row">
           <% Spree::Promotion::MATCH_POLICIES.each do |policy| %>
             <div class="col-6">
               <label><%= f.radio_button :match_policy, policy %> <%= t "spree.promotion_form.match_policies.#{policy}" %></label>

--- a/backend/app/views/spree/admin/promotions/_rules.html.erb
+++ b/backend/app/views/spree/admin/promotions/_rules.html.erb
@@ -7,7 +7,7 @@
       <% if can?(:update, @promotion) %>
         <div class="field">
           <%= label_tag :promotion_rule_type, t('spree.add_rule_of_type') %>
-          <%= select_tag('promotion_rule[type]', options_for_promotion_rule_types(@promotion), class: 'custom-select fullwidth') %>
+          <%= select_tag('promotion_rule[type]', options_for_promotion_rule_types(@promotion), include_blank: t(:choose_promotion_rule, scope: 'spree'), class: 'custom-select fullwidth') %>
         </div>
         <div class="filter-actions actions">
           <%= button t('spree.actions.add') %>

--- a/backend/app/views/spree/admin/promotions/actions/_create_quantity_adjustments.html.erb
+++ b/backend/app/views/spree/admin/promotions/actions/_create_quantity_adjustments.html.erb
@@ -1,13 +1,7 @@
-<div class="col-12">
-  <div class="row">
-    <div class="col-12">
-      <div class="field">
-        <% field_name = "#{param_prefix}[preferred_group_size]" %>
-        <%= label_tag field_name, t('spree.group_size') %>
-        <%= number_field_tag field_name, promotion_action.preferred_group_size, class: "fullwidth", min: 1 %>
-      </div>
-    </div>
-  </div>
+<div class="field">
+  <% field_name = "#{param_prefix}[preferred_group_size]" %>
+  <%= label_tag field_name, t('spree.group_size') %>
+  <%= number_field_tag field_name, promotion_action.preferred_group_size, class: "fullwidth", min: 1 %>
 </div>
 
 <%= render "spree/admin/promotions/actions/create_item_adjustments",

--- a/backend/app/views/spree/admin/promotions/actions/_promotion_calculators_with_custom_fields.html.erb
+++ b/backend/app/views/spree/admin/promotions/actions/_promotion_calculators_with_custom_fields.html.erb
@@ -1,33 +1,29 @@
-<div class="col-12">
-  <div class="calculator-fields js-calculator-fields row">
-
-    <div class="col-6">
-      <div class="field">
-        <% field_name = "#{param_prefix}[calculator_type]" %>
-        <%= label_tag field_name, Spree::Calculator.model_name.human %>
-        <%= select_tag field_name,
-                      options_from_collection_for_select(calculators, :to_s, :description, promotion_action.calculator.type),
-                      class: 'type-select js-calculator-type custom-select fullwidth' %>
-      </div>
+<div class="calculator-fields js-calculator-fields row">
+  <div class="col-6">
+    <div class="field">
+      <% field_name = "#{param_prefix}[calculator_type]" %>
+      <%= label_tag field_name, t('spree.calculator') %>
+      <%= select_tag field_name,
+                    options_from_collection_for_select(calculators, :to_s, :description, promotion_action.calculator.type),
+                    class: 'type-select js-calculator-type custom-select fullwidth' %>
     </div>
-
-    <div class="col-6">
-      <div class="settings">
-        <% calculators.each do |calculator_class| %>
-          <% calculator = promotion_action.calculator.class == calculator_class ? promotion_action.calculator : calculator_class.new %>
-          <div class="js-calculator-preferences" data-calculator-type="<%= calculator_class %>">
-            <% type_name = calculator.type.demodulize.underscore %>
-            <% if lookup_context.exists?("fields",
-                ["spree/admin/promotions/calculators/#{type_name}"], true) %>
-              <%= render "spree/admin/promotions/calculators/#{type_name}/fields",
-                calculator: calculator, prefix: param_prefix %>
-            <% else %>
-              <%= render "spree/admin/promotions/calculators/default_fields",
-                calculator: calculator, prefix: param_prefix %>
-            <% end %>
-          </div>
-        <% end %>
-      </div>
+  </div>
+  <div class="col-6">
+    <div class="settings">
+      <% calculators.each do |calculator_class| %>
+        <% calculator = promotion_action.calculator.class == calculator_class ? promotion_action.calculator : calculator_class.new %>
+        <div class="js-calculator-preferences" data-calculator-type="<%= calculator_class %>">
+          <% type_name = calculator.type.demodulize.underscore %>
+          <% if lookup_context.exists?("fields",
+              ["spree/admin/promotions/calculators/#{type_name}"], true) %>
+            <%= render "spree/admin/promotions/calculators/#{type_name}/fields",
+              calculator: calculator, prefix: param_prefix %>
+          <% else %>
+            <%= render "spree/admin/promotions/calculators/default_fields",
+              calculator: calculator, prefix: param_prefix %>
+          <% end %>
+        </div>
+      <% end %>
     </div>
   </div>
 </div>

--- a/backend/app/views/spree/admin/promotions/actions/_promotion_calculators_with_custom_fields.html.erb
+++ b/backend/app/views/spree/admin/promotions/actions/_promotion_calculators_with_custom_fields.html.erb
@@ -2,7 +2,7 @@
   <div class="col-6">
     <div class="field">
       <% field_name = "#{param_prefix}[calculator_type]" %>
-      <%= label_tag field_name, t('spree.calculator') %>
+      <%= label_tag field_name, t('spree.admin.promotions.actions.calculator_label') %>
       <%= select_tag field_name,
                     options_from_collection_for_select(calculators, :to_s, :description, promotion_action.calculator.type),
                     class: 'type-select js-calculator-type custom-select fullwidth' %>

--- a/backend/app/views/spree/admin/promotions/calculators/distributed_amount/_fields.html.erb
+++ b/backend/app/views/spree/admin/promotions/calculators/distributed_amount/_fields.html.erb
@@ -1,7 +1,9 @@
-<%= fields_for "#{prefix}[calculator_attributes]", calculator do |f| %>
-  <%= f.label :preferred_amount %>
-  <%= render "spree/admin/shared/number_with_currency", f: f, amount_attr: :preferred_amount, currency_attr: :preferred_currency %>
-<% end %>
+<div class="field">
+  <%= fields_for "#{prefix}[calculator_attributes]", calculator do |f| %>
+    <%= f.label :preferred_amount %>
+    <%= render "spree/admin/shared/number_with_currency", f: f, amount_attr: :preferred_amount, currency_attr: :preferred_currency %>
+  <% end %>
+</div>
 
 <div class="field">
   <p>

--- a/backend/app/views/spree/admin/promotions/calculators/flat_rate/_fields.html.erb
+++ b/backend/app/views/spree/admin/promotions/calculators/flat_rate/_fields.html.erb
@@ -1,4 +1,6 @@
-<%= fields_for "#{prefix}[calculator_attributes]", calculator do |f| %>
-  <%= f.label :preferred_amount %>
-  <%= render "spree/admin/shared/number_with_currency", f: f, amount_attr: :preferred_amount, currency_attr: :preferred_currency %>
-<% end %>
+<div class="field">
+  <%= fields_for "#{prefix}[calculator_attributes]", calculator do |f| %>
+    <%= f.label :preferred_amount %>
+    <%= render "spree/admin/shared/number_with_currency", f: f, amount_attr: :preferred_amount, currency_attr: :preferred_currency %>
+  <% end %>
+</div>

--- a/backend/app/views/spree/admin/promotions/rules/_item_total.html.erb
+++ b/backend/app/views/spree/admin/promotions/rules/_item_total.html.erb
@@ -1,16 +1,14 @@
-<div class="col-12">
-  <div class="row">
-    <div class="col-6">
-      <div class="field">
-        <%= select_tag "#{param_prefix}[preferred_operator]", options_for_select(Spree::Promotion::Rules::ItemTotal::OPERATORS.map{|o| [t(o, scope: 'spree.item_total_rule.operators'),o]}, promotion_rule.preferred_operator), {class: 'custom-select select_item_total fullwidth'} %>
-      </div>
+<div class="row">
+  <div class="col-6">
+    <div class="field">
+      <%= select_tag "#{param_prefix}[preferred_operator]", options_for_select(Spree::Promotion::Rules::ItemTotal::OPERATORS.map{|o| [t(o, scope: 'spree.item_total_rule.operators'),o]}, promotion_rule.preferred_operator), {class: 'custom-select select_item_total fullwidth'} %>
     </div>
-    <div class="col-6">
-      <div class="field">
-        <%= fields_for param_prefix, promotion_rule do |f| %>
-          <%= render "spree/admin/shared/number_with_currency", f: f, amount_attr: :preferred_amount, currency_attr: :preferred_currency %>
-        <% end %>
-      </div>
+  </div>
+  <div class="col-6">
+    <div class="field">
+      <%= fields_for param_prefix, promotion_rule do |f| %>
+        <%= render "spree/admin/shared/number_with_currency", f: f, amount_attr: :preferred_amount, currency_attr: :preferred_currency %>
+      <% end %>
     </div>
   </div>
 </div>

--- a/backend/app/views/spree/admin/promotions/rules/_landing_page.html.erb
+++ b/backend/app/views/spree/admin/promotions/rules/_landing_page.html.erb
@@ -1,7 +1,0 @@
-<div class="col-12">
-  <div class="field">
-    <label for="<%= "#{param_prefix}_preferred_path" %>"><%= Spree::Promotion::Rules::LandingPage.human_attribute_name(:description) %>:</label>
-    <%= text_field_tag "#{param_prefix}[preferred_path]", promotion_rule.preferred_path, class: 'fullwidth' %>  
-    <span class="info"><%= t('spree.landing_page_rule.must_have_visited_path') %></span>
-  </div>
-</div>

--- a/backend/app/views/spree/admin/promotions/rules/_nth_order.html.erb
+++ b/backend/app/views/spree/admin/promotions/rules/_nth_order.html.erb
@@ -1,14 +1,12 @@
-<div class="col-12">
-  <div class="row">
-    <div class="col-6">
-      <div class="field">
-        <%= Spree::Promotion::Rules::NthOrder.human_attribute_name(:form_text) %>
-      </div>
+<div class="row">
+  <div class="col-6">
+    <div class="field">
+      <%= Spree::Promotion::Rules::NthOrder.human_attribute_name(:form_text) %>
     </div>
-    <div class="col-6">
-      <div class="field">
-        <%= number_field_tag "#{param_prefix}[preferred_nth_order]", promotion_rule.preferred_nth_order, class: 'fullwidth' %>
-      </div>
+  </div>
+  <div class="col-6">
+    <div class="field">
+      <%= number_field_tag "#{param_prefix}[preferred_nth_order]", promotion_rule.preferred_nth_order, class: 'fullwidth' %>
     </div>
   </div>
 </div>

--- a/backend/app/views/spree/admin/promotions/rules/_option_value.html.erb
+++ b/backend/app/views/spree/admin/promotions/rules/_option_value.html.erb
@@ -1,16 +1,13 @@
-<div class="col-12">
-  <div class="field promo-rule-option-values">
-    <div class="param-prefix hidden" data-param-prefix="<%= param_prefix %>"></div>
-    <div class="row">
-      <div class="col-6"><%= label_tag nil, Spree::Product.model_name.human %></div>
-      <div class="col-6"><%= label_tag nil, plural_resource_name(Spree::OptionValue) %></div>
-    </div>
-    <div class="clear"></div>
-
-    <div class="js-promo-rule-option-values"></div>
-
-    <button class="button js-add-promo-rule-option-value"><%= t('spree.actions.add') %></button>
+<div class="field promo-rule-option-values">
+  <div class="param-prefix hidden" data-param-prefix="<%= param_prefix %>"></div>
+  <div class="row">
+    <div class="col-6"><%= label_tag nil, Spree::Product.model_name.human %></div>
+    <div class="col-6"><%= label_tag nil, plural_resource_name(Spree::OptionValue) %></div>
   </div>
+
+  <div class="js-promo-rule-option-values"></div>
+
+  <button class="button js-add-promo-rule-option-value"><%= t('spree.actions.add') %></button>
 </div>
 
 <%= content_tag :div, nil, class: "hidden js-original-promo-rule-option-values",

--- a/backend/app/views/spree/admin/promotions/rules/_product.html.erb
+++ b/backend/app/views/spree/admin/promotions/rules/_product.html.erb
@@ -1,13 +1,15 @@
-<div class="col-12">
-  <div class="field products_rule_products">
-    <%= label_tag "#{param_prefix}_product_ids_string", t('spree.product_rule.choose_products') %>
-    <%= hidden_field_tag "#{param_prefix}[product_ids_string]", promotion_rule.product_ids.join(","), class: "product_picker fullwidth" %>
+<div class="row">
+  <div class="col-12">
+    <div class="field products_rule_products">
+      <%= label_tag "#{param_prefix}_product_ids_string", t('spree.product_rule.choose_products') %>
+      <%= hidden_field_tag "#{param_prefix}[product_ids_string]", promotion_rule.product_ids.join(","), class: "product_picker fullwidth" %>
+    </div>
   </div>
-</div>
-<div class="col-12">
-  <div class="field">
-    <label>
-      <%= t('spree.product_rule.label', select: select_tag("#{param_prefix}[preferred_match_policy]", options_for_select(Spree::Promotion::Rules::Product::MATCH_POLICIES.map{|s| [t("spree.product_rule.match_#{s}"),s] }, promotion_rule.preferred_match_policy), {class: 'select_product custom-select'})).html_safe %>
-    </label>
+  <div class="col-12">
+    <div class="field">
+      <label>
+        <%= t('spree.product_rule.label', select: select_tag("#{param_prefix}[preferred_match_policy]", options_for_select(Spree::Promotion::Rules::Product::MATCH_POLICIES.map{|s| [t("spree.product_rule.match_#{s}"),s] }, promotion_rule.preferred_match_policy), {class: 'select_product custom-select'})).html_safe %>
+      </label>
+    </div>
   </div>
 </div>

--- a/backend/app/views/spree/admin/promotions/rules/_taxon.html.erb
+++ b/backend/app/views/spree/admin/promotions/rules/_taxon.html.erb
@@ -1,15 +1,9 @@
-  <div class="row">
-    <div class="col-11">
-      <div class="field taxons_rule_taxons">
-        <%= label_tag "#{param_prefix}_taxon_ids_string", t('spree.taxon_rule.choose_taxons') %>
-        <%= hidden_field_tag "#{param_prefix}[taxon_ids_string]", promotion_rule.taxon_ids.join(","), class: "taxon_picker fullwidth", id: 'product_taxon_ids' %>
-      </div>
-    </div>
-    <div class="col-12">
-      <div class="field">
-        <label>
-          <%= t('spree.taxon_rule.label', select: select_tag("#{param_prefix}[preferred_match_policy]", options_for_select(Spree::Promotion::Rules::Taxon::MATCH_POLICIES.map{|s| [t("spree.taxon_rule.match_#{s}"),s] }, promotion_rule.preferred_match_policy), {class: 'select_taxon custom-select'})).html_safe %>
-        </label>
-      </div>
-    </div>
-  </div>
+<div class="field taxons_rule_taxons">
+  <%= label_tag "#{param_prefix}_taxon_ids_string", t('spree.taxon_rule.choose_taxons') %>
+  <%= hidden_field_tag "#{param_prefix}[taxon_ids_string]", promotion_rule.taxon_ids.join(","), class: "taxon_picker fullwidth", id: 'product_taxon_ids' %>
+</div>
+<div class="field">
+  <label>
+    <%= t('spree.taxon_rule.label', select: select_tag("#{param_prefix}[preferred_match_policy]", options_for_select(Spree::Promotion::Rules::Taxon::MATCH_POLICIES.map{|s| [t("spree.taxon_rule.match_#{s}"),s] }, promotion_rule.preferred_match_policy), {class: 'select_taxon custom-select'})).html_safe %>
+  </label>
+</div>

--- a/backend/app/views/spree/admin/promotions/rules/_user.html.erb
+++ b/backend/app/views/spree/admin/promotions/rules/_user.html.erb
@@ -1,6 +1,4 @@
-<div class="col-12">
-  <div class="field">
-    <label><%= t('spree.user_rule.choose_users') %></label><br>
-    <input type='hidden' name='<%= param_prefix %>[user_ids_string]' class='user_picker fullwidth' value='<%= promotion_rule.user_ids.join(",") %>'>
-  </div>
+<div class="field">
+  <label><%= t('spree.user_rule.choose_users') %></label><br>
+  <input type='hidden' name='<%= param_prefix %>[user_ids_string]' class='user_picker fullwidth' value='<%= promotion_rule.user_ids.join(",") %>'>
 </div>

--- a/backend/app/views/spree/admin/promotions/rules/_user_role.html.erb
+++ b/backend/app/views/spree/admin/promotions/rules/_user_role.html.erb
@@ -3,7 +3,7 @@
   <%= select_tag "#{param_prefix}[preferred_role_ids]",
     options_from_collection_for_select(
       Spree::Role.all, :id, :name, promotion_rule.preferred_role_ids
-    ), class: 'custom-select fullwidth', multiple: true %>
+    ), class: 'select2 fullwidth', multiple: true %>
 </div>
 <div class="form-group">
   <label>

--- a/backend/spec/features/admin/promotion_adjustments_spec.rb
+++ b/backend/spec/features/admin/promotion_adjustments_spec.rb
@@ -25,7 +25,7 @@ describe "Promotion Adjustments", type: :feature, js: true do
       select "Create whole-order adjustment", from: "Add action of type"
       within('#action_fields') do
         click_button "Add"
-        select "Flat Rate", from: "Base Calculator"
+        select "Flat Rate", from: I18n.t('spree.admin.promotions.actions.calculator_label')
         fill_in "Amount", with: 5
       end
       within('#actions_container') { click_button "Update" }
@@ -56,7 +56,7 @@ describe "Promotion Adjustments", type: :feature, js: true do
       select "Create whole-order adjustment", from: "Add action of type"
       within('#action_fields') do
         click_button "Add"
-        select "Flat Rate", from: "Base Calculator"
+        select "Flat Rate", from: I18n.t('spree.admin.promotions.actions.calculator_label')
         fill_in "Amount", with: "5"
       end
       within('#actions_container') { click_button "Update" }
@@ -88,7 +88,7 @@ describe "Promotion Adjustments", type: :feature, js: true do
       select "Create whole-order adjustment", from: "Add action of type"
       within('#action_fields') do
         click_button "Add"
-        select "Flat Percent", from: "Base Calculator"
+        select "Flat Percent", from: I18n.t('spree.admin.promotions.actions.calculator_label')
         fill_in "Flat Percent", with: "10"
       end
       within('#actions_container') { click_button "Update" }
@@ -124,7 +124,7 @@ describe "Promotion Adjustments", type: :feature, js: true do
       select "Create per-line-item adjustment", from: "Add action of type"
       within('#action_fields') do
         click_button "Add"
-        select "Percent Per Item", from: "Base Calculator"
+        select "Percent Per Item", from: I18n.t('spree.admin.promotions.actions.calculator_label')
         fill_in "Percent", with: "10"
       end
       within('#actions_container') { click_button "Update" }
@@ -225,7 +225,7 @@ describe "Promotion Adjustments", type: :feature, js: true do
       select "Create whole-order adjustment", from: "Add action of type"
       within('#action_fields') do
         click_button "Add"
-        select "Flat Rate", from: "Base Calculator"
+        select "Flat Rate", from: I18n.t('spree.admin.promotions.actions.calculator_label')
         fill_in "Amount", with: "5"
       end
       within('#actions_container') { click_button "Update" }

--- a/backend/spec/features/admin/promotions/tiered_calculator_spec.rb
+++ b/backend/spec/features/admin/promotions/tiered_calculator_spec.rb
@@ -13,7 +13,7 @@ feature "Tiered Calculator Promotions" do
     select "Create whole-order adjustment", from: "Add action of type"
     within('#action_fields') { click_button "Add" }
 
-    select "Tiered Percent", from: "Base Calculator"
+    select "Tiered Percent", from: I18n.t('spree.admin.promotions.actions.calculator_label')
     within('#actions_container') { click_button "Update" }
 
     within("#actions_container .settings") do

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -855,6 +855,8 @@ en:
           auto: All orders will attempt to use this promotion
           single_code_html: "This promotion uses the promotion code: <code>%{code}</code>"
           multiple_codes_html: "This promotion uses %{count} promotion codes"
+        actions:
+          calculator_label: Calculated by
       stock_locations:
         form:
           general: General

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1081,6 +1081,7 @@ en:
     choose_currency: Choose Currency
     choose_dashboard_locale: Choose Dashboard Locale
     choose_location: Choose location
+    choose_promotion_action: Choose action
     choose_promotion_rule: Choose rule
     city: City
     clear_cache: Clear Cache

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1081,6 +1081,7 @@ en:
     choose_currency: Choose Currency
     choose_dashboard_locale: Choose Dashboard Locale
     choose_location: Choose location
+    choose_promotion_rule: Choose rule
     city: City
     clear_cache: Clear Cache
     clear_cache_ok: Cache was flushed


### PR DESCRIPTION
The promotions UI has some smaller glitches. Mostly wrong padding and margins, due to the various layout changes we went through in the last couple of months.

Best reviewed commit by commit, pulled and ran in the local sandbox.

### Before

![localhost_3000_admin_promotions_1_edit laptop with hidpi screen 1](https://user-images.githubusercontent.com/42868/33218009-ee6352ca-d13a-11e7-9fec-b4508b5c4ce2.png)

### After

![localhost_3000_admin_promotions_1_edit laptop with hidpi screen](https://user-images.githubusercontent.com/42868/33218019-f841b44e-d13a-11e7-8f0e-6213aa28b2d9.png)