### PR TITLE
Fix factory loading

### DIFF
--- a/api/spec/spec_helper.rb
+++ b/api/spec/spec_helper.rb
@@ -26,7 +26,7 @@ require 'with_model'
 # in spec/support/ and its subdirectories.
 Dir[File.dirname(__FILE__) + "/support/**/*.rb"].each { |f| require f }
 
-require 'spree/testing_support'
+require 'spree/testing_support/factory_bot'
 require 'spree/testing_support/partial_double_verification'
 require 'spree/testing_support/preferences'
 require 'spree/testing_support/authorization_helpers'
@@ -38,7 +38,7 @@ require 'spree/api/testing_support/setup'
 
 ActiveJob::Base.queue_adapter = :test
 
-Spree::TestingSupport.load_all_factories
+Spree::TestingSupport::FactoryBot.add_paths_and_load!
 
 RSpec.configure do |config|
   config.backtrace_exclusion_patterns = [/gems\/activesupport/, /gems\/actionpack/, /gems\/rspec/]

--- a/api/spec/spec_helper.rb
+++ b/api/spec/spec_helper.rb
@@ -26,8 +26,8 @@ require 'with_model'
 # in spec/support/ and its subdirectories.
 Dir[File.dirname(__FILE__) + "/support/**/*.rb"].each { |f| require f }
 
+require 'spree/testing_support'
 require 'spree/testing_support/partial_double_verification'
-require 'spree/testing_support/factories'
 require 'spree/testing_support/preferences'
 require 'spree/testing_support/authorization_helpers'
 require 'spree/testing_support/job_helpers'
@@ -37,6 +37,8 @@ require 'spree/api/testing_support/helpers'
 require 'spree/api/testing_support/setup'
 
 ActiveJob::Base.queue_adapter = :test
+
+Spree::TestingSupport.load_all_factories
 
 RSpec.configure do |config|
   config.backtrace_exclusion_patterns = [/gems\/activesupport/, /gems\/actionpack/, /gems\/rspec/]

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -27,9 +27,9 @@ Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 require 'database_cleaner'
 require 'with_model'
 
+require 'spree/testing_support'
 require 'spree/testing_support/partial_double_verification'
 require 'spree/testing_support/authorization_helpers'
-require 'spree/testing_support/factories'
 require 'spree/testing_support/preferences'
 require 'spree/testing_support/controller_requests'
 require 'spree/testing_support/flash'
@@ -62,6 +62,8 @@ ActionView::Base.raise_on_missing_translations = true
 Capybara.default_max_wait_time = ENV['DEFAULT_MAX_WAIT_TIME'].to_f if ENV['DEFAULT_MAX_WAIT_TIME'].present?
 
 ActiveJob::Base.queue_adapter = :test
+
+Spree::TestingSupport.load_all_factories
 
 RSpec.configure do |config|
   config.color = true

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -27,7 +27,7 @@ Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 require 'database_cleaner'
 require 'with_model'
 
-require 'spree/testing_support'
+require 'spree/testing_support/factory_bot'
 require 'spree/testing_support/partial_double_verification'
 require 'spree/testing_support/authorization_helpers'
 require 'spree/testing_support/preferences'
@@ -63,7 +63,7 @@ Capybara.default_max_wait_time = ENV['DEFAULT_MAX_WAIT_TIME'].to_f if ENV['DEFAU
 
 ActiveJob::Base.queue_adapter = :test
 
-Spree::TestingSupport.load_all_factories
+Spree::TestingSupport::FactoryBot.add_paths_and_load!
 
 RSpec.configure do |config|
   config.color = true

--- a/core/lib/spree/testing_support.rb
+++ b/core/lib/spree/testing_support.rb
@@ -36,7 +36,7 @@ module Spree
     def self.load_all_factories
       require 'factory_bot'
 
-      FactoryBot.definition_file_paths.concat(factory_bot_paths).uniq!
+      FactoryBot.definition_file_paths.unshift(*factory_bot_paths).uniq!
       FactoryBot.reload
     end
   end

--- a/core/lib/spree/testing_support.rb
+++ b/core/lib/spree/testing_support.rb
@@ -1,43 +1,31 @@
 # frozen_string_literal: true
 
+require 'spree/testing_support/factory_bot'
+
 module Spree
   module TestingSupport
-    SEQUENCES = ["#{::Spree::Core::Engine.root}/lib/spree/testing_support/sequences.rb"]
-    FACTORIES = Dir["#{::Spree::Core::Engine.root}/lib/spree/testing_support/factories/**/*_factory.rb"]
+    autoload :FactoryBot, "spree/testing_support/factory_bot"
 
-    def self.factory_bot_paths
-      @paths ||= (SEQUENCES + FACTORIES).sort.map { |path| path.sub(/.rb\z/, '') }
+    autoload :SEQUENCES, "spree/testing_support/factory_bot"
+    autoload :FACTORIES, "spree/testing_support/factory_bot"
+
+    def factory_bot_paths
+      Spree::TestingSupport::FactoryBot.definition_file_paths
     end
 
-    def self.deprecate_cherry_picking_factory_bot_files
-      # All good if the factory is being loaded by FactoryBot.
-      return if caller.find { |line| line.include? "/factory_bot/find_definitions.rb" }
-
-      Spree::Deprecation.warn(
-        "Please do not cherry-pick factories, this is not well supported by FactoryBot. " \
-        'Use `require "spree/testing_support/factories"` instead.', caller(2)
-      )
+    def check_factory_bot_version
+      Spree::TestingSupport::FactoryBot.check_version
     end
 
-    def self.check_factory_bot_version
-      require 'factory_bot/version'
-
-      requirement = Gem::Requirement.new("~> 4.8")
-      version = Gem::Version.new(FactoryBot::VERSION)
-
-      unless requirement.satisfied_by? version
-        Spree::Deprecation.warn(
-          "Please be aware that the supported version of FactoryBot is #{requirement}, " \
-          "using version #{version} could lead to factory loading issues.", caller(2)
-        )
-      end
+    def load_all_factories
+      Spree::TestingSupport::FactoryBot.add_paths_and_load!
     end
 
-    def self.load_all_factories
-      require 'factory_bot'
-
-      FactoryBot.definition_file_paths.unshift(*factory_bot_paths).uniq!
-      FactoryBot.reload
-    end
+    deprecate(
+      factory_bot_paths: "Spree::TestingSupport::FactoryBot.definition_file_paths",
+      check_factory_bot_version: "Spree::TestingSupport::FactoryBot.check_version",
+      load_all_factories: "Spree::TestingSupport::FactoryBot.add_paths_and_load!",
+      deprecator: Spree::Deprecator
+    )
   end
 end

--- a/core/lib/spree/testing_support.rb
+++ b/core/lib/spree/testing_support.rb
@@ -19,8 +19,7 @@ module Spree
       )
     end
 
-    def self.load_all_factories
-      require 'factory_bot'
+    def self.check_factory_bot_version
       require 'factory_bot/version'
 
       requirement = Gem::Requirement.new("~> 4.8")
@@ -32,6 +31,10 @@ module Spree
           "using version #{version} could lead to factory loading issues.", caller(2)
         )
       end
+    end
+
+    def self.load_all_factories
+      require 'factory_bot'
 
       FactoryBot.definition_file_paths.concat(factory_bot_paths).uniq!
       FactoryBot.reload

--- a/core/lib/spree/testing_support/factories.rb
+++ b/core/lib/spree/testing_support/factories.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
+require 'spree/testing_support/factory_bot'
 
 Spree::Deprecation.warn(
   "Please do not try to load factories directly. " \
   'Use factory_bot_rails and rely on the default configuration instead.', caller(1)
 )
 
-Spree::TestingSupport.check_factory_bot_version
-Spree::TestingSupport.load_all_factories
+Spree::TestingSupport::FactoryBot.check_version
+Spree::TestingSupport::FactoryBot::PATHS.each { |path| require path }

--- a/core/lib/spree/testing_support/factories.rb
+++ b/core/lib/spree/testing_support/factories.rb
@@ -2,5 +2,10 @@
 
 require 'spree/testing_support'
 
+Spree::Deprecation.warn(
+  "Please do not try to load factories directly. " \
+  'Use factory_bot_rails and rely on the default configuration instead.', caller(1)
+)
+
 Spree::TestingSupport.check_factory_bot_version
 Spree::TestingSupport.load_all_factories

--- a/core/lib/spree/testing_support/factories.rb
+++ b/core/lib/spree/testing_support/factories.rb
@@ -2,4 +2,5 @@
 
 require 'spree/testing_support'
 
+Spree::TestingSupport.check_factory_bot_version
 Spree::TestingSupport.load_all_factories

--- a/core/lib/spree/testing_support/factories/address_factory.rb
+++ b/core/lib/spree/testing_support/factories/address_factory.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
+  require 'spree/testing_support/factories/state_factory'
+  require 'spree/testing_support/factories/country_factory'
+end
 FactoryBot.define do
   factory :address, class: 'Spree::Address' do
     transient do

--- a/core/lib/spree/testing_support/factories/address_factory.rb
+++ b/core/lib/spree/testing_support/factories/address_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
-Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 FactoryBot.define do
   factory :address, class: 'Spree::Address' do

--- a/core/lib/spree/testing_support/factories/adjustment_factory.rb
+++ b/core/lib/spree/testing_support/factories/adjustment_factory.rb
@@ -1,7 +1,15 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+
+  require 'spree/testing_support/factories/line_item_factory'
+  require 'spree/testing_support/factories/order_factory'
+  require 'spree/testing_support/factories/tax_category_factory'
+  require 'spree/testing_support/factories/tax_rate_factory'
+  require 'spree/testing_support/factories/zone_factory'
+end
 
 FactoryBot.define do
   factory :adjustment, class: 'Spree::Adjustment' do

--- a/core/lib/spree/testing_support/factories/adjustment_factory.rb
+++ b/core/lib/spree/testing_support/factories/adjustment_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
-Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 FactoryBot.define do
   factory :adjustment, class: 'Spree::Adjustment' do

--- a/core/lib/spree/testing_support/factories/adjustment_reason_factory.rb
+++ b/core/lib/spree/testing_support/factories/adjustment_reason_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
-Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 FactoryBot.define do
   factory :adjustment_reason, class: 'Spree::AdjustmentReason' do

--- a/core/lib/spree/testing_support/factories/adjustment_reason_factory.rb
+++ b/core/lib/spree/testing_support/factories/adjustment_reason_factory.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+end
 
 FactoryBot.define do
   factory :adjustment_reason, class: 'Spree::AdjustmentReason' do

--- a/core/lib/spree/testing_support/factories/calculator_factory.rb
+++ b/core/lib/spree/testing_support/factories/calculator_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
-Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 FactoryBot.define do
   factory :calculator, aliases: [:flat_rate_calculator], class: 'Spree::Calculator::FlatRate' do

--- a/core/lib/spree/testing_support/factories/calculator_factory.rb
+++ b/core/lib/spree/testing_support/factories/calculator_factory.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+end
 
 FactoryBot.define do
   factory :calculator, aliases: [:flat_rate_calculator], class: 'Spree::Calculator::FlatRate' do

--- a/core/lib/spree/testing_support/factories/carton_factory.rb
+++ b/core/lib/spree/testing_support/factories/carton_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
-Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 FactoryBot.define do
   factory :carton, class: 'Spree::Carton' do

--- a/core/lib/spree/testing_support/factories/carton_factory.rb
+++ b/core/lib/spree/testing_support/factories/carton_factory.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+
+  require 'spree/testing_support/factories/shipment_factory'
+  require 'spree/testing_support/factories/inventory_unit_factory'
+end
 
 FactoryBot.define do
   factory :carton, class: 'Spree::Carton' do

--- a/core/lib/spree/testing_support/factories/country_factory.rb
+++ b/core/lib/spree/testing_support/factories/country_factory.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+end
 
 require 'carmen'
 

--- a/core/lib/spree/testing_support/factories/country_factory.rb
+++ b/core/lib/spree/testing_support/factories/country_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
-Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 require 'carmen'
 

--- a/core/lib/spree/testing_support/factories/credit_card_factory.rb
+++ b/core/lib/spree/testing_support/factories/credit_card_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
-Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 FactoryBot.define do
   factory :credit_card, class: 'Spree::CreditCard' do

--- a/core/lib/spree/testing_support/factories/credit_card_factory.rb
+++ b/core/lib/spree/testing_support/factories/credit_card_factory.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+end
 
 FactoryBot.define do
   factory :credit_card, class: 'Spree::CreditCard' do

--- a/core/lib/spree/testing_support/factories/customer_return_factory.rb
+++ b/core/lib/spree/testing_support/factories/customer_return_factory.rb
@@ -1,7 +1,13 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+
+  require 'spree/testing_support/factories/stock_location_factory'
+  require 'spree/testing_support/factories/order_factory'
+  require 'spree/testing_support/factories/return_item_factory'
+end
 
 FactoryBot.define do
   factory :customer_return, class: 'Spree::CustomerReturn' do

--- a/core/lib/spree/testing_support/factories/customer_return_factory.rb
+++ b/core/lib/spree/testing_support/factories/customer_return_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
-Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 FactoryBot.define do
   factory :customer_return, class: 'Spree::CustomerReturn' do

--- a/core/lib/spree/testing_support/factories/image_factory.rb
+++ b/core/lib/spree/testing_support/factories/image_factory.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+end
 
 FactoryBot.define do
   factory :image, class: 'Spree::Image' do

--- a/core/lib/spree/testing_support/factories/image_factory.rb
+++ b/core/lib/spree/testing_support/factories/image_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
-Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 FactoryBot.define do
   factory :image, class: 'Spree::Image' do

--- a/core/lib/spree/testing_support/factories/inventory_unit_factory.rb
+++ b/core/lib/spree/testing_support/factories/inventory_unit_factory.rb
@@ -1,7 +1,14 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+
+  require 'spree/testing_support/factories/line_item_factory'
+  require 'spree/testing_support/factories/variant_factory'
+  require 'spree/testing_support/factories/order_factory'
+  require 'spree/testing_support/factories/shipment_factory'
+end
 
 FactoryBot.define do
   factory :inventory_unit, class: 'Spree::InventoryUnit' do

--- a/core/lib/spree/testing_support/factories/inventory_unit_factory.rb
+++ b/core/lib/spree/testing_support/factories/inventory_unit_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
-Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 FactoryBot.define do
   factory :inventory_unit, class: 'Spree::InventoryUnit' do

--- a/core/lib/spree/testing_support/factories/line_item_factory.rb
+++ b/core/lib/spree/testing_support/factories/line_item_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
-Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 FactoryBot.define do
   factory :line_item, class: 'Spree::LineItem' do

--- a/core/lib/spree/testing_support/factories/line_item_factory.rb
+++ b/core/lib/spree/testing_support/factories/line_item_factory.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+
+  require 'spree/testing_support/factories/order_factory'
+  require 'spree/testing_support/factories/product_factory'
+end
 
 FactoryBot.define do
   factory :line_item, class: 'Spree::LineItem' do

--- a/core/lib/spree/testing_support/factories/option_type_factory.rb
+++ b/core/lib/spree/testing_support/factories/option_type_factory.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+
+  require 'spree/testing_support/factories/product_factory'
+  require 'spree/testing_support/factories/option_type_factory'
+end
 
 FactoryBot.define do
   factory :option_type, class: 'Spree::OptionType' do

--- a/core/lib/spree/testing_support/factories/option_type_factory.rb
+++ b/core/lib/spree/testing_support/factories/option_type_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
-Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 FactoryBot.define do
   factory :option_type, class: 'Spree::OptionType' do

--- a/core/lib/spree/testing_support/factories/option_value_factory.rb
+++ b/core/lib/spree/testing_support/factories/option_value_factory.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+end
 
 FactoryBot.define do
   factory :option_value, class: 'Spree::OptionValue' do

--- a/core/lib/spree/testing_support/factories/option_value_factory.rb
+++ b/core/lib/spree/testing_support/factories/option_value_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
-Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 FactoryBot.define do
   factory :option_value, class: 'Spree::OptionValue' do

--- a/core/lib/spree/testing_support/factories/order_factory.rb
+++ b/core/lib/spree/testing_support/factories/order_factory.rb
@@ -1,7 +1,16 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+
+  require 'spree/testing_support/factories/address_factory'
+  require 'spree/testing_support/factories/shipment_factory'
+  require 'spree/testing_support/factories/store_factory'
+  require 'spree/testing_support/factories/user_factory'
+  require 'spree/testing_support/factories/line_item_factory'
+  require 'spree/testing_support/factories/payment_factory'
+end
 
 FactoryBot.define do
   factory :order, class: 'Spree::Order' do

--- a/core/lib/spree/testing_support/factories/order_factory.rb
+++ b/core/lib/spree/testing_support/factories/order_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
-Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 FactoryBot.define do
   factory :order, class: 'Spree::Order' do

--- a/core/lib/spree/testing_support/factories/order_promotion_factory.rb
+++ b/core/lib/spree/testing_support/factories/order_promotion_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
-Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 FactoryBot.define do
   factory :order_promotion, class: 'Spree::OrderPromotion' do

--- a/core/lib/spree/testing_support/factories/order_promotion_factory.rb
+++ b/core/lib/spree/testing_support/factories/order_promotion_factory.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+
+  require 'spree/testing_support/factories/order_factory'
+  require 'spree/testing_support/factories/promotion_factory'
+end
 
 FactoryBot.define do
   factory :order_promotion, class: 'Spree::OrderPromotion' do

--- a/core/lib/spree/testing_support/factories/payment_factory.rb
+++ b/core/lib/spree/testing_support/factories/payment_factory.rb
@@ -1,7 +1,14 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+
+  require 'spree/testing_support/factories/payment_method_factory'
+  require 'spree/testing_support/factories/credit_card_factory'
+  require 'spree/testing_support/factories/order_factory'
+  require 'spree/testing_support/factories/store_credit_factory'
+end
 
 FactoryBot.define do
   factory :payment, aliases: [:credit_card_payment], class: 'Spree::Payment' do

--- a/core/lib/spree/testing_support/factories/payment_factory.rb
+++ b/core/lib/spree/testing_support/factories/payment_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
-Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 FactoryBot.define do
   factory :payment, aliases: [:credit_card_payment], class: 'Spree::Payment' do

--- a/core/lib/spree/testing_support/factories/payment_method_factory.rb
+++ b/core/lib/spree/testing_support/factories/payment_method_factory.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+end
 
 FactoryBot.define do
   factory :payment_method, aliases: [:credit_card_payment_method], class: 'Spree::PaymentMethod::BogusCreditCard' do

--- a/core/lib/spree/testing_support/factories/payment_method_factory.rb
+++ b/core/lib/spree/testing_support/factories/payment_method_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
-Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 FactoryBot.define do
   factory :payment_method, aliases: [:credit_card_payment_method], class: 'Spree::PaymentMethod::BogusCreditCard' do

--- a/core/lib/spree/testing_support/factories/price_factory.rb
+++ b/core/lib/spree/testing_support/factories/price_factory.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+
+  require 'spree/testing_support/factories/variant_factory'
+end
 
 FactoryBot.define do
   factory :price, class: 'Spree::Price' do

--- a/core/lib/spree/testing_support/factories/price_factory.rb
+++ b/core/lib/spree/testing_support/factories/price_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
-Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 FactoryBot.define do
   factory :price, class: 'Spree::Price' do

--- a/core/lib/spree/testing_support/factories/product_factory.rb
+++ b/core/lib/spree/testing_support/factories/product_factory.rb
@@ -1,7 +1,15 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+
+  require 'spree/testing_support/sequences'
+  require 'spree/testing_support/factories/shipping_category_factory'
+  require 'spree/testing_support/factories/stock_location_factory'
+  require 'spree/testing_support/factories/tax_category_factory'
+  require 'spree/testing_support/factories/product_option_type_factory'
+end
 
 FactoryBot.define do
   factory :base_product, class: 'Spree::Product' do

--- a/core/lib/spree/testing_support/factories/product_factory.rb
+++ b/core/lib/spree/testing_support/factories/product_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
-Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 FactoryBot.define do
   factory :base_product, class: 'Spree::Product' do

--- a/core/lib/spree/testing_support/factories/product_option_type_factory.rb
+++ b/core/lib/spree/testing_support/factories/product_option_type_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
-Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 FactoryBot.define do
   factory :product_option_type, class: 'Spree::ProductOptionType' do

--- a/core/lib/spree/testing_support/factories/product_option_type_factory.rb
+++ b/core/lib/spree/testing_support/factories/product_option_type_factory.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+
+  require 'spree/testing_support/factories/product_factory'
+  require 'spree/testing_support/factories/option_type_factory'
+end
 
 FactoryBot.define do
   factory :product_option_type, class: 'Spree::ProductOptionType' do

--- a/core/lib/spree/testing_support/factories/product_property_factory.rb
+++ b/core/lib/spree/testing_support/factories/product_property_factory.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+
+  require 'spree/testing_support/factories/product_factory'
+  require 'spree/testing_support/factories/property_factory'
+end
 
 FactoryBot.define do
   factory :product_property, class: 'Spree::ProductProperty' do

--- a/core/lib/spree/testing_support/factories/product_property_factory.rb
+++ b/core/lib/spree/testing_support/factories/product_property_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
-Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 FactoryBot.define do
   factory :product_property, class: 'Spree::ProductProperty' do

--- a/core/lib/spree/testing_support/factories/promotion_category_factory.rb
+++ b/core/lib/spree/testing_support/factories/promotion_category_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
-Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 FactoryBot.define do
   factory :promotion_category, class: 'Spree::PromotionCategory' do

--- a/core/lib/spree/testing_support/factories/promotion_category_factory.rb
+++ b/core/lib/spree/testing_support/factories/promotion_category_factory.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+end
 
 FactoryBot.define do
   factory :promotion_category, class: 'Spree::PromotionCategory' do

--- a/core/lib/spree/testing_support/factories/promotion_code_factory.rb
+++ b/core/lib/spree/testing_support/factories/promotion_code_factory.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+
+  require 'spree/testing_support/sequences'
+  require 'spree/testing_support/factories/promotion_factory'
+end
 
 FactoryBot.define do
   factory :promotion_code, class: 'Spree::PromotionCode' do

--- a/core/lib/spree/testing_support/factories/promotion_code_factory.rb
+++ b/core/lib/spree/testing_support/factories/promotion_code_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
-Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 FactoryBot.define do
   factory :promotion_code, class: 'Spree::PromotionCode' do

--- a/core/lib/spree/testing_support/factories/promotion_factory.rb
+++ b/core/lib/spree/testing_support/factories/promotion_factory.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+
+  require 'spree/testing_support/factories/promotion_code_factory'
+  require 'spree/testing_support/factories/variant_factory'
+end
 
 FactoryBot.define do
   factory :promotion, class: 'Spree::Promotion' do

--- a/core/lib/spree/testing_support/factories/promotion_factory.rb
+++ b/core/lib/spree/testing_support/factories/promotion_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
-Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 FactoryBot.define do
   factory :promotion, class: 'Spree::Promotion' do

--- a/core/lib/spree/testing_support/factories/property_factory.rb
+++ b/core/lib/spree/testing_support/factories/property_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
-Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 FactoryBot.define do
   factory :property, class: 'Spree::Property' do

--- a/core/lib/spree/testing_support/factories/property_factory.rb
+++ b/core/lib/spree/testing_support/factories/property_factory.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+end
 
 FactoryBot.define do
   factory :property, class: 'Spree::Property' do

--- a/core/lib/spree/testing_support/factories/refund_factory.rb
+++ b/core/lib/spree/testing_support/factories/refund_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
-Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 FactoryBot.define do
   sequence(:refund_transaction_id) { |n| "fake-refund-transaction-#{n}" }

--- a/core/lib/spree/testing_support/factories/refund_factory.rb
+++ b/core/lib/spree/testing_support/factories/refund_factory.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+
+  require 'spree/testing_support/factories/payment_factory'
+  require 'spree/testing_support/factories/refund_reason_factory'
+end
 
 FactoryBot.define do
   sequence(:refund_transaction_id) { |n| "fake-refund-transaction-#{n}" }

--- a/core/lib/spree/testing_support/factories/refund_reason_factory.rb
+++ b/core/lib/spree/testing_support/factories/refund_reason_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
-Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 FactoryBot.define do
   factory :refund_reason, class: 'Spree::RefundReason' do

--- a/core/lib/spree/testing_support/factories/refund_reason_factory.rb
+++ b/core/lib/spree/testing_support/factories/refund_reason_factory.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+end
 
 FactoryBot.define do
   factory :refund_reason, class: 'Spree::RefundReason' do

--- a/core/lib/spree/testing_support/factories/reimbursement_factory.rb
+++ b/core/lib/spree/testing_support/factories/reimbursement_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
-Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 FactoryBot.define do
   factory :reimbursement, class: 'Spree::Reimbursement' do

--- a/core/lib/spree/testing_support/factories/reimbursement_factory.rb
+++ b/core/lib/spree/testing_support/factories/reimbursement_factory.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+
+  require 'spree/testing_support/factories/customer_return_factory'
+end
 
 FactoryBot.define do
   factory :reimbursement, class: 'Spree::Reimbursement' do

--- a/core/lib/spree/testing_support/factories/reimbursement_type_factory.rb
+++ b/core/lib/spree/testing_support/factories/reimbursement_type_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
-Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 FactoryBot.define do
   factory :reimbursement_type, class: 'Spree::ReimbursementType' do

--- a/core/lib/spree/testing_support/factories/reimbursement_type_factory.rb
+++ b/core/lib/spree/testing_support/factories/reimbursement_type_factory.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+end
 
 FactoryBot.define do
   factory :reimbursement_type, class: 'Spree::ReimbursementType' do

--- a/core/lib/spree/testing_support/factories/return_authorization_factory.rb
+++ b/core/lib/spree/testing_support/factories/return_authorization_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
-Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 FactoryBot.define do
   factory :return_authorization, class: 'Spree::ReturnAuthorization' do

--- a/core/lib/spree/testing_support/factories/return_authorization_factory.rb
+++ b/core/lib/spree/testing_support/factories/return_authorization_factory.rb
@@ -1,7 +1,13 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+
+  require 'spree/testing_support/factories/order_factory'
+  require 'spree/testing_support/factories/stock_location_factory'
+  require 'spree/testing_support/factories/return_reason_factory'
+end
 
 FactoryBot.define do
   factory :return_authorization, class: 'Spree::ReturnAuthorization' do

--- a/core/lib/spree/testing_support/factories/return_item_factory.rb
+++ b/core/lib/spree/testing_support/factories/return_item_factory.rb
@@ -1,7 +1,13 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+
+  require 'spree/testing_support/factories/inventory_unit_factory'
+  require 'spree/testing_support/factories/return_reason_factory'
+  require 'spree/testing_support/factories/return_authorization_factory'
+end
 
 FactoryBot.define do
   factory :return_item, class: 'Spree::ReturnItem' do

--- a/core/lib/spree/testing_support/factories/return_item_factory.rb
+++ b/core/lib/spree/testing_support/factories/return_item_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
-Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 FactoryBot.define do
   factory :return_item, class: 'Spree::ReturnItem' do

--- a/core/lib/spree/testing_support/factories/return_reason_factory.rb
+++ b/core/lib/spree/testing_support/factories/return_reason_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
-Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 FactoryBot.define do
   factory :return_reason, class: 'Spree::ReturnReason' do

--- a/core/lib/spree/testing_support/factories/return_reason_factory.rb
+++ b/core/lib/spree/testing_support/factories/return_reason_factory.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+end
 
 FactoryBot.define do
   factory :return_reason, class: 'Spree::ReturnReason' do

--- a/core/lib/spree/testing_support/factories/role_factory.rb
+++ b/core/lib/spree/testing_support/factories/role_factory.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+end
 
 FactoryBot.define do
   factory :role, class: 'Spree::Role' do

--- a/core/lib/spree/testing_support/factories/role_factory.rb
+++ b/core/lib/spree/testing_support/factories/role_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
-Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 FactoryBot.define do
   factory :role, class: 'Spree::Role' do

--- a/core/lib/spree/testing_support/factories/shipment_factory.rb
+++ b/core/lib/spree/testing_support/factories/shipment_factory.rb
@@ -1,7 +1,14 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+
+  require 'spree/testing_support/factories/order_factory'
+  require 'spree/testing_support/factories/stock_location_factory'
+  require 'spree/testing_support/factories/shipping_method_factory'
+end
+
 
 FactoryBot.define do
   factory :shipment, class: 'Spree::Shipment' do

--- a/core/lib/spree/testing_support/factories/shipment_factory.rb
+++ b/core/lib/spree/testing_support/factories/shipment_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
-Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 FactoryBot.define do
   factory :shipment, class: 'Spree::Shipment' do

--- a/core/lib/spree/testing_support/factories/shipping_category_factory.rb
+++ b/core/lib/spree/testing_support/factories/shipping_category_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
-Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 FactoryBot.define do
   factory :shipping_category, class: 'Spree::ShippingCategory' do

--- a/core/lib/spree/testing_support/factories/shipping_category_factory.rb
+++ b/core/lib/spree/testing_support/factories/shipping_category_factory.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+end
 
 FactoryBot.define do
   factory :shipping_category, class: 'Spree::ShippingCategory' do

--- a/core/lib/spree/testing_support/factories/shipping_method_factory.rb
+++ b/core/lib/spree/testing_support/factories/shipping_method_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
-Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 FactoryBot.define do
   factory(

--- a/core/lib/spree/testing_support/factories/shipping_method_factory.rb
+++ b/core/lib/spree/testing_support/factories/shipping_method_factory.rb
@@ -1,7 +1,13 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+
+  require 'spree/testing_support/factories/calculator_factory'
+  require 'spree/testing_support/factories/shipping_category_factory'
+  require 'spree/testing_support/factories/zone_factory'
+end
 
 FactoryBot.define do
   factory(

--- a/core/lib/spree/testing_support/factories/shipping_rate_factory.rb
+++ b/core/lib/spree/testing_support/factories/shipping_rate_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
-Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 FactoryBot.define do
   factory :shipping_rate, class: 'Spree::ShippingRate' do

--- a/core/lib/spree/testing_support/factories/shipping_rate_factory.rb
+++ b/core/lib/spree/testing_support/factories/shipping_rate_factory.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+
+  require 'spree/testing_support/factories/shipping_method_factory'
+  require 'spree/testing_support/factories/shipment_factory'
+end
 
 FactoryBot.define do
   factory :shipping_rate, class: 'Spree::ShippingRate' do

--- a/core/lib/spree/testing_support/factories/state_factory.rb
+++ b/core/lib/spree/testing_support/factories/state_factory.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+
+  require 'spree/testing_support/factories/country_factory'
+end
+
 
 FactoryBot.define do
   factory :state, class: 'Spree::State' do

--- a/core/lib/spree/testing_support/factories/state_factory.rb
+++ b/core/lib/spree/testing_support/factories/state_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
-Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 FactoryBot.define do
   factory :state, class: 'Spree::State' do

--- a/core/lib/spree/testing_support/factories/stock_item_factory.rb
+++ b/core/lib/spree/testing_support/factories/stock_item_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
-Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 FactoryBot.define do
   factory :stock_item, class: 'Spree::StockItem' do

--- a/core/lib/spree/testing_support/factories/stock_item_factory.rb
+++ b/core/lib/spree/testing_support/factories/stock_item_factory.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+
+  require 'spree/testing_support/factories/stock_location_factory'
+  require 'spree/testing_support/factories/variant_factory'
+end
 
 FactoryBot.define do
   factory :stock_item, class: 'Spree::StockItem' do

--- a/core/lib/spree/testing_support/factories/stock_location_factory.rb
+++ b/core/lib/spree/testing_support/factories/stock_location_factory.rb
@@ -1,7 +1,13 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+
+  require 'spree/testing_support/factories/country_factory'
+  require 'spree/testing_support/factories/state_factory'
+  require 'spree/testing_support/factories/product_factory'
+end
 
 FactoryBot.define do
   factory :stock_location, class: 'Spree::StockLocation' do

--- a/core/lib/spree/testing_support/factories/stock_location_factory.rb
+++ b/core/lib/spree/testing_support/factories/stock_location_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
-Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 FactoryBot.define do
   factory :stock_location, class: 'Spree::StockLocation' do

--- a/core/lib/spree/testing_support/factories/stock_movement_factory.rb
+++ b/core/lib/spree/testing_support/factories/stock_movement_factory.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+
+  require 'spree/testing_support/factories/stock_item_factory'
+end
 
 FactoryBot.define do
   factory :stock_movement, class: 'Spree::StockMovement' do

--- a/core/lib/spree/testing_support/factories/stock_movement_factory.rb
+++ b/core/lib/spree/testing_support/factories/stock_movement_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
-Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 FactoryBot.define do
   factory :stock_movement, class: 'Spree::StockMovement' do

--- a/core/lib/spree/testing_support/factories/stock_package_factory.rb
+++ b/core/lib/spree/testing_support/factories/stock_package_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
-Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 FactoryBot.define do
   factory :stock_package, class: 'Spree::Stock::Package' do

--- a/core/lib/spree/testing_support/factories/stock_package_factory.rb
+++ b/core/lib/spree/testing_support/factories/stock_package_factory.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+
+  require 'spree/testing_support/factories/inventory_unit_factory'
+  require 'spree/testing_support/factories/variant_factory'
+end
 
 FactoryBot.define do
   factory :stock_package, class: 'Spree::Stock::Package' do

--- a/core/lib/spree/testing_support/factories/store_credit_category_factory.rb
+++ b/core/lib/spree/testing_support/factories/store_credit_category_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
-Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 FactoryBot.define do
   factory :store_credit_category, class: 'Spree::StoreCreditCategory' do

--- a/core/lib/spree/testing_support/factories/store_credit_category_factory.rb
+++ b/core/lib/spree/testing_support/factories/store_credit_category_factory.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+end
 
 FactoryBot.define do
   factory :store_credit_category, class: 'Spree::StoreCreditCategory' do

--- a/core/lib/spree/testing_support/factories/store_credit_event_factory.rb
+++ b/core/lib/spree/testing_support/factories/store_credit_event_factory.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+
+  require 'spree/testing_support/factories/store_credit_factory'
+  require 'spree/testing_support/factories/store_credit_reason_factory'
+end
 
 FactoryBot.define do
   factory :store_credit_event, class: 'Spree::StoreCreditEvent' do

--- a/core/lib/spree/testing_support/factories/store_credit_event_factory.rb
+++ b/core/lib/spree/testing_support/factories/store_credit_event_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
-Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 FactoryBot.define do
   factory :store_credit_event, class: 'Spree::StoreCreditEvent' do

--- a/core/lib/spree/testing_support/factories/store_credit_factory.rb
+++ b/core/lib/spree/testing_support/factories/store_credit_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
-Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 FactoryBot.define do
   factory :store_credit, class: 'Spree::StoreCredit' do

--- a/core/lib/spree/testing_support/factories/store_credit_factory.rb
+++ b/core/lib/spree/testing_support/factories/store_credit_factory.rb
@@ -1,7 +1,13 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+
+  require 'spree/testing_support/factories/store_credit_category_factory'
+  require 'spree/testing_support/factories/store_credit_type_factory'
+  require 'spree/testing_support/factories/user_factory'
+end
 
 FactoryBot.define do
   factory :store_credit, class: 'Spree::StoreCredit' do

--- a/core/lib/spree/testing_support/factories/store_credit_reason_factory.rb
+++ b/core/lib/spree/testing_support/factories/store_credit_reason_factory.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+end
 
 FactoryBot.define do
   factory :store_credit_reason, class: 'Spree::StoreCreditReason' do

--- a/core/lib/spree/testing_support/factories/store_credit_reason_factory.rb
+++ b/core/lib/spree/testing_support/factories/store_credit_reason_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
-Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 FactoryBot.define do
   factory :store_credit_reason, class: 'Spree::StoreCreditReason' do

--- a/core/lib/spree/testing_support/factories/store_credit_type_factory.rb
+++ b/core/lib/spree/testing_support/factories/store_credit_type_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
-Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 FactoryBot.define do
   factory :primary_credit_type, class: 'Spree::StoreCreditType' do

--- a/core/lib/spree/testing_support/factories/store_credit_type_factory.rb
+++ b/core/lib/spree/testing_support/factories/store_credit_type_factory.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+end
 
 FactoryBot.define do
   factory :primary_credit_type, class: 'Spree::StoreCreditType' do

--- a/core/lib/spree/testing_support/factories/store_factory.rb
+++ b/core/lib/spree/testing_support/factories/store_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
-Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 FactoryBot.define do
   factory :store, class: 'Spree::Store' do

--- a/core/lib/spree/testing_support/factories/store_factory.rb
+++ b/core/lib/spree/testing_support/factories/store_factory.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+end
 
 FactoryBot.define do
   factory :store, class: 'Spree::Store' do

--- a/core/lib/spree/testing_support/factories/tax_category_factory.rb
+++ b/core/lib/spree/testing_support/factories/tax_category_factory.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+
+  require 'spree/testing_support/sequences'
+end
+
 
 FactoryBot.define do
   factory :tax_category, class: 'Spree::TaxCategory' do

--- a/core/lib/spree/testing_support/factories/tax_category_factory.rb
+++ b/core/lib/spree/testing_support/factories/tax_category_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
-Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 FactoryBot.define do
   factory :tax_category, class: 'Spree::TaxCategory' do

--- a/core/lib/spree/testing_support/factories/tax_rate_factory.rb
+++ b/core/lib/spree/testing_support/factories/tax_rate_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
-Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 FactoryBot.define do
   factory :tax_rate, class: 'Spree::TaxRate' do

--- a/core/lib/spree/testing_support/factories/tax_rate_factory.rb
+++ b/core/lib/spree/testing_support/factories/tax_rate_factory.rb
@@ -1,7 +1,13 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+
+  require 'spree/testing_support/factories/calculator_factory'
+  require 'spree/testing_support/factories/tax_category_factory'
+  require 'spree/testing_support/factories/zone_factory'
+end
 
 FactoryBot.define do
   factory :tax_rate, class: 'Spree::TaxRate' do

--- a/core/lib/spree/testing_support/factories/taxon_factory.rb
+++ b/core/lib/spree/testing_support/factories/taxon_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
-Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 FactoryBot.define do
   factory :taxon, class: 'Spree::Taxon' do

--- a/core/lib/spree/testing_support/factories/taxon_factory.rb
+++ b/core/lib/spree/testing_support/factories/taxon_factory.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+
+  require 'spree/testing_support/factories/taxonomy_factory'
+end
 
 FactoryBot.define do
   factory :taxon, class: 'Spree::Taxon' do

--- a/core/lib/spree/testing_support/factories/taxonomy_factory.rb
+++ b/core/lib/spree/testing_support/factories/taxonomy_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
-Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 FactoryBot.define do
   factory :taxonomy, class: 'Spree::Taxonomy' do

--- a/core/lib/spree/testing_support/factories/taxonomy_factory.rb
+++ b/core/lib/spree/testing_support/factories/taxonomy_factory.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+end
 
 FactoryBot.define do
   factory :taxonomy, class: 'Spree::Taxonomy' do

--- a/core/lib/spree/testing_support/factories/user_factory.rb
+++ b/core/lib/spree/testing_support/factories/user_factory.rb
@@ -1,7 +1,13 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+
+  require 'spree/testing_support/sequences'
+  require 'spree/testing_support/factories/role_factory'
+  require 'spree/testing_support/factories/address_factory'
+end
 
 FactoryBot.define do
   factory :user, class: Spree::UserClassHandle.new do

--- a/core/lib/spree/testing_support/factories/user_factory.rb
+++ b/core/lib/spree/testing_support/factories/user_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
-Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 FactoryBot.define do
   factory :user, class: Spree::UserClassHandle.new do

--- a/core/lib/spree/testing_support/factories/variant_factory.rb
+++ b/core/lib/spree/testing_support/factories/variant_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
-Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 FactoryBot.define do
   sequence(:random_float) { BigDecimal("#{rand(200)}.#{rand(99)}") }

--- a/core/lib/spree/testing_support/factories/variant_factory.rb
+++ b/core/lib/spree/testing_support/factories/variant_factory.rb
@@ -1,7 +1,14 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+
+  require 'spree/testing_support/sequences'
+  require 'spree/testing_support/factories/option_value_factory'
+  require 'spree/testing_support/factories/option_type_factory'
+  require 'spree/testing_support/factories/product_factory'
+end
 
 FactoryBot.define do
   sequence(:random_float) { BigDecimal("#{rand(200)}.#{rand(99)}") }

--- a/core/lib/spree/testing_support/factories/variant_property_rule_condition_factory.rb
+++ b/core/lib/spree/testing_support/factories/variant_property_rule_condition_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
-Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 FactoryBot.define do
   factory :variant_property_rule_condition, class: 'Spree::VariantPropertyRuleCondition' do

--- a/core/lib/spree/testing_support/factories/variant_property_rule_condition_factory.rb
+++ b/core/lib/spree/testing_support/factories/variant_property_rule_condition_factory.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+
+  require 'spree/testing_support/factories/option_value_factory'
+  require 'spree/testing_support/factories/variant_property_rule_factory'
+end
 
 FactoryBot.define do
   factory :variant_property_rule_condition, class: 'Spree::VariantPropertyRuleCondition' do

--- a/core/lib/spree/testing_support/factories/variant_property_rule_factory.rb
+++ b/core/lib/spree/testing_support/factories/variant_property_rule_factory.rb
@@ -1,7 +1,13 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+
+  require 'spree/testing_support/factories/product_factory'
+  require 'spree/testing_support/factories/property_factory'
+  require 'spree/testing_support/factories/option_value_factory'
+end
 
 FactoryBot.define do
   factory :variant_property_rule, class: 'Spree::VariantPropertyRule' do

--- a/core/lib/spree/testing_support/factories/variant_property_rule_factory.rb
+++ b/core/lib/spree/testing_support/factories/variant_property_rule_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
-Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 FactoryBot.define do
   factory :variant_property_rule, class: 'Spree::VariantPropertyRule' do

--- a/core/lib/spree/testing_support/factories/variant_property_rule_value_factory.rb
+++ b/core/lib/spree/testing_support/factories/variant_property_rule_value_factory.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+
+  require 'spree/testing_support/factories/variant_property_rule_factory'
+  require 'spree/testing_support/factories/property_factory'
+end
 
 FactoryBot.define do
   factory :variant_property_rule_value, class: 'Spree::VariantPropertyRuleValue' do

--- a/core/lib/spree/testing_support/factories/variant_property_rule_value_factory.rb
+++ b/core/lib/spree/testing_support/factories/variant_property_rule_value_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
-Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 FactoryBot.define do
   factory :variant_property_rule_value, class: 'Spree::VariantPropertyRuleValue' do

--- a/core/lib/spree/testing_support/factories/zone_factory.rb
+++ b/core/lib/spree/testing_support/factories/zone_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/testing_support'
-Spree::TestingSupport.deprecate_cherry_picking_factory_bot_files
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 FactoryBot.define do
   factory :global_zone, class: 'Spree::Zone' do

--- a/core/lib/spree/testing_support/factories/zone_factory.rb
+++ b/core/lib/spree/testing_support/factories/zone_factory.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+
+  require 'spree/testing_support/sequences'
+  require 'spree/testing_support/factories/country_factory'
+end
 
 FactoryBot.define do
   factory :global_zone, class: 'Spree::Zone' do

--- a/core/lib/spree/testing_support/factory_bot.rb
+++ b/core/lib/spree/testing_support/factory_bot.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "factory_bot"
+begin
+  require "factory_bot_rails"
+rescue LoadError
+end
+
+module Spree
+  module TestingSupport
+    module FactoryBot
+      SEQUENCES = ["#{::Spree::Core::Engine.root}/lib/spree/testing_support/sequences.rb"]
+      FACTORIES = Dir["#{::Spree::Core::Engine.root}/lib/spree/testing_support/factories/**/*_factory.rb"].sort
+      PATHS = SEQUENCES + FACTORIES
+
+      def self.definition_file_paths
+        @paths ||= PATHS.map { |path| path.sub(/.rb\z/, '') }
+      end
+
+      def self.deprecate_cherry_picking
+        # All good if the factory is being loaded by FactoryBot.
+        return if caller.find { |line| line.include? "/factory_bot/find_definitions.rb" }
+
+        Spree::Deprecation.warn(
+          "Please do not cherry-pick factories, this is not well supported by FactoryBot. " \
+          'Use `require "spree/testing_support/factories"` instead.', caller(2)
+        )
+      end
+
+      def self.check_version
+        require "factory_bot/version"
+
+        requirement = Gem::Requirement.new("~> 4.8")
+        version = Gem::Version.new(::FactoryBot::VERSION)
+
+        unless requirement.satisfied_by? version
+          Spree::Deprecation.warn(
+            "Please be aware that the supported version of FactoryBot is #{requirement}, " \
+            "using version #{version} could lead to factory loading issues.", caller(2)
+          )
+        end
+      end
+
+      def self.add_definitions!
+        ::FactoryBot.definition_file_paths.unshift(*definition_file_paths).uniq!
+      end
+
+      def self.add_paths_and_load!
+        add_definitions!
+        ::FactoryBot.reload
+      end
+    end
+  end
+end

--- a/core/lib/spree/testing_support/order_walkthrough.rb
+++ b/core/lib/spree/testing_support/order_walkthrough.rb
@@ -9,14 +9,14 @@ module Spree
 
       def up_to(state)
         # Need to create a valid zone too...
-        @zone = FactoryBot.create(:zone)
-        @country = FactoryBot.create(:country)
-        @state = FactoryBot.create(:state, country: @country)
+        @zone = ::FactoryBot.create(:zone)
+        @country = ::FactoryBot.create(:country)
+        @state = ::FactoryBot.create(:state, country: @country)
 
         @zone.members << Spree::ZoneMember.create(zoneable: @country)
 
         # A shipping method must exist for rates to be displayed on checkout page
-        FactoryBot.create(:shipping_method, zones: [@zone]).tap do |sm|
+        ::FactoryBot.create(:shipping_method, zones: [@zone]).tap do |sm|
           sm.calculator.preferred_amount = 10
           sm.calculator.preferred_currency = Spree::Config[:currency]
           sm.calculator.save
@@ -24,7 +24,7 @@ module Spree
 
         order = Spree::Order.create!(
           email: "solidus@example.com",
-          store: Spree::Store.first || FactoryBot.create(:store)
+          store: Spree::Store.first || ::FactoryBot.create(:store)
         )
         add_line_item!(order)
         order.next!
@@ -46,13 +46,13 @@ module Spree
       private
 
       def add_line_item!(order)
-        FactoryBot.create(:line_item, order: order)
+        ::FactoryBot.create(:line_item, order: order)
         order.reload
       end
 
       def address(order)
-        order.bill_address = FactoryBot.create(:address, country: @country, state: @state)
-        order.ship_address = FactoryBot.create(:address, country: @country, state: @state)
+        order.bill_address = ::FactoryBot.create(:address, country: @country, state: @state)
+        order.ship_address = ::FactoryBot.create(:address, country: @country, state: @state)
         order.next!
       end
 
@@ -61,7 +61,7 @@ module Spree
       end
 
       def payment(order)
-        credit_card = FactoryBot.create(:credit_card)
+        credit_card = ::FactoryBot.create(:credit_card)
         order.payments.create!(payment_method: credit_card.payment_method, amount: order.total, source: credit_card)
         # TODO: maybe look at some way of making this payment_state change automatic
         order.payment_state = 'paid'

--- a/core/lib/spree/testing_support/sequences.rb
+++ b/core/lib/spree/testing_support/sequences.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 require 'spree/testing_support/factory_bot'
-Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+Spree::TestingSupport::FactoryBot.when_cherry_picked do
+  Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
+end
 
 FactoryBot.define do
   sequence(:sku) { |n| "SKU-#{n}" }

--- a/core/lib/spree/testing_support/sequences.rb
+++ b/core/lib/spree/testing_support/sequences.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-require 'factory_bot'
+require 'spree/testing_support/factory_bot'
+Spree::TestingSupport::FactoryBot.deprecate_cherry_picking
 
 FactoryBot.define do
   sequence(:sku) { |n| "SKU-#{n}" }

--- a/core/spec/rails_helper.rb
+++ b/core/spec/rails_helper.rb
@@ -16,7 +16,7 @@ require 'database_cleaner'
 
 Dir["./spec/support/**/*.rb"].sort.each { |f| require f }
 
-require 'spree/testing_support'
+require 'spree/testing_support/factory_bot'
 require 'spree/testing_support/preferences'
 require 'spree/testing_support/rake'
 require 'spree/testing_support/job_helpers'
@@ -24,7 +24,7 @@ require 'cancan/matchers'
 
 ActiveJob::Base.queue_adapter = :test
 
-Spree::TestingSupport.load_all_factories
+Spree::TestingSupport::FactoryBot.add_paths_and_load!
 
 RSpec.configure do |config|
   config.fixture_path = File.join(__dir__, "fixtures")

--- a/core/spec/rails_helper.rb
+++ b/core/spec/rails_helper.rb
@@ -16,13 +16,15 @@ require 'database_cleaner'
 
 Dir["./spec/support/**/*.rb"].sort.each { |f| require f }
 
-require 'spree/testing_support/factories'
+require 'spree/testing_support'
 require 'spree/testing_support/preferences'
 require 'spree/testing_support/rake'
 require 'spree/testing_support/job_helpers'
 require 'cancan/matchers'
 
 ActiveJob::Base.queue_adapter = :test
+
+Spree::TestingSupport.load_all_factories
 
 RSpec.configure do |config|
   config.fixture_path = File.join(__dir__, "fixtures")

--- a/frontend/spec/spec_helper.rb
+++ b/frontend/spec/spec_helper.rb
@@ -26,7 +26,7 @@ Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 
 require 'database_cleaner'
 
-require 'spree/testing_support'
+require 'spree/testing_support/factory_bot'
 require 'spree/testing_support/partial_double_verification'
 require 'spree/testing_support/authorization_helpers'
 require 'spree/testing_support/capybara_ext'
@@ -49,7 +49,7 @@ Capybara.javascript_driver = (ENV['CAPYBARA_DRIVER'] || :selenium_chrome_headles
 
 ActiveJob::Base.queue_adapter = :test
 
-Spree::TestingSupport.load_all_factories
+Spree::TestingSupport::FactoryBot.add_paths_and_load!
 
 RSpec.configure do |config|
   config.color = true

--- a/frontend/spec/spec_helper.rb
+++ b/frontend/spec/spec_helper.rb
@@ -26,10 +26,10 @@ Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 
 require 'database_cleaner'
 
+require 'spree/testing_support'
 require 'spree/testing_support/partial_double_verification'
 require 'spree/testing_support/authorization_helpers'
 require 'spree/testing_support/capybara_ext'
-require 'spree/testing_support/factories'
 require 'spree/testing_support/preferences'
 require 'spree/testing_support/controller_requests'
 require 'spree/testing_support/flash'
@@ -48,6 +48,8 @@ require 'webdrivers'
 Capybara.javascript_driver = (ENV['CAPYBARA_DRIVER'] || :selenium_chrome_headless).to_sym
 
 ActiveJob::Base.queue_adapter = :test
+
+Spree::TestingSupport.load_all_factories
 
 RSpec.configure do |config|
   config.color = true


### PR DESCRIPTION
**Description**
<!--
  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

  Please include screenshots in case of visual changes to the frontend or backend sections of Solidus.

  If needed you can reference another PR or issue here, e.g.:
  Ref #ISSUE
-->

The current FactoryBot support code doesn't take into account that Solidus factories need to be loaded before app-level factories, to allow modifications.

With this change using `factory_bot_rails` it will work out of the box (the initializer works with v4.8 up to v6).
Nothing is done if `FactoryBot` is used directly, assuming the a more fine grained control/configuration is being used.
The code will be activated only if FactoryBotRails is defined, so to avoid running it in production is enough to keep the gem in the developmen/test groups as advised by the factory_bot readme.

Ref https://github.com/solidusio/solidus/issues/3906 (this issue will be fixed by a back port of this PR to v2.11).

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
