### PR TITLE
Make the install generator idempotent

### DIFF
--- a/core/lib/generators/spree/install/install_generator.rb
+++ b/core/lib/generators/spree/install/install_generator.rb
@@ -4,6 +4,8 @@ require 'bundler/cli'
 
 module Spree
   class InstallGenerator < Rails::Generators::Base
+    CORE_MOUNT_ROUTE = "mount Spree::Core::Engine"
+
     class_option :migrate, type: :boolean, default: true, banner: 'Run Solidus migrations'
     class_option :seed, type: :boolean, default: true, banner: 'load seed data (migrations must be run)'
     class_option :sample, type: :boolean, default: true, banner: 'load sample data (migrations must be run)'
@@ -149,23 +151,26 @@ Spree::Auth::Engine.load_seed if defined?(Spree::Auth)
     end
 
     def install_routes
-      insert_into_file File.join('config', 'routes.rb'), after: "Rails.application.routes.draw do\n" do
-        <<-ROUTES
+      routes_file_path = File.join('config', 'routes.rb')
+      unless File.read(routes_file_path).include? CORE_MOUNT_ROUTE
+        insert_into_file routes_file_path, after: "Rails.application.routes.draw do\n" do
+          <<-ROUTES
   # This line mounts Solidus's routes at the root of your application.
   # This means, any requests to URLs such as /products, will go to Spree::ProductsController.
   # If you would like to change where this engine is mounted, simply change the :at option to something different.
   #
   # We ask that you don't use the :as option here, as Solidus relies on it being the default of "spree"
-  mount Spree::Core::Engine, at: '/'
+  #{CORE_MOUNT_ROUTE}, at: '/'
 
-        ROUTES
+ROUTES
+        end
       end
 
       unless options[:quiet]
         puts "*" * 50
         puts "We added the following line to your application's config/routes.rb file:"
         puts " "
-        puts "    mount Spree::Core::Engine, at: '/'"
+        puts "    #{CORE_MOUNT_ROUTE}, at: '/'"
       end
     end
 


### PR DESCRIPTION
Currently if you run the install generator a second time the

    mount Spree::Core::Engine

route gets injected a second time.

Thor's insert_into_file should be an reversible operation but
I guess because we inject multiple lines into the routes file
it doesn't work as expected.