### PR TITLE
Exclude line item additional taxes from unit cancel adjustment amount

### DIFF
--- a/core/app/models/spree/unit_cancel.rb
+++ b/core/app/models/spree/unit_cancel.rb
@@ -34,6 +34,7 @@ class Spree::UnitCancel < Spree::Base
   # This method is used by Adjustment#update to recalculate the cost.
   def compute_amount(line_item)
     raise "Adjustable does not match line item" unless line_item == inventory_unit.line_item
-    -(line_item.total.to_d / line_item.inventory_units.not_canceled.reject(&:original_return_item ).size)
+
+    -((line_item.total - line_item.total_before_tax).to_d / line_item.inventory_units.not_canceled.reject(&:original_return_item).size)
   end
 end

--- a/core/app/models/spree/unit_cancel.rb
+++ b/core/app/models/spree/unit_cancel.rb
@@ -35,6 +35,16 @@ class Spree::UnitCancel < Spree::Base
   def compute_amount(line_item)
     raise "Adjustable does not match line item" unless line_item == inventory_unit.line_item
 
-    -((line_item.total - line_item.total_before_tax).to_d / line_item.inventory_units.not_canceled.reject(&:original_return_item).size)
+    -weighted_line_item_amount(line_item)
+  end
+
+  private
+
+  def weighted_line_item_amount(line_item)
+    line_item.total_before_tax / quantity_of_line_item(line_item)
+  end
+
+  def quantity_of_line_item(line_item)
+    BigDecimal(line_item.inventory_units.not_canceled.reject(&:original_return_item).size)
   end
 end


### PR DESCRIPTION
# Description

Fixes #3068. It takes into account the line item taxes amount during calculation of line item amount on line item cancellation.

In order to keep code consistency, I made a refactoring along the same lines of [`core/app/models/spree/calculator/returns/default_refund_amount.rb`](https://github.com/solidusio/solidus/blob/f448dbaa78b7ec611554d53c83cd1c7ce8f50a88/core/app/models/spree/calculator/returns/default_refund_amount.rb), which performs a similar calculation.

Ref #3068

# Checklist:

- [x] [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines) are respected
- [x] Documentation/Readme have been updated accordingly
- [x] Changes are covered by tests (if possible)
- [x] Each commit has a meaningful message attached that described WHAT changed, and WHY
