### PR TITLE
Remove assert_written_to_cache

### DIFF
--- a/core/lib/spree/testing_support/caching.rb
+++ b/core/lib/spree/testing_support/caching.rb
@@ -7,16 +7,6 @@ module Spree
         @cache_write_events
       end
 
-      def assert_written_to_cache(key)
-        unless @cache_write_events.detect { |event| event[:key].starts_with?(key) }
-          fail %{Expected to find #{key} in the cache, but didn't.
-
-  Cache writes:
-  #{@cache_write_events.join("\n")}
-          }
-        end
-      end
-
       def clear_cache_events
         @cache_write_events = []
       end

--- a/core/lib/spree/testing_support/caching.rb
+++ b/core/lib/spree/testing_support/caching.rb
@@ -18,7 +18,6 @@ module Spree
       end
 
       def clear_cache_events
-        @cache_read_events = []
         @cache_write_events = []
       end
     end
@@ -30,11 +29,6 @@ RSpec.configure do |config|
 
   config.before(:each, caching: true) do
     ActionController::Base.perform_caching = true
-
-    ActiveSupport::Notifications.subscribe("read_fragment.action_controller") do |_event, _start_time, _finish_time, _, details|
-      @cache_read_events ||= []
-      @cache_read_events << details
-    end
 
     ActiveSupport::Notifications.subscribe("write_fragment.action_controller") do |_event, _start_time, _finish_time, _, details|
       @cache_write_events ||= []

--- a/frontend/spec/features/caching/products_spec.rb
+++ b/frontend/spec/features/caching/products_spec.rb
@@ -12,9 +12,6 @@ describe 'products', type: :feature, caching: true do
     product2.update_column(:updated_at, 1.day.ago)
     # warm up the cache
     visit spree.root_path
-    assert_written_to_cache("views/en/USD/spree/products/all--#{product.updated_at.utc.to_s(:number)}")
-    assert_written_to_cache("views/en/USD/spree/products/#{product.id}-#{product.updated_at.utc.to_s(:number)}")
-    assert_written_to_cache("views/en/spree/taxonomies/#{taxonomy.id}")
 
     clear_cache_events
   end
@@ -27,8 +24,6 @@ describe 'products', type: :feature, caching: true do
   it "busts the cache when a product is updated" do
     product.update_column(:updated_at, 1.day.from_now)
     visit spree.root_path
-    assert_written_to_cache("views/en/USD/spree/products/all--#{product.updated_at.utc.to_s(:number)}")
-    assert_written_to_cache("views/en/USD/spree/products/#{product.id}-#{product.updated_at.utc.to_s(:number)}")
     expect(cache_writes.count).to eq(2)
   end
 
@@ -36,21 +31,18 @@ describe 'products', type: :feature, caching: true do
     product.discard
     product2.discard
     visit spree.root_path
-    assert_written_to_cache("views/en/USD/spree/products/all--#{Date.today.to_s(:number)}-0")
     expect(cache_writes.count).to eq(1)
   end
 
   it "busts the cache when the newest product is soft-deleted" do
     product.discard
     visit spree.root_path
-    assert_written_to_cache("views/en/USD/spree/products/all--#{product2.updated_at.utc.to_s(:number)}")
     expect(cache_writes.count).to eq(1)
   end
 
   it "busts the cache when an older product is soft-deleted" do
     product2.discard
     visit spree.root_path
-    assert_written_to_cache("views/en/USD/spree/products/all--#{product.updated_at.utc.to_s(:number)}")
     expect(cache_writes.count).to eq(1)
   end
 end

--- a/frontend/spec/features/caching/taxons_spec.rb
+++ b/frontend/spec/features/caching/taxons_spec.rb
@@ -9,7 +9,6 @@ describe 'taxons', type: :feature, caching: true do
   before do
     # warm up the cache
     visit spree.root_path
-    assert_written_to_cache("views/en/spree/taxonomies/#{taxonomy.id}")
 
     clear_cache_events
   end
@@ -17,7 +16,6 @@ describe 'taxons', type: :feature, caching: true do
   it "busts the cache when max_level_in_taxons_menu conf changes" do
     Spree::Config[:max_level_in_taxons_menu] = 5
     visit spree.root_path
-    assert_written_to_cache("views/en/spree/taxonomies/#{taxonomy.id}")
     expect(cache_writes.count).to eq(1)
   end
 end


### PR DESCRIPTION
This is error prone and breaks in Rails 5.2, since the key being logged is an array.

The key we see from AS::Notifications is now an array and has additional hashes on the template names (I assume russian doll caching related). It's too hard to predict where these values come from, so we can't continue testing this.

We should have most of the benefit and testing of this by just counting the number of cache writes (which we were doing already).