### PR TITLE
Allow only stubbed changes to `Spree::Config` in specs

### DIFF
--- a/api/spec/models/spree/legacy_user_spec.rb
+++ b/api/spec/models/spree/legacy_user_spec.rb
@@ -54,7 +54,7 @@ module Spree
 
           before {
             user.clear_spree_api_key!
-            Spree::Config.roles_for_auto_api_key = ['hobbit']
+            stub_spree_preferences roles_for_auto_api_key: ['hobbit']
           }
 
           it { expect { subject }.to change { user.reload.spree_api_key }.from(nil) }
@@ -69,7 +69,7 @@ module Spree
           before {
             user.clear_spree_api_key!
             other_user.clear_spree_api_key!
-            Spree::Config.generate_api_key_for_all_roles = true
+            stub_spree_preferences(generate_api_key_for_all_roles: true)
           }
 
           it { expect { subject }.to change { user.reload.spree_api_key }.from(nil) }
@@ -89,7 +89,7 @@ module Spree
           end
 
           it "grants an api key on create when set to true" do
-            Spree::Config.generate_api_key_for_all_roles = true
+            stub_spree_preferences(generate_api_key_for_all_roles: true)
 
             expect(user.spree_api_key).to eq(nil)
 

--- a/api/spec/requests/spree/api/checkouts_controller_spec.rb
+++ b/api/spec/requests/spree/api/checkouts_controller_spec.rb
@@ -6,7 +6,7 @@ module Spree
   describe Api::CheckoutsController, type: :request do
     before(:each) do
       stub_authentication!
-      Spree::Config[:track_inventory_levels] = false
+      stub_spree_preferences track_inventory_levels: false
       country_zone = create(:zone, name: 'CountryZone')
       @state = create(:state)
       @country = @state.country
@@ -15,10 +15,6 @@ module Spree
 
       @shipping_method = create(:shipping_method, zones: [country_zone])
       @payment_method = create(:credit_card_payment_method)
-    end
-
-    after do
-      Spree::Config[:track_inventory_levels] = true
     end
 
     context "PUT 'update'" do

--- a/api/spec/requests/spree/api/orders_controller_spec.rb
+++ b/api/spec/requests/spree/api/orders_controller_spec.rb
@@ -865,7 +865,7 @@ module Spree
 
       context "can cancel an order" do
         before do
-          Spree::Config[:mails_from] = "spree@example.com"
+          stub_spree_preferences(mails_from: "spree@example.com")
 
           order.completed_at = Time.current
           order.state = 'complete'

--- a/api/spec/requests/spree/api/products_controller_spec.rb
+++ b/api/spec/requests/spree/api/products_controller_spec.rb
@@ -158,15 +158,13 @@ module Spree
       end
 
       context "tracking is disabled" do
-        before { Config.track_inventory_levels = false }
+        before { stub_spree_preferences(track_inventory_levels: false) }
 
         it "still displays valid json with total_on_hand Float::INFINITY" do
           get spree.api_product_path(product)
           expect(response).to be_ok
           expect(json_response[:total_on_hand]).to eq nil
         end
-
-        after { Config.track_inventory_levels = true }
       end
 
       context "finds a product by slug first then by id" do
@@ -296,7 +294,7 @@ module Spree
         end
 
         context "when tracking is disabled" do
-          before { Config.track_inventory_levels = false }
+          before { stub_spree_preferences(track_inventory_levels: false) }
 
           it "still displays valid json with total_on_hand Float::INFINITY" do
             post spree.api_products_path, params: {
@@ -310,8 +308,6 @@ module Spree
             expect(response.status).to eq(201)
             expect(json_response['total_on_hand']).to eq nil
           end
-
-          after { Config.track_inventory_levels = true }
         end
 
         it "puts the created product in the given taxon" do

--- a/api/spec/requests/spree/api/variants_controller_spec.rb
+++ b/api/spec/requests/spree/api/variants_controller_spec.rb
@@ -251,7 +251,7 @@ module Spree
 
       context "when tracking is disabled" do
         before do
-          Config.track_inventory_levels = false
+          stub_spree_preferences(track_inventory_levels: false)
           subject
         end
 
@@ -259,8 +259,6 @@ module Spree
           expect(response.status).to eq(200)
           expect(json_response['total_on_hand']).to eq nil
         end
-
-        after { Config.track_inventory_levels = true }
       end
     end
 

--- a/api/spec/spec_helper.rb
+++ b/api/spec/spec_helper.rb
@@ -59,7 +59,6 @@ RSpec.configure do |config|
 
   config.before(:each) do
     Rails.cache.clear
-    reset_spree_preferences
     Spree::Api::Config[:requires_authentication] = true
   end
 

--- a/backend/spec/controllers/spree/admin/orders/customer_details_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/orders/customer_details_controller_spec.rb
@@ -17,12 +17,12 @@ describe Spree::Admin::Orders::CustomerDetailsController, type: :controller do
           let!(:checkout_zone) { create(:zone, name: "Checkout Zone", countries: [canada]) }
 
           before do
-            Spree::Config.checkout_zone = checkout_zone.name
+            stub_spree_preferences(checkout_zone: checkout_zone.name)
           end
 
           context "and default_country_iso of the Canada" do
             before do
-              Spree::Config.default_country_iso = Spree::Country.find_by!(iso: "CA").iso
+              stub_spree_preferences(default_country_iso: Spree::Country.find_by!(iso: "CA").iso)
             end
 
             it 'defaults the shipping address country to Canada' do
@@ -38,7 +38,7 @@ describe Spree::Admin::Orders::CustomerDetailsController, type: :controller do
 
           context "and default_country_iso of the United States" do
             before do
-              Spree::Config.default_country_iso = Spree::Country.find_by!(iso: "US").iso
+              stub_spree_preferences(default_country_iso: Spree::Country.find_by!(iso: "US").iso)
             end
 
             it 'defaults the shipping address country to nil' do

--- a/backend/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -140,7 +140,7 @@ describe Spree::Admin::OrdersController, type: :controller do
         end
 
         context 'when order_bill_address_used is true' do
-          before { Spree::Config[:order_bill_address_used] = true }
+          before { stub_spree_preferences(order_bill_address_used: true) }
 
           it "should redirect to the customer details page" do
             get :edit, params: { id: order.number }
@@ -149,7 +149,7 @@ describe Spree::Admin::OrdersController, type: :controller do
         end
 
         context 'when order_bill_address_used is false' do
-          before { Spree::Config[:order_bill_address_used] = false }
+          before { stub_spree_preferences(order_bill_address_used: false) }
 
           it "should redirect to the customer details page" do
             get :edit, params: { id: order.number }

--- a/backend/spec/controllers/spree/admin/stock_locations_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/stock_locations_controller_spec.rb
@@ -20,7 +20,7 @@ module Spree
         let(:country) { create :country, iso: "BR" }
 
         before do
-          Spree::Config[:default_country_iso] = country.iso
+          stub_spree_preferences(default_country_iso: country.iso)
         end
 
         it "can create a new stock location" do

--- a/backend/spec/features/admin/orders/customer_details_spec.rb
+++ b/backend/spec/features/admin/orders/customer_details_spec.rb
@@ -70,10 +70,10 @@ describe "Customer Details", type: :feature, js: true do
 
   context "editing an order" do
     before do
-      configure_spree_preferences do |config|
-        config.default_country_iso = country.iso
-        config.company = true
-      end
+      stub_spree_preferences(
+        default_country_iso: country.iso,
+        company: true
+      )
 
       visit spree.admin_path
       click_link "Orders"
@@ -153,9 +153,7 @@ describe "Customer Details", type: :feature, js: true do
 
       before do
         order.bill_address.country.destroy
-        configure_spree_preferences do |config|
-          config.default_country_iso = brazil.iso
-        end
+        stub_spree_preferences(default_country_iso: brazil.iso)
       end
 
       it "sets default country when displaying form" do

--- a/backend/spec/features/admin/orders/listing_spec.rb
+++ b/backend/spec/features/admin/orders/listing_spec.rb
@@ -114,12 +114,7 @@ describe "Orders Listing", type: :feature, js: true do
 
       context "when pagination is really short" do
         before do
-          @old_per_page = Spree::Config[:orders_per_page]
-          Spree::Config[:orders_per_page] = 1
-        end
-
-        after do
-          Spree::Config[:orders_per_page] = @old_per_page
+          stub_spree_preferences(orders_per_page: 1)
         end
 
         # Regression test for https://github.com/spree/spree/issues/4004

--- a/backend/spec/features/admin/orders/new_order_spec.rb
+++ b/backend/spec/features/admin/orders/new_order_spec.rb
@@ -208,12 +208,12 @@ describe "New Order", type: :feature do
 
     before do
       Spree::Country.update_all(states_required: true)
-      Spree::Config.checkout_zone = checkout_zone.name
+      stub_spree_preferences(checkout_zone: checkout_zone.name)
     end
 
     context 'and default_country_iso of the United States' do
       before do
-        Spree::Config.default_country_iso = Spree::Country.find_by!(iso: 'US').iso
+        stub_spree_preferences(default_country_iso: Spree::Country.find_by!(iso: 'US').iso)
       end
 
       it 'the shipping address country select includes only options for Canada' do
@@ -267,7 +267,7 @@ describe "New Order", type: :feature do
 
     context 'and default_country_iso of Canada' do
       before do
-        Spree::Config.default_country_iso = Spree::Country.find_by!(iso: 'CA').iso
+        stub_spree_preferences(default_country_iso: Spree::Country.find_by!(iso: 'CA').iso)
       end
 
       it 'defaults the shipping address country to Canada' do

--- a/backend/spec/features/admin/products/products_spec.rb
+++ b/backend/spec/features/admin/products/products_spec.rb
@@ -54,7 +54,7 @@ describe "Products", type: :feature do
       context "currency displaying" do
         context "using Russian Rubles" do
           before do
-            Spree::Config[:currency] = "RUB"
+            stub_spree_preferences(currency: "RUB")
           end
 
           let!(:product) do
@@ -72,7 +72,7 @@ describe "Products", type: :feature do
       end
       context "when none of the product prices are in the same currency as the default in the store" do
         before do
-          Spree::Config[:currency] = "MXN"
+          stub_spree_preferences(currency: "MXN")
         end
 
         let!(:product) do
@@ -80,7 +80,7 @@ describe "Products", type: :feature do
         end
 
         it 'defaults it to Spree::Config.currency and sets the price as blank' do
-          Spree::Config[:currency] = "USD"
+          stub_spree_preferences(currency: "USD")
           visit spree.admin_product_path(product)
           within("#product_price_field") do
             expect(page).to have_content("USD")

--- a/backend/spec/features/admin/products/variant_spec.rb
+++ b/backend/spec/features/admin/products/variant_spec.rb
@@ -32,7 +32,7 @@ describe "Variants", type: :feature do
     context "currency displaying" do
       context "using Russian Rubles" do
         before do
-          Spree::Config[:currency] = "RUB"
+          stub_spree_preferences(currency: "RUB")
         end
 
         let!(:variant) do

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -89,7 +89,6 @@ RSpec.configure do |config|
 
   config.before do
     Rails.cache.clear
-    reset_spree_preferences
     if RSpec.current_example.metadata[:js] && page.driver.browser.respond_to?(:url_blacklist)
       page.driver.browser.url_blacklist = ['http://fonts.googleapis.com']
     end

--- a/core/lib/spree/testing_support/preferences.rb
+++ b/core/lib/spree/testing_support/preferences.rb
@@ -49,7 +49,9 @@ module Spree
       #   Solidus #3219 for more details and motivations.
       def stub_spree_preferences(preferences)
         preferences.each do |name, value|
-          allow(Spree::Config).to receive(:[]).and_call_original
+          if Spree::Config.method(:[]).owner >= Spree::Config.class
+            allow(Spree::Config).to receive(:[]).and_call_original
+          end
           allow(Spree::Config).to receive(:[]).with(name) { value }
           allow(Spree::Config).to receive(name) { value }
         end

--- a/core/lib/spree/testing_support/preferences.rb
+++ b/core/lib/spree/testing_support/preferences.rb
@@ -56,6 +56,27 @@ module Spree
           allow(Spree::Config).to receive(name) { value }
         end
       end
+
+      # This method allows to temporarily switch to an unfrozen Spree::Config preference
+      # store with all proper preferences values set.
+      #
+      # It should be used sparingly, only when `stub_spree_preferences` would not work.
+      #
+      # @example Temporarily switch to an unfrozen store and change some preferences:
+      #   with_unfrozen_spree_preference_store do
+      #     Spree::Config.currency = 'EUR'
+      #     Spree::Config.track_inventory_levels = false
+      #
+      #     expect(Spree::Config.currency).to eql 'EUR'
+      #   end
+      # @see Spree::TestingSupport::Preferences#stub_spree_preferences
+      def with_unfrozen_spree_preference_store
+        frozen_store = Spree::Config.preference_store
+        Spree::Config.preference_store = Spree::Config[:unfrozen_preference_store].dup
+        yield
+      ensure
+        Spree::Config.preference_store = frozen_store
+      end
     end
   end
 end

--- a/core/lib/spree/testing_support/preferences.rb
+++ b/core/lib/spree/testing_support/preferences.rb
@@ -29,6 +29,31 @@ module Spree
         find("#preferences_#{preference}")['checked'].should be false
         Spree::Config[preference].should be false
       end
+
+      # This is the preferred way for changing temporarily Spree preferences during
+      # tests via stubs, without changing the actual values stored in Spree::Config.
+      #
+      # By using stubs no global preference change will leak outside the lifecycle
+      # of each spec example, avoiding possible unpredictable side effects.
+      #
+      # This method  may be used for stubbing one or more different preferences
+      # at the same time.
+      #
+      # @param [Hash] preferences names and values to be stubbed
+      #
+      # @example Stubs `currency` and `track_inventory_levels` preferences
+      #   stub_spree_preferences(currency: 'EUR', track_inventory_levels: false)
+      #   expect(Spree::Config.currency).to eql 'EUR'
+      #
+      # @see https://github.com/solidusio/solidus/issues/3219
+      #   Solidus #3219 for more details and motivations.
+      def stub_spree_preferences(preferences)
+        preferences.each do |name, value|
+          allow(Spree::Config).to receive(:[]).and_call_original
+          allow(Spree::Config).to receive(:[]).with(name) { value }
+          allow(Spree::Config).to receive(name) { value }
+        end
+      end
     end
   end
 end

--- a/core/lib/spree/testing_support/preferences.rb
+++ b/core/lib/spree/testing_support/preferences.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'spree/deprecation'
+
 module Spree
   module TestingSupport
     module Preferences
@@ -10,6 +12,7 @@ module Spree
       #   config.track_inventory_levels = false
       # end
       #
+      # @deprecated
       def reset_spree_preferences(&config_block)
         Spree::Config.instance_variables.each { |iv| Spree::Config.remove_instance_variable(iv) }
         Spree::Config.preference_store = Spree::Config.default_preferences
@@ -20,6 +23,8 @@ module Spree
 
         configure_spree_preferences(&config_block) if block_given?
       end
+
+      deprecate :reset_spree_preferences, deprecator: Spree::Deprecation
 
       def configure_spree_preferences
         yield(Spree::Config) if block_given?

--- a/core/lib/spree/testing_support/preferences.rb
+++ b/core/lib/spree/testing_support/preferences.rb
@@ -80,3 +80,12 @@ module Spree
     end
   end
 end
+
+RSpec.configure do |config|
+  config.before :suite do
+    # keep a copy of the original unfrozen preference_store for later use:
+    Spree::AppConfiguration.preference :unfrozen_preference_store, :hash
+    Spree::Config.unfrozen_preference_store = Spree::Config.preference_store.dup
+    Spree::Config.preference_store.freeze
+  end
+end

--- a/core/spec/helpers/base_helper_spec.rb
+++ b/core/spec/helpers/base_helper_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Spree::BaseHelper, type: :helper do
 
     context "with no checkout zone defined" do
       before do
-        Spree::Config[:checkout_zone] = nil
+        stub_spree_preferences(checkout_zone: nil)
       end
 
       it "return complete list of countries" do
@@ -33,7 +33,7 @@ RSpec.describe Spree::BaseHelper, type: :helper do
         before do
           @country_zone = create(:zone, name: "CountryZone")
           @country_zone.members.create(zoneable: country)
-          Spree::Config[:checkout_zone] = @country_zone.name
+          stub_spree_preferences(checkout_zone: @country_zone.name)
         end
 
         it "return only the countries defined by the checkout zone" do
@@ -50,7 +50,7 @@ RSpec.describe Spree::BaseHelper, type: :helper do
           state_zone = create(:zone, name: "StateZone")
           state = create(:state, country: country)
           state_zone.members.create(zoneable: state)
-          Spree::Config[:checkout_zone] = state_zone.name
+          stub_spree_preferences(checkout_zone: state_zone.name)
         end
 
         it "return complete list of countries" do

--- a/core/spec/helpers/products_helper_spec.rb
+++ b/core/spec/helpers/products_helper_spec.rb
@@ -75,7 +75,7 @@ module Spree
       let(:variant_price) { 15 }
 
       before do
-        Spree::Config[:show_variant_full_price] = true
+        stub_spree_preferences(show_variant_full_price: true)
         variant
       end
 
@@ -148,7 +148,7 @@ THIS IS THE BEST PRODUCT EVER!
 
         product.description = description
 
-        Spree::Config[:show_raw_product_description] = true
+        stub_spree_preferences(show_raw_product_description: true)
         description = product_description(product)
         expect(description).to eq(description)
       end

--- a/core/spec/lib/spree/core/testing_support/factories/shipping_method_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/shipping_method_factory_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'shipping method factory' do
     end
 
     context 'store using alternate currency' do
-      before { Spree::Config[:currency] = 'CAD' }
+      before { stub_spree_preferences(currency: 'CAD') }
 
       it "should configure the calculator correctly" do
         shipping_method = create(factory)

--- a/core/spec/lib/spree/core/testing_support/preferences_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/preferences_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe Spree::TestingSupport::Preferences do
   describe 'resetting the app configuration' do
     before do
+      reset_spree_preferences
       @original_spree_mails_from = Spree::Config.mails_from
       @original_spree_searcher_class = Spree::Config.searcher_class
       class MySearcherClass; end

--- a/core/spec/lib/spree/core/testing_support/preferences_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/preferences_spec.rb
@@ -6,7 +6,9 @@ RSpec.describe Spree::TestingSupport::Preferences do
   describe 'resetting the app configuration' do
     around do |example|
       with_unfrozen_spree_preference_store do
-        example.run
+        Spree::Deprecation.silence do
+          example.run
+        end
       end
     end
 

--- a/core/spec/lib/spree/core/testing_support/preferences_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/preferences_spec.rb
@@ -33,4 +33,20 @@ RSpec.describe Spree::TestingSupport::Preferences do
       expect(Spree::Config.preference_store[:currency]).to eq 'USD'
     end
   end
+
+  describe '#with_unfrozen_spree_preference_store' do
+    it 'changes the original settings, but returns them to original values at exit' do
+      with_unfrozen_spree_preference_store do
+        Spree::Config.mails_from = 'override@example.com'
+        expect(Spree::Config.mails_from).to eq 'override@example.com'
+        expect(Spree::Config.preference_store[:mails_from]).to eq 'override@example.com'
+      end
+
+      # both the original frozen store and the unfrozen store are unaffected by changes above:
+      expect(Spree::Config.mails_from).to eq 'store@example.com'
+      with_unfrozen_spree_preference_store do
+        expect(Spree::Config.mails_from).to eq 'store@example.com'
+      end
+    end
+  end
 end

--- a/core/spec/lib/spree/core/testing_support/preferences_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/preferences_spec.rb
@@ -4,6 +4,12 @@ require 'rails_helper'
 
 RSpec.describe Spree::TestingSupport::Preferences do
   describe 'resetting the app configuration' do
+    around do |example|
+      with_unfrozen_spree_preference_store do
+        example.run
+      end
+    end
+
     before do
       reset_spree_preferences
       @original_spree_mails_from = Spree::Config.mails_from

--- a/core/spec/lib/spree/core/testing_support/preferences_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/preferences_spec.rb
@@ -25,4 +25,12 @@ RSpec.describe Spree::TestingSupport::Preferences do
       expect(Spree::Config.searcher_class).to eq(@original_spree_searcher_class)
     end
   end
+
+  describe '#stub_spree_preferences' do
+    it 'stubs method calls but does not affect actual stored Spree::Config settings' do
+      stub_spree_preferences(currency: 'FOO')
+      expect(Spree::Config.currency).to eq 'FOO'
+      expect(Spree::Config.preference_store[:currency]).to eq 'USD'
+    end
+  end
 end

--- a/core/spec/lib/spree/money_spec.rb
+++ b/core/spec/lib/spree/money_spec.rb
@@ -4,9 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Spree::Money do
   before do
-    configure_spree_preferences do |config|
-      config.currency = "USD"
-    end
+    stub_spree_preferences(currency: "USD")
   end
 
   describe '#initialize' do
@@ -155,9 +153,7 @@ RSpec.describe Spree::Money do
 
   context "JPY" do
     before do
-      configure_spree_preferences do |config|
-        config.currency = "JPY"
-      end
+      stub_spree_preferences(currency: "JPY")
     end
 
     it "formats correctly" do
@@ -168,9 +164,7 @@ RSpec.describe Spree::Money do
 
   context "EUR" do
     before do
-      configure_spree_preferences do |config|
-        config.currency = "EUR"
-      end
+      stub_spree_preferences(currency: "EUR")
     end
 
     # Regression test for https://github.com/spree/spree/issues/2634

--- a/core/spec/mailers/order_mailer_spec.rb
+++ b/core/spec/mailers/order_mailer_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe Spree::OrderMailer, type: :mailer do
 
   context "with preference :send_core_emails set to false" do
     it "sends no email" do
-      Spree::Config.send_core_emails = false
+      stub_spree_preferences(send_core_emails: false)
       message = Spree::OrderMailer.confirm_email(order)
       expect(message.body).to be_blank
     end

--- a/core/spec/models/spree/address_spec.rb
+++ b/core/spec/models/spree/address_spec.rb
@@ -28,8 +28,9 @@ RSpec.describe Spree::Address, type: :model do
 
     context 'address does not require state' do
       before do
-        Spree::Config.address_requires_state = false
+        stub_spree_preferences(address_requires_state: false)
       end
+
       it "address_requires_state preference is false" do
         address.state = nil
         address.state_name = nil
@@ -39,7 +40,7 @@ RSpec.describe Spree::Address, type: :model do
 
     context 'address requires state' do
       before do
-        Spree::Config.address_requires_state = true
+        stub_spree_preferences(address_requires_state: true)
       end
 
       it "state_name is not nil and country does not have any states" do
@@ -145,7 +146,7 @@ RSpec.describe Spree::Address, type: :model do
 
       context 'has a default country' do
         before do
-          Spree::Config[:default_country_iso] = default_country.iso
+          stub_spree_preferences(default_country_iso: default_country.iso)
         end
 
         it "sets up a new record with Spree::Config[:default_country_iso]" do
@@ -155,7 +156,7 @@ RSpec.describe Spree::Address, type: :model do
 
       # Regression test for https://github.com/spree/spree/issues/1142
       it "raises ActiveRecord::RecordNotFound if :default_country_iso is set to an invalid value" do
-        Spree::Config[:default_country_iso] = "00"
+        stub_spree_preferences(default_country_iso: "00")
         expect {
           Spree::Address.build_default.country
         }.to raise_error(ActiveRecord::RecordNotFound)

--- a/core/spec/models/spree/app_configuration_spec.rb
+++ b/core/spec/models/spree/app_configuration_spec.rb
@@ -5,6 +5,12 @@ require 'rails_helper'
 RSpec.describe Spree::AppConfiguration, type: :model do
   let(:prefs) { Spree::Config }
 
+  around do |example|
+    with_unfrozen_spree_preference_store do
+      example.run
+    end
+  end
+
   it "should be available from the environment" do
     prefs.layout = "my/layout"
     expect(prefs.layout).to eq "my/layout"

--- a/core/spec/models/spree/concerns/user_address_book_spec.rb
+++ b/core/spec/models/spree/concerns/user_address_book_spec.rb
@@ -256,7 +256,7 @@ module Spree
 
       context "when automatic_default_address preference is at a default of true" do
         before do
-          Spree::Config.automatic_default_address = true
+          stub_spree_preferences(automatic_default_address: true)
           expect(user).to receive(:save_in_address_book).with(kind_of(Hash), true)
           expect(user).to receive(:save_in_address_book).with(kind_of(Hash), false)
         end
@@ -269,7 +269,7 @@ module Spree
 
       context "when automatic_default_address preference is false" do
         before do
-          Spree::Config.automatic_default_address = false
+          stub_spree_preferences(automatic_default_address: false)
           expect(user).to receive(:save_in_address_book).with(kind_of(Hash), false).twice
           # and not the optional 2nd argument
         end
@@ -283,7 +283,7 @@ module Spree
       context "when address is nil" do
         context "when automatic_default_address preference is at a default of true" do
           before do
-            Spree::Config.automatic_default_address = true
+            stub_spree_preferences(automatic_default_address: true)
             expect(user).to receive(:save_in_address_book).with(kind_of(Hash), true).once
           end
 
@@ -305,7 +305,7 @@ module Spree
 
       context "when automatic_default_address preference is false" do
         before do
-          Spree::Config.automatic_default_address = false
+          stub_spree_preferences(automatic_default_address: false)
           expect(user).to receive(:save_in_address_book).with(kind_of(Hash), false).once
         end
 

--- a/core/spec/models/spree/country_spec.rb
+++ b/core/spec/models/spree/country_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Spree::Country, type: :model do
 
     context 'with the configuration setting an existing legacy default country ID' do
       before do
-        Spree::Config[:default_country_id] = 2
+        stub_spree_preferences(default_country_id: 2)
       end
 
       subject(:default_country) do
@@ -32,7 +32,7 @@ RSpec.describe Spree::Country, type: :model do
 
     context 'with the configuration setting a non-existing legacy default country ID' do
       before do
-        Spree::Config[:default_country_id] = 0
+        stub_spree_preferences(default_country_id: 0)
       end
 
       subject(:default_country) do
@@ -52,7 +52,7 @@ RSpec.describe Spree::Country, type: :model do
     end
 
     context 'with the configuration setting an non-existing ISO code' do
-      before { Spree::Config[:default_country_iso] = "ZZ" }
+      before { stub_spree_preferences(default_country_iso: "ZZ") }
 
       it 'raises a Record not Found error' do
         expect { described_class.default }.to raise_error(ActiveRecord::RecordNotFound)
@@ -71,7 +71,7 @@ RSpec.describe Spree::Country, type: :model do
         let!(:checkout_zone) { create(:zone, name: 'Checkout Zone', countries: [united_states, canada]) }
 
         before do
-          Spree::Config.checkout_zone = checkout_zone.name
+          stub_spree_preferences(checkout_zone: checkout_zone.name)
         end
 
         context 'with no arguments' do
@@ -104,7 +104,7 @@ RSpec.describe Spree::Country, type: :model do
         let!(:checkout_zone) { create(:zone, name: 'Checkout Zone', states: [state]) }
 
         before do
-          Spree::Config[:checkout_zone] = checkout_zone.name
+          stub_spree_preferences(checkout_zone: checkout_zone.name)
         end
 
         context 'with no arguments' do

--- a/core/spec/models/spree/customer_return_spec.rb
+++ b/core/spec/models/spree/customer_return_spec.rb
@@ -189,7 +189,7 @@ RSpec.describe Spree::CustomerReturn, type: :model do
 
       context 'with Config.track_inventory_levels == false' do
         before do
-          Spree::Config.track_inventory_levels = false
+          stub_spree_preferences(track_inventory_levels: false)
           expect(Spree::StockItem).not_to receive(:find_by)
           expect(Spree::StockMovement).not_to receive(:create!)
         end

--- a/core/spec/models/spree/order/payment_spec.rb
+++ b/core/spec/models/spree/order/payment_spec.rb
@@ -12,7 +12,7 @@ module Spree
 
       before do
         # So that Payment#purchase! is called during processing
-        Spree::Config[:auto_capture] = true
+        stub_spree_preferences(auto_capture: true)
       end
 
       let(:payment_method) { create(:credit_card_payment_method) }
@@ -147,12 +147,12 @@ module Spree
         before { expect(payment).to receive(:process!).and_raise(Spree::Core::GatewayError) }
 
         it "should return true when configured to allow checkout on gateway failures" do
-          Spree::Config.set allow_checkout_on_gateway_error: true
+          stub_spree_preferences(allow_checkout_on_gateway_error: true)
           expect(order.process_payments!).to be true
         end
 
         it "should return false when not configured to allow checkout on gateway failures" do
-          Spree::Config.set allow_checkout_on_gateway_error: false
+          stub_spree_preferences(allow_checkout_on_gateway_error: false)
           expect(order.process_payments!).to be false
         end
       end

--- a/core/spec/models/spree/order_inventory_spec.rb
+++ b/core/spec/models/spree/order_inventory_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Spree::OrderInventory, type: :model do
     context "store doesnt track inventory" do
       let(:new_quantity) { 1 }
 
-      before { Spree::Config.track_inventory_levels = false }
+      before { stub_spree_preferences(track_inventory_levels: false) }
 
       it "creates on hand inventory units" do
         variant.stock_items.each(&:really_destroy!)

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Spree::Order, type: :model do
@@ -507,7 +508,7 @@ RSpec.describe Spree::Order, type: :model do
     let(:order) { build(:order, ship_address: ship_address, bill_address: bill_address, store: store) }
     let(:store) { build(:store) }
 
-    before { Spree::Config[:tax_using_ship_address] = tax_using_ship_address }
+    before { stub_spree_preferences(tax_using_ship_address: tax_using_ship_address) }
     subject { order.tax_address }
 
     context "when the order has no addresses" do

--- a/core/spec/models/spree/order_updater_spec.rb
+++ b/core/spec/models/spree/order_updater_spec.rb
@@ -117,7 +117,7 @@ module Spree
               end
             end
 
-            Spree::Config.promotion_chooser_class = Spree::TestPromotionChooser
+            stub_spree_preferences(promotion_chooser_class: Spree::TestPromotionChooser)
           end
 
           it 'uses the defined promotion chooser' do
@@ -322,7 +322,7 @@ module Spree
 
           before do
             order # generate this first so we can expect it
-            Spree::Config.tax_calculator_class = custom_calculator_class
+            stub_spree_preferences(tax_calculator_class: custom_calculator_class)
           end
 
           it 'uses the configured class' do

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe Spree::Product, type: :model do
         before do
           product.master.default_price.currency = 'JPY'
           product.master.default_price.save!
-          Spree::Config[:currency] = 'JPY'
+          stub_spree_preferences(currency: 'JPY')
         end
 
         it "displays the currency in yen" do
@@ -514,12 +514,12 @@ RSpec.describe Spree::Product, type: :model do
 
   context '#total_on_hand' do
     it 'should be infinite if track_inventory_levels is false' do
-      Spree::Config[:track_inventory_levels] = false
+      stub_spree_preferences(track_inventory_levels: false)
       expect(build(:product, variants_including_master: [build(:master_variant)]).total_on_hand).to eql(Float::INFINITY)
     end
 
     it 'should be infinite if variant is on demand' do
-      Spree::Config[:track_inventory_levels] = true
+      stub_spree_preferences(track_inventory_levels: true)
       expect(build(:product, variants_including_master: [build(:on_demand_master_variant)]).total_on_hand).to eql(Float::INFINITY)
     end
 

--- a/core/spec/models/spree/promotion_handler/shipping_spec.rb
+++ b/core/spec/models/spree/promotion_handler/shipping_spec.rb
@@ -76,7 +76,7 @@ module Spree
         before do
           stub_const('CustomShippingAction', custom_klass)
 
-          Spree::Config.environment.promotions.shipping_actions = ['CustomShippingAction']
+          allow(Spree::Config.environment.promotions).to receive(:shipping_actions) { ['CustomShippingAction'] }
 
           order.order_promotions.create!(promotion: promotion, promotion_code: promotion.codes.first)
         end

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -328,7 +328,7 @@ RSpec.describe Spree::Shipment, type: :model do
 
     context "when payment is not required" do
       before do
-        Spree::Config[:require_payment_to_ship] = false
+        stub_spree_preferences(require_payment_to_ship: false)
       end
 
       it "should result in a 'ready' state" do
@@ -391,7 +391,7 @@ RSpec.describe Spree::Shipment, type: :model do
     end
 
     context "with inventory tracking" do
-      before { Spree::Config.set track_inventory_levels: true }
+      before { stub_spree_preferences(track_inventory_levels: true) }
 
       it "should validate with inventory" do
         shipment.inventory_units = [create(:inventory_unit)]
@@ -400,7 +400,7 @@ RSpec.describe Spree::Shipment, type: :model do
     end
 
     context "without inventory tracking" do
-      before { Spree::Config.set track_inventory_levels: false }
+      before { stub_spree_preferences(track_inventory_levels: false) }
 
       it "should validate with no inventory" do
         expect(shipment.valid?).to be true

--- a/core/spec/models/spree/stock/availability_spec.rb
+++ b/core/spec/models/spree/stock/availability_spec.rb
@@ -77,7 +77,7 @@ module Spree::Stock
         end
 
         context 'with config.track_inventory_levels=false' do
-          before { Spree::Config.track_inventory_levels = false }
+          before { stub_spree_preferences(track_inventory_levels: false) }
 
           it "has infinite inventory " do
             expect(subject).to eq(stock_location1.id => Spree::StockQuantities.new(variant => infinity))

--- a/core/spec/models/spree/stock/estimator_spec.rb
+++ b/core/spec/models/spree/stock/estimator_spec.rb
@@ -195,13 +195,11 @@ module Spree
               Spree::ShippingRate.new
             end
           end
-          Spree::Config.shipping_rate_selector_class = selector_class
+          stub_spree_preferences(shipping_rate_selector_class: selector_class)
 
           subject.shipping_rates(package)
 
           expect(shipping_rate.selected).to eq(true)
-
-          Spree::Config.shipping_rate_selector_class = nil
         end
 
         it 'uses the configured shipping rate sorter' do
@@ -209,7 +207,8 @@ module Spree
             def initialize(_rates)
             end
           end
-          Spree::Config.shipping_rate_sorter_class = Spree::Stock::TestSorter
+
+          stub_spree_preferences(shipping_rate_sorter_class: Spree::Stock::TestSorter)
 
           sorter = double(:sorter, sort: nil)
           allow(Spree::Stock::TestSorter).to receive(:new) { sorter }
@@ -217,8 +216,6 @@ module Spree
           subject.shipping_rates(package)
 
           expect(sorter).to have_received(:sort)
-
-          Spree::Config.shipping_rate_sorter_class = nil
         end
 
         it 'uses the configured shipping rate taxer' do
@@ -232,7 +229,8 @@ module Spree
               ]
             end
           end
-          Spree::Config.shipping_rate_tax_calculator_class = Spree::Tax::TestTaxCalculator
+
+          stub_spree_preferences(shipping_rate_tax_calculator_class: Spree::Tax::TestTaxCalculator)
 
           expect(Spree::Tax::TestTaxCalculator).to receive(:new).and_call_original
           subject.shipping_rates(package)

--- a/core/spec/models/spree/stock/quantifier_spec.rb
+++ b/core/spec/models/spree/stock/quantifier_spec.rb
@@ -27,7 +27,7 @@ module Spree
         end
 
         context 'when track_inventory_levels is false' do
-          before { configure_spree_preferences { |config| config.track_inventory_levels = false } }
+          before { stub_spree_preferences track_inventory_levels: false }
 
           specify { expect(subject.total_on_hand).to eq(Float::INFINITY) }
 

--- a/core/spec/models/spree/stock_item_spec.rb
+++ b/core/spec/models/spree/stock_item_spec.rb
@@ -196,7 +196,7 @@ RSpec.describe Spree::StockItem, type: :model do
 
     context "inventory_cache_threshold is set" do
       before do
-        Spree::Config.inventory_cache_threshold = inventory_cache_threshold
+        stub_spree_preferences(inventory_cache_threshold: inventory_cache_threshold)
       end
 
       let(:inventory_cache_threshold) { 5 }
@@ -241,7 +241,7 @@ RSpec.describe Spree::StockItem, type: :model do
 
     context "when deprecated binary_inventory_cache is used" do
       before do
-        Spree::Config.binary_inventory_cache = binary_inventory_cache
+        stub_spree_preferences(binary_inventory_cache: binary_inventory_cache)
         allow(Spree::Deprecation).to receive(:warn)
         subject.set_count_on_hand(9)
       end
@@ -256,6 +256,7 @@ RSpec.describe Spree::StockItem, type: :model do
 
       context "binary_inventory_cache is set to false" do
         let(:binary_inventory_cache) { false }
+
         it "inventory_cache_threshold remains nil" do
           expect(Spree::Config.inventory_cache_threshold).to be_nil
         end

--- a/core/spec/models/spree/stock_movement_spec.rb
+++ b/core/spec/models/spree/stock_movement_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Spree::StockMovement, type: :model do
   end
 
   it 'does not update count on hand when track inventory levels is false' do
-    Spree::Config[:track_inventory_levels] = false
+    stub_spree_preferences(track_inventory_levels: false)
     subject.quantity = 1
     subject.save
     stock_item.reload

--- a/core/spec/models/spree/store_credit_spec.rb
+++ b/core/spec/models/spree/store_credit_spec.rb
@@ -507,7 +507,7 @@ RSpec.describe Spree::StoreCredit do
       let(:auth_code)       { event_auth_code }
 
       context "credit_to_new_allocation is set" do
-        before { Spree::Config[:credit_to_new_allocation] = true }
+        before { stub_spree_preferences(credit_to_new_allocation: true) }
 
         it "returns true" do
           expect(subject).to be true

--- a/core/spec/models/spree/tax/order_adjuster_spec.rb
+++ b/core/spec/models/spree/tax/order_adjuster_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Spree::Tax::OrderAdjuster do
     let(:custom_calculator_instance) { double }
 
     before do
-      Spree::Config.tax_calculator_class = custom_calculator_class
+      stub_spree_preferences(tax_calculator_class: custom_calculator_class)
     end
 
     it 'calls the configured tax calculator' do

--- a/core/spec/models/spree/tax/taxation_integration_spec.rb
+++ b/core/spec/models/spree/tax/taxation_integration_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe "Taxation system integration tests" do
     end
 
     before do
-      Spree::Config.admin_vat_country_iso = "DE"
+      stub_spree_preferences(admin_vat_country_iso: "DE")
       order.contents.add(variant)
     end
 

--- a/core/spec/models/spree/user_spec.rb
+++ b/core/spec/models/spree/user_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Spree::LegacyUser, type: :model do
 
     context "with completable_order_created_cutoff set" do
       before do
-        Spree::Config.completable_order_created_cutoff_days = 1
+        stub_spree_preferences(completable_order_created_cutoff_days: 1)
       end
 
       it "excludes orders updated outside of the cutoff date" do
@@ -47,7 +47,7 @@ RSpec.describe Spree::LegacyUser, type: :model do
 
     context "with completable_order_created_cutoff set" do
       before do
-        Spree::Config.completable_order_updated_cutoff_days = 1
+        stub_spree_preferences(completable_order_updated_cutoff_days: 1)
       end
 
       it "excludes orders updated outside of the cutoff date" do

--- a/core/spec/models/spree/variant/vat_price_generator_spec.rb
+++ b/core/spec/models/spree/variant/vat_price_generator_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Spree::Variant::VatPriceGenerator do
     let!(:french_vat) { create(:tax_rate, included_in_price: true, amount: 0.20, zone: france_zone, tax_categories: [tax_category]) }
 
     before do
-      Spree::Config.admin_vat_country_iso = "DE"
+      stub_spree_preferences(admin_vat_country_iso: "DE")
     end
 
     it "builds a correct price including VAT for all VAT countries" do

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -516,7 +516,7 @@ RSpec.describe Spree::Variant, type: :model do
 
   describe '#in_stock?' do
     before do
-      Spree::Config.track_inventory_levels = true
+      stub_spree_preferences(track_inventory_levels: true)
     end
 
     context 'when stock_items are not backorderable' do
@@ -597,7 +597,7 @@ RSpec.describe Spree::Variant, type: :model do
 
   describe '#total_on_hand' do
     it 'should be infinite if track_inventory_levels is false' do
-      Spree::Config[:track_inventory_levels] = false
+      stub_spree_preferences(track_inventory_levels: false)
       expect(build(:variant).total_on_hand).to eql(Float::INFINITY)
     end
 
@@ -640,19 +640,19 @@ RSpec.describe Spree::Variant, type: :model do
 
   describe "#should_track_inventory?" do
     it 'should not track inventory when global setting is off' do
-      Spree::Config[:track_inventory_levels] = false
+      stub_spree_preferences(track_inventory_levels: false)
 
       expect(build(:variant).should_track_inventory?).to eq(false)
     end
 
     it 'should not track inventory when variant is turned off' do
-      Spree::Config[:track_inventory_levels] = true
+      stub_spree_preferences(track_inventory_levels: true)
 
       expect(build(:on_demand_variant).should_track_inventory?).to eq(false)
     end
 
     it 'should track inventory when global and variant are on' do
-      Spree::Config[:track_inventory_levels] = true
+      stub_spree_preferences(track_inventory_levels: true)
 
       expect(build(:variant).should_track_inventory?).to eq(true)
     end
@@ -749,8 +749,7 @@ RSpec.describe Spree::Variant, type: :model do
     end
 
     context "inventory levels globally not tracked" do
-      before { Spree::Config.track_inventory_levels = false }
-      after { Spree::Config.track_inventory_levels = true }
+      before { stub_spree_preferences(track_inventory_levels: false) }
 
       it 'includes items without inventory' do
         expect( subject ).to include out_of_stock_variant
@@ -788,7 +787,7 @@ RSpec.describe Spree::Variant, type: :model do
     end
 
     context "inventory levels globally not tracked" do
-      before { Spree::Config.track_inventory_levels = false }
+      before { stub_spree_preferences(track_inventory_levels: false) }
 
       it "includes all variants" do
         expect( subject ).to include(in_stock_variant, backordered_variant, out_of_stock_variant)

--- a/core/spec/spec_helper.rb
+++ b/core/spec/spec_helper.rb
@@ -22,10 +22,6 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
 
-  config.before :each do
-    reset_spree_preferences
-  end
-
   config.include Spree::TestingSupport::Preferences
   config.extend WithModel
 

--- a/frontend/spec/controllers/spree/checkout_controller_spec.rb
+++ b/frontend/spec/controllers/spree/checkout_controller_spec.rb
@@ -469,9 +469,7 @@ describe Spree::CheckoutController, type: :controller do
     before do
       allow(order).to receive_messages(line_items: [line_item], state: "payment")
 
-      configure_spree_preferences do |config|
-        config.track_inventory_levels = true
-      end
+      stub_spree_preferences(track_inventory_levels: true)
     end
 
     context "and back orders are not allowed" do

--- a/frontend/spec/controllers/spree/checkout_controller_with_views_spec.rb
+++ b/frontend/spec/controllers/spree/checkout_controller_with_views_spec.rb
@@ -16,7 +16,7 @@ describe Spree::CheckoutController, type: :controller do
   # Regression test for https://github.com/spree/spree/issues/3246
   context "when using GBP" do
     before do
-      Spree::Config[:currency] = "GBP"
+      stub_spree_preferences(currency: "GBP")
     end
 
     context "when order is in delivery" do

--- a/frontend/spec/controllers/spree/home_controller_spec.rb
+++ b/frontend/spec/controllers/spree/home_controller_spec.rb
@@ -18,7 +18,7 @@ describe Spree::HomeController, type: :controller do
     end
 
     context "different layout specified in config" do
-      before { Spree::Config.layout = 'layouts/application' }
+      before { stub_spree_preferences(layout: 'layouts/application') }
 
       it "renders specified layout" do
         get :index

--- a/frontend/spec/features/address_spec.rb
+++ b/frontend/spec/features/address_spec.rb
@@ -24,7 +24,7 @@ describe "Address", type: :feature, inaccessible: true do
     let!(:canada) { create(:country, name: "Canada", states_required: true, iso: "CA") }
     let!(:uk) { create(:country, name: "United Kingdom", states_required: true, iso: "GB") }
 
-    before { Spree::Config[:default_country_iso] = uk.iso }
+    before { stub_spree_preferences(default_country_iso: uk.iso) }
 
     context "but has no state" do
       it "shows the state input field" do

--- a/frontend/spec/features/caching/taxons_spec.rb
+++ b/frontend/spec/features/caching/taxons_spec.rb
@@ -14,7 +14,7 @@ describe 'taxons', type: :feature, caching: true do
   end
 
   it "busts the cache when max_level_in_taxons_menu conf changes" do
-    Spree::Config[:max_level_in_taxons_menu] = 5
+    stub_spree_preferences(max_level_in_taxons_menu: 5)
     visit spree.root_path
     expect(cache_writes.count).to eq(1)
   end

--- a/frontend/spec/features/currency_spec.rb
+++ b/frontend/spec/features/currency_spec.rb
@@ -14,7 +14,7 @@ describe "Switching currencies in backend", type: :feature do
     click_link "RoR Mug"
     click_button "Add To Cart"
     # Now that we have an order...
-    Spree::Config[:currency] = "AUD"
+    stub_spree_preferences(currency: "AUD")
     visit spree.root_path
   end
 end

--- a/frontend/spec/features/products_spec.rb
+++ b/frontend/spec/features/products_spec.rb
@@ -93,7 +93,7 @@ describe "Visiting Products", type: :feature, inaccessible: true do
 
   context "using Russian Rubles as a currency" do
     before do
-      Spree::Config[:currency] = "RUB"
+      stub_spree_preferences(currency: "RUB")
     end
 
     let!(:product) do
@@ -199,8 +199,8 @@ describe "Visiting Products", type: :feature, inaccessible: true do
 
   it "should be able to hide products without price" do
     expect(page.all('ul.product-listing li').size).to eq(9)
-    Spree::Config.show_products_without_price = false
-    Spree::Config.currency = "CAN"
+    stub_spree_preferences(show_products_without_price: false)
+    stub_spree_preferences(currency: "CAN")
     visit spree.root_path
     expect(page.all('ul.product-listing li').size).to eq(0)
   end
@@ -224,7 +224,7 @@ describe "Visiting Products", type: :feature, inaccessible: true do
   end
 
   it "should be able to display products priced between 15 and 18 dollars across multiple pages" do
-    Spree::Config.products_per_page = 2
+    stub_spree_preferences(products_per_page: 2)
     within(:css, '#taxonomies') { click_link "Ruby on Rails" }
     check "Price_Range_$15.00_-_$18.00"
     within(:css, '#sidebar_products_search') { click_button "Search" }
@@ -263,8 +263,8 @@ describe "Visiting Products", type: :feature, inaccessible: true do
 
   it "shouldn't be able to put a product without a current price in the cart" do
     product = FactoryBot.create(:base_product, description: nil, name: 'Sample', price: '19.99')
-    Spree::Config.currency = "CAN"
-    Spree::Config.show_products_without_price = true
+    stub_spree_preferences(currency: "CAN")
+    stub_spree_preferences(show_products_without_price: true)
     visit spree.product_path(product)
     expect(page).to have_content "This product is not available in the selected currency."
     expect(page).not_to have_content "add-to-cart-button"
@@ -272,8 +272,8 @@ describe "Visiting Products", type: :feature, inaccessible: true do
 
   it "should be able to list products without a price" do
     product = FactoryBot.create(:base_product, description: nil, name: 'Sample', price: '19.99')
-    Spree::Config.currency = "CAN"
-    Spree::Config.show_products_without_price = true
+    stub_spree_preferences(currency: "CAN")
+    stub_spree_preferences(show_products_without_price: true)
     visit spree.products_path
     expect(page).to have_content(product.name)
   end

--- a/frontend/spec/spec_helper.rb
+++ b/frontend/spec/spec_helper.rb
@@ -75,7 +75,6 @@ RSpec.configure do |config|
 
   config.before(:each) do
     Rails.cache.clear
-    reset_spree_preferences
   end
 
   config.before(:each, type: :feature) do


### PR DESCRIPTION
By freezing `Spree::Config.preference_store` and allowing changes to `Spree::Config` settings only via RSpec stubs we ensure no global settings state change will leak outside the lifecycle of each spec example.

Also, stubbing changes to `Spree::Config` removes the necessity to reset these settings before each spec is run, which in the past encouraged the _not-so-good_ practice of changing the global state and not returning it to the original values.

When writing tests, the preferred way to change `Spree::Config` settings is by using the helper method `stub_spree_preferences`:

```ruby
stub_spree_preferences(currency: 'EUR', track_inventory_levels: true)
```

The helper method `with_unfrozen_spree_preference_store ` can be used when for exceptional reasons one needs to use the unfrozen version of the `preference_store`. This helper method has the advantage of automatically returning the configuration state to the original value:

```ruby
around do |example|
  with_unfrozen_spree_preference_store do
    example.run
  end
end
```

resolve #3219 

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
