### PR TITLE
Improve admin return authorization controller

### DIFF
--- a/backend/app/controllers/spree/admin/return_authorizations_controller.rb
+++ b/backend/app/controllers/spree/admin/return_authorizations_controller.rb
@@ -12,8 +12,8 @@ module Spree
       def fire
         action_from_params = "#{params[:e]}!"
 
-        if @return_authorization.respond_to?(action_from_params)
-          @return_authorization.send(action_from_params)
+        if @return_authorization.state_events.include?(params[:e].to_sym) &&
+           @return_authorization.send(action_from_params)
 
           flash_message = { success: t('spree.return_authorization_updated') }
         else

--- a/backend/app/controllers/spree/admin/return_authorizations_controller.rb
+++ b/backend/app/controllers/spree/admin/return_authorizations_controller.rb
@@ -10,9 +10,18 @@ module Spree
       update.fails  :load_form_data
 
       def fire
-        @return_authorization.send("#{params[:e]}!")
+        action_from_params = "#{params[:e]}!"
+
+        if @return_authorization.respond_to?(action_from_params)
+          @return_authorization.send(action_from_params)
+
+          flash_message = { success: t('spree.return_authorization_updated') }
+        else
+          flash_message = { error: t('spree.return_authorization_fire_error') }
+        end
+
         redirect_back(fallback_location: admin_order_return_authorizations_path(@order),
-                    flash: { success: t('spree.return_authorization_updated') })
+                      flash: flash_message)
       end
 
       private

--- a/backend/spec/controllers/spree/admin/return_authorizations_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/return_authorizations_controller_spec.rb
@@ -45,6 +45,19 @@ describe Spree::Admin::ReturnAuthorizationsController, type: :controller do
           expect(flash[:error]).to eq 'Cannot perform this action on return merchandise authorization'
         end
       end
+
+      context 'when event method exists but it is not a state machine event' do
+        let(:event) { 'destroy' }
+
+        it 'redirects back with an error message' do
+          expect(return_authorization).not_to receive :destroy!
+
+          get :fire, params: params
+
+          expect(response).to redirect_to(admin_order_return_authorizations_path(order))
+          expect(flash[:error]).to eq 'Cannot perform this action on return merchandise authorization'
+        end
+      end
     end
   end
 

--- a/backend/spec/controllers/spree/admin/return_authorizations_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/return_authorizations_controller_spec.rb
@@ -34,6 +34,17 @@ describe Spree::Admin::ReturnAuthorizationsController, type: :controller do
           expect(flash[:success]).to eq 'Return merchandise authorization updated'
         end
       end
+
+      context 'when event method does not exist on return authorization' do
+        let(:event) { 'do_something_crazy' }
+
+        it 'redirects back with an error message' do
+          get :fire, params: params
+
+          expect(response).to redirect_to(admin_order_return_authorizations_path(order))
+          expect(flash[:error]).to eq 'Cannot perform this action on return merchandise authorization'
+        end
+      end
     end
   end
 

--- a/backend/spec/controllers/spree/admin/return_authorizations_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/return_authorizations_controller_spec.rb
@@ -12,6 +12,31 @@ describe Spree::Admin::ReturnAuthorizationsController, type: :controller do
   let(:inventory_unit_2) { order.inventory_units.order('id asc')[1] }
   let(:inventory_unit_3) { order.inventory_units.order('id asc')[2] }
 
+  describe '#fire' do
+    let(:return_authorization) { create(:return_authorization, order: order) }
+
+    context 'with the event parameter set' do
+      let(:params) do
+        {
+          id: return_authorization.to_param,
+          order_id: return_authorization.order.to_param,
+          e: event,
+        }
+      end
+
+      context 'when event method exists on return authorization' do
+        let(:event) { 'cancel' }
+
+        it 'sends method with ! to return authorization and redirect back' do
+          get :fire, params: params
+
+          expect(response).to redirect_to(admin_order_return_authorizations_path(order))
+          expect(flash[:success]).to eq 'Return merchandise authorization updated'
+        end
+      end
+    end
+  end
+
   describe "#load_return_reasons" do
     let!(:inactive_rma_reason) { create(:return_reason, active: false) }
 

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1789,6 +1789,7 @@ en:
       authorized: Authorized
       canceled: Canceled
     return_authorizations: Return Merchandise Authorizations
+    return_authorization_fire_error: Cannot perform this action on return merchandise authorization
     return_authorization_updated: Return merchandise authorization updated
     return_item_inventory_unit_ineligible: Return item's inventory unit must be shipped
     return_item_inventory_unit_reimbursed: Return item's inventory unit is already reimbursed


### PR DESCRIPTION
With #2284 we noticed we had no specs for the `fire` action in admin ReturnAuthorization controller. 

This PR adds specs for that method and handle when trying to fire a method that does not exist on the ReturnAuthorization instance.