### PR TITLE
Add make_default method on AddPaymentSourcesToWallet class

### DIFF
--- a/core/app/models/spree/wallet/add_payment_sources_to_wallet.rb
+++ b/core/app/models/spree/wallet/add_payment_sources_to_wallet.rb
@@ -24,14 +24,19 @@ class Spree::Wallet::AddPaymentSourcesToWallet
       # add valid sources to wallet and optionally set a default
       if sources.any?
         # arbitrarily sort by id for picking a default
-        wallet_payment_sources = sources.sort_by(&:id).map do |source|
+        sources.sort_by(&:id).each do |source|
           order.user.wallet.add(source)
         end
 
-        order.user.wallet.default_wallet_payment_source =
-          wallet_payment_sources.last
+        make_default
       end
     end
+  end
+
+  protected
+
+  def make_default
+    order.user.wallet.default_wallet_payment_source = order.user.wallet_payment_sources.last
   end
 
   private

--- a/core/spec/models/spree/wallet/add_payment_sources_to_wallet_spec.rb
+++ b/core/spec/models/spree/wallet/add_payment_sources_to_wallet_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Spree::Wallet::AddPaymentSourcesToWallet, type: :model do
+  let(:order) { create(:order_ready_to_complete) }
+
+  describe '#add_to_wallet' do
+    subject { described_class.new(order) }
+
+    it 'saves the payment source' do
+      expect { subject.add_to_wallet }.to change {
+        order.user.wallet.wallet_payment_sources.count
+      }.by(1)
+    end
+  end
+end


### PR DESCRIPTION
Ref: #2652

## Update:
### After some consideration with @tvdeyen 

With this PR we want to separate the `add_to_wallet` behavior from the `make_default` one to help if someone wants to change only the `make_default` logic without overriding the `add_to_wallet`.

## How it works

Now the `add_to_wallet` method calls the `make_default` method after adding on the user wallet the payment sources.
To change the `make_default` behavior now we can create own class and override the `make_default` method.

E.g.: https://github.com/solidusio/solidus/pull/2913#issuecomment-429913171