### PR TITLE
Remove RABL remnants

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -1,6 +1,6 @@
 # solidus_api
 
-API contains the controllers and rabl views implementing the REST API of
+API contains the controllers and Jbuilder views implementing the REST API of
 Solidus.
 
 ## Testing

--- a/api/lib/spree/api/responders.rb
+++ b/api/lib/spree/api/responders.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 require 'responders'
-require 'spree/api/responders/rabl_template'
+require 'spree/api/responders/jbuilder_template'
 
 module Spree
   module Api
     module Responders
       class AppResponder < ActionController::Responder
-        include RablTemplate
+        include JbuilderTemplate
       end
     end
   end

--- a/api/lib/spree/api/responders/jbuilder_template.rb
+++ b/api/lib/spree/api/responders/jbuilder_template.rb
@@ -3,7 +3,7 @@
 module Spree
   module Api
     module Responders
-      module RablTemplate
+      module JbuilderTemplate
         def to_format
           if template
             render template, status: options[:status] || 200
@@ -16,6 +16,8 @@ module Spree
           options[:default_template]
         end
       end
+
+      RablTemplate = ActiveSupport::Deprecation::DeprecatedConstantProxy.new('RablTemplate', 'JbuilderTemplate')
     end
   end
 end

--- a/api/spec/lib/spree_api_responders_spec.rb
+++ b/api/spec/lib/spree_api_responders_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Spree Api Responders" do
+  it "RablTemplate is deprecated Use JbuilderTemplate" do
+    warning_message = /DEPRECATION WARNING: RablTemplate is deprecated! Use JbuilderTemplate instead/
+    expect{ Spree::Api::Responders::RablTemplate.methods }.to output(warning_message).to_stderr
+  end
+end

--- a/api/spec/requests/jbuilder_cache_spec.rb
+++ b/api/spec/requests/jbuilder_cache_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe "Rabl Cache", type: :request, caching: true do
+describe "Jbuilder Cache", type: :request, caching: true do
   let!(:user)  { create(:admin_user) }
 
   before do
@@ -11,7 +11,7 @@ describe "Rabl Cache", type: :request, caching: true do
     expect(Spree::Product.count).to eq(1)
   end
 
-  it "doesn't create a cache key collision for models with different rabl templates" do
+  it "doesn't create a cache key collision for models with different jbuilder templates" do
     get "/api/variants", params: { token: user.spree_api_key }
     expect(response.status).to eq(200)
 


### PR DESCRIPTION
**Description**
RABL was removed from the project on version 2.4.0 (See #2147 #2146).
This updates the responder template to match with Jbuilder and updates
the README file.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
