### PR TITLE
Remove code column from spree_promotions table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,36 @@ PR description for more info.
 
 - Replace jquery_ujs with rails-ujs in frontend and backend [#3027](https://github.com/solidusio/solidus/pull/3027) ([kennyadsl](https://github.com/kennyadsl))
 
+**Removed code from Spree::Promotion**
+
+Previously Solidus used `code` column on `spree_promotions` to add a code
+to promotions that could be used as coupon code by users. This is no more a
+thing since we support multiple coupon codes associated to a single promotion.
+
+This change is important because it's quite common for old stores to have some
+promotion with `code` field still present in the database, even if it's not used.
+When performing the migration present in this PR it will raise an exception if
+there are records in the `spree_promotions` table with that field present.
+It's up to each store to understand how to handle this scenario before running
+this migration. We also provide other two ways to handle this, and users can
+just change the migration after it has been copied into their store.
+It's just matter of changing the content of the
+`RemoveCodeFromSpreePromotions.promotions_with_code_handler` method and make it
+return one of the following:
+
+- `Solidus::Migrations::PromotionWithCodeHandlers::MoveToSpreePromotionCode`:
+  it will convert Spree::Promotion#code to a `Spree::PromotionCode` before
+  removing the `code` column.
+- `Solidus::Migrations::PromotionWithCodeHandlers::DoNothing`: it will print
+  a message to track what we are deleting.
+
+Alternatively users can create their own class to handle data and return that
+class. The new class could inherit from `PromotionsWithCodeHandler` and
+should respond to `call`.
+
+- Remove `code` column from `spree_promotions` table.
+[#3028](https://github.com/solidusio/solidus/pull/3028) ([kennyadsl](https://github.com/kennyadsl))
+
 ### Core
 
 - Fix Spree::Variant inconsistency due to lack of product association [#3043](https://github.com/solidusio/solidus/pull/3043) ([rubenochiavone](https://github.com/rubenochiavone))

--- a/api/spec/features/checkout_spec.rb
+++ b/api/spec/features/checkout_spec.rb
@@ -143,10 +143,6 @@ module Spree
             0 => { variant_id: variant_1.id, quantity: 2 },
             1 => { variant_id: variant_2.id, quantity: 2 }
           },
-          # Would like to do this, but the save process from the orders controller
-          # does not actually call what it needs to to apply this coupon code :(
-          # coupon_code: promotion.code,
-
           # Would like to do this, but it puts the payment in a complete state,
           # which the order does not like when transitioning from confirm to complete
           # since it looks to process pending payments.
@@ -175,10 +171,6 @@ module Spree
             0 => { variant_id: variant_1.id, quantity: 2 },
             1 => { variant_id: variant_2.id, quantity: 2 }
           },
-          # Would like to do this, but the save process from the orders controller
-          # does not actually call what it needs to to apply this coupon code :(
-          # coupon_code: promotion.code,
-
           # Would like to do this, but it puts the payment in a complete state,
           # which the order does not like when transitioning from confirm to complete
           # since it looks to process pending payments.

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -36,7 +36,7 @@ module Spree
 
     before_save :normalize_blank_values
 
-    scope :coupons, -> { where.not(code: nil) }
+    scope :coupons, -> { joins(:codes).distinct }
     scope :advertised, -> { where(advertise: true) }
     scope :active, -> do
       table = arel_table

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -49,11 +49,6 @@ module Spree
     self.whitelisted_ransackable_associations = ['codes']
     self.whitelisted_ransackable_attributes = ['path', 'promotion_category_id']
 
-    # temporary code. remove after the column is dropped from the db.
-    def columns
-      super.reject { |column| column.name == "code" }
-    end
-
     def self.order_activatable?(order)
       order && !UNACTIVATABLE_ORDER_STATES.include?(order.state)
     end

--- a/core/db/migrate/20190106184413_remove_code_from_spree_promotions.rb
+++ b/core/db/migrate/20190106184413_remove_code_from_spree_promotions.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class RemoveCodeFromSpreePromotions < ActiveRecord::Migration[5.1]
+  def up
+    remove_index :spree_promotions, name: :index_spree_promotions_on_code
+    remove_column :spree_promotions, :code
+  end
+
+  def down
+    add_column :spree_promotions, :code, :string
+    add_index :spree_promotions, :code, name: :index_spree_promotions_on_code
+  end
+end

--- a/core/db/migrate/20190106184413_remove_code_from_spree_promotions.rb
+++ b/core/db/migrate/20190106184413_remove_code_from_spree_promotions.rb
@@ -1,7 +1,22 @@
 # frozen_string_literal: true
 
+require 'solidus/migrations/promotions_with_code_handlers'
+
 class RemoveCodeFromSpreePromotions < ActiveRecord::Migration[5.1]
+  class Promotion < ActiveRecord::Base
+    self.table_name = "spree_promotions"
+  end
+
   def up
+    promotions_with_code = Promotion.where.not(code: nil)
+
+    if promotions_with_code.any?
+      # You have some promotions with "code" field present! This is not good
+      # since we are going to remove that column.
+      #
+      self.class.promotions_with_code_handler.new(self, promotions_with_code).call
+    end
+
     remove_index :spree_promotions, name: :index_spree_promotions_on_code
     remove_column :spree_promotions, :code
   end
@@ -9,5 +24,18 @@ class RemoveCodeFromSpreePromotions < ActiveRecord::Migration[5.1]
   def down
     add_column :spree_promotions, :code, :string
     add_index :spree_promotions, :code, name: :index_spree_promotions_on_code
+  end
+
+  def self.promotions_with_code_handler
+    # We propose different approaches, just pick the one that you prefer or
+    # write your custom one.
+    #
+    # The fist one (raising an exception) is the default but you can
+    # comment/uncomment the one then better fits you needs or use a
+    # custom class or callable object.
+    #
+    Solidus::Migrations::PromotionWithCodeHandlers::RaiseException
+    # Solidus::Migrations::PromotionWithCodeHandlers::MoveToSpreePromotionCode
+    # Solidus::Migrations::PromotionWithCodeHandlers::DoNothing
   end
 end

--- a/core/lib/solidus/migrations/promotions_with_code_handlers.rb
+++ b/core/lib/solidus/migrations/promotions_with_code_handlers.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module Solidus
+  module Migrations
+    module PromotionWithCodeHandlers
+      class PromotionCode < ActiveRecord::Base
+        self.table_name = "spree_promotion_codes"
+      end
+
+      class Base
+        attr_reader :migration_context, :promotions
+
+        def initialize(migration_context, promotions)
+          @migration_context = migration_context
+          @promotions = promotions
+        end
+      end
+
+      class RaiseException < Base
+        def call
+          # Please note that this will block the current migration and rollback all
+          # the previous ones run with the same "rails db:migrate" command.
+          #
+          raise StandardError, "You are trying to drop 'code' column from "\
+            "spree_promotions table but you have at least one record with that "\
+            "column filled. Please take care of that or you could lose data. See:" \
+            "\n" \
+            "https://github.com/solidusio/solidus/pull/3028"\
+            "\n"
+        end
+      end
+
+      class MoveToSpreePromotionCode < Base
+        def call
+          # This is another possible approach, it will convert Spree::Promotion#code
+          # to a Spree::PromotionCode before removing the `code` field.
+          #
+          # NOTE: promotion codes will be downcased and stripped
+          promotions.find_each do |promotion|
+            normalized_code = promotion.code.downcase.strip
+
+            PromotionCode.find_or_create_by!(
+              value: normalized_code,
+              promotion_id: promotion.id
+            ) do
+              migration_context.say "Creating Spree::PromotionCode with value "\
+               "'#{normalized_code}' for Spree::Promotion with id '#{promotion.id}'"
+            end
+          end
+        end
+      end
+
+      class DoNothing < Base
+        def call
+          # This approach will delete all codes without taking any action. At
+          # least we could print a message to track what we are deleting.
+          #
+          promotions.find_each do |promotion|
+            migration_context.say "Code '#{promotion.code}' is going to be removed "\
+              "from Spree::Promotion with id '#{promotion.id}'"
+          end
+        end
+      end
+    end
+  end
+end

--- a/core/spec/migrate/20190106184413_remove_code_from_spree_promotions_spec.rb
+++ b/core/spec/migrate/20190106184413_remove_code_from_spree_promotions_spec.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require Spree::Core::Engine.root.join('db/migrate/20190106184413_remove_code_from_spree_promotions.rb')
+
+RSpec.describe RemoveCodeFromSpreePromotions do
+  let(:migrations_paths) { ActiveRecord::Migrator.migrations_paths }
+  let(:migrations) do
+    if ActiveRecord::Base.connection.respond_to?(:migration_context)
+      # Rails >= 5.2
+      ActiveRecord::MigrationContext.new(migrations_paths).migrations
+    else
+      ActiveRecord::Migrator.migrations(migrations_paths)
+    end
+  end
+  let(:previous_version) { 20180710170104 }
+  let(:current_version) { 20190106184413 }
+
+  subject { ActiveRecord::Migrator.new(:up, migrations, current_version).migrate }
+
+  # This is needed for MySQL since it is not able to rollback to the previous
+  # state when database schema changes within that transaction.
+  before(:all) { self.use_transactional_tests = false }
+  after(:all)  { self.use_transactional_tests = true }
+
+  around do |example|
+    DatabaseCleaner.clean_with(:truncation)
+    # Silence migrations output in specs report.
+    ActiveRecord::Migration.suppress_messages do
+      # Migrate back to the previous version
+      ActiveRecord::Migrator.new(:down, migrations, previous_version).migrate
+      # If other tests using Spree::Promotion ran before this one, Rails has
+      # stored information about table's columns and we need to reset those
+      # since the migration changed the database structure.
+      Spree::Promotion.reset_column_information
+
+      example.run
+
+      # Re-update column information after the migration has been executed
+      # again in the example. This will make the promotion attributes cache
+      # ready for other tests.
+      Spree::Promotion.reset_column_information
+    end
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
+  context 'when there are no promotions with code' do
+    it 'does not call any promotion with code handler' do
+      expect(described_class).not_to receive(:promotions_with_code_handler)
+
+      subject
+    end
+  end
+
+  context 'when there are promotions with code' do
+    let(:promotion_with_code) { create(:promotion) }
+
+    before do
+      # We can't set code via factory since `code=` is currently raising
+      # an error, see more at:
+      # https://github.com/solidusio/solidus/blob/cf96b03eb9e80002b69736e082fd485c870ab5d9/core/app/models/spree/promotion.rb#L65
+      promotion_with_code.update_column(:code, 'Just An Old Promo Code')
+    end
+
+    context 'with the deafult handler (Solidus::Migrations::PromotionWithCodeHandlers::RaiseException)' do
+      it 'raise a StandardError exception' do
+        expect { subject }.to raise_error(StandardError)
+      end
+    end
+
+    context 'changing the default handler' do
+      before do
+        allow(described_class)
+          .to receive(:promotions_with_code_handler)
+          .and_return(promotions_with_code_handler)
+      end
+
+      context 'to Solidus::Migrations::PromotionWithCodeHandlers::MoveToSpreePromotionCode' do
+        let(:promotions_with_code_handler) { Solidus::Migrations::PromotionWithCodeHandlers::MoveToSpreePromotionCode }
+
+        context 'when there are no Spree::PromotionCode with the same value' do
+          it 'moves the code into a Spree::PromotionCode' do
+            migration_context = double('a migration context')
+            allow_any_instance_of(promotions_with_code_handler)
+              .to receive(:migration_context)
+              .and_return(migration_context)
+
+            expect(migration_context)
+              .to receive(:say)
+              .with("Creating Spree::PromotionCode with value 'just an old promo code' for Spree::Promotion with id '#{promotion_with_code.id}'")
+
+            expect { subject }
+              .to change { Spree::PromotionCode.all.size }
+              .from(0)
+              .to(1)
+          end
+        end
+
+        context 'when there is a Spree::PromotionCode with the same value' do
+          context 'associated with the same promotion' do
+            let!(:existing_promotion_code) { create(:promotion_code, value: 'just an old promo code', promotion: promotion_with_code) }
+
+            it 'does not create a new Spree::PromotionCode' do
+              expect { subject }.not_to change { Spree::PromotionCode.all.size }
+            end
+          end
+
+          context 'associated with another promotion' do
+            let!(:existing_promotion_code) { create(:promotion_code, value: 'just an old promo code') }
+
+            it 'raises an exception' do
+              expect { subject }.to raise_error(StandardError)
+            end
+          end
+        end
+      end
+
+      context 'to Solidus::Migrations::PromotionWithCodeHandlers::DoNothing' do
+        let(:promotions_with_code_handler) { Solidus::Migrations::PromotionWithCodeHandlers::DoNothing }
+
+        it 'just prints a message' do
+          migration_context = double('a migration context')
+          allow_any_instance_of(promotions_with_code_handler)
+            .to receive(:migration_context)
+            .and_return(migration_context)
+
+          expect(migration_context)
+            .to receive(:say)
+            .with("Code 'Just An Old Promo Code' is going to be removed from Spree::Promotion with id '#{promotion_with_code.id}'")
+
+          subject
+        end
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -49,6 +49,19 @@ RSpec.describe Spree::Promotion, type: :model do
     end
   end
 
+  describe ".coupons" do
+    let(:promotion_code) { create(:promotion_code) }
+    let!(:promotion_with_code) { promotion_code.promotion }
+    let!(:another_promotion_code) { create(:promotion_code, promotion: promotion_with_code) }
+    let!(:promotion_without_code) { create(:promotion) }
+
+    subject { described_class.coupons }
+
+    it "returns only distinct promotions with a code associated" do
+      expect(subject).to eq [promotion_with_code]
+    end
+  end
+
   describe "#apply_automatically" do
     subject { build(:promotion) }
 


### PR DESCRIPTION
# Description

This PR removes `code` column form `Spree::Promotion` since promotions are now tied to multiple codes via `Spree::PromotionCode`. 

Ref. #2979 

# TODO:

- [x] [Remove columns method on Spree::Promotion](https://github.com/solidusio/solidus/blob/master/core/app/models/spree/promotion.rb#L52-L55). This should be done in sync with #3000

# Checklist:

- [ ] [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines) are respected
- [ ] Documentation/Readme have been updated accordingly
- [ ] Changes are covered by tests (if possible)
- [ ] Each commit has a meaningful message attached that described WHAT changed, and WHY
