### PR TITLE
Make Spree::Image more extensible

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 
 gemspec require: false
 
-rails_version = ENV['RAILS_VERSION'] || '~> 5.2.0'
+rails_version = ENV['RAILS_VERSION'] || '< 5.2.1'
 gem 'rails', rails_version, require: false
 
 platforms :ruby do

--- a/core/app/models/spree/image.rb
+++ b/core/app/models/spree/image.rb
@@ -5,7 +5,7 @@ module Spree
     validate :no_attachment_errors
 
     has_attached_file :attachment,
-                      styles: { mini: '48x48>', small: '100x100>', product: '240x240>', large: '600x600>' },
+                      :styles => lambda { |a| a.instance.attachment_styles },
                       default_style: :product,
                       default_url: 'noimage/:style.png',
                       url: '/spree/products/:id/:style/:basename.:extension',
@@ -17,7 +17,7 @@ module Spree
 
     # save the w,h of the original image (from which others can be calculated)
     # we need to look at the write-queue for images which have not been saved yet
-    after_post_process :find_dimensions, if: :valid?
+    after_post_process :find_dimensions, if: :attachment_accepted?
 
     # used by admin products autocomplete
     def mini_url
@@ -41,6 +41,21 @@ module Spree
         errors.add :attachment, "Paperclip returned errors for file '#{attachment_file_name}' - check ImageMagick installation or image source file."
         false
       end
+    end
+
+    def attachment_styles
+      {
+        mini: '48x48>',
+        small: '100x100>',
+        product: '240x240>',
+        large: '600x600>'
+      }
+    end
+
+    private
+
+    def attachment_accepted?
+      valid?
     end
   end
 end

--- a/core/app/models/spree/image.rb
+++ b/core/app/models/spree/image.rb
@@ -5,7 +5,7 @@ module Spree
     validate :no_attachment_errors
 
     has_attached_file :attachment,
-                      :styles => lambda { |a| a.instance.attachment_styles },
+                      styles: lambda { |a| a.instance.attachment_styles },
                       default_style: :product,
                       default_url: 'noimage/:style.png',
                       url: '/spree/products/:id/:style/:basename.:extension',


### PR DESCRIPTION
We have some special cases where we need to modify how `Spree::Image`
objects behave, so we need to override a few of the parameters in the image class.