### PR TITLE
Require spree/event/subscriber before using it

### DIFF
--- a/core/app/subscribers/spree/mailer_subscriber.rb
+++ b/core/app/subscribers/spree/mailer_subscriber.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'spree/event/subscriber'
+
 module Spree
   module MailerSubscriber
     include Spree::Event::Subscriber


### PR DESCRIPTION
**Description**

Otherwise it would raise an error when this file is loaded before `spree/core`, for example, while executing a Rails generator in `/core` directory.

Closes #3249 

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
~- [ ] I have updated Guides and README accordingly to this change (if needed)~
- [ ] I have added tests to cover this change (if needed)
