### PR TITLE
Eager loading countries when creating a new zone

### DIFF
--- a/backend/app/controllers/spree/admin/zones_controller.rb
+++ b/backend/app/controllers/spree/admin/zones_controller.rb
@@ -20,7 +20,7 @@ module Spree
 
       def load_data
         @countries = Spree::Country.order(:name)
-        @states = Spree::State.order(:name)
+        @states = Spree::State.includes(:country).order(:name)
         @zones = Spree::Zone.order(:name)
       end
     end


### PR DESCRIPTION
Zones can be created at country or state level, and the
select box that renders the state, it needs the country name
as well, to build this, it calls the mthod state_with_country
and it causes a query n+1, eager loading their countries
improves dramatically the response time when rendering the
new form.


## Before
Started GET "/admin/zones/new"
....
Rendered backend/app/views/spree/admin/zones/_state_members.html.erb (Duration: 10392.6ms | Allocations: 10016775)
...
Completed 200 OK in 11247ms (Views: 10958.5ms | ActiveRecord: 257.5ms | Allocations: 11049597)

## After
Started GET "/admin/zones/new"
....
Rendered backend/app/views/spree/admin/zones/_state_members.html.erb (Duration: 237.7ms | Allocations: 179137)
...
Completed 200 OK in 1268ms (Views: 1034.5ms | ActiveRecord: 108.2ms | Allocations: 1278890)


**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
