### PR TITLE
Fix displaying of discarded variants in admin

### DIFF
--- a/backend/app/views/spree/admin/variants/_table_filter.html.erb
+++ b/backend/app/views/spree/admin/variants/_table_filter.html.erb
@@ -11,7 +11,7 @@
       </div>
     </div>
 
-    <% if product.variants.discarded.any? %>
+    <% if product.variants.with_discarded.discarded.any? %>
       <div class="col-2">
         <div class="field checkbox">
           <label>

--- a/backend/app/views/spree/admin/variants/index.html.erb
+++ b/backend/app/views/spree/admin/variants/index.html.erb
@@ -14,7 +14,7 @@
   <% end %>
 <% end %>
 
-<% if @variants.any? || @product.variants.discarded.any? %>
+<% if @product.variants.with_discarded.any? %>
   <%= render "table_filter", product: @product %>
   <%= render "table", variants: @variants %>
 <% else %>

--- a/backend/spec/features/admin/products/variant_spec.rb
+++ b/backend/spec/features/admin/products/variant_spec.rb
@@ -48,6 +48,28 @@ describe "Variants", type: :feature do
         end
       end
     end
+
+    context 'displaying discarded variants' do
+      let!(:existing_variant) { create(:variant, sku: 'existing_variant_sku', product: product) }
+      let!(:discarded_variant) { create(:variant, sku: 'discarded_variant_sku', product: product) }
+
+      before { discarded_variant.discard! }
+
+      it 'does not display deleted variants by default' do
+        visit spree.admin_product_variants_path(product)
+
+        expect(page).to have_content(existing_variant.sku)
+        expect(page).not_to have_content(discarded_variant.sku)
+      end
+
+      it 'allows to display deleted variants with a filter' do
+        visit spree.admin_product_variants_path(product)
+        check 'Show Deleted Variants'
+        click_button 'search'
+
+        expect(page).to have_content(discarded_variant.sku)
+      end
+    end
   end
 
   context "editing existent variant" do


### PR DESCRIPTION
**Description**
<!--
  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

  Please include screenshots in case of visual changes to the frontend or backend sections of Solidus.

  If needed you can reference another PR or issue here, e.g.:
  Ref #ISSUE
-->

After [this](https://github.com/solidusio/solidus/pull/3488/commits/466251e98255a90fc4c8cc7b975b9e6a7eb11ceb#diff-8d7f47a3ad53cdbd891309971535613fc900c314655eb8c7527d7ae1f9afd53eR13), discarded variants are not displayable anymore because `Discard#discarded` scope now operates on `kept` scope and finds no result if not prepended with a larger scope, as suggested [here](https://github.com/jhawthorn/discard#default-scope).
This prevents the "deleted variants" filter from being displayed in the variants list on the admin panel.

This PR provides a quick fix for displaying the "deleted variants" filter again in the admin variants, which allows to display the deleted variants again.

Two alternative solutions that I considered, with the help of @spaghetticode:
* removing the default scope: this could be pretty hard to do and could introduce a breaking change, requiring all Solidus users to manually apply the scope that is currently used as default
* overriding the `discarded` scope: this implementation would be very dependent on the soft deletion gem in-use, because (as far as I know) there is no way to call the `super` scope from its override. It would have resulted in something like `scope :discarded, -> { with_discarded.where.not(deleted_at: nil) }`.

So I thought that the solution I'm proposing was more reasonable, let me know your thoughts if you disagree or I'm missing something.



**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)

