### PR TITLE
Add channel attribute to import order creation

### DIFF
--- a/core/lib/spree/core/importer/order.rb
+++ b/core/lib/spree/core/importer/order.rb
@@ -12,7 +12,7 @@ module Spree
             ensure_country_id_from_params params[:bill_address_attributes]
             ensure_state_id_from_params params[:bill_address_attributes]
 
-            create_params = params.slice :currency
+            create_params = params.slice :currency, :channel
             order = Spree::Order.create! create_params
             order.store ||= Spree::Store.default
             order.associate_user!(user)

--- a/core/spec/lib/spree/core/importer/order_spec.rb
+++ b/core/spec/lib/spree/core/importer/order_spec.rb
@@ -206,6 +206,21 @@ module Spree
         end
       end
 
+      context "channel" do
+        let(:params) { { channel: "custom" } }
+
+        it "sets the order channel" do
+          order = Importer::Order.import(user, {})
+          expect(order.channel).to eq "spree"
+        end
+
+        it "with a different channel" do
+          params[:channel] = "custom"
+          order = Importer::Order.import(user, params)
+          expect(order.channel).to eq "custom"
+        end
+      end
+
       context "state passed is not associated with country" do
         let(:params) do
           {


### PR DESCRIPTION
#### Description

Based on documentation https://github.com/solidusio/solidus/blob/master/guides/source/developers/orders/overview.html.md the `channel` attribute is an option value for order creation, but in the importer https://github.com/solidusio/solidus/blob/master/core/lib/spree/core/importer/order.rb never is referenced, this allows importer to use `channel` on order creation.
