### PR TITLE
Use carmen to translate available_countries helper

### DIFF
--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -119,6 +119,8 @@ module Spree
         [country.code, country.name]
       end.to_h
 
+      country_names.update I18n.t('spree.country_names', default: {}).stringify_keys
+
       countries.collect do |country|
         country.name = country_names.fetch(country.iso, country.name)
         country

--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -1,3 +1,5 @@
+require 'carmen'
+
 module Spree
   module BaseHelper
     def link_to_cart(text = nil)
@@ -113,8 +115,12 @@ module Spree
         countries = Country.all
       end
 
+      country_names = Carmen::Country.all.map do |country|
+        [country.code, country.name]
+      end.to_h
+
       countries.collect do |country|
-        country.name = t(country.iso, scope: 'spree.country_names', default: country.name)
+        country.name = country_names.fetch(country.iso, country.name)
         country
       end.sort_by { |c| c.name.parameterize }
     end

--- a/core/lib/spree/core/controller_helpers/common.rb
+++ b/core/lib/spree/core/controller_helpers/common.rb
@@ -1,3 +1,5 @@
+require 'carmen'
+
 module Spree
   module Core
     module ControllerHelpers
@@ -49,6 +51,7 @@ module Spree
           locale ||= Rails.application.config.i18n.default_locale
           locale ||= I18n.default_locale
           I18n.locale = locale
+          Carmen.i18n_backend.locale = locale
         end
 
         # Returns which layout to render.

--- a/core/spec/helpers/base_helper_spec.rb
+++ b/core/spec/helpers/base_helper_spec.rb
@@ -20,6 +20,10 @@ RSpec.describe Spree::BaseHelper, type: :helper do
       it "return complete list of countries" do
         expect(available_countries.count).to eq(Spree::Country.count)
       end
+
+      it "uses locales for country names" do
+        expect(available_countries).to include(having_attributes(name: "United States of America"))
+      end
     end
 
     context "with a checkout zone defined" do


### PR DESCRIPTION
WIP: will revisit and test properly next week

In https://github.com/solidusio-contrib/solidus_i18n/pull/106 we are looking to remove a feature from `solidus_i18n` which provides translations for each country based on the translations in the [`i18n_data`](https://github.com/grosser/i18n_data) gem.

We don't want to support this odd magic feature as part of i18n, and we'd like to remove the dependency on i18n_data, but at the same time we still want countries to be localized properly.

Ideally this would also be faster than the existing implementation as `available_countries` is a little bit slow.

This PR replaces the the existing behaviour of using `I18n.t("spree.country_names.#{iso_code}")` with using Carmen's data to perform translations.

This is the first time we are actually requiring and using carmen outside of tests and seeds, so we should consider the effect this has on startup time and memory usage.

## TODO

* [x] Continue to support overrides from `I18n` `spree.country_names.*`
* [x] Change `Carmen.i18n_backend` with each request
* [x] Benchmark
* [x] Consider startup time and memory usage