### PR TITLE
Remove state machine gem from Spree::InventoryUnit

### DIFF
--- a/core/db/migrate/20180405181459_add_default_state_to_inventory_unit.rb
+++ b/core/db/migrate/20180405181459_add_default_state_to_inventory_unit.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDefaultStateToInventoryUnit < ActiveRecord::Migration[5.1]
+  def change
+    change_column_default(:spree_inventory_units, :state, 'on_hand')
+  end
+end


### PR DESCRIPTION
This PR removes the state machine gem from `Spree::InventoryUnit` while keeping the external API intact. The logic that was previously hidden within the state machine is now contained within the `Spree::InventoryUnit` model.

Please see #2656 for the rationale behind these changes.