### PR TITLE
Spree::OptionValue#name delegates to Spree::OptionType even when nil

### DIFF
--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -59,7 +59,6 @@ Spree::Core::Engine.routes.draw do
     end
     resources :option_values
 
-    resources :option_values, only: :index
     get '/orders/mine', to: 'orders#mine', as: 'my_orders'
     get "/orders/current", to: "orders#current", as: "current_order"
 

--- a/api/spec/requests/spree/api/option_values_controller_spec.rb
+++ b/api/spec/requests/spree/api/option_values_controller_spec.rb
@@ -12,12 +12,6 @@ module Spree
       stub_authentication!
     end
 
-    def check_option_values(option_values)
-      expect(option_values.count).to eq(1)
-      expect(option_values.first).to have_attributes([:id, :name, :presentation,
-                                                      :option_type_name, :option_type_id])
-    end
-
     context "without any option type scoping" do
       before do
         # Create another option value with a brand new option type
@@ -114,6 +108,16 @@ module Spree
 
           option_value.reload
           expect(option_value.name).to eq("Option Value")
+        end
+
+        it "can create an option value" do
+          post spree.api_option_values_path, params: { option_value: {
+                                name: "Option Value",
+                                presentation: 'option value'
+                              } }
+          expect(response.status).to eq(201)
+
+          expect(json_response).to have_attributes(attributes)
         end
 
         it "permits the correct attributes" do

--- a/core/app/models/spree/option_value.rb
+++ b/core/app/models/spree/option_value.rb
@@ -14,7 +14,7 @@ module Spree
     after_save :touch, if: :saved_changes?
     after_touch :touch_all_variants
 
-    delegate :name, :presentation, to: :option_type, prefix: :option_type
+    delegate :name, :presentation, to: :option_type, prefix: :option_type, allow_nil: true
 
     self.whitelisted_ransackable_attributes = %w[name presentation]
 


### PR DESCRIPTION
**Description**
[Spree::OptionValue#name](https://github.com/solidusio/solidus/blob/v2.9.5/core/app/models/spree/option_value.rb#L17
) is delegated to `Spree::OptionType` with `option_type` prefix (option_type_name).

The json response of `Spree::Api::OptionValuesController` uses the `*option_value_attributes` helper variable which includes [:option_type_name](https://github.com/solidusio/solidus/blob/v2.9.5/api/app/helpers/spree/api/api_helpers.rb#L78).
If for some reason an option value is created without option_type the above controller will return a 500 error because of the name delegation.

For instance, `Spree::Api::OptionValuesController#create` allows to create an option value record with only `name` and `presentation` params. Once created, the json response view will call `*option_value_attributes` with `option_type_name` breaking the app.

This pr also: 
- remove `check_option_values` from the `option_values_controller_spec.rb`
because is not used anywhere in the file. 
- remove option value resource duplicated route.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change (if needed)
