### PR TITLE
Update cancel inventory tab for consistency

### DIFF
--- a/backend/app/views/spree/admin/shared/_order_submenu.html.erb
+++ b/backend/app/views/spree/admin/shared/_order_submenu.html.erb
@@ -55,9 +55,9 @@
     <% end %>
 
     <% if can?(:manage, Spree::OrderCancellations) && @order.inventory_units.cancelable.present? %>
-      <%= content_tag('li', class: "#{'active' if current == 'Cancel Inventory'}", data: {hook: 'admin_order_tabs_cancel_inventory'}) do %>
+      <li class="<%= "active" if current == "Cancel Inventory" %>" data-hook='admin_order_tabs_cancel_inventory'>
         <%= link_to t('spree.cancel_inventory'), spree.admin_order_cancellations_path(@order) %>
-      <% end %>
+      </li>
     <% end %>
   </ul>
 </nav>


### PR DESCRIPTION
The Cancel Inventory tab in admin had an inconsistent HTML
render than the rest of the file. This commit changes that
to be consistent with the other tabs rendered.

**Description**

The tabs are all rendered with HTML except for the Cancel Items tab. All tabs should be rendered the same way.

**Checklist:**
- [ ] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [ ] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
