### PR TITLE
Make clearer default answer in prompt

### DIFF
--- a/core/lib/generators/solidus/install/install_generator.rb
+++ b/core/lib/generators/solidus/install/install_generator.rb
@@ -132,7 +132,7 @@ module Solidus
         Solidus has a default authentication extension that uses Devise.
         You can find more info at https://github.com/solidusio/solidus_auth_devise.
 
-        Would you like to install it? (y/n)"))
+        Would you like to install it? (Y/n)"))
 
         @plugins_to_be_installed << 'solidus_auth_devise'
         @plugin_generators_to_run << 'solidus:auth:install'


### PR DESCRIPTION
The install generator adds `solidus_auth_devise`to the stack by default.
I.e., the gem is installed when carriage return is pressed without
explicitly typing `y` or `n`. The most common convention is to make the
default answer capitalized.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
