### PR TITLE
Use CircleCI contexts in jobs that require secrets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,6 +150,7 @@ workflows:
       - mysql_rails52
       - postgres_rails_master_activestorage
       - stoplight/push:
+          context: "Solidus Core Team"
           project: solidus/solidus-api
           git_token: $STOPLIGHT_GIT_TOKEN
           source_dir: api/openapi
@@ -158,6 +159,7 @@ workflows:
           requires:
             - persist_version
       - stoplight/publish:
+          context: "Solidus Core Team"
           api_token: $STOPLIGHT_API_TOKEN
           domain: solidus.docs.stoplight.io
           requires:


### PR DESCRIPTION
**Description**

This is a way to tell CircleCI to provide secrets defined in the Solidus Core Team context only to users that are part of that group (on GitHub) when a build is triggered.

We only perform these Stoplight jobs in the master branch and only the core team has the permissions to push to master.

Refs:
- https://nathandavison.com/blog/shaking-secrets-out-of-circleci-builds
- https://circleci.com/docs/2.0/contexts/

Thanks to @ndavison for reporting this issue via official channels. 

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
~- [ ] I have updated Guides and README accordingly to this change (if needed)~
~- [ ] I have added tests to cover this change (if needed)~
~- [ ] I have attached screenshots to this PR for visual changes (if needed)~
