### PR TITLE
Update promotion-rules.md

### DIFF
--- a/guides/promotions/promotion-rules.md
+++ b/guides/promotions/promotion-rules.md
@@ -100,7 +100,7 @@ You must then register the custom rule in an initializer in your
 `config/initializers/` directory:
 
 ```ruby
-Rails.application.config.spree.promotions.rules << MyPromotionRule
+Rails.application.config.spree.promotions.rules << Spree::Promotion::Rules::MyPromotionRule
 ```
 
 <!-- TODO:


### PR DESCRIPTION
Constant needs namespacing otherwise a Name Error is thrown at initialization. Correct registration should be:

Rails.application.config.spree.promotions.rules << Spree::Promotion::Rules::MyPromotionRule