### PR TITLE
Bump the minimal Ruby version to 2.3

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ AllCops:
     - '*/spec/dummy/**/*'
     - 'sandbox/**/*'
     - '**/templates/**/*'
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.3
 
 # Sometimes I believe this reads better
 # This also causes spacing issues on multi-line fixes

--- a/solidus.gemspec
+++ b/solidus.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.required_ruby_version     = '>= 2.2.2'
+  s.required_ruby_version     = '>= 2.3'
   s.required_rubygems_version = '>= 1.8.23'
 
   s.author       = 'Solidus Team'


### PR DESCRIPTION
# Description

Support for 2.2 has been dropped on March, 2018:

https://www.ruby-lang.org/en/news/2018/03/28/ruby-2-2-10-released/

# Checklist:

- [x] [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines) are respected
- [x] Documentation/Readme have been updated accordingly
- [x] Changes are covered by tests (if possible)
- [x] Each commit has a meaningful message attached that described WHAT changed, and WHY
