### PR TITLE
Fix Coupon Code Field's Length in Firefox

### DIFF
--- a/frontend/app/assets/stylesheets/spree/frontend/screen.css.scss
+++ b/frontend/app/assets/stylesheets/spree/frontend/screen.css.scss
@@ -963,8 +963,8 @@ p[data-hook="use_billing"] {
   }
 
   input[type="text"] {
-    flex: 3 0;
-    width: 100%;
+    flex: 1 auto;
+    width: 50%;
     margin-right: 5px;
   }
 
@@ -1268,7 +1268,7 @@ table.order-summary {
 // # Logo
 #logo {
   padding: 20px 0;
-  
+
   > a {
     display: inline-block;
   }


### PR DESCRIPTION
**Description**

The coupon code styling seems to be broken in Firefox compared to Chrome and Safari. These changes should ensure it fits nicely and consistent between browsers.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)

**Screenshots**

### Before (Firefox)

![image](https://user-images.githubusercontent.com/424392/67144447-f0ce7300-f2a8-11e9-9b85-6a994de6bc7a.png)

### After

| Chrome | Firefox | Safari |
| --- | --- | --- | 
| <img width="245" alt="chrome" src="https://user-images.githubusercontent.com/424392/67144412-a0571580-f2a8-11e9-8efd-6fbffd5d561b.png"> |  <img width="236" alt="firefox" src="https://user-images.githubusercontent.com/424392/67144415-a5b46000-f2a8-11e9-843f-2c60dfc869ad.png"> | <img width="237" alt="safari" src="https://user-images.githubusercontent.com/424392/67144418-abaa4100-f2a8-11e9-8211-24bee25568cb.png"> |



