### PR TITLE
Fix the singular translation for Spree::Role

### DIFF
--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -699,7 +699,7 @@ en:
         one: RMA Reason
         other: RMA Reasons
       spree/role:
-        one: Roles
+        one: Role
         other: Roles
       spree/shipment:
         one: Shipment


### PR DESCRIPTION
**Description**

Surely just a typo (git blame didn't bring up any good reason).

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
