### PR TITLE
Allow customizing the order mailer class

### DIFF
--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -140,7 +140,7 @@ module Spree
       end
 
       def resend
-        OrderMailer.confirm_email(@order, true).deliver_later
+        Spree::Config.order_mailer_class.confirm_email(@order, true).deliver_later
         flash[:success] = t('spree.order_email_resent')
 
         redirect_to(spree.edit_admin_order_path(@order))

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -448,7 +448,7 @@ module Spree
     end
 
     def deliver_order_confirmation_email
-      Spree::OrderMailer.confirm_email(self).deliver_later
+      Spree::Config.order_mailer_class.confirm_email(self).deliver_later
       update_column(:confirmation_delivered, true)
     end
 
@@ -889,7 +889,7 @@ module Spree
     end
 
     def send_cancel_email
-      Spree::OrderMailer.cancel_email(self).deliver_later
+      Spree::Config.order_mailer_class.cancel_email(self).deliver_later
     end
 
     def after_resume

--- a/core/app/models/spree/order_cancellations.rb
+++ b/core/app/models/spree/order_cancellations.rb
@@ -40,7 +40,7 @@ class Spree::OrderCancellations
         end
 
         update_shipped_shipments(inventory_units)
-        Spree::OrderMailer.inventory_cancellation_email(@order, inventory_units.to_a).deliver_later if Spree::OrderCancellations.send_cancellation_mailer
+        Spree::Config.order_mailer_class.inventory_cancellation_email(@order, inventory_units.to_a).deliver_later if Spree::OrderCancellations.send_cancellation_mailer
       end
 
       @order.recalculate

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -307,6 +307,15 @@ module Spree
     # @api experimental
     class_name_attribute :shipping_rate_tax_calculator_class, default: 'Spree::TaxCalculator::ShippingRate'
 
+    # Allows providing your own Mailer for order mailer.
+    #
+    # @!attribute [rw] order_mailer_class
+    # @return [ActionMailer::Base] an object that responds to "confirm_email",
+    #   "cancel_email" and "inventory_cancellation_email"
+    #   (e.g. an ActionMailer with a "confirm_email" method) with the same
+    #   signature as Spree::OrderMailer.confirm_email.
+    class_name_attribute :order_mailer_class, default: 'Spree::OrderMailer'
+
     # Allows providing your own Mailer for promotion code batch mailer.
     #
     # @!attribute [rw] promotion_code_batch_mailer_class

--- a/core/lib/spree/mailer_previews/order_preview.rb
+++ b/core/lib/spree/mailer_previews/order_preview.rb
@@ -6,19 +6,19 @@ module Spree
       def confirm
         order = Order.complete.last
         raise "Your database needs at least one completed order to render this preview" unless order
-        OrderMailer.confirm_email(order)
+        Spree::Config.order_mailer_class.confirm_email(order)
       end
 
       def cancel
         order = Order.with_state(:canceled).last
         raise "Your database needs at least one cancelled order to render this preview" unless order
-        OrderMailer.cancel_email(order)
+        Spree::Config.order_mailer_class.cancel_email(order)
       end
 
       def inventory_cancellation
         order = Spree::Order.joins(:inventory_units).merge(Spree::InventoryUnit.canceled).last
         raise "Your database needs at least one order with a canceled inventory unit to render this preview" unless order
-        OrderMailer.inventory_cancellation_email(order, [order.inventory_units.first])
+        Spree::Config.order_mailer_class.inventory_cancellation_email(order, [order.inventory_units.first])
       end
     end
   end


### PR DESCRIPTION
Adds the ability to replace default order mailer class with a custom one, so there's no need to override default partials