### PR TITLE
Tentative fix for flaky specs in `backend/spec/features/admin/users_spec.rb`

### DIFF
--- a/backend/spec/features/admin/users_spec.rb
+++ b/backend/spec/features/admin/users_spec.rb
@@ -57,19 +57,20 @@ describe 'Users', type: :feature do
   shared_examples_for 'a sortable attribute' do
     before { click_link sort_link }
 
-    it "can sort asc" do
+    it "can sort asc", :js do
       within_table(table_id) do
+        expect(page).to have_selector '.sort_link.asc'
         expect(page).to have_text text_match_1
         expect(page).to have_text text_match_2
         expect(text_match_1).to appear_before text_match_2
       end
     end
 
-    it "can sort desc" do
+    it "can sort desc", :js do
       within_table(table_id) do
         # Ransack adds a ▲ to the sort link. With exact match Capybara is not able to find that link
         click_link sort_link, exact: false
-
+        expect(page).to have_selector '.sort_link.desc'
         expect(page).to have_text text_match_1
         expect(page).to have_text text_match_2
         expect(text_match_2).to appear_before text_match_1


### PR DESCRIPTION
**Description**

These specs are failing often on circleCI builds.
    
The added expectation ensures that the click toggled the table header HTML.
This has the double benefit to ensure HTML is consistent and leaves more time
to successfully verify the flaky expectation:

`expect(text_match_1).to appear_before text_match_2`

**Checklist:**

- [x] [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines) are respected
- [ ] Documentation/Readme have been updated accordingly
- [x] Changes are covered by tests (if possible)
- [x] Each commit has a meaningful message attached that described WHAT changed, and WHY
