### PR TITLE
WIP Revert that one commit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,6 +109,16 @@ jobs:
       - setup
       - test
 
+  postgres_rails61:
+    executor: postgres
+    parallelism: *parallelism
+    environment:
+      RAILS_VERSION: '~> 6.1.0'
+      DISABLE_ACTIVE_STORAGE: true
+    steps:
+      - setup
+      - test
+
   postgres_rails60:
     executor: postgres
     parallelism: *parallelism
@@ -140,6 +150,7 @@ workflows:
       - mysql
       - postgres_rails60
       - postgres_rails52
+      - postgres_rails61
       - stoplight/push:
           context: "Solidus Core Team"
           project: solidus/solidus-api

--- a/core/app/models/spree/base.rb
+++ b/core/app/models/spree/base.rb
@@ -3,6 +3,8 @@
 class Spree::Base < ActiveRecord::Base
   include Spree::Preferences::Preferable
   include Spree::Core::Permalinks
+  serialize :preferences, Hash
+
   include Spree::RansackableAttributes
 
   def initialize_preference_defaults
@@ -16,7 +18,6 @@ class Spree::Base < ActiveRecord::Base
   def self.preference(*args)
     # after_initialize can be called multiple times with the same symbol, it
     # will only be called once on initialization.
-    serialize :preferences, Hash
     after_initialize :initialize_preference_defaults
     super
   end

--- a/core/app/models/spree/base.rb
+++ b/core/app/models/spree/base.rb
@@ -5,10 +5,6 @@ class Spree::Base < ActiveRecord::Base
   include Spree::Core::Permalinks
   include Spree::RansackableAttributes
 
-  def preferences
-    read_attribute(:preferences) || self.class.preferences_coder_class.new
-  end
-
   def initialize_preference_defaults
     if has_attribute?(:preferences)
       self.preferences = default_preferences.merge(preferences)
@@ -20,13 +16,9 @@ class Spree::Base < ActiveRecord::Base
   def self.preference(*args)
     # after_initialize can be called multiple times with the same symbol, it
     # will only be called once on initialization.
-    serialize :preferences, preferences_coder_class
+    serialize :preferences, Hash
     after_initialize :initialize_preference_defaults
     super
-  end
-
-  def self.preferences_coder_class
-    Hash
   end
 
   self.abstract_class = true

--- a/core/spec/models/spree/stock/estimator_spec.rb
+++ b/core/spec/models/spree/stock/estimator_spec.rb
@@ -96,6 +96,24 @@ module Spree
         context "general shipping methods" do
           before { Spree::ShippingMethod.all.each(&:destroy) }
 
+          context 'with a custom shipping calculator with no preference' do
+            class Spree::Calculator::Shipping::NoPreferences < Spree::ShippingCalculator
+              def compute_package(_package)
+                # no op
+              end
+            end
+
+            let!(:shipping_methods) do
+              [
+                create(:shipping_method, calculator: Spree::Calculator::Shipping::NoPreferences.new)
+              ]
+            end
+
+            it 'does not raise an error' do
+              expect { subject.shipping_rates(package) }.not_to raise_error
+            end
+          end
+
           context 'with two shipping methods of different cost' do
             let!(:shipping_methods) do
               [

--- a/core/spec/models/spree/stock/estimator_spec.rb
+++ b/core/spec/models/spree/stock/estimator_spec.rb
@@ -96,24 +96,6 @@ module Spree
         context "general shipping methods" do
           before { Spree::ShippingMethod.all.each(&:destroy) }
 
-          context 'with a custom shipping calculator with no preference' do
-            class Spree::Calculator::Shipping::NoPreferences < Spree::ShippingCalculator
-              def compute_package(_package)
-                # no op
-              end
-            end
-
-            let!(:shipping_methods) do
-              [
-                create(:shipping_method, calculator: Spree::Calculator::Shipping::NoPreferences.new)
-              ]
-            end
-
-            it 'does not raise an error' do
-              expect { subject.shipping_rates(package) }.not_to raise_error
-            end
-          end
-
           context 'with two shipping methods of different cost' do
             let!(:shipping_methods) do
               [


### PR DESCRIPTION
**Description**

Reverts "Define preference attribute only when used " as well as the fix that did not fix it in my experiecce.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [ ] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
