### PR TITLE
Remove generators from YARD docs

### DIFF
--- a/core/lib/generators/spree/custom_user/custom_user_generator.rb
+++ b/core/lib/generators/spree/custom_user/custom_user_generator.rb
@@ -3,6 +3,7 @@
 require 'rails/generators/active_record/migration'
 
 module Spree
+  # @private
   class CustomUserGenerator < Rails::Generators::NamedBase
     include ActiveRecord::Generators::Migration
 

--- a/core/lib/generators/spree/dummy/dummy_generator.rb
+++ b/core/lib/generators/spree/dummy/dummy_generator.rb
@@ -5,6 +5,7 @@ require 'active_support/core_ext/hash'
 require 'spree/core/version'
 
 module Spree
+  # @private
   class DummyGenerator < Rails::Generators::Base
     desc "Creates blank Rails application, installs Solidus and all sample data"
 
@@ -138,9 +139,10 @@ end
       end
     end
   end
-end
 
-module Spree::DummyGeneratorHelper
-  mattr_accessor :inject_extension_requirements
-  self.inject_extension_requirements = false
+  # @private
+  module DummyGeneratorHelper
+    mattr_accessor :inject_extension_requirements
+    self.inject_extension_requirements = false
+  end
 end

--- a/core/lib/generators/spree/install/install_generator.rb
+++ b/core/lib/generators/spree/install/install_generator.rb
@@ -5,6 +5,7 @@ require 'bundler'
 require 'bundler/cli'
 
 module Spree
+  # @private
   class InstallGenerator < Rails::Generators::Base
     CORE_MOUNT_ROUTE = "mount Spree::Core::Engine"
 


### PR DESCRIPTION
I'm not sure if this is what we want to do, but I feel they clutter up documentation and generally aren't useful to users.