### PR TITLE
[doc] Document the config assigment for vat_country_iso

### DIFF
--- a/guides/source/developers/taxation/displaying-prices.html.md
+++ b/guides/source/developers/taxation/displaying-prices.html.md
@@ -41,7 +41,7 @@ administrator lives in Germany, you could change the configured value to the
 ISO code for Germany:
 
 ```ruby
-Spree::Config.admin_vat_country_iso == "DE"
+Spree::Config.admin_vat_country_iso = "DE"
 ```
 
 ## Anticipate the customer's tax jurisdiction
@@ -79,5 +79,5 @@ options][pricing-options] for more information.
 
 [pricing-options]: https://github.com/solidusio/solidus/blob/master/core/app/models/spree/variant/pricing_options.rb
 [pricing-options-spec]: https://github.com/solidusio/solidus/blob/master/core/spec/models/spree/variant/pricing_options_spec.rb
-[price-selector]: https://github.com/solidusio/solidus/blob/master/core/app/models/spree/variant/price_selector.rb 
+[price-selector]: https://github.com/solidusio/solidus/blob/master/core/app/models/spree/variant/price_selector.rb
 [price-selector-spec]: https://github.com/solidusio/solidus/blob/master/core/spec/models/spree/variant/price_selector_spec.rb


### PR DESCRIPTION
This commit fixes the sample config by using `=` instead of `==` for
setting the `admin_vat_country_iso`

**Description**
<!--
  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

  If needed you can reference another PR or issue here, e.g.:
  Ref #ISSUE
-->

**Checklist:**
- [ ] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [ ] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
