### PR TITLE
Expose js function: Spree.SortableTable.refresh

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/components/sortable_table.js
+++ b/backend/app/assets/javascripts/spree/backend/components/sortable_table.js
@@ -1,32 +1,36 @@
 //= require solidus_admin/Sortable
 /* eslint no-unused-vars: "off" */
 
-Spree.ready(function() {
-  var sortable_tables = document.querySelectorAll('table.sortable');
+Spree.SortableTable = {
+  refresh: function() {
+    var sortable_tables = document.querySelectorAll('table.sortable');
 
-  _.each(sortable_tables, function(table) {
-    var url = table.getAttribute('data-sortable-link');
-    var tbody = table.querySelector('tbody');
-    var sortable = Sortable.create(tbody,{
-      handle: ".handle",
-      onEnd: function(e) {
-        var positions = {};
-        _.each(e.to.querySelectorAll('tr'), function(el, index) {
-          var idAttr = el.id;
-          if (idAttr) {
-            var objId = idAttr.split('_').slice(-1);
-            if (!isNaN(objId)) {
-              positions['positions['+objId+']'] = index + 1;
+    _.each(sortable_tables, function(table) {
+      var url = table.getAttribute('data-sortable-link');
+      var tbody = table.querySelector('tbody');
+      var sortable = Sortable.create(tbody,{
+        handle: ".handle",
+        onEnd: function(e) {
+          var positions = {};
+          _.each(e.to.querySelectorAll('tr'), function(el, index) {
+            var idAttr = el.id;
+            if (idAttr) {
+              var objId = idAttr.split('_').slice(-1);
+              if (!isNaN(objId)) {
+                positions['positions['+objId+']'] = index + 1;
+              }
             }
-          }
-        });
-        Spree.ajax({
-          type: 'POST',
-          dataType: 'json',
-          url: url,
-          data: positions,
-        });
-      }
+          });
+          Spree.ajax({
+            type: 'POST',
+            dataType: 'json',
+            url: url,
+            data: positions,
+          });
+        }
+      });
     });
-  });
-});
+  }
+};
+
+Spree.ready(Spree.SortableTable.refresh);


### PR DESCRIPTION
**Description**

The sortable table component is only loaded once when page is loaded.
So it will be very useful to be called after asynchronous requests.

The behaviour stays the same, but now we'll have a function available to refresh the sortable table component if needed by calling `Spree.SortableTable.refresh()` in the javascript.

**Motivation**

I'm adding sortable table component on Product / Parts and this exposing was needed.
https://github.com/solidusio-contrib/solidus_product_assembly/pull/92

<!--
  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

  Please include screenshots in case of visual changes to the frontend or backend sections of Solidus.

  If needed you can reference another PR or issue here, e.g.:
  Ref #ISSUE
-->

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
