### PR TITLE
Move factory_bot static attrs to dynamic

### DIFF
--- a/core/lib/spree/testing_support/factories/address_factory.rb
+++ b/core/lib/spree/testing_support/factories/address_factory.rb
@@ -7,19 +7,19 @@ FactoryBot.define do
   factory :address, class: 'Spree::Address' do
     transient do
       # There's `Spree::Address#country_iso=`, prohibiting me from using `country_iso` here
-      country_iso_code 'US'
-      state_code 'AL'
+      country_iso_code { 'US' }
+      state_code { 'AL' }
     end
 
-    firstname 'John'
-    lastname nil
-    company 'Company'
-    address1 '10 Lovely Street'
-    address2 'Northwest'
-    city 'Herndon'
+    firstname { 'John' }
+    lastname { nil }
+    company { 'Company' }
+    address1 { '10 Lovely Street' }
+    address2 { 'Northwest' }
+    city { 'Herndon' }
     sequence(:zipcode, 10001) { |i| i.to_s }
-    phone '555-555-0199'
-    alternative_phone '555-555-0199'
+    phone { '555-555-0199' }
+    alternative_phone { '555-555-0199' }
 
     state do |address|
       Spree::State.joins(:country).where('spree_countries.iso = (?)', country_iso_code).find_by(abbr: state_code) ||
@@ -36,10 +36,10 @@ FactoryBot.define do
   end
 
   factory :ship_address, parent: :address do
-    address1 'A Different Road'
+    address1 { 'A Different Road' }
   end
 
   factory :bill_address, parent: :address do
-    address1 'PO Box 1337'
+    address1 { 'PO Box 1337' }
   end
 end

--- a/core/lib/spree/testing_support/factories/adjustment_factory.rb
+++ b/core/lib/spree/testing_support/factories/adjustment_factory.rb
@@ -10,10 +10,10 @@ FactoryBot.define do
   factory :adjustment, class: 'Spree::Adjustment' do
     order
     adjustable { order }
-    amount 100.0
-    label 'Shipping'
+    amount { 100.0 }
+    label { 'Shipping' }
     association(:source, factory: :tax_rate)
-    eligible true
+    eligible { true }
 
     after(:build) do |adjustment|
       adjustments = adjustment.adjustable.adjustments
@@ -25,8 +25,8 @@ FactoryBot.define do
     factory :tax_adjustment, class: 'Spree::Adjustment' do
       order { adjustable.order }
       association(:adjustable, factory: :line_item)
-      amount 10.0
-      label 'VAT 5%'
+      amount { 10.0 }
+      label { 'VAT 5%' }
 
       after(:create) do |adjustment|
         # Set correct tax category, so that adjustment amount is not 0

--- a/core/lib/spree/testing_support/factories/calculator_factory.rb
+++ b/core/lib/spree/testing_support/factories/calculator_factory.rb
@@ -2,25 +2,25 @@
 
 FactoryBot.define do
   factory :calculator, aliases: [:flat_rate_calculator], class: 'Spree::Calculator::FlatRate' do
-    preferred_amount 10.0
+    preferred_amount { 10.0 }
   end
 
   factory :no_amount_calculator, class: 'Spree::Calculator::FlatRate' do
-    preferred_amount 0
+    preferred_amount { 0 }
   end
 
   factory :default_tax_calculator, class: 'Spree::Calculator::DefaultTax' do
   end
 
   factory :shipping_calculator, class: 'Spree::Calculator::Shipping::FlatRate' do
-    preferred_amount 10.0
+    preferred_amount { 10.0 }
   end
 
   factory :shipping_no_amount_calculator, class: 'Spree::Calculator::Shipping::FlatRate' do
-    preferred_amount 0
+    preferred_amount { 0 }
   end
 
   factory :percent_on_item_calculator, class: 'Spree::Calculator::PercentOnLineItem' do
-    preferred_percent 10
+    preferred_percent { 10 }
   end
 end

--- a/core/lib/spree/testing_support/factories/country_factory.rb
+++ b/core/lib/spree/testing_support/factories/country_factory.rb
@@ -4,7 +4,7 @@ require 'carmen'
 
 FactoryBot.define do
   factory :country, class: 'Spree::Country' do
-    iso 'US'
+    iso { 'US' }
 
     transient do
       carmen_country { Carmen::Country.coded(iso) || fail("Unknown country iso code: #{iso.inspect}") }

--- a/core/lib/spree/testing_support/factories/credit_card_factory.rb
+++ b/core/lib/spree/testing_support/factories/credit_card_factory.rb
@@ -2,16 +2,16 @@
 
 FactoryBot.define do
   factory :credit_card, class: 'Spree::CreditCard' do
-    verification_value 123
-    month 12
+    verification_value { 123 }
+    month { 12 }
     year { 1.year.from_now.year }
-    number '4111111111111111'
-    name 'Spree Commerce'
+    number { '4111111111111111' }
+    name { 'Spree Commerce' }
     association(:payment_method, factory: :credit_card_payment_method)
     association(:address)
 
     trait :failing do
-      number "0000000000000000"
+      number { "0000000000000000" }
     end
   end
 end

--- a/core/lib/spree/testing_support/factories/customer_return_factory.rb
+++ b/core/lib/spree/testing_support/factories/customer_return_factory.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
     association(:stock_location, factory: :stock_location)
 
     transient do
-      line_items_count 1
+      line_items_count { 1 }
       return_items_count { line_items_count }
       shipped_order { create :shipped_order, line_items_count: line_items_count }
       return_authorization { create :return_authorization, order: shipped_order }

--- a/core/lib/spree/testing_support/factories/inventory_unit_factory.rb
+++ b/core/lib/spree/testing_support/factories/inventory_unit_factory.rb
@@ -8,7 +8,7 @@ require 'spree/testing_support/factories/shipment_factory'
 FactoryBot.define do
   factory :inventory_unit, class: 'Spree::InventoryUnit' do
     transient do
-      order nil
+      order { nil }
     end
 
     variant
@@ -19,7 +19,7 @@ FactoryBot.define do
         build(:line_item, variant: variant)
       end
     end
-    state 'on_hand'
+    state { 'on_hand' }
     shipment { build(:shipment, state: 'pending', order: line_item.order) }
     # return_authorization
   end

--- a/core/lib/spree/testing_support/factories/line_item_factory.rb
+++ b/core/lib/spree/testing_support/factories/line_item_factory.rb
@@ -5,11 +5,11 @@ require 'spree/testing_support/factories/product_factory'
 
 FactoryBot.define do
   factory :line_item, class: 'Spree::LineItem' do
-    quantity 1
+    quantity { 1 }
     price { BigDecimal('10.00') }
     order
     transient do
-      product nil
+      product { nil }
     end
     variant do
       (product || create(:product)).master

--- a/core/lib/spree/testing_support/factories/option_type_factory.rb
+++ b/core/lib/spree/testing_support/factories/option_type_factory.rb
@@ -3,6 +3,6 @@
 FactoryBot.define do
   factory :option_type, class: 'Spree::OptionType' do
     sequence(:name) { |n| "foo-size-#{n}" }
-    presentation 'Size'
+    presentation { 'Size' }
   end
 end

--- a/core/lib/spree/testing_support/factories/option_value_factory.rb
+++ b/core/lib/spree/testing_support/factories/option_value_factory.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :option_value, class: 'Spree::OptionValue' do
     sequence(:name) { |n| "Size-#{n}" }
 
-    presentation 'S'
+    presentation { 'S' }
     option_type
   end
 end

--- a/core/lib/spree/testing_support/factories/order_factory.rb
+++ b/core/lib/spree/testing_support/factories/order_factory.rb
@@ -12,7 +12,7 @@ FactoryBot.define do
     user
     bill_address
     ship_address
-    completed_at nil
+    completed_at { nil }
     email { user.try(:email) }
     store
 
@@ -40,10 +40,10 @@ FactoryBot.define do
       ship_address
 
       transient do
-        line_items_count 1
+        line_items_count { 1 }
         line_items_attributes { [{}] * line_items_count }
-        shipment_cost 100
-        shipping_method nil
+        shipment_cost { 100 }
+        shipping_method { nil }
         stock_location { create(:stock_location) }
       end
 
@@ -64,7 +64,7 @@ FactoryBot.define do
 
       factory :completed_order_with_promotion do
         transient do
-          promotion nil
+          promotion { nil }
         end
 
         after(:create) do |order, evaluator|
@@ -81,11 +81,11 @@ FactoryBot.define do
       end
 
       factory :order_ready_to_complete do
-        state 'confirm'
-        payment_state 'checkout'
+        state { 'confirm' }
+        payment_state { 'checkout' }
 
         transient do
-          payment_type :credit_card_payment
+          payment_type { :credit_card_payment }
         end
 
         after(:create) do |order, evaluator|
@@ -100,7 +100,7 @@ FactoryBot.define do
       end
 
       factory :completed_order_with_totals do
-        state 'complete'
+        state { 'complete' }
 
         after(:create) do |order|
           order.shipments.each do |shipment|
@@ -116,11 +116,11 @@ FactoryBot.define do
         end
 
         factory :order_ready_to_ship do
-          payment_state 'paid'
-          shipment_state 'ready'
+          payment_state { 'paid' }
+          shipment_state { 'ready' }
 
           transient do
-            payment_type :credit_card_payment
+            payment_type { :credit_card_payment }
           end
 
           after(:create) do |order, evaluator|
@@ -133,7 +133,7 @@ FactoryBot.define do
 
           factory :shipped_order do
             transient do
-              with_cartons true
+              with_cartons { true }
             end
             after(:create) do |order, evaluator|
               order.shipments.each do |shipment|

--- a/core/lib/spree/testing_support/factories/payment_factory.rb
+++ b/core/lib/spree/testing_support/factories/payment_factory.rb
@@ -10,26 +10,26 @@ FactoryBot.define do
     association(:payment_method, factory: :credit_card_payment_method)
     source { create(:credit_card, user: order.user, address: order.bill_address) }
     order
-    state 'checkout'
-    response_code '12345'
+    state { 'checkout' }
+    response_code { '12345' }
 
     trait :completed do
-      state 'completed'
+      state { 'completed' }
     end
 
     trait :failing do
-      response_code '00000'
+      response_code { '00000' }
       association(:source, :failing, { factory: :credit_card })
     end
 
     factory :payment_with_refund do
       transient do
-        refund_amount 5
+        refund_amount { 5 }
       end
 
       amount { refund_amount }
 
-      state 'completed'
+      state { 'completed' }
 
       refunds { build_list :refund, 1, amount: refund_amount }
     end

--- a/core/lib/spree/testing_support/factories/payment_method_factory.rb
+++ b/core/lib/spree/testing_support/factories/payment_method_factory.rb
@@ -2,31 +2,31 @@
 
 FactoryBot.define do
   factory :payment_method, aliases: [:credit_card_payment_method], class: 'Spree::PaymentMethod::BogusCreditCard' do
-    name 'Credit Card'
-    available_to_admin true
-    available_to_users true
+    name { 'Credit Card' }
+    available_to_admin { true }
+    available_to_users { true }
   end
 
   factory :check_payment_method, class: 'Spree::PaymentMethod::Check' do
-    name 'Check'
-    available_to_admin true
-    available_to_users true
+    name { 'Check' }
+    available_to_admin { true }
+    available_to_users { true }
   end
 
   # authorize.net was moved to spree_gateway.
   # Leaving this factory in place with bogus in case anyone is using it.
   factory :simple_credit_card_payment_method, class: 'Spree::PaymentMethod::SimpleBogusCreditCard' do
-    name 'Credit Card'
-    available_to_admin true
-    available_to_users true
+    name { 'Credit Card' }
+    available_to_admin { true }
+    available_to_users { true }
   end
 
   factory :store_credit_payment_method, class: 'Spree::PaymentMethod::StoreCredit' do
-    name          "Store Credit"
-    description   "Store Credit"
-    active        true
-    available_to_admin false
-    available_to_users false
-    auto_capture true
+    name          { "Store Credit" }
+    description   { "Store Credit" }
+    active        { true }
+    available_to_admin { false }
+    available_to_users { false }
+    auto_capture { true }
   end
 end

--- a/core/lib/spree/testing_support/factories/price_factory.rb
+++ b/core/lib/spree/testing_support/factories/price_factory.rb
@@ -5,7 +5,7 @@ require 'spree/testing_support/factories/variant_factory'
 FactoryBot.define do
   factory :price, class: 'Spree::Price' do
     variant
-    amount 19.99
-    currency 'USD'
+    amount { 19.99 }
+    currency { 'USD' }
   end
 end

--- a/core/lib/spree/testing_support/factories/product_factory.rb
+++ b/core/lib/spree/testing_support/factories/product_factory.rb
@@ -9,20 +9,20 @@ require 'spree/testing_support/factories/product_option_type_factory'
 FactoryBot.define do
   factory :base_product, class: 'Spree::Product' do
     sequence(:name) { |n| "Product ##{n} - #{Kernel.rand(9999)}" }
-    description "As seen on TV!"
-    price 19.99
-    cost_price 17.00
+    description { "As seen on TV!" }
+    price { 19.99 }
+    cost_price { 17.00 }
     sku { generate(:sku) }
     available_on { 1.year.ago }
-    deleted_at nil
+    deleted_at { nil }
     shipping_category { |r| Spree::ShippingCategory.first || r.association(:shipping_category) }
 
     # ensure stock item will be created for this products master
     before(:create) { create(:stock_location) if Spree::StockLocation.count == 0 }
 
     factory :custom_product do
-      name 'Custom Product'
-      price 17.99
+      name { 'Custom Product' }
+      price { 17.99 }
 
       tax_category { |r| Spree::TaxCategory.first || r.association(:tax_category) }
     end

--- a/core/lib/spree/testing_support/factories/promotion_category_factory.rb
+++ b/core/lib/spree/testing_support/factories/promotion_category_factory.rb
@@ -2,6 +2,6 @@
 
 FactoryBot.define do
   factory :promotion_category, class: 'Spree::PromotionCategory' do
-    name 'Promotion Category'
+    name { 'Promotion Category' }
   end
 end

--- a/core/lib/spree/testing_support/factories/promotion_factory.rb
+++ b/core/lib/spree/testing_support/factories/promotion_factory.rb
@@ -5,10 +5,10 @@ require 'spree/testing_support/factories/variant_factory'
 
 FactoryBot.define do
   factory :promotion, class: 'Spree::Promotion' do
-    name 'Promo'
+    name { 'Promo' }
 
     transient do
-      code nil
+      code { nil }
     end
     before(:create) do |promotion, evaluator|
       if evaluator.code
@@ -18,7 +18,7 @@ FactoryBot.define do
 
     trait :with_line_item_adjustment do
       transient do
-        adjustment_rate 10
+        adjustment_rate { 10 }
       end
 
       after(:create) do |promotion, evaluator|
@@ -31,7 +31,7 @@ FactoryBot.define do
 
     trait :with_order_adjustment do
       transient do
-        weighted_order_adjustment_amount 10
+        weighted_order_adjustment_amount { 10 }
       end
 
       after(:create) do |promotion, evaluator|
@@ -46,7 +46,7 @@ FactoryBot.define do
 
     trait :with_item_total_rule do
       transient do
-        item_total_threshold_amount 10
+        item_total_threshold_amount { 10 }
       end
 
       after(:create) do |promotion, evaluator|

--- a/core/lib/spree/testing_support/factories/property_factory.rb
+++ b/core/lib/spree/testing_support/factories/property_factory.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :property, class: 'Spree::Property' do
-    name 'baseball_cap_color'
-    presentation 'cap color'
+    name { 'baseball_cap_color' }
+    presentation { 'cap color' }
   end
 end

--- a/core/lib/spree/testing_support/factories/refund_factory.rb
+++ b/core/lib/spree/testing_support/factories/refund_factory.rb
@@ -8,10 +8,10 @@ FactoryBot.define do
 
   factory :refund, class: 'Spree::Refund' do
     transient do
-      payment_amount 100
+      payment_amount { 100 }
     end
 
-    amount 100.00
+    amount { 100.00 }
     transaction_id { generate(:refund_transaction_id) }
     payment do
       association(:payment, state: 'completed', amount: payment_amount)

--- a/core/lib/spree/testing_support/factories/reimbursement_factory.rb
+++ b/core/lib/spree/testing_support/factories/reimbursement_factory.rb
@@ -5,7 +5,7 @@ require 'spree/testing_support/factories/customer_return_factory'
 FactoryBot.define do
   factory :reimbursement, class: 'Spree::Reimbursement' do
     transient do
-      return_items_count 1
+      return_items_count { 1 }
     end
 
     customer_return { create(:customer_return_with_accepted_items, line_items_count: return_items_count) }

--- a/core/lib/spree/testing_support/factories/reimbursement_type_factory.rb
+++ b/core/lib/spree/testing_support/factories/reimbursement_type_factory.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :reimbursement_type, class: 'Spree::ReimbursementType' do
     sequence(:name) { |n| "Reimbursement Type #{n}" }
-    active true
-    mutable true
+    active { true }
+    mutable { true }
   end
 end

--- a/core/lib/spree/testing_support/factories/return_authorization_factory.rb
+++ b/core/lib/spree/testing_support/factories/return_authorization_factory.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
     association(:order, factory: :shipped_order)
     association(:stock_location, factory: :stock_location)
     association(:reason, factory: :return_reason)
-    memo 'Items were broken'
+    memo { 'Items were broken' }
   end
 
   factory :new_return_authorization, class: 'Spree::ReturnAuthorization' do

--- a/core/lib/spree/testing_support/factories/role_factory.rb
+++ b/core/lib/spree/testing_support/factories/role_factory.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     sequence(:name) { |n| "Role ##{n}" }
 
     factory :admin_role do
-      name 'admin'
+      name { 'admin' }
     end
   end
 end

--- a/core/lib/spree/testing_support/factories/shipment_factory.rb
+++ b/core/lib/spree/testing_support/factories/shipment_factory.rb
@@ -6,14 +6,14 @@ require 'spree/testing_support/factories/shipping_method_factory'
 
 FactoryBot.define do
   factory :shipment, class: 'Spree::Shipment' do
-    tracking 'U10000'
-    cost 100.00
-    state 'pending'
+    tracking { 'U10000' }
+    cost { 100.00 }
+    state { 'pending' }
     order
     stock_location
 
     transient do
-      shipping_method nil
+      shipping_method { nil }
     end
 
     after(:create) do |shipment, evaluator|

--- a/core/lib/spree/testing_support/factories/shipping_method_factory.rb
+++ b/core/lib/spree/testing_support/factories/shipping_method_factory.rb
@@ -16,15 +16,15 @@ FactoryBot.define do
       [Spree::Zone.find_by(name: 'GlobalZone') || FactoryBot.create(:global_zone)]
     end
 
-    name 'UPS Ground'
-    code 'UPS_GROUND'
-    carrier 'UPS'
-    service_level '1DAYGROUND'
+    name { 'UPS Ground' }
+    code { 'UPS_GROUND' }
+    carrier { 'UPS' }
+    service_level { '1DAYGROUND' }
 
     calculator { |s| s.association(:shipping_calculator, strategy: :build, preferred_amount: s.cost, preferred_currency: s.currency) }
 
     transient do
-      cost 10.0
+      cost { 10.0 }
       currency { Spree::Config[:currency] }
     end
 
@@ -35,7 +35,7 @@ FactoryBot.define do
     end
 
     factory :free_shipping_method, class: 'Spree::ShippingMethod' do
-      cost nil
+      cost { nil }
       association(:calculator, factory: :shipping_no_amount_calculator, strategy: :build)
     end
   end

--- a/core/lib/spree/testing_support/factories/state_factory.rb
+++ b/core/lib/spree/testing_support/factories/state_factory.rb
@@ -5,8 +5,8 @@ require 'spree/testing_support/factories/country_factory'
 FactoryBot.define do
   factory :state, class: 'Spree::State' do
     transient do
-      country_iso 'US'
-      state_code 'AL'
+      country_iso { 'US' }
+      state_code { 'AL' }
 
       carmen_subregion do
         carmen_country = Carmen::Country.coded(country.iso)

--- a/core/lib/spree/testing_support/factories/stock_item_factory.rb
+++ b/core/lib/spree/testing_support/factories/stock_item_factory.rb
@@ -5,7 +5,7 @@ require 'spree/testing_support/factories/variant_factory'
 
 FactoryBot.define do
   factory :stock_item, class: 'Spree::StockItem' do
-    backorderable true
+    backorderable { true }
     association :stock_location, factory: :stock_location_without_variant_propagation
     variant
 

--- a/core/lib/spree/testing_support/factories/stock_location_factory.rb
+++ b/core/lib/spree/testing_support/factories/stock_location_factory.rb
@@ -6,13 +6,13 @@ require 'spree/testing_support/factories/product_factory'
 
 FactoryBot.define do
   factory :stock_location, class: 'Spree::StockLocation' do
-    name 'NY Warehouse'
-    address1 '1600 Pennsylvania Ave NW'
-    city 'Washington'
-    zipcode '20500'
-    phone '(202) 456-1111'
-    active true
-    backorderable_default true
+    name { 'NY Warehouse' }
+    address1 { '1600 Pennsylvania Ave NW' }
+    city { 'Washington' }
+    zipcode { '20500' }
+    phone { '(202) 456-1111' }
+    active { true }
+    backorderable_default { true }
 
     country  { |stock_location| Spree::Country.first || stock_location.association(:country) }
     state do |stock_location|
@@ -23,7 +23,7 @@ FactoryBot.define do
     end
 
     factory :stock_location_without_variant_propagation do
-      propagate_all_variants false
+      propagate_all_variants { false }
     end
 
     factory :stock_location_with_items do

--- a/core/lib/spree/testing_support/factories/stock_movement_factory.rb
+++ b/core/lib/spree/testing_support/factories/stock_movement_factory.rb
@@ -4,12 +4,12 @@ require 'spree/testing_support/factories/stock_item_factory'
 
 FactoryBot.define do
   factory :stock_movement, class: 'Spree::StockMovement' do
-    quantity 1
-    action 'sold'
+    quantity { 1 }
+    action { 'sold' }
     stock_item
   end
 
   trait :received do
-    action 'received'
+    action { 'received' }
   end
 end

--- a/core/lib/spree/testing_support/factories/store_credit_category_factory.rb
+++ b/core/lib/spree/testing_support/factories/store_credit_category_factory.rb
@@ -2,6 +2,6 @@
 
 FactoryBot.define do
   factory :store_credit_category, class: 'Spree::StoreCreditCategory' do
-    name "Exchange"
+    name { "Exchange" }
   end
 end

--- a/core/lib/spree/testing_support/factories/store_credit_factory.rb
+++ b/core/lib/spree/testing_support/factories/store_credit_factory.rb
@@ -9,8 +9,8 @@ FactoryBot.define do
     user
     association :created_by, factory: :user
     association :category, factory: :store_credit_category
-    amount 150.00
-    currency "USD"
+    amount { 150.00 }
+    currency { "USD" }
     association :credit_type, factory: :primary_credit_type
   end
 end

--- a/core/lib/spree/testing_support/factories/store_credit_update_reason_factory.rb
+++ b/core/lib/spree/testing_support/factories/store_credit_update_reason_factory.rb
@@ -2,6 +2,6 @@
 
 FactoryBot.define do
   factory :store_credit_update_reason, class: 'Spree::StoreCreditUpdateReason' do
-    name "Input error"
+    name { "Input error" }
   end
 end

--- a/core/lib/spree/testing_support/factories/store_factory.rb
+++ b/core/lib/spree/testing_support/factories/store_factory.rb
@@ -5,6 +5,6 @@ FactoryBot.define do
     sequence(:code) { |i| "spree_#{i}" }
     sequence(:name) { |i| "Spree Test Store #{i}" }
     sequence(:url) { |i| "www.example#{i}.com" }
-    mail_from_address 'spree@example.org'
+    mail_from_address { 'spree@example.org' }
   end
 end

--- a/core/lib/spree/testing_support/factories/tax_rate_factory.rb
+++ b/core/lib/spree/testing_support/factories/tax_rate_factory.rb
@@ -7,7 +7,7 @@ require 'spree/testing_support/factories/zone_factory'
 FactoryBot.define do
   factory :tax_rate, class: 'Spree::TaxRate' do
     zone
-    amount 0.1
+    amount { 0.1 }
     association(:calculator, factory: :default_tax_calculator)
     tax_categories { [build(:tax_category)] }
   end

--- a/core/lib/spree/testing_support/factories/taxon_factory.rb
+++ b/core/lib/spree/testing_support/factories/taxon_factory.rb
@@ -4,8 +4,8 @@ require 'spree/testing_support/factories/taxonomy_factory'
 
 FactoryBot.define do
   factory :taxon, class: 'Spree::Taxon' do
-    name 'Ruby on Rails'
+    name { 'Ruby on Rails' }
     taxonomy
-    parent_id nil
+    parent_id { nil }
   end
 end

--- a/core/lib/spree/testing_support/factories/taxonomy_factory.rb
+++ b/core/lib/spree/testing_support/factories/taxonomy_factory.rb
@@ -2,6 +2,6 @@
 
 FactoryBot.define do
   factory :taxonomy, class: 'Spree::Taxonomy' do
-    name 'Brand'
+    name { 'Brand' }
   end
 end

--- a/core/lib/spree/testing_support/factories/user_factory.rb
+++ b/core/lib/spree/testing_support/factories/user_factory.rb
@@ -7,7 +7,7 @@ require 'spree/testing_support/factories/address_factory'
 FactoryBot.define do
   factory :user, class: Spree::UserClassHandle.new do
     email { generate(:email) }
-    password 'secret'
+    password { 'secret' }
     password_confirmation { password }
 
     trait :with_api_key do

--- a/core/lib/spree/testing_support/factories/variant_factory.rb
+++ b/core/lib/spree/testing_support/factories/variant_factory.rb
@@ -9,11 +9,11 @@ FactoryBot.define do
   sequence(:random_float) { BigDecimal("#{rand(200)}.#{rand(99)}") }
 
   factory :base_variant, class: 'Spree::Variant' do
-    price 19.99
-    cost_price 17.00
+    price { 19.99 }
+    cost_price { 17.00 }
     sku { generate(:sku) }
-    is_master 0
-    track_inventory true
+    is_master { 0 }
+    track_inventory { true }
 
     product { |p| p.association(:base_product) }
 
@@ -27,16 +27,16 @@ FactoryBot.define do
     end
 
     factory :master_variant do
-      is_master 1
+      is_master { 1 }
       before(:create){ |variant| variant.product.master = variant }
       product { build(:base_product) }
     end
 
     factory :on_demand_variant do
-      track_inventory false
+      track_inventory { false }
 
       factory :on_demand_master_variant do
-        is_master 1
+        is_master { 1 }
       end
     end
   end

--- a/core/lib/spree/testing_support/factories/variant_property_rule_factory.rb
+++ b/core/lib/spree/testing_support/factories/variant_property_rule_factory.rb
@@ -11,7 +11,7 @@ FactoryBot.define do
     transient do
       property { create(:property) }
       option_value { create(:option_value) }
-      property_value nil
+      property_value { nil }
     end
 
     after(:build) do |rule, evaluator|

--- a/core/lib/spree/testing_support/factories/zone_factory.rb
+++ b/core/lib/spree/testing_support/factories/zone_factory.rb
@@ -5,7 +5,7 @@ require 'spree/testing_support/factories/country_factory'
 
 FactoryBot.define do
   factory :global_zone, class: 'Spree::Zone' do
-    name 'GlobalZone'
+    name { 'GlobalZone' }
     zone_members do |proxy|
       zone = proxy.instance_eval { @instance }
       Spree::Country.all.map do |c|


### PR DESCRIPTION
Factory_bot is now flagging static factory attributes as deprecated,
pending removal in version 5.0. This is adding a lot of noise to test output, which makes it harder to see more important failures.