### PR TITLE
Deprecate payment_method_name helper

### DIFF
--- a/backend/app/helpers/spree/admin/payments_helper.rb
+++ b/backend/app/helpers/spree/admin/payments_helper.rb
@@ -4,6 +4,7 @@ module Spree
   module Admin
     module PaymentsHelper
       def payment_method_name(payment)
+        Spree::Deprecation.warn "payment_method_name(payment) is deprecated. Instead use payment.payment_method.name"
         payment.payment_method.name
       end
     end

--- a/backend/app/views/spree/admin/orders/confirm/_payments.html.erb
+++ b/backend/app/views/spree/admin/orders/confirm/_payments.html.erb
@@ -24,7 +24,7 @@
             <%= payment.display_amount.to_html %>
           </td>
           <td>
-            <%= payment_method_name(payment) %>
+            <%= payment.payment_method.name %>
           </td>
           <td>
             <%= payment.transaction_id %>

--- a/backend/app/views/spree/admin/payments/_list.html.erb
+++ b/backend/app/views/spree/admin/payments/_list.html.erb
@@ -24,7 +24,7 @@
       <tr id="<%= dom_id(payment) %>" data-hook="payments_row" class="payment vertical-middle" data-payment-id="<%= payment.id %>">
         <td><%= link_to payment.number, spree.admin_order_payment_path(@order, payment) %></td>
         <td><%= l(payment.created_at, format: :short) %></td>
-        <td><%= payment_method_name(payment) %></td>
+        <td><%= payment.payment_method.name %></td>
         <td><%= payment.transaction_id %></td>
         <td>
           <span class="pill pill-<%= payment.state %>">

--- a/backend/app/views/spree/admin/payments/show.html.erb
+++ b/backend/app/views/spree/admin/payments/show.html.erb
@@ -2,7 +2,7 @@
 
 <% admin_breadcrumb(link_to plural_resource_name(Spree::Payment), spree.admin_order_payments_path(@order)) %>
 <% admin_breadcrumb do %>
-  <%= payment_method_name(@payment) %>
+  <%= @payment.payment_method.name %>
   <span class="pill pill-<%= @payment.state %>">
     <%= t(@payment.state, scope: 'spree.payment_states') %>
   </span>

--- a/backend/app/views/spree/admin/shared/_refunds.html.erb
+++ b/backend/app/views/spree/admin/shared/_refunds.html.erb
@@ -18,7 +18,7 @@
         <td><%= pretty_time(refund.created_at) %></td>
         <td><%= refund.payment.number %></td>
         <td class="amount"><%= refund.display_amount %></td>
-        <td><%= payment_method_name(refund.payment) %></td>
+        <td><%= refund.payment.payment_method.name %></td>
         <td><%= refund.transaction_id %></td>
         <td><%= truncate(refund.reason.name, length: 100) %></td>
         <% if show_actions %>


### PR DESCRIPTION
On top of #2650 

This used to do stuff to work around paranoia, which is no longer necessary.