### PR TITLE
Fix double store credits creation when performing refunds

### DIFF
--- a/core/app/models/spree/payment_method/bogus_credit_card.rb
+++ b/core/app/models/spree/payment_method/bogus_credit_card.rb
@@ -9,6 +9,10 @@ module Spree
 
     VALID_CCS = ['1', TEST_VISA, TEST_MC, TEST_AMEX, TEST_DISC].flatten
 
+    AUTHORIZATION_CODE = '12345'
+    FAILURE_MESSAGE = 'Bogus Gateway: Forced failure'
+    SUCCESS_MESSAGE = 'Bogus Gateway: Forced success'
+
     attr_accessor :test
 
     def gateway_class
@@ -26,40 +30,40 @@ module Spree
     def authorize(_money, credit_card, _options = {})
       profile_id = credit_card.gateway_customer_profile_id
       if VALID_CCS.include?(credit_card.number) || (profile_id && profile_id.starts_with?('BGS-'))
-        ActiveMerchant::Billing::Response.new(true, 'Bogus Gateway: Forced success', {}, test: true, authorization: '12345', avs_result: { code: 'D' })
+        ActiveMerchant::Billing::Response.new(true, SUCCESS_MESSAGE, {}, test: true, authorization: AUTHORIZATION_CODE, avs_result: { code: 'D' })
       else
-        ActiveMerchant::Billing::Response.new(false, 'Bogus Gateway: Forced failure', { message: 'Bogus Gateway: Forced failure' }, test: true)
+        ActiveMerchant::Billing::Response.new(false, FAILURE_MESSAGE, { message: FAILURE_MESSAGE }, test: true)
       end
     end
 
     def purchase(_money, credit_card, _options = {})
       profile_id = credit_card.gateway_customer_profile_id
       if VALID_CCS.include?(credit_card.number) || (profile_id && profile_id.starts_with?('BGS-'))
-        ActiveMerchant::Billing::Response.new(true, 'Bogus Gateway: Forced success', {}, test: true, authorization: '12345', avs_result: { code: 'M' })
+        ActiveMerchant::Billing::Response.new(true, SUCCESS_MESSAGE, {}, test: true, authorization: AUTHORIZATION_CODE, avs_result: { code: 'M' })
       else
-        ActiveMerchant::Billing::Response.new(false, 'Bogus Gateway: Forced failure', message: 'Bogus Gateway: Forced failure', test: true)
+        ActiveMerchant::Billing::Response.new(false, FAILURE_MESSAGE, message: FAILURE_MESSAGE, test: true)
       end
     end
 
     def credit(_money, _credit_card, _response_code, _options = {})
-      ActiveMerchant::Billing::Response.new(true, 'Bogus Gateway: Forced success', {}, test: true, authorization: '12345')
+      ActiveMerchant::Billing::Response.new(true, SUCCESS_MESSAGE, {}, test: true, authorization: AUTHORIZATION_CODE)
     end
 
     def capture(_money, authorization, _gateway_options)
       if authorization == '12345'
-        ActiveMerchant::Billing::Response.new(true, 'Bogus Gateway: Forced success', {}, test: true)
+        ActiveMerchant::Billing::Response.new(true, SUCCESS_MESSAGE, {}, test: true)
       else
-        ActiveMerchant::Billing::Response.new(false, 'Bogus Gateway: Forced failure', error: 'Bogus Gateway: Forced failure', test: true)
+        ActiveMerchant::Billing::Response.new(false, FAILURE_MESSAGE, error: FAILURE_MESSAGE, test: true)
       end
     end
 
     def void(_response_code, _credit_card, _options = {})
-      ActiveMerchant::Billing::Response.new(true, 'Bogus Gateway: Forced success', {}, test: true, authorization: '12345')
+      ActiveMerchant::Billing::Response.new(true, SUCCESS_MESSAGE, {}, test: true, authorization: AUTHORIZATION_CODE)
     end
 
     # @see Spree::PaymentMethod#try_void
     def try_void(_payment)
-      ActiveMerchant::Billing::Response.new(true, 'Bogus Gateway: Forced success', {}, test: true, authorization: '12345')
+      ActiveMerchant::Billing::Response.new(true, SUCCESS_MESSAGE, {}, test: true, authorization: AUTHORIZATION_CODE)
     end
 
     def test?

--- a/core/app/models/spree/payment_method/simple_bogus_credit_card.rb
+++ b/core/app/models/spree/payment_method/simple_bogus_credit_card.rb
@@ -9,17 +9,17 @@ module Spree
 
     def authorize(_money, credit_card, _options = {})
       if VALID_CCS.include? credit_card.number
-        ActiveMerchant::Billing::Response.new(true, 'Bogus Gateway: Forced success', {}, test: true, authorization: '12345', avs_result: { code: 'A' })
+        ActiveMerchant::Billing::Response.new(true, SUCCESS_MESSAGE, {}, test: true, authorization: AUTHORIZATION_CODE, avs_result: { code: 'A' })
       else
-        ActiveMerchant::Billing::Response.new(false, 'Bogus Gateway: Forced failure', { message: 'Bogus Gateway: Forced failure' }, test: true)
+        ActiveMerchant::Billing::Response.new(false, FAILURE_MESSAGE, { message: FAILURE_MESSAGE }, test: true)
       end
     end
 
     def purchase(_money, credit_card, _options = {})
       if VALID_CCS.include? credit_card.number
-        ActiveMerchant::Billing::Response.new(true, 'Bogus Gateway: Forced success', {}, test: true, authorization: '12345', avs_result: { code: 'A' })
+        ActiveMerchant::Billing::Response.new(true, SUCCESS_MESSAGE, {}, test: true, authorization: AUTHORIZATION_CODE, avs_result: { code: 'A' })
       else
-        ActiveMerchant::Billing::Response.new(false, 'Bogus Gateway: Forced failure', message: 'Bogus Gateway: Forced failure', test: true)
+        ActiveMerchant::Billing::Response.new(false, FAILURE_MESSAGE, message: FAILURE_MESSAGE, test: true)
       end
     end
   end

--- a/core/app/models/spree/refund.rb
+++ b/core/app/models/spree/refund.rb
@@ -48,6 +48,10 @@ module Spree
       return true if perform_after_create == false
       return true if transaction_id.present?
 
+      # This is needed otherwise set_perform_after_create_default callback
+      # will print a deprecation warning when save! creates a record
+      self.perform_after_create = false unless persisted?
+
       credit_cents = money.cents
 
       @perform_response = process!(credit_cents)
@@ -63,9 +67,7 @@ module Spree
       log_entries.build(details: perform_response.to_yaml)
 
       self.transaction_id = perform_response.authorization
-      # This is needed otherwise set_perform_after_create_default callback
-      # will print a deprecation warning when save! creates a record.
-      self.perform_after_create = false unless persisted?
+
       save!
 
       update_order

--- a/core/spec/models/spree/refund_spec.rb
+++ b/core/spec/models/spree/refund_spec.rb
@@ -6,26 +6,11 @@ RSpec.describe Spree::Refund, type: :model do
   let(:amount) { 100.0 }
   let(:amount_in_cents) { amount * 100 }
 
-  let(:authorization) { generate(:refund_transaction_id) }
-
   let(:payment) { create(:payment, amount: payment_amount, payment_method: payment_method) }
   let(:payment_amount) { amount * 2 }
   let(:payment_method) { create(:credit_card_payment_method) }
 
   let(:refund_reason) { create(:refund_reason) }
-
-  let(:gateway_response) {
-    ActiveMerchant::Billing::Response.new(
-      gateway_response_success,
-      gateway_response_message,
-      gateway_response_params,
-      gateway_response_options
-    )
-  }
-  let(:gateway_response_success) { true }
-  let(:gateway_response_message) { "" }
-  let(:gateway_response_params) { {} }
-  let(:gateway_response_options) { { authorization: authorization } }
 
   let(:transaction_id) { nil }
   let(:perform_after_create) { false }
@@ -39,13 +24,6 @@ RSpec.describe Spree::Refund, type: :model do
       transaction_id: transaction_id,
       perform_after_create: perform_after_create
     )
-  end
-
-  before do
-    allow(payment.payment_method)
-      .to receive(:credit)
-      .with(amount_in_cents, payment.source, payment.transaction_id, { originator: an_instance_of(Spree::Refund) })
-      .and_return(gateway_response)
   end
 
   describe 'create' do
@@ -109,10 +87,11 @@ RSpec.describe Spree::Refund, type: :model do
       it "sets #perform_response with the gateway response from the payment provider" do
         expect(Spree::Deprecation).to receive(:warn)
 
-        expect(refund.perform_response).to eq gateway_response
+        expect(refund.perform_response).to be_a(ActiveMerchant::Billing::Response)
+        expect(refund.perform_response.message).to eq(Spree::PaymentMethod::BogusCreditCard::SUCCESS_MESSAGE)
       end
 
-      it "does nothing, perform! already happened after create" do
+      it "does nothing, perform! already happened after create", :aggregate_failures do
         expect(Spree::Deprecation).to receive(:warn)
         refund
         expect(refund.transaction_id).not_to be_nil
@@ -168,8 +147,7 @@ RSpec.describe Spree::Refund, type: :model do
         end
 
         it 'saves the returned authorization value' do
-          subject
-          expect(refund.reload.transaction_id).to eq authorization
+          expect { subject }.to change { refund.reload.transaction_id }.from(nil).to(Spree::PaymentMethod::BogusCreditCard::AUTHORIZATION_CODE)
         end
 
         it 'saves the passed amount as the refund amount' do
@@ -183,7 +161,7 @@ RSpec.describe Spree::Refund, type: :model do
         end
 
         it "attempts to process a transaction" do
-          expect(payment.payment_method).to receive(:credit).once
+          expect(payment.payment_method).to receive(:credit).once.and_call_original
           subject
         end
 
@@ -193,13 +171,29 @@ RSpec.describe Spree::Refund, type: :model do
         end
       end
 
-      context "processing fails" do
-        let(:gateway_response_success) { false }
-        let(:gateway_response_message) { "failure message" }
+      context "when processing fails" do
+        let(:failure_message) { Spree::PaymentMethod::BogusCreditCard::FAILURE_MESSAGE }
+        let(:gateway_response) {
+          ActiveMerchant::Billing::Response.new(
+            false,
+            failure_message,
+            {},
+            test: true,
+            authorization: Spree::PaymentMethod::BogusCreditCard::AUTHORIZATION_CODE
+          )
+        }
+
+        before do
+          allow(payment.payment_method)
+            .to receive(:credit)
+            .with(amount_in_cents, payment.source, payment.transaction_id, { originator: an_instance_of(Spree::Refund) })
+            .and_return(gateway_response)
+        end
+
 
         context 'without performing after create' do
           it 'raises a GatewayError' do
-            expect { subject }.to raise_error(Spree::Core::GatewayError, gateway_response_message)
+            expect { subject }.to raise_error(Spree::Core::GatewayError, failure_message)
           end
         end
 
@@ -210,7 +204,7 @@ RSpec.describe Spree::Refund, type: :model do
             expect(Spree::Deprecation).to receive(:warn)
 
             expect do
-              expect { subject }.to raise_error(Spree::Core::GatewayError, gateway_response_message)
+              expect { subject }.to raise_error(Spree::Core::GatewayError, failure_message)
             end.not_to change(Spree::Refund, :count)
           end
         end
@@ -225,7 +219,7 @@ RSpec.describe Spree::Refund, type: :model do
           expect(payment.payment_method)
             .to receive(:credit)
             .with(amount * 100, payment.transaction_id, { originator: an_instance_of(Spree::Refund) })
-            .and_return(gateway_response)
+            .and_call_original
 
           subject
         end
@@ -240,7 +234,7 @@ RSpec.describe Spree::Refund, type: :model do
           expect(payment.payment_method)
             .to receive(:credit)
             .with(amount_in_cents, payment.source, payment.transaction_id, { originator: an_instance_of(Spree::Refund) })
-            .and_return(gateway_response)
+            .and_call_original
 
           subject
         end


### PR DESCRIPTION
**Description**

This PR aims at solving a very specific bug that happens when refunding a store credit payment by creating a new store credit record (i.e. when the preference  `credit_to_new_allocation` is `true`). 

Under these circumstances, performing the refund will generate 2 identical store credits records instead of one, so the customer ends up getting store credits for twice the refund amount. This happens because the method `process!` ends up being called twice. 

The issue does not exist in master as the code that enables the bug has already been removed. 

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
