### PR TITLE
Avoid `#method` shadowing

### DIFF
--- a/core/app/models/spree/calculator.rb
+++ b/core/app/models/spree/calculator.rb
@@ -10,12 +10,12 @@ module Spree
     def compute(computable)
       # Spree::LineItem -> :compute_line_item
       computable_name = computable.class.name.demodulize.underscore
-      method = "compute_#{computable_name}".to_sym
+      method_name = "compute_#{computable_name}".to_sym
       calculator_class = self.class
-      if respond_to?(method)
-        send(method, computable)
+      if respond_to?(method_name)
+        send(method_name, computable)
       else
-        raise NotImplementedError, "Please implement '#{method}(#{computable_name})' in your calculator: #{calculator_class.name}"
+        raise NotImplementedError, "Please implement '#{method_name}(#{computable_name})' in your calculator: #{calculator_class.name}"
       end
     end
 

--- a/core/app/models/spree/order/payments.rb
+++ b/core/app/models/spree/order/payments.rb
@@ -37,14 +37,14 @@ module Spree
 
       private
 
-      def process_payments_with(method)
+      def process_payments_with(method_name)
         # Don't run if there is nothing to pay.
         return true if payment_total >= total
 
         unprocessed_payments.each do |payment|
           break if payment_total >= total
 
-          payment.public_send(method)
+          payment.public_send(method_name)
         end
       rescue Core::GatewayError => error
         result = !!Spree::Config[:allow_checkout_on_gateway_error]

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -191,12 +191,12 @@ module Spree
 
     private
 
-    def inject_attributes_to_all_steps(attributes, method)
+    def inject_attributes_to_all_steps(attributes, method_name)
       attributes.each do |attribute|
-        PermittedAttributes.checkout_address_attributes.send(method, attribute)
-        PermittedAttributes.checkout_delivery_attributes.send(method, attribute)
-        PermittedAttributes.checkout_payment_attributes.send(method, attribute)
-        PermittedAttributes.checkout_confirm_attributes.send(method, attribute)
+        PermittedAttributes.checkout_address_attributes.send(method_name, attribute)
+        PermittedAttributes.checkout_delivery_attributes.send(method_name, attribute)
+        PermittedAttributes.checkout_payment_attributes.send(method_name, attribute)
+        PermittedAttributes.checkout_confirm_attributes.send(method_name, attribute)
       end
     end
   end


### PR DESCRIPTION
Ruby already defines the method `Object#method`, so variables and parameters are renamed in order to avoid shadowing that method.

**Description**
<!--
  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

  Please include screenshots in case of visual changes to the frontend or backend sections of Solidus.

  If needed you can reference another PR or issue here, e.g.:
  Ref #ISSUE
-->

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
