### PR TITLE
Remove protected_attributes warning

### DIFF
--- a/lib/solidus.rb
+++ b/lib/solidus.rb
@@ -5,13 +5,3 @@ require 'solidus_api'
 require 'solidus_backend'
 require 'solidus_frontend'
 require 'solidus_sample'
-
-begin
-  require 'protected_attributes'
-  puts "*" * 75
-  puts "[FATAL] Solidus does not work with the protected_attributes gem installed!"
-  puts "You MUST remove this gem from your Gemfile. It is incompatible with Solidus."
-  puts "*" * 75
-  exit
-rescue LoadError
-end


### PR DESCRIPTION
This is no longer necessary since the protected_attributes gem has a dependency on activemodel < 5.0 and we require 5.1 (and it was of dubious benefit anyways).