### PR TITLE
Bump required Ruby version to 2.5

### DIFF
--- a/api/solidus_api.gemspec
+++ b/api/solidus_api.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
     f.match(%r{^(spec|script)/})
   end
 
-  s.required_ruby_version = '>= 2.4.0'
+  s.required_ruby_version = '>= 2.5.0'
   s.required_rubygems_version = '>= 1.8.23'
 
   s.add_dependency 'jbuilder', '~> 2.8'

--- a/backend/solidus_backend.gemspec
+++ b/backend/solidus_backend.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
     f.match(%r{^(spec|script)/})
   end
 
-  s.required_ruby_version = '>= 2.4.0'
+  s.required_ruby_version = '>= 2.5.0'
   s.required_rubygems_version = '>= 1.8.23'
 
   s.add_dependency 'solidus_api', s.version

--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
     f.match(%r{^(spec|script)/})
   end
 
-  s.required_ruby_version = '>= 2.4.0'
+  s.required_ruby_version = '>= 2.5.0'
   s.required_rubygems_version = '>= 1.8.23'
 
   %w[

--- a/frontend/solidus_frontend.gemspec
+++ b/frontend/solidus_frontend.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
     f.match(%r{^(spec|script)/})
   end
 
-  s.required_ruby_version = '>= 2.4.0'
+  s.required_ruby_version = '>= 2.5.0'
   s.required_rubygems_version = '>= 1.8.23'
 
   s.add_dependency 'solidus_api', s.version

--- a/sample/solidus_sample.gemspec
+++ b/sample/solidus_sample.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
     f.match(%r{^(spec|script)/})
   end
 
-  s.required_ruby_version = '>= 2.4.0'
+  s.required_ruby_version = '>= 2.5.0'
   s.required_rubygems_version = '>= 1.8.23'
 
   s.add_dependency 'solidus_core', s.version

--- a/solidus.gemspec
+++ b/solidus.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir['README.md', 'lib/**/*']
 
-  s.required_ruby_version = '>= 2.4.0'
+  s.required_ruby_version = '>= 2.5.0'
   s.required_rubygems_version = '>= 1.8.23'
 
   s.add_dependency 'solidus_api', s.version


### PR DESCRIPTION
Support for Ruby 2.4 has been ended, to make sure we keep up with
the supported ruby versions this commit bumps the required Ruby version
to >= 2.5.0

https://www.ruby-lang.org/en/news/2020/04/05/support-of-ruby-2-4-has-ended/

**Description**
<!--
  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

  Please include screenshots in case of visual changes to the frontend or backend sections of Solidus.

  If needed you can reference another PR or issue here, e.g.:
  Ref #ISSUE
-->

**Checklist:**
- [ ] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [ ] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
