### PR TITLE
[Guides] Improve extensions pages

### DIFF
--- a/guides/source/developers/extensions/installing-extensions.html.md
+++ b/guides/source/developers/extensions/installing-extensions.html.md
@@ -1,7 +1,7 @@
 # Installing extensions
 
 Solidus extensions are gems that change or extend Solidus's functionality. Many
-Solidus extensions can be installed in a few simple steps: 
+Solidus extensions can be installed in a few simple steps:
 
 1. Add the extension gem to your project's `Gemfile`.
 2. Run `bundle install` to install the gem and its dependencies.
@@ -13,7 +13,7 @@ extension provides a generic way to define relationships between your store's
 products by using `RelationTypes`. The extension's documentation clearly lays
 out the installation process: add the `solidus_related_products` gem to your
 `Gemfile`, then run `bundle install` and `bundle exec rails generate
-solidus_related_products:install`. 
+solidus_related_products:install`.
 
 Some extensions require other custom configuration before they can be
 initialized.
@@ -26,19 +26,18 @@ to run it in a production environment.*
 ## Supported extensions
 
 You can add additional features to your store using Solidus extensions. A list
-of supported extensions can be found at [extensions.solidus.io][extensions].
+of supported extensions can be found at [solidus.io/extensions][extensions].
 
-You can use the [`solidus_cmd`][solidus-cmd] gem if you want to start creating a
-new Solidus extension.
+You can use the [`solidus_dev_support`][solidus_dev_support] gem if you want
+to start creating a new Solidus extension.
 
-[extensions]: http://extensions.solidus.io
-[solidus-cmd]: https://github.com/solidusio/solidus_cmd
+[extensions]: http://solidus.io/extensions
+[solidus_dev_support]: https://github.com/solidusio/solidus_dev_support
 
 ## Soliton
 
-You can search for other Solidus extensions using [Soliton][soliton], a Solidus
-extension search engine courtesy of [Nebulab][nebulab].
+You can search for other Solidus extensions on GitHub using [Soliton][soliton],
+a Solidus extension search engine courtesy of [Nebulab][nebulab].
 
 [soliton]: http://soliton.nebulab.it
 [nebulab]: https://nebulab.it
-

--- a/guides/source/developers/extensions/testing-extensions.html.md
+++ b/guides/source/developers/extensions/testing-extensions.html.md
@@ -7,47 +7,29 @@ Solidus extensions.
 
 [contrib]: https://github.com/solidusio-contrib
 
-## TravisCI
+## CircleCI
 
-We usually test our extensions on TravisCI and make use of their [build matrix
-feature][build-matrix] to test across multiple Solidus versions. We also test
-against multiple databases: MySQL and PostgreSQL.
+We usually test our extensions against multiple Solidus versions and databases:
+MySQL and PostgreSQL. We use a [CircleCI Orb][orb] to re-use and maintain a
+single configuration that will be executed against all Solidus extensions.
 
-Solidus extensions should be tested across all versions of Solidus that have not
-reached [End of Life](https://solidus.io/blog/2018/01/04/maintenance-eol-policy.html)
-including the `master` branch.
+This Orb will take care of testing extensions against all versions of Solidus
+that have not reached [End of Life][eol] including the `master` branch.
 
-Here's an example `.travis.yml` testing versions 2.2 through 2.7 and the
-`master` branch:
+You can find an example `.circleci/config.yml` file [here][circle-config].
 
-```yaml
-language: ruby
-rvm:
-  - 2.3.1
-env:
-  matrix:
-    - SOLIDUS_BRANCH=v2.2 DB=postgres
-    - SOLIDUS_BRANCH=v2.3 DB=postgres
-    - SOLIDUS_BRANCH=v2.4 DB=postgres
-    - SOLIDUS_BRANCH=v2.5 DB=postgres
-    - SOLIDUS_BRANCH=v2.6 DB=postgres
-    - SOLIDUS_BRANCH=v2.7 DB=postgres
-    - SOLIDUS_BRANCH=master DB=postgres
-    - SOLIDUS_BRANCH=v2.2 DB=mysql
-    - SOLIDUS_BRANCH=v2.3 DB=mysql
-    - SOLIDUS_BRANCH=v2.4 DB=mysql
-    - SOLIDUS_BRANCH=v2.5 DB=mysql
-    - SOLIDUS_BRANCH=v2.6 DB=mysql
-    - SOLIDUS_BRANCH=v2.7 DB=mysql
-    - SOLIDUS_BRANCH=master DB=mysql
-```
+It runs specs against all supported versions, databases and setups a weekly
+nightly build to be sure the extension works even when it has not been updated
+for a while since Solidus could change in the meantime.
 
-[build-matrix]: https://docs.travis-ci.com/user/customizing-the-build/#Build-Matrix
+[orb]: https://github.com/solidusio/circleci-orbs-extensions
+[circle-config]: https://github.com/solidusio/solidus_dev_support/blob/master/lib/solidus_dev_support/templates/extension/.circleci/config.yml
+[eol]: https://solidus.io/security/
 
 ## Gemfile
 
-To use the versions of Solidus specified from the TravisCI build matrix, we need
-to use those environment variables in the `Gemfile`. Here's an example:
+To use the versions of Solidus specified from the CircleCI configuration,
+we need to use those environment variables in the `Gemfile`. Here's an example:
 
 ```ruby
 source "https://rubygems.org"
@@ -113,15 +95,15 @@ sed -i 's/ActiveRecord::Migration/SolidusSupport::Migration[4.2]/' db/migrate/*.
 
 [solidus-support]: https://github.com/solidusio/solidus_support
 
-## extensions.solidus.io
+## solidus.io/extensions
 
 You can see a list of Solidus extensions and their test suite statuses at
-[extensions.solidus.io][extensions].
+[solidus.io/extensions][extensions].
 
 If you'd like to have your extension added, [join the Solidus Slack team][slack]
 let us know in the [#solidus channel][solidus-channel].
 
-[extensions]: http://extensions.solidus.io
+[extensions]: http://solidus.io/extensions
 [slack]: http://slack.solidus.io
 [solidus-channel]: https://solidusio.slack.com/messages/solidus
 
@@ -145,4 +127,3 @@ This can be fixed automatically using the
 
 [rails-test-params-backport]: https://github.com/zendesk/rails_test_params_backport
 [rails5-spec-converter]: https://github.com/tjgrathwell/rails5-spec-converter
-

--- a/guides/source/developers/extensions/writing-extensions.html.md
+++ b/guides/source/developers/extensions/writing-extensions.html.md
@@ -8,41 +8,42 @@ that allow you to extend or change the functionality of the Solidus platform.
 
 Before you write a new Solidus extension you should look for an existing
 extension that meets your needs. Solidus maintains an official list of
-[supported extensions](http://extensions.solidus.io), but you can also use
-[soliton](http://soliton.nebulab.it) to search for extensions.
+[supported extensions](http://solidus.io/extensions), but you can also use
+[soliton](http://soliton.nebulab.it) to search for extensions in GitHub.
 
 There is also a series of curated extensions available under the
 [solidus-contrib](https://github.com/solidusio-contrib) organization.
 
 ## Developing a Solidus extension locally
 
-### Install the solidus_cmd gem
+### Install the solidus_dev_support gem
 A Solidus extension is just a Rails engine, you can build the extension in
 exactly the same way you'd build any other Rails engine.
 
-However, it is recommended that you use the [`solidus_cmd`](https://github.com/solidusio-contrib/solidus_cmd)
+However, it is recommended that you use the [`solidus_dev_support`](https://github.com/solidusio/solidus_dev_support)
 gem.
 
 ```bash
-gem install solidus_cmd
+gem install solidus_dev_support
 ```
 
-The `solidus_cmd` gem will generate the boilerplate Rails engine and ensure
-that you aren't missing any of the default dependencies.
+The `solidus_dev_support` gem will generate the boilerplate Rails engine and
+ensure that you aren't missing any of the default dependencies. It also comes
+with useful helpers that you may need when working on your extension.
 
 ### Generate a new Solidus extension
-Once you've installed `solidus_cmd`, you will have access to the `solidus`
-command. Using `solidus extension` will generate a new Solidus extension
-template in your current directory.
+Once you've installed `solidus_dev_support`, you will have access to the
+`solidus` command. Using `solidus extension` will generate a new Solidus
+extension template in your current directory.
 
 ```bash
 solidus extension extension_name
 ```
 
 ### Configure your extension
-After `solidus_cmd` has generated your extension template, you will need to
-configure your `gemspec` file. This step of the process is similar to [building
-any Ruby gem](https://bundler.io/v1.16/guides/creating_gem.html).
+After `solidus_dev_support` has generated your extension template, you will
+need to configure your `gemspec` file. This step of the process is similar
+to [building any Ruby gem](https://bundler.io/v1.16/guides/creating_gem.html).
 
 This is the right time to set the version of Solidus you are targeting with
 your extension. You can set that dependency and any other dependencies you
@@ -65,11 +66,10 @@ gem "solidus_extension_name", path: "path/to/extension"
 
 You can now use the `bundle` command to install your extension.
 
-# Registering your extension
-
+### Registering your extension
 Solidus extensions benefit from being shared with the community. Sharing your
 extension will allow other Solidus developers to extend the functionality of
 your code.
 
 You can add your extension to the official list of supported extensions by
-submitting a PR to [solidusio/extensions.solidus.io](https://github.com/solidusio/extensions.solidus.io).
+submitting a PR to [solidusio/solidus-site](https://github.com/solidusio/solidus-site/blob/master/data/extensions.yml).

--- a/guides/source/developers/getting-started/develop-solidus.html.md
+++ b/guides/source/developers/getting-started/develop-solidus.html.md
@@ -128,7 +128,7 @@ env COVERAGE=true bundle exec rspec
 You can add additional features to your store using Solidus extensions. A list
 of supported extensions can be found at [extensions.solidus.io][extensions].
 
-You can use the [`solidus_cmd`][solidus-cmd] gem as an example if you want to
+You can use the [`solidus_dev_support`][solidus_dev_support] gem as an example if you want to
 start creating a new Solidus extension. Check out the doc on
 [writing extensions][writing-extensions] to learn more.
 
@@ -136,4 +136,4 @@ start creating a new Solidus extension. Check out the doc on
 [circleci]: https://circleci.com/gh/solidusio/solidus
 [extensions]: http://extensions.solidus.io
 [writing-extensions]: https://guides.solidus.io/developers/extensions/writing-extensions.html
-[solidus-cmd]: https://github.com/solidusio/solidus_cmd
+[solidus_dev_support]: https://github.com/solidusio/solidus_dev_support


### PR DESCRIPTION
**Description**

It replaces all occurrences of `solidus_cmd` with `solidus_dev_support`. 
This PR also removes references to TravisCI in favor of the new [CirlceCI Orb](https://github.com/solidusio/circleci-orbs-extensions) configuration for extensions.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- ~[ ] I have updated Guides and README accordingly to this change (if needed)~
- ~[ ] I have added tests to cover this change (if needed)~
- ~[ ] I have attached screenshots to this PR for visual changes (if needed)~
