### PR TITLE
Fix fieldset legend position in Firefox

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/templates/variants/autocomplete_stock.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/variants/autocomplete_stock.hbs
@@ -1,5 +1,5 @@
 <fieldset class="no-border-bottom">
-  <legend align="center">{{ t "select_stock" }}</legend>
+  <legend>{{ t "select_stock" }}</legend>
     <table class="stock-levels" data-hook="stock-levels">
       <colgroup>
         <col style="width: 30%;" />

--- a/backend/app/assets/javascripts/spree/backend/templates/variants/line_items_autocomplete_stock.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/variants/line_items_autocomplete_stock.hbs
@@ -19,7 +19,7 @@
   </table>
 
   <fieldset class="no-border-bottom">
-    <legend align="center" class="stock-location">
+    <legend class="stock-location">
       <button class="add_variant" title="{{ t "add" }}" data-action="add">{{ t "add" }}</button>
     </legend>
   </fieldset>

--- a/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
@@ -153,8 +153,9 @@ span.info {
 fieldset {
   border: 1px solid $color-border;
   position: relative;
+  margin-top: 2.5rem;
   margin-bottom: 35px;
-  padding: 10px 0 15px 0;
+  padding: 2rem 0 1.25rem 0;
   border-left: none;
   border-right: none;
 
@@ -172,12 +173,17 @@ fieldset {
   }
 
   legend {
+    position: absolute;
+    left: 50%;
+    top: -1.75rem;
+    transform: translateX(-50%);
     color: $color-2;
     font-size: 16px;
     font-weight: $font-weight-bold;
     text-align: center;
     padding: 8px 15px;
     width: auto;
+    background-color: $body-bg;
 
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;

--- a/backend/app/views/spree/admin/customer_returns/edit.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/edit.html.erb
@@ -8,28 +8,28 @@
 
 <% if @manual_intervention_return_items.any? %>
   <fieldset data-hook="manual_intervention_return_items" class="no-border-bottom">
-    <legend align="center"><%= t('spree.manual_intervention_required') %></legend>
+    <legend><%= t('spree.manual_intervention_required') %></legend>
     <%= render partial: 'return_item_decision', locals: {return_items: @manual_intervention_return_items, show_decision: true} %>
   </fieldset>
 <% end %>
 
 <% if @pending_return_items.any? %>
   <fieldset data-hook="pending_return_items" class="no-border-bottom">
-    <legend align="center"><%= t('spree.pending') %></legend>
+    <legend><%= t('spree.pending') %></legend>
     <%= render partial: 'return_item_decision', locals: {return_items: @pending_return_items, show_decision: true} %>
   </fieldset>
 <% end %>
 
 <% if @accepted_return_items.any? %>
   <fieldset data-hook="accepted_return_items" class="no-border-bottom">
-    <legend align="center"><%= t('spree.accepted') %></legend>
+    <legend><%= t('spree.accepted') %></legend>
     <%= render partial: 'return_item_decision', locals: {return_items: @accepted_return_items, show_decision: false} %>
   </fieldset>
 <% end %>
 
 <% if @rejected_return_items.any? %>
   <fieldset data-hook="rejected_return_items" class="no-border-bottom">
-    <legend align="center"><%= t('spree.rejected') %></legend>
+    <legend><%= t('spree.rejected') %></legend>
     <%= render partial: 'return_item_decision', locals: {return_items: @rejected_return_items, show_decision: false} %>
   </fieldset>
 <% end %>
@@ -52,7 +52,7 @@
 <% end %>
 
 <fieldset data-hook="reimbursements" class="no-border-bottom">
-  <legend align="center"><%= plural_resource_name(Spree::Reimbursement) %></legend>
+  <legend><%= plural_resource_name(Spree::Reimbursement) %></legend>
   <% if @customer_return.reimbursements.any? %>
     <%= render partial: 'reimbursements_table', locals: {reimbursements: @customer_return.reimbursements} %>
   <% else %>

--- a/backend/app/views/spree/admin/customer_returns/new.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/new.html.erb
@@ -14,7 +14,7 @@
     <fieldset class="no-border-top">
       <div data-hook="admin_customer_return_form_fields">
         <fieldset class='no-border-bottom'>
-          <legend align='center'><%= t('spree.items_in_rmas') %></legend>
+          <legend><%= t('spree.items_in_rmas') %></legend>
           <% if @rma_return_items.any? %>
             <%= render partial: 'return_item_selection', locals: {f: f, return_items: @rma_return_items} %>
           <% else %>
@@ -23,7 +23,7 @@
         </fieldset>
 
         <fieldset class='no-border-bottom'>
-          <legend align='center'><%= t('spree.other_items_in_other') %></legend>
+          <legend><%= t('spree.other_items_in_other') %></legend>
           <% if @new_return_items.any? %>
             <%= render partial: 'return_item_selection', locals: {f: f, return_items: @new_return_items} %>
           <% else %>

--- a/backend/app/views/spree/admin/images/_new.html.erb
+++ b/backend/app/views/spree/admin/images/_new.html.erb
@@ -1,6 +1,6 @@
 <%= form_for [:admin, product, image], html: { multipart: true } do |f| %>
   <fieldset data-hook="new_image">
-    <legend align="center"><%= t('spree.new_image') %></legend>
+    <legend><%= t('spree.new_image') %></legend>
 
       <%= render partial: 'form', locals: { f: f } %>
 

--- a/backend/app/views/spree/admin/images/edit.html.erb
+++ b/backend/app/views/spree/admin/images/edit.html.erb
@@ -12,7 +12,7 @@
 
 <%= form_for [:admin, @product, @image], html: { multipart: true } do |f| %>
   <fieldset data-hook="edit_image">
-    <legend align="center"><%= @image.attachment_file_name%></legend>
+    <legend><%= @image.attachment_file_name%></legend>
 
     <div class="row">
       <div data-hook="thumbnail" class="field col-2 align-center">

--- a/backend/app/views/spree/admin/images/index.html.erb
+++ b/backend/app/views/spree/admin/images/index.html.erb
@@ -14,7 +14,7 @@
 </div>
 
 <fieldset class="no-border-bottom">
-  <legend align="center"><%= t(".upload_images") %></legend>
+  <legend><%= t(".upload_images") %></legend>
 
   <div id="upload-zone">
     <%= form_for [:admin, @product, Spree::Image.new],

--- a/backend/app/views/spree/admin/option_types/new.html.erb
+++ b/backend/app/views/spree/admin/option_types/new.html.erb
@@ -2,7 +2,7 @@
 
 <%= form_for [:admin, @option_type] do |f| %>
   <fieldset>
-    <legend align="center"><%= t('spree.new_option_type') %></legend>
+    <legend><%= t('spree.new_option_type') %></legend>
     <%= render partial: 'form', locals: { f: f } %>
     <%= render partial: 'spree/admin/shared/new_resource_links' %>
   </fieldset>

--- a/backend/app/views/spree/admin/orders/_add_product.html.erb
+++ b/backend/app/views/spree/admin/orders/_add_product.html.erb
@@ -1,6 +1,6 @@
 <div id="add-line-item" class="js-shipment-add-variant" data-hook>
   <fieldset class="no-border-bottom">
-    <legend align="center"><%= t('spree.add_product') %></legend>
+    <legend><%= t('spree.add_product') %></legend>
 
     <div data-hook="add_product_name" class="field">
       <%= label_tag :add_variant_id, t('spree.name_or_sku') %>

--- a/backend/app/views/spree/admin/orders/_carton.html.erb
+++ b/backend/app/views/spree/admin/orders/_carton.html.erb
@@ -1,6 +1,6 @@
 <div id="<%= dom_id(carton) %>" data-hook="admin_carton_form">
   <fieldset class="no-border-bottom">
-    <legend align="center" class="stock-location" data-hook="stock-location">
+    <legend class="stock-location" data-hook="stock-location">
       <span class="carton-number"><%= carton.number %></span>
       -
       <span class="carton-state"><%= t('spree.shipment_states.shipped') %></span>

--- a/backend/app/views/spree/admin/orders/_shipment.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment.html.erb
@@ -6,7 +6,7 @@
 
 <div id="<%= "shipment_#{shipment.id}" %>" class="js-shipment-edit" data-hook="admin_shipment_form">
   <fieldset class="no-border-bottom">
-    <legend align="center" class="stock-location" data-hook="stock-location">
+    <legend class="stock-location" data-hook="stock-location">
       <span class="shipment-number"><%= shipment.number %></span>
       -
       <span class="shipment-state"><%= t(shipment.state, scope: "spree.shipment_states") %></span>

--- a/backend/app/views/spree/admin/orders/confirm/_customer_details.html.erb
+++ b/backend/app/views/spree/admin/orders/confirm/_customer_details.html.erb
@@ -7,7 +7,7 @@
   <div class="row">
     <div data-hook="bill_address_wrapper" class="col-6">
       <fieldset class="no-border-bottom">
-        <legend align="center"><%= t('spree.billing_address') %></legend>
+        <legend><%= t('spree.billing_address') %></legend>
         <% if order.bill_address %>
           <%= render partial: 'spree/admin/shared/address', locals: {address: order.bill_address} %>
         <% end %>
@@ -16,7 +16,7 @@
 
     <div class="col-6" data-hook="ship_address_wrapper">
       <fieldset class="no-border-bottom">
-        <legend align="center"><%= t('spree.shipping_address') %></legend>
+        <legend><%= t('spree.shipping_address') %></legend>
         <% if order.ship_address %>
           <%= render partial: 'spree/admin/shared/address', locals: {address: order.ship_address} %>
         <% end %>

--- a/backend/app/views/spree/admin/orders/confirm/_shipment.html.erb
+++ b/backend/app/views/spree/admin/orders/confirm/_shipment.html.erb
@@ -1,6 +1,6 @@
 <div id="<%= "shipment_#{shipment.id}" %>" data-hook="admin_shipment_form">
   <fieldset class="no-border-bottom">
-    <legend align="center" class="stock-location" data-hook="stock-location">
+    <legend class="stock-location" data-hook="stock-location">
       <%= Spree::Shipment.model_name.human %>
       <span class="shipment-number"><%= shipment.number %></span>
       <%= t('spree.from') %>

--- a/backend/app/views/spree/admin/orders/customer_details/_form.html.erb
+++ b/backend/app/views/spree/admin/orders/customer_details/_form.html.erb
@@ -1,7 +1,7 @@
 <fieldset data-hook="admin_customer_detail_form_fields" class="no-border-top">
 
   <fieldset class="index no-border-bottom" data-hook="customer_guest">
-    <legend align="center"><%= t('spree.account') %></legend>
+    <legend><%= t('spree.account') %></legend>
 
     <div data-hook="customer_fields" class="row">
       <div class="col-9">
@@ -43,7 +43,7 @@
   <div class="row">
     <div class="col-6" data-hook="ship_address_wrapper">
       <fieldset class="no-border-bottom">
-        <legend align="center"><%= t('spree.shipping_address') %></legend>
+        <legend><%= t('spree.shipping_address') %></legend>
         <% if Spree::Config[:order_bill_address_used] %>
           <div class="field">
             <span data-hook="use_billing">
@@ -66,7 +66,7 @@
     <% if Spree::Config[:order_bill_address_used] %>
       <div class="col-6" data-hook="bill_address_wrapper">
         <fieldset class="no-border-bottom">
-          <legend align="center"><%= t('spree.billing_address') %></legend>
+          <legend><%= t('spree.billing_address') %></legend>
           <div class="js-billing-address">
             <%= f.fields_for :bill_address do |ba_form| %>
               <%= render partial: 'spree/admin/shared/address_form', locals: { f: ba_form, type: "billing" } %>

--- a/backend/app/views/spree/admin/orders/customer_details/edit.html.erb
+++ b/backend/app/views/spree/admin/orders/customer_details/edit.html.erb
@@ -9,7 +9,7 @@
 <div class="js-customer-details" data-order-number="<%= @order.number %>">
   <div id="select-customer" data-hook>
     <fieldset class="no-border-bottom">
-      <legend align="center"><%= t('spree.customer_search') %></legend>
+      <legend><%= t('spree.customer_search') %></legend>
       <%= hidden_field_tag :customer_search,  nil, class: 'fullwidth title' %>
     </fieldset>
   </div>

--- a/backend/app/views/spree/admin/payments/index.html.erb
+++ b/backend/app/views/spree/admin/payments/index.html.erb
@@ -17,13 +17,13 @@
 <% if @payments.any? %>
 
   <fieldset data-hook="payment_list" class="no-border-bottom">
-    <legend align="center"><%= plural_resource_name(Spree::Payment) %></legend>
+    <legend><%= plural_resource_name(Spree::Payment) %></legend>
     <%= render partial: 'list', locals: { payments: @payments } %>
   </fieldset>
 
   <% if @refunds.any? %>
     <fieldset data-hook="payment_list" class="no-border-bottom">
-      <legend align="center"><%= plural_resource_name(Spree::Refund) %></legend>
+      <legend><%= plural_resource_name(Spree::Refund) %></legend>
       <%= render partial: 'spree/admin/shared/refunds', locals: { refunds: @refunds, show_actions: true } %>
     </fieldset>
   <% end %>

--- a/backend/app/views/spree/admin/payments/source_views/_gateway.html.erb
+++ b/backend/app/views/spree/admin/payments/source_views/_gateway.html.erb
@@ -1,5 +1,5 @@
 <fieldset data-hook="credit_card">
-  <legend align="center"><%= Spree::CreditCard.model_name.human %></legend>
+  <legend><%= Spree::CreditCard.model_name.human %></legend>
 
   <div class="row">
     <div class="col-4">

--- a/backend/app/views/spree/admin/payments/source_views/_storecredit.html.erb
+++ b/backend/app/views/spree/admin/payments/source_views/_storecredit.html.erb
@@ -1,5 +1,5 @@
 <fieldset data-hook="store-credit">
-  <legend align="center"><%= Spree::StoreCredit.model_name.human %></legend>
+  <legend><%= Spree::StoreCredit.model_name.human %></legend>
 
   <div class="row">
     <div class="col-4">

--- a/backend/app/views/spree/admin/prices/_master_variant_table.html.erb
+++ b/backend/app/views/spree/admin/prices/_master_variant_table.html.erb
@@ -2,7 +2,7 @@
   <div class="col-12">
     <fieldset class="no-border-bottom <%= "no-border-top" if !variants %>">
       <% if variants %>
-        <legend align="center"><%= I18n.t(:master_variant, scope: :spree) %> <%= admin_hint I18n.t(:master_variant, scope: :spree), I18n.t(:master_variant, scope: [:spree, :hints, "spree/price"]) %></legend>
+        <legend><%= I18n.t(:master_variant, scope: :spree) %> <%= admin_hint I18n.t(:master_variant, scope: :spree), I18n.t(:master_variant, scope: [:spree, :hints, "spree/price"]) %></legend>
       <% end %>
       <table class="index master_prices">
         <colgroup>

--- a/backend/app/views/spree/admin/prices/_table.html.erb
+++ b/backend/app/views/spree/admin/prices/_table.html.erb
@@ -1,7 +1,7 @@
 <%= paginate variant_prices, theme: "solidus_admin" %>
 
 <fieldset class="no-border-bottom">
-  <legend align="center"><%= I18n.t(:variant_pricing, scope: :spree) %></legend>
+  <legend><%= I18n.t(:variant_pricing, scope: :spree) %></legend>
   <table class="index prices">
     <thead data-hook="prices_header">
       <tr>

--- a/backend/app/views/spree/admin/product_properties/index.html.erb
+++ b/backend/app/views/spree/admin/product_properties/index.html.erb
@@ -15,7 +15,7 @@
 
 <%= form_for @product, url: admin_product_url(@product), method: :put do |f| %>
   <fieldset>
-    <legend align="center"><%= plural_resource_name(Spree::ProductProperty) %></legend>
+    <legend><%= plural_resource_name(Spree::ProductProperty) %></legend>
     <div class="add_product_properties" data-hook="add_product_properties"></div>
 
     <table class="index sortable" data-hook data-sortable-link="<%= update_positions_admin_product_product_properties_url %>">
@@ -44,7 +44,7 @@
 
 <%= form_tag admin_product_product_properties_path, method: :get, id: 'variant_option_value_selections' do %>
   <fieldset class='no-border-bottom'>
-    <legend align="center"><%= t('spree.variant_properties') %></legend>
+    <legend><%= t('spree.variant_properties') %></legend>
     <fieldset class='no-border-top'>
       <% @option_types.each do |option_type, option_values| %>
         <div class="field">

--- a/backend/app/views/spree/admin/products/new.html.erb
+++ b/backend/app/views/spree/admin/products/new.html.erb
@@ -5,7 +5,7 @@
 
 <%= form_for [:admin, @product], method: :post, url: admin_products_path, html: { multipart: true } do |f| %>
   <fieldset data-hook="new_product">
-    <legend align="center"><%= t('spree.new_product') %></legend>
+    <legend><%= t('spree.new_product') %></legend>
 
     <%= render partial: 'form', locals: { f: f } %>
 

--- a/backend/app/views/spree/admin/promotions/_actions.html.erb
+++ b/backend/app/views/spree/admin/promotions/_actions.html.erb
@@ -3,7 +3,7 @@
   <%= form_tag spree.admin_promotion_promotion_actions_path(@promotion), remote: true, id: 'new_promotion_action_form' do %>
     <% options = options_for_select(  Rails.application.config.spree.promotions.actions.map {|action| [ action.model_name.human, action.name] } ) %>
     <fieldset>
-      <legend align="center"><%= t('spree.promotion_actions') %></legend>
+      <legend><%= t('spree.promotion_actions') %></legend>
       <% if can?(:update, @promotion) %>
         <div class="field">
           <%= label_tag :action_type, t('spree.add_action_of_type')%>

--- a/backend/app/views/spree/admin/promotions/_rules.html.erb
+++ b/backend/app/views/spree/admin/promotions/_rules.html.erb
@@ -2,7 +2,7 @@
 
   <%= form_tag spree.admin_promotion_promotion_rules_path(@promotion), remote: true, id: 'new_product_rule_form' do %>
     <fieldset>
-      <legend align="center"><%= t('spree.rules') %></legend>
+      <legend><%= t('spree.rules') %></legend>
 
       <% if can?(:update, @promotion) %>
         <div class="field">

--- a/backend/app/views/spree/admin/properties/new.html.erb
+++ b/backend/app/views/spree/admin/properties/new.html.erb
@@ -2,7 +2,7 @@
 
 <%= form_for [:admin, @property] do |f| %>
 <fieldset data-hook="new_property">
-  <legend align="center"><%= t('spree.new_property') %></legend>
+  <legend><%= t('spree.new_property') %></legend>
   <%= render partial: 'form', locals: { f: f } %>
   <div class="filter-actions">
     <%= render partial: 'spree/admin/shared/new_resource_links' %>

--- a/backend/app/views/spree/admin/reimbursements/edit.html.erb
+++ b/backend/app/views/spree/admin/reimbursements/edit.html.erb
@@ -11,7 +11,7 @@
 
 <%= form_for [:admin, @order, @reimbursement] do |f| %>
   <fieldset class='no-border-bottom'>
-    <legend align='center'><%= t('spree.items_to_be_reimbursed') %></legend>
+    <legend><%= t('spree.items_to_be_reimbursed') %></legend>
     <table class="index reimbursement-return-items">
       <thead>
         <tr>
@@ -71,7 +71,7 @@
 <% end %>
 
 <fieldset>
-  <legend align='center'><%= t('spree.calculated_reimbursements') %></legend>
+  <legend><%= t('spree.calculated_reimbursements') %></legend>
   <table class="index calculated-reimbursements">
     <thead data-hook="customer_return_header">
       <tr>

--- a/backend/app/views/spree/admin/reimbursements/show.html.erb
+++ b/backend/app/views/spree/admin/reimbursements/show.html.erb
@@ -10,7 +10,7 @@
 <%= render partial: 'spree/shared/error_messages', locals: { target: @reimbursement } %>
 
 <fieldset class='no-border-bottom'>
-  <legend align='center'><%= t('spree.items_reimbursed') %></legend>
+  <legend><%= t('spree.items_reimbursed') %></legend>
   <table class="index reimbursement-reimbursement-items">
     <thead>
       <tr>
@@ -53,7 +53,7 @@
 </fieldset>
 
 <fieldset class="no-border-bottom">
-  <legend align='center'><%= Spree::Refund.model_name.human %></legend>
+  <legend><%= Spree::Refund.model_name.human %></legend>
   <table class="index reimbursement-refunds">
     <thead data-hook="customer_return_header">
       <tr>
@@ -73,7 +73,7 @@
 </fieldset>
 
 <fieldset class="no-border-bottom">
-  <legend align='center'><%= t('spree.credits') %></legend>
+  <legend><%= t('spree.credits') %></legend>
   <table class="index reimbursement-credits">
     <thead data-hook="customer_return_header">
       <tr>

--- a/backend/app/views/spree/admin/shared/_calculator_fields.html.erb
+++ b/backend/app/views/spree/admin/shared/_calculator_fields.html.erb
@@ -1,5 +1,5 @@
 <fieldset id="calculator_fields" class="js-calculator-fields no-border-bottom">
-  <legend align="center"><%= Spree::Calculator.model_name.human %></legend>
+  <legend><%= Spree::Calculator.model_name.human %></legend>
 
   <div id="preference-settings">
     <div class="field">

--- a/backend/app/views/spree/admin/shared/_table_filter.html.erb
+++ b/backend/app/views/spree/admin/shared/_table_filter.html.erb
@@ -1,7 +1,7 @@
 <% if content_for?(:table_filter) %>
   <div id="table-filter" data-hook>
     <fieldset>
-      <legend align="center"><%= yield :table_filter_title %></legend>
+      <legend><%= yield :table_filter_title %></legend>
       <%= yield :table_filter %>
     </fieldset>
   </div>

--- a/backend/app/views/spree/admin/shipping_methods/_form.html.erb
+++ b/backend/app/views/spree/admin/shipping_methods/_form.html.erb
@@ -68,7 +68,7 @@
   <div class="col-5">
     <div data-hook="admin_shipping_method_form_availability_fields">
       <fieldset class="categories no-border-bottom">
-        <legend align="center"><%= plural_resource_name(Spree::ShippingCategory) %></legend>
+        <legend><%= plural_resource_name(Spree::ShippingCategory) %></legend>
         <%= f.field_container :categories do %>
           <% Spree::ShippingCategory.all.each do |category| %>
             <label>
@@ -83,7 +83,7 @@
 
     <div>
       <fieldset class="no-border-bottom">
-        <legend align="center"><%= plural_resource_name(Spree::Zone) %></legend>
+        <legend><%= plural_resource_name(Spree::Zone) %></legend>
         <%= f.field_container :zones do %>
           <% shipping_method_zones = @shipping_method.zones.to_a %>
           <% Spree::Zone.all.each do |zone| %>
@@ -104,7 +104,7 @@
     </div>
     <div>
       <fieldset class="tax_categories no-border-bottom">
-        <legend align="center"><%= Spree::TaxCategory.model_name.human %></legend>
+        <legend><%= Spree::TaxCategory.model_name.human %></legend>
           <%= f.field_container :tax_categories do %>
             <%= f.select :tax_category_id, @tax_categories.map { |tc| [tc.name, tc.id] }, {include_blank: true}, class: "custom-select fullwidth" %>
             <%= error_message_on :shipping_method, :tax_category_id %>

--- a/backend/app/views/spree/admin/store_credits/edit_amount.html.erb
+++ b/backend/app/views/spree/admin/store_credits/edit_amount.html.erb
@@ -12,7 +12,7 @@
 
 <%= form_for [:admin, @user, @store_credit], url: update_amount_admin_user_store_credit_path, method: :put do |f| %>
   <fieldset>
-    <legend align="center"><%= t('spree.admin.store_credits.edit_amount') %></legend>
+    <legend><%= t('spree.admin.store_credits.edit_amount') %></legend>
     <div data-hook="admin_store_credit_form_fields" class="row">
       <div class="col-6">
         <%= f.field_container :amount do %>

--- a/backend/app/views/spree/admin/store_credits/edit_validity.html.erb
+++ b/backend/app/views/spree/admin/store_credits/edit_validity.html.erb
@@ -12,7 +12,7 @@
 
 <%= form_for [:admin, @user, @store_credit], url: invalidate_admin_user_store_credit_path, method: :put do |f| %>
   <fieldset>
-    <legend align="center"><%= t('spree.admin.store_credits.invalidate_store_credit') %></legend>
+    <legend><%= t('spree.admin.store_credits.invalidate_store_credit') %></legend>
     <div data-hook="admin_store_credit_form_fields" class="row">
       <div class="col-12">
         <%= render partial: 'update_reason_field', locals: { f: f } %>

--- a/backend/app/views/spree/admin/store_credits/new.html.erb
+++ b/backend/app/views/spree/admin/store_credits/new.html.erb
@@ -11,7 +11,7 @@
 
 <%= form_for [:admin, @user, @store_credit] do |f| %>
   <fieldset>
-    <legend align="center"><%= t('spree.admin.store_credits.new') %></legend>
+    <legend><%= t('spree.admin.store_credits.new') %></legend>
     <%= render partial: 'form', locals: { f: f } %>
     <%= render partial: 'spree/admin/shared/new_resource_links', locals: { collection_url: admin_user_store_credits_path(@user) } %>
   </fieldset>

--- a/backend/app/views/spree/admin/store_credits/show.html.erb
+++ b/backend/app/views/spree/admin/store_credits/show.html.erb
@@ -66,7 +66,7 @@
 </table>
 
 <fieldset class="no-border-bottom">
-  <legend align='center'><%= t('spree.admin.store_credits.history') %></legend>
+  <legend><%= t('spree.admin.store_credits.history') %></legend>
   <table>
     <colgroup>
       <col style="width: 20%;" />

--- a/backend/app/views/spree/admin/style_guide/topics/forms/_building_forms.html.erb
+++ b/backend/app/views/spree/admin/style_guide/topics/forms/_building_forms.html.erb
@@ -2,7 +2,7 @@
 <%- snippet = capture do %>
   <form id="table-filter">
     <fieldset>
-      <legend align="center">Search</legend>
+      <legend>Search</legend>
       <div class="row">
         <div class="field-block col-3">
           <div class="field">

--- a/backend/app/views/spree/admin/tax_rates/_form.html.erb
+++ b/backend/app/views/spree/admin/tax_rates/_form.html.erb
@@ -1,6 +1,6 @@
 <div data-hook="admin_tax_rate_form_fields">
     <fieldset data-hook="tax_rates" class=" no-border-bottom">
-      <legend align="center"><%= t('spree.general_settings') %></legend>
+      <legend><%= t('spree.general_settings') %></legend>
       <div class="row">
 
         <div class="col-5">

--- a/backend/app/views/spree/admin/users/_addresses_form.html.erb
+++ b/backend/app/views/spree/admin/users/_addresses_form.html.erb
@@ -1,8 +1,8 @@
 <div class="row">
-    
+
   <div data-hook="bill_address_wrapper" class="col-6">
     <fieldset class="no-border-bottom">
-      <legend align="center"><%= t('spree.billing_address') %></legend>
+      <legend><%= t('spree.billing_address') %></legend>
       <%= f.fields_for :bill_address, @user.bill_address || Spree::Address.build_default do |ba_form| %>
         <%= render partial: 'spree/admin/shared/address_form', locals: { f: ba_form, type: "billing" } %>
       <% end %>
@@ -11,7 +11,7 @@
 
   <div data-hook="ship_address_wrapper" class="col-6">
     <fieldset class="no-border-bottom">
-      <legend align="center"><%= t('spree.shipping_address') %></legend>
+      <legend><%= t('spree.shipping_address') %></legend>
       <%= f.fields_for :ship_address, @user.ship_address || Spree::Address.build_default do |sa_form| %>
         <%= render partial: 'spree/admin/shared/address_form', locals: { f: sa_form, type: "shipping" } %>
       <% end %>

--- a/backend/app/views/spree/admin/zones/_country_members.html.erb
+++ b/backend/app/views/spree/admin/zones/_country_members.html.erb
@@ -1,6 +1,6 @@
 <div id="country_members" data-hook="member">
   <fieldset class="no-border-bottom">
-    <legend align="center"><%= plural_resource_name(Spree::Country) %></legend>
+    <legend><%= plural_resource_name(Spree::Country) %></legend>
 
     <%= zone_form.field_container :country_ids do %>
       <%= zone_form.label :country_ids, plural_resource_name(Spree::Country) %><br>

--- a/backend/app/views/spree/admin/zones/_form.html.erb
+++ b/backend/app/views/spree/admin/zones/_form.html.erb
@@ -3,7 +3,7 @@
 
     <div data-hook="admin_zone_form_fields">
       <fieldset class="no-border-bottom">
-        <legend align="center"><%= t('spree.general_settings')%></legend>
+        <legend><%= t('spree.general_settings')%></legend>
 
         <%= zone_form.field_container :name do %>
           <%= zone_form.label :name %><br />

--- a/backend/app/views/spree/admin/zones/_state_members.html.erb
+++ b/backend/app/views/spree/admin/zones/_state_members.html.erb
@@ -1,6 +1,6 @@
 <div id="state_members" data-hook="member">
   <fieldset class="no-border-bottom">
-    <legend align="center"><%= plural_resource_name(Spree::State) %></legend>
+    <legend><%= plural_resource_name(Spree::State) %></legend>
 
     <%= zone_form.field_container :state_ids do %>
       <%= zone_form.label :state_ids, plural_resource_name(Spree::State) %><br>

--- a/frontend/app/views/spree/checkout/_address.html.erb
+++ b/frontend/app/views/spree/checkout/_address.html.erb
@@ -1,7 +1,7 @@
 <div class="columns alpha six" data-hook="billing_fieldset_wrapper">
   <fieldset id="billing" data-hook>
     <%= form.fields_for :bill_address do |bill_form| %>
-      <legend align="center"><%= t('spree.billing_address') %></legend>
+      <legend><%= t('spree.billing_address') %></legend>
       <%= render partial: 'spree/address/form', locals: { form: bill_form, address_type: 'billing', address: @order.bill_address } %>
     <% end %>
   </fieldset>
@@ -10,7 +10,7 @@
 <div class="columns omega six" data-hook="shipping_fieldset_wrapper">
   <fieldset id="shipping" data-hook>
     <%= form.fields_for :ship_address do |ship_form| %>
-      <legend align="center"><%= t('spree.shipping_address') %></legend>
+      <legend><%= t('spree.shipping_address') %></legend>
       <div class="checkbox" data-hook="use_billing">
         <%= check_box_tag 'order[use_billing]', '1', @order.shipping_eq_billing_address? %>
         <%= label_tag :order_use_billing, t('spree.use_billing_address'), id: 'use_billing' %>

--- a/frontend/app/views/spree/checkout/_confirm.html.erb
+++ b/frontend/app/views/spree/checkout/_confirm.html.erb
@@ -1,6 +1,6 @@
 <fieldset id="order_details" data-hook>
   <div class="clear"></div>
-  <legend align="center"><%= t('spree.confirm') %></legend>
+  <legend><%= t('spree.confirm') %></legend>
   <%= render partial: 'spree/shared/order_details', locals: { order: @order } %>
 </fieldset>
 

--- a/frontend/app/views/spree/checkout/_delivery.html.erb
+++ b/frontend/app/views/spree/checkout/_delivery.html.erb
@@ -1,5 +1,5 @@
 <fieldset id='shipping_method' data-hook>
-  <legend align="center"><%= t('spree.delivery') %></legend>
+  <legend><%= t('spree.delivery') %></legend>
   <div class="inner" data-hook="shipping_method_inner">
     <div id="methods">
       <%= form.fields_for :shipments do |ship_form| %>

--- a/frontend/app/views/spree/checkout/_payment.html.erb
+++ b/frontend/app/views/spree/checkout/_payment.html.erb
@@ -1,5 +1,5 @@
 <fieldset id="payment" data-hook>
-  <legend align="center"><%= t('spree.payment_information') %></legend>
+  <legend><%= t('spree.payment_information') %></legend>
   <div data-hook="checkout_payment_step">
     <% if @wallet_payment_sources.present? %>
       <div class="card_options">


### PR DESCRIPTION
Fieldset legends are a weird html tag as they have magic layout attrobutes that are different in every browser. This unifies them with less css as possible.

### Before

![screenshot-2018-5-3 default - stock locations - shipping - settings](https://user-images.githubusercontent.com/42868/39576236-c2d31048-4edd-11e8-8fc9-8c0e345e38c8.png)

### After

![screenshot-2018-5-3 default - stock locations - shipping - settings 1](https://user-images.githubusercontent.com/42868/39576235-c2b6b43e-4edd-11e8-958b-476e7e5f65aa.png)
