### PR TITLE
Add API section to developer guide table of contents

### DIFF
--- a/guides/data/nav_tree.yml
+++ b/guides/data/nav_tree.yml
@@ -12,6 +12,12 @@ top:
       - title: "Customer flow"
         href: "/developers/getting-started/customer-flow.html"
 main:
+  - title: "API"
+    dropdown:
+      - title: "Overview"
+        href: "/developers/api/overview.html"
+      - title: "Endpoints"
+        href: "/developers/api/endpoints.html"
   - title: "Adjustments"
     dropdown:
       - title: "Overview"


### PR DESCRIPTION
There are two articles in the `/developers/api/` subdirectory, but they are not yet accessible from the [guides.solidus.io](https://guides.solidus.io) table of contents. This commit adds them.