### PR TITLE
Fix Ransack error when searching for orders by customer name

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -51,7 +51,7 @@ module Spree
     end
 
     self.whitelisted_ransackable_associations = %w[shipments user order_promotions promotions bill_address ship_address line_items]
-    self.whitelisted_ransackable_attributes = %w[bill_address_name completed_at created_at email number state payment_state shipment_state total store_id]
+    self.whitelisted_ransackable_attributes = %w[completed_at created_at email number state payment_state shipment_state total store_id]
 
     attr_reader :coupon_code
     attr_accessor :temporary_address


### PR DESCRIPTION
**Description**

Fixes an issue in 3.0 where, if you try to search for an order by the customer's name, Ransack crashes.

The problem was introduced inadvertently in [94bfaa7](https://github.com/solidusio/solidus/commit/94bfaa7a1796cf0dbe45792855e99b2d255af1e5). This Ransackable attribute was supposed to be removed completely, since it is not a Ransack alias anymore, but an actual DB column that lives on the `bill_address` association.

A regression test didn't seem necessary, given the minor nature of the problem.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
