### PR TITLE
Update guides node-sass dependency to be compatible with Node versions > v10

### DIFF
--- a/guides/package.json
+++ b/guides/package.json
@@ -21,7 +21,7 @@
     "css-loader": "^0.28.9",
     "extract-text-webpack-plugin": "^3.0.2",
     "lodash": "^4.17.13",
-    "node-sass": "sass/node-sass#v5",
+    "node-sass": "^4.12.0",
     "postcss-loader": "~2.1.1",
     "randomatic": ">=3.0.0",
     "run-sequence": "^2.2.0",


### PR DESCRIPTION
**Description**
Updated the node-sass dependency for the guides/documentation since it was explicitly set to a version which does not work with newer versions of Node. Tested and now `yarn install` no longer errors on Node v11 or v12, and still works with older versions. 

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [not needed] I have updated Guides and README accordingly to this change (if needed)
- [not needed] I have added tests to cover this change (if needed)
