### PR TITLE
Remove zombie promotion specs variables

### DIFF
--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -582,7 +582,6 @@ RSpec.describe Spree::Promotion, type: :model do
     end
 
     context "when the promotion's usage limit is exceeded" do
-      let(:order) { FactoryBot.create(:completed_order_with_promotion, promotion: promotion) }
       let(:promotion) { FactoryBot.create(:promotion, :with_order_adjustment) }
 
       before do
@@ -599,7 +598,6 @@ RSpec.describe Spree::Promotion, type: :model do
     end
 
     context "when the promotion code's usage limit is exceeded" do
-      let(:order) { FactoryBot.create(:completed_order_with_promotion, promotion: promotion) }
       let(:promotion) { create(:promotion, :with_order_adjustment, code: 'abc123', per_code_usage_limit: 1) }
       let(:promotion_code) { promotion.codes.first }
 
@@ -636,8 +634,6 @@ RSpec.describe Spree::Promotion, type: :model do
     end
 
     context "when promotable is a Spree::Order" do
-      let(:promotable) { create :order }
-
       context "and it is empty" do
         it { is_expected.to be true }
       end


### PR DESCRIPTION
While working on a different issue I noticed the following vars seem to be zombies in the promo specs:
- `order`: is defined and not used
- `promotable`: is already defined in the parent context.

**Checklist:**
- [ ] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [ ] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
