### PR TITLE
Fix Money :html deprecation notice

### DIFF
--- a/core/lib/spree/money.rb
+++ b/core/lib/spree/money.rb
@@ -81,9 +81,9 @@ module Spree
     # @param options [Hash] additional formatting options
     # @return [String] the value of this money object formatted according to
     #   its options and any additional options, by default as html.
-    def to_html(options = { html: true })
+    def to_html(options = { html_wrap: true })
       output = format(options)
-      if options[:html]
+      if options[:html_wrap]
         # 1) prevent blank, breaking spaces
         # 2) prevent escaping of HTML character entities
         output = output.sub(" ", "&nbsp;").html_safe


### PR DESCRIPTION
```
[DEPRECATION] `html` is deprecated - use `html_wrap` instead. Please note that `html_wrap` will wrap all parts of currency and if you use `with_currency` option, currency element class changes from `currency` to `money-currency`.
```