### PR TITLE
Change order state to `merged` instead of destroying it when merging orders

### DIFF
--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -49,7 +49,7 @@ module Spree
           params[:q][:completed_at_lt] = params[:q].delete(:created_at_lt)
         end
 
-        @search = Spree::Order.accessible_by(current_ability, :index).ransack(params[:q])
+        @search = Spree::Order.not_merged.accessible_by(current_ability, :index).ransack(params[:q])
         @orders = @search.result.includes([:user]).
           page(params[:page]).
           per(params[:per_page] || Spree::Config[:orders_per_page])

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -54,6 +54,9 @@ module Spree
     deprecate temporary_credit_card: :temporary_payment_source, deprecator: Spree::Deprecation
     deprecate :temporary_credit_card= => :temporary_payment_source=, deprecator: Spree::Deprecation
 
+    has_many :from_merged_orders, foreign_key: :merged_to_order_id, class_name: 'Spree::Order', inverse_of: :merged_to_order
+    belongs_to :merged_to_order, foreign_key: :merged_to_order_id, class_name: 'Spree::Order', inverse_of: :from_merged_orders, optional: true
+
     # Customer info
     belongs_to :user, class_name: Spree::UserClassHandle.new, optional: true
     belongs_to :bill_address, foreign_key: :bill_address_id, class_name: 'Spree::Address', optional: true
@@ -177,6 +180,14 @@ module Spree
 
     def self.not_canceled
       where.not(state: 'canceled')
+    end
+
+    def self.merged
+      where(state: 'merged')
+    end
+
+    def self.not_merged
+      where.not(state: 'merged')
     end
 
     # Use this method in other gems that wish to register their own custom logic
@@ -846,7 +857,7 @@ module Spree
 
     # Determine if email is required (we don't want validation errors before we hit the checkout)
     def require_email
-      true unless new_record? || ['cart', 'address'].include?(state)
+      true unless new_record? || ['cart', 'address', 'merged'].include?(state)
     end
 
     def ensure_inventory_units
@@ -873,6 +884,12 @@ module Spree
     def validate_line_item_availability
       availability_validator = Spree::Stock::AvailabilityValidator.new
       raise InsufficientStock unless line_items.all? { |line_item| availability_validator.validate(line_item) }
+    end
+
+    def ensure_merged_to_order_present
+      if merged_to_order.blank?
+        errors.add(:base, :merged_to_order_must_be_present) && (return false)
+      end
     end
 
     def ensure_line_items_present

--- a/core/app/models/spree/order_merger.rb
+++ b/core/app/models/spree/order_merger.rb
@@ -31,15 +31,16 @@ module Spree
     # will add the quantity of the incoming line item to the existing line item.
     # Otherwise, it will assign the line item to the new order.
     #
-    # After the orders have been merged the `other_order` will be destroyed.
+    # After the orders have been merged the `other_order` will be marked as merged.
     #
     # @example
     #   initial_order = Spree::Order.find(1)
     #   order_to_merge = Spree::Order.find(2)
     #   merger = Spree::OrderMerger.new(initial_order)
     #   merger.merge!(order_to_merge)
-    #   # order_to_merge is destroyed, initial order now contains the line items
-    #   # of order_to_merge
+
+    # order_to_merge is marked as merged, initial order now contains the line
+    # items of order_to_merge
     #
     # @api public
     # @param [Spree::Order] other_order An order which will be merged in to the
@@ -58,9 +59,8 @@ module Spree
       set_user(user)
       persist_merge
 
-      # So that the destroy doesn't take out line items which may have been re-assigned
-      other_order.line_items.reload
-      other_order.destroy
+      other_order.merged_to_order = order
+      other_order.merge && other_order.save!
     end
 
     private

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -469,6 +469,12 @@ en:
             price:
               not_a_number: is not valid
               does_not_match_order_currency: Line item price currency must match order currency!
+        spree/order:
+          attributes:
+            base:
+              cannot_transition_from_merged: Cannot transition from merged
+              merged_to_order_must_be_present: The order must be associated with
+                the order that is merged into via the `merged_to_order` association
         spree/price:
           attributes:
             currency:
@@ -1716,6 +1722,7 @@ en:
       complete: Complete
       confirm: Confirm
       delivery: Delivery
+      merged: Merged
       payment: Payment
       resumed: Resumed
       returned: Returned

--- a/core/db/migrate/20200117125833_add_merged_to_order_id.rb
+++ b/core/db/migrate/20200117125833_add_merged_to_order_id.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddMergedToOrderId < ActiveRecord::Migration[5.2]
+  def change
+    add_column :spree_orders, :merged_to_order_id, :integer, limit: 4
+    add_foreign_key :spree_orders, :spree_orders, column: :merged_to_order_id
+  end
+end

--- a/core/spec/models/spree/order_merger_spec.rb
+++ b/core/spec/models/spree/order_merger_spec.rb
@@ -12,9 +12,15 @@ module Spree
     let(:user) { stub_model(Spree::LegacyUser, email: "spree@example.com") }
     let(:subject) { Spree::OrderMerger.new(order_1) }
 
-    it "destroys the other order" do
+    it "marks the other order as merged" do
       subject.merge!(order_2)
-      expect { order_2.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      expect(order_2).to be_merged
+    end
+
+    it "associates the merged orders" do
+      subject.merge!(order_2)
+      expect(order_2.merged_to_order).to eq order_1
+      expect(order_1.from_merged_orders).to include order_2
     end
 
     it "persist the merge" do


### PR DESCRIPTION
**Description**

This is an (opinionated, see later) attempt at https://github.com/solidusio/solidus/issues/1449.

Destroying orders when merging them is not ideal, as we lose the ability to debug what happened, which may be very important in some edge cases. 

This implementation adds the `merged` state to `Spree::Order` and updates the `Spree::OrderMerger` class accordingly. The merged order is associated with the resulting order via the `#merged_to_order` association.

The opinionated part is I kept the existing `Spree::Order#merge!` functionality and interface rather than switching to the one provided by default by the state machine when adding the merge event, see https://github.com/solidusio/solidus/compare/master...nebulab:spaghetticode/order-merged-state?expand=1#diff-2c3e70899d4f22d0569021b01b0e307fR62 (though the auto-generated`Spree::Order#merge` method is retained and used in `Spree::OrderMerge`).
Doing things differently would have required more extensive code changes, deprecations, and other tradeoffs.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
