### PR TITLE
Fix permissions to see admin menu items

### DIFF
--- a/backend/app/views/spree/admin/shared/_settings_sub_menu.html.erb
+++ b/backend/app/views/spree/admin/shared/_settings_sub_menu.html.erb
@@ -3,24 +3,24 @@
     <%= tab :stores, label: :stores, url: spree.admin_stores_path %>
   <% end %>
 
-  <% if can?(:show, Spree::PaymentMethod) %>
+  <% if can?(:admin, Spree::PaymentMethod) %>
     <%= tab :payments, url: spree.admin_payment_methods_path %>
   <% end %>
 
-  <% if can?(:show, Spree::TaxCategory) || can?(:show, Spree::TaxRate) %>
+  <% if can?(:admin, Spree::TaxCategory) || can?(:admin, Spree::TaxRate) %>
     <%= tab :taxes, url: spree.admin_tax_categories_path, match_path: %r(tax_categories|tax_rates) %>
   <% end %>
 
-  <% if can?(:show, Spree::RefundReason) || can?(:show, Spree::ReimbursementType) ||
+  <% if can?(:admin, Spree::RefundReason) || can?(:admin, Spree::ReimbursementType) ||
     can?(:show, Spree::ReturnReason) || can?(:show, Spree::AdjustmentReason) %>
     <%= tab :checkout, url: spree.admin_refund_reasons_path, match_path: %r(refund_reasons|reimbursement_types|return_reasons|adjustment_reasons|store_credit_reasons) %>
   <% end %>
 
-  <% if can?(:show, Spree::ShippingMethod) || can?(:show, Spree::ShippingCategory) || can?(:show, Spree::StockLocation) %>
+  <% if can?(:admin, Spree::ShippingMethod) || can?(:admin, Spree::ShippingCategory) || can?(:admin, Spree::StockLocation) %>
     <%= tab :shipping, url: spree.admin_shipping_methods_path, match_path: %r(shipping_methods|shipping_categories|stock_locations) %>
   <% end %>
 
-  <% if can?(:show, Spree::Zone) %>
+  <% if can?(:admin, Spree::Zone) %>
     <%= tab :zones, url: spree.admin_zones_path %>
   <% end %>
 </ul>

--- a/backend/lib/spree/backend_configuration.rb
+++ b/backend/lib/spree/backend_configuration.rb
@@ -133,17 +133,17 @@ module Spree
           'wrench',
           condition: -> {
             can?(:admin, Spree::Store) ||
-            can?(:show, Spree::AdjustmentReason) ||
-            can?(:show, Spree::PaymentMethod) ||
-            can?(:show, Spree::RefundReason) ||
-            can?(:show, Spree::ReimbursementType) ||
-            can?(:show, Spree::ShippingCategory) ||
-            can?(:show, Spree::ShippingMethod) ||
-            can?(:show, Spree::StockLocation) ||
-            can?(:show, Spree::TaxCategory) ||
-            can?(:show, Spree::TaxRate) ||
-            can?(:show, Spree::ReturnReason) ||
-            can?(:show, Spree::Zone)
+            can?(:admin, Spree::AdjustmentReason) ||
+            can?(:admin, Spree::PaymentMethod) ||
+            can?(:admin, Spree::RefundReason) ||
+            can?(:admin, Spree::ReimbursementType) ||
+            can?(:admin, Spree::ShippingCategory) ||
+            can?(:admin, Spree::ShippingMethod) ||
+            can?(:admin, Spree::StockLocation) ||
+            can?(:admin, Spree::TaxCategory) ||
+            can?(:admin, Spree::TaxRate) ||
+            can?(:admin, Spree::ReturnReason) ||
+            can?(:admin, Spree::Zone)
           },
           label: :settings,
           partial: 'spree/admin/shared/settings_sub_menu',

--- a/backend/spec/features/admin/homepage_spec.rb
+++ b/backend/spec/features/admin/homepage_spec.rb
@@ -73,8 +73,8 @@ describe "Homepage", type: :feature do
     custom_authorization! do |_user|
       can [:admin, :home], :dashboards
       can [:admin, :edit, :index, :show], Spree::Order
-      cannot [:show], Spree::StockLocation
-      cannot [:show], Spree::Zone
+      cannot [:admin], Spree::StockLocation
+      can [:admin], Spree::Zone
     end
 
     it 'should only display tabs fakedispatch has access to' do
@@ -82,7 +82,9 @@ describe "Homepage", type: :feature do
       expect(page).to have_link('Orders')
       expect(page).not_to have_link('Products')
       expect(page).not_to have_link('Promotions')
-      expect(page).not_to have_link('Settings')
+      expect(page).to have_link('Settings')
+      expect(page).not_to have_link('Stock Locations', visible: false)
+      expect(page).to have_link('Zones', visible: false)
     end
   end
 end


### PR DESCRIPTION
**Description**

Closes #3834.

Right now a user without roles like logged users or guests user can see the admin menu partially, see https://github.com/solidusio/solidus/issues/3834. 

This behavior has been introduced with https://github.com/solidusio/solidus/commit/295df5e8d92e85b3c5a7fc6c761c32b691b81b75#diff-757abc24f29994c5e06e233c60ca1f3972c2f5019fba628df718eea681adb61fR68 and it happens because a non-admin user actually has permission to show zones and shipping methods; the current code is checking against the `:show` ability, so it seems to be legit.

We use `:admin` for the rest of the menu items checks though, and this is also what we use in the controller to determine if
we can access that page, see: https://github.com/solidusio/solidus/blob/3c8ffcc34f9248b286a9d4ca94d1f9a3197ac7b2/backend/app/controllers/spree/admin/base_controller.rb#L29

Test setup lines have been removed since they are useless now.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
