### PR TITLE
Avoid changing method visibility when deprecating a method

### DIFF
--- a/backend/app/controllers/spree/admin/payment_methods_controller.rb
+++ b/backend/app/controllers/spree/admin/payment_methods_controller.rb
@@ -49,10 +49,9 @@ module Spree
       end
 
       def load_providers
+        Spree::Deprecation.warn('load_providers is deprecated. Please use load_payment_method_types instead.', caller)
         load_payment_method_types
       end
-      deprecate load_providers: :load_payment_method_types, deprecator: Spree::Deprecation
-      instance_method(:load_providers).owner.send(:private, :load_providers)
 
       def load_payment_method_types
         @payment_method_types = Rails.application.config.spree.payment_methods.sort_by(&:name)
@@ -61,11 +60,9 @@ module Spree
       end
 
       def validate_payment_provider
+        Spree::Deprecation.warn('validate_payment_provider is deprecated. Please use validate_payment_method_type instead.', caller)
         validate_payment_method_type
       end
-      deprecate validate_payment_provider: :validate_payment_method_type,
-        deprecator: Spree::Deprecation
-      instance_method(:validate_payment_provider).owner.send(:private, :validate_payment_provider)
 
       def validate_payment_method_type
         requested_type = params[:payment_method].delete(:type)

--- a/backend/app/controllers/spree/admin/payment_methods_controller.rb
+++ b/backend/app/controllers/spree/admin/payment_methods_controller.rb
@@ -52,6 +52,7 @@ module Spree
         load_payment_method_types
       end
       deprecate load_providers: :load_payment_method_types, deprecator: Spree::Deprecation
+      instance_method(:load_providers).owner.send(:private, :load_providers)
 
       def load_payment_method_types
         @payment_method_types = Rails.application.config.spree.payment_methods.sort_by(&:name)
@@ -64,6 +65,7 @@ module Spree
       end
       deprecate validate_payment_provider: :validate_payment_method_type,
         deprecator: Spree::Deprecation
+      instance_method(:validate_payment_provider).owner.send(:private, :validate_payment_provider)
 
       def validate_payment_method_type
         requested_type = params[:payment_method].delete(:type)

--- a/backend/app/controllers/spree/admin/resource_controller.rb
+++ b/backend/app/controllers/spree/admin/resource_controller.rb
@@ -134,9 +134,10 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
     self.class.parent_data[:model_name].gsub('spree/', '')
   end
 
-  alias_method :model_name, :parent_model_name
-  deprecate model_name: :parent_model_name, deprecator: Spree::Deprecation
-  instance_method(:model_name).owner.send(:private, :model_name)
+  def model_name
+    Spree::Deprecation.warn('model_name is deprecated. Please use parent_model_name instead.', caller)
+    parent_model_name
+  end
 
   def object_name
     controller_name.singularize
@@ -171,10 +172,9 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
   end
 
   def parent_data
+    Spree::Deprecation.warn('parent_data is deprecated without replacement.', caller)
     self.class.parent_data
   end
-  deprecate :parent_data, deprecator: Spree::Deprecation
-  instance_method(:parent_data).owner.send(:private, :parent_data)
 
   def parent
     if parent?

--- a/backend/app/controllers/spree/admin/resource_controller.rb
+++ b/backend/app/controllers/spree/admin/resource_controller.rb
@@ -136,6 +136,7 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
 
   alias_method :model_name, :parent_model_name
   deprecate model_name: :parent_model_name, deprecator: Spree::Deprecation
+  instance_method(:model_name).owner.send(:private, :model_name)
 
   def object_name
     controller_name.singularize
@@ -173,6 +174,7 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
     self.class.parent_data
   end
   deprecate :parent_data, deprecator: Spree::Deprecation
+  instance_method(:parent_data).owner.send(:private, :parent_data)
 
   def parent
     if parent?

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -819,6 +819,7 @@ module Spree
       end
     end
     deprecate update_params_payment_source: :set_payment_parameters_amount, deprecator: Spree::Deprecation
+    instance_method(:update_params_payment_source).owner.send(:private, :update_params_payment_source)
 
     def associate_store
       self.store ||= Spree::Store.default

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -813,13 +813,12 @@ module Spree
     #   }
     #
     def update_params_payment_source
+      Spree::Deprecation.warn('update_params_payment_source is deprecated. Please use set_payment_parameters_amount instead.', caller)
       if @updating_params[:order] && (@updating_params[:order][:payments_attributes] || @updating_params[:order][:existing_card])
         @updating_params[:order][:payments_attributes] ||= [{}]
         @updating_params[:order][:payments_attributes].first[:amount] = total
       end
     end
-    deprecate update_params_payment_source: :set_payment_parameters_amount, deprecator: Spree::Deprecation
-    instance_method(:update_params_payment_source).owner.send(:private, :update_params_payment_source)
 
     def associate_store
       self.store ||= Spree::Store.default

--- a/core/app/models/spree/payment_method.rb
+++ b/core/app/models/spree/payment_method.rb
@@ -259,5 +259,6 @@ module Spree
       end
     end
     deprecate provider_class: :gateway_class, deprecator: Spree::Deprecation
+    instance_method(:provider_class).owner.send(:protected, :provider_class)
   end
 end

--- a/core/app/models/spree/payment_method.rb
+++ b/core/app/models/spree/payment_method.rb
@@ -258,7 +258,5 @@ module Spree
         raise ::NotImplementedError, "You must implement gateway_class method for #{self.class}."
       end
     end
-    deprecate provider_class: :gateway_class, deprecator: Spree::Deprecation
-    instance_method(:provider_class).owner.send(:protected, :provider_class)
   end
 end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -1560,7 +1560,7 @@ RSpec.describe Spree::Order, type: :model do
     it 'is deprecated' do
       subject.instance_variable_set('@updating_params', {})
       expect(Spree::Deprecation).to receive(:warn)
-      subject.update_params_payment_source
+      subject.send(:update_params_payment_source)
     end
   end
 


### PR DESCRIPTION
`ActiveSupport::Deprecation::MethodWrapper#deprecate_methods` changes method
visibility to `public`.  This seems unintentional and I will submit a PR to
Rails to see if that can be updated.

For the meanwhile, this update changes method visibility back to the original
visibility. It's a bit more convoluted than might be expected because
ActiveSupport uses `Module.prepend` to override the original method, so we can't
just write `private :some_method` because that only affects the original method,
whose visibility has not been changed.

If people think it's worth creating a helper for this let me know and I will do so.