### PR TITLE
Refactor Product#available? to match docs

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -172,7 +172,7 @@ module Spree
     #
     # @return [Boolean] true if this product is available
     def available?
-      !(available_on.nil? || available_on.future?) && !deleted?
+      !deleted? && available_on&.past?
     end
 
     # Groups variants by the specified option type.


### PR DESCRIPTION
**Description**

This is a very small quality-of-life type improvement, but I noticed that the safe navigation operator can be used to simplify the logic of the `Product#available?` method.

Rephrasing the logic this way we:

- Have two(ish) conditions instead of three
- Avoid the semantic confusion of "not nil or future"
- Flip the `deleted` and `available_on` conditions, to better match the docs, which say, 
`A product is available if it has not been deleted and the available_on date is in the past.`

It’s not earth shattering by any means, but it makes the code that much more readable IMO, especially for folks new to Solidus.