### PR TITLE
Round calculator values based on order currency

### DIFF
--- a/core/app/models/spree/calculator/flat_percent_item_total.rb
+++ b/core/app/models/spree/calculator/flat_percent_item_total.rb
@@ -7,7 +7,10 @@ module Spree
     preference :flat_percent, :decimal, default: 0
 
     def compute(object)
-      computed_amount = (object.amount * preferred_flat_percent / 100).round(2)
+      order = object.is_a?(Order) ? object : object.order
+      preferred_currency = order.currency
+      currency_exponent = ::Money::Currency.find(preferred_currency).exponent
+      computed_amount = (object.amount * preferred_flat_percent / 100).round(currency_exponent)
 
       # We don't want to cause the promotion adjustments to push the order into a negative total.
       if computed_amount > object.amount

--- a/core/app/models/spree/calculator/shipping/flat_percent_item_total.rb
+++ b/core/app/models/spree/calculator/shipping/flat_percent_item_total.rb
@@ -9,12 +9,14 @@ module Spree
       preference :flat_percent, :decimal, default: 0
 
       def compute_package(package)
-        compute_from_price(total(package.contents))
+        value = compute_from_price(total(package.contents))
+        preferred_currency = package.order.currency
+        currency_exponent = ::Money::Currency.find(preferred_currency).exponent
+        value.round(currency_exponent)
       end
 
       def compute_from_price(price)
-        value = price * BigDecimal(preferred_flat_percent.to_s) / 100.0
-        value.round(2)
+        price * BigDecimal(preferred_flat_percent.to_s) / 100.0
       end
     end
   end

--- a/core/app/models/spree/calculator/tiered_percent.rb
+++ b/core/app/models/spree/calculator/tiered_percent.rb
@@ -31,7 +31,8 @@ module Spree
       end
 
       if preferred_currency.casecmp(order.currency).zero?
-        (object.amount * (percent || preferred_base_percent) / 100).round(2)
+        currency_exponent = ::Money::Currency.find(preferred_currency).exponent
+        (object.amount * (percent || preferred_base_percent) / 100).round(currency_exponent)
       else
         0
       end

--- a/core/spec/models/spree/calculator/flat_percent_item_total_spec.rb
+++ b/core/spec/models/spree/calculator/flat_percent_item_total_spec.rb
@@ -5,7 +5,7 @@ require 'shared_examples/calculator_shared_examples'
 
 RSpec.describe Spree::Calculator::FlatPercentItemTotal, type: :model do
   let(:calculator) { Spree::Calculator::FlatPercentItemTotal.new }
-  let(:line_item) { mock_model Spree::LineItem }
+  let(:line_item) { create(:line_item) }
 
   it_behaves_like 'a calculator with a description'
 
@@ -18,6 +18,15 @@ RSpec.describe Spree::Calculator::FlatPercentItemTotal, type: :model do
 
       allow(line_item).to receive_messages amount: 31.00
       expect(calculator.compute(line_item)).to eq 3.10
+    end
+
+    it "should round result based on order currency" do
+      line_item.order.currency = 'JPY'
+      allow(line_item).to receive_messages amount: 31.08
+      expect(calculator.compute(line_item)).to eq 3
+
+      allow(line_item).to receive_messages amount: 31.00
+      expect(calculator.compute(line_item)).to eq 3
     end
 
     it 'returns object.amount if computed amount is greater' do

--- a/core/spec/models/spree/calculator/shipping/flat_percent_item_total_spec.rb
+++ b/core/spec/models/spree/calculator/shipping/flat_percent_item_total_spec.rb
@@ -31,6 +31,11 @@ module Spree
         expect(subject.compute(package)).to eq(4.04)
       end
 
+      it "should round result based on order currency" do
+        package.order.currency = 'JPY'
+        expect(subject.compute(package)).to eq(4)
+      end
+
       it "should return a bigdecimal" do
         expect(subject.compute(package)).to be_a(BigDecimal)
       end

--- a/core/spec/models/spree/calculator/tiered_percent_spec.rb
+++ b/core/spec/models/spree/calculator/tiered_percent_spec.rb
@@ -135,9 +135,15 @@ RSpec.describe Spree::Calculator::TieredPercent, type: :model do
       end
 
       context "when the order's currency does not match the calculator" do
-        let(:preferred_currency) { "CAD" }
+        let(:preferred_currency) { "JPY" }
         let(:line_item_count) { 1 }
+        let(:price) { 15 }
         it { is_expected.to eq 0 }
+
+        it "rounds based on currency" do
+          allow(order).to receive_messages currency: "JPY"
+          expect(subject).to eq(2)
+        end
       end
     end
 


### PR DESCRIPTION
Fixes #1957 by getting the exponent of the desired currency from `Money::Currency`