### PR TITLE
Fix Money gem deprecations

### DIFF
--- a/core/config/initializers/money.rb
+++ b/core/config/initializers/money.rb
@@ -4,3 +4,4 @@ require 'money'
 
 Money.locale_backend = :i18n
 Money.rounding_mode = BigDecimal::ROUND_HALF_EVEN
+Money.default_currency = Money::Currency.new(Spree::Config.currency)

--- a/core/config/initializers/money.rb
+++ b/core/config/initializers/money.rb
@@ -3,3 +3,4 @@
 require 'money'
 
 Money.locale_backend = :i18n
+Money.rounding_mode = BigDecimal::ROUND_HALF_EVEN


### PR DESCRIPTION
**Description**
This PR fixes a couple of deprecation warnings we are receiving from Money gem. 

**[Money.rounding_mode deprecation](https://github.com/RubyMoney/money/pull/883)**, which emits:
```
[WARNING] The default rounding mode will change to `ROUND_HALF_UP` in the next major release. Set it explicitly using `Money.rounding_mode=` to avoid potential problems.
```

**[Money.default_currency deprecation](https://github.com/RubyMoney/money/pull/882)**, which emits:

```
[WARNING] The default currency will change to `nil` in the next major release. Make sure to set it explicitly using `Money.default_currency=` to avoid potential issues
```

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- ~[ ] I have added tests to cover this change (if needed)~
- ~[ ] I have attached screenshots to this PR for visual changes (if needed)~
