### PR TITLE
Fix order checkout flow completion with custom steps

### DIFF
--- a/core/lib/spree/core/state_machines/order.rb
+++ b/core/lib/spree/core/state_machines/order.rb
@@ -73,7 +73,7 @@ module Spree
               end
 
               event :complete do
-                transition to: :complete, from: :confirm
+                transition to: :complete, from: klass.checkout_steps.keys.last
               end
 
               if states[:payment]

--- a/guides/source/developers/orders/order-state-machine.html.md
+++ b/guides/source/developers/orders/order-state-machine.html.md
@@ -25,6 +25,30 @@ The `complete` state is triggered in one of two ways:
 2. Payment is required on the order, and at least the order total has been
    received as payment.
 
+## Customizing the checkout flow
+The central steps in the checkout flow – `address`, `delivery`, `payment` and
+`confirm`, are customizable. For example, you might decide you want skip the
+`confirm` step and proceed directly from `payment` to `complete`. To modify your
+checkout flow, create a decorator similar to the following:
+
+```ruby
+# /app/models/mystore/order_decorator.rb
+
+module MyStore::OrderDecorator
+  def self.prepended(base)
+    base.checkout_flow do
+      go_to_state :address
+      go_to_state :delivery
+      go_to_state :payment, if: ->(order) { order.payment_required? }
+      # NOTE: confirm state is commented and will NOT be part of the flow
+      # go_to_state :confirm
+    end
+  end
+
+  Spree::Order.prepend self
+end
+```
+
 ## State criteria
 
 Each order state has criteria that must be met before the state can change. For


### PR DESCRIPTION
**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)

**Description:**

The `Spree::Order` checkout flow [is configurable](https://github.com/solidusio/solidus/blame/master/core/lib/spree/core/state_machines/order.rb#L32-L37) and steps (states) can be added or removed. Unfortunately, removing the `confirm` state was causing issue #3926 since the code for the `complete` event was still taking for granted that the `confirm` state was part of the flow.

This PR fixes the problem by plugging in the last step of the configurable checkout flow instead.

Also, a paragraph explaining how to customize the checkout flow has been added to the `Order` documentation, since the feature is available in the codebase.

Fixes #3926.