### PR TITLE
Adding missing paginator when listing all stock locations

### DIFF
--- a/backend/app/controllers/spree/admin/stock_locations_controller.rb
+++ b/backend/app/controllers/spree/admin/stock_locations_controller.rb
@@ -13,6 +13,10 @@ module Spree
         flash[:error] = t('spree.stock_locations_need_a_default_country')
         redirect_to(admin_stock_locations_path) && return
       end
+
+      def collection
+        super.page(params[:page]).per(Spree::Config[:admin_products_per_page])
+      end
     end
   end
 end

--- a/backend/app/views/spree/admin/stock_locations/index.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/index.html.erb
@@ -16,6 +16,7 @@
 <% end %>
 
 <% if @stock_locations.any? %>
+  <%= paginate @stock_locations, theme: "solidus_admin" %>
   <table class="index sortable" id='listing_stock_locations' data-hook data-sortable-link="<%= update_positions_admin_stock_locations_url %>">
     <colgroup>
       <col style="width: 10%">
@@ -69,6 +70,7 @@
       <% end %>
     </tbody>
   </table>
+  <%= paginate @stock_locations, theme: "solidus_admin" %>
 <% else %>
   <div class="no-objects-found">
     <%= render 'spree/admin/shared/no_objects_found',


### PR DESCRIPTION
Current implementation only list all stock locations limited
by the defaulted per page value, but there's no way to navigate
to multiple pages.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
