### PR TITLE
Use default sass function to lighten colors

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/components/_messages.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_messages.scss
@@ -40,15 +40,15 @@
   color: $body-color;
 
   &.notice {
-    background-color: rgba(very-light($color-notice, 15), .95);
+    background-color: rgba(lighten($color-notice, 15), .95);
     border-top-color: $color-notice;
   }
   &.success {
-    background-color: rgba(very-light($color-success, 30), .95);
+    background-color: rgba(lighten($color-success, 30), .95);
     border-top-color: $color-success;
   }
   &.error {
-    background-color: rgba(very-light($color-error, 30), .95);
+    background-color: rgba(lighten($color-error, 30), .95);
     border-top-color: $color-error;
   }
 }

--- a/backend/app/assets/stylesheets/spree/backend/globals/_variables.scss
+++ b/backend/app/assets/stylesheets/spree/backend/globals/_variables.scss
@@ -89,8 +89,8 @@ $color-style-guide-table-border:    #CEE1F4;
 
 // Table colors
 $color-tbl-odd:                  $color-white !default;
-$color-tbl-even:                 very-light($color-dark-light, 4) !default;
-$color-tbl-thead:                very-light($color-dark-light, 4) !default;
+$color-tbl-even:                 $color-light !default;
+$color-tbl-thead:                $color-light !default;
 
 // Pill colors
 //
@@ -114,24 +114,24 @@ $color-pill-error: #ff967b;
 $color-pill-error-text: $color-pill-text;
 
 // Actions colors
-$color-action-edit-bg:           very-light($color-success, 5  ) !default;
-$color-action-edit-brd:          very-light($color-success, 20 ) !default;
-$color-action-clone-bg:          very-light($color-notice,  5  ) !default;
-$color-action-clone-brd:         very-light($color-notice,  15 ) !default;
-$color-action-remove-bg:         very-light($color-error,   5  ) !default;
-$color-action-remove-brd:        very-light($color-error,   10 ) !default;
-$color-action-void-bg:           very-light($color-error,   10 ) !default;
-$color-action-void-brd:          very-light($color-error,   20 ) !default;
-$color-action-cancel-bg:         very-light($color-notice,  10 ) !default;
-$color-action-cancel-brd:        very-light($color-notice,  20 ) !default;
-$color-action-capture-bg:        very-light($color-success, 5  ) !default;
-$color-action-capture-brd:       very-light($color-success, 20 ) !default;
-$color-action-save-bg:           very-light($color-success, 5  ) !default;
-$color-action-save-brd:          very-light($color-success, 20 ) !default;
-$color-action-mail-bg:           very-light($color-success, 5  ) !default;
-$color-action-mail-brd:          very-light($color-success, 20 ) !default;
-$color-action-failure-bg:        very-light($color-error,   10 ) !default;
-$color-action-failure-brd:       very-light($color-error,   20 ) !default;
+$color-action-edit-bg:           lighten($color-success, (5 * 5)  ) !default;
+$color-action-edit-brd:          lighten($color-success, (20 * 5) ) !default;
+$color-action-clone-bg:          lighten($color-notice,  (5 * 5)  ) !default;
+$color-action-clone-brd:         lighten($color-notice,  (15 * 5) ) !default;
+$color-action-remove-bg:         lighten($color-error,   (5 * 5)  ) !default;
+$color-action-remove-brd:        lighten($color-error,   (10 * 5) ) !default;
+$color-action-void-bg:           lighten($color-error,   (10 * 5) ) !default;
+$color-action-void-brd:          lighten($color-error,   (20 * 5) ) !default;
+$color-action-cancel-bg:         lighten($color-notice,  (10 * 5) ) !default;
+$color-action-cancel-brd:        lighten($color-notice,  (20 * 5) ) !default;
+$color-action-capture-bg:        lighten($color-success, (5 * 5)  ) !default;
+$color-action-capture-brd:       lighten($color-success, (20 * 5) ) !default;
+$color-action-save-bg:           lighten($color-success, (5 * 5)  ) !default;
+$color-action-save-brd:          lighten($color-success, (20 * 5) ) !default;
+$color-action-mail-bg:           lighten($color-success, (5 * 5)  ) !default;
+$color-action-mail-brd:          lighten($color-success, (20 * 5) ) !default;
+$color-action-failure-bg:        lighten($color-error,   (10 * 5) ) !default;
+$color-action-failure-brd:       lighten($color-error,   (20 * 5) ) !default;
 
 // Available states
 $states: (

--- a/backend/app/assets/stylesheets/spree/backend/sections/_taxonomies.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/_taxonomies.scss
@@ -12,7 +12,7 @@
   }
 
   .taxon {
-    background-color: very-light($color-dark-light);
+    background-color: $color-light;
     border: 1px solid $color-border;
     border-radius: $border-radius;
     color: $body-color;

--- a/backend/app/assets/stylesheets/spree/backend/shared/_tables.scss
+++ b/backend/app/assets/stylesheets/spree/backend/shared/_tables.scss
@@ -114,8 +114,8 @@ table {
   tbody {
     tr {
       &.deleted td {
-        background-color: very-light(theme-color("danger"), 6);
-        border-color: very-light(theme-color("danger"), 15);
+        background-color: lighten(theme-color("danger"), 6);
+        border-color: lighten(theme-color("danger"), 15);
       }
     }
 


### PR DESCRIPTION
Noticed that the custom sass `@function very-light` doesn't work
properly and this fact is generating display issues, both in tables
with actions, and in components such as Taxonomies.

### The issue

<img width="1189" alt="Schermata 2019-08-23 alle 11 22 12 (1)" src="https://user-images.githubusercontent.com/46188345/64698536-61f95a00-d4a3-11e9-8ad8-887c9d3f8451.png">

![Screenshot from 2019-09-10 16_01_37](https://user-images.githubusercontent.com/46188345/64698549-67ef3b00-d4a3-11e9-9a08-5a34e502b513.png)

### Resolved issue

<img width="1088" alt="Schermata 2019-09-11 alle 14 47 35" src="https://user-images.githubusercontent.com/46188345/64698594-79384780-d4a3-11e9-80fe-c33aaede2f66.png">

<img width="1133" alt="Schermata 2019-09-11 alle 14 47 15" src="https://user-images.githubusercontent.com/46188345/64698606-7d646500-d4a3-11e9-9ebb-64ba1a928658.png">


