### PR TITLE
Skip adding webpacker gem when generating dummyapp

### DIFF
--- a/core/lib/generators/spree/dummy/dummy_generator.rb
+++ b/core/lib/generators/spree/dummy/dummy_generator.rb
@@ -43,7 +43,7 @@ module Spree
       opts[:skip_test] = true
       opts[:skip_yarn] = true
       opts[:skip_bootsnap] = true
-      opts[:skip_webpack_install] = true
+      opts[:skip_javascript] = true
 
       puts "Generating dummy Rails application..."
       invoke Rails::Generators::AppGenerator,


### PR DESCRIPTION
**Description**

Currently, the dummy app generated to test extensions has the `javascript_pack_tag` helper included in `layouts/application.html.erb`. This is because `skip-webpack-install` only prevents rails to run the webpacker install task but being webpacker the default for Rails 6, it is still included in the generated view.

`--skip-javascript` avoids webpacker to be included in the rails generated app.[1]

Related pr https://github.com/solidusio/solidus/pull/3326 where `--skip-javascript` is used in the sandbox generation.

[1]: https://github.com/rails/rails/issues/35484#issuecomment-469798114

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message