### PR TITLE
Add locale chooser to admin

### DIFF
--- a/backend/app/assets/javascripts/spree/backend.js
+++ b/backend/app/assets/javascripts/spree/backend.js
@@ -37,6 +37,7 @@
 //= require spree/backend/handlebars_extensions
 //= require spree/backend/images/index
 //= require spree/backend/images/upload
+//= require spree/backend/locale_selection
 //= require spree/backend/navigation
 //= require spree/backend/option_type_autocomplete
 //= require spree/backend/option_value_picker

--- a/backend/app/assets/javascripts/spree/backend/locale_selection.js
+++ b/backend/app/assets/javascripts/spree/backend/locale_selection.js
@@ -1,0 +1,16 @@
+Spree.ready(function() {
+  var localeSelect = document.querySelector('.js-locale-selection');
+  if (!localeSelect) return;
+
+  localeSelect.addEventListener('change', function() {
+    Spree.ajax({
+      type: "PUT",
+      dataType: "json",
+      url: Spree.pathFor("admin/locale/set"),
+      data: { locale: localeSelect.value },
+      success: function(data) {
+        window.location.reload();
+      }
+    });
+  });
+});

--- a/backend/app/assets/javascripts/spree/backend/locale_selection.js
+++ b/backend/app/assets/javascripts/spree/backend/locale_selection.js
@@ -7,9 +7,11 @@ Spree.ready(function() {
       type: "PUT",
       dataType: "json",
       url: Spree.pathFor("admin/locale/set"),
-      data: { locale: localeSelect.value },
+      data: {
+        switch_to_locale: localeSelect.value
+      },
       success: function(data) {
-        window.location.reload();
+        document.location.href = data.location;
       }
     });
   });

--- a/backend/app/assets/stylesheets/spree/backend/components/_navigation.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_navigation.scss
@@ -160,6 +160,11 @@ nav.menu {
   }
 }
 
+.admin-locale-selection {
+  margin: 1em;
+  margin-bottom: 0;
+}
+
 .admin-nav.fits .admin-nav-footer {
   position: fixed;
   bottom: 0;

--- a/backend/app/controllers/spree/admin/locale_controller.rb
+++ b/backend/app/controllers/spree/admin/locale_controller.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Spree
+  module Admin
+    class LocaleController < Spree::Admin::BaseController
+      def set
+        locale = params[:locale].to_s.presence
+
+        if locale && I18n.available_locales.include?(locale.to_sym)
+          session[:locale] = locale
+
+          respond_to do |format|
+            format.json { render json: { locale: locale } }
+          end
+        else
+          respond_to do |format|
+            format.json { render json: { locale: I18n.locale }, status: 404 }
+          end
+        end
+      end
+    end
+  end
+end

--- a/backend/app/controllers/spree/admin/locale_controller.rb
+++ b/backend/app/controllers/spree/admin/locale_controller.rb
@@ -4,13 +4,14 @@ module Spree
   module Admin
     class LocaleController < Spree::Admin::BaseController
       def set
-        locale = params[:locale].to_s.presence
+        locale = params[:switch_to_locale].to_s.presence
 
         if locale && I18n.available_locales.include?(locale.to_sym)
+          I18n.locale = locale
           session[:locale] = locale
 
           respond_to do |format|
-            format.json { render json: { locale: locale } }
+            format.json { render json: { locale: locale, location: spree.admin_url } }
           end
         else
           respond_to do |format|

--- a/backend/app/views/spree/admin/shared/_locale_selection.html.erb
+++ b/backend/app/views/spree/admin/shared/_locale_selection.html.erb
@@ -1,0 +1,12 @@
+<div class="admin-locale-selection">
+  <select class="custom-select fullwidth">
+    <%=
+      options_for_select(
+        I18n.available_locales.map do |locale|
+          [I18n.t('spree.i18n.this_file_language', locale: locale, default: locale.to_s, fallback: false), locale]
+        end.sort,
+        selected: I18n.locale
+      )
+    %>
+  </select>
+</div>

--- a/backend/app/views/spree/admin/shared/_locale_selection.html.erb
+++ b/backend/app/views/spree/admin/shared/_locale_selection.html.erb
@@ -1,6 +1,6 @@
-<div class="admin-locale-selection">
-  <% available_locales = Spree.i18n_available_locales %>
-  <% if available_locales.size > 1 %>
+<% available_locales = Spree.i18n_available_locales %>
+<% if available_locales.size > 1 %>
+  <div class="admin-locale-selection">
     <select class="js-locale-selection custom-select fullwidth">
       <%=
         options_for_select(
@@ -11,5 +11,5 @@
         )
       %>
     </select>
-  <% end %>
-</div>
+  </div>
+<% end %>

--- a/backend/app/views/spree/admin/shared/_locale_selection.html.erb
+++ b/backend/app/views/spree/admin/shared/_locale_selection.html.erb
@@ -1,5 +1,5 @@
 <div class="admin-locale-selection">
-  <select class="custom-select fullwidth">
+  <select class="js-locale-selection custom-select fullwidth">
     <%=
       options_for_select(
         I18n.available_locales.map do |locale|

--- a/backend/app/views/spree/admin/shared/_locale_selection.html.erb
+++ b/backend/app/views/spree/admin/shared/_locale_selection.html.erb
@@ -1,12 +1,15 @@
 <div class="admin-locale-selection">
-  <select class="js-locale-selection custom-select fullwidth">
-    <%=
-      options_for_select(
-        I18n.available_locales.map do |locale|
-          [I18n.t('spree.i18n.this_file_language', locale: locale, default: locale.to_s, fallback: false), locale]
-        end.sort,
-        selected: I18n.locale
-      )
-    %>
-  </select>
+  <% available_locales = Spree.i18n_available_locales %>
+  <% if available_locales.size > 1 %>
+    <select class="js-locale-selection custom-select fullwidth">
+      <%=
+        options_for_select(
+          available_locales.map do |locale|
+            [I18n.t('spree.i18n.this_file_language', locale: locale, default: locale.to_s, fallback: false), locale]
+          end.sort,
+          selected: I18n.locale,
+        )
+      %>
+    </select>
+  <% end %>
 </div>

--- a/backend/app/views/spree/admin/shared/_navigation.html.erb
+++ b/backend/app/views/spree/admin/shared/_navigation.html.erb
@@ -3,6 +3,7 @@
   <div class="admin-nav-sticky">
     <%= render partial: 'spree/admin/shared/menu' %>
     <div class="admin-nav-footer">
+      <%= render partial: 'spree/admin/shared/locale_selection' %>
       <%= render partial: 'spree/admin/shared/navigation_footer' %>
     </div>
   </div>

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -5,6 +5,8 @@ Spree::Core::Engine.routes.draw do
     get '/search/users', to: "search#users", as: :search_users
     get '/search/products', to: "search#products", as: :search_products
 
+    put '/locale/set', to: 'locale#set', defaults: { format: :json }, as: :set_locale
+
     resources :dashboards, only: [] do
       collection do
         get :home

--- a/backend/spec/features/admin/locale_spec.rb
+++ b/backend/spec/features/admin/locale_spec.rb
@@ -13,6 +13,7 @@ describe "setting locale", type: :feature do
         month_names: []
       },
       spree: {
+        i18n: { this_file_language: "Français" },
         admin: {
           tab: { orders: "Ordres" }
         },

--- a/core/lib/spree/core/controller_helpers/common.rb
+++ b/core/lib/spree/core/controller_helpers/common.rb
@@ -48,10 +48,17 @@ module Spree
         private
 
         def set_user_language
-          locale = session[:locale]
-          locale ||= config_locale if respond_to?(:config_locale, true)
-          locale ||= Rails.application.config.i18n.default_locale
-          locale ||= I18n.default_locale
+          available_locales = Spree.i18n_available_locales
+          locale = [
+            params[:locale],
+            session[:locale],
+            (config_locale if respond_to?(:config_locale, true)),
+            I18n.default_locale
+          ].detect do |candidate|
+            candidate &&
+              available_locales.include?(candidate.to_sym)
+          end
+          session[:locale] = locale
           I18n.locale = locale
           Carmen.i18n_backend.locale = locale
         end

--- a/core/lib/spree/i18n.rb
+++ b/core/lib/spree/i18n.rb
@@ -7,7 +7,7 @@ require 'action_view'
 module Spree
   def self.i18n_available_locales
     I18n.available_locales.select do |locale|
-      I18n.t(:spree, locale: locale, fallback: false, default: nil)
+      I18n.t('spree.i18n.this_file_language', locale: locale, fallback: false, default: nil)
     end
   end
 

--- a/core/lib/spree/i18n.rb
+++ b/core/lib/spree/i18n.rb
@@ -5,11 +5,9 @@ require 'active_support/core_ext/array/extract_options'
 require 'action_view'
 
 module Spree
-  module I18n
-    def self.available_locales
-      I18n.available_locales.select do |locale|
-        I18n.t(:spree, locale: locale, fallback: false, default: nil)
-      end
+  def self.i18n_available_locales
+    I18n.available_locales.select do |locale|
+      I18n.t(:spree, locale: locale, fallback: false, default: nil)
     end
   end
 

--- a/core/lib/spree/i18n.rb
+++ b/core/lib/spree/i18n.rb
@@ -5,6 +5,14 @@ require 'active_support/core_ext/array/extract_options'
 require 'action_view'
 
 module Spree
+  module I18n
+    def self.available_locales
+      I18n.available_locales.select do |locale|
+        I18n.t(:spree, locale: locale, fallback: false, default: nil)
+      end
+    end
+  end
+
   class TranslationHelperWrapper # :nodoc:
     include ActionView::Helpers::TranslationHelper
   end

--- a/core/spec/lib/i18n_spec.rb
+++ b/core/spec/lib/i18n_spec.rb
@@ -5,6 +5,9 @@ require 'spree/i18n'
 
 RSpec.describe "i18n" do
   before do
+    # This reload avoids an issue with I18n.available_locales being cached
+    I18n.reload!
+
     I18n.backend.store_translations(:en,
     {
       spree: {
@@ -18,6 +21,9 @@ RSpec.describe "i18n" do
         legacy_translation: "back in the day..."
       }
     })
+  end
+  after do
+    I18n.reload!
   end
 
   it "translates within the spree scope" do
@@ -43,5 +49,31 @@ RSpec.describe "i18n" do
 
   it "should have a Spree::I18N_GENERIC_PLURAL constant" do
     expect(Spree::I18N_GENERIC_PLURAL).to eq 2.1
+  end
+
+  describe "i18n_available_locales" do
+    it "should only return :en" do
+      expect(Spree.i18n_available_locales).to eq([:en])
+    end
+
+    context 'with unprefixed translations in another locale' do
+      before do
+        I18n.backend.store_translations(:fr, { cheese: "fromage" })
+      end
+
+      it "should only return :en" do
+        expect(Spree.i18n_available_locales).to eq([:en])
+      end
+    end
+
+    context 'with spree-prefixed translations in another locale' do
+      before do
+        I18n.backend.store_translations(:fr, spree: { cheese: "fromage" })
+      end
+
+      it "should return :en and :fr" do
+        expect(Spree.i18n_available_locales).to eq([:en, :fr])
+      end
+    end
   end
 end

--- a/core/spec/lib/i18n_spec.rb
+++ b/core/spec/lib/i18n_spec.rb
@@ -11,6 +11,9 @@ RSpec.describe "i18n" do
     I18n.backend.store_translations(:en,
     {
       spree: {
+        i18n: {
+          this_file_language: "English"
+        },
         foo: "bar",
         bar: {
           foo: "bar within bar scope",
@@ -69,6 +72,16 @@ RSpec.describe "i18n" do
     context 'with spree-prefixed translations in another locale' do
       before do
         I18n.backend.store_translations(:fr, spree: { cheese: "fromage" })
+      end
+
+      it "should return :en and :fr" do
+        expect(Spree.i18n_available_locales).to eq([:en])
+      end
+    end
+
+    context 'with specific desired key' do
+      before do
+        I18n.backend.store_translations(:fr, spree: { i18n: { this_file_language: "Français" } })
       end
 
       it "should return :en and :fr" do

--- a/frontend/spec/controllers/controller_helpers_spec.rb
+++ b/frontend/spec/controllers/controller_helpers_spec.rb
@@ -9,9 +9,13 @@ describe Spree::ProductsController, type: :controller do
   before do
     I18n.enforce_available_locales = false
     Spree::Frontend::Config[:locale] = :de
+    I18n.backend.store_translations(:de, spree: {
+      i18n: { this_file_language: "Deutsch (DE)" }
+    })
   end
 
   after do
+    I18n.reload!
     Spree::Frontend::Config[:locale] = :en
     I18n.locale = :en
     I18n.enforce_available_locales = true

--- a/frontend/spec/features/locale_spec.rb
+++ b/frontend/spec/features/locale_spec.rb
@@ -15,11 +15,15 @@ describe 'setting locale', type: :feature do
 
   context 'shopping cart link and page' do
     before do
-      I18n.backend.store_translations(:fr,
-       spree: {
-         cart: 'Panier',
-         shopping_cart: 'Panier'
+      I18n.backend.store_translations(:fr, spree: {
+        i18n: { this_file_language: "Français" },
+        cart: 'Panier',
+        shopping_cart: 'Panier'
       })
+    end
+
+    after do
+      I18n.reload!
     end
 
     it 'should be in french' do


### PR DESCRIPTION
 I want to add a locale selector to the admin.

![](http://i.hawth.ca/s/d9iZr9kP.png)

It's currently too hard to change the locale of the admin. My hope is that by making it easier we will have more users switch to a non-english locale and then through that hopefully get more help keeping them up to date.

I want to implement this in Solidus backend rather than solidus_i18n. This lets us avoid the need for `deface`, and makes it more clear that i18n is a concern of Solidus itself.

It would be nice if we could recommended that all new users include `solidus_i18n`, and listed the gem inside our README's "Getting started" section. To do this we would probably want it to only provide YAML files and there's been some work towards that.

## Todo

* [x] Have the selector actually set the locale
* [x] Currently this uses I18n.available_locales, we should probably restrict it to locales which have at least _some_ translations under the `spree` namespace.
* [x] Hide selector if there is only one available locale.