### PR TITLE
Replace wrong key and add parameters in product taxons endpoint doc

### DIFF
--- a/api/openapi/api.oas2.yml
+++ b/api/openapi/api.oas2.yml
@@ -4586,10 +4586,13 @@ paths:
         - Products
       parameters:
         - in: query
-          name: taxon_id
+          name: id
           type: integer
         - $ref: '#/parameters/page'
         - $ref: '#/parameters/per_page'
+        - type: boolean
+          in: query
+          name: simple
       security:
         - api-key: []
 schemes:


### PR DESCRIPTION
**Description**
[Spree::Api::TaxonsController#products](https://github.com/solidusio/solidus/blob/v2.10.0/api/app/controllers/spree/api/taxons_controller.rb#L75) accepts `id` param to find the taxon and not `taxon_id`.

The products action also accept [simple](https://github.com/solidusio/solidus/blob/v2.10.0/api/app/controllers/spree/api/taxons_controller.rb#L79) param to filter product data and return a leaner response.

**Checklist:**
- [X] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [X] I have added a detailed description into each commit message
