### PR TITLE
Allow `register_ability` to accept strings

### DIFF
--- a/core/app/models/spree/ability.rb
+++ b/core/app/models/spree/ability.rb
@@ -10,7 +10,7 @@ module Spree
     include CanCan::Ability
 
     class_attribute :abilities
-    self.abilities = Set.new
+    self.abilities = Spree::Core::ClassConstantizer::Set.new
 
     attr_reader :user
 

--- a/core/lib/spree/core/class_constantizer.rb
+++ b/core/lib/spree/core/class_constantizer.rb
@@ -10,9 +10,10 @@ module Spree
           @collection = ::Set.new
         end
 
-        def <<(klass)
+        def add(klass)
           @collection << klass.to_s
         end
+        alias << add
 
         def concat(klasses)
           klasses.each do |klass|
@@ -20,7 +21,7 @@ module Spree
           end
         end
 
-        delegate :clear, :empty?, to: :@collection
+        delegate :clear, :delete, :empty?, to: :@collection
 
         def each
           @collection.each do |klass|

--- a/core/spec/models/spree/ability_spec.rb
+++ b/core/spec/models/spree/ability_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Spree::Ability, type: :model do
   let(:token) { nil }
 
   after(:each) {
-    Spree::Ability.abilities = Set.new
+    Spree::Ability.abilities = Spree::Core::ClassConstantizer::Set.new
   }
 
   describe "#initialize" do
@@ -45,12 +45,12 @@ RSpec.describe Spree::Ability, type: :model do
 
   context 'register_ability' do
     it 'should add the ability to the list of abilties' do
-      Spree::Ability.register_ability(FooAbility)
+      Spree::Ability.register_ability('FooAbility')
       expect(Spree::Ability.new(user).abilities).not_to be_empty
     end
 
     it 'should apply the registered abilities permissions' do
-      Spree::Ability.register_ability(FooAbility)
+      Spree::Ability.register_ability('FooAbility')
       expect(Spree::Ability.new(user).can?(:update, mock_model(Spree::Order, user: nil, id: 1))).to be true
     end
   end


### PR DESCRIPTION
This deals with Rails autoloading better and allows classes to be specified
as strings instead of class names.