### PR TITLE
When editing prices keep the currency locked.

### DIFF
--- a/backend/app/views/spree/admin/prices/_form.html.erb
+++ b/backend/app/views/spree/admin/prices/_form.html.erb
@@ -26,7 +26,7 @@
       <div data-hook="admin_product_price_form_amount" class="col-4">
         <%= f.field_container :price do %>
           <%= f.label :price %>
-          <%= render "spree/admin/shared/number_with_currency", f: f, amount_attr: :price, currency_attr: :currency %>
+          <%= render "spree/admin/shared/number_with_currency", f: f, amount_attr: :price, currency_attr: :currency, currency: @price.currency %>
         <% end %>
       </div>
   </div>

--- a/backend/spec/features/admin/products/pricing_spec.rb
+++ b/backend/spec/features/admin/products/pricing_spec.rb
@@ -74,6 +74,16 @@ describe 'Pricing' do
           click_icon :edit
         end
         expect(page).to have_content("Edit Price")
+
+        within("#price_price_field") do
+          expect(page).to have_field('price_price', with: '123.99')
+        end
+
+        fill_in "price_price", with: 999.99
+        click_button "Update"
+        expect(page).to have_content("Price has been successfully updated!")
+        expect(page).to have_content("$999.99")
+        expect(page).to have_content("€34.56")
       end
 
       it "will not reset the currency to default" do

--- a/backend/spec/features/admin/products/pricing_spec.rb
+++ b/backend/spec/features/admin/products/pricing_spec.rb
@@ -65,18 +65,26 @@ describe 'Pricing' do
     end
 
     context "editing" do
-      let(:variant) { create(:variant, price: 20) }
-      let(:product) { variant.product }
-
-      before do
-        product.master.update(price: 49.99)
-      end
+      let(:product) { create(:product, price: 123.99) }
+      let!(:variant) { product.master }
+      let!(:other_price) { product.master.prices.create(amount: 34.56, currency: "EUR") }
 
       it 'has a working edit page' do
         within "#spree_price_#{product.master.prices.first.id}" do
           click_icon :edit
         end
         expect(page).to have_content("Edit Price")
+      end
+
+      it "will not reset the currency to default" do
+        within "#spree_price_#{other_price.id}" do
+          click_icon :edit
+        end
+        expect(page).to have_content("Edit Price")
+        expect(page).to_not have_field('price_currency', with: 'USD')
+        within("#price_price_field") do
+          expect(page).to have_css('.number-with-currency-addon', text: 'EUR')
+        end
       end
     end
 


### PR DESCRIPTION
**Description**

When editing a price that has a different currency then the default currency set, the edit form defaults the currency to the default currency. 

This PR fixes that by passing in the price currency to the currency form partial. It also improves the feature spec for editing prices by actually verifying that the edit worked.

before: https://cl.ly/420fb991710b
after: https://cl.ly/2b141684337f

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
