### PR TITLE
Add preference for phone validation

### DIFF
--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -149,9 +149,9 @@ module Spree
 
     # @todo Remove this from the public API if possible.
     # @return [true] whether or not the address requires a phone number to be
-    #   valid
+    #   present
     def require_phone?
-      true
+      Spree::Config[:address_requires_phone]
     end
 
     # @todo Remove this from the public API if possible.

--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -155,7 +155,7 @@ module Spree
     end
 
     # @todo Remove this from the public API if possible.
-    # @return [true] whether or not the address requires a zipcode to be valid
+    # @return [true] whether or not the address requires a zipcode to be present
     def require_zipcode?
       true
     end

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -26,6 +26,10 @@ module Spree
   class AppConfiguration < Preferences::Configuration
     # Preferences (alphabetized to more easily lookup particular preferences)
 
+    # @!attribute [rw] address_requires_phone
+    #   @return [Boolean] should phone number be required (default: +true+)
+    preference :address_requires_phone, :boolean, default: true
+
     # @!attribute [rw] address_requires_state
     #   @return [Boolean] should state/state_name be required (default: +true+)
     preference :address_requires_state, :boolean, default: true

--- a/core/spec/models/spree/address_spec.rb
+++ b/core/spec/models/spree/address_spec.rb
@@ -136,9 +136,9 @@ RSpec.describe Spree::Address, type: :model do
     end
 
     context "phone not required" do
-      before { allow(address).to receive_messages require_phone?: false }
+      before { stub_spree_preferences(address_requires_phone: false) }
 
-      it "shows no errors when phone is blank" do
+      it "is valid when phone is blank" do
         address.phone = ""
         address.valid?
         expect(address.errors[:phone].size).to eq 0

--- a/guides/source/developers/users/addresses.html.md
+++ b/guides/source/developers/users/addresses.html.md
@@ -64,21 +64,17 @@ You may want to alter Solidus's address requirements for your store. For
 example, if you do not require customer phone numbers in order for them to check
 out.
 
-Right now, you need to [monkey-patch][monkey-patch] the `Spree::Address` model
-in order to change its requirements. For example, you could prepend your custom
-behavior that redefines `Spree::Address`'s `require_phone?` method: 
+In that case, you can set the `address_requires_phone` preference to `false` in
+an initializer.
 
 ```ruby
-module PhoneNotRequired
-  def require_phone?
-    false
-  end
+Spree::Config.configure do |config|
+  config.address_requires_phone = false
 end
-
-Spree::Address.prepend(PhoneNotRequired)
 ```
 
-Similarly, if you ship to countries that don't require postal codes, like Hong
+With the exception of phone number, you need to [monkey-patch][monkey-patch] the `Spree::Address` model
+in order to change its requirements. If you ship to countries that don't require postal codes, like Hong
 Kong or Macau, you may want to make postal codes optional instead of required.
 
 Right now, you can monkey-patch the `Spree::Address` model in order to remove or


### PR DESCRIPTION
**Description**
Adds phone number validation preference so users can easily indicate
whether or not they want to require phone numbers for addresses.
Ref: #3679

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
