### PR TITLE
Implicitly include required spec modules

### DIFF
--- a/api/spec/spec_helper.rb
+++ b/api/spec/spec_helper.rb
@@ -54,7 +54,6 @@ RSpec.configure do |config|
   config.extend Spree::Api::TestingSupport::Setup, type: :request
   config.include Spree::Api::TestingSupport::Helpers, type: :controller
   config.extend Spree::Api::TestingSupport::Setup, type: :controller
-  config.include Spree::TestingSupport::Preferences
   config.include Spree::TestingSupport::JobHelpers
 
   config.extend WithModel

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -95,7 +95,6 @@ RSpec.configure do |config|
 
   config.include FactoryBot::Syntax::Methods
 
-  config.include Spree::TestingSupport::Preferences
   config.include Spree::TestingSupport::UrlHelpers
   config.include Spree::TestingSupport::ControllerRequests, type: :controller
   config.include Spree::TestingSupport::Flash

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -99,7 +99,6 @@ RSpec.configure do |config|
   config.include Spree::TestingSupport::UrlHelpers
   config.include Spree::TestingSupport::ControllerRequests, type: :controller
   config.include Spree::TestingSupport::Flash
-  config.include Spree::TestingSupport::Translations
   config.include Spree::TestingSupport::JobHelpers
 
   config.extend WithModel

--- a/core/lib/spree/testing_support/blacklist_urls.rb
+++ b/core/lib/spree/testing_support/blacklist_urls.rb
@@ -13,6 +13,8 @@ module Spree
 end
 
 RSpec.configure do |config|
+  config.include Spree::TestingSupport::BlacklistUrls
+
   config.before(:each, type: :feature) do
     setup_url_blacklist(page.driver.browser)
   end

--- a/core/lib/spree/testing_support/preferences.rb
+++ b/core/lib/spree/testing_support/preferences.rb
@@ -122,6 +122,8 @@ module Spree
 end
 
 RSpec.configure do |config|
+  config.include Spree::TestingSupport::Preferences
+
   config.before :suite do
     %w[
       Spree::Config

--- a/core/lib/spree/testing_support/translations.rb
+++ b/core/lib/spree/testing_support/translations.rb
@@ -15,6 +15,8 @@ module Spree
 end
 
 RSpec.configure do |config|
+  config.include Spree::TestingSupport::Translations
+
   config.after(:each, type: :feature) do |example|
     check_missing_translations(page, example)
   end

--- a/core/spec/spec_helper.rb
+++ b/core/spec/spec_helper.rb
@@ -22,7 +22,6 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
 
-  config.include Spree::TestingSupport::Preferences
   config.extend WithModel
 
   config.filter_run focus: true

--- a/frontend/spec/spec_helper.rb
+++ b/frontend/spec/spec_helper.rb
@@ -87,7 +87,6 @@ RSpec.configure do |config|
   config.include Spree::TestingSupport::ControllerRequests, type: :controller
   config.include Spree::TestingSupport::Flash
   config.include Spree::TestingSupport::BlacklistUrls
-  config.include Spree::TestingSupport::Translations
 
   config.example_status_persistence_file_path = "./spec/examples.txt"
 

--- a/frontend/spec/spec_helper.rb
+++ b/frontend/spec/spec_helper.rb
@@ -82,7 +82,6 @@ RSpec.configure do |config|
 
   config.include FactoryBot::Syntax::Methods
 
-  config.include Spree::TestingSupport::Preferences
   config.include Spree::TestingSupport::UrlHelpers
   config.include Spree::TestingSupport::ControllerRequests, type: :controller
   config.include Spree::TestingSupport::Flash

--- a/frontend/spec/spec_helper.rb
+++ b/frontend/spec/spec_helper.rb
@@ -86,7 +86,6 @@ RSpec.configure do |config|
   config.include Spree::TestingSupport::UrlHelpers
   config.include Spree::TestingSupport::ControllerRequests, type: :controller
   config.include Spree::TestingSupport::Flash
-  config.include Spree::TestingSupport::BlacklistUrls
 
   config.example_status_persistence_file_path = "./spec/examples.txt"
 


### PR DESCRIPTION
**Description**
In _solidus_starter_frontend_ we had an issue with `Spree::TestingSupport::Translations` because the module file was required in the spec_helper but it wasn't included in RSpec configuration. Reference PR [here](https://github.com/nebulab/solidus_starter_frontend/pull/121).

I'm going to propose with this PR to automatically include the spec modules that we are requiring to avoid these kinds of conflicts.

**Checklist:**
- [ ] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [ ] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
