### PR TITLE
Added location_filter_class as a writable attribute

### DIFF
--- a/core/lib/spree/core/stock_configuration.rb
+++ b/core/lib/spree/core/stock_configuration.rb
@@ -5,6 +5,7 @@ module Spree
     class StockConfiguration
       attr_writer :coordinator_class
       attr_writer :estimator_class
+      attr_writer :location_filter_class
       attr_writer :location_sorter_class
       attr_writer :allocator_class
 

--- a/core/spec/lib/spree/core/stock_configuration_spec.rb
+++ b/core/spec/lib/spree/core/stock_configuration_spec.rb
@@ -39,6 +39,24 @@ RSpec.describe Spree::Core::StockConfiguration do
     end
   end
 
+  describe '#location_filter_class' do
+    let(:stock_configuration) { described_class.new }
+    subject { stock_configuration.location_filter_class }
+
+    it "returns Spree::Stock::LocationFilter::Active" do
+      is_expected.to be ::Spree::Stock::LocationFilter::Active
+    end
+
+    context "with another constant name assiged" do
+      MyFilter = Class.new
+      before { stock_configuration.location_filter_class = MyFilter.to_s }
+
+      it "returns the constant" do
+        is_expected.to be MyFilter
+      end
+    end
+  end
+
   describe '#location_sorter_class' do
     let(:stock_configuration) { described_class.new }
     subject { stock_configuration.location_sorter_class }
@@ -53,6 +71,24 @@ RSpec.describe Spree::Core::StockConfiguration do
 
       it "returns the constant" do
         is_expected.to be MySorter
+      end
+    end
+  end
+
+  describe '#allocator_class' do
+    let(:stock_configuration) { described_class.new }
+    subject { stock_configuration.allocator_class }
+
+    it "returns Spree::Stock::Allocator::OnHandFirst" do
+      is_expected.to be ::Spree::Stock::Allocator::OnHandFirst
+    end
+
+    context "with another constant name assiged" do
+      MyAllocator = Class.new
+      before { stock_configuration.allocator_class = MyAllocator.to_s }
+
+      it "returns the constant" do
+        is_expected.to be MyAllocator
       end
     end
   end


### PR DESCRIPTION
**Description**
<!--
  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

  If needed you can reference another PR or issue here, e.g.:
  Ref #ISSUE
-->

The other stock configuration classes are all configurable
but location_filter_class was missing the attr_writer.
Also includes specs for location_filter_class and
allocator_class configurations.

**Checklist:**
- [ ] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [ ] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
