### PR TITLE
Add multiple typo fixes in the guides

### DIFF
--- a/guides/calculators/overview.md
+++ b/guides/calculators/overview.md
@@ -66,7 +66,7 @@ of tax that should be applied to line items, shipments, or orders.
 ## Preferences
 
 Each `Spree::Calculator` has [static model preferences][model-preferences]. Each
-instances of a calculator has a `preferences` attribute that stores a hash of
+instance of a calculator has a `preferences` attribute that stores a hash of
 preferences.
 
 For example, you may have two flat shipping rates configured in your store.

--- a/guides/calculators/promotion-calculators.md
+++ b/guides/calculators/promotion-calculators.md
@@ -10,7 +10,7 @@ can adjust orders, line items, or shipping charges, note that some of the
 built-in calculators can only be used on a subset of promotions.
 
 The rest of this article summarizes the available promotion calculators, grouped
-by the types of promotions they can calculator (either order, line item, or
+by the types of promotions they can calculate (either order, line item, or
 shipment promotions).
 
 [shipping-calculators]: shipping-calculators.md

--- a/guides/payments/overview.md
+++ b/guides/payments/overview.md
@@ -127,7 +127,7 @@ class has a `payment_type` method that could have a value of `ApplePay`,
 
 ## Payment processing
 
-The `Spree::Payment::Processing` class's `process!` method can can operate on
+The `Spree::Payment::Processing` class's `process!` method can operate on
 completed orders. It attempts to capture orders, invoking the customer's
 selected `Spree::PaymentMethod` and sending payment details to the payment
 service provider.

--- a/guides/payments/payment-methods.md
+++ b/guides/payments/payment-methods.md
@@ -9,7 +9,7 @@ when you build your own integration for a payment service provider. <!-- For
 more information about Solidus and payment service providers, see the [Payment
 service providers][payment-service-providers] article. -->
 
-`Spree::PaymentMethod` objects have have the following attributes:
+`Spree::PaymentMethod` objects have the following attributes:
 
 - `type`: The subclass of `Spree::PaymentMethod` that this payment method
   represents.

--- a/guides/payments/payment-sources.md
+++ b/guides/payments/payment-sources.md
@@ -21,7 +21,7 @@ If your [payment processing][payment-processing] integration uses the
 not store all of the payment details. Solidus only collects enough data to allow
 customers to verify which credit card is being used.
 
-All the credit card data that you collection should be immediately sent through
+All the credit card data that you collect should be immediately sent through
 a form to the payment service provider. Your databases should not store a
 customer's complete credit card data for any amount of time.
 

--- a/guides/preferences/class-extension-points.md
+++ b/guides/preferences/class-extension-points.md
@@ -28,7 +28,7 @@ extension point for this:
 class_name_attribute :searcher_class, default: 'Spree::Core::Search::Base'
 ```
 
-Note that if that you do not use this extension point, then `searcher_class`
+Note that if you do not use this extension point, then `searcher_class`
 defaults to using `Spree::Core::Search::Base`.
 
 Extending the searcher is a multi-step process:

--- a/guides/products-and-variants/product-images.md
+++ b/guides/products-and-variants/product-images.md
@@ -44,7 +44,7 @@ current product.
 ## Paperclip settings
 
 [Paperclip][paperclip-gem] handles the creation and storage of product images.
-By default, it creates creates several version of each image at specific sizes.
+By default, it creates several versions of each image at specific sizes.
 
 You can check the default settings by calling the `attachment_definitions`
 method on `Spree::Image` in your Rails console:

--- a/guides/taxation/displaying-prices.md
+++ b/guides/taxation/displaying-prices.md
@@ -57,7 +57,7 @@ depending on the store that they are browsing. For example, if you have both a
 `us.store.com`, your customer is more likely to be in the United States.
 
 Using the `cart_tax_country_iso` property can help you comply with tax
-jurisdictions where where it is required to display VAT as part of the price.
+jurisdictions where it is required to display VAT as part of the price.
 
 Administrators can configure these values for a storefront using the "Default
 currency" and "Tax Country for Empty Carts" settings on the **Settings ->

--- a/guides/taxation/overview-of-taxation.md
+++ b/guides/taxation/overview-of-taxation.md
@@ -79,7 +79,7 @@ An order's `tax_address` can – through [duck typing][duck-typing] – be a
 `Spree::TaxLocation` instead of the shipping address. The tax location is
 computed from the store's `Spree.config.cart_tax_country_iso` setting.
 
-Note that you can only trust the tax address it is has a country. The other
+Note that you can only trust the tax address if it has a country. The other
 address fields might be empty or raise errors.
 
 <!-- TODO:


### PR DESCRIPTION
This PR intends to fix a several typos and misspellings in the `guides` folder.