### PR TITLE
Fix capitalization for Back orderable

### DIFF
--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1044,7 +1044,7 @@ en:
     back_to_zones_list: Back To Zones List
     backorderable: Backorderable
     backorderable_default: Backorderable default
-    backorderable_header: Back orderable
+    backorderable_header: Back Orderable
     backorders_allowed: backorders allowed
     balance_due: Balance Due
     base_amount: Base Amount


### PR DESCRIPTION
Tiny PR. The other table headers are in title case and this one was not.

![image](https://user-images.githubusercontent.com/11466782/45922655-e1a7a680-be97-11e8-950f-5f8b32656b9a.png)
