### PR TITLE
Add global Spree::Config.default_email_regexp

### DIFF
--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -150,6 +150,10 @@ module Spree
     #   @return [String] Two-letter ISO code of a {Spree::Country} to assumed as the country of an unidentified customer (default: "US")
     preference :default_country_iso, :string, default: 'US'
 
+    # @!attribute [rw] default_email_regexp
+    #   @return [Regexp] Regex to be used in email validations, for example in Spree::EmailValidator
+    preference :default_email_regexp, :regexp, default: URI::MailTo::EMAIL_REGEXP
+
     # @!attribute [rw] generate_api_key_for_all_roles
     #   @return [Boolean] Allow generating api key automatically for user
     #   at role_user creation for all roles. (default: +false+)

--- a/core/lib/spree/core/validators/email.rb
+++ b/core/lib/spree/core/validators/email.rb
@@ -13,9 +13,11 @@ module Spree
   #
   class EmailValidator < ActiveModel::EachValidator
     EMAIL_REGEXP = URI::MailTo::EMAIL_REGEXP
+    # Use Spree::Config.default_email_regexp instead
+    deprecate_constant :EMAIL_REGEXP
 
     def validate_each(record, attribute, value)
-      unless EMAIL_REGEXP.match? value
+      unless Spree::Config.default_email_regexp.match? value
         record.errors.add(attribute, :invalid, **{ value: value }.merge!(options))
       end
     end


### PR DESCRIPTION
This change adds a :default_email_regexp preference to be used by Spree::EmailValidator and also solidus_auth_devise, allowing the regex to be fully and easily customizable. With this introduction it will be possible to keep the Devise.email_regexp in sync with solidus's email validator regexp.

**Description**
<!--
  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

  Please include screenshots in case of visual changes to the frontend or backend sections of Solidus.

  If needed you can reference another PR or issue here, e.g.:
  Ref #ISSUE
-->

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
