### PR TITLE
Make option value to variant association unique

### DIFF
--- a/core/db/migrate/20210815004823_add_unique_index_to_option_values_variants.rb
+++ b/core/db/migrate/20210815004823_add_unique_index_to_option_values_variants.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AddUniqueIndexToOptionValuesVariants < ActiveRecord::Migration[5.2]
+  def up
+    remove_index :spree_option_values_variants, [:variant_id, :option_value_id]
+    add_index :spree_option_values_variants, [:variant_id, :option_value_id],
+              name: "index_option_values_variants_on_variant_id_and_option_value_id",
+              unique: true
+  end
+
+  def down
+    remove_index :spree_option_values_variants, [:variant_id, :option_value_id]
+    add_index :spree_option_values_variants, [:variant_id, :option_value_id],
+              name: "index_option_values_variants_on_variant_id_and_option_value_id"
+  end
+end

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -1042,4 +1042,9 @@ RSpec.describe Spree::Variant, type: :model do
     subject { variant.sku_and_options_text }
     it { is_expected.to eq("EB1 Size: S") }
   end
+
+  it "cannot have the same option value multiple times" do
+    expect { variant.option_values << variant.option_values.first }
+      .to raise_error ActiveRecord::RecordNotUnique
+  end
 end


### PR DESCRIPTION
**Description**

I can't think of a reason why someone would want to associate the same option value with a given variant multiple times. This makes the index on the `variant`/`option_value_id` columns of the `spree_option_values_variants` join table a unique index so we can't have a variant that has the same option value multiple times.

**Checklist:**

- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
