### PR TITLE
Fix fieldset legend position in Firefox

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_forms.scss
@@ -178,6 +178,8 @@ fieldset {
     text-align: center;
     padding: 8px 15px;
     width: auto;
+    margin-left: auto;
+    margin-right: auto;
 
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;


### PR DESCRIPTION
**Description**

Fix fieldset legend position in Firefox

### Before

<img width="1680" alt="firefox legends before" src="https://user-images.githubusercontent.com/42868/52824409-b167db00-30b8-11e9-929d-be00add1a2f1.png">

### After

<img width="1680" alt="firefox-legends-after" src="https://user-images.githubusercontent.com/42868/52824411-b2007180-30b8-11e9-95e4-b97369dcedd1.png">