### PR TITLE
Selectively disable stock item rows when some do not track inventory

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/stock_management.js
+++ b/backend/app/assets/javascripts/spree/backend/stock_management.js
@@ -13,7 +13,7 @@ Spree.ready(function() {
     });
 
     if (trackInventory === false) {
-      $('.js-edit-stock-item input').attr({
+      $el.find('input').attr({
         disabled: true,
         class: 'with-tip',
         title: '"Track inventory" option disabled for this variant'
@@ -21,7 +21,7 @@ Spree.ready(function() {
     }
 
     if (canEdit == false) {
-      $('.js-edit-stock-item input').attr({
+      $el.find('input').attr({
         disabled: true,
         class: 'with-tip',
         title: 'You do not have permission to manage stock'

--- a/backend/app/controllers/spree/admin/stock_items_controller.rb
+++ b/backend/app/controllers/spree/admin/stock_items_controller.rb
@@ -52,6 +52,7 @@ module Spree
       def variant_scope
         scope = Spree::Variant.accessible_by(current_ability)
         scope = scope.where(product: @product) if @product
+        scope = scope.order(:sku)
         scope
       end
 


### PR DESCRIPTION
When some variants of a product have "track inventory" set to `true` and at least one variant of the same product has "track inventory" set to `false`, all the rows on the "Product Stock" tab become disabled, and show the `"Track Inventory" disabled for this variant` popup.

After this change, only the rows for variants with "track inventory" set to `false` are disabled.

I don't think there are any frontend tests that would cover this, but would be happy to add tests if someone can point me in the right direction.