### PR TITLE
Fixing inventory unit finalizer

### DIFF
--- a/core/app/models/spree/stock/inventory_units_finalizer.rb
+++ b/core/app/models/spree/stock/inventory_units_finalizer.rb
@@ -38,7 +38,7 @@ module Spree
           inventory_units_for_shipment.group_by(&:line_item_id).each_value do |units|
             shipment = units.first.shipment
             line_item = units.first.line_item
-            shipment.stock_location.unstock line_item.variant, inventory_units.count, shipment
+            shipment.stock_location.unstock line_item.variant, units.count, shipment
           end
         end
       end

--- a/core/spec/models/spree/stock/inventory_units_finalizer_spec.rb
+++ b/core/spec/models/spree/stock/inventory_units_finalizer_spec.rb
@@ -5,29 +5,53 @@ require 'rails_helper'
 module Spree
   module Stock
     RSpec.describe InventoryUnitsFinalizer, type: :model do
-      let(:order)          { build(:order_with_line_items) }
-      let(:inventory_unit) { build(:inventory_unit, order: order, variant: order.line_items.first.variant, shipment: order.shipments.first) }
-      let(:stock_item) { inventory_unit.variant.stock_items.first }
+      context "when finalizing an order with one line_item" do
+        let(:order)          { build(:order_with_line_items) }
+        let(:inventory_unit) { build(:inventory_unit, order: order, variant: order.line_items.first.variant, shipment: order.shipments.first) }
+        let(:stock_item) { inventory_unit.variant.stock_items.first }
 
-      before do
-        stock_item.set_count_on_hand(10)
-        stock_item.update_attributes!(backorderable: false)
-        inventory_unit.update_attributes!(pending: true)
+        before do
+          stock_item.set_count_on_hand(10)
+          stock_item.update_attributes!(backorderable: false)
+          inventory_unit.update_attributes!(pending: true)
+        end
+
+        subject { described_class.new([inventory_unit]).run! }
+
+        it "updates the associated inventory units" do
+          inventory_unit.update_columns(updated_at: 1.hour.ago)
+          expect { subject }.to change { inventory_unit.reload.updated_at }
+        end
+
+        it "updates the inventory units to not be pending" do
+          expect { subject }.to change { inventory_unit.reload.pending }.to(false)
+        end
+
+        it "unstocks the variant" do
+          expect { subject }.to change { stock_item.reload.count_on_hand }.from(10).to(9)
+        end
       end
 
-      subject { described_class.new([inventory_unit]).run! }
+      context "when finalizing an order with multiple line_items" do
+        let(:order)          { build(:order_with_line_items, line_items_count: 2) }
+        let(:inventory_unit) { build(:inventory_unit, order: order, variant: order.line_items.first.variant, shipment: order.shipments.first) }
+        let(:inventory_unit_2) { build(:inventory_unit, order: order, variant: order.line_items.second.variant, shipment: order.shipments.first) }
+        let(:stock_item) { inventory_unit.variant.stock_items.first }
+        let(:stock_item_2) { inventory_unit.variant.stock_items.first }
 
-      it "updates the associated inventory units" do
-        inventory_unit.update_columns(updated_at: 1.hour.ago)
-        expect { subject }.to change { inventory_unit.reload.updated_at }
-      end
+        before do
+          stock_item.set_count_on_hand(10)
+          stock_item_2.set_count_on_hand(10)
+          inventory_unit.update_attributes!(pending: true)
+          inventory_unit_2.update_attributes!(pending: true)
+        end
 
-      it "updates the inventory units to not be pending" do
-        expect { subject }.to change { inventory_unit.reload.pending }.to(false)
-      end
+        subject { described_class.new([inventory_unit, inventory_unit_2]).run! }
 
-      it "unstocks the variant" do
-        expect { subject }.to change { stock_item.reload.count_on_hand }.from(10).to(9)
+        it "unstocks the variant with the correct quantity" do
+          expect { subject }.to change { stock_item.reload.count_on_hand }.from(10).to(9)
+          .and change { stock_item_2.reload.count_on_hand }.from(10).to(9)
+        end
       end
     end
   end


### PR DESCRIPTION
**Description**
In an order with more than one inventory_unit, the total of inventory_units in the shipment would be subtracted from the stock of each item. For example, if a customer ordered 5 of "Product A" and 3 of "Product B", both products would have their stock decreased by 8, because the code is summing the inventory_units in general, not the units specific to the line_item.