### PR TITLE
Disable Rails master builds on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,7 @@ workflows:
       - mysql
       - postgres_rails52
       - mysql_rails52
-      - postgres_rails_master_activestorage
+      # - postgres_rails_master_activestorage
       - stoplight/push:
           context: "Solidus Core Team"
           project: solidus/solidus-api


### PR DESCRIPTION
They are failing all the time and should not fail a PR. Since we
do not know how to send neutral status checks we should remove
them.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
