### PR TITLE
Deprecate 'X-SPREE-TOKEN' header

### DIFF
--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -100,9 +100,15 @@ module Spree
       end
 
       def api_key
-        request.headers["X-Spree-Token"] || params[:token]
+        bearer_token || params[:token]
       end
       helper_method :api_key
+
+      def bearer_token
+        pattern = /^Bearer /
+        header  = request.headers["Authorization"]
+        header.gsub(pattern, '') if header&.match(pattern)
+      end
 
       def order_token
         request.headers["X-Spree-Order-Token"] || params[:order_token]

--- a/api/spec/controllers/spree/api/base_controller_spec.rb
+++ b/api/spec/controllers/spree/api/base_controller_spec.rb
@@ -52,7 +52,7 @@ describe Spree::Api::BaseController, type: :controller do
     end
 
     it "with an invalid API key" do
-      request.headers["X-Spree-Token"] = "fake_key"
+      request.headers["Authorization"] = "Bearer fake_key"
       get :index, params: {}
       expect(json_response).to eq({ "error" => "Invalid API key (fake_key) specified." })
       expect(response.status).to eq(401)

--- a/api/spec/requests/api/address_books_spec.rb
+++ b/api/spec/requests/api/address_books_spec.rb
@@ -41,7 +41,7 @@ module Spree
           user.save_in_address_book(ron_address_attributes, false)
 
           get "/api/users/#{user.id}/address_book",
-            headers: { 'X-SPREE-TOKEN' => 'galleon' }
+            headers: { Authorization: 'Bearer galleon' }
 
           json_response = JSON.parse(response.body)
           expect(response.status).to eq(200)
@@ -60,7 +60,7 @@ module Spree
           expect {
             put "/api/users/#{user.id}/address_book",
               params:  { address_book: harry_address_attributes.merge('id' => address.id) },
-              headers: { 'X-SPREE-TOKEN' => 'galleon' }
+              headers: { Authorization: 'Bearer galleon' }
           }.to change { UserAddress.count }.from(1).to(2)
 
           expect(response.status).to eq(200)
@@ -74,7 +74,7 @@ module Spree
             expect {
               put "/api/users/#{user.id}/address_book",
                 params:  { address_book: harry_address_attributes },
-                headers: { 'X-SPREE-TOKEN' => 'galleon' }
+                headers: { Authorization: 'Bearer galleon' }
             }.to change { UserAddress.count }.by(1)
 
             user_address = UserAddress.last
@@ -93,7 +93,7 @@ module Spree
             expect {
               put "/api/users/#{user.id}/address_book",
                 params:  { address_book: harry_address_attributes },
-                headers: { 'X-SPREE-TOKEN' => 'galleon' }
+                headers: { Authorization: 'Bearer galleon' }
             }.to_not change { UserAddress.count }
 
             expect(response.status).to eq(200)
@@ -110,7 +110,7 @@ module Spree
           expect {
             delete "/api/users/#{user.id}/address_book",
               params:  { address_id: address.id },
-              headers: { 'X-SPREE-TOKEN' => 'galleon' }
+              headers: { Authorization: 'Bearer galleon' }
           }.to change { user.reload.user_addresses.count }.from(1).to(0)
 
           expect(response.status).to eq(200)
@@ -131,7 +131,7 @@ module Spree
           other_user.save_in_address_book(ron_address_attributes, false)
 
           get "/api/users/#{other_user.id}/address_book",
-            headers: { 'X-SPREE-TOKEN' => 'galleon' }
+            headers: { Authorization: 'Bearer galleon' }
 
           json_response = JSON.parse(response.body)
           expect(response.status).to eq(200)
@@ -150,7 +150,7 @@ module Spree
           expect {
             put "/api/users/#{other_user.id}/address_book",
             params:  { address_book: updated_harry_address.merge('id' => address.id) },
-            headers: { 'X-SPREE-TOKEN' => 'galleon' }
+            headers: { Authorization: 'Bearer galleon' }
           }.to change { UserAddress.count }.from(1).to(2)
 
           expect(response.status).to eq(200)
@@ -165,7 +165,7 @@ module Spree
           expect {
             delete "/api/users/#{other_user.id}/address_book",
               params:  { address_id: address.id },
-              headers: { 'X-SPREE-TOKEN' => 'galleon' }
+              headers: { Authorization: 'Bearer galleon' }
           }.to change { other_user.reload.user_addresses.count }.from(1).to(0)
 
           expect(response.status).to eq(200)
@@ -179,7 +179,7 @@ module Spree
           other_user.save_in_address_book(harry_address_attributes, true)
 
           get "/api/users/#{other_user.id}/address_book",
-            headers: { 'X-SPREE-TOKEN' => 'galleon' }
+            headers: { Authorization: 'Bearer galleon' }
 
           expect(response.status).to eq(401)
         end
@@ -193,7 +193,7 @@ module Spree
           expect {
             put "/api/users/#{other_user.id}/address_book",
             params:  { address_book: other_user_address.attributes.merge('address1' => 'Hogwarts') },
-            headers: { 'X-SPREE-TOKEN' => 'galleon' }
+            headers: { Authorization: 'Bearer galleon' }
           }.not_to change { UserAddress.count }
 
           expect(response.status).to eq(401)
@@ -208,7 +208,7 @@ module Spree
           expect {
             delete "/api/users/#{other_user.id}/address_book",
               params:  { address_id: address.id },
-              headers: { 'X-SPREE-TOKEN' => 'galleon' }
+              headers: { Authorization: 'Bearer galleon' }
           }.not_to change { other_user.user_addresses.count }
 
           expect(response.status).to eq(401)

--- a/api/spec/requests/spree/api/store_credit_events_controller_spec.rb
+++ b/api/spec/requests/spree/api/store_credit_events_controller_spec.rb
@@ -7,7 +7,7 @@ describe Spree::Api::StoreCreditEventsController, type: :request do
 
   describe "GET mine" do
     subject do
-      get spree.mine_api_store_credit_events_path(format: :json), headers: { 'X-Spree-Token' => api_key }
+      get spree.mine_api_store_credit_events_path(format: :json), headers: { Authorization: "Bearer #{api_key}" }
     end
 
     context "no current api user" do

--- a/backend/app/assets/javascripts/spree/backend/option_type_autocomplete.js
+++ b/backend/app/assets/javascripts/spree/backend/option_type_autocomplete.js
@@ -23,7 +23,7 @@ Spree.ready(function () {
         url: Spree.routes.option_type_search,
         quietMillis: 200,
         datatype: 'json',
-        params: { "headers": { "X-Spree-Token": Spree.api_key } },
+        params: { "headers": {  'Authorization': 'Bearer ' + Spree.api_key } },
         data: function (term) {
           return {
             q: { name_cont: term }

--- a/backend/app/assets/javascripts/spree/backend/product_picker.js
+++ b/backend/app/assets/javascripts/spree/backend/product_picker.js
@@ -23,7 +23,7 @@ $.fn.productAutocomplete = function (options) {
     ajax: {
       url: Spree.routes.admin_product_search,
       datatype: 'json',
-      params: { "headers": { "X-Spree-Token": Spree.api_key } },
+      params: { "headers": {  'Authorization': 'Bearer ' + Spree.api_key } },
       data: function (term, page) {
         return {
           q: {

--- a/backend/app/assets/javascripts/spree/backend/taxons.js
+++ b/backend/app/assets/javascripts/spree/backend/taxons.js
@@ -30,7 +30,7 @@ Spree.ready(function() {
       url: Spree.routes.taxons_search,
       params: {
         "headers": {
-          "X-Spree-Token": Spree.api_key
+          'Authorization': 'Bearer ' + Spree.api_key
         }
       },
       data: function(term, page) {

--- a/backend/app/assets/javascripts/spree/backend/user_picker.js
+++ b/backend/app/assets/javascripts/spree/backend/user_picker.js
@@ -22,7 +22,7 @@ $.fn.userAutocomplete = function () {
     ajax: {
       url: Spree.routes.users_api,
       datatype: 'json',
-      params: { "headers": { "X-Spree-Token": Spree.api_key } },
+      params: { "headers": {  'Authorization': 'Bearer ' + Spree.api_key } },
       data: function (term) {
         return {
           q: {

--- a/backend/app/assets/javascripts/spree/backend/variant_autocomplete.js
+++ b/backend/app/assets/javascripts/spree/backend/variant_autocomplete.js
@@ -26,7 +26,7 @@
         quietMillis: 500,
         params: {
           "headers": {
-            "X-Spree-Token": Spree.api_key
+            'Authorization': 'Bearer ' + Spree.api_key
           }
         },
         data: function(term, page) {

--- a/backend/app/assets/javascripts/spree/backend/views/order/customer_select.js
+++ b/backend/app/assets/javascripts/spree/backend/views/order/customer_select.js
@@ -27,7 +27,7 @@ Spree.Views.Order.CustomerSelect = Backbone.View.extend({
       placeholder: Spree.translations.choose_a_customer,
       ajax: {
         url: Spree.routes.users_api,
-        params: { "headers": { "X-Spree-Token": Spree.api_key } },
+        params: { "headers": {  'Authorization': 'Bearer ' + Spree.api_key } },
         datatype: 'json',
         data: function(term, page) {
           return {

--- a/core/app/assets/javascripts/spree.js.erb
+++ b/core/app/assets/javascripts/spree.js.erb
@@ -45,7 +45,7 @@ Spree.ajax = function(url, options) {
   options = options || {};
   options = $.extend(options, {
     headers: {
-      "X-Spree-Token": Spree.api_key
+      'Authorization': 'Bearer ' + Spree.api_key
     }
   });
   return $.ajax(url, options);

--- a/guides/source/developers/api/overview.html.md
+++ b/guides/source/developers/api/overview.html.md
@@ -21,11 +21,10 @@ role of `admin`.
 
 ### Requests
 
-To make a request to the API, pass a `X-Spree-Token` header and a Spree API key
-along with the request:
+To make a request to the API, set a Bearer Authentication header with the Spree API key:
 
 ```bash
-curl --header "X-Spree-Token: <key>" http://yourstore.com/api/products/1
+curl --header "Authorization: Bearer <key>" http://yourstore.com/api/products/1
 ```
 
 Alternatively, you can pass through the token as a URL parameter if you are


### PR DESCRIPTION
I changed the use of custom header `X-SPREE-TOKEN` with `Authorization: Bearer my_secret_token`
Suggested in #2934 