### PR TITLE
Upgrade rubocop, and lock version

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -67,7 +67,7 @@ Style/RegexpLiteral:
 Style/AsciiComments:
   Enabled: false
 
-Lint/EndAlignment:
+Layout/EndAlignment:
   Enabled: false
 
 Layout/ElseAlignment:
@@ -97,7 +97,10 @@ Layout/AlignHash:
 Style/TrailingCommaInArguments:
   Enabled: false
 
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
+  Enabled: false
+
+Style/TrailingCommaInHashLiteral:
   Enabled: false
 
 # Symbol Arrays are ok and the %i syntax widely unknown

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -297,3 +297,7 @@ Style/NumericLiterals:
 Style/FrozenStringLiteralComment:
   Enabled: true
   EnforcedStyle: always
+
+# json.() is idiomatic in jbuilder files
+Style/LambdaCall:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -301,3 +301,9 @@ Style/FrozenStringLiteralComment:
 # json.() is idiomatic in jbuilder files
 Style/LambdaCall:
   Enabled: false
+
+Naming/UncommunicativeMethodParamName:
+  AllowedNames:
+    - id
+    - to
+    - _

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -307,3 +307,16 @@ Naming/UncommunicativeMethodParamName:
     - id
     - to
     - _
+
+# Rubocop doesn't understand side-effects
+Style/IdenticalConditionalBranches:
+  Enabled: false
+
+Naming/MemoizedInstanceVariableName:
+  Enabled: false
+
+Lint/UselessComparison:
+  Enabled: false
+
+Lint/HandleExceptions:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -49,5 +49,5 @@ end
 
 gem 'rspec_junit_formatter', require: false, group: :ci
 
-custom_gemfile = File.expand_path("../Gemfile-custom", __FILE__)
+custom_gemfile = File.expand_path('Gemfile-custom', __dir__)
 eval File.read(custom_gemfile) if File.exist?(custom_gemfile)

--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ group :backend do
   gem 'teaspoon-mocha', require: false
 end
 
-gem 'rubocop', require: false
+gem 'rubocop', '~> 0.53.0', require: false
 
 group :utils do
   gem 'pry'

--- a/Rakefile
+++ b/Rakefile
@@ -31,7 +31,7 @@ desc "Run backend JS specs"
 subproject_task("backend", "spec:js", title: "backend JS", task_name: "spec:backend:js")
 
 # Add backend JS specs to `rake spec` dependencies
-task :spec => 'spec:backend:js'
+task spec: 'spec:backend:js'
 
 task test: :spec
 task test_app: 'db:reset'
@@ -67,7 +67,7 @@ namespace :gem do
 
   desc "Build all solidus gems"
   task :build do
-    pkgdir = File.expand_path("../pkg", __FILE__)
+    pkgdir = File.expand_path('pkg', __dir__)
     FileUtils.mkdir_p pkgdir
 
     %w(core api backend frontend sample).each do |gem_name|

--- a/api/Rakefile
+++ b/api/Rakefile
@@ -10,7 +10,7 @@ RSpec::Core::RakeTask.new
 task default: :spec
 
 DummyApp::RakeTasks.new(
-  gem_root: File.expand_path('../', __FILE__),
+  gem_root: File.expand_path(__dir__),
   lib_name: 'solidus_api'
 )
 

--- a/api/app/controllers/spree/api/payments_controller.rb
+++ b/api/app/controllers/spree/api/payments_controller.rb
@@ -29,7 +29,7 @@ module Spree
 
       def update
         authorize! params[:action], @payment
-        if ! @payment.pending?
+        if !@payment.pending?
           render 'update_forbidden', status: 403
         elsif @payment.update_attributes(payment_params)
           respond_with(@payment, default_template: :show)

--- a/api/app/controllers/spree/api/states_controller.rb
+++ b/api/app/controllers/spree/api/states_controller.rb
@@ -26,9 +26,9 @@ module Spree
       def scope
         if params[:country_id]
           @country = Spree::Country.accessible_by(current_ability, :read).find(params[:country_id])
-          return @country.states.accessible_by(current_ability, :read)
+          @country.states.accessible_by(current_ability, :read)
         else
-          return Spree::State.accessible_by(current_ability, :read)
+          Spree::State.accessible_by(current_ability, :read)
         end
       end
     end

--- a/api/script/rails
+++ b/api/script/rails
@@ -3,8 +3,8 @@
 
 # This command will automatically be run when you run "rails" with Rails 3 gems installed from the root of your application.
 
-ENGINE_ROOT = File.expand_path('../..', __FILE__)
-ENGINE_PATH = File.expand_path('../../lib/spree/api/engine', __FILE__)
+ENGINE_ROOT = File.expand_path('..', __dir__)
+ENGINE_PATH = File.expand_path('../lib/spree/api/engine', __dir__)
 
 require 'rails/all'
 require 'rails/engine/commands'

--- a/api/solidus_api.gemspec
+++ b/api/solidus_api.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 2.2.2'
   gem.required_rubygems_version = '>= 1.8.23'
 
-  gem.add_dependency 'solidus_core', gem.version
-  gem.add_dependency 'responders'
   gem.add_dependency 'jbuilder', '~> 2.6'
   gem.add_dependency 'kaminari-activerecord', '~> 1.1'
+  gem.add_dependency 'responders'
+  gem.add_dependency 'solidus_core', gem.version
 end

--- a/api/spec/controllers/spree/api/resource_controller_spec.rb
+++ b/api/spec/controllers/spree/api/resource_controller_spec.rb
@@ -62,8 +62,8 @@ module Spree
           get :index, params: { token: admin_user.spree_api_key }, as: :json
           expect(response).to be_successful
           expect(json_response['widgets']).to include(hash_including(
-            'name' => 'a widget',
-            'position' => 1
+                                                        'name' => 'a widget',
+                                                        'position' => 1
           ))
         end
 

--- a/api/spec/controllers/spree/api/resource_controller_spec.rb
+++ b/api/spec/controllers/spree/api/resource_controller_spec.rb
@@ -61,10 +61,12 @@ module Spree
         it "returns widgets" do
           get :index, params: { token: admin_user.spree_api_key }, as: :json
           expect(response).to be_successful
-          expect(json_response['widgets']).to include(hash_including(
-                                                        'name' => 'a widget',
-                                                        'position' => 1
-          ))
+          expect(json_response['widgets']).to include(
+            hash_including(
+              'name' => 'a widget',
+              'position' => 1
+            )
+          )
         end
 
         context "specifying ids" do

--- a/api/spec/requests/spree/api/addresses_controller_spec.rb
+++ b/api/spec/requests/spree/api/addresses_controller_spec.rb
@@ -4,7 +4,6 @@ require 'spec_helper'
 
 module Spree
   describe Api::AddressesController, type: :request do
-
     before do
       stub_authentication!
       @address = create(:address)

--- a/api/spec/requests/spree/api/checkouts_controller_spec.rb
+++ b/api/spec/requests/spree/api/checkouts_controller_spec.rb
@@ -4,7 +4,6 @@ require 'spec_helper'
 
 module Spree
   describe Api::CheckoutsController, type: :request do
-
     before(:each) do
       stub_authentication!
       Spree::Config[:track_inventory_levels] = false

--- a/api/spec/requests/spree/api/config_controller_spec.rb
+++ b/api/spec/requests/spree/api/config_controller_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 module Spree
   describe Api::ConfigController, type: :request do
-    let!(:default_country) { create :country, iso: "US"}
+    let!(:default_country) { create :country, iso: "US" }
 
     before do
       stub_authentication!

--- a/api/spec/requests/spree/api/countries_controller_spec.rb
+++ b/api/spec/requests/spree/api/countries_controller_spec.rb
@@ -4,7 +4,6 @@ require 'spec_helper'
 
 module Spree
   describe Api::CountriesController, type: :request do
-
     before do
       stub_authentication!
       @state = create(:state)

--- a/api/spec/requests/spree/api/credit_cards_controller_spec.rb
+++ b/api/spec/requests/spree/api/credit_cards_controller_spec.rb
@@ -5,7 +5,6 @@ require 'spec_helper'
 module Spree
   describe Api::CreditCardsController, type: :request do
     describe '#index' do
-
       let!(:admin_user) do
         create(:admin_user)
       end

--- a/api/spec/requests/spree/api/images_controller_spec.rb
+++ b/api/spec/requests/spree/api/images_controller_spec.rb
@@ -4,7 +4,6 @@ require 'spec_helper'
 
 module Spree
   describe Spree::Api::ImagesController, type: :request do
-
     let!(:product) { create(:product) }
     let!(:attributes) {
       [:id, :position, :attachment_content_type,

--- a/api/spec/requests/spree/api/line_items_controller_spec.rb
+++ b/api/spec/requests/spree/api/line_items_controller_spec.rb
@@ -12,7 +12,6 @@ module Spree
   end
 
   describe Api::LineItemsController, type: :request do
-
     let!(:order) { create(:order_with_line_items, line_items_count: 1) }
 
     let(:product) { create(:product) }

--- a/api/spec/requests/spree/api/option_types_controller_spec.rb
+++ b/api/spec/requests/spree/api/option_types_controller_spec.rb
@@ -4,7 +4,6 @@ require 'spec_helper'
 
 module Spree
   describe Api::OptionTypesController, type: :request do
-
     let(:attributes) { [:id, :name, :position, :presentation] }
     let!(:option_value) { create(:option_value) }
     let!(:option_type) { option_value.option_type }

--- a/api/spec/requests/spree/api/option_values_controller_spec.rb
+++ b/api/spec/requests/spree/api/option_values_controller_spec.rb
@@ -4,7 +4,6 @@ require 'spec_helper'
 
 module Spree
   describe Api::OptionValuesController, type: :request do
-
     let(:attributes) { [:id, :name, :presentation, :option_type_name, :option_type_name] }
     let!(:option_value) { create(:option_value) }
     let!(:option_type) { option_value.option_type }
@@ -103,7 +102,7 @@ module Spree
         end
 
         it "cannot create an option type with invalid attributes" do
-          post spree.api_option_type_option_values_path(option_type), params: { option_value: {name: ""} }
+          post spree.api_option_type_option_values_path(option_type), params: { option_value: { name: "" } }
           expect(response.status).to eq(422)
         end
 

--- a/api/spec/requests/spree/api/product_properties_controller_spec.rb
+++ b/api/spec/requests/spree/api/product_properties_controller_spec.rb
@@ -5,7 +5,6 @@ require 'shared_examples/protect_product_actions'
 
 module Spree
   describe Spree::Api::ProductPropertiesController, type: :request do
-
     let!(:product) { create(:product) }
     let!(:property_1) { product.product_properties.create(property_name: "My Property 1", value: "my value 1", position: 0) }
     let!(:property_2) { product.product_properties.create(property_name: "My Property 2", value: "my value 2", position: 1) }

--- a/api/spec/requests/spree/api/products_controller_spec.rb
+++ b/api/spec/requests/spree/api/products_controller_spec.rb
@@ -5,7 +5,6 @@ require 'shared_examples/protect_product_actions'
 
 module Spree
   describe Spree::Api::ProductsController, type: :request do
-
     let!(:product) { create(:product) }
     let!(:inactive_product) { create(:product, available_on: Time.current.tomorrow, name: "inactive") }
     let(:base_attributes) { Api::ApiHelpers.product_attributes }
@@ -351,7 +350,7 @@ module Spree
           expect(response.status).to eq 200
           expect(json_response['variants'].count).to eq(2) # 2 variants
 
-          variants = json_response['variants'].select { |v| !v['is_master'] }
+          variants = json_response['variants'].reject { |v| v['is_master'] }
           size_option_value = variants.last['option_values'].detect{ |x| x['option_type_name'] == 'size' }
           expect(size_option_value['name']).to eq('small')
 
@@ -375,7 +374,7 @@ module Spree
           } }
 
           expect(json_response['variants'].count).to eq(1)
-          variants = json_response['variants'].select { |v| !v['is_master'] }
+          variants = json_response['variants'].reject { |v| v['is_master'] }
           expect(variants.last['option_values'][0]['name']).to eq('large')
           expect(variants.last['sku']).to eq('456')
           expect(variants.count).to eq(1)

--- a/api/spec/requests/spree/api/promotion_application_spec.rb
+++ b/api/spec/requests/spree/api/promotion_application_spec.rb
@@ -4,7 +4,6 @@ require 'spec_helper'
 
 module Spree::Api
   describe OrdersController, type: :request do
-
     before do
       stub_authentication!
     end

--- a/api/spec/requests/spree/api/promotions_controller_spec.rb
+++ b/api/spec/requests/spree/api/promotions_controller_spec.rb
@@ -4,7 +4,6 @@ require 'spec_helper'
 
 module Spree
   describe Spree::Api::PromotionsController, type: :request do
-
     shared_examples "a JSON response" do
       it 'should be ok' do
         subject

--- a/api/spec/requests/spree/api/properties_controller_spec.rb
+++ b/api/spec/requests/spree/api/properties_controller_spec.rb
@@ -3,7 +3,6 @@
 require 'spec_helper'
 module Spree
   describe Spree::Api::PropertiesController, type: :request do
-
     let!(:property_1) { Property.create!(name: "foo", presentation: "Foo") }
     let!(:property_2) { Property.create!(name: "bar", presentation: "Bar") }
 

--- a/api/spec/requests/spree/api/return_authorizations_controller_spec.rb
+++ b/api/spec/requests/spree/api/return_authorizations_controller_spec.rb
@@ -4,7 +4,6 @@ require 'spec_helper'
 
 module Spree
   describe Api::ReturnAuthorizationsController, type: :request do
-
     let!(:order) { create(:shipped_order) }
 
     let(:product) { create(:product) }

--- a/api/spec/requests/spree/api/states_controller_spec.rb
+++ b/api/spec/requests/spree/api/states_controller_spec.rb
@@ -4,7 +4,6 @@ require 'spec_helper'
 
 module Spree
   describe Api::StatesController, type: :request do
-
     let!(:state) { create(:state, name: "Victoria") }
     let(:attributes) { [:id, :name, :abbr, :country_id] }
 

--- a/api/spec/requests/spree/api/stock_items_controller_spec.rb
+++ b/api/spec/requests/spree/api/stock_items_controller_spec.rb
@@ -4,7 +4,6 @@ require 'spec_helper'
 
 module Spree
   describe Api::StockItemsController, type: :request do
-
     let!(:stock_location) { create(:stock_location_with_items) }
     let!(:stock_item) { stock_location.stock_items.order(:id).first }
     let!(:attributes) {

--- a/api/spec/requests/spree/api/stock_locations_controller_spec.rb
+++ b/api/spec/requests/spree/api/stock_locations_controller_spec.rb
@@ -4,7 +4,6 @@ require 'spec_helper'
 
 module Spree
   describe Api::StockLocationsController, type: :request do
-
     let!(:stock_location) { create(:stock_location) }
     let!(:attributes) { [:id, :name, :address1, :address2, :city, :state_id, :state_name, :country_id, :zipcode, :phone, :active] }
 

--- a/api/spec/requests/spree/api/stock_movements_controller_spec.rb
+++ b/api/spec/requests/spree/api/stock_movements_controller_spec.rb
@@ -4,7 +4,6 @@ require 'spec_helper'
 
 module Spree
   describe Api::StockMovementsController, type: :request do
-
     let!(:stock_location) { create(:stock_location_with_items) }
     let!(:stock_item) { stock_location.stock_items.order(:id).first }
     let!(:stock_movement) { create(:stock_movement, stock_item: stock_item) }

--- a/api/spec/requests/spree/api/stores_controller_spec.rb
+++ b/api/spec/requests/spree/api/stores_controller_spec.rb
@@ -4,7 +4,6 @@ require "spec_helper"
 
 module Spree
   describe Api::StoresController, type: :request do
-
     let!(:store) do
       create(:store, name: "My Spree Store", url: "spreestore.example.com")
     end
@@ -20,8 +19,7 @@ module Spree
         create(:store,
           name: "Extra Store",
           url: "spreestore-5.example.com",
-          default: false
-        )
+          default: false)
       end
 
       it "can list the available stores" do

--- a/api/spec/requests/spree/api/taxonomies_controller_spec.rb
+++ b/api/spec/requests/spree/api/taxonomies_controller_spec.rb
@@ -4,7 +4,6 @@ require 'spec_helper'
 
 module Spree
   describe Api::TaxonomiesController, type: :request do
-
     let(:taxonomy) { create(:taxonomy) }
     let(:taxon) { create(:taxon, name: "Ruby", taxonomy: taxonomy) }
     let(:taxon2) { create(:taxon, name: "Rails", taxonomy: taxonomy) }

--- a/api/spec/requests/spree/api/taxons_controller_spec.rb
+++ b/api/spec/requests/spree/api/taxons_controller_spec.rb
@@ -4,7 +4,6 @@ require 'spec_helper'
 
 module Spree
   describe Api::TaxonsController, type: :request do
-
     let(:taxonomy) { create(:taxonomy) }
     let(:taxon) { create(:taxon, name: "Ruby", taxonomy: taxonomy) }
     let(:taxon2) { create(:taxon, name: "Rails", taxonomy: taxonomy) }

--- a/api/spec/requests/spree/api/unauthenticated_products_controller_spec.rb
+++ b/api/spec/requests/spree/api/unauthenticated_products_controller_spec.rb
@@ -5,7 +5,6 @@ require 'spec_helper'
 
 module Spree
   describe Spree::Api::ProductsController, type: :request do
-
     let!(:product) { create(:product) }
     let(:attributes) { [:id, :name, :description, :price, :available_on, :slug, :meta_description, :meta_keywords, :taxon_ids, :meta_title] }
 

--- a/api/spec/requests/spree/api/users_controller_spec.rb
+++ b/api/spec/requests/spree/api/users_controller_spec.rb
@@ -4,7 +4,6 @@ require 'spec_helper'
 
 module Spree
   describe Api::UsersController, type: :request do
-
     let(:user) { create(:user, spree_api_key: SecureRandom.hex) }
     let(:stranger) { create(:user, email: 'stranger@example.com') }
     let(:attributes) { [:id, :email, :created_at, :updated_at] }

--- a/api/spec/requests/spree/api/variants_controller_spec.rb
+++ b/api/spec/requests/spree/api/variants_controller_spec.rb
@@ -4,7 +4,6 @@ require 'spec_helper'
 
 module Spree
   describe Api::VariantsController, type: :request do
-
     let!(:product) { create(:product) }
     let!(:variant) do
       variant = product.master
@@ -89,7 +88,6 @@ module Spree
       end
 
       context "stock filtering" do
-
         context "only variants in stock" do
           subject { get spree.api_variants_path, params: { in_stock_only: "true" } }
 

--- a/api/spec/requests/spree/api/zones_controller_spec.rb
+++ b/api/spec/requests/spree/api/zones_controller_spec.rb
@@ -4,7 +4,6 @@ require 'spec_helper'
 
 module Spree
   describe Api::ZonesController, type: :request do
-
     let!(:attributes) { [:id, :name, :zone_members] }
     let!(:zone) { create(:zone, name: 'Europe') }
 

--- a/api/spec/spec_helper.rb
+++ b/api/spec/spec_helper.rb
@@ -11,7 +11,7 @@ ENV["RAILS_ENV"] ||= 'test'
 require 'solidus_api'
 require 'spree/testing_support/dummy_app'
 DummyApp.setup(
-  gem_root: File.expand_path('../../', __FILE__),
+  gem_root: File.expand_path('..', __dir__),
   lib_name: 'solidus_api'
 )
 

--- a/api/spec/test_views/spree/api/widgets/_widget.json.jbuilder
+++ b/api/spec/test_views/spree/api/widgets/_widget.json.jbuilder
@@ -1,2 +1,3 @@
 # frozen_string_literal: true
+
 json.(widget, :id, :name, :position)

--- a/api/spec/test_views/spree/api/widgets/index.json.jbuilder
+++ b/api/spec/test_views/spree/api/widgets/index.json.jbuilder
@@ -5,5 +5,5 @@ json.widgets(@collection) do |widget|
   json.partial!("spree/api/widgets/widget", widget: widget)
 end
 json.count @collection.count
-json.current_page (params[:page] or 1)
+json.current_page (params[:page] || 1)
 json.pages @collection.total_pages

--- a/api/spec/test_views/spree/api/widgets/index.json.jbuilder
+++ b/api/spec/test_views/spree/api/widgets/index.json.jbuilder
@@ -5,5 +5,5 @@ json.widgets(@collection) do |widget|
   json.partial!("spree/api/widgets/widget", widget: widget)
 end
 json.count @collection.count
-json.current_page (params[:page] || 1)
+json.current_page(params[:page] || 1)
 json.pages @collection.total_pages

--- a/backend/Rakefile
+++ b/backend/Rakefile
@@ -12,7 +12,7 @@ RSpec::Core::RakeTask.new
 task default: [:spec, 'spec:js']
 
 DummyApp::RakeTasks.new(
-  gem_root: File.expand_path('../', __FILE__),
+  gem_root: File.expand_path(__dir__),
   lib_name: 'solidus_backend'
 )
 
@@ -28,7 +28,7 @@ task :teaspoon do
     driver_options: ENV["driver_options"],
   }
 
-  options.delete_if { |k, v| v.nil? }
+  options.delete_if { |_k, v| v.nil? }
 
   abort("rake teaspoon failed") if Teaspoon::Console.new(options).failures?
 end
@@ -37,7 +37,7 @@ desc "Run javascript specs"
 task 'spec:js' => :teaspoon
 
 namespace :teaspoon do
-  task :server  do
+  task :server do
     require 'teaspoon'
     Rake::Task['dummy_environment'].invoke
     require 'teaspoon/server'

--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -32,7 +32,7 @@ module Spree
         if params[:q][:created_at_gt].present?
           params[:q][:created_at_gt] = begin
                                          Time.zone.parse(params[:q][:created_at_gt]).beginning_of_day
-                                       rescue
+                                       rescue StandardError
                                          ""
                                        end
         end
@@ -40,7 +40,7 @@ module Spree
         if params[:q][:created_at_lt].present?
           params[:q][:created_at_lt] = begin
                                          Time.zone.parse(params[:q][:created_at_lt]).end_of_day
-                                       rescue
+                                       rescue StandardError
                                          ""
                                        end
         end

--- a/backend/app/controllers/spree/admin/stock_locations_controller.rb
+++ b/backend/app/controllers/spree/admin/stock_locations_controller.rb
@@ -9,7 +9,6 @@ module Spree
 
       def set_country
         @stock_location.country = Spree::Country.default
-
       rescue ActiveRecord::RecordNotFound
         flash[:error] = t('spree.stock_locations_need_a_default_country')
         redirect_to(admin_stock_locations_path) && return

--- a/backend/app/controllers/spree/admin/users_controller.rb
+++ b/backend/app/controllers/spree/admin/users_controller.rb
@@ -74,7 +74,8 @@ module Spree
         @search = Spree::Order.includes(
           line_items: {
             variant: [:product, { option_values: :option_type }]
-          }).ransack(params[:q].merge(user_id_eq: @user.id))
+          }
+).ransack(params[:q].merge(user_id_eq: @user.id))
         @orders = @search.result.page(params[:page]).per(Spree::Config[:admin_products_per_page])
       end
 

--- a/backend/app/helpers/spree/admin/base_helper.rb
+++ b/backend/app/helpers/spree/admin/base_helper.rb
@@ -116,12 +116,13 @@ module Spree
       end
 
       # renders hidden field and link to remove record using nested_attributes
-      def link_to_remove_fields(name, f, options = {})
+      def link_to_remove_fields(name, form, options = {})
         name = '' if options[:no_text]
         options[:class] = '' unless options[:class]
         options[:class] += 'no-text with-tip' if options[:no_text]
-        url = f.object.persisted? ? [:admin, f.object] : '#'
-        link_to_with_icon('trash', name, url, class: "spree_remove_fields #{options[:class]}", data: { action: 'remove' }, title: t('spree.actions.remove')) + f.hidden_field(:_destroy)
+        url = form.object.persisted? ? [:admin, form.object] : '#'
+        link_to_with_icon('trash', name, url, class: "spree_remove_fields #{options[:class]}", data: { action: 'remove' }, title: t('spree.actions.remove')) +
+          form.hidden_field(:_destroy)
       end
 
       def spree_dom_id(record)

--- a/backend/app/helpers/spree/admin/navigation_helper.rb
+++ b/backend/app/helpers/spree/admin/navigation_helper.rb
@@ -20,9 +20,10 @@ module Spree
         end
 
         content_tag :ol, class: 'breadcrumb' do
-          safe_join admin_breadcrumbs.map { |level|
+          segments = admin_breadcrumbs.map do |level|
             content_tag(:li, level, class: "breadcrumb-item #{level == admin_breadcrumbs.last ? 'active' : ''}")
-          }
+          end
+          safe_join(segments)
         end
       end
 

--- a/backend/app/helpers/spree/admin/navigation_helper.rb
+++ b/backend/app/helpers/spree/admin/navigation_helper.rb
@@ -140,7 +140,7 @@ module Spree
         Spree::Deprecation.warn "Passing button_link_to is deprecated. Use either link_to or button_to instead.", caller
         html_options = { class: '' }.merge(html_options)
         if html_options[:method] &&
-           html_options[:method].to_s.downcase != 'get' &&
+           !html_options[:method].to_s.casecmp('get').zero? &&
            !html_options[:remote]
           form_tag(url, method: html_options.delete(:method)) do
             html_options.delete(:icon)
@@ -185,7 +185,6 @@ module Spree
           link_to(link_text, url)
         end
       end
-
     end
   end
 end

--- a/backend/script/rails
+++ b/backend/script/rails
@@ -3,8 +3,8 @@
 
 # This command will automatically be run when you run "rails" with Rails 3 gems installed from the root of your application.
 
-ENGINE_ROOT = File.expand_path('../..', __FILE__)
-ENGINE_PATH = File.expand_path('../../lib/spree/backend/engine', __FILE__)
+ENGINE_ROOT = File.expand_path('..', __dir__)
+ENGINE_PATH = File.expand_path('../lib/spree/backend/engine', __dir__)
 
 require 'rails/all'
 require 'rails/engine/commands'

--- a/backend/solidus_backend.gemspec
+++ b/backend/solidus_backend.gemspec
@@ -24,13 +24,13 @@ Gem::Specification.new do |s|
   s.add_dependency 'solidus_api', s.version
   s.add_dependency 'solidus_core', s.version
 
-  s.add_dependency 'sass-rails'
   s.add_dependency 'coffee-rails'
-  s.add_dependency 'jquery-rails'
   s.add_dependency 'font-awesome-rails', '~> 4.0'
-  s.add_dependency 'kaminari', '~> 1.1'
   s.add_dependency 'jbuilder', '~> 2.6'
+  s.add_dependency 'jquery-rails'
+  s.add_dependency 'kaminari', '~> 1.1'
+  s.add_dependency 'sass-rails'
 
-  s.add_dependency 'handlebars_assets', '~> 0.23'
   s.add_dependency 'autoprefixer-rails', '~> 7.1'
+  s.add_dependency 'handlebars_assets', '~> 0.23'
 end

--- a/backend/spec/features/admin/orders/customer_details_spec.rb
+++ b/backend/spec/features/admin/orders/customer_details_spec.rb
@@ -201,6 +201,6 @@ describe "Customer Details", type: :feature, js: true do
     fill_in "City",                    with: "Bethesda"
     fill_in "Zip Code",                with: "20170"
     select 'Alabama', from: "State"
-    fill_in "Phone",                   with: "123-456-7890"
+    fill_in "Phone", with: "123-456-7890"
   end
 end

--- a/backend/spec/features/admin/orders/new_order_spec.rb
+++ b/backend/spec/features/admin/orders/new_order_spec.rb
@@ -209,6 +209,6 @@ describe "New Order", type: :feature do
     fill_in "City",                      with: "Bethesda"
     fill_in "Zip Code",                  with: "20170"
     select state.name, from: "State"
-    fill_in "Phone",                     with: "123-456-7890"
+    fill_in "Phone", with: "123-456-7890"
   end
 end

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -480,7 +480,7 @@ describe "Order Details", type: :feature, js: true do
 
           @first_line_item  = order.contents.add(product2.master)
           @first_line_item.update_columns(created_at: 1.day.ago)
-          @last_line_item  = order.contents.add(product3.master)
+          @last_line_item = order.contents.add(product3.master)
           @last_line_item.update_columns(created_at: 1.day.from_now)
         end
 

--- a/backend/spec/features/admin/orders/payments_spec.rb
+++ b/backend/spec/features/admin/orders/payments_spec.rb
@@ -11,8 +11,7 @@ describe 'Payments', type: :feature do
         order:          order,
         amount:         order.outstanding_balance,
         payment_method: create(:credit_card_payment_method),
-        state:          state
-      )
+        state:          state)
     end
 
     let(:order) { create(:completed_order_with_totals, number: 'R100', line_items_price: 50) }
@@ -29,8 +28,7 @@ describe 'Payments', type: :feature do
         create(:payment,
           order:          order,
           amount:         order.outstanding_balance,
-          payment_method: create(:check_payment_method, available_to_admin: true) # Check
-        )
+          payment_method: create(:check_payment_method, available_to_admin: true)) # Check
       end
 
       it 'capturing a check payment from a new order' do
@@ -222,8 +220,7 @@ describe 'Payments', type: :feature do
         create(:payment,
           order:          order,
           amount:         order.outstanding_balance,
-          payment_method: payment_method
-        )
+          payment_method: payment_method)
       end
 
       before do

--- a/backend/spec/features/admin/promotions/tiered_calculator_spec.rb
+++ b/backend/spec/features/admin/promotions/tiered_calculator_spec.rb
@@ -51,7 +51,7 @@ feature "Tiered Calculator Promotions" do
 
       action.calculator = Spree::Calculator::TieredFlatRate.new
       action.calculator.preferred_base_amount = 5
-      action.calculator.preferred_tiers = {100 => 10, 200 => 15, 300 => 20}
+      action.calculator.preferred_tiers = { 100 => 10, 200 => 15, 300 => 20 }
       action.calculator.save!
 
       visit spree.edit_admin_promotion_path(promotion)

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -12,7 +12,7 @@ ENV["RAILS_ENV"] ||= 'test'
 require 'solidus_backend'
 require 'spree/testing_support/dummy_app'
 DummyApp.setup(
-  gem_root: File.expand_path('../../', __FILE__),
+  gem_root: File.expand_path('..', __dir__),
   lib_name: 'solidus_backend'
 )
 

--- a/backend/spec/teaspoon_env.rb
+++ b/backend/spec/teaspoon_env.rb
@@ -59,7 +59,7 @@ else
   require 'spree/testing_support/dummy_app'
 
   DummyApp.setup(
-    gem_root: File.expand_path('../../', __FILE__),
+    gem_root: File.expand_path('..', __dir__),
     lib_name: 'solidus_backend',
     auto_migrate: false
   )

--- a/backend/spec/views/spree/admin/shared/navigation_footer_spec.rb
+++ b/backend/spec/views/spree/admin/shared/navigation_footer_spec.rb
@@ -39,5 +39,4 @@ describe "spree/admin/shared/_navigation_footer", type: :view do
       expect(rendered).to have_link(I18n.t('spree.back_to_store'), href: "/")
     end
   end
-
 end

--- a/build-ci.rb
+++ b/build-ci.rb
@@ -48,7 +48,7 @@ class Project
   #
   # @return [Boolean]
   def self.bundle_check
-    system(*%W[bundle check --path=#{VENDOR_BUNDLE}])
+    system("bundle", "check", "--path=#{VENDOR_BUNDLE}")
   end
   private_class_method :bundle_check
 
@@ -57,13 +57,7 @@ class Project
   # @return [Boolean]
   #   the success of the installation
   def self.bundle_install
-    system(*%W[
-      bundle
-      install
-      --path=#{VENDOR_BUNDLE}
-      --jobs=#{BUNDLER_JOBS}
-      --retry=#{BUNDLER_RETRIES}
-    ])
+    system("bundle", "install", "--path=#{VENDOR_BUNDLE}", "--jobs=#{BUNDLER_JOBS}", "--retry=#{BUNDLER_RETRIES}")
   end
   private_class_method :bundle_check
 
@@ -125,7 +119,7 @@ class Project
   #
   # @return [void]
   def self.log(message)
-    $stderr.puts(message)
+    warn(message)
   end
   private_class_method :log
 

--- a/build-ci.rb
+++ b/build-ci.rb
@@ -196,6 +196,6 @@ class Project
   def chdir(&block)
     Dir.chdir(ROOT.join(name), &block)
   end
-end # Project
+end
 
 exit Project.run_cli(ARGV)

--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -37,10 +37,12 @@ module Spree
         meta[:description] = truncate(strip_tags(object.description), length: 160, separator: ' ')
       end
 
-      meta.reverse_merge!({
-        keywords: current_store.meta_keywords,
-        description: current_store.meta_description
-      }) if meta[:keywords].blank? || meta[:description].blank?
+      if meta[:keywords].blank? || meta[:description].blank?
+        meta.reverse_merge!({
+          keywords: current_store.meta_keywords,
+          description: current_store.meta_description
+        })
+      end
       meta
     end
 

--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -20,8 +20,8 @@ module Spree
     end
 
     # human readable list of variant options
-    def variant_options(v, _options = {})
-      v.options_text
+    def variant_options(variant, _options = {})
+      variant.options_text
     end
 
     def meta_data

--- a/core/app/jobs/spree/promotion_code_batch_job.rb
+++ b/core/app/jobs/spree/promotion_code_batch_job.rb
@@ -14,7 +14,7 @@ module Spree
           .promotion_code_batch_finished(promotion_code_batch)
           .deliver_now
       end
-    rescue => e
+    rescue StandardError => e
       if promotion_code_batch.email?
         Spree::PromotionCodeBatchMailer
           .promotion_code_batch_errored(promotion_code_batch)

--- a/core/app/mailers/spree/carton_mailer.rb
+++ b/core/app/mailers/spree/carton_mailer.rb
@@ -15,7 +15,7 @@ module Spree
     # Note: The signature of this method has changed. The new (non-deprecated)
     # signature is:
     #   def shipped_email(carton:, order:, resend: false)
-    def shipped_email(options, deprecated_options = {})
+    def shipped_email(options, _deprecated_options = {})
       @order = options.fetch(:order)
       @carton = options.fetch(:carton)
       @manifest = @carton.manifest_for_order(@order)

--- a/core/app/models/spree/credit_card.rb
+++ b/core/app/models/spree/credit_card.rb
@@ -11,8 +11,8 @@ module Spree
 
     accepts_nested_attributes_for :address
 
-    attr_reader :number
-    attr_accessor :encrypted_data, :verification_value
+    attr_reader :number, :verification_value
+    attr_accessor :encrypted_data
 
     validates :month, :year, numericality: { only_integer: true }, if: :require_card_numbers?, on: :create
     validates :number, presence: true, if: :require_card_numbers?, on: :create, unless: :imported

--- a/core/app/models/spree/customer_return.rb
+++ b/core/app/models/spree/customer_return.rb
@@ -66,7 +66,7 @@ module Spree
     end
 
     def return_items_belong_to_same_order
-      if return_items.select{ |return_item| return_item.inventory_unit.order_id != order_id }.any?
+      if return_items.reject{ |return_item| return_item.inventory_unit.order_id == order_id }.any?
         errors.add(:base, I18n.t('spree.return_items_cannot_be_associated_with_multiple_orders'))
       end
     end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -522,7 +522,7 @@ module Spree
     def coupon_code=(code)
       @coupon_code = begin
                        code.strip.downcase
-                     rescue
+                     rescue StandardError
                        nil
                      end
     end
@@ -578,7 +578,7 @@ module Spree
         state: 'cart',
         updated_at: Time.current
       )
-      next! if line_items.size > 0
+      next! if !line_items.empty?
     end
 
     def refresh_shipment_rates

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -8,10 +8,10 @@ module Spree
       end
 
       module ClassMethods
-        attr_accessor :next_event_transitions
         attr_accessor :previous_states
-        attr_accessor :checkout_steps
-        attr_accessor :removed_transitions
+        attr_writer :next_event_transitions
+        attr_writer :checkout_steps
+        attr_writer :removed_transitions
 
         def checkout_flow(&block)
           if block_given?

--- a/core/app/models/spree/order_cancellations.rb
+++ b/core/app/models/spree/order_cancellations.rb
@@ -26,7 +26,7 @@ class Spree::OrderCancellations
   # @param [String] whodunnit the system or person that is short shipping the inventory units
   #
   # @return [Array<UnitCancel>] the units that have been canceled due to short shipping
-  def short_ship(inventory_units, whodunnit:nil)
+  def short_ship(inventory_units, whodunnit: nil)
     if inventory_units.map(&:order_id).uniq != [@order.id]
       raise ArgumentError, "Not all inventory units belong to this order"
     end
@@ -62,7 +62,7 @@ class Spree::OrderCancellations
   # @param [String] whodunnit the system or person that is canceling the inventory unit
   #
   # @return [UnitCancel] the unit that has been canceled
-  def cancel_unit(inventory_unit, reason: Spree::UnitCancel::DEFAULT_REASON, whodunnit:nil)
+  def cancel_unit(inventory_unit, reason: Spree::UnitCancel::DEFAULT_REASON, whodunnit: nil)
     unit_cancel = nil
 
     Spree::OrderMutex.with_lock!(@order) do
@@ -97,7 +97,7 @@ class Spree::OrderCancellations
 
   private
 
-  def short_ship_unit(inventory_unit, whodunnit:nil)
+  def short_ship_unit(inventory_unit, whodunnit: nil)
     unit_cancel = Spree::UnitCancel.create!(
       inventory_unit: inventory_unit,
       reason: Spree::UnitCancel::SHORT_SHIP,

--- a/core/app/models/spree/order_mutex.rb
+++ b/core/app/models/spree/order_mutex.rb
@@ -27,7 +27,6 @@ module Spree
         end
 
         yield
-
       ensure
         order_mutex.destroy if order_mutex
       end

--- a/core/app/models/spree/price.rb
+++ b/core/app/models/spree/price.rb
@@ -36,7 +36,7 @@ module Spree
     money_methods :amount, :price
     alias_method :money, :display_amount
 
-    self.whitelisted_ransackable_attributes = %w( amount variant_id currency country_iso )
+    self.whitelisted_ransackable_attributes = %w(amount variant_id currency country_iso)
 
     # An alias for #amount
     def price

--- a/core/app/models/spree/promotion/rules/product.rb
+++ b/core/app/models/spree/promotion/rules/product.rb
@@ -65,8 +65,8 @@ module Spree
           product_ids.join(',')
         end
 
-        def product_ids_string=(s)
-          self.product_ids = s.to_s.split(',').map(&:strip)
+        def product_ids_string=(product_ids)
+          self.product_ids = product_ids.to_s.split(',').map(&:strip)
         end
       end
     end

--- a/core/app/models/spree/promotion/rules/store.rb
+++ b/core/app/models/spree/promotion/rules/store.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Spree
   class Promotion
     module Rules

--- a/core/app/models/spree/promotion/rules/taxon.rb
+++ b/core/app/models/spree/promotion/rules/taxon.rb
@@ -73,9 +73,9 @@ module Spree
           taxons.pluck(:id).join(',')
         end
 
-        def taxon_ids_string=(s)
-          ids = s.to_s.split(',').map(&:strip)
-          self.taxons = Spree::Taxon.find(ids)
+        def taxon_ids_string=(taxon_ids)
+          taxon_ids = taxon_ids.to_s.split(',').map(&:strip)
+          self.taxons = Spree::Taxon.find(taxon_ids)
         end
 
         private

--- a/core/app/models/spree/promotion/rules/taxon.rb
+++ b/core/app/models/spree/promotion/rules/taxon.rb
@@ -97,7 +97,6 @@ module Spree
         def rule_taxon_ids_with_children
           taxons.flat_map { |taxon| taxon.self_and_descendants.ids }.uniq
         end
-
       end
     end
   end

--- a/core/app/models/spree/promotion/rules/user.rb
+++ b/core/app/models/spree/promotion/rules/user.rb
@@ -21,8 +21,8 @@ module Spree
           user_ids.join(',')
         end
 
-        def user_ids_string=(s)
-          self.user_ids = s.to_s.split(',').map(&:strip)
+        def user_ids_string=(user_ids)
+          self.user_ids = user_ids.to_s.split(',').map(&:strip)
         end
       end
     end

--- a/core/app/models/spree/promotion_code/batch_builder.rb
+++ b/core/app/models/spree/promotion_code/batch_builder.rb
@@ -34,7 +34,7 @@ class ::Spree::PromotionCode::BatchBuilder
   def build_promotion_codes
     generate_random_codes
     promotion_code_batch.update!(state: "completed")
-  rescue => e
+  rescue StandardError => e
     promotion_code_batch.update!(
       error: e.inspect,
       state: "failed"

--- a/core/app/models/spree/promotion_handler/coupon.rb
+++ b/core/app/models/spree/promotion_handler/coupon.rb
@@ -25,14 +25,14 @@ module Spree
         self
       end
 
-      def set_success_code(c)
-        @status_code = c
-        @success = I18n.t(c, scope: 'spree')
+      def set_success_code(status_code)
+        @status_code = status_code
+        @success = I18n.t(status_code, scope: 'spree')
       end
 
-      def set_error_code(c)
-        @status_code = c
-        @error = I18n.t(c, scope: 'spree')
+      def set_error_code(status_code)
+        @status_code = status_code
+        @error = I18n.t(status_code, scope: 'spree')
       end
 
       def promotion

--- a/core/app/models/spree/promotion_rule_store.rb
+++ b/core/app/models/spree/promotion_rule_store.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Spree
   class PromotionRuleStore < Spree::Base
     self.table_name = "spree_promotion_rules_stores"

--- a/core/app/models/spree/return_item/eligibility_validator/inventory_shipped.rb
+++ b/core/app/models/spree/return_item/eligibility_validator/inventory_shipped.rb
@@ -6,10 +6,10 @@ module Spree
       class InventoryShipped < Spree::ReturnItem::EligibilityValidator::BaseValidator
         def eligible_for_return?
           if @return_item.inventory_unit.shipped?
-            return true
+            true
           else
             add_error(:inventory_unit_shipped, I18n.t('spree.return_item_inventory_unit_ineligible'))
-            return false
+            false
           end
         end
 

--- a/core/app/models/spree/return_item/eligibility_validator/no_reimbursements.rb
+++ b/core/app/models/spree/return_item/eligibility_validator/no_reimbursements.rb
@@ -4,13 +4,12 @@ module Spree
   class ReturnItem < Spree::Base
     module EligibilityValidator
       class NoReimbursements < Spree::ReturnItem::EligibilityValidator::BaseValidator
-
         def eligible_for_return?
           if @return_item.inventory_unit.return_items.reimbursed.valid.any?
             add_error(:inventory_unit_reimbursed, I18n.t('spree.return_item_inventory_unit_reimbursed'))
-            return false
+            false
           else
-            return true
+            true
           end
         end
 

--- a/core/app/models/spree/return_item/eligibility_validator/order_completed.rb
+++ b/core/app/models/spree/return_item/eligibility_validator/order_completed.rb
@@ -6,10 +6,10 @@ module Spree
       class OrderCompleted < Spree::ReturnItem::EligibilityValidator::BaseValidator
         def eligible_for_return?
           if @return_item.inventory_unit.order.completed?
-            return true
+            true
           else
             add_error(:order_not_completed, I18n.t('spree.return_item_order_not_completed'))
-            return false
+            false
           end
         end
 

--- a/core/app/models/spree/return_item/eligibility_validator/rma_required.rb
+++ b/core/app/models/spree/return_item/eligibility_validator/rma_required.rb
@@ -6,10 +6,10 @@ module Spree
       class RMARequired < Spree::ReturnItem::EligibilityValidator::BaseValidator
         def eligible_for_return?
           if @return_item.return_authorization.present?
-            return true
+            true
           else
             add_error(:rma_required, I18n.t('spree.return_item_rma_ineligible'))
-            return false
+            false
           end
         end
 

--- a/core/app/models/spree/return_item/eligibility_validator/time_since_purchase.rb
+++ b/core/app/models/spree/return_item/eligibility_validator/time_since_purchase.rb
@@ -6,10 +6,10 @@ module Spree
       class TimeSincePurchase < Spree::ReturnItem::EligibilityValidator::BaseValidator
         def eligible_for_return?
           if (@return_item.inventory_unit.order.completed_at + Spree::Config[:return_eligibility_number_of_days].days) > Time.current
-            return true
+            true
           else
             add_error(:number_of_days, I18n.t('spree.return_item_time_period_ineligible'))
-            return false
+            false
           end
         end
 

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -244,10 +244,12 @@ module Spree
     def selected_shipping_rate_id=(id)
       return if selected_shipping_rate_id == id
       new_rate = shipping_rates.detect { |rate| rate.id == id.to_i }
-      fail(
-        ArgumentError,
-        "Could not find shipping rate id #{id} for shipment #{number}"
-      ) unless new_rate
+      unless new_rate
+        fail(
+          ArgumentError,
+          "Could not find shipping rate id #{id} for shipment #{number}"
+        )
+      end
 
       transaction do
         selected_shipping_rate.update!(selected: false) if selected_shipping_rate

--- a/core/app/models/spree/store_credit.rb
+++ b/core/app/models/spree/store_credit.rb
@@ -192,7 +192,7 @@ class Spree::StoreCredit < Spree::PaymentSource
       save
     else
       errors.add(:invalidated_at, I18n.t('spree.store_credit.errors.cannot_invalidate_uncaptured_authorization'))
-      return false
+      false
     end
   end
 

--- a/core/app/models/spree/store_shipping_method.rb
+++ b/core/app/models/spree/store_shipping_method.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Spree
   class StoreShippingMethod < Spree::Base
     belongs_to :store, inverse_of: :store_shipping_methods

--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -138,7 +138,7 @@ module Spree
       )
     end
 
-    def translation_key(amount)
+    def translation_key(_amount)
       key = included_in_price? ? "vat" : "sales_tax"
       key += "_with_rate" if show_rate_in_label?
       key.to_sym

--- a/core/app/models/spree/zone.rb
+++ b/core/app/models/spree/zone.rb
@@ -60,7 +60,7 @@ module Spree
     end
 
     def kind
-      if members.any? && !members.any? { |member| member.try(:zoneable_type).nil? }
+      if members.any? && members.none? { |member| member.try(:zoneable_type).nil? }
         members.last.zoneable_type.demodulize.underscore
       end
     end

--- a/core/db/migrate/20180202190713_create_promotion_rule_stores.rb
+++ b/core/db/migrate/20180202190713_create_promotion_rule_stores.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreatePromotionRuleStores < ActiveRecord::Migration[5.1]
   def change
     create_table :spree_promotion_rules_stores do |t|

--- a/core/db/migrate/20180202222641_create_store_shipping_methods.rb
+++ b/core/db/migrate/20180202222641_create_store_shipping_methods.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateStoreShippingMethods < ActiveRecord::Migration[5.1]
   def change
     create_table :spree_store_shipping_methods do |t|

--- a/core/db/seeds.rb
+++ b/core/db/seeds.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-# Loads seed data out of default dir
-default_path = File.join(File.dirname(__FILE__), 'default')
-
 %w(
   stores
   store_credit

--- a/core/lib/generators/spree/dummy/dummy_generator.rb
+++ b/core/lib/generators/spree/dummy/dummy_generator.rb
@@ -13,7 +13,7 @@ module Spree
 
     def self.source_paths
       paths = superclass.source_paths
-      paths << File.expand_path('../templates', __FILE__)
+      paths << File.expand_path('templates', __dir__)
       paths.flatten
     end
 
@@ -111,7 +111,6 @@ end
 
     def application_definition
       @application_definition ||= begin
-
         dummy_application_path = File.expand_path("#{dummy_path}/config/application.rb", destination_root)
         unless options[:pretend] || !File.exist?(dummy_application_path)
           contents = File.read(dummy_application_path)

--- a/core/lib/generators/spree/install/install_generator.rb
+++ b/core/lib/generators/spree/install/install_generator.rb
@@ -22,7 +22,7 @@ module Spree
       paths = superclass.source_paths
       paths << File.expand_path('../templates', "../../#{__FILE__}")
       paths << File.expand_path('../templates', "../#{__FILE__}")
-      paths << File.expand_path('../templates', __FILE__)
+      paths << File.expand_path('templates', __dir__)
       paths.flatten
     end
 

--- a/core/lib/generators/spree/install/install_generator.rb
+++ b/core/lib/generators/spree/install/install_generator.rb
@@ -43,15 +43,15 @@ module Spree
 
     def additional_tweaks
       return unless File.exist? 'public/robots.txt'
-      append_file "public/robots.txt", <<-ROBOTS
-User-agent: *
-Disallow: /checkout
-Disallow: /cart
-Disallow: /orders
-Disallow: /user
-Disallow: /account
-Disallow: /api
-Disallow: /password
+      append_file "public/robots.txt", <<-ROBOTS.strip_heredoc
+        User-agent: *
+        Disallow: /checkout
+        Disallow: /cart
+        Disallow: /orders
+        Disallow: /user
+        Disallow: /account
+        Disallow: /api
+        Disallow: /password
       ROBOTS
     end
 
@@ -102,10 +102,10 @@ Disallow: /password
     end
 
     def include_seed_data
-      append_file "db/seeds.rb", <<-SEEDS
-\n
-Spree::Core::Engine.load_seed if defined?(Spree::Core)
-Spree::Auth::Engine.load_seed if defined?(Spree::Auth)
+      append_file "db/seeds.rb", <<-SEEDS.strip_heredoc
+
+        Spree::Core::Engine.load_seed if defined?(Spree::Core)
+        Spree::Auth::Engine.load_seed if defined?(Spree::Auth)
       SEEDS
     end
 

--- a/core/lib/spree/core/environment_extension.rb
+++ b/core/lib/spree/core/environment_extension.rb
@@ -11,7 +11,7 @@ module Spree
         def add_class_set(name)
           define_method(name) do
             set = instance_variable_get("@#{name}")
-            set = send("#{name}=", []) unless set
+            set ||= send("#{name}=", [])
             set
           end
 

--- a/core/lib/spree/core/search/base.rb
+++ b/core/lib/spree/core/search/base.rb
@@ -46,6 +46,10 @@ module Spree
           end
         end
 
+        def respond_to_missing?(name)
+          @properties.key?(name) || super(name)
+        end
+
         protected
 
         def get_base_scope

--- a/core/lib/spree/money.rb
+++ b/core/lib/spree/money.rb
@@ -100,13 +100,13 @@ module Spree
       if !other.respond_to?(:money)
         raise TypeError, "Can't compare #{other.class} to Spree::Money"
       end
-      if self.currency != other.currency
+      if currency != other.currency
         # By default, ::Money will try to run a conversion on `other.money` and
         # try a comparison on that. We do not want any currency conversion to
         # take place so we'll catch this here and raise an error.
         raise(
           DifferentCurrencyError,
-          "Can't compare #{self.currency} with #{other.currency}"
+          "Can't compare #{currency} with #{other.currency}"
         )
       end
       @money <=> other.money

--- a/core/lib/spree/testing_support/capybara_ext.rb
+++ b/core/lib/spree/testing_support/capybara_ext.rb
@@ -128,7 +128,7 @@ RSpec::Matchers.define :have_meta do |name, expected|
     has_css?("meta[name='#{name}'][content='#{expected}']", visible: false)
   end
 
-  failure_message do |actual|
+  failure_message do
     actual = first("meta[name='#{name}']")
     if actual
       "expected that meta #{name} would have content='#{expected}' but was '#{actual[:content]}'"

--- a/core/lib/spree/testing_support/dummy_app.rb
+++ b/core/lib/spree/testing_support/dummy_app.rb
@@ -75,13 +75,13 @@ module DummyApp
     config.action_controller.include_all_helpers = false
 
     if config.respond_to?(:assets)
-      config.assets.paths << File.expand_path('../dummy_app/assets/javascripts', __FILE__)
-      config.assets.paths << File.expand_path('../dummy_app/assets/stylesheets', __FILE__)
+      config.assets.paths << File.expand_path('dummy_app/assets/javascripts', __dir__)
+      config.assets.paths << File.expand_path('dummy_app/assets/stylesheets', __dir__)
     end
 
-    config.paths["config/database"] = File.expand_path('../dummy_app/database.yml', __FILE__)
-    config.paths['app/views'] = File.expand_path('../dummy_app/views', __FILE__)
-    config.paths['config/routes.rb'] = File.expand_path('../dummy_app/routes.rb', __FILE__)
+    config.paths["config/database"] = File.expand_path('dummy_app/database.yml', __dir__)
+    config.paths['app/views'] = File.expand_path('dummy_app/views', __dir__)
+    config.paths['config/routes.rb'] = File.expand_path('dummy_app/routes.rb', __dir__)
 
     ActionMailer::Base.default from: "store@example.com"
   end

--- a/core/lib/spree/testing_support/dummy_app/routes.rb
+++ b/core/lib/spree/testing_support/dummy_app/routes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 DummyApp::Application.routes.draw do
   mount Spree::Core::Engine, at: '/'
 end

--- a/core/lib/tasks/core.rake
+++ b/core/lib/tasks/core.rake
@@ -81,9 +81,7 @@ use rake db:load_file[/absolute/path/to/sample/filename.rb]'
     ActiveRecord::Base.send(:subclasses).each(&:reset_column_information)
 
     load_defaults = Spree::Country.count == 0
-    unless load_defaults # ask if there are already Countries => default data hass been loaded
-      load_defaults = prompt_for_agree('Countries present, load sample data anyways? [y/n]: ')
-    end
+    load_defaults ||= prompt_for_agree('Countries present, load sample data anyways? [y/n]: ')
     if load_defaults
       Rake::Task["db:seed"].invoke
     end
@@ -92,7 +90,7 @@ use rake db:load_file[/absolute/path/to/sample/filename.rb]'
       load_sample = prompt_for_agree("WARNING: In Production and products exist in database, load sample data anyways? [y/n]:" )
     else
       load_sample = true if ENV['AUTO_ACCEPT']
-      load_sample = prompt_for_agree('Load Sample Data? [y/n]: ') unless load_sample
+      load_sample ||= prompt_for_agree('Load Sample Data? [y/n]: ')
     end
 
     if load_sample

--- a/core/lib/tasks/order_capturing.rake
+++ b/core/lib/tasks/order_capturing.rake
@@ -11,7 +11,7 @@ namespace :order_capturing do
         if Spree::OrderCapturing.failure_handler
           begin
             Spree::OrderCapturing.new(order).capture_payments
-          rescue Exception => e
+          rescue StandardError => e
             failures << { message: "Order #{order.number} unable to capture. #{e.class}: #{e.message}" }
           end
         else

--- a/core/script/rails
+++ b/core/script/rails
@@ -3,8 +3,8 @@
 
 # This command will automatically be run when you run "rails" with Rails 3 gems installed from the root of your application.
 
-ENGINE_ROOT = File.expand_path('../..', __FILE__)
-ENGINE_PATH = File.expand_path('../../lib/spree/core/engine', __FILE__)
+ENGINE_ROOT = File.expand_path('..', __dir__)
+ENGINE_PATH = File.expand_path('../lib/spree/core/engine', __dir__)
 
 require 'rails/all'
 require 'rails/engine/commands'

--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -30,8 +30,9 @@ Gem::Specification.new do |s|
   s.add_dependency 'activemerchant', '~> 1.66'
   s.add_dependency 'acts_as_list', '~> 0.3'
   s.add_dependency 'awesome_nested_set', '~> 3.0', '>= 3.0.1'
-  s.add_dependency 'carmen', '~> 1.1.0'
   s.add_dependency 'cancancan', '~> 1.10'
+  s.add_dependency 'carmen', '~> 1.1.0'
+  s.add_dependency 'discard'
   s.add_dependency 'friendly_id', '~> 5.0'
   s.add_dependency 'kaminari-activerecord', '~> 1.1'
   s.add_dependency 'monetize', '~> 1.1'
@@ -39,5 +40,4 @@ Gem::Specification.new do |s|
   s.add_dependency 'paranoia', '~> 2.4'
   s.add_dependency 'ransack', '~> 1.8'
   s.add_dependency 'state_machines-activerecord', '~> 0.4'
-  s.add_dependency 'discard'
 end

--- a/core/spec/lib/calculated_adjustments_spec.rb
+++ b/core/spec/lib/calculated_adjustments_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Spree::CalculatedAdjustments do
     end
 
     context 'with calculator_type and calculator_attributes' do
-      subject { Calculable.new(calculator_type: calculator_class.to_s, calculator_attributes: {preferred_amount: 123}) }
+      subject { Calculable.new(calculator_type: calculator_class.to_s, calculator_attributes: { preferred_amount: 123 }) }
 
       it 'can be initialized' do
         expect(subject.calculator).to be_a(calculator_class)

--- a/core/spec/lib/spree/core/importer/order_spec.rb
+++ b/core/spec/lib/spree/core/importer/order_spec.rb
@@ -130,9 +130,11 @@ module Spree
       end
 
       it 'can build an order from API with variant sku' do
-        params = { line_items_attributes: {
-                     "0" => { sku: sku, quantity: 5 }
-} }
+        params = {
+          line_items_attributes: {
+            "0" => { sku: sku, quantity: 5 }
+          }
+        }
 
         order = Importer::Order.import(user, params)
 
@@ -278,13 +280,17 @@ module Spree
 
       context "shipments" do
         let(:params) do
-          { shipments_attributes: [
-              { tracking: '123456789',
+          {
+            shipments_attributes: [
+              {
+                tracking: '123456789',
                 cost: '14.99',
                 shipping_method: shipping_method.name,
                 stock_location: stock_location.name,
-                inventory_units: [{ sku: sku }] }
-          ] }
+                inventory_units: [{ sku: sku }]
+              }
+            ]
+          }
         end
 
         it 'ensures variant exists and is not deleted' do
@@ -325,12 +331,14 @@ module Spree
             {
               completed_at: 2.days.ago,
               shipments_attributes: [
-                { tracking: '123456789',
+                {
+                  tracking: '123456789',
                   cost: '4.99',
                   shipped_at: 1.day.ago,
                   shipping_method: shipping_method.name,
                   stock_location: stock_location.name,
-                  inventory_units: [{ sku: sku }] }
+                  inventory_units: [{ sku: sku }]
+                }
               ]
             }
           end
@@ -355,10 +363,12 @@ module Spree
       end
 
       it 'adds adjustments' do
-        params = { adjustments_attributes: [
+        params = {
+          adjustments_attributes: [
             { label: 'Shipping Discount', amount: -4.99 },
             { label: 'Promotion Discount', amount: -3.00 }
-] }
+          ]
+        }
 
         order = Importer::Order.import(user, params)
         expect(order.adjustments.all?(&:finalized?)).to be true

--- a/core/spec/lib/spree/core/importer/order_spec.rb
+++ b/core/spec/lib/spree/core/importer/order_spec.rb
@@ -131,7 +131,8 @@ module Spree
 
       it 'can build an order from API with variant sku' do
         params = { line_items_attributes: {
-                     "0" => { sku: sku, quantity: 5 } } }
+                     "0" => { sku: sku, quantity: 5 }
+} }
 
         order = Importer::Order.import(user, params)
 
@@ -282,8 +283,7 @@ module Spree
                 cost: '14.99',
                 shipping_method: shipping_method.name,
                 stock_location: stock_location.name,
-                inventory_units: [{ sku: sku }]
-              }
+                inventory_units: [{ sku: sku }] }
           ] }
         end
 
@@ -330,8 +330,7 @@ module Spree
                   shipped_at: 1.day.ago,
                   shipping_method: shipping_method.name,
                   stock_location: stock_location.name,
-                  inventory_units: [{ sku: sku }]
-                }
+                  inventory_units: [{ sku: sku }] }
               ]
             }
           end
@@ -358,7 +357,8 @@ module Spree
       it 'adds adjustments' do
         params = { adjustments_attributes: [
             { label: 'Shipping Discount', amount: -4.99 },
-            { label: 'Promotion Discount', amount: -3.00 }] }
+            { label: 'Promotion Discount', amount: -3.00 }
+] }
 
         order = Importer::Order.import(user, params)
         expect(order.adjustments.all?(&:finalized?)).to be true

--- a/core/spec/models/spree/address_spec.rb
+++ b/core/spec/models/spree/address_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe Spree::Address, type: :model do
       it "both state and state_name are entered but country does not contain the state" do
         address.state = state
         address.state_name = 'maryland'
-        address.country = create :country, states_required: :true
+        address.country = create :country, states_required: true
         expect(address).to be_valid
         expect(address.state_id).to be_nil
       end

--- a/core/spec/models/spree/calculator/flexi_rate_spec.rb
+++ b/core/spec/models/spree/calculator/flexi_rate_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe Spree::Calculator::FlexiRate, type: :model do
   end
 
   it "should allow creation of new object with all the attributes" do
-    attributes = {preferred_first_item: 1, preferred_additional_item: 1, preferred_max_items: 1}
+    attributes = { preferred_first_item: 1, preferred_additional_item: 1, preferred_max_items: 1 }
     calculator = Spree::Calculator::FlexiRate.new(attributes)
     expect(calculator).to have_attributes(attributes)
   end

--- a/core/spec/models/spree/credit_card_spec.rb
+++ b/core/spec/models/spree/credit_card_spec.rb
@@ -33,8 +33,7 @@ RSpec.describe Spree::CreditCard, type: :model do
       purchase: @success_response,
       capture: @success_response,
       void: @success_response,
-      credit: @success_response
-    )
+      credit: @success_response)
 
     allow(@payment).to receive_messages payment_method: @payment_gateway
   end

--- a/core/spec/models/spree/customer_return_spec.rb
+++ b/core/spec/models/spree/customer_return_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Spree::CustomerReturn, type: :model do
 
   describe ".validation" do
     describe "#return_items_belong_to_same_order" do
-      let(:customer_return)       { build(:customer_return) }
+      let(:customer_return) { build(:customer_return) }
 
       let(:first_order) { create(:order_with_line_items) }
       let(:second_order) { first_order }

--- a/core/spec/models/spree/order_inventory_spec.rb
+++ b/core/spec/models/spree/order_inventory_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe Spree::OrderInventory, type: :model do
   let(:variant) { subject.variant }
   let(:stock_item) { shipment.stock_location.stock_item(variant) }
 
-
   subject { described_class.new(order, line_item) }
 
   context "insufficient inventory units" do

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Spree::Order, type: :model do
@@ -604,10 +606,14 @@ RSpec.describe Spree::Order, type: :model do
     context "with more than one payment method" do
       subject { order.available_payment_methods }
 
-      let!(:first_method) { FactoryBot.create(:payment_method, available_to_users: true,
-                                               available_to_admin: true) }
-      let!(:second_method) { FactoryBot.create(:payment_method, available_to_users: true,
-                                               available_to_admin: true) }
+      let!(:first_method) {
+        FactoryBot.create(:payment_method, available_to_users: true,
+                                               available_to_admin: true)
+      }
+      let!(:second_method) {
+        FactoryBot.create(:payment_method, available_to_users: true,
+                                               available_to_admin: true)
+      }
 
       before do
         second_method.move_to_top
@@ -623,8 +629,7 @@ RSpec.describe Spree::Order, type: :model do
 
       let!(:store_with_payment_methods) do
         create(:store,
-          payment_methods: [payment_method_with_store]
-        )
+          payment_methods: [payment_method_with_store])
       end
       let!(:payment_method_with_store) { create(:payment_method) }
       let!(:store_without_payment_methods) { create(:store) }
@@ -640,7 +645,8 @@ RSpec.describe Spree::Order, type: :model do
         end
 
         context 'and the store has an extra payment method unavailable to users' do
-          let!(:admin_only_payment_method) do create(:payment_method,
+          let!(:admin_only_payment_method) do
+            create(:payment_method,
                                                      available_to_users: false,
                                                      available_to_admin: true)
           end

--- a/core/spec/models/spree/payment_method_spec.rb
+++ b/core/spec/models/spree/payment_method_spec.rb
@@ -1,18 +1,28 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Spree::PaymentMethod, type: :model do
-  let!(:payment_method_nil_display)  { create(:payment_method, active: true,
+  let!(:payment_method_nil_display)  {
+    create(:payment_method, active: true,
                                               available_to_users: true,
-                                              available_to_admin: true) }
-  let!(:payment_method_both_display) { create(:payment_method, active: true,
+                                              available_to_admin: true)
+  }
+  let!(:payment_method_both_display) {
+    create(:payment_method, active: true,
                                               available_to_users: true,
-                                              available_to_admin: true) }
-  let!(:payment_method_front_display){ create(:payment_method, active: true,
+                                              available_to_admin: true)
+  }
+  let!(:payment_method_front_display){
+    create(:payment_method, active: true,
                                               available_to_users: true,
-                                              available_to_admin: false) }
-  let!(:payment_method_back_display) { create(:payment_method, active: true,
+                                              available_to_admin: false)
+  }
+  let!(:payment_method_back_display) {
+    create(:payment_method, active: true,
                                               available_to_users: false,
-                                              available_to_admin: true) }
+                                              available_to_admin: true)
+  }
 
   describe "available_to_[<users>, <admin>, <store>]" do
     context "when searching for payment methods available to users and admins" do
@@ -21,14 +31,16 @@ RSpec.describe Spree::PaymentMethod, type: :model do
       it { is_expected.to contain_exactly(payment_method_both_display, payment_method_nil_display) }
 
       context "with a store" do
-        let!(:extra_payment_method_both_display) { create(:payment_method, active: true,
+        let!(:extra_payment_method_both_display) {
+          create(:payment_method, active: true,
                                                     available_to_users: true,
-                                                    available_to_admin: true) }
+                                                    available_to_admin: true)
+        }
         let!(:store_1) do
-          create(:store, payment_methods:[payment_method_nil_display,
-                                          payment_method_both_display,
-                                          payment_method_front_display,
-                                          payment_method_back_display])
+          create(:store, payment_methods: [payment_method_nil_display,
+                                           payment_method_both_display,
+                                           payment_method_front_display,
+                                           payment_method_back_display])
         end
 
         subject { Spree::PaymentMethod.available_to_store( store_1 ).available_to_users.available_to_admin }
@@ -38,7 +50,7 @@ RSpec.describe Spree::PaymentMethod, type: :model do
         context "when the store has no payment methods" do
           subject { Spree::PaymentMethod.available_to_store(store_without_payment_methods) }
           let!(:store_without_payment_methods) do
-            create(:store, payment_methods:[])
+            create(:store, payment_methods: [])
           end
 
           it "returns all payment methods" do
@@ -65,7 +77,7 @@ RSpec.describe Spree::PaymentMethod, type: :model do
     context "when searching for payment methods available to admin" do
       subject { Spree::PaymentMethod.available_to_admin }
 
-      it { is_expected.to contain_exactly(payment_method_back_display, payment_method_both_display, payment_method_nil_display)}
+      it { is_expected.to contain_exactly(payment_method_back_display, payment_method_both_display, payment_method_nil_display) }
     end
 
     context "when searching for payment methods available to a store" do
@@ -122,8 +134,7 @@ RSpec.describe Spree::PaymentMethod, type: :model do
             payment_method_both_display,
             payment_method_front_display,
             payment_method_back_display
-          ]
-        )
+          ])
       end
 
       let!(:store_2) do

--- a/core/spec/models/spree/payment_method_spec.rb
+++ b/core/spec/models/spree/payment_method_spec.rb
@@ -3,26 +3,34 @@
 require 'rails_helper'
 
 RSpec.describe Spree::PaymentMethod, type: :model do
-  let!(:payment_method_nil_display)  {
-    create(:payment_method, active: true,
-                                              available_to_users: true,
-                                              available_to_admin: true)
-  }
-  let!(:payment_method_both_display) {
-    create(:payment_method, active: true,
-                                              available_to_users: true,
-                                              available_to_admin: true)
-  }
-  let!(:payment_method_front_display){
-    create(:payment_method, active: true,
-                                              available_to_users: true,
-                                              available_to_admin: false)
-  }
-  let!(:payment_method_back_display) {
-    create(:payment_method, active: true,
-                                              available_to_users: false,
-                                              available_to_admin: true)
-  }
+  let!(:payment_method_nil_display) do
+    create(:payment_method, {
+      active: true,
+      available_to_users: true,
+      available_to_admin: true
+    })
+  end
+  let!(:payment_method_both_display) do
+    create(:payment_method, {
+      active: true,
+      available_to_users: true,
+      available_to_admin: true
+    })
+  end
+  let!(:payment_method_front_display) do
+    create(:payment_method, {
+      active: true,
+      available_to_users: true,
+      available_to_admin: false
+    })
+  end
+  let!(:payment_method_back_display) do
+    create(:payment_method, {
+      active: true,
+      available_to_users: false,
+      available_to_admin: true
+    })
+  end
 
   describe "available_to_[<users>, <admin>, <store>]" do
     context "when searching for payment methods available to users and admins" do
@@ -31,16 +39,20 @@ RSpec.describe Spree::PaymentMethod, type: :model do
       it { is_expected.to contain_exactly(payment_method_both_display, payment_method_nil_display) }
 
       context "with a store" do
-        let!(:extra_payment_method_both_display) {
-          create(:payment_method, active: true,
-                                                    available_to_users: true,
-                                                    available_to_admin: true)
-        }
+        let!(:extra_payment_method_both_display) do
+          create(:payment_method, {
+            active: true,
+            available_to_users: true,
+            available_to_admin: true
+          })
+        end
         let!(:store_1) do
-          create(:store, payment_methods: [payment_method_nil_display,
-                                           payment_method_both_display,
-                                           payment_method_front_display,
-                                           payment_method_back_display])
+          create(:store, payment_methods: [
+            payment_method_nil_display,
+            payment_method_both_display,
+            payment_method_front_display,
+            payment_method_back_display
+          ])
         end
 
         subject { Spree::PaymentMethod.available_to_store( store_1 ).available_to_users.available_to_admin }

--- a/core/spec/models/spree/product_duplicator_spec.rb
+++ b/core/spec/models/spree/product_duplicator_spec.rb
@@ -7,7 +7,7 @@ module Spree
     let(:product) { create(:product, properties: [create(:property, name: "MyProperty")]) }
     let!(:duplicator) { Spree::ProductDuplicator.new(product) }
 
-    let(:image) { File.open(File.expand_path('../../../fixtures/thinking-cat.jpg', __FILE__)) }
+    let(:image) { File.open(File.expand_path('../../fixtures/thinking-cat.jpg', __dir__)) }
     let(:params) { { viewable_id: product.master.id, viewable_type: 'Spree::Variant', attachment: image, alt: "position 1", position: 1 } }
 
     before do

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -471,7 +471,7 @@ RSpec.describe Spree::Product, type: :model do
 
   context "#images" do
     let(:product) { create(:product) }
-    let(:image) { File.open(File.expand_path('../../../fixtures/thinking-cat.jpg', __FILE__)) }
+    let(:image) { File.open(File.expand_path('../../fixtures/thinking-cat.jpg', __dir__)) }
     let(:params) { { viewable_id: product.master.id, viewable_type: 'Spree::Variant', attachment: image, alt: "position 2", position: 2 } }
 
     before do

--- a/core/spec/models/spree/promotion/actions/create_quantity_adjustments_spec.rb
+++ b/core/spec/models/spree/promotion/actions/create_quantity_adjustments_spec.rb
@@ -227,7 +227,7 @@ module Spree::Promotion::Actions
       end
 
       it "doesn't reload the line_items association" do
-        expect(order.line_items.first.promo_total).to eq -11
+        expect(order.line_items.first.promo_total).to eq(-11)
       end
     end
 

--- a/core/spec/models/spree/promotion/rules/store_spec.rb
+++ b/core/spec/models/spree/promotion/rules/store_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Spree::Promotion::Rules::Store, type: :model do

--- a/core/spec/models/spree/promotion_handler/coupon_spec.rb
+++ b/core/spec/models/spree/promotion_handler/coupon_spec.rb
@@ -9,12 +9,12 @@ module Spree
 
       subject { Coupon.new(order) }
 
-      def expect_order_connection(order:, promotion:, promotion_code:nil)
+      def expect_order_connection(order:, promotion:, promotion_code: nil)
         expect(order.promotions.to_a).to include(promotion)
         expect(order.order_promotions.flat_map(&:promotion_code)).to include(promotion_code)
       end
 
-      def expect_adjustment_creation(adjustable:, promotion:, promotion_code:nil)
+      def expect_adjustment_creation(adjustable:, promotion:, promotion_code: nil)
         expect(adjustable.adjustments.map(&:source).map(&:promotion)).to include(promotion)
         expect(adjustable.adjustments.map(&:promotion_code)).to include(promotion_code)
       end

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe Spree::Promotion, type: :model do
       promotion.created_at = 2.days.ago
 
       @user = create(:user)
-      @order = create(:order, user: @user, created_at: DateTime.current)
+      @order = create(:order, user: @user, created_at: Time.current)
       @payload = { order: @order, user: @user }
     end
 
@@ -133,7 +133,7 @@ RSpec.describe Spree::Promotion, type: :model do
 
     it "does activate if newer then order" do
       expect(@action1).to receive(:perform).with(hash_including(@payload))
-      promotion.created_at = DateTime.current + 2
+      promotion.created_at = Time.current + 2
       expect(promotion.activate(@payload)).to be true
     end
 

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -679,8 +679,8 @@ RSpec.describe Spree::Shipment, type: :model do
 
       shipment.destroy
 
-      expect{shipping_rate.reload}.to raise_error(ActiveRecord::RecordNotFound)
-      expect{shipping_rate_tax.reload}.to raise_error(ActiveRecord::RecordNotFound)
+      expect{ shipping_rate.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      expect{ shipping_rate_tax.reload }.to raise_error(ActiveRecord::RecordNotFound)
     end
   end
 

--- a/core/spec/models/spree/stock/estimator_spec.rb
+++ b/core/spec/models/spree/stock/estimator_spec.rb
@@ -170,7 +170,7 @@ module Spree
         end
 
         context "includes tax adjustments if applicable" do
-          let(:zone) { create(:zone, countries: [order.tax_address.country])}
+          let(:zone) { create(:zone, countries: [order.tax_address.country]) }
 
           let!(:tax_rate) { create(:tax_rate, zone: zone) }
 

--- a/core/spec/models/spree/store_credit_event_spec.rb
+++ b/core/spec/models/spree/store_credit_event_spec.rb
@@ -221,7 +221,7 @@ RSpec.describe Spree::StoreCreditEvent do
   end
 
   describe "#display_event_date" do
-    let(:date) { DateTime.new(2014, 0o6, 1) }
+    let(:date) { Time.parse("2014-06-01") }
 
     subject { create(:store_credit_auth_event, created_at: date) }
 

--- a/core/spec/models/spree/store_credit_event_spec.rb
+++ b/core/spec/models/spree/store_credit_event_spec.rb
@@ -221,7 +221,7 @@ RSpec.describe Spree::StoreCreditEvent do
   end
 
   describe "#display_event_date" do
-    let(:date) { DateTime.new(2014, 06, 1) }
+    let(:date) { DateTime.new(2014, 0o6, 1) }
 
     subject { create(:store_credit_auth_event, created_at: date) }
 

--- a/core/spec/models/spree/tax_rate_spec.rb
+++ b/core/spec/models/spree/tax_rate_spec.rb
@@ -233,7 +233,7 @@ RSpec.describe Spree::TaxRate, type: :model do
 
     context "when starts_at is set" do
       context "now" do
-        let(:validity) { { starts_at: DateTime.now } }
+        let(:validity) { { starts_at: Time.current } }
 
         it { is_expected.to eq(true) }
       end
@@ -253,7 +253,7 @@ RSpec.describe Spree::TaxRate, type: :model do
 
     context "when expires_at is set" do
       context "now" do
-        let(:validity) { { expires_at: DateTime.now } }
+        let(:validity) { { expires_at: Time.current } }
 
         it { is_expected.to eq(false) }
       end

--- a/core/spec/models/spree/tax_rate_spec.rb
+++ b/core/spec/models/spree/tax_rate_spec.rb
@@ -146,8 +146,7 @@ RSpec.describe Spree::TaxRate, type: :model do
         included_in_price: included_in_price,
         show_rate_in_label: show_rate_in_label,
         amount: 0.125,
-        zone: tax_zone
-      )
+        zone: tax_zone)
     end
 
     let(:item) { order.line_items.first }

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -792,7 +792,7 @@ RSpec.describe Spree::Variant, type: :model do
     subject { variant.display_image }
 
     context "variant has associated images" do
-      let(:attachment) { File.open(File.expand_path('../../../fixtures/thinking-cat.jpg', __FILE__)) }
+      let(:attachment) { File.open(File.expand_path('../../fixtures/thinking-cat.jpg', __dir__)) }
       let(:image_params) { { viewable_id: variant.id, viewable_type: 'Spree::Variant', attachment: attachment, alt: "position 1", position: 1 } }
       let!(:first_image) { Spree::Image.create(image_params) }
       let!(:second_image) { image_params.merge(alt: "position 2", position: 2) }

--- a/core/spec/rails_helper.rb
+++ b/core/spec/rails_helper.rb
@@ -6,7 +6,7 @@ ENV["RAILS_ENV"] ||= 'test'
 
 require 'spree/testing_support/dummy_app'
 DummyApp.setup(
-  gem_root: File.expand_path('../../', __FILE__),
+  gem_root: File.expand_path('..', __dir__),
   lib_name: 'solidus_core'
 )
 
@@ -23,7 +23,7 @@ require 'cancan/matchers'
 ActiveJob::Base.queue_adapter = :test
 
 RSpec.configure do |config|
-  config.fixture_path = File.join(File.expand_path(File.dirname(__FILE__)), "fixtures")
+  config.fixture_path = File.join(__dir__, "fixtures")
 
   config.infer_spec_type_from_file_location!
 

--- a/frontend/Rakefile
+++ b/frontend/Rakefile
@@ -10,7 +10,7 @@ RSpec::Core::RakeTask.new
 task default: :spec
 
 DummyApp::RakeTasks.new(
-  gem_root: File.expand_path('../', __FILE__),
+  gem_root: File.expand_path(__dir__),
   lib_name: 'solidus_frontend'
 )
 

--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -36,7 +36,6 @@ module Spree
           return
         end
 
-
         if @order.completed?
           finalize_order
         else
@@ -112,7 +111,7 @@ module Spree
     def ensure_valid_state
       unless skip_state_validation?
         if (params[:state] && !@order.has_checkout_step?(params[:state])) ||
-          (!params[:state] && !@order.has_checkout_step?(@order.state))
+           (!params[:state] && !@order.has_checkout_step?(@order.state))
           @order.state = 'cart'
           redirect_to checkout_state_path(@order.checkout_steps.first)
         end
@@ -176,7 +175,7 @@ module Spree
       @order.assign_default_user_addresses
       # If the user has a default address, the previous method call takes care
       # of setting that; but if he doesn't, we need to build an empty one here
-      default = {country_id: Spree::Country.default.id}
+      default = { country_id: Spree::Country.default.id }
       @order.build_bill_address(default) unless @order.bill_address
       @order.build_ship_address(default) if @order.checkout_steps.include?('delivery') && !@order.ship_address
     end

--- a/frontend/script/rails
+++ b/frontend/script/rails
@@ -3,8 +3,8 @@
 
 # This command will automatically be run when you run "rails" with Rails 3 gems installed from the root of your application.
 
-ENGINE_ROOT = File.expand_path('../..', __FILE__)
-ENGINE_PATH = File.expand_path('../../lib/spree/frontend/engine', __FILE__)
+ENGINE_ROOT = File.expand_path('..', __dir__)
+ENGINE_PATH = File.expand_path('../lib/spree/frontend/engine', __dir__)
 
 require 'rails/all'
 require 'rails/engine/commands'

--- a/frontend/solidus_frontend.gemspec
+++ b/frontend/solidus_frontend.gemspec
@@ -25,11 +25,11 @@ Gem::Specification.new do |s|
   s.add_dependency 'solidus_core', s.version
 
   s.add_dependency 'canonical-rails', '~> 0.2.0'
-  s.add_dependency 'jquery-rails'
-  s.add_dependency 'sass-rails'
   s.add_dependency 'font-awesome-rails', '~> 4.0'
-  s.add_dependency 'truncate_html', '~> 0.9', '>= 0.9.2'
+  s.add_dependency 'jquery-rails'
   s.add_dependency 'kaminari', '~> 1.1'
+  s.add_dependency 'sass-rails'
+  s.add_dependency 'truncate_html', '~> 0.9', '>= 0.9.2'
 
   s.add_development_dependency 'capybara-accessible'
 end

--- a/frontend/spec/features/products_spec.rb
+++ b/frontend/spec/features/products_spec.rb
@@ -154,7 +154,7 @@ describe "Visiting Products", type: :feature, inaccessible: true do
 
     before do
       # Need to have two images to trigger the error
-      image = File.open(File.expand_path('../../fixtures/thinking-cat.jpg', __FILE__))
+      image = File.open(File.expand_path('../fixtures/thinking-cat.jpg', __dir__))
       product.images.create!(attachment: image)
       product.images.create!(attachment: image)
 
@@ -184,7 +184,7 @@ describe "Visiting Products", type: :feature, inaccessible: true do
     let(:product) { Spree::Product.find_by(name: "Ruby on Rails Baseball Jersey") }
 
     before do
-      image = File.open(File.expand_path('../../fixtures/thinking-cat.jpg', __FILE__))
+      image = File.open(File.expand_path('../fixtures/thinking-cat.jpg', __dir__))
       v1 = product.variants.create!(price: 9.99)
       v2 = product.variants.create!(price: 10.99)
       v1.images.create!(attachment: image)

--- a/frontend/spec/spec_helper.rb
+++ b/frontend/spec/spec_helper.rb
@@ -12,7 +12,7 @@ ENV["RAILS_ENV"] ||= 'test'
 require 'solidus_frontend'
 require 'spree/testing_support/dummy_app'
 DummyApp.setup(
-  gem_root: File.expand_path('../../', __FILE__),
+  gem_root: File.expand_path('..', __dir__),
   lib_name: 'solidus_frontend'
 )
 
@@ -55,7 +55,7 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
 
-  config.fixture_path = File.join(File.expand_path(File.dirname(__FILE__)), "fixtures")
+  config.fixture_path = File.join(__dir__, "fixtures")
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, comment the following line or assign false

--- a/sample/Rakefile
+++ b/sample/Rakefile
@@ -9,7 +9,7 @@ RSpec::Core::RakeTask.new
 task default: :spec
 
 DummyApp::RakeTasks.new(
-  gem_root: File.expand_path('../', __FILE__),
+  gem_root: File.expand_path(__dir__),
   lib_name: 'solidus_sample'
 )
 

--- a/sample/spec/spec_helper.rb
+++ b/sample/spec/spec_helper.rb
@@ -7,7 +7,7 @@ ENV["RAILS_ENV"] ||= 'test'
 require 'solidus_sample'
 require 'spree/testing_support/dummy_app'
 DummyApp.setup(
-  gem_root: File.expand_path('../../', __FILE__),
+  gem_root: File.expand_path('..', __dir__),
   lib_name: 'solidus_sample'
 )
 

--- a/solidus.gemspec
+++ b/solidus.gemspec
@@ -21,9 +21,9 @@ Gem::Specification.new do |s|
   s.homepage     = 'http://solidus.io'
   s.license      = 'BSD-3-Clause'
 
-  s.add_dependency 'solidus_core', s.version
   s.add_dependency 'solidus_api', s.version
   s.add_dependency 'solidus_backend', s.version
+  s.add_dependency 'solidus_core', s.version
   s.add_dependency 'solidus_frontend', s.version
   s.add_dependency 'solidus_sample', s.version
 end


### PR DESCRIPTION
On the [new version of rubocop released Monday](https://rubygems.org/gems/rubocop/versions/0.53.0) running `rubocop` results in an error.

> Error: The `Style/TrailingCommaInLiteral` cop no longer exists.

Because rubocop sees fit to regularly make breaking changes to the config as well as change the default rules, we need to lock it down to a specific version.

This PR locks us to rubocop `~> 0.53.0` (hoping optimistically there won't be breaking changes in patch versions), and fixes all warnings under that version.

Changes which may influence behaviour (but I don't believe will cause any problems) include:
* Use Time instead of DateTime 6848ef5beec60264c0ac8fb544b394540616ccd8
* Rescue only StandardError in rake order_capturing  5497a8bd2a69b04d96abf657d127a29277e418e9
* Implement respond_to_missing on Search::Base 4819fbfd732024efea50c9af03ef796c1a61e376
