### PR TITLE
Use datalist instead of jquery-ui/autocomplete

### DIFF
--- a/backend/app/assets/javascripts/spree/backend.js
+++ b/backend/app/assets/javascripts/spree/backend.js
@@ -4,7 +4,6 @@
 //= require jquery_ujs
 //= require jquery-ui/datepicker
 //= require jquery-ui/sortable
-//= require jquery-ui/autocomplete
 //= require jquery.sticky-kit.min
 //= require solidus_admin/select2
 //= require solidus_admin/underscore

--- a/backend/app/assets/stylesheets/spree/backend.css
+++ b/backend/app/assets/stylesheets/spree/backend.css
@@ -4,7 +4,6 @@
  * the top of the compiled file, but it's generally better to create a new file per style scope.
 
  *= require jquery-ui/datepicker
- *= require jquery-ui/autocomplete
  *= require solidus_admin/select2
  *= require solidus_admin/flatpickr/flatpickr
  *= require prism

--- a/backend/app/views/spree/admin/product_properties/_product_property_fields.html.erb
+++ b/backend/app/views/spree/admin/product_properties/_product_property_fields.html.erb
@@ -6,7 +6,7 @@
     <% end %>
   </td>
   <td class='property_name'>
-    <%= f.text_field :property_name, class: 'autocomplete' %>
+    <%= f.text_field :property_name, list: 'properties' %>
   </td>
   <td class='value'>
     <%= f.text_field :value %>

--- a/backend/app/views/spree/admin/product_properties/index.html.erb
+++ b/backend/app/views/spree/admin/product_properties/index.html.erb
@@ -91,13 +91,6 @@
   <% end %>
 <% end %>
 
-<%= javascript_tag do -%>
-  var properties = <%= raw(@properties.to_json) %>;
-  $('#product_properties, #variant_property_values').on('keydown', 'input.autocomplete', function() {
-    already_auto_completed = $(this).is('ac_input');
-    if (!already_auto_completed) {
-      $(this).autocomplete({source: properties});
-      $(this).focus();
-    }
-  });
-<% end -%>
+<datalist id="properties">
+  <%= safe_join @properties.map { |name| tag(:option, value: name) } %>
+</datalist>


### PR DESCRIPTION
Replaces `jquery-ui/autocomplete`, which is only used in the product properties page, with the html5 `<datalist>` element.

[Browser support for datalist](https://caniuse.com/#feat=datalist) is patchy (notably no safari), but it is entirely fine for this page not to have autocompletion.

We had apparently already decided that the number of properties is few enough that they can be just dumped on the page as json. I'm keeping this assumption and just dumping them on the page as HTML.

**Before**
![](http://i.hawth.ca/s/8z0UVnAq.png)

**After** (display will be browser and OS dependent)
![](http://i.hawth.ca/s/IzFmlZ03.png)

See also #2469