### PR TITLE
Fixes for MySQL

### DIFF
--- a/backend/spec/features/admin/users_spec.rb
+++ b/backend/spec/features/admin/users_spec.rb
@@ -99,6 +99,10 @@ describe 'Users', type: :feature do
     end
 
     context "member since" do
+      before do
+        user_a.update_column(:created_at, 2.weeks.ago)
+      end
+
       it_behaves_like "a sortable attribute" do
         let(:text_match_1) { user_a.email }
         let(:text_match_2) { user_b.email }
@@ -107,7 +111,6 @@ describe 'Users', type: :feature do
       end
 
       it 'displays the correct results for a user search by creation date' do
-        user_a.update_column(:created_at, 2.weeks.ago)
         fill_in 'q_created_at_lt', with: 1.week.ago
         click_button 'Search'
         within_table('listing_users') do

--- a/core/db/migrate/20160101010000_solidus_one_four.rb
+++ b/core/db/migrate/20160101010000_solidus_one_four.rb
@@ -817,7 +817,10 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
       t.index ["deleted_at"], name: "index_spree_stock_items_on_deleted_at"
       t.index ["stock_location_id", "variant_id"], name: "stock_item_by_loc_and_var_id"
       t.index ["stock_location_id"], name: "index_spree_stock_items_on_stock_location_id"
-      t.index ["variant_id", "stock_location_id"], name: "index_spree_stock_items_on_variant_id_and_stock_location_id", unique: true, where: "deleted_at is null"
+
+      if connection.supports_partial_index?
+        t.index ["variant_id", "stock_location_id"], name: "index_spree_stock_items_on_variant_id_and_stock_location_id", unique: true, where: "deleted_at is null"
+      end
     end
 
     create_table "spree_stock_locations", force: :cascade do |t|

--- a/core/spec/models/spree/classification_spec.rb
+++ b/core/spec/models/spree/classification_spec.rb
@@ -94,6 +94,7 @@ module Spree
       taxon = taxon_with_5_products
       classification = taxon.classifications.first
       product = classification.product
+      product.update_columns(updated_at: 1.day.ago)
       expect {
         classification.touch
       }.to change { product.reload.updated_at }
@@ -102,6 +103,7 @@ module Spree
     it "touches the taxon" do
       taxon = taxon_with_5_products
       classification = taxon.classifications.first
+      taxon.update_columns(updated_at: 1.day.ago)
       expect {
         classification.touch
       }.to change { taxon.reload.updated_at }


### PR DESCRIPTION
Fixes a few issues with MySQL.

Notably, the roll-up migration added a database partial index which only worked properly under MySQL. This PR changes the migration to only add the index on databases supporting partial indexes.