### PR TITLE
Do not consider promotions without actions as active

### DIFF
--- a/backend/spec/controllers/spree/admin/promotions_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/promotions_controller_spec.rb
@@ -5,9 +5,11 @@ require 'spec_helper'
 describe Spree::Admin::PromotionsController, type: :controller do
   stub_authorization!
 
-  let!(:promotion1) { create(:promotion, name: "name1", code: "code1", path: "path1") }
-  let!(:promotion2) { create(:promotion, name: "name2", code: "code2", path: "path2") }
-  let!(:promotion3) { create(:promotion, name: "name2", code: "code3", path: "path3", expires_at: Date.yesterday) }
+  let!(:promotion1) { create(:promotion, :with_action, name: "name1", code: "code1", path: "path1") }
+  let!(:promotion2) { create(:promotion, :with_action, name: "name2", code: "code2", path: "path2") }
+  let!(:promotion3) do
+    create(:promotion, :with_action, name: "name2", code: "code3", path: "path3", expires_at: Date.yesterday)
+  end
   let!(:category) { create :promotion_category }
 
   describe "#show" do

--- a/backend/spec/features/admin/promotions/promotion_spec.rb
+++ b/backend/spec/features/admin/promotions/promotion_spec.rb
@@ -14,7 +14,7 @@ feature 'Promotions' do
     end
 
     context 'when promotion is active' do
-      given!(:promotion) { create :promotion }
+      given!(:promotion) { create :promotion, :with_action }
 
       scenario 'promotion status is active' do
         visit spree.admin_promotions_path

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -48,9 +48,9 @@ module Spree
     scope :started_and_unexpired, -> do
       table = arel_table
       time = Time.current
-      joins(:promotion_actions).
-          where(table[:starts_at].eq(nil).or(table[:starts_at].lt(time))).
-          where(table[:expires_at].eq(nil).or(table[:expires_at].gt(time)))
+
+      where(table[:starts_at].eq(nil).or(table[:starts_at].lt(time))).
+        where(table[:expires_at].eq(nil).or(table[:expires_at].gt(time)))
     end
     scope :has_actions, -> do
       joins(:promotion_actions)

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -39,10 +39,10 @@ module Spree
     scope :coupons, -> { joins(:codes).distinct }
     scope :advertised, -> { where(advertise: true) }
     scope :active, -> do
-      if Spree::Config.actionless_promotion_inactive
-        has_actions.started_and_unexpired
-      else
+      if Spree::Config.consider_actionless_promotion_active
         started_and_unexpired
+      else
+        has_actions.started_and_unexpired
       end
     end
     scope :started_and_unexpired, -> do
@@ -95,7 +95,7 @@ module Spree
     end
 
     def active?
-      started? && not_expired? && (Spree::Config.actionless_promotion_inactive ? actions.present? : true)
+      started? && not_expired? && (Spree::Config.consider_actionless_promotion_active || actions.present?)
     end
 
     def inactive?

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -39,11 +39,9 @@ module Spree
     scope :coupons, -> { joins(:codes).distinct }
     scope :advertised, -> { where(advertise: true) }
     scope :active, -> do
-      if Spree::Config.consider_actionless_promotion_active
-        started_and_unexpired
-      else
-        has_actions.started_and_unexpired
-      end
+      return started_and_unexpired if Spree::Config.consider_actionless_promotion_active == true
+
+      has_actions.started_and_unexpired
     end
     scope :started_and_unexpired, -> do
       table = arel_table

--- a/core/app/models/spree/promotion_handler/coupon.rb
+++ b/core/app/models/spree/promotion_handler/coupon.rb
@@ -13,9 +13,9 @@ module Spree
 
       def apply
         if coupon_code.present?
-          if promotion.present? && promotion.actions.exists?
+          if promotion.present? && promotion.active? && promotion.actions.exists?
             handle_present_promotion(promotion)
-          elsif promotion_code && promotion_code.promotion.inactive?
+          elsif promotion_code&.promotion&.expired?
             set_error_code :coupon_code_expired
           else
             set_error_code :coupon_code_not_found

--- a/core/lib/generators/solidus/install/templates/config/initializers/spree.rb.tt
+++ b/core/lib/generators/solidus/install/templates/config/initializers/spree.rb.tt
@@ -45,10 +45,10 @@ Spree.config do |config|
   # their previous location first.
   config.redirect_back_on_unauthorized = true
 
-  # Set this configuration to `false` to allow promotions
-  # with no associated actions to be active for use by customers.
-  # See https://github.com/solidusio/solidus/issues/2777 for more info.
-  config.actionless_promotion_inactive = true
+  # Set this configuration to `true` to allow promotions
+  # with no associated actions to be considered active for use by customers.
+  # See https://github.com/solidusio/solidus/pull/3749 for more info.
+  config.consider_actionless_promotion_active = false
 
   # Set this configuration to `false` to avoid running validations when
   # updating an order. Be careful since you can end up having inconsistent

--- a/core/lib/generators/solidus/install/templates/config/initializers/spree.rb.tt
+++ b/core/lib/generators/solidus/install/templates/config/initializers/spree.rb.tt
@@ -45,6 +45,11 @@ Spree.config do |config|
   # their previous location first.
   config.redirect_back_on_unauthorized = true
 
+  # Set this configuration to `false` to allow promotions
+  # with no associated actions to be active for use by customers.
+  # See https://github.com/solidusio/solidus/issues/2777 for more info.
+  config.actionless_promotion_inactive = true
+
   # Set this configuration to `false` to avoid running validations when
   # updating an order. Be careful since you can end up having inconsistent
   # data in your database turning it on.

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -217,6 +217,10 @@ module Spree
     #   @return [Integer] Promotions to show per-page in the admin (default: +15+)
     preference :promotions_per_page, :integer, default: 15
 
+    # @!attribute [rw] disable_actionless_promotion_validation
+    #   @return [Boolean] Promotions should have actions associated before activation (default: +true+)
+    preference :actionless_promotion_inactive, :boolean, default: false
+
     # @!attribute [rw] raise_with_invalid_currency
     #   Whether to raise an exception if trying to set a line item currency
     #   different from the order currency. When false a validation error

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -218,8 +218,8 @@ module Spree
     preference :promotions_per_page, :integer, default: 15
 
     # @!attribute [rw] disable_actionless_promotion_validation
-    #   @return [Boolean] Promotions should have actions associated before activation (default: +true+)
-    preference :actionless_promotion_inactive, :boolean, default: false
+    #   @return [Boolean] Promotions should have actions associated before being considered active (default: +true+)
+    preference :consider_actionless_promotion_active, :boolean, default: true
 
     # @!attribute [rw] raise_with_invalid_currency
     #   Whether to raise an exception if trying to set a line item currency

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -65,7 +65,7 @@ module Spree
             caller
           )
         end
-        if Spree::Config.consider_actionless_promotion_active != true
+        if Spree::Config.consider_actionless_promotion_active == true
           Spree::Deprecation.warn(
             'Spree::Config.consider_actionless_promotion_active set to true is ' \
             'deprecated. Please note that by switching this value, ' \

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -65,11 +65,11 @@ module Spree
             caller
           )
         end
-        if Spree::Config.actionless_promotion_inactive == true
+        if Spree::Config.consider_actionless_promotion_active != true
           Spree::Deprecation.warn(
-            'Spree::Config.actionless_promotion_inactive set to false is ' \
+            'Spree::Config.consider_actionless_promotion_active set to true is ' \
             'deprecated. Please note that by switching this value, ' \
-            'promotions with no actions will be active.',
+            'promotions with no actions will be considered active.',
             caller
           )
         end

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -65,7 +65,14 @@ module Spree
             caller
           )
         end
-
+        if Spree::Config.actionless_promotion_inactive == true
+          Spree::Deprecation.warn(
+            'Spree::Config.actionless_promotion_inactive set to false is ' \
+            'deprecated. Please note that by switching this value, ' \
+            'promotions with no actions will be active.',
+            caller
+          )
+        end
         if Spree::Config.run_order_validations_on_order_updater != true
           Spree::Deprecation.warn(
             'Spree::Config.run_order_validations_on_order_updater set to false is ' \

--- a/core/lib/spree/testing_support/dummy_app.rb
+++ b/core/lib/spree/testing_support/dummy_app.rb
@@ -121,6 +121,7 @@ Spree.config do |config|
   config.use_combined_first_and_last_name_in_address = true
   config.use_legacy_order_state_machine = false
   config.use_custom_cancancan_actions = false
+  config.consider_actionless_promotion_active = false
 
   if ENV['ENABLE_ACTIVE_STORAGE']
     config.image_attachment_module = 'Spree::Image::ActiveStorageAttachment'

--- a/core/lib/spree/testing_support/factories/promotion_factory.rb
+++ b/core/lib/spree/testing_support/factories/promotion_factory.rb
@@ -16,6 +16,12 @@ FactoryBot.define do
       end
     end
 
+    trait :with_action do
+      after(:create) do |promotion, _evaluator|
+        promotion.actions << Spree::Promotion::Actions::CreateAdjustment.new
+      end
+    end
+
     trait :with_line_item_adjustment do
       transient do
         adjustment_rate { 10 }

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -461,17 +461,12 @@ RSpec.describe Spree::Product, type: :model do
 
     # Regression test for https://github.com/spree/spree/issues/4416
     context "#possible_promotions" do
-      let!(:promotion) do
-        create(:promotion, advertise: true, starts_at: 1.day.ago)
-      end
+      let!(:promotion) { create(:promotion, :with_action, advertise: true, starts_at: 1.day.ago) }
       let!(:rule) do
         Spree::Promotion::Rules::Product.create(
           promotion: promotion,
           products: [product]
         )
-      end
-      before do
-        promotion.actions << Spree::Promotion::Actions::CreateAdjustment.new
       end
 
       it "lists the promotion as a possible promotion" do

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -470,6 +470,9 @@ RSpec.describe Spree::Product, type: :model do
           products: [product]
         )
       end
+      before do
+        promotion.actions << Spree::Promotion::Actions::CreateAdjustment.new
+      end
 
       it "lists the promotion as a possible promotion" do
         expect(product.possible_promotions).to include(promotion)

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -347,6 +347,10 @@ RSpec.describe Spree::Promotion, type: :model do
   end
 
   context "#inactive" do
+    before do
+      promotion.actions << Spree::Promotion::Actions::CreateAdjustment.new
+    end
+
     it "should not be exipired" do
       expect(promotion).not_to be_inactive
     end


### PR DESCRIPTION
This PR is based on https://github.com/solidusio/solidus/pull/3596.

From original PR:

This is a proposed solution to #2777 where action-less promotions were considered active. As opposed to my original thought of implementing validation, given that there is no state toggle on the promotion that it would make sense to embrace the inferred state. So this implementation just causes a promotion to be considered inactive until it has actions, in addition to the other required material. Otherwise it is considered inactive.

In the process I found the coupon promotion handler already treated action-less coupons as inactive, so I updated it to continue this behavior.

---

I have only added the spec and refactored it.

Thank you @wildbillcat  

**Checklist:**
- [X] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [X] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [X] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
