### PR TITLE
Change frontend to allow multiple variants

### DIFF
--- a/frontend/app/views/spree/products/_cart_form.html.erb
+++ b/frontend/app/views/spree/products/_cart_form.html.erb
@@ -7,7 +7,7 @@
         <ul>
           <% @product.variants_and_option_values_for(current_pricing_options).each_with_index do |variant, index| %>
             <li>
-              <%= radio_button_tag "variant_id", variant.id, index == 0, 'data-price' => variant.price_for_options(current_pricing_options)&.money %>
+              <%= radio_button_tag "variants[][variant_id]", variant.id, index == 0, 'data-price' => variant.price_for_options(current_pricing_options)&.money %>
               <%= label_tag "variant_id_#{ variant.id }" do %>
                 <span class="variant-description">
                   <%= variant_options variant %>
@@ -25,7 +25,7 @@
         </ul>
       </div>
     <% else %>
-      <%= hidden_field_tag "variant_id", @product.master.id %>
+      <%= hidden_field_tag "variants[][variant_id]", @product.master.id %>
     <% end %>
 
     <% if @product.price_for_options(current_pricing_options) and !@product.price.nil? %>
@@ -49,7 +49,7 @@
         </div>
 
         <div class="add-to-cart">
-          <%= number_field_tag :quantity, 1, class: 'title', min: 1 %>
+          <%= number_field_tag "variants[][quantity]", 1, class: 'title', min: 1 %>
           <%= button_tag class: 'large primary', id: 'add-to-cart-button', type: :submit do %>
             <%= t('spree.add_to_cart') %>
           <% end %>

--- a/frontend/spec/controllers/spree/orders_controller_ability_spec.rb
+++ b/frontend/spec/controllers/spree/orders_controller_ability_spec.rb
@@ -24,7 +24,7 @@ module Spree
       context '#populate' do
         it 'should check if user is authorized for :update' do
           expect(controller).to receive(:authorize!).with(:update, order, token)
-          post :populate, params: { variant_id: variant.id, token: token }
+          post :populate, params: { variants: [variant_id: variant.id], token: token }
         end
       end
 

--- a/frontend/spec/features/quantity_promotions_spec.rb
+++ b/frontend/spec/features/quantity_promotions_spec.rb
@@ -80,7 +80,7 @@ RSpec.feature "Quantity Promotions", js: true do
     # Add a different product to our cart with quantity of 2.
     visit spree.root_path
     click_link "E-11"
-    fill_in "quantity", with: "2"
+    fill_in "variants[][quantity]", with: "2"
     click_button "Add To Cart"
 
     # We now have 5 items total, so discount should increase.


### PR DESCRIPTION
Hello there! 😄

Before, the front-end _cart_form partial and OrdersController#populate
only allowed for one variant to be sent. This changes that behaviour
to allow for multiple variants, which increases flexibility for
custom front-ends where add-ons can be included on the product page.

The old parameters :variant_id and :quantity are still allowed,
however gives a deprecation warning. The new parameter is:
`variants: [{ :variant_id, :quantity }]`
The _cart_form partial and other specs that reference #populate
have been updated to use this.

**Description**
PR for issue #3977. 

1. Currently, this PR allows the use of old parameters(`:variant_id` and `:quantity`), however would it be better to remove them, and to only have the new parameter :variants?
2. If do wish to keep it, is there something more appropriate than raising a `Spree:Deprecation` warning? (Pretty sure this is not its intended use)
3. Couldn't see any documentation that needs updating. However, could it be a good idea to add more documentation about adding custom-front-end pages and also include about how you can add add-ons based on this PR? (maybe even a new documentation page)

Also note, there are similar tests because I kept the old parameters(`:variant_id` and `:quantity`).

Example on how you can have add-ons through checkboxes:

```  
  <% add_ons = Spree::Variant.first(2) %>
  <% add_ons.each do |variant|%>
    <li>
      <%= "Add on?" %>
      <%= check_box_tag "variants[][variant_id]", variant.id %>
      <%= "Quantity:" %>
      <%= number_field_tag "variants[][quantity]", 1, class: 'title', min: 1 %>
    </li>
  <% end %>
```

![add on](https://user-images.githubusercontent.com/76776099/119533299-fd208900-bd85-11eb-9ed1-a36ec6d28436.PNG)
![cart](https://user-images.githubusercontent.com/76776099/119533315-014ca680-bd86-11eb-8814-0e389f7f8981.PNG)

_Note, you also do not need to have the quantity input on add-ons if you wish it to always be set at 1._

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)

First Solidus PR 😊
