### PR TITLE
Fix stock item form to allow changing backorder value

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/views/stock/edit_stock_item_row.js
+++ b/backend/app/assets/javascripts/spree/backend/views/stock/edit_stock_item_row.js
@@ -13,7 +13,8 @@ Spree.Views.Stock.EditStockItemRow = Backbone.View.extend({
     "click .submit": "onSubmit",
     "submit form": "onSubmit",
     "click .cancel": "onCancel",
-    'input [name="count_on_hand"]': "countOnHandChanged"
+    'input [name="count_on_hand"]': "countOnHandChanged",
+    'input [name="backorderable"]': "backorderableChanged"
   },
 
   template: HandlebarsTemplates['stock_items/stock_location_stock_item'],
@@ -43,6 +44,20 @@ Spree.Views.Stock.EditStockItemRow = Backbone.View.extend({
     this.render();
   },
 
+  onChange: function() {
+    var count_on_hand_changed = this.previousAttributes.count_on_hand != this.model.attributes.count_on_hand;
+    var backorderable_changed = this.previousAttributes.backorderable != this.model.attributes.backorderable;
+    var changed = count_on_hand_changed || backorderable_changed;
+
+    this.$el.toggleClass('changed', changed);
+  },
+
+  backorderableChanged: function(ev) {
+    this.model.set("backorderable", ev.target.checked);
+
+    this.onChange();
+  },
+
   countOnHandChanged: function(ev) {
     var diff = parseInt(ev.currentTarget.value), newCount;
     if (isNaN(diff)) diff = 0;
@@ -56,7 +71,8 @@ Spree.Views.Stock.EditStockItemRow = Backbone.View.extend({
       this.model.set("count_on_hand", newCount);
       this.$count_on_hand_display.text(newCount);
     }
-    this.$el.toggleClass('changed', diff !== 0);
+
+    this.onChange();
   },
 
   onSuccess: function() {

--- a/backend/spec/features/admin/products/stock_management_spec.rb
+++ b/backend/spec/features/admin/products/stock_management_spec.rb
@@ -57,9 +57,26 @@ describe "Product Stock", type: :feature do
       expect(stock_item.stock_movements.first.quantity).to eq(-4)
     end
 
+    it "can toggle backorderable", js: true do
+      toggle_backorderable(value: false)
+
+      click_link "Product Stock"
+      within("tr#spree_variant_#{variant.id}") do
+        expect(find(:css, "input[type='checkbox']")).not_to be_checked
+      end
+    end
+
     def adjust_count_on_hand(count_on_hand)
       within("tr#spree_variant_#{variant.id}") do
         find(:css, "input[type='number']").set(count_on_hand)
+        click_icon :check
+      end
+      expect(page).to have_content('Updated Successfully')
+    end
+
+    def toggle_backorderable(value: true)
+      within("tr#spree_variant_#{variant.id}") do
+        find(:css, "input[type='checkbox']").set(value)
         click_icon :check
       end
       expect(page).to have_content('Updated Successfully')


### PR DESCRIPTION
**Description**

This PR fixes a bug on the admin stock item forms that I discovered yesterday, probably introduced in #2862. 

The form controls to submit the stock item form was not displayed if the backorder checkbox was the only attribute changed. This is wrong since we could need to change that value without also changing the count on hand value.

This PR fixes this bug by considering also the backorder value changes when we decide if showing the stock item form or not. 

**Before**

![stock-item-before](https://user-images.githubusercontent.com/167946/55398104-02883d00-5548-11e9-9572-058e30d526d3.gif)

**After**

![stock-item-after](https://user-images.githubusercontent.com/167946/55398120-0916b480-5548-11e9-9127-5bd6fa3d844a.gif)

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change (if needed)
