### PR TITLE
Switch to the correct ActiveStorage variant syntax

### DIFF
--- a/core/app/models/concerns/spree/active_storage_adapter/attachment.rb
+++ b/core/app/models/concerns/spree/active_storage_adapter/attachment.rb
@@ -9,11 +9,9 @@ module Spree
     class Attachment
       delegate_missing_to :@attachment
 
-      DEFAULT_SIZE = '100%'
-
       def initialize(attachment, styles: {})
         @attachment = attachment
-        @styles = styles
+        @styles = normalize_styles(styles)
       end
 
       def exists?
@@ -29,12 +27,10 @@ module Spree
       end
 
       def variant(style = nil)
-        size = style_to_size(style&.to_sym)
+        size = style_to_size(style)
         @attachment.variant(
-          resize: size,
-          strip: true,
-          'auto-orient': true,
-          colorspace: 'sRGB',
+          resize_to_limit: size,
+          strip: true
         ).processed
       end
 
@@ -61,8 +57,12 @@ module Spree
         @attachment.metadata
       end
 
+      def normalize_styles(styles)
+        styles.transform_values { |v| v.split('x') }
+      end
+
       def style_to_size(style)
-        @styles.fetch(style) { DEFAULT_SIZE }
+        @styles.fetch(style&.to_sym) { [width, height] }
       end
     end
   end

--- a/core/app/models/concerns/spree/active_storage_adapter/attachment.rb
+++ b/core/app/models/concerns/spree/active_storage_adapter/attachment.rb
@@ -19,11 +19,11 @@ module Spree
       end
 
       def filename
-        blob.filename.to_s
+        blob&.filename.to_s
       end
 
       def url(style = nil)
-        variant(style).url
+        variant(style)&.url
       end
 
       def variant(style = nil)


### PR DESCRIPTION
**Description**

This PR updates the syntax that we're using to create variants from main `ActiveStorage` images in our attachment decorator.
Since Rails 6.0, [`MiniMagik`](https://github.com/minimagick/minimagick) syntax [has been depreacted](https://github.com/rails/rails/blob/6-0-stable/activestorage/CHANGELOG.md) in favor of [`ImageProcessing`](https://github.com/janko/image_processing) wrapper gem. 

<!--
  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

  Please include screenshots in case of visual changes to the frontend or backend sections of Solidus.

  If needed you can reference another PR or issue here, e.g.:
  Ref #ISSUE
-->

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- ~~[ ] I have updated Guides and README accordingly to this change (if needed)~~
- ~~[ ] I have added tests to cover this change (if needed)~~
- ~~[ ] I have attached screenshots to this PR for visual changes (if needed)~~
