### PR TITLE
Add locale selector to frontend nav bar

### DIFF
--- a/frontend/app/assets/javascripts/spree/frontend.js
+++ b/frontend/app/assets/javascripts/spree/frontend.js
@@ -2,3 +2,4 @@
 //= require spree/frontend/checkout
 //= require spree/frontend/product
 //= require spree/frontend/cart
+//= require spree/frontend/locale_selector

--- a/frontend/app/assets/javascripts/spree/frontend/locale_selector.js
+++ b/frontend/app/assets/javascripts/spree/frontend/locale_selector.js
@@ -1,0 +1,5 @@
+$(function() {
+  $('#locale_selector select').change(function() {
+    this.form.submit();
+  });
+});

--- a/frontend/app/views/spree/shared/_locale_selector.html.erb
+++ b/frontend/app/views/spree/shared/_locale_selector.html.erb
@@ -1,0 +1,25 @@
+<% available_locales = current_store.available_locales %>
+<% if available_locales.many? %>
+  <li id="locale_selector" data-hook>
+    <%= form_tag spree.select_locale_path, class: 'navbar-form' do %>
+      <div class="form-group">
+        <label for="switch_to_locale" class="sr-only">
+          <%= Spree.t(:'i18n.language') %>
+        </label>
+        <%=
+          select_tag(
+            :switch_to_locale,
+            options_for_select(
+              available_locales.map do |locale|
+                [I18n.t('spree.i18n.this_file_language', locale: locale, default: locale.to_s, fallback: false), locale]
+              end.sort,
+              selected: I18n.locale
+            ),
+            class: 'form-control'
+          )
+        %>
+        <noscript><%= submit_tag t("spree.select") %></noscript>
+      </div>
+    <% end %>
+  </li>
+<% end %>

--- a/frontend/app/views/spree/shared/_nav_bar.html.erb
+++ b/frontend/app/views/spree/shared/_nav_bar.html.erb
@@ -1,5 +1,6 @@
 <nav id="top-nav-bar" class="columns ten">
   <ul id="nav-bar" class="inline" data-hook>
+    <%= render 'spree/shared/locale_selector' %>
     <%= render 'spree/shared/login_bar_items' %>
     <li id="search-bar" data-hook>
       <%= render partial: 'spree/shared/search' %>


### PR DESCRIPTION
This adds a locale selector to the frontend, a feature previously only available in solidus_i18n

![](http://i.hawth.ca/s/BGVA1TFI.png)


My main concern with this PR is that it looks pretty dumb if we have both this selector and the locale selector from solidus_i18n (which I intend to remove for a 2.0 version)

![](http://i.hawth.ca/s/zzcSegf6.png)