### PR TITLE
Make Spree::Payment::Processing#handle_void_response public

### DIFF
--- a/core/app/models/spree/payment/cancellation.rb
+++ b/core/app/models/spree/payment/cancellation.rb
@@ -29,7 +29,7 @@ module Spree
         # For payment methods already implemeting `try_void`
         if try_void_available?(payment.payment_method)
           if response = payment.payment_method.try_void(payment)
-            payment.send(:handle_void_response, response)
+            payment.handle_void_response(response)
           else
             payment.refunds.create!(amount: payment.credit_allowed, reason: refund_reason, perform_after_create: false).perform!
           end
@@ -55,7 +55,7 @@ module Spree
           'Please implement a `try_void` method instead that returns a response object if void succeeds ' \
           'or `false|nil` if not. Solidus will refund the payment then.'
         response = payment.payment_method.cancel(payment.response_code)
-        payment.send(:handle_void_response, response)
+        payment.handle_void_response(response)
       end
     end
   end

--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -122,6 +122,17 @@ module Spree
         "#{order.number}-#{number}"
       end
 
+      def handle_void_response(response)
+        record_response(response)
+
+        if response.success?
+          self.response_code = response.authorization
+          void
+        else
+          gateway_error(response)
+        end
+      end
+
       private
 
       def process_authorization
@@ -183,17 +194,6 @@ module Spree
           send("#{success_state}!")
         else
           send(failure_state)
-          gateway_error(response)
-        end
-      end
-
-      def handle_void_response(response)
-        record_response(response)
-
-        if response.success?
-          self.response_code = response.authorization
-          void
-        else
           gateway_error(response)
         end
       end


### PR DESCRIPTION
The method is called by `Spree::Payment::Cancellation#cancel`,  so it makes sense to have it public instead of relying on a hacky `send` call.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message