### PR TITLE
Accept static_model_preferences class name as string

### DIFF
--- a/core/lib/spree/preferences/static_model_preferences.rb
+++ b/core/lib/spree/preferences/static_model_preferences.rb
@@ -36,9 +36,14 @@ module Spree
       end
 
       def add(klass, name, preferences)
+        constantized_klass = klass.try(:constantize) || klass
+
         # We use class name instead of class to allow reloading in dev
-        raise "Static model preference '#{name}' on #{klass} is already defined" if @store[klass.to_s][name]
-        @store[klass.to_s][name] = Definition.new(klass, preferences)
+        if @store[constantized_klass.to_s][name]
+          raise "Static model preference '#{name}' on #{constantized_klass} is already defined"
+        end
+
+        @store[constantized_klass.to_s][name] = Definition.new(constantized_klass, preferences)
       end
 
       def for_class(klass)

--- a/core/spec/models/spree/preferences/static_model_preferences_spec.rb
+++ b/core/spec/models/spree/preferences/static_model_preferences_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 module Spree
   RSpec.describe Preferences::StaticModelPreferences do
     let(:preference_class) do
-      Class.new do
+      MyFakeStaticModelPreferencesClass ||= Class.new do
         include Preferences::Preferable
         preference :color, :string
       end
@@ -20,6 +20,11 @@ module Spree
     it "can store preferences" do
       subject.add(preference_class, 'my_definition', {})
       # just testing that it was added here
+      expect(definitions).to have_key('my_definition')
+    end
+
+    it "can add with string class name" do
+      subject.add(preference_class.to_s, 'my_definition', {})
       expect(definitions).to have_key('my_definition')
     end
 


### PR DESCRIPTION
**Description**
Make it possible to accept `static_model_preferences` class name as `string`.

Fixes #4040

**Checklist:**
- [X] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [X] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)