### PR TITLE
Making simple coordinator insufficient stock to include a message

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -26,7 +26,14 @@ module Spree
     include Spree::Order::Checkout
     include Spree::Order::Payments
 
-    class InsufficientStock < StandardError; end
+    class InsufficientStock < StandardError
+      attr_reader :items
+
+      def initialize(message = nil, items: {})
+        @items = items
+        super message
+      end
+    end
     class CannotRebuildShipments < StandardError; end
 
     extend Spree::DisplayMoney

--- a/core/app/models/spree/stock/simple_coordinator.rb
+++ b/core/app/models/spree/stock/simple_coordinator.rb
@@ -51,9 +51,7 @@ module Spree
         # Allocate any available on hand inventory and remaining desired inventory from backorders
         on_hand_packages, backordered_packages, leftover = @allocator.allocate_inventory(@desired)
 
-        unless leftover.empty?
-          raise Spree::Order::InsufficientStock
-        end
+        raise Spree::Order::InsufficientStock.new(items: leftover.quantities) unless leftover.empty?
 
         packages = @stock_locations.map do |stock_location|
           # Combine on_hand and backorders into a single package per-location

--- a/core/spec/models/spree/stock/simple_coordinator_spec.rb
+++ b/core/spec/models/spree/stock/simple_coordinator_spec.rb
@@ -129,6 +129,14 @@ module Spree
           it "raises exception" do
             expect{ shipments }.to raise_error(Spree::Order::InsufficientStock)
           end
+
+          it 'raises exception and includes unfulfillable items' do
+            begin
+              expect(shipments).not_to be_empty
+            rescue Spree::Order::InsufficientStock => e
+              expect(e.items.keys.map(&:id)).to contain_exactly(variant.id)
+            end
+          end
         end
 
         context 'with no stock locations' do


### PR DESCRIPTION
It is hard to know what items were the ones that were
unavailable, this change includes item names that
were unable to be fullfilled, then this message
can be used in the frontend easily.

What do you think about this?

I saw that the frontend does some complex code to achieve kind of the same [here](https://github.com/solidusio/solidus/blob/99c6ba9537526d11b255a58facffbb8cf328767f/frontend/app/controllers/spree/checkout_controller.rb#L251)


**Checklist:**
- [ ] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [ ] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
