### PR TITLE
Allow individual suites to be run from top-level

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,15 +6,18 @@ def print_title(gem_name = '')
 end
 
 %w[spec db:drop db:create db:migrate db:reset].each do |task|
-  desc "Run rake #{task} for each Solidus engine"
-  task task do
-    %w(api backend core frontend sample).each do |gem_name|
-      print_title(gem_name)
-      Dir.chdir("#{File.dirname(__FILE__)}/#{gem_name}") do
+  %w(api backend core frontend sample).each do |project|
+    desc "Run specs for #{project}" if task == 'spec'
+    task "#{task}:#{project}" do
+      print_title(project)
+      Dir.chdir("#{File.dirname(__FILE__)}/#{project}") do
         sh "rake #{task}"
       end
     end
   end
+
+  desc "Run rake #{task} for each Solidus engine"
+  task task => %w(api backend core frontend sample).map { |p| "#{task}:#{p}" }
 end
 
 task test: :spec


### PR DESCRIPTION
This allows running individual projects' spec suites from the top-level.
For example:

    rake spec:core

Will run the spec suite for the core project.

This also defines tasks like `db:reset:core`, but doesn't give them a description to avoid cluttering up `rake -T`.

I don't think we need to add this to the README, as the existing method still works and is more flexible. This is just another convenient way to do the same thing.

With this change, `rake -T` shows:
```
rake clean          # clean the whole repository by removing all the generated files
rake db:create      # Run rake db:create for each Solidus engine
rake db:drop        # Run rake db:drop for each Solidus engine
rake db:migrate     # Run rake db:migrate for each Solidus engine
rake db:reset       # Run rake db:reset for each Solidus engine
rake gem:build      # Build all solidus gems
rake gem:install    # Install all solidus gems
rake gem:release    # Release all gems to rubygems
rake sandbox        # Creates a sandbox application for simulating the Solidus code in a deployed Rails app
rake spec           # Run rake spec for each Solidus engine
rake spec:api       # Run specs for api
rake spec:backend   # Run specs for backend
rake spec:core      # Run specs for core
rake spec:frontend  # Run specs for frontend
rake spec:sample    # Run specs for sample
```