### PR TITLE
Use Spree::Variant#should_track_inventory? to disable 'Count on hand' input

### DIFF
--- a/backend/app/views/spree/admin/stock_items/_stock_management.html.erb
+++ b/backend/app/views/spree/admin/stock_items/_stock_management.html.erb
@@ -72,7 +72,7 @@
             </colgroup>
             <% variant.stock_items.each do |item| %>
               <% if @stock_item_stock_locations.include?(item.stock_location) %>
-                <tr class="js-edit-stock-item stock-item-edit-row" data-variant-id="<%= variant.id %>" data-stock-item="<%= item.to_json %>" data-stock-location-name="<%= item.stock_location.name %>" data-track-inventory="<%= variant.track_inventory %>">
+                <tr class="js-edit-stock-item stock-item-edit-row" data-variant-id="<%= variant.id %>" data-stock-item="<%= item.to_json %>" data-stock-location-name="<%= item.stock_location.name %>" data-track-inventory="<%= variant.should_track_inventory? %>">
                   <%# This is rendered in JS %>
                 </tr>
               <% end %>


### PR DESCRIPTION
Refs: #2960

This patch improves said PR by fixing a bug that enabled the `Count on hand` input without taking into consideration the `Spree::Config.track_inventory_levels` setting.