### PR TITLE
Add tooltips to admin calculators

### DIFF
--- a/backend/app/views/spree/admin/promotions/_actions.html.erb
+++ b/backend/app/views/spree/admin/promotions/_actions.html.erb
@@ -7,6 +7,7 @@
       <% if can?(:update, @promotion) %>
         <div class="field">
           <%= label_tag :action_type, t('spree.adjustment_type')%>
+          <%= admin_hint t('spree.adjustment_type'), t(:promotions, scope: [:spree, :hints, "spree/calculator"]) %>
           <%= select_tag 'action_type', options, include_blank: t(:choose_promotion_action, scope: 'spree'), class: 'custom-select fullwidth' %>
         </div>
         <div class="filter-actions actions">

--- a/backend/app/views/spree/admin/shared/_calculator_fields.html.erb
+++ b/backend/app/views/spree/admin/shared/_calculator_fields.html.erb
@@ -4,6 +4,11 @@
   <div id="preference-settings">
     <div class="field">
       <%= f.label(:calculator_type, Spree::Calculator.model_name.human) %>
+
+      <% if local_assigns.has_key? :hint %>
+        <%= admin_hint t("spree.#{hint}"), t(hint, scope: [:spree, :hints, "spree/calculator"]) %>
+      <% end %>
+
       <%= f.select(:calculator_type, @calculators.map { |c| [c.description, c.name] }, {}, {class: 'custom-select fullwidth js-calculator-type'}) %>
     </div>
 

--- a/backend/app/views/spree/admin/shipping_methods/_form.html.erb
+++ b/backend/app/views/spree/admin/shipping_methods/_form.html.erb
@@ -100,7 +100,7 @@
   </div>
   <div class="col-5">
     <div data-hook="admin_shipping_method_form_calculator_fields">
-      <%= render partial: 'spree/admin/shared/calculator_fields', locals: { f: f } %>
+      <%= render partial: 'spree/admin/shared/calculator_fields', locals: { f: f, hint: :shipping_methods } %>
     </div>
     <div>
       <fieldset class="tax_categories no-border-bottom">

--- a/backend/app/views/spree/admin/tax_rates/_form.html.erb
+++ b/backend/app/views/spree/admin/tax_rates/_form.html.erb
@@ -58,5 +58,5 @@
 
   <div class="clear"></div>
 
-  <%= render 'spree/admin/shared/calculator_fields', f: f %>
+  <%= render partial: 'spree/admin/shared/calculator_fields', locals: { f: f, hint: :tax_rates } %>
 </div>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1371,6 +1371,14 @@ en:
     hidden: hidden
     hide_out_of_stock: Hide out of stock
     hints:
+      spree/calculator:
+        tax_rates: This is used to calculate both sales tax (United States-style taxes)
+          and value-added tax (VAT). Typically this calculator should be the only tax
+          calculator required by your store.
+        shipping_methods: This is used to calculate the shipping rates on a per order or
+          per package rate.
+        promotions: This is used to determine the promotional discount to be applied to an
+          order, an item, or shipping charges.
       spree/price:
         country: 'This determines in what country the price is valid.<br/>Default:
           Any Country'


### PR DESCRIPTION
**Description**

This change adds tooltips for some calculators in the admin panel. I tried to create some basic text based on the guides so they can easily be changed in the future. If you have further ideas on what these should say, I'm all ears!!

_Side Note_: Since this is just changing a small piece of the frontend view, I wasn't totally sure on tests as there's no real extra functionality. As always, if you feel there should be some, don't hesitate to let me know!

This PR is in reference to: issue #3363

Thanks in advance!

**Quick view of how these look**

<img width="340" alt="Screen Shot 2019-10-14 at 9 05 04 PM" src="https://user-images.githubusercontent.com/35509748/66794815-5d6ff900-eec8-11e9-84f8-8a41965bf0f4.png">
<img width="306" alt="Screen Shot 2019-10-14 at 9 04 01 PM" src="https://user-images.githubusercontent.com/35509748/66794818-61038000-eec8-11e9-8715-c31429a14c22.png">
<img width="645" alt="Screen Shot 2019-10-14 at 9 03 40 PM" src="https://user-images.githubusercontent.com/35509748/66794820-61038000-eec8-11e9-91b1-55256d22c3ff.png">

**Checklist:**
- [X] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [X] I have added a detailed description into each commit message
- [X] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
