### PR TITLE
Fix admin promotion adjustments spec

### DIFF
--- a/backend/spec/features/admin/promotion_adjustments_spec.rb
+++ b/backend/spec/features/admin/promotion_adjustments_spec.rb
@@ -272,7 +272,7 @@ describe "Promotion Adjustments", type: :feature, js: true do
         select "Create per-line-item adjustment", from: "Add action of type"
         within('#action_fields') do
           click_button "Add"
-          select "Complex Calculator", from: "Base Calculator"
+          select "Complex Calculator", from: I18n.t('spree.admin.promotions.actions.calculator_label')
         end
         within('#actions_container') { click_button "Update" }
         expect(page).to have_text 'successfully updated'


### PR DESCRIPTION
After the merge of https://github.com/solidusio/solidus/pull/2394
the admin promotion adjustment spec that got introduced by
https://github.com/solidusio/solidus/pull/2400 broke.