### PR TITLE
Add preferred_reimbursement_type_id as permitted attributes

### DIFF
--- a/api/spec/requests/spree/api/return_authorizations_controller_spec.rb
+++ b/api/spec/requests/spree/api/return_authorizations_controller_spec.rb
@@ -17,13 +17,21 @@ module Spree
       it "can create a new return authorization" do
         stock_location = FactoryBot.create(:stock_location)
         reason = FactoryBot.create(:return_reason)
+        reimbursement = FactoryBot.create(:reimbursement_type)
+        unit = FactoryBot.create(:inventory_unit)
         rma_params = { stock_location_id: stock_location.id,
                        return_reason_id: reason.id,
+                       return_items_attributes: [{
+                         inventory_unit_id: unit.id,
+                         preferred_reimbursement_type_id: reimbursement.id,
+                       }],
                        memo: "Defective" }
         post spree.api_order_return_authorizations_path(order), params: { order_id: order.number, return_authorization: rma_params }
         expect(response.status).to eq(201)
         expect(json_response).to have_attributes(attributes)
         expect(json_response["state"]).not_to be_blank
+        return_authorization = Spree::ReturnAuthorization.last
+        expect(return_authorization.return_items.first.preferred_reimbursement_type).to eql reimbursement
       end
     end
 

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -79,7 +79,7 @@ module Spree
 
     @@property_attributes = [:name, :presentation]
 
-    @@return_authorization_attributes = [:memo, :stock_location_id, :return_reason_id, return_items_attributes: [:inventory_unit_id, :exchange_variant_id, :return_reason_id]]
+    @@return_authorization_attributes = [:memo, :stock_location_id, :return_reason_id, return_items_attributes: [:inventory_unit_id, :exchange_variant_id, :return_reason_id, :preferred_reimbursement_type_id]]
 
     @@shipment_attributes = [
       :special_instructions, :stock_location_id, :id, :tracking,


### PR DESCRIPTION

**Description**

When using the api, we can create return authorizations but cannot set the reimbursement type. The reason being the field `preferred_reimbursement_type_id` was not included in the list of **permitted attributes.**

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
