### PR TITLE
Replace Paranoia methods with Discard equivalents

### DIFF
--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -133,7 +133,7 @@ module Spree
 
       def product_scope
         if can?(:admin, Spree::Product)
-          scope = Spree::Product.with_deleted.accessible_by(current_ability, :read).includes(*product_includes)
+          scope = Spree::Product.with_discarded.accessible_by(current_ability, :read).includes(*product_includes)
 
           unless params[:show_deleted]
             scope = scope.not_deleted

--- a/api/app/controllers/spree/api/variants_controller.rb
+++ b/api/app/controllers/spree/api/variants_controller.rb
@@ -64,7 +64,7 @@ module Spree
         end
 
         if current_ability.can?(:manage, Variant) && params[:show_deleted]
-          variants = variants.with_deleted
+          variants = variants.with_discarded
         end
 
         in_stock_only = ActiveRecord::Type::Boolean.new.cast(params[:in_stock_only])

--- a/backend/app/controllers/spree/admin/products_controller.rb
+++ b/backend/app/controllers/spree/admin/products_controller.rb
@@ -78,7 +78,7 @@ module Spree
       end
 
       def find_resource
-        Spree::Product.with_deleted.friendly.find(params[:id])
+        Spree::Product.with_discarded.friendly.find(params[:id])
       end
 
       def location_after_save

--- a/backend/app/controllers/spree/admin/variants_controller.rb
+++ b/backend/app/controllers/spree/admin/variants_controller.rb
@@ -21,7 +21,7 @@ module Spree
 
       def collection
         if params[:deleted] == "on"
-          base_variant_scope ||= super.with_deleted
+          base_variant_scope ||= super.with_discarded
         else
           base_variant_scope ||= super
         end
@@ -43,7 +43,7 @@ module Spree
       end
 
       def parent
-        @parent ||= Spree::Product.with_deleted.find_by(slug: params[:product_id])
+        @parent ||= Spree::Product.with_discarded.find_by(slug: params[:product_id])
         @product = @parent
       end
     end

--- a/backend/app/views/spree/admin/prices/_master_variant_table.html.erb
+++ b/backend/app/views/spree/admin/prices/_master_variant_table.html.erb
@@ -20,17 +20,17 @@
       </tr>
     </thead>
     <% master_prices.each do |price| %>
-      <tr id="<%= spree_dom_id price %>" data-hook="prices_row" class="<%= "deleted" if price.deleted? %>">
+      <tr id="<%= spree_dom_id price %>" data-hook="prices_row" class="<%= "deleted" if price.discarded? %>">
         <td><%= price.display_country %></td>
         <td><%= price.currency %></td>
         <td><%= price.money.to_html %></td>
         <td class="actions">
           <% if can?(:update, price) %>
-            <%= link_to_edit(price, no_text: true) unless price.deleted? %>
+            <%= link_to_edit(price, no_text: true) unless price.discarded? %>
           <% end %>
           <% if can?(:destroy, price) %>
             &nbsp;
-            <%= link_to_delete(price, no_text: true) unless price.deleted? %>
+            <%= link_to_delete(price, no_text: true) unless price.discarded? %>
           <% end %>
         </td>
       </tr>

--- a/backend/app/views/spree/admin/prices/_table.html.erb
+++ b/backend/app/views/spree/admin/prices/_table.html.erb
@@ -14,18 +14,18 @@
     </thead>
     <tbody>
       <% variant_prices.each do |price| %>
-        <tr id="<%= spree_dom_id price %>" data-hook="prices_row" class="<%= "deleted" if price.deleted? %>">
+        <tr id="<%= spree_dom_id price %>" data-hook="prices_row" class="<%= "deleted" if price.discarded? %>">
           <td><%= price.variant.descriptive_name %></td>
           <td><%= price.display_country %></td>
           <td><%= price.currency %></td>
           <td><%= price.money.to_html %></td>
           <td class="actions">
             <% if can?(:update, price) %>
-              <%= link_to_edit(price, no_text: true) unless price.deleted? %>
+              <%= link_to_edit(price, no_text: true) unless price.discarded? %>
             <% end %>
             <% if can?(:destroy, price) %>
               &nbsp;
-              <%= link_to_delete(price, no_text: true) unless price.deleted? %>
+              <%= link_to_delete(price, no_text: true) unless price.discarded? %>
             <% end %>
           </td>
         </tr>

--- a/backend/app/views/spree/admin/products/index.html.erb
+++ b/backend/app/views/spree/admin/products/index.html.erb
@@ -34,7 +34,7 @@
           <div class="col-2">
             <div class="field checkbox">
               <label>
-                <%= f.check_box :with_deleted, { checked: params[:q][:with_deleted] == 'true' }, 'true', 'false' %>
+                <%= f.check_box :with_discarded, { checked: params[:q][:with_discarded] == 'true' }, 'true', 'false' %>
                 <%= t('spree.show_deleted') %>
               </label>
             </div>

--- a/backend/app/views/spree/admin/variants/_table_filter.html.erb
+++ b/backend/app/views/spree/admin/variants/_table_filter.html.erb
@@ -11,7 +11,7 @@
       </div>
     </div>
 
-    <% if product.variants.only_deleted.any? %>
+    <% if product.variants.discarded.any? %>
       <div class="col-2">
         <div class="field checkbox">
           <label>

--- a/backend/app/views/spree/admin/variants/index.html.erb
+++ b/backend/app/views/spree/admin/variants/index.html.erb
@@ -14,7 +14,7 @@
   <% end %>
 <% end %>
 
-<% if @variants.any? || @product.variants.only_deleted.any?%>
+<% if @variants.any? || @product.variants.discarded.any? %>
   <%= render "table_filter", product: @product %>
   <%= render "table", variants: @variants %>
 <% else %>

--- a/backend/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/products_controller_spec.rb
@@ -21,7 +21,7 @@ describe Spree::Admin::ProductsController, type: :controller do
       let!(:soft_deleted_product) { create(:product, sku: "ABC123") }
       before { soft_deleted_product.discard }
 
-      context 'when params[:q][:with_deleted] is not set' do
+      context 'when params[:q][:with_discarded] is not set' do
         let(:params) { { q: {} } }
 
         it 'filters out soft-deleted products by default' do
@@ -30,8 +30,8 @@ describe Spree::Admin::ProductsController, type: :controller do
         end
       end
 
-      context 'when params[:q][:with_deleted] is set to "true"' do
-        let(:params) { { q: { with_deleted: 'true' } } }
+      context 'when params[:q][:with_discarded] is set to "true"' do
+        let(:params) { { q: { with_discarded: 'true' } } }
 
         it 'includes soft-deleted products' do
           get :index, params: params

--- a/backend/spec/features/admin/products/products_spec.rb
+++ b/backend/spec/features/admin/products/products_spec.rb
@@ -99,7 +99,7 @@ describe "Products", type: :feature do
         expect(page).not_to have_content("apache baseball cap")
         check "Show Deleted"
         click_button 'Search'
-        expect(find('input[name="q[with_deleted]"]')).to be_checked
+        expect(find('input[name="q[with_discarded]"]')).to be_checked
         expect(page).to have_content("zomg shirt")
         expect(page).to have_content("apache baseball cap")
         uncheck "Show Deleted"

--- a/core/app/models/concerns/spree/default_price.rb
+++ b/core/app/models/concerns/spree/default_price.rb
@@ -6,7 +6,7 @@ module Spree
 
     included do
       has_one :default_price,
-        -> { with_deleted.currently_valid.with_default_attributes },
+        -> { with_discarded.currently_valid.with_default_attributes },
         class_name: 'Spree::Price',
         inverse_of: :variant,
         dependent: :destroy,

--- a/core/app/models/spree/inventory_unit.rb
+++ b/core/app/models/spree/inventory_unit.rb
@@ -8,7 +8,7 @@ module Spree
     POST_SHIPMENT_STATES = %w(returned)
     CANCELABLE_STATES = ['on_hand', 'backordered', 'shipped']
 
-    belongs_to :variant, -> { with_deleted }, class_name: "Spree::Variant", inverse_of: :inventory_units, optional: true
+    belongs_to :variant, -> { with_discarded }, class_name: "Spree::Variant", inverse_of: :inventory_units, optional: true
     belongs_to :shipment, class_name: "Spree::Shipment", touch: true, inverse_of: :inventory_units, optional: true
     belongs_to :carton, class_name: "Spree::Carton", inverse_of: :inventory_units, optional: true
     belongs_to :line_item, class_name: "Spree::LineItem", inverse_of: :inventory_units, optional: true

--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -13,7 +13,7 @@ module Spree
     class CurrencyMismatch < StandardError; end
 
     belongs_to :order, class_name: "Spree::Order", inverse_of: :line_items, touch: true, optional: true
-    belongs_to :variant, -> { with_deleted }, class_name: "Spree::Variant", inverse_of: :line_items, optional: true
+    belongs_to :variant, -> { with_discarded }, class_name: "Spree::Variant", inverse_of: :line_items, optional: true
     belongs_to :tax_category, class_name: "Spree::TaxCategory", optional: true
 
     has_one :product, through: :variant

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -17,7 +17,7 @@ module Spree
 
     belongs_to :order, class_name: 'Spree::Order', touch: true, inverse_of: :payments, optional: true
     belongs_to :source, polymorphic: true, optional: true
-    belongs_to :payment_method, -> { with_deleted }, class_name: 'Spree::PaymentMethod', inverse_of: :payments, optional: true
+    belongs_to :payment_method, -> { with_discarded }, class_name: 'Spree::PaymentMethod', inverse_of: :payments, optional: true
 
     has_many :offsets, -> { offset_payment }, class_name: "Spree::Payment", foreign_key: :source_id
     has_many :log_entries, as: :source

--- a/core/app/models/spree/payment_method.rb
+++ b/core/app/models/spree/payment_method.rb
@@ -108,9 +108,9 @@ module Spree
         where(type: to_s, active: true).count > 0
       end
 
-      # @deprecated Use .with_deleted.find instead
+      # @deprecated Use .with_discarded.find instead
       def find_with_destroyed(*args)
-        Spree::Deprecation.warn "#{self}.find_with_destroyed is deprecated. Use #{self}.with_deleted.find instead"
+        Spree::Deprecation.warn "#{self}.find_with_destroyed is deprecated. Use #{self}.with_discarded.find instead"
         unscoped { find(*args) }
       end
     end

--- a/core/app/models/spree/price.rb
+++ b/core/app/models/spree/price.rb
@@ -12,7 +12,7 @@ module Spree
 
     MAXIMUM_AMOUNT = BigDecimal('99_999_999.99')
 
-    belongs_to :variant, -> { with_deleted }, class_name: 'Spree::Variant', touch: true, optional: true
+    belongs_to :variant, -> { with_discarded }, class_name: 'Spree::Variant', touch: true, optional: true
     belongs_to :country, class_name: "Spree::Country", foreign_key: "country_iso", primary_key: "iso", optional: true
 
     delegate :product, to: :variant

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -48,7 +48,7 @@ module Spree
     belongs_to :shipping_category, class_name: 'Spree::ShippingCategory', inverse_of: :products, optional: true
 
     has_one :master,
-      -> { where(is_master: true).with_deleted },
+      -> { where(is_master: true).with_discarded },
       inverse_of: :product,
       class_name: 'Spree::Variant',
       autosave: true
@@ -134,7 +134,7 @@ module Spree
     self.whitelisted_ransackable_attributes = %w[name slug]
 
     def self.ransackable_scopes(_auth_object = nil)
-      %i(with_deleted with_variant_sku_cont)
+      %i(with_discarded with_variant_sku_cont)
     end
 
     # @return [Boolean] true if there are any variants

--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -28,7 +28,7 @@ module Spree
     has_many :shipping_method_zones, dependent: :destroy
     has_many :zones, through: :shipping_method_zones
 
-    belongs_to :tax_category, -> { with_deleted }, class_name: 'Spree::TaxCategory', optional: true
+    belongs_to :tax_category, -> { with_discarded }, class_name: 'Spree::TaxCategory', optional: true
     has_many :shipping_method_stock_locations, dependent: :destroy, class_name: "Spree::ShippingMethodStockLocation"
     has_many :stock_locations, through: :shipping_method_stock_locations
 

--- a/core/app/models/spree/shipping_rate.rb
+++ b/core/app/models/spree/shipping_rate.rb
@@ -6,7 +6,7 @@ module Spree
   #
   class ShippingRate < Spree::Base
     belongs_to :shipment, class_name: 'Spree::Shipment', touch: true, optional: true
-    belongs_to :shipping_method, -> { with_deleted }, class_name: 'Spree::ShippingMethod', inverse_of: :shipping_rates, optional: true
+    belongs_to :shipping_method, -> { with_discarded }, class_name: 'Spree::ShippingMethod', inverse_of: :shipping_rates, optional: true
 
     has_many :taxes,
              class_name: "Spree::ShippingRateTax",

--- a/core/app/models/spree/stock_item.rb
+++ b/core/app/models/spree/stock_item.rb
@@ -11,7 +11,7 @@ module Spree
     self.discard_column = :deleted_at
 
     belongs_to :stock_location, class_name: 'Spree::StockLocation', inverse_of: :stock_items, optional: true
-    belongs_to :variant, -> { with_deleted }, class_name: 'Spree::Variant', inverse_of: :stock_items, optional: true
+    belongs_to :variant, -> { with_discarded }, class_name: 'Spree::Variant', inverse_of: :stock_items, optional: true
     has_many :stock_movements, inverse_of: :stock_item
 
     validates :stock_location, :variant, presence: true

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -36,7 +36,7 @@ module Spree
     attr_writer :rebuild_vat_prices
     include Spree::DefaultPrice
 
-    belongs_to :product, -> { with_deleted }, touch: true, class_name: 'Spree::Product', inverse_of: :variants, optional: false
+    belongs_to :product, -> { with_discarded }, touch: true, class_name: 'Spree::Product', inverse_of: :variants, optional: false
     belongs_to :tax_category, class_name: 'Spree::TaxCategory', optional: true
 
     delegate :name, :description, :slug, :available_on, :shipping_category_id,

--- a/core/spec/models/spree/promotion/actions/create_item_adjustments_spec.rb
+++ b/core/spec/models/spree/promotion/actions/create_item_adjustments_spec.rb
@@ -172,7 +172,7 @@ module Spree
           }.not_to change { Spree::Adjustment.count }
 
           expect(adjustment.source).to eq(nil)
-          expect(Spree::PromotionAction.with_deleted.find(adjustment.source_id)).to be_present
+          expect(Spree::PromotionAction.with_discarded.find(adjustment.source_id)).to be_present
         end
 
         it "doesnt mess with unrelated adjustments" do

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -692,7 +692,7 @@ RSpec.describe Spree::Variant, type: :model do
       context 'when loading with pre-fetching of default_price' do
         it 'also keeps the previous price' do
           variant.discard
-          reloaded_variant = Spree::Variant.with_deleted.includes(:default_price).find_by(id: variant.id)
+          reloaded_variant = Spree::Variant.with_discarded.includes(:default_price).find_by(id: variant.id)
           expect(reloaded_variant.display_price).to eq(previous_variant_price)
         end
       end

--- a/frontend/app/controllers/spree/products_controller.rb
+++ b/frontend/app/controllers/spree/products_controller.rb
@@ -38,7 +38,7 @@ module Spree
 
     def load_product
       if try_spree_current_user.try(:has_spree_role?, "admin")
-        @products = Spree::Product.with_deleted
+        @products = Spree::Product.with_discarded
       else
         @products = Spree::Product.available
       end


### PR DESCRIPTION
This PR replaces the usage of Paranoia methods with their Discard equivalent methods:
- `.with_deleted` => `.with_discarded`
- `.only_deleted` => `.discarded`
- `#deleted?` => `#discarded?`

This has been extracted from the #3488 PR. After some feedback, I'm extracting the non-breaking bits into separate PRs, so we can merge them without having to wait for Solidus v3.
Once merged, I'll rebase and revisit #3488 to definitely remove Paranoia as a dependency from Solidus v3.

**Checklist:**
- [ ] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [ ] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
