### PR TITLE
Allow to configure guest_token cookie options

### DIFF
--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -56,6 +56,10 @@ module Spree
     #   @return [Boolean] When false, customers must create an account to complete an order (default: +true+)
     preference :allow_guest_checkout, :boolean, default: true
 
+    # @!attribute [rw] guest_token_cookie_options
+    #   @return [Hash] Add additional guest_token cookie options here (ie. domain or path)
+    preference :guest_token_cookie_options, :hash, default: {}
+
     # @!attribute [rw] allow_return_item_amount_editing
     #   @return [Boolean] Determines whether an admin is allowed to change a return item's pre-calculated amount (default: +false+)
     preference :allow_return_item_amount_editing, :boolean, default: false

--- a/core/lib/spree/core/controller_helpers/auth.rb
+++ b/core/lib/spree/core/controller_helpers/auth.rb
@@ -42,10 +42,10 @@ module Spree
 
         def set_guest_token
           unless cookies.signed[:guest_token].present?
-            cookies.permanent.signed[:guest_token] = {
+            cookies.permanent.signed[:guest_token] = Spree::Config[:guest_token_cookie_options].merge(
               value: SecureRandom.urlsafe_base64(nil, false),
               httponly: true
-            }
+            )
           end
         end
 

--- a/core/spec/lib/spree/core/controller_helpers/auth_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/auth_spec.rb
@@ -45,6 +45,25 @@ RSpec.describe Spree::Core::ControllerHelpers::Auth, type: :controller do
       expect(response.headers["Set-Cookie"]).to match(/guest_token.*HttpOnly/)
       expect(response.cookies['guest_token']).not_to be_nil
     end
+
+    context 'with guest_token_cookie_options configured' do
+      it 'sends cookie with these options' do
+        stub_spree_preferences(guest_token_cookie_options: {
+          domain: :all,
+          path: '/api'
+        })
+        get :index
+        expect(response.headers["Set-Cookie"]).to match(/domain=\.test\.host; path=\/api/)
+      end
+
+      it 'never overwrites httponly' do
+        stub_spree_preferences(guest_token_cookie_options: {
+          httponly: false
+        })
+        get :index
+        expect(response.headers["Set-Cookie"]).to match(/guest_token.*HttpOnly/)
+      end
+    end
   end
 
   describe '#store_location' do


### PR DESCRIPTION
**Description**

The guest_token cookie is currently always only allowed for the current domain (including subdomain).

If you want to use the cookie on a static frontend communicating with your Solidus API you want to share the cookie with all subdomains (ie. www.example.com and api.example.com) in order for the cart session to still work.

With this configuration you can do that.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
