### PR TITLE
Remove x-overflow rule from admin nav container

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/shared/_layout.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_layout.scss
@@ -38,7 +38,6 @@ body {
 
 .content-main {
   @include make-col(12);
-  overflow-x: hidden; // makes sure that the tabs are able to resize
 
   .has-sidebar & {
     @include make-col(9);


### PR DESCRIPTION
This CSS rule is not needed.

There is JS to handle overflowing tabs inside the Solidus Project that
currently resides in:

https://github.com/solidusio/solidus/blob/master/backend/app/assets/javascripts/spree/backend/components/tabs.js

Furthermore this CSS can cause issues for views. When the `.content-main`
div does not have enough content to be tall enough for the dropdown tab to
fully display a scroll bar is introduced on the right hand side of the page
and looks silly.

## Before
![bad](https://user-images.githubusercontent.com/13607675/40947554-26b096be-6818-11e8-98f6-b2a88ceaf23e.png)


## After
![good](https://user-images.githubusercontent.com/13607675/40947502-d9a2f966-6817-11e8-815d-d79de146ecc6.png)

