### PR TITLE
Do not attempt to create multiple records with `global_zone` factory

### DIFF
--- a/core/lib/spree/testing_support/factories/zone_factory.rb
+++ b/core/lib/spree/testing_support/factories/zone_factory.rb
@@ -5,7 +5,7 @@ require 'spree/testing_support/factories/country_factory'
 
 FactoryBot.define do
   factory :global_zone, class: 'Spree::Zone' do
-    name { 'GlobalZone' }
+    initialize_with { Spree::Zone.find_or_initialize_by(name: 'GlobalZone') }
     zone_members do |proxy|
       zone = proxy.instance_eval { @instance }
       Spree::Country.all.map do |c|


### PR DESCRIPTION
**Description**

The factory linting spec is breaking many PR builds lately with this error:

```
  FactoryBot::InvalidFactoryError:
    The following factories are invalid:

    * global_zone - Validation failed: Name has already been taken
    (ActiveRecord::RecordInvalid)

```
I think this has something to do with the fact that the factory `global_zone` can be used only once, as the name is fixed to "Global Zone" and the model has a uniqueness validation on `name`. Still, I don't really understand why the problem happens, as the DB should be clean when this spec example is run.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
