### PR TITLE
Allow #try_spree_current_user to search for private methods

### DIFF
--- a/core/lib/spree/core/controller_helpers/auth.rb
+++ b/core/lib/spree/core/controller_helpers/auth.rb
@@ -70,10 +70,10 @@ module Spree
         def try_spree_current_user
           # This one will be defined by apps looking to hook into Spree
           # As per authentication_helpers.rb
-          if respond_to?(:spree_current_user)
+          if respond_to?(:spree_current_user, true)
             spree_current_user
           # This one will be defined by Devise
-          elsif respond_to?(:current_spree_user)
+          elsif respond_to?(:current_spree_user, true)
             current_spree_user
           end
         end


### PR DESCRIPTION
When login helper methods #spree_current_user or #current_spree_user are
defined as private, they cannot be found by #try_spree_current_user unless we
instruct explicitly #respond_to? to search among private methods as well.