### PR TITLE
add jquery validate locale

### DIFF
--- a/frontend/vendor/assets/javascripts/jquery.validate/localization/messages_enus.js
+++ b/frontend/vendor/assets/javascripts/jquery.validate/localization/messages_enus.js
@@ -1,0 +1,8 @@
+/*
+ * Translated default messages for the jQuery validation plugin.
+ * Locale: EN (English)
+ * Region: US (United States)
+ */
+(function ($) {
+  $.extend($.validator.messages, {});
+}(jQuery));


### PR DESCRIPTION
This fixes an issue with the locale set to "en-US" and the frontend checkout.
It doesn't find a translation file, the fix is similar to this one: #2805
I think this is valid only for v2.4, in the latest master the jquery validate is not there anymore.