### PR TITLE
Add support for prefill user address in new order

### DIFF
--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -61,7 +61,11 @@ module Spree
 
       def new
         user = Spree.user_class.find_by(id: params[:user_id]) if params[:user_id]
-        @order = Spree::Core::Importer::Order.import(user, order_params)
+        order_importer_params = order_params
+        order_importer_params[:bill_address] = user&.bill_address
+        order_importer_params[:ship_address] = user&.ship_address
+
+        @order = Spree::Core::Importer::Order.import(user, order_importer_params)
         redirect_to cart_admin_order_url(@order)
       end
 

--- a/backend/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -102,7 +102,7 @@ describe Spree::Admin::OrdersController, type: :controller do
       end
 
       context "when a user_id is passed as a parameter" do
-        let(:user)  { mock_model(Spree.user_class) }
+        let(:user)  { mock_model(Spree.user_class, ship_address: mock_model(Spree::Address), bill_address: nil) }
         before { allow(Spree.user_class).to receive_messages find_by: user }
 
         it "imports a new order and assigns the user to the order" do

--- a/backend/spec/features/admin/users_spec.rb
+++ b/backend/spec/features/admin/users_spec.rb
@@ -9,6 +9,7 @@ describe 'Users', type: :feature do
   let!(:user_b) { create(:user_with_addresses, email: 'b@example.com') }
   let!(:admin_role) { create(:role, name: 'admin') }
   let!(:user_role) { create(:role, name: 'user') }
+  let!(:store) { create(:store) }
 
   let(:order) { create(:completed_order_with_totals, user: user_a, number: "R123") }
 
@@ -406,6 +407,38 @@ describe 'Users', type: :feature do
           expect(page).to have_selector(".item-quantity", text: item.quantity)
           expect(page).to have_selector(".item-total", text: item.money.to_html(html_wrap: false))
         end
+      end
+    end
+  end
+
+  context 'create new order' do
+    before do
+      allow(Spree.user_class).to receive(:find_by).with(id: user_a.id.to_s) { user_a }
+      click_link user_a.email
+      click_link 'Create order for this user'
+    end
+
+    it 'prefills the customer addresses with the user addresses' do
+      click_link 'Customer'
+
+      within '.js-billing-address' do
+        expect(page).to have_field('Street Address', with: user_a.bill_address.address1)
+        expect(page).to have_field("Street Address (cont'd)", with: user_a.bill_address.address2)
+        expect(page).to have_field('City', with: user_a.bill_address.city)
+        expect(page).to have_field('Zip Code', with: user_a.bill_address.zipcode)
+        expect(page).to have_select('Country', selected: "#{user_a.bill_address.country} of America")
+        expect(page).to have_select('State', selected: user_a.bill_address.state.name)
+        expect(page).to have_field('Phone', with: user_a.bill_address.phone)
+      end
+
+      within '.js-shipping-address' do
+        expect(page).to have_field('Street Address', with: user_a.ship_address.address1)
+        expect(page).to have_field("Street Address (cont'd)", with: user_a.ship_address.address2)
+        expect(page).to have_field('City', with: user_a.ship_address.city)
+        expect(page).to have_field('Zip Code', with: user_a.ship_address.zipcode)
+        expect(page).to have_select('Country', selected: "#{user_a.ship_address.country} of America")
+        expect(page).to have_select('State', selected: user_a.ship_address.state.name)
+        expect(page).to have_field('Phone', with: user_a.ship_address.phone)
       end
     end
   end


### PR DESCRIPTION
**Description**
Ref #3537 
When a new order is created passing a user id we want the address to be prefilled.

This associate the user address (both ship and bill) with the order using `update`

![test_address_issue_solidus](https://user-images.githubusercontent.com/21062088/76920346-e254a980-6890-11ea-8509-298b8dd2c886.gif)

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
