### PR TITLE
Handle permalink attribute on product create

### DIFF
--- a/api/openapi/solidus-api.oas.yml
+++ b/api/openapi/solidus-api.oas.yml
@@ -6289,8 +6289,6 @@ components:
           type: string
         available_on:
           type: string
-        permalink:
-          type: string
         meta_description:
           type: string
         meta_keywords:

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -68,7 +68,7 @@ module Spree
     @@product_properties_attributes = [:property_name, :value, :position]
 
     @@product_attributes = [
-      :name, :description, :available_on, :discontinue_on, :permalink, :meta_description,
+      :name, :description, :available_on, :discontinue_on, :meta_description,
       :meta_keywords, :price, :sku, :deleted_at,
       :option_values_hash, :weight, :height, :width, :depth,
       :shipping_category_id, :tax_category_id,


### PR DESCRIPTION
**Description**
An ActiveModel::UnknownAttributeError error is seen when a product is being created with a permalink attribute.

The reason for this error is because the request contains permalink key that Rails ActiveRecord is looking for in Products table. This was the case in the past but in a [commit](https://github.com/solidusio/solidus/commit/d4d955017102f31980cc3cf3c0ca7ad9f5b053bd), permalink attribute in products was renamed to slug and moved to taxons model. Ideally, permalink attribute should have been removed from permitted_attributes.rb under @@product_attributes array. Looks like that was missed.

This PR removes the attribute from product's permitted attributes and from the document

This PR takes care of issue #[3988](https://github.com/solidusio/solidus/issues/3988)

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
~~-[ ] I have updated Guides and README accordingly to this change (if needed)~~
~~- [ ] I have added tests to cover this change (if needed)~~
~~- [ ] I have attached screenshots to this PR for visual changes (if needed)~~
