### PR TITLE
Replace http method in api doc

### DIFF
--- a/api/openapi/api.oas2.yml
+++ b/api/openapi/api.oas2.yml
@@ -545,7 +545,7 @@ paths:
         - Variants
       security:
         - api-key: []
-    post:
+    put:
       responses:
         '200':
           description: ''
@@ -4296,7 +4296,7 @@ paths:
         type: string
         required: true
   '/shipments/{shipment_number}/select_shipping_method':
-    get:
+    put:
       responses:
         '200':
           description: ''


### PR DESCRIPTION
**Description**
Fix doc http methods for controller action (update) that uses `put` and not `post`.

[select_shipping_method](https://github.com/solidusio/solidus/blob/master/api/app/controllers/spree/api/shipments_controller.rb#L33) - custom action [route](https://github.com/solidusio/solidus/blob/master/api/config/routes.rb#L89)

[product variant update](https://github.com/solidusio/solidus/blob/master/api/app/controllers/spree/api/variants_controller.rb#L44)


**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
