### PR TITLE
Upgrade to CircleCI 2.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 jobs:
   postgres: &postgres
     working_directory: &workdir ~/solidus
@@ -72,7 +72,6 @@ jobs:
       RAILS_VERSION: '~> 5.1.0'
 
 workflows:
-  version: 2
   build:
     jobs:
       - postgres

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
       - run: |
           bundle install --path=vendor/bundle
 
-      - cache-save:
+      - save_cache:
           key: solidus-gems-v1-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle


### PR DESCRIPTION
**Description**

Upgrades to CircleCI 2.1, which allows us to use Orbs. This is especially important for https://github.com/solidusio/solidus/pull/3252, since we want to use [this Orb](https://github.com/nebulab/circleci-orbs-stoplight) for keeping the OAS documentation in sync with Stoplight.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
