### PR TITLE
Install Active Storage by default on new stores

### DIFF
--- a/core/lib/generators/solidus/install/install_generator.rb
+++ b/core/lib/generators/solidus/install/install_generator.rb
@@ -15,6 +15,7 @@ module Solidus
     class_option :migrate, type: :boolean, default: true, banner: 'Run Solidus migrations'
     class_option :seed, type: :boolean, default: true, banner: 'Load seed data (migrations must be run)'
     class_option :sample, type: :boolean, default: true, banner: 'Load sample data (migrations must be run)'
+    class_option :active_storage, type: :boolean, default: true, banner: 'Install ActiveStorage as image attachments handler for products and taxons'
     class_option :auto_accept, type: :boolean
     class_option :user_class, type: :string
     class_option :admin_email, type: :string
@@ -49,6 +50,16 @@ module Solidus
 
     def add_files
       template 'config/initializers/spree.rb.tt', 'config/initializers/spree.rb'
+    end
+
+    def install_file_attachment
+      if options[:active_storage]
+        say "Installing Active Storage", :green
+        rake 'active_storage:install'
+      else
+        say "Installing Paperclip", :green
+        gsub_file 'config/initializers/spree.rb', "ActiveStorageAttachment", "PaperclipAttachment"
+      end
     end
 
     def additional_tweaks

--- a/core/lib/generators/solidus/install/templates/config/initializers/spree.rb.tt
+++ b/core/lib/generators/solidus/install/templates/config/initializers/spree.rb.tt
@@ -18,9 +18,9 @@ Spree.config do |config|
   # any inventory changes.
   # config.inventory_cache_threshold = 3
 
-  # Enable Paperclip adapter for attachments on images and taxons
-  config.image_attachment_module = 'Spree::Image::PaperclipAttachment'
-  config.taxon_attachment_module = 'Spree::Taxon::PaperclipAttachment'
+  # Configure adapter for attachments on products and taxons (use ActiveStorageAttachment or PaperclipAttachment)
+  config.image_attachment_module = 'Spree::Image::ActiveStorageAttachment'
+  config.taxon_attachment_module = 'Spree::Taxon::ActiveStorageAttachment'
 
   # Defaults
   # Permission Sets:


### PR DESCRIPTION
**Description**

We are ready to default to Active Storage and it would be great for Solidus 3.0 to ship with this new default. 

We can also investigate removing paperclip as a dependency of core and re-adding it optionally with the installer in the host application Gemfile.
