### PR TITLE
Change application-template generation script to use main branch

### DIFF
--- a/bin/rails-application-template
+++ b/bin/rails-application-template
@@ -135,6 +135,6 @@ after_bundle do
 
   if ENV['UPDATE_EXAMPLE_APP_REPO']
     git remote: %{ add origin git@github.com:solidusio/solidus-example-app.git }
-    git push: %{ --force --set-upstream origin master }
+    git push: %{ --force --set-upstream origin main }
   end
 end


### PR DESCRIPTION
**Description**

To have a Heroku deploy button ready to preview Solidus, we created a repository (updated every time we release a new Minor/Major version) that has the current Solidus code here: https://github.com/solidusio/solidus-example-app.

To generate this app we can launch these commands:

```bash
export UPDATE_EXAMPLE_APP_REPO=true # Enable the automatic push to GitHub.​
# Start the generator script that will generate the app 
# inside ./solidus-example-app and push it to GitHub.
solidus/bin/rails-application-template
```

And this is currently failing because the new application will be created with the default branch named main instead of master now. We need to reflect this change in the command that tries to push the updated app to GitHub. 

✅ ~It is also required to change the main branch in the repository as well.~
