### PR TITLE
Upgrade nokogiri to 1.8.5

### DIFF
--- a/guides/Gemfile
+++ b/guides/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 gem "middleman", "~> 4.2"
 gem "oga", "~> 2.14"
-gem "nokogiri", "~>1.8.1"
+gem "nokogiri", "~>1.8.5"
 gem "middleman-s3_sync"
 gem "redcarpet"
 gem "rack", ">= 2.0.6"

--- a/guides/Gemfile.lock
+++ b/guides/Gemfile.lock
@@ -106,7 +106,7 @@ GEM
     mini_portile2 (2.3.0)
     minitest (5.11.3)
     multi_json (1.13.1)
-    nokogiri (1.8.2)
+    nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
     oga (2.15)
       ast
@@ -148,7 +148,7 @@ PLATFORMS
 DEPENDENCIES
   middleman (~> 4.2)
   middleman-s3_sync
-  nokogiri (~> 1.8.1)
+  nokogiri (~> 1.8.5)
   oga (~> 2.14)
   rack (>= 2.0.6)
   redcarpet


### PR DESCRIPTION
Upgrading to remedy exposure to [CVE-2018-14404](https://nvd.nist.gov/vuln/detail/CVE-2018-14404)
