### PR TITLE
Unhardcode admin base url in 'stock_location_stock_item' template

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/templates/stock_items/stock_location_stock_item.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/stock_items/stock_location_stock_item.hbs
@@ -1,5 +1,5 @@
 <td class="stock-location-name">
-  <a href="/admin/stock_locations/{{stockLocationId}}/stock_movements?q%5Bvariant_sku_eq%5D={{variantSku}}">
+  <a href="{{admin_url}}/stock_locations/{{stockLocationId}}/stock_movements?q%5Bvariant_sku_eq%5D={{variantSku}}">
     {{stockLocationName}}
   </a>
 </td>

--- a/backend/spec/features/admin/products/stock_management_spec.rb
+++ b/backend/spec/features/admin/products/stock_management_spec.rb
@@ -45,7 +45,7 @@ describe "Product Stock", type: :feature do
     end
 
     it "contains a link to recent stock movements", js: true do
-      expect(page).to have_link(nil, href: "/admin/stock_locations/#{stock_location.id}/stock_movements?q%5Bvariant_sku_eq%5D=#{variant.sku}")
+      expect(page).to have_link(nil, href: "http://#{page.server.host}:#{page.server.port}/admin/stock_locations/#{stock_location.id}/stock_movements?q%5Bvariant_sku_eq%5D=#{variant.sku}")
     end
 
     it "can create a positive stock adjustment", js: true do


### PR DESCRIPTION
If Solidus is not mounted at '/', the stock movements link on the product stock tab is broken.

![image](https://user-images.githubusercontent.com/84380/118409813-f2cf0280-b694-11eb-9181-7b97e5248a8c.png)


**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change (if needed)
