### PR TITLE
Remove default address dependency

### DIFF
--- a/backend/app/controllers/spree/admin/reimbursements_controller.rb
+++ b/backend/app/controllers/spree/admin/reimbursements_controller.rb
@@ -13,7 +13,7 @@ module Spree
       rescue_from Spree::Core::GatewayError, with: :spree_core_gateway_error
 
       def perform
-        @reimbursement.perform!
+        @reimbursement.perform!(try_spree_current_user)
         redirect_to location_after_save
       end
 
@@ -57,7 +57,7 @@ module Spree
       end
 
       def load_simulated_refunds
-        @reimbursement_objects = @reimbursement.simulate
+        @reimbursement_objects = @reimbursement.simulate(try_spree_current_user)
       end
 
       def spree_core_gateway_error(error)

--- a/backend/spec/controllers/spree/admin/reimbursements_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/reimbursements_controller_spec.rb
@@ -9,6 +9,13 @@ describe Spree::Admin::ReimbursementsController, type: :controller do
     Spree::RefundReason.find_or_create_by!(name: Spree::RefundReason::RETURN_PROCESSING_REASON, mutable: false)
   end
 
+  let(:user) { stub_model(Spree::LegacyUser, has_spree_role?: true, id: 1) }
+
+  before do
+    allow_any_instance_of(described_class).to receive(:try_spree_current_user).
+      and_return(user)
+  end
+
   describe '#edit' do
     let(:reimbursement) { create(:reimbursement) }
     let(:order) { reimbursement.order }

--- a/backend/spec/features/admin/orders/return_payment_state_spec.rb
+++ b/backend/spec/features/admin/orders/return_payment_state_spec.rb
@@ -7,9 +7,12 @@ describe "Return payment state spec" do
 
   before do
     Spree::RefundReason.create!(name: Spree::RefundReason::RETURN_PROCESSING_REASON, mutable: false)
+    allow_any_instance_of(Spree::Admin::ReimbursementsController).to receive(:try_spree_current_user).
+      and_return(user)
   end
 
   let!(:order) { create(:shipped_order) }
+  let(:user) { create(:admin_user) }
 
   # Regression test for https://github.com/spree/spree/issues/6229
   it "refunds and has outstanding_balance of zero", js: true do

--- a/core/app/models/spree/order_cancellations.rb
+++ b/core/app/models/spree/order_cancellations.rb
@@ -83,13 +83,17 @@ class Spree::OrderCancellations
   # @api public
   # @param [Array<InventoryUnit>] inventory_units the inventory units to be reimbursed
   # @return [Reimbursement] the reimbursement for inventory being canceled
-  def reimburse_units(inventory_units)
+  def reimburse_units(inventory_units, creator = nil)
+    unless creator
+      creator = Spree.user_class.where(email: 'spree@example.com').first
+      Spree::Deprecation.warn("Calling #reimburse_units on #{self} without creator is deprecated")
+    end
     reimbursement = nil
 
     Spree::OrderMutex.with_lock!(@order) do
       return_items = inventory_units.map(&:current_or_new_return_item)
       reimbursement = Spree::Reimbursement.new(order: @order, return_items: return_items)
-      reimbursement.return_all
+      reimbursement.return_all(creator)
     end
 
     reimbursement

--- a/core/app/models/spree/reimbursement.rb
+++ b/core/app/models/spree/reimbursement.rb
@@ -98,12 +98,16 @@ module Spree
       total - paid_amount
     end
 
-    def perform!
+    def perform!(creator = nil)
+      unless creator
+        creator = Spree.user_class.where(email: 'spree@example.com').first
+        Spree::Deprecation.warn("Calling #perform on #{self} without creator is deprecated")
+      end
       reimbursement_tax_calculator.call(self)
       reload
       update!(total: calculated_total)
 
-      reimbursement_performer.perform(self)
+      reimbursement_performer.perform(self, creator)
 
       if unpaid_amount_within_tolerance?
         reimbursed!
@@ -116,12 +120,16 @@ module Spree
       end
     end
 
-    def simulate
+    def simulate(creator = nil)
+      unless creator
+        creator = Spree.user_class.where(email: 'spree@example.com').first
+        Spree::Deprecation.warn("Calling #simulate on #{self} without creator is deprecated")
+      end
       reimbursement_simulator_tax_calculator.call(self)
       reload
       update!(total: calculated_total)
 
-      reimbursement_performer.simulate(self)
+      reimbursement_performer.simulate(self, creator)
     end
 
     def return_items_requiring_exchange
@@ -140,10 +148,14 @@ module Spree
     #
     # @api public
     # @return [void]
-    def return_all
+    def return_all(creator = nil)
+      unless creator
+        creator = Spree.user_class.where(email: 'spree@example.com').first
+        Spree::Deprecation.warn("Calling #return_all on #{self} without creator is deprecated")
+      end
       return_items.each(&:accept!)
       save!
-      perform!
+      perform!(creator)
     end
 
     private

--- a/core/app/models/spree/reimbursement_performer.rb
+++ b/core/app/models/spree/reimbursement_performer.rb
@@ -11,22 +11,30 @@ module Spree
       # - #description
       # - #display_amount
       # so they can be displayed in the Admin UI appropriately.
-      def simulate(reimbursement)
-        execute(reimbursement, true)
+      def simulate(reimbursement, creator = nil)
+        unless creator
+          creator = Spree.user_class.where(email: 'spree@example.com').first
+          Spree::Deprecation.warn("Calling #simulate on #{self} without creator is deprecated")
+        end
+        execute(reimbursement, true, creator)
       end
 
       # Actually perform the reimbursement
-      def perform(reimbursement)
-        execute(reimbursement, false)
+      def perform(reimbursement, creator = nil)
+        unless creator
+          creator = Spree.user_class.find_by(email: 'spree@example.com')
+          Spree::Deprecation.warn("Calling #perform on #{self} without creator is deprecated")
+        end
+        execute(reimbursement, false, creator)
       end
 
       private
 
-      def execute(reimbursement, simulate)
+      def execute(reimbursement, simulate, creator)
         reimbursement_type_hash = calculate_reimbursement_types(reimbursement)
 
         reimbursement_type_hash.flat_map do |reimbursement_type, return_items|
-          reimbursement_type.reimburse(reimbursement, return_items, simulate)
+          reimbursement_type.reimburse(reimbursement, return_items, simulate, creator)
         end
       end
 

--- a/core/app/models/spree/reimbursement_type.rb
+++ b/core/app/models/spree/reimbursement_type.rb
@@ -11,7 +11,7 @@ module Spree
     # This method will reimburse the return items based on however it child implements it
     # By default it takes a reimbursement, the return items it needs to reimburse, and if
     # it is a simulation or a real reimbursement. This should return an array
-    def self.reimburse(_reimbursement, _return_items, _simulate)
+    def self.reimburse(_reimbursement, _return_items, _simulate, _creator)
       raise "Implement me"
     end
   end

--- a/core/app/models/spree/reimbursement_type/credit.rb
+++ b/core/app/models/spree/reimbursement_type/credit.rb
@@ -5,9 +5,13 @@ module Spree
     extend Spree::ReimbursementType::ReimbursementHelpers
 
     class << self
-      def reimburse(reimbursement, return_items, simulate)
+      def reimburse(reimbursement, return_items, simulate, creator = nil)
+        unless creator
+          creator = Spree.user_class.where(email: 'spree@example.com').first
+          Spree::Deprecation.warn("Calling #reimburse on #{self} without creator is deprecated")
+        end
         unpaid_amount = return_items.sum(&:total).round(2, :down)
-        reimbursement_list, _unpaid_amount = create_credits(reimbursement, unpaid_amount, simulate)
+        reimbursement_list, _unpaid_amount = create_credits(reimbursement, unpaid_amount, simulate, creator)
         reimbursement_list
       end
     end

--- a/core/app/models/spree/reimbursement_type/exchange.rb
+++ b/core/app/models/spree/reimbursement_type/exchange.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Spree::ReimbursementType::Exchange < Spree::ReimbursementType
-  def self.reimburse(reimbursement, return_items, simulate)
+  def self.reimburse(reimbursement, return_items, simulate, _creator)
     return [] unless return_items.present?
 
     exchange = Spree::Exchange.new(reimbursement.order, return_items)

--- a/core/app/models/spree/reimbursement_type/original_payment.rb
+++ b/core/app/models/spree/reimbursement_type/original_payment.rb
@@ -4,7 +4,7 @@ class Spree::ReimbursementType::OriginalPayment < Spree::ReimbursementType
   extend Spree::ReimbursementType::ReimbursementHelpers
 
   class << self
-    def reimburse(reimbursement, return_items, simulate)
+    def reimburse(reimbursement, return_items, simulate, _creator)
       unpaid_amount = return_items.sum(&:total).round(2, :down)
       payments = reimbursement.order.payments.completed
 

--- a/core/app/models/spree/reimbursement_type/reimbursement_helpers.rb
+++ b/core/app/models/spree/reimbursement_type/reimbursement_helpers.rb
@@ -20,8 +20,8 @@ module Spree
       [reimbursement_list, unpaid_amount]
     end
 
-    def create_credits(reimbursement, unpaid_amount, simulate, reimbursement_list = [])
-      credits = [create_credit(reimbursement, unpaid_amount, simulate)]
+    def create_credits(reimbursement, unpaid_amount, simulate, creator, reimbursement_list = [])
+      credits = [create_credit(reimbursement, unpaid_amount, simulate, creator)]
       unpaid_amount -= credits.sum(&:amount)
       reimbursement_list += credits
 
@@ -43,19 +43,19 @@ module Spree
 
     # If you have multiple methods of crediting a customer, overwrite this method
     # Must return an array of objects the respond to #description, #display_amount
-    def create_credit(reimbursement, unpaid_amount, simulate)
-      creditable = create_creditable(reimbursement, unpaid_amount)
+    def create_credit(reimbursement, unpaid_amount, simulate, creator)
+      creditable = create_creditable(reimbursement, unpaid_amount, creator)
       credit = reimbursement.credits.build(creditable: creditable, amount: unpaid_amount)
       simulate ? credit.readonly! : credit.save!
       credit
     end
 
-    def create_creditable(reimbursement, unpaid_amount)
+    def create_creditable(reimbursement, unpaid_amount, creator)
       Spree::Reimbursement::Credit.default_creditable_class.new(
         user: reimbursement.order.user,
         amount: unpaid_amount,
         category: Spree::StoreCreditCategory.reimbursement_category(reimbursement),
-        created_by: Spree::StoreCredit.default_created_by,
+        created_by: creator,
         memo: "Refund for uncreditable payments on order #{reimbursement.order.number}",
         currency: reimbursement.order.currency
       )

--- a/core/app/models/spree/reimbursement_type/store_credit.rb
+++ b/core/app/models/spree/reimbursement_type/store_credit.rb
@@ -4,17 +4,33 @@ class Spree::ReimbursementType::StoreCredit < Spree::ReimbursementType
   extend Spree::ReimbursementType::ReimbursementHelpers
 
   class << self
-    def reimburse(reimbursement, return_items, simulate)
+    def reimburse(reimbursement, return_items, simulate, creator = nil)
+      unless creator
+        creator = Spree.user_class.where(email: 'spree@example.com').first
+        Spree::Deprecation.warn("Calling #reimburse on #{self} without creator is deprecated")
+      end
       unpaid_amount = return_items.sum(&:total).to_d.round(2, :down)
       payments = store_credit_payments(reimbursement)
       reimbursement_list = []
 
       # Credit each store credit that was used on the order
-      reimbursement_list, unpaid_amount = create_refunds(reimbursement, payments, unpaid_amount, simulate, reimbursement_list)
+      reimbursement_list, unpaid_amount = create_refunds(
+        reimbursement,
+        payments,
+        unpaid_amount,
+        simulate,
+        reimbursement_list
+      )
 
       # If there is any amount left to pay out to the customer, then create credit with that amount
       if unpaid_amount > 0.0
-        reimbursement_list, _unpaid_amount = create_credits(reimbursement, unpaid_amount, simulate, reimbursement_list)
+        reimbursement_list, _unpaid_amount = create_credits(
+          reimbursement,
+          unpaid_amount,
+          simulate,
+          creator,
+          reimbursement_list
+        )
       end
 
       reimbursement_list

--- a/core/app/models/spree/store_credit.rb
+++ b/core/app/models/spree/store_credit.rb
@@ -18,8 +18,6 @@ class Spree::StoreCredit < Spree::PaymentSource
   ADJUSTMENT_ACTION = 'adjustment'
   INVALIDATE_ACTION = 'invalidate'
 
-  DEFAULT_CREATED_BY_EMAIL = "spree@example.com"
-
   belongs_to :user, class_name: Spree::UserClassHandle.new
   belongs_to :created_by, class_name: Spree::UserClassHandle.new
   belongs_to :category, class_name: "Spree::StoreCreditCategory"
@@ -193,12 +191,6 @@ class Spree::StoreCredit < Spree::PaymentSource
     else
       errors.add(:invalidated_at, I18n.t('spree.store_credit.errors.cannot_invalidate_uncaptured_authorization'))
       false
-    end
-  end
-
-  class << self
-    def default_created_by
-      Spree.user_class.find_by(email: DEFAULT_CREATED_BY_EMAIL)
     end
   end
 

--- a/core/spec/models/spree/customer_return_spec.rb
+++ b/core/spec/models/spree/customer_return_spec.rb
@@ -282,7 +282,8 @@ RSpec.describe Spree::CustomerReturn, type: :model do
           end
 
           context 'when all reimbursements are reimbursed' do
-            before { reimbursement.perform! }
+            let(:created_by_user) { create(:user, email: 'user@email.com') }
+            before { reimbursement.perform!(created_by_user) }
 
             it { is_expected.to be true }
           end

--- a/core/spec/models/spree/order/outstanding_balance_integration_spec.rb
+++ b/core/spec/models/spree/order/outstanding_balance_integration_spec.rb
@@ -83,13 +83,14 @@ RSpec.describe "Outstanding balance integration tests" do
     context 'with a cancelled item' do
       let(:cancelations) { Spree::OrderCancellations.new(order) }
       let(:cancelled_item) { item_1 }
+      let(:created_by_user) { create(:user, email: 'user@email.com') }
 
       before do
         # Required to refund
         Spree::RefundReason.create!(name: Spree::RefundReason::RETURN_PROCESSING_REASON, mutable: false)
 
         cancelations.cancel_unit(cancelled_item.inventory_units.first)
-        cancelations.reimburse_units(cancelled_item.inventory_units)
+        cancelations.reimburse_units(cancelled_item.inventory_units, created_by_user)
 
         order.reload
       end

--- a/core/spec/models/spree/order_cancellations_spec.rb
+++ b/core/spec/models/spree/order_cancellations_spec.rb
@@ -47,10 +47,11 @@ RSpec.describe Spree::OrderCancellations do
   end
 
   describe "#reimburse_units" do
-    subject { Spree::OrderCancellations.new(order).reimburse_units(inventory_units) }
+    subject { Spree::OrderCancellations.new(order).reimburse_units(inventory_units, created_by_user) }
     let(:order) { create(:shipped_order, line_items_count: 2) }
     let(:inventory_units) { order.inventory_units }
     let!(:default_refund_reason) { Spree::RefundReason.find_or_create_by!(name: Spree::RefundReason::RETURN_PROCESSING_REASON, mutable: false) }
+    let(:created_by_user) { create(:user, email: 'user@email.com') }
 
     it "creates and performs a reimbursement" do
       expect { subject }.to change { Spree::Reimbursement.count }.by(1)

--- a/core/spec/models/spree/refund_spec.rb
+++ b/core/spec/models/spree/refund_spec.rb
@@ -176,11 +176,12 @@ RSpec.describe Spree::Refund, type: :model do
     let(:customer_return) { reimbursement.customer_return }
     let(:reimbursement) { create(:reimbursement) }
     let!(:default_refund_reason) { Spree::RefundReason.find_or_create_by!(name: Spree::RefundReason::RETURN_PROCESSING_REASON, mutable: false) }
+    let(:created_by_user) { create(:user, email: 'user@email.com') }
 
     subject { Spree::Refund.total_amount_reimbursed_for(reimbursement) }
 
     context 'with reimbursements performed' do
-      before { reimbursement.perform! }
+      before { reimbursement.perform!(created_by_user) }
 
       it 'returns the total amount' do
         amount = Spree::Refund.total_amount_reimbursed_for(reimbursement)

--- a/core/spec/models/spree/reimbursement_performer_spec.rb
+++ b/core/spec/models/spree/reimbursement_performer_spec.rb
@@ -7,25 +7,26 @@ RSpec.describe Spree::ReimbursementPerformer, type: :model do
   let(:return_item)             { reimbursement.return_items.first }
   let(:reimbursement_type)      { double("ReimbursementType") }
   let(:reimbursement_type_hash) { { reimbursement_type => [return_item] } }
+  let(:created_by_user) { create(:user, email: 'user@email.com') }
 
   before do
     expect(Spree::ReimbursementPerformer).to receive(:calculate_reimbursement_types).and_return(reimbursement_type_hash)
   end
 
   describe ".simulate" do
-    subject { Spree::ReimbursementPerformer.simulate(reimbursement) }
+    subject { Spree::ReimbursementPerformer.simulate(reimbursement, created_by_user) }
 
     it "reimburses each calculated reimbursement types with the correct return items as a simulation" do
-      expect(reimbursement_type).to receive(:reimburse).with(reimbursement, [return_item], true)
+      expect(reimbursement_type).to receive(:reimburse).with(reimbursement, [return_item], true, created_by_user)
       subject
     end
   end
 
   describe '.perform' do
-    subject { Spree::ReimbursementPerformer.perform(reimbursement) }
+    subject { Spree::ReimbursementPerformer.perform(reimbursement, created_by_user) }
 
     it "reimburses each calculated reimbursement types with the correct return items as a simulation" do
-      expect(reimbursement_type).to receive(:reimburse).with(reimbursement, [return_item], false)
+      expect(reimbursement_type).to receive(:reimburse).with(reimbursement, [return_item], false, created_by_user)
       subject
     end
   end

--- a/core/spec/models/spree/reimbursement_spec.rb
+++ b/core/spec/models/spree/reimbursement_spec.rb
@@ -66,8 +66,9 @@ RSpec.describe Spree::Reimbursement, type: :model do
     let!(:default_refund_reason) { Spree::RefundReason.find_or_create_by!(name: Spree::RefundReason::RETURN_PROCESSING_REASON, mutable: false) }
 
     let(:reimbursement) { create(:reimbursement, customer_return: customer_return, order: order, return_items: [return_item]) }
+    let(:created_by_user) { create(:user, email: 'user@email.com') }
 
-    subject { reimbursement.perform! }
+    subject { reimbursement.perform!(created_by_user) }
 
     before do
       order.shipments.each do |shipment|
@@ -230,13 +231,14 @@ RSpec.describe Spree::Reimbursement, type: :model do
   end
 
   describe "#return_all" do
-    subject { reimbursement.return_all }
+    subject { reimbursement.return_all(created_by_user) }
 
     let!(:default_refund_reason) { Spree::RefundReason.find_or_create_by!(name: Spree::RefundReason::RETURN_PROCESSING_REASON, mutable: false) }
     let(:order)                  { create(:shipped_order, line_items_count: 1) }
     let(:inventory_unit)         { order.inventory_units.first }
     let(:return_item)            { build(:return_item, inventory_unit: inventory_unit) }
     let(:reimbursement)          { build(:reimbursement, order: order, return_items: [return_item]) }
+    let(:created_by_user) { create(:user, email: 'user@email.com') }
 
     it "accepts all the return items" do
       expect { subject }.to change { return_item.acceptance_status }.to "accepted"

--- a/core/spec/models/spree/reimbursement_type/credit_spec.rb
+++ b/core/spec/models/spree/reimbursement_type/credit_spec.rb
@@ -10,13 +10,14 @@ module Spree
     let(:simulate)                { false }
     let!(:default_refund_reason)  { Spree::RefundReason.find_or_create_by!(name: Spree::RefundReason::RETURN_PROCESSING_REASON, mutable: false) }
     let(:creditable)              { DummyCreditable.new(amount: 99.99) }
+    let(:created_by_user) { create(:user, email: 'user@email.com') }
 
     class DummyCreditable < Spree::Base
       attr_accessor :amount
       self.table_name = 'spree_payments' # Your creditable class should not use this table
     end
 
-    subject { Spree::ReimbursementType::Credit.reimburse(reimbursement, [return_item], simulate) }
+    subject { Spree::ReimbursementType::Credit.reimburse(reimbursement, [return_item], simulate, created_by_user) }
 
     before do
       reimbursement.update!(total: reimbursement.calculated_total)

--- a/core/spec/models/spree/reimbursement_type/exchange_spec.rb
+++ b/core/spec/models/spree/reimbursement_type/exchange_spec.rb
@@ -9,8 +9,9 @@ module Spree
       let(:return_items)  { reimbursement.return_items }
       let(:new_exchange)  { double("Exchange") }
       let(:simulate)      { true }
+      let(:created_by_user) { create(:user, email: 'user@email.com') }
 
-      subject { Spree::ReimbursementType::Exchange.reimburse(reimbursement, return_items, simulate) }
+      subject { Spree::ReimbursementType::Exchange.reimburse(reimbursement, return_items, simulate, created_by_user) }
 
       context 'return items are supplied' do
         before do

--- a/core/spec/models/spree/reimbursement_type/original_payment_spec.rb
+++ b/core/spec/models/spree/reimbursement_type/original_payment_spec.rb
@@ -9,8 +9,9 @@ module Spree
     let(:payment)                 { reimbursement.order.payments.first }
     let(:simulate)                { false }
     let!(:default_refund_reason)  { Spree::RefundReason.find_or_create_by!(name: Spree::RefundReason::RETURN_PROCESSING_REASON, mutable: false) }
+    let(:created_by_user) { create(:user, email: 'user@email.com') }
 
-    subject { Spree::ReimbursementType::OriginalPayment.reimburse(reimbursement, [return_item], simulate) }
+    subject { Spree::ReimbursementType::OriginalPayment.reimburse(reimbursement, [return_item], simulate, created_by_user) }
 
     before { reimbursement.update!(total: reimbursement.calculated_total) }
 

--- a/core/spec/models/spree/reimbursement_type/store_credit_spec.rb
+++ b/core/spec/models/spree/reimbursement_type/store_credit_spec.rb
@@ -12,7 +12,7 @@ module Spree
     let!(:default_refund_reason)  { Spree::RefundReason.find_or_create_by!(name: Spree::RefundReason::RETURN_PROCESSING_REASON, mutable: false) }
 
     let!(:primary_credit_type)    { create(:primary_credit_type) }
-    let!(:created_by_user)        { create(:user, email: 'user@email.com') }
+    let(:created_by_user) { create(:user, email: 'user@email.com') }
     let!(:default_reimbursement_category) { create(:store_credit_category) }
 
     subject { Spree::ReimbursementType::StoreCredit.reimburse(reimbursement, [return_item, return_item2], simulate, created_by_user) }

--- a/core/spec/models/spree/reimbursement_type/store_credit_spec.rb
+++ b/core/spec/models/spree/reimbursement_type/store_credit_spec.rb
@@ -92,6 +92,17 @@ module Spree
             expect { subject }.to change { Spree::StoreCredit.count }.by(1)
             expect(Spree::StoreCredit.last.currency).to eq reimbursement.order.currency
           end
+
+          context 'without a user with email address "spree@example.com" in the database' do
+            before do
+              Spree::LegacyUser.find_by(email: "spree@example.com").destroy
+            end
+
+            it "creates a store credit with the same currency as the reimbursement's order" do
+              expect { subject }.to change { Spree::StoreCredit.count }.by(1)
+              expect(Spree::StoreCredit.last.currency).to eq reimbursement.order.currency
+            end
+          end
         end
       end
     end

--- a/core/spec/models/spree/reimbursement_type/store_credit_spec.rb
+++ b/core/spec/models/spree/reimbursement_type/store_credit_spec.rb
@@ -12,10 +12,10 @@ module Spree
     let!(:default_refund_reason)  { Spree::RefundReason.find_or_create_by!(name: Spree::RefundReason::RETURN_PROCESSING_REASON, mutable: false) }
 
     let!(:primary_credit_type)    { create(:primary_credit_type) }
-    let!(:created_by_user)        { create(:user, email: Spree::StoreCredit::DEFAULT_CREATED_BY_EMAIL) }
+    let!(:created_by_user)        { create(:user, email: 'user@email.com') }
     let!(:default_reimbursement_category) { create(:store_credit_category) }
 
-    subject { Spree::ReimbursementType::StoreCredit.reimburse(reimbursement, [return_item, return_item2], simulate) }
+    subject { Spree::ReimbursementType::StoreCredit.reimburse(reimbursement, [return_item, return_item2], simulate, created_by_user) }
 
     before do
       reimbursement.update!(total: reimbursement.calculated_total)
@@ -95,7 +95,8 @@ module Spree
 
           context 'without a user with email address "spree@example.com" in the database' do
             before do
-              Spree::LegacyUser.find_by(email: "spree@example.com").destroy
+              default_user = Spree::LegacyUser.find_by(email: "spree@example.com")
+              default_user.destroy if default_user
             end
 
             it "creates a store credit with the same currency as the reimbursement's order" do


### PR DESCRIPTION
This PR is _blocked on #2687_.

This PR aims to resolve #2645 by eliminating a hard-coded dependency on a user in the database with the email address `'spree@example.com'`. In order to achieve this, the user that creates the reimbursement has to be passed down the call chain from the backend. Since the call chain for reimbursements is particularly long, this PR has many changes in it, however they are all aimed at ensuring that when a `Spree::StoreCredit` is eventually created by a reimbursement, that it has as the creator without having to rely on specific email addresses existing.