### PR TITLE
Remove conditional code that targets Rails 5.1

### DIFF
--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -53,17 +53,6 @@ module Spree
   end
 end
 
-if Gem::Version.new(Rails.version) < Gem::Version.new('5.2')
-  warn <<~HEREDOC
-    Rails 5.1 (EOL) is deprecated and will not be supported anymore from the next Solidus version.
-    Please, upgrade to a more recent Rails version.
-
-    Read more on upgrading from Rails 5.1 to Rails 5.2 here:
-    https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#upgrading-from-rails-5-1-to-rails-5-2
-
-  HEREDOC
-end
-
 require 'spree/core/version'
 
 require 'spree/core/active_merchant_dependencies'

--- a/core/lib/spree/testing_support/dummy_app.rb
+++ b/core/lib/spree/testing_support/dummy_app.rb
@@ -52,6 +52,7 @@ module DummyApp
     config.whiny_nils = true
     config.consider_all_requests_local = true
     config.action_controller.allow_forgery_protection = true
+    config.action_controller.default_protect_from_forgery = true
     config.action_controller.perform_caching = false
     config.action_dispatch.show_exceptions = false
     config.active_support.deprecation = :stderr
@@ -59,7 +60,6 @@ module DummyApp
     config.active_support.deprecation = :stderr
     config.secret_key_base = 'SECRET_TOKEN'
 
-    config.action_controller.default_protect_from_forgery = true
     unless RAILS_6_OR_ABOVE
       config.active_record.sqlite3.represent_boolean_as_integer = true
     end

--- a/core/lib/spree/testing_support/dummy_app.rb
+++ b/core/lib/spree/testing_support/dummy_app.rb
@@ -44,20 +44,20 @@ module DummyApp
   end
 
   class Application < ::Rails::Application
-    config.eager_load                                 = false
-    config.cache_classes                              = true
-    config.cache_store                                = :memory_store
-    config.serve_static_assets                        = true
-    config.public_file_server.headers                 = { 'Cache-Control' => 'public, max-age=3600' }
-    config.whiny_nils                                 = true
-    config.consider_all_requests_local                = true
+    config.eager_load = false
+    config.cache_classes = true
+    config.cache_store = :memory_store
+    config.serve_static_assets = true
+    config.public_file_server.headers = { 'Cache-Control' => 'public, max-age=3600' }
+    config.whiny_nils = true
+    config.consider_all_requests_local = true
     config.action_controller.allow_forgery_protection = true
-    config.action_controller.perform_caching          = false
-    config.action_dispatch.show_exceptions            = false
-    config.active_support.deprecation                 = :stderr
-    config.action_mailer.delivery_method              = :test
-    config.active_support.deprecation                 = :stderr
-    config.secret_key_base                            = 'SECRET_TOKEN'
+    config.action_controller.perform_caching = false
+    config.action_dispatch.show_exceptions = false
+    config.active_support.deprecation = :stderr
+    config.action_mailer.delivery_method = :test
+    config.active_support.deprecation = :stderr
+    config.secret_key_base = 'SECRET_TOKEN'
 
     config.action_controller.default_protect_from_forgery = true
     unless RAILS_6_OR_ABOVE

--- a/core/lib/spree/testing_support/dummy_app.rb
+++ b/core/lib/spree/testing_support/dummy_app.rb
@@ -12,14 +12,10 @@ Rails.env = 'test'
 
 require 'solidus_core'
 
-RAILS_52_OR_ABOVE = Gem::Version.new(Rails.version) >= Gem::Version.new('5.2')
 RAILS_6_OR_ABOVE = Gem::Version.new(Rails.version) >= Gem::Version.new('6.0')
 
 # @private
 class ApplicationController < ActionController::Base
-  unless RAILS_52_OR_ABOVE
-    protect_from_forgery with: :exception
-  end
 end
 
 # @private
@@ -63,11 +59,9 @@ module DummyApp
     config.active_support.deprecation                 = :stderr
     config.secret_key_base                            = 'SECRET_TOKEN'
 
-    if RAILS_52_OR_ABOVE
-      config.action_controller.default_protect_from_forgery = true
-      unless RAILS_6_OR_ABOVE
-        config.active_record.sqlite3.represent_boolean_as_integer = true
-      end
+    config.action_controller.default_protect_from_forgery = true
+    unless RAILS_6_OR_ABOVE
+      config.active_record.sqlite3.represent_boolean_as_integer = true
     end
 
     # Avoid issues if an old spec/dummy still exists

--- a/core/lib/spree/testing_support/dummy_app/migrations.rb
+++ b/core/lib/spree/testing_support/dummy_app/migrations.rb
@@ -15,12 +15,8 @@ module DummyApp
 
     def needs_migration?
       return true if !database_exists?
-      if ActiveRecord::Base.connection.respond_to?(:migration_context)
-        # Rails >= 5.2
-        ActiveRecord::Base.connection.migration_context.needs_migration?
-      else
-        ActiveRecord::Migrator.needs_migration?
-      end
+
+      ActiveRecord::Base.connection.migration_context.needs_migration?
     end
 
     def auto_migrate


### PR DESCRIPTION
**Description**

🧹🧹🧹🧹

We still have some conditional code that targets Rails 5.1, which has been deprecated and we do not support anymore. 

This PR removes that code in order to keep the codebase as clean as possible.


**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- ~[ ] I have updated Guides and README accordingly to this change (if needed)~
- ~[ ] I have added tests to cover this change (if needed)~
- ~[ ] I have attached screenshots to this PR for visual changes (if needed)~
