### PR TITLE
Deprecate raising an exception when order and line item currencies mismatch

### DIFF
--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -33,6 +33,7 @@ module Spree
       greater_than: -1
     }
     validates :price, numericality: true
+    validate :price_match_order_currency
 
     after_save :update_inventory
 
@@ -42,7 +43,7 @@ module Spree
     delegate :name, :description, :sku, :should_track_inventory?, to: :variant
     delegate :currency, to: :order, allow_nil: true
 
-    attr_accessor :target_shipment
+    attr_accessor :target_shipment, :price_currency
 
     self.whitelisted_ransackable_associations = ['variant']
     self.whitelisted_ransackable_attributes = ['variant_id']
@@ -111,9 +112,10 @@ module Spree
     def money_price=(money)
       if !money
         self.price = nil
-      elsif money.currency.iso_code != currency
+      elsif money.currency.iso_code != currency && Spree::Config.raise_with_invalid_currency
         raise CurrencyMismatch, "Line item price currency must match order currency!"
       else
+        self.price_currency = money.currency.iso_code
         self.price = money.to_d
       end
     end
@@ -201,6 +203,12 @@ module Spree
 
     def destroy_inventory_units
       inventory_units.destroy_all
+    end
+
+    def price_match_order_currency
+      return if price_currency.blank? || price_currency == currency
+
+      errors.add(:price, "Line item price currency must match order currency!")
     end
   end
 end

--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -113,7 +113,8 @@ module Spree
       if !money
         self.price = nil
       elsif money.currency.iso_code != currency && Spree::Config.raise_with_invalid_currency
-        raise CurrencyMismatch, "Line item price currency must match order currency!"
+        line_item_errors = ActiveModel::Errors.new(self)
+        raise CurrencyMismatch, line_item_errors.generate_message(:price, :does_not_match_order_currency, locale: :en)
       else
         self.price_currency = money.currency.iso_code
         self.price = money.to_d
@@ -208,7 +209,7 @@ module Spree
     def price_match_order_currency
       return if price_currency.blank? || price_currency == currency
 
-      errors.add(:price, "Line item price currency must match order currency!")
+      errors.add(:price, :does_not_match_order_currency)
     end
   end
 end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -468,6 +468,7 @@ en:
           attributes:
             price:
               not_a_number: is not valid
+              does_not_match_order_currency: Line item price currency must match order currency!
         spree/price:
           attributes:
             currency:

--- a/core/lib/generators/spree/install/templates/config/initializers/spree.rb.tt
+++ b/core/lib/generators/spree/install/templates/config/initializers/spree.rb.tt
@@ -22,6 +22,14 @@ Spree.config do |config|
   config.image_attachment_module = 'Spree::Image::PaperclipAttachment'
   config.taxon_attachment_module = 'Spree::Taxon::PaperclipAttachment'
 
+  # Defaults
+
+  # Set this configuration to `true` to raise an exception when
+  # an order is populated with a line item with a mismatching
+  # currency. The `false` value will just add a validation error
+  # and will be the only behavior accepted in future versions.
+  # See https://github.com/solidusio/solidus/pull/3456 for more info.
+  config.raise_with_invalid_currency = false
 
   # Permission Sets:
 

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -116,6 +116,13 @@ module Spree
     #   @return [String] ISO 4217 Three letter currency code
     preference :currency, :string, default: "USD"
 
+    # @!attribute [rw] raise_with_invalid_currency
+    #   Whether to raise an exception if trying to set a line item currency
+    #   different from the order currency. When false a validation error
+    #   is added to the instance instead.
+    #   @return [Boolean] (default: +true+)
+    preference :raise_with_invalid_currency, :boolean, default: true
+
     # @!attribute [rw] default_country_id
     #   @deprecated Use the default country ISO preference instead
     #   @return [Integer,nil] id of {Spree::Country} to be selected by default in dropdowns (default: nil)

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -55,6 +55,17 @@ module Spree
         end
       end
 
+      config.after_initialize do
+        if Spree::Config.raise_with_invalid_currency == true
+          Spree::Deprecation.warn(
+            'Spree::Config.raise_with_invalid_currency set to true is ' \
+            'deprecated. Please note that by switching this value, ' \
+            'Spree::LineItem::CurrencyMismatch will not be raised anymore.',
+            caller
+          )
+        end
+      end
+
       # Load in mailer previews for apps to use in development.
       # We need to make sure we call `Preview.all` before requiring our
       # previews, otherwise any previews the app attempts to add need to be

--- a/core/lib/spree/testing_support/dummy_app.rb
+++ b/core/lib/spree/testing_support/dummy_app.rb
@@ -108,6 +108,7 @@ end
 Spree.user_class = 'Spree::LegacyUser'
 Spree.config do |config|
   config.mails_from = "store@example.com"
+  config.raise_with_invalid_currency = false
 end
 
 # Raise on deprecation warnings

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -230,7 +230,10 @@ RSpec.describe Spree::LineItem, type: :model do
         it 'raises an exception' do
           expect {
             line_item.money_price = new_price
-          }.to raise_exception Spree::LineItem::CurrencyMismatch
+          }.to raise_exception(
+            Spree::LineItem::CurrencyMismatch,
+            'Line item price currency must match order currency!'
+          )
         end
       end
 
@@ -240,6 +243,8 @@ RSpec.describe Spree::LineItem, type: :model do
         it 'is not valid' do
           line_item.money_price = new_price
           expect(line_item).not_to be_valid
+          expect(line_item.errors[:price])
+            .to include 'Line item price currency must match order currency!'
         end
       end
     end

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -220,10 +220,27 @@ RSpec.describe Spree::LineItem, type: :model do
     context 'when the price has a currency different from the order currency' do
       let(:currency) { "RUB" }
 
-      it 'raises an exception' do
-        expect {
+      before do
+        stub_spree_preferences(raise_with_invalid_currency: raise_with_invalid_currency)
+      end
+
+      context 'when raise_with_invalid_currency preference is true' do
+        let(:raise_with_invalid_currency) { true }
+
+        it 'raises an exception' do
+          expect {
+            line_item.money_price = new_price
+          }.to raise_exception Spree::LineItem::CurrencyMismatch
+        end
+      end
+
+      context 'when raise_with_invalid_currency preference is false' do
+        let(:raise_with_invalid_currency) { false }
+
+        it 'is not valid' do
           line_item.money_price = new_price
-        }.to raise_exception Spree::LineItem::CurrencyMismatch
+          expect(line_item).not_to be_valid
+        end
       end
     end
   end


### PR DESCRIPTION
**Description**

The current behavior is to raise an exception when the currency of the price that we are trying to set on a line item mismatches with the order currency.

However, this is creating issues because it's raising also when the currency is valid. This happens because we don't have control of the order used by Rails to set attributes on the LineItem instance and
order is still nil/unset when `money_price=` is executed.

This PR allows to conditionally avoid the raise, switching the behavior to a standard Rails validation. This is better because, at validation time, we have the instance with all the attributes set and we are sure to be able to perform the right check.

The validation behavior is the new default for new installations and the `raise` behavior has been deprecated.

This PR has the side effect to restore passing the `options` attribute to a line_item to set attributes that are needed for pricing changes.  We had this feature broken (with pending tests) since [a past security change](https://github.com/solidusio/solidus/pull/2441). 

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- ~[ ] I have updated Guides and README accordingly to this change (if needed)~
- [x] I have added tests to cover this change (if needed)
- ~[ ] I have attached screenshots to this PR for visual changes (if needed)~
