### PR TITLE
Prevent UI crash on FileNotFound errors with Active Storage

### DIFF
--- a/api/app/views/spree/api/images/_image.json.jbuilder
+++ b/api/app/views/spree/api/images/_image.json.jbuilder
@@ -3,5 +3,5 @@
 json.(image, *image_attributes)
 json.(image, :viewable_type, :viewable_id)
 Spree::Image.attachment_definitions[:attachment][:styles].each do |key, _value|
-  json.set! "#{key}_url", image.attachment.url(key)
+  json.set! "#{key}_url", image.url(key)
 end

--- a/core/app/models/concerns/spree/active_storage_adapter/attachment.rb
+++ b/core/app/models/concerns/spree/active_storage_adapter/attachment.rb
@@ -59,6 +59,10 @@ module Spree
         analyze unless analyzed?
 
         @attachment.metadata
+      rescue ActiveStorage::FileNotFoundError => error
+        logger.error("#{error} - Image id: #{attachment.record.id} is corrupted or cannot be found")
+
+        { identified: nil, width: nil, height: nil, analyzed: true }
       end
 
       def styles_to_transformations(styles)


### PR DESCRIPTION
**Description**
In a previous PR #4026, a fix was implemented to prevent an application from crashing by capturing an exception and providing a replacement image to prevent a non-operable UI. In issue #4095 it was found that the implemented fix did not capture all failure points that may be caused by a corrupt or FileNotFound issue.

This commit adds the ability for the application to catch missing images with Active Storage during an API call should a file become corrupt or deleted without removing the record. This compliments PR #4026 which prevented the same error on the backend. The change will return a json image package with attributes equal to nil and noimage replacements if an
image cannot be sourced. This should be back-ported to 3.0 if cleared for merging. 

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
