### PR TITLE
Add disable_api_routes API config

### DIFF
--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -12,133 +12,135 @@ Spree::Core::Engine.routes.draw do
     end
   end
 
-  namespace :api, defaults: { format: 'json' } do
-    resources :promotions, only: [:show]
+  unless Spree::Api::Config[:disable_api_routes]
+    namespace :api, defaults: { format: 'json' } do
+      resources :promotions, only: [:show]
 
-    resources :products do
-      resources :images
-      resources :variants
-      resources :product_properties
-    end
+      resources :products do
+        resources :images
+        resources :variants
+        resources :product_properties
+      end
 
-    concern :order_routes do
-      resources :line_items
-      resources :payments do
+      concern :order_routes do
+        resources :line_items
+        resources :payments do
+          member do
+            put :authorize
+            put :capture
+            put :purchase
+            put :void
+            put :credit
+          end
+        end
+
+        resources :addresses, only: [:show, :update]
+
+        resources :return_authorizations do
+          member do
+            put :cancel
+          end
+        end
+
+        resources :customer_returns, except: :destroy
+      end
+
+      resources :checkouts, only: [:update], concerns: :order_routes do
         member do
-          put :authorize
-          put :capture
-          put :purchase
-          put :void
-          put :credit
+          put :next
+          put :advance
+          put :complete
         end
       end
 
-      resources :addresses, only: [:show, :update]
+      resources :variants do
+        resources :images
+      end
 
-      resources :return_authorizations do
+      resources :option_types do
+        resources :option_values
+      end
+      resources :option_values
+
+      get '/orders/mine', to: 'orders#mine', as: 'my_orders'
+      get "/orders/current", to: "orders#current", as: "current_order"
+
+      resources :orders, concerns: :order_routes do
         member do
           put :cancel
+          put :empty
+          put :apply_coupon_code
+        end
+
+        resources :coupon_codes, only: [:create, :destroy]
+      end
+
+      resources :zones
+      resources :countries, only: [:index, :show] do
+        resources :states, only: [:index, :show]
+      end
+
+      resources :shipments, only: [:create, :update] do
+        collection do
+          post 'transfer_to_location'
+          post 'transfer_to_shipment'
+          get :mine
+        end
+
+        member do
+          get :estimated_rates
+          put :select_shipping_method
+
+          put :ready
+          put :ship
+          put :add
+          put :remove
         end
       end
-
-      resources :customer_returns, except: :destroy
-    end
-
-    resources :checkouts, only: [:update], concerns: :order_routes do
-      member do
-        put :next
-        put :advance
-        put :complete
-      end
-    end
-
-    resources :variants do
-      resources :images
-    end
-
-    resources :option_types do
-      resources :option_values
-    end
-    resources :option_values
-
-    get '/orders/mine', to: 'orders#mine', as: 'my_orders'
-    get "/orders/current", to: "orders#current", as: "current_order"
-
-    resources :orders, concerns: :order_routes do
-      member do
-        put :cancel
-        put :empty
-        put :apply_coupon_code
-      end
-
-      resources :coupon_codes, only: [:create, :destroy]
-    end
-
-    resources :zones
-    resources :countries, only: [:index, :show] do
       resources :states, only: [:index, :show]
-    end
 
-    resources :shipments, only: [:create, :update] do
-      collection do
-        post 'transfer_to_location'
-        post 'transfer_to_shipment'
-        get :mine
-      end
-
-      member do
-        get :estimated_rates
-        put :select_shipping_method
-
-        put :ready
-        put :ship
-        put :add
-        put :remove
-      end
-    end
-    resources :states, only: [:index, :show]
-
-    resources :taxonomies do
-      member do
-        get :jstree
-      end
-      resources :taxons do
+      resources :taxonomies do
         member do
           get :jstree
         end
+        resources :taxons do
+          member do
+            get :jstree
+          end
+        end
       end
-    end
 
-    resources :taxons, only: [:index]
+      resources :taxons, only: [:index]
 
-    resources :inventory_units, only: [:show, :update]
+      resources :inventory_units, only: [:show, :update]
 
-    resources :users do
-      resources :credit_cards, only: [:index]
-      resource :address_book, only: [:show, :update, :destroy]
-    end
-
-    resources :credit_cards, only: [:update]
-
-    resources :properties
-    resources :stock_locations do
-      resources :stock_movements
-      resources :stock_items
-    end
-
-    resources :stock_items, only: [:index, :update, :destroy]
-
-    resources :stores
-
-    resources :store_credit_events, only: [] do
-      collection do
-        get :mine
+      resources :users do
+        resources :credit_cards, only: [:index]
+        resource :address_book, only: [:show, :update, :destroy]
       end
-    end
 
-    get '/config/money', to: 'config#money'
-    get '/config', to: 'config#show'
-    put '/classifications', to: 'classifications#update', as: :classifications
-    get '/taxons/products', to: 'taxons#products', as: :taxon_products
+      resources :credit_cards, only: [:update]
+
+      resources :properties
+      resources :stock_locations do
+        resources :stock_movements
+        resources :stock_items
+      end
+
+      resources :stock_items, only: [:index, :update, :destroy]
+
+      resources :stores
+
+      resources :store_credit_events, only: [] do
+        collection do
+          get :mine
+        end
+      end
+
+      get '/config/money', to: 'config#money'
+      get '/config', to: 'config#show'
+      put '/classifications', to: 'classifications#update', as: :classifications
+      get '/taxons/products', to: 'taxons#products', as: :taxon_products
+    end
   end
 end

--- a/api/lib/spree/api_configuration.rb
+++ b/api/lib/spree/api_configuration.rb
@@ -3,5 +3,6 @@
 module Spree
   class ApiConfiguration < Preferences::Configuration
     preference :requires_authentication, :boolean, default: true
+    preference :disable_api_routes, :boolean, default: false
   end
 end

--- a/api/spec/routing/api_routes_spec.rb
+++ b/api/spec/routing/api_routes_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'api', type: :routing do
+  context 'when disable_api_routes is enabled' do
+    before do
+      stub_spree_preferences(Spree::Api::Config, disable_api_routes: true)
+      Rails.application.reload_routes!
+    end
+
+    it "does not mount the api routes" do
+      aggregate_failures do
+        expect(get: '/api/orders').to_not be_routable
+        expect(get: '/api/products').to_not be_routable
+      end
+    end
+  end
+
+  context 'when disable_api_routes is disabled' do
+    before do
+      stub_spree_preferences(Spree::Api::Config, disable_api_routes: false)
+      Rails.application.reload_routes!
+    end
+
+    it "mounts the api routes" do
+      aggregate_failures do
+        expect(get: '/api/orders').to be_routable
+        expect(get: '/api/products').to be_routable
+      end
+    end
+  end
+end

--- a/api/spec/routing/api_routes_spec.rb
+++ b/api/spec/routing/api_routes_spec.rb
@@ -3,6 +3,10 @@
 require 'spec_helper'
 
 describe 'api', type: :routing do
+  let!(:current_disable_api_routes_setting) do
+    Spree::Api::Config[:disable_api_routes]
+  end
+
   context 'when disable_api_routes is enabled' do
     before do
       stub_spree_preferences(Spree::Api::Config, disable_api_routes: true)
@@ -29,5 +33,14 @@ describe 'api', type: :routing do
         expect(get: '/api/products').to be_routable
       end
     end
+  end
+
+  after do
+    stub_spree_preferences(
+      Spree::Api::Config,
+      disable_api_routes: current_disable_api_routes_setting
+    )
+
+    Rails.application.reload_routes!
   end
 end


### PR DESCRIPTION
## Description

Implements #3669.

## Goal

```
As a `solidus_backend` user
I want `solidus_backend` to only mount the routes needed for the admin interface,
  and not all of the routes of `solidus_api`
So that we don't have to take care of securing/maintaining/monitoring those API routes
```

## Requirements

### Scenario: Setting `Spree::Api::Config[:disable_api_routes]` excludes api routes from being mounted

```
Given I have a Rails app
And I added `solidus_backend` to the app
When I set `Spree::Api::Config[:disable_api_routes]` to true
And I run `rails routes`
Then I should not see any of the `Spree::Core::Engine` api routes
And I should continue seeing the `Spree::Core::Engine` backend routes
```

## Demo

- Please check https://github.com/gsmendoza/solidus-3669-demo.

## Notes on implementation

* I changed the proposed name of `backend_routes_only` to `disable_api_routes` because I think it's ideal if `solidus_api` doesn't know anything about backend logic.
* I checked a similar configuration, `Spree::Api::Config[:requires_authentication]`, and didn't find any specs that directly test the configuration. That being said, I was able to add a routing spec for  `disable_api_routes`.
* I'm not sure if I need to add a default setting for the preference in `solidus/core/lib/generators/solidus/install/templates/config/initializers/spree.rb.tt`.
* I didn't see any documentation on `requires_authentication` in the repo.

## Checklist

- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
