### PR TITLE
Recalculate promotions after destroying/refreshing shipments

### DIFF
--- a/core/app/models/spree/order_contents.rb
+++ b/core/app/models/spree/order_contents.rb
@@ -42,8 +42,8 @@ module Spree
           # If we do not update first, then the item total will be wrong and ItemTotal
           # promotion rules would not be triggered.
           reload_totals
-          PromotionHandler::Cart.new(order).activate
           order.ensure_updated_shipments
+          PromotionHandler::Cart.new(order).activate
         end
         reload_totals
         true


### PR DESCRIPTION
**Description**

This change has basically zero impact on a standard Solidus store, but is beneficial on stores that removed the `address` order state, as in that case [`order.ensure_updated_shipments`](https://github.com/solidusio/solidus/blob/master/core/app/models/spree/order.rb#L514) would actually recreate shipments when sending the order to `delivery` state, courtesy of `next!` from [`Order#restart_checkout_flow`](https://github.com/solidusio/solidus/blob/master/core/app/models/spree/order.rb#L522) (in a Solidus default store calling `Order#ensure_updated_shipments` simply destroys the shipments leaving the order in `address` state).

The current order of execution applies all promotions, including the ones for shipping, but these will then be removed by the subsequent call to `Order#ensure_updated_shipments`. 
Swapping the lines solves the issue, otherwise, stores need to re-apply shipping promotions with a local patch.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
