### PR TITLE
Remove Deprecated EmailValidator

### DIFF
--- a/core/lib/spree/core/validators/email.rb
+++ b/core/lib/spree/core/validators/email.rb
@@ -21,10 +21,3 @@ module Spree
     end
   end
 end
-
-# @private
-EmailValidator = ActiveSupport::Deprecation::DeprecatedConstantProxy.new(
-  'EmailValidator',
-  'Spree::EmailValidator',
-  message: "EmailValidator is deprecated! Use Spree::EmailValidator instead.\nChange `validates :email, email: true` to `validates :email, 'spree/email' => true`\n"
-)

--- a/core/lib/spree/core/validators/email.rb
+++ b/core/lib/spree/core/validators/email.rb
@@ -15,7 +15,7 @@ module Spree
     EMAIL_REGEXP = /\A([^@\.]|[^@\.]([^@\s]*)[^@\.])@([^@\s]+\.)+[^@\s]+\z/
 
     def validate_each(record, attribute, value)
-      unless value =~ EMAIL_REGEXP
+      unless EMAIL_REGEXP.match? value
         record.errors.add(attribute, :invalid, { value: value }.merge!(options))
       end
     end

--- a/core/spec/lib/spree/core/validators/email_spec.rb
+++ b/core/spec/lib/spree/core/validators/email_spec.rb
@@ -12,27 +12,27 @@ RSpec.describe Spree::EmailValidator do
 
   let(:valid_emails) {
     [
-    'valid@email.com',
-    'valid@email.com.uk',
-    'e@email.com',
-    'valid+email@email.com',
-    'valid-email@email.com',
-    'valid_email@email.com',
-    'valid.email@email.com'
-  ]
+      'valid@email.com',
+      'valid@email.com.uk',
+      'e@email.com',
+      'valid+email@email.com',
+      'valid-email@email.com',
+      'valid_email@email.com',
+      'valid.email@email.com'
+    ]
   }
   let(:invalid_emails) {
     [
-    'invalid email@email.com',
-    '.invalid.email@email.com',
-    'invalid.email.@email.com',
-    '@email.com',
-    '.@email.com',
-    'invalidemailemail.com',
-    '@invalid.email@email.com',
-    'invalid@email@email.com',
-    'invalid.email@@email.com'
-  ]
+      'invalid email@email.com',
+      '.invalid.email@email.com',
+      'invalid.email.@email.com',
+      '@email.com',
+      '.@email.com',
+      'invalidemailemail.com',
+      '@invalid.email@email.com',
+      'invalid@email@email.com',
+      'invalid.email@@email.com'
+    ]
   }
 
   it 'validates valid email addresses' do


### PR DESCRIPTION
**Description**

The email validator was deprecated Mar 15th 2018 almost 18 months ago
as part of: 6d8fd3c

The deprecation warning was part of v2.6.0rc1, and remains to this day
in v2.10.0.beta1 I think it's time to remove it altogether. It's been
4 minor version upgrades now.

Fixes #1794

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
