### PR TITLE
Lint ERB files via HoundCI

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,5 +1,7 @@
 ruby:
   config_file: .rubocop.yml
+erb_lint:
+  enabled: true
 scss:
   enabled: false
 javascript:


### PR DESCRIPTION
Now that [Hound supports ERB](https://github.com/houndci/hound/pull/1641) linting I think it's a good idea to start using that linter in Solidus. 

Linting is done with this tool: https://github.com/Shopify/erb-lint

~Since we are already linting Ruby code with Rubocop I configured hound to use the same rules that we have for the rest of the application.~ See https://github.com/solidusio/solidus/pull/2982#issuecomment-447416364

What do you think?
