### PR TITLE
Update stock_items_controller.rb

### DIFF
--- a/api/app/controllers/spree/api/stock_items_controller.rb
+++ b/api/app/controllers/spree/api/stock_items_controller.rb
@@ -3,7 +3,7 @@ module Spree
     class StockItemsController < Spree::Api::BaseController
       before_action :load_stock_location, only: [:index, :show, :create]
 
-      rescue_from StockLocation::InvalidMovementError, with: :render_stock_items_error
+      rescue_from Spree::StockLocation::InvalidMovementError, with: :render_stock_items_error
 
       def index
         @stock_items = paginate(scope.ransack(params[:q]).result)


### PR DESCRIPTION
Confuses with error, when using it as a base for decorator.

```
.../app/controllers/spree/api/stock_items_controller_decorator.rb:4:in `block in <top (required)>': uninitialized constant StockLocation (NameError)
```