### PR TITLE
Fix Spree::Variant inconsistency due to lack of product association

### DIFF
--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe Spree::Variant, type: :model do
+  it { is_expected.to be_invalid }
+
   let!(:variant) { create(:variant) }
 
   it_behaves_like 'default_price'
@@ -21,6 +23,8 @@ RSpec.describe Spree::Variant, type: :model do
     it "should require a product" do
       expect(variant).to be_valid
       variant.product = nil
+      expect(variant).to be_invalid
+      variant.price = nil
       expect(variant).to be_invalid
     end
   end


### PR DESCRIPTION
# Description

`Spree::Variant` new instance throw error during validation because it lacks a product association. The lack of product causes

- Error to be raised because price is inferred using `product.master.price`
- `Module::DelegationError` to be raised because to generate VAT prices, `variant.tax_category` is required and this method is delegated to `product.tax_category`

To fix it, removed raising an error if price can't be inferred using `product.master.price`. Reporting missing product is enough for an invalid variant instance. Also add product verification before generating VAT prices for variant.

Closes #3036

# Checklist:

- [x] [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines) are respected
- [x] Changes are covered by tests (if possible)
- [x] Each commit has a meaningful message attached that described WHAT changed, and WHY
