### PR TITLE
Added empty cart button in admin cart

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/models/order.js
+++ b/backend/app/assets/javascripts/spree/backend/models/order.js
@@ -21,6 +21,15 @@ Spree.Models.Order = Backbone.Model.extend({
     };
     _.extend(options, opts);
     return this.fetch(options)
+  },
+
+  empty: function (opts) {
+    var options = {
+      url: Spree.routes.orders_api + "/" + this.id + "/empty",
+      type: 'PUT',
+    };
+    _.extend(options, opts);
+    return this.fetch(options)
   }
 });
 

--- a/backend/app/assets/javascripts/spree/backend/orders/cart.js
+++ b/backend/app/assets/javascripts/spree/backend/orders/cart.js
@@ -19,6 +19,12 @@ Spree.Order.initCartPage = function(order_number) {
     collection: collection
   });
 
+  new Spree.Views.Cart.EmptyCartButton({
+    el: $('.js-empty-cart'),
+    collection: collection,
+    model: order
+  });
+
   new Spree.Views.Order.DetailsTotal({
     el: $('#order-total'),
     model: order

--- a/backend/app/assets/javascripts/spree/backend/views/cart/empty_cart_button.js
+++ b/backend/app/assets/javascripts/spree/backend/views/cart/empty_cart_button.js
@@ -1,0 +1,29 @@
+Spree.Views.Cart.EmptyCartButton = Backbone.View.extend({
+  initialize: function() {
+    this.listenTo(this.collection, 'update', this.render);
+    this.render();
+  },
+
+  events: {
+    "click": "onClick"
+  },
+
+  onClick: function(e) {
+    e.preventDefault()
+    if (!confirm(Spree.translations.are_you_sure_delete)) {
+      return;
+    }
+
+    this.model.empty({
+      success: () => {
+        this.collection.reset()
+        this.collection.push({})
+      }
+    })
+  },
+
+  render: function() {
+    var isNew = function (item) { return item.isNew() };
+    this.$el.prop("disabled", !this.collection.length || this.collection.some(isNew));
+  }
+});

--- a/backend/app/assets/javascripts/spree/backend/views/cart/line_item_table.js
+++ b/backend/app/assets/javascripts/spree/backend/views/cart/line_item_table.js
@@ -1,11 +1,16 @@
 Spree.Views.Cart.LineItemTable = Backbone.View.extend({
   initialize: function() {
     this.listenTo(this.collection, 'add', this.add);
+    this.listenTo(this.collection, 'reset', this.reset);
   },
 
   add: function(line_item) {
     var view = new Spree.Views.Cart.LineItemRow({model: line_item});
     view.render();
     this.$el.append(view.el);
+  },
+
+  reset: function() {
+    this.$el.empty();
   }
 });

--- a/backend/app/assets/javascripts/spree/backend/views/index.js
+++ b/backend/app/assets/javascripts/spree/backend/views/index.js
@@ -1,5 +1,6 @@
 //= require 'spree/backend/views/calculators/tiered'
 //= require 'spree/backend/views/cart/add_line_item_button'
+//= require 'spree/backend/views/cart/empty_cart_button'
 //= require 'spree/backend/views/cart/line_item_row'
 //= require 'spree/backend/views/cart/line_item_table'
 //= require 'spree/backend/views/images/upload_zone'

--- a/backend/app/views/spree/admin/orders/_line_items_edit_form.html.erb
+++ b/backend/app/views/spree/admin/orders/_line_items_edit_form.html.erb
@@ -7,6 +7,7 @@
 
   <% if can?(:update, @order) && can?(:create, Spree::LineItem) %>
     <button class="js-add-line-item btn btn-primary" disabled><%= t('spree.add_line_item') %></button>
+    <button class="js-empty-cart btn btn-primary" disabled><%= t('spree.empty_cart') %></button>
   <% end %>
 
   <%= render "spree/admin/orders/order_details", { order: order } %>

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -76,6 +76,19 @@ describe "Order Details", type: :feature, js: true do
         expect(page).to have_field('quantity')
       end
 
+      it "can remove all items with empty cart" do
+        expect(page).to have_content("spree t-shirt")
+
+        accept_confirm "Are you sure you want to delete this record?" do
+          click_on 'Empty Cart'
+        end
+
+        expect(page).not_to have_content("spree t-shirt")
+
+        # Should have a new item row
+        expect(page).to have_field('quantity')
+      end
+
       # Regression test for https://github.com/spree/spree/issues/3862
       it "can cancel removing an item from a shipment" do
         expect(page).to have_content("spree t-shirt")


### PR DESCRIPTION
**Description**
<!--
  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

  If needed you can reference another PR or issue here, e.g.:
  Ref #ISSUE
-->

The frontend has an empty cart button and the API supports an
empty cart call. This adds that functionality to the backend
interface.

![Screen Shot 2019-08-28 at 12 06 52 PM](https://user-images.githubusercontent.com/5138892/63885062-62b2cc00-c98c-11e9-91fb-b5c341cdabd6.png)


**Checklist:**
- [ ] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [ ] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
