### PR TITLE
[Guides] Bump JS libs for security vulnerabilities

### DIFF
--- a/guides/package.json
+++ b/guides/package.json
@@ -33,7 +33,7 @@
     "axios": "^0.18.1",
     "dompurify": "1.0.10",
     "headroom.js": "0.9.4",
-    "jquery": "^3.2.1",
+    "jquery": "^3.4.0",
     "js-yaml": "^3.13.1",
     "lunr": "2.2.0",
     "numeral": "^2.0.6",

--- a/guides/package.json
+++ b/guides/package.json
@@ -30,12 +30,13 @@
     "webpack-merge": "^4.1.2"
   },
   "dependencies": {
+    "dompurify": "1.0.10",
     "headroom.js": "0.9.4",
     "jquery": "^3.2.1",
-    "numeral": "^2.0.6",
-    "popper.js": "^1.14.3",
+    "js-yaml": "^3.13.1",
     "lunr": "2.2.0",
-    "dompurify": "1.0.10"
+    "numeral": "^2.0.6",
+    "popper.js": "^1.14.3"
   },
   "babel": {
     "presets": [

--- a/guides/package.json
+++ b/guides/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "axios": "^0.18.1",
+    "debug": "^2.6.9",
     "dompurify": "1.0.10",
     "headroom.js": "0.9.4",
     "jquery": "^3.4.0",

--- a/guides/package.json
+++ b/guides/package.json
@@ -30,6 +30,7 @@
     "webpack-merge": "^4.1.2"
   },
   "dependencies": {
+    "axios": "^0.18.1",
     "dompurify": "1.0.10",
     "headroom.js": "0.9.4",
     "jquery": "^3.2.1",

--- a/guides/yarn.lock
+++ b/guides/yarn.lock
@@ -354,6 +354,14 @@ axios@0.17.1:
     follow-redirects "^1.2.5"
     is-buffer "^1.1.5"
 
+axios@^0.18.1:
+  version "0.18.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.18.1.tgz#ff3f0de2e7b5d180e757ad98000f1081b87bcea3"
+  integrity sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==
+  dependencies:
+    follow-redirects "1.5.10"
+    is-buffer "^2.0.2"
+
 babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
@@ -2696,6 +2704,13 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.1"
     readable-stream "^2.0.4"
 
+follow-redirects@1.5.10:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
+  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
+  dependencies:
+    debug "=3.1.0"
+
 follow-redirects@^1.2.5:
   version "1.5.9"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.9.tgz#c9ed9d748b814a39535716e531b9196a845d89c6"
@@ -3284,6 +3299,11 @@ is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
+
+is-buffer@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.3.tgz#4ecf3fcf749cbd1e472689e109ac66261a25e725"
+  integrity sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==
 
 is-builtin-module@^1.0.0:
   version "1.0.0"

--- a/guides/yarn.lock
+++ b/guides/yarn.lock
@@ -3530,6 +3530,14 @@ js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
+js-yaml@^3.13.1:
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
+  integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
 js-yaml@^3.9.0:
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"

--- a/guides/yarn.lock
+++ b/guides/yarn.lock
@@ -3530,10 +3530,10 @@ isstream@~0.1.2:
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
   integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
 
-jquery@^3.2.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.3.1.tgz#958ce29e81c9790f31be7792df5d4d95fc57fbca"
-  integrity sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg==
+jquery@^3.4.0:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
+  integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
 
 js-base64@^2.1.9, js-base64@^2.4.3:
   version "2.4.9"


### PR DESCRIPTION
js-yaml:
nodeca/js-yaml#475
nodeca/js-yaml#480

axios:
https://nvd.nist.gov/vuln/detail/CVE-2019-10742

jquery:
https://nvd.nist.gov/vuln/detail/CVE-2019-11358

debug:
https://nvd.nist.gov/vuln/detail/CVE-2017-16137