### PR TITLE
Standardize spree event context parameter

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -435,7 +435,7 @@ module Spree
 
       touch :completed_at
 
-      Spree::Event.fire 'order_finalized', order: self
+      Spree::Event.fire 'order_finalized', context: self
     end
 
     def fulfill!

--- a/core/app/models/spree/reimbursement.rb
+++ b/core/app/models/spree/reimbursement.rb
@@ -103,11 +103,11 @@ module Spree
 
       if unpaid_amount_within_tolerance?
         reimbursed!
-        Spree::Event.fire 'reimbursement_reimbursed', reimbursement: self
+        Spree::Event.fire 'reimbursement_reimbursed', context: self
         reimbursement_success_hooks.each { |hook| hook.call self }
       else
         errored!
-        Spree::Event.fire 'reimbursement_errored', reimbursement: self
+        Spree::Event.fire 'reimbursement_errored', context: self
         reimbursement_failure_hooks.each { |hook| hook.call self }
       end
 

--- a/core/app/subscribers/spree/mailer_subscriber.rb
+++ b/core/app/subscribers/spree/mailer_subscriber.rb
@@ -10,7 +10,7 @@ module Spree
     event_action :send_reimbursement_email, event_name: :reimbursement_reimbursed
 
     def order_finalized(event)
-      order = event.payload[:order]
+      order = event.payload[:context]
       unless order.confirmation_delivered?
         Spree::Config.order_mailer_class.confirm_email(order).deliver_later
         order.update_column(:confirmation_delivered, true)
@@ -18,7 +18,7 @@ module Spree
     end
 
     def send_reimbursement_email(event)
-      reimbursement = event.payload[:reimbursement]
+      reimbursement = event.payload[:context]
       Spree::Config.reimbursement_mailer_class.reimbursement_email(reimbursement.id).deliver_later
     end
   end

--- a/core/lib/spree/event.rb
+++ b/core/lib/spree/event.rb
@@ -17,7 +17,7 @@ module Spree
     # @param [Hash] opts a list of options to be passed to the triggered event
     #
     # @example Trigger an event named 'order_finalized'
-    #   Spree::Event.fire 'order_finalized', order: @order do
+    #   Spree::Event.fire 'order_finalized', context: @order do
     #     @order.finalize!
     #   end
     def fire(event_name, opts = {})

--- a/guides/source/developers/events/overview.html.md
+++ b/guides/source/developers/events/overview.html.md
@@ -62,12 +62,12 @@ module Spree
     event_action :send_reimbursement_sms, event_name: :reimbursement_reimbursed
 
     def order_finalized(event)
-      order = event.payload[:order]
+      order = event.payload[:context]
       SmsLibrary.deliver(order, :finalized)
     end
 
     def send_reimbursement_sms(event)
-      reimbursement = event.payload[:reimbursement]
+      reimbursement = event.payload[:context]
       order = reimbursement.order
       SmsLibrary.deliver(order, :reimbursed)
     end
@@ -111,7 +111,7 @@ then both a hash of options (it will be available as the event payload)
 and an optional code block can be passed:
 
 ```ruby
-Spree::Event.fire 'order_finalized', order: @order do
+Spree::Event.fire 'order_finalized', context: @order do
   @order.finalize!
 end
 ```
@@ -121,7 +121,7 @@ without the block:
 
 ```ruby
 @order.finalize!
-Spree::Event.fire 'order_finalized', order: @order
+Spree::Event.fire 'order_finalized', context: @order
 ```
 
 For further information, please refer to the RDOC documentation included in


### PR DESCRIPTION
When calling `Spree::Event.fire 'event'`. It is possible to pass in
parameters. The parameter is usually the context to the event such as an
order in order_finalized or reimbursement when a reimbursement has been
created.

In order to standardize this context rather than calling
`Spree::Event.fire 'order_finalized', order: @order`, call
`Spree::Event.fire 'order_finalized', context: @order`.

This will also allow subscribers to always know which key will contain
the context to the event.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
