### PR TITLE
Hide the master variants from stock management

### DIFF
--- a/backend/app/controllers/spree/admin/stock_items_controller.rb
+++ b/backend/app/controllers/spree/admin/stock_items_controller.rb
@@ -51,7 +51,12 @@ module Spree
 
       def variant_scope
         scope = Spree::Variant.accessible_by(current_ability)
-        scope = scope.where(product: @product) if @product
+        if @product
+          scope = scope.where(
+            product: @product,
+            is_master: !@product.has_variants?
+          )
+        end
         scope = scope.order(:sku)
         scope
       end

--- a/backend/spec/controllers/spree/admin/stock_items_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/stock_items_controller_spec.rb
@@ -30,20 +30,45 @@ module Spree
       describe "#index" do
         let!(:variant_1) { create(:variant) }
         let!(:variant_2) { create(:variant) }
+        let!(:product_1) { create(:product) }
+        let!(:product_2) { create(:product) }
+        let!(:variant_3) { create(:variant, product: product_2) }
+        let!(:variant_4) { create(:variant, product: product_2) }
 
         context "with product_slug param" do
           it "scopes the variants by the product" do
             get :index, params: { product_slug: variant_1.product.slug }
-            expect(assigns(:variants)).to include variant_1
-            expect(assigns(:variants)).not_to include variant_2
+            expect(assigns(:variants)).to contain_exactly(variant_1)
+          end
+
+          context "when a product with no variants is requested" do
+            it "returns the master variant of the product" do
+              get :index, params: { product_slug: product_1.slug }
+              expect(assigns(:variants)).to contain_exactly(product_1.master)
+            end
+          end
+
+          context "when a product with variants is requested" do
+            it "returns only the variants of the product" do
+              get :index, params: { product_slug: product_2.slug }
+              expect(assigns(:variants)).to contain_exactly(variant_3, variant_4)
+            end
           end
         end
 
         context "without product_slug params" do
           it "allows all accessible variants to be returned" do
             get :index
-            expect(assigns(:variants)).to include variant_1
-            expect(assigns(:variants)).to include variant_2
+            expect(assigns(:variants)).to contain_exactly(
+              variant_1,
+              variant_1.product.master,
+              variant_2,
+              variant_2.product.master,
+              product_1.master,
+              product_2.master,
+              variant_3,
+              variant_4
+            )
           end
         end
       end


### PR DESCRIPTION
This PR hides the master variants from the stock management list if the product has variants. This prevents a strange experience when managing inventory for these products - they don't really have SKUs, and aren't sellable in the general case.

Before:
<img width="1134" alt="Screen Shot 2021-08-26 at 3 20 29 PM" src="https://user-images.githubusercontent.com/16063079/131036685-a67c2152-e7df-456f-8c29-ffd9d4d84059.png">

After:
![image](https://user-images.githubusercontent.com/16063079/131036640-623bfab4-7507-4376-99e4-bb6572c00efd.png)

- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
