### PR TITLE
Update Jbuilder to v2.8 to fix deprecation warnings

### DIFF
--- a/api/solidus_api.gemspec
+++ b/api/solidus_api.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 2.2.2'
   gem.required_rubygems_version = '>= 1.8.23'
 
-  gem.add_dependency 'jbuilder', '~> 2.6'
+  gem.add_dependency 'jbuilder', '~> 2.8'
   gem.add_dependency 'kaminari-activerecord', '~> 1.1'
   gem.add_dependency 'responders'
   gem.add_dependency 'solidus_core', gem.version

--- a/backend/solidus_backend.gemspec
+++ b/backend/solidus_backend.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'coffee-rails'
   s.add_dependency 'font-awesome-rails', '~> 4.0'
-  s.add_dependency 'jbuilder', '~> 2.6'
+  s.add_dependency 'jbuilder', '~> 2.8'
   s.add_dependency 'jquery-rails'
   s.add_dependency 'kaminari', '~> 1.1'
   s.add_dependency 'sassc-rails'


### PR DESCRIPTION
This PR fixes several deprecation warnings that showed up when running the Solidus' API test suite by updating Jbuilder up to its latest version (as per rails/jbuilder#447)

The message is the following:

```
DEPRECATION WARNING: Calling fragment_cache_key directly is deprecated and will be
removed in Rails 6.0. All fragment accessors now use the combined_fragment_cache_key
method that retains the key as an array, such that the caching stores can interrogate
the parts for cache versions used in recyclable cache keys.
```