### PR TITLE
Fix issue 3164 - generate shipments for backend-added products when necessary

### DIFF
--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -53,11 +53,72 @@ describe "Order Details", type: :feature, js: true do
         end
       end
 
-      it "can add an item" do
-        add_line_item "spree t-shirt", quantity: 2
+      context 'when adding an item' do
+        context 'when the item can be added to the existing shipment' do
+          it "adds the item to the existing shipment" do
+            expect(order.shipments.count).to be 1
 
-        within("#order_total") do
-          expect(page).to have_content("$80.00")
+            add_line_item "spree t-shirt", quantity: 2
+
+            within("#order_total") do
+              expect(page).to have_content("$80.00")
+            end
+
+            expect(order.shipments.count).to be 1
+          end
+        end
+
+        context 'when the items cannot be added to the existing shipment' do
+          before do
+            create :payment, order: order, amount: order.amount
+            visit spree.admin_order_payments_path(order)
+            find('.fa-capture').click
+          end
+
+          it "adds an item creating a new shipment and changes the payment status" do
+            within('#payment_status') do
+              expect(page).to have_content("Paid")
+            end
+
+            visit spree.cart_admin_order_path(order)
+
+            stock_location_ids = (0..1).map do |n|
+              create :stock_location, name: "Warehouse #{n}", backorderable_default: false
+            end.map(&:id)
+
+            product = create :product
+
+            product.stock_items.where.not(stock_location_id: stock_location_ids).discard_all
+
+            product.stock_items.where(stock_location_id: stock_location_ids).each do |stock_item|
+              stock_item.set_count_on_hand 1
+            end
+
+            expect(order.shipments.count).to be 1
+
+            add_line_item product.name, quantity: 2
+
+            within 'table.line-items' do
+              expect(page).to have_content product.name
+              expect(page).to have_content product.price
+            end
+
+            expect(order.shipments.count).to be 3
+
+            within("#order_total") do
+              expect(page).to have_content("$79.98")
+            end
+
+            within('#payment_status') do
+              expect(page).to have_content("Balance due")
+            end
+
+            click_link 'Shipments'
+
+            order.shipments.each do |shipment|
+              expect(page).to have_content shipment.number
+            end
+          end
         end
       end
 

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -559,6 +559,13 @@ module Spree
       end
     end
 
+    def create_shipments_for_line_item(line_item)
+      units = Spree::Stock::InventoryUnitBuilder.new(self).missing_units_for_line_item(line_item)
+      Spree::Config.stock.coordinator_class.new(self, units).shipments.each do |shipment|
+        shipments << shipment
+      end
+    end
+
     def apply_shipping_promotions
       Spree::PromotionHandler::Shipping.new(self).activate
       recalculate

--- a/core/app/models/spree/order_inventory.rb
+++ b/core/app/models/spree/order_inventory.rb
@@ -24,7 +24,13 @@ module Spree
         desired_quantity = line_item.quantity - existing_quantity
         if desired_quantity > 0
           shipment ||= determine_target_shipment(desired_quantity)
-          add_to_shipment(shipment, desired_quantity)
+          if shipment
+            add_to_shipment(shipment, desired_quantity)
+          else
+            order.create_shipments_for_line_item(line_item).each do |new_shipment|
+              new_shipment.finalize!
+            end
+          end
         elsif desired_quantity < 0
           remove(-desired_quantity, shipment)
         end

--- a/core/app/models/spree/order_inventory.rb
+++ b/core/app/models/spree/order_inventory.rb
@@ -23,7 +23,7 @@ module Spree
         existing_quantity = inventory_units.count
         desired_quantity = line_item.quantity - existing_quantity
         if desired_quantity > 0
-          shipment ||= determine_target_shipment
+          shipment ||= determine_target_shipment(desired_quantity)
           add_to_shipment(shipment, desired_quantity)
         elsif desired_quantity < 0
           remove(-desired_quantity, shipment)
@@ -48,12 +48,18 @@ module Spree
     # Returns either one of the shipment:
     #
     # first unshipped that already includes this variant
-    # first unshipped that's leaving from a stock_location that stocks this variant
-    def determine_target_shipment
+    # first unshipped that's leaving from a stock_location that stocks this variant, with availability check
+    # first unshipped that's leaving from a stock_location that stocks this variant, without availability check
+    def determine_target_shipment(quantity)
       potential_shipments = order.shipments.select(&:ready_or_pending?)
 
       potential_shipments.detect do |shipment|
         shipment.include?(variant)
+      end || potential_shipments.detect do |shipment|
+        stock_item = shipment.stock_location.stock_item(variant.id)
+        if stock_item
+          stock_item.backorderable? || stock_item.count_on_hand >= quantity
+        end
       end || potential_shipments.detect do |shipment|
         variant.stock_location_ids.include?(shipment.stock_location_id)
       end

--- a/core/app/models/spree/stock/inventory_unit_builder.rb
+++ b/core/app/models/spree/stock/inventory_unit_builder.rb
@@ -9,13 +9,24 @@ module Spree
 
       def units
         @order.line_items.flat_map do |line_item|
-          Array.new(line_item.quantity) do
-            Spree::InventoryUnit.new(
-              pending: true,
-              variant: line_item.variant,
-              line_item: line_item
-            )
-          end
+          build_units(line_item, line_item.quantity)
+        end
+      end
+
+      def missing_units_for_line_item(line_item)
+        quantity = line_item.quantity - line_item.inventory_units.count
+        build_units(line_item, quantity)
+      end
+
+      private
+
+      def build_units(line_item, quantity)
+        Array.new(quantity) do
+          Spree::InventoryUnit.new(
+            pending: true,
+            variant: line_item.variant,
+            line_item: line_item
+          )
         end
       end
     end

--- a/core/spec/models/spree/order_inventory_spec.rb
+++ b/core/spec/models/spree/order_inventory_spec.rb
@@ -308,4 +308,23 @@ RSpec.describe Spree::OrderInventory, type: :model do
       end
     end
   end
+
+  context 'when the order has no suitable shipment for the variant' do
+    let(:new_line_item) { create :line_item, order: order }
+
+    before do
+      new_line_item.inventory_units.destroy_all
+      new_line_item.variant.stock_items.discard_all
+      create :stock_location
+      order.line_items.reload
+    end
+
+    subject { described_class.new(order, new_line_item) }
+
+    it 'creates a new shipment' do
+      expect do
+        subject.verify
+      end.to change { order.shipments.count }.from(1).to 2
+    end
+  end
 end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -1684,4 +1684,16 @@ RSpec.describe Spree::Order, type: :model do
       end
     end
   end
+
+  describe '#create_shipments_for_line_item' do
+    subject { create :order_with_line_items }
+
+    let(:line_item) { build(:line_item) }
+
+    it 'creates at least one new shipment for the order' do
+      expect do
+        subject.create_shipments_for_line_item(line_item)
+      end.to change { subject.shipments.count }.by 1
+    end
+  end
 end

--- a/core/spec/models/spree/stock/inventory_unit_builder_spec.rb
+++ b/core/spec/models/spree/stock/inventory_unit_builder_spec.rb
@@ -29,6 +29,29 @@ module Spree
           expect(subject.units.map(&:pending).uniq).to eq [true]
         end
       end
+
+      describe '#missing_units_for_line_item' do
+        context 'when all inventory units are missing' do
+          it 'builds all inventory units for the line item' do
+            units = subject.missing_units_for_line_item(line_item_2)
+            expect(units.size).to be 2
+            expect(units).to be_all { |unit| unit.line_item == line_item_2 }
+          end
+        end
+
+        context 'when some inventory units are already present' do
+          before do
+            line_item_2.inventory_units << build(:inventory_unit)
+            line_item_2.save!
+          end
+
+          it 'builds only the missing inventory unit' do
+            units = subject.missing_units_for_line_item(line_item_2)
+            expect(units.size).to be 1
+            expect(units.first.line_item).to eql line_item_2
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
**Description**

This PR fixes issue #3164. See the issue for further details.

An error occurs when trying to add a product to an existing completed order in the backend and the product stock is not compatible with existing shipments. 

This PR adds the ability, when necessary, to generate new shipments also when the order is  completed.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change (if needed)
