### PR TITLE
Revert tooltip observer change as it does not work properly.

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/components/tooltips.js
+++ b/backend/app/assets/javascripts/spree/backend/components/tooltips.js
@@ -3,26 +3,30 @@ Spree.ready(function(){
 
   $('body').tooltip({selector: '.with-tip'});
 
+  /*
+   * Poll tooltips to hide them if they are no longer being hovered.
+   *
+   * This is necessary to fix tooltips hanging around after their attached
+   * element has been removed from the DOM (and will therefore receive no
+   * mouseleave event). This may be unnecessary in a future version of
+   * bootstrap, which intends to solve this using MutationObserver.
+   */
+  var removeDesyncedTooltip = function(tooltip) {
+    var interval = setInterval(function(){
+      if(!$(tooltip.element).is(":hover")) {
+        tooltip.hide();
+        clearInterval(interval);
+      }
+    }, 200);
+    $(tooltip.element).on('hidden.bs.tooltip', function(){
+      clearInterval(interval);
+    });
+  };
+
   $('body').on('inserted.bs.tooltip', function(e){
     var $target = $(e.target);
     var tooltip = $target.data('bs.tooltip');
-
-    /*
-     * Observe target changes to understand if we need to remove tooltips.
-     *
-     * This is necessary to fix tooltips hanging around after their attached
-     * element has been removed from the DOM (and will therefore receive no
-     * mouseleave event).
-     */
-    var observer = new MutationObserver(function(mutations) {
-      // disconnect itself when content is changed, a new observer will
-      // be attached to this element when the new tooltip is created.
-      this.disconnect();
-
-      tooltip.hide();
-    });
-    observer.observe($target.get(0), { attributes: true });
-
+    removeDesyncedTooltip(tooltip);
     var $tooltip = $("#" + $target.attr("aria-describedby"));
     $tooltip.addClass("action-" + $target.data("action"));
   });

--- a/backend/app/assets/javascripts/spree/backend/components/tooltips.js
+++ b/backend/app/assets/javascripts/spree/backend/components/tooltips.js
@@ -14,7 +14,7 @@ Spree.ready(function(){
   var removeDesyncedTooltip = function(tooltip) {
     var interval = setInterval(function(){
       if(!$(tooltip.element).is(":hover")) {
-        tooltip.hide();
+        tooltip.dispose();
         clearInterval(interval);
       }
     }, 200);


### PR DESCRIPTION
fixes #2864 

The change introduced by https://github.com/solidusio/solidus/pull/2421/files caused a regression in tooltips where they don't go away when the element is removed from the DOM. It appears the MutationObserver is meant for detecting child elements being removed from the target element, and it does not actually observe the target element itself being removed.
https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver
https://developers.google.com/web/updates/2012/02/Detect-DOM-changes-with-Mutation-Observers
https://stackoverflow.com/questions/28598340/mutation-observer-fails-to-detect-elements-dom-removal

So we can either revert the change to using MutationObserver or we would need to change it to observe a different target element, such as, the parent element of our actual target. I gave a go at wrapping the the target with a parent node, and observing the parent node and I couldn't easily get it to work either.  So reverting seems easiest solution for now, and I changed from `tooltip.hide()` to `tooltip.dispose()` to unbind events as well.