### PR TITLE
Use ApplicationRecord as models base class

### DIFF
--- a/core/app/models/spree/base.rb
+++ b/core/app/models/spree/base.rb
@@ -2,6 +2,7 @@
 
 class Spree::Base < ActiveRecord::Base
   include Spree::Preferences::Preferable
+  include Spree::Core::Permalinks
   serialize :preferences, Hash
 
   include Spree::RansackableAttributes

--- a/core/app/models/spree/promotion_code_batch.rb
+++ b/core/app/models/spree/promotion_code_batch.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Spree
-  class PromotionCodeBatch < ActiveRecord::Base
+  class PromotionCodeBatch < Spree::Base
     class CantProcessStartedBatch < StandardError
     end
 

--- a/core/app/models/spree/promotion_rule_role.rb
+++ b/core/app/models/spree/promotion_rule_role.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Spree
-  class PromotionRuleRole < ActiveRecord::Base
+  class PromotionRuleRole < Spree::Base
     belongs_to :promotion_rule, class_name: 'Spree::PromotionRule', optional: true
     belongs_to :role, class_name: 'Spree::Role', optional: true
   end

--- a/core/app/models/spree/shipping_rate_tax.rb
+++ b/core/app/models/spree/shipping_rate_tax.rb
@@ -6,7 +6,7 @@ module Spree
   # @attr [Spree::TaxRate] tax_rate The tax rate used to calculate the tax amount
   # @since 1.3.0
   # @see Spree::Tax::ShippingRateTaxer
-  class ShippingRateTax < ActiveRecord::Base
+  class ShippingRateTax < Spree::Base
     belongs_to :shipping_rate, class_name: "Spree::ShippingRate", optional: true
     belongs_to :tax_rate, class_name: "Spree::TaxRate", optional: true
 

--- a/core/db/default/spree/countries.rb
+++ b/core/db/default/spree/countries.rb
@@ -5,7 +5,7 @@ require 'carmen'
 # Insert Countries into the spree_countries table, checking to ensure that no
 # duplicates are created, using as few SQL statements as possible (2)
 
-connection = ApplicationRecord.connection
+connection = Spree::Base.connection
 
 country_mapper = ->(country) do
   name            = connection.quote country.name

--- a/core/lib/solidus/migrations/promotions_with_code_handlers.rb
+++ b/core/lib/solidus/migrations/promotions_with_code_handlers.rb
@@ -3,7 +3,7 @@
 module Solidus
   module Migrations
     module PromotionWithCodeHandlers
-      class PromotionCode < ActiveRecord::Base
+      class PromotionCode < Spree::Base
         self.table_name = "spree_promotion_codes"
       end
 

--- a/core/lib/spree/core/permalinks.rb
+++ b/core/lib/spree/core/permalinks.rb
@@ -9,7 +9,7 @@ module Spree
         class_attribute :permalink_options
       end
 
-      module ClassMethods
+      class_methods do
         def make_permalink(options = {})
           options[:field] ||= :permalink
           self.permalink_options = options

--- a/core/lib/spree/core/permalinks.rb
+++ b/core/lib/spree/core/permalinks.rb
@@ -63,5 +63,3 @@ module Spree
     end
   end
 end
-
-ActiveRecord::Base.send :include, Spree::Core::Permalinks


### PR DESCRIPTION
**Description**
Ref #3450 

This PR introduces `Spree::ApplicationRecord` class and makes every ActiveRecord model previously inheriting from `ActiveRecord::Base` inherit from it. 
To leverage the new hierarchy, an existing `Spree::Core::Permalinks` monkey patch on `ActiveRecord::Base` has been moved to `Spree::ApplicationRecord`.

This way Solidus is more compliant with Rails 5+ recommendations and the risk of unwanted side effects on `ActiveRecord::Base` is mitigated.

**Checklist:**
- [X] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [X] I have added a detailed description into each commit message
