### PR TITLE
Fix DB-specific, query-related exceptions

### DIFF
--- a/core/app/helpers/spree/taxons_helper.rb
+++ b/core/app/helpers/spree/taxons_helper.rb
@@ -7,12 +7,12 @@ module Spree
     # to show the most popular products for a particular taxon (that is an exercise left to the developer.)
     def taxon_preview(taxon, max = 4)
       price_scope = Spree::Price.where(current_pricing_options.search_arguments)
-      products = taxon.active_products.joins(:prices).merge(price_scope).select("DISTINCT (spree_products.id), spree_products.*, spree_products_taxons.position").limit(max)
+      products = taxon.active_products.joins(:prices).merge(price_scope).select("DISTINCT spree_products.*, spree_products_taxons.position").limit(max)
       if products.size < max
         products_arel = Spree::Product.arel_table
         taxon.descendants.each do |descendent_taxon|
           to_get = max - products.length
-          products += descendent_taxon.active_products.joins(:prices).merge(price_scope).select("DISTINCT (spree_products.id), spree_products.*, spree_products_taxons.position").where(products_arel[:id].not_in(products.map(&:id))).limit(to_get)
+          products += descendent_taxon.active_products.joins(:prices).merge(price_scope).select("DISTINCT spree_products.*, spree_products_taxons.position").where(products_arel[:id].not_in(products.map(&:id))).limit(to_get)
           break if products.size >= max
         end
       end

--- a/core/app/models/spree/product/scopes.rb
+++ b/core/app/models/spree/product/scopes.rb
@@ -63,9 +63,10 @@ module Spree
     #
     #   SELECT COUNT(*) ...
     add_search_scope :in_taxon do |taxon|
-      includes(:classifications).
-      where("spree_products_taxons.taxon_id" => taxon.self_and_descendants.pluck(:id)).
-      order(Spree::Classification.arel_table[:position].asc)
+      includes(:classifications)
+        .where('spree_products_taxons.taxon_id' => taxon.self_and_descendants.pluck(:id))
+        .select(Spree::Classification.arel_table[:position])
+        .order(Spree::Classification.arel_table[:position].asc)
     end
 
     # This scope selects products in all taxons AND all its descendants


### PR DESCRIPTION
**Description**

I was being greeted with the following errors when running specs specifying **PostgreSQL** or **MySQL** as database engine:

* On PG: `PG::InvalidColumnReference`

This was happening because PG is extremely picky when using the `SELECT` and `ORDER BY` methods; it requires that the developer **must explicitly select** the attribute(s) that are going to be used to sort the query results.

* On MySQL: `Mysql2::Error: Duplicate column name`

This exception was being raised because the [affected](https://github.com/solidusio/solidus/blob/0d4a42e25d036546706aa271371097f4da119c54/core/app/helpers/spree/taxons_helper.rb#L10) [code](https://github.com/solidusio/solidus/blob/0d4a42e25d036546706aa271371097f4da119c54/core/app/helpers/spree/taxons_helper.rb#L15) was selecting the `id` attribute for `Spree::Product` twice. (It was being already selected by the `spree_products.*` statement)

See the following failed builds as reference for the errors:

* [Solidus / MySQL](https://circleci.com/gh/nebulab/solidus/1770?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link)
* [Solidus / PG](https://circleci.com/gh/nebulab/solidus/1773?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link)

The issue is present from Rails v5.2.3 onwards, seems like rails/rails#35361 introduced this regression. (shoutout to @kennyadsl and @spaghetticode for pointing this out to me)

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)