### PR TITLE
2777 inactive actionless promotions

### DIFF
--- a/core/app/models/spree/promotion_handler/coupon.rb
+++ b/core/app/models/spree/promotion_handler/coupon.rb
@@ -13,9 +13,9 @@ module Spree
 
       def apply
         if coupon_code.present?
-          if promotion.present? && promotion.actions.exists?
+          if promotion.present? && promotion.active? && promotion.actions.exists?
             handle_present_promotion(promotion)
-          elsif promotion_code && promotion_code.promotion.inactive?
+          elsif promotion_code&.promotion&.expired?
             set_error_code :coupon_code_expired
           else
             set_error_code :coupon_code_not_found

--- a/core/lib/generators/solidus/install/templates/config/initializers/spree.rb.tt
+++ b/core/lib/generators/solidus/install/templates/config/initializers/spree.rb.tt
@@ -34,6 +34,11 @@ Spree.config do |config|
   # See https://github.com/solidusio/solidus/pull/3456 for more info.
   config.raise_with_invalid_currency = false
 
+  # Set this configuration to `false` to allow promotions
+  # with no associated actions to be active for use by customers.
+  # See https://github.com/solidusio/solidus/issues/2777 for more info.
+  config.actionless_promotion_inactive = true
+
   # Set this configuration to `false` to avoid running validations when
   # updating an order. Be careful since you can end up having inconsistent
   # data in your database turning it on.

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -206,6 +206,10 @@ module Spree
     #   @return [Integer] Promotions to show per-page in the admin (default: +15+)
     preference :promotions_per_page, :integer, default: 15
 
+    # @!attribute [rw] disable_actionless_promotion_validation
+    #   @return [Boolean] Promotions should have actions associated before activation (default: +true+)
+    preference :actionless_promotion_inactive, :boolean, default: false
+
     # @!attribute [rw] raise_with_invalid_currency
     #   Whether to raise an exception if trying to set a line item currency
     #   different from the order currency. When false a validation error

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -64,7 +64,14 @@ module Spree
             caller
           )
         end
-
+        if Spree::Config.actionless_promotion_inactive == true
+          Spree::Deprecation.warn(
+            'Spree::Config.actionless_promotion_inactive set to false is ' \
+            'deprecated. Please note that by switching this value, ' \
+            'promotions with no actions will be active.',
+            caller
+          )
+        end
         if Spree::Config.run_order_validations_on_order_updater != true
           Spree::Deprecation.warn(
             'Spree::Config.run_order_validations_on_order_updater set to false is ' \

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -465,6 +465,9 @@ RSpec.describe Spree::Product, type: :model do
           products: [product]
         )
       end
+      before do
+        promotion.actions << Spree::Promotion::Actions::CreateAdjustment.new
+      end
 
       it "lists the promotion as a possible promotion" do
         expect(product.possible_promotions).to include(promotion)

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -347,6 +347,10 @@ RSpec.describe Spree::Promotion, type: :model do
   end
 
   context "#inactive" do
+    before do
+      promotion.actions << Spree::Promotion::Actions::CreateAdjustment.new
+    end
+
     it "should not be exipired" do
       expect(promotion).not_to be_inactive
     end


### PR DESCRIPTION
**Description**
This is a proposed solution to https://github.com/solidusio/solidus/issues/2777 where action-less promotions were considered active. As opposed to my original thought of implementing validation, given that there is no state toggle on the promotion that it would make sense to embrace the inferred state. So this implementation just causes a promotion to be considered inactive until it has actions, in addition to the other required material. Otherwise it is considered inactive. 

In the process I found the coupon promotion handler already treated action-less coupons as inactive, so I updated it to continue this behavior. 

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
