### PR TITLE
Load defaults for the latest Rails minor version in the dummy app

### DIFF
--- a/backend/spec/features/admin/products/edit/images_spec.rb
+++ b/backend/spec/features/admin/products/edit/images_spec.rb
@@ -78,7 +78,7 @@ describe "Product Images", type: :feature do
         end
 
         click_button "Update"
-        Spree::Image.first.attachment.blob.update(key: 11)
+        invalidate_attachment(Spree::Image.first.attachment)
         visit current_path
         expect(page).to have_xpath("//img[contains(@src, 'assets/noimage/mini')]")
       end
@@ -135,5 +135,13 @@ describe "Product Images", type: :feature do
       # ensure correct cell count
       expect(page).to have_css("thead th", count: 4)
     end
+  end
+
+  def invalidate_attachment(attachment)
+    blob = attachment.blob
+    blob.variant_records.each do |variant_record|
+      variant_record.update(variation_digest: SecureRandom.uuid)
+    end
+    blob.update(key: SecureRandom.uuid)
   end
 end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -490,7 +490,10 @@ module Spree
         raise CannotRebuildShipments.new(I18n.t('spree.cannot_rebuild_shipments_shipments_not_pending'))
       else
         shipments.destroy_all
-        self.shipments = Spree::Config.stock.coordinator_class.new(self).shipments
+        # TODO: We can use `self.shipments#=` instead of `#push` when
+        # https://github.com/rails/rails/issues/42102 is fixed and we deprecate
+        # Rails versions with the bug
+        shipments.push(*Spree::Config.stock.coordinator_class.new(self).shipments)
       end
     end
 

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -45,7 +45,6 @@ module Spree
 
     has_many :variants,
       -> { where(is_master: false).order(:position) },
-      inverse_of: :product,
       class_name: 'Spree::Variant'
 
     has_many :variants_including_master,

--- a/core/app/models/spree/stock/simple_coordinator.rb
+++ b/core/app/models/spree/stock/simple_coordinator.rb
@@ -73,11 +73,16 @@ module Spree
         packages = split_packages(packages)
 
         # Turn the Stock::Packages into a Shipment with rates
-        packages.map do |package|
+        shipments = packages.map do |package|
           shipment = package.shipment = package.to_shipment
           shipment.shipping_rates = Spree::Config.stock.estimator_class.new.shipping_rates(package)
           shipment
         end
+
+        # Make sure we don't add the proposed shipments to the order
+        order.shipments = order.shipments - shipments
+
+        shipments
       end
 
       def split_packages(initial_packages)

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -30,7 +30,7 @@ module Spree
     attr_writer :rebuild_vat_prices
     include Spree::DefaultPrice
 
-    belongs_to :product, -> { with_discarded }, touch: true, class_name: 'Spree::Product', inverse_of: :variants, optional: false
+    belongs_to :product, -> { with_discarded }, touch: true, class_name: 'Spree::Product', inverse_of: :variants_including_master, optional: false
     belongs_to :tax_category, class_name: 'Spree::TaxCategory', optional: true
 
     delegate :name, :description, :slug, :available_on, :discontinue_on, :discontinued?,

--- a/core/lib/spree/testing_support/dummy_app.rb
+++ b/core/lib/spree/testing_support/dummy_app.rb
@@ -46,6 +46,12 @@ module DummyApp
   end
 
   class Application < ::Rails::Application
+    config.load_defaults("#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}")
+    # TODO: Remove the three following settings once the codebase has been adapted
+    # to load_defaults
+    config.active_record.has_many_inversing = nil
+    config.active_storage.track_variants = nil
+    config.active_record.belongs_to_required_by_default = false
     config.eager_load = false
     config.cache_classes = true
     config.cache_store = :memory_store

--- a/core/lib/spree/testing_support/dummy_app.rb
+++ b/core/lib/spree/testing_support/dummy_app.rb
@@ -47,10 +47,8 @@ module DummyApp
 
   class Application < ::Rails::Application
     config.load_defaults("#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}")
-    # TODO: Remove the two following settings once the codebase has been adapted
-    # to load_defaults
+    # TODO: Remove once the codebase has been adapted to the new default
     config.active_record.has_many_inversing = nil
-    config.active_storage.track_variants = nil
     config.eager_load = false
     config.cache_classes = true
     config.cache_store = :memory_store

--- a/core/lib/spree/testing_support/dummy_app.rb
+++ b/core/lib/spree/testing_support/dummy_app.rb
@@ -47,8 +47,6 @@ module DummyApp
 
   class Application < ::Rails::Application
     config.load_defaults("#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}")
-    # TODO: Remove once the codebase has been adapted to the new default
-    config.active_record.has_many_inversing = nil
     config.eager_load = false
     config.cache_classes = true
     config.cache_store = :memory_store

--- a/core/lib/spree/testing_support/dummy_app.rb
+++ b/core/lib/spree/testing_support/dummy_app.rb
@@ -47,11 +47,10 @@ module DummyApp
 
   class Application < ::Rails::Application
     config.load_defaults("#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}")
-    # TODO: Remove the three following settings once the codebase has been adapted
+    # TODO: Remove the two following settings once the codebase has been adapted
     # to load_defaults
     config.active_record.has_many_inversing = nil
     config.active_storage.track_variants = nil
-    config.active_record.belongs_to_required_by_default = false
     config.eager_load = false
     config.cache_classes = true
     config.cache_store = :memory_store

--- a/core/spec/lib/search/variant_spec.rb
+++ b/core/spec/lib/search/variant_spec.rb
@@ -59,6 +59,7 @@ module Spree
           described_class.new(variant.sku, scope: Spree::Variant.in_stock).results
         ).to include variant
 
+        variant.stock_items.reload # See https://github.com/rails/rails/issues/42094
         variant.stock_items.each { |si| si.set_count_on_hand(0) }
         expect(
           described_class.new(variant.sku, scope: Spree::Variant.in_stock).results

--- a/core/spec/lib/spree/core/testing_support/dummy_app_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/dummy_app_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DummyApp do
+  it 'loads default from the Rails version in use' do
+    expect(
+      DummyApp::Application.config.loaded_config_version
+    ).to eq("#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}")
+  end
+end

--- a/core/spec/models/spree/adjustment_spec.rb
+++ b/core/spec/models/spree/adjustment_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Spree::Adjustment, type: :model do
   let!(:store) { create :store }
-  let(:order) { Spree::Order.new }
+  let(:order) { create :order }
   let(:line_item) { create :line_item, order: order }
 
   let(:adjustment) { Spree::Adjustment.create!(label: 'Adjustment', adjustable: order, order: order, amount: 5) }
@@ -43,7 +43,7 @@ RSpec.describe Spree::Adjustment, type: :model do
   end
 
   context '#currency' do
-    let(:order) { Spree::Order.new currency: 'JPY' }
+    let(:order) { create :order, currency: 'JPY' }
 
     it 'returns the adjustables currency' do
       expect(adjustment.currency).to eq 'JPY'
@@ -67,7 +67,7 @@ RSpec.describe Spree::Adjustment, type: :model do
     end
 
     context "with currency set to JPY" do
-      let(:order) { Spree::Order.new currency: 'JPY' }
+      let(:order) { create :order, currency: 'JPY' }
 
       context "when adjustable is set to an order" do
         it "displays in JPY" do

--- a/core/spec/models/spree/order_contents_spec.rb
+++ b/core/spec/models/spree/order_contents_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Spree::OrderContents, type: :model do
 
       it "ensure shipment calls update_amounts instead of order calling ensure_updated_shipments" do
         expect(subject.order).to_not receive(:ensure_updated_shipments)
-        expect(shipment).to receive(:update_amounts)
+        expect(shipment).to receive(:update_amounts).at_least(:once)
         subject.add(variant, 1, shipment: shipment)
       end
 

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Spree::Payment, type: :model do
   let(:refund_reason) { create(:refund_reason) }
 
   let(:gateway) do
-    gateway = Spree::PaymentMethod::BogusCreditCard.new(active: true, name: 'Bogus gateway')
+    gateway = Spree::PaymentMethod::BogusCreditCard.create!(active: true, name: 'Bogus gateway')
     allow(gateway).to receive_messages(source_required?: true)
     gateway
   end

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe Spree::Product, type: :model do
         it "should set deleted_at value" do
           product.discard
           expect(product.deleted_at).not_to be_nil
-          expect(product.variants_including_master).to all(be_discarded)
+          expect(product.variants_including_master.reload).to all(be_discarded)
         end
       end
     end

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -616,7 +616,7 @@ RSpec.describe Spree::Variant, type: :model do
       variant.discard
 
       expect(variant.images).to be_empty
-      expect(variant.stock_items).to be_empty
+      expect(variant.stock_items.reload).to be_empty
       expect(variant.prices).to be_empty
       expect(variant.currently_valid_prices).to be_empty
     end

--- a/frontend/spec/features/taxons_spec.rb
+++ b/frontend/spec/features/taxons_spec.rb
@@ -4,9 +4,9 @@ require 'spec_helper'
 
 describe "viewing products", type: :feature, inaccessible: true do
   let!(:taxonomy) { create(:taxonomy, name: "Category") }
-  let!(:super_clothing) { taxonomy.root.children.create(name: "Super Clothing") }
-  let!(:t_shirts) { super_clothing.children.create(name: "T-Shirts") }
-  let!(:xxl) { t_shirts.children.create(name: "XXL") }
+  let!(:super_clothing) { taxonomy.root.children.create!(name: "Super Clothing", taxonomy: taxonomy) }
+  let!(:t_shirts) { super_clothing.children.create!(name: "T-Shirts", taxonomy: taxonomy) }
+  let!(:xxl) { t_shirts.children.create!(name: "XXL", taxonomy: taxonomy) }
   let!(:product) do
     product = create(:product, name: "Superman T-Shirt")
     product.taxons << t_shirts


### PR DESCRIPTION
Before this change, the dummy app used in the test suite was not loading
any new default that Rails has added since 5.0.

However, we still use old defaults for three settings that make our test
suite fail. Each one of them will be worked out in individual commits.

See https://api.rubyonrails.org/classes/Rails/Application/Configuration.html#method-i-load_defaults

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
