### PR TITLE
Add steps for installing database gems

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,16 @@ Use at own risk.
   bundle install
   ```
 
+  _Note_: If you're using PostgreSQL or MySQL, you'll need to install those gems through the DB environment variable.
+
+  ```bash
+  # PostgreSQL
+  DB=postgresql bundle install
+
+  # MySQL
+  DB=mysql bundle install
+  ```
+
 ### Sandbox
 
 Solidus is meant to be run within the context of Rails application. You can
@@ -230,7 +240,11 @@ data already loaded.
   You can create a sandbox with PostgreSQL or MySQL by setting the DB environment variable.
 
   ```bash
+  # PostgreSQL
   DB=postgresql bundle exec rake sandbox
+
+  # MySQL
+  DB=mysql bundle exec rake sandbox
   ```
 
 * Start the server


### PR DESCRIPTION
**Description**
I just started playing around with Solidus and noticed some hiccups during the setup process. Turns out, there's a `DB` environment variable that's used to indicate which database you want to use. This also scopes down the database-related gems that are needed to install. `DB` should also be used during `bundle install` so you gather the correct gems during setup.

**Checklist:**
- [X] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [X] I have added a detailed description into each commit message
- [X] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
