### PR TITLE
Improve HTTP usage in update_positions

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/components/sortable_table.js
+++ b/backend/app/assets/javascripts/spree/backend/components/sortable_table.js
@@ -19,7 +19,7 @@ Spree.ready(function() {
         });
         Spree.ajax({
           type: 'POST',
-          dataType: 'script',
+          dataType: 'json',
           url: url,
           data: positions,
         });

--- a/backend/app/controllers/spree/admin/option_types_controller.rb
+++ b/backend/app/controllers/spree/admin/option_types_controller.rb
@@ -9,7 +9,6 @@ module Spree
         end
 
         respond_to do |format|
-          format.html { redirect_to admin_product_variants_url(params[:product_id]) }
           format.js { head :no_content }
         end
       end

--- a/backend/app/controllers/spree/admin/option_types_controller.rb
+++ b/backend/app/controllers/spree/admin/option_types_controller.rb
@@ -10,7 +10,7 @@ module Spree
 
         respond_to do |format|
           format.html { redirect_to admin_product_variants_url(params[:product_id]) }
-          format.js { render plain: 'Ok' }
+          format.js { head :no_content }
         end
       end
 

--- a/backend/app/controllers/spree/admin/resource_controller.rb
+++ b/backend/app/controllers/spree/admin/resource_controller.rb
@@ -79,7 +79,7 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
     end
 
     respond_to do |format|
-      format.js { render plain: 'Ok' }
+      format.js { head :no_content }
     end
   end
 


### PR DESCRIPTION
This fixes some mildly bad HTTP behaviour that didn't really affect anything, but we might as well do it more properly.

* We were responding with `Content-Type: text/javascript` with a body of `"Ok"`. `"Ok"` is not valid JSON :no_entry_sign:
* `OptionTypesController#update_values_positions` had an unused `format.html` response, which didn't work.
* We were doing ajax with `dataType: 'script'` (ie. get some javascript and eval it), which isn't actually what we wanted.