### PR TITLE
Exclude canceled orders in the #usage_count of promotions and promotion codes

### DIFF
--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -55,11 +55,12 @@ module Spree
     #
     # @param excluded_orders [Array<Spree::Order>] Orders to exclude from query
     # @return [ActiveRecord::Relation] Scoped Adjustments
-    def self.in_completed_orders(excluded_orders: [])
-      joins(:order).
-      merge(Spree::Order.complete).
-      where.not(spree_orders: { id: excluded_orders }).
-      distinct
+    def self.in_completed_orders(excluded_orders: [], exclude_canceled: false)
+      result = joins(:order)
+               .merge(Spree::Order.complete)
+               .where.not(spree_orders: { id: excluded_orders })
+               .distinct
+      exclude_canceled ? result.merge(Spree::Order.not_canceled) : result
     end
 
     def finalize!

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -192,7 +192,7 @@ module Spree
     def usage_count(excluded_orders: [])
       Spree::Adjustment.promotion.
         eligible.
-        in_completed_orders(excluded_orders: excluded_orders).
+        in_completed_orders(excluded_orders: excluded_orders, exclude_canceled: true).
         where(source_id: actions).
         count(:order_id)
     end

--- a/core/app/models/spree/promotion_code.rb
+++ b/core/app/models/spree/promotion_code.rb
@@ -30,7 +30,7 @@ class Spree::PromotionCode < Spree::Base
   def usage_count(excluded_orders: [])
     adjustments.
     eligible.
-    in_completed_orders(excluded_orders: excluded_orders).
+    in_completed_orders(excluded_orders: excluded_orders, exclude_canceled: true).
     count(:order_id)
   end
 

--- a/core/spec/models/spree/promotion_code_spec.rb
+++ b/core/spec/models/spree/promotion_code_spec.rb
@@ -147,6 +147,11 @@ RSpec.describe Spree::PromotionCode do
         before { order.adjustments.promotion.update_all(eligible: false) }
         it { is_expected.to eq 0 }
       end
+      context "and the order is canceled" do
+        before { order.cancel! }
+        it { is_expected.to eq 0 }
+        it { expect(order.state).to eq 'canceled' }
+      end
     end
   end
 

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -386,6 +386,11 @@ RSpec.describe Spree::Promotion, type: :model do
         before { order.adjustments.promotion.update_all(eligible: false) }
         it { is_expected.to eq 0 }
       end
+      context "and the order is canceled" do
+        before { order.cancel! }
+        it { is_expected.to eq 0 }
+        it { expect(order.state).to eq 'canceled' }
+      end
     end
   end
 


### PR DESCRIPTION
**Description**

This change is extracted from a clients project. I thought it might be useful to have this on Solidus because excluding the count of canceled orders in `#usage-count` allows for a more accurate count(and limit) of promotions and promotion_codes.

**Checklist:**
- [X] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [X] I have added a detailed description into each commit message
- [X] I have added tests to cover this change (if needed)
