### PR TITLE
Bump mysql2 and pg Gemfile dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,8 @@ source 'https://rubygems.org'
 gemspec require: false
 
 platforms :ruby do
-  gem 'mysql2', '~> 0.4.10', require: false
-  gem 'pg', '~> 0.21', require: false
+  gem 'mysql2', '~> 0.5.0', require: false
+  gem 'pg', '~> 1.0', require: false
   gem 'sqlite3', require: false
   gem 'fast_sqlite', require: false
 end


### PR DESCRIPTION
Rails 5.1.6 supports both mysql2 0.5.0 and pg 1.0.0