### PR TITLE
Only run spring stop in install generator if spring is available

### DIFF
--- a/core/lib/generators/solidus/install/install_generator.rb
+++ b/core/lib/generators/solidus/install/install_generator.rb
@@ -182,7 +182,7 @@ module Solidus
       end
 
       bundle_cleanly{ run "bundle install" } if @plugins_to_be_installed.any?
-      run "spring stop"
+      run "spring stop" if defined?(Spring)
 
       @plugin_generators_to_run.each do |plugin_generator_name|
         generate "#{plugin_generator_name} --skip_migrations=true"


### PR DESCRIPTION


**Description**

The `spring stop` command in the install generator was being run even if spring is not installed. This command was causing the install generator to report an error.

We should only run this command if Spring is available.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [?] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
