### PR TITLE
Introduce new EventBus adapter

### DIFF
--- a/core/lib/spree/event.rb
+++ b/core/lib/spree/event.rb
@@ -174,6 +174,14 @@ module Spree
       Spree::Config.events.adapter
     end
 
+    def adapter
+      Spree::Deprecation.warn <<~MSG
+        `Spree::Event.adapter` is deprecated. Please, use
+        `Spree::Event.default_adapter` instead.
+      MSG
+      default_adapter
+    end
+
     # @!attribute [r] subscribers
     #   @return <Spree::Event::SubscriberRegistry> The registry for supporting class reloading for Spree::Event::Subscriber instances
     def subscriber_registry

--- a/core/lib/spree/event.rb
+++ b/core/lib/spree/event.rb
@@ -6,44 +6,88 @@ require_relative 'event/configuration'
 require_relative 'event/subscriber'
 
 module Spree
+  # Event bus for Solidus.
+  #
+  # This module serves as the interface to access the Event Bus system in
+  # Solidus. You can use different underlying adapters to provide the core
+  # logic. It's recommended that you use {Spree::Event::Adapters::Default}.
+  #
+  # You use the {#fire} method to trigger an event:
+  #
+  #  @example
+  #    Spree::Event.fire 'order_finalized', order: order
+  #
+  # Then, you can use {#subscribe} to hook into the event:
+  #
+  #   @example
+  #     Spree::Event.subscribe 'order_finalized' do |event|
+  #       # Take the order at event.payload[:order]
+  #     end
+  #
+  # You can also subscribe to an event through a module including
+  # {Spree::Event::Subscriber}:
+  #
+  #  @example
+  #    module MySubscriber
+  #      include Spree::Event::Subscriber
+  #
+  #      event_action :order_finalized
+  #
+  #      def order_finalized(event)
+  #        # Again, take the order at event.payload[:order]
+  #      end
+  #    end
   module Event
     extend self
 
     delegate :activate_autoloadable_subscribers, :activate_all_subscribers, :deactivate_all_subscribers, to: :subscriber_registry
 
-    # Allows to trigger events that can be subscribed using #subscribe. An
-    # optional block can be passed that will be executed immediately. The
-    # actual code implementation is delegated to the adapter.
+    # Allows to trigger events that can be subscribed using {#subscribe}.
     #
-    # @param [String] event_name the name of the event. The suffix ".spree"
-    #  will be added automatically if not present
-    # @param [Hash] opts a list of options to be passed to the triggered event
+    # The actual code implementation is delegated to the adapter.
+    #
+    # @param [String, Symbol] event_name the name of the event.
+    # @param [Hash] opts a list of options to be passed to the triggered event.
+    # They will be made available through the {Spree::Event::Event} instance
+    # that is yielded to the subscribers (see {Spree::Event::Event#payload}).
+    # However, take into account that the deprecated
+    # {Spree::Event::Adapters::ActiveSupportNotifications} adapter will yield a
+    # {ActiveSupport::Notifications::Fanout::Subscribers::Timed} instance
+    # instead.
+    # @option opts [Any] :adapter Reserved to indicate the adapter to use as
+    # event bus. Defaults to {#default_adapter}
+    # @return [Spree::Event::Event] an event object, unless the adapter is
+    # {Spree::Event::Adapters::ActiveSupportNotifications}
     #
     # @example Trigger an event named 'order_finalized'
     #   Spree::Event.fire 'order_finalized', order: @order do
     #     @order.finalize!
     #   end
-    def fire(event_name, opts = {})
-      adapter.fire normalize_name(event_name), opts do
-        yield opts if block_given?
-      end
+    #
+    # TODO: Change signature so that `opts` are keyword arguments, and include
+    # `adapter:` in them. We want to do that on Solidus 4.0. Spree::Deprecation
+    # can't be used because of this: https://github.com/solidusio/solidus/pull/4130#discussion_r668666924
+    def fire(event_name, opts = {}, &block)
+      adapter = opts.delete(:adapter) || default_adapter
+      handle_block_on_fire(block, opts, adapter) if block_given?
+      adapter.fire normalize_name(event_name), opts
     end
 
-    # Subscribe to an event with the given name. The provided block is executed
-    # every time the subscribed event is fired.
+    # Subscribe to events matching the given name.
     #
-    # @param [String, Regexp] event_name the name of the event.
-    #  When String, the suffix ".spree" will be added automatically if not present,
-    #  when using the default adapter for ActiveSupportNotifications.
-    #  When Regexp, due to the unpredictability of all possible regexp combinations,
-    #  adding the suffix is developer's responsibility (if you don't, you will
-    #  subscribe to all notifications, including internal Rails notifications
-    #  as well).
+    # The provided block is executed every time the subscribed event is fired.
     #
-    # @see Spree::Event::Adapters::ActiveSupportNotifications#normalize_name
+    # @param [String, Symbol, Regexp] event_name the name of the event. When it's a
+    # {Regexp} it subscribes to all that match.
+    # @param [Any] adapter the event bus adapter to use.
+    # @yield block to execute when an event is triggered
     #
-    # @return a subscription object that can be used as reference in order
-    #  to remove the subscription
+    # @return [Spree::Event::Listener] a subscription object that can be used as
+    # reference in order to remove the subscription. However, take into account
+    # that the deprecated {Spree::Event::Adapters::ActiveSupportNotifications}
+    # adapter will return a
+    # {ActiveSupport::Notifications::Fanout::Subscribers::Timed} instance
+    # instead.
     #
     # @example Subscribe to the `order_finalized` event
     #   Spree::Event.subscribe 'order_finalized' do |event|
@@ -52,51 +96,81 @@ module Spree
     #   end
     #
     # @see Spree::Event#unsubscribe
-    def subscribe(event_name, &block)
-      name = normalize_name(event_name)
-      listener_names << name
-      adapter.subscribe(name, &block)
+    def subscribe(event_name, adapter: default_adapter, &block)
+      event_name = normalize_name(event_name)
+      adapter.subscribe(event_name, &block).tap do
+        if legacy_adapter?(adapter)
+          listener_names << adapter.normalize_name(event_name)
+        end
+      end
     end
 
     # Unsubscribes a whole event or a specific subscription object
     #
-    # @param [String, Object] subscriber the event name as a string (with
-    #  or without the ".spree" suffix) or the subscription object
+    # When unsubscribing from an event, all previous listeners are deactivated.
+    # Still, you can add new subscriptions to the same event and they'll be
+    # called if the event is fired:
+    #
+    # @example
+    #   Spree::Event.subscribe('foo') { do_something }
+    #   Spree::Event.unsubscribe 'foo'
+    #   Spree::Event.subscribe('foo') { do_something_else }
+    #   Spree::Event.fire 'foo' # `do_something_else` will be called, but
+    #   # `do_something` won't
+    #
+    # @param [String, Symbol, Spree::Event::Listener] subscriber_or_event_name the
+    # event name as a string or the subscription object. Take into account that
+    # if the deprecated {Spree::Event::Adapters::ActiveSupportNotifications}
+    # adapter is used, the subscription object will be a
+    # {ActiveSupport::Notifications::Fanout::Subscribers::Timed} object.
     #
     # @example Unsubscribe a single subscription
-    #   subscription = Spree::Event.fire 'order_finalized'
+    #   subscription = Spree::Event.subscribe('order_finalized') { do_something
+    #   }
     #   Spree::Event.unsubscribe(subscription)
     # @example Unsubscribe all `order_finalized` event subscriptions
     #   Spree::Event.unsubscribe('order_finalized')
-    # @example Unsubscribe an event by name with explicit prefix
-    #   Spree::Event.unsubscribe('order_finalized.spree')
-    def unsubscribe(subscriber)
-      name_or_subscriber = subscriber.is_a?(String) ? normalize_name(subscriber) : subscriber
-      adapter.unsubscribe(name_or_subscriber)
+    def unsubscribe(subscriber_or_event_name, adapter: default_adapter)
+      if subscriber_or_event_name.is_a?(Listener) || subscriber_or_event_name.is_a?(ActiveSupport::Notifications::Fanout::Subscribers::Timed)
+        unsubscribe_listener(subscriber_or_event_name, adapter)
+      else
+        unsubscribe_event(subscriber_or_event_name, adapter)
+      end
     end
 
-    # Lists all subscriptions currently registered under the ".spree"
-    # namespace. Actual implementation is delegated to the adapter
+    # Lists all subscriptions.
     #
-    # @return [Hash] an hash with event names as keys and arrays of subscriptions
-    #  as values
+    # Actual implementation is delegated to the adapter.
+    #
+    # @return [Hash<<String,Regexp>,Spree::Event::Listener>] an hash with
+    # patterns as keys and arrays of subscriptions as values. Take into account
+    # that the deprecated {Spree::Event::Adapters::ActiveSupportNotifications}
+    # adapter will map to
+    # {ActiveSupport::Notifications::Fanout::Subscribers::Timed} instances
+    # instead.
     #
     # @example Current subscriptions
     #  Spree::Event.listeners
-    #    # => {"order_finalized.spree"=> [#<ActiveSupport...>],
-    #      "reimbursement_reimbursed.spree"=> [#<ActiveSupport...>]}
-    def listeners
-      adapter.listeners_for(listener_names)
+    #    # => {"order_finalized"=> [#<Spree::Event::Listener...>],
+    #         "reimbursement_reimbursed"=> [#<Spree::Event::Listener...>]}
+    def listeners(adapter: default_adapter)
+      if legacy_adapter?(adapter)
+        adapter.listeners_for(listener_names)
+      else
+        init = Hash.new { |h, k| h[k] = [] }
+        adapter.listeners.each_with_object(init) do |listener, map|
+          map[listener.pattern] << listener
+        end
+      end
     end
 
-    # The adapter used by Spree::Event, defaults to
-    # Spree::Event::Adapters::ActiveSupportNotifications
+    # The default adapter used by Spree::Event.
     #
     # @example Change the adapter
-    #   Spree::Config.events.adapter = "Spree::EventBus.new"
+    #   Spree::Config.events.adapter = "Spree::OtherAdapter.new"
     #
-    # @see Spree::AppConfiguration
-    def adapter
+    # @see Spree::Event::Configuration
+    def default_adapter
       Spree::Config.events.adapter
     end
 
@@ -108,12 +182,65 @@ module Spree
 
     private
 
-    def normalize_name(name)
-     adapter.normalize_name(name)
+    def unsubscribe_listener(listener, adapter)
+      adapter.unsubscribe(listener)
+    end
+
+    def unsubscribe_event(event_name, adapter)
+      adapter.unsubscribe(normalize_name(event_name))
     end
 
     def listener_names
       @listeners_names ||= Set.new
+    end
+
+    def normalize_name(name)
+      case name
+      when Symbol
+        name.to_s
+      else
+        name
+      end
+    end
+
+    def handle_block_on_fire(block, opts, adapter)
+      example = <<~MSG
+        Please, instead of:
+
+          Spree::Event.fire 'event_name', order: order do
+            order.do_something
+          end
+
+        Use:
+
+          order.do_something
+          Spree::Event.fire 'event_name', order: order
+      MSG
+      if legacy_adapter?(adapter)
+        Spree::Deprecation.warn <<~MSG
+          Blocks on `Spree::Event.fire` are ignored in the new adapter
+          `Spree::Event::Adapters::Default`, and your current adapter
+          (`Spree::Event::Adapters::ActiveSupportNotifications`) is deprecated.
+          For an easier transition it's recommendable to update your code.
+
+          #{example}
+
+        MSG
+        block.call(opts)
+      else
+        raise ArgumentError, <<~MSG
+          Blocks passed to `Spree::Event.fire` are ignored unless the adapter is
+          `Spree::Event::Adapters::ActiveSupportNotifications` (which is
+          deprecated).
+
+          #{example}
+
+        MSG
+      end
+    end
+
+    def legacy_adapter?(adapter)
+      adapter == Adapters::ActiveSupportNotifications
     end
   end
 end

--- a/core/lib/spree/event/adapters/active_support_notifications.rb
+++ b/core/lib/spree/event/adapters/active_support_notifications.rb
@@ -3,28 +3,47 @@
 module Spree
   module Event
     module Adapters
+      # Deprecated adapter for the event bus system.
+      #
+      # Please, upgrade to {Spree::Event::Adapters::Default}.
+      #
+      # This adapter normalizes the event name so that it includes
+      # {Spree::Event::Configuration#suffix}.
+      # When the event name is a string or a symbol, if the suffix is missing,
+      # then it is added automatically. When the event name is a regexp, due
+      # to the huge variability of regexps, adding or not the suffix is
+      # developer's responsibility (if you don't, you will subscribe to all
+      # internal rails events as well).  When the event type is not supported,
+      # an error is raised.
+      #
+      # The suffix can be changed through `config.events.suffix=` in `spree.rb`.
       module ActiveSupportNotifications
         class InvalidEventNameType < StandardError; end
 
         extend self
 
+        # @api private
         def fire(event_name, opts)
-          ActiveSupport::Notifications.instrument event_name, opts do
+          ActiveSupport::Notifications.instrument normalize_name(event_name), opts do
             yield opts if block_given?
           end
         end
 
+        # @api private
         def subscribe(event_name)
-          ActiveSupport::Notifications.subscribe event_name do |*args|
+          ActiveSupport::Notifications.subscribe normalize_name(event_name) do |*args|
             event = ActiveSupport::Notifications::Event.new(*args)
             yield event
           end
         end
 
+        # @api private
         def unsubscribe(subscriber_or_name)
+          subscriber_or_name = subscriber_or_name.is_a?(String) ? normalize_name(subscriber_or_name) : subscriber_or_name
           ActiveSupport::Notifications.unsubscribe(subscriber_or_name)
         end
 
+        # @api private
         def listeners_for(names)
           names.each_with_object({}) do |name, memo|
             listeners = ActiveSupport::Notifications.notifier.listeners_for(name)
@@ -32,16 +51,6 @@ module Spree
           end
         end
 
-        # Normalizes the event name according to this specific adapter rules.
-        #  When the event name is a string or a symbol, if the suffix is missing, then
-        #  it is added automatically.
-        #  When the event name is a regexp, due to the huge variability of regexps, adding
-        #  or not the suffix is developer's responsibility (if you don't, you will subscribe
-        #  to all internal rails events as well).
-        #  When the event type is not supported, an error is raised.
-        #
-        # @param [String, Symbol, Regexp] event_name the event name, with or without the
-        #  suffix (Spree::Config.events.suffix defaults to `.spree`).
         def normalize_name(event_name)
           case event_name
           when Regexp
@@ -54,10 +63,7 @@ module Spree
           end
         end
 
-        # The suffix used for namespacing event names, defaults to
-        # `.spree`
-        #
-        # @see Spree::Event::Configuration#suffix
+        # @api private
         def suffix
           Spree::Config.events.suffix
         end

--- a/core/lib/spree/event/adapters/default.rb
+++ b/core/lib/spree/event/adapters/default.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'spree/event/event'
+require 'spree/event/listener'
+
+module Spree
+  module Event
+    module Adapters
+      # Adapter for {Spree::Event}
+      #
+      # Please, access it through {Spree::Event} module. You only need to
+      # configure an instance of it to be used as the default adapter.  E.g., in
+      # `spree.rb` initializer:
+      #
+      # @example
+      #   require "spree/event/adapters/default"
+      #
+      #   Spree.config do |config|
+      #     # ...
+      #     config.events.adapter = Spree::Event::Adapters::Default.new
+      #     # ...
+      #   end
+      #
+      # You won't need to do that from Solidus version 4.0 as this adapter will
+      # be the default one.
+      class Default
+        # @api private
+        attr_reader :listeners
+
+        def initialize
+          @listeners = []
+        end
+
+        # @api private
+        def fire(event_name, opts = {})
+          Event.new(payload: opts).tap do |event|
+            listeners_for_event(event_name).each do |listener|
+              listener.call(event)
+            end
+          end
+        end
+
+        # @api private
+        def subscribe(event_name_or_regexp, &block)
+          Listener.new(pattern: event_name_or_regexp, block: block).tap do |listener|
+            @listeners << listener
+          end
+        end
+
+        # @api private
+        def unsubscribe(subscriber_or_event_name)
+          if subscriber_or_event_name.is_a?(Listener)
+            unsubscribe_listener(subscriber_or_event_name)
+          else
+            unsubscribe_event(subscriber_or_event_name)
+          end
+        end
+
+        private
+
+        def listeners_for_event(event_name)
+          @listeners.select do |listener|
+            listener.matches?(event_name)
+          end
+        end
+
+        def unsubscribe_listener(listener)
+          @listeners.delete(listener)
+        end
+
+        def unsubscribe_event(event_name)
+          @listeners.each do |listener|
+            listener.unsubscribe(event_name)
+          end
+        end
+      end
+    end
+  end
+end

--- a/core/lib/spree/event/configuration.rb
+++ b/core/lib/spree/event/configuration.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+require 'spree/core/versioned_value'
+require 'spree/event/adapters/active_support_notifications'
+require 'spree/event/adapters/default'
+
 module Spree
   module Event
     class Configuration
@@ -14,11 +18,63 @@ module Spree
       end
 
       def adapter
-        @adapter ||= Spree::Event::Adapters::ActiveSupportNotifications
+        @adapter ||= Spree::Core::VersionedValue.new(
+          Spree::Event::Adapters::ActiveSupportNotifications,
+          "4.0.0.alpha" => Spree::Event::Adapters::Default.new
+        ).call.tap do |value|
+          deprecate_if_legacy_adapter(value)
+        end
       end
 
+      # Only used by {Spree::Event::Adapters::ActiveSupportNotifications}.
       def suffix
         @suffix ||= '.spree'
+      end
+
+      private
+
+      def deprecate_if_legacy_adapter(adapter)
+        Spree::Deprecation.warn <<~MSG if adapter == Spree::Event::Adapters::ActiveSupportNotifications
+          `Spree::Event::Adapters::ActiveSupportNotifications` adapter is
+          deprecated. Please, take your time to update it to an instance of
+          `Spree::Event::Adapters::Default`. I.e., in your `spree.rb`:
+
+          require 'spree/event/adapters/default'
+
+          Spree.config do |config|
+            # ...
+            config.events.adapter = Spree::Event::Adapters.Default.new
+            # ...
+          end
+
+          That will be the new default on Solidus 4.
+
+          Take into account there're two critical changes in behavior in the new adapter:
+
+          - Event names are no longer automatically suffixed with `.spree`, as
+          they're no longer in the same bucket that Rails's ones. So, for
+          instance, if you were relying on a global subscription to all Solidus
+          events with:
+
+            Spree::Event.subscribe /.*\.spree$/
+
+          You should change it to:
+
+            Spree::Event.subscribe /.*/
+
+          - Providing a block to `Spree::Event.fire` is no longer supported. If
+          you're doing something like:
+
+            Spree::Event.fire 'event_name', order: order do
+              order.do_something
+            end
+
+            You now need to change it to:
+
+            order.do_something
+            Spree::Event.fire 'event_name', order: order
+
+        MSG
       end
     end
   end

--- a/core/lib/spree/event/event.rb
+++ b/core/lib/spree/event/event.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Spree
+  module Event
+    # A triggered event
+    #
+    # An instance of it is automatically created on {Spree::Event.fire}.  The
+    # instance is consumed on {Spree::Event.subscribe}.
+    #
+    # @example
+    #   Spree::Event.fire 'event_name', foo: 'bar'
+    #   Spree::Event.subscribe 'event_name' do |event|
+    #     puts event.payload['foo'] #=> 'bar'
+    #   end
+    class Event
+      # Hash with the options given to {Spree::Event.fire}
+      #
+      # @return [Hash]
+      attr_reader :payload
+
+      # @api private
+      def initialize(payload:)
+        @payload = payload
+      end
+    end
+  end
+end

--- a/core/lib/spree/event/listener.rb
+++ b/core/lib/spree/event/listener.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Spree
+  module Event
+    # Subscription to an event
+    #
+    # An instance of it is returned on {Spree::Event.subscribe}.
+    #
+    # You're not expected to perform any action with it, besides using it as
+    # a reference to unsubscribe.
+    #
+    # @example
+    #   listener = Spree::Event.subscribe 'event_name'
+    #   Spree::Event.unsubscribe listener
+    class Listener
+      # @api private
+      attr_reader :pattern, :block
+
+      # @api private
+      def initialize(pattern:, block:)
+        @pattern = pattern
+        @block = block
+        @exclusions = []
+      end
+
+      # @api private
+      def call(event)
+        @block.call(event)
+      end
+
+      # @api private
+      def matches?(event_name)
+        pattern === event_name &&
+          !excludes?(event_name)
+      end
+
+      # @api private
+      def unsubscribe(event_name)
+        return unless matches?(event_name)
+
+        @exclusions << event_name
+      end
+
+      private
+
+      def excludes?(event_name)
+        @exclusions.include?(event_name)
+      end
+    end
+  end
+end

--- a/core/lib/spree/testing_support/dummy_app.rb
+++ b/core/lib/spree/testing_support/dummy_app.rb
@@ -133,6 +133,9 @@ end
 Spree.user_class = 'Spree::LegacyUser'
 Spree.config do |config|
   config.mails_from = "store@example.com"
+  # TODO: Remove on Solidus 4.0 as it'll be the default
+  require 'spree/event/adapters/default'
+  config.events.adapter = Spree::Event::Adapters::Default.new
 
   if ENV['DISABLE_ACTIVE_STORAGE']
     config.image_attachment_module = 'Spree::Image::PaperclipAttachment'

--- a/core/spec/lib/spree/app_configuration_spec.rb
+++ b/core/spec/lib/spree/app_configuration_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'spree/event/adapters/default'
 
 RSpec.describe Spree::AppConfiguration do
   let(:prefs) { Spree::Config }
@@ -134,7 +135,7 @@ RSpec.describe Spree::AppConfiguration do
     expect(prefs.admin_vat_location.country_id).to eq(nil)
   end
 
-  it 'has default Event adapter' do
-    expect(prefs.events.adapter).to eq Spree::Event::Adapters::ActiveSupportNotifications
+  it 'can access event adapter' do
+    expect(prefs.events.adapter).to be_an_instance_of(Spree::Event::Adapters::Default)
   end
 end

--- a/core/spec/lib/spree/event/adapters/active_support_notifications_spec.rb
+++ b/core/spec/lib/spree/event/adapters/active_support_notifications_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'spree/event'
+require 'spree/event/adapters/active_support_notifications'
 
 module Spree
   module Event

--- a/core/spec/lib/spree/event/adapters/default_spec.rb
+++ b/core/spec/lib/spree/event/adapters/default_spec.rb
@@ -1,0 +1,230 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'spree/event/adapters/default'
+
+module Spree
+  module Event
+    module Adapters
+      RSpec.describe Default do
+        describe '#fire' do
+          it 'executes listeners subscribed as a string to the event name' do
+            bus = described_class.new
+            dummy = Class.new do
+              attr_reader :run
+
+              def initialize
+                @run = false
+              end
+
+              def toggle
+                @run = true
+              end
+            end.new
+            bus.subscribe('foo') { dummy.toggle }
+
+            bus.fire 'foo'
+
+            expect(dummy.run).to be(true)
+          end
+
+          it 'executes listeners subscribed as a regexp to the event name' do
+            bus = described_class.new
+            dummy = Class.new do
+              attr_reader :run
+
+              def initialize
+                @run = false
+              end
+
+              def toggle
+                @run = true
+              end
+            end.new
+            bus.subscribe(/oo/) { dummy.toggle }
+
+            bus.fire 'foo'
+
+            expect(dummy.run).to be(true)
+          end
+
+          it "doesn't execute listeners not subscribed to the event name" do
+            bus = described_class.new
+            dummy = Class.new do
+              attr_reader :run
+
+              def initialize
+                @run = false
+              end
+
+              def toggle
+                @run = true
+              end
+            end.new
+            bus.subscribe('bar') { dummy.toggle }
+
+            bus.fire 'barr'
+            bus.fire /arr/
+
+            expect(dummy.run).to be(false)
+          end
+
+          it 'binds given options to the subscriber as the event payload' do
+            bus = described_class.new
+            dummy = Class.new do
+              attr_accessor :box
+            end.new
+            bus.subscribe('foo') { |event| dummy.box = event.payload[:box] }
+
+            bus.fire 'foo', box: 'foo'
+
+            expect(dummy.box).to eq('foo')
+          end
+        end
+
+        describe '#subscribe' do
+          it 'registers to matching event as string' do
+            bus = described_class.new
+
+            block = ->{}
+            bus.subscribe('foo', &block)
+
+            expect(bus.listeners.first.block.object_id).to eq(block.object_id)
+          end
+
+          it 'registers to matching event as regexp' do
+            bus = described_class.new
+
+            block = ->{}
+            bus.subscribe(/oo/, &block)
+
+            expect(bus.listeners.first.block.object_id).to eq(block.object_id)
+          end
+
+          it 'returns a listener object with given block' do
+            bus = described_class.new
+
+            listener = bus.subscribe('foo') { 'bar' }
+
+            expect(listener.block.call).to eq('bar')
+          end
+        end
+
+        describe '#unsubscribe' do
+          context 'when given a listener' do
+            it 'unsubscribes given listener' do
+              bus = described_class.new
+              dummy = Class.new do
+                attr_reader :run
+
+                def initialize
+                  @run = false
+                end
+
+                def toggle
+                  @run = true
+                end
+              end.new
+              listener = bus.subscribe('foo') { dummy.toggle }
+
+              bus.unsubscribe listener
+              bus.fire 'foo'
+
+              expect(dummy.run).to be(false)
+            end
+          end
+
+          context 'when given an event name' do
+            it 'unsubscribes all listeners for that event' do
+              bus = described_class.new
+              dummy = Class.new do
+                attr_reader :run
+
+                def initialize
+                  @run = false
+                end
+
+                def toggle
+                  @run = true
+                end
+              end.new
+
+              bus.subscribe('foo') { dummy.toggle }
+              bus.unsubscribe 'foo'
+              bus.fire 'foo'
+
+              expect(dummy.run).to be(false)
+            end
+          end
+
+          it 'unsubscribes listeners that match event with a regexp' do
+            bus = described_class.new
+            dummy = Class.new do
+              attr_reader :run
+
+              def initialize
+                @run = false
+              end
+
+              def toggle
+                @run = true
+              end
+            end.new
+            bus.subscribe(/foo/) { dummy.toggle }
+            bus.unsubscribe 'foo'
+
+            bus.fire 'foo'
+
+            expect(dummy.run).to be(false)
+          end
+
+          it "doesn't unsubscribe listeners for other events" do
+            bus = described_class.new
+            dummy = Class.new do
+              attr_reader :run
+
+              def initialize
+                @run = false
+              end
+
+              def toggle
+                @run = true
+              end
+            end.new
+
+            bus.subscribe('foo') { dummy.toggle }
+            bus.unsubscribe 'bar'
+            bus.fire 'foo'
+
+            expect(dummy.run).to be(true)
+          end
+
+          it 'can resubscribe other listeners to the same event' do
+            bus = described_class.new
+            dummy1, dummy2 = Array.new(2) do
+              Class.new do
+                attr_reader :run
+
+                def initialize
+                  @run = false
+                end
+
+                def toggle
+                  @run = true
+                end
+              end.new
+            end
+
+            bus.subscribe('foo') { dummy1.toggle }
+            bus.unsubscribe 'foo'
+            bus.subscribe('foo') { dummy2.toggle }
+            bus.fire 'foo'
+
+            expect(dummy1.run).to be(false)
+            expect(dummy2.run).to be(true)
+          end
+        end
+      end
+    end
+  end
+end

--- a/core/spec/lib/spree/event/adapters/default_spec.rb
+++ b/core/spec/lib/spree/event/adapters/default_spec.rb
@@ -63,8 +63,27 @@ module Spree
             end.new
             bus.subscribe('bar') { dummy.toggle }
 
+            bus.fire 'foo'
+
+            expect(dummy.run).to be(false)
+          end
+
+          it "doesn't execute listeners partially matching as a string" do
+            bus = described_class.new
+            dummy = Class.new do
+              attr_reader :run
+
+              def initialize
+                @run = false
+              end
+
+              def toggle
+                @run = true
+              end
+            end.new
+            bus.subscribe('bar') { dummy.toggle }
+
             bus.fire 'barr'
-            bus.fire /arr/
 
             expect(dummy.run).to be(false)
           end

--- a/core/spec/lib/spree/event/listener_spec.rb
+++ b/core/spec/lib/spree/event/listener_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'spree/event/listener'
+
+RSpec.describe Spree::Event::Listener do
+  describe '#call' do
+    it 'returns the result of calling block with given event' do
+      listener = described_class.new(pattern: 'foo', block: ->(event) { event[:bar] })
+
+      expect(listener.call(bar: 'bar')).to eq('bar')
+    end
+  end
+
+  describe '#matches?' do
+    it 'return true when given event name matches pattern as a string' do
+      listener = described_class.new(pattern: 'foo', block: -> {})
+
+      expect(listener.matches?('foo')).to be(true)
+    end
+
+    it 'return true when given event name matches pattern as a regexp' do
+      listener = described_class.new(pattern: /oo/, block: -> {})
+
+      expect(listener.matches?('foo')).to be(true)
+    end
+
+    it "returns false when given event name doesn't match pattern" do
+      listener = described_class.new(pattern: 'foo', block: -> {})
+
+      expect(listener.matches?('bar')).to be(false)
+    end
+
+    it "returns false when given event name matches but the listener is unsubscribed from the event" do
+      listener = described_class.new(pattern: 'foo', block: -> {})
+
+      listener.unsubscribe('foo')
+
+      expect(listener.matches?('foo')).to be(false)
+    end
+  end
+
+  describe '#unsubscribe' do
+    context 'when event name matches' do
+      it "adds an exclusion so that it no longer matches" do
+        listener = described_class.new(pattern: 'foo', block: -> {})
+
+        expect(listener.matches?('foo')).to be(true)
+
+        listener.unsubscribe('foo')
+
+        expect(listener.matches?('foo')).to be(false)
+      end
+    end
+
+    context "when event name doesn't match" do
+      it 'does nothing' do
+        listener = described_class.new(pattern: 'foo', block: -> {})
+
+        listener.unsubscribe('bar')
+
+        expect(listener.matches?('foo')).to be(true)
+        expect(listener.matches?('bar')).to be(false)
+      end
+    end
+  end
+end

--- a/core/spec/lib/spree/event_spec.rb
+++ b/core/spec/lib/spree/event_spec.rb
@@ -17,6 +17,14 @@ RSpec.describe Spree::Event do
     end
   end
 
+  describe '.adapter' do
+    it 'deprecates and forwards to default_adapter' do
+      expect(Spree::Deprecation).to receive(:warn).with(/deprecated.*default_adapter/m)
+
+      expect(subject.adapter).to be(subject.default_adapter)
+    end
+  end
+
   describe '.fire' do
     it 'forwards to adapter' do
       bus = build_bus


### PR DESCRIPTION
**Description**

We're deprecating `Spree::Event::Adapters::ActiveSupportNotifications`
for a couple of reasons:

- It uses the same bus that standard Rails notifications. It forces us
  to try to normalize the event names given through `Spree::Event.fire`
  & `Spree::Event.subscribe` to add a `.spree` suffix. However, it's not
  a complete solution as we're missing subscriptions placed through a
  regular expression (like `Spree::Event.subscribe /.*/`, which
  subscribes to all events, including Rails ones).

- It relies heavily on global state. Besides not being able to create
  two different buses (see the previous point), it makes it cumbersome
  to test events in isolation.

This commit introduces a new `Spree::Event::Adapters::EventBus` adapter,
which instances make for independent event buses. As our implementation
of the event bus system relies on a global bus for all Solidus events,
the idea is to initialize a single instance and configure it as
`Spree::Config.events.adapter`. However, we've added a new optional
`adapter:` parameter to all relevant methods in `Spree::Event` to inject
other buses when testing. E.g.:

```ruby
bus = Spree::Event::Adapters::EventBus.new
Spree::Event.subscribe('foo', adapter: bus) { do_something }
Spree::Event.fire('foo', adapter: bus)
```

The old adapter is still the default one due to backward compatibility
reasons. However, we display a deprecation warning to let users know
that they're encouraged to change. There're two critical updates that
they need to be aware of (they're also described in the deprecated
message):

- Event name normalization won't happen anymore. E.g. in order to
  subscribe to all Solidus events probably users will need to change
  from `Spree::Event.subscribe /\.spree$/` to `Spree::Event.subscribe
  /.*/`. There's no way to reliably warn when the `.spree` prefix is
  used, as users can still decide to use it as far as they're consistent
  when performing different operations. On top of that, we still can't
  inspect regular expressions with confidence.

- The old adapter allowed to provide a block on `Spree::Event.fire`, like in:

  ```ruby
  Spree::Event.fire 'foo', order: order do
    order.do_something
  end
  ```

  As this block is entirely unnecessary and it can lead to
  confusion (is it executed before or after the subscribers?), it's no
  longer supported in the new adapter. To provide a safer upgrade
  experience, we raise an `ArgumentError` when the new adapter is being
  used, and a block is provided.

The new `EventBus` adapter will be made the default one on the next
major Solidus release.

The old adapter is leaking the abstraction through the returned values
(`ActiveSupport::Notifications::Fanout::Subscribers::Timed` instances).
In the new adapter, we introduce `Spree::Event::Event` &
`Spree::Event::Listener` objects that the adapters need to return.

The main `Spree::Event` module will still keep a copy of the
subscriptions when the legacy adapter is used. This behavior was
introduced to differentiate Solidus events from others, but it can cause
inconsistencies if we compare it with the copy on the adapter. As
something no longer needed, we're branching to don't perform the logic
when the adapter is the new one.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
