### PR TITLE
Fix Spree::Order::InsufficientStock error raised when confirming an order

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -465,7 +465,8 @@ module Spree
     end
 
     def insufficient_stock_lines
-      line_items.select(&:insufficient_stock?)
+      availability_validator = Spree::Stock::AvailabilityValidator.new
+      line_items.select { |line_item| line_item.insufficient_stock? || !availability_validator.validate(line_item) }
     end
 
     ##

--- a/frontend/spec/features/checkout_insufficient_stock_spec.rb
+++ b/frontend/spec/features/checkout_insufficient_stock_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe "Checkout confirm page", type: :feature do
+  include_context 'checkout setup'
+
+  context 'when there is not enough stock at the default stock location' do
+    context "when the product is not backorderable" do
+      let(:user) { create(:user) }
+
+      let(:order) { Spree::TestingSupport::OrderWalkthrough.up_to(:payment) }
+      let(:order_product) { order.products.first }
+      let(:order_stock_item) { order_product.stock_items.first }
+
+      before do
+        order_stock_item.update! backorderable: false
+
+        allow_any_instance_of(Spree::CheckoutController).to receive_messages(current_order: order)
+        allow_any_instance_of(Spree::CheckoutController).to receive_messages(try_spree_current_user: user)
+        allow_any_instance_of(Spree::OrdersController).to receive_messages(try_spree_current_user: user)
+      end
+
+      context 'when there are not other backorderable stock locations' do
+        before { visit spree.checkout_state_path(:confirm) }
+
+        it 'redirects to cart page and shows an unavailable product message' do
+          expect(page).to have_content "#{order_product.name} became unavailable"
+          expect(page).to have_current_path spree.cart_path
+        end
+      end
+
+      context 'when there is another backorderable stock location' do
+        before do
+          create :stock_location, backorderable_default: true, default: false
+          visit spree.checkout_state_path(:confirm)
+        end
+
+        it 'redirects to cart page and shows an unavailable product message' do
+          expect(page).to have_content "#{order_product.name} became unavailable"
+          expect(page).to have_current_path spree.cart_path
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Description

When two users try to purchase the last item remaining from a non-backordeable stock location at the same time then the last one will experience an unhandled error `Spree::Order::InsufficientStock`. This happens only if there is a second backorderable stock location for the product.

## Fix

Improved `Spree::Order.insufficient_stock_lines` method to also map `@order.line_items` that are not validated using `Spree::Stock::AvailabilityValidator`.

## Tests

Added tests from @spaghetticode's [gist](https://gist.githubusercontent.com/spaghetticode/35dd0d91625a65d75aee32e383af795c/raw/184f921564770c1d2c8c1006d9e1714171b3f6cd/checkout_insufficient_stock_spec.rb). Had to improve on it since now validation prevents user to advance to next checkout page.

Closes #3020.

# Checklist:

- [x] [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines) are respected
- [x] Changes are covered by tests (if possible)
- [x] Each commit has a meaningful message attached that described WHAT changed, and WHY
