### PR TITLE
[API] Remove country and state input from address-input doc

### DIFF
--- a/api/openapi/api.oas2.yml
+++ b/api/openapi/api.oas2.yml
@@ -5644,24 +5644,6 @@ definitions:
         type: string
       company:
         type: string
-      country:
-        type: object
-        properties:
-          iso:
-            type: string
-          name:
-            type: string
-          iso3:
-            type: string
-          iso_name:
-            type: string
-      state:
-        type: object
-        properties:
-          name:
-            type: string
-          abbr:
-            type: string
   line-item-input:
     type: object
     title: Line item input


### PR DESCRIPTION
**Description**
Currently, the [api doc](https://solidus.docs.stoplight.io/api-reference/addresses/update-order-address#request-body) is showing `country` and `state` objects as part of the `bill/ship_address` request body:

<img width="950" alt="Screenshot 2020-04-17 at 12 16 13" src="https://user-images.githubusercontent.com/8694436/79559117-79399f00-80a5-11ea-9b74-1d99d5b4166f.png">

`address-input` already includes `state_id` and `country_id` associations.
`Spree::Order` accepts nested attributes for `bill_address` and `ship_address` and never expects a `country` or `state` hash attributes.


**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
