### PR TITLE
Show a deprecation message for PaymentMethod::DISPLAY

### DIFF
--- a/core/app/models/spree/payment_method.rb
+++ b/core/app/models/spree/payment_method.rb
@@ -21,6 +21,10 @@ module Spree
     # @private
     def self.const_missing(name)
       if name == :DISPLAY
+        Spree::Deprecation.warn(
+          "#{self}::DISPLAY has been deprecated and will be removed in Solidus v3.",
+          caller
+        )
         const_set(:DISPLAY, [:both, :front_end, :back_end])
       else
         super

--- a/core/spec/models/spree/payment_method_spec.rb
+++ b/core/spec/models/spree/payment_method_spec.rb
@@ -396,13 +396,13 @@ RSpec.describe Spree::PaymentMethod, type: :model do
 
   describe "::DISPLAY" do
     it "returns [:both, :front_end, :back_end]" do
-      # Emits deprecation warning on first reference
-      Spree::Deprecation.silence do
-        expect(Spree::PaymentMethod::DISPLAY).to eq([:both, :front_end, :back_end])
-      end
+      expect(Spree::Deprecation).to receive(:warn).
+        with(/^Spree::PaymentMethod::DISPLAY has been deprecated and will be removed/, any_args).once
 
+      # Emits deprecation warning on first reference
+      expect(described_class::DISPLAY).to eq([:both, :front_end, :back_end])
       # but not subsequent
-      expect(Spree::PaymentMethod::DISPLAY).to eq([:both, :front_end, :back_end])
+      expect(described_class::DISPLAY).to eq([:both, :front_end, :back_end])
     end
   end
 end


### PR DESCRIPTION
`Spree::PaymentMethod::DISPLAY` was deprecated in aaed1ec but a deprecation message was never added afterwards.
This adds a deprecation message on the first call of `Spree::PaymentMethod::DISPLAY` constant.

**Checklist:**
- [ ] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [ ] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
