### PR TITLE
Skip forgery protection in api controllers

### DIFF
--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -7,6 +7,7 @@ module Spree
     class BaseController < ActionController::Base
       self.responder = Spree::Api::Responders::AppResponder
       respond_to :json
+      protect_from_forgery unless: -> { request.format.json? }
 
       include CanCan::ControllerAdditions
       include Spree::Core::ControllerHelpers::Store

--- a/backend/spec/features/admin/orders/payments_spec.rb
+++ b/backend/spec/features/admin/orders/payments_spec.rb
@@ -22,7 +22,7 @@ describe 'Payments', type: :feature do
     end
 
     # Regression tests for https://github.com/spree/spree/issues/1453
-    context 'with a check payment' do
+    context 'with a check payment', js: true do
       let(:order) { create(:completed_order_with_totals, number: 'R100') }
       let!(:payment) do
         create(:payment,
@@ -205,7 +205,7 @@ describe 'Payments', type: :feature do
         visit spree.admin_order_payments_path(order.reload)
       end
 
-      it "can successfully be created and captured" do
+      it "can successfully be created and captured", js: true do
         click_on 'Update'
         expect(page).to have_content("Payment has been successfully created!")
         click_icon(:capture)

--- a/core/lib/generators/spree/dummy/templates/rails/test.rb
+++ b/core/lib/generators/spree/dummy/templates/rails/test.rb
@@ -20,9 +20,6 @@ Dummy::Application.configure do
   # Raise exceptions instead of rendering exception templates
   config.action_dispatch.show_exceptions = false
 
-  # Disable request forgery protection in test environment
-  config.action_controller.allow_forgery_protection    = false
-
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.

--- a/core/lib/spree/testing_support/dummy_app.rb
+++ b/core/lib/spree/testing_support/dummy_app.rb
@@ -13,8 +13,15 @@ Rails.env = 'test'
 require 'solidus_core'
 
 # @private
+def forgery_protected_by_default?
+  Gem::Version.new(Rails.version) >= Gem::Version.new('5.2')
+end
+
+# @private
 class ApplicationController < ActionController::Base
-  protect_from_forgery with: :exception
+  if !forgery_protected_by_default?
+    protect_from_forgery with: :exception
+  end
 end
 
 # @private
@@ -50,13 +57,17 @@ module DummyApp
     config.public_file_server.headers                 = { 'Cache-Control' => 'public, max-age=3600' }
     config.whiny_nils                                 = true
     config.consider_all_requests_local                = true
+    config.action_controller.allow_forgery_protection = true
     config.action_controller.perform_caching          = false
     config.action_dispatch.show_exceptions            = false
     config.active_support.deprecation                 = :stderr
     config.action_mailer.delivery_method              = :test
-    config.action_controller.allow_forgery_protection = false
     config.active_support.deprecation                 = :stderr
     config.secret_key_base                            = 'SECRET_TOKEN'
+
+    if forgery_protected_by_default?
+      config.action_controller.default_protect_from_forgery = true
+    end
 
     if config.active_record.sqlite3
       # Rails >= 5.2


### PR DESCRIPTION
Fixes #2799

Rails is now enabling forgery protection by default so we need to explicitly disable it for api requests, as described here:

http://api.rubyonrails.org/classes/ActionController/RequestForgeryProtection.html

This PR also enables forgery protection by default in the specs dummy app so that we can really test that the api code is working in a real Rails 5.2+ environment.