### PR TITLE
Convert ES6 arrow syntax to ES5 for compatibility

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/views/cart/empty_cart_button.js
+++ b/backend/app/assets/javascripts/spree/backend/views/cart/empty_cart_button.js
@@ -15,10 +15,10 @@ Spree.Views.Cart.EmptyCartButton = Backbone.View.extend({
     }
 
     this.model.empty({
-      success: () => {
+      success: function () {
         this.collection.reset()
         this.collection.push({})
-      }
+      }.bind(this)
     })
   },
 


### PR DESCRIPTION
**Description**

ES6 arrow syntax was introduced in #3316 . This PR changes it back to ES5 syntax which obviates the need to put Uglifier into harmony mode just to run Solidus. See also #3480.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
