### PR TITLE
Use right language_locale_key

### DIFF
--- a/backend/app/controllers/spree/admin/locale_controller.rb
+++ b/backend/app/controllers/spree/admin/locale_controller.rb
@@ -8,7 +8,7 @@ module Spree
 
         if locale && I18n.available_locales.include?(locale.to_sym)
           I18n.locale = locale
-          session[:locale] = locale
+          session[set_user_language_locale_key] = locale
 
           respond_to do |format|
             format.json { render json: { locale: locale, location: spree.admin_url } }

--- a/core/lib/spree/core/controller_helpers/common.rb
+++ b/core/lib/spree/core/controller_helpers/common.rb
@@ -62,7 +62,7 @@ module Spree
             candidate &&
               available_locales.include?(candidate.to_sym)
           end
-          session[:locale] = locale
+          session[set_user_language_locale_key] = locale
           I18n.locale = locale
           Carmen.i18n_backend.locale = locale
         end

--- a/frontend/app/controllers/spree/locale_controller.rb
+++ b/frontend/app/controllers/spree/locale_controller.rb
@@ -7,7 +7,7 @@ module Spree
       requested_locale = params[:switch_to_locale] || params[:locale]
 
       if requested_locale && available_locales.map(&:to_s).include?(requested_locale)
-        session[:locale] = requested_locale
+        session[set_user_language_locale_key] = requested_locale
         I18n.locale = requested_locale
         flash.notice = t('spree.locale_changed')
       else


### PR DESCRIPTION
ref #2856

This PR is going to use the right language_locale_key when it is
used in Admin or in Frontend.