### PR TITLE
fix path when editing image alternative text in backoffice

### DIFF
--- a/backend/app/views/spree/admin/images/_image_row.html.erb
+++ b/backend/app/views/spree/admin/images/_image_row.html.erb
@@ -38,7 +38,7 @@
 
   <td class="actions">
     <% if can?(:update, image) %>
-      <%= link_to_with_icon 'check', t('spree.actions.save'), api_variant_image_path(@product, image), no_text: true, data: {action: 'save'} %>
+      <%= link_to_with_icon 'check', t('spree.actions.save'), api_product_image_path(@product, image), no_text: true, data: {action: 'save'} %>
 
       <%= link_to_with_icon 'cancel', t('spree.actions.cancel'), nil, no_text: true, data: {action: 'cancel'} %>
 


### PR DESCRIPTION
When you upload a product image in BO, you can update the alternative text and save the change.
When doing this the url generated is
`/en/api/variants/<PRODUCT_SLUG>/images/4`

This is not actually causing any bug on the default solidus behaviour because the variant is not used in
`Spree::Api::ImagesController#update` but if we would like to use the variant via the method `Spree::Api::ImagesController#scope` for example, it would produce an error (this is the case in our app for example)

```
     def scope
        if params[:product_id]
          Spree::Product.friendly.find(params[:product_id])
        elsif params[:variant_id]
          Spree::Variant.find(params[:variant_id])
        end
      end
```

Example of log when saving the image alternative text:

``` 
Started PUT "/en/api/variants/75-aoc-esp-rioja-crianza-rg-marques-caceres-13c6-acq/images/19" for 83.60.66.210 at 2018-03-12 11:38:56 +0100
Processing by Spree::Api::ImagesController#update as JSON
   Parameters: {"image"=>{"alt"=>"seigneur dagil"}, "variant_id"=>"75-aoc-esp-rioja-crianza-rg-marques-caceres-13c6-acq", "id"=>"19", "locale"=>"en"}
```

As you see from the log we could not find the variant via the product slug. 

Replacing the path by 
`/en/api/products/<PRODUCT_SLUG>/images/4`
should fix this issue.