### PR TITLE
Revert method removal and replace it with a deprecation

### DIFF
--- a/core/lib/spree/core/environment_extension.rb
+++ b/core/lib/spree/core/environment_extension.rb
@@ -24,6 +24,11 @@ module Spree
       end
 
       def add_class(name)
+        Spree::Deprecation.warn(
+          'This method is deprecated. ' \
+          "Please use `#{self.class}.add_class_set(#{name.inspect})` instead.",
+          caller,
+        )
         singleton_class.send(:add_class_set, name)
       end
     end

--- a/core/lib/spree/core/environment_extension.rb
+++ b/core/lib/spree/core/environment_extension.rb
@@ -22,6 +22,10 @@ module Spree
           end
         end
       end
+
+      def add_class(name)
+        singleton_class.send(:add_class_set, name)
+      end
     end
   end
 end

--- a/core/spec/lib/spree/core/environment_extension_spec.rb
+++ b/core/spec/lib/spree/core/environment_extension_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 require 'spree/core/environment_extension'
 
 RSpec.describe Spree::Core::EnvironmentExtension do
-  let(:base) { Class.new }
+  let(:base) { Class.new { def self.to_s; 'ExampleClass'; end } }
   subject! { base.include(described_class).new }
 
   describe '.add_class_set' do
@@ -30,6 +30,17 @@ RSpec.describe Spree::Core::EnvironmentExtension do
         it { expect(subject.foo).to include(class_two) }
         it { expect(subject.foo).not_to include(class_three) }
       end
+    end
+  end
+
+  describe '#add_class' do
+    it 'is deprecated' do
+      expect(Spree::Deprecation).to receive(:warn) do |message, _caller|
+        expect(message).to include('ExampleClass.add_class_set(:foo)')
+      end
+      expect(base).to receive(:add_class_set).with(:foo)
+
+      base.new.add_class(:foo)
     end
   end
 end


### PR DESCRIPTION
**Description**
This method was removed within the 2.9 release (by me!) under the false impression that it wasn't really useful for anyone. This PR restores it, possibly saving a headache to users that still have to upgrade to 2.9. The added deprecation has clear instructions on how to move forward.

I've found about this problem via:
- [a Slack comment](https://solidusio.slack.com/archives/C0JBKDF35/p1578434066137900)
- an app I was updating to v2.9

_I'm targeting just 2.9, but I'll be happy to send another PR for master once this is merged_

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
