### PR TITLE
Replace duplicate data-hook name

### DIFF
--- a/backend/app/views/spree/admin/payment_methods/_form.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/_form.html.erb
@@ -39,7 +39,7 @@
             <%= Spree::PaymentMethod.human_attribute_name :available_to_users %>
           </label>
         </div>
-        <div data-hook="available_to_user" class="field">
+        <div data-hook="available_to_admin" class="field">
           <label>
             <%= f.check_box :available_to_admin %>
             <%= Spree::PaymentMethod.human_attribute_name :available_to_admin %>


### PR DESCRIPTION
**Description**

In payment_methods/_form, the data-hook :available_to_user is used
both for available_to_user, and available_to_admin. I'm assuming that
the data hook for available_to_admin is actually supposed to be
:available_to_admin and not a duplicate :available_to_user.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
