### PR TITLE
Remove delimiter on number with currency field

### DIFF
--- a/backend/app/views/spree/admin/shared/_number_with_currency.html.erb
+++ b/backend/app/views/spree/admin/shared/_number_with_currency.html.erb
@@ -5,7 +5,7 @@
 
 <div class="input-group number-with-currency <%= "number-with-currency-with-select" unless currency %> js-number-with-currency">
   <div class="input-group-addon number-with-currency-symbol"></div>
-  <%= f.text_field amount_attr, value: number_to_currency(f.object.public_send(amount_attr), unit: ''), class: 'form-control number-with-currency-amount', required: required %>
+  <%= f.text_field amount_attr, value: number_to_currency(f.object.public_send(amount_attr), unit: '', delimiter: ''), class: 'form-control number-with-currency-amount', required: required %>
   <% if currency %>
     <div class="input-group-addon number-with-currency-addon" data-currency="<%= currency %>">
       <%= ::Money::Currency.find(currency).iso_code %>


### PR DESCRIPTION
Noticed a weird bug when editing a promotion - after updating the promotion, the item total dropped from 1000 down to 1. Looks like the delimiter is causing the amount to get truncated when values are 1000 and over.

Probably due to this:
```
irb(main):001:0> '1,000'.to_i
=> 1
```

This removes the delimiter from the `number_with_currency` partial, which is used on the promotion edit page. If there are any other fields that should get a similar treatment, feel free to let me know - happy to make the change.