### PR TITLE
Lock sqlite3 version to 1.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ group :backend, :frontend, :core, :api do
     when /postgres/
       gem 'pg', '~> 1.0', require: false
     else
-      gem 'sqlite3', require: false
+      gem 'sqlite3', '~> 1.3.6', require: false
       gem 'fast_sqlite', require: false
     end
   end

--- a/lib/sandbox.sh
+++ b/lib/sandbox.sh
@@ -49,6 +49,10 @@ group :test, :development do
 end
 RUBY
 
+# Ensure sqlite3 version to match ActiveRecord SQLite adapter requirement
+# (see https://github.com/solidusio/solidus/issues/3087 for details)
+sed -i "/gem 'sqlite3'/c\gem 'sqlite3', '~> 1.3.6'" Gemfile
+
 bundle install --gemfile Gemfile
 bundle exec rake db:drop db:create
 bundle exec rails g spree:install --auto-accept --user_class=Spree::User --enforce_available_locales=true


### PR DESCRIPTION
Fixes #3087. It includes the following changes:

**Lock sqlite3 version to 1.3**

ActiveRecord 5.2.2 has sqlite3 dependency locked to `~> 1.3.6`, we need to reflect that in order to avoid conflicts due to sqlite3 1.4 version releasement.

**Fix sqlite3 version conflict on sandbox generation**

`rails new` generates a Gemfile with `gem 'sqlite3'` dependency declaration, but since sqlite3 1.4 has been released it conflicts with activerecord sqlite3 adapter dependency declaration, which is `sqlite3 ~> 1.3.6`.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [ ] I have added a CHANGELOG entry for this change (if needed)
