### PR TITLE
Respect completed_at timestamp in order factories

### DIFF
--- a/core/lib/spree/testing_support/factories/order_factory.rb
+++ b/core/lib/spree/testing_support/factories/order_factory.rb
@@ -68,6 +68,7 @@ FactoryBot.define do
 
       factory :completed_order_with_promotion do
         transient do
+          completed_at { Time.current }
           promotion { nil }
         end
 
@@ -79,7 +80,7 @@ FactoryBot.define do
           order.order_promotions.create!(promotion: promotion, promotion_code: promotion_code)
 
           # Complete the order after the promotion has been activated
-          order.update_column(:completed_at, Time.current)
+          order.update_column(:completed_at, evaluator.completed_at)
           order.update_column(:state, "complete")
         end
       end
@@ -104,13 +105,16 @@ FactoryBot.define do
       end
 
       factory :completed_order_with_totals do
+        transient do
+          completed_at { Time.current }
+        end
         state { 'complete' }
 
-        after(:create) do |order|
+        after(:create) do |order, evaluator|
           order.shipments.each do |shipment|
             shipment.inventory_units.update_all state: 'on_hand', pending: false
           end
-          order.update_column(:completed_at, Time.current)
+          order.update_column(:completed_at, evaluator.completed_at)
         end
 
         factory :completed_order_with_pending_payment do

--- a/core/spec/lib/spree/core/testing_support/factories/order_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/order_factory_spec.rb
@@ -122,6 +122,26 @@ RSpec.shared_examples "an order with line items factory" do |expected_order_stat
     end
   end
 end
+
+RSpec.shared_examples 'supplied completed_at is respected' do
+  context 'when passed a completed_at timestamp' do
+    let(:completed_at) { 2.days.ago }
+    let(:order) { create(factory, completed_at: completed_at) }
+
+    it 'respects the timestamp' do
+      expect(order.completed_at).to be_within(5.seconds).of(completed_at)
+    end
+  end
+
+  context 'when no completed_at timestamp is passed' do
+    let(:order) { create(factory) }
+
+    it 'defaults to the current time' do
+      expect(order.completed_at).to be_within(5.seconds).of(Time.current)
+    end
+  end
+end
+
 RSpec.describe 'order factory' do
   let(:factory_class) { Spree::Order }
 
@@ -200,6 +220,7 @@ RSpec.describe 'order factory' do
     it_behaves_like 'a working factory'
     it_behaves_like 'an order with line items factory', "complete", "on_hand"
     it_behaves_like 'shipping methods are assigned'
+    it_behaves_like 'supplied completed_at is respected'
 
     it "has the expected attributes" do
       order = create(factory)
@@ -255,6 +276,7 @@ RSpec.describe 'order factory' do
     it_behaves_like 'a working factory'
     it_behaves_like 'an order with line items factory', "complete", "on_hand"
     it_behaves_like 'shipping methods are assigned'
+    it_behaves_like 'supplied completed_at is respected'
 
     it "has the expected attributes" do
       order = create(factory)
@@ -278,6 +300,7 @@ RSpec.describe 'order factory' do
     it_behaves_like 'a working factory'
     it_behaves_like 'an order with line items factory', "complete", "on_hand"
     it_behaves_like 'shipping methods are assigned'
+    it_behaves_like 'supplied completed_at is respected'
 
     it "has the expected attributes" do
       order = create(factory)
@@ -304,6 +327,7 @@ RSpec.describe 'order factory' do
     it_behaves_like 'a working factory'
     it_behaves_like 'an order with line items factory', "complete", "on_hand"
     it_behaves_like 'shipping methods are assigned'
+    it_behaves_like 'supplied completed_at is respected'
 
     it "has the expected attributes" do
       order = create(factory)
@@ -345,6 +369,7 @@ RSpec.describe 'order factory' do
     it_behaves_like 'a working factory'
     it_behaves_like 'an order with line items factory', "complete", "shipped"
     it_behaves_like 'shipping methods are assigned'
+    it_behaves_like 'supplied completed_at is respected'
 
     it "has the expected attributes" do
       order = create(factory)

--- a/core/spec/lib/spree/core/testing_support/factories/order_factory_spec.rb
+++ b/core/spec/lib/spree/core/testing_support/factories/order_factory_spec.rb
@@ -137,7 +137,7 @@ RSpec.shared_examples 'supplied completed_at is respected' do
     let(:order) { create(factory) }
 
     it 'defaults to the current time' do
-      expect(order.completed_at).to be_within(5.seconds).of(Time.current)
+      expect(order.completed_at).to be_within(2.seconds).of(Time.current)
     end
   end
 end


### PR DESCRIPTION
The order factories that automatically complete orders previously used
Time.current when setting the completed_at timestamp. For developers who want
to pre-date their order completions, this can be confusing. This change allows
orders to be cleanly pre-dated in this way.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
