### PR TITLE
refactor api_key routes into solidus_api

### DIFF
--- a/api/app/controllers/spree/api/users/api_key_controller.rb
+++ b/api/app/controllers/spree/api/users/api_key_controller.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Spree
+  module Api
+    module Users
+      class ApiKeyController < Spree::Api::BaseController
+        def create
+          authorize! :manage, model_class
+          user.generate_spree_api_key!
+          respond_with(user, default_template: 'spree/api/users/api_key')
+        end
+
+        def destroy
+          authorize! :manage, model_class
+          user.clear_spree_api_key!
+          head 204
+        end
+
+        private
+
+        def user
+          @user ||= model_class.find(params[:user_id])
+        end
+
+        def model_class
+          Spree.user_class
+        end
+      end
+    end
+  end
+end

--- a/api/app/helpers/spree/api/api_helpers.rb
+++ b/api/app/helpers/spree/api/api_helpers.rb
@@ -26,6 +26,7 @@ module Spree
         :creditcard_attributes,
         :payment_source_attributes,
         :user_attributes,
+        :user_api_key_attributes,
         :property_attributes,
         :stock_location_attributes,
         :stock_movement_attributes,
@@ -153,6 +154,8 @@ module Spree
       ]
 
       @@user_attributes = [:id, :email, :created_at, :updated_at]
+
+      @@user_api_key_attributes = [:spree_api_key]
 
       @@property_attributes = [:id, :name, :presentation]
 

--- a/api/app/views/spree/api/users/api_key.json.jbuilder
+++ b/api/app/views/spree/api/users/api_key.json.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.(@user, *user_api_key_attributes)

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -1,17 +1,6 @@
 # frozen_string_literal: true
 
 Spree::Core::Engine.routes.draw do
-  namespace :admin do
-    resources :users do
-      resource :api_key, controller: 'users/api_key', only: [:create, :destroy]
-
-      member do
-        put :generate_api_key # Deprecated
-        put :clear_api_key # Deprecated
-      end
-    end
-  end
-
   namespace :api, defaults: { format: 'json' } do
     resources :promotions, only: [:show]
 
@@ -114,6 +103,7 @@ Spree::Core::Engine.routes.draw do
     resources :users do
       resources :credit_cards, only: [:index]
       resource :address_book, only: [:show, :update, :destroy]
+      resource :api_key, controller: 'users/api_key', only: [:create, :destroy]
     end
 
     resources :credit_cards, only: [:update]

--- a/api/spec/requests/spree/api/users/api_key_controller_spec.rb
+++ b/api/spec/requests/spree/api/users/api_key_controller_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module Spree
+  describe Api::Users::ApiKeyController, type: :request do
+    let(:user) { create(:user) }
+    let(:admin) { create(:admin_user) }
+
+    before do
+      stub_authentication!
+    end
+
+    context 'with ability to manage user' do
+      stub_authorization! do
+        can [:manage], user
+      end
+
+      describe '#create' do
+        it 'return api_key' do
+          expect(user.spree_api_key).to be(nil)
+          post "/api/users/#{user.id}/api_key"
+          expect(response.status).to eq(200)
+          api_key = json_response['spree_api_key']
+          expect(api_key).not_to be(nil)
+          user.reload
+          expect(user.spree_api_key).to eq(api_key)
+        end
+      end
+
+      describe '#delete' do
+        it 'clean user api_key' do
+          user.generate_spree_api_key!
+          expect(user.spree_api_key).not_to be(nil)
+          delete "/api/users/#{user.id}/api_key"
+          expect(response.status).to eq(204)
+          user.reload
+          expect(user.spree_api_key).to be(nil)
+        end
+      end
+    end
+
+    context 'without ability to manage user' do
+      describe '#create' do
+        it 'return 401' do
+          expect(user.spree_api_key).to be(nil)
+          post "/api/users/#{user.id}/api_key"
+          assert_unauthorized!
+          user.reload
+          expect(user.spree_api_key).to be(nil)
+        end
+      end
+
+      describe '#delete' do
+        it 'return 401' do
+          user.generate_spree_api_key!
+          expect(user.spree_api_key).not_to be(nil)
+          delete "/api/users/#{user.id}/api_key"
+          assert_unauthorized!
+          user.reload
+          expect(user.spree_api_key).not_to be(nil)
+        end
+      end
+    end
+  end
+end

--- a/backend/app/assets/javascripts/spree/backend.js
+++ b/backend/app/assets/javascripts/spree/backend.js
@@ -59,5 +59,6 @@
 //= require spree/backend/taxonomy
 //= require spree/backend/taxons
 //= require spree/backend/user_picker
+//= require spree/backend/user_api_key
 //= require spree/backend/variant_autocomplete
 //= require spree/backend/zone

--- a/backend/app/assets/javascripts/spree/backend/models/index.js
+++ b/backend/app/assets/javascripts/spree/backend/models/index.js
@@ -5,3 +5,4 @@
 //= require spree/backend/models/stock_item
 //= require spree/backend/models/taxonomy
 //= require spree/backend/models/payment
+//= require spree/backend/models/user

--- a/backend/app/assets/javascripts/spree/backend/models/user.js
+++ b/backend/app/assets/javascripts/spree/backend/models/user.js
@@ -1,0 +1,47 @@
+Spree.Models.User = Backbone.Model.extend({
+  urlRoot: Spree.routes.users_api,
+
+  apiKeyUrl: function() {
+    return `${this.url()}/api_key`;
+  },
+
+  updateSpreeGlobal: function(value) {
+    if (this.get('isCurrentUser')) {
+      Spree.api_key = value;
+    }
+  },
+
+  clearKey: function() {
+    const model = this;
+    fetch(this.apiKeyUrl(), {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${Spree.api_key}`
+      }
+    }).then(function(response) {
+      if (response.ok) {
+        model.set({ apiKey: null });
+        show_flash('success', Spree.t('admin.api.key_cleared'));
+        model.updateSpreeGlobal(null);
+      }
+    })
+  },
+
+  generateKey: function() {
+    const model = this;
+    fetch(this.apiKeyUrl(), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${Spree.api_key}`
+      }
+    }).then(function(response) {
+      if (response.ok) return response.json()
+    }).then(function({ spree_api_key }) {
+      model.set({ apiKey: spree_api_key });
+      show_flash('success', Spree.t('admin.api.key_generated'));
+      model.updateSpreeGlobal(spree_api_key);
+    })
+  }
+})

--- a/backend/app/assets/javascripts/spree/backend/namespaces.js
+++ b/backend/app/assets/javascripts/spree/backend/namespaces.js
@@ -10,6 +10,7 @@ _.extend(window.Spree, {
     Payment: {},
     Promotions: {},
     Stock: {},
-    Tables: {}
+    Tables: {},
+    User: {}
   }
 })

--- a/backend/app/assets/javascripts/spree/backend/templates/index.js
+++ b/backend/app/assets/javascripts/spree/backend/templates/index.js
@@ -15,3 +15,4 @@
 //= require spree/backend/templates/variants/autocomplete
 //= require spree/backend/templates/variants/line_items_autocomplete_stock
 //= require spree/backend/templates/variants/split
+//= require spree/backend/templates/users/api_key

--- a/backend/app/assets/javascripts/spree/backend/templates/users/api_key.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/users/api_key.hbs
@@ -1,0 +1,25 @@
+  {{#if apiKey}}
+    <div id="current-api-key">
+      <strong>{{ t 'key' localeOpts }}: </strong>
+      {{#if isCurrentUser}}
+        {{apiKey}}
+      {{else}}
+        <i>({{ t 'hidden' }})</i>
+      {{/if}}
+      <div class="filter-actions actions">
+        <button class='btn btn-default clear-key-btn'>
+          {{ t 'clear_key' localeOpts }}
+        </button>
+        <button class='btn btn-default regenerate-key-btn'>
+          {{ t 'regenerate_key' localeOpts }}
+        </button>
+      </div>
+    </div>
+  {{else}}
+    <div class="no-objects-found">{{ t 'no_key' localeOpts }}</div>
+    <div class="filter-actions actions">
+      <button class='btn btn-primary generate-key-btn'>
+        {{ t 'generate_key' localeOpts }}
+      </button>
+    </div>
+  {{/if}}

--- a/backend/app/assets/javascripts/spree/backend/user_api_key.js
+++ b/backend/app/assets/javascripts/spree/backend/user_api_key.js
@@ -1,0 +1,16 @@
+Spree.ready(function() {
+  var el = $('#user-api-key');
+
+  if (el.length > 0) {
+    var model = new Spree.Models.User({
+      id: el.data('user-id'),
+      apiKey: el.data('api-key'),
+      isCurrentUser: el.data('is-current-user')
+    });
+
+    new Spree.Views.User.ApiKey({
+      el: el,
+      model: model
+    });
+  }
+});

--- a/backend/app/assets/javascripts/spree/backend/views/index.js
+++ b/backend/app/assets/javascripts/spree/backend/views/index.js
@@ -24,3 +24,4 @@
 //= require 'spree/backend/views/promotions/option_values_rule'
 //= require 'spree/backend/views/tables/editable_table'
 //= require 'spree/backend/views/tables/editable_table_row'
+//= require 'spree/backend/views/user/api_key'

--- a/backend/app/assets/javascripts/spree/backend/views/user/api_key.js
+++ b/backend/app/assets/javascripts/spree/backend/views/user/api_key.js
@@ -1,0 +1,46 @@
+Spree.Views.User.ApiKey = Backbone.View.extend({
+  initialize: function(options) {
+    this.localeOptsObj = { scope: 'admin.users.edit' };
+    this.listenTo(this.model, 'change', this.render);
+    this.render();
+  },
+
+  events: {
+    'click .clear-key-btn': 'onClear',
+    'click .regenerate-key-btn': 'onRegenerate',
+    'click .generate-key-btn': 'onGenerate'
+  },
+
+  template: HandlebarsTemplates['users/api_key'],
+
+  render: function() {
+    var renderAttr = {
+      apiKey: this.model.get('apiKey'),
+      isCurrentUser: this.model.get('isCurrentUser'),
+      localeOpts: {
+        hash: this.localeOptsObj
+      }
+    };
+    this.$el.html(this.template(renderAttr));
+    return this;
+  },
+
+  onClear: function(e) {
+    e.preventDefault();
+    if (confirm(Spree.t('confirm_clear_key', this.localeOptsObj))) {
+      this.model.clearKey();
+    }
+  },
+
+  onRegenerate: function(e) {
+    e.preventDefault();
+    if (confirm(Spree.t('confirm_regenerate_key', this.localeOptsObj))) {
+      this.model.generateKey();
+    }
+  },
+
+  onGenerate: function(e) {
+    e.preventDefault();
+    this.model.generateKey();
+  }
+});

--- a/backend/app/controllers/spree/admin/users/api_key_controller.rb
+++ b/backend/app/controllers/spree/admin/users/api_key_controller.rb
@@ -5,6 +5,15 @@ module Spree
     module Users
       class ApiKeyController < Spree::Admin::BaseController
         def create
+          Spree::Deprecation.warn <<-WARN.strip_heredoc, caller
+            The route or controller action you are using is deprecated.
+
+            Instead of:
+            admin_user_api_key        POST   /admin/users/:user_id/api_key
+
+            Please use:
+            api_user_api_key          POST   /api/users/:user_id/api_key
+          WARN
           if user.generate_spree_api_key!
             flash[:success] = t('spree.admin.api.key_generated')
           end
@@ -12,6 +21,15 @@ module Spree
         end
 
         def destroy
+          Spree::Deprecation.warn <<-WARN.strip_heredoc, caller
+            The route or controller action you are using is deprecated.
+
+            Instead of:
+            admin_user_api_key     DELETE /admin/users/:user_id/api_key
+
+            Please use:
+            api_user_api_key       DELETE /api/users/:user_id/api_key
+          WARN
           if user.clear_spree_api_key!
             flash[:success] = t('spree.admin.api.key_cleared')
           end

--- a/backend/app/controllers/spree/admin/users_controller.rb
+++ b/backend/app/controllers/spree/admin/users_controller.rb
@@ -89,7 +89,7 @@ module Spree
           generate_api_key_admin_user PUT    /admin/users/:id/generate_api_key
 
           Please use:
-          admin_user_api_key          POST   /admin/users/:user_id/api_key
+          api_user_api_key            POST   /api/users/:user_id/api_key
         WARN
 
         if @user.generate_spree_api_key!
@@ -106,7 +106,7 @@ module Spree
           clear_api_key_admin_user PUT    /admin/users/:id/clear_api_key
 
           Please use:
-          admin_user_api_key       DELETE /admin/users/:user_id/api_key
+          api_user_api_key         DELETE /api/users/:user_id/api_key
         WARN
 
         if @user.clear_spree_api_key!

--- a/backend/app/views/spree/admin/users/edit.html.erb
+++ b/backend/app/views/spree/admin/users/edit.html.erb
@@ -29,28 +29,11 @@
   <fieldset data-hook="admin_user_api_key" id="admin_user_edit_api_key">
     <legend><%= t('.api_access') %></legend>
 
-    <% if @user.spree_api_key.present? %>
-      <div id="current-api-key">
-        <strong><%= t('.key') %>: </strong>
-        <% if @user == try_spree_current_user %>
-          <%= @user.spree_api_key %>
-        <% else %>
-          <i>(<%= t('spree.hidden') %>)</i>
-        <% end %>
-
-      </div>
-      <div class="filter-actions actions">
-        <%= button_to t('.clear_key'), spree.admin_user_api_key_path(@user), method: :delete, data: { confirm: t('.confirm_clear_key') }, class: 'btn btn-default' %>
-        <%= button_to t('.regenerate_key'), spree.admin_user_api_key_path(@user), method: :post, data: { confirm: t('.confirm_regenerate_key') }, class: 'btn btn-default' %>
-      </div>
-
-    <% else %>
-
-      <div class="no-objects-found"><%= t('.no_key') %></div>
-
-      <div class="filter-actions actions">
-        <%= button_to t('.generate_key'), spree.admin_user_api_key_path(@user), method: :post, class: 'btn btn-primary' %>
-      </div>
-    <% end %>
+    <div id="user-api-key"
+      data-user-id="<%= @user.id %>"
+      data-api-key="<%= @user.spree_api_key %>"
+      data-is-current-user="<%= @user == try_spree_current_user %>"
+    >
+    </div>
   </fieldset>
 <% end %>

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -166,11 +166,15 @@ Spree::Core::Engine.routes.draw do
     end
 
     resources :users do
+      resource :api_key, controller: 'users/api_key', only: [:create, :destroy] # Deprecated
+
       member do
         get :orders
         get :items
         get :addresses
         put :addresses
+        put :generate_api_key # Deprecated
+        put :clear_api_key # Deprecated
       end
       resources :store_credits, except: [:destroy] do
         member do

--- a/backend/spec/controllers/spree/admin/users/api_key_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/users/api_key_controller_spec.rb
@@ -13,6 +13,7 @@ describe Spree::Admin::Users::ApiKeyController, type: :controller do
       end
 
       it "allows admins to create a new user's API key" do
+        expect(Spree::Deprecation).to receive(:warn)
         post :create, params: { user_id: user.id }
 
         expect(flash[:success]).to eq I18n.t('spree.admin.api.key_generated')
@@ -41,6 +42,7 @@ describe Spree::Admin::Users::ApiKeyController, type: :controller do
       end
 
       it "allows admins to clear an existing user's API key" do
+        expect(Spree::Deprecation).to receive(:warn)
         user.generate_spree_api_key!
         delete :destroy, params: { user_id: user.id }
 


### PR DESCRIPTION
**Description**
This continue from #3625

The current api_key routes are useless outside admin, because return a redirection into admin and you will need to set the admin csrf token to use.

I'm adding new routes and controller for api_key in solidus_api and updated the admin users edit view to use solidus_api and backbone for update user's api_key.

I found an edge case here (in admin), if you clear the api_key for the current user you wouldn't generate a new one since you need an api_key to send the request to solidus_api.

I was thinking in how to solve this and become with two options:

- Don't allow user to clear there own api_key.

- Add a similar route into admin to generate an api_key.

I prefer the first option to avoid repetitive code.

What do you think?

**Checklist:**
- [X] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [X] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
