### PR TITLE
Lock Rails version up to 5.2.1

### DIFF
--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
     actionmailer actionpack actionview activejob activemodel activerecord
     activesupport railties
   ].each do |rails_dep|
-    s.add_dependency rails_dep, ['>= 5.1', '< 5.3.x']
+    s.add_dependency rails_dep, ['>= 5.1', '< 5.2.2']
   end
 
   s.add_dependency 'activemerchant', '~> 1.66'


### PR DESCRIPTION
There are incompatibilities between core code and Rails 5.2.2 that we need to investigate better.

Locking Rails to 5.2.1 should allow us to have all the ecosystem working in the meantime, for example this should immediately fix:

- extensions tests against master
- sandbox
- Heroku demo

ref #2989