### PR TITLE
Remove user prereq from First Order promorule

### DIFF
--- a/core/app/models/spree/promotion/rules/first_order.rb
+++ b/core/app/models/spree/promotion/rules/first_order.rb
@@ -18,8 +18,6 @@ module Spree
             if !completed_orders.blank? && completed_orders.first != order
               eligibility_errors.add(:base, eligibility_error_message(:not_first_order))
             end
-          else
-            eligibility_errors.add(:base, eligibility_error_message(:no_user_or_email_specified))
           end
 
           eligibility_errors.empty?

--- a/core/lib/spree/testing_support/factories/promotion_factory.rb
+++ b/core/lib/spree/testing_support/factories/promotion_factory.rb
@@ -60,5 +60,15 @@ FactoryBot.define do
       end
     end
     factory :promotion_with_item_total_rule, traits: [:with_item_total_rule]
+    trait :with_first_order_rule do
+      after(:create) do |promotion, _evaluator|
+        rule = Spree::Promotion::Rules::FirstOrder.create!(
+          promotion: promotion,
+        )
+        promotion.rules << rule
+        promotion.save!
+      end
+    end
+    factory :promotion_with_first_order_rule, traits: [:with_first_order_rule]
   end
 end

--- a/core/spec/models/spree/promotion/rules/first_order_spec.rb
+++ b/core/spec/models/spree/promotion/rules/first_order_spec.rb
@@ -8,11 +8,11 @@ RSpec.describe Spree::Promotion::Rules::FirstOrder, type: :model do
   let(:user) { mock_model(Spree::LegacyUser) }
 
   context "without a user or email" do
-    it { expect(rule).not_to be_eligible(order) }
-    it "sets an error message" do
+    it { expect(rule).to be_eligible(order) }
+    it "does not set an error message" do
       rule.eligible?(order)
       expect(rule.eligibility_errors.full_messages.first).
-        to eq "You need to login or provide your email before applying this coupon code."
+        to be_nil
     end
   end
 

--- a/frontend/spec/features/first_order_promotion_spec.rb
+++ b/frontend/spec/features/first_order_promotion_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.feature "First Order promotion" do
+  given!(:promotion) do
+    FactoryBot.create(
+      :promotion_with_first_order_rule,
+      :with_order_adjustment,
+      code: "FIRSTONEFREE",
+      per_code_usage_limit: 10
+    )
+  end
+
+  background do
+    create(:store)
+    product = FactoryBot.create(:product)
+    visit spree.root_path
+    click_link product.name
+    click_button "Add To Cart"
+  end
+
+  scenario "Adding first order promotion to cart and checking out as guest" do
+    fill_in "Coupon code", with: "FIRSTONEFREE"
+    click_button "Apply Code"
+    expect(page).to have_content("The coupon code was successfully applied to your order")
+
+    within("#cart_adjustments") do
+      expect(page).to have_content("-$10.00")
+    end
+  end
+
+  scenario "Trying to reuse first order promotion" do
+    previous_user = FactoryBot.create(
+      :user,
+      email: "sam@tom.com"
+    )
+    _previous_order = create(:completed_order_with_totals, user: previous_user)
+    fill_in "Coupon code", with: "FIRSTONEFREE"
+    click_button "Apply Code"
+    expect(page).to have_content("The coupon code was successfully applied to your order")
+    click_on "Checkout"
+    fill_in "Customer E-Mail", with: "sam@tom.com"
+    fill_in_address
+    click_on "Save and Continue"
+    expect(page).to_not have_content("#summary-order-charges")
+  end
+
+  def fill_in_address
+    address = "order_bill_address_attributes"
+    fill_in "#{address}_firstname", with: "Ryan"
+    fill_in "#{address}_lastname", with: "Bigg"
+    fill_in "#{address}_address1", with: "143 Swan Street"
+    fill_in "#{address}_city", with: "Richmond"
+    select "United States of America", from: "#{address}_country_id"
+    fill_in "#{address}_zipcode", with: "12345"
+    fill_in "#{address}_phone", with: "(555) 555-5555"
+  end
+end


### PR DESCRIPTION
When a customer applies a promotion with a "first order" rule, the rule
checks for a User or email associated with the order. This is not
strictly necessary, since the order can be checked after the coupon is
applied and if the user is found to have an existing order the coupon
gets removed then.