### PR TITLE
Add payment method selection to the install generator

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,7 @@ require 'bundler'
 task default: :spec
 
 def print_title(gem_name = '')
-  title = ["Solidus", gem_name].join(' ')
+  title = ["Solidus", gem_name].join(' ').strip
   puts "\n#{'-' * title.size}\n#{title}\n#{'-' * title.size}"
 end
 

--- a/core/lib/generators/solidus/install/install_generator.rb
+++ b/core/lib/generators/solidus/install/install_generator.rb
@@ -10,8 +10,8 @@ module Solidus
     CORE_MOUNT_ROUTE = "mount Spree::Core::Engine"
 
     class_option :migrate, type: :boolean, default: true, banner: 'Run Solidus migrations'
-    class_option :seed, type: :boolean, default: true, banner: 'load seed data (migrations must be run)'
-    class_option :sample, type: :boolean, default: true, banner: 'load sample data (migrations must be run)'
+    class_option :seed, type: :boolean, default: true, banner: 'Load seed data (migrations must be run)'
+    class_option :sample, type: :boolean, default: true, banner: 'Load sample data (migrations must be run)'
     class_option :auto_accept, type: :boolean
     class_option :user_class, type: :string
     class_option :admin_email, type: :string

--- a/core/lib/generators/solidus/install/install_generator.rb
+++ b/core/lib/generators/solidus/install/install_generator.rb
@@ -114,7 +114,7 @@ module Solidus
     end
 
     def install_default_plugins
-      if options[:with_authentication] && (options[:auto_accept] || yes?("
+      if options[:with_authentication] && (options[:auto_accept] || !no?("
   Solidus has a default authentication extension that uses Devise.
   You can find more info at https://github.com/solidusio/solidus_auth_devise.
 

--- a/core/lib/generators/solidus/install/install_generator.rb
+++ b/core/lib/generators/solidus/install/install_generator.rb
@@ -106,7 +106,7 @@ module Solidus
     def install_default_plugins
       if options[:with_authentication] && (options[:auto_accept] || yes?("
   Solidus has a default authentication extension that uses Devise.
-  You can find more info at github.com/solidusio/solidus_auth_devise.
+  You can find more info at https://github.com/solidusio/solidus_auth_devise.
 
   Would you like to install it? (y/n)"))
 


### PR DESCRIPTION
**Description**

This improves the install generator making the final result better equipped for production use.

The default payment method is PayPal Commerce Platform that has a convenient no-code-required onboarding process. New methods can be added easily for similar solutions, which are encouraged.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)


**Preview**

```
      create  config/initializers/spree.rb
      append  public/robots.txt
       exist  app/assets/images
      create  vendor/assets/javascripts/spree/frontend
      create  vendor/assets/javascripts/spree/backend
      create  vendor/assets/stylesheets/spree/frontend
      create  vendor/assets/stylesheets/spree/backend
      create  vendor/assets/images/spree/frontend
      create  vendor/assets/images/spree/backend
      create  vendor/assets/javascripts/spree/frontend/all.js
      create  vendor/assets/stylesheets/spree/frontend/all.css
      create  vendor/assets/javascripts/spree/backend/all.js
      create  vendor/assets/stylesheets/spree/backend/all.css
      create  app/overrides

  Solidus has a default authentication extension that uses Devise.
  You can find more info at https://github.com/solidusio/solidus_auth_devise.

  Would you like to install it? (y/n) 
     gemfile  solidus_auth_devise

  You can select a payment method to be included in the installation process.
  Please select a payment method name: [paypal, none] (paypal) 
     gemfile  solidus_paypal_commerce_platform
      append  db/seeds.rb
     copying  migrations
    creating  database
        rake  db:create
```

help banner:

```
Usage:
  rails generate spree:install [options]

Options:
  [--skip-namespace], [--no-skip-namespace]                            # Skip namespace (affects only isolated applications)
  [--migrate=Run Solidus migrations], [--no-migrate]                   # Indicates when to generate migrate
                                                                       # Default: true
  [--seed=Load seed data (migrations must be run)], [--no-seed]        # Indicates when to generate seed
                                                                       # Default: true
  [--sample=Load sample data (migrations must be run)], [--no-sample]  # Indicates when to generate sample
                                                                       # Default: true
  [--auto-accept], [--no-auto-accept]                                  # Indicates when to generate auto accept
  [--user-class=USER_CLASS]                                            # Indicates when to generate user class
  [--admin-email=ADMIN_EMAIL]                                          # Indicates when to generate admin email
  [--admin-password=ADMIN_PASSWORD]                                    # Indicates when to generate admin password
  [--lib-name=LIB_NAME]                                                # Indicates when to generate lib name
                                                                       # Default: spree
  [--with-authentication], [--no-with-authentication]                  # Indicates when to generate with authentication
                                                                       # Default: true
  [--enforce-available-locales], [--no-enforce-available-locales]      # Indicates when to generate enforce available locales
  [--payment-method=PAYMENT_METHOD]                                    # Indicates which payment method to install.
                                                                       # Default: paypal
                                                                       # Possible values: paypal, none

Runtime options:
  -f, [--force]                    # Overwrite files that already exist
  -p, [--pretend], [--no-pretend]  # Run but do not make any changes
  -q, [--quiet], [--no-quiet]      # Suppress status output
  -s, [--skip], [--no-skip]        # Skip files that already exist

Description:
    Create spree files for install generator.
```