### PR TITLE
Fix autoload issue. Replace require/load with require_dependency.

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'spree/order/checkout'
-require 'spree/order/number_generator'
-
 module Spree
   # The customers cart until completed, then acts as permanent record of the transaction.
   #

--- a/core/lib/generators/spree/install/install_generator.rb
+++ b/core/lib/generators/spree/install/install_generator.rb
@@ -84,12 +84,12 @@ module Spree
     config.to_prepare do
       # Load application's model / class decorators
       Dir.glob(File.join(File.dirname(__FILE__), "../app/**/*_decorator*.rb")) do |c|
-        Rails.configuration.cache_classes ? require(c) : load(c)
+        require_dependency(c)
       end
 
       # Load application's view overrides
       Dir.glob(File.join(File.dirname(__FILE__), "../app/overrides/*.rb")) do |c|
-        Rails.configuration.cache_classes ? require(c) : load(c)
+        require_dependency(c)
       end
     end
       APP


### PR DESCRIPTION
Hello!

I developed the best practices for overriding solidus and found bug of the Order class autoload. It simply did not reload In development mode. After look at the sources it became clear that the problem in this two require (https://github.com/solidusio/solidus/blob/master/core/app/models/spree/order.rb#L3).

When you use require for loading constants rails can't mark them as autoloaded (for more information check https://guides.rubyonrails.org/autoloading_and_reloading_constants.html#autoloading-and-require).

I completely removed the require in order.rb, it is not needed there, although it could be replaced with require_dependency, but this is unnecessary. Also changed install generator because require_dependency is autoload friendly equivalent to
`Rails.configuration.cache_classes ? require(c) : load(c)`.


As an example of issue, I have two files
models/spree/order_decorator.rb
```
Spree::Order.prepend(Spree::OrderExtension::Base)
```

models/spree/order_extension/base.rb
```
module Spree
  module OrderExtension
    module Base
      def self.prepended(base)
        # add callback or anything else
      end
    end
  end
end
```
Аfter few reloads you get an invalid ancestors chain
![2018-12-19 13 36 16](https://user-images.githubusercontent.com/3278464/50217045-9cace680-0398-11e9-80cb-f590324e250c.png)
This can lead to adding 10 callbacks instead of one or something like that :)

Other constants are autoloading correctly.