### PR TITLE
Make Payment#gateway_order_id public

### DIFF
--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -117,6 +117,11 @@ module Spree
         options
       end
 
+      # The unique identifier to be passed in to the payment gateway
+      def gateway_order_id
+        "#{order.number}-#{number}"
+      end
+
       private
 
       def process_authorization
@@ -218,11 +223,6 @@ module Spree
 
         logger.error("#{I18n.t('spree.gateway_error')}: #{log}")
         raise Core::GatewayError.new(message)
-      end
-
-      # The unique identifier to be passed in to the payment gateway
-      def gateway_order_id
-        "#{order.number}-#{number}"
       end
 
       # The gateway response information without the params since the params


### PR DESCRIPTION
This method, although in Solidus codebase is currently called only by the class that defines it, can be useful in other scenarios (for example when one wants to use it outside the standard Solidus payment creation flow) so it should be public.

Also, it represents information that is not consumed only inside the `Spree::Payment` model, but ends up stored externally on the payment provider backend.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
