### PR TITLE
Require sass >= 3.5.2

### DIFF
--- a/backend/solidus_backend.gemspec
+++ b/backend/solidus_backend.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'jquery-rails'
   s.add_dependency 'kaminari', '~> 1.1'
   s.add_dependency 'sass-rails'
+  s.add_dependency 'sass', '>= 3.5.2'
 
   s.add_dependency 'autoprefixer-rails', '~> 7.1'
   s.add_dependency 'handlebars_assets', '~> 0.23'


### PR DESCRIPTION
Bootstrap 4.x requires at least sass 3.5.2.

For more information see:
https://github.com/twbs/bootstrap-rubygem/pull/122
https://github.com/sass/sass/issues/2383