### PR TITLE
Fixing product discard and classifications issue

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -25,7 +25,7 @@ module Spree
       variants_including_master.discard_all
       self.product_option_types = []
       self.product_properties = []
-      self.classifications = []
+      self.classifications.destroy_all
       self.product_promotion_rules = []
     end
 

--- a/core/spec/models/spree/classification_spec.rb
+++ b/core/spec/models/spree/classification_spec.rb
@@ -44,6 +44,18 @@ module Spree
       end
     end
 
+    context "Discard'ing a product" do
+      before :each do
+        element = taxon_with_5_products.products[1]
+        expect(element.classifications.first.position).to eq(2)
+        element.discard
+      end
+
+      it "resets positions" do
+        expect positions_to_be_valid(taxon_with_5_products)
+      end
+    end
+
     context "replacing taxon's products" do
       before :each do
         products = taxon_with_5_products.products.to_a


### PR DESCRIPTION
When removing a product via discard, it was destroying all
classifications via delete_all, acts as list callbacks were
not called leaving gaps in position.

Created this one instead  of #3172 

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
