### PR TITLE
Introduce "suppliable" scope to represent any variant which can_supply?(1)

### DIFF
--- a/api/app/controllers/spree/api/variants_controller.rb
+++ b/api/app/controllers/spree/api/variants_controller.rb
@@ -66,8 +66,13 @@ module Spree
         end
 
         in_stock_only = ActiveRecord::Type::Boolean.new.cast(params[:in_stock_only])
+        suppliable_only = ActiveRecord::Type::Boolean.new.cast(params[:suppliable_only])
         variants = variants.accessible_by(current_ability, :read)
-        variants = variants.in_stock if in_stock_only || cannot?(:view_out_of_stock, Spree::Variant)
+        if in_stock_only || cannot?(:view_out_of_stock, Spree::Variant)
+          variants = variants.in_stock
+        elsif suppliable_only
+          variants = variants.suppliable
+        end
         variants
       end
 

--- a/api/spec/requests/spree/api/variants_controller_spec.rb
+++ b/api/spec/requests/spree/api/variants_controller_spec.rb
@@ -114,6 +114,32 @@ module Spree
           end
         end
 
+        context "only suplliable variants" do
+          subject { get spree.api_variants_path, params: { suppliable_only: "true" } }
+
+          context "variant is backorderable" do
+            before do
+              variant.stock_items.update_all(count_on_hand: 0, backorderable: true)
+            end
+
+            it "is not returned in the results" do
+              subject
+              expect(json_response["variants"].count).to eq 1
+            end
+          end
+
+          context "variant is unsuppliable" do
+            before do
+              variant.stock_items.update_all(count_on_hand: 0, backorderable: false)
+            end
+
+            it "is returned in the results" do
+              subject
+              expect(json_response["variants"].count).to eq 0
+            end
+          end
+        end
+
         context "all variants" do
           subject { get spree.api_variants_path, params: { in_stock_only: "false" } }
 

--- a/backend/app/assets/javascripts/spree/backend/orders/edit.js
+++ b/backend/app/assets/javascripts/spree/backend/orders/edit.js
@@ -1,6 +1,6 @@
 Spree.ready(function () {
   'use strict';
 
-  $('[data-hook="add_product_name"]').find('.variant_autocomplete').variantAutocomplete({ in_stock_only: true });
+  $('[data-hook="add_product_name"]').find('.variant_autocomplete').variantAutocomplete({ suppliable_only: true });
   $("[data-hook='admin_orders_index_search']").find(".variant_autocomplete").variantAutocomplete();
 });

--- a/backend/app/assets/javascripts/spree/backend/views/cart/line_item_row.js
+++ b/backend/app/assets/javascripts/spree/backend/views/cart/line_item_row.js
@@ -84,6 +84,6 @@ Spree.Views.Cart.LineItemRow = Backbone.View.extend({
       noCancel: this.model.isNew() && this.model.collection.length == 1
     });
     this.$el.html(html);
-    this.$("[name=variant_id]").variantAutocomplete({ in_stock_only: true });
+    this.$("[name=variant_id]").variantAutocomplete({ suppliable_only: true });
   }
 });

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -754,6 +754,40 @@ RSpec.describe Spree::Variant, type: :model do
     end
   end
 
+  describe ".suppliable" do
+    subject { Spree::Variant.suppliable }
+    let!(:in_stock_variant) { create(:variant) }
+    let!(:out_of_stock_variant) { create(:variant) }
+    let!(:backordered_variant) { create(:variant) }
+    let!(:stock_location) { create(:stock_location) }
+
+    before do
+      in_stock_variant.stock_items.update_all(count_on_hand: 10)
+      backordered_variant.stock_items.update_all(count_on_hand: 0, backorderable: true)
+      out_of_stock_variant.stock_items.update_all(count_on_hand: 0, backorderable: false)
+    end
+
+    it "includes the in stock variant" do
+      expect( subject ).to include(in_stock_variant)
+    end
+
+    it "includes out of stock variant" do
+      expect( subject ).to include(backordered_variant)
+    end
+
+    it "does not include out of stock variant" do
+      expect( subject ).not_to include(out_of_stock_variant)
+    end
+
+    context "inventory levels globally not tracked" do
+      before { Spree::Config.track_inventory_levels = false }
+
+      it "includes all variants" do
+        expect( subject ).to include(in_stock_variant, backordered_variant, out_of_stock_variant)
+      end
+    end
+  end
+
   describe "#display_image" do
     subject { variant.display_image }
 


### PR DESCRIPTION
Previously when using the API to query variants, we could only restrict by variants which were `in_stock`, which meant any variant which either does not track inventory or has a `count_on_hand > 0`.

In the admin we were using the in_stock scope, which made it impossible to add out of stock but backorderable products to the cart, despite them being possible to add on the frontend (See #2522).

This PR creates a new "suppliable" scope, which returns all variants which are in stock, backorderable, or don't have their inventory tracked. It also adds support to the API variants route to query using this scope and changes to admin variant selectors to query this instead.

Fixes #2522