### PR TITLE
[RFC] Use nested checkboxes and radio buttons all over admin

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/sections/_products.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/_products.scss
@@ -18,7 +18,6 @@ div[data-hook="admin_products_index_search_buttons"] {
   }
   input[type="checkbox"] {
     width: auto;
-    vertical-align: bottom;
   }
 }
 

--- a/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
@@ -92,7 +92,7 @@ span.info {
   padding: 10px 0;
 
   &.checkbox {
-    min-height: 73px;
+    min-height: 5.9rem;
     display: flex;
     align-items: center;
 
@@ -103,22 +103,23 @@ span.info {
 
     label {
       cursor: pointer;
-      display: block;
+      margin-top: 2.25rem;
     }
   }
 
   ul {
     list-style: none;
-    margin: 5px 0;
+    margin: 0.5rem 0;
     padding-left: 0;
 
     li {
       display: inline-block;
-      padding-right: 10px;
+      padding-right: 1rem;
 
       label {
         font-weight: normal;
         text-transform: none;
+        margin-bottom: 0;
       }
 
       &.white-space-nowrap {

--- a/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
@@ -41,11 +41,6 @@ textarea {
 }
 
 label {
-  font-weight: $font-weight-bold;
-  font-size: 90%;
-  display: inline;
-  margin-bottom: 5px;
-
   &.required:after {
     content: " *";
   }

--- a/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
@@ -44,6 +44,11 @@ label {
   &.required:after {
     content: " *";
   }
+
+  input[type="radio"],
+  input[type="checkbox"] {
+    margin-right: 0.25rem;
+  }
 }
 
 .label-block label { display: block }

--- a/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
@@ -46,14 +46,6 @@ label {
   display: inline;
   margin-bottom: 5px;
 
-  &.inline {
-    display: inline-block !important;
-  }
-
-  &.block {
-    display: block !important;
-  }
-
   &.required:after {
     content: " *";
   }

--- a/backend/app/views/spree/admin/orders/_shipment.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment.html.erb
@@ -16,8 +16,10 @@
 
     <% if shipment.ready? && can?(:ship, shipment) %>
       <%= form_tag("#", class: "admin-ship-shipment") do %>
-        <%= check_box_tag :send_mailer, true, true %>
-        <%= label_tag :send_mailer, t('spree.send_mailer') %>
+        <label>
+          <%= check_box_tag :send_mailer, true, true %>
+          <%= t('spree.send_mailer') %>
+        </label>
         <%= submit_tag t('spree.actions.ship'), class: "ship-shipment-button" %>
       <% end %>
     <% end %>

--- a/backend/app/views/spree/admin/orders/customer_details/_form.html.erb
+++ b/backend/app/views/spree/admin/orders/customer_details/_form.html.erb
@@ -41,10 +41,12 @@
       <fieldset class="no-border-bottom">
         <legend align="center"><%= t('spree.shipping_address') %></legend>
         <% if Spree::Config[:order_bill_address_used] %>
-          <div class="field" style="position: absolute;margin-top: -15px;left: 0;">
+          <div class="field">
             <span data-hook="use_billing">
-              <%= check_box_tag 'order[use_billing]', '1', (@order.ship_address.new_record? && @order.bill_address == @order.ship_address) %>
-              <%= label_tag 'order[use_billing]', t('spree.use_billing_address') %>
+              <label>
+                <%= check_box_tag 'order[use_billing]', '1', (@order.ship_address.new_record? && @order.bill_address == @order.ship_address) %>
+                <%= t('spree.use_billing_address') %>
+              </label>
             </span>
           </div>
         <% end %>

--- a/backend/app/views/spree/admin/orders/customer_details/_form.html.erb
+++ b/backend/app/views/spree/admin/orders/customer_details/_form.html.erb
@@ -21,12 +21,16 @@
             <% else %>
               <% guest = @order.user.nil? %>
               <li>
-                <%= radio_button_tag :guest_checkout, true, guest %>
-                <%= label_tag :guest_checkout_true, t('spree.say_yes') %>
+                <label>
+                  <%= radio_button_tag :guest_checkout, true, guest %>
+                  <%= t('spree.say_yes') %>
+                </label>
               </li>
               <li>
-                <%= radio_button_tag :guest_checkout, false, !guest, disabled: @order.cart? %>
-                <%= label_tag :guest_checkout_false, t('spree.say_no') %>
+                <label>
+                  <%= radio_button_tag :guest_checkout, false, !guest, disabled: @order.cart? %>
+                  <%= t('spree.say_no') %>
+                </label>
               </li>
               <%= hidden_field_tag :user_id, @order.user_id %>
             <% end %>

--- a/backend/app/views/spree/admin/payment_methods/_form.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/_form.html.erb
@@ -34,16 +34,22 @@
           <%= f.select :auto_capture, [["#{t('spree.use_app_default')} (#{Spree::Config[:auto_capture]})", ''], [t('spree.say_yes'), true], [t('spree.say_no'), false]], {}, {class: 'custom-select fullwidth'} %>
         </div>
         <div data-hook="available_to_user" class="field">
-          <%= f.check_box :available_to_users %>
-          <%= f.label :available_to_users %>
+          <label>
+            <%= f.check_box :available_to_users %>
+            <%= Spree::PaymentMethod.human_attribute_name :available_to_users %>
+          </label>
         </div>
         <div data-hook="available_to_user" class="field">
-          <%= f.check_box :available_to_admin %>
-          <%= f.label :available_to_admin %>
+          <label>
+            <%= f.check_box :available_to_admin %>
+            <%= Spree::PaymentMethod.human_attribute_name :available_to_admin %>
+          </label>
         </div>
         <div data-hook="active" class="field">
-          <%= f.check_box :active %>
-          <%= f.label :active %>
+          <label>
+            <%= f.check_box :active %>
+            <%= Spree::PaymentMethod.human_attribute_name :active %>
+          </label>
         </div>
       </div>
 

--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -71,9 +71,10 @@
 
       <div data-hook="admin_product_form_promotionable">
         <%= f.field_container :promotionable do %>
-          <%= f.label :promotionable do %>
-            <%= f.check_box :promotionable %> <%= Spree::Product.human_attribute_name(:promotionable) %>
-          <% end %>
+          <label>
+            <%= f.check_box :promotionable %>
+            <%= Spree::Product.human_attribute_name(:promotionable) %>
+          </label>
           <%= f.field_hint :promotionable %>
         <% end %>
       </div>

--- a/backend/app/views/spree/admin/promotions/_form.html.erb
+++ b/backend/app/views/spree/admin/promotions/_form.html.erb
@@ -12,10 +12,10 @@
           <% end %>
 
           <%= f.field_container :advertise do %>
-            <%= label_tag do %>
+            <label>
               <%= f.check_box :advertise %>
-              <%= Spree::Promotion.human_attribute_name(:advertise) %>
-            <% end %>
+              <%= Spree::Promotion.human_attribute_name :advertise %>
+            </label>
           <% end %>
         </div>
 

--- a/backend/app/views/spree/admin/shared/_rebuild_vat_prices_checkbox.html.erb
+++ b/backend/app/views/spree/admin/shared/_rebuild_vat_prices_checkbox.html.erb
@@ -1,8 +1,8 @@
 <div data-hook="admin_<%= model_name %>_form_generate_vat_prices" class="<%= local_assigns[:wrapper_class] %> checkbox">
-  <%= form.label :rebuild_vat_prices do %>
+  <label>
     <%= form.check_box :rebuild_vat_prices, checked: form.object.prices.size <= 1 %>
     <%= Spree::Variant.human_attribute_name(:rebuild_vat_prices) %>
-  <% end %>
+  </label>
 </div>
 
 <script type="text/javascript">

--- a/backend/app/views/spree/admin/shared/named_types/_form.html.erb
+++ b/backend/app/views/spree/admin/shared/named_types/_form.html.erb
@@ -5,8 +5,10 @@
       <%= f.text_field :name, class: 'fullwidth' %>
     <% end %>
     <div class="checkbox">
-      <%= f.check_box :active %>
-      <%= f.label :active %>
+      <label>
+        <%= f.check_box :active %>
+        <%= f.object.class.human_attribute_name :active %>
+      </label>
     </div>
   </div>
 </div>

--- a/backend/app/views/spree/admin/shared/preference_fields/_boolean.html.erb
+++ b/backend/app/views/spree/admin/shared/preference_fields/_boolean.html.erb
@@ -2,12 +2,13 @@
 <% html_options = local_assigns[:html_options] || {} %>
 
 <div class="field">
-  <% if local_assigns[:form] %>
-    <%= form.check_box attribute, html_options %>
-    <%= form.label attribute, label %>
-  <% else %>
-    <%= hidden_field_tag name, 0 %>
-    <%= check_box_tag name, 1, value, html_options %>
-    <%= label_tag name, label %>
-  <% end %>
+  <label>
+    <% if local_assigns[:form] %>
+      <%= form.check_box attribute, html_options %>
+    <% else %>
+      <%= hidden_field_tag name, 0 %>
+      <%= check_box_tag name, 1, value, html_options %>
+    <% end %>
+    <%= label || form.object.class.human_attribute_name(attribute) %>
+  </label>
 </div>

--- a/backend/app/views/spree/admin/shipping_methods/_form.html.erb
+++ b/backend/app/views/spree/admin/shipping_methods/_form.html.erb
@@ -48,9 +48,11 @@
   </div>
 </div>
 
-<%= f.field_container :available_to_users do %>
-  <%= f.check_box(:available_to_users) %>
-  <%= f.label :available_to_users %>
+<%= f.field_container :available_to_users, class: %w(checkbox) do %>
+  <label>
+    <%= f.check_box(:available_to_users) %>
+    <%= Spree::ShippingMethod.human_attribute_name :available_to_users %>
+  </label>
   <%= error_message_on :shipping_method, :available_to_users %>
 <% end %>
 
@@ -61,10 +63,10 @@
         <legend align="center"><%= plural_resource_name(Spree::ShippingCategory) %></legend>
         <%= f.field_container :categories do %>
           <% Spree::ShippingCategory.all.each do |category| %>
-            <%= label_tag do %>
+            <label>
               <%= check_box_tag('shipping_method[shipping_categories][]', category.id, @shipping_method.shipping_categories.include?(category)) %>
               <%= category.name %><br>
-            <% end %>
+            </label>
           <% end %>
           <%= error_message_on :shipping_method, :shipping_category_id %>
         <% end %>
@@ -77,10 +79,10 @@
         <%= f.field_container :zones do %>
           <% shipping_method_zones = @shipping_method.zones.to_a %>
           <% Spree::Zone.all.each do |zone| %>
-            <%= label_tag do %>
+            <label>
               <%= check_box_tag('shipping_method[zones][]', zone.id, shipping_method_zones.include?(zone)) %>
               <%= zone.name %>
-            <% end %>
+            </label>
             <br>
           <% end %>
           <%= error_message_on :shipping_method, :zone_id %>

--- a/backend/app/views/spree/admin/stock_locations/_form.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/_form.html.erb
@@ -22,44 +22,58 @@
     <legend><%= t('.settings') %></legend>
 
     <%= f.field_container :active do %>
-      <%= f.check_box :active %>
-      <%= f.label :active %>
-      <%= f.field_hint :active %>
+      <label>
+        <%= f.check_box :active %>
+        <%= Spree::StockLocation.human_attribute_name :active %>
+        <%= f.field_hint :active %>
+      </label>
     <% end %>
 
     <%= f.field_container :default do %>
-      <%= f.check_box :default %>
-      <%= f.label :default %>
+      <label>
+        <%= f.check_box :default %>
+        <%= Spree::StockLocation.human_attribute_name :default %>
+      </label>
     <% end %>
 
     <%= f.field_container :backorderable_default do %>
-      <%= f.check_box :backorderable_default %>
-      <%= f.label :backorderable_default %>
-      <%= f.field_hint :backorderable_default %>
+      <label>
+        <%= f.check_box :backorderable_default %>
+        <%= Spree::StockLocation.human_attribute_name :backorderable_default %>
+        <%= f.field_hint :backorderable_default %>
+      </label>
     <% end %>
 
     <%= f.field_container :propagate_all_variants do %>
-      <%= f.check_box :propagate_all_variants %>
-      <%= f.label :propagate_all_variants %>
-      <%= f.field_hint :propagate_all_variants %>
+      <label>
+        <%= f.check_box :propagate_all_variants %>
+        <%= Spree::StockLocation.human_attribute_name :propagate_all_variants %>
+        <%= f.field_hint :propagate_all_variants %>
+      </label>
     <% end %>
 
     <%= f.field_container :restock_inventory do %>
-      <%= f.check_box :restock_inventory %>
-      <%= f.label :restock_inventory %>
-      <%= f.field_hint :restock_inventory %>
+      <label>
+        <%= f.check_box :restock_inventory %>
+        <%= Spree::StockLocation.human_attribute_name :restock_inventory %>
+        <%= f.field_hint :restock_inventory %>
+      </label>
     <% end %>
 
     <%= f.field_container :fulfillable do %>
-      <%= f.check_box :fulfillable %>
-      <%= f.label :fulfillable %>
-      <%= f.field_hint :fulfillable %>
+      <label>
+        <%= f.check_box :fulfillable %>
+        <%= Spree::StockLocation.human_attribute_name :fulfillable %>
+        <%= f.field_hint :fulfillable %>
+      </label>
     <% end %>
 
     <%= f.field_container :check_stock_on_transfer do %>
-      <%= f.check_box :check_stock_on_transfer %>
-      <%= f.label :check_stock_on_transfer %>
-      <%= f.field_hint :check_stock_on_transfer %>
+      <label>
+        <%= f.check_box :check_stock_on_transfer %>
+        <%= Spree::StockLocation.human_attribute_name :check_stock_on_transfer %>
+        <%= f.field_hint :check_stock_on_transfer %>
+      </label>
     <% end %>
   </fieldset>
 

--- a/backend/app/views/spree/admin/tax_categories/_form.html.erb
+++ b/backend/app/views/spree/admin/tax_categories/_form.html.erb
@@ -15,8 +15,10 @@
 
   <div class="col-1">
     <%= f.field_container :is_default, class: ['checkbox'] do %>
-      <%= f.check_box :is_default %>
-      <%= f.label :is_default %>
+      <label>
+        <%= f.check_box :is_default %>
+        <%= Spree::TaxCategory.human_attribute_name(:is_default) %>
+      </label>
     <% end %>
   </div>
 

--- a/backend/app/views/spree/admin/tax_rates/_form.html.erb
+++ b/backend/app/views/spree/admin/tax_rates/_form.html.erb
@@ -14,8 +14,10 @@
             <br/><span class="info"><%= t('spree.tax_rate_amount_explanation') %></span>
           </div>
           <div data-hook="included" class="field">
-            <%= f.check_box :included_in_price %>
-            <%= f.label :included_in_price, t('spree.included_in_price') %>
+            <label>
+              <%= f.check_box :included_in_price %>
+              <%= t('spree.included_in_price') %>
+            </label>
           </div>
         </div>
 
@@ -29,8 +31,10 @@
             <%= f.collection_select(:tax_category_ids, @available_categories, :id, :name, {}, {class: 'select2 fullwidth', multiple: "multiple"}) %>
           </div>
           <div data-hook="show_rate" class="field">
-            <%= f.check_box :show_rate_in_label %>
-            <%= f.label :show_rate_in_label, t('spree.show_rate_in_label') %>
+            <label>
+              <%= f.check_box :show_rate_in_label %>
+              <%= t('spree.show_rate_in_label') %>
+            </label>
           </div>
 
           <div class="date-range-filter field">

--- a/backend/app/views/spree/admin/users/_form.html.erb
+++ b/backend/app/views/spree/admin/users/_form.html.erb
@@ -19,8 +19,11 @@
             <%= hidden_field_tag('user[spree_role_ids][]', nil) %>
             <% @roles.each do |role| %>
               <li>
-                <%= check_box_tag 'user[spree_role_ids][]', role.id, @user_roles.include?(role), id: "user_spree_role_#{role.name}" %>
-                <%= label_tag "user_spree_role_#{role.name}", role.name %>
+                <label>
+                  <%= check_box_tag 'user[spree_role_ids][]', role.id,
+                    @user_roles.include?(role), id: "user_spree_role_#{role.name}" %>
+                  <%= role.name %>
+                </label>
               </li>
             <% end %>
           <% else %>
@@ -39,8 +42,10 @@
           <% if can?(:manage, Spree::UserStockLocation) %>
             <% @stock_locations.each do |stock_location| %>
               <li>
-                <%= check_box_tag 'user[stock_location_ids][]', stock_location.id, @user.stock_locations.include?(stock_location), id: "user_spree_stock_locations_#{stock_location.name}" %>
-                <%= label_tag stock_location.name %>
+                <label>
+                  <%= check_box_tag 'user[stock_location_ids][]', stock_location.id, @user.stock_locations.include?(stock_location), id: "user_spree_stock_locations_#{stock_location.name}" %>
+                  <%= stock_location.name %>
+                </label>
               </li>
             <% end %>
           <% else %>

--- a/backend/app/views/spree/admin/variants/_form.html.erb
+++ b/backend/app/views/spree/admin/variants/_form.html.erb
@@ -9,10 +9,10 @@
       </div>
       <div class="col-3">
         <div class="field checkbox" data-hook="track_inventory">
-          <%= f.label :track_inventory do %>
+          <label>
             <%= f.check_box :track_inventory %>
             <%= Spree::Variant.human_attribute_name(:track_inventory) %>
-          <% end %>
+          </label>
         </div>
       </div>
     </div>

--- a/backend/app/views/spree/admin/variants/_table_filter.html.erb
+++ b/backend/app/views/spree/admin/variants/_table_filter.html.erb
@@ -14,10 +14,10 @@
     <% if product.variants.only_deleted.any? %>
       <div class="col-2">
         <div class="field checkbox">
-          <%= label_tag :deleted do %>
+          <label>
             <%= check_box_tag :deleted, "on", params[:deleted] == "on" %>
             <%= t('.show_deleted') %>
-          <% end %>
+          </label>
         </div>
       </div>
     <% end %>

--- a/backend/app/views/spree/admin/zones/_form.html.erb
+++ b/backend/app/views/spree/admin/zones/_form.html.erb
@@ -19,12 +19,16 @@
           <%= label_tag t('spree.type') %>
           <ul>
             <li>
-              <%= zone_form.radio_button('kind', 'country', { id: 'country_based' }) %>
-              <%= label_tag :country_based, t('spree.country_based') %>
+              <label>
+                <%= zone_form.radio_button('kind', 'country', { id: 'country_based' }) %>
+                <%= t('spree.country_based') %>
+              </label>
             </li>
             <li>
-              <%= zone_form.radio_button('kind', 'state', { id: 'state_based' }) %>
-              <%= label_tag :state_based, t('spree.state_based') %>
+              <label>
+                <%= zone_form.radio_button('kind', 'state', { id: 'state_based' }) %>
+                <%= t('spree.state_based') %>
+              </label>
             </li>
           </ul>
         </div>


### PR DESCRIPTION
Following our own styleguide and due to better styleability we
should nest checkboxes and radio buttons into their labels.

This also removes some redundant and unused style definitions 
regarding labels, checkboxes and radio buttons.

The most debatable change might be the label font-size change (from 90% to 100%)


### Before

![orders labels before](https://user-images.githubusercontent.com/42868/33543940-38468bd2-d8d9-11e7-98ef-c3752bddf35b.png)

### After

![orders labels after](https://user-images.githubusercontent.com/42868/33543941-386274dc-d8d9-11e7-8856-2bded782d74a.png)
