### PR TITLE
Namespace all testing_support/ files under Spree::TestingSupport namespace

### DIFF
--- a/api/spec/requests/spree/api/orders_controller_spec.rb
+++ b/api/spec/requests/spree/api/orders_controller_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'spree/testing_support/bar_ability'
 
 module Spree
   describe Api::OrdersController, type: :request do
@@ -373,18 +372,6 @@ module Spree
     it "can view an order if the token is passed in header" do
       get spree.api_order_path(order), headers: { "X-Spree-Order-Token" => order.guest_token }
       expect(response.status).to eq(200)
-    end
-
-    context "with BarAbility registered" do
-      before { Spree::Ability.register_ability(::BarAbility) }
-      after { Spree::Ability.remove_ability(::BarAbility) }
-
-      it "can view an order" do
-        user = build(:user, spree_roles: [Spree::Role.new(name: 'bar')])
-        allow(Spree.user_class).to receive_messages find_by: user
-        get spree.api_order_path(order)
-        expect(response.status).to eq(200)
-      end
     end
 
     it "cannot cancel an order that doesn't belong to them" do

--- a/backend/spec/controllers/spree/admin/orders/customer_details_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/orders/customer_details_controller_spec.rb
@@ -2,7 +2,6 @@
 
 require "spec_helper"
 require "cancan"
-require "spree/testing_support/bar_ability"
 
 describe Spree::Admin::Orders::CustomerDetailsController, type: :controller do
   context "with authorization" do

--- a/backend/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -2,7 +2,6 @@
 
 require 'spec_helper'
 require 'cancan'
-require 'spree/testing_support/bar_ability'
 
 describe Spree::Admin::OrdersController, type: :controller do
   let!(:store) { create(:store) }
@@ -357,14 +356,6 @@ describe Spree::Admin::OrdersController, type: :controller do
       user.spree_roles << Spree::Role.find_or_create_by(name: 'admin')
       get :index
       expect(response).to render_template :index
-    end
-
-    it 'should grant access to users with an bar role' do
-      user.spree_roles << Spree::Role.find_or_create_by(name: 'bar')
-      Spree::Ability.register_ability(BarAbility)
-      get :index
-      expect(response).to render_template :index
-      Spree::Ability.remove_ability(BarAbility)
     end
 
     it 'should deny access to users without an admin role' do

--- a/backend/spec/controllers/spree/admin/users_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/users_controller_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'spree/testing_support/bar_ability'
 
 describe Spree::Admin::UsersController, type: :controller do
   let(:user) { create(:user) }

--- a/core/lib/spree/testing_support/bar_ability.rb
+++ b/core/lib/spree/testing_support/bar_ability.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
+Spree::Deprecation.warn "BarAbility is deprecated. Use stub_authorization! instead"
+
 # Fake ability for testing administration
+# @private
 class BarAbility
   include CanCan::Ability
 

--- a/core/lib/spree/testing_support/capybara_ext.rb
+++ b/core/lib/spree/testing_support/capybara_ext.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 module CapybaraExt
-  def page!
-  end
-
   def click_icon(type)
     find(".fa-#{type}").click
   end

--- a/core/lib/spree/testing_support/capybara_ext.rb
+++ b/core/lib/spree/testing_support/capybara_ext.rb
@@ -1,121 +1,125 @@
 # frozen_string_literal: true
 
-module CapybaraExt
-  def click_icon(type)
-    find(".fa-#{type}").click
-  end
+module Spree
+  module TestingSupport
+    module CapybaraExt
+      def click_icon(type)
+        find(".fa-#{type}").click
+      end
 
-  def eventually_fill_in(field, options = {})
-    expect(page).to have_css('#' + field)
-    fill_in field, options
-  end
+      def eventually_fill_in(field, options = {})
+        expect(page).to have_css('#' + field)
+        fill_in field, options
+      end
 
-  def within_row(num, &block)
-    within("table.index tbody tr:nth-of-type(#{num})", &block)
-  end
+      def within_row(num, &block)
+        within("table.index tbody tr:nth-of-type(#{num})", &block)
+      end
 
-  def column_text(num)
-    find("td:nth-of-type(#{num})").text
-  end
+      def column_text(num)
+        find("td:nth-of-type(#{num})").text
+      end
 
-  def fill_in_quantity(table_column, selector, quantity)
-    Spree::Deprecation.warn <<-WARN.strip_heredoc
-      fill_in_quantity is deprecated. Instead use:
-        within(#{table_column.inspect}) do
-          fill_in #{selector.inspect}, with: #{quantity.inspect}
+      def fill_in_quantity(table_column, selector, quantity)
+        Spree::Deprecation.warn <<-WARN.strip_heredoc
+          fill_in_quantity is deprecated. Instead use:
+            within(#{table_column.inspect}) do
+              fill_in #{selector.inspect}, with: #{quantity.inspect}
+            end
+        WARN
+        within(table_column) do
+          fill_in selector, with: quantity
         end
-    WARN
-    within(table_column) do
-      fill_in selector, with: quantity
-    end
-  end
+      end
 
-  def select2_search(value, options)
-    options = {
-      search: value, # by default search for the value
-      select: true
-    }.merge(options)
-    label = find_label_by_text(options[:from])
-    within label.first(:xpath, ".//..") do
-      options[:from] = "##{find('.select2-container')['id']}"
-    end
-    select2_search_without_selection(options[:search], from: options[:from])
-    select_select2_result(value) if options[:select]
-  end
+      def select2_search(value, options)
+        options = {
+          search: value, # by default search for the value
+          select: true
+        }.merge(options)
+        label = find_label_by_text(options[:from])
+        within label.first(:xpath, ".//..") do
+          options[:from] = "##{find('.select2-container')['id']}"
+        end
+        select2_search_without_selection(options[:search], from: options[:from])
+        select_select2_result(value) if options[:select]
+      end
 
-  def select2_search_without_selection(value, options)
-    find("#{options[:from]}:not(.select2-container-disabled):not(.select2-offscreen)").click
+      def select2_search_without_selection(value, options)
+        find("#{options[:from]}:not(.select2-container-disabled):not(.select2-offscreen)").click
 
-    within_entire_page do
-      find("input.select2-input.select2-focused").set(value)
-    end
-  end
+        within_entire_page do
+          find("input.select2-input.select2-focused").set(value)
+        end
+      end
 
-  def targetted_select2_search(value, options)
-    select2_search_without_selection(value, from: options[:from])
-    select_select2_result(value)
-  end
+      def targetted_select2_search(value, options)
+        select2_search_without_selection(value, from: options[:from])
+        select_select2_result(value)
+      end
 
-  # Executes the given block within the context of the entire capybara
-  # document. Can be used to 'escape' from within the context of another within
-  # block.
-  def within_entire_page(&block)
-    within(:xpath, '//body', &block)
-  end
+      # Executes the given block within the context of the entire capybara
+      # document. Can be used to 'escape' from within the context of another within
+      # block.
+      def within_entire_page(&block)
+        within(:xpath, '//body', &block)
+      end
 
-  def select2(value, options)
-    label = find_label_by_text(options[:from])
+      def select2(value, options)
+        label = find_label_by_text(options[:from])
 
-    within label.first(:xpath, ".//..") do
-      options[:from] = "##{find('.select2-container')['id']}"
-    end
-    targetted_select2(value, options)
-  end
+        within label.first(:xpath, ".//..") do
+          options[:from] = "##{find('.select2-container')['id']}"
+        end
+        targetted_select2(value, options)
+      end
 
-  def select2_no_label(value, options = {})
-    raise "Must pass a hash containing 'from'" if !options.is_a?(Hash) || !options.key?(:from)
+      def select2_no_label(value, options = {})
+        raise "Must pass a hash containing 'from'" if !options.is_a?(Hash) || !options.key?(:from)
 
-    placeholder = options[:from]
+        placeholder = options[:from]
 
-    click_link placeholder
+        click_link placeholder
 
-    select_select2_result(value)
-  end
+        select_select2_result(value)
+      end
 
-  def targetted_select2(value, options)
-    # find select2 element and click it
-    find(options[:from]).find('a').click
-    select_select2_result(value)
-  end
+      def targetted_select2(value, options)
+        # find select2 element and click it
+        find(options[:from]).find('a').click
+        select_select2_result(value)
+      end
 
-  def select_select2_result(value)
-    # results are in a div appended to the end of the document
-    within_entire_page do
-      page.find("div.select2-result-label", text: /#{Regexp.escape(value)}/i, match: :prefer_exact).click
-    end
-  end
+      def select_select2_result(value)
+        # results are in a div appended to the end of the document
+        within_entire_page do
+          page.find("div.select2-result-label", text: /#{Regexp.escape(value)}/i, match: :prefer_exact).click
+        end
+      end
 
-  def find_label_by_text(text)
-    # This used to find the label by it's text using an xpath query, so we use
-    # a case insensitive search to avoid breakage with existing usage.
-    # We need to select labels which are not .select2-offscreen, as select2
-    # makes a duplicate label with the same text, and we want to be sure to
-    # find the original.
-    find('label:not(.select2-offscreen)', text: /#{Regexp.escape(text)}/i, match: :one)
-  end
+      def find_label_by_text(text)
+        # This used to find the label by it's text using an xpath query, so we use
+        # a case insensitive search to avoid breakage with existing usage.
+        # We need to select labels which are not .select2-offscreen, as select2
+        # makes a duplicate label with the same text, and we want to be sure to
+        # find the original.
+        find('label:not(.select2-offscreen)', text: /#{Regexp.escape(text)}/i, match: :one)
+      end
 
-  def wait_for_ajax
-    Spree::Deprecation.warn <<-WARN.squish, caller
-      wait_for_ajax has been deprecated.
-      Please refer to the capybara documentation on how to properly wait for asyncronous behavior:
-      https://github.com/teamcapybara/capybara#asynchronous-javascript-ajax-and-friends
-    WARN
+      def wait_for_ajax
+        Spree::Deprecation.warn <<-WARN.squish, caller
+          wait_for_ajax has been deprecated.
+          Please refer to the capybara documentation on how to properly wait for asyncronous behavior:
+          https://github.com/teamcapybara/capybara#asynchronous-javascript-ajax-and-friends
+        WARN
 
-    counter = 0
-    while page.evaluate_script("typeof($) === 'undefined' || $.active > 0")
-      counter += 1
-      sleep(0.1)
-      raise "AJAX request took longer than 5 seconds." if counter >= 50
+        counter = 0
+        while page.evaluate_script("typeof($) === 'undefined' || $.active > 0")
+          counter += 1
+          sleep(0.1)
+          raise "AJAX request took longer than 5 seconds." if counter >= 50
+        end
+      end
     end
   end
 end
@@ -135,6 +139,9 @@ RSpec::Matchers.define :have_meta do |name, expected|
   end
 end
 
+# @private
+CapybaraExt = ActiveSupport::Deprecation::DeprecatedConstantProxy.new('CapybaraExt', 'Spree::TestingSupport::CapybaraExt')
+
 RSpec.configure do |c|
-  c.include CapybaraExt
+  c.include Spree::TestingSupport::CapybaraExt
 end

--- a/core/lib/spree/testing_support/dummy_app.rb
+++ b/core/lib/spree/testing_support/dummy_app.rb
@@ -12,19 +12,24 @@ Rails.env = 'test'
 
 require 'solidus_core'
 
+# @private
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 end
 
+# @private
 class ApplicationRecord < ActiveRecord::Base
 end
 
+# @private
 class ApplicationMailer < ActionMailer::Base
 end
 
+# @private
 module ApplicationHelper
 end
 
+# @private
 module DummyApp
   def self.setup(gem_root:, lib_name:, auto_migrate: true)
     ENV["LIB_NAME"] = lib_name

--- a/core/lib/spree/testing_support/order_walkthrough.rb
+++ b/core/lib/spree/testing_support/order_walkthrough.rb
@@ -1,80 +1,87 @@
 # frozen_string_literal: true
 
-class OrderWalkthrough
-  def self.up_to(state)
-    new.up_to(state)
-  end
+module Spree
+  module TestingSupport
+    class OrderWalkthrough
+      def self.up_to(state)
+        new.up_to(state)
+      end
 
-  def up_to(state)
-    # Need to create a valid zone too...
-    @zone = FactoryBot.create(:zone)
-    @country = FactoryBot.create(:country)
-    @state = FactoryBot.create(:state, country: @country)
+      def up_to(state)
+        # Need to create a valid zone too...
+        @zone = FactoryBot.create(:zone)
+        @country = FactoryBot.create(:country)
+        @state = FactoryBot.create(:state, country: @country)
 
-    @zone.members << Spree::ZoneMember.create(zoneable: @country)
+        @zone.members << Spree::ZoneMember.create(zoneable: @country)
 
-    # A shipping method must exist for rates to be displayed on checkout page
-    FactoryBot.create(:shipping_method, zones: [@zone]).tap do |sm|
-      sm.calculator.preferred_amount = 10
-      sm.calculator.preferred_currency = Spree::Config[:currency]
-      sm.calculator.save
+        # A shipping method must exist for rates to be displayed on checkout page
+        FactoryBot.create(:shipping_method, zones: [@zone]).tap do |sm|
+          sm.calculator.preferred_amount = 10
+          sm.calculator.preferred_currency = Spree::Config[:currency]
+          sm.calculator.save
+        end
+
+        order = Spree::Order.create!(
+          email: "spree@example.com",
+          store: Spree::Store.first || FactoryBot.create(:store)
+        )
+        add_line_item!(order)
+        order.next!
+
+        states_to_process = if state == :complete
+                              states
+                            else
+                              end_state_position = states.index(state.to_sym)
+                              states[0..end_state_position]
+                            end
+
+        states_to_process.each do |state_to_process|
+          send(state_to_process, order)
+        end
+
+        order
+      end
+
+      private
+
+      def add_line_item!(order)
+        FactoryBot.create(:line_item, order: order)
+        order.reload
+      end
+
+      def address(order)
+        order.bill_address = FactoryBot.create(:address, country: @country, state: @state)
+        order.ship_address = FactoryBot.create(:address, country: @country, state: @state)
+        order.next!
+      end
+
+      def delivery(order)
+        order.next!
+      end
+
+      def payment(order)
+        credit_card = FactoryBot.create(:credit_card)
+        order.payments.create!(payment_method: credit_card.payment_method, amount: order.total, source: credit_card)
+        # TODO: maybe look at some way of making this payment_state change automatic
+        order.payment_state = 'paid'
+        order.next!
+      end
+
+      def confirm(order)
+        order.complete!
+      end
+
+      def complete(order)
+        # noop?
+      end
+
+      def states
+        [:address, :delivery, :payment, :confirm]
+      end
     end
-
-    order = Spree::Order.create!(
-      email: "spree@example.com",
-      store: Spree::Store.first || FactoryBot.create(:store)
-    )
-    add_line_item!(order)
-    order.next!
-
-    states_to_process = if state == :complete
-                          states
-                        else
-                          end_state_position = states.index(state.to_sym)
-                          states[0..end_state_position]
-                        end
-
-    states_to_process.each do |state_to_process|
-      send(state_to_process, order)
-    end
-
-    order
-  end
-
-  private
-
-  def add_line_item!(order)
-    FactoryBot.create(:line_item, order: order)
-    order.reload
-  end
-
-  def address(order)
-    order.bill_address = FactoryBot.create(:address, country: @country, state: @state)
-    order.ship_address = FactoryBot.create(:address, country: @country, state: @state)
-    order.next!
-  end
-
-  def delivery(order)
-    order.next!
-  end
-
-  def payment(order)
-    credit_card = FactoryBot.create(:credit_card)
-    order.payments.create!(payment_method: credit_card.payment_method, amount: order.total, source: credit_card)
-    # TODO: maybe look at some way of making this payment_state change automatic
-    order.payment_state = 'paid'
-    order.next!
-  end
-
-  def confirm(order)
-    order.complete!
-  end
-
-  def complete(order)
-    # noop?
-  end
-
-  def states
-    [:address, :delivery, :payment, :confirm]
   end
 end
+
+# @private
+OrderWalkthrough = ActiveSupport::Deprecation::DeprecatedConstantProxy.new('OrderWalkthrough', 'Spree::TestingSupport::OrderWalkthrough')

--- a/core/spec/models/spree/ability_spec.rb
+++ b/core/spec/models/spree/ability_spec.rb
@@ -4,7 +4,10 @@ require 'rails_helper'
 require 'cancan'
 require 'cancan/matchers'
 require 'spree/testing_support/ability_helpers'
-require 'spree/testing_support/bar_ability'
+
+Spree::Deprecation.silence do
+  require 'spree/testing_support/bar_ability'
+end
 
 # Fake ability for testing registration of additional abilities
 class FooAbility

--- a/frontend/spec/controllers/spree/checkout_controller_with_views_spec.rb
+++ b/frontend/spec/controllers/spree/checkout_controller_with_views_spec.rb
@@ -23,7 +23,7 @@ describe Spree::CheckoutController, type: :controller do
       before do
         # Using a let block won't acknowledge the currency setting
         # Therefore we just do it like this...
-        order = OrderWalkthrough.up_to(:address)
+        order = Spree::TestingSupport::OrderWalkthrough.up_to(:address)
         allow(controller).to receive_messages current_order: order
       end
 

--- a/frontend/spec/features/checkout_spec.rb
+++ b/frontend/spec/features/checkout_spec.rb
@@ -215,7 +215,7 @@ describe "Checkout", type: :feature, inaccessible: true do
   context "doesn't allow bad credit card numbers" do
     let!(:payment_method) { create(:credit_card_payment_method) }
     before(:each) do
-      order = OrderWalkthrough.up_to(:delivery)
+      order = Spree::TestingSupport::OrderWalkthrough.up_to(:delivery)
 
       user = create(:user)
       order.user = user
@@ -243,7 +243,7 @@ describe "Checkout", type: :feature, inaccessible: true do
     let!(:user) { create(:user) }
 
     let!(:order) do
-      order = OrderWalkthrough.up_to(:delivery)
+      order = Spree::TestingSupport::OrderWalkthrough.up_to(:delivery)
 
       order.reload
       order.user = user
@@ -291,7 +291,7 @@ describe "Checkout", type: :feature, inaccessible: true do
 
     before do
       Capybara.ignore_hidden_elements = false
-      order = OrderWalkthrough.up_to(:delivery)
+      order = Spree::TestingSupport::OrderWalkthrough.up_to(:delivery)
       allow(order).to receive_messages(available_payment_methods: [check_payment, credit_cart_payment])
       order.user = create(:user)
       order.recalculate
@@ -326,7 +326,7 @@ describe "Checkout", type: :feature, inaccessible: true do
 
     before do
       user.wallet.add(credit_card)
-      order = OrderWalkthrough.up_to(:delivery)
+      order = Spree::TestingSupport::OrderWalkthrough.up_to(:delivery)
 
       allow_any_instance_of(Spree::CheckoutController).to receive_messages(current_order: order)
       allow_any_instance_of(Spree::CheckoutController).to receive_messages(try_spree_current_user: user)
@@ -568,7 +568,7 @@ describe "Checkout", type: :feature, inaccessible: true do
 
   context "when order is completed" do
     let!(:user) { create(:user) }
-    let!(:order) { OrderWalkthrough.up_to(:delivery) }
+    let!(:order) { Spree::TestingSupport::OrderWalkthrough.up_to(:delivery) }
 
     before(:each) do
       allow_any_instance_of(Spree::CheckoutController).to receive_messages(current_order: order)

--- a/frontend/spec/features/checkout_unshippable_spec.rb
+++ b/frontend/spec/features/checkout_unshippable_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe "checkout with unshippable items", type: :feature, inaccessible: true do
   let!(:stock_location) { create(:stock_location) }
-  let(:order) { OrderWalkthrough.up_to(:address) }
+  let(:order) { Spree::TestingSupport::OrderWalkthrough.up_to(:address) }
 
   before do
     create(:line_item, order: order)

--- a/frontend/spec/features/order_spec.rb
+++ b/frontend/spec/features/order_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 describe 'orders', type: :feature do
-  let(:order) { OrderWalkthrough.up_to(:complete) }
+  let(:order) { Spree::TestingSupport::OrderWalkthrough.up_to(:complete) }
   let(:user) { create(:user) }
 
   before do


### PR DESCRIPTION
Previously our test files defined a bunch of top level classes. This shouldn't really matter because it's just for tests, but it clutters up our documentation :frowning_face:.

![](http://i.hawth.ca/s/3CVenRJV.png)

This PR makes some changes to avoid cluttering up the root namespace (at least as it appears to docs):
* namespace OrderWalkthrough and CapybaraExt under the `Spree::TestingSupport` (with deprecations in place for the root constants)
* hides the `dummy_app` related classes from yard (`ApplicationController`, etc.)
* Deprecates `BarAbility`, and hides it from yard

**After:**
![](http://i.hawth.ca/s/BbSHRI7P.png)