### PR TITLE
Fix Turbolinks installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,15 +189,19 @@ config.assets.debug = false
 
 To gain some extra speed you may enable Turbolinks inside of Solidus admin.
 
-Add `gem 'turbolinks', '~> 5.0.0'` into your `Gemfile` (if not already present) and append these lines to `vendor/assets/spree/backend/all.js`:
+Add `gem 'turbolinks', '~> 5.0.0'` into your `Gemfile` (if not already present)
+and change `vendor/assets/javascripts/spree/backend/all.js` as follows:
 
 ```js
 //= require turbolinks
-//= require backend/app/assets/javascripts/spree/backend/turbolinks-integration.js
+//
+// ... current file content
+//
+//= require spree/backend/turbolinks-integration.js
 ```
 
-**CAUTION** Please be aware that Turbolinks can break extensions and/or customizations to the Solidus admin.
-Use at own risk.
+**CAUTION** Please be aware that Turbolinks can break extensions
+and/or customizations to the Solidus admin. Use at your own risk.
 
 ## Developing Solidus
 

--- a/guides/source/developers/getting-started/installation-options.html.md
+++ b/guides/source/developers/getting-started/installation-options.html.md
@@ -81,12 +81,16 @@ Solidus admin. First, add the `turbolinks` gem to your project's `Gemfile`:
 gem 'turbolinks', '~> 5.0.0'
 ```
 
-Then, enable Turbolinks in the backend by appending these lines to the
-JavaScript manifest at `vendor/assets/spree/backend/all/js`:
+Then, enable Turbolinks in the backend by changing the Backend
+JavaScript manifest at `vendor/assets/javascripts/spree/backend/all.js`
+as follow:
 
 ```js
 //= require turbolinks
-//= require backend/app/assets/javascripts/spree/backend/turbolinks-integration.js
+//
+// ... current file content
+//
+//= require spree/backend/turbolinks-integration.js
 ```
 
 Note that Turbolinks can break your custom Solidus extensions or other


### PR DESCRIPTION
**Description**

This PR fixes Turbolinks installation instructions both in Guides and README. 

Closes https://github.com/solidusio/solidus/issues/3440.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [ ] ~I have added tests to cover this change (if needed)~
- [ ] ~I have attached screenshots to this PR for visual changes (if needed)~
