### PR TITLE
Fix a store credit spec that is time zone dependent

### DIFF
--- a/core/spec/models/spree/store_credit_event_spec.rb
+++ b/core/spec/models/spree/store_credit_event_spec.rb
@@ -235,7 +235,7 @@ RSpec.describe Spree::StoreCreditEvent do
   end
 
   describe "#display_event_date" do
-    let(:date) { Time.parse("2014-06-01") }
+    let(:date) { Time.zone.parse("2014-06-01") }
 
     subject { create(:store_credit_auth_event, created_at: date) }
 


### PR DESCRIPTION
This test fails running in Europe in the morning:

```
  expected: "June 01, 2014"
       got: "May 31, 2014"
```