### PR TITLE
Properly limit per-quantity calculator types

### DIFF
--- a/backend/app/views/spree/admin/promotions/actions/_create_quantity_adjustments.html.erb
+++ b/backend/app/views/spree/admin/promotions/actions/_create_quantity_adjustments.html.erb
@@ -4,5 +4,8 @@
   <%= number_field_tag field_name, promotion_action.preferred_group_size, class: "fullwidth", min: 1 %>
 </div>
 
-<%= render "spree/admin/promotions/actions/create_item_adjustments",
-  promotion_action: promotion_action, param_prefix: param_prefix %>
+<%= render "spree/admin/promotions/actions/promotion_calculators_with_custom_fields",
+  calculators: Rails.application.config.spree.calculators.promotion_actions_create_quantity_adjustments,
+  promotion_action: promotion_action,
+  param_prefix: param_prefix
+%>


### PR DESCRIPTION
item-adjustments and quantity-adjustments have their own config for allowed calculators. When presenting a list of calculators for admins editing promos we need to respect that config.

## Before

![screen shot 2018-02-20 at 2 42 54 pm](https://user-images.githubusercontent.com/1529452/36453426-cecf865c-164c-11e8-8169-923832177c1b.png)


## After

![screen shot 2018-02-20 at 2 43 12 pm](https://user-images.githubusercontent.com/1529452/36453435-d3fb814e-164c-11e8-83d3-0cdde030782f.png)
