### PR TITLE
[Backend] Handle errors and flash messages editing a taxon

### DIFF
--- a/api/spec/requests/spree/api/taxons_controller_spec.rb
+++ b/api/spec/requests/spree/api/taxons_controller_spec.rb
@@ -189,7 +189,7 @@ module Spree
       end
 
       it "cannot create a new taxon with invalid attributes" do
-        post spree.api_taxonomy_taxons_path(taxonomy), params: { taxon: { foo: :bar } }
+        post spree.api_taxonomy_taxons_path(taxonomy), params: { taxon: { name: '' } }
         expect(response.status).to eq(422)
         expect(json_response["error"]).to eq("Invalid resource. Please fix errors and try again.")
 

--- a/backend/app/controllers/spree/admin/taxons_controller.rb
+++ b/backend/app/controllers/spree/admin/taxons_controller.rb
@@ -62,7 +62,13 @@ module Spree
         end
 
         respond_with(@taxon) do |format|
-          format.html { redirect_to edit_admin_taxonomy_url(@taxonomy) }
+          format.html do
+            if @taxon.valid?
+              redirect_to edit_admin_taxonomy_url(@taxonomy)
+            else
+              render :edit
+            end
+          end
         end
       end
 


### PR DESCRIPTION
## Description
If there was any error when trying to edit a taxon, it
was not showing any error and just redirecting to taxons index,
this change renders edit form showing errors correctly instead
of just redirect without any flash message.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
