### PR TITLE
Deprecate weird taxon product filters

### DIFF
--- a/core/app/models/spree/taxon.rb
+++ b/core/app/models/spree/taxon.rb
@@ -37,9 +37,6 @@ module Spree
     # @return [Array] filters that should be used for a taxon
     def applicable_filters
       fs = []
-      # fs << ProductFilters.taxons_below(self)
-      ## unless it's a root taxon? left open for demo purposes
-
       fs << Spree::Core::ProductFilters.price_filter if Spree::Core::ProductFilters.respond_to?(:price_filter)
       fs << Spree::Core::ProductFilters.brand_filter if Spree::Core::ProductFilters.respond_to?(:brand_filter)
       fs

--- a/core/lib/spree/core/product_filters.rb
+++ b/core/lib/spree/core/product_filters.rb
@@ -164,6 +164,7 @@ module Spree
       # This scope selects products in any of the active taxons or their children.
       #
       def self.taxons_below(taxon)
+        Spree::Deprecation.warn "taxons_below is deprecated in solidus_core. Please add it to your own application to continue using it."
         return Spree::Core::ProductFilters.all_taxons if taxon.nil?
         {
           name:   'Taxons under ' + taxon.name,

--- a/core/lib/spree/core/product_filters.rb
+++ b/core/lib/spree/core/product_filters.rb
@@ -181,6 +181,7 @@ module Spree
       #
       # idea: expand the format to allow nesting of labels?
       def self.all_taxons
+        Spree::Deprecation.warn "all_taxons is deprecated in solidus_core. Please add it to your own application to continue using it."
         taxons = Spree::Taxonomy.all.map { |t| [t.root] + t.root.descendants }.flatten
         {
           name:   'All taxons',

--- a/frontend/app/views/spree/shared/_filters.html.erb
+++ b/frontend/app/views/spree/shared/_filters.html.erb
@@ -1,4 +1,4 @@
-<% filters = @taxon ? @taxon.applicable_filters : [Spree::Core::ProductFilters.all_taxons] %>
+<% filters = @taxon.applicable_filters %>
 <% unless filters.empty? %>
   <%= form_tag '', method: :get, id: 'sidebar_products_search' do %>
     <%= hidden_field_tag 'per_page', params[:per_page] %>


### PR DESCRIPTION
This doesn't look like these were ever used, and I can't imagine anyone
finding them randomly and using them.

Better to pull these out of core and let people add it themselves if they
want it.

Also, they're untested.