### PR TITLE
Relax Money dependency in development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,10 +18,6 @@ group :backend, :frontend, :core, :api do
   # and https://github.com/rails/sprockets-rails/issues/369
   gem 'sprockets', '~> 3'
 
-  # Temporary locking money to 6.13.8.
-  # See https://github.com/solidusio/solidus/issues/3903
-  gem 'money', '<= 6.13.8'
-
   platforms :ruby do
     case ENV['DB']
     when /mysql/


### PR DESCRIPTION
**Description**

Ref #3903

The CHF currency issue we were having has been fixed and a new version (1.14.1) that contains [the fix](https://github.com/RubyMoney/money/pull/967) has been released. CI should be green now. 

We can backport this commit to v2.11 when merged.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- ~[ ] I have updated Guides and README accordingly to this change (if needed)~
- ~[ ] I have added tests to cover this change (if needed)~
- ~[ ] I have attached screenshots to this PR for visual changes (if needed)~
