### PR TITLE
Adjust CircleCI config to reflect Rails versions that we support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,15 +128,6 @@ jobs:
       - setup
       - test
 
-  mysql_rails52:
-    executor: mysql
-    parallelism: *parallelism
-    environment:
-      RAILS_VERSION: '~> 5.2.0'
-    steps:
-      - setup
-      - test
-
 workflows:
   build:
     jobs:
@@ -147,7 +138,6 @@ workflows:
       - postgres
       - mysql
       - postgres_rails52
-      - mysql_rails52
       # - postgres_rails_master_activestorage
       - stoplight/push:
           context: "Solidus Core Team"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,19 +102,18 @@ jobs:
       - setup
       - test
 
-  postgres_rails_master_activestorage:
-    executor: postgres
+  mysql:
+    executor: mysql
     parallelism: *parallelism
-    environment:
-      RAILS_VERSION: 'master'
-      ENABLE_ACTIVE_STORAGE: true
     steps:
       - setup
       - test
 
-  mysql:
-    executor: mysql
+  postgres_rails60:
+    executor: postgres
     parallelism: *parallelism
+    environment:
+      RAILS_VERSION: '~> 6.0.0'
     steps:
       - setup
       - test
@@ -137,8 +136,8 @@ workflows:
               only: /master|v\d\.\d+/
       - postgres
       - mysql
+      - postgres_rails60
       - postgres_rails52
-      # - postgres_rails_master_activestorage
       - stoplight/push:
           context: "Solidus Core Team"
           project: solidus/solidus-api

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ group :backend, :frontend, :core, :api do
   if ENV['RAILS_VERSION'] == 'master'
     gem 'rails', github: 'rails', require: false
   else
-    gem 'rails', ENV['RAILS_VERSION'] || '~> 6.0.0', require: false
+    gem 'rails', ENV['RAILS_VERSION'] || '~> 6.1.0', require: false
   end
   # rubocop:enable Bundler/DuplicatedGem
 


### PR DESCRIPTION
**Description**

We recently added support for Rails 6.1 but we still need to run specs against Rails 6.0. This PR takes care of that.

To reduce the amount of CI time needed, I decided to remove MySQL tests for older Rails versions. 
