### PR TITLE
Move Spree::Taxon#applicable_filters

### DIFF
--- a/core/app/models/spree/taxon.rb
+++ b/core/app/models/spree/taxon.rb
@@ -36,6 +36,8 @@ module Spree
     # @note This method is meant to be overridden on a store by store basis.
     # @return [Array] filters that should be used for a taxon
     def applicable_filters
+      Spree::Deprecation.warn "Spree::Taxon#applicable_filters is deprecated, if you are using this functionality please move it into your own application."
+
       fs = []
       # fs << ProductFilters.taxons_below(self)
       ## unless it's a root taxon? left open for demo purposes

--- a/frontend/app/controllers/spree/products_controller.rb
+++ b/frontend/app/controllers/spree/products_controller.rb
@@ -3,7 +3,7 @@ module Spree
     before_action :load_product, only: :show
     before_action :load_taxon, only: :index
 
-    helper 'spree/taxons'
+    helper 'spree/taxons', 'spree/taxon_filters'
 
     respond_to :html
 

--- a/frontend/app/controllers/spree/taxons_controller.rb
+++ b/frontend/app/controllers/spree/taxons_controller.rb
@@ -1,6 +1,6 @@
 module Spree
   class TaxonsController < Spree::StoreController
-    helper 'spree/products'
+    helper 'spree/products', 'spree/taxon_filters'
 
     respond_to :html
 

--- a/frontend/app/helpers/spree/taxon_filters_helper.rb
+++ b/frontend/app/helpers/spree/taxon_filters_helper.rb
@@ -1,0 +1,11 @@
+require 'spree/core/product_filters'
+
+module Spree
+  module TaxonFiltersHelper
+    def applicable_filters_for(_taxon)
+      [:brand_filter, :price_filter].map do |filter_name|
+        Spree::Core::ProductFilters.send(filter_name) if Spree::Core::ProductFilters.respond_to?(filter_name)
+      end.compact
+    end
+  end
+end

--- a/frontend/app/views/spree/shared/_filters.html.erb
+++ b/frontend/app/views/spree/shared/_filters.html.erb
@@ -1,4 +1,4 @@
-<% filters = @taxon ? @taxon.applicable_filters : [Spree::Core::ProductFilters.all_taxons] %>
+<% filters = @taxon ? applicable_filters_for(@taxon) : [Spree::Core::ProductFilters.all_taxons] %>
 <% unless filters.empty? %>
   <%= form_tag '', method: :get, id: 'sidebar_products_search' do %>
     <%= hidden_field_tag 'per_page', params[:per_page] %>

--- a/frontend/spec/helpers/taxon_filters_helper_spec.rb
+++ b/frontend/spec/helpers/taxon_filters_helper_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+RSpec.describe Spree::TaxonFiltersHelper, type: :helper do
+  let(:taxon) { nil }
+  subject { applicable_filters_for(taxon) }
+
+  it "returns the price/brand filters" do
+    expect(subject.map { |y| y[:name] }).to eq ['Brands', 'Price Range']
+  end
+end


### PR DESCRIPTION
How we handle product filters in core is pretty janky, as they're only used by our frontend but interwoven through core.

As is clear from [the documentation of product_filters](https://github.com/solidusio/solidus/blob/master/core/lib/spree/core/product_filters.rb):

> THIS FILE SHOULD BE OVER-RIDDEN IN YOUR SITE EXTENSION!
>   the exact code probably won't be useful, though you're welcome to modify and reuse
>   the current contents are mainly for testing and documentation

By moving the `Spree::Taxon#applicable_filters` call (which was untested) into the frontend, we can eventually remove the applicable_filters call in `Spree::Taxon` (along with its `@note This method is meant to be overridden on a store by store basis.`), which is just as easy to customize in a helper.

With #applicable_filters removed, we can then remove the product_filters requirement of Spree::Taxon.