### PR TITLE
Respect current ability in users controllers

### DIFF
--- a/backend/app/controllers/spree/admin/users_controller.rb
+++ b/backend/app/controllers/spree/admin/users_controller.rb
@@ -168,7 +168,7 @@ module Spree
       end
 
       def load_stock_locations
-        @stock_locations = Spree::StockLocation.all
+        @stock_locations = Spree::StockLocation.accessible_by(current_ability)
       end
 
       def set_roles

--- a/backend/app/controllers/spree/admin/users_controller.rb
+++ b/backend/app/controllers/spree/admin/users_controller.rb
@@ -161,7 +161,7 @@ module Spree
       end
 
       def load_roles
-        @roles = Spree::Role.all
+        @roles = Spree::Role.accessible_by(current_ability)
         if @user
           @user_roles = @user.spree_roles
         end

--- a/backend/app/controllers/spree/admin/users_controller.rb
+++ b/backend/app/controllers/spree/admin/users_controller.rb
@@ -176,8 +176,8 @@ module Spree
       end
 
       def set_roles
-        if user_params[:spree_role_ids] && can?(:manage, Spree::Role)
-          @user.spree_roles = Spree::Role.where(id: user_params[:spree_role_ids])
+        if user_params[:spree_role_ids]
+          @user.spree_roles = Spree::Role.accessible_by(current_ability).where(id: user_params[:spree_role_ids])
         end
       end
 

--- a/backend/app/controllers/spree/admin/users_controller.rb
+++ b/backend/app/controllers/spree/admin/users_controller.rb
@@ -141,6 +141,10 @@ module Spree
           attributes += [{ spree_role_ids: [] }]
         end
 
+        if can? :manage, Spree::StockLocation
+          attributes += [{ stock_location_ids: [] }]
+        end
+
         unless can? :update_password, @user
           attributes -= [:password, :password_confirmation]
         end
@@ -178,7 +182,10 @@ module Spree
       end
 
       def set_stock_locations
-        @user.stock_locations = Spree::StockLocation.where(id: (params[:user][:stock_location_ids] || []))
+        if user_params[:stock_location_ids]
+          @user.stock_locations =
+            Spree::StockLocation.accessible_by(current_ability).where(id: user_params[:stock_location_ids])
+        end
       end
     end
   end

--- a/backend/app/controllers/spree/admin/users_controller.rb
+++ b/backend/app/controllers/spree/admin/users_controller.rb
@@ -124,7 +124,7 @@ module Spree
       def collection
         return @collection if @collection
 
-        @search = Spree.user_class.ransack(params[:q])
+        @search = super.ransack(params[:q])
         @collection = @search.result.includes(:spree_roles)
         @collection = @collection.includes(:spree_orders)
         @collection = @collection.page(params[:page]).per(Spree::Config[:admin_products_per_page])

--- a/backend/spec/controllers/spree/admin/users_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/users_controller_spec.rb
@@ -142,6 +142,36 @@ describe Spree::Admin::UsersController, type: :controller do
         expect(assigns(:roles)).to eq [accessible_role]
       end
     end
+
+    context "when the user can manage all stock_locations" do
+      stub_authorization! do |_user|
+        can :manage, Spree.user_class
+        can :index, Spree::StockLocation
+      end
+
+      it "assigns a list of all stock_locations as @stock_locations" do
+        stock_location = create(:stock_location)
+
+        get :new, params: { id: user.id }
+        expect(assigns(:stock_locations)).to eq [stock_location]
+      end
+    end
+
+    context "when user cannot list some stock_locations" do
+      stub_authorization! do |_user|
+        can :manage, Spree.user_class
+        can :index, Spree::StockLocation
+        cannot :index, Spree::StockLocation, name: 'not_accessible_stock_location'
+      end
+
+      it "assigns a list of accessible stock_locations as @stock_locations" do
+        accessible_stock_location = create(:stock_location, name: 'accessible_stock_location')
+        create(:stock_location, name: 'not_accessible_stock_location')
+
+        get :new, params: { id: user.id }
+        expect(assigns(:stock_locations)).to eq [accessible_stock_location]
+      end
+    end
   end
 
   describe "#create" do


### PR DESCRIPTION
**Description**

Admin users were able to see users, roles, and stock locations that they don't have permission to manage in admin users index and form. This fixes those authorization inconsistencies reported in issue #3668.

* Users that the admin user can't manage are not listed anymore.
* Roles that the admin user can't manage are not listed in the search input nor in the users' create/update form.
* Stock locations that the admin user can't manage are not listed in the user's create/update form.
* Fixed problem that not accessible roles and stock locations passed in `:spree_role_ids` and `:stock_locations_ids` params were still being assigned to the user.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
