### PR TITLE
Improve promotion statuses

### DIFF
--- a/backend/app/helpers/spree/admin/promotions_helper.rb
+++ b/backend/app/helpers/spree/admin/promotions_helper.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Spree
+  module Admin
+    module PromotionsHelper
+      def admin_promotion_status(promotion)
+        return :active if promotion.active?
+        return :not_started if promotion.not_started?
+        return :expired if promotion.expired?
+
+        :inactive
+      end
+    end
+  end
+end

--- a/backend/app/views/spree/admin/promotions/index.html.erb
+++ b/backend/app/views/spree/admin/promotions/index.html.erb
@@ -82,7 +82,7 @@
           </td>
           <td>
             <span class="pill pill-<%= promotion.active? ? 'active' : 'inactive' %>">
-              <%= t(promotion.active?? :active : :inactive, scope: 'spree') %>
+              <%= t(admin_promotion_status(promotion), scope: 'spree.admin.promotion_status') %>
             </span>
           </td>
           <td>

--- a/backend/spec/features/admin/promotions/promotion_spec.rb
+++ b/backend/spec/features/admin/promotions/promotion_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+feature 'Promotions' do
+  stub_authorization!
+
+  context 'index' do
+    context 'when no promotions' do
+      scenario 'shows no promotions found message' do
+        visit spree.admin_promotions_path
+        expect(page).to have_content('No Promotions found.')
+      end
+    end
+
+    context 'when promotion is active' do
+      given!(:promotion) { create :promotion }
+
+      scenario 'promotion status is active' do
+        visit spree.admin_promotions_path
+
+        within_row(1) do
+          expect(column_text(3)).to eq("Active")
+        end
+      end
+    end
+
+    context 'when promotion is in the future' do
+      given!(:promotion) { create :promotion, starts_at: 1.day.after }
+
+      scenario 'promotion status is not started' do
+        visit spree.admin_promotions_path
+
+        within_row(1) do
+          expect(column_text(3)).to eq("Not started")
+        end
+      end
+    end
+
+    context 'when promotion is in the past' do
+      given!(:promotion) { create :promotion, expires_at: 1.day.ago }
+
+      scenario 'promotion status is expired' do
+        visit spree.admin_promotions_path
+
+        within_row(1) do
+          expect(column_text(3)).to eq("Expired")
+        end
+      end
+    end
+  end
+end

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -64,9 +64,24 @@ module Spree
       super
     end
 
+    def not_started?
+      !started?
+    end
+
+    def started?
+      starts_at.nil? || starts_at < Time.current
+    end
+
+    def expired?
+      expires_at.present? && expires_at < Time.current
+    end
+
+    def not_expired?
+      !expired?
+    end
+
     def active?
-      (starts_at.nil? || starts_at < Time.current) &&
-        (expires_at.nil? || expires_at > Time.current)
+      started? && not_expired?
     end
 
     def inactive?

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -850,6 +850,11 @@ en:
           expires_at_placeholder: Never
           general: General
           starts_at_placeholder: Immediately
+      promotion_status:
+        active: Active
+        expired: Expired
+        inactive: Inactive
+        not_started: Not started
       stock_locations:
         form:
           address: Address

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -384,6 +384,86 @@ RSpec.describe Spree::Promotion, type: :model do
     end
   end
 
+  describe '#not_started?' do
+    let(:promotion) { Spree::Promotion.new(starts_at: starts_at) }
+    subject { promotion.not_started? }
+
+    context 'no starts_at date' do
+      let(:starts_at) { nil }
+      it { is_expected.to be_falsey }
+    end
+
+    context 'when starts_at date is in the past' do
+      let(:starts_at) { Time.current - 1.day }
+      it { is_expected.to be_falsey }
+    end
+
+    context 'when starts_at date is not already reached' do
+      let(:starts_at) { Time.current + 1.day }
+      it { is_expected.to be_truthy }
+    end
+  end
+
+  describe '#started?' do
+    let(:promotion) { Spree::Promotion.new(starts_at: starts_at) }
+    subject { promotion.started? }
+
+    context 'when no starts_at date' do
+      let(:starts_at) { nil }
+      it { is_expected.to be_truthy }
+    end
+
+    context 'when starts_at date is in the past' do
+      let(:starts_at) { Time.current - 1.day }
+      it { is_expected.to be_truthy }
+    end
+
+    context 'when starts_at date is not already reached' do
+      let(:starts_at) { Time.current + 1.day }
+      it { is_expected.to be_falsey }
+    end
+  end
+
+  describe '#expired?' do
+    let(:promotion) { Spree::Promotion.new(expires_at: expires_at) }
+    subject { promotion.expired? }
+
+    context 'when no expires_at date' do
+      let(:expires_at) { nil }
+      it { is_expected.to be_falsey }
+    end
+
+    context 'when expires_at date is not already reached' do
+      let(:expires_at) { Time.current + 1.days }
+      it { is_expected.to be_falsey }
+    end
+
+    context 'when expires_at date is in the past' do
+      let(:expires_at) { Time.current - 1.days }
+      it { is_expected.to be_truthy }
+    end
+  end
+
+  describe '#not_expired?' do
+    let(:promotion) { Spree::Promotion.new(expires_at: expires_at) }
+    subject { promotion.not_expired? }
+
+    context 'when no expired_at date' do
+      let(:expires_at) { nil }
+      it { is_expected.to be_truthy }
+    end
+
+    context 'when expires_at date is not already reached' do
+      let(:expires_at) { Time.current + 1.days }
+      it { is_expected.to be_truthy }
+    end
+
+    context 'when expires_at date is in the past' do
+      let(:expires_at) { Time.current - 1.days }
+      it { is_expected.to be_falsey }
+    end
+  end
+
   context "#active" do
     it "should be active" do
       expect(promotion.active?).to eq(true)


### PR DESCRIPTION
**Description**

The current promotions index page only shows two statuses, active and inactive, this doesn't give enough information when the store has many promotions. This adds the unstarted and expired promotion statuses looking for an improvement in the user experience in this admin section.

Before
![image](https://user-images.githubusercontent.com/2718753/55368755-d8377080-54b0-11e9-8e95-b4a71e8d55f8.png)

After
![image](https://user-images.githubusercontent.com/2718753/55675050-fc60cc00-5879-11e9-8ed1-963cac66a341.png)


**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
