### PR TITLE
Deprecate Searcher::Base method_missing properties magic

### DIFF
--- a/core/lib/spree/core/search/base.rb
+++ b/core/lib/spree/core/search/base.rb
@@ -27,16 +27,17 @@ module Spree
 
         def retrieve_products
           @products = get_base_scope
-          curr_page = page || 1
+          curr_page = @properties[:page] || 1
 
           unless Spree::Config.show_products_without_price
             @products = @products.joins(:prices).merge(Spree::Price.where(pricing_options.search_arguments)).distinct
           end
-          @products = @products.page(curr_page).per(per_page)
+          @products = @products.page(curr_page).per(@properties[:per_page])
         end
 
         def method_missing(name)
-          if @properties.key? name
+          if @properties.key?(name)
+            Spree::Deprecation.warn "Accessing Searcher's #{name} property using #{self.class.name}##{name} is deprecated without replacement"
             @properties[name]
           else
             super
@@ -47,8 +48,8 @@ module Spree
 
         def get_base_scope
           base_scope = Spree::Product.display_includes.available
-          base_scope = base_scope.in_taxon(taxon) unless taxon.blank?
-          base_scope = get_products_conditions_for(base_scope, keywords)
+          base_scope = base_scope.in_taxon(@properties[:taxon]) unless @properties[:taxon].blank?
+          base_scope = get_products_conditions_for(base_scope, @properties[:keywords])
           base_scope = add_search_scopes(base_scope)
           base_scope = add_eagerload_scopes(base_scope)
           base_scope
@@ -71,19 +72,19 @@ module Spree
           # `where` constraints affecting joined tables are added to the search;
           # which is the case as soon as a taxon is added to the base scope.
           scope = scope.preload(master: :currently_valid_prices)
-          scope = scope.preload(master: :images) if include_images
+          scope = scope.preload(master: :images) if @properties[:include_images]
           scope
         end
 
         def add_search_scopes(base_scope)
-          search.each do |name, scope_attribute|
+          @properties[:search].each do |name, scope_attribute|
             scope_name = name.to_sym
             if base_scope.respond_to?(:search_scopes) && base_scope.search_scopes.include?(scope_name.to_sym)
               base_scope = base_scope.send(scope_name, *scope_attribute)
             else
               base_scope = base_scope.merge(Spree::Product.ransack({ scope_name => scope_attribute }).result)
             end
-          end if search
+          end if @properties[:search]
           base_scope
         end
 

--- a/core/lib/spree/core/search/base.rb
+++ b/core/lib/spree/core/search/base.rb
@@ -77,14 +77,16 @@ module Spree
         end
 
         def add_search_scopes(base_scope)
-          @properties[:search].each do |name, scope_attribute|
-            scope_name = name.to_sym
-            if base_scope.respond_to?(:search_scopes) && base_scope.search_scopes.include?(scope_name.to_sym)
-              base_scope = base_scope.send(scope_name, *scope_attribute)
-            else
-              base_scope = base_scope.merge(Spree::Product.ransack({ scope_name => scope_attribute }).result)
+          if @properties[:search]
+            @properties[:search].each do |name, scope_attribute|
+              scope_name = name.to_sym
+              if base_scope.respond_to?(:search_scopes) && base_scope.search_scopes.include?(scope_name.to_sym)
+                base_scope = base_scope.send(scope_name, *scope_attribute)
+              else
+                base_scope = base_scope.merge(Spree::Product.ransack({ scope_name => scope_attribute }).result)
+              end
             end
-          end if @properties[:search]
+          end
           base_scope
         end
 


### PR DESCRIPTION
Previously, every key of the searcher's `@properties` could be accessed by method_missing magic. Instead we should require explicitness.