### PR TITLE
Allow Variant to check stock by stock_location

### DIFF
--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -356,9 +356,12 @@ module Spree
 
     # Fetches the on-hand quantity of the variant.
     #
+    # @param stock_location [Spree::StockLocation] Optionally restrict stock
+    #   quantity check to a specific stock location. If unspecified it will
+    #   check inventory in all available StockLocations.
     # @return [Fixnum] the number currently on-hand
-    def total_on_hand
-      Spree::Stock::Quantifier.new(self).total_on_hand
+    def total_on_hand(stock_location = nil)
+      Spree::Stock::Quantifier.new(self, stock_location).total_on_hand
     end
 
     # Shortcut method to determine if inventory tracking is enabled for this

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -346,9 +346,12 @@ module Spree
     end
 
     # @param quantity [Fixnum] how many are desired
+    # @param stock_location [Spree::StockLocation] Optionally restrict stock
+    #   quantity check to a specific stock location. If unspecified it will
+    #   check inventory in all available StockLocations.
     # @return [Boolean] true if the desired quantity can be supplied
-    def can_supply?(quantity = 1)
-      Spree::Stock::Quantifier.new(self).can_supply?(quantity)
+    def can_supply?(quantity = 1, stock_location = nil)
+      Spree::Stock::Quantifier.new(self, stock_location).can_supply?(quantity)
     end
 
     # Fetches the on-hand quantity of the variant.

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -649,6 +649,22 @@ RSpec.describe Spree::Variant, type: :model do
       variant = build(:variant)
       expect(variant.total_on_hand).to eq(Spree::Stock::Quantifier.new(variant).total_on_hand)
     end
+
+    context "with a stock_location specified" do
+      subject { variant.total_on_hand(stock_location) }
+
+      let(:quantifier) { instance_double(Spree::Stock::Quantifier) }
+      let(:stock_location) { build_stubbed(:stock_location) }
+
+      it "initializes the quantifier with the stock location" do
+        expect(Spree::Stock::Quantifier).
+          to receive(:new).
+          with(variant, stock_location).
+          and_return(quantifier)
+        allow(quantifier).to receive(:total_on_hand)
+        subject
+      end
+    end
   end
 
   describe '#tax_category' do

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -580,6 +580,22 @@ RSpec.describe Spree::Variant, type: :model do
         expect(quantifier).to receive(:can_supply?).with(10)
         variant.can_supply?(10)
       end
+
+      context "with a stock_location specified" do
+        subject { variant.can_supply?(10, stock_location) }
+
+        let(:quantifier) { instance_double(Spree::Stock::Quantifier) }
+        let(:stock_location) { build_stubbed(:stock_location) }
+
+        it "initializes the quantifier with the stock location" do
+          expect(Spree::Stock::Quantifier).
+            to receive(:new).
+            with(variant, stock_location).
+            and_return(quantifier)
+          allow(quantifier).to receive(:can_supply?).with(10)
+          subject
+        end
+      end
     end
 
     context 'when stock_items are backorderable' do


### PR DESCRIPTION
**Description**
Quantifier already has the ability to restrict stock checks to certain locations. This change just exposes that ability at the Variant level. This allows applications with multiple stock locations to check variant stock for a specific location without explicitly having to instantiate a new Quantifier with the stock location.

These changes allow both `Variant#total_on_hand` and `Variant#can_supply?` to optionally take a `stock_location`

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] ~I have updated Guides and README accordingly to this change (if needed)~
- [x] I have added tests to cover this change (if needed)
- [ ] ~I have attached screenshots to this PR for visual changes (if needed)~
