### PR TITLE
[API] Add bang method when finding product property

### DIFF
--- a/api/app/controllers/spree/api/product_properties_controller.rb
+++ b/api/app/controllers/spree/api/product_properties_controller.rb
@@ -36,9 +36,8 @@ module Spree
       end
 
       def update
-        if @product_property
-          authorize! :update, @product_property
-          @product_property.update(product_property_params)
+        authorize! :update, @product_property
+        if @product_property.update(product_property_params)
           respond_with(@product_property, status: 200, default_template: :show)
         else
           invalid_resource!(@product_property)
@@ -46,13 +45,9 @@ module Spree
       end
 
       def destroy
-        if @product_property
-          authorize! :destroy, @product_property
-          @product_property.destroy
-          respond_with(@product_property, status: 204)
-        else
-          invalid_resource!(@product_property)
-        end
+        authorize! :destroy, @product_property
+        @product_property.destroy
+        respond_with(@product_property, status: 204)
       end
 
       private
@@ -65,7 +60,7 @@ module Spree
       def product_property
         if @product
           @product_property ||= @product.product_properties.find_by(id: params[:id])
-          @product_property ||= @product.product_properties.includes(:property).where(spree_properties: { name: params[:id] }).first
+          @product_property ||= @product.product_properties.includes(:property).where(spree_properties: { name: params[:id] }).first!
           authorize! :read, @product_property
         end
       end

--- a/api/spec/requests/spree/api/product_properties_controller_spec.rb
+++ b/api/spec/requests/spree/api/product_properties_controller_spec.rb
@@ -96,6 +96,18 @@ module Spree
         expect(response.status).to eq(204)
         expect { property_1.reload }.to raise_error(ActiveRecord::RecordNotFound)
       end
+
+      context 'when product property does not exist' do
+        it 'cannot update because is not found' do
+          put spree.api_product_product_property_path(product, 'no property'), params: { product_property: { value: "my value 456" } }
+          expect(response.status).to eq(404)
+        end
+
+        it 'cannot delete because is not found' do
+          delete spree.api_product_product_property_path(product, 'no property')
+          expect(response.status).to eq(404)
+        end
+      end
     end
 
     context "with product identified by id" do


### PR DESCRIPTION
**Description**
If the controller does not find the product property it cannot return an invalid resource response for that record and then it breaks with 500.
This commit adds the bang method so that the controller can rely on the base controller [rescue_from ActiveRecord::RecordNotFound](https://github.com/solidusio/solidus/blob/v2.10.0/api/app/controllers/spree/api/base_controller.rb#L28) to return a proper message.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change (if needed)

