### PR TITLE
Add UUID to StoreCredit#generate_authorization_code

### DIFF
--- a/core/app/models/spree/store_credit.rb
+++ b/core/app/models/spree/store_credit.rb
@@ -150,7 +150,12 @@ class Spree::StoreCredit < Spree::PaymentSource
   end
 
   def generate_authorization_code
-    "#{id}-SC-#{Time.current.utc.strftime('%Y%m%d%H%M%S%6N')}"
+    [
+      id,
+      'SC',
+      Time.current.utc.strftime('%Y%m%d%H%M%S%6N'),
+      SecureRandom.uuid
+    ].join('-')
   end
 
   def editable?

--- a/core/spec/models/spree/store_credit_spec.rb
+++ b/core/spec/models/spree/store_credit_spec.rb
@@ -897,4 +897,12 @@ RSpec.describe Spree::StoreCredit do
       end
     end
   end
+
+  describe "#generate_authorization_code" do
+    it "doesn't rely on time for uniqueness" do
+      freeze_time do
+        expect(subject.generate_authorization_code).not_to eq(subject.generate_authorization_code)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes #4041 

The value returned by `StoreCredit#generate_authorization_code` depends on time, which means that it may not be unique when a store credit is saved more than once at the same moment. This is not very likely to happen, but not impossible at all.

By introducing a UUID into the code we can be sure that this code will end up being unique. The previous format of the code is retained, since there may be applications relying on it.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
