### PR TITLE
fixed nested attributes delete issue

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/admin.js
+++ b/backend/app/assets/javascripts/spree/backend/admin.js
@@ -101,7 +101,7 @@ Spree.ready(function(){
 
   $('body').on('click', 'a.spree_remove_fields', function() {
     var el = $(this);
-    el.prev("input[type=hidden]").val("1");
+    el.next("input[type=hidden]").val("1");
     el.closest(".fields").hide();
     if (el.prop("href").substr(-1) == '#') {
       el.parents("tr").fadeOut('hide');


### PR DESCRIPTION
# Description
I found an issue , when we try to add the a nested record like in product property page if we add a  new property, and fill any data in the newly added fields. after that I'll click on delete icon, without making field empty. 

In this case I see that newly added field not shown in page, but if I click on save or edit button, I see that the records are created in the database.

Here the issue is , when we click on the delete button, Javascript code try to find that dom element and try to change val, but the dom element not found. so the destroy value not set and it submit as a nil value.
