### PR TITLE
remove unused routes and actions from return authorizations

### DIFF
--- a/api/app/controllers/spree/api/return_authorizations_controller.rb
+++ b/api/app/controllers/spree/api/return_authorizations_controller.rb
@@ -4,7 +4,7 @@ module Spree
   module Api
     class ReturnAuthorizationsController < Spree::Api::BaseController
       before_action :load_order
-      around_action :lock_order, only: [:create, :update, :destroy, :add, :receive, :cancel]
+      around_action :lock_order, only: [:create, :update, :destroy, :cancel]
 
       rescue_from Spree::Order::InsufficientStock, with: :insufficient_stock_error
 

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -35,9 +35,7 @@ Spree::Core::Engine.routes.draw do
 
       resources :return_authorizations do
         member do
-          put :add
           put :cancel
-          put :receive
         end
       end
     end


### PR DESCRIPTION
`add` and `receive` actions for this controller was removed in https://github.com/solidusio/solidus/commit/a8b51afb8e33a98b116eb88940ce0bde0aeec4be#diff-34985b492fae3d51c9ad1b6e583f06db and https://github.com/solidusio/solidus/commit/8ae1e15f7ca423518200488e97ca0bb928e66092#diff-34985b492fae3d51c9ad1b6e583f06db, so is not necessary keep in routes or controller