### PR TITLE
Fixing mark default billing address

### DIFF
--- a/core/app/models/concerns/spree/user_address_book.rb
+++ b/core/app/models/concerns/spree/user_address_book.rb
@@ -171,7 +171,7 @@ module Spree
     end
 
     def mark_default_bill_address(address)
-      user_addresses.mark_default(user_addresses.find_by(address: address), :billing)
+      user_addresses.mark_default(user_addresses.find_by(address: address), address_type: :billing)
     end
 
     def remove_from_address_book(address_id)

--- a/core/spec/models/spree/concerns/user_address_book_spec.rb
+++ b/core/spec/models/spree/concerns/user_address_book_spec.rb
@@ -584,36 +584,21 @@ module Spree
     end
 
     describe "#mark_default_ship_address" do
-      let(:address) { build :address }
-      let(:user_address) { double }
-      let(:user_addresses) { double }
+      let(:user_address) { user.user_addresses.create(address: build(:address), default: false) }
 
-      before do
-        allow(user).to receive(:user_addresses).and_return user_addresses
-        allow(user_addresses).to receive(:find_by).and_return user_address
-      end
-
-      it "calls #mark_default with default address kind" do
-        expect(user_addresses).to receive(:mark_default).with(user_address)
-
-        user.mark_default_ship_address(address)
+      it "marks address specified as default shipping" do
+        user.mark_default_ship_address(user_address.address)
+        expect(user_address.reload.default).to be_truthy
       end
     end
 
     describe "#mark_default_bill_address" do
-      let(:address) { build :address }
-      let(:user_address) { double }
-      let(:user_addresses) { double }
+      let(:user) { create(:user_with_addresses) }
+      let(:user_address) { user.user_addresses.find_by(default_billing: false) }
 
-      before do
-        allow(user).to receive(:user_addresses).and_return user_addresses
-        allow(user_addresses).to receive(:find_by).and_return user_address
-      end
-
-      it "calls #mark_default with billing address kind" do
-        expect(user_addresses).to receive(:mark_default).with(user_address, :billing)
-
-        user.mark_default_bill_address(address)
+      it "marks address specified as default billing" do
+        user.mark_default_bill_address(user_address.address)
+        expect(user_address.reload.default_billing).to be_truthy
       end
     end
   end


### PR DESCRIPTION
User.mark_default_bill_address was not working, It was calling 
mark_default method with two params, but the second one 
had to be a named param.


**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
