### PR TITLE
Add discontinue on to products

### DIFF
--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -83,6 +83,17 @@
         <% end %>
       </div>
 
+      <div data-hook="admin_product_form_discontinue_on">
+        <%= f.field_container :discontinue_on do %>
+          <%= f.label :discontinue_on %>
+          <%= f.field_hint :discontinue_on %>
+
+          <%= render "spree/admin/shared/datepicker", f: f, date_attr: :discontinue_on %>
+
+          <%= f.error_message_on :discontinue_on %>
+        <% end %>
+      </div>
+
       <div data-hook="admin_product_form_promotionable">
         <%= f.field_container :promotionable do %>
           <label>

--- a/backend/spec/features/admin/products/products_spec.rb
+++ b/backend/spec/features/admin/products/products_spec.rb
@@ -287,6 +287,14 @@ describe "Products", type: :feature do
         expect(page).to have_content("successfully updated!")
         expect(Spree::Product.last.available_on).to eq('Tue, 25 Dec 2012 00:00:00 UTC +00:00')
       end
+
+      it 'should correctly update discontinue_on' do
+        visit spree.admin_product_path(product)
+        fill_in "product_discontinue_on", with: "2020/12/4"
+        click_button "Update"
+        expect(page).to have_content("successfully updated!")
+        expect(product.reload.discontinue_on.to_s).to eq('2020-12-04 00:00:00 UTC')
+      end
     end
 
     context 'deleting a product', js: true do

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -168,11 +168,13 @@ module Spree
     end
 
     # Determines if product is available. A product is available if it has not
-    # been deleted and the available_on date is in the past.
+    # been deleted, the available_on date is in the past
+    # and the discontinue_on date is nil or in the future.
     #
     # @return [Boolean] true if this product is available
     def available?
-      !deleted? && available_on&.past?
+      !deleted? && available_on&.past? &&
+        (discontinue_on.nil? || discontinue_on.future?)
     end
 
     # Groups variants by the specified option type.

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -173,8 +173,17 @@ module Spree
     #
     # @return [Boolean] true if this product is available
     def available?
-      !deleted? && available_on&.past? &&
-        (discontinue_on.nil? || discontinue_on.future?)
+      !deleted? && available_on&.past? && !discontinued?
+    end
+
+    # Determines if product is discontinued.
+    #
+    # A product is discontinued if the discontinue_on date
+    # is not nil and in the past.
+    #
+    # @return [Boolean] true if this product is discontinued
+    def discontinued?
+      !!discontinue_on&.past?
     end
 
     # Groups variants by the specified option type.

--- a/core/app/models/spree/product/scopes.rb
+++ b/core/app/models/spree/product/scopes.rb
@@ -184,7 +184,10 @@ module Spree
           end
           # Can't use add_search_scope for this as it needs a default argument
           def self.available(available_on = nil)
-            with_master_price.where("#{Spree::Product.quoted_table_name}.available_on <= ?", available_on || Time.current)
+            with_master_price
+              .where("#{Spree::Product.quoted_table_name}.available_on <= ?", available_on || Time.current)
+              .where("#{Spree::Product.quoted_table_name}.discontinue_on IS NULL OR" \
+                     "#{Spree::Product.quoted_table_name}.discontinue_on >= ?", Time.current)
           end
           search_scopes << :available
 

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -33,8 +33,8 @@ module Spree
     belongs_to :product, -> { with_discarded }, touch: true, class_name: 'Spree::Product', inverse_of: :variants, optional: false
     belongs_to :tax_category, class_name: 'Spree::TaxCategory', optional: true
 
-    delegate :name, :description, :slug, :available_on, :discontinue_on, :shipping_category_id,
-             :meta_description, :meta_keywords, :shipping_category,
+    delegate :name, :description, :slug, :available_on, :discontinue_on, :discontinued?,
+             :shipping_category_id, :meta_description, :meta_keywords, :shipping_category,
              to: :product
     delegate :tax_category, to: :product, prefix: true
     delegate :tax_rates, to: :tax_category

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -33,7 +33,7 @@ module Spree
     belongs_to :product, -> { with_discarded }, touch: true, class_name: 'Spree::Product', inverse_of: :variants, optional: false
     belongs_to :tax_category, class_name: 'Spree::TaxCategory', optional: true
 
-    delegate :name, :description, :slug, :available_on, :shipping_category_id,
+    delegate :name, :description, :slug, :available_on, :discontinue_on, :shipping_category_id,
              :meta_description, :meta_keywords, :shipping_category,
              to: :product
     delegate :tax_category, to: :product, prefix: true

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1413,6 +1413,9 @@ en:
         available_on: This sets the availability date for the product. If this value
           is not set, or it is set to a date in the future, then the product is not
           available on the storefront.
+        discontinue_on: This sets the discontinue date for the product. If this value
+          is set to a date, then the product is not available on the storefront from
+          that day on anymore.
         promotionable: 'This determines whether or not promotions can apply to this
           product.<br/>Default: Checked'
         shipping_category: 'This determines what kind of shipping this product requires.<br/>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -177,6 +177,7 @@ en:
         cost_price: Cost Price
         depth: Depth
         description: Description
+        discontinue_on: Discontinue on
         height: Height
         master_price: Master Price
         meta_description: Meta Description

--- a/core/db/migrate/20201008213609_add_discontinue_on_to_spree_products.rb
+++ b/core/db/migrate/20201008213609_add_discontinue_on_to_spree_products.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDiscontinueOnToSpreeProducts < ActiveRecord::Migration[5.2]
+  def change
+    add_column :spree_products, :discontinue_on, :datetime
+  end
+end

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -69,7 +69,7 @@ module Spree
     @@product_properties_attributes = [:property_name, :value, :position]
 
     @@product_attributes = [
-      :name, :description, :available_on, :permalink, :meta_description,
+      :name, :description, :available_on, :discontinue_on, :permalink, :meta_description,
       :meta_keywords, :price, :sku, :deleted_at,
       :option_values_hash, :weight, :height, :width, :depth,
       :shipping_category_id, :tax_category_id,

--- a/core/spec/models/spree/product/scopes_spec.rb
+++ b/core/spec/models/spree/product/scopes_spec.rb
@@ -124,6 +124,28 @@ RSpec.describe "Product scopes", type: :model do
         expect(Spree::Product.available).to match_array([product])
       end
 
+      context "with no discontinue_on" do
+        it "includes the product" do
+          expect(Spree::Product.available).to match_array([product])
+        end
+      end
+
+      context "with future discontinue_on" do
+        before { product.update!(discontinue_on: 1.day.from_now) }
+
+        it "includes the product" do
+          expect(Spree::Product.available).to match_array([product])
+        end
+      end
+
+      context "with past discontinue_on" do
+        before { product.update!(discontinue_on: 1.day.ago) }
+
+        it "doesn't include the product" do
+          expect(Spree::Product.available).to match_array([])
+        end
+      end
+
       context "with no master price" do
         before { product.master.prices.delete_all }
 

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -162,23 +162,61 @@ RSpec.describe Spree::Product, type: :model do
       end
     end
 
-    context "#available?" do
-      it "should be available if date is in the past" do
-        product.available_on = 1.day.ago
-        expect(product).to be_available
+    describe "#available?" do
+      context "if available_on is in the past" do
+        let(:product) { build(:product, available_on: 1.day.ago) }
+
+        it "should be available" do
+          expect(product).to be_available
+        end
       end
 
-      it "should not be available if date is nil or in the future" do
-        product.available_on = nil
-        expect(product).not_to be_available
+      context "if available_on is nil" do
+        let(:product) { build(:product, available_on: nil) }
 
-        product.available_on = 1.day.from_now
-        expect(product).not_to be_available
+        it "should not be available" do
+          expect(product).not_to be_available
+        end
       end
 
-      it "should not be available if soft-destroyed" do
-        product.discard
-        expect(product).not_to be_available
+      context "if available_on is in the future" do
+        let(:product) { build(:product, available_on: 1.day.from_now) }
+
+        it "should not be available" do
+          expect(product).not_to be_available
+        end
+      end
+
+      context "if discontinue_on is in the past" do
+        let(:product) { build(:product, discontinue_on: 1.day.ago) }
+
+        it "should not be available" do
+          expect(product).not_to be_available
+        end
+      end
+
+      context "if discontinue_on is nil" do
+        let(:product) { build(:product, discontinue_on: nil) }
+
+        it "should be available" do
+          expect(product).to be_available
+        end
+      end
+
+      context "if discontinue_on is in the future" do
+        let(:product) { build(:product, discontinue_on: 1.day.from_now) }
+
+        it "should be available" do
+          expect(product).to be_available
+        end
+      end
+
+      context "if deleted" do
+        let(:product) { build(:product, deleted_at: 1.day.ago) }
+
+        it "should not be available" do
+          expect(product).not_to be_available
+        end
       end
     end
 

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -220,6 +220,28 @@ RSpec.describe Spree::Product, type: :model do
       end
     end
 
+    describe "#discontinued?" do
+      subject { product.discontinued? }
+
+      context "if discontinue_on is in the past" do
+        let(:product) { build(:product, discontinue_on: 1.day.ago) }
+
+        it { is_expected.to be(true) }
+      end
+
+      context "if discontinue_on is nil" do
+        let(:product) { build(:product, discontinue_on: nil) }
+
+        it { is_expected.to be(false) }
+      end
+
+      context "if discontinue_on is in the future" do
+        let(:product) { build(:product, discontinue_on: 1.day.from_now) }
+
+        it { is_expected.to be(false) }
+      end
+    end
+
     context "variants_and_option_values" do
       let!(:high) { create(:variant, product: product) }
       let!(:low) { create(:variant, product: product) }

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -17,6 +17,11 @@ RSpec.describe Spree::Variant, type: :model do
       expect(product).to receive(:discontinue_on)
       variant.discontinue_on
     end
+
+    it 'discontinued? to product' do
+      expect(product).to receive(:discontinued?)
+      variant.discontinued?
+    end
   end
 
   context "validations" do

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -9,6 +9,16 @@ RSpec.describe Spree::Variant, type: :model do
 
   it_behaves_like 'default_price'
 
+  describe 'delegates' do
+    let(:product) { build(:product) }
+    let(:variant) { build(:variant, product: product) }
+
+    it 'discontinue_on to product' do
+      expect(product).to receive(:discontinue_on)
+      variant.discontinue_on
+    end
+  end
+
   context "validations" do
     it "should validate price is greater than 0" do
       variant.price = -1


### PR DESCRIPTION
**Description**

Adds a `discontinue_on` attribute to products. This accompanies the `available_on` attribute to complete the "Time Based Availability" feature. The `Product.available` scope and `Product#avaliable?` method take this new date filed into account to calculate the availability of products.

Refs #465

![Monosnap 2020-10-09 12-55-16](https://user-images.githubusercontent.com/42868/95575283-b5373680-0a2e-11eb-8f6e-dde2a9469ec5.png)

_Note_ 

Contrary to the suggestions in #465 I used the `discontinue_on` attribute introduced in Spree 3.1 for compatibility reasons. If we think this is a mistake we can also rename the attribute, but this will make migrations for former Spree users harder.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change
- [x] I have added tests to cover this change
- [x] I have attached screenshots to this PR for visual changes
