### PR TITLE
Split builds more intelligently in build-ci.rb

### DIFF
--- a/build-ci.rb
+++ b/build-ci.rb
@@ -4,7 +4,7 @@
 require 'pathname'
 
 class Project
-  attr_reader :name
+  attr_reader :name, :title, :weight
 
   NODE_TOTAL = Integer(ENV.fetch('CIRCLE_NODE_TOTAL', 1))
   NODE_INDEX = Integer(ENV.fetch('CIRCLE_NODE_INDEX', 0))
@@ -17,11 +17,21 @@ class Project
 
   DEFAULT_MODE = 'test'.freeze
 
-  def initialize(name)
+  def initialize(name, test_type: :rspec, title: nil, weight:)
     @name = name
+    @title = title || name
+    @test_type = test_type
+    @weight = weight
   end
 
-  ALL = %w[api backend core frontend sample].map(&method(:new)).freeze
+  ALL = [
+    new('api', weight: 50),
+    new('backend', weight: 215),
+    new('backend', test_type: :teaspoon, title: "backend JS", weight: 15),
+    new('core', weight: 220),
+    new('frontend', weight: 95),
+    new('sample', weight: 22)
+  ].freeze
 
   # Install subproject
   #
@@ -98,7 +108,14 @@ class Project
   #
   # @return [Array<Project>]
   def self.current_projects
-    NODE_INDEX.step(ALL.length - 1, NODE_TOTAL).map(&ALL.method(:fetch))
+    unallocated = ALL.sort_by(&:weight).reverse
+    nodes = Array.new(NODE_TOTAL) { [] }
+
+    while project = unallocated.shift
+      nodes.min_by { |projects| projects.sum(&:weight) } << project
+    end
+
+    nodes[NODE_INDEX]
   end
   private_class_method :current_projects
 
@@ -140,19 +157,22 @@ class Project
   # @return [Boolean]
   #   the success of the tests
   def run_tests
-    @success = true
+    send(:"run_#{@test_type}")
+  end
+
+  def run_rspec
     run_test_cmd(%w[bundle exec rspec] + rspec_arguments)
-    if name == "backend"
-      run_test_cmd(%w[bundle exec teaspoon] + teaspoon_arguments)
-    end
-    @success
+  end
+
+  def run_teaspoon
+    run_test_cmd(%w[bundle exec teaspoon] + teaspoon_arguments)
   end
 
   def run_test_cmd(args)
     puts "Run: #{args.join(' ')}"
     result = system(*args)
     puts(result ? "Success" : "Failed")
-    @success &&= result
+    result
   end
 
   def teaspoon_arguments


### PR DESCRIPTION
When building on CircleCI, we split the subproject builds between several containers in order to finish faster.

Previously we did this by just splitting the projects round-robin. This actually worked out well due to our number of workers (3) and the alphabetization of our projects.

* Worker 1: solidus_api, solidus_frontend
* Worker 2: solidus_backend (rspec), solidus_backend (JS), solidus_sample
* Worker 3: solidus_core

core and backend's specs take about the same amount of time to run, so this worked fairly okay because backend's JS tests and solidus_sample are both pretty quick. If we were to add/remove/rename a subproject, rename an existing one, or consider backend's JS tests separately from rspec (the change which motivated this), we would be less lucky and our CI would take longer.

This change splits backend JS from backend rspec, and gives each project a weight in build-ci.rb.

With this change, our CI runs:

* Worker 1: solidus_core
* Worker 2: solidus_backend (rspec)
* Worker 3: solidus_frontend, solidus_api, solidus_sample, solidus_backend (JS)

It's not a huge improvement, but it will probably make CI builds 20-30 seconds faster now by giving backend a worker all of its own, and it should stay fast regardless of what changes we make to our project structure in the future.