### PR TITLE
[backend] Disable customer returns buttons after first click

### DIFF
--- a/backend/app/views/spree/admin/customer_returns/_return_item_decision.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/_return_item_decision.html.erb
@@ -50,7 +50,7 @@
           <td>
             <%= form_for [:admin, return_item] do |f| %>
               <%= f.hidden_field 'reception_status_event', value: 'receive' %>
-              <%= f.button t('spree.actions.receive'), class: 'with-tip', "data-action" => 'save' %>
+              <%= f.submit t('spree.actions.receive'), class: 'btn btn-primary' %>
             <% end %>
           </td>
         <% end %>

--- a/backend/app/views/spree/admin/customer_returns/edit.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/edit.html.erb
@@ -39,9 +39,7 @@
     <% if @customer_return.completely_decided? %>
       <%= form_for [:admin, @order, Spree::Reimbursement.new] do |f| %>
         <%= hidden_field_tag :build_from_customer_return_id, @customer_return.id %>
-        <%= f.button class: 'button' do %>
-          <%= t('spree.create_reimbursement') %>
-        <% end %>
+        <%= f.submit t('spree.create_reimbursement'), class: 'btn btn-primary' %>
       <% end %>
     <% else %>
       <div class="no-objects-found">

--- a/backend/app/views/spree/admin/reimbursements/edit.html.erb
+++ b/backend/app/views/spree/admin/reimbursements/edit.html.erb
@@ -96,7 +96,7 @@
   <% end %>
   <div class="form-buttons filter-actions actions" data-hook="reimburse-buttons">
     <% if !@reimbursement.reimbursed? %>
-      <%= button_to [:perform, :admin, @order, @reimbursement], { class: 'button btn btn-primary', method: 'post' } do %>
+      <%= button_to [:perform, :admin, @order, @reimbursement], { class: 'button btn btn-primary', method: 'post', data: { disable_with: t('spree.reimburse') }} do %>
         <%= t('spree.reimburse') %>
       <% end %>
       <%= link_to t('spree.actions.cancel'), url_for([:edit, :admin, @order, @reimbursement.customer_return]), class: 'btn btn-default' %>

--- a/backend/app/views/spree/admin/reimbursements/edit.html.erb
+++ b/backend/app/views/spree/admin/reimbursements/edit.html.erb
@@ -62,9 +62,7 @@
   </fieldset>
 
   <div class="form-buttons filter-actions actions" data-hook="buttons">
-    <%= f.button do %>
-      <%= t('spree.update') %>
-    <% end %>
+    <%= f.submit t('spree.update'), class: "btn btn-primary" %>
   </div>
   <br>
 <% end %>

--- a/backend/spec/features/admin/orders/customer_returns_spec.rb
+++ b/backend/spec/features/admin/orders/customer_returns_spec.rb
@@ -41,8 +41,20 @@ describe 'Customer returns', type: :feature do
       expect(page).to have_button("Create", disabled: true)
     end
 
-    context 'when creating a return with state "In Transit" and then marking it as "Received"', :flaky do
-      it 'marks the order as returned', :js do
+    context 'when creating a return with state "In Transit" and then marking it as "Received"' do
+      it 'disables the "Receive" button at submit', :js do
+        create_customer_return('in_transit')
+
+        page.execute_script "$('form').submit(function(e) { e.preventDefault()})"
+
+        within('[data-hook="rejected_return_items"] tbody tr:nth-child(1)') do
+          click_button('Receive')
+
+          expect(page).to have_button("Receive", disabled: true)
+        end
+      end
+
+      it 'marks the order as returned', :js, :flaky do
         create_customer_return('in_transit')
         expect(page).to have_content 'Customer Return has been successfully created'
         expect(order_state_label).to eq('Complete')

--- a/backend/spec/features/admin/orders/return_payment_state_spec.rb
+++ b/backend/spec/features/admin/orders/return_payment_state_spec.rb
@@ -14,16 +14,7 @@ describe "Return payment state spec" do
   let!(:order) { create(:shipped_order) }
   let(:user) { create(:admin_user) }
 
-  # Regression test for https://github.com/spree/spree/issues/6229
-  it "refunds and has outstanding_balance of zero", js: true do
-    expect(order).to have_attributes(
-      total: 110,
-      refund_total: 0,
-      payment_total: 110,
-      outstanding_balance: 0,
-      payment_state: 'paid'
-    )
-
+  def create_customer_return
     # From an order with a shipped shipment
     visit "/admin/orders/#{order.number}/edit"
 
@@ -43,6 +34,19 @@ describe "Return payment state spec" do
     select 'Received', from: 'customer_return[return_items_attributes][0][reception_status_event]', visible: false
     select Spree::StockLocation.first.name, from: 'customer_return[stock_location_id]', visible: false
     click_on 'Create'
+  end
+
+  # Regression test for https://github.com/spree/spree/issues/6229
+  it "refunds and has outstanding_balance of zero", js: true do
+    expect(order).to have_attributes(
+      total: 110,
+      refund_total: 0,
+      payment_total: 110,
+      outstanding_balance: 0,
+      payment_state: 'paid'
+    )
+
+    create_customer_return
 
     # Create reimbursement
     click_on 'Create reimbursement'
@@ -61,5 +65,16 @@ describe "Return payment state spec" do
       outstanding_balance: 0,
       payment_state: 'paid'
     )
+  end
+
+  it 'disables the "Create Reimbursement" button at submit', :js do
+    create_customer_return
+
+    page.execute_script "$('form').submit(function(e) { e.preventDefault()})"
+
+    # Create reimbursement
+    click_on 'Create reimbursement'
+
+    expect(page).to have_button("Create reimbursement", disabled: true)
   end
 end


### PR DESCRIPTION
**Description**
This PR continue the work started with https://github.com/solidusio/solidus/pull/3342:


> It may happen that admin users click multiple times (purposely or not) on submit buttons in the backend area.
> 
> This can be a problem as at times it may silently generate unwanted duplicate records, or show an error page due to duplicate records. This is much more likely to happen on real shops when unanticipated server load makes the application unresponsive (at first click nothing seems to happen, so then why not click again?) and where some controller create actions may be patched and be slower.
> 
> By changing button_tag to f.submit or submit_tag the button gets disabled after the first click, thanks to the automatically added attribute data-disable-with="Create"

by disabling the missing submit buttons in the customer returns backend page.

**Checklist:**
- [ ] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [ ] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change (if needed)
