### PR TITLE
Refund shipping costs

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/returns/return_item_selection.js
+++ b/backend/app/assets/javascripts/spree/backend/returns/return_item_selection.js
@@ -16,7 +16,8 @@ Spree.ready(function() {
   }
 
   var formFields = $("[data-hook='admin_customer_return_form_fields'], \
-                     [data-hook='admin_return_authorization_form_fields']");
+                     [data-hook='admin_return_authorization_form_fields'], \
+                     [data-hook='admin_reimbursement_settlements_form_fields'] ");
 
   if(formFields.length > 0) {
     updateSuggestedAmount();

--- a/backend/app/controllers/spree/admin/reimbursements_controller.rb
+++ b/backend/app/controllers/spree/admin/reimbursements_controller.rb
@@ -40,7 +40,7 @@ module Spree
       end
 
       # We don't currently have a real Reimbursement "new" page. And the only
-      # built-in way to create reimburesments via Solidus admin is from the
+      # built-in way to create reimbursements via Solidus admin is from the
       # customer returns admin page via a button that supplies the
       # "build_from_customer_return" parameter. The "edit" page is not
       # suitable for use here for that reason as well.

--- a/backend/app/controllers/spree/admin/reimbursements_controller.rb
+++ b/backend/app/controllers/spree/admin/reimbursements_controller.rb
@@ -10,6 +10,7 @@ module Spree
       before_action :load_stock_locations, only: :edit
       before_action :load_simulated_refunds, only: :edit
       before_action :load_settlements, only: :edit
+      after_action :attempt_accept_new_settlements, only: :update
 
       rescue_from Spree::Core::GatewayError, with: :spree_core_gateway_error
 
@@ -69,6 +70,12 @@ module Spree
         end
 
         @existing_settlements = @reimbursement.settlements.for_shipment.not_pending
+      end
+
+      def attempt_accept_new_settlements
+        @reimbursement.settlements.pending.each do |settlement|
+          settlement.attempt_accept!
+        end
       end
 
       def load_simulated_refunds

--- a/backend/app/controllers/spree/admin/reimbursements_controller.rb
+++ b/backend/app/controllers/spree/admin/reimbursements_controller.rb
@@ -61,13 +61,14 @@ module Spree
       # any Shipments associated with a returned InventoryUnit.
       def load_settlements
         returned_items_shipments = @reimbursement.return_items.map(&:shipment).uniq
-        associated_shipments = @reimbursement.settlements.map(&:shipment)
-        unassociated_shipments = returned_items_shipments - associated_shipments
+        unavailable_shipments = @reimbursement.settlements.unavailable_for_new_settlement.map(&:shipment)
+        available_shipments = returned_items_shipments - unavailable_shipments
 
-        new_settlements = unassociated_shipments.map do |shipment|
+        @form_settlements = available_shipments.map do |shipment|
           Spree::Settlement.new(shipment: shipment, amount: shipment.amount)
         end
-        @form_settlements = (@reimbursement.settlements + new_settlements).sort_by(&:shipment_id)
+
+        @existing_settlements = @reimbursement.settlements.for_shipment.not_pending
       end
 
       def load_simulated_refunds

--- a/backend/app/controllers/spree/admin/reimbursements_controller.rb
+++ b/backend/app/controllers/spree/admin/reimbursements_controller.rb
@@ -66,7 +66,7 @@ module Spree
         available_shipments = returned_items_shipments - unavailable_shipments
 
         @form_settlements = available_shipments.map do |shipment|
-          Spree::Settlement.new(shipment: shipment, amount: shipment.amount)
+          Spree::Settlement.new(shipment: shipment, amount: shipment.total_before_tax)
         end
 
         @existing_settlements = @reimbursement.settlements.for_shipment.not_pending

--- a/backend/app/controllers/spree/admin/settlements_controller.rb
+++ b/backend/app/controllers/spree/admin/settlements_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Spree
+  module Admin
+    class SettlementsController < BaseController
+      before_action :load_settlement, only: [:accept, :reject]
+
+      def accept
+        @settlement.accept
+        redirect_to location_after_save
+      end
+
+      def reject
+        status = @settlement.acceptance_status
+        @settlement.reject
+        if status == 'accepted'
+          @settlement.acceptance_status_errors = { settlement_manually_rejected: t('spree.settlement_manually_rejected') }
+          @settlement.save
+        end
+        redirect_to location_after_save
+      end
+
+      private
+
+      def load_settlement
+        @settlement = Spree::Settlement.find params[:id]
+      end
+
+      def location_after_save
+        url_for([:edit, :admin, @settlement.reimbursement.order, @settlement.reimbursement])
+      end
+    end
+  end
+end

--- a/backend/app/views/spree/admin/reimbursements/edit.html.erb
+++ b/backend/app/views/spree/admin/reimbursements/edit.html.erb
@@ -70,13 +70,53 @@
         <th class="settlement-checkbox shipment-checkbox">
           <%= check_box_tag 'select-all' %>
         </th>
-        <th><%= Spree::Shipment.model_name.human %></th>
-        <th class="wrap-text"><%= Spree::ShippingMethod.human_attribute_name(:name) %></th>
+        <th class="wrap-text"><%= Spree::Shipment.model_name.human %></th>
         <th class="wrap-text"><%= Spree::Settlement.human_attribute_name(:reimbursement_type_id) %></th>
         <th class="wrap-text"><%= Spree::Settlement.human_attribute_name(:amount) %></th>
-        <th class="wrap-text"><%= Spree::Settlement.human_attribute_name(:total) %></th>
+        <th><%= Spree::Settlement.human_attribute_name(:total) %></th>
+        <th class="wrap-text"><%= Spree::Settlement.human_attribute_name(:acceptance_status) %></th>
+        <th class="wrap-text"><%= Spree::Settlement.human_attribute_name(:acceptance_status_errors) %></th>
+        <th class="actions"></th>
         </thead>
         <tbody>
+        <% @existing_settlements.each do |settlement| %>
+          <tr>
+            <td></td>
+            <td>
+              <%= settlement.shipment.number %>
+              <%= settlement.shipment.shipping_method.name %>
+            </td>
+            <td>
+              <%= settlement.reimbursement_type.name.humanize %>
+            </td>
+            <td>
+              <%= settlement.display_amount %>
+            </td>
+            <td>
+              <%= settlement.display_total %>
+            </td>
+            <td>
+              <span class="pill pill-<%= settlement.acceptance_status %>">
+                <%= t(
+                      settlement.acceptance_status,
+                      scope: 'spree.settlement_states'
+                    ) %>
+              </span>
+            </td>
+            <td class="wrap-text">
+              <%= settlement.acceptance_status_errors %>
+            </td>
+            <td class="actions">
+              <% if settlement.acceptance_status == 'manual_intervention_required' %>
+                <%= link_to_with_icon('thumbs-up', t('spree.accept'), [:accept, :admin, settlement], { class: 'no-text with-tip icon_link', no_text: true, method: 'put' }) %>
+                /
+              <% end %>
+              <% if ['accepted', 'manual_intervention_required'].include?(settlement.acceptance_status) %>
+                <%= link_to_with_icon('thumbs-down', t('spree.reject'), [:reject, :admin, settlement], { class: 'no-text with-tip icon_link', no_text: true, method: 'put' }) %>
+              <% end %>
+            </td>
+          </tr>
+        <% end %>
         <%= f.fields_for :settlements, @form_settlements do |settlement_fields| %>
           <% settlement = settlement_fields.object %>
           <% shipment = settlement.shipment %>
@@ -87,8 +127,6 @@
             </td>
             <td>
               <%= shipment.number %>
-            </td>
-            <td>
               <%= shipment.shipping_method.name %>
             </td>
             <td>
@@ -104,6 +142,18 @@
             <td>
               <%= settlement.display_total %>
             </td>
+            <td>
+              <span class="pill pill-<%= settlement.acceptance_status %>">
+                <%= t(
+                      settlement.acceptance_status,
+                      scope: 'spree.settlement_states'
+                    ) %>
+              </span>
+            </td>
+            <td>
+              <%= settlement.acceptance_status_errors %>
+            </td>
+            <td></td>
           </tr>
         <% end %>
         </tbody>

--- a/backend/app/views/spree/admin/reimbursements/edit.html.erb
+++ b/backend/app/views/spree/admin/reimbursements/edit.html.erb
@@ -107,11 +107,11 @@
               <%= settlement.acceptance_status_errors %>
             </td>
             <td class="actions">
-              <% if settlement.acceptance_status == 'manual_intervention_required' %>
+              <% if settlement.manual_intervention_required? %>
                 <%= link_to_with_icon('thumbs-up', t('spree.accept'), [:accept, :admin, settlement], { class: 'no-text with-tip icon_link', no_text: true, method: 'put' }) %>
                 /
               <% end %>
-              <% if ['accepted', 'manual_intervention_required'].include?(settlement.acceptance_status) %>
+              <% if settlement.unavailable_for_new_settlements? %>
                 <%= link_to_with_icon('thumbs-down', t('spree.reject'), [:reject, :admin, settlement], { class: 'no-text with-tip icon_link', no_text: true, method: 'put' }) %>
               <% end %>
             </td>

--- a/backend/app/views/spree/admin/reimbursements/edit.html.erb
+++ b/backend/app/views/spree/admin/reimbursements/edit.html.erb
@@ -62,6 +62,55 @@
     </table>
   </fieldset>
 
+  <div data-hook="admin_reimbursement_settlements_form_fields">
+    <fieldset class='no-border-bottom'>
+      <legend align='center'><%= t('spree.shipments_to_be_reimbursed') %></legend>
+      <table class="index reimbursement-settlements">
+        <thead>
+        <th class="settlement-checkbox shipment-checkbox">
+          <%= check_box_tag 'select-all' %>
+        </th>
+        <th><%= Spree::Shipment.model_name.human %></th>
+        <th class="wrap-text"><%= Spree::ShippingMethod.human_attribute_name(:name) %></th>
+        <th class="wrap-text"><%= Spree::Settlement.human_attribute_name(:reimbursement_type_id) %></th>
+        <th class="wrap-text"><%= Spree::Settlement.human_attribute_name(:amount) %></th>
+        <th class="wrap-text"><%= Spree::Settlement.human_attribute_name(:total) %></th>
+        </thead>
+        <tbody>
+        <%= f.fields_for :settlements, @form_settlements do |settlement_fields| %>
+          <% settlement = settlement_fields.object %>
+          <% shipment = settlement.shipment %>
+          <tr>
+            <td class="settlement-checkbox">
+              <%= settlement_fields.hidden_field :shipment_id %>
+              <%= settlement_fields.check_box :_destroy, {checked: settlement.persisted?, class: 'add-item'}, '0', '1' %>
+            </td>
+            <td>
+              <%= shipment.number %>
+            </td>
+            <td>
+              <%= shipment.shipping_method.name %>
+            </td>
+            <td>
+              <%=settlement_fields.select(:reimbursement_type_id,
+                reimbursement_types.collect { |r| [r.name.humanize, r.id] },
+                {include_blank: true},
+                {class: 'custom-select fullwidth'}
+               ) %>
+            </td>
+            <td>
+              <%= settlement_fields.text_field :amount, { class: 'refund-amount-input' } %>
+            </td>
+            <td>
+              <%= settlement.display_total %>
+            </td>
+          </tr>
+        <% end %>
+        </tbody>
+      </table>
+    </fieldset>
+  </div>
+
   <div class="form-buttons filter-actions actions" data-hook="buttons">
     <%= f.button do %>
       <%= t('spree.update') %>

--- a/backend/app/views/spree/admin/reimbursements/show.html.erb
+++ b/backend/app/views/spree/admin/reimbursements/show.html.erb
@@ -65,7 +65,7 @@
     </tr>
     </thead>
     <tbody>
-    <% @reimbursement.settlements.each do |settlement| %>
+    <% @reimbursement.settlements.for_shipment.accepted.each do |settlement| %>
 
       <tr>
         <td>
@@ -75,7 +75,7 @@
           <%= settlement.shipment.shipping_method.name %>
         </td>
         <td>
-          <%= settlement.reimbursement_type %>
+          <%= settlement.reimbursement_type.name.humanize %>
         </td>
         <td>
           <%= settlement.display_amount %>

--- a/backend/app/views/spree/admin/reimbursements/show.html.erb
+++ b/backend/app/views/spree/admin/reimbursements/show.html.erb
@@ -52,6 +52,43 @@
   </table>
 </fieldset>
 
+<fieldset class='no-border-bottom'>
+  <legend align='center'><%= t('spree.settlements') %></legend>
+  <table class="index reimbursement-settlements-items">
+    <thead>
+    <tr>
+      <th><%= Spree::Shipment.model_name.human %></th>
+      <th class="wrap-text"><%= Spree::ShippingMethod.human_attribute_name(:name) %></th>
+      <th class="wrap-text"><%= Spree::Settlement.human_attribute_name(:reimbursement_type) %></th>
+      <th class="wrap-text"><%= Spree::Settlement.human_attribute_name(:amount) %></th>
+      <th class="wrap-text"><%= Spree::Settlement.human_attribute_name(:total) %></th>
+    </tr>
+    </thead>
+    <tbody>
+    <% @reimbursement.settlements.each do |settlement| %>
+
+      <tr>
+        <td>
+          <%= settlement.shipment.number %>
+        </td>
+        <td>
+          <%= settlement.shipment.shipping_method.name %>
+        </td>
+        <td>
+          <%= settlement.reimbursement_type %>
+        </td>
+        <td>
+          <%= settlement.display_amount %>
+        </td>
+        <td>
+          <%= settlement.display_total %>
+        </td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+</fieldset>
+
 <fieldset class="no-border-bottom">
   <legend align='center'><%= Spree::Refund.model_name.human %></legend>
   <table class="index reimbursement-refunds">

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -127,6 +127,12 @@ Spree::Core::Engine.routes.draw do
     resources :stores, only: [:index, :new, :create, :edit, :update]
 
     resources :return_items, only: [:update]
+    resources :settlements do
+      member do
+        put :accept
+        put :reject
+      end
+    end
 
     resources :taxonomies do
       collection do

--- a/backend/spec/controllers/spree/admin/reimbursements_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/reimbursements_controller_spec.rb
@@ -25,12 +25,12 @@ describe Spree::Admin::ReimbursementsController, type: :controller do
       expect(assigns(:stock_locations)).not_to include(inactive_stock_location)
     end
 
-    describe "#load_return_items" do
-      let!(:second_shipment) { create(:shipment, order: order) }
-      let!(:second_return_item) {
+    describe "#load_settlements" do
+      let!(:shipment_without_settlement) { create(:shipment, order: order) }
+      let!(:return_item) {
         create(
           :return_item,
-          inventory_unit: second_shipment.inventory_units.first,
+          inventory_unit: shipment_without_settlement.inventory_units.first,
           reimbursement: reimbursement,
           acceptance_status: 'accepted'
         )
@@ -42,16 +42,27 @@ describe Spree::Admin::ReimbursementsController, type: :controller do
           expect(assigns(:form_settlements).size).to eq 2
           expect(assigns(:form_settlements).select(&:new_record?).size).to eq 2
         end
+
+        it "does not have @existing_settlements" do
+          subject
+          expect(assigns(:existing_settlements).size).to eq 0
+        end
       end
 
-      context "with existing settlement" do
-        let!(:settlement) { create(:settlement, reimbursement: reimbursement, shipment: second_shipment) }
+      context "with an existing settlement" do
+        let!(:settlement) { create(:settlement, reimbursement: reimbursement, shipment: shipment_without_settlement) }
 
-        it "has 1 existing settlement and 1 new settlement" do
+        it "has 1 new @form_settlement" do
           subject
-          expect(assigns(:form_settlements).size).to eq 2
-          expect(assigns(:form_settlements).select(&:persisted?)).to eq [settlement]
+          expect(assigns(:form_settlements).size).to eq 1
           expect(assigns(:form_settlements).select(&:new_record?).size).to eq 1
+        end
+
+        it "has 1 @existing_settlements" do
+          subject
+          expect(assigns(:existing_settlements).size).to eq 1
+          expect(assigns(:existing_settlements).select(&:persisted?).size).to eq 1
+          expect(assigns(:existing_settlements).select(&:persisted?)).to eq [settlement]
         end
       end
     end

--- a/backend/spec/controllers/spree/admin/reimbursements_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/reimbursements_controller_spec.rb
@@ -50,7 +50,14 @@ describe Spree::Admin::ReimbursementsController, type: :controller do
       end
 
       context "with an existing settlement" do
-        let!(:settlement) { create(:settlement, reimbursement: reimbursement, shipment: shipment_without_settlement) }
+        let!(:settlement) {
+          create(
+            :settlement,
+            reimbursement: reimbursement,
+            shipment: shipment_without_settlement,
+            acceptance_status: 'accepted'
+          )
+        }
 
         it "has 1 new @form_settlement" do
           subject

--- a/backend/spec/features/admin/reimbursements_spec.rb
+++ b/backend/spec/features/admin/reimbursements_spec.rb
@@ -2,16 +2,23 @@
 
 require 'spec_helper'
 
-describe 'Promotions', type: :feature do
+describe 'Reimbursements and settlements', type: :feature do
   stub_authorization!
   let!(:reimbursement) { create(:reimbursement) }
 
-  it "should display the reimbursements table" do
+  it "should display the reimbursements and settlements table" do
     visit spree.admin_order_reimbursement_path(reimbursement.order, reimbursement)
+
     expect(page).to have_css('table thead tr th', text: 'Product')
     expect(page).to have_css('table thead tr th', text: 'Preferred Reimbursement Type')
     expect(page).to have_css('table thead tr th', text: 'Reimbursement Type Override')
     expect(page).to have_css('table thead tr th', text: 'Exchange for')
+    expect(page).to have_css('table thead tr th', text: 'Amount Before Sales Tax')
+    expect(page).to have_css('table thead tr th', text: 'Total')
+
+    expect(page).to have_css('table thead tr th', text: 'Shipment')
+    expect(page).to have_css('table thead tr th', text: 'Name')
+    expect(page).to have_css('table thead tr th', text: 'Reimbursement Type')
     expect(page).to have_css('table thead tr th', text: 'Amount Before Sales Tax')
     expect(page).to have_css('table thead tr th', text: 'Total')
   end

--- a/core/app/models/spree/reimbursement.rb
+++ b/core/app/models/spree/reimbursement.rb
@@ -31,7 +31,7 @@ module Spree
     class_attribute :reimbursement_tax_calculator
     self.reimbursement_tax_calculator = ReimbursementTaxCalculator
     # A separate attribute here allows you to use a more performant calculator for estimates
-    # and a different one (e.g. one that hits a 3rd party API) for the final caluclations.
+    # and a different one (e.g. one that hits a 3rd party API) for the final calculations.
     class_attribute :reimbursement_simulator_tax_calculator
     self.reimbursement_simulator_tax_calculator = ReimbursementTaxCalculator
 
@@ -88,7 +88,8 @@ module Spree
     def calculated_total
       # rounding down to handle edge cases for consecutive partial returns where rounding
       # might cause us to try to reimburse more than was originally billed
-      return_items.to_a.sum(&:total).to_d.round(2, :down)
+      return_items.to_a.sum(&:total).to_d.round(2, :down) +
+        settlements.accepted.to_a.sum(&:total).to_d.round(2, :down)
     end
 
     def paid_amount

--- a/core/app/models/spree/reimbursement.rb
+++ b/core/app/models/spree/reimbursement.rb
@@ -11,6 +11,9 @@ module Spree
     has_many :credits, inverse_of: :reimbursement, class_name: 'Spree::Reimbursement::Credit'
 
     has_many :return_items, inverse_of: :reimbursement
+    has_many :settlements, inverse_of: :reimbursement
+
+    accepts_nested_attributes_for :settlements, allow_destroy: true
 
     validates :order, presence: true
     validate :validate_return_items_belong_to_same_order

--- a/core/app/models/spree/reimbursement/reimbursement_type_validator.rb
+++ b/core/app/models/spree/reimbursement/reimbursement_type_validator.rb
@@ -9,6 +9,10 @@ module Spree
         preferred_type == expired_reimbursement_type
     end
 
+    def valid_settlement_reimbursement_type?(settlement)
+      settlement.reimbursement_type.class != exchange_reimbursement_type
+    end
+
     def past_reimbursable_time_period?(return_item)
       shipped_at = return_item.inventory_unit.shipment.shipped_at
       shipped_at && shipped_at < refund_time_constraint.ago

--- a/core/app/models/spree/reimbursement_performer.rb
+++ b/core/app/models/spree/reimbursement_performer.rb
@@ -25,15 +25,15 @@ module Spree
       def execute(reimbursement, simulate)
         reimbursement_type_hash = calculate_reimbursement_types(reimbursement)
 
-        reimbursement_type_hash.flat_map do |reimbursement_type, return_items|
-          reimbursement_type.reimburse(reimbursement, return_items, simulate)
+        reimbursement_type_hash.flat_map do |reimbursement_type, reimbursement_items|
+          reimbursement_type.reimburse(reimbursement, reimbursement_items, simulate)
         end
       end
 
       def calculate_reimbursement_types(reimbursement)
         # Engine returns hash of preferred reimbursement types pointing at return items
-        # {Spree::ReimbursementType::OriginalPayment => [ReturnItem, ...], Spree::ReimbursementType::Exchange => [ReturnItem, ...]}
-        reimbursement_type_engine.new(reimbursement.return_items).calculate_reimbursement_types
+        # {Spree::ReimbursementType::OriginalPayment => [ReimbursementItem, ...], Spree::ReimbursementType::Exchange => [ReimbursementItem, ...]}
+        reimbursement_type_engine.new(reimbursement).calculate_reimbursement_types
       end
     end
   end

--- a/core/app/models/spree/reimbursement_tax_calculator.rb
+++ b/core/app/models/spree/reimbursement_tax_calculator.rb
@@ -13,13 +13,16 @@ module Spree
     class << self
       def call(reimbursement)
         reimbursement.return_items.includes(:inventory_unit).each do |return_item|
-          set_tax!(return_item)
+          set_return_item_tax!(return_item)
+        end
+        reimbursement.settlements.each do |settlement|
+          set_settlement_tax!(settlement)
         end
       end
 
       private
 
-      def set_tax!(return_item)
+      def set_return_item_tax!(return_item)
         percent_of_tax = (return_item.amount <= 0) ? 0 : return_item.amount / Spree::ReturnItem.refund_amount_calculator.new.compute(return_item)
 
         additional_tax_total = percent_of_tax * return_item.inventory_unit.additional_tax_total
@@ -28,6 +31,13 @@ module Spree
         return_item.update_attributes!({
           additional_tax_total: additional_tax_total,
           included_tax_total:   included_tax_total
+        })
+      end
+
+      def set_settlement_tax!(settlement)
+        settlement.update_attributes!({
+          additional_tax_total: settlement.shipment.additional_tax_total,
+          included_tax_total:   settlement.shipment.included_tax_total
         })
       end
     end

--- a/core/app/models/spree/reimbursement_tax_calculator.rb
+++ b/core/app/models/spree/reimbursement_tax_calculator.rb
@@ -35,6 +35,7 @@ module Spree
       end
 
       def set_settlement_tax!(settlement)
+        return unless settlement.shipment
         settlement.update_attributes!({
           additional_tax_total: settlement.shipment.additional_tax_total,
           included_tax_total:   settlement.shipment.included_tax_total

--- a/core/app/models/spree/reimbursement_type.rb
+++ b/core/app/models/spree/reimbursement_type.rb
@@ -7,6 +7,7 @@ module Spree
     ORIGINAL = 'original'
 
     has_many :return_items
+    has_many :settlements
 
     # This method will reimburse the return items based on however it child implements it
     # By default it takes a reimbursement, the return items it needs to reimburse, and if

--- a/core/app/models/spree/reimbursement_type/credit.rb
+++ b/core/app/models/spree/reimbursement_type/credit.rb
@@ -5,8 +5,8 @@ module Spree
     extend Spree::ReimbursementType::ReimbursementHelpers
 
     class << self
-      def reimburse(reimbursement, return_items, simulate)
-        unpaid_amount = return_items.sum(&:total).round(2, :down)
+      def reimburse(reimbursement, reimbursement_items, simulate)
+        unpaid_amount = reimbursement_items.sum(&:total).round(2, :down)
         reimbursement_list, _unpaid_amount = create_credits(reimbursement, unpaid_amount, simulate)
         reimbursement_list
       end

--- a/core/app/models/spree/reimbursement_type/original_payment.rb
+++ b/core/app/models/spree/reimbursement_type/original_payment.rb
@@ -4,8 +4,8 @@ class Spree::ReimbursementType::OriginalPayment < Spree::ReimbursementType
   extend Spree::ReimbursementType::ReimbursementHelpers
 
   class << self
-    def reimburse(reimbursement, return_items, simulate)
-      unpaid_amount = return_items.sum(&:total).round(2, :down)
+    def reimburse(reimbursement, reimbursement_items, simulate)
+      unpaid_amount = reimbursement_items.sum(&:total).round(2, :down)
       payments = reimbursement.order.payments.completed
 
       refund_list, _unpaid_amount = create_refunds(reimbursement, payments, unpaid_amount, simulate)

--- a/core/app/models/spree/reimbursement_type/store_credit.rb
+++ b/core/app/models/spree/reimbursement_type/store_credit.rb
@@ -4,8 +4,8 @@ class Spree::ReimbursementType::StoreCredit < Spree::ReimbursementType
   extend Spree::ReimbursementType::ReimbursementHelpers
 
   class << self
-    def reimburse(reimbursement, return_items, simulate)
-      unpaid_amount = return_items.sum(&:total).to_d.round(2, :down)
+    def reimburse(reimbursement, reimbursement_items, simulate)
+      unpaid_amount = reimbursement_items.sum(&:total).to_d.round(2, :down)
       payments = store_credit_payments(reimbursement)
       reimbursement_list = []
 

--- a/core/app/models/spree/settlement.rb
+++ b/core/app/models/spree/settlement.rb
@@ -22,7 +22,6 @@ module Spree
     delegate :eligible_for_settlement?, :requires_manual_intervention?, to: :validator
 
     before_create :set_default_amount, unless: :amount_changed?
-    after_create :attempt_accept
 
     scope :pending, -> { where(acceptance_status: 'pending') }
     scope :not_pending, -> { where.not(acceptance_status: 'pending').order(:updated_at) }

--- a/core/app/models/spree/settlement.rb
+++ b/core/app/models/spree/settlement.rb
@@ -71,6 +71,10 @@ module Spree
       self.amount = shipment.try(:amount) || 0
     end
 
+    def unavailable_for_new_settlements?
+      manual_intervention_required? || accepted?
+    end
+
     private
 
     def persist_acceptance_status_errors

--- a/core/app/models/spree/settlement.rb
+++ b/core/app/models/spree/settlement.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+module Spree
+  class Settlement < Spree::Base
+    # @!scope class
+    # @!attribute settlement_eligibility_validator
+    # Configurable validator for determining whether given settlement is eligible
+    # for settlement.
+    # @return [Class]
+    class_attribute :settlement_eligibility_validator
+    self.settlement_eligibility_validator = Settlement::EligibilityValidator::Default
+
+    belongs_to :reimbursement, inverse_of: :settlements
+    belongs_to :reimbursement_type
+    belongs_to :shipment, inverse_of: :settlements
+
+    validate :shipment_belongs_to_same_order
+
+    serialize :acceptance_status_errors
+
+    delegate :eligible_for_settlement?, :requires_manual_intervention?, to: :validator
+
+    before_create :set_default_amount, unless: :amount_changed?
+
+    extend DisplayMoney
+    money_methods :amount, :total, :total_excluding_vat
+
+    state_machine :acceptance_status, initial: :pending do
+      event :attempt_accept do
+        transition to: :accepted, from: :accepted
+        transition to: :accepted, from: :pending, if: ->(settlement) { settlement.eligible_for_settlement? }
+        transition to: :manual_intervention_required, from: :pending, if: ->(settlement) { settlement.requires_manual_intervention? }
+        transition to: :rejected, from: :pending
+      end
+
+      # bypasses eligibility checks
+      event :accept do
+        transition to: :accepted, from: [:accepted, :pending, :manual_intervention_required]
+      end
+
+      # bypasses eligibility checks
+      event :reject do
+        transition to: :rejected, from: [:accepted, :pending, :manual_intervention_required]
+      end
+
+      # bypasses eligibility checks
+      event :require_manual_intervention do
+        transition to: :manual_intervention_required, from: [:accepted, :pending, :manual_intervention_required]
+      end
+
+      after_transition any => any, do: :persist_acceptance_status_errors
+    end
+
+    # @return [BigDecimal] the cost of the item after tax
+    def total
+      amount + additional_tax_total
+    end
+
+    # @return [BigDecimal] the cost of the item before VAT tax
+    def total_excluding_vat
+      amount - included_tax_total
+    end
+
+    def set_default_amount
+      self.amount = shipment.try(:amount) || 0
+    end
+
+    private
+
+    def persist_acceptance_status_errors
+      update_attributes(acceptance_status_errors: validator.errors)
+    end
+
+    def validator
+      @validator ||= settlement_eligibility_validator.new(self)
+    end
+
+    def shipment_belongs_to_same_order
+      return unless shipment && reimbursement
+      if reimbursement.order_id != shipment.order_id
+        errors.add(:shipment, :must_belong_to_reimbursement_order)
+      end
+    end
+  end
+end

--- a/core/app/models/spree/settlement.rb
+++ b/core/app/models/spree/settlement.rb
@@ -15,7 +15,6 @@ module Spree
     belongs_to :shipment, inverse_of: :settlements
 
     validate :shipment_belongs_to_same_order
-    validates :reimbursement_type, presence: true
 
     serialize :acceptance_status_errors
 

--- a/core/app/models/spree/settlement/eligibility_validator/base_validator.rb
+++ b/core/app/models/spree/settlement/eligibility_validator/base_validator.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Spree
+  class Settlement < Spree::Base
+    module EligibilityValidator
+      class BaseValidator
+        attr_reader :errors
+
+        def initialize(settlement)
+          @settlement = settlement
+          @errors = {}
+        end
+
+        def eligible_for_settlement?
+          raise NotImplementedError, I18n.t('spree.implement_eligible_for_settlement')
+        end
+
+        def requires_manual_intervention?
+          raise NotImplementedError, I18n.t('spree.implement_requires_manual_intervention')
+        end
+
+        private
+
+        def add_error(key, error)
+          @errors[key] = error
+        end
+      end
+    end
+  end
+end

--- a/core/app/models/spree/settlement/eligibility_validator/default.rb
+++ b/core/app/models/spree/settlement/eligibility_validator/default.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Spree
+  class Settlement < Spree::Base
+    module EligibilityValidator
+      class Default < Spree::Settlement::EligibilityValidator::BaseValidator
+        class_attribute :permitted_eligibility_validators
+        self.permitted_eligibility_validators = [
+          Settlement::EligibilityValidator::OrderCompleted,
+          Settlement::EligibilityValidator::TimeSincePurchase,
+          Settlement::EligibilityValidator::ShipmentShipped,
+          Settlement::EligibilityValidator::ItemReturned
+        ]
+
+        def eligible_for_settlement?
+          validators.all?(&:eligible_for_settlement?)
+        end
+
+        def requires_manual_intervention?
+          validators.any?(&:requires_manual_intervention?)
+        end
+
+        def errors
+          validators.map(&:errors).reduce({}, :merge)
+        end
+
+        private
+
+        def validators
+          @validators ||= permitted_eligibility_validators.map{ |v| v.new(@settlement) }
+        end
+      end
+    end
+  end
+end

--- a/core/app/models/spree/settlement/eligibility_validator/default.rb
+++ b/core/app/models/spree/settlement/eligibility_validator/default.rb
@@ -9,7 +9,9 @@ module Spree
           Settlement::EligibilityValidator::OrderCompleted,
           Settlement::EligibilityValidator::TimeSincePurchase,
           Settlement::EligibilityValidator::ShipmentShipped,
-          Settlement::EligibilityValidator::ItemReturned
+          Settlement::EligibilityValidator::ItemReturned,
+          Settlement::EligibilityValidator::SettlementExists,
+          Settlement::EligibilityValidator::SettlementAmount
         ]
 
         def eligible_for_settlement?

--- a/core/app/models/spree/settlement/eligibility_validator/item_returned.rb
+++ b/core/app/models/spree/settlement/eligibility_validator/item_returned.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Spree
+  class Settlement < Spree::Base
+    module EligibilityValidator
+      class ItemReturned < Spree::Settlement::EligibilityValidator::BaseValidator
+        def eligible_for_settlement?
+          return unless @settlement.reimbursement && @settlement.shipment
+          shipment_returned_items = Spree::ReturnItem
+            .joins(inventory_unit: :shipment)
+            .where("spree_shipments.id = ?", @settlement.shipment.id)
+          if (shipment_returned_items & @settlement.reimbursement.return_items).any?
+            true
+          else
+            add_error(:item_returned, I18n.t('spree.settlement_return_items_ineligible'))
+            false
+          end
+        end
+
+        def requires_manual_intervention?
+          @errors.present?
+        end
+      end
+    end
+  end
+end

--- a/core/app/models/spree/settlement/eligibility_validator/item_returned.rb
+++ b/core/app/models/spree/settlement/eligibility_validator/item_returned.rb
@@ -5,7 +5,7 @@ module Spree
     module EligibilityValidator
       class ItemReturned < Spree::Settlement::EligibilityValidator::BaseValidator
         def eligible_for_settlement?
-          return unless @settlement.reimbursement && @settlement.shipment
+          return true unless @settlement.shipment
           shipment_returned_items = Spree::ReturnItem
             .joins(inventory_unit: :shipment)
             .where("spree_shipments.id = ?", @settlement.shipment.id)

--- a/core/app/models/spree/settlement/eligibility_validator/no_settlement.rb
+++ b/core/app/models/spree/settlement/eligibility_validator/no_settlement.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Spree
+  class Settlement < Spree::Base
+    module EligibilityValidator
+      class NoSettlement < Spree::Settlement::EligibilityValidator::BaseValidator
+        def eligible_for_settlement?
+          return unless @settlement.shipment
+          if Spree::Settlement.where(shipment: @settlement.shipment).where.not(id: @settlement.id).empty?
+            true
+          else
+            add_error(:settlement_already_exists, I18n.t('spree.settlement_already_exists_for_shipment'))
+            false
+          end
+        end
+
+        def requires_manual_intervention?
+          false
+        end
+      end
+    end
+  end
+end

--- a/core/app/models/spree/settlement/eligibility_validator/order_completed.rb
+++ b/core/app/models/spree/settlement/eligibility_validator/order_completed.rb
@@ -5,7 +5,6 @@ module Spree
     module EligibilityValidator
       class OrderCompleted < Spree::Settlement::EligibilityValidator::BaseValidator
         def eligible_for_settlement?
-          return unless @settlement.reimbursement
           if @settlement.reimbursement.order.completed?
             true
           else

--- a/core/app/models/spree/settlement/eligibility_validator/order_completed.rb
+++ b/core/app/models/spree/settlement/eligibility_validator/order_completed.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Spree
+  class Settlement < Spree::Base
+    module EligibilityValidator
+      class OrderCompleted < Spree::Settlement::EligibilityValidator::BaseValidator
+        def eligible_for_settlement?
+          return unless @settlement.reimbursement
+          if @settlement.reimbursement.order.completed?
+            true
+          else
+            add_error(:order_not_completed, I18n.t('spree.settlement_order_not_completed'))
+            false
+          end
+        end
+
+        def requires_manual_intervention?
+          false
+        end
+      end
+    end
+  end
+end

--- a/core/app/models/spree/settlement/eligibility_validator/settlement_amount.rb
+++ b/core/app/models/spree/settlement/eligibility_validator/settlement_amount.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Spree
+  class Settlement < Spree::Base
+    module EligibilityValidator
+      class SettlementAmount < Spree::Settlement::EligibilityValidator::BaseValidator
+        def eligible_for_settlement?
+          return true unless @settlement.shipment
+          if @settlement.amount > @settlement.shipment.cost
+            add_error(:settlement_amount, I18n.t('spree.settlement_amount_greater_than_shipment_cost'))
+            false
+          else
+            true
+          end
+        end
+
+        def requires_manual_intervention?
+          false
+        end
+      end
+    end
+  end
+end

--- a/core/app/models/spree/settlement/eligibility_validator/settlement_amount.rb
+++ b/core/app/models/spree/settlement/eligibility_validator/settlement_amount.rb
@@ -6,7 +6,7 @@ module Spree
       class SettlementAmount < Spree::Settlement::EligibilityValidator::BaseValidator
         def eligible_for_settlement?
           return true unless @settlement.shipment
-          if @settlement.amount > @settlement.shipment.cost
+          if @settlement.amount > @settlement.shipment.total_before_tax
             add_error(:settlement_amount, I18n.t('spree.settlement_amount_greater_than_shipment_cost'))
             false
           else

--- a/core/app/models/spree/settlement/eligibility_validator/settlement_exists.rb
+++ b/core/app/models/spree/settlement/eligibility_validator/settlement_exists.rb
@@ -5,7 +5,7 @@ module Spree
     module EligibilityValidator
       class SettlementExists < Spree::Settlement::EligibilityValidator::BaseValidator
         def eligible_for_settlement?
-          return unless @settlement.shipment
+          return true unless @settlement.shipment
           if Spree::Settlement
             .where(shipment: @settlement.shipment, acceptance_status: 'accepted')
             .where.not(id: @settlement.id).empty?

--- a/core/app/models/spree/settlement/eligibility_validator/settlement_exists.rb
+++ b/core/app/models/spree/settlement/eligibility_validator/settlement_exists.rb
@@ -3,10 +3,12 @@
 module Spree
   class Settlement < Spree::Base
     module EligibilityValidator
-      class NoSettlement < Spree::Settlement::EligibilityValidator::BaseValidator
+      class SettlementExists < Spree::Settlement::EligibilityValidator::BaseValidator
         def eligible_for_settlement?
           return unless @settlement.shipment
-          if Spree::Settlement.where(shipment: @settlement.shipment).where.not(id: @settlement.id).empty?
+          if Spree::Settlement
+            .where(shipment: @settlement.shipment, acceptance_status: 'accepted')
+            .where.not(id: @settlement.id).empty?
             true
           else
             add_error(:settlement_already_exists, I18n.t('spree.settlement_already_exists_for_shipment'))

--- a/core/app/models/spree/settlement/eligibility_validator/shipment_shipped.rb
+++ b/core/app/models/spree/settlement/eligibility_validator/shipment_shipped.rb
@@ -5,7 +5,7 @@ module Spree
     module EligibilityValidator
       class ShipmentShipped < Spree::Settlement::EligibilityValidator::BaseValidator
         def eligible_for_settlement?
-          return unless @settlement.shipment
+          return true unless @settlement.shipment
           if @settlement.shipment.shipped?
             true
           else

--- a/core/app/models/spree/settlement/eligibility_validator/shipment_shipped.rb
+++ b/core/app/models/spree/settlement/eligibility_validator/shipment_shipped.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Spree
+  class Settlement < Spree::Base
+    module EligibilityValidator
+      class ShipmentShipped < Spree::Settlement::EligibilityValidator::BaseValidator
+        def eligible_for_settlement?
+          return unless @settlement.shipment
+          if @settlement.shipment.shipped?
+            true
+          else
+            add_error(:shipment_shipped, I18n.t('spree.settlement_shipment_ineligible'))
+            false
+          end
+        end
+
+        def requires_manual_intervention?
+          @errors.present?
+        end
+      end
+    end
+  end
+end

--- a/core/app/models/spree/settlement/eligibility_validator/time_since_purchase.rb
+++ b/core/app/models/spree/settlement/eligibility_validator/time_since_purchase.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Spree
+  class Settlement < Spree::Base
+    module EligibilityValidator
+      class TimeSincePurchase < Spree::Settlement::EligibilityValidator::BaseValidator
+        def eligible_for_settlement?
+          return unless @settlement.reimbursement
+          if (@settlement.reimbursement.order.completed_at + Spree::Config[:settlement_eligibility_number_of_days].days) > Time.current
+            true
+          else
+            add_error(:number_of_days, I18n.t('spree.settlement_time_period_ineligible'))
+            false
+          end
+        end
+
+        def requires_manual_intervention?
+          false
+        end
+      end
+    end
+  end
+end

--- a/core/app/models/spree/settlement/eligibility_validator/time_since_purchase.rb
+++ b/core/app/models/spree/settlement/eligibility_validator/time_since_purchase.rb
@@ -5,7 +5,6 @@ module Spree
     module EligibilityValidator
       class TimeSincePurchase < Spree::Settlement::EligibilityValidator::BaseValidator
         def eligible_for_settlement?
-          return unless @settlement.reimbursement
           if (@settlement.reimbursement.order.completed_at + Spree::Config[:settlement_eligibility_number_of_days].days) > Time.current
             true
           else

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -13,6 +13,7 @@ module Spree
     has_many :shipping_methods, through: :shipping_rates
     has_many :state_changes, as: :stateful
     has_many :cartons, -> { distinct }, through: :inventory_units
+    has_many :settlements, inverse_of: :shipment
 
     before_validation :set_cost_zero_when_nil
 

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1859,6 +1859,7 @@ en:
     server: Server
     server_error: The server returned an error
     settings: Settings
+    settlement_already_exists_for_shipment: A settlement already exists for this shipment
     settlement_can_only_be_created_if_shipment_has_returned_items: Settlement can only be created for shipments that have returned items
     settlement_order_not_completed: Settlement's order must be completed
     settlement_return_items_ineligible: Settlement's shipment must contain a return item from the reimbursement

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1859,11 +1859,18 @@ en:
     server: Server
     server_error: The server returned an error
     settings: Settings
-    settlement_already_exists_for_shipment: A settlement already exists for this shipment
+    settlement_already_exists_for_shipment: An accepted settlement already exists for this shipment
+    settlement_amount_greater_than_shipment_cost: The settlement's amount can't be greater than the shipment's cost
     settlement_can_only_be_created_if_shipment_has_returned_items: Settlement can only be created for shipments that have returned items
+    settlement_manually_rejected: The settlement was manually rejected
     settlement_order_not_completed: Settlement's order must be completed
     settlement_return_items_ineligible: Settlement's shipment must contain a return item from the reimbursement
     settlement_shipment_ineligible: Settlement's shipment must be shipped
+    settlement_states:
+      pending: Pending
+      manual_intervention_required: Manual
+      accepted: Accepted
+      rejected: Rejected
     settlement_time_period_ineligible: Settlement is outside the eligible time period
     ship: ship
     ship_address: Ship Address

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -276,6 +276,12 @@ en:
         state: State
       spree/role:
         name: Name
+      spree/settlement:
+        amount: Amount Before Sales Tax
+        acceptance_status: Acceptance status
+        acceptance_status_errors: Acceptance errors
+        reimbursement_type_id: Reimbursement Type
+        total: Total
       spree/shipping_category:
         name: Name
       spree/shipment:
@@ -686,6 +692,10 @@ en:
               cannot_be_associated_unless_accepted: cannot be associated to a return item that is not accepted.
             inventory_unit:
               other_completed_return_item_exists: "%{inventory_unit_id} has already been taken by return item %{return_item_id}"
+        spree/settlement:
+          attributes:
+            shipment:
+              must_belong_to_reimbursement_order: must belong to the same customer order as the reimbursement
         spree/shipment:
           attributes:
             state:
@@ -1366,6 +1376,7 @@ en:
     image: Image
     images: Images
     implement_eligible_for_return: "Must implement #eligible_for_return? for your EligibilityValidator."
+    implement_eligible_for_settlement: "Must implement #eligible_for_settlement? for your EligibilityValidator."
     implement_requires_manual_intervention: "Must implement #requires_manual_intervention? for your EligibilityValidator."
     inactive: Inactive
     incl: incl.
@@ -1838,6 +1849,8 @@ en:
     select: Select
     select_a_reason: Select a reason
     select_a_stock_location: Select a stock location
+    settlements: Settlements
+    shipments_to_be_reimbursed: Shipments to be reimbursed
     select_stock: Select stock
     selected_quantity_not_available: ! 'selected of %{item} is not available.'
     send_copy_of_all_mails_to: Send Copy of All Mails To
@@ -1846,6 +1859,11 @@ en:
     server: Server
     server_error: The server returned an error
     settings: Settings
+    settlement_can_only_be_created_if_shipment_has_returned_items: Settlement can only be created for shipments that have returned items
+    settlement_order_not_completed: Settlement's order must be completed
+    settlement_return_items_ineligible: Settlement's shipment must contain a return item from the reimbursement
+    settlement_shipment_ineligible: Settlement's shipment must be shipped
+    settlement_time_period_ineligible: Settlement is outside the eligible time period
     ship: ship
     ship_address: Ship Address
     ship_address_required: Valid shipping address required

--- a/core/db/migrate/20180530092700_create_spree_settlements.rb
+++ b/core/db/migrate/20180530092700_create_spree_settlements.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateSpreeSettlements < ActiveRecord::Migration[5.2]
+class CreateSpreeSettlements < ActiveRecord::Migration[5.1]
   def change
     create_table :spree_settlements do |t|
       t.decimal :amount, precision: 12, scale: 4, default: "0.0", null: false

--- a/core/db/migrate/20180530092700_create_spree_settlements.rb
+++ b/core/db/migrate/20180530092700_create_spree_settlements.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class CreateSpreeSettlements < ActiveRecord::Migration[5.2]
+  def change
+    create_table :spree_settlements do |t|
+      t.decimal :amount, precision: 12, scale: 4, default: "0.0", null: false
+      t.decimal :included_tax_total, precision: 12, scale: 4, default: "0.0", null: false
+      t.decimal :additional_tax_total, precision: 12, scale: 4, default: "0.0", null: false
+      t.string :acceptance_status
+      t.text :acceptance_status_errors
+
+      t.references :reimbursement, index: false
+      t.references :reimbursement_type, index: false
+      t.references :shipment
+
+      t.timestamps precision: 6
+    end
+  end
+end

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -194,6 +194,10 @@ module Spree
     #   @return [Integer] default: 365
     preference :return_eligibility_number_of_days, :integer, default: 365
 
+    # @!attribute [rw] settlement_eligibility_number_of_days
+    #   @return [Integer] default: 365
+    preference :settlement_eligibility_number_of_days, :integer, default: 365
+
     # @!attribute [rw] roles_for_auto_api_key
     #   @return [Array] An array of roles where generating an api key for a user
     #   at role_user creation is desired when user has one of these roles.

--- a/core/lib/spree/testing_support/factories/reimbursement_factory.rb
+++ b/core/lib/spree/testing_support/factories/reimbursement_factory.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factories/customer_return_factory'
+require 'spree/testing_support/factories/settlement_factory'
 
 FactoryBot.define do
   factory :reimbursement, class: 'Spree::Reimbursement' do
     transient do
       return_items_count 1
+      settlements_count 0
     end
 
     customer_return { create(:customer_return_with_accepted_items, line_items_count: return_items_count) }
@@ -16,6 +18,13 @@ FactoryBot.define do
         reimbursement.return_items = reimbursement.customer_return.return_items
       end
       reimbursement.total = reimbursement.return_items.map { |ri| ri.amount }.sum
+    end
+
+    after(:create) do |reimbursement, evaluator|
+      if evaluator.settlements_count > 0
+        shipment = reimbursement.return_items.first.shipment
+        create_list(:settlement, evaluator.settlements_count, reimbursement: reimbursement, shipment: shipment)
+      end
     end
   end
 end

--- a/core/lib/spree/testing_support/factories/settlement_factory.rb
+++ b/core/lib/spree/testing_support/factories/settlement_factory.rb
@@ -6,11 +6,12 @@ FactoryBot.define do
   factory :settlement, class: 'Spree::Settlement' do
     acceptance_status 'pending'
     reimbursement
+    reimbursement_type
     transient do
       has_shipment? true
     end
-    before(:create) do |settlement, _evaluator|
-      if _evaluator.has_shipment?
+    before(:create) do |settlement, evaluator|
+      if evaluator.has_shipment?
         settlement.shipment ||= settlement.reimbursement.return_items.first.shipment
       end
     end

--- a/core/lib/spree/testing_support/factories/settlement_factory.rb
+++ b/core/lib/spree/testing_support/factories/settlement_factory.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factories/reimbursement_factory'
+require 'spree/testing_support/factories/reimbursement_type_factory'
 
 FactoryBot.define do
   factory :settlement, class: 'Spree::Settlement' do

--- a/core/lib/spree/testing_support/factories/settlement_factory.rb
+++ b/core/lib/spree/testing_support/factories/settlement_factory.rb
@@ -7,7 +7,6 @@ FactoryBot.define do
   factory :settlement, class: 'Spree::Settlement' do
     acceptance_status 'pending'
     reimbursement
-    reimbursement_type
     transient do
       has_shipment? true
     end

--- a/core/lib/spree/testing_support/factories/settlement_factory.rb
+++ b/core/lib/spree/testing_support/factories/settlement_factory.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'spree/testing_support/factories/reimbursement_factory'
+
+FactoryBot.define do
+  factory :settlement, class: 'Spree::Settlement' do
+    acceptance_status 'pending'
+    reimbursement
+    transient do
+      has_shipment? true
+    end
+    before(:create) do |settlement, _evaluator|
+      if _evaluator.has_shipment?
+        settlement.shipment ||= settlement.reimbursement.return_items.first.shipment
+      end
+    end
+  end
+end

--- a/core/lib/spree/testing_support/factories/settlement_factory.rb
+++ b/core/lib/spree/testing_support/factories/settlement_factory.rb
@@ -6,14 +6,5 @@ require 'spree/testing_support/factories/reimbursement_type_factory'
 FactoryBot.define do
   factory :settlement, class: 'Spree::Settlement' do
     acceptance_status 'pending'
-    reimbursement
-    transient do
-      has_shipment? true
-    end
-    before(:create) do |settlement, evaluator|
-      if evaluator.has_shipment?
-        settlement.shipment ||= settlement.reimbursement.return_items.first.shipment
-      end
-    end
   end
 end

--- a/core/spec/lib/spree/core/testing_support/factories/settlement_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/settlement_factory_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'spree/testing_support/factories/settlement_factory'
+
+RSpec.describe 'settlement factory' do
+  let(:factory_class) { Spree::Settlement }
+
+  describe 'plain settlement' do
+    let(:factory) { :settlement }
+
+    it_behaves_like 'a working factory'
+  end
+end

--- a/core/spec/models/spree/reimbursement/reimbursement_type_engine_spec.rb
+++ b/core/spec/models/spree/reimbursement/reimbursement_type_engine_spec.rb
@@ -6,21 +6,15 @@ module Spree
   RSpec.describe Reimbursement::ReimbursementTypeEngine, type: :model do
     describe '#calculate_reimbursement_types' do
       let(:reimbursement_type_engine) { Spree::Reimbursement::ReimbursementTypeEngine.new(reimbursement) }
-      let(:expired_reimbursement_type) { Spree::ReimbursementType::OriginalPayment }
-      let(:override_reimbursement_type) { Spree::ReimbursementType::OriginalPayment.new }
-      let(:preferred_reimbursement_type) { Spree::ReimbursementType::OriginalPayment.new }
-      let(:settlement_reimbursement_type) { Spree::ReimbursementType::OriginalPayment.new }
-      let(:exchange_reimbursement_type) { Spree::ReimbursementType::Exchange.new }
+      let(:original_payment) { Spree::ReimbursementType::OriginalPayment.new }
+      let(:store_credit) { Spree::ReimbursementType::StoreCredit.new }
+      let(:exchange) { Spree::ReimbursementType::Exchange.new }
       let(:calculated_reimbursement_types) { subject }
       let(:all_reimbursement_types) {
         [
-          reimbursement_type_engine.default_reimbursement_type,
-          reimbursement_type_engine.exchange_reimbursement_type,
-          expired_reimbursement_type,
-          override_reimbursement_type,
-          preferred_reimbursement_type,
-          settlement_reimbursement_type,
-          exchange_reimbursement_type
+          original_payment,
+          store_credit,
+          exchange
         ]
       }
 
@@ -41,7 +35,7 @@ module Spree
         let(:reimbursement)   { create(:reimbursement, customer_return: customer_return, return_items: return_items) }
 
         before do
-          reimbursement_type_engine.expired_reimbursement_type = expired_reimbursement_type
+          reimbursement_type_engine.expired_reimbursement_type = exchange.class
           allow(return_item.inventory_unit.shipment).to receive(:shipped_at).and_return(Date.yesterday)
           allow(return_item).to receive(:exchange_required?).and_return(false)
         end
@@ -64,14 +58,14 @@ module Spree
 
         context 'the return item does not require exchange' do
           context 'the return item has an override reimbursement type' do
-            before { allow(return_item).to receive(:override_reimbursement_type).and_return(override_reimbursement_type) }
+            before { allow(return_item).to receive(:override_reimbursement_type).and_return(store_credit) }
 
             it 'returns a hash with the override reimbursement type associated to the return items' do
-              expect(calculated_reimbursement_types[override_reimbursement_type.class]).to eq(return_items)
+              expect(calculated_reimbursement_types[store_credit.class]).to eq(return_items)
             end
 
             it 'the return items are not included in any of the other reimbursement types' do
-              (all_reimbursement_types - [override_reimbursement_type.class]).each do |r_type|
+              (all_reimbursement_types - [store_credit.class]).each do |r_type|
                 expect(calculated_reimbursement_types[r_type]).to eq([])
               end
             end
@@ -81,17 +75,17 @@ module Spree
 
           context 'the return item does not have an override reimbursement type' do
             context 'the return item has a preferred reimbursement type' do
-              before { allow(return_item).to receive(:preferred_reimbursement_type).and_return(preferred_reimbursement_type) }
+              before { allow(return_item).to receive(:preferred_reimbursement_type).and_return(store_credit) }
 
               context 'the reimbursement type is not valid for the return item' do
                 before { expect(reimbursement_type_engine).to receive(:valid_preferred_reimbursement_type?).and_return(false) }
 
                 it 'returns a hash with no return items associated to the preferred reimbursement type' do
-                  expect(calculated_reimbursement_types[preferred_reimbursement_type]).to eq([])
+                  expect(calculated_reimbursement_types[store_credit.class]).to eq([])
                 end
 
                 it 'the return items are not included in any of the other reimbursement types' do
-                  (all_reimbursement_types - [preferred_reimbursement_type]).each do |r_type|
+                  (all_reimbursement_types - [store_credit.class]).each do |r_type|
                     expect(calculated_reimbursement_types[r_type]).to eq([])
                   end
                 end
@@ -101,11 +95,11 @@ module Spree
 
               context 'the reimbursement type is valid for the return item' do
                 it 'returns a hash with the expired reimbursement type associated to the return items' do
-                  expect(calculated_reimbursement_types[preferred_reimbursement_type.class]).to eq(return_items)
+                  expect(calculated_reimbursement_types[store_credit.class]).to eq(return_items)
                 end
 
                 it 'the return items are not included in any of the other reimbursement types' do
-                  (all_reimbursement_types - [preferred_reimbursement_type.class]).each do |r_type|
+                  (all_reimbursement_types - [store_credit.class]).each do |r_type|
                     expect(calculated_reimbursement_types[r_type]).to eq([])
                   end
                 end
@@ -119,11 +113,11 @@ module Spree
                 before { allow(reimbursement_type_engine).to receive(:past_reimbursable_time_period?).and_return(true) }
 
                 it 'returns a hash with the expired reimbursement type associated to the return items' do
-                  expect(calculated_reimbursement_types[expired_reimbursement_type]).to eq(return_items)
+                  expect(calculated_reimbursement_types[exchange.class]).to eq(return_items)
                 end
 
                 it 'the return items are not included in any of the other reimbursement types' do
-                  (all_reimbursement_types - [expired_reimbursement_type]).each do |r_type|
+                  (all_reimbursement_types - [exchange.class]).each do |r_type|
                     expect(calculated_reimbursement_types[r_type]).to eq([])
                   end
                 end
@@ -151,21 +145,25 @@ module Spree
 
       context 'the reimbursement contains a settlement' do
         let(:return_item) { create(:return_item, acceptance_status: 'accepted') }
-        let(:customer_return) { build(:customer_return, return_items: [return_item]) }
-        let(:reimbursement) { create(:reimbursement, customer_return: customer_return, return_items: [return_item]) }
+        let(:return_items)    { [return_item] }
+        let(:customer_return) { build(:customer_return, return_items: return_items) }
+        let(:settlement) { create(:settlement) }
+        let(:reimbursement) { create(:reimbursement, customer_return: customer_return, return_items: return_items, settlements: [settlement]) }
 
         context 'the settlement is accepted' do
-          let!(:settlement) { create(:settlement, reimbursement: reimbursement, acceptance_status: 'accepted') }
+          before do
+            settlement.acceptance_status = 'accepted'
+          end
 
           context 'the settlement has a reimbursement_type' do
-            before { allow_any_instance_of(Spree::Settlement).to receive(:reimbursement_type).and_return(settlement_reimbursement_type) }
+            before { allow_any_instance_of(Spree::Settlement).to receive(:reimbursement_type).and_return(store_credit) }
 
             it 'returns a hash with the reimbursement type associated to the settlement' do
-              expect(calculated_reimbursement_types[settlement_reimbursement_type.class]).to include(settlement)
+              expect(calculated_reimbursement_types[store_credit.class]).to include(settlement)
             end
 
             it 'the settlement is not included in any of the other reimbursement types' do
-              (all_reimbursement_types - [reimbursement_type_engine.default_reimbursement_type]).each do |r_type|
+              (all_reimbursement_types - [store_credit.class]).each do |r_type|
                 expect(calculated_reimbursement_types[r_type]).not_to include(settlement)
               end
             end
@@ -184,7 +182,7 @@ module Spree
           end
 
           context 'the settlement has an invalid reimbursement_type' do
-            before { allow_any_instance_of(Spree::Settlement).to receive(:reimbursement_type).and_return(exchange_reimbursement_type) }
+            before { allow_any_instance_of(Spree::Settlement).to receive(:reimbursement_type).and_return(exchange) }
 
             it 'the settlement is not included in any of the reimbursement types' do
               all_reimbursement_types.each do |r_type|
@@ -195,7 +193,9 @@ module Spree
         end
 
         context 'the settlement is rejected' do
-          let!(:settlement) { create(:settlement, reimbursement: reimbursement, acceptance_status: 'rejected') }
+          before do
+            settlement.acceptance_status = 'rejected'
+          end
 
           it 'the settlement is not included in any of the reimbursement types' do
             all_reimbursement_types.each do |r_type|

--- a/core/spec/models/spree/reimbursement/reimbursement_type_engine_spec.rb
+++ b/core/spec/models/spree/reimbursement/reimbursement_type_engine_spec.rb
@@ -5,21 +5,23 @@ require 'rails_helper'
 module Spree
   RSpec.describe Reimbursement::ReimbursementTypeEngine, type: :model do
     describe '#calculate_reimbursement_types' do
-      let(:return_item)   { create(:return_item) }
-      let(:return_items)  { [return_item] }
-      let(:reimbursement_type_engine) { Spree::Reimbursement::ReimbursementTypeEngine.new(return_items) }
+      let(:reimbursement_type_engine) { Spree::Reimbursement::ReimbursementTypeEngine.new(reimbursement) }
       let(:expired_reimbursement_type) { Spree::ReimbursementType::OriginalPayment }
       let(:override_reimbursement_type) { Spree::ReimbursementType::OriginalPayment.new }
       let(:preferred_reimbursement_type) { Spree::ReimbursementType::OriginalPayment.new }
+      let(:settlement_reimbursement_type) { Spree::ReimbursementType::OriginalPayment.new }
+      let(:exchange_reimbursement_type) { Spree::ReimbursementType::Exchange.new }
       let(:calculated_reimbursement_types) { subject }
       let(:all_reimbursement_types) {
         [
-                                        reimbursement_type_engine.default_reimbursement_type,
-                                        reimbursement_type_engine.exchange_reimbursement_type,
-                                        expired_reimbursement_type,
-                                        override_reimbursement_type,
-                                        preferred_reimbursement_type
-                                    ]
+          reimbursement_type_engine.default_reimbursement_type,
+          reimbursement_type_engine.exchange_reimbursement_type,
+          expired_reimbursement_type,
+          override_reimbursement_type,
+          preferred_reimbursement_type,
+          settlement_reimbursement_type,
+          exchange_reimbursement_type
+        ]
       }
 
       subject { reimbursement_type_engine.calculate_reimbursement_types }
@@ -32,38 +34,27 @@ module Spree
         end
       end
 
-      before do
-        reimbursement_type_engine.expired_reimbursement_type = expired_reimbursement_type
-        allow(return_item.inventory_unit.shipment).to receive(:shipped_at).and_return(Date.yesterday)
-        allow(return_item).to receive(:exchange_required?).and_return(false)
-      end
+      context 'the reimbursement does not contain a settlement' do
+        let(:return_item)     { create(:return_item, acceptance_status: 'accepted') }
+        let(:return_items)    { [return_item] }
+        let(:customer_return) { build(:customer_return, return_items: return_items) }
+        let(:reimbursement)   { create(:reimbursement, customer_return: customer_return, return_items: return_items) }
 
-      context 'the return item requires exchange' do
-        before { allow(return_item).to receive(:exchange_required?).and_return(true) }
-
-        it 'returns a hash with the exchange reimbursement type associated to the return items' do
-          expect(calculated_reimbursement_types[reimbursement_type_engine.exchange_reimbursement_type]).to eq(return_items)
+        before do
+          reimbursement_type_engine.expired_reimbursement_type = expired_reimbursement_type
+          allow(return_item.inventory_unit.shipment).to receive(:shipped_at).and_return(Date.yesterday)
+          allow(return_item).to receive(:exchange_required?).and_return(false)
         end
 
-        it 'the return items are not included in any of the other reimbursement types' do
-          (all_reimbursement_types - [reimbursement_type_engine.exchange_reimbursement_type]).each do |r_type|
-            expect(calculated_reimbursement_types[r_type]).to eq([])
-          end
-        end
+        context 'the return item requires exchange' do
+          before { allow(return_item).to receive(:exchange_required?).and_return(true) }
 
-        it_should_behave_like 'reimbursement type hash'
-      end
-
-      context 'the return item does not require exchange' do
-        context 'the return item has an override reimbursement type' do
-          before { allow(return_item).to receive(:override_reimbursement_type).and_return(override_reimbursement_type) }
-
-          it 'returns a hash with the override reimbursement type associated to the return items' do
-            expect(calculated_reimbursement_types[override_reimbursement_type.class]).to eq(return_items)
+          it 'returns a hash with the exchange reimbursement type associated to the return items' do
+            expect(calculated_reimbursement_types[reimbursement_type_engine.exchange_reimbursement_type]).to eq([return_item])
           end
 
           it 'the return items are not included in any of the other reimbursement types' do
-            (all_reimbursement_types - [override_reimbursement_type.class]).each do |r_type|
+            (all_reimbursement_types - [reimbursement_type_engine.exchange_reimbursement_type]).each do |r_type|
               expect(calculated_reimbursement_types[r_type]).to eq([])
             end
           end
@@ -71,70 +62,144 @@ module Spree
           it_should_behave_like 'reimbursement type hash'
         end
 
-        context 'the return item does not have an override reimbursement type' do
-          context 'the return item has a preferred reimbursement type' do
-            before { allow(return_item).to receive(:preferred_reimbursement_type).and_return(preferred_reimbursement_type) }
+        context 'the return item does not require exchange' do
+          context 'the return item has an override reimbursement type' do
+            before { allow(return_item).to receive(:override_reimbursement_type).and_return(override_reimbursement_type) }
 
-            context 'the reimbursement type is not valid for the return item' do
-              before { expect(reimbursement_type_engine).to receive(:valid_preferred_reimbursement_type?).and_return(false) }
-
-              it 'returns a hash with no return items associated to the preferred reimbursement type' do
-                expect(calculated_reimbursement_types[preferred_reimbursement_type]).to eq([])
-              end
-
-              it 'the return items are not included in any of the other reimbursement types' do
-                (all_reimbursement_types - [preferred_reimbursement_type]).each do |r_type|
-                  expect(calculated_reimbursement_types[r_type]).to eq([])
-                end
-              end
-
-              it_should_behave_like 'reimbursement type hash'
+            it 'returns a hash with the override reimbursement type associated to the return items' do
+              expect(calculated_reimbursement_types[override_reimbursement_type.class]).to eq(return_items)
             end
 
-            context 'the reimbursement type is valid for the return item' do
-              it 'returns a hash with the expired reimbursement type associated to the return items' do
-                expect(calculated_reimbursement_types[preferred_reimbursement_type.class]).to eq(return_items)
+            it 'the return items are not included in any of the other reimbursement types' do
+              (all_reimbursement_types - [override_reimbursement_type.class]).each do |r_type|
+                expect(calculated_reimbursement_types[r_type]).to eq([])
               end
+            end
 
-              it 'the return items are not included in any of the other reimbursement types' do
-                (all_reimbursement_types - [preferred_reimbursement_type.class]).each do |r_type|
-                  expect(calculated_reimbursement_types[r_type]).to eq([])
+            it_should_behave_like 'reimbursement type hash'
+          end
+
+          context 'the return item does not have an override reimbursement type' do
+            context 'the return item has a preferred reimbursement type' do
+              before { allow(return_item).to receive(:preferred_reimbursement_type).and_return(preferred_reimbursement_type) }
+
+              context 'the reimbursement type is not valid for the return item' do
+                before { expect(reimbursement_type_engine).to receive(:valid_preferred_reimbursement_type?).and_return(false) }
+
+                it 'returns a hash with no return items associated to the preferred reimbursement type' do
+                  expect(calculated_reimbursement_types[preferred_reimbursement_type]).to eq([])
                 end
+
+                it 'the return items are not included in any of the other reimbursement types' do
+                  (all_reimbursement_types - [preferred_reimbursement_type]).each do |r_type|
+                    expect(calculated_reimbursement_types[r_type]).to eq([])
+                  end
+                end
+
+                it_should_behave_like 'reimbursement type hash'
               end
 
-              it_should_behave_like 'reimbursement type hash'
+              context 'the reimbursement type is valid for the return item' do
+                it 'returns a hash with the expired reimbursement type associated to the return items' do
+                  expect(calculated_reimbursement_types[preferred_reimbursement_type.class]).to eq(return_items)
+                end
+
+                it 'the return items are not included in any of the other reimbursement types' do
+                  (all_reimbursement_types - [preferred_reimbursement_type.class]).each do |r_type|
+                    expect(calculated_reimbursement_types[r_type]).to eq([])
+                  end
+                end
+
+                it_should_behave_like 'reimbursement type hash'
+              end
+            end
+
+            context 'the return item does not have a preferred reimbursement type' do
+              context 'the return item is past the time constraint' do
+                before { allow(reimbursement_type_engine).to receive(:past_reimbursable_time_period?).and_return(true) }
+
+                it 'returns a hash with the expired reimbursement type associated to the return items' do
+                  expect(calculated_reimbursement_types[expired_reimbursement_type]).to eq(return_items)
+                end
+
+                it 'the return items are not included in any of the other reimbursement types' do
+                  (all_reimbursement_types - [expired_reimbursement_type]).each do |r_type|
+                    expect(calculated_reimbursement_types[r_type]).to eq([])
+                  end
+                end
+
+                it_should_behave_like 'reimbursement type hash'
+              end
+
+              context 'the return item is within the time constraint' do
+                it 'returns a hash with the default reimbursement type associated to the return items' do
+                  expect(calculated_reimbursement_types[reimbursement_type_engine.default_reimbursement_type]).to eq(return_items)
+                end
+
+                it 'the return items are not included in any of the other reimbursement types' do
+                  (all_reimbursement_types - [reimbursement_type_engine.default_reimbursement_type]).each do |r_type|
+                    expect(calculated_reimbursement_types[r_type]).to eq([])
+                  end
+                end
+
+                it_should_behave_like 'reimbursement type hash'
+              end
+            end
+          end
+        end
+      end
+
+      context 'the reimbursement contains a settlement' do
+        let(:return_item) { create(:return_item, acceptance_status: 'accepted') }
+        let(:customer_return) { build(:customer_return, return_items: [return_item]) }
+        let(:reimbursement) { create(:reimbursement, customer_return: customer_return, return_items: [return_item]) }
+
+        context 'the settlement is accepted' do
+          let!(:settlement) { create(:settlement, reimbursement: reimbursement, acceptance_status: 'accepted') }
+
+          context 'the settlement has a reimbursement_type' do
+            before { allow_any_instance_of(Spree::Settlement).to receive(:reimbursement_type).and_return(settlement_reimbursement_type) }
+
+            it 'returns a hash with the reimbursement type associated to the settlement' do
+              expect(calculated_reimbursement_types[settlement_reimbursement_type.class]).to include(settlement)
+            end
+
+            it 'the settlement is not included in any of the other reimbursement types' do
+              (all_reimbursement_types - [reimbursement_type_engine.default_reimbursement_type]).each do |r_type|
+                expect(calculated_reimbursement_types[r_type]).not_to include(settlement)
+              end
             end
           end
 
-          context 'the return item does not have a preferred reimbursement type' do
-            context 'the return item is past the time constraint' do
-              before { allow(reimbursement_type_engine).to receive(:past_reimbursable_time_period?).and_return(true) }
-
-              it 'returns a hash with the expired reimbursement type associated to the return items' do
-                expect(calculated_reimbursement_types[expired_reimbursement_type]).to eq(return_items)
-              end
-
-              it 'the return items are not included in any of the other reimbursement types' do
-                (all_reimbursement_types - [expired_reimbursement_type]).each do |r_type|
-                  expect(calculated_reimbursement_types[r_type]).to eq([])
-                end
-              end
-
-              it_should_behave_like 'reimbursement type hash'
+          context 'the settlement does not have a reimbursement_type' do
+            it 'returns a hash with the default reimbursement type associated to the settlement' do
+              expect(calculated_reimbursement_types[reimbursement_type_engine.default_reimbursement_type]).to include(settlement)
             end
 
-            context 'the return item is within the time constraint' do
-              it 'returns a hash with the default reimbursement type associated to the return items' do
-                expect(calculated_reimbursement_types[reimbursement_type_engine.default_reimbursement_type]).to eq(return_items)
+            it 'the settlement is not included in any of the other reimbursement types' do
+              (all_reimbursement_types - [reimbursement_type_engine.default_reimbursement_type]).each do |r_type|
+                expect(calculated_reimbursement_types[r_type]).not_to include(settlement)
               end
+            end
+          end
 
-              it 'the return items are not included in any of the other reimbursement types' do
-                (all_reimbursement_types - [reimbursement_type_engine.default_reimbursement_type]).each do |r_type|
-                  expect(calculated_reimbursement_types[r_type]).to eq([])
-                end
+          context 'the settlement has an invalid reimbursement_type' do
+            before { allow_any_instance_of(Spree::Settlement).to receive(:reimbursement_type).and_return(exchange_reimbursement_type) }
+
+            it 'the settlement is not included in any of the reimbursement types' do
+              all_reimbursement_types.each do |r_type|
+                expect(calculated_reimbursement_types[r_type]).not_to include(settlement)
               end
+            end
+          end
+        end
 
-              it_should_behave_like 'reimbursement type hash'
+        context 'the settlement is rejected' do
+          let!(:settlement) { create(:settlement, reimbursement: reimbursement, acceptance_status: 'rejected') }
+
+          it 'the settlement is not included in any of the reimbursement types' do
+            all_reimbursement_types.each do |r_type|
+              expect(calculated_reimbursement_types[r_type]).not_to include(settlement)
             end
           end
         end

--- a/core/spec/models/spree/reimbursement_performer_spec.rb
+++ b/core/spec/models/spree/reimbursement_performer_spec.rb
@@ -3,10 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe Spree::ReimbursementPerformer, type: :model do
+  let(:settlement)              { create(:settlement, reimbursement: reimbursement) }
   let(:reimbursement)           { create(:reimbursement, return_items_count: 1) }
   let(:return_item)             { reimbursement.return_items.first }
   let(:reimbursement_type)      { double("ReimbursementType") }
-  let(:reimbursement_type_hash) { { reimbursement_type => [return_item] } }
+  let(:reimbursement_type_hash) { { reimbursement_type => [return_item, settlement] } }
 
   before do
     expect(Spree::ReimbursementPerformer).to receive(:calculate_reimbursement_types).and_return(reimbursement_type_hash)
@@ -15,8 +16,8 @@ RSpec.describe Spree::ReimbursementPerformer, type: :model do
   describe ".simulate" do
     subject { Spree::ReimbursementPerformer.simulate(reimbursement) }
 
-    it "reimburses each calculated reimbursement types with the correct return items as a simulation" do
-      expect(reimbursement_type).to receive(:reimburse).with(reimbursement, [return_item], true)
+    it "reimburses each calculated reimbursement types with the correct return items and settlements as a simulation" do
+      expect(reimbursement_type).to receive(:reimburse).with(reimbursement, [return_item, settlement], true)
       subject
     end
   end
@@ -24,8 +25,8 @@ RSpec.describe Spree::ReimbursementPerformer, type: :model do
   describe '.perform' do
     subject { Spree::ReimbursementPerformer.perform(reimbursement) }
 
-    it "reimburses each calculated reimbursement types with the correct return items as a simulation" do
-      expect(reimbursement_type).to receive(:reimburse).with(reimbursement, [return_item], false)
+    it "reimburses each calculated reimbursement types with the correct return items and settlements" do
+      expect(reimbursement_type).to receive(:reimburse).with(reimbursement, [return_item, settlement], false)
       subject
     end
   end

--- a/core/spec/models/spree/reimbursement_spec.rb
+++ b/core/spec/models/spree/reimbursement_spec.rb
@@ -195,9 +195,9 @@ RSpec.describe Spree::Reimbursement, type: :model do
       let(:return_item_amount) { BigDecimal('10.003') }
       let(:settlement_amount) { BigDecimal('5.003') }
       let(:return_item) { create(:return_item, inventory_unit: inventory_unit, acceptance_status: 'accepted', amount: return_item_amount) }
+      let(:settlement) { create(:settlement, shipment: shipment, acceptance_status: 'accepted', amount: settlement_amount) }
       let(:customer_return) { build(:customer_return, return_items: [return_item], shipped_order: order) }
-      let(:reimbursement) { create(:reimbursement, customer_return: customer_return, order: order, return_items: [return_item]) }
-      let!(:settlement) { create(:settlement, reimbursement: reimbursement, shipment: shipment, acceptance_status: 'accepted', amount: settlement_amount) }
+      let(:reimbursement) { create(:reimbursement, customer_return: customer_return, order: order, return_items: [return_item], settlements: [settlement]) }
 
       subject { reimbursement.calculated_total }
 

--- a/core/spec/models/spree/reimbursement_tax_calculator_spec.rb
+++ b/core/spec/models/spree/reimbursement_tax_calculator_spec.rb
@@ -8,6 +8,9 @@ RSpec.describe Spree::ReimbursementTaxCalculator, type: :model do
   let(:reimbursement) { create(:reimbursement, return_items_count: 1) }
   let(:return_item) { reimbursement.return_items.first }
   let(:line_item) { return_item.inventory_unit.line_item }
+  let(:order) { reimbursement.order }
+  let(:shipment) { reimbursement.order.shipments.first }
+  let!(:settlement) { create(:settlement, reimbursement: reimbursement, shipment: shipment, amount: shipment.cost) }
 
   subject do
     Spree::ReimbursementTaxCalculator.call(reimbursement)
@@ -22,31 +25,66 @@ RSpec.describe Spree::ReimbursementTaxCalculator, type: :model do
       expect(return_item.additional_tax_total).to eq 0
       expect(return_item.included_tax_total).to eq 0
     end
+
+    it 'leaves the settlements additional_tax_total and included_tax_total at zero' do
+      subject
+
+      expect(settlement.additional_tax_total).to eq 0
+      expect(settlement.included_tax_total).to eq 0
+    end
   end
 
   context 'with additional tax' do
     let!(:tax_rate) { create(:tax_rate, name: "Sales Tax", amount: 0.10, included_in_price: false, zone: tax_zone) }
     let(:tax_zone) { create(:zone, :with_country) }
+    let(:additional_tax_total) { shipment.cost * tax_rate.amount }
+
+    before do
+      shipment.additional_tax_total = additional_tax_total
+      shipment.save
+
+      subject
+    end
 
     it 'sets additional_tax_total on the return items' do
-      subject
       return_item.reload
 
       expect(return_item.additional_tax_total).to be > 0
       expect(return_item.additional_tax_total).to eq line_item.additional_tax_total
+    end
+
+    it 'sets additional_tax_total on the settlements' do
+      settlement.reload
+
+      expect(settlement.additional_tax_total).to be > 0
+      expect(settlement.additional_tax_total).to eq shipment.additional_tax_total
     end
   end
 
   context 'with included tax' do
     let!(:tax_rate) { create(:tax_rate, name: "VAT Tax", amount: 0.1, included_in_price: true, zone: tax_zone) }
     let(:tax_zone) { create(:zone, :with_country) }
+    let(:included_tax_total) { shipment.cost / (100 * (1 + tax_rate.amount)) }
+
+    before do
+      shipment.included_tax_total = included_tax_total
+      shipment.save
+
+      subject
+    end
 
     it 'sets included_tax_total on the return items' do
-      subject
       return_item.reload
 
       expect(return_item.included_tax_total).to be > 0
       expect(return_item.included_tax_total).to eq line_item.included_tax_total
+    end
+
+    it 'sets included_tax_total on the settlements' do
+      settlement.reload
+
+      expect(settlement.included_tax_total).to be > 0
+      expect(settlement.included_tax_total).to eq shipment.included_tax_total
     end
   end
 end

--- a/core/spec/models/spree/reimbursement_tax_calculator_spec.rb
+++ b/core/spec/models/spree/reimbursement_tax_calculator_spec.rb
@@ -5,12 +5,12 @@ require 'rails_helper'
 RSpec.describe Spree::ReimbursementTaxCalculator, type: :model do
   let!(:tax_rate) { nil }
 
-  let(:reimbursement) { create(:reimbursement, return_items_count: 1) }
   let(:return_item) { reimbursement.return_items.first }
+  let(:settlement) { reimbursement.settlements.first }
   let(:line_item) { return_item.inventory_unit.line_item }
   let(:order) { reimbursement.order }
   let(:shipment) { reimbursement.order.shipments.first }
-  let!(:settlement) { create(:settlement, reimbursement: reimbursement, shipment: shipment, amount: shipment.cost) }
+  let(:reimbursement) { create(:reimbursement, return_items_count: 1, settlements_count: 1) }
 
   subject do
     Spree::ReimbursementTaxCalculator.call(reimbursement)

--- a/core/spec/models/spree/settlements/eligibility_validator/default_spec.rb
+++ b/core/spec/models/spree/settlements/eligibility_validator/default_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Spree::Settlement::EligibilityValidator::Default, type: :model do
+  let(:settlement) { create(:settlement) }
+  let(:validator) { Spree::Settlement::EligibilityValidator::Default.new(settlement) }
+
+  let(:item_returned_eligibility_class) { double("ItemReturnedEligibilityValidatorClass") }
+  let(:time_eligibility_class) { double("TimeEligibilityValidatorClass") }
+
+  let(:item_returned_eligibility_instance) { double(errors: item_returned_error) }
+  let(:time_eligibility_instance) { double(errors: time_error) }
+
+  let(:item_returned_error) { {} }
+  let(:time_error) { {} }
+
+  before do
+    validator.permitted_eligibility_validators = [item_returned_eligibility_class, time_eligibility_class]
+
+    expect(item_returned_eligibility_class).to receive(:new).and_return(item_returned_eligibility_instance)
+    expect(time_eligibility_class).to receive(:new).and_return(time_eligibility_instance)
+  end
+
+  describe "#eligible_for_settlement?" do
+    subject { validator.eligible_for_settlement? }
+
+    it "checks that all permitted eligibility validators are eligible for settlement" do
+      expect(item_returned_eligibility_instance).to receive(:eligible_for_settlement?).and_return(true)
+      expect(time_eligibility_instance).to receive(:eligible_for_settlement?).and_return(true)
+
+      expect(subject).to be true
+    end
+  end
+
+  describe "#requires_manual_intervention?" do
+    subject { validator.requires_manual_intervention? }
+
+    context "any of the permitted eligibility validators require manual intervention" do
+      it "returns true" do
+        expect(item_returned_eligibility_instance).to receive(:requires_manual_intervention?).and_return(false)
+        expect(time_eligibility_instance).to receive(:requires_manual_intervention?).and_return(true)
+
+        expect(subject).to be true
+      end
+    end
+
+    context "no permitted eligibility validators require manual intervention" do
+      it "returns false" do
+        expect(item_returned_eligibility_instance).to receive(:requires_manual_intervention?).and_return(false)
+        expect(time_eligibility_instance).to receive(:requires_manual_intervention?).and_return(false)
+
+        expect(subject).to be false
+      end
+    end
+  end
+
+  describe "#errors" do
+    subject { validator.errors }
+
+    context "the validator errors are empty" do
+      it "returns an empty hash" do
+        expect(subject).to eq({})
+      end
+    end
+
+    context "the validators have errors" do
+      let(:item_returned_error) { { item_returned: item_returned_error_text } }
+      let(:time_error) { { time: time_error_text } }
+
+      let(:item_returned_error_text) { "Item returned eligibility error" }
+      let(:time_error_text) { "Time eligibility error" }
+
+      it "gathers all errors from permitted eligibility validators into a single errors hash" do
+        expect(subject).to eq({ item_returned: item_returned_error_text, time: time_error_text })
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/settlements/eligibility_validator/item_returned_spec.rb
+++ b/core/spec/models/spree/settlements/eligibility_validator/item_returned_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Spree::Settlement::EligibilityValidator::ItemReturned do
+  let(:validator) { Spree::Settlement::EligibilityValidator::ItemReturned.new(settlement) }
+
+  describe "#eligible_for_settlement?" do
+    subject { validator.eligible_for_settlement? }
+
+    context "the shipment shares a return item with the reimbursement" do
+      let(:settlement) { create(:settlement) }
+
+      it "returns true" do
+        expect(subject).to be true
+      end
+    end
+
+    context "the shipment does not share a return item with the reimbursement" do
+      let(:order) { create(:completed_order_with_totals) }
+      let(:shipment) { create(:shipment, order: order) }
+      let(:line_item) { order.line_items.first }
+      let(:inventory_unit) { line_item.inventory_units.first }
+      let(:return_item) { build(:return_item, inventory_unit: inventory_unit, acceptance_status: 'accepted') }
+      let(:customer_return) { build(:customer_return, return_items: [return_item]) }
+      let(:reimbursement) { create(:reimbursement, customer_return: customer_return, order: order, return_items: [return_item]) }
+      let(:settlement) { build(:settlement, shipment: shipment, reimbursement: reimbursement) }
+
+      it "returns false" do
+        expect(subject).to be false
+      end
+
+      it "sets an error" do
+        subject
+        expect(validator.errors[:item_returned]).to eq I18n.t('spree.settlement_return_items_ineligible')
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/settlements/eligibility_validator/no_settlement.rb
+++ b/core/spec/models/spree/settlements/eligibility_validator/no_settlement.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Spree::Settlement::EligibilityValidator::NoSettlement do
+  let(:settlement) { create(:settlement) }
+  let(:validator) { Spree::Settlement::EligibilityValidator::NoSettlement.new(settlement) }
+
+  describe "#eligible_for_settlement?" do
+    subject { validator.eligible_for_settlement? }
+
+    context "shipment has no existing settlement" do
+
+      it "returns true" do
+        expect(subject).to be true
+      end
+    end
+
+    context "shipment has an existing settlement" do
+      let!(:another_settlement) { settlement.dup.save }
+
+      it "returns false" do
+        expect(subject).to be false
+      end
+
+      it "sets an error" do
+        subject
+        expect(validator.errors[:settlement_already_exists]).to eq I18n.t('spree.settlement_already_exists_for_shipment')
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/settlements/eligibility_validator/order_completed_spec.rb
+++ b/core/spec/models/spree/settlements/eligibility_validator/order_completed_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Spree::Settlement::EligibilityValidator::OrderCompleted do
+  let(:shipment)       { create(:shipment, order: order) }
+  let(:inventory_unit) { create(:inventory_unit, shipment: shipment) }
+  let(:return_item)    { create(:return_item, inventory_unit: inventory_unit, acceptance_status: :accepted) }
+  let(:reimbursement)  { create(:reimbursement, order: order, return_items: [return_item]) }
+  let(:settlement)     { create(:settlement, shipment: shipment, reimbursement: reimbursement) }
+  let(:validator)      { Spree::Settlement::EligibilityValidator::OrderCompleted.new(settlement) }
+
+  describe "#eligible_for_settlement?" do
+    subject { validator.eligible_for_settlement? }
+
+    context "the order was completed" do
+      let(:order) { create(:completed_order_with_totals) }
+
+      it "returns true" do
+        expect(subject).to be true
+      end
+    end
+
+    context "the order is not completed" do
+      let(:order) { create(:order) }
+
+      it "returns false" do
+        expect(subject).to be false
+      end
+
+      it "sets an error" do
+        subject
+        expect(validator.errors[:order_not_completed]).to eq I18n.t('spree.settlement_order_not_completed')
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/settlements/eligibility_validator/settlement_amount_spec.rb
+++ b/core/spec/models/spree/settlements/eligibility_validator/settlement_amount_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Spree::Settlement::EligibilityValidator::SettlementAmount do
+  let(:settlement) { create(:settlement) }
+  let(:validator) { Spree::Settlement::EligibilityValidator::SettlementAmount.new(settlement) }
+
+  describe "#eligible_for_settlement?" do
+    subject { validator.eligible_for_settlement? }
+
+    context "settlement is associated with a shipment" do
+      context "settlement's amount is smaller or equal to shipment's cost" do
+        before do
+          settlement.shipment.cost = 15
+          settlement.amount = 10
+        end
+
+        it "returns true" do
+          expect(subject).to be true
+        end
+      end
+
+      context "settlement's amount is greater than shipment's cost" do
+        before do
+          settlement.shipment.cost = 15
+          settlement.amount = 20
+        end
+
+        it "returns false" do
+          expect(subject).to be false
+        end
+
+        it "sets an error" do
+          subject
+          expect(validator.errors[:settlement_amount]).to eq I18n.t('spree.settlement_amount_greater_than_shipment_cost')
+        end
+      end
+    end
+
+    context "settlement is not associated with a shipment" do
+      before do
+        settlement.shipment = nil
+        settlement.amount = 20
+      end
+
+      it "returns true" do
+        expect(subject).to be true
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/settlements/eligibility_validator/settlement_amount_spec.rb
+++ b/core/spec/models/spree/settlements/eligibility_validator/settlement_amount_spec.rb
@@ -38,6 +38,23 @@ RSpec.describe Spree::Settlement::EligibilityValidator::SettlementAmount do
           expect(validator.errors[:settlement_amount]).to eq I18n.t('spree.settlement_amount_greater_than_shipment_cost')
         end
       end
+
+      context "settlement's amount is smaller than shipment's cost and shipment has an adjustment" do
+        before do
+          settlement.shipment.cost = 15
+          settlement.amount = 15
+          allow(shipment).to receive(:total_before_tax).and_return(10)
+        end
+
+        it "returns false" do
+          expect(subject).to be false
+        end
+
+        it "sets an error" do
+          subject
+          expect(validator.errors[:settlement_amount]).to eq I18n.t('spree.settlement_amount_greater_than_shipment_cost')
+        end
+      end
     end
 
     context "settlement is not associated with a shipment" do

--- a/core/spec/models/spree/settlements/eligibility_validator/settlement_amount_spec.rb
+++ b/core/spec/models/spree/settlements/eligibility_validator/settlement_amount_spec.rb
@@ -3,13 +3,15 @@
 require 'rails_helper'
 
 RSpec.describe Spree::Settlement::EligibilityValidator::SettlementAmount do
-  let(:settlement) { create(:settlement) }
+  let(:shipment) { create(:shipment) }
   let(:validator) { Spree::Settlement::EligibilityValidator::SettlementAmount.new(settlement) }
 
   describe "#eligible_for_settlement?" do
     subject { validator.eligible_for_settlement? }
 
     context "settlement is associated with a shipment" do
+      let(:settlement) { create(:settlement, shipment: shipment) }
+
       context "settlement's amount is smaller or equal to shipment's cost" do
         before do
           settlement.shipment.cost = 15
@@ -39,8 +41,9 @@ RSpec.describe Spree::Settlement::EligibilityValidator::SettlementAmount do
     end
 
     context "settlement is not associated with a shipment" do
+      let(:settlement) { create(:settlement, shipment: shipment) }
+
       before do
-        settlement.shipment = nil
         settlement.amount = 20
       end
 

--- a/core/spec/models/spree/settlements/eligibility_validator/settlement_exists_spec.rb
+++ b/core/spec/models/spree/settlements/eligibility_validator/settlement_exists_spec.rb
@@ -2,22 +2,24 @@
 
 require 'rails_helper'
 
-RSpec.describe Spree::Settlement::EligibilityValidator::NoSettlement do
+RSpec.describe Spree::Settlement::EligibilityValidator::SettlementExists do
   let(:settlement) { create(:settlement) }
-  let(:validator) { Spree::Settlement::EligibilityValidator::NoSettlement.new(settlement) }
+  let(:validator) { Spree::Settlement::EligibilityValidator::SettlementExists.new(settlement) }
 
   describe "#eligible_for_settlement?" do
     subject { validator.eligible_for_settlement? }
 
-    context "shipment has no existing settlement" do
-
+    context "shipment has no existing accepted settlement" do
       it "returns true" do
         expect(subject).to be true
       end
     end
 
-    context "shipment has an existing settlement" do
-      let!(:another_settlement) { settlement.dup.save }
+    context "shipment has an existing accepted settlement" do
+      let!(:existing_settlement) { settlement.dup }
+      before do
+        existing_settlement.save!
+      end
 
       it "returns false" do
         expect(subject).to be false

--- a/core/spec/models/spree/settlements/eligibility_validator/settlement_exists_spec.rb
+++ b/core/spec/models/spree/settlements/eligibility_validator/settlement_exists_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Spree::Settlement::EligibilityValidator::SettlementExists do
     context "shipment has an existing accepted settlement" do
       let!(:existing_settlement) { settlement.dup }
       before do
-        existing_settlement.save!
+        existing_settlement.accept!
       end
 
       it "returns false" do

--- a/core/spec/models/spree/settlements/eligibility_validator/settlement_exists_spec.rb
+++ b/core/spec/models/spree/settlements/eligibility_validator/settlement_exists_spec.rb
@@ -3,7 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe Spree::Settlement::EligibilityValidator::SettlementExists do
-  let(:settlement) { create(:settlement) }
+  let(:shipment) { create(:shipment) }
+  let(:settlement) { create(:settlement, shipment: shipment) }
   let(:validator) { Spree::Settlement::EligibilityValidator::SettlementExists.new(settlement) }
 
   describe "#eligible_for_settlement?" do
@@ -16,7 +17,8 @@ RSpec.describe Spree::Settlement::EligibilityValidator::SettlementExists do
     end
 
     context "shipment has an existing accepted settlement" do
-      let!(:existing_settlement) { settlement.dup }
+      let(:existing_settlement) { settlement.dup }
+
       before do
         existing_settlement.accept!
       end

--- a/core/spec/models/spree/settlements/eligibility_validator/shipment_shipped_spec.rb
+++ b/core/spec/models/spree/settlements/eligibility_validator/shipment_shipped_spec.rb
@@ -3,20 +3,23 @@
 require 'rails_helper'
 
 RSpec.describe Spree::Settlement::EligibilityValidator::ShipmentShipped do
-  let(:settlement) { create(:settlement) }
+  let(:shipment) { create(:shipment) }
+  let(:settlement) { create(:settlement, shipment: shipment) }
   let(:validator) { Spree::Settlement::EligibilityValidator::ShipmentShipped.new(settlement) }
 
   describe "#eligible_for_settlement?" do
     subject { validator.eligible_for_settlement? }
 
     context "the shipment has been shipped" do
+      before { allow(shipment).to receive(:state).and_return('shipped') }
+
       it "returns true" do
         expect(subject).to be true
       end
     end
 
     context "the shipment has not been shipped yet" do
-      before { allow(settlement.shipment).to receive(:state).and_return(:pending) }
+      before { allow(shipment).to receive(:state).and_return('pending') }
 
       it "returns false" do
         expect(subject).to be false

--- a/core/spec/models/spree/settlements/eligibility_validator/shipment_shipped_spec.rb
+++ b/core/spec/models/spree/settlements/eligibility_validator/shipment_shipped_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Spree::Settlement::EligibilityValidator::ShipmentShipped do
+  let(:settlement) { create(:settlement) }
+  let(:validator) { Spree::Settlement::EligibilityValidator::ShipmentShipped.new(settlement) }
+
+  describe "#eligible_for_settlement?" do
+    subject { validator.eligible_for_settlement? }
+
+    context "the shipment has been shipped" do
+      it "returns true" do
+        expect(subject).to be true
+      end
+    end
+
+    context "the shipment has not been shipped yet" do
+      before { allow(settlement.shipment).to receive(:state).and_return(:pending) }
+
+      it "returns false" do
+        expect(subject).to be false
+      end
+
+      it "sets an error" do
+        subject
+        expect(validator.errors[:shipment_shipped]).to eq I18n.t('spree.settlement_shipment_ineligible')
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/settlements/eligibility_validator/time_since_purchase_spec.rb
+++ b/core/spec/models/spree/settlements/eligibility_validator/time_since_purchase_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Spree::Settlement::EligibilityValidator::TimeSincePurchase, type: :model do
+  include ActiveSupport::Testing::TimeHelpers
+
+  let(:settlement) { instance_double(Spree::Settlement) }
+  let(:validator) { described_class.new(settlement) }
+
+  describe "#eligible_for_settlement?" do
+    subject { validator.eligible_for_settlement? }
+
+    let(:interval) { Spree::Config[:settlement_eligibility_number_of_days] }
+
+    before do
+      allow(settlement).
+        to receive_message_chain('reimbursement.order.completed_at').
+          and_return(completed_at)
+    end
+
+    around(:each) do |e|
+      travel_to(Time.current) { e.run }
+    end
+
+    context "it is within the return timeframe" do
+      let(:completed_at) { 1.day.ago }
+      it { is_expected.to be_truthy }
+    end
+
+    context "it is past the return timeframe" do
+      let(:completed_at) { interval.day.ago }
+
+      it { is_expected.to be_falsy }
+
+      it "sets an error" do
+        subject
+        expect(validator.errors[:number_of_days]).to eq I18n.t('spree.settlement_time_period_ineligible')
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/settlements_spec.rb
+++ b/core/spec/models/spree/settlements_spec.rb
@@ -41,13 +41,15 @@ RSpec.describe Spree::Settlement, type: :model do
 
     context "amount is not specified" do
       context "settlement has a shipment" do
-        subject { create(:settlement) }
+        let(:shipment) { create(:shipment) }
+
+        subject { create(:settlement, shipment: shipment) }
 
         it { expect(subject.amount).to eq subject.shipment.amount }
       end
 
       context "settlement does not have a shipment" do
-        subject { create(:settlement, has_shipment?: false) }
+        subject { create(:settlement) }
 
         it { expect(subject.amount).to eq 0 }
       end

--- a/core/spec/models/spree/settlements_spec.rb
+++ b/core/spec/models/spree/settlements_spec.rb
@@ -1,0 +1,281 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.shared_examples "an invalid state transition" do |status, expected_status|
+  let(:status) { status }
+
+  it "cannot transition to #{expected_status}" do
+    expect { subject }.to raise_error(StateMachines::InvalidTransition)
+  end
+end
+
+RSpec.describe Spree::Settlement, type: :model do
+  all_acceptance_statuses = Spree::Settlement.state_machines[:acceptance_status].states.map(&:name).map(&:to_s)
+
+  describe "display money methods" do
+    let(:amount) { 21.22 }
+    let(:included_tax_total) { 1.22 }
+    let(:additional_tax_total) { 2.55 }
+    let(:settlement) {
+      build(
+        :settlement,
+        amount: amount,
+        included_tax_total: included_tax_total,
+        additional_tax_total: additional_tax_total
+      )
+    }
+
+    describe "#display_amount" do
+      it "returns a Spree::Money" do
+        expect(settlement.display_amount).to eq Spree::Money.new(amount)
+      end
+    end
+
+    describe "#display_total" do
+      it "returns a Spree::Money" do
+        expect(settlement.display_total).to eq Spree::Money.new(amount + additional_tax_total)
+      end
+    end
+
+    describe "#display_total_excluding_vat" do
+      it "returns a Spree::Money" do
+        expect(settlement.display_total_excluding_vat).to eq Spree::Money.new(amount - included_tax_total)
+      end
+    end
+  end
+
+  describe "amount calculations on create" do
+    let(:amount) { 21.22 }
+    let(:included_tax_total) { 1.22 }
+
+    context "amount is not specified" do
+
+      context "settlement has a shipment" do
+        subject { create(:settlement) }
+
+        it { expect(subject.amount).to eq subject.shipment.amount }
+      end
+
+      context "settlement does not have a shipment" do
+        subject { create(:settlement, has_shipment?: false) }
+
+        it { expect(subject.amount).to eq 0 }
+      end
+    end
+
+    context "amount is specified" do
+      subject { create(:settlement, amount: 45) }
+
+      it { expect(subject.amount).to eq 45 }
+    end
+  end
+
+  describe "acceptance_status state_machine" do
+    subject(:settlement) { build_stubbed(:settlement) }
+
+    it "starts off in the pending state" do
+      expect(settlement).to be_pending
+    end
+  end
+
+  describe "#attempt_accept" do
+    let(:settlement) { create(:settlement, acceptance_status: status) }
+    let(:validator_errors) { {} }
+    let(:validator_double) { double(errors: validator_errors) }
+
+    subject { settlement.attempt_accept! }
+
+    before do
+      allow(settlement).to receive(:validator).and_return(validator_double)
+    end
+
+    context "pending status" do
+      let(:status) { 'pending' }
+
+      before do
+        allow(settlement).to receive(:eligible_for_settlement?).and_return(true)
+        subject
+      end
+
+      it "transitions successfully" do
+        expect(settlement).to be_accepted
+      end
+
+      it "has no acceptance status errors" do
+        expect(settlement.acceptance_status_errors).to be_empty
+      end
+    end
+
+    (all_acceptance_statuses - ['accepted', 'pending']).each do |invalid_transition_status|
+      context "settlement has an acceptance status of #{invalid_transition_status}" do
+        it_behaves_like "an invalid state transition", invalid_transition_status, 'accepted'
+      end
+    end
+
+    context "not eligible for settlement" do
+      let(:status) { 'pending' }
+      let(:validator_errors) { { number_of_days: "Settlement is outside the eligible time period" } }
+
+      before do
+        allow(settlement).to receive(:eligible_for_settlement?).and_return(false)
+      end
+
+      context "manual intervention required" do
+        before do
+          allow(settlement).to receive(:requires_manual_intervention?).and_return(true)
+          subject
+        end
+
+        it "transitions to manual intervention required" do
+          expect(settlement).to be_manual_intervention_required
+        end
+
+        it "sets the acceptance status errors" do
+          expect(settlement.acceptance_status_errors).to eq validator_errors
+        end
+      end
+
+      context "manual intervention not required" do
+        before do
+          allow(settlement).to receive(:requires_manual_intervention?).and_return(false)
+          subject
+        end
+
+        it "transitions to rejected" do
+          expect(settlement).to be_rejected
+        end
+
+        it "sets the acceptance status errors" do
+          expect(settlement.acceptance_status_errors).to eq validator_errors
+        end
+      end
+    end
+  end
+
+  describe "#reject" do
+    let(:settlement) { create(:settlement, acceptance_status: status) }
+
+    subject { settlement.reject! }
+
+    context "pending status" do
+      let(:status) { 'pending' }
+
+      before { subject }
+
+      it "transitions successfully" do
+        expect(settlement).to be_rejected
+      end
+
+      it "has no acceptance status errors" do
+        expect(settlement.acceptance_status_errors).to be_empty
+      end
+    end
+
+    (all_acceptance_statuses - ['accepted', 'pending', 'manual_intervention_required']).each do |invalid_transition_status|
+      context "settlement has an acceptance status of #{invalid_transition_status}" do
+        it_behaves_like "an invalid state transition", invalid_transition_status, 'rejected'
+      end
+    end
+  end
+
+  describe "#accept" do
+    let(:settlement) { create(:settlement, acceptance_status: status) }
+
+    subject { settlement.accept! }
+
+    context "pending status" do
+      let(:status) { 'pending' }
+
+      before { subject }
+
+      it "transitions successfully" do
+        expect(settlement).to be_accepted
+      end
+
+      it "has no acceptance status errors" do
+        expect(settlement.acceptance_status_errors).to be_empty
+      end
+    end
+
+    (all_acceptance_statuses - ['accepted', 'pending', 'manual_intervention_required']).each do |invalid_transition_status|
+      context "settlement has an acceptance status of #{invalid_transition_status}" do
+        it_behaves_like "an invalid state transition", invalid_transition_status, 'accepted'
+      end
+    end
+  end
+
+  describe "#require_manual_intervention" do
+    let(:settlement) { create(:settlement, acceptance_status: status) }
+
+    subject { settlement.require_manual_intervention! }
+
+    context "pending status" do
+      let(:status) { 'pending' }
+
+      before { subject }
+
+      it "transitions successfully" do
+        expect(settlement).to be_manual_intervention_required
+      end
+
+      it "has no acceptance status errors" do
+        expect(settlement.acceptance_status_errors).to be_empty
+      end
+    end
+
+    (all_acceptance_statuses - ['accepted', 'pending', 'manual_intervention_required']).each do |invalid_transition_status|
+      context "settlement has an acceptance status of #{invalid_transition_status}" do
+        it_behaves_like "an invalid state transition", invalid_transition_status, 'manual_intervention_required'
+      end
+    end
+  end
+
+  describe "validity for shipments" do
+    let(:order) { create(:shipped_order) }
+    let(:inventory_unit) { order.line_items.first.inventory_units.first }
+    let(:return_item) { build_stubbed(:return_item, inventory_unit: inventory_unit, acceptance_status: 'accepted') }
+    let(:customer_return) { build(:customer_return, return_items: [return_item], shipped_order: order) }
+    let(:reimbursement) { build_stubbed(:reimbursement, customer_return: customer_return, order: order, return_items: [return_item]) }
+    let(:settlement) { build(:settlement, reimbursement: reimbursement, shipment: shipment) }
+
+    subject { settlement }
+
+    context "when shipment belongs to same order as reimbursement" do
+      let(:shipment) { inventory_unit.shipment }
+
+      it "is valid" do
+        expect(subject).to be_valid
+      end
+    end
+
+    context "when shipment does not belong to same order as reimbursement" do
+      let(:shipment) { build_stubbed(:shipment) }
+
+      it "is not valid" do
+        expect(subject).to_not be_valid
+        expect(subject.errors.messages).to eq({ shipment: [I18n.t(:must_belong_to_reimbursement_order, scope: 'activerecord.errors.models.spree/settlement.attributes.shipment')] })
+      end
+    end
+  end
+
+  describe "included tax in total" do
+    let(:settlement) { build_stubbed(:settlement, amount: 100, included_tax_total: 10) }
+
+    it "includes included tax total" do
+      expect(settlement.amount).to eq 100
+      expect(settlement.included_tax_total).to eq 10
+      expect(settlement.total).to eq 100
+    end
+  end
+
+  describe "add tax to total" do
+    let(:settlement) { build_stubbed(:settlement, amount: 100, additional_tax_total: 10) }
+
+    it "includes included tax total" do
+      expect(settlement.amount).to eq 100
+      expect(settlement.additional_tax_total).to eq 10
+      expect(settlement.total).to eq 110
+    end
+  end
+end


### PR DESCRIPTION
This PR allows to refund shipping costs and fixes #2628.

A new Settlement model has been added with an association to the Reimbursement and Shipment models.
Settlements and ReturnItems share similarities, they are both "reimbursement items" so they share a common interface and must both implement the #total method.

To create a settlement, you must first create a customer refund and a reimbursement.
From the reimbursement page, you can then add a settlement for a shipment and update the reimbursement.
When adding a settlement, eligibility validators are run against the settlement to decide its state: accepted, rejected or manual_intervention_required. This behaviour is similar to return items.

![screenshot-localhost 3000-2018-06-20-14-06-15](https://user-images.githubusercontent.com/1450340/41657389-8c7b09fc-7493-11e8-92c5-81b055abf579.png)

The settlement is taken into account when creating refunds and/or store credits.

The interface also provides a button to reject settlements in case we don't want them any more.

Let me know if you have any question / feedback.
I hope this will be useful.