### PR TITLE
Add Rails 6.1.0.alpha/master support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,13 @@ source 'https://rubygems.org'
 group :backend, :frontend, :core, :api do
   gemspec require: false
 
-  rails_version = ENV['RAILS_VERSION'] || '~> 6.0.0'
-  gem 'rails', rails_version, require: false
+  # rubocop:disable Bundler/DuplicatedGem
+  if ENV['RAILS_VERSION'] == 'master'
+    gem 'rails', github: 'rails', require: false
+  else
+    gem 'rails', ENV['RAILS_VERSION'] || '~> 6.0.0', require: false
+  end
+  # rubocop:enable Bundler/DuplicatedGem
 
   # Temporarily locking sprockets to v3.x
   # see https://github.com/solidusio/solidus/issues/3374

--- a/api/spec/spec_helper.rb
+++ b/api/spec/spec_helper.rb
@@ -61,6 +61,7 @@ RSpec.configure do |config|
     Rails.cache.clear
   end
 
+  config.include ActiveSupport::Testing::Assertions
   config.include ActiveJob::TestHelper
 
   config.use_transactional_fixtures = true

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -106,6 +106,7 @@ RSpec.configure do |config|
   end
 
   config.include FactoryBot::Syntax::Methods
+  config.include ActiveSupport::Testing::Assertions
   config.include ActiveJob::TestHelper
 
   config.include Spree::TestingSupport::Preferences

--- a/core/lib/spree/awesome_nested_set_override.rb
+++ b/core/lib/spree/awesome_nested_set_override.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module AwesomeNestedSetOvveride
+  # Add :polimorphic key option only when used to make it work with Rails 6.1+
+  # https://github.com/osmaelo/rails/commit/2c008d9f6311d92b3660193285230505e74a114f
+  # This can be removed when upgrading to an awesome_nested_set version
+  # compliant with Rails 6.1+.
+  def acts_as_nested_set_relate_parent!
+    # Disable Rubocop to keep original code for diffs
+    # rubocop:disable
+    options = {
+      :class_name => self.base_class.to_s,
+      :foreign_key => parent_column_name,
+      :primary_key => primary_column_name,
+      :counter_cache => acts_as_nested_set_options[:counter_cache],
+      :inverse_of => (:children unless acts_as_nested_set_options[:polymorphic]),
+      :touch => acts_as_nested_set_options[:touch]
+    }
+    options[:polymorphic] = true if acts_as_nested_set_options[:polymorphic]
+    options[:optional] = true if ActiveRecord::VERSION::MAJOR >= 5
+    belongs_to :parent, options
+    # rubocop:disable
+  end
+
+  CollectiveIdea::Acts::NestedSet.prepend self
+end

--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -93,3 +93,7 @@ require 'spree/permission_sets'
 require 'spree/preferences/store'
 require 'spree/preferences/static_model_preferences'
 require 'spree/preferences/scoped_store'
+
+if Gem::Version.new(Rails.version) >= Gem::Version.new('6.1.0.alpha')
+  require 'spree/awesome_nested_set_override'
+end

--- a/core/lib/spree/testing_support/factories/user_factory.rb
+++ b/core/lib/spree/testing_support/factories/user_factory.rb
@@ -17,7 +17,10 @@ FactoryBot.define do
     end
 
     factory :admin_user do
-      spree_roles { [Spree::Role.find_by(name: 'admin') || create(:role, name: 'admin')] }
+      after(:create) do |user, _|
+        admin_role = Spree::Role.find_by(name: 'admin') || create(:role, name: 'admin')
+        user.spree_roles << admin_role
+      end
     end
 
     factory :user_with_addresses do |_u|

--- a/core/spec/models/spree/ability_spec.rb
+++ b/core/spec/models/spree/ability_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Spree::Ability, type: :model do
     let(:resource) { Object.new }
 
     context 'with admin user' do
-      let(:user) { build :admin_user }
+      let(:user) { create :admin_user }
       it_should_behave_like 'access granted'
       it_should_behave_like 'index allowed'
     end

--- a/core/spec/rails_helper.rb
+++ b/core/spec/rails_helper.rb
@@ -41,6 +41,7 @@ RSpec.configure do |config|
     Rails.cache.clear
   end
 
+  config.include ActiveSupport::Testing::Assertions
   config.include ActiveJob::TestHelper
   config.include FactoryBot::Syntax::Methods
 end


### PR DESCRIPTION
**Description**
This PR adds the ability to run Solidus with Rails master version.

It's useful to be able to start testing Solidus against Rails master to know what to expect and to reduce the time needed to upgrade after each Rails release.

There's also some Solidus [new features](https://github.com/solidusio/solidus/issues/2725) that require work and that will be widely used only from Rails 6.1.0 on.

**Checklist:**
- [X] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [X] I have added a detailed description into each commit message
- [X] I have added tests to cover this change (if needed)