### PR TITLE
Fix install instructions in Solidus Guides

### DIFF
--- a/guides/source/developers/getting-started/first-time-installation.html.md
+++ b/guides/source/developers/getting-started/first-time-installation.html.md
@@ -57,12 +57,13 @@ You can find more details on Solidus' dependencies in the
 First, we need a new Rails project:
 
 ```bash
-rails new your_solidus_project_name --skip_webpack_install
+rails new your_solidus_project_name --skip-javascript
 ```
 
 This command will create a new Rails application without installing
-[webpacker][webpacker], which is not required for a sample Solidus store. You
-are free to install and configure webpacker in your Solidus store though.
+the JavaScript compiler shipped with Rails by default ([webpacker][webpacker]),
+which is not required for a sample Solidus store.
+You are still free to install and configure it in your Solidus store though.
 
 Once the new project has finished being created, we can open the project's newly
 created `Gemfile` in a text editor and add the required Solidus gems as new


### PR DESCRIPTION
**Description**

As adopted from @kennyadsl commit on the edge guides solidusio/edgeguides#12:

Using --skip-webpack-install is only preventing the Rails install
generator from running webacker:install, but the webpacker gem is
still added to the Gemfile causing an error when starting the server:
'Webpacker configuration file not found'

In the context of a fresh app that uses the bare minimum set of tools to
run Solidus we don't need that. People can still add it later if needed.


**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
~~- [ ] I have added tests to cover this change (if needed)~~
~~- [ ] I have attached screenshots to this PR for visual changes (if needed)~~
