### PR TITLE
Money#allocate calculates weights already

### DIFF
--- a/core/app/models/spree/distributed_amounts_handler.rb
+++ b/core/app/models/spree/distributed_amounts_handler.rb
@@ -36,12 +36,8 @@ module Spree
       elligible_amounts.sum
     end
 
-    def weights
-      elligible_amounts.map { |amount| amount.to_f / subtotal.to_f }
-    end
-
     def allocated_amounts
-      total_amount.to_money.allocate(weights).map(&:to_money)
+      total_amount.to_money.allocate(elligible_amounts).map(&:to_money)
     end
   end
 end

--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'discard', '~> 1.0'
   s.add_dependency 'friendly_id', '~> 5.0'
   s.add_dependency 'kaminari-activerecord', '~> 1.1'
-  s.add_dependency 'monetize', '~> 1.8.0'
+  s.add_dependency 'monetize', '~> 1.9'
   s.add_dependency 'paperclip', ['>= 4.2', '< 6']
   s.add_dependency 'paranoia', '~> 2.4'
   s.add_dependency 'ransack', '~> 2.0'

--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'discard', '~> 1.0'
   s.add_dependency 'friendly_id', '~> 5.0'
   s.add_dependency 'kaminari-activerecord', '~> 1.1'
-  s.add_dependency 'monetize', '~> 1.9'
+  s.add_dependency 'monetize', '~> 1.8'
   s.add_dependency 'paperclip', ['>= 4.2', '< 6']
   s.add_dependency 'paranoia', '~> 2.4'
   s.add_dependency 'ransack', '~> 2.0'


### PR DESCRIPTION
Related to https://github.com/solidusio/solidus/pull/2826/commits/3f027e24805f146507d032404a8c727d815d778a. Assuming build is still green for both monetize 1.8 and 1.9 we can loose that dependency again.