### PR TITLE
Tenative fix for flaky spec

### DIFF
--- a/backend/spec/features/admin/products/edit/taxons_spec.rb
+++ b/backend/spec/features/admin/products/edit/taxons_spec.rb
@@ -29,6 +29,7 @@ describe "Product Display Order", type: :feature do
 
       select2_search "Clothing", from: "Taxon"
       click_button "Update"
+      expect(page).to have_content "Product \"#{product.name}\" has been successfully updated!"
       assert_selected_taxons([taxon_1, taxon_2])
     end
 


### PR DESCRIPTION
Checking the flash message after form submission may clarify if this flaky spec
failure is caused by something unexpected before submitting the form.

Also, this helps in delaying the failing expectation, as the page DOM and
HTML should be fully updated by that time.

- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
