### PR TITLE
Promo code batch join chars

### DIFF
--- a/backend/app/views/spree/admin/promotion_code_batches/new.html.erb
+++ b/backend/app/views/spree/admin/promotion_code_batches/new.html.erb
@@ -10,6 +10,11 @@
     <%= f.text_field :base_code, class: "fullwidth" %>
   <% end %>
 
+  <%= f.field_container :join_characters do %>
+    <%= f.label :join_characters %>
+    <%= f.text_field :join_characters, class: "fullwidth" %>
+  <% end %>
+
   <%= f.field_container :number_of_codes do %>
     <%= f.label :number_of_codes %>
     <%= f.text_field :number_of_codes, class: "fullwidth" %>

--- a/backend/app/views/spree/admin/promotions/_activations_new.html.erb
+++ b/backend/app/views/spree/admin/promotions/_activations_new.html.erb
@@ -50,6 +50,10 @@
           <%= batch.number_field :number_of_codes, class: "fullwidth", min: 1, required: true %>
         </div>
         <div class="field">
+          <%= batch.label :join_characters %>
+          <%= batch.text_field :join_characters, class: "fullwidth" %>
+        </div>
+        <div class="field">
           <%= f.label :per_code_usage_limit %>
           <%= f.text_field :per_code_usage_limit, class: "fullwidth" %>
         </div>

--- a/core/app/models/spree/promotion_code/batch_builder.rb
+++ b/core/app/models/spree/promotion_code/batch_builder.rb
@@ -7,11 +7,10 @@ class ::Spree::PromotionCode::BatchBuilder
   DEFAULT_OPTIONS = {
     random_code_length: 6,
     batch_size: 1000,
-    sample_characters: ('a'..'z').to_a + (2..9).to_a.map(&:to_s),
-    join_characters: "_"
+    sample_characters: ('a'..'z').to_a + (2..9).to_a.map(&:to_s)
   }
 
-  [:random_code_length, :batch_size, :sample_characters, :join_characters].each do |attr|
+  [:random_code_length, :batch_size, :sample_characters].each do |attr|
     define_singleton_method(attr) do
       Spree::Deprecation.warn "#{name}.#{attr} is deprecated. Use #{name}::DEFAULT_OPTIONS[:#{attr}] instead"
       DEFAULT_OPTIONS[attr]
@@ -70,7 +69,7 @@ class ::Spree::PromotionCode::BatchBuilder
       @options[:sample_characters].sample
     end.join
 
-    "#{base_code}#{@options[:join_characters]}#{suffix}"
+    "#{base_code}#{@promotion_code_batch.join_characters}#{suffix}"
   end
 
   def get_unique_codes(code_set)

--- a/core/db/migrate/20180328172631_add_join_characters_to_promotion_code_batch.rb
+++ b/core/db/migrate/20180328172631_add_join_characters_to_promotion_code_batch.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddJoinCharactersToPromotionCodeBatch < ActiveRecord::Migration[5.1]
+  def change
+    add_column(:spree_promotion_code_batches,
+               :join_characters,
+               :string,
+               null: false,
+               default: '_')
+  end
+end

--- a/core/spec/models/spree/promotion_code/batch_builder_spec.rb
+++ b/core/spec/models/spree/promotion_code/batch_builder_spec.rb
@@ -86,7 +86,15 @@ RSpec.describe Spree::PromotionCode::BatchBuilder do
     end
 
     context "with a custom join separator" do
-      let(:options) { { join_characters: "x" } }
+      let(:promotion_code_batch) do
+        Spree::PromotionCodeBatch.create!(
+          promotion_id: promotion.id,
+          base_code: base_code,
+          number_of_codes: number_of_codes,
+          email: "test@email.com",
+          join_characters: "x"
+        )
+      end
 
       it "builds codes with the same base prefix" do
         subject.build_promotion_codes


### PR DESCRIPTION
This PR aims to resolve #1946, allowing customization of promotion separator characters (currently always `'_'`) via the admin. It stores the characters to use on the `PromotionCodeBatch` model, and has a default set to `'_'`, so that users who do not wish to make use of this functionality do not need to change their workflows.