### PR TITLE
fix sed call so it works on mac

### DIFF
--- a/lib/sandbox.sh
+++ b/lib/sandbox.sh
@@ -51,7 +51,7 @@ RUBY
 
 # Ensure sqlite3 version to match ActiveRecord SQLite adapter requirement
 # (see https://github.com/solidusio/solidus/issues/3087 for details)
-sed -i "/gem 'sqlite3'/c\gem 'sqlite3', '~> 1.3.6'" Gemfile
+sed -i -e "s/gem 'sqlite3'/gem 'sqlite3', '~> 1.3.6'/g" Gemfile
 
 bundle install --gemfile Gemfile
 bundle exec rake db:drop db:create


### PR DESCRIPTION
before:

```
sed: 1: "Gemfile": extra characters at the end of G command
```

this commit tries to make it work on all systems. Might not work on Windows systems though.

**Description**
<!--
  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

  If needed you can reference another PR or issue here, e.g.:
  Ref #ISSUE
-->

**Checklist:**
- [ ] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [ ] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have added a CHANGELOG entry for this change (if needed)
