### PR TITLE
Promotion rule product limit improvements

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/product_picker.js
+++ b/backend/app/assets/javascripts/spree/backend/product_picker.js
@@ -15,7 +15,8 @@ $.fn.productAutocomplete = function (options) {
     initSelection: function (element, callback) {
       $.get(Spree.pathFor('admin/search/products'), {
         ids: element.val().split(','),
-        token: Spree.api_key
+        token: Spree.api_key,
+        show_all: true
       }, function (data) {
         callback(multiple ? data.products : data.products[0]);
       });

--- a/backend/app/controllers/spree/admin/search_controller.rb
+++ b/backend/app/controllers/spree/admin/search_controller.rb
@@ -29,9 +29,19 @@ module Spree
           @products = Spree::Product.ransack(params[:q]).result
         end
 
-        @products = @products.distinct.page(params[:page]).per(params[:per_page])
+        @products = list_products
         expires_in 15.minutes, public: true
         headers['Surrogate-Control'] = "max-age=#{15.minutes}"
+      end
+
+      private
+
+      def list_products
+        if params[:show_all]
+          @products.distinct.page(params[:page])
+        else
+          @products.distinct.page(params[:page]).per(params[:per_page])
+        end
       end
     end
   end

--- a/backend/spec/controllers/spree/admin/search_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/search_controller_spec.rb
@@ -87,11 +87,29 @@ describe Spree::Admin::SearchController, type: :controller do
       end
     end
 
-    context 'when idds param is not present' do
+    context 'when ids param is not present' do
       let(:params) { { q: { name_cont: 'jersey' } } }
 
       it_should_behave_like 'product search' do
         let(:expected_products) { [product_one, product_two] }
+      end
+    end
+
+    context 'when all products are requested to be shown' do
+      context 'when a per page limit is set' do
+        let(:params) { { show_all: true, per_page: 1 } }
+
+        it_should_behave_like 'product search' do
+          let(:expected_products) { [product_one, product_two] }
+        end
+      end
+
+      context 'when a per page limit is not set' do
+        let(:params) { { show_all: true } }
+
+        it_should_behave_like 'product search' do
+          let(:expected_products) { [product_one, product_two] }
+        end
       end
     end
   end


### PR DESCRIPTION
**Description**
  Ref #3902 

Adding a further parameter `show_all` to the `select2` rule when picking products in the admin interface. 
The parameter should act only when the selection is initialized at page load and should not have an impact on the product drop-down.
Now the promotion rule section for products should properly show all products associated with the rule and not just up to a certain limit as described in #3902 .

**Screenshots**
With 8 products associated to the rule:

_Before_
<img width="500" alt="Screenshot 2021-02-14 at 12 41 52" src="https://user-images.githubusercontent.com/1135197/107875950-49c11200-6ec3-11eb-8b77-2fbd813ac70b.png">

_After_
<img width="500" alt="Screenshot 2021-02-14 at 12 42 14" src="https://user-images.githubusercontent.com/1135197/107875964-5fced280-6ec3-11eb-9ceb-3de03119f576.png">

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)

**Credits**
@aldesantis for the lead