### PR TITLE
Fix permissions for users to change their own orders 

### DIFF
--- a/api/spec/requests/spree/api/checkouts_controller_spec.rb
+++ b/api/spec/requests/spree/api/checkouts_controller_spec.rb
@@ -329,8 +329,7 @@ module Spree
       it "returns the order if the order is already complete" do
         order.update_columns(completed_at: Time.current, state: 'complete')
         put spree.api_checkout_path(order.to_param), params: { order_token: order.guest_token }
-        expect(json_response['number']).to eq(order.number)
-        expect(response.status).to eq(200)
+        assert_unauthorized!
       end
 
       # Regression test for https://github.com/spree/spree/issues/3784

--- a/api/spec/requests/spree/api/line_items_controller_spec.rb
+++ b/api/spec/requests/spree/api/line_items_controller_spec.rb
@@ -52,6 +52,27 @@ module Spree
         allow_any_instance_of(Order).to receive_messages user: current_api_user
       end
 
+      context "dealing with a completed order" do
+        let!(:order) { create(:completed_order_with_totals) }
+
+        it "can't add a new line item" do
+          post spree.api_order_line_items_path(order), params: { line_item: { variant_id: product.master.to_param, quantity: 1 } }
+          assert_unauthorized!
+        end
+
+        it "can't update a line item" do
+          line_item = order.line_items.first
+          put spree.api_order_line_item_path(order, line_item), params: { line_item: { quantity: 10 } }
+          assert_unauthorized!
+        end
+
+        it "can't delete a line item" do
+          line_item = order.line_items.first
+          delete spree.api_order_line_item_path(order, line_item)
+          assert_unauthorized!
+        end
+      end
+
       it "can add a new line item to an existing order" do
         post spree.api_order_line_items_path(order), params: { line_item: { variant_id: product.master.to_param, quantity: 1 } }
         expect(response.status).to eq(201)

--- a/core/lib/spree/permission_sets/default_customer.rb
+++ b/core/lib/spree/permission_sets/default_customer.rb
@@ -11,6 +11,9 @@ module Spree
         can [:read, :update], Order do |order, token|
           order.user == user || (order.guest_token.present? && token == order.guest_token)
         end
+        cannot :update, Order do |order|
+          order.completed?
+        end
         can :create, ReturnAuthorization do |return_authorization|
           return_authorization.order.user == user
         end

--- a/frontend/spec/controllers/spree/orders_controller_ability_spec.rb
+++ b/frontend/spec/controllers/spree/orders_controller_ability_spec.rb
@@ -18,7 +18,6 @@ module Spree
 
     context 'when an order exists in the cookies.signed' do
       let(:token) { 'some_token' }
-      let(:specified_order) { create(:order) }
 
       before do
         allow(controller).to receive_messages current_order: order
@@ -26,54 +25,39 @@ module Spree
       end
 
       context '#populate' do
-        it 'should check if user is authorized for :edit' do
-          expect(controller).to receive(:authorize!).with(:edit, order, token)
+        it 'should check if user is authorized for :update' do
+          expect(controller).to receive(:authorize!).with(:update, order, token)
           post :populate, params: { variant_id: variant.id, token: token }
-        end
-        it "should check against the specified order" do
-          expect(controller).to receive(:authorize!).with(:edit, specified_order, token)
-          post :populate, params: { id: specified_order.number, variant_id: variant.id, token: token }
         end
       end
 
       context '#edit' do
-        it 'should check if user is authorized for :edit' do
-          expect(controller).to receive(:authorize!).with(:edit, order, token)
+        it 'should check if user is authorized for :read' do
+          expect(controller).to receive(:authorize!).with(:read, order, token)
           get :edit, params: { token: token }
-        end
-        it "should check against the specified order" do
-          expect(controller).to receive(:authorize!).with(:edit, specified_order, token)
-          get :edit, params: { id: specified_order.number, token: token }
         end
       end
 
       context '#update' do
-        it 'should check if user is authorized for :edit' do
+        it 'should check if user is authorized for :update' do
           allow(order).to receive :update_attributes
-          expect(controller).to receive(:authorize!).with(:edit, order, token)
+          expect(controller).to receive(:authorize!).with(:update, order, token)
           post :update, params: { order: { email: "foo@bar.com" }, token: token }
-        end
-        it "should check against the specified order" do
-          allow(order).to receive :update_attributes
-          expect(controller).to receive(:authorize!).with(:edit, specified_order, token)
-          post :update, params: { order: { email: "foo@bar.com" }, id: specified_order.number, token: token }
         end
       end
 
       context '#empty' do
-        it 'should check if user is authorized for :edit' do
-          expect(controller).to receive(:authorize!).with(:edit, order, token)
+        it 'should check if user is authorized for :update' do
+          expect(controller).to receive(:authorize!).with(:update, order, token)
           post :empty, params: { token: token }
-        end
-        it "should check against the specified order" do
-          expect(controller).to receive(:authorize!).with(:edit, specified_order, token)
-          post :empty, params: { id: specified_order.number, token: token }
         end
       end
 
       context "#show" do
+        let(:specified_order) { create(:order) }
+
         it "should check against the specified order" do
-          expect(controller).to receive(:authorize!).with(:edit, specified_order, token)
+          expect(controller).to receive(:authorize!).with(:read, specified_order, token)
           get :show, params: { id: specified_order.number, token: token }
         end
       end

--- a/frontend/spec/controllers/spree/orders_controller_spec.rb
+++ b/frontend/spec/controllers/spree/orders_controller_spec.rb
@@ -105,7 +105,7 @@ describe Spree::OrdersController, type: :controller do
     context "#update" do
       context "with authorization" do
         before do
-          allow(controller).to receive :check_authorization
+          allow(controller).to receive :authorize!
           allow(controller).to receive_messages current_order: order
         end
 
@@ -180,7 +180,7 @@ describe Spree::OrdersController, type: :controller do
 
     context "#empty" do
       before do
-        allow(controller).to receive :check_authorization
+        allow(controller).to receive :authorize!
       end
 
       it "should destroy line items in the current order" do
@@ -212,7 +212,7 @@ describe Spree::OrdersController, type: :controller do
     let!(:line_item) { order.contents.add(variant, 1) }
 
     before do
-      allow(controller).to receive(:check_authorization)
+      allow(controller).to receive :authorize!
       allow(controller).to receive_messages(current_order: order)
     end
 


### PR DESCRIPTION
ref #546 and #2772 

With this PR the default permissions set does not allow to change an order after its completion by its owner (other users cannot change it anyway 🔐 )

This is what the majority of users expect. 

I also changed some specs which were just testing the wrong thing, more details in the commit messages.

cc @sebfie 