### PR TITLE
Fix broken URL in customer-flow guide

### DIFF
--- a/guides/source/developers/getting-started/customer-flow.html.md
+++ b/guides/source/developers/getting-started/customer-flow.html.md
@@ -68,7 +68,7 @@ Customer adds the product to their cart.
   - The `tax_category_id` for each item is set according to the [tax
     category][tax-categories] of each item in the cart.
 
-[spree-order]: overview.html
+[spree-order]: ../orders/overview.html
 [spree-variant]: ../products-and-variants/variants.html
 [tax-categories]: ../taxation/overview.html#tax-categories
 


### PR DESCRIPTION
Fix a 404/broken URL on the [Customer flow](https://guides.solidus.io/developers/getting-started/customer-flow.html) guide page. I believe that the `overview.html` link was supposed to point to the [overview page](https://guides.solidus.io/developers/orders/overview.html) about `Spree::Order`. This PR would fix that and allow the URL to be consistent with the other `Spree` URLs on the page.