### PR TITLE
Add new type encrypted_string for preferences

### DIFF
--- a/backend/app/views/spree/admin/shared/preference_fields/_encrypted_string.html.erb
+++ b/backend/app/views/spree/admin/shared/preference_fields/_encrypted_string.html.erb
@@ -1,0 +1,12 @@
+<% label = local_assigns[:label].presence %>
+<% html_options = {class: 'input_string fullwidth'}.update(local_assigns[:html_options] || {}) %>
+
+<div class="field">
+  <% if local_assigns[:form] %>
+    <%= form.label attribute, label %>
+    <%= form.text_field attribute, html_options %>
+  <% else %>
+    <%= label_tag name, label %>
+    <%= text_field_tag name, value, html_options %>
+  <% end %>
+</div>

--- a/core/lib/spree/encryptor.rb
+++ b/core/lib/spree/encryptor.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Spree
+  # Spree::Encryptor is a thin wrapper around ActiveSupport::MessageEncryptor.
+  class Encryptor
+    # @param key [String] the 256 bits signature key
+    def initialize(key)
+      @crypt = ActiveSupport::MessageEncryptor.new(key)
+    end
+
+    # Encrypt a value
+    # @param value [String] the value to encrypt
+    # @return [String] the encrypted value
+    def encrypt(value)
+        @crypt.encrypt_and_sign(value)
+    end
+
+    # Decrypt an encrypted value
+    # @param encrypted_value [String] the value to decrypt
+    # @return [String] the decrypted value
+    def decrypt(encrypted_value)
+        @crypt.decrypt_and_verify(encrypted_value)
+    end
+  end
+end

--- a/core/lib/spree/preferences/preferable.rb
+++ b/core/lib/spree/preferences/preferable.rb
@@ -141,11 +141,13 @@ module Spree
 
       private
 
-      def convert_preference_value(value, type)
+      def convert_preference_value(value, type, preference_encryptor = nil)
         return nil if value.nil?
         case type
         when :string, :text
           value.to_s
+        when :encrypted_string
+          preference_encryptor.encrypt(value.to_s)
         when :password
           value.to_s
         when :decimal

--- a/core/lib/spree/preferences/preferable_class_methods.rb
+++ b/core/lib/spree/preferences/preferable_class_methods.rb
@@ -11,6 +11,7 @@ module Spree::Preferences
       password
       string
       text
+      encrypted_string
     )
 
     def defined_preferences

--- a/core/lib/spree/preferences/preferable_class_methods.rb
+++ b/core/lib/spree/preferences/preferable_class_methods.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'spree/encryptor'
+
 module Spree::Preferences
   module PreferableClassMethods
     DEFAULT_ADMIN_FORM_PREFERENCE_TYPES = %i(
@@ -16,7 +18,10 @@ module Spree::Preferences
     end
 
     def preference(name, type, options = {})
-      options.assert_valid_keys(:default)
+      options.assert_valid_keys(:default, :encryption_key)
+      preference_encryptor = preference_encryptor(options) if type == :encrypted_string
+
+      options[:default] = preference_encryptor.encrypt(options[:default]) if type == :encrypted_string
       default = options[:default]
       default = ->{ options[:default] } unless default.is_a?(Proc)
 
@@ -34,13 +39,15 @@ module Spree::Preferences
       # cache_key will be nil for new objects, then if we check if there
       # is a pending preference before going to default
       define_method preference_getter_method(name) do
-        preferences.fetch(name) do
+        value = preferences.fetch(name) do
           default.call
         end
+        value = preference_encryptor.decrypt(value) if preference_encryptor.present?
+        value
       end
 
       define_method preference_setter_method(name) do |value|
-        value = convert_preference_value(value, type)
+        value = convert_preference_value(value, type, preference_encryptor)
         preferences[name] = value
 
         # If this is an activerecord object, we need to inform
@@ -70,6 +77,14 @@ module Spree::Preferences
 
     def preference_type_getter_method(name)
       "preferred_#{name}_type".to_sym
+    end
+
+    def preference_encryptor(options)
+      key = options[:encryption_key] ||
+            ENV['SOLIDUS_PREFERENCES_MASTER_KEY'] ||
+            Rails.application.credentials.secret_key_base
+
+      Spree::Encryptor.new(key)
     end
 
     # List of preference types allowed as form fields in the Solidus admin

--- a/core/spec/lib/spree/encryptor_spec.rb
+++ b/core/spec/lib/spree/encryptor_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'spree/encryptor'
+
+RSpec.describe Spree::Encryptor do
+  let(:key) { 'p3s6v9y$B?E(H+MbQeThWmZq4t7w!z%C' }
+  let(:value) { 'payment_system_sdk_id' }
+
+  describe '#encrypt' do
+    it 'returns the encrypted value' do
+      encryptor = described_class.new(key)
+      expect(encryptor.encrypt(value)).not_to eq(value)
+    end
+  end
+
+  describe '#decrypt' do
+    it 'returns the original decrypted value' do
+      encryptor = described_class.new(key)
+      encrypted_value = encryptor.encrypt(value)
+
+      expect(encryptor.decrypt(encrypted_value)).to eq(value)
+    end
+  end
+end

--- a/core/spec/models/spree/preferences/preferable_spec.rb
+++ b/core/spec/models/spree/preferences/preferable_spec.rb
@@ -266,6 +266,44 @@ RSpec.describe Spree::Preferences::Preferable, type: :model do
         expect(@a.preferences[:product_attributes]).to eq({ id: 1, name: 2 })
       end
     end
+
+    context "converts encrypted_string preferences to encrypted values" do
+      it "with string, encryption key provided as option" do
+        A.preference :secret, :encrypted_string,
+                     encryption_key: 'VkYp3s6v9y$B?E(H+MbQeThWmZq4t7w!'
+
+        @a.set_preference(:secret, 'secret_client_id')
+        expect(@a.get_preference(:secret)).to eq('secret_client_id')
+        expect(@a.preferences[:secret]).not_to eq('secret_client_id')
+      end
+
+      it "with string, encryption key provided as env variable" do
+        ENV['SOLIDUS_PREFERENCES_MASTER_KEY'] = 'VkYp3s6v9y$B?E(H+MbQeThWmZq4t7w!'
+        A.preference :secret, :encrypted_string
+
+        @a.set_preference(:secret, 'secret_client_id')
+        expect(@a.get_preference(:secret)).to eq('secret_client_id')
+        expect(@a.preferences[:secret]).not_to eq('secret_client_id')
+      end
+
+      it "with string, encryption key provided as option, setted using syntactic sugar method" do
+        A.preference :secret, :encrypted_string,
+                     encryption_key: 'VkYp3s6v9y$B?E(H+MbQeThWmZq4t7w!'
+
+        @a.preferred_secret = 'secret_client_id'
+        expect(@a.preferred_secret).to eq('secret_client_id')
+        expect(@a.preferences[:secret]).not_to eq('secret_client_id')
+      end
+
+      it "with string, default value" do
+        A.preference :secret, :encrypted_string,
+                     default: 'my_default_secret',
+                     encryption_key: 'VkYp3s6v9y$B?E(H+MbQeThWmZq4t7w!'
+
+        expect(@a.get_preference(:secret)).to eq('my_default_secret')
+        expect(@a.preferences[:secret]).not_to eq('my_default_secret')
+      end
+    end
   end
 
   describe "persisted preferables" do
@@ -290,6 +328,7 @@ RSpec.describe Spree::Preferences::Preferable, type: :model do
       class PrefTest < Spree::Base
         preference :pref_test_pref, :string, default: 'abc'
         preference :pref_test_any, :any, default: []
+        preference :pref_test_encrypted_string, :encrypted_string, encryption_key: 'VkYp3s6v9y$B?E(H+MbQeThWmZq4t7w!'
       end
     end
 
@@ -317,6 +356,17 @@ RSpec.describe Spree::Preferences::Preferable, type: :model do
         expect(pr.get_preference(:pref_test_any)).to eq([1, 2])
         pr.save!
         expect(pr.get_preference(:pref_test_any)).to eq([1, 2])
+      end
+
+      it "saves encrypted preferences for serialized object" do
+        pr = PrefTest.new
+        pr.set_preference(:pref_test_encrypted_string, 'secret_client_id')
+        expect(pr.get_preference(:pref_test_encrypted_string)).to eq('secret_client_id')
+        pr.save!
+        preferences_value_on_db = ActiveRecord::Base.connection.execute(
+          "SELECT preferences FROM pref_tests WHERE id=#{pr.id}"
+        ).first
+        expect(preferences_value_on_db).not_to include('secret_client_id')
       end
     end
 

--- a/guides/source/developers/preferences/add-model-preferences.html.md
+++ b/guides/source/developers/preferences/add-model-preferences.html.md
@@ -1,8 +1,10 @@
 # Add model preferences
 
 Solidus comes with many model-specific preferences. They are configured to have
-default values that are appropriate for typical stores. Preferences can be set
-on any model that inherits from [`Spree::Base`][spree-base].
+default values that are appropriate for typical stores. Additional preferences
+can be added by your application or included extensions.
+
+Preferences can be set on any model that inherits from [`Spree::Base`][spree-base].
 
 Note that model preferences apply only to the current model. To learn more about
 application-wide preferences, see the [App configuration][app-configuration]
@@ -18,24 +20,32 @@ You can define preferences for a model within the model itself:
 
 ```ruby
 module MyStore
-  class SubscriptionRules < Spree::Base
+  class User < Spree::Base
     preference :hot_salsa, :boolean
     preference :dark_chocolate, :boolean, default: true
     preference :color, :string
+    preference :favorite_number, :integer
+    preference :language, :string, default: "English"
   end
 end
 ```
+
+This will work because User is a subclass of Spree::Base. If found,
+the preferences attribute gets serialized into a Hash and merged with the default values.
 
 <!-- TODO:
   Let's replace this example code with something a little more realistic. What
   kind of object would a store want multiple custom preferences on?
 -->
 
+## Supported type for preferences
+
 For each preference you define, a data type should be provided. The available
 types are:
 
 - `boolean`
 - `string`
+- `encrypted_string`
 - `password`
 - `integer`
 - `text`
@@ -43,7 +53,30 @@ types are:
 - `hash`
 
 An optional default value may be defined. (See the `:dark_chocolate` preference
-in the block above.) This is the value used unless another value has been set. 
+in the block above.) This is the value used unless another value has been set.
+
+### Details for encrypted_string type
+
+We encourage the usage of environment variables for keeping your secrets,
+but in case when this is not possible you can use a preference of type
+`encrypted_string`.
+
+A preference of type `encrypted_string` accept an option named `encryption_key`,
+the value of the option will be used as key for the encryption of the preference.
+
+If no `encryption_key` is passed the application would use the value of the
+environment variable `SOLIDUS_PREFERENCES_MASTER_KEY` as encryption key.
+
+If no environment variable `SOLIDUS_PREFERENCES_MASTER_KEY` is set the application
+would use the Rails master key as encryption key.
+
+Solidus will NOT manage the rotation, or secure storage, of the key, this things
+need to be handled by hand.
+
+To access the unencrypted value of a preference of type `encrypted_string` use the method generated
+by Solidus, see [Access your preferences](#access-your-preferences).
+
+If you try to fetch the value directly from the preferences hash, you'll get the encrypted string.
 
 ### Add columns for your preferences
 
@@ -53,7 +86,7 @@ relevant model using a migration:
 ```ruby
 class AddPreferencesToSubscriptionRules < ActiveRecord::Migration[5.0]
   def change
-    add_column :my_store_subscription_rules, :preferences, :text
+    add_column :my_store_users, :preferences, :text
   end
 end
 ```
@@ -68,18 +101,80 @@ bundle exec rails db:migrate
 
 ### Access your preferences
 
-Now you can access their values from the model they are set on:
+Once preferences have been defined for a model, they can be accessed either using the shortcut methods that are generated for each preference or the generic methods that are not specific to a particular preference.
+
+#### Shortcut Methods
+
+There are several shortcut methods that are generated. They are shown below.
+
+Reader methods:
 
 ```ruby
-MyStore::SubscriptionRules.find(1).preferences
-# => {:hot_salsa => nil, :dark_chocolate => true, :color => "grey"}
+user.preferred_color                # => nil
+user.preferred_language             # => "English"
 ```
 
-Or, the value of a specific preference:
+Writer methods:
 
 ```ruby
-MyStore::SubscriptionRules.find(1).preferences.fetch(:dark_chocolate)
-# => true
+user.preferred_hot_salsa = false    # => false
+user.preferred_language = "English" # => "English"
+```
+
+Check if a preference is available:
+
+```ruby
+user.has_preference? :hot_salsa     # => True
+```
+
+#### Generic Methods
+
+Each shortcut method is essentially a wrapper for the various generic methods shown below:
+
+Query method:
+
+```ruby
+user.prefers?(:hot_salsa)           # => false
+user.prefers?(:dark_chocolate)      # => false
+```
+
+Reader methods:
+
+```ruby
+user.get_preference :color                  # => nil
+user.get_preference :language               # => English
+user.preferences.fetch(:dark_chocolate)     # => false
+```
+
+Writer method:
+
+```ruby
+user.set_preference(:hot_salsa, false)     # => false
+user.set_preference(:language, "English")  # => "English"
+```
+
+#### Accessing All Preferences
+
+You can get a hash of all stored preferences by accessing the `preferences` helper:
+
+```ruby
+user.preferences # => {"language"=>"English", "color"=>nil}
+```
+
+This hash will contain the value for every preference that has been defined for the model instance, whether the value is the default or one that has been previously stored.
+
+#### Default and Type
+
+You can access the default value for a preference:
+
+```ruby
+user.preferred_color_default # => 'blue'
+```
+
+Types are used to generate forms or display the preference. You can also get the type defined for a preference:
+
+```ruby
+user.preferred_color_type # => :string
 ```
 
 [app-configuration]: app-configuration.html


### PR DESCRIPTION
**Description**

This pull request wants to resolve the issue Ref #3652 adding a new type encrypted_string as a possible type when declaring preferences.

The new type encrypted_string would encrypt the value assigned to the preference so that when saved to a Database the value would be safe if a malicious actor gets access to the DB or a dump.

The value to be encrypted need to be set/get using the preferences setter and getter method, the encryption would be skipped if the preferences hash is accessed directly.
The idea behind this is that the value would always be encrypted inside the preferences' hash so that the end-user doesn't need to change the way it interacts with the preferences.
 
This implementation would not handle the encryption key, it's up to the end-user to safely generate, store, and rotate the key.
The key can be passed as an option to the preference (encryption_key), it the option is missing the system would look for an environment variable called SOLIDUS_PREFERENCES_MASTER_KEY, if even this variable is missing the system will use the Rails secret key.

I'm not sure that this solution would cover all the use cases that the author of the original issue had in mind, so I open the pull request as a draft to ask for feedback about possible missing use cases. 
 
**Checklist:**

- [X] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [X] I have added a detailed description into each commit message
- [X] I have updated Guides and README accordingly to this change (if needed)
- [X] I have added tests to cover this change (if needed)
- [X] I have attached screenshots to this PR for visual changes (if needed)
