### PR TITLE
Fix use_legacy_address_state_validator deprecation message

### DIFF
--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -86,7 +86,7 @@ module Spree
             Spree::Config.use_legacy_address_state_validator set to true has been
             deprecated and will be removed in Solidus 3.0. The Spree::Address state
             validation has been extracted into a configurable external class.
-            Switch Spree::Config.use_legacy_address_state_validator to true to start
+            Switch Spree::Config.use_legacy_address_state_validator to false to start
             using the external validation class.
           DEPRECATION
         end


### PR DESCRIPTION
To activate the new behavior the value should be false, not true.
