### PR TITLE
Remove update_totals/persist_totals delegation

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -138,7 +138,6 @@ module Spree
       find_by! number: value
     end
 
-    delegate :update_totals, :persist_totals, to: :updater
     delegate :firstname, :lastname, to: :bill_address, prefix: true, allow_nil: true
     alias_method :billing_firstname, :bill_address_firstname
     alias_method :billing_lastname, :bill_address_lastname


### PR DESCRIPTION
These are private methods on `OrderUpdater`, so there's no need for doing
this. Calling these just fails. It's been like like this since 2.2ish when these were made
private.