### PR TITLE
Use pluck(:value).first to avoid loading entire row and using try!

### DIFF
--- a/backend/app/views/spree/admin/promotions/index.html.erb
+++ b/backend/app/views/spree/admin/promotions/index.html.erb
@@ -78,7 +78,7 @@
         <tr id="<%= spree_dom_id promotion %>">
           <td><%= promotion.name %></td>
           <td>
-            <%= (promotion.codes.size == 1) ? promotion.codes.take.try!(:value) : t('spree.number_of_codes', count: promotion.codes.size) %>
+            <%= (promotion.codes.size == 1) ? promotion.codes.pluck(:value).first : t('spree.number_of_codes', count: promotion.codes.size) %>
           </td>
           <td>
             <span class="pill pill-<%= promotion.active? ? 'active' : 'inactive' %>">


### PR DESCRIPTION
**Update:** The ordering was actually already fixed in https://github.com/solidusio/solidus/pull/3224 but this continues to improve on the code & query by only loading the value attribute as a String instead of loading the entire database row & initializing a full ActiveRecord object.

# Overview
The SQL queries to determine each promotions code or batches of codes
count are currently the slowest queries on the promotions index page.

In our application containing approximately 32 Million codes and
counting they've significantly slowed down the page by approximately
80-100 seconds currently.

This was caused by the SQL's ORDER BY clause trying to sort all the
records as they were being counted which was not necessary. Then when
calling `.first` to initialize the ActiveRecord object it would add
even further delay to the rendering approximately 5 seconds.

By using `pluck(:code)` the ORDER BY statement is dropped, and we don't
have to initialize a full ActiveRecord object either.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
