### PR TITLE
Remove cancancan customizations

### DIFF
--- a/api/app/controllers/spree/api/addresses_controller.rb
+++ b/api/app/controllers/spree/api/addresses_controller.rb
@@ -6,7 +6,7 @@ module Spree
       before_action :find_order
 
       def show
-        authorize! :read, @order, order_token
+        authorize! :show, @order, order_token
         find_address
         respond_with(@address)
       end

--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -133,13 +133,13 @@ module Spree
 
       def product_scope
         if can?(:admin, Spree::Product)
-          scope = Spree::Product.with_deleted.accessible_by(current_ability, :read).includes(*product_includes)
+          scope = Spree::Product.with_deleted.accessible_by(current_ability).includes(*product_includes)
 
           unless params[:show_deleted]
             scope = scope.not_deleted
           end
         else
-          scope = Spree::Product.accessible_by(current_ability, :read).available.includes(*product_includes)
+          scope = Spree::Product.accessible_by(current_ability).available.includes(*product_includes)
         end
 
         scope
@@ -159,7 +159,7 @@ module Spree
 
       def authorize_for_order
         @order = Spree::Order.find_by(number: order_id)
-        authorize! :read, @order, order_token
+        authorize! :show, @order, order_token
       end
 
       def lock_order

--- a/api/app/controllers/spree/api/countries_controller.rb
+++ b/api/app/controllers/spree/api/countries_controller.rb
@@ -7,7 +7,7 @@ module Spree
 
       def index
         @countries = Spree::Country.
-          accessible_by(current_ability, :read).
+          accessible_by(current_ability).
           ransack(params[:q]).
           result.
           order('name ASC')
@@ -21,7 +21,7 @@ module Spree
       end
 
       def show
-        @country = Spree::Country.accessible_by(current_ability, :read).find(params[:id])
+        @country = Spree::Country.accessible_by(current_ability).find(params[:id])
         respond_with(@country)
       end
     end

--- a/api/app/controllers/spree/api/credit_cards_controller.rb
+++ b/api/app/controllers/spree/api/credit_cards_controller.rb
@@ -9,7 +9,7 @@ module Spree
       def index
         @credit_cards = user
           .credit_cards
-          .accessible_by(current_ability, :read)
+          .accessible_by(current_ability)
           .with_payment_profile
           .ransack(params[:q]).result
 
@@ -29,7 +29,7 @@ module Spree
 
       def user
         if params[:user_id].present?
-          @user ||= Spree.user_class.accessible_by(current_ability, :read).find(params[:user_id])
+          @user ||= Spree.user_class.accessible_by(current_ability).find(params[:user_id])
         end
       end
 

--- a/api/app/controllers/spree/api/images_controller.rb
+++ b/api/app/controllers/spree/api/images_controller.rb
@@ -4,12 +4,12 @@ module Spree
   module Api
     class ImagesController < Spree::Api::BaseController
       def index
-        @images = scope.images.accessible_by(current_ability, :read)
+        @images = scope.images.accessible_by(current_ability)
         respond_with(@images)
       end
 
       def show
-        @image = Spree::Image.accessible_by(current_ability, :read).find(params[:id])
+        @image = Spree::Image.accessible_by(current_ability).find(params[:id])
         respond_with(@image)
       end
 

--- a/api/app/controllers/spree/api/inventory_units_controller.rb
+++ b/api/app/controllers/spree/api/inventory_units_controller.rb
@@ -26,7 +26,7 @@ module Spree
       private
 
       def inventory_unit
-        @inventory_unit ||= Spree::InventoryUnit.accessible_by(current_ability, :read).find(params[:id])
+        @inventory_unit ||= Spree::InventoryUnit.accessible_by(current_ability).find(params[:id])
       end
 
       def prepare_event

--- a/api/app/controllers/spree/api/option_types_controller.rb
+++ b/api/app/controllers/spree/api/option_types_controller.rb
@@ -5,15 +5,15 @@ module Spree
     class OptionTypesController < Spree::Api::BaseController
       def index
         if params[:ids]
-          @option_types = Spree::OptionType.includes(:option_values).accessible_by(current_ability, :read).where(id: params[:ids].split(','))
+          @option_types = Spree::OptionType.includes(:option_values).accessible_by(current_ability).where(id: params[:ids].split(','))
         else
-          @option_types = Spree::OptionType.includes(:option_values).accessible_by(current_ability, :read).load.ransack(params[:q]).result
+          @option_types = Spree::OptionType.includes(:option_values).accessible_by(current_ability).load.ransack(params[:q]).result
         end
         respond_with(@option_types)
       end
 
       def show
-        @option_type = Spree::OptionType.accessible_by(current_ability, :read).find(params[:id])
+        @option_type = Spree::OptionType.accessible_by(current_ability).find(params[:id])
         respond_with(@option_type)
       end
 

--- a/api/app/controllers/spree/api/option_values_controller.rb
+++ b/api/app/controllers/spree/api/option_values_controller.rb
@@ -46,9 +46,9 @@ module Spree
 
       def scope
         if params[:option_type_id]
-          @scope ||= Spree::OptionType.find(params[:option_type_id]).option_values.accessible_by(current_ability, :read)
+          @scope ||= Spree::OptionType.find(params[:option_type_id]).option_values.accessible_by(current_ability)
         else
-          @scope ||= Spree::OptionValue.accessible_by(current_ability, :read).load
+          @scope ||= Spree::OptionValue.accessible_by(current_ability).load
         end
       end
 

--- a/api/app/controllers/spree/api/orders_controller.rb
+++ b/api/app/controllers/spree/api/orders_controller.rb
@@ -50,7 +50,7 @@ module Spree
       end
 
       def index
-        authorize! :index, Order
+        authorize! :admin, Order
         orders_includes = [
           :user,
           :payments,

--- a/api/app/controllers/spree/api/payments_controller.rb
+++ b/api/app/controllers/spree/api/payments_controller.rb
@@ -62,7 +62,7 @@ module Spree
 
       def find_order
         @order = Spree::Order.find_by(number: order_id)
-        authorize! :read, @order, order_token
+        authorize! :show, @order, order_token
       end
 
       def find_payment

--- a/api/app/controllers/spree/api/product_properties_controller.rb
+++ b/api/app/controllers/spree/api/product_properties_controller.rb
@@ -9,7 +9,7 @@ module Spree
       def index
         @product_properties = @product.
           product_properties.
-          accessible_by(current_ability, :read).
+          accessible_by(current_ability).
           ransack(params[:q]).
           result
 
@@ -59,14 +59,14 @@ module Spree
 
       def find_product
         @product = super(params[:product_id])
-        authorize! :read, @product
+        authorize! :show, @product
       end
 
       def product_property
         if @product
           @product_property ||= @product.product_properties.find_by(id: params[:id])
           @product_property ||= @product.product_properties.includes(:property).where(spree_properties: { name: params[:id] }).first
-          authorize! :read, @product_property
+          authorize! :show, @product_property
         end
       end
 

--- a/api/app/controllers/spree/api/properties_controller.rb
+++ b/api/app/controllers/spree/api/properties_controller.rb
@@ -6,7 +6,7 @@ module Spree
       before_action :find_property, only: [:show, :update, :destroy]
 
       def index
-        @properties = Spree::Property.accessible_by(current_ability, :read)
+        @properties = Spree::Property.accessible_by(current_ability)
 
         if params[:ids]
           ids = params[:ids].split(",").flatten
@@ -59,9 +59,9 @@ module Spree
       private
 
       def find_property
-        @property = Spree::Property.accessible_by(current_ability, :read).find(params[:id])
+        @property = Spree::Property.accessible_by(current_ability).find(params[:id])
       rescue ActiveRecord::RecordNotFound
-        @property = Spree::Property.accessible_by(current_ability, :read).find_by!(name: params[:id])
+        @property = Spree::Property.accessible_by(current_ability).find_by!(name: params[:id])
       end
 
       def property_params

--- a/api/app/controllers/spree/api/resource_controller.rb
+++ b/api/app/controllers/spree/api/resource_controller.rb
@@ -4,7 +4,7 @@ class Spree::Api::ResourceController < Spree::Api::BaseController
   before_action :load_resource, only: [:show, :update, :destroy]
 
   def index
-    collection_scope = model_class.accessible_by(current_ability, :read)
+    collection_scope = model_class.accessible_by(current_ability)
     if params[:ids]
       ids = params[:ids].split(",").flatten
       collection_scope = collection_scope.where(id: ids)
@@ -65,7 +65,7 @@ class Spree::Api::ResourceController < Spree::Api::BaseController
   protected
 
   def load_resource
-    @object = model_class.accessible_by(current_ability, :read).find(params[:id])
+    @object = model_class.accessible_by(current_ability).find(params[:id])
     instance_variable_set("@#{object_name}", @object)
   end
 

--- a/api/app/controllers/spree/api/return_authorizations_controller.rb
+++ b/api/app/controllers/spree/api/return_authorizations_controller.rb
@@ -29,7 +29,7 @@ module Spree
 
         @return_authorizations = @order.
           return_authorizations.
-          accessible_by(current_ability, :read).
+          accessible_by(current_ability).
           ransack(params[:q]).
           result
 
@@ -44,7 +44,7 @@ module Spree
 
       def show
         authorize! :admin, ReturnAuthorization
-        @return_authorization = @order.return_authorizations.accessible_by(current_ability, :read).find(params[:id])
+        @return_authorization = @order.return_authorizations.accessible_by(current_ability).find(params[:id])
         respond_with(@return_authorization)
       end
 
@@ -70,7 +70,7 @@ module Spree
 
       def load_order
         @order ||= Spree::Order.find_by!(number: order_id)
-        authorize! :read, @order
+        authorize! :show, @order
       end
 
       def return_authorization_params

--- a/api/app/controllers/spree/api/shipments_controller.rb
+++ b/api/app/controllers/spree/api/shipments_controller.rb
@@ -134,7 +134,7 @@ module Spree
         # TODO: Can remove conditional here once deprecated #find_order is removed.
         unless @order.present?
           @order = Spree::Order.find_by!(number: params[:shipment][:order_id])
-          authorize! :read, @order
+          authorize! :show, @order
         end
       end
 

--- a/api/app/controllers/spree/api/states_controller.rb
+++ b/api/app/controllers/spree/api/states_controller.rb
@@ -25,10 +25,10 @@ module Spree
 
       def scope
         if params[:country_id]
-          @country = Spree::Country.accessible_by(current_ability, :read).find(params[:country_id])
-          @country.states.accessible_by(current_ability, :read)
+          @country = Spree::Country.accessible_by(current_ability).find(params[:country_id])
+          @country.states.accessible_by(current_ability)
         else
-          Spree::State.accessible_by(current_ability, :read)
+          Spree::State.accessible_by(current_ability)
         end
       end
     end

--- a/api/app/controllers/spree/api/stock_items_controller.rb
+++ b/api/app/controllers/spree/api/stock_items_controller.rb
@@ -63,7 +63,7 @@ module Spree
 
       def scope
         includes = { variant: [{ option_values: :option_type }, :product] }
-        @stock_location.stock_items.accessible_by(current_ability, :read).includes(includes)
+        @stock_location.stock_items.accessible_by(current_ability).includes(includes)
       end
 
       def stock_item_params

--- a/api/app/controllers/spree/api/stock_locations_controller.rb
+++ b/api/app/controllers/spree/api/stock_locations_controller.rb
@@ -4,10 +4,10 @@ module Spree
   module Api
     class StockLocationsController < Spree::Api::BaseController
       def index
-        authorize! :read, StockLocation
+        authorize! :index, StockLocation
 
         @stock_locations = StockLocation.
-          accessible_by(current_ability, :read).
+          accessible_by(current_ability).
           order('name ASC').
           ransack(params[:q]).
           result
@@ -49,7 +49,7 @@ module Spree
       private
 
       def stock_location
-        @stock_location ||= Spree::StockLocation.accessible_by(current_ability, :read).find(params[:id])
+        @stock_location ||= Spree::StockLocation.accessible_by(current_ability).find(params[:id])
       end
 
       def stock_location_params

--- a/api/app/controllers/spree/api/stock_movements_controller.rb
+++ b/api/app/controllers/spree/api/stock_movements_controller.rb
@@ -6,7 +6,7 @@ module Spree
       before_action :stock_location, except: [:update, :destroy]
 
       def index
-        authorize! :read, StockMovement
+        authorize! :index, StockMovement
         @stock_movements = paginate(scope.ransack(params[:q]).result)
         respond_with(@stock_movements)
       end
@@ -29,11 +29,11 @@ module Spree
       private
 
       def stock_location
-        @stock_location ||= Spree::StockLocation.accessible_by(current_ability, :read).find(params[:stock_location_id])
+        @stock_location ||= Spree::StockLocation.accessible_by(current_ability).find(params[:stock_location_id])
       end
 
       def scope
-        @stock_location.stock_movements.accessible_by(current_ability, :read)
+        @stock_location.stock_movements.accessible_by(current_ability)
       end
 
       def stock_movement_params

--- a/api/app/controllers/spree/api/stores_controller.rb
+++ b/api/app/controllers/spree/api/stores_controller.rb
@@ -6,8 +6,8 @@ module Spree
       before_action :get_store, except: [:index, :create]
 
       def index
-        authorize! :read, Store
-        @stores = Spree::Store.accessible_by(current_ability, :read).all
+        authorize! :index, Store
+        @stores = Spree::Store.accessible_by(current_ability).all
         respond_with(@stores)
       end
 
@@ -32,7 +32,7 @@ module Spree
       end
 
       def show
-        authorize! :read, @store
+        authorize! :show, @store
         respond_with(@store)
       end
 

--- a/api/app/controllers/spree/api/taxonomies_controller.rb
+++ b/api/app/controllers/spree/api/taxonomies_controller.rb
@@ -50,7 +50,7 @@ module Spree
 
       def taxonomies
         @taxonomies = Taxonomy.
-          accessible_by(current_ability, :read).
+          accessible_by(current_ability).
           order('name').
           includes(root: :children).
           ransack(params[:q]).
@@ -58,7 +58,7 @@ module Spree
       end
 
       def taxonomy
-        @taxonomy ||= Spree::Taxonomy.accessible_by(current_ability, :read).find(params[:id])
+        @taxonomy ||= Spree::Taxonomy.accessible_by(current_ability).find(params[:id])
       end
 
       def taxonomy_params

--- a/api/app/controllers/spree/api/taxons_controller.rb
+++ b/api/app/controllers/spree/api/taxons_controller.rb
@@ -7,9 +7,9 @@ module Spree
         if taxonomy
           @taxons = taxonomy.root.children
         elsif params[:ids]
-          @taxons = Spree::Taxon.accessible_by(current_ability, :read).where(id: params[:ids].split(','))
+          @taxons = Spree::Taxon.accessible_by(current_ability).where(id: params[:ids].split(','))
         else
-          @taxons = Spree::Taxon.accessible_by(current_ability, :read).order(:taxonomy_id, :lft).ransack(params[:q]).result
+          @taxons = Spree::Taxon.accessible_by(current_ability).order(:taxonomy_id, :lft).ransack(params[:q]).result
         end
 
         unless params[:without_children]
@@ -96,12 +96,12 @@ module Spree
 
       def taxonomy
         if params[:taxonomy_id].present?
-          @taxonomy ||= Spree::Taxonomy.accessible_by(current_ability, :read).find(params[:taxonomy_id])
+          @taxonomy ||= Spree::Taxonomy.accessible_by(current_ability).find(params[:taxonomy_id])
         end
       end
 
       def taxon
-        @taxon ||= taxonomy.taxons.accessible_by(current_ability, :read).find(params[:id])
+        @taxon ||= taxonomy.taxons.accessible_by(current_ability).find(params[:id])
       end
 
       def taxon_params

--- a/api/app/controllers/spree/api/variants_controller.rb
+++ b/api/app/controllers/spree/api/variants_controller.rb
@@ -53,7 +53,7 @@ module Spree
       private
 
       def product
-        @product ||= Spree::Product.accessible_by(current_ability, :read).friendly.find(params[:product_id]) if params[:product_id]
+        @product ||= Spree::Product.accessible_by(current_ability).friendly.find(params[:product_id]) if params[:product_id]
       end
 
       def scope
@@ -69,7 +69,7 @@ module Spree
 
         in_stock_only = ActiveRecord::Type::Boolean.new.cast(params[:in_stock_only])
         suppliable_only = ActiveRecord::Type::Boolean.new.cast(params[:suppliable_only])
-        variants = variants.accessible_by(current_ability, :read)
+        variants = variants.accessible_by(current_ability)
         if in_stock_only || cannot?(:view_out_of_stock, Spree::Variant)
           variants = variants.in_stock
         elsif suppliable_only

--- a/api/app/controllers/spree/api/zones_controller.rb
+++ b/api/app/controllers/spree/api/zones_controller.rb
@@ -21,7 +21,7 @@ module Spree
 
       def index
         @zones = Spree::Zone.
-          accessible_by(current_ability, :read).
+          accessible_by(current_ability).
           order('name ASC').
           ransack(params[:q]).
           result
@@ -55,7 +55,7 @@ module Spree
       end
 
       def zone
-        @zone ||= Spree::Zone.accessible_by(current_ability, :read).find(params[:id])
+        @zone ||= Spree::Zone.accessible_by(current_ability).find(params[:id])
       end
     end
   end

--- a/backend/app/controllers/spree/admin/customer_returns_controller.rb
+++ b/backend/app/controllers/spree/admin/customer_returns_controller.rb
@@ -32,13 +32,13 @@ module Spree
       end
 
       def find_resource
-        Spree::CustomerReturn.accessible_by(current_ability, :read).find(params[:id])
+        Spree::CustomerReturn.accessible_by(current_ability).find(params[:id])
       end
 
       def collection
         parent # trigger loading the order
         @collection ||= Spree::ReturnItem
-          .accessible_by(current_ability, :read)
+          .accessible_by(current_ability)
           .where(inventory_unit_id: @order.inventory_units.pluck(:id))
           .map(&:customer_return).uniq.compact
         @customer_returns = @collection

--- a/backend/app/controllers/spree/admin/promotion_codes_controller.rb
+++ b/backend/app/controllers/spree/admin/promotion_codes_controller.rb
@@ -6,7 +6,7 @@ module Spree
   module Admin
     class PromotionCodesController < Spree::Admin::ResourceController
       def index
-        @promotion = Spree::Promotion.accessible_by(current_ability, :read).find(params[:promotion_id])
+        @promotion = Spree::Promotion.accessible_by(current_ability).find(params[:promotion_id])
         @promotion_codes = @promotion.promotion_codes.order(:value)
 
         respond_to do |format|
@@ -22,12 +22,12 @@ module Spree
       end
 
       def new
-        @promotion = Spree::Promotion.accessible_by(current_ability, :read).find(params[:promotion_id])
+        @promotion = Spree::Promotion.accessible_by(current_ability).find(params[:promotion_id])
         @promotion_code = @promotion.promotion_codes.build
       end
 
       def create
-        @promotion = Spree::Promotion.accessible_by(current_ability, :read).find(params[:promotion_id])
+        @promotion = Spree::Promotion.accessible_by(current_ability).find(params[:promotion_id])
         @promotion_code = @promotion.promotion_codes.build(value: params[:promotion_code][:value])
 
         if @promotion_code.save

--- a/backend/app/controllers/spree/admin/return_authorizations_controller.rb
+++ b/backend/app/controllers/spree/admin/return_authorizations_controller.rb
@@ -47,7 +47,7 @@ module Spree
       end
 
       def load_reimbursement_types
-        @reimbursement_types = Spree::ReimbursementType.accessible_by(current_ability, :read).active
+        @reimbursement_types = Spree::ReimbursementType.accessible_by(current_ability).active
       end
 
       def load_return_reasons

--- a/backend/app/controllers/spree/admin/root_controller.rb
+++ b/backend/app/controllers/spree/admin/root_controller.rb
@@ -12,7 +12,7 @@ module Spree
       private
 
       def admin_root_redirect_path
-        if can?(:display, Spree::Order) && can?(:admin, Spree::Order)
+        if can?(:read, Spree::Order) && can?(:admin, Spree::Order)
           spree.admin_orders_path
         elsif can?(:admin, :dashboards) && can?(:home, :dashboards)
           spree.home_admin_dashboards_path

--- a/backend/app/controllers/spree/admin/stock_items_controller.rb
+++ b/backend/app/controllers/spree/admin/stock_items_controller.rb
@@ -15,8 +15,8 @@ module Spree
       private
 
       def build_resource
-        variant = Spree::Variant.accessible_by(current_ability, :read).find(params[:variant_id])
-        stock_location = Spree::StockLocation.accessible_by(current_ability, :read).find(params[:stock_location_id])
+        variant = Spree::Variant.accessible_by(current_ability).find(params[:variant_id])
+        stock_location = Spree::StockLocation.accessible_by(current_ability).find(params[:stock_location_id])
         stock_location.stock_movements.build(stock_movement_params).tap do |stock_movement|
           stock_movement.originator = try_spree_current_user
           stock_movement.stock_item = stock_location.set_up_stock_item(variant)
@@ -36,11 +36,11 @@ module Spree
       end
 
       def load_product
-        @product = Spree::Product.accessible_by(current_ability, :read).friendly.find(params[:product_slug]) if params[:product_slug]
+        @product = Spree::Product.accessible_by(current_ability).friendly.find(params[:product_slug]) if params[:product_slug]
       end
 
       def load_stock_management_data
-        @stock_locations = Spree::StockLocation.accessible_by(current_ability, :read)
+        @stock_locations = Spree::StockLocation.accessible_by(current_ability)
         @stock_item_stock_locations = params[:stock_location_id].present? ? @stock_locations.where(id: params[:stock_location_id]) : @stock_locations
         @variant_display_attributes = self.class.variant_display_attributes
         @variants = Spree::Config.variant_search_class.new(params[:variant_search_term], scope: variant_scope).results
@@ -50,7 +50,7 @@ module Spree
       end
 
       def variant_scope
-        scope = Spree::Variant.accessible_by(current_ability, :read)
+        scope = Spree::Variant.accessible_by(current_ability)
         scope = scope.where(product: @product) if @product
         scope
       end

--- a/backend/app/helpers/spree/admin/customer_returns_helper.rb
+++ b/backend/app/helpers/spree/admin/customer_returns_helper.rb
@@ -4,7 +4,7 @@ module Spree
   module Admin
     module CustomerReturnsHelper
       def reimbursement_types
-        @reimbursement_types ||= Spree::ReimbursementType.accessible_by(current_ability, :read).active
+        @reimbursement_types ||= Spree::ReimbursementType.accessible_by(current_ability).active
       end
     end
   end

--- a/backend/app/views/spree/admin/promotions/edit.html.erb
+++ b/backend/app/views/spree/admin/promotions/edit.html.erb
@@ -5,13 +5,13 @@
 
 <% content_for :page_actions do %>
   <li>
-    <% if can?(:display, Spree::PromotionCode) %>
+    <% if can?(:read, Spree::PromotionCode) %>
       <%= link_to t('spree.view_promotion_codes_list'), admin_promotion_promotion_codes_path(promotion_id: @promotion.id), class: 'btn btn-primary' %>
 
       <%= link_to t('spree.download_promotion_codes_list'), admin_promotion_promotion_codes_path(promotion_id: @promotion.id, format: :csv), class: 'btn btn-primary' %>
     <% end %>
 
-    <% if can?(:display, Spree::PromotionCodeBatch) %>
+    <% if can?(:read, Spree::PromotionCodeBatch) %>
       <%= link_to plural_resource_name(Spree::PromotionCodeBatch), admin_promotion_promotion_code_batches_path(promotion_id: @promotion.id), class: 'btn btn-primary' %>
     <% end %>
   </li>

--- a/backend/app/views/spree/admin/shared/_order_submenu.html.erb
+++ b/backend/app/views/spree/admin/shared/_order_submenu.html.erb
@@ -20,13 +20,13 @@
       <%= link_to plural_resource_name(Spree::Shipment), spree.edit_admin_order_url(@order) %>
     </li>
 
-    <% if can? :display, Spree::Adjustment %>
+    <% if can? :read, Spree::Adjustment %>
       <li class="<%= "active" if current == "Adjustments" %>" data-hook='admin_order_tabs_adjustments'>
         <%= link_to plural_resource_name(Spree::Adjustment), spree.admin_order_adjustments_url(@order) %>
       </li>
     <% end %>
 
-    <% if can?(:display, Spree::Payment) %>
+    <% if can?(:read, Spree::Payment) %>
       <li class="<%= "active" if current == "Payments" %>" data-hook='admin_order_tabs_payments'>
         <%= link_to plural_resource_name(Spree::Payment), spree.admin_order_payments_url(@order) %>
       </li>
@@ -38,7 +38,7 @@
       </li>
     <% end %>
 
-    <% if can? :display, Spree::ReturnAuthorization %>
+    <% if can? :read, Spree::ReturnAuthorization %>
       <% if @order.completed? %>
         <li class="tab <%= "active" if current == "Return Authorizations" %>" data-hook='admin_order_tabs_return_authorizations'>
           <%= link_to t('spree.admin.tab.rma'), spree.admin_order_return_authorizations_url(@order) %>
@@ -46,7 +46,7 @@
       <% end %>
     <% end %>
 
-    <% if can? :display, Spree::CustomerReturn %>
+    <% if can? :read, Spree::CustomerReturn %>
       <% if @order.completed? %>
         <li class="<%= "active" if current == "Customer Returns" %>" data-hook='admin_order_tabs_customer_returns'>
           <%= link_to plural_resource_name(Spree::CustomerReturn), spree.admin_order_customer_returns_url(@order) %>

--- a/backend/app/views/spree/admin/shared/_payments_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_payments_tabs.html.erb
@@ -1,7 +1,7 @@
 <% content_for :tabs do %>
   <nav>
     <ul class="tabs" data-hook="admin_settings_payments_tabs">
-      <% if can?(:display, Spree::PaymentMethod) %>
+      <% if can?(:read, Spree::PaymentMethod) %>
         <%= settings_tab_item plural_resource_name(Spree::PaymentMethod), spree.admin_payment_methods_path %>
       <% end %>
     </ul>

--- a/backend/app/views/spree/admin/shared/_settings_checkout_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_settings_checkout_tabs.html.erb
@@ -1,23 +1,23 @@
 <% content_for :tabs do %>
   <nav>
     <ul class="tabs" data-hook="admin_settings_checkout_tabs">
-      <% if can?(:display, Spree::RefundReason) %>
+      <% if can?(:read, Spree::RefundReason) %>
         <%= settings_tab_item plural_resource_name(Spree::RefundReason), spree.admin_refund_reasons_path %>
       <% end %>
 
-      <% if can?(:display, Spree::ReimbursementType) %>
+      <% if can?(:read, Spree::ReimbursementType) %>
         <%= settings_tab_item plural_resource_name(Spree::ReimbursementType), spree.admin_reimbursement_types_path %>
       <% end %>
 
-      <% if can?(:display, Spree::ReturnReason) %>
+      <% if can?(:read, Spree::ReturnReason) %>
         <%= settings_tab_item plural_resource_name(Spree::ReturnReason), spree.admin_return_reasons_path %>
       <% end %>
 
-      <% if can?(:display, Spree::AdjustmentReason) %>
+      <% if can?(:read, Spree::AdjustmentReason) %>
         <%= settings_tab_item plural_resource_name(Spree::AdjustmentReason), spree.admin_adjustment_reasons_path %>
       <% end %>
 
-      <% if can?(:display, Spree::StoreCreditReason) %>
+      <% if can?(:read, Spree::StoreCreditReason) %>
         <%= settings_tab_item plural_resource_name(Spree::StoreCreditReason), spree.admin_store_credit_reasons_path %>
       <% end %>
     </ul>

--- a/backend/app/views/spree/admin/shared/_settings_sub_menu.html.erb
+++ b/backend/app/views/spree/admin/shared/_settings_sub_menu.html.erb
@@ -3,24 +3,24 @@
     <%= tab :stores, label: :stores, url: spree.admin_stores_path %>
   <% end %>
 
-  <% if can?(:display, Spree::PaymentMethod) %>
+  <% if can?(:read, Spree::PaymentMethod) %>
     <%= tab :payments, url: spree.admin_payment_methods_path %>
   <% end %>
 
-  <% if can?(:display, Spree::TaxCategory) || can?(:display, Spree::TaxRate) %>
+  <% if can?(:read, Spree::TaxCategory) || can?(:read, Spree::TaxRate) %>
     <%= tab :taxes, url: spree.admin_tax_categories_path, match_path: %r(tax_categories|tax_rates) %>
   <% end %>
 
-  <% if can?(:display, Spree::RefundReason) || can?(:display, Spree::ReimbursementType) ||
-    can?(:display, Spree::ReturnReason) || can?(:display, Spree::AdjustmentReason) %>
+  <% if can?(:read, Spree::RefundReason) || can?(:read, Spree::ReimbursementType) ||
+    can?(:read, Spree::ReturnReason) || can?(:read, Spree::AdjustmentReason) %>
     <%= tab :checkout, url: spree.admin_refund_reasons_path, match_path: %r(refund_reasons|reimbursement_types|return_reasons|adjustment_reasons) %>
   <% end %>
 
-  <% if can?(:display, Spree::ShippingMethod) || can?(:display, Spree::ShippingCategory) || can?(:display, Spree::StockLocation) %>
+  <% if can?(:read, Spree::ShippingMethod) || can?(:read, Spree::ShippingCategory) || can?(:read, Spree::StockLocation) %>
     <%= tab :shipping, url: spree.admin_shipping_methods_path, match_path: %r(shipping_methods|shipping_categories|stock_locations) %>
   <% end %>
 
-  <% if can?(:display, Spree::Zone) %>
+  <% if can?(:read, Spree::Zone) %>
     <%= tab :zones, url: spree.admin_zones_path %>
   <% end %>
 </ul>

--- a/backend/app/views/spree/admin/shared/_shipping_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_shipping_tabs.html.erb
@@ -1,16 +1,16 @@
 <% content_for :tabs do %>
   <nav>
     <ul class="tabs" data-hook="admin_settings_shipping_tabs">
-      <% if can?(:display, Spree::ShippingMethod) %>
+      <% if can?(:read, Spree::ShippingMethod) %>
         <%= settings_tab_item plural_resource_name(Spree::ShippingMethod), spree.admin_shipping_methods_path %>
       <% end %>
 
-      <% if can?(:display, Spree::ShippingCategory) %>
+      <% if can?(:read, Spree::ShippingCategory) %>
         <%= settings_tab_item plural_resource_name(Spree::ShippingCategory), spree.admin_shipping_categories_path %>
 
       <% end %>
 
-      <% if can?(:display, Spree::StockLocation) %>
+      <% if can?(:read, Spree::StockLocation) %>
         <%= settings_tab_item plural_resource_name(Spree::StockLocation), spree.admin_stock_locations_path %>
       <% end %>
     </ul>

--- a/backend/app/views/spree/admin/shared/_taxes_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_taxes_tabs.html.erb
@@ -1,11 +1,11 @@
 <% content_for :tabs do %>
   <nav>
     <ul class="tabs" data-hook="admin_settings_taxes_tabs">
-      <% if can? :display, Spree::TaxCategory %>
+      <% if can? :read, Spree::TaxCategory %>
         <%= settings_tab_item plural_resource_name(Spree::TaxCategory), spree.admin_tax_categories_path %>
       <% end %>
 
-      <% if can? :display, Spree::TaxRate %>
+      <% if can? :read, Spree::TaxRate %>
         <%= settings_tab_item plural_resource_name(Spree::TaxRate), spree.admin_tax_rates_path %>
       <% end %>
     </ul>

--- a/backend/app/views/spree/admin/stock_locations/edit.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/edit.html.erb
@@ -8,7 +8,7 @@
 
 <% content_for :page_actions do %>
   <ul class="actions inline-menu">
-    <% if can?(:display, Spree::StockMovement) %>
+    <% if can?(:read, Spree::StockMovement) %>
       <li>
         <%= link_to plural_resource_name(Spree::StockMovement), admin_stock_location_stock_movements_path(@stock_location.id), class: 'btn btn-primary'  %>
       </li>

--- a/backend/app/views/spree/admin/stock_locations/index.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/index.html.erb
@@ -51,7 +51,7 @@
             </span>
           </td>
           <td>
-            <% if can?(:display, Spree::StockMovement) %>
+            <% if can?(:read, Spree::StockMovement) %>
               <%= link_to plural_resource_name(Spree::StockMovement), admin_stock_location_stock_movements_path(stock_location.id) %>
             <% else %>
               Stock Movements

--- a/backend/app/views/spree/admin/stock_movements/index.html.erb
+++ b/backend/app/views/spree/admin/stock_movements/index.html.erb
@@ -1,6 +1,6 @@
 <% admin_breadcrumb(t('spree.settings')) %>
 <% admin_breadcrumb(t('spree.admin.tab.shipping')) %>
-<% if can?(:display, Spree::StockLocation) %>
+<% if can?(:read, Spree::StockLocation) %>
   <% admin_breadcrumb(link_to plural_resource_name(Spree::StockLocation), spree.admin_stock_locations_path) %>
 <% else %>
   <% admin_breadcrumb(plural_resource_name(Spree::StockLocation)) %>

--- a/backend/app/views/spree/admin/users/_form.html.erb
+++ b/backend/app/views/spree/admin/users/_form.html.erb
@@ -11,7 +11,7 @@
       <%= error_message_on :user, :email %>
     <% end %>
 
-    <% if can? :display, Spree::Role %>
+    <% if can? :read, Spree::Role %>
       <div data-hook="admin_user_form_roles" class="field">
         <%= label_tag nil, plural_resource_name(Spree::Role) %>
         <ul>
@@ -35,7 +35,7 @@
       </div>
     <% end %>
 
-    <% if Spree::Config[:can_restrict_stock_management] && can?(:display, Spree::StockLocation) %>
+    <% if Spree::Config[:can_restrict_stock_management] && can?(:read, Spree::StockLocation) %>
       <div data-hook="admin_user_form_stock_locations" class="field">
         <%= label_tag nil, plural_resource_name(Spree::StockLocation) %>
         <ul>

--- a/backend/app/views/spree/admin/users/_tabs.html.erb
+++ b/backend/app/views/spree/admin/users/_tabs.html.erb
@@ -19,7 +19,7 @@
           <%= link_to t("spree.admin.user.items"), spree.items_admin_user_path(@user) %>
         </li>
       <% end %>
-      <% if can?(:display, Spree::StoreCredit) %>
+      <% if can?(:read, Spree::StoreCredit) %>
         <li<%== ' class="active"' if current == :store_credits %>>
           <%= link_to t("spree.admin.user.store_credit"), spree.admin_user_store_credits_path(@user) %>
         </li>

--- a/backend/app/views/spree/admin/variants/index.html.erb
+++ b/backend/app/views/spree/admin/variants/index.html.erb
@@ -21,7 +21,7 @@
   <% if !Spree::OptionType.any? %>
     <p class='first_add_option_types no-objects-found' data-hook="first_add_option_types">
       <%= t('spree.to_add_variants_you_must_first_define') %>
-      <% if can?(:display, Spree::OptionType) %>
+      <% if can?(:read, Spree::OptionType) %>
         <%= link_to plural_resource_name(Spree::OptionType), admin_option_types_path%>
       <% else %>
         <%= plural_resource_name(Spree::OptionType) %>

--- a/backend/spec/controllers/spree/admin/root_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/root_controller_spec.rb
@@ -17,7 +17,7 @@ describe Spree::Admin::RootController do
     context "when a user can admin and display spree orders" do
       before do
         ability.can :admin, Spree::Order
-        ability.can :display, Spree::Order
+        ability.can :read, Spree::Order
       end
 
       it { is_expected.to redirect_to(spree.admin_orders_path) }

--- a/core/app/models/spree/ability.rb
+++ b/core/app/models/spree/ability.rb
@@ -29,24 +29,11 @@ module Spree
     def initialize(current_user)
       @user = current_user || Spree.user_class.new
 
-      alias_actions
       activate_permission_sets
       register_extension_abilities
     end
 
     private
-
-    def alias_actions
-      clear_aliased_actions
-
-      # override cancan default aliasing (we don't want to differentiate between read and index)
-      alias_action :delete, to: :destroy
-      alias_action :edit, to: :update
-      alias_action :new, to: :create
-      alias_action :new_action, to: :create
-      alias_action :show, to: :read
-      alias_action :index, :read, to: :display
-    end
 
     # Before, this was the only way to extend this ability. Permission sets have been added since.
     # It is recommended to use them instead for extension purposes if possible.

--- a/core/lib/spree/permission_sets/configuration_display.rb
+++ b/core/lib/spree/permission_sets/configuration_display.rb
@@ -5,20 +5,20 @@ module Spree
     class ConfigurationDisplay < PermissionSets::Base
       def activate!
           can [:edit, :admin], :general_settings
-          can [:display, :admin], Spree::TaxCategory
-          can [:display, :admin], Spree::TaxRate
-          can [:display, :admin], Spree::Zone
-          can [:display, :admin], Spree::Country
-          can [:display, :admin], Spree::State
-          can [:display, :admin], Spree::PaymentMethod
-          can [:display, :admin], Spree::Taxonomy
-          can [:display, :admin], Spree::ShippingMethod
-          can [:display, :admin], Spree::ShippingCategory
-          can [:display, :admin], Spree::StockLocation
-          can [:display, :admin], Spree::StockMovement
-          can [:display, :admin], Spree::RefundReason
-          can [:display, :admin], Spree::ReimbursementType
-          can [:display, :admin], Spree::ReturnReason
+          can [:read, :admin], Spree::TaxCategory
+          can [:read, :admin], Spree::TaxRate
+          can [:read, :admin], Spree::Zone
+          can [:read, :admin], Spree::Country
+          can [:read, :admin], Spree::State
+          can [:read, :admin], Spree::PaymentMethod
+          can [:read, :admin], Spree::Taxonomy
+          can [:read, :admin], Spree::ShippingMethod
+          can [:read, :admin], Spree::ShippingCategory
+          can [:read, :admin], Spree::StockLocation
+          can [:read, :admin], Spree::StockMovement
+          can [:read, :admin], Spree::RefundReason
+          can [:read, :admin], Spree::ReimbursementType
+          can [:read, :admin], Spree::ReturnReason
       end
     end
   end

--- a/core/lib/spree/permission_sets/default_customer.rb
+++ b/core/lib/spree/permission_sets/default_customer.rb
@@ -4,11 +4,11 @@ module Spree
   module PermissionSets
     class DefaultCustomer < PermissionSets::Base
       def activate!
-        can :display, Country
-        can :display, OptionType
-        can :display, OptionValue
+        can :read, Country
+        can :read, OptionType
+        can :read, OptionValue
         can :create, Order
-        can [:read, :update], Order do |order, token|
+        can [:show, :edit, :update], Order do |order, token|
           order.user == user || (order.guest_token.present? && token == order.guest_token)
         end
         cannot :update, Order do |order|
@@ -17,20 +17,20 @@ module Spree
         can :create, ReturnAuthorization do |return_authorization|
           return_authorization.order.user == user
         end
-        can [:display, :update], CreditCard, user_id: user.id
-        can :display, Product
-        can :display, ProductProperty
-        can :display, Property
+        can [:read, :update], CreditCard, user_id: user.id
+        can :read, Product
+        can :read, ProductProperty
+        can :read, Property
         can :create, Spree.user_class
         can [:read, :update, :update_email], Spree.user_class, id: user.id
-        can :display, State
-        can :display, StockItem, stock_location: { active: true }
-        can :display, StockLocation, active: true
-        can :display, Taxon
-        can :display, Taxonomy
+        can :read, State
+        can :read, StockItem, stock_location: { active: true }
+        can :read, StockLocation, active: true
+        can :read, Taxon
+        can :read, Taxonomy
         can [:save_in_address_book, :remove_from_address_book], Spree.user_class, id: user.id
-        can [:display, :view_out_of_stock], Variant
-        can :display, Zone
+        can [:read, :view_out_of_stock], Variant
+        can :read, Zone
       end
     end
   end

--- a/core/lib/spree/permission_sets/order_display.rb
+++ b/core/lib/spree/permission_sets/order_display.rb
@@ -4,17 +4,17 @@ module Spree
   module PermissionSets
     class OrderDisplay < PermissionSets::Base
       def activate!
-        can [:display, :admin, :edit, :cart], Spree::Order
-        can [:display, :admin], Spree::Payment
-        can [:display, :admin], Spree::Shipment
-        can [:display, :admin], Spree::Adjustment
-        can [:display, :admin], Spree::LineItem
-        can [:display, :admin], Spree::ReturnAuthorization
-        can [:display, :admin], Spree::CustomerReturn
-        can [:display, :admin], Spree::OrderCancellations
-        can [:display, :admin], Spree::Reimbursement
-        can [:display, :admin], Spree::ReturnItem
-        can [:display, :admin], Spree::Refund
+        can [:read, :admin, :edit, :cart], Spree::Order
+        can [:read, :admin], Spree::Payment
+        can [:read, :admin], Spree::Shipment
+        can [:read, :admin], Spree::Adjustment
+        can [:read, :admin], Spree::LineItem
+        can [:read, :admin], Spree::ReturnAuthorization
+        can [:read, :admin], Spree::CustomerReturn
+        can [:read, :admin], Spree::OrderCancellations
+        can [:read, :admin], Spree::Reimbursement
+        can [:read, :admin], Spree::ReturnItem
+        can [:read, :admin], Spree::Refund
       end
     end
   end

--- a/core/lib/spree/permission_sets/order_management.rb
+++ b/core/lib/spree/permission_sets/order_management.rb
@@ -4,7 +4,7 @@ module Spree
   module PermissionSets
     class OrderManagement < PermissionSets::Base
       def activate!
-        can :display, Spree::ReimbursementType
+        can :read, Spree::ReimbursementType
         can :manage, Spree::Order
         can :manage, Spree::Payment
         can :manage, Spree::Shipment

--- a/core/lib/spree/permission_sets/product_display.rb
+++ b/core/lib/spree/permission_sets/product_display.rb
@@ -4,15 +4,15 @@ module Spree
   module PermissionSets
     class ProductDisplay < PermissionSets::Base
       def activate!
-        can [:display, :admin, :edit], Spree::Product
-        can [:display, :admin], Spree::Image
-        can [:display, :admin], Spree::Variant
-        can [:display, :admin], Spree::OptionValue
-        can [:display, :admin], Spree::ProductProperty
-        can [:display, :admin], Spree::OptionType
-        can [:display, :admin], Spree::Property
-        can [:display, :admin], Spree::Taxonomy
-        can [:display, :admin], Spree::Taxon
+        can [:read, :admin, :edit], Spree::Product
+        can [:read, :admin], Spree::Image
+        can [:read, :admin], Spree::Variant
+        can [:read, :admin], Spree::OptionValue
+        can [:read, :admin], Spree::ProductProperty
+        can [:read, :admin], Spree::OptionType
+        can [:read, :admin], Spree::Property
+        can [:read, :admin], Spree::Taxonomy
+        can [:read, :admin], Spree::Taxon
       end
     end
   end

--- a/core/lib/spree/permission_sets/promotion_display.rb
+++ b/core/lib/spree/permission_sets/promotion_display.rb
@@ -4,11 +4,11 @@ module Spree
   module PermissionSets
     class PromotionDisplay < PermissionSets::Base
       def activate!
-        can [:display, :admin, :edit], Spree::Promotion
-        can [:display, :admin], Spree::PromotionRule
-        can [:display, :admin], Spree::PromotionAction
-        can [:display, :admin], Spree::PromotionCategory
-        can [:display, :admin], Spree::PromotionCode
+        can [:read, :admin, :edit], Spree::Promotion
+        can [:read, :admin], Spree::PromotionRule
+        can [:read, :admin], Spree::PromotionAction
+        can [:read, :admin], Spree::PromotionCategory
+        can [:read, :admin], Spree::PromotionCode
       end
     end
   end

--- a/core/lib/spree/permission_sets/restricted_stock_display.rb
+++ b/core/lib/spree/permission_sets/restricted_stock_display.rb
@@ -4,8 +4,8 @@ module Spree
   module PermissionSets
     class RestrictedStockDisplay < PermissionSets::Base
       def activate!
-        can [:display, :admin], Spree::StockItem, stock_location_id: location_ids
-        can :display, Spree::StockLocation, id: location_ids
+        can [:read, :admin], Spree::StockItem, stock_location_id: location_ids
+        can :read, Spree::StockLocation, id: location_ids
       end
 
       private

--- a/core/lib/spree/permission_sets/restricted_stock_management.rb
+++ b/core/lib/spree/permission_sets/restricted_stock_management.rb
@@ -5,7 +5,7 @@ module Spree
     class RestrictedStockManagement < PermissionSets::Base
       def activate!
         can :manage, Spree::StockItem, stock_location_id: location_ids
-        can :display, Spree::StockLocation, id: location_ids
+        can :read, Spree::StockLocation, id: location_ids
       end
 
       private

--- a/core/lib/spree/permission_sets/stock_display.rb
+++ b/core/lib/spree/permission_sets/stock_display.rb
@@ -4,8 +4,8 @@ module Spree
   module PermissionSets
     class StockDisplay < PermissionSets::Base
       def activate!
-        can [:display, :admin], Spree::StockItem
-        can :display, Spree::StockLocation
+        can [:read, :admin], Spree::StockItem
+        can :read, Spree::StockLocation
       end
     end
   end

--- a/core/lib/spree/permission_sets/stock_management.rb
+++ b/core/lib/spree/permission_sets/stock_management.rb
@@ -5,7 +5,7 @@ module Spree
     class StockManagement < PermissionSets::Base
       def activate!
         can :manage, Spree::StockItem
-        can :display, Spree::StockLocation
+        can :read, Spree::StockLocation
       end
     end
   end

--- a/core/lib/spree/permission_sets/user_display.rb
+++ b/core/lib/spree/permission_sets/user_display.rb
@@ -4,9 +4,9 @@ module Spree
   module PermissionSets
     class UserDisplay < PermissionSets::Base
       def activate!
-        can [:display, :admin, :edit, :addresses, :orders, :items], Spree.user_class
-        can [:display, :admin], Spree::StoreCredit
-        can :display, Spree::Role
+        can [:read, :admin, :edit, :addresses, :orders, :items], Spree.user_class
+        can [:read, :admin], Spree::StoreCredit
+        can :read, Spree::Role
       end
     end
   end

--- a/core/lib/spree/permission_sets/user_management.rb
+++ b/core/lib/spree/permission_sets/user_management.rb
@@ -4,7 +4,7 @@ module Spree
   module PermissionSets
     class UserManagement < PermissionSets::Base
       def activate!
-        can [:admin, :display, :create, :update, :save_in_address_book, :remove_from_address_book, :addresses, :orders, :items], Spree.user_class
+        can [:admin, :read, :create, :update, :save_in_address_book, :remove_from_address_book, :addresses, :orders, :items], Spree.user_class
 
         # Note: This does not work with accessible_by.
         # See https://github.com/solidusio/solidus/pull/1263
@@ -14,7 +14,7 @@ module Spree
 
         cannot [:delete, :destroy], Spree.user_class
         can :manage, Spree::StoreCredit
-        can :display, Spree::Role
+        can :read, Spree::Role
       end
     end
   end

--- a/core/spec/models/spree/ability_spec.rb
+++ b/core/spec/models/spree/ability_spec.rb
@@ -159,25 +159,27 @@ RSpec.describe Spree::Ability, type: :model do
 
       context 'requested by same user' do
         before(:each) { resource.user = user }
-        it_should_behave_like 'access granted'
+        it { expect(ability).to be_able_to(:show, resource) }
         it_should_behave_like 'no index allowed'
       end
 
       context 'requested by other user' do
         before(:each) { resource.user = Spree.user_class.new }
+        it { expect(ability).not_to be_able_to(:show, resource) }
         it_should_behave_like 'create only'
       end
 
       context 'requested with proper token' do
         let(:token) { 'TOKEN123' }
         before(:each) { allow(resource).to receive_messages guest_token: 'TOKEN123' }
-        it_should_behave_like 'access granted'
+        it { expect(ability).to be_able_to(:show, resource, token) }
         it_should_behave_like 'no index allowed'
       end
 
       context 'requested with inproper token' do
         let(:token) { 'FAIL' }
         before(:each) { allow(resource).to receive_messages guest_token: 'TOKEN123' }
+        it { expect(ability).not_to be_able_to(:show, resource, token) }
         it_should_behave_like 'create only'
       end
     end
@@ -254,7 +256,7 @@ RSpec.describe Spree::Ability, type: :model do
       context 'requested by same user' do
         let(:resource) { user }
         it_should_behave_like 'access granted'
-        it_should_behave_like 'no index allowed'
+        it_should_behave_like 'index allowed'
       end
       context 'requested by other user' do
         let(:resource) { Spree.user_class.create }

--- a/core/spec/models/spree/permission_sets/configuration_display.rb
+++ b/core/spec/models/spree/permission_sets/configuration_display.rb
@@ -13,20 +13,20 @@ RSpec.describe Spree::PermissionSets::ConfigurationDisplay do
     end
 
     it { is_expected.to be_able_to(:edit, :general_settings) }
-    it { is_expected.to be_able_to(:display, Spree::TaxCategory) }
-    it { is_expected.to be_able_to(:display, Spree::TaxRate) }
-    it { is_expected.to be_able_to(:display, Spree::Zone) }
-    it { is_expected.to be_able_to(:display, Spree::Country) }
-    it { is_expected.to be_able_to(:display, Spree::State) }
-    it { is_expected.to be_able_to(:display, Spree::PaymentMethod) }
-    it { is_expected.to be_able_to(:display, Spree::Taxonomy) }
-    it { is_expected.to be_able_to(:display, Spree::ShippingMethod) }
-    it { is_expected.to be_able_to(:display, Spree::ShippingCategory) }
-    it { is_expected.to be_able_to(:display, Spree::StockLocation) }
-    it { is_expected.to be_able_to(:display, Spree::StockMovement) }
-    it { is_expected.to be_able_to(:display, Spree::RefundReason) }
-    it { is_expected.to be_able_to(:display, Spree::ReimbursementType) }
-    it { is_expected.to be_able_to(:display, Spree::ReturnReason) }
+    it { is_expected.to be_able_to(:read, Spree::TaxCategory) }
+    it { is_expected.to be_able_to(:read, Spree::TaxRate) }
+    it { is_expected.to be_able_to(:read, Spree::Zone) }
+    it { is_expected.to be_able_to(:read, Spree::Country) }
+    it { is_expected.to be_able_to(:read, Spree::State) }
+    it { is_expected.to be_able_to(:read, Spree::PaymentMethod) }
+    it { is_expected.to be_able_to(:read, Spree::Taxonomy) }
+    it { is_expected.to be_able_to(:read, Spree::ShippingMethod) }
+    it { is_expected.to be_able_to(:read, Spree::ShippingCategory) }
+    it { is_expected.to be_able_to(:read, Spree::StockLocation) }
+    it { is_expected.to be_able_to(:read, Spree::StockMovement) }
+    it { is_expected.to be_able_to(:read, Spree::RefundReason) }
+    it { is_expected.to be_able_to(:read, Spree::ReimbursementType) }
+    it { is_expected.to be_able_to(:read, Spree::ReturnReason) }
     it { is_expected.to be_able_to(:admin, :general_settings) }
     it { is_expected.to be_able_to(:admin, Spree::TaxCategory) }
     it { is_expected.to be_able_to(:admin, Spree::TaxRate) }
@@ -46,20 +46,20 @@ RSpec.describe Spree::PermissionSets::ConfigurationDisplay do
 
   context "when not activated" do
     it { is_expected.not_to be_able_to(:edit, :general_settings) }
-    it { is_expected.not_to be_able_to(:display, Spree::TaxCategory) }
-    it { is_expected.not_to be_able_to(:display, Spree::TaxRate) }
-    it { is_expected.not_to be_able_to(:display, Spree::Zone) }
-    it { is_expected.not_to be_able_to(:display, Spree::Country) }
-    it { is_expected.not_to be_able_to(:display, Spree::State) }
-    it { is_expected.not_to be_able_to(:display, Spree::PaymentMethod) }
-    it { is_expected.not_to be_able_to(:display, Spree::Taxonomy) }
-    it { is_expected.not_to be_able_to(:display, Spree::ShippingMethod) }
-    it { is_expected.not_to be_able_to(:display, Spree::ShippingCategory) }
-    it { is_expected.not_to be_able_to(:display, Spree::StockLocation) }
-    it { is_expected.not_to be_able_to(:display, Spree::StockMovement) }
-    it { is_expected.not_to be_able_to(:display, Spree::RefundReason) }
-    it { is_expected.not_to be_able_to(:display, Spree::ReimbursementType) }
-    it { is_expected.not_to be_able_to(:display, Spree::ReturnReason) }
+    it { is_expected.not_to be_able_to(:read, Spree::TaxCategory) }
+    it { is_expected.not_to be_able_to(:read, Spree::TaxRate) }
+    it { is_expected.not_to be_able_to(:read, Spree::Zone) }
+    it { is_expected.not_to be_able_to(:read, Spree::Country) }
+    it { is_expected.not_to be_able_to(:read, Spree::State) }
+    it { is_expected.not_to be_able_to(:read, Spree::PaymentMethod) }
+    it { is_expected.not_to be_able_to(:read, Spree::Taxonomy) }
+    it { is_expected.not_to be_able_to(:read, Spree::ShippingMethod) }
+    it { is_expected.not_to be_able_to(:read, Spree::ShippingCategory) }
+    it { is_expected.not_to be_able_to(:read, Spree::StockLocation) }
+    it { is_expected.not_to be_able_to(:read, Spree::StockMovement) }
+    it { is_expected.not_to be_able_to(:read, Spree::RefundReason) }
+    it { is_expected.not_to be_able_to(:read, Spree::ReimbursementType) }
+    it { is_expected.not_to be_able_to(:read, Spree::ReturnReason) }
     it { is_expected.not_to be_able_to(:admin, :general_settings) }
     it { is_expected.not_to be_able_to(:admin, Spree::TaxCategory) }
     it { is_expected.not_to be_able_to(:admin, Spree::TaxRate) }

--- a/core/spec/models/spree/permission_sets/order_display_spec.rb
+++ b/core/spec/models/spree/permission_sets/order_display_spec.rb
@@ -12,13 +12,13 @@ RSpec.describe Spree::PermissionSets::OrderDisplay do
       described_class.new(ability).activate!
     end
 
-    it { is_expected.to be_able_to(:display, Spree::Order) }
-    it { is_expected.to be_able_to(:display, Spree::Payment) }
-    it { is_expected.to be_able_to(:display, Spree::Shipment) }
-    it { is_expected.to be_able_to(:display, Spree::Adjustment) }
-    it { is_expected.to be_able_to(:display, Spree::LineItem) }
-    it { is_expected.to be_able_to(:display, Spree::ReturnAuthorization) }
-    it { is_expected.to be_able_to(:display, Spree::CustomerReturn) }
+    it { is_expected.to be_able_to(:read, Spree::Order) }
+    it { is_expected.to be_able_to(:read, Spree::Payment) }
+    it { is_expected.to be_able_to(:read, Spree::Shipment) }
+    it { is_expected.to be_able_to(:read, Spree::Adjustment) }
+    it { is_expected.to be_able_to(:read, Spree::LineItem) }
+    it { is_expected.to be_able_to(:read, Spree::ReturnAuthorization) }
+    it { is_expected.to be_able_to(:read, Spree::CustomerReturn) }
     it { is_expected.to be_able_to(:admin, Spree::Order) }
     it { is_expected.to be_able_to(:admin, Spree::Payment) }
     it { is_expected.to be_able_to(:admin, Spree::Shipment) }
@@ -28,19 +28,19 @@ RSpec.describe Spree::PermissionSets::OrderDisplay do
     it { is_expected.to be_able_to(:admin, Spree::CustomerReturn) }
     it { is_expected.to be_able_to(:edit, Spree::Order) }
     it { is_expected.to be_able_to(:cart, Spree::Order) }
-    it { is_expected.to be_able_to(:display, Spree::Reimbursement) }
-    it { is_expected.to be_able_to(:display, Spree::ReturnItem) }
-    it { is_expected.to be_able_to(:display, Spree::Refund) }
+    it { is_expected.to be_able_to(:read, Spree::Reimbursement) }
+    it { is_expected.to be_able_to(:read, Spree::ReturnItem) }
+    it { is_expected.to be_able_to(:read, Spree::Refund) }
   end
 
   context "when not activated" do
-    it { is_expected.not_to be_able_to(:display, Spree::Order) }
-    it { is_expected.not_to be_able_to(:display, Spree::Payment) }
-    it { is_expected.not_to be_able_to(:display, Spree::Shipment) }
-    it { is_expected.not_to be_able_to(:display, Spree::Adjustment) }
-    it { is_expected.not_to be_able_to(:display, Spree::LineItem) }
-    it { is_expected.not_to be_able_to(:display, Spree::ReturnAuthorization) }
-    it { is_expected.not_to be_able_to(:display, Spree::CustomerReturn) }
+    it { is_expected.not_to be_able_to(:read, Spree::Order) }
+    it { is_expected.not_to be_able_to(:read, Spree::Payment) }
+    it { is_expected.not_to be_able_to(:read, Spree::Shipment) }
+    it { is_expected.not_to be_able_to(:read, Spree::Adjustment) }
+    it { is_expected.not_to be_able_to(:read, Spree::LineItem) }
+    it { is_expected.not_to be_able_to(:read, Spree::ReturnAuthorization) }
+    it { is_expected.not_to be_able_to(:read, Spree::CustomerReturn) }
     it { is_expected.not_to be_able_to(:admin, Spree::Order) }
     it { is_expected.not_to be_able_to(:admin, Spree::Payment) }
     it { is_expected.not_to be_able_to(:admin, Spree::Shipment) }
@@ -49,8 +49,8 @@ RSpec.describe Spree::PermissionSets::OrderDisplay do
     it { is_expected.not_to be_able_to(:admin, Spree::ReturnAuthorization) }
     it { is_expected.not_to be_able_to(:admin, Spree::CustomerReturn) }
     it { is_expected.not_to be_able_to(:cart, Spree::Order) }
-    it { is_expected.not_to be_able_to(:display, Spree::Reimbursement) }
-    it { is_expected.not_to be_able_to(:display, Spree::ReturnItem) }
-    it { is_expected.not_to be_able_to(:display, Spree::Refund) }
+    it { is_expected.not_to be_able_to(:read, Spree::Reimbursement) }
+    it { is_expected.not_to be_able_to(:read, Spree::ReturnItem) }
+    it { is_expected.not_to be_able_to(:read, Spree::Refund) }
   end
 end

--- a/core/spec/models/spree/permission_sets/order_management_spec.rb
+++ b/core/spec/models/spree/permission_sets/order_management_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Spree::PermissionSets::OrderManagement do
     it { is_expected.to be_able_to(:manage, Spree::LineItem) }
     it { is_expected.to be_able_to(:manage, Spree::ReturnAuthorization) }
     it { is_expected.to be_able_to(:manage, Spree::CustomerReturn) }
-    it { is_expected.to be_able_to(:display, Spree::ReimbursementType) }
+    it { is_expected.to be_able_to(:read, Spree::ReimbursementType) }
     it { is_expected.to be_able_to(:manage, Spree::OrderCancellations) }
     it { is_expected.to be_able_to(:manage, Spree::Reimbursement) }
     it { is_expected.to be_able_to(:manage, Spree::ReturnItem) }
@@ -34,7 +34,7 @@ RSpec.describe Spree::PermissionSets::OrderManagement do
     it { is_expected.not_to be_able_to(:manage, Spree::LineItem) }
     it { is_expected.not_to be_able_to(:manage, Spree::ReturnAuthorization) }
     it { is_expected.not_to be_able_to(:manage, Spree::CustomerReturn) }
-    it { is_expected.not_to be_able_to(:display, Spree::ReimbursementType) }
+    it { is_expected.not_to be_able_to(:read, Spree::ReimbursementType) }
     it { is_expected.not_to be_able_to(:manage, Spree::OrderCancellations) }
     it { is_expected.not_to be_able_to(:manage, Spree::Reimbursement) }
     it { is_expected.not_to be_able_to(:manage, Spree::ReturnItem) }

--- a/core/spec/models/spree/permission_sets/product_display_spec.rb
+++ b/core/spec/models/spree/permission_sets/product_display_spec.rb
@@ -12,15 +12,15 @@ RSpec.describe Spree::PermissionSets::ProductDisplay do
       described_class.new(ability).activate!
     end
 
-    it { is_expected.to be_able_to(:display, Spree::Product) }
-    it { is_expected.to be_able_to(:display, Spree::Image) }
-    it { is_expected.to be_able_to(:display, Spree::Variant) }
-    it { is_expected.to be_able_to(:display, Spree::OptionValue) }
-    it { is_expected.to be_able_to(:display, Spree::ProductProperty) }
-    it { is_expected.to be_able_to(:display, Spree::OptionType) }
-    it { is_expected.to be_able_to(:display, Spree::Property) }
-    it { is_expected.to be_able_to(:display, Spree::Taxonomy) }
-    it { is_expected.to be_able_to(:display, Spree::Taxon) }
+    it { is_expected.to be_able_to(:read, Spree::Product) }
+    it { is_expected.to be_able_to(:read, Spree::Image) }
+    it { is_expected.to be_able_to(:read, Spree::Variant) }
+    it { is_expected.to be_able_to(:read, Spree::OptionValue) }
+    it { is_expected.to be_able_to(:read, Spree::ProductProperty) }
+    it { is_expected.to be_able_to(:read, Spree::OptionType) }
+    it { is_expected.to be_able_to(:read, Spree::Property) }
+    it { is_expected.to be_able_to(:read, Spree::Taxonomy) }
+    it { is_expected.to be_able_to(:read, Spree::Taxon) }
     it { is_expected.to be_able_to(:admin, Spree::Product) }
     it { is_expected.to be_able_to(:admin, Spree::Image) }
     it { is_expected.to be_able_to(:admin, Spree::Variant) }
@@ -34,15 +34,15 @@ RSpec.describe Spree::PermissionSets::ProductDisplay do
   end
 
   context "when not activated" do
-    it { is_expected.not_to be_able_to(:display, Spree::Product) }
-    it { is_expected.not_to be_able_to(:display, Spree::Image) }
-    it { is_expected.not_to be_able_to(:display, Spree::Variant) }
-    it { is_expected.not_to be_able_to(:display, Spree::OptionValue) }
-    it { is_expected.not_to be_able_to(:display, Spree::ProductProperty) }
-    it { is_expected.not_to be_able_to(:display, Spree::OptionType) }
-    it { is_expected.not_to be_able_to(:display, Spree::Property) }
-    it { is_expected.not_to be_able_to(:display, Spree::Taxonomy) }
-    it { is_expected.not_to be_able_to(:display, Spree::Taxon) }
+    it { is_expected.not_to be_able_to(:read, Spree::Product) }
+    it { is_expected.not_to be_able_to(:read, Spree::Image) }
+    it { is_expected.not_to be_able_to(:read, Spree::Variant) }
+    it { is_expected.not_to be_able_to(:read, Spree::OptionValue) }
+    it { is_expected.not_to be_able_to(:read, Spree::ProductProperty) }
+    it { is_expected.not_to be_able_to(:read, Spree::OptionType) }
+    it { is_expected.not_to be_able_to(:read, Spree::Property) }
+    it { is_expected.not_to be_able_to(:read, Spree::Taxonomy) }
+    it { is_expected.not_to be_able_to(:read, Spree::Taxon) }
     it { is_expected.not_to be_able_to(:admin, Spree::Product) }
     it { is_expected.not_to be_able_to(:admin, Spree::Image) }
     it { is_expected.not_to be_able_to(:admin, Spree::Variant) }

--- a/core/spec/models/spree/permission_sets/promotion_display_spec.rb
+++ b/core/spec/models/spree/permission_sets/promotion_display_spec.rb
@@ -12,11 +12,11 @@ RSpec.describe Spree::PermissionSets::PromotionDisplay do
       described_class.new(ability).activate!
     end
 
-    it { is_expected.to be_able_to(:display, Spree::Promotion) }
-    it { is_expected.to be_able_to(:display, Spree::PromotionRule) }
-    it { is_expected.to be_able_to(:display, Spree::PromotionAction) }
-    it { is_expected.to be_able_to(:display, Spree::PromotionCategory) }
-    it { is_expected.to be_able_to(:display, Spree::PromotionCode) }
+    it { is_expected.to be_able_to(:read, Spree::Promotion) }
+    it { is_expected.to be_able_to(:read, Spree::PromotionRule) }
+    it { is_expected.to be_able_to(:read, Spree::PromotionAction) }
+    it { is_expected.to be_able_to(:read, Spree::PromotionCategory) }
+    it { is_expected.to be_able_to(:read, Spree::PromotionCode) }
     it { is_expected.to be_able_to(:admin, Spree::Promotion) }
     it { is_expected.to be_able_to(:admin, Spree::PromotionRule) }
     it { is_expected.to be_able_to(:admin, Spree::PromotionAction) }
@@ -26,11 +26,11 @@ RSpec.describe Spree::PermissionSets::PromotionDisplay do
   end
 
   context "when not activated" do
-    it { is_expected.not_to be_able_to(:display, Spree::Promotion) }
-    it { is_expected.not_to be_able_to(:display, Spree::PromotionRule) }
-    it { is_expected.not_to be_able_to(:display, Spree::PromotionAction) }
-    it { is_expected.not_to be_able_to(:display, Spree::PromotionCategory) }
-    it { is_expected.not_to be_able_to(:display, Spree::PromotionCode) }
+    it { is_expected.not_to be_able_to(:read, Spree::Promotion) }
+    it { is_expected.not_to be_able_to(:read, Spree::PromotionRule) }
+    it { is_expected.not_to be_able_to(:read, Spree::PromotionAction) }
+    it { is_expected.not_to be_able_to(:read, Spree::PromotionCategory) }
+    it { is_expected.not_to be_able_to(:read, Spree::PromotionCode) }
     it { is_expected.not_to be_able_to(:admin, Spree::Promotion) }
     it { is_expected.not_to be_able_to(:admin, Spree::PromotionRule) }
     it { is_expected.not_to be_able_to(:admin, Spree::PromotionAction) }

--- a/core/spec/models/spree/permission_sets/restricted_stock_display_spec.rb
+++ b/core/spec/models/spree/permission_sets/restricted_stock_display_spec.rb
@@ -25,18 +25,18 @@ RSpec.describe Spree::PermissionSets::RestrictedStockDisplay do
       described_class.new(ability).activate!
     end
 
-    it { is_expected.to be_able_to(:display, sl1) }
-    it { is_expected.to_not be_able_to(:display, sl2) }
+    it { is_expected.to be_able_to(:read, sl1) }
+    it { is_expected.to_not be_able_to(:read, sl2) }
 
-    it { is_expected.to be_able_to(:display, item1) }
-    it { is_expected.to_not be_able_to(:display, item2) }
+    it { is_expected.to be_able_to(:read, item1) }
+    it { is_expected.to_not be_able_to(:read, item2) }
   end
 
   context "when not activated" do
-    it { is_expected.to_not be_able_to(:display, sl1) }
-    it { is_expected.to_not be_able_to(:display, sl2) }
+    it { is_expected.to_not be_able_to(:read, sl1) }
+    it { is_expected.to_not be_able_to(:read, sl2) }
 
-    it { is_expected.to_not be_able_to(:display, item1) }
-    it { is_expected.to_not be_able_to(:display, item2) }
+    it { is_expected.to_not be_able_to(:read, item1) }
+    it { is_expected.to_not be_able_to(:read, item2) }
   end
 end

--- a/core/spec/models/spree/permission_sets/restricted_stock_management_spec.rb
+++ b/core/spec/models/spree/permission_sets/restricted_stock_management_spec.rb
@@ -25,16 +25,16 @@ RSpec.describe Spree::PermissionSets::RestrictedStockManagement do
       described_class.new(ability).activate!
     end
 
-    it { is_expected.to be_able_to(:display, sl1) }
-    it { is_expected.to_not be_able_to(:display, sl2) }
+    it { is_expected.to be_able_to(:read, sl1) }
+    it { is_expected.to_not be_able_to(:read, sl2) }
 
     it { is_expected.to be_able_to(:manage, item1) }
     it { is_expected.to_not be_able_to(:manage, item2) }
   end
 
   context "when not activated" do
-    it { is_expected.to_not be_able_to(:display, sl1) }
-    it { is_expected.to_not be_able_to(:display, sl2) }
+    it { is_expected.to_not be_able_to(:read, sl1) }
+    it { is_expected.to_not be_able_to(:read, sl2) }
 
     it { is_expected.to_not be_able_to(:manage, item1) }
     it { is_expected.to_not be_able_to(:manage, item2) }

--- a/core/spec/models/spree/permission_sets/stock_display_spec.rb
+++ b/core/spec/models/spree/permission_sets/stock_display_spec.rb
@@ -12,14 +12,14 @@ RSpec.describe Spree::PermissionSets::StockDisplay do
       described_class.new(ability).activate!
     end
 
-    it { is_expected.to be_able_to(:display, Spree::StockItem) }
+    it { is_expected.to be_able_to(:read, Spree::StockItem) }
     it { is_expected.to be_able_to(:admin, Spree::StockItem) }
-    it { is_expected.to be_able_to(:display, Spree::StockLocation) }
+    it { is_expected.to be_able_to(:read, Spree::StockLocation) }
   end
 
   context "when not activated" do
-    it { is_expected.not_to be_able_to(:display, Spree::StockItem) }
+    it { is_expected.not_to be_able_to(:read, Spree::StockItem) }
     it { is_expected.not_to be_able_to(:admin, Spree::StockItem) }
-    it { is_expected.not_to be_able_to(:display, Spree::StockLocation) }
+    it { is_expected.not_to be_able_to(:read, Spree::StockLocation) }
   end
 end

--- a/core/spec/models/spree/permission_sets/stock_management_spec.rb
+++ b/core/spec/models/spree/permission_sets/stock_management_spec.rb
@@ -13,11 +13,11 @@ RSpec.describe Spree::PermissionSets::StockManagement do
     end
 
     it { is_expected.to be_able_to(:manage, Spree::StockItem) }
-    it { is_expected.to be_able_to(:display, Spree::StockLocation) }
+    it { is_expected.to be_able_to(:read, Spree::StockLocation) }
   end
 
   context "when not activated" do
     it { is_expected.not_to be_able_to(:manage, Spree::StockItem) }
-    it { is_expected.not_to be_able_to(:display, Spree::StockLocation) }
+    it { is_expected.not_to be_able_to(:read, Spree::StockLocation) }
   end
 end

--- a/core/spec/models/spree/permission_sets/user_display_spec.rb
+++ b/core/spec/models/spree/permission_sets/user_display_spec.rb
@@ -12,28 +12,28 @@ RSpec.describe Spree::PermissionSets::UserDisplay do
       described_class.new(ability).activate!
     end
 
-    it { is_expected.to be_able_to(:display, Spree.user_class) }
+    it { is_expected.to be_able_to(:read, Spree.user_class) }
     it { is_expected.to be_able_to(:admin, Spree.user_class) }
     it { is_expected.to be_able_to(:edit, Spree.user_class) }
     it { is_expected.to be_able_to(:addresses, Spree.user_class) }
     it { is_expected.to be_able_to(:orders, Spree.user_class) }
     it { is_expected.to be_able_to(:items, Spree.user_class) }
-    it { is_expected.to be_able_to(:display, Spree::StoreCredit) }
+    it { is_expected.to be_able_to(:read, Spree::StoreCredit) }
     it { is_expected.to be_able_to(:admin, Spree::StoreCredit) }
-    it { is_expected.to be_able_to(:display, Spree::Role) }
+    it { is_expected.to be_able_to(:read, Spree::Role) }
     it { is_expected.not_to be_able_to(:delete, Spree.user_class) }
     it { is_expected.not_to be_able_to(:destroy, Spree.user_class) }
   end
 
   context "when not activated" do
-    it { is_expected.not_to be_able_to(:display, Spree.user_class) }
+    it { is_expected.not_to be_able_to(:read, Spree.user_class) }
     it { is_expected.not_to be_able_to(:admin, Spree.user_class) }
     it { is_expected.not_to be_able_to(:edit, Spree.user_class) }
     it { is_expected.not_to be_able_to(:addresses, Spree.user_class) }
     it { is_expected.not_to be_able_to(:orders, Spree.user_class) }
     it { is_expected.not_to be_able_to(:items, Spree.user_class) }
-    it { is_expected.not_to be_able_to(:display, Spree::StoreCredit) }
+    it { is_expected.not_to be_able_to(:read, Spree::StoreCredit) }
     it { is_expected.not_to be_able_to(:admin, Spree::StoreCredit) }
-    it { is_expected.not_to be_able_to(:display, Spree::Role) }
+    it { is_expected.not_to be_able_to(:read, Spree::Role) }
   end
 end

--- a/core/spec/models/spree/permission_sets/user_management_spec.rb
+++ b/core/spec/models/spree/permission_sets/user_management_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Spree::PermissionSets::UserManagement do
     end
 
     it { is_expected.to be_able_to(:admin, Spree.user_class) }
-    it { is_expected.to be_able_to(:display, Spree.user_class) }
+    it { is_expected.to be_able_to(:read, Spree.user_class) }
     it { is_expected.to be_able_to(:create, Spree.user_class) }
     it { is_expected.to be_able_to(:update, Spree.user_class) }
     it { is_expected.to be_able_to(:save_in_address_book, Spree.user_class) }
@@ -36,7 +36,7 @@ RSpec.describe Spree::PermissionSets::UserManagement do
     it { is_expected.not_to be_able_to(:destroy, Spree.user_class) }
 
     it { is_expected.to be_able_to(:manage, Spree::StoreCredit) }
-    it { is_expected.to be_able_to(:display, Spree::Role) }
+    it { is_expected.to be_able_to(:read, Spree::Role) }
   end
 
   context "when not activated" do
@@ -51,6 +51,6 @@ RSpec.describe Spree::PermissionSets::UserManagement do
     it { is_expected.not_to be_able_to(:items, Spree.user_class) }
     it { is_expected.not_to be_able_to(:destroy, Spree.user_class) }
     it { is_expected.not_to be_able_to(:manage, Spree::StoreCredit) }
-    it { is_expected.not_to be_able_to(:display, Spree::Role) }
+    it { is_expected.not_to be_able_to(:read, Spree::Role) }
   end
 end

--- a/frontend/app/controllers/spree/orders_controller.rb
+++ b/frontend/app/controllers/spree/orders_controller.rb
@@ -15,7 +15,7 @@ module Spree
 
     def show
       @order = Spree::Order.find_by!(number: params[:id])
-      authorize! :read, @order, cookies.signed[:guest_token]
+      authorize! :show, @order, cookies.signed[:guest_token]
     end
 
     def update
@@ -40,7 +40,7 @@ module Spree
     # Shows the current incomplete order from the session
     def edit
       @order = current_order || Spree::Order.incomplete.find_or_initialize_by(guest_token: cookies.signed[:guest_token])
-      authorize! :read, @order, cookies.signed[:guest_token]
+      authorize! :edit, @order, cookies.signed[:guest_token]
       associate_user
     end
 

--- a/frontend/spec/controllers/spree/orders_controller_ability_spec.rb
+++ b/frontend/spec/controllers/spree/orders_controller_ability_spec.rb
@@ -29,8 +29,8 @@ module Spree
       end
 
       context '#edit' do
-        it 'should check if user is authorized for :read' do
-          expect(controller).to receive(:authorize!).with(:read, order, token)
+        it 'should check if user is authorized for :edit' do
+          expect(controller).to receive(:authorize!).with(:edit, order, token)
           get :edit, params: { token: token }
         end
       end
@@ -54,7 +54,7 @@ module Spree
         let(:specified_order) { create(:order) }
 
         it "should check against the specified order" do
-          expect(controller).to receive(:authorize!).with(:read, specified_order, token)
+          expect(controller).to receive(:authorize!).with(:show, specified_order, token)
           get :show, params: { id: specified_order.number, token: token }
         end
       end


### PR DESCRIPTION
**Description**
While testing solidus against cancancan 3.0 I noticed that the usage was "not correct (*Euphemismus*)".
This PR aims to remove the customizations introduced to cancancan, which are not necessary.
The current customizations are not compatible with version 3.0.0 of cancancan since Solidus makes use of `merge` of Abilities. The `3.0.0` has a breaking change which changes how `aliased_actions` are merged.

I removed all custom aliases and replaced `display` with `read`. Also, I corrected the rule which would have caused issues during the migration.

This is probably a breaking change, because it will cause problems for the plugins.
Plugins should now use standard `cancancan` actions and replace `display` with `read`.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
