### PR TITLE
Fix 1.4 migration wrap

### DIFF
--- a/core/db/migrate/20160101010000_solidus_one_four.rb
+++ b/core/db/migrate/20160101010000_solidus_one_four.rb
@@ -1075,17 +1075,6 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
       t.index ["track_inventory"], name: "index_spree_variants_on_track_inventory"
     end
 
-    create_table "spree_wallet_payment_sources", force: :cascade do |t|
-      t.integer "user_id", null: false
-      t.string "payment_source_type", null: false
-      t.integer "payment_source_id", null: false
-      t.boolean "default", default: false, null: false
-      t.datetime "created_at", null: false
-      t.datetime "updated_at", null: false
-      t.index ["user_id", "payment_source_id", "payment_source_type"], name: "index_spree_wallet_payment_sources_on_source_and_user", unique: true
-      t.index ["user_id"], name: "index_spree_wallet_payment_sources_on_user_id"
-    end
-
     create_table "spree_zone_members", force: :cascade do |t|
       t.string "zoneable_type"
       t.integer "zoneable_id"

--- a/core/db/migrate/20160420044191_create_spree_wallet_payment_sources.rb
+++ b/core/db/migrate/20160420044191_create_spree_wallet_payment_sources.rb
@@ -1,0 +1,25 @@
+class CreateSpreeWalletPaymentSources < ActiveRecord::Migration[4.2]
+  def change
+    return if table_exists?(:spree_wallet_payment_sources)
+
+    create_table :spree_wallet_payment_sources do |t|
+      t.references(
+        :user,
+        foreign_key: { to_table: Spree.user_class.table_name },
+        index: true,
+        null: false,
+      )
+      t.references :payment_source, polymorphic: true, null: false
+      t.boolean :default, default: false, null: false
+
+      t.timestamps null: false
+    end
+
+    add_index(
+      :spree_wallet_payment_sources,
+      [:user_id, :payment_source_id, :payment_source_type],
+      unique: true,
+      name: 'index_spree_wallet_payment_sources_on_source_and_user',
+    )
+  end
+end

--- a/core/db/migrate/20160420181916_migrate_credit_cards_to_wallet_payment_sources.rb
+++ b/core/db/migrate/20160420181916_migrate_credit_cards_to_wallet_payment_sources.rb
@@ -1,0 +1,27 @@
+class MigrateCreditCardsToWalletPaymentSources < ActiveRecord::Migration[4.2]
+  class CreditCard < ActiveRecord::Base
+    self.table_name = 'spree_credit_cards'
+  end
+  class WalletPaymentSource < ActiveRecord::Base
+    self.table_name = 'spree_wallet_payment_sources'
+  end
+
+  def up
+    credit_cards = CreditCard.
+      where.not(gateway_customer_profile_id: nil).
+      where.not(user_id: nil)
+
+    credit_cards.find_each do |credit_card|
+      WalletPaymentSource.find_or_create_by!(
+        user_id: credit_card.user_id,
+        payment_source_id: credit_card.id,
+        payment_source_type: 'Spree::CreditCard'
+      ) do |wallet_source|
+        wallet_source.default = credit_card.default
+      end
+    end
+  end
+
+  def down
+  end
+end


### PR DESCRIPTION
This pr brings back the wallet payment sources migration because it was in solidus one four migration even if it was added in v2.2
The issue came out trying to update from solidus v2.0 to v2.4 and launching migrations. As a result I ended with the new `solidus_one_four.rb` migration which should have contained only the old migrations.

To find out all the deleted migrations I did these steps:
`git diff --name-status v2.0 v2.3 | grep core/db/migrate | grep A > new-migrations` to find all new migrations starting from v2.0 to v2.3, here's the output
```
A	core/db/migrate/20160420044191_create_spree_wallet_payment_sources.rb
A	core/db/migrate/20160420181916_migrate_credit_cards_to_wallet_payment_sources.rb
A	core/db/migrate/20160924135758_remove_is_default_from_prices.rb
A	core/db/migrate/20161009141333_remove_currency_from_line_items.rb
A	core/db/migrate/20161014221052_add_available_to_columns_and_remove_display_on_from_payment_methods.rb
A	core/db/migrate/20161017102621_create_spree_promotion_code_batch.rb
A	core/db/migrate/20161123154034_add_available_to_users_and_remove_display_on_from_shipping_methods.rb
A	core/db/migrate/20161129035810_add_index_to_spree_payments_number.rb
A	core/db/migrate/20170223235001_remove_spree_store_credits_column.rb
A	core/db/migrate/20170412103617_transform_tax_rate_category_relation.rb
A	core/db/migrate/20170422134804_add_roles_unique_constraints.rb
A	core/db/migrate/20170522143442_add_time_range_to_tax_rate.rb
A	core/db/migrate/20170608074534_rename_bogus_gateways.rb
```
After that I did a `git reset` on master with all these files as params to check what file has been deleted.
In the end I removed the duplicated migration code into `solidus_one_four.rb`

I'm not sure but I think we should find a way to not import `solidus_one_four.rb` in an existing project.

ref: #2229 