### PR TITLE
Patch for FileNotFoundError bug on failed image downloads.

### DIFF
--- a/backend/spec/features/admin/products/edit/images_spec.rb
+++ b/backend/spec/features/admin/products/edit/images_spec.rb
@@ -69,6 +69,21 @@ describe "Product Images", type: :feature do
       expect(page).not_to have_field "image[alt]", with: "ruby on rails t-shirt"
     end
 
+    context 'Using Active Storage',
+            if: Spree::Config.image_attachment_module == Spree::Image::ActiveStorageAttachment do
+      it "should show a no image placeholder when images fail to download" do
+        click_link "new_image_link"
+        within_fieldset 'New Image' do
+          attach_file('image_attachment', file_path)
+        end
+
+        click_button "Update"
+        Spree::Image.first.attachment.blob.update(key: 11)
+        visit current_path
+        expect(page).to have_xpath("//img[contains(@src, 'assets/noimage/mini')]")
+      end
+    end
+
     context "with several variants" do
       it "should allow an admin to re-assign an image to another variant" do
         click_link "new_image_link"

--- a/core/app/models/concerns/spree/active_storage_adapter.rb
+++ b/core/app/models/concerns/spree/active_storage_adapter.rb
@@ -107,6 +107,8 @@ module Spree
 
     def url(style = default_style)
       attachment.url(style)
+    rescue ActiveStorage::FileNotFoundError
+      "noimage/#{style}.png"
     end
 
     def destroy_attachment(_name)


### PR DESCRIPTION
**Description**
This PR aimed to solve the Active::Storage::FileNotFoundError bug described in Issue #4017 by to handling FileNotFound error when ActiveStorage fails to download from a remote service such as S3.

In rare circumstances, an image would fail to upload to a third party storage service, causing the application to hard crash when trying to retrieve an image resource. This commit implements a fix to return a place holder image to alert the user of an error and also prevents the application from crashing. This fix will not, however, save any errors associated with the failed upload such as credential errors. This fix was tested by artificially changing the blob record to force
a FileNotFoundError.

The handling of the FileNotFound error maybe a temporary fix as we are aiming to discover another pathway to handle the exception and remove the invalid objects simultaneously. 

![image](https://user-images.githubusercontent.com/68167430/114581262-cb6fba80-9c3c-11eb-9c0e-1bf2c56d3ae6.png)

<!--
  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

  Please include screenshots in case of visual changes to the frontend or backend sections of Solidus.

  If needed you can reference another PR or issue here, e.g.:
  Ref #4017 
-->

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
