### PR TITLE
Disable backend footer profile edit link if role cannot edit users

### DIFF
--- a/backend/app/views/spree/admin/shared/_navigation_footer.html.erb
+++ b/backend/app/views/spree/admin/shared/_navigation_footer.html.erb
@@ -6,9 +6,16 @@
 <% if try_spree_current_user %>
   <ul id="login-nav" class="admin-login-nav">
     <li data-hook="user-account-link">
-      <%= link_to spree.polymorphic_path([:edit, :admin, try_spree_current_user]) do %>
-        <i class='fa fa-user'></i>
-        <%= try_spree_current_user.email %>
+      <% if can?(:admin, try_spree_current_user) %>
+        <%= link_to spree.edit_admin_user_path(try_spree_current_user) do %>
+          <i class='fa fa-user'></i>
+          <%= try_spree_current_user.email %>
+        <% end %>
+      <% else %>
+        <a>
+          <i class='fa fa-user'></i>
+          <%= try_spree_current_user.email %>
+        </a>
       <% end %>
     </li>
 

--- a/backend/spec/views/spree/admin/shared/navigation_footer_spec.rb
+++ b/backend/spec/views/spree/admin/shared/navigation_footer_spec.rb
@@ -4,8 +4,10 @@ require 'spec_helper'
 
 describe "spree/admin/shared/_navigation_footer", type: :view do
   let(:user) { FactoryBot.build_stubbed(:admin_user) }
+  let(:ability) { Object.new.extend(CanCan::Ability) }
   before do
     allow(view).to receive(:try_spree_current_user).and_return(user)
+    allow(controller).to receive(:current_ability).and_return(ability)
   end
 
   it "has a a login-nav section" do
@@ -13,9 +15,32 @@ describe "spree/admin/shared/_navigation_footer", type: :view do
     expect(rendered).to have_selector("#login-nav")
   end
 
-  it "has a user-account-link" do
-    render
-    expect(rendered).to have_link(user.email, href: Spree::Core::Engine.routes.url_helpers.edit_admin_user_path(user))
+  context "authorized user" do
+    before do
+      ability.can :admin, user
+    end
+
+    it "has a user-account-link that links to edit_admin_user_path" do
+      render
+      expect(rendered).to have_link(user.email, href: Spree::Core::Engine.routes.url_helpers.edit_admin_user_path(user))
+    end
+
+    it "has not a user-account-link that links to admin_path" do
+      render
+      expect(rendered).to_not have_link(user.email, href: Spree::Core::Engine.routes.url_helpers.admin_path)
+    end
+  end
+
+  context "unauthorized user" do
+    it "has a user-account-link that links to admin_path" do
+      render
+      expect(rendered).to_not have_link(user.email, href: Spree::Core::Engine.routes.url_helpers.admin_path)
+    end
+
+    it "has not a user-account-link that links to edit_admin_user_path" do
+      render
+      expect(rendered).to_not have_link(user.email, href: Spree::Core::Engine.routes.url_helpers.edit_admin_user_path(user))
+    end
   end
 
   context "with a required spree_logout_path helper" do


### PR DESCRIPTION
A user with a role that can access the backend main page but has no permissions to edit users will get a misleading "Authorization Failure" error.
With this fix the user will be cleanly routed to the main page without displaying any errors.