### PR TITLE
Set correct quantity on order import

### DIFF
--- a/core/lib/spree/core/importer/order.rb
+++ b/core/lib/spree/core/importer/order.rb
@@ -20,8 +20,8 @@ module Spree
 
             shipments_attrs = params.delete(:shipments_attributes)
 
-            create_shipments_from_params(shipments_attrs, order)
             create_line_items_from_params(params.delete(:line_items_attributes), order)
+            create_shipments_from_params(shipments_attrs, order)
             create_adjustments_from_params(params.delete(:adjustments_attributes), order)
             create_payments_from_params(params.delete(:payments_attributes), order)
 

--- a/core/spec/lib/spree/core/importer/order_spec.rb
+++ b/core/spec/lib/spree/core/importer/order_spec.rb
@@ -360,6 +360,31 @@ module Spree
             expect(order.shipment_total.to_f).to eq 4.99
           end
         end
+
+        context "when line items and shipments are present" do
+          let(:params) do
+            {
+              completed_at: 2.days.ago,
+              line_items_attributes: line_items,
+              shipments_attributes: [
+                {
+                  tracking: '123456789',
+                  cost: '4.99',
+                  shipped_at: 1.day.ago,
+                  shipping_method: shipping_method.name,
+                  stock_location: stock_location.name,
+                  inventory_units: [{ sku: sku }]
+                }
+              ]
+            }
+          end
+
+          it 'builds quantities properly' do
+            order = Importer::Order.import(user, params)
+            line_item = order.line_items.first
+            expect(line_item.quantity).to eq(5)
+          end
+        end
       end
 
       it 'adds adjustments' do


### PR DESCRIPTION
When importing an order, we need to create the line items before we
check for them (which happens when creating shipments). Previously, we
were checking for / auto-creating line items, and then adding to them.
This resulted in incorrect quantities on imported order line items.