### PR TITLE
Extend Decorator documentation

### DIFF
--- a/guides/source/developers/extensions/decorators.html.md
+++ b/guides/source/developers/extensions/decorators.html.md
@@ -34,7 +34,7 @@ total by $10 (or whatever your currency is).
 
 ## Using ActiveRecord methods in decorators
 
-In order to access ActiveRecord methods, you'll need to define a special
+In order to access some class-level methods, you'll need to define a special
 method.
 
 ```ruby
@@ -46,8 +46,6 @@ module MyStore::ProductDecorator
     base.has_many :comments, dependent: :destroy
     base.scope    :sellable, -> { base.where(...).order(...) }
     base.delegate :something, to: :something
-
-    base.singleton_class.prepend ClassMethods
   end
 
   ...

--- a/guides/source/developers/extensions/decorators.html.md
+++ b/guides/source/developers/extensions/decorators.html.md
@@ -32,7 +32,7 @@ total by $10 (or whatever your currency is).
 
 [monkey-patch]: https://en.wikipedia.org/wiki/Monkey_patch
 
-## Using ActiveRecord methods in decorators
+## Using class-level methods in decorators
 
 In order to access some class-level methods, you'll need to define a special
 method.

--- a/guides/source/developers/extensions/decorators.html.md
+++ b/guides/source/developers/extensions/decorators.html.md
@@ -32,6 +32,34 @@ total by $10 (or whatever your currency is).
 
 [monkey-patch]: https://en.wikipedia.org/wiki/Monkey_patch
 
+## Using ActiveRecord methods in decorators
+
+In order to access ActiveRecord methods, you'll need to define a special
+method.
+
+```ruby
+module MyStore::ProductDecorator
+
+  # This is the place to define custom associations, delegations, scopes and
+  # other ActiveRecord stuff
+  def self.prepended(base)
+    base.has_many :comments, dependent: :destroy
+    base.scope    :sellable, -> { base.where(...).order(...) }
+    base.delegate :something, to: :something
+
+    base.singleton_class.prepend ClassMethods
+  end
+
+  ...
+
+  Spree::Product.prepend self
+end
+```
+
+In this example, a decorator has been used to extend the functionality of
+`Spree::Product`. The decorator includes an ActiveRecord association, scope,
+and delegation.
+
 ## Decorators and Solidus upgrades
 
 Decorators can complicate your Solidus upgrades. If you depend on decorators,


### PR DESCRIPTION
This change adds an example of using ActiveRecord inside a model
decorator. Largely adapted from a gist:
https://gist.github.com/kushniryb/101c161eab8d2d2e2e35e4a17b781d1b
