### PR TITLE
[v2.8] Backport for some required bugfixes

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/views/stock/edit_stock_item_row.js
+++ b/backend/app/assets/javascripts/spree/backend/views/stock/edit_stock_item_row.js
@@ -13,7 +13,8 @@ Spree.Views.Stock.EditStockItemRow = Backbone.View.extend({
     "click .submit": "onSubmit",
     "submit form": "onSubmit",
     "click .cancel": "onCancel",
-    'input [name="count_on_hand"]': "countOnHandChanged"
+    'input [name="count_on_hand"]': "countOnHandChanged",
+    'input [name="backorderable"]': "backorderableChanged"
   },
 
   template: HandlebarsTemplates['stock_items/stock_location_stock_item'],
@@ -43,6 +44,20 @@ Spree.Views.Stock.EditStockItemRow = Backbone.View.extend({
     this.render();
   },
 
+  onChange: function() {
+    var count_on_hand_changed = this.previousAttributes.count_on_hand != this.model.attributes.count_on_hand;
+    var backorderable_changed = this.previousAttributes.backorderable != this.model.attributes.backorderable;
+    var changed = count_on_hand_changed || backorderable_changed;
+
+    this.$el.toggleClass('changed', changed);
+  },
+
+  backorderableChanged: function(ev) {
+    this.model.set("backorderable", ev.target.checked);
+
+    this.onChange();
+  },
+
   countOnHandChanged: function(ev) {
     var diff = parseInt(ev.currentTarget.value), newCount;
     if (isNaN(diff)) diff = 0;
@@ -56,7 +71,8 @@ Spree.Views.Stock.EditStockItemRow = Backbone.View.extend({
       this.model.set("count_on_hand", newCount);
       this.$count_on_hand_display.text(newCount);
     }
-    this.$el.toggleClass('changed', diff !== 0);
+
+    this.onChange();
   },
 
   onSuccess: function() {

--- a/backend/app/assets/stylesheets/spree/backend/globals/_functions.scss
+++ b/backend/app/assets/stylesheets/spree/backend/globals/_functions.scss
@@ -1,5 +1,5 @@
 // Make color very close to white
-@function very-light($color, $adjust: 3){  
+@function very-light($color, $adjust: 3){
   @if type-of($adjust) == 'number' and $adjust > 0 {
     @for $i from 0 through 100 {
       @if lighten($color, $i) == white and ($i - $adjust) > $adjust {
@@ -10,6 +10,7 @@
   @else {
     @debug "Please correct $adjust value. It should be number and larger then 0. Currently it is '#{type-of($adjust)}' with value '#{$adjust}'"
   }
+  @return $color;
 };
 
 // Quick fix for dynamic variables missing in SASS

--- a/backend/spec/features/admin/products/stock_management_spec.rb
+++ b/backend/spec/features/admin/products/stock_management_spec.rb
@@ -57,9 +57,26 @@ describe "Product Stock", type: :feature do
       expect(stock_item.stock_movements.first.quantity).to eq(-4)
     end
 
+    it "can toggle backorderable", js: true do
+      toggle_backorderable(value: false)
+
+      click_link "Product Stock"
+      within("tr#spree_variant_#{variant.id}") do
+        expect(find(:css, "input[type='checkbox']")).not_to be_checked
+      end
+    end
+
     def adjust_count_on_hand(count_on_hand)
       within("tr#spree_variant_#{variant.id}") do
         find(:css, "input[type='number']").set(count_on_hand)
+        click_icon :check
+      end
+      expect(page).to have_content('Updated Successfully')
+    end
+
+    def toggle_backorderable(value: true)
+      within("tr#spree_variant_#{variant.id}") do
+        find(:css, "input[type='checkbox']").set(value)
         click_icon :check
       end
       expect(page).to have_content('Updated Successfully')

--- a/core/app/models/spree/store_credit.rb
+++ b/core/app/models/spree/store_credit.rb
@@ -39,7 +39,7 @@ class Spree::StoreCredit < Spree::PaymentSource
   before_validation :associate_credit_type
   before_validation :validate_category_unchanged, on: :update
   before_destroy :validate_no_amount_used
-  validate :validate_no_amount_used, if: :discarded?
+  before_discard :validate_no_amount_used
 
   attr_accessor :action, :action_amount, :action_originator, :action_authorization_code, :store_credit_reason
 

--- a/core/app/models/spree/store_credit.rb
+++ b/core/app/models/spree/store_credit.rb
@@ -268,6 +268,7 @@ class Spree::StoreCredit < Spree::PaymentSource
   def validate_no_amount_used
     if amount_used > 0
       errors.add(:amount_used, 'is greater than zero. Can not delete store credit')
+      throw :abort
     end
   end
 


### PR DESCRIPTION
This PR is a backport into v2.8 of: 

- Fix stock item form to allow changing backorder value #3159
- Ensure return from CSS function #3146
- Fixes for discard 1.1.0 #3202

A new 2.8.x patch version will be released after we merge this.