### PR TITLE
Fix detecting exec js version by adding minimal requirement for autoprefixer-rails

### DIFF
--- a/backend/solidus_backend.gemspec
+++ b/backend/solidus_backend.gemspec
@@ -32,6 +32,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'responders'
   s.add_dependency 'sassc-rails'
 
-  s.add_dependency 'autoprefixer-rails'
+  s.add_dependency 'autoprefixer-rails', '~> 10.2', '>= 10.2.5.1'
   s.add_dependency 'handlebars_assets', '~> 0.23'
 end


### PR DESCRIPTION
Fixes #4055

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
