### PR TITLE
Set mininum line item quantity in admin cart

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/templates/orders/line_item.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/orders/line_item.hbs
@@ -20,7 +20,7 @@
 {{#if editing}}
   <td class="line-item-qty-edit">
     <form>
-      <input type="number" name="quantity" value="{{ line_item.quantity }}" min="0" class="line_item_quantity" size="5">
+      <input type="number" name="quantity" value="{{ line_item.quantity }}" min="1" class="line_item_quantity" size="5">
     </form>
   </td>
 {{else}}


### PR DESCRIPTION


**Description**
It does not make much sense to add zero of anything to an order. This
commit changes the minimum quantity for a line item in the admin cart to
one.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message

I don't think a test is necessary for this change.