### PR TITLE
Remove sqlite3 version lock in sandbox/development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ group :backend, :frontend, :core, :api do
     when /postgres/
       gem 'pg', '~> 1.0', require: false
     else
-      gem 'sqlite3', '~> 1.3.6', require: false
+      gem 'sqlite3', require: false
       gem 'fast_sqlite', require: false
     end
   end

--- a/lib/sandbox.sh
+++ b/lib/sandbox.sh
@@ -49,10 +49,6 @@ group :test, :development do
 end
 RUBY
 
-# Ensure sqlite3 version to match ActiveRecord SQLite adapter requirement
-# (see https://github.com/solidusio/solidus/issues/3087 for details)
-sed -i -e "s/gem 'sqlite3'/gem 'sqlite3', '~> 1.3.6'/g" Gemfile
-
 bundle install --gemfile Gemfile
 bundle exec rake db:drop db:create
 bundle exec rails g spree:install --auto-accept --user_class=Spree::User --enforce_available_locales=true


### PR DESCRIPTION
**Description**
This PR reverts what has been done in #3088, since it's no more needed. 
Without this fix, we also have Rails 6 sandbox generation broken, as reported in https://github.com/solidusio/solidus/issues/3053#issuecomment-527495856.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- ~[ ] I have updated Guides and README accordingly to this change (if needed)~
- ~[ ] I have added tests to cover this change (if needed)~
