### PR TITLE
[WIP] Add option for user to store creditcard

### DIFF
--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -30,6 +30,7 @@ module Spree
       if update_order
 
         assign_temp_address
+        assign_temp_payment_source
 
         unless transition_forward
           redirect_on_failure
@@ -55,6 +56,10 @@ module Spree
 
     def assign_temp_address
       @order.temporary_address = !params[:save_user_address]
+    end
+
+    def assign_temp_payment_source
+      @order.temporary_payment_source = !params[:save_user_payment_source]
     end
 
     def redirect_on_failure

--- a/frontend/app/views/spree/checkout/_payment.html.erb
+++ b/frontend/app/views/spree/checkout/_payment.html.erb
@@ -63,5 +63,12 @@
 
 <div class="form-buttons" data-hook="buttons">
   <%= submit_tag t('spree.save_and_continue'), class: 'continue button primary' %>
+  <% if try_spree_current_user %>
+    <span data-hook="save_user_payment_source">
+      &nbsp; &nbsp;
+      <%= check_box_tag 'save_user_payment_source', '1', true %>
+      <%= label_tag :save_user_payment_source, t('spree.save_my_payment_source') %>
+    </span>
+  <% end %>
   <script>Spree.disableSaveOnClick();</script>
 </div>

--- a/frontend/spec/controllers/spree/checkout_controller_spec.rb
+++ b/frontend/spec/controllers/spree/checkout_controller_spec.rb
@@ -272,6 +272,24 @@ describe Spree::CheckoutController, type: :controller do
             expect(order.payments).to be_empty
           end
         end
+
+        context 'with user checked the save payment source option' do
+          let(:params_save_payment_source) { params.merge({ save_user_payment_source: '1' }) }
+
+          it "will set temporary_payment_source to false" do
+            expect {
+              post :update, params: params_save_payment_source
+            }.to change{ order.temporary_payment_source }.to(false)
+          end
+        end
+
+        context 'with user not checked the save payment source option' do
+          it "will set temporary_payment_source to true" do
+            expect {
+              post :update, params: params
+            }.to change{ order.temporary_payment_source }.to(true)
+          end
+        end
       end
 
       context "when in the confirm state" do


### PR DESCRIPTION
following up on #1584 (finally) this PR will update the temp cc and introduce an option for users to save the creditcard profile in the wallet. 

- [ ] think about subscriptions and how we can provide a hook for non stored payment options