### PR TITLE
Improve pricing options flexibility

### DIFF
--- a/api/app/helpers/spree/api/api_helpers.rb
+++ b/api/app/helpers/spree/api/api_helpers.rb
@@ -51,7 +51,7 @@ module Spree
       end
 
       @@product_attributes = [
-        :id, :name, :description, :price, :display_price, :available_on,
+        :id, :name, :description, :available_on,
         :slug, :meta_description, :meta_keywords, :shipping_category_id,
         :taxon_ids, :total_on_hand, :meta_title
       ]
@@ -61,7 +61,7 @@ module Spree
       ]
 
       @@variant_attributes = [
-        :id, :name, :sku, :price, :weight, :height, :width, :depth, :is_master,
+        :id, :name, :sku, :weight, :height, :width, :depth, :is_master,
         :slug, :description, :track_inventory
       ]
 

--- a/api/app/views/spree/api/products/_product.json.jbuilder
+++ b/api/app/views/spree/api/products/_product.json.jbuilder
@@ -3,7 +3,8 @@
 @product_attributes ||= product_attributes
 json.cache! [I18n.locale, @current_user_roles.include?('admin'), current_pricing_options, @product_attributes, @exclude_data, product] do
   json.(product, *@product_attributes)
-  json.display_price(product.display_price.to_s)
+  json.price(product.price_for(current_pricing_options).try(:to_d))
+  json.display_price(product.price_for(current_pricing_options).to_s)
 
   @exclude_data ||= {}
   unless @exclude_data[:variants]

--- a/api/app/views/spree/api/variants/_small.json.jbuilder
+++ b/api/app/views/spree/api/variants/_small.json.jbuilder
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
-json.cache! [I18n.locale, variant] do
+json.cache! [I18n.locale, current_pricing_options, variant] do
   json.(variant, *variant_attributes)
-  json.display_price(variant.display_price.to_s)
+  json.price(variant.price_for(current_pricing_options).try(:to_d))
+  json.display_price(variant.price_for(current_pricing_options).to_s)
   json.options_text(variant.options_text)
   json.track_inventory(variant.should_track_inventory?)
   json.in_stock(variant.in_stock?)

--- a/backend/app/views/spree/admin/variants/_form.html.erb
+++ b/backend/app/views/spree/admin/variants/_form.html.erb
@@ -65,7 +65,7 @@
       <div class="col-3">
         <div class="field" data-hook="price">
           <%= f.label :price %>
-          <%= render "spree/admin/shared/number_with_currency", f: f, amount_attr: :price, currency: @variant.default_price.currency %>
+          <%= render "spree/admin/shared/number_with_currency", f: f, amount_attr: :price, currency: @variant.find_or_build_default_price.currency %>
         </div>
       </div>
 

--- a/core/app/models/spree/variant/pricing_options.rb
+++ b/core/app/models/spree/variant/pricing_options.rb
@@ -49,6 +49,16 @@ module Spree
         new(currency: price.currency, country_iso: price.country_iso)
       end
 
+      # This creates the correct pricing options for a price, so the store owners can easily customize how to
+      # find the pricing based on the view context, having available current_store, current_spree_user, request.host_name, etc.
+      # @return [Spree::Variant::PricingOptions] pricing options for pricing a line item
+      def self.from_context(context)
+        new(
+          currency: context.current_store.try!(:default_currency).presence || Spree::Config[:currency],
+          country_iso: context.current_store.try!(:cart_tax_country_iso).presence
+        )
+      end
+
       # @return [Hash] The hash of exact desired attributes
       attr_reader :desired_attributes
 

--- a/core/lib/spree/core/controller_helpers/pricing.rb
+++ b/core/lib/spree/core/controller_helpers/pricing.rb
@@ -14,10 +14,7 @@ module Spree
         end
 
         def current_pricing_options
-          Spree::Config.pricing_options_class.new(
-            currency: current_store.try!(:default_currency).presence || Spree::Config[:currency],
-            country_iso: current_store.try!(:cart_tax_country_iso).presence
-          )
+          Spree::Config.pricing_options_class.from_context(self)
         end
 
         def current_currency

--- a/core/spec/lib/spree/core/controller_helpers/pricing_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/pricing_spec.rb
@@ -77,5 +77,18 @@ RSpec.describe Spree::Core::ControllerHelpers::Pricing, type: :controller do
         it { is_expected.to be_nil }
       end
     end
+
+    context "from context" do
+      subject { controller.current_pricing_options }
+
+      let(:store) { FactoryBot.create :store, default_currency: 'USD' }
+
+      context "when the whole context is passed" do
+        it "receives the right object " do
+          expect(Spree::Config.pricing_options_class).to receive(:from_context).with(controller)
+          is_expected.to be_nil
+        end
+      end
+    end
   end
 end

--- a/core/spec/models/spree/variant/pricing_options_spec.rb
+++ b/core/spec/models/spree/variant/pricing_options_spec.rb
@@ -70,6 +70,29 @@ RSpec.describe Spree::Variant::PricingOptions do
     end
   end
 
+  context ".from_context" do
+    let(:view_context) { double(ApplicationController, current_store: store) }
+    subject { described_class.from_context(view_context) }
+
+    context "if the store has not defined default_currency" do
+      let(:store) { FactoryBot.create :store, default_currency: nil , cart_tax_country_iso: nil }
+
+      it "fallbacks to Spree::Config.currency" do
+        expect(Spree::Variant::PricingOptions).to receive(:new).with(currency: Spree::Config.currency, country_iso: nil)
+        expect(subject).to be_nil
+      end
+    end
+
+    context 'if the store has default_currency and cart_tax_country_iso' do
+      let(:store) { FactoryBot.create :store, default_currency: 'MXN' }
+
+      it "uses current_store information" do
+        expect(Spree::Variant::PricingOptions).to receive(:new).with(currency: store.default_currency, country_iso: store.cart_tax_country_iso)
+        expect(subject).to be_nil
+      end
+    end
+  end
+
   describe '#desired_attributes' do
     context "when called with no arguments" do
       it "returns the default pricing options" do

--- a/core/spec/models/spree/variant/pricing_options_spec.rb
+++ b/core/spec/models/spree/variant/pricing_options_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Spree::Variant::PricingOptions do
     subject { described_class.from_context(view_context) }
 
     context "if the store has not defined default_currency" do
-      let(:store) { FactoryBot.create :store, default_currency: nil , cart_tax_country_iso: nil }
+      let(:store) { FactoryBot.create :store, default_currency: nil, cart_tax_country_iso: nil }
 
       it "fallbacks to Spree::Config.currency" do
         expect(Spree::Variant::PricingOptions).to receive(:new).with(currency: Spree::Config.currency, country_iso: nil)


### PR DESCRIPTION
The last piece, I think, to make pricing options totally flexible is to allow how it's built from a view context, allowing developers to decide how to find the prices based, example: users role

It also adjusts the API to use `object.price_for(current_pricing_options)`

I can add tests if you think this is a good idea.