### PR TITLE
Replace button_link_to with either button_to or link_to

### DIFF
--- a/backend/app/helpers/spree/admin/navigation_helper.rb
+++ b/backend/app/helpers/spree/admin/navigation_helper.rb
@@ -137,21 +137,19 @@ module Spree
       end
 
       def button_link_to(text, url, html_options = {})
+        Spree::Deprecation.warn "Passing button_link_to is deprecated. Use either link_to or button_to instead.", caller
         html_options = { class: '' }.merge(html_options)
         if html_options[:method] &&
            html_options[:method].to_s.downcase != 'get' &&
            !html_options[:remote]
           form_tag(url, method: html_options.delete(:method)) do
-            if html_options.delete(:icon)
-              Spree::Deprecation.warn "Passing :icon to button_link_to is deprecated and has no effect.", caller
-            end
+            html_options.delete(:icon)
             button_tag(text, html_options)
           end
         else
           html_options[:class] += ' button'
 
           if html_options[:icon]
-            Spree::Deprecation.warn "Using :icon option is deprecated. Icons could not be visible in future versions.", caller
             html_options[:class] += " fa fa-#{html_options[:icon]}"
           end
           link_to(text, url, html_options)

--- a/backend/app/helpers/spree/admin/orders_helper.rb
+++ b/backend/app/helpers/spree/admin/orders_helper.rb
@@ -8,9 +8,9 @@ module Spree
         links = []
         @order_events.sort.each do |event|
           next unless @order.send("can_#{event}?")
-          links << button_link_to(t(event, scope: 'spree'), [event, :admin, @order],
-                                  method: :put,
-                                  data: { confirm: t('spree.order_sure_want_to', event: t(event, scope: 'spree')) })
+          links << button_to(t(event, scope: 'spree'), [event, :admin, @order],
+                             method: :put,
+                             data: { confirm: t('spree.order_sure_want_to', event: t(event, scope: 'spree')) })
         end
         safe_join(links, '&nbsp;'.html_safe)
       end

--- a/backend/app/views/spree/admin/adjustment_reasons/index.html.erb
+++ b/backend/app/views/spree/admin/adjustment_reasons/index.html.erb
@@ -7,7 +7,7 @@
 <% content_for :page_actions do %>
   <ul class="actions inline-menu">
     <li>
-      <%= button_link_to t('spree.new_adjustment_reason'), new_object_url, { id: 'admin_new_named_type' } %>
+      <%= link_to t('spree.new_adjustment_reason'), new_object_url, id: 'admin_new_named_type', class: 'btn btn-primary' %>
     </li>
   </ul>
 <% end %>

--- a/backend/app/views/spree/admin/adjustments/index.html.erb
+++ b/backend/app/views/spree/admin/adjustments/index.html.erb
@@ -5,7 +5,7 @@
 <% content_for :page_actions do %>
   <% if can? :create, Spree::Adjustment %>
     <li>
-      <%= button_link_to t('spree.new_adjustment'), new_admin_order_adjustment_url(@order) %>
+      <%= link_to t('spree.new_adjustment'), new_admin_order_adjustment_url(@order), class: 'btn btn-primary' %>
     </li>
   <% end %>
 <% end %>

--- a/backend/app/views/spree/admin/adjustments/new.html.erb
+++ b/backend/app/views/spree/admin/adjustments/new.html.erb
@@ -15,7 +15,7 @@
 
     <div class="filter-actions actions" data-hook="buttons">
       <%= button_tag t('spree.continue'), class: 'btn btn-primary' %>
-      <%= button_link_to t('spree.actions.cancel'), admin_order_adjustments_url(@order) %>
+      <%= link_to t('spree.actions.cancel'), admin_order_adjustments_url(@order), class: 'btn btn-primary' %>
     </div>
   </fieldset>
 <% end %>

--- a/backend/app/views/spree/admin/customer_returns/index.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/index.html.erb
@@ -3,7 +3,7 @@
 <% content_for :page_actions do %>
   <% if can? :create, Spree::CustomerReturn %>
     <li>
-      <%= button_link_to t('spree.new_customer_return'), spree.new_admin_order_customer_return_path(@order) %>
+      <%= link_to t('spree.new_customer_return'), spree.new_admin_order_customer_return_path(@order), class: 'btn btn-primary' %>
     </li>
   <% end %>
 <% end %>

--- a/backend/app/views/spree/admin/customer_returns/new.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/new.html.erb
@@ -41,7 +41,7 @@
 
       <div class="form-buttons filter-actions actions" data-hook="buttons">
         <%= button_tag t('spree.actions.create'), class: 'btn btn-primary' %>
-        <%= button_link_to t('spree.actions.cancel'), admin_order_customer_returns_url(@order) %>
+        <%= link_to t('spree.actions.cancel'), admin_order_customer_returns_url(@order), class: 'btn btn-primary' %>
       </div>
     </fieldset>
   <% end %>

--- a/backend/app/views/spree/admin/images/edit.html.erb
+++ b/backend/app/views/spree/admin/images/edit.html.erb
@@ -7,7 +7,7 @@
 
 
 <% content_for :page_actions do %>
-  <li><%= button_link_to t('spree.back_to_images_list'), admin_product_images_url(@product) %></li>
+  <li><%= link_to t('spree.back_to_images_list'), admin_product_images_url(@product), class: 'btn btn-primary' %></li>
 <% end %>
 
 <%= form_for [:admin, @product, @image], html: { multipart: true } do |f| %>

--- a/backend/app/views/spree/admin/log_entries/index.html.erb
+++ b/backend/app/views/spree/admin/log_entries/index.html.erb
@@ -4,8 +4,8 @@
 <% admin_breadcrumb(plural_resource_name(Spree::LogEntry)) %>
 
 <% content_for :page_actions do %>
-  <li><%= button_link_to t('spree.logs'), spree.admin_order_payment_log_entries_url(@order, @payment) %></li>
-  <li><%= button_link_to t('spree.back_to_payment'), spree.admin_order_payment_url(@order, @payment) %></li>
+  <li><%= link_to t('spree.logs'), spree.admin_order_payment_log_entries_url(@order, @payment), class: 'btn btn-primary' %></li>
+  <li><%= link_to t('spree.back_to_payment'), spree.admin_order_payment_url(@order, @payment), class: 'btn btn-primary' %></li>
 <% end %>
 
 <table class='index' id='listing_log_entries'>

--- a/backend/app/views/spree/admin/option_types/index.html.erb
+++ b/backend/app/views/spree/admin/option_types/index.html.erb
@@ -5,7 +5,7 @@
 <% content_for :page_actions do %>
   <% if can?(:create, Spree::OptionType) %>
     <li id="new_ot_link">
-      <%= button_link_to t('spree.new_option_type'), new_admin_option_type_url, { remote: true, id: 'new_option_type_link' } %>
+      <%= link_to t('spree.new_option_type'), new_admin_option_type_url, remote: true, id: 'new_option_type_link', class: 'btn btn-primary' %>
     </li>
   <% end %>
 <% end %>

--- a/backend/app/views/spree/admin/orders/cart.html.erb
+++ b/backend/app/views/spree/admin/orders/cart.html.erb
@@ -1,9 +1,9 @@
 <% content_for :page_actions do %>
     <% if can?(:fire, @order) %>
-        <li><%= event_links %></li>
+      <li><%= event_links %></li>
     <% end %>
     <% if can?(:resend, @order) && @order.completed? %>
-        <li><%= button_link_to t('spree.resend'), resend_admin_order_url(@order), method: :post %></li>
+      <li><%= button_to t('spree.resend'), resend_admin_order_url(@order), method: :post %></li>
     <% end %>
 <% end %>
 

--- a/backend/app/views/spree/admin/orders/customer_details/show.html.erb
+++ b/backend/app/views/spree/admin/orders/customer_details/show.html.erb
@@ -4,7 +4,7 @@
 
 
 <% content_for :page_actions do %>
-  <li><%= button_link_to t('spree.back_to_orders_list'), admin_orders_path %></li>
+  <li><%= link_to t('spree.back_to_orders_list'), admin_orders_path, class: 'btn btn-primary' %></li>
 <% end %>
 
 

--- a/backend/app/views/spree/admin/orders/edit.html.erb
+++ b/backend/app/views/spree/admin/orders/edit.html.erb
@@ -3,7 +3,7 @@
     <li><%= event_links %></li>
   <% end %>
   <% if can?(:resend, @order) && @order.completed? %>
-    <li><%= button_link_to t('spree.resend'), resend_admin_order_url(@order), method: :post %></li>
+    <li><%= button_to t('spree.resend'), resend_admin_order_url(@order), method: :post, class: 'btn btn-primary' %></li>
   <% end %>
 <% end %>
 

--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -5,7 +5,7 @@
 
 <% content_for :page_actions do %>
   <li>
-    <%= button_link_to t('spree.new_order'), new_admin_order_url, id: 'admin_new_order' %>
+    <%= link_to t('spree.new_order'), new_admin_order_url, id: 'admin_new_order', class: 'btn btn-primary' %>
   </li>
 <% end if can? :create, Spree::Order %>
 

--- a/backend/app/views/spree/admin/payment_methods/index.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/index.html.erb
@@ -8,7 +8,7 @@
 <% content_for :page_actions do %>
   <% if can?(:create, Spree::PaymentMethod) %>
     <li>
-      <%= button_link_to t('spree.new_payment_method'), new_object_url, id: 'admin_new_payment_methods_link' %>
+      <%= link_to t('spree.new_payment_method'), new_object_url, id: 'admin_new_payment_methods_link', class: 'btn btn-primary' %>
     </li>
   <% end %>
 <% end %>

--- a/backend/app/views/spree/admin/payments/index.html.erb
+++ b/backend/app/views/spree/admin/payments/index.html.erb
@@ -3,7 +3,7 @@
 <% content_for :page_actions do %>
   <% if @order.outstanding_balance? %>
     <li id="new_payment_section">
-      <%= button_link_to t('spree.new_payment'), new_admin_order_payment_url(@order) %>
+      <%= link_to t('spree.new_payment'), new_admin_order_payment_url(@order), class: 'btn btn-primary' %>
     </li>
   <% end %>
 <% end %>

--- a/backend/app/views/spree/admin/payments/show.html.erb
+++ b/backend/app/views/spree/admin/payments/show.html.erb
@@ -10,7 +10,7 @@
 
 
 <% content_for :page_actions do %>
-  <li><%= button_link_to t('spree.logs'), spree.admin_order_payment_log_entries_url(@order, @payment) %></li>
+  <li><%= link_to t('spree.logs'), spree.admin_order_payment_log_entries_url(@order, @payment), class: 'btn btn-primary' %></li>
 <% end %>
 
 <%= render partial: "spree/admin/payments/source_views/#{@payment.payment_method.partial_name}", locals: { payment: @payment.source.is_a?(Spree::Payment) ? @payment.source : @payment } %>

--- a/backend/app/views/spree/admin/prices/index.html.erb
+++ b/backend/app/views/spree/admin/prices/index.html.erb
@@ -3,7 +3,7 @@
 
 <% content_for :page_actions do %>
   <li id="new_price_link">
-    <%= button_link_to t(".new_price"), new_object_url %>
+    <%= link_to t(".new_price"), new_object_url, class: 'btn btn-primary' %>
   </li>
 <% end if can?(:create, Spree::Product) %>
 

--- a/backend/app/views/spree/admin/products/edit.html.erb
+++ b/backend/app/views/spree/admin/products/edit.html.erb
@@ -1,7 +1,7 @@
 <% content_for :page_actions do %>
   <% if can?(:create, Spree::Product) %>
     <li id="new_product_link">
-      <%= button_link_to t('spree.new_product'), new_object_url, { id: 'admin_new_product' } %>
+      <%= link_to t('spree.new_product'), new_object_url, id: 'admin_new_product', class: 'btn btn-primary' %>
     </li>
   <% end %>
 <% end %>

--- a/backend/app/views/spree/admin/products/index.html.erb
+++ b/backend/app/views/spree/admin/products/index.html.erb
@@ -4,7 +4,7 @@
 
 <% content_for :page_actions do %>
   <li>
-    <%= button_link_to t('spree.new_product'), new_object_url %>
+    <%= link_to t('spree.new_product'), new_object_url, class: 'btn btn-primary' %>
   </li>
 <% end if can?(:create, Spree::Product) %>
 

--- a/backend/app/views/spree/admin/promotion_categories/index.html.erb
+++ b/backend/app/views/spree/admin/promotion_categories/index.html.erb
@@ -5,7 +5,7 @@
 <% content_for :page_actions do %>
   <% if can?(:create, Spree::PromotionCategory) %>
     <li>
-      <%= button_link_to t('spree.new_promotion_category'), spree.new_admin_promotion_category_path %>
+      <%= link_to t('spree.new_promotion_category'), spree.new_admin_promotion_category_path, class: 'btn btn-primary' %>
     </li>
   <% end %>
 <% end %>

--- a/backend/app/views/spree/admin/promotion_code_batches/index.html.erb
+++ b/backend/app/views/spree/admin/promotion_code_batches/index.html.erb
@@ -5,7 +5,7 @@
 <% content_for :page_actions do %>
   <li>
     <% if can?(:create, Spree::PromotionCodeBatch) %>
-      <%= button_link_to t('spree.new_promotion_code_batch'), new_object_url %>
+      <%= link_to t('spree.new_promotion_code_batch'), new_object_url, class: 'btn btn-primary' %>
     <% end %>
   </li>
 <% end %>

--- a/backend/app/views/spree/admin/promotion_codes/index.html.erb
+++ b/backend/app/views/spree/admin/promotion_codes/index.html.erb
@@ -4,7 +4,7 @@
 
 <% content_for :page_actions do %>
   <li>
-    <%= button_link_to t('spree.download_promotion_code_list'), admin_promotion_promotion_codes_path(promotion_id: @promotion.id, format: :csv) %>
+    <%= link_to t('spree.download_promotion_code_list'), admin_promotion_promotion_codes_path(promotion_id: @promotion.id, format: :csv), class: 'btn btn-primary' %>
   </li>
 <% end %>
 

--- a/backend/app/views/spree/admin/promotions/edit.html.erb
+++ b/backend/app/views/spree/admin/promotions/edit.html.erb
@@ -6,11 +6,11 @@
 <% content_for :page_actions do %>
   <li>
     <% if can?(:display, Spree::PromotionCode) %>
-      <%= button_link_to t('spree.download_promotion_code_list'), admin_promotion_promotion_codes_path(promotion_id: @promotion.id, format: :csv) %>
+      <%= link_to t('spree.download_promotion_code_list'), admin_promotion_promotion_codes_path(promotion_id: @promotion.id, format: :csv), class: 'btn btn-primary' %>
     <% end %>
 
     <% if can?(:display, Spree::PromotionCodeBatch) %>
-      <%= button_link_to plural_resource_name(Spree::PromotionCodeBatch), admin_promotion_promotion_code_batches_path(promotion_id: @promotion.id) %>
+      <%= link_to plural_resource_name(Spree::PromotionCodeBatch), admin_promotion_promotion_code_batches_path(promotion_id: @promotion.id), class: 'btn btn-primary' %>
     <% end %>
   </li>
 <% end %>

--- a/backend/app/views/spree/admin/promotions/index.html.erb
+++ b/backend/app/views/spree/admin/promotions/index.html.erb
@@ -3,7 +3,7 @@
 <% content_for :page_actions do %>
   <% if can? :create, Spree::Promotion %>
     <li>
-      <%= button_link_to t('spree.new_promotion'), spree.new_admin_promotion_path %>
+      <%= link_to t('spree.new_promotion'), spree.new_admin_promotion_path, class: 'btn btn-primary' %>
     </li>
   <% end %>
 <% end %>

--- a/backend/app/views/spree/admin/properties/index.html.erb
+++ b/backend/app/views/spree/admin/properties/index.html.erb
@@ -5,7 +5,7 @@
 <% content_for :page_actions do %>
   <% if can?(:create, Spree::Property) %>
     <li id="new_property_link">
-      <%= button_link_to t('spree.new_property'), new_admin_property_url, { remote: true, id: 'new_property_link' } %>
+      <%= link_to t('spree.new_property'), new_admin_property_url, remote: true, id: 'new_property_link', class: 'btn btn-primary' %>
     </li>
   <% end %>
 <% end %>

--- a/backend/app/views/spree/admin/refund_reasons/index.html.erb
+++ b/backend/app/views/spree/admin/refund_reasons/index.html.erb
@@ -9,7 +9,7 @@
   <ul class="actions inline-menu">
     <% if can?(:create, Spree::RefundReason) %>
       <li>
-        <%= button_link_to t('spree.new_refund_reason'), new_object_url, { id: 'admin_new_named_type' } %>
+        <%= link_to t('spree.new_refund_reason'), new_object_url, id: 'admin_new_named_type', class: 'btn btn-primary' %>
       </li>
     <% end %>
   </ul>

--- a/backend/app/views/spree/admin/refunds/edit.html.erb
+++ b/backend/app/views/spree/admin/refunds/edit.html.erb
@@ -23,7 +23,7 @@
 
     <div class="form-buttons filter-actions actions" data-hook="buttons">
       <%= button_tag t('spree.actions.save'), class: 'btn btn-primary' %>
-      <%= button_link_to t('spree.actions.cancel'), admin_order_payments_url(@refund.payment.order) %>
+      <%= link_to t('spree.actions.cancel'), admin_order_payments_url(@refund.payment.order), class: 'btn btn-primary' %>
     </div>
   </fieldset>
 <% end %>

--- a/backend/app/views/spree/admin/refunds/new.html.erb
+++ b/backend/app/views/spree/admin/refunds/new.html.erb
@@ -36,7 +36,7 @@
 
     <div class="form-buttons filter-actions actions" data-hook="buttons">
       <%= button_tag Spree::Refund.model_name.human, class: 'btn btn-primary' %>
-      <%= button_link_to t('spree.actions.cancel'), admin_order_payments_url(@refund.payment.order) %>
+      <%= link_to t('spree.actions.cancel'), admin_order_payments_url(@refund.payment.order), class: 'btn btn-primary' %>
     </div>
   </fieldset>
 <% end %>

--- a/backend/app/views/spree/admin/reimbursements/edit.html.erb
+++ b/backend/app/views/spree/admin/reimbursements/edit.html.erb
@@ -4,7 +4,7 @@
 
 
 <% content_for :page_actions do %>
-  <li><%= button_link_to t('spree.back_to_customer_return'), url_for([:edit, :admin, @order, @reimbursement.customer_return]) %></li>
+  <li><%= link_to t('spree.back_to_customer_return'), url_for([:edit, :admin, @order, @reimbursement.customer_return]), class: 'btn btn-primary' %></li>
 <% end %>
 
 <%= render partial: 'spree/shared/error_messages', locals: { target: @reimbursement } %>
@@ -100,7 +100,7 @@
       <%= button_to [:perform, :admin, @order, @reimbursement], { class: 'button', method: 'post' } do %>
         <%= t('spree.reimburse') %>
       <% end %>
-      <%= button_link_to t('spree.actions.cancel'), url_for([:admin, @order, @reimbursement.customer_return]) %>
+      <%= link_to t('spree.actions.cancel'), url_for([:admin, @order, @reimbursement.customer_return]), class: 'btn btn-primary' %>
     <% end %>
   </div>
 </fieldset>

--- a/backend/app/views/spree/admin/reimbursements/index.html.erb
+++ b/backend/app/views/spree/admin/reimbursements/index.html.erb
@@ -3,7 +3,7 @@
 <% admin_breadcrumb(plural_resource_name(Spree::Reimbursement)) %>
 
 <% content_for :page_actions do %>
-  <li><%= button_link_to t('spree.back_to_customer_return_list'), spree.admin_order_customer_returns_url(@order) %></li>
+  <li><%= link_to t('spree.back_to_customer_return_list'), spree.admin_order_customer_returns_url(@order), class: 'btn btn-primary' %></li>
 <% end %>
 
 <%= render partial: 'spree/shared/error_messages', locals: { target: @customer_return } %>

--- a/backend/app/views/spree/admin/reimbursements/show.html.erb
+++ b/backend/app/views/spree/admin/reimbursements/show.html.erb
@@ -4,7 +4,7 @@
 
 
 <% content_for :page_actions do %>
-  <li><%= button_link_to t('spree.back_to_customer_return'), url_for([:edit, :admin, @order, @reimbursement.customer_return]) %></li>
+  <li><%= link_to t('spree.back_to_customer_return'), url_for([:edit, :admin, @order, @reimbursement.customer_return]), class: 'btn btn-primary' %></li>
 <% end %>
 
 <%= render partial: 'spree/shared/error_messages', locals: { target: @reimbursement } %>

--- a/backend/app/views/spree/admin/return_authorizations/edit.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/edit.html.erb
@@ -28,7 +28,7 @@
 
       <div class="form-buttons filter-actions actions" data-hook="buttons">
         <%= button_tag t('spree.actions.update'), class: 'btn btn-primary' %>
-        <%= button_link_to t('spree.actions.cancel'), admin_order_return_authorizations_url(@order) %>
+        <%= link_to t('spree.actions.cancel'), admin_order_return_authorizations_url(@order), class: 'btn btn-primary' %>
       </div>
     </fieldset>
 	<% end %>

--- a/backend/app/views/spree/admin/return_authorizations/edit.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/edit.html.erb
@@ -1,7 +1,7 @@
 <% content_for :page_actions do %>
   <% if @return_authorization.can_cancel? %>
     <li>
-      <%= button_link_to t('spree.actions.cancel'), fire_admin_order_return_authorization_url(@order, @return_authorization, e: 'cancel'), method: :put, data: { confirm: t('spree.are_you_sure') } %>
+      <%= button_to t('spree.actions.cancel'), fire_admin_order_return_authorization_url(@order, @return_authorization, e: 'cancel'), method: :put, data: { confirm: t('spree.are_you_sure') } %>
     </li>
   <% end %>
 <% end %>

--- a/backend/app/views/spree/admin/return_authorizations/index.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/index.html.erb
@@ -4,7 +4,7 @@
   <% if @order.shipments.any? &:shipped? %>
     <li>
       <% if can? :create, Spree::ReturnAuthorization %>
-        <%= button_link_to t('spree.new_return_authorization'), new_admin_order_return_authorization_url(@order) %>
+        <%= link_to t('spree.new_return_authorization'), new_admin_order_return_authorization_url(@order), class: 'btn btn-primary' %>
       <% end %>
     </li>
   <% end %>

--- a/backend/app/views/spree/admin/return_authorizations/new.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/new.html.erb
@@ -14,7 +14,7 @@
 
     <div class="form-buttons filter-actions actions" data-hook="buttons">
       <%= button_tag t('spree.actions.create'), class: 'btn btn-primary' %>
-      <%= button_link_to t('spree.actions.cancel'), admin_order_return_authorizations_url(@order) %>
+      <%= link_to t('spree.actions.cancel'), admin_order_return_authorizations_url(@order), class: 'btn btn-primary' %>
     </div>
   </fieldset>
 <% end %>

--- a/backend/app/views/spree/admin/shared/_edit_resource_links.html.erb
+++ b/backend/app/views/spree/admin/shared/_edit_resource_links.html.erb
@@ -1,4 +1,4 @@
 <div class="form-buttons filter-actions actions" data-hook="buttons">
   <%= button_tag t('spree.actions.update'), class: 'btn btn-primary' %>
-  <%= button_link_to t('spree.actions.cancel'), collection_url %>
+  <%= link_to t('spree.actions.cancel'), collection_url, class: 'btn btn-primary' %>
 </div>

--- a/backend/app/views/spree/admin/shared/named_types/_index.html.erb
+++ b/backend/app/views/spree/admin/shared/named_types/_index.html.erb
@@ -9,7 +9,7 @@
   <ul class="actions inline-menu">
     <% if can?(:create, Spree::ReturnReason) %>
       <li>
-        <%= button_link_to new_button_text, new_object_url, { id: 'admin_new_named_type' } %>
+        <%= link_to new_button_text, new_object_url, id: 'admin_new_named_type', class: 'btn btn-primary' %>
       </li>
     <% end %>
   </ul>

--- a/backend/app/views/spree/admin/shipping_categories/index.html.erb
+++ b/backend/app/views/spree/admin/shipping_categories/index.html.erb
@@ -8,7 +8,7 @@
 <% content_for :page_actions do %>
   <% if can?(:create, Spree::ShippingCategory) %>
     <li>
-      <%= button_link_to t('spree.new_shipping_category'), new_object_url %>
+      <%= link_to t('spree.new_shipping_category'), new_object_url, class: 'btn btn-primary' %>
     </li>
   <% end %>
 <% end %>

--- a/backend/app/views/spree/admin/shipping_methods/index.html.erb
+++ b/backend/app/views/spree/admin/shipping_methods/index.html.erb
@@ -8,7 +8,7 @@
 <% content_for :page_actions do %>
   <% if can?(:create, Spree::ShippingMethod) %>
     <li>
-      <%= button_link_to t('spree.new_shipping_method'), new_object_url, id: 'admin_new_shipping_method_link' %>
+      <%= link_to t('spree.new_shipping_method'), new_object_url, id: 'admin_new_shipping_method_link', class: 'btn btn-primary' %>
     </li>
   <% end %>
 <% end %>

--- a/backend/app/views/spree/admin/stock_locations/index.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/index.html.erb
@@ -9,7 +9,7 @@
   <ul class="actions inline-menu">
     <% if can?(:create, Spree::StockLocation) %>
       <li>
-        <%= button_link_to t('spree.new_stock_location'), new_object_url, { id: 'admin_new_stock_location' } %>
+        <%= link_to t('spree.new_stock_location'), new_object_url, id: 'admin_new_stock_location', class: 'btn btn-primary' %>
       </li>
     <% end %>
   </ul>

--- a/backend/app/views/spree/admin/store_credits/edit_validity.html.erb
+++ b/backend/app/views/spree/admin/store_credits/edit_validity.html.erb
@@ -20,7 +20,7 @@
     </div>
     <div class="form-buttons filter-actions actions" data-hook="buttons">
       <%= button_tag t('spree.store_credit.actions.invalidate'), class: 'btn btn-primary' %>
-      <%= button_link_to t('spree.actions.cancel'), admin_user_store_credit_path(@user, @store_credit) %>
+      <%= link_to t('spree.actions.cancel'), admin_user_store_credit_path(@user, @store_credit), class: 'btn btn-primary' %>
     </div>
   </fieldset>
 <% end %>

--- a/backend/app/views/spree/admin/stores/edit.html.erb
+++ b/backend/app/views/spree/admin/stores/edit.html.erb
@@ -5,7 +5,7 @@
 
 <% content_for :page_actions do %>
   <li>
-    <%= button_link_to t('spree.new_store'), new_admin_store_url %>
+    <%= link_to t('spree.new_store'), new_admin_store_url, class: 'btn btn-primary' %>
   </li>
 <% end %>
 

--- a/backend/app/views/spree/admin/tax_categories/index.html.erb
+++ b/backend/app/views/spree/admin/tax_categories/index.html.erb
@@ -9,7 +9,7 @@
   <ul class="actions inline-menu">
     <% if can?(:create, Spree::TaxCategory) %>
       <li>
-        <%= button_link_to t('spree.new_tax_category'), new_object_url, id: 'admin_new_tax_categories_link' %>
+        <%= link_to t('spree.new_tax_category'), new_object_url, id: 'admin_new_tax_categories_link', class: 'btn btn-primary' %>
       </li>
     <% end %>
   </ul>

--- a/backend/app/views/spree/admin/tax_rates/index.html.erb
+++ b/backend/app/views/spree/admin/tax_rates/index.html.erb
@@ -8,7 +8,7 @@
 <% content_for :page_actions do %>
   <% if can?(:create, Spree::TaxRate) %>
     <li>
-      <%= button_link_to t('spree.new_tax_rate'), new_object_url %>
+      <%= link_to t('spree.new_tax_rate'), new_object_url, class: 'btn btn-primary' %>
     </li>
   <% end %>
 <% end %>

--- a/backend/app/views/spree/admin/taxonomies/edit.html.erb
+++ b/backend/app/views/spree/admin/taxonomies/edit.html.erb
@@ -5,7 +5,7 @@
 
 <% content_for :page_actions do %>
   <li>
-    <%= button_link_to t('spree.add_taxon'), spree.admin_taxonomies_path, { class: 'add-taxon-button' } %>
+    <%= link_to t('spree.add_taxon'), spree.admin_taxonomies_path, class: 'add-taxon-button btn btn-primary' %>
   </li>
 <% end %>
 
@@ -14,7 +14,7 @@
     <%= render partial: 'form', locals: { f: f } %>
     <div class="filter-actions actions">
       <%= button_tag t('spree.actions.update'), class: 'btn btn-primary' %>
-      <%= button_link_to t('spree.actions.cancel'), admin_taxonomies_path %>
+      <%= link_to t('spree.actions.cancel'), admin_taxonomies_path, class: 'btn btn-primary' %>
     </div>
   </fieldset>
 

--- a/backend/app/views/spree/admin/taxonomies/index.html.erb
+++ b/backend/app/views/spree/admin/taxonomies/index.html.erb
@@ -5,7 +5,7 @@
 <% content_for :page_actions do %>
   <% if can?(:create, Spree::Taxonomy) %>
     <li>
-      <%= button_link_to t('spree.new_taxonomy'), spree.new_admin_taxonomy_url, id: 'admin_new_taxonomy_link' %>
+      <%= link_to t('spree.new_taxonomy'), spree.new_admin_taxonomy_url, id: 'admin_new_taxonomy_link', class: 'btn btn-primary' %>
     </li>
   <% end %>
 <% end %>

--- a/backend/app/views/spree/admin/taxons/edit.html.erb
+++ b/backend/app/views/spree/admin/taxons/edit.html.erb
@@ -3,7 +3,7 @@
 
 <% content_for :page_actions do %>
   <li>
-    <%= button_link_to t('spree.back_to_taxonomies_list'), spree.admin_taxonomies_path %>
+    <%= link_to t('spree.back_to_taxonomies_list'), spree.admin_taxonomies_path, class: 'btn btn-primary' %>
   </li>
 <% end %>
 
@@ -14,6 +14,6 @@
 
   <div class="form-buttons filter-actions" data-hook="buttons">
     <%= button_tag t('spree.actions.update'), class: 'btn btn-primary' %>
-    <%= button_link_to t('spree.actions.cancel'), edit_admin_taxonomy_url(@taxonomy) %>
+    <%= link_to t('spree.actions.cancel'), edit_admin_taxonomy_url(@taxonomy), class: 'btn btn-primary' %>
   </div>
 <% end %>

--- a/backend/app/views/spree/admin/users/_user_page_actions.html.erb
+++ b/backend/app/views/spree/admin/users/_user_page_actions.html.erb
@@ -1,7 +1,7 @@
 <% content_for :page_actions do %>
   <% if can?([:admin, :create], Spree::Order) %>
     <li>
-      <%= button_link_to t(".create_order"), spree.new_admin_order_path(user_id: @user.id) %>
+      <%= link_to t(".create_order"), spree.new_admin_order_path(user_id: @user.id), class: 'btn btn-primary' %>
     </li>
   <% end %>
 <% end %>

--- a/backend/app/views/spree/admin/users/edit.html.erb
+++ b/backend/app/views/spree/admin/users/edit.html.erb
@@ -41,8 +41,8 @@
 
       </div>
       <div class="filter-actions actions">
-        <%= button_link_to t('.clear_key'), spree.clear_api_key_admin_user_path(@user), method: :put, data: { confirm: t('.confirm_clear_key') }, class: 'btn btn-primary' %>
-        <%= button_link_to t('.regenerate_key'), spree.generate_api_key_admin_user_path(@user), method: :put, data: { confirm: t('.confirm_regenerate_key') }, class: 'btn btn-primary' %>
+        <%= button_to t('.clear_key'), spree.clear_api_key_admin_user_path(@user), method: :put, data: { confirm: t('.confirm_clear_key') }, class: 'btn btn-primary' %>
+        <%= button_to t('.regenerate_key'), spree.generate_api_key_admin_user_path(@user), method: :put, data: { confirm: t('.confirm_regenerate_key') }, class: 'btn btn-primary' %>
       </div>
 
     <% else %>
@@ -50,7 +50,7 @@
       <div class="no-objects-found"><%= t('.no_key') %></div>
 
       <div class="filter-actions actions">
-        <%= button_link_to t('.generate_key'), spree.generate_api_key_admin_user_path(@user), method: :put, class: 'btn btn-primary' %>
+        <%= button_to t('.generate_key'), spree.generate_api_key_admin_user_path(@user), method: :put, class: 'btn btn-primary' %>
       </div>
     <% end %>
   </fieldset>

--- a/backend/app/views/spree/admin/users/index.html.erb
+++ b/backend/app/views/spree/admin/users/index.html.erb
@@ -3,7 +3,7 @@
 <% content_for :page_actions do %>
   <% if can?(:admin, Spree.user_class) && can?(:create, Spree.user_class) %>
     <li>
-      <%= button_link_to t('spree.new_user'), new_admin_user_url, id: 'admin_new_user_link' %>
+      <%= link_to t('spree.new_user'), new_admin_user_url, id: 'admin_new_user_link', class: 'btn btn-primary' %>
     </li>
   <% end %>
 <% end %>

--- a/backend/app/views/spree/admin/zones/index.html.erb
+++ b/backend/app/views/spree/admin/zones/index.html.erb
@@ -4,7 +4,7 @@
 <% content_for :page_actions do %>
   <% if can?(:create, Spree::Zone) %>
     <li>
-      <%= button_link_to t('spree.new_zone'), new_object_url, id: 'admin_new_zone_link' %>
+      <%= link_to t('spree.new_zone'), new_object_url, id: 'admin_new_zone_link', class: 'btn btn-primary' %>
     </li>
   <% end %>
 <% end %>


### PR DESCRIPTION
Similar to #2600 (and built on top of it to avoid conflicts)

This replaces all uses of our `button_link_to` helper with either `button_to` or `link_to`.

There's no reason for `button_link_to` to exist. Either we want a link (which we can style like a button easily if we want) or just a button. We should explicitly use the one we want given the situation.

All occurrences of `button_link_to` can be replaced with either `button_to` or `link_to` with `class: 'btn btn-primary'`. Both Rails built-in helpers can have a `:method` specified, and both are able to perform a GET request.

I've chosen to replace all `button_link_to` with a method with `button_to`, since that was the behaviour of the method, and the most appropriate use of a `button` and `form` tag.

I've replaced all `button_link_to` which did not specify a method (a GET request is desired) with `link_to`, since that was the previous behaviour and because this is what a link is.

_(This should be rebased before merging)_