### PR TITLE
Remove state machine gem from Spree::Payment

### DIFF
--- a/core/db/migrate/20180404215857_add_default_state_to_payment.rb
+++ b/core/db/migrate/20180404215857_add_default_state_to_payment.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDefaultStateToPayment < ActiveRecord::Migration[5.1]
+  def change
+    change_column_default(:spree_payments, :state, 'checkout')
+  end
+end

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -668,12 +668,9 @@ RSpec.describe Spree::Payment, type: :model do
     end
 
     context 'when the payment was completed but now void' do
-      let(:payment) do
-        Spree::Payment.create(
-          amount: 100,
-          order: order,
-          state: 'completed'
-        )
+      before do
+        payment.state = 'completed'
+        payment.amount = 100
       end
 
       it 'updates order payment total' do


### PR DESCRIPTION
This PR removes the state machine gem from `Spree::Payment` while keeping the external API intact. The logic that was previously hidden within the state machine is now contained within the `Spree::Payment` model.

Please see #2656 for the rationale behind these changes.