### PR TITLE
Replace map.sum with sum

### DIFF
--- a/core/app/models/spree/calculator/default_tax.rb
+++ b/core/app/models/spree/calculator/default_tax.rb
@@ -54,7 +54,7 @@ module Spree
     end
 
     def sum_of_included_tax_rates(item)
-      rates_for_item(item).map(&:amount).sum
+      rates_for_item(item).sum(&:amount)
     end
   end
 end

--- a/core/app/models/spree/calculator/percent_per_item.rb
+++ b/core/app/models/spree/calculator/percent_per_item.rb
@@ -16,9 +16,9 @@ module Spree
 
     def compute(object = nil)
       return 0 if object.nil?
-      object.line_items.map { |line_item|
+      object.line_items.sum { |line_item|
         value_for_line_item(line_item)
-      }.sum
+      }
     end
 
     private

--- a/core/app/models/spree/calculator/price_sack.rb
+++ b/core/app/models/spree/calculator/price_sack.rb
@@ -12,7 +12,7 @@ module Spree
     # as object we always get line items, as calculable we have Coupon, ShippingMethod
     def compute(object)
       if object.is_a?(Array)
-        base = object.map { |element| element.respond_to?(:amount) ? element.amount : BigDecimal(element.to_s) }.sum
+        base = object.sum { |element| element.respond_to?(:amount) ? element.amount : BigDecimal(element.to_s) }
       else
         base = object.respond_to?(:amount) ? object.amount : BigDecimal(object.to_s)
       end

--- a/core/app/models/spree/customer_return.rb
+++ b/core/app/models/spree/customer_return.rb
@@ -25,11 +25,11 @@ module Spree
     delegate :id, to: :order, prefix: true, allow_nil: true
 
     def total
-      return_items.map(&:total).sum
+      return_items.sum(&:total)
     end
 
     def total_excluding_vat
-      return_items.map(&:total_excluding_vat).sum
+      return_items.sum(&:total_excluding_vat)
     end
     alias pre_tax_total total_excluding_vat
     deprecate pre_tax_total: :total_excluding_vat, deprecator: Spree::Deprecation

--- a/core/app/models/spree/exchange.rb
+++ b/core/app/models/spree/exchange.rb
@@ -17,7 +17,7 @@ module Spree
     end
 
     def display_amount
-      Spree::Money.new @reimbursement_objects.map(&:total).sum
+      Spree::Money.new @reimbursement_objects.sum(&:total)
     end
 
     def perform!

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -193,7 +193,7 @@ module Spree
 
     # For compatiblity with Calculator::PriceSack
     def amount
-      line_items.map(&:amount).sum
+      line_items.sum(&:amount)
     end
 
     # Sum of all line item amounts after promotions, before added tax

--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -149,7 +149,7 @@ module Spree
     end
 
     def update_payment_total
-      order.payment_total = payments.completed.includes(:refunds).map { |payment| payment.amount - payment.refunds.sum(:amount) }.sum
+      order.payment_total = payments.completed.includes(:refunds).sum { |payment| payment.amount - payment.refunds.sum(:amount) }
     end
 
     def update_shipment_total

--- a/core/app/models/spree/return_authorization.rb
+++ b/core/app/models/spree/return_authorization.rb
@@ -31,7 +31,7 @@ module Spree
     self.whitelisted_ransackable_attributes = ['memo']
 
     def total_excluding_vat
-      return_items.map(&:total_excluding_vat).sum
+      return_items.sum(&:total_excluding_vat)
     end
     alias pre_tax_total total_excluding_vat
     deprecate pre_tax_total: :total_excluding_vat, deprecator: Spree::Deprecation

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -150,7 +150,7 @@ module Spree
     end
 
     def item_cost
-      line_items.map(&:total).sum
+      line_items.sum(&:total)
     end
 
     def ready_or_pending?

--- a/core/app/models/spree/shipping_calculator.rb
+++ b/core/app/models/spree/shipping_calculator.rb
@@ -13,7 +13,7 @@ module Spree
     private
 
     def total(content_items)
-      content_items.map(&:amount).sum
+      content_items.sum(&:amount)
     end
   end
 end

--- a/core/app/models/spree/stock/package.rb
+++ b/core/app/models/spree/stock/package.rb
@@ -86,7 +86,7 @@ module Spree
       #   counting only those in the given state if it was specified
       def quantity(state = nil)
         matched_contents = state.nil? ? contents : contents.select { |content| content.state.to_s == state.to_s }
-        matched_contents.map(&:quantity).sum
+        matched_contents.sum(&:quantity)
       end
 
       # @return [Boolean] true if there are no inventory units in this

--- a/core/spec/models/spree/order_merger_spec.rb
+++ b/core/spec/models/spree/order_merger_spec.rb
@@ -135,7 +135,7 @@ module Spree
         expect(order_1.line_items.count).to eq(2)
 
         expect(order_1.item_count).to eq 2
-        expect(order_1.item_total).to eq order_1.line_items.map(&:amount).sum
+        expect(order_1.item_total).to eq order_1.line_items.sum(&:amount)
 
         # No guarantee on ordering of line items, so we do this:
         expect(order_1.line_items.pluck(:quantity)).to match_array([1, 1])


### PR DESCRIPTION
**Description**
`sum` allows for passing a block so there's no need to do `map` before summing by desired attribute.
<!--
  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

  Please include screenshots in case of visual changes to the frontend or backend sections of Solidus.

  If needed you can reference another PR or issue here, e.g.:
  Ref #ISSUE
-->

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
