### PR TITLE
Introduce ActionView::Component for backend components

### DIFF
--- a/backend/app/components/spree/admin/pill_component.html.erb
+++ b/backend/app/components/spree/admin/pill_component.html.erb
@@ -1,0 +1,1 @@
+<span class="pill pill-<%= state %>"><%= text %></span>

--- a/backend/app/components/spree/admin/pill_component.rb
+++ b/backend/app/components/spree/admin/pill_component.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class Spree::Admin::PillComponent < ActionView::Component::Base
+  STATES = %i[
+    active
+    complete
+    error
+    inactive
+    neutral
+    pending
+    text
+    warning
+  ]
+
+  validates :state, inclusion: STATES, unless: -> { state.is_a? String }
+
+  def initialize(state: "neutral", text: nil)
+    @state = state
+    @text = text
+  end
+
+  attr_reader :state
+
+  def text
+    @text || content || I18n.t("spree.#{state}", default: nil) || @state
+  end
+end

--- a/backend/app/views/spree/admin/adjustment_reasons/index.html.erb
+++ b/backend/app/views/spree/admin/adjustment_reasons/index.html.erb
@@ -33,9 +33,7 @@
             <%= adjustment_reason.name %>
           </td>
           <td>
-            <span class="pill pill-<%= adjustment_reason.active? ? 'active' : 'inactive' %>">
-              <%= t(adjustment_reason.active? ? :active : :inactive, scope: 'spree') %>
-            </span>
+            <%= render Spree::Amin::PillComponent, status: adjustment_reason.active? ? :active : :inactive %>
           </td>
           <td class="actions">
             <%= link_to_edit adjustment_reason, no_text: true %>

--- a/backend/app/views/spree/admin/cancellations/index.html.erb
+++ b/backend/app/views/spree/admin/cancellations/index.html.erb
@@ -37,9 +37,9 @@
           </td>
           <td class="inventory-unit-quantity align-center">1</td>
           <td class="inventory-unit-state">
-            <span class="pill pill-<%= inventory_unit.state %>">
+            <%= render Spree::Admin::PillComponent, state: inventory_unit.state do %>
               <%= t(inventory_unit.state, scope: 'spree.inventory_states') %>
-            </span>
+            <% end %>
           </td>
           <td class="inventory-unit-shipment"><%= inventory_unit.shipment.number %></td>
           <td class="inventory-unit-cancel align-right">

--- a/backend/app/views/spree/admin/customer_returns/_reimbursements_table.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/_reimbursements_table.html.erb
@@ -20,12 +20,12 @@
         </td>
         <td><%= reimbursement.display_total %></td>
         <td>
-          <span class="pill pill-<%= reimbursement.reimbursement_status %>">
+          <%= render Spree::Admin::PillComponent, state: reimbursement.reimbursement_status do %>
             <%= t(
               reimbursement.reimbursement_status,
               scope: 'spree.reimbursement_states'
             ) %>
-          </span>
+          <% end %>
         </td>
         <td><%= pretty_time(reimbursement.created_at) %></td>
         <td class="actions">

--- a/backend/app/views/spree/admin/customer_returns/_return_item_decision.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/_return_item_decision.html.erb
@@ -39,12 +39,12 @@
           <%= return_item.acceptance_status_errors %>
         </td>
         <td>
-          <span class="pill pill-<%= return_item.reception_status %>">
+          <%= render Spree::Admin::PillComponent, state: return_item.reception_status do %>
             <%= t(
               return_item.reception_status,
               scope: 'spree.reception_states'
             ) %>
-          </span>
+          <% end %>
         </td>
         <% unless return_item.received? %>
           <td>

--- a/backend/app/views/spree/admin/customer_returns/_return_item_selection.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/_return_item_selection.html.erb
@@ -38,12 +38,12 @@
           <%= return_item.display_amount %>
         </td>
         <td>
-          <span class="pill pill-<%= return_item.inventory_unit.state %>">
+          <%= render Spree::Admin::PillComponent, state: return_item.inventory_unit.state do %>
             <%= t(
               return_item.inventory_unit.state,
               scope: 'spree.inventory_states'
             ) %>
-          </span>
+          <% end %>
         </td>
         <td>
           <%= return_item.exchange_variant.try(:exchange_name) %>

--- a/backend/app/views/spree/admin/customer_returns/index.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/index.html.erb
@@ -31,9 +31,9 @@
           <td><%= pretty_time(customer_return.created_at) %></td>
           <td>
             <% if customer_return.fully_reimbursed? %>
-              <span class="pill pill-complete"><%= t('spree.reimbursed') %></span>
+              <%= render Spree::Admin::PillComponent, state: :complete, text: t('spree.reimbursed') %>
             <% else %>
-              <span class="pill pill-pending"><%= t('spree.incomplete') %></span>
+              <%= render Spree::Admin::PillComponent, state: :pending, text: t('spree.incomplete') %>
             <% end %>
           </td>
           <td class='actions align-center' data-hook="admin_orders_customer_returns_index_row_actions">

--- a/backend/lib/spree/backend.rb
+++ b/backend/lib/spree/backend.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails/all'
+require 'action_view/component/base'
 require 'jquery-rails'
 require 'coffee-rails'
 require 'sassc-rails'

--- a/backend/solidus_backend.gemspec
+++ b/backend/solidus_backend.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'solidus_api', s.version
   s.add_dependency 'solidus_core', s.version
 
+  s.add_dependency 'actionview-component', '~> 1.3'
   s.add_dependency 'coffee-rails'
   s.add_dependency 'font-awesome-rails', '~> 4.0'
   s.add_dependency 'jbuilder', '~> 2.8'

--- a/backend/spec/components/spree/admin/pill_component_spec.rb
+++ b/backend/spec/components/spree/admin/pill_component_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+# Spree's rpsec controller tests get the Spree::ControllerHacks
+# we don't need those for the anonymous controller here, so
+# we call process directly instead of get
+require 'spec_helper'
+
+describe Spree::Admin::PillComponent, type: :component do
+  def expect_html_for(*options, &block)
+    expect(
+      render_inline(described_class, *options, &block).css("body > *").to_html
+    )
+  end
+
+  describe 'known states' do
+    it 'can be active' do
+      expect_html_for(state: :active).to eq(%{<span class="pill pill-active">Active</span>})
+    end
+
+    it 'can be inactive' do
+      expect_html_for(state: :inactive).to eq(%{<span class="pill pill-inactive">Inactive</span>})
+    end
+
+    it 'can be complete' do
+      expect_html_for(state: :complete).to eq(%{<span class="pill pill-complete">complete</span>})
+    end
+
+    it 'can be error' do
+      expect_html_for(state: :error).to eq(%{<span class="pill pill-error">error</span>})
+    end
+
+    it 'can be neutral' do
+      expect_html_for(state: :neutral).to eq(%{<span class="pill pill-neutral">neutral</span>})
+    end
+
+    it 'can be pending' do
+      expect_html_for(state: :pending).to eq(%{<span class="pill pill-pending">Pending</span>})
+    end
+
+    it 'can be warning' do
+      expect_html_for(state: :warning).to eq(%{<span class="pill pill-warning">warning</span>})
+    end
+  end
+
+  it 'defaults state to "neutral"' do
+    expect_html_for.to eq(%{<span class="pill pill-neutral">neutral</span>})
+    expect_html_for { "Foobar" }.to eq(%{<span class="pill pill-neutral">Foobar</span>})
+  end
+
+  describe 'content' do
+    it 'falls back to passed "text:", block, translation, state' do
+      expect_html_for(state: "foo", text: "bar") { "baz" }.to eq(%{<span class="pill pill-foo">bar</span>})
+      expect_html_for(state: "foo") { "baz" }.to eq(%{<span class="pill pill-foo">baz</span>})
+
+      allow(I18n).to receive(:t).with("spree.foo", default: nil).and_return("FOO").once
+      expect_html_for(state: "foo").to eq(%{<span class="pill pill-foo">FOO</span>})
+
+      allow(I18n).to receive(:t).with("spree.foo", default: nil).and_return(nil).once
+      expect_html_for(state: "foo").to eq(%{<span class="pill pill-foo">foo</span>})
+    end
+  end
+
+  it "doesn't accept an unknown state" do
+    expect{ render_inline(described_class, state: :foobar) }.to raise_error(ActiveModel::ValidationError)
+    expect{ render_inline(described_class, state: nil) }.to raise_error(ActiveModel::ValidationError)
+    expect{ render_inline(described_class, state: false) }.to raise_error(ActiveModel::ValidationError)
+    expect{ render_inline(described_class, state: Object.new) }.to raise_error(ActiveModel::ValidationError)
+  end
+
+  it "accepts an unknown state if it's a String" do
+    expect{ render_inline(described_class, state: "FOO") }.not_to raise_error
+  end
+end

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -96,6 +96,9 @@ RSpec.configure do |config|
 
   config.include BaseFeatureHelper, type: :feature
 
+  require "action_view/component/test_helpers"
+  config.include ActionView::Component::TestHelpers, type: :component
+
   config.after(:each, type: :feature) do |example|
     missing_translations = page.body.scan(/translation missing: #{I18n.locale}\.(.*?)[\s<\"&]/)
     if missing_translations.any?


### PR DESCRIPTION
**Description**

Creating a set of components for the backend will help in having both
a more consistent UI and will give developers a cleaner way to extend Solidus.

https://github.com/github/actionview-component#readme

_ActionView::Component will come as a standard Rails feature in v6.1_

The provided changes regarding the use of the Pill component are incomplete and I'll finish converting existing view once reasonable consensus from the core-team is reached.

Further components can be added and introduced in future PRs, unless requested otherwise.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
