### PR TITLE
Introduce deprecation warning when using `Spree::Refund#perform!` callback

### DIFF
--- a/backend/spec/features/admin/orders/new_refund_spec.rb
+++ b/backend/spec/features/admin/orders/new_refund_spec.rb
@@ -12,12 +12,16 @@ RSpec.describe 'New Refund creation', :js do
 
   it 'creates a new refund' do
     visit spree.new_admin_order_payment_refund_path(order, payment)
+
     expect(page).not_to have_selector 'td', text: amount
+    expect(Spree::Deprecation).to receive(:warn)
+
     within '.new_refund' do
       fill_in 'refund_amount', with: amount
       select reason.name, from: 'Reason'
       click_button 'Refund'
     end
+
     expect(page).to have_content 'Refund has been successfully created!'
     expect(page).to have_selector 'td', text: amount
   end
@@ -25,6 +29,7 @@ RSpec.describe 'New Refund creation', :js do
   it 'disables the button at submit' do
     visit spree.new_admin_order_payment_refund_path(order, payment)
     page.execute_script "$('form').submit(function(e) { e.preventDefault()})"
+
     within '.new_refund' do
       fill_in 'refund_amount', with: amount
       select reason.name, from: 'Reason'

--- a/core/app/models/spree/payment/cancellation.rb
+++ b/core/app/models/spree/payment/cancellation.rb
@@ -31,7 +31,7 @@ module Spree
           if response = payment.payment_method.try_void(payment)
             payment.send(:handle_void_response, response)
           else
-            payment.refunds.create!(amount: payment.credit_allowed, reason: refund_reason)
+            payment.refunds.create!(amount: payment.credit_allowed, reason: refund_reason, perform_after_creation: false)
           end
         else
           # For payment methods not yet implemeting `try_void`

--- a/core/app/models/spree/refund.rb
+++ b/core/app/models/spree/refund.rb
@@ -8,6 +8,8 @@ module Spree
 
     has_many :log_entries, as: :source
 
+    attr_writer :perform_after_creation
+
     validates :payment, presence: true
     validates :reason, presence: true
     validates :transaction_id, presence: true, on: :update # can't require this on create because the before_create needs to run first
@@ -39,9 +41,18 @@ module Spree
 
     private
 
+    def perform_after_creation
+      return true if @perform_after_creation.nil?
+      @perform_after_creation
+    end
+
     # attempts to perform the refund.
     # raises an error if the refund fails.
     def perform!
+      if perform_after_creation
+        Spree::Deprecation.warn('From Solidus v3.0 onwards, #perform! will need to be explicitly called.')
+      end
+
       return true if transaction_id.present?
 
       credit_cents = money.cents

--- a/core/app/models/spree/reimbursement_type/reimbursement_helpers.rb
+++ b/core/app/models/spree/reimbursement_type/reimbursement_helpers.rb
@@ -34,7 +34,8 @@ module Spree
       refund = reimbursement.refunds.build({
         payment: payment,
         amount: amount,
-        reason: Spree::RefundReason.return_processing_reason
+        reason: Spree::RefundReason.return_processing_reason,
+        perform_after_creation: false
       })
 
       simulate ? refund.readonly! : refund.save!

--- a/core/lib/spree/testing_support/factories/refund_factory.rb
+++ b/core/lib/spree/testing_support/factories/refund_factory.rb
@@ -12,10 +12,13 @@ FactoryBot.define do
     end
 
     amount { 100.00 }
+    perform_after_creation { false }
     transaction_id { generate(:refund_transaction_id) }
+
     payment do
       association(:payment, state: 'completed', amount: payment_amount)
     end
+
     association(:reason, factory: :refund_reason)
   end
 end

--- a/core/spec/models/spree/payment/cancellation_spec.rb
+++ b/core/spec/models/spree/payment/cancellation_spec.rb
@@ -50,7 +50,8 @@ RSpec.describe Spree::Payment::Cancellation do
           before do
             payment.refunds.create!(
               amount: credit_amount,
-              reason: Spree::RefundReason.where(name: 'test').first_or_create
+              reason: Spree::RefundReason.where(name: 'test').first_or_create,
+              perform_after_creation: false
             )
           end
 


### PR DESCRIPTION
**Description**

This PR introduces a deprecation warning when relying on `Spree::Refund#perform!` implicitly (i.e.: calling it as a callback rather than calling it explicitly); aims to serve as a starting point for #1415

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
