### PR TITLE
Add overview of returns system

### DIFF
--- a/guides/inventory/overview.md
+++ b/guides/inventory/overview.md
@@ -9,16 +9,16 @@ physical warehouse, there are many essential moving parts:
   information, see [Inventory units](#inventory-units).
 - `Spree::StockItem`: Counts the inventory for a specific `Spree::Variant` at a
   specific `Spree::StockLocation`. For more information, see [Stock
-  items](#stock-items). 
+  items](#stock-items).
 - `Spree::StockLocation`: Represents a location where stock items are shipped
   from. Each stock location has `Spree::StockItem`s for each variant in the
-  store. 
+  store.
 - `Spree::StockMovement`: Represents stock being moved from one
   `Spree::StockLocation` to another, or being  added or removed from your
   store's inventory. For more information, see [Stock
   movements](#stock-movements).
-- `Spree::ReturnItem`: Represents an inventory unit that is returned by a customer.
-  For more information, see [Return items](#return-items).
+- `Spree::ReturnItem`: Represents an inventory unit that is returned by a
+  customer.  For more information, see [Return items](#return-items).
 
 [backorder]: https://www.investopedia.com/terms/b/backorder.asp
 
@@ -93,7 +93,7 @@ from. Each stock location has many `Spree::StockItem`s and
 
 Once a new stock location has been created, a new set of
 [`Spree::StockItem`s](#stock-items) are created for it. The new set represents
-every `Spree::Variant` in your store. 
+every `Spree::Variant` in your store.
 
 #### Stock transfers
 
@@ -118,7 +118,7 @@ your on hand inventory.
 Note that not all return items are resellable, as customer returns can be made
 for many reasons.
 
-For more information, see the [Return authorizations][return-authorizations]
+For more information, see the [Returns][returns]
 documentation.
 
-[return-authorizations]: ../returns/return-authorizations.md
+[returns]: ../returns/overview.md

--- a/guides/returns/overview.md
+++ b/guides/returns/overview.md
@@ -1,0 +1,78 @@
+# Overview
+
+Solidus includes a comprehensive returns system. This system includes logic for
+customer returns, refunds, and exchanges. The `solidus_backend` gem includes an
+admin interface for managing returns and exchanges.
+
+The returns system is built with an automated returns process in mind, and it
+can be extended to take advantage of the way that your store manages shipments,
+return shipments, or a third-party warehouse.
+
+We recommend that you [create a sandbox store][solidus-sandbox] to get familiar
+with the returns system. Create multiple return authorizations (RMAs), customer
+returns, and experiment with various reimbursement types, return reasons, and so
+on.
+
+[solidus-sandbox]: ../getting-started/develop-solidus.md#create-a-sandbox-application
+
+## Returns models
+
+The following sections summarize the core models that make up Solidus's returns
+system.
+
+### Return items
+
+The central model in Solidus's returns system is the `Spree::ReturnItem`.
+Many of the other models in the returns system require one or many return items.
+
+Each `Spree::ReturnItem` tracks a lot of information about the return, and the
+objects have many attributes. For example, it tracks whether the item is
+resellable, whether the returned item has been received, and the total amount
+that should be refunded or applied to the customer's store credit.
+
+For more information about return items, see the [Return items][return-items]
+article.
+
+[return-items]: return-items.md
+
+### Return authorizations
+
+A customer return starts with a return authorization. A store administrator
+creates a `Spree::ReturnAuthorization` (also called an RMA) for an order or part
+of an order.
+
+The RMA can authorize the return of one item or many items on the order. Once
+the RMA is created, the `Spree::ReturnItem`s on it can be included in a new
+customer return.
+
+See the [Return authorizations][return-authorizations] article for more
+information.
+
+[return-authorizations]: return-authorizations.md
+
+### Customer returns
+
+A `Spree::CustomerReturn` represents an item or a group of items that the
+customer is going to return to you.
+
+Similar to a return authorization, a `Spree::CustomerReturn` can be associated
+with one or many `Spree::ReturnItem`s from a single order.
+
+### Reimbursements
+
+A `Spree::Reimbursement` represents your store's compensation to the customer
+who is returning items. Since each `Spree::ReturnItem` can be returned for a
+different reason, you may have multiple reimbursements for a for a single
+`Spree::CustomerReturn`.
+
+See the [Reimbursements][reimbursements] article for more information.
+
+[reimbursements]: reimbursements.md
+
+### Reimbursement types
+
+Each `Spree::ReturnItem` is associated with a `Spree::ReimbursementType`. This
+allows you to offer many kinds of reimbursements, like store credit, refunds,
+and exchanges.
+
+[reimbursement-types]: reimbursement-types.md


### PR DESCRIPTION
This adds an overview article about Solidus's returns system. It introduces the models that are central to the returns system.

It also links out to other articles about the returns system that I am submitting as separate PRs.

_This is part a larger project to improve Solidus's documentation. [See this gist with the high-level table of contents](https://gist.github.com/benjaminwil/5e2d2da3d9def6b949b833b1aa2549d3). Where and how this documentation will exist is still up for discussion._