### PR TITLE
adding meta_title to api json product response

### DIFF
--- a/api/app/helpers/spree/api/api_helpers.rb
+++ b/api/app/helpers/spree/api/api_helpers.rb
@@ -51,7 +51,7 @@ module Spree
       @@product_attributes = [
         :id, :name, :description, :price, :display_price, :available_on,
         :slug, :meta_description, :meta_keywords, :shipping_category_id,
-        :taxon_ids, :total_on_hand
+        :taxon_ids, :total_on_hand, :meta_title
       ]
 
       @@product_property_attributes = [

--- a/api/spec/requests/spree/api/unauthenticated_products_controller_spec.rb
+++ b/api/spec/requests/spree/api/unauthenticated_products_controller_spec.rb
@@ -5,7 +5,7 @@ module Spree
   describe Spree::Api::ProductsController, type: :request do
 
     let!(:product) { create(:product) }
-    let(:attributes) { [:id, :name, :description, :price, :available_on, :slug, :meta_description, :meta_keywords, :taxon_ids] }
+    let(:attributes) { [:id, :name, :description, :price, :available_on, :slug, :meta_description, :meta_keywords, :taxon_ids, :meta_title] }
 
     context "without authentication" do
       before { Spree::Api::Config[:requires_authentication] = false }


### PR DESCRIPTION
the api response for a product gives the `meta_description` and `meta_keywords` but not the `meta_title`. I don't see why this attribute should not be in the api response.