### PR TITLE
fix translations keys

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/views/order/summary.js
+++ b/backend/app/assets/javascripts/spree/backend/views/order/summary.js
@@ -20,10 +20,10 @@ Spree.Views.Order.Summary = Backbone.View.extend({
     this.$('dd.order-additional_tax_total').text(this.model.get("display_additional_tax_total"))
 
     this.$('.order-shipment_state').toggleClass("hidden", !this.model.get("completed_at"))
-    this.$('dd.order-shipment_state').html(this.renderState('shipment_state', this.model.get("shipment_state")))
+    this.$('dd.order-shipment_state').html(this.renderState('shipment_states', this.model.get("shipment_state")))
 
     this.$('.order-payment_state').toggleClass("hidden", !this.model.get("completed_at"))
-    this.$('dd.order-payment_state').html(this.renderState('payment_state', this.model.get("payment_state")))
+    this.$('dd.order-payment_state').html(this.renderState('payment_states', this.model.get("payment_state")))
   },
 
   renderState: function(translation_key, value) {


### PR DESCRIPTION
Hi guys,

In admin, at order page in cart tab summary renders without translations for shipment and payment states.
I fixed it
![2018-10-07 21 49 35](https://user-images.githubusercontent.com/3278464/46585555-195b4480-ca7b-11e8-89ae-a2e5100674aa.png)
.