### PR TITLE
Enable partial doubles verification for RSpec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ end
 gem 'database_cleaner', '~> 1.3', require: false
 gem 'factory_bot_rails', '~> 4.8', require: false
 gem 'i18n-tasks', '~> 0.9', require: false
-gem 'rspec-activemodel-mocks', '~>1.0.2', require: false
+gem 'rspec-activemodel-mocks', '~>1.1', require: false
 gem 'rspec-rails', '~> 3.7', require: false
 gem 'simplecov', require: false
 gem 'with_model', require: false

--- a/core/spec/helpers/products_helper_spec.rb
+++ b/core/spec/helpers/products_helper_spec.rb
@@ -15,7 +15,9 @@ module Spree
     end
 
     before do
-      allow(helper).to receive(:current_pricing_options) { pricing_options }
+      without_partial_double_verification do
+        allow(helper).to receive(:current_pricing_options) { pricing_options }
+      end
     end
 
     context "#variant_price_diff" do

--- a/core/spec/helpers/taxons_helper_spec.rb
+++ b/core/spec/helpers/taxons_helper_spec.rb
@@ -8,7 +8,9 @@ RSpec.describe Spree::TaxonsHelper, type: :helper do
     Spree::Config.pricing_options_class.new(currency: currency)
   end
   before do
-    allow(helper).to receive(:current_pricing_options) { pricing_options }
+    without_partial_double_verification do
+      allow(helper).to receive(:current_pricing_options) { pricing_options }
+    end
   end
 
   describe "#taxon_preview" do

--- a/core/spec/lib/spree/core/controller_helpers/auth_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/auth_spec.rb
@@ -55,11 +55,15 @@ RSpec.describe Spree::Core::ControllerHelpers::Auth, type: :controller do
 
   describe '#try_spree_current_user' do
     it 'calls spree_current_user when define spree_current_user method' do
-      expect(controller).to receive(:spree_current_user)
+      without_partial_double_verification do
+        expect(controller).to receive(:spree_current_user)
+      end
       controller.try_spree_current_user
     end
     it 'calls current_spree_user when define current_spree_user method' do
-      expect(controller).to receive(:current_spree_user)
+      without_partial_double_verification do
+        expect(controller).to receive(:current_spree_user)
+      end
       controller.try_spree_current_user
     end
     it 'returns nil' do

--- a/core/spec/models/spree/inventory_unit_spec.rb
+++ b/core/spec/models/spree/inventory_unit_spec.rb
@@ -97,8 +97,6 @@ RSpec.describe Spree::InventoryUnit, type: :model do
         shipment.stock_location = stock_location
         shipment.shipping_methods << create(:shipping_method)
         shipment.order = other_order
-        # We don't care about this in this test
-        allow(shipment).to receive(:ensure_correct_adjustment)
         shipment.tap(&:save!)
       end
 
@@ -149,8 +147,6 @@ RSpec.describe Spree::InventoryUnit, type: :model do
   end
 
   describe "#current_or_new_return_item" do
-    before { allow(inventory_unit).to receive_messages(total_excluding_vat: 100.0) }
-
     subject { inventory_unit.current_or_new_return_item }
 
     context "associated with a return item" do

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Spree::Order, type: :model do
         Spree::Order.checkout_flow(&@old_checkout_flow)
       end
 
-      it '.remove_transition' do
+      it '.remove_transition', partial_double_verification: false do
         options = { from: transitions.first.keys.first, to: transitions.first.values.first }
         allow(Spree::Order).to receive(:next_event_transition).and_return([options])
         expect(Spree::Order.remove_transition(options)).to be_truthy
@@ -238,7 +238,7 @@ RSpec.describe Spree::Order, type: :model do
         order.ship_address = ship_address
       end
 
-      context 'when order has default selected_shipping_rate_id' do
+      context 'when order has default selected_shipping_rate_id', partial_double_verification: false do
         let(:shipment) { create(:shipment, order: order) }
         let(:shipping_method) { create(:shipping_method) }
         let(:shipping_rate) {
@@ -277,7 +277,7 @@ RSpec.describe Spree::Order, type: :model do
       end
     end
 
-    context "from delivery" do
+    context "from delivery", partial_double_verification: false do
       let(:ship_address) { FactoryBot.create(:ship_address) }
 
       before do
@@ -537,7 +537,7 @@ RSpec.describe Spree::Order, type: :model do
       end
     end
 
-    context "default credit card" do
+    context "default credit card", partial_double_verification: false do
       before do
         order.user = FactoryBot.create(:user)
         order.store = FactoryBot.create(:store)
@@ -568,7 +568,7 @@ RSpec.describe Spree::Order, type: :model do
       end
     end
 
-    context "a payment fails during processing" do
+    context "a payment fails during processing", partial_double_verification: false do
       before do
         order.user = FactoryBot.create(:user)
         order.email = 'spree@example.org'
@@ -656,7 +656,7 @@ RSpec.describe Spree::Order, type: :model do
       assert_state_changed(order, 'cart', 'complete')
     end
 
-    it "does not attempt to process payments" do
+    it "does not attempt to process payments", partial_double_verification: false do
       order.email = 'user@example.com'
       allow(order).to receive(:ensure_promotions_eligible).and_return(true)
       allow(order).to receive(:ensure_line_item_variants_are_not_deleted).and_return(true)

--- a/core/spec/models/spree/order/finalizing_spec.rb
+++ b/core/spec/models/spree/order/finalizing_spec.rb
@@ -26,13 +26,6 @@ RSpec.describe Spree::Order, type: :model do
       order.finalize!
     end
 
-    it "should decrease the stock for each variant in the shipment" do
-      order.shipments.each do |shipment|
-        expect(shipment.stock_location).to receive(:decrease_stock_for_variant)
-      end
-      order.finalize!
-    end
-
     it "should change the shipment state to ready if order is paid" do
       Spree::Shipment.create(order: order)
       order.shipments.reload
@@ -41,12 +34,6 @@ RSpec.describe Spree::Order, type: :model do
       order.finalize!
       order.reload # reload so we're sure the changes are persisted
       expect(order.shipment_state).to eq('ready')
-    end
-
-    it "should not sell inventory units if track_inventory_levels is false" do
-      Spree::Config.set track_inventory_levels: false
-      expect(Spree::InventoryUnit).not_to receive(:sell_units)
-      order.finalize!
     end
 
     it "should send an order confirmation email" do

--- a/core/spec/models/spree/order/finalizing_spec.rb
+++ b/core/spec/models/spree/order/finalizing_spec.rb
@@ -3,11 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe Spree::Order, type: :model do
-  let(:order) { stub_model("Spree::Order") }
-
   context "#finalize!" do
-    let!(:store) { create(:store) }
-    let(:order) { Spree::Order.create(email: 'test@example.com', store: store) }
+    let(:order) { create(:order_ready_to_complete) }
 
     before do
       order.update_column :state, 'complete'
@@ -27,9 +24,6 @@ RSpec.describe Spree::Order, type: :model do
     end
 
     it "should change the shipment state to ready if order is paid" do
-      Spree::Shipment.create(order: order)
-      order.shipments.reload
-
       allow(order).to receive_messages(paid?: true, complete?: true)
       order.finalize!
       order.reload # reload so we're sure the changes are persisted

--- a/core/spec/models/spree/order/updating_spec.rb
+++ b/core/spec/models/spree/order/updating_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Spree::Order, type: :model do
   let(:order) { create(:order) }
 
   context "#update!" do
-    context "when there are update hooks" do
+    context "when there are update hooks", partial_double_verification: false do
       before { Spree::Order.register_update_hook :foo }
       after { Spree::Order.update_hooks.clear }
       it "should call each of the update hooks" do

--- a/core/spec/models/spree/order_merger_spec.rb
+++ b/core/spec/models/spree/order_merger_spec.rb
@@ -68,7 +68,6 @@ module Spree
     context "merging using extension-specific line_item_comparison_hooks" do
       before do
         Spree::Order.register_line_item_comparison_hook(:foos_match)
-        allow(Spree::Variant).to receive(:price_modifier_amount).and_return(0.00)
       end
 
       after do
@@ -83,7 +82,9 @@ module Spree
         end
 
         specify do
-          expect(order_1).to receive(:foos_match).with(@line_item_1, kind_of(Hash)).and_return(true)
+          without_partial_double_verification do
+            expect(order_1).to receive(:foos_match).with(@line_item_1, kind_of(Hash)).and_return(true)
+          end
           subject.merge!(order_2)
           expect(order_1.line_items.count).to eq(1)
 
@@ -95,7 +96,9 @@ module Spree
 
       context "2 different line items" do
         before do
-          allow(order_1).to receive(:foos_match).and_return(false)
+          without_partial_double_verification do
+            allow(order_1).to receive(:foos_match).and_return(false)
+          end
 
           order_1.contents.add(variant, 1, foos: {})
           order_2.contents.add(variant, 1, foos: { bar: :zoo })

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -15,10 +15,6 @@ RSpec.describe Spree::Order, type: :model do
   end
   let(:code) { promotion.codes.first }
 
-  before do
-    allow(Spree::LegacyUser).to receive_messages(current: mock_model(Spree::LegacyUser, id: 123))
-  end
-
   context '#store' do
     it { is_expected.to respond_to(:store) }
 
@@ -1072,7 +1068,7 @@ RSpec.describe Spree::Order, type: :model do
 
     context 'an old-style refund exists' do
       let(:order) { create(:order_ready_to_ship) }
-      let(:payment) { order.payments.first.tap { |p| allow(p).to receive_messages(profiles_supported: false) } }
+      let(:payment) { order.payments.first.tap { |p| allow(p).to receive_messages(profiles_supported?: false) } }
       let!(:refund_payment) {
         build(:payment, amount: -1, order: order, state: 'completed', source: payment).tap do |p|
           allow(p).to receive_messages(profiles_supported?: false)

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -324,7 +324,7 @@ RSpec.describe Spree::Order, type: :model do
     end
   end
 
-  context "add_update_hook" do
+  context "add_update_hook", partial_double_verification: false do
     before do
       Spree::Order.class_eval do
         register_update_hook :add_awesome_sauce
@@ -712,7 +712,7 @@ RSpec.describe Spree::Order, type: :model do
       expect(order.find_line_item_by_variant(mock_model(Spree::Variant))).to be_nil
     end
 
-    context "match line item with options" do
+    context "match line item with options", partial_double_verification: false do
       before do
         Spree::Order.register_line_item_comparison_hook(:foos_match)
       end

--- a/core/spec/models/spree/order_updater_spec.rb
+++ b/core/spec/models/spree/order_updater_spec.rb
@@ -521,7 +521,7 @@ module Spree
         allow(shipments).to receive_messages shipped: []
 
         allow(updater).to receive(:update_totals) # Otherwise this gets called and causes a scene
-        expect(updater).not_to receive(:update_shipments).with(order)
+        expect(updater).not_to receive(:update_shipments)
         updater.update
       end
     end

--- a/core/spec/models/spree/order_updater_spec.rb
+++ b/core/spec/models/spree/order_updater_spec.rb
@@ -513,13 +513,8 @@ module Spree
 
       it "doesnt update each shipment" do
         shipment = stub_model(Spree::Shipment)
-        shipments = [shipment]
-        allow(order).to receive_messages shipments: shipments
-        allow(shipments).to receive_messages states: []
-        allow(shipments).to receive_messages ready: []
-        allow(shipments).to receive_messages pending: []
-        allow(shipments).to receive_messages shipped: []
-
+        order.shipments = [shipment]
+        allow(order.shipments).to receive_messages(states: [], ready: [], pending: [], shipped: [])
         allow(updater).to receive(:update_totals) # Otherwise this gets called and causes a scene
         expect(updater).not_to receive(:update_shipments)
         updater.update

--- a/core/spec/models/spree/payment/cancellation_spec.rb
+++ b/core/spec/models/spree/payment/cancellation_spec.rb
@@ -63,14 +63,15 @@ RSpec.describe Spree::Payment::Cancellation do
       end
     end
 
-    context 'if the payment_method does not respond to `try_void`' do
+    context 'if the payment_method does not respond to `try_void`', partial_double_verification: false do
       before do
         allow(payment_method).to receive(:respond_to?) { false }
-        expect(payment_method).to receive(:cancel) { double }
-        expect(payment).to receive(:handle_void_response)
+        allow(payment_method).to receive(:cancel) { double }
+        allow(payment).to receive(:handle_void_response)
       end
 
       it 'calls cancel instead' do
+        expect(payment_method).to receive(:cancel)
         Spree::Deprecation.silence { subject }
       end
 

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -207,22 +207,6 @@ RSpec.describe Spree::Payment, type: :model do
         expect { payment.process! }.to raise_error(Spree::Core::GatewayError)
         expect(payment.state).to eq('invalid')
       end
-
-      # Regression test for https://github.com/spree/spree/issues/4598
-      it "should allow payments with a gateway_customer_profile_id" do
-        payment.source.update!(gateway_customer_profile_id: "customer_1", brand: 'visa')
-        expect(payment.payment_method.gateway_class).to receive(:supports?).with('visa').and_return(false)
-        expect(payment).to receive(:started_processing!)
-        payment.process!
-      end
-
-      # Another regression test for https://github.com/spree/spree/issues/4598
-      it "should allow payments with a gateway_payment_profile_id" do
-        payment.source.update!(gateway_payment_profile_id: "customer_1", brand: 'visa')
-        expect(payment.payment_method.gateway_class).to receive(:supports?).with('visa').and_return(false)
-        expect(payment).to receive(:started_processing!)
-        payment.process!
-      end
     end
 
     describe "#authorize!" do

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Spree::Payment, type: :model do
 
   let(:gateway) do
     gateway = Spree::PaymentMethod::BogusCreditCard.new(active: true, name: 'Bogus gateway')
-    allow(gateway).to receive_messages source_required: true
+    allow(gateway).to receive_messages(source_required?: true)
     gateway
   end
 

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Spree::Product, type: :model do
         expect(clone.images.size).to eq(product.images.size)
       end
 
-      it 'calls #duplicate_extra' do
+      it 'calls #duplicate_extra', partial_double_verification: false do
         expect_any_instance_of(Spree::Product).to receive(:duplicate_extra) do |product, old_product|
           product.name = old_product.name.reverse
         end

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -632,8 +632,11 @@ RSpec.describe Spree::Promotion, type: :model do
     end
 
     context "with 'any' match policy" do
-      let(:promotion) { Spree::Promotion.create(name: "Promo", match_policy: 'any') }
       let(:promotable) { double('Promotable') }
+
+      before do
+        promotion.match_policy = 'any'
+      end
 
       it "should have eligible rules if any of the rules are eligible" do
         allow_any_instance_of(Spree::PromotionRule).to receive_messages(applicable?: true)

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -639,11 +639,9 @@ RSpec.describe Spree::Promotion, type: :model do
       end
 
       it "should have eligible rules if any of the rules are eligible" do
-        allow_any_instance_of(Spree::PromotionRule).to receive_messages(applicable?: true)
-        true_rule = Spree::PromotionRule.create(promotion: promotion)
-        allow(true_rule).to receive_messages(eligible?: true)
-        allow(promotion).to receive_messages(rules: [true_rule])
-        allow(promotion).to receive_message_chain(:rules, :for).and_return([true_rule])
+        true_rule = mock_model(Spree::PromotionRule, eligible?: true, applicable?: true)
+        promotion.promotion_rules = [true_rule]
+        allow(promotion.rules).to receive(:for) { promotion.rules }
         expect(promotion.eligible_rules(promotable)).to eq [true_rule]
       end
 
@@ -671,13 +669,13 @@ RSpec.describe Spree::Promotion, type: :model do
   describe '#line_item_actionable?' do
     let(:order) { double Spree::Order }
     let(:line_item) { double Spree::LineItem }
-    let(:true_rule) { double Spree::PromotionRule, eligible?: true, applicable?: true, actionable?: true }
-    let(:false_rule) { double Spree::PromotionRule, eligible?: true, applicable?: true, actionable?: false }
+    let(:true_rule) { mock_model Spree::PromotionRule, eligible?: true, applicable?: true, actionable?: true }
+    let(:false_rule) { mock_model Spree::PromotionRule, eligible?: true, applicable?: true, actionable?: false }
     let(:rules) { [] }
 
     before do
-      allow(promotion).to receive(:rules) { rules }
-      allow(rules).to receive(:for) { rules }
+      promotion.promotion_rules = rules
+      allow(promotion.rules).to receive(:for) { rules }
     end
 
     subject { promotion.line_item_actionable? order, line_item }

--- a/core/spec/models/spree/return_item_spec.rb
+++ b/core/spec/models/spree/return_item_spec.rb
@@ -294,7 +294,7 @@ RSpec.describe Spree::ReturnItem, type: :model do
         end
 
         it 'does not decrease inventory' do
-          expect(return_item).to_not receive(:process_inventory_unit)
+          expect(return_item).to_not receive(:process_inventory_unit!)
           subject
         end
 

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -512,7 +512,6 @@ RSpec.describe Spree::Shipment, type: :model do
       let(:subject) { shipment_with_inventory_units.ship! }
       before do
         allow(order).to receive(:update!)
-        allow(shipment_with_inventory_units).to receive_messages(require_inventory: false, update_order: true)
       end
 
       it 'unstocks them items' do
@@ -525,7 +524,7 @@ RSpec.describe Spree::Shipment, type: :model do
       context "from #{state}" do
         before do
           allow(order).to receive(:update!)
-          allow(shipment).to receive_messages(require_inventory: false, update_order: true, state: state)
+          allow(shipment).to receive_messages(state: state)
         end
 
         it "finalizes adjustments" do

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -267,8 +267,8 @@ RSpec.describe Spree::Shipment, type: :model do
 
         before do
           allow(line_item).to receive(:order) { order }
-          allow(shipment).to receive(:inventory_units) { inventory_units }
-          allow(inventory_units).to receive_message_chain(:includes, :joins).and_return inventory_units
+          shipment.inventory_units = inventory_units
+          allow(shipment.inventory_units).to receive_message_chain(:includes, :joins).and_return inventory_units
         end
 
         it 'should use symbols for states when adding contents to package' do

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -413,7 +413,9 @@ RSpec.describe Spree::Shipment, type: :model do
       allow(shipment.order).to receive(:update!)
 
       shipment.state = 'pending'
-      expect(shipment).to receive(:after_cancel)
+      without_partial_double_verification do
+        expect(shipment).to receive(:after_cancel)
+      end
       shipment.cancel!
       expect(shipment.state).to eq 'canceled'
     end

--- a/core/spec/models/spree/stock/estimator_spec.rb
+++ b/core/spec/models/spree/stock/estimator_spec.rb
@@ -205,11 +205,14 @@ module Spree
         end
 
         it 'uses the configured shipping rate sorter' do
-          class Spree::Stock::TestSorter; end;
+          class Spree::Stock::TestSorter
+            def initialize(_rates)
+            end
+          end
           Spree::Config.shipping_rate_sorter_class = Spree::Stock::TestSorter
 
           sorter = double(:sorter, sort: nil)
-          allow(Spree::Stock::TestSorter).to receive(:new).and_return(sorter)
+          allow(Spree::Stock::TestSorter).to receive(:new) { sorter }
 
           subject.shipping_rates(package)
 

--- a/core/spec/spec_helper.rb
+++ b/core/spec/spec_helper.rb
@@ -19,6 +19,7 @@ RSpec.configure do |config|
   end
   config.mock_with :rspec do |c|
     c.syntax = :expect
+    c.verify_partial_doubles = true
   end
 
   config.before :each do

--- a/core/spec/support/example_groups/partial_double_verification_example_group.rb
+++ b/core/spec/support/example_groups/partial_double_verification_example_group.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module PartialDoubleVerificationExampleGroup
+  extend ActiveSupport::Concern
+
+  included do
+    around do |example|
+      without_partial_double_verification { example.run }
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include PartialDoubleVerificationExampleGroup,
+                 partial_double_verification: false
+end


### PR DESCRIPTION
Enables the [partial double verification for RSpec](https://relishapp.com/rspec/rspec-mocks/docs/verifying-doubles/partial-doubles) in Solidus Core and:
- removes test cases that don't have an actual implementation (were passing because the implementation was mocked);
- fixes test cases that have a refactored implementation (renamed method names for example);
- disables partial doubles verification when testing runtime defined methods or user defined hooks (cannot find a more elegant solution to this, see rspec/rspec-rails#1076. Any suggestions are welcome).

Being new to Solidus, it will be awesome if someone with more knowledge of the codebase could take a look at the changeset and ensure I didn't removed/changed too much :smile: 