### PR TITLE
Add list of events fired by default to Guides/Events

### DIFF
--- a/guides/source/developers/events/overview.html.md
+++ b/guides/source/developers/events/overview.html.md
@@ -11,6 +11,11 @@ Among other uses, the Solidus codebase uses events in order to send
 confirmation emails when an order is finalized, or again to send emails
 when an order is refunded successfully.
 
+Currently, the events fired by default in Solidus are:
+* `order_finalized`
+* `reimbursement_reimbursed`
+* `reimbursement_errored`
+
 Events make extending Solidus with custom behavior easy. For example,
 if besides the standard email you also want to send a SMS text message to
 the customer when a order is finalized, this pseudo-code may do the trick:


### PR DESCRIPTION
**Description**

This PR adds the current list of events that Solidus fires off on production to the 'Events' overview guide.

Ref: https://github.com/solidusio/solidus/issues/3414

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
