### PR TITLE
Promotion start/expiration times

### DIFF
--- a/backend/app/helpers/spree/admin/base_helper.rb
+++ b/backend/app/helpers/spree/admin/base_helper.rb
@@ -30,7 +30,7 @@ module Spree
         end
       end
 
-      def datepicker_field_value(date, with_time = false)
+      def datepicker_field_value(date, with_time: false)
         return if date.blank?
 
         format = if with_time

--- a/backend/app/helpers/spree/admin/base_helper.rb
+++ b/backend/app/helpers/spree/admin/base_helper.rb
@@ -30,10 +30,16 @@ module Spree
         end
       end
 
-      def datepicker_field_value(date)
-        unless date.blank?
-          l(date, format: t('spree.date_picker.format', default: '%Y/%m/%d'))
+      def datepicker_field_value(date, with_time = false)
+        return if date.blank?
+
+        format = if with_time
+          t('spree.date_picker.format_with_time', default: '%Y/%m/%d %H:%M')
+        else
+          t('spree.date_picker.format', default: '%Y/%m/%d')
         end
+
+        l(date, format: format)
       end
 
       # @deprecated Render `spree/admin/shared/preference_fields/\#{preference_type}' instead

--- a/backend/app/views/spree/admin/promotions/_form.html.erb
+++ b/backend/app/views/spree/admin/promotions/_form.html.erb
@@ -44,13 +44,13 @@
       <div id="starts_at_field" class="field">
         <%= f.label :starts_at %>
         <%= f.field_hint :starts_at %>
-        <%= f.text_field :starts_at, value: datepicker_field_value(@promotion.starts_at, true), placeholder: t(".starts_at_placeholder"), class: 'datepicker datepicker-from fullwidth', data: { :'enable-time' => true, :'default-hour' => 0 } %>
+        <%= f.text_field :starts_at, value: datepicker_field_value(@promotion.starts_at, with_time: true), placeholder: t(".starts_at_placeholder"), class: 'datepicker datepicker-from fullwidth', data: { :'enable-time' => true, :'default-hour' => 0 } %>
       </div>
 
       <div id="expires_at_field" class="field">
         <%= f.label :expires_at %>
         <%= f.field_hint :expires_at %>
-        <%= f.text_field :expires_at, value: datepicker_field_value(@promotion.expires_at, true), placeholder: t(".expires_at_placeholder"), class: 'datepicker datepicker-to fullwidth', data: { :'enable-time' => true, :'default-hour' => 0 } %>
+        <%= f.text_field :expires_at, value: datepicker_field_value(@promotion.expires_at, with_time: true), placeholder: t(".expires_at_placeholder"), class: 'datepicker datepicker-to fullwidth', data: { :'enable-time' => true, :'default-hour' => 0 } %>
       </div>
     </div>
   </div>

--- a/backend/app/views/spree/admin/promotions/_form.html.erb
+++ b/backend/app/views/spree/admin/promotions/_form.html.erb
@@ -44,13 +44,13 @@
       <div id="starts_at_field" class="field">
         <%= f.label :starts_at %>
         <%= f.field_hint :starts_at %>
-        <%= f.text_field :starts_at, value: datepicker_field_value(@promotion.starts_at), placeholder: t(".starts_at_placeholder"), class: 'datepicker datepicker-from fullwidth' %>
+        <%= f.text_field :starts_at, value: datepicker_field_value(@promotion.starts_at, true), placeholder: t(".starts_at_placeholder"), class: 'datepicker datepicker-from fullwidth', data: { :'enable-time' => true, :'default-hour' => 0 } %>
       </div>
 
       <div id="expires_at_field" class="field">
         <%= f.label :expires_at %>
         <%= f.field_hint :expires_at %>
-        <%= f.text_field :expires_at, value: datepicker_field_value(@promotion.expires_at), placeholder: t(".expires_at_placeholder"), class: 'datepicker datepicker-to fullwidth' %>
+        <%= f.text_field :expires_at, value: datepicker_field_value(@promotion.expires_at, true), placeholder: t(".expires_at_placeholder"), class: 'datepicker datepicker-to fullwidth', data: { :'enable-time' => true, :'default-hour' => 0 } %>
       </div>
     </div>
   </div>

--- a/backend/app/views/spree/admin/promotions/index.html.erb
+++ b/backend/app/views/spree/admin/promotions/index.html.erb
@@ -92,10 +92,10 @@
             <%= promotion.usage_count %>
           </td>
           <td>
-            <%= promotion.starts_at.to_date.to_s(:short_date) if promotion.starts_at %>
+            <%= promotion.starts_at.to_s(:long) if promotion.starts_at %>
           </td>
           <td>
-            <%= promotion.expires_at.to_date.to_s(:short_date) if promotion.expires_at %>
+            <%= promotion.expires_at.to_s(:long) if promotion.expires_at %>
           </td>
           <td class="actions">
             <% if can?(:edit, promotion) %>


### PR DESCRIPTION
**Description**

Fixes the promotion form in the admin panel to also display the start and expiration times. This allows admins to change the exact time a promotion starts or expires.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
