### PR TITLE
Revert "deprecate pagination in searcher"

### DIFF
--- a/core/lib/spree/core/search/base.rb
+++ b/core/lib/spree/core/search/base.rb
@@ -27,15 +27,12 @@ module Spree
 
         def retrieve_products
           @products = get_base_scope
+          curr_page = page || 1
 
           unless Spree::Config.show_products_without_price
             @products = @products.joins(:prices).merge(Spree::Price.where(pricing_options.search_arguments)).distinct
           end
-          if @properties[:page]
-            curr_page = @properties[:page] || 1
-            @products = @products.page(curr_page).per(@properties[:per_page])
-          end
-          @products
+          @products = @products.page(curr_page).per(per_page)
         end
 
         def method_missing(name)
@@ -104,14 +101,9 @@ module Spree
           @properties[:search] = params[:search]
           @properties[:include_images] = params[:include_images]
 
-          if params[:per_page].present? || params[:page].present?
-            Spree::Deprecation.warn "Pagination inside the searcher is no longer supported." \
-              "Please paginate the results of the searcher yourself."
-
-            per_page = params[:per_page].to_i
-            @properties[:per_page] = per_page > 0 ? per_page : Spree::Config[:products_per_page]
-            @properties[:page] = (params[:page].to_i <= 0) ? 1 : params[:page].to_i
-          end
+          per_page = params[:per_page].to_i
+          @properties[:per_page] = per_page > 0 ? per_page : Spree::Config[:products_per_page]
+          @properties[:page] = (params[:page].to_i <= 0) ? 1 : params[:page].to_i
         end
       end
     end

--- a/core/spec/lib/search/base_spec.rb
+++ b/core/spec/lib/search/base_spec.rb
@@ -35,15 +35,13 @@ RSpec.describe Spree::Core::Search::Base do
   it "switches to next page according to the page parameter" do
     @product3 = create(:product, name: "RoR Pants", price: 14.00)
 
-    Spree::Deprecation.silence do
-      params = { per_page: "2" }
-      searcher = Spree::Core::Search::Base.new(params)
-      expect(searcher.retrieve_products.count).to eq(2)
+    params = { per_page: "2" }
+    searcher = Spree::Core::Search::Base.new(params)
+    expect(searcher.retrieve_products.count).to eq(2)
 
-      params[:page] = "2"
-      searcher = Spree::Core::Search::Base.new(params)
-      expect(searcher.retrieve_products.count).to eq(1)
-    end
+    params[:page] = "2"
+    searcher = Spree::Core::Search::Base.new(params)
+    expect(searcher.retrieve_products.count).to eq(1)
   end
 
   it "maps search params to named scopes" do

--- a/frontend/app/controllers/spree/products_controller.rb
+++ b/frontend/app/controllers/spree/products_controller.rb
@@ -8,8 +8,8 @@ module Spree
     respond_to :html
 
     def index
-      @searcher = build_searcher(params.merge(include_images: true).reject { |k, _| ["per_page", "page"].include?(k) } )
-      @products = @searcher.retrieve_products.page(params[:page] || 1).per(params[:per_page].presence || Spree::Config[:products_per_page])
+      @searcher = build_searcher(params.merge(include_images: true))
+      @products = @searcher.retrieve_products
       @taxonomies = Spree::Taxonomy.includes(root: :children)
     end
 

--- a/frontend/app/controllers/spree/taxons_controller.rb
+++ b/frontend/app/controllers/spree/taxons_controller.rb
@@ -8,8 +8,8 @@ module Spree
       @taxon = Spree::Taxon.find_by!(permalink: params[:id])
       return unless @taxon
 
-      @searcher = build_searcher(params.merge(taxon: @taxon.id, include_images: true).reject { |k, _| ["per_page", "page"].include?(k) } )
-      @products = @searcher.retrieve_products.page(params[:page] || 1).per(params[:per_page].presence || Spree::Config[:products_per_page])
+      @searcher = build_searcher(params.merge(taxon: @taxon.id, include_images: true))
+      @products = @searcher.retrieve_products
       @taxonomies = Spree::Taxonomy.includes(root: :children)
     end
 


### PR DESCRIPTION
Reverts #2119

We've had a lot of reports in both github and slack from users having problems with this change.

Considering this again, I believe it is the wrong thing to do. The purpose of the configurable searcher class is mainly to allow using more advanced external search services like elasticsearch, sphinx, solr, etc.

When using any of these do want them, and therefore the searcher class, to be responsible for pagination. For example, we have to give elasticsearch the page of results we want, otherwise it would have to return ALL the pages of all the results, which is not reasonable to do.

I think we should release a version 2.4.2 with this reverted.

cc @Sinetheta