### PR TITLE
Prevent promotion rule to show user multiple times

### DIFF
--- a/api/app/controllers/spree/api/resource_controller.rb
+++ b/api/app/controllers/spree/api/resource_controller.rb
@@ -9,7 +9,7 @@ class Spree::Api::ResourceController < Spree::Api::BaseController
       ids = params[:ids].split(",").flatten
       collection_scope = collection_scope.where(id: ids)
     else
-      collection_scope = collection_scope.ransack(params[:q]).result
+      collection_scope = collection_scope.ransack(params[:q]).result(distinct: true)
     end
 
     @collection = paginate(collection_scope)


### PR DESCRIPTION
**Description**

The ransack query used to fetch users for the promotion rule dropdown checked for attributes that may return repeated results. This adds the `distinct` flag in the result's call to prevent repeated records to be shown.
Fixes #3183 

**This affects the API's `ResourceController`, so the scope of the update may be wide, although the change will likely fix un-encountered issues (IMO we shouldn't be returning repeated records independently of the API call, but open to discuss)**

**Checklist:**
- [X] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [X] I have added a detailed description into each commit message
- ~[ ] I have updated Guides and README accordingly to this change (if needed)~
- [X] I have added tests to cover this change (if needed)
