### PR TITLE
Updating documentation around ransack

### DIFF
--- a/core/lib/generators/solidus/install/templates/config/initializers/spree.rb.tt
+++ b/core/lib/generators/solidus/install/templates/config/initializers/spree.rb.tt
@@ -114,11 +114,6 @@ end
 
 Spree.user_class = <%= (options[:user_class].blank? ? "Spree::LegacyUser" : options[:user_class]).inspect %>
 
-# If you want to add a field to the whitelisted ransackable attributes,
-# just uncomment the following code and change it as you need.
-#
-# Spree::Model.whitelisted_ransackable_attributes << 'field'
-
 # Rules for avoiding to store the current path into session for redirects
 # When at least one rule is matched, the request path will not be stored
 # in session.

--- a/guides/source/developers/customizations/customizing-admin.html.md
+++ b/guides/source/developers/customizations/customizing-admin.html.md
@@ -151,11 +151,21 @@ See the ransack documentation for more information.
 
 Additionally, for security reasons you will need to whitelist the new attribute
 needed for the search. You do this by using a specific method provided by
-[ransack][ransack].  This can be easily done by adding the following line into
-the `config/initializers/spree.rb` initializer:
+[ransack][ransack]. The easiest way to achieve this is by adding a decorator
+which will update the attributes. This ensures that the code is reloaded correctly
+when needed. (Using an initializer does not work with Rails 6+ and Zeitwerk) For this
+example, you would add the following code to `app/models/your_app/spree/order_decorator.rb`:
 
 ```rb
-Spree::Order.whitelisted_ransackable_attributes << 'last_ip_address'
+module YourApp
+  module Spree
+    class OrderDecorator
+       Spree::Order.whitelisted_ransackable_attributes << 'last_ip_address'
+
+       Spree::Order.prepend self
+    end
+  end
+end
 ```
 
 [ransack]: https://github.com/activerecord-hackery/ransack

--- a/guides/source/developers/customizations/customizing-admin.html.md
+++ b/guides/source/developers/customizations/customizing-admin.html.md
@@ -153,16 +153,18 @@ Additionally, for security reasons you will need to whitelist the new attribute
 needed for the search. You do this by using a specific method provided by
 [ransack][ransack]. The easiest way to achieve this is by adding a decorator
 which will update the attributes. This ensures that the code is reloaded correctly
-when needed. (Using an initializer does not work with Rails 6+ and Zeitwerk) For this
+when needed - using an initializer does not work with Rails 6+ and Zeitwerk. For this
 example, you would add the following code to `app/models/your_app/spree/order_decorator.rb`:
 
 ```rb
 module YourApp
   module Spree
     class OrderDecorator
-       Spree::Order.whitelisted_ransackable_attributes << 'last_ip_address'
+      def self.prepended(base)
+        base.whitelisted_ransackable_attributes << 'last_ip_address'
+      end
 
-       Spree::Order.prepend self
+      Spree::Order.prepend self                                          
     end
   end
 end


### PR DESCRIPTION
This PR updates the documentation around customizing Ransack attributes to recommend the use of a decorator instead of an initializer. This allows the code to reload correctly when using Zeitwerk under Rails 6+.

Addresses https://github.com/solidusio/solidus/issues/3706

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
