### PR TITLE
Avoid frozen string error in button helper

### DIFF
--- a/backend/app/helpers/spree/admin/navigation_helper.rb
+++ b/backend/app/helpers/spree/admin/navigation_helper.rb
@@ -128,7 +128,7 @@ module Spree
         class_names = "button"
         if icon_name
           Spree::Deprecation.warn "Using icon_name arg is deprecated. Icons could not be visible in future versions.", caller
-          class_names.prepend "fa fa-#{icon_name} "
+          class_names = "fa fa-#{icon_name} #{class_names}"
         end
         button_tag(text, options.merge(type: button_type, class: class_names))
       end


### PR DESCRIPTION
When button was passed an icon_name, which is deprecated but still prevalent in extensions, it would error with "can't modify frozen String".

This commit avoids the issue by using string interpolation instead.