### PR TITLE
Add initial RMA and return authorization documentation

### DIFF
--- a/guides/inventory/inventory-units.md
+++ b/guides/inventory/inventory-units.md
@@ -1,0 +1,38 @@
+# Inventory units
+
+<!-- TODO:
+  This article is a stub.
+-->
+
+A `Spree::InventoryUnit` object is created every time that an item is sold.
+It tracks a sold item as it changes location: from being a sold item waiting in the
+warehouse to be shipped, to being a shipped item (or potentially a returned item).
+
+Note that the `Spree::InventoryUnit` tracks an item as an object associated with
+a `Spree::Order`, a `Spree::Shipment` and a specific `Spree::LineItem`. This
+allows you to more closely track the status of an order and the line items and
+shipments associated with it.
+
+A `Spree::InventoryUnit` object has the following attributes:
+
+- `state`: The current state of the inventory unit. The state value can be
+  `on_hand`, `backordered`, `shipped`, or `returned`.
+- `variant_id`: The ID for the `Spree::Variant` corresponding with the inventory
+  unit that has been sold.
+- `shipment_id`: The ID for the `Spree::Shipment` that the inventory unit is
+  being shipped in.
+- `pending`: Documents whether the current unit is pending or finalized. If
+  `true`, the stock for this unit has not yet been allocated to a shipment. If
+  `false`, the stock has been finalized and is no longer tracked in the
+  `Spree::StockItem`'s `count_on_hand` value.
+- `line_item_id`: The ID for the `Spree::LineItem` that the inventory unit
+  corresponds with.
+- `carton_id`: The ID for the `Spree::Carton` that the inventory unit belongs
+  to.
+
+<!-- TODO:
+  The `pending` attribute may require a clearer description. Alternatively,
+  there could be additional documentation somewhere that we link to here
+  describing what "pending" and "finalized" mean in the larger scheme of
+  things.
+-->

--- a/guides/inventory/return-authorizations.md
+++ b/guides/inventory/return-authorizations.md
@@ -1,0 +1,48 @@
+# Return authorizations (RMAs)
+
+After an order is shipped, administrators can approve the return of any part
+of an order in the `solidus_backend` (from the **Orders -> Order -> RMA** page).
+
+Return authorizations are just the first part of the larger returns system built
+into Solidus. When a store administrator creates a new RMA, they fill out a form
+that defines the scope of the anticipated return.
+
+A `Spree::ReturnAuthorization` object has the following attributes:
+
+- `number`: The number assigned to the return authorization. It begins with an
+  `R` and is followed by ten-digits (`RA338330715`).
+- `state`: The state of the return authorization. The state can be `authorized`
+  or `cancelled`. 
+- `order_id`: The ID of the `Spree::Order` associated with this return
+  authorization. 
+- `memo`: An administrative note regarding the authorization.
+- `stock_location_id`: The `Spree::StockLocation` associated with this return
+  authorization.
+- `return_reason_id`: The ID for the `Spree::ReturnReason` associated with this
+  return authorization.
+
+The RMA creation process typically includes the following steps:
+
+1. The administrator presses the **New RMA** button (on the backend's **Orders
+   -> Order -> RMA** page).
+2. They select the items on the order that are being returned.
+3. For each item selected, they choose the following optional values:
+   - They choose a reimbursement type (if applicable). For example: store credit.
+   - They choose an exchange item (if applicable).
+   - They choose a reason for the return authorization for the item (if
+     applicable). For example: "Damaged/Defective".
+4. They choose a stock location that the return is authorized to be shipped to.
+5. They write a memo that documents why the return authorization is being
+   created.  
+6. Once the new RMA form is completed, they press the **Create** button and
+   generate a new `Spree::ReturnAuthorization` object. 
+
+After the customer has mailed their returns back, the administrator can mark the
+the customer return as received (on the backend's **Orders -> Order -> Customer
+Returns** page).
+
+<!-- TODO:
+  Again, we should add links here once additional returns documentation exists
+  here.
+-->
+


### PR DESCRIPTION
This pull request adds stub articles for `Spree::InventoryUnit`s and `Spree::ReturnAuthorization`s. The return authorizations article introduces the concept of RMAs but not the larger returns/reimbursements system in Solidus, which will come later as its own section.

_This is part a larger project to improve Solidus's documentation. [See this gist with the high-level table of contents](https://gist.github.com/benjaminwil/5e2d2da3d9def6b949b833b1aa2549d3). Where and how this documentation will exist is still up for discussion._