### PR TITLE
 Avoid JSON serializing Float::INFINITY 

### DIFF
--- a/api/app/views/spree/api/variants/_big.json.jbuilder
+++ b/api/app/views/spree/api/variants/_big.json.jbuilder
@@ -1,7 +1,6 @@
 json.cache! [I18n.locale, Spree::StockLocation.accessible_by(current_ability), variant] do
   json.(variant, *variant_attributes)
   json.partial!("spree/api/variants/small", variant: variant)
-  json.total_on_hand(variant.total_on_hand)
   json.variant_properties(variant.variant_properties) do |variant_property|
     json.(variant_property, *variant_property_attributes)
   end

--- a/api/app/views/spree/api/variants/_small.json.jbuilder
+++ b/api/app/views/spree/api/variants/_small.json.jbuilder
@@ -5,7 +5,12 @@ json.cache! [I18n.locale, variant] do
   json.track_inventory(variant.should_track_inventory?)
   json.in_stock(variant.in_stock?)
   json.is_backorderable(variant.is_backorderable?)
-  json.total_on_hand(variant.total_on_hand)
+
+  # We can't represent Float::INFINITY in JSON
+  # Under JSON this woulb be NULL
+  # Under oj this would error
+  json.total_on_hand(variant.should_track_inventory? ? variant.total_on_hand : nil)
+
   json.is_destroyed(variant.destroyed?)
   json.option_values(variant.option_values) do |option_value|
     json.(option_value, *option_value_attributes)

--- a/api/spec/requests/spree/api/orders_controller_spec.rb
+++ b/api/spec/requests/spree/api/orders_controller_spec.rb
@@ -289,6 +289,22 @@ module Spree
         end
       end
 
+      context 'when an item does not track inventory' do
+        before do
+          order.line_items.first.variant.update_attributes!(track_inventory: false)
+        end
+
+        it 'contains stock information on variant' do
+          subject
+          variant = json_response['line_items'][0]['variant']
+          expect(variant).to_not be_nil
+          expect(variant['in_stock']).to eq(true)
+          expect(variant['total_on_hand']).to eq(nil)
+          expect(variant['is_backorderable']).to eq(true)
+          expect(variant['is_destroyed']).to eq(false)
+        end
+      end
+
       context 'when shipment adjustments are present' do
         before do
           order.shipments.first.adjustments << adjustment


### PR DESCRIPTION
This works fine under the default JSON library (it ends up being NULL), but it errors under OJ.

Fixes #2486