### PR TITLE
Add association between stores and shipping

### DIFF
--- a/backend/app/views/spree/admin/shipping_methods/_form.html.erb
+++ b/backend/app/views/spree/admin/shipping_methods/_form.html.erb
@@ -39,6 +39,14 @@
     <% end %>
   </div>
 
+  <div class="col-5">
+    <%= f.field_container :store_ids do %>
+      <%= f.label :store_ids, plural_resource_name(Spree::Store) %>
+      <%= f.collection_select :store_ids, Spree::Store.all, :id, :name, {}, multiple: true, class: "select2 fullwidth" %>
+      <%= error_message_on :shipping_method, :store_ids %>
+    <% end %>
+  </div>
+
   <div data-hook="admin_shipping_method_form_tracking_url_field" class="col-10">
     <%= f.field_container :tracking_url do %>
       <%= f.label :tracking_url %><br />

--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -37,6 +37,11 @@ module Spree
 
     validate :at_least_one_shipping_category
 
+    scope :available_to_store, ->(store) do
+      raise ArgumentError, "You must provide a store" if store.nil?
+      store.shipping_methods.empty? ? all : where(id: store.shipping_method_ids)
+    end
+
     # @param shipping_category_ids [Array<Integer>] ids of desired shipping categories
     # @return [ActiveRecord::Relation] shipping methods which are associated
     #   with all of the provided shipping categories

--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -30,6 +30,9 @@ module Spree
     has_many :shipping_method_stock_locations, dependent: :destroy, class_name: "Spree::ShippingMethodStockLocation"
     has_many :stock_locations, through: :shipping_method_stock_locations
 
+    has_many :store_shipping_methods, inverse_of: :shipping_method
+    has_many :stores, through: :store_shipping_methods
+
     validates :name, presence: true
 
     validate :at_least_one_shipping_category

--- a/core/app/models/spree/stock/estimator.rb
+++ b/core/app/models/spree/stock/estimator.rb
@@ -53,6 +53,7 @@ module Spree
 
       def shipping_methods(package)
         package.shipping_methods
+          .available_to_store(package.shipment.order.store)
           .available_for_address(package.shipment.order.ship_address)
           .includes(:calculator)
           .to_a

--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -9,6 +9,10 @@ module Spree
   class Store < Spree::Base
     has_many :store_payment_methods, inverse_of: :store
     has_many :payment_methods, through: :store_payment_methods
+
+    has_many :store_shipping_methods, inverse_of: :store
+    has_many :shipping_methods, through: :store_shipping_methods
+
     has_many :orders, class_name: "Spree::Order"
 
     validates :code, presence: true, uniqueness: { allow_blank: true }

--- a/core/app/models/spree/store_shipping_method.rb
+++ b/core/app/models/spree/store_shipping_method.rb
@@ -1,0 +1,6 @@
+module Spree
+  class StoreShippingMethod < Spree::Base
+    belongs_to :store, inverse_of: :store_shipping_methods
+    belongs_to :shipping_method, inverse_of: :store_shipping_methods
+  end
+end

--- a/core/db/migrate/20180202222641_create_store_shipping_methods.rb
+++ b/core/db/migrate/20180202222641_create_store_shipping_methods.rb
@@ -1,0 +1,10 @@
+class CreateStoreShippingMethods < ActiveRecord::Migration[5.1]
+  def change
+    create_table :spree_store_shipping_methods do |t|
+      t.references :store, foreign_key: { to_table: "spree_stores" }
+      t.references :shipping_method, foreign_key: { to_table: "spree_shipping_methods" }
+
+      t.timestamps
+    end
+  end
+end

--- a/core/spec/models/spree/stock/estimator_spec.rb
+++ b/core/spec/models/spree/stock/estimator_spec.rb
@@ -139,6 +139,34 @@ module Spree
           end
         end
 
+        context "excludes shipping methods from other stores" do
+          before{ Spree::ShippingMethod.all.each(&:really_destroy!) }
+
+          let!(:other_method) do
+            create(
+              :shipping_method,
+              cost: 0.00,
+              stores: [build(:store, name: "Other")]
+            )
+          end
+
+          let!(:main_method) do
+            create(
+              :shipping_method,
+              cost: 5.00,
+              stores: [order.store]
+            )
+          end
+
+          it "does not return the other rate at all" do
+            expect(subject.shipping_rates(package).map(&:shipping_method_id)).to eq([main_method.id])
+          end
+
+          it "doesn't select the other rate even if it's more affordable" do
+            expect(subject.shipping_rates(package).map(&:selected)).to eq [true]
+          end
+        end
+
         context "includes tax adjustments if applicable" do
           let(:zone) { create(:zone, countries: [order.tax_address.country])}
 


### PR DESCRIPTION
Like payment methods, shipping methods are typically store specific.

![store-shipping-admin](https://user-images.githubusercontent.com/876067/35889626-3b51eb14-0b51-11e8-91d8-8488a55fd72b.png)
