### PR TITLE
Parameterize taxon's permalink also on update

### DIFF
--- a/core/app/models/spree/taxon.rb
+++ b/core/app/models/spree/taxon.rb
@@ -59,9 +59,8 @@ module Spree
     # Sets this taxons permalink to a valid url encoded string based on its
     # name and its parents permalink (if present.)
     def set_permalink
-      permalink_tail = permalink.split('/').last if permalink.present?
-      permalink_tail ||= Spree::Config.taxon_url_parametizer_class.parameterize(name)
-      self.permalink_part = permalink_tail
+      permalink_tail = permalink.present? ? permalink.split('/').last : name
+      self.permalink_part = Spree::Config.taxon_url_parametizer_class.parameterize(permalink_tail)
     end
 
     # Update the permalink for this taxon and all children (if necessary)

--- a/core/spec/models/spree/taxon_spec.rb
+++ b/core/spec/models/spree/taxon_spec.rb
@@ -26,6 +26,14 @@ RSpec.describe Spree::Taxon, type: :model do
       expect(taxon.permalink).to eql "ruby-on-rails"
     end
 
+    context "updating a taxon permalink" do
+      it 'parameterizes permalink correctly' do
+        taxon.save!
+        taxon.update_attributes(permalink: 'spécial&charactèrs')
+        expect(taxon.permalink).to eql "special-characters"
+      end
+    end
+
     context "with parent taxon" do
       let(:parent) { FactoryBot.build(:taxon, permalink: "brands") }
       before       { allow(taxon).to receive_messages parent: parent }
@@ -39,6 +47,12 @@ RSpec.describe Spree::Taxon, type: :model do
         taxon.permalink = "b/rubyonrails"
         taxon.set_permalink
         expect(taxon.permalink).to eql "brands/rubyonrails"
+      end
+
+      it 'parameterizes permalink correctly' do
+        taxon.save!
+        taxon.update_attributes(permalink_part: 'spécial&charactèrs')
+        expect(taxon.reload.permalink).to eql "brands/special-characters"
       end
 
       # Regression test for https://github.com/spree/spree/issues/3390
@@ -119,6 +133,20 @@ RSpec.describe Spree::Taxon, type: :model do
 
       it "changes child's permalink" do
         is_expected.to change{ taxon2_child.reload.permalink }.from('t/t2/t2_child').to('t/t1/foo/t2_child')
+      end
+    end
+
+    context 'changing parent permalink with special characters ' do
+      subject do
+        -> { taxon2.update!(permalink: 'spécial&charactèrs') }
+      end
+
+      it 'changes own permalink with parameterized characters' do
+        is_expected.to change{ taxon2.reload.permalink }.from('t/t2').to('t/special-characters')
+      end
+
+      it 'changes child permalink with parameterized characters' do
+        is_expected.to change{ taxon2_child.reload.permalink }.from('t/t2/t2_child').to('t/special-characters/t2_child')
       end
     end
   end


### PR DESCRIPTION
**Description**
fix bug #3086 
the fix allows to use the ```Spree::Config.taxon_url_parametizer_class``` on taxon permalink update, and not only on the name. We insure permalink is always parameterized on save.
