### PR TITLE
DRY-up BogusCreditCard model and remove invasive refund spec stub

### DIFF
--- a/core/app/models/spree/payment_method/bogus_credit_card.rb
+++ b/core/app/models/spree/payment_method/bogus_credit_card.rb
@@ -9,6 +9,10 @@ module Spree
 
     VALID_CCS = ['1', TEST_VISA, TEST_MC, TEST_AMEX, TEST_DISC].flatten
 
+    AUTHORIZATION_CODE = '12345'
+    FAILURE_MESSAGE = 'Bogus Gateway: Forced failure'
+    SUCCESS_MESSAGE = 'Bogus Gateway: Forced success'
+
     attr_accessor :test
 
     def gateway_class
@@ -26,40 +30,40 @@ module Spree
     def authorize(_money, credit_card, _options = {})
       profile_id = credit_card.gateway_customer_profile_id
       if VALID_CCS.include?(credit_card.number) || (profile_id && profile_id.starts_with?('BGS-'))
-        ActiveMerchant::Billing::Response.new(true, 'Bogus Gateway: Forced success', {}, test: true, authorization: '12345', avs_result: { code: 'D' })
+        ActiveMerchant::Billing::Response.new(true, SUCCESS_MESSAGE, {}, test: true, authorization: AUTHORIZATION_CODE, avs_result: { code: 'D' })
       else
-        ActiveMerchant::Billing::Response.new(false, 'Bogus Gateway: Forced failure', { message: 'Bogus Gateway: Forced failure' }, test: true)
+        ActiveMerchant::Billing::Response.new(false, FAILURE_MESSAGE, { message: FAILURE_MESSAGE }, test: true)
       end
     end
 
     def purchase(_money, credit_card, _options = {})
       profile_id = credit_card.gateway_customer_profile_id
       if VALID_CCS.include?(credit_card.number) || (profile_id && profile_id.starts_with?('BGS-'))
-        ActiveMerchant::Billing::Response.new(true, 'Bogus Gateway: Forced success', {}, test: true, authorization: '12345', avs_result: { code: 'M' })
+        ActiveMerchant::Billing::Response.new(true, SUCCESS_MESSAGE, {}, test: true, authorization: AUTHORIZATION_CODE, avs_result: { code: 'M' })
       else
-        ActiveMerchant::Billing::Response.new(false, 'Bogus Gateway: Forced failure', message: 'Bogus Gateway: Forced failure', test: true)
+        ActiveMerchant::Billing::Response.new(false, FAILURE_MESSAGE, message: FAILURE_MESSAGE, test: true)
       end
     end
 
     def credit(_money, _credit_card, _response_code, _options = {})
-      ActiveMerchant::Billing::Response.new(true, 'Bogus Gateway: Forced success', {}, test: true, authorization: '12345')
+      ActiveMerchant::Billing::Response.new(true, SUCCESS_MESSAGE, {}, test: true, authorization: AUTHORIZATION_CODE)
     end
 
     def capture(_money, authorization, _gateway_options)
       if authorization == '12345'
-        ActiveMerchant::Billing::Response.new(true, 'Bogus Gateway: Forced success', {}, test: true)
+        ActiveMerchant::Billing::Response.new(true, SUCCESS_MESSAGE, {}, test: true)
       else
-        ActiveMerchant::Billing::Response.new(false, 'Bogus Gateway: Forced failure', error: 'Bogus Gateway: Forced failure', test: true)
+        ActiveMerchant::Billing::Response.new(false, FAILURE_MESSAGE, error: FAILURE_MESSAGE, test: true)
       end
     end
 
     def void(_response_code, _credit_card, _options = {})
-      ActiveMerchant::Billing::Response.new(true, 'Bogus Gateway: Forced success', {}, test: true, authorization: '12345')
+      ActiveMerchant::Billing::Response.new(true, SUCCESS_MESSAGE, {}, test: true, authorization: AUTHORIZATION_CODE)
     end
 
     # @see Spree::PaymentMethod#try_void
     def try_void(_payment)
-      ActiveMerchant::Billing::Response.new(true, 'Bogus Gateway: Forced success', {}, test: true, authorization: '12345')
+      ActiveMerchant::Billing::Response.new(true, SUCCESS_MESSAGE, {}, test: true, authorization: AUTHORIZATION_CODE)
     end
 
     def test?

--- a/core/app/models/spree/payment_method/simple_bogus_credit_card.rb
+++ b/core/app/models/spree/payment_method/simple_bogus_credit_card.rb
@@ -9,17 +9,17 @@ module Spree
 
     def authorize(_money, credit_card, _options = {})
       if VALID_CCS.include? credit_card.number
-        ActiveMerchant::Billing::Response.new(true, 'Bogus Gateway: Forced success', {}, test: true, authorization: '12345', avs_result: { code: 'A' })
+        ActiveMerchant::Billing::Response.new(true, SUCCESS_MESSAGE, {}, test: true, authorization: AUTHORIZATION_CODE, avs_result: { code: 'A' })
       else
-        ActiveMerchant::Billing::Response.new(false, 'Bogus Gateway: Forced failure', { message: 'Bogus Gateway: Forced failure' }, test: true)
+        ActiveMerchant::Billing::Response.new(false, FAILURE_MESSAGE, { message: FAILURE_MESSAGE }, test: true)
       end
     end
 
     def purchase(_money, credit_card, _options = {})
       if VALID_CCS.include? credit_card.number
-        ActiveMerchant::Billing::Response.new(true, 'Bogus Gateway: Forced success', {}, test: true, authorization: '12345', avs_result: { code: 'A' })
+        ActiveMerchant::Billing::Response.new(true, SUCCESS_MESSAGE, {}, test: true, authorization: AUTHORIZATION_CODE, avs_result: { code: 'A' })
       else
-        ActiveMerchant::Billing::Response.new(false, 'Bogus Gateway: Forced failure', message: 'Bogus Gateway: Forced failure', test: true)
+        ActiveMerchant::Billing::Response.new(false, FAILURE_MESSAGE, message: FAILURE_MESSAGE, test: true)
       end
     end
   end


### PR DESCRIPTION
**Description**

This PR includes 2 commits that were originally proposed with [this bugfix](https://github.com/solidusio/solidus/pull/3989) that targets v2.11. They're proposed also for the master branch, as they can be beneficial here as well.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
