### PR TITLE
Enable extension developers to customize the namespace

### DIFF
--- a/core/lib/spree/testing_support/common_rake.rb
+++ b/core/lib/spree/testing_support/common_rake.rb
@@ -24,7 +24,7 @@ namespace :common do
     begin
       require "generators/#{ENV['LIB_NAME']}/install/install_generator"
       puts 'Running extension installation generator...'
-      "#{ENV['LIB_NAME'].camelize}::Generators::InstallGenerator".constantize.start(["--auto-run-migrations"])
+      "#{ENV['LIB_NAMESPACE'] || ENV['LIB_NAME'].camelize}::Generators::InstallGenerator".constantize.start(["--auto-run-migrations"])
     rescue LoadError
       # No extension generator to run
     end


### PR DESCRIPTION
**Description**

If you are developing an extension and you want to use `Rake::Task['extension:test_app']` you are forced to have a file named exactly as the capitalized version of the extension namespace name, so if you name your namespace extension e.g. SolidusGraphQL you are forced to create a file named `solidus_graph_q_l`, otherwise the following error is raised:

```
> bundle exec rake test_app --trace
** Invoke default (first_time)
** Invoke first_run (first_time)
** Execute first_run
** Invoke test_app (first_time)
** Execute test_app
** Invoke extension:test_app (first_time)
** Execute extension:test_app
** Invoke common:test_app (first_time)
** Execute common:test_app
rake aborted!
LoadError: cannot load such file -- solidus_graph_q_l
```

 This change allows the developer to customize the extension namespace setting a `LIB_NAMESPACE` environment variable.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
