### PR TITLE
[v2.11] Fix app and tests to work with `ActiveRecord.has_many_inverse`

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -584,7 +584,7 @@ module Spree
         raise CannotRebuildShipments.new(I18n.t('spree.cannot_rebuild_shipments_shipments_not_pending'))
       else
         shipments.destroy_all
-        self.shipments = Spree::Config.stock.coordinator_class.new(self).shipments
+        shipments.push(*Spree::Config.stock.coordinator_class.new(self).shipments)
       end
     end
 

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -49,7 +49,6 @@ module Spree
 
     has_many :variants,
       -> { where(is_master: false).order(:position) },
-      inverse_of: :product,
       class_name: 'Spree::Variant'
 
     has_many :variants_including_master,

--- a/core/app/models/spree/stock/simple_coordinator.rb
+++ b/core/app/models/spree/stock/simple_coordinator.rb
@@ -73,11 +73,16 @@ module Spree
         packages = split_packages(packages)
 
         # Turn the Stock::Packages into a Shipment with rates
-        packages.map do |package|
+        shipments = packages.map do |package|
           shipment = package.shipment = package.to_shipment
           shipment.shipping_rates = Spree::Config.stock.estimator_class.new.shipping_rates(package)
           shipment
         end
+
+        # Make sure we don't add the proposed shipments to the order
+        order.shipments = order.shipments - shipments
+
+        shipments
       end
 
       def split_packages(initial_packages)

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -30,7 +30,7 @@ module Spree
     attr_writer :rebuild_vat_prices
     include Spree::DefaultPrice
 
-    belongs_to :product, -> { with_discarded }, touch: true, class_name: 'Spree::Product', inverse_of: :variants, optional: false
+    belongs_to :product, -> { with_discarded }, touch: true, class_name: 'Spree::Product', inverse_of: :variants_including_master, optional: false
     belongs_to :tax_category, class_name: 'Spree::TaxCategory', optional: true
 
     delegate :name, :description, :slug, :available_on, :discontinue_on, :discontinued?,

--- a/core/lib/spree/testing_support/dummy_app.rb
+++ b/core/lib/spree/testing_support/dummy_app.rb
@@ -45,6 +45,7 @@ module DummyApp
   end
 
   class Application < ::Rails::Application
+    config.has_many_inverse = true
     config.eager_load = false
     config.cache_classes = true
     config.cache_store = :memory_store

--- a/core/spec/lib/search/variant_spec.rb
+++ b/core/spec/lib/search/variant_spec.rb
@@ -59,6 +59,7 @@ module Spree
           described_class.new(variant.sku, scope: Spree::Variant.in_stock).results
         ).to include variant
 
+        variant.stock_items.reload # See https://github.com/rails/rails/issues/42094
         variant.stock_items.each { |si| si.set_count_on_hand(0) }
         expect(
           described_class.new(variant.sku, scope: Spree::Variant.in_stock).results

--- a/core/spec/models/spree/adjustment_spec.rb
+++ b/core/spec/models/spree/adjustment_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Spree::Adjustment, type: :model do
   let!(:store) { create :store }
-  let(:order) { Spree::Order.new }
+  let(:order) { create :order }
   let(:line_item) { create :line_item, order: order }
 
   let(:adjustment) { Spree::Adjustment.create!(label: 'Adjustment', adjustable: order, order: order, amount: 5) }
@@ -43,7 +43,7 @@ RSpec.describe Spree::Adjustment, type: :model do
   end
 
   context '#currency' do
-    let(:order) { Spree::Order.new currency: 'JPY' }
+    let(:order) { create :order, currency: 'JPY' }
 
     it 'returns the adjustables currency' do
       expect(adjustment.currency).to eq 'JPY'
@@ -67,7 +67,7 @@ RSpec.describe Spree::Adjustment, type: :model do
     end
 
     context "with currency set to JPY" do
-      let(:order) { Spree::Order.new currency: 'JPY' }
+      let(:order) { create :order, currency: 'JPY' }
 
       context "when adjustable is set to an order" do
         it "displays in JPY" do

--- a/core/spec/models/spree/order_contents_spec.rb
+++ b/core/spec/models/spree/order_contents_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Spree::OrderContents, type: :model do
 
       it "ensure shipment calls update_amounts instead of order calling ensure_updated_shipments" do
         expect(subject.order).to_not receive(:ensure_updated_shipments)
-        expect(shipment).to receive(:update_amounts)
+        expect(shipment).to receive(:update_amounts).at_least(:once)
         subject.add(variant, 1, shipment: shipment)
       end
 

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Spree::Payment, type: :model do
   let(:refund_reason) { create(:refund_reason) }
 
   let(:gateway) do
-    gateway = Spree::PaymentMethod::BogusCreditCard.new(active: true, name: 'Bogus gateway')
+    gateway = Spree::PaymentMethod::BogusCreditCard.create!(active: true, name: 'Bogus gateway')
     allow(gateway).to receive_messages(source_required?: true)
     gateway
   end

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe Spree::Product, type: :model do
         it "should set deleted_at value" do
           product.discard
           expect(product.deleted_at).not_to be_nil
-          expect(product.variants_including_master).to all(be_discarded)
+          expect(product.variants_including_master.reload).to all(be_discarded)
         end
       end
     end

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -697,7 +697,7 @@ RSpec.describe Spree::Variant, type: :model do
       variant.discard
 
       expect(variant.images).to be_empty
-      expect(variant.stock_items).to be_empty
+      expect(variant.stock_items.reload).to be_empty
       expect(variant.prices).to be_empty
       expect(variant.currently_valid_prices).to be_empty
     end


### PR DESCRIPTION
Backports 55bd0e4

Rails 6.1 added a new default `has_many_inversing` (see
https://github.com/rails/rails/pull/34533 &
https://github.com/rails/rails/pull/37429), which is enabled by default
on new applications. This setting broke some tests and created a couple
of bugs on Solidus. This commit should fix all of this. CI will only
examine the case when the new setting is enabled, but a local run
confirmed the suite is green when it's off.

A couple of the modifications introduced are attributable to two
different bugs in Rails discovered during the process:

- https://github.com/rails/rails/issues/42102 forces us to use
  `Spree::Order#shipments#push` instead of `Spree::Order#shipments#=` when
  the proposed shipments get created from the order.
- https://github.com/rails/rails/issues/42094 only applies to a rare
  corner case, but it hit us in the test case `takes into account a
  passed in scope` for `Spree::Core::Search::Variant`.

We also fixed two bugs on our side:

- `Spree::Variant#product` Rails association was configured as the
  inverse of `Spree::Product#variants`. However,
  `Spree::Product#variants` has a custom scope which filters out master
  variants
  (https://github.com/solidusio/solidus/blob/2ea829645b00fcedd5bfd69e045bddab7f40beb9/core/app/models/spree/product.rb#L47).
  Instead, `Spree::Product#variants_including_master` is now used.
- `Spree::Stock::SimpleCoordinator#build_shipments` is meant to build
  shipments presented as an option to the user. To calculate their
  associated shipping rates, it delegates the shipments to
  `Spree::Stock::Estimator`. This service needs to know the order
  instance those shipments would be assigned to. With the current
  implementation, this information is taken from the shipment itself as
  it's already associated to that order when it's initialized on
  `Spree::Stock::Package`
  (https://github.com/solidusio/solidus/blob/2ea829645b00fcedd5bfd69e045bddab7f40beb9/core/app/models/spree/stock/package.rb#L127).
  Before the `has_many_inversing` feature, this initialization wasn't
  reflected in the inverse association `Spree::Order#shipments`, but
  it's no longer the case. For this reason, after we have calculated the
  shipping rates, we need to remove the shipping instances through
  `order.shipments = order.shipments - shipment`. Follow-up work could
  clean this up if we pass the order as a parameter to the estimator.
  Still, it would have backward compatibility issues for user-created
  estimators as the interface would change. The following snippet
  isolates the issue:

```ruby
require 'bundler/inline'

gemfile(true) do
  source 'https://rubygems.org'
  gem 'activerecord', '6.1.3.1'
  gem 'sqlite3'
end

require 'active_record'

ActiveRecord::Base.has_many_inversing = true
ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: 'bug.db')

ActiveRecord::Schema.define do
  create_table :parents, force: true do |t|
    t.timestamps
  end
  create_table :nodes, force: true do |t|
    t.references :parent, foreign_key: false
    t.timestamps
  end
end

class Parent < ActiveRecord::Base
  has_many :nodes, inverse_of: :parent
end

class Node < ActiveRecord::Base
  belongs_to :parent, inverse_of: :nodes
end

require 'minitest/autorun'

class BugTest < Minitest::Test
  def test_with_has_many_inversing # IT SUCCEEDS
    parent = Parent.new
    parent.save

    Node.new(parent: parent)

    assert_equal(
      1,
      parent.nodes.size
    )
  end

  def test_without_has_many_inversing # IT FAILS
    ActiveRecord::Base.has_many_inversing = false

    parent = Parent.new
    parent.save

    Node.new(parent: parent)

    assert_equal(
      1,
      parent.nodes.size
    )

    ActiveRecord::Base.has_many_inversing = true
  end
end
```

Other than that, other minor modifications done in the test suite
include:

- A few`#reload` calls are needed to refresh the new and improved cache.
- Some parent records need to be persisted before creating one of their
  children. We haven't investigated this point further. It could be due
  to some undocumented change of behavior in Rails or another minor bug.
