### PR TITLE
Use Spree::Order.user email format validators on Spree::EmailValidator

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -129,7 +129,7 @@ module Spree
     before_create :link_by_email
 
     validates :email, presence: true, if: :require_email
-    validates :email, 'spree/email' => true, allow_blank: true
+    validates :email, 'spree/user_email' => true, allow_blank: true
     validates :guest_token, presence: { allow_nil: true }
     validates :number, presence: true, uniqueness: { allow_blank: true, case_sensitive: true }
     validates :store_id, presence: true

--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -90,6 +90,7 @@ require 'spree/core/role_configuration'
 require 'spree/core/state_machines'
 require 'spree/core/stock_configuration'
 require 'spree/core/validators/email'
+require 'spree/core/validators/user_email'
 require 'spree/permission_sets'
 require 'spree/user_class_handle'
 

--- a/core/lib/spree/core/validators/user_email.rb
+++ b/core/lib/spree/core/validators/user_email.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require_relative 'email'
+
+module Spree
+  # === Spree::EmailValidator subclass which uses the format validator of an associated :user
+  #
+  # === Usage
+  #
+  #     require 'spree/core/validators/devise_email'
+  #
+  #     class Order < ApplicationRecord
+  #       belongs_to :user, optional: true
+  #       validates :email_address, 'spree/devise_email' => true
+  #     end
+  #
+  # If the record contains a :user association, it will reflect on that association and use
+  # its format validator, if present, to validate the email. Otherwise, validation will be delegated to
+  # Spree::EmailValidator
+  #
+  class UserEmailValidator < EmailValidator
+    def validate_each(record, attribute, value)
+      user_format_validator = user_email_format_validator(record)
+
+      if user_format_validator.is_a? ActiveModel::EachValidator
+        user_format_validator.validate_each record, attribute, value
+        return
+      end
+
+      super
+    end
+
+    protected
+
+    def user_email_format_validator(record)
+      user_association = record.class.reflect_on_association(:user)
+
+      if user_association
+        email_validators = user_association.klass.validators_on :email
+
+        return if email_validators.blank?
+
+        format_validators = email_validators.select { |validator| validator.kind == :format }
+
+        # possible improvement: should we care about multiple format validators?
+        format_validators.first
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/order/validations_spec.rb
+++ b/core/spec/models/spree/order/validations_spec.rb
@@ -12,6 +12,60 @@ module Spree
         order.valid?
         expect(order.errors[:email]).to eq(["can't be blank"])
       end
+
+      context "email validations where email is copied from user" do
+        context "when associated user class has email format validation" do
+          test_order_class = Class.new(Spree::Order) do
+            belongs_to :user, class_name: "::TestUser", optional: true
+          end
+
+          test_user_class = Class.new(Spree::LegacyUser) do
+            # same validation as Devise's default email_regexp, used in spree_auth_devise
+            validates_format_of :email, with: /\A[^@\s]+@[^@\s]+\z/, allow_blank: true, if: :will_save_change_to_email?
+          end
+
+          before {
+            stub_const "TestUser", test_user_class
+            stub_const "TestOrder", test_order_class
+          }
+
+          let(:user) {
+            # we could add more test cases for other invalid email formats here
+            ::TestUser.create! email: "foo.@example.com", password: "password", password_confirmation: "password"
+          }
+
+          let(:order) {
+            order = ::TestOrder.new
+            order.associate_user! user
+
+            order
+          }
+
+          it "will validate the email against the user format validator" do
+            order.valid?
+
+            expect(order.errors[:email]).to be_blank
+          end
+        end
+
+        context "when associated user class does not have email format validation" do
+          let(:user) {
+            Spree.user_class.create! email: "foo.@example.com", password: "password", password_confirmation: "password"
+          }
+          let(:order) {
+            order = Spree::Order.new
+            order.associate_user! user
+
+            order
+          }
+
+          it "will include an email validation error if email doesn't follow the standard spree/email format" do
+            order.valid?
+
+            expect(order.errors[:email]).to include("is invalid")
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Description

Background: #3427 

This patch solves a problem where the email for Spree::Order is copied from Spree.user_class, specifically when spree_auth_devise is used.
Without it, `Spree::Order` might be invalid after persistence when the Spree.user_class email does not match the standard `EMAIL_REGEXP` of `Spree::EmailValidator`

It would be logic to use the same email validation for both `Spree.user_class` and `Spree::Order`.

I came to the conclusion there were three variations of possible solutions:

1. use `defined?(Devise)` to check whether we should validate the email format against the old `EMAIL_REGEXP` or against `Devise.email_regexp`. This check could be done on `Spree::EmailValidator`, such as in [this PR](https://github.com/solidusio/solidus/pull/3920), upon defining the email validation on `Spree::Order` or somewhere else. Cons of this approach are referencing Devise on the code base;

2. Use ActiveRecord's reflection to reflect upon the Order's user association and use its :email format validator. The advantage is that this works whether spree_auth_devise or another user gem is used, so **it was the used approach in this PR**. Cons are its a bit more complex than solution 1. and a bit more tricky to write automated tests for, it may also not be compatible with active-modal < 3.0 but this can be fixed by not relying on ActiveRecord::Reflection and doing it "crudely" (namely, :send and :instance_eval);

3. Change default `email_regexp` config on [spree_auth_devise's Devise initializer](https://github.com/solidusio/solidus_auth_devise/blob/master/config/initializers/devise.rb) to use the same regexp as `Spree::EmailValidator`:
```
config.email_regexp = /\A([^@\.]|[^@\.]([^@\s]*)[^@\.])@([^@\s]+\.)+[^@\s]+\z/
```
I really like this approach as it minimizes changes, but it might lead to unsuspecting users of `solidus_auth_devise` having some of their User database invalidated if upgrading the gem (though this might happen only in edge cases)

So, which choice do you guys prefer?

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] ~~I have updated Guides and README accordingly to this change (if needed)~~
- [x] I have added tests to cover this change (if needed)
- [x] ~~I have attached screenshots to this PR for visual changes (if needed)~~