### PR TITLE
Remove code from Spree::Api::PromotionsController

### DIFF
--- a/api/app/controllers/spree/api/promotions_controller.rb
+++ b/api/app/controllers/spree/api/promotions_controller.rb
@@ -3,26 +3,17 @@
 module Spree
   module Api
     class PromotionsController < Spree::Api::BaseController
-      before_action :requires_admin
       before_action :load_promotion
 
       def show
-        if @promotion
-          respond_with(@promotion, default_template: :show)
-        else
-          raise ActiveRecord::RecordNotFound
-        end
+        authorize! :read, @promotion
+        respond_with(@promotion, default_template: :show)
       end
 
       private
 
-      def requires_admin
-        return if @current_user_roles.include?("admin")
-        unauthorized && return
-      end
-
       def load_promotion
-        @promotion = Spree::Promotion.find_by(id: params[:id]) || Spree::Promotion.with_coupon_code(params[:id])
+        @promotion = Spree::Promotion.with_coupon_code(params[:id]) || Spree::Promotion.find(params[:id])
       end
     end
   end


### PR DESCRIPTION
**Description**
Little change to make `Spree::Api::PromotionsController` leaner and also consistent with how solidus api deals with `ActiveRecord::RecordNotFound` and authorization.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message

