### PR TITLE
[Admin] Disallow promotions with empty action type and discount rule

### DIFF
--- a/backend/app/views/spree/admin/promotions/_actions.html.erb
+++ b/backend/app/views/spree/admin/promotions/_actions.html.erb
@@ -8,7 +8,7 @@
         <div class="field">
           <%= label_tag :action_type, t('spree.adjustment_type')%>
           <%= admin_hint t('spree.adjustment_type'), t(:promotions, scope: [:spree, :hints, "spree/calculator"]) %>
-          <%= select_tag 'action_type', options, include_blank: t(:choose_promotion_action, scope: 'spree'), class: 'custom-select fullwidth' %>
+          <%= select_tag 'action_type', options, include_blank: t(:choose_promotion_action, scope: 'spree'), class: 'custom-select fullwidth', required: true %>
         </div>
         <div class="filter-actions actions">
           <%= button_tag t('spree.actions.add'), class: 'btn btn-primary' %>

--- a/backend/app/views/spree/admin/promotions/_rules.html.erb
+++ b/backend/app/views/spree/admin/promotions/_rules.html.erb
@@ -7,7 +7,7 @@
       <% if can?(:update, @promotion) %>
         <div class="field">
           <%= label_tag :promotion_rule_type, t('spree.discount_rules') %>
-          <%= select_tag('promotion_rule[type]', options_for_promotion_rule_types(@promotion), include_blank: t(:choose_promotion_rule, scope: 'spree'), class: 'custom-select fullwidth') %>
+          <%= select_tag('promotion_rule[type]', options_for_promotion_rule_types(@promotion), include_blank: t(:choose_promotion_rule, scope: 'spree'), class: 'custom-select fullwidth', required: true) %>
         </div>
         <div class="filter-actions actions">
           <%= button_tag t('spree.actions.add'), class: 'btn btn-primary' %>

--- a/backend/spec/features/admin/promotion_adjustments_spec.rb
+++ b/backend/spec/features/admin/promotion_adjustments_spec.rb
@@ -240,6 +240,27 @@ describe "Promotion Adjustments", type: :feature, js: true do
       expect(first_action.calculator.preferred_amount).to eq(5)
     end
 
+    context 'creating a promotion with discount rules and adjustments' do
+      before do
+        fill_in "Name", with: "SAVE SAVE SAVE"
+        choose "Apply to all orders"
+        click_button "Create"
+        expect(page).to have_title("SAVE SAVE SAVE - Promotions")
+      end
+
+      it "should not allow an Discount Rule to be added without selecting an option" do
+        within('#rule_fields') { click_button "Add" }
+        message = page.find("#promotion_rule_type").native.attribute("validationMessage")
+        expect(message).to eq "Please select an item in the list."
+      end
+
+      it "should not allow an Adjusment type to be added without selecting an option" do
+        within('#action_fields') { click_button "Add" }
+        message = page.find("#action_type").native.attribute("validationMessage")
+        expect(message).to eq "Please select an item in the list."
+      end
+    end
+
     context 'creating a promotion with promotion action that has a calculator with complex preferences' do
       before do
         class ComplexCalculator < Spree::Calculator


### PR DESCRIPTION
**Description**
<!--
  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

  Please include screenshots in case of visual changes to the frontend or backend sections of Solidus.

  If needed you can reference another PR or issue here, e.g.:
  Ref #ISSUE
-->
Adds HTML5 form validations for Discount Rules and Adjustment Types for Promotions in the admin.

**Chrome Screenshots:**
![Screen Shot 2020-07-30 at 3 45 08 PM](https://user-images.githubusercontent.com/4549543/88979702-6f683000-d27f-11ea-8f5e-05b4e28ac0fe.png)
![Screen Shot 2020-07-30 at 3 45 02 PM](https://user-images.githubusercontent.com/4549543/88979703-70995d00-d27f-11ea-8f72-047230a503f9.png)


**Firefox Screenshots**
<img width="1683" alt="Screen Shot 2020-07-30 at 3 44 13 PM" src="https://user-images.githubusercontent.com/4549543/88979797-9cb4de00-d27f-11ea-8f50-f7659cb9f887.png">
<img width="1707" alt="Screen Shot 2020-07-30 at 3 44 04 PM" src="https://user-images.githubusercontent.com/4549543/88979801-9d4d7480-d27f-11ea-9b93-2be275c545cc.png">

Resolves #3707 

**Checklist:**
- [ x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [ x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ x] I have added tests to cover this change (if needed)
- [ x] I have attached screenshots to this PR for visual changes (if needed)
