### PR TITLE
Check for edit permission when showing store credit edit link

### DIFF
--- a/backend/app/views/spree/admin/store_credits/index.html.erb
+++ b/backend/app/views/spree/admin/store_credits/index.html.erb
@@ -56,7 +56,7 @@
                 <span><%= t store_credit.invalidated? ? 'spree.say_yes' : 'spree.say_no' %></span>
               </td>
               <td class="actions" data-hook="admin_store_credits_index_row_actions">
-                <% if can?(:show, store_credit) %>
+                <% if can?(:edit, store_credit) %>
                   <%= link_to_edit_url admin_user_store_credit_path(@user, store_credit), { no_text: true, class: 'edit' } %>
                 <% end %>
               </td>


### PR DESCRIPTION
**Description**

Checking for `show` makes the edit link visible also to users that cannot edit store credits. This is corrected by checking for the `edit` permission.


**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message