### PR TITLE
Add permission check for admins updating user passwords

### DIFF
--- a/backend/app/controllers/spree/admin/users_controller.rb
+++ b/backend/app/controllers/spree/admin/users_controller.rb
@@ -131,6 +131,10 @@ module Spree
           attributes += [{ spree_role_ids: [] }]
         end
 
+        unless can? :update_password, @user
+          attributes -= [:password, :password_confirmation]
+        end
+
         params.require(:user).permit(attributes)
       end
 

--- a/backend/app/views/spree/admin/users/_form.html.erb
+++ b/backend/app/views/spree/admin/users/_form.html.erb
@@ -60,18 +60,20 @@
   </div>
 
   <div data-hook="admin_user_form_password_fields" class="col-6">
-    <%= f.field_container :password do %>
-      <%= f.label :password %>
-      <%= f.password_field :password, class: 'fullwidth' %>
-      <%= f.error_message_on :password %>
-    <% end %>
-
-
-    <% if f.object.respond_to?(:password_confirmation) %>
+    <% if can? :update_password, @user %>
       <%= f.field_container :password do %>
-        <%= f.label :password_confirmation %>
-        <%= f.password_field :password_confirmation, class: 'fullwidth' %>
-        <%= f.error_message_on :password_confirmation %>
+        <%= f.label :password %>
+        <%= f.password_field :password, class: 'fullwidth' %>
+        <%= f.error_message_on :password %>
+      <% end %>
+
+
+      <% if f.object.respond_to?(:password_confirmation) %>
+        <%= f.field_container :password do %>
+          <%= f.label :password_confirmation %>
+          <%= f.password_field :password_confirmation, class: 'fullwidth' %>
+          <%= f.error_message_on :password_confirmation %>
+        <% end %>
       <% end %>
     <% end %>
   </div>

--- a/backend/spec/controllers/spree/admin/users_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/users_controller_spec.rb
@@ -202,6 +202,29 @@ describe Spree::Admin::UsersController, type: :controller do
       end
     end
 
+    context "allowed to update passwords" do
+      it "can change password of a user" do
+        expect {
+          put :update, params: { id: user.id, user: { password: "diff123", password_confirmation: "diff123" } }
+        }.to_not raise_error
+      end
+    end
+
+    context "not allowed to update passwords" do
+      stub_authorization! do |_user|
+        can [:admin, :update], Spree.user_class
+      end
+
+      it "cannot change password of a user" do
+        allow(ActionController::Parameters).
+          to receive(:action_on_unpermitted_parameters).and_return(:raise)
+
+        expect {
+          put :update, params: { id: user.id, user: { password: "diff123", password_confirmation: "diff123" } }
+        }.to raise_error(ActionController::UnpermittedParameters)
+      end
+    end
+
     it "can update ship_address attributes" do
       post :update, params: { id: user.id, user: { ship_address_attributes: valid_address_attributes } }
       expect(user.reload.ship_address.city).to eq('New York')

--- a/backend/spec/features/admin/users_spec.rb
+++ b/backend/spec/features/admin/users_spec.rb
@@ -158,14 +158,6 @@ describe 'Users', type: :feature do
       expect(page).to have_field('user_email', with: 'a@example.com99')
     end
 
-    it 'can edit the user password' do
-      fill_in 'user_password', with: 'welcome'
-      fill_in 'user_password_confirmation', with: 'welcome'
-      click_button 'Update'
-
-      expect(page).to have_text 'Account updated'
-    end
-
     it 'can edit user roles' do
       click_link 'Account'
 
@@ -211,6 +203,24 @@ describe 'Users', type: :feature do
       end
 
       expect(user_a.reload.bill_address.address1).to eq "1313 Mockingbird Ln"
+    end
+
+    it 'can edit the user password' do
+      fill_in 'user_password', with: 'welcome'
+      fill_in 'user_password_confirmation', with: 'welcome'
+      click_button 'Update'
+
+      expect(page).to have_text 'Account updated'
+    end
+
+    context 'without password permissions' do
+      custom_authorization! do |_user|
+        cannot [:update_password], Spree.user_class
+      end
+
+      it 'cannot edit the user password' do
+        expect(page).to_not have_text 'Password'
+      end
     end
 
     context 'invalid entry' do

--- a/core/lib/spree/permission_sets/user_management.rb
+++ b/core/lib/spree/permission_sets/user_management.rb
@@ -11,6 +11,9 @@ module Spree
         can :update_email, Spree.user_class do |user|
           user.spree_roles.none?
         end
+        can :update_password, Spree.user_class do |user|
+          user.spree_roles.none?
+        end
 
         cannot [:delete, :destroy], Spree.user_class
         can :manage, Spree::StoreCredit

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -117,10 +117,10 @@ module Spree
       :meta_description, :meta_keywords, :meta_title, :child_index
     ]
 
-    # intentionally leaving off email here to prevent privilege escalation
+    # Intentionally leaving off email here to prevent privilege escalation
     # by changing a user with higher priveleges' email to one a lower-priveleged
-    # admin owns. creating a user with an email is handled separate at the
-    # controller level
+    # admin owns. Creating a user with an email is handled separate at the
+    # controller level.
     @@user_attributes = [:password, :password_confirmation]
 
     @@variant_attributes = [

--- a/core/spec/models/spree/permission_sets/user_management_spec.rb
+++ b/core/spec/models/spree/permission_sets/user_management_spec.rb
@@ -25,11 +25,13 @@ RSpec.describe Spree::PermissionSets::UserManagement do
     context 'when the user does not have a role' do
       let(:user) { create(:user) }
       it { is_expected.to be_able_to(:update_email, user) }
+      it { is_expected.to be_able_to(:update_password, user) }
     end
 
     context 'when the user has a role' do
       let(:user) { create(:user, spree_roles: [create(:role)]) }
       it { is_expected.not_to be_able_to(:update_email, user) }
+      it { is_expected.not_to be_able_to(:update_password, user) }
     end
 
     it { is_expected.not_to be_able_to(:delete, Spree.user_class) }


### PR DESCRIPTION
For security purposes administrators should not be able to set a
users password. Only the accounts owner should be able to directly set
their password. administrators should only have the ability to send a
password reset email to the account owner. Otherwise someone working in
customer service or another role could take over a users account in
order to make illegal purchases with their stored credit card
information.

In order to maintain backwards compatibility, and leave more power in
control of the store owner this will leave the current admin role
behavior the same, but anyone creating custom roles will no longer
be able to update passwords unless they explicitly add a change
password permission.

Fixes #438 

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
