### PR TITLE
Remove state machine gem from Spree::Shipment (updated PR #2656)

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -161,14 +161,17 @@ module Spree
     def can_transition_from_pending_to_shipped?
       !requires_shipment?
     end
+    deprecate can_transition_from_pending_to_shipped?: '!requires_shipment?', deprecator: Spree::Deprecation
 
     def can_transition_from_pending_to_ready?
       inventory_can_ship?
     end
+    deprecate can_transition_from_pending_to_ready?: :inventory_can_ship?, deprecator: Spree::Deprecation
 
     def can_transition_from_canceled_to_ready?
       can_transition_from_pending_to_ready?
     end
+    deprecate can_transition_from_canceled_to_ready?: :inventory_can_ship?, deprecator: Spree::Deprecation
 
     extend DisplayMoney
     money_methods(

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -4,6 +4,14 @@ module Spree
   # An order's planned shipments including tracking and cost.
   #
   class Shipment < Spree::Base
+    class InvalidStateChange < StandardError; end
+
+    READY = 'ready'
+    PENDING = 'pending'
+    SHIPPED = 'shipped'
+    CANCELED = 'canceled'
+    DEFAULT_STATES = [READY, PENDING, SHIPPED, CANCELED]
+
     belongs_to :order, class_name: 'Spree::Order', touch: true, inverse_of: :shipments
     belongs_to :stock_location, class_name: 'Spree::StockLocation'
 
@@ -14,6 +22,8 @@ module Spree
     has_many :state_changes, as: :stateful
     has_many :cartons, -> { distinct }, through: :inventory_units
     has_many :line_items, -> { distinct }, through: :inventory_units
+
+    validate :is_valid_state?
 
     before_validation :set_cost_zero_when_nil
 
@@ -27,9 +37,9 @@ module Spree
 
     make_permalink field: :number, length: 11, prefix: 'H'
 
-    scope :pending, -> { with_state('pending') }
-    scope :ready,   -> { with_state('ready') }
-    scope :shipped, -> { with_state('shipped') }
+    scope :pending, -> { with_state(PENDING) }
+    scope :ready,   -> { with_state(READY) }
+    scope :shipped, -> { with_state(SHIPPED) }
     scope :trackable, -> { where("tracking IS NOT NULL AND tracking != ''") }
     scope :with_state, ->(*s) { where(state: s) }
     # sort by most recent shipped_at, falling back to created_at. add "id desc" to make specs that involve this scope more deterministic.
@@ -39,40 +49,102 @@ module Spree
 
     scope :by_store, ->(store) { joins(:order).merge(Spree::Order.by_store(store)) }
 
-    # shipment state machine (see http://github.com/pluginaweek/state_machine/tree/master for details)
-    state_machine initial: :pending, use_transactions: false do
-      event :ready do
-        transition from: :pending, to: :shipped, if: :can_transition_from_pending_to_shipped?
-        transition from: :pending, to: :ready, if: :can_transition_from_pending_to_ready?
-      end
+    def cancel!
+      cancel || raise(InvalidStateChange)
+    end
 
-      event :pend do
-        transition from: :ready, to: :pending
-      end
+    def cancel
+      return false unless can_cancel?
+      change_state!(CANCELED)
+      after_cancel
+      true
+    end
 
-      event :ship do
-        transition from: [:ready, :canceled], to: :shipped
-      end
-      after_transition to: :shipped, do: :after_ship
+    def can_cancel?
+      ready_or_pending?
+    end
 
-      event :cancel do
-        transition to: :canceled, from: [:pending, :ready]
-      end
-      after_transition to: :canceled, do: :after_cancel
+    def canceled?
+      state == CANCELED
+    end
 
-      event :resume do
-        transition from: :canceled, to: :ready, if: :can_transition_from_canceled_to_ready?
-        transition from: :canceled, to: :pending
-      end
-      after_transition from: :canceled, to: [:pending, :ready, :shipped], do: :after_resume
+    def resume!
+      resume || raise(InvalidStateChange)
+    end
 
-      after_transition do |shipment, transition|
-        shipment.state_changes.create!(
-          previous_state: transition.from,
-          next_state:     transition.to,
-          name:           'shipment'
-        )
+    def resume
+      return false unless can_resume?
+      can_transition_from_canceled_to_ready? ? change_state!(READY) : change_state!(PENDING)
+      after_resume
+      true
+    end
+
+    def can_resume?
+      canceled?
+    end
+
+    def ship!
+      ship || raise(InvalidStateChange)
+    end
+
+    def ship
+      return false unless can_ship?
+      previous_state = state
+      change_state!(SHIPPED)
+      after_ship
+      after_resume if previous_state == CANCELED
+      true
+    end
+
+    def can_ship?
+      ready? || canceled?
+    end
+
+    def shipped?
+      state == SHIPPED
+    end
+
+    def ready!
+      ready || raise(InvalidStateChange)
+    end
+
+    def ready
+      return false unless state == PENDING
+      if can_transition_from_pending_to_shipped?
+        change_state!(SHIPPED)
+        after_ship
+      elsif can_transition_from_pending_to_ready?
+        change_state!(READY)
+      else
+        return false
       end
+      true
+    end
+
+    def ready?
+      state == READY
+    end
+
+    def can_ready?
+      pending? && (can_transition_from_pending_to_shipped? || can_transition_from_pending_to_ready?)
+    end
+
+    def pend!
+      pend || raise(InvalidStateChange)
+    end
+
+    def pend
+      return false unless can_pend?
+      change_state!(PENDING)
+      true
+    end
+
+    def pending?
+      state == PENDING
+    end
+
+    def can_pend?
+      ready?
     end
 
     self.whitelisted_ransackable_associations = ['order']
@@ -259,13 +331,13 @@ module Spree
     # shipped    if already shipped (ie. does not change the state)
     # ready      all other cases
     def determine_state(order)
-      return 'canceled' if order.canceled?
-      return 'shipped' if shipped?
-      return 'pending' unless order.can_ship?
+      return CANCELED if order.canceled?
+      return SHIPPED if shipped?
+      return PENDING unless order.can_ship?
       if can_transition_from_pending_to_ready?
-        'ready'
+        READY
       else
-        'pending'
+        PENDING
       end
     end
 
@@ -350,7 +422,7 @@ module Spree
           state: new_state,
           updated_at: Time.current
         )
-        after_ship if new_state == 'shipped'
+        after_ship if new_state == SHIPPED
       end
     end
 
@@ -428,6 +500,27 @@ module Spree
       if shipped? || canceled?
         errors.add(:state, :cannot_destroy, state: state)
         throw :abort
+      end
+    end
+
+    def store_state_change(previous_state, new_state)
+      state_changes.create!(
+        previous_state: previous_state,
+        next_state:     new_state,
+        name:           'shipment'
+      )
+    end
+
+    def change_state!(new_state)
+      previous_state = state
+      return if new_state == previous_state
+      update!(state: new_state)
+      store_state_change(previous_state, new_state)
+    end
+
+    def is_valid_state?
+      unless DEFAULT_STATES.include?(state)
+        errors.add(:state, "Invalid state")
       end
     end
   end

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -74,7 +74,7 @@ module Spree
 
     def resume
       return false unless can_resume?
-      can_transition_from_canceled_to_ready? ? change_state!(READY) : change_state!(PENDING)
+      inventory_can_ship? ? change_state!(READY) : change_state!(PENDING)
       after_resume
       true
     end
@@ -110,10 +110,10 @@ module Spree
 
     def ready
       return false unless state == PENDING
-      if can_transition_from_pending_to_shipped?
+      if !requires_shipment?
         change_state!(SHIPPED)
         after_ship
-      elsif can_transition_from_pending_to_ready?
+      elsif inventory_can_ship?
         change_state!(READY)
       else
         return false
@@ -126,7 +126,7 @@ module Spree
     end
 
     def can_ready?
-      pending? && (can_transition_from_pending_to_shipped? || can_transition_from_pending_to_ready?)
+      pending? && (!requires_shipment? || inventory_can_ship?)
     end
 
     def pend!
@@ -152,14 +152,18 @@ module Spree
 
     delegate :tax_category, :tax_category_id, to: :selected_shipping_rate, allow_nil: true
 
+    def inventory_can_ship?
+      order.can_ship? &&
+        inventory_units.all? { |iu| iu.shipped? || iu.allow_ship? || iu.canceled? } &&
+        (order.paid? || !Spree::Config[:require_payment_to_ship])
+    end
+
     def can_transition_from_pending_to_shipped?
       !requires_shipment?
     end
 
     def can_transition_from_pending_to_ready?
-      order.can_ship? &&
-        inventory_units.all? { |iu| iu.shipped? || iu.allow_ship? || iu.canceled? } &&
-        (order.paid? || !Spree::Config[:require_payment_to_ship])
+      inventory_can_ship?
     end
 
     def can_transition_from_canceled_to_ready?
@@ -334,7 +338,7 @@ module Spree
       return CANCELED if order.canceled?
       return SHIPPED if shipped?
       return PENDING unless order.can_ship?
-      if can_transition_from_pending_to_ready?
+      if inventory_can_ship?
         READY
       else
         PENDING

--- a/core/db/migrate/20180404185904_add_default_state_to_shipment.rb
+++ b/core/db/migrate/20180404185904_add_default_state_to_shipment.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDefaultStateToShipment < ActiveRecord::Migration[5.1]
+  def change
+    change_column_default(:spree_shipments, :state, 'pending')
+  end
+end

--- a/core/spec/models/spree/order/state_machine_spec.rb
+++ b/core/spec/models/spree/order/state_machine_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Spree::Order, type: :model do
       end
     end
 
-    (Spree::Shipment.state_machine.states.keys - states).each do |shipment_state|
+    ['shipped', 'canceled'].each do |shipment_state|
       it "should be false if shipment_state is #{shipment_state}" do
         expect(order).to be_completed
         order.shipment_state = shipment_state

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -1213,4 +1213,34 @@ RSpec.describe Spree::Shipment, type: :model do
 
     it { is_expected.to include carton }
   end
+
+  describe '#inventory_can_ship?' do
+    let(:shipment) { create(:shipment, order: order) }
+
+    subject { shipment.inventory_can_ship? }
+
+    context "with backordered inventory" do
+      before { shipment.inventory_units.update_all(state: "backordered") }
+
+      it "returns false" do
+        expect(subject).to be false
+      end
+    end
+
+    context "with on_hand inventory" do
+      before { shipment.inventory_units.update_all(state: "on_hand") }
+
+      it "returns true" do
+        expect(subject).to be true
+      end
+    end
+
+    context "with shipped inventory" do
+      before { shipment.inventory_units.update_all(state: "shipped") }
+
+      it "returns true" do
+        expect(subject).to be true
+      end
+    end
+  end
 end

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -408,15 +408,28 @@ RSpec.describe Spree::Shipment, type: :model do
     end
   end
 
-  context "#cancel" do
-    it 'cancels the shipment' do
-      allow(shipment.order).to receive(:update!)
+  describe '#cancel!' do
+    subject { shipment.cancel! }
+    before { shipment.state = 'pending' }
 
-      shipment.state = 'pending'
-      without_partial_double_verification do
-        expect(shipment).to receive(:after_cancel)
+    it { is_expected.to be true }
+
+    context 'when not able to cancel' do
+      before { shipment.state = 'shipped' }
+      it 'raises an exception' do
+        expect { subject }.to raise_error(Spree::Shipment::InvalidStateChange)
       end
-      shipment.cancel!
+    end
+  end
+
+  describe '#cancel' do
+    subject { shipment.cancel }
+    before { shipment.state = 'pending' }
+
+    it { is_expected.to be true }
+
+    it 'cancels the shipment' do
+      subject
       expect(shipment.state).to eq 'canceled'
     end
 
@@ -424,7 +437,7 @@ RSpec.describe Spree::Shipment, type: :model do
       variant = shipment.inventory_units.first.variant
       shipment.stock_location = mock_model(Spree::StockLocation)
       expect(shipment.stock_location).to receive(:restock).with(variant, 1, shipment)
-      shipment.after_cancel
+      subject
     end
 
     context "with backordered inventory units" do
@@ -450,8 +463,58 @@ RSpec.describe Spree::Shipment, type: :model do
         expect(other_shipment.inventory_units.first).to be_backordered
 
         expect {
-          shipment.cancel!
+          shipment.cancel
         }.not_to change { other_shipment.inventory_units.first.state }
+      end
+    end
+
+    context 'when shipment cannot be canceled' do
+      before { shipment.state = 'shipped' }
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#can_cancel?' do
+    subject { shipment.can_cancel? }
+
+    context 'when shipment is ready' do
+      before { shipment.state = 'ready' }
+      it { is_expected.to be true }
+    end
+
+    context 'when shipment is pending' do
+      before { shipment.state = 'pending' }
+      it { is_expected.to be true }
+    end
+
+    context 'when shipment is neither ready nor pending' do
+      before { shipment.state = 'shipped' }
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#canceled?' do
+    subject { shipment.canceled? }
+    before { shipment.state = 'canceled' }
+
+    it { is_expected.to be true }
+
+    context 'when shipment has not been canceled' do
+      before { shipment.state = 'shipped' }
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#resume!' do
+    subject { shipment.resume! }
+    before { shipment.state = 'canceled' }
+
+    it { is_expected.to be true }
+
+    context 'when not able to ship' do
+      before { shipment.state = 'shipped' }
+      it 'raises an exception' do
+        expect { subject }.to raise_error(Spree::Shipment::InvalidStateChange)
       end
     end
   end
@@ -459,12 +522,15 @@ RSpec.describe Spree::Shipment, type: :model do
   context "#resume" do
     let(:inventory_unit) { create(:inventory_unit) }
 
+    subject { shipment.resume }
     before { shipment.state = 'canceled' }
+
+    it { is_expected.to be true }
 
     context "when order cannot ship" do
       before { allow(order).to receive_messages(can_ship?: false) }
       it "should result in a 'pending' state" do
-        shipment.resume!
+        subject
         expect(shipment.state).to eq 'pending'
       end
     end
@@ -472,7 +538,7 @@ RSpec.describe Spree::Shipment, type: :model do
     context "when order is not paid" do
       before { allow(order).to receive_messages(paid?: false) }
       it "should result in a 'ready' state" do
-        shipment.resume!
+        subject
         expect(shipment.state).to eq 'pending'
       end
     end
@@ -480,7 +546,7 @@ RSpec.describe Spree::Shipment, type: :model do
     context "when any inventory is backordered" do
       before { allow_any_instance_of(Spree::InventoryUnit).to receive(:allow_ship?).and_return(false) }
       it "should result in a 'ready' state" do
-        shipment.resume!
+        subject
         expect(shipment.state).to eq 'pending'
       end
     end
@@ -493,25 +559,73 @@ RSpec.describe Spree::Shipment, type: :model do
       end
 
       it "should result in a 'ready' state" do
-        shipment.resume!
+        subject
         expect(shipment.state).to eq 'ready'
       end
     end
 
-    it 'unstocks them items' do
+    it 'unstocks the items' do
       variant = shipment.inventory_units.first.variant
       shipment.stock_location = mock_model(Spree::StockLocation)
       expect(shipment.stock_location).to receive(:unstock).with(variant, 1, shipment)
-      shipment.after_resume
+      subject
+    end
+
+    context 'when shipment cannot resume' do
+      before { shipment.state = 'shipped' }
+      it { is_expected.to be false }
     end
   end
 
-  context "#ship" do
+  describe '#can_resume?' do
+    subject { shipment.can_resume? }
+    before { shipment.state = 'canceled' }
+
+    it { is_expected.to be true }
+
+    context 'when shipment cannot resume' do
+      before { shipment.state = 'shipped' }
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#ship!' do
+    subject { shipment.ship! }
+    before { shipment.state = 'ready' }
+
+    it { is_expected.to be true }
+
+    context 'when not able to ship' do
+      before { shipment.state = 'shipped' }
+      it 'raises an exception' do
+        expect { subject }.to raise_error(Spree::Shipment::InvalidStateChange)
+      end
+    end
+  end
+
+  describe '#ship' do
+    subject { shipment.ship }
+    before { shipment.state = 'ready' }
+
+    it { is_expected.to be true }
+
+    it 'changes the state to shipped' do
+      subject
+      expect(shipment.state).to eq 'shipped'
+    end
+
+    it 'ships the items' do
+      expect(order.shipping).to receive(:ship_shipment).with(shipment, suppress_mailer: shipment.suppress_mailer)
+      subject
+    end
+
     context "when the shipment is canceled" do
       let(:address){ create(:address) }
       let(:order){ create(:order_with_line_items, ship_address: address) }
       let(:shipment_with_inventory_units) { create(:shipment, order: order, state: 'canceled') }
-      let(:subject) { shipment_with_inventory_units.ship! }
+
+      subject { shipment_with_inventory_units.ship }
+
       before do
         allow(order).to receive(:update!)
       end
@@ -533,17 +647,205 @@ RSpec.describe Spree::Shipment, type: :model do
           shipment.adjustments.each do |adjustment|
             expect(adjustment).to receive(:finalize!)
           end
-          shipment.ship!
+          subject
         end
+      end
+    end
+
+    context 'when the shipment cannot ship' do
+      before { shipment.state = 'shipped' }
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#can_ship?' do
+    subject { shipment.can_ship? }
+
+    context 'when state is ready' do
+      before { shipment.state = 'ready' }
+      it { is_expected.to be true }
+    end
+
+    context 'when state is canceled' do
+      before { shipment.state = 'canceled' }
+      it { is_expected.to be true }
+    end
+
+    context 'when state is neither ready nor canceled' do
+      before { shipment.state = 'pending' }
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#shipped?' do
+    subject { shipment.shipped? }
+    before { shipment.state = 'shipped' }
+
+    it { is_expected.to be true }
+
+    context 'when not shipped' do
+      before { shipment.state = 'pending' }
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#ready!' do
+    subject { shipment.ready! }
+    before { shipment.state = 'pending' }
+
+    it { is_expected.to be true }
+
+    context 'when not able to ready' do
+      before { shipment.state = 'shipped' }
+      it 'raises an exception' do
+        expect { subject }.to raise_error(Spree::Shipment::InvalidStateChange)
       end
     end
   end
 
-  context "#ready" do
+  describe '#ready' do
+    subject { shipment.ready }
+
+    context 'when state is pending' do
+      context 'when a shipment is required' do
+        before { allow(shipment.stock_location).to receive(:fulfillable?) { true } }
+
+        it { is_expected.to be true }
+
+        it 'changes state to ready' do
+          subject
+          expect(shipment.state).to eq 'ready'
+        end
+      end
+
+      context 'when a shipment is not required' do
+        before { allow(shipment.stock_location).to receive(:fulfillable?) { false } }
+
+        it { is_expected.to be true }
+
+        it 'changes state to shipped' do
+          subject
+          expect(shipment.state).to eq 'shipped'
+        end
+
+        it 'ships the items' do
+          expect(order.shipping).to receive(:ship_shipment).with(shipment, suppress_mailer: shipment.suppress_mailer)
+          subject
+        end
+      end
+
+      context "when shipment is required but can't ship inventory" do
+        before { allow(shipment.stock_location).to receive(:fulfillable?) { true } }
+        before { allow(order).to receive(:can_ship?) { false } }
+        it { is_expected.to be false }
+      end
+    end
+
+    context 'when state is not pending' do
+      before { shipment.state = 'shipped' }
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#ready?' do
+    subject { shipment.ready? }
+    before { shipment.state = 'ready' }
+
+    it { is_expected.to be true }
+
+    context 'when not ready' do
+      before { shipment.state = 'pending' }
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#can_ready?' do
+    subject { shipment.can_ready? }
+
+    context 'when state is pending' do
+      before { shipment.state = 'pending' }
+
+      context 'when shipment is not required' do
+        before { allow(shipment.stock_location).to receive(:fulfillable?) { false } }
+        it { is_expected.to be true }
+      end
+
+      context "when shipment is required but can't ship inventory" do
+        before { allow(shipment.stock_location).to receive(:fulfillable?) { true } }
+        before { allow(order).to receive(:can_ship?) { false } }
+        it { is_expected.to be false }
+      end
+
+      context 'when shipment is required and inventory can ship' do
+        before { allow(shipment.stock_location).to receive(:fulfillable?) { true } }
+        before { allow(order).to receive(:can_ship?) { true } }
+        it { is_expected.to be true }
+      end
+    end
+
+    context 'when state is not pending' do
+      before { shipment.state = 'shipped' }
+      it { is_expected.to be false }
+    end
+
     # Regression test for https://github.com/spree/spree/issues/2040
-    it "cannot ready a shipment for an order if the order is unpaid" do
-      expect(order).to receive_messages(paid?: false)
-      expect(shipment).not_to be_can_ready
+    context 'when order is unpaid' do
+      before { allow(order).to receive(:paid?) { false } }
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#pend!' do
+    subject { shipment.pend! }
+    before { shipment.state = 'ready' }
+
+    it { is_expected.to be true }
+
+    context 'when not able to pend' do
+      before { shipment.state = 'shipped' }
+      it 'raises an exception' do
+        expect { subject }.to raise_error(Spree::Shipment::InvalidStateChange)
+      end
+    end
+  end
+
+  describe '#pend' do
+    subject { shipment.pend }
+    before { shipment.state = 'ready' }
+
+    it { is_expected.to be true }
+
+    it 'changes state to pending' do
+      subject
+      expect(shipment.state).to eq 'pending'
+    end
+
+    context 'when not able to pend' do
+      before { shipment.state = 'shipped' }
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#pending?' do
+    subject { shipment.pending? }
+
+    it { is_expected.to be true }
+
+    context 'when not pending' do
+      before { shipment.state = 'ready' }
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#can_pend?' do
+    subject { shipment.can_pend? }
+    before { shipment.state = 'ready' }
+
+    it { is_expected.to be true }
+
+    context 'when not able to pend' do
+      before { shipment.state = 'shipped' }
+      it { is_expected.to be false }
     end
   end
 

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -1175,36 +1175,6 @@ RSpec.describe Spree::Shipment, type: :model do
     end
   end
 
-  describe '#can_transition_from_pending_to_ready?' do
-    let(:shipment) { create(:shipment, order: order) }
-
-    subject { shipment.can_transition_from_pending_to_ready? }
-
-    context "with backordered inventory" do
-      before { shipment.inventory_units.update_all(state: "backordered") }
-
-      it "returns false" do
-        expect(subject).to be false
-      end
-    end
-
-    context "with on_hand inventory" do
-      before { shipment.inventory_units.update_all(state: "on_hand") }
-
-      it "returns true" do
-        expect(subject).to be true
-      end
-    end
-
-    context "with shipped inventory" do
-      before { shipment.inventory_units.update_all(state: "shipped") }
-
-      it "returns true" do
-        expect(subject).to be true
-      end
-    end
-  end
-
   describe '#cartons' do
     let(:carton)   { create(:carton) }
     let(:shipment) { carton.shipments.first }


### PR DESCRIPTION
This resolves the existing conflict and rebases from the latest `master` the PR #2656 by @jgayfer:

> The [state_machines](https://github.com/state-machines/state_machines) gem has been used throughout Solidus since the earliest days of Spree. We use it to track the "state" our shipments/payments/orders are in, as well as plug custom functionality into the transitions between those states (`before_transition`/`after_transition`).
>
> However, our use of intermingled state machines between Payments, Shipments and Orders causes problems for both new and established developers. The state machine transitions are difficult to understand and debug, the order the transitions are executed in can be tough to control, and properly controlling database transactions during a transition is very poorly understood.
>
> We believe the downsides of implementing our state machines using the state_machines gem to be a net negative for the project.
>
> This PR changes the `Spree::Shipment` class, explicitly defining the important methods that would have been generated from the state_machines metaprogramming. The advantages of doing this are improved code clarity, debug-ability, as well as making it more easy to completely override methods regarding state.
>
> The first two commits of this pull request remove the `state_machine` from [`Spree::Shipment`](https://github.com/solidusio/solidus/blob/master/core/app/models/spree/shipment.rb) without changing the external API of the model. The last two commits go a bit further and deprecate the [transition methods](https://github.com/solidusio/solidus/blob/fd474db749d4386f52a23efbb59d30336351028d/core/app/models/spree/shipment.rb#L79-L91) that were used by the state machine in an attempt to improve code readability. If we don't want to go ahead and deprecate the transition methods, the first two commits can just be taken on their own, keeping the external API of [`Spree::Shipment`](https://github.com/solidusio/solidus/blob/master/core/app/models/spree/shipment.rb) intact.
>
>While we could re-implement the `before_transition`/`after_transition` calls on the `Spree::Shipment` model, we believe the following examples would be a better way to support customising functionality before or after a transition (with `ship` used as an example).
>
> ```ruby
> module AfterShipAction
>   # Note that returning true/false is done to preserve the original return values of ship
>   # This pattern works for all of ship, resume, pend, ready, and cancel
>   def ship
>     if super
>       additional_after_ship_procedure
>     end
>   end
> 
>   def additional_after_ship_procedure
>     # Do something interesting!
>     true
>   end
> end
> 
> module BeforeShipCondition
>   def ship
>     if pre_ship_condition
>       super
>     end
>   end
> 
>   def pre_ship_condition
>     # Some interesting condition as to when we can ship
>     true
>   end
> end
> 
> Spree::Shipment.prepend AfterShipAction
> Spree::Shipment.prepend BeforeShipCondition
> ```