### PR TITLE
Lock jbuilder at 2.8.0

### DIFF
--- a/api/solidus_api.gemspec
+++ b/api/solidus_api.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 2.2.2'
   gem.required_rubygems_version = '>= 1.8.23'
 
-  gem.add_dependency 'jbuilder', '~> 2.8'
+  gem.add_dependency 'jbuilder', '~> 2.8.0'
   gem.add_dependency 'kaminari-activerecord', '~> 1.1'
   gem.add_dependency 'responders'
   gem.add_dependency 'solidus_core', gem.version

--- a/backend/solidus_backend.gemspec
+++ b/backend/solidus_backend.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'coffee-rails'
   s.add_dependency 'font-awesome-rails', '~> 4.0'
-  s.add_dependency 'jbuilder', '~> 2.8'
+  s.add_dependency 'jbuilder', '~> 2.8.0'
   s.add_dependency 'jquery-rails'
   s.add_dependency 'kaminari', '~> 1.1'
   s.add_dependency 'sassc-rails'


### PR DESCRIPTION
The last 2.9.0 release is breaking our API. For the test failure please see:

https://circleci.com/gh/solidusio/solidus/12040#tests/containers/2


**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
