### PR TITLE
Fill credit card input with force in checkout spec

### DIFF
--- a/frontend/spec/features/checkout_spec.rb
+++ b/frontend/spec/features/checkout_spec.rb
@@ -350,7 +350,7 @@ describe "Checkout", type: :feature, inaccessible: true do
       choose "use_existing_card_no"
 
       fill_in "Name on card", with: 'Spree Commerce'
-      fill_in "Card Number", with: '4111 1111 1111 1111'
+      fill_in_with_force "Card Number", with: '4111 1111 1111 1111'
       fill_in "card_expiry", with: '04 / 20'
       fill_in "Card Code", with: '123'
 

--- a/frontend/spec/support/features/fill_in_with_force.rb
+++ b/frontend/spec/support/features/fill_in_with_force.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module FillInWithForce
+  def fill_in_with_force(locator, with:)
+    field_id = find_field(locator)[:id]
+    page.execute_script "document.getElementById('#{field_id}').value = '#{with}';"
+  end
+end
+
+RSpec.configure do |config|
+  config.include FillInWithForce, type: :feature
+end


### PR DESCRIPTION
This fixes the flaky spec described into #2910.

Capybara `fill_in` sometime does not fill the input with all the string provided so this fix will fill it with JS bypassing the default behavior.