### PR TITLE
Update promotion actions documentation

### DIFF
--- a/guides/source/developers/promotions/promotion-actions.html.md
+++ b/guides/source/developers/promotions/promotion-actions.html.md
@@ -82,7 +82,7 @@ You must then register the custom action in an initializer in your
 `config/initializers/` directory:
 
 ```ruby
-Rails.application.config.spree.promotions.actions << MyPromotionAction
+Rails.application.config.spree.promotions.actions << MyNamespace::MyPromotionAction
 ```
 
 [create-item-adjustments]: https://github.com/solidusio/solidus/blob/master/core/app/models/spree/promotion/actions/create_item_adjustments.rb


### PR DESCRIPTION
It is important that the documentation shows
a proper example of namespacing promotion
actions.

This is a valuable addition to the documentation, but unfortunately #2781 has been left open with changes requested for three months.