### PR TITLE
Fix rake console

### DIFF
--- a/core/lib/spree/testing_support/dummy_app/rake_tasks.rb
+++ b/core/lib/spree/testing_support/dummy_app/rake_tasks.rb
@@ -54,6 +54,7 @@ task console: :dummy_environment do
   rescue LoadError
   end
 
+  require 'rails/commands'
   require 'rails/commands/console/console_command'
   Rails::Console.new(Rails.application, sandbox: true, environment: "test").start
 end


### PR DESCRIPTION
This allows `rake console` to work again. Previously it failed due to a missing require.