### PR TITLE
Explicit deprecation warning mocks

### DIFF
--- a/api/spec/requests/spree/api/checkouts_controller_spec.rb
+++ b/api/spec/requests/spree/api/checkouts_controller_spec.rb
@@ -307,10 +307,13 @@ module Spree
             }
           end
 
+          before do
+            expect(Spree::Deprecation).to receive(:warn).
+              with(/^Passing existing_card_id to PaymentCreate is deprecated/, any_args)
+          end
+
           it 'succeeds' do
-            Spree::Deprecation.silence do
-              put spree.api_checkout_path(order), params: params
-            end
+            put spree.api_checkout_path(order), params: params
 
             expect(response.status).to eq 200
             expect(order.credit_cards).to match_array [credit_card]

--- a/core/spec/lib/spree/core/controller_helpers/order_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/order_spec.rb
@@ -21,27 +21,22 @@ RSpec.describe Spree::Core::ControllerHelpers::Order, type: :controller do
   end
 
   describe '#simple_current_order' do
+    before do
+      expect(Spree::Deprecation).to receive(:warn).
+        with(/^simple_current_order is deprecated and will be removed/, any_args)
+    end
+
     it "returns an empty order" do
-      Spree::Deprecation.silence do
-        expect(controller.simple_current_order.item_count).to eq 0
-      end
+      expect(controller.simple_current_order.item_count).to eq 0
     end
+
     it 'returns Spree::Order instance' do
-      Spree::Deprecation.silence do
-        allow(controller).to receive_messages(cookies: double(signed: { guest_token: order.guest_token }))
-        expect(controller.simple_current_order).to eq order
-      end
+      allow(controller).to receive_messages(cookies: double(signed: { guest_token: order.guest_token }))
+      expect(controller.simple_current_order).to eq order
     end
+
     it 'assigns the current_store id' do
-      Spree::Deprecation.silence do
-        expect(controller.simple_current_order.store_id).to eq store.id
-      end
-    end
-    it 'is deprecated' do
-      Spree::Deprecation.silence do
-        expect(Spree::Deprecation).to(receive(:warn))
-        controller.simple_current_order
-      end
+      expect(controller.simple_current_order.store_id).to eq store.id
     end
   end
 

--- a/core/spec/lib/spree/core/controller_helpers/pricing_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/pricing_spec.rb
@@ -13,23 +13,28 @@ RSpec.describe Spree::Core::ControllerHelpers::Pricing, type: :controller do
   end
 
   describe '#current_currency' do
+    before do
+      expect(Spree::Deprecation).to receive(:warn).
+        with(/^current_currency is deprecated and will be removed/, any_args)
+    end
+
     subject { controller.current_currency }
 
     context "when store default_currency is nil" do
       let(:store) { nil }
-      it { Spree::Deprecation.silence { is_expected.to eq('USD') } }
+      it { is_expected.to eq('USD') }
     end
 
     context "when the current store default_currency empty" do
       let(:store) { FactoryBot.create :store, default_currency: '' }
 
-      it { Spree::Deprecation.silence { is_expected.to eq('USD') } }
+      it { is_expected.to eq('USD') }
     end
 
     context "when the current store default_currency is a currency" do
       let(:store) { FactoryBot.create :store, default_currency: 'EUR' }
 
-      it { Spree::Deprecation.silence { is_expected.to eq('EUR') } }
+      it { is_expected.to eq('EUR') }
     end
   end
 

--- a/core/spec/lib/spree/core/controller_helpers/strong_parameters_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/strong_parameters_spec.rb
@@ -21,14 +21,9 @@ RSpec.describe Spree::Core::ControllerHelpers::StrongParameters, type: :controll
 
   describe '#permitted_checkout_attributes' do
     it 'returns Array class' do
-      Spree::Deprecation.silence do
-        expect(controller.permitted_checkout_attributes.class).to eq Spree::CheckoutAdditionalAttributes
-      end
-    end
-
-    it 'is deprecated' do
-      expect(Spree::Deprecation).to receive(:warn)
-      controller.permitted_checkout_attributes
+      expect(Spree::Deprecation).to receive(:warn).
+        with(/^checkout_attributes is deprecated/, any_args)
+      expect(controller.permitted_checkout_attributes.class).to eq Spree::CheckoutAdditionalAttributes
     end
   end
 

--- a/core/spec/lib/spree/core/current_store_spec.rb
+++ b/core/spec/lib/spree/core/current_store_spec.rb
@@ -4,7 +4,12 @@ require 'rails_helper'
 
 RSpec.describe Spree::Core::CurrentStore do
   describe "#store" do
-    subject { Spree::Deprecation.silence { Spree::Core::CurrentStore.new(request).store } }
+    before do
+      expect(Spree::Deprecation).to receive(:warn).
+        with(/^Using Spree::Core::CurrentStore is deprecated/, any_args)
+    end
+
+    subject { Spree::Core::CurrentStore.new(request).store }
 
     context "with a default" do
       let(:request) { double(headers: {}, env: {}) }
@@ -23,11 +28,6 @@ RSpec.describe Spree::Core::CurrentStore do
           expect(subject).to eq(store_2)
         end
       end
-    end
-
-    it 'is deprecated' do
-      expect(Spree::Deprecation).to(receive(:warn))
-      Spree::Core::CurrentStore.new(double)
     end
   end
 end

--- a/core/spec/lib/spree/core/role_configuration_spec.rb
+++ b/core/spec/lib/spree/core/role_configuration_spec.rb
@@ -13,11 +13,14 @@ RSpec.describe Spree::RoleConfiguration do
   let(:instance) { Spree::RoleConfiguration.new }
 
   describe ".configure" do
-    around(:each) do |example|
-      Spree::Deprecation.silence { example.run }
+    before do
+      expect(Spree::Deprecation).to receive(:warn).
+        with(/^Spree::RoleConfiguration\.configure is deprecated/i, any_args)
     end
 
     it "yields with the instance" do
+      expect(Spree::Deprecation).to receive(:warn).
+        with(/^Spree::RoleConfiguration\.instance is deprecated/i, any_args)
       expect { |b| described_class.configure(&b) }.to yield_with_args(described_class.instance)
     end
 

--- a/core/spec/lib/spree/core/testing_support/preferences_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/preferences_spec.rb
@@ -6,13 +6,14 @@ RSpec.describe Spree::TestingSupport::Preferences do
   describe 'resetting the app configuration' do
     around do |example|
       with_unfrozen_spree_preference_store do
-        Spree::Deprecation.silence do
-          example.run
-        end
+        example.run
       end
     end
 
     before do
+      expect(Spree::Deprecation).to receive(:warn).
+        with(/^reset_spree_preferences is deprecated and will be removed/, any_args).
+        at_least(:once)
       reset_spree_preferences
       @original_spree_mails_from = Spree::Config.mails_from
       @original_spree_searcher_class = Spree::Config.searcher_class

--- a/core/spec/lib/spree/money_spec.rb
+++ b/core/spec/lib/spree/money_spec.rb
@@ -9,9 +9,7 @@ RSpec.describe Spree::Money do
 
   describe '#initialize' do
     subject do
-      Spree::Deprecation.silence do
-        described_class.new(amount, currency: currency, with_currency: true).to_s
-      end
+      described_class.new(amount, currency: currency, with_currency: true).to_s
     end
 
     context 'with no currency' do
@@ -39,30 +37,37 @@ RSpec.describe Spree::Money do
         it { should == "$10.00 USD" }
       end
 
-      context "with symbol" do
-        let(:amount){ '$10.00' }
-        it { should == "$10.00 USD" }
-      end
+      context 'with deprecated amount format' do
+        before do
+          expect(Spree::Deprecation).to receive(:warn).
+            with(/^Spree::Money was initialized with ".*", which will not be supported in the future/, any_args)
+        end
 
-      context "with extra currency" do
-        let(:amount){ '$10.00 USD' }
-        it { should == "$10.00 USD" }
-      end
+        context "with symbol" do
+          let(:amount){ '$10.00' }
+          it { should == "$10.00 USD" }
+        end
 
-      context "with different currency" do
-        let(:currency){ 'USD' }
-        let(:amount){ '$10.00 CAD' }
-        it { should == "$10.00 CAD" }
-      end
+        context "with extra currency" do
+          let(:amount){ '$10.00 USD' }
+          it { should == "$10.00 USD" }
+        end
 
-      context "with commas" do
-        let(:amount){ '1,000.00' }
-        it { should == "$1,000.00 USD" }
-      end
+        context "with different currency" do
+          let(:currency){ 'USD' }
+          let(:amount){ '$10.00 CAD' }
+          it { should == "$10.00 CAD" }
+        end
 
-      context "with comma for decimal point" do
-        let(:amount){ '10,00' }
-        it { should == "$10.00 USD" }
+        context "with commas" do
+          let(:amount){ '1,000.00' }
+          it { should == "$1,000.00 USD" }
+        end
+
+        context "with comma for decimal point" do
+          let(:amount){ '10,00' }
+          it { should == "$10.00 USD" }
+        end
       end
 
       context 'with fixnum' do

--- a/core/spec/lib/tasks/migrations/migrate_shipping_rate_taxes_spec.rb
+++ b/core/spec/lib/tasks/migrations/migrate_shipping_rate_taxes_spec.rb
@@ -4,6 +4,11 @@ require 'rails_helper'
 
 RSpec.describe 'solidus:migrations:migrate_shipping_rate_taxes' do
   describe 'up' do
+    before do
+      expect(Spree::Deprecation).to receive(:warn).
+        with(/^rake spree:migrations:migrate_shipping_rate_taxes:up has been deprecated/, any_args)
+    end
+
     include_context(
       'rake',
       task_path: Spree::Core::Engine.root.join('lib/tasks/migrations/migrate_shipping_rate_taxes.rake'),
@@ -11,11 +16,9 @@ RSpec.describe 'solidus:migrations:migrate_shipping_rate_taxes' do
     )
 
     it 'runs' do
-      Spree::Deprecation.silence do
-        expect { task.invoke }.to output(
-          "Adding persisted tax notes to historic shipping rates ... Success.\n"
-        ).to_stdout
-      end
+      expect { task.invoke }.to output(
+        "Adding persisted tax notes to historic shipping rates ... Success.\n"
+      ).to_stdout
     end
   end
 end

--- a/core/spec/mailers/test_mailer_spec.rb
+++ b/core/spec/mailers/test_mailer_spec.rb
@@ -5,9 +5,15 @@ require 'rails_helper'
 RSpec.describe Spree::TestMailer, type: :mailer do
   let(:user) { create(:user) }
 
-  it "confirm_email accepts a user id as an alternative to a User object" do
-    Spree::Deprecation.silence do
-      Spree::TestMailer.test_email('test@example.com')
+  describe '#test_email' do
+    subject { described_class.test_email('test@example.com') }
+
+    it "is deprecated" do
+      expect(Spree::Deprecation).to receive(:warn).
+        with(/^Spree::TestMailer has been deprecated and will be removed/, any_args)
+
+      test_email = subject
+      expect(test_email.to).to eq(['test@example.com'])
     end
   end
 end

--- a/core/spec/models/spree/adjustment_spec.rb
+++ b/core/spec/models/spree/adjustment_spec.rb
@@ -235,6 +235,13 @@ RSpec.describe Spree::Adjustment, type: :model do
         )
       end
 
+      def doesnt_expect_deprecation_warning
+        expect(Spree::Deprecation).not_to receive(:warn).with(
+          /Adjustment \d+ was not added to #{adjustable.class} #{adjustable.id}/,
+          any_args
+        )
+      end
+
       context 'when adding adjustments via the wrong association' do
         def create_adjustment
           adjustment_source.adjustments.create!(
@@ -256,7 +263,7 @@ RSpec.describe Spree::Adjustment, type: :model do
 
           context 'when the adjustment is destroyed before after_commit runs' do
             it 'does not repair' do
-              expect(Spree::Deprecation).not_to receive(:warn)
+              doesnt_expect_deprecation_warning
               Spree::Adjustment.transaction do
                 adjustment = create_adjustment
                 adjustment.destroy!
@@ -267,7 +274,7 @@ RSpec.describe Spree::Adjustment, type: :model do
 
         context 'when adjustable.adjustments is not loaded' do
           it 'does repair' do
-            expect(Spree::Deprecation).not_to receive(:warn)
+            doesnt_expect_deprecation_warning
             create_adjustment
           end
         end
@@ -287,14 +294,14 @@ RSpec.describe Spree::Adjustment, type: :model do
           before { adjustable.adjustments.to_a }
 
           it 'does not repair' do
-            expect(Spree::Deprecation).not_to receive(:warn)
+            doesnt_expect_deprecation_warning
             create_adjustment
           end
         end
 
         context 'when adjustable.adjustments is not loaded' do
           it 'does not repair' do
-            expect(Spree::Deprecation).not_to receive(:warn)
+            doesnt_expect_deprecation_warning
             create_adjustment
           end
         end
@@ -315,6 +322,13 @@ RSpec.describe Spree::Adjustment, type: :model do
         )
       end
 
+      def doesnt_expect_deprecation_warning
+        expect(Spree::Deprecation).not_to receive(:warn).with(
+          /Adjustment #{adjustment.id} was not removed from #{adjustable.class} #{adjustable.id}/,
+          any_args
+        )
+      end
+
       context 'when destroying adjustments not via association' do
         context 'when adjustable.adjustments is loaded' do
           before { adjustable.adjustments.to_a }
@@ -328,7 +342,7 @@ RSpec.describe Spree::Adjustment, type: :model do
 
         context 'when adjustable.adjustments is not loaded' do
           it 'does not repair' do
-            expect(Spree::Deprecation).not_to receive(:warn)
+            doesnt_expect_deprecation_warning
             adjustment.destroy!
           end
         end
@@ -339,14 +353,14 @@ RSpec.describe Spree::Adjustment, type: :model do
           before { adjustable.adjustments.to_a }
 
           it 'does not repair' do
-            expect(Spree::Deprecation).not_to receive(:warn)
+            doesnt_expect_deprecation_warning
             adjustable.adjustments.destroy(adjustment)
           end
         end
 
         context 'when adjustable.adjustments is not loaded' do
           it 'does not repair' do
-            expect(Spree::Deprecation).not_to receive(:warn)
+            doesnt_expect_deprecation_warning
             adjustable.adjustments.destroy(adjustment)
           end
         end

--- a/core/spec/models/spree/calculator_spec.rb
+++ b/core/spec/models/spree/calculator_spec.rb
@@ -13,12 +13,15 @@ RSpec.describe Spree::Calculator, type: :model do
   end
 
   describe "#calculators" do
+    before do
+      expect(Spree::Deprecation).to receive(:warn).
+        with(/^Calling \.calculators is deprecated/, any_args)
+    end
+
     subject { Spree::Calculator.calculators }
 
     it 'returns the (deprecated) calculator step' do
-      Spree::Deprecation.silence do
-        expect(subject).to be_a Spree::Core::Environment::Calculators
-      end
+      expect(subject).to be_a Spree::Core::Environment::Calculators
     end
   end
 

--- a/core/spec/models/spree/country_spec.rb
+++ b/core/spec/models/spree/country_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe Spree::Country, type: :model do
     before do
       create(:country, iso: "DE", id: 1)
       create(:country, id: 2)
+      allow(Spree::Deprecation).to receive(:warn).
+        with(/^Setting your default country via its ID is deprecated/, any_args)
     end
 
     subject(:default_country) { described_class.default }
@@ -16,12 +18,9 @@ RSpec.describe Spree::Country, type: :model do
         stub_spree_preferences(default_country_id: 2)
       end
 
-      subject(:default_country) do
-        Spree::Deprecation.silence { described_class.default }
-      end
-
       it 'emits a deprecation warning' do
-        expect(Spree::Deprecation).to receive(:warn)
+        expect(Spree::Deprecation).to receive(:warn).
+          with(/^Setting your default country via its ID is deprecated/, any_args)
         default_country
       end
 
@@ -35,10 +34,6 @@ RSpec.describe Spree::Country, type: :model do
         stub_spree_preferences(default_country_id: 0)
       end
 
-      subject(:default_country) do
-        Spree::Deprecation.silence { described_class.default }
-      end
-
       it 'loads the country configured by the ISO code' do
         expect(default_country).to eq(Spree::Country.find(2))
       end
@@ -46,8 +41,8 @@ RSpec.describe Spree::Country, type: :model do
 
     context 'with the configuration setting an existing ISO code' do
       it 'is a country with the configurations ISO code' do
-        expect(described_class.default).to be_a(Spree::Country)
-        expect(described_class.default.iso).to eq('US')
+        expect(default_country).to be_a(Spree::Country)
+        expect(default_country.iso).to eq('US')
       end
     end
 
@@ -55,7 +50,7 @@ RSpec.describe Spree::Country, type: :model do
       before { stub_spree_preferences(default_country_iso: "ZZ") }
 
       it 'raises a Record not Found error' do
-        expect { described_class.default }.to raise_error(ActiveRecord::RecordNotFound)
+        expect { default_country }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
   end

--- a/core/spec/models/spree/credit_card_spec.rb
+++ b/core/spec/models/spree/credit_card_spec.rb
@@ -36,6 +36,8 @@ RSpec.describe Spree::CreditCard, type: :model do
       credit: @success_response)
 
     allow(@payment).to receive_messages payment_method: @payment_gateway
+    allow(Spree::Deprecation).to receive(:warn).
+      with(/^CreditCard#default=? is deprecated/, any_args)
   end
 
   describe "#valid?" do
@@ -276,10 +278,6 @@ RSpec.describe Spree::CreditCard, type: :model do
 
   # TODO: Remove these specs once default is removed
   describe 'default' do
-    def default_with_silence(card)
-      Spree::Deprecation.silence { card.default }
-    end
-
     context 'with a user' do
       let(:user) { create(:user) }
       let(:credit_card) { create(:credit_card, user: user) }
@@ -288,7 +286,7 @@ RSpec.describe Spree::CreditCard, type: :model do
         wallet_payment_source = user.wallet.add(credit_card)
         user.wallet.default_wallet_payment_source = wallet_payment_source
 
-        expect(default_with_silence(credit_card)).to be_truthy
+        expect(credit_card.default).to be_truthy
       end
     end
 
@@ -296,25 +294,19 @@ RSpec.describe Spree::CreditCard, type: :model do
       let(:credit_card) { create(:credit_card) }
 
       it 'returns false' do
-        expect(default_with_silence(credit_card)).to eq(false)
+        expect(credit_card.default).to eq(false)
       end
     end
   end
 
   # TODO: Remove these specs once default= is removed
   describe 'default=' do
-    def default_with_silence(card)
-      Spree::Deprecation.silence { card.default }
-    end
-
     context 'with a user' do
       let(:user) { create(:user) }
       let(:credit_card) { create(:credit_card, user: user) }
 
       it 'updates the wallet information' do
-        Spree::Deprecation.silence do
-          credit_card.default = true
-        end
+        credit_card.default = true
         expect(user.wallet.default_wallet_payment_source.payment_source).to eq(credit_card)
       end
     end
@@ -325,20 +317,16 @@ RSpec.describe Spree::CreditCard, type: :model do
       let(:second_card) { create(:credit_card, user: user) }
 
       it 'ensures only one default' do
-        Spree::Deprecation.silence do
-          first_card.default = true
-          second_card.default = true
-        end
+        first_card.default = true
+        second_card.default = true
 
-        expect(default_with_silence(first_card)).to be_falsey
-        expect(default_with_silence(second_card)).to be_truthy
+        expect(first_card.default).to be_falsey
+        expect(second_card.default).to be_truthy
 
-        Spree::Deprecation.silence do
-          first_card.default = true
-        end
+        first_card.default = true
 
-        expect(default_with_silence(first_card)).to be_truthy
-        expect(default_with_silence(second_card)).to be_falsey
+        expect(first_card.default).to be_truthy
+        expect(second_card.default).to be_falsey
       end
     end
 
@@ -347,13 +335,11 @@ RSpec.describe Spree::CreditCard, type: :model do
       let(:second_card) { create(:credit_card, user: create(:user)) }
 
       it 'allows multiple defaults' do
-        Spree::Deprecation.silence do
-          first_card.default = true
-          second_card.default = true
-        end
+        first_card.default = true
+        second_card.default = true
 
-        expect(default_with_silence(first_card)).to be_truthy
-        expect(default_with_silence(second_card)).to be_truthy
+        expect(first_card.default).to be_truthy
+        expect(second_card.default).to be_truthy
       end
     end
 
@@ -362,9 +348,7 @@ RSpec.describe Spree::CreditCard, type: :model do
 
       it 'raises' do
         expect {
-          Spree::Deprecation.silence do
-            credit_card.default = true
-          end
+          credit_card.default = true
         }.to raise_error("Cannot set 'default' on a credit card without a user")
       end
     end

--- a/core/spec/models/spree/inventory_unit_spec.rb
+++ b/core/spec/models/spree/inventory_unit_spec.rb
@@ -134,13 +134,17 @@ RSpec.describe Spree::InventoryUnit, type: :model do
     let(:variant) { create(:variant) }
     let(:inventory_units) {
       [
-      create(:inventory_unit, variant: variant),
-      create(:inventory_unit, variant: variant)
-    ]
+        create(:inventory_unit, variant: variant),
+        create(:inventory_unit, variant: variant)
+      ]
     }
 
+    before do
+      expect(Spree::Deprecation).to receive(:warn).
+        with(/^inventory_units\.finalize_units!\(inventory_units\) is deprecated/, any_args)
+    end
+
     it "should create a stock movement" do
-      expect(Spree::Deprecation).to receive(:warn)
       Spree::InventoryUnit.finalize_units!(inventory_units)
       expect(inventory_units.any?(&:pending)).to be false
     end

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -81,35 +81,47 @@ RSpec.describe Spree::LineItem, type: :model do
         end
       end
 
-      it 'should display a deprecation warning' do
-        expect(Spree::Deprecation).to receive(:warn)
-        Spree::LineItem.new(variant: variant, order: order)
+      before do
+        expect(Spree::Deprecation).to receive(:warn).
+          with(/^You have overridden Spree::LineItem#copy_price/, any_args)
       end
 
       it 'should run the user-defined copy_price method' do
         expect_any_instance_of(Spree::LineItem).to receive(:copy_price).and_call_original
-        Spree::Deprecation.silence do
-          Spree::LineItem.new(variant: variant, order: order)
-        end
+        Spree::LineItem.new(variant: variant, order: order)
       end
     end
   end
 
   # TODO: Remove this spec after the method has been removed.
   describe '#discounted_amount' do
+    before do
+      expect(Spree::Deprecation).to receive(:warn).
+        with(/^discounted_amount is deprecated and will be removed/, any_args)
+    end
+
     it "returns the amount minus any discounts" do
       line_item.price = 10
       line_item.quantity = 2
       line_item.promo_total = -5
-      expect(Spree::Deprecation.silence { line_item.discounted_amount }).to eq(15)
+      expect(line_item.discounted_amount).to eq(15)
     end
   end
 
   # TODO: Remove this spec after the method has been removed.
   describe "#discounted_money" do
+    before do
+      allow(Spree::Deprecation).to receive(:warn).
+        with(/^discounted_amount is deprecated and will be removed/, any_args)
+      allow(Spree::Deprecation).to receive(:warn).
+        with(/^display_discounted_amount is deprecated and will be removed/, any_args)
+      expect(Spree::Deprecation).to receive(:warn).
+        with(/^discounted_money is deprecated and will be removed/, any_args)
+    end
+
     it "should return a money object with the discounted amount" do
-      expect(Spree::Deprecation.silence { line_item.discounted_amount }).to eq(10.00)
-      expect(Spree::Deprecation.silence { line_item.discounted_money.to_s }).to eq "$10.00"
+      expect(line_item.discounted_amount).to eq(10.00)
+      expect(line_item.discounted_money.to_s).to eq "$10.00"
     end
   end
 

--- a/core/spec/models/spree/order_cancellations_spec.rb
+++ b/core/spec/models/spree/order_cancellations_spec.rb
@@ -35,7 +35,8 @@ RSpec.describe Spree::OrderCancellations do
       subject { order.cancellations.cancel_unit(inventory_unit, whodunnit: "some automated system") }
 
       it "sets the user on the UnitCancel and print a deprecation" do
-        expect(Spree::Deprecation).to receive(:warn)
+        expect(Spree::Deprecation).to receive(:warn).
+          with(/^Calling #cancel_unit on .* with whodunnit is deprecated/, any_args)
         expect(subject.created_by).to eq("some automated system")
       end
     end
@@ -165,8 +166,8 @@ RSpec.describe Spree::OrderCancellations do
       let(:user) { order.user }
 
       it "sets the user on the UnitCancel and raises a deprecation # WARNING: " do
-        expect(Spree::Deprecation).to receive(:warn)
-
+        expect(Spree::Deprecation).to receive(:warn).
+          with(/^Calling #short_ship on .* with whodunnit is deprecated/, any_args)
         expect { subject }.to change { Spree::UnitCancel.count }.by(1)
         expect(Spree::UnitCancel.last.created_by).to eq("some automated system")
       end

--- a/core/spec/models/spree/order_capturing_spec.rb
+++ b/core/spec/models/spree/order_capturing_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe Spree::OrderCapturing do
     let(:order) { build(:completed_order_with_totals) }
 
     it 'is deprecated' do
-      expect(Spree::Deprecation).to(receive(:warn))
+      expect(Spree::Deprecation).to receive(:warn).
+        with(/^Spree::OrderCapturing is deprecated and will be removed/, any_args)
       subject
     end
   end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -216,11 +216,11 @@ RSpec.describe Spree::Order, type: :model do
     before { allow(order).to receive_messages shipments: [shipment] }
 
     it "update and persist totals" do
+      expect(Spree::Deprecation).to receive(:warn).
+        with(/^set_shipments_cost is deprecated and will be removed/, any_args)
       expect(order.updater).to receive :update
 
-      Spree::Deprecation.silence do
-        order.set_shipments_cost
-      end
+      order.set_shipments_cost
     end
   end
 
@@ -611,13 +611,16 @@ RSpec.describe Spree::Order, type: :model do
   context "#state_changed" do
     let(:order) { FactoryBot.create(:order) }
 
+    before do
+      expect(Spree::Deprecation).to receive(:warn).
+        with(/^state_changed is deprecated and will be removed/, any_args)
+    end
+
     it "logs state changes" do
       order.update_column(:payment_state, 'balance_due')
       order.payment_state = 'paid'
       expect(order.state_changes).to be_empty
-      Spree::Deprecation.silence do
-        order.state_changed('payment')
-      end
+      order.state_changed('payment')
       state_change = order.state_changes.find_by(name: 'payment')
       expect(state_change.previous_state).to eq('balance_due')
       expect(state_change.next_state).to eq('paid')
@@ -626,9 +629,7 @@ RSpec.describe Spree::Order, type: :model do
     it "does not do anything if state does not change" do
       order.update_column(:payment_state, 'balance_due')
       expect(order.state_changes).to be_empty
-      Spree::Deprecation.silence do
-        order.state_changed('payment')
-      end
+      order.state_changed('payment')
       expect(order.state_changes).to be_empty
     end
   end
@@ -851,7 +852,8 @@ RSpec.describe Spree::Order, type: :model do
 
     context "passing options" do
       it 'is deprecated' do
-        expect(Spree::Deprecation).to receive(:warn)
+        expect(Spree::Deprecation).to receive(:warn).
+          with(/^Passing options to Order\#generate_order_number is deprecated\./)
         order.generate_order_number(length: 2)
       end
     end

--- a/core/spec/models/spree/payment/cancellation_spec.rb
+++ b/core/spec/models/spree/payment/cancellation_spec.rb
@@ -69,15 +69,12 @@ RSpec.describe Spree::Payment::Cancellation do
         allow(payment_method).to receive(:respond_to?) { false }
         allow(payment_method).to receive(:cancel) { double }
         allow(payment).to receive(:handle_void_response)
+        expect(Spree::Deprecation).to receive(:warn).
+          with(/^Spree::PaymentMethod::.*#cancel is deprecated and will be removed/, any_args)
       end
 
       it 'calls cancel instead' do
         expect(payment_method).to receive(:cancel)
-        Spree::Deprecation.silence { subject }
-      end
-
-      it 'prints depcrecation warning' do
-        expect(Spree::Deprecation).to receive(:warn)
         subject
       end
     end

--- a/core/spec/models/spree/payment_create_spec.rb
+++ b/core/spec/models/spree/payment_create_spec.rb
@@ -83,8 +83,9 @@ module Spree
         }
       end
 
-      around do |example|
-        Spree::Deprecation.silence { example.run }
+      before do
+        expect(Spree::Deprecation).to receive(:warn).
+          with(/^Passing existing_card_id to PaymentCreate is deprecated/, any_args)
       end
 
       it 'sets the existing card as the source for the new payment' do

--- a/core/spec/models/spree/payment_method_spec.rb
+++ b/core/spec/models/spree/payment_method_spec.rb
@@ -110,32 +110,26 @@ RSpec.describe Spree::PaymentMethod, type: :model do
   end
 
   describe ".available" do
-    it "should have 4 total methods" do
+    before do
       expect(Spree::PaymentMethod.all.size).to eq(4)
+      expect(Spree::Deprecation).to receive(:warn).
+        with(/^Spree::PaymentMethod\.available is deprecated/, any_args)
     end
 
     it "should return all methods available to front-end/back-end when no parameter is passed" do
-      Spree::Deprecation.silence do
-        expect(Spree::PaymentMethod.available.size).to eq(2)
-      end
+      expect(Spree::PaymentMethod.available.size).to eq(2)
     end
 
     it "should return all methods available to front-end/back-end when passed :both" do
-      Spree::Deprecation.silence do
-        expect(Spree::PaymentMethod.available(:both).size).to eq(2)
-      end
+      expect(Spree::PaymentMethod.available(:both).size).to eq(2)
     end
 
     it "should return all methods available to front-end when passed :front_end" do
-      Spree::Deprecation.silence do
-        expect(Spree::PaymentMethod.available(:front_end).size).to eq(3)
-      end
+      expect(Spree::PaymentMethod.available(:front_end).size).to eq(3)
     end
 
     it "should return all methods available to back-end when passed :back_end" do
-      Spree::Deprecation.silence do
-        expect(Spree::PaymentMethod.available(:back_end).size).to eq(3)
-      end
+      expect(Spree::PaymentMethod.available(:back_end).size).to eq(3)
     end
 
     context 'with stores' do
@@ -161,33 +155,14 @@ RSpec.describe Spree::PaymentMethod, type: :model do
       context 'when the store is specified' do
         context 'when the store has payment methods' do
           it 'finds the payment methods for the store' do
-            Spree::Deprecation.silence do
-              expect(Spree::PaymentMethod.available(:both, store: store_1)).to match_array(
-                [payment_method_nil_display, payment_method_both_display]
-              )
-            end
+            expect(Spree::PaymentMethod.available(:both, store: store_1)).to match_array(
+              [payment_method_nil_display, payment_method_both_display]
+            )
           end
         end
 
         context "when store does not have payment_methods" do
           it "returns all matching payment methods regardless of store" do
-            Spree::Deprecation.silence do
-              expect(Spree::PaymentMethod.available(:both)).to match_array(
-                [
-                  payment_method_nil_display,
-                  payment_method_both_display,
-                  store_2_payment_method,
-                  no_store_payment_method
-                ]
-              )
-            end
-          end
-        end
-      end
-
-      context 'when the store is not specified' do
-        it "returns all matching payment methods regardless of store" do
-          Spree::Deprecation.silence do
             expect(Spree::PaymentMethod.available(:both)).to match_array(
               [
                 payment_method_nil_display,
@@ -197,6 +172,19 @@ RSpec.describe Spree::PaymentMethod, type: :model do
               ]
             )
           end
+        end
+      end
+
+      context 'when the store is not specified' do
+        it "returns all matching payment methods regardless of store" do
+          expect(Spree::PaymentMethod.available(:both)).to match_array(
+            [
+              payment_method_nil_display,
+              payment_method_both_display,
+              store_2_payment_method,
+              no_store_payment_method
+            ]
+          )
         end
       end
     end
@@ -261,12 +249,14 @@ RSpec.describe Spree::PaymentMethod, type: :model do
   end
 
   describe "display_on=" do
-    around do |example|
-      Spree::Deprecation.silence do
-        example.run
-      end
-    end
     let(:payment) { described_class.new(display_on: display_on) }
+
+    before do
+      allow(Spree::Deprecation).to receive(:warn).
+        with(/^Spree::PaymentMethod#display_on is deprecated/, any_args)
+      expect(Spree::Deprecation).to receive(:warn).
+        with(/^Spree::PaymentMethod#display_on= is deprecated/, any_args)
+    end
 
     context 'with empty string' do
       let(:display_on) { "" }

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -186,12 +186,17 @@ RSpec.describe Spree::Product, type: :model do
       let!(:high) { create(:variant, product: product) }
       let!(:low) { create(:variant, product: product) }
 
-      before { high.option_values.destroy_all }
+      before do
+        allow(Spree::Deprecation).to receive(:warn).
+          with(/`Variant.active\(currency\)` is deprecated/, any_args)
+        expect(Spree::Deprecation).to receive(:warn).
+          with(/^variants_and_option_values is deprecated and will be removed/, any_args)
+
+        high.option_values.destroy_all
+      end
 
       it "returns only variants with option values" do
-        Spree::Deprecation.silence do
-          expect(product.variants_and_option_values).to eq([low])
-        end
+        expect(product.variants_and_option_values).to eq([low])
       end
     end
 

--- a/core/spec/models/spree/promotion/actions/create_adjustment_spec.rb
+++ b/core/spec/models/spree/promotion/actions/create_adjustment_spec.rb
@@ -120,7 +120,15 @@ RSpec.describe Spree::Promotion::Actions::CreateAdjustment, type: :model do
   end
 
   context "#paranoia_destroy" do
-    subject { Spree::Deprecation.silence { action.paranoia_destroy } }
+    before do
+      expect(Spree::Deprecation).to receive(:warn).
+        with(/^Calling #destroy \(or #paranoia_destroy\) on a .* currently/, any_args)
+      expect(Spree::Deprecation).to receive(:warn).
+        with(/^Calling #delete \(or #paranoia_delete\) on a .* currently/, any_args)
+    end
+
+    subject { action.paranoia_destroy }
+
     it_should_behave_like "destroying adjustments from incomplete orders"
   end
 end

--- a/core/spec/models/spree/promotion/actions/create_item_adjustments_spec.rb
+++ b/core/spec/models/spree/promotion/actions/create_item_adjustments_spec.rb
@@ -191,7 +191,15 @@ module Spree
     end
 
     describe "#paranoia_destroy" do
-      subject { Spree::Deprecation.silence { action.paranoia_destroy } }
+      before do
+        expect(Spree::Deprecation).to receive(:warn).
+          with(/^Calling #destroy \(or #paranoia_destroy\) on a .* currently/, any_args)
+        expect(Spree::Deprecation).to receive(:warn).
+          with(/^Calling #delete \(or #paranoia_delete\) on a .* currently/, any_args)
+      end
+
+      subject { action.paranoia_destroy }
+
       it_should_behave_like "destroying adjustments from incomplete orders"
     end
   end

--- a/core/spec/models/spree/return_item_spec.rb
+++ b/core/spec/models/spree/return_item_spec.rb
@@ -44,10 +44,12 @@ RSpec.describe Spree::ReturnItem, type: :model do
     end
 
     context 'when the `skip_customer_return_processing` flag is set' do
-      before { Spree::Deprecation.silence { return_item.skip_customer_return_processing = false } }
-
       it 'shows a deprecation warning' do
-        expect(Spree::Deprecation).to receive(:warn)
+        expect(Spree::Deprecation).to receive(:warn).
+          with(/^From Solidus v2\.11 onwards, #skip_customer_return_processing does nothing/, any_args).
+          at_least(:once)
+
+        return_item.skip_customer_return_processing = false
         subject
       end
     end

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -27,6 +27,11 @@ RSpec.describe Spree::Shipment, type: :model do
   let(:line_item) { mock_model(Spree::LineItem, variant: variant) }
 
   context '#transfer_to_location' do
+    before do
+      allow(Spree::Deprecation).to receive(:warn).
+        with(/^Please use the Spree::FulfilmentChanger class instead of Spree::Shipment#transfer_to_location/, any_args)
+    end
+
     it 'transfers unit to a new shipment with given location' do
       order = create(:completed_order_with_totals, line_items_count: 2)
       shipment = order.shipments.first
@@ -34,9 +39,7 @@ RSpec.describe Spree::Shipment, type: :model do
 
       aggregate_failures("verifying new shipment attributes") do
         expect do
-          Spree::Deprecation.silence do
-            shipment.transfer_to_location(variant, 1, stock_location)
-          end
+          shipment.transfer_to_location(variant, 1, stock_location)
         end.to change { Spree::Shipment.count }.by(1)
 
         new_shipment = order.shipments.order(:created_at).last
@@ -144,10 +147,12 @@ RSpec.describe Spree::Shipment, type: :model do
   end
 
   it "#discounted_cost" do
+    expect(Spree::Deprecation).to receive(:warn).
+      with(/^discounted_cost is deprecated and will be removed/, any_args)
     shipment = create(:shipment)
     shipment.cost = 10
     shipment.promo_total = -1
-    expect(Spree::Deprecation.silence { shipment.discounted_cost }).to eq(9)
+    expect(shipment.discounted_cost).to eq(9)
   end
 
   describe '#total_before_tax' do

--- a/core/spec/models/spree/shipping_method_spec.rb
+++ b/core/spec/models/spree/shipping_method_spec.rb
@@ -218,10 +218,13 @@ RSpec.describe Spree::ShippingMethod, type: :model do
   end
 
   describe "display_on=" do
+    before do
+      expect(Spree::Deprecation).to receive(:warn).
+        with(/^display_on= is deprecated and will be removed/, any_args)
+    end
+
     subject do
-      Spree::Deprecation.silence do
-        described_class.new(display_on: display_on).available_to_users
-      end
+      described_class.new(display_on: display_on).available_to_users
     end
 
     context "with 'back_end'" do
@@ -241,10 +244,13 @@ RSpec.describe Spree::ShippingMethod, type: :model do
   end
 
   describe "display_on" do
+    before do
+      expect(Spree::Deprecation).to receive(:warn).
+        with(/^display_on is deprecated and will be removed/, any_args)
+    end
+
     subject do
-      Spree::Deprecation.silence do
-        described_class.new(available_to_users: available_to_users).display_on
-      end
+      described_class.new(available_to_users: available_to_users).display_on
     end
 
     context "when available_to_users is true" do

--- a/core/spec/models/spree/stock/simple_coordinator_spec.rb
+++ b/core/spec/models/spree/stock/simple_coordinator_spec.rb
@@ -58,7 +58,8 @@ module Spree
 
       describe "#allocate_inventory" do
         it 'is deprecated' do
-          expect(Spree::Deprecation).to receive(:warn)
+          expect(Spree::Deprecation).to receive(:warn).
+            with(/^allocate_inventory is deprecated and will be removed/, any_args)
           subject.send :allocate_inventory, subject.instance_variable_get(:@availability).on_hand_by_stock_location_id
         end
       end

--- a/core/spec/models/spree/store_spec.rb
+++ b/core/spec/models/spree/store_spec.rb
@@ -3,14 +3,20 @@
 require 'rails_helper'
 
 RSpec.describe Spree::Store, type: :model do
+  before do
+    allow(Spree::Deprecation).to receive(:warn).
+      with(/^by_url is deprecated and will be removed/, any_args)
+  end
+
   it { is_expected.to respond_to(:cart_tax_country_iso) }
 
   describe ".by_url (deprecated)" do
     let!(:store)    { create(:store, url: "website1.com\nwww.subdomain.com") }
     let!(:store_2)  { create(:store, url: 'freethewhales.com') }
 
-    around do |example|
-      Spree::Deprecation.silence { example.run }
+    before do
+      expect(Spree::Deprecation).to receive(:warn).
+        with(/^by_url is deprecated and will be removed/, any_args)
     end
 
     it "should find stores by url" do
@@ -27,11 +33,12 @@ RSpec.describe Spree::Store, type: :model do
     let!(:store_2) { create(:store, default: false, url: 'www.subdomain.com') }
     let!(:store_3) { create(:store, default: false, url: 'www.another.com', code: 'CODE') }
 
-    delegate :current, to: :described_class
-
-    around do |example|
-      Spree::Deprecation.silence { example.run }
+    before do
+      expect(Spree::Deprecation).to receive(:warn).
+        with(/^Spree::Store.current is DEPRECATED/, any_args)
     end
+
+    delegate :current, to: :described_class
 
     context "with no match" do
       it 'should return the default domain' do

--- a/core/spec/models/spree/tax_rate_spec.rb
+++ b/core/spec/models/spree/tax_rate_spec.rb
@@ -151,9 +151,13 @@ RSpec.describe Spree::TaxRate, type: :model do
 
     let(:item) { order.line_items.first }
 
+    before do
+      expect(Spree::Deprecation).to receive(:warn).
+        with(/^`Spree::TaxRate#adjust` is deprecated/, any_args)
+    end
+
     describe 'adjustments' do
       before do
-        expect(Spree::Deprecation).to receive(:warn)
         tax_rate.adjust(nil, item)
       end
 
@@ -297,8 +301,13 @@ RSpec.describe Spree::TaxRate, type: :model do
     let(:tax_rate) { create(:tax_rate, tax_categories: [tax_category]) }
     let(:tax_category) { create(:tax_category) }
 
+    before do
+      expect(Spree::Deprecation).to receive(:warn).
+        with(/^tax_category is deprecated and will be removed/, any_args)
+    end
+
     it "returns the first tax category" do
-      tax_category = Spree::Deprecation.silence { tax_rate.tax_category }
+      tax_category = tax_rate.tax_category
       expect(tax_category).to eq(tax_category)
     end
   end
@@ -307,10 +316,13 @@ RSpec.describe Spree::TaxRate, type: :model do
     let(:tax_rate) { Spree::TaxRate.new }
     let(:tax_category) { create(:tax_category) }
 
+    before do
+      expect(Spree::Deprecation).to receive(:warn).
+        with(/^tax_category= is deprecated and will be removed/, any_args)
+    end
+
     it "can assign the tax categories" do
-      Spree::Deprecation.silence {
-        tax_rate.tax_category = tax_category
-      }
+      tax_rate.tax_category = tax_category
       expect(tax_rate.tax_categories).to eq([tax_category])
     end
   end

--- a/core/spec/models/spree/user_spec.rb
+++ b/core/spec/models/spree/user_spec.rb
@@ -93,10 +93,13 @@ RSpec.describe Spree::LegacyUser, type: :model do
         create(:credit_card, user_id: user.id, payment_method: payment_method, gateway_customer_profile_id: "2342343")
       end
 
+      before do
+        expect(Spree::Deprecation).to receive(:warn).
+          with(/^user.payment_sources is deprecated/, any_args)
+      end
+
       it "has payment sources" do
-        Spree::Deprecation.silence do
-          expect(user.payment_sources.first.gateway_customer_profile_id).not_to be_empty
-        end
+        expect(user.payment_sources.first.gateway_customer_profile_id).not_to be_empty
       end
     end
   end
@@ -174,10 +177,10 @@ RSpec.describe Spree.user_class, type: :model do
   describe "#total_available_store_credit" do
     before do
       allow_any_instance_of(Spree::LegacyUser).to receive(:total_available_store_credit).and_wrap_original do |method, *args|
-        Spree::Deprecation.silence do
-          method.call(*args)
-        end
+        method.call(*args)
       end
+      expect(Spree::Deprecation).to receive(:warn).
+        with(/^total_available_store_credit is deprecated and will be removed/, any_args)
     end
 
     context "user does not have any associated store credits" do

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -160,9 +160,12 @@ RSpec.describe Spree::Variant, type: :model do
         let!(:old_option_values_variant_ids) { variant.option_values_variants.pluck(:id) }
 
         before do
+          allow(Spree::Deprecation).to receive(:warn).
+            with(/^.*\.with_deleted has been deprecated/, any_args)
+
           # #really_destroy! will be replaced here with #destroy when Paranoia
           # will be removed in Solidus 3.0
-          Spree::Deprecation.silence { variant.really_destroy! }
+          variant.really_destroy!
         end
 
         it "leaves no stale records behind" do
@@ -353,11 +356,13 @@ RSpec.describe Spree::Variant, type: :model do
 
   describe '.price_in' do
     before do
+      expect(Spree::Deprecation).to receive(:warn).
+        with(/^price_in is deprecated and will be removed/, any_args)
       variant.prices << create(:price, variant: variant, currency: "EUR", amount: 33.33)
     end
 
     subject do
-      Spree::Deprecation.silence { variant.price_in(currency) }
+      variant.price_in(currency)
     end
 
     context "when currency is not specified" do
@@ -387,12 +392,16 @@ RSpec.describe Spree::Variant, type: :model do
 
   describe '.amount_in' do
     before do
+      allow(Spree::Deprecation).to receive(:warn).
+        with(/^price_in is deprecated and will be removed/, any_args)
+
+      expect(Spree::Deprecation).to receive(:warn).
+        with(/^amount_in is deprecated and will be removed/, any_args)
+
       variant.prices << create(:price, variant: variant, currency: "EUR", amount: 33.33)
     end
 
-    subject do
-      Spree::Deprecation.silence { variant.amount_in(currency) }
-    end
+    subject { variant.amount_in(currency) }
 
     context "when currency is not specified" do
       let(:currency) { nil }

--- a/core/spec/models/spree/zone_spec.rb
+++ b/core/spec/models/spree/zone_spec.rb
@@ -57,9 +57,7 @@ RSpec.describe Spree::Zone, type: :model do
       before { country_zone.members.create(zoneable: country) }
 
       it 'should return a list of countries' do
-        Spree::Deprecation.silence do
-          expect(country_zone.country_list).to eq([country])
-        end
+        expect(country_zone.country_list).to eq([country])
       end
     end
 
@@ -69,9 +67,7 @@ RSpec.describe Spree::Zone, type: :model do
       before { state_zone.members.create(zoneable: state) }
 
       it 'should return a list of countries' do
-        Spree::Deprecation.silence do
-          expect(state_zone.country_list).to eq([state.country])
-        end
+        expect(state_zone.country_list).to eq([state.country])
       end
     end
   end


### PR DESCRIPTION
When testing, instead of silencing/mocking all deprecation warnings, test the specific deprecation warning needed for the specific test case.
Since we make fail the CI build when there're unhandled deprecation warnings, this ensures we have expectations only for specific deprecation warnings instead of silencing/mocking all warnings.

**Checklist:**
- [ ] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [ ] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
