### PR TITLE
Improve sample data for the returned/reimbursed order

### DIFF
--- a/sample/db/samples/reimbursements.rb
+++ b/sample/db/samples/reimbursements.rb
@@ -2,21 +2,43 @@
 
 Spree::Sample.load_sample("orders")
 
-order          = Spree::Order.last
-inventory_unit = order.inventory_units.first
+order = Spree::Order.last
+inventory_unit = order.inventory_units.take!
 stock_location = inventory_unit.find_stock_item.stock_location
+return_reason = Spree::ReturnReason.active.take!
+preferred_reimbursement_type = Spree::ReimbursementType.where(name: 'Original').take!
 
-return_item = Spree::ReturnItem.create(inventory_unit: inventory_unit)
+# Mark the order paid and shipped
+order.payments.pending.each(&:complete)
+order.shipments.each do |shipment|
+  shipment.suppress_mailer = false
+  shipment.ship!
+end
 
-return_item.exchange_variant = return_item.eligible_exchange_variants.last
-return_item.build_exchange_inventory_unit
-return_item.accept!
-
-customer_return = Spree::CustomerReturn.create(
-  stock_location: stock_location,
-  return_items: [return_item]
+# Create a return authorization
+return_item = Spree::ReturnItem.new(
+  inventory_unit: inventory_unit,
+  preferred_reimbursement_type: preferred_reimbursement_type
 )
 
+order.return_authorizations.create!(
+  reason: return_reason,
+  return_items: [return_item],
+  stock_location: stock_location
+)
+
+# Create a customer return and mark it as received
+customer_return = Spree::CustomerReturn.create!(
+  return_items: [return_item],
+  stock_location: stock_location
+)
+return_item.reload
+return_item.skip_customer_return_processing = true
+return_item.receive!
+customer_return.process_return!
+
+# Accept the customer return and reimburse it
+return_item.accept!
 order.reimbursements.create(
   customer_return: customer_return,
   return_items: [return_item]


### PR DESCRIPTION
**Description**

In our sample data script, we are creating two orders. One of them is also returned and refunded in order to be able to see the reimbursement mailer preview, which requires an actual reimbursement in the database to work. 

The order is set in a way that allows the email preview to work but it's actually a bit messed up. In a real UX flow, it's not possible to have the order in that state, so I tried to adjust it to be as similar as possible with how a real refunded order looks like. 

This also improves the documentation since the sample code flow used can be a guideline to understand how the complex returns flow works. 

Ref: #1146

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] ~I have updated Guides and README accordingly to this change (if needed)~
- [ ] ~I have added tests to cover this change (if needed)~
- [ ] ~I have attached screenshots to this PR for visual changes (if needed)~
