### PR TITLE
Add rails- and solidus_i18n gems to sandbox

### DIFF
--- a/lib/sandbox.sh
+++ b/lib/sandbox.sh
@@ -37,6 +37,8 @@ fi
 cd ./sandbox
 echo "gem 'solidus', :path => '..'" >> Gemfile
 echo "gem 'solidus_auth_devise', '>= 2.1.0'" >> Gemfile
+echo "gem 'rails-i18n'" >> Gemfile
+echo "gem 'solidus_i18n'" >> Gemfile
 
 cat <<RUBY >> Gemfile
 group :test, :development do


### PR DESCRIPTION
Since we are emracing i18n in Solidus even more by including lots of
functionality from `solidus_i18n` into core it helps local development
and people trying out solidus via the sandbox to have these gems
installed as well.