### PR TITLE
Update one letter variables to be more descriptive

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,6 +27,10 @@ Style/ClassVars:
 Naming/PredicateName:
   Enabled: false
 
+# We want to name rescued errors as error not simply e.
+Naming/RescuedExceptionsVariableName:
+  Enabled: false
+
 Naming/AccessorMethodName:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -121,6 +121,11 @@ Rails/DynamicFindBy:
     - find_by_param
     - find_by_param!
 
+# It's okay to skip model validations to setup a spec.
+Rails/SkipsModelValidations:
+  Exclude:
+    - '*/spec/**/*'
+
 # We use a lot of
 #
 #     expect {

--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -164,8 +164,8 @@ module Spree
 
       def lock_order
         OrderMutex.with_lock!(@order) { yield }
-      rescue Spree::OrderMutex::LockFailed => e
-        render plain: e.message, status: 409
+      rescue Spree::OrderMutex::LockFailed => error
+        render plain: error.message, status: 409
       end
 
       def insufficient_stock_error(exception)

--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -112,7 +112,7 @@ module Spree
 
       def spree_token
         token = request.headers["X-Spree-Token"]
-        return unless token.present?
+        return if token.blank?
 
         Spree::Deprecation.warn(
           'The custom X-Spree-Token request header is deprecated and will be removed in the next release.' \

--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -49,9 +49,9 @@ module Spree
       def authenticate_user
         unless @current_api_user
           if requires_authentication? && api_key.blank? && order_token.blank?
-            render "spree/api/errors/must_specify_api_key", status: 401
+            render "spree/api/errors/must_specify_api_key", status: :unauthorized
           elsif order_token.blank? && (requires_authentication? || api_key.present?)
-            render "spree/api/errors/invalid_api_key", status: 401
+            render "spree/api/errors/invalid_api_key", status: :unauthorized
           end
         end
       end
@@ -65,7 +65,7 @@ module Spree
       end
 
       def unauthorized
-        render "spree/api/errors/unauthorized", status: 401
+        render "spree/api/errors/unauthorized", status: :unauthorized
       end
 
       def gateway_error(exception)
@@ -78,7 +78,7 @@ module Spree
           exception: exception.message,
           error: exception.message,
           missing_param: exception.param
-        }, status: 422
+        }, status: :unprocessable_entity
       end
 
       def requires_authentication?
@@ -86,7 +86,7 @@ module Spree
       end
 
       def not_found
-        render "spree/api/errors/not_found", status: 404
+        render "spree/api/errors/not_found", status: :not_found
       end
 
       def current_ability
@@ -96,7 +96,7 @@ module Spree
       def invalid_resource!(resource)
         Rails.logger.error "invalid_resouce_errors=#{resource.errors.full_messages}"
         @resource = resource
-        render "spree/api/errors/invalid_resource", status: 422
+        render "spree/api/errors/invalid_resource", status: :unprocessable_entity
       end
 
       def api_key
@@ -165,7 +165,7 @@ module Spree
       def lock_order
         OrderMutex.with_lock!(@order) { yield }
       rescue Spree::OrderMutex::LockFailed => error
-        render plain: error.message, status: 409
+        render plain: error.message, status: :conflict
       end
 
       def insufficient_stock_error(exception)
@@ -175,7 +175,7 @@ module Spree
             errors: [I18n.t(:quantity_is_not_available, scope: "spree.api.order")],
             type: 'insufficient_stock'
           },
-          status: 422
+          status: :unprocessable_entity
         )
       end
 

--- a/api/app/controllers/spree/api/checkouts_controller.rb
+++ b/api/app/controllers/spree/api/checkouts_controller.rb
@@ -23,8 +23,8 @@ module Spree
         authorize! :update, @order, order_token
         @order.next!
         respond_with(@order, default_template: 'spree/api/orders/show', status: 200)
-      rescue StateMachines::InvalidTransition => e
-        logger.error("invalid_transition #{e.event} from #{e.from} for #{e.object.class.name}. Error: #{e.inspect}")
+      rescue StateMachines::InvalidTransition => error
+        logger.error("invalid_transition #{error.event} from #{error.from} for #{error.object.class.name}. Error: #{error.inspect}")
         respond_with(@order, default_template: 'spree/api/orders/could_not_transition', status: 422)
       end
 
@@ -42,8 +42,8 @@ module Spree
           @order.complete!
           respond_with(@order, default_template: 'spree/api/orders/show', status: 200)
         end
-      rescue StateMachines::InvalidTransition => e
-        logger.error("invalid_transition #{e.event} from #{e.from} for #{e.object.class.name}. Error: #{e.inspect}")
+      rescue StateMachines::InvalidTransition => error
+        logger.error("invalid_transition #{error.event} from #{error.from} for #{error.object.class.name}. Error: #{error.inspect}")
         respond_with(@order, default_template: 'spree/api/orders/could_not_transition', status: 422)
       end
 

--- a/api/app/helpers/spree/api/api_helpers.rb
+++ b/api/app/helpers/spree/api/api_helpers.rb
@@ -40,7 +40,7 @@ module Spree
 
       def required_fields_for(model)
         required_fields = model._validators.select do |_field, validations|
-          validations.any? { |v| v.is_a?(ActiveModel::Validations::PresenceValidator) }
+          validations.any? { |validation| validation.is_a?(ActiveModel::Validations::PresenceValidator) }
         end.map(&:first) # get fields that are invalid
         # Permalinks presence is validated, but are really automatically generated
         # Therefore we shouldn't tell API clients that they MUST send one through

--- a/api/app/views/spree/api/images/_image.json.jbuilder
+++ b/api/app/views/spree/api/images/_image.json.jbuilder
@@ -2,6 +2,6 @@
 
 json.(image, *image_attributes)
 json.(image, :viewable_type, :viewable_id)
-Spree::Image.attachment_definitions[:attachment][:styles].each do |k, _v|
-  json.set! "#{k}_url", image.attachment.url(k)
+Spree::Image.attachment_definitions[:attachment][:styles].each do |key, _value|
+  json.set! "#{key}_url", image.attachment.url(key)
 end

--- a/api/spec/controllers/spree/api/resource_controller_spec.rb
+++ b/api/spec/controllers/spree/api/resource_controller_spec.rb
@@ -25,10 +25,10 @@ module Spree
     end
 
     with_model 'Widget', scope: :all do
-      table do |t|
-        t.string :name
-        t.integer :position
-        t.timestamps null: false
+      table do |widget|
+        widget.string :name
+        widget.integer :position
+        widget.timestamps null: false
       end
 
       model do

--- a/api/spec/requests/api/address_books_spec.rb
+++ b/api/spec/requests/api/address_books_spec.rb
@@ -80,7 +80,7 @@ module Spree
             user_address = UserAddress.last
 
             expect(response.status).to eq(200)
-            update_target_ids = JSON.parse(response.body).select { |a| a['update_target'] }.map { |a| a['id'] }
+            update_target_ids = JSON.parse(response.body).select { |target| target['update_target'] }.map { |location| location['id'] }
             expect(update_target_ids).to eq([user_address.address_id])
           end
         end
@@ -97,7 +97,7 @@ module Spree
             }.to_not change { UserAddress.count }
 
             expect(response.status).to eq(200)
-            update_target_ids = JSON.parse(response.body).select { |a| a['update_target'] }.map { |a| a['id'] }
+            update_target_ids = JSON.parse(response.body).select { |target| target['update_target'] }.map { |location| location['id'] }
             expect(update_target_ids).to eq([address.id])
           end
         end

--- a/api/spec/requests/spree/api/checkouts_controller_spec.rb
+++ b/api/spec/requests/spree/api/checkouts_controller_spec.rb
@@ -132,9 +132,9 @@ module Spree
         put spree.api_checkout_path(order.to_param), params: { order_token: order.guest_token, order: { shipments_attributes: { "0" => { selected_shipping_rate_id: shipping_rate.id, id: shipment.id } } } }
         expect(response.status).to eq(200)
         # Find the correct shipment...
-        json_shipment = json_response['shipments'].detect { |s| s["id"] == shipment.id }
+        json_shipment = json_response['shipments'].detect { |value| value["id"] == shipment.id }
         # Find the correct shipping rate for that shipment...
-        json_shipping_rate = json_shipment['shipping_rates'].detect { |sr| sr["id"] == shipping_rate.id }
+        json_shipping_rate = json_shipment['shipping_rates'].detect { |value| value["id"] == shipping_rate.id }
         # ... And finally ensure that it's selected
         expect(json_shipping_rate['selected']).to be true
         # Order should automatically transfer to payment because all criteria are met

--- a/api/spec/requests/spree/api/option_types_controller_spec.rb
+++ b/api/spec/requests/spree/api/option_types_controller_spec.rb
@@ -34,9 +34,9 @@ module Spree
     end
 
     it "can retrieve a list of specific option types" do
-      option_type_1 = create(:option_type)
+      option_type_one = create(:option_type)
       create(:option_type)
-      get spree.api_option_types_path, params: { ids: "#{option_type.id},#{option_type_1.id}" }
+      get spree.api_option_types_path, params: { ids: "#{option_type.id},#{option_type_one.id}" }
       expect(json_response.count).to eq(2)
 
       check_option_values(json_response.first["option_values"])

--- a/api/spec/requests/spree/api/option_values_controller_spec.rb
+++ b/api/spec/requests/spree/api/option_values_controller_spec.rb
@@ -48,9 +48,9 @@ module Spree
       end
 
       it "can retrieve a list of option types" do
-        option_value_1 = create(:option_value, option_type: option_type)
+        option_value_one = create(:option_value, option_type: option_type)
         create(:option_value, option_type: option_type)
-        get spree.api_option_values_path, params: { ids: [option_value.id, option_value_1.id] }
+        get spree.api_option_values_path, params: { ids: [option_value.id, option_value_one.id] }
         expect(json_response.count).to eq(2)
       end
 

--- a/api/spec/requests/spree/api/orders_controller_spec.rb
+++ b/api/spec/requests/spree/api/orders_controller_spec.rb
@@ -246,12 +246,12 @@ module Spree
       it "returns orders in reverse chronological order by completed_at" do
         order.update_columns completed_at: Time.current, created_at: 3.days.ago
 
-        order2 = Order.create user: order.user, completed_at: Time.current - 1.day, created_at: 2.day.ago, store: store
-        expect(order2.created_at).to be > order.created_at
-        order3 = Order.create user: order.user, completed_at: nil, created_at: 1.day.ago, store: store
-        expect(order3.created_at).to be > order2.created_at
-        order4 = Order.create user: order.user, completed_at: nil, created_at: 0.days.ago, store: store
-        expect(order4.created_at).to be > order3.created_at
+        order_two = Order.create user: order.user, completed_at: Time.current - 1.day, created_at: 2.day.ago, store: store
+        expect(order_two.created_at).to be > order.created_at
+        order_three = Order.create user: order.user, completed_at: nil, created_at: 1.day.ago, store: store
+        expect(order_three.created_at).to be > order_two.created_at
+        order_four = Order.create user: order.user, completed_at: nil, created_at: 0.days.ago, store: store
+        expect(order_four.created_at).to be > order_three.created_at
 
         get spree.api_my_orders_path, headers: { 'SERVER_NAME' => store.url }
         expect(response.status).to eq(200)
@@ -259,8 +259,8 @@ module Spree
         orders = json_response["orders"]
         expect(orders.length).to eq(4)
         expect(orders[0]["number"]).to eq(order.number)
-        expect(orders[1]["number"]).to eq(order2.number)
-        expect([orders[2]["number"], orders[3]["number"]]).to match_array([order3.number, order4.number])
+        expect(orders[1]["number"]).to eq(order_two.number)
+        expect([orders[2]["number"], orders[3]["number"]]).to match_array([order_three.number, order_four.number])
       end
     end
 
@@ -502,18 +502,18 @@ module Spree
       end
 
       it "adds an extra line item" do
-        variant2 = create(:variant)
+        variant_two = create(:variant)
         put spree.api_order_path(order), params: { order: {
           line_items: {
             "0" => { id: line_item.id, quantity: 10 },
-            "1" => { variant_id: variant2.id, quantity: 1 }
+            "1" => { variant_id: variant_two.id, quantity: 1 }
           }
         } }
 
         expect(response.status).to eq(200)
         expect(json_response['line_items'].count).to eq(2)
         expect(json_response['line_items'][0]['quantity']).to eq(10)
-        expect(json_response['line_items'][1]['variant_id']).to eq(variant2.id)
+        expect(json_response['line_items'][1]['variant_id']).to eq(variant_two.id)
         expect(json_response['line_items'][1]['quantity']).to eq(1)
       end
 
@@ -727,7 +727,7 @@ module Spree
 
           orders = json_response[:orders]
           expect(orders.count).to be >= 3
-          expect(orders.map { |o| o[:id] }).to match_array Order.pluck(:id)
+          expect(orders.map { |order| order[:id] }).to match_array Order.pluck(:id)
         end
 
         after { ActionController::Base.perform_caching = false }

--- a/api/spec/requests/spree/api/orders_controller_spec.rb
+++ b/api/spec/requests/spree/api/orders_controller_spec.rb
@@ -246,7 +246,7 @@ module Spree
       it "returns orders in reverse chronological order by completed_at" do
         order.update_columns completed_at: Time.current, created_at: 3.days.ago
 
-        order_two = Order.create user: order.user, completed_at: Time.current - 1.day, created_at: 2.day.ago, store: store
+        order_two = Order.create user: order.user, completed_at: Time.current - 1.day, created_at: 2.days.ago, store: store
         expect(order_two.created_at).to be > order.created_at
         order_three = Order.create user: order.user, completed_at: nil, created_at: 1.day.ago, store: store
         expect(order_three.created_at).to be > order_two.created_at

--- a/api/spec/requests/spree/api/products_controller_spec.rb
+++ b/api/spec/requests/spree/api/products_controller_spec.rb
@@ -17,8 +17,8 @@ module Spree
         shipping_category_id: create(:shipping_category).id }
     end
     let(:attributes_for_variant) do
-      h = attributes_for(:variant).except(:option_values, :product)
-      h.merge({
+      attributes = attributes_for(:variant).except(:option_values, :product)
+      attributes.merge({
         options: [
           { name: "size", value: "small" },
           { name: "color", value: "black" }
@@ -40,7 +40,7 @@ module Spree
 
         it "returns unique products" do
           get spree.api_products_path
-          product_ids = json_response["products"].map { |p| p["id"] }
+          product_ids = json_response["products"].map { |product| product["id"] }
           expect(product_ids.uniq.count).to eq(product_ids.count)
         end
 
@@ -361,8 +361,8 @@ module Spree
           expect(response.status).to eq 200
           expect(json_response['variants'].count).to eq(2) # 2 variants
 
-          variants = json_response['variants'].reject { |v| v['is_master'] }
-          size_option_value = variants.last['option_values'].detect{ |x| x['option_type_name'] == 'size' }
+          variants = json_response['variants'].reject { |variant| variant['is_master'] }
+          size_option_value = variants.last['option_values'].detect{ |value| value['option_type_name'] == 'size' }
           expect(size_option_value['name']).to eq('small')
 
           expect(json_response['option_types'].count).to eq(2) # size, color
@@ -385,7 +385,7 @@ module Spree
           } }
 
           expect(json_response['variants'].count).to eq(1)
-          variants = json_response['variants'].reject { |v| v['is_master'] }
+          variants = json_response['variants'].reject { |variant| variant['is_master'] }
           expect(variants.last['option_values'][0]['name']).to eq('large')
           expect(variants.last['sku']).to eq('456')
           expect(variants.count).to eq(1)

--- a/api/spec/requests/spree/api/taxons_controller_spec.rb
+++ b/api/spec/requests/spree/api/taxons_controller_spec.rb
@@ -93,9 +93,9 @@ module Spree
         it 'returns only requested ids' do
           # We need a completly new branch to avoid having parent that can be preloaded from the rails ancestors
           python   = create(:taxon, name: "Python", parent: taxonomy.root, taxonomy: taxonomy)
-          python_3 = create(:taxon, name: "3.0", parent: python, taxonomy: taxonomy)
+          python_three = create(:taxon, name: "3.0", parent: python, taxonomy: taxonomy)
 
-          get spree.api_taxons_path, params: { ids: [rails_v3_2_2.id, python_3.id] }
+          get spree.api_taxons_path, params: { ids: [rails_v3_2_2.id, python_three.id] }
 
           expect(json_response['taxons'].size).to eq 2
         end

--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -105,8 +105,8 @@ module Spree
         @order.complete!
         flash[:success] = t('spree.order_completed')
         redirect_to edit_admin_order_url(@order)
-      rescue StateMachines::InvalidTransition => e
-        flash[:error] = e.message
+      rescue StateMachines::InvalidTransition => error
+        flash[:error] = error.message
         redirect_to confirm_admin_order_url(@order)
       end
 

--- a/backend/app/controllers/spree/admin/payment_methods_controller.rb
+++ b/backend/app/controllers/spree/admin/payment_methods_controller.rb
@@ -28,9 +28,9 @@ module Spree
         invoke_callbacks(:update, :before)
 
         attributes = payment_method_params
-        attributes.each do |k, _v|
-          if k.include?("password") && attributes[k].blank?
-            attributes.delete(k)
+        attributes.each do |key, _value|
+          if key.include?("password") && attributes[key].blank?
+            attributes.delete(key)
           end
         end
 

--- a/backend/app/controllers/spree/admin/payments_controller.rb
+++ b/backend/app/controllers/spree/admin/payments_controller.rb
@@ -46,8 +46,8 @@ module Spree
             flash[:error] = t('spree.payment_could_not_be_created')
             render :new
           end
-        rescue Spree::Core::GatewayError => e
-          flash[:error] = e.message.to_s
+        rescue Spree::Core::GatewayError => error
+          flash[:error] = error.message.to_s
           redirect_to new_admin_order_payment_path(@order)
         end
       end

--- a/core/app/helpers/spree/products_helper.rb
+++ b/core/app/helpers/spree/products_helper.rb
@@ -37,6 +37,7 @@ module Spree
       return if variant.product.variants
                   .with_prices(current_pricing_options)
                   .all? { |variant_with_prices| variant_with_prices.price_same_as_master?(current_pricing_options) }
+
       variant.price_for(current_pricing_options).to_html
     end
 

--- a/core/app/jobs/spree/promotion_code_batch_job.rb
+++ b/core/app/jobs/spree/promotion_code_batch_job.rb
@@ -14,13 +14,13 @@ module Spree
           .promotion_code_batch_finished(promotion_code_batch)
           .deliver_now
       end
-    rescue StandardError => e
+    rescue StandardError => error
       if promotion_code_batch.email?
         Spree::Config.promotion_code_batch_mailer_class
           .promotion_code_batch_errored(promotion_code_batch)
           .deliver_now
       end
-      raise e
+      raise error
     end
   end
 end

--- a/core/app/models/concerns/spree/user_methods.rb
+++ b/core/app/models/concerns/spree/user_methods.rb
@@ -74,7 +74,7 @@ module Spree
 
     def available_store_credit_total(currency:)
       store_credits.reload.to_a.
-        select { |c| c.currency == currency }.
+        select { |credit| credit.currency == currency }.
         sum(&:amount_remaining)
     end
 

--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -121,7 +121,7 @@ module Spree
     # @deprecated Do not use this
     def empty?
       Spree::Deprecation.warn("Address#empty? is deprecated.", caller)
-      attributes.except('id', 'created_at', 'updated_at', 'country_id').all? { |_, v| v.nil? }
+      attributes.except('id', 'created_at', 'updated_at', 'country_id').all? { |_, value| value.nil? }
     end
 
     # This exists because the default Object#blank?, checks empty? if it is

--- a/core/app/models/spree/calculator/price_sack.rb
+++ b/core/app/models/spree/calculator/price_sack.rb
@@ -12,7 +12,7 @@ module Spree
     # as object we always get line items, as calculable we have Coupon, ShippingMethod
     def compute(object)
       if object.is_a?(Array)
-        base = object.map { |o| o.respond_to?(:amount) ? o.amount : BigDecimal(o.to_s) }.sum
+        base = object.map { |element| element.respond_to?(:amount) ? element.amount : BigDecimal(element.to_s) }.sum
       else
         base = object.respond_to?(:amount) ? object.amount : BigDecimal(object.to_s)
       end

--- a/core/app/models/spree/calculator/shipping/flexi_rate.rb
+++ b/core/app/models/spree/calculator/shipping/flexi_rate.rb
@@ -18,9 +18,9 @@ module Spree
       def compute_from_quantity(quantity)
         sum = 0
         max = preferred_max_items.to_i
-        quantity.times do |i|
+        quantity.times do |index|
           # check max value to avoid divide by 0 errors
-          if (max == 0 && i == 0) || (max > 0) && (i % max == 0)
+          if (max == 0 && index == 0) || (max > 0) && (index % max == 0)
             sum += preferred_first_item.to_f
           else
             sum += preferred_additional_item.to_f

--- a/core/app/models/spree/calculator/tiered_flat_rate.rb
+++ b/core/app/models/spree/calculator/tiered_flat_rate.rb
@@ -11,8 +11,8 @@ module Spree
     before_validation do
       # Convert tier values to decimals. Strings don't do us much good.
       if preferred_tiers.is_a?(Hash)
-        self.preferred_tiers = preferred_tiers.map do |k, v|
-          [cast_to_d(k.to_s), cast_to_d(v.to_s)]
+        self.preferred_tiers = preferred_tiers.map do |key, value|
+          [cast_to_d(key.to_s), cast_to_d(value.to_s)]
         end.to_h
       end
     end
@@ -20,8 +20,8 @@ module Spree
     validate :preferred_tiers_content
 
     def compute(object)
-      _base, amount = preferred_tiers.sort.reverse.detect do |b, _|
-        object.amount >= b
+      _base, amount = preferred_tiers.sort.reverse.detect do |value, _|
+        object.amount >= value
       end
 
       if preferred_currency.casecmp(object.currency).zero?
@@ -41,7 +41,7 @@ module Spree
 
     def preferred_tiers_content
       if preferred_tiers.is_a? Hash
-        unless preferred_tiers.keys.all?{ |k| k.is_a?(Numeric) && k > 0 }
+        unless preferred_tiers.keys.all?{ |key| key.is_a?(Numeric) && key > 0 }
           errors.add(:base, :keys_should_be_positive_number)
         end
       else

--- a/core/app/models/spree/calculator/tiered_percent.rb
+++ b/core/app/models/spree/calculator/tiered_percent.rb
@@ -11,8 +11,8 @@ module Spree
     before_validation do
       # Convert tier values to decimals. Strings don't do us much good.
       if preferred_tiers.is_a?(Hash)
-        self.preferred_tiers = preferred_tiers.map do |k, v|
-          [cast_to_d(k.to_s), cast_to_d(v.to_s)]
+        self.preferred_tiers = preferred_tiers.map do |key, value|
+          [cast_to_d(key.to_s), cast_to_d(value.to_s)]
         end.to_h
       end
     end
@@ -26,8 +26,8 @@ module Spree
     def compute(object)
       order = object.is_a?(Order) ? object : object.order
 
-      _base, percent = preferred_tiers.sort.reverse.detect do |b, _|
-        order.item_total >= b
+      _base, percent = preferred_tiers.sort.reverse.detect do |value, _|
+        order.item_total >= value
       end
 
       if preferred_currency.casecmp(order.currency).zero?
@@ -48,10 +48,10 @@ module Spree
 
     def preferred_tiers_content
       if preferred_tiers.is_a? Hash
-        unless preferred_tiers.keys.all?{ |k| k.is_a?(Numeric) && k > 0 }
+        unless preferred_tiers.keys.all?{ |key| key.is_a?(Numeric) && key > 0 }
           errors.add(:base, :keys_should_be_positive_number)
         end
-        unless preferred_tiers.values.all?{ |k| k.is_a?(Numeric) && k >= 0 && k <= 100 }
+        unless preferred_tiers.values.all?{ |key| key.is_a?(Numeric) && key >= 0 && key <= 100 }
           errors.add(:base, :values_should_be_percent)
         end
       else

--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -72,7 +72,7 @@ module Spree
     # @return [BigDecimal] the amount of this item, taking into consideration
     #   all non-tax adjustments.
     def total_before_tax
-      amount + adjustments.select { |a| !a.tax? && a.eligible? }.sum(&:amount)
+      amount + adjustments.select { |value| !value.tax? && value.eligible? }.sum(&:amount)
     end
 
     # @return [BigDecimal] the amount of this line item before VAT tax

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -531,7 +531,7 @@ module Spree
     def create_proposed_shipments
       if completed?
         raise CannotRebuildShipments.new(I18n.t('spree.cannot_rebuild_shipments_order_completed'))
-      elsif shipments.any? { |s| !s.pending? }
+      elsif shipments.any? { |shipment| !shipment.pending? }
         raise CannotRebuildShipments.new(I18n.t('spree.cannot_rebuild_shipments_shipments_not_pending'))
       else
         shipments.destroy_all

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -41,7 +41,7 @@ module Spree
           # On first definition, state_machines will not be defined
           state_machines.clear if respond_to?(:state_machines)
           state_machine :state, initial: :cart, use_transactions: false do
-            klass.next_event_transitions.each { |t| transition(t.merge(on: :next)) }
+            klass.next_event_transitions.each { |state| transition(state.merge(on: :next)) }
 
             # Persist the state on the order
             after_transition do |order, transition|

--- a/core/app/models/spree/order/payments.rb
+++ b/core/app/models/spree/order/payments.rb
@@ -46,9 +46,9 @@ module Spree
 
           payment.public_send(method)
         end
-      rescue Core::GatewayError => e
+      rescue Core::GatewayError => error
         result = !!Spree::Config[:allow_checkout_on_gateway_error]
-        errors.add(:base, e.message) && (return result)
+        errors.add(:base, error.message) && (return result)
       end
     end
   end

--- a/core/app/models/spree/order_capturing.rb
+++ b/core/app/models/spree/order_capturing.rb
@@ -41,8 +41,8 @@ class Spree::OrderCapturing
   private
 
   def sorted_payments(order)
-    order.payments.pending.sort_by do |p|
-      [@sorted_payment_method_classes.index(p.payment_method.class), p.id]
+    order.payments.pending.sort_by do |payment|
+      [@sorted_payment_method_classes.index(payment.payment_method.class), payment.id]
     end
   end
 end

--- a/core/app/models/spree/order_taxation.rb
+++ b/core/app/models/spree/order_taxation.rb
@@ -25,12 +25,12 @@ module Spree
     # @return [void]
     def apply(taxes)
       @order.line_items.each do |item|
-        taxed_items = taxes.line_item_taxes.select { |i| i.item_id == item.id }
+        taxed_items = taxes.line_item_taxes.select { |element| element.item_id == item.id }
         update_adjustments(item, taxed_items)
       end
 
       @order.shipments.each do |item|
-        taxed_items = taxes.shipment_taxes.select { |i| i.item_id == item.id }
+        taxed_items = taxes.shipment_taxes.select { |element| element.item_id == item.id }
         update_adjustments(item, taxed_items)
       end
     end

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -47,7 +47,7 @@ module Spree
     default_scope -> { order(:created_at) }
 
     scope :from_credit_card, -> { where(source_type: 'Spree::CreditCard') }
-    scope :with_state, ->(s) { where(state: s.to_s) }
+    scope :with_state, ->(state) { where(state: state.to_s) }
     # "offset" is reserved by activerecord
     scope :offset_payment, -> { where("source_type = 'Spree::Payment' AND amount < 0 AND state = 'completed'") }
 
@@ -195,8 +195,8 @@ module Spree
       return if source.imported
 
       payment_method.create_profile(self)
-    rescue ActiveMerchant::ConnectionError => e
-      gateway_error e
+    rescue ActiveMerchant::ConnectionError => error
+      gateway_error error
     end
 
     def invalidate_old_payments

--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -199,8 +199,8 @@ module Spree
 
       def protect_from_connection_error
           yield
-      rescue ActiveMerchant::ConnectionError => e
-          gateway_error(e)
+      rescue ActiveMerchant::ConnectionError => error
+          gateway_error(error)
       end
 
       def gateway_error(error)

--- a/core/app/models/spree/payment_method.rb
+++ b/core/app/models/spree/payment_method.rb
@@ -93,8 +93,8 @@ module Spree
           else
             active.available_to_users.available_to_admin
           end
-        available_payment_methods.select do |p|
-          store.nil? || store.payment_methods.empty? || store.payment_methods.include?(p)
+        available_payment_methods.select do |payment|
+          store.nil? || store.payment_methods.empty? || store.payment_methods.include?(payment)
         end
       end
 

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -190,7 +190,7 @@ module Spree
     # @return [Hash] option_type as keys, array of variants as values.
     def categorise_variants_from_option(opt_type, pricing_options = Spree::Config.default_pricing_options)
       return {} unless option_types.include?(opt_type)
-      variants.with_prices(pricing_options).group_by { |v| v.option_values.detect { |o| o.option_type == opt_type } }
+      variants.with_prices(pricing_options).group_by { |variant| variant.option_values.detect { |option| option.option_type == opt_type } }
     end
     deprecate :categorise_variants_from_option, deprecator: Spree::Deprecation
 
@@ -323,7 +323,7 @@ module Spree
 
     def any_variants_not_track_inventory?
       if variants_including_master.loaded?
-        variants_including_master.any? { |v| !v.should_track_inventory? }
+        variants_including_master.any? { |variant| !variant.should_track_inventory? }
       else
         !Spree::Config.track_inventory_levels || variants_including_master.where(track_inventory: false).exists?
       end

--- a/core/app/models/spree/product/scopes.rb
+++ b/core/app/models/spree/product/scopes.rb
@@ -241,19 +241,20 @@ module Spree
             # Always return array with at least an empty string to avoid SQL errors
             def prepare_words(words)
               return [''] if words.blank?
-              a = words.split(/[,\s]/).map(&:strip)
-              a.any? ? a : ['']
+
+              splitted = words.split(/[,\s]/).map(&:strip)
+              splitted.any? ? splitted : ['']
             end
 
             def get_taxons(*ids_or_records_or_names)
               taxons = Spree::Taxon.table_name
-              ids_or_records_or_names.flatten.map { |t|
-                case t
-                when Integer then Spree::Taxon.find_by(id: t)
+              ids_or_records_or_names.flatten.map { |taxon|
+                case taxon
+                when Integer then Spree::Taxon.find_by(id: taxon)
                 when ActiveRecord::Base then t
                 when String
-                  Spree::Taxon.find_by(name: t) ||
-                    Spree::Taxon.where("#{taxons}.permalink LIKE ? OR #{taxons}.permalink = ?", "%/#{t}/", "#{t}/").first
+                  Spree::Taxon.find_by(name: taxon) ||
+                    Spree::Taxon.where("#{taxons}.permalink LIKE ? OR #{taxons}.permalink = ?", "%/#{taxon}/", "#{taxon}/").first
                 end
               }.compact.flatten.uniq
             end

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -138,7 +138,7 @@ module Spree
     def eligible_rules(promotable, options = {})
       # Promotions without rules are eligible by default.
       return [] if rules.none?
-      eligible = lambda { |r| r.eligible?(promotable, options) }
+      eligible = lambda { |rule| rule.eligible?(promotable, options) }
       specific_rules = rules.for(promotable)
       return [] if specific_rules.none?
 

--- a/core/app/models/spree/promotion/actions/create_quantity_adjustments.rb
+++ b/core/app/models/spree/promotion/actions/create_quantity_adjustments.rb
@@ -67,7 +67,7 @@ module Spree
           line_items = actionable_line_items(order)
 
           actioned_line_items = order.line_item_adjustments.reload.
-            select { |a| a.source == self && a.amount < 0 }.
+            select { |adjustment| adjustment.source == self && adjustment.amount < 0 }.
             map(&:adjustable)
           other_line_items = actioned_line_items - [line_item]
 

--- a/core/app/models/spree/promotion/actions/free_shipping.rb
+++ b/core/app/models/spree/promotion/actions/free_shipping.rb
@@ -21,7 +21,7 @@ module Spree
           end
           # Did we actually end up applying any adjustments?
           # If so, then this action should be classed as 'successful'
-          results.any? { |r| r == true }
+          results.any? { |result| result == true }
         end
 
         def label

--- a/core/app/models/spree/promotion/rules/option_value.rb
+++ b/core/app/models/spree/promotion/rules/option_value.rb
@@ -29,8 +29,8 @@ module Spree
         def preferred_eligible_values
           values = preferences[:eligible_values] || {}
           Hash[values.keys.map(&:to_i).zip(
-            values.values.map do |v|
-              (v.is_a?(Array) ? v : v.split(",")).map(&:to_i)
+            values.values.map do |value|
+              (value.is_a?(Array) ? value : value.split(",")).map(&:to_i)
             end
           )]
         end

--- a/core/app/models/spree/promotion/rules/product.rb
+++ b/core/app/models/spree/promotion/rules/product.rb
@@ -32,15 +32,15 @@ module Spree
 
           case preferred_match_policy
           when 'all'
-            unless eligible_products.all? { |p| order.products.include?(p) }
+            unless eligible_products.all? { |product| order.products.include?(product) }
               eligibility_errors.add(:base, eligibility_error_message(:missing_product), error_code: :missing_product)
             end
           when 'any'
-            unless order.products.any? { |p| eligible_products.include?(p) }
+            unless order.products.any? { |product| eligible_products.include?(product) }
               eligibility_errors.add(:base, eligibility_error_message(:no_applicable_products), error_code: :no_applicable_products)
             end
           when 'none'
-            unless order.products.none? { |p| eligible_products.include?(p) }
+            unless order.products.none? { |product| eligible_products.include?(product) }
               eligibility_errors.add(:base, eligibility_error_message(:has_excluded_product), error_code: :has_excluded_product)
             end
           else

--- a/core/app/models/spree/promotion_action.rb
+++ b/core/app/models/spree/promotion_action.rb
@@ -16,7 +16,7 @@ module Spree
 
     belongs_to :promotion, class_name: 'Spree::Promotion', inverse_of: :promotion_actions, optional: true
 
-    scope :of_type, ->(t) { where(type: Array.wrap(t).map(&:to_s)) }
+    scope :of_type, ->(type) { where(type: Array.wrap(type).map(&:to_s)) }
     scope :shipping, -> { of_type(Spree::Config.environment.promotions.shipping_actions.to_a) }
 
     # Updates the state of the order or performs some other action depending on

--- a/core/app/models/spree/promotion_chooser.rb
+++ b/core/app/models/spree/promotion_chooser.rb
@@ -26,8 +26,8 @@ module Spree
 
     # @return The best promotion from this set of adjustments.
     def best_promotion_adjustment
-      @best_promotion_adjustment ||= @adjustments.select(&:eligible?).min_by do |a|
-        [a.amount, -a.id]
+      @best_promotion_adjustment ||= @adjustments.select(&:eligible?).min_by do |adjustment|
+        [adjustment.amount, -adjustment.id]
       end
     end
   end

--- a/core/app/models/spree/promotion_code/batch_builder.rb
+++ b/core/app/models/spree/promotion_code/batch_builder.rb
@@ -33,12 +33,12 @@ class ::Spree::PromotionCode::BatchBuilder
   def build_promotion_codes
     generate_random_codes
     promotion_code_batch.update!(state: "completed")
-  rescue StandardError => e
+  rescue StandardError => error
     promotion_code_batch.update!(
-      error: e.inspect,
+      error: error.inspect,
       state: "failed"
     )
-    raise e
+    raise error
   end
 
   private

--- a/core/app/models/spree/promotion_rule.rb
+++ b/core/app/models/spree/promotion_rule.rb
@@ -5,7 +5,7 @@ module Spree
   class PromotionRule < Spree::Base
     belongs_to :promotion, class_name: 'Spree::Promotion', inverse_of: :promotion_rules, optional: true
 
-    scope :of_type, ->(t) { where(type: t) }
+    scope :of_type, ->(type) { where(type: type) }
 
     validates :promotion, presence: true
     validate :unique_per_promotion, on: :create

--- a/core/app/models/spree/refund.rb
+++ b/core/app/models/spree/refund.rb
@@ -68,8 +68,8 @@ module Spree
       end
 
       response
-    rescue ActiveMerchant::ConnectionError => e
-      logger.error(I18n.t('spree.gateway_error') + "  #{e.inspect}")
+    rescue ActiveMerchant::ConnectionError => error
+      logger.error(I18n.t('spree.gateway_error') + "  #{error.inspect}")
       raise Core::GatewayError.new(I18n.t('spree.unable_to_connect_to_gateway'))
     end
 

--- a/core/app/models/spree/reimbursement.rb
+++ b/core/app/models/spree/reimbursement.rb
@@ -104,11 +104,11 @@ module Spree
       if unpaid_amount_within_tolerance?
         reimbursed!
         Spree::Event.fire 'reimbursement_reimbursed', reimbursement: self
-        reimbursement_success_hooks.each { |h| h.call self }
+        reimbursement_success_hooks.each { |hook| hook.call self }
       else
         errored!
         Spree::Event.fire 'reimbursement_errored', reimbursement: self
-        reimbursement_failure_hooks.each { |h| h.call self }
+        reimbursement_failure_hooks.each { |hook| hook.call self }
       end
 
       if errored?

--- a/core/app/models/spree/reimbursement/reimbursement_type_engine.rb
+++ b/core/app/models/spree/reimbursement/reimbursement_type_engine.rb
@@ -18,7 +18,7 @@ module Spree
 
     def initialize(return_items)
       @return_items = return_items
-      @reimbursement_type_hash = Hash.new { |h, k| h[k] = [] }
+      @reimbursement_type_hash = Hash.new { |hash, key| hash[key] = [] }
     end
 
     def calculate_reimbursement_types

--- a/core/app/models/spree/reimbursement_type/reimbursement_helpers.rb
+++ b/core/app/models/spree/reimbursement_type/reimbursement_helpers.rb
@@ -63,8 +63,8 @@ module Spree
 
     def sorted_eligible_refund_payments(payments)
       if eligible_refund_methods = self.eligible_refund_methods
-        payments = payments.select { |p| eligible_refund_methods.include? p.payment_method.class }
-        payments = payments.sort_by { |p| eligible_refund_methods.index(p.payment_method.class) }
+        payments = payments.select { |payment| eligible_refund_methods.include? payment.payment_method.class }
+        payments = payments.sort_by { |payment| eligible_refund_methods.index(payment.payment_method.class) }
       end
       payments
     end

--- a/core/app/models/spree/return_item.rb
+++ b/core/app/models/spree/return_item.rb
@@ -175,7 +175,7 @@ module Spree
       event_paths.delete(:expired)
       event_paths.delete(:unexchange)
 
-      status_paths.map{ |s| I18n.t("spree.reception_states.#{s}", default: s.to_s.humanize) }.zip(event_paths)
+      status_paths.map{ |status| I18n.t("spree.reception_states.#{status}", default: status.to_s.humanize) }.zip(event_paths)
     end
 
     def part_of_exchange?

--- a/core/app/models/spree/return_item/eligibility_validator/default.rb
+++ b/core/app/models/spree/return_item/eligibility_validator/default.rb
@@ -28,7 +28,7 @@ module Spree
         private
 
         def validators
-          @validators ||= permitted_eligibility_validators.map{ |v| v.new(@return_item) }
+          @validators ||= permitted_eligibility_validators.map{ |validator| validator.new(@return_item) }
         end
       end
     end

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -31,7 +31,7 @@ module Spree
     scope :ready,   -> { with_state('ready') }
     scope :shipped, -> { with_state('shipped') }
     scope :trackable, -> { where("tracking IS NOT NULL AND tracking != ''") }
-    scope :with_state, ->(*s) { where(state: s) }
+    scope :with_state, ->(*state) { where(state: state) }
     # sort by most recent shipped_at, falling back to created_at. add "id desc" to make specs that involve this scope more deterministic.
     scope :reverse_chronological, -> {
       order(Arel.sql("coalesce(#{Spree::Shipment.table_name}.shipped_at, #{Spree::Shipment.table_name}.created_at) desc"), id: :desc)
@@ -108,7 +108,7 @@ module Spree
     # @return [BigDecimal] the amount of this item, taking into consideration
     #   all non-tax adjustments.
     def total_before_tax
-      amount + adjustments.select { |a| !a.tax? && a.eligible? }.sum(&:amount)
+      amount + adjustments.select { |adjustment| !adjustment.tax? && adjustment.eligible? }.sum(&:amount)
     end
 
     # @return [BigDecimal] the amount of this shipment before VAT tax
@@ -185,7 +185,7 @@ module Spree
     def select_shipping_method(shipping_method)
       estimator = Spree::Config.stock.estimator_class.new
       rates = estimator.shipping_rates(to_package, false)
-      rate = rates.detect { |r| r.shipping_method_id == shipping_method.id }
+      rate = rates.detect { |detected| detected.shipping_method_id == shipping_method.id }
       rate.selected = true
       self.shipping_rates = [rate]
     end

--- a/core/app/models/spree/state.rb
+++ b/core/app/models/spree/state.rb
@@ -24,7 +24,7 @@ module Spree
     # table of { country.id => [ state.id , state.name ] }, arrays sorted by name
     # blank is added elsewhere, if needed
     def self.states_group_by_country_id
-      state_info = Hash.new { |h, k| h[k] = [] }
+      state_info = Hash.new { |hash, key| hash[key] = [] }
       order(:name).each { |state|
         state_info[state.country_id.to_s].push [state.id, state.name]
       }

--- a/core/app/models/spree/stock/differentiator.rb
+++ b/core/app/models/spree/stock/differentiator.rb
@@ -14,7 +14,7 @@ module Spree
       end
 
       def missing?
-        missing.values.any? { |v| v > 0 }
+        missing.values.any? { |value| value > 0 }
       end
 
       private

--- a/core/app/models/spree/stock/package.rb
+++ b/core/app/models/spree/stock/package.rb
@@ -85,7 +85,7 @@ module Spree
       # @return [Fixnum] the number of inventory units in the package,
       #   counting only those in the given state if it was specified
       def quantity(state = nil)
-        matched_contents = state.nil? ? contents : contents.select { |c| c.state.to_s == state.to_s }
+        matched_contents = state.nil? ? contents : contents.select { |content| content.state.to_s == state.to_s }
         matched_contents.map(&:quantity).sum
       end
 

--- a/core/app/models/spree/stock_item.rb
+++ b/core/app/models/spree/stock_item.rb
@@ -111,7 +111,7 @@ module Spree
     def should_touch_variant?
       # the variant_id changes from nil when a new stock location is added
       inventory_cache_threshold &&
-        (saved_change_to_count_on_hand && saved_change_to_count_on_hand.any? { |cache| cache < inventory_cache_threshold }) ||
+        (saved_change_to_count_on_hand&.any? { |cache| cache < inventory_cache_threshold }) ||
         saved_change_to_variant_id?
     end
 

--- a/core/app/models/spree/stock_item.rb
+++ b/core/app/models/spree/stock_item.rb
@@ -111,7 +111,7 @@ module Spree
     def should_touch_variant?
       # the variant_id changes from nil when a new stock location is added
       inventory_cache_threshold &&
-        (saved_change_to_count_on_hand && saved_change_to_count_on_hand.any? { |c| c < inventory_cache_threshold }) ||
+        (saved_change_to_count_on_hand && saved_change_to_count_on_hand.any? { |cache| cache < inventory_cache_threshold }) ||
         saved_change_to_variant_id?
     end
 

--- a/core/app/models/spree/stock_quantities.rb
+++ b/core/app/models/spree/stock_quantities.rb
@@ -8,8 +8,8 @@ module Spree
 
     # @param quantities [Hash<Spree::Variant=>Numeric>]
     def initialize(quantities = {})
-      raise ArgumentError unless quantities.keys.all?{ |v| v.is_a?(Spree::Variant) }
-      raise ArgumentError unless quantities.values.all?{ |v| v.is_a?(Numeric) }
+      raise ArgumentError unless quantities.keys.all?{ |value| value.is_a?(Spree::Variant) }
+      raise ArgumentError unless quantities.values.all?{ |value| value.is_a?(Numeric) }
 
       @quantities = quantities
     end
@@ -33,16 +33,16 @@ module Spree
     # Adds two StockQuantities together
     # @return [Spree::StockQuantities]
     def +(other)
-      combine_with(other) do |_variant, a, b|
-        (a || 0) + (b || 0)
+      combine_with(other) do |_variant, first, second|
+        (first || 0) + (second || 0)
       end
     end
 
     # Subtracts another StockQuantities from this one
     # @return [Spree::StockQuantities]
     def -(other)
-      combine_with(other) do |_variant, a, b|
-        (a || 0) - (b || 0)
+      combine_with(other) do |_variant, first, second|
+        (first || 0) - (second || 0)
       end
     end
 
@@ -50,9 +50,9 @@ module Spree
     # stock which exists in both StockQuantities.
     # @return [Spree::StockQuantities]
     def &(other)
-      combine_with(other) do |_variant, a, b|
-        next unless a && b
-        [a, b].min
+      combine_with(other) do |_variant, first, second|
+        next unless first && second
+        [first, second].min
       end
     end
 
@@ -72,9 +72,9 @@ module Spree
     def combine_with(other)
       self.class.new(
         (variants | other.variants).map do |variant|
-          a = self[variant]
-          b = other[variant]
-          value = yield variant, a, b
+          self_v = self[variant]
+          other_v = other[variant]
+          value = yield variant, self_v, other_v
           [variant, value]
         end.to_h.compact
       )

--- a/core/app/models/spree/stock_quantities.rb
+++ b/core/app/models/spree/stock_quantities.rb
@@ -52,6 +52,7 @@ module Spree
     def &(other)
       combine_with(other) do |_variant, first, second|
         next unless first && second
+
         [first, second].min
       end
     end

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -250,12 +250,12 @@ module Spree
       # no option values on master
       return if is_master
 
-      option_type = Spree::OptionType.where(name: opt_name).first_or_initialize do |o|
-        o.presentation = opt_name
-        o.save!
+      option_type = Spree::OptionType.where(name: opt_name).first_or_initialize do |option|
+        option.presentation = opt_name
+        option.save!
       end
 
-      current_value = option_values.detect { |o| o.option_type.name == opt_name }
+      current_value = option_values.detect { |option| option.option_type.name == opt_name }
 
       if current_value
         return if current_value.name == opt_value
@@ -267,9 +267,9 @@ module Spree
         end
       end
 
-      option_value = Spree::OptionValue.where(option_type_id: option_type.id, name: opt_value).first_or_initialize do |o|
-        o.presentation = opt_value
-        o.save!
+      option_value = Spree::OptionValue.where(option_type_id: option_type.id, name: opt_value).first_or_initialize do |option|
+        option.presentation = opt_value
+        option.save!
       end
 
       option_values << option_value
@@ -281,7 +281,7 @@ module Spree
     # @param opt_name [String] the name of the option whose value you want
     # @return [String] the option value
     def option_value(opt_name)
-      option_values.detect { |o| o.option_type.name == opt_name }.try(:presentation)
+      option_values.detect { |option| option.option_type.name == opt_name }.try(:presentation)
     end
 
     # Returns an instance of the globally configured variant price selector class for this variant.

--- a/core/app/models/spree/wallet/add_payment_sources_to_wallet.rb
+++ b/core/app/models/spree/wallet/add_payment_sources_to_wallet.rb
@@ -19,7 +19,7 @@ class Spree::Wallet::AddPaymentSourcesToWallet
       sources = payments.map(&:source).
         uniq.
         compact.
-        select { |p| p.try(:reusable?) }
+        select { |payment| payment.try(:reusable?) }
 
       # add valid sources to wallet and optionally set a default
       if sources.any?

--- a/core/app/models/spree/zone.rb
+++ b/core/app/models/spree/zone.rb
@@ -40,7 +40,7 @@ module Spree
     end
 
     alias :members :zone_members
-    accepts_nested_attributes_for :zone_members, allow_destroy: true, reject_if: proc { |a| a['zoneable_id'].blank? }
+    accepts_nested_attributes_for :zone_members, allow_destroy: true, reject_if: proc { |member| member['zoneable_id'].blank? }
 
     self.whitelisted_ransackable_attributes = %w[name description]
 

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -11,8 +11,8 @@ module Spree
       isolate_namespace Spree
       engine_name 'spree'
 
-      config.generators do |g|
-        g.test_framework :rspec
+      config.generators do |generator|
+        generator.test_framework :rspec
       end
 
       initializer "spree.environment", before: :load_config_initializers do |app|

--- a/core/lib/spree/core/importer/order.rb
+++ b/core/lib/spree/core/importer/order.rb
@@ -53,17 +53,17 @@ module Spree
         def self.create_shipments_from_params(shipments_hash, order)
           return [] unless shipments_hash
 
-          shipments_hash.each do |s|
+          shipments_hash.each do |target|
             shipment = Shipment.new
-            shipment.tracking       = s[:tracking]
-            shipment.stock_location = Spree::StockLocation.find_by(admin_name: s[:stock_location]) || Spree::StockLocation.find_by!(name: s[:stock_location])
+            shipment.tracking       = target[:tracking]
+            shipment.stock_location = Spree::StockLocation.find_by(admin_name: target[:stock_location]) || Spree::StockLocation.find_by!(name: target[:stock_location])
 
-            inventory_units = s[:inventory_units] || []
-            inventory_units.each do |iu|
-              ensure_variant_id_from_params(iu)
+            inventory_units = target[:inventory_units] || []
+            inventory_units.each do |inventory_unit|
+              ensure_variant_id_from_params(inventory_unit)
 
-              unless line_item = order.line_items.find_by(variant_id: iu[:variant_id])
-                line_item = order.contents.add(Spree::Variant.find(iu[:variant_id]), 1)
+              unless line_item = order.line_items.find_by(variant_id: inventory_unit[:variant_id])
+                line_item = order.contents.add(Spree::Variant.find(inventory_unit[:variant_id]), 1)
               end
 
               # Spree expects a Inventory Unit to always reference a line
@@ -71,14 +71,14 @@ module Spree
               # trying to view these units. Note the Importer might not be
               # able to find the line item if line_item.variant_id |= iu.variant_id
               shipment.inventory_units.new(
-                variant_id: iu[:variant_id],
+                variant_id: inventory_unit[:variant_id],
                 line_item: line_item
               )
             end
 
             # Mark shipped if it should be.
-            if s[:shipped_at].present?
-              shipment.shipped_at = s[:shipped_at]
+            if target[:shipped_at].present?
+              shipment.shipped_at = target[:shipped_at]
               shipment.state      = 'shipped'
               shipment.inventory_units.each do |unit|
                 unit.state = 'shipped'
@@ -88,9 +88,9 @@ module Spree
             order.shipments << shipment
             shipment.save!
 
-            shipping_method = Spree::ShippingMethod.find_by(name: s[:shipping_method]) || Spree::ShippingMethod.find_by!(admin_name: s[:shipping_method])
+            shipping_method = Spree::ShippingMethod.find_by(name: target[:shipping_method]) || Spree::ShippingMethod.find_by!(admin_name: target[:shipping_method])
             rate = shipment.shipping_rates.create!(shipping_method: shipping_method,
-                                                   cost: s[:cost])
+                                                   cost: target[:cost])
             shipment.selected_shipping_rate_id = rate.id
             shipment.update_amounts
           end
@@ -98,9 +98,9 @@ module Spree
 
         def self.create_line_items_from_params(line_items_hash, order)
           return {} unless line_items_hash
-          line_items_hash.each_key do |k|
-            extra_params = line_items_hash[k].except(:variant_id, :quantity, :sku)
-            line_item = ensure_variant_id_from_params(line_items_hash[k])
+          line_items_hash.each_key do |key|
+            extra_params = line_items_hash[key].except(:variant_id, :quantity, :sku)
+            line_item = ensure_variant_id_from_params(line_items_hash[key])
             line_item = order.contents.add(Spree::Variant.find(line_item[:variant_id]), line_item[:quantity])
             # Raise any errors with saving to prevent import succeeding with line items failing silently.
             if extra_params.present?
@@ -113,11 +113,11 @@ module Spree
 
         def self.create_adjustments_from_params(adjustments, order)
           return [] unless adjustments
-          adjustments.each do |a|
+          adjustments.each do |target|
             adjustment = order.adjustments.build(
               order:  order,
-              amount: a[:amount].to_d,
-              label:  a[:label]
+              amount: target[:amount].to_d,
+              label:  target[:label]
             )
             adjustment.save!
             adjustment.finalize!
@@ -126,14 +126,14 @@ module Spree
 
         def self.create_payments_from_params(payments_hash, order)
           return [] unless payments_hash
-          payments_hash.each do |p|
+          payments_hash.each do |target|
             payment = order.payments.build order: order
-            payment.amount = p[:amount].to_f
+            payment.amount = target[:amount].to_f
             # Order API should be using state as that's the normal payment field.
             # spree_wombat serializes payment state as status so imported orders should fall back to status field.
-            payment.state = p[:state] || p[:status] || 'completed'
-            payment.payment_method = Spree::PaymentMethod.find_by!(name: p[:payment_method])
-            payment.source = create_source_payment_from_params(p[:source], payment) if p[:source]
+            payment.state = target[:state] || target[:status] || 'completed'
+            payment.payment_method = Spree::PaymentMethod.find_by!(name: target[:payment_method])
+            payment.source = create_source_payment_from_params(target[:source], payment) if target[:source]
             payment.save!
           end
         end
@@ -170,8 +170,8 @@ module Spree
             search[:iso_name] = iso_name.upcase
           elsif iso = address[:country]['iso']
             search[:iso] = iso.upcase
-          elsif iso3 = address[:country]['iso3']
-            search[:iso3] = iso3.upcase
+          elsif iso_three = address[:country]['iso3']
+            search[:iso3] = iso_three.upcase
           end
 
           address.delete(:country)

--- a/core/lib/spree/core/product_filters.rb
+++ b/core/lib/spree/core/product_filters.rb
@@ -55,7 +55,7 @@ module Spree
       # below scope would be something like ["$10 - $15", "$15 - $18", "$18 - $20"]
       #
       Spree::Product.add_search_scope :price_range_any do |*opts|
-        conds = opts.map { |o| Spree::Core::ProductFilters.price_filter[:conds][o] }.reject(&:nil?)
+        conds = opts.map { |element| Spree::Core::ProductFilters.price_filter[:conds][element] }.reject(&:nil?)
         scope = conds.shift
         conds.each do |new_scope|
           scope = scope.or(new_scope)
@@ -68,17 +68,17 @@ module Spree
       end
 
       def self.price_filter
-        v = Spree::Price.arel_table
-        conds = [[I18n.t('spree.under_price', price: format_price(10)), v[:amount].lteq(10)],
-                 ["#{format_price(10)} - #{format_price(15)}", v[:amount].in(10..15)],
-                 ["#{format_price(15)} - #{format_price(18)}", v[:amount].in(15..18)],
-                 ["#{format_price(18)} - #{format_price(20)}", v[:amount].in(18..20)],
-                 [I18n.t('spree.or_over_price', price: format_price(20)), v[:amount].gteq(20)]]
+        value = Spree::Price.arel_table
+        conds = [[I18n.t('spree.under_price', price: format_price(10)), value[:amount].lteq(10)],
+                 ["#{format_price(10)} - #{format_price(15)}", value[:amount].in(10..15)],
+                 ["#{format_price(15)} - #{format_price(18)}", value[:amount].in(15..18)],
+                 ["#{format_price(18)} - #{format_price(20)}", value[:amount].in(18..20)],
+                 [I18n.t('spree.or_over_price', price: format_price(20)), value[:amount].gteq(20)]]
         {
           name:   I18n.t('spree.price_range'),
           scope:  :price_range_any,
           conds:  Hash[*conds.flatten],
-          labels: conds.map { |k, _v| [k, k] }
+          labels: conds.map { |key, _value| [key, key] }
         }
       end
 
@@ -95,7 +95,7 @@ module Spree
       #   being blank: note that this relies on with_property doing a left outer join
       #   rather than an inner join.
       Spree::Product.add_search_scope :brand_any do |*opts|
-        conds = opts.map { |o| ProductFilters.brand_filter[:conds][o] }.reject(&:nil?)
+        conds = opts.map { |value| ProductFilters.brand_filter[:conds][value] }.reject(&:nil?)
         scope = conds.shift
         conds.each do |new_scope|
           scope = scope.or(new_scope)
@@ -107,12 +107,12 @@ module Spree
         brand_property = Spree::Property.find_by(name: 'brand')
         brands = brand_property ? Spree::ProductProperty.where(property_id: brand_property.id).pluck(:value).uniq.map(&:to_s) : []
         pp = Spree::ProductProperty.arel_table
-        conds = Hash[*brands.map { |b| [b, pp[:value].eq(b)] }.flatten]
+        conds = Hash[*brands.map { |brand| [brand, pp[:value].eq(brand)] }.flatten]
         {
           name:   'Brands',
           scope:  :brand_any,
           conds:  conds,
-          labels: brands.sort.map { |k| [k, k] }
+          labels: brands.sort.map { |key| [key, key] }
         }
       end
 
@@ -149,7 +149,7 @@ module Spree
         {
           name:   'Applicable Brands',
           scope:  :selective_brand_any,
-          labels: brands.sort.map { |k| [k, k] }
+          labels: brands.sort.map { |key| [key, key] }
         }
       end
 
@@ -171,7 +171,7 @@ module Spree
         {
           name:   'Taxons under ' + taxon.name,
           scope:  :taxons_id_in_tree_any,
-          labels: taxon.children.sort_by(&:position).map { |t| [t.name, t.id] },
+          labels: taxon.children.sort_by(&:position).map { |element| [element.name, element.id] },
           conds:  nil
         }
       end
@@ -184,11 +184,11 @@ module Spree
       # idea: expand the format to allow nesting of labels?
       def self.all_taxons
         Spree::Deprecation.warn "all_taxons is deprecated in solidus_core. Please add it to your own application to continue using it."
-        taxons = Spree::Taxonomy.all.map { |t| [t.root] + t.root.descendants }.flatten
+        taxons = Spree::Taxonomy.all.map { |element| [element.root] + element.root.descendants }.flatten
         {
           name:   'All taxons',
           scope:  :taxons_id_equals_any,
-          labels: taxons.sort_by(&:name).map { |t| [t.name, t.id] },
+          labels: taxons.sort_by(&:name).map { |element| [element.name, element.id] },
           conds:  nil # not needed
         }
       end

--- a/core/lib/spree/core/role_configuration.rb
+++ b/core/lib/spree/core/role_configuration.rb
@@ -69,8 +69,8 @@ module Spree
     # Not public due to the fact this class is a Singleton
     # @!visibility private
     def initialize
-      @roles = Hash.new do |h, name|
-        h[name] = Role.new(name, Set.new)
+      @roles = Hash.new do |hash, name|
+        hash[name] = Role.new(name, Set.new)
       end
     end
 

--- a/core/lib/spree/core/search/variant.rb
+++ b/core/lib/spree/core/search/variant.rb
@@ -57,7 +57,7 @@ module Spree
         end
 
         def search_term_params(word)
-          terms = Hash[search_terms(word).map { |t| [t, word] }]
+          terms = Hash[search_terms(word).map { |term| [term, word] }]
           terms.merge(m: 'or')
         end
       end

--- a/core/lib/spree/preferences/static_model_preferences.rb
+++ b/core/lib/spree/preferences/static_model_preferences.rb
@@ -30,8 +30,8 @@ module Spree
       end
 
       def initialize
-        @store = Hash.new do |h, klass|
-          h[klass] = {}
+        @store = Hash.new do |data, klass|
+          data[klass] = {}
         end
       end
 

--- a/core/spec/models/spree/classification_spec.rb
+++ b/core/spec/models/spree/classification_spec.rb
@@ -34,9 +34,9 @@ module Spree
 
     context "removing product from taxon" do
       before :each do
-        p = taxon_with_5_products.products[1]
-        expect(p.classifications.first.position).to eq(2)
-        taxon_with_5_products.products.destroy(p)
+        element = taxon_with_5_products.products[1]
+        expect(element.classifications.first.position).to eq(2)
+        taxon_with_5_products.products.destroy(element)
       end
 
       it "resets positions" do
@@ -59,9 +59,9 @@ module Spree
 
     context "removing taxon from product" do
       before :each do
-        p = taxon_with_5_products.products[1]
-        p.taxons.destroy(taxon_with_5_products)
-        p.save!
+        element = taxon_with_5_products.products[1]
+        element.taxons.destroy(taxon_with_5_products)
+        element.save!
       end
 
       it "resets positions" do
@@ -71,9 +71,9 @@ module Spree
 
     context "replacing product's taxons" do
       before :each do
-        p = taxon_with_5_products.products[1]
-        p.taxons = []
-        p.save!
+        element = taxon_with_5_products.products[1]
+        element.taxons = []
+        element.save!
       end
 
       it "resets positions" do

--- a/core/spec/models/spree/concerns/user_address_book_spec.rb
+++ b/core/spec/models/spree/concerns/user_address_book_spec.rb
@@ -77,7 +77,7 @@ module Spree
           end
 
           context "and changing another address field at the same time" do
-            let(:updated_address_attributes) { address.attributes.tap { |a| a[:first_name] = "Newbie" } }
+            let(:updated_address_attributes) { address.attributes.tap { |value| value[:first_name] = "Newbie" } }
 
             subject { user.save_in_address_book(updated_address_attributes, true) }
 
@@ -104,7 +104,7 @@ module Spree
         let(:address1) { create(:address) }
         let(:address2) { create(:address, firstname: "Different") }
         let(:updated_attrs) do
-          address2.attributes.tap { |a| a[:firstname] = "Johnny" }
+          address2.attributes.tap { |value| value[:firstname] = "Johnny" }
         end
 
         before do
@@ -191,8 +191,8 @@ module Spree
 
           it "archives address2" do
             subject
-            user_address2 = user.user_addresses.all_historical.find_by(address_id: address2.id)
-            expect(user_address2.archived).to be true
+            user_address_two = user.user_addresses.all_historical.find_by(address_id: address2.id)
+            expect(user_address_two.archived).to be true
           end
 
           context "via a new address that matches an archived one" do

--- a/core/spec/models/spree/order_merger_spec.rb
+++ b/core/spec/models/spree/order_merger_spec.rb
@@ -77,13 +77,13 @@ module Spree
 
       context "2 equal line items" do
         before do
-          @line_item_1 = order_1.contents.add(variant, 1, foos: {})
-          @line_item_2 = order_2.contents.add(variant, 1, foos: {})
+          @line_item_one = order_1.contents.add(variant, 1, foos: {})
+          @line_item_two = order_2.contents.add(variant, 1, foos: {})
         end
 
         specify do
           without_partial_double_verification do
-            expect(order_1).to receive(:foos_match).with(@line_item_1, kind_of(Hash)).and_return(true)
+            expect(order_1).to receive(:foos_match).with(@line_item_one, kind_of(Hash)).and_return(true)
           end
           subject.merge!(order_2)
           expect(order_1.line_items.count).to eq(1)

--- a/core/spec/models/spree/order_updater_spec.rb
+++ b/core/spec/models/spree/order_updater_spec.rb
@@ -158,6 +158,7 @@ module Spree
                                 amount: -500,
                                 finalized: true,
                                 label: 'Some other credit')
+
             line_item.adjustments.each { |item| item.update_column(:eligible, true) }
 
             order.recalculate

--- a/core/spec/models/spree/order_updater_spec.rb
+++ b/core/spec/models/spree/order_updater_spec.rb
@@ -158,7 +158,7 @@ module Spree
                                 amount: -500,
                                 finalized: true,
                                 label: 'Some other credit')
-            line_item.adjustments.each { |a| a.update_column(:eligible, true) }
+            line_item.adjustments.each { |item| item.update_column(:eligible, true) }
 
             order.recalculate
 
@@ -172,7 +172,7 @@ module Spree
               create_adjustment('Promotion A', -200)
               create_adjustment('Promotion B', -200)
             end
-            line_item.adjustments.each { |a| a.update_column(:eligible, true) }
+            line_item.adjustments.each { |item| item.update_column(:eligible, true) }
 
             order.recalculate
 
@@ -186,7 +186,7 @@ module Spree
               create_adjustment('Promotion A', -200)
               create_adjustment('Promotion B', -200)
             end
-            line_item.adjustments.each { |a| a.update_column(:eligible, true) }
+            line_item.adjustments.each { |item| item.update_column(:eligible, true) }
 
             order.recalculate
 

--- a/core/spec/models/spree/preference_spec.rb
+++ b/core/spec/models/spree/preference_spec.rb
@@ -12,10 +12,10 @@ RSpec.describe Spree::Preference, type: :model do
 
   describe "type coversion for values" do
     def round_trip_preference(key, value)
-      p = Spree::Preference.new
-      p.value = value
-      p.key = key
-      p.save
+      element = Spree::Preference.new
+      element.value = value
+      element.key = key
+      element.save
 
       Spree::Preference.find_by(key: key)
     end

--- a/core/spec/models/spree/preferences/preferable_spec.rb
+++ b/core/spec/models/spree/preferences/preferable_spec.rb
@@ -272,9 +272,9 @@ RSpec.describe Spree::Preferences::Preferable, type: :model do
     before(:all) do
       class CreatePrefTest < ActiveRecord::Migration[4.2]
         def self.up
-          create_table :pref_tests do |t|
-            t.string :col
-            t.text :preferences
+          create_table :pref_tests do |item|
+            item.string :col
+            item.text :preferences
           end
         end
 

--- a/core/spec/models/spree/preferences/statically_configurable_spec.rb
+++ b/core/spec/models/spree/preferences/statically_configurable_spec.rb
@@ -30,8 +30,8 @@ module Spree
     end
 
     subject do
-      klass.new.tap do |o|
-        o.preference_source = preference_source
+      klass.new.tap do |item|
+        item.preference_source = preference_source
       end
     end
 

--- a/core/spec/models/spree/promotion_rule_spec.rb
+++ b/core/spec/models/spree/promotion_rule_spec.rb
@@ -17,13 +17,13 @@ module Spree
     end
 
     it "validates unique rules for a promotion" do
-      p1 = TestRule.new
-      p1.promotion_id = 1
-      p1.save
+      promotion_one = TestRule.new
+      promotion_one.promotion_id = 1
+      promotion_one.save
 
-      p2 = TestRule.new
-      p2.promotion_id = 1
-      expect(p2).not_to be_valid
+      promotion_two = TestRule.new
+      promotion_two.promotion_id = 1
+      expect(promotion_two).not_to be_valid
     end
 
     it "generates its own partial path" do

--- a/core/spec/models/spree/reimbursement_type/original_payment_spec.rb
+++ b/core/spec/models/spree/reimbursement_type/original_payment_spec.rb
@@ -57,7 +57,7 @@ module Spree
       context "multiple payment methods" do
         let(:simulate) { true }
         let!(:check_payment) { create(:check_payment, order: reimbursement.order, amount: 5.0, state: "completed") }
-        let(:payment) { reimbursement.order.payments.detect { |p| p.payment_method.is_a? Spree::PaymentMethod::BogusCreditCard } }
+        let(:payment) { reimbursement.order.payments.detect { |item| item.payment_method.is_a? Spree::PaymentMethod::BogusCreditCard } }
         let(:refund_amount) { 10.0 }
 
         let(:refund_payment_methods) { subject.map { |refund| refund.payment.payment_method } }

--- a/core/spec/models/spree/return_item/exchange_variant_eligibility/same_product_spec.rb
+++ b/core/spec/models/spree/return_item/exchange_variant_eligibility/same_product_spec.rb
@@ -18,7 +18,7 @@ module Spree
         context "product has variants" do
           it "returns all variants for the same product" do
             product = create(:product, variants: Array.new(3) { create(:variant) })
-            product.variants.map { |v| v.stock_items.first.update_column(:count_on_hand, 10) }
+            product.variants.map { |value| value.stock_items.first.update_column(:count_on_hand, 10) }
 
             expect(SameProduct.eligible_variants(product.variants.first).sort).to eq product.variants.sort
           end

--- a/core/spec/models/spree/stock/availability_validator_spec.rb
+++ b/core/spec/models/spree/stock/availability_validator_spec.rb
@@ -115,8 +115,8 @@ module Spree
         let(:stock_location) { order.shipments.first.stock_location }
 
         before do
-          shipment2 = order.shipments.create!(stock_location: order.shipments.first.stock_location)
-          order.contents.add(variant, 1, shipment: shipment2)
+          shipment_two = order.shipments.create!(stock_location: order.shipments.first.stock_location)
+          order.contents.add(variant, 1, shipment: shipment_two)
           variant.stock_items.first.update_columns(count_on_hand: count_on_hand, backorderable: false)
         end
 

--- a/core/spec/models/spree/stock/differentiator_spec.rb
+++ b/core/spec/models/spree/stock/differentiator_spec.rb
@@ -19,11 +19,11 @@ module Spree
       let(:order) { mock_model(Order, line_items: [line_item1, line_item2]) }
 
       let(:package1) do
-        Package.new(stock_location).tap { |p| p.add(inventory_unit1) }
+        Package.new(stock_location).tap { |package| package.add(inventory_unit1) }
       end
 
       let(:package2) do
-        Package.new(stock_location).tap { |p| p.add(inventory_unit2) }
+        Package.new(stock_location).tap { |package| package.add(inventory_unit2) }
       end
 
       let(:packages) { [package1, package2] }

--- a/core/spec/models/spree/stock/estimator_spec.rb
+++ b/core/spec/models/spree/stock/estimator_spec.rb
@@ -8,8 +8,8 @@ module Spree
       let(:shipping_rate) { 4.00 }
       let!(:shipping_method) { create(:shipping_method, cost: shipping_rate, currency: currency) }
       let(:package) do
-        build(:stock_package, contents: inventory_units.map { |i| ContentItem.new(i) }).tap do |p|
-          p.shipment = p.to_shipment
+        build(:stock_package, contents: inventory_units.map { |unit| ContentItem.new(unit) }).tap do |package|
+          package.shipment = package.to_shipment
         end
       end
       let(:order) { create(:order_with_line_items, shipping_method: shipping_method) }
@@ -61,7 +61,7 @@ module Spree
         end
 
         context "when the order's ship address is in a different zone" do
-          before { shipping_method.zones.each{ |z| z.members.delete_all } }
+          before { shipping_method.zones.each{ |zone| zone.members.delete_all } }
           it_should_behave_like "shipping rate doesn't match"
         end
 

--- a/core/spec/models/spree/stock/package_spec.rb
+++ b/core/spec/models/spree/stock/package_spec.rb
@@ -51,41 +51,41 @@ module Spree
       end
 
       it 'builds the correct list of shipping methods based on stock location and categories' do
-        category1 = create(:shipping_category)
-        category2 = create(:shipping_category)
-        method1   = create(:shipping_method, available_to_all: true)
-        method2   = create(:shipping_method, stock_locations: [stock_location])
-        method1.shipping_categories = [category1, category2]
-        method2.shipping_categories = [category1, category2]
-        variant1 = mock_model(Variant, shipping_category_id: category1.id)
-        variant2 = mock_model(Variant, shipping_category_id: category2.id)
-        variant3 = mock_model(Variant, shipping_category_id: nil)
-        contents = [ContentItem.new(build(:inventory_unit, variant: variant1)),
-                    ContentItem.new(build(:inventory_unit, variant: variant1)),
-                    ContentItem.new(build(:inventory_unit, variant: variant2)),
-                    ContentItem.new(build(:inventory_unit, variant: variant3))]
+        category_one = create(:shipping_category)
+        category_two = create(:shipping_category)
+        method_one   = create(:shipping_method, available_to_all: true)
+        method_two   = create(:shipping_method, stock_locations: [stock_location])
+        method_one.shipping_categories = [category_one, category_two]
+        method_two.shipping_categories = [category_one, category_two]
+        variant_one = mock_model(Variant, shipping_category_id: category_one.id)
+        variant_two = mock_model(Variant, shipping_category_id: category_two.id)
+        variant_three = mock_model(Variant, shipping_category_id: nil)
+        contents = [ContentItem.new(build(:inventory_unit, variant: variant_one)),
+                    ContentItem.new(build(:inventory_unit, variant: variant_one)),
+                    ContentItem.new(build(:inventory_unit, variant: variant_two)),
+                    ContentItem.new(build(:inventory_unit, variant: variant_three))]
 
         package = Package.new(stock_location, contents)
-        expect(package.shipping_methods).to match_array([method1, method2])
+        expect(package.shipping_methods).to match_array([method_one, method_two])
       end
       # Contains regression test for https://github.com/spree/spree/issues/2804
       it 'builds a list of shipping methods common to all categories' do
-        category1 = create(:shipping_category)
-        category2 = create(:shipping_category)
-        method1   = create(:shipping_method)
-        method2   = create(:shipping_method)
-        method1.shipping_categories = [category1, category2]
-        method2.shipping_categories = [category1]
-        variant1 = mock_model(Variant, shipping_category_id: category1.id)
-        variant2 = mock_model(Variant, shipping_category_id: category2.id)
-        variant3 = mock_model(Variant, shipping_category_id: nil)
-        contents = [ContentItem.new(build(:inventory_unit, variant: variant1)),
-                    ContentItem.new(build(:inventory_unit, variant: variant1)),
-                    ContentItem.new(build(:inventory_unit, variant: variant2)),
-                    ContentItem.new(build(:inventory_unit, variant: variant3))]
+        category_one = create(:shipping_category)
+        category_two = create(:shipping_category)
+        method_one   = create(:shipping_method)
+        method_two   = create(:shipping_method)
+        method_one.shipping_categories = [category_one, category_two]
+        method_two.shipping_categories = [category_one]
+        variant_one = mock_model(Variant, shipping_category_id: category_one.id)
+        variant_two = mock_model(Variant, shipping_category_id: category_two.id)
+        variant_three = mock_model(Variant, shipping_category_id: nil)
+        contents = [ContentItem.new(build(:inventory_unit, variant: variant_one)),
+                    ContentItem.new(build(:inventory_unit, variant: variant_one)),
+                    ContentItem.new(build(:inventory_unit, variant: variant_two)),
+                    ContentItem.new(build(:inventory_unit, variant: variant_three))]
 
         package = Package.new(stock_location, contents)
-        expect(package.shipping_methods).to match_array([method1])
+        expect(package.shipping_methods).to match_array([method_one])
       end
 
       it 'builds an empty list of shipping methods when no categories' do

--- a/core/spec/models/spree/stock/simple_coordinator_spec.rb
+++ b/core/spec/models/spree/stock/simple_coordinator_spec.rb
@@ -90,8 +90,8 @@ module Spree
 
           expect(shipments.size).to eq 2
 
-          location_1_shipment = shipments.detect { |p| p.stock_location == stock_location_1 }
-          location_2_shipment = shipments.detect { |p| p.stock_location == stock_location_2 }
+          location_1_shipment = shipments.detect { |shipment| shipment.stock_location == stock_location_1 }
+          location_2_shipment = shipments.detect { |shipment| shipment.stock_location == stock_location_2 }
 
           expect(location_1_shipment).to be_present
           expect(location_2_shipment).to be_present
@@ -107,8 +107,8 @@ module Spree
         let!(:variant) { create(:variant, track_inventory: true) }
 
         before do
-          stock_item1 = variant.stock_items.create!(stock_location: stock_location_1, backorderable: false)
-          stock_item1.set_count_on_hand(location_1_inventory)
+          stock_item_one = variant.stock_items.create!(stock_location: stock_location_1, backorderable: false)
+          stock_item_one.set_count_on_hand(location_1_inventory)
         end
 
         let!(:order) { create(:order) }
@@ -119,7 +119,7 @@ module Spree
         shared_examples "a fulfillable package" do
           it "packages correctly" do
             expect(shipments).not_to be_empty
-            inventory_units = shipments.flat_map { |s| s.inventory_units }
+            inventory_units = shipments.flat_map { |shipment| shipment.inventory_units }
             expect(inventory_units.size).to eq(5)
             expect(inventory_units.uniq.size).to eq(5)
           end
@@ -157,8 +157,8 @@ module Spree
         context 'with two stock locations' do
           let!(:stock_location_2) { create(:stock_location, propagate_all_variants: false, active: true) }
           before do
-            stock_item2 = variant.stock_items.create!(stock_location: stock_location_2, backorderable: false)
-            stock_item2.set_count_on_hand(location_2_inventory)
+            stock_item_two = variant.stock_items.create!(stock_location: stock_location_2, backorderable: false)
+            stock_item_two.set_count_on_hand(location_2_inventory)
           end
 
           context "with no inventory" do
@@ -214,11 +214,11 @@ module Spree
           let!(:stock_location_2) { create(:stock_location, propagate_all_variants: false, active: true) }
           let!(:stock_location_3) { create(:stock_location, propagate_all_variants: false, active: true) }
           before do
-            stock_item2 = variant.stock_items.create!(stock_location: stock_location_2, backorderable: false)
-            stock_item2.set_count_on_hand(location_2_inventory)
+            stock_item_two = variant.stock_items.create!(stock_location: stock_location_2, backorderable: false)
+            stock_item_two.set_count_on_hand(location_2_inventory)
 
-            stock_item3 = variant.stock_items.create!(stock_location: stock_location_3, backorderable: false)
-            stock_item3.set_count_on_hand(location_3_inventory)
+            stock_item_three = variant.stock_items.create!(stock_location: stock_location_3, backorderable: false)
+            stock_item_three.set_count_on_hand(location_3_inventory)
           end
 
           # Regression test for https://github.com/solidusio/solidus/issues/2122

--- a/core/spec/models/spree/stock/splitter/base_spec.rb
+++ b/core/spec/models/spree/stock/splitter/base_spec.rb
@@ -9,12 +9,12 @@ module Spree
         let(:stock_location) { mock_model(Spree::StockLocation) }
 
         it 'continues to splitter chain' do
-          splitter1 = Base.new(stock_location)
-          splitter2 = Base.new(stock_location, splitter1)
+          splitter_one = Base.new(stock_location)
+          splitter_two = Base.new(stock_location, splitter_one)
           packages = []
 
-          expect(splitter1).to receive(:split).with(packages)
-          splitter2.split(packages)
+          expect(splitter_one).to receive(:split).with(packages)
+          splitter_two.split(packages)
         end
       end
     end

--- a/core/spec/models/spree/stock/splitter/shipping_category_spec.rb
+++ b/core/spec/models/spree/stock/splitter/shipping_category_spec.rb
@@ -29,15 +29,15 @@ module Spree
       subject { described_class.new(stock_location) }
 
       it 'splits each package by shipping category' do
-        package1 = Package.new(stock_location)
-        4.times { package1.add inventory_unit1 }
-        8.times { package1.add inventory_unit2 }
+        package_one = Package.new(stock_location)
+        4.times { package_one.add inventory_unit1 }
+        8.times { package_one.add inventory_unit2 }
 
-        package2 = Package.new(stock_location)
-        6.times { package2.add inventory_unit1 }
-        9.times { package2.add inventory_unit2, :backordered }
+        package_two = Package.new(stock_location)
+        6.times { package_two.add inventory_unit1 }
+        9.times { package_two.add inventory_unit2, :backordered }
 
-        packages = subject.split([package1, package2])
+        packages = subject.split([package_one, package_two])
         expect(packages[0].quantity).to eq 4
         expect(packages[1].quantity).to eq 8
         expect(packages[2].quantity).to eq 6

--- a/core/spec/models/spree/stock_quantities_spec.rb
+++ b/core/spec/models/spree/stock_quantities_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Spree::StockQuantities, type: :model do
 
   describe "#each" do
     def expect_each
-      expect { |b| subject.each(&b) }
+      expect { |item| subject.each(&item) }
     end
 
     context "with no items" do

--- a/frontend/app/controllers/spree/orders_controller.rb
+++ b/frontend/app/controllers/spree/orders_controller.rb
@@ -59,8 +59,8 @@ module Spree
 
       begin
         @line_item = @order.contents.add(variant, quantity)
-      rescue ActiveRecord::RecordInvalid => e
-        @order.errors.add(:base, e.record.errors.full_messages.join(", "))
+      rescue ActiveRecord::RecordInvalid => error
+        @order.errors.add(:base, error.record.errors.full_messages.join(", "))
       end
 
       respond_with(@order) do |format|

--- a/frontend/lib/generators/solidus/views/override_generator.rb
+++ b/frontend/lib/generators/solidus/views/override_generator.rb
@@ -24,6 +24,7 @@ module Solidus
       def copy_views
         views_to_copy.each do |file|
           next if File.directory?(file)
+
           dest_file = Pathname.new(file).relative_path_from(source_dir)
           copy_file file, Rails.root.join('app', 'views', 'spree', dest_file)
         end
@@ -33,8 +34,8 @@ module Solidus
 
       def views_to_copy
         if @options['only']
-          VIEWS.select do |v|
-            Pathname.new(v).relative_path_from(source_dir).to_s.include?(@options['only'])
+          VIEWS.select do |view|
+            Pathname.new(view).relative_path_from(source_dir).to_s.include?(@options['only'])
           end
         else
           VIEWS

--- a/frontend/lib/spree/frontend/middleware/seo_assist.rb
+++ b/frontend/lib/spree/frontend/middleware/seo_assist.rb
@@ -38,11 +38,11 @@ module Spree
         end
 
         def build_query(params)
-          params.map { |k, v|
-            if v.class == Array
-              build_query(v.map { |x| ["#{k}[]", x] })
+          params.map { |key, value|
+            if value.class == Array
+              build_query(value.map { |parameter| ["#{key}[]", parameter] })
             else
-              k + "=" + Rack::Utils.escape(v)
+              key + "=" + Rack::Utils.escape(value)
             end
           }.join("&")
         end

--- a/guides/helpers/image_helpers.rb
+++ b/guides/helpers/image_helpers.rb
@@ -18,7 +18,7 @@ module ImageHelpers
     asset = "source/assets/images/#{filename}"
 
     if File.exist?(asset)
-      file = File.open(asset, 'r') { |f| f.read }
+      file = File.open(asset, 'r') { |file_io| file_io.read }
       # we pass svg-targeting css classes through here, ex. .svg-color--blue. The class targets fill, stroke, poly, circle, etc.
       css_class = options[:class]
       # this could be passed via helper, right now this default covers most of our svg use cases.


### PR DESCRIPTION
Throughout Solidus' codebase there are many one-letter variables.
These are not ideal as they are not expressive and meaningful for human
beings.

This is a continuation of work done by @mkoltonski in https://github.com/solidusio/solidus/pull/3304 with the feedback from @dportalesr incorporated.

Fixes #3294 

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
