### PR TITLE
Fix deprecation warning for Spree::Shipment#reverse_chronological scope

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -34,7 +34,7 @@ module Spree
     scope :with_state, ->(*s) { where(state: s) }
     # sort by most recent shipped_at, falling back to created_at. add "id desc" to make specs that involve this scope more deterministic.
     scope :reverse_chronological, -> {
-      order(Arel.sql('coalesce(spree_shipments.shipped_at, spree_shipments.created_at) desc'), id: :desc)
+      order(Arel.sql("coalesce(#{Spree::Shipment.table_name}.shipped_at, #{Spree::Shipment.table_name}.created_at) desc"), id: :desc)
     }
 
     scope :by_store, ->(store) { joins(:order).merge(Spree::Order.by_store(store)) }

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -33,7 +33,10 @@ module Spree
     scope :trackable, -> { where("tracking IS NOT NULL AND tracking != ''") }
     scope :with_state, ->(*s) { where(state: s) }
     # sort by most recent shipped_at, falling back to created_at. add "id desc" to make specs that involve this scope more deterministic.
-    scope :reverse_chronological, -> { order('coalesce(spree_shipments.shipped_at, spree_shipments.created_at) desc', id: :desc) }
+    scope :reverse_chronological, -> {
+      order(Arel.sql('coalesce(spree_shipments.shipped_at, spree_shipments.created_at) desc'), id: :desc)
+    }
+
     scope :by_store, ->(store) { joins(:order).merge(Spree::Order.by_store(store)) }
 
     # shipment state machine (see http://github.com/pluginaweek/state_machine/tree/master for details)


### PR DESCRIPTION
Hi everyone! :wave:

This is a small PR to fix a deprecation warning that shows up when running certain tests. The message goes like this:

```
DEPRECATION WARNING: Dangerous query method (method whose arguments are used as raw
SQL) called with non-attribute argument(s): "coalesce(spree_shipments.shipped_at,
spree_shipments.created_at) desc". Non-attribute arguments will be disallowed in Rails 6.0.
This method should not be called with user-provided values, such as request parameters or
model attributes. Known-safe values can be passed by wrapping them in Arel.sql().
(called from block in <class::Shipment> at /solidus/core/app/models/spree/shipment.rb:36)
```

From what I can see, the attributes used in here shouldn't generate any problems as they just store timestamps and the user is not passing any parameters to said query so SQL injection is unlikely.

Running the full test suite following this patch doesn't show the aforementioned warning anymore. This PR also future proofs this scope for an eventual Rails 6 update.

Let me know what you think!