### PR TITLE
Add support for Sprockets v4 to the DummyApp

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'rspec-rails', '~> 6.0.3', require: false
 gem 'rspec-retry', '~> 0.6.2', require: false
 gem 'simplecov', require: false
 gem 'simplecov-cobertura', require: false
+gem 'rack', '< 3', require: false
 gem 'rake', require: false, groups: [:lint, :release]
 gem 'rails-controller-testing', require: false
 gem 'puma', '< 6', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -12,11 +12,6 @@ else
 end
 # rubocop:enable Bundler/DuplicatedGem
 
-# Temporarily locking sprockets to v3.x
-# see https://github.com/solidusio/solidus/issues/3374
-# and https://github.com/rails/sprockets-rails/issues/369
-gem 'sprockets', '~> 3'
-
 gem 'pry'
 gem 'launchy', require: false
 

--- a/core/lib/spree/testing_support/dummy_app.rb
+++ b/core/lib/spree/testing_support/dummy_app.rb
@@ -34,8 +34,11 @@ end
 module DummyApp
   def self.setup(gem_root:, lib_name:, auto_migrate: true)
     ENV["LIB_NAME"] = lib_name
-    DummyApp::Application.config.root = File.join(gem_root, 'spec', 'dummy')
+    root = Pathname(gem_root).join('spec/dummy')
+    root.join("app/assets/config").mkpath
+    root.join("app/assets/config/manifest.js").write("// Intentionally empty\n")
 
+    DummyApp::Application.config.root = root
     DummyApp::Application.initialize! unless DummyApp::Application.initialized?
 
     if auto_migrate


### PR DESCRIPTION
~~🛑 **BLOCKED BY https://github.com/rails/sprockets-rails/pull/446**~~

**Description**
Sprockets 4 introduced a mandatory configuration manifest at a specific location. We don't have the ability to set it at that specific location in the DummyApp we use for our specs.

~~I've opened https://github.com/rails/sprockets-rails/pull/446 on sprockets-rails which should fix this issue. I'll leave this PR open (working with that branch) waiting to know if that PR will be accepted.~~

**Update:** Now an empty manifest will be written in the expected location inside `spec/dummy` during the dummy app setup.

Closes #3374, closes #3376

~~After merging this we need to revert~~ This also reverts #3378.

**Checklist:**
- [ ] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [ ] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
