### PR TITLE
Fix flaky product feature spec #4110

### DIFF
--- a/frontend/spec/features/products_spec.rb
+++ b/frontend/spec/features/products_spec.rb
@@ -9,11 +9,8 @@ describe "Visiting Products", type: :feature, inaccessible: true do
     ((first_store = Spree::Store.first) && first_store.name).to_s
   end
 
-  before(:each) do
-    visit spree.root_path
-  end
-
   it "should be able to show the shopping cart after adding a product to it" do
+    visit spree.root_path
     click_link "Ruby on Rails Ringer T-Shirt"
     expect(page).to have_content("$19.99")
 
@@ -31,8 +28,8 @@ describe "Visiting Products", type: :feature, inaccessible: true do
     end
 
     it "should use *_path helper to generate the product links" do
-     visit spree.root_path
-     expect(page).to have_xpath(".//a[@href='#{spree.product_path(product)}']")
+      visit spree.root_path
+      expect(page).to have_xpath(".//a[@href='#{spree.product_path(product)}']")
     end
   end
 
@@ -41,6 +38,7 @@ describe "Visiting Products", type: :feature, inaccessible: true do
     let(:metas) { { meta_description: 'Brand new Ruby on Rails Jersey', meta_title: 'Ruby on Rails Baseball Jersey Buy High Quality Geek Apparel', meta_keywords: 'ror, jersey, ruby' } }
 
     it 'should return the correct title when displaying a single product' do
+      visit spree.root_path
       click_link jersey.name
       expect(page).to have_title('Ruby on Rails Baseball Jersey - ' + store_name)
       within('div#product-description') do
@@ -51,6 +49,7 @@ describe "Visiting Products", type: :feature, inaccessible: true do
     end
 
     it 'displays metas' do
+      visit spree.root_path
       jersey.update metas
       click_link jersey.name
       expect(page).to have_meta(:description, 'Brand new Ruby on Rails Jersey')
@@ -58,12 +57,14 @@ describe "Visiting Products", type: :feature, inaccessible: true do
     end
 
     it 'displays title if set' do
+      visit spree.root_path
       jersey.update metas
       click_link jersey.name
       expect(page).to have_title('Ruby on Rails Baseball Jersey Buy High Quality Geek Apparel')
     end
 
     it "doesn't use meta_title as heading on page" do
+      visit spree.root_path
       jersey.update metas
       click_link jersey.name
       within("h1") do
@@ -73,6 +74,7 @@ describe "Visiting Products", type: :feature, inaccessible: true do
     end
 
     it 'uses product name in title when meta_title set to empty string' do
+      visit spree.root_path
       jersey.update meta_title: ''
       click_link jersey.name
       expect(page).to have_title('Ruby on Rails Baseball Jersey - ' + store_name)
@@ -83,6 +85,7 @@ describe "Visiting Products", type: :feature, inaccessible: true do
     let(:product) { Spree::Product.available.first }
 
     it 'has correct schema.org/Offer attributes' do
+      visit spree.root_path
       expect(page).to have_css("#product_#{product.id} [itemprop='price'][content='19.99']")
       expect(page).to have_css("#product_#{product.id} [itemprop='priceCurrency'][content='USD']")
       click_link product.name
@@ -141,6 +144,7 @@ describe "Visiting Products", type: :feature, inaccessible: true do
   end
 
   it "should be able to search for a product" do
+    visit spree.root_path
     fill_in "keywords", with: "shirt"
     click_button "Search"
 
@@ -165,6 +169,7 @@ describe "Visiting Products", type: :feature, inaccessible: true do
     end
 
     it "displays price of first variant listed", js: true do
+      visit spree.root_path
       click_link product.name
       within("#product-price") do
         expect(page).to have_content variant.price
@@ -173,6 +178,7 @@ describe "Visiting Products", type: :feature, inaccessible: true do
     end
 
     it "doesn't display out of stock for master product" do
+      visit spree.root_path
       product.master.stock_items.update_all count_on_hand: 0, backorderable: false
 
       click_link product.name
@@ -202,6 +208,7 @@ describe "Visiting Products", type: :feature, inaccessible: true do
   end
 
   it "should be able to hide products without price" do
+    visit spree.root_path
     expect(page.all('ul.product-listing li').size).to eq(9)
     stub_spree_preferences(show_products_without_price: false)
     stub_spree_preferences(currency: "CAN")
@@ -210,6 +217,7 @@ describe "Visiting Products", type: :feature, inaccessible: true do
   end
 
   it "should be able to display products priced under 10 dollars" do
+    visit spree.root_path
     within(:css, '#taxonomies') { click_link "Ruby on Rails" }
     check "Price_Range_Under_$10.00"
     within(:css, '#sidebar_products_search') { click_button "Search" }
@@ -217,6 +225,7 @@ describe "Visiting Products", type: :feature, inaccessible: true do
   end
 
   it "should be able to display products priced between 15 and 18 dollars" do
+    visit spree.root_path
     within(:css, '#taxonomies') { click_link "Ruby on Rails" }
     check "Price_Range_$15.00_-_$18.00"
     within(:css, '#sidebar_products_search') { click_button "Search" }
@@ -228,6 +237,7 @@ describe "Visiting Products", type: :feature, inaccessible: true do
   end
 
   it "should be able to display products priced between 15 and 18 dollars across multiple pages" do
+    visit spree.root_path
     stub_spree_preferences(products_per_page: 2)
     within(:css, '#taxonomies') { click_link "Ruby on Rails" }
     check "Price_Range_$15.00_-_$18.00"
@@ -243,6 +253,7 @@ describe "Visiting Products", type: :feature, inaccessible: true do
   end
 
   it "should be able to display products priced 18 dollars and above" do
+    visit spree.root_path
     within(:css, '#taxonomies') { click_link "Ruby on Rails" }
     check "Price_Range_$18.00_-_$20.00"
     check "Price_Range_$20.00_or_over"
@@ -283,6 +294,7 @@ describe "Visiting Products", type: :feature, inaccessible: true do
   end
 
   it "should return the correct title when displaying a single product" do
+    visit spree.root_path
     product = Spree::Product.find_by(name: "Ruby on Rails Baseball Jersey")
     click_link product.name
 


### PR DESCRIPTION
## Ticket

https://github.com/solidusio/solidus/pull/4110

## Demo of fix

https://www.dropbox.com/s/6yax0jcknnurbz1/4110-flaky-feature-spec-detected-test-2021-06-23_15.33.37.mp4?dl=0

## Description

I still haven't found the root cause of the issue, but it seems that visiting the root path only once per spec prevents the failure from occurring.

In https://app.circleci.com/pipelines/github/solidusio/solidus/2527/workflows/e98388e1-970b-4600-974b-bd2ced1e095e/jobs/25276/parallel-runs/2?filterBy=ALL, the spec ran 100 times and did not result in a failure.

In contrast, if you run the same spec in https://github.com/nebulab/solidus/tree/gsmendoza/4110-flaky-feature-spec-detected-original-spec-100-times, the same spec is more likely to fail.

## Checklist

- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed) - N/A
- [x] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed) - N/A
