### PR TITLE
Increase Capybara window width size

### DIFF
--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -47,7 +47,7 @@ Capybara.register_driver :selenium_chrome_headless do |app|
   browser_options = ::Selenium::WebDriver::Chrome::Options.new
   browser_options.args << '--headless'
   browser_options.args << '--disable-gpu'
-  browser_options.args << '--window-size=1440,1080'
+  browser_options.args << '--window-size=1920,1080'
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
 end
 


### PR DESCRIPTION
**Description**

Increasing Capybara window width size may help solve some JS-related issues, such as not being able to click an element because some JS element is "blocking" the view (i.e.: datepicker); this happens because these elements are not automatically dismissed under test environments

#3166 may find this useful

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
