### PR TITLE
Lock money gem in development until next release

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,10 @@ group :backend, :frontend, :core, :api do
   # and https://github.com/rails/sprockets-rails/issues/369
   gem 'sprockets', '~> 3'
 
+  # Temporary locking money to 6.13.8.
+  # See https://github.com/solidusio/solidus/issues/3903
+  gem 'money', '<= 6.13.8'
+
   platforms :ruby do
     case ENV['DB']
     when /mysql/


### PR DESCRIPTION
**Description**

See https://github.com/solidusio/solidus/issues/3903. This will make our test suite green again.