### PR TITLE
fix broken rake task that was causing spree_sample:load to fail

### DIFF
--- a/core/lib/tasks/core.rake
+++ b/core/lib/tasks/core.rake
@@ -3,7 +3,7 @@
 require 'active_record'
 
 def prompt_for_agree(prompt)
-  print prompt
+  puts prompt
   ["y", "yes"].include? STDIN.gets.strip.downcase
 end
 


### PR DESCRIPTION
Found this after an issue with the rake task was reported on Slack. 

This change seemed to fix the problem for me.