### PR TITLE
Include 'i18n-tasks' Gem Config Setup for CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,6 +96,31 @@ jobs:
           paths:
             - solidus-version
 
+  i18n_tasks:
+    executor: base
+    steps:
+      - setup
+
+      - run:
+          name: "i18n-tasks gem: Install default configuration"
+          command: |
+            mkdir -p config
+            cp $(bundle exec i18n-tasks gem-path)/templates/config/i18n-tasks.yml config/
+
+      - run:
+          name: "i18n-tasks gem: Add RSpec tests for missing and unused keys"
+          command: |
+            mkdir -p spec
+            cp $(bundle exec i18n-tasks gem-path)/templates/rspec/i18n_spec.rb api/spec/support
+
+      - run:
+          name: "i18n-tasks gem: Remove un-used keys"
+          command: bundle exec i18n-tasks remove-unused
+          
+      - run:
+          name: "i18n-tasks gem: Normalize translation data"
+          command: bundle exec i18n-tasks normalize
+
   postgres:
     executor: postgres
     parallelism: &parallelism 3
@@ -137,6 +162,7 @@ workflows:
           filters:
             branches:
               only: /master|v\d\.\d+/
+      - i18n_tasks
       - postgres
       - mysql
       - postgres_rails60


### PR DESCRIPTION
**Description**
Include `i18n-tasks` gem config setup in `.circleci/config.yml`
- The aim of doing that is to get rid of the post-install message and to follow the suggested actions by the gem

Fixes / Referecnce #3978

Side notes:
- Some tests failed on my local machine on this branch and `master`. But the tests seem to pass here in the GitHub Actions.
- It's my first time working with CircleCI. Apologies in advance if there are any silly mistakes, haha. Just please point them out to me, and I'll try to fix them.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
