### PR TITLE
Use BigDecimal() instead of BigDecimal.new()

### DIFF
--- a/backend/spec/features/admin/promotions/tiered_calculator_spec.rb
+++ b/backend/spec/features/admin/promotions/tiered_calculator_spec.rb
@@ -38,7 +38,7 @@ feature "Tiered Calculator Promotions" do
     first_action_calculator = first_action.calculator
     expect(first_action_calculator.class).to eq Spree::Calculator::TieredPercent
     expect(first_action_calculator.preferred_base_percent).to eq 5
-    expect(first_action_calculator.preferred_tiers).to eq(BigDecimal.new(100) => BigDecimal.new(10))
+    expect(first_action_calculator.preferred_tiers).to eq(BigDecimal(100) => BigDecimal(10))
   end
 
   context "with an existing tiered flat rate calculator" do
@@ -66,8 +66,8 @@ feature "Tiered Calculator Promotions" do
 
       calculator = promotion.actions.first.calculator
       expect(calculator.preferred_tiers).to eq({
-        BigDecimal.new(100) => 10,
-        BigDecimal.new(300) => 20
+        BigDecimal(100) => 10,
+        BigDecimal(300) => 20
       })
     end
   end

--- a/core/app/models/spree/calculator/default_tax.rb
+++ b/core/app/models/spree/calculator/default_tax.rb
@@ -42,7 +42,7 @@ module Spree
     end
 
     def round_to_two_places(amount)
-      BigDecimal.new(amount.to_s).round(2, BigDecimal::ROUND_HALF_UP)
+      BigDecimal(amount.to_s).round(2, BigDecimal::ROUND_HALF_UP)
     end
 
     def deduced_total_by_rate(item, rate)

--- a/core/app/models/spree/calculator/flexi_rate.rb
+++ b/core/app/models/spree/calculator/flexi_rate.rb
@@ -16,7 +16,7 @@ module Spree
       items_count = object.quantity
       items_count = [items_count, preferred_max_items].min unless preferred_max_items.zero?
 
-      return BigDecimal.new(0) if items_count == 0
+      return BigDecimal(0) if items_count == 0
 
       additional_items_count = items_count - 1
       preferred_first_item + preferred_additional_item * additional_items_count

--- a/core/app/models/spree/calculator/returns/default_refund_amount.rb
+++ b/core/app/models/spree/calculator/returns/default_refund_amount.rb
@@ -25,7 +25,7 @@ module Spree
       end
 
       def quantity_of_line_item(inventory_unit)
-        BigDecimal.new(inventory_unit.line_item.quantity)
+        BigDecimal(inventory_unit.line_item.quantity)
       end
     end
   end

--- a/core/app/models/spree/calculator/tiered_flat_rate.rb
+++ b/core/app/models/spree/calculator/tiered_flat_rate.rb
@@ -34,7 +34,7 @@ module Spree
     def cast_to_d(value)
       value.to_s.to_d
     rescue ArgumentError
-      BigDecimal.new(0)
+      BigDecimal(0)
     end
 
     def preferred_tiers_content

--- a/core/app/models/spree/calculator/tiered_percent.rb
+++ b/core/app/models/spree/calculator/tiered_percent.rb
@@ -40,7 +40,7 @@ module Spree
     def cast_to_d(value)
       value.to_s.to_d
     rescue ArgumentError
-      BigDecimal.new(0)
+      BigDecimal(0)
     end
 
     def preferred_tiers_content

--- a/core/app/models/spree/inventory_unit.rb
+++ b/core/app/models/spree/inventory_unit.rb
@@ -134,7 +134,7 @@ module Spree
     end
 
     def percentage_of_line_item
-      1 / BigDecimal.new(line_item.quantity)
+      1 / BigDecimal(line_item.quantity)
     end
 
     def current_return_item

--- a/core/app/models/spree/promotion/actions/create_adjustment.rb
+++ b/core/app/models/spree/promotion/actions/create_adjustment.rb
@@ -39,7 +39,7 @@ module Spree
           if !amount.is_a?(BigDecimal)
             Spree::Deprecation.warn "#{calculator.class.name}#compute returned #{amount.inspect}, it should return a BigDecimal"
           end
-          amount ||= BigDecimal.new(0)
+          amount ||= BigDecimal(0)
           amount = amount.abs
           [(calculable.item_total + calculable.ship_total), amount].min * -1
         end

--- a/core/app/models/spree/promotion/actions/create_item_adjustments.rb
+++ b/core/app/models/spree/promotion/actions/create_item_adjustments.rb
@@ -33,7 +33,7 @@ module Spree
           if !promotion_amount.is_a?(BigDecimal)
             Spree::Deprecation.warn "#{calculator.class.name}#compute returned #{promotion_amount.inspect}, it should return a BigDecimal"
           end
-          promotion_amount ||= BigDecimal.new(0)
+          promotion_amount ||= BigDecimal(0)
           promotion_amount = promotion_amount.abs
           [adjustable.amount, promotion_amount].min * -1
         end

--- a/core/app/models/spree/promotion/actions/create_quantity_adjustments.rb
+++ b/core/app/models/spree/promotion/actions/create_quantity_adjustments.rb
@@ -56,7 +56,7 @@ module Spree::Promotion::Actions
       if !adjustment_amount.is_a?(BigDecimal)
         Spree::Deprecation.warn "#{calculator.class.name}#compute returned #{adjustment_amount.inspect}, it should return a BigDecimal"
       end
-      adjustment_amount ||= BigDecimal.new(0)
+      adjustment_amount ||= BigDecimal(0)
       adjustment_amount = adjustment_amount.abs
 
       order = line_item.order

--- a/core/app/models/spree/promotion/rules/item_total.rb
+++ b/core/app/models/spree/promotion/rules/item_total.rb
@@ -17,7 +17,7 @@ module Spree
         def eligible?(order, _options = {})
           return false unless order.currency == preferred_currency
           item_total = order.item_total
-          unless item_total.send(preferred_operator == 'gte' ? :>= : :>, BigDecimal.new(preferred_amount.to_s))
+          unless item_total.send(preferred_operator == 'gte' ? :>= : :>, BigDecimal(preferred_amount.to_s))
             eligibility_errors.add(:base, ineligible_message)
           end
 

--- a/core/app/models/spree/promotion_chooser.rb
+++ b/core/app/models/spree/promotion_chooser.rb
@@ -16,7 +16,7 @@ module Spree
         end
         best_promotion_adjustment.amount
       else
-        BigDecimal.new('0')
+        BigDecimal('0')
       end
     end
 

--- a/core/lib/spree/localized_number.rb
+++ b/core/lib/spree/localized_number.rb
@@ -22,7 +22,7 @@ module Spree
       number = number.gsub(separator, '.') unless separator == '.'
 
       # Handle empty string for ruby 2.4 compatibility
-      BigDecimal.new(number.presence || 0)
+      BigDecimal(number.presence || 0)
     end
   end
 end

--- a/core/lib/spree/preferences/preferable.rb
+++ b/core/lib/spree/preferences/preferable.rb
@@ -150,7 +150,7 @@ module Spree
           begin
             value.to_s.to_d
           rescue ArgumentError
-            BigDecimal.new(0)
+            BigDecimal(0)
           end
         when :integer
           value.to_i

--- a/core/lib/spree/testing_support/factories/line_item_factory.rb
+++ b/core/lib/spree/testing_support/factories/line_item_factory.rb
@@ -4,7 +4,7 @@ require 'spree/testing_support/factories/product_factory'
 FactoryBot.define do
   factory :line_item, class: 'Spree::LineItem' do
     quantity 1
-    price { BigDecimal.new('10.00') }
+    price { BigDecimal('10.00') }
     order
     transient do
       product nil

--- a/core/lib/spree/testing_support/factories/order_factory.rb
+++ b/core/lib/spree/testing_support/factories/order_factory.rb
@@ -15,7 +15,7 @@ FactoryBot.define do
     store
 
     transient do
-      line_items_price BigDecimal.new(10)
+      line_items_price { BigDecimal(10) }
     end
 
     # TODO: Improve the name of order_with_totals factory.

--- a/core/lib/spree/testing_support/factories/variant_factory.rb
+++ b/core/lib/spree/testing_support/factories/variant_factory.rb
@@ -4,7 +4,7 @@ require 'spree/testing_support/factories/option_type_factory'
 require 'spree/testing_support/factories/product_factory'
 
 FactoryBot.define do
-  sequence(:random_float) { BigDecimal.new("#{rand(200)}.#{rand(99)}") }
+  sequence(:random_float) { BigDecimal("#{rand(200)}.#{rand(99)}") }
 
   factory :base_variant, class: 'Spree::Variant' do
     price 19.99

--- a/core/spec/lib/spree/money_spec.rb
+++ b/core/spec/lib/spree/money_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Spree::Money do
       end
 
       context 'with BigDecimal' do
-        let(:amount){ BigDecimal.new('10.00') }
+        let(:amount){ BigDecimal('10.00') }
         it { should == "$10.00 USD" }
       end
     end

--- a/core/spec/models/spree/calculator/refunds/default_refund_amount_spec.rb
+++ b/core/spec/models/spree/calculator/refunds/default_refund_amount_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Spree::Calculator::Returns::DefaultRefundAmount, type: :model do
         # line_item_quantity = 3
         # adjustment_amount  = 10
         # 100 - (10 / 3)     = 96.66666666666666667
-        expect(subject).to eq BigDecimal.new('96.66666666666666667')
+        expect(subject).to eq BigDecimal('96.66666666666666667')
       end
     end
 

--- a/core/spec/models/spree/calculator/tiered_flat_rate_spec.rb
+++ b/core/spec/models/spree/calculator/tiered_flat_rate_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Spree::Calculator::TieredFlatRate, type: :model do
         before { calculator.preferred_tiers = { 20 => 20 } }
         it "converts successfully" do
           is_expected.to be true
-          expect(calculator.preferred_tiers).to eq({ BigDecimal.new('20') => BigDecimal.new('20') })
+          expect(calculator.preferred_tiers).to eq({ BigDecimal('20') => BigDecimal('20') })
         end
       end
 
@@ -26,7 +26,7 @@ RSpec.describe Spree::Calculator::TieredFlatRate, type: :model do
         before { calculator.preferred_tiers = { 20.5 => 20.5 } }
         it "converts successfully" do
           is_expected.to be true
-          expect(calculator.preferred_tiers).to eq({ BigDecimal.new('20.5') => BigDecimal.new('20.5') })
+          expect(calculator.preferred_tiers).to eq({ BigDecimal('20.5') => BigDecimal('20.5') })
         end
       end
 
@@ -34,7 +34,7 @@ RSpec.describe Spree::Calculator::TieredFlatRate, type: :model do
         before { calculator.preferred_tiers = { "20" => 20 } }
         it "converts successfully" do
           is_expected.to be true
-          expect(calculator.preferred_tiers).to eq({ BigDecimal.new('20') => BigDecimal.new('20') })
+          expect(calculator.preferred_tiers).to eq({ BigDecimal('20') => BigDecimal('20') })
         end
       end
 
@@ -42,7 +42,7 @@ RSpec.describe Spree::Calculator::TieredFlatRate, type: :model do
         before { calculator.preferred_tiers = { "  20 " => 20 } }
         it "converts successfully" do
           is_expected.to be true
-          expect(calculator.preferred_tiers).to eq({ BigDecimal.new('20') => BigDecimal.new('20') })
+          expect(calculator.preferred_tiers).to eq({ BigDecimal('20') => BigDecimal('20') })
         end
       end
 
@@ -50,7 +50,7 @@ RSpec.describe Spree::Calculator::TieredFlatRate, type: :model do
         before { calculator.preferred_tiers = { "20.5" => "20.5" } }
         it "converts successfully" do
           is_expected.to be true
-          expect(calculator.preferred_tiers).to eq({ BigDecimal.new('20.5') => BigDecimal.new('20.5') })
+          expect(calculator.preferred_tiers).to eq({ BigDecimal('20.5') => BigDecimal('20.5') })
         end
       end
     end

--- a/core/spec/models/spree/calculator/tiered_percent_spec.rb
+++ b/core/spec/models/spree/calculator/tiered_percent_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Spree::Calculator::TieredPercent, type: :model do
         before { calculator.preferred_tiers = { 20 => 20 } }
         it "converts successfully" do
           is_expected.to be true
-          expect(calculator.preferred_tiers).to eq({ BigDecimal.new('20') => BigDecimal.new('20') })
+          expect(calculator.preferred_tiers).to eq({ BigDecimal('20') => BigDecimal('20') })
         end
       end
 
@@ -42,7 +42,7 @@ RSpec.describe Spree::Calculator::TieredPercent, type: :model do
         before { calculator.preferred_tiers = { 20.5 => 20.5 } }
         it "converts successfully" do
           is_expected.to be true
-          expect(calculator.preferred_tiers).to eq({ BigDecimal.new('20.5') => BigDecimal.new('20.5') })
+          expect(calculator.preferred_tiers).to eq({ BigDecimal('20.5') => BigDecimal('20.5') })
         end
       end
 
@@ -50,7 +50,7 @@ RSpec.describe Spree::Calculator::TieredPercent, type: :model do
         before { calculator.preferred_tiers = { "20" => 20 } }
         it "converts successfully" do
           is_expected.to be true
-          expect(calculator.preferred_tiers).to eq({ BigDecimal.new('20') => BigDecimal.new('20') })
+          expect(calculator.preferred_tiers).to eq({ BigDecimal('20') => BigDecimal('20') })
         end
       end
 
@@ -58,7 +58,7 @@ RSpec.describe Spree::Calculator::TieredPercent, type: :model do
         before { calculator.preferred_tiers = { "  20 " => 20 } }
         it "converts successfully" do
           is_expected.to be true
-          expect(calculator.preferred_tiers).to eq({ BigDecimal.new('20') => BigDecimal.new('20') })
+          expect(calculator.preferred_tiers).to eq({ BigDecimal('20') => BigDecimal('20') })
         end
       end
 
@@ -66,7 +66,7 @@ RSpec.describe Spree::Calculator::TieredPercent, type: :model do
         before { calculator.preferred_tiers = { "20.5" => "20.5" } }
         it "converts successfully" do
           is_expected.to be true
-          expect(calculator.preferred_tiers).to eq({ BigDecimal.new('20.5') => BigDecimal.new('20.5') })
+          expect(calculator.preferred_tiers).to eq({ BigDecimal('20.5') => BigDecimal('20.5') })
         end
       end
     end

--- a/core/spec/models/spree/price_spec.rb
+++ b/core/spec/models/spree/price_spec.rb
@@ -143,6 +143,6 @@ RSpec.describe Spree::Price, type: :model do
 
     subject { price.net_amount }
 
-    it { is_expected.to eq(BigDecimal.new(20) / 1.1) }
+    it { is_expected.to eq(BigDecimal(20) / 1.1) }
   end
 end

--- a/core/spec/models/spree/reimbursement/credit_spec.rb
+++ b/core/spec/models/spree/reimbursement/credit_spec.rb
@@ -12,7 +12,7 @@ module Spree
         before { allow(reimbursement).to receive(:credits).and_return([credit_double, credit_double]) }
 
         it 'should sum the amounts of all of the reimbursements credits' do
-          expect(subject).to eq BigDecimal.new('199.98')
+          expect(subject).to eq BigDecimal('199.98')
         end
       end
     end

--- a/core/spec/models/spree/reimbursement_spec.rb
+++ b/core/spec/models/spree/reimbursement_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Spree::Reimbursement, type: :model do
     let(:shipping_method)         { create :shipping_method, zones: [tax_zone] }
     let(:variant)                 { create :variant }
     let(:order)                   { create(:order_with_line_items, state: 'payment', line_items_attributes: [{ variant: variant, price: line_items_price }], shipment_cost: 0, shipping_method: shipping_method) }
-    let(:line_items_price)        { BigDecimal.new(10) }
+    let(:line_items_price)        { BigDecimal(10) }
     let(:line_item)               { order.line_items.first }
     let(:inventory_unit)          { line_item.inventory_units.first }
     let(:payment)                 { build(:payment, amount: payment_amount, order: order, state: 'checkout') }

--- a/core/spec/models/spree/user_spec.rb
+++ b/core/spec/models/spree/user_spec.rb
@@ -102,7 +102,7 @@ end
 
 RSpec.describe Spree.user_class, type: :model do
   context "reporting" do
-    let(:order_value) { BigDecimal.new("80.94") }
+    let(:order_value) { BigDecimal("80.94") }
     let(:order_count) { 4 }
     let(:orders) { Array.new(order_count, double(total: order_value)) }
 

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -108,7 +108,7 @@ For example, if you want to add a method to the `Spree::Order` model, you would 
 module MyStore
   module OrderDecorator
     def total
-      super + BigDecimal.new(10.0)
+      super + BigDecimal(10.0)
     end
   end
 end


### PR DESCRIPTION
`BigDecimal.new` is being deprecated in BigDecimal 1.3.3. It's likely to be included in ruby 2.5, which will be out later this month.

https://github.com/ruby/bigdecimal/commit/5337373