### PR TITLE
Add missing data-hook on customer_returns tab

### DIFF
--- a/backend/app/views/spree/admin/shared/_order_submenu.html.erb
+++ b/backend/app/views/spree/admin/shared/_order_submenu.html.erb
@@ -48,7 +48,7 @@
 
     <% if can? :display, Spree::CustomerReturn %>
       <% if @order.completed? %>
-        <li class="<%= "active" if current == "Customer Returns" %>">
+        <li class="<%= "active" if current == "Customer Returns" %>" data-hook='admin_order_tabs_customer_returns'>
           <%= link_to plural_resource_name(Spree::CustomerReturn), spree.admin_order_customer_returns_url(@order) %>
         </li>
       <% end %>


### PR DESCRIPTION
This missing data-hook will help people trying to customize the orders tab with Deface.

Without the data-hook, there is no way to select the customer_return tab to replace or remove it.

This is my first pull request on solidus, I think I followed the contributing guidelines, let me know if I can improve the PR.