### PR TITLE
Don't run validations in Order#record_ip_address

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -765,7 +765,7 @@ module Spree
 
     def record_ip_address(ip_address)
       if last_ip_address != ip_address
-        update_attributes!(last_ip_address: ip_address)
+        update_column(:last_ip_address, ip_address)
       end
     end
 

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -1470,6 +1470,25 @@ RSpec.describe Spree::Order, type: :model do
       end
     end
 
+    describe "#record_ip_address" do
+      let(:ip_address) { "127.0.0.1" }
+
+      subject { -> { order.record_ip_address(ip_address) } }
+
+      it "updates the last used IP address" do
+        expect(subject).to change(order, :last_ip_address).to(ip_address)
+      end
+
+      # IP address tracking should not raise validation exceptions
+      context "with an invalid order" do
+        before { allow(order).to receive(:valid?).and_return(false) }
+
+        it "updates the IP address" do
+          expect(subject).to change(order, :last_ip_address).to(ip_address)
+        end
+      end
+    end
+
     describe "#display_order_total_after_store_credit" do
       let(:order_total_after_store_credit) { 10.00 }
 


### PR DESCRIPTION
When updating the user's latest IP address for an Order, don't run order validations and callbacks.
The IP address tracking should not interfere with/block the request in case validation check is not met.

Related issue: #3075 

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change (if needed)
