### PR TITLE
Avoid installing webpacker in sandbox

### DIFF
--- a/lib/sandbox.sh
+++ b/lib/sandbox.sh
@@ -27,7 +27,7 @@ bundle exec rails new sandbox --database="$RAILSDB" \
   --skip-rc \
   --skip-spring \
   --skip-test \
-  --skip-yarn
+  --skip-javascript
 
 if [ ! -d "sandbox" ]; then
   echo 'sandbox rails application failed'


### PR DESCRIPTION
**Description**

With rails/rails#34275 `rails new` option named `--skip_yarn` is changed into `--skip_javascript`. This PR reflects this change and keeps allowing us to still use sprockets for JS in our sandbox.

**TODO**

- [x] ~Using this option with Rails 6, sandbox does not contain any `app/assets/javascripts` folder, so I think Solidus manifests is not loaded correctly. This needs to be investigated.~ My fault, that folder is not needed in the sandbox since the sandbox application will use the manifests defined in the solidus gems. 


**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- ~[ ] I have updated Guides and README accordingly to this change (if needed)~
- ~[ ] I have added tests to cover this change (if needed)~
