### PR TITLE
Update guides ffi gem

### DIFF
--- a/guides/Gemfile.lock
+++ b/guides/Gemfile.lock
@@ -26,7 +26,7 @@ GEM
     execjs (2.7.0)
     fast_blank (1.0.0)
     fastimage (2.1.3)
-    ffi (1.9.23)
+    ffi (1.9.25)
     fog-aws (3.0.0)
       fog-core (~> 2.1)
       fog-json (~> 1.1)


### PR DESCRIPTION
This gem version had a security issue:

https://nvd.nist.gov/vuln/detail/CVE-2018-1000201