### PR TITLE
Fix broken links in guides.

### DIFF
--- a/guides/source/developers/payments/payment-sources.html.md
+++ b/guides/source/developers/payments/payment-sources.html.md
@@ -12,7 +12,7 @@ Solidus includes some payment sources such as `Spree::CreditCard` and
 `Spree::StoreCredit`. However, your [payment method][payment-methods] could
 define any custom payment source in its `payment_source_class` method.
 
-[payment-methods]: payment-methods.html
+[payment-methods]: payment-methods.html.md
 
 ## Credit cards
 
@@ -31,4 +31,4 @@ storing customer data. See the [PCI Security Standards][pci] website for more
 information.
 
 [pci]: https://www.pcisecuritystandards.org
-[payment-processing]: payment-processing.html
+[payment-processing]: payment-processing.html.md


### PR DESCRIPTION
**Description**
These links both 404'd. They were missing parts of an extension.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
