### PR TITLE
Remove bottom border of non-form fieldsets

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
@@ -167,6 +167,9 @@ fieldset {
 
   &.no-border-bottom {
     border-bottom: none;
+  }
+
+  &.no-margin-bottom {
     margin-bottom: 0;
   }
 

--- a/backend/app/views/spree/admin/images/index.html.erb
+++ b/backend/app/views/spree/admin/images/index.html.erb
@@ -13,7 +13,7 @@
   <%= render 'new', product: @product, image: Spree::Image.new(viewable: @product) %>
 </div>
 
-<fieldset>
+<fieldset class="no-border-bottom">
   <legend align="center"><%= t(".upload_images") %></legend>
 
   <div id="upload-zone">

--- a/backend/app/views/spree/admin/store_credits/index.html.erb
+++ b/backend/app/views/spree/admin/store_credits/index.html.erb
@@ -13,7 +13,7 @@
 
 <% if @store_credits.any? %>
   <% @store_credits.group_by(&:currency).each do |currency, credits| %>
-    <fieldset class="sc-current-balance">
+    <fieldset class="sc-current-balance no-border-bottom">
       <legend>
         <%= currency %> <%= t('spree.admin.store_credits.current_balance') %>
         <% total = credits.sum(&:amount_remaining) %>

--- a/backend/app/views/spree/admin/store_credits/show.html.erb
+++ b/backend/app/views/spree/admin/store_credits/show.html.erb
@@ -73,7 +73,7 @@
   </tr>
 </table>
 
-<fieldset>
+<fieldset class="no-border-bottom">
   <legend align='center'><%= t('spree.admin.store_credits.history') %></legend>
   <table>
     <colgroup>

--- a/backend/app/views/spree/admin/taxons/index.html.erb
+++ b/backend/app/views/spree/admin/taxons/index.html.erb
@@ -1,16 +1,16 @@
 <% admin_breadcrumb(link_to plural_resource_name(Spree::Product), spree.admin_products_path) %>
 <% admin_breadcrumb(t('spree.admin.taxons.display_order')) %>
 
-<% content_for :table_filter_title do %>
-  <%= t('spree.choose_a_taxon_to_sort_products_for') %>
-<% end %>
+<fieldset class="no-border-bottom">
+  <legend>
+    <%= t('spree.choose_a_taxon_to_sort_products_for') %>
+  </legend>
 
-<% content_for :table_filter do %>
   <div data-hook="admin_orders_index_search" class="col-4">
     <input type='text' id='taxon_id' />
   </div>
-<% end %>
+</fieldset>
 
-<div class='col-10'>
+<div class='col-12'>
   <div id='taxon_products' class='list-group'></div>
 </div>

--- a/backend/app/views/spree/admin/users/_sidebar.html.erb
+++ b/backend/app/views/spree/admin/users/_sidebar.html.erb
@@ -4,7 +4,7 @@
 
 <% content_for :sidebar do %>
   <nav class="menu">
-    <fieldset class='no-border-top' data-hook="admin_user_lifetime_stats">
+    <fieldset class="no-border-top no-border-bottom" data-hook="admin_user_lifetime_stats">
       <dl id="user-lifetime-stats">
         <dt><%= t('spree.total_sales') %>:</dt>
           <dd><%= @user.display_lifetime_value.to_html %></dd>

--- a/backend/app/views/spree/admin/users/items.html.erb
+++ b/backend/app/views/spree/admin/users/items.html.erb
@@ -7,7 +7,7 @@
 <%= render 'spree/admin/users/tabs', current: :items %>
 <%= render partial: 'spree/admin/users/user_page_actions' %>
 
-<fieldset data-hook="admin_user_items_purchased">
+<fieldset data-hook="admin_user_items_purchased" class="no-border-bottom">
   <legend><%= t("spree.admin.user.items_purchased") %></legend>
 
   <%= paginate @orders, theme: "solidus_admin" %>

--- a/backend/app/views/spree/admin/users/orders.html.erb
+++ b/backend/app/views/spree/admin/users/orders.html.erb
@@ -7,7 +7,7 @@
 <%= render 'spree/admin/users/tabs', current: :orders %>
 <%= render partial: 'spree/admin/users/user_page_actions' %>
 
-<fieldset data-hook="admin_user_order_history">
+<fieldset data-hook="admin_user_order_history" class="no-border-bottom">
   <legend><%= t("spree.admin.user.order_history") %></legend>
 
   <%= paginate @orders, theme: "solidus_admin" %>


### PR DESCRIPTION
We have too many borders in our layout. Whitespace, tables and headers are separating content areas already, no need for additional borders. That only distracts the eye.

Keeps the bottom border for fieldsets that are holding a form. This makes sense as the form buttons sit on top of the bottom border and visually encloses the form field set.

### Before

![items purchased - admin example com - users 2017-12-01 23-31-33](https://user-images.githubusercontent.com/42868/33506366-e66fb5bc-d6ef-11e7-82e0-3e5337a48317.png)

![boxy-layout-before](https://user-images.githubusercontent.com/42868/33506371-eb594c78-d6ef-11e7-8bf1-acc06bff8d26.png)

### After

![items purchased - admin example com - users 2017-12-01 23-32-04](https://user-images.githubusercontent.com/42868/33506383-f51ff48c-d6ef-11e7-9ca8-c105872069de.png)

![boxy-layout-after](https://user-images.githubusercontent.com/42868/33506375-f2868cf4-d6ef-11e7-8b25-636f45a526be.png)
