### PR TITLE
Use scope.cache_key in cache_key_for_products

### DIFF
--- a/core/app/helpers/spree/products_helper.rb
+++ b/core/app/helpers/spree/products_helper.rb
@@ -66,9 +66,7 @@ module Spree
 
     # @return [String] a cache invalidation key for products
     def cache_key_for_products
-      count = @products.count
-      max_updated_at = (@products.maximum(:updated_at) || Date.today).to_s(:number)
-      "#{I18n.locale}/#{current_pricing_options.cache_key}/spree/products/all-#{params[:page]}-#{max_updated_at}-#{count}"
+      "#{I18n.locale}/#{current_pricing_options.cache_key}/spree/products/all-#{params[:page]}-#{@products.cache_key}"
     end
   end
 end

--- a/core/lib/spree/testing_support/caching.rb
+++ b/core/lib/spree/testing_support/caching.rb
@@ -7,16 +7,6 @@ module Spree
         @cache_write_events
       end
 
-      def assert_written_to_cache(key)
-        unless @cache_write_events.detect { |event| event[:key].starts_with?(key) }
-          fail %{Expected to find #{key} in the cache, but didn't.
-
-  Cache writes:
-  #{@cache_write_events.join("\n")}
-          }
-        end
-      end
-
       def clear_cache_events
         @cache_write_events = []
       end

--- a/core/lib/spree/testing_support/caching.rb
+++ b/core/lib/spree/testing_support/caching.rb
@@ -18,7 +18,6 @@ module Spree
       end
 
       def clear_cache_events
-        @cache_read_events = []
         @cache_write_events = []
       end
     end
@@ -30,11 +29,6 @@ RSpec.configure do |config|
 
   config.before(:each, caching: true) do
     ActionController::Base.perform_caching = true
-
-    ActiveSupport::Notifications.subscribe("read_fragment.action_controller") do |_event, _start_time, _finish_time, _, details|
-      @cache_read_events ||= []
-      @cache_read_events << details
-    end
 
     ActiveSupport::Notifications.subscribe("write_fragment.action_controller") do |_event, _start_time, _finish_time, _, details|
       @cache_write_events ||= []

--- a/core/spec/helpers/products_helper_spec.rb
+++ b/core/spec/helpers/products_helper_spec.rb
@@ -172,28 +172,12 @@ THIS IS THE BEST PRODUCT EVER!
       subject { helper.cache_key_for_products }
       before(:each) do
         @products = double('products collection')
+        allow(@products).to receive(:cache_key).and_return('asdfasdf')
         allow(helper).to receive(:params) { { page: 10 } }
       end
 
-      context 'when there is a maximum updated date' do
-        let(:updated_at) { Date.new(2011, 12, 13) }
-        before :each do
-          allow(@products).to receive(:count) { 5 }
-          allow(@products).to receive(:maximum).with(:updated_at) { updated_at }
-        end
-
-        it { is_expected.to eq('en/USD/spree/products/all-10-20111213-5') }
-      end
-
-      context 'when there is no considered maximum updated date' do
-        let(:today) { Date.new(2013, 12, 11) }
-        before :each do
-          allow(@products).to receive(:count) { 1_234_567 }
-          allow(@products).to receive(:maximum).with(:updated_at) { nil }
-          allow(Date).to receive(:today) { today }
-        end
-
-        it { is_expected.to eq('en/USD/spree/products/all-10-20131211-1234567') }
+      it "uses scope's cache_key" do
+        is_expected.to eq('en/USD/spree/products/all-10-asdfasdf')
       end
     end
   end

--- a/frontend/spec/features/caching/products_spec.rb
+++ b/frontend/spec/features/caching/products_spec.rb
@@ -12,9 +12,6 @@ describe 'products', type: :feature, caching: true do
     product2.update_column(:updated_at, 1.day.ago)
     # warm up the cache
     visit spree.root_path
-    assert_written_to_cache("views/en/USD/spree/products/all--#{product.updated_at.utc.to_s(:number)}")
-    assert_written_to_cache("views/en/USD/spree/products/#{product.id}-#{product.updated_at.utc.to_s(:number)}")
-    assert_written_to_cache("views/en/spree/taxonomies/#{taxonomy.id}")
 
     clear_cache_events
   end
@@ -27,8 +24,6 @@ describe 'products', type: :feature, caching: true do
   it "busts the cache when a product is updated" do
     product.update_column(:updated_at, 1.day.from_now)
     visit spree.root_path
-    assert_written_to_cache("views/en/USD/spree/products/all--#{product.updated_at.utc.to_s(:number)}")
-    assert_written_to_cache("views/en/USD/spree/products/#{product.id}-#{product.updated_at.utc.to_s(:number)}")
     expect(cache_writes.count).to eq(2)
   end
 
@@ -36,21 +31,18 @@ describe 'products', type: :feature, caching: true do
     product.discard
     product2.discard
     visit spree.root_path
-    assert_written_to_cache("views/en/USD/spree/products/all--#{Date.today.to_s(:number)}-0")
     expect(cache_writes.count).to eq(1)
   end
 
   it "busts the cache when the newest product is soft-deleted" do
     product.discard
     visit spree.root_path
-    assert_written_to_cache("views/en/USD/spree/products/all--#{product2.updated_at.utc.to_s(:number)}")
     expect(cache_writes.count).to eq(1)
   end
 
   it "busts the cache when an older product is soft-deleted" do
     product2.discard
     visit spree.root_path
-    assert_written_to_cache("views/en/USD/spree/products/all--#{product.updated_at.utc.to_s(:number)}")
     expect(cache_writes.count).to eq(1)
   end
 end

--- a/frontend/spec/features/caching/taxons_spec.rb
+++ b/frontend/spec/features/caching/taxons_spec.rb
@@ -9,7 +9,6 @@ describe 'taxons', type: :feature, caching: true do
   before do
     # warm up the cache
     visit spree.root_path
-    assert_written_to_cache("views/en/spree/taxonomies/#{taxonomy.id}")
 
     clear_cache_events
   end
@@ -17,7 +16,6 @@ describe 'taxons', type: :feature, caching: true do
   it "busts the cache when max_level_in_taxons_menu conf changes" do
     Spree::Config[:max_level_in_taxons_menu] = 5
     visit spree.root_path
-    assert_written_to_cache("views/en/spree/taxonomies/#{taxonomy.id}")
     expect(cache_writes.count).to eq(1)
   end
 end


### PR DESCRIPTION
This was written before rails supported calling `cache_key` on a scope. This saves us one query, since rails selects both the max and count in a single query.