### PR TITLE
Revert "Deprecate callback setting variant price from master"

### DIFF
--- a/api/spec/requests/spree/api/products_controller_spec.rb
+++ b/api/spec/requests/spree/api/products_controller_spec.rb
@@ -126,7 +126,7 @@ module Spree
 
       it "gets a single product" do
         product.master.images.create!(attachment: image("blank.jpg"))
-        product.variants.create!(price: 50)
+        product.variants.create!
         product.variants.first.images.create!(attachment: image("blank.jpg"))
         product.set_property("spree", "rocks")
         product.taxons << create(:taxon)

--- a/api/spec/requests/spree/api/variants_controller_spec.rb
+++ b/api/spec/requests/spree/api/variants_controller_spec.rb
@@ -300,7 +300,7 @@ module Spree
       end
 
       it "can create a new variant" do
-        post spree.api_product_variants_path(product), params: { variant: { sku: "12345", price: "10" } }
+        post spree.api_product_variants_path(product), params: { variant: { sku: "12345" } }
         expect(json_response).to have_attributes(new_attributes)
         expect(response.status).to eq(201)
         expect(json_response["sku"]).to eq("12345")
@@ -314,8 +314,7 @@ module Spree
           post spree.api_product_variants_path(product), params: {
             variant: {
               sku: "12345",
-              option_value_ids: option_values.map(&:id),
-              price: "10"
+              option_value_ids: option_values.map(&:id)
             }
           }
         end.to change { Spree::OptionValuesVariant.count }.by(2)
@@ -326,7 +325,6 @@ module Spree
           post spree.api_product_variants_path(product), params: {
             variant: {
               sku: "12345",
-              price: 25,
               options: [{
                 name: 'Color',
                 value: 'White'

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -58,9 +58,7 @@ module Spree
       autosave: true
 
     before_validation :set_cost_currency
-    before_validation :set_price, if: (proc do
-      Spree::Config[:require_master_price] && !is_master? && price.nil? && product && product.master
-    end)
+    before_validation :set_price, if: -> { product && product.master }
     before_validation :build_vat_prices, if: -> { rebuild_vat_prices? || new_record? && product }
 
     validates :product, presence: true
@@ -381,14 +379,7 @@ module Spree
 
     # Ensures a new variant takes the product master price when price is not supplied
     def set_price
-      Spree::Deprecation.warn(
-        "The creation of the default price for a variant through the automatic
-        inheritance from its master variant's default price is deprecated.
-        Please, provide the amount for the price manually. E.g., use
-        `product.variants.create(price: 50)` instead of
-        `product.variants.create'"
-      )
-      self.price = product.master.price
+      self.price = product.master.price if price.nil? && Spree::Config[:require_master_price] && !is_master?
     end
 
     def check_price

--- a/core/lib/spree/core/product_duplicator.rb
+++ b/core/lib/spree/core/product_duplicator.rb
@@ -52,7 +52,6 @@ module Spree
     def duplicate_variant(variant)
       new_variant = variant.dup
       new_variant.sku = "COPY OF #{new_variant.sku}"
-      new_variant.price = variant.price
       new_variant.deleted_at = nil
       new_variant.option_values = variant.option_values.map { |option_value| option_value }
       new_variant

--- a/core/spec/models/spree/product_duplicator_spec.rb
+++ b/core/spec/models/spree/product_duplicator_spec.rb
@@ -76,8 +76,8 @@ module Spree
       let(:option_value1) { create(:option_value, name: "OptionValue1", option_type: option_type) }
       let(:option_value2) { create(:option_value, name: "OptionValue2", option_type: option_type) }
 
-      let!(:variant1) { create(:variant, product: product, price: 10, option_values: [option_value1]) }
-      let!(:variant2) { create(:variant, product: product, price: 10, option_values: [option_value2]) }
+      let!(:variant1) { create(:variant, product: product, option_values: [option_value1]) }
+      let!(:variant2) { create(:variant, product: product, option_values: [option_value2]) }
 
       it "will duplciate the variants" do
         # will change the count by 3, since there will be a master variant as well

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -42,25 +42,12 @@ RSpec.describe Spree::Variant, type: :model do
     end
   end
 
-  context 'before validation' do
-    it 'deprecates having price inherited from the master variant' do
-      product = build(:product, price: 25)
-      variant = build(:variant, is_master: false, price: nil, product: product)
-
-      expect(Spree::Deprecation).to receive(:warn).with(/provide the amount for the price manually/)
-
-      variant.valid?
-
-      expect(variant.price).to eq(25)
-    end
-  end
-
   context "after create" do
     let!(:product) { create(:product) }
 
     it "propagate to stock items" do
       expect_any_instance_of(Spree::StockLocation).to receive(:propagate_variant)
-      product.variants.create!(price: 10)
+      product.variants.create!
     end
 
     context "stock location has disable propagate all variants" do
@@ -68,7 +55,7 @@ RSpec.describe Spree::Variant, type: :model do
 
       it "propagate to stock items" do
         expect_any_instance_of(Spree::StockLocation).not_to receive(:propagate_variant)
-        product.variants.create!(price: 10)
+        product.variants.create!
       end
     end
 
@@ -82,7 +69,7 @@ RSpec.describe Spree::Variant, type: :model do
 
       context 'when a variant is created' do
         before(:each) do
-          product.variants.create!(price: 10)
+          product.variants.create!
         end
 
         it { expect(product.master).to_not be_in_stock }

--- a/sample/db/samples/variants.rb
+++ b/sample/db/samples/variants.rb
@@ -30,218 +30,184 @@ variants = [
     product: solidus_tshirt,
     option_values: [small, blue],
     sku: "SOL-00003",
-    cost_price: 17,
-    price: 25
+    cost_price: 17
   },
   {
     product: solidus_tshirt,
     option_values: [small, black],
     sku: "SOL-00002",
-    cost_price: 17,
-    price: 25
+    cost_price: 17
   },
   {
     product: solidus_tshirt,
     option_values: [small, white],
     sku: "SOL-00004",
-    cost_price: 17,
-    price: 25
+    cost_price: 17
   },
   {
     product: solidus_tshirt,
     option_values: [medium, blue],
     sku: "SOL-00005",
-    cost_price: 17,
-    price: 25
+    cost_price: 17
   },
   {
     product: solidus_tshirt,
     option_values: [large, white],
     sku: "SOL-00006",
-    cost_price: 17,
-    price: 25
+    cost_price: 17
   },
   {
     product: solidus_tshirt,
     option_values: [large, black],
     sku: "SOL-00007",
-    cost_price: 17,
-    price: 25
+    cost_price: 17
   },
   {
     product: solidus_tshirt,
     option_values: [extra_large, blue],
     sku: "SOL-0008",
-    cost_price: 17,
-    price: 25
+    cost_price: 17
   },
   {
     product: solidus_long,
     option_values: [small, black],
     sku: "SOL-LS02",
-    cost_price: 17,
-    price: 25
+    cost_price: 17
   },
   {
     product: solidus_long,
     option_values: [small, white],
     sku: "SOL-LS01",
-    cost_price: 17,
-    price: 25
+    cost_price: 17
   },
   {
     product: solidus_long,
     option_values: [small, blue],
     sku: "SOL-LS03",
-    cost_price: 17,
-    price: 25
+    cost_price: 17
   },
   {
     product: solidus_long,
     option_values: [medium, white],
     sku: "SOL-LS04",
-    cost_price: 17,
-    price: 25
+    cost_price: 17
   },
   {
     product: solidus_long,
     option_values: [medium, black],
     sku: "SOL-LS05",
-    cost_price: 17,
-    price: 25
+    cost_price: 17
   },
   {
     product: solidus_long,
     option_values: [medium, blue],
     sku: "SOL-LS06",
-    cost_price: 17,
-    price: 25
+    cost_price: 17
   },
   {
     product: solidus_long,
     option_values: [large, white],
     sku: "SOL-LS07",
-    cost_price: 17,
-    price: 25
+    cost_price: 17
   },
   {
     product: solidus_long,
     option_values: [large, black],
     sku: "SOL-LS08",
-    cost_price: 17,
-    price: 25
+    cost_price: 17
   },
   {
     product: solidus_long,
     option_values: [large, blue],
     sku: "SOL-LS09",
-    cost_price: 17,
-    price: 25
+    cost_price: 17
   },
   {
     product: solidus_womens_tshirt,
     option_values: [small, black],
     sku: "SOL-WM001",
-    cost_price: 17,
-    price: 25
+    cost_price: 17
   },
   {
     product: solidus_womens_tshirt,
     option_values: [small, blue],
     sku: "SOL-WM002",
-    cost_price: 17,
-    price: 25
+    cost_price: 17
   },
   {
     product: solidus_womens_tshirt,
     option_values: [small, white],
     sku: "SOL-WM003",
-    cost_price: 17,
-    price: 25
+    cost_price: 17
   },
   {
     product: solidus_womens_tshirt,
     option_values: [medium, blue],
     sku: "SOL-WM004",
-    cost_price: 17,
-    price: 25
+    cost_price: 17
   },
   {
     product: solidus_womens_tshirt,
     option_values: [medium, white],
     sku: "SOL-WM005",
-    cost_price: 17,
-    price: 25
+    cost_price: 17
   },
   {
     product: solidus_womens_tshirt,
     option_values: [medium, black],
     sku: "SOL-WM006",
-    cost_price: 17,
-    price: 25
+    cost_price: 17
   }
 ]
 
 masters = {
   solidus_tote => {
     sku: "SOL-TOT01",
-    cost_price: 17,
-    price: 25
+    cost_price: 17
   },
   ruby_tote => {
     sku: "RUB-TOT01",
-    cost_price: 17,
-    price: 25
+    cost_price: 17
   },
   solidus_snapback_cap => {
     sku: "SOL-SNC01",
-    cost_price: 17,
-    price: 25
+    cost_price: 17
   },
   solidus_tshirt => {
     sku: "SOL-00001",
-    cost_price: 17,
-    price: 25
+    cost_price: 17
   },
   solidus_long => {
     sku: "SOL-LS00",
-    cost_price: 17,
-    price: 25
+    cost_price: 17
   },
   solidus_hoodie => {
     sku: "SOL-HD00",
-    cost_price: 27,
-    price: 25
+    cost_price: 27
   },
   ruby_hoodie => {
     sku: "RUB-HD01",
-    cost_price: 27,
-    price: 25
+    cost_price: 27
   },
   ruby_hoodie_zip => {
     sku: "RUB-HD00",
-    cost_price: 27,
-    price: 25
+    cost_price: 27
   },
   ruby_polo => {
     sku: "RUB-PL01",
-    cost_price: 23,
-    price: 25
+    cost_price: 23
   },
   solidus_mug => {
     sku: "SOL-MG01",
-    cost_price: 7,
-    price: 25
+    cost_price: 7
   },
   ruby_mug => {
     sku: "RUB-MG01",
-    cost_price: 7,
-    price: 25
+    cost_price: 7
   },
   solidus_womens_tshirt => {
     sku: "SOL-WM00",
-    cost_price: 17,
-    price: 25
+    cost_price: 17
   }
 }
 


### PR DESCRIPTION
Reverts solidusio/solidus#4078

For now, we've decided to put the greater goal behind this change
(inheriting all prices from master when creating variants) on hold. The
reason for that is that we have higher priorities and that we'll revisit
refactoring core logic when we implement more events or services on
Solidus.

As the reverted commit raised a deprecation warning, it's better to wait until
we have a clearer direction in mind.