### PR TITLE
Show v2.10 install instructions along with new ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,22 +101,53 @@ required for Paperclip. (You can install it using [Homebrew](https://brew.sh) if
 you're on a Mac.)
 
 To add solidus, begin with a Rails 5/6 application and a database configured and
-created. Add the following to your Gemfile.
+created.
 
-```ruby
-gem 'solidus'
-```
+### Installing Solidus
 
-Run the `bundle` command to install.
+<details>
+  <summary>For Solidus v2.10 and below</summary>
 
-After installing gems, you'll have to run the generator to create necessary
-configuration files and migrations.
+  Add the following to your Gemfile. Skip the `solidus_auth_devise` part
+  if you want to use a custom authentication system.
 
-```bash
-bin/rails g solidus:install
-```
+  ```ruby
+  gem 'solidus'
+  gem 'solidus_auth_devise'
+  ```
 
-And start the rails server
+  Run the `bundle` command to install.
+
+  After installing gems, you'll have to run the generator to create necessary
+  configuration files and migrations.
+
+  ```bash
+  bin/rails g spree:install
+  ```
+</details>
+
+<details>
+  <summary>For Solidus v2.11 (still unreleased) and above</summary>
+
+  Add the following to your Gemfile.
+
+  ```ruby
+  gem 'solidus'
+  ```
+
+  Run the `bundle` command to install.
+
+  After installing gems, you'll have to run the generator to create necessary
+  configuration files and migrations.
+
+  ```bash
+  bin/rails g solidus:install
+  ```
+</details>
+
+### Accessing Solidus Store
+
+Start the Rails server with the command:
 
 ```bash
 bin/rails s

--- a/guides/source/developers/getting-started/first-time-installation.html.md
+++ b/guides/source/developers/getting-started/first-time-installation.html.md
@@ -112,13 +112,36 @@ After the gems have been successfully installed, you need to create the
 necessary configuration files and instructions for the database using generators
 provided by Solidus and Railties.
 
-First, run the `solidus:install` generator:
+#### For Solidus v2.11 (still unreleased) and above
+
+Run the `solidus:install` generator:
 
 ```bash
 bin/rails generate solidus:install
 ```
 
 This may take a few minutes to complete, and it requires some user confirmation.
+
+#### For Solidus v2.10 and below
+
+If you are using Solidus 2.10 or below, this step is quite different.
+
+First of all, if you want to install the default authentication system provided
+by Solidus ([`solidus_auth_devise`][solidus-auth-devise]), your `Gemfile` should
+look like:
+
+```
+gem 'solidus'
+gem 'solidus_auth_devise'
+```
+
+Once you have run `bundle install`, you can install Solidus with the command:
+
+```bash
+bin/rails generate spree:install
+```
+
+[solidus-auth-devise]: https://github.com/solidusio/solidus_auth_devise
 
 ### Set the administrator username and password
 

--- a/guides/source/developers/getting-started/installation-options.html.md
+++ b/guides/source/developers/getting-started/installation-options.html.md
@@ -48,7 +48,7 @@ bin/rails spree_sample:load                 # loads sample data
 ## Authentication via Devise
 
 During the installation, you have been prompted to add the default authentication extension
-to your project. It is called [`solidus-auth-devise`][solidus-auth-devise] and it uses the
+to your project. It is called [`solidus_auth_devise`][solidus-auth-devise] and it uses the
 well-known authentication library for Rails called [Devise][devise].
 
 If you answered "yes", there's nothing else left to do. The extension is already
@@ -61,7 +61,7 @@ or run the Solidus installer with the following command:
 bin/rails generate solidus:install --with-authentication=false
 ```
 
-If you prefer to install [`solidus-auth-devise`][solidus-auth-devise] gem manually,
+If you prefer to install [`solidus_auth_devise`][solidus-auth-devise] gem manually,
 after adding it in your Gemfile, you can run the following commands to install and
 run its migrations, then seed the database:
 


### PR DESCRIPTION
**Description**

With #3538, we changed the name of the command to install Solidus into a Rails application. This change will be available only starting from the next release (or to who is using solidus master). 

This PR re-adds old install instructions both in README and Guides since they are expected by users installing Solidus today.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x]  I have attached screenshots to this PR for visual changes (if needed)
