### PR TITLE
Return API Users with distinct result when using Ransack

### DIFF
--- a/api/app/controllers/spree/api/users_controller.rb
+++ b/api/app/controllers/spree/api/users_controller.rb
@@ -1,6 +1,19 @@
 # frozen_string_literal: true
 
 class Spree::Api::UsersController < Spree::Api::ResourceController
+  def index
+    user_scope = model_class.accessible_by(current_ability, :read)
+    if params[:ids]
+      ids = params[:ids].split(",").flatten
+      @users = user_scope.where(id: ids)
+    else
+      @users = user_scope.ransack(params[:q]).result
+    end
+
+    @users = paginate(@users.distinct)
+    respond_with(@users)
+  end
+
   private
 
   attr_reader :user

--- a/api/spec/requests/spree/api/users_controller_spec.rb
+++ b/api/spec/requests/spree/api/users_controller_spec.rb
@@ -144,6 +144,21 @@ module Spree
         expect(response.status).to eq(422)
         expect(json_response).to eq({ "error" => "Cannot delete record." })
       end
+
+      it "returns distinct search results" do
+        distinct_user = create(:user, email: 'distinct_test@solidus.com')
+        distinct_user.addresses << create(:address)
+        distinct_user.addresses << create(:address)
+        get spree.api_users_path, params: {
+          q: {
+            m: 'or',
+            email_start: 'distinct_test',
+            firstname_or_lastname_start: 'distinct_test'
+          }
+        }
+        expect(json_response['count']).to eq(1)
+        expect(json_response['users'].first['email']).to eq distinct_user.email
+      end
     end
   end
 end


### PR DESCRIPTION
**Description**
Return API Users ransack searches with a distinct result.

Fixes #3183
-->

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
