### PR TITLE
Privatize PaymentMethod::Check#simulated_successful_billing_response

### DIFF
--- a/core/app/models/spree/payment_method/check.rb
+++ b/core/app/models/spree/payment_method/check.rb
@@ -33,6 +33,8 @@ module Spree
       false
     end
 
+    private
+
     def simulated_successful_billing_response
       ActiveMerchant::Billing::Response.new(true, "", {}, {})
     end


### PR DESCRIPTION
**Description**
This method should only be called from within itself. The response is
specific to this class and being able to obtain this response from
outside of it doesn't make sense to me.

**Other notes**
I did an `ag` for occurrences of this method in the project and it looks like it is only ever called from within the class so this is a safe change to make.

<img width="1129" alt="Screen Shot 2019-04-17 at 1 33 45 PM" src="https://user-images.githubusercontent.com/13607675/56319061-88de7a80-6115-11e9-8376-96e0788ade4a.png">

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
