### PR TITLE
[DOCUMENTATION] Update TaxLocation Namespace

### DIFF
--- a/guides/source/developers/taxation/overview.html.md
+++ b/guides/source/developers/taxation/overview.html.md
@@ -76,7 +76,7 @@ Spree::Config[:tax_using_ship_address] = true
 ### Use `Spree::TaxLocation` as the tax address
 
 An order's `tax_address` can – through [duck typing][duck-typing] – be a
-`Spree::TaxLocation` instead of the shipping address. The tax location is
+`Spree::Tax::TaxLocation` instead of the shipping address. The tax location is
 computed from the store's `Spree.config.cart_tax_country_iso` setting.
 
 Note that you can only trust the tax address if it has a country. The other


### PR DESCRIPTION
The TaxLocation namespace is wrong. This updates the documentation
to the correct reference.

https://github.com/solidusio/solidus/blob/f27114010a0725c57580ac0b03d701de8812597e/core/app/models/spree/tax/tax_location.rb

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
