### PR TITLE
Remove has checkout step

### DIFF
--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -194,7 +194,7 @@ module Spree
     end
 
     def update_inventory
-      if (saved_changes? || target_shipment.present?) && order.has_checkout_step?("delivery")
+      if saved_changes? || target_shipment.present?
         Spree::OrderInventory.new(order, self).verify(target_shipment)
       end
     end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -844,7 +844,7 @@ module Spree
     end
 
     def ensure_inventory_units
-      if has_checkout_step?("delivery")
+      if Spree::Config.build_shipment_predicate_class.call(self)
         inventory_validator = Spree::Stock::InventoryValidator.new
 
         errors = line_items.map { |line_item| inventory_validator.validate(line_item) }.compact

--- a/core/app/models/spree/order_inventory.rb
+++ b/core/app/models/spree/order_inventory.rb
@@ -18,6 +18,7 @@ module Spree
     # restock items if the order is completed. That is so because stock items
     # are always unstocked when the order is completed through +shipment.finalize+
     def verify(shipment = nil)
+      return unless Spree::Config.build_shipment_predicate_class.call(order)
       if order.completed? || shipment.present?
 
         existing_quantity = inventory_units.count

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -17,6 +17,7 @@
 # a.get :color
 # a.preferred_color
 #
+require 'spree/core/shipments/predicates/build'
 require "spree/core/search/base"
 require "spree/core/search/variant"
 require 'spree/preferences/configuration'
@@ -267,6 +268,16 @@ module Spree
     def available_currencies
       @available_currencies ||= ::Money::Currency.all
     end
+
+    # Allows implementing custom shipment building criterion based on an order
+    # instance. Warning: change this setting is not recommended.
+    # @!attribute [rw] build_shipment_predicate_class
+    #   @note Setting this to false is not recommended. This setting is provided
+    #     to help users who have made heavy modifications to disable shipments
+    #     in their store.
+    #   @return [Class] The predicate class that responds to #call(order) to
+    #     determine if shipments should be built.
+    class_name_attribute :build_shipment_predicate_class, default: 'Spree::Core::Shipments::Predicates::Build'
 
     # searcher_class allows spree extension writers to provide their own Search class
     class_name_attribute :searcher_class, default: 'Spree::Core::Search::Base'

--- a/core/lib/spree/core/shipments/predicates/build.rb
+++ b/core/lib/spree/core/shipments/predicates/build.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Spree
+  module Core
+    module Shipments
+      module Predicates
+        class Build
+          def self.call(_order)
+            true
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR aims to resolve #2502 by enabling branching on a configuration option rather than on `order.has_checkout_step?`, thereby allowing shipments to be either built or not independent of the names of checkout steps.