### PR TITLE
Fix responders gem dependency

### DIFF
--- a/backend/lib/spree/backend.rb
+++ b/backend/lib/spree/backend.rb
@@ -9,6 +9,7 @@ require 'font-awesome-rails'
 require 'autoprefixer-rails'
 require 'jbuilder'
 require 'kaminari'
+require 'responders'
 
 require 'spree_core'
 require 'spree_api'

--- a/backend/solidus_backend.gemspec
+++ b/backend/solidus_backend.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'jbuilder', '~> 2.8'
   s.add_dependency 'jquery-rails'
   s.add_dependency 'kaminari', '~> 1.1'
+  s.add_dependency 'responders'
   s.add_dependency 'sassc-rails'
 
   s.add_dependency 'autoprefixer-rails'

--- a/frontend/solidus_frontend.gemspec
+++ b/frontend/solidus_frontend.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'font-awesome-rails', '~> 4.0'
   s.add_dependency 'jquery-rails'
   s.add_dependency 'kaminari', '~> 1.1'
+  s.add_dependency 'responders'
   s.add_dependency 'sassc-rails'
   s.add_dependency 'truncate_html', '~> 0.9', '>= 0.9.2'
 


### PR DESCRIPTION
**Description**

We removed `responders` gem dependency from core with #2090 but we are using `respond_with` in both `solidus_frontend` and `solidus_backend` controllers. 

It is working because the dependency is satisfied by `solidus_api` (and `solidus_auth_devise` since `responders` is a direct `devise` dependency as well). 

This dependency is currently not explicit in `solidus_frontend` and `solidus_backend` gemspecs. This PR fixes this issue.


**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- ~[ ] I have updated Guides and README accordingly to this change (if needed)~
- ~[ ] I have added tests to cover this change (if needed)~
