### PR TITLE
Do not display non-eligible adjustments in the admin cart overview

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/views/order/details_adjustments.js
+++ b/backend/app/assets/javascripts/spree/backend/views/order/details_adjustments.js
@@ -10,11 +10,7 @@ Spree.Views.Order.DetailsAdjustments = Backbone.View.extend({
     collection
       .map(function(item) {
         return (item.get("adjustments") || [])
-          .filter(function(adjustment) {
-            if (adjustment.eligible === true) {
-              return adjustment;
-            }
-          });
+          .filter(function(adjustment) { return (adjustment.eligible === true); });
       })
       .flatten(true)
       .each(function(adjustment){

--- a/backend/app/assets/javascripts/spree/backend/views/order/details_adjustments.js
+++ b/backend/app/assets/javascripts/spree/backend/views/order/details_adjustments.js
@@ -8,7 +8,14 @@ Spree.Views.Order.DetailsAdjustments = Backbone.View.extend({
     var totals = {};
     var collection = this.collection ? this.collection.chain() : _.chain([this.model]);
     collection
-      .map(function(item){ return item.get("adjustments") || [] })
+      .map(function(item) {
+        return (item.get("adjustments") || [])
+          .filter(function(adjustment) {
+            if (adjustment.eligible === true) {
+              return adjustment;
+            }
+          });
+      })
       .flatten(true)
       .each(function(adjustment){
         var label = adjustment.label;

--- a/backend/spec/features/admin/orders/adjustments_spec.rb
+++ b/backend/spec/features/admin/orders/adjustments_spec.rb
@@ -21,6 +21,7 @@ describe "Adjustments", type: :feature do
   let(:tax_category) { create(:tax_category) }
   let(:variant) { create(:variant, tax_category: tax_category) }
 
+  let!(:non_eligible_adjustment) { order.adjustments.create!(order: order, label: 'Non-Eligible', amount: 10, eligible: false) }
   let!(:adjustment) { order.adjustments.create!(order: order, label: 'Rebate', amount: 10) }
 
   before(:each) do
@@ -40,8 +41,11 @@ describe "Adjustments", type: :feature do
       end
     end
 
-    it "only shows eligible adjustments" do
-      expect(page).not_to have_content("ineligible")
+    it "shows both eligible and non-eligible adjustments" do
+      expect(page).to have_content("Rebate")
+      expect(page).to have_content("Non-Eligible")
+      expect(find('tr', text: 'Rebate')[:class]).not_to eq('adjustment-ineligible')
+      expect(find('tr', text: 'Non-Eligible')[:class]).to eq('adjustment-ineligible')
     end
   end
 

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -225,6 +225,21 @@ describe "Order Details", type: :feature, js: true do
         end
       end
 
+      context "with adjustments" do
+        let(:order) do
+          super().tap do |o|
+            o.adjustments.create!(order: order, label: 'Non-Eligible', amount: 10, eligible: false)
+            o.adjustments.create!(order: order, label: 'Rebate', amount: 10)
+          end
+        end
+
+        it "shows only eligible adjustments" do
+          visit spree.cart_admin_order_path(order)
+          expect(page).to have_content("Rebate")
+          expect(page).not_to have_content("Non-Eligible")
+        end
+      end
+
       context "variant doesn't track inventory" do
         let(:track_inventory) { false }
         let(:backorderable) { false }


### PR DESCRIPTION
See #2860 and #2484 .
This PR tackles the points discussed in the previous PR from 2018.
In particular it adds a regression test for the issue.
It also improves another test, since it was testing nothing