### PR TITLE
standardize JS semi-colon style in backend

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/admin.js
+++ b/backend/app/assets/javascripts/spree/backend/admin.js
@@ -19,8 +19,8 @@ Spree.ready(function() {
   // Highlight hovered table column
   $('table').on("mouseenter", 'td.actions a, td.actions button', function(){
     var tr = $(this).closest('tr');
-    var klass = 'highlight action-' + $(this).data('action')
-    tr.addClass(klass)
+    var klass = 'highlight action-' + $(this).data('action');
+    tr.addClass(klass);
 
     var observer = new MutationObserver(function(mutations) {
       tr.removeClass(klass);
@@ -38,20 +38,20 @@ Spree.ready(function() {
 });
 
 
-$.fn.visible = function(cond) { this[cond ? 'show' : 'hide' ]() };
+$.fn.visible = function(cond) { this[cond ? 'show' : 'hide' ](); };
 
 // Apply to individual radio button that makes another element visible when checked
 $.fn.radioControlsVisibilityOfElement = function(dependentElementSelector){
-  if(!this.get(0)){ return  }
+  if(!this.get(0)){ return; }
   var showValue = this.get(0).value;
   var radioGroup = $("input[name='" + this.get(0).name + "']");
   radioGroup.each(function(){
     $(this).click(function(){
-      $(dependentElementSelector).visible(this.checked && this.value == showValue)
+      $(dependentElementSelector).visible(this.checked && this.value == showValue);
     });
-    if(this.checked){ this.click() }
+    if(this.checked){ this.click(); }
   });
-}
+};
 
 Spree.ready(function(){
   var uniqueId = 1;
@@ -63,18 +63,18 @@ Spree.ready(function(){
       var el = $(this);
       el.val("");
       // Replace last occurrence of a number
-      el.prop("id", el.prop("id").replace(/\d+(?=[^\d]*$)/, new_id))
-      el.prop("name", el.prop("name").replace(/\d+(?=[^\d]*$)/, new_id))
-    })
+      el.prop("id", el.prop("id").replace(/\d+(?=[^\d]*$)/, new_id));
+      el.prop("name", el.prop("name").replace(/\d+(?=[^\d]*$)/, new_id));
+    });
     // When cloning a new row, set the href of all icons to be an empty "#"
     // This is so that clicking on them does not perform the actions for the
     // duplicated row
     new_table_row.find("a").each(function () {
       var el = $(this);
       el.prop('href', '#');
-    })
+    });
     $(target).prepend(new_table_row);
-  })
+  });
 
   $('body').on('click', '.delete-resource', function() {
     var el = $(this);
@@ -119,7 +119,7 @@ Spree.ready(function(){
           show_flash('error', response.responseText);
         }
 
-      })
+      });
     }
     return false;
   });
@@ -135,5 +135,5 @@ Spree.ready(function(){
     }).done(function() {
       window.location.reload();
     });
-  }
+  };
 });

--- a/backend/app/assets/javascripts/spree/backend/calculator.js
+++ b/backend/app/assets/javascripts/spree/backend/calculator.js
@@ -15,7 +15,7 @@ Spree.CalculatorEditView = Backbone.View.extend({
       $(this).toggle(selected);
     });
   }
-})
+});
 
 Spree.ready(function() {
   $('.js-calculator-fields').each(function() {

--- a/backend/app/assets/javascripts/spree/backend/collections/line_items.js
+++ b/backend/app/assets/javascripts/spree/backend/collections/line_items.js
@@ -6,4 +6,4 @@ Spree.Collections.LineItems = Backbone.Collection.extend({
   url: function () {
     return this.parent.url() + "/line_items";
   }
-})
+});

--- a/backend/app/assets/javascripts/spree/backend/collections/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/collections/shipments.js
@@ -3,4 +3,4 @@
 
 Spree.Collections.Shipments = Backbone.Collection.extend({
   model: Spree.Models.Shipment
-})
+});

--- a/backend/app/assets/javascripts/spree/backend/collections/states.js
+++ b/backend/app/assets/javascripts/spree/backend/collections/states.js
@@ -1,13 +1,13 @@
 Spree.Collections.States = Backbone.Collection.extend({
   initialize: function (models, options) {
-    this.country_id = options.country_id
+    this.country_id = options.country_id;
   },
 
   url: function () {
-    return Spree.routes.states_search + "?country_id=" + this.country_id
+    return Spree.routes.states_search + "?country_id=" + this.country_id;
   },
 
   parse: function(resp, options) {
     return resp.states;
   }
-})
+});

--- a/backend/app/assets/javascripts/spree/backend/components/number_with_currency.js
+++ b/backend/app/assets/javascripts/spree/backend/components/number_with_currency.js
@@ -5,8 +5,8 @@ Spree.initNumberWithCurrency = function() {
     });
     view.render();
   });
-}
+};
 
 Spree.ready(function() {
-  Spree.initNumberWithCurrency()
-})
+  Spree.initNumberWithCurrency();
+});

--- a/backend/app/assets/javascripts/spree/backend/components/tabs.js
+++ b/backend/app/assets/javascripts/spree/backend/components/tabs.js
@@ -5,7 +5,7 @@ Tabs = (function() {
     _.bindAll(this, 'overflowTabs');
 
     this.el = el;
-    this.tabs = this.el.querySelectorAll("li:not(.tabs-dropdown)")
+    this.tabs = this.el.querySelectorAll("li:not(.tabs-dropdown)");
 
     /* <li class='tabs-dropdown'><a href='#'></a><ul></ul></li> */
     this.dropdown = document.createElement('li');

--- a/backend/app/assets/javascripts/spree/backend/datepicker.js
+++ b/backend/app/assets/javascripts/spree/backend/datepicker.js
@@ -31,19 +31,19 @@ Spree.ready(function(){
           instance.setDate(otherDate);
           otherInstance.setDate(date);
         }
-      }
-    }
+      };
+    };
 
     var $left = $('.date-range-filter .datepicker-from');
     var $right = $('.date-range-filter .datepicker-to');
     var leftInstance = $left[0]._flatpickr;
     var rightInstance = $right[0]._flatpickr;
     var leftSwapDates = swapDates($right, rightInstance, function(date, otherDate) {
-      return date > otherDate
-    })
+      return date > otherDate;
+    });
     var rightSwapDates = swapDates($left, leftInstance, function(date, otherDate) {
-      return date < otherDate
-    })
+      return date < otherDate;
+    });
 
     leftInstance.config.onChange.push(leftSwapDates);
     rightInstance.config.onChange.push(rightSwapDates);

--- a/backend/app/assets/javascripts/spree/backend/format_money.js
+++ b/backend/app/assets/javascripts/spree/backend/format_money.js
@@ -8,4 +8,4 @@ Spree.formatMoney = function(amount, currency) {
   var decimal = Spree.t('currency_separator');
 
   return accounting.formatMoney(amount, currencyInfo[0], currencyInfo[1], thousand, decimal, currencyInfo[2]);
-}
+};

--- a/backend/app/assets/javascripts/spree/backend/handlebars_extensions.js
+++ b/backend/app/assets/javascripts/spree/backend/handlebars_extensions.js
@@ -14,7 +14,7 @@ Handlebars.registerHelper("human_model_name", function(model) {
 });
 
 Handlebars.registerHelper("admin_url", function() {
-  return Spree.pathFor("admin")
+  return Spree.pathFor("admin");
 });
 
 Handlebars.registerHelper("concat", function() {

--- a/backend/app/assets/javascripts/spree/backend/models/image_upload.js
+++ b/backend/app/assets/javascripts/spree/backend/models/image_upload.js
@@ -15,7 +15,7 @@ Spree.Models.ImageUpload = Backbone.Model.extend({
       serverError: false,
       filename: '',
       size: ''
-    }
+    };
   },
 
   acceptedTypes: {
@@ -61,14 +61,14 @@ Spree.Models.ImageUpload = Backbone.Model.extend({
           xhr.upload.onprogress = function (event) {
             if (event.lengthComputable) {
               var complete = (event.loaded / event.total * 100 | 0);
-              that.set({progress: complete})
+              that.set({progress: complete});
             }
           };
         }
         return xhr;
       }
     }).done(function() {
-      that.set({progress: 100})
+      that.set({progress: 100});
     }).error(function(jqXHR, textStatus, errorThrown) {
       that.set({serverError: true});
     });

--- a/backend/app/assets/javascripts/spree/backend/models/line_item.js
+++ b/backend/app/assets/javascripts/spree/backend/models/line_item.js
@@ -8,4 +8,4 @@ Spree.Models.LineItem = Backbone.Model.extend({
   initialize: function(options) {
     this.order = this.collection.parent;
   }
-})
+});

--- a/backend/app/assets/javascripts/spree/backend/models/order.js
+++ b/backend/app/assets/javascripts/spree/backend/models/order.js
@@ -20,7 +20,7 @@ Spree.Models.Order = Backbone.Model.extend({
       type: 'PUT',
     };
     _.extend(options, opts);
-    return this.fetch(options)
+    return this.fetch(options);
   }
 });
 
@@ -35,4 +35,4 @@ Spree.Models.Order.fetch = function(number, opts) {
   });
   model.fetch(options);
   return model;
-}
+};

--- a/backend/app/assets/javascripts/spree/backend/models/shipment.js
+++ b/backend/app/assets/javascripts/spree/backend/models/shipment.js
@@ -10,10 +10,10 @@ Spree.Models.Shipment = Backbone.Model.extend({
 
   estimatedRates: function() {
     var ratesCollection = Backbone.Collection.extend({
-      parse: function(resp){ return resp.shipping_rates }
+      parse: function(resp){ return resp.shipping_rates; }
     });
     var rates = new ratesCollection();
-    rates.fetch({ url: this.url() + "/estimated_rates" })
+    rates.fetch({ url: this.url() + "/estimated_rates" });
     return rates;
   },
 
@@ -24,4 +24,4 @@ Spree.Models.Shipment = Backbone.Model.extend({
       data: JSON.stringify({ shipping_method_id: shippingMethodId })
     }, options));
   }
-})
+});

--- a/backend/app/assets/javascripts/spree/backend/namespaces.js
+++ b/backend/app/assets/javascripts/spree/backend/namespaces.js
@@ -12,4 +12,4 @@ _.extend(window.Spree, {
     Stock: {},
     Tables: {}
   }
-})
+});

--- a/backend/app/assets/javascripts/spree/backend/option_value_picker.js
+++ b/backend/app/assets/javascripts/spree/backend/option_value_picker.js
@@ -2,7 +2,7 @@ $.fn.optionValueAutocomplete = function (options) {
   'use strict';
 
   // Default options
-  options = options || {}
+  options = options || {};
   var multiple = typeof(options['multiple']) !== 'undefined' ? options['multiple'] : true;
   var productSelect = options['productSelect'];
 

--- a/backend/app/assets/javascripts/spree/backend/orders/cart.js
+++ b/backend/app/assets/javascripts/spree/backend/orders/cart.js
@@ -1,8 +1,8 @@
-Spree.Order || (Spree.Order = {})
+Spree.Order || (Spree.Order = {});
 
 Spree.Order.initCartPage = function(order_number) {
-  var order = new Spree.Models.Order.fetch(order_number)
-  var collection = order.get("line_items")
+  var order = new Spree.Models.Order.fetch(order_number);
+  var collection = order.get("line_items");
 
   new Spree.Views.Order.Summary({
     el: $('#order_tab_summary'),
@@ -45,8 +45,8 @@ Spree.Order.initCartPage = function(order_number) {
     if(!collection.length) {
       collection.push({});
     }
-  })
-}
+  });
+};
 
 Spree.ready(function() {
   if ($(".js-order-cart-page").length) {

--- a/backend/app/assets/javascripts/spree/backend/payments/new.js
+++ b/backend/app/assets/javascripts/spree/backend/payments/new.js
@@ -2,10 +2,10 @@ Spree.ready(function() {
   if ($("#new_payment").length) {
     new Spree.Views.Payment.New({
       el: $('#new_payment')
-    })
+    });
   }
 
   $(".js-edit-credit-card").each(function() {
-    new Spree.Views.Payment.EditCreditCard({ el: this })
+    new Spree.Views.Payment.EditCreditCard({ el: this });
   });
 });

--- a/backend/app/assets/javascripts/spree/backend/product_picker.js
+++ b/backend/app/assets/javascripts/spree/backend/product_picker.js
@@ -2,8 +2,8 @@ $.fn.productAutocomplete = function (options) {
   'use strict';
 
   // Default options
-  options = options || {}
-  var multiple = typeof(options['multiple']) !== 'undefined' ? options['multiple'] : true
+  options = options || {};
+  var multiple = typeof(options['multiple']) !== 'undefined' ? options['multiple'] : true;
 
   function formatProduct(product) {
     return Select2.util.escapeMarkup(product.name);

--- a/backend/app/assets/javascripts/spree/backend/routes.js
+++ b/backend/app/assets/javascripts/spree/backend/routes.js
@@ -1,27 +1,27 @@
-Spree.routes.checkouts_api = Spree.pathFor('api/checkouts')
-Spree.routes.classifications_api = Spree.pathFor('api/classifications')
-Spree.routes.option_value_search = Spree.pathFor('api/option_values')
-Spree.routes.option_type_search = Spree.pathFor('api/option_types')
-Spree.routes.orders_api = Spree.pathFor('api/orders')
-Spree.routes.product_search = Spree.pathFor('api/products')
-Spree.routes.admin_product_search = Spree.pathFor('admin/search/products')
-Spree.routes.shipments_api = Spree.pathFor('api/shipments')
-Spree.routes.checkouts_api = Spree.pathFor('api/checkouts')
-Spree.routes.stock_locations_api = Spree.pathFor('api/stock_locations')
-Spree.routes.taxon_products_api = Spree.pathFor('api/taxons/products')
-Spree.routes.taxons_search = Spree.pathFor('api/taxons')
-Spree.routes.user_search = Spree.pathFor('admin/search/users')
-Spree.routes.variants_api = Spree.pathFor('api/variants')
-Spree.routes.users_api = Spree.pathFor('api/users')
+Spree.routes.checkouts_api = Spree.pathFor('api/checkouts');
+Spree.routes.classifications_api = Spree.pathFor('api/classifications');
+Spree.routes.option_value_search = Spree.pathFor('api/option_values');
+Spree.routes.option_type_search = Spree.pathFor('api/option_types');
+Spree.routes.orders_api = Spree.pathFor('api/orders');
+Spree.routes.product_search = Spree.pathFor('api/products');
+Spree.routes.admin_product_search = Spree.pathFor('admin/search/products');
+Spree.routes.shipments_api = Spree.pathFor('api/shipments');
+Spree.routes.checkouts_api = Spree.pathFor('api/checkouts');
+Spree.routes.stock_locations_api = Spree.pathFor('api/stock_locations');
+Spree.routes.taxon_products_api = Spree.pathFor('api/taxons/products');
+Spree.routes.taxons_search = Spree.pathFor('api/taxons');
+Spree.routes.user_search = Spree.pathFor('admin/search/users');
+Spree.routes.variants_api = Spree.pathFor('api/variants');
+Spree.routes.users_api = Spree.pathFor('api/users');
 
 Spree.routes.line_items_api = function(order_id) {
-  return Spree.pathFor('api/orders/' + order_id + '/line_items')
-}
+  return Spree.pathFor('api/orders/' + order_id + '/line_items');
+};
 
 Spree.routes.payments_api = function(order_id) {
-  return Spree.pathFor('api/orders/' + order_id + '/payments')
-}
+  return Spree.pathFor('api/orders/' + order_id + '/payments');
+};
 
 Spree.routes.stock_items_api = function(stock_location_id) {
-  return Spree.pathFor('api/stock_locations/' + stock_location_id + '/stock_items')
-}
+  return Spree.pathFor('api/stock_locations/' + stock_location_id + '/stock_items');
+};

--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -13,7 +13,7 @@ var ShipmentAddVariantView = Backbone.View.extend({
     Spree.ajax({
       url: Spree.routes.variants_api + "/" + variant_id,
       success: function(variant){
-        $stock_details.html(template({variant: variant})).show()
+        $stock_details.html(template({variant: variant})).show();
       }
     });
   },
@@ -26,7 +26,7 @@ var ShipmentAddVariantView = Backbone.View.extend({
     var stock_location_id = $(e.target).data('stock-location-id');
     var quantity = this.$("input.quantity[data-stock-location-id='" + stock_location_id + "']").val();
 
-    addVariantFromStockLocation(stock_location_id, variant_id, quantity)
+    addVariantFromStockLocation(stock_location_id, variant_id, quantity);
   }
 });
 
@@ -51,7 +51,7 @@ var ShipShipmentView = Backbone.View.extend({
         send_mailer: this.$("[name='send_mailer']").is(":checked")
       },
       success: function(){
-        window.location.reload()
+        window.location.reload();
       }
     });
     return false;
@@ -127,7 +127,7 @@ var ShipmentSplitItemView = Backbone.View.extend({
     this.shipment_number = options.shipment_number;
     this.max_quantity = options.max_quantity;
     this.shipmentItemView = options.shipmentItemView;
-    this.render()
+    this.render();
   },
 
   events: {
@@ -192,7 +192,7 @@ var ShipmentSplitItemView = Backbone.View.extend({
 
   render: function() {
     /* Only display other shipments */
-    var shipments = _.reject(this.shipments, _.matcher({'number': this.shipment_number}))
+    var shipments = _.reject(this.shipments, _.matcher({'number': this.shipment_number}));
 
     var renderAttr = {
       variant: this.variant,
@@ -211,10 +211,10 @@ var ShipmentSplitItemView = Backbone.View.extend({
 
 var ShipmentItemView = Backbone.View.extend({
   initialize: function(options) {
-    this.shipment_number = options.shipment_number
-    this.order_number = options.order_number
-    this.quantity = this.$el.data('item-quantity')
-    this.variant_id = this.$el.data('variant-id')
+    this.shipment_number = options.shipment_number;
+    this.order_number = options.order_number;
+    this.quantity = this.$el.data('item-quantity');
+    this.variant_id = this.$el.data('variant-id');
   },
 
   events: {
@@ -259,8 +259,8 @@ var ShipmentItemView = Backbone.View.extend({
 
 var ShipmentEditView = Backbone.View.extend({
   initialize: function(){
-    this.shipment_number = this.model.get('number')
-    this.order_number = this.model.collection.parent.get('number')
+    this.shipment_number = this.model.get('number');
+    this.order_number = this.model.collection.parent.get('number');
 
     var shipment = this.model;
 
@@ -302,8 +302,8 @@ Spree.ready(function(){
       success: function(order){
         $('.js-shipment-edit').show();
         $(".js-shipment-edit").each(function(){
-          var shipmentNumber = $('[data-shipment-number]', this).data('shipmentNumber')
-          var shipment = order.get("shipments").find({number: shipmentNumber})
+          var shipmentNumber = $('[data-shipment-number]', this).data('shipmentNumber');
+          var shipment = order.get("shipments").find({number: shipmentNumber});
           new ShipmentEditView({ el: this, model: shipment });
         });
       }

--- a/backend/app/assets/javascripts/spree/backend/spree-select2.js
+++ b/backend/app/assets/javascripts/spree/backend/spree-select2.js
@@ -6,4 +6,4 @@ Spree.ready(function() {
     dropdownAutoWidth: true,
     minimumResultsForSearch: 8
   });
-})
+});

--- a/backend/app/assets/javascripts/spree/backend/stock_management.js
+++ b/backend/app/assets/javascripts/spree/backend/stock_management.js
@@ -10,7 +10,7 @@ Spree.ready(function() {
   });
 
   $('.js-add-stock-item').each(function() {
-    var $el = $(this)
+    var $el = $(this);
     var model = new Spree.Models.StockItem({
       variant_id: $el.data('variant-id')
     });

--- a/backend/app/assets/javascripts/spree/backend/store_credits.js
+++ b/backend/app/assets/javascripts/spree/backend/store_credits.js
@@ -1,8 +1,8 @@
 Spree.ready(function() {
   $('.store-credit-memo-row').each(function() {
     var row = this;
-    var field = row.querySelector('[name="store_credit[memo]"]')
-    var textDisplay = row.querySelector('.store-credit-memo-text')
+    var field = row.querySelector('[name="store_credit[memo]"]');
+    var textDisplay = row.querySelector('.store-credit-memo-text');
 
     $(row).on('ajax:success', function(event, data) {
       row.classList.remove('editing');

--- a/backend/app/assets/javascripts/spree/backend/taxons.js
+++ b/backend/app/assets/javascripts/spree/backend/taxons.js
@@ -63,7 +63,7 @@ Spree.ready(function() {
       success: function(data) {
         $('#taxon_products').html(productListTemplate(data.products));
 
-        var el = document.querySelector('#taxon_products')
+        var el = document.querySelector('#taxon_products');
 
         new Sortable(el, {
           draggable: ".sort_item",

--- a/backend/app/assets/javascripts/spree/backend/translation.js
+++ b/backend/app/assets/javascripts/spree/backend/translation.js
@@ -7,7 +7,7 @@
       .reduce(function(prev, curr) {
         return prev && prev[curr];
       }, obj || self);
-  }
+  };
 
   Spree.t = function(key, options) {
     options = (options || {});
@@ -23,11 +23,11 @@
       console.warn("No translation found for " + key + ".");
       return key;
     }
-  }
+  };
 
   Spree.human_attribute_name = function(model, attr) {
     return Spree.t("activerecord.attributes." + model + '.' + attr);
-  }
+  };
 
   Spree.human_model_name = function(model) {
     var model_name = Spree.t("activerecord.models." + model);
@@ -36,5 +36,5 @@
     } else {
       return model_name.one;
     }
-  }
+  };
 })();

--- a/backend/app/assets/javascripts/spree/backend/views/cart/add_line_item_button.js
+++ b/backend/app/assets/javascripts/spree/backend/views/cart/add_line_item_button.js
@@ -13,7 +13,7 @@ Spree.Views.Cart.AddLineItemButton = Backbone.View.extend({
   },
 
   render: function() {
-    var isNew = function(item) { return item.isNew() };
+    var isNew = function(item) { return item.isNew(); };
     this.$el.prop("disabled", !this.collection.length || this.collection.some(isNew));
   }
 });

--- a/backend/app/assets/javascripts/spree/backend/views/cart/line_item_row.js
+++ b/backend/app/assets/javascripts/spree/backend/views/cart/line_item_row.js
@@ -17,9 +17,9 @@ Spree.Views.Cart.LineItemRow = Backbone.View.extend({
   },
 
   onEdit: function(e) {
-    e.preventDefault()
-    this.editing = true
-    this.render()
+    e.preventDefault();
+    this.editing = true;
+    this.render();
   },
 
   onCancel: function(e) {
@@ -37,25 +37,25 @@ Spree.Views.Cart.LineItemRow = Backbone.View.extend({
     this.$('[name=quantity]').toggleClass('error', !this.$('[name=quantity]').val());
     this.$('.select2-container').toggleClass('error', !this.$('[name=variant_id]').val());
 
-    return !this.$('.select2-container').hasClass('error') && !this.$('[name=quantity]').hasClass('error')
+    return !this.$('.select2-container').hasClass('error') && !this.$('[name=quantity]').hasClass('error');
   },
 
   onSave: function(e) {
-    e.preventDefault()
+    e.preventDefault();
     if(!this.validate()) {
       return;
     }
     var attrs = {
       quantity: parseInt(this.$('input.line_item_quantity').val())
-    }
+    };
     if (this.model.isNew()) {
-      attrs['variant_id'] = this.$("[name=variant_id]").val()
+      attrs['variant_id'] = this.$("[name=variant_id]").val();
     }
     var model = this.model;
     this.model.save(attrs, {
       patch: true,
       success: function() {
-        model.order.advance()
+        model.order.advance();
       }
     });
     this.editing = false;
@@ -63,17 +63,17 @@ Spree.Views.Cart.LineItemRow = Backbone.View.extend({
   },
 
   onDelete: function(e) {
-    e.preventDefault()
+    e.preventDefault();
     if(!confirm(Spree.translations.are_you_sure_delete)) {
       return;
     }
-    this.remove()
+    this.remove();
     var model = this.model;
     this.model.destroy({
       success: function() {
-        model.order.advance()
+        model.order.advance();
       }
-    })
+    });
   },
 
   render: function() {

--- a/backend/app/assets/javascripts/spree/backend/views/images/upload_progress.js
+++ b/backend/app/assets/javascripts/spree/backend/views/images/upload_progress.js
@@ -19,7 +19,7 @@ Spree.Views.Images.UploadProgress = Backbone.View.extend({
   attributes: function() {
     return {
       "data-upload-id": this.model.cid
-    }
+    };
   },
 
   render: function() {

--- a/backend/app/assets/javascripts/spree/backend/views/order/address.js
+++ b/backend/app/assets/javascripts/spree/backend/views/order/address.js
@@ -18,7 +18,7 @@ Spree.Views.Order.Address = Backbone.View.extend({
   },
 
   onChange: function() {
-    this.model.set(this.getValues())
+    this.model.set(this.getValues());
   },
 
   eachField: function(callback){
@@ -42,7 +42,7 @@ Spree.Views.Order.Address = Backbone.View.extend({
   render: function() {
     var model = this.model;
     this.eachField(function(name, el) {
-      el.val(model.get(name))
-    })
+      el.val(model.get(name));
+    });
   }
 });

--- a/backend/app/assets/javascripts/spree/backend/views/order/customer_details.js
+++ b/backend/app/assets/javascripts/spree/backend/views/order/customer_details.js
@@ -21,8 +21,8 @@ Spree.Views.Order.CustomerDetails = Backbone.View.extend({
     this.onGuestCheckoutChanged();
     this.onChange();
 
-    this.listenTo(this.model, "change", this.render)
-    this.render()
+    this.listenTo(this.model, "change", this.render);
+    this.render();
   },
 
   events: {
@@ -33,7 +33,7 @@ Spree.Views.Order.CustomerDetails = Backbone.View.extend({
 
   onGuestCheckoutChanged: function() {
     if(this.$('#guest_checkout_true').is(':checked')) {
-      this.model.set({user_id: null})
+      this.model.set({user_id: null});
     }
   },
 
@@ -41,7 +41,7 @@ Spree.Views.Order.CustomerDetails = Backbone.View.extend({
     this.model.set({
       use_billing: this.$('#order_use_billing').is(':checked'),
       email: this.$("#order_email").val()
-    })
+    });
   },
 
   onSelectCustomer: function(customer) {
@@ -49,11 +49,11 @@ Spree.Views.Order.CustomerDetails = Backbone.View.extend({
       email: customer.email,
       user_id: customer.id,
       bill_address: customer.bill_address
-    })
+    });
   },
 
   render: function() {
-    var user_id = this.model.get("user_id") || $("#user_id").val()
+    var user_id = this.model.get("user_id") || $("#user_id").val();
     this.$("#user_id").val(user_id);
     this.$('#guest_checkout_true')
       .prop("checked", !user_id);
@@ -62,6 +62,6 @@ Spree.Views.Order.CustomerDetails = Backbone.View.extend({
       .prop("disabled", !user_id);
 
     this.$('#shipping').toggleClass("hidden", !!this.model.get("use_billing"));
-    this.$('#order_email').val(this.model.get("email"))
+    this.$('#order_email').val(this.model.get("email"));
   }
-})
+});

--- a/backend/app/assets/javascripts/spree/backend/views/order/customer_select.js
+++ b/backend/app/assets/javascripts/spree/backend/views/order/customer_select.js
@@ -9,7 +9,7 @@ Spree.Views.Order.CustomerSelect = Backbone.View.extend({
 
   onSelect: function(e) {
     var customer = e.choice;
-    this.trigger("select", customer)
+    this.trigger("select", customer);
   },
 
   render: function() {
@@ -20,8 +20,8 @@ Spree.Views.Order.CustomerSelect = Backbone.View.extend({
         customer: customer,
         bill_address: customer.bill_address,
         ship_address: customer.ship_address
-      })
-    }
+      });
+    };
 
     this.$el.select2({
       placeholder: Spree.translations.choose_a_customer,
@@ -37,19 +37,19 @@ Spree.Views.Order.CustomerSelect = Backbone.View.extend({
               addresses_firstname_start: term,
               addresses_lastname_start: term
             }
-          }
+          };
         },
         results: function(data, page) {
           return {
             results: data.users,
             more: data.current_page < data.pages
-          }
+          };
         }
       },
       formatResult: formatCustomerResult,
       formatSelection: function (customer) {
         return Select2.util.escapeMarkup(customer.email);
       }
-    })
+    });
   }
 });

--- a/backend/app/assets/javascripts/spree/backend/views/order/details_adjustments.js
+++ b/backend/app/assets/javascripts/spree/backend/views/order/details_adjustments.js
@@ -1,14 +1,14 @@
 Spree.Views.Order.DetailsAdjustments = Backbone.View.extend({
   initialize: function() {
     this.listenTo(this.model, "change", this.render);
-    this.render()
+    this.render();
   },
 
   adjustmentTotals: function() {
     var totals = {};
     var collection = this.collection ? this.collection.chain() : _.chain([this.model]);
     collection
-      .map(function(item){ return item.get("adjustments") || [] })
+      .map(function(item){ return item.get("adjustments") || []; })
       .flatten(true)
       .each(function(adjustment){
         var label = adjustment.label;
@@ -23,7 +23,7 @@ Spree.Views.Order.DetailsAdjustments = Backbone.View.extend({
   render: function() {
     var model = this.model;
     var tbody = this.$('tbody');
-    var adjustmentTotals = this.adjustmentTotals()
+    var adjustmentTotals = this.adjustmentTotals();
 
     tbody.empty();
     _.each(adjustmentTotals, function(amount, label) {
@@ -36,4 +36,4 @@ Spree.Views.Order.DetailsAdjustments = Backbone.View.extend({
 
     this.$el.toggleClass("hidden", _.isEmpty(adjustmentTotals));
   }
-})
+});

--- a/backend/app/assets/javascripts/spree/backend/views/order/details_total.js
+++ b/backend/app/assets/javascripts/spree/backend/views/order/details_total.js
@@ -1,12 +1,12 @@
 Spree.Views.Order.DetailsTotal = Backbone.View.extend({
   initialize: function() {
     this.listenTo(this.model, "change", this.render);
-    this.render()
+    this.render();
   },
 
   render: function() {
-    var lineItemCount = this.model.get("line_items").length
-    this.$el.toggleClass('hidden', !lineItemCount)
-    this.$('.order-total').text(this.model.get("display_total"))
+    var lineItemCount = this.model.get("line_items").length;
+    this.$el.toggleClass('hidden', !lineItemCount);
+    this.$('.order-total').text(this.model.get("display_total"));
   }
-})
+});

--- a/backend/app/assets/javascripts/spree/backend/views/order/shipping_method.js
+++ b/backend/app/assets/javascripts/spree/backend/views/order/shipping_method.js
@@ -54,4 +54,4 @@ Spree.Views.Order.ShippingMethod = Backbone.View.extend({
     this.$el.html(html);
     this.$('select').val(this.shippingMethodId);
   }
-})
+});

--- a/backend/app/assets/javascripts/spree/backend/views/order/summary.js
+++ b/backend/app/assets/javascripts/spree/backend/views/order/summary.js
@@ -1,29 +1,29 @@
 Spree.Views.Order.Summary = Backbone.View.extend({
   initialize: function () {
     this.listenTo(this.model, "change", this.render);
-    this.render()
+    this.render();
   },
 
   render: function () {
-    this.$('dd.order-state').html(this.renderState('order_state', this.model.get("state")))
+    this.$('dd.order-state').html(this.renderState('order_state', this.model.get("state")));
 
     this.$("#item_total").text(this.model.get("display_item_total"));
     this.$("#order_total").text(this.model.get("display_total"));
 
-    this.$('.order-shipment_total').toggleClass("hidden", !Number(this.model.get("ship_total")))
-    this.$('dd.order-shipment_total').text(this.model.get("display_ship_total"))
+    this.$('.order-shipment_total').toggleClass("hidden", !Number(this.model.get("ship_total")));
+    this.$('dd.order-shipment_total').text(this.model.get("display_ship_total"));
 
-    this.$('.order-included_tax_total').toggleClass("hidden", !Number(this.model.get("included_tax_total")))
-    this.$('dd.order-included_tax_total').text(this.model.get("display_included_tax_total"))
+    this.$('.order-included_tax_total').toggleClass("hidden", !Number(this.model.get("included_tax_total")));
+    this.$('dd.order-included_tax_total').text(this.model.get("display_included_tax_total"));
 
-    this.$('.order-additional_tax_total').toggleClass("hidden", !Number(this.model.get("additional_tax_total")))
-    this.$('dd.order-additional_tax_total').text(this.model.get("display_additional_tax_total"))
+    this.$('.order-additional_tax_total').toggleClass("hidden", !Number(this.model.get("additional_tax_total")));
+    this.$('dd.order-additional_tax_total').text(this.model.get("display_additional_tax_total"));
 
-    this.$('.order-shipment_state').toggleClass("hidden", !this.model.get("completed_at"))
-    this.$('dd.order-shipment_state').html(this.renderState('shipment_state', this.model.get("shipment_state")))
+    this.$('.order-shipment_state').toggleClass("hidden", !this.model.get("completed_at"));
+    this.$('dd.order-shipment_state').html(this.renderState('shipment_state', this.model.get("shipment_state")));
 
-    this.$('.order-payment_state').toggleClass("hidden", !this.model.get("completed_at"))
-    this.$('dd.order-payment_state').html(this.renderState('payment_state', this.model.get("payment_state")))
+    this.$('.order-payment_state').toggleClass("hidden", !this.model.get("completed_at"));
+    this.$('dd.order-payment_state').html(this.renderState('payment_state', this.model.get("payment_state")));
   },
 
   renderState: function(translation_key, value) {

--- a/backend/app/assets/javascripts/spree/backend/views/payment/edit_credit_card.js
+++ b/backend/app/assets/javascripts/spree/backend/views/payment/edit_credit_card.js
@@ -5,7 +5,7 @@ Spree.Views.Payment.EditCreditCard = Backbone.View.extend({
     this.$(".cardExpiry").payment('formatCardExpiry');
     this.$(".cardCode").payment('formatCardCVC');
 
-    this.render()
+    this.render();
   },
 
   events: {
@@ -15,9 +15,9 @@ Spree.Views.Payment.EditCreditCard = Backbone.View.extend({
 
   render: function() {
     var isNew = (this.$('[name=card]:checked').val() === 'new') || (this.$('[name=card]').length == 0);
-    this.$('.js-new-credit-card-form').toggleClass('hidden', !isNew)
-    this.$('.js-new-credit-card-form :input').prop('disabled', !isNew)
+    this.$('.js-new-credit-card-form').toggleClass('hidden', !isNew);
+    this.$('.js-new-credit-card-form :input').prop('disabled', !isNew);
 
-    this.$(".ccType").val($.payment.cardType(this.$('.cardNumber').val()))
+    this.$(".ccType").val($.payment.cardType(this.$('.cardNumber').val()));
   }
-})
+});

--- a/backend/app/assets/javascripts/spree/backend/views/payment/new.js
+++ b/backend/app/assets/javascripts/spree/backend/views/payment/new.js
@@ -1,6 +1,6 @@
 Spree.Views.Payment.New = Backbone.View.extend({
   initialize: function() {
-    this.onSelectMethod()
+    this.onSelectMethod();
   },
 
   events: {
@@ -9,7 +9,7 @@ Spree.Views.Payment.New = Backbone.View.extend({
   },
 
   onSelectMethod: function(e) {
-    this.selectedId = parseInt(this.$('input[name="payment[payment_method_id]"]:checked').val())
+    this.selectedId = parseInt(this.$('input[name="payment[payment_method_id]"]:checked').val());
     this.render();
   },
 

--- a/backend/app/assets/javascripts/spree/backend/views/promotions/option_values_rule.js
+++ b/backend/app/assets/javascripts/spree/backend/views/promotions/option_values_rule.js
@@ -25,7 +25,7 @@ Spree.Views.Promotions.OptionValuesRuleRow = Backbone.View.extend({
 
     // Note: This doesn't work. This always selects the first product select on the page.
     // optionValueAutocomplete also doesn't work, so this cancels out.
-    this.$('.js-promo-rule-option-value-option-values-select').optionValueAutocomplete({productSelect: '.js-promo-rule-option-value-product-select'})
+    this.$('.js-promo-rule-option-value-option-values-select').optionValueAutocomplete({productSelect: '.js-promo-rule-option-value-product-select'});
 
     if(this.productId == null) {
       this.$('.js-promo-rule-option-value-option-values-select').prop('disabled', true);
@@ -44,11 +44,11 @@ Spree.Views.Promotions.OptionValuesRuleRow = Backbone.View.extend({
 
 Spree.Views.Promotions.OptionValuesRule = Backbone.View.extend({
   initialize: function() {
-    _.bindAll(this, 'addOptionValue')
+    _.bindAll(this, 'addOptionValue');
     this.$optionValues = this.$('.js-promo-rule-option-values');
     this.paramPrefix = this.$('.param-prefix').data('param-prefix');
 
-    var originalOptionValues = this.$optionValues.data('original-option-values')
+    var originalOptionValues = this.$optionValues.data('original-option-values');
     if ($.isEmptyObject(originalOptionValues)) {
       this.addOptionValue(null, null);
     } else {

--- a/backend/app/assets/javascripts/spree/backend/views/state_select.js
+++ b/backend/app/assets/javascripts/spree/backend/views/state_select.js
@@ -1,6 +1,6 @@
 Spree.Views.StateSelect = Backbone.View.extend({
   initialize: function() {
-    this.states = {} // null object
+    this.states = {}; // null object
 
     this.$state_select = this.$('.js-state_id');
     this.$state_input = this.$('.js-state_name');
@@ -9,10 +9,10 @@ Spree.Views.StateSelect = Backbone.View.extend({
     this.model.set({
       state_name: this.$state_input.val(),
       state_id: this.$state_select.val()
-    })
+    });
 
     this.updateStates();
-    this.listenTo(this.model, 'change:country_id', this.updateStates)
+    this.listenTo(this.model, 'change:country_id', this.updateStates);
     this.render();
   },
 
@@ -25,7 +25,7 @@ Spree.Views.StateSelect = Backbone.View.extend({
     this.model.set({
       state_name: this.$state_input.val(),
       state_id: this.$state_select.val()
-    })
+    });
   },
 
   updateStates: function() {
@@ -50,17 +50,17 @@ Spree.Views.StateSelect = Backbone.View.extend({
         $state_select.append(
           $('<option>').prop('value', state.id).text(state.get("name"))
         );
-      })
-      this.$state_select.val(this.model.get("state_id"))
+      });
+      this.$state_select.val(this.model.get("state_id"));
       this.$state_select.show().prop("disabled", false);
     } else {
       this.$state_input.show().prop('disabled', false);
     }
   }
-})
+});
 
 Spree.Views.StateSelect.stateCache = _.memoize(function(country_id) {
-  var states = new Spree.Collections.States([], {country_id: country_id})
+  var states = new Spree.Collections.States([], {country_id: country_id});
   states.fetched = false;
   states.fetch({
     success: function() {

--- a/backend/app/assets/javascripts/spree/backend/views/zones/form.js
+++ b/backend/app/assets/javascripts/spree/backend/views/zones/form.js
@@ -13,4 +13,4 @@ Spree.Views.Zones.Form = Backbone.View.extend({
     $('#country_members').toggleClass('hidden', kind !== 'country');
     $('#country_members :input').prop('disabled', kind !== 'country');
   }
-})
+});

--- a/backend/app/assets/javascripts/spree/backend/zone.js
+++ b/backend/app/assets/javascripts/spree/backend/zone.js
@@ -3,6 +3,6 @@ Spree.ready(function(){
     var view = new Spree.Views.Zones.Form({
       el: $('.js-zones-form')
     });
-    view.render()
+    view.render();
   }
 });


### PR DESCRIPTION
This is a pretty low priority PR. I noticed that semi-colon usage was pretty erratic in the JS. It seemed that generally it was preferable to end statements with a semi-colon, so I went ahead and tried to standardize that across all of the JS. 