### PR TITLE
Fix the ability to update cart content on completed order

### DIFF
--- a/api/spec/requests/spree/api/line_items_controller_spec.rb
+++ b/api/spec/requests/spree/api/line_items_controller_spec.rb
@@ -154,6 +154,17 @@ module Spree
             post spree.api_order_line_items_path(order), params: { line_item: { variant_id: product.master.to_param, quantity: 1 } }
             expect(order.reload.shipments).not_to be_empty
           end
+
+          it "cannot update a line item on order" do
+            line_item = order.line_items.first
+            put spree.api_order_line_item_path(order, line_item), params: { line_item: { quantity: 101 } }
+            assert_unauthorized!
+          end
+
+          it "cannot add a line item on order" do
+            post spree.api_order_line_items_path(order), params: { line_item: { variant_id: product.master.to_param, quantity: 1 } }
+            assert_unauthorized!
+          end
         end
       end
     end


### PR DESCRIPTION
Hello,

We just got an issue with our solidus api : 
- We have a react frontend and we use solidus as an api
- We can update order content event if it's paid or completed

Step to reproduce : 
- Create an order, pay it
- Create a curl request on api to update the order content
- It responses with a 200

At the moment, I just created a rspec test to show the issue, in fact I need some advise to know how to fix it : 
- Should I use cancancan?
- Should I check order status on a before filter on lineItemsController?

To make a fast fix on my website, I did : 

```
module Spree
  module Api
    module LineItemsControllerDecorator
      def check_order_state
        unauthorized if ["complete", "canceled", "confirm"].include?(@order.state) # Maybe check if it's a final state?
      end
    end
  end
end

Spree::Api::LineItemsController.prepend Spree::Api::LineItemsControllerDecorator
Spree::Api::LineItemsController.before_action :check_order_state, only: [:create, :update]
```

Thank you ! 