### PR TITLE
Fix flaky specs in `backend/spec/features/admin/users_spec.rb`

### DIFF
--- a/backend/spec/features/admin/users_spec.rb
+++ b/backend/spec/features/admin/users_spec.rb
@@ -59,6 +59,7 @@ describe 'Users', type: :feature do
 
     it "can sort asc" do
       within_table(table_id) do
+        expect(page).to have_selector '.sort_link.asc'
         expect(page).to have_text text_match_1
         expect(page).to have_text text_match_2
         expect(text_match_1).to appear_before text_match_2
@@ -70,6 +71,7 @@ describe 'Users', type: :feature do
         # Ransack adds a ▲ to the sort link. With exact match Capybara is not able to find that link
         click_link sort_link, exact: false
 
+        expect(page).to have_selector '.sort_link.desc'
         expect(page).to have_text text_match_1
         expect(page).to have_text text_match_2
         expect(text_match_2).to appear_before text_match_1

--- a/backend/spec/features/admin/users_spec.rb
+++ b/backend/spec/features/admin/users_spec.rb
@@ -70,7 +70,9 @@ describe 'Users', type: :feature do
       within_table(table_id) do
         # Ransack adds a ▲ to the sort link. With exact match Capybara is not able to find that link
         click_link sort_link, exact: false
+      end
 
+      within_table(table_id) do
         expect(page).to have_selector '.sort_link.desc'
         expect(page).to have_text text_match_1
         expect(page).to have_text text_match_2


### PR DESCRIPTION
*(This is a reopening for PR #3061 closed by mistake)*

These specs are failing often on circleCI builds.

The added expectation ensures that the click toggled the table header HTML.
This has the double benefit to ensure HTML is consistent and leaves more time
to successfully verify the flaky expectation:

`expect(text_match_1).to appear_before text_match_2`

Also, the `within_table` in the second example must be splitted in order to get
green specs. This is seems to be caused by rack_test not being able to detect 
updates inside the selected HTML block after a page reload.
    
Re-selecting the HTML block with a second `within_table` does the job.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [ ] I have added a CHANGELOG entry for this change (if needed)
