### PR TITLE
replace link_to_add_fields usage and deprecate helper function

### DIFF
--- a/backend/app/helpers/spree/admin/base_helper.rb
+++ b/backend/app/helpers/spree/admin/base_helper.rb
@@ -120,6 +120,8 @@ module Spree
         css_classes = options[:class] ? options[:class] + " spree_add_fields" : "spree_add_fields"
         link_to_with_icon('plus', name, 'javascript:', data: { target: target }, class: css_classes)
       end
+      deprecate link_to_add_fields: "Please use button_tag instead, Example: \n" \
+        "button_tag \"Name\", type: \"button\", data: { target: \"tbody#div\" }", deprecator: Spree::Deprecation
 
       # renders hidden field and link to remove record using nested_attributes
       def link_to_remove_fields(name, form, options = {})

--- a/backend/app/views/spree/admin/option_types/edit.html.erb
+++ b/backend/app/views/spree/admin/option_types/edit.html.erb
@@ -6,7 +6,9 @@
 <% content_for :page_actions do %>
   <li>
     <span id="new_add_option_value" data-hook>
-      <%= link_to_add_fields t('spree.add_option_value'), "tbody#option_values", class: 'btn btn-primary' %>
+      <%= button_tag t('spree.add_option_value'), type: 'button',
+            data: { target: 'tbody#option_values' },
+            class: 'btn btn-primary spree_add_fields' %>
     </span>
   </li>
 <% end %>

--- a/backend/app/views/spree/admin/product_properties/index.html.erb
+++ b/backend/app/views/spree/admin/product_properties/index.html.erb
@@ -7,7 +7,9 @@
   <% if can?(:create, Spree::ProductProperty) %>
     <ul class="tollbar inline-menu">
       <li>
-        <%= link_to_add_fields t('spree.add_product_properties'), 'tbody#product_properties', class: 'plus btn btn-primary' %>
+        <%= button_tag t('spree.add_product_properties'), type: 'button',
+              data: { target: 'tbody#product_properties' },
+              class: 'btn btn-primary spree_add_fields' %>
       </li>
     </ul>
   <% end %>
@@ -55,7 +57,9 @@
       <div class="form-buttons filter-actions actions">
         <%= button_tag t('spree.filter_results'), class: 'btn btn-primary' %>
         <% if @option_value_ids.present? %>
-          <%= link_to_add_fields t('spree.add_variant_properties'), 'tbody#variant_property_values', class: 'plus button' %>
+          <%= button_tag t('spree.add_variant_properties'), type: 'button',
+                data: { target: 'tbody#variant_property_values' },
+                class: 'button spree_add_fields' %>
         <% end %>
       </div>
     </fieldset>

--- a/backend/spec/features/admin/products/option_types_spec.rb
+++ b/backend/spec/features/admin/products/option_types_spec.rb
@@ -94,7 +94,7 @@ describe "Option Types", type: :feature do
     expect(page).to have_css("tbody#option_values tr", count: 1)
 
     # Add a new option type
-    click_link "Add Option Value"
+    click_button "Add Option Value"
     expect(page).to have_css("tbody#option_values tr", count: 2)
 
     # Remove default option type


### PR DESCRIPTION
**Description**

**Problem**:
The link_to_add_fields function will (when used for buttons) create the following markup
`<a ...>
  <span class="text">Add Option Value</span>
</a>`
The span with class text will be removed when the menu is minimized.
So we only see the plus icon with no text when the menu is minimized.

This happens in the option type edit screen and in the product properties index screen.
_/admin/option_types/1/edit_
_/admin/products/ruby-hoodie/product_properties_ (2 occurrences)

See Screenshot:
![Screenshot from 2020-03-09 16-59-14](https://user-images.githubusercontent.com/728284/76238392-16482300-6230-11ea-814d-d381f71305b3.png)


**Solution**:
This PR removes the symbols from the buttons just by using **link_to** instead of **link_to_add_fields**.
The Buttons will have no more symbol but the text stays when the menu is minimized.
These three buttons where the only buttons with symbols in the Backend.

The helper function is also deprecated

See also #3544
