### PR TITLE
Support multiple errors in Promotion Handlers

### DIFF
--- a/api/app/controllers/spree/api/checkouts_controller.rb
+++ b/api/app/controllers/spree/api/checkouts_controller.rb
@@ -121,8 +121,8 @@ module Spree
           handler = PromotionHandler::Coupon.new(@order)
           handler.apply
 
-          if handler.error.present?
-            @coupon_message = handler.error
+          if handler.errors.any?
+            @coupon_message = handler.errors.full_messages.join(", ")
             respond_with(@order, default_template: 'spree/api/orders/could_not_apply_coupon', status: 422)
             return true
           end

--- a/api/app/controllers/spree/api/coupon_codes_controller.rb
+++ b/api/app/controllers/spree/api/coupon_codes_controller.rb
@@ -15,7 +15,7 @@ module Spree
         if @handler.successful?
           render 'spree/api/promotions/handler', status: 200
         else
-          logger.error("apply_coupon_code_error=#{@handler.error.inspect}")
+          logger.error("apply_coupon_code_error=#{@handler.errors.full_messages.join(',')}")
           render 'spree/api/promotions/handler', status: 422
         end
       end

--- a/api/app/controllers/spree/api/coupon_codes_controller.rb
+++ b/api/app/controllers/spree/api/coupon_codes_controller.rb
@@ -29,7 +29,7 @@ module Spree
         if @handler.successful?
           render 'spree/api/promotions/handler', status: 200
         else
-          logger.error("remove_coupon_code_error=#{@handler.error.inspect}")
+          logger.error("remove_coupon_code_error=#{@handler.errors.full_messages.join(', ')}")
           render 'spree/api/promotions/handler', status: 422
         end
       end

--- a/api/app/controllers/spree/api/orders_controller.rb
+++ b/api/app/controllers/spree/api/orders_controller.rb
@@ -113,7 +113,7 @@ module Spree
         if @handler.successful?
           render "spree/api/promotions/handler", status: 200
         else
-          logger.error("apply_coupon_code_error=#{@handler.error.inspect}")
+          logger.error("apply_coupon_code_error=#{@handler.errors.full_messages.join(', ')}")
           render "spree/api/promotions/handler", status: 422
         end
       end

--- a/api/app/views/spree/api/promotions/handler.json.jbuilder
+++ b/api/app/views/spree/api/promotions/handler.json.jbuilder
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 json.success(@handler.success)
+json.error(@handler.error)
 json.errors(@handler.errors.details[:base])
 json.successful(@handler.successful?)
 json.status_code(@handler.status_code)

--- a/api/app/views/spree/api/promotions/handler.json.jbuilder
+++ b/api/app/views/spree/api/promotions/handler.json.jbuilder
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
 json.success(@handler.success)
-json.error(@handler.error)
+json.errors(@handler.errors.details[:base])
 json.successful(@handler.successful?)
-json.status_code(@handler.status_code)

--- a/api/app/views/spree/api/promotions/handler.json.jbuilder
+++ b/api/app/views/spree/api/promotions/handler.json.jbuilder
@@ -3,3 +3,4 @@
 json.success(@handler.success)
 json.errors(@handler.errors.details[:base])
 json.successful(@handler.successful?)
+json.status_code(@handler.status_code)

--- a/api/openapi/solidus-api.oas.yml
+++ b/api/openapi/solidus-api.oas.yml
@@ -6174,18 +6174,26 @@ components:
           type: string
         order_number:
           type: string
+    promotion-handler-error:
+      type: object
+      title: Promotion handler error
+      properties:
+        error:
+          type: string
+        error_code:
+          type: string
     coupon-code-handler:
       type: object
       title: Coupon code handler
       properties:
         success:
           type: string
-        error:
-          type: string
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/promotion-handler-error'
         successful:
           type: boolean
-        status_code:
-          type: string
     address-book:
       type: array
       title: Address book

--- a/api/openapi/solidus-api.oas.yml
+++ b/api/openapi/solidus-api.oas.yml
@@ -6188,12 +6188,18 @@ components:
       properties:
         success:
           type: string
+        error:
+          type: string
+          deprecated: true
         errors:
           type: array
           items:
             $ref: '#/components/schemas/promotion-handler-error'
         successful:
           type: boolean
+        status_code:
+          type: string
+          deprecated: true
     address-book:
       type: array
       title: Address book

--- a/api/spec/features/checkout_spec.rb
+++ b/api/spec/features/checkout_spec.rb
@@ -63,6 +63,7 @@ module Spree
     end
 
     def add_promotion(_promotion)
+      expect(Spree::Deprecation).to receive(:warn)
       expect {
         post "/api/orders/#{@order.number}/coupon_codes",
           params: { coupon_code: promotion_code.value }

--- a/api/spec/requests/spree/api/coupon_codes_controller_spec.rb
+++ b/api/spec/requests/spree/api/coupon_codes_controller_spec.rb
@@ -32,7 +32,7 @@ module Spree
           expect(order.reload.promotions).to eq([promo])
           expect(json_response).to eq({
             "success" => I18n.t('spree.coupon_code_applied'),
-            "error" => nil,
+            "errors" => [],
             "successful" => true,
             "status_code" => "coupon_code_applied"
           })
@@ -49,7 +49,12 @@ module Spree
           expect(order.reload.promotions).to eq([])
           expect(json_response).to eq({
             "success" => nil,
-            "error" => I18n.t('spree.coupon_code_unknown_error'),
+            "errors" => [
+              {
+                "error" => I18n.t('spree.coupon_code_unknown_error'),
+                "error_code" => "coupon_code_unknown_error"
+              }
+            ],
             "successful" => false,
             "status_code" => "coupon_code_unknown_error"
           })
@@ -79,7 +84,7 @@ module Spree
           expect(order.reload.promotions).to eq([])
           expect(json_response).to eq({
             "success" => I18n.t('spree.coupon_code_removed'),
-            "error" => nil,
+            "errors" => [],
             "successful" => true,
             "status_code" => "coupon_code_removed"
           })
@@ -94,7 +99,12 @@ module Spree
           expect(order.reload.promotions).to eq([])
           expect(json_response).to eq({
             "success" => nil,
-            "error" => I18n.t('spree.coupon_code_not_present'),
+            "errors" => [
+              {
+                "error" => I18n.t('spree.coupon_code_not_present'),
+                "error_code" => "coupon_code_not_present"
+              }
+            ],
             "successful" => false,
             "status_code" => "coupon_code_not_present"
           })

--- a/api/spec/requests/spree/api/coupon_codes_controller_spec.rb
+++ b/api/spec/requests/spree/api/coupon_codes_controller_spec.rb
@@ -26,12 +26,14 @@ module Spree
         let(:order) { create(:order_with_line_items) }
 
         it 'applies the coupon' do
+          expect(Spree::Deprecation).to receive(:warn)
           post spree.api_order_coupon_codes_path(order), params: { coupon_code: promo_code.value }
 
           expect(response.status).to eq(200)
           expect(order.reload.promotions).to eq([promo])
           expect(json_response).to eq({
             "success" => I18n.t('spree.coupon_code_applied'),
+            "error" => nil,
             "errors" => [],
             "successful" => true,
             "status_code" => "coupon_code_applied"
@@ -43,12 +45,14 @@ module Spree
         let(:order) { create(:order) }
 
         it 'returns an error' do
+          expect(Spree::Deprecation).to receive(:warn)
           post spree.api_order_coupon_codes_path(order), params: { coupon_code: promo_code.value }
 
           expect(response.status).to eq(422)
           expect(order.reload.promotions).to eq([])
           expect(json_response).to eq({
             "success" => nil,
+            "error" => I18n.t('spree.coupon_code_unknown_error'),
             "errors" => [
               {
                 "error" => I18n.t('spree.coupon_code_unknown_error'),
@@ -74,6 +78,7 @@ module Spree
       let(:order) { create(:order_with_line_items, user: current_api_user) }
 
       before do
+        expect(Spree::Deprecation).to receive(:warn).twice
         post spree.api_order_coupon_codes_path(order), params: { coupon_code: promo_code.value }
         delete spree.api_order_coupon_code_path(order, promo_code.value)
       end
@@ -84,6 +89,7 @@ module Spree
           expect(order.reload.promotions).to eq([])
           expect(json_response).to eq({
             "success" => I18n.t('spree.coupon_code_removed'),
+            "error" => nil,
             "errors" => [],
             "successful" => true,
             "status_code" => "coupon_code_removed"
@@ -93,12 +99,14 @@ module Spree
 
       context 'when unsuccessful' do
         it 'returns an error' do
+          expect(Spree::Deprecation).to receive(:warn)
           delete spree.api_order_coupon_code_path(order, promo_code.value)
 
           expect(response.status).to eq(422)
           expect(order.reload.promotions).to eq([])
           expect(json_response).to eq({
             "success" => nil,
+            "error" => I18n.t('spree.coupon_code_not_present'),
             "errors" => [
               {
                 "error" => I18n.t('spree.coupon_code_not_present'),

--- a/api/spec/requests/spree/api/orders_controller_spec.rb
+++ b/api/spec/requests/spree/api/orders_controller_spec.rb
@@ -953,7 +953,7 @@ module Spree
           expect(order.reload.promotions).to eq [promo]
           expect(json_response).to eq({
             "success" => I18n.t('spree.coupon_code_applied'),
-            "error" => nil,
+            "errors" => [],
             "successful" => true,
             "status_code" => "coupon_code_applied"
           })
@@ -972,7 +972,12 @@ module Spree
           expect(order.reload.promotions).to eq []
           expect(json_response).to eq({
             "success" => nil,
-            "error" => I18n.t('spree.coupon_code_unknown_error'),
+            "errors" => [
+              {
+                "error" => I18n.t('spree.coupon_code_unknown_error'),
+                "error_code" => "coupon_code_unknown_error"
+              }
+            ],
             "successful" => false,
             "status_code" => "coupon_code_unknown_error"
           })

--- a/api/spec/requests/spree/api/orders_controller_spec.rb
+++ b/api/spec/requests/spree/api/orders_controller_spec.rb
@@ -945,7 +945,7 @@ module Spree
         let(:order) { create(:order_with_line_items) }
 
         it 'applies the coupon' do
-          expect(Spree::Deprecation).to receive(:warn)
+          expect(Spree::Deprecation).to receive(:warn).twice
 
           put spree.apply_coupon_code_api_order_path(order), params: { coupon_code: promo_code.value }
 
@@ -953,6 +953,7 @@ module Spree
           expect(order.reload.promotions).to eq [promo]
           expect(json_response).to eq({
             "success" => I18n.t('spree.coupon_code_applied'),
+            "error" => nil,
             "errors" => [],
             "successful" => true,
             "status_code" => "coupon_code_applied"
@@ -964,7 +965,7 @@ module Spree
         let(:order) { create(:order) } # no line items to apply the code to
 
         it 'returns an error' do
-          expect(Spree::Deprecation).to receive(:warn)
+          expect(Spree::Deprecation).to receive(:warn).twice
 
           put spree.apply_coupon_code_api_order_path(order), params: { coupon_code: promo_code.value }
 
@@ -972,6 +973,7 @@ module Spree
           expect(order.reload.promotions).to eq []
           expect(json_response).to eq({
             "success" => nil,
+            "error" => I18n.t('spree.coupon_code_unknown_error'),
             "errors" => [
               {
                 "error" => I18n.t('spree.coupon_code_unknown_error'),

--- a/api/spec/requests/spree/api/promotion_application_spec.rb
+++ b/api/spec/requests/spree/api/promotion_application_spec.rb
@@ -19,6 +19,7 @@ module Spree::Api
       end
 
       it "can apply a coupon code to the order" do
+        expect(Spree::Deprecation).to receive(:warn)
         expect(order.total).to eq(110.00)
         post spree.api_order_coupon_codes_path(order), params: { coupon_code: "10off", order_token: order.guest_token }
         expect(response.status).to eq(200)
@@ -37,6 +38,7 @@ module Spree::Api
         end
 
         it "fails to apply" do
+          expect(Spree::Deprecation).to receive(:warn)
           post spree.api_order_coupon_codes_path(order), params: { coupon_code: "10off", order_token: order.guest_token }
           expect(response.status).to eq(422)
           expect(json_response["success"]).to be_blank

--- a/api/spec/requests/spree/api/promotion_application_spec.rb
+++ b/api/spec/requests/spree/api/promotion_application_spec.rb
@@ -24,7 +24,7 @@ module Spree::Api
         expect(response.status).to eq(200)
         expect(order.reload.total).to eq(109.00)
         expect(json_response["success"]).to eq("The coupon code was successfully applied to your order.")
-        expect(json_response["error"]).to be_blank
+        expect(json_response["errors"]).to be_empty
         expect(json_response["successful"]).to be true
         expect(json_response["status_code"]).to eq("coupon_code_applied")
       end
@@ -40,7 +40,7 @@ module Spree::Api
           post spree.api_order_coupon_codes_path(order), params: { coupon_code: "10off", order_token: order.guest_token }
           expect(response.status).to eq(422)
           expect(json_response["success"]).to be_blank
-          expect(json_response["error"]).to eq("The coupon code is expired")
+          expect(json_response["errors"]).to eq([{ "error" => "The coupon code is expired", "error_code" => "coupon_code_expired" }])
           expect(json_response["successful"]).to be false
           expect(json_response["status_code"]).to eq("coupon_code_expired")
         end

--- a/backend/app/assets/javascripts/spree/backend/adjustments.js
+++ b/backend/app/assets/javascripts/spree/backend/adjustments.js
@@ -16,7 +16,7 @@ Spree.ready(function() {
       },
       error: function(msg) {
         if (msg.responseJSON["errors"]) {
-          show_flash('error', msg.responseJSON["errors"].map((error) => error.error).join(', '));
+          show_flash('error', msg.responseJSON["errors"].map(error => error.error).join(', '));
         } else {
           show_flash('error', "There was a problem adding this coupon code.");
         }

--- a/backend/app/assets/javascripts/spree/backend/adjustments.js
+++ b/backend/app/assets/javascripts/spree/backend/adjustments.js
@@ -15,8 +15,8 @@ Spree.ready(function() {
         window.location.reload();
       },
       error: function(msg) {
-        if (msg.responseJSON["error"]) {
-          show_flash('error', msg.responseJSON["error"]);
+        if (msg.responseJSON["errors"]) {
+          show_flash('error', msg.responseJSON["errors"].map((error) => error.error).join(', '));
         } else {
           show_flash('error', "There was a problem adding this coupon code.");
         }

--- a/backend/spec/features/admin/orders/adjustments_promotions_spec.rb
+++ b/backend/spec/features/admin/orders/adjustments_promotions_spec.rb
@@ -25,6 +25,7 @@ describe "Adjustments Promotions", type: :feature do
   context "admin adding a promotion" do
     context "successfully" do
       it "should create a new adjustment", js: true do
+        expect(Spree::Deprecation).to receive(:warn)
         fill_in "coupon_code", with: "10_off"
         click_button "Add Coupon Code"
         expect(page).to have_content("$10 off")
@@ -34,6 +35,7 @@ describe "Adjustments Promotions", type: :feature do
 
     context "for non-existing promotion" do
       it "should show an error message", js: true do
+        expect(Spree::Deprecation).to receive(:warn)
         fill_in "coupon_code", with: "does_not_exist"
         click_button "Add Coupon Code"
         expect(page).to have_content("doesn't exist.")
@@ -42,6 +44,7 @@ describe "Adjustments Promotions", type: :feature do
 
     context "for already applied promotion" do
       it "should show an error message", js: true do
+        expect(Spree::Deprecation).to receive(:warn).twice
         fill_in "coupon_code", with: "10_off"
         click_button "Add Coupon Code"
         expect(page).to have_content('-$10.00')

--- a/core/app/models/spree/promotion_handler/coupon.rb
+++ b/core/app/models/spree/promotion_handler/coupon.rb
@@ -3,12 +3,15 @@
 module Spree
   module PromotionHandler
     class Coupon
-      attr_reader :order, :coupon_code
-      attr_accessor :error, :success, :status_code
+      extend ActiveModel::Naming
+
+      attr_reader :order, :coupon_code, :errors
+      attr_accessor :success
 
       def initialize(order)
         @order = order
         @coupon_code = order.coupon_code && order.coupon_code.downcase
+        @errors = ActiveModel::Errors.new(self)
       end
 
       def apply
@@ -40,13 +43,13 @@ module Spree
       end
 
       def set_success_code(status_code)
-        @status_code = status_code
         @success = I18n.t(status_code, scope: 'spree')
+        @success_status_code = status_code
       end
 
       def set_error_code(status_code, options = {})
-        @status_code = status_code
-        @error = options[:error] || I18n.t(status_code, scope: 'spree')
+        @errors.clear
+        @errors.add(:base, options[:error] || I18n.t(status_code, scope: 'spree'), error_code: status_code)
       end
 
       def promotion
@@ -58,7 +61,16 @@ module Spree
       end
 
       def successful?
-        success.present? && error.blank?
+        success.present? && errors.empty?
+      end
+
+      def error
+        Spree::Deprecation.warn "#error is deprecated. Please start using #errors."
+        errors.full_messages.first
+      end
+
+      def status_code
+        errors.any? ? errors.details[:base].first[:error_code] : @success_status_code
       end
 
       private
@@ -72,8 +84,8 @@ module Spree
         return promotion_applied if promotion_exists_on_order?(order, promotion)
 
         unless promotion.eligible?(order, promotion_code: promotion_code)
-          set_promotion_eligibility_error_code(promotion)
-          return (error || ineligible_for_this_order)
+          @errors = promotion.eligibility_errors
+          return (errors.any? || ineligible_for_this_order)
         end
 
         # If any of the actions for the promotion return `true`,
@@ -85,15 +97,6 @@ module Spree
         else
           set_error_code :coupon_code_unknown_error
         end
-      end
-
-      def set_promotion_eligibility_error_code(promotion)
-        return unless eligibility_error_code_present?(promotion)
-
-        eligibility_error = promotion.eligibility_errors.details[:base].first
-
-        @status_code = eligibility_error[:error_code]
-        @error = eligibility_error[:error]
       end
 
       def promotion_usage_limit_exceeded
@@ -110,13 +113,6 @@ module Spree
 
       def promotion_exists_on_order?(order, promotion)
         order.promotions.include? promotion
-      end
-
-      def eligibility_error_code_present?(promotion)
-        promotion.eligibility_errors.present? &&
-          promotion.eligibility_errors.details.present? &&
-          promotion.eligibility_errors.details.key?(:base) &&
-          promotion.eligibility_errors.details[:base].first[:error_code].present?
       end
     end
   end

--- a/core/spec/models/spree/promotion_handler/coupon_spec.rb
+++ b/core/spec/models/spree/promotion_handler/coupon_spec.rb
@@ -47,29 +47,43 @@ module Spree
           context 'not found' do
             let(:status) { :coupon_code_not_found }
 
-            it 'has status_code' do
+            it 'sets error' do
               subject
-              expect(coupon.status_code).to eq(status)
-            end
-
-            it 'has error message' do
-              subject
-              expect(coupon.error).to eq(I18n.t(status, scope: 'spree'))
+              expect(coupon.errors.details[:base]).to eq([{
+                error: I18n.t(status, scope: 'spree'),
+                error_code: status
+              }])
             end
           end
 
           context 'not present' do
             let(:status) { :coupon_code_not_present }
 
-            it 'has status_code' do
+            it 'sets error' do
               subject
-              expect(coupon.status_code).to eq(status)
+              expect(coupon.errors.details[:base]).to eq([{
+                error: I18n.t(status, scope: 'spree'),
+                error_code: status
+              }])
             end
+          end
+        end
 
-            it 'has error message' do
-              subject
-              expect(coupon.error).to eq(I18n.t(status, scope: 'spree'))
-            end
+        describe "#error fallback" do
+          it "returns first error message" do
+            coupon.errors.add :base, "Sample error", error_code: :sample
+            expect(coupon.error).to eq("Sample error")
+          end
+
+          it "return nil if there are no errors" do
+            expect(coupon.error).to be_nil
+          end
+        end
+
+        describe "#status_code fallback" do
+          it "returns first error code" do
+            coupon.errors.add :base, "Sample error", error_code: :sample
+            expect(coupon.status_code).to eq(:sample)
           end
         end
       end
@@ -86,7 +100,10 @@ module Spree
 
           it "populates error message" do
             subject.apply
-            expect(subject.error).to eq I18n.t('spree.coupon_code_not_found')
+            expect(subject.errors.details[:base]).to eq([{
+              error: I18n.t('spree.coupon_code_not_found'),
+              error_code: :coupon_code_not_found
+            }])
           end
         end
       end
@@ -124,7 +141,10 @@ module Spree
                 subject.apply
                 expect(subject.success).to be_present
                 subject.apply
-                expect(subject.error).to eq I18n.t('spree.coupon_code_already_applied')
+                expect(subject.errors.details[:base]).to eq([{
+                  error: I18n.t('spree.coupon_code_already_applied'),
+                  error_code: :coupon_code_already_applied
+                }])
               end
             end
 
@@ -216,7 +236,10 @@ module Spree
               subject.apply
               expect(subject.success).to be_present
               subject.apply
-              expect(subject.error).to eq I18n.t('spree.coupon_code_already_applied')
+              expect(subject.errors.details[:base]).to eq([{
+                error: I18n.t('spree.coupon_code_already_applied'),
+                error_code: :coupon_code_already_applied
+              }])
             end
           end
         end
@@ -254,7 +277,10 @@ module Spree
 
               it "returns a coupon has already been applied error" do
                 subject.apply
-                expect(subject.error).to eq I18n.t('spree.coupon_code_already_applied')
+                expect(subject.errors.details[:base]).to eq([{
+                  error: I18n.t('spree.coupon_code_already_applied'),
+                  error_code: :coupon_code_already_applied
+                }])
               end
             end
 
@@ -268,7 +294,10 @@ module Spree
 
               it "returns a coupon failed to activate error" do
                 subject.apply
-                expect(subject.error).to eq I18n.t('spree.coupon_code_unknown_error')
+                expect(subject.errors.details[:base]).to eq([{
+                  error: I18n.t('spree.coupon_code_unknown_error'),
+                  error_code: :coupon_code_unknown_error
+                }])
               end
             end
 
@@ -287,7 +316,10 @@ module Spree
 
               it "returns a coupon is at max usage error" do
                 subject.apply
-                expect(subject.error).to eq I18n.t('spree.coupon_code_max_usage')
+                expect(subject.errors.details[:base]).to eq([{
+                  error: I18n.t('spree.coupon_code_max_usage'),
+                  error_code: :coupon_code_max_usage
+                }])
               end
             end
           end
@@ -394,7 +426,7 @@ module Spree
 
           it 'successfully removes the coupon code from the order' do
             subject.remove
-            expect(subject.error).to eq nil
+            expect(subject.errors).to be_empty
             expect(subject.success).to eq I18n.t('spree.coupon_code_removed')
             expect(order.reload.total).to eq(130)
           end
@@ -409,7 +441,10 @@ module Spree
           it 'returns an error' do
             subject.remove
             expect(subject.success).to eq nil
-            expect(subject.error).to eq I18n.t('spree.coupon_code_not_present')
+            expect(subject.errors.details[:base]).to eq([{
+              error: I18n.t('spree.coupon_code_not_present'),
+              error_code: :coupon_code_not_present
+            }])
             expect(order.reload.total).to eq(130)
           end
         end

--- a/core/spec/models/spree/promotion_handler/coupon_spec.rb
+++ b/core/spec/models/spree/promotion_handler/coupon_spec.rb
@@ -72,10 +72,12 @@ module Spree
         describe "#error fallback" do
           it "returns first error message" do
             coupon.errors.add :base, "Sample error", error_code: :sample
+            expect(Spree::Deprecation).to receive(:warn)
             expect(coupon.error).to eq("Sample error")
           end
 
           it "return nil if there are no errors" do
+            expect(Spree::Deprecation).to receive(:warn)
             expect(coupon.error).to be_nil
           end
         end

--- a/core/spec/spec_helper.rb
+++ b/core/spec/spec_helper.rb
@@ -6,6 +6,7 @@ if ENV["COVERAGE"]
 end
 
 require 'rspec/core'
+
 require 'spree/testing_support/partial_double_verification'
 require 'spree/testing_support/preferences'
 require 'spree/config'

--- a/core/spec/spec_helper.rb
+++ b/core/spec/spec_helper.rb
@@ -6,7 +6,6 @@ if ENV["COVERAGE"]
 end
 
 require 'rspec/core'
-
 require 'spree/testing_support/partial_double_verification'
 require 'spree/testing_support/preferences'
 require 'spree/config'

--- a/frontend/app/assets/javascripts/spree/frontend/checkout/coupon-code.js
+++ b/frontend/app/assets/javascripts/spree/frontend/checkout/coupon-code.js
@@ -32,7 +32,7 @@ Spree.onCouponCodeApply = function(e) {
     handler = xhr.responseJSON;
     const errorMessages = $.map(
       handler["errors"],
-      function (err) {return err.error}
+      function (err) { return err.error }
     )
     couponStatus.addClass(errorClass).html(errorMessages.join('<br>'));
   });

--- a/frontend/app/assets/javascripts/spree/frontend/checkout/coupon-code.js
+++ b/frontend/app/assets/javascripts/spree/frontend/checkout/coupon-code.js
@@ -30,10 +30,11 @@ Spree.onCouponCodeApply = function(e) {
     var handler;
     // handler = JSON.parse(xhr.responseText)
     handler = xhr.responseJSON;
-    const errorMessages = $.map(handler["errors"],
-      function(err) { return err.error })
-      .join('<br>')
-    couponStatus.addClass(errorClass).html(errorMessages);
+    const errorMessages = $.map(
+      handler["errors"],
+      function (err) {return err.error}
+    )
+    couponStatus.addClass(errorClass).html(errorMessages.join('<br>'));
   });
 };
 

--- a/frontend/app/assets/javascripts/spree/frontend/checkout/coupon-code.js
+++ b/frontend/app/assets/javascripts/spree/frontend/checkout/coupon-code.js
@@ -30,7 +30,10 @@ Spree.onCouponCodeApply = function(e) {
     var handler;
     // handler = JSON.parse(xhr.responseText)
     handler = xhr.responseJSON;
-    couponStatus.addClass(errorClass).html(handler["error"]);
+    const errorMessages = $.map(handler["errors"],
+      function(err) { return err.error })
+      .join('<br>')
+    couponStatus.addClass(errorClass).html(errorMessages);
   });
 };
 

--- a/frontend/app/controllers/spree/coupon_codes_controller.rb
+++ b/frontend/app/controllers/spree/coupon_codes_controller.rb
@@ -2,6 +2,8 @@
 
 module Spree
   class CouponCodesController < Spree::StoreController
+    include ActionView::Helpers::OutputSafetyHelper
+
     before_action :load_order, only: :create
     around_action :lock_order, only: :create
 
@@ -18,7 +20,7 @@ module Spree
               flash[:success] = handler.success
               redirect_to cart_path
             else
-              flash.now[:error] = handler.errors.full_messages.join(" <br/> ").html_safe
+              flash.now[:error] = safe_join(handler.errors.full_messages, " <br /> ".html_safe)
               render 'spree/coupon_codes/new'
             end
           end

--- a/frontend/app/controllers/spree/coupon_codes_controller.rb
+++ b/frontend/app/controllers/spree/coupon_codes_controller.rb
@@ -19,9 +19,12 @@ module Spree
             if handler.successful?
               flash[:success] = handler.success
               redirect_to cart_path
-            else
-              flash.now[:error] = safe_join(handler.errors.full_messages, " <br /> ".html_safe)
+            elsif handler.errors.count == 1
+              flash.now[:error] = handler.errors.full_messages.first
               render 'spree/coupon_codes/new'
+            else
+              flash.now[:error] = t('spree.coupon_code_not_eligible')
+              render 'spree/coupon_codes/new', locals: { errors: handler.errors }
             end
           end
         end

--- a/frontend/app/controllers/spree/coupon_codes_controller.rb
+++ b/frontend/app/controllers/spree/coupon_codes_controller.rb
@@ -18,7 +18,7 @@ module Spree
               flash[:success] = handler.success
               redirect_to cart_path
             else
-              flash.now[:error] = handler.error
+              flash.now[:error] = handler.errors.full_messages.join(" <br/> ").html_safe
               render 'spree/coupon_codes/new'
             end
           end

--- a/frontend/app/views/spree/coupon_codes/new.html.erb
+++ b/frontend/app/views/spree/coupon_codes/new.html.erb
@@ -6,7 +6,7 @@
   <% if local_assigns[:errors] && errors.any? %>
     <div id="coupon_status" class="error">
       <% for error in errors.full_messages %>
-        <%= error %><br/>
+        <%= error %> <br>
       <% end %>
     </div>
   <% end %>

--- a/frontend/app/views/spree/coupon_codes/new.html.erb
+++ b/frontend/app/views/spree/coupon_codes/new.html.erb
@@ -3,4 +3,11 @@
     <%= text_field_tag :coupon_code, nil, placeholder: t("spree.coupon_code"), size: 10 %>
     <%= submit_tag t("spree.apply_code") %>
   <% end %>
+  <% if local_assigns[:errors] && errors.any? %>
+    <div id="coupon_status" class="error">
+      <% for error in errors.full_messages %>
+        <%= error %><br/>
+      <% end %>
+    </div>
+  <% end %>
 </div>

--- a/frontend/spec/features/checkout_spec.rb
+++ b/frontend/spec/features/checkout_spec.rb
@@ -493,6 +493,7 @@ describe "Checkout", type: :feature, inaccessible: true do
     end
 
     it "applies them & refreshes the page on user clicking the Apply Code button" do
+      expect(Spree::Deprecation).to receive(:warn)
       fill_in "Coupon Code", with: promotion.codes.first.value
       click_on "Apply Code"
 
@@ -502,6 +503,7 @@ describe "Checkout", type: :feature, inaccessible: true do
 
     context "with invalid coupon" do
       it "doesnt apply the promotion" do
+        expect(Spree::Deprecation).to receive(:warn)
         fill_in "Coupon Code", with: 'invalid'
         click_on "Apply Code"
 

--- a/frontend/spec/features/coupon_code_spec.rb
+++ b/frontend/spec/features/coupon_code_spec.rb
@@ -57,12 +57,14 @@ describe "Coupon code promotions", type: :feature, js: true do
         end
 
         it "informs about an invalid coupon code" do
+          expect(Spree::Deprecation).to receive(:warn)
           fill_in "order_coupon_code", with: "coupon_codes_rule_man"
           click_button "Apply Code"
           expect(page).to have_content(I18n.t('spree.coupon_code_not_found'))
         end
 
         it "can enter an invalid coupon code, then a real one" do
+          expect(Spree::Deprecation).to receive(:warn).twice
           fill_in "order_coupon_code", with: "coupon_codes_rule_man"
           click_button "Apply Code"
           expect(page).to have_content(I18n.t('spree.coupon_code_not_found'))
@@ -73,6 +75,7 @@ describe "Coupon code promotions", type: :feature, js: true do
 
         context "with a promotion" do
           it "applies a promotion to an order" do
+            expect(Spree::Deprecation).to receive(:warn)
             fill_in "order_coupon_code", with: "onetwo"
             click_button "Apply Code"
             expect(page).to have_content("Promotion (Onetwo) -$10.00", normalize_ws: true)
@@ -110,6 +113,7 @@ describe "Coupon code promotions", type: :feature, js: true do
           end
 
           it "shows wallet payments on coupon code errors" do
+            expect(Spree::Deprecation).to receive(:warn)
             fill_in "order_coupon_code", with: "coupon_codes_rule_man"
             click_button "Apply Code"
 


### PR DESCRIPTION
**Description:**
Fixes #3227
This PR adds support for multiple errors in Promotion Handlers by merging error messages of the underlying rules and introducing support for multiple errors on the Coupon. For backward compatibility `#error` method is maintained and falls back to the first error. In case there is at least one error `#status_code` will also return the code of the first error.

Note, that the merge behaviour is only implemented when promotion is set to match all rules, as with match any it is not very obvious what should be the visual presentation and if all possible rules should be exposed/visible to the customer.

<img width="987" alt="Screenshot 2021-01-18 at 11 56 33 PM" src="https://user-images.githubusercontent.com/15780/104968091-9b25d080-59ed-11eb-8dab-9db865c23650.png">


**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
