### PR TITLE
Only perform regexes on Strings

### DIFF
--- a/core/lib/spree/preferences/preferable.rb
+++ b/core/lib/spree/preferences/preferable.rb
@@ -158,8 +158,7 @@ module Spree
           value.to_i
         when :boolean
           if !value ||
-             value == 0 ||
-             value =~ /\A(f|false|0)\Z/i ||
+             value.to_s =~ /\A(f|false|0|^)\Z/i ||
              (value.respond_to?(:empty?) && value.empty?)
             false
           else


### PR DESCRIPTION


**Description**
We were getting warnings from Ruby 2.7

warning: deprecated Object#=~ is called on TrueClass; it always returns
nil

In the case that true was passed in as a preference here we would try to
perform a regex on it and get nil from value =~ /<regex>/.

This meant that the conditional would not be met and this case would not
return false but instead return true.

This is the correct behaviour but it's pretty sketchy. We should not be
relying on what calling regex matching methods on things that aren't
strings return here.

Ref https://github.com/solidusio/solidus/issues/3611

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
