### PR TITLE
Fixes for consistent handling of resource errors on admin 

### DIFF
--- a/backend/app/controllers/spree/admin/base_controller.rb
+++ b/backend/app/controllers/spree/admin/base_controller.rb
@@ -62,6 +62,12 @@ module Spree
       def order_mutex_redirect_path
         edit_admin_order_path(@order)
       end
+
+      def resource_not_found(flash_class:, redirect_url:)
+        flash[:error] = flash_message_for(flash_class.new, :not_found)
+        redirect_to redirect_url
+        nil
+      end
     end
   end
 end

--- a/backend/app/controllers/spree/admin/cancellations_controller.rb
+++ b/backend/app/controllers/spree/admin/cancellations_controller.rb
@@ -36,6 +36,8 @@ module Spree
       def load_order
         @order = Spree::Order.find_by!(number: params[:order_id])
         authorize! action, @order
+      rescue ActiveRecord::RecordNotFound
+        resource_not_found(flash_class: Spree::Order, redirect_url: admin_orders_path)
       end
 
       def model_class

--- a/backend/app/controllers/spree/admin/customer_returns_controller.rb
+++ b/backend/app/controllers/spree/admin/customer_returns_controller.rb
@@ -42,6 +42,8 @@ module Spree
 
       def collection
         parent # trigger loading the order
+        return unless @order
+
         @collection ||= Spree::ReturnItem
           .accessible_by(current_ability, :read)
           .where(inventory_unit_id: @order.inventory_units.pluck(:id))

--- a/backend/app/controllers/spree/admin/images_controller.rb
+++ b/backend/app/controllers/spree/admin/images_controller.rb
@@ -4,7 +4,6 @@ module Spree
   module Admin
     class ImagesController < ResourceController
       before_action :load_data
-
       create.before :set_viewable
       update.before :set_viewable
 
@@ -24,6 +23,8 @@ module Spree
           [variant.sku_and_options_text, variant.id]
         end
         @variants.insert(0, [t('spree.all'), @product.master.id])
+      rescue ActiveRecord::RecordNotFound
+        resource_not_found(flash_class: Spree::Product, redirect_url: admin_products_path)
       end
 
       def set_viewable

--- a/backend/app/controllers/spree/admin/orders/customer_details_controller.rb
+++ b/backend/app/controllers/spree/admin/orders/customer_details_controller.rb
@@ -61,6 +61,8 @@ module Spree
 
         def load_order
           @order = Spree::Order.includes(:adjustments).find_by!(number: params[:order_id])
+        rescue ActiveRecord::RecordNotFound
+          resource_not_found(flash_class: Spree::Order, redirect_url: admin_orders_path)
         end
 
         def model_class

--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -10,7 +10,6 @@ module Spree
       around_action :lock_order, only: [:update, :advance, :complete, :confirm, :cancel, :resume, :approve, :resend]
 
       rescue_from Spree::Order::InsufficientStock, with: :insufficient_stock_error
-
       respond_to :html
 
       def index
@@ -168,6 +167,8 @@ module Spree
       def load_order
         @order = Spree::Order.includes(:adjustments).find_by!(number: params[:id])
         authorize! action, @order
+      rescue ActiveRecord::RecordNotFound
+        resource_not_found(flash_class: Spree::Order, redirect_url: admin_orders_path)
       end
 
       # Used for extensions which need to provide their own custom event links on the order details view.

--- a/backend/app/controllers/spree/admin/payments_controller.rb
+++ b/backend/app/controllers/spree/admin/payments_controller.rb
@@ -92,6 +92,8 @@ module Spree
         @order = Spree::Order.find_by!(number: params[:order_id])
         authorize! action, @order
         @order
+      rescue ActiveRecord::RecordNotFound
+        resource_not_found(flash_class: Spree::Order, redirect_url: admin_orders_path)
       end
 
       def load_payment

--- a/backend/app/controllers/spree/admin/taxons_controller.rb
+++ b/backend/app/controllers/spree/admin/taxons_controller.rb
@@ -3,6 +3,7 @@
 module Spree
   module Admin
     class TaxonsController < Spree::Admin::BaseController
+      rescue_from ActiveRecord::RecordNotFound, with: :resource_not_found
       respond_to :html, :json, :js
 
       def index
@@ -82,6 +83,10 @@ module Spree
 
       def taxon_params
         params.require(:taxon).permit(permitted_taxon_attributes)
+      end
+
+      def resource_not_found
+        super(flash_class: Taxon, redirect_url: admin_taxonomies_path)
       end
     end
   end

--- a/backend/app/controllers/spree/admin/variants_controller.rb
+++ b/backend/app/controllers/spree/admin/variants_controller.rb
@@ -43,8 +43,10 @@ module Spree
       end
 
       def parent
-        @parent ||= Spree::Product.with_discarded.find_by(slug: params[:product_id])
+        @parent ||= Spree::Product.with_discarded.find_by!(slug: params[:product_id])
         @product = @parent
+      rescue ActiveRecord::RecordNotFound
+        resource_not_found(flash_class: Spree::Product, redirect_url: admin_products_path)
       end
     end
   end

--- a/backend/spec/controllers/spree/admin/cancellations_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/cancellations_controller_spec.rb
@@ -17,6 +17,14 @@ describe Spree::Admin::CancellationsController do
         expect(response).to be_ok
       end
     end
+
+    context "existent order id not given" do
+      it "redirects and flashes about the non-existent order" do
+        get :index, params: { order_id: 'non-existent-order' }
+        expect(response).to redirect_to(spree.admin_orders_path)
+        expect(flash[:error]).to eql("Order is not found")
+      end
+    end
   end
 
   describe "#cancel" do

--- a/backend/spec/controllers/spree/admin/customer_returns_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/customer_returns_controller_spec.rb
@@ -26,6 +26,14 @@ module Spree
         end
       end
 
+      context "existent order id not given" do
+        it "redirects and flashes about the non-existent order" do
+          get :index, params: { order_id: 'non-existent-order' }
+          expect(response).to redirect_to(spree.admin_orders_path)
+          expect(flash[:error]).to eql("Order is not found")
+        end
+      end
+
       describe "#new" do
         let(:order) { create(:shipped_order, line_items_count: 1) }
         let!(:inactive_reimbursement_type)      { create(:reimbursement_type, active: false) }

--- a/backend/spec/controllers/spree/admin/images_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/images_controller_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Spree::Admin::ImagesController, type: :controller do
+  stub_authorization!
+
+  it "cannot find a non-existent product" do
+    get :index, params: { product_id: "non-existent-product" }
+    expect(response).to redirect_to(spree.admin_products_path)
+    expect(flash[:error]).to eql("Product is not found")
+  end
+end

--- a/backend/spec/controllers/spree/admin/orders/customer_details_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/orders/customer_details_controller_spec.rb
@@ -53,6 +53,13 @@ describe Spree::Admin::Orders::CustomerDetailsController, type: :controller do
           end
         end
       end
+      context "existent order id not given" do
+        it "redirects and flashes about the non-existent order" do
+          get :edit, params: { order_id: 'non-existent-order' }
+          expect(response).to redirect_to(spree.admin_orders_path)
+          expect(flash[:error]).to eql("Order is not found")
+        end
+      end
     end
 
     context "#update" do

--- a/backend/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -396,13 +396,13 @@ describe Spree::Admin::OrdersController, type: :controller do
     end
   end
 
-  context "order number not given" do
+  context "existent order number not given" do
     stub_authorization!
 
-    it "raise active record not found" do
-      expect {
-        get :edit, params: { id: 0 }
-      }.to raise_error ActiveRecord::RecordNotFound
+    it "cannot find non-existent order" do
+      get :edit, params: { id: 0 }
+      expect(response).to redirect_to(spree.admin_orders_path)
+      expect(flash[:error]).to eql("Order is not found")
     end
   end
 end

--- a/backend/spec/controllers/spree/admin/payments_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/payments_controller_spec.rb
@@ -152,6 +152,14 @@ module Spree
             expect(response).to redirect_to(spree.edit_admin_order_customer_path(order))
           end
         end
+
+        context "existent order id not given" do
+          it "redirects and flashes about the non-existent order" do
+            get :index, params: { order_id: 'non-existent-order' }
+            expect(response).to redirect_to(spree.admin_orders_path)
+            expect(flash[:error]).to eql("Order is not found")
+          end
+        end
       end
 
       describe '#fire' do

--- a/backend/spec/controllers/spree/admin/prices_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/prices_controller_spec.rb
@@ -41,5 +41,14 @@ describe Spree::Admin::PricesController do
         expect(assigns(:product)).to eq(product)
       end
     end
+    context "existent product id not given" do
+      subject { get :index, params: { product_id: 'non-existent-product' } }
+
+      it "cannot find non-existent product" do
+        subject
+        expect(response).to redirect_to(spree.admin_products_path)
+        expect(flash[:error]).to eql("Product is not found")
+      end
+    end
   end
 end

--- a/backend/spec/controllers/spree/admin/product_properties_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/product_properties_controller_spec.rb
@@ -64,6 +64,21 @@ module Spree
               expect(assigns(:variant_property_rule)).to eq first_rule
             end
           end
+
+          context "existent product id not given" do
+            let(:parameters) do
+              {
+                product_id: 'non-existent-product'
+              }
+            end
+
+            before { subject }
+
+            it "cannot find non-existent product" do
+              expect(response).to redirect_to(spree.admin_products_path)
+              expect(flash[:error]).to eql("Product is not found")
+            end
+          end
         end
       end
     end

--- a/backend/spec/controllers/spree/admin/store_credits_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/store_credits_controller_spec.rb
@@ -308,4 +308,12 @@ describe Spree::Admin::StoreCreditsController do
       end
     end
   end
+  context 'User does not exist' do
+    let(:store_credit) { create(:store_credit, user: user, category: a_credit_category) }
+    it "cannot find a store-credit for non-existent user" do
+      get :index, params: { user_id: 'non-existent-user', id: store_credit.id }
+      expect(response).to redirect_to(spree.admin_users_path)
+      expect(flash[:error]).to eql("User is not found")
+    end
+  end
 end

--- a/backend/spec/controllers/spree/admin/taxons_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/taxons_controller_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Spree::Admin::TaxonsController, type: :controller do
+  stub_authorization!
+
+  describe "#edit" do
+    let!(:taxon) { create(:taxon) }
+
+    it "finds existing taxon" do
+      get :edit, params: { taxonomy_id: taxon.taxonomy, id: taxon.id }
+      expect(response.status).to eq(200)
+    end
+
+    it "cannot find a non-existing taxon with existent taxonomy" do
+      get :edit, params: { taxonomy_id: taxon.taxonomy, id: 'non-existent-taxon' }
+      expect(response).to redirect_to(spree.admin_taxonomies_path)
+      expect(flash[:error]).to eql("Taxon is not found")
+    end
+
+    it "cannot find a existing taxon with non-existent taxonomy" do
+      get :edit, params: { taxonomy_id: 'non-existent-taxonomy', id: taxon.id }
+      expect(response).to redirect_to(spree.admin_taxonomies_path)
+      expect(flash[:error]).to eql("Taxon is not found")
+    end
+  end
+end

--- a/backend/spec/controllers/spree/admin/variants_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/variants_controller_spec.rb
@@ -53,6 +53,15 @@ module Spree
                 expect(assigns(:collection)).to include deleted_variant
               end
             end
+            context "existent product id not given" do
+              let(:params) { { product_id: 'non-existent-product' } }
+
+              it "cannot find non-existent product" do
+                subject
+                expect(response).to redirect_to(spree.admin_products_path)
+                expect(flash[:error]).to eql("Product is not found")
+              end
+            end
           end
         end
       end


### PR DESCRIPTION
**Description**

Referring to the detailed examples in issues #3604 and #3143, there was inconsistency in the way errors were handled due to non-existent resources on the admin panel. The aim was to bring consistency to these errors by redirecting all errors to the relevant page with a relevant flash_message.

This PR fixes all the mentioned issues as well as additional inconsistencies and creates mulitple tests to ensure all the fixes are not affected in the future.

### Previously, these nil-resource routes were redirected correctly:
 **products**
 `/admin/products/nil-product/edit`
 `/admin/products/nil-product/stock`
**users**
 `/admin/users/nil-user/edit` 
 `/admin/users/nil-user/addresses` 
 `/admin/users/nil-user/orders`
 `/admin/users/nil-user/items` 
**promotions**
`/admin/promotion_categories/nil-category/edit`
`/admin/promotions/nil-promotion/edit`
**option types**
`/admin/option_types/nil-type/edit`
**property types**
`/admin/properties/nil-prop/edit`
**taxonomies**
`/admin/taxonomies/nil-taxonomy/edit`
  
### After this PR, the following are fixed and redirected correctly as well:
**orders**
`/admin/orders/nil-order/edit`
`/admin/orders/nil-order/customer_returns`
`/admin/orders/nil-order/customer_returns/1/edit`
`/admin/orders/nil-order/cart`
`/admin/orders/nil-order/customer/edit`
`/admin/orders/nil-order/adjustments`
`/admin/orders/nil-order/payments`
`/admin/orders/nil-order/return_authorizations`
`/admin/orders/nil-order/cancellations`
**products**
`/admin/products/nil-product/images`
`/admin/products/nil-product/prices`
`/admin/products/nil-product/product_properties`
`/admin/products/nil-product/variants`
 **taxons**
`/admin/taxonomies/nil-taxon/taxons/3/edit`
`/admin/taxonomies/1/taxons/nil-taxon/edit`
**users**
`/admin/users/nil-user/store_credits`



**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] ~~I have updated Guides and README accordingly to this change (if needed)~~
- [x] I have added tests to cover this change (if needed)
- [ ] ~~I have attached screenshots to this PR for visual changes (if needed)~~
