### PR TITLE
Move Spree::Address#name attribute to the db

### DIFF
--- a/api/spec/requests/spree/api/users_controller_spec.rb
+++ b/api/spec/requests/spree/api/users_controller_spec.rb
@@ -153,7 +153,7 @@ module Spree
           q: {
             m: 'or',
             email_start: 'distinct_test',
-            firstname_or_lastname_start: 'distinct_test'
+            name_start: 'distinct_test'
           }
         }
         expect(json_response['count']).to eq(1)

--- a/backend/app/assets/javascripts/spree/backend/user_picker.js
+++ b/backend/app/assets/javascripts/spree/backend/user_picker.js
@@ -28,7 +28,7 @@ $.fn.userAutocomplete = function () {
           q: {
             m: 'or',
             email_start: term,
-            firstname_or_lastname_start: term
+            name_start: term
           }
         };
       },

--- a/backend/app/assets/javascripts/spree/backend/views/order/customer_select.js
+++ b/backend/app/assets/javascripts/spree/backend/views/order/customer_select.js
@@ -34,7 +34,7 @@ Spree.Views.Order.CustomerSelect = Backbone.View.extend({
             q: {
               m: 'or',
               email_start: term,
-              firstname_or_lastname_start: term
+              name_start: term
             }
           }
         },

--- a/backend/app/controllers/spree/admin/search_controller.rb
+++ b/backend/app/controllers/spree/admin/search_controller.rb
@@ -16,7 +16,7 @@ module Spree
           @users = Spree.user_class.ransack({
             m: 'or',
             email_start: params[:q],
-            firstname_or_lastname_start: params[:q]
+            name_start: params[:q]
           }).result.limit(10)
         end
       end

--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -66,8 +66,8 @@
 
             <div class="col-12 col-xl-6">
               <div class="field">
-                <%= label_tag :q_bill_address_firstname_or_lastname_start, t('spree.name_contains') %>
-                <%= f.text_field :bill_address_firstname_or_lastname_start, size: 25 %>
+                <%= label_tag :q_bill_address_name_start, t('spree.name_contains') %>
+                <%= f.text_field :bill_address_name_start, size: 25 %>
               </div>
             </div>
 

--- a/core/app/models/concerns/spree/user_methods.rb
+++ b/core/app/models/concerns/spree/user_methods.rb
@@ -34,9 +34,9 @@ module Spree
 
       include Spree::RansackableAttributes unless included_modules.include?(Spree::RansackableAttributes)
 
-      ransack_alias :firstname_or_lastname, :addresses_firstname_or_addresses_lastname
+      ransack_alias :name, :addresses_name
       self.whitelisted_ransackable_associations = %w[addresses spree_roles]
-      self.whitelisted_ransackable_attributes = %w[firstname_or_lastname id email created_at]
+      self.whitelisted_ransackable_attributes = %w[name id email created_at]
     end
 
     def wallet

--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -22,6 +22,7 @@ module Spree
       self.class.state_validator_class.new(self).perform
     end
 
+    self.ignored_columns = %w(firstname lastname)
     DB_ONLY_ATTRS = %w(id updated_at created_at).freeze
     TAXATION_ATTRS = %w(state_id country_id zipcode).freeze
 

--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -24,9 +24,8 @@ module Spree
 
     DB_ONLY_ATTRS = %w(id updated_at created_at).freeze
     TAXATION_ATTRS = %w(state_id country_id zipcode).freeze
-    LEGACY_NAME_ATTRS = %w(firstname lastname).freeze
 
-    self.whitelisted_ransackable_attributes = %w[firstname lastname]
+    self.whitelisted_ransackable_attributes = %w[name]
 
     scope :with_values, ->(attributes) do
       where(value_attributes(attributes))
@@ -160,29 +159,6 @@ module Spree
 
     def country_iso
       country && country.iso
-    end
-
-    # @return [String] the full name on this address
-    def name
-      Spree::Address::Name.new(
-        read_attribute(:firstname),
-        read_attribute(:lastname)
-      ).value
-    end
-
-    def name=(value)
-      return if value.nil?
-
-      name_from_value = Spree::Address::Name.new(value)
-      write_attribute(:firstname, name_from_value.first_name)
-      write_attribute(:lastname, name_from_value.last_name)
-    end
-
-    def as_json(options = {})
-      super.tap do |hash|
-        hash.except!(*LEGACY_NAME_ATTRS)
-        hash['name'] = name
-      end
     end
   end
 end

--- a/core/app/models/spree/address/name.rb
+++ b/core/app/models/spree/address/name.rb
@@ -2,8 +2,8 @@
 
 module Spree
   class Address
-    # Provides a value object to help transitioning from legacy
-    # firstname and lastname fields to a unified name field.
+    # Provides a value object to help splitting and joining
+    # name fields
     class Name
       attr_reader :first_name, :last_name, :value
 

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -50,9 +50,8 @@ module Spree
       go_to_state :confirm
     end
 
-    ransack_alias :bill_address_firstname_or_lastname, :bill_address_firstname_or_bill_address_lastname
     self.whitelisted_ransackable_associations = %w[shipments user order_promotions promotions bill_address ship_address line_items]
-    self.whitelisted_ransackable_attributes = %w[bill_address_firstname_or_lastname completed_at created_at email number state payment_state shipment_state total store_id]
+    self.whitelisted_ransackable_attributes = %w[bill_address_name completed_at created_at email number state payment_state shipment_state total store_id]
 
     attr_reader :coupon_code
     attr_accessor :temporary_address

--- a/core/db/migrate/20210122110141_add_name_to_spree_addresses.rb
+++ b/core/db/migrate/20210122110141_add_name_to_spree_addresses.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddNameToSpreeAddresses < ActiveRecord::Migration[5.2]
+  def up
+    add_column :spree_addresses, :name, :string
+    add_index :spree_addresses, :name
+  end
+
+  def down
+    remove_index :spree_addresses, :name
+    remove_column :spree_addresses, :name
+  end
+end

--- a/core/spec/models/spree/address_spec.rb
+++ b/core/spec/models/spree/address_spec.rb
@@ -266,6 +266,7 @@ RSpec.describe Spree::Address, type: :model do
       address = Spree::Address.new(name: 'Jane Von Doe')
 
       expect(address.as_json).to include('name' => 'Jane Von Doe')
+      expect(address.as_json.keys).not_to include('firstname', 'lastname')
     end
   end
 


### PR DESCRIPTION
**Description**
Ref https://github.com/solidusio/solidus/issues/3234

This PR pushes forward the migration to `Spree::Address#name` to replace `firstname` and `lastname` attributes. It adds a correseponding `name` column to the DB and replaces all the remaining direct attribute accesses to `firstname` and `lastname` with `name`.

~The DB migration contains a blocking warning to force users to evaluate the impact of the upgrade and to choose the correct strategy to handle it in their store. In a future PR we will provide a complementary rake task to migrage existing data from `firstname` and `lastname` columns to the new `name` columns.  New stores won't receive any warning and will be able to start working with the `name` field from scratch.~

☝️ This piece will be moved into a separate rake task.

<!--
  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

  Please include screenshots in case of visual changes to the frontend or backend sections of Solidus.

  If needed you can reference another PR or issue here, e.g.:
  Ref #ISSUE
-->

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- ~~[ ] I have updated Guides and README accordingly to this change (if needed)~~
- ~~[ ] I have added tests to cover this change (if needed)~~
- ~~[ ] I have attached screenshots to this PR for visual changes (if needed)~~
