### PR TITLE
Move to sassc-rails

### DIFF
--- a/backend/lib/spree/backend.rb
+++ b/backend/lib/spree/backend.rb
@@ -3,7 +3,7 @@
 require 'rails/all'
 require 'jquery-rails'
 require 'coffee-rails'
-require 'sass-rails'
+require 'sassc-rails'
 require 'handlebars_assets'
 require 'font-awesome-rails'
 require 'autoprefixer-rails'

--- a/backend/solidus_backend.gemspec
+++ b/backend/solidus_backend.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'jbuilder', '~> 2.6'
   s.add_dependency 'jquery-rails'
   s.add_dependency 'kaminari', '~> 1.1'
-  s.add_dependency 'sass-rails'
+  s.add_dependency 'sassc-rails'
   s.add_dependency 'sass', '>= 3.5.2'
 
   s.add_dependency 'autoprefixer-rails', '~> 7.1'

--- a/frontend/lib/spree/frontend.rb
+++ b/frontend/lib/spree/frontend.rb
@@ -3,7 +3,7 @@
 require 'rails/all'
 require 'jquery-rails'
 require 'canonical-rails'
-require 'sass-rails'
+require 'sassc-rails'
 require 'font-awesome-rails'
 require 'responders'
 require 'kaminari'


### PR DESCRIPTION
Ruby Sass is deprecated and will be unmaintained. This commit
moves Solidus to the recommended sassc-rails gem.

Refs #2882 