### PR TITLE
When a controller action fails to be authorized, redirect back or default to /unauthorized

### DIFF
--- a/core/lib/generators/solidus/install/templates/config/initializers/spree.rb.tt
+++ b/core/lib/generators/solidus/install/templates/config/initializers/spree.rb.tt
@@ -34,6 +34,11 @@ Spree.config do |config|
   # See https://github.com/solidusio/solidus/pull/3456 for more info.
   config.raise_with_invalid_currency = false
 
+  # Set this configuration to false to always redirect the user to
+  # /unauthorized when needed, without trying to redirect them to
+  # their previous location first.
+  config.redirect_back_on_unauthorized = true
+
   # Set this configuration to `false` to avoid running validations when
   # updating an order. Be careful since you can end up having inconsistent
   # data in your database turning it on.

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -220,6 +220,12 @@ module Spree
     #   @return [Boolean] (default: +true+)
     preference :raise_with_invalid_currency, :boolean, default: true
 
+    # @!attribute [rw] redirect_back_on_unauthorized
+    #   Whether to try to redirect users back when they try to access
+    #   unauthorized routes, before redirect them to /unauthorized.
+    #   @return [Boolean] (default: +false+)
+    preference :redirect_back_on_unauthorized, :boolean, default: false
+
     # @!attribute [rw] require_master_price
     #   @return [Boolean] Require a price on the master variant of a product (default: +true+)
     preference :require_master_price, :boolean, default: true

--- a/core/lib/spree/core/controller_helpers/auth.rb
+++ b/core/lib/spree/core/controller_helpers/auth.rb
@@ -11,7 +11,7 @@ module Spree
         # @!attribute [rw] unauthorized_redirect
         #   @!scope class
         #   Extension point for overriding behaviour of access denied errors.
-        #   Default behaviour is to redirect to "/unauthorized" with a flash
+        #   Default behaviour is to redirect back or to "/unauthorized" with a flash
         #   message.
         #   @return [Proc] action to take when access denied error is raised.
 
@@ -22,7 +22,7 @@ module Spree
           class_attribute :unauthorized_redirect
           self.unauthorized_redirect = -> do
             flash[:error] = I18n.t('spree.authorization_failure')
-            redirect_to "/unauthorized"
+            redirect_back(fallback_location: "/unauthorized")
           end
 
           rescue_from CanCan::AccessDenied do

--- a/core/lib/spree/core/controller_helpers/auth.rb
+++ b/core/lib/spree/core/controller_helpers/auth.rb
@@ -22,7 +22,20 @@ module Spree
           class_attribute :unauthorized_redirect
           self.unauthorized_redirect = -> do
             flash[:error] = I18n.t('spree.authorization_failure')
-            redirect_back(fallback_location: "/unauthorized")
+            if Spree::Config.redirect_back_on_unauthorized
+              redirect_back(fallback_location: "/unauthorized")
+            else
+              Spree::Deprecation.warn <<-WARN.strip_heredoc, caller
+                Having Spree::Config.redirect_back_on_unauthorized set
+                to `false` is deprecated and will not be supported in Solidus 3.0.
+
+                Please change this configuration to `true` and be sure that your
+                application does not break trying to redirect back when there is
+                an unauthorized access.
+              WARN
+
+              redirect_to "/unauthorized"
+            end
           end
 
           rescue_from CanCan::AccessDenied do

--- a/core/lib/spree/testing_support/dummy_app.rb
+++ b/core/lib/spree/testing_support/dummy_app.rb
@@ -117,6 +117,7 @@ Spree.user_class = 'Spree::LegacyUser'
 Spree.config do |config|
   config.mails_from = "store@example.com"
   config.raise_with_invalid_currency = false
+  config.redirect_back_on_unauthorized = true
   config.run_order_validations_on_order_updater = true
   config.use_combined_first_and_last_name_in_address = true
 

--- a/core/spec/lib/spree/core/controller_helpers/auth_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/auth_spec.rb
@@ -91,4 +91,26 @@ RSpec.describe Spree::Core::ControllerHelpers::Auth, type: :controller do
       expect(controller.try_spree_current_user).to eq nil
     end
   end
+
+  describe '#unauthorized_redirect' do
+    before do
+      def controller.index
+        authorize!(:read, :something)
+      end
+    end
+
+    context "http_referrer is present" do
+      before { request.env['HTTP_REFERER'] = '/redirect' }
+
+      it "redirects back" do
+        get :index
+        expect(response).to redirect_to('/redirect')
+      end
+    end
+
+    it "redirects to unauthorized" do
+      get :index
+      expect(response).to redirect_to('/unauthorized')
+    end
+  end
 end


### PR DESCRIPTION
**Description**
This change allows for a user to be redirected back whenever a request is not authorized. The current behavior redirects the user to `/unauthorized` all the time, but this is not ideal when browsing the admin, since you need to manually go back to where you came from.

**Changes:**
* `Spree::Core::ControllerHelpers::Auth`: In `self.unauthorized_redirect`, use `redirect_back` with a fallback location.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
