### PR TITLE
Specify discard ~> 1.0

### DIFF
--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'awesome_nested_set', '~> 3.0', '>= 3.0.1'
   s.add_dependency 'cancancan', '~> 1.10'
   s.add_dependency 'carmen', '~> 1.1.0'
-  s.add_dependency 'discard'
+  s.add_dependency 'discard', '~> 1.0'
   s.add_dependency 'friendly_id', '~> 5.0'
   s.add_dependency 'kaminari-activerecord', '~> 1.1'
   s.add_dependency 'monetize', '~> 1.1'


### PR DESCRIPTION
I've just released discard 1.0.0 (no breaking changes, it's just time to follow SemVer), so we should require this instead of allowing any possible version (we should not allow 2.0, whatever that will be).

I'll also backport this to the 2.5.0 branch