### PR TITLE
Must hide tooltips before re-rendering or they'll persist after eleme…

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/admin.js
+++ b/backend/app/assets/javascripts/spree/backend/admin.js
@@ -87,6 +87,7 @@ Spree.ready(function(){
         },
         dataType: 'script',
         success: function(response) {
+          el.tooltip('dispose')
           el.parents("tr").fadeOut('hide', function() {
             $(this).remove();
           });
@@ -101,6 +102,7 @@ Spree.ready(function(){
 
   $('body').on('click', 'a.spree_remove_fields', function() {
     var el = $(this);
+    el.tooltip('dispose')
     el.prev("input[type=hidden]").val("1");
     el.closest(".fields").hide();
     if (el.prop("href").substr(-1) == '#') {

--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -138,6 +138,7 @@ var ShipmentSplitItemView = Backbone.View.extend({
 
   cancelItemSplit: function(e){
     e.preventDefault();
+    $(e.target).tooltip('dispose')
 
     this.shipmentItemView.removeSplit();
     this.remove();

--- a/backend/app/assets/javascripts/spree/backend/views/cart/line_item_row.js
+++ b/backend/app/assets/javascripts/spree/backend/views/cart/line_item_row.js
@@ -18,12 +18,14 @@ Spree.Views.Cart.LineItemRow = Backbone.View.extend({
 
   onEdit: function(e) {
     e.preventDefault()
+    $(e.target).tooltip('dispose')
     this.editing = true
     this.render()
   },
 
   onCancel: function(e) {
     e.preventDefault();
+    $(e.target).tooltip('dispose')
     if (this.model.isNew()) {
       this.remove();
       this.model.destroy();
@@ -42,6 +44,7 @@ Spree.Views.Cart.LineItemRow = Backbone.View.extend({
 
   onSave: function(e) {
     e.preventDefault()
+    $(e.target).tooltip('dispose')
     if(!this.validate()) {
       return;
     }
@@ -64,6 +67,7 @@ Spree.Views.Cart.LineItemRow = Backbone.View.extend({
 
   onDelete: function(e) {
     e.preventDefault()
+    $(e.target).tooltip('dispose')
     if(!confirm(Spree.translations.are_you_sure_delete)) {
       return;
     }

--- a/backend/app/assets/javascripts/spree/backend/views/order/shipment_tracking.js
+++ b/backend/app/assets/javascripts/spree/backend/views/order/shipment_tracking.js
@@ -19,6 +19,7 @@ Spree.Views.Order.ShipmentTracking = Backbone.View.extend({
   },
 
   onSave: function(event) {
+    $(event.target).tooltip('dispose')
     this.editing = false;
     this.model.save({
       tracking: this.$('input[type="text"]').val()
@@ -31,6 +32,7 @@ Spree.Views.Order.ShipmentTracking = Backbone.View.extend({
   },
 
   onCancel: function(event) {
+    $(event.target).tooltip('dispose')
     this.editing = false;
     this.render();
   },

--- a/backend/app/assets/javascripts/spree/backend/views/order/shipping_method.js
+++ b/backend/app/assets/javascripts/spree/backend/views/order/shipping_method.js
@@ -23,6 +23,7 @@ Spree.Views.Order.ShippingMethod = Backbone.View.extend({
   },
 
   onSave: function(event) {
+    $(event.target).tooltip('dispose')
     this.editing = false;
     this.shippingMethodId = this.$('select').val();
     this.shippingRates = new Backbone.Collection();
@@ -37,6 +38,7 @@ Spree.Views.Order.ShippingMethod = Backbone.View.extend({
   },
 
   onCancel: function(event) {
+    $(event.target).tooltip('dispose')
     this.editing = false;
     this.shippingRates = new Backbone.Collection();
     this.render();

--- a/backend/app/assets/javascripts/spree/backend/views/payment/payment_row.js
+++ b/backend/app/assets/javascripts/spree/backend/views/payment/payment_row.js
@@ -8,11 +8,13 @@ Spree.Views.Payment.PaymentRow = Backbone.View.extend({
 
   onEdit: function(e) {
     e.preventDefault();
+    $(e.target).tooltip('dispose')
     this.$el.addClass("editing");
   },
 
   onCancel: function(e) {
     e.preventDefault();
+    $(e.target).tooltip('dispose')
     this.$el.removeClass("editing");
   },
 
@@ -29,6 +31,7 @@ Spree.Views.Payment.PaymentRow = Backbone.View.extend({
       }
     };
     e.preventDefault();
+    $(e.target).tooltip('dispose')
     this.model.save({
       amount: amount
     }, options);


### PR DESCRIPTION
…nts removed from DOM.

refs #2864 

The issue with tooltips persisting on line item form is caused by the original tooltip element being removed from the DOM when the templates re-rendered after clicking an action.  The recommended workaround for this is to first hide your tooltip before removing the elements from the DOM: https://github.com/twbs/bootstrap/issues/2298

I haven't browsed around looking for this issue in other spots, but it wouldn't surprise me if there are other instances of this to fix. Would like to get feedback on this solution before checking for other places to fix.