### PR TITLE
Fix dummy app generator to skip Bootsnap and Webpack in Rails 6

### DIFF
--- a/core/lib/generators/spree/dummy/dummy_generator.rb
+++ b/core/lib/generators/spree/dummy/dummy_generator.rb
@@ -42,6 +42,8 @@ module Spree
       opts[:skip_spring] = true
       opts[:skip_test] = true
       opts[:skip_yarn] = true
+      opts[:skip_bootsnap] = true
+      opts[:skip_webpack_install] = true
 
       puts "Generating dummy Rails application..."
       invoke Rails::Generators::AppGenerator,


### PR DESCRIPTION
**Description**

Fixes the dummy app generator, which now fails because Rails 6 uses Bootsnap and Webpacker by default, which are not included in our Gemfile (and not needed for the dummy app).

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
