### PR TITLE
Make StockItem#count_on_hand= public

### DIFF
--- a/core/app/models/spree/stock_item.rb
+++ b/core/app/models/spree/stock_item.rb
@@ -91,10 +91,6 @@ module Spree
 
     private
 
-    def count_on_hand=(value)
-      write_attribute(:count_on_hand, value)
-    end
-
     # Process backorders based on amount of stock received
     # If stock was -20 and is now -15 (increase of 5 units), then we should process 5 inventory orders.
     # If stock was -20 but then was -25 (decrease of 5 units), do nothing.

--- a/core/spec/models/spree/stock_item_spec.rb
+++ b/core/spec/models/spree/stock_item_spec.rb
@@ -288,7 +288,7 @@ RSpec.describe Spree::StockItem, type: :model do
   describe 'validations' do
     before do
       subject.backorderable = backorderable
-      subject.send(:count_on_hand=, count_on_hand)
+      subject.count_on_hand = count_on_hand
     end
 
     describe 'count_on_hand' do


### PR DESCRIPTION
This was made private when `StockItems` were originally introduced to try to avoid user error where `count_on_hand` was set without calling `process_backorders`.

We can't possibly protect our users from all errors, and I can think of several reasons to want to set this without processing backorders.