### PR TITLE
Refactor address state validation

### DIFF
--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -218,6 +218,12 @@ module Spree
     end
 
     def state_validate
+      Spree::Deprecation.warn \
+        "#{self.class}#state_validate private method has been deprecated" \
+        " and will be removed in Solidus v3." \
+        " Check https://github.com/solidusio/solidus/pull/3129 for more details.",
+        caller
+
       # Skip state validation without country (also required)
       # or when disabled by preference
       return if country.blank? || !Spree::Config[:address_requires_state]
@@ -253,6 +259,12 @@ module Spree
     end
 
     def validate_state_matches_country
+      Spree::Deprecation.warn \
+        "#{self.class}#validate_state_matches_country private method has been deprecated" \
+        " and will be removed in Solidus v3." \
+        " Check https://github.com/solidusio/solidus/pull/3129 for more details.",
+        caller
+
       return unless country
 
       self.state = nil if country.states.empty?

--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -8,6 +8,9 @@ module Spree
   class Address < Spree::Base
     extend ActiveModel::ForbiddenAttributesProtection
 
+    mattr_accessor :state_validator_class
+    self.state_validator_class = Spree::Address::StateValidator
+
     belongs_to :country, class_name: "Spree::Country", optional: true
     belongs_to :state, class_name: "Spree::State", optional: true
 
@@ -16,8 +19,20 @@ module Spree
     validates :phone, presence: true, if: :require_phone?
 
     validate :validate_name
-    validate :state_validate
-    validate :validate_state_matches_country
+
+    validate do
+      if Spree::Config.use_legacy_address_state_validator
+        begin
+          @silence_state_deprecations = true
+          state_validate
+          validate_state_matches_country
+        ensure
+          @silence_state_deprecations = false
+        end
+      else
+        self.class.state_validator_class.new(self).perform
+      end
+    end
 
     alias_attribute :first_name, :firstname
     alias_attribute :last_name, :lastname
@@ -218,11 +233,13 @@ module Spree
     end
 
     def state_validate
-      Spree::Deprecation.warn \
-        "#{self.class}#state_validate private method has been deprecated" \
-        " and will be removed in Solidus v3." \
-        " Check https://github.com/solidusio/solidus/pull/3129 for more details.",
-        caller
+      unless @silence_state_deprecations
+        Spree::Deprecation.warn \
+          "#{self.class}#state_validate private method has been deprecated" \
+          " and will be removed in Solidus v3." \
+          " Check https://github.com/solidusio/solidus/pull/3129 for more details.",
+          caller
+      end
 
       # Skip state validation without country (also required)
       # or when disabled by preference
@@ -259,11 +276,13 @@ module Spree
     end
 
     def validate_state_matches_country
-      Spree::Deprecation.warn \
-        "#{self.class}#validate_state_matches_country private method has been deprecated" \
-        " and will be removed in Solidus v3." \
-        " Check https://github.com/solidusio/solidus/pull/3129 for more details.",
-        caller
+      unless @silence_state_deprecations
+        Spree::Deprecation.warn \
+          "#{self.class}#validate_state_matches_country private method has been deprecated" \
+          " and will be removed in Solidus v3." \
+          " Check https://github.com/solidusio/solidus/pull/3129 for more details.",
+          caller
+      end
 
       return unless country
 

--- a/core/app/models/spree/address/state_validator.rb
+++ b/core/app/models/spree/address/state_validator.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module Spree
+  class Address::StateValidator
+    attr_reader :address
+    delegate :state, :state_name, :country, to: :address
+
+    def initialize(address)
+      @address = address
+    end
+
+    def perform
+      return unless state_required?
+
+      if country.present?
+        normalize_state if state.present?
+        normalize_state_name if state_name.present?
+      end
+
+      validate_not_blank
+      validate_matches_country
+    end
+
+    private
+
+    def normalize_state
+      # discard the 'state' attribute when having a country with no states
+      address.state = nil if country.states.blank?
+    end
+
+    def normalize_state_name
+      # discard the 'state_name' when having a valid 'state' and country combo
+      if state.present? && state.country == country
+        address.state_name = nil
+        return
+      end
+
+      # set the state from the state name if the country contains one with that name
+      states_from_name = country.states.with_name_or_abbr(state_name)
+      if states_from_name.size == 1
+        address.state = states_from_name.first
+        address.state_name = nil
+      end
+    end
+
+    def validate_not_blank
+      if state.blank? && state_name.blank?
+        address.errors.add(:state, :blank)
+      end
+    end
+
+    def validate_matches_country
+      if state.present? && state.country != country
+        address.errors.add(:state, :does_not_match_country)
+      end
+    end
+
+    # Don't require a state if disabled at config level or
+    # the associated country doesn't require states
+    def state_required?
+      Spree::Config.address_requires_state && country_requires_states?
+    end
+
+    def country_requires_states?
+      # default to `true` if country not present
+      return true if country.blank?
+
+      country.states_required
+    end
+  end
+end

--- a/core/lib/generators/solidus/install/templates/config/initializers/spree.rb.tt
+++ b/core/lib/generators/solidus/install/templates/config/initializers/spree.rb.tt
@@ -16,6 +16,9 @@ Spree.config do |config|
   # Use legacy Spree::Order state machine
   config.use_legacy_order_state_machine = false
 
+  # Use the legacy address' state validation logic
+  config.use_legacy_address_state_validator = false
+
   # Uncomment to stop tracking inventory levels in the application
   # config.track_inventory_levels = false
 

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -30,6 +30,10 @@ module Spree
     #   @return [Boolean] should state/state_name be required (default: +true+)
     preference :address_requires_state, :boolean, default: true
 
+    # @!attribute [rw] legacy
+    #   @return [Boolean] use the legacy address' state validation logic (default: +true+)
+    preference :use_legacy_address_state_validator, :boolean, default: true
+
     # @!attribute [rw] admin_interface_logo
     #   @return [String] URL of logo used in admin (default: +'logo/solidus.svg'+)
     preference :admin_interface_logo, :string, default: 'logo/solidus.svg'

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -74,6 +74,16 @@ module Spree
             caller
           )
         end
+
+        if Spree::Config.use_legacy_address_state_validator != false
+          Spree::Deprecation.warn(<<~DEPRECATION.squish, caller)
+            Spree::Config.use_legacy_address_state_validator set to true has been
+            deprecated and will be removed in Solidus 3.0. The Spree::Address state
+            validation has been extracted into a configurable external class.
+            Switch Spree::Config.use_legacy_address_state_validator to true to start
+            using the external validation class.
+          DEPRECATION
+        end
       end
 
       # Load in mailer previews for apps to use in development.

--- a/core/lib/spree/testing_support/dummy_app.rb
+++ b/core/lib/spree/testing_support/dummy_app.rb
@@ -114,6 +114,7 @@ end
 
 Spree.user_class = 'Spree::LegacyUser'
 Spree.config do |config|
+  config.use_legacy_address_state_validator = false
   config.mails_from = "store@example.com"
   config.raise_with_invalid_currency = false
   config.redirect_back_on_unauthorized = true

--- a/core/spec/models/spree/address/state_validator_spec.rb
+++ b/core/spec/models/spree/address/state_validator_spec.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Spree::Address::StateValidator do
+  let(:country) { create :country, states_required: true }
+  let(:state) { create :state, name: 'maryland', abbr: 'md', country: country }
+  let(:address) { build(:address, country: country) }
+
+  subject do
+    -> { described_class.new(address).perform }
+  end
+
+  describe 'state attributes normalization' do
+    context "having a country with no states" do
+      before do
+        address.country = country
+        address.state = state
+        allow(country).to receive(:states).and_return([])
+      end
+
+      it "nullifies the state attr" do
+        address.state = state
+        expect(subject).to change(address, :state).from(state).to(nil)
+      end
+    end
+
+    context "with state_name attr present" do
+      before do
+        address.country = country
+        address.state_name = state_name
+      end
+
+      context "and state attr present" do
+        let(:state_name) { "A State Name" }
+
+        before do
+          address.state = state
+        end
+
+        it "nullifies the state_name if the state attr belongs to the country" do
+          expect(subject).to change(address, :state_name).from(state_name).to(nil)
+          expect(subject).to_not change(address, :state).from(state)
+        end
+
+        context "belonging to a different country" do
+          before do
+            allow(state).to receive(:country).and_return(spy(Spree::Country))
+          end
+
+          it "doesn't nullify the state name" do
+            expect(subject).to_not change(address, :state_name).from(state_name)
+          end
+        end
+      end
+
+      context "with state_name matching an existing country's state" do
+        let(:state_name) { state.name }
+
+        before do
+          address.state = nil
+        end
+
+        it "sets the state having the specified state name" do
+          expect(subject).
+            to change{ [address.state, address.state_name] }.
+            from([nil, state.name]).
+            to([state, nil])
+        end
+      end
+    end
+  end
+
+  context "state is not required" do
+    shared_examples "no state validation" do
+      it "doesn't validate the state presence" do
+        address.state = nil
+        address.state_name = nil
+        subject.call
+
+        expect(address.errors).to be_empty
+      end
+    end
+
+    context "address_requires_state preference is false" do
+      before do
+        stub_spree_preferences(address_requires_state: false)
+      end
+
+      include_examples "no state validation"
+    end
+
+    context "country does not require state" do
+      before do
+        country.states_required = false
+      end
+
+      include_examples "no state validation"
+    end
+  end
+
+  context 'address requires state' do
+    before do
+      stub_spree_preferences(address_requires_state: true)
+    end
+
+    it "state_name is not nil and country does not have any states" do
+      address.state = nil
+      address.state_name = 'alabama'
+      subject.call
+      expect(address.errors).to be_empty
+    end
+
+    it "errors when state_name is nil" do
+      address.state_name = nil
+      address.state = nil
+      subject.call
+      expect(address.errors.messages).to eq({ state: ["can't be blank"] })
+    end
+
+    context "state country doesn't match the address' country" do
+      context "with address country having states" do
+        let(:italy) { create(:country, iso: 'IT', states_required: true) }
+        let!(:it_state) { create(:state, country: italy) }
+        let(:us_state) { create(:state, country_iso: 'US') }
+
+        it 'is invalid' do
+          address.country = italy
+          address.state = us_state
+          subject.call
+          expect(address.errors["state"]).to eq(['does not match the country'])
+        end
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/credit_card_spec.rb
+++ b/core/spec/models/spree/credit_card_spec.rb
@@ -90,12 +90,15 @@ RSpec.describe Spree::CreditCard, type: :model do
     end
 
     let!(:persisted_card) { Spree::CreditCard.find(credit_card.id) }
+    let(:country) { create(:country, states_required: true) }
+    let(:state) { create(:state, country: country) }
     let(:valid_address_attributes) do
       {
         name: "Hugo Furst",
         address1: "123 Main",
         city: "Somewhere",
-        country_id: 1,
+        country_id: country.id,
+        state_id: state.id,
         zipcode: 55_555,
         phone: "1234567890"
       }


### PR DESCRIPTION
**Description**

Deprecates and refactors state validation by extracting out the normalization and validation logic into a separate service-like object, which might be also user-provided, for example:
```
Spree::Address.state_validator_class = UserProvided::Address::StateValidator
```

The following private methods have been deprecated from `Spree::Address` model:
- `state_validate`
- `validate_state_matches_country`

This PR introduces the following configuration flag `Spree::Config.use_legacy_address_state_validator` that enables to switch from the old state validation behavior to the new in a smooth way.
For newly generated applications, this flag is set to `false`, which means it will use the new state validator class.
For existing applications upgrading to Solidus v2.11 it is set to `true`, hence keeping the same behavior as in the previous Solidus versions.

**Checklist:**
- [ ] Write a recap in this PR description with the normalization and validation rules
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
