### PR TITLE
Fix in_taxons scope when taxon is an ActiveRecord::Base

### DIFF
--- a/core/app/models/spree/product/scopes.rb
+++ b/core/app/models/spree/product/scopes.rb
@@ -251,7 +251,7 @@ module Spree
               ids_or_records_or_names.flatten.map { |taxon|
                 case taxon
                 when Integer then Spree::Taxon.find_by(id: taxon)
-                when ActiveRecord::Base then t
+                when ActiveRecord::Base then taxon
                 when String
                   Spree::Taxon.find_by(name: taxon) ||
                     Spree::Taxon.where("#{taxons}.permalink LIKE ? OR #{taxons}.permalink = ?", "%/#{taxon}/", "#{taxon}/").first


### PR DESCRIPTION
**Description**

The variable has been missed in solidusio/solidus#3400

We also need to backport this in 2.10 and release a new version.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
