### PR TITLE
Show 'guest' correctly in order customer details

### DIFF
--- a/backend/app/views/spree/admin/orders/customer_details/show.html.erb
+++ b/backend/app/views/spree/admin/orders/customer_details/show.html.erb
@@ -12,7 +12,7 @@
   <section>
     <%= content_tag :h4, t('spree.account') %>
     <%= t('spree.email') %>: <%= @order.email %><br>
-    <%= t('spree.guest_checkout') %>: <%= @order.user ? t('spree.yes') : t('spree.no') %>
+    <%= t('spree.guest_checkout') %>: <%= @order.user.nil? ? t('spree.yes') : t('spree.no') %>
   </section>
 
   <section>


### PR DESCRIPTION
**Description**
<!--
  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

  Please include screenshots in case of visual changes to the frontend or backend sections of Solidus.

  If needed you can reference another PR or issue here, e.g.:
  Ref #ISSUE
-->

There is a small visual bug in the `admin_order_customer`path, where the UI shows the order as a `guest order` if there was a user associated to it, and vice-versa.

This PR fixes that.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
