### PR TITLE
Revert "Raise canceling a payment when try_void"

### DIFF
--- a/core/app/models/spree/payment/cancellation.rb
+++ b/core/app/models/spree/payment/cancellation.rb
@@ -26,10 +26,16 @@ module Spree
       # @param payment [Spree::Payment] - the payment that should be canceled
       #
       def cancel(payment)
-        if response = payment.payment_method.try_void(payment)
-          payment.handle_void_response(response)
+        # For payment methods already implemeting `try_void`
+        if try_void_available?(payment.payment_method)
+          if response = payment.payment_method.try_void(payment)
+            payment.handle_void_response(response)
+          else
+            payment.refunds.create!(amount: payment.credit_allowed, reason: refund_reason, perform_after_create: false).perform!
+          end
         else
-          payment.refunds.create!(amount: payment.credit_allowed, reason: refund_reason, perform_after_create: false).perform!
+          # For payment methods not yet implemeting `try_void`
+          deprecated_behavior(payment)
         end
       end
 
@@ -37,6 +43,19 @@ module Spree
 
       def refund_reason
         Spree::RefundReason.where(name: reason).first_or_create
+      end
+
+      def try_void_available?(payment_method)
+        payment_method.respond_to?(:try_void) &&
+          payment_method.method(:try_void).owner != Spree::PaymentMethod
+      end
+
+      def deprecated_behavior(payment)
+        Spree::Deprecation.warn "#{payment.payment_method.class.name}#cancel is deprecated and will be removed. " \
+          'Please implement a `try_void` method instead that returns a response object if void succeeds ' \
+          'or `false|nil` if not. Solidus will refund the payment then.'
+        response = payment.payment_method.cancel(payment.response_code)
+        payment.handle_void_response(response)
       end
     end
   end

--- a/core/spec/models/spree/payment/cancellation_spec.rb
+++ b/core/spec/models/spree/payment/cancellation_spec.rb
@@ -23,42 +23,59 @@ RSpec.describe Spree::Payment::Cancellation do
     let(:payment_method) { create(:payment_method) }
     let(:payment) { create(:payment, payment_method: payment_method, amount: 10) }
 
-    context 'if payment method returns void response' do
-      before do
-        expect(payment_method).to receive(:try_void).with(payment) { double }
+    context 'if the payment_method responds to `try_void`' do
+      context 'if payment method returns void response' do
+        before do
+          expect(payment_method).to receive(:try_void).with(payment) { double }
+        end
+
+        it 'handles the void' do
+          expect(payment).to receive(:handle_void_response)
+          subject
+        end
       end
 
-      it 'handles the void' do
-        expect(payment).to receive(:handle_void_response)
-        subject
+      context 'if payment method rejects the void' do
+        before do
+          expect(payment_method).to receive(:try_void).with(payment) { false }
+        end
+
+        it 'refunds the payment' do
+          expect { subject }.to change { payment.refunds.count }.from(0).to(1)
+        end
+
+        context 'if payment has partial refunds' do
+          let(:credit_amount) { payment.amount / 2 }
+
+          before do
+            payment.refunds.create!(
+              amount: credit_amount,
+              reason: Spree::RefundReason.where(name: 'test').first_or_create,
+              perform_after_create: false
+            ).perform!
+          end
+
+          it 'only refunds the allowed credit amount' do
+            subject
+            refund = payment.refunds.last
+            expect(refund.amount).to eq(credit_amount)
+          end
+        end
       end
     end
 
-    context 'if payment method rejects the void' do
+    context 'if the payment_method does not respond to `try_void`', partial_double_verification: false do
       before do
-        expect(payment_method).to receive(:try_void).with(payment) { false }
+        allow(payment_method).to receive(:respond_to?) { false }
+        allow(payment_method).to receive(:cancel) { double }
+        allow(payment).to receive(:handle_void_response)
+        expect(Spree::Deprecation).to receive(:warn).
+          with(/^Spree::PaymentMethod::.*#cancel is deprecated and will be removed/, any_args)
       end
 
-      it 'refunds the payment' do
-        expect { subject }.to change { payment.refunds.count }.from(0).to(1)
-      end
-
-      context 'if payment has partial refunds' do
-        let(:credit_amount) { payment.amount / 2 }
-
-        before do
-          payment.refunds.create!(
-            amount: credit_amount,
-            reason: Spree::RefundReason.where(name: 'test').first_or_create,
-            perform_after_create: false
-          ).perform!
-        end
-
-        it 'only refunds the allowed credit amount' do
-          subject
-          refund = payment.refunds.last
-          expect(refund.amount).to eq(credit_amount)
-        end
+      it 'calls cancel instead' do
+        expect(payment_method).to receive(:cancel)
+        subject
       end
     end
   end


### PR DESCRIPTION
This reverts [this](https://github.com/solidusio/solidus/commit/4e1002c79) commit, as it was supposed to only stay in v3.0 but got accidentally backported to v2.11.