### PR TITLE
Pass stock location to inventory unit factory

### DIFF
--- a/core/lib/spree/testing_support/factories/inventory_unit_factory.rb
+++ b/core/lib/spree/testing_support/factories/inventory_unit_factory.rb
@@ -9,6 +9,7 @@ FactoryBot.define do
   factory :inventory_unit, class: 'Spree::InventoryUnit' do
     transient do
       order { nil }
+      stock_location { nil }
     end
 
     variant
@@ -20,7 +21,13 @@ FactoryBot.define do
       end
     end
     state { 'on_hand' }
-    shipment { build(:shipment, state: 'pending', order: line_item.order) }
+    shipment do
+      if stock_location
+        build(:shipment, state: 'pending', order: line_item.order, stock_location: stock_location)
+      else
+        build(:shipment, state: 'pending', order: line_item.order)
+      end
+    end
     # return_authorization
   end
 end

--- a/core/lib/spree/testing_support/factories/stock_package_factory.rb
+++ b/core/lib/spree/testing_support/factories/stock_package_factory.rb
@@ -17,7 +17,7 @@ FactoryBot.define do
 
     after(:build) do |package, evaluator|
       evaluator.variants_contents.each do |variant, count|
-        package.add_multiple build_list(:inventory_unit, count, variant: variant)
+        package.add_multiple build_list(:inventory_unit, count, variant: variant, stock_location: evaluator.stock_location)
       end
     end
 


### PR DESCRIPTION
**Description**
When building fulfilled stock packages in specs using the stock package factory, this passes the given transient stock location to the inventory units that get built. This prevents the inventory unit factory from building unique stock locations for each inventory unit that gets built, and ensures that the stock package is using the same stock location as the inventory units it contains.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
