### PR TITLE
Fix calculator class check bug

### DIFF
--- a/core/app/models/concerns/spree/calculated_adjustments.rb
+++ b/core/app/models/concerns/spree/calculated_adjustments.rb
@@ -32,7 +32,7 @@ module Spree
 
     def calculator_type=(calculator_type)
       klass = calculator_type.constantize if calculator_type
-      self.calculator = klass.new if klass && !calculator.is_a?(klass)
+      self.calculator = klass.new if klass && !calculator.instance_of?(klass)
     end
   end
 end

--- a/core/spec/lib/calculated_adjustments_spec.rb
+++ b/core/spec/lib/calculated_adjustments_spec.rb
@@ -108,4 +108,24 @@ RSpec.describe Spree::CalculatedAdjustments do
       expect(subject.calculator.preferred_first_item).to eq(123)
     end
   end
+
+  describe '#calculator_type=' do
+    subject { Calculable.new }
+
+    let(:calculator_subclass) { Spree::Calculator::Shipping::FlatRate }
+    let(:calculator_superclass) { Spree::ShippingCalculator }
+
+    before(:each) do
+      subject.calculator_type = calculator_subclass.to_s
+    end
+
+    it 'sets calculator type' do
+      expect(subject.calculator_type).to eq(calculator_subclass.to_s)
+    end
+
+    it 'switches from calculator subclass to calculator superclass' do
+      subject.calculator_type = calculator_superclass.to_s
+      expect(subject.calculator_type).to eq(calculator_superclass.to_s)
+    end
+  end
 end


### PR DESCRIPTION
This PR fixes a bug found when attempting to change a shipping method's calculator to a different calculator that is a subclass of its current calculator. The existing implementation of this code prevents switching between calculators that subclass other calculators.

Using `#is_a?` to check the calculator class doesn't play well with calculators that are subclasses of each other. For example, given calculator A and calculator B, where B is a subclass of A: if a shipping method is configured to use calculator B, it becomes impossible to switch the shipping method to calculator A since `A.is_a?(B)` returns true. Whereas `A.instance_of?(B)` returns false.

If the intention is to prevent the same calculator from being set twice, `#instance_of?` is the correct choice since it disregards subclasses and only returns true if both are the exact same class.