### PR TITLE
Update taxon icon to use present instead of exists

### DIFF
--- a/backend/app/views/spree/admin/taxons/attachment_forms/_paperclip.html.erb
+++ b/backend/app/views/spree/admin/taxons/attachment_forms/_paperclip.html.erb
@@ -2,7 +2,7 @@
   <%= f.field_container attachment do %>
     <%= f.label attachment %><br>
     <%= f.file_field attachment %>
-    <% if f.object.send(attachment).exists? %>
+    <% if f.object.send(attachment).present? %>
       <%= image_tag f.object.send(attachment, definition[:default_style]) %>
       <%= link_to t('spree.actions.remove'),
                   admin_taxonomy_taxon_attachment_path(@taxonomy,


### PR DESCRIPTION
`exists?` on a paperclip object attempts to access the image where
it's stored, whereas `present?` just checks if the object exists on
Solidus.

Using `exists?` here causes an error if the image doesn't exist. Luckily,
paperclip double checks that the image filename is present before
attempting to fetch it from the storage service, but paperclip_cloudinary
does not do this, meaning that any store using paperclip_cloudinary is
unable to view the admin taxon edit page for taxons without icons.

[This was an issue on the demo store](https://github.com/solidusio/solidus-demo/issues/69), which uses paperclip_cloudinary. I've patched it up there, but figured I should add a fix here as well.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
