### PR TITLE
[WIP] Add payment redirect support for checkout

### DIFF
--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -159,6 +159,11 @@ module Spree
       payment_method.try!(:store_credit?)
     end
 
+    # @return [String] the (computed) redirection url for offsite payment. returning nil for onsite payment methods
+    def redirect_url
+      payment_method&.redirect_url(self)
+    end
+
     private
 
     def source_actions

--- a/core/app/models/spree/payment_method.rb
+++ b/core/app/models/spree/payment_method.rb
@@ -265,6 +265,11 @@ module Spree
       is_a? Spree::PaymentMethod::StoreCredit
     end
 
+    # provides hook for redirecting to offsite payment method.
+    def redirect_url(_payment)
+      nil
+    end
+
     protected
 
     # Represents the gateway class of this payment method

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -462,6 +462,15 @@ module Spree
     # Enumerable of taxons adhering to the present_taxon_class interface
     class_name_attribute :taxon_attachment_module, default: 'Spree::Taxon::PaperclipAttachment'
 
+    # Handler for handling the confirm callback for payment gateways
+    # `Spree::PaymentGatewayConfirmHandler`
+    # is the default.
+    #
+    # @!attribute[rw] params
+    # @return
+    class_name_attribute :payment_gateway_confirm_handler_class, default: 'Spree::PaymentGatewayConfirmHandler'
+    class_name_attribute :payment_gateway_cancel_handler_class, default: 'Spree::PaymentGatewayCancelHandler'
+
     # Allows providing your own class instance for generating order numbers.
     #
     # @!attribute [rw] order_number_generator

--- a/core/lib/spree/core/controller_helpers/payment_gateway_callbacks.rb
+++ b/core/lib/spree/core/controller_helpers/payment_gateway_callbacks.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Spree
+  module Core
+    module ControllerHelpers
+      module PaymentGatewayCallbacks
+      end
+    end
+  end
+end

--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -31,6 +31,7 @@ module Spree
       if update_order
 
         assign_temp_address
+        return if follow_payment_redirect
 
         unless transition_forward
           redirect_on_failure
@@ -280,6 +281,16 @@ module Spree
       try_spree_current_user.wallet.wallet_payment_sources
         .map(&:payment_source)
         .select { |ps| ps.is_a?(Spree::CreditCard) }
+    end
+
+    def follow_payment_redirect
+      return unless params[:state] == "payment"
+
+      payment = @order.payments.valid.last
+      if redirect_url = payment.try(:redirect_url)
+        redirect_to redirect_url
+        true
+      end
     end
   end
 end

--- a/frontend/app/controllers/spree/payment_gateway_callback_controller.rb
+++ b/frontend/app/controllers/spree/payment_gateway_callback_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Spree
+  class PaymentGatewayCallbackController < Spree::StoreController
+    def confirm
+      Spree::Config.payment_gateway_confirm_handler_class.new(params).call
+    end
+
+    def cancel
+      Spree::Config.payment_gateway_cancel_handler_class.new(params).call
+    end
+  end
+end

--- a/frontend/config/routes.rb
+++ b/frontend/config/routes.rb
@@ -21,6 +21,9 @@ Spree::Core::Engine.routes.draw do
     resources :coupon_codes, only: :create
   end
 
+  post '/payment/confirm', controller: 'payment_gateway_callback#confirm', as: :confirm_payment_callback
+  get '/payment/cancel', controller: 'payment_gateway_callback#cancel', as: :cancel_payment_callback
+
   get '/cart', to: 'orders#edit', as: :cart
   patch '/cart', to: 'orders#update', as: :update_cart
   put '/cart/empty', to: 'orders#empty', as: :empty_cart

--- a/frontend/spec/controllers/spree/checkout_controller_spec.rb
+++ b/frontend/spec/controllers/spree/checkout_controller_spec.rb
@@ -458,6 +458,20 @@ describe Spree::CheckoutController, type: :controller do
         end
       end
     end
+
+    context "Using a payment method with a redirect url" do
+      let!(:payment_method) { create(:check_payment_method) }
+      before do
+        allow_any_instance_of(Spree::PaymentMethod).to receive_messages redirect_url: "http://example.com"
+        allow(controller).to receive_messages current_order: order
+        order.update! user: user
+      end
+
+      it "redirects to the payment method site" do
+        patch :update, params: { state: "payment", order: { payments_attributes: [payment_method_id: payment_method.id] } }
+        expect(response).to redirect_to("http://example.com")
+      end
+    end
   end
 
   context "When last inventory item has been purchased" do


### PR DESCRIPTION
`CheckoutController` never had the concept of redirecting the user to the "offsite" payment method site. This situation was handled in various bad ways in the past, mostly with the
substitution of the checkout submit button with a link tag, using some JS.

This PR adds the possibility to redirect if the active payment wants to redirect to its site, before proceeding to the next checkout step.

Based on the work Alessandro Lepore did for solidus_paybright

- [ ] add guides samples
- [ ] add configuration for base callback webhooks