### PR TITLE
Document REST API params to control nested taxons

### DIFF
--- a/api/openapi/solidus-api.oas.yml
+++ b/api/openapi/solidus-api.oas.yml
@@ -3747,6 +3747,13 @@ paths:
         - Taxonomies
       security:
         - api-key: []
+      parameters:
+        - schema:
+            type: string
+            default: nested
+          in: query
+          name: set
+          description: When `set=nested` it will recoursively return all the taxons of that taxonomy
     parameters:
       - name: id
         in: path

--- a/api/openapi/solidus-api.oas.yml
+++ b/api/openapi/solidus-api.oas.yml
@@ -4012,6 +4012,11 @@ paths:
         - $ref: '#/components/parameters/page'
         - $ref: '#/components/parameters/per_page'
         - $ref: '#/components/parameters/q'
+        - schema:
+            type: boolean
+          in: query
+          name: without_children
+          description: 'When set to `true`, it won''t recursively return all the taxons'' children.'
       security:
         - api-key: []
   /users:


### PR DESCRIPTION
**Description**

This PR documents a couple of params that users can pass to control if the taxons returned need to be nested or not. 

<details>
<summary>
  Document set=nested on GET /taxonomies/:id
</summary>
  <img width="592" alt="CleanShot 2021-07-13 at 16 37 32@2x" src="https://user-images.githubusercontent.com/167946/125471512-048349db-3c04-4e8d-a892-21b5dfd78dd8.png">
</details>


<details>
<summary>
  Document without_children param for GET /taxons
</summary>

  <img width="722" alt="CleanShot 2021-07-13 at 16 44 58@2x" src="https://user-images.githubusercontent.com/167946/125472715-2268244b-5b00-4cf1-b3ac-e0d6c3c32741.png">
</details>


