### PR TITLE
Add link to stock movements page from variant stock display

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/stock_management.js
+++ b/backend/app/assets/javascripts/spree/backend/stock_management.js
@@ -7,6 +7,8 @@ Spree.ready(function() {
     new Spree.Views.Stock.EditStockItemRow({
       el: $el,
       stockLocationName: $el.data('stock-location-name'),
+      stockLocationId: $el.data("stock-item").stock_location_id,
+      variantSku: $el.data("variant-sku"),
       model: model
     });
 

--- a/backend/app/assets/javascripts/spree/backend/templates/stock_items/stock_location_stock_item.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/stock_items/stock_location_stock_item.hbs
@@ -1,4 +1,8 @@
-<td class="stock-location-name">{{stockLocationName}}</td>
+<td class="stock-location-name">
+  <a href="/admin/stock_locations/{{stockLocationId}}/stock_movements?q%5Bvariant_sku_eq%5D={{variantSku}}">
+    {{stockLocationName}}
+  </a>
+</td>
 <td class="align-center">
   <input id="backorderable-{{id}}"
          name="backorderable"

--- a/backend/app/assets/javascripts/spree/backend/views/stock/edit_stock_item_row.js
+++ b/backend/app/assets/javascripts/spree/backend/views/stock/edit_stock_item_row.js
@@ -3,6 +3,8 @@ Spree.Views.Stock.EditStockItemRow = Backbone.View.extend({
 
   initialize: function(options) {
     this.stockLocationName = options.stockLocationName;
+    this.stockLocationId = options.stockLocationId;
+    this.variantSku = options.variantSku;
     this.negative = this.model.attributes.count_on_hand < 0;
     this.previousAttributes = _.clone(this.model.attributes);
     this.listenTo(this.model, 'sync', this.onSuccess);
@@ -22,6 +24,8 @@ Spree.Views.Stock.EditStockItemRow = Backbone.View.extend({
   render: function() {
     var renderAttr = {
       stockLocationName: this.stockLocationName,
+      stockLocationId: this.stockLocationId,
+      variantSku: this.variantSku,
       editing: this.editing,
       negative: this.negative
     };

--- a/backend/app/views/spree/admin/stock_items/_stock_management.html.erb
+++ b/backend/app/views/spree/admin/stock_items/_stock_management.html.erb
@@ -72,7 +72,7 @@
             </colgroup>
             <% variant.stock_items.each do |item| %>
               <% if @stock_item_stock_locations.include?(item.stock_location) %>
-                <tr class="js-edit-stock-item stock-item-edit-row" data-variant-id="<%= variant.id %>" data-stock-item="<%= item.to_json %>" data-stock-location-name="<%= item.stock_location.name %>" data-track-inventory="<%= variant.should_track_inventory? %>" data-can-edit="<%= can?(:admin, Spree::StockItem) %>">
+                <tr class="js-edit-stock-item stock-item-edit-row" data-variant-id="<%= variant.id %>" data-stock-item="<%= item.to_json %>" data-stock-location-name="<%= item.stock_location.name %>" data-track-inventory="<%= variant.should_track_inventory? %>" data-can-edit="<%= can?(:admin, Spree::StockItem) %>" data-variant-sku="<%= variant.sku %>">
                   <%# This is rendered in JS %>
                 </tr>
               <% end %>

--- a/backend/spec/features/admin/products/stock_management_spec.rb
+++ b/backend/spec/features/admin/products/stock_management_spec.rb
@@ -41,6 +41,10 @@ describe "Product Stock", type: :feature do
       end
     end
 
+    it "contains a link to recent stock movements", js: true do
+      expect(page).to have_link(nil, href: "/admin/stock_locations/#{stock_location.id}/stock_movements?q%5Bvariant_sku_eq%5D=#{variant.sku}")
+    end
+
     it "can create a positive stock adjustment", js: true do
       adjust_count_on_hand('14')
       stock_item.reload


### PR DESCRIPTION
**Description**
ref: #3666 

Adds a link to the stock movements page from the individual variant stock displays. Because of the work already done on #3666, this page will show recent stock movements for whatever variant you clicked on. 

<img width="1199" alt="Screen Shot 2020-09-25 at 2 56 39 PM" src="https://user-images.githubusercontent.com/5720486/94310656-966d7600-ff3f-11ea-87b8-a09942a427c6.png">

<img width="1242" alt="Screen Shot 2020-09-25 at 2 58 17 PM" src="https://user-images.githubusercontent.com/5720486/94310663-979ea300-ff3f-11ea-8b8b-5d59da39192d.png">

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
