### PR TITLE
Ensure #resource_not_found mentions the right model

### DIFF
--- a/backend/app/controllers/spree/admin/resource_controller.rb
+++ b/backend/app/controllers/spree/admin/resource_controller.rb
@@ -5,8 +5,8 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
 
   helper_method :new_object_url, :edit_object_url, :object_url, :collection_url
   before_action :load_resource, except: :update_positions
-  rescue_from ActiveRecord::RecordNotFound do
-    resource_not_found
+  rescue_from ActiveRecord::RecordNotFound do |exception|
+    resource_not_found(flash_class: exception.model.constantize)
   end
   rescue_from ActiveRecord::RecordInvalid, with: :resource_invalid
 

--- a/backend/spec/controllers/spree/admin/resource_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/resource_controller_spec.rb
@@ -221,4 +221,21 @@ describe Spree::Admin::WidgetsController, type: :controller do
       end
     end
   end
+
+  describe 'rescue_from ActveRecord::RecordNotFound' do
+    let(:widget) { Widget.create!(name: 'a widget') }
+
+    subject do
+      get :edit, params: { id: widget.to_param }
+    end
+
+    it 'shows an error message with a reference to the model that was not found and redirect to the collection' do
+      allow(controller).to receive(:edit) { Spree::Product.find(123) }
+
+      subject
+
+      expect(response).to redirect_to('/admin/widgets')
+      expect(flash[:error]).to eql('Product is not found')
+    end
+  end
 end


### PR DESCRIPTION
**Description**

Before this #resource_not_found was assuming not-found errors would
only come from #model_class.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
