### PR TITLE
keep admin routes in backend

### DIFF
--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -1,17 +1,6 @@
 # frozen_string_literal: true
 
 Spree::Core::Engine.routes.draw do
-  namespace :admin do
-    resources :users do
-      resource :api_key, controller: 'users/api_key', only: [:create, :destroy]
-
-      member do
-        put :generate_api_key # Deprecated
-        put :clear_api_key # Deprecated
-      end
-    end
-  end
-
   namespace :api, defaults: { format: 'json' } do
     resources :promotions, only: [:show]
 

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -166,11 +166,15 @@ Spree::Core::Engine.routes.draw do
     end
 
     resources :users do
+      resource :api_key, controller: 'users/api_key', only: [:create, :destroy]
+
       member do
         get :orders
         get :items
         get :addresses
         put :addresses
+        put :generate_api_key # Deprecated
+        put :clear_api_key # Deprecated
       end
       resources :store_credits, except: [:destroy] do
         member do


### PR DESCRIPTION
**Description**
I found that admin api_key routes are inside api routes file. I didn't find that these routes were used in api.

So I think we should move that routes into admin routes file.

This doesn't change any functionality, so I think doesn't need any extra spec.

**Checklist:**
- [X] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [ ] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
