### PR TITLE
Making taxon form to render attachment definitions dynamically

### DIFF
--- a/backend/app/views/spree/admin/taxons/_form.html.erb
+++ b/backend/app/views/spree/admin/taxons/_form.html.erb
@@ -20,11 +20,7 @@
       </div>
     <% end %>
 
-    <%= f.field_container :icon do %>
-      <%= f.label :icon %><br />
-      <%= f.file_field :icon %>
-      <%= image_tag f.object.icon(:mini) if f.object.icon_present? %>
-    <% end %>
+    <%= render "spree/admin/taxons/attachment_forms/#{f.object.attachment_partial_name}", f: f %>
   </div>
 
   <div class="col-5">

--- a/backend/app/views/spree/admin/taxons/attachment_forms/_paperclip.html.erb
+++ b/backend/app/views/spree/admin/taxons/attachment_forms/_paperclip.html.erb
@@ -1,0 +1,7 @@
+<% f.object.class.attachment_definitions.each do |attachment, definition| %>
+  <%= f.field_container attachment do %>
+    <%= f.label attachment %><br>
+    <%= f.file_field attachment %>
+    <%= image_tag f.object.send(attachment, definition[:default_style]) if f.object.send(attachment).present? %>
+  <% end %>
+<% end %>

--- a/core/app/models/spree/taxon/paperclip_attachment.rb
+++ b/core/app/models/spree/taxon/paperclip_attachment.rb
@@ -18,4 +18,8 @@ module Spree::Taxon::PaperclipAttachment
   def icon_present?
     icon.present?
   end
+
+  def attachment_partial_name
+    'paperclip'
+  end
 end


### PR DESCRIPTION
**Description**
Solidus now allows to inject easily more attachment definitions via
configurable modules (#3237), if a user adds a new attachment, it would be needed
to override the partial _form and add this new attachment, this change
takes all definitions and render the inputs dynamically.

**Checklist:**
- [ ] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [ ] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
