### PR TITLE
Remove Rails 5.1 support

### DIFF
--- a/core/lib/spree/testing_support/dummy_app/rake_tasks.rb
+++ b/core/lib/spree/testing_support/dummy_app/rake_tasks.rb
@@ -43,10 +43,8 @@ namespace :db do
           [path],
           ActiveRecord::SchemaMigration
         ).migrate
-      elsif Rails.gem_version >= Gem::Version.new('5.2.0')
-        ActiveRecord::MigrationContext.new([path]).migrate
       else
-        ActiveRecord::Migrator.migrate(path)
+        ActiveRecord::MigrationContext.new([path]).migrate
       end
     end
 

--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
     actionmailer actionpack actionview activejob activemodel activerecord
     activesupport railties
   ].each do |rails_dep|
-    s.add_dependency rails_dep, ['>= 5.1', '< 7.0.x']
+    s.add_dependency rails_dep, ['>= 5.2', '< 7.0.x']
   end
 
   s.add_dependency 'activemerchant', '~> 1.66'


### PR DESCRIPTION
**Description**
Our code is still compatible with Rails 5.1 but that version is in its `EOL` phase, so it's not receiving security patches anymore. 

This PR removes support for Rails 5.1, and it's a follow-up of #3333. We should merge this PR after we release the next version, probably `2.10`. 

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- ~[ ] I have updated Guides and README accordingly to this change (if needed)~
- ~[ ] I have added tests to cover this change (if needed)~
