### PR TITLE
Fix migration to be reversible

### DIFF
--- a/core/db/migrate/20170831201542_remove_default_tax_from_spree_zones.rb
+++ b/core/db/migrate/20170831201542_remove_default_tax_from_spree_zones.rb
@@ -1,5 +1,5 @@
 class RemoveDefaultTaxFromSpreeZones < ActiveRecord::Migration[5.1]
   def change
-    remove_column :spree_zones, :default_tax, default: false
+    remove_column :spree_zones, :default_tax, :boolean, default: false
   end
 end


### PR DESCRIPTION
The migration as written is not reversible unless we specify the data type. This fixes the issue and allows for an easily reversible migration.