### PR TITLE
Remove devise translations

### DIFF
--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -12,13 +12,11 @@ en:
         spree/fulfilment_changer:
           attributes:
             current_shipment:
-              can_not_have_backordered_inventory_units: has backordered inventory
-                units
+              can_not_have_backordered_inventory_units: has backordered inventory units
               has_already_been_shipped: has already been shipped
             desired_shipment:
               can_not_transfer_within_same_shipment: can not be same as current shipment
-              not_enough_stock_at_desired_location: not enough stock in desired stock
-                location
+              not_enough_stock_at_desired_location: not enough stock in desired stock location
   activerecord:
     attributes:
       spree/address:
@@ -206,8 +204,7 @@ en:
         description: Must be the customer's first order
       spree/promotion/rules/first_repeat_purchase_since:
         description: Available only to user who have not purchased in a while
-        form_text: 'Apply this promotion to users whose last order was more than X
-          days ago: '
+        form_text: 'Apply this promotion to users whose last order was more than X days ago: '
       spree/promotion/rules/item_total:
         description: Order total meets these criteria
       spree/promotion/rules/landing_page:
@@ -408,17 +405,14 @@ en:
         spree/calculator/tiered_flat_rate:
           attributes:
             base:
-              keys_should_be_positive_number: Tier keys should all be numbers larger
-                than 0
+              keys_should_be_positive_number: Tier keys should all be numbers larger than 0
             preferred_tiers:
               should_be_hash: should be a hash
         spree/calculator/tiered_percent:
           attributes:
             base:
-              keys_should_be_positive_number: Tier keys should all be numbers larger
-                than 0
-              values_should_be_percent: Tier values should all be percentages between
-                0% and 100%
+              keys_should_be_positive_number: Tier keys should all be numbers larger than 0
+              values_should_be_percent: Tier values should all be percentages between 0% and 100%
             preferred_tiers:
               should_be_hash: should be a hash
         spree/classification:
@@ -433,8 +427,7 @@ en:
         spree/inventory_unit:
           attributes:
             base:
-              cannot_destroy_shipment_state: Cannot destroy an inventory unit for
-                a %{state} shipment
+              cannot_destroy_shipment_state: Cannot destroy an inventory unit for a %{state} shipment
             state:
               cannot_destroy: Cannot destroy a %{state} inventory unit
         spree/line_item:
@@ -457,21 +450,17 @@ en:
         spree/reimbursement:
           attributes:
             base:
-              return_items_order_id_does_not_match: One or more of the return items
-                specified do not belong to the same order as the reimbursement.
+              return_items_order_id_does_not_match: One or more of the return items specified do not belong to the same order as the reimbursement.
         spree/return_item:
           attributes:
             inventory_unit:
-              other_completed_return_item_exists: "%{inventory_unit_id} has already
-                been taken by return item %{return_item_id}"
+              other_completed_return_item_exists: "%{inventory_unit_id} has already been taken by return item %{return_item_id}"
             reimbursement:
-              cannot_be_associated_unless_accepted: cannot be associated to a return
-                item that is not accepted.
+              cannot_be_associated_unless_accepted: cannot be associated to a return item that is not accepted.
         spree/shipment:
           attributes:
             base:
-              cannot_remove_items_shipment_state: Cannot remove items from a %{state}
-                shipment
+              cannot_remove_items_shipment_state: Cannot remove items from a %{state} shipment
             state:
               cannot_destroy: Cannot destroy a %{state} shipment
         spree/store:
@@ -807,8 +796,7 @@ en:
       payments:
         source_forms:
           storecredit:
-            not_supported: Creating store credit payments via the admin is not currently
-              supported.
+            not_supported: Creating store credit payments via the admin is not currently supported.
       prices:
         any_country: Any Country
         edit:
@@ -860,8 +848,7 @@ en:
           amount_used_cannot_be_greater: cannot be greater than the credited amount
           amount_used_not_zero: is greater than zero. Can not delete store credit
           cannot_be_modified: cannot be modified
-          cannot_change_used_store_credit: Store credit that has been claimed cannot
-            be changed
+          cannot_change_used_store_credit: Store credit that has been claimed cannot be changed
           update_reason_required: A reason for the change must be selected
         history: Store credit history
         invalidate_store_credit: Invalidating store credit
@@ -926,10 +913,8 @@ en:
         edit:
           api_access: API Access
           clear_key: Clear key
-          confirm_clear_key: Are you sure you want to clear this user's API key? It
-            will invalidate the existing key.
-          confirm_regenerate_key: Are you sure you want to regenerate this user's
-            API key? It will invalidate the existing key.
+          confirm_clear_key: Are you sure you want to clear this user's API key? It will invalidate the existing key.
+          confirm_regenerate_key: Are you sure you want to regenerate this user's API key? It will invalidate the existing key.
           generate_key: Generate API key
           key: Key
           no_key: No key
@@ -942,8 +927,7 @@ en:
         form:
           dimensions: Dimensions
           pricing: Pricing
-          pricing_hint: These values are populated from the product details page and
-            can be overridden below
+          pricing_hint: These values are populated from the product details page and can be overridden below
           use_product_tax_category: Use Product Tax Category
         new:
           new_variant: New Variant
@@ -1031,8 +1015,7 @@ en:
     both: Both
     calculated_reimbursements: Calculated Reimbursements
     calculator: Calculator
-    calculator_settings_warning: If you are changing the calculator type or preference
-      source, you must save first before you can edit the calculator settings
+    calculator_settings_warning: If you are changing the calculator type or preference source, you must save first before you can edit the calculator settings
     cancel: Cancel
     cancel_inventory: Cancel Items
     canceled: Canceled
@@ -1040,18 +1023,13 @@ en:
     canceler: Canceler
     cancellation: Cancellation
     cannot_create_payment_link: Please define some payment methods first.
-    cannot_create_payment_without_payment_methods_html: You cannot create a payment
-      for an order without any payment methods defined. %{link}
+    cannot_create_payment_without_payment_methods_html: You cannot create a payment for an order without any payment methods defined. %{link}
     cannot_create_returns: Cannot create returns as this order has no shipped units.
     cannot_perform_operation: Cannot perform requested operation
-    cannot_rebuild_shipments_order_completed: Cannot rebuild shipments for a completed
-      order.
-    cannot_rebuild_shipments_shipments_not_pending: Cannot rebuild shipments for an
-      order with non-pending shipments.
-    cannot_set_shipping_method_without_address: Cannot set shipping method until customer
-      details are provided.
-    cannot_update_email: You do not have access to update this user's email address.
-      <br />Please contact a superuser if you need to perform this action.
+    cannot_rebuild_shipments_order_completed: Cannot rebuild shipments for a completed order.
+    cannot_rebuild_shipments_shipments_not_pending: Cannot rebuild shipments for an order with non-pending shipments.
+    cannot_set_shipping_method_without_address: Cannot set shipping method until customer details are provided.
+    cannot_update_email: You do not have access to update this user's email address. <br />Please contact a superuser if you need to perform this action.
     capture: Capture
     capture_events: Capture events
     card_code: Card Code
@@ -1082,8 +1060,7 @@ en:
     city: City
     clear_cache: Clear Cache
     clear_cache_ok: Cache was flushed
-    clear_cache_warning: Clearing cache will temporarily reduce the performance of
-      your store.
+    clear_cache_warning: Clearing cache will temporarily reduce the performance of your store.
     clone: Clone
     close: Close
     closed: Closed
@@ -1101,11 +1078,9 @@ en:
     continue_shopping: Continue shopping
     cost_currency: Cost Currency
     cost_price: Cost Price
-    could_not_connect_to_jirafe: Could not connect to Jirafe to sync data. This will
-      be automatically retried later.
+    could_not_connect_to_jirafe: Could not connect to Jirafe to sync data. This will be automatically retried later.
     could_not_create_customer_return: Could not create customer return
-    could_not_create_stock_movement: There was a problem saving this stock movement.
-      Please try again.
+    could_not_create_stock_movement: There was a problem saving this stock movement. Please try again.
     count_on_hand: Count On Hand
     countries: Countries
     country: Country
@@ -1118,17 +1093,14 @@ en:
       US: United States of America
     coupon: Coupon
     coupon_code: Coupon code
-    coupon_code_already_applied: The coupon code has already been applied to this
-      order
+    coupon_code_already_applied: The coupon code has already been applied to this order
     coupon_code_applied: The coupon code was successfully applied to your order.
-    coupon_code_better_exists: The previously applied coupon code results in a better
-      deal
+    coupon_code_better_exists: The previously applied coupon code results in a better deal
     coupon_code_expired: The coupon code is expired
     coupon_code_max_usage: Coupon code usage limit exceeded
     coupon_code_not_eligible: This coupon code is not eligible for this order
     coupon_code_not_found: The coupon code you entered doesn't exist. Please try again.
-    coupon_code_unknown_error: This coupon code could not be applied to the cart at
-      this time.
+    coupon_code_unknown_error: This coupon code could not be applied to the cart at this time.
     create: Create
     create_a_new_account: Create a new account
     create_one: Create One.
@@ -1159,10 +1131,8 @@ en:
       jirafe:
         app_id: App ID
         app_token: App Token
-        currently_unavailable: Jirafe is currently unavailable. Spree will automatically
-          connect to Jirafe once it is available.
-        explanation: The fields below may already be populated if you chose to register
-          with Jirafe from the admin dashboard.
+        currently_unavailable: Jirafe is currently unavailable. Spree will automatically connect to Jirafe once it is available.
+        explanation: The fields below may already be populated if you chose to register with Jirafe from the admin dashboard.
         header: Jirafe Analytics Settings
         site_id: Site ID
         token: Token
@@ -1178,8 +1148,7 @@ en:
     default_refund_amount: Default Refund Amount
     delete: Delete
     deleted_successfully: Deleted successfully
-    deleted_variants_present: Some line items in this order have products that are
-      no longer available.
+    deleted_variants_present: Some line items in this order have products that are no longer available.
     delivery: Delivery
     depth: Depth
     description: Description
@@ -1219,25 +1188,16 @@ en:
     editing_zone: Editing Zone
     eligibility_errors:
       messages:
-        has_excluded_product: Your cart contains a product that prevents this coupon
-          code from being applied.
-        has_excluded_taxon: Your cart contains a product from an excluded category
-          that prevents this coupon code from being applied.
-        item_total_less_than: This coupon code can't be applied to orders less than
-          %{amount}.
-        item_total_less_than_or_equal: This coupon code can't be applied to orders
-          less than or equal to %{amount}.
+        has_excluded_product: Your cart contains a product that prevents this coupon code from being applied.
+        has_excluded_taxon: Your cart contains a product from an excluded category that prevents this coupon code from being applied.
+        item_total_less_than: This coupon code can't be applied to orders less than %{amount}.
+        item_total_less_than_or_equal: This coupon code can't be applied to orders less than or equal to %{amount}.
         limit_once_per_user: This coupon code can only be used once per user.
-        missing_product: This coupon code can't be applied because you don't have
-          all of the necessary products in your cart.
-        missing_taxon: You need to add a product from all applicable categories before
-          applying this coupon code.
-        no_applicable_products: You need to add an applicable product before applying
-          this coupon code.
-        no_matching_taxons: You need to add a product from an applicable category
-          before applying this coupon code.
-        no_user_or_email_specified: You need to login or provide your email before
-          applying this coupon code.
+        missing_product: This coupon code can't be applied because you don't have all of the necessary products in your cart.
+        missing_taxon: You need to add a product from all applicable categories before applying this coupon code.
+        no_applicable_products: You need to add an applicable product before applying this coupon code.
+        no_matching_taxons: You need to add a product from an applicable category before applying this coupon code.
+        no_user_or_email_specified: You need to login or provide your email before applying this coupon code.
         no_user_specified: You need to login before applying this coupon code.
         not_first_order: This coupon code can only be applied to your first order.
     email: Email
@@ -1249,12 +1209,10 @@ en:
     error: error
     errors:
       messages:
-        cannot_delete_finalized_stock_location: Stock Location cannot be destroyed
-          if you have open stock transfers.
+        cannot_delete_finalized_stock_location: Stock Location cannot be destroyed if you have open stock transfers.
         could_not_create_taxon: Could not create taxon
         no_payment_methods_available: No payment methods are configured for this environment
-        no_shipping_methods_available: No shipping methods available for selected
-          location, please change your address and try again.
+        no_shipping_methods_available: No shipping methods available for selected location, please change your address and try again.
     errors_prohibited_this_record_from_being_saved:
       one: 1 error prohibited this record from being saved
       other: "%{count} errors prohibited this record from being saved"
@@ -1273,9 +1231,7 @@ en:
         user:
           signup: User signup
     exceptions:
-      count_on_hand_setter: Cannot set count_on_hand manually, as it is set automatically
-        by the recalculate_count_on_hand callback. Please use `update_column(:count_on_hand,
-        value)` instead.
+      count_on_hand_setter: Cannot set count_on_hand manually, as it is set automatically by the recalculate_count_on_hand callback. Please use `update_column(:count_on_hand, value)` instead.
     exchange_for: Exchange For
     excl: excl.
     existing_shipments: Existing shipments
@@ -1326,58 +1282,34 @@ en:
     hide_out_of_stock: Hide out of stock
     hints:
       spree/price:
-        country: 'This determines in what country the price is valid.<br/>Default:
-          Any Country'
-        master_variant: Changing master variant prices will not change variant prices
-          below, but will be used to populate all new variants
-        options: These options are used to create variants in the variants table.
-          They can be changed in the variants tab
+        country: 'This determines in what country the price is valid.<br/>Default: Any Country'
+        master_variant: Changing master variant prices will not change variant prices below, but will be used to populate all new variants
+        options: These options are used to create variants in the variants table. They can be changed in the variants tab
       spree/product:
-        available_on: This sets the availability date for the product. If this value
-          is not set, or it is set to a date in the future, then the product is not
-          available on the storefront.
-        promotionable: 'This determines whether or not promotions can apply to this
-          product.<br/>Default: Checked'
-        shipping_category: 'This determines what kind of shipping this product requires.<br/>
-          Default: Default'
-        tax_category: 'This determines what kind of taxation is applied to this product.<br/>
-          Default: None'
+        available_on: This sets the availability date for the product. If this value is not set, or it is set to a date in the future, then the product is not available on the storefront.
+        promotionable: 'This determines whether or not promotions can apply to this product.<br/>Default: Checked'
+        shipping_category: 'This determines what kind of shipping this product requires.<br/> Default: Default'
+        tax_category: 'This determines what kind of taxation is applied to this product.<br/> Default: None'
       spree/promotion:
-        expires_at: This determines when the promotion expires. <br/> If no value
-          is specified, the promotion will never expire.
-        starts_at: This determines when the promotion can be applied to orders. <br/>
-          If no value is specified, the promotion will be immediately available.
+        expires_at: This determines when the promotion expires. <br/> If no value is specified, the promotion will never expire.
+        starts_at: This determines when the promotion can be applied to orders. <br/> If no value is specified, the promotion will be immediately available.
       spree/stock_location:
-        active: 'This determines whether stock from this location can be used when
-          building packages.<br/> Default: Checked'
-        backorderable_default: 'When checked, stock items in this location will default
-          to allowing backorders.<br/> Default: Unchecked'
-        check_stock_on_transfer: 'When checked, inventory levels will be checked when
-          performing stock transfers.<br/> Default: Checked'
-        fulfillable: 'When unchecked, this indicates that items in this location don''t
-          require actual fulfilment. Stock will not be checked when shipping and emails
-          will not be sent.<br/> Default: Checked'
-        propagate_all_variants: 'When checked, this will create a stock item for in
-          this stock location.<br/> Default: Checked'
-        restock_inventory: 'When checked, returned inventory can be added back to
-          this location''s stock levels.<br/> Default: checked'
+        active: 'This determines whether stock from this location can be used when building packages.<br/> Default: Checked'
+        backorderable_default: 'When checked, stock items in this location will default to allowing backorders.<br/> Default: Unchecked'
+        check_stock_on_transfer: 'When checked, inventory levels will be checked when performing stock transfers.<br/> Default: Checked'
+        fulfillable: 'When unchecked, this indicates that items in this location don''t require actual fulfilment. Stock will not be checked when shipping and emails will not be sent.<br/> Default: Checked'
+        propagate_all_variants: 'When checked, this will create a stock item for in this stock location.<br/> Default: Checked'
+        restock_inventory: 'When checked, returned inventory can be added back to this location''s stock levels.<br/> Default: checked'
       spree/store:
-        available_locales: This determines which locales are available for your customers
-          to choose from in the storefront.
-        cart_tax_country_iso: 'This determines which country is used for taxes on
-          carts (orders which don''t yet have an address).<br/> Default: None.'
+        available_locales: This determines which locales are available for your customers to choose from in the storefront.
+        cart_tax_country_iso: 'This determines which country is used for taxes on carts (orders which don''t yet have an address).<br/> Default: None.'
       spree/tax_rate:
-        validity_period: This determines the validity period within which the tax
-          rate is valid and will be applied to eligible items. <br /> If no start
-          date value is specified, the tax rate will be immediately available. <br
-          /> If no expiration date value is specified, the tax rate will never expire
+        validity_period: This determines the validity period within which the tax rate is valid and will be applied to eligible items. <br /> If no start date value is specified, the tax rate will be immediately available. <br /> If no expiration date value is specified, the tax rate will never expire
       spree/variant:
         deleted: Deleted Variant
         deleted_explanation: This variant was deleted on %{date}.
-        deleted_explanation_with_replacement: This variant was deleted on %{date}.
-          It has since been replaced by another with the same SKU.
-        tax_category: 'This determines what kind of taxation is applied to this variant.<br/>
-          Default: Use tax category of the product associated with this variant'
+        deleted_explanation_with_replacement: This variant was deleted on %{date}. It has since been replaced by another with the same SKU.
+        tax_category: 'This determines what kind of taxation is applied to this variant.<br/> Default: Use tax category of the product associated with this variant'
     home: Home
     i18n:
       available_locales: Available Locales
@@ -1396,15 +1328,12 @@ en:
     identifier: Identifier
     image: Image
     images: Images
-    implement_eligible_for_return: 'Must implement #eligible_for_return? for your
-      EligibilityValidator.'
-    implement_requires_manual_intervention: 'Must implement #requires_manual_intervention?
-      for your EligibilityValidator.'
+    implement_eligible_for_return: 'Must implement #eligible_for_return? for your EligibilityValidator.'
+    implement_requires_manual_intervention: 'Must implement #requires_manual_intervention? for your EligibilityValidator.'
     inactive: Inactive
     incl: incl.
     included_in_price: Included in Price
-    included_price_validation: cannot be selected unless you have set a Default Tax
-      Zone
+    included_price_validation: cannot be selected unless you have set a Default Tax Zone
     incomplete: Incomplete
     info_number_of_skus_not_shown:
       one: and one other
@@ -1413,8 +1342,7 @@ en:
     instructions_to_reset_password: Please enter your email on the form below
     insufficient_stock: Insufficient stock available, only %{on_hand} remaining
     insufficient_stock_for_order: Insufficient stock for order
-    insufficient_stock_lines_present: Some line items in this order have insufficient
-      quantity.
+    insufficient_stock_lines_present: Some line items in this order have insufficient quantity.
     intercept_email_address: Intercept Email Address
     intercept_email_instructions: Override email recipient and replace with this address.
     internal_name: Internal Name
@@ -1444,8 +1372,7 @@ en:
       operators:
         gt: greater than
         gte: greater than or equal to
-    items_cannot_be_shipped: We are unable to calculate shipping rates for the selected
-      items.
+    items_cannot_be_shipped: We are unable to calculate shipping rates for the selected items.
     items_in_rmas: Items in RMA's (Return Merchandise Authorizations)
     items_reimbursed: Items reimbursed
     items_to_be_reimbursed: Items to be reimbursed
@@ -1480,8 +1407,7 @@ en:
     logs: Logs
     look_for_similar_items: Look for similar items
     make_refund: Make refund
-    make_sure_the_above_reimbursement_amount_is_correct: Make sure the above reimbursement
-      amount is correct
+    make_sure_the_above_reimbursement_amount_is_correct: Make sure the above reimbursement amount is correct
     manage_promotion_categories: Manage Promotion Categories
     manage_stock: Store Stock
     manage_variants: Manage Variants
@@ -1509,8 +1435,7 @@ en:
     name: Name
     name_on_card: Name on card
     name_or_sku: Name or SKU (enter at least first 4 characters of product name)
-    negative_movement_absent_item: Cannot create negative movement for absent stock
-      item.
+    negative_movement_absent_item: Cannot create negative movement for absent stock item.
     new: New
     new_adjustment: New Adjustment
     new_adjustment_reason: New Adjustment Reason
@@ -1552,8 +1477,7 @@ en:
     no_actions_added: No actions added
     no_images_found: No images found
     no_inventory_selected: No inventory selected
-    no_option_values_on_product_html: This product has no associated option values.
-      Add some to it through Option Types in the %{link}.
+    no_option_values_on_product_html: This product has no associated option values. Add some to it through Option Types in the %{link}.
     no_orders_found: No orders found
     no_payment_found: No payment found
     no_payment_methods_found: No payment methods found
@@ -1578,12 +1502,10 @@ en:
     normal_amount: Normal Amount
     not: not
     not_available: N/A
-    not_enough_stock: There is not enough inventory at the source location to complete
-      this transfer.
+    not_enough_stock: There is not enough inventory at the source location to complete this transfer.
     not_found: "%{resource} is not found"
     note: Note
-    note_already_received_a_refund: 'Note: This order has already received a refund.  Make
-      sure the above reimbursement amount is correct.'
+    note_already_received_a_refund: 'Note: This order has already received a refund.  Make sure the above reimbursement amount is correct.'
     notice_messages:
       product_cloned: Product has been cloned
       product_deleted: Product has been deleted
@@ -1617,16 +1539,14 @@ en:
     order_mailer:
       cancel_email:
         dear_customer: Dear Customer,
-        instructions: Your order has been CANCELED.  Please retain this cancellation
-          information for your records.
+        instructions: Your order has been CANCELED.  Please retain this cancellation information for your records.
         order_summary_canceled: Order Summary [CANCELED]
         subject: Cancellation of Order
         subtotal: 'Subtotal:'
         total: 'Order Total:'
       confirm_email:
         dear_customer: Dear Customer,
-        instructions: Please review and retain the following order information for
-          your records.
+        instructions: Please review and retain the following order information for your records.
         order_summary: Order Summary
         subject: Order Confirmation
         subtotal: 'Subtotal:'
@@ -1634,8 +1554,7 @@ en:
         total: 'Order Total:'
       inventory_cancellation:
         dear_customer: Dear Customer,
-        instructions: Some items in your order have been CANCELED.  Please retain
-          this cancellation information for your records.
+        instructions: Some items in your order have been CANCELED.  Please retain this cancellation information for your records.
         order_summary_canceled: Canceled Items
         subject: Cancellation of Items
     order_mutex_admin_error: Order is being modified by someone else. Please try again.
@@ -1681,15 +1600,11 @@ en:
     payment_identifier: Payment Identifier
     payment_information: Payment Information
     payment_method: Payment Method
-    payment_method_not_supported: That payment method is unsupported. Please choose
-      another one.
-    payment_method_settings_warning: If you are changing the payment method type,
-      you must save first before you can edit the payment method settings
+    payment_method_not_supported: That payment method is unsupported. Please choose another one.
+    payment_method_settings_warning: If you are changing the payment method type, you must save first before you can edit the payment method settings
     payment_methods: Payment Methods
-    payment_processing_failed: Payment could not be processed, please check the details
-      you entered
-    payment_processor_choose_banner_text: If you need help choosing a payment processor,
-      please visit
+    payment_processing_failed: Payment could not be processed, please check the details you entered
+    payment_processor_choose_banner_text: If you need help choosing a payment processor, please visit
     payment_processor_choose_link: our payments page
     payment_state: Payment State
     payment_states:
@@ -1733,8 +1648,7 @@ en:
     product: Product
     product_details: Product Details
     product_has_no_description: This product has no description
-    product_not_available_in_this_currency: This product is not available in the selected
-      currency.
+    product_not_available_in_this_currency: This product is not available in the selected currency.
     product_properties: Product Properties
     product_rule:
       choose_products: Choose products
@@ -1766,9 +1680,7 @@ en:
         any: Match any of these rules
     promotion_rule: Promotion Rule
     promotion_successfully_created: Promotion has been successfully created!
-    promotion_total_changed_before_complete: One or more of the promotions on your
-      order have become ineligible and were removed. Please check the new order amounts
-      and try again.
+    promotion_total_changed_before_complete: One or more of the promotions on your order have become ineligible and were removed. Please check the new order amounts and try again.
     promotion_uses: Promotion uses
     promotionable: Promotable
     promotions: Promotions
@@ -1846,24 +1758,20 @@ en:
     resumed: Resumed
     return: return
     return_authorization: Return Merchandise Authorization
-    return_authorization_fire_error: Cannot perform this action on return merchandise
-      authorization
+    return_authorization_fire_error: Cannot perform this action on return merchandise authorization
     return_authorization_states:
       authorized: Authorized
       canceled: Canceled
     return_authorization_updated: Return merchandise authorization updated
     return_authorizations: Return Merchandise Authorizations
     return_item_inventory_unit_ineligible: Return item's inventory unit must be shipped
-    return_item_inventory_unit_reimbursed: Return item's inventory unit is already
-      reimbursed
+    return_item_inventory_unit_reimbursed: Return item's inventory unit is already reimbursed
     return_item_order_not_completed: Return item's order must be completed
     return_item_rma_ineligible: Return item requires an RMA
     return_item_time_period_ineligible: Return item is outside the eligible time period
     return_items: Return Items
-    return_items_cannot_be_associated_with_multiple_orders: Return items cannot be
-      associated with multiple orders.
-    return_items_cannot_be_created_for_inventory_units_that_are_already_awaiting_exchange: Return
-      items cannot be created for inventory units that are already awaiting exchange.
+    return_items_cannot_be_associated_with_multiple_orders: Return items cannot be associated with multiple orders.
+    return_items_cannot_be_created_for_inventory_units_that_are_already_awaiting_exchange: Return items cannot be created for inventory units that are already awaiting exchange.
     return_number: Return Number
     return_quantity: Return Quantity
     return_reasons: Return Reasons
@@ -1970,11 +1878,9 @@ en:
     special_instructions: Special Instructions
     split: Split
     split_failed: Unable to complete split
-    spree_gateway_error_flash_for_checkout: There was a problem with your payment
-      information. Please check your information and try again.
+    spree_gateway_error_flash_for_checkout: There was a problem with your payment information. Please check your information and try again.
     ssl:
-      change_protocol: Please switch to using HTTP (rather than HTTPS) and retry this
-        request.
+      change_protocol: Please switch to using HTTP (rather than HTTPS) and retry this request.
     start: Start
     state: State
     state_based: State Based
@@ -1988,11 +1894,9 @@ en:
     stock_location: Stock Location
     stock_location_info: Stock location info
     stock_locations: Stock Locations
-    stock_locations_need_a_default_country: You must create a default country before
-      creating a stock location.
+    stock_locations_need_a_default_country: You must create a default country before creating a stock location.
     stock_management: Product Stock
-    stock_management_requires_a_stock_location: Please create a stock location in
-      order to manage stock.
+    stock_management_requires_a_stock_location: Please create a stock location in order to manage stock.
     stock_movements: Stock Movements
     stock_movements_for_stock_location: Stock Movements for %{stock_location_name}
     stock_not_below_zero: Stock must not be below zero.
@@ -2016,8 +1920,7 @@ en:
         invalidate: Invalidated
         void: Credit
       errors:
-        cannot_invalidate_uncaptured_authorization: Cannot invalidate a store credit
-          with an uncaptured authorization
+        cannot_invalidate_uncaptured_authorization: Cannot invalidate a store credit with an uncaptured authorization
         unable_to_fund: Unable to pay for order using store credits
       expiring: Expiring
       insufficient_authorized_amount: Unable to capture more than authorized amount
@@ -2028,8 +1931,7 @@ en:
       successful_action: Successful store credit %{action}
       unable_to_credit: 'Unable to credit code: %{auth_code}'
       unable_to_find: Could not find store credit
-      unable_to_find_for_action: 'Could not find store credit for auth code: %{auth_code}
-        for action: %{action}'
+      unable_to_find_for_action: 'Could not find store credit for auth code: %{auth_code} for action: %{action}'
       unable_to_void: 'Unable to void code: %{auth_code}'
       user_has_no_store_credits: User does not have any available store credit
     store_credit_category:
@@ -2051,8 +1953,7 @@ en:
     tax_category: Tax Category
     tax_code: Tax Code
     tax_included: Tax (incl.)
-    tax_rate_amount_explanation: Tax rates are a decimal amount to aid in calculations,
-      (i.e. if the tax rate is 5% then enter 0.05)
+    tax_rate_amount_explanation: Tax rates are a decimal amount to aid in calculations, (i.e. if the tax rate is 5% then enter 0.05)
     tax_rates: Tax Rates
     taxon: Taxon
     taxon_edit: Edit Taxon
@@ -2066,10 +1967,8 @@ en:
     taxonomies: Taxonomies
     taxonomy: Taxonomy
     taxonomy_edit: Edit taxonomy
-    taxonomy_tree_error: The requested change has not been accepted and the tree has
-      been returned to its previous state, please try again.
-    taxonomy_tree_instruction: "* Right click a child in the tree to access the menu
-      for adding, deleting or sorting a child."
+    taxonomy_tree_error: The requested change has not been accepted and the tree has been returned to its previous state, please try again.
+    taxonomy_tree_instruction: "* Right click a child in the tree to access the menu for adding, deleting or sorting a child."
     taxons: Taxons
     test: Test
     test_mailer:
@@ -2078,12 +1977,9 @@ en:
         message: If you have received this email, then your email settings are correct.
         subject: Test Mail
     test_mode: Test Mode
-    thank_you_for_your_order: Thank you for your business.  Please print out a copy
-      of this confirmation page for your records.
-    there_are_no_items_for_this_order: There are no items for this order. Please add
-      an item to the order to continue.
-    there_were_problems_with_the_following_fields: There were problems with the following
-      fields
+    thank_you_for_your_order: Thank you for your business.  Please print out a copy of this confirmation page for your records.
+    there_are_no_items_for_this_order: There are no items for this order. Please add an item to the order to continue.
+    there_were_problems_with_the_following_fields: There were problems with the following fields
     this_order_has_already_received_a_refund: This order has already received a refund
     thumbnail: Thumbnail
     tiered_flat_rate: Tiered Flat Rate
@@ -2114,8 +2010,7 @@ en:
     type: Type
     type_to_search: Type to search
     unable_to_connect_to_gateway: Unable to connect to gateway.
-    unable_to_create_reimbursements: Unable to create reimbursements because there
-      are items pending manual intervention.
+    unable_to_create_reimbursements: Unable to create reimbursements because there are items pending manual intervention.
     unable_to_find_all_inventory_units: Unable to find all specified inventory units
     under_price: Under %{price}
     unfinalize_all_adjustments: Unfinalize All Adjustments
@@ -2141,12 +2036,9 @@ en:
       choose_users: Choose Users
     users: Users
     validation:
-      cannot_be_less_than_shipped_units: cannot be less than the number of shipped
-        units.
-      cannot_destroy_line_item_as_inventory_units_have_shipped: Cannot destroy line
-        item as some inventory units have shipped.
-      exceeds_available_stock: exceeds available stock. Please ensure line items have
-        a valid quantity.
+      cannot_be_less_than_shipped_units: cannot be less than the number of shipped units.
+      cannot_destroy_line_item_as_inventory_units_have_shipped: Cannot destroy line item as some inventory units have shipped.
+      exceeds_available_stock: exceeds available stock. Please ensure line items have a valid quantity.
       is_too_large: is too large -- stock on hand cannot cover requested quantity!
       must_be_int: must be an integer
       must_be_non_negative: must be a non-negative value
@@ -2174,8 +2066,7 @@ en:
     you_cannot_undo_action: You will not be able to undo this action
     you_have_no_orders_yet: You have no orders yet
     your_cart_is_empty: Your cart is empty
-    your_order_is_empty_add_product: Your order is empty, please search for and add
-      a product above
+    your_order_is_empty_add_product: Your order is empty, please search for and add a product above
     zip: Zip
     zipcode: Zip Code
     zone: Zone

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -718,49 +718,6 @@ en:
       user:
         one: User
         other: Users
-  devise:
-    confirmations:
-      confirmed: Your account was successfully confirmed. You are now signed in.
-      send_instructions: You will receive an email with instructions about how to
-        confirm your account in a few minutes.
-    failure:
-      inactive: Your account was not activated yet.
-      invalid: Invalid email or password.
-      invalid_token: Invalid authentication token.
-      locked: Your account is locked.
-      timeout: Your session expired, please sign in again to continue.
-      unauthenticated: You need to sign in or sign up before continuing.
-      unconfirmed: You have to confirm your account before continuing.
-    mailer:
-      confirmation_instructions:
-        subject: Confirmation Instructions
-      reset_password_instructions:
-        subject: Reset Password Instructions
-      unlock_instructions:
-        subject: Unlock Instructions
-    oauth_callbacks:
-      failure: Could not authorize you from %{kind} because %{reason}.
-      success: Successfully authorized from %{kind} account.
-    unlocks:
-      send_instructions: You will receive an email with instructions about how to
-        unlock your account in a few minutes.
-      unlocked: Your account was successfully unlocked. You are now signed in.
-    user_passwords:
-      user:
-        cannot_be_blank: Your password cannot be blank.
-        send_instructions: You will receive an email with instructions about how to
-          reset your password in a few minutes.
-        updated: Your password was changed successfully. You are now signed in.
-    user_registrations:
-      destroyed: Bye! Your account was successfully cancelled. We hope to see you
-        again soon.
-      inactive_signed_up: You have signed up successfully. However, we could not sign
-        you in because your account is %{reason}.
-      signed_up: Welcome! You have signed up successfully.
-      updated: You updated your account successfully.
-    user_sessions:
-      signed_in: Signed in successfully.
-      signed_out: Signed out successfully.
   errors:
     messages:
       already_confirmed: was already confirmed


### PR DESCRIPTION
This PR remove devise translations, since they are also removed in the solidus_i18n project (see https://github.com/solidusio/solidus_i18n/pull/107) and they are provided by the devise_i18n gem (https://github.com/tigrish/devise-i18n).