### PR TITLE
Fix highlighting on tax sub menu

### DIFF
--- a/backend/app/views/spree/admin/shared/_settings_sub_menu.html.erb
+++ b/backend/app/views/spree/admin/shared/_settings_sub_menu.html.erb
@@ -8,7 +8,7 @@
   <% end %>
 
   <% if can?(:display, Spree::TaxCategory) || can?(:display, Spree::TaxRate) %>
-    <%= tab :taxes, url: spree.admin_tax_categories_path %>
+    <%= tab :taxes, url: spree.admin_tax_categories_path, match_path: %r(tax_categories|tax_rates) %>
   <% end %>
 
   <% if can?(:display, Spree::RefundReason) || can?(:display, Spree::ReimbursementType) ||


### PR DESCRIPTION
I noticed that one of the bugs from #2853 exists under the "Taxes" menu as well.