### PR TITLE
Fix rails 61 deprecations

### DIFF
--- a/core/app/models/spree/taxon.rb
+++ b/core/app/models/spree/taxon.rb
@@ -134,7 +134,7 @@ module Spree
 
     def touch_ancestors_and_taxonomy
       # Touches all ancestors at once to avoid recursive taxonomy touch, and reduce queries.
-      self.class.where(id: ancestors.pluck(:id)).update_all(updated_at: Time.current)
+      self.class.default_scoped.where(id: ancestors.pluck(:id)).update_all(updated_at: Time.current)
       # Have taxonomy touch happen in #touch_ancestors_and_taxonomy rather than association option in order for imports to override.
       taxonomy.try!(:touch)
     end

--- a/core/lib/spree/testing_support/dummy_app.rb
+++ b/core/lib/spree/testing_support/dummy_app.rb
@@ -60,9 +60,8 @@ module DummyApp
     config.active_support.deprecation = :stderr
     config.secret_key_base = 'SECRET_TOKEN'
 
-    unless RAILS_6_OR_ABOVE
-      config.active_record.sqlite3.represent_boolean_as_integer = true
-    end
+    config.action_mailer.delivery_job = "ActionMailer::MailDeliveryJob" if RAILS_6_OR_ABOVE
+    config.active_record.sqlite3.represent_boolean_as_integer = true unless RAILS_6_OR_ABOVE
 
     config.storage_path = Rails.root.join('tmp', 'storage')
 


### PR DESCRIPTION
**Description**

Fixes two Rails 6.1 deprecation warnings:
1. Use MailDeliveryJob instead of DeliveryJob
2. Fix 'Class level methods will no longer inherit scoping from `*` in Rails 6.1.' warning

**Note:** The second warning still occurs in several tests but originates from the `acts_as_list` and `awesome_nested_set` gem

