### PR TITLE
Enable Docker for demoing purposes

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,18 @@ Try out Solidus with one-click on Heroku:
 
 [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/solidusio/solidus)
 
+Alternatively, you can use Docker to run a demo on your local machine. Run the
+following command to download the image and run it at
+[http://localhost:3000](http://localhost:3000).
+
+```
+docker run --rm -it -p 3000:3000 solidusio/solidus-demo:latest
+```
+
+The admin interface can be accessed at
+[http://localhost:3000/admin/](http://localhost:3000/admin/), the default
+credentials are `admin@example.com` and `test123`.
+
 ## Getting started
 
 Begin by making sure you have

--- a/lib/demo/Dockerfile
+++ b/lib/demo/Dockerfile
@@ -1,0 +1,21 @@
+#
+# This image is intended to be used to test and demo Solidus
+# it is not intended for production purposes 
+#
+FROM ruby:2.5.1
+
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
+
+RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs
+
+RUN mkdir /solidus
+
+WORKDIR /solidus
+
+ADD . /solidus
+
+RUN bundle install
+
+RUN bundle exec rake sandbox
+
+CMD ["sh", "./lib/demo/docker-entrypoint.sh"]

--- a/lib/demo/README.md
+++ b/lib/demo/README.md
@@ -1,0 +1,27 @@
+# Solidus Docker Demo
+The Dockerfile in this folder is intended for demoing purposes, meaning that a
+user can run an installation of Solidus using a Docker container.
+
+## How to build the image
+Make sure Docker is installed in your local and run the following command:
+
+```shell
+docker build -t solidusio/solidus-demo:latest -f lib/demo/Dockerfile .
+```
+
+## How to run the image
+You can either run the image you built locally or run the official image pushed
+in Dockerhub.
+
+```shell
+docker run --rm -it -p 3000:3000 solidusio/solidus-demo:latest
+```
+
+## How to push the image
+If you want to push the image you can use the following command, just note that
+this specific command will push the image to the official Solidus Dockerhub
+account.
+
+```shell
+docker push solidusio/solidus-demo:latest
+```

--- a/lib/demo/docker-entrypoint.sh
+++ b/lib/demo/docker-entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+export RAILS_ENV=development
+
+cd sandbox && \
+bundle exec rails s -p 3000 -b '0.0.0.0'


### PR DESCRIPTION
**Description**
Enables Solidus to be ran using Docker for demoing purposes. This provides an easy way for newcomers to test the storefront out without going through the install process and avoiding a Heroku deployment.

Ref #3103

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)

**How to test it out:**
As the README states, just run the following command to download the image and run it at [http://localhost:3000](http://localhost:3000).

```
docker run --rm -it -p 3000:3000 kinduff/solidus-demo:latest
```

The admin can be found at [http://localhost:3000/admin/](http://localhost:3000/admin/), credentials are `admin@example.com` and `test123`.

**Notes & Questions:**
This PR is not ready to be merged since I pushed the Docker image to my own Dockerhub account.

Wanted to submit and ask before adding more work into this if it would be worth to create some sort of Rake task to generate an image for each of the existing versions or just rely on master.

Also to ask if anyone has insights about how to automate this with Circle CI and have an up to date image everytime there's a change.