### PR TITLE
More error codes to apply_coupon_code api response

### DIFF
--- a/core/app/models/spree/promotion/rules/first_order.rb
+++ b/core/app/models/spree/promotion/rules/first_order.rb
@@ -16,7 +16,7 @@ module Spree
 
           if user || email
             if !completed_orders.blank? && completed_orders.first != order
-              eligibility_errors.add(:base, eligibility_error_message(:not_first_order))
+              eligibility_errors.add(:base, eligibility_error_message(:not_first_order), error_code: :not_first_order)
             end
           end
 

--- a/core/app/models/spree/promotion/rules/item_total.rb
+++ b/core/app/models/spree/promotion/rules/item_total.rb
@@ -20,7 +20,7 @@ module Spree
           return false unless order.currency == preferred_currency
           item_total = order.item_total
           unless item_total.send(preferred_operator == 'gte' ? :>= : :>, BigDecimal(preferred_amount.to_s))
-            eligibility_errors.add(:base, ineligible_message)
+            eligibility_errors.add(:base, ineligible_message, error_code: ineligible_error_code)
           end
 
           eligibility_errors.empty?
@@ -37,6 +37,14 @@ module Spree
             eligibility_error_message(:item_total_less_than, amount: formatted_amount)
           else
             eligibility_error_message(:item_total_less_than_or_equal, amount: formatted_amount)
+          end
+        end
+
+        def ineligible_error_code
+          if preferred_operator == 'gte'
+            :item_total_less_than
+          else
+            :item_total_less_than_or_equal
           end
         end
       end

--- a/core/app/models/spree/promotion/rules/one_use_per_user.rb
+++ b/core/app/models/spree/promotion/rules/one_use_per_user.rb
@@ -11,10 +11,10 @@ module Spree
         def eligible?(order, _options = {})
           if order.user.present?
             if promotion.used_by?(order.user, [order])
-              eligibility_errors.add(:base, eligibility_error_message(:limit_once_per_user))
+              eligibility_errors.add(:base, eligibility_error_message(:limit_once_per_user), error_code: :limit_once_per_user)
             end
           else
-            eligibility_errors.add(:base, eligibility_error_message(:no_user_specified))
+            eligibility_errors.add(:base, eligibility_error_message(:no_user_specified), error_code: :no_user_specified)
           end
 
           eligibility_errors.empty?

--- a/core/app/models/spree/promotion/rules/product.rb
+++ b/core/app/models/spree/promotion/rules/product.rb
@@ -33,15 +33,15 @@ module Spree
           case preferred_match_policy
           when 'all'
             unless eligible_products.all? { |p| order.products.include?(p) }
-              eligibility_errors.add(:base, eligibility_error_message(:missing_product))
+              eligibility_errors.add(:base, eligibility_error_message(:missing_product), error_code: :missing_product)
             end
           when 'any'
             unless order.products.any? { |p| eligible_products.include?(p) }
-              eligibility_errors.add(:base, eligibility_error_message(:no_applicable_products))
+              eligibility_errors.add(:base, eligibility_error_message(:no_applicable_products), error_code: :no_applicable_products)
             end
           when 'none'
             unless order.products.none? { |p| eligible_products.include?(p) }
-              eligibility_errors.add(:base, eligibility_error_message(:has_excluded_product))
+              eligibility_errors.add(:base, eligibility_error_message(:has_excluded_product), error_code: :has_excluded_product)
             end
           else
             raise "unexpected match policy: #{preferred_match_policy.inspect}"

--- a/core/app/models/spree/promotion/rules/taxon.rb
+++ b/core/app/models/spree/promotion/rules/taxon.rb
@@ -27,21 +27,21 @@ module Spree
             end
 
             unless matches_all
-              eligibility_errors.add(:base, eligibility_error_message(:missing_taxon))
+              eligibility_errors.add(:base, eligibility_error_message(:missing_taxon), error_code: :missing_taxon)
             end
           when 'any'
             unless order_taxons.where(id: rule_taxon_ids_with_children).exists?
-              eligibility_errors.add(:base, eligibility_error_message(:no_matching_taxons))
+              eligibility_errors.add(:base, eligibility_error_message(:no_matching_taxons), error_code: :no_matching_taxons)
             end
           when 'none'
             if order_taxons.where(id: rule_taxon_ids_with_children).exists?
-              eligibility_errors.add(:base, eligibility_error_message(:has_excluded_taxon))
+              eligibility_errors.add(:base, eligibility_error_message(:has_excluded_taxon), error_code: :has_excluded_taxon)
             end
           else
             # Change this to an exception in a future version of Solidus
             warn_invalid_match_policy(assume: 'any')
             unless order_taxons.where(id: rule_taxon_ids_with_children).exists?
-              eligibility_errors.add(:base, eligibility_error_message(:no_matching_taxons))
+              eligibility_errors.add(:base, eligibility_error_message(:no_matching_taxons), error_code: :no_matching_taxons)
             end
           end
 

--- a/core/app/models/spree/promotion/rules/user_logged_in.rb
+++ b/core/app/models/spree/promotion/rules/user_logged_in.rb
@@ -10,7 +10,7 @@ module Spree
 
         def eligible?(order, _options = {})
           unless order.user.present?
-            eligibility_errors.add(:base, eligibility_error_message(:no_user_specified))
+            eligibility_errors.add(:base, eligibility_error_message(:no_user_specified), error_code: :no_user_specified)
           end
           eligibility_errors.empty?
         end

--- a/core/spec/models/spree/promotion/rules/first_order_spec.rb
+++ b/core/spec/models/spree/promotion/rules/first_order_spec.rb
@@ -51,6 +51,11 @@ RSpec.describe Spree::Promotion::Rules::FirstOrder, type: :model do
             expect(rule.eligibility_errors.full_messages.first).
               to eq "This coupon code can only be applied to your first order."
           end
+          it "sets an error code" do
+            rule.eligible?(order)
+            expect(rule.eligibility_errors.details[:base].first[:error_code]).
+              to eq :not_first_order
+          end
         end
       end
     end
@@ -70,6 +75,11 @@ RSpec.describe Spree::Promotion::Rules::FirstOrder, type: :model do
           rule.eligible?(order)
           expect(rule.eligibility_errors.full_messages.first).
             to eq "This coupon code can only be applied to your first order."
+        end
+        it "sets an error code" do
+          rule.eligible?(order)
+          expect(rule.eligibility_errors.details[:base].first[:error_code]).
+            to eq :not_first_order
         end
       end
     end

--- a/core/spec/models/spree/promotion/rules/item_total_spec.rb
+++ b/core/spec/models/spree/promotion/rules/item_total_spec.rb
@@ -44,6 +44,11 @@ RSpec.describe Spree::Promotion::Rules::ItemTotal, type: :model do
         expect(rule.eligibility_errors.full_messages.first).
           to eq "This coupon code can't be applied to orders less than or equal to $50.00."
       end
+      it "sets an error code" do
+        rule.eligible?(order)
+        expect(rule.eligibility_errors.details[:base].first[:error_code]).
+          to eq :item_total_less_than_or_equal
+      end
     end
 
     context "when item total is lower than preferred amount" do
@@ -57,6 +62,11 @@ RSpec.describe Spree::Promotion::Rules::ItemTotal, type: :model do
         rule.eligible?(order)
         expect(rule.eligibility_errors.full_messages.first).
           to eq "This coupon code can't be applied to orders less than or equal to $50.00."
+      end
+      it "sets an error code" do
+        rule.eligible?(order)
+        expect(rule.eligibility_errors.details[:base].first[:error_code]).
+          to eq :item_total_less_than_or_equal
       end
     end
   end
@@ -107,6 +117,11 @@ RSpec.describe Spree::Promotion::Rules::ItemTotal, type: :model do
         rule.eligible?(order)
         expect(rule.eligibility_errors.full_messages.first).
           to eq "This coupon code can't be applied to orders less than $50.00."
+      end
+      it "sets an error code" do
+        rule.eligible?(order)
+        expect(rule.eligibility_errors.details[:base].first[:error_code]).
+          to eq :item_total_less_than
       end
     end
   end

--- a/core/spec/models/spree/promotion/rules/one_use_per_user_spec.rb
+++ b/core/spec/models/spree/promotion/rules/one_use_per_user_spec.rb
@@ -24,6 +24,11 @@ RSpec.describe Spree::Promotion::Rules::OneUsePerUser, type: :model do
           expect(rule.eligibility_errors.full_messages.first).
             to eq "This coupon code can only be used once per user."
         end
+        it "sets an error code" do
+          rule.eligible?(order)
+          expect(rule.eligibility_errors.details[:base].first[:error_code]).
+            to eq :limit_once_per_user
+        end
       end
 
       context 'when the user has not used this promotion before' do
@@ -38,6 +43,11 @@ RSpec.describe Spree::Promotion::Rules::OneUsePerUser, type: :model do
         subject
         expect(rule.eligibility_errors.full_messages.first).
           to eq "You need to login before applying this coupon code."
+      end
+      it "sets an error code" do
+        rule.eligible?(order)
+        expect(rule.eligibility_errors.details[:base].first[:error_code]).
+          to eq :no_user_specified
       end
     end
   end

--- a/core/spec/models/spree/promotion/rules/product_spec.rb
+++ b/core/spec/models/spree/promotion/rules/product_spec.rb
@@ -38,6 +38,11 @@ RSpec.describe Spree::Promotion::Rules::Product, type: :model do
           expect(rule.eligibility_errors.full_messages.first).
             to eq "You need to add an applicable product before applying this coupon code."
         end
+        it "sets an error code" do
+          rule.eligible?(order)
+          expect(rule.eligibility_errors.details[:base].first[:error_code]).
+            to eq :no_applicable_products
+        end
       end
     end
 
@@ -61,6 +66,11 @@ RSpec.describe Spree::Promotion::Rules::Product, type: :model do
           expect(rule.eligibility_errors.full_messages.first).
             to eq "This coupon code can't be applied because you don't have all of the necessary products in your cart."
         end
+        it "sets an error code" do
+          rule.eligible?(order)
+          expect(rule.eligibility_errors.details[:base].first[:error_code]).
+            to eq :missing_product
+        end
       end
     end
 
@@ -83,6 +93,11 @@ RSpec.describe Spree::Promotion::Rules::Product, type: :model do
           rule.eligible?(order)
           expect(rule.eligibility_errors.full_messages.first).
             to eq "Your cart contains a product that prevents this coupon code from being applied."
+        end
+        it "sets an error code" do
+          rule.eligible?(order)
+          expect(rule.eligibility_errors.details[:base].first[:error_code]).
+            to eq :has_excluded_product
         end
       end
     end

--- a/core/spec/models/spree/promotion/rules/taxon_spec.rb
+++ b/core/spec/models/spree/promotion/rules/taxon_spec.rb
@@ -48,6 +48,11 @@ RSpec.describe Spree::Promotion::Rules::Taxon, type: :model do
           expect(rule.eligibility_errors.full_messages.first).
             to eq "You need to add a product from an applicable category before applying this coupon code."
         end
+        it "sets an error code" do
+          rule.eligible?(order)
+          expect(rule.eligibility_errors.details[:base].first[:error_code]).
+            to eq :no_matching_taxons
+        end
       end
 
       context 'when a product has a taxon child of a taxon rule' do
@@ -82,6 +87,11 @@ RSpec.describe Spree::Promotion::Rules::Taxon, type: :model do
           rule.eligible?(order)
           expect(rule.eligibility_errors.full_messages.first).
             to eq "You need to add a product from all applicable categories before applying this coupon code."
+        end
+        it "sets an error code" do
+          rule.eligible?(order)
+          expect(rule.eligibility_errors.details[:base].first[:error_code]).
+            to eq :missing_taxon
         end
       end
 
@@ -121,6 +131,11 @@ RSpec.describe Spree::Promotion::Rules::Taxon, type: :model do
           rule.eligible?(order)
           expect(rule.eligibility_errors.full_messages.first).
             to eq "Your cart contains a product from an excluded category that prevents this coupon code from being applied."
+        end
+        it "sets an error code" do
+          rule.eligible?(order)
+          expect(rule.eligibility_errors.details[:base].first[:error_code]).
+            to eq :has_excluded_taxon
         end
       end
     end

--- a/core/spec/models/spree/promotion/rules/user_logged_in_spec.rb
+++ b/core/spec/models/spree/promotion/rules/user_logged_in_spec.rb
@@ -23,6 +23,11 @@ RSpec.describe Spree::Promotion::Rules::UserLoggedIn, type: :model do
         expect(rule.eligibility_errors.full_messages.first).
           to eq "You need to login before applying this coupon code."
       end
+      it "sets an error code" do
+        rule.eligible?(order)
+        expect(rule.eligibility_errors.details[:base].first[:error_code]).
+          to eq :no_user_specified
+      end
     end
   end
 end


### PR DESCRIPTION
Makes it possible for decoupled frontend to identify error and display custom error messages.


**Description**

With the current implementation, if a promotion is not eligible, the api endpoint returns the translated eligibility error message. There is no error code sent with the response.

This PR adds error codes to some of the api error responses. If no code is present in the error, the generic `coupon_code_not_eligible` code is returned.

It makes it possible for a decoupled frontend to identify the error when applying a coupon code and display a custom error message.

The only way I found to pass the error code from a promotion rule to the coupon promotion handler is by adding the code as a detail to the error, see: https://guides.rubyonrails.org/active_record_validations.html#validations-overview-errors-details
It is then possible to retrieve the code in the coupon promotion handler with: `promotion.eligibility_errors.details[:base].first[:code]`

Let me know if there's a better way to do that or if I can improve the PR in any other way.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
