### PR TITLE
Remove deprecated name-related Address fields

### DIFF
--- a/api/app/helpers/spree/api/api_helpers.rb
+++ b/api/app/helpers/spree/api/api_helpers.rb
@@ -126,18 +126,11 @@ module Spree
         :id, :number, :state, :order_id, :memo, :created_at, :updated_at
       ]
 
-      @@address_base_attributes = [
+      @@address_attributes = [
         :id, :name, :address1, :address2, :city, :zipcode, :phone, :company,
         :alternative_phone, :country_id, :country_iso, :state_id, :state_name,
         :state_text
       ]
-
-      @@address_attributes = if Spree::Config.use_combined_first_and_last_name_in_address
-                               @@address_base_attributes
-                             else
-                               @@address_base_attributes +
-                                 Spree::Address::LEGACY_NAME_ATTRS.map(&:to_sym)
-                             end
 
       @@country_attributes = [:id, :iso_name, :iso, :iso3, :name, :numcode]
 

--- a/api/openapi/solidus-api.oas.yml
+++ b/api/openapi/solidus-api.oas.yml
@@ -5675,20 +5675,8 @@ components:
           type: integer
         country_iso:
           type: string
-        firstname:
-          type: string
-          deprecated: true
-          description: '*Deprecated: will be removed in Solidus 3.0, please use `name` property*'
-        full_name:
-          type: string
-          deprecated: true
-          description: '*Deprecated: will be removed in Solidus 3.0, please use `name` property*'
         id:
           type: integer
-        lastname:
-          type: string
-          deprecated: true
-          description: '*Deprecated: will be removed in Solidus 3.0, please use `name` property*'
         name:
           type: string
         phone:
@@ -6225,14 +6213,6 @@ components:
           type: integer
         name:
           type: string
-        firstname:
-          type: string
-          deprecated: true
-          description: '*Deprecated: will be removed in Solidus 3.0, please use `name` property*'
-        lastname:
-          type: string
-          deprecated: true
-          description: '*Deprecated: will be removed in Solidus 3.0, please use `name` property*'
         address1:
           type: string
         address2:

--- a/api/spec/features/checkout_spec.rb
+++ b/api/spec/features/checkout_spec.rb
@@ -75,7 +75,7 @@ module Spree
       # It seems we are missing an order-scoped address api endpoint since we need
       # to use update here.
       expect {
-        update_order(order_params: { order: { address_type => address.attributes.except('id') } })
+        update_order(order_params: { order: { address_type => address.as_json.except('id') } })
       }.to change { @order.reload.public_send(address_type) }.to address
     end
 

--- a/backend/app/assets/stylesheets/spree/backend/sections/_orders.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/_orders.scss
@@ -64,10 +64,6 @@
   margin-bottom: 15px;
 }
 
-label[for="order_bill_address_attributes_firstname"] {
-  margin-top: 53.5px;
-}
-
 label[for="order_bill_address_attributes_name"] {
   margin-top: 53.5px;
 }

--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -65,21 +65,10 @@
             </div>
 
             <div class="col-12 col-xl-6">
-              <% if Spree::Config.use_combined_first_and_last_name_in_address %>
-                <div class="field">
-                  <%= label_tag :q_bill_address_firstname_or_lastname_start, t('spree.name_contains') %>
-                  <%= f.text_field :bill_address_firstname_or_lastname_start, size: 25 %>
-                </div>
-              <% else %>
-                <div class="field">
-                  <%= label_tag :q_bill_address_firstname_start, t('spree.first_name_begins_with') %>
-                  <%= f.text_field :bill_address_firstname_start, size: 25 %>
-                </div>
-                <div class="field">
-                  <%= label_tag :q_bill_address_lastname_start, t('spree.last_name_begins_with') %>
-                  <%= f.text_field :bill_address_lastname_start, size: 25 %>
-                </div>
-              <% end %>
+              <div class="field">
+                <%= label_tag :q_bill_address_firstname_or_lastname_start, t('spree.name_contains') %>
+                <%= f.text_field :bill_address_firstname_or_lastname_start, size: 25 %>
+              </div>
             </div>
 
             <div class="col-12 col-xl-6">

--- a/backend/app/views/spree/admin/search/users.json.jbuilder
+++ b/backend/app/views/spree/admin/search/users.json.jbuilder
@@ -16,9 +16,6 @@ json.array!(@users) do |user|
     :country_id,
     :company
   ]
-  unless Spree::Config.use_combined_first_and_last_name_in_address
-    address_fields.push(:firstname, :lastname)
-  end
   json.ship_address do
     if user.ship_address
       json.(user.ship_address, *address_fields)

--- a/backend/app/views/spree/admin/shared/_address_form.html.erb
+++ b/backend/app/views/spree/admin/shared/_address_form.html.erb
@@ -1,22 +1,10 @@
 <% s_or_b = type.chars.first %>
 
 <div id="<%= type %>" data-hook="address_fields">
-  <% if Spree::Config.use_combined_first_and_last_name_in_address %>
-    <div class="field <%= "#{type}-row" %>">
-      <%= f.label :name %>
-      <%= f.text_field :name, class: 'fullwidth' %>
-    </div>
-  <% else %>
-    <div class="field <%= "#{type}-row" %>">
-      <%= f.label :firstname %>
-      <%= f.text_field :firstname, class: 'fullwidth' %>
-    </div>
-
-    <div class="field <%= "#{type}-row" %>">
-      <%= f.label :lastname %>
-      <%= f.text_field :lastname, class: 'fullwidth' %>
-    </div>
-  <% end %>
+  <div class="field <%= "#{type}-row" %>">
+    <%= f.label :name %>
+    <%= f.text_field :name, class: 'fullwidth' %>
+  </div>
 
   <% if Spree::Config[:company] %>
     <div class="field <%= "#{type}-row" %>">

--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -22,9 +22,9 @@ module Spree
       self.class.state_validator_class.new(self).perform
     end
 
-    DB_ONLY_ATTRS = %w(id updated_at created_at)
-    TAXATION_ATTRS = %w(state_id country_id zipcode)
-    LEGACY_NAME_ATTRS = %w(firstname lastname)
+    DB_ONLY_ATTRS = %w(id updated_at created_at).freeze
+    TAXATION_ATTRS = %w(state_id country_id zipcode).freeze
+    LEGACY_NAME_ATTRS = %w(firstname lastname).freeze
 
     self.whitelisted_ransackable_attributes = %w[firstname lastname]
 

--- a/core/app/models/spree/address/name.rb
+++ b/core/app/models/spree/address/name.rb
@@ -7,24 +7,6 @@ module Spree
     class Name
       attr_reader :first_name, :last_name, :value
 
-      # Creates an instance of Spree::Address::Name parsing input attributes.
-      # @param attributes [Hash] an hash possibly containing name-related
-      #   attributes (name, firstname, lastname, first_name, last_name)
-      # @return [Spree::Address::Name] the object created
-      def self.from_attributes(attributes)
-        params = attributes.with_indifferent_access
-
-        if params[:name].present?
-          Spree::Address::Name.new(params[:name])
-        elsif params[:firstname].present?
-          Spree::Address::Name.new(params[:firstname], params[:lastname])
-        elsif params[:first_name].present?
-          Spree::Address::Name.new(params[:first_name], params[:last_name])
-        else
-          Spree::Address::Name.new
-        end
-      end
-
       def initialize(*components)
         @value = components.join(' ').strip
         initialize_name_components(components)

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -147,9 +147,7 @@ module Spree
       find_by! number: value
     end
 
-    delegate :name, :firstname, :lastname, to: :bill_address, prefix: true, allow_nil: true
-    alias_method :billing_firstname, :bill_address_firstname
-    alias_method :billing_lastname, :bill_address_lastname
+    delegate :name, to: :bill_address, prefix: true, allow_nil: true
     alias_method :billing_name, :bill_address_name
 
     class_attribute :update_hooks

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -26,8 +26,6 @@ en:
         address2: Street Address (cont'd)
         city: City
         company: Company
-        firstname: First Name
-        lastname: Last Name
         name: Name
         phone: Phone
         zipcode: Zip Code
@@ -130,8 +128,6 @@ en:
       spree/order/bill_address:
         address1: Billing address street
         city: Billing address city
-        firstname: Billing address first name
-        lastname: Billing address last name
         name: Billing address name
         phone: Billing address phone
         state: Billing address state
@@ -139,8 +135,6 @@ en:
       spree/order/ship_address:
         address1: Shipping address street
         city: Shipping address city
-        firstname: Shipping address first name
-        lastname: Shipping address last name
         name: Shipping address name
         phone: Shipping address phone
         state: Shipping address state

--- a/core/lib/generators/solidus/install/templates/config/initializers/spree.rb.tt
+++ b/core/lib/generators/solidus/install/templates/config/initializers/spree.rb.tt
@@ -10,9 +10,6 @@ Spree.config do |config|
   # from address for transactional emails
   config.mails_from = "store@example.com"
 
-  # Use combined first and last name attribute in HTML views and API responses
-  config.use_combined_first_and_last_name_in_address = true
-
   # Use legacy Spree::Order state machine
   config.use_legacy_order_state_machine = false
 

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -303,10 +303,6 @@ module Spree
     #   @return [] Track on_hand values for variants / products. (default: true)
     preference :track_inventory_levels, :boolean, default: true
 
-    # @!attribute [rw] use_combined_first_and_last_name_in_address
-    #   @return [Boolean] Use Spree::Address combined first and last name in HTML views and
-    #   API responses. (default: +false+)
-    preference :use_combined_first_and_last_name_in_address, :boolean, default: false
 
     # @!attribute [rw] use_legacy_order_state_machine
     #   @return [Boolean] Uses the legacy order state machine from Spree::Order::Checkout

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -39,8 +39,7 @@ module Spree
     mattr_reader(*ATTRIBUTES)
 
     @@address_attributes = [
-      :id, :name, :firstname, :lastname, :first_name, :last_name,
-      :address1, :address2, :city, :country_id, :state_id,
+      :id, :name, :address1, :address2, :city, :country_id, :state_id,
       :zipcode, :phone, :state_name, :country_iso, :alternative_phone, :company,
       country: [:iso, :name, :iso3, :iso_name],
       state: [:name, :abbr]

--- a/core/lib/spree/testing_support/dummy_app.rb
+++ b/core/lib/spree/testing_support/dummy_app.rb
@@ -119,7 +119,6 @@ Spree.config do |config|
   config.raise_with_invalid_currency = false
   config.redirect_back_on_unauthorized = true
   config.run_order_validations_on_order_updater = true
-  config.use_combined_first_and_last_name_in_address = true
   config.use_legacy_order_state_machine = false
   config.use_custom_cancancan_actions = false
   config.consider_actionless_promotion_active = false

--- a/core/spec/models/spree/address/name_spec.rb
+++ b/core/spec/models/spree/address/name_spec.rb
@@ -22,49 +22,4 @@ RSpec.describe Spree::Address::Name do
     expect(name.first_name).to eq('Jane')
     expect(name.last_name).to eq('Von Doe')
   end
-
-  context 'from attributes' do
-    it 'returns name with nil first name if no relevant attribute found' do
-      name = described_class.from_attributes({})
-
-      expect(name.first_name).to be_nil
-      expect(name.last_name).to be_nil
-    end
-
-    it 'prioritizes name over firstname' do
-      attributes = {
-        name: 'Jane Doe',
-        firstname: 'Joe',
-        lastname: 'Bloggs'
-      }
-      name = described_class.from_attributes(attributes)
-
-      expect(name.first_name).to eq('Jane')
-      expect(name.last_name).to eq('Doe')
-    end
-
-    it 'prioritizes firstname over first_name' do
-      attributes = {
-        firstname: 'Jane',
-        lastname: 'Doe',
-        first_name: 'Joe',
-        last_name: 'Bloggs'
-      }
-      name = described_class.from_attributes(attributes)
-
-      expect(name.first_name).to eq('Jane')
-      expect(name.last_name).to eq('Doe')
-    end
-
-    it 'eventually uses first_name' do
-      attributes = {
-        first_name: 'Jane',
-        last_name: 'Doe'
-      }
-      name = described_class.from_attributes(attributes)
-
-      expect(name.first_name).to eq('Jane')
-      expect(name.last_name).to eq('Doe')
-    end
-  end
 end

--- a/core/spec/models/spree/address_spec.rb
+++ b/core/spec/models/spree/address_spec.rb
@@ -5,23 +5,6 @@ require 'rails_helper'
 RSpec.describe Spree::Address, type: :model do
   subject { Spree::Address }
 
-  context "aliased attributes" do
-    before do
-      allow(Spree::Deprecation).to receive(:warn).and_call_original
-      allow(Spree::Deprecation).to receive(:warn).with(/firstname|lastname/, any_args)
-    end
-
-    let(:address) { Spree::Address.new firstname: 'Ryan', lastname: 'Bigg' }
-
-    it " first_name" do
-      expect(address.first_name).to eq("Ryan")
-    end
-
-    it "last_name" do
-      expect(address.last_name).to eq("Bigg")
-    end
-  end
-
   context "validation" do
     let(:country) { create :country, states_required: true }
     let(:state) { create :state, name: 'maryland', abbr: 'md', country: country }
@@ -143,7 +126,7 @@ RSpec.describe Spree::Address, type: :model do
 
   context ".immutable_merge" do
     RSpec::Matchers.define :be_address_equivalent_attributes do |expected|
-      fields_of_interest = [:firstname, :lastname, :company, :address1, :address2, :city, :zipcode, :phone, :alternative_phone]
+      fields_of_interest = [:name, :company, :address1, :address2, :city, :zipcode, :phone, :alternative_phone]
       match do |actual|
         expected_attrs = expected.symbolize_keys.slice(*fields_of_interest)
         actual_attrs = actual.symbolize_keys.slice(*fields_of_interest)
@@ -238,21 +221,6 @@ RSpec.describe Spree::Address, type: :model do
         expect(subject).to eq('address1' => '1234 way', 'address2' => 'apt 2')
       end
     end
-
-    context 'with aliased attributes' do
-      let(:base_attributes) { { 'first_name' => 'Jordan' } }
-      let(:merge_attributes) { { 'last_name' => 'Brough' } }
-
-      it 'renames them to the normalized value' do
-        expect(subject).to eq('firstname' => 'Jordan', 'lastname' => 'Brough')
-      end
-
-      it 'does not modify the original hashes' do
-        subject
-        expect(base_attributes).to eq('first_name' => 'Jordan')
-        expect(merge_attributes).to eq('last_name' => 'Brough')
-      end
-    end
   end
 
   describe '.taxation_attributes' do
@@ -294,30 +262,6 @@ RSpec.describe Spree::Address, type: :model do
   end
 
   context '#name' do
-    it 'concatenates firstname and lastname' do
-      address = Spree::Address.new(firstname: 'Michael J.', lastname: 'Jackson')
-
-      expect(address.name).to eq('Michael J. Jackson')
-    end
-
-    it 'returns lastname when firstname is blank' do
-      address = Spree::Address.new(firstname: nil, lastname: 'Jackson')
-
-      expect(address.name).to eq('Jackson')
-    end
-
-    it 'returns firstanme when lastname is blank' do
-      address = Spree::Address.new(firstname: 'Michael J.', lastname: nil)
-
-      expect(address.name).to eq('Michael J.')
-    end
-
-    it 'returns empty string when firstname and lastname are blank' do
-      address = Spree::Address.new(firstname: nil, lastname: nil)
-
-      expect(address.name).to eq('')
-    end
-
     it 'is included in json representation' do
       address = Spree::Address.new(name: 'Jane Von Doe')
 
@@ -348,31 +292,5 @@ RSpec.describe Spree::Address, type: :model do
     subject { described_class.new }
 
     it { is_expected.to be_require_phone }
-  end
-
-  context 'deprecations' do
-    let(:address) { described_class.new }
-
-    specify 'json representation does not contain deprecated fields' do
-      expect(address.as_json).not_to include('firstname', 'lastname')
-    end
-
-    specify 'firstname is deprecated' do
-      expect(Spree::Deprecation).to receive(:warn).with(/firstname/, any_args)
-
-      address.firstname
-    end
-
-    specify 'lastname is deprecated' do
-      expect(Spree::Deprecation).to receive(:warn).with(/lastname/, any_args)
-
-      address.lastname
-    end
-
-    specify 'full_name is deprecated' do
-      expect(Spree::Deprecation).to receive(:warn).with(/full_name/, any_args)
-
-      address.full_name
-    end
   end
 end

--- a/frontend/app/views/spree/address/_form.html.erb
+++ b/frontend/app/views/spree/address/_form.html.erb
@@ -1,21 +1,9 @@
 <% address_id = address_type.chars.first %>
 <div class="inner" data-hook=<%="#{address_type}_inner" %>>
- <% if Spree::Config.use_combined_first_and_last_name_in_address %>
-    <div class="field field-required" id="<%= "#{address_id}name" %>">
-      <%= form.label :name, t('spree.name') %>
-      <%= form.text_field :name, class: 'required', autocomplete: address_type + ' name', required: true, autofocus: true %>
-    </div>
-  <% else %>
-    <div class="field field-required" id="<%= "#{address_id}firstname" %>">
-      <%= form.label :firstname, t('spree.first_name') %>
-      <%= form.text_field :firstname, class: 'required', autocomplete: address_type + ' given-name', required: true, autofocus: true %>
-    </div>
-
-    <div class="field" id="<%= "#{address_id}lastname" %>">
-      <%= form.label :lastname, t('spree.last_name') %>
-      <%= form.text_field :lastname, autocomplete: address_type + ' family-name' %>
-    </div>
-  <% end %>
+  <div class="field field-required" id="<%= "#{address_id}name" %>">
+    <%= form.label :name, t('spree.name') %>
+    <%= form.text_field :name, class: 'required', autocomplete: address_type + ' name', required: true, autofocus: true %>
+  </div>
 
   <% if Spree::Config[:company] %>
     <div class="field" id=<%="#{address_id}company" %>>

--- a/frontend/app/views/spree/address/_form_hidden.html.erb
+++ b/frontend/app/views/spree/address/_form_hidden.html.erb
@@ -1,9 +1,4 @@
-<% if Spree::Config.use_combined_first_and_last_name_in_address %>
-  <%= form.hidden_field :name %>
-<% else %>
-  <%= form.hidden_field :firstname %>
-  <%= form.hidden_field :lastname %>
-<% end %>
+<%= form.hidden_field :name %>
 <%= form.hidden_field :company %>
 <%= form.hidden_field :address1 %>
 <%= form.hidden_field :address2 %>

--- a/guides/source/developers/users/addresses.html.md
+++ b/guides/source/developers/users/addresses.html.md
@@ -18,8 +18,6 @@ Spree::User.find(1).addresses
 `Spree::Address` objects have the following attributes:
 
 - `name`: The full name for the person at this address.
-- `firstname`: *Deprecated: will be removed in Solidus 3.0, please use `name` attribute* - The first name for the person at this address.
-- `lastname`: *Deprecated: will be removed in Solidus 3.0, please use `name` attribute* - The last name for the person at this address.
 - `address1` and `address2`: The street address (with an optional second line).
 - `city`: The city where the address is.
 - `zipcode`: The postal code.


### PR DESCRIPTION
**Description**

Ref #3816 and #3234

This PR removes deprecated public-accessible `Address` name fields and their aliases:
- `full_name`
- `firstname`
- `first_name`
- `lastname`
- `last_name`.

`Address` `name` attribute is still interally persisted on the DB as two separate `firstname` and `lastname` columms, in a future PR we can move them to a new `name` column and provide a rake task to help migrate existing data.

<!--
  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

  Please include screenshots in case of visual changes to the frontend or backend sections of Solidus.

  If needed you can reference another PR or issue here, e.g.:
  Ref #ISSUE
-->

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- ~~[] I have added tests to cover this change (if needed)~~
- [x] I have attached screenshots to this PR for visual changes (if needed)
