### PR TITLE
Replace --auto-accept with --interactive

### DIFF
--- a/bin/rails-application-template
+++ b/bin/rails-application-template
@@ -119,7 +119,7 @@ RUBY
 after_bundle do
   generate(
     "solidus:install",
-    "--auto-accept",
+    "--no-interactive",
     "--user_class=Spree::User",
     "--enforce_available_locales=true",
     "--with-authentication=false",

--- a/bin/sandbox
+++ b/bin/sandbox
@@ -62,7 +62,7 @@ RUBY
 unbundled bundle install --gemfile Gemfile
 unbundled bin/rails db:drop db:create
 unbundled bin/rails generate solidus:install \
-  --auto-accept \
+  --no-interactive \
   --user_class=Spree::User \
   --enforce_available_locales=true \
   --with_authentication=false \

--- a/core/lib/generators/solidus/install/install_generator.rb
+++ b/core/lib/generators/solidus/install/install_generator.rb
@@ -19,7 +19,6 @@ module Solidus
     class_option :user_class, type: :string
     class_option :admin_email, type: :string
     class_option :admin_password, type: :string
-    class_option :lib_name, type: :string, default: 'spree'
     class_option :with_authentication, type: :boolean, default: true
     class_option :enforce_available_locales, type: :boolean, default: nil
     class_option :payment_method,
@@ -30,6 +29,7 @@ module Solidus
 
     # @deprecated
     class_option :auto_accept, type: :boolean, hide: true
+    class_option :lib_name, type: :string, hide: true
 
     def self.source_paths
       paths = superclass.source_paths
@@ -48,6 +48,10 @@ module Solidus
 
       # We need to make options mutable so they can be filled in interactively.
       self.options = options.dup if interactive?
+
+      if options[:lib_name]
+        warn "DEPRECATION: using --lib-name is deprecated, it wasn't doing anything and will be removed in a future version."
+      end
 
       @run_migrations = options[:migrate]
       @load_seed_data = options[:seed]
@@ -79,8 +83,6 @@ module Solidus
     end
 
     def setup_assets
-      @lib_name = 'spree'
-
       empty_directory 'app/assets/images'
 
       %w{javascripts stylesheets images}.each do |path|

--- a/core/lib/generators/solidus/install/install_generator.rb
+++ b/core/lib/generators/solidus/install/install_generator.rb
@@ -17,9 +17,9 @@ module Solidus
     class_option :sample, type: :boolean, default: true, desc: 'Load sample data (migrations must be run)'
     class_option :interactive, type: :boolean, default: true, desc: 'Ask the user interactively how to install Solidus'
     class_option :user_class, type: :string, desc: 'Specify a custom user class', default: "Spree::LegacyUser"
-    class_option :admin_email, type: :string
-    class_option :admin_password, type: :string
-    class_option :with_authentication, type: :boolean, default: true
+    class_option :admin_email, type: :string, desc: 'Sprecify an email for the default admin user', default: 'admin@example.com'
+    class_option :admin_password, type: :string, desc: 'Sprecify a password for the default admin user', default: 'test123'
+    class_option :with_authentication, type: :boolean, default: true, desc: 'Will setup user authentication with devise, changes the user-class to "Spree::User"'
     class_option :enforce_available_locales, type: :boolean, default: nil
     class_option :payment_method,
                  type: :string,

--- a/core/lib/generators/solidus/install/install_generator.rb
+++ b/core/lib/generators/solidus/install/install_generator.rb
@@ -66,7 +66,7 @@ module Solidus
     def additional_tweaks
       return unless File.exist? 'public/robots.txt'
 
-      append_file "public/robots.txt", <<-ROBOTS.strip_heredoc
+      append_file "public/robots.txt", <<~ROBOTS
         User-agent: *
         Disallow: /checkout
         Disallow: /cart
@@ -104,21 +104,21 @@ module Solidus
     end
 
     def configure_application
-      application <<-RUBY
-    # Load application's model / class decorators
-    initializer 'spree.decorators' do |app|
-      config.to_prepare do
-        Dir.glob(Rails.root.join('app/**/*_decorator*.rb')) do |path|
-          require_dependency(path)
+      application <<~RUBY
+        # Load application's model / class decorators
+        initializer 'spree.decorators' do |app|
+          config.to_prepare do
+            Dir.glob(Rails.root.join('app/**/*_decorator*.rb')) do |path|
+              require_dependency(path)
+            end
+          end
         end
-      end
-    end
       RUBY
 
       if !options[:enforce_available_locales].nil?
-        application <<-RUBY
-    # Prevent this deprecation message: https://github.com/svenfuchs/i18n/commit/3b6e56e
-    I18n.enforce_available_locales = #{options[:enforce_available_locales]}
+        application <<~RUBY
+          # Prevent this deprecation message: https://github.com/svenfuchs/i18n/commit/3b6e56e
+          I18n.enforce_available_locales = #{options[:enforce_available_locales]}
         RUBY
       end
     end
@@ -154,7 +154,7 @@ module Solidus
     end
 
     def include_seed_data
-      append_file "db/seeds.rb", <<-RUBY.strip_heredoc
+      append_file "db/seeds.rb", <<~RUBY
 
         Spree::Core::Engine.load_seed if defined?(Spree::Core)
         Spree::Auth::Engine.load_seed if defined?(Spree::Auth)
@@ -209,12 +209,12 @@ module Solidus
       unless File.read(routes_file_path).include? CORE_MOUNT_ROUTE
         insert_into_file routes_file_path, after: "Rails.application.routes.draw do\n" do
           <<-RUBY
-  # This line mounts Solidus's routes at the root of your application.
-  # This means, any requests to URLs such as /products, will go to Spree::ProductsController.
-  # If you would like to change where this engine is mounted, simply change the :at option to something different.
-  #
-  # We ask that you don't use the :as option here, as Solidus relies on it being the default of "spree"
-  #{CORE_MOUNT_ROUTE}, at: '/'
+            # This line mounts Solidus's routes at the root of your application.
+            # This means, any requests to URLs such as /products, will go to Spree::ProductsController.
+            # If you would like to change where this engine is mounted, simply change the :at option to something different.
+            #
+            # We ask that you don't use the :as option here, as Solidus relies on it being the default of "spree"
+            #{CORE_MOUNT_ROUTE}, at: '/'
 
           RUBY
         end

--- a/core/lib/generators/solidus/install/install_generator.rb
+++ b/core/lib/generators/solidus/install/install_generator.rb
@@ -125,7 +125,7 @@ module Solidus
       end
     end
 
-    def install_default_plugins
+    def install_auth
       if interactive?
         question = <<~QUESTION
           Solidus has a default authentication extension that uses Devise.

--- a/core/lib/generators/solidus/install/install_generator.rb
+++ b/core/lib/generators/solidus/install/install_generator.rb
@@ -16,7 +16,7 @@ module Solidus
     class_option :seed, type: :boolean, default: true, desc: 'Load seed data (migrations must be run)'
     class_option :sample, type: :boolean, default: true, desc: 'Load sample data (migrations must be run)'
     class_option :interactive, type: :boolean, default: true, desc: 'Ask the user interactively how to install Solidus'
-    class_option :user_class, type: :string
+    class_option :user_class, type: :string, desc: 'Specify a custom user class', default: "Spree::LegacyUser"
     class_option :admin_email, type: :string
     class_option :admin_password, type: :string
     class_option :with_authentication, type: :boolean, default: true
@@ -137,7 +137,10 @@ module Solidus
 
       options[:with_authentication] = !no?(question)
 
-      gem 'solidus_auth_devise' if options[:with_authentication]
+      if options[:with_authentication]
+        options[:user_class] = "Spree::User"
+        gem 'solidus_auth_devise'
+      end
     end
 
     def install_payment_method

--- a/core/lib/generators/solidus/install/install_generator.rb
+++ b/core/lib/generators/solidus/install/install_generator.rb
@@ -12,6 +12,8 @@ module Solidus
       'none' => nil,
     }
 
+    desc "Description:\n  Install Solidus on the current app."
+
     class_option :migrate, type: :boolean, default: true, desc: 'Run Solidus migrations'
     class_option :seed, type: :boolean, default: true, desc: 'Load seed data (migrations must be run)'
     class_option :sample, type: :boolean, default: true, desc: 'Load sample data (migrations must be run)'

--- a/core/lib/generators/solidus/install/install_generator.rb
+++ b/core/lib/generators/solidus/install/install_generator.rb
@@ -58,8 +58,8 @@ module Solidus
       @load_sample_data = options[:sample]
 
       unless @run_migrations
-         @load_seed_data = false
-         @load_sample_data = false
+        @load_seed_data = false
+        @load_sample_data = false
       end
     end
 

--- a/core/lib/generators/solidus/install/install_generator.rb
+++ b/core/lib/generators/solidus/install/install_generator.rb
@@ -12,9 +12,9 @@ module Solidus
       'none' => nil,
     }
 
-    class_option :migrate, type: :boolean, default: true, banner: 'Run Solidus migrations'
-    class_option :seed, type: :boolean, default: true, banner: 'Load seed data (migrations must be run)'
-    class_option :sample, type: :boolean, default: true, banner: 'Load sample data (migrations must be run)'
+    class_option :migrate, type: :boolean, default: true, desc: 'Run Solidus migrations'
+    class_option :seed, type: :boolean, default: true, desc: 'Load seed data (migrations must be run)'
+    class_option :sample, type: :boolean, default: true, desc: 'Load sample data (migrations must be run)'
     class_option :interactive, type: :boolean, default: true, desc: 'Ask the user interactively how to install Solidus'
     class_option :user_class, type: :string
     class_option :admin_email, type: :string

--- a/core/lib/generators/solidus/install/templates/config/initializers/spree.rb.tt
+++ b/core/lib/generators/solidus/install/templates/config/initializers/spree.rb.tt
@@ -112,7 +112,7 @@ Spree::Api::Config.configure do |config|
 end
 <% end -%>
 
-Spree.user_class = <%= (options[:user_class].blank? ? "Spree::LegacyUser" : options[:user_class]).inspect %>
+Spree.user_class = <%= options.fetch(:user_class).inspect %>
 
 # Rules for avoiding to store the current path into session for redirects
 # When at least one rule is matched, the request path will not be stored

--- a/core/lib/spree/testing_support/common_rake.rb
+++ b/core/lib/spree/testing_support/common_rake.rb
@@ -14,7 +14,7 @@ namespace :common do
     ENV["RAILS_ENV"] = 'test'
 
     Spree::DummyGenerator.start ["--lib_name=#{ENV['LIB_NAME']}", "--quiet"]
-    Solidus::InstallGenerator.start ["--lib_name=#{ENV['LIB_NAME']}", "--auto-accept", "--with-authentication=false", "--migrate=false", "--seed=false", "--sample=false", "--quiet", "--user_class=#{args[:user_class]}"]
+    Solidus::InstallGenerator.start ["--lib_name=#{ENV['LIB_NAME']}", "--no-interactive", "--with-authentication=false", "--migrate=false", "--seed=false", "--sample=false", "--quiet", "--user_class=#{args[:user_class]}"]
 
     puts "Setting up dummy database..."
 


### PR DESCRIPTION
**Description**

The current solidus install generator will ask for a number of things unless `--auto-accept` is provided. Since many of the things asked are not simple yes/no questions, and by default Rails doesn't require any interaction when generating a new app, we should move to an opt-in `--interactive` flag.

The current PR only switches to the new CLI option and cleans up the generator to make it more maintainable by solidus core and usable by end-users.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
