### PR TITLE
Uniform bill_address and ship_address behaviour in Spree::UserAddressBook module

### DIFF
--- a/core/app/models/concerns/spree/user_address_book.rb
+++ b/core/app/models/concerns/spree/user_address_book.rb
@@ -40,18 +40,21 @@ module Spree
     end
 
     def default_address
-      Spree::Deprecation.warn "This association is deprecated. Please start using ship_address = address"
+      Spree::Deprecation.warn "#default_address is deprecated. Please start using #ship_address."
       ship_address
     end
 
     def default_user_address
-      Spree::Deprecation.warn "This association is deprecated. Please start using #default_user_ship_address."
+      Spree::Deprecation.warn "#default_user_address is deprecated. Please start using #default_user_ship_address."
       default_user_ship_address
     end
 
     def default_address=(address)
-      Spree::Deprecation.warn "This setter does not take into account Spree::Config.automatic_default_address and is deprecated. "\
-        "Please start using ship_address = address"
+      Spree::Deprecation.warn(
+        "#default_address= does not take Spree::Config.automatic_default_address into account and is deprecated. " \
+        "Please use #ship_address=."
+      )
+
       self.ship_address = address if address
     end
 
@@ -59,7 +62,7 @@ module Spree
       # see "Nested Attributes Examples" section of http://apidock.com/rails/ActionView/Helpers/FormHelper/fields_for
       # this #{fieldname}_attributes= method works with fields_for in the views
       # even without declaring accepts_nested_attributes_for
-      Spree::Deprecation.warn "This setter is deprecated. Please start using ship_address_attributes = attributes"
+      Spree::Deprecation.warn "#default_address_attributes= is deprecated. Please use #ship_address_attributes=."
 
       self.default_address = Spree::Address.immutable_merge(ship_address, attributes)
     end
@@ -155,8 +158,10 @@ module Spree
     end
 
     def mark_default_address(address)
-      Spree::Deprecation.warn "This method is deprecated and it sets the ship_address only. " \
-        "Please start using #mark_default_ship_address for that"
+      Spree::Deprecation.warn(
+        "#mark_default_address is deprecated and it sets the ship_address only. " \
+        "Please use #mark_default_ship_address."
+      )
 
       mark_default_ship_address(address)
     end

--- a/core/app/models/concerns/spree/user_address_book.rb
+++ b/core/app/models/concerns/spree/user_address_book.rb
@@ -26,7 +26,7 @@ module Spree
       has_one :default_user_bill_address, ->{ default_billing }, class_name: 'Spree::UserAddress', foreign_key: 'user_id'
       has_one :bill_address, through: :default_user_bill_address, source: :address
 
-      has_one :default_user_ship_address, ->{ default }, class_name: 'Spree::UserAddress', foreign_key: 'user_id'
+      has_one :default_user_ship_address, ->{ default_shipping }, class_name: 'Spree::UserAddress', foreign_key: 'user_id'
       has_one :ship_address, through: :default_user_ship_address, source: :address
     end
 

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -744,8 +744,8 @@ module Spree
     # @note This doesn't persist the change bill_address or ship_address
     def assign_default_user_addresses
       if user
-        bill_address = (user.bill_address || user.default_address)
-        ship_address = (user.ship_address || user.default_address)
+        bill_address = user.bill_address
+        ship_address = user.ship_address
         # this is one of 2 places still using User#bill_address
         self.bill_address ||= bill_address if bill_address.try!(:valid?)
         # Skip setting ship address if order doesn't have a delivery checkout step

--- a/core/app/models/spree/user_address.rb
+++ b/core/app/models/spree/user_address.rb
@@ -6,7 +6,7 @@ module Spree
     belongs_to :address, class_name: "Spree::Address", optional: true
 
     validates_uniqueness_of :address_id, scope: :user_id
-    validates_uniqueness_of :user_id, conditions: -> { active.default }, message: :default_address_exists, if: :default?
+    validates_uniqueness_of :user_id, conditions: -> { active.default_shipping }, message: :default_address_exists, if: :default?
 
     scope :with_address_values, ->(address_attributes) do
       joins(:address).merge(
@@ -15,9 +15,14 @@ module Spree
     end
 
     scope :all_historical, -> { unscope(where: :archived) }
-    scope :default, -> { where(default: true) }
+    scope :default_shipping, -> { where(default: true) }
     scope :default_billing, -> { where(default_billing: true) }
     scope :active, -> { where(archived: false) }
+
+    scope :default, -> do
+      Spree::Deprecation.warn "This scope is deprecated. Please start using ::default_shipping."
+      default_shipping
+    end
 
     default_scope -> { order([default: :desc, updated_at: :desc]) }
   end

--- a/core/app/models/spree/user_address.rb
+++ b/core/app/models/spree/user_address.rb
@@ -16,6 +16,7 @@ module Spree
 
     scope :all_historical, -> { unscope(where: :archived) }
     scope :default, -> { where(default: true) }
+    scope :default_billing, -> { where(default_billing: true) }
     scope :active, -> { where(archived: false) }
 
     default_scope -> { order([default: :desc, updated_at: :desc]) }

--- a/core/db/migrate/20200320144521_add_default_billng_flag_to_user_addresses.rb
+++ b/core/db/migrate/20200320144521_add_default_billng_flag_to_user_addresses.rb
@@ -1,4 +1,5 @@
-class AddDefaultBillngFlagToUserAddresses < ActiveRecord::Migration[6.0]
+# frozen_string_literal: true
+class AddDefaultBillngFlagToUserAddresses < ActiveRecord::Migration[5.2]
   def change
     add_column :spree_user_addresses, :default_billing, :boolean, default: false
   end

--- a/core/db/migrate/20200320144521_add_default_billng_flag_to_user_addresses.rb
+++ b/core/db/migrate/20200320144521_add_default_billng_flag_to_user_addresses.rb
@@ -1,0 +1,5 @@
+class AddDefaultBillngFlagToUserAddresses < ActiveRecord::Migration[6.0]
+  def change
+    add_column :spree_user_addresses, :default_billing, :boolean, default: false
+  end
+end

--- a/core/spec/models/spree/concerns/user_address_book_spec.rb
+++ b/core/spec/models/spree/concerns/user_address_book_spec.rb
@@ -496,7 +496,7 @@ module Spree
 
     describe "#default_address" do
       let(:deprecation_message) do
-        "This association is deprecated. Please start using ship_address = address"
+        "#default_address is deprecated. Please start using #ship_address."
       end
 
       it "calls #ship_address and warns caller of deprecation" do
@@ -510,7 +510,7 @@ module Spree
 
     describe "#default_user_address" do
       let(:deprecation_message) do
-        "This association is deprecated. Please start using #default_user_ship_address."
+        "#default_user_address is deprecated. Please start using #default_user_ship_address."
       end
 
       it "calls #ship_address and warns caller of deprecation" do
@@ -526,8 +526,8 @@ module Spree
       let(:address) { build :address }
 
       let(:deprecation_message) do
-        "This setter does not take into account Spree::Config.automatic_default_address and is deprecated. "\
-        "Please start using ship_address = address"
+        "#default_address= does not take Spree::Config.automatic_default_address into account and is deprecated. " \
+        "Please use #ship_address=."
       end
 
       it "calls #ship_address= and warns caller of deprecation" do
@@ -540,7 +540,7 @@ module Spree
 
     describe "#default_address_attributes=" do
       let(:deprecation_message) do
-        "This setter is deprecated. Please start using ship_address_attributes = attributes"
+        "#default_address_attributes= is deprecated. Please use #ship_address_attributes=."
       end
 
       it "warns caller of deprecation" do
@@ -570,8 +570,8 @@ module Spree
     describe "#mark_default_address" do
       let(:address) { build :address }
       let(:deprecation_message) do
-        "This method is deprecated and it sets the ship_address only. " \
-        "Please start using #mark_default_ship_address for that"
+        "#mark_default_address is deprecated and it sets the ship_address only. " \
+        "Please use #mark_default_ship_address."
       end
 
       it "calls #mark_default_ship_address and warns caller of deprecation" do

--- a/core/spec/models/spree/concerns/user_address_book_spec.rb
+++ b/core/spec/models/spree/concerns/user_address_book_spec.rb
@@ -415,5 +415,52 @@ module Spree
         expect(user.bill_address).to eq(address)
       end
     end
+
+    describe "#mark_default_address" do
+      let(:address) { build :address }
+
+      it "calls #mark_default_ship_address and warns user of deprecation" do
+        expect(user).to receive(:mark_default_ship_address)
+
+        expect {
+          user.mark_default_address(address)
+        }
+        .to output("Hey, this method is deprecated and it sets the ship_address only! Please start using #mark_default_ship_address for that\n").to_stdout
+      end
+    end
+
+    describe "#mark_default_ship_address" do
+      let(:address) { build :address }
+      let(:user_address) { double }
+      let(:user_addresses) { double }
+
+      before do
+        allow(user).to receive(:user_addresses).and_return user_addresses
+        allow(user_addresses).to receive(:find_by).and_return user_address
+      end
+
+      it "calls #mark_default with default address kind" do
+        expect(user_addresses).to receive(:mark_default).with(user_address)
+
+        user.mark_default_ship_address(address)
+      end
+    end
+
+    describe "#mark_default_bill_address" do
+      let(:address) { build :address }
+      let(:user_address) { double }
+      let(:user_addresses) { double }
+
+      before do
+        allow(user).to receive(:user_addresses).and_return user_addresses
+        allow(user_addresses).to receive(:find_by).and_return user_address
+      end
+
+      it "calls #mark_default with billing address kind" do
+        expect(user_addresses).to receive(:mark_default).with(user_address, :billing)
+
+        user.mark_default_bill_address(address)
+      end
+    end
   end
 end

--- a/core/spec/models/spree/concerns/user_address_book_spec.rb
+++ b/core/spec/models/spree/concerns/user_address_book_spec.rb
@@ -14,21 +14,23 @@ module Spree
       context "saving a shipping address" do
         let(:user_address) { user.user_addresses.find_first_by_address_values(address.attributes) }
 
-        subject { user.save_in_address_book(address.attributes, true) }
+        subject do
+          -> { user.save_in_address_book(address.attributes, true) }
+        end
 
         context "the address is a new record" do
           let(:address) { build(:address) }
 
           it "creates a new Address" do
-            expect { subject }.to change { Spree::Address.count }.by(1)
+            is_expected.to change { Spree::Address.count }.by(1)
           end
 
           it "creates a UserAddress" do
-            expect { subject }.to change { Spree::UserAddress.count }.by(1)
+            is_expected.to change { Spree::UserAddress.count }.by(1)
           end
 
           it "sets the UserAddress default flag to true" do
-            subject
+            subject.call
             expect(user_address.default).to eq true
             expect(user_address.default_billing).to be_falsey
           end
@@ -44,7 +46,7 @@ module Spree
           end
 
           it "adds the address to the user's the associated addresses" do
-            expect { subject }.to change { user.reload.addresses.count }.by(1)
+            is_expected.to change { user.reload.addresses.count }.by(1)
           end
         end
 
@@ -62,12 +64,8 @@ module Spree
 
           context "saving a shipping address" do
             context "makes all the other associated shipping addresses not be the default and ignores the billing ones" do
-              it do
-                expect { subject }.to change { original_user_address.reload.default }.from(true).to(false)
-              end
-              it do
-                expect { subject }.not_to change { original_user_bill_address.reload.default_billing }
-              end
+              it { is_expected.to change { original_user_address.reload.default }.from(true).to(false) }
+              it { is_expected.not_to change { original_user_bill_address.reload.default_billing } }
             end
 
             context "an odd flip-flop corner case discovered running backfill rake task" do
@@ -87,15 +85,11 @@ module Spree
           end
 
           context "saving a billing address" do
-            subject { user.save_in_address_book(address.attributes, true, :billing) }
+            subject { -> { user.save_in_address_book(address.attributes, true, :billing) } }
 
             context "makes all the other associated billing addresses not be the default and ignores the shipping ones" do
-              it do
-                expect { subject }.not_to change { original_user_address.reload.default }
-              end
-              it do
-                expect { subject }.to change { original_user_bill_address.reload.default_billing }.from(true).to(false)
-              end
+              it { is_expected.not_to change { original_user_address.reload.default } }
+              it { is_expected.to change { original_user_bill_address.reload.default_billing }.from(true).to(false) }
             end
 
             context "an odd flip-flop corner case discovered running backfill rake task" do
@@ -123,12 +117,12 @@ module Spree
 
           context "properly sets the default flag" do
             context "shipping address" do
-              it { expect(subject).to eq user.ship_address }
+              it { expect(subject.call).to eq user.ship_address }
             end
 
             context "billing address" do
               subject { user.save_in_address_book(address.attributes, true, :billing) }
-              it { expect(subject).to eq user.bill_address }
+              it { is_expected.to eq user.bill_address }
             end
           end
 
@@ -151,12 +145,12 @@ module Spree
 
             context "is the new default" do
               context "shipping address" do
-                it { expect(subject).to eq user.ship_address }
+                it { is_expected.to eq user.ship_address }
               end
 
               context "billing address" do
                 subject { user.save_in_address_book(address.attributes, true, :billing) }
-                it { expect(subject).to eq user.bill_address }
+                it { is_expected.to eq user.bill_address }
               end
             end
           end
@@ -494,7 +488,7 @@ module Spree
       let!(:user) { create(:user) }
       let!(:address) { create(:address) }
 
-      # https://github.com/solidusio/solidus/issuesÎ/1241
+      # https://github.com/solidusio/solidus/issues/1241
       it "resets the association and persists" do
         # Load (which will cache) the has_one association
         expect(user.bill_address).to be_nil

--- a/core/spec/models/spree/concerns/user_address_book_spec.rb
+++ b/core/spec/models/spree/concerns/user_address_book_spec.rb
@@ -11,7 +11,7 @@ module Spree
     let!(:user) { create(:user) }
 
     describe "#save_in_address_book" do
-      context "saving a default (shipping) address" do
+      context "saving a shipping address" do
         let(:user_address) { user.user_addresses.find_first_by_address_values(address.attributes) }
 
         subject { user.save_in_address_book(address.attributes, true) }
@@ -33,7 +33,7 @@ module Spree
             expect(user_address.default_billing).to be_falsey
           end
 
-          context "billing address" do
+          context "saving a billing address" do
             subject { user.save_in_address_book(address.attributes, true, :billing) }
 
             it "sets the UserAddress default_billing flag to true" do

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe Spree::Order, type: :model do
             let(:address_kind) { :ship }
             before do
               order.user = FactoryBot.create(:user)
-              order.user.default_address = default_address
+              order.user.ship_address = default_address
               order.next!
               order.reload
             end
@@ -150,7 +150,7 @@ RSpec.describe Spree::Order, type: :model do
             let(:address_kind) { :bill }
             before do
               order.user = FactoryBot.create(:user)
-              order.user.default_address = default_address
+              order.user.bill_address = default_address
               order.next!
               order.reload
             end

--- a/core/spec/models/spree/user_address_spec.rb
+++ b/core/spec/models/spree/user_address_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Spree::UserAddress, type: :model do
+  context "::default" do
+    let(:deprecation_message) do
+      "This scope is deprecated. Please start using ::default_shipping."
+    end
+
+    it "calls ::default_shipping and warns caller of deprecation" do
+      expect(described_class).to receive(:default_shipping)
+      expect(Spree::Deprecation).to receive(:warn).with deprecation_message
+
+      described_class.default
+    end
+  end
+end


### PR DESCRIPTION
Responding to the issue [#3539](https://github.com/solidusio/solidus/issues/3539), the association `has_one :bill_address` provided by `UserAddressBook` to `LegacyUser` has been made similar to the one already in place for `default_address` _alias_ `ship_address`.

Namely, `user.bill_address` is now the `Address` pointed by the only `UserAddress` having the new `default_billing` flag column set to `true`, which plays the same role as the `default` one (which retains the function of selecting the one and only default _shipping_ address).

Being now possible to set the two default addresses independently, 

- `#persist_order_address` now calls `#save_in_address_book` in the same way for the two addresses, solving the issue.

- the new public methods `#mark_default_ship_address` and `#mark_default_bill_address` are provided. `#mark_default_address` just calls the former for backward compatibility, and can be deprecated.