### PR TITLE
Fix circular reference in factory

### DIFF
--- a/core/lib/spree/testing_support/factories/order_factory.rb
+++ b/core/lib/spree/testing_support/factories/order_factory.rb
@@ -30,7 +30,6 @@ FactoryBot.define do
       after(:build) do |order, evaluator|
         order.line_items << build(
           :line_item,
-          order: order,
           price: evaluator.line_items_price
         )
       end


### PR DESCRIPTION
This was causing a double in-memory addition of the same line item to an
order.

From the repository root:

```bash
gem which factory_bot
bin/rails console
```

And then, from the console:

```ruby
$LOAD_PATH << '/lib/directory/for/factory/bot/from/above/'
require_relative '../core/lib/spree/testing_support/factories/order_factory'
order = FactoryBot.create(:order_with_totals)
order.line_items.count # 1
order.line_items.size # 2, before this commit
order.line_items.size # 1, after this commit
```

**Description**
<!--
  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

  Please include screenshots in case of visual changes to the frontend or backend sections of Solidus.

  If needed you can reference another PR or issue here, e.g.:
  Ref #ISSUE
-->

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)

cc @kennyadsl 