### PR TITLE
Fix gateway_error when no order is defined

### DIFF
--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -71,8 +71,11 @@ module Spree
       end
 
       def gateway_error(exception)
-        @order.errors.add(:base, exception.message)
-        invalid_resource!(@order)
+        # Fall back to a blank order if one isn't set, as we only need this for
+        # its errors interface.
+        model = @order || Spree::Order.new
+        model.errors.add(:base, exception.message)
+        invalid_resource!(model)
       end
 
       def parameter_missing_error(exception)

--- a/api/spec/controllers/spree/api/base_controller_spec.rb
+++ b/api/spec/controllers/spree/api/base_controller_spec.rb
@@ -145,7 +145,7 @@ describe Spree::Api::BaseController, type: :controller do
       get :index
     end
 
-    context "with @order defined" do
+    context "with @order not defined" do
       controller(Spree::Api::BaseController) do
         def index
           raise Spree::Core::GatewayError, "Insufficient Funds"
@@ -167,7 +167,7 @@ describe Spree::Api::BaseController, type: :controller do
       end
     end
 
-    context "with @order not defined" do
+    context "with @order defined" do
       controller(Spree::Api::BaseController) do
         def index
           @order = Spree::Order.new

--- a/api/spec/controllers/spree/api/base_controller_spec.rb
+++ b/api/spec/controllers/spree/api/base_controller_spec.rb
@@ -2,9 +2,6 @@
 
 require 'spec_helper'
 
-class FakesController < Spree::Api::BaseController
-end
-
 describe Spree::Api::BaseController, type: :controller do
   render_views
   controller(Spree::Api::BaseController) do


### PR DESCRIPTION
If the current controller raises a gateway error, but does not have
`@order` defined, this error handler will raise a NoMethodError when it
tries to access `nil.errors`.

We can resolve this by falling back to an empty Order instance if none
is defined. This maintains the existing behaviour, and as the response
only serializes the errors hash, there shouldn't be any surprises with
null fields, etc.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change (if needed)
