### PR TITLE
Dynamically render ReportsController translations

### DIFF
--- a/backend/app/controllers/spree/admin/reports_controller.rb
+++ b/backend/app/controllers/spree/admin/reports_controller.rb
@@ -14,7 +14,11 @@ module Spree
           if report_description_key.nil?
             report_description_key = "#{report_key}_description"
           end
-          @@available_reports[report_key] = { name: I18n.t(report_key, scope: 'spree'), description: I18n.t(report_description_key, scope: 'spree') }
+
+          @@available_reports[report_key] = {
+            name: report_key,
+            description: report_description_key,
+          }
         end
       end
 

--- a/backend/app/views/spree/admin/reports/index.html.erb
+++ b/backend/app/views/spree/admin/reports/index.html.erb
@@ -11,8 +11,8 @@
   <tbody>
     <% @reports.each do |key, value| %>
     <tr data-hook="reports_row">
-      <td><%= link_to value[:name], send("#{key}_admin_reports_url".to_sym) %></td>
-      <td><%= value[:description] %></td>
+      <td><%= link_to t(value[:name], scope: 'spree'), send("#{key}_admin_reports_url".to_sym) %></td>
+      <td><%= t(value[:description], scope: 'spree') %></td>
     </tr>
     <% end %>
   </tbody>

--- a/backend/spec/controllers/spree/admin/reports_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/reports_controller_spec.rb
@@ -9,24 +9,16 @@ describe Spree::Admin::ReportsController, type: :controller do
     it 'should contain sales_total' do
       expect(Spree::Admin::ReportsController.available_reports.keys.include?(:sales_total)).to be true
     end
-
-    it 'should have the proper sales total report description' do
-      expect(Spree::Admin::ReportsController.available_reports[:sales_total][:description]).to eql('Sales Total For All Orders')
-    end
   end
 
   describe 'ReportsController.add_available_report!' do
     context 'when adding the report name' do
       it 'should contain the report' do
-        I18n.backend.store_translations(:en, spree: {
-          some_report: 'Awesome Report',
-          some_report_description: 'This report is great!'
-        })
         Spree::Admin::ReportsController.add_available_report!(:some_report)
         expect(Spree::Admin::ReportsController.available_reports.keys.include?(:some_report)).to be true
         expect(Spree::Admin::ReportsController.available_reports[:some_report]).to eq(
-          name: 'Awesome Report',
-          description: 'This report is great!'
+          name: :some_report,
+          description: 'some_report_description'
         )
       end
     end


### PR DESCRIPTION
This PR corrects an issue that occurs when attempting to extend `Spree::Admin::ReportsController` with additional reports. The `ReportsController.add_available_report!` class method currently translates its arguments with `I18n.t` when called, rather than when the `/admin/reports` page is actually rendered.

If additional reports are being decorated onto this controller via `class_eval` or prepended modules, there is a possibility that the `i18n` library has not yet been initialized – this results in static "translation missing" errors in the admin. In particular, this is the case with `config.to_prepare`, which is commonly used to load these kinds of Solidus modifications.

To correct this issue, we can switch to dynamically rendering the translations in the view, rather than generating them statically in the controller at startup.