### PR TITLE
Admin payments UI cleanup

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/sections/_log_entries.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/_log_entries.scss
@@ -1,17 +1,13 @@
 .log_entry {
   &.success {
-    background: lighten($color-2, 15);
-
-    td h4 {
-      color: darken($body-color, 25);
+    i {
+      color: $color-2;
     }
   }
 
   &.fail {
-    background: lighten($color-5, 25);
-
-    td h4 {
-      color: lighten($body-color, 50);
+    i {
+      color: $color-5;
     }
   }
 }

--- a/backend/app/assets/stylesheets/spree/backend/shared/_icons.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_icons.scss
@@ -26,7 +26,7 @@
 
 .fa-trash     { @extend .fa-trash-o  }
 
-.fa-capture   { @extend .fa-check    }
+.fa-capture   { @extend .fa-thumbs-up }
 .fa-credit    { @extend .fa-check    }
 .fa-approve   { @extend .fa-check    }
 .fa-icon-cogs { @extend .fa-cogs     }

--- a/backend/app/assets/stylesheets/spree/backend/shared/_layout.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_layout.scss
@@ -29,10 +29,6 @@ body {
   }
 }
 
-.content-main {
-  overflow-x: hidden; // makes sure that the tabs are able to resize
-}
-
 #content {
   position: relative;
   padding: 0;

--- a/backend/app/assets/stylesheets/spree/backend/shared/_tables.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_tables.scss
@@ -123,4 +123,9 @@ table {
       border-top: none;
     }
   }
+
+  pre {
+    font-size: 100%;
+    margin-bottom: 0;
+  }
 }

--- a/backend/app/assets/stylesheets/spree/backend/shared/_typography.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_typography.scss
@@ -68,7 +68,6 @@ dl {
     width: 40%;
     font-weight: $font-weight-bold;
     padding-left: 0;
-    font-size: 85%;
     clear: left;
   }
 

--- a/backend/app/controllers/spree/admin/log_entries_controller.rb
+++ b/backend/app/controllers/spree/admin/log_entries_controller.rb
@@ -6,6 +6,9 @@ module Spree
       before_action :find_order_and_payment
 
       def index
+        Spree::Deprecation.warn 'Using a dedicated route for payment log entries ' \
+          'has been deprecated in favor of displaying the log entries on ' \
+          'the payment screen itself.', caller_locations(0)
         @log_entries = @payment.log_entries
       end
 

--- a/backend/app/views/spree/admin/log_entries/index.html.erb
+++ b/backend/app/views/spree/admin/log_entries/index.html.erb
@@ -8,22 +8,4 @@
   <li><%= link_to t('spree.back_to_payment'), spree.admin_order_payment_url(@order, @payment), class: 'btn btn-primary' %></li>
 <% end %>
 
-<table class='index' id='listing_log_entries'>
-  <% @log_entries.each do |entry| %>
-      <thead>
-        <tr class="log_entry <%= entry.parsed_details.success? ? 'success' : 'fail' %>">
-          <td colspan='2'>
-            <h4><i class='fa fa-<%= entry.parsed_details.success? ? 'check' : 'remove' %>'></i> <%= pretty_time(entry.created_at) %></h4>
-          </td>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td><%= Spree::LogEntry.human_attribute_name(:details) %></td>
-          <td>
-            <pre><%= entry.parsed_details.message %></pre>
-          </td>
-        </tr>
-      </tbody>
-  <% end %>
-</table>
+<%= render 'spree/admin/payments/log_entries', log_entries: @log_entries %>

--- a/backend/app/views/spree/admin/payments/_capture_events.html.erb
+++ b/backend/app/views/spree/admin/payments/_capture_events.html.erb
@@ -1,19 +1,16 @@
-<% if @payment.capture_events.exists? %>
-  <h3><%= plural_resource_name(Spree::PaymentCaptureEvent) %></h3>
-  <table class="index" id="capture_events">
-    <thead>
-      <tr data-hook="payments_header">
-        <th><%= "#{t('spree.date')}/#{t('spree.time')}" %></th>
-        <th><%= t('spree.amount') %></th>
+<table class="index" id="capture_events">
+  <thead>
+    <tr data-hook="payments_header">
+      <th><%= "#{t('spree.date')}/#{t('spree.time')}" %></th>
+      <th><%= t('spree.amount') %></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @payment.capture_events.each do |capture_event| %>
+      <tr id="<%= dom_id(capture_event) %>" data-hook="capture_events_row">
+        <td><%= pretty_time(capture_event.created_at) %></td>
+        <td><%= capture_event.display_amount %></td>
       </tr>
-    </thead>
-    <tbody>
-      <% @payment.capture_events.each do |capture_event| %>
-        <tr id="<%= dom_id(capture_event) %>" data-hook="capture_events_row">
-          <td><%= pretty_time(capture_event.created_at) %></td>
-          <td><%= capture_event.display_amount %></td>
-        </tr>
-      <% end %>
-    </tbody>
-  </table>
-<% end %>
+    <% end %>
+  </tbody>
+</table>

--- a/backend/app/views/spree/admin/payments/_capture_events.html.erb
+++ b/backend/app/views/spree/admin/payments/_capture_events.html.erb
@@ -1,15 +1,15 @@
 <table class="index" id="capture_events">
   <thead>
     <tr data-hook="payments_header">
-      <th><%= "#{t('spree.date')}/#{t('spree.time')}" %></th>
-      <th><%= t('spree.amount') %></th>
+      <th><%= Spree::PaymentCaptureEvent.human_attribute_name(:created_at) %></th>
+      <th class="text-right"><%= Spree::PaymentCaptureEvent.human_attribute_name(:amount) %></th>
     </tr>
   </thead>
   <tbody>
     <% @payment.capture_events.each do |capture_event| %>
       <tr id="<%= dom_id(capture_event) %>" data-hook="capture_events_row">
         <td><%= pretty_time(capture_event.created_at) %></td>
-        <td><%= capture_event.display_amount %></td>
+        <td class="text-right"><%= capture_event.display_amount %></td>
       </tr>
     <% end %>
   </tbody>

--- a/backend/app/views/spree/admin/payments/_list.html.erb
+++ b/backend/app/views/spree/admin/payments/_list.html.erb
@@ -48,7 +48,7 @@
         </td>
         <td class="actions">
           <div class="editing-show">
-            <%= link_to_with_icon 'save', t('spree.actions.save'), nil, no_text: true, class: "js-save", data: {action: 'save'} %>
+            <%= link_to_with_icon 'ok', t('spree.actions.save'), nil, no_text: true, class: "js-save", data: {action: 'save'} %>
             <%= link_to_with_icon 'cancel', t('spree.actions.cancel'), nil, no_text: true, class: "js-cancel", data: {action: 'cancel'} %>
           </div>
           <div class="editing-hide">

--- a/backend/app/views/spree/admin/payments/_log_entries.html.erb
+++ b/backend/app/views/spree/admin/payments/_log_entries.html.erb
@@ -1,0 +1,22 @@
+<table class='index' id='listing_log_entries'>
+  <% log_entries.each do |entry| %>
+    <thead>
+      <tr class="log_entry <%= entry.parsed_details.success? ? 'success' : 'fail' %>">
+        <td colspan='2'>
+          <h4>
+            <i class='fa fa-<%= entry.parsed_details.success? ? 'check' : 'remove' %>'></i>
+            <%= pretty_time(entry.created_at) %>
+          </h4>
+        </td>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><%= Spree::LogEntry.human_attribute_name(:details) %></td>
+        <td>
+          <pre><%= entry.parsed_details.message %></pre>
+        </td>
+      </tr>
+    </tbody>
+  <% end %>
+</table>

--- a/backend/app/views/spree/admin/payments/_log_entries.html.erb
+++ b/backend/app/views/spree/admin/payments/_log_entries.html.erb
@@ -1,22 +1,29 @@
 <table class='index' id='listing_log_entries'>
+  <colgroup>
+    <col style="width: 30%" />
+    <col style="width: 60%" />
+    <col style="width: 10%" />
+  </colgroup>
+  <thead>
+    <tr>
+      <th><%= Spree::LogEntry.human_attribute_name(:created_at) %></th>
+      <th><%= Spree::LogEntry.human_attribute_name(:details) %></th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
   <% log_entries.each do |entry| %>
-    <thead>
-      <tr class="log_entry <%= entry.parsed_details.success? ? 'success' : 'fail' %>">
-        <td colspan='2'>
-          <h4>
-            <i class='fa fa-<%= entry.parsed_details.success? ? 'check' : 'remove' %>'></i>
-            <%= pretty_time(entry.created_at) %>
-          </h4>
-        </td>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><%= Spree::LogEntry.human_attribute_name(:details) %></td>
-        <td>
-          <pre><%= entry.parsed_details.message %></pre>
-        </td>
-      </tr>
-    </tbody>
+    <tr class="log_entry <%= entry.parsed_details.success? ? 'success' : 'fail' %>">
+      <td>
+        <%= pretty_time(entry.created_at) %>
+      </td>
+      <td>
+        <pre><%= entry.parsed_details.message %></pre>
+      </td>
+      <td class="text-right">
+        <i class='fa fa-<%= entry.parsed_details.success? ? 'check' : 'remove' %>'></i>
+      </td>
+    </tr>
   <% end %>
+  </tbody>
 </table>

--- a/backend/app/views/spree/admin/payments/show.html.erb
+++ b/backend/app/views/spree/admin/payments/show.html.erb
@@ -8,11 +8,6 @@
   </span>
 <% end %>
 
-
-<% content_for :page_actions do %>
-  <li><%= link_to t('spree.logs'), spree.admin_order_payment_log_entries_url(@order, @payment), class: 'btn btn-primary' %></li>
-<% end %>
-
 <%= render partial: "spree/admin/payments/source_views/#{@payment.payment_method.partial_name}", locals: { payment: @payment.source.is_a?(Spree::Payment) ? @payment.source : @payment } %>
 
 <div data-hook="amount" class="align-center">
@@ -23,5 +18,12 @@
   <fieldset class="no-border-bottom">
     <legend><%= plural_resource_name(Spree::PaymentCaptureEvent) %></legend>
     <%= render 'spree/admin/payments/capture_events' %>
+  </fieldset>
+<% end %>
+
+<% if @payment.log_entries.any? %>
+  <fieldset class="no-border-bottom">
+    <legend><%= plural_resource_name(Spree::LogEntry) %></legend>
+    <%= render 'spree/admin/payments/log_entries', log_entries: @payment.log_entries %>
   </fieldset>
 <% end %>

--- a/backend/app/views/spree/admin/payments/show.html.erb
+++ b/backend/app/views/spree/admin/payments/show.html.erb
@@ -19,4 +19,9 @@
   <h5><%= label_tag nil, Spree::Payment.human_attribute_name(:amount) %>: <span class="green"><%= @payment.display_amount.to_html %></span> </h5>
 </div>
 
-<%= render 'spree/admin/payments/capture_events' %>
+<% if @payment.capture_events.any? %>
+  <fieldset class="no-border-bottom">
+    <legend><%= plural_resource_name(Spree::PaymentCaptureEvent) %></legend>
+    <%= render 'spree/admin/payments/capture_events' %>
+  </fieldset>
+<% end %>

--- a/backend/spec/features/admin/orders/log_entries_spec.rb
+++ b/backend/spec/features/admin/orders/log_entries_spec.rb
@@ -23,7 +23,7 @@ describe "Log entries", type: :feature do
     it "shows a successful attempt" do
       visit spree.admin_order_payments_path(payment.order)
       click_on payment.number
-      click_link "Logs"
+
       within("#listing_log_entries") do
         expect(page).to have_content("Transaction successful")
       end
@@ -47,7 +47,7 @@ describe "Log entries", type: :feature do
     it "shows a failed attempt" do
       visit spree.admin_order_payments_path(payment.order)
       click_on payment.number
-      click_link "Logs"
+
       within("#listing_log_entries") do
         expect(page).to have_content("Transaction failed")
       end

--- a/backend/spec/features/admin/orders/payments_spec.rb
+++ b/backend/spec/features/admin/orders/payments_spec.rb
@@ -105,7 +105,7 @@ describe 'Payments', type: :feature do
         within_row(1) do
           click_icon(:edit)
           fill_in('amount', with: '$1')
-          click_icon(:save)
+          click_icon(:ok)
           expect(page).to have_selector('td.amount span', text: '$1.00')
           expect(payment.reload.amount).to eq(1.00)
         end
@@ -125,7 +125,7 @@ describe 'Payments', type: :feature do
         within_row(1) do
           click_icon(:edit)
           fill_in('amount', with: 'invalid')
-          click_icon(:save)
+          click_icon(:ok)
         end
         expect(page).to have_selector('.flash.error', text: 'Invalid resource. Please fix errors and try again.')
         expect(payment.reload.amount).to eq(150.00)

--- a/backend/spec/features/admin/orders/payments_spec.rb
+++ b/backend/spec/features/admin/orders/payments_spec.rb
@@ -49,11 +49,9 @@ describe 'Payments', type: :feature do
 
       visit spree.admin_order_payment_path(order, payment)
       expect(page).to have_content 'Capture Events'
-      # within '#capture_events' do
-      within_row(1) do
+      within '#capture_events' do
         expect(page).to have_content(capture_amount / 100)
       end
-      # end
     end
 
     it 'displays the address for a credit card when present' do

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -97,6 +97,7 @@ en:
         total: Total price
       spree/log_entry:
         details: Message
+        created_at: Date/Time
       spree/option_type:
         name: Name
         presentation: Presentation

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -148,6 +148,9 @@ en:
         number: Identifier
         response_code: Transaction ID
         state: State
+      spree/payment_capture_event:
+        created_at: Date/Time
+        amount: Amount
       spree/payment_method:
         active: Active
         auto_capture: Auto Capture


### PR DESCRIPTION
# Description

Removes a lot of confusion and UI misconceptions from the order payments screens

1. Changes icons of payment capture and save actions
2. Moves the payment logs buttons into context
3. Fixes navigation issues on payment log entries screen

# Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message

# Screenshots

## Payment save button before
<img width="824" alt="payment save before" src="https://user-images.githubusercontent.com/42868/52847717-3bda2a00-310d-11e9-9f8f-a8351183ef71.png">

## Payment save button after
<img width="824" alt="payment save after" src="https://user-images.githubusercontent.com/42868/52847716-3b419380-310d-11e9-8146-0c04ba2922ee.png">

## Payment capture before
<img width="825" alt="payment capture before" src="https://user-images.githubusercontent.com/42868/52847714-3b419380-310d-11e9-8980-5f1a1c21a2dd.png">

## Payment capture after
<img width="828" alt="payment capture after" src="https://user-images.githubusercontent.com/42868/52847713-3aa8fd00-310d-11e9-8339-da789abf5b3a.png">

## Payment details before
<img width="830" alt="credit card void - payments - r987654321 - orders 2019-02-27 21-28-37" src="https://user-images.githubusercontent.com/42868/53520747-aa889180-3ad6-11e9-9868-8c51b48f290d.png">

## Log entries before

![log entries before](https://user-images.githubusercontent.com/42868/53520843-e6bbf200-3ad6-11e9-8608-fb459018718b.png)

## Payment details with integrated log entries after
<img width="829" alt="payment details after" src="https://user-images.githubusercontent.com/42868/53520614-5382bc80-3ad6-11e9-91f8-15ae915ef5f2.png">