### PR TITLE
Display originator email in stock movement admin

### DIFF
--- a/backend/app/helpers/spree/admin/stock_movements_helper.rb
+++ b/backend/app/helpers/spree/admin/stock_movements_helper.rb
@@ -12,6 +12,8 @@ module Spree
           else
             originator.number
           end
+        elsif originator.respond_to?(:email)
+          originator.email
         else
           ""
         end

--- a/backend/app/helpers/spree/admin/stock_movements_helper.rb
+++ b/backend/app/helpers/spree/admin/stock_movements_helper.rb
@@ -4,11 +4,13 @@ module Spree
   module Admin
     module StockMovementsHelper
       def pretty_originator(stock_movement)
-        if stock_movement.originator.respond_to?(:number)
-          if stock_movement.originator.respond_to?(:order)
-            link_to stock_movement.originator.number, [:edit, :admin, stock_movement.originator.order]
+        originator = stock_movement.originator
+
+        if originator.respond_to?(:number)
+          if originator.respond_to?(:order)
+            link_to originator.number, [:edit, :admin, originator.order]
           else
-            stock_movement.originator.number
+            originator.number
           end
         else
           ""

--- a/backend/spec/helpers/admin/stock_movements_helper_spec.rb
+++ b/backend/spec/helpers/admin/stock_movements_helper_spec.rb
@@ -18,8 +18,16 @@ describe Spree::Admin::StockMovementsHelper, type: :helper do
       end
     end
 
-    context "originator doesn't have a number" do
-      let(:originator) { build(:user) }
+    context "originator has an email" do
+      let(:originator) { build(:user, email: "stock_mover@example.com") }
+
+      it "returns the originator's email" do
+        expect(subject).to eq "stock_mover@example.com"
+      end
+    end
+
+    context "the stock movement doesn't have an originator" do
+      let(:originator) { nil }
 
       it "returns an empty string" do
         expect(subject).to eq ""

--- a/backend/spec/helpers/admin/stock_movements_helper_spec.rb
+++ b/backend/spec/helpers/admin/stock_movements_helper_spec.rb
@@ -11,7 +11,7 @@ describe Spree::Admin::StockMovementsHelper, type: :helper do
     subject { helper.pretty_originator(stock_movement) }
 
     context "originator has a number" do
-      let(:originator) { create(:order) }
+      let(:originator) { build(:order) }
 
       it "returns the originator's number" do
         expect(subject).to eq originator.number
@@ -19,7 +19,7 @@ describe Spree::Admin::StockMovementsHelper, type: :helper do
     end
 
     context "originator doesn't have a number" do
-      let(:originator) { create(:user) }
+      let(:originator) { build(:user) }
 
       it "returns an empty string" do
         expect(subject).to eq ""


### PR DESCRIPTION
**Description**
<!--
  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

  Please include screenshots in case of visual changes to the frontend or backend sections of Solidus.

  If needed you can reference another PR or issue here, e.g.:
  Ref #ISSUE
-->

This gets #3666 started.

From the issue:

> Add an originator for stock movements initiated by admin users. Admin stock movements currently have no originator, but it's useful to see who made the movement, so the originator in this case should just be the admin user who initiated it.

This PR is meant to remedy that trouble.

One point that might be worth discussing is whether or not we should link to the actual user. I think it would be kind of difficult to figure out whether the originator is a user unless we do a class check and I think those are not in favour.

Since we can't really figure out if the originator is a user then providing a link in the admin to the originator becomes difficult. It may be worth going after the most common use case which is that if the originator responds to email then it's probably a `Spree::User` and we could do another conditional and provide a link if it's a user.

Let me know what you think!

Screenshot:

![Screen Shot 2020-06-20 at 12 06 25 PM](https://user-images.githubusercontent.com/13607675/85209660-86197f80-b2ee-11ea-9e73-c5de9619bf3a.png)

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
