### PR TITLE
Allow for HTML options on image partial

### DIFF
--- a/frontend/app/views/spree/shared/_image.html.erb
+++ b/frontend/app/views/spree/shared/_image.html.erb
@@ -1,11 +1,12 @@
 <% size ||= :mini %>
 <% itemprop ||= nil %>
+<% options ||= {} %>
 
 <% if image_url = image.try(:url, size)  %>
   <% if image_alt = image.try(:alt) %>
-    <%= image_tag image_url, alt: image_alt, itemprop: itemprop %>
+    <%= image_tag image_url, { alt: image_alt, itemprop: itemprop }.merge(options) %>
   <% else %>
-    <%= image_tag image_url, itemprop: itemprop %>
+    <%= image_tag image_url, { itemprop: itemprop }.merge(options) %>
   <% end %>
 <% else %>
   <span class="image-placeholder <%= size %>"></span>


### PR DESCRIPTION
**Description**
Allows the passing of HTML attributes to the image partial. 

Recently added this to a project as I needed a class passed down to the image.

Little unsure if there's a better alternative to `options ||= {}` so any guidance there would be great! 🙌

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
