### PR TITLE
Add a shipment_id index to shipping_rates table

### DIFF
--- a/core/db/migrate/20180328135938_add_shipment_id_index_to_spree_shipping_rates.rb
+++ b/core/db/migrate/20180328135938_add_shipment_id_index_to_spree_shipping_rates.rb
@@ -1,0 +1,5 @@
+class AddShipmentIdIndexToSpreeShippingRates < ActiveRecord::Migration[5.0]
+  def change
+    add_index :spree_shipping_rates, :shipment_id
+  end
+end


### PR DESCRIPTION
This missing index speeds up the `Spree::Shipment#selected_shipping_rate` query
for large applications from 4 seconds to 4 milliseconds. This is for a table with
1,297,260 shipping rates.

Beware that this migration could take a while (~2 seconds for above mentioned table).