### PR TITLE
Tweaks to override-solidus-assets.md

### DIFF
--- a/guides/assets/override-solidus-assets.md
+++ b/guides/assets/override-solidus-assets.md
@@ -93,6 +93,9 @@ For example, to replace the `solidus_frontend`'s
 replacement to `your_app/app/assets/stylesheets/spree/frontend/_variables.scss`
 with your own definitions inside.
 
+This is more brittle than overriding single definitions, as described above,
+and isn't guaranteed to work in future Solidus versions.
+
 Note that this method *completely* replaces any functionality provided by the
 stylesheet or JavaScript file.
 

--- a/guides/assets/override-solidus-assets.md
+++ b/guides/assets/override-solidus-assets.md
@@ -68,7 +68,7 @@ For example, just create a new JavaScript file,
 include the new method definition:
 
 ```javascript
-var Spree.showVariantImages = function(variant_id) {
+Spree.showVariantImages = function(variant_id) {
  alert('hello world');
 }
 ```


### PR DESCRIPTION
Fixes a JS typo and warns about view-like overriding of files.

At some point in the future it's possible we will use an asset bundler other than sprockets (like webpack or rollup). If we do so we won't be able to support sprocket's view-like file lookup and overriding (and it is an unusual thing to support for JS in the first place).