### PR TITLE
Admin UI for shipping methods - stock locations association

### DIFF
--- a/backend/app/assets/javascripts/spree/backend.js
+++ b/backend/app/assets/javascripts/spree/backend.js
@@ -61,3 +61,4 @@
 //= require spree/backend/user_picker
 //= require spree/backend/variant_autocomplete
 //= require spree/backend/zone
+//= require spree/backend/shipping_methods/stock_locations_picker

--- a/backend/app/assets/javascripts/spree/backend/shipping_methods/stock_locations_picker.js
+++ b/backend/app/assets/javascripts/spree/backend/shipping_methods/stock_locations_picker.js
@@ -1,0 +1,18 @@
+Spree.ready(function() {
+  var $stockLocationsSelect = $('#shipping_method_stock_location_ids'),
+      $availableToAllCheckbox = $('#shipping_method_available_to_all');
+
+  if ($stockLocationsSelect.length === 0 || $availableToAllCheckbox.length === 0) {
+    return;
+  }
+
+  function toggleLocationSelectVisibility() {
+    $stockLocationsSelect.toggleClass('hidden', $availableToAllCheckbox[0].checked);
+  }
+
+  $availableToAllCheckbox.on('click', function() {
+    toggleLocationSelectVisibility();
+  });
+
+  toggleLocationSelectVisibility();
+})

--- a/backend/app/views/spree/admin/shipping_methods/_form.html.erb
+++ b/backend/app/views/spree/admin/shipping_methods/_form.html.erb
@@ -54,6 +54,24 @@
       <%= error_message_on :shipping_method, :tracking_url %>
     <% end %>
   </div>
+
+  <div class="col-5 label-block">
+    <%= f.field_container :stock_locations do %>
+      <label>
+        <%= f.check_box(:available_to_all) %>
+        <%= Spree::ShippingMethod.human_attribute_name :available_to_all %>
+        <%= f.field_hint :available_to_all %>
+        <%= error_message_on :shipping_method, :available_to_all %>
+      </label>
+      <%= f.collection_select :stock_location_ids,
+        Spree::StockLocation.order_default, :id, :name,
+        {},
+        class: 'fullwidth select2',
+        multiple: true,
+        placeholder: t('spree.admin.shipping_methods.form.stock_locations_placeholder') %>
+      <%= error_message_on :shipping_method, :stock_locations %>
+    <% end %>
+  </div>
 </div>
 
 <%= f.field_container :available_to_users, class: %w(checkbox) do %>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -319,6 +319,8 @@ en:
         name: Name
         service_level: Service Level
         tracking_url: Tracking URL
+        stock_locations: Stock Locations
+        available_to_all: Available to all stock locations
       spree/shipping_rate:
         amount: Amount
         label: Label
@@ -884,6 +886,9 @@ en:
         expired: Expired
         inactive: Inactive
         not_started: Not started
+      shipping_methods:
+        form:
+          stock_locations_placeholder: 'Choose stock locations'
       stock_locations:
         form:
           address: Address
@@ -1412,6 +1417,9 @@ en:
           If no value is specified, the promotion will be immediately available.
         promo_code_will_be_disabled: Selecting this option, promo codes will be disabled for this promotion
           because all its rules / actions will be applied automatically to all orders.
+      spree/shipping_method:
+        available_to_all: Uncheck to select specific stock locations this
+          shipping method will be available in.
       spree/stock_location:
         active: 'This determines whether stock from this location can be used when
           building packages.<br/> Default: Checked'


### PR DESCRIPTION
This introduces the admin UI allowing to associate a shipping method to specific stock locations.
This makes editable also `Spree::ShippingMethod#available_to_all` from admin, being an attribute directly related to stock locations association behavior.

This feature is mostly used when a shipping method must be available to a specific subset of stock locations.
The shipping methods for a package [are queried](https://github.com/solidusio/solidus/blob/61110460baaac24b56160a4037f56320fb7870c7/core/app/models/spree/stock/package.rb#L109-L115) using the following methods:
- [`Spree::ShippingMethod.with_all_shipping_category_ids`](https://github.com/solidusio/solidus/blob/89f25d1519128c8f33b2f944f297f4081335e8c9/core/app/models/spree/shipping_method.rb#L40-L55)
- [`Spree::ShippingMethod.available_in_stock_location`](https://github.com/solidusio/solidus/blob/89f25d1519128c8f33b2f944f297f4081335e8c9/core/app/models/spree/shipping_method.rb#L57-L77)

The second query method filters the shipping methods having `available_to_all` enabled OR having the stock location associated.
By disabling `available_to_all` it becomes possible to make specific shipping methods available for specific stock locations.

<img width="1452" alt="Screenshot 2020-05-15 at 11 45 13" src="https://user-images.githubusercontent.com/97211/82036773-98761d00-96a1-11ea-9e61-ec0c6d72b915.png">


**Checklist:**
- [ ] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [ ] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
