### PR TITLE
Fix issue when trying to edit a variant without a default price

### DIFF
--- a/backend/app/views/spree/admin/variants/_form.html.erb
+++ b/backend/app/views/spree/admin/variants/_form.html.erb
@@ -65,7 +65,7 @@
       <div class="col-3">
         <div class="field" data-hook="price">
           <%= f.label :price %>
-          <%= render "spree/admin/shared/number_with_currency", f: f, amount_attr: :price, currency: @variant.default_price.currency %>
+          <%= render "spree/admin/shared/number_with_currency", f: f, amount_attr: :price, currency: @variant.default_price.try(:currency) %>
         </div>
       </div>
 

--- a/backend/spec/features/admin/products/pricing_spec.rb
+++ b/backend/spec/features/admin/products/pricing_spec.rb
@@ -72,11 +72,31 @@ describe 'Pricing' do
         product.master.update(price: 49.99)
       end
 
-      it 'has a working edit page' do
+      it "has a working edit page" do
         within "#spree_price_#{product.master.prices.first.id}" do
           click_icon :edit
         end
         expect(page).to have_content("Edit Price")
+      end
+
+      context "updating default price currency" do
+        it "has a variant working edit page" do
+          within "#spree_price_#{variant.prices.first.id}" do
+            click_icon :edit
+          end
+          expect(page).to have_content("Edit Price")
+          select "EUR", from: "price_currency"
+          click_button "Update"
+
+          within ".tabs" do
+            click_link "Variants"
+          end
+          within "#spree_variant_#{variant.id}" do
+            click_icon :edit
+          end
+
+          expect(page).to have_content("Edit Variant")
+        end
       end
     end
 


### PR DESCRIPTION
#### Description
Issue reported on https://github.com/solidusio/solidus/issues/2924, that cause that the variant editing page gets broken if you choose another currency that the default

#### Issue
- https://github.com/solidusio/solidus/issues/2924
