### PR TITLE
Add deprecation path for arity-zero preference defaults

### DIFF
--- a/core/spec/models/spree/preferences/configuration_spec.rb
+++ b/core/spec/models/spree/preferences/configuration_spec.rb
@@ -35,6 +35,38 @@ RSpec.describe Spree::Preferences::Configuration, type: :model do
     expect(config.get(:foo)).to be(false)
   end
 
+  context "when default is a proc with arity zero" do
+    it "warns a deprecation message when it's a lambda" do
+      expect(Spree::Deprecation).to receive(:warn).with(/arity.*changed from 0 to 1/m)
+
+      config = Class.new(Spree::Preferences::Configuration) do
+        preference :lambda_with_arity_zero, :string, default: -> { 'foo' }
+      end.new
+
+      config.get(:lambda_with_arity_zero)
+    end
+
+    it "still takes the return value as the default" do
+      allow(Spree::Deprecation).to receive(:warn)
+
+      config = Class.new(Spree::Preferences::Configuration) do
+        preference :lambda_with_arity_zero, :string, default: -> { 'foo' }
+      end.new
+
+      expect(config.get(:lambda_with_arity_zero)).to eq('foo')
+    end
+
+    it "doesn't warn a deprecation message when it isn't a lambda" do
+      config = Class.new(Spree::Preferences::Configuration) do
+        preference :proc_with_arity_zero, :string, default: proc { 'foo' }
+      end.new
+
+      expect(Spree::Deprecation).not_to receive(:warn)
+
+      config.get(:proc_with_arity_zero)
+    end
+  end
+
   describe '#load_defaults' do
     it 'changes loaded_defaults' do
       config.load_defaults '2.1'


### PR DESCRIPTION
**Description**

Solidus 3.1 shipped with a new preferences system, where a default can
take different values depending on the Solidus version defaults that
have been loaded. See #4064 for details.

To achieve those above, when a proc is given as the default value
constructor, it now should take the loaded Solidus version as an
argument. That's a breaking change, as some extensions or user-defined
preferences may be using zero-arity lambdas.

This commit deprecates zero-arity lambdas but wraps them into another
lambda, taking and disregarding a single argument. That's only needed
for procs with lambda semantics, as raw procs will ignore the provided
extra argument.

When it comes to the implementation, as it's something to be ditched in
the next major release, we've opted for the more straightforward
solution. I.e., wrapping the lambda into the `Preferable` module even if
it only affects `AppConfiguration` classes. The default-handling logic
is very entangled into the former, and it'd take more work to extract
it.

Fixes #4165

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
