### PR TITLE
Fix "Stock" admin nav double highlight

### DIFF
--- a/backend/app/models/spree/backend_configuration.rb
+++ b/backend/app/models/spree/backend_configuration.rb
@@ -115,6 +115,7 @@ module Spree
           condition: -> { can?(:admin, Spree::StockItem) },
           label: :stock,
           url: :admin_stock_items_path,
+          match_path: '/stock_items',
           position: 3
         ),
         MenuItem.new(

--- a/backend/app/models/spree/backend_configuration.rb
+++ b/backend/app/models/spree/backend_configuration.rb
@@ -22,7 +22,7 @@ module Spree
 
     # An item which should be drawn in the admin menu
     class MenuItem
-      attr_reader :icon, :label, :partial, :condition, :sections, :url
+      attr_reader :icon, :label, :partial, :condition, :sections, :url, :match_path
 
       attr_accessor :position
 
@@ -39,6 +39,8 @@ module Spree
       # @param url [String] A url where this link should send the user to
       # @param position [Integer] The position in which the menu item should render
       #   nil will cause the item to render last
+      # @param match_path [String, Regexp] (nil) If the {url} to determine the active tab is ambigous
+      #   you can pass a String or Regexp to identify this menu item
       def initialize(
         sections,
         icon,
@@ -46,7 +48,8 @@ module Spree
         label: nil,
         partial: nil,
         url: nil,
-        position: nil
+        position: nil,
+        match_path: nil
       )
 
         @condition = condition || -> { true }
@@ -56,6 +59,7 @@ module Spree
         @partial = partial
         @url = url
         @position = position
+        @match_path = match_path
       end
     end
 

--- a/backend/app/views/spree/admin/shared/_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_tabs.html.erb
@@ -5,7 +5,8 @@
         *menu_item.sections,
         icon: menu_item.icon,
         label: menu_item.label,
-        url: menu_item.url.is_a?(Symbol) ? spree.public_send(menu_item.url) : menu_item.url
+        url: menu_item.url.is_a?(Symbol) ? spree.public_send(menu_item.url) : menu_item.url,
+        match_path: menu_item.match_path,
       ) do
     %>
       <%- render partial: menu_item.partial if menu_item.partial %>

--- a/backend/spec/models/spree/backend_configuration/menu_item_spec.rb
+++ b/backend/spec/models/spree/backend_configuration/menu_item_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Spree::BackendConfiguration::MenuItem do
+  describe '#match_path' do
+    subject do
+      described_class.new([], nil, {
+        match_path: '/stock_items'
+      }).match_path
+    end
+
+    it 'can be read' do
+      is_expected.to eq('/stock_items')
+    end
+  end
+end

--- a/backend/spec/models/spree/backend_configuration_spec.rb
+++ b/backend/spec/models/spree/backend_configuration_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Spree::BackendConfiguration do
+  describe '#menu_items' do
+    subject do
+      described_class.new.menu_items
+    end
+
+    describe 'menu tab for stock items' do
+      let(:stock_menu_item) do
+        subject.detect { |item| item.label == :stock }
+      end
+
+      # Regression for https://github.com/solidusio/solidus/issues/2950
+      it 'has match_path set to /stock_items' do
+        expect(stock_menu_item.match_path).to eq('/stock_items')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Without setting `match_path` the `tab` helper uses the current controller name as criteria to activate the tab in the menu. Since the stock items controller can be accessed for a single product or all products we need to make sure it only matches the `/admin/stock_items` path for the "Stock" menu tab.

<img width="1552" alt="store stock - apache baseball jersey - products 2018-11-22 22-05-07" src="https://user-images.githubusercontent.com/42868/48921827-ba268780-eea2-11e8-88bf-d5b78839ae23.png">
