### PR TITLE
Try another CircleCI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,23 @@ commands:
       - store_test_results:
           path: /tmp/test-results
 
+  test_without_failing:
+    steps:
+      - run:
+          name: Run Tests
+          command: ./bin/build-ci test || circleci-agent step halt
+
+      - store_artifacts:
+          path: /tmp/test-artifacts
+          destination: test-artifacts
+
+      - store_artifacts:
+          path: /tmp/test-results
+          destination: raw-test-output
+
+      - store_test_results:
+          path: /tmp/test-results
+
 jobs:
   persist_version:
     executor: base
@@ -110,7 +127,7 @@ jobs:
       ENABLE_ACTIVE_STORAGE: true
     steps:
       - setup
-      - test
+      - test_without_failing
 
   mysql:
     executor: mysql


### PR DESCRIPTION
Sorry, I tried to make it on our fork to try a CircleCI configuration for #3796 but instead, make it on the official repository...

This keeps the spec running against rails master, but fake the result. I don't think what you prefer : 
1. not having automated test on rails master
2. having spec that are wrongly green and need to check the output to know for sure if they passed or failed

@tvdeyen or @kennyadsl , you can safely close this PR once you'll read this message if you decide to keep going the road of #3796