### PR TITLE
Add ordering to menu items

### DIFF
--- a/backend/app/models/spree/backend_configuration.rb
+++ b/backend/app/models/spree/backend_configuration.rb
@@ -22,7 +22,9 @@ module Spree
 
     # An item which should be drawn in the admin menu
     class MenuItem
-      attr_reader :icon, :label, :partial, :condition, :sections, :url, :position
+      attr_reader :icon, :label, :partial, :condition, :sections, :url
+
+      attr_accessor :position
 
       # @param sections [Array<Symbol>] The sections which are contained within
       #   this admin menu section.

--- a/backend/app/models/spree/backend_configuration.rb
+++ b/backend/app/models/spree/backend_configuration.rb
@@ -22,7 +22,7 @@ module Spree
 
     # An item which should be drawn in the admin menu
     class MenuItem
-      attr_reader :icon, :label, :partial, :condition, :sections, :url
+      attr_reader :icon, :label, :partial, :condition, :sections, :url, :position
 
       # @param sections [Array<Symbol>] The sections which are contained within
       #   this admin menu section.
@@ -35,13 +35,16 @@ module Spree
       # @param partial [String] A partial to draw within this menu item for use
       #   in declaring a submenu
       # @param url [String] A url where this link should send the user to
+      # @param position [Integer] The position in which the menu item should render
+      #   nil will cause the item to render last
       def initialize(
         sections,
         icon,
         condition: nil,
         label: nil,
         partial: nil,
-        url: nil
+        url: nil,
+        position: nil
       )
 
         @condition = condition || -> { true }
@@ -50,6 +53,7 @@ module Spree
         @label = label || sections.first
         @partial = partial
         @url = url
+        @position = position
       end
     end
 
@@ -65,6 +69,11 @@ module Spree
     #
     # @!attribute menu_items
     #   @return [Array<Spree::BackendConfiguration::MenuItem>]
+    #
+    # Positioning can be determined by setting the position attribute to
+    # an Integer or nil. Menu Items will be rendered with smaller lower values
+    # first and higher values last. A position value of nil will cause the menu
+    # item to be rendered at the end of the list.
     attr_writer :menu_items
 
     # Return the menu items which should be drawn in the menu
@@ -76,7 +85,7 @@ module Spree
         MenuItem.new(
           ORDER_TABS,
           'shopping-cart',
-          condition: -> { can?(:admin, Spree::Order) },
+          condition: -> { can?(:admin, Spree::Order) }
         ),
         MenuItem.new(
           PRODUCT_TABS,

--- a/backend/app/models/spree/backend_configuration.rb
+++ b/backend/app/models/spree/backend_configuration.rb
@@ -85,13 +85,38 @@ module Spree
         MenuItem.new(
           ORDER_TABS,
           'shopping-cart',
-          condition: -> { can?(:admin, Spree::Order) }
+          condition: -> { can?(:admin, Spree::Order) },
+          position: 0
         ),
         MenuItem.new(
           PRODUCT_TABS,
           'th-large',
           condition: -> { can?(:admin, Spree::Product) },
-          partial: 'spree/admin/shared/product_sub_menu'
+          partial: 'spree/admin/shared/product_sub_menu',
+          position: 1
+        ),
+        MenuItem.new(
+          PROMOTION_TABS,
+          'bullhorn',
+          partial: 'spree/admin/shared/promotion_sub_menu',
+          condition: -> { can?(:admin, Spree::Promotion) },
+          url: :admin_promotions_path,
+          position: 2
+        ),
+        MenuItem.new(
+          STOCK_TABS,
+          'cubes',
+          condition: -> { can?(:admin, Spree::StockItem) },
+          label: :stock,
+          url: :admin_stock_items_path,
+          position: 3
+        ),
+        MenuItem.new(
+          USER_TABS,
+          'user',
+          condition: -> { Spree.user_class && can?(:admin, Spree.user_class) },
+          url: :admin_users_path,
+          position: 4
         ),
         MenuItem.new(
           CONFIGURATION_TABS,
@@ -99,27 +124,8 @@ module Spree
           condition: -> { can?(:admin, Spree::Store) },
           label: :settings,
           partial: 'spree/admin/shared/settings_sub_menu',
-          url: :admin_stores_path
-        ),
-        MenuItem.new(
-          PROMOTION_TABS,
-          'bullhorn',
-          partial: 'spree/admin/shared/promotion_sub_menu',
-          condition: -> { can?(:admin, Spree::Promotion) },
-          url: :admin_promotions_path
-        ),
-        MenuItem.new(
-          STOCK_TABS,
-          'cubes',
-          condition: -> { can?(:admin, Spree::StockItem) },
-          label: :stock,
-          url: :admin_stock_items_path
-        ),
-        MenuItem.new(
-          USER_TABS,
-          'user',
-          condition: -> { Spree.user_class && can?(:admin, Spree.user_class) },
-          url: :admin_users_path
+          url: :admin_stores_path,
+          position: 5
         )
       ]
     end

--- a/backend/app/views/spree/admin/shared/_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_tabs.html.erb
@@ -1,4 +1,4 @@
-<% Spree::Backend::Config.menu_items.each do |menu_item| %>
+<% Spree::Backend::Config.menu_items.sort_by { |item| item.position || Float::INFINITY }.each do |menu_item| %>
   <% if instance_exec(&menu_item.condition) %>
     <%=
       tab(


### PR DESCRIPTION
This change allows menu items to be ordered. If the order value is nil
the menu item will come at the end of the list.

After:
![b63a27f7-a7f5-449f-b233-3c4d964d3bd9](https://user-images.githubusercontent.com/11466782/48308020-9e74c600-e51f-11e8-9bba-ffb98eb563b5.png)
