### PR TITLE
Make Order#shipping_discount consider only credits

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -229,7 +229,7 @@ module Spree
     end
 
     def shipping_discount
-      shipment_adjustments.eligible.sum(:amount) * - 1
+      shipment_adjustments.credit.eligible.sum(:amount) * - 1
     end
 
     def to_param

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -1720,4 +1720,19 @@ RSpec.describe Spree::Order, type: :model do
       end.to change { subject.shipments.count }.by 1
     end
   end
+
+  describe '#shipping_discount' do
+    let(:shipment) { create(:shipment) }
+    let(:order) { shipment.order }
+
+    let!(:charge_shipment_adjustment) { create :adjustment, adjustable: shipment, amount: 20 }
+    let!(:shipment_adjustment) { create :adjustment, adjustable: shipment, amount: -10 }
+    let!(:other_shipment_adjustment) { create :adjustment, adjustable: shipment, amount: -30 }
+
+    subject { order.shipping_discount }
+
+    it 'sums eligible shipping adjustments with negative amount (credit)' do
+      expect(subject).to eq 40
+    end
+  end
 end


### PR DESCRIPTION
**Description**

`Order#shipping_discount` should consider only shipment adjustments that are `credits` (ie. with amount < 0) as the other ones would not result in a price discount.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
