### PR TITLE
Disable adjust stock field when user does not have the correct permission

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/stock_management.js
+++ b/backend/app/assets/javascripts/spree/backend/stock_management.js
@@ -3,6 +3,7 @@ Spree.ready(function() {
     var $el = $(this);
     var model = new Spree.Models.StockItem($el.data('stock-item'));
     var trackInventory = $el.data('track-inventory');
+    var canEdit = $el.data('can-edit')
     new Spree.Views.Stock.EditStockItemRow({
       el: $el,
       stockLocationName: $el.data('stock-location-name'),
@@ -14,6 +15,14 @@ Spree.ready(function() {
         disabled: true,
         class: 'with-tip',
         title: '"Track inventory" option disabled for this variant'
+      });
+    }
+
+    if (canEdit == false) {
+      $('.js-edit-stock-item input').attr({
+        disabled: true,
+        class: 'with-tip',
+        title: 'You do not have permission to manage stock'
       });
     }
   });

--- a/backend/app/views/spree/admin/stock_items/_stock_management.html.erb
+++ b/backend/app/views/spree/admin/stock_items/_stock_management.html.erb
@@ -72,7 +72,7 @@
             </colgroup>
             <% variant.stock_items.each do |item| %>
               <% if @stock_item_stock_locations.include?(item.stock_location) %>
-                <tr class="js-edit-stock-item stock-item-edit-row" data-variant-id="<%= variant.id %>" data-stock-item="<%= item.to_json %>" data-stock-location-name="<%= item.stock_location.name %>" data-track-inventory="<%= variant.should_track_inventory? %>">
+                <tr class="js-edit-stock-item stock-item-edit-row" data-variant-id="<%= variant.id %>" data-stock-item="<%= item.to_json %>" data-stock-location-name="<%= item.stock_location.name %>" data-track-inventory="<%= variant.should_track_inventory? %>" data-can-edit="<%= can?(:admin, Spree::StockItem) %>">
                   <%# This is rendered in JS %>
                 </tr>
               <% end %>


### PR DESCRIPTION
**Description**
Currently, if you only have display permission for StockItems, you can still see and interact with the stock edit field on the Stock Item page. When you attempt to submit, the API returns 401 unauthorized - however this might be confusing to admin users who don't know about their permission level. 

This PR disables the stock edit field (and "Back Orderable" tick boxes) if you do not have the correct permissions to edit stock items, with an explanation tooltip as to why you can't edit the stock items.

This should solve issue #2241 

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
