### PR TITLE
Convert jQuery data attribute to number

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/views/tables/selectable_table/sum_return_item_amount.js
+++ b/backend/app/assets/javascripts/spree/backend/views/tables/selectable_table/sum_return_item_amount.js
@@ -15,8 +15,11 @@ Spree.Views.Tables.SelectableTable.SumReturnItemAmount = Backbone.View.extend({
   },
 
   totalSelectedReturnItemAmount: function () {
-    var totalAmount = 0.00;
+    var totalAmount = 0;
     var selectedItems = [];
+    var decimals = 0;
+    var separator = Spree.t('currency_separator');
+    var amount, decimalAmount;
 
     if(this.model.get('allSelected')) {
       selectedItems = $('.selectable');
@@ -24,9 +27,13 @@ Spree.Views.Tables.SelectableTable.SumReturnItemAmount = Backbone.View.extend({
       selectedItems = $(this.model.attributes.selectedItems);
     }
     selectedItems.each(function(_, selectedItem){
-      totalAmount += $(selectedItem).data('price');
+      amount = $(selectedItem).data('price');
+      decimalAmount = amount.toString().split(separator)[1] || '';
+      decimals = Math.max(decimals, decimalAmount.length);
+
+      totalAmount += parseFloat(amount);
     })
 
-    return totalAmount;
+    return accounting.formatNumber(totalAmount, decimals, Spree.t('currency_delimiter'), separator);
   },
 });


### PR DESCRIPTION
JQuery numeric string data attributes are not casted to numbers consistently. 

There are instances when they are kept as string, this behavior seems to be related to the presence of insignificant
zeros in the original string:

```javascript
  $('<div data-price="12.00"></div>').data('price')
  > "12.00"

  $('<div data-price="12.10"></div>').data('price')
  > "12.10"
```

but:

```javascript
  $('<div data-price="12.1"></div>').data('price')
  > 12.1
```

So, we need to enforce the typecast when summing those attributes in the function `totalSelectedReturnItemAmount`.

After the sum, since we want to show a 2 decimal number, we need to convert the total amount with `toFixed(2)`.

|  Before   |  After   |
|---|---|
| <img width="843" alt="Screen Shot 2021-01-19 at 9 40 02 AM" src="https://user-images.githubusercontent.com/141220/105010731-60975480-5a3c-11eb-8cdf-5be82b1ffd21.png"> | <img width="830" alt="Screen Shot 2021-01-19 at 9 45 02 AM" src="https://user-images.githubusercontent.com/141220/105010760-6725cc00-5a3c-11eb-8641-f3cfb97542e3.png"> |



**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
