### PR TITLE
Fix markdown link syntax in payment service provider guide

### DIFF
--- a/guides/payments/payment-service-providers.md
+++ b/guides/payments/payment-service-providers.md
@@ -20,7 +20,7 @@ service providers:
 - [`solidus_culqi`][solidus-culqi]
 - [`solidus_payu_latam`][solidus-payu-latam]
 
-[solidus-affirm]: (https://github.com/StemboltHQ/solidus_affirm
+[solidus-affirm]: https://github.com/StemboltHQ/solidus_affirm
 [solidus-adyen]: https://github.com/StemboltHQ/solidus-adyen
 [solidus-braintree]: https://github.com/solidusio/solidus_braintree
 [solidus-culqi]: https://github.com/ccarruitero/solidus_culqi


### PR DESCRIPTION
Fix the markdown link syntax in payment service provider guide.

FYI This PR is opened directly by following the "Edit this page" link on https://tvdeyen.github.io/solidus/payments/payment-service-providers.html

See #2706 for further information