### PR TITLE
Update order_tabs Order number format

### DIFF
--- a/backend/app/views/spree/admin/shared/_order_tabs.html.erb
+++ b/backend/app/views/spree/admin/shared/_order_tabs.html.erb
@@ -1,5 +1,5 @@
 <% admin_breadcrumb(link_to plural_resource_name(Spree::Order), spree.admin_orders_path) %>
-<% admin_breadcrumb(link_to "##{@order.number}", spree.edit_admin_order_path(@order)) %>
+<% admin_breadcrumb(link_to @order.number, spree.edit_admin_order_path(@order)) %>
 
 
 <% content_for :sidebar_title do %>


### PR DESCRIPTION
Many Solidus objects have a "number" field, including Orders, Shipments, Payments, etc. Counterintuitively this "number" generally begins with a letter. :) It’s "R" in the case of Orders, "H" in the case of Shipments, etc.

In almost all cases we simply display this as a string:

<img width="263" alt="Screen Shot 2020-11-08 at 2 16 54 PM" src="https://user-images.githubusercontent.com/2460418/98485764-aaa6c300-21cd-11eb-94d6-0990a0532704.png">

<img width="450" alt="Screen Shot 2020-11-08 at 2 21 54 PM" src="https://user-images.githubusercontent.com/2460418/98485799-ce6a0900-21cd-11eb-9935-ee316bf4136b.png">

<img width="449" alt="Screen Shot 2020-11-08 at 2 21 46 PM" src="https://user-images.githubusercontent.com/2460418/98485805-d3c75380-21cd-11eb-8830-bc78db44e9f2.png">

However, there is one exception, which is the Order breadcrumb, which prepends a "#" symbol:

<img width="296" alt="Screen Shot 2020-11-08 at 2 22 49 PM" src="https://user-images.githubusercontent.com/2460418/98485811-e3469c80-21cd-11eb-8a47-3d09336cce1d.png">

This PR removes the "#" in the Order breadcrumb for consistency with other Order views as well as Shipments, Payments, etc.