### PR TITLE
Improving the way positioning update happens in classifications

### DIFF
--- a/api/app/controllers/spree/api/classifications_controller.rb
+++ b/api/app/controllers/spree/api/classifications_controller.rb
@@ -6,14 +6,15 @@ module Spree
       def update
         authorize! :update, Product
         authorize! :update, Taxon
-        classification = Spree::Classification.find_by(
-          product_id: params[:product_id],
-          taxon_id: params[:taxon_id]
-        )
-        # Because position we get back is 0-indexed.
-        # acts_as_list is 1-indexed.
-        classification.insert_at(params[:position].to_i + 1)
-        head :ok
+
+        taxon = Spree::Taxon.find(params[:taxon_id])
+        classification = taxon.classifications.find_by(product_id: params[:product_id])
+
+        if classification.insert_at(params[:position].to_i)
+          head :ok
+        else
+          render json: { errors: classification.errors.full_messages }, status: :unprocessable_entity
+        end
       end
     end
   end

--- a/api/spec/requests/spree/api/classifications_controller_spec.rb
+++ b/api/spec/requests/spree/api/classifications_controller_spec.rb
@@ -20,7 +20,7 @@ module Spree
 
     context "as a user" do
       it "cannot change the order of a product" do
-        put spree.api_classifications_path, params: { taxon_id: taxon, product_id: taxon.products.first, position: 1 }
+        put spree.api_classifications_path, params: { taxon_id: taxon.id, product_id: taxon.products.first.id, position: 1 }
         expect(response.status).to eq(401)
       end
     end
@@ -30,12 +30,24 @@ module Spree
 
       let(:last_product) { taxon.products.last }
 
-      it "can change the order a product" do
+      it "can change the order of a product" do
         classification = taxon.classifications.find_by(product_id: last_product.id)
         expect(classification.position).to eq(3)
         put spree.api_classifications_path, params: { taxon_id: taxon.id, product_id: last_product.id, position: 0 }
         expect(response.status).to eq(200)
         expect(classification.reload.position).to eq(1)
+      end
+
+      it "can change the order of a product regardless gaps in positions due discarded products" do
+        taxon.classifications.reload
+        # rubocop:disable Rails/SkipsModelValidations
+        taxon.classifications.second.update_column(:position, 3)
+        taxon.classifications.third.update_column(:position, 5)
+        # rubocop:enable Rails/SkipsModelValidations
+        classification = taxon.classifications.find_by(product_id: last_product.id)
+        put spree.api_classifications_path, params: { taxon_id: taxon.id, product_id: last_product.id, position: 1 }
+        expect(response.status).to eq(200)
+        expect(classification.reload.position).to eq(3)
       end
 
       it "should touch the taxon" do
@@ -44,6 +56,18 @@ module Spree
         put spree.api_classifications_path, params: { taxon_id: taxon.id, product_id: last_product.id, position: 0 }
         taxon.reload
         expect(taxon_last_updated_at.to_i).to_not eq(taxon.updated_at.to_i)
+      end
+
+      it 'returns an error if index is negative' do
+        put spree.api_classifications_path, params: { taxon_id: taxon.id, product_id: last_product.id, position: -1 }
+        expect(response.status).to eq(422)
+        expect(response.body).to include('Position must be within 0..2')
+      end
+
+      it 'returns an error if index is greater than last position' do
+        put spree.api_classifications_path, params: { taxon_id: taxon.id, product_id: last_product.id, position: 3 }
+        expect(response.status).to eq(422)
+        expect(response.body).to include('Position must be within 0..2')
       end
     end
   end

--- a/core/app/models/spree/classification.rb
+++ b/core/app/models/spree/classification.rb
@@ -9,5 +9,28 @@ module Spree
 
     # For https://github.com/spree/spree/issues/3494
     validates_uniqueness_of :taxon_id, scope: :product_id, message: :already_linked
+
+    # We can not rely on html element position index, there could be gaps between
+    # positions due discarded products, their classification is destroyed
+    # but taxon classifications are not rebuilt leaving gaps
+    def insert_at(position)
+      return false if invalid_position(position)
+
+      real_position = taxon.classifications.order(:position).to_a[position].position
+      super(real_position)
+    end
+
+    private
+
+    def last_position
+      taxon.classifications.count - 1
+    end
+
+    def invalid_position(position)
+      unless (0..last_position).cover? position
+        errors.add(:position, "must be within 0..#{last_position}")
+        true
+      end
+    end
   end
 end

--- a/core/spec/models/spree/classification_spec.rb
+++ b/core/spec/models/spree/classification_spec.rb
@@ -92,6 +92,38 @@ module Spree
       end
     end
 
+    context '#insert_at' do
+      it 'moves the element at the top' do
+        classification = taxon_with_5_products.classifications.last
+        classification.insert_at(0)
+        expect(classification.position).to be(1)
+      end
+
+      it 'moves the element to the second place' do
+        classification = taxon_with_5_products.classifications.last
+        classification.insert_at(1)
+        expect(classification.position).to be(2)
+      end
+
+      it 'moves the element at the bottom' do
+        classification = taxon_with_5_products.classifications.first
+        classification.insert_at(4)
+        expect(classification.position).to be(5)
+      end
+
+      it 'moves the element before a gap' do
+        taxon_with_5_products.classifications.second.destroy
+        classification = taxon_with_5_products.classifications.third
+        classification.insert_at(1)
+        expect(classification.position).to be(2)
+      end
+
+      it 'fails moving the the element if position is out of boundaries' do
+        classification = taxon_with_5_products.classifications.first
+        expect(classification.insert_at(6)).to be_falsey
+      end
+    end
+
     it "touches the product" do
       taxon = taxon_with_5_products
       classification = taxon.classifications.first

--- a/core/spec/models/spree/product/scopes_spec.rb
+++ b/core/spec/models/spree/product/scopes_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "Product scopes", type: :model do
 
       it 'after ordering changed' do
         [@child_taxon, other_taxon].each do |taxon|
-          Spree::Classification.find_by(taxon: taxon, product: product).insert_at(2)
+          Spree::Classification.find_by(taxon: taxon, product: product).insert_at(1)
           expect(Spree::Product.in_taxon(taxon)).to eq([product_2, product])
         end
       end


### PR DESCRIPTION

**Description**
It used to rely on item position coming from a html index, but
if a product was deleted, its classification was destroyed as well
leaving a gap, so classification positions are no longer consecutive
breaking the dependency of the index in the html, this uses internal
index instead of the one coming from the frontend

The issue:
consider the following classifications
[product_id, taxon_id, position]
1, 1, 1
3, 1, 3
4, 1, 4
5, 1, 5
6, 1, 6

And we wanted to move product_id 6 to before product_id 5, the javascript code sends position 4, so the code updated the product 6 before the product 4 instead of the product 5, this change fixes this issue.

The reason of the position gaps is because product has dependent: :delete_all in classifications but it does not rebuild the position index to consecutive values.


**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
