### PR TITLE
Deprecate core tasks and migration scripts

### DIFF
--- a/core/app/mailers/spree/test_mailer.rb
+++ b/core/app/mailers/spree/test_mailer.rb
@@ -3,6 +3,8 @@
 module Spree
   class TestMailer < BaseMailer
     def test_email(email)
+      Spree::Deprecation.warn("Spree::TestMailer has been deprecated and will be removed with Solidus 3.0")
+
       store = Spree::Store.default
       subject = "#{store.name} #{t('.subject')}"
       mail(to: email, from: from_address(store), subject: subject)

--- a/core/db/migrate/20170608074534_rename_bogus_gateways.rb
+++ b/core/db/migrate/20170608074534_rename_bogus_gateways.rb
@@ -1,17 +1,18 @@
 # frozen_string_literal: true
 
 class RenameBogusGateways < ActiveRecord::Migration[5.0]
+  # This migration was only performing a data migration useful updating to
+  # Solidus v2.3.
+  # Once the update is done, this is no more required to run so we can clean
+  # this file to just be a noop.
+  # For more info on the original content see:
+  # https://github.com/solidusio/solidus/pull/2001
+
   def up
-    require 'solidus/migrations/rename_gateways'
-    say_with_time 'Renaming bogus gateways into payment methods' do
-      Solidus::Migrations::RenameGateways.new.up
-    end
+    # no-op
   end
 
   def down
-    require 'solidus/migrations/rename_gateways'
-    say_with_time 'Renaming bogus payment methods into gateways' do
-      Solidus::Migrations::RenameGateways.new.down
-    end
+    # no-op
   end
 end

--- a/core/lib/solidus/migrations/rename_gateways.rb
+++ b/core/lib/solidus/migrations/rename_gateways.rb
@@ -12,6 +12,8 @@ module Solidus
       attr_reader :gateway_mapping
 
       def initialize(gateway_mapping = DEFAULT_MAPPING)
+        Spree::Deprecation.warn 'Solidus::Migrations::RenameGateways is deprecated and will be removed with Solidus 3.0.'
+
         @gateway_mapping = gateway_mapping
       end
 

--- a/core/lib/tasks/email.rake
+++ b/core/lib/tasks/email.rake
@@ -3,6 +3,8 @@
 namespace :email do
   desc 'Sends test email to specified address - Example: EMAIL=spree@example.com bundle exec rake email:test'
   task test: :environment do
+    Spree::Deprecation.warn("rake email:test has been deprecated and will be removed with Solidus 3.0")
+
     raise ArgumentError, "Must pass EMAIL environment variable. Example: EMAIL=spree@example.com bundle exec rake email:test" unless ENV['EMAIL'].present?
     Spree::TestMailer.test_email(ENV['EMAIL']).deliver!
   end

--- a/core/lib/tasks/migrations/copy_order_bill_address_to_credit_card.rake
+++ b/core/lib/tasks/migrations/copy_order_bill_address_to_credit_card.rake
@@ -13,6 +13,8 @@ namespace 'spree:migrations:copy_order_bill_address_to_credit_card' do
   # This task should be safe to run multiple times.
 
   task up: :environment do
+    Spree::Deprecation.warn("rake spree:migrations:copy_order_bill_address_to_credit_card:up has been deprecated and will be removed with Solidus 3.0.")
+
     if Spree::CreditCard.connection.adapter_name =~ /postgres/i
       postgres_copy
     else
@@ -21,6 +23,8 @@ namespace 'spree:migrations:copy_order_bill_address_to_credit_card' do
   end
 
   task down: :environment do
+    Spree::Deprecation.warn("rake spree:migrations:copy_order_bill_address_to_credit_card:down has been deprecated and will be removed with Solidus 3.0.")
+
     Spree::CreditCard.update_all(address_id: nil)
   end
 

--- a/core/lib/tasks/migrations/migrate_shipping_rate_taxes.rake
+++ b/core/lib/tasks/migrations/migrate_shipping_rate_taxes.rake
@@ -4,6 +4,8 @@ namespace :solidus do
   namespace :migrations do
     namespace :migrate_shipping_rate_taxes do
       task up: :environment do
+        Spree::Deprecation.warn("rake spree:migrations:migrate_shipping_rate_taxes:up has been deprecated and will be removed with Solidus 3.0.")
+
         print "Adding persisted tax notes to historic shipping rates ... "
         Spree::ShippingRate.where.not(tax_rate_id: nil).find_each do |shipping_rate|
           tax_rate = Spree::TaxRate.unscoped.find(shipping_rate.tax_rate_id)

--- a/core/lib/tasks/migrations/migrate_user_addresses.rake
+++ b/core/lib/tasks/migrations/migrate_user_addresses.rake
@@ -10,6 +10,8 @@ namespace 'spree:migrations:migrate_user_addresses' do
   # to the user's address book. This will catch up all the historical data.
 
   task up: :environment do
+    Spree::Deprecation.warn("rake spree:migrations:migrate_user_addresses:up has been deprecated and will be removed with Solidus 3.0.")
+
     Spree.user_class.find_each(batch_size: 500) do |user|
       ship_address = Spree::Address.find_by(id: user.ship_address_id)
       bill_address = Spree::Address.find_by(id: user.bill_address_id)
@@ -26,6 +28,7 @@ namespace 'spree:migrations:migrate_user_addresses' do
   end
 
   task down: :environment do
+    Spree::Deprecation.warn("rake spree:migrations:migrate_user_addresses:down has been deprecated and will be removed with Solidus 3.0.")
     Spree::UserAddress.delete_all
   end
 end

--- a/core/lib/tasks/migrations/rename_gateways.rake
+++ b/core/lib/tasks/migrations/rename_gateways.rake
@@ -4,6 +4,7 @@ require 'solidus/migrations/rename_gateways'
 
 namespace 'solidus:migrations:rename_gateways' do
   task up: :environment do
+    Spree::Deprecation.warn("rake solidus:migrations:rename_gateways:up has been deprecated and will be removed with Solidus 3.0.")
     count = Solidus::Migrations::RenameGateways.new.up
 
     unless ENV['VERBOSE'] == 'false' || !verbose
@@ -12,6 +13,7 @@ namespace 'solidus:migrations:rename_gateways' do
   end
 
   task down: :environment do
+    Spree::Deprecation.warn("rake solidus:migrations:rename_gateways:down has been deprecated and will be removed with Solidus 3.0.")
     count = Solidus::Migrations::RenameGateways.new.down
 
     unless ENV['VERBOSE'] == 'false' || !verbose

--- a/core/lib/tasks/order_capturing.rake
+++ b/core/lib/tasks/order_capturing.rake
@@ -3,6 +3,8 @@
 namespace :order_capturing do
   desc "Looks for orders with inventory that is fully shipped/short-shipped, and captures money for it"
   task capture_payments: :environment do
+    Spree::Deprecation.warn("rake order_capturing:capture_payments has been deprecated and will be removed with Solidus 3.0.")
+
     failures = []
     orders = Spree::Order.complete.where(payment_state: 'balance_due').where('completed_at > ?', Spree::Config[:order_capturing_time_window].days.ago)
 

--- a/core/spec/lib/tasks/migrations/migrate_shipping_rate_taxes_spec.rb
+++ b/core/spec/lib/tasks/migrations/migrate_shipping_rate_taxes_spec.rb
@@ -11,9 +11,11 @@ RSpec.describe 'solidus:migrations:migrate_shipping_rate_taxes' do
     )
 
     it 'runs' do
-      expect { task.invoke }.to output(
-        "Adding persisted tax notes to historic shipping rates ... Success.\n"
-      ).to_stdout
+      Spree::Deprecation.silence do
+        expect { task.invoke }.to output(
+          "Adding persisted tax notes to historic shipping rates ... Success.\n"
+        ).to_stdout
+      end
     end
   end
 end

--- a/core/spec/mailers/test_mailer_spec.rb
+++ b/core/spec/mailers/test_mailer_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe Spree::TestMailer, type: :mailer do
   let(:user) { create(:user) }
 
   it "confirm_email accepts a user id as an alternative to a User object" do
-    Spree::TestMailer.test_email('test@example.com')
+    Spree::Deprecation.silence do
+      Spree::TestMailer.test_email('test@example.com')
+    end
   end
 end


### PR DESCRIPTION
**Description**

We have a lot of tasks and scripts used as helpers during versions upgrades. These files can be removed so I started deprecating them. They should not be used by anyone but if that's the case they will be noticed before the removal.

**Checklist:**

- [ ] [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines) are respected
- [ ] Documentation/Readme have been updated accordingly
- [ ] Changes are covered by tests (if possible)
- [ ] Each commit has a meaningful message attached that described WHAT changed, and WHY
