### PR TITLE
Allow customizing the reimbursement mailer class

### DIFF
--- a/core/app/models/spree/reimbursement.rb
+++ b/core/app/models/spree/reimbursement.rb
@@ -162,7 +162,7 @@ module Spree
     end
 
     def send_reimbursement_email
-      Spree::ReimbursementMailer.reimbursement_email(id).deliver_later
+      Spree::Config.reimbursement_mailer_class.reimbursement_email(id).deliver_later
     end
 
     # If there are multiple different reimbursement types for a single

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -316,6 +316,14 @@ module Spree
     #   signature as Spree::PromotionCodeBatchMailer.promotion_code_batch_finished.
     class_name_attribute :promotion_code_batch_mailer_class, default: 'Spree::PromotionCodeBatchMailer'
 
+    # Allows providing your own Mailer for reimbursement mailer.
+    #
+    # @!attribute [rw] reimbursement_mailer_class
+    # @return [ActionMailer::Base] an object that responds to "reimbursement_email"
+    #   (e.g. an ActionMailer with a "reimbursement_email" method) with the same
+    #   signature as Spree::ReimbursementMailer.reimbursement_email.
+    class_name_attribute :reimbursement_mailer_class, default: 'Spree::ReimbursementMailer'
+
     # Allows providing your own Mailer for shipped cartons.
     #
     # @!attribute [rw] carton_shipped_email_class

--- a/core/lib/spree/mailer_previews/reimbursement_preview.rb
+++ b/core/lib/spree/mailer_previews/reimbursement_preview.rb
@@ -6,7 +6,7 @@ module Spree
       def reimbursement
         reimbursement = Reimbursement.last
         raise "Your database needs at least one Reimbursement to render this preview" unless reimbursement
-        ReimbursementMailer.reimbursement_email(reimbursement)
+        Spree::Config.reimbursement_mailer_class.reimbursement_email(reimbursement)
       end
     end
   end


### PR DESCRIPTION
Adds the ability to replace default reimbursement mailer class with a custom one, so there's no need to override default partials

