### PR TITLE
Bump CircleCI image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
       CIRCLE_TEST_REPORTS: /tmp/test-results
       CIRCLE_ARTIFACTS: /tmp/test-artifacts
     docker:
-      - image: circleci/ruby:2.4.1-node-browsers
+      - image: circleci/ruby:2.5-node-browsers
       - image: jhawthorn/circleci-postgres-fast
         environment:
           POSTGRES_USER: root


### PR DESCRIPTION
Previously on CircleCI we were running an old image with an old version of chrome and chromedriver which [no longer worked in the latest Capybara](https://github.com/teamcapybara/capybara/commit/4027b0d93ba0e8c26f97a1ae515fa3f2dc6918a1).

We could fix this by bumping to `circleci/ruby:2.4.3-node-browsers`, but to avoid this in the future we can specify only the major.minor version of ruby we want, like `circleci/ruby:2.4-node-browsers`.

While we're bumping images, we might as well go to ruby 2.5, which was released in December.

This commit bumps our CircleCI image to `circleci/ruby:2.5-node-browsers`.