### PR TITLE
Allow selecting admin-only shipping methods

### DIFF
--- a/api/app/controllers/spree/api/orders_controller.rb
+++ b/api/app/controllers/spree/api/orders_controller.rb
@@ -10,7 +10,7 @@ module Spree
       skip_before_action :authenticate_user, only: :apply_coupon_code
 
       before_action :find_order, except: [:create, :mine, :current, :index]
-      around_action :lock_order, except: [:create, :mine, :current, :index]
+      around_action :lock_order, except: [:create, :mine, :current, :index, :show]
 
       # Dynamically defines our stores checkout steps to ensure we check authorization on each step.
       Spree::Order.checkout_steps.keys.each do |step|

--- a/api/app/controllers/spree/api/shipments_controller.rb
+++ b/api/app/controllers/spree/api/shipments_controller.rb
@@ -4,7 +4,7 @@ module Spree
       before_action :find_order_on_create, only: :create
       before_action :find_shipment, only: [:update, :ship, :ready, :add, :remove, :estimated_rates]
       before_action :load_transfer_params, only: [:transfer_to_location, :transfer_to_shipment]
-      around_action :lock_order, except: [:mine]
+      around_action :lock_order, except: [:mine, :estimated_rates]
       before_action :update_shipment, only: [:ship, :ready, :add, :remove]
 
       def mine

--- a/api/app/controllers/spree/api/shipments_controller.rb
+++ b/api/app/controllers/spree/api/shipments_controller.rb
@@ -25,7 +25,7 @@ module Spree
       def estimated_rates
         authorize! :update, @shipment
         estimator = Spree::Config.stock.estimator_class.new
-        @shipping_rates = estimator.shipping_rates(@shipment.to_package)
+        @shipping_rates = estimator.shipping_rates(@shipment.to_package, false)
       end
 
       def create

--- a/api/app/controllers/spree/api/shipments_controller.rb
+++ b/api/app/controllers/spree/api/shipments_controller.rb
@@ -2,7 +2,7 @@ module Spree
   module Api
     class ShipmentsController < Spree::Api::BaseController
       before_action :find_order_on_create, only: :create
-      before_action :find_shipment, only: [:update, :ship, :ready, :add, :remove]
+      before_action :find_shipment, only: [:update, :ship, :ready, :add, :remove, :estimated_rates]
       before_action :load_transfer_params, only: [:transfer_to_location, :transfer_to_shipment]
       around_action :lock_order, except: [:mine]
       before_action :update_shipment, only: [:ship, :ready, :add, :remove]
@@ -20,6 +20,12 @@ module Spree
         else
           render "spree/api/errors/unauthorized", status: :unauthorized
         end
+      end
+
+      def estimated_rates
+        authorize! :update, @shipment
+        estimator = Spree::Config.stock.estimator_class.new
+        @shipping_rates = estimator.shipping_rates(@shipment.to_package)
       end
 
       def create

--- a/api/app/views/spree/api/shipments/estimated_rates.json.jbuilder
+++ b/api/app/views/spree/api/shipments/estimated_rates.json.jbuilder
@@ -1,0 +1,3 @@
+json.shipping_rates @shipping_rates do |shipping_rate|
+  json.partial!("spree/api/shipping_rates/shipping_rate", shipping_rate: shipping_rate)
+end

--- a/api/app/views/spree/api/shipments/estimated_rates.json.jbuilder
+++ b/api/app/views/spree/api/shipments/estimated_rates.json.jbuilder
@@ -1,3 +1,4 @@
 json.shipping_rates @shipping_rates do |shipping_rate|
-  json.partial!("spree/api/shipping_rates/shipping_rate", shipping_rate: shipping_rate)
+  json.(shipping_rate, :name, :cost, :shipping_method_id, :shipping_method_code)
+  json.display_cost(shipping_rate.display_cost.to_s)
 end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -82,6 +82,8 @@ Spree::Core::Engine.routes.draw do
       end
 
       member do
+        get :estimated_rates
+
         put :ready
         put :ship
         put :add

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -83,6 +83,7 @@ Spree::Core::Engine.routes.draw do
 
       member do
         get :estimated_rates
+        put :select_shipping_method
 
         put :ready
         put :ship

--- a/api/spec/requests/spree/api/shipments_controller_spec.rb
+++ b/api/spec/requests/spree/api/shipments_controller_spec.rb
@@ -237,6 +237,35 @@ describe Spree::Api::ShipmentsController, type: :request do
     end
   end
 
+  describe "#estimated_rates" do
+    let(:shipping_method) { shipment.shipping_method }
+
+    sign_in_as_admin!
+
+    subject do
+      get spree.estimated_rates_api_shipment_path(shipment)
+    end
+
+    it "returns the correct response" do
+      subject
+
+      expect(response).to be_success
+      expect(json_response).to eq(
+        "shipping_rates"=> [
+          {
+            "id" => nil,
+            "name" => shipping_method.name,
+            "cost" => "100.0",
+            "selected" => true,
+            "shipping_method_id" => shipping_method.id,
+            "shipping_method_code" => shipping_method.code,
+            "display_cost" => "$100.00"
+          }
+        ]
+      )
+    end
+  end
+
   describe "#ship" do
     let(:shipment) { create(:order_ready_to_ship).shipments.first }
 

--- a/backend/app/assets/javascripts/spree/backend/models/shipment.js
+++ b/backend/app/assets/javascripts/spree/backend/models/shipment.js
@@ -6,5 +6,22 @@ Spree.Models.Shipment = Backbone.Model.extend({
   relations: {
     "selected_shipping_rate": Backbone.Model,
     "shipping_rates": Backbone.Collection,
+  },
+
+  estimatedRates: function() {
+    var ratesCollection = Backbone.Collection.extend({
+      parse: function(resp){ return resp.shipping_rates }
+    });
+    var rates = new ratesCollection();
+    rates.fetch({ url: this.url() + "/estimated_rates" })
+    return rates;
+  },
+
+  selectShippingMethodId: function(shippingMethodId, options) {
+    this.sync("update", this, _.extend({
+      url: this.url() + "/select_shipping_method",
+      contentType: 'application/json',
+      data: JSON.stringify({ shipping_method_id: shippingMethodId })
+    }, options));
   }
 })

--- a/backend/app/assets/javascripts/spree/backend/templates/orders/shipping_method.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/orders/shipping_method.hbs
@@ -3,13 +3,15 @@
 </th>
 {{#if editing}}
 <td colspan="4">
+{{#if shipping_rates}}
   <form>
-    <select class="custom-select fullwidth" name="selected_shipping_rate_id">
+    <select class="custom-select fullwidth" name="selected_shipping_method_id">
       {{#each shipping_rates}}
-      <option value="{{ id }}">{{name}} {{display_cost}}</option>
+      <option value="{{ shipping_method_id }}">{{name}} {{display_cost}}</option>
       {{/each}}
     </select>
   </form>
+{{/if}}
 </td>
 {{else}}
 <td colspan="3">
@@ -22,7 +24,9 @@
 
 <td class="actions">
   {{#if editing}}
+    {{#if shipping_rates}}
     <button class="js-save fa fa-check no-text with-tip" data-action="save" title="{{ t "actions.save" }}"></button>
+    {{/if}}
     <button class="js-cancel fa fa-cancel no-text with-tip" data-action="cancel" title="{{ t "actions.cancel" }}"></button>
   {{else}}
     <button class="js-edit fa fa-edit no-text with-tip" data-action="edit" title=""{{ t "actions.edit" }}"></button>

--- a/backend/app/assets/javascripts/spree/backend/views/order/shipping_method.js
+++ b/backend/app/assets/javascripts/spree/backend/views/order/shipping_method.js
@@ -10,32 +10,35 @@ Spree.Views.Order.ShippingMethod = Backbone.View.extend({
   },
 
   initialize: function(options) {
-    this.shippingRateId = this.model.get('selected_shipping_rate').get('id')
+    this.shippingMethodId = this.model.get('selected_shipping_rate').get('shipping_method_id');
+    this.shippingRates = new Backbone.Collection();
     this.render();
   },
 
   onEdit: function(event) {
     this.editing = true;
+    this.shippingRates = this.model.estimatedRates();
+    this.listenTo(this.shippingRates, "sync", this.render);
     this.render();
   },
 
   onSave: function(event) {
     this.editing = false;
-    this.model.save({
-      selected_shipping_rate_id: this.$('select').val()
-    }, {
-      patch: true,
+    this.shippingMethodId = this.$('select').val();
+    this.shippingRates = new Backbone.Collection();
+    this.model.selectShippingMethodId(this.shippingMethodId, {
       success: function() {
-        // FIXME: should update page without reloading
         window.location.reload();
       }
     });
+    this.render();
 
     return false;
   },
 
   onCancel: function(event) {
     this.editing = false;
+    this.shippingRates = new Backbone.Collection();
     this.render();
   },
 
@@ -45,10 +48,10 @@ Spree.Views.Order.ShippingMethod = Backbone.View.extend({
       order: this.model.collection.parent.toJSON(),
       shipment: this.model.toJSON(),
       selected_shipping_rate: this.model.get("selected_shipping_rate").toJSON(),
-      shipping_rates: this.model.get("shipping_rates").toJSON()
+      shipping_rates: this.shippingRates.toJSON()
     });
 
     this.$el.html(html);
-    this.$('select').val(this.shippingRateId);
+    this.$('select').val(this.shippingMethodId);
   }
 })

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -119,6 +119,24 @@ describe "Order Details", type: :feature, js: true do
           expect(page).to have_content("UPS Ground")
         end
 
+        it "can use admin-only shipping methods" do
+          create(:shipping_method, name: "Admin Free Shipping", cost: 0, available_to_users: false)
+
+          visit spree.edit_admin_order_path(order)
+
+          screenshot_and_open_image
+
+          within("tr", text: "Shipping Method") do
+            click_icon :edit
+            select "Admin Free Shipping $0.00"
+            click_icon :check
+          end
+
+          expect(page).not_to have_css('#selected_shipping_rate_id')
+          expect(page).to have_no_content("UPS Ground")
+          expect(page).to have_content("Admin Free Shipping")
+        end
+
         it "will show the variant sku" do
           visit spree.edit_admin_order_path(order)
           sku = order.line_items.first.variant.sku

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -537,7 +537,7 @@ describe "Order Details", type: :feature, js: true do
       within("tr", text: "Shipping Method") do
         click_icon :edit
       end
-      select "UPS Ground $100.00", from: "selected_shipping_rate_id"
+      select "UPS Ground $100.00"
       click_icon :check
 
       expect(page).not_to have_css('#selected_shipping_rate_id')

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -219,6 +219,14 @@ module Spree
       shipping_rates
     end
 
+    def select_shipping_method(shipping_method)
+      estimator = Spree::Config.stock.estimator_class.new
+      rates = estimator.shipping_rates(to_package, false)
+      rate = rates.detect { |r| r.shipping_method_id == shipping_method.id }
+      rate.selected = true
+      self.shipping_rates = [rate]
+    end
+
     def selected_shipping_rate
       shipping_rates.detect(&:selected?)
     end


### PR DESCRIPTION
When calculating shipping rates, the standard behaviour is to calculate the rates using the `Stock::Estimator` and persist the results as `ShippingRate`s. The user then selects their desired rate.

This behaviour falls apart when we want to have some shipping rates available only to admins. We don't want to persist those rates because it would make them available to users.

This PR solves the issue by introducing two new api endpoints:

```
GET /api/shipments/:id/estimated_rates
PUT /api/shipments/:id/select_shipping_method
```

The new `estimated_rates` endpoint will re-run the estimator and return the rates (including admin-only rates) _without_ persisting them.

The `select_shipping_method` endpoint will re-run the estimator and persist _only_ the specified rate, marking it as selected. This allows selecting admin-only rates.

The order shipments page has been updated to use these endpoints instead of relying on persisted shipping rates.

Fixes #1711