### PR TITLE
Fix admin portugues locale

### DIFF
--- a/backend/vendor/assets/javascripts/solidus_admin/select2_locales/select2_locale_pt.js
+++ b/backend/vendor/assets/javascripts/solidus_admin/select2_locales/select2_locale_pt.js
@@ -4,7 +4,7 @@
 (function ($) {
     "use strict";
 
-    $.fn.select2.locales['pt-PT'] = {
+    $.fn.select2.locales['pt'] = {
         formatNoMatches: function () { return "Nenhum resultado encontrado"; },
         formatInputTooShort: function (input, min) { var n = min - input.length; return "Introduza " + n + " car" + (n == 1 ? "ácter" : "acteres"); },
         formatInputTooLong: function (input, max) { var n = input.length - max; return "Apague " + n + " car" + (n == 1 ? "ácter" : "acteres"); },
@@ -13,5 +13,5 @@
         formatSearching: function () { return "A pesquisar…"; }
     };
 
-    $.extend($.fn.select2.defaults, $.fn.select2.locales['pt-PT']);
+    $.extend($.fn.select2.defaults, $.fn.select2.locales['pt']);
 })(jQuery);


### PR DESCRIPTION
**Description**
When changing the admin backend language to Português (PT), it will look for the file select2_locale_pt-PT.js that does not exist.

Outpus the error
`The asset "solidus_admin/select2_locales/select2_locale_pt.js" is not present in the asset pipeline.`

To Reproduce:
1. Open the admin backend
2. Select Português (PT) in the language selection menu at the bottom right

It is looking for the right file. The file select2_locale_pt-PT.js must be renamed to select2_locale_pt.js and the two references "pt-PT" must be changed to "pt"

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
