### PR TITLE
Improve gemspecs of solidus and subcomponents

### DIFF
--- a/api/solidus_api.gemspec
+++ b/api/solidus_api.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |gem|
   gem.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(spec|script)/})
   end
-  gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.name          = "solidus_api"
   gem.require_paths = ["lib"]
   gem.version = Spree.solidus_version

--- a/api/solidus_api.gemspec
+++ b/api/solidus_api.gemspec
@@ -11,9 +11,10 @@ Gem::Specification.new do |gem|
   gem.summary       = 'REST API for the Solidus e-commerce framework.'
   gem.description   = gem.summary
 
-  gem.files         = `git ls-files`.split($\)
+  gem.files = `git ls-files -z`.split("\x0").reject do |f|
+    f.match(%r{^(spec|script)/})
+  end
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
-  gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.name          = "solidus_api"
   gem.require_paths = ["lib"]
   gem.version = Spree.solidus_version

--- a/api/solidus_api.gemspec
+++ b/api/solidus_api.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
 
   s.author      = 'Solidus Team'
   s.email       = 'contact@solidus.io'
-  s.homepage    = 'http://solidus.io/'
+  s.homepage    = 'http://solidus.io'
   s.license     = 'BSD-3-Clause'
 
   s.files = `git ls-files -z`.split("\x0").reject do |f|

--- a/api/solidus_api.gemspec
+++ b/api/solidus_api.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
   s.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(spec|script)/})
   end
-  s.require_paths = ["lib"]
 
   s.required_ruby_version = '>= 2.4.0'
   s.required_rubygems_version = '>= 1.8.23'

--- a/api/solidus_api.gemspec
+++ b/api/solidus_api.gemspec
@@ -2,27 +2,28 @@
 
 require_relative '../core/lib/spree/core/version.rb'
 
-Gem::Specification.new do |gem|
-  gem.author        = 'Solidus Team'
-  gem.email         = 'contact@solidus.io'
-  gem.homepage      = 'http://solidus.io/'
-  gem.license       = 'BSD-3-Clause'
+Gem::Specification.new do |s|
+  s.platform    = Gem::Platform::RUBY
+  s.name        = "solidus_api"
+  s.version     = Spree.solidus_version
+  s.summary     = 'REST API for the Solidus e-commerce framework.'
+  s.description = s.summary
 
-  gem.summary       = 'REST API for the Solidus e-commerce framework.'
-  gem.description   = gem.summary
+  s.author      = 'Solidus Team'
+  s.email       = 'contact@solidus.io'
+  s.homepage    = 'http://solidus.io/'
+  s.license     = 'BSD-3-Clause'
 
-  gem.files = `git ls-files -z`.split("\x0").reject do |f|
+  s.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(spec|script)/})
   end
-  gem.name          = "solidus_api"
-  gem.require_paths = ["lib"]
-  gem.version = Spree.solidus_version
+  s.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 2.4.0'
-  gem.required_rubygems_version = '>= 1.8.23'
+  s.required_ruby_version = '>= 2.4.0'
+  s.required_rubygems_version = '>= 1.8.23'
 
-  gem.add_dependency 'jbuilder', '~> 2.8'
-  gem.add_dependency 'kaminari-activerecord', '~> 1.1'
-  gem.add_dependency 'responders'
-  gem.add_dependency 'solidus_core', gem.version
+  s.add_dependency 'jbuilder', '~> 2.8'
+  s.add_dependency 'kaminari-activerecord', '~> 1.1'
+  s.add_dependency 'responders'
+  s.add_dependency 'solidus_core', s.version
 end

--- a/backend/solidus_backend.gemspec
+++ b/backend/solidus_backend.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
   s.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(spec|script)/})
   end
-  s.requirements << 'none'
 
   s.required_ruby_version = '>= 2.4.0'
   s.required_rubygems_version = '>= 1.8.23'

--- a/backend/solidus_backend.gemspec
+++ b/backend/solidus_backend.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
   s.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(spec|script)/})
   end
-  s.require_path = 'lib'
   s.requirements << 'none'
 
   s.required_ruby_version = '>= 2.4.0'

--- a/backend/solidus_backend.gemspec
+++ b/backend/solidus_backend.gemspec
@@ -14,7 +14,9 @@ Gem::Specification.new do |s|
   s.homepage    = 'http://solidus.io'
   s.license     = 'BSD-3-Clause'
 
-  s.files        = `git ls-files`.split("\n")
+  s.files = `git ls-files -z`.split("\x0").reject do |f|
+    f.match(%r{^(spec|script)/})
+  end
   s.require_path = 'lib'
   s.requirements << 'none'
 

--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -14,7 +14,9 @@ Gem::Specification.new do |s|
   s.homepage    = 'http://solidus.io'
   s.license     = 'BSD-3-Clause'
 
-  s.files        = `git ls-files`.split("\n")
+  s.files = `git ls-files -z`.split("\x0").reject do |f|
+    f.match(%r{^(spec|script)/})
+  end
   s.require_path = 'lib'
 
   s.required_ruby_version = '>= 2.4.0'

--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
   s.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(spec|script)/})
   end
-  s.require_path = 'lib'
 
   s.required_ruby_version = '>= 2.4.0'
   s.required_rubygems_version = '>= 1.8.23'

--- a/frontend/solidus_frontend.gemspec
+++ b/frontend/solidus_frontend.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
   s.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(spec|script)/})
   end
-  s.requirements << 'none'
 
   s.required_ruby_version = '>= 2.4.0'
   s.required_rubygems_version = '>= 1.8.23'

--- a/frontend/solidus_frontend.gemspec
+++ b/frontend/solidus_frontend.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
   s.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(spec|script)/})
   end
-  s.require_path = 'lib'
   s.requirements << 'none'
 
   s.required_ruby_version = '>= 2.4.0'

--- a/frontend/solidus_frontend.gemspec
+++ b/frontend/solidus_frontend.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
 
   s.author      = 'Solidus Team'
   s.email       = 'contact@solidus.io'
-  s.homepage    = 'http://solidus.io/'
+  s.homepage    = 'http://solidus.io'
   s.license     = 'BSD-3-Clause'
 
   s.files = `git ls-files -z`.split("\x0").reject do |f|

--- a/frontend/solidus_frontend.gemspec
+++ b/frontend/solidus_frontend.gemspec
@@ -14,7 +14,9 @@ Gem::Specification.new do |s|
   s.homepage    = 'http://solidus.io/'
   s.license     = 'BSD-3-Clause'
 
-  s.files        = `git ls-files`.split("\n")
+  s.files = `git ls-files -z`.split("\x0").reject do |f|
+    f.match(%r{^(spec|script)/})
+  end
   s.require_path = 'lib'
   s.requirements << 'none'
 

--- a/sample/solidus_sample.gemspec
+++ b/sample/solidus_sample.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
   s.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(spec|script)/})
   end
-  s.requirements << 'none'
 
   s.required_ruby_version = '>= 2.4.0'
   s.required_rubygems_version = '>= 1.8.23'

--- a/sample/solidus_sample.gemspec
+++ b/sample/solidus_sample.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
   s.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(spec|script)/})
   end
-  s.require_path = 'lib'
   s.requirements << 'none'
 
   s.required_ruby_version = '>= 2.4.0'

--- a/sample/solidus_sample.gemspec
+++ b/sample/solidus_sample.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
 
   s.author      = 'Solidus Team'
   s.email       = 'contact@solidus.io'
-  s.homepage    = 'http://solidus.io/'
+  s.homepage    = 'http://solidus.io'
   s.license     = 'BSD-3-Clause'
 
   s.files = `git ls-files -z`.split("\x0").reject do |f|

--- a/sample/solidus_sample.gemspec
+++ b/sample/solidus_sample.gemspec
@@ -14,7 +14,9 @@ Gem::Specification.new do |s|
   s.homepage    = 'http://solidus.io/'
   s.license     = 'BSD-3-Clause'
 
-  s.files        = `git ls-files`.split("\n")
+  s.files = `git ls-files -z`.split("\x0").reject do |f|
+    f.match(%r{^(spec|script)/})
+  end
   s.require_path = 'lib'
   s.requirements << 'none'
 

--- a/solidus.gemspec
+++ b/solidus.gemspec
@@ -10,7 +10,6 @@ Gem::Specification.new do |s|
   s.description = 'Solidus is an open source e-commerce framework for Ruby on Rails.'
 
   s.files        = Dir['README.md', 'lib/**/*']
-  s.require_path = 'lib'
   s.requirements << 'none'
 
   s.required_ruby_version = '>= 2.4.0'

--- a/solidus.gemspec
+++ b/solidus.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |s|
   s.license     = 'BSD-3-Clause'
 
   s.files = Dir['README.md', 'lib/**/*']
-  s.requirements << 'none'
 
   s.required_ruby_version = '>= 2.4.0'
   s.required_rubygems_version = '>= 1.8.23'

--- a/solidus.gemspec
+++ b/solidus.gemspec
@@ -9,16 +9,16 @@ Gem::Specification.new do |s|
   s.summary     = 'Full-stack e-commerce framework for Ruby on Rails.'
   s.description = 'Solidus is an open source e-commerce framework for Ruby on Rails.'
 
-  s.files        = Dir['README.md', 'lib/**/*']
+  s.author      = 'Solidus Team'
+  s.email       = 'contact@solidus.io'
+  s.homepage    = 'http://solidus.io'
+  s.license     = 'BSD-3-Clause'
+
+  s.files = Dir['README.md', 'lib/**/*']
   s.requirements << 'none'
 
   s.required_ruby_version = '>= 2.4.0'
   s.required_rubygems_version = '>= 1.8.23'
-
-  s.author       = 'Solidus Team'
-  s.email        = 'contact@solidus.io'
-  s.homepage     = 'http://solidus.io'
-  s.license      = 'BSD-3-Clause'
 
   s.add_dependency 'solidus_api', s.version
   s.add_dependency 'solidus_backend', s.version


### PR DESCRIPTION
**Description**

This PR refactors gemspecs of Solidus and all its subcomponents mainly to make them uniform. 
Having them in the same format makes it easier to find information for users that are navigating and comparing them since they already know where to find information.

It also removes specs for the gem builds, since they are not used and increase the package size without any real benefits.

For what is worth, here's the exact saving:

```
# With tests

 12K    solidus
508K    core
108K    api
880K    backend
188K    frontend
9.0M    sample

Total
10.696K - (1.696K without sample)

# Without tests

 12K    solidus
300K    core
 48K    api
816K    backend
144K    frontend
9.0M    sample

Total
10.320K - (1.320K without sample)
```

With a size decrease of 22% if we don't consider solidus_sample 


**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- ~[ ] I have updated Guides and README accordingly to this change (if needed)~
- ~[ ] I have added tests to cover this change (if needed)~
- ~[ ] I have attached screenshots to this PR for visual changes (if needed)~
