### PR TITLE
Add Refund#perform_response and reintroduce @response ivar

### DIFF
--- a/core/app/models/spree/refund.rb
+++ b/core/app/models/spree/refund.rb
@@ -52,6 +52,14 @@ module Spree
 
       @perform_response = process!(credit_cents)
 
+      @response = Spree::DeprecatedInstanceVariableProxy.new(
+        self,
+        :perform_response,
+        :@response,
+        Spree::Deprecation,
+        "Please, do not use Spree::Refund @response anymore, use Spree::Refund#perform_response"
+      )
+
       log_entries.build(details: perform_response.to_yaml)
       update!(transaction_id: perform_response.authorization)
       update_order

--- a/core/app/models/spree/refund.rb
+++ b/core/app/models/spree/refund.rb
@@ -14,7 +14,9 @@ module Spree
 
     validate :amount_is_less_than_or_equal_to_allowed_amount, on: :create
 
+    attr_reader :perform_response
     attr_accessor :perform_after_create
+
     after_create :set_perform_after_create_default
     after_create :perform!
     after_create :clear_perform_after_create
@@ -48,10 +50,10 @@ module Spree
 
       credit_cents = money.cents
 
-      response = process!(credit_cents)
-      log_entries.build(details: response.to_yaml)
+      @perform_response = process!(credit_cents)
 
-      update!(transaction_id: response.authorization)
+      log_entries.build(details: perform_response.to_yaml)
+      update!(transaction_id: perform_response.authorization)
       update_order
     end
 

--- a/core/spec/models/spree/refund_spec.rb
+++ b/core/spec/models/spree/refund_spec.rb
@@ -99,8 +99,15 @@ RSpec.describe Spree::Refund, type: :model do
     context "with perform_after_create: true" do
       let(:perform_after_create) { true }
 
+      it "sets #perform_response with the gateway response from the payment provider" do
+        expect(Spree::Deprecation).to receive(:warn)
+
+        expect(refund.perform_response).to eq gateway_response
+      end
+
       it "does nothing, perform! already happened after create" do
         expect(Spree::Deprecation).to receive(:warn)
+
         refund
         expect(refund.transaction_id).not_to be_nil
 

--- a/core/spec/models/spree/refund_spec.rb
+++ b/core/spec/models/spree/refund_spec.rb
@@ -99,6 +99,13 @@ RSpec.describe Spree::Refund, type: :model do
     context "with perform_after_create: true" do
       let(:perform_after_create) { true }
 
+      it "deprecates usage of the instance variable @response" do
+        expect(Spree::Deprecation).to receive(:warn).twice
+
+        response = refund.instance_variable_get("@response")
+        response.to_s
+      end
+
       it "sets #perform_response with the gateway response from the payment provider" do
         expect(Spree::Deprecation).to receive(:warn)
 
@@ -107,7 +114,6 @@ RSpec.describe Spree::Refund, type: :model do
 
       it "does nothing, perform! already happened after create" do
         expect(Spree::Deprecation).to receive(:warn)
-
         refund
         expect(refund.transaction_id).not_to be_nil
 


### PR DESCRIPTION
**Description**

This PR reintroduces the instance variable `@response` in `Spree::Refund#perform!` that was recently removed in https://github.com/solidusio/solidus/pull/3641.

There may be stores or extensions that rely on the existence of this ivar, so it was reintroduced
but deprecated in favor of the instance method `#perform_response` which has a more appropriate name.

There are instances when we need to be able to access the payment gateway response received during the refund perform process, notably in [core/app/models/spree/payment/cancellation.rb:31 ](https://github.com/solidusio/solidus/blob/a77df8a9160f40f0185ea3b42859a9330f91e058/core/app/models/spree/payment/cancellation.rb#L31) where it assumes that `#try_void` returns the gateway response:

```
  if response = payment.payment_method.try_void(payment)
    payment.send(:handle_void_response, response)
  else
    #...
  end
```

the next line calls [core/app/models/spree/payment/processing.rb:191](https://github.com/solidusio/solidus/blob/a77df8a9160f40f0185ea3b42859a9330f91e058/core/app/models/spree/payment/processing.rb#L191) which makes super clear that we're expecting an object that responds to `#success?` and `#authorization`, ie. the gateway response:

```
  def handle_void_response(response)
    record_response(response)

    if response.success?
      self.response_code = response.authorization
      void
    else
      gateway_error(response)
    end
  end
```

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
