### PR TITLE
Show the admin/settings menu for any of its elements

### DIFF
--- a/backend/lib/spree/backend_configuration.rb
+++ b/backend/lib/spree/backend_configuration.rb
@@ -131,7 +131,20 @@ module Spree
         MenuItem.new(
           CONFIGURATION_TABS,
           'wrench',
-          condition: -> { can?(:admin, Spree::Store) },
+          condition: -> {
+            can?(:admin, Spree::Store) ||
+            can?(:show, Spree::AdjustmentReason) ||
+            can?(:show, Spree::PaymentMethod) ||
+            can?(:show, Spree::RefundReason) ||
+            can?(:show, Spree::ReimbursementType) ||
+            can?(:show, Spree::ShippingCategory) ||
+            can?(:show, Spree::ShippingMethod) ||
+            can?(:show, Spree::StockLocation) ||
+            can?(:show, Spree::TaxCategory) ||
+            can?(:show, Spree::TaxRate) ||
+            can?(:show, Spree::ReturnReason) ||
+            can?(:show, Spree::Zone)
+          },
           label: :settings,
           partial: 'spree/admin/shared/settings_sub_menu',
           url: :admin_stores_path,

--- a/backend/spec/features/admin/homepage_spec.rb
+++ b/backend/spec/features/admin/homepage_spec.rb
@@ -73,6 +73,8 @@ describe "Homepage", type: :feature do
     custom_authorization! do |_user|
       can [:admin, :home], :dashboards
       can [:admin, :edit, :index, :show], Spree::Order
+      cannot [:show], Spree::StockLocation
+      cannot [:show], Spree::Zone
     end
 
     it 'should only display tabs fakedispatch has access to' do

--- a/backend/spec/lib/spree/backend_configuration_spec.rb
+++ b/backend/spec/lib/spree/backend_configuration_spec.rb
@@ -18,5 +18,26 @@ RSpec.describe Spree::BackendConfiguration do
         expect(stock_menu_item.match_path).to eq('/stock_items')
       end
     end
+
+    describe 'menu tab for settings' do
+      let(:menu_item) { subject.find { |item| item.label == :settings } }
+      let(:view) { double("view") }
+
+      it 'is shown if any of its submenus are present' do
+        allow(view).to receive(:can?).and_return(true, false)
+
+        result = view.instance_exec(&menu_item.condition)
+
+        expect(result).to eq(true)
+      end
+
+      it 'is not shown if none of its submenus are present' do
+        expect(view).to receive(:can?).exactly(12).times.and_return(false)
+
+        result = view.instance_exec(&menu_item.condition)
+
+        expect(result).to eq(false)
+      end
+    end
   end
 end


### PR DESCRIPTION
**Description**

It's possible to create permission sets the only give access to a
subset of the settings menu items, without this the settings menu was
kept hidden.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
