### PR TITLE
Add max_line_length for Markdown files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -20,3 +20,4 @@ max_line_length = 120
 
 [*.md]
 trim_trailing_whitespace = false
+max_line_length = 80


### PR DESCRIPTION
**Description**

It seems to be an unwritten rule that Markdown files should be wrapped at 80 characters. I don't fully agree with this (I think 120 makes much more sense nowadays), but it should at least be specified in `.editorconfig`, so that text editors can pick it up and show a ruler/wrap automatically.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
