### PR TITLE
Fix typos in guides

### DIFF
--- a/guides/source/users/promotions/overview.html.md
+++ b/guides/source/users/promotions/overview.html.md
@@ -70,7 +70,6 @@ methods:
   configured promotion rules. See [Multiple promotion
   codes](#multiple-promotion-codes) below for more information.
 
-[promotion-rules]: promotion-rules.html
 
 ### Multiple promotions codes
 
@@ -95,7 +94,7 @@ codes that were generated for it:
 
 1. Go to the **Promotions** page of the Solidus admin.
 2. Select the **Edit** button next to the promotion that you want to download
-   promotion codes for.dd
+   promotion codes for.
 3. Select the **Download Code List** button to download a list of codes in CSV
    format.
 
@@ -116,3 +115,6 @@ List** link next to the batch you want the codes for.
 You can set up promotion categories to organize your promotions. Promotion
 categories have a **Name** and a **Code**. Your customers cannot see promotion
 categories. Only store administrators can see promotion categories.
+
+[promotion-rules]: promotion-rules.html
+[promotion-actions]: promotion-actions.html

--- a/guides/source/users/promotions/promotion-calculators.html.md
+++ b/guides/source/users/promotions/promotion-calculators.html.md
@@ -26,16 +26,16 @@ available to calculate:
 | [Distributed Amount][1] |            | Available   |                             |               |
 | [Free Shipping][2]      |            |             |                             | Available     |
 | [Flat Percent][3]       | Available  |             |                             |               |
-| [Flat Rat][4]           | Available  | Available   | Available                   |               |
+| [Flat Rate][4]          | Available  | Available   | Available                   |               |
 | [Flexible Rate][5]      | Available  | Available   | Available                   |               |
 | [Tiered Flat Rate][6]   | Available  |             |                             |               |
 | [Tiered Percent][7]     | Available  | Available   |                             |               |
 | [Percent Per Item][8]   |            | Available   |                             |               |
 
 The following sections outline all of the promotion calculators, the contexts
-they can be used in, and how they work. 
+they can be used in, and how they work.
 
-[1]: #distributed-amount 
+[1]: #distributed-amount
 [2]: #free-shipping
 [3]: #flat-percent
 [4]: #flat-rate
@@ -63,7 +63,7 @@ items as a discount.
 
 The free shipping calculator only requires that you use the promotion action
 type **Free shipping** when you create the promotion action. Then, all shipping
-charges from an order are deducted when the promotion is activated. 
+charges from an order are deducted when the promotion is activated.
 
 ## Flat percent
 
@@ -97,7 +97,7 @@ To replicate the example above, you could set the **First Item** amount to
 ## Tiered flat rate
 
 The **Tiered Flat Rate** calculator provides a tiered flat rate discount. This
-allows you to charge a rate-based discount that depends on the order total. 
+allows you to charge a rate-based discount that depends on the order total.
 
 This calculator has the following settings:
 
@@ -150,7 +150,7 @@ Amount ($)** of money that triggers the next tier. For each trigger that you
 create, you also set a new **Discount Percentage (%)**  that should be used as
 new discount level for that tier.
 
-In the following example, there are tiers set up for the $100 and $100 purchase
+In the following example, there are tiers set up for the $100 and $200 purchase
 mark:
 
 |   | Tier             | Discount (%) |
@@ -164,8 +164,7 @@ mark:
   example information.
 -->
 
-## Percent per item 
+## Percent per item
 
 The **Percent Per Item** calculator provides a percentage-based discount for
-each applicable line item in an order. 
-
+each applicable line item in an order.


### PR DESCRIPTION
**Description**
Found some typos in the documentation when reading through it.
This PR fixes some of them
