### PR TITLE
API uploads images via URL

### DIFF
--- a/api/openapi/api.oas2.yml
+++ b/api/openapi/api.oas2.yml
@@ -5885,6 +5885,7 @@ definitions:
         type: string
       attachment:
         type: string
+        description: 'This field can be used to pass an image URL. When used in this manner, the image undergoes the standard post upload processing via paperclip.'
       position:
         type: integer
       viewable_type:

--- a/api/spec/requests/spree/api/images_controller_spec.rb
+++ b/api/spec/requests/spree/api/images_controller_spec.rb
@@ -32,6 +32,22 @@ module Spree
         end.to change(Image, :count).by(1)
       end
 
+      it 'can upload a new image from a valid URL' do
+        expect do
+          post spree.api_product_images_path(product.id), params: {
+            image: {
+              attachment: 'https://github.com/solidusio/brand/raw/1827e7afb7ebcf5a1fc9cf7bf6cf9d277183ef11/PNG/solidus-logo-dark.png',
+              viewable_type: 'Spree::Variant',
+              viewable_id: product.master.to_param,
+              alt: 'just a test'
+            },
+          }
+          expect(response.status).to eq(201)
+          expect(json_response).to have_attributes(attributes)
+          expect(json_response[:alt]).to eq('just a test')
+        end.to change(Image, :count).by(1)
+      end
+
       context "working with an existing product image" do
         let!(:product_image) { product.master.images.create!(attachment: image('thinking-cat.jpg')) }
 
@@ -67,6 +83,20 @@ module Spree
           expect(response.status).to eq(200)
           expect(json_response).to have_attributes(attributes)
           expect(product_image.reload.position).to eq(2)
+        end
+
+        it "can update image URL" do
+          expect(product_image.position).to eq(1)
+          put spree.api_variant_image_path(product.master.id, product_image), params: {
+            image: {
+              position: 2,
+              attachment: 'https://github.com/solidusio/brand/raw/1827e7afb7ebcf5a1fc9cf7bf6cf9d277183ef11/PNG/solidus-logo-dark.png'
+            },
+          }
+          expect(response.status).to eq(200)
+          expect(json_response).to have_attributes(attributes)
+          expect(product_image.reload.position).to eq(2)
+          expect(product_image.reload.attachment_height).to eq(420)
         end
 
         it "can delete an image" do


### PR DESCRIPTION
**Description**
<!--
  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

  Please include screenshots in case of visual changes to the frontend or backend sections of Solidus.

  If needed you can reference another PR or issue here, e.g.:
  Ref #ISSUE
-->
This enhancement give the images API the ability to create images from URLs.  A
simple check determines whether or not the attachment parameter is a URL.  If it
is a URL, OpenURI is used to download the image and it subsequently undergoes
the standard post upload processing (via paperclip).  If it is not a URL, then
the attachment parameter is handled in the same manner it was prior to this
commit.

Fixes #3572

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
