### PR TITLE
Add initial value to reduce function for tab widths

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/components/tabs.js
+++ b/backend/app/assets/javascripts/spree/backend/components/tabs.js
@@ -22,7 +22,7 @@ Tabs = (function() {
     });
     this.totalTabsWidth = this.tabWidths.reduce(function(previousValue, currentValue) {
       return previousValue + currentValue;
-    });
+    }, 0);
 
     window.addEventListener("resize", this.overflowTabs);
     this.overflowTabs();


### PR DESCRIPTION

**Description**
When calculating total tab width, we recently saw a case where there
were no tabs and thus no IV for reduce. This adds a default starting
value of 0 which prevents a js exception in that case. I checked the rest of the js and found no other occurrences of a `reduce` call without an initial value.

**Checklist:**
- [X] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [X] I have added a detailed description into each commit message
- [X] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
