### PR TITLE
Remove Pending Request Spec: Api Admin update payment state expectations.

### DIFF
--- a/api/spec/requests/spree/api/payments_controller_spec.rb
+++ b/api/spec/requests/spree/api/payments_controller_spec.rb
@@ -157,6 +157,7 @@ module Spree
               put spree.api_order_payment_path(order, payment), params: { payment: { amount: 'invalid' } }
               expect(response.status).to eq(422)
               expect(json_response["error"]).to eq("Invalid resource. Please fix errors and try again.")
+              expect(payment.reload.state).to eq("pending")
             end
 
             it "returns a 403 status when the payment is not pending" do
@@ -186,10 +187,6 @@ module Spree
               expect(response.status).to eq(422)
               expect(json_response["error"]).to eq "Invalid resource. Please fix errors and try again."
               expect(json_response["errors"]["base"][0]).to eq "Could not authorize card"
-            end
-
-            it "does not raise a stack level error" do
-              skip "Investigate why a payment.reload after the request raises 'stack level too deep'"
               expect(payment.reload.state).to eq("failed")
             end
           end
@@ -213,6 +210,7 @@ module Spree
               expect(response.status).to eq(422)
               expect(json_response["error"]).to eq "Invalid resource. Please fix errors and try again."
               expect(json_response["errors"]["base"][0]).to eq "Insufficient funds"
+              expect(payment.reload.state).to eq("failed")
             end
           end
         end
@@ -235,6 +233,7 @@ module Spree
               expect(response.status).to eq(422)
               expect(json_response["error"]).to eq "Invalid resource. Please fix errors and try again."
               expect(json_response["errors"]["base"][0]).to eq "Insufficient funds"
+              expect(payment.reload.state).to eq("failed")
             end
           end
         end


### PR DESCRIPTION
Removes Pending spec:  payment.reload after the request raises 'stack level too deep'

Adds expectation for payment.reload.state. 
These states could lead to discussion about what the correctness of these expectations.

**Description**

Motivation: 

As newcomer to the codebase, a pending spec is typically a decent place to start.  
I could not reproduce the behavior for the skipped expectation. 
I was not sure of the expected states... so added them for discussion purposes.


**Checklist:**
- [ X] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [ X] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
