### PR TITLE
Add name to Spree::Address

### DIFF
--- a/api/spec/requests/spree/api/orders_controller_spec.rb
+++ b/api/spec/requests/spree/api/orders_controller_spec.rb
@@ -537,13 +537,13 @@ module Spree
       end
 
       it "receives error message if trying to add billing address with errors" do
-        billing_address[:firstname] = ""
+        billing_address[:city] = ""
 
         put spree.api_order_path(order), params: { order: { bill_address_attributes: billing_address } }
 
         expect(json_response['error']).not_to be_nil
         expect(json_response['errors']).not_to be_nil
-        expect(json_response['errors']['bill_address.firstname'].first).to eq "can't be blank"
+        expect(json_response['errors']['bill_address.city'].first).to eq "can't be blank"
       end
 
       it "can add shipping address" do
@@ -557,13 +557,13 @@ module Spree
       it "receives error message if trying to add shipping address with errors" do
         order.update!(ship_address_id: nil)
 
-        shipping_address[:firstname] = ""
+        shipping_address[:city] = ""
 
         put spree.api_order_path(order), params: { order: { ship_address_attributes: shipping_address } }
 
         expect(json_response['error']).not_to be_nil
         expect(json_response['errors']).not_to be_nil
-        expect(json_response['errors']['ship_address.firstname'].first).to eq "can't be blank"
+        expect(json_response['errors']['ship_address.city'].first).to eq "can't be blank"
       end
 
       it "cannot set the user_id for the order" do

--- a/backend/app/views/spree/admin/shared/_address.html.erb
+++ b/backend/app/views/spree/admin/shared/_address.html.erb
@@ -1,8 +1,8 @@
 <div data-hook="address">
-  <%= "#{address.name} " %><%= address.company unless address.company.blank? %><br />
-  <%= address.phone %><%= address.alternative_phone unless address.alternative_phone.blank? %><br />
-  <%= address.address1 %><br />
-  <% if address.address2.present? %><%= address.address2 %><br /><% end %>
-  <%= "#{address.city}, #{address.state_text}, #{address.zipcode}" %><br />
+  <%= address.name %> <%= address.company unless address.company.blank? %><br>
+  <%= address.phone %><%= address.alternative_phone unless address.alternative_phone.blank? %><br>
+  <%= address.address1 %><br>
+  <% if address.address2.present? %><%= address.address2 %><br><% end %>
+  <%= "#{address.city}, #{address.state_text}, #{address.zipcode}" %><br>
   <%= address.country.name %>
 </div>

--- a/backend/app/views/spree/admin/shared/_address.html.erb
+++ b/backend/app/views/spree/admin/shared/_address.html.erb
@@ -1,8 +1,8 @@
 <div data-hook="address">
-  <%="#{address.firstname} #{address.lastname} "%><%= address.company unless address.company.blank? %><br />
-  <%="#{address.phone}" %><%= address.alternative_phone unless address.alternative_phone.blank? %><br />
+  <%= "#{address.name} " %><%= address.company unless address.company.blank? %><br />
+  <%= address.phone %><%= address.alternative_phone unless address.alternative_phone.blank? %><br />
   <%= address.address1 %><br />
-  <% if address.address2.present? %><%= "#{address.address2}" %><br /><% end %>
+  <% if address.address2.present? %><%= address.address2 %><br /><% end %>
   <%= "#{address.city}, #{address.state_text}, #{address.zipcode}" %><br />
-  <%= "#{address.country.name}" %>
+  <%= address.country.name %>
 </div>

--- a/backend/spec/controllers/spree/admin/search_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/search_controller_spec.rb
@@ -33,6 +33,12 @@ describe Spree::Admin::SearchController, type: :controller do
         end
       end
 
+      context 'when searching by ship addresss name' do
+        it_should_behave_like 'user found by search' do
+          let(:user_attribute) { user.ship_address.name }
+        end
+      end
+
       context 'when searching by ship addresss first name' do
         it_should_behave_like 'user found by search' do
           let(:user_attribute) { user.ship_address.firstname }

--- a/core/app/models/spree/address/name.rb
+++ b/core/app/models/spree/address/name.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Spree
+  class Address
+    # Provides a value object to help transitioning from legacy
+    # firstname and lastname fields to a unified name field.
+    class Name
+      attr_reader :first_name, :last_name, :value
+
+      # Creates an instance of Spree::Address::Name parsing input attributes.
+      # @param attributes [Hash] an hash possibly containing name-related
+      #   attributes (name, firstname, lastname, first_name, last_name)
+      # @return [Spree::Address::Name] the object created
+      def self.from_attributes(attributes)
+        params = attributes.with_indifferent_access
+
+        if params[:name].present?
+          Spree::Address::Name.new(params[:name])
+        elsif params[:firstname].present?
+          Spree::Address::Name.new(params[:firstname], params[:lastname])
+        elsif params[:first_name].present?
+          Spree::Address::Name.new(params[:first_name], params[:last_name])
+        else
+          Spree::Address::Name.new
+        end
+      end
+
+      def initialize(*components)
+        @value = components.join(' ').strip
+        initialize_name_components(components)
+      end
+
+      def to_s
+        @value
+      end
+
+      private
+
+      def initialize_name_components(components)
+        if components.size == 2
+          @first_name = components[0].to_s
+          @last_name = components[1].to_s
+        else
+          @first_name, @last_name = @value.split(/[[:space:]]/, 2)
+        end
+      end
+    end
+  end
+end

--- a/core/app/models/spree/credit_card.rb
+++ b/core/app/models/spree/credit_card.rb
@@ -163,7 +163,7 @@ module Spree
     #   the object to ActiveMerchant.
     # @return [String] the first name on this credit card
     def first_name
-      name.to_s.split(/[[:space:]]/, 2)[0]
+      Spree::Address::Name.new(name).first_name
     end
 
     # @note ActiveMerchant needs first_name/last_name because we pass it a
@@ -172,7 +172,7 @@ module Spree
     #   the object to ActiveMerchant.
     # @return [String] the last name on this credit card
     def last_name
-      name.to_s.split(/[[:space:]]/, 2)[1]
+      Spree::Address::Name.new(name).last_name
     end
 
     # @return [ActiveMerchant::Billing::CreditCard] an ActiveMerchant credit

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -136,9 +136,10 @@ module Spree
       find_by! number: value
     end
 
-    delegate :firstname, :lastname, to: :bill_address, prefix: true, allow_nil: true
+    delegate :name, :firstname, :lastname, to: :bill_address, prefix: true, allow_nil: true
     alias_method :billing_firstname, :bill_address_firstname
     alias_method :billing_lastname, :bill_address_lastname
+    alias_method :billing_name, :bill_address_name
 
     class_attribute :update_hooks
     self.update_hooks = Set.new
@@ -398,7 +399,7 @@ module Spree
 
     def name
       if (address = bill_address || ship_address)
-        "#{address.firstname} #{address.lastname}"
+        address.name
       end
     end
 

--- a/core/spec/lib/spree/core/importer/order_spec.rb
+++ b/core/spec/lib/spree/core/importer/order_spec.rb
@@ -36,8 +36,7 @@ module Spree
       let(:ship_address) {
         {
          address1: '123 Testable Way',
-         firstname: 'Fox',
-         lastname: 'Mulder',
+         name: 'Fox Mulder',
          city: 'Washington',
          country_id: country.id,
          state_id: state.id,

--- a/core/spec/models/spree/address/name_spec.rb
+++ b/core/spec/models/spree/address/name_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Spree::Address::Name do
+  it 'concatenates components to form a full name' do
+    name = described_class.new('Jane', 'Von', 'Doe')
+
+    expect(name.to_s).to eq('Jane Von Doe')
+  end
+
+  it 'keeps first name and last name' do
+    name = described_class.new('Jane', 'Doe')
+
+    expect(name.first_name).to eq('Jane')
+    expect(name.last_name).to eq('Doe')
+  end
+
+  it 'splits full name to emulate first name and last name' do
+    name = described_class.new('Jane Von Doe')
+
+    expect(name.first_name).to eq('Jane')
+    expect(name.last_name).to eq('Von Doe')
+  end
+
+  context 'from attributes' do
+    it 'returns name with nil first name if no relevant attribute found' do
+      name = described_class.from_attributes({})
+
+      expect(name.first_name).to be_nil
+      expect(name.last_name).to be_nil
+    end
+
+    it 'prioritizes name over firstname' do
+      attributes = {
+        name: 'Jane Doe',
+        firstname: 'Joe',
+        lastname: 'Bloggs'
+      }
+      name = described_class.from_attributes(attributes)
+
+      expect(name.first_name).to eq('Jane')
+      expect(name.last_name).to eq('Doe')
+    end
+
+    it 'prioritizes firstname over first_name' do
+      attributes = {
+        firstname: 'Jane',
+        lastname: 'Doe',
+        first_name: 'Joe',
+        last_name: 'Bloggs'
+      }
+      name = described_class.from_attributes(attributes)
+
+      expect(name.first_name).to eq('Jane')
+      expect(name.last_name).to eq('Doe')
+    end
+
+    it 'eventually uses first_name' do
+      attributes = {
+        first_name: 'Jane',
+        last_name: 'Doe'
+      }
+      name = described_class.from_attributes(attributes)
+
+      expect(name.first_name).to eq('Jane')
+      expect(name.last_name).to eq('Doe')
+    end
+  end
+end

--- a/core/spec/models/spree/address_spec.rb
+++ b/core/spec/models/spree/address_spec.rb
@@ -350,25 +350,29 @@ RSpec.describe Spree::Address, type: :model do
     end
   end
 
-  context '#full_name' do
-    context 'both first and last names are present' do
-      let(:address) { Spree::Address.new firstname: 'Michael', lastname: 'Jackson' }
-      specify { expect(address.full_name).to eq('Michael Jackson') }
+  context '#name' do
+    it 'concatenates firstname and lastname' do
+      address = Spree::Address.new(firstname: 'Michael J.', lastname: 'Jackson')
+
+      expect(address.name).to eq('Michael J. Jackson')
     end
 
-    context 'first name is blank' do
-      let(:address) { Spree::Address.new firstname: nil, lastname: 'Jackson' }
-      specify { expect(address.full_name).to eq('Jackson') }
+    it 'returns lastname when firstname is blank' do
+      address = Spree::Address.new(firstname: nil, lastname: 'Jackson')
+
+      expect(address.name).to eq('Jackson')
     end
 
-    context 'last name is blank' do
-      let(:address) { Spree::Address.new firstname: 'Michael', lastname: nil }
-      specify { expect(address.full_name).to eq('Michael') }
+    it 'returns firstanme when lastname is blank' do
+      address = Spree::Address.new(firstname: 'Michael J.', lastname: nil)
+
+      expect(address.name).to eq('Michael J.')
     end
 
-    context 'both first and last names are blank' do
-      let(:address) { Spree::Address.new firstname: nil, lastname: nil }
-      specify { expect(address.full_name).to eq('') }
+    it 'returns empty string when firstname and lastname are blank' do
+      address = Spree::Address.new(firstname: nil, lastname: nil)
+
+      expect(address.name).to eq('')
     end
   end
 

--- a/core/spec/models/spree/concerns/user_address_book_spec.rb
+++ b/core/spec/models/spree/concerns/user_address_book_spec.rb
@@ -102,9 +102,9 @@ module Spree
 
       context "updating an address and making default at once" do
         let(:address1) { create(:address) }
-        let(:address2) { create(:address, firstname: "Different") }
+        let(:address2) { create(:address, name: "Different") }
         let(:updated_attrs) do
-          address2.attributes.tap { |value| value[:firstname] = "Johnny" }
+          address2.attributes.tap { |value| value[:name] = "Johnny" }
         end
 
         before do
@@ -114,7 +114,7 @@ module Spree
 
         it "returns the edit as the first address" do
           user.save_in_address_book(updated_attrs, true)
-          expect(user.user_addresses.first.address.firstname).to eq "Johnny"
+          expect(user.user_addresses.first.address.name).to eq "Johnny"
         end
       end
 
@@ -173,7 +173,7 @@ module Spree
         end
 
         context "via an edit to another address" do
-          let(:address2) { create(:address, firstname: "Different") }
+          let(:address2) { create(:address, name: "Different") }
           let(:edited_attributes) do
             # conceptually edit address2 to match the values of address
             edited_attributes = address.attributes
@@ -219,7 +219,7 @@ module Spree
 
     context "#remove_from_address_book" do
       let(:address1) { create(:address) }
-      let(:address2) { create(:address, firstname: "Different") }
+      let(:address2) { create(:address, name: "Different") }
       let(:remove_id) { address1.id }
       subject { user.remove_from_address_book(remove_id) }
 

--- a/core/spec/models/spree/credit_card_spec.rb
+++ b/core/spec/models/spree/credit_card_spec.rb
@@ -90,8 +90,7 @@ RSpec.describe Spree::CreditCard, type: :model do
     let!(:persisted_card) { Spree::CreditCard.find(credit_card.id) }
     let(:valid_address_attributes) do
       {
-        firstname: "Hugo",
-        lastname: "Furst",
+        name: "Hugo Furst",
         address1: "123 Main",
         city: "Somewhere",
         country_id: 1,

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -908,7 +908,7 @@ RSpec.describe Spree::Order, type: :model do
       end
 
       context "and has an invalid bill address associated " do
-        let(:bill_address) { build(:address, firstname: nil) } # invalid address
+        let(:bill_address) { build(:address, city: nil) } # invalid address
 
         it "does not associate any bill address" do
           expect { subject }.not_to change { order.bill_address }.from(nil)
@@ -930,7 +930,7 @@ RSpec.describe Spree::Order, type: :model do
       end
 
       context "and has an invalid ship address associated " do
-        let(:ship_address) { build(:address, firstname: nil) } # invalid address
+        let(:ship_address) { build(:address, city: nil) } # invalid address
 
         it "does not associate any ship address" do
           expect { subject }.not_to change { order.ship_address }.from(nil)

--- a/frontend/app/views/spree/checkout/payment/_gateway.html.erb
+++ b/frontend/app/views/spree/checkout/payment/_gateway.html.erb
@@ -3,7 +3,7 @@
 
 <div class="field field-required card_name" data-hook="card_name">
   <%= label_tag "name_on_card_#{payment_method.id}", t('spree.name_on_card') %>
-  <%= text_field_tag "#{param_prefix}[name]", "#{@order.billing_firstname} #{@order.billing_lastname}", { id: "name_on_card_#{payment_method.id}", autocomplete: "cc-name", class: 'cardName' } %>
+  <%= text_field_tag "#{param_prefix}[name]", @order.billing_name, { id: "name_on_card_#{payment_method.id}", autocomplete: "cc-name", class: 'cardName' } %>
 </div>
 
 <div class="field field-required card_number" data-hook="card_number">

--- a/frontend/app/views/spree/shared/_address.html.erb
+++ b/frontend/app/views/spree/shared/_address.html.erb
@@ -1,5 +1,5 @@
 <div class="address vcard">
-  <div class="fn"><%= address.full_name %></div>
+  <div class="fn"><%= address.name %></div>
   <% unless address.company.blank? %>
     <div class="org">
       <%= address.company %>

--- a/frontend/spec/features/checkout_spec.rb
+++ b/frontend/spec/features/checkout_spec.rb
@@ -113,8 +113,8 @@ describe "Checkout", type: :feature, inaccessible: true do
       end
 
       context "when user has default addresses saved" do
-        let(:saved_bill_address) { create(:address, firstname: 'Bill') }
-        let(:saved_ship_address) { create(:address, firstname: 'Steve') }
+        let(:saved_bill_address) { create(:address, name: 'Bill') }
+        let(:saved_ship_address) { create(:address, name: 'Steve') }
 
         it "shows the saved addresses" do
           within("#billing") do
@@ -194,8 +194,8 @@ describe "Checkout", type: :feature, inaccessible: true do
 
         # Regression test for https://github.com/solidusio/solidus/issues/1811
         context "when does have saved addresses" do
-          let(:saved_bill_address) { create(:address, firstname: 'Bill') }
-          let(:saved_ship_address) { create(:address, firstname: 'Steve') }
+          let(:saved_bill_address) { create(:address, name: 'Bill') }
+          let(:saved_ship_address) { create(:address, name: 'Steve') }
 
           it 'shows empty addresses' do
             within("#billing") do

--- a/sample/db/samples/addresses.rb
+++ b/sample/db/samples/addresses.rb
@@ -3,12 +3,10 @@
 united_states = Spree::Country.find_by!(iso: "US")
 new_york = Spree::State.find_by!(name: "New York")
 
-first_names = ["Sterling", "Jennette", "Salome", "Lyla", "Lola", "Cheree",
-               "Hettie", "Barbie", "Amelia", "Marceline", "Keeley", "Mi",
-               "Karon", "Jessika", "Emmy"]
-last_names = ["Torp", "Vandervort", "Stroman", "Lang", "Zulauf", "Bruen",
-              "Torp", "Gutmann", "Renner", "Bergstrom", "Sauer", "Gaylord",
-              "Mills", "Daugherty", "Stark"]
+names = ["Sterling Torp", "Jennette Vandervort", "Salome Stroman", "Lyla Lang",
+         "Lola Zulauf", "Cheree Bruen", "Hettie Torp", "Barbie Gutmann",
+         "Amelia Renner", "Marceline Bergstrom", "Keeley Sauer", "Mi Gaylord",
+         "Karon Mills", "Jessika Daugherty", "Emmy Stark"]
 street_addresses = ["7377 Jacobi Passage", "4725 Serena Ridges",
                     "79832 Hamill Creek", "0746 Genoveva Villages",
                     "86717 D'Amore Hollow", "8529 Delena Well",
@@ -28,8 +26,7 @@ phone_numbers = ["(392)859-7319 x670", "738-831-3210 x6047",
 
 2.times do
   Spree::Address.create!(
-    firstname: first_names.sample,
-    lastname: last_names.sample,
+    name: names.sample,
     address1: street_addresses.sample,
     address2: secondary_addresses.sample,
     city: cities.sample,


### PR DESCRIPTION
**Description**
This PR proposes a first step to solve #3234 .

The main idea is to add a new `name` attribute to `Spree::Address` and to deprecate `firstname`, `lastname` and `full_name` usage while keeping full backward compatibility.

This PR adds a virtual attribute `name` that replaces `full_name` and favors reading form it when accessing Address data. It uses a `Spree::Address::Name` value object to handle name parsing during deprecation period.

**Checklist:**
- [X] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [X] I have added a detailed description into each commit message
- [X] I have added tests to cover this change (if needed)