### PR TITLE
Ensure cartons find soft deleted shipping methods

### DIFF
--- a/core/app/models/spree/carton.rb
+++ b/core/app/models/spree/carton.rb
@@ -3,7 +3,7 @@
 class Spree::Carton < Spree::Base
   belongs_to :address, class_name: 'Spree::Address', optional: true
   belongs_to :stock_location, class_name: 'Spree::StockLocation', inverse_of: :cartons, optional: true
-  belongs_to :shipping_method, class_name: 'Spree::ShippingMethod', inverse_of: :cartons, optional: true
+  belongs_to :shipping_method, -> { with_discarded }, class_name: 'Spree::ShippingMethod', inverse_of: :cartons, optional: true
 
   has_many :inventory_units, class_name: "Spree::InventoryUnit", inverse_of: :carton, dependent: :nullify
   has_many :orders, -> { distinct }, through: :inventory_units

--- a/core/spec/models/spree/carton_spec.rb
+++ b/core/spec/models/spree/carton_spec.rb
@@ -5,6 +5,14 @@ require 'rails_helper'
 RSpec.describe Spree::Carton do
   let(:carton) { create(:carton) }
 
+  describe 'shipping method' do
+    it 'returns soft deleted shipping method' do
+      carton = create(:carton)
+      carton.shipping_method.discard
+      expect(carton.reload.shipping_method).to be_present
+    end
+  end
+
   describe "#create" do
     subject { carton }
 


### PR DESCRIPTION
**Description**

Ensure cartons can find soft deleted shipping methods they belong to. If they can't, the `#tracking_url` method blows up when it tries to call `#build_tracking_url` on a nil shipping method.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
