### PR TITLE
Add initial shipments documentation for end users

### DIFF
--- a/backend/app/views/spree/admin/shipping_methods/_form.html.erb
+++ b/backend/app/views/spree/admin/shipping_methods/_form.html.erb
@@ -1,7 +1,7 @@
 <div data-hook="admin_shipping_method_form_fields" class="row">
   <div data-hook="admin_shipping_method_form_name_field" class="col-5">
     <%= f.field_container :name do %>
-      <%= f.label :name %><br />
+      <%= f.label :name, class: 'required' %>
       <%= f.text_field :name, class: 'fullwidth' %>
       <%= error_message_on :shipping_method, :name %>
     <% end %>
@@ -9,32 +9,32 @@
 
   <div data-hook="admin_shipping_method_form_internal_name_field" class="col-5">
     <%= f.field_container :admin_name do %>
-      <%= f.label :admin_name %><br />
-      <%= f.text_field :admin_name, class: 'fullwidth', label: false  %>
+      <%= f.label :admin_name %>
+      <%= f.text_field :admin_name, class: 'fullwidth', label: false %>
       <%= error_message_on :shipping_method, :admin_name %>
     <% end %>
   </div>
 
   <div data-hook="admin_shipping_method_form_code" class="col-5">
     <%= f.field_container :code do %>
-      <%= f.label :code %><br />
-      <%= f.text_field :code, class: 'fullwidth', label: false  %>
+      <%= f.label :code %>
+      <%= f.text_field :code, class: 'fullwidth', label: false %>
       <%= error_message_on :shipping_method, :code %>
     <% end %>
   </div>
 
   <div class="col-5">
     <%= f.field_container :carrier do %>
-      <%= f.label :carrier %><br />
-      <%= f.text_field :carrier, class: 'fullwidth', label: false  %>
+      <%= f.label :carrier %>
+      <%= f.text_field :carrier, class: 'fullwidth', label: false %>
       <%= error_message_on :shipping_method, :carrier %>
     <% end %>
   </div>
 
   <div class="col-5">
     <%= f.field_container :service_level do %>
-      <%= f.label :service_level %><br />
-      <%= f.text_field :service_level, class: 'fullwidth', label: false  %>
+      <%= f.label :service_level %>
+      <%= f.text_field :service_level, class: 'fullwidth', label: false %>
       <%= error_message_on :shipping_method, :service_level %>
     <% end %>
   </div>
@@ -49,7 +49,7 @@
 
   <div data-hook="admin_shipping_method_form_tracking_url_field" class="col-10">
     <%= f.field_container :tracking_url do %>
-      <%= f.label :tracking_url %><br />
+      <%= f.label :tracking_url %>
       <%= f.text_field :tracking_url, class: 'fullwidth', placeholder: t('spree.tracking_url_placeholder') %>
       <%= error_message_on :shipping_method, :tracking_url %>
     <% end %>

--- a/backend/app/views/spree/admin/stores/_form.html.erb
+++ b/backend/app/views/spree/admin/stores/_form.html.erb
@@ -8,6 +8,7 @@
 
     <%= f.field_container :code do %>
       <%= f.label :code, class: 'required' %>
+      <%= f.field_hint :code %>
       <%= f.text_field :code, required: true, class: 'fullwidth' %>
       <%= f.error_message_on :code %>
     <% end %>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -297,15 +297,17 @@ en:
         abbr: Abbreviation
         name: Name
       spree/store:
-        url: Site URL
+        available_locales: Locales Available in the Storefront
+        cart_tax_country_iso: Tax Country for Empty Carts
+        code: Slug
         default: Default
+        default_currency: Default Currency
+        mail_from_address: Mail From Address
         meta_description: Meta Description
         meta_keywords: Meta Keywords
-        seo_title: Seo Title
         name: Site Name
-        mail_from_address: Mail From Address
-        cart_tax_country_iso: Tax Country for Empty Carts
-        available_locales: Locales available in the storefront
+        seo_title: SEO Title
+        url: Site URL
       spree/store_credit:
         amount: Amount
         amount_authorized: Amount Authorized
@@ -325,7 +327,7 @@ en:
       spree/stock_item:
         count_on_hand: Count On Hand
       spree/stock_location:
-        admin_name: Internal Name
+        admin_name: Internal name
         active: Active
         address1: Street Address
         address2: Street Address (cont'd)
@@ -336,11 +338,10 @@ en:
         country_id: Country
         default: Default
         fulfillable: Fulfillable
-        internal_name: Internal Name
         name: Name
         phone: Phone
         propagate_all_variants: Propagate all variants
-        restock_inventory: Restock Inventory
+        restock_inventory: Restock inventory
         state_id: State
         zipcode: Zip
       spree/stock_movement:
@@ -1297,8 +1298,9 @@ en:
         fulfillable: "When unchecked, this indicates that items in this location don't require actual fulfilment. Stock will not be checked when shipping and emails will not be sent.<br/> Default: Checked"
         check_stock_on_transfer: "When checked, inventory levels will be checked when performing stock transfers.<br/> Default: Checked"
       spree/store:
-        cart_tax_country_iso: "This determines which country is used for taxes on carts (orders which don't yet have an address).<br/> Default: None."
         available_locales: "This determines which locales are available for your customers to choose from in the storefront."
+        cart_tax_country_iso: "This determines which country is used for taxes on carts (orders which don't yet have an address).<br/> Default: None."
+        code: "An identifier for your store. Developers may need this value if you operate multiple storefronts."
       spree/variant:
         tax_category: "This determines what kind of taxation is applied to this variant.<br/> Default: Use tax category of the product associated with this variant"
         deleted: "Deleted Variant"
@@ -1381,7 +1383,6 @@ en:
     insufficient_stock_lines_present: Some line items in this order have insufficient quantity.
     intercept_email_address: Intercept Email Address
     intercept_email_instructions: Override email recipient and replace with this address.
-    internal_name: Internal Name
     invalid_exchange_variant: Invalid exchange variant.
     invalid_payment_method_type: Invalid payment method type.
     invalid_promotion_action: Invalid promotion action.

--- a/guides/source/users/orders/shipments.html.md
+++ b/guides/source/users/orders/shipments.html.md
@@ -1,0 +1,1 @@
+# Shipments

--- a/guides/source/users/products/product-details.html.md
+++ b/guides/source/users/products/product-details.html.md
@@ -32,7 +32,7 @@ would have the slug `summer-t-shirt`.
 ### Available On
 
 Note that the **Available On** field should be filled if you want the product to
-be displayed on the storefront. 
+be displayed on the storefront.
 
 If the **Available On** value is a date in the future, then the product is only
 available after the date that has been set.
@@ -51,8 +51,8 @@ systems:
   products.
 - **Weight**: The product's weight.
 - **Height**: The product's height.
-- **Width**: The product's width. 
-- **Depth**: The product's depth. 
+- **Width**: The product's width.
+- **Depth**: The product's depth.
 - **Shipping Categories**: This sets the product's shipping category.
 - **Tax Category**: This sets the products' tax category.
 
@@ -69,12 +69,16 @@ order's shipment costs.
 
 ## SEO information
 
-- **Meta Title**: 
-- **Meta Keywords**: Add a list of keywords that should be added to this
+- **Meta Title**: Adds content to the product page's HTML `<title>` tag, which
+    is used by search engines.
+- **Meta Keywords**: A list of keywords that should be added to this
   product's metadata. These meta keywords are used by search
   engines.[^meta-keywords]
 - **Meta Description**: The summary text that accompanies your page in search
   engine results.[^meta-descriptions]
+
+If the product's SEO fields are not filled in, then the product inherits [the
+store's global SEO information settings][stores].
 
 [^meta-keywords]: Meta keywords are used for SEO purposes. For more information
   about meta keywords see the article [Meta Keywords: What They Are and How They
@@ -87,3 +91,4 @@ order's shipment costs.
 
 [meta-keywords]: https://www.wordstream.com/meta-keyword
 [meta-description]: https://moz.com/learn/seo/meta-description
+[stores]: ../settings/stores.html

--- a/guides/source/users/settings/overview.html.md
+++ b/guides/source/users/settings/overview.html.md
@@ -4,7 +4,62 @@ Solidus's **Settings** section includes a number of pages that help you manage
 store-wide settings, including tax rates, shipping methods, and payment methods.
 
 This article introduces each settings page and how the settings affect your
-store. 
+store.
+
+## Stores
+
+The **Settings > Stores** page allows you to manage some of the global settings
+across all of your stores. These global settings include your site's name,
+site-wide SEO tag data, and the sender email address used when emails are sent
+by your store.
+
+If your Solidus application manages multiple stores, you can choose the store
+you want to edit from a list.
+
+For more information about these settings, see the [Stores][stores] article.
+
+[stores]: stores.html
+
+## Payments
+
+You can manage Solidus's available payment methods from the **Settings >
+Payments** page. Typically, a payment method is displayed as an option that
+customers can use to pay at checkout.
+
+For more information about managing payment methods, see the
+[Payments][payments] article.
+
+[payments]: payments.html
+
+## Taxes
+
+You can manage the tax rates and categories that Solidus uses from the
+**Settings > Taxes** page. Solidus's taxes relate to shipping charges as well as
+the products that you sell.
+
+For more information about tax management, see the [Taxes][taxes] article.
+
+[taxes]: taxes.html
+
+## Refunds and Returns
+
+You can manage Solidus's returns system from the **Settings > Refunds and
+Returns** page. Because the returns system is flexible, there are many settings.
+
+For more information about managing Solidus's returns system, see the [Refunds
+and returns][returns] article.
+
+[returns]: refunds-and-returns.html
+
+## Shipping
+
+You can manage Solidus's available shipping methods, shipping categories, and
+stock locations from the **Settings > Shipping** page.
+
+For more information about managing Solidus's shipping settings, see the
+[Shipping][shipping] article.
+
+[shipping]: shipping.html
 
 ## Zones
 
@@ -15,8 +70,3 @@ and/or tax. A country or state could exist in multiple zones or none at all.
 For more information on how to use zones, see the [Zones][zones] article.
 
 [zones]: zones.html
-
-## Taxes
-
-With Solidus, you can create tax rates and tax categories that correspond with
-each item in your store and each location that you ship to. 

--- a/guides/source/users/settings/payments.html.md
+++ b/guides/source/users/settings/payments.html.md
@@ -1,0 +1,4 @@
+# Payments
+
+You can manage your store's payment methods form the **Settings > Payments**
+page.

--- a/guides/source/users/settings/refunds-and-returns.html.md
+++ b/guides/source/users/settings/refunds-and-returns.html.md
@@ -1,0 +1,4 @@
+# Refunds and returns
+
+You can manage Solidus's returns system from the **Settings > Refunds and
+Returns** page.

--- a/guides/source/users/settings/shipping.html.md
+++ b/guides/source/users/settings/shipping.html.md
@@ -1,0 +1,176 @@
+# Shipping
+
+You can manage Solidus's available shipping methods, shipping categories, and
+stock locations from the **Settings > Shipping** page.
+
+## Shipping methods
+
+You can manage your store's shipping methods on the **Settings > Shipping**
+page, on the **Shipping Methods** tab.
+
+When you create a shipping method, the following settings are available:
+
+- **Name**: The name for the shipping method. Customer may see this name during
+    checkout and on invoices.
+- **Internal Name**: The administrative name for the shipping method. Customers
+    do not see the internal name for the shipping method.
+- **Code**: An optional code that identifies the shipping method.
+- **Carrier**: The carrier being used by this shipping method.
+- **Tracking URL**: A tracking URL pattern that provides tracking for packages.
+  For example, `https://quickship.com/package?num=:tracking`, where `:tracking`
+  is a variable that is replaced by every shipment's tracking number.
+- **Available to users**: Sets whether the shipping method should be available
+  to users during checkout. If this is not checked, only store administrators
+  can assign the shipping method to shipments from the admin interface.
+- **Shipping Categories**: Only products with the selected shipping categories
+  can use this shipping method. For more information, see [Shipping
+  categories](#shipping-categories) below.
+- **Base Calculator**: The shipping calculator that should be used for the
+  current shipping method. The available fields depend on the calculator
+  chosen. For more information, see [Shipping
+  calculators](#shipping-calculators) below.
+- **Zones**: Only customers in the selected zones can use this shipping method.
+  For more information, see the [Zones][zones] documentation.
+- **Tax Category**: Optionally set a tax category that applies to this shipping
+  method. See the [Taxes][taxes] article for more information about tax
+  categories.
+
+<!-- TODO: The **Service Level** field is not currently documented.  -->
+
+[taxes]: taxes.html
+[zones]: zones.html
+
+### Shipping calculators
+
+<!-- TODO:
+  The shipping calculators section is a good candidate to be split out into its
+  own article.
+-->
+
+Shipping methods require a shipping calculator in order to calculate shipping
+for each possible shipment that your store could send out.
+
+The following shipping calculators are available by default:
+
+- **Flat percent**: Pick a flat percentage of the order price to charge.
+- **Flat rate**: Pick a flat rate to charge.
+- **Flexible rate per package item**: Pick rates for the first item and another
+  rate for any number of additional items. See [Flexible rate per package
+  item](#flexible-rate-per-package-item) for more information.
+- **Flat rate per package item**: Pick a flat rate for each item being shipped.
+- **Price sack**: Charge a shipping rate or a discounted shipping rate,
+  depending on the order subtotal. See [Price sack](#price-sack) for more
+  information.
+
+If your shipments require more specialized calculations, or you would like to
+integrate a live shipping estimates from an external service, talk to your
+developers.
+
+#### Flexible rate per package item
+
+When you select the **Flexible rate per package item** calculator, the following
+settings are available:
+
+- **First Item**: The rate that should be charged for the first item in a
+  package.
+- **Additional Item**: The rate that should be charged for additional items in a
+  package.
+- **Max Items**: The maximum number of items that the flexible rate should be
+  applied to.
+- **Currency**: The currency that shipping is charged in.
+
+For example, you can charge $5 for the first item and $1 for each additional
+item. If you set the **Max Items** setting to `3`, then a customer is charged $7
+shipping if they buy three items ($5 + $1 + $1).
+
+The flexible rate is re-applied if the customer goes over the set **Max Items**
+number. For example, if they buy six items instead of three items, they are
+only charged an additional $7 (a second flexible rate of $5 + $1 + $1).
+
+#### Price sack
+
+When you select the **Price sack** calculator, the following settings are
+available:
+
+- **Minimal Amount**: If the order subtotal is less than this value, the
+    shipping rate equals the normal amount that you set.
+- **Normal Amount**: The normal shipping charge.
+- **Discount Amount**: The discounted shipping charge. This is charged only if
+    the order subtotal is greater than the set minimal amount.
+- **Currency**: The currency that shipping is charged in.
+
+For example, you could create a price sack shipping calculator with these
+settings:
+
+- **Minimal Amount**: `$50`
+- **Normal Amount**: `$15`
+- **Discount Amount**: `$5`
+
+A customer who orders a t-shirt that costs $20 would be offered a shipping rate
+of $15 using this shipping method. A customer who order three t-shirts, for a
+subtotal of $60, would be offered a shipping rate of $5.
+
+## Shipping categories
+
+You can manage your store's shipping categories on the **Settings > Shipping**
+page, on the **Shipping Categories** tab.
+
+When you create a new shipping category, you simply give it a **Name** value.
+You can assign this shipping category to any of your
+[products][product-details].
+
+Shipping categories relate to your store's [shipping
+methods](#shipping-methods). Each shipping method can allow or disallow products
+with certain shipping categories.
+
+If you assign two products to two different shipping categories, you could
+ensure that these items are always sent as separate shipments.
+
+For example, if your store can only ship oversized products via a specific
+carrier, called "USPS Oversized Parcels", then you could create a shipping
+category called "Oversized" for that shipping method, which can then be assigned
+only to oversized products.
+
+[product-details]: ../products/product-details.html
+
+## Stock locations
+
+You can manage your store's stock locations on the **Settings > Shipping** page,
+on the **Stock Locations** tab. Each stock location represents a location where
+your products ship from.
+
+Product stock can be managed from the [**Stock**][stock] page or while you add
+or edit products (from the [**Product Stock**][product-stock] tab).
+
+Stock locations have the following settings:
+
+- **Name**: Required. The name for the stock location. Customers could see this
+    name during checkout or in invoices.
+- **Code**: An optional code that identifies the current stock location.
+- **Internal Name**: The administrative name of the stock location. Only store
+    administrators would see this name.
+- **Active**: Sets whether the stock location is active and can be used.
+- **Default**: Sets whether this stock location should be used as the default
+    stock location. Only one of your stock locations can be the default one.
+- **Backorderable default**: Sets whether this stock location should allow
+    backorders by default. This is enabled by default.
+- **Propagate all variants**: Sets whether this stock location should create
+    stock items for all of your store's [variants][variants]. This is enabled by
+    default.
+- **Restock inventory**: Sets whether returned items should restock inventory at
+    this stock location. This is enabled by default.
+- **Fulfillable**: Sets whether the stock items at this location are
+    fulfillable. When the checkbox is checked, then stock is checked before
+    shipments can be confirmed, and emails will be sent to customers about the
+    stock items. This is enabled by default.
+- **Check stock on transfer**: Sets whether stock should be checked when
+    transferred to another stock location. This is enabled by default.
+
+<!-- TODO: Add screenshot of stock location address fields. -->
+
+You can also optionally set the address for the stock location using the
+provided **Address** fields.
+
+[product-stock]: ../products/product-stock.html
+[stock]: ../stock/overview.html
+[variants]: ../products/variants.html

--- a/guides/source/users/settings/stores.html.md
+++ b/guides/source/users/settings/stores.html.md
@@ -1,0 +1,57 @@
+# Stores
+
+The **Settings > Stores** page allows you to manage some of the global settings
+across all of your stores. These settings are useful if you manage multiple
+stores and need distinct settings for some of your stores.
+
+The following settings are available for each for your stores:
+
+- **Site Name**: The customer-facing name of the current store.
+- **Code**: An identifier for your store. Developers may need it if you operate
+  multiple storefronts. You should not change this value before speaking with
+  your store's developers.
+- **SEO Title**: The content for the homepage's HTML `<title>` tag, which is
+  used by search engines.
+- **Meta Keywords**: A list of keywords that should be added to this product's
+  metadata. These meta keywords are used by search engines.[^meta-keywords]
+- **Meta Description**: The summary text that accompanies your homepage in
+  search engine results.[^meta-descriptions]
+- **Site URL**: The URL that customers use to access the current store.
+- **Mail From Address**: The email address that should be used to send emails to
+  customers and other users of your store.
+- **Default Currency**: Optionally set the default currency that should be used
+  throughout the current store. See the [Default currency](#default-currency)
+  section before for more information.
+- **Tax Country for Empty Carts**: Optionally set a tax country for empty carts.
+  We recommend setting this to the country where a majority of your customers
+  order from.
+- **Locales Available in the Storefront**: A list of available locales[^locales]
+  that customers can choose in the storefront.
+
+## Default currency
+
+When you set a default currency for a store, note that you need to provide
+prices for each [product][products] in that currency. Any product can have
+multiple prices associated with it.
+
+<!-- TODO:
+  Default currency comes up often on the Solidus Slack team. It seems to be a
+  point of confusion for developers, and maybe for administrators. There is
+  opportunity to provide more information about setting currencies, prices, etc.
+-->
+
+[^locales]: Locales allow your store to be displayed in multiple languages. See
+  Wikipedia's [Locale][locale] article for more information. Talk to your
+  developers about integrating locales into your store.
+[^meta-keywords]: Meta keywords are used for SEO purposes. For more information
+  about meta keywords see the article [Meta Keywords: What They Are and How They
+  Work][meta-keywords] from WordStream.
+[^meta-descriptions]: Meta descriptions are short descriptions that accompany a
+  link to your page in search engine results pages (SERPs). While each search
+  engine works differently, Google truncates meta descriptions after 300
+  characters. For more information, see the [Meta Description][meta-description]
+  article on Moz.com.
+
+[locale]: https://en.wikipedia.org/wiki/Locale_(computer_software)
+[meta-keywords]: https://www.wordstream.com/meta-keyword
+[meta-description]: https://moz.com/learn/seo/meta-description

--- a/guides/source/users/settings/taxes.html.md
+++ b/guides/source/users/settings/taxes.html.md
@@ -24,7 +24,7 @@ exempt from tax.
 
 When you create or edit a tax category, it uses the following settings:
 
-- **Name**: The name for your tax category. 
+- **Name**: The name for your tax category.
 - **Tax Code**: An optional tax code that describes your tax category.
 - **Default**: A checkbox that sets whether the current tax category should be
   used as the default tax category for new products.


### PR DESCRIPTION
This adds documentation about the Solidus shipping interface for end users. The audience for this documentation is store administrators or anyone who has to touch the `solidus_backend` as a business person.

It also changes some of the English translation strings for the backend interface, which is a minor UX improvement.