### PR TITLE
Add active storage configuration for dummy app

### DIFF
--- a/core/lib/generators/solidus/install/install_generator.rb
+++ b/core/lib/generators/solidus/install/install_generator.rb
@@ -120,6 +120,21 @@ module Solidus
     I18n.enforce_available_locales = #{options[:enforce_available_locales]}
         RUBY
       end
+
+      if options[:active_storage]
+        application <<-RUBY
+          initializer 'solidus.active_storage' do
+            config.storage_path = Rails.root.join('tmp', 'storage')
+            config.active_storage.service_configurations = {
+              test: {
+                service: 'Disk',
+                root: config.storage_path
+              }
+            }
+            config.active_storage.service = :test
+          end
+        RUBY
+      end
     end
 
     def plugin_install_preparation


### PR DESCRIPTION
**Description**
As active storage is the default in new stores https://github.com/solidusio/solidus/pull/3938 the generated dummy app needs to be configured so that new extensions can tests with it https://github.com/solidusio/solidus/issues/3967.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
