### PR TITLE
Docker: Change public keys server after deprecation

### DIFF
--- a/.dockerdev/Dockerfile
+++ b/.dockerdev/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update -qq \
 RUN curl -sSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
   && echo 'deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main' $PG_VERSION > /etc/apt/sources.list.d/pgdg.list
 
-RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 8C718D3B5072E1F5 \
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 8C718D3B5072E1F5 \
  && echo "deb http://repo.mysql.com/apt/debian/ buster mysql-"$MYSQL_VERSION > /etc/apt/sources.list.d/mysql.list
 
 RUN curl -sSL https://deb.nodesource.com/setup_$NODE_VERSION.x | bash -


### PR DESCRIPTION
ha.pool.sks-keyservers.net has been deprecated, so we'll use
keyserver.ubuntu.com from this point on.

![screenshot-sks-keyservers net-2021 08 02-09_51_56](https://user-images.githubusercontent.com/52650/127824897-be724eff-a816-4591-933a-ea71642ea218.png)


**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
