### PR TITLE
Ensure return from CSS function

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/globals/_functions.scss
+++ b/backend/app/assets/stylesheets/spree/backend/globals/_functions.scss
@@ -1,5 +1,5 @@
 // Make color very close to white
-@function very-light($color, $adjust: 3){  
+@function very-light($color, $adjust: 3){
   @if type-of($adjust) == 'number' and $adjust > 0 {
     @for $i from 0 through 100 {
       @if lighten($color, $i) == white and ($i - $adjust) > $adjust {
@@ -10,6 +10,7 @@
   @else {
     @debug "Please correct $adjust value. It should be number and larger then 0. Currently it is '#{type-of($adjust)}' with value '#{$adjust}'"
   }
+  @return $color;
 };
 
 // Quick fix for dynamic variables missing in SASS


### PR DESCRIPTION
**Description**
When compiling SCSS, the newly included `sassc` compiler seems to be more vigilant about logic checks. In particular, it returns an error if a CSS function ends without a `@return` statement. The `very-light` function has the possibility of doing that, which causes such an error when we test our solidus app against v2.8.2.

I am not sure if it's possible to write tests for css functions, and I do not see any existing tests that appear to target them so I assume that's not a requirement right now.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
