### PR TITLE
Fix deprecations to make Solidus work with Rails 5.2.2

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -552,6 +552,7 @@ module Spree
       Spree::PromotionHandler::Shipping.new(self).activate
       recalculate
     end
+    alias_method :apply_free_shipping_promotions, :apply_shipping_promotions
     deprecate apply_free_shipping_promotions: :apply_shipping_promotions, deprecator: Spree::Deprecation
 
     # Clean shipments and make order back to address state

--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -28,7 +28,7 @@ module Spree
     scope :by_url, lambda { |url| where("url like ?", "%#{url}%") }
 
     class << self
-      deprecate :by_url, "Spree::Store.by_url is DEPRECATED", deprecator: Spree::Deprecation
+      deprecate by_url: "Spree::Store.by_url is DEPRECATED", deprecator: Spree::Deprecation
     end
 
     def available_locales

--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
     actionmailer actionpack actionview activejob activemodel activerecord
     activesupport railties
   ].each do |rails_dep|
-    s.add_dependency rails_dep, ['>= 5.1', '< 5.2.2']
+    s.add_dependency rails_dep, ['>= 5.1', '< 5.3.x']
   end
 
   s.add_dependency 'activemerchant', '~> 1.66'


### PR DESCRIPTION
This PR fixes a couple of wrong calls of `deprecate` method. These errors are raising errors from Rails `5.2.2` since [this PR](https://github.com/rails/rails/pull/33325) has been merged.

This PR is also reverting the `5.2.1` lock of Rails version.

Unfortunately, if this works, I think we should also apply these fixes to Solidus `v2.6` and `v2.7` otherwise Rails `5.2.2` cannot be used by users that use those versions via RubyGems.