### PR TITLE
Deprecate unused calculators

### DIFF
--- a/core/app/models/spree/calculator/free_shipping.rb
+++ b/core/app/models/spree/calculator/free_shipping.rb
@@ -8,6 +8,7 @@ module Spree
   #   now a Promotion Action which deals with these types of promotions instead.
   class Calculator::FreeShipping < Calculator
     def compute(object)
+      Spree::Deprecation.warn('This method is deprecated, because it is no longer used')
       if object.is_a?(Array)
         return if object.empty?
         order = object.first.order

--- a/core/app/models/spree/calculator/percent_per_item.rb
+++ b/core/app/models/spree/calculator/percent_per_item.rb
@@ -15,6 +15,8 @@ module Spree
     preference :percent, :decimal, default: 0
 
     def compute(object = nil)
+      Spree::Deprecation.warn('This method is deprecated, please use adjustments at line item level')
+
       return 0 if object.nil?
       object.line_items.sum { |line_item|
         value_for_line_item(line_item)

--- a/core/app/models/spree/calculator/price_sack.rb
+++ b/core/app/models/spree/calculator/price_sack.rb
@@ -11,6 +11,7 @@ module Spree
 
     # as object we always get line items, as calculable we have Coupon, ShippingMethod
     def compute(object)
+      Spree::Deprecation.warn('This method is deprecated, please use adjustments at line item level')
       if object.is_a?(Array)
         base = object.sum { |element| element.respond_to?(:amount) ? element.amount : BigDecimal(element.to_s) }
       else

--- a/core/spec/models/spree/calculator/free_shipping_spec.rb
+++ b/core/spec/models/spree/calculator/free_shipping_spec.rb
@@ -5,4 +5,16 @@ require 'shared_examples/calculator_shared_examples'
 
 RSpec.describe Spree::Calculator::FreeShipping, type: :model do
   it_behaves_like 'a calculator with a description'
+
+  describe '#compute' do
+    let(:order) { stub_model(Spree::Order) }
+
+    before do
+      expect(Spree::Deprecation).to receive(:warn).with(/method is deprecated/)
+    end
+
+    it 'warns about deprecation' do
+      described_class.new.compute(order)
+    end
+  end
 end

--- a/core/spec/models/spree/calculator/percent_per_item_spec.rb
+++ b/core/spec/models/spree/calculator/percent_per_item_spec.rb
@@ -8,5 +8,17 @@ require_dependency 'spree/calculator'
 module Spree
   RSpec.describe Calculator::PercentPerItem, type: :model do
     it_behaves_like 'a calculator with a description'
+
+    describe '#compute' do
+      let(:order) { stub_model(Spree::Order) }
+
+      before do
+        expect(Spree::Deprecation).to receive(:warn).with(/method is deprecated/)
+      end
+
+      it 'warns about deprecation' do
+        described_class.new.compute(order)
+      end
+    end
   end
 end

--- a/core/spec/models/spree/calculator/price_sack_spec.rb
+++ b/core/spec/models/spree/calculator/price_sack_spec.rb
@@ -14,22 +14,28 @@ RSpec.describe Spree::Calculator::PriceSack, type: :model do
 
   it_behaves_like 'a calculator with a description'
 
-  let(:order) { stub_model(Spree::Order) }
-  let(:shipment) { stub_model(Spree::Shipment, amount: 10) }
+  describe '#compute' do
+    let(:order) { stub_model(Spree::Order) }
+    let(:shipment) { stub_model(Spree::Shipment, amount: 10) }
 
-  # Regression test for https://github.com/spree/spree/issues/714 and https://github.com/spree/spree/issues/739
-  it "computes with an order object" do
-    calculator.compute(order)
-  end
+    before do
+      expect(Spree::Deprecation).to receive(:warn).with(/method is deprecated/).at_least(1)
+    end
 
-  # Regression test for https://github.com/spree/spree/issues/1156
-  it "computes with a shipment object" do
-    calculator.compute(shipment)
-  end
+    # Regression test for https://github.com/spree/spree/issues/714 and https://github.com/spree/spree/issues/739
+    it "computes with an order object" do
+      calculator.compute(order)
+    end
 
-  # Regression test for https://github.com/spree/spree/issues/2055
-  it "computes the correct amount" do
-    expect(calculator.compute(2)).to eq(calculator.preferred_normal_amount)
-    expect(calculator.compute(6)).to eq(calculator.preferred_discount_amount)
+    # Regression test for https://github.com/spree/spree/issues/1156
+    it "computes with a shipment object" do
+      calculator.compute(shipment)
+    end
+
+    # Regression test for https://github.com/spree/spree/issues/2055
+    it "computes the correct amount" do
+      expect(calculator.compute(2)).to eq(calculator.preferred_normal_amount)
+      expect(calculator.compute(6)).to eq(calculator.preferred_discount_amount)
+    end
   end
 end


### PR DESCRIPTION
The following models have been deprecated without making any warning messages.

https://github.com/solidusio/solidus/blob/33821050ad299640ea31d104a59dd38bcd97ae2a/core/app/models/spree/calculator/free_shipping.rb#L6
https://github.com/solidusio/solidus/blob/33821050ad299640ea31d104a59dd38bcd97ae2a/core/app/models/spree/calculator/percent_per_item.rb#L12

This PR is going to add the related deprecation message.

**Checklist:**
- [X] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [X] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [X] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
