### PR TITLE
Remove a N+1 query on shipment model

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -262,7 +262,7 @@ module Spree
     def to_package
       package = Stock::Package.new(stock_location)
       package.shipment = self
-      inventory_units.includes(:variant).joins(:variant).group_by(&:state).each do |state, state_inventory_units|
+      inventory_units.includes(variant: :product).joins(:variant).group_by(&:state).each do |state, state_inventory_units|
         package.add_multiple state_inventory_units, state.to_sym
       end
       package


### PR DESCRIPTION
**Description**
In `to_package` method, I've added `product` to includes.
We have discovered that when we call `Spree::Stock::Estimator#calculate_shipping_rates` with a `shipment.to_package`, it currently makes a `product` DB query for each `variant`.
In our test, this subtle change has drastically reduced the number of queries to `product` by a factor equivalent to `variant` number.

Concerning the test to add, since I'm not very sure on how to proceed, I would like some guidance. (I've looked at estimator_spec and shipment_spec but since this issue arise when both are coupled, I'm not sure where is the place to start)

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
