### PR TITLE
Clarify README instructions for Sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,11 +210,16 @@ testing purposes.
 This sandbox includes solidus\_auth\_devise and generates with seed and sample
 data already loaded.
 
-* Create the sandbox application (`DB=mysql` or `DB=postgresql` can be specified
-  to override the default sqlite)
+* Create the sandbox application 
 
   ```bash
   bundle exec rake sandbox
+  ```
+
+  You can create a sandbox with PostgreSQL or MySQL by setting the DB environment variable.
+
+  ```bash
+  DB=postgresql bundle exec rake sandbox
   ```
 
 * Start the server


### PR DESCRIPTION
Clarifies instructions on instantiating sandbox app with an alternate
database type.

**Description**
At the request of @jacobherrington, this PR clarifies the documentation on how to instantiate a sandbox app using alternate database types.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
