### PR TITLE
Use Devise email_regexp for order e-mail validations when using spree_auth_devise

### DIFF
--- a/core/lib/spree/core/validators/email.rb
+++ b/core/lib/spree/core/validators/email.rb
@@ -15,7 +15,9 @@ module Spree
     EMAIL_REGEXP = /\A([^@\.]|[^@\.]([^@\s]*)[^@\.])@([^@\s]+\.)+[^@\s]+\z/
 
     def validate_each(record, attribute, value)
-      unless EMAIL_REGEXP.match? value
+      email_regexp = defined?(Devise) ? Devise.email_regexp : EMAIL_REGEXP
+
+      unless email_regexp.match? value
         record.errors.add(attribute, :invalid, { value: value }.merge!(options))
       end
     end

--- a/core/spec/models/spree/order/validations_spec.rb
+++ b/core/spec/models/spree/order/validations_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 module Spree
   RSpec.describe Spree::Order, type: :model do
@@ -11,6 +11,38 @@ module Spree
         allow(order).to receive_messages(require_email: true)
         order.valid?
         expect(order.errors[:email]).to eq(["can't be blank"])
+      end
+
+      context "email validations where email is copied from user" do
+        let(:user) {
+          Spree::LegacyUser.create! email: "foo.@example.com", password: "password", password_confirmation: "password"
+        }
+        let(:order) {
+          order = Spree::Order.new
+          order.associate_user! user
+
+          order
+        }
+        context "when DEVISE is defined" do
+          before {
+            # this is the default email_regexp as seen in https://github.com/heartcombo/devise/blob/master/lib/devise.rb#L116
+            stub_const "Devise", double("Devise", email_regexp: /\A[^@\s]+@[^@\s]+\z/)
+          }
+
+          it "will validate the email against its email_regexp configuration" do
+            order.valid?
+
+            expect(order.errors[:email]).to be_blank
+          end
+        end
+
+        context "when DEVISE is not defined" do
+          it "will include an email validation error if email doesn't follow spree/email format" do
+            order.valid?
+
+            expect(order.errors[:email]).to include("is invalid")
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
## Description

Background: #3427 

The `EmailValidator` provided by spree and the format validation provided by Devise use different regexps. This will lead to a Order containing an email format error, after persistence, if the email is copied from `Spree::User` in [spree_auth_devise](https://github.com/spree/spree_auth_devise), such as when `associate_user!` is called.

It would be logic to use the same email validation for both `Spree::User` and `Order::Entities`.

This is currently only an outline of the problem. I have added a test where the Order's email is copied from an spree-invalid User email, and followed the suggestion from a comment in the issue to sketch a quick solution.

However I am considering the following alternative approaches:
1. change the default `email_regexp used` in `spree_auth_devise` to be the same as the one in `Spree::EmailValidator`. This might be a good option as I feel that the email_regexp in `Spree::EmailValidator` is waaaay too permissible (see References)
2. use `defined?(Devise)` inside [`Spree::Order`](https://github.com/solidusio/solidus/blob/master/core/app/models/spree/order.rb#L132) instead of patching `Spree::EmailValidator` (this is my prefered approach in the case of changing solidus itself, but it might not be easy to test as Devise is evaluated on class definition. But a method / lambda validator would make the test added pass)
3. decorate / subclass `Spree::EmailValidator` and use it in the validation of the Order
4. Use this very, VERY black magic to get the email format validator:
```
 Spree.user_class.send(:_validators)[:email]
                            .select { |x| x.class == ActiveModel::Validations::FormatValidator }
                            .first.instance_eval { @options[:with] }
```

I will be committing my preferred solution this weekend ~~and removing the trailing white spaces vscode left~~ :)

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)

### References

https://deliverbility.com/valid-email-address-format/
https://help.xmatters.com/ondemand/trial/valid_email_format.htm#:~:text=A%20valid%20email%20address%20consists,the%20left%20of%20the%20%40%20symbol.&text=For%20example%2C%20in%20the%20address,com%22%20is%20the%20email%20domain.
https://github.com/heartcombo/devise/blob/07f2712a22aa05b8da61c85307b80a3bd2ed6c4c/lib/devise/models/validatable.rb#L34
https://github.com/heartcombo/devise/blob/b52e642c0131f7b0d9f2dd24d8607a186f18223e/lib/devise.rb#L116