### PR TITLE
Remove all usage of FooAbility and BarAbility when testing abilities

### DIFF
--- a/core/spec/models/spree/ability_spec.rb
+++ b/core/spec/models/spree/ability_spec.rb
@@ -5,10 +5,6 @@ require 'cancan'
 require 'cancan/matchers'
 require 'spree/testing_support/ability_helpers'
 
-Spree::Deprecation.silence do
-  require 'spree/testing_support/bar_ability'
-end
-
 RSpec.describe Spree::Ability, type: :model do
   let(:user) { build(:user) }
   let(:ability) { Spree::Ability.new(user) }

--- a/core/spec/models/spree/ability_spec.rb
+++ b/core/spec/models/spree/ability_spec.rb
@@ -98,7 +98,17 @@ RSpec.describe Spree::Ability, type: :model do
       it 'should be able to admin on the order and shipment pages' do
         user.spree_roles << Spree::Role.find_or_create_by(name: 'bar')
 
-        Spree::Ability.register_ability(BarAbility)
+        bar_ability = Class.new do
+          include CanCan::Ability
+
+          def initialize(user)
+            if user.has_spree_role? 'bar'
+              can [:admin, :index, :show], Spree::Order
+              can [:admin, :manage], Spree::Shipment
+            end
+          end
+        end
+        Spree::Ability.register_ability(bar_ability)
 
         expect(ability).not_to be_able_to :admin, resource
 

--- a/core/spec/models/spree/ability_spec.rb
+++ b/core/spec/models/spree/ability_spec.rb
@@ -122,8 +122,6 @@ RSpec.describe Spree::Ability, type: :model do
         # It can create new users if is has access to the :admin, User!!
 
         # TODO: change the Ability class so only users and customers get the extra premissions?
-
-        Spree::Ability.remove_ability(BarAbility)
       end
     end
 


### PR DESCRIPTION
**Description**

This is preparatory work for #3816. We need to remove `BarAbility` that is deprecated, but it's actually still used in the codebase. 

This PR removes its usage and takes advantage of the change to also remove `FooAbility` class, which is very similar but wasn't under the radar in a [previous refactor](https://github.com/solidusio/solidus/pull/2629) because it's not defining a top-level class in our documentation.

Needs backport on v2.11.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message