### PR TITLE
Fix reference to logo on heroku template

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "name": "Solidus Sandbox",
   "description": "A demonstration store using Solidus with some test data.",
   "repository": "https://github.com/solidusio/solidus",
-  "logo": "http://solidus.io/favicon.ico",
+  "logo": "https://solidus.io/assets/images/favicon/favicon.ico",
   "keywords": [
     "solidus",
     "demo"


### PR DESCRIPTION
When you attempt to create a solidus app using the one click installer the logo is missing

![image](https://user-images.githubusercontent.com/4173376/46547803-b909ae80-c892-11e8-945b-ce2b06cc4ec0.png)

I updated the logo path to use the one you have on your website, I guess thats the one you were using before. 