### PR TITLE
Allow users to create blank issues in GitHub

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: Feature request
     url: https://github.com/solidusio/solidus/discussions?discussions_q=category%3AIdeas


### PR DESCRIPTION
**Description**

Block people from creating blank issues is not super welcoming, especially because we only have the Bug Report template available so I'm sure we are not covering all the possible things people may want to discuss with Issues. 
