### PR TITLE
Rails 5.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2
 jobs:
-  postgres:
+  postgres: &postgres
     working_directory: &workdir ~/solidus
     environment: &environment
       DB: postgresql
@@ -46,9 +46,9 @@ jobs:
       - store_test_results:
           path: /tmp/test-results
 
-  mysql:
+  mysql: &mysql
     working_directory: *workdir
-    environment:
+    environment: &mysql_environment
       <<: *environment
       DB: mysql
       DB_HOST: 127.0.0.1
@@ -58,9 +58,23 @@ jobs:
     parallelism: *parallelism
     steps: *steps
 
+  postgres_rails51:
+    <<: *postgres
+    environment:
+      <<: *environment
+      RAILS_VERSION: '~> 5.1.0'
+
+  mysql_rails51:
+    <<: *mysql
+    environment:
+      <<: *mysql_environment
+      RAILS_VERSION: '~> 5.1.0'
+
 workflows:
   version: 2
   build:
     jobs:
       - postgres
       - mysql
+      - postgres_rails51
+      - mysql_rails51

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,9 @@ source 'https://rubygems.org'
 
 gemspec require: false
 
+rails_version = ENV['RAILS_VERSION'] || '~> 5.2.0'
+gem 'rails', rails_version, require: false
+
 platforms :ruby do
   gem 'mysql2', '~> 0.5.0', require: false
   gem 'pg', '~> 1.0', require: false

--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
     actionmailer actionpack actionview activejob activemodel activerecord
     activesupport railties
   ].each do |rails_dep|
-    s.add_dependency rails_dep, '~> 5.1.0'
+    s.add_dependency rails_dep, ['>= 5.1', '< 5.3.x']
   end
 
   s.add_dependency 'activemerchant', '~> 1.66'

--- a/lib/sandbox.sh
+++ b/lib/sandbox.sh
@@ -35,12 +35,13 @@ if [ ! -d "sandbox" ]; then
 fi
 
 cd ./sandbox
-echo "gem 'solidus', :path => '..'" >> Gemfile
-echo "gem 'solidus_auth_devise', '>= 2.1.0'" >> Gemfile
-echo "gem 'rails-i18n'" >> Gemfile
-echo "gem 'solidus_i18n'" >> Gemfile
-
 cat <<RUBY >> Gemfile
+
+gem 'solidus', path: '..'
+gem 'solidus_auth_devise', '>= 2.1.0'
+gem 'rails-i18n'
+gem 'solidus_i18n'
+
 group :test, :development do
   platforms :mri do
     gem 'pry-byebug'


### PR DESCRIPTION
This PR isn't totally ready to merge (needs some unreleased changes in other gems), but Rails 5.2 is now out.

We need:
* [x] New gem of paranoia
* [x] New gem of canonical-rails
* [x] New gem of friendly_id
