### PR TITLE
Add CodeTriage badge and fix OpenCollective badges links

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ combine it with your own custom frontend, admin interface, and API.
 [![Slack](http://slack.solidus.io/badge.svg)](http://slack.solidus.io)
 [![Backers on Open Collective](https://opencollective.com/solidus/backers/badge.svg)](#backers)
 [![Sponsors on Open Collective](https://opencollective.com/solidus/sponsors/badge.svg)](#sponsors)
+[![Open Source Helpers](https://www.codetriage.com/solidusio/solidus/badges/users.svg)](https://www.codetriage.com/solidusio/solidus)
 
 ### Supported by
 

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ combine it with your own custom frontend, admin interface, and API.
 [![Gem](https://img.shields.io/gem/v/solidus.svg)](https://rubygems.org/gems/solidus)
 [![License](http://img.shields.io/badge/license-BSD-yellowgreen.svg)](LICENSE.md)
 [![Slack](http://slack.solidus.io/badge.svg)](http://slack.solidus.io)
-[![Backers on Open Collective](https://opencollective.com/solidus/backers/badge.svg)](#backers)
-[![Sponsors on Open Collective](https://opencollective.com/solidus/sponsors/badge.svg)](#sponsors)
+[![Backers on Open Collective](https://opencollective.com/solidus/backers/badge.svg)](https://opencollective.com/solidus)
+[![Sponsors on Open Collective](https://opencollective.com/solidus/sponsors/badge.svg)](https://opencollective.com/solidus)
 [![Open Source Helpers](https://www.codetriage.com/solidusio/solidus/badges/users.svg)](https://www.codetriage.com/solidusio/solidus)
 
 ### Supported by


### PR DESCRIPTION
**Description**

This PR adds a [CodeTriage](https://www.codetriage.com/) badge and fixes OpenCollective badges links, which currently refer to not existing README sections.

**Checklist:**

- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
