### PR TITLE
Image attachment content type validation fix for ActiveStorage

### DIFF
--- a/core/app/models/spree/image/active_storage_attachment.rb
+++ b/core/app/models/spree/image/active_storage_attachment.rb
@@ -7,6 +7,10 @@ module Spree::Image::ActiveStorageAttachment
   delegate :width, :height, to: :attachment, prefix: true
 
   included do
+    validates :attachment, presence: true
+    validate :attachment_is_an_image
+    validate :supported_content_type
+
     has_attachment :attachment,
                    styles: {
                    mini: '48x48>',
@@ -15,7 +19,11 @@ module Spree::Image::ActiveStorageAttachment
                    large: '1200x1200>'
                  },
                  default_style: :product
-    validates :attachment, presence: true
-    validate :attachment_is_an_image
+
+    def supported_content_type
+      unless attachment.content_type.in?(Spree::Config.allowed_image_mime_types)
+        errors.add(:attachment, :content_type_not_supported)
+      end
+    end
   end
 end

--- a/core/app/models/spree/image/paperclip_attachment.rb
+++ b/core/app/models/spree/image/paperclip_attachment.rb
@@ -15,7 +15,7 @@ module Spree::Image::PaperclipAttachment
                       convert_options: { all: '-strip -auto-orient -colorspace sRGB' }
     validates_attachment :attachment,
       presence: true,
-      content_type: { content_type: %w[image/jpeg image/jpg image/png image/gif] }
+      content_type: { content_type: Spree::Config.allowed_image_mime_types }
 
     # save the w,h of the original image (from which others can be calculated)
     # we need to look at the write-queue for images which have not been saved yet

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -445,6 +445,14 @@ module Spree
     # Enumerable of images adhering to the present_image_class interface
     class_name_attribute :image_attachment_module, default: 'Spree::Image::ActiveStorageAttachment'
 
+    # @!attribute [rw] allowed_image_mime_types
+    #
+    # Defines which MIME types are allowed for images
+    # `%w(image/jpeg image/jpg image/png image/gif).freeze` is the default.
+    #
+    # @return [Array]
+    class_name_attribute :allowed_image_mime_types, default: %w(image/jpeg image/jpg image/png image/gif).freeze
+
     # Allows switching attachment library for Taxon
     #
     # `Spree::Taxon::ActiveStorageAttachment`

--- a/core/lib/spree/testing_support/fixtures/file.txt
+++ b/core/lib/spree/testing_support/fixtures/file.txt
@@ -1,0 +1,1 @@
+This is a text file

--- a/core/spec/lib/search/base_spec.rb
+++ b/core/spec/lib/search/base_spec.rb
@@ -22,11 +22,12 @@ RSpec.describe Spree::Core::Search::Base do
 
   context "when include_images is included in the initialization params" do
     let(:params) { { include_images: true, keyword: @product1.name, taxon: @taxon.id } }
+    let(:image_file) { File.open(File.join('lib', 'spree', 'testing_support', 'fixtures', 'blank.jpg')) }
     subject { described_class.new(params).retrieve_products }
 
     before do
-      @product1.master.images.create(attachment_file_name: "Test", position: 2)
-      @product1.master.images.create(attachment_file_name: "Test1", position: 1)
+      @product1.master.images.create(attachment_file_name: 'test', attachment: image_file, position: 2)
+      @product1.master.images.create(attachment_file_name: 'test1', attachment: image_file, position: 1)
       @product1.reload
     end
 

--- a/core/spec/lib/search/base_spec.rb
+++ b/core/spec/lib/search/base_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 require 'spree/core/product_filters'
 
 RSpec.describe Spree::Core::Search::Base do
+  include ImageSpecHelper
   before do
     include Spree::Core::ProductFilters
     @taxon = create(:taxon, name: "Ruby on Rails")
@@ -22,7 +23,7 @@ RSpec.describe Spree::Core::Search::Base do
 
   context "when include_images is included in the initialization params" do
     let(:params) { { include_images: true, keyword: @product1.name, taxon: @taxon.id } }
-    let(:image_file) { File.open(File.join('lib', 'spree', 'testing_support', 'fixtures', 'blank.jpg')) }
+    let(:image_file) { open_image('blank.jpg') }
     subject { described_class.new(params).retrieve_products }
 
     before do

--- a/core/spec/models/spree/image_spec.rb
+++ b/core/spec/models/spree/image_spec.rb
@@ -3,6 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Spree::Image, type: :model do
+  include ImageSpecHelper
   it_behaves_like 'an attachment' do
     subject { create(:image) }
     let(:attachment_name) { :attachment }
@@ -10,19 +11,17 @@ RSpec.describe Spree::Image, type: :model do
   end
 
   it 'is valid when attachment has allowed content type' do
-    image = build(:image,
-                  attachment: File.open(File.join('lib', 'spree', 'testing_support', 'fixtures', 'blank.jpg')))
+    image = build(:image, attachment: open_image('blank.jpg'))
     expect(image).to be_valid
   end
 
   it 'is not valid when attachment has restricted content type' do
-    image = build(:image,
-                  attachment: File.open(File.join('lib', 'spree', 'testing_support', 'fixtures', 'file.txt')))
+    image = build(:image, attachment: open_image('file.txt'))
     expect(image).to_not be_valid
   end
 
   describe 'attachment details' do
-    let(:image_file) { File.open(File.join('lib', 'spree', 'testing_support', 'fixtures', 'blank.jpg')) }
+    let(:image_file) { open_image('blank.jpg') }
     subject { create(:image, attachment: image_file) }
 
     it 'returns if attachment is present' do

--- a/core/spec/models/spree/image_spec.rb
+++ b/core/spec/models/spree/image_spec.rb
@@ -9,6 +9,18 @@ RSpec.describe Spree::Image, type: :model do
     let(:default_style) { :product }
   end
 
+  it 'is valid when attachment has allowed content type' do
+    image = build(:image,
+                  attachment: File.open(File.join('lib', 'spree', 'testing_support', 'fixtures', 'blank.jpg')))
+    expect(image).to be_valid
+  end
+
+  it 'is not valid when attachment has restricted content type' do
+    image = build(:image,
+                  attachment: File.open(File.join('lib', 'spree', 'testing_support', 'fixtures', 'file.txt')))
+    expect(image).to_not be_valid
+  end
+
   describe 'attachment details' do
     let(:image_file) { File.open(File.join('lib', 'spree', 'testing_support', 'fixtures', 'blank.jpg')) }
     subject { create(:image, attachment: image_file) }

--- a/core/spec/support/image_spec_helper.rb
+++ b/core/spec/support/image_spec_helper.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module ImageSpecHelper
+  def open_image(image)
+    File.open(File.join('lib', 'spree', 'testing_support', 'fixtures', image))
+  end
+end

--- a/core/spec/support/shared_examples/attachment.rb
+++ b/core/spec/support/shared_examples/attachment.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples 'an attachment' do
+  include ImageSpecHelper
   context 'valid attachment' do
     before do
       subject.send(
         :"#{attachment_name}=",
-        File.open(File.join('lib', 'spree', 'testing_support', 'fixtures', 'blank.jpg'))
+        open_image('blank.jpg')
       )
     end
 


### PR DESCRIPTION
**Description**
<!--
  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

  Please include screenshots in case of visual changes to the frontend or backend sections of Solidus.

  If needed you can reference another PR or issue here, e.g.: Ref #4017 
  
-->
Ref #4017 

This PR aimed to solve the bugs described in Issue #4017 by implementing a validation for content type and to handle a FileNotFound error when ActiveStorage fails to upload to a remote service such as S3. 

The validation allows file types jpeg, png, jpg and gif. More file types can be added and removed by editing the accepted_image_types definition found in active_storage_attachment.rb. Validation tests have been added to the image_spec.rb in core.

The handling of the FileNotFound error maybe a temporary fix as we are aiming to discover another pathway to handle the exception and remove the invalid objects simultaneously. Currently when the error is raised on method call, it returns a corrupted image file path.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
