### PR TITLE
Update Tab colors with its own variables

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/components/_tabs.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_tabs.scss
@@ -1,7 +1,7 @@
 .tabs {
   display: flex;
   margin: 1em 0;
-  border-bottom: 1px solid $color-border;
+  border-bottom: 1px solid $color-tab-border;
   white-space: nowrap;
 
   &,
@@ -26,9 +26,9 @@
   top: 2px;
 
   > a {
-    color: $color-navbar-submenu;
+    color: $color-tab;
     display: block;
-    border: 1px solid $color-border;
+    border: 1px solid $color-tab-border;
     border-radius: 4px 4px 0 0;
     line-height: 1;
   }
@@ -38,19 +38,19 @@
   }
 
   &:not(.active) > a {
-    background: $color-tbl-thead;
+    background: $color-tab-bg;
   }
 
   &.active > a,
   &.active:hover {
-    background: white;
-    border-bottom-color: white;
-    color: $color-navbar-active;
+    background: $color-tab-active-bg;
+    border-bottom-color: $color-tab-active-border;
+    color: $color-tab-active;
     font-weight: $font-weight-bold;
   }
 
   &:not(.active):hover > a {
-    color: $color-navbar-active;
+    color: $color-tab-active;
   }
 }
 
@@ -70,7 +70,7 @@
 
   > a {
     position: relative;
-    background: white;
+    background: $color-tab-active-bg;
     z-index: 1;
 
     &:before {
@@ -81,7 +81,7 @@
   }
 
   &:hover > a {
-    background: white;
+    background: $color-tab-active-bg;
   }
 
   &:not(:hover) ul {
@@ -99,7 +99,7 @@
 .tabs li.in-dropdown {
   a {
     display: block;
-    border: 1px solid $color-border;
+    border: 1px solid $color-tab-border;
     background: white;
   }
 

--- a/backend/app/assets/stylesheets/spree/backend/globals/_variables.scss
+++ b/backend/app/assets/stylesheets/spree/backend/globals/_variables.scss
@@ -53,6 +53,14 @@ $color-navbar-footer-bg:        $color-light !default;
 $color-navbar-footer-active:    $color-primary !default;
 $color-icon-navbar:             $color-dark-light !default;
 
+// Basic Tabs colors
+$color-tab:                     $color-dark-light !default;
+$color-tab-bg:                  very-light($color-dark-light, 4) !default;
+$color-tab-border:              $color-border !default;
+$color-tab-active:              $color-primary !default;
+$color-tab-active-bg:           $color-white !default;
+$color-tab-active-border:       $color-white !default;
+
 // Basic flash colors
 @include bs-deprecated-variable("color-success", "brand-success");
 $color-success:                 $color-green !default;


### PR DESCRIPTION
Avoid using navbar variables and general variables color, about Tabs.
Dedicated variables has been added.

This is necessary to fix the color of the active tab item, and to avoid such mistakes on the future.

<img width="747" alt="white_color" src="https://user-images.githubusercontent.com/46188345/61364491-3c2a4d00-a886-11e9-9164-224027932934.png">

The right view:

<img width="745" alt="corrected_view" src="https://user-images.githubusercontent.com/46188345/61365293-c32bf500-a887-11e9-951b-d5264c32a22f.png">