### PR TITLE
Improve Spree::Event guides

### DIFF
--- a/guides/source/developers/events/overview.html.md
+++ b/guides/source/developers/events/overview.html.md
@@ -1,12 +1,19 @@
 # Events
 
-The `Spree::Event` module allows to fire and subscribe events inside Solidus codebase and extensions.
+The `Spree::Event` module allows to fire and subscribe events inside the
+Solidus codebase and extensions.
 
-The module can use different adapters that actually manage events at low level, the default adapter is Rails `ActiveSupport::Notification`. Future releases may include other adapters.
+The module can use different adapters that actually manage events at a low
+level, the default adapter is Rails `ActiveSupport::Notification`. Future
+releases may include other adapters.
 
-Among other uses, Solidus codebase uses events in order to send confirmation emails when an order is finalized, or again to send emails when an order is refunded successfully.
+Among other uses, the Solidus codebase uses events in order to send
+confirmation emails when an order is finalized, or again to send emails
+when an order is refunded successfully.
 
-Events make easy extending Solidus with custom behavior. For example, if besides the standard email you also want to send a SMS text message to the customer when a order is finalized, this pseudo-code may do the trick:
+Events make extending Solidus with custom behavior easy. For example,
+if besides the standard email you also want to send a SMS text message to
+the customer when a order is finalized, this pseudo-code may do the trick:
 
 ```ruby
 Spree::Event.subscribe 'order_finalized' do |event|
@@ -25,7 +32,9 @@ Spree::Config.events.adapter = "Spree::EventBus.new"
 
 ## Subscribing to events
 
-`Spree::Event.subscribe` allows to subscribe to a certain event. The event name is mandatory, the optional block will be executed every time the event is fired:
+`Spree::Event.subscribe` allows to subscribe to a certain event. The event
+name is mandatory, the optional block will be executed every time the event
+is fired:
 
 ```ruby
 Spree::Event.subscribe 'order_finalized' do |event|
@@ -36,7 +45,9 @@ end
 
 ## Firing events
 
-`Spree::Event.fire` allows to fire an event. The event name is mandatory, then both a hash of options (it will be available as the event payload) and an optional code block can be passed:
+`Spree::Event.fire` allows you to fire an event. The event name is mandatory,
+then both a hash of options (it will be available as the event payload)
+and an optional code block can be passed:
 
 ```ruby
 Spree::Event.fire 'order_finalized', order: @order do
@@ -44,11 +55,13 @@ Spree::Event.fire 'order_finalized', order: @order do
 end
 ```
 
-This is an alternative way to basically have the same functionality but without the block:
+This is an alternative way to basically have the same functionality but
+without the block:
 
 ```ruby
 @order.finalize!
 Spree::Event.fire 'order_finalized', order: @order
 ```
 
-For further information, please refer to the RDOC documentation included in the `Spree::Event` module.
+For further information, please refer to the RDOC documentation included in
+the `Spree::Event` module.


### PR DESCRIPTION
**Description**

This PR re-formats `Spree::Event` guides page and adds a paragraph that explains how to create subscribers modules, after #3232 changes.

cc @elia 

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
~- [ ] I have added tests to cover this change (if needed)~
