### PR TITLE
DRY paranoia and discard inclusion into models

### DIFF
--- a/core/app/models/concerns/spree/soft_deletable.rb
+++ b/core/app/models/concerns/spree/soft_deletable.rb
@@ -8,7 +8,8 @@ module Spree
 
     included do
       acts_as_paranoid
-      include Spree::ParanoiaDeprecations
+      include Spree::ParanoiaDeprecations::InstanceMethods
+      extend Spree::ParanoiaDeprecations::ClassMethods
 
       include Discard::Model
       self.discard_column = :deleted_at

--- a/core/app/models/concerns/spree/soft_deletable.rb
+++ b/core/app/models/concerns/spree/soft_deletable.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'discard'
+
+module Spree
+  module SoftDeletable
+    extend ActiveSupport::Concern
+
+    included do
+      acts_as_paranoid
+      include Spree::ParanoiaDeprecations
+
+      include Discard::Model
+      self.discard_column = :deleted_at
+    end
+  end
+end

--- a/core/app/models/spree/payment_method.rb
+++ b/core/app/models/spree/payment_method.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'discard'
 require 'spree/preferences/statically_configurable'
 
 module Spree
@@ -15,11 +14,7 @@ module Spree
     preference :server, :string, default: 'test'
     preference :test_mode, :boolean, default: true
 
-    acts_as_paranoid
-    include Spree::ParanoiaDeprecations
-
-    include Discard::Model
-    self.discard_column = :deleted_at
+    include Spree::SoftDeletable
 
     acts_as_list
 

--- a/core/app/models/spree/price.rb
+++ b/core/app/models/spree/price.rb
@@ -1,14 +1,8 @@
 # frozen_string_literal: true
 
-require 'discard'
-
 module Spree
   class Price < Spree::Base
-    acts_as_paranoid
-    include Spree::ParanoiaDeprecations
-
-    include Discard::Model
-    self.discard_column = :deleted_at
+    include Spree::SoftDeletable
 
     MAXIMUM_AMOUNT = BigDecimal('99_999_999.99')
 

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'discard'
-
 module Spree
   # Products represent an entity for sale in a store. Products can have
   # variations, called variants. Product properties include description,
@@ -15,11 +13,7 @@ module Spree
     extend FriendlyId
     friendly_id :slug_candidates, use: :history
 
-    acts_as_paranoid
-    include Spree::ParanoiaDeprecations
-
-    include Discard::Model
-    self.discard_column = :deleted_at
+    include Spree::SoftDeletable
 
     after_discard do
       variants_including_master.discard_all

--- a/core/app/models/spree/promotion_action.rb
+++ b/core/app/models/spree/promotion_action.rb
@@ -1,18 +1,12 @@
 # frozen_string_literal: true
 
-require 'discard'
-
 module Spree
   # Base class for all types of promotion action.
   #
   # PromotionActions perform the necessary tasks when a promotion is activated
   # by an event and determined to be eligible.
   class PromotionAction < Spree::Base
-    acts_as_paranoid
-    include Spree::ParanoiaDeprecations
-
-    include Discard::Model
-    self.discard_column = :deleted_at
+    include Spree::SoftDeletable
 
     belongs_to :promotion, class_name: 'Spree::Promotion', inverse_of: :promotion_actions, optional: true
 

--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -1,17 +1,10 @@
 # frozen_string_literal: true
 
-require 'discard'
-
 module Spree
   # Represents a means of having a shipment delivered, such as FedEx or UPS.
   #
   class ShippingMethod < Spree::Base
-    acts_as_paranoid
-    include Spree::ParanoiaDeprecations
-
-    include Discard::Model
-    self.discard_column = :deleted_at
-
+    include Spree::SoftDeletable
     include Spree::CalculatedAdjustments
     DISPLAY = ActiveSupport::Deprecation::DeprecatedObjectProxy.new(
       [:both, :front_end, :back_end],

--- a/core/app/models/spree/stock_item.rb
+++ b/core/app/models/spree/stock_item.rb
@@ -1,14 +1,8 @@
 # frozen_string_literal: true
 
-require 'discard'
-
 module Spree
   class StockItem < Spree::Base
-    acts_as_paranoid
-    include Spree::ParanoiaDeprecations
-
-    include Discard::Model
-    self.discard_column = :deleted_at
+    include Spree::SoftDeletable
 
     belongs_to :stock_location, class_name: 'Spree::StockLocation', inverse_of: :stock_items, optional: true
     belongs_to :variant, -> { with_discarded }, class_name: 'Spree::Variant', inverse_of: :stock_items, optional: true

--- a/core/app/models/spree/store_credit.rb
+++ b/core/app/models/spree/store_credit.rb
@@ -1,13 +1,7 @@
 # frozen_string_literal: true
 
-require 'discard'
-
 class Spree::StoreCredit < Spree::PaymentSource
-  acts_as_paranoid
-  include Spree::ParanoiaDeprecations
-
-  include Discard::Model
-  self.discard_column = :deleted_at
+  include Spree::SoftDeletable
 
   VOID_ACTION       = 'void'
   CREDIT_ACTION     = 'credit'

--- a/core/app/models/spree/store_credit_event.rb
+++ b/core/app/models/spree/store_credit_event.rb
@@ -1,14 +1,8 @@
 # frozen_string_literal: true
 
-require 'discard'
-
 module Spree
   class StoreCreditEvent < Spree::Base
-    acts_as_paranoid
-    include Spree::ParanoiaDeprecations
-
-    include Discard::Model
-    self.discard_column = :deleted_at
+    include Spree::SoftDeletable
 
     belongs_to :store_credit, optional: true
     belongs_to :originator, polymorphic: true, optional: true

--- a/core/app/models/spree/tax_category.rb
+++ b/core/app/models/spree/tax_category.rb
@@ -1,14 +1,8 @@
 # frozen_string_literal: true
 
-require 'discard'
-
 module Spree
   class TaxCategory < Spree::Base
-    acts_as_paranoid
-    include Spree::ParanoiaDeprecations
-
-    include Discard::Model
-    self.discard_column = :deleted_at
+    include Spree::SoftDeletable
 
     after_discard do
       self.tax_rate_tax_categories = []

--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -1,14 +1,8 @@
 # frozen_string_literal: true
 
-require 'discard'
-
 module Spree
   class TaxRate < Spree::Base
-    acts_as_paranoid
-    include Spree::ParanoiaDeprecations
-
-    include Discard::Model
-    self.discard_column = :deleted_at
+    include Spree::SoftDeletable
 
     # Need to deal with adjustments before calculator is destroyed.
     before_destroy :remove_adjustments_from_incomplete_orders

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'discard'
-
 module Spree
   # == Master Variant
   #
@@ -20,11 +18,7 @@ module Spree
   class Variant < Spree::Base
     acts_as_list scope: :product
 
-    acts_as_paranoid
-    include Spree::ParanoiaDeprecations
-
-    include Discard::Model
-    self.discard_column = :deleted_at
+    include Spree::SoftDeletable
 
     after_discard do
       stock_items.discard_all

--- a/core/lib/spree/paranoia_deprecations.rb
+++ b/core/lib/spree/paranoia_deprecations.rb
@@ -2,20 +2,40 @@
 
 module Spree
   module ParanoiaDeprecations
-    def paranoia_destroy
-      Spree::Deprecation.warn <<-WARN.strip_heredoc, caller
-        Calling #destroy (or #paranoia_destroy) on a #{self.class} currently performs a soft-destroy using the paranoia gem.
-        In Solidus 3.0, paranoia will be removed, and this will perform a HARD destroy instead. To continue soft-deleting, use #discard instead.
-      WARN
-      super
+    module InstanceMethods
+      def paranoia_destroy
+        Spree::Deprecation.warn <<~WARN, caller
+          Calling #destroy (or #paranoia_destroy) on a #{self.class} currently performs a soft-destroy using the paranoia gem.
+          In Solidus 3.0, paranoia will be removed, and this will perform a HARD destroy instead. To continue soft-deleting, use #discard instead.
+        WARN
+        super
+      end
+
+      def paranoia_delete
+        Spree::Deprecation.warn <<~WARN, caller
+          Calling #delete (or #paranoia_delete) on a #{self.class} currently performs a soft-destroy using the paranoia gem.
+          In Solidus 3.0, paranoia will be removed, and this will perform a HARD destroy instead. To continue soft-deleting, use #discard instead.
+        WARN
+        super
+      end
     end
 
-    def paranoia_delete
-      Spree::Deprecation.warn <<-WARN.strip_heredoc, caller
-        Calling #delete (or #paranoia_delete) on a #{self.class} currently performs a soft-destroy using the paranoia gem.
-        In Solidus 3.0, paranoia will be removed, and this will perform a HARD destroy instead. To continue soft-deleting, use #discard instead.
-      WARN
-      super
+    module ClassMethods
+      def with_deleted
+        Spree::Deprecation.warn <<~WARN, caller
+          #{self}.with_deleted has been deprecated. Use #{self}.with_discarded instead.
+          In Solidus 3.0, paranoia will be removed, and this method will be replaced by #{self}.with_discarded.
+        WARN
+        super
+      end
+
+      def only_deleted
+        Spree::Deprecation.warn <<~WARN, caller
+          #{self}.only_deleted has been deprecated. Use #{self}.discarded instead.
+          In Solidus 3.0, paranoia will be removed, and this method will be replaced by #{self}.discarded.
+        WARN
+        super
+      end
     end
   end
 end

--- a/core/spec/models/spree/concerns/soft_deletable_spec.rb
+++ b/core/spec/models/spree/concerns/soft_deletable_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Spree::SoftDeletable do
+  with_model :Post do
+    table do |t|
+      t.datetime :deleted_at
+    end
+
+    model do
+      include Spree::SoftDeletable
+    end
+  end
+
+  it 'includes Paranoia' do
+    expect(Post).to respond_to(:with_deleted)
+    expect(Post.new).to respond_to(:deleted?)
+  end
+
+  it 'includes Discard' do
+    expect(Post).to respond_to(:with_discarded)
+    expect(Post.new).to respond_to(:discarded?)
+    expect(Post.discard_column).to eq(:deleted_at)
+  end
+end

--- a/core/spec/models/spree/order_merger_spec.rb
+++ b/core/spec/models/spree/order_merger_spec.rb
@@ -144,16 +144,13 @@ module Spree
     end
 
     context "merging together orders with invalid line items" do
-      let(:variant_2) { create(:variant) }
-
       before do
-        order_1.contents.add(variant, 1)
-        order_2.contents.add(variant_2, 1)
+        order_1.contents.add(create(:variant), 1)
+        order_2.contents.add(create(:variant), 1)
       end
 
       it "should create errors with invalid line items" do
-        variant_2.really_destroy!
-        order_2.line_items.to_a.first.reload # so that it registers as invalid
+        allow(order_2.line_items.first).to receive(:variant) { nil }
         subject.merge!(order_2)
         expect(order_1.errors.full_messages).not_to be_empty
       end

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -417,13 +417,6 @@ RSpec.describe Spree::Product, type: :model do
         end
       end
     end
-
-    context "#really_destroy!" do
-      it "destroy the product" do
-        product.really_destroy!
-        expect(product).not_to be_persisted
-      end
-    end
   end
 
   context "properties" do

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -159,7 +159,11 @@ RSpec.describe Spree::Variant, type: :model do
       context "and a variant is really deleted" do
         let!(:old_option_values_variant_ids) { variant.option_values_variants.pluck(:id) }
 
-        before { variant.really_destroy! }
+        before do
+          # #really_destroy! will be replaced here with #destroy when Paranoia
+          # will be removed in Solidus 3.0
+          Spree::Deprecation.silence { variant.really_destroy! }
+        end
 
         it "leaves no stale records behind" do
           expect(old_option_values_variant_ids).to be_present


### PR DESCRIPTION
This PR DRYs the soft delete inclusion logic into a reusable concern.
This also deprecates `.with_deleted` and `.only_deleted` Paranoia' scopes, which will be removed in Solidus v3.

This has been extracted from the #3488 PR. After some feedback, I'm extracting the non-breaking bits into separate PRs, so we can merge them without having to wait for Solidus v3.
Once merged, I'll rebase and revisit #3488 to definitely remove Paranoia as a dependency from Solidus v3.

**Checklist:**
- [ ] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [ ] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
