### PR TITLE
Caching product results in frontend

### DIFF
--- a/core/lib/spree/testing_support/caching.rb
+++ b/core/lib/spree/testing_support/caching.rb
@@ -10,6 +10,15 @@ module Spree
       def clear_cache_events
         @cache_write_events = []
       end
+
+      def render_collection_cache_hits_for(partial = nil)
+        @render_collection_events.inject(0) do |final, event|
+          if event[:identifier].include?(partial)
+            final += event[:cache_hits]
+          end
+          final
+        end
+      end
     end
   end
 end
@@ -23,6 +32,11 @@ RSpec.configure do |config|
     ActiveSupport::Notifications.subscribe("write_fragment.action_controller") do |_event, _start_time, _finish_time, _, details|
       @cache_write_events ||= []
       @cache_write_events << details
+    end
+
+    ActiveSupport::Notifications.subscribe("render_collection.action_view") do |_event, _start_time, _finish_time, _, details|
+      @render_collection_events ||= []
+      @render_collection_events << details
     end
   end
 

--- a/frontend/app/views/spree/shared/_product_tile.html.erb
+++ b/frontend/app/views/spree/shared/_product_tile.html.erb
@@ -1,0 +1,15 @@
+<% url = spree.product_path(product, taxon_id: @taxon.try(:id)) %>
+<li id="product_<%= product.id %>" class="columns three <%= cycle("alpha", "secondary", "", "omega secondary", name: "classes") %>" data-hook="products_list_item" itemscope itemtype="http://schema.org/Product">
+  <div class="product-image">
+    <%= link_to(render('spree/shared/image', image: product.gallery.images.first, size: :small, itemprop: "image"), url, itemprop: 'url') %>
+  </div>
+  <%= link_to truncate(product.name, length: 50), url, class: 'info', itemprop: "name", title: product.name %>
+  <div itemprop="offers" itemscope itemtype="http://schema.org/Offer">
+    <% if price = product.price_for_options(current_pricing_options)&.money %>
+      <span class="price selling" itemprop="price" content="<%= price.to_d %>">
+        <%= price.to_html %>
+      </span>
+    <% end %>
+    <span itemprop="priceCurrency" content="<%= current_pricing_options.currency %>"></span>
+  </div>
+</li>

--- a/frontend/app/views/spree/shared/_products.html.erb
+++ b/frontend/app/views/spree/shared/_products.html.erb
@@ -23,25 +23,10 @@
 
 <% if products.any? %>
   <ul id="products" class="inline product-listing" data-hook>
-    <% products.each do |product| %>
-      <% url = spree.product_path(product, taxon_id: @taxon.try(:id)) %>
-      <li id="product_<%= product.id %>" class="columns three <%= cycle("alpha", "secondary", "", "omega secondary", name: "classes") %>" data-hook="products_list_item" itemscope itemtype="http://schema.org/Product">
-        <% cache(@taxon.present? ? [I18n.locale, current_pricing_options, @taxon, product] : [I18n.locale, current_pricing_options, product]) do %>
-          <div class="product-image">
-            <%= link_to(render('spree/shared/image', image: product.gallery.images.first, size: :small, itemprop: "image"), url, itemprop: 'url') %>
-          </div>
-          <%= link_to truncate(product.name, length: 50), url, class: 'info', itemprop: "name", title: product.name %>
-          <span itemprop="offers" itemscope itemtype="http://schema.org/Offer">
-            <% if price = product.price_for_options(current_pricing_options)&.money %>
-              <span class="price selling" itemprop="price" content="<%= price.to_d %>">
-                <%= price.to_html %>
-              </span>
-            <% end %>
-            <span itemprop="priceCurrency" content="<%= current_pricing_options.currency %>"></span>
-          </span>
-        <% end %>
-      </li>
-    <% end %>
+    <%= render partial: 'spree/shared/product_tile',
+               collection: products,
+               as: :product,
+               cached: Proc.new { |product| [I18n.locale, current_pricing_options, product, @taxon] } %>
     <% reset_cycle("classes") %>
   </ul>
 <% end %>

--- a/frontend/spec/features/caching/products_spec.rb
+++ b/frontend/spec/features/caching/products_spec.rb
@@ -24,25 +24,28 @@ describe 'products', type: :feature, caching: true do
   it "busts the cache when a product is updated" do
     product.update_column(:updated_at, 1.day.from_now)
     visit spree.root_path
-    expect(cache_writes.count).to eq(2)
+    expect(cache_writes.count).to eq(1)
   end
 
   it "busts the cache when all products are soft-deleted" do
     product.discard
     product2.discard
     visit spree.root_path
+    expect(render_collection_cache_hits_for('_product_tile')).to be_zero
     expect(cache_writes.count).to eq(1)
   end
 
   it "busts the cache when the newest product is soft-deleted" do
     product.discard
     visit spree.root_path
+    expect(render_collection_cache_hits_for('_product_tile')).to eq(1)
     expect(cache_writes.count).to eq(1)
   end
 
   it "busts the cache when an older product is soft-deleted" do
     product2.discard
     visit spree.root_path
+    expect(render_collection_cache_hits_for('_product_tile')).to eq(1)
     expect(cache_writes.count).to eq(1)
   end
 end


### PR DESCRIPTION
Taking advantage of [Rails collection caching](https://guides.rubyonrails.org/caching_with_rails.html#collection-caching) to perform multi get if possible
it fetches multiple items at once instead of one by one if the cache storage driver allows it.

Added as point of reference about how to make Solidus stores even faster.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
