### PR TITLE
Recalculate order inside UnitCancel adjust!

### DIFF
--- a/core/app/models/spree/unit_cancel.rb
+++ b/core/app/models/spree/unit_cancel.rb
@@ -24,6 +24,9 @@ class Spree::UnitCancel < Spree::Base
       eligible: true,
       finalized: true
     )
+
+    inventory_unit.line_item.order.recalculate
+    adjustment
   end
 
   # This method is used by Adjustment#update to recalculate the cost.

--- a/core/spec/models/spree/order_cancellations_spec.rb
+++ b/core/spec/models/spree/order_cancellations_spec.rb
@@ -95,6 +95,24 @@ RSpec.describe Spree::OrderCancellations do
       expect { subject }.to change { order.total }.by(-10.0)
     end
 
+    context "multiple inventory units" do
+      subject { Spree::OrderCancellations.new(order).short_ship(inventory_units) }
+      let!(:order) { create(:order_with_line_items) }
+      let!(:inventory_units) do
+        order.line_items.first.quantity = 4
+        # It already has 1 line_item in it
+        3.times do
+          create(:inventory_unit, line_item: order.line_items.first)
+        end
+        order.recalculate
+        order.line_items.first.inventory_units.to_a
+      end
+
+      it "adjusts the order" do
+        expect { subject }.to change { order.total }.by(-40.0)
+      end
+    end
+
     it "sends a cancellation email" do
       mail_double = double
       expect(Spree::OrderMailer).to receive(:inventory_cancellation_email).with(order, [inventory_unit]).and_return(mail_double)

--- a/core/spec/models/spree/unit_cancel_spec.rb
+++ b/core/spec/models/spree/unit_cancel_spec.rb
@@ -55,5 +55,27 @@ RSpec.describe Spree::UnitCancel do
         expect { subject }.to raise_error RuntimeError, "Adjustable does not match line item"
       end
     end
+
+    context "multiple inventory units" do
+      let(:line_item) { create(:line_item, quantity: 4, price: 100.0) }
+
+      let(:inventory_units) do
+        [
+          create(:inventory_unit, line_item: line_item),
+          create(:inventory_unit, line_item: line_item),
+          create(:inventory_unit, line_item: line_item),
+          create(:inventory_unit, line_item: line_item),
+        ]
+      end
+
+      it "properly creates adjustments for line_item" do
+        inventory_units.each do |inventory_unit|
+          Spree::UnitCancel.create!(inventory_unit: inventory_unit, reason: Spree::UnitCancel::SHORT_SHIP).adjust!
+          inventory_unit.cancel!
+          line_item.reload
+        end
+        expect(line_item.total.to_d).to eq(0)
+      end
+    end
   end
 end

--- a/core/spec/models/spree/unit_cancel_spec.rb
+++ b/core/spec/models/spree/unit_cancel_spec.rb
@@ -57,7 +57,14 @@ RSpec.describe Spree::UnitCancel do
     end
 
     context "multiple inventory units" do
-      let(:line_item) { create(:line_item, quantity: 4, price: 100.0) }
+      let(:order) { create(:order_with_line_items) }
+      let(:line_item) do
+        # Change our quantity to 4
+        order.line_items.first.quantity = 4
+        # Make sure that there are no inventory_units before
+        order.line_items.first.inventory_units.clear
+        order.line_items.first
+      end
 
       let(:inventory_units) do
         [
@@ -72,7 +79,6 @@ RSpec.describe Spree::UnitCancel do
         inventory_units.each do |inventory_unit|
           Spree::UnitCancel.create!(inventory_unit: inventory_unit, reason: Spree::UnitCancel::SHORT_SHIP).adjust!
           inventory_unit.cancel!
-          line_item.reload
         end
         expect(line_item.total.to_d).to eq(0)
       end


### PR DESCRIPTION
This follows along with #2380 and provides a spec for the issue and an alternate fix. I have changed the `order.update!` call to be `order.recalculate` and moved it into the `adjust!` method. This keeps the original compute function clear of side effects.