### PR TITLE
Accept source as permitted attribute importing orders

### DIFF
--- a/api/app/controllers/spree/api/orders_controller.rb
+++ b/api/app/controllers/spree/api/orders_controller.rb
@@ -9,6 +9,9 @@ module Spree
       class_attribute :admin_order_attributes
       self.admin_order_attributes = [:import, :number, :completed_at, :locked_at, :channel, :user_id, :created_at]
 
+      class_attribute :admin_payment_attributes
+      self.admin_payment_attributes = [:payment_method, :amount, :state, source: {}]
+
       skip_before_action :authenticate_user, only: :apply_coupon_code
 
       before_action :find_order, except: [:create, :mine, :current, :index]
@@ -151,6 +154,14 @@ module Spree
       def permitted_shipment_attributes
         if can?(:admin, Spree::Shipment)
           super + admin_shipment_attributes
+        else
+          super
+        end
+      end
+
+      def permitted_payment_attributes
+        if can?(:admin, Spree::Payment)
+          super + admin_payment_attributes
         else
           super
         end

--- a/api/spec/requests/spree/api/orders_controller_spec.rb
+++ b/api/spec/requests/spree/api/orders_controller_spec.rb
@@ -815,6 +815,43 @@ module Spree
           expect(response.status).to eq 201
           expect(json_response["user_id"]).to eq(user.id)
         end
+
+        context "with payment" do
+          let(:params) do
+            {
+              payments: [{
+                amount: '10.0',
+                payment_method: create(:payment_method).name,
+                source: {
+                  month: "01",
+                  year: Date.today.year.to_s.last(2),
+                  cc_type: "123",
+                  last_digits: "1111",
+                  name: "Credit Card"
+                }
+              }]
+            }
+          end
+
+          context "with source" do
+            it "creates a payment" do
+              post spree.api_orders_path, params: { order: params }
+              payment = json_response['payments'].first
+
+              expect(response.status).to eq 201
+              expect(payment['amount']).to eql "10.0"
+              expect(payment['source']['last_digits']).to eql "1111"
+            end
+
+            context "when payment_method is missing" do
+              it "returns an error" do
+                params[:payments][0].delete(:payment_method)
+                post spree.api_orders_path, params: { order: params }
+                expect(response.status).to eq 404
+              end
+            end
+          end
+        end
       end
 
       context "updating" do


### PR DESCRIPTION
#### Description
Sending the `source` data inside `payments` payload to `spree/api/orders#create` is returning an error:
`ActiveRecord::RecordInvalid: Validation failed: Source can't be blank`