### PR TITLE
Improve product -> master attributes delegation

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -60,14 +60,28 @@ module Spree
     end
 
     MASTER_ATTRIBUTES = [
-      :rebuild_vat_prices, :sku, :price, :currency, :weight, :height, :width, :depth,
-      :cost_currency, :price_in, :price_for, :amount_in, :cost_price
+      :rebuild_vat_prices,
+      :sku,
+      :price,
+      :currency,
+      :weight,
+      :height,
+      :width,
+      :depth,
+      :cost_currency,
+      :price_in,
+      :price_for,
+      :amount_in,
+      :cost_price,
     ]
     MASTER_ATTRIBUTES.each do |attr|
       delegate :"#{attr}", :"#{attr}=", to: :find_or_build_master
     end
 
-    delegate :display_amount, :display_price, :has_default_price?, to: :find_or_build_master
+    delegate :display_amount,
+             :display_price,
+             :has_default_price?,
+             to: :find_or_build_master
 
     delegate :images, to: :master, prefix: true
     alias_method :images, :master_images

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -77,13 +77,13 @@ module Spree
              :display_amount,
              :display_price,
              :has_default_price?,
+             :images,
              :price_for,
              :price_in,
              :rebuild_vat_prices=,
              to: :find_or_build_master
 
-    delegate :images, to: :master, prefix: true
-    alias_method :images, :master_images
+    alias_method :master_images, :images
 
     has_many :variant_images, -> { order(:position) }, source: :images, through: :variants_including_master
 

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -60,14 +60,14 @@ module Spree
     end
 
     MASTER_ATTRIBUTES = [
-      :sku,
-      :price,
-      :weight,
-      :height,
-      :width,
-      :depth,
       :cost_currency,
       :cost_price,
+      :depth,
+      :height,
+      :price,
+      :sku,
+      :weight,
+      :width,
     ]
     MASTER_ATTRIBUTES.each do |attr|
       delegate :"#{attr}", :"#{attr}=", to: :find_or_build_master

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -63,7 +63,6 @@ module Spree
       :rebuild_vat_prices,
       :sku,
       :price,
-      :currency,
       :weight,
       :height,
       :width,

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -60,7 +60,6 @@ module Spree
     end
 
     MASTER_ATTRIBUTES = [
-      :rebuild_vat_prices,
       :sku,
       :price,
       :weight,
@@ -80,6 +79,7 @@ module Spree
     delegate :display_amount,
              :display_price,
              :has_default_price?,
+             :rebuild_vat_prices=,
              to: :find_or_build_master
 
     delegate :images, to: :master, prefix: true

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -67,18 +67,18 @@ module Spree
       :width,
       :depth,
       :cost_currency,
-      :price_in,
-      :price_for,
-      :amount_in,
       :cost_price,
     ]
     MASTER_ATTRIBUTES.each do |attr|
       delegate :"#{attr}", :"#{attr}=", to: :find_or_build_master
     end
 
-    delegate :display_amount,
+    delegate :amount_in,
+             :display_amount,
              :display_price,
              :has_default_price?,
+             :price_for,
+             :price_in,
              :rebuild_vat_prices=,
              to: :find_or_build_master
 


### PR DESCRIPTION
With #2427 we found out that we are delegating some methods to master variant incorrectly. Some of the attributes defined in `MASTER_ATTRIBUTES` only have their setter or getter corresponding method on the variant side. 

I made this little script to verify which one would trigger a `NoMethodError`:

```ruby
product = Spree::Product.last

Spree::Product::MASTER_ATTRIBUTES.each do |attribute|
  begin  
    product.send(attribute) 
  rescue Exception => e  
    puts "#{attribute} has no getter" if e.is_a? NoMethodError 
  end
  
  begin
    product.send("#{attribute}=", 'test') 
  rescue Exception => e  
    puts "#{attribute} has no setter" if e.is_a? NoMethodError 
  end
end
```

Running this in console produces this output:


```text
currency has no getter
currency has no setter
rebuild_vat_prices has no getter
price_in has no setter
price_for has no setter
amount_in has no setter
```

This leads me in changing how we are defining those delegations.
