### PR TITLE
Depreacate reimbursement hooks

### DIFF
--- a/core/app/models/spree/reimbursement.rb
+++ b/core/app/models/spree/reimbursement.rb
@@ -104,10 +104,20 @@ module Spree
       if unpaid_amount_within_tolerance?
         reimbursed!
         Spree::Event.fire 'reimbursement_reimbursed', reimbursement: self
+        if reimbursement_success_hooks.any?
+          Spree::Deprecation.warn \
+            "reimbursement_success_hooks are deprecated. Please remove them " \
+            "and subscribe to `reimbursement_reimbursed` event instead", caller(1)
+        end
         reimbursement_success_hooks.each { |hook| hook.call self }
       else
         errored!
         Spree::Event.fire 'reimbursement_errored', reimbursement: self
+        if reimbursement_failure_hooks.any?
+          Spree::Deprecation.warn \
+            "reimbursement_failure_hooks are deprecated. Please remove them " \
+            "and subscribe to `reimbursement_errored` event instead", caller(1)
+        end
         reimbursement_failure_hooks.each { |hook| hook.call self }
       end
 


### PR DESCRIPTION
The introduction of dedicated events for succesful and failed reimbursement made the existing hooks implemented as class attributes obsolete. 
They are now deprecated, waiting for a major release before their complete removal.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
