### PR TITLE
Deprecate @payment_sources ivar in checkout controller

### DIFF
--- a/core/lib/spree/deprecation.rb
+++ b/core/lib/spree/deprecation.rb
@@ -4,4 +4,54 @@ require 'active_support/deprecation'
 
 module Spree
   Deprecation = ActiveSupport::Deprecation.new('3.0', 'Solidus')
+
+  # This DeprecatedInstanceVariableProxy transforms instance variable to
+  # deprecated instance variable.
+  #
+  # It differs from ActiveSupport::DeprecatedInstanceVariableProxy since
+  # it allows to define a custom message.
+  #
+  #   class Example
+  #     def initialize(deprecator)
+  #       @request = Spree::DeprecatedInstanceVariableProxy.new(self, :request, :@request, deprecator, "Please, do not use this thing.")
+  #       @_request = :a_request
+  #     end
+  #
+  #     def request
+  #       @_request
+  #     end
+  #
+  #     def old_request
+  #       @request
+  #     end
+  #   end
+  #
+  # When someone execute any method on @request variable this will trigger
+  # +warn+ method on +deprecator_instance+ and will fetch <tt>@_request</tt>
+  # variable via +request+ method and execute the same method on non-proxy
+  # instance variable.
+  #
+  # Default deprecator is <tt>Spree::Deprecation</tt>.
+  class DeprecatedInstanceVariableProxy < ActiveSupport::Deprecation::DeprecationProxy
+    def initialize(instance, method, var = "@#{method}", deprecator = Spree::Deprecation, message = nil)
+      @instance = instance
+      @method = method
+      @var = var
+      @deprecator = deprecator
+      @message = message
+    end
+
+    private
+
+    def target
+      @instance.__send__(@method)
+    end
+
+    def warn(callstack, called, args)
+      message = @message || "#{@var} is deprecated! Call #{@method}.#{called} instead of #{@var}.#{called}."
+      message = [message, "Args: #{args.inspect}"].join(" ")
+
+      @deprecator.warn(message, callstack)
+    end
+  end
 end

--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -219,9 +219,14 @@ module Spree
         @wallet_payment_sources = try_spree_current_user.wallet.wallet_payment_sources
         @default_wallet_payment_source = @wallet_payment_sources.detect(&:default) ||
                                          @wallet_payment_sources.first
-        # TODO: How can we deprecate this instance variable?  We could try
-        # wrapping it in a delegating object that produces deprecation warnings.
-        @payment_sources = try_spree_current_user.wallet.wallet_payment_sources.map(&:payment_source).select { |ps| ps.is_a?(Spree::CreditCard) }
+
+        @payment_sources = Spree::DeprecatedInstanceVariableProxy.new(
+          self,
+          :deprecated_payment_sources,
+          :@payment_sources,
+          Spree::Deprecation,
+          "Please, do not use @payment_sources anymore, use @wallet_payment_sources instead."
+        )
       end
     end
 
@@ -250,6 +255,23 @@ module Spree
           redirect_to spree.checkout_state_path(@order.state)
         end
       end
+    end
+
+    # This method returns payment sources of the current user. It is no more
+    # used into our frontend. We used to assign the content of this method
+    # into an ivar (@payment_sources) into the checkout payment step. This
+    # method is here only to be able to deprecate this ivar and will be removed.
+    #
+    # DO NOT USE THIS METHOD!
+    #
+    # @return [Array<Spree::PaymentSource>] Payment sources connected to
+    #   current user wallet.
+    # @deprecated This method has been added to deprecate @payment_sources
+    #   ivar and will be removed. Use @wallet_payment_sources instead.
+    def deprecated_payment_sources
+      try_spree_current_user.wallet.wallet_payment_sources
+        .map(&:payment_source)
+        .select { |ps| ps.is_a?(Spree::CreditCard) }
     end
   end
 end


### PR DESCRIPTION
**Description**

This method returns payment sources of the current user. It is no more used in our frontend. We used to assign the content of this method into an ivar (@payment_sources) into the checkout payment step. The new `deprecated_payment_sources ` method is here only to be able to deprecate this ivar and will be removed with the ivar itself.

Trying to call this method in a view (for example `@payment_sources.empty?`) will produce this warning:

```text
DEPRECATION WARNING: Please, do not use @payment_sources anymore, use @wallet_payment_sources instead. Args: [] (called from ...) 
```

**Note**

I had to introduce a custom class to deprecate instance variables passing a custom message otherwise we would have a misleading deprecation message:

```
DEPRECATION WARNING: @payment_sources is deprecated! Call deprecated_payment_sources.empty? instead of @payment_sources.empty?. Args: [] (called from ...)
```

 I also opened a PR in Rails to improve this: rails/rails#35442




**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message