### PR TITLE
Fix stock configuration examples in documentation

### DIFF
--- a/guides/source/developers/shipments/stock-allocator.html.md
+++ b/guides/source/developers/shipments/stock-allocator.html.md
@@ -50,9 +50,8 @@ For example, you can register it in your `/config/initializer/spree.rb` initiali
 ```ruby
 # /config/initializer/spree.rb
 Spree.config do |config|
-    # ...
-
-    config.stock.allocator_class = 'Spree::Stock::Allocator::CustomAllocator'
-  end
+  # ...
+  config.stock.allocator_class = 'Spree::Stock::Allocator::CustomAllocator'
+  # ...
 end
 ```

--- a/guides/source/developers/shipments/stock-locations-filter.html.md
+++ b/guides/source/developers/shipments/stock-locations-filter.html.md
@@ -41,7 +41,10 @@ the split shipments logic.
 For example, you can register it in your `/config/initializers/spree.rb` initializer:
 
 ```ruby
-# /config/initializers/spree.rb
-
-Rails.application.config.spree.stock.location_filter_class = 'Spree::Stock::LocationFilter::SameOrderCountry'
+# /config/initializer/spree.rb
+Spree.config do |config|
+  # ... 
+  config.stock.location_filter_class = 'Spree::Stock::LocationFilter::SameOrderCountry'
+  # ... 
+end
 ```

--- a/guides/source/developers/shipments/stock-locations-sorter.html.md
+++ b/guides/source/developers/shipments/stock-locations-sorter.html.md
@@ -39,7 +39,10 @@ Once you have created the logic for the new sorter, you need to register it so t
 For example, you can register it in your `/config/initializers/spree.rb` initializer:
 
 ```ruby
-# /config/initializers/spree.rb
-
-Rails.application.config.spree.stock.location_sorter_class = 'Spree::Stock::LocationSorter::Priority'
+# /config/initializer/spree.rb
+Spree.config do |config|
+  # ...
+  config.stock.location_sorter_class = 'Spree::Stock::LocationSorter::Priority'
+  # ...
+end
 ```


### PR DESCRIPTION
Fix an issue with the documentation related to the custom configuration
of the stock location filter and sorter. The way it was documented
didn't work.


**Checklist:**
- [X] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [X] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
