### PR TITLE
Deprecate Rails 5.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,24 +103,6 @@ jobs:
       - setup
       - test
 
-  postgres_rails51:
-    executor: postgres
-    parallelism: *parallelism
-    environment:
-      RAILS_VERSION: '~> 5.1.0'
-    steps:
-      - setup
-      - test
-
-  mysql_rails51:
-    executor: mysql
-    parallelism: *parallelism
-    environment:
-      RAILS_VERSION: '~> 5.1.0'
-    steps:
-      - setup
-      - test
-
   postgres_rails52:
     executor: postgres
     parallelism: *parallelism
@@ -148,8 +130,6 @@ workflows:
               only: /master|v\d\.\d/
       - postgres
       - mysql
-      - postgres_rails51
-      - mysql_rails51
       - postgres_rails52
       - mysql_rails52
       - stoplight/push:

--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -53,6 +53,17 @@ module Spree
   end
 end
 
+if Gem::Version.new(Rails.version) < Gem::Version.new('5.2')
+  warn <<~HEREDOC
+    Rails 5.1 (EOL) is deprecated and will not be supported anymore from the next Solidus version.
+    Please, upgrade to a more recent Rails version.
+
+    Read more on upgrading from Rails 5.1 to Rails 5.2 here:
+    https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#upgrading-from-rails-5-1-to-rails-5-2
+
+  HEREDOC
+end
+
 require 'spree/core/version'
 
 require 'spree/core/active_merchant_dependencies'

--- a/core/spec/models/spree/payment_create_spec.rb
+++ b/core/spec/models/spree/payment_create_spec.rb
@@ -156,20 +156,10 @@ module Spree
       context "unpermitted" do
         let(:attributes) { ActionController::Parameters.new(valid_attributes) }
 
-        if Rails.gem_version < Gem::Version.new('5.1')
-          it "ignores all attributes" do
-            expect(new_payment).to have_attributes(
-              amount: 0,
-              payment_method: nil,
-              source: nil
-            )
-          end
-        else
-          it "raises an exception" do
-            expect {
-              new_payment
-            }.to raise_exception(ActionController::UnfilteredParameters)
-          end
+        it "raises an exception" do
+          expect {
+            new_payment
+          }.to raise_exception(ActionController::UnfilteredParameters)
         end
       end
 


### PR DESCRIPTION
**Description**
This PR removes Rails 5.1 from our CI and prints a warning message in the Rails console for users who are still using Rails 5.1. 

After the next version release (`2.10`?), we can merge #3328 and complete this transition. 

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
~- [ ] I have updated Guides and README accordingly to this change (if needed)~
~- [ ] I have added tests to cover this change (if needed)~
