### PR TITLE
Improve Active Storage configuration for in-memory Dummy App

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,8 +98,6 @@ jobs:
   postgres:
     executor: postgres
     parallelism: &parallelism 3
-    environment:
-      ENABLE_ACTIVE_STORAGE: true
     steps:
       - setup
       - test
@@ -107,8 +105,6 @@ jobs:
   mysql:
     executor: mysql
     parallelism: *parallelism
-    environment:
-      ENABLE_ACTIVE_STORAGE: true
     steps:
       - setup
       - test
@@ -118,6 +114,7 @@ jobs:
     parallelism: *parallelism
     environment:
       RAILS_VERSION: '~> 6.0.0'
+      DISABLE_ACTIVE_STORAGE: true
     steps:
       - setup
       - test
@@ -127,6 +124,7 @@ jobs:
     parallelism: *parallelism
     environment:
       RAILS_VERSION: '~> 5.2.0'
+      DISABLE_ACTIVE_STORAGE: true
     steps:
       - setup
       - test

--- a/core/lib/spree/testing_support/dummy_app.rb
+++ b/core/lib/spree/testing_support/dummy_app.rb
@@ -68,7 +68,7 @@ module DummyApp
 
     config.storage_path = Rails.root.join('tmp', 'storage')
 
-    if ENV['ENABLE_ACTIVE_STORAGE']
+    unless ENV['DISABLE_ACTIVE_STORAGE']
       initializer 'solidus.active_storage' do
         config.active_storage.service_configurations = {
           test: {
@@ -119,9 +119,9 @@ Spree.user_class = 'Spree::LegacyUser'
 Spree.config do |config|
   config.mails_from = "store@example.com"
 
-  if ENV['ENABLE_ACTIVE_STORAGE']
-    config.image_attachment_module = 'Spree::Image::ActiveStorageAttachment'
-    config.taxon_attachment_module = 'Spree::Taxon::ActiveStorageAttachment'
+  if ENV['DISABLE_ACTIVE_STORAGE']
+    config.image_attachment_module = 'Spree::Image::PaperclipAttachment'
+    config.taxon_attachment_module = 'Spree::Taxon::PaperclipAttachment'
   end
 end
 

--- a/core/lib/spree/testing_support/dummy_app/migrations.rb
+++ b/core/lib/spree/testing_support/dummy_app/migrations.rb
@@ -27,9 +27,6 @@ module DummyApp
         ActiveRecord::Base.remove_connection
 
         sh 'rake db:reset VERBOSE=false'
-        unless ENV['DISABLE_ACTIVE_STORAGE']
-          sh 'rake active_storage:install db:migrate VERBOSE=false'
-        end
 
         # We have a brand new database, so we must re-establish our connection
         ActiveRecord::Base.establish_connection

--- a/core/lib/spree/testing_support/dummy_app/migrations.rb
+++ b/core/lib/spree/testing_support/dummy_app/migrations.rb
@@ -27,7 +27,7 @@ module DummyApp
         ActiveRecord::Base.remove_connection
 
         sh 'rake db:reset VERBOSE=false'
-        if ENV['ENABLE_ACTIVE_STORAGE']
+        unless ENV['DISABLE_ACTIVE_STORAGE']
           sh 'rake active_storage:install db:migrate VERBOSE=false'
         end
 


### PR DESCRIPTION
**Description**

We have now Active Storage installed by default on new apps. This PR configures the CI to reflect the new default (now it needs an ENV variable to disable it, otherwise it assumes it's enabled), and removes an extra call to install Active Storage migrations.