### PR TITLE
Add specs and convert Admin::Variant#destroy to discard

### DIFF
--- a/backend/app/controllers/spree/admin/variants_controller.rb
+++ b/backend/app/controllers/spree/admin/variants_controller.rb
@@ -8,22 +8,6 @@ module Spree
       before_action :redirect_on_empty_option_values, only: [:new]
       before_action :load_data, only: [:new, :create, :edit, :update]
 
-      # override the destroy method to set deleted_at value
-      # instead of actually deleting the product.
-      def destroy
-        @variant = Spree::Variant.find(params[:id])
-        if @variant.destroy
-          flash[:success] = t('spree.notice_messages.variant_deleted')
-        else
-          flash[:success] = t('spree.notice_messages.variant_not_deleted')
-        end
-
-        respond_with(@variant) do |format|
-          format.html { redirect_to admin_product_variants_url(params[:product_id]) }
-          format.js { render_js_for_destroy }
-        end
-      end
-
       private
 
       def new_before

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -43,7 +43,7 @@ Spree::Core::Engine.routes.draw do
       member do
         post :clone
       end
-      resources :variants do
+      resources :variants, only: [:index, :edit, :update, :new, :create, :destroy] do
         collection do
           post :update_positions
         end

--- a/backend/spec/controllers/spree/admin/variants_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/variants_controller_spec.rb
@@ -54,6 +54,16 @@ module Spree
           end
         end
       end
+
+      describe "#delete" do
+        let!(:variant) { create(:variant) }
+        let(:product) { variant.product }
+
+        it "can be deleted" do
+          delete :destroy, params: { product_id: product.to_param, id: variant.to_param }
+          expect(variant.reload).to be_discarded
+        end
+      end
     end
   end
 end

--- a/backend/spec/features/admin/products/variant_spec.rb
+++ b/backend/spec/features/admin/products/variant_spec.rb
@@ -68,4 +68,21 @@ describe "Variants", type: :feature do
       end
     end
   end
+
+  context "deleting a variant", js: true do
+    let!(:variant) { create(:variant, product: product) }
+    let!(:option_type) { create(:option_type) }
+    let!(:option_value) { create(:option_value, option_type: option_type) }
+
+    it "can delete a variant" do
+      visit spree.admin_product_variants_path(product)
+      within 'tr', text: 'Size: S' do
+        accept_alert do
+          click_icon :trash
+        end
+      end
+
+      expect(page).to have_no_text('Size: S')
+    end
+  end
 end


### PR DESCRIPTION
This action was originally created to set the `deleted_at` column before the project used paranoia. At a later date, when paranoia was included, this was changed to call destroy, since paranoia causes that to just set `deleted_at`. At this time the override probably could have been removed.

We've now gone almost full circle and are preferring discard over paranoia. We don't need this method and can use the implementation in the `ResourceController`.

We also got here without it having any specs (which is why I missed it in the initial discard conversion), which have been added.