### PR TITLE
Improve integration of backend JS specs

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,20 +5,31 @@ def print_title(gem_name = '')
   puts "\n#{'-' * title.size}\n#{title}\n#{'-' * title.size}"
 end
 
+def subproject_task(project, task, title: project, task_name: nil)
+  task_name ||= "#{task}:#{project}"
+  task task_name do
+    print_title(title)
+    Dir.chdir("#{File.dirname(__FILE__)}/#{project}") do
+      sh "rake #{task}"
+    end
+  end
+end
+
 %w[spec db:drop db:create db:migrate db:reset].each do |task|
   %w(api backend core frontend sample).each do |project|
     desc "Run specs for #{project}" if task == 'spec'
-    task "#{task}:#{project}" do
-      print_title(project)
-      Dir.chdir("#{File.dirname(__FILE__)}/#{project}") do
-        sh "rake #{task}"
-      end
-    end
+    subproject_task(project, task)
   end
 
   desc "Run rake #{task} for each Solidus engine"
   task task => %w(api backend core frontend sample).map { |p| "#{task}:#{p}" }
 end
+
+desc "Run backend JS specs"
+subproject_task("backend", "spec:js", title: "backend JS", task_name: "spec:backend:js")
+
+# Add backend JS specs to `rake spec` dependencies
+task :spec => 'spec:backend:js'
 
 task test: :spec
 task test_app: 'db:reset'

--- a/Rakefile
+++ b/Rakefile
@@ -6,15 +6,18 @@ def print_title(gem_name = '')
 end
 
 %w[spec db:drop db:create db:migrate db:reset].each do |task|
-  desc "Run rake #{task} for each Solidus engine"
-  task task do
-    %w(api backend core frontend sample).each do |gem_name|
-      print_title(gem_name)
-      Dir.chdir("#{File.dirname(__FILE__)}/#{gem_name}") do
+  %w(api backend core frontend sample).each do |project|
+    desc "Run specs for #{project}" if task == 'spec'
+    task "#{task}:#{project}" do
+      print_title(project)
+      Dir.chdir("#{File.dirname(__FILE__)}/#{project}") do
         sh "rake #{task}"
       end
     end
   end
+
+  desc "Run rake #{task} for each Solidus engine"
+  task task => %w(api backend core frontend sample).map { |p| "#{task}:#{p}" }
 end
 
 task test: :spec

--- a/backend/Rakefile
+++ b/backend/Rakefile
@@ -7,7 +7,7 @@ require 'solidus_backend'
 require 'spree/testing_support/dummy_app/rake_tasks'
 
 RSpec::Core::RakeTask.new
-task default: :spec
+task default: [:spec, 'spec:js']
 
 DummyApp::RakeTasks.new(
   gem_root: File.expand_path('../', __FILE__),

--- a/backend/Rakefile
+++ b/backend/Rakefile
@@ -14,7 +14,6 @@ DummyApp::RakeTasks.new(
   lib_name: 'solidus_backend'
 )
 
-desc "Run the javascript specs"
 task :teaspoon do
   require 'teaspoon'
   Rake::Task['dummy_environment'].invoke
@@ -31,6 +30,9 @@ task :teaspoon do
 
   abort("rake teaspoon failed") if Teaspoon::Console.new(options).failures?
 end
+
+desc "Run javascript specs"
+task 'spec:js' => :teaspoon
 
 namespace :teaspoon do
   task :server  do

--- a/backend/spec/teaspoon_env.rb
+++ b/backend/spec/teaspoon_env.rb
@@ -1,31 +1,34 @@
 ENV['RAILS_ENV'] = 'test'
-ENV["LIB_NAME"] = 'solidus_backend'
 
-require 'spree_backend'
+# Similar to setup described in
+# https://github.com/jejacks0n/teaspoon/wiki/Micro-Applications
 
-require 'teaspoon'
-require 'teaspoon-mocha'
+if defined?(DummyApp)
+  require 'teaspoon-mocha'
 
-unless defined?(DummyApp)
+  Teaspoon.configure do |config|
+    config.mount_at = "/teaspoon"
+    config.root = Spree::Backend::Engine.root
+    config.asset_paths = ["spec/javascripts", "spec/javascripts/stylesheets"]
+    config.fixture_paths = ["spec/javascripts/fixtures"]
+
+    config.suite do |suite|
+      suite.use_framework :mocha, "2.3.3"
+      suite.matcher = "{spec/javascripts,app/assets}/**/*_spec.{js,js.coffee,coffee}"
+      suite.helper = "spec_helper"
+      suite.boot_partial = "/boot"
+      suite.expand_assets = true
+    end
+  end
+else
+  require 'solidus_backend'
+
+  require 'teaspoon'
+
   require 'spree/testing_support/dummy_app'
 
   DummyApp.setup(
     gem_root: File.expand_path('../../', __FILE__),
     lib_name: 'solidus_backend'
   )
-end
-
-Teaspoon.configure do |config|
-  config.mount_at = "/teaspoon"
-  config.root = Spree::Backend::Engine.root
-  config.asset_paths = ["spec/javascripts", "spec/javascripts/stylesheets"]
-  config.fixture_paths = ["spec/javascripts/fixtures"]
-
-  config.suite do |suite|
-    suite.use_framework :mocha, "2.3.3"
-    suite.matcher = "{spec/javascripts,app/assets}/**/*_spec.{js,js.coffee,coffee}"
-    suite.helper = "spec_helper"
-    suite.boot_partial = "/boot"
-    suite.expand_assets = true
-  end
 end


### PR DESCRIPTION
Builds on top of #2446

This makes backend's teaspoon more reliable to get running, and integrates it better with the whole project.

* Adds `rake spec:js` from `backend/`, since developers shouldn't care that we are using teaspoon
* Running `rake` in `backend/` will run the JS tests
* Adds `rake spec:backend:js` to the top-level Rakefile
* Running `rake` or `rake spec` at the top-level will run backend JS tests, allowing `rake` to fully replace `build.sh`