### PR TITLE
Replace ActiveJob::TestHelper with own module.

### DIFF
--- a/api/spec/spec_helper.rb
+++ b/api/spec/spec_helper.rb
@@ -63,8 +63,6 @@ RSpec.configure do |config|
     Rails.cache.clear
   end
 
-  config.include ActiveSupport::Testing::Assertions
-
   config.use_transactional_fixtures = true
 
   config.example_status_persistence_file_path = "./spec/examples.txt"

--- a/api/spec/spec_helper.rb
+++ b/api/spec/spec_helper.rb
@@ -30,6 +30,7 @@ require 'spree/testing_support/partial_double_verification'
 require 'spree/testing_support/factories'
 require 'spree/testing_support/preferences'
 require 'spree/testing_support/authorization_helpers'
+require 'spree/testing_support/job_helpers'
 
 require 'spree/api/testing_support/caching'
 require 'spree/api/testing_support/helpers'
@@ -54,6 +55,7 @@ RSpec.configure do |config|
   config.include Spree::Api::TestingSupport::Helpers, type: :controller
   config.extend Spree::Api::TestingSupport::Setup, type: :controller
   config.include Spree::TestingSupport::Preferences
+  config.include Spree::TestingSupport::JobHelpers
 
   config.extend WithModel
 
@@ -62,7 +64,6 @@ RSpec.configure do |config|
   end
 
   config.include ActiveSupport::Testing::Assertions
-  config.include ActiveJob::TestHelper
 
   config.use_transactional_fixtures = true
 

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -38,6 +38,7 @@ require 'spree/testing_support/order_walkthrough'
 require 'spree/testing_support/capybara_ext'
 require 'spree/testing_support/precompiled_assets'
 require 'spree/testing_support/translations'
+require 'spree/testing_support/job_helpers'
 
 require 'capybara-screenshot/rspec'
 Capybara.save_path = ENV['CIRCLE_ARTIFACTS'] if ENV['CIRCLE_ARTIFACTS']
@@ -93,13 +94,13 @@ RSpec.configure do |config|
 
   config.include FactoryBot::Syntax::Methods
   config.include ActiveSupport::Testing::Assertions
-  config.include ActiveJob::TestHelper
 
   config.include Spree::TestingSupport::Preferences
   config.include Spree::TestingSupport::UrlHelpers
   config.include Spree::TestingSupport::ControllerRequests, type: :controller
   config.include Spree::TestingSupport::Flash
   config.include Spree::TestingSupport::Translations
+  config.include Spree::TestingSupport::JobHelpers
 
   config.extend WithModel
 

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -93,7 +93,6 @@ RSpec.configure do |config|
   config.include BaseFeatureHelper, type: :system
 
   config.include FactoryBot::Syntax::Methods
-  config.include ActiveSupport::Testing::Assertions
 
   config.include Spree::TestingSupport::Preferences
   config.include Spree::TestingSupport::UrlHelpers

--- a/core/lib/spree/testing_support/job_helpers.rb
+++ b/core/lib/spree/testing_support/job_helpers.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Spree
+  module TestingSupport
+    module JobHelpers
+      def perform_enqueued_jobs
+        adapter = ActiveJob::Base.queue_adapter
+
+        old = adapter.perform_enqueued_jobs
+        old_at = adapter.perform_enqueued_at_jobs
+
+        begin
+          adapter.perform_enqueued_jobs = true
+          adapter.perform_enqueued_at_jobs = true
+
+          yield
+        ensure
+          adapter.perform_enqueued_jobs = old
+          adapter.perform_enqueued_at_jobs = old_at
+        end
+      end
+    end
+  end
+end

--- a/core/spec/rails_helper.rb
+++ b/core/spec/rails_helper.rb
@@ -19,6 +19,7 @@ Dir["./spec/support/**/*.rb"].sort.each { |f| require f }
 require 'spree/testing_support/factories'
 require 'spree/testing_support/preferences'
 require 'spree/testing_support/rake'
+require 'spree/testing_support/job_helpers'
 require 'cancan/matchers'
 
 ActiveJob::Base.queue_adapter = :test
@@ -43,7 +44,8 @@ RSpec.configure do |config|
     Rails.cache.clear
   end
 
+  config.include Spree::TestingSupport::JobHelpers
+
   config.include ActiveSupport::Testing::Assertions
-  config.include ActiveJob::TestHelper
   config.include FactoryBot::Syntax::Methods
 end

--- a/core/spec/rails_helper.rb
+++ b/core/spec/rails_helper.rb
@@ -46,6 +46,5 @@ RSpec.configure do |config|
 
   config.include Spree::TestingSupport::JobHelpers
 
-  config.include ActiveSupport::Testing::Assertions
   config.include FactoryBot::Syntax::Methods
 end


### PR DESCRIPTION
Issue #3526.

**Description**
This is my first contribution. I decided to make an attempt to resolve this issue as it was flagged as "Good First Issue". Looking forward to your feedback!

The test code does no longer rely on `ActiveJob::TestHelper`.
The only method used from this module was `perform_enqueued_jobs`.
I implemented a method providing this functionality in an own testing helper module,
such that existing test cases do not have to be changed and remain readable.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
