### PR TITLE
Update usage count in Promotion eligibility check

### DIFF
--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -56,6 +56,14 @@ module Spree
     extend DisplayMoney
     money_methods :amount
 
+    def self.adjusted_orders(excluded_orders: [])
+      eligible.
+      joins(:order).
+      merge(Spree::Order.complete).
+      where.not(spree_orders: { id: excluded_orders }).
+      distinct
+    end
+
     def finalize!
       update!(finalized: true)
     end

--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -56,6 +56,10 @@ module Spree
     extend DisplayMoney
     money_methods :amount
 
+    # Returns Adjustments of completed Orders.
+    #
+    # @param excluded_orders [Array<Spree::Order>] Orders to exclude from query
+    # @return [ActiveRecord::Relation] Scoped Adjustments
     def self.in_completed_orders(excluded_orders: [])
       joins(:order).
       merge(Spree::Order.complete).

--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -56,8 +56,7 @@ module Spree
     extend DisplayMoney
     money_methods :amount
 
-    def self.adjusted_orders(excluded_orders: [])
-      eligible.
+    def self.in_completed_orders(excluded_orders: [])
       joins(:order).
       merge(Spree::Order.complete).
       where.not(spree_orders: { id: excluded_orders }).

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -177,13 +177,9 @@ module Spree
     #
     # @return [Integer] usage count
     def usage_count(excluded_orders = [])
-      Spree::Adjustment.eligible.
-        promotion.
+      Spree::Adjustment.promotion.
+        adjusted_orders(excluded_orders: excluded_orders).
         where(source_id: actions).
-        joins(:order).
-        merge(Spree::Order.complete).
-        where.not(spree_orders: { id: excluded_orders }).
-        distinct.
         count(:order_id)
     end
 

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -127,7 +127,7 @@ module Spree
     def eligible?(promotable, promotion_code: nil)
       return false if inactive?
       return false if usage_limit_exceeded?([promotable])
-      return false if promotion_code && promotion_code.usage_limit_exceeded?([promotable])
+      return false if promotion_code&.usage_limit_exceeded?([promotable])
       return false if blacklisted?(promotable)
 
       !!eligible_rules(promotable, {})
@@ -139,6 +139,7 @@ module Spree
     def eligible_rules(promotable, options = {})
       # Promotions without rules are eligible by default.
       return [] if rules.none?
+
       eligible = lambda { |rule| rule.eligible?(promotable, options) }
       specific_rules = rules.for(promotable)
       return [] if specific_rules.none?
@@ -254,6 +255,7 @@ module Spree
 
     def apply_automatically_disallowed_with_codes_or_paths
       return unless apply_automatically
+
       errors.add(:apply_automatically, :disallowed_with_code) if codes.any?
       errors.add(:apply_automatically, :disallowed_with_path) if path.present?
     end

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -167,6 +167,7 @@ module Spree
 
     # Whether the promotion has exceeded it's usage restrictions.
     #
+    # @param excluded_orders [Array<Spree::Order>] Orders to exclude from usage limit
     # @return true or false
     def usage_limit_exceeded?(excluded_orders: [])
       if usage_limit
@@ -176,6 +177,7 @@ module Spree
 
     # Number of times the code has been used overall
     #
+    # @param excluded_orders [Array<Spree::Order>] Orders to exclude from usage count
     # @return [Integer] usage count
     def usage_count(excluded_orders: [])
       Spree::Adjustment.promotion.

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -178,7 +178,8 @@ module Spree
     # @return [Integer] usage count
     def usage_count(excluded_orders = [])
       Spree::Adjustment.promotion.
-        adjusted_orders(excluded_orders: excluded_orders).
+        eligible.
+        in_completed_orders(excluded_orders: excluded_orders).
         where(source_id: actions).
         count(:order_id)
     end

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -126,8 +126,8 @@ module Spree
     # called anytime order.recalculate happens
     def eligible?(promotable, promotion_code: nil)
       return false if inactive?
-      return false if usage_limit_exceeded?([promotable])
-      return false if promotion_code&.usage_limit_exceeded?([promotable])
+      return false if usage_limit_exceeded?(excluded_orders: [promotable])
+      return false if promotion_code&.usage_limit_exceeded?(excluded_orders: [promotable])
       return false if blacklisted?(promotable)
 
       !!eligible_rules(promotable, {})
@@ -168,16 +168,16 @@ module Spree
     # Whether the promotion has exceeded it's usage restrictions.
     #
     # @return true or false
-    def usage_limit_exceeded?(excluded_orders = [])
+    def usage_limit_exceeded?(excluded_orders: [])
       if usage_limit
-        usage_count(excluded_orders) >= usage_limit
+        usage_count(excluded_orders: excluded_orders) >= usage_limit
       end
     end
 
     # Number of times the code has been used overall
     #
     # @return [Integer] usage count
-    def usage_count(excluded_orders = [])
+    def usage_count(excluded_orders: [])
       Spree::Adjustment.promotion.
         eligible.
         in_completed_orders(excluded_orders: excluded_orders).

--- a/core/app/models/spree/promotion_code.rb
+++ b/core/app/models/spree/promotion_code.rb
@@ -25,12 +25,9 @@ class Spree::PromotionCode < Spree::Base
   #
   # @return [Integer] usage count
   def usage_count(excluded_orders = [])
-    adjustments.eligible.
-      joins(:order).
-      merge(Spree::Order.complete).
-      where.not(spree_orders: { id: excluded_orders }).
-      distinct.
-      count(:order_id)
+    adjustments.
+    adjusted_orders(excluded_orders: excluded_orders).
+    count(:order_id)
   end
 
   def usage_limit

--- a/core/app/models/spree/promotion_code.rb
+++ b/core/app/models/spree/promotion_code.rb
@@ -14,6 +14,7 @@ class Spree::PromotionCode < Spree::Base
 
   # Whether the promotion code has exceeded its usage restrictions
   #
+  # @param excluded_orders [Array<Spree::Order>] Orders to exclude from usage limit
   # @return true or false
   def usage_limit_exceeded?(excluded_orders: [])
     if usage_limit
@@ -23,6 +24,7 @@ class Spree::PromotionCode < Spree::Base
 
   # Number of times the code has been used overall
   #
+  # @param excluded_orders [Array<Spree::Order>] Orders to exclude from usage count
   # @return [Integer] usage count
   def usage_count(excluded_orders: [])
     adjustments.

--- a/core/app/models/spree/promotion_code.rb
+++ b/core/app/models/spree/promotion_code.rb
@@ -15,16 +15,16 @@ class Spree::PromotionCode < Spree::Base
   # Whether the promotion code has exceeded its usage restrictions
   #
   # @return true or false
-  def usage_limit_exceeded?(excluded_orders = [])
+  def usage_limit_exceeded?(excluded_orders: [])
     if usage_limit
-      usage_count(excluded_orders) >= usage_limit
+      usage_count(excluded_orders: excluded_orders) >= usage_limit
     end
   end
 
   # Number of times the code has been used overall
   #
   # @return [Integer] usage count
-  def usage_count(excluded_orders = [])
+  def usage_count(excluded_orders: [])
     adjustments.
     eligible.
     in_completed_orders(excluded_orders: excluded_orders).

--- a/core/app/models/spree/promotion_code.rb
+++ b/core/app/models/spree/promotion_code.rb
@@ -26,7 +26,8 @@ class Spree::PromotionCode < Spree::Base
   # @return [Integer] usage count
   def usage_count(excluded_orders = [])
     adjustments.
-    adjusted_orders(excluded_orders: excluded_orders).
+    eligible.
+    in_completed_orders(excluded_orders: excluded_orders).
     count(:order_id)
   end
 

--- a/core/app/models/spree/promotion_code.rb
+++ b/core/app/models/spree/promotion_code.rb
@@ -15,19 +15,20 @@ class Spree::PromotionCode < Spree::Base
   # Whether the promotion code has exceeded its usage restrictions
   #
   # @return true or false
-  def usage_limit_exceeded?
+  def usage_limit_exceeded?(excluded_orders = [])
     if usage_limit
-      usage_count >= usage_limit
+      usage_count(excluded_orders) >= usage_limit
     end
   end
 
   # Number of times the code has been used overall
   #
   # @return [Integer] usage count
-  def usage_count
+  def usage_count(excluded_orders = [])
     adjustments.eligible.
       joins(:order).
       merge(Spree::Order.complete).
+      where.not(spree_orders: { id: excluded_orders }).
       distinct.
       count(:order_id)
   end

--- a/core/lib/spree/testing_support/factories/promotion_factory.rb
+++ b/core/lib/spree/testing_support/factories/promotion_factory.rb
@@ -27,7 +27,14 @@ FactoryBot.define do
         Spree::Promotion::Actions::CreateItemAdjustments.create!(calculator: calculator, promotion: promotion)
       end
     end
+
     factory :promotion_with_item_adjustment, traits: [:with_line_item_adjustment]
+
+    trait :with_free_shipping do
+      after(:create) do |promotion|
+        Spree::Promotion::Actions::FreeShipping.create!(promotion: promotion)
+      end
+    end
 
     trait :with_order_adjustment do
       transient do

--- a/core/spec/models/spree/promotion_code_spec.rb
+++ b/core/spec/models/spree/promotion_code_spec.rb
@@ -147,15 +147,6 @@ RSpec.describe Spree::PromotionCode do
         before { order.adjustments.promotion.update_all(eligible: false) }
         it { is_expected.to eq 0 }
       end
-
-      context "and adjustment is recalculated at promo code last available usage" do
-        before do
-          promotion.update(per_code_usage_limit: 1)
-          order.adjustments.map(&:recalculate)
-        end
-
-        it { is_expected.to eq 1 }
-      end
     end
   end
 

--- a/core/spec/models/spree/promotion_code_spec.rb
+++ b/core/spec/models/spree/promotion_code_spec.rb
@@ -147,6 +147,15 @@ RSpec.describe Spree::PromotionCode do
         before { order.adjustments.promotion.update_all(eligible: false) }
         it { is_expected.to eq 0 }
       end
+
+      context "and adjustment is recalculated at promo code last available usage" do
+        before do
+          promotion.update(per_code_usage_limit: 1)
+          order.adjustments.map(&:recalculate)
+        end
+
+        it { is_expected.to eq 1 }
+      end
     end
   end
 

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -349,6 +349,15 @@ RSpec.describe Spree::Promotion, type: :model do
         before { order.adjustments.promotion.update_all(eligible: false) }
         it { is_expected.to eq 0 }
       end
+
+      context "and adjustment is recalculated at promo last available usage" do
+        before do
+          promotion.update(usage_limit: 1)
+          order.adjustments.each(&:recalculate)
+        end
+
+        it { is_expected.to eq 1 }
+      end
     end
   end
 

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -434,12 +434,12 @@ RSpec.describe Spree::Promotion, type: :model do
     end
 
     context 'when expires_at date is not already reached' do
-      let(:expires_at) { Time.current + 1.days }
+      let(:expires_at) { Time.current + 1.day }
       it { is_expected.to be_falsey }
     end
 
     context 'when expires_at date is in the past' do
-      let(:expires_at) { Time.current - 1.days }
+      let(:expires_at) { Time.current - 1.day }
       it { is_expected.to be_truthy }
     end
   end
@@ -454,12 +454,12 @@ RSpec.describe Spree::Promotion, type: :model do
     end
 
     context 'when expires_at date is not already reached' do
-      let(:expires_at) { Time.current + 1.days }
+      let(:expires_at) { Time.current + 1.day }
       it { is_expected.to be_truthy }
     end
 
     context 'when expires_at date is in the past' do
-      let(:expires_at) { Time.current - 1.days }
+      let(:expires_at) { Time.current - 1.day }
       it { is_expected.to be_falsey }
     end
   end


### PR DESCRIPTION
**Description**

This PR addresses issue #3205.

Eligibility check on an Adjustment bound to a Promotion with a usage limit should not include in usage count the current Adjustment itself.

With this PR the eligibility check does not consider the Order of the Adjustment it is applied to.
I updated the check adding an optional array of Orders to exclude from the computation (in the same vein as Promotion `#used_by?`) to avoid any breaking change to Promotion and PromotionCode puplic APIs.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change