### PR TITLE
Make order-related service objects configurable

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -269,7 +269,7 @@ module Spree
     end
 
     def contents
-      @contents ||= Spree::OrderContents.new(self)
+      @contents ||= Spree::Config.order_contents_class.new(self)
     end
 
     def shipping

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -277,7 +277,7 @@ module Spree
     end
 
     def cancellations
-      @cancellations ||= Spree::OrderCancellations.new(self)
+      @cancellations ||= Spree::Config.order_cancellations_class.new(self)
     end
 
     # Associates the specified user with the order.

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -273,7 +273,7 @@ module Spree
     end
 
     def shipping
-      @shipping ||= Spree::OrderShipping.new(self)
+      @shipping ||= Spree::Config.order_shipping_class.new(self)
     end
 
     def cancellations

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -379,6 +379,13 @@ module Spree
     #   Spree::OrderContents.
     class_name_attribute :order_contents_class, default: 'Spree::OrderContents'
 
+    # Allows providing your own class for shipping an order.
+    #
+    # @!attribute [rw] order_shipping_class
+    # @return [Class] a class with the same public interfaces as
+    #   Spree::OrderShipping.
+    class_name_attribute :order_shipping_class, default: 'Spree::OrderShipping'
+
     # Allows providing your own class for canceling payments.
     #
     # @!attribute [rw] payment_canceller

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -372,6 +372,13 @@ module Spree
     #   Spree::Wallet::DefaultPaymentBuilder.
     class_name_attribute :default_payment_builder_class, default: 'Spree::Wallet::DefaultPaymentBuilder'
 
+    # Allows providing your own class for managing the contents of an order.
+    #
+    # @!attribute [rw] order_contents_class
+    # @return [Class] a class with the same public interfaces as
+    #   Spree::OrderContents.
+    class_name_attribute :order_contents_class, default: 'Spree::OrderContents'
+
     # Allows providing your own class for canceling payments.
     #
     # @!attribute [rw] payment_canceller

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -386,6 +386,14 @@ module Spree
     #   Spree::OrderShipping.
     class_name_attribute :order_shipping_class, default: 'Spree::OrderShipping'
 
+    # Allows providing your own class for managing the inventory units of a
+    # completed order.
+    #
+    # @!attribute [rw] order_cancellations_class
+    # @return [Class] a class with the same public interfaces as
+    #   Spree::OrderCancellations.
+    class_name_attribute :order_cancellations_class, default: 'Spree::OrderCancellations'
+
     # Allows providing your own class for canceling payments.
     #
     # @!attribute [rw] payment_canceller


### PR DESCRIPTION
**Description**

Solidus has a few "service objects" that are used to manage orders:

- `Spree::OrderContents`, for managing the contents and the state of an order,
- `Spree::OrderShipping`, for shipping a completed order, and
- `Spree::OrderCancellations`, for managing a completed order's inventory units.

In custom stores, it's common to customize these classes to inject your own logic/checks in different flows.

This PR makes it possible to replace these classes with a custom implementation without monkey-patching the default implementations or the corresponding builders on `Spree::Order`.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
