### PR TITLE
Add instructions to create a sandbox with Rails 5.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,16 @@ data already loaded.
   DB=mysql bundle exec rake sandbox
   ```
 
+  If you need to create a Rails 5.2 application for your sandbox, for example
+  if you are still using Ruby 2.4 which is not supported by Rails 6, you can
+  use the `RAILS_VERSION` environment variable.
+
+  ```bash
+    export RAILS_VERSION='~> 5.2.0'
+    bundle install
+    bundle exec rake sandbox
+  ```
+
 * Start the server
 
   ```bash

--- a/guides/source/developers/getting-started/develop-solidus.html.md
+++ b/guides/source/developers/getting-started/develop-solidus.html.md
@@ -45,6 +45,16 @@ cd sandbox
 rails server
 ```
 
+If you need to create a Rails 5.2 application for your sandbox, for example
+if you are still using Ruby 2.4 which is not supported by Rails 6, you can
+use the `RAILS_VERSION` environment variable.
+
+```bash
+  export RAILS_VERSION='~> 5.2.0'
+  bundle install
+  bundle exec rake sandbox
+```
+
 [contributing]: https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md
 [solidus-auth-devise]: https://github.com/solidusio/solidus_auth_devise
 


### PR DESCRIPTION
**Description**

This is especially needed for users that are using Ruby 2.4, since Rails 6, the default version used for the sandbox, does not support that Ruby version.

Closes https://github.com/solidusio/solidus/issues/3412

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- ~[ ] I have added tests to cover this change (if needed)~
- ~[ ] I have attached screenshots to this PR for visual changes (if needed)~
