### PR TITLE
[Guides] Add System Requirements page

### DIFF
--- a/guides/data/nav/developers.yml
+++ b/guides/data/nav/developers.yml
@@ -11,6 +11,8 @@
         href: "/developers/getting-started/forking-solidus.html"
       - title: "Customer flow"
         href: "/developers/getting-started/customer-flow.html"
+      - title: "System Requirements"
+        href: "/developers/getting-started/system-requirements.html"
 -
   - title: "API"
     dropdown:

--- a/guides/source/developers/getting-started/first-time-installation.html.md
+++ b/guides/source/developers/getting-started/first-time-installation.html.md
@@ -37,28 +37,7 @@ Because Solidus is a Rails engine, much of what the [Rails Guide on
 Engines](http://guides.rubyonrails.org/engines.html) explains applies directly
 to Solidus, too.
 
-We also recommend configuring your development environment so that you can
-[install RubyGems without `sudo`][gem-install-without-sudo].
-
-[gem-install-without-sudo]: https://www.michaelehead.com/2016/02/06/installing-gems-without-sudo.html
-
-## System requirements
-
-The following software is required to get Solidus running:
-
-- [Ruby](https://www.ruby-lang.org) 2.2.2 or newer
-- [SQLite 3](https://sqlite.org)
-- [Rails](http://guides.rubyonrails.org/getting_started.html) 5.0.0 or newer
-- [ImageMagick](http://imagemagick.org/script/download.php)
-
-We recommend using [Homebrew][brew] to install these dependencies on your
-Mac. Throughout this article, we will use the `brew` command for installing
-system dependencies. [The Ruby documentation also recommends using
-Homebrew][ruby-homebrew] if you need to upgrade from your system's Ruby.
-
-[ruby-homebrew]: https://www.ruby-lang.org/en/documentation/installation/#homebrew
-
-### Quick start
+## Setup and installation
 
 Using Homebrew, you can install all of the requirements using the following
 commands:
@@ -68,80 +47,10 @@ brew install ruby sqlite3 imagemagick
 gem install rails
 ```
 
-See more detailed installation information below.
+You can find more details on Solidus' dependencies in the
+[System Requirements][system-requirements] page.
 
-### Upgrade Ruby on macOS
-
-If you run macOS Sierra or an older OS, you system's version of Ruby will need
-to be upgraded from 2.0.x to 2.2.2 or newer. You can check what version of Ruby
-you have installed with the following command:
-
-```bash
-ruby --version
-```
-
-The Ruby documentation recommends installing another, newer instance of Ruby
-using Homebrew:
-
-```bash
-brew install ruby
-```
-
-Homebrew prioritizes the Homebrew installation of Ruby
-(`/usr/local/bin/ruby`) above the system installation (`/usr/bin/ruby`).
-
-### Install SQLite 3
-
-Rails and Solidus use SQLite 3 as the default relational database. SQLite is a
-widely-supported, lightweight way to send and receive data. Using Homebrew,
-you can install the latest version of SQLite 3 using the following command:
-
-```bash
-brew install sqlite3
-```
-
-Alternatively, you can [download the pre-compiled binary from the SQLite
-website](https://www.sqlite.org/download.html).
-
-After installation, check the version number:
-
-```bash
-sqlite3 --version
-```
-
-If all is well, this command will return a version number that looks something
-like `3.16.0 2016-11-04 19:09:39 0f3eed3324eda2a2b8d3301e5a43dc58a3a5fd5f`.
-
-### Install Rails
-
-Rails includes everything you need to build and extend a web application. Once
-you have Ruby and SQLite 3 installed on your system, you can install Rails via
-the [RubyGems](https://rubygems.org) `gem` command that comes as a part of Ruby:
-
-```bash
-gem install rails
-```
-
-This will install Rails as well as its dependencies.
-
-### Install ImageMagick
-
-ImageMagick helps you create, edit, and save to hundreds of image file formats.
-It is required by [Paperclip](https://github.com/thoughtbot/paperclip),
-which Solidus currently uses to handle file attachments. To install ImageMagick
-via Homebrew, use the command:
-
-```bash
-brew install imagemagick
-```
-
-Alternatively, you can [download a pre-compiled binary for macOS from the
-ImageMagick website](http://imagemagick.org/script/download.php).
-
-## Setup and installation
-
-Once you have installed all of the system requirements, we can start setting up
-Solidus.
+[system-requirements]: system-requirements.html
 
 ### Create and configure new Rails project
 

--- a/guides/source/developers/getting-started/system-requirements.html.md
+++ b/guides/source/developers/getting-started/system-requirements.html.md
@@ -1,0 +1,99 @@
+# System requirements
+
+The following software is required to get Solidus running:
+
+- [Ruby](https://www.ruby-lang.org) 2.2.2 or newer
+- [SQLite 3](https://sqlite.org)
+- [Rails](http://guides.rubyonrails.org/getting_started.html) 5.0.0 or newer
+- [ImageMagick](http://imagemagick.org/script/download.php)
+
+We recommend using [Homebrew][brew] to install these dependencies on your
+Mac. Throughout this article, we will use the `brew` command for installing
+system dependencies. [The Ruby documentation also recommends using
+Homebrew][ruby-homebrew] if you need to upgrade from your system's Ruby.
+
+We also recommend configuring your development environment so that you can
+[install RubyGems without `sudo`][gem-install-without-sudo].
+
+[ruby-homebrew]: https://www.ruby-lang.org/en/documentation/installation/#homebrew
+[gem-install-without-sudo]: https://www.michaelehead.com/2016/02/06/installing-gems-without-sudo.html
+
+## Quick start
+
+Using Homebrew, you can install all of the requirements using the following
+commands:
+
+```bash
+brew install ruby sqlite3 imagemagick
+gem install rails
+```
+
+See more detailed installation information below.
+
+## Upgrade Ruby on macOS
+
+If you run macOS Sierra or an older OS, you system's version of Ruby will need
+to be upgraded from 2.0.x to 2.2.2 or newer. You can check what version of Ruby
+you have installed with the following command:
+
+```bash
+ruby --version
+```
+
+The Ruby documentation recommends installing another, newer instance of Ruby
+using Homebrew:
+
+```bash
+brew install ruby
+```
+
+Homebrew prioritizes the Homebrew installation of Ruby
+(`/usr/local/bin/ruby`) above the system installation (`/usr/bin/ruby`).
+
+## Install SQLite 3
+
+Rails and Solidus use SQLite 3 as the default relational database. SQLite is a
+widely-supported, lightweight way to send and receive data. Using Homebrew,
+you can install the latest version of SQLite 3 using the following command:
+
+```bash
+brew install sqlite3
+```
+
+Alternatively, you can [download the pre-compiled binary from the SQLite
+website](https://www.sqlite.org/download.html).
+
+After installation, check the version number:
+
+```bash
+sqlite3 --version
+```
+
+If all is well, this command will return a version number that looks something
+like `3.16.0 2016-11-04 19:09:39 0f3eed3324eda2a2b8d3301e5a43dc58a3a5fd5f`.
+
+## Install Rails
+
+Rails includes everything you need to build and extend a web application. Once
+you have Ruby and SQLite 3 installed on your system, you can install Rails via
+the [RubyGems](https://rubygems.org) `gem` command that comes as a part of Ruby:
+
+```bash
+gem install rails
+```
+
+This will install Rails as well as its dependencies.
+
+## Install ImageMagick
+
+ImageMagick helps you create, edit, and save to hundreds of image file formats.
+It is required by [Paperclip](https://github.com/thoughtbot/paperclip),
+which Solidus currently uses to handle file attachments. To install ImageMagick
+via Homebrew, use the command:
+
+```bash
+brew install imagemagick
+```
+
+Alternatively, you can [download a pre-compiled binary for macOS from the
+ImageMagick website](http://imagemagick.org/script/download.php).


### PR DESCRIPTION
**Description**

Currently, the System Requirements section is on top of the first installation page, pushing the real expected content at the bottom of the page.

By splitting requirements into another page we give a quick overview on the installation process of Solidus, leaving some details to who needs them only.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- ~[ ] I have added tests to cover this change (if needed)~
- ~[ ] I have attached screenshots to this PR for visual changes (if needed)~
