### PR TITLE
Replace `uniq` with `distinct` for cartons association

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -12,7 +12,7 @@ module Spree
     has_many :shipping_rates, -> { order(:cost) }, dependent: :destroy, inverse_of: :shipment
     has_many :shipping_methods, through: :shipping_rates
     has_many :state_changes, as: :stateful
-    has_many :cartons, -> { uniq }, through: :inventory_units
+    has_many :cartons, -> { distinct }, through: :inventory_units
 
     before_validation :set_cost_zero_when_nil
 

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -895,4 +895,13 @@ RSpec.describe Spree::Shipment, type: :model do
       end
     end
   end
+
+  describe '#cartons' do
+    let(:carton)   { create(:carton) }
+    let(:shipment) { carton.shipments.first }
+
+    subject { shipment.cartons }
+
+    it { is_expected.to include carton }
+  end
 end


### PR DESCRIPTION
This PR is going to fix the issue #2653 

Spree::Shipment#cartons should return a carton collection, to do this `distinct` is provided instead of `uniq` as scope parameter.