### PR TITLE
Avoid too many prompts during solidus:install generator

### DIFF
--- a/core/lib/generators/solidus/install/install_generator.rb
+++ b/core/lib/generators/solidus/install/install_generator.rb
@@ -174,7 +174,7 @@ module Solidus
       run "spring stop"
 
       @plugin_generators_to_run.each do |plugin_generator_name|
-        generate "#{plugin_generator_name} --skip_migrations=false"
+        generate "#{plugin_generator_name} --skip_migrations=true"
       end
     end
 


### PR DESCRIPTION
**Description**

Right now, the `solidus:install` generator is asking if we want to run migrations with a prompt (yes/no) after each extra plugin installations (authentication and payment method). This is not needed because migrations are copied anyway during the install and [we will run all the migrations together at the end of the process](https://github.com/solidusio/solidus/blob/0d2c83d017120d64b2867db6546cae03182d7051/core/lib/generators/solidus/install/install_generator.rb#L181-L189). In fact, `--skip-migrations=true` does not skip copying migrations but only avoid the prompt that asks to run them immediately after the copy.  

I tested this fix on a brand new application.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- ~[ ] I have updated Guides and README accordingly to this change (if needed)~
- ~[ ] I have added tests to cover this change (if needed)~
- ~[ ] I have attached screenshots to this PR for visual changes (if needed)~
