### PR TITLE
Fix issue with available_on datepicker

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/datepicker.js
+++ b/backend/app/assets/javascripts/spree/backend/datepicker.js
@@ -11,7 +11,8 @@ Spree.ready(function(){
   });
 
   $('.datepicker').flatpickr({
-    allowInput: true
+    allowInput: true,
+    dateFormat: Spree.t('date_picker.js_format')
   });
 
   // Handle range dates

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1467,7 +1467,7 @@ en:
     date_picker:
       first_day: 0
       format: "%Y/%m/%d"
-      js_format: yy/mm/dd
+      js_format: Y/m/d
     date_range: Date Range
     default: Default
     default_refund_amount: Default Refund Amount


### PR DESCRIPTION
This PR fixes https://github.com/solidusio/solidus/issues/2721.
I'd like to fix it already in version 2.7 and release a 2.7.4 if possible.
The datepicker should take the `js_format` from i18n file (not in use anywhere else).
I'll open also a PR on solidus_i18n to set it already correctly for the other locales.

I am not sure if this is a breaking change. If someone has overridden `js_format` with something weird it will probably stop working.