### PR TITLE
Show only active promotions filter

### DIFF
--- a/backend/app/views/spree/admin/promotions/index.html.erb
+++ b/backend/app/views/spree/admin/promotions/index.html.erb
@@ -16,31 +16,38 @@
   <div data-hook="admin_promotions_index_search">
     <%= search_form_for [:admin, @search] do |f| %>
       <div class="row">
-        <div class="col-3">
+        <div class="col-4">
           <div class="field">
             <%= label_tag :q_name_cont, Spree::Promotion.human_attribute_name(:name) %>
             <%= f.text_field :name_cont, tabindex: 1 %>
           </div>
         </div>
 
-        <div class="col-3">
+        <div class="col-2">
           <div class="field">
             <%= label_tag :q_codes_value_cont, Spree::Promotion.human_attribute_name(:code) %>
             <%= f.text_field :codes_value_cont, tabindex: 1 %>
           </div>
         </div>
 
-        <div class="col-3">
+        <div class="col-2">
           <div class="field">
             <%= label_tag :q_path_cont, Spree::Promotion.human_attribute_name(:path) %>
             <%= f.text_field :path_cont, tabindex: 1 %>
           </div>
         </div>
 
-        <div class="col-3">
+        <div class="col-2">
           <div class="field">
             <%= label_tag :q_promotion_category_id_eq, Spree::PromotionCategory.model_name.human %><br>
             <%= f.collection_select(:promotion_category_id_eq, @promotion_categories, :id, :name, { include_blank: t('spree.match_choices.all') }, { class: 'custom-select fullwidth' }) %>
+          </div>
+        </div>
+
+        <div class="col-2">
+          <div class="field">
+            <%= label_tag :active, t('spree.active') %><br>
+            <%= f.check_box :active, label: false, as: :boolean, checked_value: true %>
           </div>
         </div>
       </div>

--- a/backend/spec/controllers/spree/admin/promotions_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/promotions_controller_spec.rb
@@ -7,6 +7,7 @@ describe Spree::Admin::PromotionsController, type: :controller do
 
   let!(:promotion1) { create(:promotion, name: "name1", code: "code1", path: "path1") }
   let!(:promotion2) { create(:promotion, name: "name2", code: "code2", path: "path2") }
+  let!(:promotion3) { create(:promotion, name: "name2", code: "code3", path: "path3", expires_at: Date.yesterday) }
   let!(:category) { create :promotion_category }
 
   describe "#show" do
@@ -19,7 +20,7 @@ describe Spree::Admin::PromotionsController, type: :controller do
   describe "#index" do
     it "succeeds" do
       get :index
-      expect(assigns[:promotions]).to match_array [promotion2, promotion1]
+      expect(assigns[:promotions]).to match_array [promotion3, promotion2, promotion1]
     end
 
     it "assigns promotion categories" do
@@ -30,7 +31,7 @@ describe Spree::Admin::PromotionsController, type: :controller do
     context "search" do
       it "pages results" do
         get :index, params: { per_page: '1' }
-        expect(assigns[:promotions]).to eq [promotion2]
+        expect(assigns[:promotions]).to eq [promotion3]
       end
 
       it "filters by name" do
@@ -46,6 +47,11 @@ describe Spree::Admin::PromotionsController, type: :controller do
       it "filters by path" do
         get :index, params: { q: { path_cont: promotion1.path } }
         expect(assigns[:promotions]).to eq [promotion1]
+      end
+
+      it "filters by active" do
+        get :index, params: { q: { active: true } }
+        expect(assigns[:promotions]).to match_array [promotion2, promotion1]
       end
     end
   end

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -48,6 +48,9 @@ module Spree
 
     self.whitelisted_ransackable_associations = ['codes']
     self.whitelisted_ransackable_attributes = %w[name path promotion_category_id]
+    def self.ransackable_scopes(*)
+      %i(active)
+    end
 
     def self.order_activatable?(order)
       order && !UNACTIVATABLE_ORDER_STATES.include?(order.state)


### PR DESCRIPTION
**Description**
This adds active as a ransackable scope to be used in the admin search. 

Motivation is that for stores that have a large number of promotions build up, and it is helpful to just see what is active. This is helpful to make sure old/test promotions aren't mistakenly enabled, as they can be costly if not monitored closely. 

Standard scope:
![image](https://user-images.githubusercontent.com/1048873/80297783-6e8da280-8754-11ea-93d7-b11c69b89c8b.png)

Active filter enabled:
![image](https://user-images.githubusercontent.com/1048873/80297758-4140f480-8754-11ea-91f7-63364822c345.png)

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
