### PR TITLE
Remove state machine gem from Spree::Shipment

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -157,14 +157,17 @@ module Spree
     def can_transition_from_pending_to_shipped?
       !requires_shipment?
     end
+    deprecate can_transition_from_pending_to_shipped?: '!requires_shipment?', deprecator: Spree::Deprecation
 
     def can_transition_from_pending_to_ready?
       inventory_can_ship?
     end
+    deprecate can_transition_from_pending_to_ready?: :inventory_can_ship?, deprecator: Spree::Deprecation
 
     def can_transition_from_canceled_to_ready?
       can_transition_from_pending_to_ready?
     end
+    deprecate can_transition_from_canceled_to_ready?: :inventory_can_ship?, deprecator: Spree::Deprecation
 
     extend DisplayMoney
     money_methods(

--- a/core/db/migrate/20180404185904_add_default_state_to_shipment.rb
+++ b/core/db/migrate/20180404185904_add_default_state_to_shipment.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDefaultStateToShipment < ActiveRecord::Migration[5.1]
+  def change
+    change_column_default(:spree_shipments, :state, 'pending')
+  end
+end

--- a/core/spec/models/spree/order/state_machine_spec.rb
+++ b/core/spec/models/spree/order/state_machine_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Spree::Order, type: :model do
       end
     end
 
-    (Spree::Shipment.state_machine.states.keys - states).each do |shipment_state|
+    ['shipped', 'canceled'].each do |shipment_state|
       it "should be false if shipment_state is #{shipment_state}" do
         expect(order).to be_completed
         order.shipment_state = shipment_state

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -1208,4 +1208,34 @@ RSpec.describe Spree::Shipment, type: :model do
 
     it { is_expected.to include carton }
   end
+
+  describe '#inventory_can_ship?' do
+    let(:shipment) { create(:shipment, order: order) }
+
+    subject { shipment.inventory_can_ship? }
+
+    context "with backordered inventory" do
+      before { shipment.inventory_units.update_all(state: "backordered") }
+
+      it "returns false" do
+        expect(subject).to be false
+      end
+    end
+
+    context "with on_hand inventory" do
+      before { shipment.inventory_units.update_all(state: "on_hand") }
+
+      it "returns true" do
+        expect(subject).to be true
+      end
+    end
+
+    context "with shipped inventory" do
+      before { shipment.inventory_units.update_all(state: "shipped") }
+
+      it "returns true" do
+        expect(subject).to be true
+      end
+    end
+  end
 end

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -1170,36 +1170,6 @@ RSpec.describe Spree::Shipment, type: :model do
     end
   end
 
-  describe '#can_transition_from_pending_to_ready?' do
-    let(:shipment) { create(:shipment, order: order) }
-
-    subject { shipment.can_transition_from_pending_to_ready? }
-
-    context "with backordered inventory" do
-      before { shipment.inventory_units.update_all(state: "backordered") }
-
-      it "returns false" do
-        expect(subject).to be false
-      end
-    end
-
-    context "with on_hand inventory" do
-      before { shipment.inventory_units.update_all(state: "on_hand") }
-
-      it "returns true" do
-        expect(subject).to be true
-      end
-    end
-
-    context "with shipped inventory" do
-      before { shipment.inventory_units.update_all(state: "shipped") }
-
-      it "returns true" do
-        expect(subject).to be true
-      end
-    end
-  end
-
   describe '#cartons' do
     let(:carton)   { create(:carton) }
     let(:shipment) { carton.shipments.first }


### PR DESCRIPTION
The [state_machines gem](https://github.com/state-machines/state_machines) has been used throughout Solidus since the earliest days of Spree. We use it to track the "state" our shipments/payments/orders are in, as well as plug custom functionality into the transitions between those states (`before_transition`/`after_transition`). 

However, our use of intermingled state machines between Payments, Shipments and Orders causes problems for both new and established developers. The state machine transitions are difficult to understand and debug, the order the transitions are executed in can be tough to control, and properly controlling database transactions during a transition is very poorly understood. 

We believe the downsides of implementing our state machines using the state_machines gem to be a net negative for the project.

This PR changes the `Spree::Shipment` class, explicitly defining the important methods that would have been generated from the state_machines metaprogramming. The advantages of doing this are improved code clarity, debug-ability, as well as making it more easy to completely override methods regarding state.

The first two commits of this pull request remove the `state_machine` from [`Spree::Shipment`](https://github.com/solidusio/solidus/blob/master/core/app/models/spree/shipment.rb) without changing the external API of the model. The last two commits go a bit further and deprecate the [transition methods](https://github.com/solidusio/solidus/blob/fd474db749d4386f52a23efbb59d30336351028d/core/app/models/spree/shipment.rb#L79-L91) that were used by the state machine in an attempt to improve code readability. If we don't want to go ahead and deprecate the transition methods, the first two commits can just be taken on their own, keeping the external API of [`Spree::Shipment`](https://github.com/solidusio/solidus/blob/master/core/app/models/spree/shipment.rb) intact.

While we could re-implement the `before_transition`/`after_transition` calls on the `Spree::Shipment` model, we believe the following examples would be a better way to support customising functionality before or after a transition (with `ship` used as an example).

```ruby
module AfterShipAction
  # Note that returning true/false is done to preserve the original return values of ship
  # This pattern works for all of ship, resume, pend, ready, and cancel
  def ship
    if super
      additional_after_ship_procedure
    end
  end

  def additional_after_ship_procedure
    # Do something interesting!
    true
  end
end

module BeforeShipCondition
  def ship
    if pre_ship_condition
      super
    end
  end

  def pre_ship_condition
    # Some interesting condition as to when we can ship
    true
  end
end

Spree::Shipment.prepend AfterShipAction
Spree::Shipment.prepend BeforeShipCondition
```