### PR TITLE
Remove code setter/getter from Spree::Promotion

### DIFF
--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -53,14 +53,6 @@ module Spree
       order && !UNACTIVATABLE_ORDER_STATES.include?(order.state)
     end
 
-    def code
-      raise "Attempted to call code on a Spree::Promotion. Promotions are now tied to multiple code records"
-    end
-
-    def code=(_val)
-      raise "Attempted to call code= on a Spree::Promotion. Promotions are now tied to multiple code records"
-    end
-
     def self.with_coupon_code(val)
       joins(:codes).where(
         PromotionCode.arel_table[:value].eq(val.downcase)


### PR DESCRIPTION
**Description**
They have been deprecated long time ago, `code` column has been already removed from the database table with #3028. It's time to say goodbye.

Ref: #3028 

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
