### PR TITLE
Don't combine splat and hash, just use the attribute form

### DIFF
--- a/core/app/models/concerns/spree/user_address_book.rb
+++ b/core/app/models/concerns/spree/user_address_book.rb
@@ -5,7 +5,7 @@ module Spree
     extend ActiveSupport::Concern
 
     included do
-      has_many :user_addresses, -> { active }, **{ foreign_key: "user_id", class_name: "Spree::UserAddress" } do
+      has_many :user_addresses, -> { active }, foreign_key: "user_id", class_name: "Spree::UserAddress" do
         def find_first_by_address_values(address_attrs)
           detect { |ua| ua.address == Spree::Address.new(address_attrs) }
         end


### PR DESCRIPTION
**Description**

Instead of double-splatting a hash use attributes directly