### PR TITLE
Move EmailValidator under Spree namespace

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -129,7 +129,7 @@ module Spree
     before_create :link_by_email
 
     validates :email, presence: true, if: :require_email
-    validates :email, email: true, allow_blank: true
+    validates :email, 'spree/email' => true, allow_blank: true
     validates :guest_token, presence: { allow_nil: true }
     validates :number, presence: true, uniqueness: { allow_blank: true }
     validates :store_id, presence: true

--- a/core/lib/spree/core/validators/email.rb
+++ b/core/lib/spree/core/validators/email.rb
@@ -1,9 +1,30 @@
 # frozen_string_literal: true
 
-class EmailValidator < ActiveModel::EachValidator
-  def validate_each(record, attribute, value)
-    unless value =~ /\A([^@\.]|[^@\.]([^@\s]*)[^@\.])@([^@\s]+\.)+[^@\s]+\z/
-      record.errors.add(attribute, :invalid, { value: value }.merge!(options))
+module Spree
+  # == An ActiveModel Email Validator
+  #
+  # === Usage
+  #
+  #     require 'spree/core/validators/email'
+  #
+  #     class Person < ApplicationRecord
+  #       validates :email_address, 'spree/email' => true
+  #     end
+  #
+  class EmailValidator < ActiveModel::EachValidator
+    EMAIL_REGEXP = /\A([^@\.]|[^@\.]([^@\s]*)[^@\.])@([^@\s]+\.)+[^@\s]+\z/
+
+    def validate_each(record, attribute, value)
+      unless value =~ EMAIL_REGEXP
+        record.errors.add(attribute, :invalid, { value: value }.merge!(options))
+      end
     end
   end
 end
+
+# @private
+EmailValidator = ActiveSupport::Deprecation::DeprecatedConstantProxy.new(
+  'EmailValidator',
+  'Spree::EmailValidator',
+  message: "EmailValidator is deprecated! Use Spree::EmailValidator instead.\nChange `validates :email, email: true` to `validates :email, 'spree/email' => true`\n"
+)

--- a/core/spec/lib/spree/core/validators/email_spec.rb
+++ b/core/spec/lib/spree/core/validators/email_spec.rb
@@ -3,11 +3,11 @@
 require 'rails_helper'
 require 'spree/core/validators/email'
 
-RSpec.describe EmailValidator do
+RSpec.describe Spree::EmailValidator do
   class Tester
     include ActiveModel::Validations
     attr_accessor :email_address
-    validates :email_address, email: true
+    validates :email_address, 'spree/email' => true
   end
 
   let(:valid_emails) {


### PR DESCRIPTION
Change all usages of

    validates :email, email: true

to

    validates :email, 'spree/email' => true