### PR TITLE
Fix coupon code placeholder value.

### DIFF
--- a/frontend/app/views/spree/checkout/_coupon_code.html.erb
+++ b/frontend/app/views/spree/checkout/_coupon_code.html.erb
@@ -1,7 +1,7 @@
 <div class="coupon-code" data-hook='coupon_code'>
   <%= form_for order, url: update_checkout_path(order.state) do |form| %>
     <%= form.label :coupon_code %>
-    <%= form.text_field :coupon_code, placeholder: :coupon_code %>
+    <%= form.text_field :coupon_code, placeholder: true %>
 
     <button type="submit" class="button coupon-code-apply-button" id="coupon-code-apply-button">
       <%= t('spree.apply_code') %>


### PR DESCRIPTION
Hello!

https://github.com/solidusio/solidus/blob/4497ef5c15d5a9f0d62aec0cceb3d5b83f603320/frontend/app/views/spree/checkout/_coupon_code.html.erb#L4
This is not valid code

You probably thought i18n would be used, but it’s not. Rails cast it to string and renders at it is.
Placeholder attribute can be string or true. If it is true then rails use human attribute name for order#coupon_code. FYI: https://stackoverflow.com/questions/25677031/how-do-i-translate-placeholder-text-in-rails-4