### PR TITLE
Link to solidus_dev_support instead of solidus_cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ project.
 A list can be found at [extensions.solidus.io](http://extensions.solidus.io/).
 
 If you want to write an extension for Solidus, you can use the
-[solidus_cmd](https://www.github.com/solidusio/solidus_cmd.git) gem.
+[solidus_dev_support](https://github.com/solidusio/solidus_dev_support.git) gem.
 
 ## Contributing
 


### PR DESCRIPTION
**Description**
[solidus_cmd](https://www.github.com/solidusio/solidus_cmd.git ) is now outdated and has been replaced by [solidus_dev_support](https://github.com/solidusio/solidus_dev_support.git). This PR updates the documentation in the README to reflect this.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
