### PR TITLE
fix negative total displaying in cart by displaying zero if total is …

### DIFF
--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -12,7 +12,7 @@ module Spree
         text = "#{text}: (#{t('spree.empty')})"
         css_class = 'empty'
       else
-        text = "#{text}: (#{current_order.item_count})  <span class='amount'>#{protect_from_negative(current_order)}</span>"
+        text = "#{text}: (#{current_order.item_count})  <span class='amount'>#{display_order_total(current_order)}</span>"
         css_class = 'full'
       end
 
@@ -157,7 +157,7 @@ module Spree
       resource_class.model_name.human(count: Spree::I18N_GENERIC_PLURAL)
     end
 
-    def protect_from_negative(current_order)
+    def display_order_total(current_order)
       if current_order.total.negative?
         Spree::Money.new(0, currency: current_order.currency).to_html
       else

--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -12,7 +12,7 @@ module Spree
         text = "#{text}: (#{t('spree.empty')})"
         css_class = 'empty'
       else
-        text = "#{text}: (#{current_order.item_count})  <span class='amount'>#{current_order.display_total.to_html}</span>"
+        text = "#{text}: (#{current_order.item_count})  <span class='amount'>#{protect_from_negative(current_order)}</span>"
         css_class = 'full'
       end
 
@@ -155,6 +155,14 @@ module Spree
 
     def plural_resource_name(resource_class)
       resource_class.model_name.human(count: Spree::I18N_GENERIC_PLURAL)
+    end
+
+    def protect_from_negative(current_order)
+      if current_order.total.negative? 
+        Spree::Money.new(0, currency: current_order.currency).to_html
+      else
+        current_order.display_total.to_html 
+      end
     end
   end
 end

--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -158,10 +158,10 @@ module Spree
     end
 
     def protect_from_negative(current_order)
-      if current_order.total.negative? 
+      if current_order.total.negative?
         Spree::Money.new(0, currency: current_order.currency).to_html
       else
-        current_order.display_total.to_html 
+        current_order.display_total.to_html
       end
     end
   end

--- a/core/spec/helpers/base_helper_spec.rb
+++ b/core/spec/helpers/base_helper_spec.rb
@@ -184,5 +184,5 @@ RSpec.describe Spree::BaseHelper, type: :helper do
         expect(subject).to eq(order.display_total.to_html)
       end
     end
-  end 
+  end
 end

--- a/core/spec/helpers/base_helper_spec.rb
+++ b/core/spec/helpers/base_helper_spec.rb
@@ -166,10 +166,10 @@ RSpec.describe Spree::BaseHelper, type: :helper do
     end
   end
 
-  context "protect_from_negative" do
+  context "display_order_total" do
     context "if the total is less than zero" do
       let(:order) { create(:order, total: -1.00) }
-      subject { protect_from_negative(order) }
+      subject { display_order_total(order) }
 
       it "should return a Spree::Money object with a value of zero as html" do
         expect(subject).to eq(Spree::Money.new(0, order: order.currency).to_html)
@@ -178,7 +178,7 @@ RSpec.describe Spree::BaseHelper, type: :helper do
 
     context "if the total is greater than or equal to zero" do
       let(:order) { create :order_with_totals }
-      subject { protect_from_negative(order) }
+      subject { display_order_total(order) }
 
       it "should return a the order total" do
         expect(subject).to eq(order.display_total.to_html)

--- a/core/spec/helpers/base_helper_spec.rb
+++ b/core/spec/helpers/base_helper_spec.rb
@@ -165,4 +165,24 @@ RSpec.describe Spree::BaseHelper, type: :helper do
       subject
     end
   end
+
+  context "protect_from_negative" do
+    context "if the total is less than zero" do
+      let(:order) { create(:order, total: -1.00) }
+      subject { protect_from_negative(order) }
+
+      it "should return a Spree::Money object with a value of zero as html" do
+        expect(subject).to eq(Spree::Money.new(0, order: order.currency).to_html)
+      end
+    end
+
+    context "if the total is greater than or equal to zero" do
+      let(:order) { create :order_with_totals }
+      subject { protect_from_negative(order) }
+
+      it "should return a the order total" do
+        expect(subject).to eq(order.display_total.to_html)
+      end
+    end
+  end 
 end

--- a/frontend/app/views/spree/orders/_form.html.erb
+++ b/frontend/app/views/spree/orders/_form.html.erb
@@ -23,7 +23,7 @@
   <% end %>
   <tr class="cart-total">
     <td colspan="4" align='right'><h5><%= t('spree.total') %></h5></td>
-    <td colspan><h5><%= order.display_total %></h5></td>
+    <td colspan><h5><%= order.total.negative? ? '0.00' : order.display_total %></h5></td>
     <td></td>
   </tr>
 </table>

--- a/frontend/app/views/spree/orders/_form.html.erb
+++ b/frontend/app/views/spree/orders/_form.html.erb
@@ -23,7 +23,7 @@
   <% end %>
   <tr class="cart-total">
     <td colspan="4" align='right'><h5><%= t('spree.total') %></h5></td>
-    <td colspan><h5><%= order.total.negative? ? '0.00' : order.display_total %></h5></td>
+    <td colspan><h5><%= protect_from_negative(current_order) %></h5></td>
     <td></td>
   </tr>
 </table>

--- a/frontend/app/views/spree/orders/_form.html.erb
+++ b/frontend/app/views/spree/orders/_form.html.erb
@@ -23,7 +23,7 @@
   <% end %>
   <tr class="cart-total">
     <td colspan="4" align='right'><h5><%= t('spree.total') %></h5></td>
-    <td colspan><h5><%= protect_from_negative(current_order) %></h5></td>
+    <td colspan><h5><%= display_order_total(current_order) %></h5></td>
     <td></td>
   </tr>
 </table>


### PR DESCRIPTION
…less than zero

Refs #2741 

If an admin set the promotions in a specific way, it was possible to make the cart display a negative value before checkout. The bug is purely visual as Solidus sets the checkout value to $0.00. This PR simply makes the frontend reflect that behavior in the cart.

Feedback is welcome.