### PR TITLE
Fix spec failure due to DB order

### DIFF
--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Spree::Shipment, type: :model do
           end
         end.to change { Spree::Shipment.count }.by(1)
 
-        new_shipment = order.shipments.last
+        new_shipment = order.shipments.order(:created_at).last
         expect(new_shipment.number).to_not eq(shipment.number)
         expect(new_shipment.stock_location).to eq(stock_location)
         expect(new_shipment.line_items.count).to eq(1)


### PR DESCRIPTION
The shipments association here was being loaded in the recalculate. The association itself isn't ordered, so the shipments could be in any order. Because of this, shipments.last wasn't necessarily the most recent shipment, and this spec could fail.

This probably started failing after #2555 was merged