### PR TITLE
Use ActiveRecord relation for Spree::Shipment#line_items

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -13,6 +13,7 @@ module Spree
     has_many :shipping_methods, through: :shipping_rates
     has_many :state_changes, as: :stateful
     has_many :cartons, -> { distinct }, through: :inventory_units
+    has_many :line_items, -> { distinct }, through: :inventory_units
 
     before_validation :set_cost_zero_when_nil
 
@@ -186,10 +187,6 @@ module Spree
 
     def item_cost
       line_items.map(&:total).sum
-    end
-
-    def line_items
-      inventory_units.includes(:line_item).map(&:line_item).uniq
     end
 
     def ready_or_pending?


### PR DESCRIPTION
The original plain ruby instance method has been replaced by an ActiveRecord
`has_many` relation. This pure SQL solution should improve a bit performances
and allow to add further relations using `has_many ... through: line_items`.