### PR TITLE
Validate uniqueness with case_sensitive: true explicitly

### DIFF
--- a/core/app/models/spree/option_type.rb
+++ b/core/app/models/spree/option_type.rb
@@ -15,7 +15,7 @@ module Spree
     has_many :product_option_types, dependent: :destroy, inverse_of: :option_type
     has_many :products, through: :product_option_types
 
-    validates :name, presence: true, uniqueness: { allow_blank: true }
+    validates :name, presence: true, uniqueness: { allow_blank: true, case_sensitive: true }
     validates :presentation, presence: true
 
     default_scope -> { order(:position) }

--- a/core/app/models/spree/option_value.rb
+++ b/core/app/models/spree/option_value.rb
@@ -8,7 +8,7 @@ module Spree
     has_many :option_values_variants, dependent: :destroy
     has_many :variants, through: :option_values_variants
 
-    validates :name, presence: true, uniqueness: { scope: :option_type_id, allow_blank: true }
+    validates :name, presence: true, uniqueness: { scope: :option_type_id, allow_blank: true, case_sensitive: true }
     validates :presentation, presence: true
 
     after_save :touch, if: :saved_changes?

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -126,7 +126,7 @@ module Spree
     validates :email, presence: true, if: :require_email
     validates :email, 'spree/email' => true, allow_blank: true
     validates :guest_token, presence: { allow_nil: true }
-    validates :number, presence: true, uniqueness: { allow_blank: true }
+    validates :number, presence: true, uniqueness: { allow_blank: true, case_sensitive: true }
     validates :store_id, presence: true
 
     def self.find_by_param(value)

--- a/core/app/models/spree/preference.rb
+++ b/core/app/models/spree/preference.rb
@@ -3,5 +3,5 @@
 class Spree::Preference < Spree::Base
   serialize :value
 
-  validates :key, presence: true, uniqueness: { allow_blank: true }
+  validates :key, presence: true, uniqueness: { allow_blank: true, case_sensitive: true }
 end

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -115,7 +115,7 @@ module Spree
     validates :name, presence: true
     validates :price, presence: true, if: proc { Spree::Config[:require_master_price] }
     validates :shipping_category_id, presence: true
-    validates :slug, presence: true, uniqueness: { allow_blank: true }
+    validates :slug, presence: true, uniqueness: { allow_blank: true, case_sensitive: true }
 
     attr_accessor :option_values_hash
 

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -28,7 +28,7 @@ module Spree
     validates_associated :rules
 
     validates :name, presence: true
-    validates :path, uniqueness: { allow_blank: true }
+    validates :path, uniqueness: { allow_blank: true, case_sensitive: true }
     validates :usage_limit, numericality: { greater_than: 0, allow_nil: true }
     validates :per_code_usage_limit, numericality: { greater_than_or_equal_to: 0, allow_nil: true }
     validates :description, length: { maximum: 255 }

--- a/core/app/models/spree/promotion_code.rb
+++ b/core/app/models/spree/promotion_code.rb
@@ -5,7 +5,7 @@ class Spree::PromotionCode < Spree::Base
   belongs_to :promotion_code_batch, class_name: "Spree::PromotionCodeBatch", optional: true
   has_many :adjustments
 
-  validates :value, presence: true, uniqueness: { allow_blank: true }
+  validates :value, presence: true, uniqueness: { allow_blank: true, case_sensitive: true }
   validates :promotion, presence: true
 
   before_save :normalize_code

--- a/core/app/models/spree/role.rb
+++ b/core/app/models/spree/role.rb
@@ -5,7 +5,7 @@ module Spree
     has_many :role_users, class_name: "Spree::RoleUser", dependent: :destroy
     has_many :users, through: :role_users
 
-    validates_uniqueness_of :name
+    validates_uniqueness_of :name, case_sensitive: true
 
     def admin?
       name == "admin"

--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -17,7 +17,7 @@ module Spree
 
     has_many :orders, class_name: "Spree::Order"
 
-    validates :code, presence: true, uniqueness: { allow_blank: true }
+    validates :code, presence: true, uniqueness: { allow_blank: true, case_sensitive: true }
     validates :name, presence: true
     validates :url, presence: true
     validates :mail_from_address, presence: true

--- a/core/app/models/spree/tax_category.rb
+++ b/core/app/models/spree/tax_category.rb
@@ -9,7 +9,7 @@ module Spree
     end
 
     validates :name, presence: true
-    validates_uniqueness_of :name, unless: :deleted_at
+    validates_uniqueness_of :name, case_sensitive: true, unless: :deleted_at
 
     has_many :tax_rate_tax_categories,
       class_name: 'Spree::TaxRateTaxCategory',

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -74,7 +74,7 @@ module Spree
 
     validates :cost_price, numericality: { greater_than_or_equal_to: 0, allow_nil: true }
     validates :price,      numericality: { greater_than_or_equal_to: 0, allow_nil: true }
-    validates_uniqueness_of :sku, allow_blank: true, if: :enforce_unique_sku?
+    validates_uniqueness_of :sku, allow_blank: true, case_sensitive: true, if: :enforce_unique_sku?
 
     after_create :create_stock_items
     after_create :set_position

--- a/core/app/models/spree/zone.rb
+++ b/core/app/models/spree/zone.rb
@@ -13,7 +13,7 @@ module Spree
     has_many :shipping_method_zones, dependent: :destroy
     has_many :shipping_methods, through: :shipping_method_zones
 
-    validates :name, presence: true, uniqueness: { allow_blank: true }
+    validates :name, presence: true, uniqueness: { allow_blank: true, case_sensitive: true }
     after_save :remove_defunct_members
 
     scope :with_member_ids, ->(state_ids, country_ids) do


### PR DESCRIPTION
**Description**

This will fix the following deprecation warning

```
DEPRECATION WARNING: Uniqueness validator will no longer enforce case
sensitive comparison in Rails 6.1. To continue case sensitive comparison
on the :attr attribute in Model model, pass `case_sensitive: true`
option explicitly to the uniqueness validator.
```

Please note that this is not needed for non-text columns since this option is ignored in that case, see:

https://github.com/rails/rails/blob/5665d0867bb34b941db778630d558c7694bb1506/activerecord/lib/active_record/validations/uniqueness.rb#L143-L144

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- ~[ ] I have updated Guides and README accordingly to this change (if needed)~
- ~[ ] I have added tests to cover this change (if needed)~
- ~[ ] I have attached screenshots to this PR for visual changes (if needed)~
