### PR TITLE
Lock Sprockets to v3.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,11 @@ group :backend, :frontend, :core, :api do
   rails_version = ENV['RAILS_VERSION'] || '~> 6.0.0'
   gem 'rails', rails_version, require: false
 
+  # Temporarily locking sprockets to v3.x
+  # see https://github.com/solidusio/solidus/issues/3374
+  # and https://github.com/rails/sprockets-rails/issues/369
+  gem 'sprockets', '~> 3'
+
   platforms :ruby do
     case ENV['DB']
     when /mysql/


### PR DESCRIPTION
**Description**

Ref https://github.com/solidusio/solidus/issues/3374

This is a temporary fix that will allow master to be green again (so we can continue working on PRs) while we wait for https://github.com/rails/sprockets-rails/pull/446 to be merged (or some other working solution).
    
**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message