### PR TITLE
Generate new stores with MySQL timestamp precision 6

### DIFF
--- a/core/db/migrate/20160101010000_solidus_one_four.rb
+++ b/core/db/migrate/20160101010000_solidus_one_four.rb
@@ -29,8 +29,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
       t.string   "login"
       t.integer  "ship_address_id"
       t.integer  "bill_address_id"
-      t.datetime "created_at", null: false
-      t.datetime "updated_at", null: false
+      t.datetime "created_at", null: false, precision: 6
+      t.datetime "updated_at", null: false, precision: 6
       t.string   "openid_identifier"
     end
 
@@ -39,8 +39,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
       t.integer "sluggable_id", null: false
       t.string "sluggable_type", limit: 50
       t.string "scope"
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.index ["slug", "sluggable_type", "scope"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type_and_scope", unique: true
       t.index ["slug", "sluggable_type"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type"
       t.index ["sluggable_id"], name: "index_friendly_id_slugs_on_sluggable_id"
@@ -60,8 +60,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
       t.string "company"
       t.integer "state_id"
       t.integer "country_id"
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.index ["country_id"], name: "index_spree_addresses_on_country_id"
       t.index ["firstname"], name: "index_addresses_on_firstname"
       t.index ["lastname"], name: "index_addresses_on_lastname"
@@ -72,8 +72,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
       t.string "name"
       t.string "code"
       t.boolean "active", default: true
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.index ["active"], name: "index_spree_adjustment_reasons_on_active"
       t.index ["code"], name: "index_spree_adjustment_reasons_on_code"
     end
@@ -86,8 +86,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
       t.decimal "amount", precision: 10, scale: 2
       t.string "label"
       t.boolean "eligible", default: true
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.integer "order_id", null: false
       t.boolean "included", default: false
       t.integer "promotion_code_id"
@@ -113,8 +113,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
       t.string "type", limit: 75
       t.datetime "attachment_updated_at"
       t.text "alt"
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.index ["viewable_id"], name: "index_assets_on_viewable_id"
       t.index ["viewable_type", "type"], name: "index_assets_on_viewable_type_and_type"
     end
@@ -123,8 +123,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
       t.string "type"
       t.string "calculable_type"
       t.integer "calculable_id"
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.text "preferences"
       t.index ["calculable_id", "calculable_type"], name: "index_spree_calculators_on_calculable_id_and_calculable_type"
       t.index ["id", "type"], name: "index_spree_calculators_on_id_and_type"
@@ -138,8 +138,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
       t.integer "shipping_method_id"
       t.string "tracking"
       t.datetime "shipped_at"
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.integer "imported_from_shipment_id"
       t.index ["external_number"], name: "index_spree_cartons_on_external_number"
       t.index ["imported_from_shipment_id"], name: "index_spree_cartons_on_imported_from_shipment_id", unique: true
@@ -154,8 +154,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
       t.string "name"
       t.integer "numcode"
       t.boolean "states_required", default: false
-      t.datetime "updated_at"
-      t.datetime "created_at"
+      t.datetime "updated_at", precision: 6
+      t.datetime "created_at", precision: 6
       t.index ["iso"], name: "index_spree_countries_on_iso"
     end
 
@@ -166,8 +166,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
       t.string "last_digits"
       t.string "gateway_customer_profile_id"
       t.string "gateway_payment_profile_id"
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.string "name"
       t.integer "user_id"
       t.integer "payment_method_id"
@@ -180,8 +180,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
     create_table "spree_customer_returns", force: :cascade do |t|
       t.string "number"
       t.integer "stock_location_id"
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
     end
 
     create_table "spree_inventory_units", force: :cascade do |t|
@@ -189,8 +189,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
       t.integer "variant_id"
       t.integer "order_id"
       t.integer "shipment_id"
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.boolean "pending", default: true
       t.integer "line_item_id"
       t.integer "carton_id"
@@ -205,8 +205,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
       t.integer "line_item_id", null: false
       t.integer "action_id", null: false
       t.integer "quantity", default: 0
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.index ["action_id"], name: "index_spree_line_item_actions_on_action_id"
       t.index ["line_item_id"], name: "index_spree_line_item_actions_on_line_item_id"
     end
@@ -216,8 +216,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
       t.integer "order_id"
       t.integer "quantity", null: false
       t.decimal "price", precision: 10, scale: 2, null: false
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.string "currency"
       t.decimal "cost_price", precision: 10, scale: 2
       t.integer "tax_category_id"
@@ -233,24 +233,24 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
       t.string "source_type"
       t.integer "source_id"
       t.text "details"
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.index ["source_id", "source_type"], name: "index_spree_log_entries_on_source_id_and_source_type"
     end
 
     create_table "spree_option_type_prototypes", force: :cascade do |t|
       t.integer "prototype_id"
       t.integer "option_type_id"
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
     end
 
     create_table "spree_option_types", force: :cascade do |t|
       t.string "name", limit: 100
       t.string "presentation", limit: 100
       t.integer "position", default: 0, null: false
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.index ["position"], name: "index_spree_option_types_on_position"
     end
 
@@ -259,8 +259,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
       t.string "name"
       t.string "presentation"
       t.integer "option_type_id"
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.index ["option_type_id"], name: "index_spree_option_values_on_option_type_id"
       t.index ["position"], name: "index_spree_option_values_on_position"
     end
@@ -268,15 +268,15 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
     create_table "spree_option_values_variants", force: :cascade do |t|
       t.integer "variant_id"
       t.integer "option_value_id"
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.index ["variant_id", "option_value_id"], name: "index_option_values_variants_on_variant_id_and_option_value_id"
       t.index ["variant_id"], name: "index_spree_option_values_variants_on_variant_id"
     end
 
     create_table "spree_order_mutexes", force: :cascade do |t|
       t.integer "order_id", null: false
-      t.datetime "created_at"
+      t.datetime "created_at", precision: 6
       t.index ["order_id"], name: "index_spree_order_mutexes_on_order_id", unique: true
     end
 
@@ -295,8 +295,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
       t.string "payment_state"
       t.string "email"
       t.text "special_instructions"
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.string "currency"
       t.string "last_ip_address"
       t.integer "created_by_id"
@@ -330,8 +330,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
       t.integer "order_id"
       t.integer "promotion_id"
       t.integer "promotion_code_id"
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.index ["order_id", "promotion_id"], name: "index_spree_orders_promotions_on_order_id_and_promotion_id"
       t.index ["promotion_code_id"], name: "index_spree_orders_promotions_on_promotion_code_id"
     end
@@ -339,8 +339,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
     create_table "spree_payment_capture_events", force: :cascade do |t|
       t.decimal "amount", precision: 10, scale: 2, default: "0.0"
       t.integer "payment_id"
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.index ["payment_id"], name: "index_spree_payment_capture_events_on_payment_id"
     end
 
@@ -350,8 +350,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
       t.text "description"
       t.boolean "active", default: true
       t.datetime "deleted_at"
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.string "display_on"
       t.boolean "auto_capture"
       t.text "preferences"
@@ -369,8 +369,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
       t.string "state"
       t.string "response_code"
       t.string "avs_response"
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.string "number"
       t.string "cvv_response_code"
       t.string "cvv_response_message"
@@ -382,8 +382,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
     create_table "spree_preferences", force: :cascade do |t|
       t.text "value"
       t.string "key"
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.index ["key"], name: "index_spree_preferences_on_key", unique: true
     end
 
@@ -393,8 +393,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
       t.string "currency"
       t.datetime "deleted_at"
       t.boolean "is_default", default: true, null: false
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.string "country_iso", limit: 2
       t.index ["country_iso"], name: "index_spree_prices_on_country_iso"
       t.index ["variant_id", "currency"], name: "index_spree_prices_on_variant_id_and_currency"
@@ -404,8 +404,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
       t.integer "position"
       t.integer "product_id"
       t.integer "option_type_id"
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.index ["option_type_id"], name: "index_spree_product_option_types_on_option_type_id"
       t.index ["position"], name: "index_spree_product_option_types_on_position"
       t.index ["product_id"], name: "index_spree_product_option_types_on_product_id"
@@ -414,8 +414,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
     create_table "spree_product_promotion_rules", force: :cascade do |t|
       t.integer "product_id"
       t.integer "promotion_rule_id"
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.index ["product_id"], name: "index_products_promotion_rules_on_product_id"
       t.index ["promotion_rule_id"], name: "index_products_promotion_rules_on_promotion_rule_id"
     end
@@ -424,8 +424,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
       t.string "value"
       t.integer "product_id"
       t.integer "property_id"
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.integer "position", default: 0
       t.index ["position"], name: "index_spree_product_properties_on_position"
       t.index ["product_id"], name: "index_product_properties_on_product_id"
@@ -442,8 +442,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
       t.string "meta_keywords"
       t.integer "tax_category_id"
       t.integer "shipping_category_id"
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.boolean "promotionable", default: true
       t.string "meta_title"
       t.index ["available_on"], name: "index_spree_products_on_available_on"
@@ -456,8 +456,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
       t.integer "product_id"
       t.integer "taxon_id"
       t.integer "position"
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.index ["position"], name: "index_spree_products_taxons_on_position"
       t.index ["product_id"], name: "index_spree_products_taxons_on_product_id"
       t.index ["taxon_id"], name: "index_spree_products_taxons_on_taxon_id"
@@ -467,8 +467,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
       t.integer "promotion_action_id"
       t.integer "variant_id"
       t.integer "quantity", default: 1
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.index ["promotion_action_id"], name: "index_spree_promotion_action_line_items_on_promotion_action_id"
       t.index ["variant_id"], name: "index_spree_promotion_action_line_items_on_variant_id"
     end
@@ -479,8 +479,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
       t.string "type"
       t.datetime "deleted_at"
       t.text "preferences"
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.index ["deleted_at"], name: "index_spree_promotion_actions_on_deleted_at"
       t.index ["id", "type"], name: "index_spree_promotion_actions_on_id_and_type"
       t.index ["promotion_id"], name: "index_spree_promotion_actions_on_promotion_id"
@@ -488,16 +488,16 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
 
     create_table "spree_promotion_categories", force: :cascade do |t|
       t.string "name"
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.string "code"
     end
 
     create_table "spree_promotion_codes", force: :cascade do |t|
       t.integer "promotion_id", null: false
       t.string "value", null: false
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.index ["promotion_id"], name: "index_spree_promotion_codes_on_promotion_id"
       t.index ["value"], name: "index_spree_promotion_codes_on_value", unique: true
     end
@@ -505,8 +505,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
     create_table "spree_promotion_rule_taxons", force: :cascade do |t|
       t.integer "taxon_id"
       t.integer "promotion_rule_id"
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.index ["promotion_rule_id"], name: "index_spree_promotion_rule_taxons_on_promotion_rule_id"
       t.index ["taxon_id"], name: "index_spree_promotion_rule_taxons_on_taxon_id"
     end
@@ -515,8 +515,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
       t.integer "promotion_id"
       t.integer "product_group_id"
       t.string "type"
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.string "code"
       t.text "preferences"
       t.index ["product_group_id"], name: "index_promotion_rules_on_product_group_id"
@@ -526,8 +526,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
     create_table "spree_promotion_rules_users", force: :cascade do |t|
       t.integer "user_id"
       t.integer "promotion_rule_id"
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.index ["promotion_rule_id"], name: "index_promotion_rules_users_on_promotion_rule_id"
       t.index ["user_id"], name: "index_promotion_rules_users_on_user_id"
     end
@@ -543,8 +543,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
       t.string "code"
       t.boolean "advertise", default: false
       t.string "path"
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.integer "promotion_category_id"
       t.integer "per_code_usage_limit"
       t.boolean "apply_automatically", default: false
@@ -560,38 +560,38 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
     create_table "spree_properties", force: :cascade do |t|
       t.string "name"
       t.string "presentation", null: false
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
     end
 
     create_table "spree_property_prototypes", force: :cascade do |t|
       t.integer "prototype_id"
       t.integer "property_id"
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
     end
 
     create_table "spree_prototype_taxons", force: :cascade do |t|
       t.integer "taxon_id"
       t.integer "prototype_id"
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.index ["prototype_id"], name: "index_spree_prototype_taxons_on_prototype_id"
       t.index ["taxon_id"], name: "index_spree_prototype_taxons_on_taxon_id"
     end
 
     create_table "spree_prototypes", force: :cascade do |t|
       t.string "name"
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
     end
 
     create_table "spree_refund_reasons", force: :cascade do |t|
       t.string "name"
       t.boolean "active", default: true
       t.boolean "mutable", default: true
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.string "code"
     end
 
@@ -599,8 +599,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
       t.integer "payment_id"
       t.decimal "amount", precision: 10, scale: 2, default: "0.0", null: false
       t.string "transaction_id"
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.integer "refund_reason_id"
       t.integer "reimbursement_id"
       t.index ["payment_id"], name: "index_spree_refunds_on_payment_id"
@@ -613,16 +613,16 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
       t.integer "reimbursement_id"
       t.integer "creditable_id"
       t.string "creditable_type"
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
     end
 
     create_table "spree_reimbursement_types", force: :cascade do |t|
       t.string "name"
       t.boolean "active", default: true
       t.boolean "mutable", default: true
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.string "type"
       t.index ["type"], name: "index_spree_reimbursement_types_on_type"
     end
@@ -633,8 +633,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
       t.integer "customer_return_id"
       t.integer "order_id"
       t.decimal "total", precision: 10, scale: 2
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.index ["customer_return_id"], name: "index_spree_reimbursements_on_customer_return_id"
       t.index ["order_id"], name: "index_spree_reimbursements_on_order_id"
     end
@@ -644,8 +644,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
       t.string "state"
       t.integer "order_id"
       t.text "memo"
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.integer "stock_location_id"
       t.integer "return_reason_id"
       t.index ["return_reason_id"], name: "index_return_authorizations_on_return_authorization_reason_id"
@@ -655,8 +655,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
       t.integer "return_authorization_id"
       t.integer "inventory_unit_id"
       t.integer "exchange_variant_id"
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.decimal "amount", precision: 12, scale: 4, default: "0.0", null: false
       t.decimal "included_tax_total", precision: 12, scale: 4, default: "0.0", null: false
       t.decimal "additional_tax_total", precision: 12, scale: 4, default: "0.0", null: false
@@ -678,21 +678,21 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
       t.string "name"
       t.boolean "active", default: true
       t.boolean "mutable", default: true
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
     end
 
     create_table "spree_roles", force: :cascade do |t|
       t.string "name"
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
     end
 
     create_table "spree_roles_users", force: :cascade do |t|
       t.integer "role_id"
       t.integer "user_id"
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.index ["role_id"], name: "index_spree_roles_users_on_role_id"
       t.index ["user_id"], name: "index_spree_roles_users_on_user_id"
     end
@@ -705,8 +705,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
       t.integer "order_id"
       t.integer "deprecated_address_id"
       t.string "state"
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.integer "stock_location_id"
       t.decimal "adjustment_total", precision: 10, scale: 2, default: "0.0"
       t.decimal "additional_tax_total", precision: 10, scale: 2, default: "0.0"
@@ -720,15 +720,15 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
 
     create_table "spree_shipping_categories", force: :cascade do |t|
       t.string "name"
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
     end
 
     create_table "spree_shipping_method_categories", force: :cascade do |t|
       t.integer "shipping_method_id", null: false
       t.integer "shipping_category_id", null: false
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.index ["shipping_category_id", "shipping_method_id"], name: "unique_spree_shipping_method_categories", unique: true
       t.index ["shipping_method_id"], name: "index_spree_shipping_method_categories_on_shipping_method_id"
     end
@@ -736,8 +736,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
     create_table "spree_shipping_method_stock_locations", force: :cascade do |t|
       t.integer "shipping_method_id"
       t.integer "stock_location_id"
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.index ["shipping_method_id"], name: "shipping_method_id_spree_sm_sl"
       t.index ["stock_location_id"], name: "sstock_location_id_spree_sm_sl"
     end
@@ -745,16 +745,16 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
     create_table "spree_shipping_method_zones", force: :cascade do |t|
       t.integer "shipping_method_id"
       t.integer "zone_id"
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
     end
 
     create_table "spree_shipping_methods", force: :cascade do |t|
       t.string "name"
       t.string "display_on"
       t.datetime "deleted_at"
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.string "tracking_url"
       t.string "admin_name"
       t.integer "tax_category_id"
@@ -769,8 +769,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
       t.decimal "amount", precision: 8, scale: 2, default: "0.0", null: false
       t.integer "tax_rate_id"
       t.integer "shipping_rate_id"
-      t.datetime "created_at", null: false
-      t.datetime "updated_at", null: false
+      t.datetime "created_at", null: false, precision: 6
+      t.datetime "updated_at", null: false, precision: 6
       t.index ["shipping_rate_id"], name: "index_spree_shipping_rate_taxes_on_shipping_rate_id"
       t.index ["tax_rate_id"], name: "index_spree_shipping_rate_taxes_on_tax_rate_id"
     end
@@ -780,8 +780,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
       t.integer "shipping_method_id"
       t.boolean "selected", default: false
       t.decimal "cost", precision: 8, scale: 2, default: "0.0"
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.integer "tax_rate_id"
       t.index ["shipment_id", "shipping_method_id"], name: "spree_shipping_rates_join_index", unique: true
     end
@@ -793,8 +793,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
       t.integer "user_id"
       t.string "stateful_type"
       t.string "next_state"
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.index ["stateful_id", "stateful_type"], name: "index_spree_state_changes_on_stateful_id_and_stateful_type"
       t.index ["user_id"], name: "index_spree_state_changes_on_user_id"
     end
@@ -803,8 +803,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
       t.string "name"
       t.string "abbr"
       t.integer "country_id"
-      t.datetime "updated_at"
-      t.datetime "created_at"
+      t.datetime "updated_at", precision: 6
+      t.datetime "created_at", precision: 6
       t.index ["country_id"], name: "index_spree_states_on_country_id"
     end
 
@@ -812,8 +812,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
       t.integer "stock_location_id"
       t.integer "variant_id"
       t.integer "count_on_hand", default: 0, null: false
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.boolean "backorderable", default: false
       t.datetime "deleted_at"
       t.index ["deleted_at"], name: "index_spree_stock_items_on_deleted_at"
@@ -827,8 +827,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
 
     create_table "spree_stock_locations", force: :cascade do |t|
       t.string "name"
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.boolean "default", default: false, null: false
       t.string "address1"
       t.string "address2"
@@ -855,8 +855,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
       t.integer "stock_item_id"
       t.integer "quantity", default: 0
       t.string "action"
-      t.datetime "created_at", null: false
-      t.datetime "updated_at", null: false
+      t.datetime "created_at", null: false, precision: 6
+      t.datetime "updated_at", null: false, precision: 6
       t.string "originator_type"
       t.integer "originator_id"
       t.index ["stock_item_id"], name: "index_spree_stock_movements_on_stock_item_id"
@@ -864,8 +864,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
 
     create_table "spree_store_credit_categories", force: :cascade do |t|
       t.string "name"
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
     end
 
     create_table "spree_store_credit_events", force: :cascade do |t|
@@ -877,8 +877,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
       t.datetime "deleted_at"
       t.string "originator_type"
       t.integer "originator_id"
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.integer "update_reason_id"
       t.index ["deleted_at"], name: "index_spree_store_credit_events_on_deleted_at"
       t.index ["store_credit_id"], name: "index_spree_store_credit_events_on_store_credit_id"
@@ -887,15 +887,15 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
     create_table "spree_store_credit_types", force: :cascade do |t|
       t.string "name"
       t.integer "priority"
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.index ["priority"], name: "index_spree_store_credit_types_on_priority"
     end
 
     create_table "spree_store_credit_update_reasons", force: :cascade do |t|
       t.string "name"
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
     end
 
     create_table "spree_store_credits", force: :cascade do |t|
@@ -909,8 +909,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
       t.text "memo"
       t.datetime "spree_store_credits"
       t.datetime "deleted_at"
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.integer "type_id"
       t.datetime "invalidated_at"
       t.index ["deleted_at"], name: "index_spree_store_credits_on_deleted_at"
@@ -921,8 +921,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
     create_table "spree_store_payment_methods", force: :cascade do |t|
       t.integer "store_id", null: false
       t.integer "payment_method_id", null: false
-      t.datetime "created_at", null: false
-      t.datetime "updated_at", null: false
+      t.datetime "created_at", null: false, precision: 6
+      t.datetime "updated_at", null: false, precision: 6
       t.index ["payment_method_id"], name: "index_spree_store_payment_methods_on_payment_method_id"
       t.index ["store_id"], name: "index_spree_store_payment_methods_on_store_id"
     end
@@ -937,8 +937,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
       t.string "default_currency"
       t.string "code"
       t.boolean "default", default: false, null: false
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.string "cart_tax_country_iso"
       t.index ["code"], name: "index_spree_stores_on_code"
       t.index ["default"], name: "index_spree_stores_on_default"
@@ -949,8 +949,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
       t.string "description"
       t.boolean "is_default", default: false
       t.datetime "deleted_at"
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.string "tax_code"
     end
 
@@ -959,8 +959,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
       t.integer "zone_id"
       t.integer "tax_category_id"
       t.boolean "included_in_price", default: false
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.string "name"
       t.boolean "show_rate_in_label", default: true
       t.datetime "deleted_at"
@@ -971,8 +971,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
 
     create_table "spree_taxonomies", force: :cascade do |t|
       t.string "name", null: false
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.integer "position", default: 0
       t.index ["position"], name: "index_spree_taxonomies_on_position"
     end
@@ -990,8 +990,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
       t.integer "icon_file_size"
       t.datetime "icon_updated_at"
       t.text "description"
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.string "meta_title"
       t.string "meta_description"
       t.string "meta_keywords"
@@ -1006,8 +1006,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
       t.integer "inventory_unit_id", null: false
       t.string "reason"
       t.string "created_by"
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.index ["inventory_unit_id"], name: "index_spree_unit_cancels_on_inventory_unit_id"
     end
 
@@ -1016,8 +1016,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
       t.integer "address_id", null: false
       t.boolean "default", default: false
       t.boolean "archived", default: false
-      t.datetime "created_at", null: false
-      t.datetime "updated_at", null: false
+      t.datetime "created_at", null: false, precision: 6
+      t.datetime "updated_at", null: false, precision: 6
       t.index ["address_id"], name: "index_spree_user_addresses_on_address_id"
       t.index ["user_id", "address_id"], name: "index_spree_user_addresses_on_user_id_and_address_id", unique: true
       t.index ["user_id"], name: "index_spree_user_addresses_on_user_id"
@@ -1026,16 +1026,16 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
     create_table "spree_user_stock_locations", force: :cascade do |t|
       t.integer "user_id"
       t.integer "stock_location_id"
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.index ["user_id"], name: "index_spree_user_stock_locations_on_user_id"
     end
 
     create_table "spree_variant_property_rule_conditions", force: :cascade do |t|
       t.integer "option_value_id"
       t.integer "variant_property_rule_id"
-      t.datetime "created_at", null: false
-      t.datetime "updated_at", null: false
+      t.datetime "created_at", null: false, precision: 6
+      t.datetime "updated_at", null: false, precision: 6
       t.index ["variant_property_rule_id", "option_value_id"], name: "index_spree_variant_prop_rule_conditions_on_rule_and_optval"
     end
 
@@ -1044,16 +1044,16 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
       t.integer "position", default: 0
       t.integer "property_id"
       t.integer "variant_property_rule_id"
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.index ["property_id"], name: "index_spree_variant_property_rule_values_on_property_id"
       t.index ["variant_property_rule_id"], name: "index_spree_variant_property_rule_values_on_rule"
     end
 
     create_table "spree_variant_property_rules", force: :cascade do |t|
       t.integer "product_id"
-      t.datetime "created_at", null: false
-      t.datetime "updated_at", null: false
+      t.datetime "created_at", null: false, precision: 6
+      t.datetime "updated_at", null: false, precision: 6
       t.index ["product_id"], name: "index_spree_variant_property_rules_on_product_id"
     end
 
@@ -1071,8 +1071,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
       t.string "cost_currency"
       t.boolean "track_inventory", default: true
       t.integer "tax_category_id"
-      t.datetime "updated_at"
-      t.datetime "created_at"
+      t.datetime "updated_at", precision: 6
+      t.datetime "created_at", precision: 6
       t.index ["position"], name: "index_spree_variants_on_position"
       t.index ["product_id"], name: "index_spree_variants_on_product_id"
       t.index ["sku"], name: "index_spree_variants_on_sku"
@@ -1084,8 +1084,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
       t.string "zoneable_type"
       t.integer "zoneable_id"
       t.integer "zone_id"
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
       t.index ["zone_id"], name: "index_spree_zone_members_on_zone_id"
       t.index ["zoneable_id", "zoneable_type"], name: "index_spree_zone_members_on_zoneable_id_and_zoneable_type"
     end
@@ -1095,8 +1095,8 @@ class SolidusOneFour < ActiveRecord::Migration[5.0]
       t.string "description"
       t.boolean "default_tax", default: false
       t.integer "zone_members_count", default: 0
-      t.datetime "created_at"
-      t.datetime "updated_at"
+      t.datetime "created_at", precision: 6
+      t.datetime "updated_at", precision: 6
     end
   end
 end

--- a/core/db/migrate/20160420044191_create_spree_wallet_payment_sources.rb
+++ b/core/db/migrate/20160420044191_create_spree_wallet_payment_sources.rb
@@ -14,7 +14,7 @@ class CreateSpreeWalletPaymentSources < ActiveRecord::Migration[4.2]
       t.references :payment_source, polymorphic: true, null: false
       t.boolean :default, default: false, null: false
 
-      t.timestamps null: false
+      t.timestamps null: false, precision: 6
     end
 
     add_index(

--- a/core/db/migrate/20161017102621_create_spree_promotion_code_batch.rb
+++ b/core/db/migrate/20161017102621_create_spree_promotion_code_batch.rb
@@ -9,7 +9,7 @@ class CreateSpreePromotionCodeBatch < ActiveRecord::Migration[5.0]
       t.string :email
       t.string :error
       t.string :state, default: "pending"
-      t.timestamps
+      t.timestamps precision: 6
     end
 
     add_foreign_key(

--- a/core/db/migrate/20180202222641_create_store_shipping_methods.rb
+++ b/core/db/migrate/20180202222641_create_store_shipping_methods.rb
@@ -4,7 +4,7 @@ class CreateStoreShippingMethods < ActiveRecord::Migration[5.1]
       t.references :store, null: false
       t.references :shipping_method, null: false
 
-      t.timestamps
+      t.timestamps precision: 6
     end
   end
 end


### PR DESCRIPTION
Under MySQL, we end up with caching issues due to timestamps by default only having 1 second precision. In recent versions of MySQL this can be increased to microsecond precision by specifying precision.

There's another PR open, #2479, which will `ALTER TABLE` all existing tables to increase the precision. We haven't merged partly out of worry about how long the migration will take for existing users with large tables.

This PR instead creates the table with the correct precision to begin with. This won't fix the issue for existing users, but it will for new users (and our spec suite). For existing MySQL users we can recommend they copy in and apply the migration from #2479 at their own time.