### PR TITLE
Master now tracks 2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Solidus 2.7.0 (master, unreleased)
+## Solidus 2.8.0 (master, unreleased)
+
+## Solidus 2.7.0 (2018-09-14)
 
 ### Major Changes
 

--- a/core/lib/spree/core/version.rb
+++ b/core/lib/spree/core/version.rb
@@ -2,7 +2,7 @@
 
 module Spree
   def self.solidus_version
-    "2.7.0"
+    "2.8.0.alpha"
   end
 
   def self.solidus_gem_version


### PR DESCRIPTION
Also update CHANGELOG to reflect master tracking and `2.7.0` release date.