### PR TITLE
Unit cancel fix tests

### DIFF
--- a/core/app/models/spree/unit_cancel.rb
+++ b/core/app/models/spree/unit_cancel.rb
@@ -26,6 +26,9 @@ class Spree::UnitCancel < Spree::Base
       eligible: true,
       finalized: true
     )
+
+    inventory_unit.line_item.order.recalculate
+    adjustment
   end
 
   # This method is used by Adjustment#update to recalculate the cost.

--- a/core/spec/models/spree/order_cancellations_spec.rb
+++ b/core/spec/models/spree/order_cancellations_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Spree::OrderCancellations do
   describe "#cancel_unit" do
-    subject { Spree::OrderCancellations.new(order).cancel_unit(inventory_unit) }
+    subject { described_class.new(order).cancel_unit(inventory_unit) }
     let(:order) { create(:shipped_order, line_items_count: 1) }
     let(:inventory_unit) { order.inventory_units.first }
 
@@ -62,7 +62,7 @@ RSpec.describe Spree::OrderCancellations do
   end
 
   describe "#reimburse_units" do
-    subject { Spree::OrderCancellations.new(order).reimburse_units(inventory_units, created_by: created_by_user) }
+    subject { described_class.new(order).reimburse_units(inventory_units, created_by: created_by_user) }
     let(:order) { create(:shipped_order, line_items_count: 2) }
     let(:inventory_units) { order.inventory_units }
     let!(:default_refund_reason) { Spree::RefundReason.find_or_create_by!(name: Spree::RefundReason::RETURN_PROCESSING_REASON, mutable: false) }
@@ -83,7 +83,7 @@ RSpec.describe Spree::OrderCancellations do
   end
 
   describe "#short_ship" do
-    subject { Spree::OrderCancellations.new(order).short_ship([inventory_unit]) }
+    subject { described_class.new(order).short_ship([inventory_unit]) }
 
     let(:order) { create(:order_ready_to_ship, line_items_count: 1) }
     let(:inventory_unit) { order.inventory_units.first }
@@ -110,24 +110,18 @@ RSpec.describe Spree::OrderCancellations do
     end
 
     it "adjusts the order" do
-      expect { subject }.to change { order.total }.by(-10.0)
+      expect { subject }.to change { order.reload.total }.by(-10.0)
     end
 
     context "multiple inventory units" do
-      subject { Spree::OrderCancellations.new(order).short_ship(inventory_units) }
-      let!(:order) { create(:order_with_line_items) }
-      let!(:inventory_units) do
-        order.line_items.first.quantity = 4
-        # It already has 1 line_item in it
-        3.times do
-          create(:inventory_unit, line_item: order.line_items.first)
-        end
-        order.recalculate
-        order.line_items.first.inventory_units.to_a
-      end
+      subject { described_class.new(order).short_ship(inventory_units) }
+
+      let(:quantity) { 4 }
+      let!(:order) { create(:order_with_line_items, line_items_attributes: [{ quantity: quantity }]) }
+      let(:inventory_units) { Spree::InventoryUnit.find(order.line_items.first.inventory_units.pluck(:id)) }
 
       it "adjusts the order" do
-        expect { subject }.to change { order.total }.by(-40.0)
+        expect { subject }.to change { order.reload.total }.by(-40.0)
       end
     end
 
@@ -139,14 +133,14 @@ RSpec.describe Spree::OrderCancellations do
     end
 
     context "when send_cancellation_mailer is false" do
-      subject { Spree::OrderCancellations.new(order).short_ship([inventory_unit]) }
+      subject { described_class.new(order).short_ship([inventory_unit]) }
 
       before do
-        @original_send_boolean = Spree::OrderCancellations.send_cancellation_mailer
-        Spree::OrderCancellations.send_cancellation_mailer = false
+        @original_send_boolean = described_class.send_cancellation_mailer
+        described_class.send_cancellation_mailer = false
       end
 
-      after { Spree::OrderCancellations.send_cancellation_mailer = @original_send_boolean }
+      after { described_class.send_cancellation_mailer = @original_send_boolean }
 
       it "does not send a cancellation email" do
         expect(Spree::OrderMailer).not_to receive(:inventory_cancellation_email)
@@ -219,11 +213,11 @@ RSpec.describe Spree::OrderCancellations do
         let(:short_ship_tax_notifier) { double }
 
         before do
-          @old_notifier = Spree::OrderCancellations.short_ship_tax_notifier
-          Spree::OrderCancellations.short_ship_tax_notifier = short_ship_tax_notifier
+          @old_notifier = described_class.short_ship_tax_notifier
+          described_class.short_ship_tax_notifier = short_ship_tax_notifier
         end
         after do
-          Spree::OrderCancellations.short_ship_tax_notifier = @old_notifier
+          described_class.short_ship_tax_notifier = @old_notifier
         end
 
         it 'calls the short_ship_tax_notifier' do

--- a/core/spec/models/spree/unit_cancel_spec.rb
+++ b/core/spec/models/spree/unit_cancel_spec.rb
@@ -59,7 +59,14 @@ RSpec.describe Spree::UnitCancel do
     end
 
     context "multiple inventory units" do
-      let(:line_item) { create(:line_item, quantity: 4, price: 100.0) }
+      let(:order) { create(:order_with_line_items) }
+      let(:line_item) do
+        # Change our quantity to 4
+        order.line_items.first.quantity = 4
+        # Make sure that there are no inventory_units before
+        order.line_items.first.inventory_units.clear
+        order.line_items.first
+      end
 
       let(:inventory_units) do
         [
@@ -74,7 +81,6 @@ RSpec.describe Spree::UnitCancel do
         inventory_units.each do |inventory_unit|
           Spree::UnitCancel.create!(inventory_unit: inventory_unit, reason: Spree::UnitCancel::SHORT_SHIP).adjust!
           inventory_unit.cancel!
-          line_item.reload
         end
         expect(line_item.total.to_d).to eq(0)
       end


### PR DESCRIPTION
# Description

This follows along with #2401, and in addition to its `UnitCancel#adjust!` fix, it adds tests checking that, when `OrderCancellations#short_ship` is called with an `inventory_units` argument with multiple inventory units that do not map to the same objects of its `@order.inventory_units` it calculates the correct adjustment amount, where before #2401 they would fail.

Ref #2401

# Checklist:

- [x] [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines) are respected
- [ ] Documentation/Readme have been updated accordingly
- [x] Changes are covered by tests (if possible)
- [x] Each commit has a meaningful message attached that described WHAT changed, and WHY
