### PR TITLE
Fix view for orders api (Fixes Issue #2512)

### DIFF
--- a/api/app/views/spree/api/orders/_big.json.jbuilder
+++ b/api/app/views/spree/api/orders/_big.json.jbuilder
@@ -27,11 +27,10 @@ json.payments(order.payments) do |payment|
   json.payment_method { json.(payment.payment_method, :id, :name) }
   json.source do
     if payment.source
-      json.(payment.source, *payment_source_attributes)
-
-      if @current_user_roles.include?("admin")
-        json.(payment.source, :gateway_customer_profile_id, :gateway_payment_profile_id)
-      end
+      json.partial!(
+        "spree/api/payments/source_views/#{payment.payment_method.partial_name}",
+        payment_source: payment.source
+      )
     else
       json.nil!
     end

--- a/api/app/views/spree/api/orders/_big.json.jbuilder
+++ b/api/app/views/spree/api/orders/_big.json.jbuilder
@@ -26,10 +26,17 @@ json.payments(order.payments) do |payment|
   json.(payment, *payment_attributes)
   json.payment_method { json.(payment.payment_method, :id, :name) }
   json.source do
-    if payment.source
+    ##
+    # payment.source could be a Spree::Payment. If it is then we need to call
+    # source twice.
+    # @see https://github.com/solidusio/solidus/blob/v2.4/backend/app/views/spree/admin/payments/show.html.erb#L16
+    #
+    payment_source = payment.source.is_a?(Spree::Payment) ? payment.source.source : payment.source
+
+    if payment_source
       json.partial!(
         "spree/api/payments/source_views/#{payment.payment_method.partial_name}",
-        payment_source: payment.source
+        payment_source: payment_source
       )
     else
       json.nil!

--- a/api/app/views/spree/api/payments/source_views/_check.json.jbuilder
+++ b/api/app/views/spree/api/payments/source_views/_check.json.jbuilder
@@ -1,0 +1,1 @@
+json.nil!

--- a/api/app/views/spree/api/payments/source_views/_gateway.json.jbuilder
+++ b/api/app/views/spree/api/payments/source_views/_gateway.json.jbuilder
@@ -1,0 +1,6 @@
+attrs = [:id, :month, :year, :cc_type, :last_digits, :name]
+if @current_user_roles.include?("admin")
+  attrs += [:gateway_customer_profile_id, :gateway_payment_profile_id]
+end
+
+json.(payment_source, *attrs)

--- a/api/app/views/spree/api/payments/source_views/_storecredit.json.jbuilder
+++ b/api/app/views/spree/api/payments/source_views/_storecredit.json.jbuilder
@@ -1,0 +1,3 @@
+json.(payment_source, :id, :memo, :created_at)
+json.created_by payment_source.created_by.email
+json.category payment_source.category, :id, :name

--- a/api/spec/requests/spree/api/orders_controller_spec.rb
+++ b/api/spec/requests/spree/api/orders_controller_spec.rb
@@ -348,6 +348,21 @@ module Spree
           expect(credit_cards[0]['id']).to eq payment.source.id
           expect(credit_cards[0]['address']['id']).to eq credit_card.address_id
         end
+
+        it 'renders the payment source view for gateway' do
+          subject
+          expect(response).to render_template partial: 'spree/api/payments/source_views/_gateway'
+        end
+      end
+
+      context 'when store credit is present' do
+        let!(:payment) { create(:store_credit_payment, order: order, source: store_credit) }
+        let(:store_credit) { create(:store_credit) }
+
+        it 'renders the payment source view for store credit' do
+          subject
+          expect(response).to render_template partial: 'spree/api/payments/source_views/_storecredit'
+        end
       end
     end
 


### PR DESCRIPTION
 Refactor _big.json.jbuilder so that it dynamically loads the payment
source view based on that source's payment method.

Add payment views for each payment method which will be used to render a
payment source as json.

Fixes https://github.com/solidusio/solidus/issues/2512.