### PR TITLE
PoC: Decorators / Presenters [WIP]

### DIFF
--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -119,6 +119,10 @@ module Spree
         countries = Country.all
       end
 
+      Spree::CountryListPresenter.new(countries)
+    end
+
+    def countries_for_select(countries)
       country_names = Carmen::Country.all.map do |country|
         [country.code, country.name]
       end.to_h

--- a/core/app/presenters/spree/country_active_decorator_presenter.rb
+++ b/core/app/presenters/spree/country_active_decorator_presenter.rb
@@ -1,0 +1,19 @@
+module Spree
+  module CountryActiveDecoratorPresenter
+    def name
+      "CountryActiveDecoratorPresenter: #{translated_name || carmen_name || super}"
+    end
+
+    def carmen_country
+      Carmen::Country.coded iso
+    end
+
+    def carmen_name
+      carmen_country.try :name
+    end
+
+    def translated_name
+      I18n.t("spree.country_names.#{iso}", default: nil)
+    end
+  end
+end

--- a/core/app/presenters/spree/country_list_presenter.rb
+++ b/core/app/presenters/spree/country_list_presenter.rb
@@ -1,0 +1,15 @@
+module Spree
+  class CountryListPresenter < Spree::Presenter::Delegated
+    def initialize(subject)
+      subject = prepare_countries(subject)
+
+      super
+    end
+
+    protected
+
+    def prepare_countries(countries)
+      countries.map { |country| Spree::CountryPresenter.new(country) }.sort_by { |c| c.name.parameterize }
+    end
+  end
+end

--- a/core/app/presenters/spree/country_presenter.rb
+++ b/core/app/presenters/spree/country_presenter.rb
@@ -1,0 +1,19 @@
+module Spree
+  class CountryPresenter < Spree::Presenter::Delegated
+    def name
+      translated_name || carmen_name || super
+    end
+
+    def carmen_country
+      Carmen::Country.coded iso
+    end
+
+    def carmen_name
+      carmen_country.try :name
+    end
+
+    def translated_name
+      I18n.t("spree.country_names.#{iso}", default: nil)
+    end
+  end
+end

--- a/core/config/initializers/active_decorator.rb
+++ b/core/config/initializers/active_decorator.rb
@@ -1,0 +1,8 @@
+begin
+  ActiveDecorator.configure do |config|
+    config.decorator_suffix = 'ActiveDecoratorPresenter'
+  end
+rescue NameError => e
+
+  raise e unless e.missing_name? 'ActiveDecorator'
+end

--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -86,6 +86,7 @@ require 'spree/core/role_configuration'
 require 'spree/core/stock_configuration'
 require 'spree/core/validators/email'
 require 'spree/permission_sets'
+require 'spree/presenter'
 
 require 'spree/preferences/store'
 require 'spree/preferences/static_model_preferences'

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -15,6 +15,8 @@ module Spree
         g.test_framework :rspec
       end
 
+      config.eager_load_paths << "#{config.root}/app/presenters"
+
       initializer "spree.environment", before: :load_config_initializers do |app|
         app.config.spree = Spree::Config.environment
       end

--- a/core/lib/spree/presenter.rb
+++ b/core/lib/spree/presenter.rb
@@ -1,0 +1,9 @@
+module Spree
+  module Presenter
+  end
+end
+
+# require 'spree/presenter/base'
+require 'spree/presenter/simple'
+require 'spree/presenter/delegated'
+require 'spree/presenter/extended'

--- a/core/lib/spree/presenter/delegated.rb
+++ b/core/lib/spree/presenter/delegated.rb
@@ -1,0 +1,13 @@
+module Spree
+  module Presenter
+    class Delegated < SimpleDelegator
+      attr_reader :subject
+
+      def initialize(subject)
+        @subject = subject
+
+        super(subject)
+      end
+    end
+  end
+end

--- a/core/lib/spree/presenter/extended.rb
+++ b/core/lib/spree/presenter/extended.rb
@@ -1,0 +1,23 @@
+module Spree
+  module Presenter
+    class Extended < SimpleDelegator
+      # CannotOverrideMethodError = Class.new(StandardError)
+      #
+      # attr_reader :subject
+      #
+      # def initialize(subject, **locals)
+      #   @subject = subject
+      #
+      #   locals.each do |key, value|
+      #     if subject.respond_to?(key)
+      #       raise CannotOverrideMethodError.new("#{subject} already respond to #{key}!")
+      #     end
+      #
+      #     define_singleton_method(key) { value }
+      #   end
+      #
+      #   super(subject)
+      # end
+    end
+  end
+end

--- a/core/lib/spree/presenter/simple.rb
+++ b/core/lib/spree/presenter/simple.rb
@@ -1,0 +1,11 @@
+module Spree
+  module Presenter
+    class Simple
+      attr_reader :subject
+
+      def initialize(subject)
+        @subject = subject
+      end
+    end
+  end
+end


### PR DESCRIPTION
# PoC: Decorators / Presenters [WIP]

## Introduction

Hello, I'm trying to find a better way to handle view logic on Solidus.

### Brief recap about view logic management patterns

Helpers have always been the  Achilles' heel of the full object oriented of Rails. Even [Steve Klabnik complained about them](http://blog.steveklabnik.com/posts/2011-09-09-better-ruby-presenters). But, what are the alternatives?

#### Presenter pattern

The Presenter pattern couples view logic with the controller/action. So, for example, if you have a PagesController with `home` and `about` actions, you could have:

```ruby
class PagesPresenter < ApplicationPresenter
  def nav_items
    [ { name: 'Home', path: home_path } ,
      { name: 'About', path: about_path } ]
  end
end

class Pages::HomePresenter < PagesPresenter
  def greeting
    "Hi, #{current_user.nickname}!" if current_user
  end
end
```

#### Presentation Model (aka Decorator) pattern

The Presentation Model pattern couples view logic with the model instance. So, for example, if you have a User model, you could have:

```ruby
class UserDecorator
  def full_name
    "#{first_name} #{last_name}"
  end
end

UserDecorator.decorate(User.new)
```

Essentially, a presenter is a class which takes as input the object to be presented (let's call it _subject_) and returns an instance of it after having applied some view logic related augmentations (that are often called _decorations_, as presenters are often known as _decorators_, but let's avoid that name, since on Solidus _decorators_ already indicate overrides of the platform business logic).

The main advantage of it is that you have a place where to put view logic related to models, while, without presenters, you are forced whether or to dirty the model class, or to use helpers, thus precluding OOP (see e.g. https://github.com/solidusio/solidus/blob/aabb0967c0796b7c301c963f88dbf8947236773c/core/app/helpers/spree/base_helper.rb#L113-L126).

## My effort

First, I looked into the current state of things regarding existing Ruby presenters implementations. This is the summary:

### https://github.com/drapergem/draper

#### API samples

```ruby
Article.find(params[:id]).decorate
```

#### pros

- full featured

- has been around for a while

- pretty popular (~ 4.5k GH stars)

#### cons

- a bit bloated

- maintenance is "meh"

- `Decorator` suffix can't be customized (and we already have decorators concept which would lead to confusion)

## https://github.com/amatsuda/active_decorator

#### API samples

```ruby
# inside views
@author.full_name
# Explicit call
```

#### pros

- from Kaminari's author

- simple and clean

- `Decorator` suffix can be customized

#### cons

- not very popular (~ 200 GH stars)

- has auto-decoration. To me it means that we could have many issues like "why is country.name in the controller different from Spree::Country.find(1).name in the console?!"

### https://github.com/sztheory/meta_presenter

#### pros

- Uses `Presenter` instead of `Decorator`

#### cons

- still in early stage

- few GH stars (5)

## https://gitlab.com/gitlab-org/gitlab-ce/blob/master/app/presenters/README.md

```ruby
class Spree::CountriesPresenter
  presents :countries
end
# Spree::Presenter.present(countries, attributes: { current_user: user }, as: 'Spree::CountryList')
Spree::CountryListPresenter.present(countries, attributes: { current_user: user })
```

## Performance

Unfortunately, abstraction doesn't come for free: it comes with runtime overhead.
