### PR TITLE
Fix remove code from promotions migration

### DIFF
--- a/core/db/migrate/20190106184413_remove_code_from_spree_promotions.rb
+++ b/core/db/migrate/20190106184413_remove_code_from_spree_promotions.rb
@@ -9,7 +9,7 @@ class RemoveCodeFromSpreePromotions < ActiveRecord::Migration[5.1]
   end
 
   def up
-    promotions_with_code = Promotion.where.not(code: nil)
+    promotions_with_code = Promotion.where.not(code: [nil, ''])
 
     if promotions_with_code.any?
       # You have some promotions with "code" field present! This is not good

--- a/core/db/migrate/20190106184413_remove_code_from_spree_promotions.rb
+++ b/core/db/migrate/20190106184413_remove_code_from_spree_promotions.rb
@@ -5,6 +5,7 @@ require 'solidus/migrations/promotions_with_code_handlers'
 class RemoveCodeFromSpreePromotions < ActiveRecord::Migration[5.1]
   class Promotion < ActiveRecord::Base
     self.table_name = "spree_promotions"
+    self.ignored_columns = %w(type)
   end
 
   def up

--- a/core/spec/migrate/20190106184413_remove_code_from_spree_promotions_spec.rb
+++ b/core/spec/migrate/20190106184413_remove_code_from_spree_promotions_spec.rb
@@ -44,7 +44,18 @@ RSpec.describe RemoveCodeFromSpreePromotions do
     DatabaseCleaner.clean_with(:truncation)
   end
 
+  let(:promotion_with_code) { create(:promotion) }
+
+  before do
+    # We can't set code via factory since `code=` is currently raising
+    # an error, see more at:
+    # https://github.com/solidusio/solidus/blob/cf96b03eb9e80002b69736e082fd485c870ab5d9/core/app/models/spree/promotion.rb#L65
+    promotion_with_code.update_column(:code, code)
+  end
+
   context 'when there are no promotions with code' do
+    let(:code) { '' }
+
     it 'does not call any promotion with code handler' do
       expect(described_class).not_to receive(:promotions_with_code_handler)
 
@@ -53,14 +64,7 @@ RSpec.describe RemoveCodeFromSpreePromotions do
   end
 
   context 'when there are promotions with code' do
-    let(:promotion_with_code) { create(:promotion) }
-
-    before do
-      # We can't set code via factory since `code=` is currently raising
-      # an error, see more at:
-      # https://github.com/solidusio/solidus/blob/cf96b03eb9e80002b69736e082fd485c870ab5d9/core/app/models/spree/promotion.rb#L65
-      promotion_with_code.update_column(:code, 'Just An Old Promo Code')
-    end
+    let(:code) { 'Just An Old Promo Code' }
 
     context 'with the deafult handler (Solidus::Migrations::PromotionWithCodeHandlers::RaiseException)' do
       it 'raise a StandardError exception' do

--- a/core/spec/migrate/20190106184413_remove_code_from_spree_promotions_spec.rb
+++ b/core/spec/migrate/20190106184413_remove_code_from_spree_promotions_spec.rb
@@ -96,6 +96,14 @@ RSpec.describe RemoveCodeFromSpreePromotions do
           end
         end
 
+        context 'with promotions with type set (legacy feature)' do
+          let(:promotion_with_code) { create(:promotion, type: 'Spree::Promotion') }
+
+          it 'does not raise a STI error' do
+            expect { subject }.not_to raise_error
+          end
+        end
+
         context 'when there is a Spree::PromotionCode with the same value' do
           context 'associated with the same promotion' do
             let!(:existing_promotion_code) { create(:promotion_code, value: 'just an old promo code', promotion: promotion_with_code) }


### PR DESCRIPTION
This PR fixes two issues with the migration introduced into https://github.com/solidusio/solidus/pull/3028.

Ref #2979 

Please note that both issues are quite rare and we've found them by upgrading Solidus on very long-lived stores (previously on Spree).

I think it's better to backport these fixes into `v2.8` as well since the migration could fail and some custom change to it could be required.

**Promotions with type column set**

 `spree_promotions` table used to be named `spree_activators` in legacy spree versions. This table was used by many models with STI via the `type` column. After that, it was renamed into `spree_promotions` so having this `type` field does not make sense anymore.

The issue here is that if you run this migration on stores that were created before the rename there will be that `type` field automatically set to  `Spree::Promotion`. This would raise an error while the migration runs:

```text
StandardError:
       An error has occurred, this and all later migrations canceled:

       Invalid single-table inheritance type: Spree::Promotion is not a subclass of RemoveCodeFromSpreePromotions::Promotion
```

**Promotions with empty string code (not nil)**

`code` field could be both `nil` and an empty string. If multiple empty string codes are present the migration would fail since it's not possible to have more than one code with an empty string in the database.


**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change (if needed)
