### PR TITLE
improve decorators / contributing docs

### DIFF
--- a/guides/README.md
+++ b/guides/README.md
@@ -1,4 +1,15 @@
-Based on [https://github.com/joshukraine/middleman-gulp](https://github.com/joshukraine/middleman-gulp)
+# Solidus Guides
+
+If you want to contribute to the Solidus documentation be sure to read the
+[dedicated section](https://github.com/solidusio/solidus/blob/master/guides/source/contributing.html.md) first.
+
+The documentation files can be found
+[inside the `source/` folder](https://github.com/solidusio/solidus/tree/master/guides/source).
+
+---
+
+The Solidus documentation is published with [Middleman](https://middlemanapp.com),
+and based on [https://github.com/joshukraine/middleman-gulp](https://github.com/joshukraine/middleman-gulp).
 
 Requirements
 ------------
@@ -13,7 +24,7 @@ Usage
 
 1. Install ruby gems `bundle install`
 
-2. Install npm packages `npm install` 
+2. Install npm packages `npm install`
 
 3. Start the Middleman server. Note that this will also invoke Webpack via the external pipeline.
 
@@ -26,4 +37,5 @@ $ bundle exec middleman server
 ```bash
 $ bundle exec middleman build
 ```
+
 5. Set proper `base_url` in config.rb

--- a/guides/source/contributing.html.md
+++ b/guides/source/contributing.html.md
@@ -2,6 +2,9 @@
 
 We hope that you will consider contributing to the Solidus documentation.
 
+The Solidus documentation sources are hosted in the main repository
+[inside the `guides/` folder](https://github.com/solidusio/solidus/tree/master/guides#readme).
+
 We want to provide the Solidus community with consistent, easy-to-read, and
 easy-to-maintain articles. If you decide to submit a pull request, please try to
 follow the guidelines listed here.

--- a/guides/source/developers/extensions/decorators.html.md
+++ b/guides/source/developers/extensions/decorators.html.md
@@ -13,15 +13,13 @@ For example, if you want to add a method to the `Spree::Order` model, you could
 create `/app/models/mystore/order_decorator.rb` with the following contents:
 
 ```ruby
-module MyStore
-  module OrderDecorator
-    def total
-      super + BigDecimal(10.0)
-    end
+module MyStore::OrderDecorator
+  def total
+    super + BigDecimal(10.0)
   end
-end
 
-Spree::Order.prepend MyStore::OrderDecorator
+  Spree::Order.prepend self
+end
 ```
 
 This creates a new module called `MyStore::OrderDecorator` that prepends its


### PR DESCRIPTION
A couple of fixes to docs. I'd also like to address this comment:

```html
<!-- TODO:
   An article about decorators doesn't really belong in the `/extensions`
   directory. In the future, there will be a better home for it.
 -->
```

but I need to know if there's any plan to do that or what would be the desired new home for the decorators docs.

My proposal would be something like *Local Changes* or *Patching*, which would work for both the general application using Solidus directly and the extension developer adding functionality.

Also if there's any collective wisdom to share, would be great to add some guidance on how to patch templates (erb/jbuilder/ecc.) 😄.