### PR TITLE
Improve the admin UX for a product's "Available On" field

### DIFF
--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -64,6 +64,7 @@
       <div data-hook="admin_product_form_available_on">
         <%= f.field_container :available_on do %>
           <%= f.label :available_on %>
+          <%= f.field_hint :available_on %>
 
           <%= render "spree/admin/shared/datepicker", f: f, date_attr: :available_on %>
 

--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -64,8 +64,10 @@
       <div data-hook="admin_product_form_available_on">
         <%= f.field_container :available_on do %>
           <%= f.label :available_on %>
+
+          <%= render "spree/admin/shared/datepicker", f: f, date_attr: :available_on %>
+
           <%= f.error_message_on :available_on %>
-          <%= f.text_field :available_on, value: datepicker_field_value(@product.available_on), class: 'datepicker' %>
         <% end %>
       </div>
 

--- a/backend/app/views/spree/admin/shared/_datepicker.html.erb
+++ b/backend/app/views/spree/admin/shared/_datepicker.html.erb
@@ -1,0 +1,8 @@
+<div class="input-group">
+  <div class="input-group-prepend">
+    <span class="input-group-text">
+      <%= solidus_icon('fa fa-calendar') %>
+    </span>
+  </div>
+  <%= f.text_field date_attr, value: datepicker_field_value(f.object.public_send(date_attr)), class: 'form-control datepicker' %>
+</div>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1285,6 +1285,7 @@ en:
         master_variant: "Changing master variant prices will not change variant prices below, but will be used to populate all new variants"
         options: "These options are used to create variants in the variants table. They can be changed in the variants tab"
       spree/product:
+        available_on: "This sets the availability date for the product. If this value is not set, or it is set to a date in the future, then the product is not available on the storefront."
         promotionable: "This determines whether or not promotions can apply to this product.<br/>Default: Checked"
         shipping_category: "This determines what kind of shipping this product requires.<br/> Default: Default"
         tax_category: "This determines what kind of taxation is applied to this product.<br/> Default: None"


### PR DESCRIPTION
In the `solidus_backend` interface, a product's "Available On" field should be used set to a date.

If `available_on` is not set, then the product is not displayed on the storefront.

Because it's not technically a required field, it might not be clear to an admin why their new product does not appear on the storefront after it's been created. (The reason is because `available_on` has no value.)

This PR addresses the "Available On" UX in the following ways:

- It improves the admin UX by making it clear that the "Available On" field is a date picker.
- the "Available On" field now has placeholder text that clearly states "Hey, this is a *date picker* that sets the *availability* date for the product."
- Lastly, there was a SASS variable called `$input-placeholder-color` that wasn't being set anywhere, so I set it. This is the color that is now used for any `<input>` tags placeholder text across the admin now.