### PR TITLE
Add yard rake task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ tags
 .rvmrc
 .sass-cache
 .localeapp
+.yardoc

--- a/Gemfile
+++ b/Gemfile
@@ -49,5 +49,8 @@ end
 
 gem 'rspec_junit_formatter', require: false, group: :ci
 
+# Documentation
+gem 'yard'
+
 custom_gemfile = File.expand_path('Gemfile-custom', __dir__)
 eval File.read(custom_gemfile) if File.exist?(custom_gemfile)

--- a/core/.yardopts
+++ b/core/.yardopts
@@ -1,0 +1,1 @@
+--no-private

--- a/core/Rakefile
+++ b/core/Rakefile
@@ -14,6 +14,9 @@ DummyApp::RakeTasks.new(
   lib_name: 'solidus_core'
 )
 
+require 'yard'
+YARD::Rake::YardocTask.new
+
 namespace :spec do
   task :isolated do
     spec_files = Dir['spec/**/*_spec.rb']


### PR DESCRIPTION
This adds a `rake yard` task to core, and sets the default options we should be using for documentation