### PR TITLE
Fix specs on Rails master/6.1.0.alpha

### DIFF
--- a/api/lib/spree/api/testing_support/helpers.rb
+++ b/api/lib/spree/api/testing_support/helpers.rb
@@ -38,7 +38,7 @@ module Spree
         end
 
         def upload_image(filename)
-          fixture_file_upload(image(filename).path, 'image/jpg')
+          Rack::Test::UploadedFile.new(File.open(image(filename).path), 'image/jpg')
         end
       end
     end

--- a/core/lib/spree/core/product_filters.rb
+++ b/core/lib/spree/core/product_filters.rb
@@ -60,6 +60,7 @@ module Spree
         conds.each do |new_scope|
           scope = scope.or(new_scope)
         end
+
         Spree::Product.joins(master: :default_price).where(scope)
       end
 
@@ -70,9 +71,9 @@ module Spree
       def self.price_filter
         value = Spree::Price.arel_table
         conds = [[I18n.t('spree.under_price', price: format_price(10)), value[:amount].lteq(10)],
-                 ["#{format_price(10)} - #{format_price(15)}", value[:amount].in(10..15)],
-                 ["#{format_price(15)} - #{format_price(18)}", value[:amount].in(15..18)],
-                 ["#{format_price(18)} - #{format_price(20)}", value[:amount].in(18..20)],
+                 ["#{format_price(10)} - #{format_price(15)}", value[:amount].between(10..15)],
+                 ["#{format_price(15)} - #{format_price(18)}", value[:amount].between(15..18)],
+                 ["#{format_price(18)} - #{format_price(20)}", value[:amount].between(18..20)],
                  [I18n.t('spree.or_over_price', price: format_price(20)), value[:amount].gteq(20)]]
         {
           name:   I18n.t('spree.price_range'),

--- a/core/spec/lib/search/base_spec.rb
+++ b/core/spec/lib/search/base_spec.rb
@@ -11,12 +11,13 @@ RSpec.describe Spree::Core::Search::Base do
     @product1 = create(:product, name: "RoR Mug", price: 9.00)
     @product1.taxons << @taxon
     @product2 = create(:product, name: "RoR Shirt", price: 11.00)
+    @product3 = create(:product, name: "RoR Pants", price: 16.00)
   end
 
   it "returns all products by default" do
     params = { per_page: "" }
     searcher = Spree::Core::Search::Base.new(params)
-    expect(searcher.retrieve_products.count).to eq(2)
+    expect(searcher.retrieve_products.count).to eq(3)
   end
 
   context "when include_images is included in the initalization params" do
@@ -36,8 +37,6 @@ RSpec.describe Spree::Core::Search::Base do
   end
 
   it "switches to next page according to the page parameter" do
-    @product3 = create(:product, name: "RoR Pants", price: 14.00)
-
     params = { per_page: "2" }
     searcher = Spree::Core::Search::Base.new(params)
     expect(searcher.retrieve_products.count).to eq(2)
@@ -51,7 +50,6 @@ RSpec.describe Spree::Core::Search::Base do
     params = { per_page: "",
                search: { "price_range_any" => ["Under $10.00"] } }
     searcher = Spree::Core::Search::Base.new(params)
-    expect(searcher.send(:get_base_scope).to_sql).to match /<= 10/
     expect(searcher.retrieve_products.count).to eq(1)
   end
 
@@ -59,12 +57,6 @@ RSpec.describe Spree::Core::Search::Base do
     params = { per_page: "",
                search: { "price_range_any" => ["Under $10.00", "$10.00 - $15.00"] } }
     searcher = Spree::Core::Search::Base.new(params)
-    expect(searcher.send(:get_base_scope).to_sql).to match /<= 10/
-    if Rails.gem_version >= Gem::Version.new('6.0.0')
-      expect(searcher.send(:get_base_scope).to_sql).to match /between 10\.0 and 15\.0/i
-    else
-      expect(searcher.send(:get_base_scope).to_sql).to match /between 10 and 15/i
-    end
     expect(searcher.retrieve_products.count).to eq(2)
   end
 
@@ -72,7 +64,7 @@ RSpec.describe Spree::Core::Search::Base do
     params = { per_page: "",
                search: { "name_not_cont" => "Shirt" } }
     searcher = Spree::Core::Search::Base.new(params)
-    expect(searcher.retrieve_products.count).to eq(1)
+    expect(searcher.retrieve_products.count).to eq(2)
   end
 
   it "accepts a current user" do


### PR DESCRIPTION
**Description**

`Search::Base` specs started to fail  because `ActiveRecord`-generated SQL has changed in Rails master/6.1.0.alpha.
Generated SQL is bound to change and should not be used in expectations. Search results expectations now verify actual search output only.
When filtering on ranges `between` Arel operator must be used.
`in` operator implementation isn't converted anymore in a `between` SQL query, it
was a deprecated optimization now removed in rails/rails#39163

`Spree::Api::ImagesController` request specs started to fail because `ActionDispatch::TestProcess::FixtureFile#fixture_file_upload` has been changed in Rails master/6.1.0.alpha and rspec-rails is not compatible anymore with it.
`Rack::Test::UploadedFile` handles our use-case in the same away and doesn't have any compatibility issues.


**Checklist:**
- [X] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [X] I have added a detailed description into each commit message
- ~~[ ] I have updated Guides and README accordingly to this change (if needed)~~
- ~~[ ] I have added tests to cover this change (if needed)~~
- ~~[ ] I have attached screenshots to this PR for visual changes (if needed)~~
