### PR TITLE
Update defaults in dummy application

### DIFF
--- a/core/spec/rails_helper.rb
+++ b/core/spec/rails_helper.rb
@@ -37,7 +37,7 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = true
 
   config.before :suite do
-    FileUtils.rm_rf(Rails.configuration.storage_path)
+    FileUtils.rm_rf(Rails.configuration.active_storage.service_configurations[:test][:root]) unless ENV['DISABLE_ACTIVE_STORAGE']
     DatabaseCleaner.clean_with :truncation
   end
 


### PR DESCRIPTION
Here it's a description of the reason for each change. Keep in mind that
CI test against Rails 5.2 as the minimal version:

- serve_static_assets: Removed it. It's [not available since Rails
5.0](https://guides.rubyonrails.org/5_0_release_notes.html#railties-removals).

- public_file_server.enabled: Set explicitly to `true`. Even if it was
already `true`, a [real Rails application will default it to `false` in
the production environment unless a env variable
`RAILS_SERVE_STATIC_FILES` is
present](https://github.com/rails/rails/blob/f95c0b7e96eb36bc3efc0c5beffbb9e84ea664e4/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt#L27). This way it's less surprising.

- whiny_nils: Removed. It's [not available since Rails
4.1](https://guides.rubyonrails.org/4_1_release_notes.html#railties-removals).

- action_controller.allow_forgery_protection: Set to true to mimic
  production.

- action_controller.default_protect_from_forgery: Set to true to mimic
  production.

- action_controller.perform_caching: Set to true to mimic production.

- active_support.deprecation: Remove duplicated entry.

- action_mailer.delivery_job: Removed because `load_defaults` take care of
it.

- storage_path: Removed. It wasn't a Rails setting, but used as a
convenience. It was confusing.

- action_controller.include_all_helpers: Removed as it's already the
default.

- log_level: Added. It already defaulted to `:debug`, but a real Rails app
will default to `:info` in production. To make things less surprising
let's be explicit.

- action_mailer.perform_caching: Added to mimic production.

- i18n.fallbacks: Added to mimic production.

- active_record.dump_schema_after_migration: Added to mimic production and
for better performance.

- assets: No need to check whether it's a method on `config`.

See #4035

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
