### PR TITLE
Fixes deprecation warning to use successful? rather than success?

### DIFF
--- a/api/spec/requests/spree/api/shipments_controller_spec.rb
+++ b/api/spec/requests/spree/api/shipments_controller_spec.rb
@@ -262,7 +262,7 @@ describe Spree::Api::ShipmentsController, type: :request do
 
     it "returns success" do
       subject
-      expect(response).to be_success
+      expect(response).to be_successful
     end
 
     it "returns rates available to user" do


### PR DESCRIPTION

```
DEPRECATION WARNING: The success? predicate is deprecated and will be removed in Rails 6.0. Please use successful? as provided by Rack::Response::Helpers. (called from block (3 levels) in <top (required)> at solidus/api/spec/requests/spree/api/shipments_controller_spec.rb:265)
```