### PR TITLE
Fix duplicate variants on product page

### DIFF
--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -219,6 +219,16 @@ RSpec.describe Spree::Product, type: :model do
           expect(product.variants_and_option_values_for(pricing_options)).to contain_exactly(low)
         end
       end
+
+      context 'when a variant has a fallback price' do
+        before do
+          low.prices.create(country_iso: nil)
+        end
+
+        it "returns that variant once" do
+          expect(product.variants_and_option_values_for.length).to eq(2)
+        end
+      end
     end
 
     describe "#variant_option_values_by_option_type" do

--- a/core/spec/models/spree/variant/scopes_spec.rb
+++ b/core/spec/models/spree/variant/scopes_spec.rb
@@ -28,6 +28,20 @@ RSpec.describe "Variant scopes", type: :model do
         end
       end
     end
+
+    context 'when searching for a variant that has two eligible prices (one fallback)' do
+      let(:france) { create(:country, iso: "FR") }
+      let(:pricing_options) { Spree::Variant::PricingOptions.new(country_iso: "FR", currency: "EUR") }
+
+      subject { Spree::Variant.with_prices(pricing_options) }
+
+      before do
+        variant_1.prices.create!(currency: "EUR", country: france, amount: 10)
+        variant_1.prices.create!(currency: "EUR", country: nil, amount: 10)
+      end
+
+      it { is_expected.to eq([variant_1]) }
+    end
   end
 
   it ".descend_by_popularity" do


### PR DESCRIPTION
This fixes issue #1654. The default pricing options class has a
`search_arguments` which adds `nil` as a matching possibility for the
price's country field (in order to accomodate for the fallback price).

In Spree::Variant.with_prices, Spree::Price.where(search_arguments) is
merged into a Variant query. This results in duplicate variants being
returned.

From the standard product page, `Spree::Variant.with_prices` is called
by `Spree::Product#variants_and_option_values_for(current_pricing_options)`.