### PR TITLE
Use the right method in the AddApplyToAllToVariantPropertyRule migration

### DIFF
--- a/core/db/migrate/20180416083007_add_apply_to_all_to_variant_property_rule.rb
+++ b/core/db/migrate/20180416083007_add_apply_to_all_to_variant_property_rule.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class AddApplyToAllToVariantPropertyRule < ActiveRecord::Migration[5.1]
-  def change
+  def up
     add_column :spree_variant_property_rules, :apply_to_all, :boolean, default: false, null: false
     change_column :spree_variant_property_rules, :apply_to_all, :boolean, default: true
   end


### PR DESCRIPTION
**Description**

I think `change` is used here by mistake. Among other things this renders the migration irreversible.

Closes #3809

