### PR TITLE
[backend] Disable submit buttons after first click

### DIFF
--- a/backend/app/views/spree/admin/customer_returns/new.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/new.html.erb
@@ -40,7 +40,7 @@
       </div>
 
       <div class="form-buttons filter-actions actions" data-hook="buttons">
-        <%= button_tag t('spree.actions.create'), class: 'btn btn-primary' %>
+        <%= f.submit t('spree.actions.create'), class: 'btn btn-primary' %>
         <%= link_to t('spree.actions.cancel'), admin_order_customer_returns_url(@order), class: 'btn btn-primary' %>
       </div>
     </fieldset>

--- a/backend/app/views/spree/admin/payment_methods/new.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/new.html.erb
@@ -15,7 +15,7 @@
   <fieldset class="no-border-top">
     <%= render partial: 'form', locals: { f: f } %>
     <div data-hook="buttons" class="filter-actions actions">
-      <%= button_tag t('spree.actions.create'), class: 'btn btn-primary' %>
+      <%= f.submit t('spree.actions.create'), class: 'btn btn-primary' %>
     </div>
   </fieldset>
 <% end %>

--- a/backend/app/views/spree/admin/promotion_code_batches/new.html.erb
+++ b/backend/app/views/spree/admin/promotion_code_batches/new.html.erb
@@ -24,5 +24,5 @@
     <%= f.label :email %>
     <%= f.text_field :email, class: "fullwidth", value: spree_current_user.email %>
   <% end %>
-  <%= button_tag t('spree.actions.create'), class: 'btn btn-primary' %>
+  <%= f.submit t('spree.actions.create'), class: 'btn btn-primary' %>
 <% end %>

--- a/backend/app/views/spree/admin/promotion_codes/new.html.erb
+++ b/backend/app/views/spree/admin/promotion_codes/new.html.erb
@@ -24,7 +24,7 @@
     </div>
 
     <div class="form-buttons filter-actions actions" data-hook="buttons">
-      <%= button_tag t('spree.actions.create'), class: 'btn btn-primary' %>
+      <%= f.submit t('spree.actions.create'), class: 'btn btn-primary' %>
       <%= link_to t('spree.actions.cancel'), admin_promotion_promotion_codes_url(@promotion), class: 'button' %>
     </div>
   </fieldset>

--- a/backend/app/views/spree/admin/return_authorizations/new.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/new.html.erb
@@ -13,7 +13,7 @@
     <%= render partial: 'form', locals: { f: f } %>
 
     <div class="form-buttons filter-actions actions" data-hook="buttons">
-      <%= button_tag t('spree.actions.create'), class: 'btn btn-primary' %>
+      <%= f.submit t('spree.actions.create'), class: 'btn btn-primary' %>
       <%= link_to t('spree.actions.cancel'), admin_order_return_authorizations_url(@order), class: 'btn btn-primary' %>
     </div>
   </fieldset>

--- a/backend/app/views/spree/admin/shared/_new_resource_links.html.erb
+++ b/backend/app/views/spree/admin/shared/_new_resource_links.html.erb
@@ -1,4 +1,4 @@
 <div class="form-buttons filter-actions actions" data-hook="buttons">
-  <%= button_tag t('spree.actions.create'), class: 'btn btn-primary' %>
+  <%= submit_tag t('spree.actions.create'), class: 'btn btn-primary' %>
   <%= link_to t('spree.actions.cancel'), collection_url, class: 'button' %>
 </div>

--- a/backend/app/views/spree/admin/taxonomies/new.html.erb
+++ b/backend/app/views/spree/admin/taxonomies/new.html.erb
@@ -12,7 +12,7 @@
   <fieldset class="no-border-top">
     <br>
     <div class="filter-actions actions" data-hook="buttons">
-      <%= button_tag t('spree.actions.create'), class: 'btn btn-primary' %>
+      <%= f.submit t('spree.actions.create'), class: 'btn btn-primary' %>
     </div>
   </fieldset>
 <% end %>

--- a/backend/spec/features/admin/configuration/payment_methods_spec.rb
+++ b/backend/spec/features/admin/configuration/payment_methods_spec.rb
@@ -32,8 +32,8 @@ describe "Payment Methods", type: :feature do
     end
   end
 
-  context "admin creating a new payment method" do
-    it "should be able to create a new payment method" do
+  context "admin creating a new payment method", :js do
+    it "creates a new payment method and disables the form" do
       click_link "Payments"
       expect(page).to have_link 'Payment Methods'
       click_link "admin_new_payment_methods_link"
@@ -43,6 +43,15 @@ describe "Payment Methods", type: :feature do
       select Spree::PaymentMethod::Check.model_name.human, from: "Type"
       click_button "Create"
       expect(page).to have_content("successfully created!")
+
+      visit spree.new_admin_payment_method_path
+      page.execute_script "$('form').submit(function(e) { e.preventDefault()})"
+      fill_in "payment_method_name", with: "check90"
+      fill_in "payment_method_description", with: "check90 desc"
+      select Spree::PaymentMethod::Check.model_name.human, from: "Type"
+      click_button "Create"
+
+      expect(page).to have_button("Create", disabled: true)
     end
   end
 

--- a/backend/spec/features/admin/configuration/shipping_methods_spec.rb
+++ b/backend/spec/features/admin/configuration/shipping_methods_spec.rb
@@ -25,7 +25,7 @@ describe "Shipping Methods", type: :feature do
   end
 
   context "create", js: true do
-    it "should be able to create a new shipping method" do
+    it "creates a new shipping method and disables the submit button", :js do
       click_link "New Shipping Method"
 
       fill_in "shipping_method_name", with: "bullock cart"
@@ -36,6 +36,18 @@ describe "Shipping Methods", type: :feature do
 
       click_on "Create"
       expect(current_path).to eql(spree.edit_admin_shipping_method_path(Spree::ShippingMethod.last))
+
+      visit spree.new_admin_shipping_method_path
+      page.execute_script "$('form').submit(function(e) { e.preventDefault()})"
+      fill_in "shipping_method_name", with: "bullock cart"
+
+      within("#shipping_method_categories_field") do
+        check first("input[type='checkbox']")["name"]
+      end
+
+      click_on "Create"
+
+      expect(page).to have_button("Create", disabled: true)
     end
 
     context 'with shipping method having a calculator with array or hash preference type' do

--- a/backend/spec/features/admin/configuration/taxonomies_spec.rb
+++ b/backend/spec/features/admin/configuration/taxonomies_spec.rb
@@ -38,6 +38,13 @@ describe "Taxonomies", type: :feature do
       click_button "Create"
       expect(page).to have_content("can't be blank")
     end
+
+    it "disables the button at submit", :js do
+      page.execute_script "$('form').submit(function(e) { e.preventDefault()})"
+      fill_in "taxonomy_name", with: "sports"
+      click_button "Create"
+      expect(page).to have_button("Create", disabled: true)
+    end
   end
 
   context "edit" do

--- a/backend/spec/features/admin/orders/customer_returns_spec.rb
+++ b/backend/spec/features/admin/orders/customer_returns_spec.rb
@@ -8,21 +8,34 @@ describe 'Customer returns', type: :feature do
   context 'when the order has more than one line item' do
     let(:order) { create :shipped_order, line_items_count: 2 }
 
+    def create_customer_return
+      find('#select-all').click
+      page.execute_script "$('select.add-item').val('receive')"
+      select 'NY Warehouse', from: 'Stock Location'
+      click_button 'Create'
+    end
+
+    before do
+      visit spree.new_admin_order_customer_return_path(order)
+    end
+
     context 'when creating a return with state "Received"' do
       it 'marks the order as returned', :js do
-        visit spree.new_admin_order_customer_return_path(order)
-
-        find('#select-all').click
-        page.execute_script "$('select.add-item').val('receive')"
-        select 'NY Warehouse', from: 'Stock Location'
-        click_button 'Create'
+        create_customer_return
 
         expect(page).to have_content 'Customer Return has been successfully created'
-
         within 'dd.order-state' do
           expect(page).to have_content 'Returned'
         end
       end
+    end
+
+    it 'disables the button at submit', :js do
+      page.execute_script "$('form').submit(function(e) { e.preventDefault()})"
+
+      create_customer_return
+
+      expect(page).to have_button("Create", disabled: true)
     end
   end
 end

--- a/backend/spec/features/admin/orders/return_authorizations_spec.rb
+++ b/backend/spec/features/admin/orders/return_authorizations_spec.rb
@@ -8,20 +8,49 @@ describe "ReturnAuthorizations", type: :feature do
   stub_authorization!
 
   let!(:order) { create(:shipped_order) }
-  let!(:return_authorization) { create(:return_authorization, order: order) }
 
-  it "can visit the return authorizations list page" do
-    visit spree.admin_order_return_authorizations_path(order)
-  end
-
-  describe "edit" do
-    it "can visit the return authorizations edit page" do
-      visit spree.edit_admin_order_return_authorization_path(order, return_authorization)
+  describe "create" do
+    def create_return_authorization
+      find("#select-all").click
+      select "NY Warehouse", from: "Stock Location"
+      click_button "Create"
     end
 
-    it "return authorizations edit page has a data hook for extensions to add content above, below or within the RA form" do
-      visit spree.edit_admin_order_return_authorization_path(order, return_authorization)
-      expect(page).to have_selector("[data-hook=return-authorization-form-wrapper]")
+    before do
+      visit spree.new_admin_order_return_authorization_path(order)
+    end
+
+    it "creates a return authorization" do
+      create_return_authorization
+
+      expect(page).to have_content "Return Authorization has been successfully created!"
+    end
+
+    it "disables the button at submit", :js do
+      page.execute_script "$('form').submit(function(e) { e.preventDefault()})"
+
+      create_return_authorization
+
+      expect(page).to have_button("Create", disabled: true)
+    end
+  end
+
+  describe "when a return authorization exists" do
+    let!(:return_authorization) { create(:return_authorization, order: order) }
+
+    it "can visit the return authorizations list page" do
+      visit spree.admin_order_return_authorizations_path(order)
+    end
+
+    describe "edit" do
+      it "can visit the return authorizations edit page" do
+        visit spree.edit_admin_order_return_authorization_path(order, return_authorization)
+      end
+
+      it "return authorizations edit page has a data hook for extensions to add content above, below or within the RA form" do
+        visit spree.edit_admin_order_return_authorization_path(order, return_authorization)
+        expect(page).to have_selector("[data-hook=return-authorization-form-wrapper]")
+      end
     end
   end
 end

--- a/backend/spec/features/admin/products/products_spec.rb
+++ b/backend/spec/features/admin/products/products_spec.rb
@@ -172,6 +172,18 @@ describe "Products", type: :feature do
         expect(page).to have_content("successfully updated!")
       end
 
+      it "disables the button at submit", :js do
+        page.execute_script "$('form').submit(function(e) { e.preventDefault()})"
+        fill_in "product_name", with: "Baseball Cap"
+        fill_in "product_sku", with: "B100"
+        fill_in "product_price", with: "100"
+        fill_in "product_available_on", with: "2012/01/24"
+        select @shipping_category.name, from: "product_shipping_category_id"
+        click_button "Create"
+
+        expect(page).to have_button("Create", disabled: true)
+      end
+
       it "should show validation errors", js: false do
         fill_in "product_name", with: "Baseball Cap"
         fill_in "product_sku", with: "B100"

--- a/backend/spec/features/admin/promotion_adjustments_spec.rb
+++ b/backend/spec/features/admin/promotion_adjustments_spec.rb
@@ -167,6 +167,15 @@ describe "Promotion Adjustments", type: :feature, js: true do
       expect(promotion.actions.first).to be_a(Spree::Promotion::Actions::FreeShipping)
     end
 
+    it "disables the button at submit", :js do
+      page.execute_script "$('form').submit(function(e) { e.preventDefault()})"
+      fill_in "Name", with: "SAVE SAVE SAVE"
+      choose "Apply to all orders"
+      click_button "Create"
+
+      expect(page).to have_button("Create", disabled: true)
+    end
+
     it "should allow an admin to create an automatic promotion" do
       fill_in "Name", with: "SAVE SAVE SAVE"
       choose "Apply to all orders"

--- a/backend/spec/features/admin/promotions/promotion_code_batches_spec.rb
+++ b/backend/spec/features/admin/promotions/promotion_code_batches_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+feature "Promotion Code Batches", partial_double_verification: false do
+  stub_authorization!
+
+  describe "create" do
+    let(:promotion) { create :promotion }
+
+    before do
+      user = double.as_null_object
+      allow_any_instance_of(ActionView::Base).to receive(:spree_current_user) { user }
+      visit spree.new_admin_promotion_promotion_code_batch_path(promotion)
+    end
+
+    def create_code_batch
+      fill_in "Base code", with: "base"
+      fill_in "Number of codes", with: 3
+      click_button "Create"
+    end
+
+    it "creates a new promotion code batch and disables the submit button", :js do
+      create_code_batch
+
+      expect(page).to have_content "Promotion Code Batch has been successfully created!"
+
+      visit spree.new_admin_promotion_promotion_code_batch_path(promotion)
+
+      page.execute_script "$('form').submit(function(e) { e.preventDefault()})"
+
+      create_code_batch
+
+      expect(page).to have_button("Create", disabled: true)
+    end
+  end
+end

--- a/backend/spec/features/admin/promotions/promotion_code_spec.rb
+++ b/backend/spec/features/admin/promotions/promotion_code_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+feature "Promotion Codes" do
+  stub_authorization!
+
+  describe "create" do
+    let(:promotion) { create :promotion }
+
+    before do
+      visit spree.new_admin_promotion_promotion_code_path(promotion)
+    end
+
+    it "creates a new promotion code" do
+      fill_in "Value", with: "XYZ"
+      click_button "Create"
+
+      expect(page).to have_content "Promotion Code has been successfully created!"
+    end
+
+    it "disables the button at submit", :js do
+      page.execute_script "$('form').submit(function(e) { e.preventDefault()})"
+
+      fill_in "Value", with: "XYZ"
+      click_button "Create"
+
+      expect(page).to have_button("Create", disabled: true)
+    end
+  end
+end

--- a/backend/spec/support/feature/base_feature_helper.rb
+++ b/backend/spec/support/feature/base_feature_helper.rb
@@ -4,7 +4,12 @@ module BaseFeatureHelper
   def click_nav(nav_text, subnav_text = nil)
     primary_nav = find(".admin-nav-menu>ul>li>a", text: /#{nav_text}/i)
     if subnav_text
-      primary_nav.find('+ul>li>a', text: /#{subnav_text}/i).click
+      unless Capybara.current_driver == :rack_test
+        # we need to make the navigation visible with Selenium driver,
+        # and RackTest implementation of `hover`raises NotImplementedError
+        primary_nav.hover
+      end
+      primary_nav.sibling("ul").find("li > a", text: /#{subnav_text}/i).click
     else
       primary_nav.click
     end


### PR DESCRIPTION
**Description**
It may happen that admin users click multiple times (purposely or not) on submit buttons in the backend area. 

This can be a problem as at times it may silently generate unwanted duplicate records, or show an error page due to duplicate records. This is much more likely to happen on real shops when unanticipated server load makes the application unresponsive (at first click nothing seems to happen, so then why not click again?) and where some controller `create` actions may be patched and be slower.

By changing `button_tag` to `f.submit` or `submit_tag`  the button gets disabled after the first click, thanks to the automatically added attribute `data-disable-with="Create"`

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change (if needed)
