### PR TITLE
Fix ActionMailer preview loading

### DIFF
--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -85,8 +85,9 @@ module Spree
         # We need to make sure we call `Preview.all` before requiring our
         # previews, otherwise any previews the app attempts to add need to be
         # manually required.
-        if Rails.env.development?
+        if Rails.env.development? || Rails.env.test?
           ActionMailer::Preview.all
+
           Dir[root.join("lib/spree/mailer_previews/**/*_preview.rb")].each do |file|
             require_dependency file
           end

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -80,14 +80,12 @@ module Spree
             caller
           )
         end
-      end
 
-      # Load in mailer previews for apps to use in development.
-      # We need to make sure we call `Preview.all` before requiring our
-      # previews, otherwise any previews the app attempts to add need to be
-      # manually required.
-      if Rails.env.development?
-        initializer "spree.mailer_previews" do
+        # Load in mailer previews for apps to use in development.
+        # We need to make sure we call `Preview.all` before requiring our
+        # previews, otherwise any previews the app attempts to add need to be
+        # manually required.
+        if Rails.env.development?
           ActionMailer::Preview.all
           Dir[root.join("lib/spree/mailer_previews/**/*_preview.rb")].each do |file|
             require_dependency file

--- a/core/lib/spree/testing_support/dummy_app.rb
+++ b/core/lib/spree/testing_support/dummy_app.rb
@@ -62,6 +62,7 @@ module DummyApp
     config.secret_key_base = 'SECRET_TOKEN'
 
     config.action_mailer.delivery_job = "ActionMailer::MailDeliveryJob" if RAILS_6_OR_ABOVE
+    config.action_mailer.preview_path = File.expand_path('dummy_app/mailer_previews', __dir__)
     config.active_record.sqlite3.represent_boolean_as_integer = true unless RAILS_6_OR_ABOVE
 
     config.storage_path = Rails.root.join('tmp', 'storage')

--- a/core/lib/spree/testing_support/dummy_app/mailer_previews/test_mailer_preview.rb
+++ b/core/lib/spree/testing_support/dummy_app/mailer_previews/test_mailer_preview.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class TestMailerPreview < ActionMailer::Preview
+end

--- a/core/spec/lib/spree/core/engine_spec.rb
+++ b/core/spec/lib/spree/core/engine_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Spree::Core::Engine do
+  it 'loads engine and app previews' do
+    expect(ActionMailer::Preview.all).to match_array([
+      TestMailerPreview,
+      Spree::MailerPreviews::ReimbursementPreview,
+      Spree::MailerPreviews::OrderPreview,
+      Spree::MailerPreviews::CartonPreview,
+    ])
+  end
+end


### PR DESCRIPTION
**Description**

This fixes #3898, by moving the loading of the app's previews (and our own) to an `after_initialize` block, which gets rid of the deprecation warning about constant loading during app initialization.

I also managed to write a test that verifies that both the engine's and the app's previews are properly loaded. I had to enable preview loading in `Rails.env.test?` as well in order for the test to pass, but I think that won't be a problem.

Btw, it seems like we'll be able to get rid of this hack if/when https://github.com/rails/rails/pull/31595 gets merged.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
