### PR TITLE
Remove unnecessary decimal conversion

### DIFF
--- a/core/app/models/concerns/spree/user_reporting.rb
+++ b/core/app/models/concerns/spree/user_reporting.rb
@@ -10,7 +10,7 @@ module Spree
     end
 
     def order_count
-      BigDecimal(spree_orders.complete.count)
+      spree_orders.complete.count
     end
 
     def average_order_value

--- a/core/spec/models/spree/user_spec.rb
+++ b/core/spec/models/spree/user_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe Spree.user_class, type: :model do
     describe "#order_count" do
       before { load_orders }
       it "returns the count of completed orders for the user" do
-        expect(subject.order_count).to eq BigDecimal(order_count)
+        expect(subject.order_count).to eq order_count
       end
     end
 


### PR DESCRIPTION
**Description**
This removes an unnecessary conversion of the count of completed orders (which is always necessarily an integer!) into a decimal number.

**Checklist:**
- [X] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [X] I have added a detailed description into each commit message
- [X] I have updated Guides and README accordingly to this change (if needed)
- [X] I have added tests to cover this change (if needed)
