### PR TITLE
Clean CheckoutsController routes

### DIFF
--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -20,12 +20,6 @@ Spree::Core::Engine.routes.draw do
     end
 
     concern :order_routes do
-      member do
-        put :cancel
-        put :empty
-        put :apply_coupon_code
-      end
-
       resources :line_items
       resources :payments do
         member do
@@ -69,7 +63,13 @@ Spree::Core::Engine.routes.draw do
     get '/orders/mine', to: 'orders#mine', as: 'my_orders'
     get "/orders/current", to: "orders#current", as: "current_order"
 
-    resources :orders, concerns: :order_routes
+    resources :orders, concerns: :order_routes do
+      member do
+        put :cancel
+        put :empty
+        put :apply_coupon_code
+      end
+    end
 
     resources :zones
     resources :countries, only: [:index, :show] do


### PR DESCRIPTION
The Api::Checkouts::Controller does not have any actions to match the
order_concern routes (empty, cancel, apply_coupon_code).