### PR TITLE
Lock mysql2 to 0.4.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source 'https://rubygems.org'
 gemspec require: false
 
 platforms :ruby do
-  gem 'mysql2', require: false
+  gem 'mysql2', '~> 0.4.10', require: false
   gem 'pg', '~> 0.21', require: false
   gem 'sqlite3', require: false
   gem 'fast_sqlite', require: false


### PR DESCRIPTION
Current Rails releases don't yet support the newly released 0.5.0