### PR TITLE
Do not allow successful checkout when order has only a void payment

### DIFF
--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -58,7 +58,7 @@ module Spree
     scope :failed, -> { with_state('failed') }
 
     scope :risky, -> { where("avs_response IN (?) OR (cvv_response_code IS NOT NULL and cvv_response_code != 'M') OR state = 'failed'", RISKY_AVS_CODES) }
-    scope :valid, -> { where.not(state: %w(failed invalid)) }
+    scope :valid, -> { where.not(state: %w(failed invalid void)) }
 
     scope :store_credits, -> { where(source_type: Spree::StoreCredit.to_s) }
     scope :not_store_credits, -> { where(arel_table[:source_type].not_eq(Spree::StoreCredit.to_s).or(arel_table[:source_type].eq(nil))) }

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -1255,4 +1255,16 @@ RSpec.describe Spree::Payment, type: :model do
       end
     end
   end
+
+  describe '::valid scope' do
+    before do
+      create :payment, state: :void
+      create :payment, state: :failed
+      create :payment, state: :invalid
+    end
+
+    it 'does not include void, failed and invalid payments' do
+      expect(described_class.valid).to be_empty
+    end
+  end
 end

--- a/frontend/spec/features/checkout_spec.rb
+++ b/frontend/spec/features/checkout_spec.rb
@@ -211,6 +211,26 @@ describe "Checkout", type: :feature, inaccessible: true do
     end
   end
 
+  context "when order has only a void payment" do
+    let(:order) { Spree::TestingSupport::OrderWalkthrough.up_to(:payment) }
+
+    before do
+      user = create(:user)
+      order.user = user
+      order.recalculate
+
+      allow_any_instance_of(Spree::CheckoutController).to receive_messages(current_order: order)
+      allow_any_instance_of(Spree::CheckoutController).to receive_messages(try_spree_current_user: user)
+    end
+
+    it "does not allow successful order submission" do
+      visit spree.checkout_path
+      order.payments.first.update state: :void
+      click_button 'Place Order'
+      expect(page).to have_current_path spree.checkout_state_path(:payment)
+    end
+  end
+
   # Regression test for https://github.com/spree/spree/issues/2694 and https://github.com/spree/spree/issues/4117
   context "doesn't allow bad credit card numbers" do
     let!(:payment_method) { create(:credit_card_payment_method) }


### PR DESCRIPTION
When a payment has been marked for some reason as `void`, the customer should
not be able to complete the checkout process successfully.

The customer is now redirected to the payment page, where they can add another
payment to the order in order to complete it successfully.

This scope for `Spree::Payment` model:
```ruby
scope :valid, -> { where.not(state: %w(failed invalid)) }
```
now includes also `void`, first because adding it there fixes the issue during the checkout, second because the word `void` means quite the opposite of `valid`.

One spec in the backend is currently failing (`spec/features/admin/orders/payments_spec.rb:65`) so I'd like to understand from the community if its behavior can be changed there or other solutions make more sense. 

The reasoning behind this change is that, when an order with payment gets stale, admins may want to set the payment as `void` for some reason. When the customer resumes the checkout after some days they should not be able to complete it with that voided payment.

- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change (if needed)
