### PR TITLE
Preparation for v2.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Solidus 2.10.0 (master, unreleased)
+## Solidus 2.11.0 (master, unreleased)
+
+## Solidus 2.10.0 (2020-01-15)
 
 ### Major Changes
 

--- a/core/lib/spree/core/version.rb
+++ b/core/lib/spree/core/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Spree
-  VERSION = "2.10.0.beta1"
+  VERSION = "2.11.0.alpha"
 
   def self.solidus_version
     VERSION


### PR DESCRIPTION
**Description**

Now that v2.10 has been released, master will track 2.11 and CHANGELOG is prepared for the new version.
