### PR TITLE
Remove Deface overrides initializer

### DIFF
--- a/core/lib/generators/solidus/install/install_generator.rb
+++ b/core/lib/generators/solidus/install/install_generator.rb
@@ -93,15 +93,6 @@ module Solidus
         end
       end
     end
-
-    # Load application's view overrides
-    initializer 'spree.overrides' do |app|
-      config.to_prepare do
-        Dir.glob(Rails.root.join('app/overrides/*.rb')) do |path|
-          require_dependency(path)
-        end
-      end
-    end
       RUBY
 
       if !options[:enforce_available_locales].nil?


### PR DESCRIPTION
**Description**

Removes the `spree.overrides` initializer added by our installer. Since Deface [already loads all files in `app/overrides`](https://github.com/spree/deface/blob/475d689ba93169ea9725dbf203c21534344efd58/lib/deface/environment.rb#L82), there's no need for us to also load them.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
