### PR TITLE
Add Adjustment documentation reference links

### DIFF
--- a/guides/source/developers/adjustments/overview.html.md
+++ b/guides/source/developers/adjustments/overview.html.md
@@ -5,12 +5,18 @@ taxes and promotions generate price adjustments. Adjustments can be either a
 positive or a negative amount.
 
 Adjustments values come from [adjustment sources](#adjustment-sources) (for
-example, a tax rate or a promotion action), and they affect the total price
-of an [adjustable](#adjustables) (an order, line item, or shipment).
+example, a [tax rate][taxation] or a [promotion action][promotion actions]), and
+they affect the total price of an [adjustable](#adjustables)
+(an [order][orders], line item, or [shipment][shipments]).
 
 <!-- TODO:
-  Add links to documentation about orders, line items, and shipments.
+  Add link to documentation about line items.
 -->
+
+[orders]: ../orders/overview.html
+[promotion actions]: ../promotions/promotion-actions.html
+[shipments]: ../shipments/overview.html
+[taxation]: ../taxation/overview.html
 
 Adjustments have the following attributes:
 
@@ -26,13 +32,11 @@ Adjustments have the following attributes:
 - `included`: If set to `true`, the adjustment amount is included in the final
   price of the object it is associated with. Otherwise, the adjustment is added
   to the total price. This property only applies to tax adjustments. See the
-  taxation documentation for more information.
+  [taxation][taxation] documentation for more information.
 - `finalized`: Indicates whether the adjustment is finalized. If set to `true`,
   then the adjustment is no longer automatically updated.
 
-<!-- TODO:
-  Add links to taxation documentation.
--->
+[taxation]: ../taxation/overview.html
 
 ## Adjustment sources
 
@@ -54,15 +58,14 @@ Note that tax adjustments may be treated differently than promotional
 adjustments in some circumstances:
 
 - By default, tax adjustments are always applied before promotional adjustments.
-  This is to comply with well-known tax regulations. See the taxation
+  This is to comply with well-known tax regulations. See the [taxation][taxation]
   documentation for more information.
 - Typically, an adjustment's value is added to the price of the object it is
-  associated with. However, value-added tax adjustments are already included in
-  the price and do not change any totals.
+  associated with. However, [value-added tax][value-added tax] adjustments are
+  already included in the price and do not change any totals.
 
-<!-- TODO:
-  Add links to relevant taxation documentation.
--->
+[taxation]: ../taxation/overview.html
+[value-added tax]: ../taxation/overview.html#sales-tax-and-value-added-tax
 
 ## Adjustables
 
@@ -109,13 +112,12 @@ For example, you can find all of the adjustments with an `eligible` value of
 - `charge`: Returns adjustments with a positive value.
 - `credit`: Returns adjustments with a negative value.
 - `is_included`: Returns adjustments that are included in the object's price.
-   Typically, only value-added tax adjustments have this value.
+   Typically, only [value-added tax][value-added tax] adjustments have this
+   value.
 - `additional`: Adjustments which modify the object's price. The default for all
   adjustments.
 
-<!-- TODO:
-  Add link to taxation documentation to `is_included` item in the list.
--->
+[value-added tax]: ../taxation/overview.html#sales-tax-and-value-added-tax
 
 [rails-scopes]: http://guides.rubyonrails.org/active_record_querying.html#scopes
 


### PR DESCRIPTION
**Description**
This adds link references for some articles related to the adjustment documentation overview.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
