### PR TITLE
Count only completed orders

### DIFF
--- a/backend/app/views/spree/admin/users/index.html.erb
+++ b/backend/app/views/spree/admin/users/index.html.erb
@@ -82,7 +82,7 @@
       <tr id="<%= spree_dom_id user %>" data-hook="admin_users_index_rows">
         <td class='user_email'><%=link_to user.email, edit_admin_user_url(user) %></td>
         <td><%= user.spree_roles.map(&:name).to_sentence %></td>
-        <td class="align-center"><%= link_to user.orders.count, spree.orders_admin_user_path(user) %></td>
+        <td class="align-center"><%= link_to user.order_count, spree.orders_admin_user_path(user) %></td>
         <td class="align-center"><%= link_to user.display_lifetime_value, spree.items_admin_user_path(user) %></td>
         <td class="align-center"><%= l user.created_at.to_date %></td>
         <td data-hook="admin_users_index_row_actions" class="actions">


### PR DESCRIPTION
**Description**

In the backend `User#index` action, we use the [`display_lifetime_value`](https://github.com/solidusio/solidus/blob/master/core/app/models/concerns/spree/user_reporting.rb#L8-L10) helper to get the total value of all _completed_ orders. However, we display the count of _all_ orders, including _incomplete_ orders, which is inconsistent.

This commit changes this behavior and uses the existing [`order_count`](https://github.com/solidusio/solidus/blob/master/core/app/models/concerns/spree/user_reporting.rb#L12-L14) helper.

Note that one strange aspect of the current `order_count` helper is that it converts the count to a decimal unnecessarily, which will appear strangely, (e.g., `1.0`) in the backend view. This is fixed in a separate PR by https://github.com/solidusio/solidus/pull/3124.

**Checklist:**
- [X] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [X] I have added a detailed description into each commit message
- [X] I have updated Guides and README accordingly to this change (if needed)
- [X] I have added tests to cover this change (if needed)
