### PR TITLE
Replace jquery_ujs with rails-ujs in frontend and backend

### DIFF
--- a/backend/app/assets/javascripts/spree/backend.js
+++ b/backend/app/assets/javascripts/spree/backend.js
@@ -1,7 +1,5 @@
 //= require solidus_admin/bind-polyfill
 //= require handlebars
-//= require jquery
-//= require rails-ujs
 //= require jquery.sticky-kit.min
 //= require solidus_admin/select2
 //= require solidus_admin/underscore

--- a/backend/app/assets/javascripts/spree/backend.js
+++ b/backend/app/assets/javascripts/spree/backend.js
@@ -1,7 +1,7 @@
 //= require solidus_admin/bind-polyfill
 //= require handlebars
 //= require jquery
-//= require jquery_ujs
+//= require rails-ujs
 //= require jquery.sticky-kit.min
 //= require solidus_admin/select2
 //= require solidus_admin/underscore

--- a/backend/app/assets/javascripts/spree/backend/store_credits.js
+++ b/backend/app/assets/javascripts/spree/backend/store_credits.js
@@ -9,9 +9,25 @@ Spree.ready(function() {
       field.defaultValue = field.value;
       textDisplay.textContent = field.value;
 
-      show_flash('success', data.message);
+      if (typeof data !== "undefined") {
+        // we are using jquery_ujs
+        message = data.message
+      } else {
+        // we are using rails-ujs
+        message = event.detail[0].message
+      }
+
+      show_flash('success', message);
     }).on('ajax:error', function(event, xhr, status, error) {
-      show_flash('error', xhr.responseJSON.message);
+      if (typeof xhr !== "undefined") {
+        // we are using jquery_ujs
+        message = xhr.responseJSON.message
+      } else {
+        // we are using rails-ujs
+        message = event.detail[0].message
+      }
+
+      show_flash('error', message);
     });
 
     row.querySelector('.edit-memo').addEventListener('click', function() {

--- a/backend/spec/features/admin/store_credits_spec.rb
+++ b/backend/spec/features/admin/store_credits_spec.rb
@@ -56,6 +56,55 @@ describe "Store credits admin" do
     end
   end
 
+  describe "displaying a store credit details page" do
+    before do
+      visit spree.admin_path
+      click_link "Users"
+      click_link store_credit.user.email
+      click_link "Store Credit"
+      page.find(".sc-table td.actions a.fa-edit").click
+    end
+
+    it "shows the store credit's information" do
+      within ".content" do
+        expect(page).to have_content "Credited #{store_credit.display_amount}"
+        expect(page).to have_content "Created By #{store_credit.created_by.email}"
+        expect(page).to have_content "Type #{store_credit.category_name}"
+        expect(page).to have_content 'Store credit history'
+      end
+    end
+
+    it "lets edit store credit's memo", js: true do
+      allow_any_instance_of(Spree::Admin::StoreCreditsController)
+        .to receive(:try_spree_current_user)
+        .and_return(admin_user)
+
+      # When there are no errors
+      within '.store-credit-memo-row' do
+        click_button 'Edit'
+        fill_in 'store_credit_memo', with: 'Lottery Won'
+        click_button 'Save'
+        expect(page).to have_content "Memo Lottery Won"
+      end
+      expect(page).to have_content "Store Credit has been successfully updated!"
+
+      # When there are errors
+      allow_any_instance_of(Spree::StoreCredit).to receive(:save) { false }
+      allow_any_instance_of(Spree::StoreCredit)
+        .to receive_message_chain(:errors, :full_messages)
+        .and_return(["Memo is not valid"])
+
+      within '.store-credit-memo-row' do
+        find(:css, ".edit-memo").click
+        fill_in 'store_credit_memo', with: 'Lottery Won Twice'
+        find(:css, ".save-memo").click
+        expect(page).to have_content "Memo Lottery Won"
+        expect(page).not_to have_content "Memo Lottery Won Twice"
+      end
+      expect(page).to have_content "Unable to update store credit [\"Memo is not valid\"]"
+    end
+  end
+
   describe "updating store credit" do
     let(:updated_amount) { "99.0" }
     let!(:update_reason) { create(:store_credit_update_reason) }

--- a/backend/spec/javascripts/spec_helper.js
+++ b/backend/spec/javascripts/spec_helper.js
@@ -4,6 +4,8 @@
 //= require support/chai-jq-0.0.7
 
 //= require_self
+//= require jquery
+//= require rails-ujs
 //= require spree/backend
 //= require_tree ./support
 

--- a/core/lib/generators/spree/install/templates/vendor/assets/javascripts/spree/backend/all.js
+++ b/core/lib/generators/spree/install/templates/vendor/assets/javascripts/spree/backend/all.js
@@ -5,6 +5,6 @@
 // the compiled file.
 //
 //= require jquery
-//= require jquery_ujs
+//= require rails-ujs
 //= require spree/backend
 //= require_tree .

--- a/core/lib/generators/spree/install/templates/vendor/assets/javascripts/spree/frontend/all.js
+++ b/core/lib/generators/spree/install/templates/vendor/assets/javascripts/spree/frontend/all.js
@@ -5,6 +5,6 @@
 // the compiled file.
 //
 //= require jquery
-//= require jquery_ujs
+//= require rails-ujs
 //= require spree/frontend
 //= require_tree .

--- a/core/lib/spree/testing_support/dummy_app/assets/javascripts/spree/backend/all.js
+++ b/core/lib/spree/testing_support/dummy_app/assets/javascripts/spree/backend/all.js
@@ -5,6 +5,6 @@
 // the compiled file.
 //
 //= require jquery
-//= require jquery_ujs
+//= require rails-ujs
 //= require spree/backend
 //= require_tree .

--- a/core/lib/spree/testing_support/dummy_app/assets/javascripts/spree/frontend/all.js
+++ b/core/lib/spree/testing_support/dummy_app/assets/javascripts/spree/frontend/all.js
@@ -5,6 +5,6 @@
 // the compiled file.
 //
 //= require jquery
-//= require jquery_ujs
+//= require rails-ujs
 //= require spree/frontend
 //= require_tree .

--- a/guides/source/developers/assets/asset-management.html.md
+++ b/guides/source/developers/assets/asset-management.html.md
@@ -103,7 +103,7 @@ in this `spree/backend` directory:
 
 ```javascript
 //= require jquery
-//= require jquery_ujs
+//= require rails-ujs
 //= require spree/backend
 //= require_tree .
 ```
@@ -159,4 +159,3 @@ migrations see the [`install_generator` for
 
 [rails-generators]: http://guides.rubyonrails.org/generators.html
 [solidus-static-content-install-generator]: https://github.com/solidusio-contrib/solidus_static_content/blob/master/lib/generators/solidus_static_content/install/install_generator.rb
-


### PR DESCRIPTION
### Why swtiching to rails-ujs?

Starting from version 5.1, Rails already includes a built-in unobtrusive scripting adapter, named `rails-ujs`. This library does not depend anymore on jQuery, like `jquery_ujs` and we should start adopting it.

This PR switches Solidus to this new library to second what Rails does, still allowing users to change it in their own app manifests if needed. 

### Backward compatibility

Backward compatibility should be respected since existing stores manifests files are not changed, so when users upgrade to newer version of Solidus they should still use what they was previously doing.

The only breaking scenario could be when stores changed the provided `backend` manifest from:

```js
//= require jquery
//= require jquery_ujs
//= require spree/backend
//= require_tree .

```

to

```js
//= require spree/backend
//= require_tree .
```

which should be legit since `jquery` and `jquery_ujs` were already included into `spree/backend` manifest. (This PR also removes these double requires). In this case, users can just re-add these two requires to their manifest using either `rails-ujs` or `jquery_ujs`.

### Differences between rails-ujs and jquery_ujs

The only difference in the API is related to how ajax event are handled:

`rails-ujs` passes all the event information into the event.detail object while `jquery_ujs` accepts different parameters. For more details see:

- https://edgeguides.rubyonrails.org/working_with_javascript_in_rails.html#rails-ujs-event-handlers
- https://github.com/rails/jquery-ujs/wiki/ajax
1b20df7


