### PR TITLE
Don't hack into ActionMailer to add our mail previews path

### DIFF
--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -55,18 +55,13 @@ module Spree
         end
       end
 
-      config.after_initialize do
-        # Load in mailer previews for apps to use in development.
-        # We need to make sure we call `Preview.all` before requiring our
-        # previews, otherwise any previews the app attempts to add need to be
-        # manually required.
-        if Rails.env.development? || Rails.env.test?
-          ActionMailer::Preview.all
+      # Load in mailer previews for apps to use in development.
+      initializer "spree.core.action_mailer.set_preview_path", after: "action_mailer.set_configs" do |app|
+        original_preview_path = app.config.action_mailer.preview_path
+        solidus_preview_path = Spree::Core::Engine.root.join 'lib/spree/mailer_previews'
 
-          Dir[root.join("lib/spree/mailer_previews/**/*_preview.rb")].each do |file|
-            require_dependency file
-          end
-        end
+        app.config.action_mailer.preview_path = "{#{original_preview_path},#{solidus_preview_path}}"
+        ActionMailer::Base.preview_path = app.config.action_mailer.preview_path
       end
     end
   end

--- a/core/lib/spree/testing_support/dummy_app.rb
+++ b/core/lib/spree/testing_support/dummy_app.rb
@@ -64,6 +64,7 @@ module DummyApp
 
     config.action_mailer.delivery_job = "ActionMailer::MailDeliveryJob" if RAILS_6_OR_ABOVE
     config.action_mailer.preview_path = File.expand_path('dummy_app/mailer_previews', __dir__)
+    config.action_mailer.show_previews = true
     config.active_record.sqlite3.represent_boolean_as_integer = true unless RAILS_6_OR_ABOVE
 
     config.storage_path = Rails.root.join('tmp', 'storage')


### PR DESCRIPTION
**Description**
<!--
  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

  Please include screenshots in case of visual changes to the frontend or backend sections of Solidus.

  If needed you can reference another PR or issue here, e.g.:
  Ref #ISSUE
-->

Instead just append our AM preview path let the app control wether they're enabled or not, without forcing it only on some environments.

From the Rails guides of the versions we support:
- https://guides.rubyonrails.org/v6.1/action_mailer_basics.html#previewing-emails
- https://guides.rubyonrails.org/v6.0/action_mailer_basics.html#previewing-emails
- https://guides.rubyonrails.org/v5.2/action_mailer_basics.html#previewing-emails

The path is used inside a glob, that's why we use the `{path1,path2}` notation to add the path to the existing one.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
