### PR TITLE
Fix ruby 2.7 warnings on core

### DIFF
--- a/core/app/models/concerns/spree/user_address_book.rb
+++ b/core/app/models/concerns/spree/user_address_book.rb
@@ -5,7 +5,7 @@ module Spree
     extend ActiveSupport::Concern
 
     included do
-      has_many :user_addresses, -> { active }, { foreign_key: "user_id", class_name: "Spree::UserAddress" } do
+      has_many :user_addresses, -> { active }, **{ foreign_key: "user_id", class_name: "Spree::UserAddress" } do
         def find_first_by_address_values(address_attrs)
           detect { |ua| ua.address == Spree::Address.new(address_attrs) }
         end

--- a/core/app/models/spree/payment_method.rb
+++ b/core/app/models/spree/payment_method.rb
@@ -62,7 +62,7 @@ module Spree
           @human
         ].compact
         options = { scope: [:activerecord, :models], count: 1, default: defaults }.merge!(options.except(:default))
-        I18n.translate(defaults.shift, options)
+        I18n.translate(defaults.shift, **options)
       end
     end
 

--- a/core/app/models/spree/promotion_rule.rb
+++ b/core/app/models/spree/promotion_rule.rb
@@ -45,7 +45,7 @@ module Spree
     end
 
     def eligibility_error_message(key, options = {})
-      I18n.t(key, { scope: [:spree, :eligibility_errors, :messages] }.merge(options))
+      I18n.t(key, **{ scope: [:spree, :eligibility_errors, :messages] }.merge(options))
     end
   end
 end

--- a/core/app/models/spree/return_item/exchange_variant_eligibility/same_option_value.rb
+++ b/core/app/models/spree/return_item/exchange_variant_eligibility/same_option_value.rb
@@ -23,7 +23,7 @@ module Spree
         # blue pants with 34 waist and 32 inseam
 
         def self.eligible_variants(variant, options = {})
-          product_variants = SameProduct.eligible_variants(variant, options).includes(option_values: :option_type)
+          product_variants = SameProduct.eligible_variants(variant, **options).includes(option_values: :option_type)
           relevant_option_values = variant.option_values.select { |ov| option_type_restrictions.include? ov.option_type.name }
 
           if relevant_option_values.present?

--- a/core/lib/spree/i18n.rb
+++ b/core/lib/spree/i18n.rb
@@ -31,7 +31,7 @@ module Spree
         Instead use I18n.t('spree.your_translation_key')
       WARN
       options[:scope] = [:spree, *options[:scope]]
-      TranslationHelperWrapper.new.translate(key, options)
+      TranslationHelperWrapper.new.translate(key, **options)
     end
 
     alias_method :t, :translate

--- a/core/spec/models/spree/order/payment_spec.rb
+++ b/core/spec/models/spree/order/payment_spec.rb
@@ -111,13 +111,13 @@ module Spree
       end
 
       it "keeps source attributes on assignment" do
-        OrderUpdateAttributes.new(order, payments_attributes: [payment_attributes]).apply
+        OrderUpdateAttributes.new(order, { payments_attributes: [payment_attributes] }).apply
         expect(order.unprocessed_payments.last.source.number).to be_present
       end
 
       # For the reason of this test, please see spree/spree_gateway#132
       it "keeps source attributes through OrderUpdateAttributes" do
-        OrderUpdateAttributes.new(order, payments_attributes: [payment_attributes]).apply
+        OrderUpdateAttributes.new(order, { payments_attributes: [payment_attributes] }).apply
         expect(order.unprocessed_payments.last.source.number).to be_present
       end
     end

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -850,11 +850,11 @@ RSpec.describe Spree::Payment, type: :model do
     describe "invalidating payments updates in memory objects" do
       let(:payment_method) { create(:check_payment_method) }
       before do
-        Spree::PaymentCreate.new(order, amount: 1, payment_method_id: payment_method.id).build.save!
+        Spree::PaymentCreate.new(order, { amount: 1, payment_method_id: payment_method.id }).build.save!
         expect(order.payments.map(&:state)).to contain_exactly(
           'checkout'
         )
-        Spree::PaymentCreate.new(order, amount: 2, payment_method_id: payment_method.id).build.save!
+        Spree::PaymentCreate.new(order, { amount: 2, payment_method_id: payment_method.id }).build.save!
       end
 
       it 'should not have stale payments' do

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -122,33 +122,33 @@ RSpec.describe Spree::Promotion, type: :model do
       @payload[:path] = 'content/cvv'
       expect(@action1).to receive(:perform).with(hash_including(@payload))
       expect(@action2).to receive(:perform).with(hash_including(@payload))
-      promotion.activate(@payload)
+      promotion.activate(**@payload)
     end
 
     it "does not perform actions against an order in a finalized state" do
       expect(@action1).not_to receive(:perform)
 
       @order.state = 'complete'
-      promotion.activate(@payload)
+      promotion.activate(**@payload)
 
       @order.state = 'awaiting_return'
-      promotion.activate(@payload)
+      promotion.activate(**@payload)
 
       @order.state = 'returned'
-      promotion.activate(@payload)
+      promotion.activate(**@payload)
     end
 
     it "does activate if newer then order" do
       expect(@action1).to receive(:perform).with(hash_including(@payload))
       promotion.created_at = Time.current + 2
-      expect(promotion.activate(@payload)).to be true
+      expect(promotion.activate(**@payload)).to be true
     end
 
     context "keeps track of the orders" do
       context "when activated" do
         it "assigns the order" do
           expect(promotion.orders).to be_empty
-          expect(promotion.activate(@payload)).to be true
+          expect(promotion.activate(**@payload)).to be true
           expect(promotion.orders.first).to eql @order
         end
 
@@ -165,7 +165,7 @@ RSpec.describe Spree::Promotion, type: :model do
           expect(@order.promotions.size).to eq(0)
 
           expect(
-            promotion.activate(@payload)
+            promotion.activate(**@payload)
           ).to eq(true)
 
           aggregate_failures do
@@ -180,19 +180,19 @@ RSpec.describe Spree::Promotion, type: :model do
         it "will not assign the order" do
           @order.state = 'complete'
           expect(promotion.orders).to be_empty
-          expect(promotion.activate(@payload)).to be_falsey
+          expect(promotion.activate(**@payload)).to be_falsey
           expect(promotion.orders).to be_empty
         end
       end
       context "when the order is already associated" do
         before do
           expect(promotion.orders).to be_empty
-          expect(promotion.activate(@payload)).to be true
+          expect(promotion.activate(**@payload)).to be true
           expect(promotion.orders.to_a).to eql [@order]
         end
 
         it "will not assign the order again" do
-          expect(promotion.activate(@payload)).to be true
+          expect(promotion.activate(**@payload)).to be true
           expect(promotion.orders.reload.to_a).to eql [@order]
         end
       end

--- a/core/spec/models/spree/tax/tax_location_spec.rb
+++ b/core/spec/models/spree/tax/tax_location_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Spree::Tax::TaxLocation do
   end
 
   describe "initialization" do
-    subject { described_class.new(args) }
+    subject { described_class.new(**args) }
 
     context 'with a country object' do
       let(:args) { { country: country } }
@@ -40,7 +40,7 @@ RSpec.describe Spree::Tax::TaxLocation do
 
   describe "#country" do
     let(:country) { create(:country) }
-    subject { described_class.new(args).country }
+    subject { described_class.new(**args).country }
 
     context 'with a country object' do
       let(:args) { { country: country } }
@@ -56,7 +56,7 @@ RSpec.describe Spree::Tax::TaxLocation do
   end
 
   describe "#empty?" do
-    subject { described_class.new(args).empty? }
+    subject { described_class.new(**args).empty? }
 
     context 'with a country present' do
       let(:args) { { country: country } }


### PR DESCRIPTION
**Description**

Ruby 2.7 enabled some new warnings on how you can pass default and hash parameters to a function.
This PR fixes the warning inside our core code, the remaining on the core are coming from some external gems, I'm going to open issues on the affected gems about this.

I thought that doing one component at a time, instead of all the code at once, can create enable reviews and avoid some small errors that can be missed when doing repetitive tasks like this one.

Let me know what you think about this.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
