### PR TITLE
Fix <td> closing tag

### DIFF
--- a/frontend/app/views/spree/orders/_form.html.erb
+++ b/frontend/app/views/spree/orders/_form.html.erb
@@ -22,7 +22,7 @@
     <%= render "spree/orders/adjustments" %>
   <% end %>
   <tr class="cart-total">
-    <td colspan="4" align='right'><h5><%= t('spree.total') %></h5></th>
+    <td colspan="4" align='right'><h5><%= t('spree.total') %></h5></td>
     <td colspan><h5><%= order.display_total %></h5></td>
     <td></td>
   </tr>


### PR DESCRIPTION
Fix wrong `td` HTML tag closing (currently `</th>`).