### PR TITLE
Splitted shipment should update order totals/payment status

### DIFF
--- a/core/app/models/spree/fulfilment_changer.rb
+++ b/core/app/models/spree/fulfilment_changer.rb
@@ -96,6 +96,10 @@ module Spree
       # are up-to-date, too.
       desired_shipment.refresh_rates
 
+      # In order to reflect the changes in the order totals
+      desired_shipment.order.reload
+      desired_shipment.order.recalculate
+
       true
     end
 

--- a/core/spec/models/spree/fulfilment_changer_spec.rb
+++ b/core/spec/models/spree/fulfilment_changer_spec.rb
@@ -57,6 +57,15 @@ RSpec.describe Spree::FulfilmentChanger do
       subject
     end
 
+    it 'updates order totals' do
+      original_total = order.total
+      original_shipment_total = order.shipment_total
+
+      expect { subject }.
+        to change { order.total }.from(original_total).to(original_total + original_shipment_total).
+        and change { order.shipment_total }.by(original_shipment_total)
+    end
+
     context "when transferring to another stock location" do
       let(:desired_stock_location) { create(:stock_location) }
       let!(:stock_item) do


### PR DESCRIPTION
Fixes #2554, detailed issue info is in there

Here's a gif with the solution in place:

![working](http://g.recordit.co/bm9F2bm675.gif)

I also added a small test to make sure after calling `run!` in `Spree::FulfilmentChanger` the order is properly recalculated