### PR TITLE
Shipment Setup Examples documentation - small correction to the amount of shipping categories needed

### DIFF
--- a/guides/source/developers/shipments/shipment-setup-examples.html.md
+++ b/guides/source/developers/shipments/shipment-setup-examples.html.md
@@ -106,7 +106,7 @@ additional FedEx shipping method specifically for oversized items.
 
 ### Shipping categories
 
-Your store's products can be classified into three shipping categories:
+Your store's products can be classified into two shipping categories:
 
 - **Default**: For any product that can be shipped using your regular shipping
   methods.


### PR DESCRIPTION
**Description**
The [article](https://guides.solidus.io/developers/shipments/shipment-setup-examples.html) says three Shipping categories are needed but only two are present. Changed it accordingly.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
