### PR TITLE
Enable ActiveStorage specs against Rails 6.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,6 +98,8 @@ jobs:
   postgres:
     executor: postgres
     parallelism: &parallelism 3
+    environment:
+      ENABLE_ACTIVE_STORAGE: true
     steps:
       - setup
       - test
@@ -105,6 +107,8 @@ jobs:
   mysql:
     executor: mysql
     parallelism: *parallelism
+    environment:
+      ENABLE_ACTIVE_STORAGE: true
     steps:
       - setup
       - test

--- a/backend/app/views/spree/admin/taxons/attachment_forms/_paperclip.html.erb
+++ b/backend/app/views/spree/admin/taxons/attachment_forms/_paperclip.html.erb
@@ -2,7 +2,7 @@
   <%= f.field_container attachment do %>
     <%= f.label attachment %><br>
     <%= f.file_field attachment %>
-    <% if f.object.send(attachment).present? %>
+    <% if f.object.send(:"#{attachment}_present?") %>
       <%= image_tag f.object.send(attachment, definition[:default_style]) %>
       <%= link_to t('spree.actions.remove'),
                   admin_taxonomy_taxon_attachment_path(@taxonomy,


### PR DESCRIPTION
**Description**

This PR is only useful to highlight the specs failures we have enabling ActiveStorage on Rails 6.1 and should be merged only after we fixed the existing issues.

Some ActiveStorage internals changed since we worked on this (see #2974 #3501) and we have to make some changes to reflect the new API.
