### PR TITLE
Fix the code syntax in installation options guide

### DIFF
--- a/guides/getting-started/installation-options.md
+++ b/guides/getting-started/installation-options.md
@@ -84,7 +84,7 @@ gem 'turbolinks', '~> 5.0.0'
 Then, enable Turbolinks in the backend by appending these lines to the
 JavaScript manifest at `vendor/assets/spree/backend/all/js`:
 
-```ruby
+```js
 //= require turbolinks
 //= require backend/app/assets/javascripts/spree/backend/turbolinks-integration.js
 ```


### PR DESCRIPTION
Set the syntax for the javascript manifest installation options to `js`, as the manifest files are Javascript not Ruby.

FYI This PR is opened directly by following the "Edit this page" link on https://tvdeyen.github.io/solidus/getting-started/installation-options.html

See #2706 for further information