### PR TITLE
Chore/make admin more responsive

### DIFF
--- a/backend/app/views/spree/admin/adjustment_reasons/shared/_form.html.erb
+++ b/backend/app/views/spree/admin/adjustment_reasons/shared/_form.html.erb
@@ -1,5 +1,5 @@
 <div data-hook="admin_adjustment_reason_form_fields" class="row">
-  <div class="col-3">
+  <div class="col-12 col-md-6 col-lg-4">
     <%= f.field_container :name do %>
       <%= f.label :name, class: 'required' %><br />
       <%= f.text_field :name, class: 'fullwidth' %>

--- a/backend/app/views/spree/admin/option_types/_form.html.erb
+++ b/backend/app/views/spree/admin/option_types/_form.html.erb
@@ -1,5 +1,5 @@
 <div data-hook="admin_option_type_form_fields" class="align-center row">
-  <div class="col-6">
+  <div class="col-12 col-md-6">
     <%= f.field_container :name do %>
       <%= f.label :name, class: 'required' %><br />
       <%= f.text_field :name, class: "fullwidth" %>
@@ -7,7 +7,7 @@
     <% end %>
   </div>
 
-  <div class="col-6">
+  <div class="col-12 col-md-6">
     <%= f.field_container :presentation do %>
       <%= f.label :presentation, class: 'required' %><br />
       <%= f.text_field :presentation, class: "fullwidth" %>

--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -2,7 +2,7 @@
 
   <div class="row">
 
-    <div class="left col-9" data-hook="admin_product_form_left">
+    <div class="col-12 col-md-8 col-lg-9" data-hook="admin_product_form_left">
       <div data-hook="admin_product_form_name">
         <%= f.field_container :name do %>
           <%= f.label :name, class: 'required' %>
@@ -28,7 +28,7 @@
       </div>
     </div>
 
-    <div class="right col-3" data-hook="admin_product_form_right">
+    <div class="col-12 col-md-4 col-lg-3" data-hook="admin_product_form_right">
       <div data-hook="admin_product_form_price">
         <%= f.field_container :price do %>
           <%= f.label :price, class: Spree::Config.require_master_price ? 'required' : '' %>
@@ -146,7 +146,7 @@
 
   <div class="row">
 
-    <div class="col-9">
+    <div class="col-12 col-md-9">
       <div data-hook="admin_product_form_taxons">
         <%= f.field_container :taxons do %>
           <%= f.label :taxon_ids, plural_resource_name(Spree::Taxon) %><br />

--- a/backend/app/views/spree/admin/promotion_categories/_form.html.erb
+++ b/backend/app/views/spree/admin/promotion_categories/_form.html.erb
@@ -1,7 +1,7 @@
 <%= render partial: 'spree/shared/error_messages', locals: { target: @promotion_category } %>
 
 <div class='row'>
-  <div class='col-4'>
+  <div class='col-12 col-md-6 col-lg-4'>
     <%= f.field_container :name do %>
       <%= f.label :name %>
       <%= f.text_field :name, class: 'fullwidth' %>

--- a/backend/app/views/spree/admin/promotions/_form.html.erb
+++ b/backend/app/views/spree/admin/promotions/_form.html.erb
@@ -3,7 +3,7 @@
   <legend><%= t '.general' %></legend>
 
   <div class="row">
-    <div id="general_fields" class="col-9">
+    <div id="general_fields" class="col-12 col-md-9">
       <div class="row">
         <div class="col-12">
           <%= f.field_container :name do %>
@@ -24,7 +24,7 @@
       </div>
     </div>
 
-    <div id="expiry_fields" class="col-3">
+    <div id="expiry_fields" class="col-12 col-md-3">
       <%= f.field_container :overall_usage_limit do %>
         <%= f.label :usage_limit %><br />
         <%= f.number_field :usage_limit, min: 0, class: 'fullwidth' %><br>

--- a/backend/app/views/spree/admin/promotions/edit.html.erb
+++ b/backend/app/views/spree/admin/promotions/edit.html.erb
@@ -23,11 +23,11 @@
 <% end %>
 
 <div id="promotion-filters" class="row">
-  <div id="rules_container" class="col-6">
+  <div id="rules_container" class="col-12 col-md-6">
     <%= render partial: 'rules' %>
   </div>
 
-  <div id="actions_container" class="col-6">
+  <div id="actions_container" class="col-12 col-md-6">
     <%= render partial: 'actions' %>
   </div>
 </div>

--- a/backend/app/views/spree/admin/properties/_form.html.erb
+++ b/backend/app/views/spree/admin/properties/_form.html.erb
@@ -1,12 +1,12 @@
 <div data-hook="admin_property_form" class="align-center row">
-  <div class="col-6">
+  <div class="col-12 col-md-6">
     <%= f.field_container :name do %>
       <%= f.label :name, class: 'required' %><br />
       <%= f.text_field :name, class: 'fullwidth' %>
       <%= f.error_message_on :name %>
     <% end %>
   </div>
-  <div class="col-6">
+  <div class="col-12 col-md-6">
     <%= f.field_container :presentation do %>
       <%= f.label :presentation, class: 'required' %><br />
       <%= f.text_field :presentation, class: 'fullwidth' %>

--- a/backend/app/views/spree/admin/refund_reasons/shared/_form.html.erb
+++ b/backend/app/views/spree/admin/refund_reasons/shared/_form.html.erb
@@ -1,5 +1,5 @@
 <div data-hook="admin_named_type_form_fields" class="row">
-  <div class="col-3">
+  <div class="col-12 col-md-6 col-lg-4">
     <%= f.field_container :name do %>
       <%= f.label :name, class: 'required' %><br />
       <%= f.text_field :name, class: 'fullwidth' %>

--- a/backend/app/views/spree/admin/shared/named_types/_form.html.erb
+++ b/backend/app/views/spree/admin/shared/named_types/_form.html.erb
@@ -1,5 +1,5 @@
 <div data-hook="admin_named_type_form_fields" class="row">
-  <div class="col-4">
+  <div class="col-12 col-md-6 col-lg-4">
     <%= f.field_container :name do %>
       <%= f.label :name, class: 'required' %><br />
       <%= f.text_field :name, class: 'fullwidth' %>

--- a/backend/app/views/spree/admin/shipping_methods/_form.html.erb
+++ b/backend/app/views/spree/admin/shipping_methods/_form.html.erb
@@ -1,5 +1,5 @@
 <div data-hook="admin_shipping_method_form_fields" class="row">
-  <div data-hook="admin_shipping_method_form_name_field" class="col-5">
+  <div data-hook="admin_shipping_method_form_name_field" class="col-12 col-md-6">
     <%= f.field_container :name do %>
       <%= f.label :name %><br />
       <%= f.text_field :name, class: 'fullwidth' %>
@@ -7,7 +7,7 @@
     <% end %>
   </div>
 
-  <div data-hook="admin_shipping_method_form_internal_name_field" class="col-5">
+  <div data-hook="admin_shipping_method_form_internal_name_field" class="col-12 col-md-6">
     <%= f.field_container :admin_name do %>
       <%= f.label :admin_name %><br />
       <%= f.text_field :admin_name, class: 'fullwidth', label: false  %>
@@ -15,7 +15,7 @@
     <% end %>
   </div>
 
-  <div data-hook="admin_shipping_method_form_code" class="col-5">
+  <div data-hook="admin_shipping_method_form_code" class="col-12 col-md-6">
     <%= f.field_container :code do %>
       <%= f.label :code %><br />
       <%= f.text_field :code, class: 'fullwidth', label: false  %>
@@ -23,7 +23,7 @@
     <% end %>
   </div>
 
-  <div class="col-5">
+  <div class="col-12 col-md-6">
     <%= f.field_container :carrier do %>
       <%= f.label :carrier %><br />
       <%= f.text_field :carrier, class: 'fullwidth', label: false  %>
@@ -31,7 +31,7 @@
     <% end %>
   </div>
 
-  <div class="col-5">
+  <div class="col-12 col-md-6">
     <%= f.field_container :service_level do %>
       <%= f.label :service_level %><br />
       <%= f.text_field :service_level, class: 'fullwidth', label: false  %>
@@ -39,7 +39,7 @@
     <% end %>
   </div>
 
-  <div class="col-5">
+  <div class="col-12 col-md-6">
     <%= f.field_container :store_ids do %>
       <%= f.label :store_ids, plural_resource_name(Spree::Store) %>
       <%= f.collection_select :store_ids, Spree::Store.all, :id, :name, {}, multiple: true, class: "select2 fullwidth" %>
@@ -47,7 +47,7 @@
     <% end %>
   </div>
 
-  <div data-hook="admin_shipping_method_form_tracking_url_field" class="col-10">
+  <div data-hook="admin_shipping_method_form_tracking_url_field" class="col-12">
     <%= f.field_container :tracking_url do %>
       <%= f.label :tracking_url %><br />
       <%= f.text_field :tracking_url, class: 'fullwidth', placeholder: t('spree.tracking_url_placeholder') %>
@@ -65,7 +65,7 @@
 <% end %>
 
 <div class="row">
-  <div class="col-5">
+  <div class="col-12 col-md-6">
     <div data-hook="admin_shipping_method_form_availability_fields">
       <fieldset class="categories no-border-bottom">
         <legend align="center"><%= plural_resource_name(Spree::ShippingCategory) %></legend>
@@ -98,7 +98,7 @@
       </fieldset>
     </div>
   </div>
-  <div class="col-5">
+  <div class="col-12 col-md-6">
     <div data-hook="admin_shipping_method_form_calculator_fields">
       <%= render partial: 'spree/admin/shared/calculator_fields', locals: { f: f } %>
     </div>

--- a/backend/app/views/spree/admin/tax_rates/_form.html.erb
+++ b/backend/app/views/spree/admin/tax_rates/_form.html.erb
@@ -3,7 +3,7 @@
       <legend align="center"><%= t('spree.general_settings') %></legend>
       <div class="row">
 
-        <div class="col-5">
+        <div class="col-12 col-md-6">
           <div data-hook="name" class="field">
             <%= f.label :name %>
             <%= f.text_field :name, class: 'fullwidth' %>
@@ -21,7 +21,7 @@
           </div>
         </div>
 
-        <div class="col-5">
+        <div class="col-12 col-md-6">
           <div data-hook="zone" class="field">
             <%= f.label :zone, Spree::Zone.model_name.human %>
             <%= f.collection_select(:zone_id, @available_zones, :id, :name, {}, {class: 'custom-select fullwidth'}) %>

--- a/backend/app/views/spree/admin/users/_form.html.erb
+++ b/backend/app/views/spree/admin/users/_form.html.erb
@@ -1,5 +1,5 @@
 <div data-hook="admin_user_form_fields" class="row">
-  <div class="col-6">
+  <div class="col-12 col-md-6">
     <%= f.field_container :email do %>
       <%= f.label :email %>
       <% if can?(:update_email, @user) %>
@@ -59,7 +59,7 @@
 
   </div>
 
-  <div data-hook="admin_user_form_password_fields" class="col-6">
+  <div data-hook="admin_user_form_password_fields" class="col-12 col-md-6">
     <%= f.field_container :password do %>
       <%= f.label :password %>
       <%= f.password_field :password, class: 'fullwidth' %>

--- a/backend/app/views/spree/admin/zones/_form.html.erb
+++ b/backend/app/views/spree/admin/zones/_form.html.erb
@@ -1,5 +1,5 @@
 <div class="row js-zones-form">
-  <div class="col-5">
+  <div class="col-12 col-md-6">
 
     <div data-hook="admin_zone_form_fields">
       <fieldset class="no-border-bottom">
@@ -35,7 +35,7 @@
       </fieldset>
     </div>
   </div>
-  <div class="col-5">
+  <div class="col-12 col-md-6">
 
     <%= render partial: 'state_members', locals: { zone_form: zone_form }%>
     <%= render partial: 'country_members', locals: { zone_form: zone_form } %>

--- a/backend/app/views/spree/layouts/admin.html.erb
+++ b/backend/app/views/spree/layouts/admin.html.erb
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="<%= I18n.locale %>">
   <head data-hook="admin_inside_head">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <%= render 'spree/admin/shared/head' %>
   </head>
 


### PR DESCRIPTION
This PR adds Bootstrap breakpoints to most of the forms in the admin area. 

A good next step would be making the sidebar animated on mobile resolutions, but that's a more drastic change.

This probably needs to be squashed if everyone is okay with the change.