### PR TITLE
Fix address validation switching to a country without states

### DIFF
--- a/frontend/app/assets/javascripts/spree/frontend/checkout/address.js
+++ b/frontend/app/assets/javascripts/spree/frontend/checkout/address.js
@@ -43,6 +43,7 @@ Spree.ready(function($) {
       var statePara = $("#" + region + "state");
       var stateSelect = statePara.find("select");
       var stateInput = statePara.find("input");
+      var stateSpanRequired = statePara.find('[id$="state-required"]');
       if (states.length > 0) {
         var selected = parseInt(stateSelect.val());
         stateSelect.html("");

--- a/frontend/app/views/spree/address/_form.html.erb
+++ b/frontend/app/views/spree/address/_form.html.erb
@@ -49,6 +49,7 @@
       <%= form.label :state, t('spree.state') %>
 
       <span class="js-address-fields" style="display: none;">
+        <%= form.hidden_field :state_id, value: nil %>
         <%=
           form.collection_select(
             :state_id, address.country.states, :id, :name,
@@ -60,6 +61,8 @@
               autocomplete: address_type + ' address-level1',
             })
           %>
+
+        <%= form.hidden_field :state_name, value: nil %>
         <%=
           form.text_field(
             :state_name,


### PR DESCRIPTION
Saving an address with a country without states, after saving an address that instead has states will raise a validation error, since we are not resetting the state. We always had this issue, it's just raising after #2371, which describes the same issue but for backend.

This PR fixes this problem by adding hidden fields that reset `state_id` and/or `state_name` if they are disabled (via js).

#### Why WIP?

It needs some specs as well, but I'd like to understand if it's better to perform this kind of state resets at model level instead. Any comment is appreciated!