### PR TITLE
Officialize new taxation system

### DIFF
--- a/core/app/models/spree/tax_calculator/default.rb
+++ b/core/app/models/spree/tax_calculator/default.rb
@@ -8,10 +8,6 @@ module Spree
     # The class used for tax calculation is configurable, so that the
     # calculation can easily be pushed to third-party services. Users looking
     # to provide their own calculator should adhere to the API of this class.
-    #
-    # @api experimental
-    # @note This API is currently in development and likely to change.
-    #   Specifically, the input format is not yet finalized.
     class Default
       include Spree::Tax::TaxHelpers
 

--- a/core/app/models/spree/tax_calculator/shipping_rate.rb
+++ b/core/app/models/spree/tax_calculator/shipping_rate.rb
@@ -10,9 +10,6 @@ module Spree
     # class.
     #
     # @see Spree::Tax::ShippingRateTaxer
-    # @api experimental
-    # @note This API is currently in development and likely to change.
-    #   Specifically, the input format is not yet finalized.
     class ShippingRate
       include Spree::Tax::TaxHelpers
 

--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -88,7 +88,11 @@ module Spree
     scope :included_in_price, -> { where(included_in_price: true) }
 
     # Creates necessary tax adjustments for the order.
+    #
+    # @deprecated Please use `Spree::Tax::OrderAdjuster#adjust!` instead
     def adjust(_order_tax_zone, item)
+      Spree::Deprecation.warn("`Spree::TaxRate#adjust` is deprecated. Please use `Spree::Tax::OrderAdjuster#adjust!` instead.", caller)
+
       amount = compute_amount(item)
 
       item.adjustments.create!(

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -306,7 +306,6 @@ module Spree
     # @!attribute [rw] shipping_rate_tax_calculator_class
     # @return [Class] a class with the same public interfaces as
     #   Spree::TaxCalculator::ShippingRate
-    # @api experimental
     class_name_attribute :shipping_rate_tax_calculator_class, default: 'Spree::TaxCalculator::ShippingRate'
 
     # Allows providing your own Mailer for order mailer.
@@ -384,7 +383,6 @@ module Spree
     # @!attribute [rw] tax_adjuster_class
     # @return [Class] a class with the same public interfaces as
     #   Spree::Tax::OrderAdjuster
-    # @api experimental
     class_name_attribute :tax_adjuster_class, default: 'Spree::Tax::OrderAdjuster'
 
     # Allows providing your own class for calculating taxes on an order.
@@ -392,7 +390,6 @@ module Spree
     # @!attribute [rw] tax_calculator_class
     # @return [Class] a class with the same public interfaces as
     #   Spree::TaxCalculator::Default
-    # @api experimental
     class_name_attribute :tax_calculator_class, default: 'Spree::TaxCalculator::Default'
 
     # Allows providing your own class for choosing which store to use.

--- a/core/spec/models/spree/tax_rate_spec.rb
+++ b/core/spec/models/spree/tax_rate_spec.rb
@@ -153,6 +153,7 @@ RSpec.describe Spree::TaxRate, type: :model do
 
     describe 'adjustments' do
       before do
+        expect(Spree::Deprecation).to receive(:warn)
         tax_rate.adjust(nil, item)
       end
 


### PR DESCRIPTION
**Description**

Ref: #1892 

We should have probably done this long time ago, but I think we should start deprecating methods that we don't want to see anymore in stores and extensions. 

Having the new way for calculating order taxes marked as experimental added some further confusion we can easily remove.

**Note**

- [x] I expect the CI to fail in the first run, at least for the test of the now deprecated `Spree::TaxRate#adjust` method. I hope it will show us also other places where we are eventually using it and I missed.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- ~[ ] I have updated Guides and README accordingly to this change (if needed)~
- ~[ ] I have added tests to cover this change (if needed)~
