### PR TITLE
Fix Ruby 2.7 warnings on backend

### DIFF
--- a/backend/spec/lib/spree/backend_configuration/menu_item_spec.rb
+++ b/backend/spec/lib/spree/backend_configuration/menu_item_spec.rb
@@ -5,9 +5,7 @@ require 'spec_helper'
 RSpec.describe Spree::BackendConfiguration::MenuItem do
   describe '#match_path' do
     subject do
-      described_class.new([], nil, {
-        match_path: '/stock_items'
-      }).match_path
+      described_class.new([], nil, match_path: '/stock_items').match_path
     end
 
     it 'can be read' do


### PR DESCRIPTION
**Description**

Fix Ruby 2.7 warnings removing not needed hash on the backend.
This is the continuation of the work started by #3737 

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
