### PR TITLE
DRY Spree::OrderContents

### DIFF
--- a/core/app/models/spree/order_contents.rb
+++ b/core/app/models/spree/order_contents.rb
@@ -79,12 +79,8 @@ module Spree
       line_item
     end
 
-    def order_updater
-      @updater ||= Spree::OrderUpdater.new(order)
-    end
-
     def reload_totals
-      order_updater.update
+      @order.recalculate
     end
 
     def add_to_line_item(variant, quantity, options = {})


### PR DESCRIPTION
Some duplicated code has been removed from `Spree::OrderContents` and replaced
by a direct call to `Spree::Order#recalculate`