### PR TITLE
Remove order-dependency from locale specs

### DIFF
--- a/frontend/spec/support/shared_contexts/locales.rb
+++ b/frontend/spec/support/shared_contexts/locales.rb
@@ -10,6 +10,7 @@ shared_context 'fr locale' do
   end
 
   after do
+    I18n.locale = :en # reset locale after each spec.
     I18n.reload!
   end
 end


### PR DESCRIPTION
Previously, `bundle exec rspec --seed 13070 --format documentation` would fail in the front-end app due to test ordering. This PR removes this order dependency.