### PR TITLE
add explicit closing div to admin order edit

### DIFF
--- a/backend/app/views/spree/admin/orders/edit.html.erb
+++ b/backend/app/views/spree/admin/orders/edit.html.erb
@@ -18,7 +18,7 @@
   <%= render 'spree/admin/orders/risk_analysis', latest_payment: @order.payments.reorder("created_at DESC").first %>
 <% end %>
 
-<div data-hook="admin_order_edit_sub_header" />
+<div data-hook="admin_order_edit_sub_header"></div>
 
 <% if @order.line_items.empty? %>
   <div class="no-objects-found">


### PR DESCRIPTION
**Description**
Backend order edit form is not rendering correctly.

Before:
<img width="1686" alt="Screenshot 2020-01-09 at 14 58 35" src="https://user-images.githubusercontent.com/4252/72073821-01631800-32f1-11ea-82e2-c9e8a3f9285d.png">
<img width="1153" alt="Screenshot 2020-01-09 at 14 57 42" src="https://user-images.githubusercontent.com/4252/72073806-f7d9b000-32f0-11ea-9ce4-c929e7dd5d38.png">

After:

<img width="1688" alt="Screenshot 2020-01-09 at 14 58 20" src="https://user-images.githubusercontent.com/4252/72073848-0de77080-32f1-11ea-825d-a5077bf58a66.png">


**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
