### PR TITLE
Add a Netlify configuration for deploying guides site

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,7 @@
+[Settings]
+  ID = "Solidus_Guides"
+
+[build]
+  base    = "guides/"
+  publish = "guides/build/"
+  command = "middleman build"


### PR DESCRIPTION
Netlify has a free team plan for open source sites.

Deployment is easy and automated, so that every push to the `master` branch will update the guides site.