### PR TITLE
Fix searching deleted products by SKU

### DIFF
--- a/backend/app/assets/javascripts/spree/backend.js
+++ b/backend/app/assets/javascripts/spree/backend.js
@@ -47,6 +47,7 @@
 //= require spree/backend/orders
 //= require spree/backend/payments/edit
 //= require spree/backend/payments/new
+//= require spree/backend/products/index
 //= require spree/backend/product_picker
 //= require spree/backend/progress
 //= require spree/backend/promotions

--- a/backend/app/assets/javascripts/spree/backend/namespaces.js
+++ b/backend/app/assets/javascripts/spree/backend/namespaces.js
@@ -8,6 +8,7 @@ _.extend(window.Spree, {
     Cart: {},
     Zones: {},
     Payment: {},
+    Product: {},
     Promotions: {},
     Stock: {},
     Tables: {}

--- a/backend/app/assets/javascripts/spree/backend/products/index.js
+++ b/backend/app/assets/javascripts/spree/backend/products/index.js
@@ -1,0 +1,7 @@
+Spree.ready(function() {
+  if ($('[data-hook="admin_products_index_search"]').length) {
+    new Spree.Views.Product.Search({
+      el: $('[data-hook="admin_products_index_search"]')
+    })
+  }
+});

--- a/backend/app/assets/javascripts/spree/backend/views/index.js
+++ b/backend/app/assets/javascripts/spree/backend/views/index.js
@@ -21,6 +21,7 @@
 //= require 'spree/backend/views/payment/new'
 //= require 'spree/backend/views/payment/payment_row'
 //= require 'spree/backend/views/payment/edit_credit_card'
+//= require 'spree/backend/views/product/search'
 //= require 'spree/backend/views/promotions/option_values_rule'
 //= require 'spree/backend/views/tables/editable_table'
 //= require 'spree/backend/views/tables/editable_table_row'

--- a/backend/app/assets/javascripts/spree/backend/views/product/search.js
+++ b/backend/app/assets/javascripts/spree/backend/views/product/search.js
@@ -1,0 +1,44 @@
+Spree.Views.Product.Search = Backbone.View.extend({
+  initialize: function() {
+    this.render();
+  },
+
+  events: {
+    "change .js-with-discarded-input": "onChange"
+  },
+
+  onChange: function(e) {
+    const withDiscarded = $(e.target).is(":checked");
+
+    var keptInput = this.$el.find(".js-kept-variant-sku-input input");
+    var allInput = this.$el.find(".js-all-variant-sku-input input");
+
+    if (withDiscarded) {
+      allInput.val(keptInput.val());
+      keptInput.val("");
+    } else {
+      keptInput.val(allInput.val());
+      allInput.val("");
+    }
+
+    allInput.prop("disabled", !withDiscarded)
+    keptInput.prop("disabled", withDiscarded)
+
+    this.render();
+  },
+
+  render: function() {
+    var withDiscarded = this.$el.find(".js-with-discarded-input").is(":checked");
+
+    var keptContainer = this.$el.find(".js-kept-variant-sku-input");
+    var allContainer = this.$el.find(".js-all-variant-sku-input");
+
+    if (withDiscarded) {
+      keptContainer.hide();
+      allContainer.show();
+    } else {
+      keptContainer.show();
+      allContainer.hide();
+    }
+  },
+});

--- a/backend/app/views/spree/admin/products/index.html.erb
+++ b/backend/app/views/spree/admin/products/index.html.erb
@@ -26,15 +26,21 @@
 
           <div class="col-4">
             <div class="field">
-              <%= f.label :with_variant_sku_cont, Spree::Variant.human_attribute_name(:sku) %>
-              <%= f.text_field :with_variant_sku_cont, size: 15 %>
+              <div class="js-kept-variant-sku-input">
+                <%= f.label :with_kept_variant_sku_cont, Spree::Variant.human_attribute_name(:sku) %>
+                <%= f.text_field :with_kept_variant_sku_cont, size: 15 %>
+              </div>
+              <div class="js-all-variant-sku-input">
+                <%= f.label :with_all_variant_sku_cont, Spree::Variant.human_attribute_name(:sku) %>
+                <%= f.text_field :with_all_variant_sku_cont, size: 15 %>
+              </div>
             </div>
           </div>
 
           <div class="col-2">
             <div class="field checkbox">
               <label>
-                <%= f.check_box :with_discarded, { checked: params[:q][:with_discarded] == 'true' }, 'true', 'false' %>
+                <%= f.check_box :with_discarded, { checked: params[:q][:with_discarded] == 'true', class: 'js-with-discarded-input' }, 'true', 'false' %>
                 <%= t('spree.show_deleted') %>
               </label>
             </div>

--- a/backend/spec/features/admin/products/products_spec.rb
+++ b/backend/spec/features/admin/products/products_spec.rb
@@ -89,8 +89,8 @@ describe "Products", type: :feature do
       end
     end
 
-    context "searching products" do
-      it "should be able to search deleted products", js: true do
+    context "searching products", js: true do
+      it "should be able to search deleted products" do
         create(:product, name: 'apache baseball cap', deleted_at: "2011-01-06 18:21:13")
         create(:product, name: 'zomg shirt')
 
@@ -125,6 +125,32 @@ describe "Products", type: :feature do
         expect(page).to have_content("apache baseball cap")
         expect(page).not_to have_content("apache baseball cap2")
         expect(page).not_to have_content("zomg shirt")
+      end
+
+      # Regression test for https://github.com/solidusio/solidus/issues/3912
+      it "should be able to search deleted products by their properties" do
+        create(:product, name: "First Product", sku: "A101").discard
+        create(:product, name: "Second Product", sku: "A102")
+        create(:product, name: "Third Product", sku: "B100")
+
+        click_nav "Products"
+        expect(page).not_to have_content("First Product")
+        expect(page).to have_content("Second Product")
+        expect(page).to have_content("Third Product")
+
+        fill_in "SKU", with: "A1"
+        check "Show Deleted"
+        click_button "Search"
+        expect(find('input[name="q[with_discarded]"]')).to be_checked
+        expect(page).to have_content("First Product")
+        expect(page).to have_content("Second Product")
+        expect(page).not_to have_content("Third Product")
+
+        uncheck "Show Deleted"
+        click_button "Search"
+        expect(page).not_to have_content("First Product")
+        expect(page).to have_content("Second Product")
+        expect(page).not_to have_content("Third Product")
       end
 
       # Regression test for https://github.com/solidusio/solidus/issues/2016

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -134,7 +134,7 @@ module Spree
     self.whitelisted_ransackable_attributes = %w[name slug]
 
     def self.ransackable_scopes(_auth_object = nil)
-      %i(with_discarded with_variant_sku_cont)
+      %i(with_discarded with_variant_sku_cont with_all_variant_sku_cont with_kept_variant_sku_cont)
     end
 
     # @return [Boolean] true if there are any variants

--- a/core/app/models/spree/product/scopes.rb
+++ b/core/app/models/spree/product/scopes.rb
@@ -194,11 +194,29 @@ module Spree
             group("spree_products.id").joins(:taxons).where(Spree::Taxon.arel_table[:name].eq(name))
           end
 
-          def self.with_variant_sku_cont(sku)
-            sku_match = "%#{sku}%"
+          def self.with_all_variant_sku_cont(sku)
             variant_table = Spree::Variant.arel_table
-            subquery = Spree::Variant.where(variant_table[:sku].matches(sku_match).and(variant_table[:product_id].eq(arel_table[:id])))
+            subquery = Spree::Variant.with_discarded.where(
+              variant_table[:sku].matches("%#{sku}%").and(
+                variant_table[:product_id].eq(arel_table[:id])
+              )
+            )
             where(subquery.arel.exists)
+          end
+
+          def self.with_kept_variant_sku_cont(sku)
+            variant_table = Spree::Variant.arel_table
+            subquery = Spree::Variant.where(
+              variant_table[:sku].matches("%#{sku}%").and(
+                variant_table[:product_id].eq(arel_table[:id])
+              )
+            )
+            where(subquery.arel.exists)
+          end
+
+          def self.with_variant_sku_cont(sku)
+            Spree::Deprecation.warn("use .with_kept_variant_sku_cont instead")
+            with_kept_variant_sku_cont(sku)
           end
 
           class << self

--- a/core/spec/models/spree/product/scopes_spec.rb
+++ b/core/spec/models/spree/product/scopes_spec.rb
@@ -183,4 +183,58 @@ RSpec.describe "Product scopes", type: :model do
       end
     end
   end
+
+  describe ".with_all_variant_sku_cont" do
+    let!(:product) { create(:product, sku: sku) }
+    let(:sku) { "SEARCH-SKU-1" }
+
+    subject { Spree::Product.with_all_variant_sku_cont("SEARCH") }
+
+    it "returns the product" do
+      expect(subject).to contain_exactly(product)
+    end
+
+    context "when the variant has been discarded" do
+      before { product.master.discard }
+
+      it "returns the product" do
+        expect(subject).to contain_exactly(product)
+      end
+    end
+
+    context "when the SKU doesn't match" do
+      let(:sku) { "NON-MATCHING-SKU" }
+
+      it "does not include the product" do
+        expect(subject).to be_empty
+      end
+    end
+  end
+
+  describe ".with_kept_variant_sku_cont" do
+    let!(:product) { create(:product, sku: sku) }
+    let(:sku) { "SEARCH-SKU-1" }
+
+    subject { Spree::Product.with_kept_variant_sku_cont("SEARCH") }
+
+    it "returns the product" do
+      expect(subject).to contain_exactly(product)
+    end
+
+    context "when the variant has been discarded" do
+      before { product.master.discard }
+
+      it "does not include the product" do
+        expect(subject).to be_empty
+      end
+    end
+
+    context "when the SKU doesn't match" do
+      let(:sku) { "NON-MATCHING-SKU" }
+
+      it "does not include the product" do
+        expect(subject).to be_empty
+      end
+    end
+  end
 end


### PR DESCRIPTION
**Description**

We've added two new scopes to `Spree::Product` and deprecated on existing one.
- `with_variant_sku_cont`: Has been deprecated in favour of `with_kept_variant_sku_cont`
- `with_all_variant_sku_cont`: Will search for products that have a variant containing the provided SKU, even if it has been discarded.
- `with_kept_variant_sku_cont`: Maintains the existing behaviour of `with_variant_sku_cont`, but with a more descriptive name.

This allows us, along with a new Backbone view to help control the two inputs we now have on the page (one for each scope), to correctly return deleted products when searching by SKU. Our view will swap out the inputs based on the value of the "with_deleted" checkbox so that the user experience is unchanged.

While attempting to fix this issue, there are a few other approaches we tried before settling on this one:
- Updating the scope to always include discarded variants. This came close but had an issue when the product had some discarded variants and would return the product regardless of the value of the "with_deleted" checkbox.
- Adding a parameter to the scope to conditionally include discarded variants. Ransack had some trouble with parameterizing the values from this. It would add extra stuff to the input field.

Fixes #3912

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] ~~I have updated Guides and README accordingly to this change (if needed)~~
- [x] I have added tests to cover this change (if needed)
- [ ] ~~I have attached screenshots to this PR for visual changes (if needed)~~
