### PR TITLE
Ignore discarded prices on Variant#default_price

### DIFF
--- a/core/app/models/concerns/spree/default_price.rb
+++ b/core/app/models/concerns/spree/default_price.rb
@@ -33,7 +33,7 @@ module Spree
     # Select from {#prices} the one to be considered as the default
     #
     # This method works with the in-memory association, so non-persisted prices
-    # are taken into account. Discarded prices are also considered.
+    # are taken into account.
     #
     # A price is a candidate to be considered as the default when it meets
     # {Spree::Variant.default_price_attributes} criteria. When more than one candidate is
@@ -46,7 +46,7 @@ module Spree
     def default_price
       prioritized_default(
         prices_meeting_criteria_to_be_default(
-          (prices + prices.with_discarded).uniq
+          prices
         )
       )
     end

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -269,14 +269,6 @@ RSpec.describe Spree::Variant, type: :model do
 
       expect(variant.default_price.attributes).to eq(price.attributes)
     end
-
-    it 'includes discarded prices' do
-      variant = create(:variant)
-      price = create(:price, variant: variant, currency: 'USD')
-      price.discard
-
-      expect(variant.default_price).to eq(price)
-    end
   end
 
   describe '#default_price_or_build' do
@@ -779,30 +771,6 @@ RSpec.describe Spree::Variant, type: :model do
       expect(variant.images).to be_empty
       expect(variant.stock_items.reload).to be_empty
       expect(variant.prices).to be_empty
-    end
-
-    describe 'default_price' do
-      let!(:previous_variant_price) { variant.default_price }
-
-      it "should discard default_price" do
-        variant.discard
-        variant.reload
-        expect(previous_variant_price.reload).to be_discarded
-      end
-
-      it "should keep its price if deleted" do
-        variant.discard
-        variant.reload
-        expect(variant.default_price).to eq(previous_variant_price)
-      end
-
-      context 'when loading with pre-fetching of default_price' do
-        it 'also keeps the previous price' do
-          variant.discard
-          reloaded_variant = Spree::Variant.with_discarded.find_by(id: variant.id)
-          expect(reloaded_variant.default_price).to eq(previous_variant_price)
-        end
-      end
     end
   end
 


### PR DESCRIPTION
**Description**

Fixes bug where discarded prices were taken into account in order to
tell the default price for a variant.

The rationale behind the previous behavior was to be able to render a
price when discarded products are included in the backend products
listing page (see 'Show deleted' checkbox near the top-right edge). It
was introduced in commit 87cef09.

However, this logic was incorrect in two ways:

- It affected non-discarded variants, where we don't want to consider
  discarded prices.
- Even for discarded variants, it could lead to display the wrong
  information. As all prices get discarded when a variant is discarded,
  there's no guarantee that the one that is rendered was the previously
  considered as the default.

The list of products on the backend will render the price field for
discarded products as blank. In case we want to track default prices, we
should add a flag to uniquely identify them.

Extracted from #3994


**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
