### PR TITLE
Stop calling perform! as Spree::Refund after_create callback 

### DIFF
--- a/backend/app/controllers/spree/admin/refunds_controller.rb
+++ b/backend/app/controllers/spree/admin/refunds_controller.rb
@@ -11,7 +11,7 @@ module Spree
       rescue_from Spree::Core::GatewayError, with: :spree_core_gateway_error
 
       def create
-        @refund.attributes = refund_params.merge(perform_after_creation: false)
+        @refund.attributes = refund_params.merge(perform_after_create: false)
         if @refund.save && @refund.perform!
           flash[:success] = flash_message_for(@refund, :successfully_created)
           respond_with(@refund) do |format|

--- a/backend/spec/controllers/spree/admin/refunds_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/refunds_controller_spec.rb
@@ -6,22 +6,48 @@ describe Spree::Admin::RefundsController do
   stub_authorization!
 
   describe "POST create" do
-    context "a Spree::Core::GatewayError is raised" do
-      let(:payment) { create(:payment) }
+    let(:refund_reason) { create(:refund_reason) }
+    let(:refund_amount) { 100.0 }
 
-      subject do
-        post :create,
-          params: {
-          refund: { amount: "50.0", refund_reason_id: "1" },
+    let(:payment) { create(:payment, amount: payment_amount) }
+    let(:payment_amount) { refund_amount * 2 }
+
+    subject do
+      post(
+        :create,
+        params: {
+          refund: {
+            amount: refund_amount,
+            refund_reason_id: refund_reason.id,
+            transaction_id: nil
+          },
           order_id: payment.order_id,
           payment_id: payment.id
         }
+      )
+    end
+
+    context "and no Spree::Core::GatewayError is raised" do
+      it "creates a refund record" do
+        expect{ subject }.to change(Spree::Refund, :count).by(1)
       end
 
-      before(:each) do
-        def controller.create
-          raise Spree::Core::GatewayError.new('An error has occurred')
-        end
+      it "calls #perform!" do
+        subject
+        # transaction_id comes from Spree::Gateway::Bogus.credit
+        expect(Spree::Refund.last.transaction_id).to eq("12345")
+      end
+    end
+
+    context "a Spree::Core::GatewayError is raised" do
+      before do
+        expect_any_instance_of(Spree::Refund).
+          to receive(:perform!).
+          and_raise(Spree::Core::GatewayError.new('An error has occurred'))
+      end
+
+      it "does not create a refund record" do
+        expect{ subject }.to_not change { Spree::Refund.count }
       end
 
       it "sets an error message with the correct text" do

--- a/core/app/models/spree/payment/cancellation.rb
+++ b/core/app/models/spree/payment/cancellation.rb
@@ -31,7 +31,7 @@ module Spree
           if response = payment.payment_method.try_void(payment)
             payment.send(:handle_void_response, response)
           else
-            payment.refunds.create!(amount: payment.credit_allowed, reason: refund_reason).perform!
+            payment.refunds.create!(amount: payment.credit_allowed, reason: refund_reason, perform_after_create: false).perform!
           end
         else
           # For payment methods not yet implemeting `try_void`

--- a/core/app/models/spree/payment/cancellation.rb
+++ b/core/app/models/spree/payment/cancellation.rb
@@ -31,7 +31,7 @@ module Spree
           if response = payment.payment_method.try_void(payment)
             payment.send(:handle_void_response, response)
           else
-            payment.refunds.create!(amount: payment.credit_allowed, reason: refund_reason)
+            payment.refunds.create!(amount: payment.credit_allowed, reason: refund_reason).perform!
           end
         else
           # For payment methods not yet implemeting `try_void`

--- a/core/app/models/spree/refund.rb
+++ b/core/app/models/spree/refund.rb
@@ -14,6 +14,11 @@ module Spree
 
     validate :amount_is_less_than_or_equal_to_allowed_amount, on: :create
 
+    attr_accessor :perform_after_create
+    after_create :set_perform_after_create_default
+    after_create :perform!
+    after_create :clear_perform_after_create
+
     scope :non_reimbursement, -> { where(reimbursement_id: nil) }
 
     delegate :currency, to: :payment
@@ -38,6 +43,7 @@ module Spree
     # Attempts to perform the refund,
     # raises an error if the refund fails.
     def perform!
+      return true if perform_after_create == false
       return true if transaction_id.present?
 
       credit_cents = money.cents
@@ -50,6 +56,38 @@ module Spree
     end
 
     private
+
+    # This callback takes care of setting the behavior that determines if it is needed
+    # to execute the perform! callback after_create.
+    # Existing code that creates refund without explicitely passing
+    #
+    # perform_after_create: false
+    #
+    # as attribute will still call perform! but a deprecation warning is emitted in order
+    # to ask users to change their code with the new supported behavior.
+    def set_perform_after_create_default
+      return true if perform_after_create == false
+
+      Spree::Deprecation.warn <<-WARN.strip_heredoc, caller
+        From Solidus v3.0 onwards, #perform! will need to be explicitly called when creating new
+        refunds. Please, change your code from:
+
+          Spree::Refund.create(your: attributes)
+
+        to:
+
+          Spree::Refund.create(your: attributes, perform_after_create: false).perform!
+      WARN
+
+      self.perform_after_create = true
+    end
+
+    # This is needed to avoid that when you create a refund with perform_after_create = false,
+    # it's not possibile to call perform! on that instance, since the value of this attribute
+    # will remain false until a reload of the instance.
+    def clear_perform_after_create
+      @perform_after_create = nil
+    end
 
     # return an activemerchant response object if successful or else raise an error
     def process!(credit_cents)

--- a/core/app/models/spree/reimbursement_type/reimbursement_helpers.rb
+++ b/core/app/models/spree/reimbursement_type/reimbursement_helpers.rb
@@ -34,7 +34,8 @@ module Spree
       refund = reimbursement.refunds.build({
         payment: payment,
         amount: amount,
-        reason: Spree::RefundReason.return_processing_reason
+        reason: Spree::RefundReason.return_processing_reason,
+        perform_after_create: false
       })
 
       if simulate

--- a/core/app/models/spree/reimbursement_type/reimbursement_helpers.rb
+++ b/core/app/models/spree/reimbursement_type/reimbursement_helpers.rb
@@ -37,7 +37,13 @@ module Spree
         reason: Spree::RefundReason.return_processing_reason
       })
 
-      simulate ? refund.readonly! : refund.save!
+      if simulate
+        refund.readonly!
+      else
+        refund.save!
+        refund.perform!
+      end
+
       refund
     end
 

--- a/core/lib/spree/testing_support/factories/refund_factory.rb
+++ b/core/lib/spree/testing_support/factories/refund_factory.rb
@@ -13,6 +13,7 @@ FactoryBot.define do
 
     amount { 100.00 }
     transaction_id { generate(:refund_transaction_id) }
+    perform_after_create { false }
     payment do
       association(:payment, state: 'completed', amount: payment_amount)
     end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe Spree::Order, type: :model do
       let(:payment) { create(:payment, order: order, amount: payment_amount, state: 'completed') }
 
       before do
-        create(:refund, payment: payment, amount: payment_amount)
+        create(:refund, payment: payment, amount: payment_amount).perform!
       end
 
       it "cancels the order" do
@@ -281,7 +281,7 @@ RSpec.describe Spree::Order, type: :model do
       order.cancellations.short_ship([order.inventory_units.first])
       expect(order.outstanding_balance).to be_negative
       expect(order.payment_state).to eq('credit_owed')
-      create(:refund, amount: order.outstanding_balance.abs, payment: payment, transaction_id: nil)
+      create(:refund, amount: order.outstanding_balance.abs, payment: payment, transaction_id: nil).perform!
       order.reload
       expect(order.outstanding_balance).to eq(0)
       expect(order.payment_state).to eq('paid')

--- a/core/spec/models/spree/payment/cancellation_spec.rb
+++ b/core/spec/models/spree/payment/cancellation_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Spree::Payment::Cancellation do
             payment.refunds.create!(
               amount: credit_amount,
               reason: Spree::RefundReason.where(name: 'test').first_or_create
-            )
+            ).perform!
           end
 
           it 'only refunds the allowed credit amount' do

--- a/core/spec/models/spree/payment/cancellation_spec.rb
+++ b/core/spec/models/spree/payment/cancellation_spec.rb
@@ -50,7 +50,8 @@ RSpec.describe Spree::Payment::Cancellation do
           before do
             payment.refunds.create!(
               amount: credit_amount,
-              reason: Spree::RefundReason.where(name: 'test').first_or_create
+              reason: Spree::RefundReason.where(name: 'test').first_or_create,
+              perform_after_create: false
             ).perform!
           end
 

--- a/core/spec/models/spree/refund_spec.rb
+++ b/core/spec/models/spree/refund_spec.rb
@@ -3,58 +3,71 @@
 require 'rails_helper'
 
 RSpec.describe Spree::Refund, type: :model do
+  let(:amount) { 100.0 }
+  let(:amount_in_cents) { amount * 100 }
+
+  let(:authorization) { generate(:refund_transaction_id) }
+
+  let(:payment) { create(:payment, amount: payment_amount, payment_method: payment_method) }
+  let(:payment_amount) { amount * 2 }
+  let(:payment_method) { create(:credit_card_payment_method) }
+
+  let(:refund_reason) { create(:refund_reason) }
+
+  let(:gateway_response) {
+    ActiveMerchant::Billing::Response.new(
+      gateway_response_success,
+      gateway_response_message,
+      gateway_response_params,
+      gateway_response_options
+    )
+  }
+  let(:gateway_response_success) { true }
+  let(:gateway_response_message) { "" }
+  let(:gateway_response_params) { {} }
+  let(:gateway_response_options) { {} }
+
+  before do
+    allow(payment.payment_method)
+      .to receive(:credit)
+      .with(amount_in_cents, payment.source, payment.transaction_id, { originator: an_instance_of(Spree::Refund) })
+      .and_return(gateway_response)
+  end
+
   describe 'create' do
-    let(:amount) { 100.0 }
-    let(:amount_in_cents) { amount * 100 }
-
-    let(:authorization) { generate(:refund_transaction_id) }
-
-    let(:payment) { create(:payment, amount: payment_amount, payment_method: payment_method) }
-    let(:payment_amount) { amount * 2 }
-    let(:payment_method) { create(:credit_card_payment_method) }
-
-    let(:refund_reason) { create(:refund_reason) }
-
-    let(:gateway_response) {
-      ActiveMerchant::Billing::Response.new(
-        gateway_response_success,
-        gateway_response_message,
-        gateway_response_params,
-        gateway_response_options
-      )
-    }
-    let(:gateway_response_success) { true }
-    let(:gateway_response_message) { "" }
-    let(:gateway_response_params) { {} }
-    let(:gateway_response_options) { {} }
-
     subject { create(:refund, payment: payment, amount: amount, reason: refund_reason, transaction_id: nil) }
 
-    before do
-      allow(payment.payment_method)
-        .to receive(:credit)
-        .with(amount_in_cents, payment.source, payment.transaction_id, { originator: an_instance_of(Spree::Refund) })
-        .and_return(gateway_response)
+    it "creates a refund record" do
+      expect{ subject }.to change { Spree::Refund.count }.by(1)
     end
 
-    context "transaction id exists on creation" do
-      let(:transaction_id) { "12kfjas0" }
-      subject { create(:refund, payment: payment, amount: amount, reason: refund_reason, transaction_id: transaction_id) }
+    it "saves the amount" do
+      expect(subject.reload.amount).to eq amount
+      expect(subject.money).to be_a(Spree::Money)
+    end
 
-      it "creates a refund record" do
-        expect{ subject }.to change { Spree::Refund.count }.by(1)
-      end
+    it "does not attempt to process a transaction" do
+      expect(subject.transaction_id).to be_nil
+    end
+  end
+
+  describe "#perform!" do
+    subject do
+      refund = Spree::Refund.create!(
+        payment: payment,
+        amount: amount,
+        reason: refund_reason,
+        transaction_id: transaction_id
+      )
+      refund.perform!
+      refund
+    end
+
+    context "when transaction_id exists" do
+      let(:transaction_id) { "12kfjas0" }
 
       it "maintains the transaction id" do
         expect(subject.reload.transaction_id).to eq transaction_id
-      end
-
-      it "saves the amount" do
-        expect(subject.reload.amount).to eq amount
-      end
-
-      it "creates a log entry" do
-        expect(subject.log_entries).to be_present
       end
 
       it "does not attempt to process a transaction" do
@@ -63,103 +76,109 @@ RSpec.describe Spree::Refund, type: :model do
       end
     end
 
-    context "processing is successful" do
-      let(:gateway_response_options) { { authorization: authorization } }
+    context "when transaction_id is nil" do
+      let(:transaction_id) { nil }
 
-      it 'should create a refund' do
-        expect{ subject }.to change{ Spree::Refund.count }.by(1)
+      context "processing is successful" do
+        let(:gateway_response_options) { { authorization: authorization } }
+
+        it 'should create a refund' do
+          expect{ subject }.to change{ Spree::Refund.count }.by(1)
+        end
+
+        it 'returns the newly created refund' do
+          expect(subject).to be_a(Spree::Refund)
+        end
+
+        it 'should save the returned authorization value' do
+          expect(subject.reload.transaction_id).to eq authorization
+        end
+
+        it 'should save the passed amount as the refund amount' do
+          expect(subject.amount).to eq amount
+        end
+
+        it 'should create a log entry' do
+          expect(subject.log_entries).to be_present
+        end
+
+        it "attempts to process a transaction" do
+          expect(payment.payment_method).to receive(:credit).once
+          subject
+        end
+
+        it 'should update the payment total' do
+          expect(payment.order.updater).to receive(:update)
+          subject
+        end
       end
 
-      it 'return the newly created refund' do
-        expect(subject).to be_a(Spree::Refund)
+      context "processing fails" do
+        let(:gateway_response_success) { false }
+        let(:gateway_response_message) { "failure message" }
+
+        it 'should raise error and not create a refund' do
+          expect do
+            expect { subject }.to raise_error(Spree::Core::GatewayError, gateway_response_message)
+          end.to change{ Spree::Refund.count }
+        end
       end
 
-      it 'should save the returned authorization value' do
-        expect(subject.reload.transaction_id).to eq authorization
+      context 'without payment profiles supported' do
+        let(:gateway_response_options) { { authorization: authorization } }
+        before do
+          allow(payment.payment_method).to receive(:payment_profiles_supported?) { false }
+        end
+
+        it 'should not supply the payment source' do
+          expect(payment.payment_method)
+            .to receive(:credit)
+            .with(amount * 100, payment.transaction_id, { originator: an_instance_of(Spree::Refund) })
+            .and_return(gateway_response)
+
+          subject
+        end
       end
 
-      it 'should save the passed amount as the refund amount' do
-        expect(subject.amount).to eq amount
+      context 'with payment profiles supported' do
+        let(:gateway_response_options) { { authorization: authorization } }
+        before do
+          allow(payment.payment_method).to receive(:payment_profiles_supported?) { true }
+        end
+
+        it 'should supply the payment source' do
+          expect(payment.payment_method)
+            .to receive(:credit)
+            .with(amount_in_cents, payment.source, payment.transaction_id, { originator: an_instance_of(Spree::Refund) })
+            .and_return(gateway_response)
+
+          subject
+        end
       end
 
-      it 'should create a log entry' do
-        expect(subject.log_entries).to be_present
+      context 'with an activemerchant gateway connection error' do
+        before do
+          expect(payment.payment_method)
+            .to receive(:credit)
+            .with(amount_in_cents, payment.source, payment.transaction_id, { originator: an_instance_of(Spree::Refund) })
+            .and_raise(ActiveMerchant::ConnectionError.new("foo", nil))
+        end
+
+        it 'raises Spree::Core::GatewayError' do
+          expect { subject }.to raise_error(Spree::Core::GatewayError, I18n.t('spree.unable_to_connect_to_gateway'))
+        end
       end
 
-      it "attempts to process a transaction" do
-        expect(payment.payment_method).to receive(:credit).once
-        subject
-      end
+      context 'with amount too large' do
+        let(:payment_amount) { 10 }
+        let(:amount) { payment_amount * 2 }
 
-      it 'should update the payment total' do
-        expect(payment.order.updater).to receive(:update)
-        subject
-      end
-    end
-
-    context "processing fails" do
-      let(:gateway_response_success) { false }
-      let(:gateway_response_message) { "failure message" }
-
-      it 'should raise error and not create a refund' do
-        expect do
-          expect { subject }.to raise_error(Spree::Core::GatewayError, gateway_response_message)
-        end.to_not change{ Spree::Refund.count }
-      end
-    end
-
-    context 'without payment profiles supported' do
-      before do
-        allow(payment.payment_method).to receive(:payment_profiles_supported?) { false }
-      end
-
-      it 'should not supply the payment source' do
-        expect(payment.payment_method)
-          .to receive(:credit)
-          .with(amount * 100, payment.transaction_id, { originator: an_instance_of(Spree::Refund) })
-          .and_return(gateway_response)
-
-        subject
-      end
-    end
-
-    context 'with payment profiles supported' do
-      before do
-        allow(payment.payment_method).to receive(:payment_profiles_supported?) { true }
-      end
-
-      it 'should supply the payment source' do
-        expect(payment.payment_method)
-          .to receive(:credit)
-          .with(amount_in_cents, payment.source, payment.transaction_id, { originator: an_instance_of(Spree::Refund) })
-          .and_return(gateway_response)
-
-        subject
-      end
-    end
-
-    context 'with an activemerchant gateway connection error' do
-      before do
-        expect(payment.payment_method)
-          .to receive(:credit)
-          .with(amount_in_cents, payment.source, payment.transaction_id, { originator: an_instance_of(Spree::Refund) })
-          .and_raise(ActiveMerchant::ConnectionError.new("foo", nil))
-      end
-
-      it 'raises Spree::Core::GatewayError' do
-        expect { subject }.to raise_error(Spree::Core::GatewayError, I18n.t('spree.unable_to_connect_to_gateway'))
-      end
-    end
-
-    context 'with amount too large' do
-      let(:payment_amount) { 10 }
-      let(:amount) { payment_amount * 2 }
-
-      it 'is invalid' do
-        expect { subject }.to raise_error { |error|
-          expect(error).to be_a(ActiveRecord::RecordInvalid)
-          expect(error.record.errors.full_messages).to eq ["Amount #{I18n.t('activerecord.errors.models.spree/refund.attributes.amount.greater_than_allowed')}"]
-        }
+        it 'is invalid' do
+          expect { subject }.to raise_error { |error|
+            expect(error).to be_a(ActiveRecord::RecordInvalid)
+            expect(error.record.errors.full_messages).to eq ["Amount #{I18n.t('activerecord.errors.models.spree/refund.attributes.amount.greater_than_allowed')}"]
+          }
+        end
       end
     end
 


### PR DESCRIPTION
**Description**

This PR allows creating Refunds without `perform!` being automatically called by a Rails callback. 

This is a combination of two leftover PRs that we want to bring into Solidus `v2.11`:

- #1415 Remove callbacks from refund model by @swively
- #3181 Introduce deprecation warning when using `Spree::Refund#perform!` callback by @aitbw

They were both incomplete: the first one was doing the job but without taking care of adding a deprecation warning, the second one was only adding the deprecation warning without actually change the behavior. If this is an accepted approach we can close both of them.

I merged them together and added some missing pieces. In 3.0 we'll introduce a deprecation warning for that attribute so that people can remove that since it will be useless.

**Some notes for the CHANGELOG entry:**

```
From Solidus v3.0 onwards, #perform! will need to be explicitly called when creating new refunds. Please, change your code from:

Spree::Refund.create(your: attributes)

to:

Spree::Refund.create(your: attributes, perform_after_creation: false).perform!

The `perform_after_creation` attribute will be deprecated in Solidus 3.x 
```

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- ~[ ] I have attached screenshots to this PR for visual changes (if needed)~
