### PR TITLE
Fix typo in comment in navigation_helper.rb

### DIFF
--- a/backend/app/helpers/spree/admin/navigation_helper.rb
+++ b/backend/app/helpers/spree/admin/navigation_helper.rb
@@ -7,7 +7,7 @@ module Spree
         @admin_breadcrumbs ||= []
       end
 
-      # Add items to current page breadcrumb heirarchy
+      # Add items to current page breadcrumb hierarchy
       def admin_breadcrumb(*ancestors, &block)
         admin_breadcrumbs.concat(ancestors) if ancestors.present?
         admin_breadcrumbs.push(capture(&block)) if block_given?


### PR DESCRIPTION
**Description**
Fixes a typo in comment in navigation_helper.rb.

No CI should be needed.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
