### PR TITLE
Add missing link to RMAs docs in Inventory overview

### DIFF
--- a/guides/source/developers/inventory/overview.html.md
+++ b/guides/source/developers/inventory/overview.html.md
@@ -121,4 +121,5 @@ for many reasons.
 For more information, see the [Returns][returns]
 documentation.
 
+[return-authorizations]: ../returns/return-authorizations.html
 [returns]: ../returns/overview.html


### PR DESCRIPTION
This adds a missing link in [Inventory overview docs](https://guides.solidus.io/developers/inventory/overview.html):

![image](https://user-images.githubusercontent.com/97211/79590317-2082fa00-80d7-11ea-91d9-1cabd66e0cbf.png)

Preview of the fixed version:
https://deploy-preview-3590--solidus-guides.netlify.app/developers/inventory/overview.html

**Checklist:**
- [ ] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [ ] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
