### PR TITLE
Make order customer email links consistent

### DIFF
--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -184,8 +184,9 @@
           <% if order.user %>
             <%= link_to order.email, edit_admin_user_path(order.user) %>
           <% else %>
-            <%= mail_to order.email %>
+            <%= order.email %>
           <% end %>
+          <%= link_to_with_icon('email', t('spree.actions.send_email'), "mailto:#{order.email}", no_text: true) %>
         </td>
         <td class="align-right"><%= order.display_total.to_html %></td>
         <td class='actions align-center' data-hook="admin_orders_index_row_actions">

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -793,6 +793,7 @@ en:
       refund: Refund
       remove: Remove
       save: Save
+      send_email: Send Email
       ship: Ship
       split: Split
       update: Update


### PR DESCRIPTION
**Description**
Currently when looking at the table of orders on the backend, the customer email will always be displayed as a link. However, the behavior of this link is completely different based on whether the customer has a user account or not. If they _do_, it will link to that user's User page on the backend. If they _don't_, it is a simple mailto link.

(Can you tell that clicking one of these will do one thing and clicking the other will do something totally different?)

<img width="758" alt="Screen Shot 2020-09-21 at 11 42 53 AM" src="https://user-images.githubusercontent.com/2460418/93808016-4a999480-fc00-11ea-82ba-5413773e729b.png">

This behavior is inconsistent, and in my opinion, confusing. There are two ways to make the behavior consistent:

(1) We could make all links function as mailto.
(2) We could make emails with User accounts link to those user pages, and emails with no user accounts display as plain text.

In my opinion, (2) is the slightly less pretty, but much more intuitive and helpful of these two options:

<img width="750" alt="Screen Shot 2020-09-21 at 11 43 52 AM" src="https://user-images.githubusercontent.com/2460418/93807626-ba5b4f80-fbff-11ea-8804-26ddb165b7e0.png">


**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
