### PR TITLE
[Backend] More precise cancan validations for some resource links

### DIFF
--- a/backend/app/views/spree/admin/images/index.html.erb
+++ b/backend/app/views/spree/admin/images/index.html.erb
@@ -13,29 +13,31 @@
   <%= render 'new', product: @product, image: Spree::Image.new(viewable: @product) %>
 </div>
 
-<fieldset class="no-border-bottom">
-  <legend align="center"><%= t(".upload_images") %></legend>
+<% if can?(:create, Spree::Image) %>
+  <fieldset class="no-border-bottom">
+    <legend align="center"><%= t(".upload_images") %></legend>
 
-  <div id="upload-zone">
-    <%= form_for [:admin, @product, Spree::Image.new],
-        html: { multipart: true, id: 'upload-form' } do |f| %>
-      <label class="upload">
-        <i class="fa fa-5x fa-cloud-upload"></i>
-        <p>
-          <span class="button"><%= t(".choose_files") %></span>
-        </p>
-        <p>
-          <%= t(".drag_and_drop") %>
-        </p>
+    <div id="upload-zone">
+      <%= form_for [:admin, @product, Spree::Image.new],
+          html: { multipart: true, id: 'upload-form' } do |f| %>
+        <label class="upload">
+          <i class="fa fa-5x fa-cloud-upload"></i>
+          <p>
+            <span class="button"><%= t(".choose_files") %></span>
+          </p>
+          <p>
+            <%= t(".drag_and_drop") %>
+          </p>
 
-        <%= f.file_field :attachment, multiple: '', class: 'hidden' %>
-        <%= f.hidden_field :viewable_id, value: @product.master.id %>
-      </label>
-    <% end %>
-  </div>
+          <%= f.file_field :attachment, multiple: '', class: 'hidden' %>
+          <%= f.hidden_field :viewable_id, value: @product.master.id %>
+        </label>
+      <% end %>
+    </div>
 
-  <div id="progress-zone" class="row"></div>
-</fieldset>
+    <div id="progress-zone" class="row"></div>
+  </fieldset>
+<% end %>
 
 <% no_images = @product.gallery.images.empty? %>
 

--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -7,7 +7,7 @@
   <li>
     <%= link_to t('spree.new_order'), new_admin_order_url, id: 'admin_new_order', class: 'btn btn-primary' %>
   </li>
-<% end if can? :create, Spree::Order %>
+<% end if can? :manage, Spree::Order %>
 
 <% content_for :table_filter_title do %>
   <%= t('spree.filter') %>
@@ -197,9 +197,11 @@
   </table>
 <% else %>
   <div class="no-objects-found">
-    <%= render 'spree/admin/shared/no_objects_found',
-                 resource: Spree::Order,
-                 new_resource_url: spree.new_admin_order_path %>
+    <% if can? :manage, Spree::Order %>
+      <%= render 'spree/admin/shared/no_objects_found',
+                   resource: Spree::Order,
+                   new_resource_url: spree.new_admin_order_path %>
+    <% end %>
   </div>
 <% end %>
 

--- a/backend/app/views/spree/admin/payments/index.html.erb
+++ b/backend/app/views/spree/admin/payments/index.html.erb
@@ -3,7 +3,9 @@
 <% content_for :page_actions do %>
   <% if @order.outstanding_balance? %>
     <li id="new_payment_section">
-      <%= link_to t('spree.new_payment'), new_admin_order_payment_url(@order), class: 'btn btn-primary' %>
+      <% if can? :create, Spree::Payment %>
+        <%= link_to t('spree.new_payment'), new_admin_order_payment_url(@order), class: 'btn btn-primary' %>
+      <% end %>
     </li>
   <% end %>
 <% end %>

--- a/backend/app/views/spree/admin/return_authorizations/index.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/index.html.erb
@@ -3,7 +3,7 @@
 <% content_for :page_actions do %>
   <% if @order.shipments.any? &:shipped? %>
     <li>
-      <% if can? :create, Spree::ReturnAuthorization %>
+      <% if can? :manage, Spree::ReturnAuthorization %>
         <%= link_to t('spree.new_return_authorization'), new_admin_order_return_authorization_url(@order), class: 'btn btn-primary' %>
       <% end %>
     </li>

--- a/backend/app/views/spree/admin/users/items.html.erb
+++ b/backend/app/views/spree/admin/users/items.html.erb
@@ -72,9 +72,11 @@
     </table>
   <% else %>
     <div class="no-objects-found">
-      <%= render 'spree/admin/shared/no_objects_found',
-                   resource: Spree::Order,
-                   new_resource_url: spree.new_admin_order_path(user_id: @user.id) %>
+      <% if can? :manage, Spree::Order %>
+        <%= render 'spree/admin/shared/no_objects_found',
+                     resource: Spree::Order,
+                     new_resource_url: spree.new_admin_order_path(user_id: @user.id) %>
+      <% end %>
     </div>
   <% end %>
   <%= paginate @orders, theme: "solidus_admin" %>

--- a/backend/app/views/spree/admin/users/items.html.erb
+++ b/backend/app/views/spree/admin/users/items.html.erb
@@ -74,7 +74,7 @@
     <div class="no-objects-found">
       <%= render 'spree/admin/shared/no_objects_found',
                    resource: Spree::Order,
-                   new_resource_url: spree.new_admin_order_path %>
+                   new_resource_url: spree.new_admin_order_path(user_id: @user.id) %>
     </div>
   <% end %>
   <%= paginate @orders, theme: "solidus_admin" %>

--- a/backend/app/views/spree/admin/users/orders.html.erb
+++ b/backend/app/views/spree/admin/users/orders.html.erb
@@ -72,9 +72,11 @@
     </table>
   <% else %>
     <div class="no-objects-found">
-      <%= render 'spree/admin/shared/no_objects_found',
-                   resource: Spree::Order,
-                   new_resource_url: spree.new_admin_order_path(user_id: @user.id) %>
+      <% if can? :manage, Spree::Order %>
+        <%= render 'spree/admin/shared/no_objects_found',
+                     resource: Spree::Order,
+                     new_resource_url: spree.new_admin_order_path(user_id: @user.id) %>
+      <% end %>
     </div>
   <% end %>
 

--- a/backend/spec/features/admin/orders/listing_spec.rb
+++ b/backend/spec/features/admin/orders/listing_spec.rb
@@ -21,8 +21,9 @@ describe "Orders Listing", type: :feature, js: true do
 
   context 'without create permission' do
     custom_authorization! do |_user|
-      can :manage, Spree::Order
-      cannot :create, Spree::Order
+      cannot :manage, Spree::Order
+      can :admin, Spree::Order
+      can :display, Spree::Order
     end
 
     it 'does not display the new order button' do

--- a/backend/spec/features/admin/orders/payments_spec.rb
+++ b/backend/spec/features/admin/orders/payments_spec.rb
@@ -16,6 +16,18 @@ describe 'Payments', type: :feature do
       visit "/admin/orders/#{order.number}/payments"
     end
 
+    context "when the user cannot create payments" do
+      custom_authorization! do |_user|
+        cannot :create, Spree::Payment
+      end
+
+      it "does not show the link for creating new payments" do
+        within "#content-header" do
+          expect(page).not_to have_content "New Payment"
+        end
+      end
+    end
+
     # Regression tests for https://github.com/spree/spree/issues/1453
     context 'with a check payment', js: true do
       let(:order) { create(:completed_order_with_totals, number: 'R100') }

--- a/backend/spec/features/admin/orders/return_authorizations_spec.rb
+++ b/backend/spec/features/admin/orders/return_authorizations_spec.rb
@@ -9,47 +9,66 @@ describe "ReturnAuthorizations", type: :feature do
 
   let!(:order) { create(:shipped_order) }
 
-  describe "create" do
-    def create_return_authorization
-      find("#select-all").click
-      select "NY Warehouse", from: "Stock Location"
-      click_button "Create"
+  context "when the user cannot manage return authorizations" do
+    custom_authorization! do |_user|
+      cannot :manage, Spree::ReturnAuthorization
+      can [:display, :admin], Spree::ReturnAuthorization
     end
 
     before do
-      visit spree.new_admin_order_return_authorization_path(order)
-    end
-
-    it "creates a return authorization" do
-      create_return_authorization
-
-      expect(page).to have_content "Return Authorization has been successfully created!"
-    end
-
-    it "disables the button at submit", :js do
-      page.execute_script "$('form').submit(function(e) { e.preventDefault()})"
-
-      create_return_authorization
-
-      expect(page).to have_button("Create", disabled: true)
-    end
-  end
-
-  describe "when a return authorization exists" do
-    let!(:return_authorization) { create(:return_authorization, order: order) }
-
-    it "can visit the return authorizations list page" do
       visit spree.admin_order_return_authorizations_path(order)
     end
 
-    describe "edit" do
-      it "can visit the return authorizations edit page" do
-        visit spree.edit_admin_order_return_authorization_path(order, return_authorization)
+    it "does not show the link for creating new RMAs" do
+      within "#content-header" do
+        expect(page).not_to have_content "New RMA"
+      end
+    end
+  end
+
+  context "when the user can manage return authorizations" do
+    describe "create" do
+      def create_return_authorization
+        find("#select-all").click
+        select "NY Warehouse", from: "Stock Location"
+        click_button "Create"
       end
 
-      it "return authorizations edit page has a data hook for extensions to add content above, below or within the RA form" do
-        visit spree.edit_admin_order_return_authorization_path(order, return_authorization)
-        expect(page).to have_selector("[data-hook=return-authorization-form-wrapper]")
+      before do
+        visit spree.new_admin_order_return_authorization_path(order)
+      end
+
+      it "creates a return authorization" do
+        create_return_authorization
+
+        expect(page).to have_content "Return Authorization has been successfully created!"
+      end
+
+      it "disables the button at submit", :js do
+        page.execute_script "$('form').submit(function(e) { e.preventDefault()})"
+
+        create_return_authorization
+
+        expect(page).to have_button("Create", disabled: true)
+      end
+    end
+
+    describe "when a return authorization exists" do
+      let!(:return_authorization) { create(:return_authorization, order: order) }
+
+      it "can visit the return authorizations list page" do
+        visit spree.admin_order_return_authorizations_path(order)
+      end
+
+      describe "edit" do
+        it "can visit the return authorizations edit page" do
+          visit spree.edit_admin_order_return_authorization_path(order, return_authorization)
+        end
+
+        it "return authorizations edit page has a data hook for extensions to add content above, below or within the RA form" do
+          visit spree.edit_admin_order_return_authorization_path(order, return_authorization)
+          expect(page).to have_selector("[data-hook=return-authorization-form-wrapper]")
+        end
       end
     end
   end

--- a/backend/spec/features/admin/products/edit/images_spec.rb
+++ b/backend/spec/features/admin/products/edit/images_spec.rb
@@ -16,15 +16,30 @@ describe "Product Images", type: :feature do
   end
 
   context "uploading, editing, and deleting an image", js: true do
-    it "should allow an admin to upload and edit an image for a product" do
+    before do
       Spree::Image.attachment_definitions[:attachment].delete :storage
-
       create(:product)
 
       visit spree.admin_path
       click_nav "Products"
       click_icon(:edit)
       click_link "Images"
+    end
+
+    context 'when the user cannot create images' do
+      custom_authorization! do |_user|
+        cannot :create, Spree::Image
+      end
+
+      it "does not show links for creating images" do
+        within '#content-header' do
+          expect(page).not_to have_content 'New Image'
+        end
+        expect(page).not_to have_content 'Choose files to upload'
+      end
+    end
+
+    it "should allow an admin to upload and edit an image for a product" do
       click_link "new_image_link"
       within_fieldset 'New Image' do
         attach_file('image_attachment', file_path)

--- a/backend/spec/features/admin/users_spec.rb
+++ b/backend/spec/features/admin/users_spec.rb
@@ -22,6 +22,21 @@ describe 'Users', type: :feature do
 
   let(:orders) { [order, order_2] }
 
+  describe 'the user items page' do
+    context 'when the user cannot manage orders' do
+      custom_authorization! do |_user|
+        cannot :manage, Spree::Order
+        can [:display, :admin], Spree::Order
+      end
+
+      before { visit spree.items_admin_user_path(user_a) }
+
+      it 'does not show the link for creating new orders' do
+        expect(page).not_to have_content 'No Orders found. Create One.'
+      end
+    end
+  end
+
   shared_examples_for 'a user page' do
     it 'has lifetime stats' do
       orders


### PR DESCRIPTION
**Description**

This the continuation of the [work](https://github.com/solidusio/solidus/pull/2823) done by @memotoro that I was unable to continue on the original PR.

I added some integration tests in order to verify permissions work as expected, and I reintroduced
the user id specification to some new order links as the context implies we're going to create an order for the given user.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
