### PR TITLE
Link to guides after installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ bundle exec rails s
 The [`solidus_frontend`](https://github.com/solidusio/solidus/tree/master/frontend) storefront will be accessible at [http://localhost:3000/](http://localhost:3000/)
 and the admin can be found at [http://localhost:3000/admin/](http://localhost:3000/admin/).
 
+For information on how to customize your store, check out the [customization guides](https://guides.solidus.io/developers/customizations/overview.html).
+
 ### Default Username/Password
 
 As part of running the above installation steps, you will be asked to set an admin email/password combination. The default values are `admin@example.com` and `test123`, respectively.


### PR DESCRIPTION
We get a good amount of people completing the installation and setup of a Solidus store, but unsure about how to start customizing it showing up in Slack and asking questions which might be answered by these guides.

The logical next step after setting up Solidus store is to start customizing it, so I think it makes sense to send people to the customization guides here as a first step.


**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] ~I have updated Guides and README accordingly to this change (if needed)~
- [ ] ~I have added tests to cover this change (if needed)~