### PR TITLE
Use I18n date format for `pretty_time` helper

### DIFF
--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -127,8 +127,8 @@ module Spree
       product_or_variant.price_for(current_pricing_options).to_html
     end
 
-    def pretty_time(time)
-      I18n.l(time, format: :solidus_long)
+    def pretty_time(time, format = :long)
+      I18n.l(time, format: :"solidus.#{format}")
     end
 
     def link_to_tracking(shipment, options = {})

--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -128,8 +128,7 @@ module Spree
     end
 
     def pretty_time(time)
-      [I18n.l(time.to_date, format: :long),
-       time.strftime("%l:%M %p")].join(" ")
+      I18n.l(time, format: :solidus_long)
     end
 
     def link_to_tracking(shipment, options = {})

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -701,7 +701,9 @@ en:
               has_to_be_payment_source_class: "has to be a Spree::PaymentSource"
   time:
     formats:
-      solidus_long: '%B %d, %Y %l:%M %p'
+      solidus:
+        long: '%B %d, %Y %-l:%M %p'
+        short: "%b %-d '%y %-l:%M%P"
   devise:
     confirmations:
       confirmed: Your account was successfully confirmed. You are now signed in.

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -699,7 +699,9 @@ en:
           attributes:
             payment_source:
               has_to_be_payment_source_class: "has to be a Spree::PaymentSource"
-
+  time:
+    formats:
+      solidus_long: '%B %d, %Y %l:%M %p'
   devise:
     confirmations:
       confirmed: Your account was successfully confirmed. You are now signed in.

--- a/core/spec/helpers/base_helper_spec.rb
+++ b/core/spec/helpers/base_helper_spec.rb
@@ -130,6 +130,14 @@ RSpec.describe Spree::BaseHelper, type: :helper do
     it "pretty prints time in long format" do
       is_expected.to eq "November 06, 2012 1:33 PM"
     end
+
+    context 'with format set to short' do
+      subject { pretty_time(date, :short) }
+
+      it "pretty prints time in short format" do
+        is_expected.to eq "Nov 6 '12 1:33pm"
+      end
+    end
   end
 
   context "plural_resource_name" do

--- a/core/spec/helpers/base_helper_spec.rb
+++ b/core/spec/helpers/base_helper_spec.rb
@@ -122,9 +122,13 @@ RSpec.describe Spree::BaseHelper, type: :helper do
     end
   end
 
-  context "pretty_time" do
-    it "prints in a format" do
-      expect(pretty_time(DateTime.new(2012, 5, 6, 13, 33))).to eq "May 06, 2012  1:33 PM"
+  describe "#pretty_time" do
+    subject { pretty_time(date) }
+
+    let(:date) { Time.new(2012, 11, 6, 13, 33) }
+
+    it "pretty prints time in long format" do
+      is_expected.to eq "November 06, 2012 1:33 PM"
     end
   end
 


### PR DESCRIPTION
Instead of concatenating strings we should use a `i18n` date format instead.

Also introduces support for custom Solidus' time formats. Currently we are using the Rails `:long` date format that Rails apps and extensions might override. Instead we use our own `solidus` namespace to avoid conflicts.

```yml
en:
  time:
    formats:
      solidus:
        long: ...
```
