### PR TITLE
Explicitly require spree/auth_configuration

### DIFF
--- a/core/lib/spree/testing_support/authorization_helpers.rb
+++ b/core/lib/spree/testing_support/authorization_helpers.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'cancan'
+require 'spree/auth_configuration'
 
 module Spree
   module TestingSupport


### PR DESCRIPTION
**Description**
Otherwise the corresponding constant will be autoloaded during
initialization, causing in turn a warning from Rails 6 / Zeitwerk.


```
DEPRECATION WARNING: Initialization autoloaded the constant Spree::AuthConfiguration.

Being able to do this is deprecated. Autoloading during initialization is going
to be an error condition in future versions of Rails.

Reloading does not reboot the application, and therefore code executed during
initialization does not run again. So, if you reload Spree::AuthConfiguration, for example,
the expected changes won't be reflected in that stale Class object.

This autoloaded constant has been unloaded.

Please, check the "Autoloading and Reloading Constants" guide for solutions.
 (called from <top (required)> at /********/config/environment.rb:5)

Randomized with seed 9913
```

**Checklist:**
- [ ] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [ ] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
