### PR TITLE
Upgrade acts_as_list gem dependency to allow v1.x

### DIFF
--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   end
 
   s.add_dependency 'activemerchant', '~> 1.66'
-  s.add_dependency 'acts_as_list', '~> 0.3'
+  s.add_dependency 'acts_as_list', '< 2.0'
   s.add_dependency 'awesome_nested_set', '~> 3.2'
   s.add_dependency 'cancancan', ['>= 2.2', '< 4.0']
   s.add_dependency 'carmen', '~> 1.1.0'


### PR DESCRIPTION
**Description**
Updates the acts_as_list gem dependency for solidus-core from `~0.3` (which matches up to v0.9.19) to `< 2.0` 
(the current acts_as_list version is 1.0 released 2019-09-26)
