### PR TITLE
Add padding to the order summary

### DIFF
--- a/frontend/app/assets/stylesheets/spree/frontend/screen.css.scss
+++ b/frontend/app/assets/stylesheets/spree/frontend/screen.css.scss
@@ -1092,6 +1092,9 @@ div[data-hook="inside_cart_form"] {
 /*--------------------------------------*/
 #order_summary {
   margin-top: 0;
+  h1 {
+    padding-left: 10px;
+  }
 }
 #order {
   p[data-hook="links"] {


### PR DESCRIPTION
This change aligns the order summary heading to the subheadings

Before
<img width="873" alt="screen shot 2018-10-07 at 5 07 54 pm" src="https://user-images.githubusercontent.com/11466782/46587571-05501c80-ca54-11e8-9d27-5dc43762fb33.png">

After
<img width="466" alt="screen shot 2018-10-07 at 5 08 30 pm" src="https://user-images.githubusercontent.com/11466782/46587572-0c772a80-ca54-11e8-8138-08f8ab5789f1.png">

