### PR TITLE
Fix shipping_method_spec test flakiness

### DIFF
--- a/core/spec/models/spree/shipping_method_spec.rb
+++ b/core/spec/models/spree/shipping_method_spec.rb
@@ -244,7 +244,7 @@ RSpec.describe Spree::ShippingMethod, type: :model do
 
       it 'returns the associated records' do
         expect(store.shipping_methods).to eq(subject)
-        expect(described_class.available_to_store(store)).to eq(subject)
+        expect(described_class.available_to_store(store)).to match_array(subject)
       end
     end
   end


### PR DESCRIPTION
Checking collection equality with eq can flake depending on the order of
items in the collection. Instead, using match_array allows for out of
order items.

Manually testing a second matcher with the collection `.reverse`d gives a 100% fail rate. Changing the assertion to a match_array gives a 100% pass rate.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
