### PR TITLE
Add preferences to configure product and taxon images style

### DIFF
--- a/core/app/models/spree/image/active_storage_attachment.rb
+++ b/core/app/models/spree/image/active_storage_attachment.rb
@@ -12,13 +12,8 @@ module Spree::Image::ActiveStorageAttachment
     validate :supported_content_type
 
     has_attachment :attachment,
-                   styles: {
-                   mini: '48x48>',
-                   small: '400x400>',
-                   product: '680x680>',
-                   large: '1200x1200>'
-                 },
-                 default_style: :product
+                   styles: Spree::Config.product_image_styles,
+                   default_style: Spree::Config.product_image_style_default
 
     def supported_content_type
       unless attachment.content_type.in?(Spree::Config.allowed_image_mime_types)

--- a/core/app/models/spree/image/paperclip_attachment.rb
+++ b/core/app/models/spree/image/paperclip_attachment.rb
@@ -7,8 +7,8 @@ module Spree::Image::PaperclipAttachment
     validate :no_attachment_errors
 
     has_attached_file :attachment,
-                      styles: { mini: '48x48>', small: '400x400>', product: '680x680>', large: '1200x1200>' },
-                      default_style: :product,
+                      styles: Spree::Config.product_image_styles,
+                      default_style: Spree::Config.product_image_style_default,
                       default_url: 'noimage/:style.png',
                       url: '/spree/products/:id/:style/:basename.:extension',
                       path: ':rails_root/public/spree/products/:id/:style/:basename.:extension',

--- a/core/app/models/spree/taxon/active_storage_attachment.rb
+++ b/core/app/models/spree/taxon/active_storage_attachment.rb
@@ -6,8 +6,8 @@ module Spree::Taxon::ActiveStorageAttachment
 
   included do
     has_attachment :icon,
-                   styles: { mini: '32x32>', normal: '128x128>' },
-                   default_style: :mini
+                   styles: Spree::Config.taxon_image_styles,
+                   default_style: Spree::Config.taxon_image_style_default
     validate :icon_is_an_image
   end
 end

--- a/core/app/models/spree/taxon/paperclip_attachment.rb
+++ b/core/app/models/spree/taxon/paperclip_attachment.rb
@@ -5,14 +5,14 @@ module Spree::Taxon::PaperclipAttachment
 
   included do
     has_attached_file :icon,
-      styles: { mini: '32x32>', normal: '128x128>' },
-      default_style: :mini,
+      styles: Spree::Config.taxon_image_styles,
+      default_style: Spree::Config.taxon_image_style_default,
       url: '/spree/taxons/:id/:style/:basename.:extension',
       path: ':rails_root/public/spree/taxons/:id/:style/:basename.:extension',
       default_url: '/assets/default_taxon.png'
 
     validates_attachment :icon,
-      content_type: { content_type: %w[image/jpg image/jpeg image/png image/gif] }
+      content_type: { content_type: Spree::Config.allowed_image_mime_types }
   end
 
   def icon_present?

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -453,6 +453,46 @@ module Spree
     # @return [Array]
     class_name_attribute :allowed_image_mime_types, default: %w(image/jpeg image/jpg image/png image/gif).freeze
 
+    # @!attribute [rw] product_image_style_default
+    #
+    # Defines which style to default to when style is not provided
+    # :product is the default.
+    #
+    # @return [Symbol]
+    class_name_attribute :product_image_style_default, default: :product
+
+    # @!attribute [rw] product_image_styles
+    #
+    # Defines image styles/sizes hash for styles
+    # `{ mini: '48x48>',
+    #    small: '400x400>',
+    #    product: '680x680>',
+    #    large: '1200x1200>' } is the default.
+    #
+    # @return [Hash]
+    class_name_attribute :product_image_styles, default: { mini: '48x48>',
+                                                          small: '400x400>',
+                                                          product: '680x680>',
+                                                          large: '1200x1200>' }
+    # @!attribute [rw] taxon_image_style_default
+    #
+    # Defines which style to default to when style is not provided
+    # :mini is the default.
+    #
+    # @return [Symbol]
+    class_name_attribute :taxon_image_style_default, default: :mini
+
+    # @!attribute [rw] taxon_styles
+    #
+    # Defines taxon styles/sizes hash for styles
+    # `{ mini: '48x48>',
+    #    small: '400x400>',
+    #    product: '680x680>',
+    #    large: '1200x1200>' } is the default.
+    #
+    # @return [Hash]
+    class_name_attribute :taxon_image_styles, default: { mini: '32x32>', normal: '128x128>' }
+
     # Allows switching attachment library for Taxon
     #
     # `Spree::Taxon::ActiveStorageAttachment`


### PR DESCRIPTION
This commit adds Spree configuration options for styles, which will make
it easier to customize product and taxon image styles. Currently, the
user would have to create an override file or supersede the current
modules ActiveStorageAttachment for either class. This will make editing
styles clean and a single step process by allowing users to edit their
spree.rb configuration to modify these settings.

**Description**
<!--
  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

  Please include screenshots in case of visual changes to the frontend or backend sections of Solidus.

  If needed you can reference another PR or issue here, e.g.:
  Ref #ISSUE
-->

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
