### PR TITLE
Change to true/false to yes/no in Auto Capture Select Text

### DIFF
--- a/backend/app/views/spree/admin/payment_methods/_form.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/_form.html.erb
@@ -31,7 +31,12 @@
         </div>
         <div data-hook="auto_capture" class="field">
           <%= f.label :auto_capture %>
-          <%= f.select :auto_capture, [["#{t('spree.use_app_default')} (#{Spree::Config[:auto_capture]})", ''], [t('spree.say_yes'), true], [t('spree.say_no'), false]], {}, {class: 'custom-select fullwidth'} %>
+          <%= f.select :auto_capture,
+            [["#{t('spree.use_app_default')} (#{Spree::Config[:auto_capture] ? t('spree.say_yes') : t('spree.say_no')})", ''],
+             [t('spree.say_yes'), true],
+             [t('spree.say_no'), false]],
+          {},
+          {class: 'custom-select fullwidth'} %>
         </div>
         <div data-hook="available_to_user" class="field">
           <label>


### PR DESCRIPTION
**Description**
  Ref #3697

This modifies the text in the Auto Capture dropdown menu to make the verbiage more consistent. It checks whether `Spree::Config.auto_capture` is set to true or false. If it is set to true, the primary dropdown will read "Use App Default (Yes)". If it is set to "false"—or if it is not set (the default config state)—it will read "Use App Default (No)".

`Spree::Config.auto_capture = true`:
<img width="375" alt="Screen Shot 2020-07-10 at 4 38 30 PM" src="https://user-images.githubusercontent.com/100786/87210977-6f05f600-c2cc-11ea-8b72-550799f34236.png">

`Spree::Config.auto_capture = false`:
<img width="363" alt="Screen Shot 2020-07-10 at 4 39 07 PM" src="https://user-images.githubusercontent.com/100786/87211004-87761080-c2cc-11ea-9cf9-5a0a09397c95.png">

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
