### PR TITLE
Add soft-delete support for Api::ResourceController

### DIFF
--- a/api/app/controllers/spree/api/resource_controller.rb
+++ b/api/app/controllers/spree/api/resource_controller.rb
@@ -53,7 +53,13 @@ class Spree::Api::ResourceController < Spree::Api::BaseController
   def destroy
     authorize! :destroy, @object
 
-    if @object.destroy
+    destroy_result = if @object.respond_to?(:discard)
+      @object.discard
+    else
+      @object.destroy
+    end
+
+    if destroy_result
       respond_with(@object, status: 204)
     else
       invalid_resource!(@object)

--- a/api/spec/controllers/spree/api/resource_controller_spec.rb
+++ b/api/spec/controllers/spree/api/resource_controller_spec.rb
@@ -172,17 +172,18 @@ module Spree
 
     describe "#destroy" do
       let!(:widget) { Widget.create!(name: "a widget") }
+
       it "returns unauthorized" do
         delete :destroy, params: { id: widget.to_param, token: user.spree_api_key }, as: :json
         assert_not_found!
-        expect { widget.reload }.not_to raise_error
+        expect { Widget.find(widget.id) }.not_to raise_error
       end
 
       context "it is authorized to destroy widgets" do
-        it "can destroy a widget" do
+        it "hard-deletes the widget" do
           delete :destroy, params: { id: widget.to_param, token: admin_user.spree_api_key }, as: :json
           expect(response.status).to eq 204
-          expect { widget.reload }.to raise_error(ActiveRecord::RecordNotFound)
+          expect { Widget.find(widget.id) }.to raise_error(ActiveRecord::RecordNotFound)
         end
       end
     end

--- a/api/spec/controllers/spree/api/soft_deletable_resource_controller_spec.rb
+++ b/api/spec/controllers/spree/api/soft_deletable_resource_controller_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module Spree
+  module Api
+    class WidgetsController < Spree::Api::ResourceController
+      def model_class
+        Widget
+      end
+    end
+  end
+
+  describe Api::WidgetsController, type: :controller do
+    after(:all) do
+      Rails.application.reload_routes!
+    end
+
+    with_model 'Widget', scope: :all do
+      table do |widget|
+        widget.datetime :deleted_at
+        widget.timestamps null: false
+      end
+
+      model do
+        include Spree::SoftDeletable
+      end
+    end
+
+    before do
+      Spree::Core::Engine.routes.draw do
+        namespace :api do
+          resources :widgets
+        end
+      end
+    end
+
+    let(:user) { create(:user, :with_api_key) }
+    let(:admin_user) { create(:admin_user, :with_api_key) }
+
+    describe "#destroy" do
+      let(:widget) { Widget.create! }
+
+      it "soft-deletes the widget" do
+        delete :destroy, params: { id: widget.to_param, token: admin_user.spree_api_key }, as: :json
+        expect(response.status).to eq 204
+
+        expect { Widget.find(widget.id) }.to raise_error(ActiveRecord::RecordNotFound)
+        expect(Widget.with_discarded.find(widget.id)).to eq(widget)
+      end
+    end
+  end
+end


### PR DESCRIPTION
With Paranoia being replaced by Discard (#3488) this adds soft-delete support also to `Api::ResourceController` the same way it is [implemented in `Admin::ResourceController`](https://github.com/solidusio/solidus/blob/47dacbad7b7d056058dc78a3cc8da45334da0a2e/backend/app/controllers/spree/admin/resource_controller.rb#L94-L101). This way, when deleting a record having Discard included, it will soft-delete the record instead of hard-deleting it.

**Checklist:**
- [ ] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [ ] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
