### PR TITLE
Improve unstocking inventory units from stock locations

### DIFF
--- a/core/app/models/spree/stock/inventory_units_finalizer.rb
+++ b/core/app/models/spree/stock/inventory_units_finalizer.rb
@@ -34,11 +34,9 @@ module Spree
       end
 
       def unstock_inventory_units
-        inventory_units.group_by(&:shipment_id).each_value do |inventory_units_for_shipment|
-          inventory_units_for_shipment.group_by(&:line_item_id).each_value do |units|
-            shipment = units.first.shipment
-            line_item = units.first.line_item
-            shipment.stock_location.unstock line_item.variant, units.count, shipment
+        inventory_units.group_by(&:shipment).each do |shipment, units_by_shipment|
+          units_by_shipment.group_by(&:variant).each do |variant, units|
+            shipment.stock_location.unstock variant, units.count, shipment
           end
         end
       end

--- a/core/spec/models/spree/stock/inventory_units_finalizer_spec.rb
+++ b/core/spec/models/spree/stock/inventory_units_finalizer_spec.rb
@@ -7,8 +7,10 @@ module Spree
     RSpec.describe InventoryUnitsFinalizer, type: :model do
       context "when finalizing an order with one line_item" do
         let(:order)          { build(:order_with_line_items) }
-        let(:inventory_unit) { build(:inventory_unit, order: order, variant: order.line_items.first.variant, shipment: order.shipments.first) }
-        let(:stock_item) { inventory_unit.variant.stock_items.first }
+        let(:inventory_unit) { build(:inventory_unit, order: order, variant: variant, line_item: line_item, shipment: order.shipments.first) }
+        let(:stock_item)     { inventory_unit.variant.stock_items.first }
+        let(:line_item)      { order.line_items.first }
+        let(:variant)        { create(:variant) }
 
         before do
           stock_item.set_count_on_hand(10)
@@ -27,7 +29,11 @@ module Spree
           expect { subject }.to change { inventory_unit.reload.pending }.to(false)
         end
 
-        it "unstocks the variant" do
+        it "doesn't unstocks the line item variant" do
+          expect { subject }.to_not change { line_item.variant.stock_items.first.reload.count_on_hand }
+        end
+
+        it "unstocks the inventory_unit variant" do
           expect { subject }.to change { stock_item.reload.count_on_hand }.from(10).to(9)
         end
       end


### PR DESCRIPTION
**Description**

This PR fixes the bug reported from this issue https://github.com/solidusio/solidus/issues/3527.

The `Spree::Stock::InventoryUnitsFinalizer#unstock_inventory_units` method was unstocking the `line_item` original `variant` but not the `variant` set in the `inventory_unit`, this PR fixes this error and improve the code a bit.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
