### PR TITLE
Add CircleCI job to run tests against Rails master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,6 +96,15 @@ jobs:
       - setup
       - test
 
+  postgres_rails_master:
+    executor: postgres
+    parallelism: *parallelism
+    environment:
+      RAILS_VERSION: 'master'
+    steps:
+      - setup
+      - test
+
   mysql:
     executor: mysql
     parallelism: *parallelism
@@ -132,6 +141,7 @@ workflows:
       - mysql
       - postgres_rails52
       - mysql_rails52
+      - postgres_rails_master
       - stoplight/push:
           project: solidus/solidus-api
           git_token: $STOPLIGHT_GIT_TOKEN


### PR DESCRIPTION
**Description**
This PR adds a CircleCI job to run tests against Rails master. Right now it's needed to bring forward [the work to support ActiveStorage](https://github.com/solidusio/solidus/pull/3501) and could be useful to spot as soon as possible potentially breaking changes brought in by Rails new features.

The job could be disabled or set as a non-blocking status check in Github's branch protection rules to avoid blocking unrelated PRs.

**Checklist:**
- [X] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [X] I have added a detailed description into each commit message