### PR TITLE
New preference to control available currencies

### DIFF
--- a/backend/app/views/spree/admin/promotions/calculators/tiered_flat_rate/_fields.html.erb
+++ b/backend/app/views/spree/admin/promotions/calculators/tiered_flat_rate/_fields.html.erb
@@ -10,7 +10,7 @@
   <%= select_tag(
     "#{prefix}[calculator_attributes][preferred_currency]",
     options_for_select(
-      Money::Currency.all,
+      Spree::Config.available_currencies,
       calculator.preferred_currency || Spree::Config[:currency]
     ),
     { class: 'custom-select fullwidth' }

--- a/backend/app/views/spree/admin/promotions/calculators/tiered_percent/_fields.html.erb
+++ b/backend/app/views/spree/admin/promotions/calculators/tiered_percent/_fields.html.erb
@@ -10,7 +10,7 @@
   <%= select_tag(
     "#{prefix}[calculator_attributes][preferred_currency]",
     options_for_select(
-      Money::Currency.all,
+      Spree::Config.available_currencies,
       calculator.preferred_currency || Spree::Config[:currency]
     ),
     { class: 'custom-select fullwidth' }

--- a/backend/app/views/spree/admin/shared/_js_locale_data.html.erb
+++ b/backend/app/views/spree/admin/shared/_js_locale_data.html.erb
@@ -15,7 +15,7 @@
 
   Spree.currencyInfo = <%==
     JSON.dump(
-      Money::Currency.all.map { |c|
+      Spree::Config.available_currencies.map { |c|
         format =
           if c.symbol == "" || c.symbol_first
             "%s%v"

--- a/backend/app/views/spree/admin/shared/_number_with_currency.html.erb
+++ b/backend/app/views/spree/admin/shared/_number_with_currency.html.erb
@@ -11,6 +11,6 @@
       <%= ::Money::Currency.find(currency).iso_code %>
     </div>
   <% else %>
-    <%= f.select currency_attr, ::Money::Currency.all.map(&:iso_code), {include_blank: true}, {required: required, class: 'number-with-currency-select'} %>
+    <%= f.select currency_attr, Spree::Config.available_currencies.map(&:iso_code), {selected: Spree::Config.currency}, {required: required, class: 'number-with-currency-select'} %>
   <% end %>
 </div>

--- a/backend/app/views/spree/admin/stores/_form.html.erb
+++ b/backend/app/views/spree/admin/stores/_form.html.erb
@@ -43,7 +43,7 @@
 <%= f.field_container :default_currency do %>
   <%= f.label :default_currency %>
   <%= f.select :default_currency,
-    ::Money::Currency.all.map(&:iso_code),
+    Spree::Config.available_currencies.map(&:iso_code),
     { include_blank: true },
     { class: 'select2 fullwidth' } %>
   <%= f.error_message_on :default_currency %>

--- a/backend/spec/javascripts/views/number_with_currency_spec.js
+++ b/backend/spec/javascripts/views/number_with_currency_spec.js
@@ -24,15 +24,15 @@ describe("Spree.Views.NumberWithCurrency", function() {
       loadView();
     });
 
-    it("has no currency selected", function() {
-      expect($select).to.have.$val('');
-      expect($symbol).to.have.$text('');
+    it("has a default currency selected", function() {
+      expect($select).to.have.$val('USD');
+      expect($symbol).to.have.$text('$');
     });
 
-    it("can select USD", function() {
-      $select.val('USD').trigger('change');
+    it("can select CAD", function() {
+      $select.val('CAD').trigger('change');
 
-      expect($select).to.have.$val('USD');
+      expect($select).to.have.$val('CAD');
       expect($symbol).to.have.$text('$');
     });
 

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -257,6 +257,15 @@ module Spree
     #   @return [Boolean] Indicates if stock management can be restricted by location
     preference :can_restrict_stock_management, :boolean, default: false
 
+    # Allows restricting what currencies will be available.
+    #
+    # @!attribute [r] available_currencies
+    #   @returns [Array] An array of available currencies from Money::Currency.all
+    attr_writer :available_currencies
+    def available_currencies
+      @available_currencies ||= ::Money::Currency.all
+    end
+
     # searcher_class allows spree extension writers to provide their own Search class
     class_name_attribute :searcher_class, default: 'Spree::Core::Search::Base'
 


### PR DESCRIPTION
This change allows stores to control what currencies will be available, it could improve usability a bit in some dropdowns by limiting the number of options.