### PR TITLE
Ensure payment methods are ordered correctly

### DIFF
--- a/backend/app/controllers/spree/admin/payments_controller.rb
+++ b/backend/app/controllers/spree/admin/payments_controller.rb
@@ -80,11 +80,11 @@ module Spree
 
       def load_data
         @amount = params[:amount] || load_order.total
-        @payment_methods = Spree::PaymentMethod.active.available_to_admin
+        @payment_methods = Spree::PaymentMethod.active.available_to_admin.ordered_by_position
         if @payment && @payment.payment_method
           @payment_method = @payment.payment_method
         else
-          @payment_method = @payment_methods.first
+          @payment_method = @payment_methods.ordered_by_position.first
         end
       end
 

--- a/backend/spec/controllers/spree/admin/payments_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/payments_controller_spec.rb
@@ -100,6 +100,18 @@ module Spree
               expect(assigns[:payment_methods]).to be_empty
             end
           end
+
+          it "loads the payment methods in order" do
+            check = create :check_payment_method, position: 2
+            credit_card = create :payment_method, position: 1
+
+            get :new, params: { order_id: order.number }
+
+            expect(assigns(:payment_methods)).to eq [
+              credit_card, check
+            ]
+            expect(assigns(:payment_method)).to eq credit_card
+          end
         end
       end
 


### PR DESCRIPTION
**Description**

Previously we were not respecting the payment method order in the admin. This orders them and tests that they are being ordered properly.