### PR TITLE
Fix solidus stock locations sorting

### DIFF
--- a/core/app/models/spree/stock/simple_coordinator.rb
+++ b/core/app/models/spree/stock/simple_coordinator.rb
@@ -87,16 +87,6 @@ module Spree
         end
       end
 
-      def sort_availability(availability)
-        sorted_availability = availability.sort_by do |stock_location_id, _|
-          @stock_locations.find_index do |stock_location|
-            stock_location.id == stock_location_id
-          end
-        end
-
-        Hash[sorted_availability]
-      end
-
       def get_units(quantities)
         # Change our raw quantities back into inventory units
         quantities.flat_map do |variant, quantity|

--- a/core/app/models/spree/stock_location.rb
+++ b/core/app/models/spree/stock_location.rb
@@ -26,7 +26,7 @@ module Spree
     validates_uniqueness_of :code, allow_blank: true, case_sensitive: false
 
     scope :active, -> { where(active: true) }
-    scope :order_default, -> { order(default: :desc, name: :asc) }
+    scope :order_default, -> { order(default: :desc, position: :asc) }
 
     after_create :create_stock_items, if: :propagate_all_variants?
     after_save :ensure_one_default

--- a/core/spec/models/spree/stock/availability_spec.rb
+++ b/core/spec/models/spree/stock/availability_spec.rb
@@ -20,6 +20,24 @@ module Spree::Stock
         let!(:variant) { create(:master_variant) }
         let(:stock_item) { variant.stock_items[0] }
 
+        it "maintains the StockLocation order with which it is initialised" do
+          stock_location2 = create(:stock_location)
+          stock_location3 = create(:stock_location)
+          sorted_availability = described_class.new(variants: variants, stock_locations: [
+            stock_location3,
+            stock_location1,
+            stock_location2
+          ])
+
+          sorted_subject_ids = sorted_availability.on_hand_by_stock_location_id.keys
+
+          expect(sorted_subject_ids).to eq([
+            stock_location3.id,
+            stock_location1.id,
+            stock_location2.id,
+          ])
+        end
+
         context 'with count_on_hand positive' do
           before { stock_item.set_count_on_hand(2) }
 
@@ -92,6 +110,24 @@ module Spree::Stock
       context 'with a single variant' do
         let!(:variant) { create(:master_variant) }
         let(:stock_item) { variant.stock_items[0] }
+
+        it "maintains the StockLocation order with which it is initialised" do
+          stock_location2 = create(:stock_location)
+          stock_location3 = create(:stock_location)
+          sorted_availability = described_class.new(variants: variants, stock_locations: [
+            stock_location3,
+            stock_location1,
+            stock_location2
+          ])
+
+          sorted_subject_ids = sorted_availability.on_hand_by_stock_location_id.keys
+
+          expect(sorted_subject_ids).to eq([
+            stock_location3.id,
+            stock_location1.id,
+            stock_location2.id,
+          ])
+        end
 
         context 'with backorderable false' do
           before { stock_item.update!(backorderable: false) }

--- a/core/spec/models/spree/stock/location_sorter/default_first_spec.rb
+++ b/core/spec/models/spree/stock/location_sorter/default_first_spec.rb
@@ -8,12 +8,14 @@ module Spree
       RSpec.describe DefaultFirst, type: :model do
         subject { described_class.new(stock_locations) }
 
-        let!(:first_stock_location) { create(:stock_location, default: false) }
-        let!(:second_stock_location) { create(:stock_location, default: true) }
+        let!(:first) { create(:stock_location, default: false, position: 2) }
+        let!(:second) { create(:stock_location, default: true, position: 3) }
+        let!(:third) { create(:stock_location, default: false, position: 1) }
+        let!(:fourth) { create(:stock_location, default: false, position: 4) }
         let(:stock_locations) { Spree::StockLocation.all }
-        let(:sorted_stock_locations) { stock_locations.reverse }
+        let(:sorted_stock_locations) { [second, third, first, fourth] }
 
-        it 'returns the default stock location first' do
+        it 'returns the default stock location first and the remaining locations by position' do
           expect(subject.sort).to eq(sorted_stock_locations)
         end
       end

--- a/guides/source/developers/shipments/stock-locations-sorter.html.md
+++ b/guides/source/developers/shipments/stock-locations-sorter.html.md
@@ -13,7 +13,8 @@ Currently, we only provide two sorters, which you should use unless you need cus
 - [Unsorted](https://github.com/solidusio/solidus/blob/master/core/app/models/spree/stock/location_sorter/unsorted.rb),
   which allocates inventory from stock locations as they are returned from the DB.
 - [Default first](https://github.com/solidusio/solidus/blob/master/core/app/models/spree/stock/location_sorter/default_first.rb),
-  which allocates inventory from the default stock location first.
+  which allocates inventory from the default stock location first and then selects the next stock location
+  based on the position column (can be edited in the Admin UI).
 
 ## Custom sorter API
 


### PR DESCRIPTION
- This might need backporting as this issue has been here for a couple of versions.

**Description**

There are two challenges that this PR aims to solve:

1. Fixing the sorting of stock locations:

The order of the stock locations that is returned from the configured
sorter is lost in the SimpleCoordinator. This occurs in
the Stock::Availiability class when creating the #stock_item_scope.

Previously, the #sort_availability method
was used to order the stock locations, but this was
lost during the refactor to allow extending the default Solidus
allocation logic.

This re-orders the stock locations for all methods
called by the stock allocators. Namely `on_hand_by_stock_location_id `
and `backorderable_by_stock_location_id ` 


2. Sort stock locations by position after default. (Fix: #3601)

This is useful because the Admin UI allows the switching of position through a drag and drop interface. 
Currently, this interface is not used. It would be more intuitive to have the default stock location used first,
then select the next stock location based on its `position` column value. For more info, see this [issue]( https://github.com/solidusio/solidus/issues/3601).

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
