### PR TITLE
Add missing CSS classes

### DIFF
--- a/backend/app/views/spree/admin/product_properties/index.html.erb
+++ b/backend/app/views/spree/admin/product_properties/index.html.erb
@@ -7,7 +7,7 @@
   <% if can?(:create, Spree::ProductProperty) %>
     <ul class="tollbar inline-menu">
       <li>
-        <%= link_to_add_fields t('spree.add_product_properties'), 'tbody#product_properties', class: 'plus button' %>
+        <%= link_to_add_fields t('spree.add_product_properties'), 'tbody#product_properties', class: 'plus btn btn-primary' %>
       </li>
     </ul>
   <% end %>

--- a/backend/app/views/spree/admin/variants/index.html.erb
+++ b/backend/app/views/spree/admin/variants/index.html.erb
@@ -8,7 +8,7 @@
       <%= link_to(
         t('spree.new_variant'),
         new_admin_product_variant_url(@product),
-        class: 'button'
+        class: 'btn btn-primary'
       ) %>
     </li>
   <% end %>


### PR DESCRIPTION
This is a small UI mistake. We are missing a CSS class here which makes this button look different than the other Product buttons.

Before:
![image](https://user-images.githubusercontent.com/11466782/60556585-b2b44000-9d07-11e9-9956-325f4e7adcb1.png)

After:
![image](https://user-images.githubusercontent.com/11466782/60556610-cf507800-9d07-11e9-8195-c5cf33767821.png)

Example of another Product button:
![image](https://user-images.githubusercontent.com/11466782/60556622-e1321b00-9d07-11e9-82fa-6d820f1a47f4.png)


