### PR TITLE
Prevent multiple refund creations with accidental double clicks

### DIFF
--- a/backend/app/views/spree/admin/refunds/new.html.erb
+++ b/backend/app/views/spree/admin/refunds/new.html.erb
@@ -35,7 +35,7 @@
     </div>
 
     <div class="form-buttons filter-actions actions" data-hook="buttons">
-      <%= button_tag Spree::Refund.model_name.human, class: 'btn btn-primary' %>
+      <%= f.submit Spree::Refund.model_name.human, class: 'btn btn-primary' %>
       <%= link_to t('spree.actions.cancel'), admin_order_payments_url(@refund.payment.order), class: 'btn btn-primary' %>
     </div>
   </fieldset>

--- a/backend/spec/features/admin/orders/new_refund_spec.rb
+++ b/backend/spec/features/admin/orders/new_refund_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'New Refund creation', :js do
+  stub_authorization!
+
+  let(:order) { create :order_ready_to_ship }
+  let(:payment) { order.payments.first }
+  let(:amount) { '10.99' }
+  let!(:reason) { create :refund_reason }
+
+  it 'creates a new refund' do
+    visit spree.new_admin_order_payment_refund_path(order, payment)
+    expect(page).not_to have_selector 'td', text: amount
+    within '.new_refund' do
+      fill_in 'refund_amount', with: amount
+      select reason.name, from: 'Reason'
+      click_button 'Refund'
+    end
+    expect(page).to have_content 'Refund has been successfully created!'
+    expect(page).to have_selector 'td', text: amount
+  end
+
+  it 'disables the button at submit' do
+    visit spree.new_admin_order_payment_refund_path(order, payment)
+    page.execute_script "$('form').submit(function(e) { e.preventDefault()})"
+    within '.new_refund' do
+      fill_in 'refund_amount', with: amount
+      select reason.name, from: 'Reason'
+      click_button 'Refund'
+      expect(find('input[type="submit"]')).to be_disabled
+    end
+  end
+end


### PR DESCRIPTION
When creating refunds, if the admin user accidentally clicks multiple times on the submit button then multiple refunds may be created. 

This PR avoids the issue by disabling the button after click.