### PR TITLE
Add countries to state selection for zones

### DIFF
--- a/backend/app/views/spree/admin/zones/_state_members.html.erb
+++ b/backend/app/views/spree/admin/zones/_state_members.html.erb
@@ -4,7 +4,7 @@
 
     <%= zone_form.field_container :state_ids do %>
       <%= zone_form.label :state_ids, plural_resource_name(Spree::State) %><br>
-      <%= zone_form.collection_select :state_ids, @states, :id, :name, {}, { multiple: true, class: "select2 fullwidth" } %>
+      <%= zone_form.collection_select :state_ids, @states, :id, :state_with_country, {}, { multiple: true, class: "select2 fullwidth" } %>
     <% end %>
   </fieldset>
 </div>

--- a/core/app/models/spree/state.rb
+++ b/core/app/models/spree/state.rb
@@ -36,5 +36,9 @@ module Spree
     def to_s
       name
     end
+
+    def state_with_country
+      "#{name} (#{country})"
+    end
   end
 end


### PR DESCRIPTION
# Description
<!--
  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
-->

This PR adds countries to the state selection when editing a zone. 

<img width="465" alt="screen shot 2019-01-15 at 8 10 31 pm" src="https://user-images.githubusercontent.com/11466782/51222082-b727a080-1901-11e9-84c8-cf5ab016023c.png">

This helps you keep from accidentally trying to ship things to Maryland, Liberia when you'd like to ship things to Maryland, USA.  😬 

# Checklist:

- [x] [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines) are respected
~- [ ] Documentation/Readme have been updated accordingly~
~- [ ] Changes are covered by tests (if possible)~
- [x] Each commit has a meaningful message attached that described WHAT changed, and WHY
