### PR TITLE
Remove promotions admin UI that misleadingly doesn't do anything on the solidus_frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Solidus 2.7.0 (master, unreleased)
 
+### Admin
+
+- The promotions "Advertise" checkbox and the "URL Path" promotion activation method have been removed from the admin UI because the features are not implemented in solidus_frontend [#2737](https://github.com/solidusio/solidus/pull/2737) ([benjaminwil](https://github.com/benjaminwil)
+
 ## Solidus 2.6.0 (2018-05-16)
 
 ### Major changes

--- a/backend/app/views/spree/admin/promotions/_activations_new.html.erb
+++ b/backend/app/views/spree/admin/promotions/_activations_new.html.erb
@@ -19,12 +19,6 @@
         <%= t('.multiple_codes') %>
       </label>
     </div>
-    <div class="form-check">
-      <label class="form-check-label">
-        <%= radio_button_tag('activation_type', 'path', activation_type == 'path') %>
-        <%= t('.path') %>
-      </label>
-    </div>
   </div>
   <div class="col-9">
     <input name="promotion[apply_automatically]" type="hidden" value="0">
@@ -60,11 +54,5 @@
       <% end %>
     </div>
 
-    <div data-activation-type="path">
-      <div class="field" id="promotion_path_field">
-        <%= f.label :path, class: "required" %>
-        <%= f.text_field :path, class: "fullwidth", required: true %>
-      </div>
-    </div>
   </div>
 </div>

--- a/backend/app/views/spree/admin/promotions/_form.html.erb
+++ b/backend/app/views/spree/admin/promotions/_form.html.erb
@@ -5,21 +5,12 @@
   <div class="row">
     <div id="general_fields" class="col-9">
       <div class="row">
-        <div class="col-3">
+        <div class="col-12">
           <%= f.field_container :name do %>
             <%= f.label :name, class: 'required' %>
             <%= f.text_field :name, class: 'fullwidth', required: true %>
           <% end %>
 
-          <%= f.field_container :advertise do %>
-            <label>
-              <%= f.check_box :advertise %>
-              <%= Spree::Promotion.human_attribute_name :advertise %>
-            </label>
-          <% end %>
-        </div>
-
-        <div class="col-9">
           <%= f.field_container :description do %>
             <%= f.label :description %><br />
             <%= f.text_area :description, rows: 7, class: 'fullwidth' %>

--- a/backend/spec/features/admin/promotion_adjustments_spec.rb
+++ b/backend/spec/features/admin/promotion_adjustments_spec.rb
@@ -180,20 +180,6 @@ describe "Promotion Adjustments", type: :feature, js: true do
       expect(promotion.rules).to be_blank
     end
 
-    it "should allow an admin to create a promo requiring a landing page to be visited" do
-      fill_in "Name", with: "SAVE SAVE SAVE"
-      choose "URL Path"
-      fill_in "Path", with: "content/cvv"
-      click_button "Create"
-      expect(page).to have_title("SAVE SAVE SAVE - Promotions")
-
-      promotion = Spree::Promotion.find_by(name: "SAVE SAVE SAVE")
-      expect(promotion.path).to eq("content/cvv")
-      expect(promotion).not_to be_apply_automatically
-      expect(promotion.codes).to be_empty
-      expect(promotion.rules).to be_blank
-    end
-
     it "should allow an admin to create a promo with generated codes" do
       fill_in "Name", with: "SAVE SAVE SAVE"
       choose "Multiple promotion codes"

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -177,7 +177,6 @@ en:
       spree/product_property:
         value: Value
       spree/promotion:
-        advertise: Advertise
         apply_automatically: Apply Automatically
         code: Code
         description: Description
@@ -185,7 +184,7 @@ en:
         expires_at: End
         name: Name
         path: Path
-        per_code_usage_limit: Per Code Usage Limit
+        per_code_usage_limit: Per code usage limit
         promotion_uses: Promotion Uses
         starts_at: Start
         status: Status
@@ -859,7 +858,6 @@ en:
         activations_new:
           auto: Apply to all orders
           multiple_codes: Multiple promotion codes
-          path: URL Path
           single_code: Single promotion code
         activations_edit:
           auto: All orders will attempt to use this promotion


### PR DESCRIPTION
While the UI I am removing are candidates for useful features, these features are not actually implemented or working on the `solidus_frontend`. I also do not think that the UI really "helps" developers who may want to implement these features or features like them.

I think that we should remove these UI elements for now because they mislead store administrators. When we re-add them to the admin UI, we should make sure that developers have a clear path forward for implementing the features.

