### PR TITLE
Fix address validation having a country w/o states

### DIFF
--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -253,6 +253,9 @@ module Spree
     end
 
     def validate_state_matches_country
+      return unless country
+
+      self.state = nil if country.states.empty?
       if state && state.country != country
         errors.add(:state, :does_not_match_country)
       end


### PR DESCRIPTION
This is an extract from #3129 and addresses the [concern](https://github.com/solidusio/solidus/pull/3129#issuecomment-689655524) having a separate commit fixing #3098 and enabling the stores to backport the fix more easily without being forced to upgrade.

This mainly fixes the address' state validation bug when switching from a country with states (regions) to one without.
Before validating that the associated state belongs to the associated country, ensure the country does have states; if it doesn't, nullify the `state_id` since we don't need one here.

This is quite a tricky bug that has been partially introduced when the `validate_state_matches_country` validation method has been merged.
Note: both state validation methods are being deprecated in #3129 and partially refactored into a configurable validation class allowing to override the default behavior and handling any region-based edge case around the address' state normalization and validation logic.

**Checklist:**
- [ ] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [ ] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
