### PR TITLE
Remove deprecated cancan abilities

### DIFF
--- a/backend/app/views/spree/admin/products/index.html.erb
+++ b/backend/app/views/spree/admin/products/index.html.erb
@@ -84,7 +84,7 @@
               &nbsp;
               <%= link_to_clone product, no_text: true, class: 'clone' if can?(:clone, product) %>
               &nbsp;
-              <%= link_to_delete product, no_text: true if can?(:delete, product) && !product.deleted? %>
+              <%= link_to_delete product, no_text: true if can?(:destroy, product) && !product.deleted? %>
             </td>
           </tr>
       <% end %>


### PR DESCRIPTION
**Description**

With 915ffa3149fd1a532e22c55bb9fd715292991b6b we correctly switched a custom cancan alias to use the correct one and print a deprecation warning when the wrong one was used.

But we forgot to update the code to reflect this change. No deprecation warnings were raising because we have the `use_custom_cancancan_actions` set to false on new apps.

I switched that preference to true locally and specs started to raise deprecations warnings, signaling where we were using the wrong alias and this commit is the result of that investigation.

