### PR TITLE
Mention deface in README for developers installing solidus and solidus_auth_devise

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,41 +44,51 @@ Try out Solidus with one-click on Heroku:
 Getting started
 ---------------
 
-Begin by making sure you have [Imagemagick](http://imagemagick.org/script/download.php) installed, which is required for Paperclip. (You can install it using [Homebrew](https://brew.sh) if you're on a Mac.)
+Begin by making sure you have
+[Imagemagick](http://imagemagick.org/script/download.php) installed, which is
+required for Paperclip. (You can install it using [Homebrew](https://brew.sh) if
+you're on a Mac.)
 
-To add solidus, begin with a Rails 5 application and a database configured and created. Add the following to your
-Gemfile.
+To add Solidus, begin with a Rails 5 application and a database configured and
+created. Add the following to your Gemfile:
 
 ```ruby
 gem 'solidus'
 gem 'solidus_auth_devise'
+gem 'deface'
 ```
 
-Run the `bundle` command to install.
+Then, run the `bundle` command to install the Solidus gems and their
+dependencies.
 
-After installing gems, you'll have to run the generators to create necessary
-configuration files and migrations.
+After installing gems, run the generators to create necessary configuration
+files and migrations:
 
-```
-bundle exec rails g spree:install
-bundle exec rails g solidus:auth:install
+```shell
+bundle exec rails generate spree:install
+bundle exec rails generate solidus:auth:install
 bundle exec rake railties:install:migrations
 ```
 
-Run migrations to create the new models in the database.
+Then, run migrations to create the new models in the database:
 
-```
+```shell
 bundle exec rake db:migrate
 ```
 
-Finally start the rails server
+Finally, start the Rails server:
 
-```
-bundle exec rails s
+```shell
+bundle exec rails server
 ```
 
-The [`solidus_frontend`](https://github.com/solidusio/solidus/tree/master/frontend) storefront will be accessible at [http://localhost:3000/](http://localhost:3000/)
-and the admin can be found at [http://localhost:3000/admin/](http://localhost:3000/admin/).
+Once the server is running, the [`solidus_frontend`][solidus-frontend]
+storefront is accessible at [http://localhost:3000/](http://localhost:3000/).
+The [`solidus_backend`][solidus-backend] admin is accessible at
+[http://localhost:3000/admin/](http://localhost:3000/admin/).
+
+[solidus-frontend]: https://github.com/solidusio/solidus/tree/master/frontend
+[solidus-backend]: https://github.com/solidusio/solidus/tree/master/backend
 
 ### Default Username/Password
 

--- a/guides/getting-started/first-time-installation.md
+++ b/guides/getting-started/first-time-installation.md
@@ -153,12 +153,18 @@ rails new your_solidus_project_name
 ```
 
 Once the new project has finished being created, we can open the project's newly
-created `Gemfile` in a text editor and add the required Solidus gems as new
-lines:
+created `Gemfile` in a text editor and add the required Solidus gems:
 
 ```ruby 
 gem 'solidus'
 gem 'solidus_auth_devise'
+```
+
+Because you are using `solidus_auth_devise`, the [Deface][deface] gem is also
+required:
+
+```ruby
+gem 'deface'
 ```
 
 By requiring [`solidus`][solidus-repo] in your `Gemfile`, you are actually


### PR DESCRIPTION
We should mention `deface` in the README's "Getting started" section because it is required to run the `spree:install` generator if `solidus_auth_devise` is being used.

When `solidus_auth_devise` no longer requires `deface` I can remove this info.

### Steps to reproduce

You can reproduce the issue if you attempt to install Solidus by following the instructions in the `README.md` or the `/guides/getting-started` documentation:

1. Create a new Rails app: `rails new my_store`
2. Add `solidus` and `solidus_auth_devise` to your `Gemfile`.
3. `bundle` your application.
4. Run the `spree:install` generator: `bundle exec rails g spree:install`

### Expected behavior

The `spree:install` generator should work, eventually prompting you to make an admin account.

### Actual behavior

The generator stops because of `solidus_auth_devise`:

```
deface is required to run solidus_auth_devise with solidus versions < 2.5.
Please add deface to your Gemfile
```

If you add `deface` to your Gemfile everything goes great!

This pull request cleans up the "Getting started" section of the `README.md` and adds instructions to add `deface` to your `Gemfile`. It does the same thing in the `/guides/getting-started` documentation.

### System configuration

**Solidus Version**:

- `solidus_* 2.4.2`

**Extensions in use**:

- `solidus_auth_devise 2.1.0`    