### PR TITLE
Add BCC email to spree_store

### DIFF
--- a/api/app/helpers/spree/api/api_helpers.rb
+++ b/api/app/helpers/spree/api/api_helpers.rb
@@ -175,7 +175,8 @@ module Spree
 
       @@store_attributes = [
         :id, :name, :url, :meta_description, :meta_keywords, :seo_title,
-        :mail_from_address, :default_currency, :code, :default, :available_locales
+        :mail_from_address, :default_currency, :code, :default, :available_locales,
+        :bcc_email
       ]
 
       @@store_credit_history_attributes = [

--- a/api/openapi/solidus-api.oas.yml
+++ b/api/openapi/solidus-api.oas.yml
@@ -5976,6 +5976,8 @@ components:
           type: integer
         mail_from_address:
           type: string
+        bcc_email:
+          type: string
         meta_description:
           type: string
         meta_keywords:
@@ -6498,6 +6500,8 @@ components:
         default_currency:
           type: string
         mail_from_address:
+          type: string
+        bcc_email:
           type: string
         cart_tax_country_iso:
           type: string

--- a/api/spec/requests/spree/api/stores_controller_spec.rb
+++ b/api/spec/requests/spree/api/stores_controller_spec.rb
@@ -33,6 +33,7 @@ module Spree
             "meta_keywords" => nil,
             "seo_title" => nil,
             "mail_from_address" => "spree@example.org",
+            "bcc_email" => nil,
             "default_currency" => nil,
             "code" => store.code,
             "default" => true,
@@ -46,6 +47,7 @@ module Spree
             "meta_keywords" => nil,
             "seo_title" => nil,
             "mail_from_address" => "spree@example.org",
+            "bcc_email" => nil,
             "default_currency" => nil,
             "code" => non_default_store.code,
             "default" => false,
@@ -64,6 +66,7 @@ module Spree
           "meta_keywords" => nil,
           "seo_title" => nil,
           "mail_from_address" => "spree@example.org",
+          "bcc_email" => nil,
           "default_currency" => nil,
           "code" => store.code,
           "default" => true,
@@ -85,12 +88,14 @@ module Spree
       it "can update an existing store" do
         store_hash = {
           url: "spree123.example.com",
-          mail_from_address: "me@example.com"
+          mail_from_address: "me@example.com",
+          bcc_email: "bcc@example.net"
         }
         put spree.api_store_path(store), params: { store: store_hash }
         expect(response.status).to eq(200)
         expect(store.reload.url).to eql "spree123.example.com"
         expect(store.reload.mail_from_address).to eql "me@example.com"
+        expect(store.reload.bcc_email).to eql "bcc@example.net"
       end
 
       context "deleting a store" do

--- a/backend/app/views/spree/admin/stores/_form.html.erb
+++ b/backend/app/views/spree/admin/stores/_form.html.erb
@@ -44,6 +44,12 @@
       <%= f.error_message_on :mail_from_address %>
     <% end %>
 
+    <%= f.field_container :bcc_email do %>
+      <%= f.label :bcc_email %>
+      <%= f.text_field :bcc_email, class: 'fullwidth' %>
+      <%= f.error_message_on :bcc_email %>
+    <% end %>
+
     <%= f.field_container :default_currency do %>
       <%= f.label :default_currency %>
       <%= f.select :default_currency,

--- a/core/app/mailers/spree/base_mailer.rb
+++ b/core/app/mailers/spree/base_mailer.rb
@@ -6,6 +6,10 @@ module Spree
       store.mail_from_address
     end
 
+    def bcc_address(store)
+      store.bcc_email
+    end
+
     def money(amount, currency = Spree::Config[:currency])
       Spree::Money.new(amount, currency: currency).to_s
     end

--- a/core/app/mailers/spree/order_mailer.rb
+++ b/core/app/mailers/spree/order_mailer.rb
@@ -7,7 +7,7 @@ module Spree
       @store = @order.store
       subject = build_subject(t('.subject'), resend)
 
-      mail(to: @order.email, from: from_address(@store), subject: subject)
+      mail(to: @order.email, bcc: bcc_address(@store), from: from_address(@store), subject: subject)
     end
 
     def cancel_email(order, resend = false)

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -359,6 +359,7 @@ en:
         default: Default
         default_currency: Default Currency
         mail_from_address: Mail From Address
+        bcc_email: BCC Email
         meta_description: Meta Description
         meta_keywords: Meta Keywords
         name: Site Name

--- a/core/db/migrate/20200530111458_add_bcc_email_to_spree_stores.rb
+++ b/core/db/migrate/20200530111458_add_bcc_email_to_spree_stores.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddBccEmailToSpreeStores < ActiveRecord::Migration[5.2]
+  def change
+    add_column :spree_stores, :bcc_email, :string
+  end
+end

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -108,7 +108,8 @@ module Spree
 
     @@store_attributes = [:name, :url, :seo_title, :meta_keywords,
                           :meta_description, :default_currency,
-                          :mail_from_address, :cart_tax_country_iso]
+                          :mail_from_address, :cart_tax_country_iso,
+                          :bcc_email]
 
     @@taxonomy_attributes = [:name]
 

--- a/core/spec/mailers/order_mailer_spec.rb
+++ b/core/spec/mailers/order_mailer_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Spree::OrderMailer, type: :mailer do
     product = stub_model(Spree::Product, name: %{The "BEST" product})
     variant = stub_model(Spree::Variant, product: product)
     price = stub_model(Spree::Price, variant: variant, amount: 5.00)
-    store = FactoryBot.build :store, mail_from_address: "store@example.com"
+    store = FactoryBot.build :store, mail_from_address: "store@example.com", bcc_email: "bcc@example.com"
     line_item = stub_model(Spree::LineItem, variant: variant, order: order, quantity: 1, price: 4.99)
     allow(variant).to receive_messages(default_price: price)
     allow(order).to receive_messages(line_items: [line_item])
@@ -19,6 +19,11 @@ RSpec.describe Spree::OrderMailer, type: :mailer do
   it "uses the order's store for the from address" do
     message = Spree::OrderMailer.confirm_email(order)
     expect(message.from).to eq ["store@example.com"]
+  end
+
+  it "uses the order's store for the bcc address" do
+    message = Spree::OrderMailer.confirm_email(order)
+    expect(message.bcc).to eq ["bcc@example.com"]
   end
 
   it "doesn't aggressively escape double quotes in confirmation body" do


### PR DESCRIPTION
**THIS PR SPONSORED BY [Super Good Software](https://supergood.software/)**

**Description**
Adds a BCC email field to the spree store edit page.
This indicates a BCC email that you want all order confirmation
emails to be BCCed to. As indicated in #3615 , this is a feature
that I think a lot of eCommerce stores are interested in, at
the very least to server as a notification of a new order.

![image](https://user-images.githubusercontent.com/5720486/83337336-0a448e00-a280-11ea-973d-ad47a711d4e3.png)

Also adds the ability to add/update this field through the API

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
