### PR TITLE
Align some deprecation messages in Order model

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -579,7 +579,6 @@ module Spree
 
     # @deprecated This now happens during #recalculate
     def set_shipments_cost
-      shipments.each(&:update_amounts)
       recalculate
     end
     deprecate set_shipments_cost: :recalculate, deprecator: Spree::Deprecation

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -368,7 +368,7 @@ module Spree
     # include taxes then price adjustments are created instead.
     # @deprecated This now happens during #recalculate
     def create_tax_charge!
-      Spree::Config.tax_adjuster_class.new(self).adjust!
+      recalculate
     end
     deprecate create_tax_charge!: :recalculate, deprecator: Spree::Deprecation
 

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -366,11 +366,11 @@ module Spree
 
     # Creates new tax charges if there are any applicable rates. If prices already
     # include taxes then price adjustments are created instead.
-    # @deprecated This now happens during #update!
+    # @deprecated This now happens during #recalculate
     def create_tax_charge!
       Spree::Config.tax_adjuster_class.new(self).adjust!
     end
-    deprecate create_tax_charge!: :update!, deprecator: Spree::Deprecation
+    deprecate create_tax_charge!: :recalculate, deprecator: Spree::Deprecation
 
     def reimbursement_total
       reimbursements.sum(:total)
@@ -577,11 +577,12 @@ module Spree
       bill_address == ship_address
     end
 
+    # @deprecated This now happens during #recalculate
     def set_shipments_cost
       shipments.each(&:update_amounts)
       recalculate
     end
-    deprecate set_shipments_cost: :update!, deprecator: Spree::Deprecation
+    deprecate set_shipments_cost: :recalculate, deprecator: Spree::Deprecation
 
     def is_risky?
       payments.risky.count > 0

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -181,7 +181,6 @@ RSpec.describe Spree::Order, type: :model do
     before { allow(order).to receive_messages shipments: [shipment] }
 
     it "update and persist totals" do
-      expect(shipment).to receive :update_amounts
       expect(order.updater).to receive :update
 
       Spree::Deprecation.silence do


### PR DESCRIPTION
**Description**

After update! => recalculate rename.

ref:
- https://github.com/solidusio/solidus/pull/1689
- https://github.com/solidusio/solidus/pull/2072

~~❓should `create_tax_charge!` implementation be replaced with a call to `recalculate` too?~~

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)