### PR TITLE
[Admin] Change shipment email checkbox label

### DIFF
--- a/backend/spec/features/admin/orders/shipments_spec.rb
+++ b/backend/spec/features/admin/orders/shipments_spec.rb
@@ -48,7 +48,7 @@ describe "Shipments", type: :feature do
     end
 
     it "doesn't send a shipping confirmation email when ask to suppress the mailer" do
-      uncheck 'Send Mailer'
+      uncheck 'Send Shipment Email'
 
       expect {
         perform_enqueued_jobs {

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1957,7 +1957,7 @@ en:
     select_a_stock_location: Select a stock location
     selected_quantity_not_available: selected of %{item} is not available.
     send_copy_of_all_mails_to: Send Copy of All Mails To
-    send_mailer: Send Mailer
+    send_mailer: Send Shipment Email
     send_mails_as: Send Mails As
     server: Server
     server_error: The server returned an error


### PR DESCRIPTION
**Description**

This quick PR changes the label of a checkbox in the admin, order shipments page:

<img width="879" alt="Schermata 2020-01-25 alle 13 45 56" src="https://user-images.githubusercontent.com/167946/73121341-68333300-3f79-11ea-9a59-89a1a643337c.png">

I think that it's not immediately clear what it refers to and "mailer" is also probably not the right word. 

<img width="878" alt="Schermata 2020-01-25 alle 13 57 29" src="https://user-images.githubusercontent.com/167946/73121464-aaa93f80-3f7a-11ea-8e1e-99f3a74b9f45.png">

Of course, waiting for a native English confirmation here.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] ~I have updated Guides and README accordingly to this change (if needed)~
- [ ] ~I have added tests to cover this change (if needed)~
- [x] I have attached screenshots to this PR for visual changes (if needed)
