### PR TITLE
Ensure migrations are run before teaspoon specs

### DIFF
--- a/backend/spec/teaspoon_env.rb
+++ b/backend/spec/teaspoon_env.rb
@@ -4,6 +4,8 @@ ENV['RAILS_ENV'] = 'test'
 # https://github.com/jejacks0n/teaspoon/wiki/Micro-Applications
 
 if defined?(DummyApp)
+  DummyApp::Migrations.auto_migrate
+
   require 'teaspoon-mocha'
 
   Teaspoon.configure do |config|
@@ -29,6 +31,7 @@ else
 
   DummyApp.setup(
     gem_root: File.expand_path('../../', __FILE__),
-    lib_name: 'solidus_backend'
+    lib_name: 'solidus_backend',
+    auto_migrate: false
   )
 end


### PR DESCRIPTION
I thought I had fixed this in #2447, but apparently not. With this commit, I believe, _finally_ all of the
following work:

    rake db:drop && rake teaspoon
    rake db:drop && bundle exec teaspoon
    rake db:reset && rake teaspoon
    rake db:reset && bundle exec teaspoon