### PR TITLE
Align Rubocop ruby version to gemspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,7 +12,7 @@ AllCops:
     - 'sandbox/**/*'
     - '**/templates/**/*'
     - 'guides/node_modules/**/*'
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
 
 # Sometimes I believe this reads better
 # This also causes spacing issues on multi-line fixes


### PR DESCRIPTION
**Description**
Solidus [gemspec](https://github.com/solidusio/solidus/blob/b0092d0f3bda447494a586bf8eb96a18322b8bed/solidus.gemspec#L19) requires ruby to be at least 2.5.0, so Rubocop ruby version needs to be set to the same value.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
