### PR TITLE
Adding pagination to home_controller.

### DIFF
--- a/frontend/app/controllers/spree/home_controller.rb
+++ b/frontend/app/controllers/spree/home_controller.rb
@@ -4,8 +4,8 @@ module Spree
     respond_to :html
 
     def index
-      @searcher = build_searcher(params.merge(include_images: true))
-      @products = @searcher.retrieve_products
+      @searcher = build_searcher(params.merge(include_images: true).reject { |k, _| ["per_page", "page"].include?(k) } )
+      @products = @searcher.retrieve_products.page(params[:page] || 1).per(params[:per_page].presence || Spree::Config[:products_per_page])
       @taxonomies = Spree::Taxonomy.includes(root: :children)
     end
   end


### PR DESCRIPTION
This change is needed in Solidus 2.4.0 to add pagination to home_controller (products_controller and taxons_controller already have it).