### PR TITLE
Fix core specs to run in isolation

### DIFF
--- a/core/Rakefile
+++ b/core/Rakefile
@@ -12,4 +12,12 @@ DummyApp::RakeTasks.new(
   lib_name: 'solidus_core'
 )
 
+namespace :spec do
+  task :isolated do
+    Dir['spec/**/*_spec.rb'].all? do |file|
+      sh('rspec', file)
+    end || raise("Failures")
+  end
+end
+
 task test_app: 'db:reset'

--- a/core/Rakefile
+++ b/core/Rakefile
@@ -14,9 +14,18 @@ DummyApp::RakeTasks.new(
 
 namespace :spec do
   task :isolated do
-    Dir['spec/**/*_spec.rb'].all? do |file|
-      sh('rspec', file)
-    end || raise("Failures")
+    spec_files = Dir['spec/**/*_spec.rb']
+    failed_specs =
+      spec_files.reject do |file|
+        puts "rspec #{file}"
+        system('rspec', file)
+      end
+
+    if !failed_specs.empty?
+      puts "Failed specs:"
+      puts failed_specs
+      exit 1
+    end
   end
 end
 

--- a/core/app/models/spree/calculator/percent_on_line_item.rb
+++ b/core/app/models/spree/calculator/percent_on_line_item.rb
@@ -1,13 +1,11 @@
 require_dependency 'spree/calculator'
 
 module Spree
-  class Calculator
-    class PercentOnLineItem < Calculator
-      preference :percent, :decimal, default: 0
+  class Calculator::PercentOnLineItem < Calculator
+    preference :percent, :decimal, default: 0
 
-      def compute(object)
-        (object.amount * preferred_percent) / 100
-      end
+    def compute(object)
+      (object.amount * preferred_percent) / 100
     end
   end
 end

--- a/core/app/models/spree/payment_method/credit_card.rb
+++ b/core/app/models/spree/payment_method/credit_card.rb
@@ -8,7 +8,7 @@ module Spree
   #
   class PaymentMethod::CreditCard < PaymentMethod
     def payment_source_class
-      CreditCard
+      Spree::CreditCard
     end
 
     def partial_name

--- a/core/lib/spree/testing_support/preferences.rb
+++ b/core/lib/spree/testing_support/preferences.rb
@@ -11,7 +11,10 @@ module Spree
       def reset_spree_preferences(&config_block)
         Spree::Config.instance_variables.each { |iv| Spree::Config.remove_instance_variable(iv) }
         Spree::Config.preference_store = Spree::Config.default_preferences
-        Rails.application.config.spree = Spree::Config.environment
+
+        if defined?(Railties)
+          Rails.application.config.spree = Spree::Config.environment
+        end
 
         configure_spree_preferences(&config_block) if block_given?
       end

--- a/core/spec/lib/search/base_spec.rb
+++ b/core/spec/lib/search/base_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'spree/core/product_filters'
 
 RSpec.describe Spree::Core::Search::Base do
   before do

--- a/core/spec/models/spree/calculator/percent_on_line_item_spec.rb
+++ b/core/spec/models/spree/calculator/percent_on_line_item_spec.rb
@@ -2,19 +2,17 @@ require 'rails_helper'
 require 'shared_examples/calculator_shared_examples'
 
 module Spree
-  class Calculator
-    RSpec.describe PercentOnLineItem, type: :model do
-      context "compute" do
-        let(:line_item) { double("LineItem", amount: 100) }
+  RSpec.describe Calculator::PercentOnLineItem, type: :model do
+    context "compute" do
+      let(:line_item) { double("LineItem", amount: 100) }
 
-        before { subject.preferred_percent = 15 }
+      before { subject.preferred_percent = 15 }
 
-        it "computes based on item price and quantity" do
-          expect(subject.compute(line_item)).to eq 15
-        end
+      it "computes based on item price and quantity" do
+        expect(subject.compute(line_item)).to eq 15
       end
-
-      it_behaves_like 'a calculator with a description'
     end
+
+    it_behaves_like 'a calculator with a description'
   end
 end

--- a/core/spec/models/spree/calculator/percent_per_item_spec.rb
+++ b/core/spec/models/spree/calculator/percent_per_item_spec.rb
@@ -1,12 +1,10 @@
-require_dependency 'spree/calculator'
-
 require 'rails_helper'
 require 'shared_examples/calculator_shared_examples'
 
+require_dependency 'spree/calculator'
+
 module Spree
-  class Calculator
-    RSpec.describe PercentPerItem, type: :model do
-      it_behaves_like 'a calculator with a description'
-    end
+  RSpec.describe Calculator::PercentPerItem, type: :model do
+    it_behaves_like 'a calculator with a description'
   end
 end

--- a/core/spec/models/spree/payment/cancellation_spec.rb
+++ b/core/spec/models/spree/payment/cancellation_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe Spree::Payment::Cancellation do
   describe '#initialize' do

--- a/core/spec/models/spree/preferences/statically_configurable_spec.rb
+++ b/core/spec/models/spree/preferences/statically_configurable_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'spree/preferences/statically_configurable'
 
 module Spree
   RSpec.describe Preferences::StaticallyConfigurable do

--- a/core/spec/models/spree/promotion/actions/create_item_adjustments_spec.rb
+++ b/core/spec/models/spree/promotion/actions/create_item_adjustments_spec.rb
@@ -1,188 +1,184 @@
 require 'rails_helper'
 
 module Spree
-  class Promotion
-    module Actions
-      RSpec.describe CreateItemAdjustments, type: :model do
-        let(:order) { create(:order_with_line_items, line_items_count: 1) }
-        let(:promotion) { create(:promotion, :with_line_item_adjustment, adjustment_rate: adjustment_amount) }
-        let(:adjustment_amount) { 10 }
-        let(:action) { promotion.actions.first! }
-        let(:line_item) { order.line_items.to_a.first }
-        let(:payload) { { order: order, promotion: promotion } }
+  RSpec.describe Promotion::Actions::CreateItemAdjustments, type: :model do
+    let(:order) { create(:order_with_line_items, line_items_count: 1) }
+    let(:promotion) { create(:promotion, :with_line_item_adjustment, adjustment_rate: adjustment_amount) }
+    let(:adjustment_amount) { 10 }
+    let(:action) { promotion.actions.first! }
+    let(:line_item) { order.line_items.to_a.first }
+    let(:payload) { { order: order, promotion: promotion } }
 
-        before do
-          allow(action).to receive(:promotion).and_return(promotion)
-          promotion.promotion_actions = [action]
+    before do
+      allow(action).to receive(:promotion).and_return(promotion)
+      promotion.promotion_actions = [action]
+    end
+
+    context "#perform" do
+      # Regression test for https://github.com/spree/spree/issues/3966
+      context "when calculator computes 0" do
+        let(:adjustment_amount) { 0 }
+
+        it "does not create an adjustment when calculator returns 0" do
+          action.perform(payload)
+          expect(action.adjustments).to be_empty
+        end
+      end
+
+      context "when calculator returns a non-zero value" do
+        let(:adjustment_amount) { 10 }
+
+        it "creates adjustment with item as adjustable" do
+          action.perform(payload)
+          expect(action.adjustments.count).to eq(1)
+          expect(line_item.adjustments).to eq(action.adjustments)
         end
 
-        context "#perform" do
-          # Regression test for https://github.com/spree/spree/issues/3966
-          context "when calculator computes 0" do
-            let(:adjustment_amount) { 0 }
+        it "creates adjustment with self as source" do
+          action.perform(payload)
+          expect(line_item.adjustments.first.source).to eq action
+        end
 
-            it "does not create an adjustment when calculator returns 0" do
-              action.perform(payload)
-              expect(action.adjustments).to be_empty
-            end
-          end
+        it "does not perform twice on the same item" do
+          2.times { action.perform(payload) }
+          expect(action.adjustments.count).to eq(1)
+        end
 
-          context "when calculator returns a non-zero value" do
-            let(:adjustment_amount) { 10 }
+        context "with products rules" do
+          let(:rule) { double Spree::Promotion::Rules::Product }
 
-            it "creates adjustment with item as adjustable" do
-              action.perform(payload)
-              expect(action.adjustments.count).to eq(1)
-              expect(line_item.adjustments).to eq(action.adjustments)
-            end
+          before { allow(promotion).to receive(:eligible_rules) { [rule] } }
 
-            it "creates adjustment with self as source" do
-              action.perform(payload)
-              expect(line_item.adjustments.first.source).to eq action
-            end
+          context "when the rule is actionable" do
+            before { allow(rule).to receive(:actionable?).and_return(true) }
 
-            it "does not perform twice on the same item" do
-              2.times { action.perform(payload) }
-              expect(action.adjustments.count).to eq(1)
-            end
-
-            context "with products rules" do
-              let(:rule) { double Spree::Promotion::Rules::Product }
-
-              before { allow(promotion).to receive(:eligible_rules) { [rule] } }
-
-              context "when the rule is actionable" do
-                before { allow(rule).to receive(:actionable?).and_return(true) }
-
-                it "creates an adjustment" do
-                  expect {
-                    expect {
-                      action.perform(payload)
-                    }.to change { action.adjustments.count }.by(1)
-                  }.to change { line_item.adjustments.count }.by(1)
-
-                  expect(action.adjustments.last).to eq line_item.adjustments.last
-                end
-              end
-
-              context "when the rule is not actionable" do
-                before { allow(rule).to receive(:actionable?).and_return(false) }
-
-                it "does not create an adjustment" do
-                  expect {
-                    expect {
-                      action.perform(payload)
-                    }.to_not change { action.adjustments.count }
-                  }.to_not change { line_item.adjustments.count }
-                end
-              end
-            end
-
-            context "when a promotion code is used" do
-              let!(:promotion_code) { create(:promotion_code, promotion: promotion) }
-              let(:payload) { { order: order, promotion: promotion, promotion_code: promotion_code } }
-
-              it "should connect the adjustment to the promotion_code" do
+            it "creates an adjustment" do
+              expect {
                 expect {
                   action.perform(payload)
-                }.to change { line_item.adjustments.count }.by(1)
-                expect(line_item.adjustments.last.promotion_code).to eq promotion_code
-              end
-            end
-          end
-        end
+                }.to change { action.adjustments.count }.by(1)
+              }.to change { line_item.adjustments.count }.by(1)
 
-        context "#compute_amount" do
-          before { promotion.promotion_actions = [action] }
-
-          context "when the adjustable is actionable" do
-            it "calls compute on the calculator" do
-              expect(action.calculator).to receive(:compute).with(line_item).and_call_original
-              action.compute_amount(line_item)
-            end
-
-            context "calculator returns amount greater than item total" do
-              before do
-                action.calculator.preferred_amount = 300
-                allow(line_item).to receive_messages(amount: 100)
-              end
-
-              it "does not exceed it" do
-                expect(action.compute_amount(line_item)).to eql(-100)
-              end
+              expect(action.adjustments.last).to eq line_item.adjustments.last
             end
           end
 
-          context "when the adjustable is not actionable" do
-            before { allow(promotion).to receive(:line_item_actionable?) { false } }
+          context "when the rule is not actionable" do
+            before { allow(rule).to receive(:actionable?).and_return(false) }
 
-            it 'returns 0' do
-              expect(action.compute_amount(line_item)).to eql(0)
-            end
-          end
-        end
-
-        describe '#remove_from' do
-          # this adjustment should not get removed
-          let!(:other_adjustment) { create(:adjustment, adjustable: line_item, order: order, source: nil) }
-
-          before do
-            action.perform(payload)
-            @action_adjustment = line_item.adjustments.where(source: action).first!
-          end
-
-          it 'removes the action adjustment' do
-            expect(line_item.adjustments).to match_array([other_adjustment, @action_adjustment])
-
-            action.remove_from(order)
-
-            expect(line_item.adjustments).to eq([other_adjustment])
-          end
-        end
-
-        context "#paranoia_destroy" do
-          let!(:action) { promotion.actions.first }
-          let(:other_action) { other_promotion.actions.first }
-          let(:promotion) { create(:promotion, :with_line_item_adjustment) }
-          let(:other_promotion) { create(:promotion, :with_line_item_adjustment) }
-
-          context 'with incomplete orders' do
-            let(:order) { create(:order) }
-
-            it 'destroys adjustments' do
-              order.adjustments.create!(label: 'Check', amount: 0, order: order, source: action)
-
-              expect {
-                action.paranoia_destroy
-              }.to change { Adjustment.count }.by(-1)
-            end
-          end
-
-          context 'with complete orders' do
-            let(:order) { create(:completed_order_with_totals) }
-
-            it "does not change adjustments for completed orders" do
-              order = create :order, completed_at: Time.current
-              adjustment = action.adjustments.create!(label: "Check", amount: 0, order: order, adjustable: order)
-
+            it "does not create an adjustment" do
               expect {
                 expect {
-                  action.paranoia_destroy
-                }.not_to change { adjustment.reload.source_id }
-              }.not_to change { Spree::Adjustment.count }
-
-              expect(adjustment.source).to eq(nil)
-              expect(Spree::PromotionAction.with_deleted.find(adjustment.source_id)).to be_present
-            end
-
-            it "doesnt mess with unrelated adjustments" do
-              order.adjustments.create!(label: "Check", amount: 0, order: order, source: action)
-
-              expect {
-                action.paranoia_destroy
-              }.not_to change { other_action.adjustments.count }
+                  action.perform(payload)
+                }.to_not change { action.adjustments.count }
+              }.to_not change { line_item.adjustments.count }
             end
           end
+        end
+
+        context "when a promotion code is used" do
+          let!(:promotion_code) { create(:promotion_code, promotion: promotion) }
+          let(:payload) { { order: order, promotion: promotion, promotion_code: promotion_code } }
+
+          it "should connect the adjustment to the promotion_code" do
+            expect {
+              action.perform(payload)
+            }.to change { line_item.adjustments.count }.by(1)
+            expect(line_item.adjustments.last.promotion_code).to eq promotion_code
+          end
+        end
+      end
+    end
+
+    context "#compute_amount" do
+      before { promotion.promotion_actions = [action] }
+
+      context "when the adjustable is actionable" do
+        it "calls compute on the calculator" do
+          expect(action.calculator).to receive(:compute).with(line_item).and_call_original
+          action.compute_amount(line_item)
+        end
+
+        context "calculator returns amount greater than item total" do
+          before do
+            action.calculator.preferred_amount = 300
+            allow(line_item).to receive_messages(amount: 100)
+          end
+
+          it "does not exceed it" do
+            expect(action.compute_amount(line_item)).to eql(-100)
+          end
+        end
+      end
+
+      context "when the adjustable is not actionable" do
+        before { allow(promotion).to receive(:line_item_actionable?) { false } }
+
+        it 'returns 0' do
+          expect(action.compute_amount(line_item)).to eql(0)
+        end
+      end
+    end
+
+    describe '#remove_from' do
+      # this adjustment should not get removed
+      let!(:other_adjustment) { create(:adjustment, adjustable: line_item, order: order, source: nil) }
+
+      before do
+        action.perform(payload)
+        @action_adjustment = line_item.adjustments.where(source: action).first!
+      end
+
+      it 'removes the action adjustment' do
+        expect(line_item.adjustments).to match_array([other_adjustment, @action_adjustment])
+
+        action.remove_from(order)
+
+        expect(line_item.adjustments).to eq([other_adjustment])
+      end
+    end
+
+    context "#paranoia_destroy" do
+      let!(:action) { promotion.actions.first }
+      let(:other_action) { other_promotion.actions.first }
+      let(:promotion) { create(:promotion, :with_line_item_adjustment) }
+      let(:other_promotion) { create(:promotion, :with_line_item_adjustment) }
+
+      context 'with incomplete orders' do
+        let(:order) { create(:order) }
+
+        it 'destroys adjustments' do
+          order.adjustments.create!(label: 'Check', amount: 0, order: order, source: action)
+
+          expect {
+            action.paranoia_destroy
+          }.to change { Adjustment.count }.by(-1)
+        end
+      end
+
+      context 'with complete orders' do
+        let(:order) { create(:completed_order_with_totals) }
+
+        it "does not change adjustments for completed orders" do
+          order = create :order, completed_at: Time.current
+          adjustment = action.adjustments.create!(label: "Check", amount: 0, order: order, adjustable: order)
+
+          expect {
+            expect {
+              action.paranoia_destroy
+            }.not_to change { adjustment.reload.source_id }
+          }.not_to change { Spree::Adjustment.count }
+
+          expect(adjustment.source).to eq(nil)
+          expect(Spree::PromotionAction.with_deleted.find(adjustment.source_id)).to be_present
+        end
+
+        it "doesnt mess with unrelated adjustments" do
+          order.adjustments.create!(label: "Check", amount: 0, order: order, source: action)
+
+          expect {
+            action.paranoia_destroy
+          }.not_to change { other_action.adjustments.count }
         end
       end
     end


### PR DESCRIPTION
I was running into the issue fairly often that running a spec file in isolation (like `rspec some/specific_spec.rb`) wouldn't work.

This PR introduces `rake spec:isolated` within core, which runs all the specs one at a time in their own rspec process, printing any files with failures. I don't think we should run this on CI just because it's a bit slow. Running it occasionally or when spec setup changes are being made should be sufficient.

This fixes a number of issues which should allow all spec files in core to be run on their own.