### PR TITLE
Remove user address reference when removing address from the address

### DIFF
--- a/core/app/models/concerns/spree/user_address_book.rb
+++ b/core/app/models/concerns/spree/user_address_book.rb
@@ -130,6 +130,7 @@ module Spree
     def remove_from_address_book(address_id)
       user_address = user_addresses.find_by(address_id: address_id)
       if user_address
+        remove_user_address_reference(address_id)
         user_address.update(archived: true, default: false)
       else
         false
@@ -144,6 +145,12 @@ module Spree
       user_address.address = new_address
       user_address.archived = false
       user_address
+    end
+
+    def remove_user_address_reference(address_id)
+      self.bill_address_id = bill_address_id == address_id.to_i ? nil : bill_address_id
+      self.ship_address_id = ship_address_id == address_id.to_i ? nil : ship_address_id
+      save if changed?
     end
   end
 end

--- a/core/spec/models/spree/concerns/user_address_book_spec.rb
+++ b/core/spec/models/spree/concerns/user_address_book_spec.rb
@@ -221,6 +221,7 @@ module Spree
       let(:address1) { create(:address) }
       let(:address2) { create(:address, firstname: "Different") }
       let(:remove_id) { address1.id }
+
       subject { user.remove_from_address_book(remove_id) }
 
       before do
@@ -241,6 +242,49 @@ module Spree
 
       it "returns false if the addresses is not there" do
         expect(user.remove_from_address_book(0)).to be false
+      end
+
+      context 'when user has previous order addresses' do
+        let(:order) { create(:order, ship_address: address1, bill_address: address2) }
+
+        before { user.persist_order_address(order) }
+
+        context 'when address does not match any user address references' do
+          let(:another_address) { create(:address) }
+
+          let(:remove_id) { another_address.id }
+
+          it 'leaves current user ship address' do
+            expect { subject }.not_to change(user, :ship_address_id).from(address1.id)
+          end
+
+          it 'leaves current user bill address' do
+            expect { subject }.not_to change(user, :bill_address_id).from(address2.id)
+          end
+        end
+
+        context 'when address matches user ship address' do
+          it 'removes the ship address reference from user' do
+            expect { subject }.to change(user, :ship_address_id).from(address1.id).to(nil)
+          end
+        end
+
+        context 'when address matches user bill address' do
+          let(:remove_id) { address2.id }
+
+          it 'removes the bill address reference from user' do
+            expect { subject }.to change(user, :bill_address_id).from(address2.id).to(nil)
+          end
+        end
+
+        context 'when address matches user bill and ship address' do
+          let(:order) { create(:order, ship_address: address1, bill_address: address1) }
+
+          it 'removes the address references from user' do
+            expect { subject }.to change(user, :ship_address_id).from(address1.id).to(nil)
+              .and change(user, :bill_address_id).from(address1.id).to(nil)
+          end
+        end
       end
     end
 


### PR DESCRIPTION
**Description**

The address book should provide the user the ability to manage all his addresses.

`ship_address_id` and `bill_address_id` are persisted on the `Spree::User` record after transitioning from `address`: `Spree::User#persist_order_address`.
https://github.com/solidusio/solidus/blob/18f6ebc1171155c85594f072e675ea6e51ceb1f9/core/app/models/concerns/spree/user_address_book.rb#L70-L77
These address fields are used to assign user default addresses to the order before transitioning to `address`: `Spree::Order#assign_default_user_addresses`.
https://github.com/solidusio/solidus/blob/d0d1e3d56330c3ccda440d07dd20cbba5aa5934d/core/app/models/spree/order.rb#L716-L726

Currently, when a user empties his address book the `user` record still has the `ship_address_id` and `bill_address_id` references. 
In the `address` checkout step because of `assign_default_user_addresses ` the order addresses are filled with addresses linked on the user record.

As a **user** I expect that when I empty my address book no address will be shown during my next checkout.

As a **developer** I expect to use the address book to provide the user full management capability on his addresses.

This commit removes the address reference from the user record when an address is removed from the address book.


**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change (if needed)
