### PR TITLE
Removing leftover jquery validate script from checkout edit form

### DIFF
--- a/frontend/app/views/spree/checkout/edit.html.erb
+++ b/frontend/app/views/spree/checkout/edit.html.erb
@@ -30,7 +30,3 @@
 Spree.current_order_id = "<%= @order.number %>"
 Spree.current_order_token = "<%= @order.guest_token %>"
 </script>
-
-<% if I18n.locale != :en %>
-  <%= javascript_include_tag 'jquery.validate/localization/messages_' + I18n.locale.to_s.downcase.gsub('-', '') %>
-<% end %>


### PR DESCRIPTION
Title says it all, I believe.

This is generating an error in my solidus install.