### PR TITLE
Fix double highlight on admin menu when Product Stock tab is active

### DIFF
--- a/backend/app/helpers/spree/admin/navigation_helper.rb
+++ b/backend/app/helpers/spree/admin/navigation_helper.rb
@@ -77,6 +77,11 @@ module Spree
         if options[:css_class]
           css_classes << options[:css_class]
         end
+
+        if params[:product_slug].present? && link.include?('Stock')
+          css_classes.delete('selected')
+        end
+
         content_tag('li', link + (yield if block_given?), class: css_classes.join(' ') )
       end
 


### PR DESCRIPTION
Refs: #2950

Here's a screenshot to demonstrate how the menu looks after the proposed patch

![screenshot_2018-11-22 store stock - apache baseball jersey - products](https://user-images.githubusercontent.com/9470839/48918554-b32c5480-ee63-11e8-988e-c19847a4d240.png)

Open to suggestions! :raised_hands:
