### PR TITLE
Guides: do not escape markdown headers in custom renderer

### DIFF
--- a/guides/lib/custom_markdown_renderer.rb
+++ b/guides/lib/custom_markdown_renderer.rb
@@ -22,7 +22,7 @@ class CustomMarkdownRenderer < Redcarpet::Render::HTML
 
   def header(text, header_level)
     content_tag "h#{header_level}", id: text.parameterize, class: 'offset' do
-      text
+      mark_safe(text)
     end
   end
 


### PR DESCRIPTION
**Description**
Browsing the developers guide I found some html entities rendered inside headings tags.

<img width="895" alt="Screenshot 2019-11-19 at 15 48 49" src="https://user-images.githubusercontent.com/1382917/69161413-6a958e80-0aeb-11ea-90ed-0142e07bc5c6.png">

This PR updates `CustomMarkdownRenderer` to avoid to render html entities by considering source markdown headers safe.


**Checklist:**
- [X] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [X] I have added a detailed description into each commit message
- [X] I have attached screenshots to this PR for visual changes (if needed)
