### PR TITLE
Replace new product inline form with normal form

### DIFF
--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -14,7 +14,7 @@
       <div data-hook="admin_product_form_slug">
         <%= f.field_container :slug do %>
           <%= f.label :slug, class: ('required' if !f.object.new_record?) %>
-          <%= f.text_field :slug, class: 'fullwidth title', required: !f.object.new_record? %>
+          <%= f.text_field :slug, class: 'fullwidth title', required: !f.object.new_record?, disabled: f.object.new_record? %>
           <%= f.error_message_on :slug %>
         <% end %>
       </div>

--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -13,8 +13,8 @@
 
       <div data-hook="admin_product_form_slug">
         <%= f.field_container :slug do %>
-          <%= f.label :slug, class: 'required' %>
-          <%= f.text_field :slug, class: 'fullwidth title', required: true %>
+          <%= f.label :slug, class: ('required' if !f.object.new_record?) %>
+          <%= f.text_field :slug, class: 'fullwidth title', required: !f.object.new_record? %>
           <%= f.error_message_on :slug %>
         <% end %>
       </div>

--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -122,9 +122,9 @@
 
       <div data-hook="admin_product_form_shipping_categories">
         <%= f.field_container :shipping_categories do %>
-          <%= f.label :shipping_category_id, Spree::ShippingCategory.model_name.human %>
+          <%= f.label :shipping_category_id, Spree::ShippingCategory.model_name.human, class: 'required' %>
           <%= f.field_hint :shipping_category %>
-          <%= f.collection_select(:shipping_category_id, @shipping_categories, :id, :name, { include_blank: t('spree.match_choices.none') }, { class: 'custom-select' }) %>
+          <%= f.collection_select(:shipping_category_id, @shipping_categories, :id, :name, { include_blank: t('spree.match_choices.none') }, { class: 'custom-select' , required: true}) %>
           <%= f.error_message_on :shipping_category %>
         <% end %>
       </div>

--- a/backend/app/views/spree/admin/products/index.html.erb
+++ b/backend/app/views/spree/admin/products/index.html.erb
@@ -3,8 +3,8 @@
 <% admin_breadcrumb(plural_resource_name(Spree::Product)) %>
 
 <% content_for :page_actions do %>
-  <li id="new_product_link">
-    <%= button_link_to t('spree.new_product'), new_object_url, { remote: true, id: 'admin_new_product' } %>
+  <li>
+    <%= button_link_to t('spree.new_product'), new_object_url %>
   </li>
 <% end if can?(:create, Spree::Product) %>
 

--- a/backend/app/views/spree/admin/products/new.html.erb
+++ b/backend/app/views/spree/admin/products/new.html.erb
@@ -1,3 +1,6 @@
+<% admin_breadcrumb link_to(plural_resource_name(Spree::Product), spree.admin_products_path) %>
+<% admin_breadcrumb t('spree.new_product') %>
+
 <%= render partial: 'spree/shared/error_messages', locals: { target: @product } %>
 
 <%= form_for [:admin, @product], method: :post, url: admin_products_path, html: { multipart: true } do |f| %>

--- a/backend/app/views/spree/admin/products/new.html.erb
+++ b/backend/app/views/spree/admin/products/new.html.erb
@@ -1,68 +1,11 @@
 <%= render partial: 'spree/shared/error_messages', locals: { target: @product } %>
 
 <%= form_for [:admin, @product], method: :post, url: admin_products_path, html: { multipart: true } do |f| %>
-
   <fieldset data-hook="new_product">
-
     <legend align="center"><%= t('spree.new_product') %></legend>
 
-    <%= f.field_container :name do %>
-      <%= f.label :name, class: 'required' %><br />
-      <%= f.text_field :name, class: 'fullwidth title', required: true %>
-      <%= f.error_message_on :name %>
-    <% end %>
-
-    <div data-hook="new_product_attrs" class="row">
-      <% unless @product.has_variants? %>
-        <div data-hook="new_product_sku" class="col-3">
-          <%= f.field_container :sku do %>
-            <%= f.label :sku, t('spree.sku') %><br />
-            <%= f.text_field :sku, size: 16, class: 'fullwidth' %>
-            <%= f.error_message_on :sku %>
-          <% end %>
-        </div>
-      <% end %>
-
-      <div data-hook="new_product_price" class="col-3">
-        <%= f.field_container :price do %>
-          <%= f.label :price, class: 'required' %><br />
-          <%= f.text_field :price, value: number_to_currency(@product.price, unit: ''), class: 'fullwidth', required: true %>
-          <%= f.error_message_on :price %>
-        <% end %>
-      </div>
-
-      <div data-hook="new_product_available_on" class="col-3">
-        <%= f.field_container :available_on do %>
-          <%= f.label :available_on %>
-          <%= f.error_message_on :available_on %>
-          <%= f.text_field :available_on, class: 'datepicker fullwidth' %>
-        <% end %>
-      </div>
-
-    </div>
-
-    <div class='row'>
-      <div data-hook="new_product_shipping_category" class="col-3">
-        <%= f.field_container :shipping_category do %>
-          <%= f.label :shipping_category_id, Spree::ShippingCategory.
-                model_name.human, class: 'required' %>
-          <%= f.field_hint :shipping_category %><br />
-          <%= f.collection_select(:shipping_category_id, @shipping_categories, :id, :name, { include_blank: t('spree.match_choices.none') }, { class: 'custom-select fullwidth' }) %>
-          <%= f.error_message_on :shipping_category_id %>
-        <% end %>
-      </div>
-
-      <div data-hook="new_product_tax_category" class="col-3">
-        <%= f.field_container :tax_category do %>
-          <%= f.label :tax_category_id, Spree::TaxCategory.model_name.human %>
-          <%= f.field_hint :tax_category %>
-          <%= f.collection_select(:tax_category_id, @tax_categories, :id, :name, { include_blank: t('spree.match_choices.none') }, { class: 'custom-select fullwidth' }) %>
-          <%= f.error_message_on :tax_category %>
-        <% end %>
-      </div>
-    </div>
+    <%= render partial: 'form', locals: { f: f } %>
 
     <%= render partial: 'spree/admin/shared/new_resource_links' %>
-
   </fieldset>
 <% end %>

--- a/backend/app/views/spree/admin/products/new.js.erb
+++ b/backend/app/views/spree/admin/products/new.js.erb
@@ -1,4 +1,0 @@
-$("#new_product_wrapper").html('<%= escape_javascript(render template: "spree/admin/products/new", formats: [:html], handlers: [:erb]) %>');
-handle_date_picker_fields();
-$("#table-filter").hide();
-$("#admin_new_product").parent().hide();

--- a/backend/spec/features/admin/products/products_spec.rb
+++ b/backend/spec/features/admin/products/products_spec.rb
@@ -156,10 +156,7 @@ describe "Products", type: :feature do
       before(:each) do
         @shipping_category = create(:shipping_category)
         click_nav "Products"
-        click_link "admin_new_product"
-        within('#new_product') do
-          expect(page).to have_content("SKU")
-        end
+        click_on "New Product"
       end
 
       it "should allow an admin to create a new product", js: true do
@@ -174,7 +171,7 @@ describe "Products", type: :feature do
         expect(page).to have_content("successfully updated!")
       end
 
-      it "should show validation errors", js: true do
+      it "should show validation errors", js: false do
         fill_in "product_name", with: "Baseball Cap"
         fill_in "product_sku", with: "B100"
         fill_in "product_price", with: "100"


### PR DESCRIPTION
Previously, creating a new product involved filling out a small inline form which held with only the required attributes of a product.

This requires admin users to understand and learn to use two separate forms with the same purpose (filling in product data). It's also awkward if the user wants to fill in some of the information not on this page as they have to create the product and then fill in the rest of the information they cared about.

This commit removes the inline new product form in favour of linking to a new product page with the same form as the edit page.

**Before:**

![](http://i.hawth.ca/s/FD2pguFX.png)

**After:**

![](http://i.hawth.ca/s/5YrD0xrh.png)


**Todo:**
* [x] ~Specifying slug doesn't work on a new product~ It does work, but is cleared if validations fail due to a bug in friendly_id, which I will file there
* [x] Slug should not be required on new records (it is generated automatically)
* [x] Missing breadcrumbs
* [x] ~Should we add the tabs? Disabled?~ Can't render. We can revisit if this is important
* [x] Fix specs?
  
  
  
  