### PR TITLE
Fix Spree::Promotion.has_actions scope

### DIFF
--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -47,7 +47,7 @@ module Spree
         where(table[:expires_at].eq(nil).or(table[:expires_at].gt(time)))
     end
     scope :has_actions, -> do
-      joins(:promotion_actions)
+      joins(:promotion_actions).distinct
     end
     scope :applied, -> { joins(:order_promotions).distinct }
 

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -82,6 +82,30 @@ RSpec.describe Spree::Promotion, type: :model do
     end
   end
 
+  describe '.has_actions' do
+    subject { described_class.has_actions }
+
+    let(:promotion) { create(:promotion, starts_at: Date.yesterday, name: "name1") }
+
+    before { promotion }
+
+    it "doesn't return promotion without actions" do
+      expect(subject).to be_empty
+    end
+
+    context 'when promotion has two actions' do
+      let(:promotion) { create(:promotion, :with_action, starts_at: Date.yesterday, name: "name1") }
+
+      before do
+        promotion.actions << Spree::Promotion::Actions::CreateAdjustment.new
+      end
+
+      it 'returns distinct promotion' do
+        expect(subject).to match [promotion]
+      end
+    end
+  end
+
   describe "#apply_automatically" do
     subject { build(:promotion) }
 


### PR DESCRIPTION
The scope would return multiple copies of the same promotion without
this change.

I hope this bug does not result in duplicate promotions being applied to orders. The bug is also present in 2.9.11, and might warrant a backport.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change (if needed)

