### PR TITLE
Load email validator from core instead of order

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'spree/core/validators/email'
 require 'spree/order/checkout'
 require 'spree/order/number_generator'
 

--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -84,6 +84,7 @@ require 'spree/core/controller_helpers/store'
 require 'spree/core/controller_helpers/strong_parameters'
 require 'spree/core/role_configuration'
 require 'spree/core/stock_configuration'
+require 'spree/core/validators/email'
 require 'spree/permission_sets'
 
 require 'spree/preferences/store'


### PR DESCRIPTION
It may be desirable to use the email validator from elsewhere before order.rb has been loaded.

Additionally, this fixes an issue where EmailValidator would be unloaded in development mode. Spree::Order is autoloaded, and because Spree::EmailValidator is inside the same namespace, this confuses rails into thinking Spree::EmailValidator was defined in this file and can be reloaded. I believe this to be a bug in rails.