### PR TITLE
Update install templates to use jquery3 (vulnerability fix)

### DIFF
--- a/backend/spec/javascripts/spec_helper.js
+++ b/backend/spec/javascripts/spec_helper.js
@@ -4,7 +4,7 @@
 //= require support/chai-jq-0.0.7
 
 //= require_self
-//= require jquery
+//= require jquery3
 //= require rails-ujs
 //= require spree/backend
 //= require_tree ./support

--- a/core/lib/generators/solidus/install/templates/vendor/assets/javascripts/spree/backend/all.js
+++ b/core/lib/generators/solidus/install/templates/vendor/assets/javascripts/spree/backend/all.js
@@ -4,7 +4,7 @@
 // It's not advisable to add code directly here, but if you do, it'll appear at the bottom of the
 // the compiled file.
 //
-//= require jquery
+//= require jquery3
 //= require rails-ujs
 //= require spree/backend
 //= require_tree .

--- a/core/lib/generators/solidus/install/templates/vendor/assets/javascripts/spree/frontend/all.js
+++ b/core/lib/generators/solidus/install/templates/vendor/assets/javascripts/spree/frontend/all.js
@@ -4,7 +4,7 @@
 // It's not advisable to add code directly here, but if you do, it'll appear at the bottom of the
 // the compiled file.
 //
-//= require jquery
+//= require jquery3
 //= require rails-ujs
 //= require spree/frontend
 //= require_tree .

--- a/guides/source/developers/assets/asset-management.html.md
+++ b/guides/source/developers/assets/asset-management.html.md
@@ -102,7 +102,7 @@ you that your Solidus backend include jQuery and any other files that you create
 in this `spree/backend` directory:
 
 ```javascript
-//= require jquery
+//= require jquery3
 //= require rails-ujs
 //= require spree/backend
 //= require_tree .


### PR DESCRIPTION
**Description**
jQuery has known vulnerabilities in versions prior to 3.5.0. This commit updates the load configuration to require and resolve to a version greater than 3.5.0 thereby alleviating the vulnerability. This applies to new installs only as it modifies the install template.

This change is in response to Issue #3905 


**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
