### PR TITLE
Revert "Add payment method selection to the install generator"

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,7 @@ require 'bundler'
 task default: :spec
 
 def print_title(gem_name = '')
-  title = ["Solidus", gem_name].join(' ').strip
+  title = ["Solidus", gem_name].join(' ')
   puts "\n#{'-' * title.size}\n#{title}\n#{'-' * title.size}"
 end
 

--- a/core/lib/generators/solidus/install/install_generator.rb
+++ b/core/lib/generators/solidus/install/install_generator.rb
@@ -7,14 +7,9 @@ module Solidus
   class InstallGenerator < Rails::Generators::Base
     CORE_MOUNT_ROUTE = "mount Spree::Core::Engine"
 
-    PAYMENT_METHODS = {
-      'paypal' => 'solidus_paypal_commerce_platform',
-      'none' => nil,
-    }
-
     class_option :migrate, type: :boolean, default: true, banner: 'Run Solidus migrations'
-    class_option :seed, type: :boolean, default: true, banner: 'Load seed data (migrations must be run)'
-    class_option :sample, type: :boolean, default: true, banner: 'Load sample data (migrations must be run)'
+    class_option :seed, type: :boolean, default: true, banner: 'load seed data (migrations must be run)'
+    class_option :sample, type: :boolean, default: true, banner: 'load sample data (migrations must be run)'
     class_option :auto_accept, type: :boolean
     class_option :user_class, type: :string
     class_option :admin_email, type: :string
@@ -22,11 +17,6 @@ module Solidus
     class_option :lib_name, type: :string, default: 'spree'
     class_option :with_authentication, type: :boolean, default: true
     class_option :enforce_available_locales, type: :boolean, default: nil
-    class_option :payment_method,
-                 type: :string,
-                 enum: PAYMENT_METHODS.keys,
-                 default: PAYMENT_METHODS.keys.first,
-                 desc: "Indicates which payment method to install."
 
     def self.source_paths
       paths = superclass.source_paths
@@ -112,30 +102,14 @@ module Solidus
     end
 
     def install_default_plugins
-      if options[:with_authentication] && (options[:auto_accept] || !no?("
+      if options[:with_authentication] && (options[:auto_accept] || yes?("
   Solidus has a default authentication extension that uses Devise.
-  You can find more info at https://github.com/solidusio/solidus_auth_devise.
+  You can find more info at github.com/solidusio/solidus_auth_devise.
 
   Would you like to install it? (y/n)"))
 
         gem 'solidus_auth_devise'
       end
-    end
-
-    def install_payment_method
-      name = options[:payment_method]
-
-      unless options[:auto_accept]
-        available_names = PAYMENT_METHODS.keys
-
-        name = ask("
-  You can select a payment method to be included in the installation process.
-  Please select a payment method name:", limited_to: available_names, default: available_names.first)
-      end
-
-      gem_name = PAYMENT_METHODS.fetch(name)
-
-      gem gem_name if gem_name
     end
 
     def include_seed_data


### PR DESCRIPTION
**Description**

Apparently introducing the payment is causing issues on the dummy app generation within extensions.
We need to revert the PR and reintroduce it when the issue is solved.

See, as an example, https://app.circleci.com/pipelines/github/solidusio-contrib/solidus_static_content/170/workflows/b770419d-d80e-4048-8820-b0f404896fd4/jobs/402.