### PR TITLE
symbol can't be argument for :count in east slavic locales

### DIFF
--- a/backend/app/views/spree/admin/promotion_categories/index.html.erb
+++ b/backend/app/views/spree/admin/promotion_categories/index.html.erb
@@ -1,5 +1,5 @@
 <% admin_breadcrumb(link_to plural_resource_name(Spree::Promotion), spree.admin_promotions_path) %>
-<% admin_breadcrumb(Spree::PromotionCategory.model_name.human(count: :many)) %>
+<% admin_breadcrumb(plural_resource_name(Spree::PromotionCategory)) %>
 
 
 <% content_for :page_actions do %>

--- a/backend/spec/features/admin/users_spec.rb
+++ b/backend/spec/features/admin/users_spec.rb
@@ -37,7 +37,7 @@ describe 'Users', type: :feature do
     end
 
     it 'can go back to the users list' do
-      expect(page).to have_link Spree::LegacyUser.model_name.human(count: :other), href: spree.admin_users_path
+      expect(page).to have_link Spree::LegacyUser.model_name.human(count: Spree::I18N_GENERIC_PLURAL), href: spree.admin_users_path
     end
 
     it 'can navigate to the account page' do


### PR DESCRIPTION
Hi guys!

Symbol can't be argument for :count in east slavic locales, east slavic pluralization rule requires number because it uses modulo division, [https://github.com/svenfuchs/rails-i18n/blob/master/lib/rails_i18n/common_pluralizations/east_slavic.rb](https://github.com/svenfuchs/rails-i18n/blob/master/lib/rails_i18n/common_pluralizations/east_slavic.rb)
