### PR TITLE
Calling to_proc is faster than argumentless method

### DIFF
--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -136,16 +136,12 @@ module Spree
     end
 
     def update_shipment_amounts
-      shipments.each do |shipment|
-        shipment.update_amounts
-      end
+      shipments.each(&:update_amounts)
     end
 
     # give each of the shipments a chance to update themselves
     def update_shipments
-      shipments.each do |shipment|
-        shipment.update_state
-      end
+      shipments.each(&:update_state)
     end
 
     def update_payment_total

--- a/core/lib/spree/testing_support/factories/reimbursement_factory.rb
+++ b/core/lib/spree/testing_support/factories/reimbursement_factory.rb
@@ -15,7 +15,7 @@ FactoryBot.define do
       if reimbursement.return_items.empty?
         reimbursement.return_items = reimbursement.customer_return.return_items
       end
-      reimbursement.total = reimbursement.return_items.map { |ri| ri.amount }.sum
+      reimbursement.total = reimbursement.return_items.sum(&:amount)
     end
   end
 end

--- a/core/lib/spree/testing_support/shared_examples/gallery.rb
+++ b/core/lib/spree/testing_support/shared_examples/gallery.rb
@@ -10,7 +10,7 @@ RSpec.shared_examples 'a gallery' do
       include_context 'has multiple images'
 
       it 'has the associated images' do
-        expect(subject.map { |picture| picture.id }).
+        expect(subject.map(&:id)).
           to match_array([first_image.id, second_image.id])
       end
     end

--- a/core/spec/models/spree/stock/simple_coordinator_spec.rb
+++ b/core/spec/models/spree/stock/simple_coordinator_spec.rb
@@ -119,7 +119,7 @@ module Spree
         shared_examples "a fulfillable package" do
           it "packages correctly" do
             expect(shipments).not_to be_empty
-            inventory_units = shipments.flat_map { |shipment| shipment.inventory_units }
+            inventory_units = shipments.flat_map(&:inventory_units)
             expect(inventory_units.size).to eq(5)
             expect(inventory_units.uniq.size).to eq(5)
           end

--- a/core/spec/models/spree/taxon_spec.rb
+++ b/core/spec/models/spree/taxon_spec.rb
@@ -190,7 +190,7 @@ RSpec.describe Spree::Taxon, type: :model do
       it 'returns all descendant variants' do
         variants = taxon.all_variants
         expect(variants.count).to eq(9)
-        expect(variants).to match_array([product1, product2, product3].flat_map{ |p| p.variants_including_master })
+        expect(variants).to match_array([product1, product2, product3].flat_map(&:variants_including_master))
       end
     end
   end


### PR DESCRIPTION
**Description**
Symbol#to_proc is faster than argumentless method call in block. [Block vs Symbol#](https://github.com/JuanitoFatas/fast-ruby#block-vs-symbolto_proc-code)
<!--
  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

  Please include screenshots in case of visual changes to the frontend or backend sections of Solidus.

  If needed you can reference another PR or issue here, e.g.:
  Ref #ISSUE
-->

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
