### PR TITLE
Make all belongs_to associations optional

### DIFF
--- a/core/app/models/concerns/spree/user_address_book.rb
+++ b/core/app/models/concerns/spree/user_address_book.rb
@@ -25,7 +25,7 @@ module Spree
       has_many :addresses, through: :user_addresses
 
       # bill_address is only minimally used now, but we can't get rid of it without a major version release
-      belongs_to :bill_address, class_name: 'Spree::Address'
+      belongs_to :bill_address, class_name: 'Spree::Address', optional: true
 
       has_one :default_user_address, ->{ default }, class_name: 'Spree::UserAddress', foreign_key: 'user_id'
       has_one :default_address, through: :default_user_address, source: :address

--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -8,8 +8,8 @@ module Spree
   class Address < Spree::Base
     extend ActiveModel::ForbiddenAttributesProtection
 
-    belongs_to :country, class_name: "Spree::Country"
-    belongs_to :state, class_name: "Spree::State"
+    belongs_to :country, class_name: "Spree::Country", optional: true
+    belongs_to :state, class_name: "Spree::State", optional: true
 
     validates :firstname, :address1, :city, :country_id, presence: true
     validates :zipcode, presence: true, if: :require_zipcode?

--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -16,11 +16,11 @@ module Spree
   #    order's adjustment total. This allows an adjustment to be preserved if
   #    it becomes ineligible so it might be reinstated.
   class Adjustment < Spree::Base
-    belongs_to :adjustable, polymorphic: true, touch: true
-    belongs_to :source, polymorphic: true
-    belongs_to :order, class_name: 'Spree::Order', inverse_of: :all_adjustments
-    belongs_to :promotion_code, class_name: 'Spree::PromotionCode'
-    belongs_to :adjustment_reason, class_name: 'Spree::AdjustmentReason', inverse_of: :adjustments
+    belongs_to :adjustable, polymorphic: true, touch: true, optional: true
+    belongs_to :source, polymorphic: true, optional: true
+    belongs_to :order, class_name: 'Spree::Order', inverse_of: :all_adjustments, optional: true
+    belongs_to :promotion_code, class_name: 'Spree::PromotionCode', optional: true
+    belongs_to :adjustment_reason, class_name: 'Spree::AdjustmentReason', inverse_of: :adjustments, optional: true
 
     validates :adjustable, presence: true
     validates :order, presence: true

--- a/core/app/models/spree/asset.rb
+++ b/core/app/models/spree/asset.rb
@@ -2,7 +2,7 @@
 
 module Spree
   class Asset < Spree::Base
-    belongs_to :viewable, polymorphic: true, touch: true
+    belongs_to :viewable, polymorphic: true, touch: true, optional: true
     acts_as_list scope: [:viewable_id, :viewable_type]
   end
 end

--- a/core/app/models/spree/base.rb
+++ b/core/app/models/spree/base.rb
@@ -6,8 +6,6 @@ class Spree::Base < ActiveRecord::Base
 
   include Spree::RansackableAttributes
 
-  self.belongs_to_required_by_default = false
-
   def initialize_preference_defaults
     if has_attribute?(:preferences)
       self.preferences = default_preferences.merge(preferences)

--- a/core/app/models/spree/calculator.rb
+++ b/core/app/models/spree/calculator.rb
@@ -2,7 +2,7 @@
 
 module Spree
   class Calculator < Spree::Base
-    belongs_to :calculable, polymorphic: true
+    belongs_to :calculable, polymorphic: true, optional: true
 
     # This method calls a compute_<computable> method. must be overriden in concrete calculator.
     #

--- a/core/app/models/spree/carton.rb
+++ b/core/app/models/spree/carton.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 class Spree::Carton < Spree::Base
-  belongs_to :address, class_name: 'Spree::Address'
-  belongs_to :stock_location, class_name: 'Spree::StockLocation', inverse_of: :cartons
-  belongs_to :shipping_method, class_name: 'Spree::ShippingMethod', inverse_of: :cartons
+  belongs_to :address, class_name: 'Spree::Address', optional: true
+  belongs_to :stock_location, class_name: 'Spree::StockLocation', inverse_of: :cartons, optional: true
+  belongs_to :shipping_method, class_name: 'Spree::ShippingMethod', inverse_of: :cartons, optional: true
 
   has_many :inventory_units, class_name: "Spree::InventoryUnit", inverse_of: :carton, dependent: :nullify
   has_many :orders, -> { distinct }, through: :inventory_units

--- a/core/app/models/spree/classification.rb
+++ b/core/app/models/spree/classification.rb
@@ -4,8 +4,8 @@ module Spree
   class Classification < Spree::Base
     self.table_name = 'spree_products_taxons'
     acts_as_list scope: :taxon
-    belongs_to :product, class_name: "Spree::Product", inverse_of: :classifications, touch: true
-    belongs_to :taxon, class_name: "Spree::Taxon", inverse_of: :classifications, touch: true
+    belongs_to :product, class_name: "Spree::Product", inverse_of: :classifications, touch: true, optional: true
+    belongs_to :taxon, class_name: "Spree::Taxon", inverse_of: :classifications, touch: true, optional: true
 
     # For https://github.com/spree/spree/issues/3494
     validates_uniqueness_of :taxon_id, scope: :product_id, message: :already_linked

--- a/core/app/models/spree/credit_card.rb
+++ b/core/app/models/spree/credit_card.rb
@@ -4,8 +4,8 @@ module Spree
   # The default `source` of a `Spree::Payment`.
   #
   class CreditCard < Spree::PaymentSource
-    belongs_to :user, class_name: Spree::UserClassHandle.new, foreign_key: 'user_id'
-    belongs_to :address
+    belongs_to :user, class_name: Spree::UserClassHandle.new, foreign_key: 'user_id', optional: true
+    belongs_to :address, optional: true
 
     before_save :set_last_digits
 

--- a/core/app/models/spree/customer_return.rb
+++ b/core/app/models/spree/customer_return.rb
@@ -2,7 +2,7 @@
 
 module Spree
   class CustomerReturn < Spree::Base
-    belongs_to :stock_location
+    belongs_to :stock_location, optional: true
 
     has_many :return_items, inverse_of: :customer_return
     has_many :return_authorizations, through: :return_items

--- a/core/app/models/spree/inventory_unit.rb
+++ b/core/app/models/spree/inventory_unit.rb
@@ -8,10 +8,10 @@ module Spree
     POST_SHIPMENT_STATES = %w(returned)
     CANCELABLE_STATES = ['on_hand', 'backordered', 'shipped']
 
-    belongs_to :variant, -> { with_deleted }, class_name: "Spree::Variant", inverse_of: :inventory_units
-    belongs_to :shipment, class_name: "Spree::Shipment", touch: true, inverse_of: :inventory_units
-    belongs_to :carton, class_name: "Spree::Carton", inverse_of: :inventory_units
-    belongs_to :line_item, class_name: "Spree::LineItem", inverse_of: :inventory_units
+    belongs_to :variant, -> { with_deleted }, class_name: "Spree::Variant", inverse_of: :inventory_units, optional: true
+    belongs_to :shipment, class_name: "Spree::Shipment", touch: true, inverse_of: :inventory_units, optional: true
+    belongs_to :carton, class_name: "Spree::Carton", inverse_of: :inventory_units, optional: true
+    belongs_to :line_item, class_name: "Spree::LineItem", inverse_of: :inventory_units, optional: true
 
     has_many :return_items, inverse_of: :inventory_unit, dependent: :destroy
     has_one :original_return_item, class_name: "Spree::ReturnItem", foreign_key: :exchange_inventory_unit_id, dependent: :destroy

--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -12,9 +12,9 @@ module Spree
   class LineItem < Spree::Base
     class CurrencyMismatch < StandardError; end
 
-    belongs_to :order, class_name: "Spree::Order", inverse_of: :line_items, touch: true
-    belongs_to :variant, -> { with_deleted }, class_name: "Spree::Variant", inverse_of: :line_items
-    belongs_to :tax_category, class_name: "Spree::TaxCategory"
+    belongs_to :order, class_name: "Spree::Order", inverse_of: :line_items, touch: true, optional: true
+    belongs_to :variant, -> { with_deleted }, class_name: "Spree::Variant", inverse_of: :line_items, optional: true
+    belongs_to :tax_category, class_name: "Spree::TaxCategory", optional: true
 
     has_one :product, through: :variant
 

--- a/core/app/models/spree/line_item_action.rb
+++ b/core/app/models/spree/line_item_action.rb
@@ -2,7 +2,7 @@
 
 module Spree
   class LineItemAction < Spree::Base
-    belongs_to :line_item
-    belongs_to :action, class_name: "Spree::PromotionAction"
+    belongs_to :line_item, optional: true
+    belongs_to :action, class_name: "Spree::PromotionAction", optional: true
   end
 end

--- a/core/app/models/spree/log_entry.rb
+++ b/core/app/models/spree/log_entry.rb
@@ -2,7 +2,7 @@
 
 module Spree
   class LogEntry < Spree::Base
-    belongs_to :source, polymorphic: true
+    belongs_to :source, polymorphic: true, optional: true
 
     def parsed_details
       @details ||= YAML.load(details)

--- a/core/app/models/spree/option_value.rb
+++ b/core/app/models/spree/option_value.rb
@@ -2,7 +2,7 @@
 
 module Spree
   class OptionValue < Spree::Base
-    belongs_to :option_type, class_name: 'Spree::OptionType', inverse_of: :option_values
+    belongs_to :option_type, class_name: 'Spree::OptionType', inverse_of: :option_values, optional: true
     acts_as_list scope: :option_type
 
     has_many :option_values_variants, dependent: :destroy

--- a/core/app/models/spree/option_values_variant.rb
+++ b/core/app/models/spree/option_values_variant.rb
@@ -2,7 +2,7 @@
 
 module Spree
   class OptionValuesVariant < Spree::Base
-    belongs_to :variant
-    belongs_to :option_value
+    belongs_to :variant, optional: true
+    belongs_to :option_value, optional: true
   end
 end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -55,15 +55,15 @@ module Spree
     deprecate :temporary_credit_card= => :temporary_payment_source=, deprecator: Spree::Deprecation
 
     # Customer info
-    belongs_to :user, class_name: Spree::UserClassHandle.new
-    belongs_to :bill_address, foreign_key: :bill_address_id, class_name: 'Spree::Address'
+    belongs_to :user, class_name: Spree::UserClassHandle.new, optional: true
+    belongs_to :bill_address, foreign_key: :bill_address_id, class_name: 'Spree::Address', optional: true
     alias_attribute :billing_address, :bill_address
 
-    belongs_to :ship_address, foreign_key: :ship_address_id, class_name: 'Spree::Address'
+    belongs_to :ship_address, foreign_key: :ship_address_id, class_name: 'Spree::Address', optional: true
     alias_attribute :shipping_address, :ship_address
     alias_attribute :ship_total, :shipment_total
 
-    belongs_to :store, class_name: 'Spree::Store'
+    belongs_to :store, class_name: 'Spree::Store', optional: true
 
     # Items
     has_many :line_items, -> { order(:created_at, :id) }, dependent: :destroy, inverse_of: :order
@@ -101,9 +101,9 @@ module Spree
 
     # Logging
     has_many :state_changes, as: :stateful
-    belongs_to :created_by, class_name: Spree::UserClassHandle.new
-    belongs_to :approver, class_name: Spree::UserClassHandle.new
-    belongs_to :canceler, class_name: Spree::UserClassHandle.new
+    belongs_to :created_by, class_name: Spree::UserClassHandle.new, optional: true
+    belongs_to :approver, class_name: Spree::UserClassHandle.new, optional: true
+    belongs_to :canceler, class_name: Spree::UserClassHandle.new, optional: true
 
     accepts_nested_attributes_for :line_items
     accepts_nested_attributes_for :bill_address

--- a/core/app/models/spree/order_mutex.rb
+++ b/core/app/models/spree/order_mutex.rb
@@ -4,7 +4,7 @@ module Spree
   class OrderMutex < Spree::Base
     class LockFailed < StandardError; end
 
-    belongs_to :order, class_name: "Spree::Order"
+    belongs_to :order, class_name: "Spree::Order", optional: true
 
     scope :expired, -> { where(arel_table[:created_at].lteq(Spree::Config[:order_mutex_max_age].seconds.ago)) }
 

--- a/core/app/models/spree/order_promotion.rb
+++ b/core/app/models/spree/order_promotion.rb
@@ -8,9 +8,9 @@ module Spree
   class OrderPromotion < Spree::Base
     self.table_name = 'spree_orders_promotions'
 
-    belongs_to :order, class_name: 'Spree::Order'
-    belongs_to :promotion, class_name: 'Spree::Promotion'
-    belongs_to :promotion_code, class_name: 'Spree::PromotionCode'
+    belongs_to :order, class_name: 'Spree::Order', optional: true
+    belongs_to :promotion, class_name: 'Spree::Promotion', optional: true
+    belongs_to :promotion_code, class_name: 'Spree::PromotionCode', optional: true
 
     validates :order, presence: true
     validates :promotion, presence: true

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -15,9 +15,9 @@ module Spree
     NON_RISKY_AVS_CODES = ['B', 'D', 'H', 'J', 'M', 'Q', 'T', 'V', 'X', 'Y'].freeze
     RISKY_AVS_CODES     = ['A', 'C', 'E', 'F', 'G', 'I', 'K', 'L', 'N', 'O', 'P', 'R', 'S', 'U', 'W', 'Z'].freeze
 
-    belongs_to :order, class_name: 'Spree::Order', touch: true, inverse_of: :payments
-    belongs_to :source, polymorphic: true
-    belongs_to :payment_method, -> { with_deleted }, class_name: 'Spree::PaymentMethod', inverse_of: :payments
+    belongs_to :order, class_name: 'Spree::Order', touch: true, inverse_of: :payments, optional: true
+    belongs_to :source, polymorphic: true, optional: true
+    belongs_to :payment_method, -> { with_deleted }, class_name: 'Spree::PaymentMethod', inverse_of: :payments, optional: true
 
     has_many :offsets, -> { offset_payment }, class_name: "Spree::Payment", foreign_key: :source_id
     has_many :log_entries, as: :source

--- a/core/app/models/spree/payment_capture_event.rb
+++ b/core/app/models/spree/payment_capture_event.rb
@@ -2,7 +2,7 @@
 
 module Spree
   class PaymentCaptureEvent < Spree::Base
-    belongs_to :payment, class_name: 'Spree::Payment'
+    belongs_to :payment, class_name: 'Spree::Payment', optional: true
 
     def display_amount
       Spree::Money.new(amount, { currency: payment.currency })

--- a/core/app/models/spree/payment_source.rb
+++ b/core/app/models/spree/payment_source.rb
@@ -4,7 +4,7 @@ module Spree
   class PaymentSource < Spree::Base
     self.abstract_class = true
 
-    belongs_to :payment_method
+    belongs_to :payment_method, optional: true
 
     has_many :payments, as: :source
     has_many :wallet_payment_sources, class_name: 'Spree::WalletPaymentSource', as: :payment_source, inverse_of: :payment_source

--- a/core/app/models/spree/price.rb
+++ b/core/app/models/spree/price.rb
@@ -12,8 +12,8 @@ module Spree
 
     MAXIMUM_AMOUNT = BigDecimal('99_999_999.99')
 
-    belongs_to :variant, -> { with_deleted }, class_name: 'Spree::Variant', touch: true
-    belongs_to :country, class_name: "Spree::Country", foreign_key: "country_iso", primary_key: "iso"
+    belongs_to :variant, -> { with_deleted }, class_name: 'Spree::Variant', touch: true, optional: true
+    belongs_to :country, class_name: "Spree::Country", foreign_key: "country_iso", primary_key: "iso", optional: true
 
     delegate :product, to: :variant
     delegate :tax_rates, to: :variant

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -44,8 +44,8 @@ module Spree
     has_many :product_promotion_rules, dependent: :destroy
     has_many :promotion_rules, through: :product_promotion_rules
 
-    belongs_to :tax_category, class_name: 'Spree::TaxCategory'
-    belongs_to :shipping_category, class_name: 'Spree::ShippingCategory', inverse_of: :products
+    belongs_to :tax_category, class_name: 'Spree::TaxCategory', optional: true
+    belongs_to :shipping_category, class_name: 'Spree::ShippingCategory', inverse_of: :products, optional: true
 
     has_one :master,
       -> { where(is_master: true).with_deleted },

--- a/core/app/models/spree/product_option_type.rb
+++ b/core/app/models/spree/product_option_type.rb
@@ -2,8 +2,8 @@
 
 module Spree
   class ProductOptionType < Spree::Base
-    belongs_to :product, class_name: 'Spree::Product', inverse_of: :product_option_types, touch: true
-    belongs_to :option_type, class_name: 'Spree::OptionType', inverse_of: :product_option_types
+    belongs_to :product, class_name: 'Spree::Product', inverse_of: :product_option_types, touch: true, optional: true
+    belongs_to :option_type, class_name: 'Spree::OptionType', inverse_of: :product_option_types, optional: true
     acts_as_list scope: :product
   end
 end

--- a/core/app/models/spree/product_promotion_rule.rb
+++ b/core/app/models/spree/product_promotion_rule.rb
@@ -2,7 +2,7 @@
 
 module Spree
   class ProductPromotionRule < Spree::Base
-    belongs_to :product
-    belongs_to :promotion_rule
+    belongs_to :product, optional: true
+    belongs_to :promotion_rule, optional: true
   end
 end

--- a/core/app/models/spree/product_property.rb
+++ b/core/app/models/spree/product_property.rb
@@ -6,8 +6,8 @@ module Spree
 
     acts_as_list scope: :product
 
-    belongs_to :product, touch: true, class_name: 'Spree::Product', inverse_of: :product_properties
-    belongs_to :property, class_name: 'Spree::Property', inverse_of: :product_properties
+    belongs_to :product, touch: true, class_name: 'Spree::Product', inverse_of: :product_properties, optional: true
+    belongs_to :property, class_name: 'Spree::Property', inverse_of: :product_properties, optional: true
 
     self.whitelisted_ransackable_attributes = ['value']
   end

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -7,7 +7,7 @@ module Spree
 
     attr_reader :eligibility_errors
 
-    belongs_to :promotion_category
+    belongs_to :promotion_category, optional: true
 
     has_many :promotion_rules, autosave: true, dependent: :destroy, inverse_of: :promotion
     alias_method :rules, :promotion_rules

--- a/core/app/models/spree/promotion_action.rb
+++ b/core/app/models/spree/promotion_action.rb
@@ -14,7 +14,7 @@ module Spree
     include Discard::Model
     self.discard_column = :deleted_at
 
-    belongs_to :promotion, class_name: 'Spree::Promotion', inverse_of: :promotion_actions
+    belongs_to :promotion, class_name: 'Spree::Promotion', inverse_of: :promotion_actions, optional: true
 
     scope :of_type, ->(t) { where(type: Array.wrap(t).map(&:to_s)) }
     scope :shipping, -> { of_type(Spree::Config.environment.promotions.shipping_actions.to_a) }

--- a/core/app/models/spree/promotion_code.rb
+++ b/core/app/models/spree/promotion_code.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class Spree::PromotionCode < Spree::Base
-  belongs_to :promotion, inverse_of: :codes
-  belongs_to :promotion_code_batch, class_name: "Spree::PromotionCodeBatch"
+  belongs_to :promotion, inverse_of: :codes, optional: true
+  belongs_to :promotion_code_batch, class_name: "Spree::PromotionCodeBatch", optional: true
   has_many :adjustments
 
   validates :value, presence: true, uniqueness: { allow_blank: true }

--- a/core/app/models/spree/promotion_code_batch.rb
+++ b/core/app/models/spree/promotion_code_batch.rb
@@ -5,7 +5,7 @@ module Spree
     class CantProcessStartedBatch < StandardError
     end
 
-    belongs_to :promotion, class_name: "Spree::Promotion"
+    belongs_to :promotion, class_name: "Spree::Promotion", optional: true
     has_many :promotion_codes, class_name: "Spree::PromotionCode", dependent: :destroy
 
     validates :number_of_codes, numericality: { greater_than: 0 }

--- a/core/app/models/spree/promotion_rule.rb
+++ b/core/app/models/spree/promotion_rule.rb
@@ -3,7 +3,7 @@
 module Spree
   # Base class for all promotion rules
   class PromotionRule < Spree::Base
-    belongs_to :promotion, class_name: 'Spree::Promotion', inverse_of: :promotion_rules
+    belongs_to :promotion, class_name: 'Spree::Promotion', inverse_of: :promotion_rules, optional: true
 
     scope :of_type, ->(t) { where(type: t) }
 

--- a/core/app/models/spree/promotion_rule_role.rb
+++ b/core/app/models/spree/promotion_rule_role.rb
@@ -2,7 +2,7 @@
 
 module Spree
   class PromotionRuleRole < ActiveRecord::Base
-    belongs_to :promotion_rule, class_name: 'Spree::PromotionRule'
-    belongs_to :role, class_name: 'Spree::Role'
+    belongs_to :promotion_rule, class_name: 'Spree::PromotionRule', optional: true
+    belongs_to :role, class_name: 'Spree::Role', optional: true
   end
 end

--- a/core/app/models/spree/promotion_rule_store.rb
+++ b/core/app/models/spree/promotion_rule_store.rb
@@ -4,7 +4,7 @@ module Spree
   class PromotionRuleStore < Spree::Base
     self.table_name = "spree_promotion_rules_stores"
 
-    belongs_to :promotion_rule, class_name: "Spree::PromotionRule"
-    belongs_to :store, class_name: "Spree::Store"
+    belongs_to :promotion_rule, class_name: "Spree::PromotionRule", optional: true
+    belongs_to :store, class_name: "Spree::Store", optional: true
   end
 end

--- a/core/app/models/spree/promotion_rule_taxon.rb
+++ b/core/app/models/spree/promotion_rule_taxon.rb
@@ -2,7 +2,7 @@
 
 module Spree
   class PromotionRuleTaxon < Spree::Base
-    belongs_to :promotion_rule
-    belongs_to :taxon
+    belongs_to :promotion_rule, optional: true
+    belongs_to :taxon, optional: true
   end
 end

--- a/core/app/models/spree/promotion_rule_user.rb
+++ b/core/app/models/spree/promotion_rule_user.rb
@@ -4,7 +4,7 @@ module Spree
   class PromotionRuleUser < Spree::Base
     self.table_name = 'spree_promotion_rules_users'
 
-    belongs_to :promotion_rule, class_name: 'Spree::PromotionRule'
-    belongs_to :user, class_name: Spree::UserClassHandle.new
+    belongs_to :promotion_rule, class_name: 'Spree::PromotionRule', optional: true
+    belongs_to :user, class_name: Spree::UserClassHandle.new, optional: true
   end
 end

--- a/core/app/models/spree/refund.rb
+++ b/core/app/models/spree/refund.rb
@@ -2,9 +2,9 @@
 
 module Spree
   class Refund < Spree::Base
-    belongs_to :payment, inverse_of: :refunds
-    belongs_to :reason, class_name: 'Spree::RefundReason', foreign_key: :refund_reason_id
-    belongs_to :reimbursement, inverse_of: :refunds
+    belongs_to :payment, inverse_of: :refunds, optional: true
+    belongs_to :reason, class_name: 'Spree::RefundReason', foreign_key: :refund_reason_id, optional: true
+    belongs_to :reimbursement, inverse_of: :refunds, optional: true
 
     has_many :log_entries, as: :source
 

--- a/core/app/models/spree/reimbursement.rb
+++ b/core/app/models/spree/reimbursement.rb
@@ -4,8 +4,8 @@ module Spree
   class Reimbursement < Spree::Base
     class IncompleteReimbursementError < StandardError; end
 
-    belongs_to :order, inverse_of: :reimbursements
-    belongs_to :customer_return, inverse_of: :reimbursements, touch: true
+    belongs_to :order, inverse_of: :reimbursements, optional: true
+    belongs_to :customer_return, inverse_of: :reimbursements, touch: true, optional: true
 
     has_many :refunds, inverse_of: :reimbursement
     has_many :credits, inverse_of: :reimbursement, class_name: 'Spree::Reimbursement::Credit'

--- a/core/app/models/spree/reimbursement/credit.rb
+++ b/core/app/models/spree/reimbursement/credit.rb
@@ -6,8 +6,8 @@ module Spree
       class_attribute :default_creditable_class
       self.default_creditable_class = Spree::StoreCredit
 
-      belongs_to :reimbursement, inverse_of: :credits
-      belongs_to :creditable, polymorphic: true
+      belongs_to :reimbursement, inverse_of: :credits, optional: true
+      belongs_to :creditable, polymorphic: true, optional: true
 
       validates :creditable, presence: true
 

--- a/core/app/models/spree/return_authorization.rb
+++ b/core/app/models/spree/return_authorization.rb
@@ -4,14 +4,14 @@ module Spree
   # Models the return of Inventory Units to a Stock Location for an Order.
   #
   class ReturnAuthorization < Spree::Base
-    belongs_to :order, class_name: 'Spree::Order', inverse_of: :return_authorizations
+    belongs_to :order, class_name: 'Spree::Order', inverse_of: :return_authorizations, optional: true
 
     has_many :return_items, inverse_of: :return_authorization, dependent: :destroy
     has_many :inventory_units, through: :return_items, dependent: :nullify
     has_many :customer_returns, through: :return_items
 
-    belongs_to :stock_location
-    belongs_to :reason, class_name: 'Spree::ReturnReason', foreign_key: :return_reason_id
+    belongs_to :stock_location, optional: true
+    belongs_to :reason, class_name: 'Spree::ReturnReason', foreign_key: :return_reason_id, optional: true
 
     before_create :generate_number
 

--- a/core/app/models/spree/return_item.rb
+++ b/core/app/models/spree/return_item.rb
@@ -29,15 +29,15 @@ module Spree
     class_attribute :refund_amount_calculator
     self.refund_amount_calculator = Calculator::Returns::DefaultRefundAmount
 
-    belongs_to :return_authorization, inverse_of: :return_items
-    belongs_to :inventory_unit, inverse_of: :return_items
-    belongs_to :exchange_variant, class_name: 'Spree::Variant'
-    belongs_to :exchange_inventory_unit, class_name: 'Spree::InventoryUnit', inverse_of: :original_return_item
-    belongs_to :customer_return, inverse_of: :return_items
-    belongs_to :reimbursement, inverse_of: :return_items
-    belongs_to :preferred_reimbursement_type, class_name: 'Spree::ReimbursementType'
-    belongs_to :override_reimbursement_type, class_name: 'Spree::ReimbursementType'
-    belongs_to :return_reason, class_name: 'Spree::ReturnReason', foreign_key: :return_reason_id
+    belongs_to :return_authorization, inverse_of: :return_items, optional: true
+    belongs_to :inventory_unit, inverse_of: :return_items, optional: true
+    belongs_to :exchange_variant, class_name: 'Spree::Variant', optional: true
+    belongs_to :exchange_inventory_unit, class_name: 'Spree::InventoryUnit', inverse_of: :original_return_item, optional: true
+    belongs_to :customer_return, inverse_of: :return_items, optional: true
+    belongs_to :reimbursement, inverse_of: :return_items, optional: true
+    belongs_to :preferred_reimbursement_type, class_name: 'Spree::ReimbursementType', optional: true
+    belongs_to :override_reimbursement_type, class_name: 'Spree::ReimbursementType', optional: true
+    belongs_to :return_reason, class_name: 'Spree::ReturnReason', foreign_key: :return_reason_id, optional: true
 
     validate :eligible_exchange_variant
     validate :belongs_to_same_customer_order

--- a/core/app/models/spree/role_user.rb
+++ b/core/app/models/spree/role_user.rb
@@ -3,8 +3,8 @@
 module Spree
   class RoleUser < Spree::Base
     self.table_name = "spree_roles_users"
-    belongs_to :role, class_name: "Spree::Role"
-    belongs_to :user, class_name: Spree::UserClassHandle.new
+    belongs_to :role, class_name: "Spree::Role", optional: true
+    belongs_to :user, class_name: Spree::UserClassHandle.new, optional: true
 
     after_create :auto_generate_spree_api_key
 

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -4,8 +4,8 @@ module Spree
   # An order's planned shipments including tracking and cost.
   #
   class Shipment < Spree::Base
-    belongs_to :order, class_name: 'Spree::Order', touch: true, inverse_of: :shipments
-    belongs_to :stock_location, class_name: 'Spree::StockLocation'
+    belongs_to :order, class_name: 'Spree::Order', touch: true, inverse_of: :shipments, optional: true
+    belongs_to :stock_location, class_name: 'Spree::StockLocation', optional: true
 
     has_many :adjustments, as: :adjustable, inverse_of: :adjustable, dependent: :delete_all
     has_many :inventory_units, dependent: :destroy, inverse_of: :shipment

--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -28,7 +28,7 @@ module Spree
     has_many :shipping_method_zones, dependent: :destroy
     has_many :zones, through: :shipping_method_zones
 
-    belongs_to :tax_category, -> { with_deleted }, class_name: 'Spree::TaxCategory'
+    belongs_to :tax_category, -> { with_deleted }, class_name: 'Spree::TaxCategory', optional: true
     has_many :shipping_method_stock_locations, dependent: :destroy, class_name: "Spree::ShippingMethodStockLocation"
     has_many :stock_locations, through: :shipping_method_stock_locations
 

--- a/core/app/models/spree/shipping_method_category.rb
+++ b/core/app/models/spree/shipping_method_category.rb
@@ -2,7 +2,7 @@
 
 module Spree
   class ShippingMethodCategory < Spree::Base
-    belongs_to :shipping_method, class_name: 'Spree::ShippingMethod'
-    belongs_to :shipping_category, class_name: 'Spree::ShippingCategory', inverse_of: :shipping_method_categories
+    belongs_to :shipping_method, class_name: 'Spree::ShippingMethod', optional: true
+    belongs_to :shipping_category, class_name: 'Spree::ShippingCategory', inverse_of: :shipping_method_categories, optional: true
   end
 end

--- a/core/app/models/spree/shipping_method_stock_location.rb
+++ b/core/app/models/spree/shipping_method_stock_location.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 class Spree::ShippingMethodStockLocation < Spree::Base
-  belongs_to :shipping_method
-  belongs_to :stock_location
+  belongs_to :shipping_method, optional: true
+  belongs_to :stock_location, optional: true
 end

--- a/core/app/models/spree/shipping_method_zone.rb
+++ b/core/app/models/spree/shipping_method_zone.rb
@@ -2,7 +2,7 @@
 
 module Spree
   class ShippingMethodZone < Spree::Base
-    belongs_to :zone
-    belongs_to :shipping_method
+    belongs_to :zone, optional: true
+    belongs_to :shipping_method, optional: true
   end
 end

--- a/core/app/models/spree/shipping_rate.rb
+++ b/core/app/models/spree/shipping_rate.rb
@@ -5,8 +5,8 @@ module Spree
   # method has been selected to deliver the shipment.
   #
   class ShippingRate < Spree::Base
-    belongs_to :shipment, class_name: 'Spree::Shipment', touch: true
-    belongs_to :shipping_method, -> { with_deleted }, class_name: 'Spree::ShippingMethod', inverse_of: :shipping_rates
+    belongs_to :shipment, class_name: 'Spree::Shipment', touch: true, optional: true
+    belongs_to :shipping_method, -> { with_deleted }, class_name: 'Spree::ShippingMethod', inverse_of: :shipping_rates, optional: true
 
     has_many :taxes,
              class_name: "Spree::ShippingRateTax",

--- a/core/app/models/spree/shipping_rate_tax.rb
+++ b/core/app/models/spree/shipping_rate_tax.rb
@@ -7,8 +7,8 @@ module Spree
   # @since 1.3.0
   # @see Spree::Tax::ShippingRateTaxer
   class ShippingRateTax < ActiveRecord::Base
-    belongs_to :shipping_rate, class_name: "Spree::ShippingRate"
-    belongs_to :tax_rate, class_name: "Spree::TaxRate"
+    belongs_to :shipping_rate, class_name: "Spree::ShippingRate", optional: true
+    belongs_to :tax_rate, class_name: "Spree::TaxRate", optional: true
 
     extend DisplayMoney
     money_methods :absolute_amount

--- a/core/app/models/spree/state.rb
+++ b/core/app/models/spree/state.rb
@@ -2,7 +2,7 @@
 
 module Spree
   class State < Spree::Base
-    belongs_to :country, class_name: 'Spree::Country'
+    belongs_to :country, class_name: 'Spree::Country', optional: true
     has_many :addresses, dependent: :nullify
 
     validates :country, :name, presence: true

--- a/core/app/models/spree/state_change.rb
+++ b/core/app/models/spree/state_change.rb
@@ -2,8 +2,8 @@
 
 module Spree
   class StateChange < Spree::Base
-    belongs_to :user
-    belongs_to :stateful, polymorphic: true
+    belongs_to :user, optional: true
+    belongs_to :stateful, polymorphic: true, optional: true
     before_create :assign_user
 
     def <=>(other)

--- a/core/app/models/spree/stock_item.rb
+++ b/core/app/models/spree/stock_item.rb
@@ -10,8 +10,8 @@ module Spree
     include Discard::Model
     self.discard_column = :deleted_at
 
-    belongs_to :stock_location, class_name: 'Spree::StockLocation', inverse_of: :stock_items
-    belongs_to :variant, -> { with_deleted }, class_name: 'Spree::Variant', inverse_of: :stock_items
+    belongs_to :stock_location, class_name: 'Spree::StockLocation', inverse_of: :stock_items, optional: true
+    belongs_to :variant, -> { with_deleted }, class_name: 'Spree::Variant', inverse_of: :stock_items, optional: true
     has_many :stock_movements, inverse_of: :stock_item
 
     validates :stock_location, :variant, presence: true

--- a/core/app/models/spree/stock_location.rb
+++ b/core/app/models/spree/stock_location.rb
@@ -16,8 +16,8 @@ module Spree
     has_many :user_stock_locations, dependent: :delete_all
     has_many :users, through: :user_stock_locations
 
-    belongs_to :state, class_name: 'Spree::State'
-    belongs_to :country, class_name: 'Spree::Country'
+    belongs_to :state, class_name: 'Spree::State', optional: true
+    belongs_to :country, class_name: 'Spree::Country', optional: true
 
     has_many :shipping_method_stock_locations, dependent: :destroy
     has_many :shipping_methods, through: :shipping_method_stock_locations

--- a/core/app/models/spree/stock_movement.rb
+++ b/core/app/models/spree/stock_movement.rb
@@ -2,8 +2,8 @@
 
 module Spree
   class StockMovement < Spree::Base
-    belongs_to :stock_item, class_name: 'Spree::StockItem', inverse_of: :stock_movements
-    belongs_to :originator, polymorphic: true
+    belongs_to :stock_item, class_name: 'Spree::StockItem', inverse_of: :stock_movements, optional: true
+    belongs_to :originator, polymorphic: true, optional: true
 
     after_create :update_stock_item_quantity
 

--- a/core/app/models/spree/store_credit.rb
+++ b/core/app/models/spree/store_credit.rb
@@ -18,10 +18,10 @@ class Spree::StoreCredit < Spree::PaymentSource
   ADJUSTMENT_ACTION = 'adjustment'
   INVALIDATE_ACTION = 'invalidate'
 
-  belongs_to :user, class_name: Spree::UserClassHandle.new
-  belongs_to :created_by, class_name: Spree::UserClassHandle.new
-  belongs_to :category, class_name: "Spree::StoreCreditCategory"
-  belongs_to :credit_type, class_name: 'Spree::StoreCreditType', foreign_key: 'type_id'
+  belongs_to :user, class_name: Spree::UserClassHandle.new, optional: true
+  belongs_to :created_by, class_name: Spree::UserClassHandle.new, optional: true
+  belongs_to :category, class_name: "Spree::StoreCreditCategory", optional: true
+  belongs_to :credit_type, class_name: 'Spree::StoreCreditType', foreign_key: 'type_id', optional: true
   has_many :store_credit_events
 
   validates_presence_of :user_id, :category_id, :type_id, :created_by_id, :currency

--- a/core/app/models/spree/store_credit_event.rb
+++ b/core/app/models/spree/store_credit_event.rb
@@ -10,9 +10,9 @@ module Spree
     include Discard::Model
     self.discard_column = :deleted_at
 
-    belongs_to :store_credit
-    belongs_to :originator, polymorphic: true
-    belongs_to :store_credit_reason, class_name: 'Spree::StoreCreditReason', inverse_of: :store_credit_events
+    belongs_to :store_credit, optional: true
+    belongs_to :originator, polymorphic: true, optional: true
+    belongs_to :store_credit_reason, class_name: 'Spree::StoreCreditReason', inverse_of: :store_credit_events, optional: true
 
     validates_presence_of :store_credit_reason, if: :action_requires_reason?
 

--- a/core/app/models/spree/store_payment_method.rb
+++ b/core/app/models/spree/store_payment_method.rb
@@ -2,7 +2,7 @@
 
 module Spree
   class StorePaymentMethod < Spree::Base
-    belongs_to :store, inverse_of: :store_payment_methods
-    belongs_to :payment_method, inverse_of: :store_payment_methods
+    belongs_to :store, inverse_of: :store_payment_methods, optional: true
+    belongs_to :payment_method, inverse_of: :store_payment_methods, optional: true
   end
 end

--- a/core/app/models/spree/store_shipping_method.rb
+++ b/core/app/models/spree/store_shipping_method.rb
@@ -2,7 +2,7 @@
 
 module Spree
   class StoreShippingMethod < Spree::Base
-    belongs_to :store, inverse_of: :store_shipping_methods
-    belongs_to :shipping_method, inverse_of: :store_shipping_methods
+    belongs_to :store, inverse_of: :store_shipping_methods, optional: true
+    belongs_to :shipping_method, inverse_of: :store_shipping_methods, optional: true
   end
 end

--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -17,7 +17,7 @@ module Spree
     include Spree::CalculatedAdjustments
     include Spree::AdjustmentSource
 
-    belongs_to :zone, class_name: "Spree::Zone", inverse_of: :tax_rates
+    belongs_to :zone, class_name: "Spree::Zone", inverse_of: :tax_rates, optional: true
 
     has_many :tax_rate_tax_categories,
       class_name: 'Spree::TaxRateTaxCategory',

--- a/core/app/models/spree/tax_rate_tax_category.rb
+++ b/core/app/models/spree/tax_rate_tax_category.rb
@@ -2,7 +2,7 @@
 
 module Spree
   class TaxRateTaxCategory < Spree::Base
-    belongs_to :tax_rate, class_name: 'Spree::TaxRate', inverse_of: :tax_rate_tax_categories
-    belongs_to :tax_category, class_name: 'Spree::TaxCategory', inverse_of: :tax_rate_tax_categories
+    belongs_to :tax_rate, class_name: 'Spree::TaxRate', inverse_of: :tax_rate_tax_categories, optional: true
+    belongs_to :tax_category, class_name: 'Spree::TaxCategory', inverse_of: :tax_rate_tax_categories, optional: true
   end
 end

--- a/core/app/models/spree/unit_cancel.rb
+++ b/core/app/models/spree/unit_cancel.rb
@@ -7,7 +7,7 @@ class Spree::UnitCancel < Spree::Base
   SHORT_SHIP = 'Short Ship'
   DEFAULT_REASON = 'Cancel'
 
-  belongs_to :inventory_unit
+  belongs_to :inventory_unit, optional: true
   has_one :adjustment, as: :source, dependent: :destroy
 
   validates :inventory_unit, presence: true

--- a/core/app/models/spree/user_address.rb
+++ b/core/app/models/spree/user_address.rb
@@ -2,8 +2,8 @@
 
 module Spree
   class UserAddress < Spree::Base
-    belongs_to :user, class_name: UserClassHandle.new, foreign_key: "user_id"
-    belongs_to :address, class_name: "Spree::Address"
+    belongs_to :user, class_name: UserClassHandle.new, foreign_key: "user_id", optional: true
+    belongs_to :address, class_name: "Spree::Address", optional: true
 
     validates_uniqueness_of :address_id, scope: :user_id
     validates_uniqueness_of :user_id, conditions: -> { active.default }, message: :default_address_exists, if: :default?

--- a/core/app/models/spree/user_stock_location.rb
+++ b/core/app/models/spree/user_stock_location.rb
@@ -2,7 +2,7 @@
 
 module Spree
   class UserStockLocation < Spree::Base
-    belongs_to :user, class_name: Spree::UserClassHandle.new, inverse_of: :user_stock_locations
-    belongs_to :stock_location, class_name: "Spree::StockLocation", inverse_of: :user_stock_locations
+    belongs_to :user, class_name: Spree::UserClassHandle.new, inverse_of: :user_stock_locations, optional: true
+    belongs_to :stock_location, class_name: "Spree::StockLocation", inverse_of: :user_stock_locations, optional: true
   end
 end

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -37,7 +37,7 @@ module Spree
     include Spree::DefaultPrice
 
     belongs_to :product, -> { with_deleted }, touch: true, class_name: 'Spree::Product', inverse_of: :variants, optional: false
-    belongs_to :tax_category, class_name: 'Spree::TaxCategory'
+    belongs_to :tax_category, class_name: 'Spree::TaxCategory', optional: true
 
     delegate :name, :description, :slug, :available_on, :shipping_category_id,
              :meta_description, :meta_keywords, :shipping_category,

--- a/core/app/models/spree/variant_property_rule.rb
+++ b/core/app/models/spree/variant_property_rule.rb
@@ -13,7 +13,7 @@
 # targeted by the rule, the properties will automatically apply to the variant.
 module Spree
   class VariantPropertyRule < Spree::Base
-    belongs_to :product, touch: true
+    belongs_to :product, touch: true, optional: true
 
     has_many :values, class_name: 'Spree::VariantPropertyRuleValue', dependent: :destroy
     has_many :properties, through: :values

--- a/core/app/models/spree/variant_property_rule_condition.rb
+++ b/core/app/models/spree/variant_property_rule_condition.rb
@@ -2,8 +2,8 @@
 
 module Spree
   class VariantPropertyRuleCondition < Spree::Base
-    belongs_to :option_value
-    belongs_to :variant_property_rule, touch: true
+    belongs_to :option_value, optional: true
+    belongs_to :variant_property_rule, touch: true, optional: true
 
     validates_uniqueness_of :option_value_id, scope: :variant_property_rule_id
   end

--- a/core/app/models/spree/variant_property_rule_value.rb
+++ b/core/app/models/spree/variant_property_rule_value.rb
@@ -6,7 +6,7 @@ module Spree
 
     acts_as_list scope: :variant_property_rule
 
-    belongs_to :property
-    belongs_to :variant_property_rule, touch: true
+    belongs_to :property, optional: true
+    belongs_to :variant_property_rule, touch: true, optional: true
   end
 end

--- a/core/app/models/spree/wallet_payment_source.rb
+++ b/core/app/models/spree/wallet_payment_source.rb
@@ -2,8 +2,8 @@
 
 module Spree
   class WalletPaymentSource < Spree::Base
-    belongs_to :user, class_name: Spree::UserClassHandle.new, foreign_key: 'user_id', inverse_of: :wallet_payment_sources
-    belongs_to :payment_source, polymorphic: true, inverse_of: :wallet_payment_sources
+    belongs_to :user, class_name: Spree::UserClassHandle.new, foreign_key: 'user_id', inverse_of: :wallet_payment_sources, optional: true
+    belongs_to :payment_source, polymorphic: true, inverse_of: :wallet_payment_sources, optional: true
 
     validates_presence_of :user
     validates_presence_of :payment_source

--- a/core/app/models/spree/zone_member.rb
+++ b/core/app/models/spree/zone_member.rb
@@ -2,8 +2,8 @@
 
 module Spree
   class ZoneMember < Spree::Base
-    belongs_to :zone, class_name: 'Spree::Zone', counter_cache: true, inverse_of: :zone_members
-    belongs_to :zoneable, polymorphic: true
+    belongs_to :zone, class_name: 'Spree::Zone', counter_cache: true, inverse_of: :zone_members, optional: true
+    belongs_to :zoneable, polymorphic: true, optional: true
 
     delegate :name, to: :zoneable, allow_nil: true
   end


### PR DESCRIPTION
## Second try of #3260 

Since Rails 5.1 `belongs_to` associations are required by default. We used to disable this option globally with a ActiveRecord class setting. With this we make the Rails 5.1 default setting obsolote and turn this off app wide.

```rb
Rails.application.config.active_record.belongs_to_required_by_default # => true
Spree::Base.belongs_to_required_by_default # => false
ActiveRecord::Base.belongs_to_required_by_default # => false
```

The fun fact is, the tests all pass with this removed. But this has the potential to break stores if their data is not consistent.

We have several options to solve this

1. We tell our users to clean up the database before running the next Solidus update where this included.
2. We include this in a mayor version update
3. We explicitely make all our `belongs_to` associations `optional`

I am in favor of the latter, so I made all `belongs_to` associations optional for now.

**Description**
<!--
  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

  If needed you can reference another PR or issue here, e.g.:
  Ref #ISSUE
-->

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
