### PR TITLE
Update Rubocop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ AllCops:
     - '*/spec/dummy/**/*'
     - 'sandbox/**/*'
     - '**/templates/**/*'
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.3
 
 # Sometimes I believe this reads better
 # This also causes spacing issues on multi-line fixes
@@ -85,10 +85,10 @@ Layout/ClosingParenthesisIndentation:
 Layout/MultilineMethodCallIndentation:
   Enabled: false
 
-Layout/IndentArray:
+Layout/IndentFirstArrayElement:
   Enabled: false
 
-Layout/IndentHash:
+Layout/IndentFirstHashElement:
   Enabled: false
 
 Layout/AlignHash:


### PR DESCRIPTION
**Description**

This change is needed to avoid using deprecated configuration. Also, the target Ruby version is moved from 2.2 to 2.3.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
~- [ ] I have updated Guides and README accordingly to this change (if needed)~
~- [ ] I have added tests to cover this change (if needed)~
