### PR TITLE
Update backend New Image link for consistency

### DIFF
--- a/backend/app/views/spree/admin/images/index.html.erb
+++ b/backend/app/views/spree/admin/images/index.html.erb
@@ -5,7 +5,9 @@
 
 <% content_for :page_actions do %>
   <% if can?(:create, Spree::Image) %>
-    <li><%= link_to_with_icon('plus', t('spree.new_image'), new_admin_product_image_url(@product), id: 'new_image_link', class: 'btn btn-primary') %></li>
+    <li>
+      <%= link_to t('spree.new_image'), new_admin_product_image_url(@product), id: 'new_image_link', class: 'btn btn-primary' %>
+    </li>
   <% end %>
 <% end %>
 


### PR DESCRIPTION
This makes the New Image link consistent with visual style of other backend views.

Other Views:

<img width="110" alt="Screen Shot 2020-10-03 at 5 31 58 PM" src="https://user-images.githubusercontent.com/2460418/95004304-57be6800-059e-11eb-8ebf-4e1207fcbb65.png">

<img width="158" alt="Screen Shot 2020-10-03 at 5 32 07 PM" src="https://user-images.githubusercontent.com/2460418/95004306-5db44900-059e-11eb-94eb-0cd35b5d180e.png">

Current Behavior:

<img width="139" alt="Screen Shot 2020-10-03 at 5 31 40 PM" src="https://user-images.githubusercontent.com/2460418/95004301-4e350000-059e-11eb-8b20-5c445aec3f5a.png">

New Behavior:

<img width="137" alt="Screen Shot 2020-10-03 at 5 33 07 PM" src="https://user-images.githubusercontent.com/2460418/95004317-82102580-059e-11eb-9985-e7dd924d4b43.png">


**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
