### PR TITLE
Ask to provide screenshots for PRs with visual changes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,8 @@
 <!--
   Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
 
+  Please include screenshots in case of visual changes to the frontend or backend sections of Solidus.
+
   If needed you can reference another PR or issue here, e.g.:
   Ref #ISSUE
 -->
@@ -11,3 +13,4 @@
 - [ ] I have added a detailed description into each commit message
 - [ ] I have updated Guides and README accordingly to this change (if needed)
 - [ ] I have added tests to cover this change (if needed)
+- [ ] I have attached screenshots to this PR for visual changes (if needed)


### PR DESCRIPTION
**Description**

When reviewing PRs for the admin/frontend sections that include visual
changes, it's very handy to be able to visualize these changes without
resorting to checking out the code, starting  the server and navigating 
to the modified pages.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
