### PR TITLE
Ability to unset a taxon icon

### DIFF
--- a/backend/app/controllers/spree/admin/taxons_controller.rb
+++ b/backend/app/controllers/spree/admin/taxons_controller.rb
@@ -72,6 +72,19 @@ module Spree
         respond_with(@taxon) { |format| format.json { render json: '' } }
       end
 
+      def clear_icon
+        @taxon = Spree::Taxon.find(params[:taxon_id])
+        @taxon.icon = nil
+
+        if @taxon.save
+          flash[:success] = flash_message_for(@taxon, :successfully_icon_cleared)
+        end
+
+        respond_with(@taxon) do |format|
+          format.html { redirect_to edit_admin_taxonomy_url(@taxon.taxonomy_id) }
+        end
+      end
+
       private
 
       def taxon_params

--- a/backend/app/views/spree/admin/taxons/attachment_forms/_paperclip.html.erb
+++ b/backend/app/views/spree/admin/taxons/attachment_forms/_paperclip.html.erb
@@ -3,5 +3,6 @@
     <%= f.label attachment %><br>
     <%= f.file_field attachment %>
     <%= image_tag f.object.send(attachment, definition[:default_style]) if f.object.send(attachment).present? %>
+    <%= link_to t('spree.clear_icon'), admin_taxon_icon_path(@taxon.id), method: 'delete', data: { confirm: t('spree.taxon_confirm_clear_icon') }, class: 'btn btn-sm btn-danger' if f.object.send(attachment).present? %>
   <% end %>
 <% end %>

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -139,6 +139,7 @@ Spree::Core::Engine.routes.draw do
       collection do
         get :search
       end
+      resource :icon, only: :destroy, to: "taxons#clear_icon"
     end
 
     resources :reimbursement_types, only: [:index]

--- a/backend/spec/features/admin/taxons_spec.rb
+++ b/backend/spec/features/admin/taxons_spec.rb
@@ -41,6 +41,24 @@ describe "Taxonomies and taxons", type: :feature do
     expect(page).to have_current_path %r{/admin/taxonomies/\d+/taxons/\d+/edit}
   end
 
+  it "can clear taxon icon", js: true do
+    @taxon = create(:taxon, name: 'Shirts')
+    visit spree.edit_admin_taxonomy_taxon_path(@taxon.taxonomy_id, @taxon.id)
+
+    attach_file "taxon_icon", Rails.root.join('..', '..', 'spec', 'support', 'ror_ringer.jpeg')
+
+    click_button "Update"
+    expect(page).to have_content("Taxon \"Shirts\" has been successfully updated!")
+
+    visit spree.edit_admin_taxonomy_taxon_path(@taxon.taxonomy_id, @taxon.id)
+
+    accept_confirm do
+      click_on "Clear icon"
+    end
+
+    expect(page).to have_content("Taxon \"Shirts\" icon has been successfully cleared!")
+  end
+
   context "inside sidebar menu" do
     def only_one_selected_tab_inside?(sub_tab_selector, tab_name, tab_path)
       within(sub_tab_selector) do

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1127,6 +1127,7 @@ en:
     clear_cache_ok: Cache was flushed
     clear_cache_warning: Clearing cache will temporarily reduce the performance of
       your store.
+    clear_icon: Clear icon
     clone: Clone
     close: Close
     closed: Closed
@@ -2090,6 +2091,7 @@ en:
     subtract: Subtract
     success: Success
     successfully_created: "%{resource} has been successfully created!"
+    successfully_icon_cleared: "%{resource} icon has been successfully cleared!"
     successfully_refunded: "%{resource} has been successfully refunded!"
     successfully_removed: "%{resource} has been successfully removed!"
     successfully_signed_up_for_analytics: Successfully signed up for Spree Analytics
@@ -2111,6 +2113,7 @@ en:
       match_all: all
       match_any: at least one
       match_none: none
+    taxon_confirm_clear_icon: Are you sure you want to clear this taxon's icon?
     taxonomies: Taxonomies
     taxonomy: Taxonomy
     taxonomy_edit: Edit taxonomy


### PR DESCRIPTION
***Description***

The following PR fixes #3349 

Ability to clear a `taxon` icon through the `taxon`'s edit page.

Feedback is very much appreciated.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
