### PR TITLE
[Events] Add subscribers automatically

### DIFF
--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -47,6 +47,7 @@ module Spree
       # Setup Event Subscribers
       initializer 'spree.core.initialize_subscribers' do |app|
         app.reloader.to_prepare do
+          Spree::Event.require_subscriber_files
           Spree::Event.subscribers.each(&:subscribe!)
         end
 

--- a/core/lib/spree/event.rb
+++ b/core/lib/spree/event.rb
@@ -26,6 +26,30 @@ module Spree
       end
     end
 
+    # Loads all Solidus' core and application's event subscribers files.
+    # The latter are loaded automatically only when the preference
+    # Spree::Config.events.autoload_subscribers is set to a truthy value.
+    #
+    # Files must be placed under the directory `app/subscribers` and their
+    # name must end with `_subscriber.rb`.
+    #
+    # Loading the files has the side effect of adding their module to the
+    # list in Spree::Event.subscribers.
+    def require_subscriber_files
+      pattern = "app/subscribers/**/*_subscriber.rb"
+
+      # Load Solidus subscribers
+      # rubocop:disable Rails/DynamicFindBy
+      solidus_core_dir = Gem::Specification.find_by_name('solidus_core').gem_dir
+      # rubocop:enable Rails/DynamicFindBy
+      Dir.glob(File.join(solidus_core_dir, pattern)) { |c| require_dependency(c.to_s) }
+
+      # Load application subscribers, only when the flag is set to true:
+      if Spree::Config.events.autoload_subscribers
+        Rails.root.glob(pattern) { |c| require_dependency(c.to_s) }
+      end
+    end
+
     # Subscribe to an event with the given name. The provided block is executed
     # every time the subscribed event is fired.
     #

--- a/core/lib/spree/event/configuration.rb
+++ b/core/lib/spree/event/configuration.rb
@@ -11,7 +11,11 @@ module Spree
         end
       end
 
-      attr_writer :adapter, :suffix
+      attr_writer :adapter, :suffix, :autoload_subscribers
+
+      def autoload_subscribers
+        @autoload_subscribers.nil? ? true : !!@autoload_subscribers
+      end
 
       def adapter
         @adapter ||= Spree::Event::Adapters::ActiveSupportNotifications

--- a/core/lib/spree/event/configuration.rb
+++ b/core/lib/spree/event/configuration.rb
@@ -6,9 +6,7 @@ module Spree
   module Event
     class Configuration
       def subscribers
-        @subscribers ||= ::Spree::Core::ClassConstantizer::Set.new.tap do |set|
-          set << 'Spree::MailerSubscriber'
-        end
+        @subscribers ||= ::Spree::Core::ClassConstantizer::Set.new
       end
 
       attr_writer :adapter, :suffix, :autoload_subscribers

--- a/core/lib/spree/event/subscriber.rb
+++ b/core/lib/spree/event/subscriber.rb
@@ -26,6 +26,8 @@ module Spree
 
         base.mattr_accessor :event_actions
         base.event_actions = {}
+
+        Spree::Event.subscribers << base.name
       end
 
       # Declares a method name in the including module that can be subscribed/unsubscribed

--- a/guides/source/developers/events/overview.html.md
+++ b/guides/source/developers/events/overview.html.md
@@ -95,10 +95,18 @@ method allows to map a method of the subscriber module to an event that
 happens in the system. If the `event_name` argument is not specified,
 the event name and the method name should match.
 
-These subscribers modules are loaded with the rest of your application but
-you need to manually subscribe to them.
+These subscriber modules are loaded with the rest of your application, you
+don't need to manually subscribe them when:
 
-For example, you could subscribe to them programmatically with something like:
+* `Spree::Config.events.autoload_subscribers` returns a truthy value (default);
+* you put them in the directory (or any subdirectory of) `app/subscribers`;
+* their filename ends with `_subscriber.rb`;
+
+On the other hand, if you need to resort to manual subscription because you did
+not follow the naming convention explained above, or you prefer to have complete
+control on what is loaded and when, you can override the default behaviour by
+setting `Spree::Config.events.autoload_subscribers = false` in a initializer.
+At that point you can subscribe your event subscribers, with something similar to:
 
 ```ruby
 if defined?(SmsLibrary)


### PR DESCRIPTION
**Description**

_(This PR is based on some work done by @elia and @AlessioRocco for [Meundies](https://github.com/meundies))_

Until now, adding subscribers to `Spree::Event.subscribers` was developers' responsibility.

This PR aims at automating the task by making Rails load subscriber files located in standard paths both in Solidus core and in the store app during the Rails initialization processs. When each file is required, it's now also added to the `Spree::Event.subscribers` list.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
