### PR TITLE
Relax Paperclip dependency

### DIFF
--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'friendly_id', '~> 5.0'
   s.add_dependency 'kaminari-activerecord', '~> 1.1'
   s.add_dependency 'monetize', '~> 1.8'
-  s.add_dependency 'paperclip', ['>= 4.2', '< 6']
+  s.add_dependency 'paperclip', '>= 4.2'
   s.add_dependency 'paranoia', '~> 2.4'
   s.add_dependency 'ransack', '~> 2.0'
   s.add_dependency 'state_machines-activerecord', '~> 0.6'


### PR DESCRIPTION
Paperclip 6 allows use of the AWS SDK gem v3, which allows ONLY loading
the libraries used for S3 and no others, while otherwise maintaining API
compatibility. Less bytes over the wire!

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
