### PR TITLE
Adds ability to remove attachments from taxons

### DIFF
--- a/backend/app/controllers/spree/admin/taxons/attachment_controller.rb
+++ b/backend/app/controllers/spree/admin/taxons/attachment_controller.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Spree
+  module Admin
+    module Taxons
+      class AttachmentController < Spree::Admin::BaseController
+        def destroy
+          taxonomy = Spree::Taxonomy.find(params[:taxonomy_id])
+          taxon = taxonomy.taxons.find(params[:taxon_id])
+          if taxon.destroy_attachment(params[:attachment_definition])
+            flash[:success] = t('spree.successfully_removed', resource: params[:attachment_definition].titleize)
+          else
+            flash[:error] = t('spree.taxon_attachment_removal_error')
+          end
+          redirect_to edit_admin_taxonomy_taxon_path(taxonomy, taxon.id)
+        end
+      end
+    end
+  end
+end

--- a/backend/app/views/spree/admin/taxons/attachment_forms/_paperclip.html.erb
+++ b/backend/app/views/spree/admin/taxons/attachment_forms/_paperclip.html.erb
@@ -2,6 +2,15 @@
   <%= f.field_container attachment do %>
     <%= f.label attachment %><br>
     <%= f.file_field attachment %>
-    <%= image_tag f.object.send(attachment, definition[:default_style]) if f.object.send(attachment).present? %>
+    <% if f.object.send(attachment).exists? %>
+      <%= image_tag f.object.send(attachment, definition[:default_style]) %>
+      <%= link_to t('spree.actions.remove'),
+                  admin_taxonomy_taxon_attachment_path(@taxonomy,
+                                                       @taxon.id,
+                                                       attachment_definition: attachment,
+                                                       authenticity_token: form_authenticity_token),
+                  method: :delete,
+                  class: 'btn btn-sm btn-danger' %>
+    <% end %>
   <% end %>
 <% end %>

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -132,7 +132,9 @@ Spree::Core::Engine.routes.draw do
       collection do
         post :update_positions
       end
-      resources :taxons
+      resources :taxons do
+        resource :attachment, controller: 'taxons/attachment', only: [:destroy]
+      end
     end
 
     resources :taxons, only: [:index, :show] do

--- a/backend/spec/features/admin/taxons_spec.rb
+++ b/backend/spec/features/admin/taxons_spec.rb
@@ -75,4 +75,16 @@ describe "Taxonomies and taxons", type: :feature do
       end
     end
   end
+
+  scenario "Removes attachments from taxon" do
+    taxon = create(:taxon)
+    taxon.update(icon: File.new(file_fixture('ror_ringer.jpeg')))
+
+    visit spree.edit_admin_taxonomy_taxon_path(taxon.taxonomy, taxon.id)
+    within('#taxon_icon_field') do
+      click_on 'Remove'
+    end
+
+    expect(page).to have_content("Icon has been successfully removed!")
+  end
 end

--- a/core/app/models/spree/taxon/paperclip_attachment.rb
+++ b/core/app/models/spree/taxon/paperclip_attachment.rb
@@ -22,4 +22,13 @@ module Spree::Taxon::PaperclipAttachment
   def attachment_partial_name
     'paperclip'
   end
+
+  def destroy_attachment(definition)
+    return false unless respond_to?(definition)
+
+    attached_file = send(definition)
+    return false unless attached_file.exists?
+
+    attached_file.destroy
+  end
 end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -2114,6 +2114,7 @@ en:
       (i.e. if the tax rate is 5% then enter 0.05)
     tax_rates: Tax Rates
     taxon: Taxon
+    taxon_attachment_removal_error: There was an error removing the attachment
     taxon_edit: Edit Taxon
     taxon_placeholder: Add a Taxon
     taxon_rule:

--- a/core/spec/models/spree/taxons/paperclip_attachment_spec.rb
+++ b/core/spec/models/spree/taxons/paperclip_attachment_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe "Spree::Taxon::PaperclipAttachment", type: :model do
+  describe "#destroy_attachment" do
+    let(:taxon) { create(:taxon) }
+
+    context "when trying to destroy a valid attachment definition" do
+      context "and taxon has a file attached " do
+        it "removes the attachment" do
+          taxon.update(icon: File.new(Rails.root.join('..', '..', 'spec', 'fixtures', 'thinking-cat.jpg')))
+          expect(taxon.destroy_attachment(:icon)).to be_truthy
+        end
+      end
+      context "and the taxon does not have any file attached yet" do
+        it "returns false" do
+          expect(taxon.destroy_attachment(:icon)).to be_falsey
+        end
+      end
+    end
+
+    context "when trying to destroy an invalid attachment" do
+      it 'returns false' do
+        expect(taxon.destroy_attachment(:foo)).to be_falsey
+      end
+    end
+  end
+end


### PR DESCRIPTION
This takes advantage of the pluggable attachment definitions
and implements the paperclip version

This is another approach of #3366, original approach and source of inspiration

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
