### PR TITLE
Give line-item-select-variant a max-width

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/sections/_orders.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/_orders.scss
@@ -70,4 +70,8 @@ table.line-items {
     border-radius: 4px;
     border: 1px solid theme-color("danger");
   }
+
+  .line-item-select-variant .select2-chosen {
+    max-width: 400px;
+  }
 }


### PR DESCRIPTION
Fixes #2483

This fixes a CSS issue where this select2 box would become huge and hide the rest of the table behind the sidebar.
  