### PR TITLE
Replace Spree.routes with Spree.pathFor

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -93,6 +93,7 @@
     "Sortable": "readonly",
     "Spree": "readonly",
     "Turbolinks": "readonly",
-    "update_state": "writable"
+    "update_state": "writable",
+    "Proxy": "readonly"
   }
 }

--- a/backend/app/assets/javascripts/spree/backend/adjustments.js
+++ b/backend/app/assets/javascripts/spree/backend/adjustments.js
@@ -6,7 +6,7 @@ Spree.ready(function() {
 
     Spree.ajax({
       type: 'POST',
-      url: Spree.routes.apply_coupon_code(window.order_number),
+      url: Spree.pathFor('api/orders/' + window.order_number + '/coupon_codes'),
       data: {
         coupon_code: $("#coupon_code").val(),
         token: Spree.api_key

--- a/backend/app/assets/javascripts/spree/backend/admin.js
+++ b/backend/app/assets/javascripts/spree/backend/admin.js
@@ -131,7 +131,7 @@ Spree.ready(function(){
       data: {
         token: Spree.api_key
       },
-      url: Spree.routes.checkouts_api + "/" + window.order_number + "/advance"
+      url: Spree.pathFor('api/checkouts/' + window.order_number + '/advance')
     }).done(function() {
       window.location.reload();
     });

--- a/backend/app/assets/javascripts/spree/backend/collections/states.js
+++ b/backend/app/assets/javascripts/spree/backend/collections/states.js
@@ -4,7 +4,7 @@ Spree.Collections.States = Backbone.Collection.extend({
   },
 
   url: function () {
-    return Spree.routes.states_search + "?country_id=" + this.country_id
+    return Spree.pathFor('api/states?country_id=' + this.country_id)
   },
 
   parse: function(resp, options) {

--- a/backend/app/assets/javascripts/spree/backend/models/order.js
+++ b/backend/app/assets/javascripts/spree/backend/models/order.js
@@ -4,7 +4,7 @@
 //= require spree/backend/models/address
 
 Spree.Models.Order = Backbone.Model.extend({
-  urlRoot: Spree.routes.orders_api,
+  urlRoot: Spree.pathFor('api/orders'),
   idAttribute: "number",
 
   relations: {
@@ -16,7 +16,7 @@ Spree.Models.Order = Backbone.Model.extend({
 
   advance: function(opts) {
     var options = {
-      url: Spree.routes.checkouts_api + "/" + this.id + "/advance",
+      url: Spree.pathFor('api/checkouts/' + this.id + '/advance'),
       type: 'PUT',
     };
     _.extend(options, opts);
@@ -25,7 +25,7 @@ Spree.Models.Order = Backbone.Model.extend({
 
   empty: function (opts) {
     var options = {
-      url: Spree.routes.orders_api + "/" + this.id + "/empty",
+      url: Spree.pathFor('api/orders/' + this.id + '/empty'),
       type: 'PUT',
     };
     _.extend(options, opts);

--- a/backend/app/assets/javascripts/spree/backend/models/payment.js
+++ b/backend/app/assets/javascripts/spree/backend/models/payment.js
@@ -1,5 +1,5 @@
 Spree.Models.Payment = Backbone.Model.extend({
   urlRoot: function() {
-    return Spree.routes.payments_api(this.get('order_id'));
+    return Spree.pathFor('api/orders/' + this.get('order_id') + '/payments')
   }
 });

--- a/backend/app/assets/javascripts/spree/backend/models/shipment.js
+++ b/backend/app/assets/javascripts/spree/backend/models/shipment.js
@@ -1,7 +1,7 @@
 Spree.Models.Shipment = Backbone.Model.extend({
   idAttribute: "number",
   paramRoot: "shipment",
-  urlRoot: Spree.routes.shipments_api,
+  urlRoot: Spree.pathFor('api/shipments'),
 
   relations: {
     "selected_shipping_rate": Backbone.Model,

--- a/backend/app/assets/javascripts/spree/backend/models/stock_item.js
+++ b/backend/app/assets/javascripts/spree/backend/models/stock_item.js
@@ -1,6 +1,6 @@
 Spree.Models.StockItem = Backbone.Model.extend({
   paramRoot: 'stock_item',
   urlRoot: function() {
-    return Spree.routes.stock_items_api(this.get('stock_location_id'));
+    return Spree.pathFor('api/stock_locations/' + this.get('stock_location_id') + '/stock_items');
   }
 });

--- a/backend/app/assets/javascripts/spree/backend/option_type_autocomplete.js
+++ b/backend/app/assets/javascripts/spree/backend/option_type_autocomplete.js
@@ -11,7 +11,7 @@ Spree.ready(function () {
       multiple: true,
       initSelection: function (element, callback) {
         return Spree.ajax({
-          url: Spree.routes.option_type_search,
+          url: Spree.pathFor('api/option_types'),
           data: { ids: element.val() },
           type: 'get',
           success: function(data) {
@@ -20,7 +20,7 @@ Spree.ready(function () {
         });
       },
       ajax: {
-        url: Spree.routes.option_type_search,
+        url: Spree.pathFor('api/option_types'),
         quietMillis: 200,
         datatype: 'json',
         params: { "headers": {  'Authorization': 'Bearer ' + Spree.api_key } },

--- a/backend/app/assets/javascripts/spree/backend/option_value_picker.js
+++ b/backend/app/assets/javascripts/spree/backend/option_value_picker.js
@@ -14,7 +14,7 @@ $.fn.optionValueAutocomplete = function (options) {
     minimumInputLength: 3,
     multiple: multiple,
     initSelection: function (element, callback) {
-      $.get(Spree.routes.option_value_search, {
+      $.get(Spree.pathFor('api/option_values'), {
         ids: element.val().split(','),
         token: Spree.api_key
       }, function (data) {
@@ -22,7 +22,7 @@ $.fn.optionValueAutocomplete = function (options) {
       });
     },
     ajax: {
-      url: Spree.routes.option_value_search,
+      url: Spree.pathFor('api/option_values'),
       datatype: 'json',
       data: function (term, page) {
         // Note: This doesn't work. variants_product_id isn't an allowed filter

--- a/backend/app/assets/javascripts/spree/backend/product_picker.js
+++ b/backend/app/assets/javascripts/spree/backend/product_picker.js
@@ -13,7 +13,7 @@ $.fn.productAutocomplete = function (options) {
     minimumInputLength: 3,
     multiple: multiple,
     initSelection: function (element, callback) {
-      $.get(Spree.routes.admin_product_search, {
+      $.get(Spree.pathFor('admin/search/products'), {
         ids: element.val().split(','),
         token: Spree.api_key
       }, function (data) {
@@ -21,7 +21,7 @@ $.fn.productAutocomplete = function (options) {
       });
     },
     ajax: {
-      url: Spree.routes.admin_product_search,
+      url: Spree.pathFor('admin/search/products'),
       datatype: 'json',
       params: { "headers": {  'Authorization': 'Bearer ' + Spree.api_key } },
       data: function (term, page) {

--- a/backend/app/assets/javascripts/spree/backend/routes.js
+++ b/backend/app/assets/javascripts/spree/backend/routes.js
@@ -1,27 +1,46 @@
-Spree.routes.checkouts_api = Spree.pathFor('api/checkouts')
-Spree.routes.classifications_api = Spree.pathFor('api/classifications')
-Spree.routes.option_value_search = Spree.pathFor('api/option_values')
-Spree.routes.option_type_search = Spree.pathFor('api/option_types')
-Spree.routes.orders_api = Spree.pathFor('api/orders')
-Spree.routes.product_search = Spree.pathFor('api/products')
-Spree.routes.admin_product_search = Spree.pathFor('admin/search/products')
-Spree.routes.shipments_api = Spree.pathFor('api/shipments')
-Spree.routes.checkouts_api = Spree.pathFor('api/checkouts')
-Spree.routes.stock_locations_api = Spree.pathFor('api/stock_locations')
-Spree.routes.taxon_products_api = Spree.pathFor('api/taxons/products')
-Spree.routes.taxons_search = Spree.pathFor('api/taxons')
-Spree.routes.user_search = Spree.pathFor('admin/search/users')
-Spree.routes.variants_api = Spree.pathFor('api/variants')
-Spree.routes.users_api = Spree.pathFor('api/users')
+/**
+ * @deprecated Spree.routes will be removed in a future release. Please use Spree.pathFor instead.
+ * See: https://github.com/solidusio/solidus/issues/3405
+ */
 
-Spree.routes.line_items_api = function(order_id) {
-  return Spree.pathFor('api/orders/' + order_id + '/line_items')
+var admin_routes = {
+  classifications_api: Spree.pathFor('api/classifications'),
+  option_value_search: Spree.pathFor('api/option_values'),
+  option_type_search: Spree.pathFor('api/option_types'),
+  orders_api: Spree.pathFor('api/orders'),
+  product_search: Spree.pathFor('api/products'),
+  admin_product_search: Spree.pathFor('admin/search/products'),
+  shipments_api: Spree.pathFor('api/shipments'),
+  checkouts_api: Spree.pathFor('api/checkouts'),
+  stock_locations_api: Spree.pathFor('api/stock_locations'),
+  taxon_products_api: Spree.pathFor('api/taxons/products'),
+  taxons_search: Spree.pathFor('api/taxons'),
+  user_search: Spree.pathFor('admin/search/users'),
+  variants_api: Spree.pathFor('api/variants'),
+  users_api: Spree.pathFor('api/users'),
+
+  line_items_api: function(order_id) {
+    return Spree.pathFor('api/orders/' + order_id + '/line_items')
+  },
+
+  payments_api: function(order_id) {
+    return Spree.pathFor('api/orders/' + order_id + '/payments')
+  },
+
+  stock_items_api: function(stock_location_id) {
+    return Spree.pathFor('api/stock_locations/' + stock_location_id + '/stock_items')
+  }
 }
 
-Spree.routes.payments_api = function(order_id) {
-  return Spree.pathFor('api/orders/' + order_id + '/payments')
+var frontend_routes = {
+  states_search: Spree.pathFor('api/states'),
+  apply_coupon_code: function(order_id) {
+    return Spree.pathFor("api/orders/" + order_id + "/coupon_codes");
+  }
 }
 
-Spree.routes.stock_items_api = function(stock_location_id) {
-  return Spree.pathFor('api/stock_locations/' + stock_location_id + '/stock_items')
+if(typeof Proxy == "function") {
+  Spree.routes = new Proxy(Object.assign(admin_routes, frontend_routes), Spree.routesDeprecationProxy);
+} else {
+  Object.assign(Spree.routes, admin_routes)
 }

--- a/backend/app/assets/javascripts/spree/backend/shipments.js
+++ b/backend/app/assets/javascripts/spree/backend/shipments.js
@@ -11,7 +11,7 @@ var ShipShipmentView = Backbone.View.extend({
   onSubmit: function(e){
     Spree.ajax({
       type: "PUT",
-      url: Spree.routes.shipments_api + "/" + this.shipment_number + "/ship",
+      url: Spree.pathFor('api/shipments/' + this.shipment_number + '/ship'),
       data: {
         send_mailer: this.$("[name='send_mailer']").is(":checked")
       },
@@ -27,7 +27,7 @@ adjustShipmentItems = function(shipment_number, variant_id, quantity){
   var shipment = _.findWhere(shipments, {number: shipment_number});
   var inventory_units = _.where(shipment.inventory_units, {variant_id: variant_id});
 
-  var url = Spree.routes.shipments_api + "/" + shipment_number;
+  var url = Spree.pathFor('api/shipments/' + shipment_number);
 
   var new_quantity = 0;
   if(inventory_units.length<quantity){
@@ -106,7 +106,7 @@ var ShipmentSplitItemView = Backbone.View.extend({
       split_attr.stock_location_id = target_id;
       jqXHR = Spree.ajax({
         type: "POST",
-        url: Spree.routes.shipments_api + "/transfer_to_location",
+        url: Spree.pathFor('api/shipments/transfer_to_location'),
         data: split_attr
       });
     } else if (target_type == 'shipment') {
@@ -114,7 +114,7 @@ var ShipmentSplitItemView = Backbone.View.extend({
       split_attr.target_shipment_number = target_id;
       jqXHR = Spree.ajax({
         type: "POST",
-        url: Spree.routes.shipments_api + "/transfer_to_shipment",
+        url: Spree.pathFor('api/shipments/transfer_to_shipment'),
         data: split_attr
       });
     } else {
@@ -179,7 +179,7 @@ var ShipmentItemView = Backbone.View.extend({
     var _this = this;
     Spree.ajax({
       type: "GET",
-      url: Spree.routes.variants_api + "/" + this.variant_id,
+      url: Spree.pathFor('api/variants/' + this.variant_id),
     }).success(function(variant){
       var split = new ShipmentSplitItemView({
         shipmentItemView: _this,

--- a/backend/app/assets/javascripts/spree/backend/taxon_autocomplete.js
+++ b/backend/app/assets/javascripts/spree/backend/taxon_autocomplete.js
@@ -10,7 +10,7 @@ $.fn.taxonAutocomplete = function () {
 
         Spree.ajax({
           type: "GET",
-          url: Spree.routes.taxons_search,
+          url: Spree.pathFor('api/taxons'),
           data: {
             ids: ids,
             per_page: count,
@@ -22,7 +22,7 @@ $.fn.taxonAutocomplete = function () {
         });
       },
       ajax: {
-        url: Spree.routes.taxons_search,
+        url: Spree.pathFor('api/taxons'),
         datatype: 'json',
         data: function (term, page) {
           return {

--- a/backend/app/assets/javascripts/spree/backend/taxons.js
+++ b/backend/app/assets/javascripts/spree/backend/taxons.js
@@ -9,7 +9,7 @@ Spree.ready(function() {
   var saveSort = function(e) {
     var item = e.item;
     Spree.ajax({
-      url: Spree.routes.classifications_api,
+      url: Spree.pathFor('api/classifications'),
       method: 'PUT',
       data: {
         product_id: item.getAttribute('data-product-id'),
@@ -27,7 +27,7 @@ Spree.ready(function() {
     dropdownCssClass: "taxon_select_box",
     placeholder: Spree.translations.find_a_taxon,
     ajax: {
-      url: Spree.routes.taxons_search,
+      url: Spree.pathFor('api/taxons'),
       params: {
         "headers": {
           'Authorization': 'Bearer ' + Spree.api_key
@@ -55,7 +55,7 @@ Spree.ready(function() {
 
   $('#taxon_id').on("change", function(e) {
     Spree.ajax({
-      url: Spree.routes.taxon_products_api,
+      url: Spree.pathFor('api/taxons/products'),
       data: {
         id: e.val,
         simple: 1

--- a/backend/app/assets/javascripts/spree/backend/user_picker.js
+++ b/backend/app/assets/javascripts/spree/backend/user_picker.js
@@ -10,7 +10,7 @@ $.fn.userAutocomplete = function () {
     multiple: true,
     initSelection: function (element, callback) {
       Spree.ajax({
-        url: Spree.routes.users_api,
+        url: Spree.pathFor('api/users'),
         data: {
           ids: element.val()
         },
@@ -20,7 +20,7 @@ $.fn.userAutocomplete = function () {
       });
     },
     ajax: {
-      url: Spree.routes.users_api,
+      url: Spree.pathFor('api/users'),
       datatype: 'json',
       params: { "headers": {  'Authorization': 'Bearer ' + Spree.api_key } },
       data: function (term) {

--- a/backend/app/assets/javascripts/spree/backend/variant_autocomplete.js
+++ b/backend/app/assets/javascripts/spree/backend/variant_autocomplete.js
@@ -16,12 +16,12 @@
       minimumInputLength: 3,
       initSelection: function(element, callback) {
         Spree.ajax({
-          url: Spree.routes.variants_api + "/" + element.val(),
+          url: Spree.pathFor('api/variants/' + element.val()),
           success: callback
         });
       },
       ajax: {
-        url: Spree.routes.variants_api,
+        url: Spree.pathFor('api/variants'),
         datatype: "json",
         quietMillis: 500,
         params: {

--- a/backend/app/assets/javascripts/spree/backend/views/order/customer_select.js
+++ b/backend/app/assets/javascripts/spree/backend/views/order/customer_select.js
@@ -26,7 +26,7 @@ Spree.Views.Order.CustomerSelect = Backbone.View.extend({
     this.$el.select2({
       placeholder: Spree.translations.choose_a_customer,
       ajax: {
-        url: Spree.routes.users_api,
+        url: Spree.pathFor('api/users'),
         params: { "headers": {  'Authorization': 'Bearer ' + Spree.api_key } },
         datatype: 'json',
         data: function(term, page) {

--- a/core/app/assets/javascripts/spree.js.erb
+++ b/core/app/assets/javascripts/spree.js.erb
@@ -51,12 +51,41 @@ Spree.ajax = function(url, options) {
   return $.ajax(url, options);
 };
 
-Spree.routes = {
+/**
+ * @deprecated Spree.routes will be removed in a future release. Please use Spree.pathFor instead.
+ * See: https://github.com/solidusio/solidus/issues/3405
+ */
+Spree.routesDeprecationProxy = {
+  get: function(obj, prop) {
+    <% if Rails.env != "production" %>
+      console.log("Spree.routes is deprecated, please use pathFor instead. See: https://github.com/solidusio/solidus/issues/3405");
+    <% end %>
+
+    return obj[prop]
+  },
+
+  set: function(obj, prop, value) {
+    <% if Rails.env != "production" %>
+      console.log("Spree.routes is deprecated, please use pathFor instead. See: https://github.com/solidusio/solidus/issues/3405");
+    <% end %>
+
+    obj[prop] = value
+    return value;
+  }
+};
+
+var frontend_routes = {
   states_search: Spree.pathFor('api/states'),
   apply_coupon_code: function(order_id) {
     return Spree.pathFor("api/orders/" + order_id + "/coupon_codes");
   }
-};
+}
+
+if(typeof Proxy == "function") {
+  Spree.routes = new Proxy(frontend_routes, Spree.routesDeprecationProxy);
+} else {
+  Spree.routes = frontend_routes
+}
 
 Spree.getJSON = function(url, data, success) {
   if (typeof data === 'function') {

--- a/frontend/app/assets/javascripts/spree/frontend/checkout/address.js
+++ b/frontend/app/assets/javascripts/spree/frontend/checkout/address.js
@@ -14,7 +14,7 @@ Spree.ready(function($) {
       if (countryId != null) {
         if (statesByCountry[countryId] == null) {
           $.get(
-            Spree.routes.states_search,
+            Spree.pathFor('api/states'),
             {
               country_id: countryId
             },

--- a/frontend/app/assets/javascripts/spree/frontend/checkout/coupon-code.js
+++ b/frontend/app/assets/javascripts/spree/frontend/checkout/coupon-code.js
@@ -15,7 +15,7 @@ Spree.onCouponCodeApply = function(e) {
   };
   var req = Spree.ajax({
     method: 'POST',
-    url: Spree.routes.apply_coupon_code(Spree.current_order_id),
+    url: Spree.pathFor('api/orders/' + Spree.current_order_id + '/coupon_codes'),
     data: JSON.stringify(data),
     contentType: "application/json"
   });


### PR DESCRIPTION
**THIS PR SPONSORED BY [Super Good Software](https://supergood.software/)**

**Description**
This PR replaces all instances of Spree.routes with Spree.pathFor. Spree.routes still
exists, we're just preferring to use Spree.pathFor per #3405.

I've added some lines about deprecation to the JS files where Spree.routes live. We should probably output a warning message to console on use, but I'm not 100% sure what the best way to go about it is, since it's just a variable. How do you console.warn when calling a variable in Javascript? 🤔 If there's a good way to do this, please let me know and I'll add it in.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
