### PR TITLE
Move currently_valid_prices to a method

### DIFF
--- a/core/app/models/concerns/spree/default_price.rb
+++ b/core/app/models/concerns/spree/default_price.rb
@@ -13,6 +13,13 @@ module Spree
         autosave: true
     end
 
+    # Returns `#prices` prioritized for being considered as default price
+    #
+    # @return [ActiveRecord::Relation<Spree::Price>]
+    def currently_valid_prices
+      prices.currently_valid
+    end
+
     def find_or_build_default_price
       default_price || build_default_price(Spree::Config.default_pricing_options.desired_attributes)
     end

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -24,7 +24,6 @@ module Spree
       stock_items.discard_all
       images.destroy_all
       prices.discard_all
-      currently_valid_prices.discard_all
     end
 
     attr_writer :rebuild_vat_prices
@@ -53,13 +52,6 @@ module Spree
     has_many :images, -> { order(:position) }, as: :viewable, dependent: :destroy, class_name: "Spree::Image"
 
     has_many :prices,
-      class_name: 'Spree::Price',
-      dependent: :destroy,
-      inverse_of: :variant,
-      autosave: true
-
-    has_many :currently_valid_prices,
-      -> { currently_valid },
       class_name: 'Spree::Price',
       dependent: :destroy,
       inverse_of: :variant,

--- a/core/lib/spree/core/search/base.rb
+++ b/core/lib/spree/core/search/base.rb
@@ -51,7 +51,7 @@ module Spree
           # separate queries most of the time but opt for a join as soon as any
           # `where` constraints affecting joined tables are added to the search;
           # which is the case as soon as a taxon is added to the base scope.
-          scope = scope.preload(master: :currently_valid_prices)
+          scope = scope.preload(master: :prices)
           scope = scope.preload(master: :images) if @properties[:include_images]
           scope
         end

--- a/core/spec/models/spree/price_spec.rb
+++ b/core/spec/models/spree/price_spec.rb
@@ -96,6 +96,33 @@ RSpec.describe Spree::Price, type: :model do
         expect(price.country).to eq(country)
       end
     end
+
+    describe '.currently_valid' do
+      it 'prioritizes first those associated to a country' do
+        price_1 = create(:price, country: create(:country))
+        price_2 = create(:price, country: nil) { |price| price.touch }
+
+        result = described_class.currently_valid
+
+        expect(
+          result.index(price_1) < result.index(price_2)
+        ).to be(true)
+      end
+
+      context 'when country data is the same' do
+        it 'prioritizes first those recently updated' do
+          price_1 = create(:price, country: nil)
+          price_2 = create(:price, country: nil)
+          price_1.touch
+
+          result = described_class.currently_valid
+
+          expect(
+            result.index(price_1) < result.index(price_2)
+          ).to be(true)
+        end
+      end
+    end
   end
 
   describe "#currency" do

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -678,14 +678,12 @@ RSpec.describe Spree::Variant, type: :model do
 
       expect(variant.stock_items).not_to be_empty
       expect(variant.prices).not_to be_empty
-      expect(variant.currently_valid_prices).not_to be_empty
 
       variant.discard
 
       expect(variant.images).to be_empty
       expect(variant.stock_items.reload).to be_empty
       expect(variant.prices).to be_empty
-      expect(variant.currently_valid_prices).to be_empty
     end
 
     describe 'default_price' do

--- a/core/spec/support/concerns/default_price.rb
+++ b/core/spec/support/concerns/default_price.rb
@@ -41,4 +41,18 @@ RSpec.shared_examples_for "default_price" do
       it { is_expected.to be_falsey }
     end
   end
+
+  describe '#currently_valid_prices' do
+    it 'returns prioritized prices' do
+      price_1 = create(:price, country: create(:country))
+      price_2 = create(:price, country: nil)
+      variant = create(:variant, prices: [price_1, price_2])
+
+      result = variant.currently_valid_prices
+
+      expect(
+        result.index(price_1) < result.index(price_2)
+      ).to be(true)
+    end
+  end
 end


### PR DESCRIPTION
Having `currently_valid_prices` as an association between `Variant` and
`Price` made it a source of inconsistencies with the undecorated
`prices` association:

```
Spree::Variant.new.tap do |v|
  v.currently_valid_prices << Spree::Price.new
end.prices.any? # => false
```

Note: Extraction from #3994


**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
