### PR TITLE
Improve gem-release configuration

### DIFF
--- a/.gem_release.yml
+++ b/.gem_release.yml
@@ -2,7 +2,6 @@ bump:
   recurse: false
   file: 'core/lib/spree/core/version.rb'
   message: Bump Solidus to %{version}
-  branch: true
 
 release:
   recurse: true


### PR DESCRIPTION
Sometimes we don't want to create a new branch when releasing, pushing the new version to master is just fine.

Removing this configuration allows run commands like:

```
gem bump -v rc --pretend --tag --push --remote upstream
```
