### PR TITLE
Remove unintentional failing spec addition

### DIFF
--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -1535,16 +1535,6 @@ describe Spree::Order, type: :model do
     end
   end
 
-  context 'update_params_payment_source' do
-    subject { described_class.new }
-
-    it 'is deprecated' do
-      subject.instance_variable_set('@updating_params', {})
-      expect(Spree::Deprecation).to receive(:warn)
-      subject.update_params_payment_source
-    end
-  end
-
   describe "#validate_payments_attributes" do
     let(:attributes) { [ActionController::Parameters.new(payment_method_id: payment_method.id)] }
     subject do


### PR DESCRIPTION
I believe this was accidentally added -- probably while resolving a merge
conflict while bringing this change from master:
https://github.com/solidusio/solidus/commit/80d3316944d2262fc6a3a13f8d453299796c52f3#diff-bcc8495cd68d136981bdf1f391bce4c0
into this change in the v2.3 branch:
https://github.com/solidusio/solidus/commit/837d1fcfbc08565a66efc509482286c8ff3c5671#diff-bcc8495cd68d136981bdf1f391bce4c0

This method is not deprecated in v2.3 so the spec will fail.

Additionally, it appears in v2.4+ the deprecation has unintentionally made the
method public. We can look into that separately.