### PR TITLE
Fix migration `20161123154034` and `20120411123334`

### DIFF
--- a/api/db/migrate/20120411123334_resize_api_key_field.rb
+++ b/api/db/migrate/20120411123334_resize_api_key_field.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ResizeApiKeyField < ActiveRecord::Migration[4.2]
-  def change
+  def up
     unless defined?(User)
       change_column :spree_users, :api_key, :string, limit: 48
     end

--- a/core/db/migrate/20161123154034_add_available_to_users_and_remove_display_on_from_shipping_methods.rb
+++ b/core/db/migrate/20161123154034_add_available_to_users_and_remove_display_on_from_shipping_methods.rb
@@ -13,7 +13,7 @@ class AddAvailableToUsersAndRemoveDisplayOnFromShippingMethods < ActiveRecord::M
     add_column(:spree_shipping_methods, :display_on, :string)
     execute("UPDATE spree_shipping_methods "\
             "SET display_on='both' "\
-            "WHERE (available_to_users=#{quoted_true}")
+            "WHERE (available_to_users=#{quoted_true})")
     execute("UPDATE spree_shipping_methods "\
             "SET display_on='back_end' "\
             "WHERE (available_to_users=#{quoted_false})")


### PR DESCRIPTION
* migration `20120411123334` was missing a parenthesis causing DB rollback errors
* migration `20120411123334` is not reversible so `change` cannot be used

- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message