### PR TITLE
More flexible frontend JS includes

### DIFF
--- a/frontend/app/assets/javascripts/spree/frontend/checkout.js
+++ b/frontend/app/assets/javascripts/spree/frontend/checkout.js
@@ -1,8 +1,6 @@
 //= require jquery.payment
 //= require_self
-//= require spree/frontend/checkout/address
-//= require spree/frontend/checkout/payment
-//= require spree/frontend/checkout/coupon-code
+//= require_directory ./checkout
 
 Spree.disableSaveOnClick = function() {
   $("form.edit_order").submit(function() {


### PR DESCRIPTION
Instead of requiring individual checkout JS files by name, we can require the `/checkout` directory instead. This should have the effect of making it easier for extensions or individual stores to add JS files without needing to override `frontend.js` or `frontend/checkout.js` to make sure that those files are included.