### PR TITLE
allow customize database credentials for test app

### DIFF
--- a/core/lib/generators/spree/dummy/templates/rails/database.yml
+++ b/core/lib/generators/spree/dummy/templates/rails/database.yml
@@ -32,6 +32,8 @@ production:
   encoding: utf8
 <% when 'postgres', 'postgresql' %>
 <% db_host = ENV['DB_HOST'] -%>
+<% db_username = ENV['DB_USERNAME'] -%>
+<% db_password = ENV['DB_PASSWORD'] -%>
 development:
   adapter: postgresql
   database: <%= database_prefix %><%= options[:lib_name] %>_solidus_development
@@ -43,7 +45,10 @@ development:
 test:
   adapter: postgresql
   database: <%= database_prefix %><%= options[:lib_name] %>_solidus_test
-  username: postgres
+  username: <%= db_username || 'postgres' %>
+<% unless db_password.blank? %>
+  password: <%= db_password %>
+<% end %>
   min_messages: warning
 <% unless db_host.blank? %>
   host: <%= db_host %>


### PR DESCRIPTION
**Description**
This allow set postgresql database credentials for dummy app from env variables.

I think not everyone use default postgresql credential, and this will be useful in that cases.

**Checklist:**
- [ ] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [ ] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
