### PR TITLE
Fix for incorrect deprecation class

### DIFF
--- a/core/lib/spree/testing_support.rb
+++ b/core/lib/spree/testing_support.rb
@@ -25,7 +25,7 @@ module Spree
       factory_bot_paths: "Spree::TestingSupport::FactoryBot.definition_file_paths",
       check_factory_bot_version: "Spree::TestingSupport::FactoryBot.check_version",
       load_all_factories: "Spree::TestingSupport::FactoryBot.add_paths_and_load!",
-      deprecator: Spree::Deprecator
+      deprecator: Spree::Deprecation
     )
   end
 end


### PR DESCRIPTION
It looks like `Spree::Deprecator` reference added in 2.11.5 should have been `Spree::Deprecation` instead. This should fix https://github.com/solidusio/solidus/issues/3990

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
