### PR TITLE
Remove non-existing middleware

### DIFF
--- a/backend/lib/spree/backend/engine.rb
+++ b/backend/lib/spree/backend/engine.rb
@@ -5,8 +5,6 @@ require 'spree/backend/config'
 module Spree
   module Backend
     class Engine < ::Rails::Engine
-      config.middleware.use "Spree::Backend::Middleware::SeoAssist"
-
       # Leave initializer empty for backwards-compatability. Other apps
       # might still rely on this event.
       initializer "spree.backend.environment", before: :load_config_initializers do; end


### PR DESCRIPTION
Am I missing something? This middleware does not exist and therefore cannot be loaded.
It should be here, right? https://github.com/solidusio/solidus/tree/master/backend/lib/spree/backend
On the other side, the Frontend one is present: https://github.com/solidusio/solidus/tree/master/frontend/lib/spree/frontend/middleware

This instruction makes the installation of solidus_backend fail. 😢 
