### PR TITLE
Build default address with an existing method in checkout address

### DIFF
--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -203,9 +203,8 @@ module Spree
       @order.assign_default_user_addresses
       # If the user has a default address, the previous method call takes care
       # of setting that; but if he doesn't, we need to build an empty one here
-      default = { country_id: Spree::Country.default.id }
-      @order.build_bill_address(default) unless @order.bill_address
-      @order.build_ship_address(default) if @order.checkout_steps.include?('delivery') && !@order.ship_address
+      @order.bill_address ||= Spree::Address.build_default
+      @order.ship_address ||= Spree::Address.build_default if @order.checkout_steps.include?('delivery')
     end
 
     def before_delivery


### PR DESCRIPTION
**Description**

[`Spree::Address#build_default`](https://github.com/solidusio/solidus/blob/6820f191325e62d7f677a24a9a80df8c02a092ad/core/app/models/spree/address.rb#L37) exists to do exactly that and we are not using it consistently in the codebase.

Closes https://github.com/solidusio/solidus/issues/3441

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- ~[ ] I have updated Guides and README accordingly to this change (if needed)~
- ~[ ] I have added tests to cover this change (if needed)~
- ~[ ] I have attached screenshots to this PR for visual changes (if needed)~
