### PR TITLE
Add hint to tax category default checkbox

### DIFF
--- a/backend/app/views/spree/admin/tax_categories/_form.html.erb
+++ b/backend/app/views/spree/admin/tax_categories/_form.html.erb
@@ -18,6 +18,7 @@
       <label>
         <%= f.check_box :is_default %>
         <%= Spree::TaxCategory.human_attribute_name(:is_default) %>
+        <%= f.field_hint :is_default %>
       </label>
     <% end %>
   </div>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1443,6 +1443,8 @@ en:
           (orders which don't yet have an address).<br/> Default: None."
         code: 'An identifier for your store. Developers may need this value if you operate
           multiple storefronts.'
+      spree/tax_category:
+        is_default: 'When checked, this tax category will be selected by default when creating new products or variants.'
       spree/tax_rate:
         validity_period: This determines the validity period within which the tax
           rate is valid and will be applied to eligible items. <br /> If no start


### PR DESCRIPTION
**Description**

This adds a hint to the default checkbox on the tax category form.

![Screen Shot 2020-09-25 at 2 29 53 PM](https://user-images.githubusercontent.com/3756/94303344-a8e5b080-ff3b-11ea-9387-b9ecf84b1834.png)

Ref: #3774

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
