### PR TITLE
Failing spec for calculator with preferences that aren't known

### DIFF
--- a/core/spec/models/spree/stock/estimator_spec.rb
+++ b/core/spec/models/spree/stock/estimator_spec.rb
@@ -105,7 +105,25 @@ module Spree
 
             let!(:shipping_methods) do
               [
-                create(:shipping_method, calculator: Spree::Calculator::Shipping::NoPreferences.new)
+                create(:shipping_method, calculator: Spree::Calculator::Shipping::NoPreferences.new())
+              ]
+            end
+
+            it 'does not raise an error' do
+              expect { subject.shipping_rates(package) }.not_to raise_error
+            end
+          end
+
+          context 'with a custom shipping calculator with preference' do
+            class Spree::Calculator::Shipping::WithUnknownPreferences < Spree::ShippingCalculator
+              def compute_package(_package)
+                # no op
+              end
+            end
+
+            let!(:shipping_methods) do
+              [
+                create(:shipping_method, calculator: Spree::Calculator::Shipping::WithUnknownPreferences.new(preferences: {a: "b"}))
               ]
             end
 


### PR DESCRIPTION
If you try accessing a calculator with preferences in the DB, and that
calculator hasn't seen the `serialize` call, Rails will try accessing
the preferences column directly and return a string :(

**Checklist:**
- [ ] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [ ] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
