### PR TITLE
Include records on API Order / Product queries

### DIFF
--- a/api/app/controllers/spree/api/orders_controller.rb
+++ b/api/app/controllers/spree/api/orders_controller.rb
@@ -51,7 +51,18 @@ module Spree
 
       def index
         authorize! :index, Order
-        @orders = paginate(Spree::Order.ransack(params[:q]).result)
+        orders_includes = [
+          :user,
+          :payments,
+          :adjustments,
+          :line_items
+        ]
+        @orders = paginate(
+          Spree::Order
+            .ransack(params[:q])
+            .result
+            .includes(orders_includes)
+        )
         respond_with(@orders)
       end
 

--- a/api/app/controllers/spree/api/products_controller.rb
+++ b/api/app/controllers/spree/api/products_controller.rb
@@ -8,7 +8,16 @@ module Spree
           ids = params[:ids].split(",").flatten
           @products = product_scope.where(id: ids)
         else
-          @products = product_scope.ransack(params[:q]).result
+          products_includes = [
+            :variants,
+            :option_types,
+            :product_properties,
+            { classifications: :taxon }
+          ]
+          @products = product_scope
+                        .ransack(params[:q])
+                        .result
+                        .includes(products_includes)
         end
 
         @products = paginate(@products.distinct)


### PR DESCRIPTION
When querying for Orders or Products via the API, the significant number
of related records needed to render the JSON for each Order / Product
can lead to a lot of extra database traffic. By using `includes` we can
reduce the query traffic (and thus response time) significantly.