### PR TITLE
Set HttpOnly flag when sending guest_token cookie

### DIFF
--- a/core/lib/spree/core/controller_helpers/auth.rb
+++ b/core/lib/spree/core/controller_helpers/auth.rb
@@ -42,7 +42,10 @@ module Spree
 
         def set_guest_token
           unless cookies.signed[:guest_token].present?
-            cookies.permanent.signed[:guest_token] = SecureRandom.urlsafe_base64(nil, false)
+            cookies.permanent.signed[:guest_token] = {
+              value: SecureRandom.urlsafe_base64(nil, false),
+              httponly: true
+            }
           end
         end
 

--- a/core/spec/lib/spree/core/controller_helpers/auth_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/auth_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe Spree::Core::ControllerHelpers::Auth, type: :controller do
     end
     it 'sends cookie header' do
       get :index
+      expect(response.headers["Set-Cookie"]).to match(/guest_token.*HttpOnly/)
       expect(response.cookies['guest_token']).not_to be_nil
     end
   end


### PR DESCRIPTION
The `HttpOnly` flag helps mitigate the damage XSS attacks by making the cookie inaccessible to JS via the `Document.cookie` API.

It's advisable to also set the `Secure` flag which only allows cookies to be sent over HTTPS, but that doesn't play nice with development environment so it shouldn't be the default here.

To enable secure cookies you can add the following to your Rails config:
`config.force_ssl = true`
This will enable secure cookies, HSTS, and TLS redirect, but each can be disabled independently:
http://api.rubyonrails.org/v5.1.5/classes/ActionDispatch/SSL.html