### PR TITLE
Filter unpriced products in taxon_preview

### DIFF
--- a/core/app/helpers/spree/taxons_helper.rb
+++ b/core/app/helpers/spree/taxons_helper.rb
@@ -6,12 +6,13 @@ module Spree
     # that we can use configurations as well as make it easier for end users to override this determination.  One idea is
     # to show the most popular products for a particular taxon (that is an exercise left to the developer.)
     def taxon_preview(taxon, max = 4)
-      products = taxon.active_products.select("DISTINCT (spree_products.id), spree_products.*, spree_products_taxons.position").limit(max)
+      price_scope = Spree::Price.where(current_pricing_options.search_arguments)
+      products = taxon.active_products.joins(:prices).merge(price_scope).select("DISTINCT (spree_products.id), spree_products.*, spree_products_taxons.position").limit(max)
       if products.size < max
         products_arel = Spree::Product.arel_table
         taxon.descendants.each do |descendent_taxon|
           to_get = max - products.length
-          products += descendent_taxon.active_products.select("DISTINCT (spree_products.id), spree_products.*, spree_products_taxons.position").where(products_arel[:id].not_in(products.map(&:id))).limit(to_get)
+          products += descendent_taxon.active_products.joins(:prices).merge(price_scope).select("DISTINCT (spree_products.id), spree_products.*, spree_products_taxons.position").where(products_arel[:id].not_in(products.map(&:id))).limit(to_get)
           break if products.size >= max
         end
       end

--- a/core/spec/helpers/taxons_helper_spec.rb
+++ b/core/spec/helpers/taxons_helper_spec.rb
@@ -3,17 +3,39 @@
 require 'rails_helper'
 
 RSpec.describe Spree::TaxonsHelper, type: :helper do
-  # Regression test for https://github.com/spree/spree/issues/4382
-  it "#taxon_preview" do
-    taxon = create(:taxon)
-    child_taxon = create(:taxon, parent: taxon)
-    product_1 = create(:product)
-    product_2 = create(:product)
-    product_3 = create(:product)
-    taxon.products << product_1
-    taxon.products << product_2
-    child_taxon.products << product_3
+  let(:currency) { 'USD' }
+  let(:pricing_options) do
+    Spree::Config.pricing_options_class.new(currency: currency)
+  end
+  before do
+    allow(helper).to receive(:current_pricing_options) { pricing_options }
+  end
 
-    expect(taxon_preview(taxon.reload)).to eql([product_1, product_2, product_3])
+  describe "#taxon_preview" do
+    let!(:taxon) { create(:taxon) }
+    let!(:child_taxon) { create(:taxon, parent: taxon) }
+    let!(:product_1) { create(:product) }
+    let!(:product_2) { create(:product) }
+    let!(:product_3) { create(:product) }
+
+    before do
+      taxon.products << product_1
+      taxon.products << product_2
+      child_taxon.products << product_3
+      taxon.reload
+    end
+
+    # Regression test for https://github.com/spree/spree/issues/4382
+    it "returns products" do
+      expect(helper.taxon_preview(taxon)).to eql([product_1, product_2, product_3])
+    end
+
+    context "with different currency" do
+      let(:currency) { 'CAD' }
+
+      it "returns no products" do
+        expect(helper.taxon_preview(taxon)).to be_empty
+      end
+    end
   end
 end

--- a/frontend/spec/features/taxons_spec.rb
+++ b/frontend/spec/features/taxons_spec.rb
@@ -134,4 +134,25 @@ describe "viewing products", type: :feature, inaccessible: true do
       expect(tmp.sort!).to eq(["Ruby on Rails Bag", "Ruby on Rails Tote"])
     end
   end
+
+  # Regression test for https://github.com/solidusio/solidus/issues/2602
+  context "root taxon page" do
+    it "shows taxon previews" do
+      visit spree.nested_taxons_path(taxonomy.root)
+
+      expect(page).to have_css('ul.product-listing li', count: 2)
+      expect(page).to have_content("Superman T-Shirt", count: 2)
+    end
+
+    context "with prices in other currency" do
+      before { Spree::Price.update_all(currency: "CAD") }
+
+      it "shows no products" do
+        visit spree.nested_taxons_path(taxonomy.root)
+
+        expect(page).to have_css('ul.product-listing li', count: 0)
+        expect(page).to have_no_content("Superman T-Shirt")
+      end
+    end
+  end
 end


### PR DESCRIPTION
Previously, `taxon_preview` would return products without prices, resulting in an error.

This commit makes it respect the `current_pricing_options` and filter products which are available in the current price.

Fixes #2602