### PR TITLE
Standardize shared resource links

### DIFF
--- a/backend/app/views/spree/admin/shared/_edit_resource_links.html.erb
+++ b/backend/app/views/spree/admin/shared/_edit_resource_links.html.erb
@@ -1,4 +1,4 @@
 <div class="form-buttons filter-actions actions" data-hook="buttons">
   <%= button_tag t('spree.actions.update'), class: 'btn btn-primary' %>
-  <%= link_to t('spree.actions.cancel'), collection_url, class: 'btn btn-primary' %>
+  <%= link_to t('spree.actions.cancel'), collection_url, class: 'button' %>
 </div>


### PR DESCRIPTION
Currently there is a difference between `new_resource_links` and `edit_resource_links`. Namely, in one the Cancel button is of `class: 'button'` and in the other the Cancel button is of `class: 'btn btn-primary'`.

Based on how they render in the browser, I assume that new_resource_links (`class: 'button'`) is correct, as it looks like this:

<img width="217" alt="screen shot 2018-12-10 at 9 58 07 am" src="https://user-images.githubusercontent.com/2460418/49751394-21458980-fc62-11e8-92b1-5e21d5b15555.png">

Whereas the shared_resource_links (`class: 'btn btn-primary'`) looks like this, with a weird visual bug:

<img width="250" alt="screen shot 2018-12-10 at 9 55 10 am" src="https://user-images.githubusercontent.com/2460418/49751433-328e9600-fc62-11e8-993d-cd7978c611d0.png">

After this commit, which changes shared_resource_links to be similar to new_resource_links, the visual behavior is fixed and it looks like this:

<img width="271" alt="screen shot 2018-12-10 at 9 55 19 am" src="https://user-images.githubusercontent.com/2460418/49751459-43d7a280-fc62-11e8-8ddb-92b1169ff535.png">
