### PR TITLE
Rename currently_valid to prioritized_for_default

### DIFF
--- a/backend/app/controllers/spree/admin/prices_controller.rb
+++ b/backend/app/controllers/spree/admin/prices_controller.rb
@@ -10,12 +10,12 @@ module Spree
 
         @search = @product.prices.accessible_by(current_ability, :index).ransack(params[:q])
         @master_prices = @search.result
-          .currently_valid
+          .prioritized_for_default
           .for_master
           .order(:variant_id, :country_iso, :currency)
           .page(params[:page]).per(Spree::Config.admin_variants_per_page)
         @variant_prices = @search.result
-          .currently_valid
+          .prioritized_for_default
           .for_variant
           .order(:variant_id, :country_iso, :currency)
           .page(params[:page]).per(Spree::Config.admin_variants_per_page)

--- a/core/app/models/concerns/spree/default_price.rb
+++ b/core/app/models/concerns/spree/default_price.rb
@@ -17,8 +17,8 @@ module Spree
     # Returns `#prices` prioritized for being considered as default price
     #
     # @return [ActiveRecord::Relation<Spree::Price>]
-    def currently_valid_prices
-      prices.currently_valid
+    def prioritized_for_default_prices
+      prices.prioritized_for_default
     end
 
     # Returns {#default_price} or builds it from {Spree::Variant.default_price_attributes}

--- a/core/app/models/spree/price.rb
+++ b/core/app/models/spree/price.rb
@@ -20,7 +20,7 @@ module Spree
     validates :currency, inclusion: { in: ::Money::Currency.all.map(&:iso_code), message: :invalid_code }
     validates :country, presence: true, unless: -> { for_any_country? }
 
-    scope :currently_valid, -> { order(Arel.sql("country_iso IS NULL")).order(updated_at: :DESC, id: :DESC) }
+    scope :prioritized_for_default, -> { order(Arel.sql("country_iso IS NULL")).order(updated_at: :DESC, id: :DESC) }
     scope :for_master, -> { joins(:variant).where(spree_variants: { is_master: true }) }
     scope :for_variant, -> { joins(:variant).where(spree_variants: { is_master: false }) }
     scope :for_any_country, -> { where(country: nil) }

--- a/core/app/models/spree/variant/price_selector.rb
+++ b/core/app/models/spree/variant/price_selector.rb
@@ -39,7 +39,7 @@ module Spree
       # @param [Spree::Variant::PricingOptions] price_options Pricing Options to abide by
       # @return [Spree::Price, nil] The most specific price for this set of pricing options.
       def price_for_options(price_options)
-        variant.currently_valid_prices.detect do |price|
+        variant.prioritized_for_default_prices.detect do |price|
           (price.country_iso == price_options.desired_attributes[:country_iso] ||
            price.country_iso.nil?
           ) && price.currency == price_options.desired_attributes[:currency]

--- a/core/spec/models/spree/price_spec.rb
+++ b/core/spec/models/spree/price_spec.rb
@@ -97,12 +97,12 @@ RSpec.describe Spree::Price, type: :model do
       end
     end
 
-    describe '.currently_valid' do
+    describe '.prioritized_for_default' do
       it 'prioritizes first those associated to a country' do
         price_1 = create(:price, country: create(:country))
         price_2 = create(:price, country: nil) { |price| price.touch }
 
-        result = described_class.currently_valid
+        result = described_class.prioritized_for_default
 
         expect(
           result.index(price_1) < result.index(price_2)
@@ -115,7 +115,7 @@ RSpec.describe Spree::Price, type: :model do
           price_2 = create(:price, country: nil)
           price_1.touch
 
-          result = described_class.currently_valid
+          result = described_class.prioritized_for_default
 
           expect(
             result.index(price_1) < result.index(price_2)

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -320,13 +320,13 @@ RSpec.describe Spree::Variant, type: :model do
     end
   end
 
-  describe '#currently_valid_prices' do
+  describe '#prioritized_for_default_prices' do
     it 'returns prioritized prices' do
       price_1 = create(:price, country: create(:country))
       price_2 = create(:price, country: nil)
       variant = create(:variant, prices: [price_1, price_2])
 
-      result = variant.currently_valid_prices
+      result = variant.prioritized_for_default_prices
 
       expect(
         result.index(price_1) < result.index(price_2)

--- a/core/spec/support/concerns/default_price.rb
+++ b/core/spec/support/concerns/default_price.rb
@@ -42,13 +42,13 @@ RSpec.shared_examples_for "default_price" do
     end
   end
 
-  describe '#currently_valid_prices' do
+  describe '#prioritized_for_default_prices' do
     it 'returns prioritized prices' do
       price_1 = create(:price, country: create(:country))
       price_2 = create(:price, country: nil)
       variant = create(:variant, prices: [price_1, price_2])
 
-      result = variant.currently_valid_prices
+      result = variant.prioritized_for_default_prices
 
       expect(
         result.index(price_1) < result.index(price_2)


### PR DESCRIPTION
**Description**

It conveys better what it's doing, as the query only consists of `ORDER`
clauses and no record is filtered out.

Extracted from #3994

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
