### PR TITLE
Reintroduce and deprecate Order#deliver_order_confirmation_email

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -437,12 +437,29 @@ module Spree
       touch :completed_at
 
       Spree::Event.fire 'order_finalized', order: self
+
+      if method(:deliver_order_confirmation_email).owner != self.class
+        Spree::Deprecation.warn \
+          "deliver_order_confirmation_email has been deprecated and moved to " \
+          "Spree::MailerSubscriber#order_finalized, please move there any customizations.",
+          caller(1)
+      end
     end
 
     def fulfill!
       shipments.each { |shipment| shipment.update_state if shipment.persisted? }
       updater.update_shipment_state
       save!
+    end
+
+    def deliver_order_confirmation_email
+      Spree::Deprecation.warn \
+        "deliver_order_confirmation_email has been deprecated and moved to " \
+        "Spree::MailerSubscriber#order_finalized.",
+        caller(1)
+
+      Spree::Config.order_mailer_class.confirm_email(order).deliver_later
+      order.update_column(:confirmation_delivered, true)
     end
 
     # Helper methods for checkout steps


### PR DESCRIPTION
**Description**

Was removed as part of https://github.com/solidusio/solidus/pull/3081, but not being private it's better to keep it around with a deprecation for a while.

_I think it's worth merging this just into v2.9, perhaps updating the deprecation text to mention that will be removed in v2.10._

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
