### PR TITLE
Add Active Storage in Dummy App for extensions

### DIFF
--- a/core/lib/generators/spree/dummy/dummy_generator.rb
+++ b/core/lib/generators/spree/dummy/dummy_generator.rb
@@ -55,6 +55,7 @@ module Spree
       @database = options[:database]
 
       template "rails/database.yml", "#{dummy_path}/config/database.yml", force: true
+      template "rails/storage.yml", "#{dummy_path}/config/storage/test.yml", force: true
       template "rails/boot.rb", "#{dummy_path}/config/boot.rb", force: true
       template "rails/application.rb.tt", "#{dummy_path}/config/application.rb", force: true
       template "rails/routes.rb", "#{dummy_path}/config/routes.rb", force: true

--- a/core/lib/generators/spree/dummy/templates/rails/storage.yml
+++ b/core/lib/generators/spree/dummy/templates/rails/storage.yml
@@ -1,0 +1,3 @@
+test:
+  service: Disk
+  root: <%= File.expand_path("#{dummy_path}/tmp/storage", destination_root) %>

--- a/core/lib/generators/spree/dummy/templates/rails/test.rb
+++ b/core/lib/generators/spree/dummy/templates/rails/test.rb
@@ -29,6 +29,8 @@ Dummy::Application.configure do
   config.action_mailer.delivery_method = :test
   ActionMailer::Base.default from: "solidus@example.com"
 
+  config.active_storage.service = :test
+
   # Raise on deprecation warnings
   if ENV['SOLIDUS_RAISE_DEPRECATIONS'].present?
     Spree::Deprecation.behavior = :raise

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -437,23 +437,23 @@ module Spree
 
     # Allows switching attachment library for Image
     #
-    # `Spree::Image::PaperclipAttachment`
-    # is the default and provides the classic Paperclip implementation.
+    # `Spree::Image::ActiveStorageAttachment`
+    # is the default and provides the Active Storage implementation.
     #
     # @!attribute [rw] image_attachment_module
     # @return [Module] a module that can be included into Spree::Image to allow attachments
     # Enumerable of images adhering to the present_image_class interface
-    class_name_attribute :image_attachment_module, default: 'Spree::Image::PaperclipAttachment'
+    class_name_attribute :image_attachment_module, default: 'Spree::Image::ActiveStorageAttachment'
 
     # Allows switching attachment library for Taxon
     #
-    # `Spree::Taxon::PaperclipAttachment`
-    # is the default and provides the classic Paperclip implementation.
+    # `Spree::Taxon::ActiveStorageAttachment`
+    # is the default and provides the Active Storage implementation.
     #
     # @!attribute [rw] taxon_attachment_module
     # @return [Module] a module that can be included into Spree::Taxon to allow attachments
     # Enumerable of taxons adhering to the present_taxon_class interface
-    class_name_attribute :taxon_attachment_module, default: 'Spree::Taxon::PaperclipAttachment'
+    class_name_attribute :taxon_attachment_module, default: 'Spree::Taxon::ActiveStorageAttachment'
 
     # Allows providing your own class instance for generating order numbers.
     #


### PR DESCRIPTION
**Description**

This PR makes sure Active Storage is properly configured when we are generating dummy apps for extensions. This is done in the extension root with:

```ruby
bin/rake extension:test_app
```

Ref #3967

I tested this PR with solidus_starter_frontend that uses Active Storage in some system specs. See https://github.com/nebulab/solidus_starter_frontend/pull/145

No need to backport this one, it will only affect extensions testing against Solidus 3.0, which will default to using Active Storage.

Needs #3970 to be merged first.