### PR TITLE
Simplify Solidus installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,6 @@ created. Add the following to your Gemfile.
 
 ```ruby
 gem 'solidus'
-gem 'solidus_auth_devise'
 ```
 
 Run the `bundle` command to install.
@@ -115,7 +114,6 @@ configuration files and migrations.
 
 ```bash
 bundle exec rails g solidus:install
-bundle exec rails g solidus:auth:install
 bundle exec rake railties:install:migrations
 ```
 

--- a/README.md
+++ b/README.md
@@ -113,13 +113,13 @@ After installing gems, you'll have to run the generator to create necessary
 configuration files and migrations.
 
 ```bash
-bundle exec rails g solidus:install
+bin/rails g solidus:install
 ```
 
 And start the rails server
 
 ```bash
-bundle exec rails s
+bin/rails s
 ```
 
 The [`solidus_frontend`](https://github.com/solidusio/solidus/tree/master/frontend) storefront will be accessible at [http://localhost:3000/](http://localhost:3000/)
@@ -147,20 +147,20 @@ gem 'solidus', github: 'solidusio/solidus'
 **Note: The master branch is not guaranteed to ever be in a fully functioning
 state. It is too risky to use this branch in production.**
 
-By default, the installation generator (`rails g solidus:install`) will run
+By default, the installation generator (`solidus:install`) will run
 migrations as well as adding seed and sample data. This can be disabled using
 
 ```bash
-rails g solidus:install --migrate=false --sample=false --seed=false
+bin/rails g solidus:install --migrate=false --sample=false --seed=false
 ```
 
 You can always perform any of these steps later by using these commands.
 
 ```bash
-bundle exec rake railties:install:migrations
-bundle exec rake db:migrate
-bundle exec rake db:seed
-bundle exec rake spree_sample:load
+bin/rails railties:install:migrations
+bin/rails db:migrate
+bin/rails db:seed
+bin/rails spree_sample:load
 ```
 
 There are also options and rake tasks provided by

--- a/README.md
+++ b/README.md
@@ -109,21 +109,14 @@ gem 'solidus'
 
 Run the `bundle` command to install.
 
-After installing gems, you'll have to run the generators to create necessary
+After installing gems, you'll have to run the generator to create necessary
 configuration files and migrations.
 
 ```bash
 bundle exec rails g solidus:install
-bundle exec rake railties:install:migrations
 ```
 
-Run migrations to create the new models in the database.
-
-```bash
-bundle exec rake db:migrate
-```
-
-Finally start the rails server
+And start the rails server
 
 ```bash
 bundle exec rails s

--- a/bin/rails-application-template
+++ b/bin/rails-application-template
@@ -122,6 +122,7 @@ after_bundle do
     "--auto-accept",
     "--user_class=Spree::User",
     "--enforce_available_locales=true",
+    "--with-authentication=false",
   )
 
   generate('solidus_auth:install')

--- a/bin/sandbox
+++ b/bin/sandbox
@@ -65,6 +65,7 @@ unbundled bin/rails generate solidus:install \
   --auto-accept \
   --user_class=Spree::User \
   --enforce_available_locales=true \
+  --with_authentication=false \
   $@
 
 unbundled bin/rails generate solidus:auth:install

--- a/core/lib/generators/solidus/install/install_generator.rb
+++ b/core/lib/generators/solidus/install/install_generator.rb
@@ -17,6 +17,7 @@ module Solidus
     class_option :admin_email, type: :string
     class_option :admin_password, type: :string
     class_option :lib_name, type: :string, default: 'spree'
+    class_option :with_authentication, type: :boolean, default: true
     class_option :enforce_available_locales, type: :boolean, default: nil
 
     def self.source_paths
@@ -108,6 +109,17 @@ module Solidus
     # Prevent this deprecation message: https://github.com/svenfuchs/i18n/commit/3b6e56e
     I18n.enforce_available_locales = #{options[:enforce_available_locales]}
         RUBY
+      end
+    end
+
+    def install_default_plugins
+      if options[:with_authentication] && (options[:auto_accept] || yes?("
+  Solidus has a default authentication extension that uses Devise.
+  You can find more info at github.com/solidusio/solidus_auth_devise.
+
+  Would you like to install it? (y/n)"))
+
+        gem 'solidus_auth_devise'
       end
     end
 

--- a/core/lib/spree/testing_support/common_rake.rb
+++ b/core/lib/spree/testing_support/common_rake.rb
@@ -14,7 +14,7 @@ namespace :common do
     ENV["RAILS_ENV"] = 'test'
 
     Spree::DummyGenerator.start ["--lib_name=#{ENV['LIB_NAME']}", "--quiet"]
-    Solidus::InstallGenerator.start ["--lib_name=#{ENV['LIB_NAME']}", "--auto-accept", "--migrate=false", "--seed=false", "--sample=false", "--quiet", "--user_class=#{args[:user_class]}"]
+    Solidus::InstallGenerator.start ["--lib_name=#{ENV['LIB_NAME']}", "--auto-accept", "with-authentication=false", "--migrate=false", "--seed=false", "--sample=false", "--quiet", "--user_class=#{args[:user_class]}"]
 
     puts "Setting up dummy database..."
 

--- a/guides/source/developers/getting-started/develop-solidus.html.md
+++ b/guides/source/developers/getting-started/develop-solidus.html.md
@@ -27,14 +27,14 @@ By default, the sandbox includes [`solidus_auth_devise`][solidus-auth-devise],
 and the generator seeds the database and loads sample data.
 
 ```bash
-bundle exec rake sandbox
+bin/sandbox
 ```
 
 You can prepend `DB=mysql` or `DB=postgresql` to the command in order use those
 databases instead of the default SQLite 3 database. For example:
 
 ```bash
-env DB=postgresql bundle exec rake sandbox
+env DB=postgresql bin/sandbox
 ```
 
 After the sandbox has been generated, you can change into its directory and
@@ -42,7 +42,7 @@ start the server:
 
 ```bash
 cd sandbox
-rails server
+bin/rails server
 ```
 
 If you need to create a Rails 5.2 application for your sandbox, for example
@@ -52,7 +52,7 @@ use the `RAILS_VERSION` environment variable.
 ```bash
   export RAILS_VERSION='~> 5.2.0'
   bundle install
-  bundle exec rake sandbox
+  bin/sandbox
 ```
 
 [contributing]: https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md

--- a/guides/source/developers/getting-started/first-time-installation.html.md
+++ b/guides/source/developers/getting-started/first-time-installation.html.md
@@ -206,7 +206,7 @@ provided by Solidus and Railties.
 First, run the `solidus:install` generator:
 
 ```bash
-bundle exec rails generate solidus:install
+bin/rails generate solidus:install
 ```
 
 This may take a few minutes to complete, and it requires some user confirmation.
@@ -232,7 +232,7 @@ successfully start the Rails server and see the sample store in your browser.
 First, start the server:
 
 ```bash
-bundle exec rails server
+bin/rails server
 ```
 
 Once the server has started, you can access your store from the following URLs:

--- a/guides/source/developers/getting-started/first-time-installation.html.md
+++ b/guides/source/developers/getting-started/first-time-installation.html.md
@@ -161,7 +161,6 @@ lines:
 
 ```ruby
 gem 'solidus'
-gem 'solidus_auth_devise'
 ```
 
 By requiring [`solidus`][solidus-repo] in your `Gemfile`, you are actually
@@ -224,23 +223,6 @@ The default values are as follows:
 
 The password must contain a minimum of 6 characters, or the account creation
 will fail without asking the user to try again.
-
-### Prepare Solidus database migrations
-
-Next, you need to run the `solidus:auth:install` generator and install your
-database migrations using the following commands:
-
-```bash
-bundle exec rails generate solidus:auth:install
-bundle exec rake railties:install:migrations
-```
-
-Finally, you need to run the migrations that Railties created. This creates the
-e-commerce–friendly models that Solidus uses for its database:
-
-```bash
-bundle exec rake db:migrate
-```
 
 ### Start the Rails server and use the sample store
 

--- a/guides/source/developers/getting-started/installation-options.html.md
+++ b/guides/source/developers/getting-started/installation-options.html.md
@@ -27,22 +27,22 @@ When you run the `solidus:install` generator without arguments, it runs
 migrations, adds sample data, and seeds your database:
 
 ```bash
-rails generate solidus:install
+bin/rails generate solidus:install
 ```
 
 You can use command arguments to skip any of these steps of the generator:
 
 ```bash
-rails generate solidus:install --migrate=false --sample=false --seed=false
+bin/rails generate solidus:install --migrate=false --sample=false --seed=false
 ```
 
 If you want to perform these tasks later, you can use these commands.
 
 ```bash
-bundle exec rake railties:install:migrations       # installs migrations
-bundle exec rake db:migrate                        # runs migrations
-bundle exec rake db:seed                           # seeds your database
-bundle exec rake spree_sample:load                 # loads sample data
+bin/rails railties:install:migrations       # installs migrations
+bin/rails db:migrate                        # runs migrations
+bin/rails db:seed                           # seeds your database
+bin/rails spree_sample:load                 # loads sample data
 ```
 
 ## Authentication via Devise
@@ -58,7 +58,7 @@ If you don't want to install the default authentication extension, you can answe
 or run the Solidus installer with the following command:
 
 ```bash
-rails generate solidus:install --with-authentication=false
+bin/rails generate solidus:install --with-authentication=false
 ```
 
 If you prefer to install [`solidus-auth-devise`][solidus-auth-devise] gem manually,
@@ -66,10 +66,10 @@ after adding it in your Gemfile, you can run the following commands to install a
 run its migrations, then seed the database:
 
 ```bash
-bundle install                                     # install gem and dependencies
-bundle exec rake solidus_auth:install:migrations   # installs solidus_auth_devise migrations
-bundle exec rake db:migrate                        # runs solidus_auth_devise migrations
-bundle exec rake db:seed                           # seeds your database
+bundle install                              # install gem and dependencies
+bin/rails solidus_auth:install:migrations   # installs solidus_auth_devise migrations
+bin/rails db:migrate                        # runs solidus_auth_devise migrations
+bin/rails db:seed                           # seeds your database
 ```
 
 [solidus-auth-devise]: https://github.com/solidusio/solidus_auth_devise

--- a/guides/source/developers/getting-started/installation-options.html.md
+++ b/guides/source/developers/getting-started/installation-options.html.md
@@ -45,14 +45,35 @@ bundle exec rake db:seed                           # seeds your database
 bundle exec rake spree_sample:load                 # loads sample data
 ```
 
-If you use `solidus_auth_devise` for user authentication, you can also install
-and run its migrations, then seed the database separately:
+## Authentication via Devise
+
+During the installation, you have been prompted to add the default authentication extension
+to your project. It is called [`solidus-auth-devise`][solidus-auth-devise] and it uses the
+well-known authentication library for Rails called [Devise][devise].
+
+If you answered "yes", there's nothing else left to do. The extension is already
+added and installed in your application.
+
+If you don't want to install the default authentication extension, you can answer "no",
+or run the Solidus installer with the following command:
 
 ```bash
+rails generate solidus:install --with-authentication=false
+```
+
+If you prefer to install [`solidus-auth-devise`][solidus-auth-devise] gem manually,
+after adding it in your Gemfile, you can run the following commands to install and
+run its migrations, then seed the database:
+
+```bash
+bundle install                                     # install gem and dependencies
 bundle exec rake solidus_auth:install:migrations   # installs solidus_auth_devise migrations
 bundle exec rake db:migrate                        # runs solidus_auth_devise migrations
 bundle exec rake db:seed                           # seeds your database
 ```
+
+[solidus-auth-devise]: https://github.com/solidusio/solidus_auth_devise
+[devise]: https://github.com/heartcombo/devise
 
 ## Development environment performance gains
 


### PR DESCRIPTION
**Description**
This PR refreshes the installation process and simplify it.

- make `solidus_auth_devise` transparent in terms of manual tasks that a user has to do when installing Solidus. It's still optional since it will be asked with a textual prompt during the installation. 
- remove some useless commands in the installation steps
- start using bin/rails and bin/sandbox when possible, within README and Guides.


**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- ~[ ] I have added tests to cover this change (if needed)~
- ~[ ] I have attached screenshots to this PR for visual changes (if needed)~
