### PR TITLE
Add sqlite executor to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,14 @@ executors:
       - image: *image
       - image: circleci/mysql:5.7-ram
 
+  sqlite:
+    working_directory: *workdir
+    environment:
+      <<: *environment
+      DB: sqlite
+    docker:
+      - image: *image
+
 commands:
   setup:
     steps:
@@ -109,6 +117,13 @@ jobs:
       - setup
       - test
 
+  sqlite:
+    executor: sqlite
+    parallelism: *parallelism
+    steps:
+      - setup
+      - test
+
   postgres_rails60:
     executor: postgres
     parallelism: *parallelism
@@ -138,6 +153,7 @@ workflows:
               only: /master|v\d\.\d+/
       - postgres
       - mysql
+      - sqlite
       - postgres_rails60
       - postgres_rails52
       - stoplight/push:


### PR DESCRIPTION
The test suite was only run against mysql and postgres. It's good to add
sqlite as it's is commonly used during development.

I worked on this because we recently had a failing test in the task  `core/lib/tasks/migrations/migrate_default_billing_addresses_to_address_book.rake`. However, it was recently removed (https://github.com/solidusio/solidus/commit/f3f58034b7b93be9f565b07bae357c1ea92c2d1a). I spent some time fixing it and then when I pulled for new changes I realized the file wasn't there anymore... :facepalm: Anyway, having sqlite3 in the CI can help prevent problems like that. Please, tell me if you'd like to backport the fix for that task to 2.1.