### PR TITLE
Normalize API I18n keys

### DIFF
--- a/api/app/controllers/spree/api/shipments_controller.rb
+++ b/api/app/controllers/spree/api/shipments_controller.rb
@@ -113,7 +113,7 @@ module Spree
         )
 
         if fulfilment_changer.run!
-          render json: { success: true, message: t('spree.shipment_transfer_success') }, status: :accepted
+          render json: { success: true, message: t('spree.api.shipment.transfer_success') }, status: :accepted
         else
           render json: { success: false, message: fulfilment_changer.errors.full_messages.to_sentence }, status: :accepted
         end

--- a/api/app/controllers/spree/api/stock_items_controller.rb
+++ b/api/app/controllers/spree/api/stock_items_controller.rb
@@ -77,14 +77,14 @@ module Spree
 
       def adjust_stock_item_count_on_hand(count_on_hand_adjustment)
         if @stock_item.count_on_hand + count_on_hand_adjustment < 0
-          raise StockLocation::InvalidMovementError.new(t('spree.stock_not_below_zero'))
+          raise StockLocation::InvalidMovementError.new(t('spree.api.stock_not_below_zero'))
         end
         @stock_movement = @stock_location.move(@stock_item.variant, count_on_hand_adjustment, current_api_user)
         @stock_item = @stock_movement.stock_item
       end
 
       def render_stock_items_error
-        render json: { error: t('spree.stock_not_below_zero') }, status: 422
+        render json: { error: t('spree.api.stock_not_below_zero') }, status: 422
       end
     end
   end

--- a/api/app/views/spree/api/errors/invalid_api_key.json.jbuilder
+++ b/api/app/views/spree/api/errors/invalid_api_key.json.jbuilder
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-json.error(I18n.t(:invalid_api_key, key: api_key, scope: "spree.api"))
+json.error(I18n.t('spree.api.invalid_api_key', key: api_key))

--- a/api/app/views/spree/api/payments/credit_over_limit.json.jbuilder
+++ b/api/app/views/spree/api/payments/credit_over_limit.json.jbuilder
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-json.error(I18n.t(:credit_over_limit, limit: @payment.credit_allowed, scope: "spree.api.payment"))
+json.error(I18n.t('spree.api.payment.credit_over_limit', limit: @payment.credit_allowed))

--- a/api/app/views/spree/api/payments/update_forbidden.json.jbuilder
+++ b/api/app/views/spree/api/payments/update_forbidden.json.jbuilder
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-json.error(I18n.t(:update_forbidden, state: @payment.state, scope: "spree.api.payment"))
+json.error(I18n.t('spree.api.payment.update_forbidden', state: @payment.state))

--- a/api/config/locales/en.yml
+++ b/api/config/locales/en.yml
@@ -7,8 +7,6 @@ en:
       invalid_api_key: Invalid API key (%{key}) specified.
       invalid_resource: Invalid resource. Please fix errors and try again.
       invalid_taxonomy_id: Invalid taxonomy id.
-      key_cleared: Key cleared
-      key_generated: Key generated
       must_specify_api_key: You must specify an API key.
       order:
         could_not_transition: The order could not be transitioned. Please fix the
@@ -23,4 +21,6 @@ en:
       resource_not_found: The resource you were looking for could not be found.
       shipment:
         cannot_ready: Cannot ready shipment.
+        transfer_success: Variants successfully transferred
+      stock_not_below_zero: Stock must not be below zero.
       unauthorized: You are not authorized to perform that action.

--- a/api/config/locales/en.yml
+++ b/api/config/locales/en.yml
@@ -1,23 +1,26 @@
+---
 en:
   spree:
     api:
-      must_specify_api_key: "You must specify an API key."
-      invalid_api_key: "Invalid API key (%{key}) specified."
-      unauthorized: "You are not authorized to perform that action."
-      invalid_resource: "Invalid resource. Please fix errors and try again."
-      resource_not_found: "The resource you were looking for could not be found."
-      gateway_error: "There was a problem with the payment gateway: %{text}"
-      delete_restriction_error: "Cannot delete record."
-      key_generated: "Key generated"
-      key_cleared: "Key cleared"
+      delete_restriction_error: Cannot delete record.
+      gateway_error: 'There was a problem with the payment gateway: %{text}'
+      invalid_api_key: Invalid API key (%{key}) specified.
+      invalid_resource: Invalid resource. Please fix errors and try again.
+      invalid_taxonomy_id: Invalid taxonomy id.
+      key_cleared: Key cleared
+      key_generated: Key generated
+      must_specify_api_key: You must specify an API key.
       order:
-        could_not_transition: "The order could not be transitioned. Please fix the errors and try again."
-        invalid_shipping_method: "Invalid shipping method specified."
-        expected_total_mismatch: "Expected total does not match actual total."
-        quantity_is_not_available: "Quantity is not available for items in your order"
+        could_not_transition: The order could not be transitioned. Please fix the
+          errors and try again.
+        expected_total_mismatch: Expected total does not match actual total.
+        invalid_shipping_method: Invalid shipping method specified.
+        quantity_is_not_available: Quantity is not available for items in your order
       payment:
-        credit_over_limit: "This payment can only be credited up to %{limit}. Please specify an amount less than or equal to this number."
-        update_forbidden: "This payment cannot be updated because it is %{state}."
+        credit_over_limit: This payment can only be credited up to %{limit}. Please
+          specify an amount less than or equal to this number.
+        update_forbidden: This payment cannot be updated because it is %{state}.
+      resource_not_found: The resource you were looking for could not be found.
       shipment:
-        cannot_ready: "Cannot ready shipment."
-      invalid_taxonomy_id: "Invalid taxonomy id."
+        cannot_ready: Cannot ready shipment.
+      unauthorized: You are not authorized to perform that action.

--- a/api/spec/requests/spree/api/stock_items_controller_spec.rb
+++ b/api/spec/requests/spree/api/stock_items_controller_spec.rb
@@ -170,7 +170,7 @@ module Spree
           it "does not allow negative inventory for the stock item" do
             subject
             expect(response.status).to eq 422
-            expect(response.body).to match I18n.t('spree.stock_not_below_zero')
+            expect(response.body).to match I18n.t('spree.api.stock_not_below_zero')
             expect(assigns(:stock_item).count_on_hand).to eq 0
           end
         end
@@ -236,7 +236,7 @@ module Spree
             it "does not allow negative inventory for the stock item" do
               subject
               expect(response.status).to eq 422
-              expect(response.body).to match I18n.t('spree.stock_not_below_zero')
+              expect(response.body).to match I18n.t('spree.api.stock_not_below_zero')
               expect(assigns(:stock_item).count_on_hand).to eq 10
             end
           end
@@ -294,7 +294,7 @@ module Spree
             it "does not allow negative inventory for the stock item" do
               subject
               expect(response.status).to eq 422
-              expect(response.body).to match I18n.t('spree.stock_not_below_zero')
+              expect(response.body).to match I18n.t('spree.api.stock_not_below_zero')
               expect(assigns(:stock_item).count_on_hand).to eq 10
             end
           end

--- a/backend/app/controllers/spree/admin/users_controller.rb
+++ b/backend/app/controllers/spree/admin/users_controller.rb
@@ -71,24 +71,26 @@ module Spree
 
       def items
         params[:q] ||= {}
+
         @search = Spree::Order.includes(
           line_items: {
             variant: [:product, { option_values: :option_type }]
           }
 ).ransack(params[:q].merge(user_id_eq: @user.id))
+
         @orders = @search.result.page(params[:page]).per(Spree::Config[:admin_products_per_page])
       end
 
       def generate_api_key
         if @user.generate_spree_api_key!
-          flash[:success] = t('spree.api.key_generated')
+          flash[:success] = t('spree.admin.api.key_generated')
         end
         redirect_to edit_admin_user_path(@user)
       end
 
       def clear_api_key
         if @user.clear_spree_api_key!
-          flash[:success] = t('spree.api.key_cleared')
+          flash[:success] = t('spree.admin.api.key_cleared')
         end
         redirect_to edit_admin_user_path(@user)
       end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -850,6 +850,9 @@ en:
     adjustment_type: Adjustment type
     adjustments: Adjustments
     admin:
+      api:
+        key_cleared: Key cleared
+        key_generated: Key generated
       images:
         index:
           choose_files: Choose files to upload
@@ -1988,7 +1991,6 @@ en:
       ready: Ready
       shipped: Shipped
     shipment_transfer_error: There was an error transferring variants
-    shipment_transfer_success: Variants successfully transferred
     shipments: Shipments
     shipped: Shipped
     shipped_at: Shipped At
@@ -2054,7 +2056,6 @@ en:
       order to manage stock.
     stock_movements: Stock Movements
     stock_movements_for_stock_location: Stock Movements for %{stock_location_name}
-    stock_not_below_zero: Stock must not be below zero.
     stock_successfully_transferred: Stock was successfully transferred between locations.
     stop: Stop
     store: Store


### PR DESCRIPTION
Based on the work established by #2963, this PR normalizes the I18n keys for the API.

That said, some issues are pending when running `bundle exec i18n-tasks health`, as you can see below:

![image](https://user-images.githubusercontent.com/9470839/49528491-66e10b80-f88a-11e8-91cf-8788f18645d5.png)

We have two (2) options to fix this:

* Assuming the `scope` usage is the reason for these issues, remove this option and replace it with `I18n.t('spree.api.my_key')`

* Include a `i18n-tasks.yml` config file under `config` and consider all `spree.api` I18n keys used

We need to address this last issue to include an I18n health check to the CI (first mentioned in [here](https://github.com/solidusio/solidus/pull/2963#issuecomment-440978247)) in order to stay consistent within this regard.