### PR TITLE
Display billing address to left of shipping address

### DIFF
--- a/backend/app/views/spree/admin/orders/customer_details/_form.html.erb
+++ b/backend/app/views/spree/admin/orders/customer_details/_form.html.erb
@@ -41,6 +41,19 @@
   </fieldset>
 
   <div class="row">
+    <% if Spree::Config[:order_bill_address_used] %>
+      <div class="col-6" data-hook="bill_address_wrapper">
+        <fieldset class="no-border-bottom">
+          <legend align="center"><%= t('spree.billing_address') %></legend>
+          <div class="js-billing-address">
+            <%= f.fields_for :bill_address do |ba_form| %>
+              <%= render partial: 'spree/admin/shared/address_form', locals: { f: ba_form, type: "billing" } %>
+            <% end %>
+          </div>
+        </fieldset>
+      </div>
+    <% end %>
+
     <div class="col-6" data-hook="ship_address_wrapper">
       <fieldset class="no-border-bottom">
         <legend align="center"><%= t('spree.shipping_address') %></legend>
@@ -62,19 +75,6 @@
         </div>
       </fieldset>
     </div>
-
-    <% if Spree::Config[:order_bill_address_used] %>
-      <div class="col-6" data-hook="bill_address_wrapper">
-        <fieldset class="no-border-bottom">
-          <legend align="center"><%= t('spree.billing_address') %></legend>
-          <div class="js-billing-address">
-            <%= f.fields_for :bill_address do |ba_form| %>
-              <%= render partial: 'spree/admin/shared/address_form', locals: { f: ba_form, type: "billing" } %>
-            <% end %>
-          </div>
-        </fieldset>
-      </div>
-    <% end %>
   </div>
 
   <div class="clear"></div>


### PR DESCRIPTION
This makes the backend views consistent with the frontend.

Fixes #3771.

Old view:

<img width="842" alt="Screen Shot 2020-09-24 at 10 09 16 AM" src="https://user-images.githubusercontent.com/2460418/94177403-51b5e200-fe4e-11ea-855e-69830581416a.png">

New view:

<img width="865" alt="Screen Shot 2020-09-24 at 10 09 35 AM" src="https://user-images.githubusercontent.com/2460418/94177428-57132c80-fe4e-11ea-834b-283734d75bfd.png">


**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
