### PR TITLE
v2.8.2

### DIFF
--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -109,7 +109,7 @@
             <% end %>
           </div>
         </div>
-
+      <% else %>
         <div id="shipping_specs" class="row">
           <% [:height, :width, :depth, :weight].each_with_index do |field, index| %>
             <div id="shipping_specs_<%= field %>_field" class="col-6">

--- a/core/db/migrate/20180710170104_create_spree_store_credit_reasons_table.rb
+++ b/core/db/migrate/20180710170104_create_spree_store_credit_reasons_table.rb
@@ -21,15 +21,28 @@ class CreateSpreeStoreCreditReasonsTable < ActiveRecord::Migration[5.1]
       StoreCreditReason.create!(name: update_reason.name)
     end
 
-    drop_table :spree_store_credit_update_reasons
-    rename_column :spree_store_credit_events, :update_reason_id, :store_credit_reason_id
+    add_column :spree_store_credit_events, :store_credit_reason_id, :integer
+    execute "update spree_store_credit_events set store_credit_reason_id = update_reason_id"
+
+    # TODO: table spree_store_credit_update_reasons and column
+    # column spree_store_credit_update_reasons.update_reason_id
+    # must be dropped in a future Solidus release
   end
 
   def down
-    create_table :spree_store_credit_update_reasons do |t|
-      t.string :name
+    # This table and column  may not exist anymore as another irreversible
+    # migration may have removed it later. They must be added back or the
+    # `up` method would fail
+    unless table_exists? :spree_store_credit_update_reasons
+      create_table :spree_store_credit_update_reasons do |t|
+        t.string :name
 
-      t.timestamps
+        t.timestamps
+      end
+
+      unless column_exists? :spree_store_credit_events, :update_reason_id
+        add_column :spree_store_credit_events, :update_reason_id, :integer
+      end
     end
 
     StoreCreditReason.all.each do |store_credit_reason|
@@ -37,6 +50,6 @@ class CreateSpreeStoreCreditReasonsTable < ActiveRecord::Migration[5.1]
     end
 
     drop_table :spree_store_credit_reasons
-    rename_column :spree_store_credit_events, :store_credit_reason_id, :update_reason_id
+    remove_column :spree_store_credit_events, :store_credit_reason_id
   end
 end

--- a/core/db/migrate/20190106184413_remove_code_from_spree_promotions.rb
+++ b/core/db/migrate/20190106184413_remove_code_from_spree_promotions.rb
@@ -9,7 +9,7 @@ class RemoveCodeFromSpreePromotions < ActiveRecord::Migration[5.1]
   end
 
   def up
-    promotions_with_code = Promotion.where.not(code: nil)
+    promotions_with_code = Promotion.where.not(code: [nil, ''])
 
     if promotions_with_code.any?
       # You have some promotions with "code" field present! This is not good

--- a/core/db/migrate/20190106184413_remove_code_from_spree_promotions.rb
+++ b/core/db/migrate/20190106184413_remove_code_from_spree_promotions.rb
@@ -5,6 +5,7 @@ require 'solidus/migrations/promotions_with_code_handlers'
 class RemoveCodeFromSpreePromotions < ActiveRecord::Migration[5.1]
   class Promotion < ActiveRecord::Base
     self.table_name = "spree_promotions"
+    self.ignored_columns = %w(type)
   end
 
   def up

--- a/core/spec/migrate/20190106184413_remove_code_from_spree_promotions_spec.rb
+++ b/core/spec/migrate/20190106184413_remove_code_from_spree_promotions_spec.rb
@@ -44,7 +44,18 @@ RSpec.describe RemoveCodeFromSpreePromotions do
     DatabaseCleaner.clean_with(:truncation)
   end
 
+  let(:promotion_with_code) { create(:promotion) }
+
+  before do
+    # We can't set code via factory since `code=` is currently raising
+    # an error, see more at:
+    # https://github.com/solidusio/solidus/blob/cf96b03eb9e80002b69736e082fd485c870ab5d9/core/app/models/spree/promotion.rb#L65
+    promotion_with_code.update_column(:code, code)
+  end
+
   context 'when there are no promotions with code' do
+    let(:code) { '' }
+
     it 'does not call any promotion with code handler' do
       expect(described_class).not_to receive(:promotions_with_code_handler)
 
@@ -53,14 +64,7 @@ RSpec.describe RemoveCodeFromSpreePromotions do
   end
 
   context 'when there are promotions with code' do
-    let(:promotion_with_code) { create(:promotion) }
-
-    before do
-      # We can't set code via factory since `code=` is currently raising
-      # an error, see more at:
-      # https://github.com/solidusio/solidus/blob/cf96b03eb9e80002b69736e082fd485c870ab5d9/core/app/models/spree/promotion.rb#L65
-      promotion_with_code.update_column(:code, 'Just An Old Promo Code')
-    end
+    let(:code) { 'Just An Old Promo Code' }
 
     context 'with the deafult handler (Solidus::Migrations::PromotionWithCodeHandlers::RaiseException)' do
       it 'raise a StandardError exception' do

--- a/core/spec/migrate/20190106184413_remove_code_from_spree_promotions_spec.rb
+++ b/core/spec/migrate/20190106184413_remove_code_from_spree_promotions_spec.rb
@@ -96,6 +96,14 @@ RSpec.describe RemoveCodeFromSpreePromotions do
           end
         end
 
+        context 'with promotions with type set (legacy feature)' do
+          let(:promotion_with_code) { create(:promotion, type: 'Spree::Promotion') }
+
+          it 'does not raise a STI error' do
+            expect { subject }.not_to raise_error
+          end
+        end
+
         context 'when there is a Spree::PromotionCode with the same value' do
           context 'associated with the same promotion' do
             let!(:existing_promotion_code) { create(:promotion_code, value: 'just an old promo code', promotion: promotion_with_code) }


### PR DESCRIPTION
**Description**

This PR adds some fixes on Solidus `v2.8` that are already present in `master` and could help users that still have to update Solidus to this version.

A summary of changes:

1. **[Allow setting weight and dimensions on products without variants](https://github.com/solidusio/solidus/pull/3112)**
1. **[Remove destructive actions from one migrations related to store credit reasons](https://github.com/solidusio/solidus/pull/3109)**: The reason is well explained into the PR, anyway the plan in to restore those destructive actions in a future version of Solidus, probably 2.9. If users already run this migration, it should be safe to run the new one on 2.9, since this scenario has been taken into account: https://github.com/solidusio/solidus/pull/3114
1. **[Fix some errors while running the migration that removes code columns from spree_promotions](https://github.com/solidusio/solidus/pull/3108)**: While upgrading a store started many years ago, we noticed that there were cases where database has inconsistent data. This fix should simplify the upgrade.

They are meant to be released with a new patch version `v2.8.2`.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
