### PR TITLE
Fix error when listing products without price

### DIFF
--- a/frontend/app/views/spree/shared/_products.html.erb
+++ b/frontend/app/views/spree/shared/_products.html.erb
@@ -32,9 +32,11 @@
           </div>
           <%= link_to truncate(product.name, length: 50), url, class: 'info', itemprop: "name", title: product.name %>
           <span itemprop="offers" itemscope itemtype="http://schema.org/Offer">
-            <span class="price selling" itemprop="price" content="<%= product.price_for(current_pricing_options).to_d %>">
-              <%= display_price(product) %>
-            </span>
+            <% if price = product.price_for(current_pricing_options) %>
+              <span class="price selling" itemprop="price" content="<%= price.to_d %>">
+                <%= price.to_html %>
+              </span>
+            <% end %>
             <span itemprop="priceCurrency" content="<%= current_pricing_options.currency %>"></span>
           </span>
         <% end %>

--- a/frontend/spec/features/products_spec.rb
+++ b/frontend/spec/features/products_spec.rb
@@ -270,6 +270,14 @@ describe "Visiting Products", type: :feature, inaccessible: true do
     expect(page).not_to have_content "add-to-cart-button"
   end
 
+  it "should be able to list products without a price" do
+    product = FactoryBot.create(:base_product, description: nil, name: 'Sample', price: '19.99')
+    Spree::Config.currency = "CAN"
+    Spree::Config.show_products_without_price = true
+    visit spree.products_path
+    expect(page).to have_content(product.name)
+  end
+
   it "should return the correct title when displaying a single product" do
     product = Spree::Product.find_by(name: "Ruby on Rails Baseball Jersey")
     click_link product.name


### PR DESCRIPTION
I don't know why anyone would enable `Spree::Config.show_products_without_price = true`, but it's an option that we have.

With this option enabled, the product listing page would error when encountering a product with no price (or no price in the current currency). This commit hides the price when this is the case.