### PR TITLE
Attempt to fix flaky specs

### DIFF
--- a/backend/spec/features/admin/orders/new_refund_spec.rb
+++ b/backend/spec/features/admin/orders/new_refund_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'New Refund creation', :js do
       fill_in 'refund_amount', with: amount
       select reason.name, from: 'Reason'
       click_button 'Refund'
-      expect(find('input[type="submit"]')).to be_disabled
+      expect(page).to have_button('Refund', disabled: true)
     end
   end
 end

--- a/backend/spec/features/admin/products/edit/taxons_spec.rb
+++ b/backend/spec/features/admin/products/edit/taxons_spec.rb
@@ -29,7 +29,13 @@ describe "Product Display Order", type: :feature do
       select2_search "Clothing", from: "Taxon"
       assert_selected_taxons([taxon_1, taxon_2])
 
+      # Without this line we have a flaky spec probably due to select2 not
+      # closing its fixed overlay correctly. Clicking anywhere in the page
+      # before submit apparently solves the issue.
+      find('.edit_product', visible: true, obscured: false).click
+
       click_button "Update"
+
       within('.flash') do
         expect(page).to have_content(%(Product "#{product.name}" has been successfully updated!))
       end

--- a/backend/spec/features/admin/products/edit/taxons_spec.rb
+++ b/backend/spec/features/admin/products/edit/taxons_spec.rb
@@ -26,13 +26,13 @@ describe "Product Display Order", type: :feature do
       visit spree.edit_admin_product_path(product)
 
       assert_selected_taxons([taxon_1])
-
       select2_search "Clothing", from: "Taxon"
       assert_selected_taxons([taxon_1, taxon_2])
 
       click_button "Update"
-
-      expect(find(".flash")).to have_text "Product \"#{product.name}\" has been successfully updated!"
+      within('.flash') do
+        expect(page).to have_content(%(Product "#{product.name}" has been successfully updated!))
+      end
       assert_selected_taxons([taxon_1, taxon_2])
     end
 


### PR DESCRIPTION
**Description**
This is an attempt to fix a couple of flaky specs that we have:

- https://circleci.com/gh/nebulab/solidus/2687#tests/containers/1 🔴 
- https://circleci.com/gh/nebulab/solidus/2686#tests/containers/1 🔴 

Using a more standard way of checking HTML elements state for Capybara could fix the issue since, using the current code, it could not be waiting for the element to change state/appear on the page.

Labeled as WIP. I'd like to re-run specs a lot of times before merge. Progress can be monitored here:

https://circleci.com/gh/nebulab/workflows/solidus/tree/kennyadsl%2Ffix-flaky-attempt

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
~- [ ] I have updated Guides and README accordingly to this change (if needed)~
~- [ ] I have added tests to cover this change (if needed)~
