### PR TITLE
Multiple domains are considered

### DIFF
--- a/core/app/models/spree/store_selector/by_server_name.rb
+++ b/core/app/models/spree/store_selector/by_server_name.rb
@@ -22,7 +22,7 @@ module Spree
         # We select a store which either matches our server name, or is default.
         # We sort by `default ASC` so that a store matching SERVER_NAME will come
         # first, and we will find that instead of the default.
-        store = Spree::Store.where(url: server_name).or(Store.where(default: true)).order(default: :asc).first
+        store = Spree::Store.by_url(server_name).or(Store.where(default: true)).order(default: :asc).first
 
         # Provide a fallback, mostly for legacy/testing purposes
         store || Spree::Store.new

--- a/core/spec/models/spree/store_selector/by_server_name_spec.rb
+++ b/core/spec/models/spree/store_selector/by_server_name_spec.rb
@@ -23,6 +23,16 @@ RSpec.describe Spree::StoreSelector::ByServerName do
           expect(subject).to eq(store_2)
         end
       end
+
+      context "with two domains match one" do
+        let(:request) { double(headers: {}, env: { "SERVER_NAME" => 'server-name.org' } ) }
+        let(:url) { "server-name.org other-name.org" }
+        let!(:store_3) { create :store, default: false, url: url }
+
+        it "returns the store with the matching domain" do
+          expect(subject).to eq(store_3)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
**Description**
If you have two shops configured like my-shop.net and other-shop.net, while other-shop should respond to two domains (other-shop.net and www.other-shop.net) this seems not to work at the moment. The fix is less strict while checking the domain name.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
