### PR TITLE
Explicitly require Bundler within Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'bundler'
+
 task default: :spec
 
 def print_title(gem_name = '')


### PR DESCRIPTION
Closes #3021. It fixes an error related to the Rakefile, where rake
tasks which use `Bundler` constant, such as `rake sandbox`, fail if
`bundler` is not explicitly required.