### PR TITLE
Fixing admin store credit reasons tab not expanded

### DIFF
--- a/backend/app/views/spree/admin/shared/_settings_sub_menu.html.erb
+++ b/backend/app/views/spree/admin/shared/_settings_sub_menu.html.erb
@@ -13,7 +13,7 @@
 
   <% if can?(:display, Spree::RefundReason) || can?(:display, Spree::ReimbursementType) ||
     can?(:display, Spree::ReturnReason) || can?(:display, Spree::AdjustmentReason) %>
-    <%= tab :checkout, url: spree.admin_refund_reasons_path, match_path: %r(refund_reasons|reimbursement_types|return_reasons|adjustment_reasons) %>
+    <%= tab :checkout, url: spree.admin_refund_reasons_path, match_path: %r(refund_reasons|reimbursement_types|return_reasons|adjustment_reasons|store_credit_reasons) %>
   <% end %>
 
   <% if can?(:display, Spree::ShippingMethod) || can?(:display, Spree::ShippingCategory) || can?(:display, Spree::StockLocation) %>

--- a/backend/lib/spree/backend_configuration.rb
+++ b/backend/lib/spree/backend_configuration.rb
@@ -17,7 +17,8 @@ module Spree
                             :payment_methods, :shipping_methods,
                             :shipping_categories, :stock_locations,
                             :refund_reasons, :reimbursement_types,
-                            :return_reasons, :adjustment_reasons]
+                            :return_reasons, :adjustment_reasons,
+                            :store_credit_reasons]
     PROMOTION_TABS     ||= [:promotions, :promotion_categories]
     STOCK_TABS         ||= [:stock_items]
     USER_TABS          ||= [:users, :store_credits]


### PR DESCRIPTION
**Description**
Left menu was not expanded when trying to manage store credit reasons

Before
![image](https://user-images.githubusercontent.com/127449/67509542-81fa6c80-f650-11e9-8db4-eeccd2b8653f.png)

After

![image](https://user-images.githubusercontent.com/127449/67509643-ad7d5700-f650-11e9-9fea-7cc9ff37f23b.png)


**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
