### PR TITLE
Allow Importer::Order to accept array of line items and stock_location_id

### DIFF
--- a/core/lib/spree/core/importer/order.rb
+++ b/core/lib/spree/core/importer/order.rb
@@ -56,7 +56,9 @@ module Spree
           shipments_hash.each do |target|
             shipment = Shipment.new
             shipment.tracking       = target[:tracking]
-            shipment.stock_location = Spree::StockLocation.find_by(admin_name: target[:stock_location]) || Spree::StockLocation.find_by!(name: target[:stock_location])
+            shipment.stock_location = Spree::StockLocation.find_by(id: target[:stock_location_id]) ||
+            Spree::StockLocation.find_by(admin_name: target[:stock_location]) ||
+            Spree::StockLocation.find_by!(name: target[:stock_location])
 
             inventory_units = target[:inventory_units] || []
             inventory_units.each do |inventory_unit|

--- a/core/spec/lib/spree/core/importer/order_spec.rb
+++ b/core/spec/lib/spree/core/importer/order_spec.rb
@@ -142,6 +142,19 @@ module Spree
         expect(line_item.quantity).to eq(5)
       end
 
+      it 'handle when line items is an array' do
+        params = {
+          line_items_attributes: [
+            { variant_id: variant_id, quantity: 7 }
+          ]
+        }
+        order = Importer::Order.import(user, params)
+
+        line_item = order.line_items.first
+        expect(line_item.variant_id).to eq(variant_id)
+        expect(line_item.quantity).to eq(7)
+      end
+
       it 'can build an order from API shipping address' do
         params = { ship_address_attributes: ship_address,
                    line_items_attributes: line_items }

--- a/core/spec/lib/spree/core/importer/order_spec.rb
+++ b/core/spec/lib/spree/core/importer/order_spec.rb
@@ -325,6 +325,15 @@ module Spree
           }.to raise_error ActiveRecord::RecordNotFound
         end
 
+        it "accepts stock_location_id" do
+          params[:shipments_attributes][0][:stock_location] = nil
+          params[:shipments_attributes][0][:stock_location_id] = stock_location.id
+          order = Importer::Order.import(user, params)
+          shipment = order.shipments.first
+
+          expect(shipment.stock_location).to eq stock_location
+        end
+
         context 'when completed_at and shipped_at present' do
           let(:params) do
             {


### PR DESCRIPTION
**Description**
This PR is for improve `Importer::Order` to allow `stock_location_id` when create shipments and allow use an array for `line_item_attributes`.

`Importer::Order` is used internally for `solidus_api` to create orders, and like is [documented](https://solidus.docs.stoplight.io/api-reference/orders/create-order) should allow `stock_location_id` in `shipments_attributes` and an array for `line_item_attributes`.

**Checklist:**
- [X] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [X] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [X] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)