### PR TITLE
Add initial Solidus upgrades documentation

### DIFF
--- a/guides/upgrades/overview.md
+++ b/guides/upgrades/overview.md
@@ -24,7 +24,7 @@ We maintain a number of Solidus extensions with good test coverage. Our [Solidus
 extensions list][extensions] also includes a compatibility chart for each major
 and minor version of Solidus.
 
-[extensions]: http://eextensions.solidus.io
+[extensions]: http://extensions.solidus.io
 
 ## You can migrate from Spree to Solidus
 

--- a/guides/upgrades/overview.md
+++ b/guides/upgrades/overview.md
@@ -1,0 +1,42 @@
+# Upgrades
+
+Easy upgrades are a core goal of Solidus. It should be easy for your production
+store to get onto the newest, most performant version of Solidus.
+
+## Straightforward upgrades
+
+Upgrading should not take months of preparation. We aim to make upgrades
+straightforward and painless. We use [Semantic Versioning][semver] to avoid
+unnecessary breaking changes. See the [Versioning guidelines][versioning]
+article for more information.
+
+[semver]: https://semver.org/ 
+[versioning]: versioning-guidelines.md
+
+## Extensions should just work
+
+Multiple versions of your Solidus extensions should work across multiple
+versions of Solidus. We do not think that you should have to tether your Solidus
+version just so you can keep running an extension that provides your store's
+flagship feature.
+
+We maintain a number of Solidus extensions with good test coverage. Our [Solidus
+extensions list][extensions] also includes a compatibility chart for each major
+and minor version of Solidus.
+
+[extensions]: http://eextensions.solidus.io
+
+## You can migrate from Spree to Solidus
+
+If you run a store that uses Spree 2.x, you can migrate from Spree to
+Solidus with relative ease. See the [Migrate from Spree][migrate-from-spree]
+article for more information.
+
+If you have extended your Spree store's models or have made substantial
+customizations to Spree, the migration may require some additional preparation.
+
+If you want to talk about your upcoming migration with somebody, [join our Slack
+team][slack] and start a conversation about it in the *#support* channel.
+
+[migrate-from-spree]: migrate-from-spree.html
+[slack]: http://slack.solidus.io/

--- a/guides/upgrades/versioning-guidelines.md
+++ b/guides/upgrades/versioning-guidelines.md
@@ -26,7 +26,7 @@ patch version.
 
 The internal call structure should be maintained so that any overrides to
 methods can still be called in the same way. Exceptions may be made for security
-fixes if necessary. 
+fixes if necessary.
 
 ### Minor versions
 
@@ -55,7 +55,7 @@ notes.
 ## End of life policy
 
 We want to offer critical security patches for older versions of Solidus.
-However, we cannot offer support for every minor version back to 1.0. 
+However, we cannot offer support for every minor version back to 1.0.
 
 To allow us to patch security issues promptly, and to make sure developers know
 how long their Solidus version will receive security updates, we use the

--- a/guides/upgrades/versioning-guidelines.md
+++ b/guides/upgrades/versioning-guidelines.md
@@ -1,30 +1,36 @@
 # Versioning guidelines
 
-As we develop Solidus, we aim to follow [Semantic
-Versioning](http://semver.org/) as closely as we can.
-
-Traditional Spree development involved a lot of overriding behaviour through
+Traditional Spree development involved a lot of overriding behavior through
 `class_eval` and overriding views either through [Deface][deface] or by
-replacing them.  This made upgrading, even through the same `X-Y-stable` branch,
+replacing them. This made upgrading, even through the same `X-Y-stable` branch,
 quite dangerous and error-prone.
 
 Our main goal for the Solidus project is to define proper extension points so
 that fewer breaking changes are introduced, and those that are introduced are
 easily found.
 
-## Patch versions
+[deface]: https://github.com/spree/deface
+
+## Semantic versioning
+
+As we develop Solidus, we aim to follow [Semantic Versioning][semver] as closely
+as we can.
+
+[semver]: http://semver.org
+
+### Patch versions
 
 Patch versions (`x.y.Z`) are reserved for small bug fixes and security patches.
 Commits are added sparingly to ensure that stores can always stay on the latest
 patch version.
 
-The internal call structure should be maintained so that any overrides to method
-can still be called in the same way. Exceptions may be made for security fixes
-if necessary. 
+The internal call structure should be maintained so that any overrides to
+methods can still be called in the same way. Exceptions may be made for security
+fixes if necessary. 
 
-## Minor versions
+### Minor versions
 
-Minor versions (`x.Y.z`) is for any backwards-compatible changes to the public
+Minor versions (`x.Y.z`) are for any backwards-compatible changes to the public
 API.
 
 This is tough to define because our public API could be considered to be all of
@@ -40,8 +46,25 @@ we suspect there would be a store with an override.
 We would like to also follow the Rails approach: deprecating functionality in
 one minor version and removing it in the next.
 
-## Major versions
+### Major versions
 
 Major version (`X.y.z`) are for backwards incompatible changes. We will make an
 effort to document breaking changes (and all meaningful changes) in the release
 notes.
+
+## End of life policy
+
+We want to offer critical security patches for older versions of Solidus.
+However, we cannot offer support for every minor version back to 1.0. 
+
+To allow us to patch security issues promptly, and to make sure developers know
+how long their Solidus version will receive security updates, we use the
+following end of life policy:
+
+**Solidus versions receive security patches for 18 months following their
+initial release.**
+
+For example, Solidus 2.4 was released on November, 7, 2017, and will receive
+critical patches until May 7, 2019.
+
+This end of life policy affects all minor versions of Solidus following 2.0.

--- a/guides/upgrades/versioning-guidelines.md
+++ b/guides/upgrades/versioning-guidelines.md
@@ -1,0 +1,47 @@
+## Versioning guidelines
+
+As we develop Solidus, we aim to follow [Semantic
+Versioning](http://semver.org/) as closely as we can.
+
+Traditional Spree development involved a lot of overriding behaviour through
+`class_eval` and overriding views either through [Deface][deface] or by
+replacing them.  This made upgrading, even through the same `X-Y-stable` branch,
+quite dangerous and error-prone.
+
+Our main goal for the Solidus project is to define proper extension points so
+that fewer breaking changes are introduced, and those that are introduced are
+easily found.
+
+## Patch versions
+
+Patch versions (`x.y.Z`) are reserved for small bug fixes and security patches.
+Commits are added sparingly to ensure that stores can always stay on the latest
+patch version.
+
+The internal call structure should be maintained so that any overrides to method
+can still be called in the same way. Exceptions may be made for security fixes
+if necessary. 
+
+## Minor versions
+
+Minor versions (`x.Y.z`) is for any backwards-compatible changes to the public
+API.
+
+This is tough to define because our public API could be considered to be all of
+the methods on all of our ActiveRecord objects, which is not feasible to
+maintain. We use our best judgment about what methods are being used, but there
+may still be incompatible changes. Methods we have documented should only have
+backwards-compatible changes.
+
+Any `class_eval` overrides or Deface overrides may not be called any more or be
+called in a different way. We use our best judgment to add extension points when
+we suspect there would be a store with an override.
+
+We would like to also follow the Rails approach: deprecating functionality in
+one minor version and removing it in the next.
+
+## Major versions
+
+Major version (`X.y.z`) are for backwards incompatible changes. We will make an
+effort to document breaking changes (and all meaningful changes) in the release
+notes.

--- a/guides/upgrades/versioning-guidelines.md
+++ b/guides/upgrades/versioning-guidelines.md
@@ -1,4 +1,4 @@
-## Versioning guidelines
+# Versioning guidelines
 
 As we develop Solidus, we aim to follow [Semantic
 Versioning](http://semver.org/) as closely as we can.


### PR DESCRIPTION
This adds two short articles describing Solidus's core goals in regards to upgrades and how Solidus handles versioning and semver.

_This is part a larger project to improve Solidus's documentation. [See this gist with the high-level table of contents](https://gist.github.com/benjaminwil/5e2d2da3d9def6b949b833b1aa2549d3). Where and how this documentation will exist is still up for discussion._