### PR TITLE
Display error if editing non-current order

### DIFF
--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1086,6 +1086,7 @@ en:
     cannot_create_payment_without_payment_methods_html: You cannot create a payment
       for an order without any payment methods defined. %{link}
     cannot_create_returns: Cannot create returns as this order has no shipped units.
+    cannot_edit_orders: You may only edit your current shopping cart.
     cannot_perform_operation: Cannot perform requested operation
     cannot_rebuild_shipments_order_completed: Cannot rebuild shipments for a completed
       order.

--- a/frontend/app/controllers/spree/orders_controller.rb
+++ b/frontend/app/controllers/spree/orders_controller.rb
@@ -42,6 +42,10 @@ module Spree
       @order = current_order || Spree::Order.incomplete.find_or_initialize_by(guest_token: cookies.signed[:guest_token])
       authorize! :read, @order, cookies.signed[:guest_token]
       associate_user
+      if params[:id] && @order.number != params[:id]
+        flash[:error] = t('spree.cannot_edit_orders')
+        redirect_to cart_path
+      end
     end
 
     # Adds a new item to the order (creating a new order if none already exists)

--- a/frontend/spec/controllers/spree/orders_controller_spec.rb
+++ b/frontend/spec/controllers/spree/orders_controller_spec.rb
@@ -102,6 +102,31 @@ describe Spree::OrdersController, type: :controller do
       end
     end
 
+    context '#edit' do
+      before do
+        allow(controller).to receive :authorize!
+        allow(controller).to receive_messages current_order: order
+      end
+
+      it 'should render cart' do
+        get :edit, params: { id: order.number }
+
+        expect(flash[:error]).to be_nil
+        expect(response).to be_ok
+      end
+
+      context 'with another order number than the current_order' do
+        let(:other_order) { create(:completed_order_with_totals) }
+
+        it 'should display error message' do
+          get :edit, params: { id: other_order.number }
+
+          expect(flash[:error]).to eq "You may only edit your current shopping cart."
+          expect(response).to redirect_to cart_path
+        end
+      end
+    end
+
     context "#update" do
       context "with authorization" do
         before do


### PR DESCRIPTION
Users can input any order id within the orders controller routing, but
we simply render the cart with the current order. This can cause some
users confusion if they are expecting to edit an existing order after
viewing it's receipt.

So let's simply display a flash message indicating you cannot edit
existing orders if the routing id does not match the current order.

fixes #2078 

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
