### PR TITLE
Rescuing from ActiveRecord::RecordInvalid in ResourcesController

### DIFF
--- a/backend/app/controllers/spree/admin/resource_controller.rb
+++ b/backend/app/controllers/spree/admin/resource_controller.rb
@@ -6,6 +6,7 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
   helper_method :new_object_url, :edit_object_url, :object_url, :collection_url
   before_action :load_resource, except: :update_positions
   rescue_from ActiveRecord::RecordNotFound, with: :resource_not_found
+  rescue_from ActiveRecord::RecordInvalid, with: :resource_invalid
 
   respond_to :html
 
@@ -298,5 +299,20 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
 
   def render_after_update_error
     render action: 'edit'
+  end
+
+  def resource_invalid(exception)
+    invoke_callbacks(action, :fails)
+    respond_with(@object) do |format|
+      format.html do
+        flash.now[:error] = exception.message
+        if @object.new_record?
+          render_after_create_error
+        else
+          render_after_update_error
+        end
+      end
+      format.js { render layout: false }
+    end
   end
 end

--- a/backend/spec/controllers/spree/admin/resource_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/resource_controller_spec.rb
@@ -141,6 +141,17 @@ describe Spree::Admin::WidgetsController, type: :controller do
         expect(flash[:error]).to eq assigns(:widget).errors.full_messages.join(', ')
       end
     end
+
+    context 'resource invalid' do
+      before do
+        allow_any_instance_of(Widget).to receive(:update).and_raise(ActiveRecord::RecordInvalid)
+      end
+
+      it 'returns to edit page with error' do
+        put :update, params: params
+        expect(flash[:error]).to eq('Record invalid')
+      end
+    end
   end
 
   describe '#destroy' do


### PR DESCRIPTION
If for some reason, when creating/updating a record, it raises
record invalid exception, but resources controllers is not ready
to rescue from those exceptions, it just returns 422.

For example, when updating a product, if same taxon is added twice(for some reason) it returns a 422 page, because it raises record invalid exception from classifications, this change allows to handle that cases

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
