### PR TITLE
Rescue state machine exception from api base controller

### DIFF
--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -29,6 +29,7 @@ module Spree
       rescue_from ActiveRecord::RecordNotFound, with: :not_found
       rescue_from CanCan::AccessDenied, with: :unauthorized
       rescue_from Spree::Core::GatewayError, with: :gateway_error
+      rescue_from StateMachines::InvalidTransition, with: :invalid_transition
 
       helper Spree::Api::ApiHelpers
 
@@ -188,6 +189,12 @@ module Spree
 
       def default_per_page
         Kaminari.config.default_per_page
+      end
+
+      def invalid_transition(error)
+        logger.error("invalid_transition #{error.event} from #{error.from} for #{error.object.class.name}. Error: #{error.inspect}")
+
+        render "spree/api/errors/could_not_transition", locals: { resource: error.object }, status: :unprocessable_entity
       end
     end
   end

--- a/api/app/controllers/spree/api/checkouts_controller.rb
+++ b/api/app/controllers/spree/api/checkouts_controller.rb
@@ -23,9 +23,6 @@ module Spree
         authorize! :update, @order, order_token
         @order.next!
         respond_with(@order, default_template: 'spree/api/orders/show', status: 200)
-      rescue StateMachines::InvalidTransition => error
-        logger.error("invalid_transition #{error.event} from #{error.from} for #{error.object.class.name}. Error: #{error.inspect}")
-        respond_with(@order, default_template: 'spree/api/orders/could_not_transition', status: 422)
       end
 
       def advance
@@ -42,9 +39,6 @@ module Spree
           @order.complete!
           respond_with(@order, default_template: 'spree/api/orders/show', status: 200)
         end
-      rescue StateMachines::InvalidTransition => error
-        logger.error("invalid_transition #{error.event} from #{error.from} for #{error.object.class.name}. Error: #{error.inspect}")
-        respond_with(@order, default_template: 'spree/api/orders/could_not_transition', status: 422)
       end
 
       def update
@@ -57,12 +51,9 @@ module Spree
 
           return if after_update_attributes
 
-          if @order.completed? || @order.next
+          if @order.completed? || @order.next!
             state_callback(:after)
             respond_with(@order, default_template: 'spree/api/orders/show')
-          else
-            logger.error("failed_to_transition_errors=#{@order.errors.full_messages}")
-            respond_with(@order, default_template: 'spree/api/orders/could_not_transition', status: 422)
           end
         else
           invalid_resource!(@order)

--- a/api/app/controllers/spree/api/checkouts_controller.rb
+++ b/api/app/controllers/spree/api/checkouts_controller.rb
@@ -20,7 +20,6 @@ module Spree
           respond_with(@order, default_template: 'spree/api/orders/expected_total_mismatch', status: 400)
           return
         end
-        authorize! :update, @order, order_token
         @order.next!
         respond_with(@order, default_template: 'spree/api/orders/show', status: 200)
       end

--- a/api/app/views/spree/api/errors/could_not_transition.json.jbuilder
+++ b/api/app/views/spree/api/errors/could_not_transition.json.jbuilder
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+json.error(I18n.t(:could_not_transition, scope: "spree.api", resource: resource.class.name.demodulize.underscore))
+json.errors(resource.errors.to_hash)

--- a/api/app/views/spree/api/orders/could_not_transition.json.jbuilder
+++ b/api/app/views/spree/api/orders/could_not_transition.json.jbuilder
@@ -1,4 +1,9 @@
 # frozen_string_literal: true
 
+Spree::Deprecation.warn(
+  'spree/api/orders/could_not_transition is deprecated.' \
+  ' Please use spree/api/errors/could_not_transition'
+)
+
 json.error(I18n.t(:could_not_transition, scope: "spree.api.order"))
 json.errors(@order.errors.to_hash)

--- a/api/config/locales/en.yml
+++ b/api/config/locales/en.yml
@@ -8,6 +8,8 @@ en:
       invalid_resource: Invalid resource. Please fix errors and try again.
       invalid_taxonomy_id: Invalid taxonomy id.
       must_specify_api_key: You must specify an API key.
+      could_not_transition: The %{resource} could not be transitioned. Please fix the
+        errors and try again.
       order:
         could_not_transition: The order could not be transitioned. Please fix the
           errors and try again.

--- a/api/spec/requests/spree/api/checkouts_controller_spec.rb
+++ b/api/spec/requests/spree/api/checkouts_controller_spec.rb
@@ -388,7 +388,6 @@ module Spree
           state: 'address',
           email: nil
         )
-
         put spree.next_api_checkout_path(order), params: { id: order.to_param, order_token: order.guest_token }
         expect(response.status).to eq(422)
         expect(json_response['error']).to match(/could not be transitioned/)
@@ -429,6 +428,19 @@ module Spree
             subject
             expect(response.status).to eq(400)
             expect(json_response['errors']['expected_total']).to include(I18n.t('spree.api.order.expected_total_mismatch'))
+          end
+        end
+
+        context 'when cannot complete' do
+          let(:order) { create(:order) }
+
+          before { order.update(state: 'cart') }
+
+          it 'returns a state machine error' do
+            subject
+
+            expect(json_response['error']).to eq(I18n.t(:could_not_transition, scope: "spree.api", resource: 'order'))
+            expect(response.status).to eq(422)
           end
         end
       end

--- a/api/spec/requests/spree/api/orders_controller_spec.rb
+++ b/api/spec/requests/spree/api/orders_controller_spec.rb
@@ -883,6 +883,13 @@ module Spree
           expect(response.status).to eq 200
           expect(json_response["user_id"]).to eq(user.id)
         end
+
+        it "cannot cancel not completed order" do
+          put spree.cancel_api_order_path(order)
+
+          expect(json_response['error']).to eq(I18n.t(:could_not_transition, scope: "spree.api", resource: 'order'))
+          expect(response.status).to eq(422)
+        end
       end
 
       context "can cancel an order" do

--- a/api/spec/views/spree/api/orders/could_not_transition.json.jbuilder_spec.rb
+++ b/api/spec/views/spree/api/orders/could_not_transition.json.jbuilder_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe 'spree/api/orders/could_not_transition.json.jbuilder' do
+  helper(Spree::Api::ApiHelpers)
+
+  let(:template_deprecation_error) do
+    'spree/api/orders/could_not_transition is deprecated.' \
+    ' Please use spree/api/errors/could_not_transition'
+  end
+
+  it 'shows a deprecation error' do
+    assign(:order, instance_double(Spree::Order, errors: {}))
+
+    expect(Spree::Deprecation).to receive(:warn).with(template_deprecation_error)
+
+    render
+  end
+end


### PR DESCRIPTION
**Description**
When an order is not completed cannot be transitioned via `cancel!` 

`OrdersController#cancel` call `@order.cancel!` through `canceled_by`:  the state machine
exception results in a 500 error when the action is called with a not completed order. 

Pr changes:
- rescue `StateMachines::InvalidTransition` exception from the `BaseController` returning the default json response and 422 status.
- Remove rescue `StateMachines::InvalidTransition` from Api/CheckoutsController. **Note** that this change remove the log message from the [update action](https://github.com/solidusio/solidus/pull/3520/commits/f6b7b80c17308d14873a7fc2b223c06a041415f3#diff-10992068b70df9a93b07ec08575d29a6L64) when the state machine raise an exception. However the [invaid_transition](https://github.com/solidusio/solidus/pull/3520/files#diff-72139884662b996fcc462020939b7807R193) method has an explicit message that should work:

<img width="1337" alt="Screenshot 2020-03-03 at 18 26 02" src="https://user-images.githubusercontent.com/8694436/75891657-638f5380-5e30-11ea-8ad8-64986a17b53d.png">
The first string in the above image is the removed log message. The last string is what is 
logged in `invalid_transition`.

- Remove a double authorization in the `next` action.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change (if needed)
