### PR TITLE
Bump required ruby version to 2.4

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,5 +1,6 @@
 ruby:
   config_file: .rubocop.yml
+  version: 0.72.0
 erb_lint:
   enabled: true
 scss:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,7 @@ AllCops:
     - '*/spec/dummy/**/*'
     - 'sandbox/**/*'
     - '**/templates/**/*'
+    - 'guides/node_modules/**/*'
   TargetRubyVersion: 2.4
 
 # Sometimes I believe this reads better

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ AllCops:
     - '*/spec/dummy/**/*'
     - 'sandbox/**/*'
     - '**/templates/**/*'
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
 
 # Sometimes I believe this reads better
 # This also causes spacing issues on multi-line fixes

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,9 @@
 # Relaxed.Ruby.Style
 
+require:
+  - rubocop-performance
+  - rubocop-rails
+
 AllCops:
   Exclude:
     - 'vendor/**/*'

--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,9 @@ group :utils do
   gem 'pry'
   gem 'launchy', require: false
   gem 'i18n-tasks', '~> 0.9', require: false
-  gem 'rubocop', '~> 0.53.0', require: false
+  gem 'rubocop', '~> 0.72', require: false
+  gem 'rubocop-performance', '~> 1.4', require: false
+  gem 'rubocop-rails', '~> 2.3', require: false
   gem 'gem-release', require: false
 end
 

--- a/api/solidus_api.gemspec
+++ b/api/solidus_api.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version = Spree.solidus_version
 
-  gem.required_ruby_version = '>= 2.2.2'
+  gem.required_ruby_version = '>= 2.4.0'
   gem.required_rubygems_version = '>= 1.8.23'
 
   gem.add_dependency 'jbuilder', '~> 2.8'

--- a/backend/solidus_backend.gemspec
+++ b/backend/solidus_backend.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.required_ruby_version = '>= 2.2.2'
+  s.required_ruby_version = '>= 2.4.0'
   s.required_rubygems_version = '>= 1.8.23'
 
   s.add_dependency 'solidus_api', s.version

--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files        = `git ls-files`.split("\n")
   s.require_path = 'lib'
 
-  s.required_ruby_version     = '>= 2.2.2'
+  s.required_ruby_version = '>= 2.4.0'
   s.required_rubygems_version = '>= 1.8.23'
 
   %w[

--- a/frontend/solidus_frontend.gemspec
+++ b/frontend/solidus_frontend.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.required_ruby_version = '>= 2.2.2'
+  s.required_ruby_version = '>= 2.4.0'
   s.required_rubygems_version = '>= 1.8.23'
 
   s.add_dependency 'solidus_api', s.version

--- a/sample/solidus_sample.gemspec
+++ b/sample/solidus_sample.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.required_ruby_version = '>= 2.2.2'
+  s.required_ruby_version = '>= 2.4.0'
   s.required_rubygems_version = '>= 1.8.23'
 
   s.add_dependency 'solidus_core', s.version

--- a/solidus.gemspec
+++ b/solidus.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.required_ruby_version     = '>= 2.2.2'
+  s.required_ruby_version = '>= 2.4.0'
   s.required_rubygems_version = '>= 1.8.23'
 
   s.author       = 'Solidus Team'


### PR DESCRIPTION
**Description**

[Ruby 2.2 and 2.3 support has ended](https://www.ruby-lang.org/en/news/2019/03/31/support-of-ruby-2-3-has-ended/) and [Rubocop support for 2.2 ended and dropping 2.3 as well is close](https://github.com/rubocop-hq/rubocop/issues/6945).

Also, we already introduced code that is no more compliant with 2.2.

**References**

closes https://github.com/solidusio/solidus/issues/3302, closes https://github.com/solidusio/solidus/issues/2743

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- ~[ ] I have updated Guides and README accordingly to this change (if needed)~
- ~[ ] I have added tests to cover this change (if needed)~
