### PR TITLE
Set error flash when unsuccesful destroy using HTML format

### DIFF
--- a/backend/app/controllers/spree/admin/resource_controller.rb
+++ b/backend/app/controllers/spree/admin/resource_controller.rb
@@ -107,8 +107,14 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
     else
       invoke_callbacks(:destroy, :fails)
       respond_with(@object) do |format|
-        format.html { redirect_to location_after_destroy }
-        format.js { render status: :unprocessable_entity, plain: @object.errors.full_messages.to_sentence }
+        message = @object.errors.full_messages.to_sentence
+        format.html do
+          flash[:error] = message
+          redirect_to location_after_destroy
+        end
+        format.js do
+          render status: :unprocessable_entity, plain: message
+        end
       end
     end
   end

--- a/backend/app/controllers/spree/admin/resource_controller.rb
+++ b/backend/app/controllers/spree/admin/resource_controller.rb
@@ -108,7 +108,7 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
       invoke_callbacks(:destroy, :fails)
       respond_with(@object) do |format|
         format.html { redirect_to location_after_destroy }
-        format.js { render status: :unprocessable_entity, plain: @object.errors.full_messages.join(', ') }
+        format.js { render status: :unprocessable_entity, plain: @object.errors.full_messages.to_sentence }
       end
     end
   end

--- a/backend/spec/controllers/spree/admin/resource_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/resource_controller_spec.rb
@@ -168,6 +168,16 @@ describe Spree::Admin::WidgetsController, type: :controller do
           expect(response.body).to eq assigns(:widget).errors.full_messages.to_sentence
         end
       end
+
+      context 'html format' do
+        subject { delete :destroy, params: params }
+
+        it 'responds with error message' do
+          subject
+          expect(response).to be_redirect
+          expect(flash[:error]).to eq assigns(:widget).errors.full_messages.to_sentence
+        end
+      end
     end
   end
 

--- a/backend/spec/controllers/spree/admin/resource_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/resource_controller_spec.rb
@@ -37,6 +37,7 @@ describe Spree::Admin::WidgetsController, type: :controller do
       def check_destroy_constraints
         return unless name == 'undestroyable'
         errors.add :base, "You can't destroy undestroyable things!"
+        errors.add :base, "Terrible things might happen."
         throw(:abort)
       end
     end
@@ -164,7 +165,7 @@ describe Spree::Admin::WidgetsController, type: :controller do
         it 'responds with error message' do
           subject
           expect(response).to be_unprocessable
-          expect(response.body).to eq assigns(:widget).errors.full_messages.join(', ')
+          expect(response.body).to eq assigns(:widget).errors.full_messages.to_sentence
         end
       end
     end


### PR DESCRIPTION
**Description**

When destroying a resource using the admin resource controller and failing because of some `before_destroy` callback throwing `:abort` with an `ActiveModel::Error`, and using HTML, the user will now see an error message after being redirected to the list of resources. 

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
