### PR TITLE
Fix typo in documentation

### DIFF
--- a/guides/source/partials/_feedback.erb
+++ b/guides/source/partials/_feedback.erb
@@ -1,6 +1,6 @@
 <div class="content-block bg-info">
   <h2 class="title">Feedback</h2>
-  <p>Solidus is an open source platform supported by the community. We encourage everyone using Solius to contribute back to the documentation and the code.</p>
+  <p>Solidus is an open source platform supported by the community. We encourage everyone using Solidus to contribute back to the documentation and the code.</p>
   <p>If you’re interested in contributing to the docs, get started with the <a href="/contributing.html">contributing guidelines</a>. If you see something that needs fixing and can’t do it yourself, please
     <a href="mailto:contact@solidus.io">send us an email</a>.</p>
 </div>


### PR DESCRIPTION
Fix Solidus name typo.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
