### PR TITLE
Remove foreign key from promotion_rules_stores

### DIFF
--- a/core/db/migrate/20180202190713_create_promotion_rule_stores.rb
+++ b/core/db/migrate/20180202190713_create_promotion_rule_stores.rb
@@ -1,8 +1,8 @@
 class CreatePromotionRuleStores < ActiveRecord::Migration[5.1]
   def change
     create_table :spree_promotion_rules_stores do |t|
-      t.references :store, foreign_key: { to_table: "spree_stores" }
-      t.references :promotion_rule, foreign_key: { to_table: "spree_promotion_rules" }
+      t.references :store, null: false
+      t.references :promotion_rule, null: false
 
       t.timestamps
     end


### PR DESCRIPTION
Similar to the issue with store_shipping_methods (#2596), this uses a different type for the primary key than the reference, which is invalid and causes an error under MySQL.