### PR TITLE
Fix tab selection in sidebar navigation

### DIFF
--- a/backend/app/views/spree/admin/shared/_product_sub_menu.html.erb
+++ b/backend/app/views/spree/admin/shared/_product_sub_menu.html.erb
@@ -12,6 +12,6 @@
     <%= tab :taxonomies %>
   <% end %>
   <% if can? :admin, Spree::Taxon %>
-    <%= tab :taxons, label: :display_order %>
+    <%= tab :taxons, label: :display_order, match_path: '/taxons' %>
   <% end %>
 </ul>

--- a/backend/spec/features/admin/taxons_spec.rb
+++ b/backend/spec/features/admin/taxons_spec.rb
@@ -40,4 +40,39 @@ describe "Taxonomies and taxons", type: :feature do
 
     expect(page).to have_current_path %r{/admin/taxonomies/\d+/taxons/\d+/edit}
   end
+
+  context "inside sidebar menu" do
+    def only_one_selected_tab_inside?(sub_tab_selector, tab_name, tab_path)
+      within(sub_tab_selector) do
+        expect(page).to have_selector('.selected', count: 1)
+
+        within('.selected') { expect(page).to have_link(tab_name, href: tab_path) }
+      end
+    end
+
+    context "on display taxonomies page", js: true do
+      it "should be selected only one tab 'Taxonomies' in product sub tabs" do
+        visit spree.admin_taxonomies_path
+        only_one_selected_tab_inside?('[data-hook=admin_product_sub_tabs]', 'Taxonomies', spree.admin_taxonomies_path)
+      end
+    end
+
+    context "on edit taxonomy page", js: true do
+      it "should be selected only one tab 'Taxonomies' in product sub tabs" do
+        taxonomy = create :taxonomy
+
+        visit spree.edit_admin_taxonomy_path(taxonomy)
+        only_one_selected_tab_inside?('[data-hook=admin_product_sub_tabs]', 'Taxonomies', spree.admin_taxonomies_path)
+      end
+    end
+
+    context "on edit taxonomy's taxon page", js: true do
+      it "should be selected only one tab 'Taxonomies' in product sub tabs" do
+        taxonomy = create :taxonomy
+
+        visit spree.edit_admin_taxonomy_taxon_path(taxonomy, taxonomy.root.id)
+        only_one_selected_tab_inside?('[data-hook=admin_product_sub_tabs]', 'Taxonomies', spree.admin_taxonomies_path)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Hi guys!

I noticed that two tabs was selected in sidebar navigation menu on taxon edit page (admin/taxonomy/:taxonomy_id/taxons/:id/edit)
![2018-10-14 15 39 58](https://user-images.githubusercontent.com/3278464/46918138-d5b28e80-cfd6-11e8-84de-41b5499e2187.png)
I think only 'Taxonomies' tab should be selected

I added few tests and fixed it.