### PR TITLE
Tracking Number link to Tracking URL page

### DIFF
--- a/backend/app/views/spree/admin/orders/_carton.html.erb
+++ b/backend/app/views/spree/admin/orders/_carton.html.erb
@@ -50,7 +50,12 @@
       <tr class="show-tracking total">
         <td colspan="5">
           <% if carton.tracking.present? %>
-            <strong><%= Spree::Carton.human_attribute_name(:tracking) %>:</strong> <%= carton.tracking %>
+            <strong><%= Spree::Carton.human_attribute_name(:tracking) %>:</strong>
+            <% if carton.tracking_url %>
+              <%= link_to carton.tracking, carton.tracking_url, target: "_blank" %>
+            <% else %>
+              <%= carton.tracking %>
+            <% end %>
           <% else %>
             <i><%= t('spree.no_tracking_present') %></i>
           <% end %>


### PR DESCRIPTION
This change allows showing the tracking URL in the admin panel instead of only the tracking number.