### PR TITLE
Add frontend customer orders page

### DIFF
--- a/frontend/app/assets/stylesheets/spree/frontend/screen.css.scss
+++ b/frontend/app/assets/stylesheets/spree/frontend/screen.css.scss
@@ -1117,6 +1117,12 @@ table.order-summary {
             color: $link_text_color;
           }
         }
+
+        &.order-status,
+        &.order-payment-state,
+        &.order-shipment-state {
+          text-transform: capitalize;
+        }
       }
     }
   }

--- a/frontend/app/controllers/spree/users_controller.rb
+++ b/frontend/app/controllers/spree/users_controller.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class Spree::UsersController < Spree::StoreController
+  skip_before_action :set_current_order, only: :show, raise: false
+  prepend_before_action :load_object, only: :show
+
+  include Spree::Core::ControllerHelpers
+
+  def show
+    @orders = @user.orders.complete.order('completed_at desc')
+  end
+
+  private
+
+  def load_object
+    @user ||= Spree.user_class.find_by(id: try_spree_current_user&.id)
+    authorize! params[:action].to_sym, @user
+  end
+
+  def accurate_title
+    I18n.t('spree.my_account')
+  end
+end

--- a/frontend/app/views/spree/users/show.html.erb
+++ b/frontend/app/views/spree/users/show.html.erb
@@ -1,0 +1,43 @@
+<h1><%= accurate_title %></h1>
+
+<div data-hook="account_summary" class="account-summary">
+  <dl id="user-info">
+    <dt><%= t('spree.email') %></dt>
+    <dd><%= @user.email %> (<%= link_to t('spree.edit'), edit_account_path %>)</dd>
+  </dl>
+</div>
+
+<div data-hook="account_my_orders" class="account-my-orders">
+
+  <h3><%= t('spree.my_orders') %></h3>
+  <% if @orders.present? %>
+    <table class="order-summary">
+      <thead>
+      <tr>
+        <th class="order-number"><%= Spree::Order.human_attribute_name(:number) %></th>
+        <th class="order-date"><%= Spree::Order.human_attribute_name(:date) %></th>
+        <th class="order-status"><%= Spree::Order.human_attribute_name(:status) %></th>
+        <th class="order-payment-state"><%= Spree::Order.human_attribute_name(:payment_state) %></th>
+        <th class="order-shipment-state"><%= Spree::Order.human_attribute_name(:shipment_state) %></th>
+        <th class="order-total"><%= Spree::Order.human_attribute_name(:total) %></th>
+      </tr>
+      </thead>
+      <tbody>
+      <% @orders.each do |order| %>
+        <tr class="<%= cycle('even', 'odd') %>">
+          <td class="order-number"><%= link_to order.number, order_url(order) %></td>
+          <td class="order-date"><%= l order.completed_at.to_date %></td>
+          <td class="order-status"><%= t("spree.order_state.#{order.state}") %></td>
+          <td class="order-payment-state"><%= t("spree.payment_states.#{order.payment_state}") if order.payment_state %></td>
+          <td class="order-shipment-state"><%= t("spree.shipment_states.#{order.shipment_state}") if order.shipment_state %></td>
+          <td class="order-total"><%= order.display_total %></td>
+        </tr>
+      <% end %>
+      </tbody>
+    </table>
+  <% else %>
+    <p><%= t('spree.you_have_no_orders_yet') %></p>
+  <% end %>
+  <br>
+
+</div>

--- a/frontend/config/routes.rb
+++ b/frontend/config/routes.rb
@@ -31,4 +31,6 @@ Spree::Core::Engine.routes.draw do
   get '/unauthorized', to: 'home#unauthorized', as: :unauthorized
   get '/content/cvv', to: 'content#cvv', as: :cvv
   get '/cart_link', to: 'store#cart_link', as: :cart_link
+
+  resource :account, controller: 'users', only: [:show, :edit]
 end

--- a/frontend/spec/controllers/spree/users_controller_spec.rb
+++ b/frontend/spec/controllers/spree/users_controller_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Spree::UsersController, type: :controller do
+  let(:user) { Spree.user_class.new }
+
+  describe '#show' do
+    context 'when not authenticated' do
+      before { allow(Spree.user_class).to receive(:find_by) { nil } }
+
+      it 'redirects to unauthorized path' do
+        get :show
+        expect(response).to redirect_to '/unauthorized'
+      end
+    end
+
+    context 'when authenticated' do
+      before { allow(Spree.user_class).to receive(:find_by) { user } }
+
+      it 'redirects to signup path if user is not found' do
+        get :show
+        expect(response).to be_successful
+      end
+    end
+  end
+end

--- a/frontend/spec/features/user_orders_spec.rb
+++ b/frontend/spec/features/user_orders_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe "User orders page", type: :feature do
+  before do
+    allow_any_instance_of(Spree::UsersController).to receive_messages(try_spree_current_user: user)
+  end
+
+  context 'when the user is not authenticated' do
+    let(:user) { nil }
+
+    it 'fails authentication' do
+      visit spree.account_path
+      expect(page).to have_content 'Authorization Failure'
+    end
+  end
+
+  context 'when the user is authenticated' do
+    let(:user) { create :user }
+
+    let!(:cart_order) { create :order, user: user }
+    let!(:complete_order) { create :completed_order_with_totals, user: user }
+
+    it 'lists user complete orders' do
+      visit spree.account_path
+      expect(page).to have_content 'My Account'
+      expect(page).to have_content user.email
+      expect(page).to have_content complete_order.number
+      expect(page).not_to have_content cart_order.number
+    end
+  end
+end


### PR DESCRIPTION
The code is basically a cut & paste of the relevant parts from the gem
solidus_auth_devise.

The rationale for this change is that the orders history page better belongs
inside the solidus main project, because the feature does not have much to do
with the actual authentication process, and because it allows projects that
have an existing authentication system (ie. don't use solidus_auth_devise) to
have the orders page feature out of the box.

Closes #4010