### PR TITLE
Silence log messages from the capybara server

### DIFF
--- a/core/lib/spree/testing_support/capybara_ext.rb
+++ b/core/lib/spree/testing_support/capybara_ext.rb
@@ -162,3 +162,6 @@ CapybaraExt = ActiveSupport::Deprecation::DeprecatedConstantProxy.new('CapybaraE
 RSpec.configure do |c|
   c.include Spree::TestingSupport::CapybaraExt
 end
+
+# A workaround for https://github.com/rspec/rspec-rails/issues/1897
+Capybara.server = :puma, { Silent: true }


### PR DESCRIPTION
**Description**

Puma is taken as the default rack server, but until https://github.com/rspec/rspec-rails/issues/1897 is solved we should stick to the proposed workaround.

The typical output goes like this:

```
$ cd frontend; bundle exec rspec ; cd -

Randomized with seed 63849
..........Capybara starting Puma...
* Version 4.3.1 , codename: Mysterious Traveller
* Min threads: 0, max threads: 4
* Listening on tcp://127.0.0.1:59724
.................................................................................................................................................................................................................

Finished in 1 minute 33.28 seconds (files took 5.71 seconds to load)
219 examples, 0 failures

Randomized with seed 63849
```

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
