### PR TITLE
Permit return_items_attributes return_reason_id

### DIFF
--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -51,7 +51,13 @@ module Spree
       :month, :year, :expiry, :first_name, :last_name, :name
     ]
 
-    @@customer_return_attributes = [:stock_location_id, return_items_attributes: [:id, :inventory_unit_id, :return_authorization_id, :returned, :amount, :reception_status_event, :acceptance_status, :exchange_variant_id, :resellable]]
+    @@customer_return_attributes = [
+      :stock_location_id, return_items_attributes: [
+        :id, :inventory_unit_id, :return_authorization_id, :returned, :amount,
+        :reception_status_event, :acceptance_status, :exchange_variant_id,
+        :resellable, :return_reason_id
+      ]
+    ]
 
     @@image_attributes = [:alt, :attachment, :position, :viewable_type, :viewable_id]
 


### PR DESCRIPTION
When creating a new customer return, the admin interface allows to edit the return reason for return items, but the parameter was rejected by the controller since it was actually not permitted, thus preventing the editing of that field.

<img width="917" alt="Screen Shot 2021-05-25 at 9 24 46 AM" src="https://user-images.githubusercontent.com/141220/119458142-b8243480-bd3c-11eb-838e-3650244b796d.png">

<img width="687" alt="Screen Shot 2021-05-25 at 9 25 25 AM" src="https://user-images.githubusercontent.com/141220/119458170-c07c6f80-bd3c-11eb-8816-506726fec6fb.png">

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
