### PR TITLE
Create a new promotion code inside an existing promotion

### DIFF
--- a/backend/app/controllers/spree/admin/promotion_codes_controller.rb
+++ b/backend/app/controllers/spree/admin/promotion_codes_controller.rb
@@ -23,12 +23,12 @@ module Spree
 
       def new
         @promotion = Spree::Promotion.accessible_by(current_ability, :read).find(params[:promotion_id])
-        @promotion_code = @promotion.promotion_codes.new
+        @promotion_code = @promotion.promotion_codes.build
       end
 
       def create
         @promotion = Spree::Promotion.accessible_by(current_ability, :read).find(params[:promotion_id])
-        @promotion_code = @promotion.promotion_codes.new(value: params[:promotion_code][:value])
+        @promotion_code = @promotion.promotion_codes.build(value: params[:promotion_code][:value])
 
         if @promotion_code.save
           flash[:success] = flash_message_for(@promotion_code, :successfully_created)

--- a/backend/app/controllers/spree/admin/promotion_codes_controller.rb
+++ b/backend/app/controllers/spree/admin/promotion_codes_controller.rb
@@ -7,7 +7,7 @@ module Spree
     class PromotionCodesController < Spree::Admin::ResourceController
       def index
         @promotion = Spree::Promotion.accessible_by(current_ability, :read).find(params[:promotion_id])
-        @promotion_codes = @promotion.promotion_codes
+        @promotion_codes = @promotion.promotion_codes.order(:value)
 
         respond_to do |format|
           format.html do

--- a/backend/app/controllers/spree/admin/promotion_codes_controller.rb
+++ b/backend/app/controllers/spree/admin/promotion_codes_controller.rb
@@ -34,7 +34,7 @@ module Spree
           flash[:success] = flash_message_for(@promotion_code, :successfully_created)
           redirect_to admin_promotion_promotion_codes_url(@promotion)
         else
-          flash.now[:error] = @promotion_code.errors.full_messages.join(', ')
+          flash.now[:error] = @promotion_code.errors.full_messages.to_sentence
           render_after_create_error
         end
       end

--- a/backend/app/controllers/spree/admin/promotion_codes_controller.rb
+++ b/backend/app/controllers/spree/admin/promotion_codes_controller.rb
@@ -20,6 +20,24 @@ module Spree
           end
         end
       end
+
+      def new
+        @promotion = Spree::Promotion.accessible_by(current_ability, :read).find(params[:promotion_id])
+        @promotion_code = @promotion.promotion_codes.new
+      end
+
+      def create
+        @promotion = Spree::Promotion.accessible_by(current_ability, :read).find(params[:promotion_id])
+        @promotion_code = @promotion.promotion_codes.new(value: params[:promotion_code][:value])
+
+        if @promotion_code.save
+          flash[:success] = flash_message_for(@promotion_code, :successfully_created)
+          redirect_to admin_promotion_promotion_codes_url(@promotion)
+        else
+          flash.now[:error] = @promotion_code.errors.full_messages.join(', ')
+          render_after_create_error
+        end
+      end
     end
   end
 end

--- a/backend/app/controllers/spree/admin/promotions_controller.rb
+++ b/backend/app/controllers/spree/admin/promotions_controller.rb
@@ -24,7 +24,7 @@ module Spree
           flash[:success] = t('spree.promotion_successfully_created')
           redirect_to location_after_save
         else
-          flash[:error] = @promotion.errors.full_messages.join(", ")
+          flash[:error] = @promotion.errors.full_messages.to_sentence
           render action: 'new'
         end
       end

--- a/backend/app/views/spree/admin/promotion_code_batches/index.html.erb
+++ b/backend/app/views/spree/admin/promotion_code_batches/index.html.erb
@@ -37,7 +37,7 @@
                 number_of_codes: promotion_code_batch.number_of_codes
               ) %>
               <%= link_to(
-                t('spree.download_promotion_code_list'),
+                t('spree.download_promotion_codes_list'),
                 admin_promotion_promotion_code_batch_download_path(
                   promotion_code_batch_id: promotion_code_batch.id,
                   format: :csv

--- a/backend/app/views/spree/admin/promotion_codes/index.html.erb
+++ b/backend/app/views/spree/admin/promotion_codes/index.html.erb
@@ -8,7 +8,7 @@
       <%= link_to t('spree.create_promotion_code'), new_admin_promotion_promotion_code_path(promotion_id: @promotion.id), class: 'btn btn-primary' %>
     <% end %>
 
-    <%= link_to t('spree.download_promotion_code_list'), admin_promotion_promotion_codes_path(promotion_id: @promotion.id, format: :csv), class: 'btn btn-primary' %>
+    <%= link_to t('spree.download_promotion_codes_list'), admin_promotion_promotion_codes_path(promotion_id: @promotion.id, format: :csv), class: 'btn btn-primary' %>
   </li>
 <% end %>
 

--- a/backend/app/views/spree/admin/promotion_codes/index.html.erb
+++ b/backend/app/views/spree/admin/promotion_codes/index.html.erb
@@ -4,6 +4,10 @@
 
 <% content_for :page_actions do %>
   <li>
+    <% if can?(:create, Spree::PromotionCode) %>
+      <%= link_to t('spree.create_promotion_code'), new_admin_promotion_promotion_code_path(promotion_id: @promotion.id), class: 'btn btn-primary' %>
+    <% end %>
+
     <%= link_to t('spree.download_promotion_code_list'), admin_promotion_promotion_codes_path(promotion_id: @promotion.id, format: :csv), class: 'btn btn-primary' %>
   </li>
 <% end %>

--- a/backend/app/views/spree/admin/promotion_codes/new.html.erb
+++ b/backend/app/views/spree/admin/promotion_codes/new.html.erb
@@ -17,8 +17,8 @@
     <div class="row">
       <div class="col-4">
         <%= f.field_container :value do %>
-        <%= f.label :value, class: 'required' %>
-        <%= f.text_field :value, class: 'fullwidth', required: true %>
+          <%= f.label :value, class: 'required' %>
+          <%= f.text_field :value, class: 'fullwidth', required: true %>
         <% end %>
       </div>
     </div>

--- a/backend/app/views/spree/admin/promotion_codes/new.html.erb
+++ b/backend/app/views/spree/admin/promotion_codes/new.html.erb
@@ -4,9 +4,9 @@
 
 <% content_for :page_actions do %>
   <li>
-    <%= link_to t('spree.view_promotion_code_list'), admin_promotion_promotion_codes_path(promotion_id: @promotion.id), class: 'btn btn-primary' %>
+    <%= link_to t('spree.view_promotion_codes_list'), admin_promotion_promotion_codes_path(promotion_id: @promotion.id), class: 'btn btn-primary' %>
 
-    <%= link_to t('spree.download_promotion_code_list'), admin_promotion_promotion_codes_path(promotion_id: @promotion.id, format: :csv), class: 'btn btn-primary' %>
+    <%= link_to t('spree.download_promotion_codes_list'), admin_promotion_promotion_codes_path(promotion_id: @promotion.id, format: :csv), class: 'btn btn-primary' %>
   </li>
 <% end %>
 

--- a/backend/app/views/spree/admin/promotion_codes/new.html.erb
+++ b/backend/app/views/spree/admin/promotion_codes/new.html.erb
@@ -1,0 +1,31 @@
+<% admin_breadcrumb link_to plural_resource_name(Spree::Promotion), spree.admin_promotions_path %>
+<% admin_breadcrumb link_to(@promotion.name, spree.edit_admin_promotion_path(@promotion)) %>
+<% admin_breadcrumb plural_resource_name(Spree::PromotionCode) %>
+
+<% content_for :page_actions do %>
+  <li>
+    <%= link_to t('spree.view_promotion_code_list'), admin_promotion_promotion_codes_path(promotion_id: @promotion.id), class: 'btn btn-primary' %>
+
+    <%= link_to t('spree.download_promotion_code_list'), admin_promotion_promotion_codes_path(promotion_id: @promotion.id, format: :csv), class: 'btn btn-primary' %>
+  </li>
+<% end %>
+
+<%= form_for [:admin, @promotion, @promotion_code], method: :post do |f| %>
+  <fieldset class="no-border-top">
+    <%= render partial: 'spree/shared/error_messages', locals: { target: @promotion_code } %>
+
+    <div class="row">
+      <div class="col-4">
+        <%= f.field_container :value do %>
+        <%= f.label :value, class: 'required' %>
+        <%= f.text_field :value, class: 'fullwidth', required: true %>
+        <% end %>
+      </div>
+    </div>
+
+    <div class="form-buttons filter-actions actions" data-hook="buttons">
+      <%= button_tag t('spree.actions.create'), class: 'btn btn-primary' %>
+      <%= link_to t('spree.actions.cancel'), admin_promotion_promotion_codes_url(@promotion), class: 'button' %>
+    </div>
+  </fieldset>
+<% end %>

--- a/backend/app/views/spree/admin/promotions/edit.html.erb
+++ b/backend/app/views/spree/admin/promotions/edit.html.erb
@@ -6,9 +6,9 @@
 <% content_for :page_actions do %>
   <li>
     <% if can?(:display, Spree::PromotionCode) %>
-      <%= link_to t('spree.view_promotion_code_list'), admin_promotion_promotion_codes_path(promotion_id: @promotion.id), class: 'btn btn-primary' %>
+      <%= link_to t('spree.view_promotion_codes_list'), admin_promotion_promotion_codes_path(promotion_id: @promotion.id), class: 'btn btn-primary' %>
 
-      <%= link_to t('spree.download_promotion_code_list'), admin_promotion_promotion_codes_path(promotion_id: @promotion.id, format: :csv), class: 'btn btn-primary' %>
+      <%= link_to t('spree.download_promotion_codes_list'), admin_promotion_promotion_codes_path(promotion_id: @promotion.id, format: :csv), class: 'btn btn-primary' %>
     <% end %>
 
     <% if can?(:display, Spree::PromotionCodeBatch) %>

--- a/backend/app/views/spree/admin/promotions/edit.html.erb
+++ b/backend/app/views/spree/admin/promotions/edit.html.erb
@@ -6,6 +6,8 @@
 <% content_for :page_actions do %>
   <li>
     <% if can?(:display, Spree::PromotionCode) %>
+      <%= link_to t('spree.view_promotion_code_list'), admin_promotion_promotion_codes_path(promotion_id: @promotion.id), class: 'btn btn-primary' %>
+
       <%= link_to t('spree.download_promotion_code_list'), admin_promotion_promotion_codes_path(promotion_id: @promotion.id, format: :csv), class: 'btn btn-primary' %>
     <% end %>
 

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -16,7 +16,7 @@ Spree::Core::Engine.routes.draw do
     resources :promotions do
       resources :promotion_rules
       resources :promotion_actions
-      resources :promotion_codes, only: [:index]
+      resources :promotion_codes, only: [:index, :new, :create]
       resources :promotion_code_batches, only: [:index, :new, :create] do
         get '/download', to: "promotion_code_batches#download", defaults: { format: "csv" }
       end

--- a/backend/spec/controllers/spree/admin/promotion_codes_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/promotion_codes_controller_spec.rb
@@ -19,8 +19,14 @@ describe Spree::Admin::PromotionCodesController do
   end
 
   it "can create a new code" do
-    post :create, params: { value: "new_code" }
-    expect(response).to be_successful
+    post :create, params: { promotion_id: promotion.id, promotion_code: { value: "new_code" } }
+    expect(response).to redirect_to(spree.admin_promotion_promotion_codes_path(promotion))
     expect(Spree::PromotionCode.where(promotion: promotion).count).to eql(4)
+  end
+
+  it "cannot create an existing code" do
+    post :create, params: { promotion_id: promotion.id, promotion_code: { value: code1.value } }
+    expect(flash[:error]).not_to be_nil
+    expect(Spree::PromotionCode.where(promotion: promotion).count).to eql(3)
   end
 end

--- a/backend/spec/controllers/spree/admin/promotion_codes_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/promotion_codes_controller_spec.rb
@@ -11,7 +11,7 @@ describe Spree::Admin::PromotionCodesController do
   let!(:code2) { create(:promotion_code, promotion: promotion) }
   let!(:code3) { create(:promotion_code, promotion: promotion) }
 
-  it "can create a promotion rule of a valid type" do
+  it "can create a CSV file with all promotion codes" do
     get :index, params: { promotion_id: promotion.id, format: 'csv' }
     expect(response).to be_successful
     parsed = CSV.parse(response.body, headers: true)

--- a/backend/spec/controllers/spree/admin/promotion_codes_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/promotion_codes_controller_spec.rb
@@ -17,4 +17,10 @@ describe Spree::Admin::PromotionCodesController do
     parsed = CSV.parse(response.body, headers: true)
     expect(parsed.entries.map(&:to_h)).to eq([{ "Code" => code1.value }, { "Code" => code2.value }, { "Code" => code3.value }])
   end
+
+  it "can create a new code" do
+    post :create, params: { value: "new_code" }
+    expect(response).to be_successful
+    expect(Spree::PromotionCode.where(promotion: promotion).count).to eql(4)
+  end
 end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -2094,6 +2094,7 @@ en:
     variant_to_be_received: Variant to be received
     variants: Variants
     version: Version
+    view_promotion_code_list: View Code List
     void: Void
     weight: Weight
     what_is_a_cvv: What is a (CVV) Credit Card Code?

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1146,6 +1146,7 @@ en:
     customer_returns: Customer Returns
     create: Create
     create_a_new_account: Create a new account
+    create_promotion_code: Create Promotion Code
     create_reimbursement: Create reimbursement
     create_one: Create One.
     created_at: Created At

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1146,7 +1146,7 @@ en:
     customer_returns: Customer Returns
     create: Create
     create_a_new_account: Create a new account
-    create_promotion_code: Create Promotion Code
+    create_promotion_code: Create promotion code
     create_reimbursement: Create reimbursement
     create_one: Create One.
     created_at: Created At
@@ -1201,7 +1201,7 @@ en:
     discount_rules: Discount rules
     dismiss_banner: No. Thanks! I'm not interested, do not display this message again
     display: Display
-    download_promotion_code_list: Download Code List
+    download_promotion_codes_list: Download codes list
     edit: Edit
     editing_country: Editing Country
     editing_adjustment_reason: Editing Adjustment Reason
@@ -2095,7 +2095,7 @@ en:
     variant_to_be_received: Variant to be received
     variants: Variants
     version: Version
-    view_promotion_code_list: View Code List
+    view_promotion_codes_list: View codes list
     void: Void
     weight: Weight
     what_is_a_cvv: What is a (CVV) Credit Card Code?

--- a/core/lib/spree/permission_sets/promotion_management.rb
+++ b/core/lib/spree/permission_sets/promotion_management.rb
@@ -8,6 +8,7 @@ module Spree
         can :manage, Spree::PromotionRule
         can :manage, Spree::PromotionAction
         can :manage, Spree::PromotionCategory
+        can :manage, Spree::PromotionCode
       end
     end
   end

--- a/core/spec/models/spree/permission_sets/promotion_management_spec.rb
+++ b/core/spec/models/spree/permission_sets/promotion_management_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Spree::PermissionSets::PromotionManagement do
     it { is_expected.to be_able_to(:manage, Spree::PromotionRule) }
     it { is_expected.to be_able_to(:manage, Spree::PromotionAction) }
     it { is_expected.to be_able_to(:manage, Spree::PromotionCategory) }
+    it { is_expected.to be_able_to(:manage, Spree::PromotionCode) }
   end
 
   context "when not activated" do
@@ -23,5 +24,6 @@ RSpec.describe Spree::PermissionSets::PromotionManagement do
     it { is_expected.not_to be_able_to(:manage, Spree::PromotionRule) }
     it { is_expected.not_to be_able_to(:manage, Spree::PromotionAction) }
     it { is_expected.not_to be_able_to(:manage, Spree::PromotionCategory) }
+    it { is_expected.not_to be_able_to(:manage, Spree::PromotionCode) }
   end
 end


### PR DESCRIPTION
Hi folks,

@epicery we use a lot the promotion system, more particularly PromotionCode instead of PromotionCodeBatch.

Maybe we overlooked something inside the PromotionCodeBatch, but we really don't want our PromotionCode to have a suffix when we're adding one on an existing Promotion

First, we were manually creating PromotionCode objects inside an existing Promotion using the console, but it kind of suc**
Lately, we've developed the few missing parts that enable a backend user to autonomously create these new PromotionCode.

I though it might interest other people, so I made it more generic and made this PR.
Pls, let me know what you think about it.
