### PR TITLE
Fix missing image in autocomplete variant

### DIFF
--- a/core/app/models/spree/gallery/variant_gallery.rb
+++ b/core/app/models/spree/gallery/variant_gallery.rb
@@ -11,7 +11,10 @@ module Spree
       #
       # @return [Enumerable<Spree::Image>] all images in the gallery
       def images
-        @images ||= @variant.images
+        @images ||=
+          @variant.images.presence ||
+          (!@variant.is_master? && @variant.product.master.images).presence ||
+          Spree::Image.none
       end
     end
   end

--- a/core/spec/models/spree/gallery/variant_gallery_spec.rb
+++ b/core/spec/models/spree/gallery/variant_gallery_spec.rb
@@ -5,7 +5,7 @@ require 'spree/testing_support/shared_examples/gallery'
 
 RSpec.describe Spree::Gallery::VariantGallery do
   let(:gallery) { described_class.new(variant) }
-  let(:variant) { Spree::Variant.new }
+  let(:variant) { build_stubbed(:variant) }
 
   shared_context 'has multiple images' do
     let(:first_image) { build(:image) }

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -811,12 +811,45 @@ RSpec.describe Spree::Variant, type: :model do
     end
   end
 
-  describe '#gallery' do
-    let(:product) { Spree::Variant.new }
-    subject { product.gallery }
+  describe "#gallery" do
+    let(:variant) { build_stubbed(:variant) }
+    subject { variant.gallery }
 
-    it 'responds to #images' do
+    it "responds to #images" do
       expect(subject).to respond_to(:images)
+    end
+
+    context "when variant.images is empty" do
+      let(:product) { create(:product) }
+      let(:variant) { create(:variant, product: product) }
+
+      it "fallbacks to variant.product.master.images" do
+        product.master.images = [create(:image)]
+
+        expect(product.master).not_to eq variant
+
+        expect(variant.gallery.images).to eq product.master.images
+      end
+
+      context "and variant.product.master.images is also empty" do
+        it "returns Spree::Image.none" do
+          expect(product.master).not_to eq variant
+          expect(product.master.images.presence).to be nil
+
+          expect(variant.gallery.images).to eq Spree::Image.none
+        end
+      end
+
+      context "and is master" do
+        it "returns Spree::Image.none" do
+          variant = product.master
+
+          expect(variant.is_master?).to be true
+          expect(variant.images.presence).to be nil
+
+          expect(variant.gallery.images).to eq Spree::Image.none
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
# Description

If variant don't have images no image appears in autocomplete view (for example, trying to add a product variant to an order from admin). It should instead display master image as in the other parts of solidus.

~~To fix it, added `display_images` method in `Spree::Variant` to get image list to be used for variant. This method checks if `variant.images` is an empty array before returning it but also falls back to `variant.product.master.images` to avoid returning an empty array.~~

~~Since image from autocomplete variant views are created using `Spree::Gallery::VariantGallery`, changed `variant.images` call to `variant.display_images` in `images` method.~~

**Edit**

To fix it, improve `Spree::Gallery::VariantGallery#images` method to checks if `@variant.images` is empty before returning it but also falls back to `@variant.product.master.images` to avoid returning `Spree::Image.none`.

Closes #2951

# Checklist:

- [x] [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines) are respected
- [x] Changes are covered by tests (if possible)
- [x] Each commit has a meaningful message attached that described WHAT changed, and WHY

Not sure if **"Documentation/Readme have been updated accordingly"** should be done for this one.
