### PR TITLE
Remove unneeded Taxon creation in spec

### DIFF
--- a/core/spec/models/spree/taxon_spec.rb
+++ b/core/spec/models/spree/taxon_spec.rb
@@ -3,6 +3,14 @@
 require 'rails_helper'
 
 RSpec.describe Spree::Taxon, type: :model do
+  context "#destroy" do
+    subject(:nested_set_options) { described_class.acts_as_nested_set_options }
+
+    it "should destroy all associated taxons" do
+      expect(nested_set_options[:dependent]).to eq :destroy
+    end
+  end
+
   describe '#to_param' do
     let(:taxon) { FactoryBot.build(:taxon, name: "Ruby on Rails") }
 

--- a/core/spec/models/spree/taxonomy_spec.rb
+++ b/core/spec/models/spree/taxonomy_spec.rb
@@ -2,16 +2,12 @@ require 'rails_helper'
 
 RSpec.describe Spree::Taxonomy, type: :model do
   context "#destroy" do
-    before do
-       @taxonomy = create(:taxonomy)
-       @root_taxon = @taxonomy.root
-       @child_taxon = create(:taxon, taxonomy_id: @taxonomy.id, parent: @root_taxon)
+    subject(:association_options) do
+      described_class.reflect_on_association(:root).options
     end
 
     it "should destroy all associated taxons" do
-      @taxonomy.destroy
-      expect{ Spree::Taxon.find(@root_taxon.id) }.to raise_error(ActiveRecord::RecordNotFound)
-      expect{ Spree::Taxon.find(@child_taxon.id) }.to raise_error(ActiveRecord::RecordNotFound)
+      expect(association_options[:dependent]).to eq :destroy
     end
   end
 end


### PR DESCRIPTION
The specs testing that taxons and nested taxons are testing the
internals of ActiveRecord and Awesome nested set.

In order to speed up this test I have removed the object
creation/persistance in favor of simply testing that the Objects are
correctly configured to destroy their dependents.