### PR TITLE
Replace map.flatten with flat_map

### DIFF
--- a/core/app/models/spree/calculator/percent_per_item.rb
+++ b/core/app/models/spree/calculator/percent_per_item.rb
@@ -28,9 +28,9 @@ module Spree
     # Copied from per_item.rb
     def matching_products
       if compute_on_promotion?
-        calculable.promotion.rules.map do |rule|
+        calculable.promotion.rules.flat_map do |rule|
           rule.respond_to?(:products) ? rule.products : []
-        end.flatten
+        end
       end
     end
 

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -381,11 +381,11 @@ module Spree
 
     # Iterate through this product's taxons and taxonomies and touch their timestamps in a batch
     def touch_taxons
-      taxons_to_touch = taxons.map(&:self_and_ancestors).flatten.uniq
+      taxons_to_touch = taxons.flat_map(&:self_and_ancestors).uniq
       unless taxons_to_touch.empty?
         Spree::Taxon.where(id: taxons_to_touch.map(&:id)).update_all(updated_at: Time.current)
 
-        taxonomy_ids_to_touch = taxons_to_touch.map(&:taxonomy_id).flatten.uniq
+        taxonomy_ids_to_touch = taxons_to_touch.flat_map(&:taxonomy_id).uniq
         Spree::Taxonomy.where(id: taxonomy_ids_to_touch).update_all(updated_at: Time.current)
       end
     end

--- a/core/app/models/spree/product/scopes.rb
+++ b/core/app/models/spree/product/scopes.rb
@@ -233,7 +233,7 @@ module Spree
 
             # specifically avoid having an order for taxon search (conflicts with main order)
             def prepare_taxon_conditions(taxons)
-              ids = taxons.map { |taxon| taxon.self_and_descendants.pluck(:id) }.flatten.uniq
+              ids = taxons.flat_map { |taxon| taxon.self_and_descendants.pluck(:id) }.uniq
               joins(:taxons).where("#{Spree::Taxon.table_name}.id" => ids)
             end
 

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -164,7 +164,7 @@ module Spree
     end
 
     def products
-      rules.where(type: "Spree::Promotion::Rules::Product").map(&:products).flatten.uniq
+      rules.where(type: "Spree::Promotion::Rules::Product").flat_map(&:products).uniq
     end
 
     # Whether the promotion has exceeded it's usage restrictions.

--- a/core/app/models/spree/shipping_manifest.rb
+++ b/core/app/models/spree/shipping_manifest.rb
@@ -16,7 +16,7 @@ class Spree::ShippingManifest
   def items
     # Grouping by the ID means that we don't have to call out to the association accessor
     # This makes the grouping by faster because it results in less SQL cache hits.
-    @inventory_units.group_by(&:variant_id).map do |_variant_id, variant_units|
+    @inventory_units.group_by(&:variant_id).flat_map do |_variant_id, variant_units|
       variant_units.group_by(&:line_item_id).map do |_line_item_id, units|
         states = {}
         units.group_by(&:state).each { |state, iu| states[state] = iu.count }
@@ -25,6 +25,6 @@ class Spree::ShippingManifest
 
         ManifestItem.new(first_unit.line_item, first_unit.variant, units.length, states)
       end
-    end.flatten
+    end
   end
 end

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -391,9 +391,9 @@ module Spree
     #
     # @return [Array<Spree::VariantPropertyRuleValue>] variant_properties
     def variant_properties
-      product.variant_property_rules.map do |rule|
+      product.variant_property_rules.flat_map do |rule|
         rule.values if rule.applies_to_variant?(self)
-      end.flatten.compact
+      end.compact
     end
 
     # The gallery for the variant, which represents all the images

--- a/core/lib/spree/core/product_filters.rb
+++ b/core/lib/spree/core/product_filters.rb
@@ -107,7 +107,7 @@ module Spree
         brand_property = Spree::Property.find_by(name: 'brand')
         brands = brand_property ? Spree::ProductProperty.where(property_id: brand_property.id).pluck(:value).uniq.map(&:to_s) : []
         pp = Spree::ProductProperty.arel_table
-        conds = Hash[*brands.map { |brand| [brand, pp[:value].eq(brand)] }.flatten]
+        conds = Hash[*brands.flat_map { |brand| [brand, pp[:value].eq(brand)] }]
         {
           name:   'Brands',
           scope:  :brand_any,
@@ -184,7 +184,7 @@ module Spree
       # idea: expand the format to allow nesting of labels?
       def self.all_taxons
         Spree::Deprecation.warn "all_taxons is deprecated in solidus_core. Please add it to your own application to continue using it."
-        taxons = Spree::Taxonomy.all.map { |element| [element.root] + element.root.descendants }.flatten
+        taxons = Spree::Taxonomy.all.flat_map { |element| [element.root] + element.root.descendants }
         {
           name:   'All taxons',
           scope:  :taxons_id_equals_any,

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -621,7 +621,7 @@ RSpec.describe Spree::Order, type: :model do
     it "should not keep old events when checkout_flow is redefined" do
       state_machine = Spree::Order.state_machine
       expect(state_machine.states.any? { |s| s.name == :address }).to be false
-      known_states = state_machine.events[:next].branches.map(&:known_states).flatten
+      known_states = state_machine.events[:next].branches.flat_map(&:known_states)
       expect(known_states).not_to include(:address)
       expect(known_states).not_to include(:delivery)
       expect(known_states).not_to include(:confirm)

--- a/core/spec/models/spree/taxon_spec.rb
+++ b/core/spec/models/spree/taxon_spec.rb
@@ -190,7 +190,7 @@ RSpec.describe Spree::Taxon, type: :model do
       it 'returns all descendant variants' do
         variants = taxon.all_variants
         expect(variants.count).to eq(9)
-        expect(variants).to match_array([product1, product2, product3].map{ |p| p.variants_including_master }.flatten)
+        expect(variants).to match_array([product1, product2, product3].flat_map{ |p| p.variants_including_master })
       end
     end
   end

--- a/frontend/spec/features/products_spec.rb
+++ b/frontend/spec/features/products_spec.rb
@@ -218,7 +218,7 @@ describe "Visiting Products", type: :feature, inaccessible: true do
     within(:css, '#sidebar_products_search') { click_button "Search" }
 
     expect(page.all('ul.product-listing li').size).to eq(3)
-    tmp = page.all('ul.product-listing li a').map(&:text).flatten.compact
+    tmp = page.all('ul.product-listing li a').flat_map(&:text).compact
     tmp.delete("")
     expect(tmp.sort!).to eq(["Ruby on Rails Mug", "Ruby on Rails Stein", "Ruby on Rails Tote"])
   end
@@ -245,7 +245,7 @@ describe "Visiting Products", type: :feature, inaccessible: true do
     within(:css, '#sidebar_products_search') { click_button "Search" }
 
     expect(page.all('ul.product-listing li').size).to eq(4)
-    tmp = page.all('ul.product-listing li a').map(&:text).flatten.compact
+    tmp = page.all('ul.product-listing li a').flat_map(&:text).compact
     tmp.delete("")
     expect(tmp.sort!).to eq(["Ruby on Rails Bag",
                              "Ruby on Rails Baseball Jersey",

--- a/frontend/spec/features/taxons_spec.rb
+++ b/frontend/spec/features/taxons_spec.rb
@@ -73,7 +73,7 @@ describe "viewing products", type: :feature, inaccessible: true do
       within(:css, '#taxonomies') { click_link "Ruby on Rails" }
 
       expect(page.all('ul.product-listing li').size).to eq(7)
-      tmp = page.all('ul.product-listing li a').map(&:text).flatten.compact
+      tmp = page.all('ul.product-listing li a').flat_map(&:text).compact
       tmp.delete("")
       array = ["Ruby on Rails Bag",
                "Ruby on Rails Baseball Jersey",
@@ -89,7 +89,7 @@ describe "viewing products", type: :feature, inaccessible: true do
       within(:css, '#taxonomies') { click_link "Ruby" }
 
       expect(page.all('ul.product-listing li').size).to eq(1)
-      tmp = page.all('ul.product-listing li a').map(&:text).flatten.compact
+      tmp = page.all('ul.product-listing li a').flat_map(&:text).compact
       tmp.delete("")
       expect(tmp.sort!).to eq(["Ruby Baseball Jersey"])
     end
@@ -98,7 +98,7 @@ describe "viewing products", type: :feature, inaccessible: true do
       within(:css, '#taxonomies') { click_link "Apache" }
 
       expect(page.all('ul.product-listing li').size).to eq(1)
-      tmp = page.all('ul.product-listing li a').map(&:text).flatten.compact
+      tmp = page.all('ul.product-listing li a').flat_map(&:text).compact
       tmp.delete("")
       expect(tmp.sort!).to eq(["Apache Baseball Jersey"])
     end
@@ -107,7 +107,7 @@ describe "viewing products", type: :feature, inaccessible: true do
       click_link "Clothing"
 
       expect(page.all('ul.product-listing li').size).to eq(5)
-      tmp = page.all('ul.product-listing li a').map(&:text).flatten.compact
+      tmp = page.all('ul.product-listing li a').flat_map(&:text).compact
       tmp.delete("")
       expect(tmp.sort!).to eq(["Apache Baseball Jersey",
                                "Ruby Baseball Jersey",
@@ -120,7 +120,7 @@ describe "viewing products", type: :feature, inaccessible: true do
       click_link "Mugs"
 
       expect(page.all('ul.product-listing li').size).to eq(2)
-      tmp = page.all('ul.product-listing li a').map(&:text).flatten.compact
+      tmp = page.all('ul.product-listing li a').flat_map(&:text).compact
       tmp.delete("")
       expect(tmp.sort!).to eq(["Ruby on Rails Mug", "Ruby on Rails Stein"])
     end
@@ -129,7 +129,7 @@ describe "viewing products", type: :feature, inaccessible: true do
       click_link "Bags"
 
       expect(page.all('ul.product-listing li').size).to eq(2)
-      tmp = page.all('ul.product-listing li a').map(&:text).flatten.compact
+      tmp = page.all('ul.product-listing li a').flat_map(&:text).compact
       tmp.delete("")
       expect(tmp.sort!).to eq(["Ruby on Rails Bag", "Ruby on Rails Tote"])
     end


### PR DESCRIPTION
**Description**
flat_map is 1.6 faster than map.flatten - [Enumerable#map...Array#flatten vs Enumerable#flat_map](https://github.com/JuanitoFatas/fast-ruby#enumerablemaparrayflatten-vs-enumerableflat_map-code)

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
