### PR TITLE
Remove seeds for images associated to master variant

### DIFF
--- a/sample/db/samples/assets.rb
+++ b/sample/db/samples/assets.rb
@@ -27,22 +27,6 @@ def image(name, type = "jpg")
 end
 
 images = {
-  products[:solidus_tshirt].master => [
-    {
-      attachment: image("solidus_tshirt")
-    },
-    {
-      attachment: image("solidus_tshirt_back")
-    }
-  ],
-  products[:solidus_long].master => [
-    {
-      attachment: image("solidus_long")
-    },
-    {
-      attachment: image("solidus_long_back")
-    }
-  ],
   products[:solidus_snapback_cap].master => [
     {
       attachment: image("solidus_snapback_cap")
@@ -89,11 +73,6 @@ images = {
   products[:ruby_tote].master => [
     {
       attachment: image("tote_bag_ruby")
-    }
-  ],
-  products[:solidus_girly].master => [
-    {
-      attachment: image("solidus_girly")
     }
   ]
 }


### PR DESCRIPTION
**Description**
<!--
  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

  Please include screenshots in case of visual changes to the frontend or backend sections of Solidus.

  If needed you can reference another PR or issue here, e.g.:
  Ref #ISSUE
-->

Removes seeds associated with the master variant of the following products:
- solidus_tshirt
- solidus_long
- solidus_girly

This is in order to simply not show the product images in the thumbnail list of each variant because they are not related to the variant color itself.

| Before | After |
|--|--|
|<img width="768" alt="Screenshot 2020-10-23 at 11 31 03" src="https://user-images.githubusercontent.com/3853105/96987638-92734a80-1523-11eb-9f84-b76d2491fd92.png">|<img width="778" alt="Screenshot 2020-10-23 at 11 31 23" src="https://user-images.githubusercontent.com/3853105/96987645-956e3b00-1523-11eb-84c4-f7311a5af20d.png">|

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
