### PR TITLE
Update order cancellation, sets inventory units to canceled

### DIFF
--- a/core/lib/spree/core/state_machines/inventory_unit.rb
+++ b/core/lib/spree/core/state_machines/inventory_unit.rb
@@ -34,6 +34,14 @@ module Spree
             event :cancel do
               transition to: :canceled, from: ::Spree::InventoryUnit::CANCELABLE_STATES.map(&:to_sym)
             end
+
+            event :on_hand do
+              transition to: :on_hand, from: :canceled
+            end
+
+            event :backorder do
+              transition to: :backordered, from: :canceled
+            end
           end
         end
       end

--- a/core/lib/spree/core/state_machines/shipment.rb
+++ b/core/lib/spree/core/state_machines/shipment.rb
@@ -38,10 +38,10 @@ module Spree
             after_transition to: :canceled, do: :after_cancel
 
             event :resume do
-              transition from: :canceled, to: :ready, if: :can_transition_from_canceled_to_ready?
               transition from: :canceled, to: :pending
             end
             after_transition from: :canceled, to: [:pending, :ready, :shipped], do: :after_resume
+            after_transition from: :canceled, to: :pending, do: :update_state
 
             after_transition do |shipment, transition|
               shipment.state_changes.create!(


### PR DESCRIPTION
This PR fix #3719.

Before this commit when an order was canceled the inventory units
of the order will remain untouched. So there were canceled orders with
inventory units with the state on_hand or backordered.

This situation was not only inconsistent but can lead to subtle bugs
with the stock management system.
How to reproduce the bug: 

- Create an order for a single variant, but select a number of items greater than the available amount.
- The order generates 2 shipments, one with the inventory units on_hand and one with the inventory units back-ordered.
- Cancel the order.
- The inventory units on_hand remains on_hand.
- The inventory units back-ordered go to the on_hand state. 
- If you resume the order all the inventory units will be on_hand, and the shipment will be ready to be shipped.

This problem is caused by the fact that when the order is canceled, a movement is created to restock the stock_item correlated with the inventory_units. As soon as the stock_items get back to a positive value it will try to convert as much as possible back-ordered inventory units to on_hand.

<img width="1148" alt="order_complete_before" src="https://user-images.githubusercontent.com/4471596/94431682-e5ace400-0195-11eb-97dd-3ba1fba8e944.png">
<img width="1142" alt="order_canceled_before" src="https://user-images.githubusercontent.com/4471596/94431697-e9406b00-0195-11eb-9912-68b7f955f595.png">
<img width="1152" alt="order_resumed_before" src="https://user-images.githubusercontent.com/4471596/94431699-e9d90180-0195-11eb-9455-865c09a897eb.png">

With this commit the inventory units related to an order are canceled when the order is canceled.

When an order is resumed we recalculate the state of the connected
inventory units, based on the actual stocks available.

<img width="1223" alt="order_complete_after" src="https://user-images.githubusercontent.com/4471596/94435016-e300bd80-019a-11eb-9e7c-bdda821095c4.png">
<img width="1223" alt="order_canceled_after" src="https://user-images.githubusercontent.com/4471596/94435012-e2682700-019a-11eb-991a-11f39a3b5f47.png">
<img width="1223" alt="order_resumed_after" src="https://user-images.githubusercontent.com/4471596/94434999-ded4a000-019a-11eb-8468-1a84013d5901.png">

What do you think about this issue, and my solution?
I'm not sure that the testing is enough, probably I can add an E2E test, what do you think? any idea on what can be the best place to put this test?

**Checklist:**
- [X] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [X] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [X] I have added tests to cover this change (if needed)
- [X] I have attached screenshots to this PR for visual changes (if needed)
