### PR TITLE
Center "no objects found" messages

### DIFF
--- a/backend/app/views/spree/admin/adjustment_reasons/index.html.erb
+++ b/backend/app/views/spree/admin/adjustment_reasons/index.html.erb
@@ -45,7 +45,7 @@
     </tbody>
   </table>
 <% else %>
-  <div class="col-9 no-objects-found">
+  <div class="no-objects-found">
     <%= render 'spree/admin/shared/no_objects_found',
                  resource: Spree::AdjustmentReason,
                  new_resource_url: new_object_url %>

--- a/backend/app/views/spree/admin/customer_returns/index.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/index.html.erb
@@ -44,7 +44,7 @@
     </tbody>
   </table>
 <% else %>
-  <div class="col-9 no-objects-found">
+  <div class="no-objects-found">
     <%= render 'spree/admin/shared/no_objects_found',
                  resource: Spree::CustomerReturn,
                  new_resource_url: new_object_url %>

--- a/backend/app/views/spree/admin/customer_returns/new.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/new.html.erb
@@ -18,7 +18,7 @@
           <% if @rma_return_items.any? %>
             <%= render partial: 'return_item_selection', locals: {f: f, return_items: @rma_return_items} %>
           <% else %>
-            <div class="col-9 no-objects-found"><%= t('spree.none') %></div>
+            <div class="no-objects-found"><%= t('spree.none') %></div>
           <% end %>
         </fieldset>
 
@@ -27,7 +27,7 @@
           <% if @new_return_items.any? %>
             <%= render partial: 'return_item_selection', locals: {f: f, return_items: @new_return_items} %>
           <% else %>
-            <div class="col-9 no-objects-found"><%= t('spree.none') %></div>
+            <div class="no-objects-found"><%= t('spree.none') %></div>
           <% end %>
         </fieldset>
 
@@ -48,7 +48,7 @@
 
 <% else %>
 
-  <div class="col-9 no-objects-found">
+  <div class="no-objects-found">
     <%= t('spree.all_items_have_been_returned') %>,
     <%= link_to t('spree.back_to_customer_return_list'), spree.admin_order_customer_returns_path(@order) %>.
   </div>

--- a/backend/app/views/spree/admin/option_types/index.html.erb
+++ b/backend/app/views/spree/admin/option_types/index.html.erb
@@ -47,7 +47,7 @@
   </tbody>
 </table>
 <% else %>
-  <div class="col-9 no-objects-found">
+  <div class="no-objects-found">
     <%= render 'spree/admin/shared/no_objects_found',
                  resource: Spree::OptionType,
                  new_resource_url: new_object_url %>

--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -187,7 +187,7 @@
     </tbody>
   </table>
 <% else %>
-  <div class="col-9 no-objects-found">
+  <div class="no-objects-found">
     <%= render 'spree/admin/shared/no_objects_found',
                  resource: Spree::Order,
                  new_resource_url: spree.new_admin_order_path %>

--- a/backend/app/views/spree/admin/payment_methods/index.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/index.html.erb
@@ -61,7 +61,7 @@
     </tbody>
   </table>
 <% else %>
-  <div class="col-9 no-objects-found">
+  <div class="no-objects-found">
     <%= render 'spree/admin/shared/no_objects_found',
                  resource: Spree::PaymentMethod,
                  new_resource_url: new_object_url %>

--- a/backend/app/views/spree/admin/payments/index.html.erb
+++ b/backend/app/views/spree/admin/payments/index.html.erb
@@ -29,5 +29,5 @@
   <% end %>
 
 <% else %>
-  <div class="col-9 no-objects-found"><%= t('spree.order_has_no_payments') %></div>
+  <div class="no-objects-found"><%= t('spree.order_has_no_payments') %></div>
 <% end %>

--- a/backend/app/views/spree/admin/products/index.html.erb
+++ b/backend/app/views/spree/admin/products/index.html.erb
@@ -89,7 +89,7 @@
     </tbody>
   </table>
 <% else %>
-  <div class="col-9 no-objects-found">
+  <div class="no-objects-found">
     <%= render 'spree/admin/shared/no_objects_found',
                   resource: Spree::Product,
                   new_resource_url: new_object_url %>

--- a/backend/app/views/spree/admin/promotions/index.html.erb
+++ b/backend/app/views/spree/admin/promotions/index.html.erb
@@ -110,7 +110,7 @@
     </tbody>
   </table>
 <% else %>
-  <div class="col-9 no-objects-found">
+  <div class="no-objects-found">
     <%= render 'spree/admin/shared/no_objects_found',
                  resource: Spree::Promotion,
                  new_resource_url: new_object_url %>

--- a/backend/app/views/spree/admin/properties/index.html.erb
+++ b/backend/app/views/spree/admin/properties/index.html.erb
@@ -75,7 +75,7 @@
   </tbody>
 </table>
 <% else %>
-  <div class="col-9 no-objects-found">
+  <div class="no-objects-found">
     <%= render 'spree/admin/shared/no_objects_found',
                  resource: Spree::Property,
                  new_resource_url: new_object_url %>

--- a/backend/app/views/spree/admin/refund_reasons/index.html.erb
+++ b/backend/app/views/spree/admin/refund_reasons/index.html.erb
@@ -50,7 +50,7 @@
     </tbody>
   </table>
 <% else %>
-  <div class="col-9 no-objects-found">
+  <div class="no-objects-found">
     <%= render 'spree/admin/shared/no_objects_found',
                  resource: Spree::RefundReason,
                  new_resource_url: new_object_url %>

--- a/backend/app/views/spree/admin/shared/named_types/_index.html.erb
+++ b/backend/app/views/spree/admin/shared/named_types/_index.html.erb
@@ -50,7 +50,7 @@
     </tbody>
   </table>
 <% else %>
-  <div class="col-9 no-objects-found">
+  <div class="no-objects-found">
     <%= render 'spree/admin/shared/no_objects_found',
                  resource: resource,
                  new_resource_url: new_object_url %>

--- a/backend/app/views/spree/admin/shipping_categories/index.html.erb
+++ b/backend/app/views/spree/admin/shipping_categories/index.html.erb
@@ -43,7 +43,7 @@
   </tbody>
 </table>
 <% else %>
-  <div class="col-9 no-objects-found">
+  <div class="no-objects-found">
     <%= render 'spree/admin/shared/no_objects_found',
                  resource: Spree::ShippingCategory,
                  new_resource_url: new_object_url %>

--- a/backend/app/views/spree/admin/shipping_methods/index.html.erb
+++ b/backend/app/views/spree/admin/shipping_methods/index.html.erb
@@ -52,7 +52,7 @@
     </tbody>
   </table>
 <% else %>
-  <div class="col-9 no-objects-found">
+  <div class="no-objects-found">
     <%= render 'spree/admin/shared/no_objects_found',
                  resource: Spree::ShippingMethod,
                  new_resource_url: new_object_url %>

--- a/backend/app/views/spree/admin/stock_locations/index.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/index.html.erb
@@ -70,7 +70,7 @@
     </tbody>
   </table>
 <% else %>
-  <div class="col-9 no-objects-found">
+  <div class="no-objects-found">
     <%= render 'spree/admin/shared/no_objects_found',
                         resource: Spree::StockLocation,
                         new_resource_url: new_object_url %>

--- a/backend/app/views/spree/admin/stock_movements/index.html.erb
+++ b/backend/app/views/spree/admin/stock_movements/index.html.erb
@@ -38,7 +38,7 @@
   </tbody>
 </table>
 <% else %>
-  <div class="col-9 no-objects-found">
+  <div class="no-objects-found">
     <%= render 'spree/admin/shared/no_objects_found',
                  resource: Spree::StockMovement,
                  new_resource_url: new_object_url %>

--- a/backend/app/views/spree/admin/store_credits/index.html.erb
+++ b/backend/app/views/spree/admin/store_credits/index.html.erb
@@ -67,7 +67,7 @@
     </fieldset>
   <% end %>
 <% else %>
-  <div class="col-9 no-objects-found">
+  <div class="no-objects-found">
     <%= render 'spree/admin/shared/no_objects_found',
                  resource: Spree::StoreCredit,
                  new_resource_url: new_object_url %>

--- a/backend/app/views/spree/admin/tax_categories/index.html.erb
+++ b/backend/app/views/spree/admin/tax_categories/index.html.erb
@@ -55,7 +55,7 @@
   </tbody>
 </table>
 <% else %>
-  <div class="col-9 no-objects-found">
+  <div class="no-objects-found">
     <%= render 'spree/admin/shared/no_objects_found',
                  resource: Spree::TaxCategory,
                  new_resource_url: new_object_url %>

--- a/backend/app/views/spree/admin/tax_rates/index.html.erb
+++ b/backend/app/views/spree/admin/tax_rates/index.html.erb
@@ -69,7 +69,7 @@
     </tbody>
   </table>
 <% else %>
-  <div class="col-9 no-objects-found">
+  <div class="no-objects-found">
     <%= render 'spree/admin/shared/no_objects_found',
                  resource: Spree::TaxRate,
                  new_resource_url: new_object_url %>

--- a/backend/app/views/spree/admin/taxonomies/index.html.erb
+++ b/backend/app/views/spree/admin/taxonomies/index.html.erb
@@ -15,7 +15,7 @@
   <%= render 'list' %>
 </div>
 <% else %>
-  <div class="col-9 no-objects-found">
+  <div class="no-objects-found">
     <%= render 'spree/admin/shared/no_objects_found',
                  resource: Spree::Taxonomy,
                  new_resource_url: new_object_url %>

--- a/backend/app/views/spree/admin/users/items.html.erb
+++ b/backend/app/views/spree/admin/users/items.html.erb
@@ -69,7 +69,7 @@
         <% end %>
     </table>
   <% else %>
-    <div class="col-9 no-objects-found">
+    <div class="no-objects-found">
       <%= render 'spree/admin/shared/no_objects_found',
                    resource: Spree::Order,
                    new_resource_url: spree.new_admin_order_path %>

--- a/backend/app/views/spree/admin/users/orders.html.erb
+++ b/backend/app/views/spree/admin/users/orders.html.erb
@@ -71,7 +71,7 @@
       </tbody>
     </table>
   <% else %>
-    <div class="col-9 no-objects-found">
+    <div class="no-objects-found">
       <%= render 'spree/admin/shared/no_objects_found',
                    resource: Spree::Order,
                    new_resource_url: spree.new_admin_order_path %>

--- a/backend/app/views/spree/admin/variants/index.html.erb
+++ b/backend/app/views/spree/admin/variants/index.html.erb
@@ -28,12 +28,12 @@
       <% end %>
     </p>
   <% elsif @product.empty_option_values? %>
-    <div class="col-9 no-objects-found">
+    <div class="no-objects-found">
       <%= t 'spree.no_option_values_on_product_html',
             link: link_to(t('spree.product_details'), [:edit, :admin, @product]) %>
     </div>
   <% else %>
-    <div class="col-9 no-objects-found">
+    <div class="no-objects-found">
       <%= t('spree.no_resource', resource: plural_resource_name(Spree::Variant)) %>
       <% if can? :create, Spree::Variant %>
         <%= link_to t('spree.create_one'), new_object_url %>

--- a/backend/app/views/spree/admin/zones/index.html.erb
+++ b/backend/app/views/spree/admin/zones/index.html.erb
@@ -46,7 +46,7 @@
     </tbody>
   </table>
 <% else %>
-  <div class="col-9 no-objects-found">
+  <div class="no-objects-found">
     <%= render 'spree/admin/shared/no_objects_found',
                  resource: Spree::Zone,
                  new_resource_url: new_object_url %>


### PR DESCRIPTION
Before we used 9 of 12 columns. This makes no sense and moves all of these messages to the right instead of centering them, would they supposed to be.

### Before

![no-objects2-before](https://user-images.githubusercontent.com/42868/33506015-21955bb2-d6ee-11e7-8c38-2f3279424556.png)

### After

![no-objects2-after](https://user-images.githubusercontent.com/42868/33506002-124e68b0-d6ee-11e7-95fd-58943381dd80.png)
