### PR TITLE
allow multiple taxons on product creation

### DIFF
--- a/backend/app/controllers/spree/admin/products_controller.rb
+++ b/backend/app/controllers/spree/admin/products_controller.rb
@@ -8,6 +8,7 @@ module Spree
       before_action :load_data, except: [:index]
       update.before :update_before
       helper_method :clone_object_url
+      before_action :split_params, only: [:create, :update]
 
       def show
         redirect_to action: :edit
@@ -19,12 +20,6 @@ module Spree
       end
 
       def update
-        if params[:product][:taxon_ids].present?
-          params[:product][:taxon_ids] = params[:product][:taxon_ids].split(',')
-        end
-        if params[:product][:option_type_ids].present?
-          params[:product][:option_type_ids] = params[:product][:option_type_ids].split(',')
-        end
         if updating_variant_property_rules?
           params[:product][:variant_property_rules_attributes].each do |_index, param_attrs|
             param_attrs[:option_value_ids] = param_attrs[:option_value_ids].split(',')
@@ -72,6 +67,15 @@ module Spree
       end
 
       private
+
+      def split_params
+        if params[:product][:taxon_ids].present?
+          params[:product][:taxon_ids] = params[:product][:taxon_ids].split(',')
+        end
+        if params[:product][:option_type_ids].present?
+          params[:product][:option_type_ids] = params[:product][:option_type_ids].split(',')
+        end
+      end
 
       def find_resource
         Spree::Product.with_deleted.friendly.find(params[:id])

--- a/backend/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/products_controller_spec.rb
@@ -52,18 +52,21 @@ describe Spree::Admin::ProductsController, type: :controller do
 
   # regression test for https://github.com/spree/spree/issues/2791
   context "adding taxons to a product" do
-    let!(:product) { create(:product) }
-    let!(:first_taxon) { create(:taxon) }
-    let!(:second_taxon) { create(:taxon) }
+    let(:product) { create(:product) }
+    let(:first_taxon) { create(:taxon) }
 
     it "adds a single taxon to a product" do
       put :update, params: { id: product.to_param, product: { taxon_ids: first_taxon.id.to_s } }
       expect(flash[:success]).to eq("Product #{product.name.inspect} has been successfully updated!")
     end
 
-    it "adds multiple taxons to a product" do
-      put :update, params: { id: product.to_param, product: { taxon_ids: "#{first_taxon.id}, #{second_taxon.id}" } }
-      expect(flash[:success]).to eq("Product #{product.name.inspect} has been successfully updated!")
+    context "when there are mulitple taxons" do
+      let(:second_taxon) { create(:taxon) }
+
+      it "adds multiple taxons to a product" do
+        put :update, params: { id: product.to_param, product: { taxon_ids: "#{first_taxon.id}, #{second_taxon.id}" } }
+        expect(flash[:success]).to eq("Product #{product.name.inspect} has been successfully updated!")
+      end
     end
   end
 

--- a/backend/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/products_controller_spec.rb
@@ -51,6 +51,58 @@ describe Spree::Admin::ProductsController, type: :controller do
   end
 
   # regression test for https://github.com/spree/spree/issues/2791
+  context "creating a product" do
+    before(:all) do
+      create(:shipping_category)
+    end
+
+    it "creates a product" do
+      post :create, params: {
+             product: {
+               name: "Product #1 - 9632",
+               description: "As seen on TV!",
+               price: 19.99,
+               shipping_category_id: Spree::ShippingCategory.first.id,
+             }
+           }
+      expect(flash[:success]).to eq("Product \"Product #1 - 9632\" has been successfully created!")
+    end
+
+    context "when there is a taxon" do
+      let(:first_taxon) { create(:taxon) }
+
+      it "creates a product with a taxon" do
+        post :create, params: {
+               product: {
+                 name: "Product #1 - 9632",
+                 description: "As seen on TV!",
+                 price: 19.99,
+                 shipping_category_id: Spree::ShippingCategory.first.id,
+                 taxon_ids: first_taxon.id.to_s
+               }
+             }
+        expect(flash[:success]).to eq("Product \"Product #1 - 9632\" has been successfully created!")
+      end
+
+      context "when their are multiple taxons" do
+        let(:second_taxon) { create(:taxon) }
+
+        it "creates a product with multiple taxons" do
+          post :create, params: {
+                 product: {
+                   name: "Product #1 - 9632",
+                   description: "As seen on TV!",
+                   price: 19.99,
+                   shipping_category_id: Spree::ShippingCategory.first.id,
+                   taxon_ids: "#{first_taxon.id}, #{second_taxon.id}"
+                 }
+               }
+          expect(flash[:success]).to eq("Product \"Product #1 - 9632\" has been successfully created!")
+        end
+      end
+    end
+  end
+
   context "adding taxons to a product" do
     let(:product) { create(:product) }
     let(:first_taxon) { create(:taxon) }

--- a/backend/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/products_controller_spec.rb
@@ -50,7 +50,7 @@ describe Spree::Admin::ProductsController, type: :controller do
     end
   end
 
-  # regression test for https://github.com/spree/spree/issues/2791
+  # regression test for https://github.com/solidusio/solidus/issues/2791
   context "creating a product" do
     before(:all) do
       create(:shipping_category)

--- a/backend/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/products_controller_spec.rb
@@ -50,6 +50,23 @@ describe Spree::Admin::ProductsController, type: :controller do
     end
   end
 
+  # regression test for https://github.com/spree/spree/issues/2791
+  context "adding taxons to a product" do
+    let!(:product) { create(:product) }
+    let!(:first_taxon) { create(:taxon) }
+    let!(:second_taxon) { create(:taxon) }
+
+    it "adds a single taxon to a product" do
+      put :update, params: { id: product.to_param, product: { taxon_ids: first_taxon.id.to_s } }
+      expect(flash[:success]).to eq("Product #{product.name.inspect} has been successfully updated!")
+    end
+
+    it "adds multiple taxons to a product" do
+      put :update, params: { id: product.to_param, product: { taxon_ids: "#{first_taxon.id}, #{second_taxon.id}" } }
+      expect(flash[:success]).to eq("Product #{product.name.inspect} has been successfully updated!")
+    end
+  end
+
   describe "creating variant property rules" do
     let(:first_property) { create(:property) }
     let(:second_property) { create(:property) }


### PR DESCRIPTION
add private methods for splitting up taxons and option_type_ids on the products controller, addressing a bug that only allowed for one of each to be applied on product creation

refs #2791 