### PR TITLE
Bump CircleCi gems cache key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,14 +44,14 @@ commands:
 
       - restore_cache:
           keys:
-            - solidus-gems-v1-{{ .Branch }}
-            - solidus-gems-v1
+            - solidus-gems-v2-{{ .Branch }}
+            - solidus-gems-v2
 
       - run: |
           bundle install --path=vendor/bundle
 
       - save_cache:
-          key: solidus-gems-v1-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+          key: solidus-gems-v2-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle
 


### PR DESCRIPTION
**Description**

Ref #3271 

The docker image that we are using for MySQL has been recently updated: https://hub.docker.com/r/circleci/mysql

This update changed some internal path or library that were cached into our gem cache in CircleCI for `mysql2 0.5.2`. This happens because native extensions are cached along with the gems and are not rebuilt at every job run.

To clear CircleCI cache we can only change the cache key to rebuild it from scratch, as described in their docs:

https://circleci.com/docs/2.0/caching/#clearing-cache

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
~- [ ] I have updated Guides and README accordingly to this change (if needed)~
~- [ ] I have added tests to cover this change (if needed)~
