### PR TITLE
Add OriginalPayment reimbursement type in seeds

### DIFF
--- a/core/db/default/spree/store_credit.rb
+++ b/core/db/default/spree/store_credit.rb
@@ -16,6 +16,7 @@ Spree::StoreCreditType.create_with(priority: 1).find_or_create_by!(name: Spree::
 Spree::StoreCreditType.create_with(priority: 2).find_or_create_by!(name: Spree::StoreCreditType::NON_EXPIRING)
 
 Spree::ReimbursementType.create_with(name: "Store Credit").find_or_create_by!(type: 'Spree::ReimbursementType::StoreCredit')
+Spree::ReimbursementType.create_with(name: "Original").find_or_create_by!(type: 'Spree::ReimbursementType::OriginalPayment')
 
 Spree::StoreCreditCategory.find_or_create_by!(name: 'Gift Card')
 


### PR DESCRIPTION
**Description**

When running seeds without migrations (for example in a staging environment when we load the schema or after a `db:reset`) it will not create this reimbursement type, which is instead required.

See https://github.com/solidusio/solidus/issues/1502 for more context.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
