### PR TITLE
Rename Order#ensure_updated_shipments method

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -502,18 +502,18 @@ module Spree
       recalculate
     end
 
-    # Clean shipments and make order back to address state
-    #
-    # At some point the might need to force the order to transition from address
-    # to delivery again so that proper updated shipments are created.
-    # e.g. customer goes back from payment step and changes order items
-    def ensure_updated_shipments
+    # Clean shipments and make order back to address state (or to whatever state
+    # is set by restart_checkout_flow in case of state machine modifications)
+    def check_shipments_and_restart_checkout
       if !completed? && shipments.all?(&:pending?)
         shipments.destroy_all
         update_column(:shipment_total, 0)
         restart_checkout_flow
       end
     end
+
+    alias_method :ensure_updated_shipments, :check_shipments_and_restart_checkout
+    deprecate ensure_updated_shipments: :check_shipments_and_restart_checkout, deprecator: Spree::Deprecation
 
     def restart_checkout_flow
       return if state == 'cart'

--- a/core/app/models/spree/order_contents.rb
+++ b/core/app/models/spree/order_contents.rb
@@ -42,7 +42,7 @@ module Spree
           # If we do not update first, then the item total will be wrong and ItemTotal
           # promotion rules would not be triggered.
           reload_totals
-          order.ensure_updated_shipments
+          order.check_shipments_and_restart_checkout
           PromotionHandler::Cart.new(order).activate
         end
         reload_totals
@@ -73,7 +73,7 @@ module Spree
     def after_add_or_remove(line_item, options = {})
       reload_totals
       shipment = options[:shipment]
-      shipment.present? ? shipment.update_amounts : order.ensure_updated_shipments
+      shipment.present? ? shipment.update_amounts : order.check_shipments_and_restart_checkout
       PromotionHandler::Cart.new(order, line_item).activate
       reload_totals
       line_item

--- a/core/spec/models/spree/order/state_machine_spec.rb
+++ b/core/spec/models/spree/order/state_machine_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Spree::Order, type: :model do
 
     context "when current state is address" do
       before do
-        order.ensure_updated_shipments
+        order.check_shipments_and_restart_checkout
         order.next!
         expect(order.all_adjustments).to be_empty
         expect(order.state).to eq "address"

--- a/core/spec/models/spree/order_contents_spec.rb
+++ b/core/spec/models/spree/order_contents_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe Spree::OrderContents, type: :model do
     context 'given a shipment' do
       let!(:shipment) { create(:shipment, order: order) }
 
-      it "ensure shipment calls update_amounts instead of order calling ensure_updated_shipments" do
-        expect(subject.order).to_not receive(:ensure_updated_shipments)
+      it "ensure shipment calls update_amounts instead of order calling check_shipments_and_restart_checkout" do
+        expect(subject.order).to_not receive(:check_shipments_and_restart_checkout)
         expect(shipment).to receive(:update_amounts).at_least(:once)
         subject.add(variant, 1, shipment: shipment)
       end
@@ -54,7 +54,7 @@ RSpec.describe Spree::OrderContents, type: :model do
 
     context 'not given a shipment' do
       it "ensures updated shipments" do
-        expect(subject.order).to receive(:ensure_updated_shipments)
+        expect(subject.order).to receive(:check_shipments_and_restart_checkout)
         subject.add(variant)
       end
     end
@@ -166,10 +166,10 @@ RSpec.describe Spree::OrderContents, type: :model do
     end
 
     context 'given a shipment' do
-      it "ensure shipment calls update_amounts instead of order calling ensure_updated_shipments" do
+      it "ensure shipment calls update_amounts instead of order calling check_shipments_and_restart_checkout" do
         subject.add(variant, 1)
         shipment = create(:shipment)
-        expect(subject.order).to_not receive(:ensure_updated_shipments)
+        expect(subject.order).to_not receive(:check_shipments_and_restart_checkout)
         expect(shipment).to receive(:update_amounts)
         subject.remove(variant, 1, shipment: shipment)
       end
@@ -178,7 +178,7 @@ RSpec.describe Spree::OrderContents, type: :model do
     context 'not given a shipment' do
       it "ensures updated shipments" do
         subject.add(variant, 1)
-        expect(subject.order).to receive(:ensure_updated_shipments)
+        expect(subject.order).to receive(:check_shipments_and_restart_checkout)
         subject.remove(variant)
       end
     end
@@ -221,10 +221,10 @@ RSpec.describe Spree::OrderContents, type: :model do
 
   context "#remove_line_item" do
     context 'given a shipment' do
-      it "ensure shipment calls update_amounts instead of order calling ensure_updated_shipments" do
+      it "ensure shipment calls update_amounts instead of order calling check_shipments_and_restart_checkout" do
         line_item = subject.add(variant, 1)
         shipment = create(:shipment)
-        expect(subject.order).to_not receive(:ensure_updated_shipments)
+        expect(subject.order).to_not receive(:check_shipments_and_restart_checkout)
         expect(shipment).to receive(:update_amounts)
         subject.remove_line_item(line_item, shipment: shipment)
       end
@@ -233,7 +233,7 @@ RSpec.describe Spree::OrderContents, type: :model do
     context 'not given a shipment' do
       it "ensures updated shipments" do
         line_item = subject.add(variant, 1)
-        expect(subject.order).to receive(:ensure_updated_shipments)
+        expect(subject.order).to receive(:check_shipments_and_restart_checkout)
         subject.remove_line_item(line_item)
       end
     end
@@ -295,7 +295,7 @@ RSpec.describe Spree::OrderContents, type: :model do
     end
 
     it "ensures updated shipments" do
-      expect(subject.order).to receive(:ensure_updated_shipments)
+      expect(subject.order).to receive(:check_shipments_and_restart_checkout)
       subject.update_cart params
     end
   end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -370,6 +370,17 @@ RSpec.describe Spree::Order, type: :model do
     end
   end
 
+  describe "#ensure_updated_shipments" do
+    let(:order) { create(:order) }
+    let(:subject) { order.ensure_updated_shipments }
+
+    it "is deprecated" do
+      expect(Spree::Deprecation).to receive(:warn).with(/ensure_updated_shipments is deprecated.*use check_shipments_and_restart_checkout instead/, any_args)
+
+      subject
+    end
+  end
+
   context "ensure shipments will be updated" do
     subject(:order) { create :order }
     before do
@@ -384,30 +395,30 @@ RSpec.describe Spree::Order, type: :model do
         end
 
         it "destroys current shipments" do
-          order.ensure_updated_shipments
+          order.check_shipments_and_restart_checkout
           expect(order.shipments).to be_empty
         end
 
         it "puts order back in address state" do
-          order.ensure_updated_shipments
+          order.check_shipments_and_restart_checkout
           expect(order.state).to eql "cart"
         end
 
         it "resets shipment_total" do
           order.update_column(:shipment_total, 5)
-          order.ensure_updated_shipments
+          order.check_shipments_and_restart_checkout
           expect(order.shipment_total).to eq(0)
         end
 
         it "does nothing if any shipments are ready" do
           shipment = create(:shipment, order: subject, state: "ready")
-          expect { subject.ensure_updated_shipments }.not_to change { subject.reload.shipments.pluck(:id) }
+          expect { subject.check_shipments_and_restart_checkout }.not_to change { subject.reload.shipments.pluck(:id) }
           expect { shipment.reload }.not_to raise_error
         end
 
         it "does nothing if any shipments are shipped" do
           shipment = create(:shipment, order: subject, state: "shipped")
-          expect { subject.ensure_updated_shipments }.not_to change { subject.reload.shipments.pluck(:id) }
+          expect { subject.check_shipments_and_restart_checkout }.not_to change { subject.reload.shipments.pluck(:id) }
           expect { shipment.reload }.not_to raise_error
         end
       end
@@ -420,18 +431,18 @@ RSpec.describe Spree::Order, type: :model do
       end
 
       it "destroys current shipments" do
-        order.ensure_updated_shipments
+        order.check_shipments_and_restart_checkout
         expect(order.shipments).to be_empty
       end
 
       it "resets shipment_total" do
         order.update_column(:shipment_total, 5)
-        order.ensure_updated_shipments
+        order.check_shipments_and_restart_checkout
         expect(order.shipment_total).to eq(0)
       end
 
       it "puts the order in the cart state" do
-        order.ensure_updated_shipments
+        order.check_shipments_and_restart_checkout
         expect(order.state).to eq "cart"
       end
     end
@@ -446,19 +457,19 @@ RSpec.describe Spree::Order, type: :model do
 
       it "does not destroy the current shipments" do
         expect {
-          order.ensure_updated_shipments
+          order.check_shipments_and_restart_checkout
         }.not_to change { order.shipments }
       end
 
       it "does not reset the shipment total" do
         expect {
-          order.ensure_updated_shipments
+          order.check_shipments_and_restart_checkout
         }.not_to change { order.shipment_total }
       end
 
       it "does not put the order back in the address state" do
         expect {
-          order.ensure_updated_shipments
+          order.check_shipments_and_restart_checkout
         }.not_to change { order.state }
       end
     end
@@ -470,15 +481,15 @@ RSpec.describe Spree::Order, type: :model do
         order.shipments.create!
 
         expect {
-          order.ensure_updated_shipments
+          order.check_shipments_and_restart_checkout
         }.not_to change { order.shipment_total }
 
         expect {
-          order.ensure_updated_shipments
+          order.check_shipments_and_restart_checkout
         }.not_to change { order.shipments }
 
         expect {
-          order.ensure_updated_shipments
+          order.check_shipments_and_restart_checkout
         }.not_to change { order.state }
       end
     end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -399,7 +399,7 @@ RSpec.describe Spree::Order, type: :model do
           expect(order.shipments).to be_empty
         end
 
-        it "puts order back in address state" do
+        it "puts order back in cart state" do
           order.check_shipments_and_restart_checkout
           expect(order.state).to eql "cart"
         end


### PR DESCRIPTION

**Description**

The naming of this method is confusing and it may induce developers to believe it refreshes shipments while it actually only destroys them on a standard Solidus store.

The method definition is thoroughly tested in the codebase, and the wanted behavior is to actually remove shipments without recreating them back.

The old name is still available but deprecated with a message that suggests using the new one.

FYI if the original order's state machine is patched for example by removing the `address` state, then shipments will be actually recreated since the order will be `next`ed to the `delivery` state and a callback will create them again.

I'm not 100% satisfied with the new name `clean_shipments_and_restart_checkout`, if anybody has a better one I'll be happy to change it.

**Checklist:**
- [ ] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [ ] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change (if needed)
