### PR TITLE
Add Rails 6.1 support

### DIFF
--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -76,9 +76,10 @@ module Spree
       end
 
       def parameter_missing_error(exception)
+        message = exception.original_message || exception.message
         render json: {
-          exception: exception.message,
-          error: exception.message,
+          exception: message,
+          error: message,
           missing_param: exception.param
         }, status: :unprocessable_entity
       end

--- a/backend/spec/helpers/admin/navigation_helper_spec.rb
+++ b/backend/spec/helpers/admin/navigation_helper_spec.rb
@@ -3,6 +3,10 @@
 require 'spec_helper'
 
 describe Spree::Admin::NavigationHelper, type: :helper do
+  before do
+    allow(controller).to receive(:controller_name).and_return('test')
+  end
+
   describe "#tab" do
     context "creating an admin tab" do
       it "should capitalize the first letter of each word in the tab's label" do

--- a/core/app/models/spree/base.rb
+++ b/core/app/models/spree/base.rb
@@ -3,8 +3,6 @@
 class Spree::Base < ActiveRecord::Base
   include Spree::Preferences::Preferable
   include Spree::Core::Permalinks
-  serialize :preferences, Hash
-
   include Spree::RansackableAttributes
 
   def initialize_preference_defaults
@@ -18,6 +16,7 @@ class Spree::Base < ActiveRecord::Base
   def self.preference(*args)
     # after_initialize can be called multiple times with the same symbol, it
     # will only be called once on initialization.
+    serialize :preferences, Hash
     after_initialize :initialize_preference_defaults
     super
   end

--- a/core/app/models/spree/product/scopes.rb
+++ b/core/app/models/spree/product/scopes.rb
@@ -70,7 +70,6 @@ module Spree
           add_search_scope :in_taxon do |taxon|
             includes(:classifications)
               .where('spree_products_taxons.taxon_id' => taxon.self_and_descendants.pluck(:id))
-              .select(Spree::Classification.arel_table[:position])
               .order(Spree::Classification.arel_table[:position].asc)
           end
 

--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
     actionmailer actionpack actionview activejob activemodel activerecord
     activesupport railties
   ].each do |rails_dep|
-    s.add_dependency rails_dep, ['>= 5.2', '< 6.1.x']
+    s.add_dependency rails_dep, ['>= 5.2', '< 6.2.x']
   end
 
   s.add_dependency 'activemerchant', '~> 1.66'

--- a/core/spec/helpers/base_helper_spec.rb
+++ b/core/spec/helpers/base_helper_spec.rb
@@ -121,10 +121,9 @@ RSpec.describe Spree::BaseHelper, type: :helper do
 
   # Regression test for https://github.com/spree/spree/issues/2396
   context "meta_data_tags" do
+    let(:controller_name) { 'test' }
+
     it "truncates a product description to 160 characters" do
-      # Because the controller_name method returns "test"
-      # controller_name is used by this method to infer what it is supposed
-      # to be generating meta_data_tags for
       @test = Spree::Product.new(description: "a" * 200)
       tags = Nokogiri::HTML.parse(meta_data_tags)
       content = tags.css("meta[name=description]").first["content"]

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -826,7 +826,7 @@ RSpec.describe Spree::Promotion, type: :model do
       end
 
       it "should have eligible rules if any of the rules are eligible" do
-        true_rule = mock_model(Spree::PromotionRule, eligible?: true, applicable?: true)
+        true_rule = stub_model(Spree::PromotionRule, eligible?: true, applicable?: true)
         promotion.promotion_rules = [true_rule]
         allow(promotion.rules).to receive(:for) { promotion.rules }
         expect(promotion.eligible_rules(promotable)).to eq [true_rule]
@@ -856,8 +856,8 @@ RSpec.describe Spree::Promotion, type: :model do
   describe '#line_item_actionable?' do
     let(:order) { double Spree::Order }
     let(:line_item) { double Spree::LineItem }
-    let(:true_rule) { mock_model Spree::PromotionRule, eligible?: true, applicable?: true, actionable?: true }
-    let(:false_rule) { mock_model Spree::PromotionRule, eligible?: true, applicable?: true, actionable?: false }
+    let(:true_rule) { stub_model Spree::PromotionRule, eligible?: true, applicable?: true, actionable?: true }
+    let(:false_rule) { stub_model Spree::PromotionRule, eligible?: true, applicable?: true, actionable?: false }
     let(:rules) { [] }
 
     before do


### PR DESCRIPTION
**Description**
Fixes #3784 

This PR fixes some incompatibilities with Rails 6.1:
- default values of ActiveRecord serialized hash attributes have changed
- the current version of `rspec-activemodel-mocks`s mock_model is not compatible with some ActiveRecord associations
- current controller is not available anymore in `helper`s specs
- `select` in joins now always works correctly
- ActionController's error messages now provide `DidYouMean` suggestions

**TODO**:
- [x] waiting for [this PR](https://github.com/CanCanCommunity/cancancan/pull/657) to be merged to fix CanCanCan errors
- [x] waiting for https://github.com/jumph4x/canonical-rails/pull/63 and https://github.com/jumph4x/canonical-rails/pull/65  to be merged to fix solidus_frontend dependencies
- [x] waiting for [a new version of font-awesome-rails to be released](https://github.com/bokmann/font-awesome-rails/issues/206) to fix solidus_frontend dependencies

<!--
  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

  Please include screenshots in case of visual changes to the frontend or backend sections of Solidus.

  If needed you can reference another PR or issue here, e.g.:
  Ref #ISSUE
-->

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- ~~[ ] I have updated Guides and README accordingly to this change (if needed)~~
- ~~[ ] I have added tests to cover this change (if needed)~~
- ~~[ ] I have attached screenshots to this PR for visual changes (if needed)~~
