### PR TITLE
Inline the attachment form for taxon icons

### DIFF
--- a/backend/app/views/spree/admin/taxons/_form.html.erb
+++ b/backend/app/views/spree/admin/taxons/_form.html.erb
@@ -20,7 +20,24 @@
       </div>
     <% end %>
 
-    <%= render "spree/admin/taxons/attachment_forms/#{f.object.attachment_partial_name}", f: f %>
+    <% if f.object.class.attachment_definitions.size > 1 %>
+      <%= render "spree/admin/taxons/attachment_forms/#{f.object.attachment_partial_name}", f: f %>
+    <% else %>
+      <%= f.field_container :icon do %>
+        <%= f.label :icon %><br>
+        <%= f.file_field :icon %>
+        <% if f.object.icon_present? %>
+          <%= image_tag f.object.icon(:mini) %>
+          <%= link_to t('spree.actions.remove'),
+                      admin_taxonomy_taxon_attachment_path(@taxonomy,
+                                                           @taxon.id,
+                                                           attachment_definition: :icon,
+                                                           authenticity_token: form_authenticity_token),
+                      method: :delete,
+                      class: 'btn btn-sm btn-danger' %>
+        <% end %>
+      <% end %>
+    <% end %>
   </div>
 
   <div class="col-5">

--- a/backend/app/views/spree/admin/taxons/attachment_forms/_paperclip.html.erb
+++ b/backend/app/views/spree/admin/taxons/attachment_forms/_paperclip.html.erb
@@ -1,3 +1,10 @@
+<%
+Spree::Deprecation.warn(
+  "This partial with its support for multiple Spree::Taxon attachments is deprecated and will be removed in a future " \
+  "version of Solidus, please overwrite the standard view if you need to support custom attachments."
+)
+%>
+
 <% f.object.class.attachment_definitions.each do |attachment, definition| %>
   <%= f.field_container attachment do %>
     <%= f.label attachment %><br>

--- a/core/app/models/spree/taxon/active_storage_attachment.rb
+++ b/core/app/models/spree/taxon/active_storage_attachment.rb
@@ -9,11 +9,10 @@ module Spree::Taxon::ActiveStorageAttachment
                    styles: { mini: '32x32>', normal: '128x128>' },
                    default_style: :mini
     validate :icon_is_an_image
-
-
   end
 
   def attachment_partial_name
+    Spree::Deprecation.warn("calling #attachment_partial_name on Spree::Taxon is deprecated without replacement.")
     'paperclip'
   end
 end

--- a/core/app/models/spree/taxon/paperclip_attachment.rb
+++ b/core/app/models/spree/taxon/paperclip_attachment.rb
@@ -20,6 +20,7 @@ module Spree::Taxon::PaperclipAttachment
   end
 
   def attachment_partial_name
+    Spree::Deprecation.warn("calling #attachment_partial_name on Spree::Taxon is deprecated without replacement.")
     'paperclip'
   end
 


### PR DESCRIPTION
**Description**
<!--
  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

  Please include screenshots in case of visual changes to the frontend or backend sections of Solidus.

  If needed you can reference another PR or issue here, e.g.:
  Ref #ISSUE
-->

There's no explicit support for multiple taxon attachment anywhere else in the solidus codebase, and the attachment_partial_name was using "paperclip" even for active_storage.

Given attachment adapters are substantially dormant prior to Rails 6.1 we just need to explain the change in the changelog without the burden of an overcomplex deprecation cycle.

Original PR: https://github.com/solidusio/solidus/pull/3308

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
