### PR TITLE
RfC: Remove some order transitions

### DIFF
--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -60,7 +60,7 @@ module Spree
             end
 
             event :return do
-              transition to: :returned, from: [:returned, :complete, :awaiting_return, :canceled], if: :all_inventory_units_returned?
+              transition to: :returned, from: [:complete, :awaiting_return], if: :all_inventory_units_returned?
             end
 
             event :resume do

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -68,7 +68,7 @@ module Spree
             end
 
             event :authorize_return do
-              transition to: :awaiting_return
+              transition to: :awaiting_return, from: :complete
             end
 
             event :complete do

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -56,7 +56,7 @@ module Spree
             end
 
             event :cancel do
-              transition to: :canceled, if: :allow_cancel?
+              transition to: :canceled, if: :allow_cancel?, from: :complete
             end
 
             event :return do

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -94,11 +94,11 @@ RSpec.describe Spree::Order, type: :model do
       let!(:store_credit_payment_method) { create(:store_credit_payment_method) }
       let(:order_total) { 500.00 }
       let(:store_credit) { create(:store_credit, amount: order_total) }
-      let(:order) { create(:order_with_line_items, user: store_credit.user, line_items_price: order_total) }
+      let(:order) { create(:order_ready_to_complete, user: store_credit.user, line_items_price: order_total) }
 
       before do
         order.add_store_credit_payments
-        order.finalize!
+        order.complete!
         order.capture_payments!
       end
 


### PR DESCRIPTION
**Description**

This removes many, many transitions from the Order state machine, allowing us to reason more clearly about what the system is supposed to be doing and when.

I have used the wonderful https://github.com/state-machines/state_machines-graphviz gem to make the following visualisations.

Currently, our order state machine is automatically visualized like this: 

![Spree::Order_state](https://user-images.githubusercontent.com/703401/75552959-bd120f80-5a37-11ea-8b65-cb55fe09149e.png)

With these changes, this image becomes a lot more streamlined and understandable:

![Spree::Order_state](https://user-images.githubusercontent.com/703401/75553046-edf24480-5a37-11ea-8f94-27b9a63e897e.png)

I have on purpose not added specs for this, as this is exclusively a feature removal for which I do not see why we should add tests. :)



**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
