### PR TITLE
Only display Store Credit links with permission

### DIFF
--- a/backend/app/views/spree/admin/store_credits/index.html.erb
+++ b/backend/app/views/spree/admin/store_credits/index.html.erb
@@ -6,7 +6,7 @@
 <%= render 'spree/admin/users/sidebar' %>
 <%= render 'spree/admin/users/tabs', current: :store_credits %>
 <% content_for :page_actions do %>
-  <% if can?(:create, Spree::StoreCredit) %>
+  <% if can?(:create, @user.store_credits.new) %>
     <li><%= link_to t('spree.admin.store_credits.add'), new_admin_user_store_credit_path(@user), class: 'button btn btn-primary' %></li>
   <% end %>
 <% end %>

--- a/backend/app/views/spree/admin/users/_tabs.html.erb
+++ b/backend/app/views/spree/admin/users/_tabs.html.erb
@@ -19,7 +19,7 @@
           <%= link_to t("spree.admin.user.items"), spree.items_admin_user_path(@user) %>
         </li>
       <% end %>
-      <% if can?(:display, Spree::StoreCredit) %>
+      <% if can?(:display, @user.store_credits.new) %>
         <li<%== ' class="active"' if current == :store_credits %>>
           <%= link_to t("spree.admin.user.store_credit"), spree.admin_user_store_credits_path(@user) %>
         </li>


### PR DESCRIPTION
**Description**

This change hides the "Add Store Credit" button if the user does not have permission to create a customers store credits.

Within our application we are scoping user permissions by stores. The admin users are only allowed to manage a customers store credits if they're a manager of the customers store. So the permissions check needs to be done on a new users store credit rather than the class itself.

https://github.com/CanCanCommunity/cancancan/wiki/Nested-Resources#accessing-parent-in-ability

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
