### PR TITLE
Cancel authorized (pending) payments when cancelling an order (cont.)

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -914,15 +914,27 @@ module Spree
     end
 
     def after_cancel
-      shipments.each(&:cancel!)
-      payments.completed.each { |payment| payment.cancel! unless payment.fully_refunded? }
-      payments.store_credits.pending.each(&:void_transaction!)
+      cancel_shipments!
+      cancel_payments!
 
       send_cancel_email
       # rubocop:disable Rails/SkipsModelValidations
       update_column(:canceled_at, Time.current)
       # rubocop:enable Rails/SkipsModelValidations
       recalculate
+    end
+
+    def cancel_shipments!
+      shipments.each(&:cancel!)
+    end
+
+    def cancel_payments!
+      payments.each do |payment|
+        next if payment.fully_refunded?
+        next unless payment.pending? || payment.completed?
+
+        payment.cancel!
+      end
     end
 
     def send_cancel_email

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# jj
 
 require 'rails_helper'
 
@@ -131,6 +130,15 @@ RSpec.describe Spree::Order, type: :model do
       end
     end
 
+    context 'when the payment is pending' do
+      let(:order) { create(:completed_order_with_pending_payment) }
+      let(:payment) { order.payments.first }
+
+      it 'voids the pending payment' do
+        expect { subject }.to change { payment.reload.state }.from('pending').to('void')
+      end
+    end
+
     context 'with a store credit payment' do
       let(:order) { create(:completed_order_with_totals) }
       let(:payment) { create(:store_credit_payment, amount: order.total, order: order) }
@@ -157,7 +165,7 @@ RSpec.describe Spree::Order, type: :model do
         end
 
         it 'refunds the payment' do
-          expect { subject  }.to change { Spree::Refund.count }.by(1)
+          expect { subject }.to change { Spree::Refund.count }.by(1)
         end
       end
     end
@@ -1630,7 +1638,6 @@ RSpec.describe Spree::Order, type: :model do
         expect(subject.display_store_credit_remaining_after_capture.money.cents).to eq(amount_remaining * 100.0)
       end
     end
-
   end
 
   context 'update_params_payment_source' do


### PR DESCRIPTION
**Description**
This PR is a rebase and a continuation of #2265

> release funds on a credit card auth for cancelled orders whose
> payments have been authorized but not yet captured.

**Checklist:**
- [X] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [X] I have added a detailed description into each commit message
- [X] I have updated Guides and README accordingly to this change (if needed)
- [X] I have added tests to cover this change (if needed)
- [X] I have attached screenshots to this PR for visual changes (if needed)
