### PR TITLE
Allow customizing the promotion code batch mailer class

### DIFF
--- a/core/app/jobs/spree/promotion_code_batch_job.rb
+++ b/core/app/jobs/spree/promotion_code_batch_job.rb
@@ -10,13 +10,13 @@ module Spree
       ).build_promotion_codes
 
       if promotion_code_batch.email?
-        Spree::PromotionCodeBatchMailer
+        Spree::Config.promotion_code_batch_mailer_class
           .promotion_code_batch_finished(promotion_code_batch)
           .deliver_now
       end
     rescue StandardError => e
       if promotion_code_batch.email?
-        Spree::PromotionCodeBatchMailer
+        Spree::Config.promotion_code_batch_mailer_class
           .promotion_code_batch_errored(promotion_code_batch)
           .deliver_now
       end

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -307,6 +307,15 @@ module Spree
     # @api experimental
     class_name_attribute :shipping_rate_tax_calculator_class, default: 'Spree::TaxCalculator::ShippingRate'
 
+    # Allows providing your own Mailer for promotion code batch mailer.
+    #
+    # @!attribute [rw] promotion_code_batch_mailer_class
+    # @return [ActionMailer::Base] an object that responds to "promotion_code_batch_finished",
+    #   and "promotion_code_batch_errored"
+    #   (e.g. an ActionMailer with a "promotion_code_batch_finished" method) with the same
+    #   signature as Spree::PromotionCodeBatchMailer.promotion_code_batch_finished.
+    class_name_attribute :promotion_code_batch_mailer_class, default: 'Spree::PromotionCodeBatchMailer'
+
     # Allows providing your own Mailer for shipped cartons.
     #
     # @!attribute [rw] carton_shipped_email_class


### PR DESCRIPTION
Adds the ability to replace default promotion code batch mailer class with a custom one, so there's no need to override default partials
