### PR TITLE
Change instances of "udpate" to "update"

### DIFF
--- a/api/spec/requests/spree/api/orders_controller_spec.rb
+++ b/api/spec/requests/spree/api/orders_controller_spec.rb
@@ -557,7 +557,7 @@ module Spree
       context "order has shipments" do
         before { order.create_proposed_shipments }
 
-        it "clears out all existing shipments on line item udpate" do
+        it "clears out all existing shipments on line item update" do
           put spree.api_order_path(order), params: { order: {
             line_items: {
               0 => { id: line_item.id, quantity: 10 }

--- a/backend/app/views/spree/admin/shipping_categories/index.html.erb
+++ b/backend/app/views/spree/admin/shipping_categories/index.html.erb
@@ -30,7 +30,7 @@
     <tr id="<%= spree_dom_id shipping_category %>" data-hook="category_row">
       <td><%= shipping_category.name %></td>
       <td class="actions">
-        <% if can?(:udpate, shipping_category) %>
+        <% if can?(:update, shipping_category) %>
           <%= link_to_edit shipping_category, no_text: true %>
         <% end %>
 


### PR DESCRIPTION
Fixed an instance of a permissions check on shipping categories checking for "udpate" instead of "update" and fixed the same spelling mistake in an API spec title/description.