### PR TITLE
Backport #4080 to Solidus 3.0

### DIFF
--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -51,7 +51,13 @@ module Spree
       :month, :year, :expiry, :first_name, :last_name, :name
     ]
 
-    @@customer_return_attributes = [:stock_location_id, return_items_attributes: [:id, :inventory_unit_id, :return_authorization_id, :returned, :amount, :reception_status_event, :acceptance_status, :exchange_variant_id, :resellable]]
+    @@customer_return_attributes = [
+      :stock_location_id, return_items_attributes: [
+        :id, :inventory_unit_id, :return_authorization_id, :returned, :amount,
+        :reception_status_event, :acceptance_status, :exchange_variant_id,
+        :resellable, :return_reason_id
+      ]
+    ]
 
     @@image_attributes = [:alt, :attachment, :position, :viewable_type, :viewable_id]
 


### PR DESCRIPTION
This PR backports https://github.com/solidusio/solidus/pull/4080 to Solidus 3.0.

When creating a new customer return, the admin interface allows to edit the return reason for return items, but the parameter was rejected by the controller since it was actually not permitted, thus preventing the editing of that field.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
