### PR TITLE
Backend: more robust update_positions for resource controller

### DIFF
--- a/backend/app/controllers/spree/admin/resource_controller.rb
+++ b/backend/app/controllers/spree/admin/resource_controller.rb
@@ -76,7 +76,7 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
   def update_positions
     ActiveRecord::Base.transaction do
       params[:positions].each do |id, index|
-        model_class.find(id).set_list_position(index)
+        model_class.find_by(id: id)&.set_list_position(index)
       end
     end
 

--- a/backend/spec/controllers/spree/admin/resource_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/resource_controller_spec.rb
@@ -197,5 +197,17 @@ describe Spree::Admin::WidgetsController, type: :controller do
     it 'updates the position of widget 2' do
       expect { subject }.to change { widget_2.reload.position }.from(2).to(1)
     end
+
+    context 'passing a not persisted item' do
+      subject do
+        post :update_positions, params: { id: widget_1.to_param,
+          positions: { widget_1.id => '2', widget_2.id => '1', 'widget' => '3' }, format: 'js' }
+      end
+
+      it 'only updates the position of persisted attributes' do
+        subject
+        expect(Widget.all.order('position')).to eq [widget_2, widget_1]
+      end
+    end
   end
 end


### PR DESCRIPTION
The persisted product_properties should be sortable per product. this did not work.

Reason:
It did not work because the non persistent dom_id's from the product property table pollutes the param string in the following way:

```
Parameters: {"positions"=>{"89"=>"1", "90"=>"2", "property"=>"3"}, "product_id"=>"ruby-hoodie"}
```

The dom_id helper used for sorting creates "spree_new_product_property" for the non persistent items table row. this is converted to the param `"property"=>"3"` above when positions are updated.
The default update_positions method from resources_controller rolls back the transaction so the position update does not work.

Possible Solutions where:

1. remove the creation of an id at all in the view. But i thought this wasn't a good option.

2. Override the update_positions method of the ProductPropertiesController (like its already done in the OptionTypesController).

i did the latter.