### PR TITLE
Configurable order state machine  and reduce the number of possible transitions

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -23,7 +23,8 @@ module Spree
     ORDER_NUMBER_LETTERS = false
     ORDER_NUMBER_PREFIX  = 'R'
 
-    include Spree::Order::Checkout
+    include ::Spree::Config.state_machines.order
+
     include Spree::Order::Payments
 
     class InsufficientStock < StandardError

--- a/core/lib/generators/solidus/install/templates/config/initializers/spree.rb.tt
+++ b/core/lib/generators/solidus/install/templates/config/initializers/spree.rb.tt
@@ -13,6 +13,9 @@ Spree.config do |config|
   # Use combined first and last name attribute in HTML views and API responses
   config.use_combined_first_and_last_name_in_address = true
 
+  # Use legacy Spree::Order state machine
+  config.use_legacy_order_state_machine = false
+
   # Uncomment to stop tracking inventory levels in the application
   # config.track_inventory_levels = false
 

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -282,6 +282,11 @@ module Spree
     #   API responses. (default: +false+)
     preference :use_combined_first_and_last_name_in_address, :boolean, default: false
 
+    # @!attribute [rw] use_legacy_order_state_machine
+    #   @return [Boolean] Uses the legacy order state machine from Spree::Order::Checkout
+    #   (default: +false+)
+    preference :use_legacy_order_state_machine, :boolean, default: true
+
     # Other configurations
 
     # Allows restricting what currencies will be available.

--- a/core/lib/spree/core/state_machines.rb
+++ b/core/lib/spree/core/state_machines.rb
@@ -9,7 +9,8 @@ module Spree
                   :return_item_reception,
                   :payment,
                   :inventory_unit,
-                  :shipment
+                  :shipment,
+                  :order
 
       def return_authorization
         @return_authorization ||= begin
@@ -63,6 +64,24 @@ module Spree
         end
 
         @shipment.constantize
+      end
+
+      def order
+        @order ||= begin
+          if Spree::Config.use_legacy_order_state_machine
+            Spree::Deprecation.warn(
+              "Spree::Order state machine defined in Spree::Order::Checkout is deprecated." \
+              "Future versions of Solidus will use Spree::Core::StateMachines::Order}",
+              caller
+            )
+            'Spree::Order::Checkout'
+          else
+            require 'spree/core/state_machines/order'
+            'Spree::Core::StateMachines::Order'
+          end
+        end
+
+        @order.constantize
       end
 
       def reimbursement

--- a/core/lib/spree/core/state_machines/order.rb
+++ b/core/lib/spree/core/state_machines/order.rb
@@ -1,0 +1,249 @@
+# frozen_string_literal: true
+
+module Spree
+  module Core
+    class StateMachines
+      module Order
+        def self.included(klass)
+          klass.extend ClassMethods
+        end
+
+        module ClassMethods
+          attr_accessor :previous_states
+          attr_writer :next_event_transitions
+          attr_writer :checkout_steps
+          attr_writer :removed_transitions
+
+          def checkout_flow(&block)
+            if block_given?
+              @checkout_flow = block
+              define_state_machine!
+            else
+              @checkout_flow
+            end
+          end
+
+          def define_state_machine!
+            self.checkout_steps = {}
+            self.next_event_transitions = []
+            self.previous_states = [:cart]
+            self.removed_transitions = []
+
+            # Build the checkout flow using the checkout_flow defined either
+            # within the Order class, or a decorator for that class.
+            #
+            # This method may be called multiple times depending on if the
+            # checkout_flow is re-defined in a decorator or not.
+            instance_eval(&checkout_flow)
+
+            klass = self
+
+            # To avoid multiple occurrences of the same transition being defined
+            # On first definition, state_machines will not be defined
+            state_machines.clear if respond_to?(:state_machines)
+            state_machine :state, initial: :cart, use_transactions: false do
+              klass.next_event_transitions.each { |state| transition(state.merge(on: :next)) }
+
+              # Persist the state on the order
+              after_transition do |order, transition|
+                order.state = order.state
+                order.state_changes.create(
+                  previous_state: transition.from,
+                  next_state:     transition.to,
+                  name:           'order',
+                  user_id:        order.user_id
+                )
+                order.save
+              end
+
+              event :cancel do
+                transition to: :canceled, if: :allow_cancel?
+              end
+
+              event :return do
+                transition to: :returned, from: [:returned, :complete, :awaiting_return, :canceled], if: :all_inventory_units_returned?
+              end
+
+              event :resume do
+                transition to: :resumed, from: :canceled, if: :canceled?
+              end
+
+              event :authorize_return do
+                transition to: :awaiting_return
+              end
+
+              event :complete do
+                transition to: :complete, from: :confirm
+              end
+
+              if states[:payment]
+                event :payment_failed do
+                  transition to: :payment, from: :confirm
+                end
+
+                after_transition to: :complete, do: :add_payment_sources_to_wallet
+                before_transition to: :payment, do: :add_default_payment_from_wallet
+                before_transition to: :payment, do: :ensure_billing_address
+
+                before_transition to: :confirm, do: :add_store_credit_payments
+
+                # see also process_payments_before_complete below which needs to
+                # be added in the correct sequence.
+              end
+
+              before_transition from: :cart, do: :ensure_line_items_present
+
+              if states[:address]
+                before_transition to: :address, do: :assign_default_user_addresses
+                before_transition from: :address, do: :persist_user_address!
+              end
+
+              if states[:delivery]
+                before_transition to: :delivery, do: :ensure_shipping_address
+                before_transition to: :delivery, do: :create_proposed_shipments
+                before_transition to: :delivery, do: :ensure_available_shipping_rates
+                before_transition from: :delivery, do: :apply_shipping_promotions
+              end
+
+              before_transition to: :resumed, do: :ensure_line_item_variants_are_not_deleted
+              before_transition to: :resumed, do: :validate_line_item_availability
+
+              # Sequence of before_transition to: :complete
+              # calls matter so that we do not process payments
+              # until validations have passed
+              before_transition to: :complete, do: :validate_line_item_availability
+              before_transition to: :complete, do: :ensure_promotions_eligible
+              before_transition to: :complete, do: :ensure_line_item_variants_are_not_deleted
+              before_transition to: :complete, do: :ensure_inventory_units
+              if states[:payment]
+                before_transition to: :complete, do: :process_payments_before_complete
+              end
+
+              after_transition to: :complete, do: :finalize!
+              after_transition to: :resumed,  do: :after_resume
+              after_transition to: :canceled, do: :after_cancel
+
+              after_transition from: any - :cart, to: any - [:confirm, :complete] do |order|
+                order.recalculate
+              end
+
+              after_transition do |order, transition|
+                order.logger.debug "Order #{order.number} transitioned from #{transition.from} to #{transition.to} via #{transition.event}"
+              end
+
+              after_failure do |order, transition|
+                order.logger.debug "Order #{order.number} halted transition on event #{transition.event} state #{transition.from}: #{order.errors.full_messages.join}"
+              end
+            end
+          end
+
+          def go_to_state(name, options = {})
+            checkout_steps[name] = options
+            previous_states.each do |state|
+              add_transition({ from: state, to: name }.merge(options))
+            end
+            if options[:if]
+              previous_states << name
+            else
+              self.previous_states = [name]
+            end
+          end
+
+          def insert_checkout_step(name, options = {})
+            before = options.delete(:before)
+            after = options.delete(:after) unless before
+            after = checkout_steps.keys.last unless before || after
+
+            cloned_steps = checkout_steps.clone
+            cloned_removed_transitions = removed_transitions.clone
+            checkout_flow do
+              cloned_steps.each_pair do |key, value|
+                go_to_state(name, options) if key == before
+                go_to_state(key, value)
+                go_to_state(name, options) if key == after
+              end
+              cloned_removed_transitions.each do |transition|
+                remove_transition(transition)
+              end
+            end
+          end
+
+          def remove_checkout_step(name)
+            cloned_steps = checkout_steps.clone
+            cloned_removed_transitions = removed_transitions.clone
+            checkout_flow do
+              cloned_steps.each_pair do |key, value|
+                go_to_state(key, value) unless key == name
+              end
+              cloned_removed_transitions.each do |transition|
+                remove_transition(transition)
+              end
+            end
+          end
+
+          def remove_transition(options = {})
+            removed_transitions << options
+            next_event_transitions.delete(find_transition(options))
+          end
+
+          def find_transition(options = {})
+            return nil if options.nil? || !options.include?(:from) || !options.include?(:to)
+
+            next_event_transitions.detect do |transition|
+              transition[options[:from].to_sym] == options[:to].to_sym
+            end
+          end
+
+          def next_event_transitions
+            @next_event_transitions ||= []
+          end
+
+          def checkout_steps
+            @checkout_steps ||= {}
+          end
+
+          def checkout_step_names
+            checkout_steps.keys
+          end
+
+          def add_transition(options)
+            next_event_transitions << { options.delete(:from) => options.delete(:to) }.merge(options)
+          end
+
+          def removed_transitions
+            @removed_transitions ||= []
+          end
+        end
+
+        def checkout_steps
+          steps = self.class.checkout_steps.each_with_object([]) { |(step, options), checkout_steps|
+            next if options.include?(:if) && !options[:if].call(self)
+
+            checkout_steps << step
+          }.map(&:to_s)
+          # Ensure there is always a complete step
+          steps << "complete" unless steps.include?("complete")
+          steps
+        end
+
+        def has_checkout_step?(step)
+          step.present? && checkout_steps.include?(step)
+        end
+
+        def passed_checkout_step?(step)
+          has_checkout_step?(step) && checkout_step_index(step) < checkout_step_index(state)
+        end
+
+        def checkout_step_index(step)
+          checkout_steps.index(step).to_i
+        end
+
+        def can_go_to_state?(state)
+          return false unless has_checkout_step?(self.state) && has_checkout_step?(state)
+
+          checkout_step_index(state) > checkout_step_index(self.state)
+        end
+      end
+    end
+  end
+end

--- a/core/lib/spree/core/state_machines/order.rb
+++ b/core/lib/spree/core/state_machines/order.rb
@@ -57,11 +57,11 @@ module Spree
               end
 
               event :cancel do
-                transition to: :canceled, if: :allow_cancel?
+                transition to: :canceled, if: :allow_cancel?, from: :complete
               end
 
               event :return do
-                transition to: :returned, from: [:returned, :complete, :awaiting_return, :canceled], if: :all_inventory_units_returned?
+                transition to: :returned, from: [:complete, :awaiting_return], if: :all_inventory_units_returned?
               end
 
               event :resume do
@@ -69,7 +69,7 @@ module Spree
               end
 
               event :authorize_return do
-                transition to: :awaiting_return
+                transition to: :awaiting_return, from: :complete
               end
 
               event :complete do

--- a/core/lib/spree/testing_support/dummy_app.rb
+++ b/core/lib/spree/testing_support/dummy_app.rb
@@ -119,6 +119,7 @@ Spree.config do |config|
   config.raise_with_invalid_currency = false
   config.run_order_validations_on_order_updater = true
   config.use_combined_first_and_last_name_in_address = true
+  config.use_legacy_order_state_machine = false
 
   if ENV['ENABLE_ACTIVE_STORAGE']
     config.image_attachment_module = 'Spree::Image::ActiveStorageAttachment'


### PR DESCRIPTION
This PR can be divided into two logical parts that are interdependent and
breaking each one in their way. These parts are described in detail later.


**Make Order state machine configurable**

In 7c4f82c21, all relevant state machines except for the order one have
been extracted into modules. This performs the same exercise for the
order state machine. A lot of this code is deeply interlinked with the
rest of the system, so you'd have to take lots of care when replacing
this; but it should be possible nonetheless.

The new state machine is named `Spree::Core::StateMachines::Order` and
includes the same code of the old one.

The newly named state machine is active on new stores generated from
scratch and in Solidus tests, but old stores will still use the old one,
unless the preference `Spree::Config.use_legacy_order_state_machine` is
explicitly set to `false`.

When using the old named state machine a deprecation warning will be
printed at boot time, as Solidus 3.0 will start using the new order state
machine by default.

**Reduce the number of new order state machine transitions** 

This removes many, many transitions from the Order state machine definitions
included in `Spree::Core::StateMachines::Order`, allowing us to reason more
clearly about what the system is supposed to be doing and when.

This new state machine definition is not active yet on existing stores, but
will become standard from Solidus 3.0.

The  legacy state machine definitions from `Spree::Order::Checkout` are left
untouched, so old stores can continue to use them.

A bunch of transitions have been removed, and now an order can transition to:

  * Canceled only when Complete;
  * Awaiting Return only when Complete;
  * Returned only when Complete or Awaiting Return.

This change was initially proposed with https://github.com/solidusio/solidus/pull/3532 but for convenience it 
has been included directly here as the original PR,  being a breaking change, was 
not mergeable in isolation without the premise of the first part of this PR. Please
consider taking a look at the original PR for the interesting discussion.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
