### PR TITLE
Variant property rules to optionally match all conditions

### DIFF
--- a/backend/app/views/spree/admin/product_properties/index.html.erb
+++ b/backend/app/views/spree/admin/product_properties/index.html.erb
@@ -66,6 +66,14 @@
   <%= f.fields_for :variant_property_rules, @variant_property_rule do |rule_form| %>
     <%= rule_form.hidden_field 'id', value: @variant_property_rule.id %>
     <%= rule_form.hidden_field 'option_value_ids', value: @option_value_ids.join(',') %>
+    <div class="col-12">
+      <div class="field checkbox">
+        <label>
+          <%= rule_form.check_box 'apply_to_all', value: @variant_property_rule.apply_to_all %>
+          <%= t('spree.applies_to_all_variant_properties') %>
+        </label>
+      </div>
+    </div>
     <% if @option_value_ids.present? %>
       <fieldset class='no-border-top'>
         <table class="index sortable" data-hook data-sortable-link="<%= update_positions_admin_product_variant_property_rule_values_url %>">

--- a/backend/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/products_controller_spec.rb
@@ -62,6 +62,7 @@ describe Spree::Admin::ProductsController, type: :controller do
           id: product.id,
           variant_property_rules_attributes: {
             "0" => {
+              apply_to_all: true,
               option_value_ids: option_value.id,
               values_attributes: {
                 "0" => {
@@ -83,6 +84,11 @@ describe Spree::Admin::ProductsController, type: :controller do
 
     it "creates a variant property rule" do
       expect { subject }.to change { product.variant_property_rules.count }.by(1)
+    end
+
+    it "creates a variant property rule that applies to all" do
+      subject
+      expect(product.variant_property_rules.first.apply_to_all).to be_truthy
     end
 
     it "creates a variant property rule condition" do

--- a/core/app/models/spree/variant_property_rule.rb
+++ b/core/app/models/spree/variant_property_rule.rb
@@ -38,7 +38,11 @@ module Spree
     # @param variant [Spree::Variant] variant to check
     # @return [Boolean]
     def applies_to_variant?(variant)
-      (option_value_ids & variant.option_value_ids).present?
+      if apply_to_all
+        matches_option_value_ids?(variant.option_value_ids)
+      else
+        (option_value_ids & variant.option_value_ids).present?
+      end
     end
   end
 end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -797,6 +797,7 @@ en:
     add_product: Add Product
     add_product_properties: Add Product Properties
     add_variant_properties: Add Variant Properties
+    applies_to_all_variant_properties: Applies to all Variant Properties above
     add_rule_of_type: Add rule of type
     add_state: Add State
     add_stock: Add Stock

--- a/core/db/migrate/20180416083007_property_rules_apply_to_all.rb
+++ b/core/db/migrate/20180416083007_property_rules_apply_to_all.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class PropertyRulesApplyToAll < ActiveRecord::Migration[5.1]
+  def change
+    add_column :spree_variant_property_rules, :apply_to_all, :boolean, default: false
+  end
+end

--- a/core/spec/models/spree/variant_property_rule_spec.rb
+++ b/core/spec/models/spree/variant_property_rule_spec.rb
@@ -70,6 +70,13 @@ RSpec.describe Spree::VariantPropertyRule, type: :model do
       it { is_expected.to eq true }
     end
 
+    context "variant cannot match only some of the rule's conditions when applies to all" do
+      let(:rule) { create(:variant_property_rule, option_value: rule_option_value, apply_to_all: true) }
+      let(:option_values) { [variant_option_value_1, variant_option_value_2] }
+
+      it { is_expected.to eq false }
+    end
+
     context "variant matches none of the rule's conditions" do
       let(:option_values) { [create(:option_value)] }
 


### PR DESCRIPTION
I was expecting `applies_to_variant?` on `VariantPropertyRule` to only match when all rule conditions match. 

### What's wrong with how it is?

When variant property rules match any of the rule's conditions it means you cannot link a property to a specific variant (if you have multiple option types)

### Backward compatibility

Is kept as the flag defaults to false (so it'll continue to match to any of the rule's conditions)

### Discussion

https://solidusio.slack.com/archives/C0JBKDF35/p1523712836000092
https://solidusio.slack.com/archives/C0JBKDF35/p1523833492000117