### PR TITLE
Use headless chrome with teaspoon

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -32,3 +32,7 @@ When running the application there is a styleguide available at:
 Run the tests
 
     bundle exec rspec
+
+Run the javascript tests (must have chromedriver installed)
+
+    bundle exec teaspoon

--- a/backend/spec/teaspoon_env.rb
+++ b/backend/spec/teaspoon_env.rb
@@ -1,5 +1,26 @@
 ENV['RAILS_ENV'] = 'test'
 
+# Teaspoon doesn't allow you to pass client driver options to the Selenium WebDriver. This monkey patch
+# is a temporary fix until this PR is merged: https://github.com/jejacks0n/teaspoon/pull/519.
+require 'teaspoon/driver/selenium'
+
+Teaspoon::Driver::Selenium.class_eval do
+  def run_specs(runner, url)
+    driver = ::Selenium::WebDriver.for(driver_options[:client_driver], @options.except(:client_driver) || {})
+    driver.navigate.to(url)
+
+    ::Selenium::WebDriver::Wait.new(driver_options).until do
+      done = driver.execute_script("return window.Teaspoon && window.Teaspoon.finished")
+      driver.execute_script("return window.Teaspoon && window.Teaspoon.getMessages() || []").each do |line|
+        runner.process("#{line}\n")
+      end
+      done
+    end
+  ensure
+    driver.quit if driver
+  end
+end
+
 # Similar to setup described in
 # https://github.com/jejacks0n/teaspoon/wiki/Micro-Applications
 
@@ -13,6 +34,12 @@ if defined?(DummyApp)
     config.root = Spree::Backend::Engine.root
     config.asset_paths = ["spec/javascripts", "spec/javascripts/stylesheets"]
     config.fixture_paths = ["spec/javascripts/fixtures"]
+
+    config.driver = :selenium
+    capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
+      chromeOptions: { args: %w(headless disable-gpu window-size=1920,1440) }
+    )
+    config.driver_options = { client_driver: :chrome, desired_capabilities: capabilities }
 
     config.suite do |suite|
       suite.use_framework :mocha, "2.3.3"


### PR DESCRIPTION
This replaces teaspoon's default phantomJS with Selenium's headless chrome webdriver. 

Teaspoon does not yet support submitting driver client options. See https://github.com/jejacks0n/teaspoon/pull/530 and https://github.com/jejacks0n/teaspoon/pull/519. Temporarily monkey patches the 'run_specs' method on teaspoon's selenium driver until relevant PR is merged.