### PR TITLE
Attachment adapters

### DIFF
--- a/backend/app/views/spree/admin/taxons/_form.html.erb
+++ b/backend/app/views/spree/admin/taxons/_form.html.erb
@@ -23,7 +23,7 @@
     <%= f.field_container :icon do %>
       <%= f.label :icon %><br />
       <%= f.file_field :icon %>
-      <%= image_tag f.object.icon(:mini) if f.object.icon.present? %>
+      <%= image_tag f.object.icon(:mini) if f.object.icon_present? %>
     <% end %>
   </div>
 

--- a/core/app/models/spree/image.rb
+++ b/core/app/models/spree/image.rb
@@ -2,55 +2,13 @@
 
 module Spree
   class Image < Asset
-    validate :no_attachment_errors
-
-    has_attached_file :attachment,
-                      styles: { mini: '48x48>', small: '100x100>', product: '240x240>', large: '600x600>' },
-                      default_style: :product,
-                      default_url: 'noimage/:style.png',
-                      url: '/spree/products/:id/:style/:basename.:extension',
-                      path: ':rails_root/public/spree/products/:id/:style/:basename.:extension',
-                      convert_options: { all: '-strip -auto-orient -colorspace sRGB' }
-    validates_attachment :attachment,
-      presence: true,
-      content_type: { content_type: %w(image/jpeg image/jpg image/png image/gif) }
-
-    # save the w,h of the original image (from which others can be calculated)
-    # we need to look at the write-queue for images which have not been saved yet
-    after_post_process :find_dimensions, if: :valid?
+    include ::Spree::Config.image_attachment_module
 
     def mini_url
       Spree::Deprecation.warn(
         'Spree::Image#mini_url is DEPRECATED. Use Spree::Image#url(:mini) instead.'
       )
-      attachment.url(:mini, false)
-    end
-
-    def url(size)
-      attachment.url(size)
-    end
-
-    def filename
-      attachment_file_name
-    end
-
-    def find_dimensions
-      temporary = attachment.queued_for_write[:original]
-      filename = temporary.path unless temporary.nil?
-      filename = attachment.path if filename.blank?
-      geometry = Paperclip::Geometry.from_file(filename)
-      self.attachment_width  = geometry.width
-      self.attachment_height = geometry.height
-    end
-
-    # if there are errors from the plugin, then add a more meaningful message
-    def no_attachment_errors
-      unless attachment.errors.empty?
-        # uncomment this to get rid of the less-than-useful interim messages
-        # errors.clear
-        errors.add :attachment, "Paperclip returned errors for file '#{attachment_file_name}' - check ImageMagick installation or image source file."
-        false
-      end
+      url(:mini)
     end
   end
 end

--- a/core/app/models/spree/image/paperclip_attachment.rb
+++ b/core/app/models/spree/image/paperclip_attachment.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Spree::Image::PaperclipAttachment
+  extend ActiveSupport::Concern
+
+  included do
+    validate :no_attachment_errors
+
+    has_attached_file :attachment,
+                      styles: { mini: '48x48>', small: '100x100>', product: '240x240>', large: '600x600>' },
+                      default_style: :product,
+                      default_url: 'noimage/:style.png',
+                      url: '/spree/products/:id/:style/:basename.:extension',
+                      path: ':rails_root/public/spree/products/:id/:style/:basename.:extension',
+                      convert_options: { all: '-strip -auto-orient -colorspace sRGB' }
+    validates_attachment :attachment,
+      presence: true,
+      content_type: { content_type: %w[image/jpeg image/jpg image/png image/gif] }
+
+    # save the w,h of the original image (from which others can be calculated)
+    # we need to look at the write-queue for images which have not been saved yet
+    after_post_process :find_dimensions, if: :valid?
+  end
+
+  def url(size)
+    attachment.url(size)
+  end
+
+  def filename
+    attachment_file_name
+  end
+
+  def attachment_present?
+    attachment.present?
+  end
+
+  def find_dimensions
+    temporary = attachment.queued_for_write[:original]
+    filename = temporary.path unless temporary.nil?
+    filename = attachment.path if filename.blank?
+    geometry = Paperclip::Geometry.from_file(filename)
+    self.attachment_width  = geometry.width
+    self.attachment_height = geometry.height
+  end
+
+  # if there are errors from the plugin, then add a more meaningful message
+  def no_attachment_errors
+    unless attachment.errors.empty?
+      # uncomment this to get rid of the less-than-useful interim messages
+      # errors.clear
+      errors.add :attachment, "Paperclip returned errors for file '#{attachment_file_name}' - check ImageMagick installation or image source file."
+      false
+    end
+  end
+end

--- a/core/app/models/spree/taxon.rb
+++ b/core/app/models/spree/taxon.rb
@@ -25,15 +25,7 @@ module Spree
     after_save :touch_ancestors_and_taxonomy
     after_touch :touch_ancestors_and_taxonomy
 
-    has_attached_file :icon,
-      styles: { mini: '32x32>', normal: '128x128>' },
-      default_style: :mini,
-      url: '/spree/taxons/:id/:style/:basename.:extension',
-      path: ':rails_root/public/spree/taxons/:id/:style/:basename.:extension',
-      default_url: '/assets/default_taxon.png'
-
-    validates_attachment :icon,
-      content_type: { content_type: ["image/jpg", "image/jpeg", "image/png", "image/gif"] }
+    include ::Spree::Config.taxon_attachment_module
 
     self.whitelisted_ransackable_attributes = %w[name]
 

--- a/core/app/models/spree/taxon/paperclip_attachment.rb
+++ b/core/app/models/spree/taxon/paperclip_attachment.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Spree::Taxon::PaperclipAttachment
+  extend ActiveSupport::Concern
+
+  included do
+    has_attached_file :icon,
+      styles: { mini: '32x32>', normal: '128x128>' },
+      default_style: :mini,
+      url: '/spree/taxons/:id/:style/:basename.:extension',
+      path: ':rails_root/public/spree/taxons/:id/:style/:basename.:extension',
+      default_url: '/assets/default_taxon.png'
+
+    validates_attachment :icon,
+      content_type: { content_type: %w[image/jpg image/jpeg image/png image/gif] }
+  end
+
+  def icon_present?
+    icon.present?
+  end
+end

--- a/core/lib/generators/spree/install/templates/config/initializers/spree.rb.tt
+++ b/core/lib/generators/spree/install/templates/config/initializers/spree.rb.tt
@@ -18,6 +18,9 @@ Spree.config do |config|
   # any inventory changes.
   # config.inventory_cache_threshold = 3
 
+  # Enable Paperclip adapter for attachments on images and taxons
+  config.image_attachment_module = 'Spree::Image::PaperclipAttachment'
+  config.taxon_attachment_module = 'Spree::Taxon::PaperclipAttachment'
 
   # Frontend:
 

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -433,6 +433,16 @@ module Spree
     # Enumerable of images adhering to the present_image_class interface
     class_name_attribute :image_attachment_module, default: 'Spree::Image::PaperclipAttachment'
 
+    # Allows switching attachment library for Taxon
+    #
+    # `Spree::Taxon::PaperclipAttachment`
+    # is the default and provides the classic Paperclip implementation.
+    #
+    # @!attribute [rw] taxon_attachment_module
+    # @return [Module] a module that can be included into Spree::Taxon to allow attachments
+    # Enumerable of taxons adhering to the present_taxon_class interface
+    class_name_attribute :taxon_attachment_module, default: 'Spree::Taxon::PaperclipAttachment'
+
     # Allows providing your own class instance for generating order numbers.
     #
     # @!attribute [rw] order_number_generator

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -423,6 +423,16 @@ module Spree
     # Enumerable of images adhering to the present_image_class interface
     class_name_attribute :product_gallery_class, default: 'Spree::Gallery::ProductGallery'
 
+    # Allows switching attachment library for Image
+    #
+    # `Spree::Image::PaperclipAttachment`
+    # is the default and provides the classic Paperclip implementation.
+    #
+    # @!attribute [rw] image_attachment_module
+    # @return [Module] a module that can be included into Spree::Image to allow attachments
+    # Enumerable of images adhering to the present_image_class interface
+    class_name_attribute :image_attachment_module, default: 'Spree::Image::PaperclipAttachment'
+
     # Allows providing your own class instance for generating order numbers.
     #
     # @!attribute [rw] order_number_generator

--- a/core/lib/spree/testing_support/dummy_app.rb
+++ b/core/lib/spree/testing_support/dummy_app.rb
@@ -12,14 +12,11 @@ Rails.env = 'test'
 
 require 'solidus_core'
 
-# @private
-def forgery_protected_by_default?
-  Gem::Version.new(Rails.version) >= Gem::Version.new('5.2')
-end
+RAILS_52_OR_ABOVE = Gem::Version.new(Rails.version) >= Gem::Version.new('5.2')
 
 # @private
 class ApplicationController < ActionController::Base
-  if !forgery_protected_by_default?
+  unless RAILS_52_OR_ABOVE
     protect_from_forgery with: :exception
   end
 end
@@ -65,12 +62,8 @@ module DummyApp
     config.active_support.deprecation                 = :stderr
     config.secret_key_base                            = 'SECRET_TOKEN'
 
-    if forgery_protected_by_default?
+    if RAILS_52_OR_ABOVE
       config.action_controller.default_protect_from_forgery = true
-    end
-
-    if config.active_record.sqlite3
-      # Rails >= 5.2
       config.active_record.sqlite3.represent_boolean_as_integer = true
     end
 


### PR DESCRIPTION
**Description**

_This PR has been extracted from https://github.com/solidusio/solidus/pull/2974 as [suggested](https://github.com/solidusio/solidus/pull/2974#issuecomment-503125134) by @kennyadsl_

Paperclip has been officially deprecated and is no more maintained, but the supposed replacement with ActiveStorage is not possible to due to lack of proper support for public long-term urls. 

This PR allows Image and Taxon to switch their attachment implementation, extracting Paperclip to a concern, and opening the door for alternative implementations (e.g. Carrierwave, Shrine, AttachmentFu, [et cetera](https://www.ruby-toolbox.com/categories/rails_file_uploads)).

 
**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)