### PR TITLE
Make partially shipped shipment able to be ready

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -82,7 +82,7 @@ module Spree
 
     def can_transition_from_pending_to_ready?
       order.can_ship? &&
-        inventory_units.all? { |iu| iu.allow_ship? || iu.canceled? } &&
+        inventory_units.all? { |iu| iu.shipped? || iu.allow_ship? || iu.canceled? } &&
         (order.paid? || !Spree::Config[:require_payment_to_ship])
     end
 


### PR DESCRIPTION
Previously, all inventory units in a shipment needed to be `on_hand` or `cancelled` in order for the shipment to be considered shippable.

This worked fine for most users, but it caused issues for users who were partially shipping shipments manually using cartons.

This commit allows shipments with some shipped inventory units to still be considered "ready".

Fixes #2622
Alternative to #2621