### PR TITLE
Lock Rails version to < 6.1.x

### DIFF
--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
     actionmailer actionpack actionview activejob activemodel activerecord
     activesupport railties
   ].each do |rails_dep|
-    s.add_dependency rails_dep, ['>= 5.2', '< 7.0.x']
+    s.add_dependency rails_dep, ['>= 5.2', '< 6.1.x']
   end
 
   s.add_dependency 'activemerchant', '~> 1.66'


### PR DESCRIPTION
**Description**

This way it doesn't try to use Rails 6.1, which has not yet been released yet and we are not yet compatible with. Not sure why the CI isn't failing on master, I suspect it's for some cached gems.

This is causing all extensions specs to fail and needs to be backported in all versions that are compatible with Rails 6.
