### PR TITLE
Improve trustworthiness of a content items price.

### DIFF
--- a/core/app/models/spree/stock/content_item.rb
+++ b/core/app/models/spree/stock/content_item.rb
@@ -31,7 +31,7 @@ module Spree
       end
 
       def price
-        variant.price
+        line_item.price
       end
 
       def amount

--- a/core/spec/models/spree/calculator/shipping/flat_percent_item_total_spec.rb
+++ b/core/spec/models/spree/calculator/shipping/flat_percent_item_total_spec.rb
@@ -6,16 +6,23 @@ require 'shared_examples/calculator_shared_examples'
 module Spree
   module Calculator::Shipping
     RSpec.describe FlatPercentItemTotal, type: :model do
-      let(:variant1) { build(:variant, price: 10.11) }
-      let(:variant2) { build(:variant, price: 20.2222) }
-
       it_behaves_like 'a calculator with a description'
 
-      let(:line_item1) { build(:line_item, variant: variant1) }
-      let(:line_item2) { build(:line_item, variant: variant2) }
+      let(:line_item1) { build(:line_item, price: 10.11) }
+      let(:line_item2) { build(:line_item, price: 20.2222) }
+
+      let(:inventory_unit1) { build(:inventory_unit, line_item: line_item1) }
+      let(:inventory_unit2) { build(:inventory_unit, line_item: line_item2) }
 
       let(:package) do
-        build(:stock_package, variants_contents: { variant1 => 2, variant2 => 1 })
+        build(
+          :stock_package,
+          contents: [
+            Spree::Stock::ContentItem.new(inventory_unit1),
+            Spree::Stock::ContentItem.new(inventory_unit1),
+            Spree::Stock::ContentItem.new(inventory_unit2),
+          ]
+        )
       end
 
       subject { FlatPercentItemTotal.new(preferred_flat_percent: 10) }

--- a/core/spec/models/spree/shipping_calculator_spec.rb
+++ b/core/spec/models/spree/shipping_calculator_spec.rb
@@ -4,11 +4,21 @@ require 'rails_helper'
 
 module Spree
   RSpec.describe ShippingCalculator, type: :model do
-    let(:variant1) { build(:variant, price: 10) }
-    let(:variant2) { build(:variant, price: 20) }
+    let(:line_item1) { build(:line_item, price: 10) }
+    let(:line_item2) { build(:line_item, price: 20) }
+
+    let(:inventory_unit1) { build(:inventory_unit, line_item: line_item1) }
+    let(:inventory_unit2) { build(:inventory_unit, line_item: line_item2) }
 
     let(:package) do
-      build(:stock_package, variants_contents: { variant1 => 2, variant2 => 1 })
+      build(
+        :stock_package,
+        contents: [
+          Spree::Stock::ContentItem.new(inventory_unit1),
+          Spree::Stock::ContentItem.new(inventory_unit1),
+          Spree::Stock::ContentItem.new(inventory_unit2)
+        ]
+      )
     end
 
     subject { ShippingCalculator.new }

--- a/core/spec/models/spree/stock/content_item_spec.rb
+++ b/core/spec/models/spree/stock/content_item_spec.rb
@@ -53,12 +53,12 @@ module Spree
 
       describe '#price' do
         subject { instance.price }
-        it { is_expected.to eq(19.99.to_d) }
+        it { is_expected.to eq(10.to_d) }
       end
 
       describe '#amount' do
         subject { instance.amount }
-        it { is_expected.to eq(19.99.to_d) }
+        it { is_expected.to eq(10.to_d) }
       end
 
       describe '#quantity' do

--- a/core/spec/models/spree/stock/content_item_spec.rb
+++ b/core/spec/models/spree/stock/content_item_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module Spree
+  module Stock
+    RSpec.describe ContentItem, type: :model do
+      let(:instance) { ContentItem.new(inventory_unit, state) }
+      let(:inventory_unit) { build(:inventory_unit) }
+      let(:state) { :on_hand }
+
+      describe '#variant' do
+        subject { instance.variant }
+        it { is_expected.to eq(inventory_unit.variant) }
+      end
+
+      describe '#weight' do
+        subject { instance.weight }
+        it { is_expected.to eq(0.to_d) }
+      end
+
+      describe '#line_item' do
+        subject { instance.line_item }
+        it { is_expected.to eq(inventory_unit.line_item) }
+      end
+
+      describe '#on_hand?' do
+        subject { instance.on_hand? }
+
+        context 'the state is on hand' do
+          it { is_expected.to eq(true) }
+        end
+
+        context 'the state is not on hand' do
+          let(:state) { 'foo' }
+          it { is_expected.to eq(false) }
+        end
+      end
+
+      describe '#backordered?' do
+        subject { instance.backordered? }
+
+        context 'the state is not backordered' do
+          let(:state) { 'foo' }
+          it { is_expected.to eq(false) }
+        end
+
+        context 'the state is backordered' do
+          let(:state) { :backordered }
+          it { is_expected.to eq(true) }
+        end
+      end
+
+      describe '#price' do
+        subject { instance.price }
+        it { is_expected.to eq(19.99.to_d) }
+      end
+
+      describe '#amount' do
+        subject { instance.amount }
+        it { is_expected.to eq(19.99.to_d) }
+      end
+
+      describe '#quantity' do
+        subject { instance.quantity }
+        it { is_expected.to eq(1) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
A line items price is more trustworthy than a variants price in regards
to what a customer is paying for something.

In the case that there are applications that charge different prices for variants based on criteria then using a line items price is a more accurate representation and a better source of truth as to what someone will pay for an item.

For shipping calculators that depend on how much something is costs this is an improvement.