### PR TITLE
Replace `Spree::Event#name_with_suffix` with `adapter#normalize_name`

### DIFF
--- a/core/lib/spree/event.rb
+++ b/core/lib/spree/event.rb
@@ -21,7 +21,7 @@ module Spree
     #     @order.finalize!
     #   end
     def fire(event_name, opts = {})
-      adapter.fire name_with_suffix(event_name.to_s), opts do
+      adapter.fire normalize_name(event_name), opts do
         yield opts if block_given?
       end
     end
@@ -30,7 +30,8 @@ module Spree
     # every time the subscribed event is fired.
     #
     # @param [String] event_name the name of the event. The suffix ".spree"
-    #  will be added automatically if not present
+    #  will be added automatically if not present, when using the default
+    #  adapter for ActiveSupportNotifications.
     #
     # @return a subscription object that can be used as reference in order
     #  to remove the subscription
@@ -43,7 +44,7 @@ module Spree
     #
     # @see Spree::Event#unsubscribe
     def subscribe(event_name, &block)
-      name = name_with_suffix(event_name)
+      name = normalize_name(event_name)
       listener_names << name
       adapter.subscribe(name, &block)
     end
@@ -61,7 +62,7 @@ module Spree
     # @example Unsubscribe an event by name with explicit prefix
     #   Spree::Event.unsubscribe('order_finalized.spree')
     def unsubscribe(subscriber)
-      name_or_subscriber = subscriber.is_a?(String) ? name_with_suffix(subscriber) : subscriber
+      name_or_subscriber = subscriber.is_a?(String) ? normalize_name(subscriber) : subscriber
       adapter.unsubscribe(name_or_subscriber)
     end
 
@@ -95,6 +96,7 @@ module Spree
     #
     # @see Spree::Event::Configuration#suffix
     def suffix
+      Spree::Deprecation.warn "This method is deprecated and will be removed. Please use Event::Adapters::ActiveSupportNotifications#suffix"
       Spree::Config.events.suffix
     end
 
@@ -106,8 +108,8 @@ module Spree
 
     private
 
-    def name_with_suffix(name)
-      name.end_with?(suffix) ? name : [name, suffix].join
+    def normalize_name(name)
+     adapter.normalize_name(name)
     end
 
     def listener_names

--- a/core/lib/spree/event/adapters/active_support_notifications.rb
+++ b/core/lib/spree/event/adapters/active_support_notifications.rb
@@ -29,6 +29,22 @@ module Spree
             memo[name] = listeners if listeners.present?
           end
         end
+
+        # Normalizes the event name according to this specific adapter rules.
+        # @param [String, Symbol] event_name the event name, with or without the
+        #   .spree" suffix)
+        def normalize_name(event_name)
+          name = event_name.to_s
+          name.end_with?(suffix) ? name : [name, suffix].join
+        end
+
+        # The suffix used for namespacing event names, defaults to
+        # `.spree`
+        #
+        # @see Spree::Event::Configuration#suffix
+        def suffix
+          Spree::Config.events.suffix
+        end
       end
     end
   end

--- a/core/spec/lib/spree/event/adapters/active_support_notifications_spec.rb
+++ b/core/spec/lib/spree/event/adapters/active_support_notifications_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'spree/event'
+
+module Spree
+  module Event
+    module Adapters
+      RSpec.describe ActiveSupportNotifications do
+        describe "#normalize_name" do
+          subject { described_class.normalize_name(event_name) }
+
+          context "when event name is a string" do
+            let(:event_name) { "foo" }
+
+            it "adds the suffix to the event name" do
+              expect(subject).to eql "foo.spree"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/core/spec/lib/spree/event_spec.rb
+++ b/core/spec/lib/spree/event_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-require 'spree/event'
+require 'rails_helper'
 
 RSpec.describe Spree::Event do
   let(:subscription_name) { 'foo_bar' }


### PR DESCRIPTION
`Spree::Event#name_with_suffix` is not generic enough to stay in the `Spree::Event` class,  as different adapters may not have the concept of a name suffix, while, on the other hand, may need some different naming manipulation.
    
So, event name manipulation is now delegated to the specific event adapter using the method `#normalize_name`. 
As we currently have only `ActiveSupportNotifications`, the existing code from `Spree::Event` has been moved in that adapter class.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change (if needed)
