### PR TITLE
Remove static attribute in store credit reason factory

### DIFF
--- a/core/lib/spree/testing_support/factories/store_credit_reason_factory.rb
+++ b/core/lib/spree/testing_support/factories/store_credit_reason_factory.rb
@@ -2,6 +2,6 @@
 
 FactoryBot.define do
   factory :store_credit_reason, class: 'Spree::StoreCreditReason' do
-    name "Input error"
+    name { "Input error" }
   end
 end


### PR DESCRIPTION
### Description

We already converted the rest of the factories attributes to dynamic into #2831 but after merging that PR, we merged #2798 which was pretty old and was still using the old "way".

# Checklist:

- [ ] [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines) are respected
- [ ] Documentation/Readme have been updated accordingly
- [ ] Changes are covered by tests (if possible)
- [ ] Each commit has a meaningful message attached that described WHAT changed, and WHY
