### PR TITLE
Enable/Disable store credit at checkout step

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -676,8 +676,6 @@ module Spree
 
       remaining_total = outstanding_balance - authorized_total
 
-      matching_store_credits = user.store_credits.where(currency: currency)
-
       if matching_store_credits.any?
         payment_method = Spree::PaymentMethod::StoreCredit.first
 
@@ -823,6 +821,20 @@ module Spree
     end
 
     private
+
+    def matching_store_credits
+      @matching_store_credits ||= if use_store_credits?
+                                    user.store_credits.where(currency: currency)
+                                  else
+                                    []
+                                  end
+    end
+
+    def use_store_credits?
+      return Spree::Config[:default_use_store_credits] if use_store_credits.nil?
+
+      super
+    end
 
     def process_payments_before_complete
       return if !payment_required?

--- a/core/db/migrate/20200525083006_add_use_store_credits_to_spree_orders.rb
+++ b/core/db/migrate/20200525083006_add_use_store_credits_to_spree_orders.rb
@@ -1,0 +1,5 @@
+class AddUseStoreCreditsToSpreeOrders < ActiveRecord::Migration[5.2]
+  def change
+    add_column :spree_orders, :use_store_credits, :boolean, default: nil
+  end
+end

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -56,6 +56,10 @@ module Spree
     #   @return [Boolean] When false, customers must create an account to complete an order (default: +true+)
     preference :allow_guest_checkout, :boolean, default: true
 
+    # @!attribute [rw] default_use_store_credits
+    #   @return [Boolean] When true, user store credits will applied for default (default: +true+)
+    preference :default_use_store_credits, :boolean, default: true
+
     # @!attribute [rw] guest_token_cookie_options
     #   @return [Hash] Add additional guest_token cookie options here (ie. domain or path)
     preference :guest_token_cookie_options, :hash, default: {}

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -1297,9 +1297,25 @@ RSpec.describe Spree::Order, type: :model do
         end
 
         context "there is a credit card payment" do
+          subject(:add_store_credit_payments!) { order.add_store_credit_payments }
+
+          let!(:cc_payment) { create(:payment, order: order) }
+
           it "invalidates the credit card payment" do
-            cc_payment = create(:payment, order: order)
             expect { subject }.to change { cc_payment.reload.state }.to 'invalid'
+          end
+
+          context "when the order doesn't use store credits" do
+            let(:order) do
+              create(:order_with_totals,
+                     use_store_credits: false,
+                     user: store_credit.user,
+                     line_items_price: order_total).tap(&:recalculate)
+            end
+
+            it "doesn't invalidates the credit card payment" do
+              expect { add_store_credit_payments! }.not_to(change { cc_payment.reload.state })
+            end
           end
         end
       end


### PR DESCRIPTION
**Description**
This PR adds the ability for the user to enable/disable the store credits at checkout step 

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [ ] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
