### PR TITLE
Allow multiple events subscription with regexp

### DIFF
--- a/core/lib/spree/event.rb
+++ b/core/lib/spree/event.rb
@@ -29,9 +29,15 @@ module Spree
     # Subscribe to an event with the given name. The provided block is executed
     # every time the subscribed event is fired.
     #
-    # @param [String] event_name the name of the event. The suffix ".spree"
-    #  will be added automatically if not present, when using the default
-    #  adapter for ActiveSupportNotifications.
+    # @param [String, Regexp] event_name the name of the event.
+    #  When String, the suffix ".spree" will be added automatically if not present,
+    #  when using the default adapter for ActiveSupportNotifications.
+    #  When Regexp, due to the unpredictability of all possible regexp combinations,
+    #  adding the suffix is developer's responsibility (if you don't, you will
+    #  subscribe to all notifications, including internal Rails notifications
+    #  as well).
+    #
+    # @see Spree::Event::Adapters::ActiveSupportNotifications#normalize_name
     #
     # @return a subscription object that can be used as reference in order
     #  to remove the subscription

--- a/core/spec/lib/spree/event/adapters/active_support_notifications_spec.rb
+++ b/core/spec/lib/spree/event/adapters/active_support_notifications_spec.rb
@@ -17,6 +17,22 @@ module Spree
               expect(subject).to eql "foo.spree"
             end
           end
+
+          context "when event name is a regexp" do
+            let(:event_name) { /.*/ }
+
+            it "never changes the regexp" do
+              expect(subject).to eq event_name
+            end
+          end
+
+          context "when event name is a class not handled" do
+            let(:event_name) { Object.new }
+
+            it "raises a InvalidEventNameType error" do
+              expect { subject }.to raise_error(described_class::InvalidEventNameType)
+            end
+          end
         end
       end
     end

--- a/core/spec/lib/spree/event_spec.rb
+++ b/core/spec/lib/spree/event_spec.rb
@@ -66,6 +66,13 @@ RSpec.describe Spree::Event do
           Spree::Event.fire subscription_name
           expect(item).to have_received :do_something
         end
+
+        it 'can subscribe to multiple events using a regexp' do
+          Spree::Event.subscribe(/.*\.spree$/) { item.do_something_else }
+          Spree::Event.fire subscription_name
+          Spree::Event.fire 'another_event'
+          expect(item).to have_received(:do_something_else).twice
+        end
       end
 
       describe '#unsubscribe' do

--- a/guides/source/developers/events/overview.html.md
+++ b/guides/source/developers/events/overview.html.md
@@ -48,6 +48,19 @@ Spree::Event.subscribe 'order_finalized' do |event|
 end
 ```
 
+When using the default event adapter it's possible to subscribe to multiple
+events using a regexp:
+
+```ruby
+Spree::Event.subscribe /.*\.spree$/ do |event|
+  puts "Event with name `#{event.name}` was just fired!"
+end
+```
+
+Please note that, unless you add explicitly the `.spree` suffix namespace,
+you will register to all ActiveSupportNotifications, including Rails internal
+ones.
+
 Another way to subscribe to events is creating a "subscriber" module that
 includes the `Spree::Event::Subscriber` module. For example:
 


### PR DESCRIPTION
Ref https://github.com/solidusio/solidus/issues/3481

`Spree::Event` events can now be subscribed also using regexp event names, when using the default  ActiveSupportNotification adapter.
As ActiveSupportNotification can manage regexp when subscribing to events, it makes sense to allow `Spree::Event` to leverage this feature.

Every specific adapter can decide independently their supported event name types. 

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
