### PR TITLE
Fix space between taxons on admin taxonomies

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/templates/taxons/_tree.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/taxons/_tree.hbs
@@ -13,8 +13,10 @@
         <a href="#" class="js-taxon-delete fa fa-trash icon_link no-text"></a>
       </div>
     </div>
+    {{#if taxons }}
     <ul>
       {{> taxons/_tree }}
     </ul>
+    {{/if}}
   </li>
 {{/each}}

--- a/backend/app/assets/stylesheets/spree/backend/sections/_taxonomies.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/_taxonomies.scss
@@ -12,14 +12,12 @@
   }
 
   .taxon {
-    border-radius: $border-radius;
-  }
-
-  .taxon {
     background-color: very-light($color-3);
     border: 1px solid $color-border;
+    border-radius: $border-radius;
     color: $body-color;
     font-weight: $font-weight-bold;
+    margin: 5px 0;
     padding: 0.5em;
 
     &.sortable {


### PR DESCRIPTION
### Issue
https://github.com/solidusio/solidus/issues/2811

### What it does?
- Fix issue with the space between taxons on admin edit taxonomy

### Preview
Before:
![screencapture-localhost-4000-admin-taxonomies-1-edit-2018-07-24-14_36_24](https://user-images.githubusercontent.com/957520/43162991-5ec76cc4-8f52-11e8-992e-85b2d09cff20.png)

After:
![screencapture-localhost-4000-admin-taxonomies-1-edit-2018-07-24-14_31_31](https://user-images.githubusercontent.com/957520/43162997-6246f2ac-8f52-11e8-9cdf-67596207ef0f.png)
