### PR TITLE
Backend stock movements improvements

### DIFF
--- a/backend/app/views/spree/admin/stock_locations/edit.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/edit.html.erb
@@ -7,6 +7,13 @@
 
 
 <% content_for :page_actions do %>
+  <ul class="actions inline-menu">
+    <% if can?(:display, Spree::StockMovement) %>
+      <li>
+        <%= link_to plural_resource_name(Spree::StockMovement), admin_stock_location_stock_movements_path(@stock_location.id), class: 'btn btn-primary'  %>
+      </li>
+    <% end %>
+  </ul>
 <% end %>
 
 <%= render partial: 'spree/shared/error_messages', locals: { target: @stock_location } %>

--- a/backend/app/views/spree/admin/stock_movements/index.html.erb
+++ b/backend/app/views/spree/admin/stock_movements/index.html.erb
@@ -12,14 +12,6 @@
 <% end %>
 <% admin_breadcrumb(plural_resource_name(Spree::StockMovement)) %>
 
-<% content_for :page_actions do %>
-  <% if can?(:display, Spree::StockLocation) %>
-    <li>
-      <%= link_to_with_icon 'arrow-left', t('spree.back_to_stock_locations_list'), admin_stock_locations_path, class: 'button' %>
-    </li>
-  <% end %>
-<% end %>
-
 <% if @stock_movements.any? %>
 <table class="index" id='listing_stock_movements'>
   <colgroup>

--- a/backend/app/views/spree/admin/stock_movements/index.html.erb
+++ b/backend/app/views/spree/admin/stock_movements/index.html.erb
@@ -1,5 +1,3 @@
-<%= render 'spree/admin/shared/shipping_tabs' %>
-
 <% admin_breadcrumb(t('spree.settings')) %>
 <% admin_breadcrumb(t('spree.admin.tab.shipping')) %>
 <% if can?(:display, Spree::StockLocation) %>

--- a/backend/app/views/spree/admin/stock_movements/index.html.erb
+++ b/backend/app/views/spree/admin/stock_movements/index.html.erb
@@ -1,7 +1,18 @@
 <%= render 'spree/admin/shared/shipping_tabs' %>
 
-<% admin_breadcrumb(t('spree.stock_movements_for_stock_location', stock_location_name: @stock_location.name)) %>
-
+<% admin_breadcrumb(t('spree.settings')) %>
+<% admin_breadcrumb(t('spree.admin.tab.shipping')) %>
+<% if can?(:display, Spree::StockLocation) %>
+  <% admin_breadcrumb(link_to plural_resource_name(Spree::StockLocation), spree.admin_stock_locations_path) %>
+<% else %>
+  <% admin_breadcrumb(plural_resource_name(Spree::StockLocation)) %>
+<% end %>
+<% if can?(:update, @stock_location) %>
+  <% admin_breadcrumb(link_to(admin_stock_location_display_name(@stock_location), spree.edit_admin_stock_location_path(@stock_location.id))) %>
+<% else %>
+  <% admin_breadcrumb(admin_stock_location_display_name(@stock_location)) %>
+<% end %>
+<% admin_breadcrumb(plural_resource_name(Spree::StockMovement)) %>
 
 <% content_for :page_actions do %>
   <% if can?(:display, Spree::StockLocation) %>

--- a/backend/app/views/spree/admin/stock_movements/index.html.erb
+++ b/backend/app/views/spree/admin/stock_movements/index.html.erb
@@ -20,9 +20,9 @@
   </colgroup>
   <thead>
     <tr data-hook="admin_stock_movements_index_headers">
-      <th><%= Spree::StockMovement.human_attribute_name(:stock_item) %>
+      <th><%= Spree::StockMovement.human_attribute_name(:variant) %>
       <th><%= Spree::StockMovement.human_attribute_name(:quantity) %></th>
-      <th><%= Spree::StockMovement.human_attribute_name(:action) %></th>
+      <th><%= Spree::StockMovement.human_attribute_name(:originated_by) %></th>
     </tr>
   </thead>
   <tbody>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -342,8 +342,9 @@ en:
         state_id: State
         zipcode: Zip
       spree/stock_movement:
-        action: Action
+        originated_by: Originated By
         quantity: Quantity
+        variant: Variant
       spree/tax_category:
         description: Description
         name: Name


### PR DESCRIPTION
Change something into stock movements page:

- Change index column `stock item` into `Variant`
- Change index column `Action` into `Originated by`
- Add breadcrumbs
- Remove back to stock locations buttons
- Remove shipping tabs (no tab is selected)

##### Before
<img width="897" alt="schermata 2018-03-06 alle 00 24 56" src="https://user-images.githubusercontent.com/167946/37005603-ef412bb0-20d4-11e8-8c5e-47fd8a406228.png">

##### After
<img width="898" alt="schermata 2018-03-06 alle 00 25 26" src="https://user-images.githubusercontent.com/167946/37005606-f1a2e0c4-20d4-11e8-99b6-2694acc86ba0.png">
