### PR TITLE
Add response with error message on failure destroy action

### DIFF
--- a/backend/app/controllers/spree/admin/resource_controller.rb
+++ b/backend/app/controllers/spree/admin/resource_controller.rb
@@ -108,6 +108,7 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
       invoke_callbacks(:destroy, :fails)
       respond_with(@object) do |format|
         format.html { redirect_to location_after_destroy }
+        format.js { render status: :unprocessable_entity, plain: @object.errors.full_messages.join(', ') }
       end
     end
   end


### PR DESCRIPTION
Hello again!

Now I noticed bug in admin when validations prevent destroy. 
Your resource controller doesn't handle js format when destroy failures but your js code expects error message 
![2018-10-18 2 31 46](https://user-images.githubusercontent.com/3278464/47122089-fcdeb980-d27d-11e8-9f9c-14e2d2294ae2.png)

Test and fix in commit! :)
