### PR TITLE
Support rspec-rails 3.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ end
 gem 'database_cleaner', '~> 1.3', require: false
 gem 'factory_bot_rails', '~> 4.8', require: false
 gem 'rspec-activemodel-mocks', '~>1.0.2', require: false
-gem 'rspec-rails', '~> 3.6.0', require: false
+gem 'rspec-rails', '~> 3.7', require: false
 gem 'simplecov', require: false
 gem 'timecop', require: false
 gem 'with_model', require: false


### PR DESCRIPTION
We previously had errors on rspec-rails 3.7 due to not having puma, but that is no longer an issue.