### PR TITLE
Fix tab background color, too dark #3311

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/globals/_variables.scss
+++ b/backend/app/assets/stylesheets/spree/backend/globals/_variables.scss
@@ -55,7 +55,7 @@ $color-icon-navbar:             $color-dark-light !default;
 
 // Basic Tabs colors
 $color-tab:                     $color-dark-light !default;
-$color-tab-bg:                  very-light($color-dark-light, 4) !default;
+$color-tab-bg:                  $color-light !default;
 $color-tab-border:              $color-border !default;
 $color-tab-active:              $color-primary !default;
 $color-tab-active-bg:           $color-white !default;


### PR DESCRIPTION


**Description**
<!--
  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

  If needed you can reference another PR or issue here, e.g.:
  Ref #3311
-->

In solidus backend I noticed that non active tabs have a dark background color, that makes the tab title unreadable.

Ref #3311

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
