### PR TITLE
[v2.10] Fix API Documentation generation with multiple digits versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,7 +127,7 @@ workflows:
       - persist_version:
           filters:
             branches:
-              only: /master|v\d\.\d/
+              only: /master|v\d\.\d+/
       - postgres
       - mysql
       - postgres_rails52


### PR DESCRIPTION
**Description**

Right now the persist_version job is not triggered since the regex only takes into account versions with one digit after the decimal point. The regex actually matches but CircleCI needs it to match the entire string, from their doc:

> Both only and ignore lists can have full names and regular expressions.
> Regular expressions must match the entire string.

https://circleci.com/docs/2.0/configuration-reference/#branches

This is what happens before the change:

<img width="1066" alt="Screenshot 2020-05-21 at 17 38 48" src="https://user-images.githubusercontent.com/167946/82576274-f1eeb800-9b89-11ea-81ed-136205c3b901.png">

and after:

<img width="1062" alt="Screenshot 2020-05-21 at 17 33 17" src="https://user-images.githubusercontent.com/167946/82576218-daafca80-9b89-11ea-80f2-594b99a8c410.png">

**Checklist:**
- [ ] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [ ] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
