### PR TITLE
Fix Search::Base#respond_to_missing? arity

### DIFF
--- a/core/lib/spree/core/search/base.rb
+++ b/core/lib/spree/core/search/base.rb
@@ -46,8 +46,8 @@ module Spree
           end
         end
 
-        def respond_to_missing?(name)
-          @properties.key?(name) || super(name)
+        def respond_to_missing?(name, include_private)
+          @properties.key?(name) || super
         end
 
         protected


### PR DESCRIPTION
ref https://github.com/solidusio/solidus/commit/9219f1e384aa68f049eb0dd984ac7b780dd3884d

**Description**

The method's signature was wrong and ended up in an error when actually called through `respond_to?`.

https://ruby-doc.org/core-3.0.0/Object.html#method-i-respond_to_missing-3F

<!--
  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

  Please include screenshots in case of visual changes to the frontend or backend sections of Solidus.

  If needed you can reference another PR or issue here, e.g.:
  Ref #ISSUE
-->

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
