### PR TITLE
Fix error dropping postgres db in automigration

### DIFF
--- a/core/lib/spree/testing_support/dummy_app/migrations.rb
+++ b/core/lib/spree/testing_support/dummy_app/migrations.rb
@@ -26,9 +26,13 @@ module DummyApp
     def auto_migrate
       if needs_migration?
         puts "Configuration changed. Re-running migrations"
+
+        # Disconnect to avoid "database is being accessed by other users" on postgres
+        ActiveRecord::Base.remove_connection
+
         sh 'rake db:reset VERBOSE=false'
 
-        # We might have a brand new database, so we must re-establish our connection
+        # We have a brand new database, so we must re-establish our connection
         ActiveRecord::Base.establish_connection
       end
     end


### PR DESCRIPTION
I was getting this error when automigration the datbase

    Caused by:
    PG::ObjectInUse: ERROR:  database "solidus_backend_test" is being accessed by other users
    DETAIL:  There is 1 other session using the database.

This is because we were connecting to the database to check whether migrations were up to date, and that connection remained open as we tried to drop the DB from a separate process.

This commit fixes the issue by calling `ActiveRecord::Base.remove_connection` before shelling out to `rake db:reset`