### PR TITLE
Fix RubyMoney/Money i18n deprecation warning

### DIFF
--- a/core/config/initializers/money.rb
+++ b/core/config/initializers/money.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+Money.locale_backend = :i18n


### PR DESCRIPTION
This PR fixes the warning message coming from RubyMoney/money discussed in https://github.com/RubyMoney/money/issues/816

```
[DEPRECATION] `use_i18n` is deprecated - use `Money.locale_backend = :i18n` instead
```

It might be worth waiting to see if this is fixed in the money gem before we merge this PR.