### PR TITLE
Enable api checkout spec that was skipped

### DIFF
--- a/api/spec/requests/spree/api/checkouts_controller_spec.rb
+++ b/api/spec/requests/spree/api/checkouts_controller_spec.rb
@@ -59,12 +59,8 @@ module Spree
       end
 
       it "will return an error if the order cannot transition" do
-        skip "not sure if this test is valid"
-        order.bill_address = nil
-        order.save
-        order.update_column(:state, "address")
+        order.update!(state: 'address', ship_address: nil)
         put spree.api_checkout_path(order.to_param), params: { order_token: order.guest_token }
-        # Order has not transitioned
         expect(response.status).to eq(422)
       end
 


### PR DESCRIPTION
__NOTE__: https://github.com/solidusio/solidus/pull/3520 introduces a deprecation warning for invalid state transition. If the current pr will be merged before #3520 then #3520 needs to be rebased against master to add the deprecation expectation to the *no more* skipped test described here. Not doing so will break the CI.

**Description**
The skipped spec makes sense when the `ship_address` is set to nil. This is because the state machine is checking on the ship address and not the bill address.
https://github.com/solidusio/solidus/blob/v2.10.0/core/app/models/spree/order/checkout.rb#L100

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
