### PR TITLE
Use Spree.user_class instead of Spree::LegacyUser in production code

### DIFF
--- a/core/lib/tasks/migrations/migrate_default_billing_addresses_to_address_book.rake
+++ b/core/lib/tasks/migrations/migrate_default_billing_addresses_to_address_book.rake
@@ -6,7 +6,7 @@ namespace :solidus do
       task up: :environment do
         print "Migrating default billing addresses to address book ... "
         if Spree::UserAddress.where(default_billing: true).any?
-          Spree::LegacyUser.joins(:bill_address).update_all(bill_address_id: nil) # rubocop:disable Rails/SkipsModelValidations
+          Spree.user_class.joins(:bill_address).update_all(bill_address_id: nil) # rubocop:disable Rails/SkipsModelValidations
         end
         adapter_type = Spree::Base.connection.adapter_name.downcase.to_sym
         if adapter_type == :mysql2


### PR DESCRIPTION
Other apps will probably have different user classes, and need to use
them.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
