### PR TITLE
Handle deprecation for Rails 6 in DummyApp

### DIFF
--- a/core/lib/spree/testing_support/dummy_app.rb
+++ b/core/lib/spree/testing_support/dummy_app.rb
@@ -13,6 +13,7 @@ Rails.env = 'test'
 require 'solidus_core'
 
 RAILS_52_OR_ABOVE = Gem::Version.new(Rails.version) >= Gem::Version.new('5.2')
+RAILS_6_OR_ABOVE = Gem::Version.new(Rails.version) >= Gem::Version.new('6.0')
 
 # @private
 class ApplicationController < ActionController::Base
@@ -64,7 +65,9 @@ module DummyApp
 
     if RAILS_52_OR_ABOVE
       config.action_controller.default_protect_from_forgery = true
-      config.active_record.sqlite3.represent_boolean_as_integer = true
+      unless RAILS_6_OR_ABOVE
+        config.active_record.sqlite3.represent_boolean_as_integer = true
+      end
     end
 
     # Avoid issues if an old spec/dummy still exists


### PR DESCRIPTION
`.represent_boolean_as_integer=` is always true. Setting this is
deprecated and will be removed in Rails 6.1

Not sure if this is the right way to handle these types of deprecations.

Ref: https://github.com/rails/rails/commit/f59b08119bc0c01a00561d38279b124abc82561b

**Checklist:**
- [ ] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [ ] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
