### PR TITLE
Add a Sponsor button to our repository

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+open_collective: solidus


### PR DESCRIPTION
**Description**

This adds a sponsor button to the GitHub repository that links to our Open Collective account.

<img width="106" alt="Schermata 2019-06-13 alle 16 08 07" src="https://user-images.githubusercontent.com/167946/59439379-7a4ecf80-8df5-11e9-8bc8-f11bdf8abce4.png">


Ref: https://help.github.com/en/articles/displaying-a-sponsor-button-in-your-repository
