### PR TITLE
Set dummy app forgery protection to false

### DIFF
--- a/core/lib/generators/spree/dummy/templates/rails/test.rb
+++ b/core/lib/generators/spree/dummy/templates/rails/test.rb
@@ -20,6 +20,9 @@ Dummy::Application.configure do
   # Raise exceptions instead of rendering exception templates
   config.action_dispatch.show_exceptions = false
 
+  # Disable request forgery protection in test environment
+  config.action_controller.allow_forgery_protection = false
+
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.

--- a/core/lib/spree/testing_support/dummy_app.rb
+++ b/core/lib/spree/testing_support/dummy_app.rb
@@ -17,6 +17,7 @@ RAILS_6_OR_ABOVE = Rails.gem_version >= Gem::Version.new('6.0')
 
 # @private
 class ApplicationController < ActionController::Base
+  protect_from_forgery with: :exception
 end
 
 # @private
@@ -52,8 +53,8 @@ module DummyApp
     config.public_file_server.headers = { 'Cache-Control' => 'public, max-age=3600' }
     config.whiny_nils = true
     config.consider_all_requests_local = true
-    config.action_controller.allow_forgery_protection = true
-    config.action_controller.default_protect_from_forgery = true
+    config.action_controller.allow_forgery_protection = false
+    config.action_controller.default_protect_from_forgery = false
     config.action_controller.perform_caching = false
     config.action_dispatch.show_exceptions = false
     config.active_support.deprecation = :stderr


### PR DESCRIPTION
**Description**
This reverts a previous change setting dummy app forgery protection to true. Rails prefers testing to be performed with forgery protection set to false.

Verification effort: test suite passes

Ref #3873

**Checklist:**
- [X] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [X] I have added a detailed description into each commit message
- [X] I have updated Guides and README accordingly to this change (if needed)
- [X] I have added tests to cover this change (if needed)
- [X] I have attached screenshots to this PR for visual changes (if needed)
