### PR TITLE
Ensured deleted products are visible in the admin product index page when searching by sku

### DIFF
--- a/backend/spec/features/admin/products/products_spec.rb
+++ b/backend/spec/features/admin/products/products_spec.rb
@@ -151,6 +151,29 @@ describe "Products", type: :feature do
         expect(page).not_to have_content("zomg shirt")
         expect(page).to have_css('#listing_products > tbody > tr', count: 1)
       end
+
+      it "should be able to search for deleted products by sku" do
+        create(:product, name: 'nginx cap ', sku: 'B201', deleted_at: "2021-01-02 18:21:13")
+        create(:product, name: 'solidus shirt', sku: 'GG201')
+
+        click_nav "Products"
+        expect(page).to have_content("solidus shirt")
+        expect(page).not_to have_content("nginx cap ")
+
+        # when show deleted is checked
+        fill_in 'SKU', with: "B2"
+        check 'Show Deleted'
+        click_button 'Search'
+        expect(find('input[name="q[with_discarded]"]')).to be_checked
+        expect(page).to have_content('nginx cap ')
+        expect(page).not_to have_content('solidus shirt')
+
+        fill_in 'SKU', with: 'GG'
+        click_button 'Search'
+        expect(find('input[name="q[with_discarded]"]')).to be_checked
+        expect(page).not_to have_content('nginx cap ')
+        expect(page).to have_content('solidus shirt')
+      end
     end
 
     context "creating a new product" do

--- a/core/app/models/concerns/spree/soft_deletable.rb
+++ b/core/app/models/concerns/spree/soft_deletable.rb
@@ -10,7 +10,7 @@ module Spree
       include Discard::Model
       self.discard_column = :deleted_at
 
-      default_scope { kept }
+      default_scope -> { kept }
     end
   end
 end

--- a/core/app/models/spree/product/scopes.rb
+++ b/core/app/models/spree/product/scopes.rb
@@ -197,7 +197,8 @@ module Spree
           def self.with_variant_sku_cont(sku)
             sku_match = "%#{sku}%"
             variant_table = Spree::Variant.arel_table
-            subquery = Spree::Variant.where(variant_table[:sku].matches(sku_match).and(variant_table[:product_id].eq(arel_table[:id])))
+            subquery = Spree::Variant.with_discarded
+                      .where(variant_table[:sku].matches(sku_match).and(variant_table[:product_id].eq(arel_table[:id])))
             where(subquery.arel.exists)
           end
 

--- a/core/spec/models/spree/product/scopes_spec.rb
+++ b/core/spec/models/spree/product/scopes_spec.rb
@@ -183,4 +183,28 @@ RSpec.describe "Product scopes", type: :model do
       end
     end
   end
+
+  describe '.with_variant_sku_cont' do
+    let!(:product) { create(:product, name: 'ring cap') }
+    let!(:variant_1) { create(:variant, product: product, sku: 'H100') }
+    let!(:variant_2) { create(:variant, product: product, sku: 'H290') }
+
+    context 'query products' do
+      it 'scope returns empty array' do
+        product.discard
+        expect(Spree::Product.with_variant_sku_cont('H1').to_a).to eq []
+      end
+
+      it 'scope returns product' do
+        product = Spree::Product.with_variant_sku_cont('H1').first
+        expect(product.name).to eq 'ring cap'
+      end
+
+      it 'returns product when with_discarded is passed on product' do
+        product.discard
+        product = Spree::Product.with_discarded.with_variant_sku_cont('H1').first
+        expect(product.name).to eq 'ring cap'
+      end
+    end
+  end
 end


### PR DESCRIPTION
**Description**

 Changed the `Spree::SoftDeletable` default_scope from `default_scope { kept }` to 
 `default_scope -> { kept }`.  I did this because the initial implementation caused select
  queries to include the default scope even when directed not to. Such that when you would
  use the `with_discarded` method.
  Also, change the `with_variant_sku_cont`  scope to include variants that have been deleted so as to
  allow deleted products to be shown on the index page.
  
  Pictures of changes:
   
<img width="1221" alt="Screen Shot 2021-02-03 at 1 16 25 PM" src="https://user-images.githubusercontent.com/23207591/106734968-b49d5e00-6624-11eb-8157-b2c8c3eeba8c.png">

  Ref #https://github.com/solidusio/solidus/issues/3912




**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
