### PR TITLE
Making sure order by columns do not collide with other tables

### DIFF
--- a/core/app/models/spree/price.rb
+++ b/core/app/models/spree/price.rb
@@ -26,7 +26,7 @@ module Spree
     validates :currency, inclusion: { in: ::Money::Currency.all.map(&:iso_code), message: :invalid_code }
     validates :country, presence: true, unless: -> { for_any_country? }
 
-    scope :currently_valid, -> { order(Arel.sql("country_iso IS NULL, updated_at DESC, id DESC")) }
+    scope :currently_valid, -> { order(Arel.sql("country_iso IS NULL")).order(updated_at: :DESC, id: :DESC) }
     scope :for_master, -> { joins(:variant).where(spree_variants: { is_master: true }) }
     scope :for_variant, -> { joins(:variant).where(spree_variants: { is_master: false }) }
     scope :for_any_country, -> { where(country: nil) }


### PR DESCRIPTION
With some complex eager loading relationships, it was causing sql sintax errors
referring to multiple tables having the same column name