### PR TITLE
Add order_recalculated event

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -440,7 +440,7 @@ module Spree
 
       updater.update_shipment_state
       save!
-      updater.run_hooks
+      updater.run_hooks if update_hooks.any?
 
       touch :completed_at
 

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -183,6 +183,9 @@ module Spree
     # Use this method in other gems that wish to register their own custom logic
     # that should be called after Order#update
     def self.register_update_hook(hook)
+      Spree::Deprecation.warn \
+        "Spree::Order::update_hooks are deprecated. Please remove them " \
+        "and subscribe to `order_recalculated` and/or `order_finalized` event instead", caller(1)
       update_hooks.add(hook)
     end
 

--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -17,7 +17,7 @@ module Spree
     # object with callbacks (otherwise you will end up in an infinite recursion as the
     # associations try to save and then in turn try to call +update!+ again.)
     def update
-      @order.transaction do
+      order.transaction do
         update_item_count
         update_shipment_amounts
         update_totals
@@ -27,6 +27,7 @@ module Spree
           update_shipment_state
         end
         run_hooks
+        Spree::Event.fire 'order_recalculated', order: order
         persist_totals
       end
     end

--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -26,7 +26,7 @@ module Spree
           update_shipments
           update_shipment_state
         end
-        run_hooks
+        run_hooks if update_hooks.any?
         Spree::Event.fire 'order_recalculated', order: order
         persist_totals
       end

--- a/core/app/models/spree/order_updater.rb
+++ b/core/app/models/spree/order_updater.rb
@@ -33,6 +33,10 @@ module Spree
     end
 
     def run_hooks
+      Spree::Deprecation.warn \
+        "This method is deprecated. Please run your hooks by subscribing " \
+        "to `order_recalculated` and/or `order_finalized` events instead, depending " \
+        " on when OrderUpdater#run_hooks was called.", caller(1)
       update_hooks.each { |hook| order.send hook }
     end
 

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -369,7 +369,11 @@ RSpec.describe Spree::Order, type: :model do
   context ".register_update_hook", partial_double_verification: false do
     let(:order) { create(:order) }
 
-    before { Spree::Order.register_update_hook :foo }
+    before do
+      allow(Spree::Deprecation).to receive(:warn)
+      Spree::Order.register_update_hook :foo
+    end
+
     after { Spree::Order.update_hooks.clear }
 
     it "calls hooks during #recalculate" do

--- a/core/spec/models/spree/order_updater_spec.rb
+++ b/core/spec/models/spree/order_updater_spec.rb
@@ -552,5 +552,23 @@ module Spree
         }.to change { line_item.reload.adjustment_total }.from(100).to(0)
       end
     end
+
+    context "with 'order_recalculated' event subscription" do
+      let(:item) { spy('object') }
+
+      let!(:event) do
+        Spree::Event.subscribe :order_recalculated do
+          item.do_something
+        end
+      end
+
+      after { Spree::Event.unsubscribe event }
+
+      it "fires the 'order_recalculated' event" do
+        order.recalculate
+
+        expect(item).to have_received(:do_something)
+      end
+    end
   end
 end

--- a/guides/source/developers/events/overview.html.md
+++ b/guides/source/developers/events/overview.html.md
@@ -13,6 +13,7 @@ when an order is refunded successfully.
 
 Currently, the events fired by default in Solidus are:
 * `order_finalized`
+* `order_recalculated`
 * `reimbursement_reimbursed`
 * `reimbursement_errored`
 


### PR DESCRIPTION
This PR adds the new event `order_recalculated`, also deprecating the use of order update hooks and the public method `OrderUpdater#run_hooks`. A conditional check has been added before running `#run_hooks` in order to avoid tons of not-needed deprecation messages.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
