### PR TITLE
Moving API attribute helpers to API config

### DIFF
--- a/api/app/helpers/spree/api/api_helpers.rb
+++ b/api/app/helpers/spree/api/api_helpers.rb
@@ -37,7 +37,16 @@ module Spree
         :variant_property_attributes
       ]
 
-      mattr_reader(*ATTRIBUTES)
+      ATTRIBUTES.each do |attribute|
+        define_method attribute do
+          Spree::Api::Config.send(attribute)
+        end
+
+        define_singleton_method attribute do
+          Spree::Deprecation.warn("Please use Spree::Api::Config::#{attribute} instead.")
+          Spree::Api::Config.send(attribute)
+        end
+      end
 
       def required_fields_for(model)
         required_fields = model._validators.select do |_field, validations|
@@ -51,142 +60,12 @@ module Spree
         required_fields
       end
 
-      @@product_attributes = [
-        :id, :name, :description, :available_on,
-        :slug, :meta_description, :meta_keywords, :shipping_category_id,
-        :taxon_ids, :total_on_hand, :meta_title
-      ]
-
-      @@product_property_attributes = [
-        :id, :product_id, :property_id, :value, :property_name
-      ]
-
-      @@variant_attributes = [
-        :id, :name, :sku, :weight, :height, :width, :depth, :is_master,
-        :slug, :description, :track_inventory
-      ]
-
-      @@variant_property_attributes = [
-        :id, :property_id, :value, :property_name
-      ]
-
-      @@image_attributes = [
-        :id, :position, :attachment_content_type, :attachment_file_name, :type,
-        :attachment_updated_at, :attachment_width, :attachment_height, :alt
-      ]
-
-      @@option_value_attributes = [
-        :id, :name, :presentation, :option_type_name, :option_type_id,
-        :option_type_presentation
-      ]
-
-      @@order_attributes = [
-        :id, :number, :item_total, :total, :ship_total, :state, :adjustment_total,
-        :user_id, :created_at, :updated_at, :completed_at, :payment_total,
-        :shipment_state, :payment_state, :email, :special_instructions, :channel,
-        :included_tax_total, :additional_tax_total, :display_included_tax_total,
-        :display_additional_tax_total, :tax_total, :currency,
-        :covered_by_store_credit, :display_total_applicable_store_credit,
-        :order_total_after_store_credit, :display_order_total_after_store_credit,
-        :total_applicable_store_credit, :display_total_available_store_credit,
-        :display_store_credit_remaining_after_capture, :canceler_id
-
-      ]
-
-      @@line_item_attributes = [:id, :quantity, :price, :variant_id]
-
-      @@option_type_attributes = [:id, :name, :presentation, :position]
-
-      @@payment_attributes = [
-        :id, :source_type, :source_id, :amount, :display_amount,
-        :payment_method_id, :state, :avs_response, :created_at,
-        :updated_at
-      ]
-
-      @@payment_method_attributes = [:id, :name, :description]
-
-      @@shipment_attributes = [:id, :tracking, :tracking_url, :number, :cost, :shipped_at, :state]
-
-      @@taxonomy_attributes = [:id, :name]
-
-      @@taxon_attributes = [
-        :id, :name, :pretty_name, :permalink, :parent_id,
-        :taxonomy_id
-      ]
-
-      @@inventory_unit_attributes = [
-        :id, :state, :variant_id, :shipment_id
-      ]
-
-      @@customer_return_attributes = [
-        :id, :number, :stock_location_id, :created_at, :updated_at
-      ]
-
-      @@return_authorization_attributes = [
-        :id, :number, :state, :order_id, :memo, :created_at, :updated_at
-      ]
-
-      @@address_attributes = [
-        :id, :name, :address1, :address2, :city, :zipcode, :phone, :company,
-        :alternative_phone, :country_id, :country_iso, :state_id, :state_name,
-        :state_text
-      ]
-
-      @@country_attributes = [:id, :iso_name, :iso, :iso3, :name, :numcode]
-
-      @@state_attributes = [:id, :name, :abbr, :country_id]
-
-      @@adjustment_attributes = [
-        :id, :source_type, :source_id, :adjustable_type, :adjustable_id,
-        :amount, :label, :promotion_code_id,
-        :finalized, :eligible, :created_at, :updated_at
-      ]
-
-      @@creditcard_attributes = [
-        :id, :month, :year, :cc_type, :last_digits, :name
-      ]
-
-      @@payment_source_attributes = [
-        :id, :month, :year, :cc_type, :last_digits, :name
-      ]
-
-      @@user_attributes = [:id, :email, :created_at, :updated_at]
-
-      @@property_attributes = [:id, :name, :presentation]
-
-      @@stock_location_attributes = [
-        :id, :name, :address1, :address2, :city, :state_id, :state_name,
-        :country_id, :zipcode, :phone, :active
-      ]
-
-      @@stock_movement_attributes = [:id, :quantity, :stock_item_id]
-
-      @@stock_item_attributes = [
-        :id, :count_on_hand, :backorderable, :stock_location_id,
-        :variant_id
-      ]
-
-      @@promotion_attributes = [
-        :id, :name, :description, :expires_at, :starts_at, :type, :usage_limit,
-        :match_policy, :advertise, :path
-      ]
-
-      @@store_attributes = [
-        :id, :name, :url, :meta_description, :meta_keywords, :seo_title,
-        :mail_from_address, :default_currency, :code, :default, :available_locales,
-        :bcc_email
-      ]
-
-      @@store_credit_history_attributes = [
-        :display_amount, :display_user_total_amount, :display_action,
-        :display_event_date, :display_remaining_amount
-      ]
-
       def variant_attributes
+        preference_attributes = Spree::Api::Config.variant_attributes
         if @current_user_roles&.include?("admin")
-          @@variant_attributes + [:cost_price]
+          preference_attributes + [:cost_price]
         else
-          @@variant_attributes
+          preference_attributes
         end
       end
 

--- a/api/lib/spree/api_configuration.rb
+++ b/api/lib/spree/api_configuration.rb
@@ -3,5 +3,133 @@
 module Spree
   class ApiConfiguration < Preferences::Configuration
     preference :requires_authentication, :boolean, default: true
+
+    preference :product_attributes, :array, default: [
+      :id, :name, :description, :available_on,
+      :slug, :meta_description, :meta_keywords, :shipping_category_id,
+      :taxon_ids, :total_on_hand, :meta_title
+    ]
+
+    preference :product_property_attributes, :array, default: [:id, :product_id, :property_id, :value, :property_name]
+
+    preference :variant_attributes, :array, default: [
+      :id, :name, :sku, :weight, :height, :width, :depth, :is_master,
+      :slug, :description, :track_inventory
+    ]
+
+    preference :image_attributes, :array, default: [
+      :id, :position, :attachment_content_type, :attachment_file_name, :type,
+      :attachment_updated_at, :attachment_width, :attachment_height, :alt
+    ]
+
+    preference :option_value_attributes, :array, default: [
+      :id, :name, :presentation, :option_type_name, :option_type_id,
+      :option_type_presentation
+    ]
+
+    preference :order_attributes, :array, default: [
+      :id, :number, :item_total, :total, :ship_total, :state, :adjustment_total,
+      :user_id, :created_at, :updated_at, :completed_at, :payment_total,
+      :shipment_state, :payment_state, :email, :special_instructions, :channel,
+      :included_tax_total, :additional_tax_total, :display_included_tax_total,
+      :display_additional_tax_total, :tax_total, :currency,
+      :covered_by_store_credit, :display_total_applicable_store_credit,
+      :order_total_after_store_credit, :display_order_total_after_store_credit,
+      :total_applicable_store_credit, :display_total_available_store_credit,
+      :display_store_credit_remaining_after_capture, :canceler_id
+    ]
+
+    preference :line_item_attributes, :array, default: [:id, :quantity, :price, :variant_id]
+
+    preference :option_type_attributes, :array, default: [:id, :name, :presentation, :position]
+
+    preference :payment_attributes, :array, default: [
+      :id, :source_type, :source_id, :amount, :display_amount,
+      :payment_method_id, :state, :avs_response, :created_at,
+      :updated_at
+    ]
+
+    preference :payment_method_attributes, :array, default: [:id, :name, :description]
+
+    preference :shipment_attributes, :array, default: [:id, :tracking, :tracking_url, :number, :cost, :shipped_at, :state]
+
+    preference :taxonomy_attributes, :array, default: [:id, :name]
+
+    preference :taxon_attributes, :array, default: [
+      :id, :name, :pretty_name, :permalink, :parent_id,
+      :taxonomy_id
+    ]
+
+    preference :address_attributes, :array, default: [
+      :id, :name, :address1, :address2, :city, :zipcode, :phone, :company,
+      :alternative_phone, :country_id, :country_iso, :state_id, :state_name,
+      :state_text
+    ]
+
+    preference :country_attributes, :array, default: [:id, :iso_name, :iso, :iso3, :name, :numcode]
+
+    preference :state_attributes, :array, default: [:id, :name, :abbr, :country_id]
+
+    preference :adjustment_attributes, :array, default: [
+      :id, :source_type, :source_id, :adjustable_type, :adjustable_id,
+      :amount, :label, :promotion_code_id,
+      :finalized, :eligible, :created_at, :updated_at
+    ]
+
+    preference :inventory_unit_attributes, :array, default: [
+      :id, :state, :variant_id, :shipment_id
+    ]
+
+    preference :customer_return_attributes, :array, default: [
+      :id, :number, :stock_location_id, :created_at, :updated_at
+    ]
+
+    preference :return_authorization_attributes, :array, default: [
+      :id, :number, :state, :order_id, :memo, :created_at, :updated_at
+    ]
+
+    preference :creditcard_attributes, :array, default: [
+      :id, :month, :year, :cc_type, :last_digits, :name
+    ]
+
+    preference :payment_source_attributes, :array, default: [
+      :id, :month, :year, :cc_type, :last_digits, :name
+    ]
+
+    preference :user_attributes, :array, default: [:id, :email, :created_at, :updated_at]
+
+    preference :property_attributes, :array, default: [:id, :name, :presentation]
+
+    preference :stock_location_attributes, :array, default: [
+      :id, :name, :address1, :address2, :city, :state_id, :state_name,
+      :country_id, :zipcode, :phone, :active
+    ]
+
+    preference :stock_movement_attributes, :array, default: [:id, :quantity, :stock_item_id]
+
+    preference :stock_item_attributes, :array, default: [
+      :id, :count_on_hand, :backorderable, :stock_location_id,
+      :variant_id
+    ]
+
+    preference :promotion_attributes, :array, default: [
+      :id, :name, :description, :expires_at, :starts_at, :type, :usage_limit,
+      :match_policy, :advertise, :path
+    ]
+
+    preference :store_attributes, :array, default: [
+      :id, :name, :url, :meta_description, :meta_keywords, :seo_title,
+      :mail_from_address, :default_currency, :code, :default, :available_locales,
+      :bcc_email
+    ]
+
+    preference :store_credit_history_attributes, :array, default: [
+      :display_amount, :display_user_total_amount, :display_action,
+      :display_event_date, :display_remaining_amount
+    ]
+
+    preference :variant_property_attributes, :array, default: [
+      :id, :property_id, :value, :property_name
+    ]
   end
 end

--- a/api/spec/helpers/api_helpers_spec.rb
+++ b/api/spec/helpers/api_helpers_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+RSpec.describe Spree::Api::ApiHelpers, type: :helper do
+  describe 'attributes access' do
+    Spree::Api::ApiHelpers::ATTRIBUTES.each do |attribute|
+      it "warns about deprecated access for #{attribute}" do
+        expect(Spree::Deprecation).to receive(:warn).
+          with("Please use Spree::Api::Config::#{attribute} instead.")
+
+        expect(Spree::Api::ApiHelpers.send(attribute)).to eq(
+          Spree::Api::Config.send(attribute)
+        )
+      end
+    end
+  end
+end

--- a/api/spec/requests/spree/api/products_controller_spec.rb
+++ b/api/spec/requests/spree/api/products_controller_spec.rb
@@ -7,7 +7,7 @@ module Spree
   describe Spree::Api::ProductsController, type: :request do
     let!(:product) { create(:product) }
     let!(:inactive_product) { create(:product, available_on: Time.current.tomorrow, name: "inactive") }
-    let(:base_attributes) { Api::ApiHelpers.product_attributes }
+    let(:base_attributes) { Spree::Api::Config.product_attributes }
     let(:show_attributes) { base_attributes.dup.push(:has_variants) }
     let(:new_attributes) { base_attributes }
 

--- a/api/spec/requests/spree/api/promotions_controller_spec.rb
+++ b/api/spec/requests/spree/api/promotions_controller_spec.rb
@@ -14,7 +14,7 @@ module Spree
         subject
         payload = HashWithIndifferentAccess.new(JSON.parse(response.body))
         expect(payload).to_not be_nil
-        Spree::Api::ApiHelpers.promotion_attributes.each do |attribute|
+        Spree::Api::Config.promotion_attributes.each do |attribute|
           expect(payload).to be_has_key(attribute)
         end
       end

--- a/api/spec/requests/spree/api/variants_controller_spec.rb
+++ b/api/spec/requests/spree/api/variants_controller_spec.rb
@@ -11,7 +11,7 @@ module Spree
       variant
     end
 
-    let!(:base_attributes) { Api::ApiHelpers.variant_attributes }
+    let!(:base_attributes) { Spree::Api::Config.variant_attributes }
     let!(:show_attributes) { base_attributes.dup.push(:in_stock, :display_price, :variant_properties) }
     let!(:new_attributes) { base_attributes }
 


### PR DESCRIPTION
Issue: https://github.com/solidusio/solidus/issues/4027

Edgeguides Pr: https://github.com/solidusio/edgeguides/pull/37

**Description**

As described in [this issue](https://github.com/solidusio/solidus/issues/4027) there is a problem with the way data is autoloaded when pushing new attributes in an initalizer.

A proposed change was to move the attributes location from the helper module to the api config class.

This PR follows this approach.

Albeit this PR does not change existing behavior, it introduces a deprecation when directly accessing attributes from the static helper methods.

To take advantage of the autoload fix, attributes in initializers should be set this way:

```ruby
Spree::Api::Config.configure do |config|
  config.user_attributes += [ :your_custom_attributes ]
end
```

Edgeguides has been updated accordingly.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
