### PR TITLE
Memoize Spree::User#wallet method

### DIFF
--- a/core/app/models/concerns/spree/user_methods.rb
+++ b/core/app/models/concerns/spree/user_methods.rb
@@ -39,7 +39,7 @@ module Spree
     end
 
     def wallet
-      Spree::Wallet.new(self)
+      @wallet ||= Spree::Wallet.new(self)
     end
 
     # has_spree_role? simply needs to return true or false whether a user has a role or not.


### PR DESCRIPTION
**Description**

We are already using memoization on some `Spree::Order` methods:

- https://github.com/solidusio/solidus/blob/master/core/app/models/spree/order.rb#L263-L265
- https://github.com/solidusio/solidus/blob/master/core/app/models/spree/order.rb#L294-L296
- https://github.com/solidusio/solidus/blob/master/core/app/models/spree/order.rb#L298-L300
- https://github.com/solidusio/solidus/blob/master/core/app/models/spree/order.rb#L302-L304

and `Spree::User#wallet` seems a good candidate to memoize.
 
Without memoization every time someone calls this method a new instance of `Spree::Wallet` is created but I think we should interact ever with the same instance, It seems logical to me that a user has just one wallet, this way the code reflect the reality and It also improves performance and memory usage.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message