### PR TITLE
Avoid prepend accumulation problems

### DIFF
--- a/core/lib/generators/solidus/install/install_generator.rb
+++ b/core/lib/generators/solidus/install/install_generator.rb
@@ -87,6 +87,10 @@ module Solidus
       application <<-RUBY
     # Load application's model / class decorators
     initializer 'spree.decorators' do |app|
+      # Ensure decorated constants are unloaded before reloading decorators
+      config.to_prepare_blocks.unshift -> { ActiveSupport::Dependencies.clear }
+
+      # Load application's decorators
       config.to_prepare do
         app.root.glob('app/**/*_decorator*.rb') { |path| require_dependency(path.to_s)
       end

--- a/core/lib/generators/solidus/install/install_generator.rb
+++ b/core/lib/generators/solidus/install/install_generator.rb
@@ -88,18 +88,14 @@ module Solidus
     # Load application's model / class decorators
     initializer 'spree.decorators' do |app|
       config.to_prepare do
-        Dir.glob(Rails.root.join('app/**/*_decorator*.rb')) do |path|
-          require_dependency(path)
-        end
+        app.root.glob('app/**/*_decorator*.rb') { |path| require_dependency(path.to_s)
       end
     end
 
     # Load application's view overrides
     initializer 'spree.overrides' do |app|
       config.to_prepare do
-        Dir.glob(Rails.root.join('app/overrides/*.rb')) do |path|
-          require_dependency(path)
-        end
+        app.root.glob('app/overrides/*.rb') { |path| require_dependency(path.to_s) }
       end
     end
       RUBY

--- a/guides/source/developers/customizations/decorators.html.md
+++ b/guides/source/developers/customizations/decorators.html.md
@@ -4,8 +4,22 @@ Solidus autoloads any file in the `/app` directory that has the suffix
 `_decorator.rb`, just like any other Rails models or controllers. This allows
 you to [monkey patch][monkey-patch] Solidus functionality for your store.
 
+*Solidus install generator will add code such as this to `config/application.rb`*
+
+```ruby
+initializer 'spree.decorators' do |app|
+  # Ensure decorated constants are unloaded before reloading decorators
+  config.to_prepare_blocks.unshift -> { ActiveSupport::Dependencies.clear }
+
+  # Load application's decorators
+  config.to_prepare do
+    app.root.glob('app/**/*_decorator*.rb') { |path| require_dependency(path.to_s) }
+  end
+end
+```
+
 For example, if you want to add a method to the `Spree::Order` model, you could
-create `/app/models/mystore/order_decorator.rb` with the following contents:
+create `/app/models/my_store/order_decorator.rb` with the following contents:
 
 ```ruby
 module MyStore::OrderDecorator


### PR DESCRIPTION
**Description**
Loading decorators within `to_prepare` with `prepend` or `include`
ends up adding multiple copies of the decorator to the ancestors of
the decorated class. This typically causes trouble when using `super`
within methods or when changes done in `prepended` or `included` are
not idempotent.

Clearing dependencies also solves problems related to overwriting
constants and removed methods (i.e. when a method is removed by a
decorator, previous instances of the decorator that are still in the
ancestors list will still have that method defined and will intercept
calls to it).

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
