### PR TITLE
Taking advantage of rails insert all to create inventory units

### DIFF
--- a/core/app/models/spree/inventory_unit.rb
+++ b/core/app/models/spree/inventory_unit.rb
@@ -118,6 +118,10 @@ module Spree
       on_hand?
     end
 
+    def value_attributes
+      attributes.slice('pending', 'state', 'variant_id', 'line_item_id', 'shipment_id')
+    end
+
     private
 
     def fulfill_order

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -1157,6 +1157,20 @@ RSpec.describe Spree::Order, type: :model do
 
       expect { shipment.reload }.not_to raise_error
     end
+
+    it "creates the right inventory units" do
+      order = create(:order_with_line_items)
+      order.create_proposed_shipments
+      expect(order.shipments.first.inventory_units.count).to be(1)
+    end
+
+    it "validates inventory units info" do
+      order = create(:order_with_line_items)
+      inventory_unit = Spree::InventoryUnit.new
+      shipment = build(:shipment, inventory_units: [inventory_unit])
+      allow_any_instance_of(Spree::Stock::SimpleCoordinator).to receive(:shipments).and_return([shipment])
+      expect { order.create_proposed_shipments }.to raise_error(ActiveRecord::RecordNotSaved)
+    end
   end
 
   describe "#all_inventory_units_returned?" do


### PR DESCRIPTION
**Description**
By default, rails saves automatically all the new objects recursively, in the case of
solidus, whenever the shipments are assigned to the order,  all dependent objects are
saved automatically,  but speaking about the inventory units, they get inserted one by one, 
we can take advantage of new Rails 6 insert_all functionality here to speed up the creation

**Checklist:**
- [ ] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [ ] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
