### PR TITLE
Fix non thread safe gateway initialization

### DIFF
--- a/core/app/models/spree/billing_integration.rb
+++ b/core/app/models/spree/billing_integration.rb
@@ -9,8 +9,13 @@ module Spree
 
     def gateway
       integration_options = options
-      ActiveMerchant::Billing::Base.integration_mode = integration_options[:server].to_sym
-      integration_options[:test] = true if integration_options[:test_mode]
+
+      # All environments except production considered to be test
+      test_server = integration_options[:server] != 'production'
+      test_mode = integration_options[:test_mode]
+
+      integration_options[:test] = (test_server || test_mode)
+
       @gateway ||= gateway_class.new(integration_options)
     end
 

--- a/core/app/models/spree/payment_method.rb
+++ b/core/app/models/spree/payment_method.rb
@@ -130,9 +130,13 @@ module Spree
     def gateway
       gateway_options = options
       gateway_options.delete :login if gateway_options.key?(:login) && gateway_options[:login].nil?
-      if gateway_options[:server]
-        ActiveMerchant::Billing::Base.mode = gateway_options[:server].to_sym
-      end
+
+      # All environments except production considered to be test
+      test_server = gateway_options[:server] != 'production'
+      test_mode = gateway_options[:test_mode]
+
+      gateway_options[:test] = (test_server || test_mode)
+
       @gateway ||= gateway_class.new(gateway_options)
     end
     alias_method :provider, :gateway


### PR DESCRIPTION
Hi!

Noticed non thread safe code here https://github.com/solidusio/solidus/blob/e7260a27a7c292908a835f374d5ba73fe7284cd0/core/app/models/spree/payment_method.rb#L134
It can cause problems with payments. And this kind of setup should be used only in initializers.

Instead of this I instantiate gateway object with test option based on :server and :test_mode.

btw, :test_mode option has no effect in active merchant gateways.