### PR TITLE
Improve deprecation message for 'deprecated_method_type_override'

### DIFF
--- a/core/app/models/spree/payment_method.rb
+++ b/core/app/models/spree/payment_method.rb
@@ -184,7 +184,7 @@ module Spree
     # If method_type has been overridden, call it and return the value, otherwise return nil
     def deprecated_method_type_override
       if method(:method_type).owner != Spree::PaymentMethod
-        Spree::Deprecation.warn "overriding PaymentMethod#method_type is deprecated and will be removed from Solidus 3.0 (override partial_name instead)", caller
+        Spree::Deprecation.warn "#{method(:method_type).owner} is overriding PaymentMethod#method_type. This is deprecated and will be removed from Solidus 3.0 (override partial_name instead).", caller[1..-1]
         method_type
       end
     end


### PR DESCRIPTION
Previously the stack trace line that the deprecation message would print was
the `#partial_name` method inside PaymentMethod itself, which isn't very
helpful.

Also, print out corresponding class name.


  