### PR TITLE
Uniform how we create sample store in deafult and sample data

### DIFF
--- a/core/db/default/spree/stores.rb
+++ b/core/db/default/spree/stores.rb
@@ -1,9 +1,8 @@
-# Possibly already created by a migration.
-unless Spree::Store.where(code: 'spree').exists?
-  Spree::Store.new do |s|
-    s.code              = 'spree'
-    s.name              = 'Sample Store'
-    s.url               = 'example.com'
-    s.mail_from_address = 'store@example.com'
-  end.save!
+unless Spree::Store.where(code: 'sample-store').exists?
+  Spree::Store.create!(
+    name: "Sample Store",
+    code: "sample-store",
+    url: "example.com",
+    mail_from_address: "store@example.com"
+  )
 end

--- a/sample/db/samples/stores.rb
+++ b/sample/db/samples/stores.rb
@@ -1,6 +1,8 @@
-Spree::Store.create!(
-  name: "Sample Store",
-  code: "sample-store",
-  url: "solidus.example.com",
-  mail_from_address: "store@example.com"
-)
+unless Spree::Store.where(code: 'sample-store').exists?
+  Spree::Store.create!(
+    name: "Sample Store",
+    code: "sample-store",
+    url: "example.com",
+    mail_from_address: "store@example.com"
+  )
+end


### PR DESCRIPTION
Also, we are not creating a store in migrations since #2229, but populating database with default data and sample data (for example creating the sandbox) is creating two different stores.