### PR TITLE
TaxHelpers#rates_for_item now respects the validity period of tax rates

### DIFF
--- a/core/app/models/spree/tax/tax_helpers.rb
+++ b/core/app/models/spree/tax/tax_helpers.rb
@@ -9,7 +9,7 @@ module Spree
         @rates_for_order ||= Spree::TaxRate.for_address(item.order.tax_address)
 
         @rates_for_order.select do |rate|
-          rate.tax_categories.map(&:id).include?(item.tax_category_id)
+          rate.active? && rate.tax_categories.map(&:id).include?(item.tax_category_id)
         end
       end
     end

--- a/core/app/models/spree/tax_rate.rb
+++ b/core/app/models/spree/tax_rate.rb
@@ -31,6 +31,12 @@ module Spree
     scope :for_address, ->(address) { joins(:zone).merge(Spree::Zone.for_address(address)) }
     scope :for_country,
           ->(country) { for_address(Spree::Tax::TaxLocation.new(country: country)) }
+    scope :active, -> do
+      table = arel_table
+      time = Time.current
+      where(table[:starts_at].eq(nil).or(table[:starts_at].lt(time))).
+        where(table[:expires_at].eq(nil).or(table[:expires_at].gt(time)))
+    end
 
     # Finds geographically matching tax rates for a tax zone.
     # We do not know if they are/aren't applicable until we attempt to apply these rates to

--- a/core/spec/models/spree/calculator/default_tax_spec.rb
+++ b/core/spec/models/spree/calculator/default_tax_spec.rb
@@ -138,18 +138,6 @@ RSpec.describe Spree::Calculator::DefaultTax, type: :model do
           end
         end
 
-        context 'when multiple other rates exist that are currently not valid' do
-          let!(:invalid_rate) do
-            create(:tax_rate, tax_categories: [tax_category], amount: 0.10,
-                   included_in_price: included_in_price, zone: zone,
-                   starts_at: 1.day.from_now, expires_at: 2.days.from_now)
-          end
-
-          it 'should be equal to the sum of item totals * valid rate and not consider invalid rates' do
-            expect(calculator.compute(item)).to eq(1.43)
-          end
-        end
-
         context "when line item is adjusted" do
           let(:adjustment_total) { -1 }
 

--- a/core/spec/models/spree/calculator/default_tax_spec.rb
+++ b/core/spec/models/spree/calculator/default_tax_spec.rb
@@ -138,6 +138,18 @@ RSpec.describe Spree::Calculator::DefaultTax, type: :model do
           end
         end
 
+        context 'when multiple other rates exist that are currently not valid' do
+          let!(:invalid_rate) do
+            create(:tax_rate, tax_categories: [tax_category], amount: 0.10,
+                   included_in_price: included_in_price, zone: zone,
+                   starts_at: 1.day.from_now, expires_at: 2.days.from_now)
+          end
+
+          it 'should be equal to the sum of item totals * valid rate and not consider invalid rates' do
+            expect(calculator.compute(item)).to eq(1.43)
+          end
+        end
+
         context "when line item is adjusted" do
           let(:adjustment_total) { -1 }
 

--- a/core/spec/models/spree/tax/tax_helpers_spec.rb
+++ b/core/spec/models/spree/tax/tax_helpers_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+class DummyClass
+  include Spree::Tax::TaxHelpers
+
+  def valid_rates(item)
+    rates_for_item(item)
+  end
+end
+
+RSpec.describe Spree::Tax::TaxHelpers do
+  let(:tax_category) { create(:tax_category) }
+  let(:irrelevant_tax_category) { create(:tax_category) }
+
+  let(:item) { create(:line_item, tax_category: tax_category) }
+  let(:tax_address) { item.order.tax_address }
+  
+  let(:zone) { create(:zone, name: "Country Zone", countries: [tax_address.country]) }
+
+  let!(:tax_rate) do
+    create(:tax_rate, tax_categories: [tax_category], zone: zone)
+  end
+
+  describe '#rates_for_item', :focus do
+
+    it 'returns tax rates that match the tax category of the given item' do
+      expect(DummyClass.new.valid_rates(item)).to contain_exactly(tax_rate)
+    end
+
+    context 'when multiple rates exist that are currently not valid' do
+      let(:starts_at) { 1.day.from_now }
+      let(:expires_at) { 2.days.from_now }
+
+      let!(:invalid_tax_rate) do
+        create(:tax_rate, tax_categories: [tax_category], zone: zone,
+               starts_at: starts_at, expires_at: expires_at)
+      end
+      
+      it 'returns only active rates that match the tax category of given item' do
+        expect(Spree::TaxRate.for_address(tax_address)).to contain_exactly(tax_rate, invalid_tax_rate)
+
+        expect(DummyClass.new.valid_rates(item)).to contain_exactly(tax_rate)
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/tax/tax_helpers_spec.rb
+++ b/core/spec/models/spree/tax/tax_helpers_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Spree::Tax::TaxHelpers do
     create(:tax_rate, tax_categories: [tax_category], zone: zone)
   end
 
-  describe '#rates_for_item', :focus do
+  describe '#rates_for_item' do
 
     it 'returns tax rates that match the tax category of the given item' do
       expect(DummyClass.new.valid_rates(item)).to contain_exactly(tax_rate)

--- a/core/spec/models/spree/tax/tax_helpers_spec.rb
+++ b/core/spec/models/spree/tax/tax_helpers_spec.rb
@@ -3,7 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe Spree::Tax::TaxHelpers do
-
   before do
     stub_const('DummyClass', (Class.new do
       include Spree::Tax::TaxHelpers

--- a/core/spec/models/spree/tax/tax_helpers_spec.rb
+++ b/core/spec/models/spree/tax/tax_helpers_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe Spree::Tax::TaxHelpers do
 
   let(:item) { create(:line_item, tax_category: tax_category) }
   let(:tax_address) { item.order.tax_address }
-  
   let(:zone) { create(:zone, name: "Country Zone", countries: [tax_address.country]) }
 
   let!(:tax_rate) do
@@ -24,7 +23,6 @@ RSpec.describe Spree::Tax::TaxHelpers do
   end
 
   describe '#rates_for_item' do
-
     it 'returns tax rates that match the tax category of the given item' do
       expect(DummyClass.new.valid_rates(item)).to contain_exactly(tax_rate)
     end
@@ -37,7 +35,7 @@ RSpec.describe Spree::Tax::TaxHelpers do
         create(:tax_rate, tax_categories: [tax_category], zone: zone,
                starts_at: starts_at, expires_at: expires_at)
       end
-      
+
       it 'returns only active rates that match the tax category of given item' do
         expect(Spree::TaxRate.for_address(tax_address)).to contain_exactly(tax_rate, invalid_tax_rate)
 

--- a/core/spec/models/spree/tax/tax_helpers_spec.rb
+++ b/core/spec/models/spree/tax/tax_helpers_spec.rb
@@ -2,15 +2,18 @@
 
 require 'rails_helper'
 
-class DummyClass
-  include Spree::Tax::TaxHelpers
-
-  def valid_rates(item)
-    rates_for_item(item)
-  end
-end
-
 RSpec.describe Spree::Tax::TaxHelpers do
+
+  before do
+    stub_const('DummyClass', (Class.new do
+      include Spree::Tax::TaxHelpers
+
+      def valid_rates(item)
+        rates_for_item(item)
+      end
+    end))
+  end
+
   let(:tax_category) { create(:tax_category) }
   let(:irrelevant_tax_category) { create(:tax_category) }
 

--- a/core/spec/models/spree/tax_rate_spec.rb
+++ b/core/spec/models/spree/tax_rate_spec.rb
@@ -145,43 +145,43 @@ RSpec.describe Spree::TaxRate, type: :model do
     end
 
     context "when the start date is in the past" do
-      let!(:rate) { create(:tax_rate, starts_at: 1.day.ago )}
+      let!(:rate) { create(:tax_rate, starts_at: 1.day.ago ) }
 
       it { is_expected.to eq([rate]) }
     end
 
     context "when the start date is in the future" do
-      let!(:rate) { create(:tax_rate, starts_at: 1.day.from_now )}
+      let!(:rate) { create(:tax_rate, starts_at: 1.day.from_now ) }
 
       it { is_expected.to be_empty }
     end
 
     context "when the expiry date is in the future" do
-      let!(:rate) { create(:tax_rate, expires_at: 1.day.from_now )}
+      let!(:rate) { create(:tax_rate, expires_at: 1.day.from_now ) }
 
       it { is_expected.to eq([rate]) }
     end
 
     context "when the expiry date is in the past" do
-      let!(:rate) { create(:tax_rate, expires_at: 1.day.ago )}
+      let!(:rate) { create(:tax_rate, expires_at: 1.day.ago ) }
 
       it { is_expected.to be_empty }
     end
 
     context "when the start date in the past and expiry date is in the future" do
-      let!(:rate) { create(:tax_rate, starts_at: 1.day.ago, expires_at: 1.day.from_now )}
+      let!(:rate) { create(:tax_rate, starts_at: 1.day.ago, expires_at: 1.day.from_now ) }
 
       it { is_expected.to eq([rate]) }
     end
 
     context "when the start date and expiry date are in the past" do
-      let!(:rate) { create(:tax_rate, starts_at: 1.day.ago, expires_at: 1.day.ago )}
+      let!(:rate) { create(:tax_rate, starts_at: 1.day.ago, expires_at: 1.day.ago ) }
 
       it { is_expected.to be_empty }
     end
 
     context "when the start date and expiry date are in the future" do
-      let!(:rate) { create(:tax_rate, starts_at: 1.day.from_now, expires_at: 1.day.from_now )}
+      let!(:rate) { create(:tax_rate, starts_at: 1.day.from_now, expires_at: 1.day.from_now ) }
 
       it { is_expected.to be_empty }
     end

--- a/core/spec/models/spree/tax_rate_spec.rb
+++ b/core/spec/models/spree/tax_rate_spec.rb
@@ -135,6 +135,58 @@ RSpec.describe Spree::TaxRate, type: :model do
     end
   end
 
+  context ".active" do
+    subject(:active_tax_rates) { Spree::TaxRate.active }
+
+    context "when the tax rate has no start or expiry date" do
+      let!(:rate) { create(:tax_rate) }
+
+      it { is_expected.to eq([rate]) }
+    end
+
+    context "when the start date is in the past" do
+      let!(:rate) { create(:tax_rate, starts_at: 1.day.ago )}
+
+      it { is_expected.to eq([rate]) }
+    end
+
+    context "when the start date is in the future" do
+      let!(:rate) { create(:tax_rate, starts_at: 1.day.from_now )}
+
+      it { is_expected.to be_empty }
+    end
+
+    context "when the expiry date is in the future" do
+      let!(:rate) { create(:tax_rate, expires_at: 1.day.from_now )}
+
+      it { is_expected.to eq([rate]) }
+    end
+
+    context "when the expiry date is in the past" do
+      let!(:rate) { create(:tax_rate, expires_at: 1.day.ago )}
+
+      it { is_expected.to be_empty }
+    end
+
+    context "when the start date in the past and expiry date is in the future" do
+      let!(:rate) { create(:tax_rate, starts_at: 1.day.ago, expires_at: 1.day.from_now )}
+
+      it { is_expected.to eq([rate]) }
+    end
+
+    context "when the start date and expiry date are in the past" do
+      let!(:rate) { create(:tax_rate, starts_at: 1.day.ago, expires_at: 1.day.ago )}
+
+      it { is_expected.to be_empty }
+    end
+
+    context "when the start date and expiry date are in the future" do
+      let!(:rate) { create(:tax_rate, starts_at: 1.day.from_now, expires_at: 1.day.from_now )}
+
+      it { is_expected.to be_empty }
+    end
+  end
+
   describe "#adjust" do
     let(:taxable_address) { create(:address) }
     let(:order) { create(:order_with_line_items, ship_address: order_address) }


### PR DESCRIPTION
**Description**
When calculating the tax for line items whose tax is included in the price, solidus uses TaxRates in the calculation even though they are invalid according to their start_date and/or end_date. This results in incorrect tax calculations if there are multiple tax rates for the same tax category and only some of them are currently valid.

This PR ensures that `TaxHelpers#rates_for_item` only returns tax rates that are currently valid. Before, it would return any tax rate that matched the items' tax category.

This addresses https://github.com/solidusio/solidus/issues/3766

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [ ] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
