### PR TITLE
Update Solidus events guide

### DIFF
--- a/guides/source/developers/events/overview.html.md
+++ b/guides/source/developers/events/overview.html.md
@@ -92,18 +92,6 @@ if defined?(SmsLibrary)
 end
 ```
 
-or just by adding thme to the list of default subscribers, using the
-`Spree::Config.events.subscribers` configuration:
-
-```ruby
-# config/initializers/spree.rb
-
-Spree::Config.events.subscribers << 'Spree::SmsSubscriber'
-```
-
-All the modules present in this array will be loaded while your application
-boots and the `subscribe!` method is automatically called on them.
-
 ## Firing events
 
 `Spree::Event.fire` allows you to fire an event. The event name is mandatory,


### PR DESCRIPTION
The alternative way to add subscribers may not work as expected after app initialization, and it's less future proof than the explicit `Spree::Event::Subscriber#subscribe!` interface as it relies on just adding something to an array.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
