### PR TITLE
Centralize legacy event bus deprecation and test legacy on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,6 +130,15 @@ jobs:
       - setup
       - test
 
+  event_bus_legacy_adapter:
+    executor: postgres
+    parallelism: *parallelism
+    environment:
+      CI_LEGACY_EVENT_BUS_ADAPTER: '1'
+    steps:
+      - setup
+      - test
+
 workflows:
   build:
     jobs:
@@ -141,6 +150,7 @@ workflows:
       - mysql
       - postgres_rails60
       - postgres_rails52
+      - event_bus_legacy_adapter
       - stoplight/push:
           context: "Solidus Core Team"
           project: solidus/solidus-api

--- a/core/lib/spree/event/adapters/deprecation_handler.rb
+++ b/core/lib/spree/event/adapters/deprecation_handler.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'spree/event/adapters/active_support_notifications'
+require 'spree/deprecation'
+
+module Spree
+  module Event
+    module Adapters
+      # @api private
+      module DeprecationHandler
+        LEGACY_ADAPTER = ActiveSupportNotifications
+
+        CI_LEGACY_ADAPTER_ENV_KEY = 'CI_LEGACY_EVENT_BUS_ADAPTER'
+
+        def self.legacy_adapter?(adapter)
+          adapter == LEGACY_ADAPTER
+        end
+
+        def self.legacy_adapter_set_by_env
+          return LEGACY_ADAPTER if ENV[CI_LEGACY_ADAPTER_ENV_KEY].present?
+        end
+
+        def self.render_deprecation_message?(adapter)
+          legacy_adapter?(adapter) && legacy_adapter_set_by_env.nil?
+        end
+      end
+    end
+  end
+end

--- a/core/lib/spree/event/configuration.rb
+++ b/core/lib/spree/event/configuration.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
-require 'spree/core/versioned_value'
+require 'spree/event/adapters/deprecation_handler'
 require 'spree/event/adapters/active_support_notifications'
-require 'spree/event/adapters/default'
 
 module Spree
   module Event
@@ -17,64 +16,56 @@ module Spree
         @autoload_subscribers.nil? ? true : !!@autoload_subscribers
       end
 
+      # TODO: Update to Adapters::Default.new on Solidus 4
       def adapter
-        @adapter ||= Spree::Core::VersionedValue.new(
-          Spree::Event::Adapters::ActiveSupportNotifications,
-          "4.0.0.alpha" => Spree::Event::Adapters::Default.new
-        ).call.tap do |value|
-          deprecate_if_legacy_adapter(value)
+        @adapter ||= Adapters::ActiveSupportNotifications.tap do |adapter|
+          Spree::Deprecation.warn <<~MSG if Adapters::DeprecationHandler.render_deprecation_message?(adapter)
+            `Spree::Event::Adapters::ActiveSupportNotifications` adapter is
+            deprecated. Please, take your time to update it to an instance of
+            `Spree::Event::Adapters::Default`. I.e., in your `spree.rb`:
+
+            require 'spree/event/adapters/default'
+
+            Spree.config do |config|
+              # ...
+              config.events.adapter = Spree::Event::Adapters.Default.new
+              # ...
+            end
+
+            That will be the new default on Solidus 4.
+
+            Take into account there're two critical changes in behavior in the new adapter:
+
+            - Event names are no longer automatically suffixed with `.spree`, as
+            they're no longer in the same bucket that Rails's ones. So, for
+            instance, if you were relying on a global subscription to all Solidus
+            events with:
+
+              Spree::Event.subscribe /.*\.spree$/
+
+            You should change it to:
+
+              Spree::Event.subscribe /.*/
+
+            - Providing a block to `Spree::Event.fire` is no longer supported. If
+            you're doing something like:
+
+              Spree::Event.fire 'event_name', order: order do
+                order.do_something
+              end
+
+              You now need to change it to:
+
+              order.do_something
+              Spree::Event.fire 'event_name', order: order
+
+          MSG
         end
       end
 
       # Only used by {Spree::Event::Adapters::ActiveSupportNotifications}.
       def suffix
         @suffix ||= '.spree'
-      end
-
-      private
-
-      def deprecate_if_legacy_adapter(adapter)
-        Spree::Deprecation.warn <<~MSG if adapter == Spree::Event::Adapters::ActiveSupportNotifications
-          `Spree::Event::Adapters::ActiveSupportNotifications` adapter is
-          deprecated. Please, take your time to update it to an instance of
-          `Spree::Event::Adapters::Default`. I.e., in your `spree.rb`:
-
-          require 'spree/event/adapters/default'
-
-          Spree.config do |config|
-            # ...
-            config.events.adapter = Spree::Event::Adapters.Default.new
-            # ...
-          end
-
-          That will be the new default on Solidus 4.
-
-          Take into account there're two critical changes in behavior in the new adapter:
-
-          - Event names are no longer automatically suffixed with `.spree`, as
-          they're no longer in the same bucket that Rails's ones. So, for
-          instance, if you were relying on a global subscription to all Solidus
-          events with:
-
-            Spree::Event.subscribe /.*\.spree$/
-
-          You should change it to:
-
-            Spree::Event.subscribe /.*/
-
-          - Providing a block to `Spree::Event.fire` is no longer supported. If
-          you're doing something like:
-
-            Spree::Event.fire 'event_name', order: order do
-              order.do_something
-            end
-
-            You now need to change it to:
-
-            order.do_something
-            Spree::Event.fire 'event_name', order: order
-
-        MSG
       end
     end
   end

--- a/core/lib/spree/testing_support/dummy_app.rb
+++ b/core/lib/spree/testing_support/dummy_app.rb
@@ -135,8 +135,11 @@ Spree.load_defaults(Spree.solidus_version)
 Spree.config do |config|
   config.mails_from = "store@example.com"
   # TODO: Remove on Solidus 4.0 as it'll be the default
-  require 'spree/event/adapters/default'
-  config.events.adapter = Spree::Event::Adapters::Default.new
+  require 'spree/event/adapters/deprecation_handler'
+  if Spree::Event::Adapters::DeprecationHandler.legacy_adapter_set_by_env.nil?
+    require 'spree/event/adapters/default'
+    config.events.adapter = Spree::Event::Adapters::Default.new
+  end
 
   if ENV['DISABLE_ACTIVE_STORAGE']
     config.image_attachment_module = 'Spree::Image::PaperclipAttachment'

--- a/core/spec/lib/spree/app_configuration_spec.rb
+++ b/core/spec/lib/spree/app_configuration_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe Spree::AppConfiguration do
     expect(prefs.admin_vat_location.country_id).to eq(nil)
   end
 
-  it 'can access event adapter' do
-    expect(prefs.events.adapter).to be_an_instance_of(Spree::Event::Adapters::Default)
+  it 'can access event configuration' do
+    expect(prefs.events).to be_an_instance_of(Spree::Event::Configuration)
   end
 end

--- a/core/spec/lib/spree/event/adapters/deprecation_handler_spec.rb
+++ b/core/spec/lib/spree/event/adapters/deprecation_handler_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'spree/event/adapters/deprecation_handler'
+require 'spree/event/adapters/default'
+
+module Spree
+  module Event
+    module Adapters
+      RSpec.describe DeprecationHandler do
+        let(:env_key) { described_class::CI_LEGACY_ADAPTER_ENV_KEY }
+
+        let(:reset_env_key) do
+          lambda do |example|
+            old_value = ENV[env_key]
+            example.run
+            ENV[env_key] = old_value
+          end
+        end
+
+        describe '#legacy_adapter?' do
+          context 'when the events adapter is the legacy' do
+            it 'returns true' do
+              expect(described_class.legacy_adapter?(ActiveSupportNotifications)).to be(true)
+            end
+          end
+
+          context 'when the events adapter is not the legacy' do
+            it 'returns false' do
+              expect(described_class.legacy_adapter?(Default.new)).to be(false)
+            end
+          end
+        end
+
+        describe '#legacy_adapter_set_by_env' do
+          around { |example| reset_env_key.(example) }
+
+          context 'when env var is set' do
+            it 'returns the legacy adapter' do
+              ENV[env_key] = '1'
+
+              expect(described_class.legacy_adapter_set_by_env).to be(ActiveSupportNotifications)
+            end
+          end
+
+          context 'when env var is not set' do
+            it 'returns nil' do
+              ENV[env_key] = nil
+
+              expect(described_class.legacy_adapter_set_by_env).to be(nil)
+            end
+          end
+        end
+
+        describe '#render_deprecation_message?' do
+          context 'when adapter is legacy and is not set by env' do
+            around { |example| reset_env_key.(example) }
+
+            it 'returns true' do
+              ENV[env_key] = nil
+
+              expect(described_class.render_deprecation_message?(ActiveSupportNotifications)).to be(true)
+            end
+          end
+
+          context 'when adapter is legacy and is set by env' do
+            around { |example| reset_env_key.(example) }
+
+            it 'returns true' do
+              ENV[env_key] = '1'
+
+              expect(described_class.render_deprecation_message?(ActiveSupportNotifications)).to be(false)
+            end
+          end
+
+          context 'when adapter is not legacy' do
+            it 'returns false' do
+              expect(described_class.render_deprecation_message?(Default.new)).to be(false)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/core/spec/lib/spree/event/configuration_spec.rb
+++ b/core/spec/lib/spree/event/configuration_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'spree/event/configuration'
+
+RSpec.describe Spree::Event::Configuration do
+  describe '#adapter' do
+    context "when it hasn't been explicitly set" do
+      let(:supress_warning_env_key) { Spree::Event::Adapters::DeprecationHandler::CI_LEGACY_ADAPTER_ENV_KEY }
+
+      it 'is ActiveSupportNotifications adapter' do
+        allow(Spree::Deprecation).to receive(:warn)
+
+        expect(described_class.new.adapter).to be(Spree::Event::Adapters::ActiveSupportNotifications)
+      end
+
+      it 'renders a deprecation message when no supressed via env' do
+        old_value = ENV[supress_warning_env_key]
+        ENV[supress_warning_env_key] = nil
+        expect(Spree::Deprecation).to receive(:warn).with(/adapter is.*deprecated/m)
+
+        described_class.new.adapter
+      ensure
+        ENV[supress_warning_env_key] = old_value
+      end
+
+      it "doesn't render a deprecation message when supressed via env" do
+        old_value = ENV[supress_warning_env_key]
+        ENV[supress_warning_env_key] = '1'
+        expect(Spree::Deprecation).not_to receive(:warn).with(/adapter is.*deprecated/m)
+
+        described_class.new.adapter
+      ensure
+        ENV[supress_warning_env_key] = old_value
+      end
+    end
+
+    context "when it has been explicitly set" do
+      it "doesn't render a deprecation message" do
+        expect(Spree::Deprecation).not_to receive(:warn)
+
+        config = described_class.new
+        config.adapter = Spree::Event::Adapters::ActiveSupportNotifications
+
+        config.adapter
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Description**

This commit adds a new job on CI to perform the test suite with the
legacy adapter configured.

Besides that, it extracts the deprecation logic into its module to avoid
having it scattered through different parts of the system.

Relates to discussion:

https://github.com/solidusio/solidus/pull/4130#discussion_r682733694


**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
