### PR TITLE
Switch to maintained Paperclip fork

### DIFF
--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'kaminari-activerecord', '~> 1.1'
   s.add_dependency 'mini_magick', '~> 4.10'
   s.add_dependency 'monetize', '~> 1.8'
-  s.add_dependency 'paperclip', '>= 4.2'
+  s.add_dependency 'kt-paperclip', '~> 6.3'
   s.add_dependency 'ransack', '~> 2.0'
   s.add_dependency 'state_machines-activerecord', '~> 0.6'
 end


### PR DESCRIPTION
**Description**

Since Paperclip dependency is not going away anytime soon, it would be better switching to the official maintained fork to keep up with security updates and Ruby 3 compability.

Paperclip has been deprecated for 3 years and abandoned for a year, [the creators suggest](https://thoughtbot.com/blog/paperclip-new-maintainers) to migrate to the maintained fork [Paperclip-kt](https://github.com/kreeti/kt-paperclip).

<!--
  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

  Please include screenshots in case of visual changes to the frontend or backend sections of Solidus.

  If needed you can reference another PR or issue here, e.g.:
  Ref #ISSUE
-->

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- ~~[ ] I have updated Guides and README accordingly to this change (if needed)~~
- ~~[ ] I have added tests to cover this change (if needed)~~
- ~~[ ] I have attached screenshots to this PR for visual changes (if needed)~~
