### PR TITLE
Remove unused route

### DIFF
--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -66,11 +66,7 @@ Spree::Core::Engine.routes.draw do
 
     delete '/option_values/:id', to: "option_values#destroy", as: :option_value
 
-    resources :properties do
-      collection do
-        get :filtered
-      end
-    end
+    resources :properties
 
     delete '/product_properties/:id', to: "product_properties#destroy", as: :product_property
 


### PR DESCRIPTION
**Description**

That route is unused and we don't have that action in `Spree::Admin::PropertiesController` anymore, since https://github.com/spree/spree/pull/4369

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] ~I have updated Guides and README accordingly to this change (if needed)~
- [ ] ~I have added tests to cover this change (if needed)~
- [ ] ~I have attached screenshots to this PR for visual changes (if needed)~
