### PR TITLE
Disable perform_caching in DummyApp

### DIFF
--- a/core/lib/spree/testing_support/dummy_app.rb
+++ b/core/lib/spree/testing_support/dummy_app.rb
@@ -51,15 +51,14 @@ module DummyApp
     config.cache_classes = true
     config.action_controller.allow_forgery_protection = false
     config.action_controller.default_protect_from_forgery = false
+    config.action_mailer.perform_caching = false
+    config.i18n.fallbacks = true
 
     # In the test environment, we use the `caching: true` RSpec metadata to
     # enable caching on select specs. See
     # core/lib/spree/testing_support/caching.rb. See also
     # https://github.com/solidusio/solidus/issues/4110
     config.action_controller.perform_caching = false
-
-    config.action_mailer.perform_caching = false
-    config.i18n.fallbacks = true
 
     # Make debugging easier:
     config.consider_all_requests_local = true

--- a/core/lib/spree/testing_support/dummy_app.rb
+++ b/core/lib/spree/testing_support/dummy_app.rb
@@ -51,7 +51,13 @@ module DummyApp
     config.cache_classes = true
     config.action_controller.allow_forgery_protection = false
     config.action_controller.default_protect_from_forgery = false
-    config.action_controller.perform_caching = true
+
+    # In the test environment, we use the `caching: true` RSpec metadata to
+    # enable caching on select specs. See
+    # core/lib/spree/testing_support/caching.rb. See also
+    # https://github.com/solidusio/solidus/issues/4110
+    config.action_controller.perform_caching = false
+
     config.action_mailer.perform_caching = false
     config.i18n.fallbacks = true
 


### PR DESCRIPTION
## Description

In the test environment, we use the `caching: true` RSpec metadata to enable caching only on select specs. See `core/lib/spree/testing_support/caching.rb`.

Fixes #4110.

See https://github.com/solidusio/solidus/issues/4110#issuecomment-868276279

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
