### PR TITLE
[API] Complete Shipments Big json with small json fields

### DIFF
--- a/api/app/views/spree/api/shipments/_big.json.jbuilder
+++ b/api/app/views/spree/api/shipments/_big.json.jbuilder
@@ -2,13 +2,7 @@
 
 json.cache! [I18n.locale, shipment] do
   json.(shipment, *shipment_attributes)
-  json.selected_shipping_rate do
-    if shipment.selected_shipping_rate
-      json.partial!("spree/api/shipping_rates/shipping_rate", shipping_rate: shipment.selected_shipping_rate)
-    else
-      json.nil!
-    end
-  end
+  json.partial!("spree/api/shipments/small", shipment: shipment)
   json.inventory_units(shipment.inventory_units) do |inventory_unit|
     json.(inventory_unit, *inventory_unit_attributes)
     json.variant do
@@ -36,9 +30,6 @@ json.cache! [I18n.locale, shipment] do
     end
     json.ship_address do
       json.partial!("spree/api/addresses/address", address: shipment.order.shipping_address)
-    end
-    json.adjustments(shipment.order.adjustments) do |adjustment|
-      json.partial!("spree/api/adjustments/adjustment", adjustment: adjustment)
     end
     json.payments(shipment.order.payments) do |payment|
       json.(payment, :id, :amount, :display_amount, :state)


### PR DESCRIPTION
**Description**
shipments Big json should be a super set of Small json. This adds in the
https://github.com/solidusio/solidus/blob/e7260a27a7c292908a835f374d5ba73fe7284cd0/api/app/views/spree/api/shipments/_big.json.jbuilder file the missing fields that https://github.com/solidusio/solidus/blob/e7260a27a7c292908a835f374d5ba73fe7284cd0/api/app/views/spree/api/shipments/_small.json.jbuilder contains.

Slack conversation: https://solidusio.slack.com/archives/C0JBKDF35/p1559156244045800

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
