### PR TITLE
Distribute over eligible line items

### DIFF
--- a/core/app/models/spree/calculator/distributed_amount.rb
+++ b/core/app/models/spree/calculator/distributed_amount.rb
@@ -14,6 +14,7 @@ module Spree
       if line_item && preferred_currency.casecmp(line_item.currency).zero?
         Spree::DistributedAmountsHandler.new(
           line_item,
+          calculable.promotion,
           preferred_amount
         ).amount
       else

--- a/core/app/models/spree/distributed_amounts_handler.rb
+++ b/core/app/models/spree/distributed_amounts_handler.rb
@@ -9,9 +9,9 @@ module Spree
       @total_amount = total_amount
     end
 
-    # @return [Float] the weighted adjustment for the initialized line item
+    # @return [BigDecimal] the weighted adjustment for the initialized line item
     def amount
-      distributed_amounts[@line_item.id].to_f
+      distributed_amounts[@line_item.id].to_d
     end
 
     private

--- a/core/spec/models/spree/calculator/distributed_amount_spec.rb
+++ b/core/spec/models/spree/calculator/distributed_amount_spec.rb
@@ -69,6 +69,7 @@ RSpec.describe Spree::Calculator::DistributedAmount, type: :model do
     context "when the order currency matches the store's currency" do
       let(:currency) { "USD" }
       it { is_expected.to eq 5 }
+      it { is_expected.to be_a BigDecimal }
     end
 
     context "when the order currency does not match the store's currency" do

--- a/core/spec/models/spree/calculator/distributed_amount_spec.rb
+++ b/core/spec/models/spree/calculator/distributed_amount_spec.rb
@@ -2,6 +2,52 @@ require 'rails_helper'
 require 'shared_examples/calculator_shared_examples'
 
 RSpec.describe Spree::Calculator::DistributedAmount, type: :model do
+  context 'applied to an order' do
+    let(:calculator) { Spree::Calculator::DistributedAmount.new }
+    let(:promotion) {
+      create :promotion,
+        name: '15 spread'
+    }
+    let(:order) {
+      create :completed_order_with_promotion,
+        promotion: promotion,
+        line_items_attributes: [{ price: 20 }, { price: 30 }, { price: 100 }]
+    }
+
+    before do
+      calculator.preferred_amount = 15
+      Spree::Promotion::Actions::CreateItemAdjustments.create!(calculator: calculator, promotion: promotion)
+      order.recalculate
+    end
+
+    it 'correctly distributes the entire discount' do
+      expect(order.promo_total).to eq(-15)
+      expect(order.line_items.map(&:adjustment_total)).to eq([-2, -3, -10])
+    end
+
+    context 'with product promotion rule' do
+      let(:first_product) { order.line_items.first.product }
+
+      before do
+        rule = Spree::Promotion::Rules::Product.create!(
+          promotion: promotion,
+          product_promotion_rules: [
+            Spree::ProductPromotionRule.new(product: first_product),
+          ],
+        )
+        promotion.rules << rule
+        promotion.save!
+        order.recalculate
+      end
+
+      it 'still distributes the entire discount' do
+        pending('over allocation to elligible line items')
+        expect(order.promo_total).to eq(-15)
+        expect(order.line_items.map(&:adjustment_total)).to eq([-15, 0, 0])
+      end
+    end
+  end
+
   describe "#compute_line_item" do
     subject { calculator.compute_line_item(order.line_items.first) }
 

--- a/core/spec/models/spree/calculator/distributed_amount_spec.rb
+++ b/core/spec/models/spree/calculator/distributed_amount_spec.rb
@@ -41,7 +41,6 @@ RSpec.describe Spree::Calculator::DistributedAmount, type: :model do
       end
 
       it 'still distributes the entire discount' do
-        pending('over allocation to elligible line items')
         expect(order.promo_total).to eq(-15)
         expect(order.line_items.map(&:adjustment_total)).to eq([-15, 0, 0])
       end
@@ -52,6 +51,7 @@ RSpec.describe Spree::Calculator::DistributedAmount, type: :model do
     subject { calculator.compute_line_item(order.line_items.first) }
 
     let(:calculator) { Spree::Calculator::DistributedAmount.new }
+    let(:promotion) { create(:promotion) }
 
     let(:order) do
       FactoryBot.create(
@@ -63,6 +63,7 @@ RSpec.describe Spree::Calculator::DistributedAmount, type: :model do
     before do
       calculator.preferred_amount = 15
       calculator.preferred_currency = currency
+      Spree::Promotion::Actions::CreateItemAdjustments.create!(calculator: calculator, promotion: promotion)
     end
 
     context "when the order currency matches the store's currency" do

--- a/core/spec/models/spree/distributed_amounts_handler_spec.rb
+++ b/core/spec/models/spree/distributed_amounts_handler_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Spree::DistributedAmountsHandler, type: :model do
                 described_class.new(order.line_items[1], total_amount).amount,
                 described_class.new(order.line_items[2], total_amount).amount
               ]
-            ).to eq(
+            ).to match_array(
               [3.33, 3.33, 3.34]
             )
           end

--- a/core/spec/models/spree/distributed_amounts_handler_spec.rb
+++ b/core/spec/models/spree/distributed_amounts_handler_spec.rb
@@ -7,19 +7,20 @@ RSpec.describe Spree::DistributedAmountsHandler, type: :model do
       line_items_attributes: line_items_attributes
     )
   end
-  let(:promotion) { FactoryBot.build(:promotion) }
+
+  let(:handler) {
+    described_class.new(order.line_items, total_amount)
+  }
 
   describe "#amount" do
     let(:total_amount) { 15 }
-
-    subject { described_class.new(line_item, promotion, total_amount).amount }
 
     context "when there is only one line item" do
       let(:line_items_attributes) { [{ price: 100 }] }
       let(:line_item) { order.line_items.first }
 
       it "applies the entire amount to the line item" do
-        expect(subject).to eq(15)
+        expect(handler.amount(line_item)).to eq(15)
       end
     end
 
@@ -32,9 +33,9 @@ RSpec.describe Spree::DistributedAmountsHandler, type: :model do
         it "evenly distributes the total amount" do
           expect(
             [
-              described_class.new(order.line_items[0], promotion, total_amount).amount,
-              described_class.new(order.line_items[1], promotion, total_amount).amount,
-              described_class.new(order.line_items[2], promotion, total_amount).amount
+              handler.amount(order.line_items[0]),
+              handler.amount(order.line_items[1]),
+              handler.amount(order.line_items[2])
             ]
           ).to eq(
             [5, 5, 5]
@@ -47,9 +48,9 @@ RSpec.describe Spree::DistributedAmountsHandler, type: :model do
           it "applies the remainder of the total amount to the last item" do
             expect(
               [
-                described_class.new(order.line_items[0], promotion, total_amount).amount,
-                described_class.new(order.line_items[1], promotion, total_amount).amount,
-                described_class.new(order.line_items[2], promotion, total_amount).amount
+                handler.amount(order.line_items[0]),
+                handler.amount(order.line_items[1]),
+                handler.amount(order.line_items[2])
               ]
             ).to match_array(
               [3.33, 3.33, 3.34]
@@ -66,9 +67,9 @@ RSpec.describe Spree::DistributedAmountsHandler, type: :model do
         it "distributes the total amount relative to the item's price" do
           expect(
             [
-              described_class.new(order.line_items[0], promotion, total_amount).amount,
-              described_class.new(order.line_items[1], promotion, total_amount).amount,
-              described_class.new(order.line_items[2], promotion, total_amount).amount
+              handler.amount(order.line_items[0]),
+              handler.amount(order.line_items[1]),
+              handler.amount(order.line_items[2])
             ]
           ).to eq(
             [7.5, 2.5, 5]

--- a/core/spec/models/spree/distributed_amounts_handler_spec.rb
+++ b/core/spec/models/spree/distributed_amounts_handler_spec.rb
@@ -7,11 +7,12 @@ RSpec.describe Spree::DistributedAmountsHandler, type: :model do
       line_items_attributes: line_items_attributes
     )
   end
+  let(:promotion) { FactoryBot.build(:promotion) }
 
   describe "#amount" do
     let(:total_amount) { 15 }
 
-    subject { described_class.new(line_item, total_amount).amount }
+    subject { described_class.new(line_item, promotion, total_amount).amount }
 
     context "when there is only one line item" do
       let(:line_items_attributes) { [{ price: 100 }] }
@@ -31,9 +32,9 @@ RSpec.describe Spree::DistributedAmountsHandler, type: :model do
         it "evenly distributes the total amount" do
           expect(
             [
-              described_class.new(order.line_items[0], total_amount).amount,
-              described_class.new(order.line_items[1], total_amount).amount,
-              described_class.new(order.line_items[2], total_amount).amount
+              described_class.new(order.line_items[0], promotion, total_amount).amount,
+              described_class.new(order.line_items[1], promotion, total_amount).amount,
+              described_class.new(order.line_items[2], promotion, total_amount).amount
             ]
           ).to eq(
             [5, 5, 5]
@@ -46,9 +47,9 @@ RSpec.describe Spree::DistributedAmountsHandler, type: :model do
           it "applies the remainder of the total amount to the last item" do
             expect(
               [
-                described_class.new(order.line_items[0], total_amount).amount,
-                described_class.new(order.line_items[1], total_amount).amount,
-                described_class.new(order.line_items[2], total_amount).amount
+                described_class.new(order.line_items[0], promotion, total_amount).amount,
+                described_class.new(order.line_items[1], promotion, total_amount).amount,
+                described_class.new(order.line_items[2], promotion, total_amount).amount
               ]
             ).to match_array(
               [3.33, 3.33, 3.34]
@@ -65,9 +66,9 @@ RSpec.describe Spree::DistributedAmountsHandler, type: :model do
         it "distributes the total amount relative to the item's price" do
           expect(
             [
-              described_class.new(order.line_items[0], total_amount).amount,
-              described_class.new(order.line_items[1], total_amount).amount,
-              described_class.new(order.line_items[2], total_amount).amount
+              described_class.new(order.line_items[0], promotion, total_amount).amount,
+              described_class.new(order.line_items[1], promotion, total_amount).amount,
+              described_class.new(order.line_items[2], promotion, total_amount).amount
             ]
           ).to eq(
             [7.5, 2.5, 5]

--- a/core/spec/models/spree/distributed_amounts_handler_spec.rb
+++ b/core/spec/models/spree/distributed_amounts_handler_spec.rb
@@ -57,9 +57,9 @@ RSpec.describe Spree::DistributedAmountsHandler, type: :model do
         end
       end
 
-      context "and the line items are not equally priced" do
+      context "and the line items do not have equal subtotal amounts" do
         let(:line_items_attributes) do
-          [{ price: 150 }, { price: 50 }, { price: 100 }]
+          [{ price: 50, quantity: 3 }, { price: 50, quantity: 1 }, { price: 50, quantity: 2 }]
         end
 
         it "distributes the total amount relative to the item's price" do


### PR DESCRIPTION
There's a surprising interaction between the distributed amount calculator and the product promotion rule. The entire discount amount is distributed among _all_ of an order's line_items, but only adjustments on line_items that match the promotion rule are considered "actionable" and contribute towards the order promo total.

https://github.com/solidusio/solidus/blob/master/core/app/models/spree/promotion/actions/create_item_adjustments.rb#L32

This means that as you add products to your cart, your discount can actually go _down_, which I don't imagine is a behaviour anyone would want.

![screen shot 2018-02-18 at 10 11 59 am](https://user-images.githubusercontent.com/1529452/36355157-39d2219a-1494-11e8-9007-fcef5aa8173d.png)

Here the total discount has dropped from the preferred amount of $10 to ($22.99 / $38.98) = $5.90 the portion of the discount which was distributed to the item on sale.

I think there's larger discussion to be had about line item adjustments, but for now I'd just like to fix this one calculator. If only "actionable" line items can receive an adjustment then we need to distribute the desired amount among only those line items.

![screen shot 2018-02-18 at 10 41 00 am](https://user-images.githubusercontent.com/1529452/36355452-3f79066e-1498-11e8-8641-d2394774dcd7.png)
