### PR TITLE
Allow to specify if billing address is required for orders

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -562,6 +562,14 @@ module Spree
       end
     end
 
+    def ensure_billing_address
+      return unless billing_address_required?
+      return if bill_address&.valid?
+
+      errors.add(:base, I18n.t('spree.bill_address_required'))
+      false
+    end
+
     def billing_address_required?
       Spree::Config.billing_address_required
     end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -562,6 +562,10 @@ module Spree
       end
     end
 
+    def billing_address_required?
+      Spree::Config.billing_address_required
+    end
+
     def create_proposed_shipments
       if completed?
         raise CannotRebuildShipments.new(I18n.t('spree.cannot_rebuild_shipments_order_completed'))

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -82,6 +82,7 @@ module Spree
 
               after_transition to: :complete, do: :add_payment_sources_to_wallet
               before_transition to: :payment, do: :add_default_payment_from_wallet
+              before_transition to: :payment, do: :ensure_billing_address
 
               before_transition to: :confirm, do: :add_store_credit_payments
 

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1984,6 +1984,7 @@ en:
     ship: ship
     ship_address: Ship Address
     ship_address_required: Valid shipping address required
+    bill_address_required: Valid billing address required
     ship_total: Ship Total
     shipment: Shipment
     shipment_adjustments: Shipment adjustments

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -96,6 +96,13 @@ module Spree
     #   @return [Boolean] Whether use of an address in checkout marks it as user's default
     preference :automatic_default_address, :boolean, default: true
 
+    # @!attribute [rw] billing_address_required
+    #   Controls whether billing address is required or not in the checkout process
+    #   by default, can be overridden at order level.
+    #   (default: +false+)
+    #   @return [Boolean]
+    preference :billing_address_required, :boolean, default: false
+
     # @!attribute [rw] binary_inventory_cache
     #   Only invalidate product caches when they change from in stock to out of
     #   stock. By default, caches are invalidated on any change of inventory

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -5,7 +5,7 @@ require 'spree/testing_support/order_walkthrough'
 
 RSpec.describe Spree::Order, type: :model do
   let!(:store) { create(:store) }
-  let(:order) { Spree::Order.new(store: store) }
+  let(:order) { create(:order, store: store) }
 
   def assert_state_changed(order, from, to)
     state_change_exists = order.state_changes.where(previous_state: from, next_state: to).exists?
@@ -139,6 +139,7 @@ RSpec.describe Spree::Order, type: :model do
           it_behaves_like "it references the user's the default address" do
             let(:address_kind) { :ship }
             before do
+              order.ship_address = nil
               order.user = FactoryBot.create(:user)
               order.user.ship_address = default_address
               order.next!
@@ -149,6 +150,7 @@ RSpec.describe Spree::Order, type: :model do
           it_behaves_like "it references the user's the default address" do
             let(:address_kind) { :bill }
             before do
+              order.bill_address = nil
               order.user = FactoryBot.create(:user)
               order.user.bill_address = default_address
               order.next!
@@ -204,6 +206,7 @@ RSpec.describe Spree::Order, type: :model do
       end
 
       it "does not call persist_order_address if there is no address on the order" do
+        order.bill_address = nil
         order.user = FactoryBot.create(:user)
         order.save!
 
@@ -278,10 +281,8 @@ RSpec.describe Spree::Order, type: :model do
     end
 
     context "from delivery", partial_double_verification: false do
-      let(:ship_address) { FactoryBot.create(:ship_address) }
 
       before do
-        order.ship_address = ship_address
         order.state = 'delivery'
         allow(order).to receive(:apply_shipping_promotions)
         allow(order).to receive(:ensure_available_shipping_rates) { true }

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -303,6 +303,16 @@ RSpec.describe Spree::Order, type: :model do
           assert_state_changed(order, 'delivery', 'payment')
           expect(order.state).to eq('payment')
         end
+
+        it 'fails if billing address is required and missing' do
+          payment_method = create(:payment_method)
+          allow(payment_method).to receive(:billing_address_required?).and_return(true)
+          allow(order).to receive(:available_payment_methods).and_return([payment_method])
+          order.bill_address = nil
+          allow(Spree::Config).to receive(:billing_address_required).and_return(true)
+
+          expect { order.next! }.to raise_error(StateMachines::InvalidTransition, /#{I18n.t('spree.bill_address_required')}/)
+        end
       end
 
       context "without payment required" do


### PR DESCRIPTION
With the implementation of default bill address, we have found that some legacy users are going thought the checkout process without billing address failing at the confirm step, this change makes sure that billing address is present.

I am not totally sure if this should be controlled via config variable but I'm assuming all payment methods require billing address

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change (if needed)
