### PR TITLE
Guides (API): Some additional API token info

### DIFF
--- a/api/openapi/authentication.md
+++ b/api/openapi/authentication.md
@@ -10,6 +10,14 @@ You can use your API key to access all resources in the API. The API key must be
 Authorization: Bearer API_KEY
 ```
 
+As an admin, you can find your API token in the admin section under Users > Your e-email > API Access (at `admin/users/<user_id>/edit`)
+
+Example:
+
+```
+curl --header "Authorization: Bearer 1a6a9936ad150a2ee345c65331da7a3ccc2de" http://www.my-solidus-site.com/api/stores
+```
+
 By default, API keys are only generated for admins, but you can easily customize Solidus to generate them for all users, which is useful for instance if you want users to be able to sign in and manage their profile via the API.
 
 ### Order token


### PR DESCRIPTION
*UPDATE*: Ignore everything below. All that remains is a small extra tip on where to find your API token and a `curl` example.

**Description**

The [API guide](https://solidus.docs.stoplight.io/authentication) states that the API token should be passed in through the `Authentication` header. I discovered this doesn't work, and from [this line](https://github.com/solidusio/solidus/blob/master/api/app/controllers/spree/api/base_controller.rb#L114) it looks like the correct header is `X-Spree-Token`, which also works in practice for me.

Either I misunderstood something, or the guides are wrong.

I also added a `curl` example and spelled out where people can find their admin token.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
