### PR TITLE
Remove dangerous query method warning

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -33,7 +33,7 @@ module Spree
     scope :trackable, -> { where("tracking IS NOT NULL AND tracking != ''") }
     scope :with_state, ->(*s) { where(state: s) }
     # sort by most recent shipped_at, falling back to created_at. add "id desc" to make specs that involve this scope more deterministic.
-    scope :reverse_chronological, -> { order('coalesce(spree_shipments.shipped_at, spree_shipments.created_at) desc', id: :desc) }
+    scope :reverse_chronological, -> { order(Arel::Nodes::NamedFunction.new('COALESCE', [arel_table[:shipped_at], arel_table[:created_at]]).desc, id: :desc) }
     scope :by_store, ->(store) { joins(:order).merge(Spree::Order.by_store(store)) }
 
     # shipment state machine (see http://github.com/pluginaweek/state_machine/tree/master for details)


### PR DESCRIPTION
Warning message:

    DEPRECATION WARNING: Dangerous query method (method whose arguments
    are used as raw SQL) called with non-attribute argument(s):
    "coalesce(spree_shipments.shipped_at, spree_shipments.created_at)
    desc". Non-attribute arguments will be disallowed in Rails 6.0.
    This method should not be called with user-provided values, such as
    request parameters or model attributes. Known-safe values can be
    passed by wrapping them in Arel.sql(). (called from block in
    <class:Shipment> at solidus/core/app/models/spree/shipment.rb:37)

SQL generated by the scope before this update:

    > Spree::Shipment.reverse_chronological.to_sql
     => "SELECT \"spree_shipments\".* FROM \"spree_shipments\" ORDER BY
      coalesce(spree_shipments.shipped_at, spree_shipments.created_at)
      desc, \"spree_shipments\".\"id\" DESC"

SQL generated by the scope after this update:

    > Spree::Shipment.reverse_chronological.to_sql
     => "SELECT \"spree_shipments\".* FROM \"spree_shipments\" ORDER BY
      COALESCE(\"spree_shipments\".\"shipped_at\",
      \"spree_shipments\".\"created_at\") DESC,
      \"spree_shipments\".\"id\" DESC"