### PR TITLE
Make payment.rb methods more concise

### DIFF
--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -179,11 +179,11 @@ module Spree
     end
 
     def source_required?
-      payment_method.present? && payment_method.source_required?
+      !!payment_method&.source_required?
     end
 
     def profiles_supported?
-      payment_method.respond_to?(:payment_profiles_supported?) && payment_method.payment_profiles_supported?
+      !!payment_method.try(:payment_profiles_supported?)
     end
 
     def create_payment_profile


### PR DESCRIPTION
**Description**

In payment.rb, the `source_required?` method uses the `foo.present? && foo.bar` pattern, which can more concisely be expressed in Ruby >= 2.3 using the safe navigation operator as `foo&.bar`.

Likewise, the `profiles_supported?` method uses the `foo.respond_to?(:bar) && foo.bar` pattern, which can more concisely be expressed using Rails's `try` method as `foo.try(:bar)`.
