### PR TITLE
Updated decorator pathing for new applications

### DIFF
--- a/core/lib/generators/solidus/install/install_generator.rb
+++ b/core/lib/generators/solidus/install/install_generator.rb
@@ -102,16 +102,20 @@ module Solidus
       empty_directory "app/overrides"
     end
 
+    def create_decorators_directory
+      empty_directory "app/decorators"
+    end
+
     def configure_application
       application <<-RUBY
-    # Load application's model / class decorators
-    initializer 'spree.decorators' do |app|
-      config.to_prepare do
-        Dir.glob(Rails.root.join('app/**/*_decorator*.rb')) do |path|
-          require_dependency(path)
+      # Load application's model / class decorators
+      initializer 'spree.decorators' do |app|
+        config.to_prepare do
+          Dir.glob(Rails.root.join('app/decorators/**/*.rb')) do |path|
+            require_dependency(path)
+          end
         end
       end
-    end
       RUBY
 
       if !options[:enforce_available_locales].nil?

--- a/guides/source/developers/customizations/decorators.html.md
+++ b/guides/source/developers/customizations/decorators.html.md
@@ -1,14 +1,14 @@
 # Decorators
 
-Solidus autoloads any file in the `/app` directory that has the suffix
-`_decorator.rb`, just like any other Rails models or controllers. This allows
-you to [monkey patch][monkey-patch] Solidus functionality for your store.
+Solidus auto-loads any file in the `/app/decorators` directory, just like any
+other Rails models or controllers. This allows you to [monkey patch][monkey-patch]
+Solidus functionality for your store.
 
 For example, if you want to add a method to the `Spree::Order` model, you could
-create `/app/models/mystore/order_decorator.rb` with the following contents:
+create `/app/decorators/mystore/order.rb` with the following contents:
 
 ```ruby
-module MyStore::OrderDecorator
+module MyStore::Order
   def total
     super + BigDecimal(10.0)
   end
@@ -17,7 +17,7 @@ module MyStore::OrderDecorator
 end
 ```
 
-This creates a new module called `MyStore::OrderDecorator` that prepends its
+This creates a new module called `MyStore::Order` that prepends its
 methods early in the method lookup chain. So, for method calls on `Spree::Order`
 objects, the decorator's `total` method would override the original `total`
 method.
@@ -33,7 +33,7 @@ You'll need to define a special method in order to access some class-level
 methods
 
 ```ruby
-module MyStore::ProductDecorator
+module MyStore::Product
 
   # This is the place to define custom associations, delegations, scopes and
   # other ActiveRecord stuff


### PR DESCRIPTION
**Description**
The current functionality of finding decorators was by pulling files with the 'decorator' suffix in a file name. This seems redundant and forces modules to end with "Decorator." It makes more sense that decorators should be discovered based on their inclusion in the "app/decorators" sub-folder of the user's application. Updated guides to reflect name spacing changes.
<!--
  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

  Please include screenshots in case of visual changes to the frontend or backend sections of Solidus.

  If needed you can reference another PR or issue here, e.g.:
  Ref #ISSUE
-->

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
