### PR TITLE
Improve jbuilder serialization for Oj gem

### DIFF
--- a/api/app/helpers/spree/api/api_helpers.rb
+++ b/api/app/helpers/spree/api/api_helpers.rb
@@ -183,6 +183,10 @@ module Spree
           @@variant_attributes
         end
       end
+
+      def total_on_hand_for(object)
+        object.total_on_hand.finite? ? object.total_on_hand : nil
+      end
     end
   end
 end

--- a/api/app/views/spree/api/products/_product.json.jbuilder
+++ b/api/app/views/spree/api/products/_product.json.jbuilder
@@ -2,7 +2,8 @@
 
 @product_attributes ||= product_attributes
 json.cache! [I18n.locale, @current_user_roles.include?('admin'), current_pricing_options, @product_attributes, @exclude_data, product] do
-  json.(product, *@product_attributes)
+  json.(product, *(@product_attributes - [:total_on_hand]))
+  json.total_on_hand(total_on_hand_for(product))
   json.price(product.price_for(current_pricing_options).try(:to_d))
   json.display_price(product.price_for(current_pricing_options).to_s)
 

--- a/api/app/views/spree/api/variants/_small.json.jbuilder
+++ b/api/app/views/spree/api/variants/_small.json.jbuilder
@@ -9,10 +9,7 @@ json.cache! [I18n.locale, current_pricing_options, variant] do
   json.in_stock(variant.in_stock?)
   json.is_backorderable(variant.is_backorderable?)
 
-  # We can't represent Float::INFINITY in JSON
-  # Under JSON this woulb be NULL
-  # Under oj this would error
-  json.total_on_hand(variant.should_track_inventory? ? variant.total_on_hand : nil)
+  json.total_on_hand(total_on_hand_for(variant))
 
   json.is_destroyed(variant.destroyed?)
   json.option_values(variant.option_values) do |option_value|

--- a/api/spec/requests/spree/api/products_controller_spec.rb
+++ b/api/spec/requests/spree/api/products_controller_spec.rb
@@ -295,6 +295,25 @@ module Spree
           expect(json_response['shipping_category_id']).to eq shipping_id
         end
 
+        context "when tracking is disabled" do
+          before { Config.track_inventory_levels = false }
+
+          it "still displays valid json with total_on_hand Float::INFINITY" do
+            post spree.api_products_path, params: {
+              product: {
+                name: "The Other Product",
+                price: 19.99,
+                shipping_category_id: create(:shipping_category).id
+              }
+            }
+
+            expect(response.status).to eq(201)
+            expect(json_response['total_on_hand']).to eq nil
+          end
+
+          after { Config.track_inventory_levels = true }
+        end
+
         it "puts the created product in the given taxon" do
           product_data[:taxon_ids] = taxon_1.id.to_s
           post spree.api_products_path, params: { product: product_data }

--- a/api/spec/requests/spree/api/variants_controller_spec.rb
+++ b/api/spec/requests/spree/api/variants_controller_spec.rb
@@ -248,6 +248,20 @@ module Spree
           expect(json_response["variant_properties"].first).to have_attributes(expected_attrs)
         end
       end
+
+      context "when tracking is disabled" do
+        before do
+          Config.track_inventory_levels = false
+          subject
+        end
+
+        it "still displays valid json with total_on_hand Float::INFINITY" do
+          expect(response.status).to eq(200)
+          expect(json_response['total_on_hand']).to eq nil
+        end
+
+        after { Config.track_inventory_levels = true }
+      end
     end
 
     it "can learn how to create a new variant" do


### PR DESCRIPTION
**Description**

This PR makes sure we are always nullifying total_on_hand before passing trying to serialize it, if it is a `Float::Infinity`, which was causing [issues with `oj`](https://github.com/solidusio/solidus/pull/2495#issuecomment-365352792).

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message