### PR TITLE
A promotion without actions should log errors

### DIFF
--- a/core/app/models/spree/promotion_handler/coupon.rb
+++ b/core/app/models/spree/promotion_handler/coupon.rb
@@ -17,6 +17,9 @@ module Spree
             handle_present_promotion(promotion)
           elsif promotion_code && promotion_code.promotion.inactive?
             set_error_code :coupon_code_expired
+          elsif promotion_code && !promotion.actions.exists?
+            set_error_code :coupon_code_not_found
+            Rails.logger.warn I18n.t(:coupon_code_no_promotion_actions, coupon_code: coupon_code)
           else
             set_error_code :coupon_code_not_found
           end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1175,6 +1175,7 @@ en:
     coupon_code_removed: The coupon code was successfully removed from this order.
     coupon_code_unknown_error: This coupon code could not be applied to the cart at
       this time.
+    coupon_code_no_promotion_actions: "Failed to apply the coupon code '%{coupon_code}' because it does not have any actions."
     create: Create
     create_a_new_account: Create a new account
     create_one: Create One.

--- a/core/spec/models/spree/promotion_handler/coupon_spec.rb
+++ b/core/spec/models/spree/promotion_handler/coupon_spec.rb
@@ -88,6 +88,12 @@ module Spree
             subject.apply
             expect(subject.error).to eq I18n.t('spree.coupon_code_not_found')
           end
+
+          it "logs a warning message" do
+            allow(Rails.logger).to receive(:warn).at_least(:once)
+            subject.apply
+            expect(Rails.logger).to have_received(:warn).with I18n.t(:coupon_code_no_promotion_actions, coupon_code: '10off')
+          end
         end
       end
 

--- a/guides/source/users/promotions/promotion-actions.html.md
+++ b/guides/source/users/promotions/promotion-actions.html.md
@@ -25,8 +25,12 @@ following steps:
    of many types of discount depending on the promotion calculator being used.
    (For example, the amount could be a flat percentage or a flexible rate.)
 
-Note that if you choose the promotion action type **Free Shipping** that steps
-3. and 4. are not applicable.
+### Notes
+1. If you choose the promotion action type **Free Shipping**, then steps
+**3** and **4** are not applicable.
+2. You can set a coupon code to your promotion, but your customers will be 
+unable to use it when no actions are present. In these cases, a warning message
+will be shown in the logs.
 
 [create-a-new-promotion]: overview.html#create-a-new-promotion
 [promotion-calculators]: promotion-calculators.html


### PR DESCRIPTION
**Description**

The following PR fixes #2777 

When a customer tries to apply a promotion coupon code that has no actions, the following will occur: 
- They should get the `The coupon code you entered doesn't exist.` error message 
- A warning is logged mentioning said coupon

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
