### PR TITLE
Removes deprecated usage of associate_user on OrdersController

### DIFF
--- a/frontend/app/controllers/spree/orders_controller.rb
+++ b/frontend/app/controllers/spree/orders_controller.rb
@@ -41,7 +41,6 @@ module Spree
     def edit
       @order = current_order(build_order_if_necessary: true)
       authorize! :read, @order, cookies.signed[:guest_token]
-      associate_user
       if params[:id] && @order.number != params[:id]
         flash[:error] = t('spree.cannot_edit_orders')
         redirect_to cart_path


### PR DESCRIPTION
**Description**
This Pull Request solves the issue https://github.com/solidusio/solidus/issues/3559

Based on [this discussion](https://github.com/solidusio/solidus/pull/3494#discussion_r386117331) this `associate_user` call is deprecated due to changes during the creation or building of an order via `current_order` where before the creation and association of an user were made in different places now it is done immediately. This seems to classify as refactoring, and for that reason I didn't add tests

There is also a call of `associate_user` in `CheckoutController` which is called after `load_order` that calls `current_order` but I didn't remove it here due to the discussion regarding the order of execution and its impacts on some stores. I would like @elia's comment regarding this, and maybe we could do it on this PR as well.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
