### PR TITLE
Add dimensions and weight to product samples

### DIFF
--- a/sample/db/samples/products.rb
+++ b/sample/db/samples/products.rb
@@ -26,28 +26,44 @@ products = [
     tax_category: tax_category,
     shipping_category: shipping_category,
     price: 15.99,
-    eur_price: 14
+    eur_price: 14,
+    weight: 0.5,
+    height: 5,
+    width: 5,
+    depth: 5
   },
   {
     name: "Ruby on Rails Bag",
     tax_category: tax_category,
     shipping_category: shipping_category,
     price: 22.99,
-    eur_price: 19
+    eur_price: 19,
+    weight: 0.5,
+    height: 5,
+    width: 5,
+    depth: 5
   },
   {
     name: "Ruby on Rails Baseball Jersey",
     tax_category: tax_category,
     shipping_category: shipping_category,
     price: 19.99,
-    eur_price: 16
+    eur_price: 16,
+    weight: 0.5,
+    height: 20,
+    width: 10,
+    depth: 5
   },
   {
     name: "Ruby on Rails Jr. Spaghetti",
     tax_category: tax_category,
     shipping_category: shipping_category,
     price: 19.99,
-    eur_price: 16
+    eur_price: 16,
+    weight: 0.5,
+    height: 20,
+    width: 10,
+    depth: 5
 
   },
   {
@@ -55,33 +71,58 @@ products = [
     shipping_category: shipping_category,
     tax_category: tax_category,
     price: 19.99,
-    eur_price: 16
+    eur_price: 16,
+    weight: 0.5,
+    height: 20,
+    width: 10,
+    depth: 5
+
   },
   {
     name: "Ruby Baseball Jersey",
     tax_category: tax_category,
     shipping_category: shipping_category,
     price: 19.99,
-    eur_price: 16
+    eur_price: 16,
+    weight: 0.5,
+    height: 20,
+    width: 10,
+    depth: 5
+
   },
   {
     name: "Apache Baseball Jersey",
     tax_category: tax_category,
     shipping_category: shipping_category,
     price: 19.99,
-    eur_price: 16
+    eur_price: 16,
+    weight: 0.5,
+    height: 20,
+    width: 10,
+    depth: 5
+
   },
   {
     name: "Ruby on Rails Mug",
     shipping_category: shipping_category,
     price: 13.99,
-    eur_price: 12
+    eur_price: 12,
+    weight: 1,
+    height: 5,
+    width: 5,
+    depth: 5
+
   },
   {
     name: "Ruby on Rails Stein",
     shipping_category: shipping_category,
     price: 16.99,
-    eur_price: 14
+    eur_price: 14,
+    weight: 1,
+    height: 5,
+    width: 5,
+    depth: 5
+
   }
 ]
 


### PR DESCRIPTION
**Description**
<!--
  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

  If needed you can reference another PR or issue here, e.g.:
  Ref #ISSUE
-->
I'm adding weight, height, width, and depth to all products added by product samples file. I decided to add this data when I run in a simple issue adding Easypost to my project. In development didn't work properly because products didn't have a proper weight set. I think this should be set directly into the solidus gem since we already have samples here and would fix all these kind of issues.

**Checklist:**
- [ ] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
