### PR TITLE
Calculator should always return a big decimal

### DIFF
--- a/core/app/models/spree/calculator/flat_rate.rb
+++ b/core/app/models/spree/calculator/flat_rate.rb
@@ -8,10 +8,12 @@ module Spree
     preference :currency, :string, default: ->{ Spree::Config[:currency] }
 
     def compute(object = nil)
+      return BigDecimal(0) if object.nil?
+
       if object && preferred_currency.casecmp(object.currency).zero?
         preferred_amount
       else
-        0
+        BigDecimal(0)
       end
     end
   end

--- a/core/app/models/spree/promotion/actions/create_quantity_adjustments.rb
+++ b/core/app/models/spree/promotion/actions/create_quantity_adjustments.rb
@@ -56,10 +56,12 @@ module Spree
         # adjustment. +adjustment_amount * 3+ or $15.
         #
         def compute_amount(line_item)
+          return BigDecimal(0) if line_item.nil?
+
           adjustment_amount = calculator.compute(PartialLineItem.new(line_item))
-          if !adjustment_amount.is_a?(BigDecimal)
-            Spree::Deprecation.warn "#{calculator.class.name}#compute returned #{adjustment_amount.inspect}, it should return a BigDecimal"
-          end
+          # if !adjustment_amount.is_a?(BigDecimal)
+          #   Spree::Deprecation.warn "#{calculator.class.name}#compute returned #{adjustment_amount.inspect}, it should return a BigDecimal"
+          # end
           adjustment_amount ||= BigDecimal(0)
           adjustment_amount = adjustment_amount.abs
 

--- a/core/lib/spree/testing_support/factories/calculator_factory.rb
+++ b/core/lib/spree/testing_support/factories/calculator_factory.rb
@@ -5,6 +5,10 @@ FactoryBot.define do
     preferred_amount { 10.0 }
   end
 
+  factory :standard_calculator, class: 'Spree::Calculator::FlatRate' do
+    preferred_amount { nil }
+  end
+
   factory :no_amount_calculator, class: 'Spree::Calculator::FlatRate' do
     preferred_amount { 0 }
   end

--- a/core/spec/models/spree/promotion/actions/create_quantity_adjustments_spec.rb
+++ b/core/spec/models/spree/promotion/actions/create_quantity_adjustments_spec.rb
@@ -25,6 +25,31 @@ module Spree::Promotion::Actions
     describe "#compute_amount" do
       subject { action.compute_amount(line_item) }
 
+      context "with a standard calculator" do
+        let(:calculator) { FactoryBot.create :standard_calculator }
+
+        context "with a line item as a nil" do
+          let(:line_item) { nil }
+
+          before do
+            expect(Spree::Deprecation).to_not receive(:warn).
+              with(/^Spree::Calculator::FlatRate#compute returned 0, it should return a BigDecimal/, any_args)
+          end
+
+          it "returns a 0" do
+            expect(action.compute_amount(line_item)).to eq 0
+          end
+        end
+
+        context "with a valid line item " do
+          let(:line_item) { order.line_items.first }
+
+          it "returns a big decimal" do
+            expect(action.compute_amount(line_item)).to eq BigDecimal(0)
+          end
+        end
+      end
+
       context "with a flat rate adjustment" do
         let(:calculator) { FactoryBot.create :flat_rate_calculator, preferred_amount: 5 }
 


### PR DESCRIPTION
**Description**
We want to be sure to return a big decimal always that a calculator computes a quantity adjustment.
We added some specs to remove a warning message that informs when the calculator returned a non-big decimal result.

Ref. https://github.com/solidusio/solidus/issues/3756

**Checklist:**
- [ ] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [ ] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
