### PR TITLE
Use Kaminari's limit_value

### DIFF
--- a/api/app/views/spree/api/shared/_pagination.json.jbuilder
+++ b/api/app/views/spree/api/shared/_pagination.json.jbuilder
@@ -4,4 +4,4 @@ json.count        pagination.count
 json.total_count  pagination.total_count
 json.current_page pagination.current_page
 json.pages        pagination.total_pages
-json.per_page     pagination.current_per_page
+json.per_page     pagination.limit_value


### PR DESCRIPTION
Kaminari has deprecated `current_per_page` and here we
use the new `limit_value` method

**Description**

Debugging some issues with the API we found that the value being returned for `current_per_page` was not consistent with the params being sent. I found that we are using a deprecated method within Kaminari causing the issue.

https://github.com/kaminari/kaminari/blob/master/kaminari-core/lib/kaminari/models/page_scope_methods.rb#L58-L64

**Checklist:**
- [ ] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [ ] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
