### PR TITLE
creating an order should activate promotions

### DIFF
--- a/api/app/controllers/spree/api/orders_controller.rb
+++ b/api/app/controllers/spree/api/orders_controller.rb
@@ -33,7 +33,7 @@ module Spree
           respond_with(@order, default_template: :show, status: 201)
         else
           @order = Spree::Order.create!(user: current_api_user, store: current_store)
-          if OrderUpdateAttributes.new(@order, order_params).apply
+          if @order.contents.update_cart order_params
             respond_with(@order, default_template: :show, status: 201)
           else
             invalid_resource!(@order)

--- a/api/spec/requests/spree/api/orders_controller_spec.rb
+++ b/api/spec/requests/spree/api/orders_controller_spec.rb
@@ -76,6 +76,20 @@ module Spree
             end
           end
         end
+
+        context "with existing promotion" do
+          let(:discount) { 2 }
+          before do
+            create(:promotion, :with_line_item_adjustment, apply_automatically: true, adjustment_rate: discount )
+          end
+
+          it "activates the promotion" do
+            post spree.api_orders_path, params: { order: { line_items: { "0" => { variant_id: variant.to_param, quantity: 1 } } } }
+            order = Order.last
+            line_item = order.line_items.first
+            expect(order.total).to eq(line_item.price - discount)
+          end
+        end
       end
 
       context "when the current user can administrate the order" do


### PR DESCRIPTION
- I have a promotion that can apply on a product
- via API, I create an order, adding the product with promotion

Expected: I should have the promotion applied to the order.

Current: no promotion applied