### PR TITLE
Only use #original_message in Api::BaseController#parameter_missing_error if defined

### DIFF
--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -76,7 +76,8 @@ module Spree
       end
 
       def parameter_missing_error(exception)
-        message = exception.original_message || exception.message
+        # use original_message to remove DidYouMean suggestions, if defined
+        message = exception.try(:original_message) || exception.message
         render json: {
           exception: message,
           error: message,

--- a/api/spec/controllers/spree/api/base_controller_spec.rb
+++ b/api/spec/controllers/spree/api/base_controller_spec.rb
@@ -13,11 +13,37 @@ describe Spree::Api::BaseController, type: :controller do
     def index
       render json: { "products" => [] }
     end
+
+    def create
+      params.require(:order).permit(:number)
+      render json: { "order" => {} }
+    end
   end
 
   before do
     @routes = ActionDispatch::Routing::RouteSet.new.tap do |r|
-      r.draw { get 'index', to: 'spree/api/base#index' }
+      r.draw do
+        get 'index', to: 'spree/api/base#index'
+        post 'create', to: 'spree/api/base#create'
+      end
+    end
+  end
+
+  context "when validating presence of params" do
+    let!(:user) { create(:user, spree_api_key: "fake_key") }
+
+    context "if params are missing" do
+      it "returns an unprocessable_entity" do
+        post :create, params: { token: "fake_key" }
+        expect(response.status).to eq(422)
+      end
+    end
+
+    context "if params are not missing" do
+      it "does not return an unprocessable_entity" do
+        post :create, params: { token: "fake_key", order: { number: "R12345" } }
+        expect(response.status).to eq(200)
+      end
     end
   end
 


### PR DESCRIPTION
While working on https://github.com/solidusio-contrib/solidus_related_products/pull/88 for solidus_related_products, I came across a bug that has caused every branch on that repository to fail its specs. 

Sometimes, for reasons that I don't completely understand, the `ParameterMissing` error class does not define `#original_message`, causing a `NoMethodError` to be raised, which obscures the original execption and returns a 500 status response.

Further background is detailed in #3941 

As error handling should not raise its own obscuring error, use the #try method to obtain #original_message, if defined.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
