### PR TITLE
Backport #3913 to V2.11

### DIFF
--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'kaminari-activerecord', '~> 1.1'
   s.add_dependency 'mini_magick', '~> 4.10'
   s.add_dependency 'monetize', '~> 1.8'
-  s.add_dependency 'paperclip', '>= 4.2'
+  s.add_dependency 'kt-paperclip', '>= 4.4.0'
   s.add_dependency 'paranoia', '~> 2.4'
   s.add_dependency 'ransack', '~> 2.0'
   s.add_dependency 'state_machines-activerecord', '~> 0.6'


### PR DESCRIPTION
**Description**

This PR backports #3913 to Solidus 2.11. 

In order to avoid tedious warnings on Ruby 2.7 and greater, we need to switch to the maintained fork of paperclip on 2.11 as well. The deprecation is now [fixed](https://github.com/kreeti/kt-paperclip/commit/f0367733ddf37141ae00517c6697cc3dd233dab9) in kt-paperclip 6.4.x.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
