### PR TITLE
Fix typo in "Addresses" developers guide

### DIFF
--- a/guides/source/developers/users/addresses.html.md
+++ b/guides/source/developers/users/addresses.html.md
@@ -25,7 +25,7 @@ Spree::User.find(1).addresses
 - `phone` and `alternative_phone`: The customer's phone number(s).
 - `state_name`: If the customer uses a region name that doesn't correspond with
   a country's list of states, the address can store the user-entered
-- `state_name` as a fallback. 
+  `state_name` as a fallback.
 - `alternative_phone`: The alternative phone number.
 - `company`: A company name.
 - `state_id` and `country_id`: IDs for the `Spree::State` and `Spree::Country`


### PR DESCRIPTION
Fixes a typo in "Addresses" developers guide: the last part of the `state_name` attribute description was on a new list item.

**Checklist:**
- [ ] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [ ] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
