### PR TITLE
Set model_class on admin promotion rules controller

### DIFF
--- a/backend/app/controllers/spree/admin/promotion_rules_controller.rb
+++ b/backend/app/controllers/spree/admin/promotion_rules_controller.rb
@@ -35,6 +35,10 @@ class Spree::Admin::PromotionRulesController < Spree::Admin::BaseController
     @promotion = Spree::Promotion.find(params[:promotion_id])
   end
 
+  def model_class
+    Spree::PromotionRule
+  end
+
   def validate_promotion_rule_type
     requested_type = params[:promotion_rule].delete(:type)
     promotion_rule_types = Rails.application.config.spree.promotions.rules

--- a/backend/spec/controllers/spree/admin/promotion_rules_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/promotion_rules_controller_spec.rb
@@ -3,21 +3,34 @@
 require 'spec_helper'
 
 describe Spree::Admin::PromotionRulesController, type: :controller do
-  stub_authorization!
-
   let!(:promotion) { create(:promotion) }
 
-  it "can create a promotion rule of a valid type" do
-    post :create, params: { promotion_id: promotion.id, promotion_rule: { type: "Spree::Promotion::Rules::Product" } }
-    expect(response).to be_redirect
-    expect(response).to redirect_to spree.edit_admin_promotion_path(promotion)
-    expect(promotion.rules.count).to eq(1)
+  context "when the user is authorized" do
+    stub_authorization! do |_u|
+      Spree::PermissionSets::PromotionManagement.new(self).activate!
+    end
+
+    it "can create a promotion rule of a valid type" do
+      post :create, params: { promotion_id: promotion.id, promotion_rule: { type: "Spree::Promotion::Rules::Product" } }
+      expect(response).to be_redirect
+      expect(response).to redirect_to spree.edit_admin_promotion_path(promotion)
+      expect(promotion.rules.count).to eq(1)
+    end
+
+    it "can not create a promotion rule of an invalid type" do
+      post :create, params: { promotion_id: promotion.id, promotion_rule: { type: "Spree::InvalidType" } }
+      expect(response).to be_redirect
+      expect(response).to redirect_to spree.edit_admin_promotion_path(promotion)
+      expect(promotion.rules.count).to eq(0)
+    end
   end
 
-  it "can not create a promotion rule of an invalid type" do
-    post :create, params: { promotion_id: promotion.id, promotion_rule: { type: "Spree::InvalidType" } }
-    expect(response).to be_redirect
-    expect(response).to redirect_to spree.edit_admin_promotion_path(promotion)
-    expect(promotion.rules.count).to eq(0)
+  context "when the user is not authorized" do
+    it "sets an error message and redirects the user" do
+      post :create, params: { promotion_id: promotion.id, promotion_rule: { type: "Spree::Promotion::Rules::Product" } }
+
+      expect(flash[:error]).to eq("Authorization Failure")
+      expect(response).to redirect_to('/unauthorized')
+    end
   end
 end


### PR DESCRIPTION
If a user has the `PromotionManagement` permission set, they are currently unable to add new promotion rules to promotions.

This is happening because the promotion rules controller doesn't inherit from the `Spree::Admin::ResourceController`, so if it doesn't respond to `:model_class`, it will try to authorize using `controller_name.to_sym` instead of the correct class constant.

https://github.com/solidusio/solidus/blob/master/backend/app/controllers/spree/admin/base_controller.rb#L21