### PR TITLE
Simplify fetching order to calculate rates

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -144,7 +144,7 @@ module Spree
       # StockEstimator.new assigment below will replace the current shipping_method
       original_shipping_method_id = shipping_method.try!(:id)
 
-      new_rates = Spree::Config.stock.estimator_class.new.shipping_rates(to_package)
+      new_rates = Spree::Config.stock.estimator_class.new(order).shipping_rates(to_package)
 
       # If one of the new rates matches the previously selected shipping
       # method, select that instead of the default provided by the estimator.
@@ -163,7 +163,7 @@ module Spree
     end
 
     def select_shipping_method(shipping_method)
-      estimator = Spree::Config.stock.estimator_class.new
+      estimator = Spree::Config.stock.estimator_class.new(order)
       rates = estimator.shipping_rates(to_package, false)
       rate = rates.detect { |detected| detected.shipping_method_id == shipping_method.id }
       rate.selected = true

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -144,7 +144,7 @@ module Spree
       # StockEstimator.new assigment below will replace the current shipping_method
       original_shipping_method_id = shipping_method.try!(:id)
 
-      new_rates = Spree::Config.stock.estimator_class.new(order).shipping_rates(to_package)
+      new_rates = Spree::Config.stock.estimator(order).shipping_rates(to_package)
 
       # If one of the new rates matches the previously selected shipping
       # method, select that instead of the default provided by the estimator.
@@ -163,7 +163,7 @@ module Spree
     end
 
     def select_shipping_method(shipping_method)
-      estimator = Spree::Config.stock.estimator_class.new(order)
+      estimator = Spree::Config.stock.estimator(order)
       rates = estimator.shipping_rates(to_package, false)
       rate = rates.detect { |detected| detected.shipping_method_id == shipping_method.id }
       rate.selected = true

--- a/core/app/models/spree/stock/estimator.rb
+++ b/core/app/models/spree/stock/estimator.rb
@@ -27,7 +27,7 @@ module Spree
         elsif package.shipment.order && order.nil?
           @order = package.shipment.order
         end
-        
+
         rates = calculate_shipping_rates(package)
         rates.select! { |rate| rate.shipping_method.available_to_users? } if frontend_only
         choose_default_shipping_rate(rates)

--- a/core/app/models/spree/stock/estimator.rb
+++ b/core/app/models/spree/stock/estimator.rb
@@ -8,6 +8,9 @@ module Spree
       class OrderRequired < StandardError; end
 
       def initialize(order = nil)
+        Spree::Deprecation.warn('A Spree::Order is required as an argument,
+          please initialize with Spree::Stock::Estimator.new(order),
+          Spree::Stock::Estimator.new will throw an ArgumentError after deprecation')
         @order = order
       end
 
@@ -20,7 +23,7 @@ module Spree
       #   descending cost, with the least costly marked "selected"
       def shipping_rates(package, frontend_only = true)
         raise ShipmentRequired if package.shipment.nil?
-        raise OrderRequired if package.shipment.order.nil? && @order.nil?
+        raise OrderRequired if package.shipment.order.nil? && order.nil?
 
         if order && package.shipment.order.nil?
           package.shipment.order = order

--- a/core/app/models/spree/stock/simple_coordinator.rb
+++ b/core/app/models/spree/stock/simple_coordinator.rb
@@ -75,7 +75,7 @@ module Spree
         # Turn the Stock::Packages into a Shipment with rates
         shipments = packages.map do |package|
           shipment = package.shipment = package.to_shipment
-          shipment.shipping_rates = Spree::Config.stock.estimator_class.new(order).shipping_rates(package)
+          shipment.shipping_rates = Spree::Config.stock.estimator(order).shipping_rates(package)
           shipment
         end
 

--- a/core/app/models/spree/stock/simple_coordinator.rb
+++ b/core/app/models/spree/stock/simple_coordinator.rb
@@ -75,7 +75,7 @@ module Spree
         # Turn the Stock::Packages into a Shipment with rates
         shipments = packages.map do |package|
           shipment = package.shipment = package.to_shipment
-          shipment.shipping_rates = Spree::Config.stock.estimator_class.new.shipping_rates(package)
+          shipment.shipping_rates = Spree::Config.stock.estimator_class.new(order).shipping_rates(package)
           shipment
         end
 

--- a/core/lib/spree/core/stock_configuration.rb
+++ b/core/lib/spree/core/stock_configuration.rb
@@ -19,6 +19,17 @@ module Spree
         @estimator_class.constantize
       end
 
+      def estimator(order = nil)
+        begin
+          estimator_class.new(order)
+        rescue ArgumentError => e
+          Spree::Deprecation.warn('A Spree::Order is required as an argument
+            to the estimator class, please initialize with Spree::Stock::Estimator.new(order),
+            Spree::Stock::Estimator.new will throw an ArgumentError after deprecation')
+          estimator_class.new
+        end
+      end
+
       def location_filter_class
         @location_filter_class ||= '::Spree::Stock::LocationFilter::Active'
         @location_filter_class.constantize

--- a/core/lib/spree/core/stock_configuration.rb
+++ b/core/lib/spree/core/stock_configuration.rb
@@ -20,14 +20,12 @@ module Spree
       end
 
       def estimator(order = nil)
-        begin
           estimator_class.new(order)
-        rescue ArgumentError => e
+        rescue ArgumentError
           Spree::Deprecation.warn('A Spree::Order is required as an argument
             to the estimator class, please initialize with Spree::Stock::Estimator.new(order),
             Spree::Stock::Estimator.new will throw an ArgumentError after deprecation')
           estimator_class.new
-        end
       end
 
       def location_filter_class

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -197,7 +197,7 @@ RSpec.describe Spree::Shipment, type: :model do
       before { allow(shipment).to receive(:can_get_rates?){ true } }
 
       it 'should request new rates, and maintain shipping_method selection' do
-        expect(Spree::Stock::Estimator).to receive(:new).with(no_args).and_return(mock_estimator)
+        expect(Spree::Stock::Estimator).to receive(:new).with(shipment.order).and_return(mock_estimator)
         allow(shipment).to receive_messages(shipping_method: shipping_method2)
 
         expect(shipment.refresh_rates).to eq(shipping_rates)
@@ -205,7 +205,7 @@ RSpec.describe Spree::Shipment, type: :model do
       end
 
       it 'should handle no shipping_method selection' do
-        expect(Spree::Stock::Estimator).to receive(:new).with(no_args).and_return(mock_estimator)
+        expect(Spree::Stock::Estimator).to receive(:new).with(shipment.order).and_return(mock_estimator)
         allow(shipment).to receive_messages(shipping_method: nil)
         expect(shipment.refresh_rates).to eq(shipping_rates)
         expect(shipment.reload.selected_shipping_rate).not_to be_nil

--- a/core/spec/models/spree/stock/estimator_spec.rb
+++ b/core/spec/models/spree/stock/estimator_spec.rb
@@ -35,7 +35,7 @@ module Spree
 
         context 'initialized with an order' do
           subject { Estimator.new(order) }
-          before { package.shipment.order = nil }  
+          before { package.shipment.order = nil }
 
           it 'uses the order from the initializer' do
             expect(subject.shipping_rates(package).first.cost).to eq 4

--- a/core/spec/models/spree/stock/estimator_spec.rb
+++ b/core/spec/models/spree/stock/estimator_spec.rb
@@ -33,6 +33,15 @@ module Spree
           end
         end
 
+        context 'initialized with an order' do
+          subject { Estimator.new(order) }
+          before { package.shipment.order = nil }  
+
+          it 'uses the order from the initializer' do
+            expect(subject.shipping_rates(package).first.cost).to eq 4
+          end
+        end
+
         context 'without an order' do
           before { package.shipment.order = nil }
           it 'raises an error' do

--- a/core/spec/models/spree/stock/simple_coordinator_spec.rb
+++ b/core/spec/models/spree/stock/simple_coordinator_spec.rb
@@ -15,6 +15,13 @@ module Spree
           subject.shipments
         end
 
+        it 'allows estimator class be initialized without an order' do
+          expect(Spree::Config.stock.estimator_class).to receive(:new).with(order).and_raise(ArgumentError)
+          expect(Spree::Config.stock).to receive(:estimator_class).exactly(3).and_call_original
+          expect(Spree::Config.stock.estimator_class).to receive(:new).with(no_args).and_call_original
+          subject.shipments
+        end
+
         it 'uses the configured stock location filter' do
           expect(Spree::Config.stock).to receive(:location_filter_class).and_call_original
           subject.shipments
@@ -262,4 +269,11 @@ module Spree
       end
     end
   end
+end
+
+class CustomEstimator
+  def shipping_rates(package) 
+    [] 
+  end
+  def shipments;end
 end

--- a/core/spec/models/spree/stock/simple_coordinator_spec.rb
+++ b/core/spec/models/spree/stock/simple_coordinator_spec.rb
@@ -270,10 +270,3 @@ module Spree
     end
   end
 end
-
-class CustomEstimator
-  def shipping_rates(package) 
-    [] 
-  end
-  def shipments;end
-end


### PR DESCRIPTION
**Description**

resolves #4046 
<!--
  `Spree::Stock::Estimator` was using `shipment.package.order` but passing in order to `Spree::Stock::Estimator` makes the lookup for order simpler without referencing complicated AR caching.

-->

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
