### PR TITLE
Admin-side navbar collapse

### DIFF
--- a/backend/app/assets/javascripts/spree/backend.js
+++ b/backend/app/assets/javascripts/spree/backend.js
@@ -30,6 +30,7 @@
 //= require spree/backend/components/tooltips
 //= require spree/backend/components/editable_table
 //= require spree/backend/components/sortable_table
+//= require spree/backend/components/admin_nav
 //= require spree/backend/datepicker
 //= require spree/backend/flash
 //= require spree/backend/gateway

--- a/backend/app/assets/javascripts/spree/backend/components/admin_nav.js
+++ b/backend/app/assets/javascripts/spree/backend/components/admin_nav.js
@@ -1,9 +1,9 @@
 Spree.ready(function() {
-  toggleTooltips()
-  if(window.screen.width <= 1024 && !document.cookie.includes("admin_nav_hidden")){
-    //Set default nav to collapse on small screens - but don't override user preference
+  toggleTooltips();
+  if (window.screen.width <= 1024 && !document.cookie.includes("admin_nav_hidden")) {
+    // Set default nav to collapse on small screens - but don't override user preference
     document.body.classList.add("admin-nav-hidden");
-    document.cookie = "admin_nav_hidden=true; expires=Fri, 31 Dec 9999 23:59:59 GMT"
+    document.cookie = "admin_nav_hidden=true; expires=Fri, 31 Dec 9999 23:59:59 GMT";
   }
 
   var adminNavToggle = document.querySelector("#admin-nav-toggle");
@@ -12,17 +12,16 @@ Spree.ready(function() {
     adminNavToggle.addEventListener("click", function() {
       document.body.classList.toggle("admin-nav-hidden");
       toggleTooltips();
-      document.cookie = "admin_nav_hidden=" + document.body.classList.contains("admin-nav-hidden") + "; expires=Fri, 31 Dec 9999 23:59:59 GMT"
+      document.cookie = "admin_nav_hidden=" + document.body.classList.contains("admin-nav-hidden") + "; expires=Fri, 31 Dec 9999 23:59:59 GMT";
     });
   }
 
-  function toggleTooltips(){
-    $(".tab-with-icon .text:visible").each(function(){
-      $(this.closest(".tab-with-icon")).attr("data-original-title","").tooltip()
-    })
-    $(".tab-with-icon .text:hidden").each(function(){
-      $(this.closest(".tab-with-icon")).attr("data-original-title",$(this).text()).tooltip()
-    })
+  function toggleTooltips() {
+    $(".tab-with-icon .text:visible").each(function() {
+      $(this.closest(".tab-with-icon")).attr("data-original-title", "").tooltip();
+    });
+    $(".tab-with-icon .text:hidden").each(function() {
+      $(this.closest(".tab-with-icon")).attr("data-original-title", $(this).text()).tooltip();
+    });
   }
-
 });

--- a/backend/app/assets/javascripts/spree/backend/components/admin_nav.js
+++ b/backend/app/assets/javascripts/spree/backend/components/admin_nav.js
@@ -12,12 +12,14 @@ Spree.ready(function() {
     adminNav.style.display = "none";
   }
 
-  adminNavToggle.addEventListener("click", function() {
-    if (document.body.classList.contains("admin-nav-extended")) {
-      showNav();
-    } else {
-      hideNav();
-    }
-    document.body.classList.toggle("admin-nav-extended");
-  });
+  if (adminNavToggle) {
+    adminNavToggle.addEventListener("click", function() {
+      if (document.body.classList.contains("admin-nav-extended")) {
+        showNav();
+      } else {
+        hideNav();
+      }
+      document.body.classList.toggle("admin-nav-extended");
+    });
+  }
 });

--- a/backend/app/assets/javascripts/spree/backend/components/admin_nav.js
+++ b/backend/app/assets/javascripts/spree/backend/components/admin_nav.js
@@ -1,0 +1,23 @@
+Spree.ready(function() {
+  var adminNavToggle = document.querySelector("#admin-nav-toggle");
+  var adminNav =  document.querySelector(".admin-nav");
+
+  function showNav() {
+    adminNavToggle.innerHTML = '<i class=\"fa fa-chevron-left fa-2x\">';
+    adminNav.style.display = "block";
+  }
+
+  function hideNav() {
+    adminNavToggle.innerHTML = '<i class=\"fa fa-chevron-right fa-2x\">';
+    adminNav.style.display = "none";
+  }
+
+  adminNavToggle.addEventListener("click", function() {
+    if (document.body.classList.contains("admin-nav-extended")) {
+      showNav();
+    } else {
+      hideNav();
+    }
+    document.body.classList.toggle("admin-nav-extended");
+  });
+});

--- a/backend/app/assets/javascripts/spree/backend/components/admin_nav.js
+++ b/backend/app/assets/javascripts/spree/backend/components/admin_nav.js
@@ -1,14 +1,11 @@
 Spree.ready(function() {
-  if (JSON.parse(sessionStorage.getItem("navExtended"))) {
-    document.body.classList.add("admin-nav-hidden");
-  }
-
   var adminNavToggle = document.querySelector("#admin-nav-toggle");
 
   if (adminNavToggle) {
     adminNavToggle.addEventListener("click", function() {
       document.body.classList.toggle("admin-nav-hidden");
-      sessionStorage.setItem("navExtended", document.body.classList.contains("admin-nav-hidden"));
+      console.log(document.cookie)
+      document.cookie = "admin_nav_hidden=" + document.body.classList.contains("admin-nav-hidden") + "; expires=Fri, 31 Dec 9999 23:59:59 GMT"
     });
   }
 });

--- a/backend/app/assets/javascripts/spree/backend/components/admin_nav.js
+++ b/backend/app/assets/javascripts/spree/backend/components/admin_nav.js
@@ -1,5 +1,6 @@
 Spree.ready(function() {
-  if(window.screen.width >= 1024 && !document.cookie.includes("admin_nav_hidden")){
+  toggleTooltips()
+  if(window.screen.width <= 1024 && !document.cookie.includes("admin_nav_hidden")){
     //Set default nav to collapse on small screens - but don't override user preference
     document.body.classList.add("admin-nav-hidden");
     document.cookie = "admin_nav_hidden=true; expires=Fri, 31 Dec 9999 23:59:59 GMT"
@@ -10,7 +11,18 @@ Spree.ready(function() {
   if (adminNavToggle) {
     adminNavToggle.addEventListener("click", function() {
       document.body.classList.toggle("admin-nav-hidden");
+      toggleTooltips();
       document.cookie = "admin_nav_hidden=" + document.body.classList.contains("admin-nav-hidden") + "; expires=Fri, 31 Dec 9999 23:59:59 GMT"
     });
   }
+
+  function toggleTooltips(){
+    $(".tab-with-icon .text:visible").each(function(){
+      $(this.closest(".tab-with-icon")).attr("data-original-title","").tooltip()
+    })
+    $(".tab-with-icon .text:hidden").each(function(){
+      $(this.closest(".tab-with-icon")).attr("data-original-title",$(this).text()).tooltip()
+    })
+  }
+
 });

--- a/backend/app/assets/javascripts/spree/backend/components/admin_nav.js
+++ b/backend/app/assets/javascripts/spree/backend/components/admin_nav.js
@@ -1,9 +1,14 @@
 Spree.ready(function() {
+  if (JSON.parse(sessionStorage.getItem("navExtended"))) {
+    document.body.classList.add("admin-nav-hidden");
+  }
+
   var adminNavToggle = document.querySelector("#admin-nav-toggle");
 
   if (adminNavToggle) {
     adminNavToggle.addEventListener("click", function() {
-      document.body.classList.toggle("admin-nav-extended");
+      document.body.classList.toggle("admin-nav-hidden");
+      sessionStorage.setItem("navExtended", document.body.classList.contains("admin-nav-hidden"));
     });
   }
 });

--- a/backend/app/assets/javascripts/spree/backend/components/admin_nav.js
+++ b/backend/app/assets/javascripts/spree/backend/components/admin_nav.js
@@ -1,10 +1,15 @@
 Spree.ready(function() {
+  if(window.screen.width >= 1024 && !document.cookie.includes("admin_nav_hidden")){
+    //Set default nav to collapse on small screens - but don't override user preference
+    document.body.classList.add("admin-nav-hidden");
+    document.cookie = "admin_nav_hidden=true; expires=Fri, 31 Dec 9999 23:59:59 GMT"
+  }
+
   var adminNavToggle = document.querySelector("#admin-nav-toggle");
 
   if (adminNavToggle) {
     adminNavToggle.addEventListener("click", function() {
       document.body.classList.toggle("admin-nav-hidden");
-      console.log(document.cookie)
       document.cookie = "admin_nav_hidden=" + document.body.classList.contains("admin-nav-hidden") + "; expires=Fri, 31 Dec 9999 23:59:59 GMT"
     });
   }

--- a/backend/app/assets/javascripts/spree/backend/components/admin_nav.js
+++ b/backend/app/assets/javascripts/spree/backend/components/admin_nav.js
@@ -1,24 +1,8 @@
 Spree.ready(function() {
   var adminNavToggle = document.querySelector("#admin-nav-toggle");
-  var adminNav =  document.querySelector(".admin-nav");
-
-  function showNav() {
-    adminNavToggle.innerHTML = '<i class=\"fa fa-chevron-left fa-2x\">';
-    adminNav.style.display = "block";
-  }
-
-  function hideNav() {
-    adminNavToggle.innerHTML = '<i class=\"fa fa-chevron-right fa-2x\">';
-    adminNav.style.display = "none";
-  }
 
   if (adminNavToggle) {
     adminNavToggle.addEventListener("click", function() {
-      if (document.body.classList.contains("admin-nav-extended")) {
-        showNav();
-      } else {
-        hideNav();
-      }
       document.body.classList.toggle("admin-nav-extended");
     });
   }

--- a/backend/app/assets/stylesheets/spree/backend/components/_breadcrumb.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_breadcrumb.scss
@@ -1,15 +1,16 @@
 .breadcrumb {
+  margin-left:20px;
   font-size: 16px;
   margin-bottom: 0;
-  
+
   a {
     color: $breadcrumb-color;
-    
+
     &:hover {
       color: $breadcrumb-active-color;
     }
   }
-  
+
   .active {
     font-weight: $font-weight-bold;
   }

--- a/backend/app/assets/stylesheets/spree/backend/components/_navigation.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_navigation.scss
@@ -97,8 +97,7 @@ nav.menu {
   background-color: $color-white;
   border-bottom: 1px solid $color-border;
   text-align: center;
-  height: $main-header-height;
-  padding: 0 2em 0 1em;
+  padding: 0 1.25em;
   // Using line height for proper vertical centering.
   // As line height does not take the border width into account we need to subtract it.
   line-height: $main-header-height - 1px;
@@ -176,6 +175,7 @@ nav.menu {
         left: -2.1em;
         top: 1.5em;
         margin-top: -1em;
+        pointer-events:none;
       }
 
       > li {

--- a/backend/app/assets/stylesheets/spree/backend/components/_navigation.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_navigation.scss
@@ -5,9 +5,8 @@ $padding-y-navbar-submenu: 9px;
 #admin-nav-toggle {
   position: absolute;
   top: 0;
-  right: 0;
-  padding: 1.75em 1em 1.75em 0;
-  background-color: $color-1;
+  left: 1;
+  padding: 1.75em 1em;
   cursor: pointer;
 
   i {
@@ -24,9 +23,17 @@ $padding-y-navbar-submenu: 9px;
     width: $width-sidebar-collapsed;
   }
 
-  .tab-with-icon .text,
+  .tab-with-icon .text{
+    opacity: 0;
+  }
+
+  .admin-login-nav a{
+    text-overflow:clip;
+  }
+
   .brand-link {
-    display: none;
+    opacity:0;
+    transition: opacity $sidebar-transition;
   }
 
   .selected:not(:hover) .admin-subnav {
@@ -206,6 +213,7 @@ nav.menu {
     font-family: $font-family-base;
     -webkit-font-smoothing: auto;
     -moz-osx-font-smoothing: auto;
+    transition: opacity $sidebar-transition;
   }
 
   .admin-subnav {

--- a/backend/app/assets/stylesheets/spree/backend/components/_navigation.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_navigation.scss
@@ -24,7 +24,7 @@ $padding-y-navbar-submenu: 9px;
   }
 
   .tab-with-icon .text{
-    opacity: 0;
+    display:none;
   }
 
   .admin-login-nav a{
@@ -213,7 +213,6 @@ nav.menu {
     font-family: $font-family-base;
     -webkit-font-smoothing: auto;
     -moz-osx-font-smoothing: auto;
-    transition: opacity $sidebar-transition;
   }
 
   .admin-subnav {

--- a/backend/app/assets/stylesheets/spree/backend/components/_navigation.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_navigation.scss
@@ -2,6 +2,51 @@ $padding-x-navbar: 26px;
 $padding-y-navbar: 13px;
 $padding-y-navbar-submenu: 9px;
 
+#admin-nav-toggle {
+  position: absolute;
+  top: 0;
+  right: 0;
+  padding: 1.75em 1em 1.75em 0;
+  background-color: $color-1;
+  cursor: pointer;
+
+  i {
+    transform: rotate(0);
+    transition: transform $sidebar-transition;
+  }
+}
+
+.admin-nav-hidden {
+  padding-left: $width-sidebar-collapsed;
+
+  .admin-nav,
+  .admin-nav-footer {
+    width: $width-sidebar-collapsed;
+  }
+
+  .tab-with-icon .text,
+  .brand-link {
+    display: none;
+  }
+
+  .selected:not(:hover) .admin-subnav {
+    visibility: hidden;
+    opacity: 0;
+  }
+
+  .admin-nav-menu .selected li {
+    padding-left: 0;
+  }
+
+  #admin-nav-toggle {
+    padding-right: 1.5em;
+
+    i {
+      transform: rotate(180deg);
+    }
+  }
+}
+
 nav.menu {
   ul {
     list-style: none;
@@ -26,16 +71,27 @@ nav.menu {
 }
 
 .admin-nav {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  z-index: $zindex-sticky;
+  width: $width-sidebar;
   border-right: $border-sidebar;
   background: $color-sidebar-bg;
-  z-index: $zindex-sticky;
+  transition: width $sidebar-transition;
+
+  @media print {
+    display: none
+  }
 }
 
 .admin-nav-header {
   background-color: $color-white;
   border-bottom: 1px solid $color-border;
   text-align: center;
-  padding: 0 1.25em;
+  height: $main-header-height;
+  padding: 0 2em 0 1em;
   // Using line height for proper vertical centering.
   // As line height does not take the border width into account we need to subtract it.
   line-height: $main-header-height - 1px;
@@ -45,7 +101,7 @@ nav.menu {
   > ul {
     margin: 1.5em 0 0;
   }
-  
+
   ul {
     padding: 0;
     list-style: none;
@@ -75,10 +131,12 @@ nav.menu {
     }
 
     &:not(.selected):not(:hover) > ul {
-      display: none;
+      visibility: hidden;
+      opacity: 0;
     }
 
-    &:not(.selected) {
+    &:not(.selected),
+    .admin-nav-hidden & {
       position: relative;
 
       // flyout nav
@@ -98,7 +156,7 @@ nav.menu {
         z-index: 1;
         top: 1.5em;
       }
-      
+
       &:after {
         content: '';
         display: block;
@@ -111,10 +169,10 @@ nav.menu {
         top: 1.5em;
         margin-top: -1em;
       }
-      
+
       > li {
         background: $color-white;
-        
+
         a {
           font-weight: $font-weight-bold;
         }
@@ -125,6 +183,7 @@ nav.menu {
 
   a {
     display: block;
+    min-height: 39px;
     padding: $padding-y-navbar $padding-x-navbar;
     color: $color-navbar;
     font-weight: $font-weight-bold;
@@ -154,6 +213,8 @@ nav.menu {
     margin: 0;
     padding-top:    $padding-y-navbar - $padding-y-navbar-submenu;
     padding-bottom: $padding-y-navbar - $padding-y-navbar-submenu;
+    opacity: 1;
+    transition: opacity $sidebar-transition;
 
     li {
       background: $color-navbar-submenu-bg;
@@ -180,7 +241,11 @@ nav.menu {
 }
 
 .admin-nav-footer {
+  width: $width-sidebar;
   background-color: $color-navbar-footer-bg;
+  border-top: $border-sidebar;
+  border-right: $border-sidebar;
+  transition: width $sidebar-transition;
 
   a {
     color: $color-navbar-footer;
@@ -198,9 +263,6 @@ nav.menu {
 .admin-nav.fits .admin-nav-footer {
   position: fixed;
   bottom: 0;
-  width: $width-sidebar;
-  border-top: $border-sidebar;
-  border-right: $border-sidebar;
 }
 
 .admin-login-nav {

--- a/backend/app/assets/stylesheets/spree/backend/components/_navigation.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_navigation.scss
@@ -162,6 +162,7 @@ nav.menu {
       &:before {
         z-index: 1;
         top: 1.5em;
+        pointer-events:none;
       }
 
       &:after {

--- a/backend/app/assets/stylesheets/spree/backend/globals/_variables.scss
+++ b/backend/app/assets/stylesheets/spree/backend/globals/_variables.scss
@@ -161,6 +161,8 @@ $actions-brd-colors: $color-action-edit-brd, $color-action-clone-brd, $color-act
 //--------------------------------------------------------------
 $width-sidebar:                  200px !default;
 $width-sidebar-flyout:           225px !default;
+$width-sidebar-collapsed:        52px !default;
+$sidebar-transition:             250ms ease-in !default;
 $border-sidebar:                 1px solid $color-sidebar-border !default;
 
 // Main

--- a/backend/app/assets/stylesheets/spree/backend/shared/_header.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_header.scss
@@ -1,8 +1,8 @@
 .main-header {
   display: flex;
   align-items: center;
-  padding: 15px $grid-gutter-width;
   background-color: $color-header-bg;
+  padding: 15px $grid-gutter-width 15px 0;
   border-bottom: 1px solid $color-border;
   border-top: 4px solid $color-primary;
   height: $main-header-height;

--- a/backend/app/assets/stylesheets/spree/backend/shared/_layout.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_layout.scss
@@ -16,7 +16,6 @@ body {
 #admin-nav-toggle {
   position: absolute;
   top: 15px;
-  margin-left: 199px;
   padding: 7px 0;
   padding-right: 8px;
   z-index: 1;
@@ -30,17 +29,6 @@ body {
   }
 }
 
-.admin-nav {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  width: $width-sidebar;
-  transform: translate3d(0, 0, 0);
-  transition: transform 350ms ease-in-out;
-  @media print { display: none }
-}
-
 #admin-nav-toggle i {
   transform: rotate(0);
   transition: transform 350ms linear;
@@ -48,10 +36,6 @@ body {
 
 .admin-nav-hidden {
   padding-left: 0;
-
-  .admin-nav {
-    transform: translate3d(-100%, 0, 0);
-  }
 
   #admin-nav-toggle i {
     transform: rotate(180deg);

--- a/backend/app/assets/stylesheets/spree/backend/shared/_layout.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_layout.scss
@@ -46,7 +46,7 @@ body {
   transition: transform 350ms linear;
 }
 
-.admin-nav-extended {
+.admin-nav-hidden {
   padding-left: 0;
 
   .admin-nav {

--- a/backend/app/assets/stylesheets/spree/backend/shared/_layout.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_layout.scss
@@ -6,7 +6,7 @@ body {
   position: relative;
   min-height: 100%;
   padding-left: $width-sidebar;
-  transition: padding 350ms linear;
+  transition: padding $sidebar-transition;
 }
 
 .admin {
@@ -56,6 +56,7 @@ body {
   #admin-nav-toggle i {
     transform: rotate(180deg);
   }
+  transition: padding $sidebar-transition;
 }
 
 .content-wrapper {

--- a/backend/app/assets/stylesheets/spree/backend/shared/_layout.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_layout.scss
@@ -17,13 +17,12 @@ body {
   position: absolute;
   top: 15px;
   margin-left: 199px;
-  cursor: pointer;
+  padding-right: 5px;
+  z-index: 1;
   background-color: $color-1;
   border: 1px solid $color-border;
   border-left: none;
-
-  z-index: 1;
-  padding-right: 5px;
+  cursor: pointer;
 
   i {
     margin-left: 5px;

--- a/backend/app/assets/stylesheets/spree/backend/shared/_layout.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_layout.scss
@@ -6,6 +6,7 @@ body {
   position: relative;
   min-height: 100%;
   padding-left: $width-sidebar;
+  transition: padding 350ms linear;
 }
 
 .admin {
@@ -14,9 +15,19 @@ body {
 
 #admin-nav-toggle {
   position: absolute;
-  top: 25px;
-  margin-left: 5px;
+  top: 15px;
+  margin-left: 199px;
   cursor: pointer;
+  background-color: $color-1;
+  border: 1px solid $color-border;
+  border-left: none;
+
+  z-index: 1;
+  padding-right: 5px;
+
+  i {
+    margin-left: 5px;
+  }
 }
 
 .admin-nav {
@@ -25,10 +36,27 @@ body {
   bottom: 0;
   left: 0;
   width: $width-sidebar;
+  transform: translate3d(0, 0, 0);
+  transition: transform 350ms ease-in-out;
   @media print { display: none }
 }
 
-.admin-nav-extended { padding-left: 0; }
+#admin-nav-toggle i {
+  transform: rotate(0);
+  transition: transform 350ms linear;
+}
+
+.admin-nav-extended {
+  padding-left: 0;
+
+  .admin-nav {
+    transform: translate3d(-100%, 0, 0);
+  }
+
+  #admin-nav-toggle i {
+    transform: rotate(180deg);
+  }
+}
 
 .content-wrapper {
   background-color: $content-wrapper-bg;

--- a/backend/app/assets/stylesheets/spree/backend/shared/_layout.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_layout.scss
@@ -12,6 +12,13 @@ body {
   background-color: $admin-body-bg;
 }
 
+#admin-nav-toggle {
+  position: absolute;
+  top: 25px;
+  margin-left: 5px;
+  cursor: pointer;
+}
+
 .admin-nav {
   position: absolute;
   top: 0;
@@ -20,6 +27,8 @@ body {
   width: $width-sidebar;
   @media print { display: none }
 }
+
+.admin-nav-extended { padding-left: 0; }
 
 .content-wrapper {
   background-color: $content-wrapper-bg;

--- a/backend/app/assets/stylesheets/spree/backend/shared/_layout.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_layout.scss
@@ -17,7 +17,8 @@ body {
   position: absolute;
   top: 15px;
   margin-left: 199px;
-  padding-right: 5px;
+  padding: 7px 0;
+  padding-right: 8px;
   z-index: 1;
   background-color: $color-1;
   border: 1px solid $color-border;

--- a/backend/app/views/spree/admin/shared/_header.html.erb
+++ b/backend/app/views/spree/admin/shared/_header.html.erb
@@ -1,4 +1,5 @@
 <div id="content-header" class="main-header" data-hook>
+  <span id="admin-nav-toggle"><i class="fa fa-angle-double-left fa-2x"></i></span>
   <%= render_admin_breadcrumbs %>
 
   <% if content_for?(:page_actions) %>

--- a/backend/app/views/spree/admin/shared/_navigation.html.erb
+++ b/backend/app/views/spree/admin/shared/_navigation.html.erb
@@ -1,6 +1,5 @@
 <div class="admin-nav">
   <%= render partial: 'spree/admin/shared/navigation_header' %>
-  <span id="admin-nav-toggle"><i class="fa fa-angle-double-left fa-2x"></i></span>
   <div class="admin-nav-sticky">
     <%= render partial: 'spree/admin/shared/menu' %>
     <div class="admin-nav-footer">

--- a/backend/app/views/spree/admin/shared/_navigation.html.erb
+++ b/backend/app/views/spree/admin/shared/_navigation.html.erb
@@ -1,6 +1,6 @@
-<span id="admin-nav-toggle"><i class="fa fa-chevron-left fa-2x"></i></span>
 <div class="admin-nav">
   <%= render partial: 'spree/admin/shared/navigation_header' %>
+  <span id="admin-nav-toggle"><i class="fa fa-angle-double-left fa-3x"></i></span>
   <div class="admin-nav-sticky">
     <%= render partial: 'spree/admin/shared/menu' %>
     <div class="admin-nav-footer">

--- a/backend/app/views/spree/admin/shared/_navigation.html.erb
+++ b/backend/app/views/spree/admin/shared/_navigation.html.erb
@@ -1,6 +1,6 @@
 <div class="admin-nav">
   <%= render partial: 'spree/admin/shared/navigation_header' %>
-  <span id="admin-nav-toggle"><i class="fa fa-angle-double-left fa-3x"></i></span>
+  <span id="admin-nav-toggle"><i class="fa fa-angle-double-left fa-2x"></i></span>
   <div class="admin-nav-sticky">
     <%= render partial: 'spree/admin/shared/menu' %>
     <div class="admin-nav-footer">

--- a/backend/app/views/spree/admin/shared/_navigation.html.erb
+++ b/backend/app/views/spree/admin/shared/_navigation.html.erb
@@ -1,3 +1,4 @@
+<span id="admin-nav-toggle"><i class="fa fa-chevron-left fa-2x"></i></span>
 <div class="admin-nav">
   <%= render partial: 'spree/admin/shared/navigation_header' %>
   <div class="admin-nav-sticky">

--- a/backend/app/views/spree/layouts/admin.html.erb
+++ b/backend/app/views/spree/layouts/admin.html.erb
@@ -3,8 +3,7 @@
   <head data-hook="admin_inside_head">
     <%= render 'spree/admin/shared/head' %>
   </head>
-
-  <body class="admin">
+  <body class="admin <%= "admin-nav-hidden" if cookies[:admin_nav_hidden] == "true" %>">
     <%= render "spree/admin/shared/navigation" %>
     <%= render "spree/admin/shared/header" %>
     <%= render "spree/admin/shared/flash" %>

--- a/backend/vendor/assets/stylesheets/solidus_admin/bootstrap/_variables.scss
+++ b/backend/vendor/assets/stylesheets/solidus_admin/bootstrap/_variables.scss
@@ -834,7 +834,7 @@ $figure-caption-color:              $gray-600 !default;
 // Breadcrumbs
 
 $breadcrumb-padding-y:              .75rem !default;
-$breadcrumb-padding-x:              1rem !default;
+$breadcrumb-padding-x:              3rem !default;
 $breadcrumb-item-padding:           .5rem !default;
 
 $breadcrumb-margin-bottom:          1rem !default;


### PR DESCRIPTION
**Description**
Makes the admin-side navbar collapsible by clicking a collapse icon at the top of the page.

![navbar-collapse](https://user-images.githubusercontent.com/5720486/55765440-5659c100-5a35-11e9-9669-77df1564866d.gif)

Additional functionality:

- The navbar defaults to closed on iPad sized screens or smaller.
- When the navbar is collapsed or opened, a cookie is stored that remembers your preference - on the next page load, the navbar will be in the same state as it was on the previous page.
- When the navbar is closed, a tooltip is set for the navbar icons which - on hover- displays the name of the button you have selected. If you prefer a closed navbar, but don't know what the icons mean, you can still find your way around.

![image](https://user-images.githubusercontent.com/5720486/55765529-d8e28080-5a35-11e9-9769-4b5e727ff84c.png)

@jacobherrington and @tvdeyen did most of the heavy lifting here, I just cleaned it up and added a few things.

ref #2961 - should close this issue if everything looks good!

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
