### PR TITLE
Remove broken `Shipment.has_many :cartons` relationship

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -10,7 +10,6 @@ module Spree
     has_many :shipping_rates, -> { order(:cost) }, dependent: :destroy, inverse_of: :shipment
     has_many :shipping_methods, through: :shipping_rates
     has_many :state_changes, as: :stateful
-    has_many :cartons, -> { uniq }, through: :inventory_units
 
     before_validation :set_cost_zero_when_nil
 


### PR DESCRIPTION
This has been broken since Solidus 2.3 (Rails 5.1).

Solidus 2.2 gave this warning:

> DEPRECATION WARNING: uniq is deprecated and will be removed from Rails 5.1 (use distinct instead) (called from block in <class:Shipment>

No one is using it apparently :) and I think it's probably best not to declare
this as a `has_many` anyway, for the sake of simplifying the in-memory object
situation for orders/shipments/inventory units/cartons.