### PR TITLE
add en-US locale to select2

### DIFF
--- a/backend/vendor/assets/javascripts/solidus_admin/select2_locales/select2_locale_en-US.js
+++ b/backend/vendor/assets/javascripts/solidus_admin/select2_locales/select2_locale_en-US.js
@@ -1,0 +1,10 @@
+/**
+ * Select2 English US translations
+ */
+(function ($) {
+    "use strict";
+
+    $.fn.select2.locales['en-US'] = {};
+
+    $.extend($.fn.select2.defaults, $.fn.select2.locales['en-US']);
+})(jQuery);


### PR DESCRIPTION
This adds the en-US file to avoid errors with en-US locale.

It could be used to overwrite some translations if needed.