### PR TITLE
Use `.take` in admin promotion index template

### DIFF
--- a/backend/app/views/spree/admin/promotions/index.html.erb
+++ b/backend/app/views/spree/admin/promotions/index.html.erb
@@ -78,7 +78,7 @@
         <tr id="<%= spree_dom_id promotion %>">
           <td><%= promotion.name %></td>
           <td>
-            <%= (promotion.codes.size == 1) ? promotion.codes.first.try!(:value) : t('spree.number_of_codes', count: promotion.codes.size) %>
+            <%= (promotion.codes.size == 1) ? promotion.codes.take.try!(:value) : t('spree.number_of_codes', count: promotion.codes.size) %>
           </td>
           <td>
             <span class="pill pill-<%= promotion.active? ? 'active' : 'inactive' %>">


### PR DESCRIPTION
**Description**

`.first` executes an ordered query. This causes noticeable performance issues
with millions of promotions codes. `.take` simply returns the first element the
database can find. Since there is the guard clause for `size == 1`, in this
case `.take` is just a faster `.first`.

The issue is reported here, and contains more details / rationale:

https://github.com/solidusio/solidus/issues/3223

Tests are not provided due to the difficulty in re-creating production-scale performance issues in a test environment.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
