### PR TITLE
Use relative path to specify layouts path

### DIFF
--- a/backend/app/controllers/spree/admin/base_controller.rb
+++ b/backend/app/controllers/spree/admin/base_controller.rb
@@ -4,7 +4,7 @@ module Spree
   module Admin
     class BaseController < Spree::BaseController
       helper 'spree/admin/navigation'
-      layout '/spree/layouts/admin'
+      layout 'spree/layouts/admin'
 
       before_action :authorize_admin
 

--- a/backend/app/controllers/spree/admin/style_guide_controller.rb
+++ b/backend/app/controllers/spree/admin/style_guide_controller.rb
@@ -4,7 +4,7 @@ module Spree
   module Admin
     class StyleGuideController < Spree::Admin::BaseController
       respond_to :html
-      layout '/spree/layouts/admin_style_guide'
+      layout 'spree/layouts/admin_style_guide'
 
       def index
         @topics = {


### PR DESCRIPTION
**Description**

We are currently setting layouts to render using an absolute path. I don't think using the absolute path has any benefit and it is now deprecated in Rails 6 with rails/rails#35793.

This PR fixes the deprecation:

```
DEPRECATION WARNING: Rendering layouts from an absolute path is deprecated. ...
```

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- ~[ ] I have updated Guides and README accordingly to this change (if needed)~
- ~[ ] I have added tests to cover this change (if needed)~
