### PR TITLE
Add a Master SKU field to the products form

### DIFF
--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -109,6 +109,7 @@
             <% end %>
           </div>
         </div>
+
         <div id="shipping_specs" class="row">
           <% [:height, :width, :depth, :weight].each_with_index do |field, index| %>
             <div id="shipping_specs_<%= field %>_field" class="col-6">

--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -82,6 +82,13 @@
         <% end %>
       </div>
 
+      <div data-hook="admin_product_form_sku">
+        <%= f.field_container :sku do %>
+          <%= f.label :sku, t('spree.master_sku') %>
+          <%= f.text_field :sku, size: 16 %>
+        <% end %>
+      </div>
+
       <% if @product.has_variants? %>
         <div data-hook="admin_product_form_multiple_variants">
           <%= f.label :skus, t('spree.skus') %>
@@ -102,14 +109,6 @@
             <% end %>
           </div>
         </div>
-      <% else %>
-        <div data-hook="admin_product_form_sku">
-          <%= f.field_container :sku do %>
-            <%= f.label :sku, Spree::Variant.human_attribute_name(:sku) %>
-            <%= f.text_field :sku, size: 16 %>
-          <% end %>
-        </div>
-
         <div id="shipping_specs" class="row">
           <% [:height, :width, :depth, :weight].each_with_index do |field, index| %>
             <div id="shipping_specs_<%= field %>_field" class="col-6">

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1450,6 +1450,7 @@ en:
     manual_intervention_required: Manual intervention required
     manage_variants: Manage Variants
     master_price: Master Price
+    master_sku: Master SKU
     master_variant: Master Variant
     match_choices:
       all: All


### PR DESCRIPTION
I have come across a use case in which the product's sku attribute needs to be
editable by the admin even in the event that the product has variants. This
commit adds a user interface element for a Master SKU which updates the
Spree::Product's sku attribute. It is visible regardless of the number of
variants, which satisfies my use case.

Solves #2874 

A product with variants and a product SKU:
![image](https://user-images.githubusercontent.com/11466782/46145166-e2886180-c224-11e8-8b4e-75020377345a.png)

A product with variants and no product SKU:
![image](https://user-images.githubusercontent.com/11466782/46144863-db148880-c223-11e8-941d-e7f2ea4c54e1.png)

A product with no variants and a product SKU:
![image](https://user-images.githubusercontent.com/11466782/46145135-cb497400-c224-11e8-9173-4d8af39ab927.png)
