### PR TITLE
render shipment json when payment source is nil

### DIFF
--- a/api/app/views/spree/api/shipments/_big.json.jbuilder
+++ b/api/app/views/spree/api/shipments/_big.json.jbuilder
@@ -42,10 +42,12 @@ json.cache! [I18n.locale, shipment] do
     end
     json.payments(shipment.order.payments) do |payment|
       json.(payment, :id, :amount, :display_amount, :state)
-      json.source do
-        attrs = [:id]
-        (attrs << :cc_type) if payment.source.respond_to?(:cc_type)
-        json.(payment.source, *attrs)
+      if payment.source
+        json.source do
+          attrs = [:id]
+          (attrs << :cc_type) if payment.source.respond_to?(:cc_type)
+          json.(payment.source, *attrs)
+        end
       end
       json.payment_method { json.(payment.payment_method, :id, :name) }
     end

--- a/api/spec/requests/spree/api/shipments_controller_spec.rb
+++ b/api/spec/requests/spree/api/shipments_controller_spec.rb
@@ -214,6 +214,17 @@ describe Spree::Api::ShipmentsController, type: :request do
               expect(json_response['shipments'][0]['order']['payments'][0]['source'].keys).to match_array ["id"]
             end
           end
+
+          context "check payment" do
+            let(:current_api_user) { shipped_order.user }
+            let(:shipped_order)    { create(:shipped_order, payment_type: :check_payment) }
+
+            before { subject }
+
+            it 'does not try to render a nil source' do
+              expect(json_response['shipments'][0]['order']['payments'][0]['source']).to eq(nil)
+            end
+          end
         end
 
         context 'with filtering' do


### PR DESCRIPTION
When using a payment by check, the payment source is nil.
This cause the json rendering of a shipment to fails because it expects a payment.source to always be present.