### PR TITLE
Fix CI error due to pg 1.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gemspec require: false
 
 platforms :ruby do
   gem 'mysql2', require: false
-  gem 'pg', require: false
+  gem 'pg', '~> 0.21', require: false
   gem 'sqlite3', require: false
   gem 'fast_sqlite', require: false
 end


### PR DESCRIPTION
pg 1.0.0 causes activerecord to error as it [explicitly depends on ~> 0.18](https://github.com/rails/rails/blob/f30f20ccec9edbffc2b80b2d7e839a4fa9ac1eac/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L4)

See also:
https://github.com/rails/rails/pull/31671
https://bitbucket.org/ged/ruby-pg/issues/270/pg-100-x64-mingw32-rails-server-not-start