### PR TITLE
Add options to PromotionCode::BatchBuilder and spec for unique promotion code contention

### DIFF
--- a/core/app/models/spree/promotion_code/batch_builder.rb
+++ b/core/app/models/spree/promotion_code/batch_builder.rb
@@ -1,15 +1,32 @@
 class ::Spree::PromotionCode::BatchBuilder
-  attr_reader :promotion_code_batch
+  attr_reader :promotion_code_batch, :options
   delegate :promotion, :number_of_codes, :base_code, to: :promotion_code_batch
 
-  class_attribute :random_code_length, :batch_size, :sample_characters, :join_characters
-  self.random_code_length = 6
-  self.batch_size = 1_000
-  self.sample_characters = ('a'..'z').to_a + (2..9).to_a.map(&:to_s)
-  self.join_characters = "_"
+  DEFAULT_OPTIONS = {
+    random_code_length: 6,
+    batch_size: 1000,
+    sample_characters: ('a'..'z').to_a + (2..9).to_a.map(&:to_s),
+    join_characters: "_"
+  }
 
-  def initialize(promotion_code_batch)
+  [:random_code_length, :batch_size, :sample_characters, :join_characters].each do |attr|
+    define_singleton_method(attr) do
+      Spree::Deprecation.warn "#{name}.#{attr} is deprecated. Use #{name}::DEFAULT_OPTIONS[:#{attr}] instead"
+      DEFAULT_OPTIONS[attr]
+    end
+
+    define_singleton_method(:"#{attr}=") do |val|
+      Spree::Deprecation.warn "#{name}.#{attr}= is deprecated. Use #{name}::DEFAULT_OPTIONS[:#{attr}]= instead"
+      DEFAULT_OPTIONS[attr] = val
+    end
+
+    delegate attr, to: self
+  end
+
+  def initialize(promotion_code_batch, options = {})
     @promotion_code_batch = promotion_code_batch
+    options.assert_valid_keys(*DEFAULT_OPTIONS.keys)
+    @options = DEFAULT_OPTIONS.merge(options)
   end
 
   def build_promotion_codes
@@ -27,9 +44,10 @@ class ::Spree::PromotionCode::BatchBuilder
 
   def generate_random_codes
     created_codes = 0
+    batch_size = @options[:batch_size]
 
     while created_codes < number_of_codes
-      max_codes_to_generate = [self.class.batch_size, number_of_codes - created_codes].min
+      max_codes_to_generate = [batch_size, number_of_codes - created_codes].min
 
       new_codes = Array.new(max_codes_to_generate) { generate_random_code }.uniq
       codes_for_current_batch = get_unique_codes(new_codes)
@@ -46,11 +64,11 @@ class ::Spree::PromotionCode::BatchBuilder
   end
 
   def generate_random_code
-    suffix = Array.new(self.class.random_code_length) do
-      sample_characters.sample
+    suffix = Array.new(@options[:random_code_length]) do
+      @options[:sample_characters].sample
     end.join
 
-    "#{base_code}#{join_characters}#{suffix}"
+    "#{base_code}#{@options[:join_characters]}#{suffix}"
   end
 
   def get_unique_codes(code_set)

--- a/core/spec/models/spree/promotion_code/batch_builder_spec.rb
+++ b/core/spec/models/spree/promotion_code/batch_builder_spec.rb
@@ -4,11 +4,12 @@ RSpec.describe Spree::PromotionCode::BatchBuilder do
   let(:promotion) { create(:promotion) }
   let(:base_code) { "abc" }
   let(:options) { {} }
+  let(:number_of_codes) { 10 }
   let(:promotion_code_batch) do
     Spree::PromotionCodeBatch.create!(
       promotion_id: promotion.id,
       base_code: base_code,
-      number_of_codes: 10,
+      number_of_codes: number_of_codes,
       email: "test@email.com"
     )
   end
@@ -52,6 +53,22 @@ RSpec.describe Spree::PromotionCode::BatchBuilder do
 
       it "updates the promotion code batch state to completed" do
         expect(promotion_code_batch.state).to eq("completed")
+      end
+    end
+
+    context "with likely code contention" do
+      let(:number_of_codes) { 50 }
+      let(:options) do
+        {
+          batch_size: 10,
+          sample_characters: (0..9).to_a.map(&:to_s),
+          random_code_length: 2
+        }
+      end
+
+      it "creates the correct number of codes" do
+        subject.build_promotion_codes
+        expect(promotion.codes.size).to eq(number_of_codes)
       end
     end
   end

--- a/core/spec/models/spree/promotion_code/batch_builder_spec.rb
+++ b/core/spec/models/spree/promotion_code/batch_builder_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe Spree::PromotionCode::BatchBuilder do
   let(:promotion) { create(:promotion) }
   let(:base_code) { "abc" }
+  let(:options) { {} }
   let(:promotion_code_batch) do
     Spree::PromotionCodeBatch.create!(
       promotion_id: promotion.id,
@@ -12,7 +13,7 @@ RSpec.describe Spree::PromotionCode::BatchBuilder do
     )
   end
 
-  subject { described_class.new(promotion_code_batch) }
+  subject { described_class.new(promotion_code_batch, options) }
 
   describe "#build_promotion_codes" do
     context "with a failed build" do
@@ -66,11 +67,7 @@ RSpec.describe Spree::PromotionCode::BatchBuilder do
     end
 
     context "with a custom join separator" do
-      around do |example|
-        Spree::PromotionCode::BatchBuilder.join_characters = "x"
-        example.run
-        Spree::PromotionCode::BatchBuilder.join_characters = "_"
-      end
+      let(:options) { { join_characters: "x" } }
 
       it "builds codes with the same base prefix" do
         subject.build_promotion_codes


### PR DESCRIPTION
The issue fixed by #2578 wasn't caught by our specs. It was hard to write a spec to test that issue because the `PromotionCode::BatchBuilder` was configured by `class_attribute`s.

This PR deprecates the existing class-attributes in favour of having a defaults option hash.

It uses this to add an additional spec which runs the BatchBuilder with settings that make it extremely likely that there will a conflict: from a space of 100 possible codes (`00` to `99`) we generate 50.

An online birthday problem calculator tells me this is 99.99997% likely that the generator will encounter at least one conflict. That seems plenty. I haven't verified this, but intuitively it seems very likely.


This would have caught the issue prior to #2578 
```
Failures:

  1) Spree::PromotionCode::BatchBuilder#build_promotion_codes with likely code contention creates the correct number of codes
     Failure/Error: expect(promotion.codes.size).to eq(number_of_codes)

       expected: 50
            got: 61

       (compared using ==)
     # ./spec/models/spree/promotion_code/batch_builder_spec.rb:71:in `block (4 levels) in <top (required)>'
```