### PR TITLE
[RFC] New stock management

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/templates/stock_items/stock_location_stock_item.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/stock_items/stock_location_stock_item.hbs
@@ -1,5 +1,5 @@
-<td>{{stockLocationName}}</td>
-<td>
+<td class="stock-location-name">{{stockLocationName}}</td>
+<td class="align-center">
   <input id="backorderable-{{id}}"
          name="backorderable"
          type="checkbox"
@@ -8,7 +8,7 @@
          {{#if backorderable}} checked="checked" {{/if}}
    >
 </td>
-<td>
+<td class="align-center">
   {{#if editing}}
     <form>
       <input

--- a/backend/app/assets/javascripts/spree/backend/templates/stock_items/stock_location_stock_item.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/stock_items/stock_location_stock_item.hbs
@@ -4,33 +4,32 @@
          name="backorderable"
          type="checkbox"
          value="backorderable"
-         {{#unless editing}} disabled="disabled" {{/unless}}
          {{#if backorderable}} checked="checked" {{/if}}
    >
 </td>
 <td class="align-center">
-  {{#if editing}}
-    <form>
-      <input
-      {{#if negative}}
-        class="fullwidth negative"
-      {{else}}
-        class="fullwidth"
-      {{/if}}
-      name="count_on_hand"
-      type="number"
-      value="{{count_on_hand}}"
-    >
-    </form>
-  {{else}}
-    <span {{#if negative}}class="negative"{{/if}}>{{count_on_hand}}</span>
-  {{/if}}
+  <span
+    {{#if negative}}
+    class="negative count-on-hand-display"
+    {{else}}
+    class="count-on-hand-display"
+    {{/if}}
+    >{{count_on_hand}}</span>
+</td>
+<td>
+  <form>
+    <input
+    {{#if negative}}
+      class="fullwidth negative"
+    {{else}}
+      class="fullwidth"
+    {{/if}}
+    name="count_on_hand"
+    type="number"
+    value="0">
+  </form>
 </td>
 <td class="actions">
-  {{#if editing}}
-    <a class="submit fa fa-check icon_link with-tip no-text" data-action="save" href="#"></a>
-    <a class="cancel fa fa-cancel icon_link with-tip no-text" data-action="cancel" href="#"></a>
-  {{else}}
-    <a class="edit fa fa-edit icon_link with-tip no-text" data-action="edit" href="#"></a>
-  {{/if}}
+  <a class="submit fa fa-check icon_link with-tip no-text" data-action="save" href="#"></a>
+  <a class="cancel fa fa-cancel icon_link with-tip no-text" data-action="cancel" href="#"></a>
 </td>

--- a/backend/app/assets/javascripts/spree/backend/views/stock/add_stock_item.js
+++ b/backend/app/assets/javascripts/spree/backend/views/stock/add_stock_item.js
@@ -6,14 +6,23 @@ Spree.Views.Stock.AddStockItem = Backbone.View.extend({
   },
 
   events: {
-    "click .submit": "onSubmit"
+    "click .submit": "onSubmit",
+    "submit form": "onSubmit",
+    'input [name="count_on_hand"]': "onChange",
+    'change [name="stock_location_id"]': "onChange",
+    'click [name="backorderable"]': "onChange"
   },
 
   validate: function() {
-    var locationSelectContainer = this.$locationSelect.siblings('.select2-container');
-    locationSelectContainer.toggleClass('error', !this.$locationSelect.val());
+    this.$locationSelect.toggleClass('error', !this.$locationSelect.val());
     this.$countInput.toggleClass('error', !this.$countInput.val());
-    return locationSelectContainer.hasClass('error') || this.$countInput.hasClass('error');
+    return this.$locationSelect.hasClass('error') || this.$countInput.hasClass('error');
+  },
+
+  onChange: function (event) {
+    var $target = $(event.target)
+    if ($target.val() !== '') $target.removeClass('error');
+    this.$el.addClass('changed');
   },
 
   onSuccess: function() {
@@ -25,6 +34,7 @@ Spree.Views.Stock.AddStockItem = Backbone.View.extend({
       stockLocationName: stockLocationName
     });
     editView.$el.insertBefore(this.$el);
+    editView.$el.addClass('stock-item-edit-row');
     this.model = new Spree.Models.StockItem({
       variant_id: this.model.get('variant_id'),
       stock_location_id: this.model.get('stock_location_id')
@@ -58,6 +68,7 @@ Spree.Views.Stock.AddStockItem = Backbone.View.extend({
       success: this.onSuccess.bind(this),
       error: this.onError.bind(this)
     };
+    this.$el.removeClass('changed');
     this.model.save(null, options);
   }
 });

--- a/backend/app/assets/javascripts/spree/backend/views/stock/edit_stock_item_row.js
+++ b/backend/app/assets/javascripts/spree/backend/views/stock/edit_stock_item_row.js
@@ -3,16 +3,17 @@ Spree.Views.Stock.EditStockItemRow = Backbone.View.extend({
 
   initialize: function(options) {
     this.stockLocationName = options.stockLocationName;
-    this.editing = false;
     this.negative = this.model.attributes.count_on_hand < 0;
+    this.previousAttributes = _.clone(this.model.attributes);
+    this.listenTo(this.model, 'sync', this.onSuccess);
     this.render();
   },
 
   events: {
-    "click .edit": "onEdit",
     "click .submit": "onSubmit",
     "submit form": "onSubmit",
-    "click .cancel": "onCancel"
+    "click .cancel": "onCancel",
+    'input [name="count_on_hand"]': "countOnHandChanged"
   },
 
   template: HandlebarsTemplates['stock_items/stock_location_stock_item'],
@@ -26,26 +27,37 @@ Spree.Views.Stock.EditStockItemRow = Backbone.View.extend({
     _.extend(renderAttr, this.model.attributes);
     this.$el.attr("data-variant-id", this.model.get('variant_id'));
     this.$el.html(this.template(renderAttr));
+    this.$count_on_hand_display = this.$('.count-on-hand-display');
     return this;
   },
 
   onEdit: function(ev) {
     ev.preventDefault();
-    this.editing = true;
     this.render();
   },
 
   onCancel: function(ev) {
     ev.preventDefault();
-    this.model.set(this.model.previousAttributes());
-    this.editing = false;
+    this.model.set(this.previousAttributes);
+    this.$el.removeClass('changed');
     this.render();
   },
 
+  countOnHandChanged: function(ev) {
+    var diff = parseInt(ev.currentTarget.value), newCount;
+    if (isNaN(diff)) diff = 0;
+    newCount = this.previousAttributes.count_on_hand + diff;
+    ev.preventDefault();
+    this.model.set("count_on_hand", newCount);
+    this.$el.toggleClass('changed', diff !== 0);
+    this.$count_on_hand_display.text(newCount);
+  },
+
   onSuccess: function() {
-    this.editing = false;
+    this.$el.removeClass('changed');
+    this.previousAttributes = _.clone(this.model.attributes);
     this.render();
-    show_flash("success", Spree.translations.updated_successfully);
+    this.$('[name="count_on_hand"]').focus();
   },
 
   onError: function(model, response, options) {
@@ -62,9 +74,11 @@ Spree.Views.Stock.EditStockItemRow = Backbone.View.extend({
       backorderable: backorderable
     });
     var options = {
-      success: this.onSuccess.bind(this),
+      success: function() {
+        show_flash("success", Spree.translations.updated_successfully);
+      },
       error: this.onError.bind(this)
     };
-    this.model.save({ force: true }, options);
+    this.model.save({}, options);
   }
 });

--- a/backend/app/assets/javascripts/spree/backend/views/stock/edit_stock_item_row.js
+++ b/backend/app/assets/javascripts/spree/backend/views/stock/edit_stock_item_row.js
@@ -48,9 +48,15 @@ Spree.Views.Stock.EditStockItemRow = Backbone.View.extend({
     if (isNaN(diff)) diff = 0;
     newCount = this.previousAttributes.count_on_hand + diff;
     ev.preventDefault();
-    this.model.set("count_on_hand", newCount);
+    // Do not allow negative stock values
+    if (newCount < 0) {
+      ev.currentTarget.value = -1 * this.previousAttributes.count_on_hand;
+      this.$count_on_hand_display.text(0);
+    } else {
+      this.model.set("count_on_hand", newCount);
+      this.$count_on_hand_display.text(newCount);
+    }
     this.$el.toggleClass('changed', diff !== 0);
-    this.$count_on_hand_display.text(newCount);
   },
 
   onSuccess: function() {

--- a/backend/app/assets/stylesheets/spree/backend/sections/_stock_management.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/_stock_management.scss
@@ -4,8 +4,26 @@
     border-top-width: 1px;
   }
 
-  .stock-item-edit-row td {
-    height: 50px; // height of input field in edit mode
+  .stock-item-edit-row {
+    &.changed {
+      .submit, .cancel {
+        display: inline-block;
+      }
+    }
+
+    td {
+      vertical-align: middle;
+
+      &:not(.actions) {
+        padding: 0.5rem 0.75rem;
+      }
+    }
+  }
+
+  .actions {
+    .submit, .cancel {
+      display: none;
+    }
   }
 
   td {

--- a/backend/app/assets/stylesheets/spree/backend/sections/_stock_management.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/_stock_management.scss
@@ -1,4 +1,4 @@
-#listing_product_stock {
+.stock-table {
 
   tbody + tbody {
     border-top-width: 1px;
@@ -12,6 +12,34 @@
     .select2-container.error {
       border-radius: 4px;
       border: 1px solid theme-color("danger");
+    }
+  }
+
+  .stock-variant-field-table {
+    tr td {
+      padding: 2px;
+      border: none;
+      text-align: left;
+    }
+    tr td:first-child {
+      font-weight: bold;
+    }
+    margin-bottom: 0px;
+  }
+
+  > tbody {
+    .variant-image {
+      width: 31%;
+      padding: 0 2%;
+      img { width: 100%; }
+    }
+    .variant-details {
+      width: 65%;
+      padding: 0px 5px;
+    }
+    .variant-image,
+    .variant-details {
+      float: left;
     }
   }
 }

--- a/backend/app/assets/stylesheets/spree/backend/sections/_stock_management.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/_stock_management.scss
@@ -27,7 +27,7 @@
   }
 
   td {
-    input.error {
+    .error {
       border-color: theme-color("danger");
     }
 

--- a/backend/app/assets/stylesheets/spree/backend/sections/_stock_management.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/_stock_management.scss
@@ -4,6 +4,10 @@
     border-top-width: 1px;
   }
 
+  .stock-item-edit-row td {
+    height: 50px; // height of input field in edit mode
+  }
+
   td {
     input.error {
       border-color: theme-color("danger");
@@ -15,16 +19,30 @@
     }
   }
 
-  .stock-variant-field-table {
-    tr td {
-      padding: 2px;
+  .variant-stock-items {
+    border: 0 none;
+  }
+
+  table {
+    td {
+      padding: 4px 0;
       border: none;
-      text-align: left;
     }
-    tr td:first-child {
-      font-weight: bold;
+
+    &.stock-variant-field-table {
+      margin-bottom: 0;
+
+      td {
+        text-align: left;
+
+        &:first-child {
+          font-weight: bold;
+          text-align: left;
+          padding-right: 0.5rem;
+          width: 15%;
+        }
+      }
     }
-    margin-bottom: 0px;
   }
 
   > tbody {
@@ -41,5 +59,16 @@
     .variant-details {
       float: left;
     }
+    .variant-container {
+      overflow: hidden;
+    }
   }
+}
+
+.stock-location-items-cell {
+  padding: 0;
+}
+
+.stock-location-items-table {
+  margin-bottom: 0;
 }

--- a/backend/app/assets/stylesheets/spree/backend/spree_admin.scss
+++ b/backend/app/assets/stylesheets/spree/backend/spree_admin.scss
@@ -29,7 +29,6 @@
 @import 'spree/backend/components/table-filter';
 @import 'spree/backend/components/navigation';
 @import 'spree/backend/components/sidebar';
-@import 'spree/backend/components/stock_table';
 @import 'spree/backend/components/editable_table';
 @import 'spree/backend/components/pills';
 @import 'spree/backend/components/tabs';

--- a/backend/app/views/spree/admin/shared/_variant_search.html.erb
+++ b/backend/app/views/spree/admin/shared/_variant_search.html.erb
@@ -4,7 +4,7 @@
       <div class="field-block col-3">
         <div class="field">
           <%= label_tag nil, Spree::StockLocation.model_name.human %>
-          <%= select_tag :stock_location_id, options_from_collection_for_select(stock_locations, :id, :name, params[:stock_location_id]), { include_blank: true, class: 'custom-select fullwidth', "data-placeholder" => t('spree.select_a_stock_location') } %>
+          <%= select_tag :stock_location_id, options_from_collection_for_select(stock_locations, :id, :name, params[:stock_location_id]), { include_blank: t('spree.all'), class: 'custom-select fullwidth', "data-placeholder" => t('spree.select_a_stock_location') } %>
         </div>
       </div>
       <div class="<%= if content_for?(:sidebar) then 'col-6' else 'col-9' end %>">

--- a/backend/app/views/spree/admin/stock_items/_stock_management.html.erb
+++ b/backend/app/views/spree/admin/stock_items/_stock_management.html.erb
@@ -1,3 +1,5 @@
+<% admin_layout "full-width" %>
+
 <%= paginate @variants, theme: "solidus_admin" %>
 
 <table class="index stock-table" id="listing_product_stock">

--- a/backend/app/views/spree/admin/stock_items/_stock_management.html.erb
+++ b/backend/app/views/spree/admin/stock_items/_stock_management.html.erb
@@ -24,8 +24,6 @@
     </tr>
   </thead>
   <% variants.each do |variant| %>
-    <%- locations_without_items = @stock_item_stock_locations - variant.stock_items.flat_map(&:stock_location) %>
-    <%- display_add_row = locations_without_items.any? && can?(:create, Spree::StockItem) %>
     <tbody class="variant-stock-items">
       <tr id="<%= spree_dom_id variant %>">
         <td>
@@ -77,25 +75,29 @@
                 </tr>
               <% end %>
             <% end %>
+            <% locations_without_items = @stock_item_stock_locations - variant.stock_items.flat_map(&:stock_location) %>
+            <% if locations_without_items.any? && can?(:create, Spree::StockItem) %>
+              <tr class="js-add-stock-item stock-item-edit-row" data-variant-id="<%= variant.id %>">
+                <form>
+                  <td class='location-name-cell'>
+                    <%= select_tag :stock_location_id, options_from_collection_for_select(locations_without_items, :id, :name), class: 'custom-select', prompt: t('spree.add_to_stock_location'), id: "variant-stock-location-#{variant.id}" %>
+                  </td>
+                  <td class="align-center">
+                    <%= check_box_tag :backorderable, 'backorderable', false, id: "variant-backorderable-#{variant.id}" %>
+                  </td>
+                  <td>
+                    <%= number_field_tag :count_on_hand, "", class: 'fullwidth', id: "variant-count-on-hand-#{variant.id}" %>
+                  </td>
+                  <td></td>
+                  <td class="actions">
+                    <%= link_to_with_icon 'plus', t('spree.actions.create'), '#', no_text: true, data: { action: 'add' }, class: "submit" %>
+                  </td>
+                </form>
+              </tr>
+            <% end %>
           </table>
         </td>
       </tr>
-      <% if display_add_row %>
-        <tr class="js-add-stock-item stock-item-edit-row" data-variant-id="<%= variant.id %>">
-          <td class='location-name-cell'>
-            <%= select_tag :stock_location_id, options_from_collection_for_select(locations_without_items, :id, :name), { include_blank: true, class: 'custom-select', "data-placeholder" => t('spree.add_to_stock_location'), id: "variant-stock-location-#{variant.id}" } %>
-          </td>
-          <td class="align-center">
-            <%= check_box_tag :backorderable, 'backorderable', false, id: "variant-backorderable-#{variant.id}" %>
-          </td>
-          <td class="align-center">
-            <%= number_field_tag :count_on_hand, "", class: 'fullwidth', id: "variant-count-on-hand-#{variant.id}" %>
-          </td>
-          <td class="actions">
-            <%= link_to_with_icon 'plus', t('spree.actions.create'), '#', no_text: true, data: { action: 'add' }, class: "submit" %>
-          </td>
-        </tr>
-      <% end %>
     </tbody>
   <% end %>
 </table>

--- a/backend/app/views/spree/admin/stock_items/_stock_management.html.erb
+++ b/backend/app/views/spree/admin/stock_items/_stock_management.html.erb
@@ -5,11 +5,12 @@
 <table class="index stock-table" id="listing_product_stock">
   <colgroup>
     <col style="width: 30%">
-    <col style="width: 20%">
     <col style="width: 15%">
+    <col style="width: 14%">
+    <col style="width: 11%">
+    <col style="width: 11%">
     <col style="width: 10%">
-    <col style="width: 20%">
-    <col style="width: 5%">
+    <col style="width: 9%">
   </colgroup>
   <thead>
     <tr>
@@ -18,6 +19,7 @@
       <th><%= Spree::StockLocation.model_name.human %></th>
       <th class="align-center"><%= t('spree.backorderable_header') %></th>
       <th class="align-center"><%= t('spree.count_on_hand') %></th>
+      <th><%= t('spree.modify_stock_count') %></th>
       <th class="actions"></th>
     </tr>
   </thead>
@@ -59,13 +61,14 @@
             <% end %>
           </table>
         </td>
-        <td class="stock-location-items-cell" colspan="4">
+        <td class="stock-location-items-cell" colspan="5">
           <table class="stock-location-items-table">
             <colgroup>
-              <col style="width: 30%" />
+              <col style="width: 25%" />
               <col style="width: 20%" />
-              <col style="width: 40%" />
-              <col style="width: 10%" />
+              <col style="width: 20%" />
+              <col style="width: 20%" />
+              <col style="width: 15%" />
             </colgroup>
             <% variant.stock_items.each do |item| %>
               <% if @stock_item_stock_locations.include?(item.stock_location) %>

--- a/backend/app/views/spree/admin/stock_items/_stock_management.html.erb
+++ b/backend/app/views/spree/admin/stock_items/_stock_management.html.erb
@@ -4,30 +4,29 @@
 
 <table class="index stock-table" id="listing_product_stock">
   <colgroup>
-    <col style="width: 50%" />
-    <col style="width: 20%" />
-    <col style="width: 10%" />
-    <col style="width: 5%" />
-    <col style="width: 5%" />
-    <col style="width: 10%" />
+    <col style="width: 30%">
+    <col style="width: 20%">
+    <col style="width: 15%">
+    <col style="width: 10%">
+    <col style="width: 20%">
+    <col style="width: 5%">
   </colgroup>
   <thead>
     <tr>
       <th><%= t('spree.item') %></th>
-      <th><%= t('spree.options') %></th>
+      <th><%= Spree::Variant.model_name.human %></th>
       <th><%= Spree::StockLocation.model_name.human %></th>
-      <th><%= t('spree.backorderable_header') %></th>
-      <th><%= t('spree.count_on_hand') %></th>
+      <th class="align-center"><%= t('spree.backorderable_header') %></th>
+      <th class="align-center"><%= t('spree.count_on_hand') %></th>
       <th class="actions"></th>
     </tr>
   </thead>
   <% variants.each do |variant| %>
     <%- locations_without_items = @stock_item_stock_locations - variant.stock_items.flat_map(&:stock_location) %>
     <%- display_add_row = locations_without_items.any? && can?(:create, Spree::StockItem) %>
-    <%- row_count = @stock_item_stock_locations.count + 2 %>
     <tbody class="variant-stock-items">
       <tr id="<%= spree_dom_id variant %>">
-        <td class="no-padding" rowspan="<%= row_count %>">
+        <td>
           <div class='variant-container'>
             <div class='variant-image'>
               <%= render 'spree/admin/shared/image', image: variant.display_image(fallback: false), size: :small %>
@@ -48,7 +47,7 @@
             </div>
           </div>
         </td>
-        <td rowspan="<%= row_count %>">
+        <td class="align-center">
           <table class='stock-variant-field-table'>
             <% variant.option_values.sort_by(&:option_type_name).each do |option_value| %>
               <tr>
@@ -60,14 +59,24 @@
             <% end %>
           </table>
         </td>
+        <td class="stock-location-items-cell" colspan="4">
+          <table class="stock-location-items-table">
+            <colgroup>
+              <col style="width: 30%" />
+              <col style="width: 20%" />
+              <col style="width: 40%" />
+              <col style="width: 10%" />
+            </colgroup>
+            <% variant.stock_items.each do |item| %>
+              <% if @stock_item_stock_locations.include?(item.stock_location) %>
+                <tr class="js-edit-stock-item stock-item-edit-row" data-variant-id="<%= variant.id %>" data-stock-item="<%= item.to_json %>" data-stock-location-name="<%= item.stock_location.name %>">
+                  <%# This is rendered in JS %>
+                </tr>
+              <% end %>
+            <% end %>
+          </table>
+        </td>
       </tr>
-      <% variant.stock_items.each do |item| %>
-        <% if @stock_item_stock_locations.include?(item.stock_location) %>
-          <tr class="js-edit-stock-item stock-item-edit-row" data-variant-id="<%= variant.id %>" data-stock-item="<%= item.to_json %>" data-stock-location-name="<%= item.stock_location.name %>">
-            <%# This is rendered in JS %>
-          </tr>
-        <% end %>
-      <% end %>
       <% if display_add_row %>
         <tr class="js-add-stock-item stock-item-edit-row" data-variant-id="<%= variant.id %>">
           <td class='location-name-cell'>

--- a/backend/spec/features/admin/products/stock_management_spec.rb
+++ b/backend/spec/features/admin/products/stock_management_spec.rb
@@ -44,26 +44,23 @@ describe "Product Stock", type: :feature do
     it "can create a positive stock adjustment", js: true do
       adjust_count_on_hand('14')
       stock_item.reload
-      expect(stock_item.count_on_hand).to eq 14
+      expect(stock_item.count_on_hand).to eq 24
       expect(stock_item.stock_movements.count).to eq 1
-      expect(stock_item.stock_movements.first.quantity).to eq 4
+      expect(stock_item.stock_movements.first.quantity).to eq 14
     end
 
     it "can create a negative stock adjustment", js: true do
-      adjust_count_on_hand('4')
+      adjust_count_on_hand('-4')
       stock_item.reload
-      expect(stock_item.count_on_hand).to eq 4
+      expect(stock_item.count_on_hand).to eq 6
       expect(stock_item.stock_movements.count).to eq 1
-      expect(stock_item.stock_movements.first.quantity).to eq(-6)
+      expect(stock_item.stock_movements.first.quantity).to eq(-4)
     end
 
     def adjust_count_on_hand(count_on_hand)
-      within('.variant-stock-items', text: variant.sku) do
-        within('tr', text: stock_item.stock_location.name) do
-          click_icon :edit
-          find(:css, "input[type='number']").set(count_on_hand)
-          click_icon :check
-        end
+      within("tr#spree_variant_#{variant.id}") do
+        find(:css, "input[type='number']").set(count_on_hand)
+        click_icon :check
       end
       expect(page).to have_content('Updated successfully')
     end

--- a/backend/spec/features/admin/products/stock_management_spec.rb
+++ b/backend/spec/features/admin/products/stock_management_spec.rb
@@ -65,7 +65,7 @@ describe "Product Stock", type: :feature do
       expect(page).to have_content('Updated successfully')
     end
 
-    context "with multiple stock locations" do
+    context "with stock locations that don't have stock items for variant yet" do
       before do
         create(:stock_location, name: 'Other location', propagate_all_variants: false)
       end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1462,6 +1462,7 @@ en:
     meta_title: Meta Title
     metadata: Metadata
     minimal_amount: Minimal Amount
+    modify_stock_count: Modify (+/-)
     month: Month
     more: More
     move_stock_between_locations: Move Stock Between Locations

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -803,7 +803,7 @@ en:
     add_stock_management: Add Stock Management
     add_taxon: Add taxon
     add_to_cart: Add To Cart
-    add_to_stock_location: Add to location
+    add_to_stock_location: Select location to propagate stock
     add_variant: Add Variant
     adding_match: Adding match
     additional_item: Additional Item


### PR DESCRIPTION
The current stock management view had some flaws:

1. You have to input absolute values. Something that is not reflecting how people actually set stock in their stores
2. The layout was broken, because the HTML we was using is invalid
3. The "add stock item" validation was broken, because the code was not updated after we are not using select2 anymore.

This view could definitely be improved even more, but for now I am proposing to make these ~small~ changes.

### Update stock

![solidus-stock-items-modify](https://user-images.githubusercontent.com/42868/45940283-80d3b780-bfd8-11e8-8649-e0582e648102.gif)

### Propagate stock to location not fulfilling the variant yet

![solidus-add-stock-item](https://user-images.githubusercontent.com/42868/45944157-6ce48180-bfe9-11e8-9637-dbea811a863b.gif)

Closes #2857 #2028 #2530