### PR TITLE
Remove CHANGELOG entry from PR's template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,4 +11,3 @@
 - [ ] I have added a detailed description into each commit message
 - [ ] I have updated Guides and README accordingly to this change (if needed)
 - [ ] I have added tests to cover this change (if needed)
-- [ ] I have added a CHANGELOG entry for this change (if needed)


### PR DESCRIPTION
This is not needed since we generate the CHANGELOG automatically before
each release. We can't expect contributors to maintain the CHANGELOG.

Ref: https://github.com/solidusio/solidus/pull/3099#discussion_r257225896

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
