### PR TITLE
Fix Italy state seed generation

### DIFF
--- a/core/db/default/spree/states.rb
+++ b/core/db/default/spree/states.rb
@@ -1,14 +1,22 @@
 # frozen_string_literal: true
 
+def create_states(subregions, country)
+  subregions.each do |subregion|
+    Spree::State.where(abbr: subregion.code, country: country).first_or_create!(
+      name: subregion.name
+    )
+  end
+end
+
 ActiveRecord::Base.transaction do
   Spree::Country.all.each do |country|
     carmen_country = Carmen::Country.coded(country.iso)
     next unless carmen_country.subregions?
 
-    carmen_country.subregions.each do |subregion|
-      Spree::State.where(abbr: subregion.code, country: country).first_or_create!(
-        name: subregion.name
-      )
+    if Spree::Config[:countries_that_use_nested_subregions].include? country.iso
+      create_states(carmen_country.subregions.flat_map(&:subregions), country)
+    else
+      create_states(carmen_country.subregions, country)
     end
   end
 end

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -248,6 +248,14 @@ module Spree
     #   (default: +['admin']+)
     preference :roles_for_auto_api_key, :array, default: ['admin']
 
+    # @!attribute [rw] countries_that_use_nested_subregions
+    #   @return [Array] An array of countries that use nested subregions, instead
+    #   of the default subregions that come with Carmen. Will be used on store creation
+    #   to ensure the correct states are generated, and when running the states
+    #   regenerate rake task.
+    #   (default: +['IT']+)
+    preference :countries_that_use_nested_subregions, :array, default: ['IT']
+
     # @!attribute [rw] run_order_validations_on_order_updater
     #   @return [Boolean] Whether to run validation when updating an order with the OrderUpdater
     preference :run_order_validations_on_order_updater, :boolean, default: false


### PR DESCRIPTION
**Description**
Previously, Italy was using the top-level `subregions` - `regions`
in Carmen to generate states, however for a mailing address this
is incorrect, and it instead needs to use `provinces`, which is
nested as the second level of `subregions` in Carmen. This fixes the
seed generation, allowing for more countries to make this switch
as necessary (there are a handful of other countries that need this)

<strike>Also, adds a `state:regenerate` rake task that updates states for
countries that were generated incorrectly, like Italy. This is so
people updgrading from v2.10 to v2.11 can easily update to the
correct state list.</strike> This has been moved to a rake task, if you want
this functionality, you'll need to copy it over into your own code! 
https://gist.github.com/seand7565/6342d7ce7a89b2412fcb4eab7f2c8a61

This PR only fixes Italy, but lays down some structure to allow fixing 
other countries that need this treatment. For instance, if Spain needs 
to use the nested subregions instead of the top-level subregions, we 
just need to add Spains ISO code to `countries_that_use_nested_subregions` 
in `states.rb` and the ISO array on line 7 of `states.rake`. 

Ref: #3670 

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
