### PR TITLE
Fix partner image

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Support this project by becoming a Key Stakeholder. Your logo will show up here 
 
 <a href="https://nebulab.it/"><img src="https://images.opencollective.com/proxy/images?src=https%3A%2F%2Fopencollective-production.s3-us-west-1.amazonaws.com%2F3cc3c170-20cc-11e9-9582-214168b65c9a.png&height=100"></a>
 <a href="https://www.enginecommerce.com/"><img src="https://images.opencollective.com/proxy/images?src=https%3A%2F%2Flogo.clearbit.com%2Fenginecommerce.com&height=100"></a>
-<a href="https://supergood.software/"><img src="https://images.opencollective.com/proxy/images?src=https%3A%2F%2Flogo.clearbit.com%2Fsupergood.software&height=100"></a>
+<a href="https://supergood.software/"><img src="https://images.opencollective.com/proxy/images?src=https%3A%2F%2Fopencollective-production.s3-us-west-1.amazonaws.com%2F3bbb1440-727f-11e9-a366-37673cc38cee.png&height=100"></a>
 
 ## Summary
 


### PR DESCRIPTION
Not sure what happened, but the Super Good logo disappeared from Open Collective. It has been reuploaded, and this just updates the URL in the README. You can see [here](https://github.com/jarednorman/solidus/tree/super-good) that it is actually fixed.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)