### PR TITLE
Allow splitting shipments when not tracking inventory

### DIFF
--- a/api/app/controllers/spree/api/shipments_controller.rb
+++ b/api/app/controllers/spree/api/shipments_controller.rb
@@ -127,7 +127,8 @@ module Spree
           current_shipment: @original_shipment,
           desired_shipment: @desired_shipment,
           variant: @variant,
-          quantity: @quantity
+          quantity: @quantity,
+          track_inventory: Spree::Config.track_inventory_levels
         )
 
         if fulfilment_changer.run!

--- a/backend/spec/features/admin/orders/customer_returns_spec.rb
+++ b/backend/spec/features/admin/orders/customer_returns_spec.rb
@@ -41,7 +41,7 @@ describe 'Customer returns', type: :feature do
       expect(page).to have_button("Create", disabled: true)
     end
 
-    context 'when creating a return with state "In Transit" and then marking it as "Received"' do
+    context 'when creating a return with state "In Transit" and then marking it as "Received"', :flaky do
       it 'marks the order as returned', :js do
         create_customer_return('in_transit')
         expect(page).to have_content 'Customer Return has been successfully created'


### PR DESCRIPTION
**Description**

Closes #2817.

When `Spree::Config.track_inventory_levels` is `false` we are not supposed to change inventory levels when shipping orders.

At the moment though, if we try to split a shipment with the following scenario:

- `track_inventory_levels` is false
- there is no inventory in the second stock location for the related stock item

we end up creating a second shipment with items backorderable, making the second shipment impossible to ship.

This is because the FulfilmentChanger class at the moment does not take into account this scenario. But it was currently doing a lot of things that are not required when inventory levels are not tracked.

This fix proposes two different paths, driven by a new argument required in the initialization of the class, that performs a
complex stock movement when we are tracking inventory and a more simple otherwise.

Not passing this new argument to the class' `new` method is deprecated, assuming the old behavior for backward compatibility.


**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
