### PR TITLE
The shipment of a partial expedition should return to :ready

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -82,7 +82,7 @@ module Spree
 
     def can_transition_from_pending_to_ready?
       order.can_ship? &&
-        inventory_units.all? { |iu| iu.allow_ship? || iu.canceled? } &&
+        inventory_units.on_hand.all? { |iu| iu.allow_ship? || iu.canceled? } &&
         (order.paid? || !Spree::Config[:require_payment_to_ship])
     end
 

--- a/core/spec/models/spree/order_shipping_spec.rb
+++ b/core/spec/models/spree/order_shipping_spec.rb
@@ -208,6 +208,10 @@ RSpec.describe Spree::OrderShipping do
         expect { subject }.to change { unshipped_inventory.map(&:reload).map(&:state) }.from(['on_hand']).to(['shipped'])
       end
 
+      it "shipment should be ready" do
+        expect(shipment.reload.state).to eq("ready")
+      end
+
       it "creates a carton with the shipment's inventory units" do
         expect { subject }.to change { order.cartons.count }.by(1)
         expect(subject.inventory_units).to match_array(unshipped_inventory)

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -81,6 +81,7 @@ RSpec.describe Spree::Shipment, type: :model do
 
     it 'returns pending if backordered' do
       allow(shipment).to receive_messages inventory_units: [mock_model(Spree::InventoryUnit, allow_ship?: false, canceled?: false)]
+      allow(shipment.inventory_units).to receive_messages(on_hand: shipment.inventory_units)
       expect(shipment.determine_state(order)).to eq 'pending'
     end
 
@@ -301,6 +302,7 @@ RSpec.describe Spree::Shipment, type: :model do
         shipment.update_attributes!(state: 'ready')
 
         allow(shipment).to receive_messages(inventory_units: [mock_model(Spree::InventoryUnit, allow_ship?: false, canceled?: false)])
+        allow(shipment.inventory_units).to receive_messages(on_hand: shipment.inventory_units)
         expect(shipment).to receive(:update_columns).with(state: 'pending', updated_at: kind_of(Time))
         shipment.update_state
       end

--- a/core/spec/models/spree/store_credit_event_spec.rb
+++ b/core/spec/models/spree/store_credit_event_spec.rb
@@ -221,7 +221,7 @@ RSpec.describe Spree::StoreCreditEvent do
   end
 
   describe "#display_event_date" do
-    let(:date) { Time.parse("2014-06-01") }
+    let(:date) { Time.zone.parse("2014-06-01") }
 
     subject { create(:store_credit_auth_event, created_at: date) }
 


### PR DESCRIPTION
Hello,

On my solidus website, we need to ship order’s shipments partially, after sending the first part of a shipment, the shipment stays on state `:pending` instead of `:ready`. We think it should be in state `ready`  because the button “ship” does not appear and we cannot send the rest  of the items

This commits fixed my issue.

The problem seems to be in `can_transition_from_pending_to_ready?` because to transition you check that all  inventory_units are allowed to be ship even for the products already sent so you cannot transition to ready

I think we should only check for inventory units on state `:on_hand` to correct the case of sending partial shipments

Maybe am I missing something?

Thx for you comments