### PR TITLE
Remove FAIL_FAST environment variable

### DIFF
--- a/api/spec/spec_helper.rb
+++ b/api/spec/spec_helper.rb
@@ -63,8 +63,6 @@ RSpec.configure do |config|
 
   config.extend WithModel
 
-  config.fail_fast = ENV['FAIL_FAST'] || false
-
   config.before(:each) do
     Rails.cache.clear
     reset_spree_preferences

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -120,8 +120,6 @@ RSpec.configure do |config|
 
   config.extend WithModel
 
-  config.fail_fast = ENV['FAIL_FAST'] || false
-
   config.example_status_persistence_file_path = "./spec/examples.txt"
 
   config.order = :random

--- a/core/spec/spec_helper.rb
+++ b/core/spec/spec_helper.rb
@@ -35,8 +35,6 @@ RSpec.configure do |config|
   config.include Spree::TestingSupport::Preferences
   config.extend WithModel
 
-  config.fail_fast = ENV['FAIL_FAST'] || false
-
   config.filter_run focus: true
   config.run_all_when_everything_filtered = true
 

--- a/frontend/spec/spec_helper.rb
+++ b/frontend/spec/spec_helper.rb
@@ -104,8 +104,6 @@ RSpec.configure do |config|
   config.include Spree::TestingSupport::ControllerRequests, type: :controller
   config.include Spree::TestingSupport::Flash
 
-  config.fail_fast = ENV['FAIL_FAST'] || false
-
   config.example_status_persistence_file_path = "./spec/examples.txt"
 
   config.order = :random

--- a/sample/spec/spec_helper.rb
+++ b/sample/spec/spec_helper.rb
@@ -31,8 +31,6 @@ RSpec.configure do |config|
   # instead of true.
   config.use_transactional_fixtures = false
 
-  config.fail_fast = ENV['FAIL_FAST'] || false
-
   config.example_status_persistence_file_path = "./spec/examples.txt"
 
   config.order = :random


### PR DESCRIPTION
`fail_fast` can be set just by specifying `rspec --fail-fast`. Previously, our use of the `FAIL_FAST` was overriding this feature, though.

I've removed this from the README because it
a) isn't important - nobody needs this to get started developing
b) is described in rspec's docs along with other options