### PR TITLE
Enable route namespacing on unauthorized redirects

### DIFF
--- a/core/lib/spree/core/controller_helpers/auth.rb
+++ b/core/lib/spree/core/controller_helpers/auth.rb
@@ -22,7 +22,7 @@ module Spree
           class_attribute :unauthorized_redirect
           self.unauthorized_redirect = -> do
             flash[:error] = I18n.t('spree.authorization_failure')
-            redirect_to "/unauthorized"
+            redirect_to "#{spree.root_path}unauthorized"
           end
 
           rescue_from CanCan::AccessDenied do


### PR DESCRIPTION
Hardcoded URLs don't work as expected when Solidus routes are mounted within a
namespace: the namespace part is simply lost. In order to avoid this problem
and include the namespace, when present, a routing helper must be used.

This fixes issue #2692 