### PR TITLE
[guides] Fix awesome nested set gem link

### DIFF
--- a/guides/source/developers/products-and-variants/taxonomies-and-taxons.html.md
+++ b/guides/source/developers/products-and-variants/taxonomies-and-taxons.html.md
@@ -70,5 +70,5 @@ locations within the hierarchy of the item. This logic is handled by the
 `awesome_nested_set` gem. See [the gem's documentation][awesome-nested-set]
 for more information about these fields.
 
-[awesome-nested-set-usage]: https://github.com/collectiveidea/awesome_nested_set
+[awesome-nested-set]: https://github.com/collectiveidea/awesome_nested_set
 [nested-set-model]: http://en.wikipedia.org/wiki/Nested_set_model


### PR DESCRIPTION
**Description**

The markdown link was named incorrectly, so the page was not showing the proper link.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
