### PR TITLE
Add no other promotions rule

### DIFF
--- a/backend/app/views/spree/admin/promotions/rules/_first_order.html.erb
+++ b/backend/app/views/spree/admin/promotions/rules/_first_order.html.erb
@@ -1,0 +1,1 @@
+<%# Don't delete this file! It is required for a promotion rule %>

--- a/backend/app/views/spree/admin/promotions/rules/_no_other_promotion.html.erb
+++ b/backend/app/views/spree/admin/promotions/rules/_no_other_promotion.html.erb
@@ -1,0 +1,1 @@
+<%# Don't delete this file! It is required for a promotion rule %>

--- a/backend/app/views/spree/admin/promotions/rules/_one_use_per_user.html.erb
+++ b/backend/app/views/spree/admin/promotions/rules/_one_use_per_user.html.erb
@@ -1,0 +1,1 @@
+<%# Don't delete this file! It is required for a promotion rule %>

--- a/backend/app/views/spree/admin/promotions/rules/_user_logged_in.html.erb
+++ b/backend/app/views/spree/admin/promotions/rules/_user_logged_in.html.erb
@@ -1,0 +1,1 @@
+<%# Don't delete this file! It is required for a promotion rule %>

--- a/core/app/models/spree/promotion/rules/no_other_promotion.rb
+++ b/core/app/models/spree/promotion/rules/no_other_promotion.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Spree
+  class Promotion < Spree::Base
+
+    module Rules
+      class NoOtherPromotion < PromotionRule
+
+        def applicable?(promotable)
+          promotable.is_a?(Spree::Order)
+        end
+
+        def eligible?(order, _options = {})
+          if order.promotions.present?
+            eligibility_errors.add(:base, eligibility_error_message(:order_has_other_promotion))
+          end
+
+          eligibility_errors.empty?
+        end
+
+      end
+    end
+
+  end
+end

--- a/core/app/models/spree/promotion/rules/no_other_promotion.rb
+++ b/core/app/models/spree/promotion/rules/no_other_promotion.rb
@@ -2,10 +2,8 @@
 
 module Spree
   class Promotion < Spree::Base
-
     module Rules
       class NoOtherPromotion < PromotionRule
-
         def applicable?(promotable)
           promotable.is_a?(Spree::Order)
         end
@@ -17,9 +15,7 @@ module Spree
 
           eligibility_errors.empty?
         end
-
       end
     end
-
   end
 end

--- a/core/app/models/spree/promotion_handler/coupon.rb
+++ b/core/app/models/spree/promotion_handler/coupon.rb
@@ -13,6 +13,10 @@ module Spree
 
       def apply
         if coupon_code.present?
+          if promotion_stacking_disabled?
+            set_error_code :promotion_stacking_disabled
+            return self
+          end
           if promotion.present? && promotion.actions.exists?
             handle_present_promotion(promotion)
           elsif promotion_code && promotion_code.promotion.inactive?
@@ -86,6 +90,16 @@ module Spree
 
       def promotion_exists_on_order?(order, promotion)
         order.promotions.include? promotion
+      end
+
+      def promotion_stacking_disabled?
+        if order.promotions.present?
+          order.promotions.each do |promotion|
+            return true if promotion.rules.any? { |r| r[:type] == "Spree::Promotion::Rules::NoOtherPromotion" }
+          end
+        end
+
+        false
       end
     end
   end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -203,6 +203,8 @@ en:
         description: Must be the customer's first order
       spree/promotion/rules/landing_page:
           description: Customer must have visited the specified page
+      spree/promotion/rules/no_other_promotion:
+          description: Order must not have any other promotions
       spree/promotion/rules/one_use_per_user:
         description: Only One Use Per User
       spree/promotion/rules/option_value:
@@ -529,6 +531,7 @@ en:
       spree/promotion/rules/first_order: First order
       spree/promotion/rules/item_total: Item total
       spree/promotion/rules/landing_page: Landing Page
+      spree/promotion/rules/no_other_promotion: No Other Promotion
       spree/promotion/rules/one_use_per_user: One Use Per User
       spree/promotion/rules/option_value: Option Value(s)
       spree/promotion/rules/product: Product(s)
@@ -1242,6 +1245,7 @@ en:
         no_user_or_email_specified: You need to login or provide your email before applying this coupon code.
         no_user_specified: You need to login before applying this coupon code.
         not_first_order: This coupon code can only be applied to your first order.
+        order_has_other_promotion: This coupon code cannot be used with another promotion.
     email: Email
     empty: Empty
     empty_cart: Empty Cart
@@ -1722,6 +1726,7 @@ en:
         any: Match any of these rules
     promotion_rule: Promotion Rule
     promotions: Promotions
+    promotion_stacking_disabled: A coupon you used cannot be used with other coupons.
     promotion_successfully_created: Promotion has been successfully created!
     promotion_total_changed_before_complete: "One or more of the promotions on your order have become ineligible and were removed. Please check the new order amounts and try again."
     promotion_uses: Promotion uses

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -487,6 +487,7 @@ module Spree
             Spree::Promotion::Rules::FirstRepeatPurchaseSince
             Spree::Promotion::Rules::UserRole
             Spree::Promotion::Rules::Store
+            Spree::Promotion::Rules::NoOtherPromotion
           ]
 
           promos.actions = %w[

--- a/core/spec/models/spree/promotion/rules/no_other_promotion_spec.rb
+++ b/core/spec/models/spree/promotion/rules/no_other_promotion_spec.rb
@@ -4,7 +4,6 @@ require 'rails_helper'
 
 RSpec.describe Spree::Promotion::Rules::NoOtherPromotion, type: :model do
   let(:rule) { Spree::Promotion::Rules::NoOtherPromotion.new }
-
   context "with no other promotions" do
     let(:order) { mock_model(Spree::Order, promotions: nil) }
     it "should be eligible" do
@@ -14,9 +13,7 @@ RSpec.describe Spree::Promotion::Rules::NoOtherPromotion, type: :model do
 
   context "with another promotion" do
     let(:promotion) { FactoryBot.create :promotion }
-    let(:order) { mock_model(Spree::Order,
-                             promotions: promotion) }
-
+    let(:order) { mock_model(Spree::Order, promotions: promotion) }
     it "should not be eligible" do
       expect(rule).not_to be_eligible(order)
     end

--- a/core/spec/models/spree/promotion/rules/no_other_promotion_spec.rb
+++ b/core/spec/models/spree/promotion/rules/no_other_promotion_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Spree::Promotion::Rules::NoOtherPromotion, type: :model do
+  let(:rule) { Spree::Promotion::Rules::NoOtherPromotion.new }
+
+  context "with no other promotions" do
+    let(:order) { mock_model(Spree::Order, promotions: nil) }
+    it "should be eligible" do
+      expect(rule).to be_eligible(order)
+    end
+  end
+
+  context "with another promotion" do
+    let(:promotion) { FactoryBot.create :promotion }
+    let(:order) { mock_model(Spree::Order,
+                             promotions: promotion) }
+
+    it "should not be eligible" do
+      expect(rule).not_to be_eligible(order)
+    end
+  end
+end


### PR DESCRIPTION
This is a promotion rule that seems like it should ship with Solidus. The primary reason I feel this way is because it requires modifying the Spree::PromotionHandler::Coupon class.

Another solution might be extracting `promotion_stacking_disabled?` into some kind of flag on the promotion model instead of a method that is less than efficient. 