### PR TITLE
Avoid removing product_properties and properties when discard a product

### DIFF
--- a/api/app/controllers/spree/api/product_properties_controller.rb
+++ b/api/app/controllers/spree/api/product_properties_controller.rb
@@ -48,7 +48,7 @@ module Spree
       def destroy
         if @product_property
           authorize! :destroy, @product_property
-          @product_property.destroy
+          @product_property.discard
           respond_with(@product_property, status: 204)
         else
           invalid_resource!(@product_property)

--- a/api/app/controllers/spree/api/properties_controller.rb
+++ b/api/app/controllers/spree/api/properties_controller.rb
@@ -49,7 +49,7 @@ module Spree
       def destroy
         if @property
           authorize! :destroy, @property
-          @property.destroy
+          @property.discard
           respond_with(@property, status: 204)
         else
           invalid_resource!(@property)

--- a/api/spec/requests/spree/api/product_properties_controller_spec.rb
+++ b/api/spec/requests/spree/api/product_properties_controller_spec.rb
@@ -91,10 +91,10 @@ module Spree
         expect(response.status).to eq(200)
       end
 
-      it "can delete a product property" do
+      it "can soft-delete a product property" do
         delete spree.api_product_product_property_path(product, property_1.property_name)
         expect(response.status).to eq(204)
-        expect { property_1.reload }.to raise_error(ActiveRecord::RecordNotFound)
+        expect(property_1.reload.deleted_at).not_to be_nil
       end
     end
 

--- a/api/spec/requests/spree/api/properties_controller_spec.rb
+++ b/api/spec/requests/spree/api/properties_controller_spec.rb
@@ -92,10 +92,10 @@ module Spree
         expect(response.status).to eq(200)
       end
 
-      it "can delete a property" do
+      it "can soft-delete a property" do
         delete spree.api_property_path(property_1.name)
         expect(response.status).to eq(204)
-        expect { property_1.reload }.to raise_error(ActiveRecord::RecordNotFound)
+        expect(property_1.reload.deleted_at).not_to be_nil
       end
     end
   end

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -24,7 +24,7 @@ module Spree
     after_discard do
       variants_including_master.discard_all
       self.product_option_types = []
-      self.product_properties = []
+      product_properties.discard_all
       self.classifications = []
       self.product_promotion_rules = []
     end

--- a/core/app/models/spree/product_property.rb
+++ b/core/app/models/spree/product_property.rb
@@ -1,12 +1,17 @@
 # frozen_string_literal: true
 
+require 'discard'
+
 module Spree
   class ProductProperty < Spree::Base
     include Spree::OrderedPropertyValueList
 
     acts_as_list scope: :product
 
-    belongs_to :product, touch: true, class_name: 'Spree::Product', inverse_of: :product_properties
+    include Discard::Model
+    self.discard_column = :deleted_at
+
+    belongs_to :product, -> { with_deleted }, touch: true, class_name: 'Spree::Product', inverse_of: :product_properties
     belongs_to :property, class_name: 'Spree::Property', inverse_of: :product_properties
 
     self.whitelisted_ransackable_attributes = ['value']

--- a/core/app/models/spree/property.rb
+++ b/core/app/models/spree/property.rb
@@ -2,6 +2,9 @@
 
 module Spree
   class Property < Spree::Base
+    include Discard::Model
+    self.discard_column = :deleted_at
+
     has_many :product_properties, dependent: :delete_all, inverse_of: :property
     has_many :products, through: :product_properties
 

--- a/core/db/migrate/20190614162405_add_deleted_at_to_product_properties.rb
+++ b/core/db/migrate/20190614162405_add_deleted_at_to_product_properties.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddDeletedAtToProductProperties < ActiveRecord::Migration[5.1]
+  def change
+    add_column :spree_product_properties, :deleted_at, :datetime
+    add_index :spree_product_properties, :deleted_at
+  end
+end

--- a/core/db/migrate/20190614162406_add_deleted_at_to_properties.rb
+++ b/core/db/migrate/20190614162406_add_deleted_at_to_properties.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddDeletedAtToProperties < ActiveRecord::Migration[5.1]
+  def change
+    add_column :spree_properties, :deleted_at, :datetime
+    add_index :spree_properties, :deleted_at
+  end
+end

--- a/core/lib/spree/core/product_duplicator.rb
+++ b/core/lib/spree/core/product_duplicator.rb
@@ -68,6 +68,7 @@ module Spree
         prop.dup.tap do |new_prop|
           new_prop.created_at = nil
           new_prop.updated_at = nil
+          new_prop.deleted_at = nil
         end
       end
     end

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -477,6 +477,17 @@ RSpec.describe Spree::Product, type: :model do
         expect(product.possible_promotions).to include(promotion)
       end
     end
+
+    context "#discard" do
+      let(:product_property) { create(:product_property) }
+      let(:product) { product_property.product }
+
+      it "does not delete product properties objects" do
+        product.discard
+        expect(product.product_properties).to be_empty
+        expect(product_property.reload.deleted_at).not_to be_nil
+      end
+    end
   end
 
   context "#images" do


### PR DESCRIPTION
#### Description
Removing(soft-delete) `products` is deleting the `product_properties`, but when you want to bring back the product, the `product_properties` are gone, this change add the soft-delete to `product_property` model