### PR TITLE
Add missing I18n namespace

### DIFF
--- a/core/app/views/spree/order_mailer/inventory_cancellation_email.text.erb
+++ b/core/app/views/spree/order_mailer/inventory_cancellation_email.text.erb
@@ -1,9 +1,9 @@
-<%= t('order_mailer.inventory_cancellation.dear_customer') %>
+<%= t('spree.order_mailer.inventory_cancellation.dear_customer') %>
 
-<%= t('order_mailer.inventory_cancellation.instructions') %>
+<%= t('spree.order_mailer.inventory_cancellation.instructions') %>
 
 ============================================================
-<%= t('order_mailer.inventory_cancellation.order_summary_canceled') %>
+<%= t('spree.order_mailer.inventory_cancellation.order_summary_canceled') %>
 ============================================================
 <% @inventory_units.each do |item| %>
   <%= item.variant.sku %> <%= raw(item.variant.product.name) %> <%= raw(item.variant.options_text) -%>


### PR DESCRIPTION
**Description**

This PR adds the missing `spree` I18n namespace to a view under `core/`

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
