### PR TITLE
Add Gemfile.lock to docs site project

### DIFF
--- a/guides/Gemfile.lock
+++ b/guides/Gemfile.lock
@@ -1,0 +1,161 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (5.0.7)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
+    ansi (1.5.0)
+    ast (2.4.0)
+    backports (3.11.3)
+    builder (3.2.3)
+    coffee-script (2.4.1)
+      coffee-script-source
+      execjs
+    coffee-script-source (1.12.2)
+    compass-import-once (1.0.5)
+      sass (>= 3.2, < 3.5)
+    concurrent-ruby (1.0.5)
+    contracts (0.13.0)
+    dotenv (2.4.0)
+    erubis (2.7.0)
+    excon (0.62.0)
+    execjs (2.7.0)
+    fast_blank (1.0.0)
+    fastimage (2.1.3)
+    ffi (1.9.23)
+    fog-aws (3.0.0)
+      fog-core (~> 2.1)
+      fog-json (~> 1.1)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
+    fog-core (2.1.0)
+      builder
+      excon (~> 0.58)
+      formatador (~> 0.2)
+      mime-types
+    fog-json (1.1.0)
+      fog-core (~> 2.0)
+      multi_json (~> 1.10)
+    fog-xml (0.1.3)
+      fog-core
+      nokogiri (>= 1.5.11, < 2.0.0)
+    formatador (0.2.5)
+    haml (5.0.4)
+      temple (>= 0.8.0)
+      tilt
+    hamster (3.0.0)
+      concurrent-ruby (~> 1.0)
+    hashie (3.5.7)
+    i18n (0.7.0)
+    ipaddress (0.8.3)
+    kramdown (1.16.2)
+    listen (3.0.8)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+    map (6.6.0)
+    memoist (0.16.0)
+    middleman (4.2.1)
+      coffee-script (~> 2.2)
+      compass-import-once (= 1.0.5)
+      haml (>= 4.0.5)
+      kramdown (~> 1.2)
+      middleman-cli (= 4.2.1)
+      middleman-core (= 4.2.1)
+      sass (>= 3.4.0, < 4.0)
+    middleman-blog (4.0.2)
+      addressable (~> 2.3)
+      middleman-core (~> 4.0)
+      tzinfo (>= 0.3.0)
+    middleman-cli (4.2.1)
+      thor (>= 0.17.0, < 2.0)
+    middleman-core (4.2.1)
+      activesupport (>= 4.2, < 5.1)
+      addressable (~> 2.3)
+      backports (~> 3.6)
+      bundler (~> 1.1)
+      contracts (~> 0.13.0)
+      dotenv
+      erubis
+      execjs (~> 2.0)
+      fast_blank
+      fastimage (~> 2.0)
+      hamster (~> 3.0)
+      hashie (~> 3.4)
+      i18n (~> 0.7.0)
+      listen (~> 3.0.0)
+      memoist (~> 0.14)
+      padrino-helpers (~> 0.13.0)
+      parallel
+      rack (>= 1.4.5, < 3)
+      sass (>= 3.4)
+      servolux
+      tilt (~> 2.0)
+      uglifier (~> 3.0)
+    middleman-s3_sync (4.0.3)
+      ansi (~> 1.5.0)
+      fog-aws (>= 0.1.1)
+      map
+      middleman-cli
+      middleman-core (>= 4.0.0)
+      parallel
+      ruby-progressbar
+      unf
+    mime-types (3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0521)
+    mini_portile2 (2.3.0)
+    minitest (5.11.3)
+    multi_json (1.13.1)
+    nokogiri (1.8.2)
+      mini_portile2 (~> 2.3.0)
+    oga (2.15)
+      ast
+      ruby-ll (~> 2.1)
+    padrino-helpers (0.13.3.4)
+      i18n (~> 0.6, >= 0.6.7)
+      padrino-support (= 0.13.3.4)
+      tilt (>= 1.4.1, < 3)
+    padrino-support (0.13.3.4)
+      activesupport (>= 3.1)
+    parallel (1.12.1)
+    public_suffix (3.0.2)
+    rack (2.0.5)
+    rb-fsevent (0.10.3)
+    rb-inotify (0.9.10)
+      ffi (>= 0.5.0, < 2)
+    redcarpet (3.4.0)
+    ruby-ll (2.1.2)
+      ansi
+      ast
+    ruby-progressbar (1.9.0)
+    sass (3.4.25)
+    servolux (0.13.0)
+    temple (0.8.0)
+    thor (0.20.0)
+    thread_safe (0.3.6)
+    tilt (2.0.8)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
+    uglifier (3.2.0)
+      execjs (>= 0.3.0, < 3)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.5)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  middleman (~> 4.2)
+  middleman-blog (~> 4.0)
+  middleman-s3_sync
+  nokogiri (~> 1.8.1)
+  oga (~> 2.14)
+  redcarpet
+
+BUNDLED WITH
+   1.15.1


### PR DESCRIPTION
This file wasn't included in the initial PR as it was filtered by the `.gitignore` for Solidus.