### PR TITLE
Fix order state with customer returns when receiving return items

### DIFF
--- a/backend/app/controllers/spree/admin/customer_returns_controller.rb
+++ b/backend/app/controllers/spree/admin/customer_returns_controller.rb
@@ -70,8 +70,6 @@ module Spree
           return_item = item_params[:id] ? Spree::ReturnItem.find(item_params[:id]) : Spree::ReturnItem.new
           return_item.assign_attributes(item_params)
 
-          return_item.skip_customer_return_processing = true
-
           if item_params[:reception_status_event].blank?
             return redirect_to(new_object_url, flash: { error: 'Reception status choice required' })
           end

--- a/backend/spec/controllers/spree/admin/return_items_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/return_items_controller_spec.rb
@@ -8,22 +8,49 @@ describe Spree::Admin::ReturnItemsController, type: :controller do
   describe '#update' do
     let(:customer_return) { create(:customer_return) }
     let(:return_item) { customer_return.return_items.first }
-    let(:old_acceptance_status) { 'pending' }
-    let(:new_acceptance_status) { 'rejected' }
 
-    subject do
-      put :update, params: { id: return_item.to_param, return_item: { acceptance_status: new_acceptance_status } }
-    end
+    describe ':acceptance_status' do
+      let(:old_acceptance_status) { 'pending' }
+      let(:new_acceptance_status) { 'rejected' }
 
-    it 'updates the return item' do
-      expect {
+      subject do
+        put :update, params: { id: return_item.to_param, return_item: { acceptance_status: new_acceptance_status } }
+      end
+
+      it 'updates the return item' do
+        expect {
+          subject
+        }.to change { return_item.reload.acceptance_status }.from(old_acceptance_status).to(new_acceptance_status)
+      end
+
+      it 'redirects to the customer return' do
         subject
-      }.to change { return_item.reload.acceptance_status }.from(old_acceptance_status).to(new_acceptance_status)
+        expect(response).to redirect_to spree.edit_admin_order_customer_return_path(customer_return.order, customer_return)
+      end
     end
 
-    it 'redirects to the customer return' do
-      subject
-      expect(response).to redirect_to spree.edit_admin_order_customer_return_path(customer_return.order, customer_return)
+    describe ':reception_status' do
+      let(:old_reception_status) { 'in_transit' }
+      let(:new_reception_status) { 'received' }
+      let(:reception_status_event) { 'receive' }
+
+      before { return_item.update reception_status: 'in_transit'}
+
+      subject do
+        put :update, params: { id: return_item.to_param, return_item: { reception_status_event: reception_status_event } }
+      end
+
+      it 'updates the return item' do
+        expect {
+          subject
+        }.to change { return_item.reload.reception_status }.from(old_reception_status).to(new_reception_status)
+        expect(customer_return.order.state).to eq('returned')
+      end
+
+      it 'redirects to the customer return' do
+        subject
+        expect(response).to redirect_to spree.edit_admin_order_customer_return_path(customer_return.order, customer_return)
+      end
     end
   end
 end

--- a/backend/spec/controllers/spree/admin/return_items_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/return_items_controller_spec.rb
@@ -34,7 +34,11 @@ describe Spree::Admin::ReturnItemsController, type: :controller do
       let(:new_reception_status) { 'received' }
       let(:reception_status_event) { 'receive' }
 
-      before { return_item.update reception_status: 'in_transit'}
+      before do
+        allow(Spree::Deprecation).to receive(:warn).with(a_string_matching('#process_inventory_unit! will not call'))
+
+        return_item.update! reception_status: 'in_transit'
+      end
 
       subject do
         put :update, params: { id: return_item.to_param, return_item: { reception_status_event: reception_status_event } }

--- a/backend/spec/features/admin/orders/customer_returns_spec.rb
+++ b/backend/spec/features/admin/orders/customer_returns_spec.rb
@@ -5,35 +5,38 @@ require 'spec_helper'
 describe 'Customer returns', type: :feature do
   stub_authorization!
 
+  def create_customer_return(value)
+    find('#select-all').click
+    page.execute_script "$('select.add-item').val(#{value.to_s.inspect})"
+    select 'NY Warehouse', from: 'Stock Location'
+    click_button 'Create'
+  end
+
+  def order_state_label
+    find('dd.order-state').text
+  end
+
+  before do
+    visit spree.new_admin_order_customer_return_path(order)
+  end
+
   context 'when the order has more than one line item' do
     let(:order) { create :shipped_order, line_items_count: 2 }
 
-    def create_customer_return
-      find('#select-all').click
-      page.execute_script "$('select.add-item').val('receive')"
-      select 'NY Warehouse', from: 'Stock Location'
-      click_button 'Create'
-    end
-
-    before do
-      visit spree.new_admin_order_customer_return_path(order)
-    end
-
     context 'when creating a return with state "Received"' do
       it 'marks the order as returned', :js do
-        create_customer_return
+        create_customer_return('receive')
 
         expect(page).to have_content 'Customer Return has been successfully created'
-        within 'dd.order-state' do
-          expect(page).to have_content 'Returned'
-        end
+
+        expect(order_state_label).to eq('Returned')
       end
     end
 
     it 'disables the button at submit', :js do
       page.execute_script "$('form').submit(function(e) { e.preventDefault()})"
 
-      create_customer_return
+      create_customer_return('receive')
 
       expect(page).to have_button("Create", disabled: true)
     end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -288,7 +288,11 @@ module Spree
     end
 
     def all_inventory_units_returned?
-      inventory_units.all?(&:returned?)
+      # Inventory units are transitioned to the "return" state through CustomerReturn and
+      # ReturnItem instead of using Order#inventory_units, thus making the latter method
+      # potentially return stale data. This situation requires to *reload* `inventory_units`
+      # in order to pick-up the latest changes and make the check on `returned?` reliable.
+      inventory_units.reload.all?(&:returned?)
     end
 
     def contents

--- a/core/app/models/spree/return_item.rb
+++ b/core/app/models/spree/return_item.rb
@@ -196,12 +196,14 @@ module Spree
 
     def process_inventory_unit!
       inventory_unit.return!
-      if customer_return
-        customer_return.stock_location.restock(inventory_unit.variant, 1, customer_return) if should_restock?
-        unless skip_customer_return_processing
-          Deprecation.warn 'From Solidus v2.9 onwards, #process_inventory_unit! will not call customer_return#process_return!'
-          customer_return.process_return!
-        end
+
+      if should_restock?
+        customer_return.stock_location.restock(inventory_unit.variant, 1, customer_return)
+      end
+
+      if customer_return && !skip_customer_return_processing
+        Deprecation.warn 'From Solidus v2.9 onwards, #process_inventory_unit! will not call customer_return#process_return!'
+        customer_return.process_return!
       end
     end
 
@@ -276,9 +278,9 @@ module Spree
     end
 
     def should_restock?
-      resellable? &&
+      customer_return &&
+        resellable? &&
         variant.should_track_inventory? &&
-        customer_return &&
         customer_return.stock_location.restock_inventory?
     end
   end

--- a/core/app/models/spree/return_item.rb
+++ b/core/app/models/spree/return_item.rb
@@ -90,8 +90,13 @@ module Spree
       COMPLETED_RECEPTION_STATUSES.map(&:to_s).include?(reception_status.to_s)
     end
 
-
-    attr_accessor :skip_customer_return_processing
+    def skip_customer_return_processing=(value)
+      @skip_customer_return_processing = value
+      Deprecation.warn \
+        'From Solidus v2.11 onwards, #skip_customer_return_processing does ' \
+        'nothing, and #process_inventory_unit! will restore calling ' \
+        'customer_return#process_return!', caller(1)
+    end
 
     # @param inventory_unit [Spree::InventoryUnit] the inventory for which we
     #   want a return item
@@ -201,8 +206,11 @@ module Spree
         customer_return.stock_location.restock(inventory_unit.variant, 1, customer_return)
       end
 
-      if customer_return && !skip_customer_return_processing
-        Deprecation.warn 'From Solidus v2.9 onwards, #process_inventory_unit! will not call customer_return#process_return!'
+      unless @skip_customer_return_processing.nil?
+        Deprecation.warn \
+          'From Solidus v2.11 onwards, #skip_customer_return_processing does ' \
+          'nothing, and #process_inventory_unit! will restore calling ' \
+          'customer_return#process_return!'
       end
 
       customer_return&.process_return!

--- a/core/app/models/spree/return_item.rb
+++ b/core/app/models/spree/return_item.rb
@@ -203,8 +203,9 @@ module Spree
 
       if customer_return && !skip_customer_return_processing
         Deprecation.warn 'From Solidus v2.9 onwards, #process_inventory_unit! will not call customer_return#process_return!'
-        customer_return.process_return!
       end
+
+      customer_return&.process_return!
     end
 
     def sibling_intended_for_exchange(status)

--- a/core/lib/spree/core/state_machines/return_item/reception_status.rb
+++ b/core/lib/spree/core/state_machines/return_item/reception_status.rb
@@ -19,8 +19,8 @@ module Spree
 
           included do
             state_machine :reception_status, initial: :awaiting do
-              after_transition to: ::Spree::ReturnItem::COMPLETED_RECEPTION_STATUSES,  do: :attempt_accept
-              after_transition to: ::Spree::ReturnItem::COMPLETED_RECEPTION_STATUSES,  do: :check_unexchange
+              after_transition to: ::Spree::ReturnItem::COMPLETED_RECEPTION_STATUSES, do: :attempt_accept, if: :can_attempt_accept?
+              after_transition to: ::Spree::ReturnItem::COMPLETED_RECEPTION_STATUSES, do: :check_unexchange
               after_transition to: :received, do: :process_inventory_unit!
 
               event(:cancel) { transition to: :cancelled, from: :awaiting }

--- a/core/lib/spree/testing_support/factories/return_item_factory.rb
+++ b/core/lib/spree/testing_support/factories/return_item_factory.rb
@@ -6,7 +6,6 @@ require 'spree/testing_support/factories/return_authorization_factory'
 
 FactoryBot.define do
   factory :return_item, class: 'Spree::ReturnItem' do
-    skip_customer_return_processing { true }
     association(:inventory_unit, factory: :inventory_unit, state: :shipped)
     association(:return_reason, factory: :return_reason)
     return_authorization do |_return_item|

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -1187,6 +1187,18 @@ RSpec.describe Spree::Order, type: :model do
         expect(subject).to eq false
       end
     end
+
+    context "all inventory units are returned on the database (e.g. through another association)" do
+      it "is true" do
+        expect {
+          Spree::InventoryUnit
+            .where(id: order.inventory_unit_ids)
+            .update_all(state: 'returned')
+        }.to change {
+          order.all_inventory_units_returned?
+        }.from(false).to(true)
+      end
+    end
   end
 
   context "store credit" do

--- a/core/spec/models/spree/return_item_spec.rb
+++ b/core/spec/models/spree/return_item_spec.rb
@@ -222,6 +222,23 @@ RSpec.describe Spree::ReturnItem, type: :model do
     it "starts off in the awaiting state" do
       expect(return_item).to be_awaiting
     end
+
+    context 'when transitioning to :received' do
+      let(:return_item) { create(:return_item) }
+      subject { return_item.receive! }
+
+      # StateMachines has some "smart" code for guessing how many arguments to
+      # send to the callback methods that interferes with rspec-mocks.
+      around { |e| without_partial_double_verification { e.call } }
+
+      it 'calls #attempt_accept, #check_unexchange, and #process_inventory_unit!' do
+        expect(return_item).to receive(:attempt_accept)
+        expect(return_item).to receive(:check_unexchange)
+        expect(return_item).to receive(:process_inventory_unit!)
+
+        subject
+      end
+    end
   end
 
   describe "acceptance_status state_machine" do

--- a/core/spec/models/spree/return_item_spec.rb
+++ b/core/spec/models/spree/return_item_spec.rb
@@ -2,17 +2,17 @@
 
 require 'rails_helper'
 
-RSpec.shared_examples "an invalid state transition" do |status, expected_status|
-  let(:status) { status }
-
-  it "cannot transition to #{expected_status}" do
-    expect { subject }.to raise_error(StateMachines::InvalidTransition)
-  end
-end
-
 RSpec.describe Spree::ReturnItem, type: :model do
   all_reception_statuses = Spree::ReturnItem.state_machines[:reception_status].states.map(&:name).map(&:to_s)
   all_acceptance_statuses = Spree::ReturnItem.state_machines[:acceptance_status].states.map(&:name).map(&:to_s)
+
+  shared_examples "an invalid state transition" do |status, expected_status|
+    let(:status) { status }
+
+    it "cannot transition to #{expected_status}" do
+      expect { subject }.to raise_error(StateMachines::InvalidTransition)
+    end
+  end
 
   before do
     allow_any_instance_of(Spree::Order).to receive(:return!).and_return(true)

--- a/core/spec/models/spree/return_item_spec.rb
+++ b/core/spec/models/spree/return_item_spec.rb
@@ -43,8 +43,8 @@ RSpec.describe Spree::ReturnItem, type: :model do
       subject
     end
 
-    context 'when the `skip_customer_return_processing` flag is not set to true' do
-      before { return_item.skip_customer_return_processing = false }
+    context 'when the `skip_customer_return_processing` flag is set' do
+      before { Spree::Deprecation.silence { return_item.skip_customer_return_processing = false } }
 
       it 'shows a deprecation warning' do
         expect(Spree::Deprecation).to receive(:warn)
@@ -808,6 +808,18 @@ RSpec.describe Spree::ReturnItem, type: :model do
             expect(subject).to be_valid
           end
         end
+      end
+    end
+  end
+
+  describe '#skip_customer_return_processing=' do
+    context 'when it receives a value' do
+      let(:return_item) { described_class.new }
+      subject { return_item.skip_customer_return_processing = :foo }
+
+      it 'shows a deprecation warning' do
+        expect(Spree::Deprecation).to receive(:warn)
+        subject
       end
     end
   end

--- a/core/spec/models/spree/return_item_spec.rb
+++ b/core/spec/models/spree/return_item_spec.rb
@@ -238,6 +238,18 @@ RSpec.describe Spree::ReturnItem, type: :model do
 
         subject
       end
+
+      context 'when the :acceptance_status is in a state that does not support the :attempt_accept event' do
+        before { return_item.require_manual_intervention! }
+
+        it 'only skips the call to :attempt_accept' do
+          expect(return_item).not_to receive(:attempt_accept)
+          expect(return_item).to receive(:check_unexchange)
+          expect(return_item).to receive(:process_inventory_unit!)
+
+          subject
+        end
+      end
     end
   end
 

--- a/sample/db/samples/reimbursements.rb
+++ b/sample/db/samples/reimbursements.rb
@@ -38,7 +38,6 @@ customer_return = Spree::CustomerReturn.create!(
   stock_location: stock_location
 )
 return_item.reload
-return_item.skip_customer_return_processing = true
 return_item.receive!
 customer_return.process_return!
 


### PR DESCRIPTION
_📝 Notes on reviewing: I suggest to review this PR commit by commit, knowing that the core of the fix is in the last commits:_

1. **Let Order#all_inventory_units_returned? always use fresh data** (88b1220)
  _Which fixes the check on the Order state transition toward "returned"._
2. **Let the order transition to Returned after return items are all Received** (6228fe9)
  _This one contains the feature specs demonstrating the problem along with the changes that make them pass._
3. **Deprecate skip_customer_return_processing** (0dd92fd)
  _Walk back the attempted fix introduced by #3199._

---

**Description**

_Why?_

Currently when a customer return transitions from "In transit" toward "Received" doesn't trigger the transition of the Order status to "Returned".

_How_

The problem is a composite of multiple bugs.

The first one was that `order.inventory_units` was memoized with completely different instances from `ReturnItem#inventory_unit`. So the check to see if they were all returned was, at times, ineffective.

The second part is that the `state_machines` library can halt callback chains without telling anything to anyone. That was happening in some cases when `ReturnItem#attempt_accept` was failing. In those cases, just to increase confusion, the acceptance state-machine was interfering with the reception state-machine.

The third part is that the introduction of the accessor for `skip_customer_return_processing` was fixing one code path (the one still visible in the [original PR](https://github.com/solidusio/solidus/pull/3199)) but was disrupting another one, namely marking the order as returned after the return-item state-machine was getting the "receive" event.

Ref #3199 

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
