### PR TITLE
Verify ownership of payment_source when creating WalletPaymentSource

### DIFF
--- a/backend/spec/features/admin/orders/payments_spec.rb
+++ b/backend/spec/features/admin/orders/payments_spec.rb
@@ -182,7 +182,7 @@ describe 'Payments', type: :feature do
 
     context "user existing card" do
       let!(:cc) do
-        create(:credit_card, payment_method: payment_method, gateway_customer_profile_id: "BGS-RFRE")
+        create(:credit_card, payment_method: payment_method, gateway_customer_profile_id: "BGS-RFRE", user: order.user)
       end
 
       before do

--- a/core/app/models/spree/wallet_payment_source.rb
+++ b/core/app/models/spree/wallet_payment_source.rb
@@ -13,12 +13,22 @@ module Spree
     }
 
     validate :check_for_payment_source_class
+    validate :validate_payment_source_ownership
 
     private
 
     def check_for_payment_source_class
       if !payment_source.is_a?(Spree::PaymentSource)
         errors.add(:payment_source, :has_to_be_payment_source_class)
+      end
+    end
+
+    def validate_payment_source_ownership
+      return unless payment_source.present?
+
+      if payment_source.respond_to?(:user_id) &&
+         payment_source.user_id != user_id
+        errors.add(:payment_source, :not_owned_by_user)
       end
     end
   end

--- a/core/app/models/spree/wallet_payment_source.rb
+++ b/core/app/models/spree/wallet_payment_source.rb
@@ -1,19 +1,21 @@
 # frozen_string_literal: true
 
-class Spree::WalletPaymentSource < ActiveRecord::Base
-  belongs_to :user, class_name: Spree::UserClassHandle.new, foreign_key: 'user_id', inverse_of: :wallet_payment_sources
-  belongs_to :payment_source, polymorphic: true, inverse_of: :wallet_payment_sources
+module Spree
+  class WalletPaymentSource < Spree::Base
+    belongs_to :user, class_name: Spree::UserClassHandle.new, foreign_key: 'user_id', inverse_of: :wallet_payment_sources
+    belongs_to :payment_source, polymorphic: true, inverse_of: :wallet_payment_sources
 
-  validates_presence_of :user
-  validates_presence_of :payment_source
+    validates_presence_of :user
+    validates_presence_of :payment_source
 
-  validate :check_for_payment_source_class
+    validate :check_for_payment_source_class
 
-  private
+    private
 
-  def check_for_payment_source_class
-    if !payment_source.is_a?(Spree::PaymentSource)
-      errors.add(:payment_source, :has_to_be_payment_source_class)
+    def check_for_payment_source_class
+      if !payment_source.is_a?(Spree::PaymentSource)
+        errors.add(:payment_source, :has_to_be_payment_source_class)
+      end
     end
   end
 end

--- a/core/app/models/spree/wallet_payment_source.rb
+++ b/core/app/models/spree/wallet_payment_source.rb
@@ -7,6 +7,10 @@ module Spree
 
     validates_presence_of :user
     validates_presence_of :payment_source
+    validates :user_id, uniqueness: {
+      scope: [:payment_source_type, :payment_source_id],
+      message: :payment_source_already_exists
+    }
 
     validate :check_for_payment_source_class
 

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -488,6 +488,7 @@ en:
           attributes:
             payment_source:
               has_to_be_payment_source_class: has to be a Spree::PaymentSource
+              not_owned_by_user: does not belong to user
             user_id:
               payment_source_already_exists: already has the Spree::PaymentSource in their wallet
     models:

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -488,6 +488,8 @@ en:
           attributes:
             payment_source:
               has_to_be_payment_source_class: has to be a Spree::PaymentSource
+            user_id:
+              payment_source_already_exists: already has the Spree::PaymentSource in their wallet
     models:
       spree/address:
         one: Address

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -359,6 +359,7 @@ RSpec.describe Spree::Order, type: :model do
 
       before do
         user = create(:user, email: 'spree@example.org', bill_address: user_bill_address)
+        default_credit_card.update(user: user)
         wallet_payment_source = user.wallet.add(default_credit_card)
         user.wallet.default_wallet_payment_source = wallet_payment_source
         order.user = user
@@ -497,12 +498,7 @@ RSpec.describe Spree::Order, type: :model do
 
     context "with a payment in the pending state" do
       let(:order) { create :order_ready_to_complete }
-      let(:payment) { create :payment, state: "pending", amount: order.total }
-
-      before do
-        order.payments = [payment]
-        order.save!
-      end
+      let(:payment) { create :payment, order: order, state: "pending", amount: order.total }
 
       it "allows the order to complete" do
         expect { order.complete! }.
@@ -542,7 +538,7 @@ RSpec.describe Spree::Order, type: :model do
         order.user = FactoryBot.create(:user)
         order.store = FactoryBot.create(:store)
         order.email = 'spree@example.org'
-        order.payments << FactoryBot.create(:payment)
+        order.payments << FactoryBot.create(:payment, order: order)
 
         # make sure we will actually capture a payment
         allow(order).to receive_messages(payment_required?: true)

--- a/core/spec/models/spree/wallet_payment_source_spec.rb
+++ b/core/spec/models/spree/wallet_payment_source_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Spree::WalletPaymentSource, type: :model do
     end
 
     it "is invalid if `payment_source` is already in the user's wallet" do
-      credit_card = create(:credit_card)
+      credit_card = create(:credit_card, user: user)
       Spree::WalletPaymentSource.create(
         payment_source: credit_card,
         user: user
@@ -47,9 +47,20 @@ RSpec.describe Spree::WalletPaymentSource, type: :model do
       )
     end
 
+    it "is invalid when `payment_source` is not owned by the user" do
+      wallet_payment_source = subject.new(
+        payment_source: create(:credit_card),
+        user: user
+      )
+      expect(wallet_payment_source).not_to be_valid
+      expect(wallet_payment_source.errors.messages).to eq(
+        { payment_source: ["does not belong to user"] }
+      )
+    end
+
     it "is valid with a `credit_card` as `payment_source`" do
       valid_attrs = {
-        payment_source: create(:credit_card),
+        payment_source: create(:credit_card, user: user),
         user: user
       }
       expect(subject.new(valid_attrs)).to be_valid
@@ -57,7 +68,7 @@ RSpec.describe Spree::WalletPaymentSource, type: :model do
 
     it "is valid with `store_credit` as `payment_source`" do
       valid_attrs = {
-        payment_source: create(:store_credit),
+        payment_source: create(:store_credit, user: user),
         user: user
       }
       expect(subject.new(valid_attrs)).to be_valid

--- a/core/spec/models/spree/wallet_spec.rb
+++ b/core/spec/models/spree/wallet_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe Spree::Wallet, type: :model do
     end
 
     context 'with a wallet payment source that does not belong to the wallet' do
-      let(:other_wallet_credit_card) { other_wallet.add(credit_card) }
+      let(:other_wallet_credit_card) { other_wallet.add(other_credit_card) }
       let(:other_wallet) { Spree::Wallet.new(other_user) }
       let(:other_credit_card) { create(:credit_card, user_id: other_user.id) }
       let(:other_user) { create(:user) }


### PR DESCRIPTION
This merge request takes care of these things:

1. It's currently possible for payment sources created by one user to be added to the wallet of another user. This potentially allows one user to use payments stored for other users.
2. Cleans up data by restricting payment sources being added to a user's wallet if that payment source has already been added to the wallet.
3. Matches namespacing and inheritance for the Spree::WalletPaymentSource class to be the same as the other models in `spree_core` inheriting from `Spree::Base`