### PR TITLE
Add coverage report badge using Codecov

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   browser-tools: circleci/browser-tools@1.3
+  codecov: codecov/codecov@3.2.3
 
 executors:
   base:
@@ -89,6 +90,30 @@ commands:
       - store_test_results:
           path: /tmp/test-results
 
+  test_with_coverage:
+    # This command creates a dir to hold coverage data, run test suites with coverage enabled and
+    # generate the coverage report.
+    description: Run Tests With Coverage Enabled
+    steps:
+      - run:
+          name: Setup Coverage Env Vars
+          command: |
+              echo 'export COVERAGE_FILE=$COVERAGE_DIR/coverage.xml' >> $BASH_ENV
+              source $BASH_ENV
+      - run:
+          name: Verify Coverage Env Vars
+          command: |
+              echo $COVERAGE
+              echo $COVERAGE_DIR
+              echo $COVERAGE_FILE
+      - run:
+          name: Setup Coverage Directory
+          command: mkdir -p $COVERAGE_DIR
+      - test
+      - run:
+          name: Report Coverage
+          command: bundle exec rake solidus:coverage[cobertura]
+
   # TODO: Integrate with `setup` when we deprecate support
   # for Rails 6.1 (vips is the default from Rails 7)
   libvips:
@@ -117,10 +142,13 @@ jobs:
   postgres:
     executor: postgres
     parallelism: &parallelism 3
+    environment:
+      COVERAGE: 'true'
+      COVERAGE_DIR: /tmp/coverage
     steps:
       - setup
       - libvips
-      - test
+      - test_with_coverage
 
   legacy_events:
     executor: postgres
@@ -184,7 +212,10 @@ workflows:
           filters:
             branches:
               only: /master|v\d\.\d+/
-      - postgres
+      - postgres:
+          post-steps:
+            - codecov/upload:
+                file: $COVERAGE_FILE
       - mysql
       - sqlite
       - postgres_rails61

--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'database_cleaner', '~> 1.3', require: false
 gem 'rspec-activemodel-mocks', '~> 1.1', require: false
 gem 'rspec-rails', '~> 4.0.1', require: false
 gem 'simplecov', require: false
+gem 'simplecov-cobertura', require: false
 gem 'rails-controller-testing', require: false
 gem 'puma', require: false
 gem 'i18n-tasks', '~> 0.9', require: false

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 # Solidus
 
 [![Circle CI](https://circleci.com/gh/solidusio/solidus/tree/master.svg?style=shield)](https://circleci.com/gh/solidusio/solidus/tree/master)
+[![codecov](https://codecov.io/gh/solidusio/solidus/branch/master/graph/badge.svg)](https://codecov.io/gh/solidusio/solidus/branch/master)
 [![Gem](https://img.shields.io/gem/v/solidus.svg)](https://rubygems.org/gems/solidus)
 [![License](http://img.shields.io/badge/license-BSD-yellowgreen.svg)](LICENSE.md)
 [![Reviewed by Hound](https://img.shields.io/badge/Reviewed_by-Hound-8E64B0.svg)](https://houndci.com)

--- a/Rakefile
+++ b/Rakefile
@@ -102,3 +102,19 @@ namespace :gem do
     end
   end
 end
+
+namespace :solidus do
+  desc "Report code coverage results for all solidus gems"
+  task :coverage, [:formatter] do |task, args|
+    require "simplecov"
+    SimpleCov.merge_timeout 3600
+    if ENV["COVERAGE_DIR"]
+      SimpleCov.coverage_dir(ENV["COVERAGE_DIR"])
+    end
+    if args[:formatter] == "cobertura"
+      require "simplecov-cobertura"
+      SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter
+    end
+    SimpleCov.result.format!
+  end
+end

--- a/api/spec/spec_helper.rb
+++ b/api/spec/spec_helper.rb
@@ -2,6 +2,11 @@
 
 if ENV["COVERAGE"]
   require 'simplecov'
+  if ENV["COVERAGE_DIR"]
+    SimpleCov.coverage_dir(ENV["COVERAGE_DIR"])
+  end
+  SimpleCov.command_name('solidus:api')
+  SimpleCov.merge_timeout(3600)
   SimpleCov.start('rails')
 end
 

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -2,6 +2,11 @@
 
 if ENV["COVERAGE"]
   require 'simplecov'
+  if ENV["COVERAGE_DIR"]
+    SimpleCov.coverage_dir(ENV["COVERAGE_DIR"])
+  end
+  SimpleCov.command_name('solidus:backend')
+  SimpleCov.merge_timeout(3600)
   SimpleCov.start('rails')
 end
 

--- a/backend/spec/teaspoon_env.rb
+++ b/backend/spec/teaspoon_env.rb
@@ -1,5 +1,15 @@
 # frozen_string_literal: true
 
+if ENV["COVERAGE"]
+  require 'simplecov'
+  if ENV["COVERAGE_DIR"]
+    SimpleCov.coverage_dir(ENV["COVERAGE_DIR"])
+  end
+  SimpleCov.command_name('solidus:backend:teaspoon')
+  SimpleCov.merge_timeout(3600)
+  SimpleCov.start('rails') unless SimpleCov.running
+end
+
 ENV['RAILS_ENV'] = 'test'
 
 require 'teaspoon/driver/selenium'

--- a/bin/build
+++ b/bin/build
@@ -5,6 +5,14 @@ set -e
 # Target postgresql. Override with: `env DB=sqlite bin/build`
 export DB=${DB:-postgresql}
 
+if [ -n "$COVERAGE" ]; then
+  # Coverage report directory. Override with: `env COVERAGE_DIR=/tmp/coverage`
+  export COVERAGE_DIR=$(realpath ${COVERAGE_DIR:-$(dirname ${BASH_SOURCE[0]})/../coverage})
+
+  # Make sure coverage report directory exists
+  mkdir -p $COVERAGE_DIR
+fi
+
 bin/setup
 
 echo "***********************"
@@ -27,3 +35,11 @@ echo "**************************"
 echo "* Testing Solidus Sample *"
 echo "**************************"
 bin/rspec sample/spec
+
+if [ -n "$COVERAGE" ]; then
+  # Generate coverage report
+  echo "******************************"
+  echo "* Generating Coverage Report *"
+  echo "******************************"
+  bundle exec rake solidus:coverage
+fi

--- a/core/spec/spec_helper.rb
+++ b/core/spec/spec_helper.rb
@@ -2,6 +2,11 @@
 
 if ENV["COVERAGE"]
   require 'simplecov'
+  if ENV["COVERAGE_DIR"]
+    SimpleCov.coverage_dir(ENV["COVERAGE_DIR"])
+  end
+  SimpleCov.command_name('solidus:core')
+  SimpleCov.merge_timeout(3600)
   SimpleCov.start('rails')
 end
 


### PR DESCRIPTION
**Description**

Add code coverage report to whole project (not only for each sub-project) and code coverage badge to `README.md`.

**Question**

- Code coverage badge relies on https://codecov.io/. Is using https://codecov.io/ OK for solidus? If so, it would be great if someone could provide a `CODECOV_TOKEN` to be added in this PR.

Fixes #3048

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
