### PR TITLE
[v2.10] Fix Taxon Promo Rule Specs

### DIFF
--- a/core/spec/models/spree/promotion/rules/taxon_spec.rb
+++ b/core/spec/models/spree/promotion/rules/taxon_spec.rb
@@ -101,6 +101,7 @@ RSpec.describe Spree::Promotion::Rules::Taxon, type: :model do
         before do
           taxon.children << taxon2
           taxon.save!
+          taxon.reload
           product.taxons = [taxon2, taxon3]
           rule.taxons = [taxon, taxon3]
         end


### PR DESCRIPTION
**Description**

This fixes a spec in v2.10 that is currently failing due to some new association caching in Rails (not sure where).

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
