### PR TITLE
Stop negative totals during checkout

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -862,6 +862,12 @@ module Spree
       end
     end
 
+    def ensure_positive_total
+      if outstanding_balance < 0
+        errors.add(:base, I18n.t('spree.cart_balance_negative')) && (return false)
+      end
+    end
+
     def ensure_available_shipping_rates
       if shipments.empty? || shipments.any? { |shipment| shipment.shipping_rates.blank? }
         # After this point, order redirects back to 'address' state and asks user to pick a proper address

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -83,6 +83,8 @@ module Spree
               after_transition to: :complete, do: :add_payment_sources_to_wallet
               before_transition to: :payment, do: :add_default_payment_from_wallet
 
+              before_transition to: :payment, do: :ensure_positive_total
+
               before_transition to: :confirm, do: :add_store_credit_payments
 
               # see also process_payments_before_complete below which needs to

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1085,7 +1085,8 @@ en:
       one: Subtotal (1 item)
       other: Subtotal (%{count} items)
     carton_external_number: External Number
-    carton_orders: Other orders with Carton
+    carton_orders: 'Other orders with Carton'
+    cart_balance_negative: "Cart balance cannot be negative"
     categories: Categories
     category: Category
     character_limit: Limit of 255 characters

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -297,10 +297,34 @@ RSpec.describe Spree::Order, type: :model do
           allow(order).to receive_messages payment_required?: true
         end
 
-        it "transitions to payment" do
-          order.next!
-          assert_state_changed(order, 'delivery', 'payment')
-          expect(order.state).to eq('payment')
+        context "with a zero total" do
+          it "transitions to payment" do
+            order.next!
+            assert_state_changed(order, 'delivery', 'payment')
+            expect(order.state).to eq('payment')
+          end
+        end
+
+        context "with a positive total" do
+          before do
+            order.total = 1
+          end
+
+          it "transitions to payment" do
+            order.next!
+            assert_state_changed(order, 'delivery', 'payment')
+            expect(order.state).to eq('payment')
+          end
+        end
+
+        context "with a negative total" do
+          before do
+            order.total = -1
+          end
+
+          it "raises an exception" do
+            expect { order.next! }.to raise_error(StateMachines::InvalidTransition)
+          end
         end
       end
 


### PR DESCRIPTION
Currently it is possible to check out with a negative total. 

![image](https://user-images.githubusercontent.com/11466782/45882680-7e712380-bd74-11e8-9df2-c511c1f5e306.png)

This PR stops the transition to the payment step if the cart total is below zero.

Would love some feedback on this as I'm sure there are other solutions.

Closes #2741 