### PR TITLE
[Admin] Automatically check edited return items in RMA form

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/views/tables/return_items.js
+++ b/backend/app/assets/javascripts/spree/backend/views/tables/return_items.js
@@ -4,6 +4,11 @@ Spree.Views.Tables.ReturnItems = Backbone.View.extend({
       var tfoot = document.createElement('tfoot')
       new Spree.Views.Tables.SelectableTable.SumReturnItemAmount({el: tfoot, model: this.model});
       this.$el.append(tfoot);
+
+      this.$el.find('input, select').not('.add-item').on('change', function(e) {
+        $(this).closest('tr').find('input.add-item').prop('checked', true)
+          .change();
+      });
     }
   },
 })

--- a/backend/spec/features/admin/orders/return_authorizations_spec.rb
+++ b/backend/spec/features/admin/orders/return_authorizations_spec.rb
@@ -27,7 +27,7 @@ describe "ReturnAuthorizations", type: :feature do
   end
 
   context "when the user can manage return authorizations" do
-    describe "create" do
+    describe "create", :js do
       def create_return_authorization
         find("#select-all").click
         select "NY Warehouse", from: "Stock Location"
@@ -38,13 +38,19 @@ describe "ReturnAuthorizations", type: :feature do
         visit spree.new_admin_order_return_authorization_path(order)
       end
 
-      it "creates a return authorization", :js do
+      it "creates a return authorization" do
         create_return_authorization
 
         expect(page).to have_content "Return Authorization has been successfully created!"
       end
 
-      it "disables the button at submit", :js do
+      it "automatically checks edited rows" do
+        expect do
+          find(".refund-amount-input").native.send_keys [1, :tab]
+        end.to change { find(".add-item").checked? }.from(false).to(true)
+      end
+
+      it "disables the button at submit" do
         page.execute_script "$('form').submit(function(e) { e.preventDefault()})"
 
         create_return_authorization


### PR DESCRIPTION
This feature got lost with #3565. It automatically checks rows where the admin changes something, under the assumption that, if a value is changed, then the user means to include the row into the RMA/return.

An integration spec is added to properly track this feature.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
