### PR TITLE
Let Address#build_default accept args and block

### DIFF
--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -30,8 +30,9 @@ module Spree
       where(value_attributes(attributes))
     end
 
-    def self.build_default
-      new(country: Spree::Country.default)
+    # @return [Address] an address with default attributes
+    def self.build_default(*args, &block)
+      where(country: Spree::Country.default).build(*args, &block)
     end
 
     # @return [Address] an equal address already in the database or a newly created one

--- a/core/spec/models/spree/address_spec.rb
+++ b/core/spec/models/spree/address_spec.rb
@@ -152,6 +152,29 @@ RSpec.describe Spree::Address, type: :model do
         it "sets up a new record with Spree::Config[:default_country_iso]" do
           expect(Spree::Address.build_default.country).to eq default_country
         end
+
+        it 'accepts other attributes' do
+          address = Spree::Address.build_default(first_name: 'Ryan')
+
+          expect(address.country).to eq default_country
+          expect(address.first_name).to eq 'Ryan'
+        end
+
+        it 'accepts a block' do
+          address = Spree::Address.build_default do |record|
+            record.first_name = 'Ryan'
+          end
+
+          expect(address.country).to eq default_country
+          expect(address.first_name).to eq 'Ryan'
+        end
+
+        it 'can override the country' do
+          another_country = build :country
+          address = Spree::Address.build_default(country: another_country)
+
+          expect(address.country).to eq another_country
+        end
       end
 
       # Regression test for https://github.com/spree/spree/issues/1142


### PR DESCRIPTION
**Description**

Let `Address#build_default` it delegate to build/new and leverage scopes for default
attributes. This stems from refactoring code that looked like this:

```rb
Spree::Address.build_default.tap do |address|
  address.first_name = "Ryan"
end
```

With this change it will look like this:

```rb
Spree::Address.build_default(first_name: "Ryan")
```

or

```rb
Spree::Address.build_default do |address|
  address.first_name = "Ryan"
end
```

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
