### PR TITLE
Restore field for editing promotion per_code_usage_limit in admin

### DIFF
--- a/backend/app/views/spree/admin/promotions/_form.html.erb
+++ b/backend/app/views/spree/admin/promotions/_form.html.erb
@@ -42,6 +42,13 @@
         </span>
       <% end %>
 
+      <% if @promotion.persisted? %>
+        <%= f.field_container :per_code_usage_limit do %>
+          <%= f.label :per_code_usage_limit %><br />
+          <%= f.number_field :per_code_usage_limit, min: 0, class: 'fullwidth' %><br>
+        <% end %>
+      <% end %>
+
       <div id="starts_at_field" class="field">
         <%= f.label :starts_at %>
         <%= f.field_hint :starts_at %>


### PR DESCRIPTION
Fixes #2422

The ability to edit the per_code_usage_limit on existing promotions was lost
during the updates in 374b931.

The fix here is a bit awkward because the placement of the field changes in the new-promotion page vs the edit-promotion page.  The field is in a nice place on the new-promotion page (area where you specify that you are going to want multiple codes) but that area doesn't exist on the edit-promotion page.

I'm very open to other ideas on how to restore this.  But in the worst case this PR at least restores the ability to see and edit the value.

Before:

![screenshot-2018-1-10 asdf - promotions](https://user-images.githubusercontent.com/23050/34794137-f0648496-f60a-11e7-97f6-a9b81059c270.png)

After:

![screenshot-2018-1-10 asdf - promotions 1](https://user-images.githubusercontent.com/23050/34794161-08239054-f60b-11e7-8016-dd8f3205fd44.png)
