### PR TITLE
Do not pass non persistent new records when sorting tables by removing non numeric ids

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/components/sortable_table.js
+++ b/backend/app/assets/javascripts/spree/backend/components/sortable_table.js
@@ -15,7 +15,9 @@ Spree.ready(function() {
           var idAttr = el.id;
           if (idAttr) {
             var objId = idAttr.split('_').slice(-1);
-            positions['positions['+objId+']'] = index + 1;
+            if (!isNaN(objId)) {
+              positions['positions['+objId+']'] = index + 1;
+            }
           }
         });
         Spree.ajax({


### PR DESCRIPTION
In addition to #3581:

Sorting Tables in Backend: params for non-persisted records in the JS code that makes the ajax request are skipped.

