### PR TITLE
Add and start populating `spree_addresses.name` field

### DIFF
--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -92,6 +92,12 @@ module Spree
       if base['lastname'].presence || base['last_name'].presence
         base['lastname'] = name_from_attributes.last_name
       end
+
+      virtual_name = name_from_attributes.value
+      if base['name'].blank? && virtual_name.present?
+        base['name'] = virtual_name
+      end
+
       excluded_attributes = DB_ONLY_ATTRS + %w(first_name last_name)
 
       base.except(*excluded_attributes)
@@ -120,7 +126,11 @@ module Spree
     # @return [Boolean] true if the two addresses have the same address fields
     def ==(other_address)
       return false unless other_address && other_address.respond_to?(:value_attributes)
-      value_attributes == other_address.value_attributes
+      if Spree::Config.use_combined_first_and_last_name_in_address
+        value_attributes.except(*LEGACY_NAME_ATTRS) == other_address.value_attributes.except(*LEGACY_NAME_ATTRS)
+      else
+        value_attributes == other_address.value_attributes
+      end
     end
 
     # @deprecated Do not use this. Use Address.== instead.

--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -193,6 +193,16 @@ module Spree
       country && country.iso
     end
 
+    before_save :set_name_from_firstname_and_lastname
+
+    def set_name_from_firstname_and_lastname
+      name_from_firstname_and_lastname = Spree::Address::Name.from_attributes(attributes.except(:name, 'name'))
+
+      if read_attribute(:name).blank? && name_from_firstname_and_lastname.present?
+        write_attribute(:name, name_from_firstname_and_lastname)
+      end
+    end
+
     # @return [String] the full name on this address
     def name
       self[:name] || begin

--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -195,15 +195,18 @@ module Spree
 
     # @return [String] the full name on this address
     def name
-      Spree::Address::Name.new(
-        read_attribute(:firstname),
-        read_attribute(:lastname)
-      ).value
+      self[:name] || begin
+        Spree::Address::Name.new(
+          read_attribute(:firstname),
+          read_attribute(:lastname)
+        ).value
+      end
     end
 
     def name=(value)
       return if value.nil?
 
+      write_attribute(:name, value)
       name_from_value = Spree::Address::Name.new(value)
       write_attribute(:firstname, name_from_value.first_name)
       write_attribute(:lastname, name_from_value.last_name)

--- a/core/db/migrate/20210122110141_add_name_to_spree_addresses.rb
+++ b/core/db/migrate/20210122110141_add_name_to_spree_addresses.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddNameToSpreeAddresses < ActiveRecord::Migration[5.2]
+  def up
+    add_column :spree_addresses, :name, :string
+    add_index :spree_addresses, :name
+  end
+
+  def down
+    remove_index :spree_addresses, :name
+    remove_column :spree_addresses, :name
+  end
+end

--- a/core/spec/models/spree/address_spec.rb
+++ b/core/spec/models/spree/address_spec.rb
@@ -3,8 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe Spree::Address, type: :model do
-  subject { Spree::Address }
-
   context "aliased attributes" do
     before do
       allow(Spree::Deprecation).to receive(:warn).and_call_original
@@ -164,7 +162,7 @@ RSpec.describe Spree::Address, type: :model do
       let(:country) { create(:country, iso: 'ZW') }
 
       it 'uses the setters' do
-        expect(subject.factory(address_attributes).country_id).to eq(country.id)
+        expect(described_class.factory(address_attributes).country_id).to eq(country.id)
       end
     end
   end

--- a/core/spec/models/spree/address_spec.rb
+++ b/core/spec/models/spree/address_spec.rb
@@ -442,4 +442,31 @@ RSpec.describe Spree::Address, type: :model do
       address.full_name
     end
   end
+
+  describe '==' do
+    context 'when first address has same name (virtual or not) as the second' do
+      let(:first_address) { build(:address, name: 'Mary Jane Watson') }
+      let(:second_address) { build(:address, name: nil, firstname: 'Mary Jane', lastname: 'Watson', zipcode: first_address.zipcode) }
+
+      context 'when firstname and lastname do not match' do
+        context 'when the preference `use_combined_first_and_last_name_in_address` is true' do
+          it 'they are still considered equals' do
+            expect(first_address.name).to eq(second_address.name)
+            expect(first_address).to eq(second_address)
+          end
+        end
+
+        context 'when the preference `use_combined_first_and_last_name_in_address` is false' do
+          before { stub_spree_preferences(use_combined_first_and_last_name_in_address: false) }
+
+          # This seems to be the most sensible behavior, as if we're not combining attributes,
+          # firstname and lastname should be accounted for when checking equality.
+          it 'they are not considered equals' do
+            expect(first_address.name).to eq(second_address.name)
+            expect(first_address).not_to eq(second_address)
+          end
+        end
+      end
+    end
+  end
 end

--- a/core/spec/models/spree/address_spec.rb
+++ b/core/spec/models/spree/address_spec.rb
@@ -109,6 +109,16 @@ RSpec.describe Spree::Address, type: :model do
     end
   end
 
+  context "when saving a record" do
+    context "when the `name` field is not explicitly set" do
+      subject { build :address, name: nil, firstname: 'John', lastname: 'Doe' }
+
+      it "sets `name` from `firstname` and `lastname`" do
+        expect { subject.save }.to change { subject.read_attribute(:name) }.from(nil).to('John Doe')
+      end
+    end
+  end
+
   context ".build_default" do
     context "no user given" do
       let!(:default_country) { create(:country) }


### PR DESCRIPTION
**Description**

In order to prepare apps for the Solidus 3.0 migration where `firstname` and `lastname` fields are completely removed from the DB, this PR introduces the field `name` and starts using it when creating new records, so backfilling will be required only for historical data prior to incorporating this change.

Also, this PR fixes a possible issue when comparing new addresses with double first names to historical records when the preference `use_combined_first_and_last_name_in_address` is set to true.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
