### PR TITLE
Raise canceling a payment when try_void is not implemented

### DIFF
--- a/core/spec/models/spree/payment/cancellation_spec.rb
+++ b/core/spec/models/spree/payment/cancellation_spec.rb
@@ -23,59 +23,42 @@ RSpec.describe Spree::Payment::Cancellation do
     let(:payment_method) { create(:payment_method) }
     let(:payment) { create(:payment, payment_method: payment_method, amount: 10) }
 
-    context 'if the payment_method responds to `try_void`' do
-      context 'if payment method returns void response' do
-        before do
-          expect(payment_method).to receive(:try_void).with(payment) { double }
-        end
-
-        it 'handles the void' do
-          expect(payment).to receive(:handle_void_response)
-          subject
-        end
+    context 'if payment method returns void response' do
+      before do
+        expect(payment_method).to receive(:try_void).with(payment) { double }
       end
 
-      context 'if payment method rejects the void' do
-        before do
-          expect(payment_method).to receive(:try_void).with(payment) { false }
-        end
-
-        it 'refunds the payment' do
-          expect { subject }.to change { payment.refunds.count }.from(0).to(1)
-        end
-
-        context 'if payment has partial refunds' do
-          let(:credit_amount) { payment.amount / 2 }
-
-          before do
-            payment.refunds.create!(
-              amount: credit_amount,
-              reason: Spree::RefundReason.where(name: 'test').first_or_create,
-              perform_after_create: false
-            ).perform!
-          end
-
-          it 'only refunds the allowed credit amount' do
-            subject
-            refund = payment.refunds.last
-            expect(refund.amount).to eq(credit_amount)
-          end
-        end
+      it 'handles the void' do
+        expect(payment).to receive(:handle_void_response)
+        subject
       end
     end
 
-    context 'if the payment_method does not respond to `try_void`', partial_double_verification: false do
+    context 'if payment method rejects the void' do
       before do
-        allow(payment_method).to receive(:respond_to?) { false }
-        allow(payment_method).to receive(:cancel) { double }
-        allow(payment).to receive(:handle_void_response)
-        expect(Spree::Deprecation).to receive(:warn).
-          with(/^Spree::PaymentMethod::.*#cancel is deprecated and will be removed/, any_args)
+        expect(payment_method).to receive(:try_void).with(payment) { false }
       end
 
-      it 'calls cancel instead' do
-        expect(payment_method).to receive(:cancel)
-        subject
+      it 'refunds the payment' do
+        expect { subject }.to change { payment.refunds.count }.from(0).to(1)
+      end
+
+      context 'if payment has partial refunds' do
+        let(:credit_amount) { payment.amount / 2 }
+
+        before do
+          payment.refunds.create!(
+            amount: credit_amount,
+            reason: Spree::RefundReason.where(name: 'test').first_or_create,
+            perform_after_create: false
+          ).perform!
+        end
+
+        it 'only refunds the allowed credit amount' do
+          subject
+          refund = payment.refunds.last
+          expect(refund.amount).to eq(credit_amount)
+        end
       end
     end
   end


### PR DESCRIPTION
**Description**

The previous (deprecated) behavior was still calling cancel without trying to void the payment first.
The actual raise will be handled in Spree::PaymentMethod since it's already present in that class.

**Note:** This is part of #3816, but since it's not trivial I'd like to have a more accurate review from the core team, especially from @tvdeyen. 🙏 
