### PR TITLE
Correct adjustment type application order in guide

### DIFF
--- a/guides/source/developers/adjustments/overview.html.md
+++ b/guides/source/developers/adjustments/overview.html.md
@@ -57,7 +57,7 @@ The following objects are the sources of adjustments:
 Note that tax adjustments may be treated differently than promotional
 adjustments in some circumstances:
 
-- By default, tax adjustments are always applied before promotional adjustments.
+- By default, promotional adjustments are always applied before tax adjustments.
   This is to comply with well-known tax regulations. See the [taxation][taxation]
   documentation for more information.
 - Typically, an adjustment's value is added to the price of the object it is


### PR DESCRIPTION
**Description**
On the adjustments page of the guide, It states,

`By default, tax adjustments are always applied before promotional adjustments.`

The opposite is true. See https://github.com/solidusio/solidus/blob/master/core/app/models/spree/order_updater.rb#L111


**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
