### PR TITLE
Upgrade acts_as_list gem dependency to allow v1.x

### DIFF
--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   end
 
   s.add_dependency 'activemerchant', '~> 1.66'
-  s.add_dependency 'acts_as_list', '~> 0.3'
+  s.add_dependency 'acts_as_list', '< 2.0'
   s.add_dependency 'awesome_nested_set', '~> 3.2'
   s.add_dependency 'cancancan', ['>= 2.2', '< 4.0']
   s.add_dependency 'carmen', '~> 1.1.0'


### PR DESCRIPTION
This is a backport to Solidus 2.10 of https://github.com/solidusio/solidus/pull/3736.

Solidus 2.10 with Rails 6 emits some deprecations with acts_as_list < 1.0. 

Straight from a 2.10 sandbox:
```ruby
Spree::OptionType.find_or_create_by name: ‘foo’, presentation: ‘foo’
DEPRECATION WARNING: Class level methods will no longer inherit scoping from `create` in Rails 6.1. To continue using the scoped relation, pass it into the block directly. To instead access the full set of models, as Rails 6.1 will, use `Spree::OptionType.default_scoped`. (called from irb_binding at (irb):1)
 => #<Spree::OptionType id: 6, name: “foo”, presentation: “foo”, position: 6, created_at: “2020-12-28 16:37:22”, updated_at: “2020-12-28 16:37:22">
```

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
