### PR TITLE
Allow orders with different shipping categories

### DIFF
--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -41,7 +41,7 @@ module Spree
 
     scope :available_to_store, ->(store) do
       raise ArgumentError, "You must provide a store" if store.nil?
-      store.shipping_methods.empty? ? all : where(id: store.shipping_method_ids)
+      store.shipping_methods.empty? ? all : where(id: store.shipping_methods.ids)
     end
 
     # @param shipping_category_ids [Array<Integer>] ids of desired shipping categories

--- a/core/spec/models/spree/shipping_method_spec.rb
+++ b/core/spec/models/spree/shipping_method_spec.rb
@@ -257,4 +257,36 @@ RSpec.describe Spree::ShippingMethod, type: :model do
       it { should == 'back_end' }
     end
   end
+
+  describe '.available_to_store' do
+    let(:store) { create(:store) }
+    let(:first_shipping_method) { create(:shipping_method, stores: [store]) }
+    let(:second_shipping_method) { create(:shipping_method, stores: [store]) }
+
+    subject { [first_shipping_method, second_shipping_method] }
+
+    it 'raises an exception if no store is passed as argument' do
+      expect {
+        described_class.available_to_store(nil)
+      }.to raise_exception(ArgumentError, 'You must provide a store')
+    end
+
+    context 'when the store has no shipping methods associated' do
+      before { store.shipping_methods = [] }
+
+      it 'returns all shipping methods' do
+        expect(store.shipping_methods).to eq([])
+        expect(described_class.available_to_store(store)).to eq(subject)
+      end
+    end
+
+    context 'when the store has shipping methods associated' do
+      before { create(:shipping_method) }
+
+      it 'returns the associated records' do
+        expect(store.shipping_methods).to eq(subject)
+        expect(described_class.available_to_store(store)).to eq(subject)
+      end
+    end
+  end
 end


### PR DESCRIPTION
**Description**

This PR allows users to submit orders with items that belong to different shipping categories.

This issue is present from Solidus v2.6 through v2.8, as well as in `master`

Once merged:
- Closes #2998 
- Closes #3315

See also:
  * solidusio/solidus_multi_domain#99
  * solidusio/solidus_multi_domain#105

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
