### PR TITLE
Adds conditional validation to `ReturnItem`

### DIFF
--- a/core/app/models/spree/return_item.rb
+++ b/core/app/models/spree/return_item.rb
@@ -30,7 +30,7 @@ module Spree
     self.refund_amount_calculator = Calculator::Returns::DefaultRefundAmount
 
     belongs_to :return_authorization, inverse_of: :return_items, optional: true
-    belongs_to :inventory_unit, inverse_of: :return_items, optional: true
+    belongs_to :inventory_unit, inverse_of: :return_items
     belongs_to :exchange_variant, class_name: 'Spree::Variant', optional: true
     belongs_to :exchange_inventory_unit, class_name: 'Spree::InventoryUnit', inverse_of: :original_return_item, optional: true
     belongs_to :customer_return, inverse_of: :return_items, optional: true
@@ -42,7 +42,6 @@ module Spree
     validate :eligible_exchange_variant
     validate :belongs_to_same_customer_order
     validate :validate_acceptance_status_for_reimbursement
-    validates :inventory_unit, presence: true
     validate :validate_no_other_completed_return_items
 
     after_create :cancel_others, unless: :cancelled?


### PR DESCRIPTION
**Description**

An issue exists between the association and validation of
`ReturnItem.inventory_unit`. There are three valid states for
the association:

- A ReturnItem is valid when it has no inventory_unit
- A ReturnItem is valid when it has an inventory_unit that is valid
- A ReturnItem is invalid when it has an inventory_unit that is invalid

This adds a conditional to the validation so that it only applies when
`inventory_unit_id` is present.  Tests have been updated to reflect
these three cases.

Resolves #4086

<!--
  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

  Please include screenshots in case of visual changes to the frontend or backend sections of Solidus.

  If needed you can reference another PR or issue here, e.g.:
  Ref #ISSUE
-->

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
