### PR TITLE
Use solidus_auth_devise GitHub master for sandbox

### DIFF
--- a/lib/sandbox.sh
+++ b/lib/sandbox.sh
@@ -36,7 +36,7 @@ fi
 
 cd ./sandbox
 echo "gem 'solidus', :path => '..'" >> Gemfile
-echo "gem 'solidus_auth_devise'" >> Gemfile
+echo "gem 'solidus_auth_devise', '>= 2.1.0'" >> Gemfile
 
 cat <<RUBY >> Gemfile
 group :test, :development do


### PR DESCRIPTION
We need at least the 2.1 gem release of solidus auth devise, because we dropped the deface dependency in Solidus 2.5.0.
    
Without this might break the sandbox (the build in demo app), if people have an older version of solidus auth devise installed.