### PR TITLE
Fix customer return validation for return items without inventory units

### DIFF
--- a/core/app/models/spree/customer_return.rb
+++ b/core/app/models/spree/customer_return.rb
@@ -40,7 +40,8 @@ module Spree
     # Temporarily tie a customer_return to one order
     def order
       return nil if return_items.blank?
-      return_items.first.inventory_unit.order
+
+      return_items.first.inventory_unit&.order
     end
 
     def fully_reimbursed?
@@ -65,7 +66,7 @@ module Spree
     end
 
     def return_items_belong_to_same_order
-      if return_items.reject{ |return_item| return_item.inventory_unit.order_id == order_id }.any?
+      if return_items.reject{ |return_item| return_item.inventory_unit&.order_id == order_id }.any?
         errors.add(:base, I18n.t('spree.return_items_cannot_be_associated_with_multiple_orders'))
       end
     end

--- a/core/spec/models/spree/customer_return_spec.rb
+++ b/core/spec/models/spree/customer_return_spec.rb
@@ -50,6 +50,18 @@ RSpec.describe Spree::CustomerReturn, type: :model do
           expect(subject).to eq true
         end
       end
+
+      context "inventory is not present" do
+        before do
+          customer_return.return_items.clear
+
+          customer_return.return_items << Spree::ReturnItem.new
+        end
+
+        it "is invalid" do
+          expect(subject).to eq false
+        end
+      end
     end
   end
 


### PR DESCRIPTION
**Description**
Fixes customer return validation for return items without inventory units.

Fixes #4059

**Checklist:**
- [X] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [X] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
