### PR TITLE
Remove legacy address state validation logic

### DIFF
--- a/core/lib/generators/solidus/install/templates/config/initializers/spree.rb.tt
+++ b/core/lib/generators/solidus/install/templates/config/initializers/spree.rb.tt
@@ -16,9 +16,6 @@ Spree.config do |config|
   # Use legacy Spree::Order state machine
   config.use_legacy_order_state_machine = false
 
-  # Use the legacy address' state validation logic
-  config.use_legacy_address_state_validator = false
-
   # Uncomment to stop tracking inventory levels in the application
   # config.track_inventory_levels = false
 

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -34,10 +34,6 @@ module Spree
     #   @return [Boolean] should state/state_name be required (default: +true+)
     preference :address_requires_state, :boolean, default: true
 
-    # @!attribute [rw] legacy
-    #   @return [Boolean] use the legacy address' state validation logic (default: +true+)
-    preference :use_legacy_address_state_validator, :boolean, default: true
-
     # @!attribute [rw] admin_interface_logo
     #   @return [String] URL of logo used in admin (default: +'logo/solidus.svg'+)
     preference :admin_interface_logo, :string, default: 'logo/solidus.svg'

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -80,16 +80,6 @@ module Spree
             caller
           )
         end
-
-        if Spree::Config.use_legacy_address_state_validator != false
-          Spree::Deprecation.warn(<<~DEPRECATION.squish, caller)
-            Spree::Config.use_legacy_address_state_validator set to true has been
-            deprecated and will be removed in Solidus 3.0. The Spree::Address state
-            validation has been extracted into a configurable external class.
-            Switch Spree::Config.use_legacy_address_state_validator to false to start
-            using the external validation class.
-          DEPRECATION
-        end
       end
 
       # Load in mailer previews for apps to use in development.

--- a/core/lib/spree/testing_support/dummy_app.rb
+++ b/core/lib/spree/testing_support/dummy_app.rb
@@ -115,7 +115,6 @@ end
 
 Spree.user_class = 'Spree::LegacyUser'
 Spree.config do |config|
-  config.use_legacy_address_state_validator = false
   config.mails_from = "store@example.com"
   config.raise_with_invalid_currency = false
   config.redirect_back_on_unauthorized = true

--- a/core/spec/models/spree/address_spec.rb
+++ b/core/spec/models/spree/address_spec.rb
@@ -30,10 +30,6 @@ RSpec.describe Spree::Address, type: :model do
     context 'state validation' do
       let(:state_validator) { instance_spy(Spree::Address.state_validator_class) }
 
-      before do
-        stub_spree_preferences(use_legacy_address_state_validator: false)
-      end
-
       it "calls the state validator" do
         allow(Spree::Address.state_validator_class).
           to receive(:new).with(address).
@@ -51,30 +47,6 @@ RSpec.describe Spree::Address, type: :model do
         address.state_name = nil
         expect(address.valid?).to eq(false)
         expect(address.errors['state']).to eq(["can't be blank"])
-      end
-
-      context 'legacy state validator' do
-        before do
-          stub_spree_preferences(use_legacy_address_state_validator: true)
-        end
-
-        it 'doesnt show deprecation warnings when calling #valid?' do
-          expect(Spree::Deprecation).to_not receive(:warn).
-            with(/^Spree::Address#state_validate private method has been deprecated/, any_args)
-          expect(Spree::Deprecation).to_not receive(:warn).
-            with(/^Spree::Address#validate_state_matches_country private method has been deprecated/, any_args)
-          address.valid?
-        end
-
-        it 'shows the deprecation warnings when calling validation methods directly' do
-          expect(Spree::Deprecation).to receive(:warn).
-            with(/^Spree::Address#state_validate private method has been deprecated/, any_args)
-          address.send(:state_validate)
-
-          expect(Spree::Deprecation).to receive(:warn).
-            with(/^Spree::Address#validate_state_matches_country private method has been deprecated/, any_args)
-          address.send(:validate_state_matches_country)
-        end
       end
     end
 


### PR DESCRIPTION
Address state validation logic has been extracted into a dedicated class in #3129
The legacy validation logic has been kept for compatibility reasons allowing stores to upgrade without being forced to switch to the new validation logic.
With this PR, the old validation is definitely removed.

NOTE: this PR is part of a bigger deprecations removal initiative. See PR #3818 for other deprecations being removed.

### Removals without deprecation

- `Spree::Config.use_legacy_address_state_validator`: preference introduced for switching between the legacy state validator and the new one. By removing the legacy state validator this preference is no more needed.

**Checklist:**
- [ ] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [ ] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
