### PR TITLE
Bump removal horizon for 3.x deprecations

### DIFF
--- a/core/lib/spree/deprecation.rb
+++ b/core/lib/spree/deprecation.rb
@@ -3,7 +3,7 @@
 require 'active_support/deprecation'
 
 module Spree
-  Deprecation = ActiveSupport::Deprecation.new('3.0', 'Solidus')
+  Deprecation = ActiveSupport::Deprecation.new('4.0', 'Solidus')
 
   # This DeprecatedInstanceVariableProxy transforms instance variable to
   # deprecated instance variable.


### PR DESCRIPTION
**Description**

Now that we are close to the release of `3.0`, we need to change the deprecation horizon of our `Spree::Deprecation` class in order to print the right messages to users when we emit a deprecation warning.

This change will tell users that code deprecated using `Spree::Deprecation` will be removed in Solidus `4.0`.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
