### PR TITLE
Fix hook attr name for settings tab item in admin

### DIFF
--- a/backend/app/helpers/spree/admin/navigation_helper.rb
+++ b/backend/app/helpers/spree/admin/navigation_helper.rb
@@ -181,7 +181,8 @@ module Spree
                     url.ends_with?("#{controller.controller_name.singularize}/edit")
         options[:class] = 'fa'
         options[:class] += ' active' if is_active
-        options[:datahook] = "admin_settings_#{link_text.downcase.tr(' ', '_')}"
+        options[:data] ||= {}
+        options[:data][:hook] = "admin_settings_#{link_text.downcase.tr(' ', '_')}"
         content_tag(:li, options) do
           link_to(link_text, url)
         end


### PR DESCRIPTION
This changes the hook attribute name for settings tab items (in admin) from:
`datahook` to `data-hook`.

**Checklist:**
- [ ] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [ ] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
