### PR TITLE
Allow builds with Rails master to fail on Circle CI

### DIFF
--- a/bin/build-ci
+++ b/bin/build-ci
@@ -95,7 +95,7 @@ class Project
       log("- #{project.name} #{build ? 'SUCCESS' : 'FAILURE'}")
     end
 
-    builds.all?
+    builds.all? || ENV['RAILS_VERSION'] == 'master'
   end
   private_class_method :test
 


### PR DESCRIPTION
Do not fail the circle ci step if the `RAILS_VERSION` is set to `master`.

It is not very welcoming for contributors to get a mail from Circle CI that the build has failed, just because we also test for latest unreleased version of Rails

<img width="298" alt=" build (d5a7dc4) — Inbox 2020-10-09 23-44-07" src="https://user-images.githubusercontent.com/42868/95634119-6ff42280-0a89-11eb-9ba8-0c86af97913c.png">

Also the list of open PRs looks a bit discouraging with all of them failing.

<img width="332" alt="solidus 2020-10-09 23-46-18" src="https://user-images.githubusercontent.com/42868/95634225-aaf65600-0a89-11eb-91bf-59b3829152fc.png">

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
