### PR TITLE
Scope image by product_id or variant_id in ImagesController

### DIFF
--- a/api/app/controllers/spree/api/images_controller.rb
+++ b/api/app/controllers/spree/api/images_controller.rb
@@ -9,7 +9,7 @@ module Spree
       end
 
       def show
-        @image = Spree::Image.accessible_by(current_ability, :read).find(params[:id])
+        @image = scope.images.accessible_by(current_ability, :read).find(params[:id])
         respond_with(@image)
       end
 
@@ -20,13 +20,13 @@ module Spree
       end
 
       def update
-        @image = Spree::Image.accessible_by(current_ability, :update).find(params[:id])
+        @image = scope.images.accessible_by(current_ability, :update).find(params[:id])
         @image.update(image_params)
         respond_with(@image, default_template: :show)
       end
 
       def destroy
-        @image = Spree::Image.accessible_by(current_ability, :destroy).find(params[:id])
+        @image = scope.images.accessible_by(current_ability, :destroy).find(params[:id])
         @image.destroy
         respond_with(@image, status: 204)
       end


### PR DESCRIPTION
**Description**
The image route is under the product and variant resources:
`/api/products/:product_id/images/:id`
`/api/variants/:variant_id/images/:id`

When reading or performing any change on the product/variant image, the controller should scope the product or the variant when finding the image id.
The risk in only find by image id is to delete or read an image that belongs to another product.
The route path gives an expectation that the controller must meet: a request to a product or variant image.

**NOTE:** The product scope was present in the controller but removed by this pr https://github.com/solidusio/solidus/pull/1580. Not clear how that removal was needed but putting back the scope now is not breaking any spec and the functionality in admin still working.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change (if needed)
