### PR TITLE
Add per-store configurable locales

### DIFF
--- a/api/app/helpers/spree/api/api_helpers.rb
+++ b/api/app/helpers/spree/api/api_helpers.rb
@@ -168,7 +168,7 @@ module Spree
 
       @@store_attributes = [
         :id, :name, :url, :meta_description, :meta_keywords, :seo_title,
-        :mail_from_address, :default_currency, :code, :default
+        :mail_from_address, :default_currency, :code, :default, :available_locales
       ]
 
       @@store_credit_history_attributes = [

--- a/api/spec/requests/spree/api/stores_controller_spec.rb
+++ b/api/spec/requests/spree/api/stores_controller_spec.rb
@@ -35,7 +35,8 @@ module Spree
             "mail_from_address" => "spree@example.org",
             "default_currency" => nil,
             "code" => store.code,
-            "default" => true
+            "default" => true,
+            "available_locales" => ["en"]
           },
           {
             "id" => non_default_store.id,
@@ -47,7 +48,8 @@ module Spree
             "mail_from_address" => "spree@example.org",
             "default_currency" => nil,
             "code" => non_default_store.code,
-            "default" => false
+            "default" => false,
+            "available_locales" => ["en"]
           }
         ])
       end
@@ -64,7 +66,8 @@ module Spree
           "mail_from_address" => "spree@example.org",
           "default_currency" => nil,
           "code" => store.code,
-          "default" => true
+          "default" => true,
+          "available_locales" => ["en"]
         )
       end
 

--- a/backend/app/views/spree/admin/stores/_form.html.erb
+++ b/backend/app/views/spree/admin/stores/_form.html.erb
@@ -58,3 +58,14 @@
     { class: "custom-select fullwidth" } %>
   <%= f.error_message_on :cart_tax_country_iso %>
 <% end %>
+
+<%= f.field_container :available_locales do %>
+  <%= f.label :available_locales %>
+  <%= f.select :available_locales,
+    Spree.i18n_available_locales.map { |locale|
+      [I18n.t('spree.i18n.this_file_language', locale: locale, default: locale.to_s, fallback: false), locale]
+    }.sort,
+    { },
+    { class: 'custom-select fullwidth', multiple: true } %>
+  <%= f.error_message_on :default_currency %>
+<% end %>

--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -31,6 +31,24 @@ module Spree
       deprecate :by_url, "Spree::Store.by_url is DEPRECATED", deprecator: Spree::Deprecation
     end
 
+    def available_locales
+      locales = super()
+      if locales
+        super().split(",").map(&:to_sym)
+      else
+        Spree.i18n_available_locales
+      end
+    end
+
+    def available_locales=(locales)
+      locales = locales.reject(&:blank?)
+      if locales.empty?
+        super(nil)
+      else
+        super(locales.map(&:to_s).join(","))
+      end
+    end
+
     def self.current(store_key)
       Spree::Deprecation.warn "Spree::Store.current is DEPRECATED"
       current_store = Store.find_by(code: store_key) || Store.by_url(store_key).first if store_key

--- a/core/db/migrate/20180313220213_add_available_locales_to_stores.rb
+++ b/core/db/migrate/20180313220213_add_available_locales_to_stores.rb
@@ -1,0 +1,7 @@
+class AddAvailableLocalesToStores < ActiveRecord::Migration[5.1]
+  def change
+    change_table :spree_stores do |t|
+      t.column :available_locales, :string
+    end
+  end
+end

--- a/core/db/migrate/20180313220213_add_available_locales_to_stores.rb
+++ b/core/db/migrate/20180313220213_add_available_locales_to_stores.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddAvailableLocalesToStores < ActiveRecord::Migration[5.1]
   def change
     change_table :spree_stores do |t|

--- a/core/spec/models/spree/store_spec.rb
+++ b/core/spec/models/spree/store_spec.rb
@@ -96,4 +96,61 @@ RSpec.describe Spree::Store, type: :model do
       end
     end
   end
+
+  describe '#available_locales' do
+    let(:store) { described_class.new(available_locales: locales) }
+    subject { store.available_locales }
+
+    context 'with available_locales: []' do
+      let(:locales) { [] }
+
+      it "returns all available locales" do
+        expect(subject).to eq([:en])
+      end
+
+      it "serializes as nil" do
+        expect(store[:available_locales]).to be nil
+      end
+    end
+
+    context 'with available_locales: [:en]' do
+      let(:locales) { [:en] }
+
+      it "returns [:en]" do
+        expect(subject).to eq([:en])
+      end
+
+      it "serializes correctly" do
+        expect(store[:available_locales]).to eq("en")
+      end
+    end
+
+    context 'with available_locales: [:en, :fr]' do
+      let(:locales) { [:en, :fr] }
+
+      it "returns [:fr]" do
+        expect(subject).to eq([:en, :fr])
+      end
+
+      it "serializes correctly" do
+        expect(store[:available_locales]).to eq("en,fr")
+      end
+    end
+
+    context 'with available_locales: [:fr]' do
+      let(:locales) { [:fr] }
+
+      it "returns [:fr]" do
+        expect(subject).to eq([:fr])
+      end
+    end
+
+    context 'with available_locales: ["fr"]' do
+      let(:locales) { ["fr"] }
+
+      it "returns symbols [:fr]" do
+        expect(subject).to eq([:fr])
+      end
+    end
+  end
 end


### PR DESCRIPTION
Built on top of ~#2626~ and ~#2559~

This attempts to replicate the feature added to solidus_i18n in https://github.com/solidusio-contrib/solidus_i18n/pull/95. I think this is a feature which we might as well support by default, and I think the implementation is simplified by implementing it in core rather than an extension.

This is just the last two commits here (but relies on features from my other open i18n-related PRs)

* Add available_locales to Stores f57c315b4ad01fb6a45978afdc6a433d237284b3
* Add available_locales selection to backend e2e536163182ecc8c3e40e8024aef258d45e29a2
* The final step would be adding a locale selector to frontend which uses this data (which I intend to do in a future PR)

cc @DanielePalombo @kennyadsl 