### PR TITLE
Unit cancel fix - take three

### DIFF
--- a/backend/app/controllers/spree/admin/cancellations_controller.rb
+++ b/backend/app/controllers/spree/admin/cancellations_controller.rb
@@ -10,8 +10,8 @@ module Spree
       end
 
       def short_ship
-        inventory_unit_ids = params[:inventory_unit_ids] || []
-        inventory_units = Spree::InventoryUnit.where(id: inventory_unit_ids)
+        inventory_unit_ids = (params[:inventory_unit_ids] || []).map(&:to_i)
+        inventory_units = @order.inventory_units.select { |iu| inventory_unit_ids.include? iu.id }
 
         if inventory_units.size != inventory_unit_ids.size
           flash[:error] = t('spree.unable_to_find_all_inventory_units')

--- a/backend/spec/controllers/spree/admin/cancellations_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/cancellations_controller_spec.rb
@@ -72,7 +72,7 @@ describe Spree::Admin::CancellationsController do
 
       it "cancels the inventory" do
         subject
-        expect(order.inventory_units.map(&:state).uniq).to match_array(['canceled'])
+        expect(order.reload.inventory_units.map(&:state).uniq).to match_array(['canceled'])
       end
     end
   end

--- a/core/app/models/spree/unit_cancel.rb
+++ b/core/app/models/spree/unit_cancel.rb
@@ -27,7 +27,9 @@ class Spree::UnitCancel < Spree::Base
       finalized: true
     )
 
-    inventory_unit.line_item.order.recalculate
+    inventory_unit.line_item.adjustment_total += amount
+    inventory_unit.order.recalculate
+
     adjustment
   end
 

--- a/core/app/models/spree/unit_cancel.rb
+++ b/core/app/models/spree/unit_cancel.rb
@@ -26,6 +26,9 @@ class Spree::UnitCancel < Spree::Base
       eligible: true,
       finalized: true
     )
+
+    inventory_unit.line_item.order.recalculate
+    adjustment
   end
 
   # This method is used by Adjustment#update to recalculate the cost.

--- a/core/spec/models/spree/unit_cancel_spec.rb
+++ b/core/spec/models/spree/unit_cancel_spec.rb
@@ -59,7 +59,14 @@ RSpec.describe Spree::UnitCancel do
     end
 
     context "multiple inventory units" do
-      let(:line_item) { create(:line_item, quantity: 4, price: 100.0) }
+      let(:order) { create(:order_with_line_items) }
+      let(:line_item) do
+        # Change our quantity to 4
+        order.line_items.first.quantity = 4
+        # Make sure that there are no inventory_units before
+        order.line_items.first.inventory_units.clear
+        order.line_items.first
+      end
 
       let(:inventory_units) do
         [
@@ -74,7 +81,6 @@ RSpec.describe Spree::UnitCancel do
         inventory_units.each do |inventory_unit|
           Spree::UnitCancel.create!(inventory_unit: inventory_unit, reason: Spree::UnitCancel::SHORT_SHIP).adjust!
           inventory_unit.cancel!
-          line_item.reload
         end
         expect(line_item.total.to_d).to eq(0)
       end


### PR DESCRIPTION
# Description

This follows along with #2401, and in addition to its fix on UnitCancel it fixes Spree::Admin::CancellationsController, which currently passes to short_ship records that are not associated to OrderCancellations `@order` instance variable [1.] messing up UnitCancel calculations on `@order` associations tree instances [2.].

1. https://github.com/solidusio/solidus/blob/375305d7791c605d414f486792cffadee44778fd/backend/app/controllers/spree/admin/cancellations_controller.rb#L14
2. https://github.com/solidusio/solidus/pull/2401#discussion_r154160454

Ref #2401

# Checklist:

- [x] [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines) are respected
- [ ] Documentation/Readme have been updated accordingly
- [x] Changes are covered by tests (if possible)
- [x] Each commit has a meaningful message attached that described WHAT changed, and WHY
