### PR TITLE
UI fixes for admin locale select

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/components/_navigation.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_navigation.scss
@@ -162,7 +162,6 @@ nav.menu {
 
 .admin-locale-selection {
   margin: 1em;
-  margin-bottom: 0;
 }
 
 .admin-nav.fits .admin-nav-footer {
@@ -175,8 +174,8 @@ nav.menu {
 
 .admin-login-nav {
   list-style: none;
-  margin: 0;
-  padding: 1rem 0;
+  padding: 0;
+  margin: 1rem 0;
 
   li {
     padding: 0.3rem 1.2rem;

--- a/backend/app/views/spree/admin/stores/_form.html.erb
+++ b/backend/app/views/spree/admin/stores/_form.html.erb
@@ -64,6 +64,7 @@
 
     <%= f.field_container :available_locales do %>
       <%= f.label :available_locales %>
+      <%= f.field_hint :available_locales %>
       <%= f.select :available_locales,
         Spree.i18n_available_locales.map { |locale|
           [I18n.t('spree.i18n.this_file_language', locale: locale, default: locale.to_s, fallback: false), locale]

--- a/backend/app/views/spree/admin/stores/_form.html.erb
+++ b/backend/app/views/spree/admin/stores/_form.html.erb
@@ -1,71 +1,76 @@
-<%= f.field_container :name do %>
-  <%= f.label :name, class: 'required' %>
-  <%= f.text_field :name, required: true, class: 'fullwidth' %>
-  <%= f.error_message_on :name %>
-<% end %>
+<div class="row">
+  <div class="col-12 col-md-6">
+    <%= f.field_container :name do %>
+      <%= f.label :name, class: 'required' %>
+      <%= f.text_field :name, required: true, class: 'fullwidth' %>
+      <%= f.error_message_on :name %>
+    <% end %>
 
-<%= f.field_container :code do %>
-  <%= f.label :code, class: 'required' %>
-  <%= f.text_field :code, required: true, class: 'fullwidth' %>
-  <%= f.error_message_on :code %>
-<% end %>
+    <%= f.field_container :code do %>
+      <%= f.label :code, class: 'required' %>
+      <%= f.text_field :code, required: true, class: 'fullwidth' %>
+      <%= f.error_message_on :code %>
+    <% end %>
 
-<%= f.field_container :seo_title do %>
-  <%= f.label :seo_title %>
-  <%= f.text_field :seo_title, class: 'fullwidth'  %>
-  <%= f.error_message_on :seo_title %>
-<% end %>
+    <%= f.field_container :seo_title do %>
+      <%= f.label :seo_title %>
+      <%= f.text_field :seo_title, class: 'fullwidth'  %>
+      <%= f.error_message_on :seo_title %>
+    <% end %>
 
-<%= f.field_container :meta_keywords do %>
-  <%= f.label :meta_keywords %>
-  <%= f.text_field :meta_keywords, class: 'fullwidth'  %>
-  <%= f.error_message_on :meta_keywords %>
-<% end %>
+    <%= f.field_container :meta_keywords do %>
+      <%= f.label :meta_keywords %>
+      <%= f.text_field :meta_keywords, class: 'fullwidth'  %>
+      <%= f.error_message_on :meta_keywords %>
+    <% end %>
 
-<%= f.field_container :meta_description do %>
-  <%= f.label :meta_description %>
-  <%= f.text_field :meta_description, class: 'fullwidth'  %>
-  <%= f.error_message_on :meta_description %>
-<% end %>
+    <%= f.field_container :meta_description do %>
+      <%= f.label :meta_description %>
+      <%= f.text_area :meta_description, class: 'fullwidth'  %>
+      <%= f.error_message_on :meta_description %>
+    <% end %>
+  </div>
+  <div class="col-12 col-md-6">
+    <%= f.field_container :url do %>
+      <%= f.label :url, class: 'required' %>
+      <%= f.text_field :url, required: true, class: 'fullwidth'  %>
+      <%= f.error_message_on :url %>
+    <% end %>
 
-<%= f.field_container :url do %>
-  <%= f.label :url, class: 'required' %>
-  <%= f.text_field :url, required: true, class: 'fullwidth'  %>
-  <%= f.error_message_on :url %>
-<% end %>
+    <%= f.field_container :mail_from_address do %>
+      <%= f.label :mail_from_address, class: 'required' %>
+      <%= f.text_field :mail_from_address, required: true, class: 'fullwidth'  %>
+      <%= f.error_message_on :mail_from_address %>
+    <% end %>
 
-<%= f.field_container :mail_from_address do %>
-  <%= f.label :mail_from_address, class: 'required' %>
-  <%= f.text_field :mail_from_address, required: true, class: 'fullwidth'  %>
-  <%= f.error_message_on :mail_from_address %>
-<% end %>
+    <%= f.field_container :default_currency do %>
+      <%= f.label :default_currency %>
+      <%= f.select :default_currency,
+        Spree::Config.available_currencies.map(&:iso_code),
+        { include_blank: true },
+        { class: 'custom-select fullwidth' } %>
+      <%= f.error_message_on :default_currency %>
+    <% end %>
 
-<%= f.field_container :default_currency do %>
-  <%= f.label :default_currency %>
-  <%= f.select :default_currency,
-    Spree::Config.available_currencies.map(&:iso_code),
-    { include_blank: true },
-    { class: 'select2 fullwidth' } %>
-  <%= f.error_message_on :default_currency %>
-<% end %>
+    <%= f.field_container :cart_tax_country_iso do %>
+      <%= f.label :cart_tax_country_iso %>
+      <%= f.field_hint :cart_tax_country_iso %>
+      <%= f.select :cart_tax_country_iso,
+        Spree::Country.all.map { |c| [c.name, c.iso] },
+        { include_blank: t(".no_cart_tax_country") },
+        { class: "custom-select fullwidth" } %>
+      <%= f.error_message_on :cart_tax_country_iso %>
+    <% end %>
 
-<%= f.field_container :cart_tax_country_iso do %>
-  <%= f.label :cart_tax_country_iso %>
-  <%= f.field_hint :cart_tax_country_iso %>
-  <%= f.select :cart_tax_country_iso,
-    Spree::Country.all.map { |c| [c.name, c.iso] },
-    { include_blank: t(".no_cart_tax_country") },
-    { class: "custom-select fullwidth" } %>
-  <%= f.error_message_on :cart_tax_country_iso %>
-<% end %>
-
-<%= f.field_container :available_locales do %>
-  <%= f.label :available_locales %>
-  <%= f.select :available_locales,
-    Spree.i18n_available_locales.map { |locale|
-      [I18n.t('spree.i18n.this_file_language', locale: locale, default: locale.to_s, fallback: false), locale]
-    }.sort,
-    { },
-    { class: 'select2 fullwidth', multiple: true } %>
-  <%= f.error_message_on :default_currency %>
-<% end %>
+    <%= f.field_container :available_locales do %>
+      <%= f.label :available_locales %>
+      <%= f.select :available_locales,
+        Spree.i18n_available_locales.map { |locale|
+          [I18n.t('spree.i18n.this_file_language', locale: locale, default: locale.to_s, fallback: false), locale]
+        }.sort,
+        { },
+        { class: 'select2 fullwidth', multiple: true } %>
+      <%= f.error_message_on :default_currency %>
+    <% end %>
+  </div>
+</div>

--- a/backend/app/views/spree/admin/stores/_form.html.erb
+++ b/backend/app/views/spree/admin/stores/_form.html.erb
@@ -66,6 +66,6 @@
       [I18n.t('spree.i18n.this_file_language', locale: locale, default: locale.to_s, fallback: false), locale]
     }.sort,
     { },
-    { class: 'custom-select fullwidth', multiple: true } %>
+    { class: 'select2 fullwidth', multiple: true } %>
   <%= f.error_message_on :default_currency %>
 <% end %>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -305,6 +305,7 @@ en:
         name: Site Name
         mail_from_address: Mail From Address
         cart_tax_country_iso: Tax Country for Empty Carts
+        available_locales: Locales available in the storefront
       spree/store_credit:
         amount: Amount
         amount_authorized: Amount Authorized
@@ -1297,6 +1298,7 @@ en:
         check_stock_on_transfer: "When checked, inventory levels will be checked when performing stock transfers.<br/> Default: Checked"
       spree/store:
         cart_tax_country_iso: "This determines which country is used for taxes on carts (orders which don't yet have an address).<br/> Default: None."
+        available_locales: "This determines which locales are available for your customers to choose from in the storefront."
       spree/variant:
         tax_category: "This determines what kind of taxation is applied to this variant.<br/> Default: Use tax category of the product associated with this variant"
         deleted: "Deleted Variant"


### PR DESCRIPTION
Now that we have a admin local select and store owners can configure available locales for their stores we should improve the UI/UX a little bit.

1. ~~Admins should only be able to choose from configured available locales instead of all locales in the system~~  

2. The store administration form uses two columns to display all the fields.

3. The locale select uses select2, because it is a multi select and this is where select2 still shines. 

4. When the local select is displayed alone, as on the login screen, it has correct margins.

### Screenshot

![sample store - stores 2018-04-07 01-04-12](https://user-images.githubusercontent.com/42868/38447737-a1d73790-39ff-11e8-8336-a57e19ed04fe.png)
