### PR TITLE
Use taxon children when searching classification

### DIFF
--- a/core/app/models/spree/promotion/rules/taxon.rb
+++ b/core/app/models/spree/promotion/rules/taxon.rb
@@ -48,13 +48,10 @@ module Spree
           eligibility_errors.empty?
         end
 
-        # TODO: Fix bug - well described by jhawthorn in #1409:
-        # `eligible?` checks the configured taxons and all descendants,
-        # `actionable?` only seems to check against the taxons themselves (not children)
         def actionable?(line_item)
           found = Spree::Classification.where(
             product_id: line_item.variant.product_id,
-            taxon_id: taxon_ids
+            taxon_id: rule_taxon_ids_with_children
           ).exists?
 
           case preferred_match_policy

--- a/core/spec/models/spree/promotion/rules/taxon_spec.rb
+++ b/core/spec/models/spree/promotion/rules/taxon_spec.rb
@@ -151,14 +151,14 @@ RSpec.describe Spree::Promotion::Rules::Taxon, type: :model do
     let(:order) { create :order_with_line_items }
     let(:taxon) { create :taxon, name: 'first' }
 
-    before do
-      rule.preferred_match_policy = 'invalid'
-      rule.save!(validate: false)
-      line_item.product.taxons << taxon
-      rule.taxons << taxon
-    end
-
     context 'with an invalid match policy' do
+      before do
+        rule.preferred_match_policy = 'invalid'
+        rule.save!(validate: false)
+        line_item.product.taxons << taxon
+        rule.taxons << taxon
+      end
+
       it 'logs a warning and uses "any" policy' do
         expect(Spree::Deprecation).to(
           receive(:warn).
@@ -168,6 +168,43 @@ RSpec.describe Spree::Promotion::Rules::Taxon, type: :model do
         expect(
           rule.actionable?(line_item)
         ).to be_truthy
+      end
+    end
+
+    context 'when a product has a taxon of a taxon rule' do
+      before do
+        product.taxons << taxon
+        rule.taxons << taxon
+        rule.save!
+      end
+
+      it 'is actionable' do
+        expect(rule).to be_actionable(line_item)
+      end
+    end
+
+    context 'when a product has a taxon child of a taxon rule' do
+      before do
+        taxon.children << taxon2
+        product.taxons << taxon2
+        rule.taxons << taxon
+        rule.save!
+      end
+
+      it 'is actionable' do
+        expect(rule).to be_actionable(line_item)
+      end
+    end
+
+    context 'when a product does not have taxon or child taxon of a taxon rule' do
+      before do
+        product.taxons << taxon2
+        rule.taxons << taxon
+        rule.save!
+      end
+
+      it 'is not actionable' do
+        expect(rule).not_to be_actionable(line_item)
       end
     end
   end


### PR DESCRIPTION
**Description**

In current implementation, `eligible?` checks the configured taxons and all descendants and `actionable?` only seems to check against the taxons themselves. This leads to buggy behavior. See: https://github.com/solidusio/solidus/pull/1409#issuecomment-243260852

This commit modifies `actionable?` and have it check against configured taxons and all descendants in order to have a coherent behavior.