### PR TITLE
Consolidation of promotion code batch form fields into partial.

### DIFF
--- a/backend/app/views/spree/admin/promotion_code_batches/_form_fields.html.erb
+++ b/backend/app/views/spree/admin/promotion_code_batches/_form_fields.html.erb
@@ -10,7 +10,7 @@
   <%= batch.label :join_characters %>
   <%= batch.text_field :join_characters, class: "fullwidth" %>
 </div>
-<% unless params["promotion_id"] %>
+<% unless promotion_id %>
   <div class="field">
     <%= f.label :per_code_usage_limit %>
     <%= f.text_field :per_code_usage_limit, class: "fullwidth" %>

--- a/backend/app/views/spree/admin/promotion_code_batches/_form_fields.html.erb
+++ b/backend/app/views/spree/admin/promotion_code_batches/_form_fields.html.erb
@@ -1,0 +1,22 @@
+<div class="field">
+  <%= batch.label :base_code, class: "required" %>
+  <%= batch.text_field :base_code, class: "fullwidth", required: true %>
+</div>
+<div class="field">
+  <%= batch.label :number_of_codes, class: "required" %>
+  <%= batch.number_field :number_of_codes, class: "fullwidth", min: 1, required: true %>
+</div>
+<div class="field">
+  <%= batch.label :join_characters %>
+  <%= batch.text_field :join_characters, class: "fullwidth" %>
+</div>
+<% unless params["promotion_id"] %>
+  <div class="field">
+    <%= f.label :per_code_usage_limit %>
+    <%= f.text_field :per_code_usage_limit, class: "fullwidth" %>
+  </div>
+<% end %>
+<div class="field">
+  <%= batch.label :email %>
+  <%= batch.text_field :email, class: "fullwidth" %>
+</div>

--- a/backend/app/views/spree/admin/promotion_code_batches/new.html.erb
+++ b/backend/app/views/spree/admin/promotion_code_batches/new.html.erb
@@ -1,28 +1,8 @@
 <% admin_breadcrumb(link_to plural_resource_name(Spree::Promotion), spree.admin_promotions_path) %>
 <% admin_breadcrumb(link_to @promotion.name, spree.admin_promotion_path(@promotion.id)) %>
 <% admin_breadcrumb(plural_resource_name(Spree::PromotionCodeBatch)) %>
-
-<%= form_for :promotion_code_batch, url: collection_url do |f| %>
-  <%= f.hidden_field :promotion_id, value: params[:promotion_id] %>
-
-  <%= f.field_container :base_code do %>
-    <%= f.label :base_code %>
-    <%= f.text_field :base_code, class: "fullwidth" %>
-  <% end %>
-
-  <%= f.field_container :join_characters do %>
-    <%= f.label :join_characters %>
-    <%= f.text_field :join_characters, class: "fullwidth" %>
-  <% end %>
-
-  <%= f.field_container :number_of_codes do %>
-    <%= f.label :number_of_codes %>
-    <%= f.text_field :number_of_codes, class: "fullwidth" %>
-  <% end %>
-
-  <%= f.field_container :email do %>
-    <%= f.label :email %>
-    <%= f.text_field :email, class: "fullwidth", value: spree_current_user.email %>
-  <% end %>
-  <%= f.submit t('spree.actions.create'), class: 'btn btn-primary' %>
+<%= form_for :promotion_code_batch, url: collection_url do |batch| %>
+  <%= batch.hidden_field :promotion_id, value: params[:promotion_id] %>
+  <%= render partial: 'form_fields', locals: {batch: batch} %>
+  <%= batch.submit t('spree.actions.create'), class: 'btn btn-primary' %>
 <% end %>

--- a/backend/app/views/spree/admin/promotion_code_batches/new.html.erb
+++ b/backend/app/views/spree/admin/promotion_code_batches/new.html.erb
@@ -3,6 +3,6 @@
 <% admin_breadcrumb(plural_resource_name(Spree::PromotionCodeBatch)) %>
 <%= form_for :promotion_code_batch, url: collection_url do |batch| %>
   <%= batch.hidden_field :promotion_id, value: params[:promotion_id] %>
-  <%= render partial: 'form_fields', locals: {batch: batch} %>
+  <%= render partial: 'form_fields', locals: {batch: batch, promotion_id: params[:promotion_id]} %>
   <%= batch.submit t('spree.actions.create'), class: 'btn btn-primary' %>
 <% end %>

--- a/backend/app/views/spree/admin/promotions/_activations_new.html.erb
+++ b/backend/app/views/spree/admin/promotions/_activations_new.html.erb
@@ -35,7 +35,7 @@
 
     <div data-activation-type="multiple_codes">
       <%= fields_for :promotion_code_batch, @promotion_code_batch do |batch| %>
-        <%= render partial: 'spree/admin/promotion_code_batches/form_fields', locals: {f: f, batch: batch} %>
+        <%= render partial: 'spree/admin/promotion_code_batches/form_fields', locals: {f: f, batch: batch, promotion_id: params[:promotion_id]} %>
       <% end %>
     </div>
 

--- a/backend/app/views/spree/admin/promotions/_activations_new.html.erb
+++ b/backend/app/views/spree/admin/promotions/_activations_new.html.erb
@@ -35,26 +35,7 @@
 
     <div data-activation-type="multiple_codes">
       <%= fields_for :promotion_code_batch, @promotion_code_batch do |batch| %>
-        <div class="field">
-          <%= batch.label :base_code, class: "required" %>
-          <%= batch.text_field :base_code, class: "fullwidth", required: true %>
-        </div>
-        <div class="field">
-          <%= batch.label :number_of_codes, class: "required" %>
-          <%= batch.number_field :number_of_codes, class: "fullwidth", min: 1, required: true %>
-        </div>
-        <div class="field">
-          <%= batch.label :join_characters %>
-          <%= batch.text_field :join_characters, class: "fullwidth" %>
-        </div>
-        <div class="field">
-          <%= f.label :per_code_usage_limit %>
-          <%= f.text_field :per_code_usage_limit, class: "fullwidth" %>
-        </div>
-        <div class="field">
-          <%= batch.label :email %>
-          <%= batch.text_field :email, class: "fullwidth" %>
-        </div>
+        <%= render partial: 'spree/admin/promotion_code_batches/form_fields', locals: {f: f, batch: batch} %>
       <% end %>
     </div>
 

--- a/backend/app/views/spree/admin/promotions/_activations_new.html.erb
+++ b/backend/app/views/spree/admin/promotions/_activations_new.html.erb
@@ -51,6 +51,10 @@
           <%= f.label :per_code_usage_limit %>
           <%= f.text_field :per_code_usage_limit, class: "fullwidth" %>
         </div>
+        <div class="field">
+          <%= batch.label :email %>
+          <%= batch.text_field :email, class: "fullwidth" %>
+        </div>
       <% end %>
     </div>
 

--- a/backend/spec/features/admin/promotion_adjustments_spec.rb
+++ b/backend/spec/features/admin/promotion_adjustments_spec.rb
@@ -195,6 +195,8 @@ describe "Promotion Adjustments", type: :feature, js: true do
       fill_in "Base code", with: "testing"
       fill_in "Number of codes", with: "10"
 
+      expect(page).to have_field("promotion_code_batch_email")
+
       perform_enqueued_jobs {
         click_button "Create"
         expect(page).to have_title("SAVE SAVE SAVE - Promotions")

--- a/backend/spec/features/admin/promotions/promotion_code_batches_spec.rb
+++ b/backend/spec/features/admin/promotions/promotion_code_batches_spec.rb
@@ -20,6 +20,10 @@ feature "Promotion Code Batches", partial_double_verification: false do
       click_button "Create"
     end
 
+    it "renders partial without 'Per code usage limit' " do
+      expect(page).to_not have_field("promotion_per_code_usage_limit")
+    end
+
     it "creates a new promotion code batch and disables the submit button", :js do
       create_code_batch
 


### PR DESCRIPTION
**Description**

This pull request resolves [issue 3952](https://github.com/solidusio/solidus/issues/3952)

- Implemented field for email on pathway 1 for creating promotion code batches (during promotion creation).

- Implemented partial for form fields when creating promotion code batches and refactored promotion code batch creation forms.

- Implemented conditional for "per code usage limit" to display when promotion id is not present in the page's parameters to prevent breaking pathway 2 for creating promotion code batches

- All tests are passing 


Pathway 1
![image](https://user-images.githubusercontent.com/68167430/109011238-ec208880-766d-11eb-8236-3de3e943341b.png)

Pathway 2
![image](https://user-images.githubusercontent.com/68167430/109012901-c5635180-766f-11eb-8bab-12a484a3c514.png)

  If needed you can reference another PR or issue here, e.g.:
  Ref #3952


**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
