### PR TITLE
Pre-select current tax category on product form

### DIFF
--- a/backend/app/controllers/spree/admin/products_controller.rb
+++ b/backend/app/controllers/spree/admin/products_controller.rb
@@ -10,6 +10,7 @@ module Spree
       helper_method :clone_object_url
       before_action :split_params, only: [:create, :update]
       before_action :normalize_variant_property_rules, only: [:update]
+      before_action :set_default_tax_category, only: [:new, :edit]
 
       def show
         redirect_to action: :edit
@@ -45,6 +46,10 @@ module Spree
       end
 
       private
+
+      def set_default_tax_category
+        @product.tax_category_id ||= @default_tax_category&.id
+      end
 
       def split_params
         if params[:product][:taxon_ids].present?

--- a/backend/app/views/spree/admin/products/_form.html.erb
+++ b/backend/app/views/spree/admin/products/_form.html.erb
@@ -158,7 +158,7 @@
         <%= f.field_container :tax_category do %>
           <%= f.label :tax_category_id, Spree::TaxCategory.model_name.human %>
           <%= f.field_hint :tax_category, default_tax_category: @default_tax_category&.name %>
-          <%= f.collection_select(:tax_category_id, @tax_categories, :id, :name, { include_blank: t('spree.match_choices.none'), selected: @default_tax_category&.id }, { class: 'custom-select' }) %>
+          <%= f.collection_select(:tax_category_id, @tax_categories, :id, :name, { include_blank: t('spree.match_choices.none') }, { class: 'custom-select' }) %>
           <%= f.error_message_on :tax_category %>
         <% end %>
       </div>


### PR DESCRIPTION
The `tax_category` select on the product form page should pre-select the default category only when the product does not have a tax category yet. If it does, then the current product tax category should be pre-selected, instead of the default one.


<!--
  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

  Please include screenshots in case of visual changes to the frontend or backend sections of Solidus.

  If needed you can reference another PR or issue here, e.g.:
  Ref #ISSUE
-->

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
