### PR TITLE
Fix Sprockets 4 support for extensions

### DIFF
--- a/core/lib/generators/spree/install/install_generator.rb
+++ b/core/lib/generators/spree/install/install_generator.rb
@@ -58,6 +58,9 @@ module Spree
 
     def setup_assets
       @lib_name = 'spree'
+
+      empty_directory 'app/assets/images'
+
       %w{javascripts stylesheets images}.each do |path|
         empty_directory "vendor/assets/#{path}/spree/frontend" if defined? Spree::Frontend || Rails.env.test?
         empty_directory "vendor/assets/#{path}/spree/backend" if defined? Spree::Backend || Rails.env.test?


### PR DESCRIPTION
**Description**

This fixes an issue with extension tests failing due to Sprockets 4 requiring an `app/assets/images` directory to be present.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
