### PR TITLE
 Fix a bug with the settings subnav 

### DIFF
--- a/backend/app/models/spree/backend_configuration.rb
+++ b/backend/app/models/spree/backend_configuration.rb
@@ -16,8 +16,7 @@ module Spree
                             :payment_methods, :shipping_methods,
                             :shipping_categories, :stock_locations,
                             :refund_reasons, :reimbursement_types,
-                            :return_authorization_reasons, :return_reasons,
-                            :adjustment_reasons]
+                            :return_reasons, :adjustment_reasons]
     PROMOTION_TABS     ||= [:promotions, :promotion_categories]
     STOCK_TABS         ||= [:stock_items]
     USER_TABS          ||= [:users, :store_credits]

--- a/backend/app/models/spree/backend_configuration.rb
+++ b/backend/app/models/spree/backend_configuration.rb
@@ -15,7 +15,9 @@ module Spree
                             :tax_rates, :zones,
                             :payment_methods, :shipping_methods,
                             :shipping_categories, :stock_locations,
-                            :refund_reasons, :reimbursement_types, :return_authorization_reasons]
+                            :refund_reasons, :reimbursement_types,
+                            :return_authorization_reasons, :return_reasons,
+                            :adjustment_reasons]
     PROMOTION_TABS     ||= [:promotions, :promotion_categories]
     STOCK_TABS         ||= [:stock_items]
     USER_TABS          ||= [:users, :store_credits]

--- a/backend/app/views/spree/admin/shared/_settings_sub_menu.html.erb
+++ b/backend/app/views/spree/admin/shared/_settings_sub_menu.html.erb
@@ -12,8 +12,8 @@
   <% end %>
 
   <% if can?(:display, Spree::RefundReason) || can?(:display, Spree::ReimbursementType) ||
-     can?(:display, Spree::ReturnReason) || can?(:display, Spree::AdjustmentReason) %>
-    <%= tab :checkout, url: spree.admin_refund_reasons_path %>
+    can?(:display, Spree::ReturnReason) || can?(:display, Spree::AdjustmentReason) %>
+    <%= tab :checkout, url: spree.admin_refund_reasons_path, match_path: %r(refund_reasons|reimbursement_types|return_reasons|adjustment_reasons) %>
   <% end %>
 
   <% if can?(:display, Spree::ShippingMethod) || can?(:display, Spree::ShippingCategory) || can?(:display, Spree::StockLocation) %>


### PR DESCRIPTION
There is currently a UI bug causing the settings subnav to display incorrectly on some routes.

`/admin/return_reasons` and `/admin/adjustment_reasons` fail to display the subnav at all:
![image](https://user-images.githubusercontent.com/11466782/45879406-0271de00-bd6a-11e8-9e7a-d781e3234738.png)

While `/admin/reimbursement_types` doesn't highlight the active tab:
![image](https://user-images.githubusercontent.com/11466782/45879451-28977e00-bd6a-11e8-9af8-e9c745699188.png)

This PR fixes both issues. 

I also want to verify that removing `:return_authorization_reasons` from line 18 of `backend_configuration.rb` is okay. If that is used anywhere, we can put it back.