### PR TITLE
Add missing bash tag to code block

### DIFF
--- a/guides/source/developers/getting-started/develop-solidus.html.md
+++ b/guides/source/developers/getting-started/develop-solidus.html.md
@@ -40,7 +40,7 @@ DB=postgresql bundle exec rake sandbox
 After the sandbox has been generated, you can change into its directory and
 start the server:
 
-```
+```bash
 cd sandbox
 rails server
 ```


### PR DESCRIPTION
While reading the docs, I noticed this block was missing the bash tag. 
<img width="715" alt="screen shot 2018-09-20 at 6 50 47 pm" src="https://user-images.githubusercontent.com/11466782/45852585-1edc2f00-bd06-11e8-97a0-722fba504c38.png">
