### PR TITLE
Use symbols in polymorphic path for event_links

### DIFF
--- a/backend/app/controllers/spree/admin/resource_controller.rb
+++ b/backend/app/controllers/spree/admin/resource_controller.rb
@@ -187,7 +187,7 @@ class Spree::Admin::ResourceController < Spree::Admin::BaseController
                   .find_by!(self.class.parent_data[:find_by] => params["#{parent_model_name}_id"])
     instance_variable_set("@#{parent_model_name}", @parent)
   rescue ActiveRecord::RecordNotFound => e
-    resource_not_found(flash_class: e.model.constantize, redirect_url: spree.polymorphic_url([:admin, parent_model_name.pluralize]))
+    resource_not_found(flash_class: e.model.constantize, redirect_url: spree.polymorphic_url([:admin, parent_model_name.pluralize.to_sym]))
   end
 
   def parent?

--- a/backend/app/helpers/spree/admin/orders_helper.rb
+++ b/backend/app/helpers/spree/admin/orders_helper.rb
@@ -11,7 +11,7 @@ module Spree
           translated_event = t(event, scope: [:spree, :admin, :order, :events])
           links << button_to(
             translated_event,
-            [event, :admin, @order],
+            [event.to_sym, :admin, @order],
             method: :put,
             data: { confirm: t(:order_sure_want_to, event: translated_event, scope: :spree) }
           )


### PR DESCRIPTION
**Description**

Rails 6.0.3.7 introduced a security fix, that forces us to use symbols
in polymorphic paths.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change (if needed)