### PR TITLE
Remove name column from default ransackable attributes

### DIFF
--- a/core/app/models/concerns/spree/ransackable_attributes.rb
+++ b/core/app/models/concerns/spree/ransackable_attributes.rb
@@ -7,7 +7,7 @@ module Spree::RansackableAttributes
     class_attribute :whitelisted_ransackable_attributes
 
     class_attribute :default_ransackable_attributes
-    self.default_ransackable_attributes = %w[id name]
+    self.default_ransackable_attributes = %w[id]
   end
 
   class_methods do

--- a/core/app/models/spree/country.rb
+++ b/core/app/models/spree/country.rb
@@ -8,6 +8,8 @@ module Spree
 
     validates :name, :iso_name, presence: true
 
+    self.whitelisted_ransackable_attributes = %w[name]
+
     def self.default
       if Spree::Config.default_country_id
         Spree::Deprecation.warn("Setting your default country via its ID is deprecated. Please set your default country via the `default_country_iso` setting.", caller)

--- a/core/app/models/spree/option_type.rb
+++ b/core/app/models/spree/option_type.rb
@@ -25,6 +25,8 @@ module Spree
     after_touch :touch_all_products
     after_save :touch_all_products
 
+    self.whitelisted_ransackable_attributes = %w[name]
+
     def touch_all_products
       products.find_each(&:touch)
     end

--- a/core/app/models/spree/option_value.rb
+++ b/core/app/models/spree/option_value.rb
@@ -16,7 +16,7 @@ module Spree
 
     delegate :name, :presentation, to: :option_type, prefix: :option_type
 
-    self.whitelisted_ransackable_attributes = ['presentation']
+    self.whitelisted_ransackable_attributes = %w[name presentation]
 
     # Updates the updated_at column on all the variants associated with this
     # option value.

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -131,7 +131,7 @@ module Spree
     alias :options :product_option_types
 
     self.whitelisted_ransackable_associations = %w[stores variants_including_master master variants]
-    self.whitelisted_ransackable_attributes = %w[slug]
+    self.whitelisted_ransackable_attributes = %w[name slug]
 
     def self.ransackable_scopes(_auth_object = nil)
       %i(with_deleted with_variant_sku_cont)

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -47,7 +47,7 @@ module Spree
     scope :applied, -> { joins(:order_promotions).distinct }
 
     self.whitelisted_ransackable_associations = ['codes']
-    self.whitelisted_ransackable_attributes = ['path', 'promotion_category_id']
+    self.whitelisted_ransackable_attributes = %w[name path promotion_category_id]
 
     def self.order_activatable?(order)
       order && !UNACTIVATABLE_ORDER_STATES.include?(order.state)

--- a/core/app/models/spree/property.rb
+++ b/core/app/models/spree/property.rb
@@ -11,6 +11,8 @@ module Spree
 
     after_touch :touch_all_products
 
+    self.whitelisted_ransackable_attributes = %w[name]
+
     private
 
     def touch_all_products

--- a/core/app/models/spree/state.rb
+++ b/core/app/models/spree/state.rb
@@ -19,6 +19,8 @@ module Spree
       deprecate find_all_by_name_or_abbr: :with_name_or_abbr, deprecator: Spree::Deprecation
     end
 
+    self.whitelisted_ransackable_attributes = %w[name]
+
     # table of { country.id => [ state.id , state.name ] }, arrays sorted by name
     # blank is added elsewhere, if needed
     def self.states_group_by_country_id

--- a/core/app/models/spree/stock_location.rb
+++ b/core/app/models/spree/stock_location.rb
@@ -31,6 +31,8 @@ module Spree
     after_create :create_stock_items, if: :propagate_all_variants?
     after_save :ensure_one_default
 
+    self.whitelisted_ransackable_attributes = %w[name]
+
     def state_text
       state.try(:abbr) || state.try(:name) || state_name
     end

--- a/core/app/models/spree/taxon.rb
+++ b/core/app/models/spree/taxon.rb
@@ -35,6 +35,8 @@ module Spree
     validates_attachment :icon,
       content_type: { content_type: ["image/jpg", "image/jpeg", "image/png", "image/gif"] }
 
+    self.whitelisted_ransackable_attributes = %w[name]
+
     # @note This method is meant to be overridden on a store by store basis.
     # @return [Array] filters that should be used for a taxon
     def applicable_filters

--- a/core/app/models/spree/taxonomy.rb
+++ b/core/app/models/spree/taxonomy.rb
@@ -13,6 +13,8 @@ module Spree
 
     default_scope -> { order(position: :asc) }
 
+    self.whitelisted_ransackable_attributes = %w[name]
+
     private
 
     def set_name

--- a/core/app/models/spree/zone.rb
+++ b/core/app/models/spree/zone.rb
@@ -42,7 +42,7 @@ module Spree
     alias :members :zone_members
     accepts_nested_attributes_for :zone_members, allow_destroy: true, reject_if: proc { |a| a['zoneable_id'].blank? }
 
-    self.whitelisted_ransackable_attributes = ['description']
+    self.whitelisted_ransackable_attributes = %w[name description]
 
     # Returns all zones that contain any of the zone members of the zone passed
     # in. This also includes any country zones that contain the state of the


### PR DESCRIPTION
Fixes #3179. `name` column included by default within default ransackable attributes causes ransack searches with search matchers based on `name` column to crash when appied on models which don’t have a `name` column. This PR removes the `name` column from default ransackable attributes and adds it explicitly on models which support search by name.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
