### PR TITLE
[Admin] Fix Square Logos appearance

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/components/_navigation.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_navigation.scss
@@ -355,8 +355,11 @@ nav.menu {
 
 .brand-link {
   display: block;
+  height: $main-header-height - 1px;
+  overflow: hidden;
 
   img {
-    max-width: 125px;
+    max-height: 100%;
+    max-width: 100%;
   }
 }


### PR DESCRIPTION
**Description**
Ref #3692

This just adds an explicit height to the `.brand-link` div in admin. This height is controlled by the `$main-header-height` variable. Then it sets the image to have a max-width/height of 100%. It should prevent logos of any size or aspect ratio from overflowing and preventing access to the ui. See square, tall, and wide logos below:

<img width="325" alt="Screen Shot 2020-07-10 at 3 50 29 PM" src="https://user-images.githubusercontent.com/100786/87209788-0a489c80-c2c8-11ea-9365-71b675f62dc5.png">
<img width="231" alt="Screen Shot 2020-07-10 at 3 53 23 PM" src="https://user-images.githubusercontent.com/100786/87209794-0d438d00-c2c8-11ea-8a4b-25bacabf5464.png">
<img width="311" alt="Screen Shot 2020-07-10 at 3 53 55 PM" src="https://user-images.githubusercontent.com/100786/87209797-0fa5e700-c2c8-11ea-9db0-48e21517b215.png">


**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
