### PR TITLE
Disable 'count on hand' input when 'track inventory' option is set to false

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/stock_management.js
+++ b/backend/app/assets/javascripts/spree/backend/stock_management.js
@@ -2,11 +2,20 @@ Spree.ready(function() {
   $('.js-edit-stock-item').each(function() {
     var $el = $(this);
     var model = new Spree.Models.StockItem($el.data('stock-item'));
+    var trackInventory = $el.data('track-inventory');
     new Spree.Views.Stock.EditStockItemRow({
       el: $el,
       stockLocationName: $el.data('stock-location-name'),
       model: model
     });
+
+    if (trackInventory === false) {
+      $('.js-edit-stock-item input').attr({
+        disabled: true,
+        class: 'with-tip',
+        title: '"Track inventory" option disabled for this variant'
+      });
+    }
   });
 
   $('.js-add-stock-item').each(function() {

--- a/backend/app/views/spree/admin/stock_items/_stock_management.html.erb
+++ b/backend/app/views/spree/admin/stock_items/_stock_management.html.erb
@@ -72,7 +72,7 @@
             </colgroup>
             <% variant.stock_items.each do |item| %>
               <% if @stock_item_stock_locations.include?(item.stock_location) %>
-                <tr class="js-edit-stock-item stock-item-edit-row" data-variant-id="<%= variant.id %>" data-stock-item="<%= item.to_json %>" data-stock-location-name="<%= item.stock_location.name %>">
+                <tr class="js-edit-stock-item stock-item-edit-row" data-variant-id="<%= variant.id %>" data-stock-item="<%= item.to_json %>" data-stock-location-name="<%= item.stock_location.name %>" data-track-inventory="<%= variant.track_inventory %>">
                   <%# This is rendered in JS %>
                 </tr>
               <% end %>


### PR DESCRIPTION
This patch aims to fix #2946 by disabling the `Count on hand` input when the `Track inventory` option/attribute is set to `false`.

Here's an screenshot for demonstration purposes:

![screenshot_2018-11-20 store stock - apache baseball jersey - products](https://user-images.githubusercontent.com/9470839/48793665-12f0f700-ecce-11e8-829d-9f484fab1dcc.png)

It also includes a tooltip to help users understand why said input is disabled.

Open to suggestions!