### PR TITLE
Fix frontend spec CC entry.

### DIFF
--- a/frontend/spec/features/checkout_spec.rb
+++ b/frontend/spec/features/checkout_spec.rb
@@ -348,7 +348,7 @@ describe "Checkout", type: :feature, inaccessible: true do
       choose "use_existing_card_no"
 
       fill_in "Name on card", with: 'Spree Commerce'
-      fill_in "Card Number", with: '4111111111111111'
+      fill_in "Card Number", with: '4111 1111 1111 1111'
       fill_in "card_expiry", with: '04 / 20'
       fill_in "Card Code", with: '123'
 
@@ -522,7 +522,7 @@ describe "Checkout", type: :feature, inaccessible: true do
 
       choose "Credit Card"
       fill_in "Name on card", with: 'Spree Commerce'
-      fill_in "Card Number", with: '4111111111111111'
+      fill_in "Card Number", with: '4111 1111 1111 1111'
       fill_in "card_expiry", with: '04 / 20'
       fill_in "Card Code", with: '123'
       click_button "Save and Continue"
@@ -655,7 +655,7 @@ describe "Checkout", type: :feature, inaccessible: true do
       click_on "Save and Continue"
       click_on "Save and Continue"
 
-      fill_in_credit_card(number: "4111111111111111")
+      fill_in_credit_card(number: "4111 1111 1111 1111")
       click_on "Save and Continue"
 
       expect(page).to have_current_path("/checkout/confirm")


### PR DESCRIPTION
Alternative to #2399
Related to #2386

Sometimes when running frontend's `spec/features/checkout_spec.rb`, the payment fails.

![](http://i.hawth.ca/u/screenshot_2017-11-24-14-18-47.907.png)

When I take the screenshot before submitting the button it looks like the credit card hasn't been entered correctly.

![](http://i.hawth.ca/u/screenshot_2017-11-24-14-20-06.471.png)

So I think this is the same issue as #2386, but with the CC field, not the expiry.

This is fixed by filling in the CC with spaces. I still don't know why this fixes the issue and it might just be because it slows down the input enough. It does make the spec pass reliably, though.