### PR TITLE
Update canonical-rails syntax for latest version

### DIFF
--- a/frontend/config/initializers/canonical_rails.rb
+++ b/frontend/config/initializers/canonical_rails.rb
@@ -12,5 +12,5 @@ CanonicalRails.setup do |config|
   # Parameter spamming can cause index dilution by creating seemingly different URLs with identical or near-identical content.
   # Unless whitelisted, these parameters will be omitted
 
-  config.whitelisted_parameters = [:keywords, :page, :search, :taxon]
+  config.allowed_parameters = [:keywords, :page, :search, :taxon]
 end

--- a/frontend/solidus_frontend.gemspec
+++ b/frontend/solidus_frontend.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'solidus_api', s.version
   s.add_dependency 'solidus_core', s.version
 
-  s.add_dependency 'canonical-rails', '~> 0.2.0'
+  s.add_dependency 'canonical-rails', '~> 0.2.10'
   s.add_dependency 'font-awesome-rails', '~> 4.0'
   s.add_dependency 'jquery-rails'
   s.add_dependency 'kaminari', '~> 1.1'


### PR DESCRIPTION
**Description**
canonical-rails version 0.2.10 changed the method `whitelisted_parameters` to `allowed_parameters`. (See https://github.com/jumph4x/canonical-rails/pull/58/files.)

Any user running `bundle update` and going from version <= 0.2.9 to 0.2.10 will fail to compile their asset pipeline, resulting in the error `NoMethodError: undefined method 'whitelisted_parameters=' for CanonicalRails:Module`.

This updates to the current syntax, and also sets the dependency at 0.2.10 to prevent any incompatibility issues that might arise from using the new `allowed_parameters` with old  versions that still expect `whitelisted_parameters`.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
