### PR TITLE
First attempt to make images shared with multiple variants

### DIFF
--- a/api/app/controllers/spree/api/images_controller.rb
+++ b/api/app/controllers/spree/api/images_controller.rb
@@ -20,7 +20,8 @@ module Spree
       end
 
       def update
-        @image = scope.images.accessible_by(current_ability, :update).find(params[:id])
+        @image = scope.variant_images.accessible_by(current_ability, :update).find(params[:id])
+        @image.viewable.variants = scope.variants_including_master.where(id: params[:variant_ids]).presence || [scope.master]
         @image.update(image_params)
         respond_with(@image, default_template: :show)
       end

--- a/backend/app/controllers/spree/admin/images_controller.rb
+++ b/backend/app/controllers/spree/admin/images_controller.rb
@@ -6,7 +6,7 @@ module Spree
       before_action :load_data
 
       create.before :set_viewable
-      update.before :set_viewable
+      create.after :update_variant_image
 
       private
 
@@ -27,8 +27,15 @@ module Spree
       end
 
       def set_viewable
-        @image.viewable_type = 'Spree::Variant'
-        @image.viewable_id = params[:image][:viewable_id]
+        variant = @product.variants_including_master.find(params[:image][:viewable_id])
+        @variant_image = variant.images_variants.create
+        @image.viewable_type = 'Spree::ImagesVariant'
+        @image.viewable_id = @variant_image.id
+      end
+
+      def update_variant_image
+        @variant_image.image = @image
+        @variant_image.save
       end
     end
   end

--- a/backend/app/views/spree/admin/images/_image_row.html.erb
+++ b/backend/app/views/spree/admin/images/_image_row.html.erb
@@ -25,7 +25,7 @@
   <% if @product.has_variants? %>
     <td>
       <%= fields_for image do |f| %>
-        <%= f.select :viewable_id, options_for_select(@variants, image.viewable_id), {}, class: 'select2 fullwidth', autocomplete: "off" %>
+        <%= select_tag :variant_ids, options_for_select(@variants, image.viewable.variants.map(&:id)), class: 'select2 fullwidth', autocomplete: "off", multiple: true %>
       <% end %>
     </td>
   <% end # @product.has_variants? %>

--- a/core/app/models/spree/gallery/product_gallery.rb
+++ b/core/app/models/spree/gallery/product_gallery.rb
@@ -3,6 +3,8 @@
 module Spree
   module Gallery
     class ProductGallery
+      attr_reader :product
+
       def initialize(product)
         @product = product
       end
@@ -11,7 +13,13 @@ module Spree
       #
       # @return [Enumerable<Spree::Image>] all images in the gallery
       def images
-        @images ||= @product.variant_images
+        @images ||= product.variant_images.uniq + Spree::Image.for_variants(all_variants.map(&:id))
+      end
+
+      private
+
+      def all_variants
+        product.variants_including_master
       end
     end
   end

--- a/core/app/models/spree/gallery/variant_gallery.rb
+++ b/core/app/models/spree/gallery/variant_gallery.rb
@@ -3,6 +3,7 @@
 module Spree
   module Gallery
     class VariantGallery
+      attr_reader :variant
       def initialize(variant)
         @variant = variant
       end
@@ -12,8 +13,8 @@ module Spree
       # @return [Enumerable<Spree::Image>] all images in the gallery
       def images
         @images ||=
-          @variant.images.presence ||
-          (!@variant.is_master? && @variant.product.master.images).presence ||
+            (variant.images + Spree::Image.for_variants(variant.id)).presence ||
+          (!variant.is_master? && variant.product.master.images).presence ||
           Spree::Image.none
       end
     end

--- a/core/app/models/spree/image.rb
+++ b/core/app/models/spree/image.rb
@@ -4,6 +4,9 @@ module Spree
   class Image < Asset
     include ::Spree::Config.image_attachment_module
 
+    # Backward compatibility patch while images are migrated to new habtm model
+    scope :for_variants, -> (variant_ids) { where(viewable_type: 'Spree::Variant', viewable_id: variant_ids) }
+
     def mini_url
       Spree::Deprecation.warn(
         'Spree::Image#mini_url is DEPRECATED. Use Spree::Image#url(:mini) instead.'

--- a/core/app/models/spree/images_variant.rb
+++ b/core/app/models/spree/images_variant.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Spree
+  class ImagesVariant < Spree::Base
+    has_one :image, -> { order(:position) }, as: :viewable, class_name: 'Spree::Image'
+    has_and_belongs_to_many :variants, class_name: 'Spree::Variant'
+  end
+end

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -19,10 +19,10 @@ module Spree
     acts_as_list scope: :product
 
     include Spree::SoftDeletable
+    include ::Spree::Config.variant_images_definition_module
 
     after_discard do
       stock_items.discard_all
-      images.destroy_all
       prices.discard_all
       currently_valid_prices.discard_all
     end
@@ -49,8 +49,6 @@ module Spree
 
     has_many :option_values_variants
     has_many :option_values, through: :option_values_variants
-
-    has_many :images, -> { order(:position) }, as: :viewable, dependent: :destroy, class_name: "Spree::Image"
 
     has_many :prices,
       class_name: 'Spree::Price',

--- a/core/app/models/spree/variant/habtm_images_definition.rb
+++ b/core/app/models/spree/variant/habtm_images_definition.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Spree::Variant::HabtmImagesDefinition
+  extend ActiveSupport::Concern
+
+  included do
+    has_and_belongs_to_many :images_variants, class_name: 'Spree::ImagesVariant'
+    has_many :images, through: :images_variants
+
+    after_discard do
+      images_variants.destroy_all
+    end
+  end
+end

--- a/core/app/models/spree/variant/hm_images_definition.rb
+++ b/core/app/models/spree/variant/hm_images_definition.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Spree::Variant::HmImagesDefinition
+  extend ActiveSupport::Concern
+
+  included do
+    has_many :images, -> { order(:position) }, as: :viewable, dependent: :destroy, class_name: "Spree::Image"
+
+    after_discard do
+      images.destroy_all
+    end
+  end
+end

--- a/core/db/migrate/20200520205057_create_images_variants.rb
+++ b/core/db/migrate/20200520205057_create_images_variants.rb
@@ -1,0 +1,14 @@
+# frozen_string_liteal: true
+
+class CreateImagesVariants < ActiveRecord::Migration[6.0]
+  def change
+    create_table :spree_images_variants do |t|
+      t.references :image
+    end
+
+    create_table :spree_images_variants_variants do |t|
+      t.references :variant
+      t.references :images_variant
+    end
+  end
+end

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -435,6 +435,14 @@ module Spree
     # Enumerable of images adhering to the present_image_class interface
     class_name_attribute :variant_gallery_class, default: 'Spree::Gallery::VariantGallery'
 
+    # Allows providing your own module defining Variants and images relationships
+    #
+    # @!attribute [rw] variant_images_definition_module
+    # @return [Module] a module that implements Variant relationship with images,
+    # can be `has_many :images, as: :viewable` by default or use
+    # Spree::Variant::HABTMImagesDefinition for `has_many :images, trought: :images_variants`
+    class_name_attribute :variant_images_definition_module, default: 'Spree::Variant::HabtmImagesDefinition'
+
     # Allows providing your own class for image galleries on Products
     #
     # @!attribute [rw] product_gallery_class

--- a/core/spec/models/spree/gallery/product_gallery_spec.rb
+++ b/core/spec/models/spree/gallery/product_gallery_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe Spree::Gallery::ProductGallery do
     let(:second_image) { build(:image) }
 
     before do
-      product.images << first_image
-      product.images << second_image
+      product.master.images_variants.create(image: first_image)
+      product.master.images_variants.create(image: second_image)
     end
   end
 

--- a/core/spec/models/spree/gallery/variant_gallery_spec.rb
+++ b/core/spec/models/spree/gallery/variant_gallery_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe Spree::Gallery::VariantGallery do
     let(:second_image) { build(:image) }
 
     before do
-      variant.images << first_image
-      variant.images << second_image
+      variant.images_variants.create(image: first_image)
+      variant.images_variants.create(image: second_image)
     end
   end
 

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -357,7 +357,7 @@ RSpec.describe Spree::Product, type: :model do
       it "destroys related associations" do
         create(:variant, product: product)
         product.option_types = [create(:option_type)]
-        product.master.images = [create(:image)]
+        product.master.images_variants.create(image: create(:image))
         product.taxons = [create(:taxon)]
         product.properties = [create(:property)]
 
@@ -474,12 +474,19 @@ RSpec.describe Spree::Product, type: :model do
 
   context "#images" do
     let(:product) { create(:product) }
-    let(:image) { File.open(File.expand_path('../../fixtures/thinking-cat.jpg', __dir__)) }
-    let(:params) { { viewable_id: product.master.id, viewable_type: 'Spree::Variant', attachment: image, alt: "position 2", position: 2 } }
+    let(:image_attachment) { File.open(File.expand_path('../../fixtures/thinking-cat.jpg', __dir__)) }
+    let(:params) { { attachment: image_attachment, alt: "position 2", position: 2 } }
 
     before do
-      Spree::Image.create(params)
-      Spree::Image.create(params.merge({ alt: "position 1", position: 1 }))
+      image2 = create(:image, params)
+      image1 = create(:image, params.merge(alt: 'position 1', position: 1))
+      images_variant2 = Spree::ImagesVariant.create(image: image2)
+      images_variant1 = Spree::ImagesVariant.create(image: image1)
+      image2.update(viewable: images_variant2)
+      image1.update(viewable: images_variant1)
+      images_variant2.update(variants: [product.master])
+      images_variant1.update(variants: [product.master])
+
       Spree::Image.create(params.merge({ viewable_type: 'ThirdParty::Extension', alt: "position 1", position: 2 }))
     end
 

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -664,7 +664,7 @@ RSpec.describe Spree::Variant, type: :model do
 
   describe "#discard" do
     it "discards related associations" do
-      variant.images = [create(:image)]
+      variant.images_variants.create(image: create(:image))
 
       expect(variant.stock_items).not_to be_empty
       expect(variant.prices).not_to be_empty
@@ -835,7 +835,7 @@ RSpec.describe Spree::Variant, type: :model do
       let(:variant) { create(:variant, product: product) }
 
       it "fallbacks to variant.product.master.images" do
-        product.master.images = [create(:image)]
+        product.master.images_variants.create(image: create(:image))
 
         expect(product.master).not_to eq variant
 


### PR DESCRIPTION
First attempt to implement #3609

The idea was to create a two new tables to allow images to belong
to multiple variants, the first one is to be the polymorphic association
and then the M-N table following rails conventions.
It is going to be hard to maintain old functionality due the change of
relationships and variable naming, it basically works without rewriting
the frontend, gallery helped but the trick will be do it backward compatible
with old images when migrating to newer version of solidus, maybe a rake task?

If this path is worth pursuing I can keep working to fix/add tests and figure out a way to make it to work with old data and offer a mechanism to migrate it to this new architecture

**Checklist:**
- [ ] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [ ] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
