### PR TITLE
Avoid asking user to run migration creating the sandbox

### DIFF
--- a/bin/sandbox
+++ b/bin/sandbox
@@ -69,7 +69,8 @@ unbundled bin/rails generate solidus:install \
   --payment-method=none
   $@
 
-unbundled bin/rails generate solidus:auth:install
+unbundled bin/rails generate solidus:auth:install \
+  --auto_run_migrations=true
 
 echo "
 🚀 This app is intended for test purposes. If you're interested in running


### PR DESCRIPTION
**Description**

It's not needed since the sandbox always starts in a clean env and should work with a single command.

Closes: https://github.com/solidusio/solidus/issues/3830