### PR TITLE
Make frontend's LocaleController compatible with solidus_i18n

### DIFF
--- a/frontend/app/controllers/spree/locale_controller.rb
+++ b/frontend/app/controllers/spree/locale_controller.rb
@@ -13,7 +13,8 @@ module Spree
       else
         flash[:error] = t('spree.locale_not_changed')
       end
-      redirect_back_or_default(spree.root_path)
+
+      redirect_to spree.root_path
     end
   end
 end

--- a/frontend/app/controllers/spree/locale_controller.rb
+++ b/frontend/app/controllers/spree/locale_controller.rb
@@ -3,8 +3,12 @@
 module Spree
   class LocaleController < Spree::StoreController
     def set
-      if params[:locale] && I18n.available_locales.map(&:to_s).include?(params[:locale])
-        session[:locale] = I18n.locale = params[:locale]
+      available_locales = Spree.i18n_available_locales
+      requested_locale = params[:switch_to_locale] || params[:locale]
+
+      if requested_locale && available_locales.map(&:to_s).include?(requested_locale)
+        session[:locale] = requested_locale
+        I18n.locale = requested_locale
         flash.notice = t('spree.locale_changed')
       else
         flash[:error] = t('spree.locale_not_changed')

--- a/frontend/app/controllers/spree/locale_controller.rb
+++ b/frontend/app/controllers/spree/locale_controller.rb
@@ -3,9 +3,6 @@
 module Spree
   class LocaleController < Spree::StoreController
     def set
-      if request.referer && request.referer.starts_with?('http://' + request.host)
-        session['user_return_to'] = request.referer
-      end
       if params[:locale] && I18n.available_locales.map(&:to_s).include?(params[:locale])
         session[:locale] = I18n.locale = params[:locale]
         flash.notice = t('spree.locale_changed')

--- a/frontend/config/routes.rb
+++ b/frontend/config/routes.rb
@@ -6,6 +6,7 @@ Spree::Core::Engine.routes.draw do
   resources :products, only: [:index, :show]
 
   get '/locale/set', to: 'locale#set'
+  post '/locale/set', to: 'locale#set', as: :select_locale
 
   # non-restful checkout stuff
   patch '/checkout/update/:state', to: 'checkout#update', as: :update_checkout

--- a/frontend/spec/controllers/locale_controller_spec.rb
+++ b/frontend/spec/controllers/locale_controller_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Spree::LocaleController, type: :controller do
+  include_context "fr locale"
+
+  context 'switch_to_locale specified' do
+    context "available locale" do
+      it 'sets locale and redirects' do
+        get :set, params: { switch_to_locale: 'fr' }
+        expect(I18n.locale).to eq :fr
+        expect(response).to redirect_to('/')
+        expect(session[:locale]).to eq('fr')
+        expect(flash[:notice]).to eq(I18n.t("spree.locale_changed"))
+      end
+    end
+
+    context "unavailable locale" do
+      it 'does not change locale and redirects' do
+        get :set, params: { switch_to_locale: 'klingon' }
+        expect(I18n.locale).to eq :en
+        expect(response).to redirect_to('/')
+        expect(flash[:error]).to eq(I18n.t("spree.locale_not_changed"))
+      end
+    end
+  end
+
+  context 'locale specified' do
+    context "available locale" do
+      it 'sets locale and redirects' do
+        get :set, params: { locale: 'fr' }
+        expect(I18n.locale).to eq :fr
+        expect(response).to redirect_to('/')
+        expect(flash[:notice]).to eq(I18n.t("spree.locale_changed"))
+      end
+    end
+
+    context "unavailable locale" do
+      it 'does not change locale and redirects' do
+        get :set, params: { locale: 'klingon' }
+        expect(I18n.locale).to eq :en
+        expect(response).to redirect_to('/')
+        expect(flash[:error]).to eq(I18n.t("spree.locale_not_changed"))
+      end
+    end
+  end
+
+  context 'both locale and switch_to_locale specified' do
+    it 'uses switch_to_locale value' do
+      get :set, params: { locale: 'en', switch_to_locale: 'fr' }
+      expect(I18n.locale).to eq :fr
+      expect(response).to redirect_to('/')
+      expect(flash[:notice]).to eq(I18n.t("spree.locale_changed"))
+    end
+  end
+end

--- a/frontend/spec/features/locale_spec.rb
+++ b/frontend/spec/features/locale_spec.rb
@@ -14,17 +14,7 @@ describe 'setting locale', type: :feature do
   end
 
   context 'shopping cart link and page' do
-    before do
-      I18n.backend.store_translations(:fr, spree: {
-        i18n: { this_file_language: "Français" },
-        cart: 'Panier',
-        shopping_cart: 'Panier'
-      })
-    end
-
-    after do
-      I18n.reload!
-    end
+    include_context "fr locale"
 
     it 'should be in french' do
       with_locale('fr') do

--- a/frontend/spec/support/shared_contexts/locales.rb
+++ b/frontend/spec/support/shared_contexts/locales.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+shared_context 'fr locale' do
+  before do
+    I18n.backend.store_translations(:fr, spree: {
+      i18n: { this_file_language: "Français" },
+      cart: 'Panier',
+      shopping_cart: 'Panier'
+    })
+  end
+
+  after do
+    I18n.reload!
+  end
+end


### PR DESCRIPTION
Written on top of #2559

This adjusts the behaviour of frontend's `LocaleController#set` so that it can be used by `solidus_i18n` without needing to make any changes to the controller.

Specifically, this plays nicely with `filter :locale` in routes from the `routing-filter` gem, which is included by solidus_i18n.