### PR TITLE
Fix small typo in the 'customizing permissions' guide

### DIFF
--- a/guides/source/developers/customizations/customizing-permissions.html.md
+++ b/guides/source/developers/customizations/customizing-permissions.html.md
@@ -73,7 +73,7 @@ in one of the following ways:
   `Spree::Role.create(name: 'role_name')` in the Rails console
 - Add the line
   `Spree::Role.find_or_create_by(name: 'role_name')` in one of the configuration
-  files (`config/intializers/spree.rb`, `config/application.rb`,
+  files (`config/initializers/spree.rb`, `config/application.rb`,
   `db/migrations`, `db/seeds`) for each role you wish to create
 
 Now that the new role has been created you can simply assign a new list of


### PR DESCRIPTION
**Description**
This PR fixes a small typo in the "customizing permissions" guide:
- ~`intializers`~ -> `initializers`

![Screenshot 2021-08-17 at 18 30 31](https://user-images.githubusercontent.com/1634023/129764832-9b1607f1-01b7-4359-88e7-f6e0864b9c1a.png)

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
