### PR TITLE
Remove foreign key from store_shipping_methods

### DIFF
--- a/core/db/migrate/20180202222641_create_store_shipping_methods.rb
+++ b/core/db/migrate/20180202222641_create_store_shipping_methods.rb
@@ -1,8 +1,8 @@
 class CreateStoreShippingMethods < ActiveRecord::Migration[5.1]
   def change
     create_table :spree_store_shipping_methods do |t|
-      t.references :store, foreign_key: { to_table: "spree_stores" }
-      t.references :shipping_method, foreign_key: { to_table: "spree_shipping_methods" }
+      t.references :store, null: false
+      t.references :shipping_method, null: false
 
       t.timestamps
     end


### PR DESCRIPTION
This didn't work under MySQL because there was a mismatch between the type of the tables' PK and the reference because of Rails 5.1's move to bigint.

It would be nice to have a foreign key here, but it must work.