### PR TITLE
Don't allow deletion for users with orders

### DIFF
--- a/backend/app/views/spree/admin/users/index.html.erb
+++ b/backend/app/views/spree/admin/users/index.html.erb
@@ -89,7 +89,7 @@
           <% if can?(:edit, user) %>
             <%= link_to_edit user, no_text: true %>
           <% end %>
-          <% if can?(:destroy, user) %>
+          <% if can?(:destroy, user) && user.orders.count.zero? %>
             <%= link_to_delete user, no_text: true %>
           <% end %>
         </td>

--- a/backend/spec/features/admin/users_spec.rb
+++ b/backend/spec/features/admin/users_spec.rb
@@ -289,6 +289,24 @@ describe 'Users', type: :feature do
     end
   end
 
+  context 'deleting users' do
+    let!(:an_user) { create(:user_with_addresses, email: 'an_user@example.com') }
+    let!(:order) { create(:completed_order_with_totals, user_id: an_user.id) }
+
+    context 'if an user has placed orders' do
+      before do
+        visit spree.admin_path
+        click_link 'Users'
+      end
+
+      it "can't be deleted" do
+        within "#spree_user_#{an_user.id}" do
+          expect(page).not_to have_selector('.fa-trash')
+        end
+      end
+    end
+  end
+
   context 'order history with sorting' do
     before do
       orders


### PR DESCRIPTION
**Description**

This PR hides the `delete` button for users that have **at least** one order associated to their profiles, which aims to serve as a starting point to solve #3126.

Ref: #3138

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
