### PR TITLE
Added a link to the frontend product from the backend product edit page

### DIFF
--- a/backend/app/views/spree/admin/products/edit.html.erb
+++ b/backend/app/views/spree/admin/products/edit.html.erb
@@ -4,6 +4,11 @@
       <%= link_to t('spree.new_product'), new_object_url, id: 'admin_new_product', class: 'btn btn-primary' %>
     </li>
   <% end %>
+  <% if defined?(Spree::Frontend::Engine) %>
+    <li id="view_product_link">
+      <%= link_to t('spree.view_product'), spree.product_path(@product), id: 'admin_view_product', class: 'btn btn-primary ml-2' %>
+    </li>
+  <% end %>
 <% end %>
 
 <%= render partial: 'spree/admin/shared/product_tabs', locals: { current: 'Product Details' } %>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -2098,6 +2098,7 @@ en:
     variant_to_be_received: Variant to be received
     variants: Variants
     version: Version
+    view_product: View Product On Store
     view_promotion_codes_list: View codes list
     void: Void
     weight: Weight


### PR DESCRIPTION
It's handy to be able to quickly get to the frontend product page from the backend product edit page.