### PR TITLE
eager load records instead of n+1 for update_positions

### DIFF
--- a/backend/app/controllers/spree/admin/resource_controller.rb
+++ b/backend/app/controllers/spree/admin/resource_controller.rb
@@ -78,8 +78,11 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
 
   def update_positions
     ActiveRecord::Base.transaction do
-      params[:positions].each do |id, index|
-        model_class.find_by(id: id)&.set_list_position(index)
+      positions = params[:positions]
+      records = model_class.where(id: positions.keys).to_a
+
+      positions.each do |id, index|
+        records.find { |r| r.id == id.to_i }&.set_list_position(index)
       end
     end
 


### PR DESCRIPTION
**Description**

Improves the performance of update_positions by eager loading all of the records instead of 1-by-1.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
