### PR TITLE
Only require the necessary Rails frameworks

### DIFF
--- a/backend/lib/spree/backend.rb
+++ b/backend/lib/spree/backend.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-require 'rails/all'
+require 'spree_core'
+require 'spree_api'
+
 require 'jquery-rails'
 require 'coffee-rails'
 require 'sassc-rails'
@@ -10,9 +12,6 @@ require 'autoprefixer-rails'
 require 'jbuilder'
 require 'kaminari'
 require 'responders'
-
-require 'spree_core'
-require 'spree_api'
 
 require 'spree/backend/action_callbacks'
 require 'spree/backend/callbacks'

--- a/backend/spec/lib/spree/backend_spec.rb
+++ b/backend/spec/lib/spree/backend_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'spree/backend'
+
+RSpec.describe Spree::Backend do
+  it 'loads only the necessary Rails Frameworks' do
+    aggregate_failures do
+      expect(defined? ActionCable::Engine).to be_falsey
+      expect(defined? ActionController::Railtie).to be_truthy
+      expect(defined? ActionMailer::Railtie).to be_truthy
+      expect(defined? ActionView::Railtie).to be_truthy
+      expect(defined? ActiveJob::Railtie).to be_truthy
+      expect(defined? ActiveModel::Railtie).to be_truthy
+      expect(defined? ActiveRecord::Railtie).to be_truthy
+      expect(defined? ActiveStorage::Engine).to be_truthy
+      expect(defined? Rails::TestUnit::Railtie).to be_falsey
+      expect(defined? Sprockets::Railtie).to be_truthy
+    end
+  end
+end

--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -1,6 +1,14 @@
 # frozen_string_literal: true
 
-require 'rails/all'
+require "action_controller/railtie"
+require "action_mailer/railtie"
+require "action_view/railtie"
+require "active_job/railtie"
+require "active_model/railtie"
+require "active_record/railtie"
+require "active_storage/engine"
+require "sprockets/railtie"
+
 require 'acts_as_list'
 require 'awesome_nested_set'
 require 'cancan'

--- a/core/lib/spree/testing_support/dummy_app.rb
+++ b/core/lib/spree/testing_support/dummy_app.rb
@@ -7,6 +7,7 @@ require 'rails'
 require 'active_record/railtie'
 require 'action_controller/railtie'
 require 'action_mailer/railtie'
+require 'active_storage/engine'
 
 Rails.env = 'test'
 

--- a/core/spec/lib/spree/core_spec.rb
+++ b/core/spec/lib/spree/core_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'spree/core'
+
+RSpec.describe Spree::Core do
+  it 'loads only the necessary Rails Frameworks' do
+    aggregate_failures do
+      expect(defined? ActionCable::Engine).to be_falsey
+      expect(defined? ActionController::Railtie).to be_truthy
+      expect(defined? ActionMailer::Railtie).to be_truthy
+      expect(defined? ActionView::Railtie).to be_truthy
+      expect(defined? ActiveJob::Railtie).to be_truthy
+      expect(defined? ActiveModel::Railtie).to be_truthy
+      expect(defined? ActiveRecord::Railtie).to be_truthy
+      expect(defined? ActiveStorage::Engine).to be_truthy
+      expect(defined? Rails::TestUnit::Railtie).to be_falsey
+      expect(defined? Sprockets::Railtie).to be_truthy
+    end
+  end
+end

--- a/core/spec/lib/spree/event/subscriber_spec.rb
+++ b/core/spec/lib/spree/event/subscriber_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'active_support/all'
 require 'spec_helper'
 require 'spree/event'
 

--- a/frontend/lib/spree/frontend.rb
+++ b/frontend/lib/spree/frontend.rb
@@ -1,15 +1,14 @@
 # frozen_string_literal: true
 
-require 'rails/all'
+require 'solidus_core'
+require 'solidus_api'
+
 require 'jquery-rails'
 require 'canonical-rails'
 require 'sassc-rails'
 require 'font-awesome-rails'
 require 'responders'
 require 'kaminari'
-
-require 'solidus_core'
-require 'solidus_api'
 
 require 'spree/frontend/middleware/seo_assist'
 require 'spree/frontend/engine'

--- a/frontend/spec/lib/spree/frontend_spec.rb
+++ b/frontend/spec/lib/spree/frontend_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'spree/frontend'
+
+RSpec.describe Spree::Frontend do
+  it 'loads only the necessary Rails Frameworks' do
+    aggregate_failures do
+      expect(defined? ActionCable::Engine).to be_falsey
+      expect(defined? ActionController::Railtie).to be_truthy
+      expect(defined? ActionMailer::Railtie).to be_truthy
+      expect(defined? ActionView::Railtie).to be_truthy
+      expect(defined? ActiveJob::Railtie).to be_truthy
+      expect(defined? ActiveModel::Railtie).to be_truthy
+      expect(defined? ActiveRecord::Railtie).to be_truthy
+      expect(defined? ActiveStorage::Engine).to be_truthy
+      expect(defined? Rails::TestUnit::Railtie).to be_falsey
+      expect(defined? Sprockets::Railtie).to be_truthy
+    end
+  end
+end


### PR DESCRIPTION
**Description**

By requiring rails/all Solidus was loading a bunch of unnecessary code
taking more time and consuming more memory. This change allows apps
that want to cherry-pick Rails frameworks to benefit from the more
attentive choice.

The list of frameworks I enabled for each component of Solidus comes from searching the subdir (e.g. `core/`) with this regular expression: `/\b(Action|Active|Application)[A-Z]/`.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
