### PR TITLE
Remove eager touching from OptionValue

### DIFF
--- a/backend/app/controllers/spree/admin/option_types_controller.rb
+++ b/backend/app/controllers/spree/admin/option_types_controller.rb
@@ -3,6 +3,8 @@ module Spree
     class OptionTypesController < ResourceController
       before_action :setup_new_option_value, only: :edit
 
+      update.after :touch_variants
+
       def update_values_positions
         params[:positions].each do |id, index|
           Spree::OptionValue.where(id: id).update_all(position: index)
@@ -34,6 +36,11 @@ module Spree
         else
           Spree::OptionType.all
         end
+      end
+
+      def touch_variants
+        option_values = @object.option_values
+        ActiveRecord::Base.transaction { option_values.each(&:touch_all_variants) }
       end
     end
   end

--- a/core/app/models/spree/option_value.rb
+++ b/core/app/models/spree/option_value.rb
@@ -9,9 +9,6 @@ module Spree
     validates :name, presence: true, uniqueness: { scope: :option_type_id, allow_blank: true }
     validates :presentation, presence: true
 
-    after_save :touch, if: :saved_changes?
-    after_touch :touch_all_variants
-
     delegate :name, :presentation, to: :option_type, prefix: :option_type
 
     self.whitelisted_ransackable_attributes = ['presentation']

--- a/core/spec/models/spree/option_value_spec.rb
+++ b/core/spec/models/spree/option_value_spec.rb
@@ -1,44 +1,23 @@
 require 'rails_helper'
 
 RSpec.describe Spree::OptionValue, type: :model do
-  include ActiveSupport::Testing::TimeHelpers
+  describe '#touch_all_variants' do
+    subject { option_value.touch_all_variants }
 
-  context "touching" do
-    let!(:variant) do
-      travel_to(1.day.ago) do
-        create(:variant)
-      end
-    end
-    let(:option_value) { variant.option_values.first }
+    let(:option_value) { described_class.new }
+    let(:variants) { build_stubbed_list :variant, 1 }
 
-    it "should touch a variant" do
-      now = Time.current
-      travel_to(now) do
-        option_value.touch
-        expect(variant.reload.updated_at).to be_within(1.second).of(now)
-      end
+    before do
+      # Stub out ActiveRecord methods
+      allow(option_value).to receive(:variants).and_return(variants)
+      allow(variants).to receive(:find_each).and_yield(variants.first)
     end
 
-    context "from the after_save hook" do
-      it "should not touch the variant if there are no changes" do
-        now = Time.current
-        travel_to(now) do
-          option_value.save!
-          expect(variant.reload.updated_at).to be <= 1.day.ago
-        end
-      end
-
-      it "should touch the variant if there are changes" do
-        now = Time.current
-        travel_to(now) do
-          option_value.name += "--1"
-          option_value.save!
-          expect(variant.reload.updated_at).to be_within(1.second).of(now)
-        end
-      end
+    it 'touches all associated variants' do
+      expect(variants).to all receive(:touch)
+      subject
     end
   end
-
   describe "#presentation_with_option_type" do
     let(:option_value) { build(:option_value) }
     subject { option_value.presentation_with_option_type }


### PR DESCRIPTION
**Before:**
Any time an option value is saved with changes (or touched) all
associated variants are also touched.

In the core test suite this is called 803 times creating roughly 2 db
requests per call.

**After**:
Touching variants after an option value is updated now occurs in the
admin controllers when option types or option values are modified there.


**Some stats:** 
**Runtimes**
before -> bundle exec rake spec:core  270.94s user 4.17s system 99% cpu 4:37.70 total
after -> bundle exec rake spec:core  266.91s user 4.36s system 99% cpu 4:33.93 total

**Number of times run/module:**
api:  158
backend: 71
core: 803

![touch_all_variants](https://user-images.githubusercontent.com/6353433/35020483-36378510-fae1-11e7-9196-aacf53e053f3.png)
