### PR TITLE
Fix the factories loading mechanism

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,13 +36,15 @@ group :backend, :frontend, :core, :api do
   end
 
   gem 'database_cleaner', '~> 1.3', require: false
-  gem 'factory_bot_rails', '~> 4.8', require: false
   gem 'rspec-activemodel-mocks', '~> 1.1', require: false
   gem 'rspec-rails', '~> 4.0.1', require: false
   gem 'simplecov', require: false
   gem 'with_model', require: false
   gem 'rails-controller-testing', require: false
   gem 'puma', require: false
+
+  # Ensure the requirement is also updated in core/lib/spree/testing_support.rb
+  gem 'factory_bot_rails', '~> 4.8', require: false
 end
 
 group :backend, :frontend do

--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ group :backend, :frontend, :core, :api do
   gem 'database_cleaner', '~> 1.3', require: false
   gem 'factory_bot_rails', '~> 4.8', require: false
   gem 'rspec-activemodel-mocks', '~> 1.1', require: false
-  gem 'rspec-rails', '~> 4.0.0.beta2', require: false
+  gem 'rspec-rails', '~> 4.0.1', require: false
   gem 'simplecov', require: false
   gem 'with_model', require: false
   gem 'rails-controller-testing', require: false

--- a/core/lib/spree/testing_support.rb
+++ b/core/lib/spree/testing_support.rb
@@ -11,6 +11,17 @@ module Spree
 
     def self.load_all_factories
       require 'factory_bot'
+      require 'factory_bot/version'
+
+      requirement = Gem::Requirement.new("~> 4.8")
+      version = Gem::Version.new(FactoryBot::VERSION)
+
+      unless requirement.satisfied_by? version
+        Spree::Deprecation.warn(
+          "Please be aware that the supported version of FactoryBot is #{requirement}, " \
+          "using version #{version} could lead to factory loading issues.", caller(2)
+        )
+      end
 
       FactoryBot.definition_file_paths.concat(factory_bot_paths).uniq!
       FactoryBot.reload

--- a/core/lib/spree/testing_support.rb
+++ b/core/lib/spree/testing_support.rb
@@ -9,6 +9,16 @@ module Spree
       @paths ||= (SEQUENCES + FACTORIES).sort.map { |path| path.sub(/.rb\z/, '') }
     end
 
+    def self.deprecate_cherry_picking_factory_bot_files
+      # All good if the factory is being loaded by FactoryBot.
+      return if caller.find { |line| line.include? "/factory_bot/find_definitions.rb" }
+
+      Spree::Deprecation.warn(
+        "Please do not cherry-pick factories, this is not well supported by FactoryBot. " \
+        'Use `require "spree/testing_support/factories"` instead.', caller(2)
+      )
+    end
+
     def self.load_all_factories
       require 'factory_bot'
       require 'factory_bot/version'

--- a/core/lib/spree/testing_support.rb
+++ b/core/lib/spree/testing_support.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Spree
+  module TestingSupport
+    SEQUENCES = ["#{::Spree::Core::Engine.root}/lib/spree/testing_support/sequences.rb"]
+    FACTORIES = Dir["#{::Spree::Core::Engine.root}/lib/spree/testing_support/factories/**/*_factory.rb"]
+
+    def self.factory_bot_paths
+      @paths ||= (SEQUENCES + FACTORIES).sort.map { |path| path.sub(/.rb\z/, '') }
+    end
+
+    def self.load_all_factories
+      require 'factory_bot'
+
+      FactoryBot.definition_file_paths.concat(factory_bot_paths).uniq!
+      FactoryBot.reload
+    end
+  end
+end

--- a/core/lib/spree/testing_support/factories.rb
+++ b/core/lib/spree/testing_support/factories.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'factory_bot'
+require 'spree/testing_support'
 
-Dir["#{File.dirname(__FILE__)}/factories/**"].each do |f|
-  require File.expand_path(f)
-end
+Spree::TestingSupport.load_all_factories

--- a/core/lib/spree/testing_support/factories/address_factory.rb
+++ b/core/lib/spree/testing_support/factories/address_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support/factories/state_factory'
-require 'spree/testing_support/factories/country_factory'
+require 'spree/testing_support'
+Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
 
 FactoryBot.define do
   factory :address, class: 'Spree::Address' do

--- a/core/lib/spree/testing_support/factories/adjustment_factory.rb
+++ b/core/lib/spree/testing_support/factories/adjustment_factory.rb
@@ -1,10 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support/factories/line_item_factory'
-require 'spree/testing_support/factories/order_factory'
-require 'spree/testing_support/factories/tax_category_factory'
-require 'spree/testing_support/factories/tax_rate_factory'
-require 'spree/testing_support/factories/zone_factory'
+require 'spree/testing_support'
+Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
 
 FactoryBot.define do
   factory :adjustment, class: 'Spree::Adjustment' do

--- a/core/lib/spree/testing_support/factories/adjustment_reason_factory.rb
+++ b/core/lib/spree/testing_support/factories/adjustment_reason_factory.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'spree/testing_support'
+Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+
 FactoryBot.define do
   factory :adjustment_reason, class: 'Spree::AdjustmentReason' do
     sequence(:name) { |n| "Refund for return ##{n}" }

--- a/core/lib/spree/testing_support/factories/calculator_factory.rb
+++ b/core/lib/spree/testing_support/factories/calculator_factory.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'spree/testing_support'
+Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+
 FactoryBot.define do
   factory :calculator, aliases: [:flat_rate_calculator], class: 'Spree::Calculator::FlatRate' do
     preferred_amount { 10.0 }

--- a/core/lib/spree/testing_support/factories/carton_factory.rb
+++ b/core/lib/spree/testing_support/factories/carton_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support/factories/shipment_factory'
-require 'spree/testing_support/factories/inventory_unit_factory'
+require 'spree/testing_support'
+Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
 
 FactoryBot.define do
   factory :carton, class: 'Spree::Carton' do

--- a/core/lib/spree/testing_support/factories/country_factory.rb
+++ b/core/lib/spree/testing_support/factories/country_factory.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'spree/testing_support'
+Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+
 require 'carmen'
 
 FactoryBot.define do

--- a/core/lib/spree/testing_support/factories/credit_card_factory.rb
+++ b/core/lib/spree/testing_support/factories/credit_card_factory.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'spree/testing_support'
+Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+
 FactoryBot.define do
   factory :credit_card, class: 'Spree::CreditCard' do
     verification_value { 123 }

--- a/core/lib/spree/testing_support/factories/customer_return_factory.rb
+++ b/core/lib/spree/testing_support/factories/customer_return_factory.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support/factories/stock_location_factory'
-require 'spree/testing_support/factories/order_factory'
-require 'spree/testing_support/factories/return_item_factory'
+require 'spree/testing_support'
+Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
 
 FactoryBot.define do
   factory :customer_return, class: 'Spree::CustomerReturn' do

--- a/core/lib/spree/testing_support/factories/image_factory.rb
+++ b/core/lib/spree/testing_support/factories/image_factory.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'spree/testing_support'
+Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+
 FactoryBot.define do
   factory :image, class: 'Spree::Image' do
     attachment { Spree::Core::Engine.root.join('lib', 'spree', 'testing_support', 'fixtures', 'blank.jpg').open }

--- a/core/lib/spree/testing_support/factories/inventory_unit_factory.rb
+++ b/core/lib/spree/testing_support/factories/inventory_unit_factory.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support/factories/line_item_factory'
-require 'spree/testing_support/factories/variant_factory'
-require 'spree/testing_support/factories/order_factory'
-require 'spree/testing_support/factories/shipment_factory'
+require 'spree/testing_support'
+Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
 
 FactoryBot.define do
   factory :inventory_unit, class: 'Spree::InventoryUnit' do

--- a/core/lib/spree/testing_support/factories/line_item_factory.rb
+++ b/core/lib/spree/testing_support/factories/line_item_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support/factories/order_factory'
-require 'spree/testing_support/factories/product_factory'
+require 'spree/testing_support'
+Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
 
 FactoryBot.define do
   factory :line_item, class: 'Spree::LineItem' do

--- a/core/lib/spree/testing_support/factories/option_type_factory.rb
+++ b/core/lib/spree/testing_support/factories/option_type_factory.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'spree/testing_support'
+Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+
 FactoryBot.define do
   factory :option_type, class: 'Spree::OptionType' do
     sequence(:name) { |n| "foo-size-#{n}" }

--- a/core/lib/spree/testing_support/factories/option_value_factory.rb
+++ b/core/lib/spree/testing_support/factories/option_value_factory.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'spree/testing_support'
+Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+
 FactoryBot.define do
   factory :option_value, class: 'Spree::OptionValue' do
     sequence(:name) { |n| "Size-#{n}" }

--- a/core/lib/spree/testing_support/factories/order_factory.rb
+++ b/core/lib/spree/testing_support/factories/order_factory.rb
@@ -1,11 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support/factories/address_factory'
-require 'spree/testing_support/factories/shipment_factory'
-require 'spree/testing_support/factories/store_factory'
-require 'spree/testing_support/factories/user_factory'
-require 'spree/testing_support/factories/line_item_factory'
-require 'spree/testing_support/factories/payment_factory'
+require 'spree/testing_support'
+Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
 
 FactoryBot.define do
   factory :order, class: 'Spree::Order' do

--- a/core/lib/spree/testing_support/factories/order_promotion_factory.rb
+++ b/core/lib/spree/testing_support/factories/order_promotion_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support/factories/order_factory'
-require 'spree/testing_support/factories/promotion_factory'
+require 'spree/testing_support'
+Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
 
 FactoryBot.define do
   factory :order_promotion, class: 'Spree::OrderPromotion' do

--- a/core/lib/spree/testing_support/factories/payment_factory.rb
+++ b/core/lib/spree/testing_support/factories/payment_factory.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support/factories/payment_method_factory'
-require 'spree/testing_support/factories/credit_card_factory'
-require 'spree/testing_support/factories/order_factory'
-require 'spree/testing_support/factories/store_credit_factory'
+require 'spree/testing_support'
+Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
 
 FactoryBot.define do
   factory :payment, aliases: [:credit_card_payment], class: 'Spree::Payment' do

--- a/core/lib/spree/testing_support/factories/payment_method_factory.rb
+++ b/core/lib/spree/testing_support/factories/payment_method_factory.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'spree/testing_support'
+Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+
 FactoryBot.define do
   factory :payment_method, aliases: [:credit_card_payment_method], class: 'Spree::PaymentMethod::BogusCreditCard' do
     name { 'Credit Card' }

--- a/core/lib/spree/testing_support/factories/price_factory.rb
+++ b/core/lib/spree/testing_support/factories/price_factory.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support/factories/variant_factory'
+require 'spree/testing_support'
+Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
 
 FactoryBot.define do
   factory :price, class: 'Spree::Price' do

--- a/core/lib/spree/testing_support/factories/product_factory.rb
+++ b/core/lib/spree/testing_support/factories/product_factory.rb
@@ -1,10 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support/sequences'
-require 'spree/testing_support/factories/shipping_category_factory'
-require 'spree/testing_support/factories/stock_location_factory'
-require 'spree/testing_support/factories/tax_category_factory'
-require 'spree/testing_support/factories/product_option_type_factory'
+require 'spree/testing_support'
+Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
 
 FactoryBot.define do
   factory :base_product, class: 'Spree::Product' do

--- a/core/lib/spree/testing_support/factories/product_option_type_factory.rb
+++ b/core/lib/spree/testing_support/factories/product_option_type_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support/factories/product_factory'
-require 'spree/testing_support/factories/option_type_factory'
+require 'spree/testing_support'
+Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
 
 FactoryBot.define do
   factory :product_option_type, class: 'Spree::ProductOptionType' do

--- a/core/lib/spree/testing_support/factories/product_property_factory.rb
+++ b/core/lib/spree/testing_support/factories/product_property_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support/factories/product_factory'
-require 'spree/testing_support/factories/property_factory'
+require 'spree/testing_support'
+Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
 
 FactoryBot.define do
   factory :product_property, class: 'Spree::ProductProperty' do

--- a/core/lib/spree/testing_support/factories/promotion_category_factory.rb
+++ b/core/lib/spree/testing_support/factories/promotion_category_factory.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'spree/testing_support'
+Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+
 FactoryBot.define do
   factory :promotion_category, class: 'Spree::PromotionCategory' do
     name { 'Promotion Category' }

--- a/core/lib/spree/testing_support/factories/promotion_code_factory.rb
+++ b/core/lib/spree/testing_support/factories/promotion_code_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support/sequences'
-require 'spree/testing_support/factories/promotion_factory'
+require 'spree/testing_support'
+Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
 
 FactoryBot.define do
   factory :promotion_code, class: 'Spree::PromotionCode' do

--- a/core/lib/spree/testing_support/factories/promotion_factory.rb
+++ b/core/lib/spree/testing_support/factories/promotion_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support/factories/promotion_code_factory'
-require 'spree/testing_support/factories/variant_factory'
+require 'spree/testing_support'
+Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
 
 FactoryBot.define do
   factory :promotion, class: 'Spree::Promotion' do

--- a/core/lib/spree/testing_support/factories/property_factory.rb
+++ b/core/lib/spree/testing_support/factories/property_factory.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'spree/testing_support'
+Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+
 FactoryBot.define do
   factory :property, class: 'Spree::Property' do
     name { 'baseball_cap_color' }

--- a/core/lib/spree/testing_support/factories/refund_factory.rb
+++ b/core/lib/spree/testing_support/factories/refund_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support/factories/payment_factory'
-require 'spree/testing_support/factories/refund_reason_factory'
+require 'spree/testing_support'
+Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
 
 FactoryBot.define do
   sequence(:refund_transaction_id) { |n| "fake-refund-transaction-#{n}" }

--- a/core/lib/spree/testing_support/factories/refund_reason_factory.rb
+++ b/core/lib/spree/testing_support/factories/refund_reason_factory.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'spree/testing_support'
+Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+
 FactoryBot.define do
   factory :refund_reason, class: 'Spree::RefundReason' do
     sequence(:name) { |n| "Refund for return ##{n}" }

--- a/core/lib/spree/testing_support/factories/reimbursement_factory.rb
+++ b/core/lib/spree/testing_support/factories/reimbursement_factory.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support/factories/customer_return_factory'
+require 'spree/testing_support'
+Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
 
 FactoryBot.define do
   factory :reimbursement, class: 'Spree::Reimbursement' do

--- a/core/lib/spree/testing_support/factories/reimbursement_type_factory.rb
+++ b/core/lib/spree/testing_support/factories/reimbursement_type_factory.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'spree/testing_support'
+Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+
 FactoryBot.define do
   factory :reimbursement_type, class: 'Spree::ReimbursementType' do
     sequence(:name) { |n| "Reimbursement Type #{n}" }

--- a/core/lib/spree/testing_support/factories/return_authorization_factory.rb
+++ b/core/lib/spree/testing_support/factories/return_authorization_factory.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support/factories/order_factory'
-require 'spree/testing_support/factories/stock_location_factory'
-require 'spree/testing_support/factories/return_reason_factory'
+require 'spree/testing_support'
+Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
 
 FactoryBot.define do
   factory :return_authorization, class: 'Spree::ReturnAuthorization' do

--- a/core/lib/spree/testing_support/factories/return_item_factory.rb
+++ b/core/lib/spree/testing_support/factories/return_item_factory.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support/factories/inventory_unit_factory'
-require 'spree/testing_support/factories/return_reason_factory'
-require 'spree/testing_support/factories/return_authorization_factory'
+require 'spree/testing_support'
+Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
 
 FactoryBot.define do
   factory :return_item, class: 'Spree::ReturnItem' do

--- a/core/lib/spree/testing_support/factories/return_reason_factory.rb
+++ b/core/lib/spree/testing_support/factories/return_reason_factory.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'spree/testing_support'
+Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+
 FactoryBot.define do
   factory :return_reason, class: 'Spree::ReturnReason' do
     sequence(:name) { |n| "Defect ##{n}" }

--- a/core/lib/spree/testing_support/factories/role_factory.rb
+++ b/core/lib/spree/testing_support/factories/role_factory.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'spree/testing_support'
+Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+
 FactoryBot.define do
   factory :role, class: 'Spree::Role' do
     sequence(:name) { |n| "Role ##{n}" }

--- a/core/lib/spree/testing_support/factories/shipment_factory.rb
+++ b/core/lib/spree/testing_support/factories/shipment_factory.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support/factories/order_factory'
-require 'spree/testing_support/factories/stock_location_factory'
-require 'spree/testing_support/factories/shipping_method_factory'
+require 'spree/testing_support'
+Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
 
 FactoryBot.define do
   factory :shipment, class: 'Spree::Shipment' do

--- a/core/lib/spree/testing_support/factories/shipping_category_factory.rb
+++ b/core/lib/spree/testing_support/factories/shipping_category_factory.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'spree/testing_support'
+Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+
 FactoryBot.define do
   factory :shipping_category, class: 'Spree::ShippingCategory' do
     sequence(:name) { |n| "ShippingCategory ##{n}" }

--- a/core/lib/spree/testing_support/factories/shipping_method_factory.rb
+++ b/core/lib/spree/testing_support/factories/shipping_method_factory.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support/factories/calculator_factory'
-require 'spree/testing_support/factories/shipping_category_factory'
-require 'spree/testing_support/factories/zone_factory'
+require 'spree/testing_support'
+Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
 
 FactoryBot.define do
   factory(

--- a/core/lib/spree/testing_support/factories/shipping_rate_factory.rb
+++ b/core/lib/spree/testing_support/factories/shipping_rate_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support/factories/shipping_method_factory'
-require 'spree/testing_support/factories/shipment_factory'
+require 'spree/testing_support'
+Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
 
 FactoryBot.define do
   factory :shipping_rate, class: 'Spree::ShippingRate' do

--- a/core/lib/spree/testing_support/factories/state_factory.rb
+++ b/core/lib/spree/testing_support/factories/state_factory.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support/factories/country_factory'
+require 'spree/testing_support'
+Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
 
 FactoryBot.define do
   factory :state, class: 'Spree::State' do

--- a/core/lib/spree/testing_support/factories/stock_item_factory.rb
+++ b/core/lib/spree/testing_support/factories/stock_item_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support/factories/stock_location_factory'
-require 'spree/testing_support/factories/variant_factory'
+require 'spree/testing_support'
+Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
 
 FactoryBot.define do
   factory :stock_item, class: 'Spree::StockItem' do

--- a/core/lib/spree/testing_support/factories/stock_location_factory.rb
+++ b/core/lib/spree/testing_support/factories/stock_location_factory.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support/factories/country_factory'
-require 'spree/testing_support/factories/state_factory'
-require 'spree/testing_support/factories/product_factory'
+require 'spree/testing_support'
+Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
 
 FactoryBot.define do
   factory :stock_location, class: 'Spree::StockLocation' do

--- a/core/lib/spree/testing_support/factories/stock_movement_factory.rb
+++ b/core/lib/spree/testing_support/factories/stock_movement_factory.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support/factories/stock_item_factory'
+require 'spree/testing_support'
+Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
 
 FactoryBot.define do
   factory :stock_movement, class: 'Spree::StockMovement' do

--- a/core/lib/spree/testing_support/factories/stock_package_factory.rb
+++ b/core/lib/spree/testing_support/factories/stock_package_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support/factories/inventory_unit_factory'
-require 'spree/testing_support/factories/variant_factory'
+require 'spree/testing_support'
+Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
 
 FactoryBot.define do
   factory :stock_package, class: 'Spree::Stock::Package' do

--- a/core/lib/spree/testing_support/factories/store_credit_category_factory.rb
+++ b/core/lib/spree/testing_support/factories/store_credit_category_factory.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'spree/testing_support'
+Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+
 FactoryBot.define do
   factory :store_credit_category, class: 'Spree::StoreCreditCategory' do
     name { "Exchange" }

--- a/core/lib/spree/testing_support/factories/store_credit_event_factory.rb
+++ b/core/lib/spree/testing_support/factories/store_credit_event_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support/factories/store_credit_factory'
-require 'spree/testing_support/factories/store_credit_reason_factory'
+require 'spree/testing_support'
+Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
 
 FactoryBot.define do
   factory :store_credit_event, class: 'Spree::StoreCreditEvent' do

--- a/core/lib/spree/testing_support/factories/store_credit_factory.rb
+++ b/core/lib/spree/testing_support/factories/store_credit_factory.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support/factories/store_credit_category_factory'
-require 'spree/testing_support/factories/store_credit_type_factory'
-require 'spree/testing_support/factories/user_factory'
+require 'spree/testing_support'
+Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
 
 FactoryBot.define do
   factory :store_credit, class: 'Spree::StoreCredit' do

--- a/core/lib/spree/testing_support/factories/store_credit_reason_factory.rb
+++ b/core/lib/spree/testing_support/factories/store_credit_reason_factory.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'spree/testing_support'
+Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+
 FactoryBot.define do
   factory :store_credit_reason, class: 'Spree::StoreCreditReason' do
     sequence :name do |n|

--- a/core/lib/spree/testing_support/factories/store_credit_type_factory.rb
+++ b/core/lib/spree/testing_support/factories/store_credit_type_factory.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'spree/testing_support'
+Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+
 FactoryBot.define do
   factory :primary_credit_type, class: 'Spree::StoreCreditType' do
     name      { Spree::StoreCreditType::DEFAULT_TYPE_NAME }

--- a/core/lib/spree/testing_support/factories/store_factory.rb
+++ b/core/lib/spree/testing_support/factories/store_factory.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'spree/testing_support'
+Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+
 FactoryBot.define do
   factory :store, class: 'Spree::Store' do
     sequence(:code) { |i| "spree_#{i}" }

--- a/core/lib/spree/testing_support/factories/tax_category_factory.rb
+++ b/core/lib/spree/testing_support/factories/tax_category_factory.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support/sequences'
+require 'spree/testing_support'
+Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
 
 FactoryBot.define do
   factory :tax_category, class: 'Spree::TaxCategory' do

--- a/core/lib/spree/testing_support/factories/tax_rate_factory.rb
+++ b/core/lib/spree/testing_support/factories/tax_rate_factory.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support/factories/calculator_factory'
-require 'spree/testing_support/factories/tax_category_factory'
-require 'spree/testing_support/factories/zone_factory'
+require 'spree/testing_support'
+Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
 
 FactoryBot.define do
   factory :tax_rate, class: 'Spree::TaxRate' do

--- a/core/lib/spree/testing_support/factories/taxon_factory.rb
+++ b/core/lib/spree/testing_support/factories/taxon_factory.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support/factories/taxonomy_factory'
+require 'spree/testing_support'
+Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
 
 FactoryBot.define do
   factory :taxon, class: 'Spree::Taxon' do

--- a/core/lib/spree/testing_support/factories/taxonomy_factory.rb
+++ b/core/lib/spree/testing_support/factories/taxonomy_factory.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'spree/testing_support'
+Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+
 FactoryBot.define do
   factory :taxonomy, class: 'Spree::Taxonomy' do
     name { 'Brand' }

--- a/core/lib/spree/testing_support/factories/user_factory.rb
+++ b/core/lib/spree/testing_support/factories/user_factory.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support/sequences'
-require 'spree/testing_support/factories/role_factory'
-require 'spree/testing_support/factories/address_factory'
+require 'spree/testing_support'
+Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
 
 FactoryBot.define do
   factory :user, class: Spree::UserClassHandle.new do

--- a/core/lib/spree/testing_support/factories/variant_factory.rb
+++ b/core/lib/spree/testing_support/factories/variant_factory.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support/sequences'
-require 'spree/testing_support/factories/option_value_factory'
-require 'spree/testing_support/factories/option_type_factory'
-require 'spree/testing_support/factories/product_factory'
+require 'spree/testing_support'
+Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
 
 FactoryBot.define do
   sequence(:random_float) { BigDecimal("#{rand(200)}.#{rand(99)}") }

--- a/core/lib/spree/testing_support/factories/variant_property_rule_condition_factory.rb
+++ b/core/lib/spree/testing_support/factories/variant_property_rule_condition_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support/factories/option_value_factory'
-require 'spree/testing_support/factories/variant_property_rule_factory'
+require 'spree/testing_support'
+Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
 
 FactoryBot.define do
   factory :variant_property_rule_condition, class: 'Spree::VariantPropertyRuleCondition' do

--- a/core/lib/spree/testing_support/factories/variant_property_rule_factory.rb
+++ b/core/lib/spree/testing_support/factories/variant_property_rule_factory.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support/factories/product_factory'
-require 'spree/testing_support/factories/property_factory'
-require 'spree/testing_support/factories/option_value_factory'
+require 'spree/testing_support'
+Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
 
 FactoryBot.define do
   factory :variant_property_rule, class: 'Spree::VariantPropertyRule' do

--- a/core/lib/spree/testing_support/factories/variant_property_rule_value_factory.rb
+++ b/core/lib/spree/testing_support/factories/variant_property_rule_value_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support/factories/variant_property_rule_factory'
-require 'spree/testing_support/factories/property_factory'
+require 'spree/testing_support'
+Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
 
 FactoryBot.define do
   factory :variant_property_rule_value, class: 'Spree::VariantPropertyRuleValue' do

--- a/core/lib/spree/testing_support/factories/zone_factory.rb
+++ b/core/lib/spree/testing_support/factories/zone_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support/sequences'
-require 'spree/testing_support/factories/country_factory'
+require 'spree/testing_support'
+Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
 
 FactoryBot.define do
   factory :global_zone, class: 'Spree::Zone' do

--- a/core/spec/lib/spree/core/testing_support/factories/address_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/address_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'spree/testing_support/factories/address_factory'
 
 RSpec.describe 'address factory' do
   let(:factory_class) { Spree::Address }

--- a/core/spec/lib/spree/core/testing_support/factories/adjustment_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/adjustment_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'spree/testing_support/factories/adjustment_factory'
 
 RSpec.describe 'adjustment factory' do
   let(:factory_class) { Spree::Adjustment }

--- a/core/spec/lib/spree/core/testing_support/factories/adjustment_reason_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/adjustment_reason_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'spree/testing_support/factories/adjustment_reason_factory'
 
 RSpec.describe 'adjustment reason factory' do
   let(:factory_class) { Spree::AdjustmentReason }

--- a/core/spec/lib/spree/core/testing_support/factories/calculator_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/calculator_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'spree/testing_support/factories/calculator_factory'
 
 RSpec.describe 'calculator factory' do
   let(:factory_class) { Spree::Calculator }

--- a/core/spec/lib/spree/core/testing_support/factories/carton_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/carton_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'spree/testing_support/factories/carton_factory'
 
 RSpec.describe 'carton factory' do
   let(:factory_class) { Spree::Carton }

--- a/core/spec/lib/spree/core/testing_support/factories/country_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/country_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'spree/testing_support/factories/country_factory'
 
 RSpec.describe 'country factory' do
   let(:factory_class) { Spree::Country }

--- a/core/spec/lib/spree/core/testing_support/factories/credit_card_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/credit_card_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'spree/testing_support/factories/credit_card_factory'
 
 RSpec.describe 'credit card factory' do
   let(:factory_class) { Spree::CreditCard }

--- a/core/spec/lib/spree/core/testing_support/factories/customer_return_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/customer_return_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'spree/testing_support/factories/customer_return_factory'
 
 RSpec.describe 'customer return factory' do
   let(:factory_class) { Spree::CustomerReturn }

--- a/core/spec/lib/spree/core/testing_support/factories/image_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/image_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'spree/testing_support/factories/image_factory'
 
 RSpec.describe 'image factory' do
   let(:factory_class) { Spree::Image }

--- a/core/spec/lib/spree/core/testing_support/factories/inventory_unit_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/inventory_unit_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'spree/testing_support/factories/inventory_unit_factory'
 
 RSpec.describe 'inventory unit factory' do
   let(:factory_class) { Spree::InventoryUnit }

--- a/core/spec/lib/spree/core/testing_support/factories/line_item_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/line_item_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'spree/testing_support/factories/line_item_factory'
 
 RSpec.describe 'line item factory' do
   let(:factory_class) { Spree::LineItem }

--- a/core/spec/lib/spree/core/testing_support/factories/option_type_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/option_type_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'spree/testing_support/factories/option_type_factory'
 
 RSpec.describe 'option type factory' do
   let(:factory_class) { Spree::OptionType }

--- a/core/spec/lib/spree/core/testing_support/factories/option_value_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/option_value_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'spree/testing_support/factories/option_value_factory'
 
 RSpec.describe 'option value factory' do
   let(:factory_class) { Spree::OptionValue }

--- a/core/spec/lib/spree/core/testing_support/factories/order_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/order_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'spree/testing_support/factories/order_factory'
 
 RSpec.shared_examples "shipping methods are assigned" do
   context "given a shipping method" do

--- a/core/spec/lib/spree/core/testing_support/factories/order_promotion_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/order_promotion_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'spree/testing_support/factories/order_promotion_factory'
 
 RSpec.describe 'order promotion factory' do
   let(:factory_class) { Spree::OrderPromotion }

--- a/core/spec/lib/spree/core/testing_support/factories/payment_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/payment_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'spree/testing_support/factories/payment_factory'
 
 RSpec.describe 'payment factory' do
   let(:factory_class) { Spree::Payment }

--- a/core/spec/lib/spree/core/testing_support/factories/payment_method_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/payment_method_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'spree/testing_support/factories/payment_method_factory'
 
 RSpec.describe 'payment method factory' do
   let(:factory_class) { Spree::PaymentMethod }

--- a/core/spec/lib/spree/core/testing_support/factories/price_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/price_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'spree/testing_support/factories/price_factory'
 
 RSpec.describe 'price factory' do
   let(:factory_class) { Spree::Price }

--- a/core/spec/lib/spree/core/testing_support/factories/product_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/product_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'spree/testing_support/factories/product_factory'
 
 RSpec.describe 'product factory' do
   let(:factory_class) { Spree::Product }

--- a/core/spec/lib/spree/core/testing_support/factories/product_option_type_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/product_option_type_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'spree/testing_support/factories/product_option_type_factory'
 
 RSpec.describe 'product option type factory' do
   let(:factory_class) { Spree::ProductOptionType }

--- a/core/spec/lib/spree/core/testing_support/factories/product_property_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/product_property_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'spree/testing_support/factories/product_property_factory'
 
 RSpec.describe 'product property factory' do
   let(:factory_class) { Spree::ProductProperty }

--- a/core/spec/lib/spree/core/testing_support/factories/promotion_category_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/promotion_category_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'spree/testing_support/factories/promotion_category_factory'
 
 RSpec.describe 'promotion category factory' do
   let(:factory_class) { Spree::PromotionCategory }

--- a/core/spec/lib/spree/core/testing_support/factories/promotion_code_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/promotion_code_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'spree/testing_support/factories/promotion_code_factory'
 
 RSpec.describe 'promotion code factory' do
   let(:factory_class) { Spree::PromotionCode }

--- a/core/spec/lib/spree/core/testing_support/factories/promotion_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/promotion_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'spree/testing_support/factories/promotion_factory'
 
 RSpec.describe 'promotion code factory' do
   let(:factory_class) { Spree::Promotion }

--- a/core/spec/lib/spree/core/testing_support/factories/property_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/property_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'spree/testing_support/factories/property_factory'
 
 RSpec.describe 'property factory' do
   let(:factory_class) { Spree::Property }

--- a/core/spec/lib/spree/core/testing_support/factories/refund_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/refund_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'spree/testing_support/factories/refund_factory'
 
 RSpec.describe 'refund factory' do
   let(:factory_class) { Spree::Refund }

--- a/core/spec/lib/spree/core/testing_support/factories/refund_reason_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/refund_reason_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'spree/testing_support/factories/refund_factory'
 
 RSpec.describe 'refund factory' do
   let(:factory_class) { Spree::Refund }

--- a/core/spec/lib/spree/core/testing_support/factories/reimbursement_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/reimbursement_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'spree/testing_support/factories/reimbursement_factory'
 
 RSpec.describe 'reimbursement factory' do
   let(:factory_class) { Spree::Reimbursement }

--- a/core/spec/lib/spree/core/testing_support/factories/reimbursement_type_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/reimbursement_type_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'spree/testing_support/factories/reimbursement_type_factory'
 
 RSpec.describe 'reimbursement type factory' do
   let(:factory_class) { Spree::ReimbursementType }

--- a/core/spec/lib/spree/core/testing_support/factories/return_authorization_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/return_authorization_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'spree/testing_support/factories/return_authorization_factory'
 
 RSpec.describe 'return authorization factory' do
   let(:factory_class) { Spree::ReturnAuthorization }

--- a/core/spec/lib/spree/core/testing_support/factories/return_item_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/return_item_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'spree/testing_support/factories/return_item_factory'
 
 RSpec.describe 'return item factory' do
   let(:factory_class) { Spree::ReturnItem }

--- a/core/spec/lib/spree/core/testing_support/factories/return_reason_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/return_reason_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'spree/testing_support/factories/return_reason_factory'
 
 RSpec.describe 'return reason factory' do
   let(:factory_class) { Spree::ReturnReason }

--- a/core/spec/lib/spree/core/testing_support/factories/role_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/role_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'spree/testing_support/factories/role_factory'
 
 RSpec.describe 'role factory' do
   let(:factory_class) { Spree::Role }

--- a/core/spec/lib/spree/core/testing_support/factories/shipment_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/shipment_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'spree/testing_support/factories/shipment_factory'
 
 RSpec.describe 'shipment factory' do
   let(:factory_class) { Spree::Shipment }

--- a/core/spec/lib/spree/core/testing_support/factories/shipping_category_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/shipping_category_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'spree/testing_support/factories/shipping_category_factory'
 
 RSpec.describe 'shipping category factory' do
   let(:factory_class) { Spree::ShippingCategory }

--- a/core/spec/lib/spree/core/testing_support/factories/shipping_method_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/shipping_method_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'spree/testing_support/factories/shipping_method_factory'
 
 RSpec.describe 'shipping method factory' do
   let(:factory_class) { Spree::ShippingMethod }

--- a/core/spec/lib/spree/core/testing_support/factories/shipping_rate_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/shipping_rate_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'spree/testing_support/factories/shipping_rate_factory'
 
 RSpec.describe 'shipping rate factory' do
   let(:factory_class) { Spree::ShippingRate }

--- a/core/spec/lib/spree/core/testing_support/factories/state_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/state_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'spree/testing_support/factories/state_factory'
 
 RSpec.describe 'state factory' do
   let(:factory_class) { Spree::State }

--- a/core/spec/lib/spree/core/testing_support/factories/stock_item_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/stock_item_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'spree/testing_support/factories/stock_item_factory'
 
 RSpec.describe 'stock item factory' do
   let(:factory_class) { Spree::StockItem }

--- a/core/spec/lib/spree/core/testing_support/factories/stock_location_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/stock_location_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'spree/testing_support/factories/stock_location_factory'
 
 RSpec.describe 'stock location factory' do
   let(:factory_class) { Spree::StockLocation }

--- a/core/spec/lib/spree/core/testing_support/factories/stock_movement_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/stock_movement_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'spree/testing_support/factories/stock_movement_factory'
 
 RSpec.describe 'stock movement factory' do
   let(:factory_class) { Spree::StockMovement }

--- a/core/spec/lib/spree/core/testing_support/factories/stock_package_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/stock_package_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'spree/testing_support/factories/stock_package_factory'
 
 RSpec.describe 'stock package factory' do
   let(:factory_class) { Spree::Stock::Package }

--- a/core/spec/lib/spree/core/testing_support/factories/store_credit_category_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/store_credit_category_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'spree/testing_support/factories/store_credit_category_factory'
 
 RSpec.describe 'store credit category factory' do
   let(:factory_class) { Spree::StoreCreditCategory }

--- a/core/spec/lib/spree/core/testing_support/factories/store_credit_event_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/store_credit_event_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'spree/testing_support/factories/store_credit_event_factory'
 
 RSpec.describe 'store credit event factory' do
   let(:factory_class) { Spree::StoreCreditEvent }

--- a/core/spec/lib/spree/core/testing_support/factories/store_credit_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/store_credit_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'spree/testing_support/factories/store_credit_factory'
 
 RSpec.describe 'store credit factory' do
   let(:factory_class) { Spree::StoreCredit }

--- a/core/spec/lib/spree/core/testing_support/factories/store_credit_reason_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/store_credit_reason_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'spree/testing_support/factories/store_credit_reason_factory'
 
 RSpec.describe 'store credit reason factory' do
   let(:factory_class) { Spree::StoreCreditReason }

--- a/core/spec/lib/spree/core/testing_support/factories/store_credit_type_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/store_credit_type_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'spree/testing_support/factories/store_credit_type_factory'
 
 RSpec.describe 'store credit type factory' do
   let(:factory_class) { Spree::StoreCreditType }

--- a/core/spec/lib/spree/core/testing_support/factories/store_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/store_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'spree/testing_support/factories/store_factory'
 
 RSpec.describe 'store factory' do
   let(:factory_class) { Spree::Store }

--- a/core/spec/lib/spree/core/testing_support/factories/tax_category_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/tax_category_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'spree/testing_support/factories/tax_category_factory'
 
 RSpec.describe 'tax category factory' do
   let(:factory_class) { Spree::TaxCategory }

--- a/core/spec/lib/spree/core/testing_support/factories/tax_rate_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/tax_rate_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'spree/testing_support/factories/tax_rate_factory'
 
 RSpec.describe 'tax rate factory' do
   let(:factory_class) { Spree::TaxRate }

--- a/core/spec/lib/spree/core/testing_support/factories/taxon_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/taxon_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'spree/testing_support/factories/taxon_factory'
 
 RSpec.describe 'taxon factory' do
   let(:factory_class) { Spree::Taxon }

--- a/core/spec/lib/spree/core/testing_support/factories/taxonomy_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/taxonomy_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'spree/testing_support/factories/taxonomy_factory'
 
 RSpec.describe 'taxonomy factory' do
   let(:factory_class) { Spree::Taxonomy }

--- a/core/spec/lib/spree/core/testing_support/factories/user_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/user_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'spree/testing_support/factories/user_factory'
 
 RSpec.describe 'user factory' do
   let(:factory_class) { Spree.user_class }

--- a/core/spec/lib/spree/core/testing_support/factories/variant_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/variant_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'spree/testing_support/factories/variant_factory'
 
 RSpec.describe 'variant factory' do
   let(:factory_class) { Spree::Variant }

--- a/core/spec/lib/spree/core/testing_support/factories/variant_property_rule_condition_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/variant_property_rule_condition_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'spree/testing_support/factories/variant_property_rule_condition_factory'
 
 RSpec.describe 'variant property rule condition factory' do
   let(:factory_class) { Spree::VariantPropertyRuleCondition }

--- a/core/spec/lib/spree/core/testing_support/factories/variant_property_rule_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/variant_property_rule_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'spree/testing_support/factories/variant_property_rule_factory'
 
 RSpec.describe 'variant property rule factory' do
   let(:factory_class) { Spree::VariantPropertyRule }

--- a/core/spec/lib/spree/core/testing_support/factories/variant_property_rule_value_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/variant_property_rule_value_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'spree/testing_support/factories/variant_property_rule_value_factory'
 
 RSpec.describe 'variant property rule value factory' do
   let(:factory_class) { Spree::VariantPropertyRuleValue }

--- a/core/spec/lib/spree/core/testing_support/factories/zone_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/zone_factory_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'spree/testing_support/factories/zone_factory'
 
 RSpec.describe 'zone factory' do
   let(:factory_class) { Spree::Zone }


### PR DESCRIPTION
**Description**
<!--
  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

  Please include screenshots in case of visual changes to the frontend or backend sections of Solidus.

  If needed you can reference another PR or issue here, e.g.:
  Ref #ISSUE
-->

Requiring factories, although it was the correct way of doing it back in the day, has not been well supported by FactoryBot for a number of major versions<sup>1</sup>. Some applications were even relying on `require` to cherry pick only the factories they wanted.

This PR fixes both of the problems with deprecations that clearly indicate the way forward ~~and updates the version of factory_bot_rails to the latest available~~. **UPDATE:** I'll leave the upgrade to a future PR as some stuff is broken on the latest version.

**Checklist:**
- [ ] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [ ] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)

---

_1: The latest is 6, and it's already not the right way in 4, I didn't bother searching earlier versions_

