### PR TITLE
Fixes for discard 1.1.0

### DIFF
--- a/core/app/models/spree/store_credit.rb
+++ b/core/app/models/spree/store_credit.rb
@@ -39,7 +39,7 @@ class Spree::StoreCredit < Spree::PaymentSource
   before_validation :associate_credit_type
   before_validation :validate_category_unchanged, on: :update
   before_destroy :validate_no_amount_used
-  validate :validate_no_amount_used, if: :discarded?
+  before_discard :validate_no_amount_used
 
   attr_accessor :action, :action_amount, :action_originator, :action_authorization_code, :store_credit_reason
 

--- a/core/app/models/spree/store_credit.rb
+++ b/core/app/models/spree/store_credit.rb
@@ -268,6 +268,7 @@ class Spree::StoreCredit < Spree::PaymentSource
   def validate_no_amount_used
     if amount_used > 0
       errors.add(:amount_used, 'is greater than zero. Can not delete store credit')
+      throw :abort
     end
   end
 


### PR DESCRIPTION
**Description**

This PR fixes a bug with the last version of discard. I think the bug was more related to how we were using discard than to the discard update itself.

**TLDR;**

`discarded?` was returning true, even when the record updated to `deleted_at` wasn't yet persisted. This behavior seems to be changed (probably correctly?) so this validation

```
validate :validate_no_amount_used, if: :discarded?
```

was never performed on the first `discard` call, which is exactly what we need. 

This PR changes that way to validate the record into a `before_discard` callback (similar to what we have with the `after_destroy`), [throwing `abort` to interrupt the callback chain](https://api.rubyonrails.org/classes/ActiveModel/Callbacks.html).

Asking for a @jarednorman review as well, since he's the new discard maintainer. 🎉 


**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
