### PR TITLE
Remove CSS resizing logo when menu collapses

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/components/_navigation.scss
+++ b/backend/app/assets/stylesheets/spree/backend/components/_navigation.scss
@@ -64,10 +64,6 @@ $padding-y-navbar-submenu: 9px;
 
   .brand-link {
     overflow: hidden;
-
-    img {
-      max-width: 125px;
-    }
   }
 
   .admin-nav-menu {


### PR DESCRIPTION
**Description**
<!--
  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

  Please include screenshots in case of visual changes to the frontend or backend sections of Solidus.

  If needed you can reference another PR or issue here, e.g.:
  Ref #ISSUE
-->

This seemed unintentional, the logo should probably not shrink when the menu collapses?

Before:
![Peek 2020-10-07 23-18](https://user-images.githubusercontent.com/11466782/95414429-7e103a80-08f3-11eb-9618-ae73c96e9e0b.gif)

After:
![Peek 2020-10-07 23-182](https://user-images.githubusercontent.com/11466782/95414430-7ea8d100-08f3-11eb-8789-9e67d6fe6a00.gif)

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
~- [ ] I have updated Guides and README accordingly to this change (if needed)~
~- [ ] I have added tests to cover this change (if needed)~
- [x] I have attached screenshots to this PR for visual changes (if needed)
