### PR TITLE
Hide Master Price input when there's no default price

### DIFF
--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -32,11 +32,22 @@
       <div data-hook="admin_product_form_price">
         <%= f.field_container :price do %>
           <%= f.label :price, class: Spree::Config.require_master_price ? 'required' : '' %>
-          <%= render "spree/admin/shared/number_with_currency", f: f,
-                     amount_attr: :price,
-                     required: Spree::Config.require_master_price,
-                     currency: Spree::Config.default_pricing_options.currency %>
-          <%= f.error_message_on :price %>
+
+          <% if f.object.new_record? || f.object.has_default_price? %>
+            <%= render "spree/admin/shared/number_with_currency",
+                       f: f,
+                       amount_attr: :price,
+                       required: Spree::Config.require_master_price,
+                       currency: Spree::Config.default_pricing_options.currency %>
+            <%= f.error_message_on :price %>
+          <% else %>
+            <span class="info">
+              <%= t('spree.product_without_default_price_info',
+                    default_currency: Spree::Config.default_pricing_options.currency) %>
+              <%= link_to t('spree.product_without_default_price_cta'),
+                          spree.admin_product_prices_url(@product) %>
+            </span>
+          <% end %>
         <% end %>
       </div>
 

--- a/backend/spec/features/admin/products/edit/products_spec.rb
+++ b/backend/spec/features/admin/products/edit/products_spec.rb
@@ -50,6 +50,31 @@ describe 'Product Details', type: :feature do
     end
   end
 
+  context "when default price is deleted" do
+    it "does not show the master price", js: true do
+      product = create(:product, name: 'Bún thịt nướng', sku: 'A100',
+              description: 'lorem ipsum', available_on: '2013-08-14 01:02:03')
+
+      visit spree.admin_path
+      click_nav "Products"
+      within_row(1) { click_icon :edit }
+
+      click_link 'Prices'
+
+      within "#spree_price_#{product.master.default_price.id}" do
+        accept_alert do
+          click_icon :trash
+        end
+      end
+      expect(page).to have_content("Price has been successfully removed")
+
+      click_link 'Product Details'
+
+      expect(page).not_to have_field('product_price')
+      expect(page).to have_content('This Product has no price in the default currency (USD).')
+    end
+  end
+
   # Regression test for https://github.com/spree/spree/issues/3385
   context "deleting a product", js: true do
     it "is still able to find the master variant" do

--- a/backend/spec/features/admin/products/products_spec.rb
+++ b/backend/spec/features/admin/products/products_spec.rb
@@ -289,7 +289,7 @@ describe "Products", type: :feature do
         check "Show Deleted"
         click_button "Search"
         click_link product.name
-        expect(page).to have_field('Master Price', with: product.price.to_f)
+        expect(page).to_not have_field('Master Price')
         expect(page).to_not have_content('Images')
         expect(page).to_not have_content('Prices')
         expect(page).to_not have_content('Product Properties')

--- a/core/app/models/concerns/spree/default_price.rb
+++ b/core/app/models/concerns/spree/default_price.rb
@@ -21,7 +21,7 @@ module Spree
     delegate :price=, to: :find_or_build_default_price
 
     def has_default_price?
-      !default_price.nil?
+      default_price.present? && !default_price.discarded?
     end
   end
 end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1765,6 +1765,8 @@ en:
       product_source:
         group: From product group
         manual: Manually choose
+    product_without_default_price_info: 'This Product has no price in the default currency (%{default_currency}).'
+    product_without_default_price_cta: 'Please, create a Master Price!'
     products: Products
     promotion: Promotion
     promotion_action: Promotion Action

--- a/core/spec/support/concerns/default_price.rb
+++ b/core/spec/support/concerns/default_price.rb
@@ -32,5 +32,13 @@ RSpec.shared_examples_for "default_price" do
   describe '#has_default_price?' do
     subject { super().has_default_price? }
     it { is_expected.to be_truthy }
+
+    context 'when default price is discarded' do
+      before do
+        instance.default_price.discard
+      end
+
+      it { is_expected.to be_falsey }
+    end
   end
 end


### PR DESCRIPTION
**Description**

This PR hides the Master Price input in the Amin Product Edit page when there's no available (not deleted) price for that product's master variant.

closes #1861 
closes #1989 


**Before**

<img width="332" alt="Schermata 2019-03-26 alle 18 48 08" src="https://user-images.githubusercontent.com/167946/55020778-d9bbf100-4ff7-11e9-8024-b7631b4dbf46.png">

👆 Please note that all prices on this product have been deleted, `$999` comes from a deleted (discarded) price.

**After**

<img width="387" alt="Schermata 2019-03-26 alle 18 47 35" src="https://user-images.githubusercontent.com/167946/55020815-f0fade80-4ff7-11e9-8460-90ddd170bd1b.png">


**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
