### PR TITLE
Add factory_bot lint test to core

### DIFF
--- a/core/lib/spree/testing_support/factories/store_credit_event_factory.rb
+++ b/core/lib/spree/testing_support/factories/store_credit_event_factory.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
     store_credit
     amount             { 100.00 }
     authorization_code { "#{store_credit.id}-SC-20140602164814476128" }
+    action               { Spree::StoreCredit::AUTHORIZE_ACTION }
 
     factory :store_credit_auth_event, class: 'Spree::StoreCreditEvent' do
       action             { Spree::StoreCredit::AUTHORIZE_ACTION }

--- a/core/lib/spree/testing_support/factories/store_credit_reason_factory.rb
+++ b/core/lib/spree/testing_support/factories/store_credit_reason_factory.rb
@@ -2,6 +2,8 @@
 
 FactoryBot.define do
   factory :store_credit_reason, class: 'Spree::StoreCreditReason' do
-    name { "Input error" }
+    sequence :name do |n|
+      "Input error #{n}"
+    end
   end
 end

--- a/core/spec/lib/factory_spec.rb
+++ b/core/spec/lib/factory_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe "Factories" do
+  it "should pass linting" do
+    FactoryBot.lint(FactoryBot.factories.reject{ |f| f.name == :customer_return_without_return_items })
+  end
+end


### PR DESCRIPTION
**THIS PR SPONSORED BY [Super Good Software](https://supergood.software/)**

**Description**

Adds a test that lints FactoryBot. Also makes changes to two tests to
conform to the lint - store_credit_event_factory needs to have an
action, even if the action is replaced with one of the sub factories.
store_credit_reason_factory tripped the linter because of a uniqueness
contraint for the name - should not come up in normal testing, but I
added a sequencer to account for it in the linter anyway.

The linter ignores just one factory - customer_return_without_return_items
this factory is intentionally invalid (see:
[customer_return_factory_spec.rb](https://github.com/solidusio/solidus/blob/1aa554fb04d2e28d279ec28a6ddb36b6ca2e5956/core/spec/lib/spree/core/testing_support/factories/customer_return_factory_spec.rb#L37)
).. though I think we should re-evaluate that, maybe open an issue for changing it.

This PR is attempting to close (at the time of writing) the oldest issue for Solidus, #568 

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
