### PR TITLE
cleanup order validate_payments_attributes

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -779,13 +779,12 @@ module Spree
 
     def validate_payments_attributes(attributes)
       attributes = Array(attributes)
-      # Ensure the payment methods specified are allowed for this user
-      payment_methods = Spree::PaymentMethod.where(id: available_payment_methods)
+
       attributes.each do |payment_attributes|
         payment_method_id = payment_attributes[:payment_method_id]
 
         # raise RecordNotFound unless it is an allowed payment method
-        payment_methods.find(payment_method_id) if payment_method_id
+        available_payment_methods.find(payment_method_id) if payment_method_id
       end
     end
 


### PR DESCRIPTION
I think it's not necessary make a query over `available_payment_methods`. Until I can see `available_payment_methods` already return a list of payment methods that are available for the order.