### PR TITLE
Link to documentation after sandbox task

### DIFF
--- a/lib/sandbox.sh
+++ b/lib/sandbox.sh
@@ -57,3 +57,8 @@ bundle install --gemfile Gemfile
 bundle exec rake db:drop db:create
 bundle exec rails g spree:install --auto-accept --user_class=Spree::User --enforce_available_locales=true
 bundle exec rails g solidus:auth:install
+
+echo "
+This app is intended for test purposes. If you're interested in running
+Solidus in production, visit:
+https://guides.solidus.io/developers/getting-started/first-time-installation.html 🚀"


### PR DESCRIPTION
**Description**
This adds a message to the end of sandbox creation to inform the user
that the application is intended for test purposes and directs people to
the First-time installation guide.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
~- [ ] I have updated Guides and README accordingly to this change (if needed)~
~- [ ] I have added tests to cover this change (if needed)~
