### PR TITLE
Replace update_attributes with update

### DIFF
--- a/api/app/controllers/spree/api/addresses_controller.rb
+++ b/api/app/controllers/spree/api/addresses_controller.rb
@@ -15,7 +15,7 @@ module Spree
         authorize! :update, @order, order_token
         find_address
 
-        if @order.update_attributes({ "#{@order_source}_attributes" => address_params })
+        if @order.update({ "#{@order_source}_attributes" => address_params })
           @address = @order.send(@order_source)
           respond_with(@address, default_template: :show)
         else

--- a/api/app/controllers/spree/api/credit_cards_controller.rb
+++ b/api/app/controllers/spree/api/credit_cards_controller.rb
@@ -18,7 +18,7 @@ module Spree
       end
 
       def update
-        if @credit_card.update_attributes(credit_card_update_params)
+        if @credit_card.update(credit_card_update_params)
           respond_with(@credit_card, default_template: :show)
         else
           invalid_resource!(@credit_card)

--- a/api/app/controllers/spree/api/images_controller.rb
+++ b/api/app/controllers/spree/api/images_controller.rb
@@ -21,7 +21,7 @@ module Spree
 
       def update
         @image = Spree::Image.accessible_by(current_ability, :update).find(params[:id])
-        @image.update_attributes(image_params)
+        @image.update(image_params)
         respond_with(@image, default_template: :show)
       end
 

--- a/api/app/controllers/spree/api/inventory_units_controller.rb
+++ b/api/app/controllers/spree/api/inventory_units_controller.rb
@@ -14,7 +14,7 @@ module Spree
         authorize! :update, inventory_unit.order
 
         inventory_unit.transaction do
-          if inventory_unit.update_attributes(inventory_unit_params)
+          if inventory_unit.update(inventory_unit_params)
             fire
             render :show, status: 200
           else

--- a/api/app/controllers/spree/api/option_types_controller.rb
+++ b/api/app/controllers/spree/api/option_types_controller.rb
@@ -29,7 +29,7 @@ module Spree
 
       def update
         @option_type = Spree::OptionType.accessible_by(current_ability, :update).find(params[:id])
-        if @option_type.update_attributes(option_type_params)
+        if @option_type.update(option_type_params)
           render :show
         else
           invalid_resource!(@option_type)

--- a/api/app/controllers/spree/api/option_values_controller.rb
+++ b/api/app/controllers/spree/api/option_values_controller.rb
@@ -29,7 +29,7 @@ module Spree
 
       def update
         @option_value = scope.accessible_by(current_ability, :update).find(params[:id])
-        if @option_value.update_attributes(option_value_params)
+        if @option_value.update(option_value_params)
           render :show
         else
           invalid_resource!(@option_value)

--- a/api/app/controllers/spree/api/payments_controller.rb
+++ b/api/app/controllers/spree/api/payments_controller.rb
@@ -31,7 +31,7 @@ module Spree
         authorize! params[:action], @payment
         if !@payment.pending?
           render 'update_forbidden', status: 403
-        elsif @payment.update_attributes(payment_params)
+        elsif @payment.update(payment_params)
           respond_with(@payment, default_template: :show)
         else
           invalid_resource!(@payment)

--- a/api/app/controllers/spree/api/product_properties_controller.rb
+++ b/api/app/controllers/spree/api/product_properties_controller.rb
@@ -38,7 +38,7 @@ module Spree
       def update
         if @product_property
           authorize! :update, @product_property
-          @product_property.update_attributes(product_property_params)
+          @product_property.update(product_property_params)
           respond_with(@product_property, status: 200, default_template: :show)
         else
           invalid_resource!(@product_property)

--- a/api/app/controllers/spree/api/properties_controller.rb
+++ b/api/app/controllers/spree/api/properties_controller.rb
@@ -39,7 +39,7 @@ module Spree
       def update
         if @property
           authorize! :update, @property
-          @property.update_attributes(property_params)
+          @property.update(property_params)
           respond_with(@property, status: 200, default_template: :show)
         else
           invalid_resource!(@property)

--- a/api/app/controllers/spree/api/resource_controller.rb
+++ b/api/app/controllers/spree/api/resource_controller.rb
@@ -43,7 +43,7 @@ class Spree::Api::ResourceController < Spree::Api::BaseController
   def update
     authorize! :update, @object
 
-    if @object.update_attributes(permitted_resource_params)
+    if @object.update(permitted_resource_params)
       respond_with(@object, status: 200, default_template: :show)
     else
       invalid_resource!(@object)

--- a/api/app/controllers/spree/api/return_authorizations_controller.rb
+++ b/api/app/controllers/spree/api/return_authorizations_controller.rb
@@ -50,7 +50,7 @@ module Spree
 
       def update
         @return_authorization = @order.return_authorizations.accessible_by(current_ability, :update).find(params[:id])
-        if @return_authorization.update_attributes(return_authorization_params)
+        if @return_authorization.update(return_authorization_params)
           respond_with(@return_authorization, default_template: :show)
         else
           invalid_resource!(@return_authorization)

--- a/api/app/controllers/spree/api/shipments_controller.rb
+++ b/api/app/controllers/spree/api/shipments_controller.rb
@@ -146,7 +146,7 @@ module Spree
       end
 
       def update_shipment
-        @shipment.update_attributes(shipment_params)
+        @shipment.update(shipment_params)
         @shipment.reload
       end
 

--- a/api/app/controllers/spree/api/stock_items_controller.rb
+++ b/api/app/controllers/spree/api/stock_items_controller.rb
@@ -40,7 +40,7 @@ module Spree
         adjustment -= @stock_item.count_on_hand if params[:stock_item][:force]
 
         Spree::StockItem.transaction do
-          if @stock_item.update_attributes(stock_item_params)
+          if @stock_item.update(stock_item_params)
             adjust_stock_item_count_on_hand(adjustment)
             respond_with(@stock_item, status: 200, default_template: :show)
           else

--- a/api/app/controllers/spree/api/stock_locations_controller.rb
+++ b/api/app/controllers/spree/api/stock_locations_controller.rb
@@ -33,7 +33,7 @@ module Spree
 
       def update
         authorize! :update, stock_location
-        if stock_location.update_attributes(stock_location_params)
+        if stock_location.update(stock_location_params)
           respond_with(stock_location, status: 200, default_template: :show)
         else
           invalid_resource!(stock_location)

--- a/api/app/controllers/spree/api/stores_controller.rb
+++ b/api/app/controllers/spree/api/stores_controller.rb
@@ -24,7 +24,7 @@ module Spree
 
       def update
         authorize! :update, @store
-        if @store.update_attributes(store_params)
+        if @store.update(store_params)
           respond_with(@store, status: 200, default_template: :show)
         else
           invalid_resource!(@store)

--- a/api/app/controllers/spree/api/taxonomies_controller.rb
+++ b/api/app/controllers/spree/api/taxonomies_controller.rb
@@ -33,7 +33,7 @@ module Spree
 
       def update
         authorize! :update, taxonomy
-        if taxonomy.update_attributes(taxonomy_params)
+        if taxonomy.update(taxonomy_params)
           respond_with(taxonomy, status: 200, default_template: :show)
         else
           invalid_resource!(taxonomy)

--- a/api/app/controllers/spree/api/taxons_controller.rb
+++ b/api/app/controllers/spree/api/taxons_controller.rb
@@ -56,7 +56,7 @@ module Spree
 
       def update
         authorize! :update, taxon
-        if taxon.update_attributes(taxon_params)
+        if taxon.update(taxon_params)
           respond_with(taxon, status: 200, default_template: :show)
         else
           invalid_resource!(taxon)

--- a/api/app/controllers/spree/api/variants_controller.rb
+++ b/api/app/controllers/spree/api/variants_controller.rb
@@ -43,7 +43,7 @@ module Spree
 
       def update
         @variant = scope.accessible_by(current_ability, :update).find(params[:id])
-        if @variant.update_attributes(variant_params)
+        if @variant.update(variant_params)
           respond_with(@variant, status: 200, default_template: :show)
         else
           invalid_resource!(@product)

--- a/api/app/controllers/spree/api/zones_controller.rb
+++ b/api/app/controllers/spree/api/zones_controller.rb
@@ -37,7 +37,7 @@ module Spree
 
       def update
         authorize! :update, zone
-        if zone.update_attributes(zone_params)
+        if zone.update(zone_params)
           respond_with(zone, status: 200, default_template: :show)
         else
           invalid_resource!(zone)

--- a/api/spec/requests/spree/api/classifications_controller_spec.rb
+++ b/api/spec/requests/spree/api/classifications_controller_spec.rb
@@ -39,7 +39,7 @@ module Spree
       end
 
       it "should touch the taxon" do
-        taxon.update_attributes(updated_at: Time.current - 10.seconds)
+        taxon.update(updated_at: Time.current - 10.seconds)
         taxon_last_updated_at = taxon.updated_at
         put spree.api_classifications_path, params: { taxon_id: taxon.id, product_id: last_product.id, position: 0 }
         taxon.reload

--- a/api/spec/requests/spree/api/orders_controller_spec.rb
+++ b/api/spec/requests/spree/api/orders_controller_spec.rb
@@ -306,7 +306,7 @@ module Spree
 
       context 'when an item does not track inventory' do
         before do
-          order.line_items.first.variant.update_attributes!(track_inventory: false)
+          order.line_items.first.variant.update!(track_inventory: false)
         end
 
         it 'contains stock information on variant' do
@@ -547,7 +547,7 @@ module Spree
       end
 
       it "can add shipping address" do
-        order.update_attributes!(ship_address_id: nil)
+        order.update!(ship_address_id: nil)
 
         expect {
           put spree.api_order_path(order), params: { order: { ship_address_attributes: shipping_address } }
@@ -555,7 +555,7 @@ module Spree
       end
 
       it "receives error message if trying to add shipping address with errors" do
-        order.update_attributes!(ship_address_id: nil)
+        order.update!(ship_address_id: nil)
 
         shipping_address[:firstname] = ""
 

--- a/api/spec/requests/spree/api/payments_controller_spec.rb
+++ b/api/spec/requests/spree/api/payments_controller_spec.rb
@@ -137,7 +137,7 @@ module Spree
       context "for a given payment" do
         context "updating" do
           it "can update" do
-            payment.update_attributes(state: 'pending')
+            payment.update(state: 'pending')
             put spree.api_order_payment_path(order, payment), params: { payment: { amount: 2.01 } }
             expect(response.status).to eq(200)
             expect(payment.reload.amount).to eq(2.01)
@@ -145,14 +145,14 @@ module Spree
 
           context "update fails" do
             it "returns a 422 status when the amount is invalid" do
-              payment.update_attributes(state: 'pending')
+              payment.update(state: 'pending')
               put spree.api_order_payment_path(order, payment), params: { payment: { amount: 'invalid' } }
               expect(response.status).to eq(422)
               expect(json_response["error"]).to eq("Invalid resource. Please fix errors and try again.")
             end
 
             it "returns a 403 status when the payment is not pending" do
-              payment.update_attributes(state: 'completed')
+              payment.update(state: 'completed')
               put spree.api_order_payment_path(order, payment), params: { payment: { amount: 2.01 } }
               expect(response.status).to eq(403)
               expect(json_response["error"]).to eq("This payment cannot be updated because it is completed.")

--- a/api/spec/requests/spree/api/stock_items_controller_spec.rb
+++ b/api/spec/requests/spree/api/stock_items_controller_spec.rb
@@ -25,7 +25,7 @@ module Spree
         end
 
         it "cannot list stock items for an inactive stock location" do
-          stock_location.update_attributes!(active: false)
+          stock_location.update!(active: false)
           get spree.api_stock_location_stock_items_path(stock_location)
           expect(response).to be_not_found
         end
@@ -39,7 +39,7 @@ module Spree
         end
 
         it "cannot see a stock item for an inactive stock location" do
-          stock_location.update_attributes!(active: false)
+          stock_location.update!(active: false)
           get spree.api_stock_location_stock_item_path(stock_location, stock_item)
           expect(response.status).to eq(404)
         end
@@ -155,7 +155,7 @@ module Spree
 
         context 'variant does not track inventory' do
           before do
-            variant.update_attributes(track_inventory: false)
+            variant.update(track_inventory: false)
           end
 
           it "doesn't set the stock item's count_on_hand" do
@@ -221,7 +221,7 @@ module Spree
 
           context 'not tracking inventory' do
             before do
-              stock_item.variant.update_attributes(track_inventory: false)
+              stock_item.variant.update(track_inventory: false)
             end
 
             it "doesn't set the stock item's count_on_hand" do
@@ -279,7 +279,7 @@ module Spree
 
           context 'not tracking inventory' do
             before do
-              stock_item.variant.update_attributes(track_inventory: false)
+              stock_item.variant.update(track_inventory: false)
             end
 
             it "doesn't update the stock item's count_on_hand" do

--- a/api/spec/requests/spree/api/stock_locations_controller_spec.rb
+++ b/api/spec/requests/spree/api/stock_locations_controller_spec.rb
@@ -21,7 +21,7 @@ module Spree
         end
 
         it "cannot see inactive stock locations" do
-          stock_location.update_attributes!(active: false)
+          stock_location.update!(active: false)
           get spree.api_stock_locations_path
           expect(response).to be_successful
           stock_locations = json_response['stock_locations'].map { |sl| sl['name'] }
@@ -37,7 +37,7 @@ module Spree
         end
 
         it "cannot see inactive stock locations" do
-          stock_location.update_attributes!(active: false)
+          stock_location.update!(active: false)
           get spree.api_stock_location_path(stock_location)
           expect(response).to be_not_found
         end
@@ -84,7 +84,7 @@ module Spree
         end
 
         it "can see inactive stock locations" do
-          stock_location.update_attributes!(active: false)
+          stock_location.update!(active: false)
           get spree.api_stock_locations_path
           expect(response).to be_successful
           stock_locations = json_response['stock_locations'].map { |sl| sl['name'] }
@@ -122,7 +122,7 @@ module Spree
         end
 
         it "can see inactive stock locations" do
-          stock_location.update_attributes!(active: false)
+          stock_location.update!(active: false)
           get spree.api_stock_location_path(stock_location)
           expect(response).to be_successful
           expect(json_response['name']).to eq stock_location.name

--- a/backend/app/controllers/spree/admin/payment_methods_controller.rb
+++ b/backend/app/controllers/spree/admin/payment_methods_controller.rb
@@ -34,7 +34,7 @@ module Spree
           end
         end
 
-        if @payment_method.update_attributes(attributes)
+        if @payment_method.update(attributes)
           invoke_callbacks(:update, :after)
           flash[:success] = t('spree.successfully_updated', resource: t('spree.payment_method'))
           redirect_to edit_admin_payment_method_path(@payment_method)

--- a/backend/app/controllers/spree/admin/products_controller.rb
+++ b/backend/app/controllers/spree/admin/products_controller.rb
@@ -26,7 +26,7 @@ module Spree
           end
         end
         invoke_callbacks(:update, :before)
-        if @object.update_attributes(permitted_resource_params)
+        if @object.update(permitted_resource_params)
           invoke_callbacks(:update, :after)
           flash[:success] = flash_message_for(@object, :successfully_updated)
           respond_with(@object) do |format|

--- a/backend/app/controllers/spree/admin/resource_controller.rb
+++ b/backend/app/controllers/spree/admin/resource_controller.rb
@@ -30,7 +30,7 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
 
   def update
     invoke_callbacks(:update, :before)
-    if @object.update_attributes(permitted_resource_params)
+    if @object.update(permitted_resource_params)
       invoke_callbacks(:update, :after)
       respond_with(@object) do |format|
         format.html do

--- a/backend/app/controllers/spree/admin/users_controller.rb
+++ b/backend/app/controllers/spree/admin/users_controller.rb
@@ -38,7 +38,7 @@ module Spree
       end
 
       def update
-        if @user.update_attributes(user_params)
+        if @user.update(user_params)
           set_roles
           set_stock_locations
 
@@ -55,7 +55,7 @@ module Spree
 
       def addresses
         if request.put?
-          if @user.update_attributes(user_params)
+          if @user.update(user_params)
             flash.now[:success] = t('spree.account_updated')
           end
 

--- a/backend/spec/controllers/spree/admin/customer_returns_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/customer_returns_controller_spec.rb
@@ -173,7 +173,7 @@ module Spree
 
         context "a return item has an inactive return authorization reason" do
           before(:each) do
-            accepted_return_item.update_attributes(return_reason_id: inactive_rma_reason.id)
+            accepted_return_item.update(return_reason_id: inactive_rma_reason.id)
           end
 
           it "includes the inactive return authorization reason" do

--- a/backend/spec/controllers/spree/admin/orders/customer_details_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/orders/customer_details_controller_spec.rb
@@ -61,7 +61,7 @@ describe Spree::Admin::Orders::CustomerDetailsController, type: :controller do
       before { allow(Spree::Order).to receive_message_chain(:includes, :find_by!) { order } }
 
       it "updates + progresses the order" do
-        expect(order).to receive(:update_attributes) { true }
+        expect(order).to receive(:update) { true }
         expect(order).to receive(:next) { false }
         attributes = { order_id: order.number, order: { email: "" } }
         put :update, params: attributes
@@ -109,7 +109,7 @@ describe Spree::Admin::Orders::CustomerDetailsController, type: :controller do
 
       context "not false guest checkout param" do
         it "does not attempt to associate the user" do
-          allow(order).to receive_messages(update_attributes: true,
+          allow(order).to receive_messages(update: true,
                                            next: false,
                                            refresh_shipment_rates: true)
 

--- a/backend/spec/controllers/spree/admin/store_credits_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/store_credits_controller_spec.rb
@@ -193,7 +193,7 @@ describe Spree::Admin::StoreCreditsController do
       let(:updated_amount) { 300.0 }
 
       context "the store credit has been partially used" do
-        before { store_credit.update_attributes(amount_used: 10.0) }
+        before { store_credit.update(amount_used: 10.0) }
 
         context "the new amount is greater than the used amount" do
           let(:updated_amount) { 11.0 }

--- a/backend/spec/features/admin/orders/customer_details_spec.rb
+++ b/backend/spec/features/admin/orders/customer_details_spec.rb
@@ -117,7 +117,7 @@ describe "Customer Details", type: :feature, js: true do
     end
 
     it "should show validation errors" do
-      order.update_attributes!(ship_address_id: nil)
+      order.update!(ship_address_id: nil)
       click_link "Customer"
       click_button "Update"
       expect(page).to have_content("Shipping address first name can't be blank")

--- a/core/app/models/concerns/spree/user_address_book.rb
+++ b/core/app/models/concerns/spree/user_address_book.rb
@@ -130,7 +130,7 @@ module Spree
     def remove_from_address_book(address_id)
       user_address = user_addresses.find_by(address_id: address_id)
       if user_address
-        user_address.update_attributes(archived: true, default: false)
+        user_address.update(archived: true, default: false)
       else
         false
       end

--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -57,19 +57,19 @@ module Spree
     money_methods :amount
 
     def finalize!
-      update_attributes!(finalized: true)
+      update!(finalized: true)
     end
 
     def unfinalize!
-      update_attributes!(finalized: false)
+      update!(finalized: false)
     end
 
     def finalize
-      update_attributes(finalized: true)
+      update(finalized: true)
     end
 
     def unfinalize
-      update_attributes(finalized: false)
+      update(finalized: false)
     end
 
     def currency

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -659,7 +659,7 @@ module Spree
       if remaining_total.zero?
         other_payments.each(&:invalidate!)
       elsif other_payments.size == 1
-        other_payments.first.update_attributes!(amount: remaining_total)
+        other_payments.first.update!(amount: remaining_total)
       end
 
       payments.reset

--- a/core/app/models/spree/order_cancellations.rb
+++ b/core/app/models/spree/order_cancellations.rb
@@ -139,7 +139,7 @@ class Spree::OrderCancellations
 
     shipments.each do |shipment|
       if shipment.inventory_units.all? { |iu| iu.shipped? || iu.canceled? }
-        shipment.update_attributes!(state: 'shipped', shipped_at: Time.current)
+        shipment.update!(state: 'shipped', shipped_at: Time.current)
       end
     end
   end

--- a/core/app/models/spree/order_contents.rb
+++ b/core/app/models/spree/order_contents.rb
@@ -35,7 +35,7 @@ module Spree
     end
 
     def update_cart(params)
-      if order.update_attributes(params)
+      if order.update(params)
         unless order.completed?
           order.line_items = order.line_items.select { |li| li.quantity > 0 }
           # Update totals, then check if the order is eligible for any cart promotions.
@@ -61,7 +61,7 @@ module Spree
         raise ArgumentError, 'user or name must be specified'
       end
 
-      order.update_attributes!(
+      order.update!(
         approver: user,
         approver_name: name,
         approved_at: Time.current

--- a/core/app/models/spree/order_shipping.rb
+++ b/core/app/models/spree/order_shipping.rb
@@ -64,7 +64,7 @@ class Spree::OrderShipping
     inventory_units.map(&:shipment).uniq.each do |shipment|
       # Temporarily propagate the tracking number to the shipment as well
       # TODO: Remove tracking numbers from shipments.
-      shipment.update_attributes!(tracking: tracking_number)
+      shipment.update!(tracking: tracking_number)
 
       next unless shipment.inventory_units.reload.all? { |iu| iu.shipped? || iu.canceled? }
       # TODO: make OrderShipping#ship_shipment call Shipment#ship! rather than

--- a/core/app/models/spree/order_taxation.rb
+++ b/core/app/models/spree/order_taxation.rb
@@ -74,7 +74,7 @@ module Spree
         label: tax_item.label,
         included: tax_item.included_in_price
       )
-      tax_adjustment.update_attributes!(amount: tax_item.amount)
+      tax_adjustment.update!(amount: tax_item.amount)
       tax_adjustment
     end
   end

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -273,7 +273,7 @@ module Spree
       # type of payment getting refunded, hence the additional check
       # if the source is a store credit.
       if store_credit? && source.is_a?(Spree::StoreCredit)
-        source.update_attributes!({
+        source.update!({
           action: Spree::StoreCredit::ELIGIBLE_ACTION,
           action_amount: amount,
           action_authorization_code: response_code

--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -59,7 +59,7 @@ module Spree
           )
           money = ::Money.new(amount, currency)
           capture_events.create!(amount: money.to_d)
-          update_attributes!(amount: captured_amount)
+          update!(amount: captured_amount)
           handle_response(response, :complete, :failure)
         end
       end

--- a/core/app/models/spree/payment_method/bogus_credit_card.rb
+++ b/core/app/models/spree/payment_method/bogus_credit_card.rb
@@ -19,7 +19,7 @@ module Spree
       return if payment.source.has_payment_profile?
       # simulate the storage of credit card profile using remote service
       if success = VALID_CCS.include?(payment.source.number)
-        payment.source.update_attributes(gateway_customer_profile_id: generate_profile_id(success))
+        payment.source.update(gateway_customer_profile_id: generate_profile_id(success))
       end
     end
 

--- a/core/app/models/spree/reimbursement_tax_calculator.rb
+++ b/core/app/models/spree/reimbursement_tax_calculator.rb
@@ -25,7 +25,7 @@ module Spree
         additional_tax_total = percent_of_tax * return_item.inventory_unit.additional_tax_total
         included_tax_total   = percent_of_tax * return_item.inventory_unit.included_tax_total
 
-        return_item.update_attributes!({
+        return_item.update!({
           additional_tax_total: additional_tax_total,
           included_tax_total:   included_tax_total
         })

--- a/core/app/models/spree/return_item.rb
+++ b/core/app/models/spree/return_item.rb
@@ -226,7 +226,7 @@ module Spree
     private
 
     def persist_acceptance_status_errors
-      update_attributes(acceptance_status_errors: validator.errors)
+      update(acceptance_status_errors: validator.errors)
     end
 
     def currency

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -326,7 +326,7 @@ module Spree
 
     # Update Shipment and make sure Order states follow the shipment changes
     def update_attributes_and_order(params = {})
-      if update_attributes params
+      if update(params)
         if params.key? :selected_shipping_rate_id
           # Changing the selected Shipping Rate won't update the cost (for now)
           # so we persist the Shipment#cost before running `order.recalculate`

--- a/core/app/models/spree/store_credit.rb
+++ b/core/app/models/spree/store_credit.rb
@@ -63,7 +63,7 @@ class Spree::StoreCredit < Spree::PaymentSource
     end
 
     if validate_authorization(amount, order_currency)
-      update_attributes!({
+      update!({
         action: AUTHORIZE_ACTION,
         action_amount: amount,
         action_originator: options[:action_originator],
@@ -95,7 +95,7 @@ class Spree::StoreCredit < Spree::PaymentSource
         errors.add(:base, I18n.t('spree.store_credit.currency_mismatch'))
         false
       else
-        update_attributes!({
+        update!({
           action: CAPTURE_ACTION,
           action_amount: amount,
           action_originator: options[:action_originator],
@@ -114,7 +114,7 @@ class Spree::StoreCredit < Spree::PaymentSource
 
   def void(authorization_code, options = {})
     if auth_event = store_credit_events.find_by(action: AUTHORIZE_ACTION, authorization_code: authorization_code)
-      update_attributes!({
+      update!({
         action: VOID_ACTION,
         action_amount: auth_event.amount,
         action_authorization_code: authorization_code,
@@ -235,7 +235,7 @@ class Spree::StoreCredit < Spree::PaymentSource
       store_credit_events.where(action: ALLOCATION_ACTION).first_or_initialize
     end
 
-    event.update_attributes!({
+    event.update!({
       amount: action_amount || amount,
       authorization_code: action_authorization_code || event.authorization_code || generate_authorization_code,
       amount_remaining: amount_remaining,

--- a/core/lib/spree/core/importer/order.rb
+++ b/core/lib/spree/core/importer/order.rb
@@ -29,7 +29,7 @@ module Spree
 
             completed_at = params.delete(:completed_at)
 
-            order.update_attributes!(params)
+            order.update!(params)
 
             order.create_proposed_shipments unless shipments_attrs.present?
 
@@ -104,7 +104,7 @@ module Spree
             line_item = order.contents.add(Spree::Variant.find(line_item[:variant_id]), line_item[:quantity])
             # Raise any errors with saving to prevent import succeeding with line items failing silently.
             if extra_params.present?
-              line_item.update_attributes!(extra_params)
+              line_item.update!(extra_params)
             else
               line_item.save!
             end

--- a/core/lib/spree/core/importer/product.rb
+++ b/core/lib/spree/core/importer/product.rb
@@ -28,11 +28,11 @@ module Spree
         end
 
         def update
-          if product.update_attributes(product_attrs)
+          if product.update(product_attrs)
             variants_attrs.each do |variant_attribute|
               # update the variant if the id is present in the payload
               if variant_attribute['id'].present?
-                product.variants.find(variant_attribute['id'].to_i).update_attributes(variant_attribute)
+                product.variants.find(variant_attribute['id'].to_i).update(variant_attribute)
               else
                 # make sure the product is assigned before the options=
                 product.variants.create({ product: product }.merge(variant_attribute))

--- a/core/spec/lib/search/variant_spec.rb
+++ b/core/spec/lib/search/variant_spec.rb
@@ -85,7 +85,7 @@ module Spree
           example.run
           described_class.search_terms = search_terms
         end
-        before { variant.update_attributes!(weight: 5000) }
+        before { variant.update!(weight: 5000) }
 
         it { assert_found("5000", variant) }
       end

--- a/core/spec/models/spree/calculator/refunds/default_refund_amount_spec.rb
+++ b/core/spec/models/spree/calculator/refunds/default_refund_amount_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Spree::Calculator::Returns::DefaultRefundAmount, type: :model do
           source_type: 'Spree::Order'
         )
 
-        order.adjustments.first.update_attributes(amount: adjustment_amount)
+        order.adjustments.first.update(amount: adjustment_amount)
       end
 
       it 'will return the line item amount deducted of refund' do

--- a/core/spec/models/spree/carton_spec.rb
+++ b/core/spec/models/spree/carton_spec.rb
@@ -73,8 +73,8 @@ RSpec.describe Spree::Carton do
     let(:email) { 'something@something.com' }
 
     before do
-      first_order.update_attributes!(email: email)
-      second_order.update_attributes!(email: email)
+      first_order.update!(email: email)
+      second_order.update!(email: email)
     end
 
     it "returns a unique list of the order emails it is associated to" do

--- a/core/spec/models/spree/concerns/user_methods_spec.rb
+++ b/core/spec/models/spree/concerns/user_methods_spec.rb
@@ -76,19 +76,19 @@ RSpec.describe Spree::UserMethods do
       it { is_expected.to eq(100 + 200) }
 
       context 'when some has been used' do
-        before { credit_1.update_attributes!(amount_used: 35) }
+        before { credit_1.update!(amount_used: 35) }
 
         it { is_expected.to eq(100 + 200 - 35) }
 
         context 'when some has been authorized' do
-          before { credit_1.update_attributes!(amount_authorized: 10) }
+          before { credit_1.update!(amount_authorized: 10) }
 
           it { is_expected.to eq(100 + 200 - 35 - 10) }
         end
       end
 
       context 'when some has been authorized' do
-        before { credit_1.update_attributes!(amount_authorized: 10) }
+        before { credit_1.update!(amount_authorized: 10) }
 
         it { is_expected.to eq(100 + 200 - 10) }
       end

--- a/core/spec/models/spree/credit_card_spec.rb
+++ b/core/spec/models/spree/credit_card_spec.rb
@@ -109,10 +109,10 @@ RSpec.describe Spree::CreditCard, type: :model do
     end
 
     it "should save and update addresses through nested attributes" do
-      persisted_card.update_attributes({ address_attributes: valid_address_attributes })
+      persisted_card.update({ address_attributes: valid_address_attributes })
       persisted_card.save!
       updated_attributes = { id: persisted_card.address.id, address1: "123 Main St." }
-      persisted_card.update_attributes({ address_attributes: updated_attributes })
+      persisted_card.update({ address_attributes: updated_attributes })
       expect(persisted_card.address.address1).to eq "123 Main St."
     end
   end

--- a/core/spec/models/spree/customer_return_spec.rb
+++ b/core/spec/models/spree/customer_return_spec.rb
@@ -233,7 +233,7 @@ RSpec.describe Spree::CustomerReturn, type: :model do
 
     context "it was not received" do
       before do
-        return_item.update_attributes!(reception_status: "lost_in_transit")
+        return_item.update!(reception_status: "lost_in_transit")
       end
 
       it 'should not updated inventory unit to returned' do

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -456,7 +456,7 @@ RSpec.describe Spree::Order, type: :model do
         order.line_items << FactoryBot.create(:line_item)
         order.line_items.first.variant.stock_items.each do |si|
           si.set_count_on_hand(0)
-          si.update_attributes(backorderable: false)
+          si.update(backorderable: false)
         end
 
         Spree::OrderUpdater.new(order).update

--- a/core/spec/models/spree/order/outstanding_balance_integration_spec.rb
+++ b/core/spec/models/spree/order/outstanding_balance_integration_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Outstanding balance integration tests" do
   let!(:order) { create(:order_with_line_items, line_items_count: 2, line_items_price: 3, shipment_cost: 13) }
   let(:item_1) { order.line_items[0] }
   let(:item_2) { order.line_items[1] }
-  before { order.update_attributes!(state: 'complete', completed_at: Time.now) }
+  before { order.update!(state: 'complete', completed_at: Time.now) }
 
   subject do
     order.reload
@@ -44,11 +44,11 @@ RSpec.describe "Outstanding balance integration tests" do
     end
 
     context 'when the order is cancelled' do
-      before { order.update_attributes!(state: "canceled") }
+      before { order.update!(state: "canceled") }
       it { should eq(-19) }
 
       context 'and the payment is voided' do
-        before { payment.update_attributes!(state: "void") }
+        before { payment.update!(state: "void") }
         it { should eq 0 }
       end
 
@@ -116,11 +116,11 @@ RSpec.describe "Outstanding balance integration tests" do
     end
 
     context 'when the order is cancelled' do
-      before { order.update_attributes!(state: "canceled") }
+      before { order.update!(state: "canceled") }
       it { should eq(-10) }
 
       context 'and the payment is voided' do
-        before { payment.update_attributes!(state: "void") }
+        before { payment.update!(state: "void") }
         it { should eq 0 }
       end
 

--- a/core/spec/models/spree/order/payment_spec.rb
+++ b/core/spec/models/spree/order/payment_spec.rb
@@ -213,7 +213,7 @@ module Spree
         end
 
         context "for canceled orders" do
-          before { order.update_attributes(state: 'canceled') }
+          before { order.update(state: 'canceled') }
 
           it "it should be zero" do
             expect(order.total).to eq(110)

--- a/core/spec/models/spree/order_contents_spec.rb
+++ b/core/spec/models/spree/order_contents_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe Spree::OrderContents, type: :model do
 
       context 'when the order does not have a taxable address' do
         before do
-          order.update_attributes!(ship_address: nil, bill_address: nil)
+          order.update!(ship_address: nil, bill_address: nil)
           expect(order.tax_address.country_id).to be_nil
         end
 

--- a/core/spec/models/spree/order_inventory_spec.rb
+++ b/core/spec/models/spree/order_inventory_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Spree::OrderInventory, type: :model do
     let(:new_quantity) { 3 }
 
     before do
-      line_item.update_attributes!(quantity: old_quantity)
+      line_item.update!(quantity: old_quantity)
 
       line_item.update_column(:quantity, new_quantity)
       subject.line_item.reload
@@ -86,7 +86,7 @@ RSpec.describe Spree::OrderInventory, type: :model do
     end
 
     context "variant doesnt track inventory" do
-      before { variant.update_attributes!(track_inventory: false) }
+      before { variant.update!(track_inventory: false) }
       let(:new_quantity) { 1 }
 
       it "creates on hand inventory units" do
@@ -164,7 +164,7 @@ RSpec.describe Spree::OrderInventory, type: :model do
     let(:new_quantity) { 2 }
 
     before do
-      line_item.update_attributes!(quantity: old_quantity)
+      line_item.update!(quantity: old_quantity)
 
       line_item.update_column(:quantity, new_quantity)
       subject.line_item.reload

--- a/core/spec/models/spree/order_shipping_spec.rb
+++ b/core/spec/models/spree/order_shipping_spec.rb
@@ -181,7 +181,7 @@ RSpec.describe Spree::OrderShipping do
     # OrderShipping#ship rather than vice versa
     context "when the tracking number is already on the shipment" do
       before do
-        shipment.update_attributes!(tracking: 'tracking-number')
+        shipment.update!(tracking: 'tracking-number')
       end
 
       it "sets the tracking-number" do

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -678,7 +678,7 @@ RSpec.describe Spree::Order, type: :model do
       let!(:payment_method_without_store) { create(:payment_method) }
 
       context 'when the store has payment methods' do
-        before { order.update_attributes!(store: store_with_payment_methods) }
+        before { order.update!(store: store_with_payment_methods) }
 
         it 'returns only the matching payment methods for that store' do
           expect(order.available_payment_methods).to match_array(
@@ -706,7 +706,7 @@ RSpec.describe Spree::Order, type: :model do
       end
 
       context 'when the store does not have payment methods' do
-        before { order.update_attributes!(store: store_without_payment_methods) }
+        before { order.update!(store: store_without_payment_methods) }
 
         it 'returns all matching payment methods regardless of store' do
           expect(order.available_payment_methods).to match_array(
@@ -1443,12 +1443,12 @@ RSpec.describe Spree::Order, type: :model do
 
     describe "#total_applicable_store_credit" do
       context "order is in the confirm state" do
-        before { order.update_attributes(state: 'confirm') }
+        before { order.update(state: 'confirm') }
         include_examples "check total store credit from payments"
       end
 
       context "order is completed" do
-        before { order.update_attributes(state: 'complete') }
+        before { order.update(state: 'complete') }
         include_examples "check total store credit from payments"
       end
 
@@ -1462,7 +1462,7 @@ RSpec.describe Spree::Order, type: :model do
           context "the store credit is more than the order total" do
             let(:order_total) { store_credit.amount - 1 }
 
-            before { order.update_attributes(total: order_total) }
+            before { order.update(total: order_total) }
 
             it "returns the order total" do
               expect(subject.total_applicable_store_credit).to eq order_total
@@ -1472,7 +1472,7 @@ RSpec.describe Spree::Order, type: :model do
           context "the store credit is less than the order total" do
             let(:order_total) { store_credit.amount * 10 }
 
-            before { order.update_attributes(total: order_total) }
+            before { order.update(total: order_total) }
 
             it "returns the store credit amount" do
               expect(subject.total_applicable_store_credit).to eq store_credit.amount

--- a/core/spec/models/spree/payment_create_spec.rb
+++ b/core/spec/models/spree/payment_create_spec.rb
@@ -122,7 +122,7 @@ module Spree
       end
 
       context 'the order has no user' do
-        before { order.update_attributes!(user_id: nil) }
+        before { order.update!(user_id: nil) }
         it 'errors' do
           expect { new_payment }.to raise_error(ActiveRecord::RecordNotFound)
         end
@@ -130,7 +130,7 @@ module Spree
 
       context 'the order and the credit card have no user' do
         before do
-          order.update_attributes!(user_id: nil)
+          order.update!(user_id: nil)
           credit_card.update!(user_id: nil)
         end
         it 'errors' do

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe Spree::Payment, type: :model do
     describe "#process!" do
       context 'with autocapture' do
         before do
-          payment.payment_method.update_attributes!(auto_capture: true)
+          payment.payment_method.update!(auto_capture: true)
         end
 
         it "should purchase" do
@@ -145,11 +145,11 @@ RSpec.describe Spree::Payment, type: :model do
 
       context 'without autocapture' do
         before do
-          payment.payment_method.update_attributes!(auto_capture: false)
+          payment.payment_method.update!(auto_capture: false)
         end
 
         context 'when in the checkout state' do
-          before { payment.update_attributes!(state: 'checkout') }
+          before { payment.update!(state: 'checkout') }
 
           it "authorizes" do
             payment.process!
@@ -158,7 +158,7 @@ RSpec.describe Spree::Payment, type: :model do
         end
 
         context 'when in the processing state' do
-          before { payment.update_attributes!(state: 'processing') }
+          before { payment.update!(state: 'processing') }
 
           it "does not authorize" do
             payment.process!
@@ -167,7 +167,7 @@ RSpec.describe Spree::Payment, type: :model do
         end
 
         context 'when in the pending state' do
-          before { payment.update_attributes!(state: 'pending') }
+          before { payment.update!(state: 'pending') }
 
           it "does not re-authorize" do
             expect(payment).to_not receive(:authorize!)
@@ -177,7 +177,7 @@ RSpec.describe Spree::Payment, type: :model do
         end
 
         context 'when in a failed state' do
-          before { payment.update_attributes!(state: 'failed') }
+          before { payment.update!(state: 'failed') }
 
           it "raises an exception" do
             expect {
@@ -187,7 +187,7 @@ RSpec.describe Spree::Payment, type: :model do
         end
 
         context 'when in the completed state' do
-          before { payment.update_attributes!(state: 'completed') }
+          before { payment.update!(state: 'completed') }
 
           it "authorizes" do
             payment.process!
@@ -253,7 +253,7 @@ RSpec.describe Spree::Payment, type: :model do
 
         context 'when the source is a credit card without an address' do
           let(:card) { create(:credit_card, address: nil) }
-          before { order.update_attributes!(bill_address: address) }
+          before { order.update!(bill_address: address) }
           let(:address) { create(:address) }
 
           it 'send the order bill address' do
@@ -278,7 +278,7 @@ RSpec.describe Spree::Payment, type: :model do
 
           let(:store_credit_payment) { create(:store_credit_payment) }
           let(:store_credit_payment_method) { create(:store_credit_payment_method) }
-          before { order.update_attributes!(bill_address: address) }
+          before { order.update!(bill_address: address) }
           let(:address) { create(:address) }
 
           it 'send the order bill address' do
@@ -932,7 +932,7 @@ RSpec.describe Spree::Payment, type: :model do
         end
 
         context 'the order has no user' do
-          before { order.update_attributes!(user_id: nil) }
+          before { order.update!(user_id: nil) }
           it 'errors' do
             expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
           end
@@ -940,7 +940,7 @@ RSpec.describe Spree::Payment, type: :model do
 
         context 'the order and the credit card have no user' do
           before do
-            order.update_attributes!(user_id: nil)
+            order.update!(user_id: nil)
             credit_card.update!(user_id: nil)
           end
           it 'errors' do
@@ -976,7 +976,7 @@ RSpec.describe Spree::Payment, type: :model do
       # Sets the payment's order to a different Ruby object entirely
       payment.order = Spree::Order.find(payment.order_id)
       email = 'foo@example.com'
-      order.update_attributes(email: email)
+      order.update(email: email)
       expect(payment.gateway_options[:email]).to eq(email)
     end
   end

--- a/core/spec/models/spree/promotion/rules/first_repeat_purchase_since_spec.rb
+++ b/core/spec/models/spree/promotion/rules/first_repeat_purchase_since_spec.rb
@@ -42,10 +42,10 @@ RSpec.describe Spree::Promotion::Rules::FirstRepeatPurchaseSince do
         let(:order_completion_date_2) { 1.day.ago }
         before do
           old_order_1 = create :completed_order_with_totals, user: user
-          old_order_1.update_attributes(completed_at: order_completion_date_1)
+          old_order_1.update(completed_at: order_completion_date_1)
 
           old_order_2 = create :completed_order_with_totals, user: user
-          old_order_2.update_attributes(completed_at: order_completion_date_2)
+          old_order_2.update(completed_at: order_completion_date_2)
         end
 
         context "the last completed order was greater than the preferred days ago" do

--- a/core/spec/models/spree/promotion/rules/nth_order_spec.rb
+++ b/core/spec/models/spree/promotion/rules/nth_order_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Spree::Promotion::Rules::NthOrder do
       context "when the user has completed orders" do
         before do
           old_order = create :completed_order_with_totals, user: user
-          old_order.update_attributes(completed_at: 1.day.ago)
+          old_order.update(completed_at: 1.day.ago)
         end
 
         context "when this order will be the 'nth' order" do
@@ -49,7 +49,7 @@ RSpec.describe Spree::Promotion::Rules::NthOrder do
 
         context "when this order is completed and is still the 'nth' order" do
           before do
-            order.update_attributes(completed_at: Time.current)
+            order.update(completed_at: Time.current)
           end
 
           it { is_expected.to be true }

--- a/core/spec/models/spree/reimbursement_type/original_payment_spec.rb
+++ b/core/spec/models/spree/reimbursement_type/original_payment_spec.rb
@@ -63,8 +63,8 @@ module Spree
         let(:refund_payment_methods) { subject.map { |refund| refund.payment.payment_method } }
 
         before do
-          reimbursement.order.payments.first.update_attributes!(amount: 5.0)
-          return_item.update_attributes!(amount: refund_amount)
+          reimbursement.order.payments.first.update!(amount: 5.0)
+          return_item.update!(amount: refund_amount)
         end
 
         it "includes refunds all payment type" do

--- a/core/spec/models/spree/return_item_spec.rb
+++ b/core/spec/models/spree/return_item_spec.rb
@@ -26,8 +26,8 @@ RSpec.describe Spree::ReturnItem, type: :model do
     let(:return_item) { create(:return_item, inventory_unit: inventory_unit) }
 
     before do
-      inventory_unit.update_attributes!(state: 'shipped')
-      return_item.update_attributes!(reception_status: 'awaiting')
+      inventory_unit.update!(state: 'shipped')
+      return_item.update!(reception_status: 'awaiting')
       allow(return_item).to receive(:eligible_for_return?).and_return(true)
     end
 
@@ -91,9 +91,9 @@ RSpec.describe Spree::ReturnItem, type: :model do
       let(:stock_item) { stock_location.stock_item(inventory_unit.variant) }
 
       before do
-        inventory_unit.update_attributes!(state: 'shipped')
-        return_item.update_attributes!(reception_status: 'awaiting')
-        stock_location.update_attributes!(restock_inventory: true)
+        inventory_unit.update!(state: 'shipped')
+        return_item.update!(reception_status: 'awaiting')
+        stock_location.update!(restock_inventory: true)
       end
 
       it 'increases the count on hand' do
@@ -102,9 +102,9 @@ RSpec.describe Spree::ReturnItem, type: :model do
 
       context 'when variant does not track inventory' do
         before do
-          inventory_unit.update_attributes!(state: 'shipped')
-          inventory_unit.variant.update_attributes!(track_inventory: false)
-          return_item.update_attributes!(reception_status: 'awaiting')
+          inventory_unit.update!(state: 'shipped')
+          inventory_unit.variant.update!(track_inventory: false)
+          return_item.update!(reception_status: 'awaiting')
         end
 
         it 'does not increase the count on hand' do
@@ -114,7 +114,7 @@ RSpec.describe Spree::ReturnItem, type: :model do
 
       context "when the stock location's restock_inventory is false" do
         before do
-          stock_location.update_attributes!(restock_inventory: false)
+          stock_location.update!(restock_inventory: false)
         end
 
         it 'does not increase the count on hand' do
@@ -135,7 +135,7 @@ RSpec.describe Spree::ReturnItem, type: :model do
 
       Spree::ReturnItem::INTERMEDIATE_RECEPTION_STATUSES.each do |status|
         context "when the item was #{status}" do
-          before { return_item.update_attributes!(reception_status: status) }
+          before { return_item.update!(reception_status: status) }
 
           it 'processes the inventory unit' do
             subject
@@ -293,7 +293,7 @@ RSpec.describe Spree::ReturnItem, type: :model do
       subject { return_item.public_send("#{transition}!") }
       context "awaiting status" do
         before do
-          return_item.update_attributes!(reception_status: 'awaiting')
+          return_item.update!(reception_status: 'awaiting')
           allow(return_item).to receive(:eligible_for_return?).and_return(true)
         end
 

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -152,7 +152,7 @@ RSpec.describe Spree::Shipment, type: :model do
 
   describe '#total_before_tax' do
     before do
-      shipment.update_attributes!(cost: 10)
+      shipment.update!(cost: 10)
     end
     let!(:admin_adjustment) { create(:adjustment, adjustable: shipment, order: shipment.order, amount: -1, source: nil) }
     let!(:promo_adjustment) { create(:adjustment, adjustable: shipment, order: shipment.order, amount: -2, source: promo_action) }
@@ -250,7 +250,7 @@ RSpec.describe Spree::Shipment, type: :model do
       end
 
       it "can't get rates without a shipping address" do
-        shipment.order.update_attributes!(ship_address: nil)
+        shipment.order.update!(ship_address: nil)
         expect(shipment.refresh_rates).to eq([])
       end
 
@@ -298,7 +298,7 @@ RSpec.describe Spree::Shipment, type: :model do
     shared_examples_for "pending if backordered" do
       it "should have a state of pending if backordered" do
         # Set as ready so we can test for change
-        shipment.update_attributes!(state: 'ready')
+        shipment.update!(state: 'ready')
 
         allow(shipment).to receive_messages(inventory_units: [mock_model(Spree::InventoryUnit, allow_ship?: false, canceled?: false, shipped?: false)])
         expect(shipment).to receive(:update_columns).with(state: 'pending', updated_at: kind_of(Time))
@@ -310,7 +310,7 @@ RSpec.describe Spree::Shipment, type: :model do
       before { allow(order).to receive_messages can_ship?: false }
       it "should result in a 'pending' state" do
         # Set as ready so we can test for change
-        shipment.update_attributes!(state: 'ready')
+        shipment.update!(state: 'ready')
         expect(shipment).to receive(:update_columns).with(state: 'pending', updated_at: kind_of(Time))
         shipment.update_state
       end
@@ -768,8 +768,8 @@ RSpec.describe Spree::Shipment, type: :model do
         .to receive(:new).and_return(inventory_unit_finalizer)
 
       stock_item.set_count_on_hand(10)
-      stock_item.update_attributes!(backorderable: false)
-      inventory_unit.update_attributes!(pending: true)
+      stock_item.update!(backorderable: false)
+      inventory_unit.update!(pending: true)
     end
 
     subject { shipment.finalize! }

--- a/core/spec/models/spree/stock/inventory_units_finalizer_spec.rb
+++ b/core/spec/models/spree/stock/inventory_units_finalizer_spec.rb
@@ -12,8 +12,8 @@ module Spree
 
         before do
           stock_item.set_count_on_hand(10)
-          stock_item.update_attributes!(backorderable: false)
-          inventory_unit.update_attributes!(pending: true)
+          stock_item.update!(backorderable: false)
+          inventory_unit.update!(pending: true)
         end
 
         subject { described_class.new([inventory_unit]).run! }
@@ -42,8 +42,8 @@ module Spree
         before do
           stock_item.set_count_on_hand(10)
           stock_item_2.set_count_on_hand(10)
-          inventory_unit.update_attributes!(pending: true)
-          inventory_unit_2.update_attributes!(pending: true)
+          inventory_unit.update!(pending: true)
+          inventory_unit_2.update!(pending: true)
         end
 
         subject { described_class.new([inventory_unit, inventory_unit_2]).run! }

--- a/core/spec/models/spree/stock/quantifier_spec.rb
+++ b/core/spec/models/spree/stock/quantifier_spec.rb
@@ -49,7 +49,7 @@ module Spree
         end
 
         context 'when stock item prevents backordering' do
-          before { stock_item.update_attributes(backorderable: false) }
+          before { stock_item.update(backorderable: false) }
 
           specify { expect(subject.backorderable?).to be false }
 
@@ -81,7 +81,7 @@ module Spree
         end
 
         context 'when all stock items prevent backordering' do
-          before { stock_item.update_attributes(backorderable: false) }
+          before { stock_item.update(backorderable: false) }
 
           specify { expect(subject.backorderable?).to be false }
 

--- a/core/spec/models/spree/store_credit_spec.rb
+++ b/core/spec/models/spree/store_credit_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe Spree::StoreCredit do
       let!(:store_credit) { create(:store_credit) }
       let!(:test_category) { create(:store_credit_category, name: "Testing") }
 
-      subject { store_credit.update_attributes(category: test_category) }
+      subject { store_credit.update(category: test_category) }
 
       it "returns false" do
         expect(subject).to eq false
@@ -170,7 +170,7 @@ RSpec.describe Spree::StoreCredit do
       context "the authorized amount is defined" do
         let(:authorized_amount) { 15.00 }
 
-        before { store_credit.update_attributes(amount_authorized: authorized_amount) }
+        before { store_credit.update(amount_authorized: authorized_amount) }
 
         it "subtracts the authorized amount from the credited amount" do
           expect(store_credit.amount_remaining).to eq(store_credit.amount - authorized_amount)
@@ -181,7 +181,7 @@ RSpec.describe Spree::StoreCredit do
     context "the amount_used is defined" do
       let(:amount_used) { 10.0 }
 
-      before { store_credit.update_attributes(amount_used: amount_used) }
+      before { store_credit.update(amount_used: amount_used) }
 
       context "the authorized amount is not defined" do
         it "subtracts the amount used from the credited amount" do
@@ -192,7 +192,7 @@ RSpec.describe Spree::StoreCredit do
       context "the authorized amount is defined" do
         let(:authorized_amount) { 15.00 }
 
-        before { store_credit.update_attributes(amount_authorized: authorized_amount) }
+        before { store_credit.update(amount_authorized: authorized_amount) }
 
         it "subtracts the amount used and the authorized amount from the credited amount" do
           expect(store_credit.amount_remaining).to eq(store_credit.amount - amount_used - authorized_amount)
@@ -208,7 +208,7 @@ RSpec.describe Spree::StoreCredit do
       let(:originator) { nil }
 
       context "amount has not been authorized yet" do
-        before { store_credit.update_attributes(amount_authorized: authorization_amount) }
+        before { store_credit.update(amount_authorized: authorization_amount) }
 
         it "returns true" do
           expect(store_credit.authorize(store_credit.amount - authorization_amount, store_credit.currency)).to be_truthy
@@ -234,7 +234,7 @@ RSpec.describe Spree::StoreCredit do
       context "authorization has already happened" do
         let!(:auth_event) { create(:store_credit_auth_event, store_credit: store_credit) }
 
-        before { store_credit.update_attributes(amount_authorized: store_credit.amount) }
+        before { store_credit.update(amount_authorized: store_credit.amount) }
 
         it "returns true" do
           expect(store_credit.authorize(store_credit.amount, store_credit.currency, action_authorization_code: auth_event.authorization_code)).to be true
@@ -816,7 +816,7 @@ RSpec.describe Spree::StoreCredit do
     context "amount is valid" do
       let(:amount) { 10.0 }
 
-      before { store_credit.update_attributes!(amount: 30.0) }
+      before { store_credit.update!(amount: 30.0) }
 
       it "returns true" do
         expect(subject).to eq true

--- a/core/spec/models/spree/tax_category_spec.rb
+++ b/core/spec/models/spree/tax_category_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Spree::TaxCategory, type: :model do
     end
 
     it "should undefault the previous default tax category" do
-      new_tax_category.update_attributes({ is_default: true })
+      new_tax_category.update({ is_default: true })
       expect(new_tax_category.is_default).to be true
 
       tax_category.reload

--- a/core/spec/models/spree/taxon_spec.rb
+++ b/core/spec/models/spree/taxon_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Spree::Taxon, type: :model do
     context "updating a taxon permalink" do
       it 'parameterizes permalink correctly' do
         taxon.save!
-        taxon.update_attributes(permalink: 'spécial&charactèrs')
+        taxon.update(permalink: 'spécial&charactèrs')
         expect(taxon.permalink).to eql "special-characters"
       end
     end
@@ -51,7 +51,7 @@ RSpec.describe Spree::Taxon, type: :model do
 
       it 'parameterizes permalink correctly' do
         taxon.save!
-        taxon.update_attributes(permalink_part: 'spécial&charactèrs')
+        taxon.update(permalink_part: 'spécial&charactèrs')
         expect(taxon.reload.permalink).to eql "brands/special-characters"
       end
 

--- a/core/spec/models/spree/user_spec.rb
+++ b/core/spec/models/spree/user_spec.rb
@@ -200,12 +200,12 @@ RSpec.describe Spree.user_class, type: :model do
       context "part of the store credit has been used" do
         let(:amount_used) { 35.00 }
 
-        before { store_credit.update_attributes(amount_used: amount_used) }
+        before { store_credit.update(amount_used: amount_used) }
 
         context "part of the store credit has been authorized" do
           let(:authorized_amount) { 10 }
 
-          before { additional_store_credit.update_attributes(amount_authorized: authorized_amount) }
+          before { additional_store_credit.update(amount_authorized: authorized_amount) }
 
           it "returns sum of amounts minus used amount and authorized amount" do
             expect(subject.total_available_store_credit.to_f).to eq(amount + additional_amount - amount_used - authorized_amount)
@@ -223,7 +223,7 @@ RSpec.describe Spree.user_class, type: :model do
         context "part of the store credit has been authorized" do
           let(:authorized_amount) { 10 }
 
-          before { additional_store_credit.update_attributes(amount_authorized: authorized_amount) }
+          before { additional_store_credit.update(amount_authorized: authorized_amount) }
 
           it "returns sum of amounts minus authorized amount" do
             expect(subject.total_available_store_credit.to_f).to eq(amount + additional_amount - authorized_amount)

--- a/frontend/spec/controllers/spree/checkout_controller_spec.rb
+++ b/frontend/spec/controllers/spree/checkout_controller_spec.rb
@@ -91,7 +91,7 @@ describe Spree::CheckoutController, type: :controller do
 
       context "with the order in the cart state", partial_double_verification: false do
         before do
-          order.update_attributes! user: user
+          order.update! user: user
           order.update_column(:state, "cart")
         end
 
@@ -140,7 +140,7 @@ describe Spree::CheckoutController, type: :controller do
 
       context "with the order in the address state", partial_double_verification: false do
         before do
-          order.update_attributes! user: user
+          order.update! user: user
           order.update_columns(ship_address_id: create(:address).id, state: "address")
         end
 
@@ -213,7 +213,7 @@ describe Spree::CheckoutController, type: :controller do
         end
 
         before do
-          order.update_attributes! user: user
+          order.update! user: user
           3.times { order.next! } # should put us in the payment state
         end
 
@@ -245,7 +245,7 @@ describe Spree::CheckoutController, type: :controller do
         end
 
         before do
-          order.update_attributes! user: user
+          order.update! user: user
           3.times { order.next! } # should put us in the payment state
         end
 
@@ -275,7 +275,7 @@ describe Spree::CheckoutController, type: :controller do
 
       context "when in the confirm state" do
         before do
-          order.update_attributes! user: user
+          order.update! user: user
           order.update_column(:state, "confirm")
           # An order requires a payment to reach the complete state
           # This is because payment_required? is true on the order
@@ -305,7 +305,7 @@ describe Spree::CheckoutController, type: :controller do
 
     context "save unsuccessful" do
       before do
-        order.update_attributes! user: user
+        order.update! user: user
         allow(order).to receive_messages valid?: false
       end
 
@@ -340,7 +340,7 @@ describe Spree::CheckoutController, type: :controller do
 
     context "Spree::Core::GatewayError" do
       before do
-        order.update_attributes! user: user
+        order.update! user: user
         allow(order).to receive(:next).and_raise(Spree::Core::GatewayError.new("Invalid something or other."))
         post :update, params: { state: "address" }
       end

--- a/frontend/spec/controllers/spree/orders_controller_ability_spec.rb
+++ b/frontend/spec/controllers/spree/orders_controller_ability_spec.rb
@@ -37,7 +37,7 @@ module Spree
 
       context '#update' do
         it 'should check if user is authorized for :update' do
-          allow(order).to receive :update_attributes
+          allow(order).to receive :update
           expect(controller).to receive(:authorize!).with(:update, order, token)
           post :update, params: { order: { email: "foo@bar.com" }, token: token }
         end

--- a/frontend/spec/controllers/spree/orders_controller_spec.rb
+++ b/frontend/spec/controllers/spree/orders_controller_spec.rb
@@ -117,13 +117,13 @@ describe Spree::OrdersController, type: :controller do
         end
 
         it "should redirect to cart path (on success)" do
-          allow(order).to receive(:update_attributes).and_return true
+          allow(order).to receive(:update).and_return true
           put :update
           expect(response).to redirect_to(spree.cart_path)
         end
 
         it "should advance the order if :checkout button is pressed" do
-          allow(order).to receive(:update_attributes).and_return true
+          allow(order).to receive(:update).and_return true
           expect(order).to receive(:next)
           put :update, params: { checkout: true }
           expect(response).to redirect_to checkout_state_path('address')

--- a/frontend/spec/features/products_spec.rb
+++ b/frontend/spec/features/products_spec.rb
@@ -51,20 +51,20 @@ describe "Visiting Products", type: :feature, inaccessible: true do
     end
 
     it 'displays metas' do
-      jersey.update_attributes metas
+      jersey.update metas
       click_link jersey.name
       expect(page).to have_meta(:description, 'Brand new Ruby on Rails Jersey')
       expect(page).to have_meta(:keywords, 'ror, jersey, ruby')
     end
 
     it 'displays title if set' do
-      jersey.update_attributes metas
+      jersey.update metas
       click_link jersey.name
       expect(page).to have_title('Ruby on Rails Baseball Jersey Buy High Quality Geek Apparel')
     end
 
     it "doesn't use meta_title as heading on page" do
-      jersey.update_attributes metas
+      jersey.update metas
       click_link jersey.name
       within("h1") do
         expect(page).to have_content(jersey.name)
@@ -73,7 +73,7 @@ describe "Visiting Products", type: :feature, inaccessible: true do
     end
 
     it 'uses product name in title when meta_title set to empty string' do
-      jersey.update_attributes meta_title: ''
+      jersey.update meta_title: ''
       click_link jersey.name
       expect(page).to have_title('Ruby on Rails Baseball Jersey - ' + store_name)
     end

--- a/frontend/spec/features/taxons_spec.rb
+++ b/frontend/spec/features/taxons_spec.rb
@@ -30,14 +30,14 @@ describe "viewing products", type: :feature, inaccessible: true do
 
   describe 'meta tags and title' do
     it 'displays metas' do
-      t_shirts.update_attributes metas
+      t_shirts.update metas
       visit '/t/category/super-clothing/t-shirts'
       expect(page).to have_meta(:description, 'Brand new Ruby on Rails TShirts')
       expect(page).to have_meta(:keywords, 'ror, tshirt, ruby')
     end
 
     it 'display title if set' do
-      t_shirts.update_attributes metas
+      t_shirts.update metas
       visit '/t/category/super-clothing/t-shirts'
       expect(page).to have_title("Ruby On Rails TShirt")
     end
@@ -49,7 +49,7 @@ describe "viewing products", type: :feature, inaccessible: true do
 
     # Regression test for https://github.com/spree/spree/issues/2814
     it "doesn't use meta_title as heading on page" do
-      t_shirts.update_attributes metas
+      t_shirts.update metas
       visit '/t/category/super-clothing/t-shirts'
       within("h1.taxon-title") do
         expect(page).to have_content(t_shirts.name)
@@ -57,7 +57,7 @@ describe "viewing products", type: :feature, inaccessible: true do
     end
 
     it 'uses taxon name in title when meta_title set to empty string' do
-      t_shirts.update_attributes meta_title: ''
+      t_shirts.update meta_title: ''
       visit '/t/category/super-clothing/t-shirts'
       expect(page).to have_title('Category - T-Shirts - ' + store_name)
     end

--- a/sample/db/samples/orders.rb
+++ b/sample/db/samples/orders.rb
@@ -41,7 +41,7 @@ orders[1].line_items.create!(
 
 orders.each do |order|
   order.payments.create!(payment_method: payment_method)
-  order.update_attributes(store: store)
+  order.update(store: store)
 
   order.next! while !order.can_complete?
   order.complete!

--- a/sample/db/samples/variants.rb
+++ b/sample/db/samples/variants.rb
@@ -216,5 +216,5 @@ masters = {
 Spree::Variant.create!(variants)
 
 masters.each do |product, variant_attrs|
-  product.master.update_attributes!(variant_attrs)
+  product.master.update!(variant_attrs)
 end


### PR DESCRIPTION
**Description**

`update_attributes` was deprecated in Rails 6 and will be removed in Rails 6.1. This PR replaces all instances of `update_attributes` with `update`.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
