### PR TITLE
Add migration to drop table/column from `20180710170104`

### DIFF
--- a/core/db/migrate/20190220093635_drop_spree_store_credit_update_reasons.rb
+++ b/core/db/migrate/20190220093635_drop_spree_store_credit_update_reasons.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class DropSpreeStoreCreditUpdateReasons < ActiveRecord::Migration[5.1]
+  # This migration should run in a subsequent deploy after 20180710170104
+  # has been already deployed. See also migration 20180710170104.
+
+  # We can't add back the table in a `down` method here: a previous version
+  # of migration 20180710170104 would fail with `table already exists` , as
+  # it handles itself the add/remove of this table and column.
+  def up
+    if table_exists? :spree_store_credit_update_reasons
+      drop_table :spree_store_credit_update_reasons
+    end
+
+    if column_exists? :spree_store_credit_events, :update_reason_id
+      remove_column :spree_store_credit_events, :update_reason_id
+    end
+  end
+end


### PR DESCRIPTION
Migration `20180710170104` has been reworked with PR #3109 in order to avoid
risky situations for multi-instance Solidus installations.

The table `spree_store_credit_update_reasons` and the column `update_reason_id`
from table `spree_store_credit_events` can be either still be around (this
happens when migration `20180710170104` was run after the mod) or not, so we
need to check the presence of both in advance.

Also, since on rollback the older version of `20180710170104` would create this
table then it cannot be created here in a `down` method.

When using the updated version of migration `20180710170104`, the table creation 
will happen in that migration.

- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
