### PR TITLE
Make spelling of 'email' consistent

### DIFF
--- a/backend/spec/features/admin/orders/customer_details_spec.rb
+++ b/backend/spec/features/admin/orders/customer_details_spec.rb
@@ -140,7 +140,7 @@ describe "Customer Details", type: :feature, js: true do
         click_button "Update"
         expect(page).to have_content 'Customer Details Updated'
         click_link "Customer"
-        expect(page).to have_field 'Customer E-Mail', with: order.reload.email
+        expect(page).to have_field 'Customer Email', with: order.reload.email
         within '#order_user_link' do
           expect(page).to have_link user.email
         end

--- a/backend/spec/features/admin/orders/new_order_spec.rb
+++ b/backend/spec/features/admin/orders/new_order_spec.rb
@@ -245,7 +245,7 @@ describe "New Order", type: :feature do
     it "displays the user's email escaped without executing" do
       click_on "Customer"
       targetted_select2_search user.email, from: "#s2id_customer_search"
-      expect(page).to have_field("Customer E-Mail", with: xss_string)
+      expect(page).to have_field("Customer Email", with: xss_string)
     end
   end
 

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -116,7 +116,7 @@ en:
         considered_risky: Risky
         coupon_code: Coupon Code
         created_at: Order Date
-        email: Customer E-Mail
+        email: Customer Email
         included_tax_total: Tax (incl.)
         ip_address: IP Address
         item_total: Item Total

--- a/frontend/spec/features/checkout_spec.rb
+++ b/frontend/spec/features/checkout_spec.rb
@@ -625,7 +625,7 @@ describe "Checkout", type: :feature, inaccessible: true do
         state_name_css = "order_bill_address_attributes_state_name"
 
         select "Canada", from: "order_bill_address_attributes_country_id"
-        fill_in 'Customer E-Mail', with: 'test@example.com'
+        fill_in 'Customer Email', with: 'test@example.com'
         fill_in state_name_css, with: xss_string
         fill_in "Zip", with: "H0H0H0"
 

--- a/frontend/spec/features/first_order_promotion_spec.rb
+++ b/frontend/spec/features/first_order_promotion_spec.rb
@@ -40,7 +40,7 @@ RSpec.feature "First Order promotion" do
     click_button "Apply Code"
     expect(page).to have_content("The coupon code was successfully applied to your order")
     click_on "Checkout"
-    fill_in "Customer E-Mail", with: "sam@tom.com"
+    fill_in "Customer Email", with: "sam@tom.com"
     fill_in_address
     click_on "Save and Continue"
     expect(page).to_not have_content("#summary-order-charges")


### PR DESCRIPTION
**Description**
I noticed that the codebase and English localization consistently use the spelling "Email" (or "email"), except for in one place where it used the spelling "E-Mail". For the sake of consistency, this PR changes the one hyphenated spelling so that we are consistent across all of Solidus.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
