### PR TITLE
Disable codes on apply automatically promo

### DIFF
--- a/backend/app/controllers/spree/admin/promotion_codes_controller.rb
+++ b/backend/app/controllers/spree/admin/promotion_codes_controller.rb
@@ -23,7 +23,12 @@ module Spree
 
       def new
         @promotion = Spree::Promotion.accessible_by(current_ability, :read).find(params[:promotion_id])
-        @promotion_code = @promotion.promotion_codes.build
+        if @promotion.apply_automatically
+          flash[:error] = t('activerecord.errors.models.spree/promotion_code.attributes.base.disallowed_with_apply_automatically')
+          redirect_to admin_promotion_promotion_codes_url(@promotion)
+        else
+          @promotion_code = @promotion.promotion_codes.build
+        end
       end
 
       def create

--- a/backend/app/views/spree/admin/promotion_codes/index.html.erb
+++ b/backend/app/views/spree/admin/promotion_codes/index.html.erb
@@ -4,7 +4,7 @@
 
 <% content_for :page_actions do %>
   <li>
-    <% if can?(:create, Spree::PromotionCode) %>
+    <% if can?(:create, Spree::PromotionCode) && !@promotion.apply_automatically? %>
       <%= link_to t('spree.create_promotion_code'), new_admin_promotion_promotion_code_path(promotion_id: @promotion.id), class: 'btn btn-primary' %>
     <% end %>
 

--- a/backend/app/views/spree/admin/promotions/_activations_new.html.erb
+++ b/backend/app/views/spree/admin/promotions/_activations_new.html.erb
@@ -4,7 +4,7 @@
     <div class="form-check">
       <label class="form-check-label">
         <%= radio_button_tag('activation_type', 'auto', activation_type == 'auto') %>
-        <%= t('.auto') %>
+        <%= t('.auto') %> <%= f.field_hint :promo_code_will_be_disabled %>
       </label>
     </div>
     <div class="form-check">

--- a/backend/spec/controllers/spree/admin/promotion_codes_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/promotion_codes_controller_spec.rb
@@ -29,4 +29,11 @@ describe Spree::Admin::PromotionCodesController do
     expect(flash[:error]).not_to be_nil
     expect(Spree::PromotionCode.where(promotion: promotion).count).to eql(3)
   end
+
+  it "can't create a new code on promotions that apply automatically" do
+    apply_automatically_promotion = create(:promotion, apply_automatically: true)
+    get :new, params: { promotion_id: apply_automatically_promotion.id }
+    expect(response).to redirect_to(spree.admin_promotion_promotion_codes_path(apply_automatically_promotion))
+    expect(flash[:error]).not_to be_nil
+  end
 end

--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -159,7 +159,7 @@ module Spree
     private
 
     def require_promotion_code?
-      promotion? && source.promotion.codes.any?
+      promotion? && !source.promotion.apply_automatically && source.promotion.codes.any?
     end
 
     def repair_adjustments_associations_on_create

--- a/core/app/models/spree/order_promotion.rb
+++ b/core/app/models/spree/order_promotion.rb
@@ -21,7 +21,7 @@ module Spree
     private
 
     def require_promotion_code?
-      promotion && promotion.codes.any?
+      promotion && !promotion.apply_automatically && promotion.codes.any?
     end
   end
 end

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -32,7 +32,7 @@ module Spree
     validates :usage_limit, numericality: { greater_than: 0, allow_nil: true }
     validates :per_code_usage_limit, numericality: { greater_than_or_equal_to: 0, allow_nil: true }
     validates :description, length: { maximum: 255 }
-    validate :apply_automatically_disallowed_with_codes_or_paths
+    validate :apply_automatically_disallowed_with_paths
 
     before_save :normalize_blank_values
 
@@ -257,10 +257,9 @@ module Spree
       match_policy == "all"
     end
 
-    def apply_automatically_disallowed_with_codes_or_paths
+    def apply_automatically_disallowed_with_paths
       return unless apply_automatically
 
-      errors.add(:apply_automatically, :disallowed_with_code) if codes.any?
       errors.add(:apply_automatically, :disallowed_with_path) if path.present?
     end
 

--- a/core/app/models/spree/promotion_code.rb
+++ b/core/app/models/spree/promotion_code.rb
@@ -7,6 +7,7 @@ class Spree::PromotionCode < Spree::Base
 
   validates :value, presence: true, uniqueness: { allow_blank: true }
   validates :promotion, presence: true
+  validate :promotion_not_apply_automatically, on: :create
 
   before_save :normalize_code
 
@@ -35,6 +36,10 @@ class Spree::PromotionCode < Spree::Base
 
   def usage_limit
     promotion.per_code_usage_limit
+  end
+
+  def promotion_not_apply_automatically
+    errors.add(:base, :disallowed_with_apply_automatically) if promotion.apply_automatically
   end
 
   private

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -476,7 +476,6 @@ en:
         spree/promotion:
           attributes:
             apply_automatically:
-              disallowed_with_code: Disallowed for promotions with a code
               disallowed_with_path: Disallowed for promotions with a path
         spree/promotion_code:
           attributes:

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -478,6 +478,10 @@ en:
             apply_automatically:
               disallowed_with_code: Disallowed for promotions with a code
               disallowed_with_path: Disallowed for promotions with a path
+        spree/promotion_code:
+          attributes:
+            base:
+              disallowed_with_apply_automatically: Could not create promotion code on promotion that apply automatically
         spree/refund:
           attributes:
             amount:

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1407,6 +1407,8 @@ en:
           is specified, the promotion will never expire.
         starts_at: This determines when the promotion can be applied to orders. <br/>
           If no value is specified, the promotion will be immediately available.
+        promo_code_will_be_disabled: Selecting this option, promo codes will be disabled for this promotion
+          because all its rules / actions will be applied automatically to all orders.
       spree/stock_location:
         active: 'This determines whether stock from this location can be used when
           building packages.<br/> Default: Checked'

--- a/core/spec/models/spree/adjustment_spec.rb
+++ b/core/spec/models/spree/adjustment_spec.rb
@@ -199,6 +199,23 @@ RSpec.describe Spree::Adjustment, type: :model do
         it { is_expected.to include("can't be blank") }
       end
     end
+
+    context "when the adjustment is a promotion that apply automatically adjustment" do
+      let(:adjustment) { build(:adjustment, source: promotion.actions.first) }
+      let(:promotion) { create(:promotion, :with_order_adjustment, apply_automatically: true) }
+
+      context "when the promotion does not have a code" do
+        it { is_expected.to be_blank }
+      end
+
+      context "when the promotion has a code" do
+        let!(:promotion_code) do
+          promotion.codes << build(:promotion_code, promotion: promotion)
+        end
+
+        it { is_expected.to be_blank }
+      end
+    end
   end
 
   describe 'repairing adjustment associations' do

--- a/core/spec/models/spree/order_promotion_spec.rb
+++ b/core/spec/models/spree/order_promotion_spec.rb
@@ -30,4 +30,28 @@ RSpec.describe Spree::OrderPromotion do
       it { is_expected.to include("can't be blank") }
     end
   end
+
+  describe "promotion code presence error on promotion that apply automatically" do
+    subject do
+      order_promotion.promotion.apply_automatically = true
+      order_promotion.promotion.save!
+      order_promotion.valid?
+      order_promotion.errors[:promotion_code]
+    end
+
+    let(:order_promotion) { build(:order_promotion) }
+    let(:promotion) { order_promotion.promotion }
+
+    context "when the promotion does not have a code" do
+      it { is_expected.to be_blank }
+    end
+
+    context "when the promotion has a code" do
+      let!(:promotion_code) do
+        promotion.codes << build(:promotion_code, promotion: promotion)
+      end
+
+      it { is_expected.to be_blank }
+    end
+  end
 end

--- a/core/spec/models/spree/promotion_code_spec.rb
+++ b/core/spec/models/spree/promotion_code_spec.rb
@@ -203,4 +203,11 @@ RSpec.describe Spree::PromotionCode do
       }.to change{ order.reload.state }.from("confirm").to("address")
     end
   end
+
+  it "cannot create promotion code on apply automatically promotion" do
+    promotion = create(:promotion, apply_automatically: true)
+    expect {
+      create(:promotion_code, promotion: promotion)
+    }.to raise_error ActiveRecord::RecordInvalid, "Validation failed: Could not create promotion code on promotion that apply automatically"
+  end
 end

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -76,12 +76,6 @@ RSpec.describe Spree::Promotion, type: :model do
         expect(subject).to be_valid
       end
 
-      it "invalidates the promotion when it has a code" do
-        subject.codes.build(value: "foo")
-        expect(subject).to_not be_valid
-        expect(subject.errors).to include(:apply_automatically)
-      end
-
       it "invalidates the promotion when it has a path" do
         subject.path = "foo"
         expect(subject).to_not be_valid


### PR DESCRIPTION
**Description**
Disabled creation of promotion code if a promotion applies automatically to all orders. Managed also old "apply-automatically" promotions with and without associated promotion codes.

Solve #3472

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
