### PR TITLE
Change state_required detections

### DIFF
--- a/core/db/default/spree/countries.rb
+++ b/core/db/default/spree/countries.rb
@@ -13,7 +13,7 @@ country_mapper = ->(country) do
   iso             = connection.quote country.alpha_2_code
   iso_name        = connection.quote country.name.upcase
   numcode         = connection.quote country.numeric_code
-  states_required = connection.quote country.subregions?
+  states_required = connection.quote(country.subregions.any? { |c| c.subregions.detect { |r| r.type == 'state' } })
 
   [name, iso3, iso, iso_name, numcode, states_required].join(", ")
 end


### PR DESCRIPTION
`Carmen::Country#subregions?` returns true even if the subregions aren't states.
With this commit state_required variable will set true only when there is at least one nested state.

To update existing countries you can execute the following command on the console.
```
require 'carmen'

carmen_countries = Carmen::Country.all

Spree::Country.all.each do |country|
  next if carmen_countries.detect { |c| c.name == country.name }.subregions.any? { |c| c.subregions.detect { |r| r.type == 'state' } }
  
  country.update(states_required: false)
end
```

Ref https://github.com/solidusio/solidus/issues/3803

**Checklist:**
- [X] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [X] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
