### PR TITLE
Add zone link

### DIFF
--- a/guides/source/developers/taxation/overview.html.md
+++ b/guides/source/developers/taxation/overview.html.md
@@ -49,13 +49,15 @@ In Solidus, a tax rate consists of at least four values:
 
 - The descriptive name for the tax rate. For example, "Minnesota Sales Tax" for
   a Minnesota state tax rate.
-- The zone that the tax rate should apply to. <!-- TODO: Link to zones article.-->
+- The [zone][zone] that the tax rate should apply to.
 - The rate (in the form of a percentage of the price).
 - The "Included in price" boolean. This indicates whether the tax is included in
   the price (for value-added taxes) or added to the price (U.S. taxes).
 
 Solidus calculates tax based on the matching tax rate(s) for the order's [tax
-address](#tax-addresses). 
+address](#tax-addresses).
+
+[zone]: ../locations/zones.html
 
 ## Tax addresses
 


### PR DESCRIPTION
I found this comment that was showing up, so I went ahead and added the missing link
![image](https://user-images.githubusercontent.com/11466782/60554860-1dad4900-9cff-11e9-91f7-91cc4b797e89.png)
