### PR TITLE
Upgrade to CanCanCan 3.0

### DIFF
--- a/core/app/models/spree/ability.rb
+++ b/core/app/models/spree/ability.rb
@@ -34,6 +34,13 @@ module Spree
       register_extension_abilities
     end
 
+    # TODO: overrides cancancan merge action to not merge aliases
+    # see https://github.com/solidusio/solidus/pull/3148/ to remove the TODO
+    def merge(ability)
+      ability.rules.each { |rule| add_rule(rule.dup) }
+      self
+    end
+
     private
 
     def alias_actions

--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'activemerchant', '~> 1.66'
   s.add_dependency 'acts_as_list', '~> 0.3'
   s.add_dependency 'awesome_nested_set', '~> 3.0', '>= 3.0.1'
-  s.add_dependency 'cancancan', '~> 2.2'
+  s.add_dependency 'cancancan', '~> 3.0'
   s.add_dependency 'carmen', '~> 1.1.0'
   s.add_dependency 'discard', '~> 1.0'
   s.add_dependency 'friendly_id', '~> 5.0'


### PR DESCRIPTION
This PR aims to upgrade to cancancan 3.0 without the assle of rewriting all the permissions logic. see https://github.com/solidusio/solidus/pull/3148

It basically overrides the changes to the `merge` method of Ability.rb which were breaking solidus permissions mechanism. 
It should be seen as a temporary patch, so that the "proper" way of managing permissions can be released in the future in a major 3.0 release.
This allows to migrate to Rails 6.0.