### PR TITLE
Fix order deprecation messages

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -366,11 +366,11 @@ module Spree
 
     # Creates new tax charges if there are any applicable rates. If prices already
     # include taxes then price adjustments are created instead.
-    # @deprecated This now happens during #update!
+    # @deprecated This now happens during #recalculate
     def create_tax_charge!
       Spree::Config.tax_adjuster_class.new(self).adjust!
     end
-    deprecate create_tax_charge!: :update!, deprecator: Spree::Deprecation
+    deprecate create_tax_charge!: :recalculate, deprecator: Spree::Deprecation
 
     def reimbursement_total
       reimbursements.sum(:total)
@@ -582,11 +582,12 @@ module Spree
       bill_address == ship_address
     end
 
+    # @deprecated This now happens during #recalculate
     def set_shipments_cost
       shipments.each(&:update_amounts)
       recalculate
     end
-    deprecate set_shipments_cost: :update!, deprecator: Spree::Deprecation
+    deprecate set_shipments_cost: :recalculate, deprecator: Spree::Deprecation
 
     def is_risky?
       payments.risky.count > 0


### PR DESCRIPTION
**Description**
<!--
  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

  If needed you can reference another PR or issue here, e.g.:
  Ref #ISSUE
-->
Fix deprecation warnings as both `#set_shipments_cost` and `#create_tax_charge`
are now handled by a single call to `#recalculate` and not by `#update!`.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message