### PR TITLE
Make admin order event_links translatable

### DIFF
--- a/backend/app/helpers/spree/admin/orders_helper.rb
+++ b/backend/app/helpers/spree/admin/orders_helper.rb
@@ -8,11 +8,15 @@ module Spree
         links = []
         @order_events.sort.each do |event|
           next unless @order.send("can_#{event}?")
-          links << button_to(t(event, scope: 'spree'), [event, :admin, @order],
-                             method: :put,
-                             data: { confirm: t('spree.order_sure_want_to', event: t(event, scope: 'spree')) })
+          translated_event = t(event, scope: [:spree, :admin, :order, :events])
+          links << button_to(
+            translated_event,
+            [event, :admin, @order],
+            method: :put,
+            data: { confirm: t(:order_sure_want_to, event: translated_event, scope: :spree) }
+          )
         end
-        safe_join(links, '&nbsp;'.html_safe)
+        safe_join(links, "&nbsp;".html_safe)
       end
 
       def line_item_shipment_price(line_item, quantity)

--- a/backend/spec/helpers/admin/orders_helper_spec.rb
+++ b/backend/spec/helpers/admin/orders_helper_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Spree::Admin::OrdersHelper, type: :helper do
+  describe "#event_links" do
+    subject { helper.event_links }
+
+    before do
+      helper.class.include Spree::Admin::NavigationHelper
+      helper.class.include Spree::Core::Engine.routes.url_helpers
+      @order_events = %w{approve cancel resume}
+    end
+
+    context "with an uncompleted order" do
+      before do
+        @order = create(:order)
+      end
+
+      it "renders link to approve order" do
+        is_expected.to have_button("Approve")
+      end
+    end
+
+    context "with a complete order" do
+      before do
+        @order = create(:completed_order_with_totals)
+      end
+
+      it "renders link to approve order" do
+        is_expected.to have_button("Approve")
+      end
+
+      it "renders link to cancel order" do
+        is_expected.to have_button("Cancel")
+      end
+    end
+
+    context "with a canceled order" do
+      before do
+        @order = create(:completed_order_with_totals).tap(&:cancel!)
+      end
+
+      it "renders link to approve order" do
+        is_expected.to have_button("Approve")
+      end
+
+      it "renders link to resume order" do
+        is_expected.to have_button("Resume")
+      end
+    end
+  end
+end

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -852,6 +852,11 @@ en:
           drag_and_drop: or drag and drop them here
           image_process_failed: Server failed to process the image
           upload_images: Upload Images
+      order:
+        events:
+          approve: Approve
+          cancel: Cancel
+          resume: Resume
       payments:
         source_forms:
           storecredit:


### PR DESCRIPTION
**Description**

The admin/orders_helper event_links didn't had enough scope to be translatable for the particular order event. In some languages canceling and order is something different than clicking a "cancel" button in a form.

The solidus_i18n gem already has the translation scopes for these events, so I implemeted it that it will Just Work™

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
