### PR TITLE
Guides: Links and syntax fixes

### DIFF
--- a/guides/extensions/testing-extensions.md
+++ b/guides/extensions/testing-extensions.md
@@ -97,7 +97,7 @@ end
 You can replace all of the `ActiveRecord::Migration` occurrences automatically
 with `sed`:
 
-```shell
+```bash
 sed -i 's/ActiveRecord::Migration/SolidusSupport::Migration[4.2]/' db/migrate/*.rb
 ```
 

--- a/guides/getting-started/develop-solidus.md
+++ b/guides/getting-started/develop-solidus.md
@@ -6,13 +6,13 @@ pull request, please [read the contributing guidelines][contributing] first.
 Getting your Solidus development environment set up is easy. First, clone the
 Solidus GitHub repo:
 
-```shell
+```bash
 git clone git://github.com/solidusio/solidus.git
 ```
 
 Then enter the directory you just downloaded and install Solidus's dependencies:
 
-```shell
+```bash
 cd solidus
 bundle install
 ```
@@ -26,14 +26,14 @@ typical Solidus store you can use for testing.
 By default, the sandbox includes [`solidus_auth_devise`][solidus-auth-devise],
 and the generator seeds the database and loads sample data.
 
-```shell
+```bash
 bundle exec rake sandbox
 ```
 
 You can prepend `DB=mysql` or `DB=postgresql` to the command in order use those
 databases instead of the default SQLite 3 database. For example:
 
-```shell
+```bash
 DB=postgresql bundle exec rake sandbox
 ``` 
 
@@ -69,14 +69,14 @@ You can see the build statuses [on our CircleCI status page][circleci].
 To execute all of the test specs, run the `build.sh` script at the root of the
 Solidus project:
 
-```shell
+```bash
 bash build.sh
 ```
 
 This runs using PostgreSQL by default, but it can be overridden by setting the
 `DB` environment variable to `DB=sqlite` or `DB=mysql`. For example: 
 
-```shell
+```bash
 DB=mysql bash build.sh
 ```
 
@@ -87,7 +87,7 @@ Note that this will fail if you have not installed ChromeDriver on your system.
 Each gem contains its own test suite. For example, you can run only the
 `solidus_core` gem tests within the `/core` directory:
 
-```shell
+```bash
 cd core
 bundle exec rspec
 ```
@@ -95,7 +95,7 @@ bundle exec rspec
 By default, the tests run against the default SQLite 3 database. You can instead
 specify `DB=mysql` or `DB=postgresql` by prepending it to the command:
 
-```shell
+```bash
 DB=postgresql bundle exec rspec
 ```
 
@@ -104,7 +104,7 @@ DB=postgresql bundle exec rspec
 You can generate a [SimpleCov](https://github.com/colszowka/simplecov) code
 coverage report by prepending `COVERAGE=true` to the `rspec` command:
 
-```shell
+```bash
 COVERAGE=true bundle exec rspec
 ```
 

--- a/guides/getting-started/first-time-installation.md
+++ b/guides/getting-started/first-time-installation.md
@@ -63,7 +63,7 @@ Homebrew][ruby-homebrew] if you need to upgrade from your system's Ruby.
 Using Homebrew, you can install all of the requirements using the following
 commands:
 
-```shell 
+```bash 
 brew install ruby sqlite3 imagemagick
 gem install rails
 ```
@@ -76,14 +76,14 @@ If you run macOS Sierra or an older OS, you system's version of Ruby will need
 to be upgraded from 2.0.x to 2.2.2 or newer. You can check what version of Ruby
 you have installed with the following command:
 
-```shell
+```bash
 ruby --version
 ```
 
 The Ruby documentation recommends installing another, newer instance of Ruby
 installing another, newer instance of Ruby using Homebrew: 
 
-```shell
+```bash
 brew install ruby
 ```
 
@@ -96,7 +96,7 @@ Rails and Solidus use SQLite 3 as the default relational database. SQLite is a
 widely-supported, lightweight way to send and receive data. Using Homebrew,
 you can install the latest version of SQLite 3 using the following command:
 
-```shell
+```bash
 brew install sqlite3
 ```
 
@@ -106,7 +106,7 @@ website](https://www.sqlite.org/download.html).
 After the installation, check that it has been installed by checking the version
 number:
 
-```shell
+```bash
 sqlite3 --version
 ```
 
@@ -119,7 +119,7 @@ Rails includes everything you need to build and extend a web application. Once
 you have Ruby and SQLite 3 installed on your system, you can install Rails via
 the [RubyGems](https://rubygems.org) `gem` command that comes as a part of Ruby:
 
-```shell
+```bash
 gem install rails
 ```
 
@@ -132,7 +132,7 @@ It is required to use [Paperclip](https://github.com/thoughtbot/paperclip),
 which is how Solidus currently handles file attachments. To install ImageMagick
 via Homebrew, use the command: 
 
-```shell
+```bash
 brew install imagemagick
 ```
 
@@ -148,7 +148,7 @@ Solidus.
 
 First, we need a new Rails project:
 
-```shell
+```bash
 rails new your_solidus_project_name
 ```
 
@@ -181,7 +181,7 @@ the gems and create a more custom store.
 Once you have saved the `Gemfile`, ensure you are in your Rails project
 directory, and then install the project's dependencies using Bundler.
 
-```shell
+```bash
 cd /path/to/your-solidus-project-name
 bundle install
 ```
@@ -202,7 +202,7 @@ provided by Solidus and Railties.
 
 First, run the `spree:install` generator:
 
-```shell
+```bash
 bundle exec rails generate spree:install
 ```
 
@@ -223,7 +223,7 @@ The default values are as follows:
 Next, you need run the `solidus:auth:install` generator and install your
 database migrations using the following commands:
 
-```shell
+```bash
 bundle exec rails generate solidus:auth:install
 bundle exec rake railties:install:migrations
 ```
@@ -231,7 +231,7 @@ bundle exec rake railties:install:migrations
 Finally, you need to run the migrations that Railties created. This creates the
 e-commerce–friendly models that Solidus uses for its database:
 
-```shell
+```bash
 bundle exec rake db:migrate
 ```
 
@@ -242,7 +242,7 @@ successfully start the Rails server and see the sample store in your browser.
 
 First, start the server:
 
-```shell
+```bash
 bundle exec rails server
 ```
 

--- a/guides/getting-started/installation-options.md
+++ b/guides/getting-started/installation-options.md
@@ -26,19 +26,19 @@ a production system.
 When you run the `spree:install` generator without arguments, it runs
 migrations, adds sample data, and seeds your database:
 
-```shell
+```bash
 rails generate spree:install
 ```
 
 You can use command arguments to skip any of these steps of the generator:
 
-```shell
+```bash
 rails generate spree:install --migrate=false --sample=false --seed=false
 ```
 
 If you want to perform these tasks later, you can use these commands.
 
-```shell
+```bash
 bundle exec rake railties:install:migrations       # installs migrations
 bundle exec rake db:migrate                        # runs migrations
 bundle exec rake db:seed                           # seeds your database
@@ -48,7 +48,7 @@ bundle exec rake spree_sample:load                 # loads sample data
 If you use `solidus_auth_devise` for user authentication, you can also install
 and run its migrations, then seed the database, separately:
 
-```shell
+```bash
 bundle exec rake solidus_auth:install:migrations   # installs solidus_auth_devise migrations
 bundle exec rake db:migrate                        # runs solidus_auth_devise migrations
 bundle exec rake db:seed                           # seeds your database

--- a/guides/locations/countries-and-states.md
+++ b/guides/locations/countries-and-states.md
@@ -2,7 +2,7 @@
 
 Solidus uses the list of countries and states provided by [Carmen][carmen-repo],
 which uses the countries and states available in the [Debian `iso-codes`
-package][debian-iso-codes]. Solidus creates new `Spree::Country` and 
+package][debian-iso-codes]. Solidus creates new `Spree::Country` and
 `Spree::State` objects for each country and state.
 
 Carmen is generally up-to-date and should provide Solidus with any country or
@@ -16,14 +16,14 @@ state you would ever need.
 If a country or state you require is not recognized, you can add it directly
 from your Rails console:
 
-```
+```ruby
 Spree::Country.create!(iso_name:"NEW COUNTRY", name:"New Country", states_required: true)
 ```
 
 Some countries do not need to be divided into states or subregions. For those
 countries, the `Spree::Country` object's `states_required` field is set to
 `false`. You may wish to change this value for your custom country or any other
-country that you ship to. 
+country that you ship to.
 
 ## States
 
@@ -31,7 +31,7 @@ A state is any sub-region of a country, whether that is a province, district, or
 territory. If the state you require is not recognized, you can add it directly
 from your Rails console:
 
-```
+```ruby
 Spree::State.create!(name: "New State", country_id: 1)
 ```
 

--- a/guides/orders/overview.md
+++ b/guides/orders/overview.md
@@ -124,7 +124,7 @@ item belongs to. Inventory units provide a link between the order and
 
 For more information, see the [Shipments][shipments] documentation.
 
-[shipments]: ../shipments/overview-of-shipment.md
+[shipments]: ../shipments/overview-of-shipments.md
 
 ### Addresses
 

--- a/guides/payments/overview.md
+++ b/guides/payments/overview.md
@@ -74,7 +74,7 @@ credit card payment methods, and some other basic payment methods.
 
 For more information, see the [Payment methods][payment-methods] article.
 
-[payment-methods]: payment_method.md
+[payment-methods]: payment-methods.md
 
 ## Payments
 

--- a/guides/payments/payment-sources.md
+++ b/guides/payments/payment-sources.md
@@ -12,7 +12,7 @@ Solidus includes some payment sources such as `Spree::CreditCard` and
 `Spree::StoreCredit`. However, your [payment method][payment-methods] could
 define any custom payment source in its `payment_source_class` method.
 
-[payment-methods]: payment_method.html
+[payment-methods]: payment-methods.html
 
 ## Credit cards
 

--- a/guides/preferences/add-model-preferences.md
+++ b/guides/preferences/add-model-preferences.md
@@ -62,7 +62,7 @@ Your new `preferences` column should be the type `text`.
 
 Then, you can run the migration:
 
-```shell
+```bash
 bundle exec rails db:migrate
 ```
 

--- a/guides/products-and-variants/product-images.md
+++ b/guides/products-and-variants/product-images.md
@@ -49,7 +49,7 @@ By default, it creates creates several version of each image at specific sizes.
 You can check the default settings by calling the `attachment_definitions`
 method on `Spree::Image` in your Rails console:
 
-```shell
+```bash
 Spree::Image.attachment_definitions[:attachment][:styles]
 => {
   mini=>"48x48>",
@@ -76,7 +76,7 @@ Spree::Image.attachment_definitions[:attachment][:styles] = {
 If you change the default image sizes, you must regenerate the Paperclip
 thumbnails by running a Rake task:
 
-```shell
+```bash
 bundle exec rake paperclip:refresh:thumbnails CLASS=Spree::Image
 ```
 

--- a/guides/products-and-variants/product-properties.md
+++ b/guides/products-and-variants/product-properties.md
@@ -17,7 +17,7 @@ t-shirt as a table on its product page:
 You can retrieve the value for a property on a `Spree::Product` object by
 calling the `property` method on it and passing through that property's name:
 
-```shell
+```bash
 Spree::Product.find(1).property("fit")
 => "Tapered"
 ```

--- a/guides/shipments/custom-shipping-calculators.md
+++ b/guides/shipments/custom-shipping-calculators.md
@@ -66,7 +66,7 @@ Your custom shipping calculator should inherit from the existing
 `Spree::ShippingCalculator` class. We recommend following the same directory
 structure that Spree models do, so your new calculator would be created at:
 
-```shell
+```bash
 /app/models/my_store/calculator/shipping/custom_shipping_calculator.rb
 ```
 

--- a/guides/upgrades/migrate-from-spree.md
+++ b/guides/upgrades/migrate-from-spree.md
@@ -95,7 +95,7 @@ gem 'sass-rails', '~> 4.0.0'
 After you have replaced the Spree gems in your `Gemfile` and prepared to upgrade
 Rails to 4.2.x, you can update your application with Bundler:
 
-```shell
+```bash
 bundle update
 ```
 
@@ -107,7 +107,7 @@ At this point, the update should run successfully. If it does not, check your
 Now that you have successfully installed the Solidus gems, you need to copy all
 of the Solidus-specific migrations into your application:
 
-```shell
+```bash
 bundle exec rake railties:install:migrations
 ```
 ### Start the Solidus installation process

--- a/guides/users/custom-authentication.md
+++ b/guides/users/custom-authentication.md
@@ -51,14 +51,14 @@ After you have created your custom `User` model and its corresponding database
 table, you can use the `spree:custom_user` generator to generate Solidus's
 required `User` table columns and some authentication helpers:
 
-```shell
+```bash
 bundle exec rails generate spree:custom_user MyStore::User
 ```
 
 Then, you can migrate your database to add the Solidus-specific `User` table
 columns:
 
-```shell
+```bash
 bundle exec rails db:migrate
 ```
 

--- a/guides/views/custom-frontend.md
+++ b/guides/views/custom-frontend.md
@@ -83,7 +83,7 @@ file or any other initializer.
 You can check all of the default settings of `Spree::Config` by sending this
 command to your Rails console:
 
-```shell
+```bash
 Spree::Config.inspect
 ```
 

--- a/guides/views/override-views.md
+++ b/guides/views/override-views.md
@@ -25,7 +25,7 @@ information see the [Override Solidus assets][override-solidus-assets] article.
 If you want to override views from the `solidus_frontend` gem, you can use the
 provided Rails generator in your host application:
 
-```shell
+```bash
 cd your-rails-project
 bundle exec rails generate solidus:views:override
 ```
@@ -36,14 +36,14 @@ customize them for your store.
 If you only want to copy certain views into your host app, you can provide the
 `--only` argument:
 
-```shell
+```bash
 bundle exec rails generate solidus:views:override --only products/show
 ```
 
 The argument to `--only` can  also be a substring of the name of the view from
 the app/views/spree folder:
 
-```shell
+```bash
 bundle exec rails generate solidus:views:override --only product
 ```
 


### PR DESCRIPTION
While working on #2706 I also made some fixes to the guides it self:


- Fix broken link in orders overview guide
- Fix links to payment methods guide
- Add missing ruby syntax to countries & states guide
- Change the markdown shell syntax to bash 