### PR TITLE
remove redundant delegation from product model

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -60,8 +60,8 @@ module Spree
     end
 
     MASTER_ATTRIBUTES = [
-      :rebuild_vat_prices, :sku, :price, :currency, :display_amount, :display_price, :weight,
-      :height, :width, :depth, :cost_currency, :price_in, :price_for, :amount_in, :cost_price
+      :rebuild_vat_prices, :sku, :price, :currency, :weight, :height, :width, :depth,
+      :cost_currency, :price_in, :price_for, :amount_in, :cost_price
     ]
     MASTER_ATTRIBUTES.each do |attr|
       delegate :"#{attr}", :"#{attr}=", to: :find_or_build_master


### PR DESCRIPTION
It appears that since https://github.com/solidusio/solidus/commit/b6cd1adf480fa9b1a18dcae16ecfb986b3feb295 we have declared `delegate` twice for the `:display_amount` and `:display_price` attributes in the `product` model -- once in the [`MASTER_ATTRIBUTES` line](https://github.com/solidusio/solidus/blob/master/core/app/models/spree/product.rb#L62-L68) and once [explicitly below](https://github.com/solidusio/solidus/blob/master/core/app/models/spree/product.rb#L70).

This PR removes the redundant second declaration.