### PR TITLE
Get Solidus ready for 3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Solidus 3.1.0 (master, unreleased)
+## Solidus 3.2.0.alpha (master, unreleased)
+
+## Solidus 3.1.0 (v3.1, 2021-09-10)
 
 ### Major changes
 

--- a/core/lib/spree/core/version.rb
+++ b/core/lib/spree/core/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Spree
-  VERSION = "3.1.0.alpha"
+  VERSION = "3.2.0.alpha"
 
   def self.solidus_version
     VERSION

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
         NODE_VERSION: 14
         MYSQL_VERSION: "8.0"
         BUNDLER_VERSION: 2
-    image: solidus-3.1.0
+    image: solidus-3.2.0
     command: bash -c "(bundle check || bundle) && tail -f /dev/null"
     environment:
       CAPYBARA_DRIVER: selenium_chrome_headless_docker_friendly


### PR DESCRIPTION
**Description**

These are tasks needed after the 3.1 release to have `master` ready for the next release. This is part of the [How to release Solidus wiki page](https://github.com/solidusio/solidus/wiki/How-to-release-Solidus).
