### PR TITLE
Improve text in "new promotions" form for better usability

### DIFF
--- a/backend/app/views/spree/admin/promotions/_actions.html.erb
+++ b/backend/app/views/spree/admin/promotions/_actions.html.erb
@@ -6,7 +6,7 @@
       <legend align="center"><%= t('spree.promotion_actions') %></legend>
       <% if can?(:update, @promotion) %>
         <div class="field">
-          <%= label_tag :action_type, t('spree.add_action_of_type')%>
+          <%= label_tag :action_type, t('spree.adjustment_type')%>
           <%= select_tag 'action_type', options, include_blank: t(:choose_promotion_action, scope: 'spree'), class: 'custom-select fullwidth' %>
         </div>
         <div class="filter-actions actions">

--- a/backend/app/views/spree/admin/promotions/_form.html.erb
+++ b/backend/app/views/spree/admin/promotions/_form.html.erb
@@ -1,7 +1,5 @@
 <%= render partial: 'spree/shared/error_messages', locals: { target: @promotion } %>
-<fieldset class="form-group no-border-bottom">
-  <legend><%= t '.general' %></legend>
-
+<fieldset class="form-group no-border-bottom no-border-top">
   <div class="row">
     <div id="general_fields" class="col-9">
       <div class="row">
@@ -14,6 +12,9 @@
           <%= f.field_container :description do %>
             <%= f.label :description %><br />
             <%= f.text_area :description, rows: 7, class: 'fullwidth' %>
+            <span class="info">
+              <%= t('spree.character_limit') %>
+            </span>
           <% end %>
 
           <%= f.field_container :category do %>

--- a/backend/app/views/spree/admin/promotions/_rules.html.erb
+++ b/backend/app/views/spree/admin/promotions/_rules.html.erb
@@ -6,7 +6,7 @@
 
       <% if can?(:update, @promotion) %>
         <div class="field">
-          <%= label_tag :promotion_rule_type, t('spree.add_rule_of_type') %>
+          <%= label_tag :promotion_rule_type, t('spree.discount_rules') %>
           <%= select_tag('promotion_rule[type]', options_for_promotion_rule_types(@promotion), include_blank: t(:choose_promotion_rule, scope: 'spree'), class: 'custom-select fullwidth') %>
         </div>
         <div class="filter-actions actions">

--- a/backend/solidus_backend.gemspec
+++ b/backend/solidus_backend.gemspec
@@ -31,6 +31,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'kaminari', '~> 1.1'
   s.add_dependency 'sassc-rails'
 
-  s.add_dependency 'autoprefixer-rails', '~> 7.1'
+  s.add_dependency 'autoprefixer-rails'
   s.add_dependency 'handlebars_assets', '~> 0.23'
 end

--- a/backend/spec/features/admin/promotion_adjustments_spec.rb
+++ b/backend/spec/features/admin/promotion_adjustments_spec.rb
@@ -18,13 +18,13 @@ describe "Promotion Adjustments", type: :feature, js: true do
       click_button "Create"
       expect(page).to have_title("SAVE SAVE SAVE - Promotions")
 
-      select "Item total", from: "Add rule of type"
+      select "Item total", from: "Discount rules"
       within('#rule_fields') { click_button "Add" }
 
       find('[id$=_preferred_amount]').set(30)
       within('#rule_fields') { click_button "Update" }
 
-      select "Create whole-order adjustment", from: "Add action of type"
+      select "Create whole-order adjustment", from: "Adjustment type"
       within('#action_fields') do
         click_button "Add"
         select "Flat Rate", from: I18n.t('spree.admin.promotions.actions.calculator_label')
@@ -55,7 +55,7 @@ describe "Promotion Adjustments", type: :feature, js: true do
       click_button "Create"
       expect(page).to have_title("SAVE SAVE SAVE - Promotions")
 
-      select "Create whole-order adjustment", from: "Add action of type"
+      select "Create whole-order adjustment", from: "Adjustment type"
       within('#action_fields') do
         click_button "Add"
         select "Flat Rate", from: I18n.t('spree.admin.promotions.actions.calculator_label')
@@ -81,13 +81,13 @@ describe "Promotion Adjustments", type: :feature, js: true do
       click_button "Create"
       expect(page).to have_title("SAVE SAVE SAVE - Promotions")
 
-      select "Item total", from: "Add rule of type"
+      select "Item total", from: "Discount rules"
       within('#rule_fields') { click_button "Add" }
 
       find('[id$=_preferred_amount]').set(30)
       within('#rule_fields') { click_button "Update" }
 
-      select "Create whole-order adjustment", from: "Add action of type"
+      select "Create whole-order adjustment", from: "Adjustment type"
       within('#action_fields') do
         click_button "Add"
         select "Flat Percent", from: I18n.t('spree.admin.promotions.actions.calculator_label')
@@ -118,12 +118,12 @@ describe "Promotion Adjustments", type: :feature, js: true do
       click_button "Create"
       expect(page).to have_title("SAVE SAVE SAVE - Promotions")
 
-      select "Product(s)", from: "Add rule of type"
+      select "Product(s)", from: "Discount rules"
       within("#rule_fields") { click_button "Add" }
       select2_search "RoR Mug", from: "Choose products"
       within('#rule_fields') { click_button "Update" }
 
-      select "Create per-line-item adjustment", from: "Add action of type"
+      select "Create per-line-item adjustment", from: "Adjustment type"
       within('#action_fields') do
         click_button "Add"
         select "Percent Per Item", from: I18n.t('spree.admin.promotions.actions.calculator_label')
@@ -152,12 +152,12 @@ describe "Promotion Adjustments", type: :feature, js: true do
       click_button "Create"
       expect(page).to have_title("SAVE SAVE SAVE - Promotions")
 
-      select "Item total", from: "Add rule of type"
+      select "Item total", from: "Discount rules"
       within('#rule_fields') { click_button "Add" }
       find('[id$=_preferred_amount]').set(30)
       within('#rule_fields') { click_button "Update" }
 
-      select "Free shipping", from: "Add action of type"
+      select "Free shipping", from: "Adjustment type"
       within('#action_fields') { click_button "Add" }
       expect(page).to have_content('Makes all shipments for the order free')
 
@@ -205,12 +205,12 @@ describe "Promotion Adjustments", type: :feature, js: true do
       click_button "Create"
       expect(page).to have_title("SAVE SAVE SAVE - Promotions")
 
-      select "Item total", from: "Add rule of type"
+      select "Item total", from: "Discount rules"
       within('#rule_fields') { click_button "Add" }
       find('[id$=_preferred_amount]').set(50)
       within('#rule_fields') { click_button "Update" }
 
-      select "Create whole-order adjustment", from: "Add action of type"
+      select "Create whole-order adjustment", from: "Adjustment type"
       within('#action_fields') do
         click_button "Add"
         select "Flat Rate", from: I18n.t('spree.admin.promotions.actions.calculator_label')
@@ -257,7 +257,7 @@ describe "Promotion Adjustments", type: :feature, js: true do
         click_button "Create"
         expect(page).to have_title("SAVE SAVE SAVE - Promotions")
 
-        select "Create per-line-item adjustment", from: "Add action of type"
+        select "Create per-line-item adjustment", from: "Adjustment type"
         within('#action_fields') do
           click_button "Add"
           select "Complex Calculator", from: I18n.t('spree.admin.promotions.actions.calculator_label')

--- a/backend/spec/features/admin/promotions/option_value_rule_spec.rb
+++ b/backend/spec/features/admin/promotions/option_value_rule_spec.rb
@@ -16,7 +16,7 @@ feature 'Promotion with option value rule' do
   end
 
   scenario "adding an option value rule", js: true do
-    select "Option Value(s)", from: "Add rule of type"
+    select "Option Value(s)", from: "Discount rules"
     within("#rules_container") { click_button "Add" }
 
     within("#rules_container .promotion-block") do
@@ -46,7 +46,7 @@ feature 'Promotion with option value rule' do
       option_value.update!(name: xss_string)
     end
     scenario "adding an option value rule", js: true do
-      select "Option Value(s)", from: "Add rule of type"
+      select "Option Value(s)", from: "Discount rules"
       within("#rules_container") { click_button "Add" }
 
       within("#rules_container .promotion-block") do

--- a/backend/spec/features/admin/promotions/product_rule_spec.rb
+++ b/backend/spec/features/admin/promotions/product_rule_spec.rb
@@ -12,7 +12,7 @@ feature 'Promotion with product rule', js: true do
   given(:promotion) { create :promotion }
 
   def add_promotion_rule_of_type(type)
-    select type, from: "Add rule of type"
+    select type, from: "Discount rules"
     within("#rules_container") { click_button "Add" }
   end
 

--- a/backend/spec/features/admin/promotions/tiered_calculator_spec.rb
+++ b/backend/spec/features/admin/promotions/tiered_calculator_spec.rb
@@ -12,7 +12,7 @@ feature "Tiered Calculator Promotions" do
   end
 
   scenario "adding a tiered percent calculator", js: true do
-    select "Create whole-order adjustment", from: "Add action of type"
+    select "Create whole-order adjustment", from: "Adjustment type"
     within('#action_fields') { click_button "Add" }
 
     select "Tiered Percent", from: I18n.t('spree.admin.promotions.actions.calculator_label')

--- a/backend/spec/features/admin/promotions/user_rule_spec.rb
+++ b/backend/spec/features/admin/promotions/user_rule_spec.rb
@@ -16,7 +16,7 @@ feature 'Promotion with user rule', js: true do
     let!(:other_user) { create(:user, email: 'bar@example.com') }
 
     scenario "searching a user" do
-      select "User", from: "Add rule of type"
+      select "User", from: "Discount rules"
       within("#rules_container") { click_button "Add" }
 
       select2_search "foo", from: "Choose users", select: false
@@ -31,7 +31,7 @@ feature 'Promotion with user rule', js: true do
     given!(:user) { create(:user, email: xss_string) }
 
     scenario "adding an option value rule" do
-      select "User", from: "Add rule of type"
+      select "User", from: "Discount rules"
       within("#rules_container") { click_button "Add" }
 
       select2_search "<script>", from: "Choose users"

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -824,6 +824,7 @@ en:
     adjustment_successfully_closed: Adjustment has been successfully closed!
     adjustment_successfully_opened: Adjustment has been successfully opened!
     adjustment_total: Adjustment Total
+    adjustment_type: Adjustment type
     adjustments: Adjustments
     admin:
       stores:
@@ -1084,6 +1085,7 @@ en:
     carton_orders: 'Other orders with Carton'
     categories: Categories
     category: Category
+    character_limit: Limit of 255 characters
     charged: Charged
     check: Check
     check_stock_on_transfer: Check stock on transfer
@@ -1196,6 +1198,7 @@ en:
     destroy: Destroy
     details: Details
     discount_amount: Discount Amount
+    discount_rules: Discount rules
     dismiss_banner: No. Thanks! I'm not interested, do not display this message again
     display: Display
     download_promotion_code_list: Download Code List


### PR DESCRIPTION
This commit fixes issues raised in #1960 with the following exceptions:

I didn't add a character counter to the description, just static text, so no bonus points. We can leave the issue open, and I can try resolving it later.

It looks like the following issues have been already fixed-ish:

>  Change the label "Base Calculator" to "Discount type"
>  Add the currency symbol into the grey box prepended to the currency input

"Base Calculator" had already been changed to "Calculated by", and the currency symbol was already prepended to the currency input field

<img width="577" alt="screen shot 2018-10-13 at 7 37 31 pm" src="https://user-images.githubusercontent.com/100786/46911997-84939380-cf1f-11e8-9b1c-eaeb7ed4d393.png">
