### PR TITLE
Reload product before assigning images to variants

### DIFF
--- a/sample/db/samples/assets.rb
+++ b/sample/db/samples/assets.rb
@@ -128,7 +128,7 @@ products[:solidus_long].variants.each do |variant|
   end
 end
 
-products[:solidus_girly].variants.each do |variant|
+products[:solidus_girly].reload.variants.each do |variant|
   color = variant.option_value("tshirt-color").downcase
   main_image = image("solidus_girly_#{color}", "png")
   File.open(main_image) do |f|

--- a/sample/db/samples/assets.rb
+++ b/sample/db/samples/assets.rb
@@ -4,9 +4,9 @@ Spree::Sample.load_sample("products")
 Spree::Sample.load_sample("variants")
 
 products = {}
-products[:solidus_tshirt] = Spree::Product.find_by!(name: "Solidus T-Shirt")
-products[:solidus_long] = Spree::Product.find_by!(name: "Solidus Long Sleeve")
-products[:solidus_girly] = Spree::Product.find_by!(name: "Solidus Girly")
+products[:solidus_tshirt] = Spree::Product.includes(variants: [:option_values]).find_by!(name: "Solidus T-Shirt")
+products[:solidus_long] = Spree::Product.includes(variants: [:option_values]).find_by!(name: "Solidus Long Sleeve")
+products[:solidus_girly] = Spree::Product.includes(variants: [:option_values]).find_by!(name: "Solidus Girly")
 products[:solidus_snapback_cap] = Spree::Product.find_by!(name: "Solidus Snapback Cap")
 products[:solidus_hoodie] = Spree::Product.find_by!(name: "Solidus Hoodie Zip")
 products[:ruby_hoodie] = Spree::Product.find_by!(name: "Ruby Hoodie")

--- a/sample/db/samples/assets.rb
+++ b/sample/db/samples/assets.rb
@@ -20,7 +20,9 @@ products[:ruby_tote] = Spree::Product.find_by!(name: "Ruby Tote")
 def image(name, type = "jpg")
   images_path = Pathname.new(File.dirname(__FILE__)) + "images"
   path = images_path + "#{name}.#{type}"
+
   return false if !File.exist?(path)
+
   path
 end
 
@@ -103,7 +105,9 @@ products[:solidus_tshirt].variants.each do |variant|
     variant.images.create!(attachment: f)
   end
   back_image = image("solidus_tshirt_back_#{color}", "png")
+
   next unless back_image
+
   File.open(back_image) do |f|
     variant.images.create!(attachment: f)
   end
@@ -116,7 +120,9 @@ products[:solidus_long].variants.each do |variant|
     variant.images.create!(attachment: f)
   end
   back_image = image("solidus_long_back_#{color}", "png")
+
   next unless back_image
+
   File.open(back_image) do |f|
     variant.images.create!(attachment: f)
   end

--- a/sample/db/samples/variants.rb
+++ b/sample/db/samples/variants.rb
@@ -21,9 +21,7 @@ medium = Spree::OptionValue.find_by!(name: "Medium")
 large = Spree::OptionValue.find_by!(name: "Large")
 extra_large = Spree::OptionValue.find_by!(name: "Extra Large")
 
-red = Spree::OptionValue.find_by!(name: "Red")
 blue = Spree::OptionValue.find_by!(name: "Blue")
-green = Spree::OptionValue.find_by!(name: "Green")
 black = Spree::OptionValue.find_by!(name: "Black")
 white = Spree::OptionValue.find_by!(name: "White")
 


### PR DESCRIPTION
**Description**

While this doesn't actually fix the underlying problem as I wasn't able to determine what it was these changes appear to fix the flakiness of the sample loading (in my dev environment anyways).

This change adds a reload to products before assigning their variant images on the sample seeds loading. 

It also implements a couple minor rubocop and performance improvements noticed while troubleshooting the issue.

* Adds include statements to improve asset sample file performance, which also fixed option value lookup for the `solidus_tshirt` & `solidus_long` products. 
* Unfortunately the include statements just moved the bug to the `solidus_girly` product, but adding a `reload` before the variant lookup which fixed all three products works as a hack to fix the issue.
* Fixes Rubocop guard clause warnings
* Removes unused option value loading

Fixes #2978 

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
