### PR TITLE
Allow capturing or voiding payments only with positive amount

### DIFF
--- a/api/spec/requests/spree/api/payments_controller_spec.rb
+++ b/api/spec/requests/spree/api/payments_controller_spec.rb
@@ -4,8 +4,8 @@ require 'spec_helper'
 
 module Spree
   describe Spree::Api::PaymentsController, type: :request do
-    let!(:order) { create(:order) }
-    let!(:payment) { create(:payment, order: order) }
+    let!(:order) { create(:order_with_line_items) }
+    let!(:payment) { create(:payment, order: order, amount: order.amount) }
     let!(:attributes) {
       [:id, :source_type, :source_id, :amount, :display_amount,
        :payment_method_id, :state, :avs_response,

--- a/backend/spec/controllers/spree/admin/payments_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/payments_controller_spec.rb
@@ -156,7 +156,7 @@ module Spree
 
       describe '#fire' do
         describe 'authorization' do
-          let(:payment) { create(:payment, state: 'checkout') }
+          let(:payment) { create(:payment, state: 'checkout', amount: 10) }
           let(:order) { payment.order }
 
           context 'the user is authorized' do

--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -48,6 +48,8 @@ module Spree
       # a new pending payment record for the remaining amount to capture later.
       def capture!(amount = nil)
         return true if completed?
+        return false unless self.amount.positive?
+
         amount ||= money.money.cents
         started_processing!
         protect_from_connection_error do
@@ -66,6 +68,8 @@ module Spree
 
       def void_transaction!
         return true if void?
+        return false unless amount.positive?
+
         protect_from_connection_error do
           if payment_method.payment_profiles_supported?
             # Gateways supporting payment profiles will need access to credit card object because this stores the payment profile information

--- a/core/app/models/spree/payment/processing.rb
+++ b/core/app/models/spree/payment/processing.rb
@@ -46,20 +46,20 @@ module Spree
       # Takes the amount in cents to capture.
       # Can be used to capture partial amounts of a payment, and will create
       # a new pending payment record for the remaining amount to capture later.
-      def capture!(amount = nil)
+      def capture!(capture_amount = nil)
         return true if completed?
-        return false unless self.amount.positive?
+        return false unless amount.positive?
 
-        amount ||= money.money.cents
+        capture_amount ||= money.money.cents
         started_processing!
         protect_from_connection_error do
           # Standard ActiveMerchant capture usage
           response = payment_method.capture(
-            amount,
+            capture_amount,
             response_code,
             gateway_options
           )
-          money = ::Money.new(amount, currency)
+          money = ::Money.new(capture_amount, currency)
           capture_events.create!(amount: money.to_d)
           update!(amount: captured_amount)
           handle_response(response, :complete, :failure)


### PR DESCRIPTION
**Description**

There's no point in capturing or voiding a payment with zero amount. When capturing zero amount, ActiveMerchant will respond with the error `This value must be greater than or equal to 1.`, while if payment amount is zero, the error from ActiveMerchant responds with the error `Amount must be at least $0.50 usd`.



**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
