### PR TITLE
Freeze preferences for Backend, Frontend and Api specs as well

### DIFF
--- a/api/spec/features/checkout_spec.rb
+++ b/api/spec/features/checkout_spec.rb
@@ -4,7 +4,9 @@ require 'spec_helper'
 
 module Spree
   describe 'Api Feature Specs', type: :request do
-    before { Spree::Api::Config[:requires_authentication] = false }
+    before do
+      stub_spree_preferences(Spree::Api::Config, requires_authentication: false)
+    end
     let!(:promotion) { FactoryBot.create(:promotion, :with_order_adjustment, code: 'foo', weighted_order_adjustment_amount: 10) }
     let(:promotion_code) { promotion.codes.first }
     let!(:store) { FactoryBot.create(:store) }

--- a/api/spec/models/spree/legacy_user_spec.rb
+++ b/api/spec/models/spree/legacy_user_spec.rb
@@ -54,7 +54,7 @@ module Spree
 
           before {
             user.clear_spree_api_key!
-            stub_spree_preferences roles_for_auto_api_key: ['hobbit']
+            stub_spree_preferences(roles_for_auto_api_key: ['hobbit'])
           }
 
           it { expect { subject }.to change { user.reload.spree_api_key }.from(nil) }

--- a/api/spec/requests/spree/api/checkouts_controller_spec.rb
+++ b/api/spec/requests/spree/api/checkouts_controller_spec.rb
@@ -6,7 +6,7 @@ module Spree
   describe Api::CheckoutsController, type: :request do
     before(:each) do
       stub_authentication!
-      stub_spree_preferences track_inventory_levels: false
+      stub_spree_preferences(track_inventory_levels: false)
       country_zone = create(:zone, name: 'CountryZone')
       @state = create(:state)
       @country = @state.country

--- a/api/spec/requests/spree/api/products_controller_spec.rb
+++ b/api/spec/requests/spree/api/products_controller_spec.rb
@@ -326,11 +326,7 @@ module Spree
         # Regression test for https://github.com/spree/spree/issues/2140
         context "with authentication_required set to false" do
           before do
-            Spree::Api::Config.requires_authentication = false
-          end
-
-          after do
-            Spree::Api::Config.requires_authentication = true
+            stub_spree_preferences(Spree::Api::Config, requires_authentication: false)
           end
 
           it "can still create a product" do

--- a/api/spec/requests/spree/api/unauthenticated_products_controller_spec.rb
+++ b/api/spec/requests/spree/api/unauthenticated_products_controller_spec.rb
@@ -9,7 +9,9 @@ module Spree
     let(:attributes) { [:id, :name, :description, :price, :available_on, :slug, :meta_description, :meta_keywords, :taxon_ids, :meta_title] }
 
     context "without authentication" do
-      before { Spree::Api::Config[:requires_authentication] = false }
+      before do
+        stub_spree_preferences(Spree::Api::Config, requires_authentication: false)
+      end
 
       it "retrieves a list of products" do
         get spree.api_products_path

--- a/api/spec/spec_helper.rb
+++ b/api/spec/spec_helper.rb
@@ -59,7 +59,7 @@ RSpec.configure do |config|
 
   config.before(:each) do
     Rails.cache.clear
-    Spree::Api::Config[:requires_authentication] = true
+    stub_spree_preferences(Spree::Api::Config, requires_authentication: true)
   end
 
   config.include ActiveJob::TestHelper

--- a/api/spec/spec_helper.rb
+++ b/api/spec/spec_helper.rb
@@ -59,7 +59,6 @@ RSpec.configure do |config|
 
   config.before(:each) do
     Rails.cache.clear
-    stub_spree_preferences(Spree::Api::Config, requires_authentication: true)
   end
 
   config.include ActiveJob::TestHelper

--- a/backend/spec/features/admin/locale_spec.rb
+++ b/backend/spec/features/admin/locale_spec.rb
@@ -19,12 +19,11 @@ describe "setting locale", type: :feature do
         },
         listing_orders: "Ordres"
       })
-    Spree::Backend::Config[:locale] = "fr"
+    stub_spree_preferences(Spree::Backend::Config, locale: "fr")
   end
 
   after do
     I18n.locale = I18n.default_locale
-    Spree::Backend::Config[:locale] = "en"
     ActionView::Base.raise_on_missing_translations = true
   end
 

--- a/core/spec/models/spree/stock/quantifier_spec.rb
+++ b/core/spec/models/spree/stock/quantifier_spec.rb
@@ -27,7 +27,7 @@ module Spree
         end
 
         context 'when track_inventory_levels is false' do
-          before { stub_spree_preferences track_inventory_levels: false }
+          before { stub_spree_preferences(track_inventory_levels: false) }
 
           specify { expect(subject.total_on_hand).to eq(Float::INFINITY) }
 

--- a/frontend/spec/controllers/controller_helpers_spec.rb
+++ b/frontend/spec/controllers/controller_helpers_spec.rb
@@ -8,7 +8,7 @@ require 'spec_helper'
 describe Spree::ProductsController, type: :controller do
   before do
     I18n.enforce_available_locales = false
-    Spree::Frontend::Config[:locale] = :de
+    stub_spree_preferences(Spree::Frontend::Config, locale: :de)
     I18n.backend.store_translations(:de, spree: {
       i18n: { this_file_language: "Deutsch (DE)" }
     })
@@ -16,7 +16,6 @@ describe Spree::ProductsController, type: :controller do
 
   after do
     I18n.reload!
-    Spree::Frontend::Config[:locale] = :en
     I18n.locale = :en
     I18n.enforce_available_locales = true
   end

--- a/frontend/spec/features/locale_spec.rb
+++ b/frontend/spec/features/locale_spec.rb
@@ -6,11 +6,10 @@ describe 'setting locale', type: :feature do
   let!(:store) { create(:store) }
   def with_locale(locale)
     I18n.locale = locale
-    Spree::Frontend::Config[:locale] = locale
+    stub_spree_preferences(Spree::Frontend::Config, locale: locale)
     yield
   ensure
     I18n.locale = I18n.default_locale
-    Spree::Frontend::Config[:locale] = 'en'
   end
 
   context 'shopping cart link and page' do


### PR DESCRIPTION
**Description**

This PR completes the work started with #3220. 

It freezes preferences for sub gems as well, also allowing to use `stub_spree_preferences` into stores and extensions that define their own configuration classes, like `Spree::Auth::Config` in `solidus_auth_devise` for example.

I plan to backport this into 2.9.x because I think this change is mandatory to be able to correctly stub preferences (instead of resetting them) into extensions.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
~- [ ] I have updated Guides and README accordingly to this change (if needed)~
~- [ ] I have added tests to cover this change (if needed)~
