### PR TITLE
Improve line items params in the API documentation

### DIFF
--- a/api/openapi/api.oas2.yml
+++ b/api/openapi/api.oas2.yml
@@ -4353,12 +4353,7 @@ paths:
         - in: body
           name: body
           schema:
-            allOf:
-              - $ref: '#/definitions/line-item-input'
-              - type: object
-                properties:
-                  variant_id:
-                    type: integer
+            $ref: '#/definitions/line-item-input'
       security:
         - api-key: []
         - order-token: []
@@ -4420,12 +4415,7 @@ paths:
         - in: body
           name: body
           schema:
-            allOf:
-              - type: object
-                properties:
-                  variant_id:
-                    type: integer
-              - $ref: '#/definitions/line-item-input'
+            $ref: '#/definitions/line-item-input'
       security:
         - api-key: []
         - order-token: []
@@ -5638,8 +5628,16 @@ definitions:
     properties:
       quantity:
         type: integer
+        description: 'Passing `0`, the line item will be removed.'
       options:
         type: object
+        description: 'This field can be used to pass custom line item attributes. When used, it will force a new price calculation, unless `price` is one of the options.'
+      id:
+        type: integer
+        description: Required for existing line items only.
+      variant_id:
+        type: integer
+        description: Required for new line items only.
   option-type-input:
     type: object
     title: Option type input


### PR DESCRIPTION
**Description**

It is not clear that line items params can have an `id` or a `variant_id`, depending on if we are updating or creating a new item.  This PR also documents better the other fields.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- ~[ ] I have added tests to cover this change (if needed)~
- ~[ ] I have attached screenshots to this PR for visual changes (if needed)~
