### PR TITLE
Allow :state to be a permitted checkout attribute

### DIFF
--- a/api/spec/requests/spree/api/checkouts_controller_spec.rb
+++ b/api/spec/requests/spree/api/checkouts_controller_spec.rb
@@ -412,6 +412,17 @@ module Spree
           expect(response.status).to eq(422)
           expect(json_response['errors']['state'][0]).to eq('is invalid')
         end
+
+        it "cannot move to complete" do
+          expect(order.state).to eq('cart')
+          put spree.api_checkout_path(order),
+            params: { order_token: order.guest_token, order: {
+              state: 'complete'
+            } }
+
+          expect(response.status).to eq(422)
+          expect(json_response['errors']['state'][0]).to eq('cannot transition via "next"')
+        end
       end
     end
 

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -46,7 +46,7 @@ module Spree
     @@address_book_attributes = address_attributes + [:default]
 
     @@checkout_attributes = [
-      :coupon_code, :email, :special_instructions, :use_billing
+      :coupon_code, :email, :special_instructions, :use_billing, :state
     ]
 
     @@credit_card_update_attributes = [


### PR DESCRIPTION
Using the API can be problematic when updating the order once it has
made it to the confirm step. This is due to calling next when
updating the order when it is in the confirm step. Passing in a new
state fixes this and flows through the state machine starting from
the passed in state.