### PR TITLE
Deprecate calling preferences without serialization

### DIFF
--- a/core/app/models/spree/base.rb
+++ b/core/app/models/spree/base.rb
@@ -6,23 +6,36 @@ class Spree::Base < ActiveRecord::Base
   include Spree::RansackableAttributes
 
   def preferences
-    read_attribute(:preferences) || self.class.preferences_coder_class.new
+    value = read_attribute(:preferences)
+    if !value.is_a?(Hash)
+      Spree::Deprecation.warn <<~WARN
+        #{self.class.name} has a `preferences` column, but does not explicitly (de)serialize this column.
+        In order to make #{self.class.name} work with future versions of Solidus (and Rails), please add the
+        following to lines to your class:
+        ```
+        class #{self.class.name}
+          serialize :preferences, Hash
+          after_initialize :initialize_preference_defaults
+          ...
+        end
+        ```
+      WARN
+      self.class.serialize :preferences, Hash
+      self.class.after_initialize :initialize_preference_defaults
+
+      ActiveRecord::Type::Serialized.new(
+        ActiveRecord::Type::Text.new,
+        ActiveRecord::Coders::YAMLColumn.new(:preferences, Hash)
+      ).deserialize(value)
+    else
+      value
+    end
   end
 
   def initialize_preference_defaults
     if has_attribute?(:preferences)
       self.preferences = default_preferences.merge(preferences)
     end
-  end
-
-  # Only run preference initialization on models which requires it. Improves
-  # performance of record initialization slightly.
-  def self.preference(*args)
-    # after_initialize can be called multiple times with the same symbol, it
-    # will only be called once on initialization.
-    serialize :preferences, preferences_coder_class
-    after_initialize :initialize_preference_defaults
-    super
   end
 
   if Kaminari.config.page_method_name != :page
@@ -33,10 +46,6 @@ class Spree::Base < ActiveRecord::Base
 
       send Kaminari.config.page_method_name, num
     end
-  end
-
-  def self.preferences_coder_class
-    Hash
   end
 
   self.abstract_class = true

--- a/core/app/models/spree/base.rb
+++ b/core/app/models/spree/base.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'spree/preferences/persistable'
+
 class Spree::Base < ActiveRecord::Base
   include Spree::Preferences::Preferable
   include Spree::Core::Permalinks
@@ -11,17 +13,15 @@ class Spree::Base < ActiveRecord::Base
       Spree::Deprecation.warn <<~WARN
         #{self.class.name} has a `preferences` column, but does not explicitly (de)serialize this column.
         In order to make #{self.class.name} work with future versions of Solidus (and Rails), please add the
-        following to lines to your class:
+        following lines to your class:
         ```
         class #{self.class.name}
-          serialize :preferences, Hash
-          after_initialize :initialize_preference_defaults
+          include Spree::Preferences::Persistable
           ...
         end
         ```
       WARN
-      self.class.serialize :preferences, Hash
-      self.class.after_initialize :initialize_preference_defaults
+      self.class.include Spree::Preferences::Persistable
 
       ActiveRecord::Type::Serialized.new(
         ActiveRecord::Type::Text.new,
@@ -29,12 +29,6 @@ class Spree::Base < ActiveRecord::Base
       ).deserialize(value)
     else
       value
-    end
-  end
-
-  def initialize_preference_defaults
-    if has_attribute?(:preferences)
-      self.preferences = default_preferences.merge(preferences)
     end
   end
 

--- a/core/app/models/spree/base.rb
+++ b/core/app/models/spree/base.rb
@@ -6,6 +6,22 @@ class Spree::Base < ActiveRecord::Base
   include Spree::Core::Permalinks
   include Spree::RansackableAttributes
 
+  def self.preference(*args)
+    Spree::Deprecation.warn <<~WARN
+      #{name} has a `preferences` column, but does not explicitly (de)serialize this column.
+      In order to make #{name} work with future versions of Solidus (and Rails), please add the
+      following line to your class:
+      ```
+      class #{name}
+        include Spree::Preferences::Persistable
+        ...
+      end
+      ```
+    WARN
+    include Spree::Preferences::Persistable
+    preference(*args)
+  end
+
   def preferences
     value = read_attribute(:preferences)
     if !value.is_a?(Hash)

--- a/core/app/models/spree/base.rb
+++ b/core/app/models/spree/base.rb
@@ -3,7 +3,6 @@
 require 'spree/preferences/persistable'
 
 class Spree::Base < ActiveRecord::Base
-  include Spree::Preferences::Preferable
   include Spree::Core::Permalinks
   include Spree::RansackableAttributes
 

--- a/core/app/models/spree/calculator.rb
+++ b/core/app/models/spree/calculator.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
+require 'spree/preferences/persistable'
+
 module Spree
   class Calculator < Spree::Base
-    serialize :preferences, Hash
-    after_initialize :initialize_preference_defaults
+    include Spree::Preferences::Persistable
 
     belongs_to :calculable, polymorphic: true, optional: true
 

--- a/core/app/models/spree/calculator.rb
+++ b/core/app/models/spree/calculator.rb
@@ -2,6 +2,9 @@
 
 module Spree
   class Calculator < Spree::Base
+    serialize :preferences, Hash
+    after_initialize :initialize_preference_defaults
+
     belongs_to :calculable, polymorphic: true, optional: true
 
     # This method calls a compute_<computable> method. must be overriden in concrete calculator.

--- a/core/app/models/spree/payment_method.rb
+++ b/core/app/models/spree/payment_method.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'spree/preferences/persistable'
 require 'spree/preferences/statically_configurable'
 
 module Spree
@@ -11,8 +12,7 @@ module Spree
   # This class is not meant to be instantiated. Please create instances of concrete payment methods.
   #
   class PaymentMethod < Spree::Base
-    serialize :preferences, Hash
-    after_initialize :initialize_preference_defaults
+    include Spree::Preferences::Persistable
 
     preference :server, :string, default: 'test'
     preference :test_mode, :boolean, default: true

--- a/core/app/models/spree/payment_method.rb
+++ b/core/app/models/spree/payment_method.rb
@@ -11,6 +11,9 @@ module Spree
   # This class is not meant to be instantiated. Please create instances of concrete payment methods.
   #
   class PaymentMethod < Spree::Base
+    serialize :preferences, Hash
+    after_initialize :initialize_preference_defaults
+
     preference :server, :string, default: 'test'
     preference :test_mode, :boolean, default: true
 

--- a/core/app/models/spree/promotion_action.rb
+++ b/core/app/models/spree/promotion_action.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
+require 'spree/preferences/persistable'
+
 module Spree
   # Base class for all types of promotion action.
   #
   # PromotionActions perform the necessary tasks when a promotion is activated
   # by an event and determined to be eligible.
   class PromotionAction < Spree::Base
-    serialize :preferences, Hash
-    after_initialize :initialize_preference_defaults
-
+    include Spree::Preferences::Persistable
     include Spree::SoftDeletable
 
     belongs_to :promotion, class_name: 'Spree::Promotion', inverse_of: :promotion_actions, optional: true

--- a/core/app/models/spree/promotion_action.rb
+++ b/core/app/models/spree/promotion_action.rb
@@ -6,6 +6,9 @@ module Spree
   # PromotionActions perform the necessary tasks when a promotion is activated
   # by an event and determined to be eligible.
   class PromotionAction < Spree::Base
+    serialize :preferences, Hash
+    after_initialize :initialize_preference_defaults
+
     include Spree::SoftDeletable
 
     belongs_to :promotion, class_name: 'Spree::Promotion', inverse_of: :promotion_actions, optional: true

--- a/core/app/models/spree/promotion_rule.rb
+++ b/core/app/models/spree/promotion_rule.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
+require 'spree/preferences/persistable'
+
 module Spree
   # Base class for all promotion rules
   class PromotionRule < Spree::Base
-    serialize :preferences, Hash
-    after_initialize :initialize_preference_defaults
+    include Spree::Preferences::Persistable
 
     belongs_to :promotion, class_name: 'Spree::Promotion', inverse_of: :promotion_rules, optional: true
 

--- a/core/app/models/spree/promotion_rule.rb
+++ b/core/app/models/spree/promotion_rule.rb
@@ -3,6 +3,9 @@
 module Spree
   # Base class for all promotion rules
   class PromotionRule < Spree::Base
+    serialize :preferences, Hash
+    after_initialize :initialize_preference_defaults
+
     belongs_to :promotion, class_name: 'Spree::Promotion', inverse_of: :promotion_rules, optional: true
 
     scope :of_type, ->(type) { where(type: type) }

--- a/core/lib/spree/preferences/persistable.rb
+++ b/core/lib/spree/preferences/persistable.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Spree
+  module Preferences
+    module Persistable
+      extend ActiveSupport::Concern
+
+      included do
+        serialize :preferences, Hash
+        after_initialize :initialize_preference_defaults
+      end
+
+      private
+
+      def initialize_preference_defaults
+        if has_attribute?(:preferences)
+          self.preferences = default_preferences.merge(preferences)
+        end
+      end
+    end
+  end
+end

--- a/core/lib/spree/preferences/persistable.rb
+++ b/core/lib/spree/preferences/persistable.rb
@@ -6,6 +6,7 @@ module Spree
       extend ActiveSupport::Concern
 
       included do
+        include Spree::Preferences::Preferable
         serialize :preferences, Hash
         after_initialize :initialize_preference_defaults
       end

--- a/core/spec/models/spree/base_spec.rb
+++ b/core/spec/models/spree/base_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Spree::Base do
+  before(:all) do
+    class CreatePrefTest < ActiveRecord::Migration[4.2]
+      def self.up
+        create_table :pref_tests do |item|
+          item.string :col
+          item.text :preferences
+        end
+      end
+
+      def self.down
+        drop_table :pref_tests
+      end
+    end
+
+    @migration_verbosity = ActiveRecord::Migration[4.2].verbose
+    ActiveRecord::Migration[4.2].verbose = false
+    CreatePrefTest.migrate(:up)
+  end
+
+  after(:all) do
+    CreatePrefTest.migrate(:down)
+    ActiveRecord::Migration[4.2].verbose = @migration_verbosity
+  end
+
+  context "with a class that has a preference column but does not explicitly serialize" do
+    before :all do
+      class PrefTestWithoutSerialization < Spree::Base
+        self.table_name = :pref_tests
+      end
+    end
+
+    before(:each) do
+      allow(Spree::Deprecation).to receive(:warn).
+        with(/^PrefTestWithoutSerialization has a `preferences` column, but does not explicitly \(de\)serialize this column.*/m, any_args)
+    end
+
+    after(:all) do
+      Object.send(:remove_const, :PrefTestWithoutSerialization)
+    end
+
+    it "returns a Hash nevertheless" do
+      instance = PrefTestWithoutSerialization.new
+      expect(instance.preferences).to eq({})
+    end
+
+    it "returns a Hash when there's already values in the table" do
+      ActiveRecord::Base.connection.execute("INSERT INTO pref_tests (col, preferences) VALUES ('test', '---\n:percent: 20')")
+      instance = PrefTestWithoutSerialization.first
+      expect(instance.preferences).to eq(percent: 20)
+    end
+  end
+end

--- a/core/spec/models/spree/base_spec.rb
+++ b/core/spec/models/spree/base_spec.rb
@@ -45,13 +45,18 @@ RSpec.describe Spree::Base do
 
     it "returns a Hash nevertheless" do
       instance = PrefTestWithoutSerialization.new
-      expect(instance.preferences).to eq({})
+      expect(instance.preferences).to be_a(Hash)
     end
 
     it "returns a Hash when there's already values in the table" do
       ActiveRecord::Base.connection.execute("INSERT INTO pref_tests (col, preferences) VALUES ('test', '---\n:percent: 20')")
       instance = PrefTestWithoutSerialization.first
-      expect(instance.preferences).to eq(percent: 20)
+      expect(instance.preferences).to include(percent: 20)
+    end
+
+    it "includes the persistable module when calling #preference and sets the preference default" do
+      PrefTestWithoutSerialization.preference :percentage, :number, default: 5
+      expect(PrefTestWithoutSerialization.new.preferences).to eq(percentage: 5)
     end
   end
 end

--- a/core/spec/models/spree/calculator_spec.rb
+++ b/core/spec/models/spree/calculator_spec.rb
@@ -12,16 +12,16 @@ RSpec.describe Spree::Calculator, type: :model do
   class SimpleComputable
   end
 
-  describe "#calculators" do
-    before do
-      expect(Spree::Deprecation).to receive(:warn).
-        with(/^Calling \.calculators is deprecated/, any_args)
-    end
+  describe "preferences" do
+    subject { SimpleCalculator.new.preferences }
 
-    subject { Spree::Calculator.calculators }
+    it { is_expected.to eq({}) }
 
-    it 'returns the (deprecated) calculator step' do
-      expect(subject).to be_a Spree::Core::Environment::Calculators
+    context "with preferences stored" do
+      let(:calculator) { SimpleCalculator.create(preferences: { a: "1" }) }
+      subject { calculator.reload.preferences }
+
+      it { is_expected.to eq({ a: "1" }) }
     end
   end
 

--- a/core/spec/models/spree/payment_method_spec.rb
+++ b/core/spec/models/spree/payment_method_spec.rb
@@ -32,6 +32,12 @@ RSpec.describe Spree::PaymentMethod, type: :model do
     })
   end
 
+  describe "preferences" do
+    subject { described_class.new.preferences }
+
+    it { is_expected.to be_a(Hash) }
+  end
+
   describe "available_to_[<users>, <admin>, <store>]" do
     context "when searching for payment methods available to users and admins" do
       subject { Spree::PaymentMethod.available_to_users.available_to_admin }

--- a/core/spec/models/spree/preferences/preferable_spec.rb
+++ b/core/spec/models/spree/preferences/preferable_spec.rb
@@ -327,6 +327,8 @@ RSpec.describe Spree::Preferences::Preferable, type: :model do
       CreatePrefTest.migrate(:up)
 
       class PrefTest < Spree::Base
+        serialize :preferences, Hash
+        after_initialize :initialize_preference_defaults
         preference :pref_test_pref, :string, default: 'abc'
         preference :pref_test_any, :any, default: []
         preference :pref_test_encrypted_string, :encrypted_string, encryption_key: 'VkYp3s6v9y$B?E(H+MbQeThWmZq4t7w!'

--- a/core/spec/models/spree/preferences/preferable_spec.rb
+++ b/core/spec/models/spree/preferences/preferable_spec.rb
@@ -327,8 +327,8 @@ RSpec.describe Spree::Preferences::Preferable, type: :model do
       CreatePrefTest.migrate(:up)
 
       class PrefTest < Spree::Base
-        serialize :preferences, Hash
-        after_initialize :initialize_preference_defaults
+        include Spree::Preferences::Persistable
+
         preference :pref_test_pref, :string, default: 'abc'
         preference :pref_test_any, :any, default: []
         preference :pref_test_encrypted_string, :encrypted_string, encryption_key: 'VkYp3s6v9y$B?E(H+MbQeThWmZq4t7w!'

--- a/core/spec/models/spree/promotion_action_spec.rb
+++ b/core/spec/models/spree/promotion_action_spec.rb
@@ -3,6 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe Spree::PromotionAction, type: :model do
+  describe "preferences" do
+    subject { described_class.new.preferences }
+
+    it { is_expected.to eq({}) }
+  end
+
   describe '#remove_from' do
     class MyPromotionAction < Spree::PromotionAction
       def perform(options = {})

--- a/core/spec/models/spree/promotion_rule_spec.rb
+++ b/core/spec/models/spree/promotion_rule_spec.rb
@@ -12,6 +12,12 @@ module Spree
       end
     end
 
+    describe "preferences" do
+      subject { described_class.new.preferences }
+
+      it { is_expected.to be_a(Hash) }
+    end
+
     it "forces developer to implement eligible? method" do
       expect { BadTestRule.new.eligible?("promotable") }.to raise_error NotImplementedError
     end

--- a/core/spec/models/spree/stock/estimator_spec.rb
+++ b/core/spec/models/spree/stock/estimator_spec.rb
@@ -114,6 +114,29 @@ module Spree
             end
           end
 
+          context 'with a custom shipping calculator with preference' do
+            class Spree::Calculator::Shipping::WithUnknownPreferences < Spree::ShippingCalculator
+              def compute_package(_package)
+                # no op
+              end
+            end
+
+            let!(:shipping_methods) do
+              [
+                create(
+                  :shipping_method,
+                  calculator: Spree::Calculator::Shipping::WithUnknownPreferences.new(
+                    preferences: { a: "b" }
+                  )
+                )
+              ]
+            end
+
+            it 'does not raise an error' do
+              expect { subject.shipping_rates(package) }.not_to raise_error
+            end
+          end
+
           context 'with two shipping methods of different cost' do
             let!(:shipping_methods) do
               [

--- a/guides/source/developers/preferences/add-model-preferences.html.md
+++ b/guides/source/developers/preferences/add-model-preferences.html.md
@@ -4,7 +4,12 @@ Solidus comes with many model-specific preferences. They are configured to have
 default values that are appropriate for typical stores. Additional preferences
 can be added by your application or included extensions.
 
-Preferences can be set on any model that inherits from [`Spree::Base`][spree-base].
+Preferences can be set on any model that includes `Spree::Preferences::Persistable`.
+In core Solidus, these are all classes inheriting from:
+  - `Spree::Calculator`
+  - `Spree::PromotionAction`
+  - `Spree::PaymentMethod`
+  - `Spree::PromotionRule`
 
 Note that model preferences apply only to the current model. To learn more about
 application-wide preferences, see the [App configuration][app-configuration]
@@ -21,6 +26,7 @@ You can define preferences for a model within the model itself:
 ```ruby
 module MyStore
   class User < Spree::Base
+    include Spree::Preferences::Persistable
     preference :hot_salsa, :boolean
     preference :dark_chocolate, :boolean, default: true
     preference :color, :string
@@ -30,7 +36,7 @@ module MyStore
 end
 ```
 
-This will work because User is a subclass of Spree::Base. If found,
+This will work because User includes [`Spree::Preferences::Persistable`][spree-persistable]. If found,
 the preferences attribute gets serialized into a Hash and merged with the default values.
 
 <!-- TODO:
@@ -178,4 +184,4 @@ user.preferred_color_type # => :string
 ```
 
 [app-configuration]: app-configuration.html
-[spree-base]: https://github.com/solidusio/solidus/blob/master/core/app/models/spree/base.rb
+[spree-persistable]: https://github.com/solidusio/solidus/blob/master/core/lib/spree/preferences/persistable.rb


### PR DESCRIPTION
**Description**

In Solidus < 2.11.4, `Spree::Base` had a `serialize :preferences, Hash` statement. This statement fails in Rails 6.1ff, as after that Rails will try deserializing the column even if it isn't there. 

What this commit does is: 
- Remove the `serialize` call from `Spree::Base`, as many inheriting classes do not have a `preferences` column
- Add the `serialize` and `after_initialize` call to those base classes that need it
  - `Spree::Calculator`
  - `Spree::PromotionAction`
  - `Spree::PaymentMethod`
  - `Spree::PromotionRule`
- Add a new `preferences` getter to `Spree::Base` that exhibits the following behaviour: If `preferences` is not a Hash, we can safely assume that the class of the instance we're trying to get preferences from expects `Spree::Base` to perform the `serialize` call for them. In that case, call `serialize` on the instance's class, ensuring that all future loads of this type of object will have `preferences` serialized, and parse the attribute using `ActiveRecord::Type::Serialized` (as that's how `Spree::Base` worked).
- Remove the `preferences_coder_class` method. I don't think it's prudent to add an extension point here for something that was hardcoded in the past and can easily be circumnavigated by e.g. setting one's custom class to serialize using JSON: 

```rb
class MyPreferences
  serialize :preferences, JSON
  after_initialize :initialize_preference_defaults
  ...
end
```

This PR goes against the `v2.11` branch of Solidus; I would like to uphold my PR #3997 for the `master` branch. 

This means that the deprecation window for this change would be `v2.11.8` => `v3.0.0`, but I think that's doable. There is a bit of work in related projects, but it just consists in adding to lines to configuration classes. 


**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] <del> I have updated Guides and README accordingly to this change (if needed) </del>
- [x] I have added tests to cover this change (if needed)
- [ ] <del> II have attached screenshots to this PR for visual changes (if needed) </del>
