### PR TITLE
Convert Tax Categories to discard

### DIFF
--- a/core/app/models/spree/tax_category.rb
+++ b/core/app/models/spree/tax_category.rb
@@ -1,8 +1,19 @@
 # frozen_string_literal: true
 
+require 'discard'
+
 module Spree
   class TaxCategory < Spree::Base
     acts_as_paranoid
+    include Spree::ParanoiaDeprecations
+
+    include Discard::Model
+    self.discard_column = :deleted_at
+
+    after_discard do
+      self.tax_rate_tax_categories = []
+    end
+
     validates :name, presence: true
     validates_uniqueness_of :name, unless: :deleted_at
 

--- a/core/spec/models/spree/tax_category_spec.rb
+++ b/core/spec/models/spree/tax_category_spec.rb
@@ -26,4 +26,25 @@ RSpec.describe Spree::TaxCategory, type: :model do
       expect(tax_category.is_default).to be true
     end
   end
+
+  context ".discard" do
+    let(:tax_category) { create(:tax_category) }
+
+    it "set deleted_at correctly" do
+      tax_category.discard
+      expect(tax_category.deleted_at).not_to be_blank
+    end
+
+    context "when there are tax_rates associated" do
+      let(:tax_rate) { create(:tax_rate) }
+      let(:tax_category) { tax_rate.tax_categories.first }
+
+      it 'correctly discard association records' do
+        expect { tax_category.discard }
+          .to change { tax_category.tax_rates.size }
+          .from(1)
+          .to(0)
+      end
+    end
+  end
 end


### PR DESCRIPTION
**Description**

It was missing from the work done in #2354.

With the magic of ResourceController, it will start using discard when we perform admin destroys since it now responds to `.discard`.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change (if needed)
