### PR TITLE
Correct misspelling in API Documentation for Create Product

### DIFF
--- a/api/openapi/api.oas2.yml
+++ b/api/openapi/api.oas2.yml
@@ -50,7 +50,7 @@ paths:
         '422':
           $ref: '#/responses/unprocessable-entity'
       summary: Create product
-      description: Creaets a product.
+      description: Creates a product.
       operationId: create-product
       tags:
         - Products


### PR DESCRIPTION
"Creates" in the header was misspelled as "Creaets". This is just a quick fix.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
