### PR TITLE
Remove destructive actions from migration 20180710170104

### DIFF
--- a/core/db/migrate/20180710170104_create_spree_store_credit_reasons_table.rb
+++ b/core/db/migrate/20180710170104_create_spree_store_credit_reasons_table.rb
@@ -21,15 +21,28 @@ class CreateSpreeStoreCreditReasonsTable < ActiveRecord::Migration[5.1]
       StoreCreditReason.create!(name: update_reason.name)
     end
 
-    drop_table :spree_store_credit_update_reasons
-    rename_column :spree_store_credit_events, :update_reason_id, :store_credit_reason_id
+    add_column :spree_store_credit_events, :store_credit_reason_id, :integer
+    execute "update spree_store_credit_events set store_credit_reason_id = update_reason_id"
+
+    # TODO: table spree_store_credit_update_reasons and column
+    # column spree_store_credit_update_reasons.update_reason_id
+    # must be dropped in a future Solidus release
   end
 
   def down
-    create_table :spree_store_credit_update_reasons do |t|
-      t.string :name
+    # This table and column  may not exist anymore as another irreversible
+    # migration may have removed it later. They must be added back or the
+    # `up` method would fail
+    unless table_exists? :spree_store_credit_update_reasons
+      create_table :spree_store_credit_update_reasons do |t|
+        t.string :name
 
-      t.timestamps
+        t.timestamps
+      end
+
+      unless column_exists? :spree_store_credit_events, :update_reason_id
+        add_column :spree_store_credit_events, :update_reason_id, :integer
+      end
     end
 
     StoreCreditReason.all.each do |store_credit_reason|
@@ -37,6 +50,6 @@ class CreateSpreeStoreCreditReasonsTable < ActiveRecord::Migration[5.1]
     end
 
     drop_table :spree_store_credit_reasons
-    rename_column :spree_store_credit_events, :store_credit_reason_id, :update_reason_id
+    remove_column :spree_store_credit_events, :store_credit_reason_id
   end
 end


### PR DESCRIPTION
**Description**

Removing tables and renaming columns are destructive actions as they change the
DB schema in a way that is likely to be not compatible with previous code.

This is especially dangerous when deploying multi-instance applications as
migrations can run before all instances code is synced. When this happens,
these instances may experience severe downtime due to high error rates.

So destructive changes should be done in subsequent deploys: first add the new
table and columns, then later remove the stale ones.

Table `spree_store_credit_update_reasons` and its column `update_reason_id`
will need to be removed in a future release of Solidus.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
