### PR TITLE
Set payment method to none

### DIFF
--- a/bin/sandbox
+++ b/bin/sandbox
@@ -66,6 +66,7 @@ unbundled bin/rails generate solidus:install \
   --user_class=Spree::User \
   --enforce_available_locales=true \
   --with_authentication=false \
+  --payment-method=none
   $@
 
 unbundled bin/rails generate solidus:auth:install

--- a/core/lib/spree/testing_support/common_rake.rb
+++ b/core/lib/spree/testing_support/common_rake.rb
@@ -14,7 +14,7 @@ namespace :common do
     ENV["RAILS_ENV"] = 'test'
 
     Spree::DummyGenerator.start ["--lib_name=#{ENV['LIB_NAME']}", "--quiet"]
-    Solidus::InstallGenerator.start ["--lib_name=#{ENV['LIB_NAME']}", "--auto-accept", "--with-authentication=false", "--migrate=false", "--seed=false", "--sample=false", "--quiet", "--user_class=#{args[:user_class]}"]
+    Solidus::InstallGenerator.start ["--lib_name=#{ENV['LIB_NAME']}", "--auto-accept", "--with-authentication=false", "--payment-method=none", "--migrate=false", "--seed=false", "--sample=false", "--quiet", "--user_class=#{args[:user_class]}"]
 
     puts "Setting up dummy database..."
 


### PR DESCRIPTION
**Description**
By default Solidus is now looking for `solidus_paypal_commerce_platform`,
however, with the sandbox and the dummy generator we need to set this
to `none`, otherwise these scripts are not running successfully.

This commit fixes that. It does not update the application template for Heroku
though. That will be a seperate PR.

Ref #3750 #3748 #3744 

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
