### PR TITLE
The install generator is no longer using Bundler::CLI

### DIFF
--- a/core/lib/generators/solidus/install/install_generator.rb
+++ b/core/lib/generators/solidus/install/install_generator.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails/generators'
-require 'bundler'
-require 'bundler/cli'
 
 module Solidus
   # @private


### PR DESCRIPTION
**Description**

It was introduced to support this call to Bundler::CLI that is no
longer there:

https://github.com/solidusio/solidus/commit/89da6541dafde7e0a5dcf94561d610b7680ac998#diff-fee8174dbde028e2b7b26051c26aff79R169-R172

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
