### PR TITLE
Deprecate try_spree_current_user

### DIFF
--- a/backend/app/controllers/spree/admin/base_controller.rb
+++ b/backend/app/controllers/spree/admin/base_controller.rb
@@ -33,7 +33,7 @@ module Spree
       # Need to generate an API key for a user due to some backend actions
       # requiring authentication to the Spree API
       def generate_admin_api_key
-        if (user = try_spree_current_user) && user.spree_api_key.blank?
+        if (user = spree_current_user) && user.spree_api_key.blank?
           user.generate_spree_api_key!
         end
       end

--- a/backend/app/controllers/spree/admin/cancellations_controller.rb
+++ b/backend/app/controllers/spree/admin/cancellations_controller.rb
@@ -30,7 +30,7 @@ module Spree
       private
 
       def created_by
-        try_spree_current_user.try(:email)
+        spree_current_user.try(:email)
       end
 
       def load_order

--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -112,7 +112,7 @@ module Spree
       end
 
       def cancel
-        @order.canceled_by(try_spree_current_user)
+        @order.canceled_by(spree_current_user)
         flash[:success] = t('spree.order_canceled')
         redirect_to(spree.edit_admin_order_path(@order))
       end
@@ -124,7 +124,7 @@ module Spree
       end
 
       def approve
-        @order.contents.approve(user: try_spree_current_user)
+        @order.contents.approve(user: spree_current_user)
         flash[:success] = t('spree.order_approved')
         redirect_to(spree.edit_admin_order_path(@order))
       end
@@ -156,7 +156,7 @@ module Spree
 
       def order_params
         {
-          created_by_id: try_spree_current_user.try(:id),
+          created_by_id: spree_current_user.try(:id),
           frontend_viewable: false,
           store_id: current_store.try(:id)
         }.with_indifferent_access

--- a/backend/app/controllers/spree/admin/reimbursements_controller.rb
+++ b/backend/app/controllers/spree/admin/reimbursements_controller.rb
@@ -14,7 +14,7 @@ module Spree
       rescue_from Spree::Core::GatewayError, with: :spree_core_gateway_error
 
       def perform
-        @reimbursement.perform!(created_by: try_spree_current_user)
+        @reimbursement.perform!(created_by: spree_current_user)
         redirect_to location_after_save
       end
 
@@ -62,7 +62,7 @@ module Spree
       end
 
       def load_simulated_refunds
-        @reimbursement_objects = @reimbursement.simulate(created_by: try_spree_current_user)
+        @reimbursement_objects = @reimbursement.simulate(created_by: spree_current_user)
       end
 
       def spree_core_gateway_error(error)

--- a/backend/app/controllers/spree/admin/stock_items_controller.rb
+++ b/backend/app/controllers/spree/admin/stock_items_controller.rb
@@ -18,7 +18,7 @@ module Spree
         variant = Spree::Variant.accessible_by(current_ability, :show).find(params[:variant_id])
         stock_location = Spree::StockLocation.accessible_by(current_ability, :show).find(params[:stock_location_id])
         stock_location.stock_movements.build(stock_movement_params).tap do |stock_movement|
-          stock_movement.originator = try_spree_current_user
+          stock_movement.originator = spree_current_user
           stock_movement.stock_item = stock_location.set_up_stock_item(variant)
         end
       end

--- a/backend/app/controllers/spree/admin/store_credits_controller.rb
+++ b/backend/app/controllers/spree/admin/store_credits_controller.rb
@@ -17,8 +17,8 @@ module Spree
       def create
         @store_credit = @user.store_credits.build(
           permitted_resource_params.merge({
-            created_by: try_spree_current_user,
-            action_originator: try_spree_current_user
+            created_by: spree_current_user,
+            action_originator: spree_current_user
           })
         )
 
@@ -34,7 +34,7 @@ module Spree
 
       def update
         @store_credit.assign_attributes(permitted_resource_params)
-        @store_credit.created_by = try_spree_current_user
+        @store_credit.created_by = spree_current_user
 
         if @store_credit.save
           respond_to do |format|
@@ -50,7 +50,7 @@ module Spree
       def update_amount
         @store_credit = @user.store_credits.find(params[:id])
         amount = params.require(:store_credit).require(:amount)
-        if @store_credit.update_amount(amount, @store_credit_reason, try_spree_current_user)
+        if @store_credit.update_amount(amount, @store_credit_reason, spree_current_user)
           flash[:success] = flash_message_for(@store_credit, :successfully_updated)
           redirect_to admin_user_store_credit_path(@user, @store_credit)
         else
@@ -60,7 +60,7 @@ module Spree
 
       def invalidate
         @store_credit = @user.store_credits.find(params[:id])
-        if @store_credit.invalidate(@store_credit_reason, try_spree_current_user)
+        if @store_credit.invalidate(@store_credit_reason, spree_current_user)
           redirect_to admin_user_store_credit_path(@user, @store_credit)
         else
           render_edit_page
@@ -71,7 +71,7 @@ module Spree
 
       def permitted_resource_params
         params.require(:store_credit).permit([:amount, :currency, :category_id, :memo]).
-          merge(created_by: try_spree_current_user)
+          merge(created_by: spree_current_user)
       end
 
       def collection

--- a/backend/app/controllers/spree/admin/users_controller.rb
+++ b/backend/app/controllers/spree/admin/users_controller.rb
@@ -125,7 +125,7 @@ module Spree
       end
 
       def sign_in_if_change_own_password
-        if try_spree_current_user == @user && @user.password.present?
+        if spree_current_user == @user && @user.password.present?
           sign_in(@user, event: :authentication, bypass: true)
         end
       end

--- a/backend/app/views/spree/admin/shared/_head.html.erb
+++ b/backend/app/views/spree/admin/shared/_head.html.erb
@@ -41,7 +41,7 @@
 <%= render "spree/admin/shared/js_locale_data" %>
 
 <%= javascript_tag do -%>
-  Spree.api_key = "<%= try_spree_current_user.try(:spree_api_key) %>";
+  Spree.api_key = "<%= spree_current_user.try(:spree_api_key) %>";
   Spree.env = "<%= Rails.env %>";
 <% end %>
 

--- a/backend/app/views/spree/admin/shared/_navigation_footer.html.erb
+++ b/backend/app/views/spree/admin/shared/_navigation_footer.html.erb
@@ -3,18 +3,18 @@
      any typical `rails generate spree:custom_user` auth, if you need something
      else you can override it like solidus_auth_devise does.
 -->
-<% if try_spree_current_user %>
+<% if spree_current_user %>
   <ul id="login-nav" class="admin-login-nav">
     <li data-hook="user-account-link">
-      <% if can?(:admin, try_spree_current_user) %>
-        <%= link_to spree.edit_admin_user_path(try_spree_current_user) do %>
+      <% if can?(:admin, spree_current_user) %>
+        <%= link_to spree.edit_admin_user_path(spree_current_user) do %>
           <i class='fa fa-user'></i>
-          <%= try_spree_current_user.email %>
+          <%= spree_current_user.email %>
         <% end %>
       <% else %>
         <a>
           <i class='fa fa-user'></i>
-          <%= try_spree_current_user.email %>
+          <%= spree_current_user.email %>
         </a>
       <% end %>
     </li>

--- a/backend/app/views/spree/admin/users/edit.html.erb
+++ b/backend/app/views/spree/admin/users/edit.html.erb
@@ -32,7 +32,7 @@
     <% if @user.spree_api_key.present? %>
       <div id="current-api-key">
         <strong><%= t('.key') %>: </strong>
-        <% if @user == try_spree_current_user %>
+        <% if @user == spree_current_user %>
           <%= @user.spree_api_key %>
         <% else %>
           <i>(<%= t('spree.hidden') %>)</i>

--- a/backend/spec/controllers/spree/admin/base_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/base_controller_spec.rb
@@ -15,7 +15,7 @@ describe Spree::Admin::BaseController, type: :controller do
 
   context "unauthorized request" do
     before do
-      allow_any_instance_of(Spree::Admin::BaseController).to receive(:try_spree_current_user).and_return(nil)
+      allow_any_instance_of(Spree::Admin::BaseController).to receive(:spree_current_user).and_return(nil)
     end
 
     it "redirects to unauthorized" do

--- a/backend/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -32,7 +32,7 @@ describe Spree::Admin::OrdersController, type: :controller do
 
     context "#approve" do
       it "approves an order" do
-        expect(order.contents).to receive(:approve).with(user: controller.try_spree_current_user)
+        expect(order.contents).to receive(:approve).with(user: controller.spree_current_user)
         put :approve, params: { id: order.number }
         expect(flash[:success]).to eq I18n.t('spree.order_approved')
       end
@@ -40,7 +40,7 @@ describe Spree::Admin::OrdersController, type: :controller do
 
     context "#cancel" do
       it "cancels an order" do
-        expect(order).to receive(:canceled_by).with(controller.try_spree_current_user)
+        expect(order).to receive(:canceled_by).with(controller.spree_current_user)
         put :cancel, params: { id: order.number }
         expect(flash[:success]).to eq I18n.t('spree.order_canceled')
       end
@@ -77,12 +77,12 @@ describe Spree::Admin::OrdersController, type: :controller do
     context "#new" do
       let(:user) { create(:user) }
       before do
-        allow(controller).to receive_messages try_spree_current_user: user
+        allow(controller).to receive_messages spree_current_user: user
       end
 
       it "imports a new order and sets the current user as a creator" do
         expect(Spree::Core::Importer::Order).to receive(:import)
-          .with(nil, hash_including(created_by_id: controller.try_spree_current_user.id))
+          .with(nil, hash_including(created_by_id: controller.spree_current_user.id))
           .and_return(order)
         get :new
       end
@@ -107,7 +107,7 @@ describe Spree::Admin::OrdersController, type: :controller do
 
         it "imports a new order and assigns the user to the order" do
           expect(Spree::Core::Importer::Order).to receive(:import)
-            .with(user, hash_including(created_by_id: controller.try_spree_current_user.id))
+            .with(user, hash_including(created_by_id: controller.spree_current_user.id))
             .and_return(order)
           get :new, params: { user_id: user.id }
         end
@@ -288,7 +288,7 @@ describe Spree::Admin::OrdersController, type: :controller do
       let(:user) { create(:user) }
 
       before do
-        allow(controller).to receive_messages try_spree_current_user: user
+        allow(controller).to receive_messages spree_current_user: user
         user.spree_roles << Spree::Role.find_or_create_by(name: 'admin')
 
         create_list(:completed_order_with_totals, 2)
@@ -361,7 +361,7 @@ describe Spree::Admin::OrdersController, type: :controller do
     let!(:order) { create(:completed_order_with_totals, number: 'R987654321') }
 
     before do
-      allow(controller).to receive_messages try_spree_current_user: user
+      allow(controller).to receive_messages spree_current_user: user
     end
 
     it 'should grant access to users with an admin role' do

--- a/backend/spec/controllers/spree/admin/payments_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/payments_controller_spec.rb
@@ -6,7 +6,7 @@ module Spree
   module Admin
     describe PaymentsController, type: :controller do
       before do
-        allow(controller).to receive_messages try_spree_current_user: user
+        allow(controller).to receive_messages spree_current_user: user
       end
 
       let(:user) { create(:admin_user) }

--- a/backend/spec/controllers/spree/admin/reimbursements_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/reimbursements_controller_spec.rb
@@ -12,7 +12,7 @@ describe Spree::Admin::ReimbursementsController, type: :controller do
   let(:user) { stub_model(Spree::LegacyUser, has_spree_role?: true, id: 1) }
 
   before do
-    allow_any_instance_of(described_class).to receive(:try_spree_current_user).
+    allow_any_instance_of(described_class).to receive(:spree_current_user).
       and_return(user)
   end
 

--- a/backend/spec/controllers/spree/admin/root_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/root_controller_spec.rb
@@ -10,7 +10,7 @@ describe Spree::Admin::RootController do
     let(:ability) { Spree::Ability.new(user) }
 
     before do
-      allow_any_instance_of(Spree::Admin::RootController).to receive(:try_spree_current_user).and_return(user)
+      allow_any_instance_of(Spree::Admin::RootController).to receive(:spree_current_user).and_return(user)
       allow_any_instance_of(Spree::Admin::RootController).to receive(:current_ability).and_return(ability)
     end
 

--- a/backend/spec/controllers/spree/admin/stock_items_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/stock_items_controller_spec.rb
@@ -13,7 +13,7 @@ module Spree
         let(:stock_item) { variant.stock_items.first }
         let!(:user) { create :user }
 
-        before { expect(controller).to receive(:try_spree_current_user).and_return(user) }
+        before { expect(controller).to receive(:spree_current_user).and_return(user) }
         before { request.env["HTTP_REFERER"] = "product_admin_page" }
 
         subject do

--- a/backend/spec/controllers/spree/admin/store_credits_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/store_credits_controller_spec.rb
@@ -43,7 +43,7 @@ describe Spree::Admin::StoreCreditsController do
     subject { post :create, params: parameters }
 
     before  {
-      allow(controller).to receive_messages(try_spree_current_user: admin_user)
+      allow(controller).to receive_messages(spree_current_user: admin_user)
       create(:primary_credit_type)
     }
 
@@ -124,7 +124,7 @@ describe Spree::Admin::StoreCreditsController do
 
     subject { put :update, params: parameters.merge(format: :json) }
 
-    before  { allow(controller).to receive_messages(try_spree_current_user: admin_user) }
+    before  { allow(controller).to receive_messages(spree_current_user: admin_user) }
 
     context "the passed parameters are valid" do
       let(:parameters) do
@@ -187,7 +187,7 @@ describe Spree::Admin::StoreCreditsController do
 
     subject { put :update_amount, params: parameters }
 
-    before  { allow(controller).to receive_messages(try_spree_current_user: admin_user) }
+    before  { allow(controller).to receive_messages(spree_current_user: admin_user) }
 
     context "the passed parameters are valid" do
       let(:updated_amount) { 300.0 }

--- a/backend/spec/features/admin/homepage_spec.rb
+++ b/backend/spec/features/admin/homepage_spec.rb
@@ -67,7 +67,7 @@ describe "Homepage", type: :feature do
 
   context 'as fakedispatch user' do
     before do
-      allow_any_instance_of(Spree::Admin::BaseController).to receive(:try_spree_current_user).and_return(nil)
+      allow_any_instance_of(Spree::Admin::BaseController).to receive(:spree_current_user).and_return(nil)
     end
 
     custom_authorization! do |_user|

--- a/backend/spec/features/admin/orders/cancelling_and_resuming_spec.rb
+++ b/backend/spec/features/admin/orders/cancelling_and_resuming_spec.rb
@@ -9,7 +9,7 @@ describe "Cancelling + Resuming", type: :feature do
 
   before do
     allow(user).to receive(:has_spree_role?).and_return(true)
-    allow_any_instance_of(Spree::Admin::BaseController).to receive(:try_spree_current_user).and_return(user)
+    allow_any_instance_of(Spree::Admin::BaseController).to receive(:spree_current_user).and_return(user)
   end
 
   let(:order) do

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -593,7 +593,7 @@ describe "Order Details", type: :feature, js: true do
 
   context 'with only read permissions' do
     before do
-      allow_any_instance_of(Spree::Admin::BaseController).to receive(:try_spree_current_user).and_return(nil)
+      allow_any_instance_of(Spree::Admin::BaseController).to receive(:spree_current_user).and_return(nil)
     end
 
     custom_authorization! do |_user|

--- a/backend/spec/features/admin/orders/return_payment_state_spec.rb
+++ b/backend/spec/features/admin/orders/return_payment_state_spec.rb
@@ -7,7 +7,7 @@ describe "Return payment state spec" do
 
   before do
     Spree::RefundReason.create!(name: Spree::RefundReason::RETURN_PROCESSING_REASON, mutable: false)
-    allow_any_instance_of(Spree::Admin::ReimbursementsController).to receive(:try_spree_current_user).
+    allow_any_instance_of(Spree::Admin::ReimbursementsController).to receive(:spree_current_user).
       and_return(user)
   end
 

--- a/backend/spec/features/admin/orders/risk_analysis_spec.rb
+++ b/backend/spec/features/admin/orders/risk_analysis_spec.rb
@@ -19,7 +19,7 @@ describe 'Order Risk Analysis', type: :feature do
 
   context "the order is considered risky" do
     before do
-      allow_any_instance_of(Spree::Admin::BaseController).to receive_messages try_spree_current_user: create(:user)
+      allow_any_instance_of(Spree::Admin::BaseController).to receive_messages spree_current_user: create(:user)
 
       order.payments.first.update_column(:avs_response, 'N')
       visit_order

--- a/backend/spec/features/admin/products/products_spec.rb
+++ b/backend/spec/features/admin/products/products_spec.rb
@@ -372,7 +372,7 @@ describe "Products", type: :feature do
 
   context 'with only product permissions' do
     before do
-      allow_any_instance_of(Spree::Admin::BaseController).to receive(:try_spree_current_user).and_return(nil)
+      allow_any_instance_of(Spree::Admin::BaseController).to receive(:spree_current_user).and_return(nil)
     end
 
     custom_authorization! do |_user|

--- a/backend/spec/features/admin/promotions/promotion_code_batches_spec.rb
+++ b/backend/spec/features/admin/promotions/promotion_code_batches_spec.rb
@@ -9,8 +9,7 @@ feature "Promotion Code Batches", partial_double_verification: false do
     let(:promotion) { create :promotion }
 
     before do
-      user = double.as_null_object
-      allow_any_instance_of(ActionView::Base).to receive(:spree_current_user) { user }
+      allow_any_instance_of(ApplicationController).to receive(:spree_current_user) { build(:user, id: 123) }
       visit spree.new_admin_promotion_promotion_code_batch_path(promotion)
     end
 

--- a/backend/spec/features/admin/store_credits_spec.rb
+++ b/backend/spec/features/admin/store_credits_spec.rb
@@ -40,7 +40,7 @@ describe "Store credits admin" do
       click_link "Users"
       click_link store_credit.user.email
       click_link "Store Credit"
-      allow_any_instance_of(Spree::Admin::StoreCreditsController).to receive_messages(try_spree_current_user: admin_user)
+      allow_any_instance_of(Spree::Admin::StoreCreditsController).to receive_messages(spree_current_user: admin_user)
     end
 
     it "should create store credit and associate it with the user" do
@@ -76,7 +76,7 @@ describe "Store credits admin" do
 
     it "lets edit store credit's memo", js: true do
       allow_any_instance_of(Spree::Admin::StoreCreditsController)
-        .to receive(:try_spree_current_user)
+        .to receive(:spree_current_user)
         .and_return(admin_user)
 
       # When there are no errors
@@ -114,7 +114,7 @@ describe "Store credits admin" do
       click_link "Users"
       click_link store_credit.user.email
       click_link "Store Credit"
-      allow_any_instance_of(Spree::Admin::StoreCreditsController).to receive_messages(try_spree_current_user: admin_user)
+      allow_any_instance_of(Spree::Admin::StoreCreditsController).to receive_messages(spree_current_user: admin_user)
     end
 
     it "updates the store credit's amount" do

--- a/backend/spec/views/spree/admin/shared/navigation_footer_spec.rb
+++ b/backend/spec/views/spree/admin/shared/navigation_footer_spec.rb
@@ -6,7 +6,7 @@ describe "spree/admin/shared/_navigation_footer", type: :view, partial_double_ve
   let(:user) { FactoryBot.build_stubbed(:admin_user) }
   let(:ability) { Object.new.extend(CanCan::Ability) }
   before do
-    allow(view).to receive(:try_spree_current_user).and_return(user)
+    allow(view).to receive(:spree_current_user).and_return(user)
     allow(controller).to receive(:current_ability).and_return(ability)
   end
 

--- a/core/lib/spree/core/controller_helpers/auth.rb
+++ b/core/lib/spree/core/controller_helpers/auth.rb
@@ -33,7 +33,7 @@ module Spree
 
         # Needs to be overriden so that we use Spree's Ability rather than anyone else's.
         def current_ability
-          @current_ability ||= Spree::Ability.new(try_spree_current_user)
+          @current_ability ||= Spree::Ability.new(spree_current_user)
         end
 
         def redirect_back_or_default(default)

--- a/core/lib/spree/core/controller_helpers/auth.rb
+++ b/core/lib/spree/core/controller_helpers/auth.rb
@@ -18,6 +18,7 @@ module Spree
         included do
           before_action :set_guest_token
           helper_method :try_spree_current_user
+          helper_method :spree_current_user
 
           class_attribute :unauthorized_redirect
           self.unauthorized_redirect = -> do
@@ -65,6 +66,8 @@ module Spree
             current_spree_user
           end
         end
+
+        deprecate try_spree_current_user: :spree_current_user, deprecator: Spree::Deprecation
       end
     end
   end

--- a/core/lib/spree/core/controller_helpers/order.rb
+++ b/core/lib/spree/core/controller_helpers/order.rb
@@ -24,9 +24,9 @@ module Spree
 
           if should_build && (@current_order.nil? || @current_order.completed?)
             @current_order = Spree::Order.new(new_order_params)
-            @current_order.user ||= try_spree_current_user
+            @current_order.user ||= spree_current_user
             # See issue https://github.com/spree/spree/issues/3346 for reasons why this line is here
-            @current_order.created_by ||= try_spree_current_user
+            @current_order.created_by ||= spree_current_user
             @current_order.save! if should_create
           end
 
@@ -38,15 +38,15 @@ module Spree
 
         def associate_user
           @order ||= current_order
-          if try_spree_current_user && @order
-            @order.associate_user!(try_spree_current_user) if @order.user.blank? || @order.email.blank?
+          if spree_current_user && @order
+            @order.associate_user!(spree_current_user) if @order.user.blank? || @order.email.blank?
           end
         end
 
         def set_current_order
-          if try_spree_current_user && current_order
-            try_spree_current_user.orders.by_store(current_store).incomplete.where('id != ?', current_order.id).each do |order|
-              current_order.merge!(order, try_spree_current_user)
+          if spree_current_user && current_order
+            spree_current_user.orders.by_store(current_store).incomplete.where('id != ?', current_order.id).each do |order|
+              current_order.merge!(order, spree_current_user)
             end
           end
         end
@@ -58,11 +58,11 @@ module Spree
         private
 
         def last_incomplete_order
-          @last_incomplete_order ||= try_spree_current_user.last_incomplete_spree_order(store: current_store)
+          @last_incomplete_order ||= spree_current_user.last_incomplete_spree_order(store: current_store)
         end
 
         def current_order_params
-          { currency: current_pricing_options.currency, guest_token: cookies.signed[:guest_token], store_id: current_store.id, user_id: try_spree_current_user.try(:id) }
+          { currency: current_pricing_options.currency, guest_token: cookies.signed[:guest_token], store_id: current_store.id, user_id: spree_current_user.try(:id) }
         end
 
         def new_order_params
@@ -76,7 +76,7 @@ module Spree
           order = Spree::Order.incomplete.lock(should_lock).find_by(current_order_params)
 
           # Find any incomplete orders for the current user
-          if order.nil? && try_spree_current_user
+          if order.nil? && spree_current_user
             order = last_incomplete_order
           end
 

--- a/core/lib/spree/core/controller_helpers/search.rb
+++ b/core/lib/spree/core/controller_helpers/search.rb
@@ -6,7 +6,7 @@ module Spree
       module Search
         def build_searcher(params)
           Spree::Config.searcher_class.new(params).tap do |searcher|
-            searcher.current_user = try_spree_current_user
+            searcher.current_user = spree_current_user
             searcher.pricing_options = current_pricing_options
           end
         end

--- a/core/lib/spree/testing_support/dummy_app.rb
+++ b/core/lib/spree/testing_support/dummy_app.rb
@@ -18,6 +18,9 @@ RAILS_6_OR_ABOVE = Rails.gem_version >= Gem::Version.new('6.0')
 # @private
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
+
+  def spree_current_user
+  end
 end
 
 # @private

--- a/core/spec/lib/spree/core/controller_helpers/auth_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/auth_spec.rb
@@ -75,20 +75,21 @@ RSpec.describe Spree::Core::ControllerHelpers::Auth, type: :controller do
   end
 
   describe '#try_spree_current_user' do
+    it 'is deprecated' do
+      without_partial_double_verification do
+        expect(Spree::Deprecation).to receive(:warn)
+      end
+      controller.try_spree_current_user
+    end
     it 'calls spree_current_user when define spree_current_user method' do
       without_partial_double_verification do
         expect(controller).to receive(:spree_current_user)
       end
-      controller.try_spree_current_user
-    end
-    it 'calls current_spree_user when define current_spree_user method' do
-      without_partial_double_verification do
-        expect(controller).to receive(:current_spree_user)
-      end
-      controller.try_spree_current_user
+      Spree::Deprecation.silence { controller.try_spree_current_user }
     end
     it 'returns nil' do
-      expect(controller.try_spree_current_user).to eq nil
+      controller.instance_eval { undef spree_current_user }
+      Spree::Deprecation.silence { expect(controller.try_spree_current_user).to eq nil }
     end
   end
 

--- a/core/spec/lib/spree/core/controller_helpers/order_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/order_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Spree::Core::ControllerHelpers::Order, type: :controller do
   before do
     allow(controller).to receive_messages(current_store: store)
     allow(controller).to receive_messages(current_pricing_options: Spree::Config.pricing_options_class.new(currency: Spree::Config.currency))
-    allow(controller).to receive_messages(try_spree_current_user: user)
+    allow(controller).to receive_messages(spree_current_user: user)
   end
 
   describe '#current_order' do

--- a/core/spec/lib/spree/core/controller_helpers/search_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/search_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Spree::Core::ControllerHelpers::Search, type: :controller do
   describe '#build_searcher' do
     it 'returns Spree::Core::Search::Base instance' do
       allow(controller).to receive_messages(
-        try_spree_current_user: create(:user),
+        spree_current_user: create(:user),
         current_pricing_options: Spree::Config.pricing_options_class.new(currency: 'USD')
       )
       expect(controller.build_searcher({}).class).to eq Spree::Core::Search::Base

--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -207,8 +207,8 @@ module Spree
         end
       end
 
-      if try_spree_current_user && try_spree_current_user.respond_to?(:wallet)
-        @wallet_payment_sources = try_spree_current_user.wallet.wallet_payment_sources
+      if spree_current_user&.respond_to?(:wallet)
+        @wallet_payment_sources = spree_current_user.wallet.wallet_payment_sources
         @default_wallet_payment_source = @wallet_payment_sources.detect(&:default) ||
                                          @wallet_payment_sources.first
       end

--- a/frontend/app/controllers/spree/products_controller.rb
+++ b/frontend/app/controllers/spree/products_controller.rb
@@ -37,7 +37,7 @@ module Spree
     end
 
     def load_product
-      if try_spree_current_user.try(:has_spree_role?, "admin")
+      if spree_current_user.try(:has_spree_role?, "admin")
         @products = Spree::Product.with_discarded
       else
         @products = Spree::Product.available

--- a/frontend/app/views/spree/checkout/_address.html.erb
+++ b/frontend/app/views/spree/checkout/_address.html.erb
@@ -23,10 +23,10 @@
 
 <div class="form-buttons" data-hook="buttons">
   <%= submit_tag t('spree.save_and_continue'), class: 'continue button primary' %>
-  <% if try_spree_current_user %>
+  <% if spree_current_user %>
     <span data-hook="save_user_address">
       &nbsp; &nbsp;
-      <%= check_box_tag 'save_user_address', '1', try_spree_current_user.respond_to?(:persist_order_address) %>
+      <%= check_box_tag 'save_user_address', '1', spree_current_user.respond_to?(:persist_order_address) %>
       <%= label_tag :save_user_address, t('spree.save_my_address') %>
     </span>
   <% end %>

--- a/frontend/app/views/spree/orders/show.html.erb
+++ b/frontend/app/views/spree/orders/show.html.erb
@@ -13,7 +13,7 @@
     <p data-hook="links">
       <%= link_to t('spree.back_to_store'), spree.root_path, class: "button" %>
       <% unless order_just_completed?(@order) %>
-        <% if try_spree_current_user && respond_to?(:account_path) %>
+        <% if spree_current_user && respond_to?(:account_path) %>
           <%= link_to t('spree.my_account'), spree.account_path, class: "button" %>
         <% end %>
       <% end %>

--- a/frontend/spec/controllers/spree/checkout_controller_spec.rb
+++ b/frontend/spec/controllers/spree/checkout_controller_spec.rb
@@ -13,7 +13,7 @@ describe Spree::CheckoutController, type: :controller do
   end
 
   before do
-    allow(controller).to receive_messages try_spree_current_user: user
+    allow(controller).to receive_messages spree_current_user: user
     allow(controller).to receive_messages current_order: order
   end
 

--- a/frontend/spec/controllers/spree/checkout_controller_with_views_spec.rb
+++ b/frontend/spec/controllers/spree/checkout_controller_with_views_spec.rb
@@ -10,7 +10,7 @@ describe Spree::CheckoutController, type: :controller do
   let(:user) { stub_model(Spree::LegacyUser) }
 
   before do
-    allow(controller).to receive_messages try_spree_current_user: user
+    allow(controller).to receive_messages spree_current_user: user
   end
 
   # Regression test for https://github.com/spree/spree/issues/3246

--- a/frontend/spec/controllers/spree/current_order_tracking_spec.rb
+++ b/frontend/spec/controllers/spree/current_order_tracking_spec.rb
@@ -15,14 +15,14 @@ describe 'current order tracking', type: :controller do
   let(:order) { FactoryBot.create(:order) }
 
   it 'automatically tracks who the order was created by & IP address' do
-    allow(controller).to receive_messages(try_spree_current_user: user)
+    allow(controller).to receive_messages(spree_current_user: user)
     get :index
-    expect(controller.current_order(create_order_if_necessary: true).created_by).to eq controller.try_spree_current_user
+    expect(controller.current_order(create_order_if_necessary: true).created_by).to eq controller.spree_current_user
     expect(controller.current_order.last_ip_address).to eq "0.0.0.0"
   end
 
   context "current order creation" do
-    before { allow(controller).to receive_messages(try_spree_current_user: user) }
+    before { allow(controller).to receive_messages(spree_current_user: user) }
 
     it "doesn't create a new order out of the blue" do
       expect {

--- a/frontend/spec/controllers/spree/home_controller_spec.rb
+++ b/frontend/spec/controllers/spree/home_controller_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe Spree::HomeController, type: :controller do
   it "provides current user to the searcher class" do
     user = mock_model(Spree.user_class, last_incomplete_spree_order: nil, spree_api_key: 'fake')
-    allow(controller).to receive_messages try_spree_current_user: user
+    allow(controller).to receive_messages spree_current_user: user
     expect_any_instance_of(Spree::Config.searcher_class).to receive(:current_user=).with(user)
     get :index
     expect(response.status).to eq(200)

--- a/frontend/spec/controllers/spree/orders_controller_spec.rb
+++ b/frontend/spec/controllers/spree/orders_controller_spec.rb
@@ -13,7 +13,7 @@ describe Spree::OrdersController, type: :controller do
     let(:variant) { create(:variant) }
 
     before do
-      allow(controller).to receive_messages(try_spree_current_user: user)
+      allow(controller).to receive_messages(spree_current_user: user)
     end
 
     context "#populate" do
@@ -206,7 +206,7 @@ describe Spree::OrdersController, type: :controller do
     let(:user) { build :user }
 
     it "builds a new valid order with complete meta-data" do
-      allow(controller).to receive_messages(try_spree_current_user: user)
+      allow(controller).to receive_messages(spree_current_user: user)
 
       subject
 

--- a/frontend/spec/controllers/spree/products_controller_spec.rb
+++ b/frontend/spec/controllers/spree/products_controller_spec.rb
@@ -7,7 +7,7 @@ describe Spree::ProductsController, type: :controller do
 
   # Regression test for https://github.com/spree/spree/issues/1390
   it "allows admins to view non-active products" do
-    allow(controller).to receive_messages try_spree_current_user: mock_model(Spree.user_class, has_spree_role?: true, last_incomplete_spree_order: nil, spree_api_key: 'fake')
+    allow(controller).to receive_messages spree_current_user: mock_model(Spree.user_class, has_spree_role?: true, last_incomplete_spree_order: nil, spree_api_key: 'fake')
     get :show, params: { id: product.to_param }
     expect(response.status).to eq(200)
   end
@@ -20,7 +20,7 @@ describe Spree::ProductsController, type: :controller do
 
   it "should provide the current user to the searcher class" do
     user = mock_model(Spree.user_class, last_incomplete_spree_order: nil, spree_api_key: 'fake')
-    allow(controller).to receive_messages try_spree_current_user: user
+    allow(controller).to receive_messages spree_current_user: user
     expect_any_instance_of(Spree::Config.searcher_class).to receive(:current_user=).with(user)
     get :index
     expect(response.status).to eq(200)
@@ -29,7 +29,7 @@ describe Spree::ProductsController, type: :controller do
   # Regression test for https://github.com/spree/spree/issues/2249
   it "doesn't error when given an invalid referer" do
     current_user = mock_model(Spree.user_class, has_spree_role?: true, last_incomplete_spree_order: nil, generate_spree_api_key!: nil)
-    allow(controller).to receive_messages try_spree_current_user: current_user
+    allow(controller).to receive_messages spree_current_user: current_user
     request.env['HTTP_REFERER'] = "not|a$url"
 
     # Previously a URI::InvalidURIError exception was being thrown

--- a/frontend/spec/controllers/spree/taxons_controller_spec.rb
+++ b/frontend/spec/controllers/spree/taxons_controller_spec.rb
@@ -6,7 +6,7 @@ describe Spree::TaxonsController, type: :controller do
   it "should provide the current user to the searcher class" do
     taxon = create(:taxon, permalink: "test")
     user = mock_model(Spree.user_class, last_incomplete_spree_order: nil, spree_api_key: 'fake')
-    allow(controller).to receive_messages try_spree_current_user: user
+    allow(controller).to receive_messages spree_current_user: user
     expect_any_instance_of(Spree::Config.searcher_class).to receive(:current_user=).with(user)
     get :show, params: { id: taxon.permalink }
     expect(response.status).to eq(200)

--- a/frontend/spec/features/checkout_confirm_insufficient_stock_spec.rb
+++ b/frontend/spec/features/checkout_confirm_insufficient_stock_spec.rb
@@ -16,8 +16,8 @@ describe "Checkout confirm page submission", type: :feature do
       order_stock_item.update! backorderable: false
       order_stock_item.set_count_on_hand(1)
       allow_any_instance_of(Spree::CheckoutController).to receive_messages(current_order: order)
-      allow_any_instance_of(Spree::CheckoutController).to receive_messages(try_spree_current_user: user)
-      allow_any_instance_of(Spree::OrdersController).to receive_messages(try_spree_current_user: user)
+      allow_any_instance_of(Spree::CheckoutController).to receive_messages(spree_current_user: user)
+      allow_any_instance_of(Spree::OrdersController).to receive_messages(spree_current_user: user)
     end
 
     context 'when there are not other backorderable stock locations' do

--- a/frontend/spec/features/checkout_spec.rb
+++ b/frontend/spec/features/checkout_spec.rb
@@ -101,8 +101,8 @@ describe "Checkout", type: :feature, inaccessible: true do
 
       before do
         allow_any_instance_of(Spree::CheckoutController).to receive_messages(current_order: order)
-        allow_any_instance_of(Spree::CheckoutController).to receive_messages(try_spree_current_user: user)
-        allow_any_instance_of(Spree::OrdersController).to receive_messages(try_spree_current_user: user)
+        allow_any_instance_of(Spree::CheckoutController).to receive_messages(spree_current_user: user)
+        allow_any_instance_of(Spree::OrdersController).to receive_messages(spree_current_user: user)
 
         add_mug_to_cart
         click_button "Checkout"
@@ -170,8 +170,8 @@ describe "Checkout", type: :feature, inaccessible: true do
 
           # Simulate user login
           Spree::Order.last.associate_user!(user)
-          allow_any_instance_of(Spree::CheckoutController).to receive_messages(try_spree_current_user: user)
-          allow_any_instance_of(Spree::OrdersController).to receive_messages(try_spree_current_user: user)
+          allow_any_instance_of(Spree::CheckoutController).to receive_messages(spree_current_user: user)
+          allow_any_instance_of(Spree::OrdersController).to receive_messages(spree_current_user: user)
 
           # Simulate redirect back to address after login
           visit spree.checkout_state_path(:address)
@@ -220,7 +220,7 @@ describe "Checkout", type: :feature, inaccessible: true do
       order.recalculate
 
       allow_any_instance_of(Spree::CheckoutController).to receive_messages(current_order: order)
-      allow_any_instance_of(Spree::CheckoutController).to receive_messages(try_spree_current_user: user)
+      allow_any_instance_of(Spree::CheckoutController).to receive_messages(spree_current_user: user)
     end
 
     it "does not allow successful order submission" do
@@ -242,7 +242,7 @@ describe "Checkout", type: :feature, inaccessible: true do
       order.recalculate
 
       allow_any_instance_of(Spree::CheckoutController).to receive_messages(current_order: order)
-      allow_any_instance_of(Spree::CheckoutController).to receive_messages(try_spree_current_user: user)
+      allow_any_instance_of(Spree::CheckoutController).to receive_messages(spree_current_user: user)
     end
 
     it "redirects to payment page", inaccessible: true do
@@ -273,7 +273,7 @@ describe "Checkout", type: :feature, inaccessible: true do
 
     before(:each) do
       allow_any_instance_of(Spree::CheckoutController).to receive_messages(current_order: order)
-      allow_any_instance_of(Spree::CheckoutController).to receive_messages(try_spree_current_user: user)
+      allow_any_instance_of(Spree::CheckoutController).to receive_messages(spree_current_user: user)
       allow_any_instance_of(Spree::CheckoutController).to receive_messages(skip_state_validation?: true)
     end
 
@@ -317,7 +317,7 @@ describe "Checkout", type: :feature, inaccessible: true do
       order.recalculate
 
       allow_any_instance_of(Spree::CheckoutController).to receive_messages(current_order: order)
-      allow_any_instance_of(Spree::CheckoutController).to receive_messages(try_spree_current_user: order.user)
+      allow_any_instance_of(Spree::CheckoutController).to receive_messages(spree_current_user: order.user)
 
       visit spree.checkout_state_path(:payment)
     end
@@ -349,8 +349,8 @@ describe "Checkout", type: :feature, inaccessible: true do
       order = Spree::TestingSupport::OrderWalkthrough.up_to(:delivery)
 
       allow_any_instance_of(Spree::CheckoutController).to receive_messages(current_order: order)
-      allow_any_instance_of(Spree::CheckoutController).to receive_messages(try_spree_current_user: user)
-      allow_any_instance_of(Spree::OrdersController).to receive_messages(try_spree_current_user: user)
+      allow_any_instance_of(Spree::CheckoutController).to receive_messages(spree_current_user: user)
+      allow_any_instance_of(Spree::OrdersController).to receive_messages(spree_current_user: user)
 
       visit spree.checkout_state_path(:payment)
     end
@@ -571,8 +571,8 @@ describe "Checkout", type: :feature, inaccessible: true do
       before do
         user = create(:user)
         Spree::Order.last.update_column :user_id, user.id
-        allow_any_instance_of(Spree::OrdersController).to receive_messages(try_spree_current_user: user)
-        allow_any_instance_of(Spree::CheckoutController).to receive_messages(try_spree_current_user: user)
+        allow_any_instance_of(Spree::OrdersController).to receive_messages(spree_current_user: user)
+        allow_any_instance_of(Spree::CheckoutController).to receive_messages(spree_current_user: user)
         click_button "Checkout"
       end
 
@@ -588,8 +588,8 @@ describe "Checkout", type: :feature, inaccessible: true do
 
     before(:each) do
       allow_any_instance_of(Spree::CheckoutController).to receive_messages(current_order: order)
-      allow_any_instance_of(Spree::CheckoutController).to receive_messages(try_spree_current_user: user)
-      allow_any_instance_of(Spree::OrdersController).to receive_messages(try_spree_current_user: user)
+      allow_any_instance_of(Spree::CheckoutController).to receive_messages(spree_current_user: user)
+      allow_any_instance_of(Spree::OrdersController).to receive_messages(spree_current_user: user)
 
       visit spree.checkout_state_path(:delivery)
       click_button "Save and Continue"

--- a/frontend/spec/features/checkout_unshippable_spec.rb
+++ b/frontend/spec/features/checkout_unshippable_spec.rb
@@ -20,7 +20,7 @@ describe "checkout with unshippable items", type: :feature, inaccessible: true d
     order.recalculate
 
     allow_any_instance_of(Spree::CheckoutController).to receive_messages(current_order: order)
-    allow_any_instance_of(Spree::CheckoutController).to receive_messages(try_spree_current_user: user)
+    allow_any_instance_of(Spree::CheckoutController).to receive_messages(spree_current_user: user)
     allow_any_instance_of(Spree::CheckoutController).to receive_messages(skip_state_validation?: true)
     allow_any_instance_of(Spree::CheckoutController).to receive_messages(ensure_sufficient_stock_lines: true)
   end

--- a/frontend/spec/features/coupon_code_spec.rb
+++ b/frontend/spec/features/coupon_code_spec.rb
@@ -84,8 +84,8 @@ describe "Coupon code promotions", type: :feature, js: true do
         let!(:user) { create(:user, bill_address: create(:address), ship_address: create(:address)) }
 
         before do
-          allow_any_instance_of(Spree::CheckoutController).to receive_messages(try_spree_current_user: user)
-          allow_any_instance_of(Spree::OrdersController).to receive_messages(try_spree_current_user: user)
+          allow_any_instance_of(Spree::CheckoutController).to receive_messages(spree_current_user: user)
+          allow_any_instance_of(Spree::OrdersController).to receive_messages(spree_current_user: user)
         end
 
         context 'with saved credit card' do

--- a/frontend/spec/features/order_spec.rb
+++ b/frontend/spec/features/order_spec.rb
@@ -8,7 +8,7 @@ describe 'orders', type: :feature do
 
   before do
     order.update_attribute(:user_id, user.id)
-    allow_any_instance_of(Spree::OrdersController).to receive_messages(try_spree_current_user: user)
+    allow_any_instance_of(Spree::OrdersController).to receive_messages(spree_current_user: user)
   end
 
   it "can visit an order" do


### PR DESCRIPTION
**Description**
<!--
  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

  Please include screenshots in case of visual changes to the frontend or backend sections of Solidus.

  If needed you can reference another PR or issue here, e.g.:
  Ref #ISSUE
-->

It was introduced 9 years ago to overcome an obscure call loop in the early days of Spree (a00d703) and to support both a custom helper (`spree_current_user`) and the helper generated by Devise (`current_spree_user`).

Then, 8 years ago, `solidus_auth_devise` actually added support for the official custom helper (`spree_current_user`) making
`try_spree_current_user` finally unnecessary (https://github.com/solidusio/solidus_auth_devise/commit/69269765).

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
