### PR TITLE
Rename several one letter variables

### DIFF
--- a/core/app/helpers/spree/base_helper.rb
+++ b/core/app/helpers/spree/base_helper.rb
@@ -79,16 +79,16 @@ module Spree
 
       crumbs << [t('spree.products'), products_path]
       if taxon
-        crumbs += taxon.ancestors.collect { |a| [a.name, spree.nested_taxons_path(a.permalink)] } unless taxon.ancestors.empty?
+        crumbs += taxon.ancestors.collect { |ancestor| [ancestor.name, spree.nested_taxons_path(ancestor.permalink)] } unless taxon.ancestors.empty?
         crumbs << [taxon.name, spree.nested_taxons_path(taxon.permalink)]
       end
 
       separator = raw(separator)
 
-      items = crumbs.each_with_index.collect do |crumb, i|
+      items = crumbs.each_with_index.collect do |crumb, index|
         content_tag(:li, itemprop: 'itemListElement', itemscope: '', itemtype: 'https://schema.org/ListItem') do
           link_to(crumb.last, itemprop: 'item') do
-            content_tag(:span, crumb.first, itemprop: 'name') + tag('meta', { itemprop: 'position', content: (i + 1).to_s }, false, false)
+            content_tag(:span, crumb.first, itemprop: 'name') + tag('meta', { itemprop: 'position', content: (index + 1).to_s }, false, false)
           end + (crumb == crumbs.last ? '' : separator)
         end
       end
@@ -122,7 +122,7 @@ module Spree
       countries.collect do |country|
         country.name = country_names.fetch(country.iso, country.name)
         country
-      end.sort_by { |c| c.name.parameterize }
+      end.sort_by { |country| country.name.parameterize }
     end
 
     def seo_url(taxon)

--- a/core/app/helpers/spree/products_helper.rb
+++ b/core/app/helpers/spree/products_helper.rb
@@ -36,7 +36,7 @@ module Spree
     def variant_full_price(variant)
       return if variant.product.variants
                   .with_prices(current_pricing_options)
-                  .all? { |v| v.price_same_as_master?(current_pricing_options) }
+                  .all? { |product_variant| product_variant.price_same_as_master?(current_pricing_options) }
       variant.price_for(current_pricing_options).to_html
     end
 

--- a/core/app/jobs/spree/promotion_code_batch_job.rb
+++ b/core/app/jobs/spree/promotion_code_batch_job.rb
@@ -14,13 +14,13 @@ module Spree
           .promotion_code_batch_finished(promotion_code_batch)
           .deliver_now
       end
-    rescue StandardError => e
+    rescue StandardError => error
       if promotion_code_batch.email?
         Spree::Config.promotion_code_batch_mailer_class
           .promotion_code_batch_errored(promotion_code_batch)
           .deliver_now
       end
-      raise e
+      raise error
     end
   end
 end

--- a/core/app/models/concerns/spree/user_methods.rb
+++ b/core/app/models/concerns/spree/user_methods.rb
@@ -74,7 +74,7 @@ module Spree
 
     def available_store_credit_total(currency:)
       store_credits.reload.to_a.
-        select { |c| c.currency == currency }.
+        select { |credit| credit.currency == currency }.
         sum(&:amount_remaining)
     end
 

--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -72,7 +72,7 @@ module Spree
     # @return [BigDecimal] the amount of this item, taking into consideration
     #   all non-tax adjustments.
     def total_before_tax
-      amount + adjustments.select { |a| !a.tax? && a.eligible? }.sum(&:amount)
+      amount + adjustments.select { |adjustment| !adjustment.tax? && adjustment.eligible? }.sum(&:amount)
     end
 
     # @return [BigDecimal] the amount of this line item before VAT tax


### PR DESCRIPTION
**Description**

This PR renames several one-letter variables, providing more descriptive names.

Hi all, I'm really enjoying Solidus and wanted to contribute. Reek found 159 uncommunicative variable names. This PR takes it down to 152, so still plenty of work to do here. Hope this helps, cheers.


Partially Addressing: https://github.com/solidusio/solidus/issues/3294

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
