### PR TITLE
Fix staled upgrade instructions on the Gemfile's post-install message

### DIFF
--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -55,7 +55,12 @@ $ bin/rails g solidus:install
 If you are updating Solidus from an older version, please run
 the following commands to complete the update:
 
-$ bin/rails solidus:upgrade
+$ bin/rails g solidus:update
+
+Please, don't forget to look at the CHANGELOG to see what has changed and
+whether you need to perform other tasks.
+
+https://github.com/solidusio/solidus/blob/master/CHANGELOG.md
 
 Please report any issues at:
 - https://github.com/solidusio/solidus/issues


### PR DESCRIPTION
The old upgrade task was removed in #4157

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
