### PR TITLE
Better organize stock management JS and convert from coffeescript

### DIFF
--- a/backend/app/assets/javascripts/spree/backend.js
+++ b/backend/app/assets/javascripts/spree/backend.js
@@ -52,8 +52,7 @@
 //= require spree/backend/shipments
 //= require spree/backend/spree-select2
 //= require spree/backend/stock_location
-//= require spree/backend/stock_management/index_add_forms
-//= require spree/backend/stock_management/index_update_forms
+//= require spree/backend/stock_management
 //= require spree/backend/store_credits
 //= require spree/backend/style_guide
 //= require spree/backend/taxon_autocomplete

--- a/backend/app/assets/javascripts/spree/backend.js
+++ b/backend/app/assets/javascripts/spree/backend.js
@@ -54,7 +54,6 @@
 //= require spree/backend/stock_location
 //= require spree/backend/stock_management/index_add_forms
 //= require spree/backend/stock_management/index_update_forms
-//= require spree/backend/stock_management/stock_item
 //= require spree/backend/store_credits
 //= require spree/backend/style_guide
 //= require spree/backend/taxon_autocomplete

--- a/backend/app/assets/javascripts/spree/backend/models/index.js
+++ b/backend/app/assets/javascripts/spree/backend/models/index.js
@@ -2,5 +2,6 @@
 //= require spree/backend/models/line_item
 //= require spree/backend/models/order
 //= require spree/backend/models/shipment
+//= require spree/backend/models/stock_item
 //= require spree/backend/models/taxonomy
 //= require spree/backend/models/payment

--- a/backend/app/assets/javascripts/spree/backend/models/stock_item.js
+++ b/backend/app/assets/javascripts/spree/backend/models/stock_item.js
@@ -1,0 +1,6 @@
+Spree.Models.StockItem = Backbone.Model.extend({
+  paramRoot: 'stock_item',
+  urlRoot: function() {
+    return Spree.routes.stock_items_api(this.get('stock_location_id'));
+  }
+});

--- a/backend/app/assets/javascripts/spree/backend/namespaces.js
+++ b/backend/app/assets/javascripts/spree/backend/namespaces.js
@@ -7,6 +7,7 @@ _.extend(window.Spree, {
     Cart: {},
     Zones: {},
     Payment: {},
+    Stock: {},
     Tables: {}
   }
 })

--- a/backend/app/assets/javascripts/spree/backend/stock_management.js
+++ b/backend/app/assets/javascripts/spree/backend/stock_management.js
@@ -1,0 +1,22 @@
+Spree.ready(function() {
+  $('.js-edit-stock-item').each(function() {
+    var $el = $(this);
+    var model = new Spree.Models.StockItem($el.data('stock-item'));
+    new Spree.Views.Stock.EditStockItemRow({
+      el: $el,
+      stockLocationName: $el.data('stock-location-name'),
+      model: model
+    });
+  });
+
+  $('.js-add-stock-item').each(function() {
+    var $el = $(this)
+    var model = new Spree.Models.StockItem({
+      variant_id: $el.data('variant-id')
+    });
+    new Spree.Views.Stock.AddStockItem({
+      el: $el,
+      model: model
+    });
+  });
+});

--- a/backend/app/assets/javascripts/spree/backend/stock_management/index_add_forms.coffee
+++ b/backend/app/assets/javascripts/spree/backend/stock_management/index_add_forms.coffee
@@ -24,7 +24,7 @@ Spree.AddStockItemView = Backbone.View.extend
       stockLocationName: stockLocationName
     editView.$el.insertBefore(@$el)
 
-    @model = new Spree.StockItem
+    @model = new Spree.Models.StockItem
       variant_id: @model.get('variant_id')
       stock_location_id: @model.get('stock_location_id')
 
@@ -54,7 +54,7 @@ Spree.AddStockItemView = Backbone.View.extend
 Spree.ready ->
   $('.js-add-stock-item').each ->
     $el = $(this)
-    model = new Spree.StockItem
+    model = new Spree.Models.StockItem
       variant_id: $el.data('variant-id')
     new Spree.AddStockItemView
       el: $el

--- a/backend/app/assets/javascripts/spree/backend/stock_management/index_add_forms.coffee
+++ b/backend/app/assets/javascripts/spree/backend/stock_management/index_add_forms.coffee
@@ -19,7 +19,7 @@ Spree.AddStockItemView = Backbone.View.extend
     stockLocationName = selectedStockLocationOption.text().trim()
     selectedStockLocationOption.remove()
 
-    editView = new Spree.EditStockItemView
+    editView = new Spree.Views.Stock.EditStockItemRow
       model: @model
       stockLocationName: stockLocationName
     editView.$el.insertBefore(@$el)

--- a/backend/app/assets/javascripts/spree/backend/stock_management/index_add_forms.coffee
+++ b/backend/app/assets/javascripts/spree/backend/stock_management/index_add_forms.coffee
@@ -1,8 +1,0 @@
-Spree.ready ->
-  $('.js-add-stock-item').each ->
-    $el = $(this)
-    model = new Spree.Models.StockItem
-      variant_id: $el.data('variant-id')
-    new Spree.Views.Stock.AddStockItem
-      el: $el
-      model: model

--- a/backend/app/assets/javascripts/spree/backend/stock_management/index_add_forms.coffee
+++ b/backend/app/assets/javascripts/spree/backend/stock_management/index_add_forms.coffee
@@ -1,61 +1,8 @@
-Spree.AddStockItemView = Backbone.View.extend
-  initialize: ->
-    @$countInput = @$("[name='count_on_hand']")
-    @$locationSelect = @$("[name='stock_location_id']")
-    @$backorderable = @$("[name='backorderable']")
-
-  events:
-    "click .submit": "onSubmit"
-
-  validate: ->
-    locationSelectContainer = @$locationSelect.siblings('.select2-container')
-    locationSelectContainer.toggleClass('error', !@$locationSelect.val())
-    @$countInput.toggleClass('error', !@$countInput.val())
-
-    locationSelectContainer.hasClass('error') || @$countInput.hasClass('error')
-
-  onSuccess: ->
-    selectedStockLocationOption = @$locationSelect.find('option:selected')
-    stockLocationName = selectedStockLocationOption.text().trim()
-    selectedStockLocationOption.remove()
-
-    editView = new Spree.Views.Stock.EditStockItemRow
-      model: @model
-      stockLocationName: stockLocationName
-    editView.$el.insertBefore(@$el)
-
-    @model = new Spree.Models.StockItem
-      variant_id: @model.get('variant_id')
-      stock_location_id: @model.get('stock_location_id')
-
-    if @$locationSelect.find('option').length is 1 # blank value
-      @remove()
-    else
-      @$locationSelect.select2()
-      @$countInput.val("")
-      @$backorderable.prop("checked", false)
-
-  onSubmit: (ev) ->
-    ev.preventDefault()
-    return if @validate()
-
-    @model.set
-      backorderable: @$backorderable.prop("checked")
-      count_on_hand: @$countInput.val()
-      stock_location_id: @$locationSelect.val()
-    options =
-      success: =>
-        @onSuccess()
-        show_flash("success", Spree.translations.created_successfully)
-      error: (model, response, options) =>
-        show_flash("error", response.responseText)
-    @model.save(null, options)
-
 Spree.ready ->
   $('.js-add-stock-item').each ->
     $el = $(this)
     model = new Spree.Models.StockItem
       variant_id: $el.data('variant-id')
-    new Spree.AddStockItemView
+    new Spree.Views.Stock.AddStockItem
       el: $el
       model: model

--- a/backend/app/assets/javascripts/spree/backend/stock_management/index_update_forms.coffee
+++ b/backend/app/assets/javascripts/spree/backend/stock_management/index_update_forms.coffee
@@ -1,67 +1,8 @@
-errorHandler = (model, response, options) ->
-  show_flash("error", response.responseText)
-
-Spree.EditStockItemView = Backbone.View.extend
-  tagName: 'tr'
-
-  initialize: (options) ->
-    @stockLocationName = options.stockLocationName
-    @editing = false
-    @render()
-
-  events:
-    "click .edit": "onEdit"
-    "click .submit": "onSubmit"
-    "submit form": "onSubmit"
-    "click .cancel": "onCancel"
-
-  template: HandlebarsTemplates['stock_items/stock_location_stock_item']
-
-  render: ->
-    renderAttr =
-      stockLocationName: @stockLocationName
-      editing: @editing
-    _.extend(renderAttr, @model.attributes)
-
-    @$el.attr("data-variant-id", @model.get('variant_id'))
-    @$el.html(@template(renderAttr))
-
-    return @
-
-  onEdit: (ev) ->
-    ev.preventDefault()
-    @editing = true
-    @render()
-
-  onCancel: (ev) ->
-    ev.preventDefault()
-    @model.set(@model.previousAttributes())
-    @editing = false
-    @render()
-
-  onSuccess: ->
-    @editing = false
-    @render()
-    show_flash("success", Spree.translations.updated_successfully)
-
-  onSubmit: (ev) ->
-    ev.preventDefault()
-    backorderable = @$('[name=backorderable]').prop("checked")
-    countOnHand = parseInt(@$("input[name='count_on_hand']").val(), 10)
-
-    @model.set
-      count_on_hand: countOnHand
-      backorderable: backorderable
-    options =
-      success: => @onSuccess()
-      error: errorHandler
-    @model.save(force: true, options)
-
 Spree.ready ->
   $('.js-edit-stock-item').each ->
     $el = $(this)
     model = new Spree.Models.StockItem($el.data('stock-item'))
-    new Spree.EditStockItemView
+    new Spree.Views.Stock.EditStockItemRow
       el: $el
       stockLocationName: $el.data('stock-location-name')
       model: model

--- a/backend/app/assets/javascripts/spree/backend/stock_management/index_update_forms.coffee
+++ b/backend/app/assets/javascripts/spree/backend/stock_management/index_update_forms.coffee
@@ -60,7 +60,7 @@ Spree.EditStockItemView = Backbone.View.extend
 Spree.ready ->
   $('.js-edit-stock-item').each ->
     $el = $(this)
-    model = new Spree.StockItem($el.data('stock-item'))
+    model = new Spree.Models.StockItem($el.data('stock-item'))
     new Spree.EditStockItemView
       el: $el
       stockLocationName: $el.data('stock-location-name')

--- a/backend/app/assets/javascripts/spree/backend/stock_management/index_update_forms.coffee
+++ b/backend/app/assets/javascripts/spree/backend/stock_management/index_update_forms.coffee
@@ -1,8 +1,0 @@
-Spree.ready ->
-  $('.js-edit-stock-item').each ->
-    $el = $(this)
-    model = new Spree.Models.StockItem($el.data('stock-item'))
-    new Spree.Views.Stock.EditStockItemRow
-      el: $el
-      stockLocationName: $el.data('stock-location-name')
-      model: model

--- a/backend/app/assets/javascripts/spree/backend/stock_management/stock_item.coffee
+++ b/backend/app/assets/javascripts/spree/backend/stock_management/stock_item.coffee
@@ -1,4 +1,0 @@
-Spree.StockItem = Backbone.Model.extend
-  urlRoot: ->
-    Spree.routes.stock_items_api(@get('stock_location_id'))
-  paramRoot: 'stock_item'

--- a/backend/app/assets/javascripts/spree/backend/views/index.js
+++ b/backend/app/assets/javascripts/spree/backend/views/index.js
@@ -12,6 +12,7 @@
 //= require 'spree/backend/views/order/shipping_method'
 //= require 'spree/backend/views/order/summary'
 //= require 'spree/backend/views/state_select'
+//= require 'spree/backend/views/stock/edit_stock_item_row'
 //= require 'spree/backend/views/zones/form'
 //= require 'spree/backend/views/number_with_currency'
 //= require 'spree/backend/views/payment/new'

--- a/backend/app/assets/javascripts/spree/backend/views/index.js
+++ b/backend/app/assets/javascripts/spree/backend/views/index.js
@@ -12,6 +12,7 @@
 //= require 'spree/backend/views/order/shipping_method'
 //= require 'spree/backend/views/order/summary'
 //= require 'spree/backend/views/state_select'
+//= require 'spree/backend/views/stock/add_stock_item'
 //= require 'spree/backend/views/stock/edit_stock_item_row'
 //= require 'spree/backend/views/zones/form'
 //= require 'spree/backend/views/number_with_currency'

--- a/backend/app/assets/javascripts/spree/backend/views/stock/add_stock_item.js
+++ b/backend/app/assets/javascripts/spree/backend/views/stock/add_stock_item.js
@@ -1,0 +1,63 @@
+Spree.Views.Stock.AddStockItem = Backbone.View.extend({
+  initialize: function() {
+    this.$countInput = this.$("[name='count_on_hand']");
+    this.$locationSelect = this.$("[name='stock_location_id']");
+    this.$backorderable = this.$("[name='backorderable']");
+  },
+
+  events: {
+    "click .submit": "onSubmit"
+  },
+
+  validate: function() {
+    var locationSelectContainer = this.$locationSelect.siblings('.select2-container');
+    locationSelectContainer.toggleClass('error', !this.$locationSelect.val());
+    this.$countInput.toggleClass('error', !this.$countInput.val());
+    return locationSelectContainer.hasClass('error') || this.$countInput.hasClass('error');
+  },
+
+  onSuccess: function() {
+    var selectedStockLocationOption = this.$locationSelect.find('option:selected');
+    var stockLocationName = selectedStockLocationOption.text().trim();
+    selectedStockLocationOption.remove();
+    var editView = new Spree.Views.Stock.EditStockItemRow({
+      model: this.model,
+      stockLocationName: stockLocationName
+    });
+    editView.$el.insertBefore(this.$el);
+    this.model = new Spree.Models.StockItem({
+      variant_id: this.model.get('variant_id'),
+      stock_location_id: this.model.get('stock_location_id')
+    });
+    if (this.$locationSelect.find('option').length === 1) { // blank value
+      this.remove();
+    } else {
+      this.$locationSelect.select2();
+      this.$countInput.val("");
+      this.$backorderable.prop("checked", false);
+    }
+
+    show_flash("success", Spree.translations.created_successfully);
+  },
+
+  onError: function(model, response, options) {
+    show_flash("error", response.responseText);
+  },
+
+  onSubmit: function(ev) {
+    ev.preventDefault();
+    if (this.validate()) {
+      return;
+    }
+    this.model.set({
+      backorderable: this.$backorderable.prop("checked"),
+      count_on_hand: this.$countInput.val(),
+      stock_location_id: this.$locationSelect.val()
+    });
+    var options = {
+      success: this.onSuccess.bind(this),
+      error: this.onError.bind(this)
+    };
+    this.model.save(null, options);
+  }
+});

--- a/backend/app/assets/javascripts/spree/backend/views/stock/edit_stock_item_row.js
+++ b/backend/app/assets/javascripts/spree/backend/views/stock/edit_stock_item_row.js
@@ -1,0 +1,68 @@
+Spree.Views.Stock.EditStockItemRow = Backbone.View.extend({
+  tagName: 'tr',
+
+  initialize: function(options) {
+    this.stockLocationName = options.stockLocationName;
+    this.editing = false;
+    this.render();
+  },
+
+  events: {
+    "click .edit": "onEdit",
+    "click .submit": "onSubmit",
+    "submit form": "onSubmit",
+    "click .cancel": "onCancel"
+  },
+
+  template: HandlebarsTemplates['stock_items/stock_location_stock_item'],
+
+  render: function() {
+    var renderAttr = {
+      stockLocationName: this.stockLocationName,
+      editing: this.editing
+    };
+    _.extend(renderAttr, this.model.attributes);
+    this.$el.attr("data-variant-id", this.model.get('variant_id'));
+    this.$el.html(this.template(renderAttr));
+    return this;
+  },
+
+  onEdit: function(ev) {
+    ev.preventDefault();
+    this.editing = true;
+    this.render();
+  },
+
+  onCancel: function(ev) {
+    ev.preventDefault();
+    this.model.set(this.model.previousAttributes());
+    this.editing = false;
+    this.render();
+  },
+
+  onSuccess: function() {
+    this.editing = false;
+    this.render();
+    show_flash("success", Spree.translations.updated_successfully);
+  },
+
+  onError: function(model, response, options) {
+    show_flash("error", response.responseText);
+  },
+
+  onSubmit: function(ev) {
+    ev.preventDefault();
+    var backorderable = this.$('[name=backorderable]').prop("checked");
+    var countOnHand = parseInt(this.$("input[name='count_on_hand']").val(), 10);
+
+    this.model.set({
+      count_on_hand: countOnHand,
+      backorderable: backorderable
+    });
+    var options = {
+      success: this.onSuccess.bind(this),
+      error: this.onError.bind(this)
+    };
+    this.model.save({ force: true }, options);
+  }
+});


### PR DESCRIPTION
These were backbone-ified already, but were created before we had created the `Spree.Views` and `Spree.Stock` namespaces.

This PR moves the existing views and model into that namespace and folders. It also converts the existing CoffeeScript into plain JS.

There should be no change to users