### PR TITLE
Deprecate callback setting variant price from master

### DIFF
--- a/api/spec/requests/spree/api/products_controller_spec.rb
+++ b/api/spec/requests/spree/api/products_controller_spec.rb
@@ -126,7 +126,7 @@ module Spree
 
       it "gets a single product" do
         product.master.images.create!(attachment: image("blank.jpg"))
-        product.variants.create!
+        product.variants.create!(price: 50)
         product.variants.first.images.create!(attachment: image("blank.jpg"))
         product.set_property("spree", "rocks")
         product.taxons << create(:taxon)

--- a/api/spec/requests/spree/api/variants_controller_spec.rb
+++ b/api/spec/requests/spree/api/variants_controller_spec.rb
@@ -300,7 +300,7 @@ module Spree
       end
 
       it "can create a new variant" do
-        post spree.api_product_variants_path(product), params: { variant: { sku: "12345" } }
+        post spree.api_product_variants_path(product), params: { variant: { sku: "12345", price: "10" } }
         expect(json_response).to have_attributes(new_attributes)
         expect(response.status).to eq(201)
         expect(json_response["sku"]).to eq("12345")
@@ -314,7 +314,8 @@ module Spree
           post spree.api_product_variants_path(product), params: {
             variant: {
               sku: "12345",
-              option_value_ids: option_values.map(&:id)
+              option_value_ids: option_values.map(&:id),
+              price: "10"
             }
           }
         end.to change { Spree::OptionValuesVariant.count }.by(2)
@@ -325,6 +326,7 @@ module Spree
           post spree.api_product_variants_path(product), params: {
             variant: {
               sku: "12345",
+              price: 25,
               options: [{
                 name: 'Color',
                 value: 'White'

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -58,7 +58,9 @@ module Spree
       autosave: true
 
     before_validation :set_cost_currency
-    before_validation :set_price, if: -> { product && product.master }
+    before_validation :set_price, if: (proc do
+      Spree::Config[:require_master_price] && !is_master? && price.nil? && product && product.master
+    end)
     before_validation :build_vat_prices, if: -> { rebuild_vat_prices? || new_record? && product }
 
     validates :product, presence: true
@@ -379,7 +381,14 @@ module Spree
 
     # Ensures a new variant takes the product master price when price is not supplied
     def set_price
-      self.price = product.master.price if price.nil? && Spree::Config[:require_master_price] && !is_master?
+      Spree::Deprecation.warn(
+        "The creation of the default price for a variant through the automatic
+        inheritance from its master variant's default price is deprecated.
+        Please, provide the amount for the price manually. E.g., use
+        `product.variants.create(price: 50)` instead of
+        `product.variants.create'"
+      )
+      self.price = product.master.price
     end
 
     def check_price

--- a/core/lib/spree/core/product_duplicator.rb
+++ b/core/lib/spree/core/product_duplicator.rb
@@ -52,6 +52,7 @@ module Spree
     def duplicate_variant(variant)
       new_variant = variant.dup
       new_variant.sku = "COPY OF #{new_variant.sku}"
+      new_variant.price = variant.price
       new_variant.deleted_at = nil
       new_variant.option_values = variant.option_values.map { |option_value| option_value }
       new_variant

--- a/core/spec/models/spree/product_duplicator_spec.rb
+++ b/core/spec/models/spree/product_duplicator_spec.rb
@@ -76,8 +76,8 @@ module Spree
       let(:option_value1) { create(:option_value, name: "OptionValue1", option_type: option_type) }
       let(:option_value2) { create(:option_value, name: "OptionValue2", option_type: option_type) }
 
-      let!(:variant1) { create(:variant, product: product, option_values: [option_value1]) }
-      let!(:variant2) { create(:variant, product: product, option_values: [option_value2]) }
+      let!(:variant1) { create(:variant, product: product, price: 10, option_values: [option_value1]) }
+      let!(:variant2) { create(:variant, product: product, price: 10, option_values: [option_value2]) }
 
       it "will duplciate the variants" do
         # will change the count by 3, since there will be a master variant as well

--- a/sample/db/samples/variants.rb
+++ b/sample/db/samples/variants.rb
@@ -30,184 +30,218 @@ variants = [
     product: solidus_tshirt,
     option_values: [small, blue],
     sku: "SOL-00003",
-    cost_price: 17
+    cost_price: 17,
+    price: 25
   },
   {
     product: solidus_tshirt,
     option_values: [small, black],
     sku: "SOL-00002",
-    cost_price: 17
+    cost_price: 17,
+    price: 25
   },
   {
     product: solidus_tshirt,
     option_values: [small, white],
     sku: "SOL-00004",
-    cost_price: 17
+    cost_price: 17,
+    price: 25
   },
   {
     product: solidus_tshirt,
     option_values: [medium, blue],
     sku: "SOL-00005",
-    cost_price: 17
+    cost_price: 17,
+    price: 25
   },
   {
     product: solidus_tshirt,
     option_values: [large, white],
     sku: "SOL-00006",
-    cost_price: 17
+    cost_price: 17,
+    price: 25
   },
   {
     product: solidus_tshirt,
     option_values: [large, black],
     sku: "SOL-00007",
-    cost_price: 17
+    cost_price: 17,
+    price: 25
   },
   {
     product: solidus_tshirt,
     option_values: [extra_large, blue],
     sku: "SOL-0008",
-    cost_price: 17
+    cost_price: 17,
+    price: 25
   },
   {
     product: solidus_long,
     option_values: [small, black],
     sku: "SOL-LS02",
-    cost_price: 17
+    cost_price: 17,
+    price: 25
   },
   {
     product: solidus_long,
     option_values: [small, white],
     sku: "SOL-LS01",
-    cost_price: 17
+    cost_price: 17,
+    price: 25
   },
   {
     product: solidus_long,
     option_values: [small, blue],
     sku: "SOL-LS03",
-    cost_price: 17
+    cost_price: 17,
+    price: 25
   },
   {
     product: solidus_long,
     option_values: [medium, white],
     sku: "SOL-LS04",
-    cost_price: 17
+    cost_price: 17,
+    price: 25
   },
   {
     product: solidus_long,
     option_values: [medium, black],
     sku: "SOL-LS05",
-    cost_price: 17
+    cost_price: 17,
+    price: 25
   },
   {
     product: solidus_long,
     option_values: [medium, blue],
     sku: "SOL-LS06",
-    cost_price: 17
+    cost_price: 17,
+    price: 25
   },
   {
     product: solidus_long,
     option_values: [large, white],
     sku: "SOL-LS07",
-    cost_price: 17
+    cost_price: 17,
+    price: 25
   },
   {
     product: solidus_long,
     option_values: [large, black],
     sku: "SOL-LS08",
-    cost_price: 17
+    cost_price: 17,
+    price: 25
   },
   {
     product: solidus_long,
     option_values: [large, blue],
     sku: "SOL-LS09",
-    cost_price: 17
+    cost_price: 17,
+    price: 25
   },
   {
     product: solidus_womens_tshirt,
     option_values: [small, black],
     sku: "SOL-WM001",
-    cost_price: 17
+    cost_price: 17,
+    price: 25
   },
   {
     product: solidus_womens_tshirt,
     option_values: [small, blue],
     sku: "SOL-WM002",
-    cost_price: 17
+    cost_price: 17,
+    price: 25
   },
   {
     product: solidus_womens_tshirt,
     option_values: [small, white],
     sku: "SOL-WM003",
-    cost_price: 17
+    cost_price: 17,
+    price: 25
   },
   {
     product: solidus_womens_tshirt,
     option_values: [medium, blue],
     sku: "SOL-WM004",
-    cost_price: 17
+    cost_price: 17,
+    price: 25
   },
   {
     product: solidus_womens_tshirt,
     option_values: [medium, white],
     sku: "SOL-WM005",
-    cost_price: 17
+    cost_price: 17,
+    price: 25
   },
   {
     product: solidus_womens_tshirt,
     option_values: [medium, black],
     sku: "SOL-WM006",
-    cost_price: 17
+    cost_price: 17,
+    price: 25
   }
 ]
 
 masters = {
   solidus_tote => {
     sku: "SOL-TOT01",
-    cost_price: 17
+    cost_price: 17,
+    price: 25
   },
   ruby_tote => {
     sku: "RUB-TOT01",
-    cost_price: 17
+    cost_price: 17,
+    price: 25
   },
   solidus_snapback_cap => {
     sku: "SOL-SNC01",
-    cost_price: 17
+    cost_price: 17,
+    price: 25
   },
   solidus_tshirt => {
     sku: "SOL-00001",
-    cost_price: 17
+    cost_price: 17,
+    price: 25
   },
   solidus_long => {
     sku: "SOL-LS00",
-    cost_price: 17
+    cost_price: 17,
+    price: 25
   },
   solidus_hoodie => {
     sku: "SOL-HD00",
-    cost_price: 27
+    cost_price: 27,
+    price: 25
   },
   ruby_hoodie => {
     sku: "RUB-HD01",
-    cost_price: 27
+    cost_price: 27,
+    price: 25
   },
   ruby_hoodie_zip => {
     sku: "RUB-HD00",
-    cost_price: 27
+    cost_price: 27,
+    price: 25
   },
   ruby_polo => {
     sku: "RUB-PL01",
-    cost_price: 23
+    cost_price: 23,
+    price: 25
   },
   solidus_mug => {
     sku: "SOL-MG01",
-    cost_price: 7
+    cost_price: 7,
+    price: 25
   },
   ruby_mug => {
     sku: "RUB-MG01",
-    cost_price: 7
+    cost_price: 7,
+    price: 25
   },
   solidus_womens_tshirt => {
     sku: "SOL-WM00",
-    cost_price: 17
+    cost_price: 17,
+    price: 25
   }
 }
 


### PR DESCRIPTION
This simplifies logic, and it can be seen as preparatory work to propose
to the user the inheritance of all, and not just the default, prices
from master when creating a new variant.

Extracted from #3994 

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
