### PR TITLE
[v2.9] Permit address attributes via payment source attributes

### DIFF
--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -90,7 +90,7 @@ module Spree
       :number, :month, :year, :expiry, :verification_value,
       :first_name, :last_name, :cc_type, :gateway_customer_profile_id,
       :gateway_payment_profile_id, :last_digits, :name, :encrypted_data,
-      :existing_card_id, :wallet_payment_source_id
+      :existing_card_id, :wallet_payment_source_id, address_attributes: address_attributes
     ]
 
     @@stock_item_attributes = [:variant, :stock_location, :backorderable, :variant_id]

--- a/frontend/spec/features/checkout_spec.rb
+++ b/frontend/spec/features/checkout_spec.rb
@@ -374,6 +374,14 @@ describe "Checkout", type: :feature, inaccessible: true do
       expect(page).to have_current_path(spree.order_path(Spree::Order.last))
       expect(page).to have_content('Ending in 1111')
     end
+
+    it "allows user to save a billing address associated to the credit card" do
+      choose "use_existing_card_no"
+      fill_in_credit_card
+
+      click_on "Save and Continue"
+      expect(Spree::CreditCard.last.address).to be_present
+    end
   end
 
   # regression for https://github.com/spree/spree/issues/2921


### PR DESCRIPTION
**Description**
This is a complementary PR for the last security fix.

Bill address can be passed as params when submitting a new source.

This also resumes a spec that was removed a while ago and apparently it was the only one testing this feature.
