### PR TITLE
Fix ability to perform refunds after a first failed attempt

### DIFF
--- a/backend/app/controllers/spree/admin/refunds_controller.rb
+++ b/backend/app/controllers/spree/admin/refunds_controller.rb
@@ -11,8 +11,9 @@ module Spree
       rescue_from Spree::Core::GatewayError, with: :spree_core_gateway_error
 
       def create
-        @refund.attributes = refund_params.merge(perform_after_create: false)
-        if @refund.save && @refund.perform!
+        @refund.attributes = refund_params
+
+        if @refund.valid? && @refund.perform!
           flash[:success] = flash_message_for(@refund, :successfully_created)
           respond_with(@refund) do |format|
             format.html { redirect_to location_after_save }

--- a/backend/spec/controllers/spree/admin/refunds_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/refunds_controller_spec.rb
@@ -42,7 +42,7 @@ describe Spree::Admin::RefundsController do
     context "a Spree::Core::GatewayError is raised" do
       before do
         expect_any_instance_of(Spree::Refund).
-          to receive(:perform!).
+          to receive(:process!).
           and_raise(Spree::Core::GatewayError.new('An error has occurred'))
       end
 

--- a/core/app/models/spree/refund.rb
+++ b/core/app/models/spree/refund.rb
@@ -61,7 +61,13 @@ module Spree
       )
 
       log_entries.build(details: perform_response.to_yaml)
-      update!(transaction_id: perform_response.authorization)
+
+      self.transaction_id = perform_response.authorization
+      # This is needed otherwise set_perform_after_create_default callback
+      # will print a deprecation warning when save! creates a record.
+      self.perform_after_create = false unless persisted?
+      save!
+
       update_order
     end
 


### PR DESCRIPTION
**Description**

With #1415 we introduced a bug in the Admin:

When attempting to create a refund for a payment that fails with a gateway error, it's no more possible to create refunds for that payment. 


To reproduce:

1. Click the refund link on any payment

<img width="1145" alt="Screenshot 2020-11-05 at 15 41 27" src="https://user-images.githubusercontent.com/167946/98255403-aab08400-1f7d-11eb-8f74-062837e9e3a7.png">


2. Refund credit allowed is correct, let's proceed with the refund **using a gateway that will fail**

<img width="1148" alt="Screenshot 2020-11-05 at 15 41 38" src="https://user-images.githubusercontent.com/167946/98255560-cfa4f700-1f7d-11eb-9d6f-bbddf810aaaf.png">

At this point, we have the flash message correctly printed with the error:

<img width="1150" alt="Screenshot 2020-11-05 at 15 42 02" src="https://user-images.githubusercontent.com/167946/98256015-5b1e8800-1f7e-11eb-85c0-8da7ebdf6921.png">

3. A refund is actually created and we can't create new refunds:

<img width="1142" alt="Screenshot 2020-11-05 at 15 42 16" src="https://user-images.githubusercontent.com/167946/98256192-8dc88080-1f7e-11eb-8a56-16804eb6fcb0.png">

This is due to the split of record creation and calling `perform!` in `Spree::Admin::RefundsController#create`. In fact, when we create a refund in the first place, it is added to the database but when we call `perform!` right after the creation, and it fails, the record created is not marked as failed anyhow. The system assumes all refunds are successful and consider them done if when they failed, disabling us to create new ones for those payments.

In fact, the refundable amount is calculated with 

```
payment.credit_allowed = payment total - refunds amount
```

and this formula is true also when the refund has not been successful.

This comes from our past behavior of creating and calling perform! on refunds at the same time. Records weren't created if the refund failed to perform.

A more clean solution would be considering in that formula only refunds that are completed but at the moment there's no way to do that. This way we can also keep track of the failed attempts to perform refunds, saving all the information we get back from the gateway. But this is way more invasive and we can't do this in a patch level fix. 

This change is supposed to be merged in master (for 3.0) and backported to v2.11, which is the version that introduces the bug.


**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] ~I have updated Guides and README accordingly to this change (if needed)~
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
