### PR TITLE
Add webdrivers gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,7 @@ group :backend, :frontend do
   gem 'capybara', '~> 3.13', require: false
   gem 'capybara-screenshot', '>= 1.0.18', require: false
   gem 'selenium-webdriver', require: false
+  gem 'webdrivers', require: false
 end
 
 group :frontend do

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -44,6 +44,7 @@ Capybara.save_path = ENV['CIRCLE_ARTIFACTS'] if ENV['CIRCLE_ARTIFACTS']
 Capybara.exact = true
 
 require "selenium/webdriver"
+require 'webdrivers'
 
 Capybara.register_driver :selenium_chrome_headless do |app|
   browser_options = ::Selenium::WebDriver::Chrome::Options.new

--- a/backend/spec/teaspoon_env.rb
+++ b/backend/spec/teaspoon_env.rb
@@ -3,6 +3,7 @@
 ENV['RAILS_ENV'] = 'test'
 
 require 'teaspoon/driver/selenium'
+require 'webdrivers'
 
 # Similar to setup described in
 # https://github.com/jejacks0n/teaspoon/wiki/Micro-Applications

--- a/frontend/spec/spec_helper.rb
+++ b/frontend/spec/spec_helper.rb
@@ -44,6 +44,7 @@ Capybara.save_path = ENV['CIRCLE_ARTIFACTS'] if ENV['CIRCLE_ARTIFACTS']
 Capybara.default_max_wait_time = ENV['DEFAULT_MAX_WAIT_TIME'].to_f if ENV['DEFAULT_MAX_WAIT_TIME'].present?
 
 require "selenium/webdriver"
+require 'webdrivers'
 Capybara.javascript_driver = (ENV['CAPYBARA_DRIVER'] || :selenium_chrome_headless).to_sym
 
 ActiveJob::Base.queue_adapter = :test


### PR DESCRIPTION
**Description**

Running the feature specs locally is failing for me with Chrome Version 83

```
Selenium::WebDriver::Error::SessionNotCreatedError:
              session not created: Chrome version must be between 71 and 75
                (Driver info: chromedriver=2.46.628411 (3324f4c8be9ff2f70a05a30ebc72ffb013e1a71e),platform=Mac OS X 10.14.6 x86_64)
```

Adding the webdrivers gem is solving this problem for me and I suspect others as well. 


**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
