### PR TITLE
Fix css class in taxons

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/templates/products/sortable.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/products/sortable.hbs
@@ -1,5 +1,5 @@
 <a href="#" id="product_{{ id }}" data-product-id="{{ id }}" class="sort_item list-group-item">
   <i class="fa fa-sort"></i>
   <span class="product_name">{{ name }}</span>
-  <span class="right">{{ display_price }}</span>
+  <span class="float-right">{{ display_price }}</span>
 </a>


### PR DESCRIPTION
The `right` class comes from removed Skeleton CSS so we need to use the `float-right` class in Bootstrap to pull the price to the right.

## Before

![before](https://user-images.githubusercontent.com/149772/38912266-49a2ee48-430f-11e8-8168-58e93710b864.jpeg)

## After

![after](https://user-images.githubusercontent.com/149772/38912275-51721608-430f-11e8-9e41-766998a903c9.jpeg)