### PR TITLE
Add store select to payment method admin

### DIFF
--- a/backend/app/views/spree/admin/payment_methods/_form.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/_form.html.erb
@@ -62,6 +62,10 @@
           <%= f.label :description %>
           <%= f.text_area :description, {cols: 60, rows: 6, class: 'fullwidth'} %>
         </div>
+        <div data-hook="stores" class="field">
+          <%= f.label :store_ids, plural_resource_name(Spree::Store) %>
+          <%= f.collection_select :store_ids, Spree::Store.all, :id, :name, {}, multiple: true, class: "select2 fullwidth" %>
+        </div>
       </div>
     </div>
   </div>

--- a/backend/spec/features/admin/configuration/payment_methods_spec.rb
+++ b/backend/spec/features/admin/configuration/payment_methods_spec.rb
@@ -62,6 +62,20 @@ describe "Payment Methods", type: :feature do
       expect(page).to have_field("payment_method_name", with: "Payment 99")
     end
 
+    context "with multiple stores available" do
+      before do
+        create(:store, name: "Default Store", url: "spreestore.example.com")
+        visit current_path
+      end
+
+      it "should be able to change the associated stores" do
+        select "Default Store", from: "Stores"
+        click_button "Update"
+        expect(page).to have_content("successfully updated!")
+        expect(page).to have_select("payment_method_store_ids", selected: "Default Store")
+      end
+    end
+
     it "should display validation errors" do
       fill_in "payment_method_name", with: ""
       click_button "Update"


### PR DESCRIPTION
Payment methods belong to stores, but there was previously no way of managing that association in the admin. This adds a select field allowing us to easily control that association.

![store-payment-admin](https://user-images.githubusercontent.com/876067/35710042-20131052-076a-11e8-8a08-e05d11a615b5.png)
