### PR TITLE
Fix id-dependant promotion code spec failure

### DIFF
--- a/api/spec/requests/spree/api/promotions_controller_spec.rb
+++ b/api/spec/requests/spree/api/promotions_controller_spec.rb
@@ -38,7 +38,7 @@ module Spree
         end
 
         context 'when finding by code' do
-          let(:id) { promotion.codes.first }
+          let(:id) { promotion.codes.first.value }
 
           it_behaves_like "a JSON response"
         end


### PR DESCRIPTION
This spec wasn't testing what it was intending to. The "code" it was submitting wasn't a string, but a `Spree::PromotionCode` record. Our route helper helpfully called `to_param` to submit the `PromotionCode`'s id.

This spec only passed when the promotion_code id matched the promotion id.

This started failing more regularly following #2576. Thankfully `rspec --bisect` was able to find it.